### PR TITLE
If output amount is set to zero, do not flip the isInputAmountExact flag

### DIFF
--- a/src/hooks/useUniswapMarketDetails.js
+++ b/src/hooks/useUniswapMarketDetails.js
@@ -71,7 +71,7 @@ export default function useUniswapMarketDetails() {
       updateInputAmount,
     }) => {
       if (isOutputEmpty || isOutputZero) {
-        updateInputAmount();
+        updateInputAmount(undefined, undefined, false);
         setIsSufficientBalance(true);
       } else {
         const updatedInputAmount = get(tradeDetails, 'inputAmount.amount');


### PR DESCRIPTION
When the output amount is set to zero, we were "resetting" the input amount (which also resets the isInputAmountExact flag unless specified). This was causing it to switch from "updating input amount given output amount change" to instead "updating output amount given input amount change" which was not the aim when updating the output amount.