### PR TITLE
Handle ETH prices when no ETH in wallet

### DIFF
--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -165,8 +165,8 @@ const withUniswapSection = (
 };
 
 const withBalanceSavingsSection = savings => {
-  const assets = store.getState().data.genericAssets;
-  const priceOfEther = assets?.eth?.price?.value;
+  const { genericAssets } = store.getState().data;
+  const priceOfEther = genericAssets?.eth?.price?.value;
 
   let savingsAssets = savings;
   let totalUnderlyingNativeValue = '0';

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -26,10 +26,10 @@ import {
 import networkTypes from './networkTypes';
 import { add, convertAmountToNativeDisplay, multiply } from './utilities';
 import Routes from '@rainbow-me/routes';
-import { ETH_ICON_URL, ethereumUtils } from '@rainbow-me/utils';
+import { ETH_ICON_URL } from '@rainbow-me/utils';
 
-const allAssetsCountSelector = state => state.allAssetsCount;
 const allAssetsSelector = state => state.allAssets;
+const allAssetsCountSelector = state => state.allAssetsCount;
 const assetsTotalSelector = state => state.assetsTotal;
 const currentActionSelector = state => state.currentAction;
 const hiddenCoinsSelector = state => state.hiddenCoins;
@@ -164,12 +164,10 @@ const withUniswapSection = (
   };
 };
 
-const withEthPrice = allAssets => {
-  const ethAsset = ethereumUtils.getAsset(allAssets);
-  return get(ethAsset, 'native.price.amount', null);
-};
+const withBalanceSavingsSection = savings => {
+  const assets = store.getState().data.genericAssets;
+  const priceOfEther = assets?.eth?.price?.value;
 
-const withBalanceSavingsSection = (savings, priceOfEther) => {
   let savingsAssets = savings;
   let totalUnderlyingNativeValue = '0';
   if (priceOfEther) {
@@ -419,10 +417,8 @@ const uniqueTokenDataSelector = createSelector(
   buildUniqueTokenList
 );
 
-const ethPriceSelector = createSelector([allAssetsSelector], withEthPrice);
-
 const balanceSavingsSectionSelector = createSelector(
-  [savingsSelector, ethPriceSelector],
+  [savingsSelector],
   withBalanceSavingsSection
 );
 

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -26,7 +26,7 @@ import {
 import networkTypes from './networkTypes';
 import { add, convertAmountToNativeDisplay, multiply } from './utilities';
 import Routes from '@rainbow-me/routes';
-import { ETH_ICON_URL } from '@rainbow-me/utils';
+import { ETH_ICON_URL, ethereumUtils } from '@rainbow-me/utils';
 
 const allAssetsSelector = state => state.allAssets;
 const allAssetsCountSelector = state => state.allAssetsCount;
@@ -166,7 +166,7 @@ const withUniswapSection = (
 
 const withBalanceSavingsSection = savings => {
   const { genericAssets } = store.getState().data;
-  const priceOfEther = genericAssets?.eth?.price?.value;
+  const priceOfEther = ethereumUtils.getEthPriceUnit(genericAssets);
 
   let savingsAssets = savings;
   let totalUnderlyingNativeValue = '0';

--- a/src/hooks/useSendSavingsAccount.js
+++ b/src/hooks/useSendSavingsAccount.js
@@ -1,16 +1,16 @@
-import { get, map } from 'lodash';
+import { map } from 'lodash';
+import { useSelector } from 'react-redux';
 import { convertAmountToNativeDisplay, multiply } from '../helpers/utilities';
-import { ethereumUtils } from '../utils';
-import useAccountAssets from './useAccountAssets';
 import useAccountSettings from './useAccountSettings';
 import useSavingsAccount from './useSavingsAccount';
 
 export default function useSendSavingsAccount() {
-  const { allAssets } = useAccountAssets();
   const { nativeCurrency } = useAccountSettings();
   let { savings } = useSavingsAccount();
-  const eth = ethereumUtils.getAsset(allAssets);
-  const priceOfEther = get(eth, 'native.price.amount', null);
+  const { genericAssets } = useSelector(({ data: { genericAssets } }) => ({
+    genericAssets,
+  }));
+  const priceOfEther = genericAssets?.eth?.price?.value;
   if (priceOfEther) {
     savings = map(savings, asset => {
       const { cToken, cTokenBalance, exchangeRate, underlyingPrice } = asset;

--- a/src/hooks/useSendSavingsAccount.js
+++ b/src/hooks/useSendSavingsAccount.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { convertAmountToNativeDisplay, multiply } from '../helpers/utilities';
 import useAccountSettings from './useAccountSettings';
 import useSavingsAccount from './useSavingsAccount';
+import { ethereumUtils } from '@rainbow-me/utils';
 
 export default function useSendSavingsAccount() {
   const { nativeCurrency } = useAccountSettings();
@@ -10,7 +11,7 @@ export default function useSendSavingsAccount() {
   const { genericAssets } = useSelector(({ data: { genericAssets } }) => ({
     genericAssets,
   }));
-  const priceOfEther = genericAssets?.eth?.price?.value;
+  const priceOfEther = ethereumUtils.getEthPriceUnit(genericAssets);
   if (priceOfEther) {
     savings = map(savings, asset => {
       const { cToken, cTokenBalance, exchangeRate, underlyingPrice } = asset;

--- a/src/hooks/useUniswapCurrencies.js
+++ b/src/hooks/useUniswapCurrencies.js
@@ -4,7 +4,7 @@ import analytics from '@segment/analytics-react-native';
 import { find, get, isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { InteractionManager } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import CurrencySelectionTypes from '../helpers/currencySelectionTypes';
 import { multiply } from '../helpers/utilities';
 import { useNavigation } from '../navigation/Navigation';
@@ -59,6 +59,9 @@ export default function useUniswapCurrencies({
   const dispatch = useDispatch();
   const { allAssets } = useAccountAssets();
   const { chainId } = useAccountSettings();
+  const { genericAssets } = useSelector(({ data: { genericAssets } }) => ({
+    genericAssets,
+  }));
   const { navigate, setParams, dangerouslyGetParent } = useNavigation();
   const {
     params: { blockInteractions },
@@ -81,8 +84,8 @@ export default function useUniswapCurrencies({
 
     // If default input asset not found in wallet, create the missing asset
     if (!defaultChosenInputItem && defaultInputAsset) {
-      const eth = ethereumUtils.getAsset(allAssets);
-      const priceOfEther = get(eth, 'native.price.amount', null);
+      const priceOfEther = ethereumUtils.getEthPriceUnit(genericAssets);
+
       defaultChosenInputItem = createMissingAsset(
         defaultInputAsset,
         underlyingPrice,
@@ -118,6 +121,7 @@ export default function useUniswapCurrencies({
     allAssets,
     defaultInputAddress,
     defaultInputAsset,
+    genericAssets,
     isDeposit,
     isWithdrawal,
     underlyingPrice,

--- a/src/hooks/useUniswapCurrencies.js
+++ b/src/hooks/useUniswapCurrencies.js
@@ -5,19 +5,19 @@ import { find, get, isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { InteractionManager } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
-import CurrencySelectionTypes from '../helpers/currencySelectionTypes';
-import { multiply } from '../helpers/utilities';
 import { useNavigation } from '../navigation/Navigation';
-import {
-  multicallAddListeners,
-  multicallUpdateOutdatedListeners,
-} from '../redux/multicall';
 import useAccountAssets from './useAccountAssets';
 import useAccountSettings from './useAccountSettings';
 import { delayNext } from './useMagicAutofocus';
 import usePrevious from './usePrevious';
 import useUniswapAssetsInWallet from './useUniswapAssetsInWallet';
 import useUniswapCalls from './useUniswapCalls';
+import CurrencySelectionTypes from '@rainbow-me/helpers/currencySelectionTypes';
+import { multiply } from '@rainbow-me/helpers/utilities';
+import {
+  multicallAddListeners,
+  multicallUpdateOutdatedListeners,
+} from '@rainbow-me/redux/multicall';
 import Routes from '@rainbow-me/routes';
 import { ethereumUtils, isNewValueForPath } from '@rainbow-me/utils';
 import logger from 'logger';

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -326,7 +326,7 @@ export const addressAssetsReceived = (
 
 const subscribeToMissingPrices = addresses => (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
-  const { assets, uniswapPricesQuery } = getState().data;
+  const { genericAssets, uniswapPricesQuery } = getState().data;
   if (uniswapPricesQuery) {
     uniswapPricesQuery.refetch({ addresses });
   } else {
@@ -342,7 +342,7 @@ const subscribeToMissingPrices = addresses => (dispatch, getState) => {
     const newSubscription = newQuery.subscribe({
       next: async ({ data }) => {
         if (data && data.tokens) {
-          const nativePriceOfEth = ethereumUtils.getEthPriceUnit(assets);
+          const nativePriceOfEth = ethereumUtils.getEthPriceUnit(genericAssets);
           const tokenAddresses = map(data.tokens, property('id'));
 
           const yesterday = getUnixTime(subDays(new Date(), 1));

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -420,7 +420,7 @@ export const assetPricesReceived = message => dispatch => {
 };
 
 export const assetPricesChanged = message => (dispatch, getState) => {
-  const price = get(message, 'payload.prices[0]');
+  const price = get(message, 'payload.prices[0].price');
   const assetAddress = get(message, 'meta.asset_code');
   if (isNil(price) || isNil(assetAddress)) return;
   const { genericAssets } = getState().data;

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -77,16 +77,19 @@ const addressSubscription = (address, currency, action = 'subscribe') => [
   },
 ];
 
-const assetsSubscription = (assetCodes, currency, action = 'subscribe') => [
-  action,
-  {
-    payload: {
-      asset_codes: assetCodes,
-      currency: toLower(currency),
+const assetsSubscription = (pairs, currency, action = 'subscribe') => {
+  const assetCodes = concat(keys(pairs), 'eth');
+  return [
+    action,
+    {
+      payload: {
+        asset_codes: assetCodes,
+        currency: toLower(currency),
+      },
+      scope: ['prices'],
     },
-    scope: ['prices'],
-  },
-];
+  ];
+};
 
 const chartsRetrieval = (assetCodes, currency, chartType, action = 'get') => [
   action,
@@ -116,7 +119,7 @@ const explorerUnsubscribe = () => (dispatch, getState) => {
   }
   if (!isNil(assetsSocket)) {
     assetsSocket.emit(
-      ...assetsSubscription(keys(pairs), nativeCurrency, 'unsubscribe')
+      ...assetsSubscription(pairs, nativeCurrency, 'unsubscribe')
     );
     assetsSocket.close();
   }
@@ -196,7 +199,7 @@ export const explorerInit = () => async (dispatch, getState) => {
   dispatch(listenOnAssetMessages(newAssetsSocket));
 
   newAssetsSocket.on(messages.CONNECT, () => {
-    newAssetsSocket.emit(...assetsSubscription(keys(pairs), nativeCurrency));
+    newAssetsSocket.emit(...assetsSubscription(pairs, nativeCurrency));
   });
 
   if (network === NetworkTypes.mainnet) {

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -34,11 +34,11 @@ const GAS_UPDATE_GAS_PRICE_OPTION = 'gas/GAS_UPDATE_GAS_PRICE_OPTION';
 let gasPricesHandle = null;
 
 const getDefaultTxFees = () => (dispatch, getState) => {
-  const { assets } = getState().data;
+  const { genericAssets } = getState().data;
   const { defaultGasLimit } = getState().gas;
   const { nativeCurrency } = getState().settings;
   const fallbackGasPrices = getFallbackGasPrices();
-  const ethPriceUnit = ethereumUtils.getEthPriceUnit(assets);
+  const ethPriceUnit = ethereumUtils.getEthPriceUnit(genericAssets);
   const txFees = parseTxFees(
     fallbackGasPrices,
     ethPriceUnit,
@@ -208,9 +208,9 @@ export const gasUpdateTxFee = (gasLimit, overrideGasOption) => (
   const _gasLimit = gasLimit || defaultGasLimit;
   const _selectedGasPriceOption = overrideGasOption || selectedGasPriceOption;
   if (isEmpty(gasPrices)) return;
-  const { assets } = getState().data;
+  const { assets, genericAssets } = getState().data;
   const { nativeCurrency } = getState().settings;
-  const ethPriceUnit = ethereumUtils.getEthPriceUnit(assets);
+  const ethPriceUnit = ethereumUtils.getEthPriceUnit(genericAssets);
   const txFees = parseTxFees(
     gasPrices,
     ethPriceUnit,

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -31,9 +31,9 @@ import { chains } from '../references';
 import logger from 'logger';
 
 const { RNBip39 } = NativeModules;
-const getEthPriceUnit = assets => {
-  const ethAsset = getAsset(assets);
-  return get(ethAsset, 'price.value', 0);
+
+const getEthPriceUnit = genericAssets => {
+  return genericAssets?.eth?.price?.value || 0;
 };
 
 const getBalanceAmount = async (selectedGasPrice, selected) => {

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -12,15 +12,20 @@ import { find, get, isEmpty, matchesProperty, replace, toLower } from 'lodash';
 import { NativeModules } from 'react-native';
 import { ETHERSCAN_API_KEY } from 'react-native-dotenv';
 import URL from 'url-parse';
-import networkTypes from '../helpers/networkTypes';
-import { fromWei, greaterThan, isZero, subtract } from '../helpers/utilities';
-import WalletTypes from '../helpers/walletTypes';
 import {
   DEFAULT_HD_PATH,
   identifyWalletType,
   WalletLibraryType,
 } from '../model/wallet';
-import { chains } from '../references';
+import networkTypes from '@rainbow-me/helpers/networkTypes';
+import {
+  fromWei,
+  greaterThan,
+  isZero,
+  subtract,
+} from '@rainbow-me/helpers/utilities';
+import WalletTypes from '@rainbow-me/helpers/walletTypes';
+import { chains } from '@rainbow-me/references';
 import logger from 'logger';
 
 const { RNBip39 } = NativeModules;

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -13,14 +13,7 @@ import { NativeModules } from 'react-native';
 import { ETHERSCAN_API_KEY } from 'react-native-dotenv';
 import URL from 'url-parse';
 import networkTypes from '../helpers/networkTypes';
-import {
-  add,
-  convertNumberToString,
-  fromWei,
-  greaterThan,
-  isZero,
-  subtract,
-} from '../helpers/utilities';
+import { fromWei, greaterThan, isZero, subtract } from '../helpers/utilities';
 import WalletTypes from '../helpers/walletTypes';
 import {
   DEFAULT_HD_PATH,
@@ -122,29 +115,6 @@ const getEtherscanHostFromNetwork = network => {
   } else {
     return `${network}.${base_host}`;
   }
-};
-
-/**
- * @desc returns an object
- * @param  {Array} assets
- * @param  {String} assetAmount
- * @param  {String} gasPrice
- * @return {Object} ethereum, balanceAmount, balance, requestedAmount, txFeeAmount, txFee, amountWithFees
- */
-const transactionData = (assets, assetAmount, gasPrice) => {
-  const ethereum = getAsset(assets);
-  const balance = get(ethereum, 'balance.amount', 0);
-  const requestedAmount = convertNumberToString(assetAmount);
-  const txFee = fromWei(get(gasPrice, 'txFee.value.amount'));
-  const amountWithFees = add(requestedAmount, txFee);
-
-  return {
-    amountWithFees,
-    balance,
-    ethereum,
-    requestedAmount,
-    txFee,
-  };
 };
 
 /**
@@ -294,5 +264,4 @@ export default {
   isEthAddress,
   padLeft,
   removeHexPrefix,
-  transactionData,
 };


### PR DESCRIPTION
In some places, we were relying on the ETH price from the wallet account instead of subscribing to the ETH price separately and explicitly.

Some scenarios that were breaking (can test on 4th wallet of Poopcoin which has other assets but not ETH):
- Savings expanded state broken
- ETH expanded state prices broken
- Gas calculations broken for send/swap

<img width="465" alt="Screen Shot 2021-01-04 at 5 40 26 PM" src="https://user-images.githubusercontent.com/1285228/103594008-a12b9580-4eb4-11eb-92eb-3831f977a880.png">

<img width="455" alt="Screen Shot 2021-01-04 at 5 44 37 PM" src="https://user-images.githubusercontent.com/1285228/103594015-a7ba0d00-4eb4-11eb-83be-037f66855121.png">

<img width="451" alt="Screen Shot 2021-01-04 at 5 44 49 PM" src="https://user-images.githubusercontent.com/1285228/103594024-ac7ec100-4eb4-11eb-9b9c-279179db597e.png">
