### PR TITLE
Allow wallet edition with empty names

### DIFF
--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -148,7 +148,7 @@ const ChangeWalletSheet = () => {
         onCloseModal: async args => {
           if (args) {
             const newWallets = { ...wallets };
-            if (args.name) {
+            if ('name' in args) {
               newWallets[walletId].addresses.some((account, index) => {
                 if (account.address === address) {
                   newWallets[walletId].addresses[index].label = args.name;


### PR DESCRIPTION
Previously we were not saving any change if the wallet name was set to empty