### PR TITLE
Allow to resume raps after speed up

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -230,10 +230,11 @@ export const loadWallet = async (): Promise<null | Wallet> => {
 
 export const sendTransaction = async ({
   transaction,
+  existingWallet = null,
 }: TransactionRequestParam): Promise<null | Transaction> => {
   try {
     logger.sentry('about to send transaction', transaction);
-    const wallet = await loadWallet();
+    const wallet = existingWallet || (await loadWallet());
     if (!wallet) return null;
     try {
       const result = await wallet.sendTransaction(transaction);

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -70,6 +70,7 @@ interface WalletInitialized {
 
 interface TransactionRequestParam {
   transaction: TransactionRequest;
+  existingWallet?: Wallet;
 }
 
 interface MessageTypeProperty {
@@ -230,7 +231,7 @@ export const loadWallet = async (): Promise<null | Wallet> => {
 
 export const sendTransaction = async ({
   transaction,
-  existingWallet = null,
+  existingWallet,
 }: TransactionRequestParam): Promise<null | Transaction> => {
   try {
     logger.sentry('about to send transaction', transaction);

--- a/src/raps/common.js
+++ b/src/raps/common.js
@@ -70,6 +70,20 @@ export const executeRap = async (wallet, rap) => {
     if (!previousActionWasSuccess) break;
 
     const action = actions[index];
+    const currentActionHasBeenCompleted = get(
+      action,
+      'transaction.confirmed',
+      false
+    );
+
+    // If the action is complete, skip it (we're resuming a rap!)
+    if (currentActionHasBeenCompleted) {
+      logger.log(
+        '[3.5 INNER] ignoring current action because it was completed!'
+      );
+      continue;
+    }
+
     const { parameters, type } = action;
     const actionPromise = findActionByType(type);
     logger.log('[4 INNER] executing type', type);

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -55,6 +55,7 @@ import { addCashUpdatePurchases } from './addCash';
 /* eslint-disable-next-line import/no-cycle */
 import { uniqueTokensRefreshState } from './uniqueTokens';
 import { uniswapUpdateLiquidityTokens } from './uniswapLiquidity';
+import networkTypes from '@rainbow-me/networkTypes';
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 
@@ -462,7 +463,7 @@ export const dataAddNewTransaction = (
       type: DATA_ADD_NEW_TRANSACTION_SUCCESS,
     });
     saveLocalTransactions(_transactions, accountAddress, network);
-    if (!disableTxnWatcher) {
+    if (!disableTxnWatcher || network !== networkTypes.mainnet) {
       dispatch(watchPendingTransactions(accountAddress));
     }
     return parsedTransaction;

--- a/src/screens/SpeedUpAndCancelSheet.js
+++ b/src/screens/SpeedUpAndCancelSheet.js
@@ -155,11 +155,7 @@ export default function SpeedUpAndCancelSheet() {
 
   const reloadTransactions = useCallback(
     transaction => {
-      if (
-        (transaction.status === TransactionStatusTypes.speeding_up ||
-          transaction.status === TransactionStatusTypes.cancelling) &&
-        transaction.type !== TransactionTypes.send
-      ) {
+      if (transaction.type !== TransactionTypes.send) {
         logger.log('Reloading zerion in 5!');
         setTimeout(() => {
           logger.log('Reloading tx from zerion NOW!');
@@ -288,6 +284,7 @@ export default function SpeedUpAndCancelSheet() {
                 existingWallet = null;
               }
             }
+            logger.log('reloading transactions');
             reloadTransactions(transaction);
           }
         )

--- a/src/screens/SpeedUpAndCancelSheet.js
+++ b/src/screens/SpeedUpAndCancelSheet.js
@@ -1,7 +1,7 @@
 import { useRoute } from '@react-navigation/native';
 import { captureException } from '@sentry/react-native';
 import { BigNumber } from 'bignumber.js';
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, keys } from 'lodash';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, InteractionManager, TurboModuleRegistry } from 'react-native';
 import Animated, {
@@ -25,12 +25,15 @@ import { Emoji, Text } from '../components/text';
 import { getTransaction, toHex } from '../handlers/web3';
 import TransactionStatusTypes from '../helpers/transactionStatusTypes';
 import TransactionTypes from '../helpers/transactionTypes';
-import { sendTransaction } from '../model/wallet';
+import { loadWallet, sendTransaction } from '../model/wallet';
 import { gweiToWei, weiToGwei } from '../parsers/gas';
 import { getTitle } from '../parsers/transactions';
+import { executeRap } from '../raps/common';
 import { dataUpdateTransaction } from '../redux/data';
 import { explorerInit } from '../redux/explorer';
 import { updateGasPriceForSpeed } from '../redux/gas';
+import { rapsAddOrUpdate } from '../redux/raps';
+import store from '../redux/store';
 import { safeAreaInsetValues } from '../utils';
 import deviceUtils from '../utils/deviceUtils';
 import {
@@ -99,6 +102,8 @@ const text = {
   [SPEED_UP]: `This will speed up your pending transaction by replacing it. There’s still a chance your original transaction will confirm first!`,
 };
 
+let existingWallet;
+
 const calcMinGasPriceAllowed = prevGasPrice => {
   const prevGasPriceBN = new BigNumber(prevGasPrice);
 
@@ -166,6 +171,33 @@ export default function SpeedUpAndCancelSheet() {
     [dispatch]
   );
 
+  const replaceRapActionTx = useCallback(
+    (originalHash, newTxData) => {
+      // 1 - Find the rap based on the orignal tx hash
+      let currentRap;
+      const { raps } = store.getState().raps;
+      keys(raps).forEach(rapId => {
+        const rap = raps[rapId];
+        rap.actions.forEach((action, index) => {
+          if (action.transaction?.hash === originalHash) {
+            // 2 - Set the new tx hash on the rap
+            if (!action.transaction?.confirmed) {
+              rap.actions[index].transaction = {
+                ...rap.actions[index].transaction,
+                ...newTxData,
+              };
+              // 3 - Update the rap on redux with the new tx hash
+              dispatch(rapsAddOrUpdate(rap.id, rap));
+              currentRap = rap;
+            }
+          }
+        });
+      });
+      return currentRap;
+    },
+    [dispatch]
+  );
+
   const handleCancellation = useCallback(async () => {
     try {
       const gasPrice = getNewGasPrice();
@@ -216,8 +248,10 @@ export default function SpeedUpAndCancelSheet() {
         to: tx.to,
         value,
       };
+      existingWallet = await loadWallet();
       const originalHash = tx.hash;
       const { hash } = await sendTransaction({
+        existingWallet,
         transaction: fasterTxPayload,
       });
       const updatedTx = { ...tx };
@@ -228,8 +262,35 @@ export default function SpeedUpAndCancelSheet() {
       }
       updatedTx.status = TransactionStatusTypes.speeding_up;
       updatedTx.title = getTitle(updatedTx);
+      const originalHashNormalized = originalHash.split('-')[0];
+      replaceRapActionTx(originalHashNormalized, { hash });
+
       dispatch(
-        dataUpdateTransaction(originalHash, updatedTx, true, reloadTransactions)
+        dataUpdateTransaction(
+          originalHash,
+          updatedTx,
+          true,
+          async transaction => {
+            const hashNormalized = transaction.hash.split('-')[0];
+            // The tx was confirmed
+            const currentRap = replaceRapActionTx(hashNormalized, {
+              confirmed: true,
+            });
+
+            // If there's a rap, we need to resume the execution
+            if (currentRap && existingWallet) {
+              logger.log('Resuming rap', currentRap);
+              try {
+                await executeRap(existingWallet, currentRap);
+              } catch (e) {
+                logger.log('Error resuming rap', e);
+              } finally {
+                existingWallet = null;
+              }
+            }
+            reloadTransactions(transaction);
+          }
+        )
       );
     } catch (e) {
       logger.log('Error submitting speed up tx', e);
@@ -244,6 +305,7 @@ export default function SpeedUpAndCancelSheet() {
     goBack,
     nonce,
     reloadTransactions,
+    replaceRapActionTx,
     tx,
     value,
   ]);


### PR DESCRIPTION
This PR adds the ability to call `executeRap` again  to resume the remaining tasks, which fixes the scenario of speeding up one of the transactions of a rap like : 
- unlock + swap
- unlock + swap + deposit

PoW: http://recordit.co/Vz3xQcrD5u

Fixes RNBW-1009
