### PR TITLE
commented out unused vars for language Settings to fix CI build

### DIFF
--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -127,7 +127,7 @@ export default function SettingsSection({
   onPressShowSecret,
 }) {
   const { wallets } = useWallets();
-const { /*language,*/ nativeCurrency, network } = useAccountSettings();
+  const { /*language,*/ nativeCurrency, network } = useAccountSettings();
   const { isTinyPhone } = useDimensions();
 
   const onSendFeedback = useSendFeedback();

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -11,7 +11,7 @@ import { isEmulatorSync } from 'react-native-device-info';
 import FastImage from 'react-native-fast-image';
 import * as StoreReview from 'react-native-store-review';
 import styled from 'styled-components/primitives';
-import { supportedLanguages } from '../../languages';
+//import { supportedLanguages } from '../../languages';
 import AppVersionStamp from '../AppVersionStamp';
 import { Icon } from '../icons';
 import { Column, ColumnWithDividers } from '../layout';
@@ -24,7 +24,7 @@ import {
 import { Emoji } from '../text';
 import BackupIcon from '@rainbow-me/assets/settingsBackup.png';
 import CurrencyIcon from '@rainbow-me/assets/settingsCurrency.png';
-import LanguageIcon from '@rainbow-me/assets/settingsLanguage.png';
+//import LanguageIcon from '@rainbow-me/assets/settingsLanguage.png';
 import NetworkIcon from '@rainbow-me/assets/settingsNetwork.png';
 import {
   getAppStoreReviewCount,
@@ -122,12 +122,12 @@ export default function SettingsSection({
   onPressCurrency,
   onPressDev,
   onPressIcloudBackup,
-  onPressLanguage,
+  /*onPressLanguage,*/
   onPressNetwork,
   onPressShowSecret,
 }) {
   const { wallets } = useWallets();
-  const { language, nativeCurrency, network } = useAccountSettings();
+const { /*language,*/ nativeCurrency, network } = useAccountSettings();
   const { isTinyPhone } = useDimensions();
 
   const onSendFeedback = useSendFeedback();


### PR DESCRIPTION
I've commented out unused vars to fix CI build, not sure if we want to just remove these for the time being. Here's the failed build for reference: [https://app.bitrise.io/build/b2e6863fdb6809f6#?tab=log](url)