### PR TITLE
move handling of setIsWalletLoading into the useWallets hook

### DIFF
--- a/src/components/backup/BackupConfirmPasswordStep.js
+++ b/src/components/backup/BackupConfirmPasswordStep.js
@@ -12,12 +12,10 @@ import {
   View,
 } from 'react-native';
 import ShadowStack from 'react-native-shadow-stack/dist/ShadowStack';
-import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { isCloudBackupPasswordValid } from '../../handlers/cloudBackup';
 import isNativeStackAvailable from '../../helpers/isNativeStackAvailable';
 import { saveBackupPassword } from '../../model/backup';
-import { setIsWalletLoading } from '../../redux/wallets';
 import { deviceUtils } from '../../utils';
 import { RainbowButton } from '../buttons';
 import { Icon } from '../icons';
@@ -127,16 +125,15 @@ const TopIcon = () => (
   </GradientText>
 );
 
-const BackupConfirmPasswordStep = () => {
+export default function BackupConfirmPasswordStep() {
   const { params } = useRoute();
-  const dispatch = useDispatch();
   const walletCloudBackup = useWalletCloudBackup();
   const [validPassword, setValidPassword] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(true);
   const [password, setPassword] = useState('');
   const [label, setLabel] = useState('􀎽 Confirm Backup');
   const passwordRef = useRef();
-  const { selectedWallet } = useWallets();
+  const { selectedWallet, setIsWalletLoading } = useWallets();
   const routes = useNavigationState(state => state.routes);
 
   const walletId = params?.walletId || selectedWallet.id;
@@ -177,12 +174,12 @@ const BackupConfirmPasswordStep = () => {
   const onError = useCallback(
     msg => {
       passwordRef.current?.focus();
-      dispatch(setIsWalletLoading(null));
+      setIsWalletLoading(null);
       setTimeout(() => {
         Alert.alert(msg);
       }, 500);
     },
-    [dispatch]
+    [setIsWalletLoading]
   );
 
   const onSuccess = useCallback(async () => {
@@ -259,6 +256,4 @@ const BackupConfirmPasswordStep = () => {
       </KeyboardAvoidingView>
     </SheetContainer>
   );
-};
-
-export default BackupConfirmPasswordStep;
+}

--- a/src/components/backup/BackupIcloudStep.js
+++ b/src/components/backup/BackupIcloudStep.js
@@ -12,13 +12,11 @@ import {
   View,
 } from 'react-native';
 import ShadowStack from 'react-native-shadow-stack/dist/ShadowStack';
-import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import zxcvbn from 'zxcvbn';
 import { isCloudBackupPasswordValid } from '../../handlers/cloudBackup';
 import isNativeStackAvailable from '../../helpers/isNativeStackAvailable';
 import { saveBackupPassword } from '../../model/backup';
-import { setIsWalletLoading } from '../../redux/wallets';
 import { deviceUtils } from '../../utils';
 import { RainbowButton } from '../buttons';
 import { Icon } from '../icons';
@@ -150,8 +148,7 @@ const BackupIcloudStep = () => {
   const currentlyFocusedInput = useRef();
   const { params } = useRoute();
   const walletCloudBackup = useWalletCloudBackup();
-  const { selectedWallet } = useWallets();
-  const dispatch = useDispatch();
+  const { selectedWallet, setIsWalletLoading } = useWallets();
   const [validPassword, setValidPassword] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(true);
   const [password, setPassword] = useState('');
@@ -261,12 +258,12 @@ const BackupIcloudStep = () => {
   const onError = useCallback(
     msg => {
       setTimeout(onPasswordSubmit, 1000);
-      dispatch(setIsWalletLoading(null));
+      setIsWalletLoading(null);
       setTimeout(() => {
         Alert.alert(msg);
       }, 500);
     },
-    [dispatch, onPasswordSubmit]
+    [onPasswordSubmit, setIsWalletLoading]
   );
 
   const onSuccess = useCallback(async () => {

--- a/src/components/restore/RestoreIcloudStep.js
+++ b/src/components/restore/RestoreIcloudStep.js
@@ -10,7 +10,6 @@ import {
   View,
 } from 'react-native';
 import ShadowStack from 'react-native-shadow-stack/dist/ShadowStack';
-import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { isCloudBackupPasswordValid } from '../../handlers/cloudBackup';
 import { removeWalletData } from '../../handlers/localstorage/removeWallet';
@@ -24,7 +23,6 @@ import {
 } from '../../model/backup';
 import { sheetVerticalOffset } from '../../navigation/effects';
 import { usePortal } from '../../react-native-cool-modals/Portal';
-import { setIsWalletLoading } from '../../redux/wallets';
 import { deviceUtils } from '../../utils';
 import { RainbowButton } from '../buttons';
 import { Icon } from '../icons';
@@ -133,10 +131,9 @@ const TopIcon = () => (
   </GradientText>
 );
 
-const RestoreIcloudStep = ({ userData }) => {
+export default function RestoreIcloudStep({ userData }) {
   const { goBack, replace } = useNavigation();
-  const dispatch = useDispatch();
-  const { isWalletLoading } = useWallets();
+  const { isWalletLoading, setIsWalletLoading } = useWallets();
   const { accountAddress } = useAccountSettings();
   const [validPassword, setValidPassword] = useState(false);
   const [incorrectPassword, setIncorrectPassword] = useState(false);
@@ -196,7 +193,7 @@ const RestoreIcloudStep = ({ userData }) => {
 
   const onSubmit = useCallback(async () => {
     try {
-      dispatch(setIsWalletLoading(WalletLoadingStates.RESTORING_WALLET));
+      setIsWalletLoading(WalletLoadingStates.RESTORING_WALLET);
       const success = await restoreCloudBackup(password, userData);
       if (success) {
         // Store it in the keychain in case it was missing
@@ -206,17 +203,17 @@ const RestoreIcloudStep = ({ userData }) => {
         goBack();
         InteractionManager.runAfterInteractions(async () => {
           replace(Routes.SWIPE_LAYOUT);
-          dispatch(setIsWalletLoading(null));
+          setIsWalletLoading(null);
         });
       } else {
         setIncorrectPassword(true);
-        dispatch(setIsWalletLoading(null));
+        setIsWalletLoading(null);
       }
     } catch (e) {
-      dispatch(setIsWalletLoading(null));
+      setIsWalletLoading(null);
       Alert.alert('Error while restoring backup');
     }
-  }, [accountAddress, dispatch, goBack, password, replace, userData]);
+  }, [accountAddress, goBack, password, replace, setIsWalletLoading, userData]);
 
   const onPasswordSubmit = useCallback(() => {
     validPassword && onSubmit();
@@ -265,6 +262,4 @@ const RestoreIcloudStep = ({ userData }) => {
       </KeyboardAvoidingView>
     </SheetContainer>
   );
-};
-
-export default RestoreIcloudStep;
+}

--- a/src/hooks/useWalletCloudBackup.js
+++ b/src/hooks/useWalletCloudBackup.js
@@ -9,7 +9,7 @@ import {
   backupWalletToCloud,
   fetchBackupPassword,
 } from '../model/backup';
-import { setIsWalletLoading, setWalletBackedUp } from '../redux/wallets';
+import { setWalletBackedUp } from '../redux/wallets';
 import useWallets from './useWallets';
 import {
   CLOUD_BACKUP_ERRORS,
@@ -40,7 +40,7 @@ function getUserError(e) {
 
 export default function useWalletCloudBackup() {
   const dispatch = useDispatch();
-  const { latestBackup, wallets } = useWallets();
+  const { latestBackup, setIsWalletLoading, wallets } = useWallets();
 
   const walletCloudBackup = useCallback(
     async ({
@@ -111,7 +111,7 @@ export default function useWalletCloudBackup() {
         return;
       }
 
-      dispatch(setIsWalletLoading(walletLoadingStates.BACKING_UP_WALLET));
+      setIsWalletLoading(walletLoadingStates.BACKING_UP_WALLET);
       // We want to make it clear why are we requesting faceID twice
       // So we delayed it to make sure the user can read before seeing the auth prompt
       if (wasPasswordFetched) {
@@ -174,7 +174,7 @@ export default function useWalletCloudBackup() {
         });
       }
     },
-    [dispatch, latestBackup, wallets]
+    [dispatch, latestBackup, setIsWalletLoading, wallets]
   );
 
   return walletCloudBackup;

--- a/src/hooks/useWallets.js
+++ b/src/hooks/useWallets.js
@@ -1,6 +1,8 @@
-import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { findLatestBackUp } from '../model/backup';
+import { setIsWalletLoading as rawSetIsWalletLoading } from '../redux/wallets';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
 
 const walletSelector = createSelector(
@@ -20,6 +22,7 @@ const walletSelector = createSelector(
 );
 
 export default function useWallets() {
+  const dispatch = useDispatch();
   const {
     isWalletLoading,
     latestBackup,
@@ -28,11 +31,17 @@ export default function useWallets() {
     wallets,
   } = useSelector(walletSelector);
 
+  const setIsWalletLoading = useCallback(
+    isLoading => dispatch(rawSetIsWalletLoading(isLoading)),
+    [dispatch]
+  );
+
   return {
     isReadOnlyWallet: selectedWallet.type === WalletTypes.readOnly,
     isWalletLoading,
     latestBackup,
     selectedWallet,
+    setIsWalletLoading,
     walletNames,
     wallets,
   };

--- a/src/hooks/useWallets.js
+++ b/src/hooks/useWallets.js
@@ -1,21 +1,32 @@
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { createSelector } from 'reselect';
 import { findLatestBackUp } from '../model/backup';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
 
-export default function useWallets() {
-  const { isWalletLoading, selectedWallet, walletNames, wallets } = useSelector(
-    ({ wallets: { isWalletLoading, selected, walletNames, wallets } }) => ({
-      isWalletLoading,
-      selectedWallet: selected || {},
-      walletNames,
-      wallets,
-    })
-  );
+const walletSelector = createSelector(
+  ({ wallets: { isWalletLoading, selected = {}, walletNames, wallets } }) => ({
+    isWalletLoading,
+    selectedWallet: selected,
+    walletNames,
+    wallets,
+  }),
+  ({ isWalletLoading, selectedWallet, walletNames, wallets }) => ({
+    isWalletLoading,
+    latestBackup: findLatestBackUp(wallets) || false,
+    selectedWallet,
+    walletNames,
+    wallets,
+  })
+);
 
-  const latestBackup = useMemo(() => {
-    return findLatestBackUp(wallets) || false;
-  }, [wallets]);
+export default function useWallets() {
+  const {
+    isWalletLoading,
+    latestBackup,
+    selectedWallet,
+    walletNames,
+    wallets,
+  } = useSelector(walletSelector);
 
   return {
     isReadOnlyWallet: selectedWallet.type === WalletTypes.readOnly,

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -22,7 +22,6 @@ import { useNavigation } from '../navigation/Navigation';
 import {
   addressSetSelected,
   createAccountForWallet,
-  setIsWalletLoading,
   walletsLoadState,
   walletsSetSelected,
   walletsUpdate,
@@ -82,7 +81,7 @@ const getWalletRowCount = wallets => {
 };
 
 export default function ChangeWalletSheet() {
-  const { wallets, selectedWallet } = useWallets();
+  const { selectedWallet, setIsWalletLoading, wallets } = useWallets();
   const [editMode, setEditMode] = useState(false);
 
   const { goBack, navigate, replace } = useNavigation();
@@ -309,9 +308,7 @@ export default function ChangeWalletSheet() {
             isNewProfile: true,
             onCloseModal: async args => {
               if (args) {
-                dispatch(
-                  setIsWalletLoading(WalletLoadingStates.CREATING_ACCOUNT)
-                );
+                setIsWalletLoading(WalletLoadingStates.CREATING_ACCOUNT);
                 const name = get(args, 'name', '');
                 const color = get(args, 'color', colors.getRandomColor());
                 // Check if the selected wallet is the primary
@@ -372,7 +369,7 @@ export default function ChangeWalletSheet() {
                 }
               }
               creatingWallet.current = false;
-              dispatch(setIsWalletLoading(null));
+              setIsWalletLoading(null);
             },
             profile: {
               color: null,
@@ -383,7 +380,7 @@ export default function ChangeWalletSheet() {
         }, 50);
       });
     } catch (e) {
-      dispatch(setIsWalletLoading(null));
+      setIsWalletLoading(null);
       logger.log('Error while trying to add account', e);
     }
   }, [
@@ -394,6 +391,7 @@ export default function ChangeWalletSheet() {
     selectedWallet.damaged,
     selectedWallet.id,
     selectedWallet.primary,
+    setIsWalletLoading,
     wallets,
   ]);
 


### PR DESCRIPTION
move setIsWalletLoading into the useWallet hook 
💬️ i hate having `dispatch`'s all over the place and would rather have them handled by the hook handling that same activity

Utilize power of reselect instead of manual memoization inside of useWallets hook
💬️ i think that this pattern is cleaner. like conceptually i think that `selectors` should be responsible for handling any desired transformations of the selector output.