### PR TITLE
Listen for txn changes and fix txn removals

### DIFF
--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -83,7 +83,7 @@ const CoinDividerOpenButton = ({
 CoinDividerOpenButton.propTypes = {
   assetsAmount: PropTypes.number,
   coinDividerHeight: PropTypes.number,
-  initialState: PropTypes.object,
+  initialState: PropTypes.bool,
   isCoinListEdited: PropTypes.bool,
   node: PropTypes.object,
   openSmallBalances: PropTypes.bool,

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -129,7 +129,7 @@ const withEthPrice = allAssets => {
 
 const withBalanceSavingsSection = (savings, priceOfEther) => {
   let savingsAssets = savings;
-  let totalUnderlyingNativeValue = 0;
+  let totalUnderlyingNativeValue = '0';
   if (priceOfEther) {
     savingsAssets = map(savings, asset => {
       const {

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -242,7 +242,8 @@ const parseTransaction = (
       symbol: toUpper(get(internalTxn, 'asset.symbol') || ''),
       ...tokenOverrides[address],
     };
-    const priceUnit = internalTxn.price || 0;
+    const priceUnit =
+      internalTxn.price || get(internalTxn, 'asset.price.value') || 0;
     const valueUnit = internalTxn.value || 0;
     const nativeDisplay = convertRawAmountToNativeDisplay(
       valueUnit,

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -211,14 +211,7 @@ const parseTransaction = (
     };
     internalTransactions = [approveInternalTransaction];
   }
-  // logic below: prevent sending yourself money to be seen as a trade
-  if (
-    changes.length === 2 &&
-    get(changes, '[0].asset.asset_code') ===
-      get(changes, '[1].asset.asset_code')
-  ) {
-    internalTransactions = [changes[0]];
-  }
+
   // logic below: prevent sending a WalletConnect 0 amount to be seen as a Cancel
   if (isEmpty(internalTransactions) && transaction.type === 'cancel') {
     const ethInternalTransaction = {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -194,15 +194,17 @@ export const transactionsRemoved = message => (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
   const { transactions } = getState().data;
   const removeHashes = map(transactionData, txn => txn.hash);
-  remove(transactions, txn =>
-    includes(removeHashes, txn.hash.split('-').shift())
+  logger.log('[data] - remove txn hashes', removeHashes);
+  const updatedTransactions = filter(
+    transactions,
+    txn => !includes(removeHashes, txn.hash.split('-').shift())
   );
 
   dispatch({
-    payload: transactions,
+    payload: updatedTransactions,
     type: DATA_UPDATE_TRANSACTIONS,
   });
-  saveLocalTransactions(transactions, accountAddress, network);
+  saveLocalTransactions(updatedTransactions, accountAddress, network);
 };
 
 export const addressAssetsReceived = (
@@ -463,10 +465,10 @@ export const dataWatchPendingTransactions = () => async (
           updatedPending.pending = false;
           updatedPending.minedAt = minedAt;
         }
-        return updatedPending;
       } catch (error) {
         logger.log('Error watching pending txn', error);
       }
+      return updatedPending;
     })
   );
   const updatedTransactions = concat(

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -38,6 +38,7 @@ const messages = {
   },
   ADDRESS_TRANSACTIONS: {
     APPENDED: 'appended address transactions',
+    CHANGED: 'changed address transactions',
     RECEIVED: 'received address transactions',
     REMOVED: 'removed address transactions',
   },
@@ -211,7 +212,13 @@ const listenOnAddressMessages = socket => dispatch => {
     dispatch(transactionsReceived(message, true));
   });
 
+  socket.on(messages.ADDRESS_TRANSACTIONS.CHANGED, message => {
+    logger.log('txns changed', get(message, 'payload.transactions', []));
+    dispatch(transactionsReceived(message, true));
+  });
+
   socket.on(messages.ADDRESS_TRANSACTIONS.REMOVED, message => {
+    logger.log('txns removed', get(message, 'payload.transactions', []));
     dispatch(transactionsRemoved(message));
   });
 


### PR DESCRIPTION
* Remove unused logic in txn parser for "self" directed txns
* Fix error in txn removals that was trying to mutate the immutable transactions state
* Listen for txn changes (these can occur for instance after a txn has appended and gets an updated historical price)