### PR TITLE
Add cUNI support

### DIFF
--- a/src/references/compound/saving-assets.json
+++ b/src/references/compound/saving-assets.json
@@ -36,6 +36,12 @@
             "name": "USD Coin",
             "symbol": "USDC"
         },
+        "0x35A18000230DA775CAc24873d00Ff85BccdeD550": {
+            "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "decimals": 18,
+            "name": "Uniswap",
+            "symbol": "UNI"
+        },
         "0xc11b1268c1a384e55c48c2391d8d480264a3a7f4": {
             "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
             "decimals": 8,


### PR DESCRIPTION
doesn't have an icon because the UNI icon is a png that comes from Trust and not our coin icon package

<img width="708" alt="Screen Shot 2020-10-16 at 1 05 52 AM" src="https://user-images.githubusercontent.com/7061887/96215338-be9f3200-0f4b-11eb-86fd-553d3395a075.png">