### PR TITLE
Shorten proptypes error

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -29,24 +29,26 @@ if (
 
 global.storage = storage;
 
-const oldConsoleError = console.error;
+const SHORTEN_PROP_TYPES_ERROR = true;
 
-console.error = function() {
-  if (
-    typeof arguments[0] === 'string' &&
-    arguments[0].startsWith('Warning: Failed prop type')
-  ) {
-    console.log(
-      `PropTypes error in: ${arguments[0]
-        .match(/\w+.js:[0-9]+/g)
-        .slice(0, 6)
-        .join(' in ')}`
-    );
-    return;
-  }
-  oldConsoleError.apply(this, arguments);
-};
-
+if (SHORTEN_PROP_TYPES_ERROR) {
+  const oldConsoleError = console.error;
+  console.error = function() {
+    if (
+      typeof arguments[0] === 'string' &&
+      arguments[0].startsWith('Warning: Failed prop type')
+    ) {
+      console.log(
+        `PropTypes error in: ${arguments[0]
+          .match(/\w+.js:[0-9]+/g)
+          .slice(0, 6)
+          .join(' in ')}`
+      );
+      return;
+    }
+    oldConsoleError.apply(this, arguments);
+  };
+}
 if (typeof __dirname === 'undefined') global.__dirname = '/';
 if (typeof __filename === 'undefined') global.__filename = '';
 if (typeof process === 'undefined') {

--- a/shim.js
+++ b/shim.js
@@ -29,6 +29,21 @@ if (
 
 global.storage = storage;
 
+const oldConsoleError = console.error;
+
+console.error = function() {
+  if (arguments[0].startsWith('Warning: Failed prop type')) {
+    console.log(
+      `PropTypes error in: ${arguments[0]
+        .match(/\w+.js:[0-9]+/g)
+        .slice(0, 6)
+        .join(' in ')}`
+    );
+    return;
+  }
+  oldConsoleError.apply(this, arguments);
+};
+
 if (typeof __dirname === 'undefined') global.__dirname = '/';
 if (typeof __filename === 'undefined') global.__filename = '';
 if (typeof process === 'undefined') {

--- a/shim.js
+++ b/shim.js
@@ -32,7 +32,10 @@ global.storage = storage;
 const oldConsoleError = console.error;
 
 console.error = function() {
-  if (arguments[0].startsWith('Warning: Failed prop type')) {
+  if (
+    typeof arguments[0] === 'string' &&
+    arguments[0].startsWith('Warning: Failed prop type')
+  ) {
     console.log(
       `PropTypes error in: ${arguments[0]
         .match(/\w+.js:[0-9]+/g)

--- a/src/components/token-info/TokenInfoRow.js
+++ b/src/components/token-info/TokenInfoRow.js
@@ -17,10 +17,9 @@ function renderChild(child, index) {
   if (!child) return null;
 
   return (
-    <FlexItem marginHorizontal={space}>
+    <FlexItem key={`TokenInfoRow-${index}`} marginHorizontal={space}>
       {cloneElement(child, {
         align: index === 0 ? 'left' : 'right',
-        key: `TokenInfoRow-${index}`,
       })}
     </FlexItem>
   );

--- a/src/components/token-info/TokenInfoRow.js
+++ b/src/components/token-info/TokenInfoRow.js
@@ -18,7 +18,10 @@ function renderChild(child, index) {
 
   return (
     <FlexItem marginHorizontal={space}>
-      {cloneElement(child, { align: index === 0 ? 'left' : 'right' })}
+      {cloneElement(child, {
+        align: index === 0 ? 'left' : 'right',
+        key: `TokenInfoRow-${index}`,
+      })}
     </FlexItem>
   );
 }


### PR DESCRIPTION
```
PropTypes error in: TokenFamilyHeaderIcon.js:39 in TokenFamilyHeader.js:92 in View.js:34 in LayoutWithMargins.js:15 in TokenFamilyHeader.js:88 in View.js:34
```
instead of

```
Warning: Failed prop type: Invalid prop `align` of value `flex-end` supplied to `Flex`, expected one of ["baseline","center","end","start","stretch"].
    in Flex (at LayoutWithMargins.js:15)
    in ForwardRef(LayoutWithMargins) (created by Context.Consumer)
    in StyledNativeComponent (created by AssetListItemSkeleton___c5)
    in AssetListItemSkeleton___c5 (at AssetListItemSkeleton.js:142)
    in RCTView (at View.js:34)
    in View (at MaskedView.js:75)
    in RNCMaskedView (at MaskedView.js:74)
    in MaskedView (at AssetListItemSkeleton.js:164)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by AssetListItemSkeleton___c2)
    in AssetListItemSkeleton___c2 (at AssetListItemSkeleton.js:162)
    in AssetListItemSkeleton (at buildWalletSections.js:65)
    in RCTView (at View.js:34)
    in View (created by ViewRenderer)
    in ViewRenderer (created by RecyclerListView)
    in RCTView (at View.js:34)
    in View (created by ScrollComponent)
    in RCTView (at View.js:34)
    in View (created by ScrollComponent)
    in RCTScrollContentView (at ScrollView.js:1124)
    in RCTScrollView (at ScrollView.js:1235)
    in ScrollView (at ScrollView.js:1286)
    in ScrollView (created by ScrollComponent)
    in ScrollComponent (created by RecyclerListView)
    in RecyclerListView (at RecyclerAssetList.js:805)
    in RCTView (at View.js:34)
    in View (created by StickyContainer)
    in StickyContainer (at RecyclerAssetList.js:801)
    in RCTView (at View.js:34)
    in View (at RecyclerAssetList.js:795)
    in RecyclerAssetList (created by withProps(withProps(RecyclerAssetList)))
    in withProps(withProps(RecyclerAssetList)) (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (at AssetList.js:34)
    in AssetList
    in AssetList (at WalletScreen.js:127)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by FlexItem)
    in FlexItem (at FabWrapper.js:28)
    in FabWrapper (at WalletScreen.js:111)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by Page___c)
    in Page___c (at Page.js:20)
    in ForwardRef(Page) (created by Context.Consumer)
    in StyledNativeComponent (created by WalletScreen___c2)
    in WalletScreen___c2 (at WalletScreen.js:107)
    in WalletScreen (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (created by SceneView)
    in SceneView (created by ScrollPager)
    in RCTScrollContentView (at ScrollView.js:1124)
    in RCTScrollView (at ScrollView.js:1260)
    in ScrollView (at ScrollView.js:1286)
    in ScrollView (at createAnimatedComponent.js:307)
    in AnimatedComponent(ScrollView) (at createAnimatedComponent.js:318)
    in ForwardRef(AnimatedComponentWrapper) (at ScrollPager.js:175)
    in ScrollPager (at helpers.js:15)
    in ForwardRef(ScrollPagerWrapper) (at SwipeNavigator.js:14)
    in RCTView (at View.js:34)
    in View (created by TabView)
    in TabView (at MaterialTopTabView.tsx:50)
    in MaterialTopTabView (at createMaterialTopTabNavigator.tsx:41)
    in MaterialTopTabNavigator (at SwipeNavigator.js:20)
    in SwipeNavigator (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:221)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:220)
    in RCTView (at View.js:34)
    in View (at CardSheet.tsx:33)
    in ForwardRef(CardSheet) (at Card.tsx:563)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:545)
    in PanGestureHandler (at GestureHandlerNative.tsx:13)
    in PanGestureHandler (at Card.tsx:539)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:535)
    in RCTView (at View.js:34)
    in View (at Card.tsx:529)
    in Card (at CardContainer.tsx:189)
    in CardContainer (at CardStack.tsx:558)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:69)
    in MaybeScreen (at CardStack.tsx:551)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:48)
    in MaybeScreenContainer (at CardStack.tsx:461)
    in CardStack (at StackView.tsx:458)
    in KeyboardManager (at StackView.tsx:456)
    in SafeAreaProviderCompat (at StackView.tsx:453)
    in RCTView (at View.js:34)
    in View (at StackView.tsx:452)
    in StackView (at createStackNavigator.tsx:85)
    in StackNavigator (at Routes.ios.js:115)
    in MainNavigator (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:221)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:220)
    in RCTView (at View.js:34)
    in View (at CardSheet.tsx:33)
    in ForwardRef(CardSheet) (at Card.tsx:563)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:545)
    in PanGestureHandler (at GestureHandlerNative.tsx:13)
    in PanGestureHandler (at Card.tsx:539)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:535)
    in RCTView (at View.js:34)
    in View (at Card.tsx:529)
    in Card (at CardContainer.tsx:189)
    in CardContainer (at CardStack.tsx:558)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:69)
    in MaybeScreen (at CardStack.tsx:551)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:48)
    in MaybeScreenContainer (at CardStack.tsx:461)
    in CardStack (at StackView.tsx:458)
    in KeyboardManager (at StackView.tsx:456)
    in SafeAreaProviderCompat (at StackView.tsx:453)
    in RCTView (at View.js:34)
    in View (at StackView.tsx:452)
    in StackView (at createStackNavigator.tsx:85)
    in StackNavigator (at Routes.ios.js:152)
    in MainNavigatorWrapper (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (at NativeStackView.js:118)
    in RNCMScreen (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at screens.js:26)
    in ForwardRef(Screen) (at NativeStackView.js:65)
    in ScreenView (at NativeStackView.js:143)
    in RNCMScreenStack (at NativeStackView.js:141)
    in NativeStackView (at createNativeStackNavigator.js:41)
    in NativeStackNavigator (at Routes.ios.js:223)
    in NativeStackNavigator (at Routes.ios.js:307)
    in EnsureSingleNavigator (at BaseNavigationContainer.tsx:390)
    in ForwardRef(BaseNavigationContainer) (at NavigationContainer.tsx:91)
    in ThemeProvider (at NavigationContainer.tsx:90)
    in ForwardRef(NavigationContainer) (at Routes.ios.js:306)
    in AppContainerWithAnalytics
    in AppContainerWithAnalytics (at App.js:209)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by FlexItem)
    in FlexItem (at App.js:208)
    in Provider (at App.js:207)
    in RNCSafeAreaView (at src/index.tsx:31)
    in SafeAreaProvider (at App.js:206)
    in Portal (at App.js:205)
    in DevContextComponent (at DevContext.js:48)
    in DevContextWrapper (at App.js:204)
    in App (created by ConnectFunction)
    in ConnectFunction (created by withProps(withProps(Connect(App))))
    in withProps(withProps(Connect(App))) (created by ConnectFunction)
    in ConnectFunction (created by withProps(Connect(withProps(withProps(Connect(App))))))
    in withProps(Connect(withProps(withProps(Connect(App))))) (at CodePush.js:581)
    in CodePushComponent (at renderApplication.js:45)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:106)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:132)
    in AppContainer (at renderApplication.js:39)
