### PR TITLE
Add Cash improvements

### DIFF
--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -634,7 +634,7 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODEPUSH_KEY = "CHq9hB40PBZqHTxL-f-Wd_rK4anl1e7a8912-936f-4ce7-8505-32a075039f51";
-				CODE_SIGN_ENTITLEMENTS = Rainbow/Rainbow.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Rainbow/RainbowRelease.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;

--- a/ios/Rainbow/RainbowDebug.entitlements
+++ b/ios/Rainbow/RainbowDebug.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.me.rainbow.test</string>
+		<string>merchant.me.rainbow</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Rainbow/RainbowRelease.entitlements
+++ b/ios/Rainbow/RainbowRelease.entitlements
@@ -10,6 +10,7 @@
 	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
+		<string>merchant.me.rainbow</string>
 		<string>merchant.me.rainbow.test</string>
 	</array>
 </dict>

--- a/src/components/add-cash/AddCashStatus.js
+++ b/src/components/add-cash/AddCashStatus.js
@@ -8,6 +8,7 @@ import { useNavigation } from 'react-navigation-hooks';
 import { withProps } from 'recompact';
 import jumpingDaiAnimation from '../../assets/lottie/jumping-dai.json';
 import jumpingEthAnimation from '../../assets/lottie/jumping-eth.json';
