### PR TITLE
Remove apollo caching

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -1,7 +1,19 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 
+const defaultOptions = {
+  query: {
+    errorPolicy: 'all',
+    fetchPolicy: 'no-cache',
+  },
+  watchQuery: {
+    errorPolicy: 'ignore',
+    fetchPolicy: 'no-cache',
+  },
+};
+
 export const compoundClient = new ApolloClient({
   cache: new InMemoryCache(),
+  defaultOptions,
   link: new HttpLink({
     uri: 'https://api.thegraph.com/subgraphs/name/graphprotocol/compound-v2',
   }),
@@ -9,6 +21,7 @@ export const compoundClient = new ApolloClient({
 
 export const uniswapClient = new ApolloClient({
   cache: new InMemoryCache(),
+  defaultOptions,
   link: new HttpLink({
     uri: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2',
   }),

--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -13,7 +13,6 @@ const defaultOptions = {
 
 export const compoundClient = new ApolloClient({
   cache: new InMemoryCache(),
-  defaultOptions,
   link: new HttpLink({
     uri: 'https://api.thegraph.com/subgraphs/name/graphprotocol/compound-v2',
   }),


### PR DESCRIPTION
I think we're not taking advantages of this cache anyway (are we) and it let us release 40MB of 100MB that our app is using