### PR TITLE
Restore only backedup and readonly wallets

### DIFF
--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -154,7 +154,7 @@ export async function restoreCloudBackup(
       throw new Error('Invalid password');
     }
 
-    // Restore only wallets that were backed up
+    // Restore only wallets that were backed up in cloud
     // or wallets that are read-only
     const walletsToRestore: AllRainbowWallets = {};
     forEach(userData.wallets, wallet => {

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -10,6 +10,8 @@ import {
   encryptAndSaveDataToCloud,
   getDataFromCloud,
 } from '../handlers/cloudBackup';
+import WalletBackupTypes from '../helpers/walletBackupTypes';
+import WalletTypes from '../helpers/walletTypes';
 import {
   allWalletsKey,
   privateKeyKey,
@@ -23,8 +25,6 @@ import {
   publicAccessControlOptions,
   RainbowWallet,
 } from './wallet';
-import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
-import WalletTypes from '@rainbow-me/helpers/walletTypes';
 
 import logger from 'logger';
 

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -156,7 +156,7 @@ export async function restoreCloudBackup(
 
     // Restore only wallets that were backed up
     // or wallets that are read-only
-    const walletsToRestore = {};
+    const walletsToRestore: AllRainbowWallets = {};
     forEach(userData.wallets, wallet => {
       if (
         (wallet.backedUp &&


### PR DESCRIPTION
This PR fixes the scenario where non backed up wallets were being restored (bug) along with the ones that were backed up.

To check that this bug is fixed:
- Delete all backups from settings and wipe the keychain
- Import a pkey  (call it PKEY) and dont' back it up
- Import a read only (call it READONLY) and don't back it up
- Import another wallet, could be pkey or seed (call it SAFU) and back it up.

Wipe the device and restore from iCloud.
It should say that you have 1 wallet backed up. After reimporting only READONLY and SAFU should show (PKEY shouldn't be there)