### PR TITLE
Reuse wallet created during import

### DIFF
--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -49,7 +49,8 @@ export default function useInitializeWallet() {
       color = null,
       name = null,
       shouldRunMigrations = false,
-      overwrite = false
+      overwrite = false,
+      checkedWallet = null
     ) => {
       try {
         logger.sentry('Start wallet setup');
@@ -76,7 +77,8 @@ export default function useInitializeWallet() {
           seedPhrase,
           color,
           name,
-          overwrite
+          overwrite,
+          checkedWallet
         );
 
         logger.sentry('walletInit returned ', {

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -176,13 +176,20 @@ export const walletInit = async (
   seedPhrase = null,
   color = null,
   name = null,
-  overwrite = false
+  overwrite = false,
+  checkedWallet = null
 ): Promise<WalletInitialized> => {
   let walletAddress = null;
   let isNew = false;
   // Importing a seedphrase
   if (!isEmpty(seedPhrase)) {
-    const wallet = await createWallet(seedPhrase, color, name, overwrite);
+    const wallet = await createWallet(
+      seedPhrase,
+      color,
+      name,
+      overwrite,
+      checkedWallet
+    );
     walletAddress = wallet?.address;
     return { isNew, walletAddress };
   }
@@ -480,14 +487,16 @@ export const createWallet = async (
   seed: null | EthereumSeed = null,
   color: null | number = null,
   name: null | string = null,
-  overwrite: boolean = false
+  overwrite: boolean = false,
+  checkedWallet: null | EthereumWalletFromSeed = null
 ): Promise<null | EthereumWallet> => {
   const isImported = !!seed;
   logger.sentry('Creating wallet, isImported?', isImported);
   const walletSeed = seed || generateSeedPhrase();
   let addresses: RainbowAccount[] = [];
   try {
-    const { hdnode, isHDWallet, type, wallet } = getWallet(walletSeed);
+    const { hdnode, isHDWallet, type, wallet } =
+      checkedWallet || getWallet(walletSeed);
     if (!wallet) return null;
     logger.sentry('[createWallet] - getWallet from seed');
 

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -125,6 +125,7 @@ export default function ImportSeedPhraseSheet() {
   const [color, setColor] = useState(null);
   const [name, setName] = useState(null);
   const [busy, setBusy] = useState(false);
+  const [checkedWallet, setCheckedWallet] = useState(null);
   const [resolvedAddress, setResolvedAddress] = useState(null);
   const [startAnalyticsTimeout] = useTimeout();
   const wasImporting = usePrevious(isImporting);
@@ -208,7 +209,8 @@ export default function ImportSeedPhraseSheet() {
       try {
         setBusy(true);
         setTimeout(async () => {
-          const { wallet } = getWallet(input);
+          const { hdnode, isHDWallet, type, wallet } = getWallet(input);
+          setCheckedWallet({ hdnode, isHDWallet, type, wallet });
           const ens = await web3Provider.lookupAddress(wallet?.address);
           if (ens && ens !== input) {
             name = ens;
@@ -247,7 +249,14 @@ export default function ImportSeedPhraseSheet() {
     if (!wasImporting && isImporting) {
       startAnalyticsTimeout(async () => {
         const input = resolvedAddress ? resolvedAddress : seedPhrase.trim();
-        initializeWallet(input, color, name ? name : '')
+        initializeWallet(
+          input,
+          color,
+          name ? name : '',
+          false,
+          false,
+          checkedWallet
+        )
           .then(success => {
             handleSetImporting(false);
             if (success) {
@@ -279,6 +288,7 @@ export default function ImportSeedPhraseSheet() {
       }, 50);
     }
   }, [
+    checkedWallet,
     color,
     hadPreviousAddressWithValue,
     handleSetImporting,


### PR DESCRIPTION
https://linear.app/rainbow/issue/RAI-775/reuse-the-already-created-wallet-object-for-ens-lookup-during