### PR TITLE
Optimize swap list

### DIFF
--- a/src/components/exchange/ExchangeAssetList.js
+++ b/src/components/exchange/ExchangeAssetList.js
@@ -76,13 +76,14 @@ const ExchangeAssetSectionList = styled(SectionList).attrs({
   contentContainerStyle,
   directionalLockEnabled: true,
   getItemLayout,
-  initialNumToRender: 8,
+  initialNumToRender: 10,
   keyboardDismissMode: 'none',
   keyboardShouldPersistTaps: 'always',
   keyExtractor,
+  maxToRenderPerBatch: 50,
   scrollEventThrottle: 32,
   scrollIndicatorInsets,
-  windowSize: 11,
+  windowSize: 41,
 })`
   height: 100%;
 `;


### PR DESCRIPTION
this gives the swap asset list slightly more resources, enough that the list items render in time when scrolling quickly. would previously see white gaps in the list