### PR TITLE
Partially fix wallet sheet gesture when list is scrolled

### DIFF
--- a/src/screens/Routes/Routes.ios.js
+++ b/src/screens/Routes/Routes.ios.js
@@ -244,8 +244,11 @@ const routesForBottomSheetStack = {
   [Routes.CHANGE_WALLET_SHEET]: {
     navigationOptions: {
       backgroundOpacity: 0.6,
+      cornerRadius: 0,
       customStack: true,
+      headerHeight: 46,
       springDamping: 1,
+      topOffset: 128,
       transitionDuration: 0.25,
     },
     screen: ChangeWalletSheet,


### PR DESCRIPTION
this allows dismiss gestures outside of the sheet when it's scrolled. gestures on the header mostly work, seems like there are some issues deeper in the modals.

@osdnk I'm noticing that when a headerHeight is set, gestures on the header aren't immediately responded to if the list is scrolled. you need to hold your finger down or drag a couple times for it to catch the sheet

in this case, the sheet has a header height of 58. but setting it to anything higher than 46 causes it to interfere with swiping up at the very top of the list. oddly it doesn't interfere with swiping down. in this video it's set to 58:

https://www.dropbox.com/s/vsf0bpbmzzv76hv/Screen%20Recording%202020-05-25%20at%204.13.13%20AM.mov?dl=0