### PR TITLE
Save ENS after resolving

### DIFF
--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -1,6 +1,7 @@
 import networkTypes from '../../helpers/networkTypes';
 import { getGlobal, saveGlobal } from './common';
 
+const ACCOUNT_ENS = 'accountENS';
 const APPSTORE_REVIEW_COUNT = 'appStoreReviewRequestCount';
 const KEYBOARD_HEIGHT = 'keyboardHeight';
 const LANGUAGE = 'language';
@@ -11,6 +12,10 @@ export const getAppStoreReviewCount = () => getGlobal(APPSTORE_REVIEW_COUNT, 0);
 
 export const saveAppStoreReviewCount = reviewCount =>
   saveGlobal(APPSTORE_REVIEW_COUNT, reviewCount);
+
+export const getAccountENS = () => getGlobal(ACCOUNT_ENS, null);
+
+export const saveAccountENS = accountENS => saveGlobal(ACCOUNT_ENS, accountENS);
 
 export const getLanguage = () => getGlobal(LANGUAGE, 'en');
 

--- a/src/hoc/withAccountInfo.js
+++ b/src/hoc/withAccountInfo.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { compose, withProps } from 'recompose';
 import { createSelector } from 'reselect';
 import {
-  settingsUpdateAccountAddress,
   settingsUpdateAccountColor,
   settingsUpdateAccountName,
 } from '../redux/settings';
@@ -22,7 +21,6 @@ const lowerAccountAddressSelector = createSelector(
 export default Component =>
   compose(
     connect(mapStateToProps, {
-      settingsUpdateAccountAddress,
       settingsUpdateAccountColor,
       settingsUpdateAccountName,
     }),

--- a/src/hooks/useAccountProfile.js
+++ b/src/hooks/useAccountProfile.js
@@ -1,22 +1,17 @@
 import GraphemeSplitter from 'grapheme-splitter';
 import { toUpper } from 'lodash';
-import { useSelector } from 'react-redux';
 import { removeFirstEmojiFromString } from '../helpers/emojiHandler';
 import { address } from '../utils/abbreviations';
+import useAccountSettings from './useAccountSettings';
+import useWallets from './useWallets';
 
 export default function useAccountProfile() {
-  const selectedWallet = useSelector(({ wallets: { selected } }) => selected);
-  const accountData = useSelector(
-    ({ settings: { accountAddress, accountENS } }) => ({
-      accountAddress,
-      accountENS,
-    })
-  );
+  const { selectedWallet } = useWallets();
+
+  const { accountAddress, accountENS } = useAccountSettings();
 
   if (!selectedWallet) return {};
-  if (!accountData) return {};
-
-  const { accountENS, accountAddress } = accountData;
+  if (!accountAddress) return {};
 
   if (!selectedWallet || !selectedWallet.addresses.length) return {};
 

--- a/src/hooks/useAccountSettings.js
+++ b/src/hooks/useAccountSettings.js
@@ -4,7 +4,6 @@ import {
   createNativeCurrencySelector,
 } from '../hoc/accountSettingsSelectors';
 import {
-  settingsUpdateAccountAddress,
   settingsUpdateAccountColor,
   settingsUpdateAccountName,
 } from '../redux/settings';
@@ -36,7 +35,6 @@ export default function useAccountSettings() {
     })
   );
   return {
-    settingsUpdateAccountAddress,
     settingsUpdateAccountColor,
     settingsUpdateAccountName,
     ...settingsData,

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -62,11 +62,17 @@ export default function useInitializeWallet() {
         if (isImported) {
           await resetAccountState();
         }
-        dispatch(settingsUpdateAccountAddress(walletAddress));
+
         if (!(isNew || isImported)) {
           await loadGlobalData();
+        }
+
+        await dispatch(settingsUpdateAccountAddress(walletAddress));
+
+        if (!(isNew || isImported)) {
           await loadAccountData(network);
         }
+
         onHideSplashScreen();
         logger.sentry('Hide splash screen');
         initializeAccountData();


### PR DESCRIPTION
We fetch the ENS name after loading the account address from the keychain into redux. However, we were never storing the ENS longterm anywhere. This adds the storage of the ENS name to localstorage for loading the next time.

We might want to consider including the ENS name in the extra keychain data and keeping the logic to update it when we load the account address from keychain. This way we can be sure the keychain and localstorage won't ever be out of sync.
