### PR TITLE
Fix balance when creating new wallet

### DIFF
--- a/src/components/change-wallet/AddressRow.js
+++ b/src/components/change-wallet/AddressRow.js
@@ -155,7 +155,7 @@ export default function AddressRow({ data, editMode, onPress, onEditWallet }) {
                 />
               )}
               <BottomRowText style={sx.bottomRowText}>
-                {cleanedUpBalance} ETH
+                {cleanedUpBalance || 0} ETH
               </BottomRowText>
             </ColumnWithMargins>
           </Row>


### PR DESCRIPTION
After creating a new wallet the balance was showing ` ETH` when it should be `0 ETH`

Before the fix:
![IMG_9620](https://user-images.githubusercontent.com/1247834/93287139-c467f300-f7a6-11ea-801c-389d6d4fdc74.jpg)


After the fix:
![IMG_9621](https://user-images.githubusercontent.com/1247834/93287129-bdd97b80-f7a6-11ea-9a31-3129c806b83c.jpg)



