### PR TITLE
Remove unnecessary ImportSeedPhraseSheetWithData

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -6,7 +6,7 @@ import AddCashSheet from '../screens/AddCashSheet';
 import AvatarBuilder from '../screens/AvatarBuilder';
 import ChangeWalletSheet from '../screens/ChangeWalletSheet';
 import ExpandedAssetSheet from '../screens/ExpandedAssetSheet';
-import ImportSeedPhraseSheetWithData from '../screens/ImportSeedPhraseSheetWithData';
+import ImportSeedPhraseSheet from '../screens/ImportSeedPhraseSheet';
 import ModalScreen from '../screens/ModalScreen';
 import ReceiveModal from '../screens/ReceiveModal';
 import SendSheet from '../screens/SendSheet';
@@ -96,7 +96,7 @@ function MainNavigator() {
       />
       <Stack.Screen
         name={Routes.IMPORT_SEED_PHRASE_SHEET}
-        component={ImportSeedPhraseSheetWithData}
+        component={ImportSeedPhraseSheet}
         options={sheetPreset}
       />
       <Stack.Screen

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -11,7 +11,7 @@ import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
 import AvatarBuilder from '../screens/AvatarBuilder';
 import ChangeWalletSheet from '../screens/ChangeWalletSheet';
 import DepositModal from '../screens/DepositModal';
-import ImportSeedPhraseSheetWithData from '../screens/ImportSeedPhraseSheetWithData';
+import ImportSeedPhraseSheet from '../screens/ImportSeedPhraseSheet';
 import ModalScreen from '../screens/ModalScreen';
 import ReceiveModal from '../screens/ReceiveModal';
 import SavingsSheet from '../screens/SavingsSheet';
@@ -201,7 +201,7 @@ function NativeStackFallbackNavigator() {
       <Stack.Screen name={Routes.MAIN_NAVIGATOR} component={MainNavigator} />
       <Stack.Screen
         name={Routes.IMPORT_SEED_PHRASE_SHEET}
-        component={ImportSeedPhraseSheetWithData}
+        component={ImportSeedPhraseSheet}
         options={{
           ...sheetPreset,
           onTransitionStart: () => {

--- a/src/navigation/nativeStackHelpers.js
+++ b/src/navigation/nativeStackHelpers.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import AddCashSheet from '../screens/AddCashSheet';
 import ExpandedAssetSheet from '../screens/ExpandedAssetSheet';
-import ImportSeedPhraseSheetWithData from '../screens/ImportSeedPhraseSheetWithData';
+import ImportSeedPhraseSheet from '../screens/ImportSeedPhraseSheet';
 import SendSheet from '../screens/SendSheet';
 
 export const appearListener = { current: null };
@@ -16,9 +16,7 @@ export function ExpandedAssetSheetWrapper(...props) {
 }
 
 export function ImportSeedPhraseSheetWrapper(...props) {
-  return (
-    <ImportSeedPhraseSheetWithData {...props} setAppearListener={setListener} />
-  );
+  return <ImportSeedPhraseSheet {...props} setAppearListener={setListener} />;
 }
 
 export function SendSheetWrapper(...props) {

--- a/src/screens/ImportSeedPhraseSheetWithData.js
+++ b/src/screens/ImportSeedPhraseSheetWithData.js
@@ -1,6 +1,0 @@
-import { pure } from 'recompact';
-import ImportSeedPhraseSheet from './ImportSeedPhraseSheet';
-
-const ImportSeedPhraseSheetWithData = pure(ImportSeedPhraseSheet);
-
-export default ImportSeedPhraseSheetWithData;


### PR DESCRIPTION
We were getting a React hooks error that only happened in release mode, related to the use of pure from
recompact.