### PR TITLE
remove isOpen flag in sendSheet Keyboard

### DIFF
--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -20,7 +20,6 @@ import {
 } from '../components/send';
 import { createSignableTransaction, estimateGasLimit } from '../handlers/web3';
 import AssetTypes from '../helpers/assetTypes';
-import isKeyboardOpen from '../helpers/isKeyboardOpen';
 import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
 import {
   convertAmountAndPriceToNativeDisplay,
@@ -414,7 +413,6 @@ export default function SendSheet(props) {
   const { params } = useRoute();
   const assetOverride = params?.asset;
   const prevAssetOverride = usePrevious(assetOverride);
-  const keyboardIsOpen = isKeyboardOpen();
 
   useEffect(() => {
     if (assetOverride && assetOverride !== prevAssetOverride) {
@@ -533,7 +531,7 @@ export default function SendSheet(props) {
             }
           />
         )}
-        {android ? <KeyboardSizeView isOpen={keyboardIsOpen} /> : null}
+        {android ? <KeyboardSizeView /> : null}
       </SheetContainer>
     </Container>
   );


### PR DESCRIPTION
Got pulled into the hole while doing QA, the keyboard area was intermittently staying open after keyboard was closed.

Saw this in the docs: https://cloud.skylarbarrera.com/Screen-Shot-2020-11-23-at-11.15.27-PM.png


I removed flag and it's working very well: https://cloud.skylarbarrera.com/Screen_Recording_20201123-231804.mp4