### PR TITLE
fix styles for RainbowText in savings row for iphone 6's

### DIFF
--- a/src/components/savings/SavingsListRowAnimatedNumber.js
+++ b/src/components/savings/SavingsListRowAnimatedNumber.js
@@ -11,6 +11,9 @@ import { formatSavingsAmount, isSymbolStablecoin } from '../../helpers/savings';
 import { colors, fonts } from '@rainbow-me/styles';
 
 const sx = StyleSheet.create({
+  animatedNumber: {
+    height: 30,
+  },
   animatedNumberAndroid: {
     paddingLeft: 35,
     position: 'absolute',
@@ -22,7 +25,6 @@ const sx = StyleSheet.create({
     fontFamily: fonts.family.SFProRounded,
     fontSize: parseFloat(fonts.size.lmedium),
     fontWeight: fonts.weight.bold,
-    height: 30,
     letterSpacing: fonts.letterSpacing.roundedTightest,
     marginBottom: 0.5,
     marginLeft: 6,
@@ -68,12 +70,13 @@ const SavingsListRowAnimatedNumber = ({
       steps={steps}
       style={[
         sx.text,
+        isRainbowTextAvailable ? sx.animatedNumber : null,
         Platform.OS === 'android' ? sx.animatedNumberAndroid : null,
       ]}
       time={interval}
       value={Number(value)}
     >
-      {isRainbowTextAvailable ? null : formatter(initialValue)}
+      {isRainbowTextAvailable ? '' : formatter(initialValue)}
     </TextComponent>
   );
 };


### PR DESCRIPTION
before and after

![](https://files.slack.com/files-pri/TGUCQPCRG-F019ATNJ98F/screen_shot_2020-08-30_at_1.57.23_am.png)
<img width="402" alt="Screen Shot 2020-08-30 at 2 15 51 AM" src="https://user-images.githubusercontent.com/1325144/91652593-d0de1300-ea66-11ea-8a38-9da20206687e.png">
<img width="416" alt="Screen Shot 2020-08-30 at 1 57 23 AM" src="https://user-images.githubusercontent.com/1325144/91652602-ddfb0200-ea66-11ea-9466-329c7bc52cee.png">
