### PR TITLE
Prevent routes crashing if index missing

### DIFF
--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -420,8 +420,16 @@ const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
 
       const oldMainStack = prevState.routes[prevState.index];
       const newMainStack = currentState.routes[currentState.index];
-      const oldIndex = oldMainStack.routes[oldMainStack.index].index;
-      const newIndex = newMainStack.routes[newMainStack.index].index;
+      const oldIndex = get(
+        oldMainStack,
+        `routes[${oldMainStack.index}].index`,
+        null
+      );
+      const newIndex = get(
+        newMainStack,
+        `routes[${newMainStack.index}].index`,
+        null
+      );
 
       if (oldIndex !== newIndex) {
         expandedPreset.onTransitionStart({ closing: !newIndex });


### PR DESCRIPTION
Attemp to prevent: https://sentry.io/organizations/rainbow-me/issues/1626320675/?project=1855565&referrer=slack