### PR TITLE
Ultimately solve crashes related to cool-modals

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -75,7 +75,7 @@ target 'Rainbow' do
   pod 'Permission-Camera', :path => "#{permissions_path}/Camera.podspec"
   pod 'Permission-FaceID', :path => "#{permissions_path}/FaceID.podspec"
 
-  pod "PanModal", :git => 'https://github.com/osdnk/PanModal', :commit => 'eb9ff73833957de5c7ff30ccf08d3037266783d8'
+  pod "PanModal", :git => 'https://github.com/osdnk/PanModal', :commit => '4588162c55cc0e70fecafbf6af002340b6ae27e3'
 
   pod 'Shimmer'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -595,7 +595,7 @@ DEPENDENCIES:
   - libwebp
   - lottie-ios (from `../node_modules/lottie-ios`)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
-  - PanModal (from `https://github.com/osdnk/PanModal`, commit `eb9ff73833957de5c7ff30ccf08d3037266783d8`)
+  - PanModal (from `https://github.com/osdnk/PanModal`, commit `4588162c55cc0e70fecafbf6af002340b6ae27e3`)
   - Permission-Camera (from `../node_modules/react-native-permissions/ios/Camera.podspec`)
   - Permission-FaceID (from `../node_modules/react-native-permissions/ios/FaceID.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -732,7 +732,7 @@ EXTERNAL SOURCES:
   lottie-react-native:
     :path: "../node_modules/lottie-react-native"
   PanModal:
-    :commit: eb9ff73833957de5c7ff30ccf08d3037266783d8
+    :commit: 4588162c55cc0e70fecafbf6af002340b6ae27e3
     :git: https://github.com/osdnk/PanModal
   Permission-Camera:
     :path: "../node_modules/react-native-permissions/ios/Camera.podspec"
@@ -879,7 +879,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   PanModal:
-    :commit: eb9ff73833957de5c7ff30ccf08d3037266783d8
+    :commit: 4588162c55cc0e70fecafbf6af002340b6ae27e3
     :git: https://github.com/osdnk/PanModal
 
 SPEC CHECKSUMS:
@@ -1003,6 +1003,6 @@ SPEC CHECKSUMS:
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: cd4784bce0a88c44a91214da329d3a23a704f37d
+PODFILE CHECKSUM: 2c449f1173395389924e3a5f471c85e5d2a184c2
 
 COCOAPODS: 1.9.1

--- a/src/react-native-cool-modals/ios/UIViewController+slack.swift
+++ b/src/react-native-cool-modals/ios/UIViewController+slack.swift
@@ -1,34 +1,28 @@
 
 import PanModal
 
-class PossiblyTouchesPassableUIView: UIView {
-  var oldClass: AnyClass?
 
-  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    if (self.subviews[1].frame.contains(point)) {
-      return super.hitTest(point, with: event)
+public extension UIView {
+  @objc func newHitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    if (self.subviews.count == 2 && self.subviews[1] is PanModal.PanContainerView) {
+      let container = self.subviews[1]
+      if (container.subviews.count == 1 && container.subviews[0] is RNCMScreenView) {
+        let screen = container.subviews[0]
+        let hacked = ((screen.reactViewController() as? RNCMScreen)?.parentVC() as? PanModalViewController)?.hacked ?? false
+        if hacked {
+          if (self.subviews[1].frame.contains(point)) {
+            return self.subviews[1].hitTest(point, with: event)
+          }
+          return nil
+        }
+      }
     }
-    return nil
-  }
-
-  func makeOldClass() {
-    if self.oldClass != nil {
-      let oldClassMem: AnyClass = self.oldClass!
-      self.oldClass = nil
-      object_setClass(self, oldClassMem)
-    }
-  }
-
-  override func didMoveToWindow() {
-    if self.window == nil {
-      makeOldClass()
-    }
-    super.didMoveToWindow()
+    return self.newHitTest(point, with: event)
   }
 }
 
 class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSupport {
-
+  static var swizzled = false
   var config : RNCMScreenView?
   var length: CGFloat = 0
   var topAnchor: NSLayoutYAxisAnchor = NSLayoutYAxisAnchor.init()
@@ -81,9 +75,7 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
 
 
   @objc func unhackParent() {
-    if self.ppview is PossiblyTouchesPassableUIView {
-      (ppview as! PossiblyTouchesPassableUIView).makeOldClass()
-    }
+    self.hacked = false
     self.ppview = nil
   }
 
@@ -105,12 +97,17 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
 
 
   var hacked = false
+  var originalMethod: Method? = nil
   func hackParent() {
     hacked = true
     self.ppview = config!.superview!.superview!
     let poldClass: AnyClass = type(of: self.ppview!)
-    object_setClass(self.ppview!, PossiblyTouchesPassableUIView.self);
-    (self.ppview as! PossiblyTouchesPassableUIView).oldClass = poldClass
+    if !PanModalViewController.swizzled {
+      self.originalMethod = class_getInstanceMethod(poldClass, #selector(UIView.hitTest(_:with:)))
+      let swizzledMethod = class_getInstanceMethod(poldClass, #selector(UIView.newHitTest(_:with:)))
+      method_exchangeImplementations(self.originalMethod!, swizzledMethod!)
+      PanModalViewController.swizzled = true
+    }
   }
 
   var cornerRadius: CGFloat {

--- a/src/react-native-cool-modals/ios/UIViewController+slack.swift
+++ b/src/react-native-cool-modals/ios/UIViewController+slack.swift
@@ -4,7 +4,7 @@ import PanModal
 
 public extension UIView {
   @objc func newHitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    if (self.subviews.count == 2 && self.subviews[1] is PanModal.PanContainerView) {
+    if (self.superview!.superview == nil && self.subviews.count == 2 && self.subviews[1] is PanModal.PanContainerView) {
       let container = self.subviews[1]
       if (container.subviews.count == 1 && container.subviews[0] is RNCMScreenView) {
         let screen = container.subviews[0]


### PR DESCRIPTION
I have observed that using `object_setClass` leads to a ton of crashing because of some internal inconsistency in UIKit. 
Indeed, it's a bit hacky so I decided to remove this hack in favor of overriding `hitTest` with the method's swizzling. It doesn't have the impact unless the `hacked` flag is set (it happens only for screen that is dismissing to allow scrolling area under the screen) so is a no-op in the rest of usages. 