### PR TITLE
Support Wyre order reservation

### DIFF
--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -5,6 +5,7 @@ import {
   getOrderId,
   getReferenceId,
   PaymentRequestStatusTypes,
+  reserveWyreOrder,
   showApplePayRequest,
 } from '../handlers/wyre';
 import {
@@ -49,6 +50,18 @@ export default function useWyreApplePay() {
       const referenceInfo = {
         referenceId: getReferenceId(accountAddress),
       };
+      const reservationId = await reserveWyreOrder(
+        value,
+        currency,
+        accountAddress,
+        network
+      );
+
+      if (!reservationId) {
+        analytics.track('Wyre order reservation incomplete', {
+          category: 'add cash',
+        });
+      }
 
       const applePayResponse = await showApplePayRequest(
         referenceInfo,
@@ -74,7 +87,8 @@ export default function useWyreApplePay() {
           totalAmount,
           accountAddress,
           currency,
-          network
+          network,
+          reservationId
         );
         if (orderId) {
           referenceInfo.orderId = orderId;

--- a/src/references/wyre/orderExceptions.js
+++ b/src/references/wyre/orderExceptions.js
@@ -5,9 +5,11 @@ const errorCategories = {
   PAYMENT: 'PAYMENT',
   RATE_LIMIT: 'RATE_LIMIT',
   VALIDATION_EXCEPTION: 'ValidationException',
+  WALLET_ORDER_RESERVATION: 'WOReservationException',
 };
 
 const orderCreationErrorCodes = {
+  ILLEGAL_RESERVATION: 'illegalReservation',
   UNSUPPORTED_CARD_TYPE_CREDIT: 'validation.unsupportedCardType.credit',
   UNSUPPORTED_CARD_TYPE_PREPAID: 'validation.unsupportedCardType.prepaid',
   AVS: 'validation.avs',
@@ -28,6 +30,12 @@ const orderCreationErrorCodes = {
 };
 
 export const orderExceptions = {
+  [errorCategories.WALLET_ORDER_RESERVATION]: {
+    [orderCreationErrorCodes.ILLEGAL_RESERVATION]: {
+      message: 'Missing order reservation',
+      tryAgain: true,
+    },
+  },
   [errorCategories.VALIDATION_EXCEPTION]: {
     [orderCreationErrorCodes.UNSUPPORTED_CARD_TYPE_CREDIT]: {
       tryAgain: true,


### PR DESCRIPTION
Note, this has only been tested on Kovan because Wyre is still working on making it ready for mainnet. It is breaking in mainnet, so I'll look into what to do while it isn't available.

Also note, if you want to test this, you'll need to get the latest dotenvs.

Fixes: https://linear.app/rainbow/issue/RAI-757/wyre-order-reservations-endpoint-required-by-aug-3rd