### PR TITLE
Fix default value from lp tokens localstorage

### DIFF
--- a/src/handlers/localstorage/uniswap.js
+++ b/src/handlers/localstorage/uniswap.js
@@ -41,7 +41,13 @@ export const saveLiquidityInfo = (liquidityInfo, accountAddress, network) =>
   );
 
 export const getLiquidity = (accountAddress, network) =>
-  getAccountLocal(LIQUIDITY, accountAddress, network, uniswapLiquidityVersion);
+  getAccountLocal(
+    LIQUIDITY,
+    accountAddress,
+    network,
+    [],
+    uniswapLiquidityVersion
+  );
 
 export const saveLiquidity = (liquidity, accountAddress, network) =>
   saveAccountLocal(


### PR DESCRIPTION
Due to this localstorage argument error, we were not able to successfully subscribe to charts initially (we would only be able to subscribe once the user opened the chart) which causes a delay in fetching the chart data.