### PR TITLE
Update location for finding the native tag on input ref

### DIFF
--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -78,7 +78,7 @@ const isSameAsset = (a, b) => {
   return assetA === assetB;
 };
 
-const getNativeTag = field => get(field, '_nativeTag');
+const getNativeTag = field => get(field, '_inputRef._nativeTag');
 
 class ExchangeModal extends Component {
   static propTypes = {


### PR DESCRIPTION
This is so we can update the focused input appropriately after a user selects from input: ETH, output: null, to selecting output of ETH (which causes the input currency to be null)