### PR TITLE
Networking debugging

### DIFF
--- a/src/config/debug.js
+++ b/src/config/debug.js
@@ -4,6 +4,6 @@
  */
 
 export const reactNativeDisableYellowBox = false;
-export const reactNativeEnableLogbox = true;
-export const showNetworkRequests = true;
-export const showNetworkResponses = true;
+export const reactNativeEnableLogbox = false;
+export const showNetworkRequests = false;
+export const showNetworkResponses = false;

--- a/src/config/debug.js
+++ b/src/config/debug.js
@@ -3,7 +3,7 @@
  * could be useful during development.
  */
 
-export const reactNativeDisableYellowBox = false;
+export const reactNativeDisableYellowBox = true;
 export const reactNativeEnableLogbox = false;
 export const showNetworkRequests = false;
 export const showNetworkResponses = false;

--- a/src/debugging/network.js
+++ b/src/debugging/network.js
@@ -86,7 +86,7 @@ export default function monitorNetwork(
             } ${url}`
           );
           emptyLine();
-          if (timeout) {
+          if (timeout && status > 400) {
             console.log(` ⚠️ ⚠️  TIMEOUT!  ⚠️ ⚠️ `);
           }
 


### PR DESCRIPTION
- Turn off all the debugging flags by default
- Improve timeout detection (some times the flag is true but the status is 200)