### PR TITLE
Throttle the block listener for reserve updates

### DIFF
--- a/src/redux/web3listener.js
+++ b/src/redux/web3listener.js
@@ -1,6 +1,7 @@
-import { get } from 'lodash';
+import { get, throttle } from 'lodash';
 import { getReserve } from '../handlers/uniswap';
 import { web3Provider } from '../handlers/web3';
+import store from '../redux/store';
 import { uniswapUpdateTokenReserves } from './uniswap';
 import logger from 'logger';
 
@@ -21,9 +22,14 @@ const web3UpdateReserves = () => async (dispatch, getState) => {
   }
 };
 
-export const web3ListenerInit = () => dispatch => {
+const debouncedUpdateReserves = throttle(
+  store.dispatch(web3UpdateReserves),
+  8000
+);
+
+export const web3ListenerInit = () => () => {
   web3Provider.pollingInterval = 10000;
-  web3Provider.on('block', () => dispatch(web3UpdateReserves()));
+  web3Provider.on('block', debouncedUpdateReserves);
 };
 
 export const web3ListenerStop = () => () => {


### PR DESCRIPTION
When we turn off the listener and then turn it back on again, while the network request to Infura is still 1 request, ethers.js will emit all the blocks since the last block number it remembers to the latest. We were making network requests based on each block number we were receiving, so this should be throttled.

Technically, since we don't use the block number, we don't even need to listen to blocks, we could just make this call happen every 10 seconds.