### PR TITLE
Catching up with changes from master for opensea patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Removed
 
+## [1.1.5-2](https://github.com/rainbow-me/rainbow/releases/tag/v1.1.5-2)
+### Changed
+* Bugfix for transaction history with null symbol
+
 ## [1.1.4-1](https://github.com/rainbow-me/rainbow/releases/tag/v1.1.4-1)
 ### Added
 * Support for importing private key and seed key

--- a/ios/Rainbow/Info.plist
+++ b/ios/Rainbow/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.5</string>
+	<string>1.1.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "1.1.5-1",
+  "version": "1.1.7-1",
   "private": true,
   "scripts": {
     "clean": "react-native-clean-project",


### PR DESCRIPTION
This is the workaround for the OpenSea change that included regular assets in the nft endpoint
