### PR TITLE
Check for ENS name on import of a seed phrase

### DIFF
--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -31,6 +31,7 @@ import {
   usePrevious,
   useTimeout,
 } from '../hooks';
+import { getWallet } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
 import { sheetVerticalOffset } from '../navigation/effects';
 import Routes from '@rainbow-me/routes';
@@ -175,6 +176,16 @@ const ImportSeedPhraseSheet = ({ isEmpty, setAppearListener }) => {
         const ens = await web3Provider.lookupAddress(input);
         if (ens && ens !== input) {
           name = ens;
+        }
+      } else {
+        try {
+          const { wallet } = getWallet(input);
+          const ens = await web3Provider.lookupAddress(wallet?.address);
+          if (ens && ens !== input) {
+            name = ens;
+          }
+        } catch (error) {
+          logger.log('Error looking up ENS for imported HD type wallet', error);
         }
       }
 


### PR DESCRIPTION
Previously, we would only auto-fill the "new wallet" modal with ENS for read only addresses.
Now if a user imports a seed phrase / private key that has an ENS attached to it, we can auto-fill that in the "new wallet" modal as well.

Before: https://recordit.co/Z2qekfEr55
After: https://recordit.co/nnCkYr29Ug

Some logic is redundant, but didn't want to mess around with the init wallet flow just yet. Figured this may still be a useful feature for the user.