### PR TITLE
Fix updating txn title after pending txn watcher completes

### DIFF
--- a/src/parsers/newTransaction.js
+++ b/src/parsers/newTransaction.js
@@ -41,18 +41,18 @@ export const parseNewTransaction = async (
   ]);
   const hash = txDetails.hash ? `${txDetails.hash}-0` : null;
   const nonce = tx.nonce || (tx.from ? await getTransactionCount(tx.from) : '');
-  const status = txDetails.status || TransactionStatusTypes.sending;
+  const status = txDetails?.status || TransactionStatusTypes.sending;
 
   const title = getTitle({
-    protocol: txDetails.protocol,
+    protocol: txDetails?.protocol,
     status,
-    type: txDetails.type,
+    type: txDetails?.type,
   });
 
   const description = getDescription({
-    name: get(txDetails, 'asset.name'),
+    name: txDetails?.asset?.name,
     status,
-    type: txDetails.type,
+    type: txDetails?.type,
   });
 
   tx = {
@@ -61,14 +61,15 @@ export const parseNewTransaction = async (
     description,
     hash,
     minedAt: null,
-    name: get(txDetails, 'asset.name'),
+    name: txDetails?.asset?.name,
     native,
     nonce,
     pending: true,
+    protocol: txDetails?.protocol,
     status,
-    symbol: get(txDetails, 'asset.symbol'),
+    symbol: txDetails?.asset?.symbol,
     title,
-    type: get(txDetails, 'type'),
+    type: txDetails?.type,
   };
 
   return tx;

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -367,7 +367,7 @@ export const getDescription = ({ name, status, type }) => {
   }
 };
 
-const getTransactionLabel = ({
+export const getTransactionLabel = ({
   direction,
   pending,
   protocol,

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -36,7 +36,7 @@ import TransactionTypes from '../helpers/transactionTypes';
 import { divide, isZero } from '../helpers/utilities';
 import { parseAccountAssets, parseAsset } from '../parsers/accounts';
 import { parseNewTransaction } from '../parsers/newTransaction';
-import { parseTransactions } from '../parsers/transactions';
+import { getTitle, parseTransactions } from '../parsers/transactions';
 import { tokenOverrides } from '../references';
 import { ethereumUtils, isLowerCaseMatch } from '../utils';
 
@@ -460,6 +460,12 @@ export const dataWatchPendingTransactions = () => async (
           } else {
             updatedPending.status = TransactionStatusTypes.failed;
           }
+          const title = getTitle({
+            protocol: tx.protocol,
+            status: updatedPending.status,
+            type: tx.type,
+          });
+          updatedPending.title = title;
           updatedPending.pending = false;
           updatedPending.minedAt = minedAt;
         }

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -31,12 +31,17 @@ import {
   saveLocalTransactions,
 } from '../handlers/localstorage/accountLocal';
 import { getTransactionReceipt } from '../handlers/web3';
+import DirectionTypes from '../helpers/transactionDirectionTypes';
 import TransactionStatusTypes from '../helpers/transactionStatusTypes';
 import TransactionTypes from '../helpers/transactionTypes';
 import { divide, isZero } from '../helpers/utilities';
 import { parseAccountAssets, parseAsset } from '../parsers/accounts';
 import { parseNewTransaction } from '../parsers/newTransaction';
-import { getTitle, parseTransactions } from '../parsers/transactions';
+import {
+  getTitle,
+  getTransactionLabel,
+  parseTransactions,
+} from '../parsers/transactions';
 import { tokenOverrides } from '../references';
 import { ethereumUtils, isLowerCaseMatch } from '../utils';
 
@@ -454,8 +459,15 @@ export const dataWatchPendingTransactions = () => async (
         if (txObj && txObj.blockNumber) {
           const minedAt = Math.floor(Date.now() / 1000);
           txStatusesDidChange = true;
+          const isSelf = toLower(tx?.from) === toLower(tx?.to);
           if (!isZero(txObj.status)) {
-            const newStatus = getConfirmedState(tx.type);
+            const newStatus = getTransactionLabel({
+              direction: isSelf ? DirectionTypes.self : DirectionTypes.out,
+              pending: false,
+              protocol: tx?.protocol,
+              status: getConfirmedState(tx.type),
+              type: tx?.type,
+            });
             updatedPending.status = newStatus;
           } else {
             updatedPending.status = TransactionStatusTypes.failed;


### PR DESCRIPTION
With the new title and description fields, we were updating the status but not the title in the pending txn watcher once it found the confirmed txn.

In the future, we should improve our txn parsing between parsers/transaction and parsers/newTransaction and pending txn watcher.