### PR TITLE
Pass along default input to swap from expanded state

### DIFF
--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import AssetInputTypes from '../../helpers/assetInputTypes';
 import { magicMemo } from '../../utils';
 import { BalanceCoinRow } from '../coin-row';
 import { ColumnWithDividers } from '../layout';
@@ -18,7 +19,7 @@ const ChartExpandedState = ({ asset }) => (
     <BalanceCoinRow isExpandedState item={asset} />
     <ColumnWithDividers dividerRenderer={SheetDivider}>
       <SheetActionButtonRow>
-        <SwapActionButton />
+        <SwapActionButton inputType={AssetInputTypes.in} />
         <SendActionButton />
       </SheetActionButtonRow>
       <TemporaryChartPlaceholder asset={asset} />

--- a/src/components/sheet/sheet-action-buttons/SwapActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SwapActionButton.js
@@ -4,8 +4,8 @@ import Routes from '../../../screens/Routes/routesNames';
 import { colors } from '../../../styles';
 import SheetActionButton from './SheetActionButton';
 
-export default function SwapActionButton(props) {
-  const navigate = useExpandedStateNavigation();
+export default function SwapActionButton({ inputType, ...props }) {
+  const navigate = useExpandedStateNavigation(inputType);
   const handlePress = useCallback(() => navigate(Routes.EXCHANGE_MODAL), [
     navigate,
   ]);

--- a/src/helpers/assetInputTypes.js
+++ b/src/helpers/assetInputTypes.js
@@ -1,0 +1,4 @@
+export default {
+  in: 'in',
+  out: 'out',
+};

--- a/src/hooks/useExpandedStateNavigation.js
+++ b/src/hooks/useExpandedStateNavigation.js
@@ -1,15 +1,29 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Alert, InteractionManager } from 'react-native';
 import { useNavigation, useNavigationState } from 'react-navigation-hooks';
+import AssetInputTypes from '../helpers/assetInputTypes';
 import useAsset from './useAsset';
 import useWallets from './useWallets';
 
-export default function useExpandedStateNavigation() {
+export default function useExpandedStateNavigation(inputType) {
   const { goBack, navigate } = useNavigation();
   const { params } = useNavigationState();
   const { isReadOnlyWallet } = useWallets();
 
   const asset = useAsset(params.asset);
+
+  const navigationPayload = useMemo(() => {
+    switch (inputType) {
+      case AssetInputTypes.in:
+        return {
+          inputAsset: asset,
+        };
+      case AssetInputTypes.out:
+        return { outputAsset: asset };
+      default:
+        return { asset };
+    }
+  }, [asset, inputType]);
 
   return useCallback(
     route => {
@@ -18,9 +32,9 @@ export default function useExpandedStateNavigation() {
       return isReadOnlyWallet
         ? Alert.alert(`You need to import the wallet in order to do this`)
         : InteractionManager.runAfterInteractions(() =>
-            navigate(route, { asset })
+            navigate(route, navigationPayload)
           );
     },
-    [asset, goBack, isReadOnlyWallet, navigate]
+    [goBack, isReadOnlyWallet, navigate, navigationPayload]
   );
 }

--- a/src/screens/SwapModal.js
+++ b/src/screens/SwapModal.js
@@ -1,19 +1,28 @@
 import React from 'react';
+import { useNavigationParam } from 'react-navigation-hooks';
 import ExchangeModalTypes from '../helpers/exchangeModalTypes';
 import createUnlockAndSwapRap, {
   estimateUnlockAndSwap,
 } from '../raps/unlockAndSwap';
 import ExchangeModal from './ExchangeModal';
 
-const SwapModal = (props, ref) => (
-  <ExchangeModal
-    createRap={createUnlockAndSwapRap}
-    estimateRap={estimateUnlockAndSwap}
-    inputHeaderTitle="Swap"
-    showOutputField
-    ref={ref}
-    type={ExchangeModalTypes.swap}
-    {...props}
-  />
-);
+const SwapModal = (props, ref) => {
+  const defaultInputAsset = useNavigationParam('inputAsset');
+  const defaultOutputAsset = useNavigationParam('outputAsset');
+
+  return (
+    <ExchangeModal
+      createRap={createUnlockAndSwapRap}
+      defaultInputAsset={defaultInputAsset}
+      defaultOutputAsset={defaultOutputAsset}
+      estimateRap={estimateUnlockAndSwap}
+      inputHeaderTitle="Swap"
+      ref={ref}
+      showOutputField
+      type={ExchangeModalTypes.swap}
+      {...props}
+    />
+  );
+};
+
 export default React.forwardRef(SwapModal);

--- a/src/screens/SwapModal.js
+++ b/src/screens/SwapModal.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useNavigationParam } from 'react-navigation-hooks';
+import React, { useMemo } from 'react';
+import { useNavigation } from 'react-navigation-hooks';
 import ExchangeModalTypes from '../helpers/exchangeModalTypes';
 import createUnlockAndSwapRap, {
   estimateUnlockAndSwap,
@@ -7,14 +7,18 @@ import createUnlockAndSwapRap, {
 import ExchangeModal from './ExchangeModal';
 
 const SwapModal = (props, ref) => {
-  const defaultInputAsset = useNavigationParam('inputAsset');
-  const defaultOutputAsset = useNavigationParam('outputAsset');
+  const { dangerouslyGetParent } = useNavigation();
+
+  const { inputAsset, outputAsset } = useMemo(
+    () => dangerouslyGetParent()?.state?.params || {},
+    [dangerouslyGetParent]
+  );
 
   return (
     <ExchangeModal
       createRap={createUnlockAndSwapRap}
-      defaultInputAsset={defaultInputAsset}
-      defaultOutputAsset={defaultOutputAsset}
+      defaultInputAsset={inputAsset}
+      defaultOutputAsset={outputAsset}
       estimateRap={estimateUnlockAndSwap}
       inputHeaderTitle="Swap"
       ref={ref}


### PR DESCRIPTION
Fixes RAI-649 https://linear.app/rainbow/issue/RAI-649/expanded-asset-state-should-populate-swap-input