### PR TITLE
Add includeExtremes to interpolations

### DIFF
--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -46,7 +46,7 @@ const traverseData = (prev, data) => {
   ) {
     return prev;
   }
-  const points = monotoneCubicInterpolation(filtered)(100);
+  const points = monotoneCubicInterpolation(filtered)(100, true);
   return {
     nativePoints: filtered,
     points,

--- a/src/react-native-animated-charts/src/ChartProvider.js
+++ b/src/react-native-animated-charts/src/ChartProvider.js
@@ -9,6 +9,7 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'react-native-reanimated';
 import ChartContext from './ChartContext';
+import { findYExtremes } from './helpers';
 import useReactiveSharedValue from './useReactiveSharedValue';
 
 function impactHeavy() {
@@ -20,17 +21,7 @@ function impactHeavy() {
 const android = Platform.OS === 'android';
 
 const parse = data => {
-  let smallestY = null;
-  let greatestY = null;
-  for (const d of data) {
-    if (d.y !== undefined && (smallestY === null || d.y < smallestY.y)) {
-      smallestY = d;
-    }
-
-    if (d.y !== undefined && (greatestY === null || d.y > greatestY.y)) {
-      greatestY = d;
-    }
-  }
+  const { greatestY, smallestY } = findYExtremes(data);
   const smallestX = data[0];
   const greatestX = data[data.length - 1];
   return [

--- a/src/react-native-animated-charts/src/helpers.js
+++ b/src/react-native-animated-charts/src/helpers.js
@@ -1,0 +1,54 @@
+export function findYExtremes(data) {
+  let smallestY = null;
+  let greatestY = null;
+  for (const d of data) {
+    if (d.y !== undefined && (smallestY === null || d.y < smallestY.y)) {
+      smallestY = d;
+    }
+
+    if (d.y !== undefined && (greatestY === null || d.y > greatestY.y)) {
+      greatestY = d;
+    }
+  }
+  return {
+    greatestY,
+    smallestY,
+  };
+}
+
+export function addExtremesIfNeeded(res, data, includeExtremes) {
+  if (includeExtremes) {
+    const { greatestY, smallestY } = findYExtremes(data);
+
+    const [ex1, ex2] = [greatestY, smallestY].sort((a, b) => a.x < b.x);
+    let added1 = false;
+    let added2 = false;
+
+    const newRes = [];
+    for (let d of res) {
+      if (
+        (newRes.length === 0 || newRes[newRes.length - 1].x < ex1.x) &&
+        ex1.x < d.x
+      ) {
+        added1 = true;
+        newRes.push(ex1);
+      }
+      if (
+        (newRes.length === 0 || newRes[newRes.length - 1].x < ex2.x) &&
+        ex2.x < d.x
+      ) {
+        added2 = true;
+        newRes.push(ex2);
+      }
+      newRes.push(d);
+    }
+    if (!added1) {
+      newRes.push(ex1);
+    }
+    if (!added2) {
+      newRes.push(ex2);
+    }
+    return newRes;
+  }
+  return res;
+}

--- a/src/react-native-animated-charts/src/interpolations/bSplineInterpolation.js
+++ b/src/react-native-animated-charts/src/interpolations/bSplineInterpolation.js
@@ -1,3 +1,5 @@
+import { addExtremesIfNeeded } from '../helpers';
+
 class BSpline {
   constructor(points, degree, copy) {
     if (copy) {
@@ -180,11 +182,15 @@ export default function bSplineInterpolation(data, degree = 3) {
   const parsed = data.map(({ x, y }) => [x, y]);
   const spline = new BSpline(parsed, degree, true);
 
-  return t => {
+  return (range, includeExtremes) => {
     const res = [];
-    for (let i = 0; i < t; i++) {
-      res.push(spline.calcAt(i / (t - 1)));
+    for (let i = 0; i < range; i++) {
+      res.push(spline.calcAt(i / (range - 1)));
     }
-    return res.map(([x, y]) => ({ x, y }));
+    return addExtremesIfNeeded(
+      res.map(([x, y]) => ({ x, y })),
+      data,
+      includeExtremes
+    );
   };
 }

--- a/src/react-native-animated-charts/src/interpolations/monotoneCubicInterpolation.js
+++ b/src/react-native-animated-charts/src/interpolations/monotoneCubicInterpolation.js
@@ -1,3 +1,5 @@
+import { addExtremesIfNeeded } from '../helpers';
+
 export default function monotoneCubicInterpolation(data) {
   if (!data || data.length === 0) {
     return () => [];
@@ -102,7 +104,7 @@ export default function monotoneCubicInterpolation(data) {
   const _y = y.slice(0, n);
   const _m = m;
 
-  return range => {
+  return (range, includeExtremes) => {
     const firstValue = _x[0];
     const lastValue = _x[_x.length - 1];
     const res = [];
@@ -135,6 +137,6 @@ export default function monotoneCubicInterpolation(data) {
       res.push({ x: interpolatedValue, y });
     }
 
-    return res;
+    return addExtremesIfNeeded(res, data, includeExtremes);
   };
 }


### PR DESCRIPTION
I observed that after interpolating it's possible that max and min value are no longer extremes after performing interpolations. Thus I added a parameter to persist it and extremes add after creating output result for drawing chart.

This issue is especially visible in stablecoins
Before:
![image](https://user-images.githubusercontent.com/25709300/92314432-0becc300-efe0-11ea-98f7-1e8eb339300a.png)

After:
![image](https://user-images.githubusercontent.com/25709300/92314446-23c44700-efe0-11ea-8a89-3d41745fbdb7.png)
