### PR TITLE
Consolidate icloud backup logic across multiple views

### DIFF
--- a/src/components/backup/BackupConfirmPasswordStep.js
+++ b/src/components/backup/BackupConfirmPasswordStep.js
@@ -133,7 +133,7 @@ const BackupConfirmPasswordStep = () => {
   const [password, setPassword] = useState('');
   const [label, setLabel] = useState('􀎽 Confirm Backup');
   const passwordRef = useRef();
-  const { latestBackup, selectedWallet } = useWallets();
+  const { selectedWallet } = useWallets();
 
   const walletId = params?.walletId || selectedWallet.id;
   const { goBack } = useNavigation();
@@ -176,7 +176,6 @@ const BackupConfirmPasswordStep = () => {
 
   const onSubmit = useCallback(async () => {
     await walletCloudBackup({
-      latestBackup,
       onError: () => {
         passwordRef.current?.focus();
         dispatch(setIsWalletLoading(null));
@@ -192,7 +191,7 @@ const BackupConfirmPasswordStep = () => {
       password,
       walletId,
     });
-  }, [dispatch, goBack, latestBackup, password, walletCloudBackup, walletId]);
+  }, [dispatch, goBack, password, walletCloudBackup, walletId]);
 
   const onPasswordSubmit = useCallback(() => {
     validPassword && onSubmit();

--- a/src/components/backup/BackupConfirmPasswordStep.js
+++ b/src/components/backup/BackupConfirmPasswordStep.js
@@ -176,7 +176,6 @@ const BackupConfirmPasswordStep = () => {
 
   const onSubmit = useCallback(async () => {
     await walletCloudBackup({
-      createBackupFileIfNeeded: true,
       latestBackup,
       onError: () => {
         passwordRef.current?.focus();

--- a/src/components/backup/BackupIcloudStep.js
+++ b/src/components/backup/BackupIcloudStep.js
@@ -147,7 +147,7 @@ const BackupIcloudStep = () => {
   const currentlyFocusedInput = useRef();
   const { params } = useRoute();
   const walletCloudBackup = useWalletCloudBackup();
-  const { latestBackup, selectedWallet } = useWallets();
+  const { selectedWallet } = useWallets();
   const dispatch = useDispatch();
   const [validPassword, setValidPassword] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(true);
@@ -252,7 +252,6 @@ const BackupIcloudStep = () => {
 
   const onConfirmBackup = useCallback(async () => {
     await walletCloudBackup({
-      latestBackup,
       onError: () => {
         setTimeout(onPasswordSubmit, 1000);
         dispatch(setIsWalletLoading(null));
@@ -271,7 +270,6 @@ const BackupIcloudStep = () => {
   }, [
     dispatch,
     goBack,
-    latestBackup,
     onPasswordSubmit,
     password,
     walletCloudBackup,

--- a/src/components/backup/BackupIcloudStep.js
+++ b/src/components/backup/BackupIcloudStep.js
@@ -1,5 +1,5 @@
+import { useNavigation } from '@react-navigation/core';
 import { useRoute } from '@react-navigation/native';
-import { captureException } from '@sentry/react-native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
@@ -15,6 +15,7 @@ import styled from 'styled-components';
 import zxcvbn from 'zxcvbn';
 import { isCloudBackupPasswordValid } from '../../handlers/cloudBackup';
 import isNativeStackAvailable from '../../helpers/isNativeStackAvailable';
+import { saveBackupPassword } from '../../model/backup';
 import { setIsWalletLoading } from '../../redux/wallets';
 import { deviceUtils } from '../../utils';
 import { RainbowButton } from '../buttons';
@@ -154,6 +155,7 @@ const BackupIcloudStep = () => {
   const [confirmPassword, setConfirmPassword] = useState('');
 
   const walletId = params?.walletId || selectedWallet.id;
+  const { goBack } = useNavigation();
 
   const [label, setLabel] = useState(
     !validPassword ? '􀙶 Add to iCloud Backup' : '􀎽 Confirm Backup'
@@ -250,26 +252,26 @@ const BackupIcloudStep = () => {
 
   const onConfirmBackup = useCallback(async () => {
     await walletCloudBackup({
+      createBackupFileIfNeeded: true,
       latestBackup,
-      onError: error => {
-        logger.sentry('Error while calling walletCloudBackup');
-        error && captureException(error);
+      onError: () => {
         setTimeout(onPasswordSubmit, 1000);
         dispatch(setIsWalletLoading(null));
-        setTimeout(() => {
-          Alert.alert('Error while trying to backup');
-        }, 500);
       },
-      onSuccess: () => {
+      onSuccess: async () => {
+        logger.log('BackupIcloudStep:: saving backup password');
+        await saveBackupPassword(password);
         setTimeout(() => {
           Alert.alert('Your wallet has been backed up succesfully!');
         }, 1000);
+        goBack();
       },
       password,
       walletId,
     });
   }, [
     dispatch,
+    goBack,
     latestBackup,
     onPasswordSubmit,
     password,

--- a/src/components/backup/BackupIcloudStep.js
+++ b/src/components/backup/BackupIcloudStep.js
@@ -252,7 +252,6 @@ const BackupIcloudStep = () => {
 
   const onConfirmBackup = useCallback(async () => {
     await walletCloudBackup({
-      createBackupFileIfNeeded: true,
       latestBackup,
       onError: () => {
         setTimeout(onPasswordSubmit, 1000);

--- a/src/components/settings-menu/BackupSection/AlreadyBackedUpView.js
+++ b/src/components/settings-menu/BackupSection/AlreadyBackedUpView.js
@@ -71,12 +71,7 @@ const TopIconGrey = styled(TopIcon)`
 const AlreadyBackedUpView = () => {
   const { navigate } = useNavigation();
   const { params } = useRoute();
-  const {
-    isWalletLoading,
-    latestBackup,
-    wallets,
-    selectedWallet,
-  } = useWallets();
+  const { isWalletLoading, wallets, selectedWallet } = useWallets();
   const walletCloudBackup = useWalletCloudBackup();
   const walletId = params?.walletId || selectedWallet.id;
 
@@ -144,7 +139,6 @@ const AlreadyBackedUpView = () => {
     walletCloudBackup({
       handleNoLatestBackup,
       handlePasswordNotFound,
-      latestBackup,
       walletId,
     });
   }, [
@@ -152,7 +146,6 @@ const AlreadyBackedUpView = () => {
     walletId,
     handleNoLatestBackup,
     handlePasswordNotFound,
-    latestBackup,
     walletStatus,
   ]);
 

--- a/src/hooks/useWalletCloudBackup.js
+++ b/src/hooks/useWalletCloudBackup.js
@@ -15,13 +15,12 @@ import logger from 'logger';
 
 export default function useWalletCloudBackup() {
   const dispatch = useDispatch();
-  const { wallets } = useWallets();
+  const { latestBackup, wallets } = useWallets();
 
   const walletCloudBackup = useCallback(
     async ({
       handleNoLatestBackup,
       handlePasswordNotFound,
-      latestBackup,
       onError,
       onSuccess,
       password,
@@ -101,7 +100,7 @@ export default function useWalletCloudBackup() {
         captureException(e);
       }
     },
-    [dispatch, wallets]
+    [dispatch, latestBackup, wallets]
   );
 
   return walletCloudBackup;

--- a/src/hooks/useWalletCloudBackup.js
+++ b/src/hooks/useWalletCloudBackup.js
@@ -51,17 +51,15 @@ export default function useWalletCloudBackup() {
       logger.log('password fetched correctly');
 
       let updatedBackupFile = null;
-
-      if (fetchedPassword && !latestBackup) {
-        logger.log('backing up to icloud', wallets[walletId]);
-        updatedBackupFile = await backupWalletToCloud(
-          fetchedPassword,
-          wallets[walletId]
-        );
-      }
-
       try {
-        if (latestBackup && !updatedBackupFile) {
+        if (!latestBackup) {
+          logger.log('backing up to icloud', wallets[walletId]);
+          updatedBackupFile = await backupWalletToCloud(
+            fetchedPassword,
+            wallets[walletId]
+          );
+        } else {
+          logger.log('adding wallet to icloud backup', wallets[walletId]);
           updatedBackupFile = await addWalletToCloudBackup(
             fetchedPassword,
             wallets[walletId],
@@ -70,7 +68,7 @@ export default function useWalletCloudBackup() {
         }
       } catch (e) {
         onError && onError();
-        logger.sentry('error while trying to add wallet to icloud backup');
+        logger.sentry('error while trying to backup wallet to icloud');
         captureException(e);
         setTimeout(() => {
           Alert.alert('Error while trying to backup');

--- a/src/hooks/useWalletCloudBackup.js
+++ b/src/hooks/useWalletCloudBackup.js
@@ -19,7 +19,6 @@ export default function useWalletCloudBackup() {
 
   const walletCloudBackup = useCallback(
     async ({
-      createBackupFileIfNeeded,
       handleNoLatestBackup,
       handlePasswordNotFound,
       latestBackup,
@@ -54,7 +53,7 @@ export default function useWalletCloudBackup() {
 
       let updatedBackupFile = null;
 
-      if (createBackupFileIfNeeded && fetchedPassword && !latestBackup) {
+      if (fetchedPassword && !latestBackup) {
         logger.log('backing up to icloud', wallets[walletId]);
         updatedBackupFile = await backupWalletToCloud(
           fetchedPassword,

--- a/src/screens/BackupSheet.js
+++ b/src/screens/BackupSheet.js
@@ -46,7 +46,7 @@ const BackupSheet = () => {
   const switchSheetContentTransitionRef = useRef();
   const { params } = useRoute();
   const dispatch = useDispatch();
-  const { selectedWallet, latestBackup, isWalletLoading } = useWallets();
+  const { selectedWallet, isWalletLoading } = useWallets();
   const walletCloudBackup = useWalletCloudBackup();
   const [step, setStep] = useState(params?.option || 'first');
   const walletId = params?.walletId || selectedWallet.id;
@@ -101,7 +101,6 @@ const BackupSheet = () => {
     walletCloudBackup({
       handleNoLatestBackup,
       handlePasswordNotFound,
-      latestBackup,
       onSuccess,
       walletId,
     });
@@ -110,7 +109,6 @@ const BackupSheet = () => {
     walletId,
     handleNoLatestBackup,
     handlePasswordNotFound,
-    latestBackup,
     onSuccess,
   ]);
 


### PR DESCRIPTION
Wanted to consolidate the iCloud backup logic that was shared across BackupConfirmPasswordStep, BackupIcloudStep, AlreadyBackedUpView, and BackupSheet. This helps make it easier to reason about.

For comparing logic, you can step through the original functions and see that the logic is still the same based on the params passed in. We can walk through them together as well!