### PR TITLE
Fix not visible content #2

### DIFF
--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -67,16 +67,11 @@ const traverseData = (prev, data) => {
 };
 
 function useJumpingForm(isLong) {
-  const isInitial = useRef(true);
   const { setOptions } = useNavigation();
 
   const { jumpToShort, jumpToLong } = useContext(ModalContext) || {};
 
   useEffect(() => {
-    if (isInitial.current) {
-      isInitial.current = false;
-      return;
-    }
     if (!isLong) {
       setOptions({
         isShortFormEnabled: true,

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -73,9 +73,10 @@ const RoutesWithNativeStackAvailability = {
   IMPORT_SEED_PHRASE_FLOW: isNativeStackAvailable
     ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
     : Routes.IMPORT_SEED_PHRASE_SHEET,
-  SEND_FLOW: isNativeStackAvailable || android
-    ? Routes.SEND_SHEET_NAVIGATOR
-    : Routes.SEND_SHEET,
+  SEND_FLOW:
+    isNativeStackAvailable || android
+      ? Routes.SEND_SHEET_NAVIGATOR
+      : Routes.SEND_SHEET,
 };
 
 export default RoutesWithNativeStackAvailability;

--- a/src/react-native-cool-modals/ios/UIViewController+slack.swift
+++ b/src/react-native-cool-modals/ios/UIViewController+slack.swift
@@ -52,6 +52,13 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
   }
 
   @objc func jumpTo(long: NSNumber) {
+    if (hasAskedAboutShortForm > 0) {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+        // actively waiting
+        self.jumpTo(long: long)
+      }
+      return;
+    }
     self.panModalSetNeedsLayoutUpdate()
     if (long.boolValue) {
       panModalTransition(to: .longForm);
@@ -210,7 +217,9 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
   }
 
   var isShortFormEnabledInternal = 2
+  var hasAskedAboutShortForm = 2;
   var isShortFormEnabled: Bool {
+    hasAskedAboutShortForm -= 1;
     let startFromShortForm = self.config!.startFromShortForm
     if isShortFormEnabledInternal > 0 && !startFromShortForm {
       isShortFormEnabledInternal -= 1


### PR DESCRIPTION
@skylarbarrera told me that my previous PR made some regression that ExpandedChartState was not short when there're no charts data. 
So I reverted changes there and made it reliable on the native side i.e. I actively wait until the content render to perform jumping