### PR TITLE
Fix border radius for ripple animation in Minibutton on Android

### DIFF
--- a/src/components/buttons/MiniButton.js
+++ b/src/components/buttons/MiniButton.js
@@ -40,6 +40,7 @@ export default function MiniButton({
     <ButtonPressAnimation
       disabled={disabled}
       onPress={onPress}
+      radiusAndroid={borderRadius}
       scaleTo={scaleTo}
       {...props}
     >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25709300/97487571-b8ef1680-1965-11eb-87ca-b53f842121ce.png)
