### PR TITLE
Fix Holo token symbol (HOLO → HOT)

### DIFF
--- a/src/references/token-overrides.json
+++ b/src/references/token-overrides.json
@@ -126,7 +126,8 @@
   },
   "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2": {
     "color": "#8834FF",
-    "name": "Holo"
+    "name": "Holo",
+    "symbol": "HOT"
   },
   "0x607F4C5BB672230e8672085532f7e901544a7375": {
     "color": "#EBBC2F",


### PR DESCRIPTION
zerion gives us HOLO as its symbol, HOT is the correct symbol

this makes it consistent with swap and fixes missing token icon