### PR TITLE
Save DAI market data to localstorage instead of waiting for fresh DAI rate data every time

### DIFF
--- a/src/components/discover-sheet/UniswapPoolsSection.js
+++ b/src/components/discover-sheet/UniswapPoolsSection.js
@@ -19,7 +19,7 @@ const sample = {
   uniTotalSupply: 42.8096419,
 };
 
-const renderSavingsListRow = item => (
+const renderUniswapInvestmentRow = item => (
   <UniswapInvestmentRow assetType="uniswap" item={item} key={item.uniqueId} />
 );
 
@@ -30,7 +30,7 @@ export default function UniswapPools() {
         🦄 Uniswap Pools
       </Text>
       {[sample, sample, sample, sample, sample, sample].map(
-        renderSavingsListRow
+        renderUniswapInvestmentRow
       )}
     </Column>
   );

--- a/src/components/savings/APYPill.js
+++ b/src/components/savings/APYPill.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { IS_TESTING } from 'react-native-dotenv';
@@ -89,10 +88,5 @@ function APYPill({ small, value }) {
     </Centered>
   );
 }
-
-APYPill.propTypes = {
-  small: PropTypes.bool,
-  value: PropTypes.node,
-};
 
 export default React.memo(APYPill);

--- a/src/components/savings/SavingsListRow.js
+++ b/src/components/savings/SavingsListRow.js
@@ -1,6 +1,5 @@
 import analytics from '@segment/analytics-react-native';
 import BigNumber from 'bignumber.js';
-import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { InteractionManager } from 'react-native';
 import { IS_TESTING } from 'react-native-dotenv';
@@ -10,7 +9,6 @@ import {
   SavingsSheetEmptyHeight,
   SavingsSheetHeight,
 } from '../../screens/SavingsSheet';
-
 import { ButtonPressAnimation } from '../animations';
 import { CoinIcon } from '../coin-icon';
 import { Centered, Row } from '../layout';
@@ -195,16 +193,6 @@ const SavingsListRow = ({
       </Centered>
     </ButtonPressAnimation>
   );
-};
-
-SavingsListRow.propTypes = {
-  cTokenBalance: PropTypes.string,
-  lifetimeSupplyInterestAccrued: PropTypes.string,
-  supplyBalanceUnderlying: PropTypes.string,
-  supplyRate: PropTypes.string,
-  underlying: PropTypes.object,
-  underlyingBalanceNativeValue: PropTypes.string,
-  underlyingPrice: PropTypes.string,
 };
 
 export default React.memo(SavingsListRow);

--- a/src/handlers/localstorage/accountLocal.js
+++ b/src/handlers/localstorage/accountLocal.js
@@ -3,7 +3,7 @@ import { getAccountLocal, saveAccountLocal } from './common';
 const assetPricesFromUniswapVersion = '0.1.0';
 const assetsVersion = '0.2.0';
 const purchaseTransactionsVersion = '0.1.0';
-const savingsVersion = '0.1.0';
+const savingsVersion = '0.2.0';
 const transactionsVersion = '0.2.5';
 const uniqueTokensVersion = '0.2.0';
 const accountEmptyVersion = '0.1.0';
@@ -50,7 +50,7 @@ export const accountLocalKeys = [
  * @return {Object}
  */
 export const getSavings = (accountAddress, network) =>
-  getAccountLocal(SAVINGS, accountAddress, network, [], savingsVersion);
+  getAccountLocal(SAVINGS, accountAddress, network, {}, savingsVersion);
 
 /**
  * @desc save savings

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -91,13 +91,15 @@ export default function useSavingsAccount(includeDefaultDai) {
     if (!hasAccountAddress) return;
     const fetchBackupSavings = async () => {
       const backup = await getSavings(accountAddress, network);
-      setBackupSavings(backup);
+      if (!isEmpty(backup)) {
+        setBackupSavings(backup);
+      }
     };
     fetchBackupSavings();
   }, [accountAddress, hasAccountAddress, network]);
 
   useEffect(() => {
-    if (!hasAccountAddress || isNil(backupSavings)) return;
+    if (!hasAccountAddress) return;
     const parseSavingsResult = async data => {
       if (error) return;
 
@@ -117,16 +119,13 @@ export default function useSavingsAccount(includeDefaultDai) {
             underlyingPrice,
           } = getMarketData(marketData);
 
-          const ethPrice = multiply(
-            underlyingPrice,
-            token.supplyBalanceUnderlying
-          );
-
           const {
             cTokenBalance,
             lifetimeSupplyInterestAccrued,
             supplyBalanceUnderlying,
           } = token;
+
+          const ethPrice = multiply(underlyingPrice, supplyBalanceUnderlying);
 
           return {
             cToken,
@@ -153,9 +152,8 @@ export default function useSavingsAccount(includeDefaultDai) {
         };
         saveSavings(result, accountAddress, network);
         setResult(result);
-      } else if (loading) {
-        const result = backupSavings;
-        setResult(result);
+      } else if (loading && !isNil(backupSavings)) {
+        setResult(backupSavings);
       }
     };
     parseSavingsResult(data);
@@ -183,6 +181,7 @@ export default function useSavingsAccount(includeDefaultDai) {
 
     const shouldAddDai =
       includeDefaultDai && !accountHasCDAI && !isEmpty(daiMarketData);
+
     if (shouldAddDai) {
       savings = concat(accountTokens, {
         ...daiMarketData,

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -5,8 +5,8 @@ import {
   isEmpty,
   isNil,
   keyBy,
+  map,
   orderBy,
-  property,
   toLower,
 } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
@@ -104,10 +104,10 @@ export default function useSavingsAccount(includeDefaultDai) {
       if (error) return;
 
       if (data) {
-        const markets = keyBy(data?.markets || [], property('id'));
-        const resultTokens = data?.account?.tokens || [];
+        const markets = keyBy(data?.markets, 'id');
+        const resultTokens = data?.account?.tokens;
 
-        const parsedAccountTokens = resultTokens.map(token => {
+        const parsedAccountTokens = map(resultTokens, token => {
           const [cTokenAddress] = token.id.split('-');
           const marketData = markets[cTokenAddress] || {};
 


### PR DESCRIPTION
For a wallet that has no savings, showing the DAI savings deposit row would wait until fresh DAI market data arrived. Now, after the waiting for the DAI market data on the very first time of opening a wallet, any subsequent opening of the wallet will load from localstorage first.