### PR TITLE
Handle interrupted wallet creation

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -148,11 +148,11 @@ const AmountButton = ({ amount, backgroundColor, color, onPress }) => {
 const AddFundsInterstitial = ({ network, offsetY = 0 }) => {
   const { isSmallPhone } = useDimensions();
   const { navigate } = useNavigation();
-  const { selectedWallet } = useWallets();
+  const { isDamaged } = useWallets();
 
   const handlePressAmount = useCallback(
     amount => {
-      if (selectedWallet?.damaged) {
+      if (isDamaged) {
         showWalletErrorAlert();
         return;
       }
@@ -161,16 +161,16 @@ const AddFundsInterstitial = ({ network, offsetY = 0 }) => {
         screen: Routes.ADD_CASH_SCREEN_NAVIGATOR,
       });
     },
-    [navigate, selectedWallet]
+    [navigate, isDamaged]
   );
 
   const handlePressCopyAddress = useCallback(() => {
-    if (selectedWallet?.damaged) {
+    if (isDamaged) {
       showWalletErrorAlert();
       return;
     }
     navigate(Routes.RECEIVE_MODAL);
-  }, [navigate, selectedWallet]);
+  }, [navigate, isDamaged]);
 
   return (
     <Container style={buildInterstitialTransform(isSmallPhone, offsetY)}>

--- a/src/components/AppVersionStamp.js
+++ b/src/components/AppVersionStamp.js
@@ -2,17 +2,11 @@ import React, { useCallback, useState } from 'react';
 import { Alert } from 'react-native';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import styled from 'styled-components/primitives';
-import { loadAllKeysOnly } from '../model/keychain';
 import { Text } from './text';
-import { useAppVersion, useTimeout } from '@rainbow-me/hooks';
+import { useAppVersion, useTimeout, useWalletsDebug } from '@rainbow-me/hooks';
 import { colors } from '@rainbow-me/styles';
 
 const DEBUG_TAP_COUNT = 15;
-
-async function showDebugAlert() {
-  const keys = await loadAllKeysOnly();
-  Alert.alert('DEBUG INFO', JSON.stringify(keys, null, 2));
-}
 
 const StampText = styled(Text).attrs({
   align: 'center',
@@ -26,8 +20,9 @@ export default function AppVersionStamp() {
   const appVersion = useAppVersion();
   const [numberOfTaps, setNumberOfTaps] = useState(0);
   const [startTimeout, stopTimeout] = useTimeout();
+  const debug = useWalletsDebug();
 
-  const handleVersionPress = useCallback(() => {
+  const handleVersionPress = useCallback(async () => {
     stopTimeout();
 
     const tapCount = numberOfTaps + 1;
@@ -36,11 +31,16 @@ export default function AppVersionStamp() {
     // Only show the secret "debug info" alert if the
     // user has tapped this AppVersionStamp the secret amount of times
     if (tapCount === DEBUG_TAP_COUNT) {
-      showDebugAlert();
+      const { status, data } = await debug();
+      if (status === 'restored') {
+        Alert.alert('Wallet restored successfully!', data);
+      } else {
+        Alert.alert('DEBUG INFO', data);
+      }
     }
 
     startTimeout(() => setNumberOfTaps(0), 3000);
-  }, [numberOfTaps, startTimeout, stopTimeout]);
+  }, [debug, numberOfTaps, startTimeout, stopTimeout]);
 
   return (
     <TouchableWithoutFeedback onPress={handleVersionPress}>

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -70,7 +70,7 @@ export default function ProfileMasthead({
   recyclerListRef,
   showBottomDivider = true,
 }) {
-  const { selectedWallet } = useWallets();
+  const { isDamaged } = useWallets();
   const { width: deviceWidth } = useDimensions();
   const { navigate } = useNavigation();
   const {
@@ -103,15 +103,15 @@ export default function ProfileMasthead({
   ]);
 
   const handlePressReceive = useCallback(() => {
-    if (selectedWallet?.damaged) {
+    if (isDamaged) {
       showWalletErrorAlert();
       return;
     }
     navigate(Routes.RECEIVE_MODAL);
-  }, [navigate, selectedWallet]);
+  }, [navigate, isDamaged]);
 
   const handlePressAddCash = useCallback(() => {
-    if (selectedWallet?.damaged) {
+    if (isDamaged) {
       showWalletErrorAlert();
       return;
     }
@@ -119,17 +119,17 @@ export default function ProfileMasthead({
     analytics.track('Tapped Add Cash', {
       category: 'add cash',
     });
-  }, [navigate, selectedWallet]);
+  }, [navigate, isDamaged]);
 
   const handlePressChangeWallet = useCallback(() => {
     navigate(Routes.CHANGE_WALLET_SHEET);
   }, [navigate]);
 
   const handlePressCopyAddress = useCallback(() => {
-    if (selectedWallet?.damaged) {
+    if (isDamaged) {
       showWalletErrorAlert();
     }
-  }, [selectedWallet]);
+  }, [isDamaged]);
 
   return (
     <Column
@@ -158,7 +158,7 @@ export default function ProfileMasthead({
       </ButtonPressAnimation>
       <RowWithMargins align="center" margin={19}>
         <CopyFloatingEmojis
-          disabled={selectedWallet?.damaged}
+          disabled={isDamaged}
           onPress={handlePressCopyAddress}
           textToCopy={accountAddress}
         >

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -63,7 +63,7 @@ export default function TransactionList({
   requests,
   transactions,
 }) {
-  const { wallets, selectedWallet } = useWallets();
+  const { wallets, selectedWallet, isDamaged } = useWallets();
   const [tapTarget, setTapTarget] = useState([0, 0, 0, 0]);
   const onNewEmoji = useRef();
   const setOnNewEmoji = useCallback(
@@ -79,8 +79,6 @@ export default function TransactionList({
     accountName,
     accountImage,
   } = useAccountProfile();
-
-  const isDamaged = selectedWallet?.damaged;
 
   const onAddCashPress = useCallback(() => {
     if (isDamaged) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -79,6 +79,7 @@ export { default as useWalletCloudBackup } from './useWalletCloudBackup';
 export { default as useWalletConnectConnections } from './useWalletConnectConnections';
 export { default as useWalletManualBackup } from './useWalletManualBackup';
 export { default as useWallets } from './useWallets';
+export { default as useWalletsDebug } from './useWalletsDebug';
 export { default as useWalletSectionsData } from './useWalletSectionsData';
 export { default as useWalletsWithBalancesAndNames } from './useWalletsWithBalancesAndNames';
 export { default as useWyreApplePay } from './useWyreApplePay';

--- a/src/hooks/useWallets.js
+++ b/src/hooks/useWallets.js
@@ -1,4 +1,5 @@
-import { useCallback } from 'react';
+import { isEmpty } from 'lodash';
+import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { findLatestBackUp } from '../model/backup';
@@ -36,7 +37,12 @@ export default function useWallets() {
     [dispatch]
   );
 
+  const isDamaged = useMemo(() => {
+    return isEmpty(selectedWallet) || !wallets || selectedWallet?.damaged;
+  }, [selectedWallet, wallets]);
+
   return {
+    isDamaged,
     isReadOnlyWallet: selectedWallet.type === WalletTypes.readOnly,
     isWalletLoading,
     latestBackup,

--- a/src/hooks/useWalletsDebug.js
+++ b/src/hooks/useWalletsDebug.js
@@ -100,8 +100,8 @@ export default function useWalletsDebug() {
           ]);
 
           await initializeWallet();
+          status = 'restored';
         }
-        status = 'restored';
       } catch (e) {
         logger.sentry(
           'Error while trying to restore wallet on useWalletsDebug'

--- a/src/hooks/useWalletsDebug.js
+++ b/src/hooks/useWalletsDebug.js
@@ -1,0 +1,121 @@
+import { captureException } from '@sentry/react-native';
+import { Wallet } from 'ethers';
+import { isEmpty, map } from 'lodash';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import WalletTypes from '../helpers/walletTypes';
+import { loadAllKeys } from '../model/keychain';
+import {
+  DEFAULT_WALLET_NAME,
+  getWallet,
+  identifyWalletType,
+  loadAddress,
+  savePrivateKey,
+} from '../model/wallet';
+import {
+  walletsLoadState,
+  walletsSetSelected,
+  walletsUpdate,
+} from '../redux/wallets';
+import {
+  allWalletsKey,
+  privateKeyKey,
+  seedPhraseKey,
+  selectedWalletKey,
+} from '../utils/keychainConstants';
+import useInitializeWallet from './useInitializeWallet';
+import useWallets from './useWallets';
+import { colors } from '@rainbow-me/styles';
+import logger from 'logger';
+
+const keysOnly = keysWithValues => map(keysWithValues, item => item?.username);
+
+export default function useWalletsDebug() {
+  const { selectedWallet, wallets } = useWallets();
+  const initializeWallet = useInitializeWallet();
+  const dispatch = useDispatch();
+
+  const debug = useCallback(async () => {
+    const isIncomplete = isEmpty(selectedWallet) || !wallets;
+    let allKeys = await loadAllKeys();
+    let status = '';
+    if (!isIncomplete) {
+      status = 'complete';
+    } else {
+      try {
+        // Read from the old wallet data
+        const address = await loadAddress();
+
+        if (address) {
+          const seed = allKeys.find(
+            item => item.username.indexOf('_rainbowSeedPhrase') !== -1
+          );
+          if (!seed) {
+            throw Error('Missing seed');
+          }
+          const itemKey = seed.username.split(`_${seedPhraseKey}`);
+          const id = itemKey[0];
+          const seedObject = JSON.parse(seed.password);
+          const type = identifyWalletType(seedObject.seedphrase);
+
+          const currentWallet = {
+            addresses: [
+              {
+                address,
+                avatar: null,
+                color: colors.getRandomColor(),
+                index: 0,
+                label: '',
+                visible: true,
+              },
+            ],
+            color: 0,
+            id,
+            imported: false,
+            name: DEFAULT_WALLET_NAME,
+            primary: true,
+            type,
+          };
+
+          const wallets = { [id]: currentWallet };
+
+          await dispatch(walletsUpdate(wallets));
+          await dispatch(walletsSetSelected(currentWallet));
+          await dispatch(walletsLoadState());
+
+          let wallet;
+          if (type === WalletTypes.privateKey) {
+            wallet = new Wallet(seedObject.seedphrase);
+          } else {
+            const walletData = getWallet(seedObject.seedphrase);
+            wallet = walletData.wallet;
+          }
+
+          await savePrivateKey(wallet.address, wallet.privateKey);
+
+          allKeys = allKeys.concat([
+            { username: selectedWalletKey },
+            { username: allWalletsKey },
+            { username: `${address}_${privateKeyKey}` },
+          ]);
+
+          await initializeWallet();
+        }
+        status = 'restored';
+      } catch (e) {
+        logger.sentry(
+          'Error while trying to restore wallet on useWalletsDebug'
+        );
+        captureException(e);
+        status = 'failed';
+      }
+    }
+
+    return {
+      data: JSON.stringify(keysOnly(allKeys), null, 2),
+      status,
+    };
+  }, [dispatch, initializeWallet, selectedWallet, wallets]);
+
+  return debug;
+}

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -87,7 +87,12 @@ const getWalletRowCount = wallets => {
 };
 
 export default function ChangeWalletSheet() {
-  const { selectedWallet, setIsWalletLoading, wallets } = useWallets();
+  const {
+    isDamaged,
+    selectedWallet,
+    setIsWalletLoading,
+    wallets,
+  } = useWallets();
   const [editMode, setEditMode] = useState(false);
 
   const { goBack, navigate, replace } = useNavigation();
@@ -371,7 +376,7 @@ export default function ChangeWalletSheet() {
                 } catch (e) {
                   logger.sentry('Error while trying to add account');
                   captureException(e);
-                  if (selectedWallet.damaged) {
+                  if (isDamaged) {
                     setTimeout(() => {
                       showWalletErrorAlert();
                     }, 1000);
@@ -397,8 +402,8 @@ export default function ChangeWalletSheet() {
     dispatch,
     goBack,
     initializeWallet,
+    isDamaged,
     navigate,
-    selectedWallet.damaged,
     selectedWallet.id,
     selectedWallet.primary,
     setIsWalletLoading,


### PR DESCRIPTION
- Mark the wallet as damaged to prevent funds to be deposited
- Attempt to restore while tapping on version stamp

To repro the interrupted wallet creation scenario, you need to:
1 -  clear the keychain
2 - Add   `return ;` in the line 569 of `src/model/wallet.ts`
3 - Restart the app
4 - Tap on "Get a new wallet"