### PR TITLE
Add optional hex prefix for private keys when creating wallets

### DIFF
--- a/e2e/importPrivateKeyFlow.spec.js
+++ b/e2e/importPrivateKeyFlow.spec.js
@@ -3,24 +3,24 @@
 import * as Helpers from './helpers';
 
 describe('Import from private key flow', () => {
-  it('Should show the welcome screen', async () => {
+  it('with 0x - Should show the welcome screen', async () => {
     await Helpers.checkIfVisible('welcome-screen');
   });
 
-  it('Should show the "Restore Sheet" after tapping on "I already have a wallet"', async () => {
+  it('with 0x - Should show the "Restore Sheet" after tapping on "I already have a wallet"', async () => {
     await device.disableSynchronization();
     await Helpers.tap('already-have-wallet-button');
     await Helpers.delay(2000);
     await Helpers.checkIfExists('restore-sheet');
   });
 
-  it('show the "Import Sheet" when tapping on "Restore with a recovery phrase or private key"', async () => {
+  it('with 0x - Show the "Import Sheet" when tapping on "Restore with a recovery phrase or private key"', async () => {
     await Helpers.tap('restore-with-key-button');
     await Helpers.delay(2000);
     await Helpers.checkIfExists('import-sheet');
   });
 
-  it('Should show the "Add wallet modal" after tapping import with a valid private key"', async () => {
+  it('with 0x - Should show the "Add wallet modal" after tapping import with a valid private key"', async () => {
     await Helpers.typeText('import-sheet-input', process.env.DEV_PKEY, false);
     await Helpers.delay(1000);
     await Helpers.checkIfElementHasString(
@@ -31,7 +31,7 @@ describe('Import from private key flow', () => {
     await Helpers.checkIfVisible('wallet-info-modal');
   });
 
-  it('Should navigate to the Wallet screen after tapping on "Import Wallet"', async () => {
+  it('with 0x - Should navigate to the Wallet screen after tapping on "Import Wallet"', async () => {
     await Helpers.delay(2000);
     await Helpers.checkIfVisible('wallet-info-input');
     await Helpers.typeText('wallet-info-input', 'PKEY', false);
@@ -47,11 +47,81 @@ describe('Import from private key flow', () => {
   //   await Helpers.tap('backup-sheet-imported-cancel-button');
   // });
 
-  it('Should say "PKEY" in the Profile Screen header', async () => {
+  it('with 0x - Should say "PKEY" in the Profile Screen header', async () => {
     await Helpers.delay(1000);
     await Helpers.swipe('wallet-screen', 'right');
     await Helpers.delay(2000);
     await Helpers.checkIfElementByTextIsVisible('PKEY');
+  });
+
+  it('Should navigate to Settings Modal after tapping Settings Button', async () => {
+    await Helpers.tap('settings-button');
+    await Helpers.delay(3000);
+    await Helpers.checkIfVisible('settings-modal');
+  });
+
+  it('Should navigate to Developer Settings after tapping Developer Section', async () => {
+    await Helpers.tap('developer-section');
+    await Helpers.delay(3000);
+    await Helpers.checkIfVisible('developer-settings-modal');
+  });
+
+  it('Should reset keychain & reopen app', async () => {
+    await Helpers.tap('reset-keychain-section');
+    await device.launchApp({ newInstance: true });
+    await device.disableSynchronization();
+    await Helpers.delay(5000);
+    await Helpers.checkIfVisible('welcome-screen');
+  });
+
+  it('without 0x - Should show the "Restore Sheet" after tapping on "I already have a wallet"', async () => {
+    await Helpers.tap('already-have-wallet-button');
+    await Helpers.delay(2000);
+    await Helpers.checkIfExists('restore-sheet');
+  });
+
+  it('without 0x - Show the "Import Sheet" when tapping on "Restore with a recovery phrase or private key"', async () => {
+    await Helpers.tap('restore-with-key-button');
+    await Helpers.delay(2000);
+    await Helpers.checkIfExists('import-sheet');
+  });
+
+  it('without 0x - Should show the "Add wallet modal" after tapping import with a valid private key"', async () => {
+    await Helpers.typeText(
+      'import-sheet-input',
+      process.env.DEV_PKEY.substring(2),
+      false
+    );
+    await Helpers.delay(1000);
+    await Helpers.checkIfElementHasString(
+      'import-sheet-button-label',
+      'Import'
+    );
+    await Helpers.tap('import-sheet-button');
+    await Helpers.checkIfVisible('wallet-info-modal');
+  });
+
+  it('without 0x - Should navigate to the Wallet screen after tapping on "Import Wallet"', async () => {
+    await Helpers.delay(2000);
+    await Helpers.checkIfVisible('wallet-info-input');
+    await Helpers.typeText('wallet-info-input', 'TKEY', false);
+    await Helpers.tap('wallet-info-submit-button');
+    await Helpers.delay(4000);
+    await Helpers.checkIfVisible('wallet-screen');
+  });
+
+  // Saving for now in case we want to test iCloud back up sheet
+  // it('Should show the backup sheet', async () => {
+  //   await Helpers.delay(3000);
+  //   await Helpers.checkIfVisible('backup-sheet');
+  //   await Helpers.tap('backup-sheet-imported-cancel-button');
+  // });
+
+  it('without 0x - Should say "TKEY" in the Profile Screen header', async () => {
+    await Helpers.delay(1000);
+    await Helpers.swipe('wallet-screen', 'right');
+    await Helpers.delay(2000);
+    await Helpers.checkIfElementByTextIsVisible('TKEY');
   });
 
   afterAll(async () => {

--- a/src/components/settings-menu/DevSection.js
+++ b/src/components/settings-menu/DevSection.js
@@ -64,7 +64,11 @@ const DevSection = () => {
   return (
     <ScrollView testID="developer-settings-modal">
       <ListItem label="💥 Clear async storage" onPress={AsyncStorage.clear} />
-      <ListItem label="💣 Reset Keychain" onPress={wipeKeychain} />
+      <ListItem
+        label="💣 Reset Keychain"
+        onPress={wipeKeychain}
+        testID="reset-keychain-section"
+      />
       <ListItem label="🔄 Restart app" onPress={Restart} />
       <ListItem label="🗑️ Remove all backups" onPress={removeBackups} />
       <ListItem

--- a/src/hooks/useWalletsDebug.js
+++ b/src/hooks/useWalletsDebug.js
@@ -3,6 +3,7 @@ import { captureException } from '@sentry/react-native';
 import { isEmpty, map } from 'lodash';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { addHexPrefix } from '../handlers/web3';
 import WalletTypes from '../helpers/walletTypes';
 import { loadAllKeys } from '../model/keychain';
 import {
@@ -85,7 +86,7 @@ export default function useWalletsDebug() {
 
           let wallet;
           if (type === WalletTypes.privateKey) {
-            wallet = new Wallet(seedObject.seedphrase);
+            wallet = new Wallet(addHexPrefix(seedObject.seedphrase));
           } else {
             const walletData = getWallet(seedObject.seedphrase);
             wallet = walletData.wallet;

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -453,7 +453,7 @@ export const getWallet = (
   const type = identifyWalletType(walletSeed);
   switch (type) {
     case EthereumWalletType.privateKey:
-      wallet = new Wallet(walletSeed);
+      wallet = new Wallet(addHexPrefix(walletSeed));
       break;
     case EthereumWalletType.mnemonic:
       hdnode = HDNode.fromMnemonic(walletSeed);
@@ -474,7 +474,6 @@ export const getWallet = (
     const node = hdnode.derivePath(`${DEFAULT_HD_PATH}/0`);
     wallet = new Wallet(node.privateKey);
   }
-
   return { hdnode, isHDWallet, type, wallet };
 };
 
@@ -878,7 +877,7 @@ const migrateSecrets = async (): Promise<MigratedSecretsResult | null> => {
       existingAccount: undefined | Wallet;
     switch (type) {
       case EthereumWalletType.privateKey:
-        existingAccount = new Wallet(seedphrase);
+        existingAccount = new Wallet(addHexPrefix(seedphrase));
         break;
       case EthereumWalletType.mnemonic:
         hdnode = HDNode.fromMnemonic(seedphrase);


### PR DESCRIPTION
The ethers upgrade is more strict about the hex values it receives in certain functions (including the Wallet object creation). When we identify an input is a private key, we will now explicitly prefix it with 0x if needed before passing it along to the Wallet object.