### PR TITLE
default fallback to eth logo

### DIFF
--- a/src/components/coin-icon/CoinIcon.js
+++ b/src/components/coin-icon/CoinIcon.js
@@ -14,7 +14,7 @@ const StyledCoinIcon = styled(ReactCoinIcon)`
 `;
 
 const CoinIcon = ({
-  address,
+  address = 'eth',
   isHidden,
   isPinned,
   size = CoinIconSize,


### PR DESCRIPTION
Made the address for coin Icon to default fallback to ETH, this solves the issues and is more robust as a fallback, imo.