### PR TITLE
disable usage of console

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     "akd": true
   },
   "rules": {
+    "no-console": 2,
     "sort-imports": ["error", {
       "ignoreCase": true,
       "ignoreDeclarationSort": true,

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -149,6 +149,7 @@ export async function checkIfDisabled(elementId) {
     await element(by.id(elementId)).tap();
     return Promise.reject();
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.log(e);
     return Promise.resolve();
   }

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -6,7 +6,6 @@ import { detox as config } from '../package.json';
 
 // eslint-disable-next-line import/no-commonjs
 require('dotenv').config({ path: '.env' });
-console.log(process.ENV);
 
 jest.retryTimes(1);
 jasmine.getEnv().addReporter(adapter);

--- a/shim.js
+++ b/shim.js
@@ -54,12 +54,14 @@ Object.defineProperty(global, 'ios', {
 const SHORTEN_PROP_TYPES_ERROR = true;
 
 if (SHORTEN_PROP_TYPES_ERROR) {
-  const oldConsoleError = console.error;
+  const oldConsoleError = console.error; // eslint-disable-line no-console
+  // eslint-disable-next-line no-console
   console.error = function() {
     if (
       typeof arguments[0] === 'string' &&
       arguments[0].startsWith('Warning: Failed prop type')
     ) {
+      // eslint-disable-next-line no-console
       console.log(
         `PropTypes error in: ${arguments[0]
           .match(/\w+.js:[0-9]+/g)

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -4,19 +4,19 @@ import sentryUtils from './sentry';
 const Logger = {
   debug(...args) {
     if (__DEV__) {
-      console.debug(...args);
+      console.debug(...args); // eslint-disable-line no-console
     }
   },
 
   error(...args) {
     if (__DEV__) {
-      console.error(...args);
+      console.error(...args); // eslint-disable-line no-console
     }
   },
 
   log(...args) {
     if (__DEV__) {
-      console.log(...args);
+      console.log(...args); // eslint-disable-line no-console
     }
   },
 
@@ -33,12 +33,12 @@ const Logger = {
           return arg;
         }
       });
-      console.log(allArgs.length > 0 ? allArgs : allArgs[0]);
+      console.log(allArgs.length > 0 ? allArgs : allArgs[0]); // eslint-disable-line no-console
     }
   },
   sentry(...args) {
     if (__DEV__) {
-      console.log(...args);
+      console.log(...args); // eslint-disable-line no-console
     }
     if (args.length === 1 && typeof args[0] === 'string') {
       sentryUtils.addInfoBreadcrumb.apply(null, args);
@@ -49,7 +49,7 @@ const Logger = {
   },
   warn(...args) {
     if (__DEV__) {
-      console.warn(...args);
+      console.warn(...args); // eslint-disable-line no-console
     }
   },
 };


### PR DESCRIPTION
This PR turns on the `no-console` eslint rule, so from now it will throw an error.

You can still logs it by importing `logger`