### PR TITLE
Bump up max number of NFTs we get from OpenSea

### DIFF
--- a/src/handlers/opensea-api.js
+++ b/src/handlers/opensea-api.js
@@ -4,7 +4,7 @@ import { parseAccountUniqueTokens } from '../parsers/uniqueTokens';
 import { logger } from '../utils';
 
 export const UNIQUE_TOKENS_LIMIT_PER_PAGE = 50;
-export const UNIQUE_TOKENS_LIMIT_TOTAL = 350;
+export const UNIQUE_TOKENS_LIMIT_TOTAL = 2000;
 
 const api = axios.create({
   headers: {


### PR DESCRIPTION
Thanks to Wojtek's fixes, we can bump up the number of NFTs we fetch for a user without it destroying the app!