### PR TITLE
Updates to Wyre order minimums and limits

### DIFF
--- a/src/components/add-cash/AddCashForm.js
+++ b/src/components/add-cash/AddCashForm.js
@@ -14,6 +14,7 @@ import AddCashSelector from './AddCashSelector';
 import { padding } from '@rainbow-me/styles';
 
 const currencies = ['DAI', 'ETH'];
+const minimumPurchaseAmountUSD = 25;
 
 const AddCashForm = ({
   limitDaily,
@@ -158,7 +159,9 @@ const AddCashForm = ({
           />
         </Centered>
         <AddCashFooter
-          disabled={isEmpty(value) || parseFloat(value) === 0}
+          disabled={
+            isEmpty(value) || parseFloat(value) < minimumPurchaseAmountUSD
+          }
           onDisabledPress={onShake}
           onSubmit={handlePurchase}
         />

--- a/src/components/add-cash/AddCashForm.js
+++ b/src/components/add-cash/AddCashForm.js
@@ -48,7 +48,7 @@ const AddCashForm = ({
     newValue => {
       setValue(prevValue => {
         const isExceedingWeeklyLimit =
-          parseFloat(prevValue + `${parseFloat(newValue)}`) > limitWeekly;
+          parseFloat(prevValue + parseFloat(newValue)) > limitWeekly;
 
         const isInvalidFirstEntry =
           !prevValue &&

--- a/src/components/add-cash/AddCashForm.js
+++ b/src/components/add-cash/AddCashForm.js
@@ -1,7 +1,6 @@
 import { useRoute } from '@react-navigation/core';
 import analytics from '@segment/analytics-react-native';
 import { isEmpty } from 'lodash';
-import PropTypes from 'prop-types';
 import React, { Fragment, useCallback, useState } from 'react';
 import { Clock } from 'react-native-reanimated';
 import { useDimensions, useIsWalletEthZero } from '../../hooks';
@@ -17,7 +16,7 @@ const currencies = ['DAI', 'ETH'];
 const minimumPurchaseAmountUSD = 1;
 
 const AddCashForm = ({
-  limitDaily,
+  limitWeekly,
   onClearError,
   onLimitExceeded,
   onPurchase,
@@ -48,8 +47,8 @@ const AddCashForm = ({
   const handleNumpadPress = useCallback(
     newValue => {
       setValue(prevValue => {
-        const isExceedingDailyLimit =
-          parseFloat(prevValue + `${parseFloat(newValue)}`) > limitDaily;
+        const isExceedingWeeklyLimit =
+          parseFloat(prevValue + `${parseFloat(newValue)}`) > limitWeekly;
 
         const isInvalidFirstEntry =
           !prevValue &&
@@ -64,12 +63,12 @@ const AddCashForm = ({
           newValue !== 'back';
 
         if (
-          isExceedingDailyLimit ||
+          isExceedingWeeklyLimit ||
           isInvalidFirstEntry ||
           isMaxDecimalCount ||
           isMaxDecimalLength
         ) {
-          if (isExceedingDailyLimit) onLimitExceeded('daily');
+          if (isExceedingWeeklyLimit) onLimitExceeded('weekly');
           onShake();
           return prevValue;
         }
@@ -105,7 +104,7 @@ const AddCashForm = ({
         category: 'add cash',
       });
     },
-    [limitDaily, onClearError, onLimitExceeded, onShake]
+    [limitWeekly, onClearError, onLimitExceeded, onShake]
   );
 
   const onCurrencyChange = useCallback(
@@ -168,15 +167,6 @@ const AddCashForm = ({
       </ColumnWithMargins>
     </Fragment>
   );
-};
-
-AddCashForm.propTypes = {
-  limitDaily: PropTypes.number,
-  onClearError: PropTypes.func,
-  onLimitExceeded: PropTypes.func,
-  onPurchase: PropTypes.func,
-  onShake: PropTypes.func,
-  shakeAnim: PropTypes.object,
 };
 
 export default React.memo(AddCashForm);

--- a/src/components/add-cash/AddCashForm.js
+++ b/src/components/add-cash/AddCashForm.js
@@ -14,7 +14,7 @@ import AddCashSelector from './AddCashSelector';
 import { padding } from '@rainbow-me/styles';
 
 const currencies = ['DAI', 'ETH'];
-const minimumPurchaseAmountUSD = 25;
+const minimumPurchaseAmountUSD = 1;
 
 const AddCashForm = ({
   limitDaily,

--- a/src/handlers/wyre.js
+++ b/src/handlers/wyre.js
@@ -301,7 +301,7 @@ const getWyrePaymentDetails = (
   displayItems: [
     {
       amount: { currency: SOURCE_CURRENCY_USD, value: sourceAmount },
-      label: `Purchase ${destCurrency}`,
+      label: destCurrency,
     },
     {
       amount: { currency: SOURCE_CURRENCY_USD, value: purchaseFee },

--- a/src/handlers/wyre.js
+++ b/src/handlers/wyre.js
@@ -18,6 +18,7 @@ import { WYRE_SUPPORTED_COUNTRIES_ISO } from '../references/wyre';
 import logger from 'logger';
 
 const WYRE_PERCENT_FEE = 4;
+const WYRE_MINIMUM_FEE_USD = 5;
 const WYRE_FLAT_FEE_USD = 0.3;
 const SOURCE_CURRENCY_USD = 'USD';
 const PAYMENT_PROCESSOR_COUNTRY_CODE = 'US';
@@ -66,7 +67,8 @@ export const showApplePayRequest = async (
   const feeAmount = feeCalculation(
     sourceAmount,
     WYRE_PERCENT_FEE,
-    WYRE_FLAT_FEE_USD
+    WYRE_FLAT_FEE_USD,
+    WYRE_MINIMUM_FEE_USD
   );
 
   const totalAmount = add(sourceAmount, feeAmount);

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -96,15 +96,18 @@ export const mod = (numberOne, numberTwo) =>
  * @desc calculate the fee for a given amount, percent fee, and fixed fee
  * @param  {Number}   amount (base amount to calculate fee off of)
  * @param  {Number}   percent fee (4% would just be 4)
- * @param  {Number}   fixed fee (flat rate to add)
+ * @param  {Number}   minimum fee USD (calculated fee or this minimum)
+ * @param  {Number}   fixed fee USD (flat rate to add)
  * @return {String}   fixed format to 2 decimals with ROUND_HALF_UP
  */
-export const feeCalculation = (amount, percentFee, fixedFee) =>
-  BigNumber(amount)
+export const feeCalculation = (amount, percentFee, fixedFee, minimumFee) => {
+  const dynamicFee = BigNumber(amount)
     .times(percentFee)
     .dividedBy(100)
-    .plus(fixedFee)
-    .toFixed(2, BigNumber.ROUND_HALF_UP);
+    .plus(fixedFee);
+  const fee = BigNumber.max(dynamicFee, minimumFee);
+  return fee.toFixed(2, BigNumber.ROUND_HALF_UP);
+};
 
 /**
  * @desc real floor divides two numbers

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -93,23 +93,6 @@ export const mod = (numberOne, numberTwo) =>
     .toFixed();
 
 /**
- * @desc calculate the fee for a given amount, percent fee, and fixed fee
- * @param  {Number}   amount (base amount to calculate fee off of)
- * @param  {Number}   percent fee (4% would just be 4)
- * @param  {Number}   minimum fee USD (calculated fee or this minimum)
- * @param  {Number}   fixed fee USD (flat rate to add)
- * @return {String}   fixed format to 2 decimals with ROUND_HALF_UP
- */
-export const feeCalculation = (amount, percentFee, fixedFee, minimumFee) => {
-  const dynamicFee = BigNumber(amount)
-    .times(percentFee)
-    .dividedBy(100)
-    .plus(fixedFee);
-  const fee = BigNumber.max(dynamicFee, minimumFee);
-  return fee.toFixed(2, BigNumber.ROUND_HALF_UP);
-};
-
-/**
  * @desc real floor divides two numbers
  * @param  {Number}   numberOne
  * @param  {Number}   numberTwo

--- a/src/hooks/useAddCashLimits.js
+++ b/src/hooks/useAddCashLimits.js
@@ -1,11 +1,11 @@
-import { differenceInHours, differenceInYears } from 'date-fns';
+import { differenceInDays, differenceInYears } from 'date-fns';
 import { findIndex, sumBy, take } from 'lodash';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import TransactionStatusTypes from '../helpers/transactionStatusTypes';
 
-const DEFAULT_DAILY_LIMIT = 250;
-const DEFAULT_YEARLY_LIMIT = 1500;
+const DEFAULT_WEEKLY_LIMIT = 500;
+const DEFAULT_YEARLY_LIMIT = 5000;
 
 const findRemainingAmount = (limit, purchaseTransactions, index) => {
   const transactionsInTimeline =
@@ -28,15 +28,15 @@ export default function useAddCashLimits() {
   const limits = useMemo(() => {
     const now = Date.now();
 
-    const firstIndexBeyondToday = findIndex(purchaseTransactions, txn => {
+    const firstIndexBeyondThisWeek = findIndex(purchaseTransactions, txn => {
       const txnTimestampInMs = txn.timestamp || txn.minedAt * 1000;
-      return differenceInHours(now, txnTimestampInMs) >= 24;
+      return differenceInDays(now, txnTimestampInMs) >= 7;
     });
 
-    const dailyRemainingLimit = findRemainingAmount(
-      DEFAULT_DAILY_LIMIT,
+    const weeklyRemainingLimit = findRemainingAmount(
+      DEFAULT_WEEKLY_LIMIT,
       purchaseTransactions,
-      firstIndexBeyondToday
+      firstIndexBeyondThisWeek
     );
 
     const firstIndexBeyondThisYear = findIndex(
@@ -45,7 +45,7 @@ export default function useAddCashLimits() {
         const txnTimestampInMs = txn.timestamp || txn.minedAt * 1000;
         return differenceInYears(now, txnTimestampInMs) >= 1;
       },
-      Math.max(firstIndexBeyondToday, 0)
+      Math.max(firstIndexBeyondThisWeek, 0)
     );
     const yearlyRemainingLimit = findRemainingAmount(
       DEFAULT_YEARLY_LIMIT,
@@ -54,7 +54,7 @@ export default function useAddCashLimits() {
     );
 
     return {
-      dailyRemainingLimit: Math.max(dailyRemainingLimit, 0),
+      weeklyRemainingLimit: Math.max(weeklyRemainingLimit, 0),
       yearlyRemainingLimit: Math.max(yearlyRemainingLimit, 0),
     };
   }, [purchaseTransactions]);

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -69,13 +69,14 @@ export default function useWyreApplePay() {
         accountAddress,
         network
       );
-      const sourceAmountWithFees = quotation?.sourceAmount;
+      const { sourceAmountWithFees, purchaseFee } = quotation;
 
       const applePayResponse = await showApplePayRequest(
         referenceInfo,
         accountAddress,
         currency,
         sourceAmountWithFees,
+        purchaseFee,
         value,
         network
       );

--- a/src/hooks/useWyreApplePay.js
+++ b/src/hooks/useWyreApplePay.js
@@ -1,6 +1,7 @@
 import analytics from '@segment/analytics-react-native';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { Alert } from '../components/alerts';
 import {
   getOrderId,
   getReferenceId,
@@ -62,6 +63,13 @@ export default function useWyreApplePay() {
         analytics.track('Wyre order reservation incomplete', {
           category: 'add cash',
         });
+        Alert({
+          buttons: [{ text: 'Okay' }],
+          message:
+            'We were unable to reserve your purchase order. Please try again later.',
+          title: `Something went wrong!`,
+        });
+        return;
       }
       const quotation = await getWalletOrderQuotation(
         value,
@@ -69,6 +77,20 @@ export default function useWyreApplePay() {
         accountAddress,
         network
       );
+
+      if (!quotation) {
+        analytics.track('Wyre order quote incomplete', {
+          category: 'add cash',
+        });
+        Alert({
+          buttons: [{ text: 'Okay' }],
+          message:
+            'We were unable to get a quote on your purchase order. Please try again later.',
+          title: `Something went wrong!`,
+        });
+        return;
+      }
+
       const { sourceAmountWithFees, purchaseFee } = quotation;
 
       const applePayResponse = await showApplePayRequest(

--- a/src/screens/AddCashSheet.js
+++ b/src/screens/AddCashSheet.js
@@ -48,20 +48,20 @@ export default function AddCashSheet() {
   const [errorIndex, setErrorIndex] = useState(null);
   const onClearError = useCallback(() => setErrorIndex(null), []);
 
-  const { dailyRemainingLimit, yearlyRemainingLimit } = useAddCashLimits();
+  const { weeklyRemainingLimit, yearlyRemainingLimit } = useAddCashLimits();
 
   const cashLimits = useMemo(
     () => ({
-      daily:
-        dailyRemainingLimit > 0
-          ? `Up to $${dailyRemainingLimit} today`
-          : 'Daily limit reached',
+      weekly:
+        weeklyRemainingLimit > 0
+          ? `$${weeklyRemainingLimit} left this week`
+          : 'Weekly limit reached',
       yearly:
         yearlyRemainingLimit > 0
           ? `$${yearlyRemainingLimit} left this year`
           : 'Yearly limit reached',
     }),
-    [dailyRemainingLimit, yearlyRemainingLimit]
+    [weeklyRemainingLimit, yearlyRemainingLimit]
   );
 
   const {
@@ -121,7 +121,7 @@ export default function AddCashSheet() {
             />
           ) : (
             <AddCashForm
-              limitDaily={dailyRemainingLimit}
+              limitWeekly={weeklyRemainingLimit}
               onClearError={onClearError}
               onLimitExceeded={onLimitExceeded}
               onPurchase={onPurchase}


### PR DESCRIPTION
* Split up fees to show purchase vs network fee
* Use Wyre's quotation endpoint to get the final price we should be charging users in order for them to get their originally intended amount
* Alert user if we could not reserve the order or get a quote (required before requesting Apple Pay)
* Update weekly and annual limits (we used to have $250 daily and $1500 annual limits - now we have $500 daily / weekly limits, and $5000 annual limit)