### PR TITLE
Set focused as a param only in native stack

### DIFF
--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -218,41 +218,39 @@ const NativeStack = createNativeStackNavigator(
     mode: 'modal',
   }
 );
-
-const NativeStackFallback = createStackNavigator(
-  {
-    ImportSeedPhraseSheet: {
-      navigationOptions: {
-        ...sheetPreset,
-        onTransitionStart: props => {
-          sheetPreset.onTransitionStart(props);
-          onTransitionStart();
-        },
+const nativeStackRoutes = {
+  ImportSeedPhraseSheet: {
+    navigationOptions: {
+      ...sheetPreset,
+      onTransitionStart: props => {
+        sheetPreset.onTransitionStart(props);
+        onTransitionStart();
       },
-      screen: ImportSeedPhraseSheetWithData,
     },
-    MainNavigator,
-    SendSheet: {
-      navigationOptions: {
-        ...omit(sheetPreset, 'gestureResponseDistance'),
-        onTransitionStart: props => {
-          onTransitionStart(props);
-          sheetPreset.onTransitionStart(props);
-        },
-      },
-      screen: SendSheetWithData,
-    },
+    screen: ImportSeedPhraseSheetWithData,
   },
-  {
-    defaultNavigationOptions: {
-      onTransitionEnd,
-      onTransitionStart,
+  MainNavigator,
+  SendSheet: {
+    navigationOptions: {
+      ...omit(sheetPreset, 'gestureResponseDistance'),
+      onTransitionStart: props => {
+        onTransitionStart(props);
+        sheetPreset.onTransitionStart(props);
+      },
     },
-    headerMode: 'none',
-    initialRouteName: 'MainNavigator',
-    mode: 'modal',
-  }
-);
+    screen: SendSheetWithData,
+  },
+};
+
+const NativeStackFallback = createStackNavigator(nativeStackRoutes, {
+  defaultNavigationOptions: {
+    onTransitionEnd,
+    onTransitionStart,
+  },
+  headerMode: 'none',
+  initialRouteName: 'MainNavigator',
+  mode: 'modal',
+});
 
 const Stack = isNativeStackAvailable ? NativeStack : NativeStackFallback;
 
@@ -266,7 +264,11 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
       const prevRouteName = Navigation.getActiveRouteName(prevState);
       // native stack rn does not support onTransitionEnd and onTransitionStart
       // Set focus manually on route changes
-      if (prevRouteName !== routeName) {
+
+      if (
+        prevRouteName !== routeName &&
+        (nativeStackRoutes[prevRouteName] || nativeStackRoutes[routeName])
+      ) {
         Navigation.handleAction(
           NavigationActions.setParams({
             key: routeName,

--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -267,6 +267,7 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
 
       if (
         prevRouteName !== routeName &&
+        isNativeStackAvailable &&
         (nativeStackRoutes[prevRouteName] || nativeStackRoutes[routeName])
       ) {
         Navigation.handleAction(


### PR DESCRIPTION
 observed that this commit 1d5a130
made a regression. "Normal" stack animation is no longer visible when transitioning out (with no gesture)

According to the purpose of this commit, there's no reason for having this logic when routes are not inside the native stack. I' adding a proper check for this.