### PR TITLE
Fix ETH icons on activity list

### DIFF
--- a/src/components/activity-list/RecyclerActivityList.js
+++ b/src/components/activity-list/RecyclerActivityList.js
@@ -1,5 +1,4 @@
 import { get } from 'lodash';
-import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import {
   DataProvider,
@@ -62,18 +61,6 @@ const hasRowChanged = (r1, r2) => {
 };
 
 export default class RecyclerActivityList extends PureComponent {
-  static propTypes = {
-    addCashAvailable: PropTypes.bool,
-    header: PropTypes.node,
-    isLoading: PropTypes.bool,
-    sections: PropTypes.arrayOf(
-      PropTypes.shape({
-        data: PropTypes.array,
-        title: PropTypes.string.isRequired,
-      })
-    ),
-  };
-
   constructor(props) {
     super(props);
 

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -290,8 +290,8 @@ const parseTransaction = (
     return {
       ...transaction,
       address:
-        updatedAsset.address === 'eth'
-          ? updatedAsset.address
+        updatedAsset.address.toLowerCase() === 'eth'
+          ? updatedAsset.address.toLowerCase()
           : toChecksumAddress(updatedAsset.address),
       balance: convertRawAmountToBalance(valueUnit, updatedAsset),
       description,

--- a/src/parsers/transactions.js
+++ b/src/parsers/transactions.js
@@ -183,7 +183,10 @@ const parseTransaction = (
     const assetInternalTransaction = {
       address_from: transaction.from,
       address_to: transaction.to,
-      asset,
+      asset: {
+        asset_code: asset.address,
+        ...asset,
+      },
       value: transaction.value,
     };
     internalTransactions = [assetInternalTransaction];
@@ -199,7 +202,7 @@ const parseTransaction = (
       address_from: transaction.from,
       address_to: transaction.to,
       asset: {
-        address: 'eth',
+        asset_code: 'eth',
         decimals: 18,
         name: 'Ethereum',
         symbol: 'ETH',
@@ -222,13 +225,13 @@ const parseTransaction = (
   if (
     isEmpty(internalTransactions) &&
     transaction.type === TransactionTypes.execution &&
-    txn.direction === 'self'
+    txn.direction === DirectionTypes.self
   ) {
     const ethInternalTransaction = {
       address_from: transaction.from,
       address_to: transaction.to,
       asset: {
-        address: 'eth',
+        asset_code: 'eth',
         decimals: 18,
         name: 'Ethereum',
         symbol: 'ETH',
@@ -286,7 +289,10 @@ const parseTransaction = (
 
     return {
       ...transaction,
-      address: toChecksumAddress(updatedAsset.address),
+      address:
+        updatedAsset.address === 'eth'
+          ? updatedAsset.address
+          : toChecksumAddress(updatedAsset.address),
       balance: convertRawAmountToBalance(valueUnit, updatedAsset),
       description,
       from: internalTxn.address_from,


### PR DESCRIPTION
There were a couple issues:
1. We were checksumming the asset address without checking if it was the eth address
2. When substituting zerion data with asset data, we were passing along internal assets with "address" instead of "asset_code" which messed up parsing downstream that expected "asset_code" 