### PR TITLE
Ganache fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,7 @@ import { connect, Provider } from 'react-redux';
 import { compose, withProps } from 'recompact';
 import PortalConsumer from './components/PortalConsumer';
 import { FlexItem } from './components/layout';
-import { OfflineToast, TestnetToast } from './components/toasts';
+import { OfflineToast } from './components/toasts';
 import {
   reactNativeDisableYellowBox,
   reactNativeEnableLogbox,
@@ -257,7 +257,6 @@ class App extends Component {
                 </InitialRouteContext.Provider>
               )}
               <OfflineToast />
-              <TestnetToast network={this.props.network} />
             </FlexItem>
           </Provider>
         </SafeAreaProvider>

--- a/src/components/toasts/TestnetToast.js
+++ b/src/components/toasts/TestnetToast.js
@@ -40,5 +40,4 @@ const TestnetToast = () => {
   );
 };
 
-const neverRerender = () => true;
-export default React.memo(TestnetToast, neverRerender);
+export default TestnetToast;

--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -1,12 +1,15 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
-import { useCoinListEdited } from '../hooks';
+import { FlexItem } from '../components/layout';
+import { TestnetToast } from '../components/toasts';
+import { useAccountSettings, useCoinListEdited } from '../hooks';
 import ProfileScreen from '../screens/ProfileScreen';
 import QRScannerScreen from '../screens/QRScannerScreen';
 import WalletScreen from '../screens/WalletScreen';
 import { deviceUtils } from '../utils';
 import ScrollPagerWrapper, { scrollPosition } from './ScrollPagerWrapper';
 import Routes from './routesNames';
+
 const Swipe = createMaterialTopTabNavigator();
 
 const renderTabBar = () => null;
@@ -15,22 +18,26 @@ const renderPager = props => <ScrollPagerWrapper {...props} />;
 
 export function SwipeNavigator() {
   const { isCoinListEdited } = useCoinListEdited();
+  const { network } = useAccountSettings();
 
   return (
-    <Swipe.Navigator
-      initialLayout={deviceUtils.dimensions}
-      initialRouteName={Routes.WALLET_SCREEN}
-      pager={renderPager}
-      position={scrollPosition}
-      swipeEnabled={!isCoinListEdited}
-      tabBar={renderTabBar}
-    >
-      <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} />
-      <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} />
-      <Swipe.Screen
-        component={QRScannerScreen}
-        name={Routes.QR_SCANNER_SCREEN}
-      />
-    </Swipe.Navigator>
+    <FlexItem>
+      <Swipe.Navigator
+        initialLayout={deviceUtils.dimensions}
+        initialRouteName={Routes.WALLET_SCREEN}
+        pager={renderPager}
+        position={scrollPosition}
+        swipeEnabled={!isCoinListEdited}
+        tabBar={renderTabBar}
+      >
+        <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} />
+        <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} />
+        <Swipe.Screen
+          component={QRScannerScreen}
+          name={Routes.QR_SCANNER_SCREEN}
+        />
+      </Swipe.Navigator>
+      <TestnetToast network={network} />
+    </FlexItem>
   );
 }


### PR DESCRIPTION
This PR fixes two things:

- Moves the testnet toast to the top level views (Profile / wallet / scanner) to prevent overlap with other UI elements
- Fixes the bug that was preventing the ganache toast to not show up making e2e test fails.

All the iOS e2e tests are now passing locally.
