### PR TITLE
save keyboard height to local storage

### DIFF
--- a/src/components/layout/KeyboardFixedOpenLayout.js
+++ b/src/components/layout/KeyboardFixedOpenLayout.js
@@ -8,9 +8,10 @@ import { padding, position } from '../../styles';
 import { deviceUtils, safeAreaInsetValues } from '../../utils';
 import Centered from './Centered';
 import { setKeyboardHeight } from '../../handlers/localstorage/globalSettings';
+import { calculateKeyboardHeight } from '../../helpers/keyboardHeight';
 
-const FallbackKeyboardHeight = Math.floor(
-  deviceUtils.dimensions.height * 0.333
+const FallbackKeyboardHeight = calculateKeyboardHeight(
+  deviceUtils.dimensions.height
 );
 
 const Container = styled.View`

--- a/src/components/layout/KeyboardFixedOpenLayout.js
+++ b/src/components/layout/KeyboardFixedOpenLayout.js
@@ -7,6 +7,7 @@ import { withKeyboardHeight } from '../../hoc';
 import { padding, position } from '../../styles';
 import { deviceUtils, safeAreaInsetValues } from '../../utils';
 import Centered from './Centered';
+import { setKeyboardHeight } from '../../handlers/localstorage/globalSettings';
 
 const FallbackKeyboardHeight = Math.floor(
   deviceUtils.dimensions.height * 0.333
@@ -32,12 +33,10 @@ class KeyboardFixedOpenLayout extends PureComponent {
   };
 
   componentDidMount = () => {
-    if (!this.props.keyboardHeight) {
-      this.willShowListener = Keyboard.addListener(
-        'keyboardWillShow',
-        this.keyboardWillShow
-      );
-    }
+    this.willShowListener = Keyboard.addListener(
+      'keyboardWillShow',
+      this.keyboardWillShow
+    );
   };
 
   componentWillUnmount = () => this.clearKeyboardListeners();
@@ -53,7 +52,11 @@ class KeyboardFixedOpenLayout extends PureComponent {
   };
 
   keyboardWillShow = async ({ endCoordinates: { height } }) => {
-    this.props.setKeyboardHeight(Math.floor(height));
+    if (height !== this.props.keyboardHeight) {
+      const keyboardHeight = Math.floor(height);
+      setKeyboardHeight(keyboardHeight);
+      this.props.setKeyboardHeight(keyboardHeight);
+    }
     this.clearKeyboardListeners();
   };
 

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -1,6 +1,7 @@
 import { getGlobal, saveGlobal } from './common';
 
 const APPSTORE_REVIEW_COUNT = 'appStoreReviewRequestCount';
+const KEYBOARD_HEIGHT = 'keyboardHeight';
 const LANGUAGE = 'language';
 const NATIVE_CURRENCY = 'nativeCurrency';
 
@@ -12,6 +13,10 @@ export const saveAppStoreReviewCount = reviewCount =>
 export const getLanguage = () => getGlobal(LANGUAGE, 'en');
 
 export const saveLanguage = language => saveGlobal(LANGUAGE, language);
+
+export const getKeyboardHeight = () => getGlobal(KEYBOARD_HEIGHT, null);
+
+export const setKeyboardHeight = height => saveGlobal(KEYBOARD_HEIGHT, height);
 
 export const getNativeCurrency = () => getGlobal(NATIVE_CURRENCY, 'USD');
 

--- a/src/helpers/keyboardHeight.js
+++ b/src/helpers/keyboardHeight.js
@@ -1,0 +1,25 @@
+import { deviceUtils } from '../utils';
+
+export const calculateKeyboardHeight = screenHeight => {
+  let keyboardHeight = 0;
+  switch (screenHeight) {
+    case 568:
+      keyboardHeight = 216;
+      break;
+    case 667:
+      keyboardHeight = 216;
+      break;
+    case 736:
+      keyboardHeight = 226;
+      break;
+    case 812:
+      keyboardHeight = 291;
+      break;
+    case 896:
+      keyboardHeight = 301;
+      break;
+    default:
+      keyboardHeight = Math.floor(deviceUtils.dimensions.height * 0.333);
+  }
+  return keyboardHeight;
+};

--- a/src/helpers/keyboardHeight.js
+++ b/src/helpers/keyboardHeight.js
@@ -1,5 +1,3 @@
-import { deviceUtils } from '../utils';
-
 export const calculateKeyboardHeight = screenHeight => {
   let keyboardHeight = 0;
   switch (screenHeight) {
@@ -19,7 +17,7 @@ export const calculateKeyboardHeight = screenHeight => {
       keyboardHeight = 301;
       break;
     default:
-      keyboardHeight = Math.floor(deviceUtils.dimensions.height * 0.333);
+      keyboardHeight = Math.floor(screenHeight * 0.333);
   }
   return keyboardHeight;
 };

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -22,9 +22,11 @@ import {
   withStatusBarStyle,
   withUniqueTokens,
   withUniswapLiquidityTokenInfo,
+  withKeyboardHeight,
 } from '../hoc';
 import { position } from '../styles';
 import { isNewValueForObjectPaths } from '../utils';
+import { getKeyboardHeight } from '../handlers/localstorage/globalSettings';
 
 class WalletScreen extends Component {
   static propTypes = {
@@ -41,6 +43,7 @@ class WalletScreen extends Component {
     refreshAccountData: PropTypes.func,
     scrollViewTracker: PropTypes.object,
     sections: PropTypes.array,
+    setKeyboardHeight: PropTypes.func,
     setSafeTimeout: PropTypes.func,
     uniqueTokens: PropTypes.array,
   };
@@ -48,6 +51,10 @@ class WalletScreen extends Component {
   componentDidMount = async () => {
     try {
       await this.props.initializeWallet();
+      const keyboardheight = await getKeyboardHeight();
+      if (keyboardheight) {
+        this.props.setKeyboardHeight(keyboardheight);
+      }
     } catch (error) {
       // TODO error state
     }
@@ -114,6 +121,7 @@ export default compose(
   withNavigationFocus,
   withIsWalletEmpty,
   withIsWalletEthZero,
+  withKeyboardHeight,
   withStatusBarStyle('dark-content'),
   withProps(buildWalletSectionsSelector),
   withProps({ scrollViewTracker: new Animated.Value(0) })


### PR DESCRIPTION
Save keyboard height to local storage to avoid jumps and overlays in modals using keyboard

Since it has to save the height of the keyboard in runtime, this fix won't affect the very first keyboard appearance after introducing it, but the issue won't happen ever since.