### PR TITLE
fetch token reserve info only after user has selected currencies to swap

### DIFF
--- a/src/handlers/uniswap.js
+++ b/src/handlers/uniswap.js
@@ -1,18 +1,16 @@
 import { getExecutionDetails, getTokenReserves } from '@uniswap/sdk';
 import contractMap from 'eth-contract-metadata';
 import { ethers } from 'ethers';
-import { compact, get, keyBy, map, slice, toLower, zipObject } from 'lodash';
+import { get, map, toLower, zipObject } from 'lodash';
 import {
   convertRawAmountToDecimalFormat,
   divide,
   fromWei,
   multiply,
 } from '../helpers/utilities';
-import { uniswapAssetAddresses } from '../references';
 import { loadWallet } from '../model/wallet';
 import exchangeABI from '../references/uniswap-exchange-abi.json';
 import erc20ABI from '../references/erc20-abi.json';
-import { promiseUtils } from '../utils';
 import { toHex, web3Provider } from './web3';
 
 const convertArgsForEthers = methodArguments =>
@@ -25,17 +23,10 @@ const convertValueForEthers = value => {
   return ethers.utils.hexlify(valueBigNumber);
 };
 
-export const getReserve = tokenAddress => getTokenReserves(tokenAddress);
-
-export const getReserves = async () => {
-  const uniswapTokens = slice(uniswapAssetAddresses, 1);
-  const reserves = await promiseUtils.PromiseAllWithFails(
-    map(uniswapTokens, token => getTokenReserves(token))
-  );
-  return keyBy(compact(reserves), reserve =>
-    toLower(get(reserve, 'token.address'))
-  );
-};
+export const getReserve = async tokenAddress =>
+  !tokenAddress || tokenAddress === 'eth'
+    ? Promise.resolve(null)
+    : getTokenReserves(toLower(tokenAddress));
 
 const getGasLimit = async (
   accountAddress,

--- a/src/hoc/withDataInit.js
+++ b/src/hoc/withDataInit.js
@@ -20,7 +20,6 @@ import {
 import {
   uniswapLoadState,
   uniswapClearState,
-  uniswapTokenReservesRefreshState,
   uniswapUpdateState,
 } from '../redux/uniswap';
 import {
@@ -28,6 +27,10 @@ import {
   uniqueTokensLoadState,
   uniqueTokensRefreshState,
 } from '../redux/uniqueTokens';
+import {
+  web3ListenerClearState,
+  web3ListenerInit,
+} from '../redux/web3listener';
 import { walletInit } from '../model/wallet';
 import {
   walletConnectLoadState,
@@ -60,10 +63,10 @@ export default Component =>
         uniqueTokensRefreshState,
         uniswapClearState,
         uniswapLoadState,
-        uniswapTokenReservesRefreshState,
         uniswapUpdateState,
         walletConnectClearState,
         walletConnectLoadState,
+        web3ListenerInit,
       }
     ),
     withHideSplashScreen,
@@ -77,6 +80,7 @@ export default Component =>
         }
       },
       clearAccountData: ownProps => async () => {
+        web3ListenerClearState();
         const p0 = ownProps.explorerClearState();
         const p1 = ownProps.dataClearState();
         const p2 = ownProps.clearIsWalletEmpty();
@@ -104,7 +108,7 @@ export default Component =>
         try {
           ownProps.explorerInit();
           ownProps.gasPricesInit();
-          ownProps.uniswapTokenReservesRefreshState();
+          ownProps.web3ListenerInit();
           await ownProps.uniqueTokensRefreshState();
         } catch (error) {
           // TODO error state

--- a/src/hoc/withUniswapAllowances.js
+++ b/src/hoc/withUniswapAllowances.js
@@ -1,14 +1,24 @@
 import { connect } from 'react-redux';
 import {
-  uniswapGetTokenReserve,
+  uniswapClearCurrenciesAndReserves,
   uniswapUpdateAllowances,
+  uniswapUpdateInputCurrency,
+  uniswapUpdateOutputCurrency,
   uniswapUpdatePendingApprovals,
 } from '../redux/uniswap';
 
 const mapStateToProps = ({
-  uniswap: { allowances, pendingApprovals, tokenReserves },
+  uniswap: {
+    allowances,
+    inputReserve,
+    outputReserve,
+    pendingApprovals,
+    tokenReserves,
+  },
 }) => ({
   allowances,
+  inputReserve,
+  outputReserve,
   pendingApprovals,
   tokenReserves,
 });
@@ -17,8 +27,10 @@ export default Component =>
   connect(
     mapStateToProps,
     {
-      uniswapGetTokenReserve,
+      uniswapClearCurrenciesAndReserves,
       uniswapUpdateAllowances,
+      uniswapUpdateInputCurrency,
+      uniswapUpdateOutputCurrency,
       uniswapUpdatePendingApprovals,
     }
   )(Component);

--- a/src/redux/web3listener.js
+++ b/src/redux/web3listener.js
@@ -1,0 +1,24 @@
+import { get } from 'lodash';
+import { getReserve } from '../handlers/uniswap';
+import { web3Provider } from '../handlers/web3';
+import { promiseUtils } from '../utils';
+import { uniswapUpdateTokenReserves } from './uniswap';
+
+// -- Actions ---------------------------------------- //
+const web3UpdateReserves = () => async (dispatch, getState) => {
+  const { inputCurrency, outputCurrency } = getState().uniswap;
+  if (!(inputCurrency || outputCurrency)) return;
+  const [inputReserve, outputReserve] = await promiseUtils.PromiseAllWithFails([
+    getReserve(get(inputCurrency, 'address')),
+    getReserve(get(outputCurrency, 'address')),
+  ]);
+  dispatch(uniswapUpdateTokenReserves(inputReserve, outputReserve));
+};
+
+export const web3ListenerInit = () => dispatch => {
+  web3Provider.on('block', () => dispatch(web3UpdateReserves()));
+};
+
+export const web3ListenerClearState = () => {
+  web3Provider.removeAllListeners('block');
+};


### PR DESCRIPTION
- Issue: performance slowdown when requesting token reserve information
for all Uniswap tokens every 15 seconds
- Solution: remove this bulk interval call and fetch only the needed token
reserves once a user has selected currencies to swap. Set up a listener
that updates token reserve information only for these selected currencies on any new block. Once the swap modal is closed, stop listening for the token reserve info.