### PR TITLE
Fix: swap bugs for output assets without a price + non-18 decimal input assets

### DIFF
--- a/src/helpers/__tests__/utilities.test.js
+++ b/src/helpers/__tests__/utilities.test.js
@@ -1,8 +1,19 @@
 import {
+  convertAmountFromNativeValue,
   convertBipsToPercentage,
   handleSignificantDecimals,
   updatePrecisionToDisplay,
 } from '../utilities';
+
+it('convertAmountFromNativeValue', () => {
+  const result = convertAmountFromNativeValue('1', '40.00505', 5);
+  expect(result).toBe('0.02499');
+});
+
+it('convertAmountFromNativeValue with trailing zeros', () => {
+  const result = convertAmountFromNativeValue('1', '1', 5);
+  expect(result).toBe('1');
+});
 
 it('handleSignificantDecimals greater than 1, decimals 2', () => {
   const result = handleSignificantDecimals('5.123', 2);

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -193,10 +193,12 @@ export const divide = (numberOne, numberTwo) =>
  * @param  {Number}   priceUnit
  * @return {String}
  */
-export const convertAmountFromNativeValue = (value, priceUnit) =>
-  BigNumber(value)
-    .dividedBy(BigNumber(priceUnit))
-    .toFixed();
+export const convertAmountFromNativeValue = (value, priceUnit, decimals = 18) =>
+  BigNumber(
+    BigNumber(value)
+      .dividedBy(BigNumber(priceUnit))
+      .toFixed(decimals, BigNumber.ROUND_DOWN)
+  ).toFixed();
 
 /**
  * @desc convert from string to number

--- a/src/redux/send.js
+++ b/src/redux/send.js
@@ -156,7 +156,11 @@ export const sendUpdateNativeAmount = nativeAmount => (dispatch, getState) => {
   let _assetAmount = '';
   if (_nativeAmount.length) {
     const priceUnit = get(selected, 'price.value', 0);
-    const assetAmount = convertAmountFromNativeValue(_nativeAmount, priceUnit);
+    const assetAmount = convertAmountFromNativeValue(
+      _nativeAmount,
+      priceUnit,
+      selected.decimals
+    );
     _assetAmount = formatInputDecimals(assetAmount, _nativeAmount);
   }
 

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -497,11 +497,14 @@ class ExchangeModal extends Component {
             updatedOutputAmount,
             outputDecimals
           );
-
           if (rawUpdatedOutputAmount !== '0') {
+            let outputNativePrice = get(outputCurrency, 'price.value', null);
+            if (isNil(outputNativePrice)) {
+              outputNativePrice = this.getMarketPrice();
+            }
             const updatedOutputAmountDisplay = updatePrecisionToDisplay(
               rawUpdatedOutputAmount,
-              get(outputCurrency, 'price.value')
+              outputNativePrice
             );
 
             this.setOutputAmount(

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -755,7 +755,11 @@ class ExchangeModal extends Component {
         if (isNil(nativePrice)) {
           nativePrice = this.getMarketPrice();
         }
-        inputAmount = convertAmountFromNativeValue(nativeAmount, nativePrice);
+        inputAmount = convertAmountFromNativeValue(
+          nativeAmount,
+          nativePrice,
+          inputCurrency.decimals
+        );
         inputAmountDisplay = updatePrecisionToDisplay(
           inputAmount,
           nativePrice,


### PR DESCRIPTION
Bug 1: DGX —> MKR typing into the native input doesn't update the output amount
Cause: We were not taking into account the input asset's decimals when converting from native prices to input prices, causing "raw" values with decimals in the end.

Bug 2: ETH —> Matic or WCK doesn't work when typing in input
Cause: We were not overwriting the prices from Uniswap for output prices (which we want to have for displaying decimals based on native price)