### PR TITLE
Add spinner for fetching transactions 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -32,11 +32,11 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - GoogleToolboxForMac/Defines (2.2.0)
-  - GoogleToolboxForMac/Logger (2.2.0):
-    - GoogleToolboxForMac/Defines (= 2.2.0)
-  - "GoogleToolboxForMac/NSData+zlib (2.2.0)":
-    - GoogleToolboxForMac/Defines (= 2.2.0)
+  - GoogleToolboxForMac/Defines (2.2.1)
+  - GoogleToolboxForMac/Logger (2.2.1):
+    - GoogleToolboxForMac/Defines (= 2.2.1)
+  - "GoogleToolboxForMac/NSData+zlib (2.2.1)":
+    - GoogleToolboxForMac/Defines (= 2.2.1)
   - libwebp (1.0.2):
     - libwebp/core (= 1.0.2)
     - libwebp/dec (= 1.0.2)
@@ -66,7 +66,7 @@ PODS:
     - nanopb/encode (= 0.3.901)
   - nanopb/decode (0.3.901)
   - nanopb/encode (0.3.901)
-  - Protobuf (3.7.0)
+  - Protobuf (3.8.0)
   - React (0.59.8):
     - React/Core (= 0.59.8)
   - react-native-blur (0.8.0):
@@ -149,9 +149,9 @@ PODS:
     - React
   - RNScreens (1.0.0-alpha.22):
     - React
-  - SDWebImage (5.0.2):
-    - SDWebImage/Core (= 5.0.2)
-  - SDWebImage/Core (5.0.2)
+  - SDWebImage (5.0.6):
+    - SDWebImage/Core (= 5.0.6)
+  - SDWebImage/Core (5.0.6)
   - yoga (0.59.8.React)
 
 DEPENDENCIES:
@@ -257,10 +257,10 @@ SPEC CHECKSUMS:
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
-  GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
+  GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
   libwebp: b068a3bd7c45f7460f6715be7bed1a18fd5d6b48
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
-  Protobuf: 7a877b7f3e5964e3fce995e2eb323dbc6831bb5a
+  Protobuf: 3f617b9a6e73605565086864c9bc26b2bf2dd5a3
   React: 76e6aa2b87d05eb6cccb6926d72685c9a07df152
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-camera: 571e4cfe70e7021e9077c1699a53e659db971f96
@@ -272,7 +272,7 @@ SPEC CHECKSUMS:
   RNLanguages: 962e562af0d34ab1958d89bcfdb64fafc37c513e
   RNReanimated: c8dd490ca98a4edcba229bfa49f2516c95a43afb
   RNScreens: 720a9e6968beb73e8196239801e887d8401f86ed
-  SDWebImage: 6764b5fa0f73c203728052955dbefa2bf1f33282
+  SDWebImage: 920f1a2ff1ca8296ad34f6e0510a1ef1d70ac965
   yoga: 92b2102c3d373d1a790db4ab761d2b0ffc634f64
 
 PODFILE CHECKSUM: 0145e839f29994a918863125c862614f79901ada

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -249,11 +249,11 @@ SPEC CHECKSUMS:
   Crashlytics: 55e24fc23989680285a21cb1146578d9d18e432c
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Fabric: 25d0963b691fc97be566392243ff0ecef5a68338
-  Firebase: 76ec2a7cde90fb4037793f83aeeca48451543487
-  FirebaseAnalytics: b8bce8d5c40173328b8a4300da18c5c7e0a1908d
-  FirebaseCore: 31d258ec80ea97e1e8e40ce00a7ba7297afb45c2
-  FirebaseInstanceID: 4f7768a98c5c3c5bd9a4c9e431ea98dccc0a51f9
-  FirebaseMessaging: 94579ae655d817287f029ebfebd5b0811fbb3a51
+  Firebase: 68afeeb05461db02d7c9e3215cda28068670f4aa
+  FirebaseAnalytics: b3628aea54c50464c32c393fb2ea032566e7ecc2
+  FirebaseCore: 62f1b792a49bb9e8b4073f24606d2c93ffc352f0
+  FirebaseInstanceID: f3f0657372592ecdfdfe2cac604a5a75758376a6
+  FirebaseMessaging: 6894b8fe0a0cf26c3b13dad729f1131654ae0bdb
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d

