### PR TITLE
Feat: Watch pending transactions

### DIFF
--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -32,6 +32,12 @@ export const web3SetHttpProvider = network => {
 export const sendRpcCall = async payload =>
   web3Provider.send(payload.method, payload.params);
 
+export const getTransactionByHash = txHash =>
+  sendRpcCall({
+    method: 'eth_getTransactionByHash',
+    params: [txHash],
+  });
+
 /**
  * @desc check if hex string
  * @param {String} value

--- a/src/hoc/withDataInit.js
+++ b/src/hoc/withDataInit.js
@@ -7,26 +7,33 @@ import { compose, withHandlers } from 'recompact';
 import { getIsWalletEmpty } from '../handlers/localstorage/accountLocal';
 import { hasEthBalance } from '../handlers/web3';
 import { walletInit } from '../model/wallet';
+
 import {
   dataClearState,
   dataLoadState,
   dataTokenOverridesInit,
+  dataWatchPendingTransactions
 } from '../redux/data';
+
 import { explorerClearState, explorerInit } from '../redux/explorer';
 import { gasClearState, gasPricesInit } from '../redux/gas';
 import { clearIsWalletEmpty } from '../redux/isWalletEmpty';
 import { setIsWalletEthZero } from '../redux/isWalletEthZero';
 import { nonceClearState } from '../redux/nonce';
 import { contactsLoadState } from '../redux/contacts';
+
 import {
   clearOpenStateSettings,
   openStateSettingsLoadState,
 } from '../redux/openStateSettings';
+
 import { requestsLoadState, requestsClearState } from '../redux/requests';
+
 import {
   settingsLoadState,
   settingsUpdateAccountAddress,
 } from '../redux/settings';
+
 import {
   uniswapLoadState,
   uniswapClearState,
@@ -58,6 +65,7 @@ export default Component =>
       dataClearState,
       dataLoadState,
       dataTokenOverridesInit,
+      dataWatchPendingTransactions,
       explorerClearState,
       explorerInit,
       gasClearState,

--- a/src/hoc/withDataInit.js
+++ b/src/hoc/withDataInit.js
@@ -7,33 +7,26 @@ import { compose, withHandlers } from 'recompact';
 import { getIsWalletEmpty } from '../handlers/localstorage/accountLocal';
 import { hasEthBalance } from '../handlers/web3';
 import { walletInit } from '../model/wallet';
-
 import {
   dataClearState,
   dataLoadState,
   dataTokenOverridesInit,
-  dataWatchPendingTransactions
 } from '../redux/data';
-
 import { explorerClearState, explorerInit } from '../redux/explorer';
 import { gasClearState, gasPricesInit } from '../redux/gas';
 import { clearIsWalletEmpty } from '../redux/isWalletEmpty';
 import { setIsWalletEthZero } from '../redux/isWalletEthZero';
 import { nonceClearState } from '../redux/nonce';
 import { contactsLoadState } from '../redux/contacts';
-
 import {
   clearOpenStateSettings,
   openStateSettingsLoadState,
 } from '../redux/openStateSettings';
-
 import { requestsLoadState, requestsClearState } from '../redux/requests';
-
 import {
   settingsLoadState,
   settingsUpdateAccountAddress,
 } from '../redux/settings';
-
 import {
   uniswapLoadState,
   uniswapClearState,
@@ -65,7 +58,6 @@ export default Component =>
       dataClearState,
       dataLoadState,
       dataTokenOverridesInit,
-      dataWatchPendingTransactions,
       explorerClearState,
       explorerInit,
       gasClearState,

--- a/src/model/wallet.js
+++ b/src/model/wallet.js
@@ -209,7 +209,7 @@ const saveWalletDetails = async (seedPhrase, privateKey, address) => {
 
   if (canAuthenticate) {
     // eslint-disable-next-line no-undef
-    isSimulator = __DEV__ && (await DeviceInfo.isSimulator());
+    isSimulator = __DEV__ && (await DeviceInfo.isEmulator());
   }
 
   if (canAuthenticate && !isSimulator) {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -18,9 +18,7 @@ import parseTransactions from '../parsers/transactions';
 import { loweredTokenOverridesFallback } from '../references';
 import { isLowerCaseMatch } from '../utils';
 import TransactionStatusTypes from '../helpers/transactionStatusTypes';
-
 import { sendRpcCall } from '../handlers/web3';
-
 import {
   uniswapRemovePendingApproval,
   uniswapUpdateAssetPrice,
@@ -250,7 +248,6 @@ export const dataAddNewTransaction = txDetails => (dispatch, getState) =>
           payload: _transactions,
           type: DATA_ADD_NEW_TRANSACTION_SUCCESS,
         });
-        console.log('NEW TX: ', parsedTransaction);
 
         dispatch(startPendingTransactionWatcher());
 
@@ -270,45 +267,32 @@ export const dataWatchPendingTransactions = () => async (
   const updatedTransactions = [...transactions];
   let txStatusesDidChange = false;
 
-  console.log('[TX]: waiting for promise.all');
   await Promise.all(
     transactions.map(async (tx, index) => {
       if (tx.pending) {
-        try {
-          const txHash = tx.hash.split('-').shift();
-          const payload = {
-            method: 'eth_getTransactionByHash',
-            params: [txHash],
-          };
-          console.log('[TX]: Sending RPC call', payload);
-          const txObj = await sendRpcCall(payload);
-          console.log('[TX]: GOT TX OBJ', txObj);
-          if (txObj && txObj.blockNumber) {
-            txStatusesDidChange = true;
-            console.log('[TX]: HAS A blockNumber');
-            updatedTransactions[index].status = TransactionStatusTypes.sent;
-            updatedTransactions[index].pending = false;
-          }
-        } catch (e) {
-          console.log('[TX]: Error getting txbyhash', e);
+        const txHash = tx.hash.split('-').shift();
+        const payload = {
+          method: 'eth_getTransactionByHash',
+          params: [txHash],
+        };
+        const txObj = await sendRpcCall(payload);
+        if (txObj && txObj.blockNumber) {
+          txStatusesDidChange = true;
+          updatedTransactions[index].status = TransactionStatusTypes.sent;
+          updatedTransactions[index].pending = false;
         }
       }
     })
   );
 
   if (txStatusesDidChange) {
-    console.log('[TX]: txStatusesDidChange!');
-
     const { accountAddress, network } = getState().settings;
-    console.log('[TX]: txStatusesDidChange!');
     saveLocalTransactions(updatedTransactions, accountAddress, network);
 
     dispatch({
       payload: updatedTransactions,
       type: DATA_UPDATE_TRANSACTIONS,
     });
-
-    console.log('[TX]: List updated');
 
     const pendingTx = updatedTransactions.find(tx => tx.pending);
     if (!pendingTx) {
@@ -320,17 +304,13 @@ export const dataWatchPendingTransactions = () => async (
 };
 
 const startPendingTransactionWatcher = () => async dispatch => {
-  console.log('[TX]: TOP LEVEL:::WATCHING!');
   watchPendingTransactionsHandler &&
     clearTimeout(watchPendingTransactionsHandler);
 
   const done = await dispatch(dataWatchPendingTransactions());
 
   if (!done) {
-    console.log('[TX]: TOP LEVEL:: NOT DONE!');
-
     watchPendingTransactionsHandler = setTimeout(() => {
-      console.log('[TX]: TOP LEVEL::: SHOULD KEEP WATCHING!');
       dispatch(startPendingTransactionWatcher());
     }, 1000);
   }


### PR DESCRIPTION
Once there's a new transaction in pending state,  query the node to see when it's confirmed ASAP.