### PR TITLE
Use paging for OpenSea requests to fetch more unique tokens

### DIFF
--- a/src/handlers/opensea-api.js
+++ b/src/handlers/opensea-api.js
@@ -2,7 +2,8 @@ import axios from 'axios';
 import { parseAccountUniqueTokens } from '../parsers/uniqueTokens';
 import { logger } from '../utils';
 
-export const UNIQUE_TOKENS_LIMIT = 50;
+export const UNIQUE_TOKENS_LIMIT_PER_PAGE = 50;
+export const UNIQUE_TOKENS_LIMIT_TOTAL = 350;
 
 const api = axios.create({
   baseURL: 'https://api.opensea.io/api/v1',
@@ -14,9 +15,9 @@ const api = axios.create({
 
 export const apiGetAccountUniqueTokens = async (address, page) => {
   try {
-    const offset = page * UNIQUE_TOKENS_LIMIT;
+    const offset = page * UNIQUE_TOKENS_LIMIT_PER_PAGE;
     const data = await api.get(
-      `/assets?exclude_currencies=true&owner=${address}&limit=${UNIQUE_TOKENS_LIMIT}&offset=${offset}`
+      `/assets?exclude_currencies=true&owner=${address}&limit=${UNIQUE_TOKENS_LIMIT_PER_PAGE}&offset=${offset}`
     );
     return parseAccountUniqueTokens(data);
   } catch (error) {

--- a/src/handlers/opensea-api.js
+++ b/src/handlers/opensea-api.js
@@ -2,10 +2,8 @@ import axios from 'axios';
 import { parseAccountUniqueTokens } from '../parsers/uniqueTokens';
 import { logger } from '../utils';
 
-/**
- * Configuration for opensea api
- * @type axios instance
- */
+export const UNIQUE_TOKENS_LIMIT = 50;
+
 const api = axios.create({
   baseURL: 'https://api.opensea.io/api/v1',
   headers: {
@@ -14,15 +12,11 @@ const api = axios.create({
   timeout: 20000, // 20 secs
 });
 
-/**
- * @desc get opensea unique tokens
- * @param  {String}   [address='']
- * @return {Promise}
- */
-export const apiGetAccountUniqueTokens = async (address = '') => {
+export const apiGetAccountUniqueTokens = async (address, page) => {
   try {
+    const offset = page * UNIQUE_TOKENS_LIMIT;
     const data = await api.get(
-      `/assets?exclude_currencies=true&owner=${address}&limit=300`
+      `/assets?exclude_currencies=true&owner=${address}&limit=${UNIQUE_TOKENS_LIMIT}&offset=${offset}`
     );
     return parseAccountUniqueTokens(data);
   } catch (error) {

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -86,7 +86,21 @@ export const parseTransactions = (
         remainingTransactions
       )
     : concat(updatedPendingTransactions, parsedNewTransactions);
-  return uniqBy(updatedResults, txn => txn.hash);
+
+  const potentialNftTransaction = appended
+    ? find(parsedNewTransactions, txn => {
+        return (
+          !txn.protocol &&
+          (txn.type === 'send' || txn.type === 'receive') &&
+          txn.symbol !== 'ETH'
+        );
+      })
+    : null;
+
+  return {
+    dedupedResults: uniqBy(updatedResults, txn => txn.hash),
+    potentialNftTransaction,
+  };
 };
 
 const transformUniswapRefund = internalTransactions => {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -44,6 +44,8 @@ import {
 } from '../references';
 import { ethereumUtils, isLowerCaseMatch } from '../utils';
 import { addCashUpdatePurchases } from './addCash';
+/* eslint-disable-next-line import/no-cycle */
+import { uniqueTokensRefreshState } from './uniqueTokens';
 import { uniswapUpdateLiquidityTokens } from './uniswap';
 
 let pendingTransactionsHandle = null;
@@ -170,7 +172,7 @@ export const transactionsReceived = (message, appended = false) => async (
   const { accountAddress, nativeCurrency, network } = getState().settings;
   const { purchaseTransactions } = getState().addCash;
   const { transactions, tokenOverrides } = getState().data;
-  const dedupedResults = parseTransactions(
+  const { dedupedResults, potentialNftTransaction } = parseTransactions(
     transactionData,
     accountAddress,
     nativeCurrency,
@@ -180,6 +182,11 @@ export const transactionsReceived = (message, appended = false) => async (
     network,
     appended
   );
+  if (appended && potentialNftTransaction) {
+    setTimeout(() => {
+      dispatch(uniqueTokensRefreshState());
+    }, 60000);
+  }
   dispatch({
     payload: dedupedResults,
     type: DATA_UPDATE_TRANSACTIONS,

--- a/src/redux/uniqueTokens.js
+++ b/src/redux/uniqueTokens.js
@@ -1,11 +1,13 @@
-import { captureException } from '@sentry/react-native';
-import { without } from 'lodash';
+import { concat, isEmpty, without } from 'lodash';
 import {
   getUniqueTokens,
   removeUniqueTokens,
   saveUniqueTokens,
 } from '../handlers/localstorage/accountLocal';
-import { apiGetAccountUniqueTokens } from '../handlers/opensea-api';
+import {
+  apiGetAccountUniqueTokens,
+  UNIQUE_TOKENS_LIMIT,
+} from '../handlers/opensea-api';
 import networkTypes from '../helpers/networkTypes';
 import { dedupeAssetsWithFamilies, getFamilies } from '../parsers/uniqueTokens';
 import { dataUpdateAssets } from './data';
@@ -28,8 +30,6 @@ const UNIQUE_TOKENS_GET_UNIQUE_TOKENS_FAILURE =
 const UNIQUE_TOKENS_CLEAR_STATE = 'uniqueTokens/UNIQUE_TOKENS_CLEAR_STATE';
 
 // -- Actions --------------------------------------------------------------- //
-let uniqueTokensHandle = null;
-
 export const uniqueTokensLoadState = () => async (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
   dispatch({ type: UNIQUE_TOKENS_LOAD_UNIQUE_TOKENS_REQUEST });
@@ -47,12 +47,10 @@ export const uniqueTokensLoadState = () => async (dispatch, getState) => {
 export const uniqueTokensClearState = () => (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
   removeUniqueTokens(accountAddress, network);
-  clearTimeout(uniqueTokensHandle);
   dispatch({ type: UNIQUE_TOKENS_CLEAR_STATE });
 };
 
 export const uniqueTokensResetState = () => dispatch => {
-  clearTimeout(uniqueTokensHandle);
   dispatch({ type: UNIQUE_TOKENS_CLEAR_STATE });
 };
 
@@ -64,7 +62,7 @@ export const uniqueTokensRefreshState = () => async (dispatch, getState) => {
     return;
   }
 
-  dispatch(watchUniqueTokens());
+  dispatch(fetchUniqueTokens());
 };
 
 const fetchUniqueTokens = () => async (dispatch, getState) => {
@@ -72,8 +70,35 @@ const fetchUniqueTokens = () => async (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
   const { assets } = getState().data;
   const { uniqueTokens: existingUniqueTokens } = getState().uniqueTokens;
+  const shouldUpdateInBatches = isEmpty(existingUniqueTokens);
+
+  let shouldStopFetching = false;
+  let page = 0;
+  let uniqueTokens = [];
+
   try {
-    const uniqueTokens = await apiGetAccountUniqueTokens(accountAddress);
+    while (!shouldStopFetching) {
+      const newPageResults = await apiGetAccountUniqueTokens(
+        accountAddress,
+        page
+      );
+      shouldStopFetching = newPageResults.length < UNIQUE_TOKENS_LIMIT;
+      uniqueTokens = concat(uniqueTokens, newPageResults);
+      page += 1;
+      if (shouldUpdateInBatches) {
+        dispatch({
+          payload: uniqueTokens,
+          type: UNIQUE_TOKENS_GET_UNIQUE_TOKENS_SUCCESS,
+        });
+      }
+    }
+
+    if (!shouldUpdateInBatches) {
+      dispatch({
+        payload: uniqueTokens,
+        type: UNIQUE_TOKENS_GET_UNIQUE_TOKENS_SUCCESS,
+      });
+    }
     const existingFamilies = getFamilies(existingUniqueTokens);
     const newFamilies = getFamilies(uniqueTokens);
     const incomingFamilies = without(newFamilies, ...existingFamilies);
@@ -81,29 +106,10 @@ const fetchUniqueTokens = () => async (dispatch, getState) => {
       const dedupedAssets = dedupeAssetsWithFamilies(assets, incomingFamilies);
       dispatch(dataUpdateAssets(dedupedAssets));
     }
+
     saveUniqueTokens(uniqueTokens, accountAddress, network);
-    dispatch({
-      payload: uniqueTokens,
-      type: UNIQUE_TOKENS_GET_UNIQUE_TOKENS_SUCCESS,
-    });
   } catch (error) {
     dispatch({ type: UNIQUE_TOKENS_GET_UNIQUE_TOKENS_FAILURE });
-    captureException(error);
-  }
-};
-
-const watchUniqueTokens = () => async dispatch => {
-  try {
-    await dispatch(fetchUniqueTokens());
-    uniqueTokensHandle && clearTimeout(uniqueTokensHandle);
-    uniqueTokensHandle = setTimeout(() => {
-      dispatch(watchUniqueTokens());
-    }, 15000); // 15 secs
-  } catch (error) {
-    uniqueTokensHandle && clearTimeout(uniqueTokensHandle);
-    uniqueTokensHandle = setTimeout(() => {
-      dispatch(watchUniqueTokens());
-    }, 15000); // 15 secs
   }
 };
 


### PR DESCRIPTION
Currently, it is set with a 1 minute delay after receiving a txn before refetching from OpenSea. For the cases I did, it was able to get the correct update by the 1 minute. This delay could potentially be reduced.

The recurring 15 second interval has been removed.

This has been tested on sending an ETH transaction (will not refresh), an ERC20 that was sent or received (will refresh), and a trade execution (will not refresh). I decided against checking these new transactions against an existing list of ERC20s for now, as I can do these preliminary checks with just the transaction data itself.

I tested the addresses of users with a ton of NFTs on simulator. It works! However, there was one user who had close to 2000 Cryptokitties, and the app became unusable after opening the token family for Cryptokitties. Basically, the app becomes unusable until all the photos in the family were loaded. I created a separate issue for Wojtek to investigate preventing the loading of all the tokens in the family until they become close to on screen.