### PR TITLE
use Clipboard from react-native-community pkg

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -440,6 +440,8 @@ PODS:
     - React
   - RNCAsyncStorage (1.7.1):
     - React
+  - RNCClipboard (1.2.2):
+    - React
   - RNCMaskedView (0.1.9):
     - React
   - RNCPushNotificationIOS (1.1.1):
@@ -579,6 +581,7 @@ DEPENDENCIES:
   - "ReactNativePayments (from `../node_modules/@rainbow-me/react-native-payments/lib/ios`)"
   - "RNAnalytics (from `../node_modules/@segment/analytics-react-native`)"
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
@@ -734,6 +737,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@segment/analytics-react-native"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-community/async-storage"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-community/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNCPushNotificationIOS:
@@ -859,6 +864,7 @@ SPEC CHECKSUMS:
   ReactNativePayments: 40a266450628c05db440fe219b631210e4358a49
   RNAnalytics: 35a54cb740c472a0a6a3de765176b82cccc2d1ef
   RNCAsyncStorage: 44395cb9c7c1523104c2b499eb426ef7aff82bca
+  RNCClipboard: 8148e21ac347c51fd6cd4b683389094c216bb543
   RNCMaskedView: 71fc32d971f03b7f03d6ab6b86b730c4ee64f5b6
   RNCPushNotificationIOS: a0b6894f4ad9b93d9dac467fdf4d055660ac8a0d
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rainbow-me/react-native-payments": "^1.1.5",
     "@react-native-community/async-storage": "1.7.1",
     "@react-native-community/blur": "^3.4.1",
+    "@react-native-community/clipboard": "^1.2.2",
     "@react-native-community/masked-view": "^0.1.5",
     "@react-native-community/netinfo": "^5.3.2",
     "@react-native-community/push-notification-ios": "^1.0.3",

--- a/src/components/buttons/PasteAddressButton.js
+++ b/src/components/buttons/PasteAddressButton.js
@@ -1,6 +1,6 @@
+import Clipboard from '@react-native-community/clipboard';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Clipboard } from 'react-native';
 import { checkIsValidAddress } from '../../helpers/validators';
 import { withAppState } from '../../hoc';
 import { colors } from '../../styles';

--- a/src/components/copy-tooltip/CopyTooltip.ios.js
+++ b/src/components/copy-tooltip/CopyTooltip.ios.js
@@ -1,6 +1,6 @@
+import Clipboard from '@react-native-community/clipboard';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Clipboard } from 'react-native';
 import ToolTip from 'react-native-tooltip';
 import { withNavigation } from 'react-navigation';
 import { compose, onlyUpdateForKeys } from 'recompact';

--- a/src/components/fields/AddressField.js
+++ b/src/components/fields/AddressField.js
@@ -1,7 +1,8 @@
+import Clipboard from '@react-native-community/clipboard';
 import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Clipboard, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import { withNavigation } from 'react-navigation';
 import styled from 'styled-components/primitives';

--- a/src/components/send/SendHeader.js
+++ b/src/components/send/SendHeader.js
@@ -1,7 +1,8 @@
+import Clipboard from '@react-native-community/clipboard';
 import { get, isEmpty, isNumber, toLower } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
-import { Clipboard, Keyboard } from 'react-native';
+import { Keyboard } from 'react-native';
 import { withNavigation } from 'react-navigation';
 import { compose, withProps } from 'recompact';
 import styled from 'styled-components/primitives';

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -1,5 +1,6 @@
+import Clipboard from '@react-native-community/clipboard';
 import React from 'react';
-import { Clipboard, Linking, requireNativeComponent, View } from 'react-native';
+import { Linking, requireNativeComponent, View } from 'react-native';
 import { connect } from 'react-redux';
 import { compose, withHandlers, withState } from 'recompact';
 import { isAvatarPickerAvailable } from '../../config/experimental';

--- a/src/hoc/withSendFeedback.js
+++ b/src/hoc/withSendFeedback.js
@@ -1,5 +1,5 @@
+import Clipboard from '@react-native-community/clipboard';
 import { debounce } from 'lodash';
-import { Clipboard } from 'react-native';
 import Mailer from 'react-native-mail';
 import { withHandlers } from 'recompact';
 import { Alert } from '../components/alerts';

--- a/src/hooks/useClipboard.js
+++ b/src/hooks/useClipboard.js
@@ -1,5 +1,5 @@
+import Clipboard from '@react-native-community/clipboard';
 import { useEffect, useState } from 'react';
-import { Clipboard } from 'react-native';
 import useAppState from './useAppState';
 
 const listeners = new Set();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,6 +1175,11 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-native-community/clipboard@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/clipboard/-/clipboard-1.2.2.tgz#956b29df141199fd9ed47e820baf9693f9f50b55"
+  integrity sha512-WJkJSWA/fhuBhHL3rh6UDdB8+AZNMvAHoyo/ERnNxl9KZqruq7K+AIaQQlggEAsIVBIhjKt65fT+Zynj7gF8Cg==
+
 "@react-native-community/masked-view@^0.1.5":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.9.tgz#383aca2fb053e3e14405c99cce2d5805df730821"


### PR DESCRIPTION
Since It has been deprecated from `react-native` as part of the "Lean Core" effort.
This PR removes the warning, which help us fixing RAI-466