### PR TITLE
Fixes for multiRemove and network capitalization in Settings

### DIFF
--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -1,3 +1,4 @@
+import { upperFirst } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { InteractionManager, Linking, ScrollView } from 'react-native';
@@ -88,7 +89,7 @@ const SettingsSection = ({
         onPress={onPressNetwork}
         label="Network"
       >
-        <ListItemArrowGroup>{network || ''}</ListItemArrowGroup>
+        <ListItemArrowGroup>{upperFirst(network) || ''}</ListItemArrowGroup>
       </ListItem>
       <ListItem
         icon={<SettingIcon source={CurrencyIcon} />}

--- a/src/handlers/localstorage/uniswap.js
+++ b/src/handlers/localstorage/uniswap.js
@@ -1,9 +1,10 @@
+import { forEach } from 'lodash';
 import {
   getAccountLocal,
   getGlobal,
-  removeAccountLocalMulti,
   saveAccountLocal,
   saveGlobal,
+  removeAccountLocal,
 } from './common';
 
 const ASSETS = 'uniswapassets';
@@ -66,4 +67,6 @@ export const saveUniswapPendingApprovals = (
   );
 
 export const removeUniswapStorage = (accountAddress, network) =>
-  removeAccountLocalMulti(uniswapAccountLocalKeys, accountAddress, network);
+  forEach(uniswapAccountLocalKeys, key =>
+    removeAccountLocal(key, accountAddress, network)
+  );


### PR DESCRIPTION
multiRemove is only available directly on AsyncStorage, not through the react-native-storage package we are using. We will use multiGet/multiRemove once we move over to the AsyncStorage package directly.