### PR TITLE
Remove hoc to reduce amount of status bar logic

### DIFF
--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -17,7 +17,6 @@ import {
 } from '../hoc';
 import { addressUtils } from '../utils';
 import QRScannerScreen from './QRScannerScreen';
-import withStatusBarStyle from '../hoc/withStatusBarStyle';
 
 class QRScannerScreenWithData extends Component {
   static propTypes = {
@@ -135,6 +134,5 @@ export default compose(
   withWalletConnectOnSessionRequest,
   withAccountAddress,
   withSafeTimeout,
-  withWalletConnectConnections,
-  withStatusBarStyle('light-content')
+  withWalletConnectConnections
 )(QRScannerScreenWithData);

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -22,7 +22,6 @@ import {
   withDataInit,
   withIsWalletEmpty,
   withIsWalletEthZero,
-  withStatusBarStyle,
   withUniqueTokens,
   withUniswapLiquidityTokenInfo,
   withKeyboardHeight,
@@ -158,7 +157,6 @@ export default compose(
   withIsWalletEmpty,
   withIsWalletEthZero,
   withKeyboardHeight,
-  withStatusBarStyle('dark-content'),
   withProps(buildWalletSectionsSelector),
   withProps({ scrollViewTracker: new Animated.Value(0) })
 )(WalletScreen);


### PR DESCRIPTION
https://linear.app/issue/RAI-131/when-send-sheet-opens-after-scanning-a-qr-code-status-bar-doesnt