### PR TITLE
fix: convert slippage bips to percentage format

### DIFF
--- a/src/helpers/__tests__/utilities.test.js
+++ b/src/helpers/__tests__/utilities.test.js
@@ -1,4 +1,53 @@
-import { updatePrecisionToDisplay } from '../utilities';
+import {
+  convertBipsToPercentage,
+  handleSignificantDecimals,
+  updatePrecisionToDisplay,
+} from '../utilities';
+
+it('handleSignificantDecimals greater than 1, decimals 2', () => {
+  const result = handleSignificantDecimals('5.123', 2);
+  expect(result).toBe('5.12');
+});
+
+it('handleSignificantDecimals greater than 1, decimals 18', () => {
+  const result = handleSignificantDecimals('5.1234', 18);
+  expect(result).toBe('5.123');
+});
+
+it('handleSignificantDecimals greater than 1, decimals 18, long trail', () => {
+  const result = handleSignificantDecimals('5.00001234', 18);
+  expect(result).toBe('5.00');
+});
+
+it('handleSignificantDecimals less than 1 and few decimals', () => {
+  const result = handleSignificantDecimals('0.012344', 2);
+  expect(result).toBe('0.0123');
+});
+
+it('handleSignificantDecimals less than 1 and many decimals', () => {
+  const result = handleSignificantDecimals('0.00000000123', 18);
+  expect(result).toBe('0.00');
+});
+
+it('convertBipsToPercentage, 2 decimal places', () => {
+  const result = convertBipsToPercentage('1', 2);
+  expect(result).toBe('0.01');
+});
+
+it('convertBipsToPercentage, 1 decimal place', () => {
+  const result = convertBipsToPercentage('1', 1);
+  expect(result).toBe('0.0');
+});
+
+it('convertBipsToPercentage, 10 bips to 1 decimal', () => {
+  const result = convertBipsToPercentage('10', 1);
+  expect(result).toBe('0.1');
+});
+
+it('convertBipsToPercentage', () => {
+  const result = convertBipsToPercentage('12.34567', 2);
+  expect(result).toBe('0.12');
+});
 
 it('updatePrecisionToDisplay1', () => {
   const result = updatePrecisionToDisplay('0.00000000123', '0.1234987234');

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -184,20 +184,6 @@ export const convertAmountFromNativeValue = (value, priceUnit) =>
     .toFixed();
 
 /**
- * @desc handle signficant decimals in display format
- * @param  {String|Number}   value
- * @param  {Number}   decimals
- * @param  {Number}   buffer
- * @return {String}
- */
-export const handleSignificantDecimals = (value, decimals, buffer) => {
-  const result = significantDecimals(value, decimals, buffer);
-  return BigNumber(`${result}`).dp() <= 2
-    ? BigNumber(`${result}`).toFormat(2)
-    : BigNumber(`${result}`).toFormat();
-};
-
-/**
  * @desc convert from string to number
  * @param  {String}  value
  * @return {Number}
@@ -220,7 +206,7 @@ export const smallerThan = (numberOne, numberTwo) =>
  * @param  {Number}   buffer
  * @return {String}
  */
-export const significantDecimals = (value, decimals, buffer) => {
+export const handleSignificantDecimals = (value, decimals, buffer) => {
   if (
     !BigNumber(`${decimals}`).isInteger() ||
     (buffer && !BigNumber(`${buffer}`).isInteger())
@@ -242,7 +228,9 @@ export const significantDecimals = (value, decimals, buffer) => {
   }
   let result = BigNumber(`${value}`).toFixed(decimals);
   result = BigNumber(`${result}`).toFixed();
-  return result;
+  return BigNumber(`${result}`).dp() <= 2
+    ? BigNumber(`${result}`).toFormat(2)
+    : BigNumber(`${result}`).toFormat();
 };
 
 /**
@@ -340,10 +328,25 @@ export const convertAmountToBalanceDisplay = (value, asset, buffer) => {
  * @param  {Number}     buffer
  * @return {String}
  */
-export const convertAmountToPercentageDisplay = (value, buffer) => {
-  const display = handleSignificantDecimals(value, 2, buffer);
+export const convertAmountToPercentageDisplay = (
+  value,
+  decimals = 2,
+  buffer
+) => {
+  const display = handleSignificantDecimals(value, decimals, buffer);
   return `${display}%`;
 };
+
+/**
+ * @desc convert from bips amount to percentage format
+ * @param  {BigNumber}  value in bips
+ * @param  {Number}     decimals
+ * @return {String}
+ */
+export const convertBipsToPercentage = (value, decimals = 2) =>
+  BigNumber(`${value}`)
+    .shiftedBy(-2)
+    .toFixed(decimals);
 
 /**
  * @desc convert from amount value to display formatted string

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -386,7 +386,7 @@ class ExchangeModal extends React.Component {
         );
       }
 
-      const slippage = get(tradeDetails, 'marketRateSlippage', 0).toString();
+      const slippage = get(tradeDetails, 'executionRateSlippage', 0).toFixed();
 
       this.setState({
         inputExecutionRate,


### PR DESCRIPTION
https://linear.app/issue/RAI-57

Fix: convert slippage bips to percentage format

Changes made:
- Updated slippage warning thresholds to use bips for clarity
- Fix slippage bips to percentage format before being displayed
- Use execution rate slippage instead of market rate slippage

Market rate slippage is the slippage between the pre and post trade
market rates. (Market rates only take into account the input / output
token reserves.)
Execution rate slippage is the slippage between the pre-trade market
rate and the execution  rate. (Execution rates take into account the
actual trade itself as well as fees.)
The main difference between these two slippage rate is the fee.