### PR TITLE
Fix: do not hide swap modal or send modal when canceling authentication

### DIFF
--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
@@ -99,8 +99,7 @@ export default class HoldToAuthorizeButton extends PureComponent {
 
   componentDidUpdate = () => {
     if (this.state.isAuthorizing && !this.props.isAuthorizing) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ isAuthorizing: false });
+      this.onFinishAuthorizing();
     }
   };
 
@@ -109,6 +108,17 @@ export default class HoldToAuthorizeButton extends PureComponent {
   tapHandlerState = 1;
 
   animation = new Value(0);
+
+  onFinishAuthorizing = () => {
+    const { disabled } = this.props;
+    if (!disabled) {
+      buildAnimation(this.animation, {
+        duration: calculateReverseDuration(this.animation),
+        isInteraction: true,
+        toValue: 0,
+      }).start(() => this.setState({ isAuthorizing: false }));
+    }
+  };
 
   onTapChange = ({ nativeEvent: { state } }) => {
     const { disabled, onPress } = this.props;

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -8,6 +8,7 @@ const ConfirmExchangeButton = ({
   disabled,
   inputCurrencyName,
   isAssetApproved,
+  isAuthorizing,
   isSufficientBalance,
   isUnlockingAsset,
   onSubmit,
@@ -33,6 +34,7 @@ const ConfirmExchangeButton = ({
       disabledBackgroundColor={colors.grey20}
       flex={1}
       hideBiometricIcon={isUnlockingAsset || !isAssetApproved}
+      isAuthorizing={isAuthorizing}
       label={label}
       onLongPress={isAssetApproved ? onSubmit : null}
       onPress={isAssetApproved ? null : onUnlockAsset}
@@ -57,6 +59,7 @@ ConfirmExchangeButton.propTypes = {
   disabled: PropTypes.bool,
   inputCurrencyName: PropTypes.string,
   isAssetApproved: PropTypes.bool,
+  isAuthorizing: PropTypes.bool,
   isSufficientBalance: PropTypes.bool,
   isUnlockingAsset: PropTypes.bool,
   onSubmit: PropTypes.func,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -113,6 +113,7 @@ class ExchangeModal extends Component {
     inputExecutionRate: null,
     inputNativePrice: null,
     isAssetApproved: true,
+    isAuthorizing: false,
     isSufficientBalance: true,
     isUnlockingAsset: false,
     nativeAmount: null,
@@ -152,6 +153,7 @@ class ExchangeModal extends Component {
       'inputAmount',
       'inputCurrency.uniqueId',
       'isAssetApproved',
+      'isAuthorizing',
       'isSufficientBalance',
       'isUnlockingAsset',
       'nativeAmount',
@@ -558,6 +560,7 @@ class ExchangeModal extends Component {
   };
 
   handleSubmit = async () => {
+    this.setState({ isAuthorizing: true });
     const {
       accountAddress,
       dataAddNewTransaction,
@@ -570,6 +573,7 @@ class ExchangeModal extends Component {
     try {
       const gasPrice = get(selectedGasPrice, 'value.amount');
       const txn = await executeSwap(tradeDetails, gasLimit, gasPrice);
+      this.setState({ isAuthorizing: false });
       if (txn) {
         dataAddNewTransaction({
           amount: inputAmount,
@@ -579,9 +583,10 @@ class ExchangeModal extends Component {
           nonce: get(txn, 'nonce'),
           to: get(txn, 'to'),
         });
+        navigation.navigate('ProfileScreen');
       }
-      navigation.navigate('ProfileScreen');
     } catch (error) {
+      this.setState({ isAuthorizing: false });
       console.log('error submitting swap', error);
       navigation.navigate('WalletScreen');
     }
@@ -781,6 +786,7 @@ class ExchangeModal extends Component {
       // inputExecutionRate,
       // inputNativePrice,
       isAssetApproved,
+      isAuthorizing,
       isSufficientBalance,
       isUnlockingAsset,
       nativeAmount,
@@ -858,6 +864,7 @@ class ExchangeModal extends Component {
                     disabled={isAssetApproved && !Number(inputAmountDisplay)}
                     inputCurrencyName={get(inputCurrency, 'symbol')}
                     isAssetApproved={isAssetApproved}
+                    isAuthorizing={isAuthorizing}
                     isSufficientBalance={isSufficientBalance}
                     isUnlockingAsset={isUnlockingAsset}
                     onSubmit={this.handleSubmit}

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -55,6 +55,7 @@ export default class TransactionConfirmationScreen extends PureComponent {
 
   state = {
     biometryType: null,
+    isAuthorizing: false,
     sendLongPressProgress: new Animated.Value(0),
   };
 
@@ -94,21 +95,28 @@ export default class TransactionConfirmationScreen extends PureComponent {
     const { onConfirm } = this.props;
     const { sendLongPressProgress } = this.state;
 
+    this.setState({ isAuthorizing: true });
     Animated.timing(sendLongPressProgress, {
       duration: (sendLongPressProgress._value / 100) * 800,
       toValue: 0,
     }).start();
 
-    await onConfirm();
+    try {
+      await onConfirm();
+      this.setState({ isAuthorizing: false });
+    } catch (error) {
+      this.setState({ isAuthorizing: false });
+    }
   };
 
   renderSendButton = () => (
     <HoldToAuthorizeButton
       isAuthorizing={this.state.isAuthorizing}
+      label={`Hold to ${
+        this.props.method === SEND_TRANSACTION ? 'Send' : 'Sign'
+      }`}
       onLongPress={this.onLongPressSend}
-    >
-      {`Hold to ${this.props.method === SEND_TRANSACTION ? 'Send' : 'Sign'}`}
-    </HoldToAuthorizeButton>
+    />
   );
 
   requestHeader = () => {


### PR DESCRIPTION
New behavior:
- Will not navigate away when authorization fails (either by failure or
user cancel)
- Fix for Hold to Send/Swap/Sign buttons to animate back from
Authorizing state (for the Send, Swap, and WalletConnect flows)