### PR TITLE
Retry fetching testnet prices if network not ready

### DIFF
--- a/src/redux/testnetExplorer.js
+++ b/src/redux/testnetExplorer.js
@@ -63,7 +63,10 @@ export const testnetExplorerInit = () => async (dispatch, getState) => {
   const fetchAssetsBalancesAndPrices = async () => {
     const { network } = getState().settings;
     const assets = testnetAssets[network];
-
+    if (!assets || !assets.length) {
+      testnetExplorerHandle = setTimeout(fetchAssetsBalancesAndPrices, 5000);
+      return;
+    }
     const prices = await fetchAssetPrices(
       assets.map(({ asset: { coingecko_id } }) => coingecko_id),
       formattedNativeCurrency


### PR DESCRIPTION
Fixes https://sentry.io/organizations/rainbow-me/issues/1607861356/?environment=Release&project=1855565&query=is%3Aunresolved+release%3Ame.rainbow-1.2.7&statsPeriod=14d