### PR TITLE
Always calculate TxFee when entering swap screen.

### DIFF
--- a/src/raps/actions/swap.js
+++ b/src/raps/actions/swap.js
@@ -26,20 +26,17 @@ import logger from 'logger';
 const NOOP = () => undefined;
 
 export const isValidSwapInput = ({
-  inputAmount,
   inputCurrency,
   inputReserve,
-  outputAmount,
   outputCurrency,
   outputReserve,
 }) => {
-  const isMissingAmounts = !inputAmount || !outputAmount;
   const isMissingCurrency = !inputCurrency || !outputCurrency;
   const isMissingReserves =
     (get(inputCurrency, 'address') !== 'eth' && !inputReserve) ||
     (get(outputCurrency, 'address') !== 'eth' && !outputReserve);
 
-  return !(isMissingAmounts || isMissingCurrency || isMissingReserves);
+  return !(isMissingCurrency || isMissingReserves);
 };
 
 export const findSwapOutputAmount = (receipt, accountAddress) => {

--- a/src/raps/swapAndDepositCompound.js
+++ b/src/raps/swapAndDepositCompound.js
@@ -37,10 +37,8 @@ export const estimateSwapAndDepositCompound = async ({
   let gasLimits = [];
   if (requiresSwap) {
     const isValid = isValidSwapInput({
-      inputAmount,
       inputCurrency,
       inputReserve,
-      outputAmount,
       outputCurrency,
       outputReserve,
     });

--- a/src/raps/unlockAndSwap.js
+++ b/src/raps/unlockAndSwap.js
@@ -21,10 +21,8 @@ export const estimateUnlockAndSwap = async ({
   outputReserve,
 }) => {
   const isValid = isValidSwapInput({
-    inputAmount,
     inputCurrency,
     inputReserve,
-    outputAmount,
     outputCurrency,
     outputReserve,
   });

--- a/src/raps/unlockAndSwap.js
+++ b/src/raps/unlockAndSwap.js
@@ -20,6 +20,9 @@ export const estimateUnlockAndSwap = async ({
   outputCurrency,
   outputReserve,
 }) => {
+  if (!inputAmount) inputAmount = 1;
+  if (!outputAmount) outputAmount = 1;
+
   const isValid = isValidSwapInput({
     inputCurrency,
     inputReserve,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -165,7 +165,9 @@ export default function ExchangeModal({
         outputCurrency,
         outputReserve,
       });
-      updateTxFee(gasLimit);
+      if (inputCurrency && outputCurrency) {
+        updateTxFee(gasLimit);
+      }
     } catch (error) {
       updateTxFee(defaultGasLimit);
     }


### PR DESCRIPTION
Remove check for input/output amount while calculating TxFee. 
Before if input/output was empty TxFee showed default value for `eth` what made it look strange while swapping different currencies.

https://linear.app/rainbow/issue/RAI-767/swap-gas-estimations-arent-accurate-till-you-type-an-amount