### PR TITLE
Update fallback explorer to include compound type

### DIFF
--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -65,7 +65,7 @@ export default function SendAssetForm({
   const selectedAsset = useAsset(selected);
 
   const isNft = selectedAsset.type === AssetTypes.nft;
-  const isSavings = selectedAsset.type === AssetTypes.cToken;
+  const isSavings = selectedAsset.type === AssetTypes.compound;
 
   const AssetRowElement = isNft
     ? CollectiblesSendRow

--- a/src/helpers/assetTypes.js
+++ b/src/helpers/assetTypes.js
@@ -1,8 +1,9 @@
 export default {
-  cToken: 'cToken',
+  compound: 'compound',
   eth: 'eth',
   nft: 'nft',
   token: 'token',
+  trash: 'trash',
   uniswap: 'uniswap',
   uniswapV2: 'uniswap-v2',
 };

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -14,7 +14,7 @@ import { useSelector } from 'react-redux';
 import { compoundClient } from '../apollo/client';
 import { COMPOUND_ACCOUNT_AND_MARKET_QUERY } from '../apollo/queries';
 import { getSavings, saveSavings } from '../handlers/localstorage/accountLocal';
-import assetTypes from '../helpers/assetTypes';
+import AssetTypes from '../helpers/assetTypes';
 import { multiply } from '../helpers/utilities';
 import useAccountSettings from '../hooks/useAccountSettings';
 import { parseAssetName, parseAssetSymbol } from '../parsers/accounts';
@@ -136,7 +136,7 @@ export default function useSavingsAccount(includeDefaultDai) {
             lifetimeSupplyInterestAccrued,
             supplyBalanceUnderlying,
             supplyRate,
-            type: assetTypes.cToken,
+            type: AssetTypes.compound,
             underlying,
             underlyingPrice,
           };

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -262,7 +262,9 @@ export const addressAssetsReceived = (
   const payload = values(get(message, 'payload.assets', {}));
   let assets = filter(
     payload,
-    asset => asset.asset.type !== 'compound' && asset.asset.type !== 'trash'
+    asset =>
+      asset?.asset?.type !== AssetTypes.compound &&
+      asset?.asset?.type !== AssetTypes.trash
   );
 
   if (removed) {
@@ -279,19 +281,13 @@ export const addressAssetsReceived = (
     shitcoins.includes(toLower(asset?.asset?.asset_code))
   );
 
-  // Remove compound tokens
-  remove(
-    assets,
-    asset => toLower(asset?.asset?.name).indexOf('compound') !== -1
-  );
-
   let parsedAssets = parseAccountAssets(assets, uniqueTokens);
 
   // remove LP tokens
   const liquidityTokens = remove(
     parsedAssets,
     asset =>
-      asset.type === AssetTypes.uniswap || asset.type === AssetTypes.uniswapV2
+      asset?.type === AssetTypes.uniswap || asset?.type === AssetTypes.uniswapV2
   );
 
   dispatch(

--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -109,6 +109,17 @@ const findAssetsToWatch = async (address, latestTxBlockNumber, dispatch) => {
   ];
 };
 
+const getTokenType = tx => {
+  if (tx.tokenSymbol === 'UNI-V1') return AssetTypes.uniswap;
+  if (tx.tokenSymbol === 'UNI-V2') return AssetTypes.uniswapV2;
+  if (
+    toLower(tx.tokenName).indexOf('compound') !== -1 &&
+    tx.tokenSymbol !== 'COMP'
+  )
+    return AssetTypes.compound;
+  return undefined;
+};
+
 const discoverTokens = async (
   coingeckoIds,
   address,
@@ -154,12 +165,7 @@ const discoverTokens = async (
 
     return uniqBy(
       allTxs.map(tx => {
-        const type =
-          tx.tokenSymbol === 'UNI-V1'
-            ? AssetTypes.uniswap
-            : tx.tokenSymbol === 'UNI-V2'
-            ? AssetTypes.uniswapV2
-            : undefined;
+        const type = getTokenType(tx);
         return {
           asset: {
             asset_code: getCurrentAddress(tx.contractAddress.toLowerCase()),


### PR DESCRIPTION
We were removing assets with "compound" type as well  as anything with "compound" in the name in order for data from fallback explorer to match up with Zerion data. However, this second removal included the COMP token itself. Now the fallback explorer will parse the "compound" type (which includes cTokens but excludes the COMP itself)