+import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import {
   WYRE_ORDER_STATUS_TYPES,
   WYRE_TRANSFER_STATUS_TYPES,
@@ -141,14 +142,14 @@ const AddCashStatus = ({ orderCurrency, orderStatus, transferStatus }) => {
   const status = useMemo(() => {
     if (
       orderStatus === WYRE_ORDER_STATUS_TYPES.success ||
-      transferStatus === WYRE_TRANSFER_STATUS_TYPES.success
+      transferStatus === TransactionStatusTypes.purchased
     ) {
       return WYRE_TRANSFER_STATUS_TYPES.success;
     }
 
     if (
       orderStatus === WYRE_ORDER_STATUS_TYPES.failed ||
-      transferStatus === WYRE_TRANSFER_STATUS_TYPES.failed
+      transferStatus === TransactionStatusTypes.failed
     ) {
       return WYRE_TRANSFER_STATUS_TYPES.failed;
     }

--- a/src/handlers/wyre.js
+++ b/src/handlers/wyre.js
@@ -1,7 +1,7 @@
 import { PaymentRequest } from '@rainbow-me/react-native-payments';
 import { captureException } from '@sentry/react-native';
 import axios from 'axios';
-import { get, join, last, split, toLower, values } from 'lodash';
+import { get, join, split, toLower, values } from 'lodash';
 import {
   RAINBOW_WYRE_MERCHANT_ID,
   RAINBOW_WYRE_MERCHANT_ID_TEST,
@@ -143,9 +143,7 @@ export const trackWyreTransfer = async (referenceInfo, transferId, network) => {
     const transferHash = get(response, 'data.blockchainNetworkTx');
     const destAmount = get(response, 'data.destAmount');
     const destCurrency = get(response, 'data.destCurrency');
-    const statusTimeline = get(response, 'data.successTimeline', []);
-    const transferStatus = get(last(statusTimeline), 'state');
-    return { destAmount, destCurrency, transferHash, transferStatus };
+    return { destAmount, destCurrency, transferHash };
   } catch (error) {
     throw error;
   }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -27,6 +27,7 @@ export { default as useMagicFocus } from './useMagicFocus';
 export { default as useMaxInputBalance } from './useMaxInputBalance';
 export { default as useOpenSavings } from './useOpenSavings';
 export { default as usePrevious } from './usePrevious';
+export { default as usePurchaseTransactionStatus } from './usePurchaseTransactionStatus';
 export { default as useRefreshAccountData } from './useRefreshAccountData';
 export { default as useRequests } from './useRequests';
 export { default as useResetAccountState } from './useResetAccountState';

--- a/src/hooks/useAccountTransactions.js
+++ b/src/hooks/useAccountTransactions.js
@@ -1,13 +1,18 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import NetworkTypes from '../helpers/networkTypes';
 import { buildTransactionsSectionsSelector } from '../helpers/transactions';
 import useContacts from './useContacts';
 import useRequests from './useRequests';
 
 export default function useAccountTransactions(initialized, isFocused) {
-  const { isLoadingTransactions, transactions } = useSelector(
-    ({ data: { isLoadingTransactions, transactions } }) => ({
+  const { isLoadingTransactions, network, transactions } = useSelector(
+    ({
+      data: { isLoadingTransactions, transactions },
+      settings: { network },
+    }) => ({
       isLoadingTransactions,
+      network,
       transactions,
     })
   );
@@ -30,7 +35,8 @@ export default function useAccountTransactions(initialized, isFocused) {
   const { sections } = buildTransactionsSectionsSelector(accountState);
 
   return {
-    isLoadingTransactions,
+    isLoadingTransactions:
+      network === NetworkTypes.mainnet ? isLoadingTransactions : false,
     sections,
     transactions,
     transactionsCount,

--- a/src/hooks/useAddCashLimits.js
+++ b/src/hooks/useAddCashLimits.js
@@ -11,7 +11,11 @@ const findRemainingAmount = (limit, purchaseTransactions, index) => {
   const transactionsInTimeline =
     index >= 0 ? take(purchaseTransactions, index) : purchaseTransactions;
   const purchasedAmount = sumBy(transactionsInTimeline, txn =>
-    txn.status === TransactionStatusTypes.failed ? 0 : Number(txn.sourceAmount)
+    txn.status === TransactionStatusTypes.failed
+      ? 0
+      : txn.sourceAmount
+      ? Number(txn.sourceAmount)
+      : 0
   );
   return limit - purchasedAmount;
 };

--- a/src/hooks/usePurchaseTransactionStatus.js
+++ b/src/hooks/usePurchaseTransactionStatus.js
@@ -1,0 +1,22 @@
+import { find } from 'lodash';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+export default function usePurchaseTransactionStatus(transferId) {
+  const { purchaseTransactions } = useSelector(
+    ({ addCash: { purchaseTransactions } }) => ({
+      purchaseTransactions,
+    })
+  );
+
+  const transferStatus = useMemo(() => {
+    if (!transferId) return null;
+    const purchase = find(
+      purchaseTransactions,
+      txn => txn.transferId === transferId
+    );
+    return purchase ? purchase.status : null;
+  }, [purchaseTransactions, transferId]);
+
+  return transferStatus;
+}

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -55,7 +55,8 @@ export default function useWyreApplePay() {
       try {
         const { transferStatus } = await trackWyreTransfer(
           referenceInfo,
-          transferId
+          transferId,
+          network
         );
         setTransferStatus(transferStatus);
         if (
@@ -71,7 +72,7 @@ export default function useWyreApplePay() {
         retryTransferStatusTimeout(retry, 1000);
       }
     },
-    [retryTransferStatusTimeout, transferHash]
+    [network, retryTransferStatusTimeout, transferHash]
   );
 
   const getTransferHash = useCallback(
@@ -85,7 +86,7 @@ export default function useWyreApplePay() {
           destCurrency,
           transferHash,
           transferStatus,
-        } = await trackWyreTransfer(referenceInfo, transferId);
+        } = await trackWyreTransfer(referenceInfo, transferId, network);
 
         setTransferStatus(transferStatus);
         const destAssetAddress = toLower(
@@ -150,7 +151,8 @@ export default function useWyreApplePay() {
       try {
         const { data, orderStatus, transferId } = await trackWyreOrder(
           referenceInfo,
-          orderId
+          orderId,
+          network
         );
         setOrderStatus(orderStatus);
 
@@ -201,6 +203,7 @@ export default function useWyreApplePay() {
       isPaymentComplete,
       getTransferHash,
       handlePaymentCallback,
+      network,
       retryOrderStatusTimeout,
     ]
   );
@@ -215,7 +218,8 @@ export default function useWyreApplePay() {
         referenceInfo,
         accountAddress,
         currency,
-        value
+        value,
+        network
       );
 
       setOrderCurrency(currency);
@@ -227,7 +231,8 @@ export default function useWyreApplePay() {
           paymentResponse,
           totalAmount,
           accountAddress,
-          currency
+          currency,
+          network
         );
         if (orderId) {
           referenceInfo.orderId = orderId;
@@ -253,7 +258,7 @@ export default function useWyreApplePay() {
         });
       }
     },
-    [accountAddress, getOrderStatus, handlePaymentCallback]
+    [accountAddress, getOrderStatus, handlePaymentCallback, network]
   );
 
   return {

--- a/src/parsers/newTransaction.js
+++ b/src/parsers/newTransaction.js
@@ -29,7 +29,15 @@ export const parseNewTransaction = async (
     get(txDetails, 'asset.price.value', 0),
     nativeCurrency
   );
-  let tx = pick(txDetails, ['dappName', 'from', 'nonce', 'to', 'type']);
+  let tx = pick(txDetails, [
+    'dappName',
+    'from',
+    'nonce',
+    'to',
+    'sourceAmount',
+    'transferId',
+    'type',
+  ]);
   const hash = txDetails.hash ? `${txDetails.hash}-0` : null;
   const nonce = tx.nonce || (tx.from ? await getTransactionCount(tx.from) : '');
   const status = txDetails.status || TransactionStatusTypes.sending;
@@ -41,7 +49,7 @@ export const parseNewTransaction = async (
     name: get(txDetails, 'asset.name'),
     native,
     nonce,
-    pending: !!txDetails.hash,
+    pending: true,
     status,
     symbol: get(txDetails, 'asset.symbol'),
     type: get(txDetails, 'type'),

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -27,7 +27,7 @@ import {
   convertRawAmountToNativeDisplay,
 } from '../helpers/utilities';
 import { savingsAssetsList } from '../references';
-import { isLowerCaseMatch } from '../utils';
+import { ethereumUtils, isLowerCaseMatch } from '../utils';
 
 const DIRECTION_OUT = 'out';
 const LAST_TXN_HASH_BUFFER = 20;
@@ -56,7 +56,9 @@ export const parseTransactions = (
   network,
   appended = false
 ) => {
-  const purchaseTransactionHashes = map(purchaseTransactions, 'hash');
+  const purchaseTransactionHashes = map(purchaseTransactions, txn =>
+    ethereumUtils.getHash(txn)
+  );
   const data = appended
     ? transactionData
     : dataFromLastTxHash(transactionData, existingTransactions);

--- a/src/redux/addCash.js
+++ b/src/redux/addCash.js
@@ -41,7 +41,8 @@ export const addCashUpdatePurchases = purchases => (dispatch, getState) => {
     if (txn.status === TransactionStatusTypes.purchasing) {
       const updatedPurchase = find(
         purchases,
-        purchase => purchase.hash === txn.hash
+        purchase =>
+          ethereumUtils.getHash(purchase) === ethereumUtils.getHash(txn)
       );
       if (updatedPurchase) {
         return {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -41,6 +41,7 @@ import { parseNewTransaction } from '../parsers/newTransaction';
 import { parseTransactions } from '../parsers/transactions';
 import { tokenOverrides } from '../references';
 import { ethereumUtils, isLowerCaseMatch, logger } from '../utils';
+/* eslint-disable-next-line import/no-cycle */
 import { addCashUpdatePurchases } from './addCash';
 /* eslint-disable-next-line import/no-cycle */
 import { uniqueTokensRefreshState } from './uniqueTokens';
@@ -181,7 +182,7 @@ export const transactionsReceived = (message, appended = false) => async (
     payload: parsedTransactions,
     type: DATA_UPDATE_TRANSACTIONS,
   });
-  updatePurchases(parsedTransactions);
+  dispatch(updatePurchases(parsedTransactions));
   saveLocalTransactions(parsedTransactions, accountAddress, network);
 };
 
@@ -409,6 +410,7 @@ export const dataAddNewTransaction = (
     if (!disableTxnWatcher) {
       dispatch(watchPendingTransactions());
     }
+    return parsedTransaction;
     // eslint-disable-next-line no-empty
   } catch (error) {}
 };
@@ -475,7 +477,7 @@ export const dataWatchPendingTransactions = () => async (
   );
 
   if (txStatusesDidChange) {
-    updatePurchases(updatedTransactions);
+    dispatch(updatePurchases(updatedTransactions));
     const { accountAddress, network } = getState().settings;
     dispatch({
       payload: updatedTransactions,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -69,12 +69,9 @@ const ProfileScreen = ({ navigation }) => {
     navigate(Routes.CHANGE_WALLET_MODAL);
   }, [navigate]);
 
-  const addCashInDevNetworks =
-    __DEV__ &&
-    (network === NetworkTypes.kovan || network === NetworkTypes.mainnet);
-  const addCashInProdNetworks = !__DEV__ && network === NetworkTypes.mainnet;
-  const addCashAvailable =
-    Platform.OS === 'ios' && (addCashInDevNetworks || addCashInProdNetworks);
+  const addCashSupportedNetworks =
+    network === NetworkTypes.kovan || network === NetworkTypes.mainnet;
+  const addCashAvailable = Platform.OS === 'ios' && addCashSupportedNetworks;
 
   return (
     <Page component={FlexItem} style={position.sizeAsObject('100%')}>

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -30,6 +30,8 @@ const getBalanceAmount = async (selectedGasPrice, selected) => {
   return amount;
 };
 
+const getHash = txn => txn.hash.split('-').shift();
+
 const getAsset = (assets, address = 'eth') =>
   find(assets, asset => asset.address === address);
 
@@ -167,6 +169,7 @@ export default {
   getDataString,
   getEtherscanHostFromNetwork,
   getEthPriceUnit,
+  getHash,
   getNetworkFromChainId,
   hasPreviousTransactions,
   isEthAddress,


### PR DESCRIPTION
* Fixes flash of "ETH on the way" after an Add Cash failure
* Support Testwyre in Kovan and Wyre in Mainnet
* Handle polling of Wyre transfer hash outside of the hook (to prevent it from not being run if a user closes the Add Cash sheet too early)
* Rely on the pending txn watcher / Zerion for status updates (the Wyre endpoint for transfer status takes much longer)