### PR TITLE
Restore iOS BackButton in CurrencySelectModal

### DIFF
--- a/src/components/exchange/CurrencySelectModalHeader.js
+++ b/src/components/exchange/CurrencySelectModalHeader.js
@@ -3,10 +3,7 @@ import React, { useCallback } from 'react';
 import styled from 'styled-components/primitives';
 import { delayNext } from '../../hooks/useMagicAutofocus';
 import { useNavigation } from '../../navigation/Navigation';
-import {
-  BackButton as ChevronBackButton,
-  BackButton as IOSBackButton,
-} from '../header';
+import { BackButton } from '../header';
 import { Centered } from '../layout';
 import { TruncatedText } from '../text';
 import Routes from '@rainbow-me/routes';
@@ -37,8 +34,6 @@ const Title = styled(TruncatedText).attrs({
   height: 21;
 `;
 
-const BackButton = ios ? IOSBackButton : ChevronBackButton;
-
 export default function CurrencySelectModalHeader({ testID }) {
   const { navigate, dangerouslyGetState } = useNavigation();
   const { params } = useRoute();
@@ -61,7 +56,7 @@ export default function CurrencySelectModalHeader({ testID }) {
           height={CurrencySelectModalHeaderHeight}
           onPress={handlePressBack}
           testID={testID}
-          textChevron
+          textChevron={android}
           throttle
         />
       </BackButtonWrapper>


### PR DESCRIPTION
this back button was meant for android only

ios before/after:
<img width="726" alt="Screen Shot 2020-11-22 at 6 44 34 PM" src="https://user-images.githubusercontent.com/7061887/99920633-c6908580-2cf2-11eb-9d1e-f3376fccd19e.png">