### PR TITLE
Reuse received icon for purchase txns

### DIFF
--- a/ios/TransactionListViewCell.swift
+++ b/ios/TransactionListViewCell.swift
@@ -75,6 +75,11 @@ class TransactionListViewCell: TransactionListBaseCell {
        transactionIcon.image!.accessibilityIdentifier = "static";
      }
 
+    // Purchase Overrides
+    if transaction.type?.lowercased() == "purchase" && transaction.status?.lowercased() == "purchased" {
+      transactionIcon.image = UIImage.init(named: "received")
+    }
+
     // Authorize Overrides
     if transaction.type?.lowercased() == "authorize" && transaction.status?.lowercased() == "approved" {
       transactionIcon.image = UIImage.init(named: "self")


### PR DESCRIPTION
The status was previously not set properly for purchases (they were recognized as received before), but now that we set them properly, it was causing issues for the icon.