### PR TITLE
default exchange input mask to support 18 decimals max

### DIFF
--- a/src/components/exchange/ExchangeInput.js
+++ b/src/components/exchange/ExchangeInput.js
@@ -25,7 +25,7 @@ export default class ExchangeInput extends PureComponent {
     fontFamily: fonts.family.SFProDisplay,
     fontSize: fonts.size.h2,
     fontWeight: fonts.weight.medium,
-    mask: '[099999999999].[9999999999999]',
+    mask: '[099999999999999999].[999999999999999999]',
     placeholder: '0',
     placeholderTextColor: colors.alpha(colors.blueGreyDark, 0.5),
   };


### PR DESCRIPTION
As per discussion on Slack #dev channel:
- Let's add the 18 9's as the default prop mask in ExchangeInputField
- We can pad the part before the decimal with more 9s

A separate task has been created to update the mask prop more dynamically given the decimals of an asset.

There is further discussion in the Slack #dev channel regarding the first part of the mask before the decimal regarding ellipses