### PR TITLE
Safety check for WC requests

### DIFF
--- a/src/parsers/requests.js
+++ b/src/parsers/requests.js
@@ -28,6 +28,22 @@ export const getRequestDisplayDetails = (payload, assets, nativeCurrency) => {
     payload.method === SIGN_TRANSACTION
   ) {
     const transaction = get(payload, 'params[0]', null);
+
+    // Backwards compatibility with param name change
+    if (transaction.gas && !transaction.gasLimit) {
+      transaction.gasLimit = transaction.gas;
+    }
+
+    // We must pass a number through the bridge
+    if (!transaction.gasLimit) {
+      transaction.gasLimit = 0;
+    }
+
+    // Dapps usually won't send this
+    if (!transaction.nonce) {
+      transaction.nonce = 0;
+    }
+
     return getTransactionDisplayDetails(
       transaction,
       assets,


### PR DESCRIPTION
Added a few safety checks for  WC requests data that was breaking the native TX list due to passing NaN through the bridge which is an invalid native type, resulting in the requests not shown.

This fixes the problem with defisaver.com (WC request not showing because the tx list was throwing and we were swallowing the error)