### PR TITLE
Swap and approval gas estimation improvements

### DIFF
--- a/src/raps/actions/swap.js
+++ b/src/raps/actions/swap.js
@@ -75,7 +75,8 @@ const swap = async (wallet, currentRap, index, parameters) => {
   }
   let gasLimit, methodName;
   try {
-    logger.sentry('estimateSwapGasLimit', { accountAddress, tradeDetails });
+    const routeDetails = tradeDetails?.route?.path;
+    logger.sentry('estimateSwapGasLimit', { accountAddress, routeDetails });
     const {
       gasLimit: newGasLimit,
       methodName: newMethodName,
@@ -94,7 +95,11 @@ const swap = async (wallet, currentRap, index, parameters) => {
 
   let swap;
   try {
-    logger.sentry('executing swap', { gasLimit, gasPrice, tradeDetails });
+    logger.sentry('executing swap', {
+      gasLimit,
+      gasPrice,
+      methodName,
+    });
     swap = await executeSwap({
       accountAddress,
       chainId,

--- a/src/raps/actions/unlock.js
+++ b/src/raps/actions/unlock.js
@@ -20,6 +20,7 @@ const NOOP = () => undefined;
 const unlock = async (wallet, currentRap, index, parameters) => {
   const { dispatch } = store;
   const {
+    accountAddress,
     amount,
     assetToUnlock,
     contractAddress,
@@ -36,6 +37,7 @@ const unlock = async (wallet, currentRap, index, parameters) => {
   logger.log('[unlock]', amount, override, _amount);
 
   const { gasPrices } = store.getState().gas;
+
   const { address: assetAddress } = assetToUnlock;
 
   let gasLimit;
@@ -45,6 +47,7 @@ const unlock = async (wallet, currentRap, index, parameters) => {
       contractAddress,
     });
     gasLimit = await contractUtils.estimateApprove(
+      accountAddress,
       assetAddress,
       contractAddress
     );

--- a/src/raps/swapAndDepositCompound.js
+++ b/src/raps/swapAndDepositCompound.js
@@ -38,6 +38,7 @@ export const estimateSwapAndDepositCompound = async ({
     );
     if (swapAssetNeedsUnlocking) {
       const unlockGasLimit = await contractUtils.estimateApprove(
+        accountAddress,
         inputCurrency.address,
         UNISWAP_V2_ROUTER_ADDRESS
       );
@@ -69,6 +70,7 @@ export const estimateSwapAndDepositCompound = async ({
 
   if (depositAssetNeedsUnlocking) {
     const depositGasLimit = await contractUtils.estimateApprove(
+      accountAddress,
       tokenToDeposit.address,
       cTokenContract
     );

--- a/src/raps/unlockAndSwap.js
+++ b/src/raps/unlockAndSwap.js
@@ -42,15 +42,15 @@ export const estimateUnlockAndSwap = async ({
       inputCurrency.address,
       UNISWAP_V2_ROUTER_ADDRESS
     );
-    gasLimits = concat(gasLimits, unlockGasLimit);
+    gasLimits = concat(gasLimits, unlockGasLimit, ethUnits.basic_swap);
+  } else {
+    const { gasLimit: swapGasLimit } = await estimateSwapGasLimit({
+      accountAddress,
+      chainId,
+      tradeDetails,
+    });
+    gasLimits = concat(gasLimits, swapGasLimit);
   }
-
-  const { gasLimit: swapGasLimit } = await estimateSwapGasLimit({
-    accountAddress,
-    chainId,
-    tradeDetails,
-  });
-  gasLimits = concat(gasLimits, swapGasLimit);
 
   return reduce(gasLimits, (acc, limit) => add(acc, limit), '0');
 };

--- a/src/raps/unlockAndSwap.js
+++ b/src/raps/unlockAndSwap.js
@@ -38,6 +38,7 @@ export const estimateUnlockAndSwap = async ({
   );
   if (swapAssetNeedsUnlocking) {
     const unlockGasLimit = await contractUtils.estimateApprove(
+      accountAddress,
       inputCurrency.address,
       UNISWAP_V2_ROUTER_ADDRESS
     );

--- a/src/utils/contract.js
+++ b/src/utils/contract.js
@@ -7,10 +7,11 @@ import { ethUnits } from '../references';
 import erc20ABI from '../references/erc20-abi.json';
 import logger from 'logger';
 
-const estimateApproveWithExchange = async (spender, exchange) => {
+const estimateApproveWithExchange = async (owner, spender, exchange) => {
   try {
-    logger.sentry('exchange estimate approve', { exchange, spender });
-    const gasLimit = await exchange.estimateGas.approve(spender, MaxUint256);
+    const gasLimit = await exchange.estimateGas.approve(spender, MaxUint256, {
+      from: owner,
+    });
     return gasLimit ? gasLimit.toString() : ethUnits.basic_approval;
   } catch (error) {
     logger.sentry('error estimateApproveWithExchange');
@@ -19,9 +20,10 @@ const estimateApproveWithExchange = async (spender, exchange) => {
   }
 };
 
-const estimateApprove = (tokenAddress, spender) => {
+const estimateApprove = (owner, tokenAddress, spender) => {
+  logger.sentry('exchange estimate approve', { owner, spender, tokenAddress });
   const exchange = new Contract(tokenAddress, erc20ABI, web3Provider);
-  return estimateApproveWithExchange(spender, exchange);
+  return estimateApproveWithExchange(owner, spender, exchange);
 };
 
 const approve = async (


### PR DESCRIPTION
- Some approvals were failing due to the lack of the account address (owner) being specified
- We were getting a lot of noise in the Sentry logs (and doing many unnecessary gas estimation calls) for swap gas estimations that would fail due to the approval not being available
- Generally improve Sentry logging (the extra data payload was often too large and hitting the size limit, preventing us from getting all the useful information for swap trade routes info)