### PR TITLE
Fix WC transaction

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -473,7 +473,7 @@ const TransactionConfirmationScreen = () => {
       analytics.track('Approved WalletConnect transaction request');
       if (requestId) {
         dispatch(removeRequest(requestId));
-        await dispatch(walletConnectSendStatus(peerId, requestId, result));
+        await dispatch(walletConnectSendStatus(peerId, requestId, result.hash));
       }
       closeScreen(false);
     } else {


### PR DESCRIPTION
Fix the response for wc tx.  This was working before until I pushed #1546  and I forgot to pass the hash instead of the object

Before:  
![IMG_1777](https://user-images.githubusercontent.com/1247834/104659115-160b8600-5692-11eb-9ef9-722c55913826.PNG)


After:
<img width="471" alt="Screen Shot 2021-01-14 at 5 46 39 PM" src="https://user-images.githubusercontent.com/1247834/104658846-9e3d5b80-5691-11eb-9915-d034b3062d82.png">

