### PR TITLE
Allow automatic redirects for native apps

### DIFF
--- a/src/handlers/deeplinks.js
+++ b/src/handlers/deeplinks.js
@@ -34,11 +34,11 @@ function handleWalletConnect(uri) {
   const { query } = new URL(uri);
   if (uri && query) {
     dispatch(
-      walletConnectOnSessionRequest(uri, status => {
+      walletConnectOnSessionRequest(uri, (status, dappScheme) => {
         if (status === 'reject') {
-          dispatch(walletConnectRemovePendingRedirect('reject'));
+          dispatch(walletConnectRemovePendingRedirect('reject', dappScheme));
         } else {
-          dispatch(walletConnectRemovePendingRedirect('connect'));
+          dispatch(walletConnectRemovePendingRedirect('connect', dappScheme));
         }
       })
     );

--- a/src/redux/requests.js
+++ b/src/redux/requests.js
@@ -50,10 +50,12 @@ export const addRequestToApprove = (
   const dappName =
     dappNameOverride(peerMeta.url) || peerMeta.name || 'Unknown Dapp';
   const dappUrl = peerMeta.url || 'Unknown Url';
+  const dappScheme = peerMeta.scheme || null;
 
   const request = {
     clientId,
     dappName,
+    dappScheme,
     dappUrl,
     displayDetails,
     imageUrl,

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -171,6 +171,7 @@ const TransactionConfirmationScreen = () => {
     callback,
     transactionDetails: {
       dappName,
+      dappScheme,
       dappUrl,
       displayDetails,
       imageUrl,
@@ -263,7 +264,7 @@ const TransactionConfirmationScreen = () => {
           if (canceled) {
             type = `${type}-canceled`;
           }
-          dispatch(walletConnectRemovePendingRedirect(type));
+          dispatch(walletConnectRemovePendingRedirect(type, dappScheme));
         });
       }
     },
@@ -273,6 +274,7 @@ const TransactionConfirmationScreen = () => {
       pendingRedirect,
       stopPollingGasPrices,
       method,
+      dappScheme,
       dispatch,
     ]
   );


### PR DESCRIPTION
This allows native apps to pass the scheme that we can use to redirect back. If they send it, we avoid the confirmation sheet and redirect back instead.

We can't really test this until https://github.com/WalletConnect/WalletConnectSwift/pull/34 and https://github.com/WalletConnect/WalletConnectSwift/pull/35 get merged, but here's the PoW: https://recordit.co/60R7Vj3a6E

@skylarbarrera  Just make sure this doesn't break any of the existing WC behavior (it shouldn't!)