### PR TITLE
Fix issues with pending txn watcher

### DIFF
--- a/src/parsers/newTransaction.js
+++ b/src/parsers/newTransaction.js
@@ -29,12 +29,14 @@ export const parseNewTransaction = async (
     get(txDetails, 'asset.price.value', 0),
     nativeCurrency
   );
-  let tx = pick(txDetails, ['dappName', 'from', 'hash', 'nonce', 'to', 'type']);
+  let tx = pick(txDetails, ['dappName', 'from', 'nonce', 'to', 'type']);
+  const hash = txDetails.hash ? `${txDetails.hash}-0` : null;
   const nonce = tx.nonce || (tx.from ? await getTransactionCount(tx.from) : '');
   const status = txDetails.status || TransactionStatusTypes.sending;
   tx = {
     ...tx,
     balance,
+    hash,
     minedAt: null,
     name: get(txDetails, 'asset.name'),
     native,

--- a/src/raps/actions/depositCompound.js
+++ b/src/raps/actions/depositCompound.js
@@ -83,7 +83,7 @@ const depositCompound = async (wallet, currentRap, index, parameters) => {
   };
   logger.log('[deposit] adding new txn', newTransaction);
   // Disable the txn watcher because Compound can silently fail
-  dispatch(dataAddNewTransaction(newTransaction, true));
+  await dispatch(dataAddNewTransaction(newTransaction, true));
   logger.log('[deposit] calling the callback');
   currentRap.callback();
   currentRap.callback = NOOP;

--- a/src/raps/actions/swap.js
+++ b/src/raps/actions/swap.js
@@ -126,7 +126,7 @@ const swap = async (wallet, currentRap, index, parameters) => {
     type: transactionTypes.swap,
   };
   logger.log('[swap] adding new txn', newTransaction);
-  dispatch(dataAddNewTransaction(newTransaction, true));
+  await dispatch(dataAddNewTransaction(newTransaction, true));
   logger.log('[swap] calling the callback');
   currentRap.callback();
   currentRap.callback = NOOP;

--- a/src/raps/actions/unlock.js
+++ b/src/raps/actions/unlock.js
@@ -57,7 +57,7 @@ const unlock = async (wallet, currentRap, index, parameters) => {
   dispatch(rapsAddOrUpdate(currentRap.id, currentRap));
 
   logger.log('[unlock] add a new txn');
-  dispatch(
+  await dispatch(
     dataAddNewTransaction({
       amount: 0,
       asset: assetToUnlock,

--- a/src/raps/actions/withdrawCompound.js
+++ b/src/raps/actions/withdrawCompound.js
@@ -81,7 +81,7 @@ const withdrawCompound = async (wallet, currentRap, index, parameters) => {
 
   logger.log('[withdraw] adding new txn', newTransaction);
   // Disable the txn watcher because Compound can silently fail
-  dispatch(dataAddNewTransaction(newTransaction, true));
+  await dispatch(dataAddNewTransaction(newTransaction, true));
 
   logger.log('[withdraw] calling the callback');
   currentRap.callback();

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -10,6 +10,7 @@ import {
   map,
   mapKeys,
   mapValues,
+  partition,
   property,
   remove,
   uniqBy,
@@ -39,7 +40,7 @@ import { parseAccountAssets, parseAsset } from '../parsers/accounts';
 import { parseNewTransaction } from '../parsers/newTransaction';
 import { parseTransactions } from '../parsers/transactions';
 import { tokenOverrides } from '../references';
-import { ethereumUtils, isLowerCaseMatch } from '../utils';
+import { ethereumUtils, isLowerCaseMatch, logger } from '../utils';
 import { addCashUpdatePurchases } from './addCash';
 /* eslint-disable-next-line import/no-cycle */
 import { uniqueTokensRefreshState } from './uniqueTokens';
@@ -388,30 +389,29 @@ export const assetPricesChanged = message => (dispatch, getState) => {
   });
 };
 
-export const dataAddNewTransaction = (txDetails, disableTxnWatcher = false) => (
-  dispatch,
-  getState
-) =>
-  new Promise((resolve, reject) => {
-    const { transactions } = getState().data;
-    const { accountAddress, nativeCurrency, network } = getState().settings;
-    parseNewTransaction(txDetails, nativeCurrency)
-      .then(parsedTransaction => {
-        const _transactions = [parsedTransaction, ...transactions];
-        dispatch({
-          payload: _transactions,
-          type: DATA_ADD_NEW_TRANSACTION_SUCCESS,
-        });
-        saveLocalTransactions(_transactions, accountAddress, network);
-        if (!disableTxnWatcher) {
-          dispatch(watchPendingTransactions());
-        }
-        resolve(true);
-      })
-      .catch(error => {
-        reject(error);
-      });
-  });
+export const dataAddNewTransaction = (
+  txDetails,
+  disableTxnWatcher = false
+) => async (dispatch, getState) => {
+  const { transactions } = getState().data;
+  const { accountAddress, nativeCurrency, network } = getState().settings;
+  try {
+    const parsedTransaction = await parseNewTransaction(
+      txDetails,
+      nativeCurrency
+    );
+    const _transactions = [parsedTransaction, ...transactions];
+    dispatch({
+      payload: _transactions,
+      type: DATA_ADD_NEW_TRANSACTION_SUCCESS,
+    });
+    saveLocalTransactions(_transactions, accountAddress, network);
+    if (!disableTxnWatcher) {
+      dispatch(watchPendingTransactions());
+    }
+    // eslint-disable-next-line no-empty
+  } catch (error) {}
+};
 
 const getConfirmedState = type => {
   switch (type) {
@@ -435,13 +435,19 @@ export const dataWatchPendingTransactions = () => async (
   getState
 ) => {
   const { transactions } = getState().data;
-  if (!transactions.length) return false;
-  const updatedTransactions = [...transactions];
+  if (!transactions.length) return true;
   let txStatusesDidChange = false;
 
-  const pending = filter(transactions, ['pending', true]);
-  await Promise.all(
-    pending.map(async (tx, index) => {
+  const [pending, remainingTransactions] = partition(
+    transactions,
+    txn => txn.pending
+  );
+
+  if (isEmpty(pending)) return true;
+
+  const updatedPendingTransactions = await Promise.all(
+    pending.map(async tx => {
+      const updatedPending = { ...tx };
       const txHash = tx.hash.split('-').shift();
       try {
         const txObj = await getTransactionReceipt(txHash);
@@ -449,18 +455,23 @@ export const dataWatchPendingTransactions = () => async (
           const minedAt = Math.floor(Date.now() / 1000);
           txStatusesDidChange = true;
           if (!isZero(txObj.status)) {
-            updatedTransactions[index].status = getConfirmedState(
-              updatedTransactions[index].type
-            );
+            const newStatus = getConfirmedState(tx.type);
+            updatedPending.status = newStatus;
           } else {
-            updatedTransactions[index].status = TransactionStatusTypes.failed;
+            updatedPending.status = TransactionStatusTypes.failed;
           }
-          updatedTransactions[index].pending = false;
-          updatedTransactions[index].minedAt = minedAt;
+          updatedPending.pending = false;
+          updatedPending.minedAt = minedAt;
         }
-        // eslint-disable-next-line no-empty
-      } catch (error) {}
+        return updatedPending;
+      } catch (error) {
+        logger.log('Error watching pending txn', error);
+      }
     })
+  );
+  const updatedTransactions = concat(
+    updatedPendingTransactions,
+    remainingTransactions
   );
 
   if (txStatusesDidChange) {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -193,7 +193,9 @@ export const transactionsRemoved = message => (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
   const { transactions } = getState().data;
   const removeHashes = map(transactionData, txn => txn.hash);
-  remove(transactions, txn => includes(removeHashes, txn.hash));
+  remove(transactions, txn =>
+    includes(removeHashes, txn.hash.split('-').shift())
+  );
 
   dispatch({
     payload: transactions,


### PR DESCRIPTION
This PR introduces a few things:
- fix appended transactions from using unnecessary "since last successful txn hash" logic
- instead, have the "received" transactions data payload use the last successful txn logic. Also, update this logic to include an extra 20 transactions in case any changes to recent transactions may have occurred
- be explicit about waiting for a rap to add the new pending txn to the txns list before continuing with the rest of the logic

Lastly,
After sending a transaction, the pending transaction watcher logic would run forever, even if the pending transactions have been resolved by Zerion. It was silently throwing an error "You attempted to set the key on an object that is meant to be immutable and has been frozen" because `const updatedTransactions = [...transactions];` was doing a shallow copy of the transactions state from redux. This meant that the pending transactions were never updated by the watcher, and because it would never resolve, it would never mark the flag as Done and would continue to keep polling. At least the network request would not continue to happen after Zerion resolved the pending transactions (but the logic would still be running)