### PR TITLE
small 🤖  WC tweaks

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -734,7 +734,7 @@ const TransactionConfirmationScreen = () => {
   }
 
   if (isAndroidApprovalRequest) {
-    sheetHeight += 120;
+    sheetHeight += 140;
   }
 
   return (
@@ -805,7 +805,9 @@ const TransactionConfirmationScreen = () => {
                 {methodName || 'Placeholder'}
               </Text>
             </Centered>
-            <Divider color={colors.rowDividerLight} inset={[0, 143.5]} />
+            {(!keyboardVisible || ios) && (
+              <Divider color={colors.rowDividerLight} inset={[0, 143.5]} />
+            )}
             {renderTransactionSection()}
             {renderTransactionButtons()}
             <RowWithMargins css={padding(0, 24, 30)} margin={15}>


### PR DESCRIPTION
- Increased sheet height for android approvals
- hides divider on android when keyboard is open

Sheet Height
before: http://cloud.skylarbarrera.com/Screen-Shot-2021-01-22-14-18-23.62.png
bumping approval from 120 -> 140: http://cloud.skylarbarrera.com/Screen-Shot-2021-01-22-14-18-38.45.png

Divider Issue
before: http://cloud.skylarbarrera.com/Screen-Shot-2021-01-22-14-24-27.21.png

after both fixes: http://cloud.skylarbarrera.com/Screen-Recording-2021-01-22-14-33-33.mp4