### PR TITLE
Fix ripples in buttons on Android

### DIFF
--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
@@ -33,9 +33,10 @@ export default function ButtonPressAnimation({
       onLongPress={onLongPress}
       onPress={onPress}
       onPressStart={onPressStart}
-      style={style}
     >
-      <View pointerEvents="box-only">{children}</View>
+      <View pointerEvents="box-only" style={style}>
+        {children}
+      </View>
     </TouchableNativeFeedback>
   );
 }

--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
@@ -13,6 +13,9 @@ export default function ButtonPressAnimation({
   style,
   opacityTouchable = false,
 }) {
+  if (disabled) {
+    return <View style={style}>{children}</View>;
+  }
   if (opacityTouchable) {
     return (
       <TouchableOpacity

--- a/src/components/fab/FabWrapper.js
+++ b/src/components/fab/FabWrapper.js
@@ -7,9 +7,7 @@ import SendFab from './SendFab';
 
 export const FabWrapperBottomPosition = 21 + safeAreaInsetValues.bottom;
 
-const FabWrapperRow = styled(RowWithMargins).attrs({
-  margin: 12,
-})`
+const FabWrapperRow = styled(RowWithMargins).attrs({ margin: 6 })`
   bottom: ${({ isEditMode }) => (isEditMode ? -60 : FabWrapperBottomPosition)};
   position: absolute;
   right: 15;

--- a/src/components/fab/FloatingActionButton.js
+++ b/src/components/fab/FloatingActionButton.js
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { View } from 'react-native';
 import ShadowStack from 'react-native-shadow-stack';
 import styled from 'styled-components/primitives';
 import { magicMemo } from '../../utils';
@@ -46,22 +45,26 @@ const FloatingActionButton = ({
   );
 
   return (
-    <View {...props}>
+    <ButtonPressAnimation
+      disabled={disabled || android}
+      hapticType="impactLight"
+      onPress={handlePress}
+      onPressIn={handlePressIn}
+      scaleTo={scaleTo}
+      useLateHaptic={false}
+      {...props}
+    >
       <ShadowStack
         {...borders.buildCircleAsObject(size)}
         hideShadow={disabled}
         shadows={shadows}
       >
         <ButtonPressAnimation
-          disabled={disabled}
-          hapticType="impactLight"
+          disabled={disabled || ios}
           onPress={handlePress}
-          onPressIn={handlePressIn}
-          scaleTo={scaleTo}
           style={{
             height: size,
           }}
-          useLateHaptic={false}
         >
           <Content backgroundColor={disabled ? colors.grey : backgroundColor}>
             {typeof children === 'function' ? children({ size }) : children}
@@ -69,7 +72,7 @@ const FloatingActionButton = ({
           </Content>
         </ButtonPressAnimation>
       </ShadowStack>
-    </View>
+    </ButtonPressAnimation>
   );
 };
 

--- a/src/components/fab/FloatingActionButton.js
+++ b/src/components/fab/FloatingActionButton.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { View } from 'react-native';
 import ShadowStack from 'react-native-shadow-stack';
 import styled from 'styled-components/primitives';
 import { magicMemo } from '../../utils';
@@ -45,26 +46,30 @@ const FloatingActionButton = ({
   );
 
   return (
-    <ButtonPressAnimation
-      disabled={disabled}
-      hapticType="impactLight"
-      onPress={handlePress}
-      onPressIn={handlePressIn}
-      scaleTo={scaleTo}
-      useLateHaptic={false}
-      {...props}
-    >
+    <View {...props}>
       <ShadowStack
         {...borders.buildCircleAsObject(size)}
         hideShadow={disabled}
         shadows={shadows}
       >
-        <Content backgroundColor={disabled ? colors.grey : backgroundColor}>
-          {typeof children === 'function' ? children({ size }) : children}
-          {!disabled && <InnerBorder opacity={0.06} radius={size / 2} />}
-        </Content>
+        <ButtonPressAnimation
+          disabled={disabled}
+          hapticType="impactLight"
+          onPress={handlePress}
+          onPressIn={handlePressIn}
+          scaleTo={scaleTo}
+          style={{
+            height: size,
+          }}
+          useLateHaptic={false}
+        >
+          <Content backgroundColor={disabled ? colors.grey : backgroundColor}>
+            {typeof children === 'function' ? children({ size }) : children}
+            {!disabled && <InnerBorder opacity={0.06} radius={size / 2} />}
+          </Content>
+        </ButtonPressAnimation>
       </ShadowStack>
-    </ButtonPressAnimation>
+    </View>
   );
 };
 

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -55,10 +55,10 @@ export default function AvatarCircle({
 
   return (
     <ButtonPressAnimation
+      disabled={android}
       enableHapticFeedback={isAvatarPickerAvailable}
       marginTop={2}
       onPress={onPress}
-      opacityTouchable
       pressOutDuration={200}
       scaleTo={isAvatarPickerAvailable ? 0.9 : 1}
     >
@@ -70,7 +70,9 @@ export default function AvatarCircle({
         shadows={shadows[overlayStyles ? 'overlay' : 'default']}
       >
         <AvatarCircleView backgroundColor={colors.avatarColor[accountColor]}>
-          <FirstLetter>{accountSymbol}</FirstLetter>
+          <ButtonPressAnimation disabled={ios} onPress={onPress}>
+            <FirstLetter>{accountSymbol}</FirstLetter>
+          </ButtonPressAnimation>
           {!overlayStyles && <InnerBorder opacity={0.02} radius={65} />}
         </AvatarCircleView>
       </ShadowStack>

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -55,7 +55,7 @@ export default function AvatarCircle({
 
   return (
     <ButtonPressAnimation
-      disabled={android}
+      disabled={android || !isAvatarPickerAvailable}
       enableHapticFeedback={isAvatarPickerAvailable}
       marginTop={2}
       onPress={onPress}
@@ -70,7 +70,10 @@ export default function AvatarCircle({
         shadows={shadows[overlayStyles ? 'overlay' : 'default']}
       >
         <AvatarCircleView backgroundColor={colors.avatarColor[accountColor]}>
-          <ButtonPressAnimation disabled={ios} onPress={onPress}>
+          <ButtonPressAnimation
+            disabled={ios || !isAvatarPickerAvailable}
+            onPress={onPress}
+          >
             <FirstLetter>{accountSymbol}</FirstLetter>
           </ButtonPressAnimation>
           {!overlayStyles && <InnerBorder opacity={0.02} radius={65} />}

--- a/src/components/savings/SavingsListRow.js
+++ b/src/components/savings/SavingsListRow.js
@@ -61,8 +61,6 @@ const SavingsListRowShadowStack = styled(ShadowStack).attrs(
   elevation: 2;
 `;
 
-const ButtonIOS = ios ? ButtonPressAnimation : React.Fragment;
-
 const SavingsListRow = ({
   cTokenBalance,
   lifetimeSupplyInterestAccrued,
@@ -153,13 +151,17 @@ const SavingsListRow = ({
   const displayValue = formatSavingsAmount(value);
 
   return !underlying || !underlying.address ? null : (
-    <ButtonIOS onPress={onButtonPress} scaleTo={0.96}>
+    <ButtonPressAnimation
+      disabled={android}
+      onPress={onButtonPress}
+      scaleTo={0.96}
+    >
       <Centered direction="column" marginBottom={15}>
         <SavingsListRowShadowStack deviceWidth={deviceWidth}>
           <SavingsListRowGradient />
           <Row
             align="center"
-            as={ios ? null : ButtonPressAnimation}
+            as={android && ButtonPressAnimation}
             css={padding(9, 10, 10, 11)}
             justify="space-between"
             onPress={onButtonPress}
@@ -185,7 +187,7 @@ const SavingsListRow = ({
           </Row>
         </SavingsListRowShadowStack>
       </Centered>
-    </ButtonIOS>
+    </ButtonPressAnimation>
   );
 };
 

--- a/src/components/savings/SavingsListRow.js
+++ b/src/components/savings/SavingsListRow.js
@@ -61,6 +61,8 @@ const SavingsListRowShadowStack = styled(ShadowStack).attrs(
   elevation: 2;
 `;
 
+const ButtonIOS = ios ? ButtonPressAnimation : React.Fragment;
+
 const SavingsListRow = ({
   cTokenBalance,
   lifetimeSupplyInterestAccrued,
@@ -151,14 +153,17 @@ const SavingsListRow = ({
   const displayValue = formatSavingsAmount(value);
 
   return !underlying || !underlying.address ? null : (
-    <ButtonPressAnimation onPress={onButtonPress} scaleTo={0.96}>
+    <ButtonIOS onPress={onButtonPress} scaleTo={0.96}>
       <Centered direction="column" marginBottom={15}>
         <SavingsListRowShadowStack deviceWidth={deviceWidth}>
           <SavingsListRowGradient />
           <Row
             align="center"
+            as={ios ? null : ButtonPressAnimation}
             css={padding(9, 10, 10, 11)}
             justify="space-between"
+            onPress={onButtonPress}
+            scaleTo={0.96}
           >
             {underlying.symbol && supplyBalanceUnderlying ? (
               <Centered>
@@ -180,7 +185,7 @@ const SavingsListRow = ({
           </Row>
         </SavingsListRowShadowStack>
       </Centered>
-    </ButtonPressAnimation>
+    </ButtonIOS>
   );
 };
 

--- a/src/components/unique-token/UniqueTokenCard.js
+++ b/src/components/unique-token/UniqueTokenCard.js
@@ -9,7 +9,7 @@ import { colors, shadow as shadowUtil } from '@rainbow-me/styles';
 const UniqueTokenCardBorderRadius = 20;
 const UniqueTokenCardShadow = [0, 2, 6, colors.dark, 0.08];
 
-const Container = styled(ButtonPressAnimation)`
+const Container = styled.View`
   ${({ shadow }) => shadowUtil.build(...shadow)};
 `;
 
@@ -42,6 +42,7 @@ const UniqueTokenCard = ({
 
   return (
     <Container
+      as={ios && ButtonPressAnimation}
       disabled={disabled}
       enableHapticFeedback={enableHapticFeedback}
       onPress={handlePress}
@@ -49,19 +50,21 @@ const UniqueTokenCard = ({
       shadow={shadow}
     >
       <Content {...props} height={height} style={style} width={width}>
-        <UniqueTokenImage
-          backgroundColor={background || colors.lightestGrey}
-          imageUrl={image_preview_url}
-          item={item}
-          resizeMode={resizeMode}
-        />
-        {borderEnabled && (
-          <InnerBorder
-            opacity={0.04}
-            radius={UniqueTokenCardBorderRadius}
-            width={0.5}
+        <ButtonPressAnimation disabled={ios} style={{ width, height }}>
+          <UniqueTokenImage
+            backgroundColor={background || colors.lightestGrey}
+            imageUrl={image_preview_url}
+            item={item}
+            resizeMode={resizeMode}
           />
-        )}
+          {borderEnabled && (
+            <InnerBorder
+              opacity={0.04}
+              radius={UniqueTokenCardBorderRadius}
+              width={0.5}
+            />
+          )}
+        </ButtonPressAnimation>
       </Content>
     </Container>
   );

--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -26,7 +26,7 @@ export function SwipeNavigator() {
       tabBar={renderTabBar}
     >
       <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} />
-      <Swipe.Screen component={WalletScreen} nam name={Routes.WALLET_SCREEN} />
+      <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} />
       <Swipe.Screen
         component={QRScannerScreen}
         name={Routes.QR_SCANNER_SCREEN}

--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -20,13 +20,13 @@ export function SwipeNavigator() {
     <Swipe.Navigator
       initialLayout={deviceUtils.dimensions}
       initialRouteName={Routes.WALLET_SCREEN}
-      {...(ios && { pager: renderPager })}
+      pager={renderPager}
       position={scrollPosition}
       swipeEnabled={!isCoinListEdited}
       tabBar={renderTabBar}
     >
       <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} />
-      <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} />
+      <Swipe.Screen component={WalletScreen} nam name={Routes.WALLET_SCREEN} />
       <Swipe.Screen
         component={QRScannerScreen}
         name={Routes.QR_SCANNER_SCREEN}


### PR DESCRIPTION
Fixes ripples in:
1. Fabs
2. Savings sheet
3. Unique token
4. Profile Avatar

Now they are no bigger than the button size

tested and no regressions on ios