### PR TITLE
Show charts only if contains more than 5 points

### DIFF
--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -116,8 +116,8 @@ export default function ChartExpandedState({ asset }) {
   const showChart = useMemo(
     () =>
       chartExpandedAvailable &&
-      (throttledPoints?.points.length !== 0 ||
-        throttledPoints?.points.length !== 0 ||
+      (throttledPoints?.points.length > 5 ||
+        throttledPoints?.points.length > 5 ||
         (fetchingCharts && !isFetchingInitially)),
     [fetchingCharts, isFetchingInitially, throttledPoints]
   );


### PR DESCRIPTION
Sometimes data's fallback is very poor. I think that if have less (or eq) than 5 points it's pointless (pun not intended) to display charts because data are very not reliable nor regular and it's better not to show anything 