### PR TITLE
Set saving sheets decimals to 2

### DIFF
--- a/src/components/savings/SavingsSheetHeader.js
+++ b/src/components/savings/SavingsSheetHeader.js
@@ -17,7 +17,7 @@ const SavingsSheetHeader = ({ balance, lifetimeAccruedInterest }) => (
     >
       Savings
     </Rounded>
-    <DollarFigure value={balance} decimals={4} />
+    <DollarFigure value={balance} decimals={2} />
     <RowWithMargins align="center" margin={5} marginTop={1}>
       <Icon name="plusCircled" color={colors.green} />
       <Rounded


### PR DESCRIPTION
Fixes: https://linear.app/issue/RAI-381/savingssheet-for-non-stablecoin-tokens-have-more-than-2-decimals-for