### PR TITLE
Fix random byte generation

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -354,6 +354,8 @@ PODS:
     - React-Core
   - react-native-cloud-fs (2.1.0):
     - React
+  - react-native-get-random-values (1.5.0):
+    - React
   - react-native-mail (4.1.0):
     - React
   - react-native-netinfo (5.9.7):
@@ -622,6 +624,7 @@ DEPENDENCIES:
   - react-native-branch (from `../node_modules/react-native-branch`)
   - react-native-camera (from `../node_modules/react-native-camera`)
   - react-native-cloud-fs (from `../node_modules/react-native-cloud-fs`)
+  - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - react-native-mail (from `../node_modules/react-native-mail`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
@@ -779,6 +782,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-camera"
   react-native-cloud-fs:
     :path: "../node_modules/react-native-cloud-fs"
+  react-native-get-random-values:
+    :path: "../node_modules/react-native-get-random-values"
   react-native-mail:
     :path: "../node_modules/react-native-mail"
   react-native-netinfo:
@@ -956,6 +961,7 @@ SPEC CHECKSUMS:
   react-native-branch: 8bda99ca8dc5a16d32bd81c8a8d937cb3d2c5e0c
   react-native-camera: 35854c4f764a4a6cf61c1c3525888b92f0fe4b31
   react-native-cloud-fs: 8339f6e6e353f266f63a3f754882637443bc4c2c
+  react-native-get-random-values: 1404bd5cc0ab0e287f75ee1c489555688fc65f89
   react-native-mail: a864fb211feaa5845c6c478a3266de725afdce89
   react-native-netinfo: 250dc0ca126512f618a8a2ca6a936577e1f66586
   react-native-randombytes: 3638d24759d67c68f6ccba60c52a7a8a8faa6a23

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "react-native-fast-image": "^8.1.5",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "1.7.0",
+    "react-native-get-random-values": "^1.5.0",
     "react-native-haptic-feedback": "^1.8.2",
     "react-native-image-crop-picker": "^0.32.2",
     "react-native-indicators": "0.17.0",

--- a/shim.js
+++ b/shim.js
@@ -1,3 +1,4 @@
+import 'react-native-get-random-values';
 // eslint-disable-next-line import/no-unresolved
 import '@ethersproject/shims';
 import AsyncStorage from '@react-native-community/async-storage';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,6 +6346,11 @@ fancy-log@^1.3.2:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -11301,6 +11306,13 @@ react-native-gesture-handler@1.7.0:
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.4"
     prop-types "^15.7.2"
+
+react-native-get-random-values@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.5.0.tgz#91cda18f0e66e3d9d7660ba80c61c914030c1e05"
+  integrity sha512-LK+Wb8dEimJkd/dub7qziDmr9Tw4chhpzVeQ6JDo4czgfG4VXbptRyOMdu8503RiMF6y9pTH6ZUTkrrpprqT7w==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 react-native-haptic-feedback@^1.8.2:
   version "1.11.0"


### PR DESCRIPTION
Fixes this warning:

![Screen Shot 2020-11-13 at 3 07 28 AM](https://user-images.githubusercontent.com/1247834/99044866-72510d00-255e-11eb-9a41-303f973cd75f.png)


After the fix the warning is gone, randomBytes doesn't get shimmed with an insecure source and also confirmed that random byte generation is working correctly for both OS


![Screen Shot 2020-11-13 at 3 16 37 AM](https://user-images.githubusercontent.com/1247834/99045114-d96ec180-255e-11eb-8697-d197235bd3e3.png)
