### PR TITLE
Fix sendsheet keyboard handling in smaller devices

### DIFF
--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -71,7 +71,9 @@ const SheetContainer = styled(Column).attrs({
 `;
 
 const KeyboardSizeView = styled(KeyboardArea)`
-  background-color: ${colors.white};
+  width: 100%;
+  background-color: ${({ showAssetForm }) =>
+    showAssetForm ? colors.lighterGrey : colors.white};
 `;
 
 export default function SendSheet(props) {
@@ -531,7 +533,7 @@ export default function SendSheet(props) {
             }
           />
         )}
-        {android ? <KeyboardSizeView /> : null}
+        {android ? <KeyboardSizeView showAssetForm={showAssetForm} /> : null}
       </SheetContainer>
     </Container>
   );


### PR DESCRIPTION
There was a white gap under the send button on smaller devices because the KeyboardSizeView only considers the keyboard height of the alphabetic keyboard and ignores the height of the numeric one 🤷‍♂️  

Before the fix:  
<img width="340" alt="broken" src="https://user-images.githubusercontent.com/1247834/100183913-2e3f0000-2eae-11eb-89cc-771680a0c98f.png">

After the fix: 
![Screen Shot 2020-11-24 at 11 37 39 PM](https://user-images.githubusercontent.com/1247834/100183881-16677c00-2eae-11eb-9eef-7c19efcc81ff.png)


