### PR TITLE
Bugfix: Native stack navigation related issues

### DIFF
--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -40,7 +40,6 @@ export const CurrencySelectionTypes = {
 
 class CurrencySelectModal extends Component {
   static propTypes = {
-    isFocused: PropTypes.bool,
     navigation: PropTypes.object,
     sortedUniswapAssets: PropTypes.array,
     transitionPosition: PropTypes.object,
@@ -67,11 +66,14 @@ class CurrencySelectModal extends Component {
     const currentAssetsUniqueId = buildUniqueIdForListData(currentAssets);
     const nextAssetsUniqueId = buildUniqueIdForListData(nextAssets);
     const isNewAssets = currentAssetsUniqueId !== nextAssetsUniqueId;
+    const isFocused = this.props.navigation.getParam('focused', false);
+    const willBeFocused = nextProps.navigation.getParam('focused', false);
 
-    const isNewProps = isNewValueForObjectPaths(this.props, nextProps, [
-      'isFocused',
-      'type',
-    ]);
+    const isNewProps = isNewValueForObjectPaths(
+      { ...this.props, isFocused },
+      { ...nextProps, isFocused: willBeFocused },
+      ['isFocused', 'type']
+    );
 
     const isNewState = isNewValueForObjectPaths(this.state, nextState, [
       'searchQuery',
@@ -142,7 +144,6 @@ class CurrencySelectModal extends Component {
   render = () => {
     const {
       uniswapAssetsInWallet,
-      isFocused,
       sortedUniswapAssets,
       transitionPosition,
       type,
@@ -164,6 +165,7 @@ class CurrencySelectModal extends Component {
     }
 
     const listItems = filterList(assets, searchQuery, 'uniqueId');
+    const isFocused = this.props.navigation.getParam('focused', false);
 
     return (
       <KeyboardFixedOpenLayout>

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -34,8 +34,8 @@ class QRScannerScreenWithData extends Component {
   };
 
   componentDidUpdate = (prevProps, prevState) => {
-    const prevNavParam = prevProps.navigation.getParam('focus', false);
-    const newNavParam = this.props.navigation.getParam('focus', false);
+    const prevNavParam = prevProps.navigation.getParam('focused', false);
+    const newNavParam = this.props.navigation.getParam('focused', false);
 
     if (newNavParam && !prevNavParam) {
       Permissions.request('camera').then(permission => {
@@ -106,7 +106,7 @@ class QRScannerScreenWithData extends Component {
   };
 
   render = () => {
-    const isFocused = this.props.navigation.getParam('focus', false);
+    const isFocused = this.props.navigation.getParam('focused', false);
 
     return (
       <QRScannerScreen

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -34,10 +34,10 @@ class QRScannerScreenWithData extends Component {
   };
 
   componentDidUpdate = (prevProps, prevState) => {
-    const prevNavParam = prevProps.navigation.getParam('focused', false);
-    const newNavParam = this.props.navigation.getParam('focused', false);
+    const wasFocused = prevProps.navigation.getParam('focused', false);
+    const isFocused = this.props.navigation.getParam('focused', false);
 
-    if (newNavParam && !prevNavParam) {
+    if (isFocused && !wasFocused) {
       Permissions.request('camera').then(permission => {
         const isCameraAuthorized = permission === 'authorized';
         if (prevState.isCameraAuthorized !== isCameraAuthorized) {

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -34,12 +34,16 @@ class QRScannerScreenWithData extends Component {
   };
 
   componentDidUpdate = (prevProps, prevState) => {
-    if (this.props.isFocused && !prevProps.isFocused) {
-      Permissions.request('camera').then(permission => {
-        const isCameraAuthorized = permission === 'authorized';
+    const prevNavParam = prevProps.navigation.getParam('focus', false);
+    const newNavParam = this.props.navigation.getParam('focus', false);
 
+    if (newNavParam && !prevNavParam) {
+      Permissions.request('camera').then(permission => {
+        console.log('got permission status', permission);
+        const isCameraAuthorized = permission === 'authorized';
         if (prevState.isCameraAuthorized !== isCameraAuthorized) {
-          this.setState({ isCameraAuthorized });
+          console.log('permission status updated', permission);
+          !this.state.enableScanning && this.setState({ isCameraAuthorized });
         }
       });
 
@@ -54,7 +58,9 @@ class QRScannerScreenWithData extends Component {
 
   handlePastedUri = async uri => this.props.walletConnectOnSessionRequest(uri);
 
-  handlePressBackButton = () => this.props.navigation.navigate('WalletScreen');
+  handlePressBackButton = () => {
+    this.props.navigation.navigate('WalletScreen');
+  };
 
   handlePressPasteSessionUri = () => {
     Prompt({
@@ -103,17 +109,22 @@ class QRScannerScreenWithData extends Component {
     });
   };
 
-  render = () => (
-    <QRScannerScreen
-      {...this.props}
-      {...this.state}
-      enableScanning={this.state.enableScanning && this.props.isFocused}
-      onPressBackButton={this.handlePressBackButton}
-      onPressPasteSessionUri={this.handlePressPasteSessionUri}
-      onScanSuccess={this.handleScanSuccess}
-      onSheetLayout={this.handleSheetLayout}
-    />
-  );
+  render = () => {
+    const isFocused = this.props.navigation.getParam('focus', false);
+
+    return (
+      <QRScannerScreen
+        {...this.props}
+        {...this.state}
+        isFocused={isFocused}
+        enableScanning={this.state.enableScanning && isFocused}
+        onPressBackButton={this.handlePressBackButton}
+        onPressPasteSessionUri={this.handlePressPasteSessionUri}
+        onScanSuccess={this.handleScanSuccess}
+        onSheetLayout={this.handleSheetLayout}
+      />
+    );
+  };
 }
 
 export default compose(

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -41,12 +41,12 @@ class QRScannerScreenWithData extends Component {
       Permissions.request('camera').then(permission => {
         const isCameraAuthorized = permission === 'authorized';
         if (prevState.isCameraAuthorized !== isCameraAuthorized) {
-          !this.state.enableScanning && this.setState({ isCameraAuthorized });
+          this.setState({ isCameraAuthorized });
         }
       });
 
       // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ enableScanning: true });
+      !this.state.enableScanning && this.setState({ enableScanning: true });
     }
   };
 

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -39,10 +39,8 @@ class QRScannerScreenWithData extends Component {
 
     if (newNavParam && !prevNavParam) {
       Permissions.request('camera').then(permission => {
-        console.log('got permission status', permission);
         const isCameraAuthorized = permission === 'authorized';
         if (prevState.isCameraAuthorized !== isCameraAuthorized) {
-          console.log('permission status updated', permission);
           !this.state.enableScanning && this.setState({ isCameraAuthorized });
         }
       });
@@ -58,9 +56,7 @@ class QRScannerScreenWithData extends Component {
 
   handlePastedUri = async uri => this.props.walletConnectOnSessionRequest(uri);
 
-  handlePressBackButton = () => {
-    this.props.navigation.navigate('WalletScreen');
-  };
+  handlePressBackButton = () => this.props.navigation.navigate('WalletScreen');
 
   handlePressPasteSessionUri = () => {
     Prompt({

--- a/src/screens/Routes/Routes.android.js
+++ b/src/screens/Routes/Routes.android.js
@@ -2,7 +2,7 @@ import analytics from '@segment/analytics-react-native';
 import { get, omit } from 'lodash';
 import React from 'react';
 import { StatusBar } from 'react-native';
-import { createAppContainer } from 'react-navigation';
+import { createAppContainer, NavigationActions } from 'react-navigation';
 import { createMaterialTopTabNavigator } from 'react-navigation-tabs';
 import ViewPagerAdapter from 'react-native-tab-view-viewpager-adapter';
 // eslint-disable-next-line import/no-unresolved
@@ -219,10 +219,49 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
       const { params, routeName } = Navigation.getActiveRoute(currentState);
       const prevRouteName = Navigation.getActiveRouteName(prevState);
       // native stack rn does not support onTransitionEnd and onTransitionStart
+      // Set focus manually on route changes
+      if (prevRouteName !== routeName) {
+        Navigation.handleAction(
+          NavigationActions.setParams({
+            key: routeName,
+            params: { focused: true },
+          })
+        );
+
+        Navigation.handleAction(
+          NavigationActions.setParams({
+            key: prevRouteName,
+            params: { focused: false },
+          })
+        );
+      }
+
+      if (
+        prevRouteName !== 'QRScannerScreen' &&
+        routeName === 'QRScannerScreen'
+      ) {
+        StatusBar.setBarStyle('light-content');
+      }
+
+      if (
+        prevRouteName === 'QRScannerScreen' &&
+        routeName !== 'QRScannerScreen'
+      ) {
+        StatusBar.setBarStyle('dark-content');
+      }
+
       if (
         prevRouteName === 'ImportSeedPhraseSheet' &&
         (routeName === 'ProfileScreen' || routeName === 'WalletScreen')
       ) {
+        StatusBar.setBarStyle('dark-content');
+      }
+
+      if (prevRouteName === 'WalletScreen' && routeName === 'SendSheet') {
+        StatusBar.setBarStyle('light-content');
+      }
+
+      if (prevRouteName === 'SendSheet' && routeName === 'WalletScreen') {
         StatusBar.setBarStyle('dark-content');
       }
 
@@ -235,7 +274,7 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
       }
 
       if (routeName !== prevRouteName) {
-        let paramsToTrack = {};
+        let paramsToTrack = null;
 
         if (
           prevRouteName === 'MainExchangeScreen' &&

--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -261,18 +261,28 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
       const { params, routeName } = Navigation.getActiveRoute(currentState);
       const prevRouteName = Navigation.getActiveRouteName(prevState);
       // native stack rn does not support onTransitionEnd and onTransitionStart
+      // Set focus manually on route changes
+      if (prevRouteName !== routeName) {
+        Navigation.handleAction(
+          NavigationActions.setParams({
+            key: routeName,
+            params: { focused: true },
+          })
+        );
+
+        Navigation.handleAction(
+          NavigationActions.setParams({
+            key: prevRouteName,
+            params: { focused: false },
+          })
+        );
+      }
 
       if (
         prevRouteName !== 'QRScannerScreen' &&
         routeName === 'QRScannerScreen'
       ) {
         StatusBar.setBarStyle('light-content');
-        Navigation.handleAction(
-          NavigationActions.setParams({
-            key: 'QRScannerScreen',
-            params: { focused: true },
-          })
-        );
       }
 
       if (
@@ -280,12 +290,6 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
         routeName !== 'QRScannerScreen'
       ) {
         StatusBar.setBarStyle('dark-content');
-        Navigation.handleAction(
-          NavigationActions.setParams({
-            key: 'QRScannerScreen',
-            params: { focused: false },
-          })
-        );
       }
 
       if (

--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -270,7 +270,7 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
         Navigation.handleAction(
           NavigationActions.setParams({
             key: 'QRScannerScreen',
-            params: { focus: true },
+            params: { focused: true },
           })
         );
       }
@@ -283,7 +283,7 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
         Navigation.handleAction(
           NavigationActions.setParams({
             key: 'QRScannerScreen',
-            params: { focus: false },
+            params: { focused: false },
           })
         );
       }

--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -2,7 +2,7 @@ import analytics from '@segment/analytics-react-native';
 import { get, omit } from 'lodash';
 import React from 'react';
 import { StatusBar } from 'react-native';
-import { createAppContainer } from 'react-navigation';
+import { createAppContainer, NavigationActions } from 'react-navigation';
 import { createMaterialTopTabNavigator } from 'react-navigation-tabs-v1';
 // eslint-disable-next-line import/no-unresolved
 import { enableScreens } from 'react-native-screens';
@@ -261,6 +261,33 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
       const { params, routeName } = Navigation.getActiveRoute(currentState);
       const prevRouteName = Navigation.getActiveRouteName(prevState);
       // native stack rn does not support onTransitionEnd and onTransitionStart
+
+      if (
+        prevRouteName !== 'QRScannerScreen' &&
+        routeName === 'QRScannerScreen'
+      ) {
+        StatusBar.setBarStyle('light-content');
+        Navigation.handleAction(
+          NavigationActions.setParams({
+            key: 'QRScannerScreen',
+            params: { focus: true },
+          })
+        );
+      }
+
+      if (
+        prevRouteName === 'QRScannerScreen' &&
+        routeName !== 'QRScannerScreen'
+      ) {
+        StatusBar.setBarStyle('dark-content');
+        Navigation.handleAction(
+          NavigationActions.setParams({
+            key: 'QRScannerScreen',
+            params: { focus: false },
+          })
+        );
+      }
+
       if (
         prevRouteName === 'ImportSeedPhraseSheet' &&
         (routeName === 'ProfileScreen' || routeName === 'WalletScreen')

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -52,6 +52,7 @@ class WalletScreen extends Component {
     try {
       await this.props.initializeWallet();
       const keyboardheight = await getKeyboardHeight();
+
       if (keyboardheight) {
         this.props.setKeyboardHeight(keyboardheight);
       }
@@ -61,7 +62,7 @@ class WalletScreen extends Component {
   };
 
   shouldComponentUpdate = nextProps =>
-    nextProps.navigation.isFocused() &&
+    nextProps.navigation.getParam('focused', true) &&
     isNewValueForObjectPaths(this.props, nextProps, [
       'fetchingAssets',
       'fetchingUniqueTokens',


### PR DESCRIPTION
The problem:  Once you go to a view like SendSheet the isFocused property it's not updated anymore,
causing a lot of problems for the screens that depend on it, like QRScanner not starting, Wallet not re-rendering & Uniswap list not loading in the CurrencySelect modal.

The "solution":   Pass a parameter to the route that has been presented as `{ focus: true }` and disable it for the previous route by passing `{ focus: false }`

Those 3 issues mentioned above have been fixed without the need to turn off the NativeStack