### PR TITLE
Fix 64 bit arch builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -176,7 +176,7 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
+        versionCode 2
         versionName "1.0"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
@@ -190,7 +190,7 @@ android {
 	    ]
 
         ndk {
-            abiFilters 'armeabi-v7a', 'x86'
+            abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
         }
 
     }
@@ -241,12 +241,12 @@ android {
     }
 
     packagingOptions {
-        pickFirst '**/armeabi-v7a/libc++_shared.so'
-        pickFirst '**/x86/libc++_shared.so'
-        pickFirst '**/arm64-v8a/libc++_shared.so'
-        pickFirst '**/x86_64/libc++_shared.so'
-        pickFirst '**/x86/libjsc.so'
-        pickFirst '**/armeabi-v7a/libjsc.so'
+        // pickFirst '**/armeabi-v7a/libc++_shared.so'
+        // pickFirst '**/x86/libc++_shared.so'
+        // pickFirst '**/arm64-v8a/libc++_shared.so'
+        // pickFirst '**/x86_64/libc++_shared.so'
+        // pickFirst '**/x86/libjsc.so'
+        // pickFirst '**/armeabi-v7a/libjsc.so'
         exclude 'META-INF/DEPENDENCIES'
     }
 
@@ -260,7 +260,7 @@ android {
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+                        versionCodes.get(abi) * 1000 + defaultConfig.versionCode
             }
 
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -241,12 +241,6 @@ android {
     }
 
     packagingOptions {
-        // pickFirst '**/armeabi-v7a/libc++_shared.so'
-        // pickFirst '**/x86/libc++_shared.so'
-        // pickFirst '**/arm64-v8a/libc++_shared.so'
-        // pickFirst '**/x86_64/libc++_shared.so'
-        // pickFirst '**/x86/libjsc.so'
-        // pickFirst '**/armeabi-v7a/libjsc.so'
         exclude 'META-INF/DEPENDENCIES'
     }
 


### PR DESCRIPTION
Builds were getting rejected on the PlayStore because of missing / wrong config. 
After this PR I was able to submit the build with no errors.