### PR TITLE
Fix minibutton BPA on android & refactor for parity 

### DIFF
--- a/src/components/buttons/MiniButton.js
+++ b/src/components/buttons/MiniButton.js
@@ -39,7 +39,7 @@ export default function MiniButton({
   height,
   ...props
 }) {
-  const buttonOnly = (
+  return (
     <ButtonPressAnimation
       disabled={disabled}
       onPress={onPress}
@@ -47,30 +47,26 @@ export default function MiniButton({
       scaleTo={scaleTo}
       {...props}
     >
-      <ShadowStack
-        {...position.coverAsObject}
-        backgroundColor={disabled ? colors.lightGrey : colors.appleBlue}
-        borderRadius={borderRadius}
-        height={height}
-        shadows={disabled ? shadows.disabled : shadows.default}
-        width={width}
-      />
-      <Content>
-        {typeof children === 'string' ? (
-          <Text color="white" weight="semibold">
-            {children}
-          </Text>
-        ) : (
-          children
-        )}
-      </Content>
-      <InnerBorder radius={borderRadius} />
+      <View style={{ borderRadius, overflow: 'hidden' }}>
+        <ShadowStack
+          {...position.coverAsObject}
+          backgroundColor={disabled ? colors.lightGrey : colors.appleBlue}
+          borderRadius={borderRadius}
+          height={height}
+          shadows={disabled ? shadows.disabled : shadows.default}
+          width={width}
+        />
+        <Content>
+          {typeof children === 'string' ? (
+            <Text color="white" weight="semibold">
+              {children}
+            </Text>
+          ) : (
+            children
+          )}
+        </Content>
+        <InnerBorder radius={borderRadius} />
+      </View>
     </ButtonPressAnimation>
-  );
-
-  return android ? (
-    <View style={{ borderRadius, overflow: 'hidden' }}>{buttonOnly}</View>
-  ) : (
-    buttonOnly
   );
 }


### PR DESCRIPTION
before: http://cloud.skylarbarrera.com/Screen_Recording_20201208-202320.mp4

after:

🤖 :  http://cloud.skylarbarrera.com/Screen_Recording_20201208-210005.mp4

🍎 : http://cloud.skylarbarrera.com/Screen-Recording-2020-12-08-22-57-15.mp4


I can refactor to separate out for android but this works on both and parity makes me 😄 