### PR TITLE
Fix hook not loading from backup when subgraph data unavail

### DIFF
--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -1,13 +1,5 @@
 import lang from 'i18n-js';
-import {
-  compact,
-  flattenDeep,
-  get,
-  groupBy,
-  isEmpty,
-  map,
-  property,
-} from 'lodash';
+import { compact, flattenDeep, get, groupBy, map, property } from 'lodash';
 import React from 'react';
 import { LayoutAnimation } from 'react-native';
 import FastImage from 'react-native-fast-image';
@@ -323,7 +315,7 @@ const withBalanceSection = (
     nativeCurrency
   );
 
-  if (networkTypes.mainnet === network && !isEmpty(savingsSection.assets)) {
+  if (networkTypes.mainnet === network) {
     balanceSectionData.push(savingsSection);
   }
 

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -23,6 +23,7 @@ import { CDAI_CONTRACT, DAI_ADDRESS } from '../references';
 const COMPOUND_QUERY_INTERVAL = 120000; // 120 seconds
 
 const getMarketData = marketData => {
+  if (!marketData) return {};
   const underlying = getUnderlyingData(marketData);
   const cToken = getCTokenData(marketData);
   const { exchangeRate, supplyRate, underlyingPrice } = marketData;
@@ -154,7 +155,7 @@ export default function useSavingsAccount(includeDefaultDai) {
       const daiMarketData = getMarketData(markets[CDAI_CONTRACT]);
       const result = {
         accountTokens: savingsAccountData,
-        daiMarketData: daiMarketData,
+        daiMarketData,
       };
       setResult(result);
     };

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -177,7 +177,7 @@ export default function useSavingsAccount(includeDefaultDai) {
       token => token.underlying.address === DAI_ADDRESS
     );
 
-    let savings = accountTokens;
+    let savings = accountTokens || [];
 
     const shouldAddDai =
       includeDefaultDai && !accountHasCDAI && !isEmpty(daiMarketData);


### PR DESCRIPTION
This fixes the red icon issue.

Also, when the "DAI market data" was not available, it was causing an issue where even the existing localstorage data didn't get a chance to be used (causing a long delay for existing users to see their savings tokens).