### PR TITLE
Do not repeat subscription for already listened token

### DIFF
--- a/src/components/inputs/Input.js
+++ b/src/components/inputs/Input.js
@@ -26,22 +26,20 @@ const Input = (
     ...props
   },
   ref
-) => {
-  return (
-    <TextInput
-      {...props}
-      allowFontScaling={allowFontScaling}
-      autoCapitalize={autoCapitalize}
-      autoCorrect={autoCorrect}
-      keyboardType={keyboardType}
-      placeholderTextColor={placeholderTextColor}
-      ref={ref}
-      selectionColor={selectionColor}
-      spellCheck={spellCheck}
-      testID={testID}
-      textContentType={textContentType}
-    />
-  );
-};
+) => (
+  <TextInput
+    {...props}
+    allowFontScaling={allowFontScaling}
+    autoCapitalize={autoCapitalize}
+    autoCorrect={autoCorrect}
+    keyboardType={keyboardType}
+    placeholderTextColor={placeholderTextColor}
+    ref={ref}
+    selectionColor={selectionColor}
+    spellCheck={spellCheck}
+    testID={testID}
+    textContentType={textContentType}
+  />
+);
 
 export default React.forwardRef(Input);

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -227,9 +227,11 @@ export const explorerInit = () => async (dispatch, getState) => {
   }
 };
 
+const tokensListened = {};
+
 export const emitAssetRequest = assetAddress => (dispatch, getState) => {
   const { nativeCurrency } = getState().settings;
-  const { assetsSocket, tokensListened } = getState().explorer;
+  const { assetsSocket } = getState().explorer;
 
   let assetCodes;
   if (assetAddress) {
@@ -348,7 +350,6 @@ const INITIAL_STATE = {
   assetsSocket: null,
   assetsTimeoutHandler: null,
   fallback: false,
-  tokensListened: {},
 };
 
 export default (state = INITIAL_STATE, action) => {

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -229,7 +229,7 @@ export const explorerInit = () => async (dispatch, getState) => {
 
 export const emitAssetRequest = assetAddress => (dispatch, getState) => {
   const { nativeCurrency } = getState().settings;
-  const { assetsSocket } = getState().explorer;
+  const { assetsSocket, tokensListened } = getState().explorer;
 
   let assetCodes;
   if (assetAddress) {
@@ -243,7 +243,14 @@ export const emitAssetRequest = assetAddress => (dispatch, getState) => {
 
     assetCodes = concat(assetAddresses, lpTokenAddresses);
   }
-  assetsSocket.emit(...assetsSubscription(assetCodes, nativeCurrency));
+
+  const newAssetsCodes = assetCodes.filter(code => !tokensListened[code]);
+
+  newAssetsCodes.forEach(code => (tokensListened[code] = true));
+
+  if (newAssetsCodes.length !== 0) {
+    assetsSocket.emit(...assetsSubscription(newAssetsCodes, nativeCurrency));
+  }
 };
 
 export const emitChartsRequest = (
@@ -341,6 +348,7 @@ const INITIAL_STATE = {
   assetsSocket: null,
   assetsTimeoutHandler: null,
   fallback: false,
+  tokensListened: {},
 };
 
 export default (state = INITIAL_STATE, action) => {


### PR DESCRIPTION
It will improve the performance of the discover screen. I'm adding a dictionary of addresses of token that we're already subscribing and therefore there's no need to resubscribe