### PR TITLE
Update onPress redundancies

### DIFF
--- a/src/components/change-wallet/AddressRow.js
+++ b/src/components/change-wallet/AddressRow.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
@@ -15,6 +14,7 @@ import { TruncatedAddress, TruncatedText } from '../text';
 import { colors, fonts, getFontSize } from '@rainbow-me/styles';
 
 const maxAccountLabelWidth = deviceUtils.dimensions.width - 88;
+const NOOP = () => undefined;
 
 const sx = StyleSheet.create({
   accountLabel: {
@@ -180,15 +180,10 @@ export default function AddressRow({ data, editMode, onPress, onEditWallet }) {
             {!editMode && isSelected && (
               <CoinCheckButton style={sx.coinCheckIcon} toggle={isSelected} />
             )}
-            {editMode && <OptionsIcon onPress={onOptionsPress} />}
+            {editMode && <OptionsIcon onPress={NOOP} />}
           </Column>
         </Row>
       </ButtonPressAnimation>
     </View>
   );
 }
-
-AddressRow.propTypes = {
-  data: PropTypes.object,
-  onPress: PropTypes.func,
-};

--- a/src/components/coin-row/SavingsCoinRow.js
+++ b/src/components/coin-row/SavingsCoinRow.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { calculateAPY } from '../../helpers/savings';
 import { convertAmountToBalanceDisplay } from '../../helpers/utilities';
@@ -44,12 +43,6 @@ const BottomRow = ({ lifetimeSupplyInterestAccrued, supplyRate, symbol }) => {
   );
 };
 
-BottomRow.propTypes = {
-  lifetimeSupplyInterestAccrued: PropTypes.string,
-  supplyRate: PropTypes.string,
-  symbol: PropTypes.string,
-};
-
 const TopRow = ({ name, supplyBalanceUnderlying, symbol }) => (
   <Row align="center" justify="space-between" marginBottom={2}>
     <FlexItem flex={1}>
@@ -63,12 +56,6 @@ const TopRow = ({ name, supplyBalanceUnderlying, symbol }) => (
   </Row>
 );
 
-TopRow.propTypes = {
-  name: PropTypes.string,
-  supplyBalanceUnderlying: PropTypes.string,
-  symbol: PropTypes.string,
-};
-
 const SavingsCoinRow = ({ item, onPress, ...props }) => (
   <ButtonPressAnimation onPress={onPress} scaleTo={1.02}>
     <CoinRow
@@ -81,10 +68,5 @@ const SavingsCoinRow = ({ item, onPress, ...props }) => (
     />
   </ButtonPressAnimation>
 );
-
-SavingsCoinRow.propTypes = {
-  item: PropTypes.object,
-  onPress: PropTypes.func,
-};
 
 export default SavingsCoinRow;

--- a/src/components/savings/SavingsListRow.js
+++ b/src/components/savings/SavingsListRow.js
@@ -34,6 +34,8 @@ const SavingsListRowShadows = [
   [0, 5, 15, colors.dark, 0.04],
 ];
 
+const NOOP = () => undefined;
+
 const neverRerender = () => true;
 // eslint-disable-next-line react/display-name
 const SavingsListRowGradient = React.memo(
@@ -164,7 +166,7 @@ const SavingsListRow = ({
             as={android && ButtonPressAnimation}
             css={padding(9, 10, 10, 11)}
             justify="space-between"
-            onPress={onButtonPress}
+            onPress={NOOP}
             scaleTo={0.96}
           >
             {underlying.symbol && supplyBalanceUnderlying ? (
@@ -181,7 +183,7 @@ const SavingsListRow = ({
                 value={displayValue}
               />
             ) : (
-              <SavingsListRowEmptyState onPress={onButtonPress} />
+              <SavingsListRowEmptyState onPress={NOOP} />
             )}
             <APYPill value={apyTruncated} />
           </Row>

--- a/src/components/savings/SavingsListRowEmptyState.js
+++ b/src/components/savings/SavingsListRowEmptyState.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { ButtonPressAnimation } from '../animations';
@@ -45,10 +44,6 @@ const SavingsListRowEmptyState = ({ onPress }) => (
     </ButtonPressAnimation>
   </RowWithMargins>
 );
-
-SavingsListRowEmptyState.propTypes = {
-  onPress: PropTypes.func,
-};
 
 const neverRerender = () => true;
 export default React.memo(SavingsListRowEmptyState, neverRerender);


### PR DESCRIPTION
The nested onPress functions were being triggered multiple times, but we'd like to keep the row-level and button-level interactions.
This was causing an issue on the Change wallet list where editing a wallet would bring up the menu twice.
Also cleaned up some PropTypes.