### PR TITLE
Create new "autoJumpToNewHeight" option for cool-modals

### DIFF
--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -10,7 +10,6 @@ export const sharedCoolModalTopOffset = safeAreaInsetValues.top + 5;
 const buildCoolModalConfig = params => ({
   allowsDragToDismiss: true,
   allowsTapToDismiss: true,
-  autoJumpToNewHeight: params.autoJumpToNewHeight,
   backgroundOpacity: 0.7,
   blocksBackgroundTouches: true,
   cornerRadius: params.longFormHeight ? 39 : 30,
@@ -22,6 +21,7 @@ const buildCoolModalConfig = params => ({
   longFormHeight: params.longFormHeight,
   onAppear: params.onAppear || null,
   scrollEnabled: params.scrollEnabled,
+  TEMPORARY_autoJumpToNewHeight: params.TEMPORARY_autoJumpToNewHeight,
   topOffset: params.topOffset || sharedCoolModalTopOffset,
 });
 
@@ -80,8 +80,8 @@ export const backupSheetConfig = {
 
     return buildCoolModalConfig({
       ...params,
-      autoJumpToNewHeight: true,
       longFormHeight: heightForStep,
+      TEMPORARY_autoJumpToNewHeight: true,
     });
   },
 };

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -10,6 +10,7 @@ export const sharedCoolModalTopOffset = safeAreaInsetValues.top + 5;
 const buildCoolModalConfig = params => ({
   allowsDragToDismiss: true,
   allowsTapToDismiss: true,
+  autoJumpToNewHeight: params.autoJumpToNewHeight,
   backgroundOpacity: 0.7,
   blocksBackgroundTouches: true,
   cornerRadius: params.longFormHeight ? 39 : 30,
@@ -79,6 +80,7 @@ export const backupSheetConfig = {
 
     return buildCoolModalConfig({
       ...params,
+      autoJumpToNewHeight: true,
       longFormHeight: heightForStep,
     });
   },

--- a/src/react-native-cool-modals/NativeStackView.js
+++ b/src/react-native-cool-modals/NativeStackView.js
@@ -28,7 +28,6 @@ function ScreenView({ colors, descriptors, navigation, route, state }) {
     allowsDragToDismiss,
     allowsTapToDismiss,
     anchorModalToLongForm,
-    autoJumpToNewHeight,
     backgroundColor,
     backgroundOpacity,
     contentStyle,
@@ -48,6 +47,7 @@ function ScreenView({ colors, descriptors, navigation, route, state }) {
     stackAnimation,
     stackPresentation = 'push',
     startFromShortForm,
+    TEMPORARY_autoJumpToNewHeight,
     topOffset,
     transitionDuration,
   } = options;
@@ -72,21 +72,27 @@ function ScreenView({ colors, descriptors, navigation, route, state }) {
     []
   );
 
-  // When 'autoJumpToNewHeight' option is enabled, automatically "jump" towards either
+  // When 'TEMPORARY_autoJumpToNewHeight' option is enabled, automatically "jump" towards either
   // the new "longFormHeight" or new "shortFormHeight"
   useEffect(() => {
-    if (autoJumpToNewHeight && longFormHeight !== prevLongFormHeight) {
+    if (
+      TEMPORARY_autoJumpToNewHeight &&
+      longFormHeight !== prevLongFormHeight
+    ) {
       setImmediate(context.jumpToLong);
-    } else if (autoJumpToNewHeight && shortFormHeight !== prevShortFormHeight) {
+    } else if (
+      TEMPORARY_autoJumpToNewHeight &&
+      shortFormHeight !== prevShortFormHeight
+    ) {
       setImmediate(context.jumpToShort);
     }
   }, [
-    autoJumpToNewHeight,
     context,
     longFormHeight,
     prevLongFormHeight,
     prevShortFormHeight,
     shortFormHeight,
+    TEMPORARY_autoJumpToNewHeight,
   ]);
 
   return (


### PR DESCRIPTION
When `autoJumpToNewHeight` is enabled, the cool-modal will automatically `jumpToLong` whenever `longFormHeight` changes, or `jumpToShort` whenever `shortFormHeight` changes