--- a/src/components/activity-list/ActivityList.js
+++ b/src/components/activity-list/ActivityList.js
@@ -14,16 +14,17 @@ import {
 } from '../../hoc';
 import RecyclerActivityList from './RecyclerActivityList';
 
-const ActivityList = ({ header, sections }) => (
+const ActivityList = ({ header, isEmpty, sections }) => (
   <RecyclerActivityList
     header={header}
-    isEmpty={!sections.length}
+    isLoading={!isEmpty && !sections.length}
     sections={sections}
   />
 );
 
 ActivityList.propTypes = {
   header: PropTypes.node,
+  isEmpty: PropTypes.bool,
   sections: PropTypes.arrayOf(PropTypes.shape({
     data: PropTypes.array,
     renderItem: PropTypes.func,
@@ -59,6 +60,7 @@ export default compose(
   }),
   onlyUpdateForKeys([
     'hasPendingTransaction',
+    'isEmpty',
     'nativeCurrency',
     'pendingTransactionsCount',
     'sections',

--- a/src/components/activity-list/ActivityList.js
+++ b/src/components/activity-list/ActivityList.js
@@ -17,6 +17,7 @@ import RecyclerActivityList from './RecyclerActivityList';
 const ActivityList = ({ header, sections }) => (
   <RecyclerActivityList
     header={header}
+    isEmpty={!sections.length}
     sections={sections}
   />
 );

--- a/src/components/activity-list/RecyclerActivityList.js
+++ b/src/components/activity-list/RecyclerActivityList.js
@@ -62,7 +62,7 @@ const hasRowChanged = (r1, r2) => {
 export default class RecyclerActivityList extends PureComponent {
   static propTypes = {
     header: PropTypes.node,
-    isEmpty: PropTypes.bool,
+    isLoading: PropTypes.bool,
     sections: PropTypes.arrayOf(PropTypes.shape({
       data: PropTypes.array,
       title: PropTypes.string.isRequired,
@@ -103,7 +103,7 @@ export default class RecyclerActivityList extends PureComponent {
         } else if (type === ViewTypes.HEADER) {
           dim.height = 35;
         } else {
-          dim.height = this.props.isEmpty ? deviceUtils.dimensions.height : 216;
+          dim.height = this.props.isLoading ? deviceUtils.dimensions.height : 216;
         }
       },
     );
@@ -137,7 +137,7 @@ export default class RecyclerActivityList extends PureComponent {
 
   rowRenderer = (type, data) => {
     if (type === ViewTypes.COMPONENT_HEADER) {
-      return this.props.isEmpty
+      return this.props.isLoading
         ? <LoadingState>{data.header}</LoadingState>
         : data.header;
     }
@@ -158,7 +158,7 @@ export default class RecyclerActivityList extends PureComponent {
           layoutProvider={this.layoutProvider}
           renderAheadOffset={deviceUtils.dimensions.height}
           rowRenderer={this.rowRenderer}
-          scrollEnabled={!this.props.isEmpty}
+          scrollEnabled={!this.props.isLoading}
           scrollIndicatorInsets={{
             bottom: safeAreaInsetValues.bottom,
           }}

--- a/src/components/activity-list/RecyclerActivityList.js
+++ b/src/components/activity-list/RecyclerActivityList.js
@@ -1,16 +1,20 @@
-import { get } from 'lodash';
+import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { RecyclerListView, DataProvider, LayoutProvider } from 'recyclerlistview';
 import StickyContainer from 'recyclerlistview/dist/reactnative/core/StickyContainer';
 import styled from 'styled-components/primitives/dist/styled-components-primitives.esm';
 import { buildTransactionUniqueIdentifier } from '../../helpers/transactions';
+import { colors, position } from '../../styles';
 import { deviceUtils, isNewValueForPath, safeAreaInsetValues } from '../../utils';
+import { AssetListItemSkeleton } from '../asset-list';
 import {
   ContractInteractionCoinRow,
   RequestCoinRow,
   TransactionCoinRow,
 } from '../coin-row';
+import ActivityIndicator from '../ActivityIndicator';
+import { Centered, Column } from '../layout';
 import ListFooter from '../list/ListFooter';
 import ActivityListHeader from './ActivityListHeader';
 
@@ -26,6 +30,21 @@ const Wrapper = styled.View`
   overflow: hidden;
   width: 100%;
 `;
+
+const LoadingState = ({ children }) => (
+  <Column flex={1}>
+    {children}
+    <Column flex={1}>
+      <Centered style={{ paddingTop: 200, position: 'absolute', width: '100%' }}>
+        <ActivityIndicator
+          color={colors.alpha(colors.blueGreyLight, 0.666)}
+          size={32}
+        />
+      </Centered>
+      {times(11, index => <AssetListItemSkeleton key={`activitySkeleton${index}`} />)}
+    </Column>
+  </Column>
+);
 
 const hasRowChanged = (r1, r2) => {
   if (r1.hash === '_header' && isNewValueForPath(r1, r2, 'header.props.accountAddress')) {
@@ -43,6 +62,7 @@ const hasRowChanged = (r1, r2) => {
 export default class RecyclerActivityList extends PureComponent {
   static propTypes = {
     header: PropTypes.node,
+    isEmpty: PropTypes.bool,
     sections: PropTypes.arrayOf(PropTypes.shape({
       data: PropTypes.array,
       title: PropTypes.string.isRequired,
@@ -83,7 +103,7 @@ export default class RecyclerActivityList extends PureComponent {
         } else if (type === ViewTypes.HEADER) {
           dim.height = 35;
         } else {
-          dim.height = 216;
+          dim.height = this.props.isEmpty ? deviceUtils.dimensions.height : 216;
         }
       },
     );
@@ -116,7 +136,11 @@ export default class RecyclerActivityList extends PureComponent {
   };
 
   rowRenderer = (type, data) => {
-    if (type === ViewTypes.COMPONENT_HEADER) return data.header;
+    if (type === ViewTypes.COMPONENT_HEADER) {
+      return this.props.isEmpty
+        ? <LoadingState>{data.header}</LoadingState>
+        : data.header;
+    }
     if (type === ViewTypes.HEADER) return <ActivityListHeader {...data} />;
     if (type === ViewTypes.FOOTER) return <ListFooter />;
 
@@ -134,6 +158,7 @@ export default class RecyclerActivityList extends PureComponent {
           layoutProvider={this.layoutProvider}
           renderAheadOffset={deviceUtils.dimensions.height}
           rowRenderer={this.rowRenderer}
+          scrollEnabled={!this.props.isEmpty}
           scrollIndicatorInsets={{
             bottom: safeAreaInsetValues.bottom,
           }}

--- a/src/components/asset-list/AssetListItemSkeleton.js
+++ b/src/components/asset-list/AssetListItemSkeleton.js
@@ -1,21 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components/primitives';
 import { Circle, G, Rect } from 'svgs';
-import Svg from '../icons/Svg';
-import { Row } from '../layout';
+import { withNeverRerender } from '../../hoc';
 import { colors, padding } from '../../styles';
-
-const Container = styled(Row).attrs({
-  align: 'center',
-  justify: 'space-between',
-})`
-  ${({ index }) => padding((index === 0 ? 15 : 12.5), 19, 12.5, 15)}
-  opacity: ${({ index }) => (1 - (0.2 * index))};
-`;
+import { Svg } from '../icons';
+import { Row } from '../layout';
 
 const AssetListItemSkeleton = ({ color, index }) => (
-  <Container index={index}>
+  <Row
+    align="center"
+    css={`
+      ${padding((index === 0 ? 15 : 12.5), 19, 12.5, 15)}
+      opacity: ${(1 - (0.2 * index))}
+    `}
+    justify="space-between"
+  >
     <Svg height={40} width={151} viewBox="0 0 151 40">
       <G fill={color} transform="translate(0 -.667)">
         <Rect height={8} rx="1" width={100} x="51" y="6.667" />
@@ -29,7 +28,7 @@ const AssetListItemSkeleton = ({ color, index }) => (
         <Rect height={8} rx="1" width={50} x="30" y="20.667" />
       </G>
     </Svg>
-  </Container>
+  </Row>
 );
 
 AssetListItemSkeleton.propTypes = {
@@ -42,4 +41,4 @@ AssetListItemSkeleton.defaultProps = {
   index: 0,
 };
 
-export default AssetListItemSkeleton;
+export default withNeverRerender(AssetListItemSkeleton);

--- a/src/components/asset-list/index.js
+++ b/src/components/asset-list/index.js
@@ -1,3 +1,4 @@
 export { default as AssetList } from './AssetList';
 export { default as AssetListHeader } from './AssetListHeader';
+export { default as AssetListItemSkeleton } from './AssetListItemSkeleton';
 export { default as RecyclerAssetList } from './RecyclerAssetList';

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -5,6 +5,7 @@ export { default as withAccountSettings } from './withAccountSettings';
 export { default as withAccountTransactions } from './withAccountTransactions';
 export { default as withActionSheetManager } from './withActionSheetManager';
 export { default as withAppState } from './withAppState';
+export { default as withAreTransactionsFetched } from './withAreTransactionsFetched';
 export { default as withBlurTransitionProps } from './withBlurTransitionProps';
 export { default as withFetchingPrices } from './withFetchingPrices';
 export { default as withHideSplashScreen } from './withHideSplashScreen';

--- a/src/hoc/withAccountRefresh.js
+++ b/src/hoc/withAccountRefresh.js
@@ -10,7 +10,6 @@ export default Component => compose(
   withHandlers({
     refreshAccount: (ownProps) => async () => {
       try {
-        console.log(ownProps);
         await ownProps.assetsRefreshState();
         ownProps.setAssetsFetched();
         await ownProps.transactionsRefreshState();

--- a/src/hoc/withAccountRefresh.js
+++ b/src/hoc/withAccountRefresh.js
@@ -1,14 +1,20 @@
 import { assetsRefreshState, transactionsRefreshState } from '@rainbow-me/rainbow-common';
 import { connect } from 'react-redux';
 import { compose, withHandlers } from 'recompact';
+import { setAssetsFetched, setTransactionFetched } from '../redux/initialFetch';
 
 export default Component => compose(
-  connect(null, { assetsRefreshState, transactionsRefreshState }),
+  connect(null, {
+    assetsRefreshState, setAssetsFetched, setTransactionFetched, transactionsRefreshState,
+  }),
   withHandlers({
     refreshAccount: (ownProps) => async () => {
       try {
+        console.log(ownProps);
         await ownProps.assetsRefreshState();
+        ownProps.setAssetsFetched();
         await ownProps.transactionsRefreshState();
+        ownProps.setTransactionFetched();
       } catch (error) {
         // TODO more granular error messaging depending on offline status
       }

--- a/src/hoc/withAccountRefresh.js
+++ b/src/hoc/withAccountRefresh.js
@@ -5,7 +5,10 @@ import { setAssetsFetched, setTransactionFetched } from '../redux/initialFetch';
 
 export default Component => compose(
   connect(null, {
-    assetsRefreshState, setAssetsFetched, setTransactionFetched, transactionsRefreshState,
+    assetsRefreshState,
+    setAssetsFetched,
+    setTransactionFetched,
+    transactionsRefreshState,
   }),
   withHandlers({
     refreshAccount: (ownProps) => async () => {

--- a/src/hoc/withAreTransactionsFetched.js
+++ b/src/hoc/withAreTransactionsFetched.js
@@ -1,0 +1,6 @@
+import { connect } from 'react-redux';
+import { FETCHED_TRANSACTIONS } from '../redux/initialFetch';
+
+const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetched: fetchingState === FETCHED_TRANSACTIONS });
+
+export default Component => connect(mapStateToProps)(Component);

--- a/src/hoc/withAreTransactionsFetched.js
+++ b/src/hoc/withAreTransactionsFetched.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
 import { FETCHED_TRANSACTIONS } from '../redux/initialFetch';
 
-const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetched: fetchingState === FETCHED_TRANSACTIONS });
+const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({
+  areTransactionsFetched: fetchingState === FETCHED_TRANSACTIONS,
+});
 
 export default Component => connect(mapStateToProps)(Component);

--- a/src/hoc/withAreTransactionsFetching.js
+++ b/src/hoc/withAreTransactionsFetching.js
@@ -1,6 +1,0 @@
-import { connect } from 'react-redux';
-import { FETCHED_ASSETS } from '../redux/initialFetch';
-
-const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetching: fetchingState === FETCHED_ASSETS });
-
-export default Component => connect(mapStateToProps)(Component);

--- a/src/hoc/withAreTransactionsFetching.js
+++ b/src/hoc/withAreTransactionsFetching.js
@@ -1,0 +1,6 @@
+import { connect } from 'react-redux';
+import { FETCHED_ASSETS } from '../redux/initialFetch';
+
+const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetching: fetchingState === FETCHED_ASSETS });
+
+export default Component => connect(mapStateToProps)(Component);

--- a/src/model/wallet.js
+++ b/src/model/wallet.js
@@ -32,7 +32,7 @@ export const walletInit = async (seedPhrase = null) => {
     walletAddress = await createWallet();
     isWalletBrandNew = true;
   }
-  return { isWalletBrandNew, walletAddress } ;
+  return { isWalletBrandNew, walletAddress };
 };
 
 export const loadWallet = async () => {

--- a/src/redux/initialFetch.js
+++ b/src/redux/initialFetch.js
@@ -1,0 +1,32 @@
+// -- Constants --------------------------------------- //
+const SET_ASSETS_FETCHED = 'initialFetch/SET_ASSETS_FETCH';
+const SET_TRANSACTIONS_FETCHED = 'initialFetch/SET_TRANSACTIONS_FETCHED';
+const NOTHING_FETCHED = 0;
+export const FETCHED_ASSETS = 1;
+const FETCHED_TRANSACTIONS = 2;
+
+export const setTransactionFetched = () => (dispatch, getState) => {
+  if (getState().initialFetch.fetchingState === FETCHED_ASSETS) {
+    dispatch({ type: SET_TRANSACTIONS_FETCHED });
+  }
+};
+
+export const setAssetsFetched = () => (dispatch, getState) => {
+  if (getState().initialFetch.fetchingState === NOTHING_FETCHED) {
+    dispatch({ type: SET_ASSETS_FETCHED });
+  }
+};
+
+// -- Reducer ----------------------------------------- //
+const INITIAL_STATE = { fetchingState: NOTHING_FETCHED };
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+  case SET_ASSETS_FETCHED:
+    return { fetchingState: FETCHED_ASSETS };
+  case SET_TRANSACTIONS_FETCHED:
+    return { fetchingState: FETCHED_TRANSACTIONS };
+  default:
+    return state;
+  }
+};

--- a/src/redux/initialFetch.js
+++ b/src/redux/initialFetch.js
@@ -2,8 +2,8 @@
 const SET_ASSETS_FETCHED = 'initialFetch/SET_ASSETS_FETCH';
 const SET_TRANSACTIONS_FETCHED = 'initialFetch/SET_TRANSACTIONS_FETCHED';
 const NOTHING_FETCHED = 0;
-export const FETCHED_ASSETS = 1;
-const FETCHED_TRANSACTIONS = 2;
+const FETCHED_ASSETS = 1;
+export const FETCHED_TRANSACTIONS = 2;
 
 export const setTransactionFetched = () => (dispatch, getState) => {
   if (getState().initialFetch.fetchingState === FETCHED_ASSETS) {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -11,6 +11,7 @@ import actionSheetManager from './actionSheetManager';
 import imageDimensionsCache from './imageDimensionsCache';
 import isWalletEmpty from './isWalletEmpty';
 import navigation from './navigation';
+import initialFetch from './initialFetch';
 import nonce from './nonce';
 import transactionsToApprove from './transactionsToApprove';
 import walletconnect from './walletconnect';
@@ -19,6 +20,7 @@ export default combineReducers({
   actionSheetManager,
   assets,
   imageDimensionsCache,
+  initialFetch,
   isWalletEmpty,
   navigation,
   nonce,

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -9,9 +9,9 @@ import { combineReducers } from 'redux';
 
 import actionSheetManager from './actionSheetManager';
 import imageDimensionsCache from './imageDimensionsCache';
+import initialFetch from './initialFetch';
 import isWalletEmpty from './isWalletEmpty';
 import navigation from './navigation';
-import initialFetch from './initialFetch';
 import nonce from './nonce';
 import transactionsToApprove from './transactionsToApprove';
 import walletconnect from './walletconnect';

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -46,7 +46,7 @@ const ProfileScreen = ({
         onPress={onPressBackButton}
       />
     </Header>
-    {showSpinner && <LoadingOverlay title="Importing..." />}
+    {showSpinner && <LoadingOverlay />}
     <ActivityList
       accountAddress={accountAddress}
       hasPendingTransaction={hasPendingTransaction}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -23,52 +23,48 @@ const ProfileScreen = ({
   onPressSettings,
   requests,
   showBlur,
+  showSpinner,
   transactions,
   transactionsCount,
-}) => {
-  // spinner should be displayed if transactions has not been fetched,
-  // AddFundsInterstitial is not displayed (`!isEmpty`) and there's no transaction to be displayed
-  const shouldDisplaySpinner = !areTransactionsFetched && !isEmpty && transactions.length === 0;
-  return (
-    <Page component={FlexItem} style={position.sizeAsObject('100%')}>
-      {showBlur && (
-        <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
-          <BlurOverlay
-            backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
-            blurType="light"
-            opacity={blurOpacity}
-          />
-        </FadeInAnimation>
-      )}
-      <Header justify="space-between">
-        <HeaderButton onPress={onPressSettings}>
-          <Icon name="gear" />
-        </HeaderButton>
-        <BackButton
-          direction="right"
-          onPress={onPressBackButton}
+}) => (
+  <Page component={FlexItem} style={position.sizeAsObject('100%')}>
+    {showBlur && (
+      <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
+        <BlurOverlay
+          backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
+          blurType="light"
+          opacity={blurOpacity}
         />
-      </Header>
-      {shouldDisplaySpinner && <LoadingOverlay title="Importing..." />}
-      <ActivityList
-        accountAddress={accountAddress}
-        hasPendingTransaction={hasPendingTransaction}
-        header={(
-          <ProfileMasthead
-            accountAddress={accountAddress}
-            navigation={navigation}
-            showBottomDivider={!isEmpty}
-          />
-        )}
-        nativeCurrency={nativeCurrency}
-        requests={requests}
-        transactions={areTransactionsFetched}
-        transactionsCount={transactionsCount}
+      </FadeInAnimation>
+    )}
+    <Header justify="space-between">
+      <HeaderButton onPress={onPressSettings}>
+        <Icon name="gear" />
+      </HeaderButton>
+      <BackButton
+        direction="right"
+        onPress={onPressBackButton}
       />
-      {isEmpty && <AddFundsInterstitial />}
-    </Page>
-  );
-};
+    </Header>
+    {showSpinner && <LoadingOverlay title="Importing..." />}
+    <ActivityList
+      accountAddress={accountAddress}
+      hasPendingTransaction={hasPendingTransaction}
+      header={(
+        <ProfileMasthead
+          accountAddress={accountAddress}
+          navigation={navigation}
+          showBottomDivider={!isEmpty}
+        />
+      )}
+      nativeCurrency={nativeCurrency}
+      requests={requests}
+      transactions={areTransactionsFetched}
+      transactionsCount={transactionsCount}
+    />
+    {isEmpty && <AddFundsInterstitial />}
+  </Page>
+);
 
 ProfileScreen.propTypes = {
   accountAddress: PropTypes.string,
@@ -82,6 +78,7 @@ ProfileScreen.propTypes = {
   onPressSettings: PropTypes.func,
   requests: PropTypes.array,
   showBlur: PropTypes.bool,
+  showSpinner: PropTypes.bool,
   transactions: PropTypes.array,
   transactionsCount: PropTypes.number,
 };

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -13,7 +13,7 @@ import { LoadingOverlay } from '../components/modal';
 
 const ProfileScreen = ({
   accountAddress,
-  areTransactionsFetching,
+  areTransactionsFetched,
   blurOpacity,
   hasPendingTransaction,
   isEmpty,
@@ -25,50 +25,54 @@ const ProfileScreen = ({
   showBlur,
   transactions,
   transactionsCount,
-}) => (
-  <Page component={FlexItem} style={position.sizeAsObject('100%')}>
-    <Header justify="space-between">
-      <HeaderButton onPress={onPressSettings}>
-        <Icon name="gear" testID="Gear icon"/>
-      </HeaderButton>
-      <BackButton
-        testID="goToBalancesFromProfile"
-        direction="right"
-        onPress={onPressBackButton}
-      />
-    </Header>
-    {areTransactionsFetching && <LoadingOverlay title="Importing..." />}
-    <ActivityList
-      accountAddress={accountAddress}
-      hasPendingTransaction={hasPendingTransaction}
-      header={(
-        <ProfileMasthead
-          accountAddress={accountAddress}
-          navigation={navigation}
-          showBottomDivider={!isEmpty}
-        />
+}) => {
+  // spinner should be displayed if transactions has not been fetched,
+  // AddFundsInterstitial is not displayed (`!isEmpty`) and there's no transaction to be displayed
+  const shouldDisplaySpinner = !areTransactionsFetched && !isEmpty && transactions.length === 0;
+  return (
+    <Page component={FlexItem} style={position.sizeAsObject('100%')}>
+      {showBlur && (
+        <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
+          <BlurOverlay
+            backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
+            blurType="light"
+            opacity={blurOpacity}
+          />
+        </FadeInAnimation>
       )}
-      nativeCurrency={nativeCurrency}
-      requests={requests}
-      transactions={transactions}
-      transactionsCount={transactionsCount}
-    />
-    {isEmpty && <AddFundsInterstitial />}
-    {showBlur && (
-      <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
-        <BlurOverlay
-          backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
-          blurType="light"
-          opacity={blurOpacity}
+      <Header justify="space-between">
+        <HeaderButton onPress={onPressSettings}>
+          <Icon name="gear" />
+        </HeaderButton>
+        <BackButton
+          direction="right"
+          onPress={onPressBackButton}
         />
-      </FadeInAnimation>
-    )}
-  </Page>
-);
+      </Header>
+      {shouldDisplaySpinner && <LoadingOverlay title="Importing..." />}
+      <ActivityList
+        accountAddress={accountAddress}
+        hasPendingTransaction={hasPendingTransaction}
+        header={(
+          <ProfileMasthead
+            accountAddress={accountAddress}
+            navigation={navigation}
+            showBottomDivider={!isEmpty}
+          />
+        )}
+        nativeCurrency={nativeCurrency}
+        requests={requests}
+        transactions={areTransactionsFetched}
+        transactionsCount={transactionsCount}
+      />
+      {isEmpty && <AddFundsInterstitial />}
+    </Page>
+  );
+};
 
 ProfileScreen.propTypes = {
   accountAddress: PropTypes.string,
-  areTransactionsFetching: PropTypes.bool,
+  areTransactionsFetched: PropTypes.bool,
   blurOpacity: PropTypes.object,
   hasPendingTransaction: PropTypes.bool,
   isEmpty: PropTypes.bool,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -9,7 +9,6 @@ import { FlexItem, Page } from '../components/layout';
 import { Icon } from '../components/icons';
 import { ProfileMasthead } from '../components/profile';
 import { colors, position } from '../styles';
-import { LoadingOverlay } from '../components/modal';
 
 const ProfileScreen = ({
   accountAddress,
@@ -23,7 +22,6 @@ const ProfileScreen = ({
   onPressSettings,
   requests,
   showBlur,
-  showSpinner,
   transactions,
   transactionsCount,
 }) => (
@@ -46,7 +44,6 @@ const ProfileScreen = ({
         onPress={onPressBackButton}
       />
     </Header>
-    {showSpinner && <LoadingOverlay />}
     <ActivityList
       accountAddress={accountAddress}
       hasPendingTransaction={hasPendingTransaction}
@@ -57,6 +54,7 @@ const ProfileScreen = ({
           showBottomDivider={!isEmpty}
         />
       )}
+      isEmpty={isEmpty}
       nativeCurrency={nativeCurrency}
       requests={requests}
       transactions={areTransactionsFetched}
@@ -78,7 +76,6 @@ ProfileScreen.propTypes = {
   onPressSettings: PropTypes.func,
   requests: PropTypes.array,
   showBlur: PropTypes.bool,
-  showSpinner: PropTypes.bool,
   transactions: PropTypes.array,
   transactionsCount: PropTypes.number,
 };

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -9,9 +9,11 @@ import { FlexItem, Page } from '../components/layout';
 import { Icon } from '../components/icons';
 import { ProfileMasthead } from '../components/profile';
 import { colors, position } from '../styles';
+import { LoadingOverlay } from '../components/modal';
 
 const ProfileScreen = ({
   accountAddress,
+  areTransactionsFetching,
   blurOpacity,
   hasPendingTransaction,
   isEmpty,
@@ -35,6 +37,7 @@ const ProfileScreen = ({
         onPress={onPressBackButton}
       />
     </Header>
+    {areTransactionsFetching && <LoadingOverlay title="Importing..." />}
     <ActivityList
       accountAddress={accountAddress}
       hasPendingTransaction={hasPendingTransaction}
@@ -65,6 +68,7 @@ const ProfileScreen = ({
 
 ProfileScreen.propTypes = {
   accountAddress: PropTypes.string,
+  areTransactionsFetching: PropTypes.bool,
   blurOpacity: PropTypes.object,
   hasPendingTransaction: PropTypes.bool,
   isEmpty: PropTypes.bool,

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -13,7 +13,7 @@ import {
   withAccountSettings,
 } from '../hoc';
 import ProfileScreen from './ProfileScreen';
-import withAreTransactionsFetching from '../hoc/withAreTransactionsFetching';
+import witAreTransactionsFetched from '../hoc/withAreTransactionsFetched';
 
 export default compose(
   setDisplayName('ProfileScreen'),
@@ -22,7 +22,7 @@ export default compose(
   withAccountTransactions,
   withBlurTransitionProps,
   withIsWalletEmpty,
-  withAreTransactionsFetching,
+  witAreTransactionsFetched,
   withRequests,
   withHandlers({
     onPressBackButton: ({ navigation }) => () => navigation.navigate('WalletScreen'),

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -30,6 +30,6 @@ export default compose(
   }),
   withProps(({ areTransactionsFetched, isWalletEmpty, transactionsCount }) => ({
     isEmpty: isWalletEmpty && !transactionsCount,
-    showSpinner: !areTransactionsFetched && !isWalletEmpty,
+    isLoading: !areTransactionsFetched && !isWalletEmpty,
   })),
 )(ProfileScreen);

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -13,6 +13,7 @@ import {
   withAccountSettings,
 } from '../hoc';
 import ProfileScreen from './ProfileScreen';
+import withAreTransactionsFetching from '../hoc/withAreTransactionsFetching';
 
 export default compose(
   setDisplayName('ProfileScreen'),
@@ -21,6 +22,7 @@ export default compose(
   withAccountTransactions,
   withBlurTransitionProps,
   withIsWalletEmpty,
+  withAreTransactionsFetching,
   withRequests,
   withHandlers({
     onPressBackButton: ({ navigation }) => () => navigation.navigate('WalletScreen'),

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -6,14 +6,14 @@ import {
 import { setDisplayName } from 'recompose';
 import {
   withAccountAddress,
+  withAccountSettings,
   withAccountTransactions,
+  withAreTransactionsFetched,
   withBlurTransitionProps,
   withIsWalletEmpty,
   withRequests,
-  withAccountSettings,
 } from '../hoc';
 import ProfileScreen from './ProfileScreen';
-import witAreTransactionsFetched from '../hoc/withAreTransactionsFetched';
 
 export default compose(
   setDisplayName('ProfileScreen'),
@@ -22,13 +22,14 @@ export default compose(
   withAccountTransactions,
   withBlurTransitionProps,
   withIsWalletEmpty,
-  witAreTransactionsFetched,
+  withAreTransactionsFetched,
   withRequests,
   withHandlers({
     onPressBackButton: ({ navigation }) => () => navigation.navigate('WalletScreen'),
     onPressSettings: ({ navigation }) => () => navigation.navigate('SettingsModal'),
   }),
-  withProps(({ isWalletEmpty, transactionsCount }) => ({
+  withProps(({ areTransactionsFetched, isWalletEmpty, transactionsCount }) => ({
     isEmpty: isWalletEmpty && !transactionsCount,
+    showSpinner: !areTransactionsFetched && !isWalletEmpty,
   })),
 )(ProfileScreen);


### PR DESCRIPTION
## Motivation
There're a lot of things happened before making a list of transactions visible and especially when there's a lot of them it's reasonable to display feedback indicating that user is supposed to wait for a while.

## Changes
Some conditions have to be filled in a situation when spinner has to be displayed. Transactions have not to be fetched for the first time, there have to be not loaded from storage (array of them has to be empty) and `AddFundsInterstitial` shouldn't be visible.

I achieved it by hooking into the fetching process and tracking the state of fetching in store by special hoc. 