### PR TITLE
Fix goerli

### DIFF
--- a/src/references/chains.json
+++ b/src/references/chains.json
@@ -30,5 +30,13 @@
     "network": "kovan",
     "chain_id": 42,
     "network_id": 42
+  },
+  {
+    "name": "Ethereum Görli",
+    "short_name": "goe",
+    "chain": "ETH",
+    "network": "goerli",
+    "chain_id": 5,
+    "network_id": 5
   }
 ]


### PR DESCRIPTION
We were missing the chain info for Goerli testnet, which was causing issues while using dapps via walletconnect.
Fixes #1377

After the fix:
![Screen Shot 2020-11-27 at 9 27 18 PM](https://user-images.githubusercontent.com/1247834/100492120-7b61e280-30f7-11eb-9b59-12a99d8f8c5b.png)
