### PR TITLE
Fix white screen bug in release mode

### DIFF
--- a/src/components/token-family/TokenFamilyWrap.js
+++ b/src/components/token-family/TokenFamilyWrap.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Transition, Transitioning } from 'react-native-reanimated';
 import { View } from 'react-primitives';
-import { compose } from 'recompact';
-import { withFabSendAction } from '../../hoc';
 import { colors } from '../../styles';
 import TokenFamilyHeader from './TokenFamilyHeader';
 
@@ -100,4 +98,4 @@ TokenFamilyWrap.propTypes = {
   title: PropTypes.string,
 };
 
-export default compose(withFabSendAction)(TokenFamilyWrap);
+export default TokenFamilyWrap;


### PR DESCRIPTION
Removing the `withFabSendAction` HOC  from the TokenFamilyWrap which was causing this issue.