### PR TITLE
Exchange input android mask

### DIFF
--- a/src/components/exchange/ExchangeField.js
+++ b/src/components/exchange/ExchangeField.js
@@ -48,12 +48,12 @@ const ExchangeField = (
     symbol,
     testID,
     autoFocus,
+    useCustomAndroidMask = false,
     ...props
   },
   ref
 ) => {
   const handleFocusField = useCallback(() => ref?.current?.focus(), [ref]);
-
   useEffect(() => {
     autoFocus && handleFocusField();
   }, [autoFocus, handleFocusField]);
@@ -75,6 +75,7 @@ const ExchangeField = (
             placeholderTextColor={symbol ? undefined : skeletonColor}
             ref={ref}
             testID={amount ? `${testID}-${amount}` : testID}
+            useCustomAndroidMask={useCustomAndroidMask}
             value={amount}
           />
         </FieldRow>

--- a/src/components/exchange/ExchangeInput.js
+++ b/src/components/exchange/ExchangeInput.js
@@ -3,6 +3,7 @@ import { InteractionManager } from 'react-native';
 import TextInputMask from 'react-native-text-input-mask';
 import styled from 'styled-components/primitives';
 import { magicMemo } from '../../utils';
+import { Text } from '../text';
 import { buildTextStyles, colors } from '@rainbow-me/styles';
 
 const Input = styled(TextInputMask).attrs({
@@ -13,6 +14,15 @@ const Input = styled(TextInputMask).attrs({
   ${buildTextStyles};
   ${android ? 'font-weight: normal' : ''};
   flex: 1;
+`;
+
+const AndroidMaskWrapper = styled.View`
+  background-color: ${colors.white};
+  position: absolute;
+  top: 11.5;
+  right: 0;
+  bottom: 0;
+  left: 68.7;
 `;
 
 const ExchangeInput = (
@@ -32,6 +42,8 @@ const ExchangeInput = (
     testID,
     value = '',
     weight = 'semibold',
+    useCustomAndroidMask = false,
+    androidMaskMaxLength = 8,
     ...props
   },
   ref
@@ -84,27 +96,46 @@ const ExchangeInput = (
     },
     [onFocus]
   );
+  let valueToRender = value;
+  if (value?.length > androidMaskMaxLength) {
+    valueToRender = value.substring(0, androidMaskMaxLength) + '...';
+  }
 
   return (
-    <Input
-      {...props}
-      color={color}
-      editable={editable}
-      keyboardAppearance={keyboardAppearance}
-      letterSpacing={letterSpacing}
-      mask={mask}
-      onBlur={handleBlur}
-      onChange={handleChange}
-      onChangeText={handleChangeText}
-      onFocus={handleFocus}
-      placeholder={placeholder}
-      placeholderTextColor={placeholderTextColor}
-      ref={ref}
-      size={size}
-      testID={testID}
-      value={value}
-      weight={weight}
-    />
+    <React.Fragment>
+      <Input
+        {...props}
+        color={color}
+        editable={editable}
+        keyboardAppearance={keyboardAppearance}
+        letterSpacing={letterSpacing}
+        mask={mask}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        onChangeText={handleChangeText}
+        onFocus={handleFocus}
+        placeholder={placeholder}
+        placeholderTextColor={placeholderTextColor}
+        ref={ref}
+        size={size}
+        testID={testID}
+        value={value}
+        weight={weight}
+      />
+      {useCustomAndroidMask && !ref.current?.isFocused() && (
+        <AndroidMaskWrapper>
+          <Text
+            letterSpacing={letterSpacing}
+            size={size}
+            testID={testID}
+            weight={weight}
+            {...props}
+          >
+            {valueToRender}
+          </Text>
+        </AndroidMaskWrapper>
+      )}
+    </React.Fragment>
   );
 };
 

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -50,6 +50,7 @@ export default function ExchangeInputField({
         setAmount={setInputAmount}
         symbol={inputCurrencySymbol}
         testID={testID}
+        useCustomAndroidMask={android}
       />
       <NativeFieldRow>
         <ExchangeNativeField

--- a/src/components/exchange/ExchangeOutputField.js
+++ b/src/components/exchange/ExchangeOutputField.js
@@ -55,6 +55,7 @@ export default function ExchangeOutputField({
         setAmount={setOutputAmount}
         symbol={outputCurrencySymbol}
         testID={testID}
+        useCustomAndroidMask={android}
       />
     </Container>
   );


### PR DESCRIPTION
Replicate the iOS behavior where the input gets an ellipsis when it overflows without messing with the input cursor.

PoW: http://recordit.co/cdTYWPbxZi

This PR overrides #1399  because messing with the cursor has a lot of unwanted side effects