### PR TITLE
Disable FAB's

### DIFF
--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -100,6 +100,7 @@ export default function WalletScreen() {
       reattaching of react subviews */}
       <Animated.Code exec={scrollViewTracker} />
       <FabWrapper
+        disabled={isEmpty || !!params?.emptyWallet}
         fabs={fabs}
         isCoinListEdited={isCoinListEdited}
         isReadOnlyWallet={isReadOnlyWallet}


### PR DESCRIPTION
added logic to follow empty wallet logic as the AssetList per @christianbaroni 