### PR TITLE
Android paddings

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateImage.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateImage.js
@@ -11,6 +11,7 @@ const paddingHorizontal = 19;
 const Container = styled(Centered)`
   ${padding(0, paddingHorizontal)};
   height: ${({ height }) => height};
+  ${android ? `margin-bottom: 10;` : ``}
 `;
 
 const ImageWrapper = styled(Centered)`

--- a/src/components/savings/AndroidAnimatedNumbers.js
+++ b/src/components/savings/AndroidAnimatedNumbers.js
@@ -32,7 +32,7 @@ function formatter(symbol, val) {
     : `${formatSavingsAmount(val)} ${symbol}`;
 }
 
-export default function AndroidText({ animationConfig }) {
+export default function AndroidText({ style, animationConfig }) {
   const isStable = isSymbolStablecoin(animationConfig.symbol);
   const ref = useRef();
   useEffect(() => {
@@ -45,7 +45,7 @@ export default function AndroidText({ animationConfig }) {
   }, [animationConfig, isStable]);
 
   return (
-    <Row>
+    <Row style={style}>
       <TextChunk
         defaultValue={formatter(
           animationConfig.symbol,

--- a/src/components/savings/SavingsListRowAnimatedNumber.js
+++ b/src/components/savings/SavingsListRowAnimatedNumber.js
@@ -11,9 +11,9 @@ const sx = StyleSheet.create({
     height: 30,
   },
   animatedNumberAndroid: {
-    paddingLeft: 35,
+    left: 35,
     position: 'absolute',
-    top: 12,
+    top: 4,
   },
   text: {
     color: colors.dark,


### PR DESCRIPTION
2 small tweaks:

- Fix alignment of savings row:

Before: 
![Screen Shot 2020-12-02 at 6 02 18 PM](https://user-images.githubusercontent.com/1247834/100943852-05c98e00-34cc-11eb-8dfd-24c83685a9dc.png)

After:
![Screen Shot 2020-12-02 at 6 22 59 PM](https://user-images.githubusercontent.com/1247834/100943862-09f5ab80-34cc-11eb-975b-52a4bff2eab9.png)

- Add margin bottom to unique token image

Before:
![Screen Shot 2020-12-02 at 6 09 29 PM](https://user-images.githubusercontent.com/1247834/100943892-1c6fe500-34cc-11eb-88b1-648941f342e0.png)

After:
![Screen Shot 2020-12-02 at 6 25 14 PM](https://user-images.githubusercontent.com/1247834/100943901-21349900-34cc-11eb-926a-edb02e3cc001.png)
