### PR TITLE
Scanner & WalletConnect fixes for Multiwallet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -140,18 +140,23 @@ class App extends Component {
     const requests = requestsForTopic(topic);
 
     if (openAutomatically && requests) {
-      return Navigation.handleAction({
-        params: { openAutomatically, transactionDetails: last(requests) },
-        routeName: Routes.CONFIRM_REQUEST,
-      });
+      const lastRequest = last(requests);
+      if (lastRequest) {
+        return Navigation.handleAction({
+          params: { openAutomatically, transactionDetails: lastRequest },
+          routeName: Routes.CONFIRM_REQUEST,
+        });
+      }
     }
 
     if (requests && requests.length === 1) {
       const request = requests[0];
-      return Navigation.handleAction({
-        params: { openAutomatically, transactionDetails: request },
-        routeName: Routes.CONFIRM_REQUEST,
-      });
+      if (request) {
+        return Navigation.handleAction({
+          params: { openAutomatically, transactionDetails: request },
+          routeName: Routes.CONFIRM_REQUEST,
+        });
+      }
     }
 
     return Navigation.handleAction({ routeName: Routes.PROFILE_SCREEN });

--- a/src/hooks/useLoadAccountData.js
+++ b/src/hooks/useLoadAccountData.js
@@ -27,14 +27,13 @@ export default function useLoadAccountData() {
         const p1 = dispatch(dataLoadState());
         const p2 = dispatch(savingsLoadState());
         const p3 = dispatch(uniqueTokensLoadState());
-        const p4 = dispatch(requestsLoadState());
-        promises.push(p1, p2, p3, p4);
+        promises.push(p1, p2, p3);
       }
-
+      const p4 = dispatch(requestsLoadState());
       const p5 = dispatch(walletConnectLoadState());
       const p6 = dispatch(uniswapLoadState());
       const p7 = dispatch(addCashLoadState());
-      promises.push(p5, p6, p7);
+      promises.push(p4, p5, p6, p7);
 
       return promiseUtils.PromiseAllWithFails(promises);
     },

--- a/src/hooks/useLoadAccountData.js
+++ b/src/hooks/useLoadAccountData.js
@@ -27,14 +27,14 @@ export default function useLoadAccountData() {
         const p1 = dispatch(dataLoadState());
         const p2 = dispatch(savingsLoadState());
         const p3 = dispatch(uniqueTokensLoadState());
-        const p4 = dispatch(walletConnectLoadState());
-        const p5 = dispatch(requestsLoadState());
-        promises.push(p1, p2, p3, p4, p5);
+        const p4 = dispatch(requestsLoadState());
+        promises.push(p1, p2, p3, p4);
       }
 
+      const p5 = dispatch(walletConnectLoadState());
       const p6 = dispatch(uniswapLoadState());
       const p7 = dispatch(addCashLoadState());
-      promises.push(p6, p7);
+      promises.push(p5, p6, p7);
 
       return promiseUtils.PromiseAllWithFails(promises);
     },

--- a/src/hooks/useResetAccountState.js
+++ b/src/hooks/useResetAccountState.js
@@ -9,7 +9,6 @@ import { requestsResetState } from '../redux/requests';
 import { savingsClearState } from '../redux/savings';
 import { uniqueTokensResetState } from '../redux/uniqueTokens';
 import { uniswapResetState } from '../redux/uniswap';
-import { walletConnectResetState } from '../redux/walletconnect';
 import { promiseUtils } from '../utils';
 
 export default function useResetAccountState() {
@@ -20,12 +19,11 @@ export default function useResetAccountState() {
     const p1 = dispatch(dataResetState());
     const p2 = dispatch(uniqueTokensResetState());
     const p3 = dispatch(resetOpenStateSettings());
-    const p4 = dispatch(walletConnectResetState());
-    const p5 = dispatch(nonceClearState());
-    const p6 = dispatch(requestsResetState());
-    const p7 = dispatch(uniswapResetState());
-    const p8 = dispatch(savingsClearState());
-    const p9 = dispatch(addCashClearState());
+    const p4 = dispatch(nonceClearState());
+    const p5 = dispatch(requestsResetState());
+    const p6 = dispatch(uniswapResetState());
+    const p7 = dispatch(savingsClearState());
+    const p8 = dispatch(addCashClearState());
     await promiseUtils.PromiseAllWithFails([
       p0,
       p1,
@@ -36,7 +34,6 @@ export default function useResetAccountState() {
       p6,
       p7,
       p8,
-      p9,
     ]);
   }, [dispatch]);
 

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -14,6 +14,8 @@ import { updateLanguage } from '../languages';
 import { ethereumUtils, logger } from '../utils';
 import { dataResetState } from './data';
 import { explorerClearState, explorerInit } from './explorer';
+import { walletConnectUpdateSessions } from './walletconnect';
+
 
 // -- Constants ------------------------------------------------------------- //
 
@@ -85,6 +87,7 @@ export const settingsUpdateAccountAddress = accountAddress => async dispatch => 
     type: SETTINGS_UPDATE_SETTINGS_ADDRESS,
   });
   dispatch(settingsResolveAccountENS(accountAddress));
