### PR TITLE
Fix charts

### DIFF
--- a/src/components/value-chart/Chart.js
+++ b/src/components/value-chart/Chart.js
@@ -203,41 +203,22 @@ export default function ChartWrapper({
         {showChart && (
           <>
             <Labels color={color} width={WIDTH} />
-            {android ? (
-              <ChartPath
-                fill="none"
-                gestureEnabled={!fetchingCharts && !!throttledData}
-                hapticsEnabled
-                height={HEIGHT}
-                hitSlop={30}
-                longPressGestureHandlerProps={{
-                  minDurationMs: 60,
-                }}
-                selectedStrokeWidth={3}
-                stroke={color}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={3.5}
-                width={WIDTH}
-              />
-            ) : (
-              <ChartPath
-                fill="none"
-                gestureEnabled={!fetchingCharts && !!throttledData}
-                hapticsEnabled
-                height={HEIGHT}
-                hitSlop={30}
-                longPressGestureHandlerProps={{
-                  minDurationMs: 60,
-                }}
-                selectedStrokeWidth={3}
-                stroke={color}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={3.5}
-                width={WIDTH}
-              />
-            )}
+            <ChartPath
+              fill="none"
+              gestureEnabled={!fetchingCharts && !!throttledData}
+              hapticsEnabled
+              height={HEIGHT}
+              hitSlop={30}
+              longPressGestureHandlerProps={{
+                minDurationMs: 60,
+              }}
+              selectedStrokeWidth={3}
+              stroke={color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3.5}
+              width={WIDTH}
+            />
             <Dot color={colors.alpha(color, 0.03)} size={65}>
               <InnerDot color={color} />
             </Dot>


### PR DESCRIPTION
Both iOS and Android props are the same, so there's no need to keep it.

This looks like it fixed the problem where the label "Today" was showing up ~ 1 second later after the sheet was opened.

Before the fix: http://recordit.co/VlMLP1s6H1

After the fix: https://recordit.co/G9UE4g0Sfu