### PR TITLE
Fix image metadata redux loading

### DIFF
--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -30,7 +30,7 @@ export const getNativeCurrency = () => getGlobal(NATIVE_CURRENCY, 'USD');
 export const saveNativeCurrency = nativeCurrency =>
   saveGlobal(NATIVE_CURRENCY, nativeCurrency);
 
-export const getImageMetadata = () => getGlobal(IMAGE_METADATA);
+export const getImageMetadata = () => getGlobal(IMAGE_METADATA, {});
 
 export const saveImageMetadata = imageMetadata =>
   saveGlobal(IMAGE_METADATA, imageMetadata);

--- a/src/hooks/useImageMetadata.js
+++ b/src/hooks/useImageMetadata.js
@@ -17,10 +17,11 @@ export default function useImageMetadata(imageUrl) {
   );
 
   const imageMetadataSelector = useCallback(
-    state => state.imageMetadata[imageUrl],
+    state => state.imageMetadata.imageMetadata[imageUrl],
     [imageUrl]
   );
   const metadata = useSelector(imageMetadataSelector);
+
   const isCached = !!metadata && !!metadata?.color;
 
   const onCacheImageMetadata = useCallback(

--- a/src/redux/imageMetadata.js
+++ b/src/redux/imageMetadata.js
@@ -5,13 +5,14 @@ import {
 } from '../handlers/localstorage/globalSettings';
 
 // // -- Constants --------------------------------------- //
+const LOAD = 'imageMetadata/LOAD';
 const MERGE = 'imageMetadata/MERGE';
 
 export const imageMetadataCacheLoadState = () => async dispatch => {
   const metadataCache = await getImageMetadata();
   dispatch({
     payload: metadataCache,
-    type: MERGE,
+    type: LOAD,
   });
 };
 
@@ -19,7 +20,7 @@ export const updateImageMetadataCache = ({ id, metadata }) => (
   dispatch,
   getState
 ) => {
-  const { imageMetadata } = getState();
+  const { imageMetadata } = getState().imageMetadata;
   dispatch({ id, metadata, type: MERGE });
   saveImageMetadata({
     ...imageMetadata,
@@ -28,13 +29,18 @@ export const updateImageMetadataCache = ({ id, metadata }) => (
 };
 
 // // -- Reducer ----------------------------------------- //
-const INITIAL_STATE = {};
+const INITIAL_STATE = {
+  imageMetadata: {},
+};
 
 export default (state = INITIAL_STATE, action) =>
   produce(state, draft => {
     switch (action.type) {
+      case LOAD:
+        draft.imageMetadata = action.payload;
+        break;
       case MERGE:
-        draft[action.id] = action.metadata;
+        draft.imageMetadata[action.id] = action.metadata;
         break;
       default:
         break;


### PR DESCRIPTION
This fixes the loading of image meta data from localstorage into redux.

Since the dispatch in the loading function doesn't have an id passed into it and is passing along payload instead of metadata, the MERGE action will set the draft to look like draft[undefined] = undefined.

Given that draft cannot just be overwritten by the payload, I also added the imageMetadata item inside the initial state.

I also explicitly set the default value from localstorage for image metadata to empty object (default for getGlobal is [])