### PR TITLE
Disable tap to dismiss for swap modal

### DIFF
--- a/src/components/GestureBlocker.js
+++ b/src/components/GestureBlocker.js
@@ -60,4 +60,8 @@ GestureBlocker.propTypes = {
   type: PropTypes.string,
 };
 
+GestureBlocker.defaultProps = {
+  onTouchEnd: () => null,
+};
+
 export default React.memo(GestureBlocker);

--- a/src/components/gas/GasSpeedLabelPagerItem.js
+++ b/src/components/gas/GasSpeedLabelPagerItem.js
@@ -52,7 +52,7 @@ const GasSpeedLabelPagerItem = ({ label, selected, shouldAnimate }) => {
   const isLast = index === gasUtils.GasSpeedOrder.length - 1;
 
   const transitionVal = useToggle(
-    selected,
+    !selected,
     duration + (isFirst ? 50 : 0),
     Easing.out(Easing.ease)
   );

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -730,10 +730,7 @@ class ExchangeModal extends React.Component {
               radius={exchangeModalBorderRadius}
               overflow="visible"
             >
-              <GestureBlocker
-                type="top"
-                onTouchEnd={() => this.props.navigation.pop()}
-              />
+              <GestureBlocker type="top" />
               <ExchangeModalHeader />
               <ExchangeInputField
                 inputAmount={inputAmountDisplay}
@@ -784,10 +781,7 @@ class ExchangeModal extends React.Component {
               </Fragment>
             )}
             <Column>
-              <GestureBlocker
-                type="bottom"
-                onTouchEnd={() => this.props.navigation.pop()}
-              />
+              <GestureBlocker type="bottom" />
             </Column>
           </AnimatedFloatingPanels>
         </Centered>


### PR DESCRIPTION
It ws pretty easy to accidentally dismiss snap stack,  especially when trying to change the transaction speed, so the tap to dismiss is dismissed.