### PR TITLE
Fix swap modal inputs

### DIFF
--- a/src/components/exchange/ExchangeField.js
+++ b/src/components/exchange/ExchangeField.js
@@ -8,8 +8,7 @@ import { Row, RowWithMargins } from '../layout';
 import { EnDash } from '../text';
 import ExchangeInput from './ExchangeInput';
 
-const ExchangeFieldHeight = 40;
-const ExchangeFieldHeightAndroid = 64;
+const ExchangeFieldHeight = Platform.OS === 'android' ? 64 : 40;
 const ExchangeFieldPadding = 15;
 const skeletonColor = colors.alpha(colors.blueGreyDark, 0.1);
 
@@ -29,9 +28,7 @@ const FieldRow = styled(RowWithMargins).attrs({
 `;
 
 const Input = styled(ExchangeInput).attrs({ letterSpacing: 'roundedTightest' })`
-  height: ${Platform.OS === 'android'
-    ? ExchangeFieldHeightAndroid
-    : ExchangeFieldHeight};
+  height: ${ExchangeFieldHeight};
 `;
 
 const ExchangeField = (

--- a/src/components/exchange/ExchangeField.js
+++ b/src/components/exchange/ExchangeField.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { TouchableWithoutFeedback } from 'react-native';
+import { Platform, TouchableWithoutFeedback } from 'react-native';
 import styled from 'styled-components/primitives';
 import { colors } from '../../styles';
 import { TokenSelectionButton } from '../buttons';
@@ -9,6 +9,7 @@ import { EnDash } from '../text';
 import ExchangeInput from './ExchangeInput';
 
 const ExchangeFieldHeight = 40;
+const ExchangeFieldHeightAndroid = 64;
 const ExchangeFieldPadding = 15;
 const skeletonColor = colors.alpha(colors.blueGreyDark, 0.1);
 
@@ -28,7 +29,9 @@ const FieldRow = styled(RowWithMargins).attrs({
 `;
 
 const Input = styled(ExchangeInput).attrs({ letterSpacing: 'roundedTightest' })`
-  height: ${ExchangeFieldHeight};
+  height: ${Platform.OS === 'android'
+    ? ExchangeFieldHeightAndroid
+    : ExchangeFieldHeight};
 `;
 
 const ExchangeField = (

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import styled from 'styled-components/primitives';
 import { colors } from '../../styles';
 import { ColumnWithMargins, Row } from '../layout';
@@ -7,6 +8,7 @@ import ExchangeMaxButton from './ExchangeMaxButton';
 import ExchangeNativeField from './ExchangeNativeField';
 
 const BottomRowHeight = 32;
+const BottomRowHeightAndroid = 52;
 
 const Container = styled(ColumnWithMargins).attrs({ margin: 12 })`
   background-color: ${colors.white};
@@ -53,7 +55,9 @@ export default function ExchangeInputField({
       <NativeFieldRow>
         <ExchangeNativeField
           editable={!!inputCurrencySymbol}
-          height={BottomRowHeight}
+          height={
+            Platform.OS === 'android' ? BottomRowHeightAndroid : BottomRowHeight
+          }
           nativeAmount={nativeAmount}
           nativeCurrency={nativeCurrency}
           onFocus={onFocus}

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -7,8 +7,7 @@ import ExchangeField from './ExchangeField';
 import ExchangeMaxButton from './ExchangeMaxButton';
 import ExchangeNativeField from './ExchangeNativeField';
 
-const BottomRowHeight = 32;
-const BottomRowHeightAndroid = 52;
+const BottomRowHeight = Platform.OS === 'android' ? 52 : 32;
 
 const Container = styled(ColumnWithMargins).attrs({ margin: 12 })`
   background-color: ${colors.white};
@@ -55,9 +54,7 @@ export default function ExchangeInputField({
       <NativeFieldRow>
         <ExchangeNativeField
           editable={!!inputCurrencySymbol}
-          height={
-            Platform.OS === 'android' ? BottomRowHeightAndroid : BottomRowHeight
-          }
+          height={BottomRowHeight}
           nativeAmount={nativeAmount}
           nativeCurrency={nativeCurrency}
           onFocus={onFocus}

--- a/src/components/exchange/ExchangeOutputField.js
+++ b/src/components/exchange/ExchangeOutputField.js
@@ -1,11 +1,14 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import ShadowStack from 'react-native-shadow-stack';
 import styled from 'styled-components/primitives';
 import { borders, colors } from '../../styles';
 import { Row } from '../layout';
 import ExchangeField from './ExchangeField';
 
-const paddingValue = 15;
+const notchPaddingValue = 15;
+const paddingValue = 39;
+const paddingValueAndroid = 15;
 
 const FakeNotchShadow = [
   [0, 0, 1, colors.dark, 0.01],
@@ -18,14 +21,16 @@ const Container = styled(Row).attrs({ align: 'center' })`
   background-color: ${colors.white};
   overflow: hidden;
   padding-bottom: 26;
-  padding-top: ${24 + paddingValue};
+  padding-top: ${Platform.OS === 'android'
+    ? paddingValueAndroid
+    : paddingValue};
   width: 100%;
 `;
 
 const FakeNotchThing = styled(ShadowStack).attrs({
   shadows: FakeNotchShadow,
 })`
-  height: ${paddingValue};
+  height: ${notchPaddingValue};
   left: 0;
   position: absolute;
   right: 0;

--- a/src/components/exchange/ExchangeOutputField.js
+++ b/src/components/exchange/ExchangeOutputField.js
@@ -7,8 +7,7 @@ import { Row } from '../layout';
 import ExchangeField from './ExchangeField';
 
 const notchPaddingValue = 15;
-const paddingValue = 39;
-const paddingValueAndroid = 15;
+const paddingValue = Platform.OS === 'android' ? 15 : 39;
 
 const FakeNotchShadow = [
   [0, 0, 1, colors.dark, 0.01],
@@ -21,9 +20,7 @@ const Container = styled(Row).attrs({ align: 'center' })`
   background-color: ${colors.white};
   overflow: hidden;
   padding-bottom: 26;
-  padding-top: ${Platform.OS === 'android'
-    ? paddingValueAndroid
-    : paddingValue};
+  padding-top: ${paddingValue};
   width: 100%;
 `;
 

--- a/src/components/layout/KeyboardFixedOpenLayout.js
+++ b/src/components/layout/KeyboardFixedOpenLayout.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { KeyboardAvoidingView } from 'react-native';
+import { KeyboardAvoidingView, Platform } from 'react-native';
 import { Transition, Transitioning } from 'react-native-reanimated';
 import { useSafeArea } from 'react-native-safe-area-context';
 import styled from 'styled-components/primitives';
@@ -10,7 +10,7 @@ import Centered from './Centered';
 const Container = styled(Transitioning.View)`
   height: ${({ height }) => height};
   left: 0;
-  position: absolute;
+  position: ${Platform.OS === 'android' ? 'relative' : 'absolute'};
   right: 0;
   top: 0;
 `;


### PR DESCRIPTION
Fix wrong heights and alignments of inputs on android.

I used some:
`const variableHeight = 20;`
`const variableHeightAndroid = 30;`
concept to differentiate between platforms but I will happily change that if there is some better way we can do it.