### PR TITLE
Move order status checks to redux as our Apple Pay sheet check has moved up

### DIFF
--- a/src/hooks/usePurchaseTransactionStatus.js
+++ b/src/hooks/usePurchaseTransactionStatus.js
@@ -2,21 +2,32 @@ import { find } from 'lodash';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-export default function usePurchaseTransactionStatus(transferId) {
-  const { purchaseTransactions } = useSelector(
-    ({ addCash: { purchaseTransactions } }) => ({
+export default function usePurchaseTransactionStatus() {
+  const {
+    currentOrderStatus,
+    currentTransferId,
+    purchaseTransactions,
+  } = useSelector(
+    ({
+      addCash: { currentOrderStatus, currentTransferId, purchaseTransactions },
+    }) => ({
+      currentOrderStatus,
+      currentTransferId,
       purchaseTransactions,
     })
   );
 
   const transferStatus = useMemo(() => {
-    if (!transferId) return null;
+    if (!currentTransferId) return null;
     const purchase = find(
       purchaseTransactions,
-      txn => txn.transferId === transferId
+      txn => txn.transferId === currentTransferId
     );
     return purchase ? purchase.status : null;
-  }, [purchaseTransactions, transferId]);
+  }, [purchaseTransactions, currentTransferId]);
 
-  return transferStatus;
+  return {
+    orderStatus: currentOrderStatus,
+    transferStatus,
+  };
 }

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -1,6 +1,4 @@
 import analytics from '@segment/analytics-react-native';
-import { captureException, captureMessage } from '@sentry/react-native';
-import { get } from 'lodash';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {
@@ -8,10 +6,8 @@ import {
   getReferenceId,
   PaymentRequestStatusTypes,
   showApplePayRequest,
-  trackWyreOrder,
 } from '../handlers/wyre';
-import { WYRE_ORDER_STATUS_TYPES } from '../helpers/wyreStatusTypes';
-import { addCashGetTransferHash } from '../redux/addCash';
+import { addCashGetOrderStatus } from '../redux/addCash';
 import { logger } from '../utils';
 import useAccountSettings from './useAccountSettings';
 import usePurchaseTransactionStatus from './usePurchaseTransactionStatus';
@@ -22,14 +18,11 @@ export default function useWyreApplePay() {
 
   const [isPaymentComplete, setPaymentComplete] = useState(false);
   const [orderCurrency, setOrderCurrency] = useState(null);
-  const [orderStatus, setOrderStatus] = useState(null);
-  const [transferId, setTransferId] = useState(null);
 
-  const transferStatus = usePurchaseTransactionStatus(transferId);
+  const { orderStatus, transferStatus } = usePurchaseTransactionStatus();
 
   const dispatch = useDispatch();
 
-  const [retryOrderStatusTimeout] = useTimeout();
   const [startPaymentCompleteTimeout] = useTimeout();
 
   const handlePaymentCallback = useCallback(() => {
@@ -37,76 +30,6 @@ export default function useWyreApplePay() {
     // animation, we need to artificially delay before marking a purchase as pending.
     startPaymentCompleteTimeout(() => setPaymentComplete(true), 1500);
   }, [startPaymentCompleteTimeout]);
-
-  const getOrderStatus = useCallback(
-    async (
-      referenceInfo,
-      destCurrency,
-      orderId,
-      paymentResponse,
-      sourceAmount
-    ) => {
-      const retry = () =>
-        getOrderStatus(
-          referenceInfo,
-          destCurrency,
-          orderId,
-          paymentResponse,
-          sourceAmount
-        );
-
-      try {
-        const { data, orderStatus, transferId } = await trackWyreOrder(
-          referenceInfo,
-          orderId,
-          network
-        );
-        setOrderStatus(orderStatus);
-
-        const isFailed = orderStatus === WYRE_ORDER_STATUS_TYPES.failed;
-        const isPending = orderStatus === WYRE_ORDER_STATUS_TYPES.pending;
-        const isSuccess = orderStatus === WYRE_ORDER_STATUS_TYPES.success;
-        const isChecking = orderStatus === WYRE_ORDER_STATUS_TYPES.checking;
-
-        if (!isPaymentComplete) {
-          if (isFailed) {
-            logger.sentry('Wyre order data failed', data);
-            captureMessage(
-              `Wyre final check - order status failed - ${referenceInfo.referenceId}`
-            );
-            analytics.track('Purchase failed', {
-              category: 'add cash',
-              error_category: get(data, 'errorCategory', 'unknown'),
-              error_code: get(data, 'errorCode', 'unknown'),
-            });
-          } else if (isPending || isSuccess) {
-            analytics.track('Purchase completed', {
-              category: 'add cash',
-            });
-          } else if (!isChecking) {
-            logger.sentry('Wyre order data', data);
-            captureMessage(
-              `Wyre final check - order status unknown - ${referenceInfo.referenceId}`
-            );
-          }
-        }
-
-        if (transferId) {
-          setTransferId(transferId);
-          referenceInfo.transferId = transferId;
-          dispatch(
-            addCashGetTransferHash(referenceInfo, transferId, sourceAmount)
-          );
-        } else if (!isFailed) {
-          retryOrderStatusTimeout(retry, 1000);
-        }
-      } catch (error) {
-        captureException(error);
-        retryOrderStatusTimeout(retry, 1000);
-      }
-    },
-    [dispatch, isPaymentComplete, network, retryOrderStatusTimeout]
-  );
 
   const onPurchase = useCallback(
     async ({ currency, value }) => {
@@ -136,25 +59,26 @@ export default function useWyreApplePay() {
           network
         );
         if (orderId) {
+          referenceInfo.orderId = orderId;
           paymentResponse.complete(PaymentRequestStatusTypes.SUCCESS);
           handlePaymentCallback();
-          logger.log('[add cash] - watch for order status', orderId);
-          referenceInfo.orderId = orderId;
-          getOrderStatus(
-            referenceInfo,
-            currency,
-            orderId,
-            paymentResponse,
-            value
+          dispatch(
+            addCashGetOrderStatus(
+              referenceInfo,
+              currency,
+              orderId,
+              paymentResponse,
+              value
+            )
           );
         } else {
+          paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
+          handlePaymentCallback();
           analytics.track('Purchase failed', {
             category: 'add cash',
             error_category: type,
             error_code: errorCode,
           });
-          paymentResponse.complete(PaymentRequestStatusTypes.FAIL);
-          handlePaymentCallback();
         }
       } else {
         analytics.track('Purchase incomplete', {
@@ -162,7 +86,7 @@ export default function useWyreApplePay() {
         });
       }
     },
-    [accountAddress, getOrderStatus, handlePaymentCallback, network]
+    [accountAddress, dispatch, handlePaymentCallback, network]
   );
 
   return {

--- a/src/redux/addCash.js
+++ b/src/redux/addCash.js
@@ -18,14 +18,16 @@ import { dataAddNewTransaction } from './data';
 const ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS =
   'addCash/ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS';
 
-const ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION =
-  'addCash/ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION';
-
 const ADD_CASH_UPDATE_CURRENT_ORDER_STATUS =
   'addCash/ADD_CASH_UPDATE_CURRENT_ORDER_STATUS';
 
 const ADD_CASH_UPDATE_CURRENT_TRANSFER_ID =
   'addCash/ADD_CASH_UPDATE_CURRENT_TRANSFER_ID';
+
+const ADD_CASH_RESET_CURRENT_ORDER = 'addCash/ADD_CASH_RESET_CURRENT_ORDER';
+
+const ADD_CASH_ORDER_CREATION_FAILURE =
+  'addCash/ADD_CASH_ORDER_CREATION_FAILURE';
 
 const ADD_CASH_CLEAR_STATE = 'addCash/ADD_CASH_CLEAR_STATE';
 
@@ -83,7 +85,7 @@ export const addCashNewPurchaseTransaction = txDetails => (
   const updatedPurchases = [txDetails, ...purchaseTransactions];
   dispatch({
     payload: updatedPurchases,
-    type: ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION,
+    type: ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS,
   });
   savePurchaseTransactions(updatedPurchases, accountAddress, network);
 };
@@ -180,7 +182,7 @@ export const addCashGetOrderStatus = (
   );
 };
 
-export const addCashGetTransferHash = (
+const addCashGetTransferHash = (
   referenceInfo,
   transferId,
   sourceAmount
@@ -241,6 +243,16 @@ export const addCashGetTransferHash = (
   await getTransferHash(referenceInfo, transferId, sourceAmount);
 };
 
+export const addCashResetCurrentOrder = () => dispatch =>
+  dispatch({
+    type: ADD_CASH_RESET_CURRENT_ORDER,
+  });
+
+export const addCashOrderCreationFailure = () => dispatch =>
+  dispatch({
+    type: ADD_CASH_ORDER_CREATION_FAILURE,
+  });
+
 // -- Reducer ----------------------------------------- //
 const INITIAL_STATE = {
   currentOrderStatus: null,
@@ -250,12 +262,16 @@ const INITIAL_STATE = {
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
-    case ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION:
+    case ADD_CASH_RESET_CURRENT_ORDER:
       return {
         ...state,
         currentOrderStatus: null,
         currentTransferId: null,
-        purchaseTransactions: action.payload,
+      };
+    case ADD_CASH_ORDER_CREATION_FAILURE:
+      return {
+        ...state,
+        currentOrderStatus: WYRE_ORDER_STATUS_TYPES.failed,
       };
     case ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS:
       return {

--- a/src/redux/addCash.js
+++ b/src/redux/addCash.js
@@ -1,11 +1,14 @@
-import { find, map, toLower } from 'lodash';
+import analytics from '@segment/analytics-react-native';
+import { captureException, captureMessage } from '@sentry/react-native';
+import { find, get, map, toLower } from 'lodash';
 import {
   getPurchaseTransactions,
   savePurchaseTransactions,
 } from '../handlers/localstorage/accountLocal';
-import { trackWyreTransfer } from '../handlers/wyre';
+import { trackWyreOrder, trackWyreTransfer } from '../handlers/wyre';
 import TransactionStatusTypes from '../helpers/transactionStatusTypes';
 import TransactionTypes from '../helpers/transactionTypes';
+import { WYRE_ORDER_STATUS_TYPES } from '../helpers/wyreStatusTypes';
 import { AddCashCurrencies, AddCashCurrencyInfo } from '../references';
 import { ethereumUtils, logger } from '../utils';
 /* eslint-disable-next-line import/no-cycle */
@@ -14,6 +17,15 @@ import { dataAddNewTransaction } from './data';
 // -- Constants --------------------------------------- //
 const ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS =
   'addCash/ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS';
+
+const ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION =
+  'addCash/ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION';
+
+const ADD_CASH_UPDATE_CURRENT_ORDER_STATUS =
+  'addCash/ADD_CASH_UPDATE_CURRENT_ORDER_STATUS';
+
+const ADD_CASH_UPDATE_CURRENT_TRANSFER_ID =
+  'addCash/ADD_CASH_UPDATE_CURRENT_TRANSFER_ID';
 
 const ADD_CASH_CLEAR_STATE = 'addCash/ADD_CASH_CLEAR_STATE';
 
@@ -71,9 +83,101 @@ export const addCashNewPurchaseTransaction = txDetails => (
   const updatedPurchases = [txDetails, ...purchaseTransactions];
   dispatch({
     payload: updatedPurchases,
-    type: ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS,
+    type: ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION,
   });
   savePurchaseTransactions(updatedPurchases, accountAddress, network);
+};
+
+export const addCashGetOrderStatus = (
+  referenceInfo,
+  destCurrency,
+  orderId,
+  paymentResponse,
+  sourceAmount
+) => async (dispatch, getState) => {
+  logger.log('[add cash] - watch for order status', orderId);
+  const { network } = getState().settings;
+  const getOrderStatus = async (
+    referenceInfo,
+    destCurrency,
+    orderId,
+    paymentResponse,
+    sourceAmount
+  ) => {
+    try {
+      const { data, orderStatus, transferId } = await trackWyreOrder(
+        referenceInfo,
+        orderId,
+        network
+      );
+
+      dispatch({
+        payload: orderStatus,
+        type: ADD_CASH_UPDATE_CURRENT_ORDER_STATUS,
+      });
+
+      const isFailed = orderStatus === WYRE_ORDER_STATUS_TYPES.failed;
+
+      if (isFailed) {
+        logger.sentry('Wyre order data failed', data);
+        captureMessage(
+          `Wyre final check - order status failed - ${referenceInfo.referenceId}`
+        );
+        analytics.track('Purchase failed', {
+          category: 'add cash',
+          error_category: get(data, 'errorCategory', 'unknown'),
+          error_code: get(data, 'errorCode', 'unknown'),
+        });
+      }
+
+      if (transferId) {
+        dispatch({
+          payload: transferId,
+          type: ADD_CASH_UPDATE_CURRENT_TRANSFER_ID,
+        });
+        referenceInfo.transferId = transferId;
+        dispatch(
+          addCashGetTransferHash(referenceInfo, transferId, sourceAmount)
+        );
+        analytics.track('Purchase completed', {
+          category: 'add cash',
+        });
+      } else if (!isFailed) {
+        setTimeout(
+          () =>
+            getOrderStatus(
+              referenceInfo,
+              destCurrency,
+              orderId,
+              paymentResponse,
+              sourceAmount
+            ),
+          1000
+        );
+      }
+    } catch (error) {
+      captureException(error);
+      setTimeout(
+        () =>
+          getOrderStatus(
+            referenceInfo,
+            destCurrency,
+            orderId,
+            paymentResponse,
+            sourceAmount
+          ),
+        1000
+      );
+    }
+  };
+
+  await getOrderStatus(
+    referenceInfo,
+    destCurrency,
+    orderId,
+    paymentResponse,
+    sourceAmount
+  );
 };
 
 export const addCashGetTransferHash = (
@@ -139,15 +243,34 @@ export const addCashGetTransferHash = (
 
 // -- Reducer ----------------------------------------- //
 const INITIAL_STATE = {
+  currentOrderStatus: null,
+  currentTransferId: null,
   purchaseTransactions: [],
 };
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
+    case ADD_CASH_ADD_NEW_PURCHASE_TRANSACTION:
+      return {
+        ...state,
+        currentOrderStatus: null,
+        currentTransferId: null,
+        purchaseTransactions: action.payload,
+      };
     case ADD_CASH_UPDATE_PURCHASE_TRANSACTIONS:
       return {
         ...state,
         purchaseTransactions: action.payload,
+      };
+    case ADD_CASH_UPDATE_CURRENT_ORDER_STATUS:
+      return {
+        ...state,
+        currentOrderStatus: action.payload,
+      };
+    case ADD_CASH_UPDATE_CURRENT_TRANSFER_ID:
+      return {
+        ...state,
+        currentTransferId: action.payload,
       };
     case ADD_CASH_CLEAR_STATE:
       return {


### PR DESCRIPTION
Since our Apple Pay sheet check has moved up, a user could close the modal during our order status checks.