### PR TITLE
useLateHaptic flag for buttons

### DIFF
--- a/ios/Button.swift
+++ b/ios/Button.swift
@@ -19,6 +19,7 @@ class Button : RCTView {
   @objc var transformOrigin: CGPoint = CGPoint(x: 0.5, y: 0.5)
   @objc var enableHapticFeedback: Bool = true
   @objc var hapticType: String = "selection"
+  @objc var useLateHaptic: Bool = false
   @objc var minLongPressDuration: TimeInterval = 0.5 {
     didSet {
       if longPress != nil {
@@ -57,13 +58,15 @@ class Button : RCTView {
     animateTapStart(
       duration: duration,
       scale: scaleTo,
-      transformOrigin: transformOrigin
+      transformOrigin: transformOrigin,
+      useHaptic: useLateHaptic ? nil : hapticType
     )
     onPressStart([:])
   }
   
   override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-    animateTapEnd(duration: duration, useHaptic: enableHapticFeedback ? hapticType: nil)
+    let useHaptic = useLateHaptic && enableHapticFeedback ? hapticType : nil
+    animateTapEnd(duration: duration, useHaptic: useHaptic)
     onPress([:])
   }
   

--- a/ios/Button.swift
+++ b/ios/Button.swift
@@ -19,7 +19,7 @@ class Button : RCTView {
   @objc var transformOrigin: CGPoint = CGPoint(x: 0.5, y: 0.5)
   @objc var enableHapticFeedback: Bool = true
   @objc var hapticType: String = "selection"
-  @objc var useLateHaptic: Bool = false
+  @objc var useLateHaptic: Bool = true
   @objc var minLongPressDuration: TimeInterval = 0.5 {
     didSet {
       if longPress != nil {

--- a/ios/ButtonManager.m
+++ b/ios/ButtonManager.m
@@ -20,6 +20,7 @@ RCT_EXPORT_VIEW_PROPERTY(hapticType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(transformOrigin, CGPoint)
 RCT_EXPORT_VIEW_PROPERTY(minLongPressDuration, NSTimeInterval)
 RCT_EXPORT_VIEW_PROPERTY(scaleTo, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(useLateHaptic, BOOL)
 
 @end
 

--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -44,8 +44,12 @@ extension UIView {
   func animateTapStart(
     duration: TimeInterval = 0.1,
     scale: CGFloat = 0.97,
-    transformOrigin: CGPoint = .init(x: 0.5, y: 0.5)
+    transformOrigin: CGPoint = .init(x: 0.5, y: 0.5),
+    useHaptic: String? = nil
   ) {
+    if useHaptic != nil {
+      generateHapticFeedback(useHaptic!)
+    }
     let timingFunction = CAMediaTimingFunction(controlPoints: 0.25, 0.46, 0.45, 0.94)
     
     CATransaction.begin()

--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.ios.js
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.ios.js
@@ -392,6 +392,7 @@ ButtonPressAnimation.propTypes = {
   scaleTo: PropTypes.number,
   style: stylePropType,
   transformOrigin: directionPropType,
+  useLateHaptic: PropTypes.bool,
 };
 
 ButtonPressAnimation.defaultProps = {
@@ -410,4 +411,5 @@ Button.defaultProps = {
   hapticType: 'selection',
   minLongPressDuration: 500,
   scaleTo: animations.keyframes.button.to.scale,
+  useLateHaptic: false,
 };

--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.ios.js
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.ios.js
@@ -411,5 +411,5 @@ Button.defaultProps = {
   hapticType: 'selection',
   minLongPressDuration: 500,
   scaleTo: animations.keyframes.button.to.scale,
-  useLateHaptic: false,
+  useLateHaptic: true,
 };

--- a/src/components/animations/TouchableScale.js
+++ b/src/components/animations/TouchableScale.js
@@ -50,6 +50,8 @@ export default class TouchableScale extends React.Component {
       useNativeDriver: props.useNativeDriver,
     }).start();
 
+    this.handleHaptic();
+
     if (props.onPressIn) {
       props.onPressIn(...args);
     }
@@ -72,8 +74,6 @@ export default class TouchableScale extends React.Component {
       toValue: props.defaultScale,
       useNativeDriver: props.useNativeDriver,
     }).start();
-
-    this.handleHaptic();
 
     if (props.onPressOut) {
       props.onPressOut(...args);

--- a/src/components/fab/FloatingActionButton.js
+++ b/src/components/fab/FloatingActionButton.js
@@ -77,6 +77,7 @@ export default class FloatingActionButton extends Component {
         onPress={this.handlePress}
         onPressIn={this.handlePressIn}
         scaleTo={scaleTo}
+        useLateHaptic={false}
         {...props}
       >
         <ShadowStack


### PR DESCRIPTION
As agreed, I added a new flag `useLateHaptic` to allow developers to decide if they want to delay haptics till `touchesEnded` event or not (`false` by default).