### PR TITLE
Fix iCloud Backups

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -335,8 +335,8 @@ PODS:
     - React-cxxreact (= 0.63.3)
     - React-jsi (= 0.63.3)
   - React-jsinspector (0.63.3)
-  - react-native-aes-crypto (2.0.0):
-    - React
+  - react-native-aes-crypto (2.0.2):
+    - React-Core
   - react-native-background-timer (2.4.1):
     - React-Core
   - react-native-blur (0.8.0):
@@ -955,7 +955,7 @@ SPEC CHECKSUMS:
   React-jsi: df07aa95b39c5be3e41199921509bfa929ed2b9d
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
-  react-native-aes-crypto: b197adec6d65ff2386478c4e5bd2a66ec9accbbb
+  react-native-aes-crypto: d7e87fd02cee7285983c00957a34063dfc4c94b3
   react-native-background-timer: 17ea5e06803401a379ebf1f20505b793ac44d0fe
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-branch: 8bda99ca8dc5a16d32bd81c8a8d937cb3d2c5e0c

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "react-native": "0.63.3",
     "react-native-action-sheet": "^2.2.0",
     "react-native-actionsheet": "^2.4.2",
-    "react-native-aes-crypto": "brunobar79/react-native-aes#27d52ea6c2ff8470388b20993e0357ab07ad17e3",
+    "react-native-aes-crypto": "brunobar79/react-native-aes#65c49f7e70266615b2999eaa7db654d3fe4f2e3b",
     "react-native-android-keyboard-adjust": "^1.2.0",
     "react-native-background-timer": "^2.2.0",
     "react-native-branch": "^5.0.0",

--- a/src/handlers/aesEncryption.js
+++ b/src/handlers/aesEncryption.js
@@ -10,7 +10,9 @@ export default class AesEncryptor {
   }
 
   generateKey = (password, salt) =>
-    AesEncryption.pbkdf2(password, salt, 5000, 256);
+    android
+      ? AesEncryption.pbkdf2(password, salt, 5000, 256)
+      : AesEncryption.pbkdf2(password, salt);
 
   keyFromPassword = (password, salt) => this.generateKey(password, salt);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11173,9 +11173,9 @@ react-native-actionsheet@^2.4.2:
   resolved "https://registry.yarnpkg.com/react-native-actionsheet/-/react-native-actionsheet-2.4.2.tgz#6a00dd51a75ef2c8974312130e405af73191500f"
   integrity sha512-DBoWIvVwuWXuptF4t46pBqkFxaUxS+rsIdHiA05t0n4BdTIDV2R4s9bLEUVOGzb94D7VxIamsXZPA/3mmw+SXg==
 
-react-native-aes-crypto@brunobar79/react-native-aes#27d52ea6c2ff8470388b20993e0357ab07ad17e3:
-  version "2.0.0"
-  resolved "https://codeload.github.com/brunobar79/react-native-aes/tar.gz/27d52ea6c2ff8470388b20993e0357ab07ad17e3"
+react-native-aes-crypto@brunobar79/react-native-aes#65c49f7e70266615b2999eaa7db654d3fe4f2e3b:
+  version "2.0.2"
+  resolved "https://codeload.github.com/brunobar79/react-native-aes/tar.gz/65c49f7e70266615b2999eaa7db654d3fe4f2e3b"
 
 react-native-android-keyboard-adjust@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
- bumps react-native-aes-crypto which fixes cloud backups
- Updates AesEncryptor API to work on both OS