### PR TITLE
Eliminate magic numbers from RLV ✨

### DIFF
--- a/src/components/asset-list/RecyclerAssetList.js
+++ b/src/components/asset-list/RecyclerAssetList.js
@@ -26,16 +26,19 @@ import {
 import { CoinDivider } from '../coin-divider';
 import { CoinRowHeight } from '../coin-row';
 import AssetListHeader, { AssetListHeaderHeight } from './AssetListHeader';
-import { ViewTypes } from './RecyclerViewTypes';
+import { firstCoinRowMarginTop, ViewTypes } from './RecyclerViewTypes';
 import { colors } from '@rainbow-me/styles';
 
 const NOOP = () => undefined;
 let globalDeviceDimensions = 0;
 
 class LayoutItemAnimator extends BaseItemAnimator {
-  constructor(rlv) {
+  constructor(rlv, paddingBottom) {
     super();
     this.rlv = rlv;
+    this.paddingBottom = ViewTypes.FOOTER.calculateHeight({
+      paddingBottom: paddingBottom || 0,
+    });
   }
 
   animateDidMount = NOOP;
@@ -46,7 +49,9 @@ class LayoutItemAnimator extends BaseItemAnimator {
     if (
       this.rlv &&
       this.rlv.getContentDimension().height <
-        this.rlv.getCurrentScrollOffset() + globalDeviceDimensions + 46 &&
+        this.rlv.getCurrentScrollOffset() +
+          globalDeviceDimensions +
+          this.paddingBottom &&
       this.rlv.getCurrentScrollOffset() > 0
     ) {
       LayoutAnimation.configureNext({
@@ -456,7 +461,7 @@ class RecyclerAssetList extends Component {
   }
 
   componentDidMount() {
-    this.animator = new LayoutItemAnimator(this.rlv);
+    this.animator = new LayoutItemAnimator(this.rlv, this.props.paddingBottom);
     this.isCancelled = false;
   }
 
@@ -548,7 +553,11 @@ class RecyclerAssetList extends Component {
     // Auto-scroll to end of the list if something was closed/disappeared 👇
     if (
       this.rlv &&
-      this.rlv.getContentDimension().height < bottomHorizonOfScreen + 46 &&
+      this.rlv.getContentDimension().height <
+        bottomHorizonOfScreen +
+          ViewTypes.FOOTER.calculateHeight({
+            paddingBottom: this.props.paddingBottom || 0,
+          }) &&
       this.rlv.getCurrentScrollOffset() > 0 &&
       (!this.props.isCoinListEdited ||
         (!prevProps.isCoinListEdited && this.props.isCoinListEdited))
@@ -592,7 +601,8 @@ class RecyclerAssetList extends Component {
   renderList = [];
 
   checkEditStickyHeader(offsetY) {
-    const offsetHeight = CoinRowHeight * (this.coinDividerIndex - 1) + 5;
+    const offsetHeight =
+      CoinRowHeight * (this.coinDividerIndex - 1) + firstCoinRowMarginTop;
     if (this.props.isCoinListEdited && offsetY > offsetHeight) {
       this.setState({ showCoinListEditor: true });
     } else if (

--- a/src/components/asset-list/RecyclerViewTypes.js
+++ b/src/components/asset-list/RecyclerViewTypes.js
@@ -8,6 +8,7 @@ import {
   SmallBalancesWrapper,
 } from '../coin-divider';
 import { CoinRowHeight } from '../coin-row';
+import { SavingsCoinRowHeight } from '../coin-row/SavingsCoinRow';
 import { FloatingActionButtonSize } from '../fab';
 import { ListFooter } from '../list';
 import PoolsListWrapper from '../pools/PoolsListWrapper';
@@ -16,7 +17,28 @@ import { TokenFamilyHeaderHeight } from '../token-family';
 import { UniqueTokenRow } from '../unique-token';
 import AssetListHeader, { AssetListHeaderHeight } from './AssetListHeader';
 
-const firstCoinRowMarginTop = 6;
+export const firstCoinRowMarginTop = 6;
+const lastCoinRowAdditionalHeight = 1;
+
+const openSmallBalancesAdditionalHeight = 15;
+const closedSmallBalancesAdditionalHeight = 13;
+
+const savingsOpenAdditionalHeight = 6;
+const savingsClosedAdditionalHeight = -5;
+const savingsLastOpenAdditionalHeight = -4;
+const savingsLastClosedAdditionalHeight = -10;
+
+const poolsOpenAdditionalHeight = -12;
+const poolsClosedAdditionalHeight = -15;
+const poolsLastOpenAdditionalHeight = -22;
+const poolsLastClosedAdditionalHeight = -20;
+
+const firstUniqueTokenMarginTop = 4;
+const extraSpaceForDropShadow = 19;
+
+const amountOfImagesWithForcedPrioritizeLoading = 9;
+const editModeAdditionalHeight = 100;
+
 let lastRenderList = [];
 
 export const ViewTypes = {
@@ -34,7 +56,9 @@ export const ViewTypes = {
     calculateHeight: ({ isFirst, isLast, areSmallCollectibles }) =>
       CoinRowHeight +
       (isFirst ? firstCoinRowMarginTop : 0) +
-      (!isFirst && isLast && !areSmallCollectibles ? ListFooter.height + 1 : 0),
+      (!isFirst && isLast && !areSmallCollectibles
+        ? ListFooter.height + lastCoinRowAdditionalHeight
+        : 0),
     index: 1,
     renderComponent: ({ type, data }) => {
       const { item = {}, renderItem } = data;
@@ -63,13 +87,14 @@ export const ViewTypes = {
     },
     visibleDuringCoinEdit: true,
   },
+
   COIN_SMALL_BALANCES: {
     calculateHeight: ({ isOpen, smallBalancesLength, isCoinListEdited }) =>
       isOpen
         ? smallBalancesLength * CoinRowHeight +
-          15 +
-          (isCoinListEdited ? 100 : 0)
-        : 13,
+          openSmallBalancesAdditionalHeight +
+          (isCoinListEdited ? editModeAdditionalHeight : 0)
+        : closedSmallBalancesAdditionalHeight,
     index: 3,
     renderComponent: ({ data, smallBalancedChanged }) => {
       const { item = {}, renderItem } = data;
@@ -102,10 +127,14 @@ export const ViewTypes = {
     calculateHeight: ({ isOpen, isLast, amountOfRows }) =>
       isOpen
         ? TokenFamilyHeaderHeight +
-          (isLast ? ListFooter.height : 10) +
-          61 * amountOfRows -
-          4
-        : TokenFamilyHeaderHeight + (isLast ? ListFooter.height : 5) - 10,
+          (isLast
+            ? ListFooter.height + savingsLastOpenAdditionalHeight
+            : savingsOpenAdditionalHeight) +
+          SavingsCoinRowHeight * amountOfRows
+        : TokenFamilyHeaderHeight +
+          (isLast
+            ? ListFooter.height + savingsLastClosedAdditionalHeight
+            : savingsClosedAdditionalHeight),
     index: 4,
     renderComponent: ({ data }) => {
       const { item = {} } = data;
@@ -119,10 +148,14 @@ export const ViewTypes = {
     calculateHeight: ({ isOpen, isLast, amountOfRows }) =>
       isOpen
         ? TokenFamilyHeaderHeight +
-          (isLast ? ListFooter.height : 10) +
-          CoinRowHeight * amountOfRows -
-          22
-        : TokenFamilyHeaderHeight + (isLast ? ListFooter.height : 5) - 20,
+          (isLast
+            ? ListFooter.height + poolsLastOpenAdditionalHeight
+            : poolsOpenAdditionalHeight) +
+          CoinRowHeight * amountOfRows
+        : TokenFamilyHeaderHeight +
+          (isLast
+            ? ListFooter.height + poolsLastClosedAdditionalHeight
+            : poolsClosedAdditionalHeight),
     index: 5,
     renderComponent: ({ data, isCoinListEdited }) => {
       return <PoolsListWrapper {...data} isCoinListEdited={isCoinListEdited} />;
@@ -132,10 +165,9 @@ export const ViewTypes = {
   UNIQUE_TOKEN_ROW: {
     calculateHeight: ({ amountOfRows, isFirst, isHeader, isOpen }) => {
       const SectionHeaderHeight = isHeader ? TokenFamilyHeaderHeight : 0;
-      const firstRowExtraTopPadding = isFirst ? 4 : 0;
+      const firstRowExtraTopPadding = isFirst ? firstUniqueTokenMarginTop : 0;
       const heightOfRows = amountOfRows * UniqueTokenRow.cardSize;
       const heightOfRowMargins = UniqueTokenRow.cardMargin * (amountOfRows - 1);
-      const extraSpaceForDropShadow = 19;
 
       const height =
         SectionHeaderHeight +
@@ -157,7 +189,9 @@ export const ViewTypes = {
         isHeader: type.isHeader,
         item: item.tokens,
         shouldPrioritizeImageLoading:
-          index < get(sections, '[0].data.length', 0) + 9,
+          index <
+          get(sections, '[0].data.length', 0) +
+            amountOfImagesWithForcedPrioritizeLoading,
         uniqueId: item.uniqueId,
       });
     },

--- a/src/components/coin-row/SavingsCoinRow.js
+++ b/src/components/coin-row/SavingsCoinRow.js
@@ -11,6 +11,8 @@ import CoinName from './CoinName';
 import CoinRow from './CoinRow';
 import { colors } from '@rainbow-me/styles';
 
+export const SavingsCoinRowHeight = 61;
+
 const BottomRow = ({ lifetimeSupplyInterestAccrued, supplyRate, symbol }) => {
   const apy = calculateAPY(supplyRate);
   const apyTruncated = parseFloat(apy).toFixed(2);

--- a/src/components/send/SendAssetList.js
+++ b/src/components/send/SendAssetList.js
@@ -250,7 +250,7 @@ export default class SendAssetList extends React.Component {
       const renderSize =
         familyHeaderHeight + uniqueTokens[index].data.length * familyRowHeight;
       const screenHeight = this.position + this.componentHeight;
-      if (heightBelow + renderSize + 64 > screenHeight) {
+      if (heightBelow + renderSize + rowHeight > screenHeight) {
         if (renderSize < this.componentHeight) {
           setTimeout(() => {
             this.rlv.scrollToOffset(


### PR DESCRIPTION
I tried to replace all ✨magic numbers✨ with some sensibly named variable. 

Let me know if I overlooked any ✨number✨

Pools and savings are described by 4 super similar but separate variables. This is due to the fact that I wanted to keep original sizes without even a 1px change for any state. If you find it not readable I can simplify it, but not without some layout data loss 