### PR TITLE
Disable warning

### DIFF
--- a/src/components/discover-sheet/DiscoverSheet.js
+++ b/src/components/discover-sheet/DiscoverSheet.js
@@ -391,6 +391,7 @@ const renderInner = () => (
 );
 
 export default function DiscoverSheet() {
+  // eslint-disable-next-line no-unused-vars
   const topMovers = useTopMovers();
   return (
     <BottomSheet


### PR DESCRIPTION
This is making the linter to throw an error, making all the test builds to fail