### PR TITLE
Feat: Optimize gas price

### DIFF
--- a/src/hoc/withDataInit.js
+++ b/src/hoc/withDataInit.js
@@ -13,7 +13,7 @@ import {
   dataTokenOverridesInit,
 } from '../redux/data';
 import { explorerClearState, explorerInit } from '../redux/explorer';
-import { gasClearState, gasPricesInit } from '../redux/gas';
+import { gasPricesStartPolling } from '../redux/gas';
 import { clearIsWalletEmpty } from '../redux/isWalletEmpty';
 import { setIsWalletEthZero } from '../redux/isWalletEthZero';
 import { nonceClearState } from '../redux/nonce';
@@ -60,8 +60,7 @@ export default Component =>
       dataTokenOverridesInit,
       explorerClearState,
       explorerInit,
-      gasClearState,
-      gasPricesInit,
+      gasPricesStartPolling,
       nonceClearState,
       openStateSettingsLoadState,
       requestsClearState,
@@ -92,7 +91,6 @@ export default Component =>
       },
       clearAccountData: ownProps => async () => {
         web3ListenerClearState();
-        gasClearState();
         const p0 = ownProps.explorerClearState();
         const p1 = ownProps.dataClearState();
         const p2 = ownProps.clearIsWalletEmpty();
@@ -120,7 +118,6 @@ export default Component =>
           sentryUtils.addInfoBreadcrumb('Initialize account data');
           ownProps.explorerInit();
           ownProps.uniswapPairsInit();
-          ownProps.gasPricesInit();
           ownProps.web3ListenerInit();
           await ownProps.uniqueTokensRefreshState();
         } catch (error) {

--- a/src/hoc/withGas.js
+++ b/src/hoc/withGas.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
 import {
+  gasPricesStartPolling,
+  gasPricesStopPolling,
   gasUpdateDefaultGasLimit,
   gasUpdateGasPriceOption,
   gasUpdateTxFee,
@@ -25,6 +27,8 @@ const mapStateToProps = ({
 
 export default Component =>
   connect(mapStateToProps, {
+    gasPricesStartPolling,
+    gasPricesStopPolling,
     gasUpdateDefaultGasLimit,
     gasUpdateGasPriceOption,
     gasUpdateTxFee,

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -11,7 +11,7 @@ import ethUnits from '../references/ethereum-units.json';
 import { ethereumUtils, gasUtils } from '../utils';
 
 // -- Constants ------------------------------------------------------------- //
-
+const GAS_MULTIPLIER = 1.101;
 const GAS_UPDATE_DEFAULT_GAS_LIMIT = 'gas/GAS_UPDATE_DEFAULT_GAS_LIMIT';
 const GAS_PRICES_DEFAULT = 'gas/GAS_PRICES_DEFAULT';
 const GAS_PRICES_SUCCESS = 'gas/GAS_PRICES_SUCCESS';
@@ -47,7 +47,6 @@ const getDefaultTxFees = () => (dispatch, getState) => {
 };
 
 export const gasPricesStartPolling = () => async (dispatch, getState) => {
-  console.log('[GAS]: START POLLING');
   const { fallbackGasPrices, selectedGasPrice, txFees } = dispatch(
     getDefaultTxFees()
   );
@@ -62,7 +61,6 @@ export const gasPricesStartPolling = () => async (dispatch, getState) => {
 
   const getGasPrices = () =>
     new Promise((fetchResolve, fetchReject) => {
-      console.log('[GAS]: GETTING PRICES');
       const { useShortGasFormat } = getState().gas;
       apiGetGasPrices()
         .then(({ data }) => {
@@ -183,24 +181,19 @@ const getSelectedGasPrice = (
 };
 
 const bumpGasPrices = data => {
-  if (data.fast) {
-    data.fast = (parseFloat(data.fast) * 1.101).toFixed(2);
-  }
-  if (data.fastest) {
-    data.fastest = (parseFloat(data.fastest) * 1.101).toFixed(2);
-  }
-  if (data.safeLow) {
-    data.safeLow = (parseFloat(data.safeLow) * 1.101).toFixed(2);
-  }
-  if (data.average) {
-    data.average = (parseFloat(data.average) * 1.101).toFixed(2);
-  }
-
-  return data;
+  const processedData = { ...data };
+  const gasPricesKeys = ['average', 'fast', 'fastest', 'safeLow'];
+  Object.keys(processedData).forEach(key => {
+    if (gasPricesKeys.indexOf(key) !== -1) {
+      processedData[key] = (
+        parseFloat(processedData[key]) * GAS_MULTIPLIER
+      ).toFixed(2);
+    }
+  });
+  return processedData;
 };
 
 export const gasPricesStopPolling = () => () => {
-  console.log('[GAS]: STOP POLLING');
   getGasPricesTimeoutHandler && clearTimeout(getGasPricesTimeoutHandler);
 };
 

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -88,6 +88,8 @@ class ExchangeModal extends Component {
     chainId: PropTypes.number,
     dataAddNewTransaction: PropTypes.func,
     gasLimit: PropTypes.number,
+    gasPricesStartPolling: PropTypes.func,
+    gasPricesStopPolling: PropTypes.func,
     gasUpdateDefaultGasLimit: PropTypes.func,
     gasUpdateTxFee: PropTypes.func,
     inputReserve: PropTypes.object,
@@ -129,6 +131,9 @@ class ExchangeModal extends Component {
 
   componentDidMount() {
     this.props.gasUpdateDefaultGasLimit(ethUnits.basic_swap);
+    InteractionManager.runAfterInteractions(() => {
+      this.props.gasPricesStartPolling();
+    });
   }
 
   shouldComponentUpdate = (nextProps, nextState) => {
@@ -236,6 +241,7 @@ class ExchangeModal extends Component {
       );
     }
     this.props.uniswapClearCurrenciesAndReserves();
+    this.props.gasPricesStopPolling();
   };
 
   lastFocusedInput = null;

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -63,6 +63,7 @@ const SendSheet = ({
   gasLimit,
   gasPrices,
   gasPricesStartPolling,
+  gasPricesStopPolling,
   gasUpdateDefaultGasLimit,
   gasUpdateGasPriceOption,
   gasUpdateTxFee,

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -31,7 +31,6 @@ import { sendTransaction } from '../model/wallet';
 import { borders, colors } from '../styles';
 import { deviceUtils, ethereumUtils, gasUtils } from '../utils';
 import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
-import { gasPricesStopPolling } from '../redux/gas';
 
 const sheetHeight = deviceUtils.dimensions.height - 10;
 

--- a/src/screens/TransactionConfirmationScreenWithData.js
+++ b/src/screens/TransactionConfirmationScreenWithData.js
@@ -4,7 +4,7 @@ import lang from 'i18n-js';
 import { get, isNil, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Alert, Vibration, InteractionManager } from 'react-native';
+import { Alert, InteractionManager, Vibration } from 'react-native';
 import { withNavigationFocus } from 'react-navigation';
 import { compose } from 'recompact';
 import { withGas, withTransactionConfirmationScreen } from '../hoc';

--- a/src/screens/TransactionConfirmationScreenWithData.js
+++ b/src/screens/TransactionConfirmationScreenWithData.js
@@ -4,7 +4,7 @@ import lang from 'i18n-js';
 import { get, isNil, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Alert, Vibration } from 'react-native';
+import { Alert, Vibration, InteractionManager } from 'react-native';
 import { withNavigationFocus } from 'react-navigation';
 import { compose } from 'recompact';
 import { withGas, withTransactionConfirmationScreen } from '../hoc';
@@ -28,6 +28,8 @@ class TransactionConfirmationScreenWithData extends PureComponent {
   static propTypes = {
     dataAddNewTransaction: PropTypes.func,
     gasPrices: PropTypes.object,
+    gasPricesStartPolling: PropTypes.func,
+    gasPricesStopPolling: PropTypes.func,
     navigation: PropTypes.any,
     removeRequest: PropTypes.func,
     transactionCountNonce: PropTypes.number,
@@ -43,6 +45,10 @@ class TransactionConfirmationScreenWithData extends PureComponent {
     if (openAutomatically) {
       Vibration.vibrate();
     }
+
+    InteractionManager.runAfterInteractions(() => {
+      this.props.gasPricesStartPolling();
+    });
   }
 
   handleConfirm = async () => {
@@ -207,6 +213,7 @@ class TransactionConfirmationScreenWithData extends PureComponent {
 
   closeScreen = () => {
     this.props.navigation.popToTop();
+    this.props.gasPricesStopPolling();
   };
 
   render = () => {


### PR DESCRIPTION
- Use recursive setTimeout instead of setInterval
- Change always polling to polling while: 
  -  On send flow
  - On exchange flow
   - On WC call
- Stop polling when components get unmounted
- Bump all gas prices x 1.101  to get ahead in the pool (faster confirmations)