+  dispatch(walletConnectUpdateSessions());
 };
 
 const settingsResolveAccountENS = accountAddress => async (
@@ -115,6 +118,7 @@ export const settingsUpdateNetwork = network => async dispatch => {
       type: SETTINGS_UPDATE_NETWORK_SUCCESS,
     });
     saveNetwork(network);
+	dispatch(walletConnectUpdateSessions());
   } catch (error) {
     logger.log('Error updating network settings', error);
   }

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -227,12 +227,32 @@ export const removeWalletConnector = peerId => (dispatch, getState) => {
   });
 };
 
+export const walletConnectUpdateSessions = () => (dispatch, getState) => {
+  const { accountAddress, chainId, network } = getState().settings;
+  const { walletConnectors } = getState().walletconnect;
+
+  Object.keys(walletConnectors).forEach(key => {
+    const connector = walletConnectors[key];
+    const newSessionData = {
+      accounts: [accountAddress],
+      chainId,
+    };
+    connector.updateSession(newSessionData);
+
+    saveWalletConnectSession(
+      connector.peerId,
+      connector.session,
+      accountAddress,
+      network
+    );
+  });
+};
+
 export const walletConnectApproveSession = (peerId, callback) => (
   dispatch,
   getState
 ) => {
   const { accountAddress, chainId, network } = getState().settings;
-  console.log(accountAddress, chainId, network);
   const walletConnector = dispatch(getPendingRequest(peerId));
   walletConnector.approveSession({
     accounts: [accountAddress],

--- a/src/references/index.js
+++ b/src/references/index.js
@@ -3,6 +3,7 @@ import savingAssets from './compound/saving-assets.json';
 import tokenOverridesData from './token-overrides.json';
 import uniswapPairsData from './uniswap/uniswap-pairs.json';
 
+export { default as chains } from './chains.json';
 export { default as compoundCERC20ABI } from './compound/compound-cerc20-abi.json';
 export { default as compoundCETHABI } from './compound/compound-ceth-abi.json';
 export { default as erc20ABI } from './erc20-abi.json';

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -98,7 +98,6 @@ class QRScannerScreenWithData extends Component {
     const address = await addressUtils.getEthereumAddressFromQRCodeData(data);
 
     if (address) {
-      console.log('address', address, isReadOnlyWallet);
       if (isReadOnlyWallet) {
         NativeAlert.alert(`You need to import the wallet in order to do this`);
         return null;

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -4,16 +4,18 @@ import lang from 'i18n-js';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Platform, Vibration } from 'react-native';
+import { Alert as NativeAlert, Platform, Vibration } from 'react-native';
 import { isEmulatorSync } from 'react-native-device-info';
 import { PERMISSIONS, request } from 'react-native-permissions';
 import { withNavigationFocus } from 'react-navigation';
 import { compose } from 'recompact';
 import { Alert, Prompt } from '../components/alerts';
+import WalletTypes from '../helpers/walletTypes';
 import {
   withWalletConnectConnections,
   withWalletConnectOnSessionRequest,
 } from '../hoc';
+import store from '../redux/store';
 import { addressUtils } from '../utils';
 import QRScannerScreen from './QRScannerScreen';
 import Routes from './Routes/routesNames';
@@ -82,6 +84,11 @@ class QRScannerScreenWithData extends Component {
       setSafeTimeout,
     } = this.props;
 
+    const { selected } = store.getState().wallets;
+    const selectedWallet = selected || {};
+
+    const isReadOnlyWallet = selectedWallet.type === WalletTypes.readOnly;
+
     if (!data) return null;
     this.setState({ enableScanning: false });
     if (!isEmulatorSync()) {
@@ -91,6 +98,12 @@ class QRScannerScreenWithData extends Component {
     const address = await addressUtils.getEthereumAddressFromQRCodeData(data);
 
     if (address) {
+      console.log('address', address, isReadOnlyWallet);
+      if (isReadOnlyWallet) {
+        NativeAlert.alert(`You need to import the wallet in order to do this`);
+        return null;
+      }
+
       analytics.track('Scanned address QR code');
       navigation.navigate(Routes.WALLET_SCREEN);
       navigation.navigate(Routes.SEND_SHEET, { address });


### PR DESCRIPTION
- Prevent scanning address QR codes with read only wallets - https://linear.app/rainbow/issue/RAI-644/disable-scanner-for-address-qr-code-when-wallet-is-read-only
- Reject and show alert for WC requests when using read only wallet - 
- App crash when switching accounts & WC session active https://linear.app/rainbow/issue/RAI-646/app-crashing-while-switching-wallets-with-active-wc-session
- Fix WC support for testnets
