### PR TITLE
manual backup button padding & remove gradient

### DIFF
--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -117,7 +117,7 @@ export default function BackupManualStep() {
           <SheetActionButton
             color={colors.appleBlue}
             label={`􀁣 I’ve saved ${
-              type === WalletTypes.privateKey ? 'my key' : 'these words :) '
+              type === WalletTypes.privateKey ? 'my key' : 'these words'
             }`}
             onPress={onComplete}
             size="big"

--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -27,7 +27,7 @@ const Content = styled(Column).attrs({
 const Footer = styled(Column).attrs({
   justify: 'end',
 })`
-  ${padding(0, 15, 21)};
+  ${padding(android ? 0 : 20, 15, 21)};
   width: 100%;
 `;
 
@@ -117,7 +117,7 @@ export default function BackupManualStep() {
           <SheetActionButton
             color={colors.appleBlue}
             label={`􀁣 I’ve saved ${
-              type === WalletTypes.privateKey ? 'my key' : 'these words'
+              type === WalletTypes.privateKey ? 'my key' : 'these words :) '
             }`}
             onPress={onComplete}
             size="big"

--- a/src/components/secret-display/SecretDisplayCard.js
+++ b/src/components/secret-display/SecretDisplayCard.js
@@ -1,6 +1,5 @@
 import { times } from 'lodash';
 import React, { useMemo } from 'react';
-import LinearGradient from 'react-native-linear-gradient';
 import styled from 'styled-components/primitives';
 import CopyTooltip from '../copy-tooltip';
 import { Centered, ColumnWithMargins, Row, RowWithMargins } from '../layout';
@@ -8,14 +7,6 @@ import { Text } from '../text';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
 import { colors, fonts, padding, position } from '@rainbow-me/styles';
 import ShadowStack from 'react-native-shadow-stack';
-
-const BackgroundGradient = styled(LinearGradient).attrs({
-  colors: colors.gradients.offWhite,
-  end: { x: 0.5, y: 1 },
-  start: { x: 0.5, y: 0 },
-})`
-  ${position.cover};
-`;
 
 const CardShadow = styled(ShadowStack).attrs({
   ...position.coverAsObject,
@@ -91,7 +82,6 @@ export default function SecretDisplayCard({ seed, type }) {
       {ios && (
         <>
           <CardShadow />
-          <BackgroundGradient />
         </>
       )}
       <Content>


### PR DESCRIPTION
Padding for "I've saved these words" was off on iOS since we merged android. I kept android the same since it looks better as is.

I also noticed there was a really slight borderRadius issue with the LinearGradient on the SecretDisplayCard, it wasnt adding any effect so I removed entirely.

padding before: http://cloud.skylarbarrera.com/Screen-Shot-2020-12-09-at-1.56.25-PM.png

padding after: http://cloud.skylarbarrera.com/Screen-Shot-2020-12-09-at-1.56.17-PM.png

borderRadius issue before: http://cloud.skylarbarrera.com/Screen-Shot-2020-12-09-at-1.47.01-PM.png

borderRadius issue after: http://cloud.skylarbarrera.com/Screen-Shot-2020-12-09-at-1.56.08-PM.png