### PR TITLE
 🤖 ui fixes shadowStack & ExchangeModal

### DIFF
--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -5,7 +5,7 @@ import ExchangeField from './ExchangeField';
 import ExchangeMaxButton from './ExchangeMaxButton';
 import ExchangeNativeField from './ExchangeNativeField';
 
-const NativeInputHeight = android ? 64 : 32;
+const BottomRowHeight = android ? 16 : 32;
 
 const Container = styled(ColumnWithMargins).attrs({ margin: 5 })`
   padding-top: 6;
@@ -17,7 +17,7 @@ const NativeFieldRow = styled(Row).attrs({
   align: 'center',
   justify: 'space-between',
 })`
-  height: 32;
+  height: ${BottomRowHeight};
   padding-left: 19;
 `;
 
@@ -56,7 +56,7 @@ export default function ExchangeInputField({
         <ExchangeNativeField
           address={inputCurrencyAddress}
           editable
-          height={NativeInputHeight}
+          height={64}
           nativeAmount={nativeAmount}
           nativeCurrency={nativeCurrency}
           onFocus={onFocus}

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -5,8 +5,6 @@ import ExchangeField from './ExchangeField';
 import ExchangeMaxButton from './ExchangeMaxButton';
 import ExchangeNativeField from './ExchangeNativeField';
 
-const BottomRowHeight = android ? 16 : 32;
-
 const Container = styled(ColumnWithMargins).attrs({ margin: 5 })`
   padding-top: 6;
   width: 100%;
@@ -17,7 +15,7 @@ const NativeFieldRow = styled(Row).attrs({
   align: 'center',
   justify: 'space-between',
 })`
-  height: ${BottomRowHeight};
+  height: ${android ? 16 : 32};
   padding-left: 19;
 `;
 

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -5,7 +5,7 @@ import ExchangeField from './ExchangeField';
 import ExchangeMaxButton from './ExchangeMaxButton';
 import ExchangeNativeField from './ExchangeNativeField';
 
-const BottomRowHeight = android ? 52 : 32;
+const NativeInputHeight = android ? 64 : 32;
 
 const Container = styled(ColumnWithMargins).attrs({ margin: 5 })`
   padding-top: 6;
@@ -17,7 +17,7 @@ const NativeFieldRow = styled(Row).attrs({
   align: 'center',
   justify: 'space-between',
 })`
-  height: ${BottomRowHeight};
+  height: 32;
   padding-left: 19;
 `;
 
@@ -56,7 +56,7 @@ export default function ExchangeInputField({
         <ExchangeNativeField
           address={inputCurrencyAddress}
           editable
-          height={BottomRowHeight}
+          height={NativeInputHeight}
           nativeAmount={nativeAmount}
           nativeCurrency={nativeCurrency}
           onFocus={onFocus}

--- a/src/components/exchange/ExchangeNativeField.js
+++ b/src/components/exchange/ExchangeNativeField.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { PixelRatio, TouchableWithoutFeedback } from 'react-native';
+import { TouchableWithoutFeedback } from 'react-native';
 import styled from 'styled-components/primitives';
 import { Row } from '../layout';
 import { Text } from '../text';
@@ -14,7 +14,7 @@ const CurrencySymbol = styled(Text).attrs(({ height }) => ({
   size: 'larger',
   weight: 'regular',
 }))`
-  ${android ? `margin-bottom: ${PixelRatio.get() < 2.625 ? 7 : 6};` : ''};
+  ${android ? 'margin-bottom: 1.5' : ''};
 `;
 
 const NativeInput = styled(ExchangeInput).attrs({

--- a/src/components/exchange/ExchangeNativeField.js
+++ b/src/components/exchange/ExchangeNativeField.js
@@ -14,7 +14,7 @@ const CurrencySymbol = styled(Text).attrs(({ height }) => ({
   size: 'larger',
   weight: 'regular',
 }))`
-  ${android ? 'margin-bottom: 1.5' : ''};
+  ${android ? 'margin-bottom: 1.5;' : ''};
 `;
 
 const NativeInput = styled(ExchangeInput).attrs({

--- a/src/components/exchange/ExchangeNativeField.js
+++ b/src/components/exchange/ExchangeNativeField.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { TouchableWithoutFeedback } from 'react-native';
+import { PixelRatio, TouchableWithoutFeedback } from 'react-native';
 import styled from 'styled-components/primitives';
 import { Row } from '../layout';
 import { Text } from '../text';
@@ -14,7 +14,7 @@ const CurrencySymbol = styled(Text).attrs(({ height }) => ({
   size: 'larger',
   weight: 'regular',
 }))`
-  ${android ? 'margin-bottom: 8};' : ''};
+  ${android ? `margin-bottom: ${PixelRatio.get() < 2.625 ? 7 : 6};` : ''};
 `;
 
 const NativeInput = styled(ExchangeInput).attrs({

--- a/src/components/exchange/ExchangeNativeField.js
+++ b/src/components/exchange/ExchangeNativeField.js
@@ -14,7 +14,7 @@ const CurrencySymbol = styled(Text).attrs(({ height }) => ({
   size: 'larger',
   weight: 'regular',
 }))`
-  ${android ? 'margin-bottom: 1.5;' : ''};
+  ${android ? 'margin-bottom: 8};' : ''};
 `;
 
 const NativeInput = styled(ExchangeInput).attrs({

--- a/src/components/fields/PasswordField.js
+++ b/src/components/fields/PasswordField.js
@@ -44,6 +44,7 @@ const PasswordInput = styled(Input).attrs({
 `;
 
 const ShadowContainer = styled(ShadowStack).attrs(({ deviceWidth }) => ({
+  backgroundColor: colors.white,
   borderRadius: 23,
   height: 46,
   shadows: [


### PR DESCRIPTION
Fixes 2 issues:

Back up Inputs, shadowStack issue: 

Before: http://cloud.skylarbarrera.com/Screenshot_20201218-055618_Rainbow.jpg
     
After: http://cloud.skylarbarrera.com/Screenshot_20201218-074117_Rainbow.jpg

Native Currency Symbol alignment:

Before: http://cloud.skylarbarrera.com/Screenshot_20201218-073705_Rainbow-1-.jpg

After: http://cloud.skylarbarrera.com/Screenshot_20201218-072053_Rainbow-1-.jpg

Exchange Modal Reduce Height for 🤖 :

Before: http://cloud.skylarbarrera.com/Screenshot_20201218-105902.png

After: http://cloud.skylarbarrera.com/Screenshot_20201218-105243.png