### PR TITLE
Expose debug config to always require token approval

### DIFF
--- a/src/config/debug.js
+++ b/src/config/debug.js
@@ -3,6 +3,7 @@
  * could be useful during development.
  */
 
+export const alwaysRequireApprove = false;
 export const darkMode = false;
 export const parseAllTxnsOnReceive = false;
 export const reactNativeDisableYellowBox = true;

--- a/src/raps/actions/unlock.js
+++ b/src/raps/actions/unlock.js
@@ -1,6 +1,7 @@
 import { MaxUint256 } from '@ethersproject/constants';
 import { captureException } from '@sentry/react-native';
 import { get, isNull, toLower } from 'lodash';
+import { alwaysRequireApprove } from '../../config/debug';
 import TransactionStatusTypes from '../../helpers/transactionStatusTypes';
 import TransactionTypes from '../../helpers/transactionTypes';
 import {
@@ -137,6 +138,8 @@ export const assetNeedsUnlocking = async (
   if (isInputEth) {
     return false;
   }
+
+  if (alwaysRequireApprove) return true;
 
   const cacheKey = toLower(`${accountAddress}|${address}|${contractAddress}`);
 


### PR DESCRIPTION
This is to help aid in testing the approval flow. It will assume all ERC20s need approvals and not do the allowance check.