### PR TITLE
fix: removal of pending unlock transactions once they are confirmed

### DIFF
--- a/src/components/coin-row/ExchangeCoinRow.js
+++ b/src/components/coin-row/ExchangeCoinRow.js
@@ -10,11 +10,15 @@ import BottomRowText from './BottomRowText';
 import CoinName from './CoinName';
 import CoinRow from './CoinRow';
 
-const BottomRow = ({ balance, native, showBalance, symbol }) => (
-  <BottomRowText>
-    {showBalance ? `${balance.display} ≈ ${native.balance.display}` : symbol}
-  </BottomRowText>
-);
+const BottomRow = ({ balance, native, showBalance, symbol }) => {
+  let text = symbol;
+  if (showBalance && native) {
+    text = `${balance.display} ≈ ${native.balance.display}`;
+  } else if (showBalance) {
+    text = `${balance.display}`;
+  }
+  return <BottomRowText>{text}</BottomRowText>;
+};
 
 const balanceShape = {
   balance: PropTypes.shape({ display: PropTypes.string }),

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -134,6 +134,14 @@ const parseTransaction = (txn, accountAddress, nativeCurrency) => {
     };
     internalTransactions = [assetInternalTransaction];
   }
+  if (isEmpty(changes) && txn.type === 'authorize') {
+    const approveInternalTransaction = {
+      address_from: transaction.from,
+      address_to: transaction.to,
+      asset: get(txn, 'meta.asset'),
+    };
+    internalTransactions = [approveInternalTransaction];
+  }
   // logic below: prevent sending yourself money to be seen as a trade
   if (
     changes.length === 2 &&


### PR DESCRIPTION
https://linear.app/issue/RAI-51

This also includes a fix for the ExchangeCoinRow (in Asset selection) to display only the balance if the pricing data is unavailable for an asset.