### PR TITLE
Fix fake error on wallet init

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -138,7 +138,7 @@ export interface AllRainbowWallets {
 }
 
 interface AllRainbowWalletsData {
-  allWallets: AllRainbowWallets;
+  wallets: AllRainbowWallets;
   version: string;
 }
 

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -1,6 +1,6 @@
 import { captureException, captureMessage } from '@sentry/react-native';
 import { toChecksumAddress } from 'ethereumjs-util';
-import { filter, flatMap, get, keys, map, values } from 'lodash';
+import { filter, flatMap, get, isEmpty, keys, map, values } from 'lodash';
 import { backupUserDataIntoCloud } from '../handlers/cloudBackup';
 import { saveKeychainIntegrityState } from '../handlers/localstorage/globalSettings';
 import {
@@ -42,7 +42,9 @@ export const walletsLoadState = () => async (dispatch, getState) => {
   try {
     const { accountAddress } = getState().settings;
     let addressFromKeychain = accountAddress;
-    const { wallets } = await getAllWallets();
+    const allWalletsResult = await getAllWallets();
+    const wallets = get(allWalletsResult, 'wallets', {});
+    if (isEmpty(wallets)) return;
     const selected = await getSelectedWallet();
     // Prevent irrecoverable state (no selected wallet)
     let selectedWallet = get(selected, 'wallet', undefined);

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -43,7 +43,7 @@ export const walletsLoadState = () => async (dispatch, getState) => {
     const { accountAddress } = getState().settings;
     let addressFromKeychain = accountAddress;
     const allWalletsResult = await getAllWallets();
-    const wallets = get(allWalletsResult, 'wallets', {});
+    const wallets = allWalletsResult?.wallets || {};
     if (isEmpty(wallets)) return;
     const selected = await getSelectedWallet();
     // Prevent irrecoverable state (no selected wallet)


### PR DESCRIPTION
For every new user who creates a wallet, we're incorrectly triggering an error on sentry like this one: https://sentry.io/organizations/rainbow-me/issues/2071346390/events/0b91c074bff74d14ae5f68862bf01bab/?project=1855565&query=release%3Ame.rainbow%401.0%2B5&statsPeriod=24h#threads

The reason is because the first time, the  entry "allWalletsKey" is not set yet, so we create a new wallet and call walletsLoadState again.

I added a short circuit for the firs time so we don't throw that error 