### PR TITLE
Fixing the react-native-payments fork version to 1.1.5 until credit card support issues become resolved by Wyre

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@ethersproject/wallet": "^5.0.2",
     "@hocs/safe-timers": "^0.4.0",
     "@rainbow-me/react-native-animated-number": "^0.0.2",
-    "@rainbow-me/react-native-payments": "^1.1.5",
+    "@rainbow-me/react-native-payments": "1.1.5",
     "@react-native-community/art": "^1.2.0",
     "@react-native-community/async-storage": "^1.11.0",
     "@react-native-community/blur": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,7 +2174,7 @@
   dependencies:
     react-merge-refs "^1.0.0"
 
-"@rainbow-me/react-native-payments@^1.1.5":
+"@rainbow-me/react-native-payments@1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@rainbow-me/react-native-payments/-/react-native-payments-1.1.5.tgz#cdf03c8a55070f0c6cb000a58b906dc9980d9d3f"
   integrity sha512-8Eyc940oCNep9nYjEZ3bYEfJVGz2fzCb+FIfQx7BuvlfcEIYLw02J7I0Umi+08O9NdWtLswTiEpLcfN3bLEQYg==


### PR DESCRIPTION
Version 1.1.7 enables credit/ debit cards. Version 1.1.5 restricts to just debit cards.