### PR TITLE
Fix sometimes not visible content of sheets

### DIFF
--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -67,11 +67,16 @@ const traverseData = (prev, data) => {
 };
 
 function useJumpingForm(isLong) {
+  const isInitial = useRef(true);
   const { setOptions } = useNavigation();
 
   const { jumpToShort, jumpToLong } = useContext(ModalContext) || {};
 
   useEffect(() => {
+    if (isInitial.current) {
+      isInitial.current = false;
+      return;
+    }
     if (!isLong) {
       setOptions({
         isShortFormEnabled: true,

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -26,7 +26,6 @@ const buildCoolModalConfig = params => ({
   onAppear: params.onAppear || null,
   scrollEnabled: params.scrollEnabled,
   single: params.single,
-  TEMPORARY_autoJumpToNewHeight: params.TEMPORARY_autoJumpToNewHeight,
   topOffset: params.topOffset || sharedCoolModalTopOffset,
 });
 
@@ -142,7 +141,6 @@ export const restoreSheetConfig = {
       ...params,
       backgroundColor: colors.dark,
       longFormHeight: heightForStep,
-      TEMPORARY_autoJumpToNewHeight: true,
     });
   },
 };

--- a/src/react-native-cool-modals/NativeStackView.js
+++ b/src/react-native-cool-modals/NativeStackView.js
@@ -1,5 +1,5 @@
 import { StackActions, useTheme } from '@react-navigation/native';
-import React, { createContext, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, useMemo, useRef } from 'react';
 import { findNodeHandle, NativeModules, StyleSheet, View } from 'react-native';
 import Components from './screens';
 
@@ -10,16 +10,6 @@ const sx = StyleSheet.create({
     flex: 1,
   },
 });
-
-function usePrevious(value) {
-  const ref = useRef();
-
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-
-  return ref.current;
-}
 
 function ScreenView({ colors, descriptors, navigation, route, state }) {
   const { options, render: renderScene } = descriptors[route.key];
@@ -49,12 +39,9 @@ function ScreenView({ colors, descriptors, navigation, route, state }) {
     stackAnimation,
     stackPresentation = 'push',
     startFromShortForm,
-    TEMPORARY_autoJumpToNewHeight,
     topOffset,
     transitionDuration,
   } = options;
-  const prevLongFormHeight = usePrevious(longFormHeight);
-  const prevShortFormHeight = usePrevious(shortFormHeight);
 
   const context = useMemo(
     () => ({
@@ -73,29 +60,6 @@ function ScreenView({ colors, descriptors, navigation, route, state }) {
     }),
     []
   );
-
-  // When 'TEMPORARY_autoJumpToNewHeight' option is enabled, automatically "jump" towards either
-  // the new "longFormHeight" or new "shortFormHeight"
-  useEffect(() => {
-    if (
-      TEMPORARY_autoJumpToNewHeight &&
-      longFormHeight !== prevLongFormHeight
-    ) {
-      setImmediate(context.jumpToLong);
-    } else if (
-      TEMPORARY_autoJumpToNewHeight &&
-      shortFormHeight !== prevShortFormHeight
-    ) {
-      setImmediate(context.jumpToShort);
-    }
-  }, [
-    context,
-    longFormHeight,
-    prevLongFormHeight,
-    prevShortFormHeight,
-    shortFormHeight,
-    TEMPORARY_autoJumpToNewHeight,
-  ]);
 
   if (single && state.routes.length > 2) {
     return null;
@@ -153,7 +117,7 @@ function ScreenView({ colors, descriptors, navigation, route, state }) {
         stackAnimation={stackAnimation}
         stackPresentation={stackPresentation}
         startFromShortForm={startFromShortForm}
-        style={StyleSheet.absoluteFill}
+        style={[StyleSheet.absoluteFill, { backgroundColor: 'red' }]}
         topOffset={topOffset}
         transitionDuration={transitionDuration}
       >


### PR DESCRIPTION
I observe that:

1. If `jumpToLong` will be called then the size of the outer component will be evaluated then whether hasn't been previously.
2. Size of the outer component is evaluated lazily 
3. If `jumpToLong` will be called before mounting of the sheet it will have height `0`
4. Then it won't be visible
5. There's no sense in calling it on the initial mount because the purpose of the `useJumpingForm` there's no need to make it on the first render. 


Furthermore, `TEMPORARY_autoJumpToNewHeight` has been handled already in a different way and should be removed before (probably got restored during some merge)

