### PR TITLE
💸 Improve Add Cash funnel tracking

### DIFF
--- a/src/handlers/wyre.js
+++ b/src/handlers/wyre.js
@@ -19,6 +19,11 @@ const WYRE_FLAT_FEE_USD = 0.3;
 const SOURCE_CURRENCY_USD = 'USD';
 const PAYMENT_PROCESSOR_COUNTRY_CODE = 'US';
 
+export const PaymentRequestStatusTypes = {
+  FAIL: 'fail',
+  SUCCESS: 'success',
+};
+
 const wyreApi = axios.create({
   baseURL: __DEV__ ? WYRE_ENDPOINT_TEST : WYRE_ENDPOINT,
   headers: {
@@ -175,14 +180,14 @@ export const getOrderId = async (
         message
       )
     );
-    paymentResponse.complete('fail');
+    paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
     return { errorCode, type };
   } catch (error) {
     logger.sentry(
       `WYRE - getOrderId response catch - ${referenceInfo.referenceId}`
     );
     captureException(error);
-    paymentResponse.complete('fail');
+    paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
     return {};
   }
 };

--- a/src/handlers/wyre.js
+++ b/src/handlers/wyre.js
@@ -26,24 +26,17 @@ const wyreApi = axios.create({
     'Content-Type': 'application/json',
   },
   timeout: 30000, // 30 secs
-  validateStatus: function(status) {
-    // do not throw error so we can get
-    // exception ID and message from response
-    return status >= 200;
-  },
 });
 
 const WyreExceptionTypes = {
   CREATE_ORDER: 'WyreCreateOrderException',
-  TRACK_ORDER: 'WyreTrackOrderException',
-  TRACK_TRANSFER: 'WyreTrackTransferException',
 };
 
 class WyreException extends Error {
-  constructor(name, referenceInfo, errorId, message) {
+  constructor(name, referenceInfo, errorId, errorCode, message) {
     const referenceInfoIds = values(referenceInfo);
     const referenceId = join(referenceInfoIds, ':');
-    super(`${referenceId}:${errorId}:${message}`);
+    super(`${referenceId}:${errorId}:${errorCode}:${message}`);
     this.name = name;
   }
 }
@@ -120,21 +113,9 @@ export const showApplePayRequest = async (
 export const trackWyreOrder = async (referenceInfo, orderId) => {
   try {
     const response = await wyreApi.get(`/v3/orders/${orderId}`);
-    if (response.status >= 200 && response.status < 300) {
-      const orderStatus = get(response, 'data.status');
-      const transferId = get(response, 'data.transferId');
-      return { data: response.data, orderStatus, transferId };
-    }
-    const {
-      data: { exceptionId, message },
-    } = response;
-
-    throw new WyreException(
-      WyreExceptionTypes.TRACK_ORDER,
-      referenceInfo,
-      exceptionId,
-      message
-    );
+    const orderStatus = get(response, 'data.status');
+    const transferId = get(response, 'data.transferId');
+    return { data: response.data, orderStatus, transferId };
   } catch (error) {
     throw error;
   }
@@ -143,23 +124,12 @@ export const trackWyreOrder = async (referenceInfo, orderId) => {
 export const trackWyreTransfer = async (referenceInfo, transferId) => {
   try {
     const response = await wyreApi.get(`/v2/transfer/${transferId}/track`);
-    if (response.status >= 200 && response.status < 300) {
-      const transferHash = get(response, 'data.blockchainNetworkTx');
-      const destAmount = get(response, 'data.destAmount');
-      const destCurrency = get(response, 'data.destCurrency');
-      const statusTimeline = get(response, 'data.successTimeline', []);
-      const transferStatus = get(last(statusTimeline), 'state');
-      return { destAmount, destCurrency, transferHash, transferStatus };
-    }
-    const {
-      data: { exceptionId, message },
-    } = response;
-    throw new WyreException(
-      WyreExceptionTypes.TRACK_TRANSFER,
-      referenceInfo,
-      exceptionId,
-      message
-    );
+    const transferHash = get(response, 'data.blockchainNetworkTx');
+    const destAmount = get(response, 'data.destAmount');
+    const destCurrency = get(response, 'data.destCurrency');
+    const statusTimeline = get(response, 'data.successTimeline', []);
+    const transferStatus = get(last(statusTimeline), 'state');
+    return { destAmount, destCurrency, transferHash, transferStatus };
   } catch (error) {
     throw error;
   }
@@ -180,32 +150,40 @@ export const getOrderId = async (
     destCurrency
   );
   try {
-    const response = await wyreApi.post('/v3/apple-pay/process/partner', data);
+    const response = await wyreApi.post('/v3/apple-pay/process/partner', data, {
+      validateStatus: function(status) {
+        // do not throw error so we can get
+        // exception ID and message from response
+        return status >= 200;
+      },
+    });
 
     if (response.status >= 200 && response.status < 300) {
-      return get(response, 'data.id', null);
+      const orderId = get(response, 'data.id', null);
+      return { orderId };
     }
     logger.sentry('WYRE - getOrderId response - was not 200', response.data);
     const {
-      data: { exceptionId, message },
+      data: { errorCode, exceptionId, message, type },
     } = response;
     captureException(
       new WyreException(
         WyreExceptionTypes.CREATE_ORDER,
         referenceInfo,
         exceptionId,
+        errorCode,
         message
       )
     );
     paymentResponse.complete('fail');
-    return null;
+    return { errorCode, type };
   } catch (error) {
     logger.sentry(
       `WYRE - getOrderId response catch - ${referenceInfo.referenceId}`
     );
     captureException(error);
     paymentResponse.complete('fail');
-    return null;
+    return {};
   }
 };
 

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import {
   getOrderId,
   getReferenceId,
+  PaymentRequestStatusTypes,
   showApplePayRequest,
   trackWyreOrder,
   trackWyreTransfer,
@@ -169,13 +170,13 @@ export default function useWyreApplePay() {
               error_category: get(data, 'errorCategory', 'unknown'),
               error_code: get(data, 'errorCode', 'unknown'),
             });
-            paymentResponse.complete('fail');
+            paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
             handlePaymentCallback();
           } else if (isPending || isSuccess) {
             analytics.track('Purchase completed', {
               category: 'add cash',
             });
-            paymentResponse.complete('success');
+            paymentResponse.complete(PaymentRequestStatusTypes.SUCCESS);
             handlePaymentCallback();
           } else if (!isChecking) {
             logger.sentry('Wyre order data', data);
@@ -243,7 +244,7 @@ export default function useWyreApplePay() {
             error_category: type,
             error_code: errorCode,
           });
-          paymentResponse.complete('fail');
+          paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
           handlePaymentCallback();
         }
       } else {

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -221,7 +221,7 @@ export default function useWyreApplePay() {
 
       if (applePayResponse) {
         const { paymentResponse, totalAmount } = applePayResponse;
-        const orderId = await getOrderId(
+        const { orderId, errorCode, type } = await getOrderId(
           referenceInfo,
           paymentResponse,
           totalAmount,
@@ -240,8 +240,8 @@ export default function useWyreApplePay() {
         } else {
           analytics.track('Purchase failed', {
             category: 'add cash',
-            error_category: 'EARLY_FAILURE',
-            error_code: 'NO_ORDER_ID',
+            error_category: type,
+            error_code: errorCode,
           });
           paymentResponse.complete('fail');
           handlePaymentCallback();

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -246,6 +246,10 @@ export default function useWyreApplePay() {
           paymentResponse.complete('fail');
           handlePaymentCallback();
         }
+      } else {
+        analytics.track('Purchase incomplete', {
+          category: 'add cash',
+        });
       }
     },
     [accountAddress, getOrderStatus, handlePaymentCallback]


### PR DESCRIPTION
* Pass along error category and code for items without an order ID
* Track when a purchase is incomplete but not failed

Axios by default throws an error whenever a response is not in the 200 range. I had this default overridden for the Wyre API requests, but realize I only need to override it for the initial submitting of the order (where they come back with a non-200 status and some error information we want to pick up.) So I removed this check for the other Wyre API requests where we don't need it.

For the other endpoints, the response will come back 200 status but with the error statuses in the data payload itself.

Just FYI - I haven't tested this PR on device yet.