### PR TITLE
Surface Uniswap V2 LP tokens

### DIFF
--- a/src/components/coin-icon/CoinIconGroup.js
+++ b/src/components/coin-icon/CoinIconGroup.js
@@ -1,3 +1,4 @@
+import { map } from 'lodash';
 import React from 'react';
 import styled from 'styled-components/primitives';
 import { CoinIcon } from '../coin-icon';
@@ -44,9 +45,9 @@ export default function CoinIconGroup({ containerStyles, tokens }) {
 
   return (
     <Container css={containerStyles} shouldCenter={sizesTable[size].breakIndex}>
-      {slicedArray.map((setOfTokens, lineIndex) => (
+      {map(slicedArray, (setOfTokens, lineIndex) => (
         <LineWrapper key={`coinLine_${lineIndex}`}>
-          {setOfTokens.map((tokenSymbol, index) => (
+          {map(setOfTokens, (tokenSymbol, index) => (
             <Wrapper
               key={`coin_${index}_${lineIndex}`}
               width={sizesTable[size].width}

--- a/src/components/coin-icon/CoinIconGroup.js
+++ b/src/components/coin-icon/CoinIconGroup.js
@@ -50,6 +50,7 @@ export default function CoinIconGroup({ containerStyles, tokens }) {
             <Wrapper
               key={`coin_${index}_${lineIndex}`}
               width={sizesTable[size].width}
+              zIndex={-index}
             >
               <CoinIcon size={sizesTable[size].iconSize} symbol={tokenSymbol} />
             </Wrapper>

--- a/src/components/coin-icon/CoinIconGroup.js
+++ b/src/components/coin-icon/CoinIconGroup.js
@@ -46,15 +46,12 @@ export default function CoinIconGroup({ containerStyles, tokens }) {
     <Container css={containerStyles} shouldCenter={sizesTable[size].breakIndex}>
       {slicedArray.map((setOfTokens, lineIndex) => (
         <LineWrapper key={`coinLine_${lineIndex}`}>
-          {setOfTokens.map((token, index) => (
+          {setOfTokens.map((tokenSymbol, index) => (
             <Wrapper
               key={`coin_${index}_${lineIndex}`}
               width={sizesTable[size].width}
             >
-              <CoinIcon
-                size={sizesTable[size].iconSize}
-                symbol={token.tokenSymbol}
-              />
+              <CoinIcon size={sizesTable[size].iconSize} symbol={tokenSymbol} />
             </Wrapper>
           ))}
         </LineWrapper>

--- a/src/components/coin-icon/CoinIconGroup.js
+++ b/src/components/coin-icon/CoinIconGroup.js
@@ -47,13 +47,17 @@ export default function CoinIconGroup({ containerStyles, tokens }) {
     <Container css={containerStyles} shouldCenter={sizesTable[size].breakIndex}>
       {map(slicedArray, (setOfTokens, lineIndex) => (
         <LineWrapper key={`coinLine_${lineIndex}`}>
-          {map(setOfTokens, (tokenSymbol, index) => (
+          {map(setOfTokens, (token, index) => (
             <Wrapper
               key={`coin_${index}_${lineIndex}`}
               width={sizesTable[size].width}
               zIndex={-index}
             >
-              <CoinIcon size={sizesTable[size].iconSize} symbol={tokenSymbol} />
+              <CoinIcon
+                address={token.address}
+                size={sizesTable[size].iconSize}
+                symbol={token.symbol}
+              />
             </Wrapper>
           ))}
         </LineWrapper>

--- a/src/components/coin-row/CoinRow.js
+++ b/src/components/coin-row/CoinRow.js
@@ -37,10 +37,11 @@ export default function CoinRow({
   isHidden,
   isPinned,
   isPool,
+  name,
   symbol,
   testID,
   topRowRender,
-  tokenSymbols,
+  tokens,
   ...props
 }) {
   const accountSettings = useAccountSettings();
@@ -48,7 +49,7 @@ export default function CoinRow({
   return (
     <Container css={containerStyles}>
       {isPool ? (
-        <CoinIconGroup tokens={tokenSymbols} />
+        <CoinIconGroup tokens={tokens} />
       ) : (
         createElement(coinIconRender, {
           address,
@@ -61,7 +62,7 @@ export default function CoinRow({
       )}
       <Content isHidden={isHidden} justify="center" style={contentStyles}>
         <Row align="center" testID={`${testID}-${symbol || ''}`}>
-          {topRowRender({ symbol, tokenSymbols, ...accountSettings, ...props })}
+          {topRowRender({ name, symbol, ...accountSettings, ...props })}
         </Row>
         <Row align="center" marginBottom={0.5}>
           {bottomRowRender({ symbol, ...accountSettings, ...props })}

--- a/src/components/coin-row/CoinRow.js
+++ b/src/components/coin-row/CoinRow.js
@@ -61,7 +61,7 @@ export default function CoinRow({
       )}
       <Content isHidden={isHidden} justify="center" style={contentStyles}>
         <Row align="center" testID={`${testID}-${symbol || ''}`}>
-          {topRowRender({ symbol, ...accountSettings, ...props })}
+          {topRowRender({ symbol, tokenSymbols, ...accountSettings, ...props })}
         </Row>
         <Row align="center" marginBottom={0.5}>
           {bottomRowRender({ symbol, ...accountSettings, ...props })}

--- a/src/components/expanded-state/LiquidityPoolExpandedState.js
+++ b/src/components/expanded-state/LiquidityPoolExpandedState.js
@@ -69,8 +69,8 @@ const LiquidityPoolExpandedState = ({
         </TokenInfoRow>
       </TokenInfoSection>
       <SheetActionButtonRow>
-        <WithdrawActionButton symbol={lpTokenName} />
-        <DepositActionButton symbol={lpTokenName} />
+        <WithdrawActionButton symbol={lpTokenName} weight="bold" />
+        <DepositActionButton symbol={lpTokenName} weight="bold" />
       </SheetActionButtonRow>
     </SlackSheet>
   );

--- a/src/components/expanded-state/LiquidityPoolExpandedState.js
+++ b/src/components/expanded-state/LiquidityPoolExpandedState.js
@@ -1,4 +1,4 @@
-import { join, map, toLower } from 'lodash';
+import { map, toLower } from 'lodash';
 import React, { useMemo } from 'react';
 import { tokenOverrides } from '../../references';
 import { magicMemo } from '../../utils';
@@ -21,14 +21,13 @@ export const LiquidityPoolExpandedStateSheetHeight = 369 + (android ? 80 : 0);
 
 const LiquidityPoolExpandedState = ({
   asset: {
+    name,
     pricePerShare,
-    tokenSymbols,
     totalNativeDisplay,
     uniBalance,
     ...liquidityInfo
   },
 }) => {
-  const lpTokenName = join(tokenSymbols, '-');
   const tokenAssets = useMemo(() => {
     const { tokens } = liquidityInfo;
     return map(tokens, token => ({
@@ -45,6 +44,7 @@ const LiquidityPoolExpandedState = ({
     >
       <LiquidityPoolExpandedStateHeader
         assets={tokenAssets}
+        name={name}
         pricePerShare={pricePerShare}
       />
       <SheetDivider />
@@ -54,6 +54,7 @@ const LiquidityPoolExpandedState = ({
             return (
               <TokenInfoItem
                 asset={tokenAsset}
+                key={`tokeninfo-${tokenAsset.symbol}`}
                 title={`${tokenAsset.symbol} balance`}
               >
                 <TokenInfoBalanceValue />
@@ -69,8 +70,8 @@ const LiquidityPoolExpandedState = ({
         </TokenInfoRow>
       </TokenInfoSection>
       <SheetActionButtonRow>
-        <WithdrawActionButton symbol={lpTokenName} weight="bold" />
-        <DepositActionButton symbol={lpTokenName} weight="bold" />
+        <WithdrawActionButton symbol={name} weight="bold" />
+        <DepositActionButton symbol={name} weight="bold" />
       </SheetActionButtonRow>
     </SlackSheet>
   );

--- a/src/components/expanded-state/liquidity-pool/LiquidityPoolExpandedStateHeader.js
+++ b/src/components/expanded-state/liquidity-pool/LiquidityPoolExpandedStateHeader.js
@@ -1,5 +1,6 @@
 import { join, map } from 'lodash';
 import React, { useMemo } from 'react';
+import { View } from 'react-native';
 import styled from 'styled-components/primitives';
 import { useColorForAssets } from '../../../hooks/useColorForAsset';
 import { magicMemo } from '../../../utils';
@@ -45,7 +46,7 @@ function LiquidityPoolExpandedStateHeader({ assets, pricePerShare }) {
   const shadows = useMemo(() => {
     return map(assets, (asset, index) => {
       const coinIconShadow = [
-        [0, 4, 12, asset.shadowColor || colors[index], 0.3],
+        [0, 4, 12, asset.shadowColor || asset.color || colors[index], 0.3],
       ];
       return coinIconShadow;
     });
@@ -56,11 +57,15 @@ function LiquidityPoolExpandedStateHeader({ assets, pricePerShare }) {
       <Row align="center">
         {map(assets, (asset, index) => {
           return (
-            <CoinIcon
-              address={asset.address}
-              shadow={shadows[index]}
-              symbol={asset.symbol}
-            />
+            <View zIndex={-index}>
+              <CoinIcon
+                address={asset.address}
+                marginRight={-10}
+                position="relative"
+                shadow={shadows[index]}
+                symbol={asset.symbol}
+              />
+            </View>
           );
         })}
       </Row>

--- a/src/components/expanded-state/liquidity-pool/LiquidityPoolExpandedStateHeader.js
+++ b/src/components/expanded-state/liquidity-pool/LiquidityPoolExpandedStateHeader.js
@@ -1,8 +1,9 @@
+import { join, map } from 'lodash';
 import React, { useMemo } from 'react';
 import styled from 'styled-components/primitives';
-import { useColorForAsset } from '../../../hooks';
+import { useColorForAssets } from '../../../hooks/useColorForAsset';
 import { magicMemo } from '../../../utils';
-import { CoinIcon, CoinIconSize } from '../../coin-icon';
+import { CoinIcon } from '../../coin-icon';
 import { ColumnWithMargins, Row } from '../../layout';
 import { TruncatedText } from '../../text';
 import { colors, padding } from '@rainbow-me/styles';
@@ -11,15 +12,6 @@ const Container = styled(ColumnWithMargins).attrs({
   margin: 12,
 })`
   ${padding(0, 19, 24)};
-`;
-
-const ETHCoinIcon = styled(CoinIcon).attrs({
-  shadow: [[0, 4, 12, colors.dark, 0.3]],
-})`
-  bottom: 0;
-  left: ${CoinIconSize - 10};
-  position: absolute;
-  top: 0;
 `;
 
 const PerShareText = styled(TruncatedText).attrs({
@@ -43,24 +35,38 @@ const Title = styled(TruncatedText).attrs(({ color = colors.dark }) => ({
   weight: 'bold',
 }))``;
 
-function LiquidityPoolExpandedStateHeader({ asset }) {
-  const { address, pricePerShare, shadowColor, symbol } = asset;
+function LiquidityPoolExpandedStateHeader({ assets, pricePerShare }) {
+  const title = `${join(
+    map(assets, asset => asset.symbol),
+    '-'
+  )} Pool`;
+  const colors = useColorForAssets(assets);
 
-  const color = useColorForAsset(asset);
-  const coinIconShadow = useMemo(
-    () => [[0, 4, 12, shadowColor || color, 0.3]],
-    [color, shadowColor]
-  );
+  const shadows = useMemo(() => {
+    return map(assets, (asset, index) => {
+      const coinIconShadow = [
+        [0, 4, 12, asset.shadowColor || colors[index], 0.3],
+      ];
+      return coinIconShadow;
+    });
+  }, [assets, colors]);
 
   return (
     <Container>
       <Row align="center">
-        <ETHCoinIcon symbol="ETH" />
-        <CoinIcon address={address} shadow={coinIconShadow} symbol={symbol} />
+        {map(assets, (asset, index) => {
+          return (
+            <CoinIcon
+              address={asset.address}
+              shadow={shadows[index]}
+              symbol={asset.symbol}
+            />
+          );
+        })}
       </Row>
       <Row align="center" justify="space-between">
         <ColumnWithMargins align="start" margin={2}>
-          <Title>{`${symbol}-ETH Pool`}</Title>
+          <Title>{title}</Title>
           <Subtitle>
             {pricePerShare}
             <PerShareText> per share</PerShareText>

--- a/src/components/expanded-state/liquidity-pool/LiquidityPoolExpandedStateHeader.js
+++ b/src/components/expanded-state/liquidity-pool/LiquidityPoolExpandedStateHeader.js
@@ -1,4 +1,4 @@
-import { join, map } from 'lodash';
+import { map } from 'lodash';
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components/primitives';
@@ -36,11 +36,8 @@ const Title = styled(TruncatedText).attrs(({ color = colors.dark }) => ({
   weight: 'bold',
 }))``;
 
-function LiquidityPoolExpandedStateHeader({ assets, pricePerShare }) {
-  const title = `${join(
-    map(assets, asset => asset.symbol),
-    '-'
-  )} Pool`;
+function LiquidityPoolExpandedStateHeader({ assets, name, pricePerShare }) {
+  const title = `${name} Pool`;
   const colors = useColorForAssets(assets);
 
   const shadows = useMemo(() => {
@@ -57,7 +54,7 @@ function LiquidityPoolExpandedStateHeader({ assets, pricePerShare }) {
       <Row align="center">
         {map(assets, (asset, index) => {
           return (
-            <View zIndex={-index}>
+            <View key={`coinicon-${index}`} zIndex={-index}>
               <CoinIcon
                 address={asset.address}
                 marginRight={-10}
@@ -82,4 +79,4 @@ function LiquidityPoolExpandedStateHeader({ assets, pricePerShare }) {
   );
 }
 
-export default magicMemo(LiquidityPoolExpandedStateHeader, 'asset');
+export default magicMemo(LiquidityPoolExpandedStateHeader, ['asset', 'name']);

--- a/src/components/investment-cards/UniswapInvestmentRow.js
+++ b/src/components/investment-cards/UniswapInvestmentRow.js
@@ -1,4 +1,3 @@
-import { join } from 'lodash';
 import React, { Fragment, useCallback } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components/primitives';
@@ -74,11 +73,11 @@ const BottomRow = ({ uniBalance, type, relativeChange }) => {
   );
 };
 
-const TopRow = ({ tokenSymbols, totalNativeDisplay }) => {
+const TopRow = ({ name, totalNativeDisplay }) => {
   return (
     <TopRowContainer>
       <FlexItem flex={1}>
-        <CoinName>{join(tokenSymbols, '-')}</CoinName>
+        <CoinName>{name}</CoinName>
       </FlexItem>
       <PriceContainer>
         <BalanceText numberOfLines={1}>{totalNativeDisplay}</BalanceText>

--- a/src/components/investment-cards/UniswapInvestmentRow.js
+++ b/src/components/investment-cards/UniswapInvestmentRow.js
@@ -50,17 +50,20 @@ const PriceContainer = ios
       margin-bottom: 3;
     `;
 
-const BottomRow = ({ pricePerShare, relativeChange }) => {
+const BottomRow = ({ uniBalance, type, relativeChange }) => {
   const percentageChangeDisplay = relativeChange
     ? formatPercentageString(convertAmountToPercentageDisplay(relativeChange))
     : '-';
   const isPositive =
     relativeChange && percentageChangeDisplay.charAt(0) !== '-';
 
+  const tokenType = type === 'uniswap' ? 'UNI-V1' : 'UNI-V2';
+  const balanceLabel = `${uniBalance} ${tokenType}`;
+
   return (
     <BottomRowContainer>
       <FlexItem flex={1}>
-        <BottomRowText>{pricePerShare}</BottomRowText>
+        <BottomRowText>{balanceLabel}</BottomRowText>
       </FlexItem>
       <View>
         <PercentageText isPositive={isPositive}>

--- a/src/components/investment-cards/UniswapInvestmentRow.js
+++ b/src/components/investment-cards/UniswapInvestmentRow.js
@@ -51,10 +51,9 @@ const PriceContainer = ios
     `;
 
 const BottomRow = ({ pricePerShare, relativeChange }) => {
-  let percentageChangeDisplay = convertAmountToPercentageDisplay(
-    relativeChange
-  );
-  percentageChangeDisplay = formatPercentageString(percentageChangeDisplay);
+  const percentageChangeDisplay = relativeChange
+    ? formatPercentageString(convertAmountToPercentageDisplay(relativeChange))
+    : '-';
   const isPositive =
     relativeChange && percentageChangeDisplay.charAt(0) !== '-';
 

--- a/src/components/investment-cards/UniswapInvestmentRow.js
+++ b/src/components/investment-cards/UniswapInvestmentRow.js
@@ -51,11 +51,10 @@ const PriceContainer = ios
     `;
 
 const BottomRow = ({ pricePerShare, relativeChange }) => {
-  let percentageChangeDisplay = formatPercentageString(relativeChange);
-  percentageChangeDisplay = convertAmountToPercentageDisplay(
-    percentageChangeDisplay
+  let percentageChangeDisplay = convertAmountToPercentageDisplay(
+    relativeChange
   );
-
+  percentageChangeDisplay = formatPercentageString(percentageChangeDisplay);
   const isPositive =
     relativeChange && percentageChangeDisplay.charAt(0) !== '-';
 

--- a/src/components/investment-cards/UniswapInvestmentRow.js
+++ b/src/components/investment-cards/UniswapInvestmentRow.js
@@ -1,8 +1,8 @@
-import { get } from 'lodash';
-import PropTypes from 'prop-types';
+import { join } from 'lodash';
 import React, { Fragment, useCallback } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components/primitives';
+import { convertAmountToPercentageDisplay } from '../../helpers/utilities';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText, CoinRow } from '../coin-row';
 import BalanceText from '../coin-row/BalanceText';
@@ -14,7 +14,12 @@ import Routes from '@rainbow-me/routes';
 import { colors } from '@rainbow-me/styles';
 
 const formatPercentageString = percentString =>
-  percentString ? percentString.split('-').join('- ') : '-';
+  percentString
+    ? percentString
+        .toString()
+        .split('-')
+        .join('- ')
+    : '-';
 
 const PercentageText = styled(BottomRowText).attrs({
   align: 'right',
@@ -45,11 +50,14 @@ const PriceContainer = ios
       margin-bottom: 3;
     `;
 
-const BottomRow = ({ pricePerShare, native }) => {
-  const percentChange = get(native, 'change');
-  const percentageChangeDisplay = formatPercentageString(percentChange);
+const BottomRow = ({ pricePerShare, relativeChange }) => {
+  let percentageChangeDisplay = formatPercentageString(relativeChange);
+  percentageChangeDisplay = convertAmountToPercentageDisplay(
+    percentageChangeDisplay
+  );
 
-  const isPositive = percentChange && percentageChangeDisplay.charAt(0) !== '-';
+  const isPositive =
+    relativeChange && percentageChangeDisplay.charAt(0) !== '-';
 
   return (
     <BottomRowContainer>
@@ -65,12 +73,11 @@ const BottomRow = ({ pricePerShare, native }) => {
   );
 };
 
-const TopRow = ({ tokenSymbol, totalNativeDisplay }) => {
+const TopRow = ({ tokenSymbols, totalNativeDisplay }) => {
   return (
     <TopRowContainer>
       <FlexItem flex={1}>
-        {/* // TODO Remove hardcoded ETH */}
-        <CoinName>{tokenSymbol}-ETH</CoinName>
+        <CoinName>{join(tokenSymbols, '-')}</CoinName>
       </FlexItem>
       <PriceContainer>
         <BalanceText numberOfLines={1}>{totalNativeDisplay}</BalanceText>
@@ -97,22 +104,12 @@ const UniswapInvestmentRow = ({ assetType, item, ...props }) => {
         bottomRowRender={BottomRow}
         isPool
         onPress={handleOpenExpandedState}
-        tokenSymbols={[
-          { tokenSymbol: item.tokenSymbol },
-          { tokenSymbol: 'ETH' },
-        ]}
         topRowRender={TopRow}
         {...item}
         {...props}
       />
     </Content>
   );
-};
-
-UniswapInvestmentRow.propTypes = {
-  item: PropTypes.object,
-  onPress: PropTypes.func,
-  onPressContainer: PropTypes.func,
 };
 
 export default UniswapInvestmentRow;

--- a/src/components/pools/PoolsListWrapper.js
+++ b/src/components/pools/PoolsListWrapper.js
@@ -4,7 +4,7 @@ import { OpacityToggler } from '../animations';
 import { UniswapInvestmentRow } from '../investment-cards';
 import SavingsListHeader from '../savings/SavingsListHeader';
 
-const renderSavingsListRow = item => {
+const renderInvestmentsListRow = item => {
   return (
     <UniswapInvestmentRow assetType="uniswap" item={item} key={item.uniqueId} />
   );
@@ -30,7 +30,7 @@ export default function PoolsListWrapper({ data, totalValue = '0' }) {
         isVisible={!isInvestmentCardsOpen}
         pointerEvents={isInvestmentCardsOpen ? 'auto' : 'none'}
       >
-        {data.map(renderSavingsListRow)}
+        {data.map(renderInvestmentsListRow)}
       </OpacityToggler>
     </Fragment>
   );

--- a/src/components/pools/PoolsListWrapper.js
+++ b/src/components/pools/PoolsListWrapper.js
@@ -1,14 +1,13 @@
+import { map } from 'lodash';
 import React, { Fragment } from 'react';
 import { useOpenInvestmentCards } from '../../hooks';
 import { OpacityToggler } from '../animations';
 import { UniswapInvestmentRow } from '../investment-cards';
 import SavingsListHeader from '../savings/SavingsListHeader';
 
-const renderInvestmentsListRow = item => {
-  return (
-    <UniswapInvestmentRow assetType="uniswap" item={item} key={item.uniqueId} />
-  );
-};
+const renderInvestmentsListRow = item => (
+  <UniswapInvestmentRow assetType="uniswap" item={item} key={item.uniqueId} />
+);
 
 export default function PoolsListWrapper({ data, totalValue = '0' }) {
   const {
@@ -30,7 +29,7 @@ export default function PoolsListWrapper({ data, totalValue = '0' }) {
         isVisible={!isInvestmentCardsOpen}
         pointerEvents={isInvestmentCardsOpen ? 'auto' : 'none'}
       >
-        {data.map(renderInvestmentsListRow)}
+        {map(data, renderInvestmentsListRow)}
       </OpacityToggler>
     </Fragment>
   );

--- a/src/handlers/localstorage/uniswap.js
+++ b/src/handlers/localstorage/uniswap.js
@@ -11,6 +11,8 @@ const LIQUIDITY = 'uniswapliquidity';
 const LIQUIDITY_INFO = 'uniswap';
 const UNISWAP_FAVORITES = 'uniswapFavorites';
 
+const uniswapLiquidityInfoVersion = '0.2.0';
+
 export const uniswapAccountLocalKeys = [ASSETS, LIQUIDITY, LIQUIDITY_INFO];
 
 export const getUniswapFavorites = network =>
@@ -20,10 +22,22 @@ export const saveUniswapFavorites = favorites =>
   saveGlobal(UNISWAP_FAVORITES, favorites);
 
 export const getUniswapLiquidityInfo = (accountAddress, network) =>
-  getAccountLocal(LIQUIDITY_INFO, accountAddress, network, {});
+  getAccountLocal(
+    LIQUIDITY_INFO,
+    accountAddress,
+    network,
+    {},
+    uniswapLiquidityInfoVersion
+  );
 
 export const saveLiquidityInfo = (liquidityInfo, accountAddress, network) =>
-  saveAccountLocal(LIQUIDITY_INFO, liquidityInfo, accountAddress, network);
+  saveAccountLocal(
+    LIQUIDITY_INFO,
+    liquidityInfo,
+    accountAddress,
+    network,
+    uniswapLiquidityInfoVersion
+  );
 
 export const getLiquidity = (accountAddress, network) =>
   getAccountLocal(LIQUIDITY, accountAddress, network);

--- a/src/handlers/uniswapLiquidity.ts
+++ b/src/handlers/uniswapLiquidity.ts
@@ -297,16 +297,16 @@ const getLiquidityInfoV1 = async (
         price: lpToken?.asset?.price,
         tokens: [
           {
-            address: null,
-            balance: ethBalance,
-            name: 'Ethereum',
-            symbol: 'ETH',
-          },
-          {
             address: tokenAddress,
             balance: tokenBalance,
             name,
             symbol,
+          },
+          {
+            address: null,
+            balance: ethBalance,
+            name: 'Ethereum',
+            symbol: 'ETH',
           },
         ],
         totalSupply: convertRawAmountToDecimalFormat(totalSupply),

--- a/src/handlers/uniswapLiquidity.ts
+++ b/src/handlers/uniswapLiquidity.ts
@@ -22,6 +22,12 @@ interface LiquidityToken {
   symbol: string;
 }
 
+interface TokenDetails {
+  decimals: number;
+  name: string;
+  symbol: string;
+}
+
 export interface LiquidityInfo {
   address: string;
   balance: string;
@@ -54,7 +60,7 @@ const getTokenDetails = async (
   chainId: ChainId,
   tokenAddress: string,
   pairs: Record<string, SwapCurrency>
-) => {
+): Promise<TokenDetails> => {
   if (toLower(tokenAddress) === toLower(WETH[chainId].address)) {
     return {
       decimals: 18,
@@ -67,7 +73,7 @@ const getTokenDetails = async (
 
   const token = get(pairs, `[${toLower(tokenAddress)}]`);
 
-  let decimals: string | number;
+  let decimals: number;
   let name = '';
   let symbol = '';
 

--- a/src/handlers/uniswapLiquidity.ts
+++ b/src/handlers/uniswapLiquidity.ts
@@ -1,7 +1,7 @@
-import { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
+import { abi as IUniswapV2PairABI } from '@uniswap/v2-core/build/IUniswapV2Pair.json';
 import contractMap from 'eth-contract-metadata';
-import { get, map, toLower, zipObject } from 'lodash';
+import { get, keyBy, map, partition, toLower } from 'lodash';
 import { SwapCurrency } from '../handlers/uniswap';
 import {
   convertRawAmountToDecimalFormat,
@@ -14,47 +14,234 @@ import { UNISWAP_V1_EXCHANGE_ABI } from '../references/uniswap';
 import { web3Provider } from './web3';
 import logger from 'logger';
 
-export interface LiquidityInfo {
+interface LiquidityToken {
+  address: string;
   balance: string;
-  ethBalance: string;
-  ethReserve: BigNumber;
-  token: { balance: string; decimals: number; name: string; symbol: string };
-  tokenAddress: string;
+  name: string;
+  symbol: string;
+}
+
+export interface LiquidityInfo {
+  address: string;
+  balance: string;
+  price?: {
+    changed_at?: number;
+    value?: number;
+    relative_change_24h?: number;
+  };
+  tokens: LiquidityToken[];
   totalSupply: string;
   uniqueId: string;
 }
 
+export interface LPToken {
+  asset: {
+    asset_code: string;
+    price?: {
+      changed_at?: number;
+      value?: number;
+      relative_change_24h?: number;
+    };
+    type: string;
+  };
+  quantity: string;
+}
+
+const getAssetCode = (token: LPToken): string => get(token, 'asset.asset_code');
+
+const getTokenDetails = async (
+  tokenAddress: string,
+  pairs: Record<string, SwapCurrency>
+) => {
+  const tokenContract = new Contract(tokenAddress, erc20ABI, web3Provider);
+
+  const token = get(pairs, `[${toLower(tokenAddress)}]`);
+
+  let decimals: string | number = 18;
+  let name = '';
+  let symbol = '';
+
+  if (token) {
+    name = token.name;
+    symbol = token.symbol;
+    decimals = Number(token.decimals);
+  } else {
+    decimals = get(contractMap, `[${tokenAddress}].decimals`);
+    if (!decimals) {
+      try {
+        decimals = await tokenContract.decimals().catch();
+      } catch (error) {
+        decimals = 18;
+        logger.log(
+          'error getting decimals for token: ',
+          tokenAddress,
+          ' Error = ',
+          error
+        );
+      }
+    }
+
+    name = get(contractMap, `[${tokenAddress}].name`, '');
+    if (!name) {
+      try {
+        name = await tokenContract.name().catch();
+      } catch (error) {
+        logger.log(
+          'error getting name for token: ',
+          tokenAddress,
+          ' Error = ',
+          error
+        );
+      }
+    }
+
+    symbol = get(contractMap, `[${tokenAddress}].symbol`, '');
+    if (!symbol) {
+      try {
+        symbol = await tokenContract.symbol().catch();
+      } catch (error) {
+        logger.log(
+          'error getting symbol for token: ',
+          tokenAddress,
+          ' Error = ',
+          error
+        );
+      }
+    }
+  }
+  return {
+    decimals,
+    name,
+    symbol,
+  };
+};
+
 export const getLiquidityInfo = async (
   accountAddress: string,
-  liquidityPoolContracts: string[],
+  liquidityPoolTokens: LPToken[],
   pairs: Record<string, SwapCurrency>
 ): Promise<Record<string, LiquidityInfo | {}>> => {
-  const promises = map(liquidityPoolContracts, async liquidityPoolAddress => {
+  const [v1Tokens, v2Tokens] = partition(
+    liquidityPoolTokens,
+    token => token?.asset?.type === 'uniswap'
+  );
+  const v1Results = await getLiquidityInfoV1(accountAddress, v1Tokens, pairs);
+  const v2Results = await getLiquidityInfoV2(accountAddress, v2Tokens, pairs);
+  return { ...v1Results, ...v2Results };
+};
+
+const getLiquidityInfoV2 = async (
+  accountAddress: string,
+  liquidityTokens: LPToken[],
+  pairs: Record<string, SwapCurrency>
+): Promise<Record<string, LiquidityInfo | {}>> => {
+  const promises = map(liquidityTokens, async lpToken => {
     try {
+      const liquidityPoolAddress = getAssetCode(lpToken);
+      const pair = new Contract(
+        liquidityPoolAddress,
+        IUniswapV2PairABI,
+        web3Provider
+      );
+
+      const token0AddressCall = pair.token0();
+      const token1AddressCall = pair.token1();
+      const pairReservesCall = pair.getReserves();
+      const totalSupplyCall = pair.totalSupply();
+
+      const [
+        token0AddressResult,
+        token1AddressResult,
+        pairReservesResult,
+        totalSupplyResult,
+      ] = await Promise.all([
+        token0AddressCall,
+        token1AddressCall,
+        pairReservesCall,
+        totalSupplyCall,
+      ]);
+
+      const token0Address = token0AddressResult.toString();
+      const token1Address = token1AddressResult.toString();
+
+      const lpTokenBalance = lpToken.quantity;
+
+      const [token0ReserveBn, token1ReserveBn] = pairReservesResult;
+      const token0Reserve = token0ReserveBn.toString();
+      const token1Reserve = token1ReserveBn.toString();
+      const totalSupply = totalSupplyResult.toString();
+
+      const token0 = await getTokenDetails(token0Address, pairs);
+      const token1 = await getTokenDetails(token1Address, pairs);
+
+      const token0Balance = convertRawAmountToDecimalFormat(
+        divide(multiply(token0Reserve, lpTokenBalance), totalSupply),
+        Number(token0.decimals)
+      );
+
+      const token1Balance = convertRawAmountToDecimalFormat(
+        divide(multiply(token1Reserve, lpTokenBalance), totalSupply),
+        Number(token1.decimals)
+      );
+
+      return {
+        address: liquidityPoolAddress,
+        balance: convertRawAmountToDecimalFormat(lpTokenBalance),
+        price: lpToken?.asset?.price,
+        tokens: [
+          {
+            address: token0Address,
+            balance: token0Balance,
+            ...token0,
+          },
+          {
+            address: token1Address,
+            balance: token1Balance,
+            ...token1,
+          },
+        ],
+        totalSupply: convertRawAmountToDecimalFormat(totalSupply),
+        uniqueId: `uniswap_${liquidityPoolAddress}`,
+      };
+    } catch (error) {
+      logger.log('error getting uniswap info', error);
+      return {};
+    }
+  });
+
+  const results = await Promise.all(promises);
+  return keyBy(results, result => result.address);
+};
+
+const getLiquidityInfoV1 = async (
+  accountAddress: string,
+  liquidityTokens: LPToken[],
+  pairs: Record<string, SwapCurrency>
+): Promise<Record<string, LiquidityInfo | {}>> => {
+  const promises = map(liquidityTokens, async lpToken => {
+    try {
+      const liquidityPoolAddress = getAssetCode(lpToken);
       const ethReserveCall = web3Provider.getBalance(liquidityPoolAddress);
+      const lpTokenBalance = lpToken.quantity;
       const exchange = new Contract(
         liquidityPoolAddress,
         UNISWAP_V1_EXCHANGE_ABI,
         web3Provider
       );
       const tokenAddressCall = exchange.tokenAddress();
-      const balanceCall = exchange.balanceOf(accountAddress);
       const totalSupplyCall = exchange.totalSupply();
 
       const [
         ethReserveResult,
         tokenAddress,
-        balanceResult,
         totalSupplyResult,
       ] = await Promise.all([
         ethReserveCall,
         tokenAddressCall,
-        balanceCall,
         totalSupplyCall,
       ]);
 
       const ethReserve = ethReserveResult.toString();
-      const balance = balanceResult.toString();
       const totalSupply = totalSupplyResult.toString();
 
       const tokenContract = new Contract(tokenAddress, erc20ABI, web3Provider);
@@ -118,26 +305,33 @@ export const getLiquidityInfo = async (
       const reserve = reserveResult.toString();
 
       const ethBalance = fromWei(
-        divide(multiply(ethReserve, balance), totalSupply)
+        divide(multiply(ethReserve, lpTokenBalance), totalSupply)
       );
       const tokenBalance = convertRawAmountToDecimalFormat(
-        divide(multiply(reserve, balance), totalSupply),
+        divide(multiply(reserve, lpTokenBalance), totalSupply),
         Number(decimals)
       );
 
       return {
-        balance: convertRawAmountToDecimalFormat(balance),
-        ethBalance,
-        ethReserve,
-        token: {
-          balance: tokenBalance,
-          decimals,
-          name,
-          symbol,
-        },
-        tokenAddress,
+        address: liquidityPoolAddress,
+        balance: convertRawAmountToDecimalFormat(lpTokenBalance),
+        price: lpToken?.asset?.price,
+        tokens: [
+          {
+            address: null,
+            balance: ethBalance,
+            name: 'Ethereum',
+            symbol: 'ETH',
+          },
+          {
+            address: tokenAddress,
+            balance: tokenBalance,
+            name,
+            symbol,
+          },
+        ],
         totalSupply: convertRawAmountToDecimalFormat(totalSupply),
-        uniqueId: `uniswap_${tokenAddress}`,
+        uniqueId: `uniswap_${liquidityPoolAddress}`,
       };
     } catch (error) {
       logger.log('error getting uniswap info', error);
@@ -146,5 +340,5 @@ export const getLiquidityInfo = async (
   });
 
   const results = await Promise.all(promises);
-  return zipObject(liquidityPoolContracts, results);
+  return keyBy(results, result => result.address);
 };

--- a/src/handlers/uniswapLiquidity.ts
+++ b/src/handlers/uniswapLiquidity.ts
@@ -136,19 +136,22 @@ export const getLiquidityInfo = async (
     liquidityPoolTokens,
     token => token?.asset?.type === 'uniswap'
   );
-  // TODO JIN - promise all here?
-  const v1Results = await getLiquidityInfoV1(
+  const v1TokensCall = getLiquidityInfoV1(
     chainId,
     accountAddress,
     v1Tokens,
     pairs
   );
-  const v2Results = await getLiquidityInfoV2(
+  const v2TokensCall = getLiquidityInfoV2(
     chainId,
     accountAddress,
     v2Tokens,
     pairs
   );
+  const [v1Results, v2Results] = await Promise.all([
+    v1TokensCall,
+    v2TokensCall,
+  ]);
   return { ...v1Results, ...v2Results };
 };
 

--- a/src/handlers/uniswapLiquidity.ts
+++ b/src/handlers/uniswapLiquidity.ts
@@ -303,7 +303,7 @@ const getLiquidityInfoV1 = async (
             symbol,
           },
           {
-            address: null,
+            address: 'eth',
             balance: ethBalance,
             name: 'Ethereum',
             symbol: 'ETH',

--- a/src/handlers/uniswapLiquidity.ts
+++ b/src/handlers/uniswapLiquidity.ts
@@ -227,6 +227,7 @@ const getLiquidityInfoV2 = async (
           },
         ],
         totalSupply: convertRawAmountToDecimalFormat(totalSupply),
+        type: lpToken?.asset?.type,
         uniqueId: `uniswap_${liquidityPoolAddress}`,
       };
     } catch (error) {
@@ -309,6 +310,7 @@ const getLiquidityInfoV1 = async (
           },
         ],
         totalSupply: convertRawAmountToDecimalFormat(totalSupply),
+        type: lpToken?.asset?.type,
         uniqueId: `uniswap_${liquidityPoolAddress}`,
       };
     } catch (error) {

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -191,6 +191,16 @@ export const lessThan = (
   numberTwo: BigNumberish
 ): boolean => new BigNumber(numberOne).lt(numberTwo);
 
+export const handleSignificantDecimalsWithThreshold = (
+  value: BigNumberish,
+  decimals: number,
+  buffer: number = 3,
+  threshold: string = '0.0001'
+) => {
+  const result = handleSignificantDecimals(value, decimals, buffer);
+  return lessThan(result, threshold) ? `< ${threshold}` : result;
+};
+
 export const handleSignificantDecimals = (
   value: BigNumberish,
   decimals: number,

--- a/src/hoc/uniswapLiquidityTokenInfoSelector.js
+++ b/src/hoc/uniswapLiquidityTokenInfoSelector.js
@@ -16,7 +16,7 @@ export const transformPool = (liquidityPool, nativeCurrency) => {
     return null;
   }
 
-  const { balance, price, tokens, totalSupply, uniqueId } = liquidityPool;
+  const { balance, price, tokens, totalSupply, type, uniqueId } = liquidityPool;
 
   const percentageOwned = multiply(divide(balance, totalSupply), 100);
 
@@ -45,6 +45,7 @@ export const transformPool = (liquidityPool, nativeCurrency) => {
     tokenSymbols,
     totalBalanceAmount,
     totalNativeDisplay,
+    type,
     uniBalance: floor(balance, 7),
     uniqueId,
   };

--- a/src/hoc/uniswapLiquidityTokenInfoSelector.js
+++ b/src/hoc/uniswapLiquidityTokenInfoSelector.js
@@ -1,51 +1,26 @@
-import {
-  compact,
-  floor,
-  get,
-  isEmpty,
-  map,
-  orderBy,
-  sumBy,
-  values,
-} from 'lodash';
+import { compact, floor, isEmpty, map, orderBy, sumBy, values } from 'lodash';
 import { createSelector } from 'reselect';
 import {
-  convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeDisplay,
   divide,
   multiply,
 } from '../helpers/utilities';
-import { ethereumUtils } from '../utils';
 
 const assetsSelector = state => state.data.assets;
 const nativeCurrencySelector = state => state.settings.nativeCurrency;
 const uniswapLiquidityTokenInfoSelector = state =>
   state.uniswapLiquidity.uniswapLiquidityTokenInfo;
 
-export const transformPool = (liquidityPool, ethPrice, nativeCurrency) => {
+export const transformPool = (liquidityPool, nativeCurrency) => {
   if (isEmpty(liquidityPool)) {
     return null;
   }
 
-  const {
-    balance,
-    ethBalance,
-    token: { balance: tokenBalance, name: tokenName, symbol: tokenSymbol },
-    tokenAddress,
-    totalSupply,
-    uniqueId,
-  } = liquidityPool;
+  const { balance, price, tokens, totalSupply, uniqueId } = liquidityPool;
 
   const percentageOwned = multiply(divide(balance, totalSupply), 100);
-  const {
-    amount: balanceAmount,
-    display: nativeDisplay,
-  } = convertAmountAndPriceToNativeDisplay(
-    ethBalance,
-    ethPrice,
-    nativeCurrency
-  );
-  const totalBalanceAmount = multiply(balanceAmount, 2);
+
+  const totalBalanceAmount = multiply(balance, price.value);
   const totalNativeDisplay = convertAmountToNativeDisplay(
     totalBalanceAmount,
     nativeCurrency
@@ -55,20 +30,23 @@ export const transformPool = (liquidityPool, ethPrice, nativeCurrency) => {
     nativeCurrency
   );
 
+  const formattedTokens = map(tokens, token => ({
+    ...token,
+    balance: floor(parseFloat(token.balance), 4) || '< 0.0001',
+  }));
+
+  const tokenSymbols = map(formattedTokens, token => token.symbol);
+
   return {
-    ethBalance: floor(parseFloat(ethBalance), 4) || '< 0.0001',
-    nativeDisplay,
     percentageOwned,
     pricePerShare,
-    tokenAddress,
-    tokenBalance: floor(parseFloat(tokenBalance), 4) || '< 0.0001',
-    tokenName,
-    tokenSymbol,
+    relativeChange: price?.relative_change_24h,
+    tokens: formattedTokens,
+    tokenSymbols,
     totalBalanceAmount,
     totalNativeDisplay,
     uniBalance: floor(balance, 7),
     uniqueId,
-    uniTotalSupply: floor(totalSupply, 7),
   };
 };
 
@@ -77,11 +55,9 @@ const buildUniswapCards = (
   assets,
   uniswapLiquidityTokenInfo
 ) => {
-  const ethPrice = get(ethereumUtils.getAsset(assets), 'price.value', 0);
-
   const uniswapPools = compact(
     map(values(uniswapLiquidityTokenInfo), liquidityPool =>
-      transformPool(liquidityPool, ethPrice, nativeCurrency)
+      transformPool(liquidityPool, nativeCurrency)
     )
   );
   const orderedUniswapPools = orderBy(

--- a/src/hoc/uniswapLiquidityTokenInfoSelector.js
+++ b/src/hoc/uniswapLiquidityTokenInfoSelector.js
@@ -20,7 +20,7 @@ export const transformPool = (liquidityPool, nativeCurrency) => {
 
   const percentageOwned = multiply(divide(balance, totalSupply), 100);
 
-  const totalBalanceAmount = multiply(balance, price.value);
+  const totalBalanceAmount = multiply(balance, price?.value || 0);
   const totalNativeDisplay = convertAmountToNativeDisplay(
     totalBalanceAmount,
     nativeCurrency

--- a/src/hoc/uniswapLiquidityTokenInfoSelector.js
+++ b/src/hoc/uniswapLiquidityTokenInfoSelector.js
@@ -1,4 +1,13 @@
-import { compact, floor, isEmpty, map, orderBy, sumBy, values } from 'lodash';
+import {
+  compact,
+  floor,
+  isEmpty,
+  join,
+  map,
+  orderBy,
+  sumBy,
+  values,
+} from 'lodash';
 import { createSelector } from 'reselect';
 import {
   convertAmountToNativeDisplay,
@@ -36,14 +45,17 @@ export const transformPool = (liquidityPool, nativeCurrency) => {
     balance: handleSignificantDecimalsWithThreshold(token.balance, 4),
   }));
 
-  const tokenSymbols = map(formattedTokens, token => token.symbol);
+  const name = join(
+    map(formattedTokens, token => token.symbol),
+    '-'
+  );
 
   return {
+    name,
     percentageOwned,
     pricePerShare,
     relativeChange: price?.relative_change_24h,
     tokens: formattedTokens,
-    tokenSymbols,
     totalBalanceAmount,
     totalNativeDisplay,
     type,

--- a/src/hoc/uniswapLiquidityTokenInfoSelector.js
+++ b/src/hoc/uniswapLiquidityTokenInfoSelector.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 import {
   convertAmountToNativeDisplay,
   divide,
+  handleSignificantDecimalsWithThreshold,
   multiply,
 } from '../helpers/utilities';
 
@@ -32,7 +33,7 @@ export const transformPool = (liquidityPool, nativeCurrency) => {
 
   const formattedTokens = map(tokens, token => ({
     ...token,
-    balance: floor(parseFloat(token.balance), 4) || '< 0.0001',
+    balance: handleSignificantDecimalsWithThreshold(token.balance, 4),
   }));
 
   const tokenSymbols = map(formattedTokens, token => token.symbol);

--- a/src/hoc/uniswapLiquidityTokenInfoSelector.js
+++ b/src/hoc/uniswapLiquidityTokenInfoSelector.js
@@ -1,17 +1,9 @@
-import {
-  compact,
-  floor,
-  isEmpty,
-  join,
-  map,
-  orderBy,
-  sumBy,
-  values,
-} from 'lodash';
+import { compact, isEmpty, join, map, orderBy, sumBy, values } from 'lodash';
 import { createSelector } from 'reselect';
 import {
   convertAmountToNativeDisplay,
   divide,
+  handleSignificantDecimals,
   handleSignificantDecimalsWithThreshold,
   multiply,
 } from '../helpers/utilities';
@@ -59,7 +51,7 @@ export const transformPool = (liquidityPool, nativeCurrency) => {
     totalBalanceAmount,
     totalNativeDisplay,
     type,
-    uniBalance: floor(balance, 7),
+    uniBalance: handleSignificantDecimals(balance, 3),
     uniqueId,
   };
 };

--- a/src/hooks/useColorForAsset.js
+++ b/src/hooks/useColorForAsset.js
@@ -1,10 +1,32 @@
+import { map } from 'lodash';
 import { useMemo } from 'react';
 import {
   getUrlForTrustIconFallback,
   pseudoRandomArrayItemFromString,
 } from '../utils';
-import useImageMetadata from './useImageMetadata';
+import useImageMetadata, { useImagesColors } from './useImageMetadata';
 import { colors } from '@rainbow-me/styles';
+
+export function useColorForAssets(assets) {
+  const fallbackUrls = useMemo(
+    () => map(assets, asset => getUrlForTrustIconFallback(asset.address)),
+    [assets]
+  );
+
+  const fallbackColors = useImagesColors(fallbackUrls);
+
+  return useMemo(
+    () =>
+      map(assets, (asset, index) => {
+        return (
+          asset.color ||
+          fallbackColors[index] ||
+          pseudoRandomArrayItemFromString(asset.symbol, colors.avatarColor)
+        );
+      }),
+    [assets, fallbackColors]
+  );
+}
 
 export default function useColorForAsset({ address, color, symbol }) {
   const fallbackUrl = useMemo(() => getUrlForTrustIconFallback(address), [

--- a/src/hooks/useColorForAsset.js
+++ b/src/hooks/useColorForAsset.js
@@ -17,13 +17,13 @@ export function useColorForAssets(assets) {
 
   return useMemo(
     () =>
-      map(assets, (asset, index) => {
-        return (
+      map(
+        assets,
+        (asset, index) =>
           asset.color ||
           fallbackColors[index] ||
           pseudoRandomArrayItemFromString(asset.symbol, colors.avatarColor)
-        );
-      }),
+      ),
     [assets, fallbackColors]
   );
 }

--- a/src/hooks/useImageMetadata.js
+++ b/src/hooks/useImageMetadata.js
@@ -1,9 +1,16 @@
+import { map } from 'lodash';
 import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateImageMetadataCache } from '../redux/imageMetadata';
 import { getDominantColorFromImage } from '../utils';
 import useDimensions from './useDimensions';
 import { position } from '@rainbow-me/styles';
+
+export function useImagesColors(imageUrls) {
+  return useSelector(({ imageMetadata }) => {
+    return map(imageUrls, imageUrl => imageMetadata.imageMetadata[imageUrl]);
+  });
+}
 
 export default function useImageMetadata(imageUrl) {
   const dispatch = useDispatch();

--- a/src/hooks/useImageMetadata.js
+++ b/src/hooks/useImageMetadata.js
@@ -7,9 +7,9 @@ import useDimensions from './useDimensions';
 import { position } from '@rainbow-me/styles';
 
 export function useImagesColors(imageUrls) {
-  return useSelector(({ imageMetadata }) => {
-    return map(imageUrls, imageUrl => imageMetadata.imageMetadata[imageUrl]);
-  });
+  return useSelector(({ imageMetadata }) =>
+    map(imageUrls, imageUrl => imageMetadata.imageMetadata[imageUrl]?.color)
+  );
 }
 
 export default function useImageMetadata(imageUrl) {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -261,11 +261,7 @@ export const addressAssetsReceived = (
   const liquidityTokens = remove(
     assets,
     asset =>
-      asset?.asset?.type === 'uniswap' ||
-      asset?.asset?.type === 'uniswap-v2' ||
-      // Remove duplicate liquidity tokens when falling back from zerion
-      (toLower(asset?.asset.name).indexOf('uniswap') !== -1 &&
-        toLower(asset?.asset.name) !== 'uniswap')
+      asset?.asset?.type === 'uniswap' || asset?.asset?.type === 'uniswap-v2'
   );
 
   // Remove spammy tokens

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -262,6 +262,7 @@ export const addressAssetsReceived = (
     assets,
     asset =>
       asset?.asset?.type === 'uniswap' ||
+      asset?.asset?.type === 'uniswap-v2' ||
       // Remove duplicate liquidity tokens when falling back from zerion
       (toLower(asset?.asset.name).indexOf('uniswap') !== -1 &&
         toLower(asset?.asset.name) !== 'uniswap')

--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -152,15 +152,24 @@ const discoverTokens = async (
     });
 
     return uniqBy(
-      allTxs.map(tx => ({
-        asset: {
-          asset_code: getCurrentAddress(tx.contractAddress.toLowerCase()),
-          coingecko_id: coingeckoIds[tx.contractAddress.toLowerCase()],
-          decimals: Number(tx.tokenDecimal),
-          name: tx.tokenName,
-          symbol: tx.tokenSymbol,
-        },
-      })),
+      allTxs.map(tx => {
+        const type =
+          tx.tokenSymbol === 'UNI-V1'
+            ? 'uniswap'
+            : tx.tokenSymbol === 'UNI-V2'
+            ? 'uniswap-v2'
+            : undefined;
+        return {
+          asset: {
+            asset_code: getCurrentAddress(tx.contractAddress.toLowerCase()),
+            coingecko_id: coingeckoIds[tx.contractAddress.toLowerCase()],
+            decimals: Number(tx.tokenDecimal),
+            name: tx.tokenName,
+            symbol: tx.tokenSymbol,
+            type,
+          },
+        };
+      }),
       token => token.asset.asset_code
     );
   }

--- a/src/redux/uniswapLiquidity.js
+++ b/src/redux/uniswapLiquidity.js
@@ -67,30 +67,28 @@ export const uniswapUpdateLiquidityTokens = (
   dispatch(uniswapUpdateLiquidityState());
 };
 
-export const uniswapUpdateLiquidityState = () => (dispatch, getState) =>
-  new Promise((resolve, promiseReject) => {
-    const { accountAddress, network } = getState().settings;
-    const { pairs } = getState().uniswap;
-    const { liquidityTokens } = getState().uniswapLiquidity;
+export const uniswapUpdateLiquidityState = () => async (dispatch, getState) => {
+  const { accountAddress, network } = getState().settings;
+  const { pairs } = getState().uniswap;
+  const { liquidityTokens } = getState().uniswapLiquidity;
 
-    if (isEmpty(liquidityTokens)) {
-      return resolve(false);
-    }
+  if (isEmpty(liquidityTokens)) return;
 
-    const exchangeContracts = map(liquidityTokens, getAssetCode);
-    return getLiquidityInfo(accountAddress, exchangeContracts, pairs)
-      .then(liquidityInfo => {
-        saveLiquidityInfo(liquidityInfo, accountAddress, network);
-        dispatch({
-          payload: liquidityInfo,
-          type: UNISWAP_UPDATE_LIQUIDITY_TOKEN_INFO,
-        });
-        resolve(true);
-      })
-      .catch(error => {
-        promiseReject(error);
-      });
-  });
+  const exchangeContracts = map(liquidityTokens, getAssetCode);
+  try {
+    const liquidityInfo = await getLiquidityInfo(
+      accountAddress,
+      exchangeContracts,
+      pairs
+    );
+    saveLiquidityInfo(liquidityInfo, accountAddress, network);
+    dispatch({
+      payload: liquidityInfo,
+      type: UNISWAP_UPDATE_LIQUIDITY_TOKEN_INFO,
+    });
+    // eslint-disable-next-line no-empty
+  } catch (error) {}
+};
 
 // -- Reducer --------------------------------------------------------------- //
 export const INITIAL_UNISWAP_LIQUIDITY_STATE = {

--- a/src/redux/uniswapLiquidity.js
+++ b/src/redux/uniswapLiquidity.js
@@ -68,7 +68,7 @@ export const uniswapUpdateLiquidityTokens = (
 };
 
 export const uniswapUpdateLiquidityState = () => async (dispatch, getState) => {
-  const { accountAddress, network } = getState().settings;
+  const { accountAddress, chainId, network } = getState().settings;
   const { pairs } = getState().uniswap;
   const { liquidityTokens } = getState().uniswapLiquidity;
 
@@ -76,6 +76,7 @@ export const uniswapUpdateLiquidityState = () => async (dispatch, getState) => {
 
   try {
     const liquidityInfo = await getLiquidityInfo(
+      chainId,
       accountAddress,
       liquidityTokens,
       pairs

--- a/src/redux/uniswapLiquidity.js
+++ b/src/redux/uniswapLiquidity.js
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { concat, filter, get, isEmpty, map, uniqBy } from 'lodash';
+import { concat, filter, get, isEmpty, uniqBy } from 'lodash';
 import {
   getLiquidity,
   getUniswapLiquidityInfo,
@@ -74,11 +74,10 @@ export const uniswapUpdateLiquidityState = () => async (dispatch, getState) => {
 
   if (isEmpty(liquidityTokens)) return;
 
-  const exchangeContracts = map(liquidityTokens, getAssetCode);
   try {
     const liquidityInfo = await getLiquidityInfo(
       accountAddress,
-      exchangeContracts,
+      liquidityTokens,
       pairs
     );
     saveLiquidityInfo(liquidityInfo, accountAddress, network);

--- a/src/screens/SavingsSheet.js
+++ b/src/screens/SavingsSheet.js
@@ -181,6 +181,7 @@ const SavingsSheet = () => {
                 onPress={onWithdraw}
                 radiusAndroid={24}
                 radiusWrapperStyle={{ flex: 1, marginLeft: 10 }}
+                weight="bold"
                 wrapperProps={{
                   containerStyle: { flex: 1 },
                   style: { flex: 1 },
@@ -192,6 +193,7 @@ const SavingsSheet = () => {
                 onPress={onDeposit}
                 radiusAndroid={24}
                 radiusWrapperStyle={{ flex: 1, marginLeft: 10 }}
+                weight="bold"
                 wrapperProps={{
                   containerStyle: { flex: 1 },
                   style: { flex: 1 },

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -52,7 +52,7 @@ const getBalanceAmount = async (selectedGasPrice, selected) => {
 const getHash = txn => txn.hash.split('-').shift();
 
 const getAsset = (assets, address = 'eth') =>
-  find(assets, matchesProperty('address', address));
+  find(assets, matchesProperty('address', toLower(address)));
 
 export const checkWalletEthZero = assets => {
   const ethAsset = find(assets, asset => asset.address === 'eth');


### PR DESCRIPTION
This PR is to surface both Uniswap V1 and V2 liquidity pool tokens in the investments section.
V2 pools when involving ETH are actually all WETH based - I am showing WETH tokens as ETH when displaying the V2 pool data.

The order of the tokens for V2 are determined by the "sort order" from the Uniswap SDK (which compares contract addresses with each other.) The order of the tokens for V1 are to always have the ETH token be displayed second.

To help simplify the logic for when Zerion or fallback data is used, I parse out the token "type" for Uniswap LP tokens.

