### PR TITLE
Update default sim to iPhone 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "install-all": "yarn && yarn install-pods",
     "install-pods": "cd ios && bundle exec pod install --repo-update && cd ..",
     "install-bundle": "cd ios && bundle install && cd ..",
-    "ios": "react-native run-ios --simulator='iPhone X'",
+    "ios": "react-native run-ios --simulator='iPhone 11'",
     "lint": "eslint --ext '.js,.jsx' .",
     "nodeify": "./node_modules/.bin/rn-nodeify --install \"crypto\" --hack",
     "postinstall": "patch-package && rn-nodeify --install --hack"


### PR DESCRIPTION
Latest xCode version doesn't have iPhone X installed by default so I'm changing the default to be iPhone 11 when running `yarn ios`