### PR TITLE
Fix BalanceCoinRow not updating styles when toggling isHidden/isPinned

### DIFF
--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -24,9 +24,18 @@ import CoinRow from './CoinRow';
 
 const editTranslateOffset = 32;
 
+const formatPercentageString = percentString =>
+  percentString ? percentString.split('-').join('- ') : '-';
+
 const BalanceCoinRowExpandedStyles = css`
   padding-bottom: 0;
   padding-top: 0;
+`;
+
+const BalanceCoinRowCoinCheckButton = styled(CoinCheckButton).attrs({
+  isAbsolute: true,
+})`
+  top: ${({ top }) => top};
 `;
 
 const PercentageText = styled(BottomRowText).attrs({
@@ -34,9 +43,6 @@ const PercentageText = styled(BottomRowText).attrs({
 })`
   ${({ isPositive }) => (isPositive ? `color: ${colors.green};` : null)};
 `;
-
-const formatPercentageString = percentString =>
-  percentString ? percentString.split('-').join('- ') : '-';
 
 const BottomRow = ({ balance, isExpandedState, native }) => {
   const percentChange = get(native, 'change');
@@ -154,11 +160,10 @@ const BalanceCoinRow = ({
         </View>
       </ButtonPressAnimation>
       {isCoinListEdited ? (
-        <CoinCheckButton
-          isAbsolute
-          toggle={toggle}
+        <BalanceCoinRowCoinCheckButton
           onPress={handleEditModePress}
-          style={{ top: isFirstCoinRow ? firstCoinRowCoinCheckMarginTop : 9 }}
+          toggle={toggle}
+          top={isFirstCoinRow ? firstCoinRowCoinCheckMarginTop : 9}
         />
       ) : null}
     </Column>
@@ -181,13 +186,13 @@ const arePropsEqual = (prev, next) => {
 
   const isNewItem = itemIdentifier === nextItemIdentifier;
 
-  const recentlyPinnedCount =
+  const isNewRecentlyPinnedCount =
     !isNewValueForPath(prev, next, 'recentlyPinnedCount') &&
-    (get(prev, 'item.isPinned', false) || get(prev, 'item.isHidden', false));
+    (get(next, 'item.isPinned', true) || get(next, 'item.isHidden', true));
 
   return (
-    isNewItem ||
-    recentlyPinnedCount ||
+    isNewItem &&
+    isNewRecentlyPinnedCount &&
     !isNewValueForObjectPaths(prev, next, [
       'isCoinListEdited',
       'isFirstCoinRow',
@@ -198,12 +203,11 @@ const arePropsEqual = (prev, next) => {
   );
 };
 
-export default React.memo(
-  compose(
-    withOpenBalances,
-    withEditOptions,
-    withCoinListEdited,
-    withCoinRecentlyPinned
-  )(BalanceCoinRow),
-  arePropsEqual
-);
+const MemoizedBalanceCoinRow = React.memo(BalanceCoinRow, arePropsEqual);
+
+export default compose(
+  withOpenBalances,
+  withEditOptions,
+  withCoinListEdited,
+  withCoinRecentlyPinned
+)(MemoizedBalanceCoinRow);

--- a/src/components/coin-row/CoinCheckButton.js
+++ b/src/components/coin-row/CoinCheckButton.js
@@ -10,11 +10,7 @@ import { Centered } from '../layout';
 
 const Container = styled.View`
   ${position.size(CoinIconSize)};
-  position: relative;
-`;
-const ContainerAbsolute = styled.View`
-  ${position.size(CoinIconSize)};
-  position: absolute;
+  position: ${({ isAbsolute }) => (isAbsolute ? 'absolute' : 'relative')};
 `;
 
 const CircleOutline = styled.View`
@@ -31,23 +27,20 @@ const CheckmarkBackground = styled.View`
   background-color: ${colors.appleBlue};
 `;
 
-const CoinCheckButton = ({ isAbsolute, onPress, toggle, ...props }) => {
-  const Wrapper = isAbsolute ? ContainerAbsolute : Container;
-  return (
-    <Wrapper {...props}>
-      <ButtonPressAnimation onPress={onPress}>
-        <Centered {...position.sizeAsObject('100%')}>
-          <CircleOutline />
-          <OpacityToggler friction={20} isVisible={!toggle} tension={1000}>
-            <CheckmarkBackground>
-              <Icon name="checkmark" color="white" />
-            </CheckmarkBackground>
-          </OpacityToggler>
-        </Centered>
-      </ButtonPressAnimation>
-    </Wrapper>
-  );
-};
+const CoinCheckButton = ({ isAbsolute, onPress, toggle, ...props }) => (
+  <Container {...props} isAbsolute={isAbsolute}>
+    <ButtonPressAnimation onPress={onPress}>
+      <Centered {...position.sizeAsObject('100%')}>
+        <CircleOutline />
+        <OpacityToggler friction={20} isVisible={!toggle} tension={1000}>
+          <CheckmarkBackground>
+            <Icon name="checkmark" color="white" />
+          </CheckmarkBackground>
+        </OpacityToggler>
+      </Centered>
+    </ButtonPressAnimation>
+  </Container>
+);
 
 CoinCheckButton.propTypes = {
   onPress: PropTypes.func,

--- a/src/components/coin-row/CoinRow.js
+++ b/src/components/coin-row/CoinRow.js
@@ -25,6 +25,7 @@ const Content = styled(Column).attrs({ justify: 'space-between' })`
   flex: 1;
   height: ${CoinIconSize};
   margin-left: 10;
+  opacity: ${({ isHidden }) => (isHidden ? 0.4 : 1)};
 `;
 
 const enhance = compose(
@@ -65,16 +66,14 @@ const CoinRow = enhance(
         symbol,
         ...props,
       })}
-      <Row flex={1} opacity={isHidden ? 0.4 : 1}>
-        <Content style={contentStyles}>
-          <Row align="center" justify="space-between">
-            {topRowRender({ symbol, ...props })}
-          </Row>
-          <Row align="center" justify="space-between" marginBottom={0.5}>
-            {bottomRowRender({ symbol, ...props })}
-          </Row>
-        </Content>
-      </Row>
+      <Content isHidden={isHidden} style={contentStyles}>
+        <Row align="center" justify="space-between">
+          {topRowRender({ symbol, ...props })}
+        </Row>
+        <Row align="center" justify="space-between" marginBottom={0.5}>
+          {bottomRowRender({ symbol, ...props })}
+        </Row>
+      </Content>
       {typeof children === 'function'
         ? children({ symbol, ...props })
         : children}


### PR DESCRIPTION
Fixes RAI-626 https://linear.app/rainbow/issue/RAI-626/fix-balancecoinrow-styles-no-longer-update-when-tokens-are-hidden