### PR TITLE
Tweak InteractionManager to finish all interactions at some point

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 // eslint-disable-next-line import/default
 import ReactNative from 'react-native';
 import Storage from 'react-native-storage';
+import logger from 'logger';
 
 const storage = new Storage({
   defaultExpires: null,
@@ -82,6 +83,7 @@ if (!ReactNative.InteractionManager._shimmed) {
     if (finishAutomatically) {
       setTimeout(() => {
         ReactNative.InteractionManager.clearInteractionHandle(handle);
+        logger.sentry(`Interaction finished automatically`);
       }, 1000);
     }
     return handle;

--- a/shim.js
+++ b/shim.js
@@ -71,6 +71,25 @@ if (typeof localStorage !== 'undefined') {
   localStorage.debug = isDev ? '*' : '';
 }
 
+if (!ReactNative.InteractionManager._shimmed) {
+  const oldCreateInteractionHandle =
+    ReactNative.InteractionManager.createInteractionHandle;
+
+  ReactNative.InteractionManager.createInteractionHandle = function(
+    finishAutomatically = true
+  ) {
+    const handle = oldCreateInteractionHandle();
+    if (finishAutomatically) {
+      setTimeout(() => {
+        ReactNative.InteractionManager.clearInteractionHandle(handle);
+      }, 1000);
+    }
+    return handle;
+  };
+
+  ReactNative.InteractionManager._shimmed = true;
+}
+
 // If using the crypto shim, uncomment the following line to ensure
 // crypto is loaded first, so it can populate global.crypto
 // eslint-disable-next-line import/no-commonjs

--- a/shim.js
+++ b/shim.js
@@ -84,7 +84,7 @@ if (!ReactNative.InteractionManager._shimmed) {
       setTimeout(() => {
         ReactNative.InteractionManager.clearInteractionHandle(handle);
         logger.sentry(`Interaction finished automatically`);
-      }, 1000);
+      }, 2000);
     }
     return handle;
   };


### PR DESCRIPTION
I observed that InteractionManager sometimes has some uncleaned tasks. Most likely, it's a bug made us or some library. 
However, I think it's worth to assure that every interaction won't block the manager for longer than 2 seconds. I assume that none of our interactions/animations takes longer than 2 seconds and if it does, it's a bug. 