### PR TITLE
Patch packages properly

### DIFF
--- a/patches/@ethersproject+providers+5.0.12.patch
+++ b/patches/@ethersproject+providers+5.0.12.patch
@@ -2,38 +2,16 @@ diff --git a/node_modules/@ethersproject/providers/package.json b/node_modules/@
 index 843c319..83a436b 100644
 --- a/node_modules/@ethersproject/providers/package.json
 +++ b/node_modules/@ethersproject/providers/package.json
-@@ -2,18 +2,41 @@
-   "author": "Richard Moore <me@ricmoo.com>",
+@@ -3,7 +3,7 @@
    "browser": {
      "./lib/ipc-provider": "./lib/browser-ipc-provider.js",
--    "net": "./lib/browser-net.js",
--    "ws": "./lib/browser-ws.js"
-+    "net": "react-native-tcp",
+     "net": "react-native-tcp",
+-    "ws": "./lib/browser-ws.js",
 +    "ws": "./providers/lib/browser-ws.js",
-+    "zlib": "browserify-zlib",
-+    "console": "console-browserify",
-+    "constants": "constants-browserify",
-+    "crypto": "react-native-crypto",
-+    "dns": "dns.js",
-+    "domain": "domain-browser",
-+    "http": "@tradle/react-native-http",
-+    "https": "https-browserify",
-+    "os": "react-native-os",
-+    "path": "path-browserify",
-+    "querystring": "querystring-es3",
-+    "fs": "react-native-level-fs",
-+    "_stream_transform": "readable-stream/transform",
-+    "_stream_readable": "readable-stream/readable",
-+    "_stream_writable": "readable-stream/writable",
-+    "_stream_duplex": "readable-stream/duplex",
-+    "_stream_passthrough": "readable-stream/passthrough",
-+    "dgram": "react-native-udp",
-+    "stream": "stream-browserify",
-+    "timers": "timers-browserify",
-+    "tty": "tty-browserify",
-+    "vm": "vm-browserify",
-+    "tls": false
-   },
+     "zlib": "browserify-zlib",
+     "console": "console-browserify",
+     "constants": "constants-browserify",
+@@ -31,12 +31,12 @@
    "browser.esm": {
      "./lib.esm/ipc-provider": "./lib.esm/browser-ipc-provider.js",
      "net": "./lib.esm/browser-net.js",
@@ -48,38 +26,12 @@ index 843c319..83a436b 100644
    },
    "dependencies": {
      "@ethersproject/abstract-provider": "^5.0.4",
-@@ -59,5 +82,33 @@
-   },
-   "tarballHash": "0x473ceddb28dd396cfb35fc43187f2a09c4e752e908b80a933432bcb5ad5eae85",
-   "types": "./lib/index.d.ts",
--  "version": "5.0.12"
-+  "version": "5.0.12",
-+  "react-native": {
-+    "./lib/ipc-provider": "./lib/browser-ipc-provider.js",
-+    "net": "react-native-tcp",
+@@ -86,7 +86,7 @@
+   "react-native": {
+     "./lib/ipc-provider": "./lib/browser-ipc-provider.js",
+     "net": "react-native-tcp",
+-    "ws": "./lib/browser-ws.js",
 +    "ws": "./providers/lib/browser-ws.js",
-+    "zlib": "browserify-zlib",
-+    "console": "console-browserify",
-+    "constants": "constants-browserify",
-+    "crypto": "react-native-crypto",
-+    "dns": "dns.js",
-+    "domain": "domain-browser",
-+    "http": "@tradle/react-native-http",
-+    "https": "https-browserify",
-+    "os": "react-native-os",
-+    "path": "path-browserify",
-+    "querystring": "querystring-es3",
-+    "fs": "react-native-level-fs",
-+    "_stream_transform": "readable-stream/transform",
-+    "_stream_readable": "readable-stream/readable",
-+    "_stream_writable": "readable-stream/writable",
-+    "_stream_duplex": "readable-stream/duplex",
-+    "_stream_passthrough": "readable-stream/passthrough",
-+    "dgram": "react-native-udp",
-+    "stream": "stream-browserify",
-+    "timers": "timers-browserify",
-+    "tty": "tty-browserify",
-+    "vm": "vm-browserify",
-+    "tls": false
-+  }
- }
+     "zlib": "browserify-zlib",
+     "console": "console-browserify",
+     "constants": "constants-browserify",

--- a/patches/react-native-keychain+6.2.0.patch
+++ b/patches/react-native-keychain+6.2.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-keychain/RNKeychainManager/RNKeychainManager.m b/node_modules/react-native-keychain/RNKeychainManager/RNKeychainManager.m
-index 98e45fe..e5cbf2f 100644
+index 98e45fe..01e9b76 100644
 --- a/node_modules/react-native-keychain/RNKeychainManager/RNKeychainManager.m
 +++ b/node_modules/react-native-keychain/RNKeychainManager/RNKeychainManager.m
-@@ -542,4 +629,91 @@ - (OSStatus)deleteCredentialsForServer:(NSString *)server
+@@ -542,4 +542,91 @@ - (OSStatus)deleteCredentialsForServer:(NSString *)server
  }
  #endif
  

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -2,9 +2,6 @@
 
 set -eo pipefail
 
-patch-package
-echo "✅ All patches applied"
-
 # Specifying ONLY the node packages that we need to install via browserify
 # (because those aren't available in react native) and some of our deps require them.
 # If we don't specify which packages, rn-nodeify  will look into each package.json
@@ -28,7 +25,6 @@ else
   echo "Please make sure the file exists and it's located in the root of the project"
 fi
 
-#rm -rf node_modules/react-native-reanimated
-#cp -R  patches/reanimated node_modules/react-native-reanimated
+patch-package
+echo "✅ All patches applied"
 
-echo "✅ Reanimated moved from patches to mode_modules"


### PR DESCRIPTION
We were running the `patch-package` command on the postinstall script before `rn-nodeify` meaning that packages were being modified after being patched.  This was preventing the patch to be re-applied a second time since it didn't match with the original source.

To fix this I had to do two things:
- Regenerate affected patches AFTER running rn-nodeify
- Move the patch-package command at the end of the postinstall.sh script