### PR TITLE
Change default focus to USD in send flow, and fix keyboard dismiss issue

### DIFF
--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -19,7 +19,6 @@ const SendAssetFormToken = ({
 }) => (
   <ColumnWithMargins {...props} flex={0} margin={18} width="100%">
     <SendAssetFormField
-      autoFocus
       format={removeLeadingZeros}
       label={selected.symbol}
       onChange={onChangeAssetAmount}
@@ -28,6 +27,7 @@ const SendAssetFormToken = ({
       value={assetAmount}
     />
     <SendAssetFormField
+      autoFocus
       format={formatNativeInput}
       label={nativeCurrency}
       onChange={onChangeNativeAmount}

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -153,7 +153,7 @@ const SendSheet = ({
         });
       } else {
         setSelected(newSelected);
-        sendUpdateAssetAmount(amountDetails.assetAmount);
+        sendUpdateAssetAmount('');
       }
     },
     [amountDetails.assetAmount, sendUpdateAssetAmount]
@@ -321,7 +321,7 @@ const SendSheet = ({
   }, [gasUpdateDefaultGasLimit]);
 
   useEffect(() => {
-    if (isValidAddress) {
+    if (isValidAddress && showAssetList) {
       Keyboard.dismiss();
     }
   }, [isValidAddress]);


### PR DESCRIPTION
- change default focus to USD in send flow
- fix keyboard unnecessary dismiss while selecting asset directly from wallet screen, and omitting SendAssetList

Linear:
https://linear.app/issue/RAI-339/default-input-focus-to-focus-on-the-usd-input-in-send-flow