### PR TITLE
Change disable condition for FabWrapper

### DIFF
--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -69,7 +69,7 @@ export default function WalletScreen() {
       reattaching of react subviews */}
       <Animated.Code exec={scrollViewTracker} />
       <FabWrapper
-        disabled={isWalletEthZero}
+        disabled={isEmpty}
         fabs={fabs}
         scrollViewTracker={scrollViewTracker}
         sections={sections}


### PR DESCRIPTION
If you have an empty wallet open when it receives an asset for the first time Send/swap buttons don't show