### PR TITLE
Tweak logic make emergency exit after 10 sec timeout on splash screen 

### DIFF
--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -51,27 +51,13 @@ export default function useInitializeWallet() {
       shouldRunMigrations = false,
       overwrite = false
     ) => {
-      try {
-        logger.sentry('Start wallet setup');
-
-        await resetAccountState();
-        logger.sentry('resetAccountState ran ok');
-
-        const isImported = !!seedPhrase;
-        logger.sentry('isImported?', isImported);
-
-        if (shouldRunMigrations && !seedPhrase) {
-          logger.sentry('shouldRunMigrations && !seedPhrase? => true');
-          await dispatch(walletsLoadState());
-          logger.sentry('walletsLoadState call #1');
-          await runMigrations();
-          logger.sentry('done with migrations');
-        }
-
-        // Load the network first
-        await dispatch(settingsLoadNetwork());
-        logger.sentry('done loading network');
-
+      const initWalletAndLoadData = async (
+        seedPhrase,
+        color,
+        name,
+        overwrite,
+        isImported
+      ) => {
         const { isNew, walletAddress } = await walletInit(
           seedPhrase,
           color,
@@ -115,6 +101,44 @@ export default function useInitializeWallet() {
         logger.sentry('Hide splash screen');
         initializeAccountData();
         runKeychainIntegrityChecks();
+
+        return walletAddress;
+      };
+
+      try {
+        logger.sentry('Start wallet setup');
+
+        await resetAccountState();
+        logger.sentry('resetAccountState ran ok');
+
+        const isImported = !!seedPhrase;
+        logger.sentry('isImported?', isImported);
+
+        if (shouldRunMigrations && !seedPhrase) {
+          logger.sentry('shouldRunMigrations && !seedPhrase? => true');
+          await dispatch(walletsLoadState());
+          logger.sentry('walletsLoadState call #1');
+          await runMigrations();
+          logger.sentry('done with migrations');
+        }
+
+        const poorInternetEmergencyTimeout = setTimeout(async () => {
+          initWalletAndLoadData(seedPhrase, color, name, overwrite, isImported);
+        }, 10000);
+
+        // Load the network first
+        await dispatch(settingsLoadNetwork());
+        logger.sentry('done loading network');
+
+        clearTimeout(poorInternetEmergencyTimeout);
+        const walletAddress = await initWalletAndLoadData(
+          seedPhrase,
+          color,
+          name,
+          overwrite,
+          isImported
+        );
+
         return walletAddress;
       } catch (error) {
         logger.sentry('Error while initializing wallet');


### PR DESCRIPTION
The poor internet connection can make init wallet logic get stuck up to 2 mins on 
```await dispatch(settingsLoadNetwork());```
resulting in veeeeeery long splash screen.

This PR tweak logic makes an emergency exit after a 10-sec timeout to hide the splash screen - after that fetching logic is not stopped, the app is able to open with cached data and still try to connect.

https://linear.app/rainbow/issue/RAI-756/with-poor-internet-connection-app-gets-stuck-on-splash-screen