### PR TITLE
fix coinDividerOpenButton styling

### DIFF
--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -31,9 +31,9 @@ const CaretIcon = styled(FastImage).attrs({
 `;
 
 const ContainerButton = styled(ButtonPressAnimation).attrs(
-  ({ isSmallBalancesOpen }) => ({
+  ({ isSmallBalancesOpen, isSendSheet }) => ({
     radiusWrapperStyle: {
-      marginLeft: 16,
+      marginLeft: isSendSheet && android ? 16 : 0,
       width: isSmallBalancesOpen ? 80 - (android ? 4 : 0) : closedWidth - 4,
     },
     scaleTo: 0.9,
@@ -58,10 +58,12 @@ const CoinDividerOpenButton = ({
   isSmallBalancesOpen,
   isVisible,
   onPress,
+  isSendSheet,
   ...props
 }) => (
   <ContainerButton
     {...props}
+    isSendSheet={isSendSheet}
     isSmallBalancesOpen={isSmallBalancesOpen}
     onPress={onPress}
     radiusAndroid={RoundButtonCapSize / 2}

--- a/src/components/send/SendAssetList.js
+++ b/src/components/send/SendAssetList.js
@@ -386,6 +386,7 @@ export default class SendAssetList extends React.Component {
     return (
       <View marginTop={dividerMargin}>
         <SendAssetListCoinDividerOpenButton
+          isSendSheet
           isSmallBalancesOpen={openShitcoins}
           onPress={this.changeOpenShitcoins}
         />


### PR DESCRIPTION
This was a side effect of fixing the button's ripple on Send Sheet

Before: https://cloud.skylarbarrera.com/Screenshot_20201120-181630_Rainbow.jpg

After:
- Android: https://cloud.skylarbarrera.com/Screen_Recording_20201120-180834.mp4
- iOS: https://cloud.skylarbarrera.com/Screen-Recording-2020-11-20-18-09-37.mp4