### PR TITLE
add react-native-back-handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "react-native-udp": "^2.6.1",
     "react-native-version-number": "^0.3.6",
     "react-native-webview": "^10.10.0",
+    "react-navigation-backhandler": "^2.0.1",
     "react-primitives": "^0.8.0",
     "react-query": "^1.3.0",
     "react-redux": "^7.1.3",

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -11,6 +11,7 @@ import React, {
 } from 'react';
 import { Keyboard } from 'react-native';
 import Animated, { Extrapolate } from 'react-native-reanimated';
+import { useAndroidBackHandler } from 'react-navigation-backhandler';
 import { useDispatch } from 'react-redux';
 import { dismissingScreenListener } from '../../shim';
 import { interpolate } from '../components/animations';
@@ -48,6 +49,7 @@ import {
 import Routes from '@rainbow-me/routes';
 import { colors, position } from '@rainbow-me/styles';
 import { backgroundTask, isNewValueForPath } from '@rainbow-me/utils';
+
 import logger from 'logger';
 
 const AnimatedFloatingPanels = Animated.createAnimatedComponent(FloatingPanels);
@@ -107,6 +109,11 @@ export default function ExchangeModal({
 
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [slippage, setSlippage] = useState(null);
+
+  useAndroidBackHandler(() => {
+    navigate(Routes.WALLET_SCREEN);
+    return true;
+  });
 
   const {
     defaultInputAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11574,6 +11574,11 @@ react-native@0.63.3:
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
 
+react-navigation-backhandler@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-navigation-backhandler/-/react-navigation-backhandler-2.0.1.tgz#5857703b69e0e74ef25d9c8915becebf154e8591"
+  integrity sha512-k4mhEaDfqVGR9P96MbSIAOXwLLiseYlRVZGMBcHInr97ondrebjiRdXOoA9rh87+g1epEPIvqtgFGJEUp4skPg==
+
 react-primitives@^0.8.0, react-primitives@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.8.1.tgz#50ae6eb29ab3fe81848510ab7c34adefeb59330e"


### PR DESCRIPTION
May be a better way to do this than using this package but this is what react-navigation suggests.

Here's the scenario:

If you're in the swap modal & have changed an input/output currency (i.e opened up the currencySelectionList), the physical back button on Android if pressed will take you back to the selectionList. I personally think the expected action is to go back to the WalletScreen. 

I am using the goBack button for detox on android since swiping isnt super reliable. 