### PR TITLE
Disable TurboModules excluding Native Reanimated

### DIFF
--- a/ios/Rainbow/AppDelegate.mm
+++ b/ios/Rainbow/AppDelegate.mm
@@ -100,9 +100,6 @@ RCT_EXPORT_METHOD(hideAnimated) {
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  #ifndef DISABLE_REANIMATED
-  RCTEnableTurboModule(YES);
-  #endif
   #if DEBUG
     InitializeFlipper(application);
   #endif

--- a/patches/react-native+0.63.2.patch
+++ b/patches/react-native+0.63.2.patch
@@ -56,22 +56,18 @@ index b3b1135..fd9831a 100644
      const legacyModule = NativeModules[name];
      if (legacyModule != null) {
 diff --git a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
-index d8938d7..b2ea76b 100644
+index d8938d7..06e01c3 100644
 --- a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
 +++ b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
-@@ -621,10 +621,10 @@ - (void)updateModuleWithInstance:(id<RCTBridgeModule>)instance
-   NSArray *moduleClassesCopy = [moduleClasses copy];
-   NSMutableArray<RCTModuleData *> *moduleDataByID = [NSMutableArray arrayWithCapacity:moduleClassesCopy.count];
-   for (Class moduleClass in moduleClassesCopy) {
--    if (RCTTurboModuleEnabled() && [moduleClass conformsToProtocol:@protocol(RCTTurboModule)]) {
-+    NSString *moduleName = RCTBridgeModuleNameForClass(moduleClass);
-+    if (RCTTurboModuleEnabled() && ![moduleName isEqualToString:@"NativeAnimatedModule"] && [moduleClass conformsToProtocol:@protocol(RCTTurboModule)]) {
-       continue;
-     }
--    NSString *moduleName = RCTBridgeModuleNameForClass(moduleClass);
+@@ -462,7 +462,7 @@ - (id)moduleForName:(NSString *)moduleName
  
-     // Check for module name collisions
-     RCTModuleData *moduleData = _moduleDataByName[moduleName];
+ - (id)moduleForName:(NSString *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad
+ {
+-  if (RCTTurboModuleEnabled() && _turboModuleLookupDelegate) {
++  if ((RCTTurboModuleEnabled() || [moduleName  isEqual: @"ReanimatedModule"]) && _turboModuleLookupDelegate) {
+     const char *moduleNameCStr = [moduleName UTF8String];
+     if (lazilyLoad || [_turboModuleLookupDelegate moduleIsInitialized:moduleNameCStr]) {
+       id<RCTTurboModule> module = [_turboModuleLookupDelegate moduleForName:moduleNameCStr warnOnLookupFailure:NO];
 diff --git a/node_modules/react-native/React/Views/RCTView.m b/node_modules/react-native/React/Views/RCTView.m
 index a5117be..59108bb 100644
 --- a/node_modules/react-native/React/Views/RCTView.m

--- a/patches/react-native+0.63.2.patch
+++ b/patches/react-native+0.63.2.patch
@@ -1,13 +1,3 @@
-diff --git a/node_modules/react-native/Libraries/Animated/src/NativeAnimatedModule.js b/node_modules/react-native/Libraries/Animated/src/NativeAnimatedModule.js
-index fc76ec1..8895b0f 100644
---- a/node_modules/react-native/Libraries/Animated/src/NativeAnimatedModule.js
-+++ b/node_modules/react-native/Libraries/Animated/src/NativeAnimatedModule.js
-@@ -63,4 +63,4 @@ export interface Spec extends TurboModule {
-   +removeListeners: (count: number) => void;
- }
- 
--export default (TurboModuleRegistry.get<Spec>('NativeAnimatedModule'): ?Spec);
-+export default (TurboModuleRegistry.get<Spec>('NativeAnimatedModule', true): ?Spec);
 diff --git a/node_modules/react-native/Libraries/Core/Timers/JSTimers.js b/node_modules/react-native/Libraries/Core/Timers/JSTimers.js
 index 4c154db..89051c8 100644
 --- a/node_modules/react-native/Libraries/Core/Timers/JSTimers.js
@@ -39,28 +29,12 @@ index 4c154db..89051c8 100644
        'setImmediate',
      );
      immediates.push(id);
-diff --git a/node_modules/react-native/Libraries/TurboModule/TurboModuleRegistry.js b/node_modules/react-native/Libraries/TurboModule/TurboModuleRegistry.js
-index b3b1135..fd9831a 100644
---- a/node_modules/react-native/Libraries/TurboModule/TurboModuleRegistry.js
-+++ b/node_modules/react-native/Libraries/TurboModule/TurboModuleRegistry.js
-@@ -16,9 +16,9 @@ import invariant from 'invariant';
- 
- const turboModuleProxy = global.__turboModuleProxy;
- 
--export function get<T: TurboModule>(name: string): ?T {
-+export function get<T: TurboModule>(name: string, legacy: boolean = false): ?T {
-   // Bridgeless mode requires TurboModules
--  if (!global.RN$Bridgeless) {
-+  if (!global.RN$Bridgeless || legacy) {
-     // Backward compatibility layer during migration.
-     const legacyModule = NativeModules[name];
-     if (legacyModule != null) {
 diff --git a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
 index d8938d7..06e01c3 100644
 --- a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
 +++ b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
 @@ -462,7 +462,7 @@ - (id)moduleForName:(NSString *)moduleName
- 
+
  - (id)moduleForName:(NSString *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad
  {
 -  if (RCTTurboModuleEnabled() && _turboModuleLookupDelegate) {
@@ -83,4 +57,4 @@ index a5117be..59108bb 100644
 +    }
      return;
    }
- 
+

--- a/shim.js
+++ b/shim.js
@@ -23,8 +23,10 @@ if (
     },
     makeRemote() {},
     makeShareable() {},
+    registerEventHandler() {},
     startMapper() {},
     stopMapper() {},
+    unregisterEventHandler() {},
   };
 }
 


### PR DESCRIPTION
We don't take any advantages of using the new architecture excluding using reanimated v2. However, I observed a ton of crashes. Hope that disabling every turbo module excluding reanimated will dramatically reduce the number of cxx crashes.