### PR TITLE
Use the original currencies to determine swap type for WETH and ETH

### DIFF
--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -89,9 +89,9 @@ export const updatePrecisionToDisplay = (
   amount: BigNumberish,
   nativePrice: BigNumberish,
   roundUp: boolean = false
-): BigNumberish => {
-  if (!amount) return 0;
-  if (!nativePrice) return amount;
+): string => {
+  if (!amount) return '0';
+  if (!nativePrice) return new BigNumber(amount).toFixed();
   const roundingMode = roundUp ? BigNumber.ROUND_UP : BigNumber.ROUND_DOWN;
   const bnAmount = new BigNumber(amount);
   const significantDigitsOfNativePriceInteger = new BigNumber(nativePrice)

--- a/src/hooks/useUniswapMarketDetails.ts
+++ b/src/hooks/useUniswapMarketDetails.ts
@@ -2,7 +2,7 @@ import { Trade } from '@uniswap/sdk';
 import { get, isEmpty } from 'lodash';
 import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import { TextInput } from 'react-native';
-import { calculateTradeDetails, SwapCurrency } from '../handlers/uniswap';
+import { calculateTradeDetails } from '../handlers/uniswap';
 import {
   convertAmountFromNativeValue,
   greaterThanOrEqualTo,
@@ -12,6 +12,7 @@ import {
 import { logger } from '../utils';
 import useAccountSettings from './useAccountSettings';
 import useUniswapPairs from './useUniswapPairs';
+import { Asset } from '@rainbow-me/entities';
 
 const DEFAULT_NATIVE_INPUT_AMOUNT = 50;
 
@@ -39,21 +40,21 @@ export default function useUniswapMarketDetails({
   extraTradeDetails: { outputPriceValue: string };
   inputAmount: string;
   inputAsExactAmount: boolean;
-  inputCurrency: SwapCurrency;
+  inputCurrency: Asset;
   inputFieldRef: RefObject<TextInput>;
   isDeposit: boolean;
   isWithdrawal: boolean;
   maxInputBalance: string;
   nativeCurrency: string;
   outputAmount: string;
-  outputCurrency: SwapCurrency;
+  outputCurrency: Asset;
   outputFieldRef: RefObject<TextInput>;
   setIsSufficientBalance: (isSufficientBalance: boolean) => void;
   setSlippage: (slippage: number) => void;
   updateExtraTradeDetails: (extraTradeDetails: {
-    inputCurrency: SwapCurrency;
+    inputCurrency: Asset;
     nativeCurrency: string;
-    outputCurrency: SwapCurrency;
+    outputCurrency: Asset;
     tradeDetails: Trade | null;
   }) => void;
   updateInputAmount: (

--- a/src/hooks/useUniswapMarketDetails.ts
+++ b/src/hooks/useUniswapMarketDetails.ts
@@ -136,7 +136,7 @@ export default function useUniswapMarketDetails({
         setIsSufficientBalance(true);
       } else {
         if (!tradeDetails) return;
-        const rawUpdatedInputAmount = tradeDetails.inputAmount.toExact();
+        const rawUpdatedInputAmount = tradeDetails?.inputAmount?.toExact();
 
         const updatedInputAmountDisplay = updatePrecisionToDisplay(
           rawUpdatedInputAmount,
@@ -177,7 +177,7 @@ export default function useUniswapMarketDetails({
         updateOutputAmount(null, null, true);
       } else {
         if (!tradeDetails) return;
-        const rawUpdatedOutputAmount = tradeDetails.outputAmount.toExact();
+        const rawUpdatedOutputAmount = tradeDetails?.outputAmount?.toExact();
         if (!isZero(rawUpdatedOutputAmount)) {
           const { outputPriceValue } = extraTradeDetails;
           const updatedOutputAmountDisplay = updatePrecisionToDisplay(

--- a/src/raps/actions/swap.js
+++ b/src/raps/actions/swap.js
@@ -83,6 +83,8 @@ const swap = async (wallet, currentRap, index, parameters) => {
     } = await estimateSwapGasLimit({
       accountAddress,
       chainId,
+      inputCurrency,
+      outputCurrency,
       tradeDetails,
     });
     gasLimit = newGasLimit;
@@ -105,7 +107,9 @@ const swap = async (wallet, currentRap, index, parameters) => {
       chainId,
       gasLimit,
       gasPrice,
+      inputCurrency,
       methodName,
+      outputCurrency,
       tradeDetails,
       wallet,
     });

--- a/src/raps/swapAndDepositCompound.js
+++ b/src/raps/swapAndDepositCompound.js
@@ -48,6 +48,8 @@ export const estimateSwapAndDepositCompound = async ({
     const { gasLimit: swapGasLimit } = await estimateSwapGasLimit({
       accountAddress,
       chainId,
+      inputCurrency,
+      outputCurrency,
       tradeDetails,
     });
     gasLimits = concat(gasLimits, swapGasLimit);

--- a/src/raps/unlockAndSwap.js
+++ b/src/raps/unlockAndSwap.js
@@ -47,6 +47,8 @@ export const estimateUnlockAndSwap = async ({
     const { gasLimit: swapGasLimit } = await estimateSwapGasLimit({
       accountAddress,
       chainId,
+      inputCurrency,
+      outputCurrency,
       tradeDetails,
     });
     gasLimits = concat(gasLimits, swapGasLimit);


### PR DESCRIPTION
Previously, we were relying on the input / output currencies from the Uniswap SDK Trade object, but this trade object already has the ETH wrapped into WETH, so we cannot distinguish the original intent of the user to swap with or for ETH vs WETH. Now, we use the original input and output currencies selected by the user to determine the swap type.

I tested only with logs for estimation and execution (without actually executing) to see that the following swap types were chosen for these types of swaps:
ETH->DAI : eth for token (was working before)
ETH->WETH: eth for token (was working before)
DAI->ETH: token for eth (was working before)

DAI->WETH: token for token (was NOT working before)
WETH->ETH: token for eth (was NOT working before)
WETH->DAI: token for token (was NOT working before)

For testing, it would be ideal to execute a WETH->ETH trade once gas simmers down a bit.