### PR TITLE
Fix optional unwrapping in cool-modals

### DIFF
--- a/src/react-native-cool-modals/ios/UIViewController+slack.swift
+++ b/src/react-native-cool-modals/ios/UIViewController+slack.swift
@@ -111,7 +111,7 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
   }
 
   var cornerRadius: CGFloat {
-    return CGFloat(truncating: config!.cornerRadius!)
+    return CGFloat(truncating: config?.cornerRadius ?? 0)
   }
 
   var ignoreBottomOffset: Bool {


### PR DESCRIPTION
This should fix our #1 crash: https://console.firebase.google.com/u/0/project/rainbow-me/crashlytics/app/ios:me.rainbow/issues/e2c7a8f98e6729ddd4b0ae66eddaa48c?time=last-twenty-four-hours&sessionEventKey=c6fb827423744ba2b727e6b626483085_1462404963284403947

@skylarbarrera Can you play around with sheets / modals and see if everything looks normal?