### PR TITLE
Force setting correct opacity after toggling focus

### DIFF
--- a/src/navigation/ExchangeModalNavigator.js
+++ b/src/navigation/ExchangeModalNavigator.js
@@ -1,7 +1,7 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import { useIsFocused, useRoute } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useCallback, useMemo } from 'use-memo-one';
 import { withBlockedHorizontalSwipe } from '../hoc';
 import CurrencySelectModal from '../screens/CurrencySelectModal';
@@ -22,13 +22,30 @@ function SwapDetailsScreen(props) {
 }
 
 function MainExchangeNavigator() {
+  const isFocused = useIsFocused();
+  const {
+    params: { position },
+  } = useRoute();
+
+  useEffect(() => {
+    if (isFocused) {
+      position.setValue(0);
+    }
+  }, [isFocused, position]);
+
   return (
     <Stack.Navigator
       {...stackNavigationConfig}
       screenOptions={exchangeModalPreset}
       initialRouteName={Routes.MAIN_EXCHANGE_SCREEN}
     >
-      <Stack.Screen name={Routes.MAIN_EXCHANGE_SCREEN} component={SwapModal} />
+      <Stack.Screen
+        name={Routes.MAIN_EXCHANGE_SCREEN}
+        component={SwapModal}
+        initialParams={{
+          position,
+        }}
+      />
       <Stack.Screen
         name={Routes.SWAP_DETAILS_SCREEN}
         component={SwapDetailsScreen}

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -38,6 +38,17 @@ import { exchangeModalBorderRadius } from './ExchangeModal';
 const headerlessSection = data => [{ data, title: '' }];
 
 export default function CurrencySelectModal() {
+  const isFocused = useIsFocused();
+  const { params } = useRoute();
+  const onSelectCurrency = params?.onSelectCurrency;
+  const restoreFocusOnSwapModal = params?.restoreFocusOnSwapModal;
+  const transitionPosition = params.position;
+
+  useEffect(() => {
+    if (isFocused) {
+      transitionPosition.setValue(1);
+    }
+  }, [isFocused, transitionPosition]);
   const searchInputRef = useRef();
   const [assetsToFavoriteQueue, setAssetsToFavoriteQueue] = useState({});
   const [searchQuery, setSearchQuery] = useState('');
@@ -47,10 +58,6 @@ export default function CurrencySelectModal() {
   ]);
 
   const { navigate } = useNavigation();
-  const { params } = useRoute();
-  const onSelectCurrency = params?.onSelectCurrency;
-  const restoreFocusOnSwapModal = params?.restoreFocusOnSwapModal;
-  const transitionPosition = params?.position;
   const type = params?.type;
 
   const {
@@ -106,8 +113,6 @@ export default function CurrencySelectModal() {
     },
     [onSelectCurrency, navigate]
   );
-
-  const isFocused = useIsFocused();
 
   useFocusEffect(() => {
     params?.toggleGestureEnabled(false);


### PR DESCRIPTION
I observed that opacity listener sometimes does not call the "final" value. E.g. it stays on 0.998 instead of 1.0 or 0.1 instead on 0.0.
Actually, it's not guaranteed according to the implementation that the final must be really called. In order to fix it I just "manually" set the final result when the focus is changed. I haven't managed to reproduce it, but following my deduction, it should work. Definitely it's not breaking :) 