### PR TITLE
Feat: Add networking debugging

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,12 @@ import { get, last } from 'lodash';
 import PropTypes from 'prop-types';
 import nanoid from 'nanoid/non-secure';
 import React, { Component } from 'react';
-import { AppRegistry, AppState, Linking } from 'react-native';
+import {
+  AppRegistry,
+  AppState,
+  Linking,
+  unstable_enableLogBox,
+} from 'react-native';
 // eslint-disable-next-line import/default
 import CodePush from 'react-native-code-push';
 import {
@@ -23,6 +28,13 @@ import { connect, Provider } from 'react-redux';
 import { compose, withProps } from 'recompact';
 import { FlexItem } from './components/layout';
 import OfflineBadge from './components/OfflineBadge';
+import {
+  reactNativeDisableYellowBox,
+  reactNativeEnableLogbox,
+  showNetworkRequests,
+  showNetworkResponses,
+} from './config/debug';
+import monitorNetwork from './debugging/network';
 import { withDeepLink, withWalletConnectOnSessionRequest } from './hoc';
 import { registerTokenRefreshListener, saveFCMToken } from './model/firebase';
 import * as keychain from './model/keychain';
@@ -32,8 +44,12 @@ import { requestsForTopic } from './redux/requests';
 import Routes from './screens/Routes';
 import { parseQueryParams } from './utils';
 
-if (process.env.NODE_ENV === 'development') {
-  console.disableYellowBox = true;
+// eslint-disable-next-line no-undef
+if (__DEV__) {
+  console.disableYellowBox = reactNativeDisableYellowBox;
+  reactNativeEnableLogbox && unstable_enableLogBox();
+  (showNetworkRequests || showNetworkResponses) &&
+    monitorNetwork(showNetworkRequests, showNetworkResponses);
 } else {
   initSentry({ dsn: SENTRY_ENDPOINT, environment: SENTRY_ENVIRONMENT });
 }

--- a/src/config/debug.js
+++ b/src/config/debug.js
@@ -1,0 +1,9 @@
+/**
+ * This fine contains flags for debugging related features that
+ * could be useful during development.
+ */
+
+export const reactNativeDisableYellowBox = false;
+export const reactNativeEnableLogbox = true;
+export const showNetworkRequests = true;
+export const showNetworkResponses = true;

--- a/src/config/experimental.js
+++ b/src/config/experimental.js
@@ -6,5 +6,5 @@
 
 export const discoverSheetAvailable = false;
 export const chartExpandedAvailable = false;
-export const nativeTransactionListAvailable = true;
-export const nativeButtonPressAnimationAvailable = true;
+export const nativeTransactionListAvailable = false;
+export const nativeButtonPressAnimationAvailable = false;

--- a/src/debugging/network.js
+++ b/src/debugging/network.js
@@ -4,8 +4,8 @@ let internalCounter = 0;
 
 const PREFIX = `[NETWORKING]:`;
 const EXCLUDED_URLS = [
-  'http://localhost:8081/symbolicate',
-  'https://clients3.google.com/generate_204',
+  'http://localhost:8081/symbolicate', // RN packager
+  'https://clients3.google.com/generate_204', // Offline connection detection
 ];
 
 export default function monitorNetwork(

--- a/src/debugging/network.js
+++ b/src/debugging/network.js
@@ -1,0 +1,122 @@
+import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
+
+let internalCounter = 0;
+
+const PREFIX = `[NETWORKING]:`;
+const EXCLUDED_URLS = [
+  'http://localhost:8081/symbolicate',
+  'https://clients3.google.com/generate_204',
+];
+
+export default function monitorNetwork(
+  showNetworkRequests,
+  showNetworkResponses
+) {
+  const requestCache = {};
+
+  const getEmojiForStatusCode = status => {
+    if (status >= 200 && status < 400) {
+      return '✅';
+    } else {
+      return '❌';
+    }
+  };
+
+  const emptyLine = () => {
+    console.log('');
+  };
+  const separator = () => {
+    console.log(`----------------------------------------`);
+  };
+
+  if (showNetworkRequests) {
+    XHRInterceptor.setSendCallback((data, xhr) => {
+      if (EXCLUDED_URLS.indexOf(xhr._url) === -1) {
+        internalCounter++;
+        xhr._trackingName = internalCounter;
+
+        separator();
+        emptyLine();
+        console.log(
+          `${PREFIX} ➡️  REQUEST #${xhr._trackingName} -  ${xhr._method} ${xhr._url}`
+        );
+        emptyLine();
+        if (data) {
+          emptyLine();
+          console.log(' PARAMETERS: ');
+          emptyLine();
+          try {
+            const dataObj = JSON.parse(data);
+            console.log(' {');
+            Object.keys(dataObj).forEach(key => {
+              console.log(`   ${key} : `, dataObj[key]);
+            });
+            console.log(' }');
+          } catch (e) {
+            console.log(data);
+          }
+        }
+        emptyLine();
+
+        requestCache[internalCounter] = {
+          startTime: new Date().getTime(),
+        };
+      }
+    });
+  }
+
+  if (showNetworkResponses) {
+    XHRInterceptor.setResponseCallback(
+      (status, timeout, response, url, type, xhr) => {
+        if (EXCLUDED_URLS.indexOf(url) === -1) {
+          // fetch and clear the request data from the cache
+          const rid = xhr._trackingName;
+          const cachedRequest = requestCache[rid] || {};
+          requestCache[rid] = null;
+          const time =
+            (cachedRequest.startTime &&
+              new Date().getTime() - cachedRequest.startTime) ||
+            null;
+
+          separator();
+          emptyLine();
+          console.log(
+            `${PREFIX} ${getEmojiForStatusCode(status)}  RESPONSE #${rid} -  ${
+              xhr._method
+            } ${url}`
+          );
+          emptyLine();
+          if (timeout) {
+            console.log(` ⚠️ ⚠️  TIMEOUT!  ⚠️ ⚠️ `);
+          }
+
+          if (status) {
+            console.log(` Status:  ${status}`);
+          }
+
+          if (time) {
+            console.log(` Completed in:  ${time / 1000} s`);
+          }
+
+          if (response) {
+            emptyLine();
+            console.log(' RESPONSE: ');
+            emptyLine();
+            try {
+              const responseObj = JSON.parse(response);
+              console.log(' {');
+              Object.keys(responseObj).forEach(key => {
+                console.log(`   ${key} : `, responseObj[key]);
+              });
+              console.log(' }');
+            } catch (e) {
+              console.log(response);
+            }
+          }
+          emptyLine();
+        }
+      }
+    );
+  }
+  XHRInterceptor.enableInterception();
+}

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -10,7 +10,7 @@ import { BalanceCoinRow } from '../components/coin-row';
 import { UniswapInvestmentCard } from '../components/investment-cards';
 import { TokenFamilyWrap } from '../components/token-family';
 import { buildUniqueTokenList, buildCoinsList } from './assets';
-import { chartExpandedAvailable } from '../experimentalConfig';
+import { chartExpandedAvailable } from '../config/experimental';
 
 const allAssetsSelector = state => state.allAssets;
 const allAssetsCountSelector = state => state.allAssetsCount;

--- a/src/helpers/isNativeButtonAvailable.js
+++ b/src/helpers/isNativeButtonAvailable.js
@@ -1,5 +1,5 @@
 import { UIManager } from 'react-native';
-import { nativeButtonPressAnimationAvailable } from '../experimentalConfig';
+import { nativeButtonPressAnimationAvailable } from '../config/experimental';
 
 export default nativeButtonPressAnimationAvailable &&
   !!UIManager.getViewManagerConfig('Button');

--- a/src/helpers/isNativeTransactionListAvailable.js
+++ b/src/helpers/isNativeTransactionListAvailable.js
@@ -1,5 +1,5 @@
 import { UIManager } from 'react-native';
-import { nativeTransactionListAvailable } from '../experimentalConfig';
+import { nativeTransactionListAvailable } from '../config/experimental';
 
 export default nativeTransactionListAvailable &&
   !!UIManager.getViewManagerConfig('TransactionListView');

--- a/src/screens/QRScannerScreen.js
+++ b/src/screens/QRScannerScreen.js
@@ -14,7 +14,7 @@ import {
 } from '../components/walletconnect-list';
 import { colors, position } from '../styles';
 import { isNewValueForObjectPaths } from '../utils';
-import { discoverSheetAvailable } from '../experimentalConfig';
+import { discoverSheetAvailable } from '../config/experimental';
 
 const QRScannerScreen = ({
   enableScanning,


### PR DESCRIPTION
This PR does a couple of things that will improve our debugging experience:

- Created a new `config` folder for `experimental` (previously at `./experimentalConfig.js`) and `debugging`

- Added ability to enable HTTP Requests and / or responses monitoring  by switching a debug config flag, which looks like this: 

![k7DNUmEWId](https://user-images.githubusercontent.com/1247834/73883016-29329680-4831-11ea-9b1c-70d99dd58bbd.gif)

- Ability to turn on the new LogBox from RN 0.62+ that's much more helpful than the previous yellow warnings by switching a debug config flag, which looks like this:

https://twitter.com/janicduplessis/status/1206645712869560320?lang=en




