### PR TITLE
add sendFlowNavigator to android

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -45,6 +45,26 @@ import { colors } from '@rainbow-me/styles';
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();
 
+function SendFlowNavigator() {
+  return (
+    <Stack.Navigator
+      {...stackNavigationConfig}
+      initialRouteName={Routes.SEND_SHEET}
+    >
+      <Stack.Screen
+        component={ModalScreen}
+        name={Routes.MODAL_SCREEN}
+        options={overlayExpandedPreset}
+      />
+      <Stack.Screen
+        component={SendSheet}
+        name={Routes.SEND_SHEET}
+        options={bottomSheetPreset}
+      />
+    </Stack.Navigator>
+  );
+}
+
 function ImportSeedPhraseFlowNavigator() {
   return (
     <Stack.Navigator
@@ -192,7 +212,10 @@ function MainNativeNavigator() {
         component={PinAuthenticationScreen}
         name={Routes.PIN_AUTHENTICATION_SCREEN}
       />
-      <NativeStack.Screen component={SendSheet} name={Routes.SEND_SHEET} />
+      <NativeStack.Screen
+        component={SendFlowNavigator}
+        name={Routes.SEND_SHEET_NAVIGATOR}
+      />
       <NativeStack.Screen component={BackupSheet} name={Routes.BACKUP_SCREEN} />
     </NativeStack.Navigator>
   );

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -73,7 +73,9 @@ const RoutesWithNativeStackAvailability = {
   IMPORT_SEED_PHRASE_FLOW: isNativeStackAvailable
     ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
     : Routes.IMPORT_SEED_PHRASE_SHEET,
-  SEND_FLOW: Routes.SEND_SHEET_NAVIGATOR,
+  SEND_FLOW: isNativeStackAvailable || android
+    ? Routes.SEND_SHEET_NAVIGATOR
+    : Routes.SEND_SHEET,
 };
 
 export default RoutesWithNativeStackAvailability;

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -73,9 +73,7 @@ const RoutesWithNativeStackAvailability = {
   IMPORT_SEED_PHRASE_FLOW: isNativeStackAvailable
     ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
     : Routes.IMPORT_SEED_PHRASE_SHEET,
-  SEND_FLOW: isNativeStackAvailable
-    ? Routes.SEND_SHEET_NAVIGATOR
-    : Routes.SEND_SHEET,
+  SEND_FLOW: Routes.SEND_SHEET_NAVIGATOR,
 };
 
 export default RoutesWithNativeStackAvailability;


### PR DESCRIPTION
this fixes an issue where the addContact modal would navigate back to walletScreen. Probably needs a few tweaks but this follows the pattern on iOS.


@brunobar79  @osdnk lmk if you guys want to pick up or what I should do to make better