### PR TITLE
Fix incorrect max int format saved after confirmed approval

### DIFF
--- a/src/raps/actions/unlock.js
+++ b/src/raps/actions/unlock.js
@@ -91,7 +91,7 @@ const unlock = async (wallet, currentRap, index, parameters) => {
   );
 
   // Cache the approved value
-  AllowancesCache.cache[cacheKey] = MaxUint256;
+  AllowancesCache.cache[cacheKey] = MaxUint256.toString();
 
   // update rap for hash
   currentRap.actions[index].transaction.hash = approval.hash;
@@ -170,8 +170,9 @@ export const assetNeedsUnlocking = async (
       assetToUnlock,
       contractAddress
     );
+
     // Cache that value
-    if (isNull(allowance)) {
+    if (!isNull(allowance)) {
       AllowancesCache.cache[cacheKey] = allowance;
     }
   }


### PR DESCRIPTION
The max uint constant from ethers is now a bignumber and we were storing that object instead of the stringified version in the allowances cache.

During a single session, if an approval and swap was attempted repeatedly, we would fail to recognize the approval value being sufficient. (If a user closes the app and comes back to do a swap, we would refetch the latest approval and then it would proceed to work as expected.)

Also fixed a bug that was not storing the allowances to the cache on the fetch from contract utils.