### PR TITLE
SAI is no longer a stablecoin

### DIFF
--- a/src/helpers/savings.js
+++ b/src/helpers/savings.js
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-const STABLECOINS = ['DAI', 'SAI', 'USDC', 'USDT'];
+const STABLECOINS = ['DAI', 'USDC', 'USDT'];
 const APPROX_BLOCK_TIME = 15;
 const MAX_DECIMALS_TO_SHOW = 10;
 const BLOCKS_PER_YEAR = (60 / APPROX_BLOCK_TIME) * 60 * 24 * 365;


### PR DESCRIPTION
Context: 

https://rainbowhaus.slack.com/archives/CGUDDJYNL/p1601641461079400

Before the fix:
![Screen Shot 2020-10-02 at 12 36 39 PM](https://user-images.githubusercontent.com/1247834/94947642-f6b66780-04ab-11eb-8086-fc4ec6365763.png)

After the fix:

![Screen Shot 2020-10-02 at 12 34 41 PM](https://user-images.githubusercontent.com/1247834/94947608-e605f180-04ab-11eb-8183-9294abbbf3d2.png)
