### PR TITLE
Fix status bar managing in Swap

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,12 @@ import { get } from 'lodash';
 import nanoid from 'nanoid/non-secure';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { AppRegistry, AppState, unstable_enableLogBox } from 'react-native';
+import {
+  AppRegistry,
+  AppState,
+  StatusBar,
+  unstable_enableLogBox,
+} from 'react-native';
 import branch from 'react-native-branch';
 // eslint-disable-next-line import/default
 import CodePush from 'react-native-code-push';
@@ -46,6 +51,8 @@ import { logger } from 'logger';
 import { Portal } from 'react-native-cool-modals/Portal';
 
 const WALLETCONNECT_SYNC_DELAY = 500;
+
+StatusBar.pushStackEntry({ barStyle: 'dark-content' });
 
 if (__DEV__) {
   console.disableYellowBox = reactNativeDisableYellowBox;

--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,7 @@ import { Portal } from 'react-native-cool-modals/Portal';
 
 const WALLETCONNECT_SYNC_DELAY = 500;
 
-StatusBar.pushStackEntry({ barStyle: 'dark-content' });
+StatusBar.pushStackEntry({ animated: true, barStyle: 'dark-content' });
 
 if (__DEV__) {
   console.disableYellowBox = reactNativeDisableYellowBox;

--- a/src/navigation/useStatusBarManaging.js
+++ b/src/navigation/useStatusBarManaging.js
@@ -1,16 +1,18 @@
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { StatusBar } from 'react-native';
 import { useNavigation } from './Navigation';
 
 export default function useStatusBarManaging() {
   const navigation = useNavigation();
+  const ref = useRef();
   useLayoutEffect(() => {
     const unsubscribe = navigation.addListener(
       'transitionStart',
       ({ data: { closing } }) => {
         if (closing) {
-          StatusBar.setBarStyle('dark-content');
+          StatusBar.popStackEntry(ref.current);
         } else {
+          ref.current = StatusBar.pushStackEntry({ barStyle: 'light-content' });
           StatusBar.setBarStyle('light-content');
         }
       }

--- a/src/navigation/useStatusBarManaging.js
+++ b/src/navigation/useStatusBarManaging.js
@@ -12,7 +12,10 @@ export default function useStatusBarManaging() {
         if (closing) {
           StatusBar.popStackEntry(ref.current);
         } else {
-          ref.current = StatusBar.pushStackEntry({ barStyle: 'light-content' });
+          ref.current = StatusBar.pushStackEntry({
+            animated: true,
+            barStyle: 'light-content',
+          });
           StatusBar.setBarStyle('light-content');
         }
       }


### PR DESCRIPTION
I observed that while popping the state (with component-based Status Bar API), we don't have any state pushed initially 