### PR TITLE
create config generator for cool-modals-related screens

### DIFF
--- a/src/components/sheet/SheetHandleFixedToTop.js
+++ b/src/components/sheet/SheetHandleFixedToTop.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components/primitives';
-import { neverRerender } from '../../utils';
 import { Centered } from '../layout';
 import SheetHandle, { HandleHeight } from './SheetHandle';
 import { padding } from '@rainbow-me/styles';
@@ -22,10 +21,10 @@ const Container = styled(Centered).attrs({
   z-index: 9;
 `;
 
-const SheetHandleFixedToTop = ({ showBlur }) => (
-  <Container>
-    <SheetHandle showBlur={showBlur} />
-  </Container>
-);
-
-export default neverRerender(SheetHandleFixedToTop);
+export default function SheetHandleFixedToTop({ showBlur }) {
+  return (
+    <Container>
+      <SheetHandle showBlur={showBlur} />
+    </Container>
+  );
+}

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -25,6 +25,7 @@ import WelcomeScreen from '../screens/WelcomeScreen';
 import WithdrawModal from '../screens/WithdrawModal';
 import { SwipeNavigator } from './SwipeNavigator';
 import {
+  backupSheetConfig,
   defaultScreenStackOptions,
   expandedAssetSheetConfig,
   nativeStackConfig,
@@ -263,15 +264,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen
         component={BackupSheet}
         name={Routes.BACKUP_SHEET}
-        options={{
-          cornerRadius: 30,
-          customStack: true,
-          isShortFormEnabled: true,
-          longFormHeight: 394,
-          onAppear: null,
-          shortFormHeight: 394,
-          startFromShortForm: true,
-        }}
+        {...backupSheetConfig}
       />
       <NativeStack.Screen
         component={ModalScreen}

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -1,24 +1,28 @@
 import { Keyboard, Platform, StatusBar } from 'react-native';
+import { SheetHandleFixedToTopHeight } from '../components/sheet';
 import { onDidPop, onWillPop } from './Navigation';
 import { appearListener } from './nativeStackHelpers';
+import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import { deviceUtils, safeAreaInsetValues } from '@rainbow-me/utils';
 
-export const expandedAssetSheetConfig = {
-  options: ({ route: { params = {} } }) => ({
-    allowsDragToDismiss: true,
-    allowsTapToDismiss: true,
-    backgroundOpacity: 0.7,
-    blocksBackgroundTouches: true,
-    cornerRadius: params.longFormHeight ? 39 : 30,
-    customStack: true,
-    gestureEnabled: true,
-    headerHeight: 25,
-    longFormHeight: params.longFormHeight,
-    onAppear: null,
-    scrollEnabled: true,
-    topOffset: safeAreaInsetValues.top + 5,
-  }),
-};
+export const sharedCoolModalTopOffset = safeAreaInsetValues.top + 5;
+
+const buildCoolModalConfig = params => ({
+  allowsDragToDismiss: true,
+  allowsTapToDismiss: true,
+  backgroundOpacity: 0.7,
+  blocksBackgroundTouches: true,
+  cornerRadius: params.longFormHeight ? 39 : 30,
+  customStack: true,
+  gestureEnabled: true,
+  headerHeight: params.headerHeight || 25,
+  ignoreBottomOffset: true,
+  isShortFormEnabled: params.isShortFormEnabled,
+  longFormHeight: params.longFormHeight,
+  onAppear: params.onAppear || null,
+  scrollEnabled: params.scrollEnabled,
+  topOffset: params.topOffset || sharedCoolModalTopOffset,
+});
 
 export const nativeStackConfig = {
   mode: 'modal',
@@ -48,25 +52,55 @@ export const nativeStackConfig = {
   },
 };
 
-export const savingsSheetConfig = {
+const backupSheetSizes = {
+  long:
+    deviceUtils.dimensions.height +
+    safeAreaInsetValues.bottom +
+    sharedCoolModalTopOffset +
+    SheetHandleFixedToTopHeight,
+  short: 394,
+};
+
+export const backupSheetConfig = {
+  options: ({ navigation, route }) => {
+    const { params: { longFormHeight, step, ...params } = {} } = route;
+
+    const heightForStep =
+      step === WalletBackupStepTypes.cloud ||
+      step === WalletBackupStepTypes.manual
+        ? backupSheetSizes.long
+        : backupSheetSizes.short;
+
+    if (longFormHeight !== heightForStep) {
+      navigation.setParams({
+        longFormHeight: heightForStep,
+      });
+    }
+
+    return buildCoolModalConfig({
+      ...params,
+      longFormHeight: heightForStep,
+    });
+  },
+};
+
+export const expandedAssetSheetConfig = {
   options: ({ route: { params = {} } }) => ({
-    allowsDragToDismiss: true,
-    cornerRadius: 39,
-    customStack: true,
-    headerHeight: 0,
-    ignoreBottomOffset: true,
-    isShortFormEnabled: false,
-    longFormHeight: params.longFormHeight,
-    topOffset: 0,
+    ...buildCoolModalConfig({
+      ...params,
+      scrollEnabled: true,
+    }),
   }),
 };
 
-export const sharedCoolModalConfig = {
-  options: {
-    customStack: true,
-    ignoreBottomOffset: true,
-    onAppear: null,
-  },
+export const savingsSheetConfig = {
+  options: ({ route: { params = {} } }) => ({
+    ...buildCoolModalConfig({
+      ...params,
+      headerHeight: 0,
+      topOffset: 0,
+    }),
+  }),
 };
 
 export const stackNavigationConfig = {


### PR DESCRIPTION
This allows us to create a config for the BackupSheet which has its height controlled by the route's current `step` param