### PR TITLE
Defer the load of the native tx list

### DIFF
--- a/src/components/activity-list/LoadingState.js
+++ b/src/components/activity-list/LoadingState.js
@@ -1,0 +1,17 @@
+import { times } from 'lodash';
+import React from 'react';
+import { Column } from '../layout';
+import { AssetListItemSkeleton } from '../asset-list';
+
+const LoadingState = ({ children }) => (
+  <Column flex={1}>
+    {children}
+    <Column flex={1}>
+      {times(11, index => (
+        <AssetListItemSkeleton key={`activitySkeleton${index}`} />
+      ))}
+    </Column>
+  </Column>
+);
+
+export default LoadingState;

--- a/src/components/activity-list/RecyclerActivityList.js
+++ b/src/components/activity-list/RecyclerActivityList.js
@@ -1,4 +1,4 @@
-import { get, times } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { Platform } from 'react-native';
@@ -16,17 +16,16 @@ import {
   isNewValueForPath,
   safeAreaInsetValues,
 } from '../../utils';
-import { AssetListItemSkeleton } from '../asset-list';
 import {
   ContractInteractionCoinRow,
   RequestCoinRow,
   TransactionCoinRow,
 } from '../coin-row';
-import { Column } from '../layout';
 import ListFooter from '../list/ListFooter';
 import ActivityListHeader from './ActivityListHeader';
 import transactionTypes from '../../helpers/transactionTypes';
 import transactionStatusTypes from '../../helpers/transactionStatusTypes';
+import LoadingState from './LoadingState';
 
 const ViewTypes = {
   COMPONENT_HEADER: 0,
@@ -41,17 +40,6 @@ const Wrapper = styled.View`
   overflow: hidden;
   width: 100%;
 `;
-
-const LoadingState = ({ children }) => (
-  <Column flex={1}>
-    {children}
-    <Column flex={1}>
-      {times(11, index => (
-        <AssetListItemSkeleton key={`activitySkeleton${index}`} />
-      ))}
-    </Column>
-  </Column>
-);
 
 const hasRowChanged = (r1, r2) => {
   if (

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose, withHandlers, withState } from 'recompact';
 import { requireNativeComponent, Clipboard, Linking, View } from 'react-native';
-import { FloatingEmojis } from '../floating-emojis';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import { isAvatarPickerAvailable } from '../../config/experimental';
 import {
@@ -16,6 +15,8 @@ import { removeRequest } from '../../redux/requests';
 import { abbreviations, ethereumUtils } from '../../utils';
 import { showActionSheetWithOptions } from '../../utils/actionsheet';
 import { colors } from '../../styles';
+import LoadingState from '../activity-list/LoadingState';
+import { FloatingEmojis } from '../floating-emojis';
 
 const NativeTransactionListView = requireNativeComponent('TransactionListView');
 
@@ -34,10 +35,15 @@ class TransactionList extends React.PureComponent {
   };
 
   render() {
+    if (!this.props.initialized && !this.props.navigation.isFocused()) {
+      return <LoadingState>{this.props.header}</LoadingState>;
+    }
+
     const data = {
       requests: this.props.requests,
       transactions: this.props.transactions,
     };
+
     return (
       <View style={this.props.style}>
         <NativeTransactionListView

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -11,7 +11,7 @@ import TransactionList from '../components/transaction-list/TransactionList';
 import nativeTransactionListAvailable from '../helpers/isNativeTransactionListAvailable';
 import networkTypes from '../helpers/networkTypes';
 
-const ACTIVITY_LIST_INITIALIZATION_DELAY = 7000;
+const ACTIVITY_LIST_INITIALIZATION_DELAY = 5000;
 
 const ProfileScreen = ({
   accountColor,
@@ -48,7 +48,20 @@ const ProfileScreen = ({
         />
       </Header>
       {nativeTransactionListAvailable ? (
-        <TransactionList navigation={navigation} style={{ flex: 1 }} />
+        <TransactionList
+          initialized={activityListInitialized}
+          navigation={navigation}
+          style={{ flex: 1 }}
+          header={
+            <ProfileMasthead
+              accountAddress={accountAddress}
+              accountColor={accountColor}
+              accountName={accountName}
+              navigation={navigation}
+              showBottomDivider={!isEmpty}
+            />
+          }
+        />
       ) : (
         <ActivityList
           accountAddress={accountAddress}


### PR DESCRIPTION
Same behavior we added last week but applied to the native tx list.
Also downgrade the delay from 7 to 5 seconds.

This helps the bootstrap of the app tremendously and it's not noticeable for users 99% of the time.