### PR TITLE
Fix navigation that breaks for routes that have different names for non-native vs native stacks

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import React, { Fragment, useCallback } from 'react';
-import { Linking, Platform } from 'react-native';
+import { Linking } from 'react-native';
 import styled from 'styled-components/primitives';
 import networkInfo from '../helpers/networkInfo';
 import networkTypes from '../helpers/networkTypes';
@@ -71,12 +71,7 @@ const AddFundsInterstitial = ({ network, offsetY = 0 }) => {
   );
 
   const handlePressImportWallet = useCallback(
-    () =>
-      navigate(
-        Platform.OS === 'ios'
-          ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
-          : Routes.IMPORT_SEED_PHRASE_SHEET
-      ),
+    () => navigate(Routes.IMPORT_SEED_PHRASE_FLOW),
     [navigate]
   );
 

--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -104,7 +104,6 @@ const BalanceCoinRow = ({
   isFirstCoinRow,
   item,
   onPress,
-  onPressSend,
   pushSelectedCoin,
   recentlyPinnedCount,
   removeSelectedCoin,
@@ -135,10 +134,6 @@ const BalanceCoinRow = ({
     onPress && onPress(item);
   }, [onPress, item]);
 
-  const handlePressSend = useCallback(() => {
-    onPressSend && onPressSend(item);
-  }, [onPressSend, item]);
-
   return (
     <Column flex={1} justify={isFirstCoinRow ? 'end' : 'start'}>
       <Content
@@ -152,8 +147,6 @@ const BalanceCoinRow = ({
             isExpandedState ? containerExpandedStyles : containerStyles
           }
           isExpandedState={isExpandedState}
-          onPress={handlePress}
-          onPressSend={handlePressSend}
           bottomRowRender={BottomRow}
           topRowRender={TopRow}
           {...item}

--- a/src/components/fab/SendFab.js
+++ b/src/components/fab/SendFab.js
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { Alert } from 'react-native';
-import isNativeStackAvailable from '../../helpers/isNativeStackAvailable';
 import { useNavigation } from '../../navigation/Navigation';
 import Routes from '../../navigation/routesNames';
 import { colors } from '../../styles';
@@ -18,9 +17,7 @@ const SendFab = ({ disabled, isReadOnlyWallet, ...props }) => {
 
   const handlePress = useCallback(() => {
     if (!isReadOnlyWallet) {
-      navigate(
-        isNativeStackAvailable ? Routes.SEND_SHEET_NAVIGATOR : Routes.SEND_SHEET
-      );
+      navigate(Routes.SEND_FLOW);
     } else {
       Alert.alert(`You need to import the wallet in order to do this`);
     }

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -4,7 +4,6 @@ import styled from 'styled-components/primitives';
 import useExperimentalFlag, {
   AVATAR_PICKER,
 } from '../../config/experimentalHooks';
-import isNativeStackAvailable from '../../helpers/isNativeStackAvailable';
 import { useAccountProfile, useClipboard } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
 import Routes from '../../navigation/routesNames';
@@ -90,11 +89,7 @@ export default function ProfileMasthead({
   ]);
 
   const handlePressAddCash = useCallback(() => {
-    navigate(
-      isNativeStackAvailable
-        ? Routes.ADD_CASH_SCREEN_NAVIGATOR
-        : Routes.ADD_CASH_SHEET
-    );
+    navigate(Routes.ADD_CASH_FLOW);
     analytics.track('Tapped Add Cash', {
       category: 'add cash',
     });

--- a/src/components/sheet/sheet-action-buttons/SendActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import isNativeStackAvailable from '../../../helpers/isNativeStackAvailable';
 import { useExpandedStateNavigation } from '../../../hooks';
 import Routes from '../../../navigation/routesNames';
 import { colors } from '../../../styles';
@@ -8,10 +9,14 @@ export default function SendActionButton(props) {
   const navigate = useExpandedStateNavigation();
   const handlePress = useCallback(
     () =>
-      navigate(Routes.SEND_SHEET_NAVIGATOR, params => ({
-        params,
-        screen: Routes.SEND_SHEET,
-      })),
+      navigate(Routes.SEND_FLOW, params =>
+        isNativeStackAvailable
+          ? {
+              params,
+              screen: Routes.SEND_SHEET,
+            }
+          : { ...params }
+      ),
     [navigate]
   );
 

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -8,7 +8,6 @@ import styled from 'styled-components/primitives';
 import useExperimentalFlag, {
   AVATAR_PICKER,
 } from '../../config/experimentalHooks';
-import isNativeStackAvailable from '../../helpers/isNativeStackAvailable';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import { useAccountProfile } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
@@ -65,11 +64,7 @@ const TransactionList = ({
   } = useAccountProfile();
 
   const onAddCashPress = useCallback(() => {
-    navigate(
-      isNativeStackAvailable
-        ? Routes.ADD_CASH_SCREEN_NAVIGATOR
-        : Routes.ADD_CASH_SHEET
-    );
+    navigate(Routes.ADD_CASH_FLOW);
     analytics.track('Tapped Add Cash', {
       category: 'add cash',
     });

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -55,9 +55,6 @@ const enhanceRenderItem = compose(
         type: assetType,
       });
     },
-    onPressSend: ({ navigation }) => asset => {
-      navigation.navigate(Routes.SEND_SHEET, { asset });
-    },
   })
 );
 

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -1,3 +1,5 @@
+import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
+
 const Routes = {
   ADD_CASH_SCREEN_NAVIGATOR: 'AddCashSheetNavigator',
   ADD_CASH_SHEET: 'AddCashSheet',
@@ -38,4 +40,17 @@ const Routes = {
   WELCOME_SCREEN: 'WelcomeScreen',
 };
 
-export default Routes;
+const RoutesWithNativeStackAvailability = {
+  ...Routes,
+  ADD_CASH_FLOW: isNativeStackAvailable
+    ? Routes.ADD_CASH_SCREEN_NAVIGATOR
+    : Routes.ADD_CASH_SHEET,
+  IMPORT_SEED_PHRASE_FLOW: isNativeStackAvailable
+    ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
+    : Routes.IMPORT_SEED_PHRASE_SHEET,
+  SEND_FLOW: isNativeStackAvailable
+    ? Routes.SEND_SHEET_NAVIGATOR
+    : Routes.SEND_SHEET,
+};
+
+export default RoutesWithNativeStackAvailability;

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import React, { useCallback, useRef, useState } from 'react';
-import { InteractionManager, Platform } from 'react-native';
+import { InteractionManager } from 'react-native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
@@ -345,11 +345,7 @@ const ChangeWalletSheet = () => {
   ]);
 
   const onPressImportSeedPhrase = useCallback(() => {
-    navigate(
-      Platform.OS === 'ios'
-        ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
-        : Routes.IMPORT_SEED_PHRASE_SHEET
-    );
+    navigate(Routes.IMPORT_SEED_PHRASE_FLOW);
   }, [navigate]);
 
   const toggleEditMode = useCallback(() => {

--- a/src/screens/QRScannerScreenWithData.js
+++ b/src/screens/QRScannerScreenWithData.js
@@ -9,6 +9,7 @@ import { isEmulatorSync } from 'react-native-device-info';
 import { PERMISSIONS, request } from 'react-native-permissions';
 import { compose } from 'recompact';
 import { Alert, Prompt } from '../components/alerts';
+import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
 import WalletTypes from '../helpers/walletTypes';
 import {
   withWalletConnectConnections,
@@ -105,7 +106,15 @@ class QRScannerScreenWithData extends Component {
 
       analytics.track('Scanned address QR code');
       navigation.navigate(Routes.WALLET_SCREEN);
-      navigation.navigate(Routes.SEND_SHEET, { address });
+      navigation.navigate(
+        Routes.SEND_FLOW,
+        isNativeStackAvailable
+          ? {
+              params: { address },
+              screen: Routes.SEND_SHEET,
+            }
+          : { address }
+      );
       return setSafeTimeout(this.handleReenableScanning, 1000);
     }
 


### PR DESCRIPTION
I've separated out the commits such that you should be able to just walk through the commits.

The Import seed phrase sheet / navigator, send sheet / navigator, and add cash sheet / navigator need to have the route name in navigation.navigate(routeName) to be different depending on if native stacks are supported.

I've included extra routes in routesNames.js that takes care of this logic so that our code doesn't need to have it scattered in too many places.

There are some places that still require an isNativeStacksSupported check due to different param formats being passed in.
In some places, I removed the Platform ios check since the route would just use the fallback in the case that isNativeStacksSupported (which also checks ios platform) is false.
