### PR TITLE
Check eth balance only if address is set

### DIFF
--- a/src/hooks/useCheckEthBalance.js
+++ b/src/hooks/useCheckEthBalance.js
@@ -11,9 +11,11 @@ export default function useCheckEthBalance() {
 
   return useCallback(async () => {
     try {
-      const ethBalance = await hasEthBalance(accountAddress);
-      const isZero = !ethBalance;
-      dispatch(setIsWalletEthZero(isZero));
+      if (accountAddress) {
+        const ethBalance = await hasEthBalance(accountAddress);
+        const isZero = !ethBalance;
+        dispatch(setIsWalletEthZero(isZero));
+      }
     } catch (error) {
       logger.log('Error: Checking eth balance', error);
     }


### PR DESCRIPTION
This check prevents to sent an early and invalid request to get the balance while the address is still not set.