[Thu Sep 03 2020 19:14:01.520]  LOG      Keychain: loaded string for key: rainbowAddressKey
[Thu Sep 03 2020 19:14:01.521]  LOG      addressFromKeychain wasnt set on settings so it is being loaded from loadAddress
[Thu Sep 03 2020 19:14:01.545]  LOG      walletsLoadState call #1
[Thu Sep 03 2020 19:14:01.550]  LOG      Migrations: ready to run migrations starting on number 6
[Thu Sep 03 2020 19:14:01.550]  LOG      Migrations: Nothing to run
[Thu Sep 03 2020 19:14:01.551]  LOG      done with migrations
[Thu Sep 03 2020 19:14:01.552]  LOG      Storage: error getting from local for key network
[Thu Sep 03 2020 19:14:01.960]  LOG      done loading network
[Thu Sep 03 2020 19:14:01.966]  LOG      Keychain: loaded string for key: rainbowAddressKey
[Thu Sep 03 2020 19:14:01.966]  LOG      walletInit returned  {"isNew": false, "walletAddress": "0xF0f21ab2012731542731df194cfF6c77d29cB31A"}
[Thu Sep 03 2020 19:14:01.967]  LOG      Load wallet global data
[Thu Sep 03 2020 19:14:01.971]  LOG      Storage: error getting from local for key nativeCurrency
[Thu Sep 03 2020 19:14:01.989]  LOG      Storage: error getting from local for key localContacts
[Thu Sep 03 2020 19:14:02.480]  LOG      Storage: error getting from local for key topMovers
[Thu Sep 03 2020 19:14:02.490]  LOG      Storage: error getting from local for key walletBalances
[Thu Sep 03 2020 19:14:02.660]  LOG      loaded global data...
[Thu Sep 03 2020 19:14:02.127]  LOG      updated settings address 0xF0f21ab2012731542731df194cfF6c77d29cB31A
[Thu Sep 03 2020 19:14:02.127]  LOG      Load wallet account data
[Thu Sep 03 2020 19:14:02.136]  LOG      Storage: error getting from local for key savingsToggle-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.137]  LOG      [CodePush] An unknown error occurred.
[Thu Sep 03 2020 19:14:02.137]  LOG      [CodePush] 400: An update check must include a valid deployment key - please check that your app has been configured correctly. To view available deployment keys, run 'code-push deployment ls <appName> -k'.
[Thu Sep 03 2020 19:14:02.138]  LOG      Storage: error getting from local for key smallBalanceToggle-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.140]  LOG      Storage: error getting from local for key openInvestmentCards-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.140]  LOG      Storage: error getting from local for key openFamilies-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.164]  LOG      Storage: error getting from local for key hiddenCoins-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.164]  LOG      Storage: error getting from local for key pinnedCoins-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.207]  LOG      Storage: error getting from local for key showcaseTokens-0xf0f21ab2012731542731df194cff6c77d29cb31a-mainnet
[Thu Sep 03 2020 19:14:02.416]  ERROR    Warning: Failed prop type: Invalid prop `style` of type `array` supplied to `ShadowStack`, expected `object`.
    in ShadowStack (at TokenFamilyHeaderIcon.js:39)
    in TokenFamilyHeaderIcon (at TokenFamilyHeader.js:92)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by Flex)
    in Flex (at LayoutWithMargins.js:15)
    in ForwardRef(LayoutWithMargins) (created by Context.Consumer)
    in StyledNativeComponent (created by RowWithMargins)
    in RowWithMargins (at TokenFamilyHeader.js:88)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by TokenFamilyHeader___c2)
    in TokenFamilyHeader___c2 (at TokenFamilyHeader.js:87)
    in Button (at NativeButton.js:65)
    in ForwardRef(NativeButton) (at ButtonPressAnimation.ios.js:387)
    in ButtonPressAnimation (at TokenFamilyHeader.js:82)
    in TokenFamilyHeader (at TokenFamilyWrap.js:67)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by TokenFamilyWrap___c)
    in TokenFamilyWrap___c (at TokenFamilyWrap.js:65)
    in TokenFamilyWrap (at CollectibleTokenFamily.js:33)
    in CollectibleTokenFamily (at buildWalletSections.js:71)
    in RCTView (at View.js:34)
    in View (created by ViewRenderer)
    in ViewRenderer (created by RecyclerListView)
    in RCTView (at View.js:34)
    in View (created by ScrollComponent)
    in RCTView (at View.js:34)
    in View (created by ScrollComponent)
    in RCTScrollContentView (at ScrollView.js:1124)
    in RCTScrollView (at ScrollView.js:1235)
    in ScrollView (at ScrollView.js:1286)
    in ScrollView (created by ScrollComponent)
    in ScrollComponent (created by RecyclerListView)
    in RecyclerListView (at RecyclerAssetList.js:805)
    in RCTView (at View.js:34)
    in View (created by StickyContainer)
    in StickyContainer (at RecyclerAssetList.js:801)
    in RCTView (at View.js:34)
    in View (at RecyclerAssetList.js:795)
    in RecyclerAssetList (created by withProps(withProps(RecyclerAssetList)))
    in withProps(withProps(RecyclerAssetList)) (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (created by ConnectFunction)
    in ConnectFunction (at AssetList.js:34)
    in AssetList
    in AssetList (at WalletScreen.js:127)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by FlexItem)
    in FlexItem (at FabWrapper.js:28)
    in FabWrapper (at WalletScreen.js:111)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by Page___c)
    in Page___c (at Page.js:20)
    in ForwardRef(Page) (created by Context.Consumer)
    in StyledNativeComponent (created by WalletScreen___c2)
    in WalletScreen___c2 (at WalletScreen.js:107)
    in WalletScreen (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (created by SceneView)
    in SceneView (created by ScrollPager)
    in RCTScrollContentView (at ScrollView.js:1124)
    in RCTScrollView (at ScrollView.js:1260)
    in ScrollView (at ScrollView.js:1286)
    in ScrollView (at createAnimatedComponent.js:307)
    in AnimatedComponent(ScrollView) (at createAnimatedComponent.js:318)
    in ForwardRef(AnimatedComponentWrapper) (at ScrollPager.js:175)
    in ScrollPager (at helpers.js:15)
    in ForwardRef(ScrollPagerWrapper) (at SwipeNavigator.js:14)
    in RCTView (at View.js:34)
    in View (created by TabView)
    in TabView (at MaterialTopTabView.tsx:50)
    in MaterialTopTabView (at createMaterialTopTabNavigator.tsx:41)
    in MaterialTopTabNavigator (at SwipeNavigator.js:20)
    in SwipeNavigator (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:221)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:220)
    in RCTView (at View.js:34)
    in View (at CardSheet.tsx:33)
    in ForwardRef(CardSheet) (at Card.tsx:563)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:545)
    in PanGestureHandler (at GestureHandlerNative.tsx:13)
    in PanGestureHandler (at Card.tsx:539)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:535)
    in RCTView (at View.js:34)
    in View (at Card.tsx:529)
    in Card (at CardContainer.tsx:189)
    in CardContainer (at CardStack.tsx:558)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:69)
    in MaybeScreen (at CardStack.tsx:551)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:48)
    in MaybeScreenContainer (at CardStack.tsx:461)
    in CardStack (at StackView.tsx:458)
    in KeyboardManager (at StackView.tsx:456)
    in SafeAreaProviderCompat (at StackView.tsx:453)
    in RCTView (at View.js:34)
    in View (at StackView.tsx:452)
    in StackView (at createStackNavigator.tsx:85)
    in StackNavigator (at Routes.ios.js:115)
    in MainNavigator (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:221)
    in RCTView (at View.js:34)
    in View (at CardContainer.tsx:220)
    in RCTView (at View.js:34)
    in View (at CardSheet.tsx:33)
    in ForwardRef(CardSheet) (at Card.tsx:563)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:545)
    in PanGestureHandler (at GestureHandlerNative.tsx:13)
    in PanGestureHandler (at Card.tsx:539)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at Card.tsx:535)
    in RCTView (at View.js:34)
    in View (at Card.tsx:529)
    in Card (at CardContainer.tsx:189)
    in CardContainer (at CardStack.tsx:558)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:69)
    in MaybeScreen (at CardStack.tsx:551)
    in RCTView (at View.js:34)
    in View (at Screens.tsx:48)
    in MaybeScreenContainer (at CardStack.tsx:461)
    in CardStack (at StackView.tsx:458)
    in KeyboardManager (at StackView.tsx:456)
    in SafeAreaProviderCompat (at StackView.tsx:453)
    in RCTView (at View.js:34)
    in View (at StackView.tsx:452)
    in StackView (at createStackNavigator.tsx:85)
    in StackNavigator (at Routes.ios.js:152)
    in MainNavigatorWrapper (at SceneView.tsx:122)
    in StaticContainer
    in StaticContainer (at SceneView.tsx:115)
    in EnsureSingleNavigator (at SceneView.tsx:114)
    in SceneView (at useDescriptors.tsx:150)
    in RCTView (at View.js:34)
    in View (at NativeStackView.js:118)
    in RNCMScreen (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (at screens.js:26)
    in ForwardRef(Screen) (at NativeStackView.js:65)
    in ScreenView (at NativeStackView.js:143)
    in RNCMScreenStack (at NativeStackView.js:141)
    in NativeStackView (at createNativeStackNavigator.js:41)
    in NativeStackNavigator (at Routes.ios.js:223)
    in NativeStackNavigator (at Routes.ios.js:307)
    in EnsureSingleNavigator (at BaseNavigationContainer.tsx:390)
    in ForwardRef(BaseNavigationContainer) (at NavigationContainer.tsx:91)
    in ThemeProvider (at NavigationContainer.tsx:90)
    in ForwardRef(NavigationContainer) (at Routes.ios.js:306)
    in AppContainerWithAnalytics
    in AppContainerWithAnalytics (at App.js:209)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in StyledNativeComponent (created by FlexItem)
    in FlexItem (at App.js:208)
    in Provider (at App.js:207)
    in RNCSafeAreaView (at src/index.tsx:31)
    in SafeAreaProvider (at App.js:206)
    in Portal (at App.js:205)
    in DevContextComponent (at DevContext.js:48)
    in DevContextWrapper (at App.js:204)
    in App (created by ConnectFunction)
    in ConnectFunction (created by withProps(withProps(Connect(App))))
    in withProps(withProps(Connect(App))) (created by ConnectFunction)
    in ConnectFunction (created by withProps(Connect(withProps(withProps(Connect(App))))))
    in withProps(Connect(withProps(withProps(Connect(App))))) (at CodePush.js:581)
    in CodePushComponent (at renderApplication.js:45)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:106)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:132)
    in AppContainer (at renderApplication.js:39)
```
I think that our console might be less trashy with this