### PR TITLE
Remove unnecessary firebase registration

### DIFF
--- a/src/model/firebase.js
+++ b/src/model/firebase.js
@@ -6,7 +6,6 @@ import { getLocal, saveLocal } from '../handlers/localstorage/common';
 import { logger } from '../utils';
 
 export const getFCMToken = async () => {
-  await messaging().registerDeviceForRemoteMessages();
   const fcmTokenLocal = await getLocal('rainbowFcmToken');
 
   const fcmToken = get(fcmTokenLocal, 'data', null);


### PR DESCRIPTION
Based on the docs we don't need to call this at all unless we disable it manually (which we are not doing)
https://github.com/invertase/react-native-firebase/blob/master/docs/messaging/usage/index.md#auto-initialization

This potentially fixes the bug that causes the app to get stuck at the rainbow logo on the splash screen and then crashes