### PR TITLE
Fix WC transaction issues

### DIFF
--- a/src/components/transaction/TransactionSheet.js
+++ b/src/components/transaction/TransactionSheet.js
@@ -3,6 +3,7 @@ import React, { Children, Fragment } from 'react';
 import styled from 'styled-components/primitives';
 import { GasSpeedButton } from '../../components/gas';
 import { safeAreaInsetValues } from '../../utils';
+import { isMessageDisplayType } from '../../utils/signingMethods';
 import Divider from '../Divider';
 import { Column } from '../layout';
 import { borders, colors, padding } from '@rainbow-me/styles';
@@ -25,22 +26,26 @@ const SendButtonContainer = styled(Column)`
   width: 100%;
 `;
 
-const TransactionSheet = ({ children, sendButton, ...props }) => (
-  <Container {...props}>
-    {Children.map(children, (child, index) => (
-      <Fragment>
-        {child}
-        {index < children.length - 1 && <Divider />}
-      </Fragment>
-    ))}
-    <SendButtonContainer>
-      <GasSpeedButtonContainer>
-        <GasSpeedButton type="transaction" />
-      </GasSpeedButtonContainer>
-      {sendButton}
-    </SendButtonContainer>
-  </Container>
-);
+const TransactionSheet = ({ children, method, sendButton, ...props }) => {
+  return (
+    <Container {...props}>
+      {Children.map(children, (child, index) => (
+        <Fragment>
+          {child}
+          {index < children.length - 1 && <Divider />}
+        </Fragment>
+      ))}
+      <SendButtonContainer>
+        {!isMessageDisplayType(method) && (
+          <GasSpeedButtonContainer>
+            <GasSpeedButton type="transaction" />
+          </GasSpeedButtonContainer>
+        )}
+        {sendButton}
+      </SendButtonContainer>
+    </Container>
+  );
+};
 
 TransactionSheet.propTypes = {
   children: PropTypes.node,

--- a/src/components/transaction/sections/DefaultTransactionConfirmationSection.js
+++ b/src/components/transaction/sections/DefaultTransactionConfirmationSection.js
@@ -11,10 +11,11 @@ import { colors } from '@rainbow-me/styles';
 const DefaultTransactionConfirmationSection = ({
   address,
   data,
+  method,
   sendButton,
   value,
 }) => (
-  <TransactionSheet sendButton={sendButton}>
+  <TransactionSheet method={method} sendButton={sendButton}>
     <TransactionRow title={lang.t('wallet.action.to')}>
       <TruncatedAddress
         address={address}

--- a/src/components/transaction/sections/MessageSigningSection.js
+++ b/src/components/transaction/sections/MessageSigningSection.js
@@ -8,7 +8,7 @@ import TransactionRow from '../TransactionRow';
 import TransactionSheet from '../TransactionSheet';
 
 const MessageSigningSection = ({ message, method, sendButton }) => (
-  <TransactionSheet sendButton={sendButton}>
+  <TransactionSheet method={method} sendButton={sendButton}>
     <TransactionRow title={lang.t('wallet.message_signing.message')}>
       <TransactionMessage
         maxHeight={deviceUtils.isSmallPhone ? 100 : 250}

--- a/src/components/transaction/sections/TransactionConfirmationSection.js
+++ b/src/components/transaction/sections/TransactionConfirmationSection.js
@@ -43,9 +43,10 @@ const TokenSymbol = styled(Amount)`
 
 const TransactionConfirmationSection = ({
   asset: { address, amount, name, nativeAmountDisplay, symbol },
+  method,
   sendButton,
 }) => (
-  <TransactionSheet sendButton={sendButton}>
+  <TransactionSheet method={method} sendButton={sendButton}>
     <TransactionRow title={lang.t('wallet.action.to')}>
       <TruncatedAddress
         address={address}

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -48,18 +48,23 @@ const getDefaultTxFees = () => (dispatch, getState) => {
 };
 
 export const gasPricesStartPolling = () => async (dispatch, getState) => {
+  const { gasPrices } = getState().gas;
+
   const { fallbackGasPrices, selectedGasPrice, txFees } = dispatch(
     getDefaultTxFees()
   );
-
-  dispatch({
-    payload: {
-      gasPrices: fallbackGasPrices,
-      selectedGasPrice,
-      txFees,
-    },
-    type: GAS_PRICES_DEFAULT,
-  });
+  // We only set the default if we don't have any price
+  // The previous price will be always more accurate than our default values!
+  if (isEmpty(gasPrices)) {
+    dispatch({
+      payload: {
+        gasPrices: fallbackGasPrices,
+        selectedGasPrice,
+        txFees,
+      },
+      type: GAS_PRICES_DEFAULT,
+    });
+  }
 
   const getGasPrices = () =>
     new Promise((fetchResolve, fetchReject) => {


### PR DESCRIPTION
- Transactions where failing cause we were passing gasLimit: 0
- Gas calculation was setting the default values before getting the new ones on every transaction, making the number go crazy
(now the default gas value is set only when there's no previous price)
- There was a bug preventing the tx fee to be updated when the estimated gas limit was the same for two tx requests
