### PR TITLE
Patch RN to use continuous corners when possible

### DIFF
--- a/patches/react-native+0.62.2.patch
+++ b/patches/react-native+0.62.2.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-native/React/Views/RCTView.m b/node_modules/react-native/React/Views/RCTView.m
+index 831a1b5..91a302b 100644
+--- a/node_modules/react-native/React/Views/RCTView.m
++++ b/node_modules/react-native/React/Views/RCTView.m
+@@ -780,6 +780,11 @@ - (void)displayLayer:(CALayer *)layer
+     layer.contents = nil;
+     layer.needsDisplayOnBoundsChange = NO;
+     layer.mask = nil;
++    if (@available(iOS 13.0, *)) {
++      if (layer.cornerRadius < (MIN(self.bounds.size.height, self.bounds.size.width) / 2)) {
++        layer.cornerCurve = kCACornerCurveContinuous;
++      }
++    }
+     return;
+   }
+ 

--- a/patches/react-native+0.62.2.patch
+++ b/patches/react-native+0.62.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native/React/Views/RCTView.m b/node_modules/react-native/React/Views/RCTView.m
-index 831a1b5..91a302b 100644
+index 831a1b5..76fdaab 100644
 --- a/node_modules/react-native/React/Views/RCTView.m
 +++ b/node_modules/react-native/React/Views/RCTView.m
 @@ -780,6 +780,11 @@ - (void)displayLayer:(CALayer *)layer
@@ -7,7 +7,7 @@ index 831a1b5..91a302b 100644
      layer.needsDisplayOnBoundsChange = NO;
      layer.mask = nil;
 +    if (@available(iOS 13.0, *)) {
-+      if (layer.cornerRadius < (MIN(self.bounds.size.height, self.bounds.size.width) / 2)) {
++      if (layer.cornerRadius < MIN(self.bounds.size.height, self.bounds.size.width) / 2) {
 +        layer.cornerCurve = kCACornerCurveContinuous;
 +      }
 +    }


### PR DESCRIPTION
gives us better rounded corners on views if:

- all corners have equal radii of less than half smallest view dimension
- view doesn't have a border
- iOS 13+