### PR TITLE
add pending request count to determine isEmpty variable

### DIFF
--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -20,7 +20,7 @@ export default compose(
     onPressSettings: ({ navigation }) => () =>
       navigation.navigate('SettingsModal'),
   }),
-  withProps(({ isWalletEmpty, transactionsCount }) => ({
-    isEmpty: isWalletEmpty && !transactionsCount,
+  withProps(({ isWalletEmpty, transactionsCount, pendingRequestCount }) => ({
+    isEmpty: isWalletEmpty && !transactionsCount && !pendingRequestCount,
   }))
 )(ProfileScreen);


### PR DESCRIPTION
I realized that when you have an empty wallet and want to receive something, the AddFundsInterstitial doesn't disappear as it should.
![IMG_0280](https://user-images.githubusercontent.com/42337257/72086806-d932e380-3307-11ea-93f9-51293af9901c.PNG)

Just added some flag to make it disappear.