### PR TITLE
Handle price when savings underlying does not exist in wallet

### DIFF
--- a/src/screens/DepositModal.js
+++ b/src/screens/DepositModal.js
@@ -7,6 +7,7 @@ import ExchangeModalWithData from './ExchangeModalWithData';
 
 const DepositModal = ({ navigation, ...props }) => {
   const defaultInputAsset = navigation.getParam('defaultInputAsset');
+  const underlyingPrice = navigation.getParam('underlyingPrice');
   return (
     <ExchangeModalWithData
       createRap={createSwapAndDepositCompoundRap}
@@ -15,6 +16,7 @@ const DepositModal = ({ navigation, ...props }) => {
       inputHeaderTitle="Deposit"
       showOutputField={false}
       type={ExchangeModalTypes.deposit}
+      underlyingPrice={underlyingPrice}
       {...props}
     />
   );

--- a/src/screens/SavingsSheet.js
+++ b/src/screens/SavingsSheet.js
@@ -115,6 +115,7 @@ const SavingsSheet = () => {
     if (selectedWallet.type !== WalletTypes.readOnly) {
       navigate(Routes.SAVINGS_DEPOSIT_MODAL, {
         defaultInputAsset: underlying,
+        underlyingPrice,
       });
 
       analytics.track('Navigated to SavingsDepositModal', {
@@ -126,7 +127,14 @@ const SavingsSheet = () => {
       goBack();
       Alert.alert(`You need to import the wallet in order to do this`);
     }
-  }, [goBack, isEmpty, navigate, selectedWallet.type, underlying]);
+  }, [
+    goBack,
+    isEmpty,
+    navigate,
+    selectedWallet.type,
+    underlying,
+    underlyingPrice,
+  ]);
 
   return (
     <Sheet>


### PR DESCRIPTION
The issue was when you would deposit an asset whose underlying did not exist in the wallet - we were not passing along the underlying price from the Savings sheet for this scenario (only for withdrawals, not for deposits).