### PR TITLE
Add ganache support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint:js": "eslint --ext '.ts,.js,.jsx' .",
     "lint:ts": "yarn tsc --skipLibCheck --noEmit",
     "postinstall": "./scripts/postinstall.sh",
-    "update-env": "curl -H 'Authorization: token '$GITHUB_TOKEN -H 'Accept: application/vnd.github.v3.raw' -O  -L https://api.github.com/repos/rainbow-me/rainbow-env/contents/dotenv && rm -f .env && mv dotenv .env"
+    "update-env": "curl -H 'Authorization: token '$GITHUB_TOKEN -H 'Accept: application/vnd.github.v3.raw' -O  -L https://api.github.com/repos/rainbow-me/rainbow-env/contents/dotenv && rm -f .env && mv dotenv .env",
+    "ganache": "source .env && ganache-cli --f https://mainnet.infura.io/v3/${INFURA_PROJECT_ID_DEV} -p 7545 -i 1 -b 10"
   },
   "husky": {
     "hooks": {
@@ -224,7 +225,8 @@
     "stylelint-config-react-native-styled-components": "^0.3.0",
     "stylelint-processor-styled-components": "^1.10.0",
     "stylelint-react-native": "^2.2.0",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "ganache-cli": "^6.10.1"
   },
   "resolutions": {
     "**/bl": "0.9.5",

--- a/src/components/settings-menu/DevSection.js
+++ b/src/components/settings-menu/DevSection.js
@@ -3,9 +3,11 @@ import Clipboard from '@react-native-community/clipboard';
 import React, { useCallback, useContext } from 'react';
 import { ScrollView } from 'react-native';
 import { DEV_SEEDS } from 'react-native-dotenv';
+import { web3SetHttpProvider } from '../../handlers/web3';
 import { DevContext } from '../../helpers/DevContext';
 import { ListFooter, ListItem } from '../list';
 import { RadioListItem } from '../radio-list';
+import logger from 'logger';
 
 const DevSection = () => {
   const { config, setConfig } = useContext(DevContext);
@@ -16,6 +18,15 @@ const DevSection = () => {
     },
     [config, setConfig]
   );
+
+  const connectToGanache = useCallback(async () => {
+    try {
+      const ready = await web3SetHttpProvider('http://127.0.0.1:7545');
+      logger.log('connected to ganache', ready);
+    } catch (e) {
+      logger.log('error connecting to ganache');
+    }
+  }, []);
 
   return (
     <ScrollView>
@@ -36,6 +47,7 @@ const DevSection = () => {
         label="‍💻 Copy dev seeds"
         onPress={() => Clipboard.setString(DEV_SEEDS)}
       />
+      <ListItem label="‍👾 Connect to ganache" onPress={connectToGanache} />
       <ListFooter />
 
       {Object.keys(config)

--- a/src/components/toasts/TestnetToast.js
+++ b/src/components/toasts/TestnetToast.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { web3Provider } from '../../handlers/web3';
 import networkInfo from '../../helpers/networkInfo';
 import networkTypes from '../../helpers/networkTypes';
 import { useAccountSettings } from '../../hooks';
@@ -9,15 +10,27 @@ import { colors } from '@rainbow-me/styles';
 
 const TestnetToast = () => {
   const { network } = useAccountSettings();
-  const isMainnet = network === networkTypes.mainnet;
-
+  const providerUrl = web3Provider?.connection?.url;
   const { name, color } = networkInfo[network];
+  const [visible, setVisible] = useState(!network === networkTypes.mainnet);
+  const [networkName, setNetworkName] = useState(name);
+
+  useEffect(() => {
+    if (network === networkTypes.mainnet) {
+      if (providerUrl?.startsWith('http://')) {
+        setVisible(true);
+        setNetworkName('Ganache');
+      } else {
+        setVisible(false);
+      }
+    }
+  }, [network, providerUrl]);
 
   return (
-    <Toast isVisible={!isMainnet}>
+    <Toast isVisible={visible}>
       <Icon color={color} marginHorizontal={5} marginTop={5} name="dot" />
       <Text color={colors.white} size="smedium" weight="semibold">
-        <Nbsp /> {name} <Nbsp />
+        <Nbsp /> {networkName} <Nbsp />
       </Text>
     </Toast>
   );

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -26,9 +26,13 @@ export let web3Provider = new ethers.providers.JsonRpcProvider(
  * @param {String} network
  */
 export const web3SetHttpProvider = async network => {
-  web3Provider = new ethers.providers.JsonRpcProvider(
-    replace(infuraUrl, 'network', network)
-  );
+  if (network.startsWith('http://')) {
+    web3Provider = new ethers.providers.JsonRpcProvider(network);
+  } else {
+    web3Provider = new ethers.providers.JsonRpcProvider(
+      replace(infuraUrl, 'network', network)
+    );
+  }
   return web3Provider.ready;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,7 +2925,7 @@ bignumber.js@^9.0.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
   integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
-bindings@^1.5.0:
+bindings@^1.2.1, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -4947,6 +4947,19 @@ ethereumjs-abi@0.6.5:
     bn.js "^4.10.0"
     ethereumjs-util "^4.3.0"
 
+ethereumjs-util@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#e9c51e5549e8ebd757a339cc00f5380507e799c8"
+  integrity sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "0.1.6"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
 ethereumjs-util@^4.3.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz#f4bf9b3b515a484e3cc8781d61d9d980f7c83bd0"
@@ -5580,6 +5593,17 @@ fwd-stream@^1.0.4:
   integrity sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=
   dependencies:
     readable-stream "~1.0.26-4"
+
+ganache-cli@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.10.1.tgz#6e083a92dba204d649c43d8823152bb9e2219807"
+  integrity sha512-3lpBxILtJBxkNVo+U8ad2qbkzB6nZ53gXhXH6NiS0Pauqur86rGbhXz6fNASjBosZm9iJ8Nr71fJd331QODFkQ==
+  dependencies:
+    ethereumjs-util "6.1.0"
+    source-map-support "0.5.12"
+    yargs "13.2.4"
+  optionalDependencies:
+    scrypt "6.0.3"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -7232,6 +7256,16 @@ jsx-ast-utils@^2.4.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
+keccak@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.4.0.tgz#572f8a6dbee8e7b3aa421550f9e6408ca2186f80"
+  integrity sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==
+  dependencies:
+    bindings "^1.2.1"
+    inherits "^2.0.3"
+    nan "^2.2.1"
+    safe-buffer "^5.1.0"
+
 keccak@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
@@ -8214,7 +8248,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.12.1, nan@^2.14.0:
+nan@^2.0.8, nan@^2.12.1, nan@^2.14.0, nan@^2.2.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
@@ -8668,7 +8702,7 @@ ora@^3.4.0:
     strip-ansi "^5.2.0"
     wcwidth "^1.0.1"
 
-os-locale@^3.0.0:
+os-locale@^3.0.0, os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
   integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
@@ -10626,7 +10660,14 @@ scrypt-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
-secp256k1@3.8.0:
+scrypt@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/scrypt/-/scrypt-6.0.3.tgz#04e014a5682b53fa50c2d5cce167d719c06d870d"
+  integrity sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=
+  dependencies:
+    nan "^2.0.8"
+
+secp256k1@3.8.0, secp256k1@^3.0.1:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.8.0.tgz#28f59f4b01dbee9575f56a47034b7d2e3b3b352d"
   integrity sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==
@@ -11000,6 +11041,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@0.5.12:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.16, source-map-support@^0.5.6:
   version "0.5.19"
@@ -12570,13 +12619,30 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@18.1.3, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.0.0, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.2:
+yargs-parser@18.1.3, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.0.0, yargs-parser@^13.1.0, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs@13.2.4:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
+  integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.0"
 
 yargs@^12.0.2:
   version "12.0.5"


### PR DESCRIPTION
This PR adds ganache as a dev dependency and a new npm script that will launch it (`yarn ganache`)
Once you launch the server you can connect to it via Settings => Developer Settings => Connect to Ganache

This will allow you to all types of transactions from a fake mainnet, without the need of paying real gas fees.

Tested with: 
- Send ETH (including ENS support)
- Send any token
- Swap any token
- WalletConnect send tx (via example.walletconnect.org)
- Uniswap v2 via WalletConnect

Some gotchas:
- Balances won't updated since they are still loaded from zerion (will fix soon)
- Won't persist during app sessions. If you restart the app you have to manually connect again
- There's no disconnect but you can achieve that by killing the app
- Swap tx never confirm in the UI cause (probably a bug), but it will if you send another transaction

DEMO: https://recordit.co/zjYDqvE9C2

