### PR TITLE
WalletList to extract unique key based on wallet id and account id

### DIFF
--- a/src/components/change-wallet/WalletList.js
+++ b/src/components/change-wallet/WalletList.js
@@ -34,7 +34,7 @@ const getItemLayout = (data, index) => {
   };
 };
 
-const keyExtractor = item => item.id;
+const keyExtractor = item => `${item.wallet_id}-${item.id}`;
 
 const skeletonTransition = (
   <Transition.Sequence>


### PR DESCRIPTION
Just the account ID (address) was not unique enough for instances where an address could be added as both read-only and not-read-only.