### PR TITLE
Constant height of ChartHeaderSubtitle on Android

### DIFF
--- a/src/components/expanded-state/chart/chart-data-labels/ChartHeaderSubtitle.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartHeaderSubtitle.js
@@ -14,6 +14,7 @@ const ChartHeaderSubtitle = styled(TruncatedText).attrs(
   })
 )`
   margin-left: ${android ? 6 : 0};
+  ${android ? 'height: 38' : ''};
 `;
 
 export default ChartHeaderSubtitle;


### PR DESCRIPTION
I observed that sometimes chart is jumping up and down in long currency names like "Saint Fame: ICK Mask" that need to be shortened with "...", 

This makes the height fixed. 