### PR TITLE
Fix broken clipboard validation in PasteAddressButton

### DIFF
--- a/src/components/buttons/PasteAddressButton.js
+++ b/src/components/buttons/PasteAddressButton.js
@@ -7,7 +7,7 @@ import { deviceUtils } from '@rainbow-me/utils';
 
 export default function PasteAddressButton({ onPress }) {
   const [isValid, setIsValid] = useState(false);
-  const { triggerInvalidPaste } = useInvalidPaste();
+  const { onInvalidPaste } = useInvalidPaste();
   const {
     clipboard,
     enablePaste,
@@ -21,20 +21,24 @@ export default function PasteAddressButton({ onPress }) {
       setIsValid(isValidAddress);
     }
 
-    validate();
+    if (!deviceUtils.isIOS14) {
+      validate();
+    }
   }, [clipboard]);
 
   const handlePress = useCallback(() => {
     if (!enablePaste) return;
 
-    getClipboard(result => {
-      if (isValid) {
-        onPress?.(result);
-      } else {
-        triggerInvalidPaste();
+    getClipboard(async clipboardData => {
+      const isValidAddress = await checkIsValidAddressOrENS(clipboardData);
+
+      if (isValidAddress) {
+        return onPress?.(clipboardData);
       }
+
+      return onInvalidPaste();
     });
-  }, [enablePaste, getClipboard, isValid, onPress, triggerInvalidPaste]);
+  }, [enablePaste, getClipboard, onInvalidPaste, onPress]);
 
   return (
     <MiniButton

--- a/src/components/send/SendContactList.js
+++ b/src/components/send/SendContactList.js
@@ -1,20 +1,22 @@
 import { toLower } from 'lodash';
 import React, { useCallback, useMemo, useRef } from 'react';
+import DeviceInfo from 'react-native-device-info';
 import { FlatList } from 'react-native-gesture-handler';
-import { KeyboardArea } from 'react-native-keyboard-area';
+import { useSafeArea } from 'react-native-safe-area-context';
 import styled from 'styled-components/primitives';
 import { FlyInAnimation } from '../animations';
 import { SwipeableContactRow } from '../contacts';
+import { SheetHandleFixedToTopHeight } from '../sheet';
 import { InvalidPasteToast, ToastPositionContainer } from '../toasts';
 import SendEmptyState from './SendEmptyState';
 import { useKeyboardHeight } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
-import { colors } from '@rainbow-me/styles';
 import { filterList } from '@rainbow-me/utils';
 
-const KeyboardSizeView = styled(KeyboardArea)`
-  background-color: ${colors.white};
+const KeyboardArea = styled.View`
+  height: ${({ insets, keyboardHeight }) =>
+    DeviceInfo.hasNotch() ? keyboardHeight : keyboardHeight - insets.top};
 `;
 
 const rowHeight = 62;
@@ -45,6 +47,7 @@ export default function SendContactList({
   removeContact,
 }) {
   const { navigate } = useNavigation();
+  const insets = useSafeArea();
   const keyboardHeight = useKeyboardHeight();
 
   const contactRefs = useRef({});
@@ -107,10 +110,16 @@ export default function SendContactList({
           testID="send-contact-list"
         />
       )}
-      <ToastPositionContainer bottom={keyboardHeight}>
+      <ToastPositionContainer
+        bottom={
+          DeviceInfo.hasNotch()
+            ? keyboardHeight - SheetHandleFixedToTopHeight
+            : keyboardHeight - SheetHandleFixedToTopHeight * 1.5
+        }
+      >
         <InvalidPasteToast />
       </ToastPositionContainer>
-      <KeyboardSizeView isOpen />
+      <KeyboardArea insets={insets} keyboardHeight={keyboardHeight} />
     </FlyInAnimation>
   );
 }

--- a/src/components/toasts/InvalidPasteToast.js
+++ b/src/components/toasts/InvalidPasteToast.js
@@ -1,18 +1,12 @@
 import React from 'react';
-import styled from 'styled-components/primitives';
 import Toast from './Toast';
 import { useInvalidPaste } from '@rainbow-me/hooks';
-
-const StyledToast = styled(Toast)`
-  position: absolute;
-  bottom: 15;
-`;
 
 export default function InvalidPasteToast(props) {
   const { isInvalidPaste } = useInvalidPaste();
 
   return (
-    <StyledToast
+    <Toast
       isVisible={isInvalidPaste}
       text="􀉾 You can't paste that here"
       {...props}

--- a/src/components/toasts/ToastPositionContainer.js
+++ b/src/components/toasts/ToastPositionContainer.js
@@ -1,13 +1,18 @@
 import styled from 'styled-components/primitives';
 import { Column } from '../layout';
 
+const ToastPositionContainerHeight = 40;
+
 const ToastPositionContainer = styled(Column).attrs({
   pointerEvents: 'none',
 })`
-  bottom: ${({ bottom = 0 }) => bottom};
+  bottom: ${({ bottom = 0 }) => bottom - ToastPositionContainerHeight};
+  height: ${ToastPositionContainerHeight};
   left: 0;
   position: absolute;
   right: 0;
+  width: 100%;
+  z-index: 9;
 `;
 
 export default ToastPositionContainer;

--- a/src/hooks/useInvalidPaste.js
+++ b/src/hooks/useInvalidPaste.js
@@ -3,23 +3,31 @@ import useTimeout from './useTimeout';
 import { RainbowContext } from '@rainbow-me/helpers/RainbowContext';
 
 export default function useInvalidPaste() {
-  const [startTimeout] = useTimeout();
+  const [startTimeout, stopTimeout] = useTimeout();
   const { isInvalidPaste = false, setGlobalState } = useContext(RainbowContext);
 
-  const triggerInvalidPaste = useCallback(
-    () => setGlobalState({ isInvalidPaste: true }),
-    [setGlobalState]
-  );
+  const onInvalidPaste = useCallback(() => {
+    stopTimeout();
+    setGlobalState({ isInvalidPaste: true });
+  }, [setGlobalState, stopTimeout]);
+
+  const reset = useCallback(() => setGlobalState({ isInvalidPaste: false }), [
+    setGlobalState,
+  ]);
 
   // ⏰️ Reset isInvalidPaste value after 3 seconds.
   useEffect(() => {
     if (isInvalidPaste) {
-      startTimeout(() => setGlobalState({ isInvalidPaste: false }), 3000);
+      stopTimeout();
+      startTimeout(reset, 3000);
     }
-  }, [isInvalidPaste, setGlobalState, startTimeout]);
+  }, [isInvalidPaste, reset, startTimeout, stopTimeout]);
+
+  // 🚪️ Reset isInvalidPaste when we leave the screen
+  useEffect(() => () => reset(), [reset]);
 
   return {
     isInvalidPaste,
-    triggerInvalidPaste,
+    onInvalidPaste,
   };
 }

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -132,7 +132,7 @@ export default function ImportSeedPhraseSheet() {
   const { accountAddress } = useAccountSettings();
   const { selectedWallet, wallets } = useWallets();
   const { getClipboard, hasClipboardData, clipboard } = useClipboard();
-  const { triggerInvalidPaste } = useInvalidPaste();
+  const { onInvalidPaste } = useInvalidPaste();
   const { isSmallPhone } = useDimensions();
   const { goBack, navigate, replace, setParams } = useNavigation();
   const initializeWallet = useInitializeWallet();
@@ -252,16 +252,15 @@ export default function ImportSeedPhraseSheet() {
     getClipboard(result => {
       if (result !== accountAddress && isValidWallet(result)) {
         return handleSetSeedPhrase(result);
-      } else {
-        return triggerInvalidPaste();
       }
+      return onInvalidPaste();
     });
   }, [
     accountAddress,
     getClipboard,
     handleSetSeedPhrase,
     hasClipboardData,
-    triggerInvalidPaste,
+    onInvalidPaste,
   ]);
 
   useEffect(() => {

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -39,6 +39,7 @@ import {
   useInitializeWallet,
   useInvalidPaste,
   useIsWalletEthZero,
+  useKeyboardHeight,
   useMagicAutofocus,
   usePrevious,
   useTimeout,
@@ -134,6 +135,7 @@ export default function ImportSeedPhraseSheet() {
   const { getClipboard, hasClipboardData, clipboard } = useClipboard();
   const { onInvalidPaste } = useInvalidPaste();
   const { isSmallPhone } = useDimensions();
+  const keyboardHeight = useKeyboardHeight();
   const { goBack, navigate, replace, setParams } = useNavigation();
   const initializeWallet = useInitializeWallet();
   const isWalletEthZero = useIsWalletEthZero();
@@ -421,10 +423,10 @@ export default function ImportSeedPhraseSheet() {
             </FooterButton>
           )}
         </Footer>
-        <ToastPositionContainer>
-          <InvalidPasteToast />
-        </ToastPositionContainer>
       </Sheet>
+      <ToastPositionContainer bottom={keyboardHeight}>
+        <InvalidPasteToast />
+      </ToastPositionContainer>
       <KeyboardSizeView isOpen />
     </Container>
   );


### PR DESCRIPTION
Fixes these 3 issues reported by Christian in Slack

- [x] doesn’t recognize ENS names as valid
- [x] the first time you try to paste a valid address, it rejects it. then it works if you paste a second time. also sometimes the toast is triggered without pressing the paste button
- [x] cut off on small phones (iphone se 2nd gen) 