### PR TITLE
Move up Apple Pay payment response completion and support "Running checks" status

### DIFF
--- a/src/components/add-cash/AddCashStatus.js
+++ b/src/components/add-cash/AddCashStatus.js
@@ -163,11 +163,11 @@ const AddCashStatus = ({ orderCurrency, orderStatus, transferStatus }) => {
       return ADD_CASH_STATUS_TYPES.failed;
     }
 
-    if (orderStatus === WYRE_ORDER_STATUS_TYPES.checking) {
-      return ADD_CASH_STATUS_TYPES.checking;
+    if (orderStatus === WYRE_ORDER_STATUS_TYPES.pending) {
+      return ADD_CASH_STATUS_TYPES.pending;
     }
 
-    return ADD_CASH_STATUS_TYPES.pending;
+    return ADD_CASH_STATUS_TYPES.checking;
   }, [orderStatus, transferStatus]);
 
   const previousStatus = usePrevious(status);
@@ -192,10 +192,10 @@ const AddCashStatus = ({ orderCurrency, orderStatus, transferStatus }) => {
         >
           {status === ADD_CASH_STATUS_TYPES.success ? (
             <AddCashSuccess currency={currency} />
-          ) : status === ADD_CASH_STATUS_TYPES.checking ? (
-            <AddCashChecking />
-          ) : (
+          ) : status === ADD_CASH_STATUS_TYPES.pending ? (
             <AddCashPending currency={currency} />
+          ) : (
+            <AddCashChecking />
           )}
         </FloatingEmojisTapper>
       )}

--- a/src/components/add-cash/AddCashStatus.js
+++ b/src/components/add-cash/AddCashStatus.js
@@ -10,8 +10,8 @@ import jumpingDaiAnimation from '../../assets/lottie/jumping-dai.json';
 import jumpingEthAnimation from '../../assets/lottie/jumping-eth.json';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import {
+  ADD_CASH_STATUS_TYPES,
   WYRE_ORDER_STATUS_TYPES,
-  WYRE_TRANSFER_STATUS_TYPES,
 } from '../../helpers/wyreStatusTypes';
 import { useDimensions, usePrevious, useTimeout } from '../../hooks';
 import Routes from '../../screens/Routes/routesNames';
@@ -96,6 +96,15 @@ const AddCashFailed = () => (
   </Content>
 );
 
+const AddCashChecking = () => (
+  <Content>
+    <Centered height={85}>
+      <Emoji name="bank" size={50} />
+    </Centered>
+    <StatusMessageText>Running checks...</StatusMessageText>
+  </Content>
+);
+
 const AddCashPending = ({ currency }) => (
   <Fragment>
     <Content>
@@ -144,17 +153,21 @@ const AddCashStatus = ({ orderCurrency, orderStatus, transferStatus }) => {
       orderStatus === WYRE_ORDER_STATUS_TYPES.success ||
       transferStatus === TransactionStatusTypes.purchased
     ) {
-      return WYRE_TRANSFER_STATUS_TYPES.success;
+      return ADD_CASH_STATUS_TYPES.success;
     }
 
     if (
       orderStatus === WYRE_ORDER_STATUS_TYPES.failed ||
       transferStatus === TransactionStatusTypes.failed
     ) {
-      return WYRE_TRANSFER_STATUS_TYPES.failed;
+      return ADD_CASH_STATUS_TYPES.failed;
     }
 
-    return WYRE_TRANSFER_STATUS_TYPES.pending;
+    if (orderStatus === WYRE_ORDER_STATUS_TYPES.checking) {
+      return ADD_CASH_STATUS_TYPES.checking;
+    }
+
+    return ADD_CASH_STATUS_TYPES.pending;
   }, [orderStatus, transferStatus]);
 
   const previousStatus = usePrevious(status);
@@ -169,7 +182,7 @@ const AddCashStatus = ({ orderCurrency, orderStatus, transferStatus }) => {
 
   return (
     <Transitioning.View ref={ref} style={sx.container} transition={transition}>
-      {status === WYRE_TRANSFER_STATUS_TYPES.failed ? (
+      {status === ADD_CASH_STATUS_TYPES.failed ? (
         <AddCashFailed />
       ) : (
         <FloatingEmojisTapper
@@ -177,8 +190,10 @@ const AddCashStatus = ({ orderCurrency, orderStatus, transferStatus }) => {
           emojis={['money_with_wings']}
           flex={1}
         >
-          {status === WYRE_TRANSFER_STATUS_TYPES.success ? (
+          {status === ADD_CASH_STATUS_TYPES.success ? (
             <AddCashSuccess currency={currency} />
+          ) : status === ADD_CASH_STATUS_TYPES.checking ? (
+            <AddCashChecking />
           ) : (
             <AddCashPending currency={currency} />
           )}

--- a/src/handlers/wyre.js
+++ b/src/handlers/wyre.js
@@ -196,14 +196,12 @@ export const getOrderId = async (
         message
       )
     );
-    paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
     return { errorCode, type };
   } catch (error) {
     logger.sentry(
       `WYRE - getOrderId response catch - ${referenceInfo.referenceId}`
     );
     captureException(error);
-    paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
     return {};
   }
 };

--- a/src/helpers/wyreStatusTypes.js
+++ b/src/helpers/wyreStatusTypes.js
@@ -5,9 +5,9 @@ export const WYRE_ORDER_STATUS_TYPES = {
   success: 'COMPLETE',
 };
 
-export const WYRE_TRANSFER_STATUS_TYPES = {
+export const ADD_CASH_STATUS_TYPES = {
+  checking: 'RUNNING_CHECKS',
   failed: 'FAILED',
-  initiated: 'INITIATED',
   pending: 'PENDING',
   success: 'COMPLETED',
 };

--- a/src/redux/addCash.js
+++ b/src/redux/addCash.js
@@ -81,6 +81,7 @@ export const addCashGetTransferHash = (
   transferId,
   sourceAmount
 ) => async (dispatch, getState) => {
+  logger.log('[add cash] - watch for transfer hash');
   const { accountAddress, network } = getState().settings;
   const { assets } = getState().data;
   const getTransferHash = async (referenceInfo, transferId, sourceAmount) => {
@@ -96,7 +97,7 @@ export const addCashGetTransferHash = (
       );
 
       if (transferHash) {
-        logger.log('Wyre transfer hash', transferHash);
+        logger.log('[add cash] - Wyre transfer hash', transferHash);
         let asset = ethereumUtils.getAsset(assets, destAssetAddress);
         if (!asset) {
           asset = AddCashCurrencyInfo[network][destAssetAddress];
@@ -114,6 +115,7 @@ export const addCashGetTransferHash = (
           transferId,
           type: TransactionTypes.purchase,
         };
+        logger.log('[add cash] - add new pending txn');
         const newTxDetails = await dispatch(
           dataAddNewTransaction(txDetails),
           false


### PR DESCRIPTION
Previously we were showing completion on the Apple Pay sheet after it had finished running checks, but it can take a long time. Now, we will show a "Running checks..." status while it checks and complete the Apple Pay sheet sooner.