### PR TITLE
Update lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,json}": [
-      "eslint --ext '.js,.jsx,.json' -c .eslintrc.json",
-      "git add"
+    "*.{js,jsx}": [
+      "eslint --ext '.js,.jsx' -c .eslintrc.json"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
This PR addresses two separate things:

- Prevent linting of json files (linter fails when making changes to json files)
- Remove unnecessary `git add` per recommendation of @Kureev 