### PR TITLE
Bugfix: Block polling on demand

### DIFF
--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -5,6 +5,7 @@ export { default as withAccountTransactions } from './withAccountTransactions';
 export { default as withActionSheetManager } from './withActionSheetManager';
 export { default as withAppState } from './withAppState';
 export { default as withBlockedHorizontalSwipe } from './withBlockedHorizontalSwipe';
+export { default as withBlockPolling } from './withBlockPolling';
 export { default as withContacts } from './withContacts';
 export { default as withDataInit } from './withDataInit';
 export { default as withDeepLink } from './withDeepLink';

--- a/src/hoc/withBlockPolling.js
+++ b/src/hoc/withBlockPolling.js
@@ -1,0 +1,8 @@
+import { connect } from 'react-redux';
+import { web3ListenerInit, web3ListenerStop } from '../redux/web3listener';
+
+export default Component =>
+  connect(null, {
+    web3ListenerInit,
+    web3ListenerStop,
+  })(Component);

--- a/src/hoc/withDataInit.js
+++ b/src/hoc/withDataInit.js
@@ -42,10 +42,7 @@ import {
   walletConnectLoadState,
   walletConnectClearState,
 } from '../redux/walletconnect';
-import {
-  web3ListenerClearState,
-  web3ListenerInit,
-} from '../redux/web3listener';
+
 import { promiseUtils, sentryUtils } from '../utils';
 import withHideSplashScreen from './withHideSplashScreen';
 
@@ -77,7 +74,6 @@ export default Component =>
       uniswapUpdateState,
       walletConnectClearState,
       walletConnectLoadState,
-      web3ListenerInit,
     }),
     withHideSplashScreen,
     withHandlers({
@@ -90,7 +86,6 @@ export default Component =>
         }
       },
       clearAccountData: ownProps => async () => {
-        web3ListenerClearState();
         const p0 = ownProps.explorerClearState();
         const p1 = ownProps.dataClearState();
         const p2 = ownProps.clearIsWalletEmpty();
@@ -118,7 +113,6 @@ export default Component =>
           sentryUtils.addInfoBreadcrumb('Initialize account data');
           ownProps.explorerInit();
           ownProps.uniswapPairsInit();
-          ownProps.web3ListenerInit();
           await ownProps.uniqueTokensRefreshState();
         } catch (error) {
           // TODO error state

--- a/src/redux/web3listener.js
+++ b/src/redux/web3listener.js
@@ -16,9 +16,10 @@ const web3UpdateReserves = () => async (dispatch, getState) => {
 };
 
 export const web3ListenerInit = () => dispatch => {
+  web3Provider.pollingInterval = 8000;
   web3Provider.on('block', () => dispatch(web3UpdateReserves()));
 };
 
-export const web3ListenerClearState = () => {
+export const web3ListenerStop = () => () => {
   web3Provider.removeAllListeners('block');
 };

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -48,6 +48,7 @@ import {
   withAccountData,
   withAccountSettings,
   withBlockedHorizontalSwipe,
+  withBlockPolling,
   withGas,
   withTransactionConfirmationScreen,
   withTransitionProps,
@@ -106,6 +107,8 @@ class ExchangeModal extends Component {
     uniswapAddPendingApproval: PropTypes.func,
     uniswapAssetsInWallet: PropTypes.arrayOf(PropTypes.object),
     uniswapUpdateAllowances: PropTypes.func,
+    web3ListenerInit: PropTypes.func,
+    web3ListenerStop: PropTypes.func,
   };
 
   state = {
@@ -133,6 +136,7 @@ class ExchangeModal extends Component {
     this.props.gasUpdateDefaultGasLimit(ethUnits.basic_swap);
     InteractionManager.runAfterInteractions(() => {
       this.props.gasPricesStartPolling();
+      this.props.web3ListenerInit();
     });
   }
 
@@ -242,6 +246,7 @@ class ExchangeModal extends Component {
     }
     this.props.uniswapClearCurrenciesAndReserves();
     this.props.gasPricesStopPolling();
+    this.props.web3ListenerStop();
   };
 
   lastFocusedInput = null;
@@ -904,6 +909,7 @@ export default compose(
   withAccountSettings,
   withBlockedHorizontalSwipe,
   withGas,
+  withBlockPolling,
   withNavigationFocus,
   withTransactionConfirmationScreen,
   withTransitionProps,


### PR DESCRIPTION
Moved block polling to its own HOC and it's now being called only while the exchange modal is open.
This will reduce the amount of requests that the app is making in idle state considerably/