### PR TITLE
Fix linting errors

### DIFF
--- a/src/components/exchange/index.js
+++ b/src/components/exchange/index.js
@@ -1,9 +1,3 @@
-/* eslint-disable import/no-cycle */
-
-// disabled because cycle is created by outside file that import files from
-// this folder - it wouldn't make sense to separate them there
-// and break imports concept just to remove eslint error here
-
 export { default as ConfirmExchangeButton } from './ConfirmExchangeButton';
 export { default as CurrencySelectionList } from './CurrencySelectionList';
 export { default as CurrencySelectModalHeader } from './CurrencySelectModalHeader';


### PR DESCRIPTION
The linter is not complaining about the no-cycle error anymore, so we have to remove it in order to prevent an error.