### PR TITLE
Fix iOS 12 savings crash

### DIFF
--- a/src/components/savings/SavingsListRowAnimatedNumber.js
+++ b/src/components/savings/SavingsListRowAnimatedNumber.js
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react';
 import { requireNativeComponent, StyleSheet } from 'react-native';
 import useRainbowTextAvailable from '../../helpers/isRainbowTextAvailable';
 import { formatSavingsAmount, isSymbolStablecoin } from '../../helpers/savings';
+import { Text } from '../text';
 import AndroidText from './AndroidAnimatedNumbers';
 import { colors, fonts } from '@rainbow-me/styles';
 
@@ -44,6 +45,8 @@ const SavingsListRowAnimatedNumber = ({
   const isRainbowTextAvailable = useRainbowTextAvailable();
   const TextComponent = isRainbowTextAvailable
     ? requireNativeComponent('RainbowText')
+    : ios
+    ? Text
     : AndroidText;
 
   return (


### PR DESCRIPTION
fixes this crash on iOS 12 (RainbowText is only available on iOS 13, not sure if that's intentional cc @osdnk):
![Simulator Screen Shot - iPhone Xs - 2020-12-09 at 21 13 02](https://user-images.githubusercontent.com/7061887/101723903-4781a800-3a7b-11eb-805e-faeb71074925.png)