### PR TITLE
Add additionally insets for indicators in DiscoverSheet's ScrollView after mounting

### DIFF
--- a/src/components/discover-sheet/DiscoverSheetContent.js
+++ b/src/components/discover-sheet/DiscoverSheetContent.js
@@ -25,7 +25,11 @@ const HeaderTitle = styled(Text).attrs({
 
 export default function DiscoverSheetContent() {
   return (
-    <SlackSheet contentOffset={position.current} renderHeader={renderHeader}>
+    <SlackSheet
+      contentOffset={position.current}
+      discoverSheet
+      renderHeader={renderHeader}
+    >
       <HeaderTitle>Discover</HeaderTitle>
       <ColumnWithMargins flex={1} margin={42}>
         <SearchHeader />

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -1,5 +1,5 @@
 // FIXME unify with iOS
-import React, { Fragment, useMemo } from 'react';
+import React, { Fragment, useEffect, useMemo, useRef } from 'react';
 import { Pressable, StyleSheet, TouchableWithoutFeedback } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useSafeArea } from 'react-native-safe-area-context';
@@ -81,6 +81,7 @@ export default function SlackSheet({
   hideHandle = false,
   renderHeader,
   scrollEnabled = true,
+  discoverSheet,
   ...props
 }) {
   const yPosition = useReanimatedValue(0);
@@ -99,12 +100,25 @@ export default function SlackSheet({
     [bottomInset]
   );
 
+  const sheet = useRef();
+
   const scrollIndicatorInsets = useMemo(
     () => ({
       bottom: bottomInset,
       top: borderRadius + SheetHandleFixedToTopHeight,
     }),
     [borderRadius, bottomInset]
+  );
+
+  // In discover sheet we need ot set it additionally
+  useEffect(
+    () => {
+      discoverSheet &&
+        ios &&
+        sheet.current.setNativeProps({ scrollIndicatorInsets });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   return (
@@ -137,6 +151,7 @@ export default function SlackSheet({
             contentHeight={contentHeight}
             deviceHeight={deviceHeight}
             directionalLockEnabled
+            ref={sheet}
             scrollEnabled={scrollEnabled}
             scrollIndicatorInsets={scrollIndicatorInsets}
             y={yPosition}

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -110,7 +110,7 @@ export default function SlackSheet({
     [borderRadius, bottomInset]
   );
 
-  // In discover sheet we need ot set it additionally
+  // In discover sheet we need to set it additionally
   useEffect(
     () => {
       discoverSheet &&


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/25709300/104747594-639ef600-5759-11eb-90bf-1d9c3c672423.png)


Closing https://linear.app/rainbow/issue/RNBW-1005/add-top-padding-to-scroll-bar