### PR TITLE
fix: prevent launch crash associated with overriding ImgixImage render prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ios": "react-native run-ios --simulator='iPhone 11'",
     "lint": "yarn lint:ts && yarn lint:js && yarn lint:css",
     "lint:css": "stylelint './src/**/*.js'",
-    "lint:js": "eslint --ext '.ts,.js,.jsx' .",
+    "lint:js": "eslint --ext '.ts,.tsx,.js,.jsx' .",
     "lint:ts": "yarn tsc --skipLibCheck --noEmit",
     "postinstall": "./scripts/postinstall.sh",
     "start": "react-native start",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts}": [
-      "eslint --ext '.js,.jsx,.ts' -c .eslintrc.json",
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --ext '.js,.jsx,.ts,.tsx' -c .eslintrc.json",
       "stylelint"
     ]
   },

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -13,7 +13,10 @@ type HiddenImgixImageProps = { forwardedRef: React.Ref<any> };
 type MergedImgixImageProps = ImgixImageProps & HiddenImgixImageProps;
 
 // ImgixImage must be a class Component to support Animated.createAnimatedComponent.
-class ImgixImage extends React.PureComponent<MergedImgixImageProps, ImgixImageProps> {
+class ImgixImage extends React.PureComponent<
+  MergedImgixImageProps,
+  ImgixImageProps
+> {
   constructor(props: MergedImgixImageProps) {
     super(props);
     const { source } = props;
@@ -57,16 +60,15 @@ const preload = (sources: Source[]): void => {
 const ImgixImageWithForwardRef = React.forwardRef(
   (props: ImgixImageProps, ref: React.Ref<any>) => (
     <ImgixImage forwardedRef={ref} {...props} />
-  ),
+  )
 );
 
 const { cacheControl, contextTypes, priority, resizeMode } = FastImage;
 
-// We want to render using ImgixImage, assign all properties of
-// FastImage to ImgixImage, override all properties of FastImage which
-// we do not wish to override by FastImage, and finally override the
-// preload mechanic.
-export default Object.assign(
-  ImgixImageWithForwardRef,
-  { cacheControl, contextTypes, priority, resizeMode, preload },
-);
+export default Object.assign(ImgixImageWithForwardRef, {
+  cacheControl,
+  contextTypes,
+  preload,
+  priority,
+  resizeMode,
+});

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -60,13 +60,13 @@ const ImgixImageWithForwardRef = React.forwardRef(
   ),
 );
 
+const { cacheControl, contextTypes, priority, resizeMode } = FastImage;
+
 // We want to render using ImgixImage, assign all properties of
 // FastImage to ImgixImage, override all properties of FastImage which
 // we do not wish to override by FastImage, and finally override the
 // preload mechanic.
 export default Object.assign(
   ImgixImageWithForwardRef,
-  FastImage,
-  ImgixImageWithForwardRef,
-  { preload },
+  { cacheControl, contextTypes, priority, resizeMode, preload },
 );


### PR DESCRIPTION
- Automating the export of `FastImage`'s properties would cause render issues when an alternate render component i.e. `Animated.Image` was used as the render target. 
  - This would throw an `unrecognized selector sent to instance...` error on launch of the application when there was not a serialized wallet to navigate to.

This fix manually destructures the required `static` attributes from `FastImage` and assigns these to the `ImgixImage`.

I've also spotted that `lint-staged` was not sensitive to the `.tsx` format, which ensures that `pre-commit` successfully terminates on badly formatted code.