### PR TITLE
Fix: swap input / output currencies when selection causes match

### DIFF
--- a/src/redux/uniswap.js
+++ b/src/redux/uniswap.js
@@ -115,7 +115,7 @@ export const uniswapUpdateTokenReserves = (
 };
 
 export const uniswapUpdateInputCurrency = inputCurrency => async dispatch => {
-  const inputReserve = await getReserve(get(inputCurrency, 'address'));
+  const inputReserve = await getReserve(get(inputCurrency, 'address', null));
   dispatch({
     payload: {
       inputCurrency,
@@ -126,7 +126,7 @@ export const uniswapUpdateInputCurrency = inputCurrency => async dispatch => {
 };
 
 export const uniswapUpdateOutputCurrency = outputCurrency => async dispatch => {
-  const outputReserve = await getReserve(get(outputCurrency, 'address'));
+  const outputReserve = await getReserve(get(outputCurrency, 'address', null));
   dispatch({
     payload: {
       outputCurrency,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -685,25 +685,18 @@ class ExchangeModal extends Component {
     });
   };
 
-  setInputCurrency = (inputCurrency, force) => {
-    const { outputCurrency } = this.state;
+  setInputCurrency = (inputCurrency, userSelected = true) => {
+    const { inputCurrency: previousInputCurrency, outputCurrency } = this.state;
 
-    if (!isSameAsset(inputCurrency, this.state.inputCurrency)) {
+    if (!isSameAsset(inputCurrency, previousInputCurrency)) {
       this.clearForm();
     }
 
     this.setState({ inputCurrency });
+    this.props.uniswapUpdateInputCurrency(inputCurrency);
 
-    if (!force) {
-      this.props.uniswapUpdateInputCurrency(inputCurrency);
-    }
-
-    if (!force && isSameAsset(inputCurrency, outputCurrency)) {
-      if (!isNil(inputCurrency) && !isNil(outputCurrency)) {
-        this.setOutputCurrency(null, true);
-      } else {
-        this.setOutputCurrency(inputCurrency, true);
-      }
+    if (userSelected && isSameAsset(inputCurrency, outputCurrency)) {
+      this.setOutputCurrency(previousInputCurrency, false);
     }
   };
 
@@ -743,13 +736,13 @@ class ExchangeModal extends Component {
         amountDisplay !== undefined ? amountDisplay : outputAmount,
     });
 
-  setOutputCurrency = (outputCurrency, force) => {
-    const { allAssets } = this.props;
-    const { inputCurrency } = this.state;
+  setOutputCurrency = (outputCurrency, userSelected = true) => {
+    const {
+      inputCurrency,
+      outputCurrency: previousOutputCurrency,
+    } = this.state;
 
-    if (!force) {
-      this.props.uniswapUpdateOutputCurrency(outputCurrency);
-    }
+    this.props.uniswapUpdateOutputCurrency(outputCurrency);
 
     this.setState({
       inputAsExactAmount: true,
@@ -757,15 +750,8 @@ class ExchangeModal extends Component {
       showConfirmButton: !!outputCurrency,
     });
 
-    if (!force && isSameAsset(inputCurrency, outputCurrency)) {
-      const outputAddress = toLower(outputCurrency.address);
-      const asset = ethereumUtils.getAsset(allAssets, outputAddress);
-
-      if (!isNil(asset) && !isNil(inputCurrency) && !isNil(outputCurrency)) {
-        this.setInputCurrency(null, true);
-      } else {
-        this.setInputCurrency(outputCurrency, true);
-      }
+    if (userSelected && isSameAsset(inputCurrency, outputCurrency)) {
+      this.setInputCurrency(previousOutputCurrency, false);
     }
   };
 


### PR DESCRIPTION
https://linear.app/issue/RAI-55

Inverted and renamed "force" flag to be clearer (it used to represent when the currency selection was programmatically done. Now it indicates when a currency selection is from a user's selection action.)

Also removed the additional check for output currency which used to check that an asset would exist in the user's wallet when we auto-updated the input currency. This is not needed as this would imply the user could have set this in their input currency in the first place, which they can't.