### PR TITLE
Android branch fixes

### DIFF
--- a/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
@@ -9,11 +9,10 @@ import supportedNativeCurrencies from '@rainbow-me/references/native-currencies.
 import { fonts, fontWithWidth } from '@rainbow-me/styles';
 
 const Label = styled(ChartYLabel)`
-  ${fontWithWidth(fonts.weight.bold)};
+  ${fontWithWidth(fonts.weight.heavy)};
   font-size: ${fonts.size.big};
   letter-spacing: ${fonts.letterSpacing.roundedTight};
-  font-variant: tabular-nums;
-  text-align: right;
+  width: 100%;
   ${android &&
     `margin-top: -8;
      margin-bottom: -16;`}

--- a/src/components/fab/FabWrapper.js
+++ b/src/components/fab/FabWrapper.js
@@ -7,7 +7,7 @@ import SendFab from './SendFab';
 
 export const FabWrapperBottomPosition = 21 + safeAreaInsetValues.bottom;
 
-const FabWrapperRow = styled(RowWithMargins).attrs({ margin: 6 })`
+const FabWrapperRow = styled(RowWithMargins).attrs({ margin: 12 })`
   bottom: ${({ isEditMode }) => (isEditMode ? -60 : FabWrapperBottomPosition)};
   position: absolute;
   right: 15;


### PR DESCRIPTION
- use heavy font weight for chart price label
- remove monospace setting on chart price label
- fix chart price label truncation when scrubbing by giving it a fixed width
- increase spacing between FABs