### PR TITLE
Fix behavior for long press in exchange modal

### DIFF
--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
@@ -124,7 +124,7 @@ class HoldToAuthorizeButton extends PureComponent {
   };
 
   onLongPressChange = ({ nativeEvent: { state } }) => {
-    const { disabled, enableLongPress } = this.props;
+    const { disabled } = this.props;
 
     if (state === ACTIVE && !disabled) {
       haptics.notificationSuccess();
@@ -132,7 +132,7 @@ class HoldToAuthorizeButton extends PureComponent {
 
       animate(this.buttonScale, {
         toValue: 1,
-      }).start(() => this.setState({ isAuthorizing: enableLongPress }));
+      }).start(() => this.setState({ isAuthorizing: true }));
 
       this.handlePress();
     }

--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
@@ -19,7 +19,7 @@ import HoldToAuthorizeButtonIcon from './HoldToAuthorizeButtonIcon';
 
 const { divide, multiply, proc, timing, Value } = Animated;
 
-const { ACTIVE, BEGAN, END } = State;
+const { ACTIVE, BEGAN, END, FAILED } = State;
 
 const ButtonBorderRadius = 30;
 const ButtonHeight = 59;
@@ -126,13 +126,13 @@ class HoldToAuthorizeButton extends PureComponent {
   onLongPressChange = ({ nativeEvent: { state } }) => {
     const { disabled, enableLongPress } = this.props;
 
-    if (state === ACTIVE && !disabled && enableLongPress) {
+    if (state === ACTIVE && !disabled) {
       haptics.notificationSuccess();
       Keyboard.dismiss();
 
       animate(this.buttonScale, {
         toValue: 1,
-      }).start(() => this.setState({ isAuthorizing: true }));
+      }).start(() => this.setState({ isAuthorizing: enableLongPress }));
 
       this.handlePress();
     }
@@ -161,7 +161,7 @@ class HoldToAuthorizeButton extends PureComponent {
             toValue: 100,
           }).start();
         }
-      } else if (state === END) {
+      } else if (state === END || state === FAILED) {
         animate(this.buttonScale, { toValue: 1 }).start();
         if (enableLongPress) {
           animate(this.longPressProgress, {


### PR DESCRIPTION
- I tested it only on iPhone X and simulators so it would be really cool if somebody will check this one out on the physical iPhone 8 or below.

- BTW I realized that every time I fail my FaceID check there instantly appears the second one. Is it desired behavior?

Fixes RAI-217 https://linear.app/issue/RAI-217/a-long-press-on-the-tap-to-send-button-should-trigger-a-press