### PR TITLE
Handle error if savings info (including Dai market info) unavailable

### DIFF
--- a/src/components/savings/SavingsListWrapper.js
+++ b/src/components/savings/SavingsListWrapper.js
@@ -1,3 +1,4 @@
+import { map } from 'lodash';
 import React, { Fragment } from 'react';
 import { useOpenSavings } from '../../hooks';
 import { OpacityToggler } from '../animations';
@@ -24,7 +25,7 @@ export default function SavingsListWrapper({ assets, totalValue = '0' }) {
         isVisible={!isSavingsOpen}
         pointerEvents={isSavingsOpen ? 'auto' : 'none'}
       >
-        {assets.map(renderSavingsListRow)}
+        {map(assets, renderSavingsListRow)}
       </OpacityToggler>
     </Fragment>
   );

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -1,5 +1,13 @@
 import lang from 'i18n-js';
-import { compact, flattenDeep, get, groupBy, map, property } from 'lodash';
+import {
+  compact,
+  flattenDeep,
+  get,
+  groupBy,
+  isEmpty,
+  map,
+  property,
+} from 'lodash';
 import React from 'react';
 import { LayoutAnimation } from 'react-native';
 import FastImage from 'react-native-fast-image';
@@ -315,7 +323,7 @@ const withBalanceSection = (
     nativeCurrency
   );
 
-  if (networkTypes.mainnet === network) {
+  if (networkTypes.mainnet === network && !isEmpty(savingsSection.assets)) {
     balanceSectionData.push(savingsSection);
   }
 


### PR DESCRIPTION
If tokens are unavailable and the DAI market data (to show the default empty DAI savings state) is unavailable, a crash occurs. This fix is to not show the savings data until at least either the tokens or the empty DAI state (with corresponding rate data) is available.

Can test that the import of this address does not crash the wallet: 0xba2e7fed597fd0e3e70f5130bcdbbfe06bb94fe1 (it is the yYFI token contract, but it should still not crash)