### PR TITLE
Improve transaction context menu

### DIFF
--- a/src/components/coin-row/TransactionCoinRow.js
+++ b/src/components/coin-row/TransactionCoinRow.js
@@ -5,6 +5,7 @@ import { Linking } from 'react-native';
 import { css } from 'styled-components/primitives';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import TransactionTypes from '../../helpers/transactionTypes';
+import { isENSAddressFormat } from '../../helpers/validators';
 import { useAccountSettings } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
 import { abbreviations, ethereumUtils } from '../../utils';
@@ -135,8 +136,10 @@ export default function TransactionCoinRow({ item, ...props }) {
       headerInfo.address = contact.nickname;
       contactColor = contact.color;
     } else {
-      headerInfo.address = abbreviations.address(contactAddress, 4, 10);
-      contactColor = Math.floor(Math.random() * colors.avatarColor.length);
+      headerInfo.address = isENSAddressFormat(contactAddress)
+        ? contactAddress
+        : abbreviations.address(contactAddress, 4, 10);
+      contactColor = colors.getRandomColor();
     }
 
     if (hash) {

--- a/src/components/coin-row/TransactionCoinRow.js
+++ b/src/components/coin-row/TransactionCoinRow.js
@@ -1,10 +1,10 @@
-import { format } from 'date-fns';
 import { compact, get } from 'lodash';
 import React, { useCallback } from 'react';
 import { Linking } from 'react-native';
 import { css } from 'styled-components/primitives';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import TransactionTypes from '../../helpers/transactionTypes';
+import { getHumanReadableDate } from '../../helpers/transactions';
 import { isENSAddressFormat } from '../../helpers/validators';
 import { useAccountSettings } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
@@ -82,36 +82,7 @@ export default function TransactionCoinRow({ item, ...props }) {
   const onPressTransaction = useCallback(async () => {
     const { hash, from, minedAt, pending, to, status, type } = item;
 
-    const calculateTimestampOfToday = () => {
-      var d = new Date();
-      d.setHours(0, 0, 0, 0);
-      return d.getTime();
-    };
-    const calculateTimestampOfYesterday = () => {
-      var d = new Date();
-      d.setDate(d.getDate() - 1);
-      d.setHours(0, 0, 0, 0);
-      return d.getTime();
-    };
-    const calculateTimestampOfThisYear = () => {
-      var d = new Date();
-      d.setFullYear(d.getFullYear(), 0, 1);
-      d.setHours(0, 0, 0, 0);
-      return d.getTime();
-    };
-    const todayTimestamp = calculateTimestampOfToday();
-    const yesterdayTimestamp = calculateTimestampOfYesterday();
-    const thisYearTimestamp = calculateTimestampOfThisYear();
-
-    const timestamp = new Date(minedAt * 1000);
-    const date = format(
-      timestamp,
-      timestamp > todayTimestamp
-        ? `'Today'`
-        : timestamp > yesterdayTimestamp
-        ? `'Yesterday'`
-        : `'on' MMM d${timestamp > thisYearTimestamp ? '' : ' yyyy'}`
-    );
+    const date = getHumanReadableDate(minedAt);
 
     const hasAddableContact =
       (status === TransactionStatusTypes.received &&

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -1,6 +1,5 @@
 import Clipboard from '@react-native-community/clipboard';
 import analytics from '@segment/analytics-react-native';
-import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Linking, requireNativeComponent } from 'react-native';
@@ -11,6 +10,7 @@ import useExperimentalFlag, {
 } from '../../config/experimentalHooks';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import TransactionTypes from '../../helpers/transactionTypes';
+import { getHumanReadableDate } from '../../helpers/transactions';
 import { isENSAddressFormat } from '../../helpers/validators';
 import { useAccountProfile } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
@@ -109,36 +109,7 @@ const TransactionList = ({
       const item = transactions[index];
       const { hash, from, minedAt, pending, to, status, type } = item;
 
-      const calculateTimestampOfToday = () => {
-        var d = new Date();
-        d.setHours(0, 0, 0, 0);
-        return d.getTime();
-      };
-      const calculateTimestampOfYesterday = () => {
-        var d = new Date();
-        d.setDate(d.getDate() - 1);
-        d.setHours(0, 0, 0, 0);
-        return d.getTime();
-      };
-      const calculateTimestampOfThisYear = () => {
-        var d = new Date();
-        d.setFullYear(d.getFullYear(), 0, 1);
-        d.setHours(0, 0, 0, 0);
-        return d.getTime();
-      };
-      const todayTimestamp = calculateTimestampOfToday();
-      const yesterdayTimestamp = calculateTimestampOfYesterday();
-      const thisYearTimestamp = calculateTimestampOfThisYear();
-
-      const timestamp = new Date(minedAt * 1000);
-      const date = format(
-        timestamp,
-        timestamp > todayTimestamp
-          ? `'Today'`
-          : timestamp > yesterdayTimestamp
-          ? `'Yesterday'`
-          : `'on' MMM d${timestamp > thisYearTimestamp ? '' : ' yyyy'}`
-      );
+      const date = getHumanReadableDate(minedAt);
 
       const hasAddableContact =
         (status === TransactionStatusTypes.received &&

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -9,8 +9,10 @@ import useExperimentalFlag, {
   AVATAR_PICKER,
 } from '../../config/experimentalHooks';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
-import TransactionTypes from '../../helpers/transactionTypes';
-import { getHumanReadableDate } from '../../helpers/transactions';
+import {
+  getHumanReadableDate,
+  hasAddableContact,
+} from '../../helpers/transactions';
 import { isENSAddressFormat } from '../../helpers/validators';
 import { useAccountProfile } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
@@ -111,15 +113,10 @@ const TransactionList = ({
 
       const date = getHumanReadableDate(minedAt);
 
-      const hasAddableContact =
-        (status === TransactionStatusTypes.received &&
-          type !== TransactionTypes.trade) ||
-        status === TransactionStatusTypes.receiving ||
-        status === TransactionStatusTypes.sending ||
-        status === TransactionStatusTypes.sent;
       const isSent =
         status === TransactionStatusTypes.sending ||
         status === TransactionStatusTypes.sent;
+      const showContactInfo = hasAddableContact(status, type);
 
       const headerInfo = {
         address: '',
@@ -143,26 +140,26 @@ const TransactionList = ({
 
       if (hash) {
         let buttons = ['View on Etherscan', 'Cancel'];
-        if (hasAddableContact) {
+        if (showContactInfo) {
           buttons.unshift(contact ? 'View Contact' : 'Add to Contacts');
         }
 
         showActionSheetWithOptions(
           {
-            cancelButtonIndex: hasAddableContact ? 2 : 1,
+            cancelButtonIndex: showContactInfo ? 2 : 1,
             options: buttons,
             title: pending
               ? `${headerInfo.type}${
-                  hasAddableContact
+                  showContactInfo
                     ? ' ' + headerInfo.divider + ' ' + headerInfo.address
                     : ''
                 }`
-              : hasAddableContact
+              : showContactInfo
               ? `${headerInfo.type} ${date} ${headerInfo.divider} ${headerInfo.address}`
               : `${headerInfo.type} ${date}`,
           },
           buttonIndex => {
-            if (hasAddableContact && buttonIndex === 0) {
+            if (showContactInfo && buttonIndex === 0) {
               navigate(Routes.MODAL_SCREEN, {
                 address: contactAddress,
                 asset: item,
@@ -171,8 +168,8 @@ const TransactionList = ({
                 type: 'contact',
               });
             } else if (
-              (!hasAddableContact && buttonIndex === 0) ||
-              (hasAddableContact && buttonIndex === 1)
+              (!showContactInfo && buttonIndex === 0) ||
+              (showContactInfo && buttonIndex === 1)
             ) {
               const normalizedHash = hash.replace(/-.*/g, '');
               const etherscanHost = ethereumUtils.getEtherscanHostFromNetwork(

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -11,6 +11,7 @@ import useExperimentalFlag, {
 } from '../../config/experimentalHooks';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import TransactionTypes from '../../helpers/transactionTypes';
+import { isENSAddressFormat } from '../../helpers/validators';
 import { useAccountProfile } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
 import { removeRequest } from '../../redux/requests';
@@ -163,8 +164,10 @@ const TransactionList = ({
         headerInfo.address = contact.nickname;
         contactColor = contact.color;
       } else {
-        headerInfo.address = abbreviations.address(contactAddress, 4, 10);
-        contactColor = Math.floor(Math.random() * colors.avatarColor.length);
+        headerInfo.address = isENSAddressFormat(contactAddress)
+          ? contactAddress
+          : abbreviations.address(contactAddress, 4, 10);
+        contactColor = colors.getRandomColor();
       }
 
       if (hash) {

--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 import { get, groupBy, isEmpty, map, toLower } from 'lodash';
 import { createSelector } from 'reselect';
 import TransactionStatusTypes from '../helpers/transactionStatusTypes';
+import TransactionTypes from '../helpers/transactionTypes';
 
 const contactsSelector = state => state.contacts;
 const requestsSelector = state => state.requests;
@@ -146,6 +147,19 @@ export function getHumanReadableDate(date) {
       ? `'Yesterday'`
       : `'on' MMM d${timestamp > thisYearTimestamp ? '' : ' yyyy'}`
   );
+}
+
+export function hasAddableContact(status, type) {
+  if (
+    (status === TransactionStatusTypes.received &&
+      type !== TransactionTypes.trade) ||
+    status === TransactionStatusTypes.receiving ||
+    status === TransactionStatusTypes.sending ||
+    status === TransactionStatusTypes.sent
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export const buildTransactionsSectionsSelector = createSelector(

--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -136,10 +136,6 @@ const buildTransactionsSections = (
 };
 
 export function getHumanReadableDate(date) {
-  const todayTimestamp = calculateTimestampOfToday();
-  const yesterdayTimestamp = calculateTimestampOfYesterday();
-  const thisYearTimestamp = calculateTimestampOfThisYear();
-
   const timestamp = new Date(date * 1000);
 
   return format(

--- a/src/helpers/transactions.js
+++ b/src/helpers/transactions.js
@@ -135,6 +135,23 @@ const buildTransactionsSections = (
   };
 };
 
+export function getHumanReadableDate(date) {
+  const todayTimestamp = calculateTimestampOfToday();
+  const yesterdayTimestamp = calculateTimestampOfYesterday();
+  const thisYearTimestamp = calculateTimestampOfThisYear();
+
+  const timestamp = new Date(date * 1000);
+
+  return format(
+    timestamp,
+    timestamp > todayTimestamp
+      ? `'Today'`
+      : timestamp > yesterdayTimestamp
+      ? `'Yesterday'`
+      : `'on' MMM d${timestamp > thisYearTimestamp ? '' : ' yyyy'}`
+  );
+}
+
 export const buildTransactionsSectionsSelector = createSelector(
   [
     contactsSelector,


### PR DESCRIPTION
- only show address and 'add to contacts' if it's a vanilla send or receive. before we were showing it on all transactions, swaps, etc. user was confused about it
- add date of tx confirmation to context menu title

I noticed this logic is all duplicated for the native and JS lists. not sure it's worth cleaning up now, just a heads up