### PR TITLE
add fullWidth prop to Deposit - Android

### DIFF
--- a/src/components/savings/SavingsSheetEmptyState.js
+++ b/src/components/savings/SavingsSheetEmptyState.js
@@ -79,6 +79,7 @@ const SavingsSheetEmptyState = ({
       <ColumnWithMargins css={padding(19, 15)} margin={19} width="100%">
         <SheetActionButton
           color={colors.swapPurple}
+          fullWidth
           label="􀁍 Deposit from Wallet"
           onPress={onDeposit}
           size="big"


### PR DESCRIPTION
SheetActionButton was missing this prop and was affecting Android 

before: http://cloud.skylarbarrera.com/Screen-Shot-2021-01-05-15-18-01.65.png

after: http://cloud.skylarbarrera.com/Screen-Shot-2021-01-05-15-17-45.78.png