### PR TITLE
Remove "cancel" from charts menu on Android

### DIFF
--- a/src/components/coin-row/TransactionCoinRow.js
+++ b/src/components/coin-row/TransactionCoinRow.js
@@ -115,7 +115,7 @@ export default function TransactionCoinRow({ item, ...props }) {
     }
 
     if (hash) {
-      let buttons = ['View on Etherscan', 'Cancel'];
+      let buttons = ['View on Etherscan', ...(ios ? ['Cancel'] : [])];
       if (showContactInfo) {
         buttons.unshift(contact ? 'View Contact' : 'Add to Contacts');
       }

--- a/src/components/expanded-state/chart/ChartContextButton.js
+++ b/src/components/expanded-state/chart/ChartContextButton.js
@@ -49,7 +49,7 @@ export default function ChartContextButton({ asset, color }) {
       `📌️ ${currentAction === EditOptions.unpin ? 'Unpin' : 'Pin'}`,
       `🙈️ ${currentAction === EditOptions.unhide ? 'Unhide' : 'Hide'}`,
       ...(asset?.address === 'eth' ? [] : ['🔍 View on Etherscan']),
-      lang.t('wallet.action.cancel'),
+      ...(ios ? lang.t('wallet.action.cancel') : []),
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [asset?.address, currentAction]

--- a/src/components/expanded-state/chart/ChartContextButton.js
+++ b/src/components/expanded-state/chart/ChartContextButton.js
@@ -49,7 +49,7 @@ export default function ChartContextButton({ asset, color }) {
       `📌️ ${currentAction === EditOptions.unpin ? 'Unpin' : 'Pin'}`,
       `🙈️ ${currentAction === EditOptions.unhide ? 'Unhide' : 'Hide'}`,
       ...(asset?.address === 'eth' ? [] : ['🔍 View on Etherscan']),
-      ...(ios ? lang.t('wallet.action.cancel') : []),
+      ...(ios ? [lang.t('wallet.action.cancel')] : []),
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [asset?.address, currentAction]

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -241,7 +241,7 @@ export default function TransactionList({
       }
 
       if (hash) {
-        let buttons = ['View on Etherscan', 'Cancel'];
+        let buttons = ['View on Etherscan', ...(ios ? ['Cancel'] : [])];
         if (showContactInfo) {
           buttons.unshift(contact ? 'View Contact' : 'Add to Contacts');
         }


### PR DESCRIPTION
We can just press on the background or use the physical button. There's no need for the 'cancel' button. 

Before: 
![image](https://user-images.githubusercontent.com/25709300/95855111-93a4ba80-0d60-11eb-8381-d3c676cbb00d.png)

After:
![image](https://user-images.githubusercontent.com/25709300/95855036-7cfe6380-0d60-11eb-8ef0-f2e725a88a72.png)
