### PR TITLE
Reduce number of calls to the graph

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -271,7 +271,7 @@ const subscribeToMissingPrices = addresses => (dispatch, getState) => {
   } else {
     const newQuery = uniswapClient.watchQuery({
       fetchPolicy: 'network-only',
-      pollInterval: 15000, // 15 seconds
+      pollInterval: 300000, // 300 seconds
       query: UNISWAP_PRICES_QUERY,
       variables: {
         addresses,

--- a/src/redux/savings.js
+++ b/src/redux/savings.js
@@ -8,7 +8,7 @@ import { parseAssetName, parseAssetSymbol } from '../parsers/accounts';
 import { CDAI_CONTRACT } from '../references';
 
 // -- Constants --------------------------------------- //
-const COMPOUND_QUERY_INTERVAL = 10000;
+const COMPOUND_QUERY_INTERVAL = 300000;
 const SAVINGS_UPDATE_COMPOUND_DATA = 'savings/SAVINGS_UPDATE_COMPOUND_DATA';
 const SAVINGS_UPDATE_COMPOUND_SUBSCRIPTION =
   'savings/SAVINGS_UPDATE_COMPOUND_SUBSCRIPTION';
@@ -105,7 +105,7 @@ const subscribeToCompoundData = async (dispatch, getState) => {
 
     const newQuery = compoundClient.watchQuery({
       fetchPolicy: 'network-only',
-      pollInterval: COMPOUND_QUERY_INTERVAL, // 15 seconds
+      pollInterval: COMPOUND_QUERY_INTERVAL, // 300 seconds
       query: COMPOUND_ACCOUNT_AND_MARKET_QUERY,
       skip: !toLower(accountAddress),
       variables: { id: toLower(accountAddress) },


### PR DESCRIPTION
reopening this PR after having previously merged it and then reverted because of @brunobar79's point that:
```
if we merge it as it is, it might take up to 5 minutes to show your new savings balance after making a deposit
``` 

cc @osdnk 