### PR TITLE
Fix ripple effect area across the app

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -26,6 +26,10 @@ const ButtonContainer = styled(Centered).attrs({ direction: 'column' })`
 
 const InterstitialButton = styled(ButtonPressAnimation).attrs({
   backgroundColor: colors.alpha(colors.blueGreyDark, 0.06),
+  wrapperProps: {
+    containerStyle: { height: 45, width: 240 },
+    style: { flex: 1 },
+  },
 })`
   ${padding(10.5, 15, 14.5)};
   border-radius: 23px;
@@ -130,7 +134,7 @@ const AmountButton = ({ amount, backgroundColor, color, onPress }) => {
 
   return (
     <AmountButtonWrapper>
-      <AmountBPA onPress={handlePress}>
+      <AmountBPA onPress={handlePress} radiusAndroid={25}>
         <ShadowStack
           {...position.coverAsObject}
           backgroundColor={backgroundColor}
@@ -208,17 +212,22 @@ const AddFundsInterstitial = ({ network, offsetY = 0 }) => {
                 onPress={handlePressAmount}
               />
             </Row>
-            <InterstitialButton onPress={handlePressAmount}>
-              <Text
-                align="center"
-                color={colors.alpha(colors.blueGreyDark, 0.6)}
-                lineHeight="loose"
-                size="large"
-                weight="bold"
+            <Row>
+              <InterstitialButton
+                onPress={handlePressAmount}
+                radiusAndroid={23}
               >
-                􀍡 Other amount
-              </Text>
-            </InterstitialButton>
+                <Text
+                  align="center"
+                  color={colors.alpha(colors.blueGreyDark, 0.6)}
+                  lineHeight="loose"
+                  size="large"
+                  weight="bold"
+                >
+                  􀍡 Other amount
+                </Text>
+              </InterstitialButton>
+            </Row>
             {!isSmallPhone && <InterstitialDivider />}
             <Subtitle isSmallPhone={isSmallPhone}>
               or send ETH to your wallet
@@ -260,6 +269,7 @@ const AddFundsInterstitial = ({ network, offsetY = 0 }) => {
         )}
         <CopyAddressButton
           onPress={handlePressCopyAddress}
+          radiusAndroid={23}
           testID="copy-address-button"
         >
           <RowWithMargins margin={6}>

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -27,7 +27,7 @@ const ButtonContainer = styled(Centered).attrs({ direction: 'column' })`
 const InterstitialButton = styled(ButtonPressAnimation).attrs({
   backgroundColor: colors.alpha(colors.blueGreyDark, 0.06),
   wrapperProps: {
-    containerStyle: { height: 45, width: 240 },
+    containerStyle: { height: 45, width: 200 },
     style: { flex: 1 },
   },
 })`

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -92,7 +92,7 @@ const AmountText = styled(Text).attrs({
   size: 'bigger',
   weight: 'heavy',
 })`
-  ${padding(24, 15, 25)};
+  ${android ? padding(15) : padding(24, 15, 25)};
   align-self: center;
   text-shadow: 0px 0px 20px ${({ color }) => color};
   z-index: 1;

--- a/src/components/floating-emojis/CopyFloatingEmojis.js
+++ b/src/components/floating-emojis/CopyFloatingEmojis.js
@@ -33,6 +33,12 @@ const CopyFloatingEmojis = ({
               setClipboard(textToCopy);
             }
           }}
+          radiusAndroid={24}
+          wrapperProps={{
+            containerStyle: {
+              padding: 10,
+            },
+          }}
         >
           {children}
         </ButtonPressAnimation>

--- a/src/components/header/BackButton.js
+++ b/src/components/header/BackButton.js
@@ -34,6 +34,15 @@ export default function BackButton({
   return (
     <HeaderButton
       onPress={handlePress}
+      opacityTouchable={false}
+      radiusAndroid={42}
+      radiusWrapperStyle={{
+        alignItems: 'center',
+        height: 42,
+        justifyContent: 'center',
+        marginRight: 5,
+        width: 42,
+      }}
       testID={testID + '-back-button'}
       throttle={throttle}
       transformOrigin={direction}

--- a/src/components/header/HeaderButton.js
+++ b/src/components/header/HeaderButton.js
@@ -3,9 +3,9 @@ import { ButtonPressAnimation } from '../animations';
 import { padding } from '@rainbow-me/styles';
 
 const HeaderButton = styled(ButtonPressAnimation).attrs(
-  ({ scaleTo = 0.8 }) => ({
+  ({ scaleTo = 0.8, opacityTouchable = true }) => ({
     compensateForTransformOrigin: true,
-    opacityTouchable: true,
+    opacityTouchable,
     scaleTo,
   })
 )`

--- a/src/components/profile/ProfileAction.js
+++ b/src/components/profile/ProfileAction.js
@@ -24,7 +24,7 @@ const ProfileActionIcon = styled(Icon).attrs({
 `;
 
 const ProfileAction = ({ icon, iconSize = 16, onPress, text, ...props }) => (
-  <ButtonPressAnimation onPress={onPress} {...props}>
+  <ButtonPressAnimation onPress={onPress} radiusAndroid={24} {...props}>
     <Container>
       <ProfileActionIcon iconSize={iconSize} name={icon} />
       <Text

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -252,7 +252,20 @@ export default function ProfileMasthead({
         isAvatarPickerAvailable={isAvatarPickerAvailable}
         onPress={handlePressAvatar}
       />
-      <ButtonPressAnimation onPress={handlePressChangeWallet} scaleTo={0.9}>
+      <ButtonPressAnimation
+        onPress={handlePressChangeWallet}
+        radiusAndroid={24}
+        scaleTo={0.9}
+        wrapperProps={{
+          containerStyle: {
+            alignItems: 'center',
+            height: 40,
+            justifyContent: 'center',
+            paddingTop: 5,
+            width: 250,
+          },
+        }}
+      >
         <Row>
           <AccountName deviceWidth={deviceWidth}>{accountName}</AccountName>
           <DropdownArrow>
@@ -264,17 +277,33 @@ export default function ProfileMasthead({
         <ProfileAction
           icon="copy"
           onPress={handlePressCopyAddress}
+          radiusWrapperStyle={{ marginRight: 10, width: 150 }}
           scaleTo={0.88}
           text="Copy Address"
           width={127}
+          wrapperProps={{
+            containerStyle: {
+              alignItems: 'flex-start',
+              justifyContent: 'flex-start',
+              paddingLeft: 10,
+            },
+          }}
         />
         <FloatingEmojisRegion setOnNewEmoji={setOnNewEmoji} />
         <ProfileAction
           icon="qrCode"
           onPress={handlePressReceive}
+          radiusWrapperStyle={{ marginRight: 10, width: 104 }}
           scaleTo={0.88}
           text="Receive"
           width={81}
+          wrapperProps={{
+            containerStyle: {
+              alignItems: 'flex-start',
+              justifyContent: 'flex-start',
+              paddingLeft: 10,
+            },
+          }}
         />
       </RowWithMargins>
       {addCashAvailable && <AddCashButton onPress={handlePressAddCash} />}

--- a/src/components/qr-code/ShareButton.js
+++ b/src/components/qr-code/ShareButton.js
@@ -30,7 +30,7 @@ export default function ShareButton({ accountAddress, ...props }) {
   }, [accountAddress]);
 
   return (
-    <ButtonPressAnimation onPress={handlePress} {...props}>
+    <ButtonPressAnimation onPress={handlePress} radiusAndroid={28} {...props}>
       <ShadowStack
         backgroundColor={colors.dark}
         borderRadius={28}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -73,7 +73,19 @@ export default function ProfileScreen({ navigation }) {
   return (
     <ProfileScreenPage testID="profile-screen">
       <Header justify="space-between">
-        <HeaderButton onPress={onPressSettings} testID="settings-button">
+        <HeaderButton
+          onPress={onPressSettings}
+          opacityTouchable={false}
+          radiusAndroid={42}
+          radiusWrapperStyle={{
+            alignItems: 'center',
+            height: 42,
+            justifyContent: 'center',
+            marginLeft: 5,
+            width: 42,
+          }}
+          testID="settings-button"
+        >
           <Icon color={colors.black} name="gear" />
         </HeaderButton>
         <BackButton


### PR DESCRIPTION
There are probably more but this takes care of what a brand new user sees for the first time.

- Fixes the height & shape and ripple effect area of the amount buttons
- Fixes the ripple area of the "other amount" button
- Fixes the ripple area of the "copy address" button
- Fixes the ripple area of the profile navbar buttons
- Fixes the ripple area of the profile header buttons
- Fixes the ripple area of the receive modal buttons


Before: http://recordit.co/sDGnLhpEXU

After:  http://recordit.co/qQ0IS7XYG2
