### PR TITLE
Expose setString and use it in CopyFloatingEmojis

### DIFF
--- a/src/components/floating-emojis/CopyFloatingEmojis.js
+++ b/src/components/floating-emojis/CopyFloatingEmojis.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { setString } from '../../hooks/useClipboard';
 import { ButtonPressAnimation } from '../animations';
 import FloatingEmojis from './FloatingEmojis';
-import { useClipboard } from '@rainbow-me/hooks';
 import { magicMemo } from '@rainbow-me/utils';
 
 const CopyFloatingEmojis = ({
@@ -11,8 +11,6 @@ const CopyFloatingEmojis = ({
   textToCopy,
   ...props
 }) => {
-  const { setClipboard } = useClipboard();
-
   return (
     <FloatingEmojis
       distance={250}
@@ -30,7 +28,7 @@ const CopyFloatingEmojis = ({
             onPress?.(textToCopy);
             if (!disabled) {
               onNewEmoji();
-              setClipboard(textToCopy);
+              setString(textToCopy);
             }
           }}
         >

--- a/src/hooks/useClipboard.js
+++ b/src/hooks/useClipboard.js
@@ -4,7 +4,7 @@ import useAppState from './useAppState';
 
 const listeners = new Set();
 
-function setString(content) {
+export function setString(content) {
   Clipboard.setString(content);
   listeners.forEach(listener => listener(content));
 }


### PR DESCRIPTION
in `useClipboard` we're accessing clipboard what's not needed and triggers a notification on iOS. `setString` is sufficient for our case.