### PR TITLE
Fix single row height in wallet screen when on testnet

### DIFF
--- a/src/components/asset-list/RecyclerViewTypes.js
+++ b/src/components/asset-list/RecyclerViewTypes.js
@@ -38,7 +38,7 @@ export const ViewTypes = {
     calculateHeight: ({ isFirst, isLast, areSmallCollectibles }) =>
       CoinRowHeight +
       (isFirst ? firstCoinRowMarginTop : 0) +
-      (isLast && !areSmallCollectibles ? ListFooter.height + 1 : 0),
+      (!isFirst && isLast && !areSmallCollectibles ? ListFooter.height + 1 : 0),
     index: 1,
     renderComponent: ({ type, data }) => {
       const { item = {}, renderItem } = data;


### PR DESCRIPTION
This big PR resolve https://linear.app/rainbow/issue/RAI-732/on-ropsten-eth-coin-row-positioning-is-wrong