### PR TITLE
Add missing swap info modal

### DIFF
--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -814,7 +814,7 @@ const ExchangeModal = ({
   } = extraTradeDetails;
 
   const showDetailsButton =
-    !showOutputField &&
+    !isDeposit &&
     get(inputCurrency, 'symbol') &&
     get(outputCurrency, 'symbol') &&
     inputExecutionRate !== 'NaN' &&


### PR DESCRIPTION
We were using the wrong flag to determine when to show the swap details modal.