### PR TITLE
Create initial swap redux with just input and output currencies

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -63,6 +63,7 @@ export { default as useShowcaseTokens } from './useShowcaseTokens';
 export { default as useSwapDetails } from './useSwapDetails';
 export { default as useSwapInputRefs } from './useSwapInputRefs';
 export { default as useSwapInputs } from './useSwapInputs';
+export { default as useSwapInputOutputTokens } from './useSwapInputOutputTokens';
 export { default as useTimeout } from './useTimeout';
 export { default as useTopMovers } from './useTopMovers';
 export { default as useTransactionConfirmation } from './useTransactionConfirmation';

--- a/src/hooks/useSwapInputOutputTokens.ts
+++ b/src/hooks/useSwapInputOutputTokens.ts
@@ -1,0 +1,17 @@
+import { useSelector } from 'react-redux';
+import { Asset } from '@rainbow-me/entities';
+import { AppState } from '@rainbow-me/redux/store';
+
+export default function useSwapInputOutputTokens() {
+  const inputCurrency: Asset = useSelector(
+    (state: AppState) => state.swap.inputCurrency
+  );
+  const outputCurrency: Asset = useSelector(
+    (state: AppState) => state.swap.outputCurrency
+  );
+
+  return {
+    inputCurrency,
+    outputCurrency,
+  };
+}

--- a/src/hooks/useSwapInputRefs.ts
+++ b/src/hooks/useSwapInputRefs.ts
@@ -1,10 +1,13 @@
 import { useCallback, useRef } from 'react';
+import { TextInput } from 'react-native';
 import useMagicAutofocus from './useMagicAutofocus';
+import useSwapInputOutputTokens from './useSwapInputOutputTokens';
 
-export default function useSwapInputRefs({ inputCurrency, outputCurrency }) {
-  const inputFieldRef = useRef();
-  const nativeFieldRef = useRef();
-  const outputFieldRef = useRef();
+export default function useSwapInputRefs() {
+  const { inputCurrency, outputCurrency } = useSwapInputOutputTokens();
+  const inputFieldRef = useRef<TextInput>();
+  const nativeFieldRef = useRef<TextInput>();
+  const outputFieldRef = useRef<TextInput>();
 
   const findNextInput = useCallback(
     currentFocusedInputHandle => {

--- a/src/hooks/useSwapInputs.js
+++ b/src/hooks/useSwapInputs.js
@@ -14,7 +14,6 @@ import logger from 'logger';
 export default function useSwapInputs({
   defaultInputAsset,
   inputCurrency,
-  isDeposit,
   isWithdrawal,
   maxInputBalance,
   nativeFieldRef,
@@ -78,7 +77,6 @@ export default function useSwapInputs({
 
       if (newAmountDisplay) {
         analytics.track('Updated input amount', {
-          category: isDeposit ? 'savings' : 'swap',
           defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
           type,
           value: convertStringToNumber(newAmountDisplay),
@@ -88,7 +86,6 @@ export default function useSwapInputs({
     [
       defaultInputAsset,
       inputCurrency,
-      isDeposit,
       isWithdrawal,
       maxInputBalance,
       nativeFieldRef,
@@ -139,14 +136,13 @@ export default function useSwapInputs({
       setOutputAmountDisplay(newAmountDisplay || newOutputAmount);
       if (newAmountDisplay) {
         analytics.track('Updated output amount', {
-          category: isWithdrawal || isDeposit ? 'savings' : 'swap',
           defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
           type,
           value: convertStringToNumber(newAmountDisplay),
         });
       }
     },
-    [defaultInputAsset, isDeposit, isWithdrawal, type]
+    [defaultInputAsset, type]
   );
 
   return {

--- a/src/hooks/useSwapInputs.ts
+++ b/src/hooks/useSwapInputs.ts
@@ -1,6 +1,7 @@
 import analytics from '@segment/analytics-react-native';
 import { get } from 'lodash';
-import { useCallback, useState } from 'react';
+import { RefObject, useCallback, useState } from 'react';
+import { TextInput } from 'react-native';
 import {
   convertAmountFromNativeValue,
   convertAmountToNativeAmount,
@@ -9,25 +10,37 @@ import {
   isZero,
   updatePrecisionToDisplay,
 } from '../helpers/utilities';
+import useSwapInputOutputTokens from './useSwapInputOutputTokens';
 import logger from 'logger';
 
 export default function useSwapInputs({
   defaultInputAsset,
-  inputCurrency,
   isWithdrawal,
   maxInputBalance,
   nativeFieldRef,
   supplyBalanceUnderlying,
   type,
+}: {
+  defaultInputAsset: string;
+  isWithdrawal: boolean;
+  maxInputBalance: string;
+  nativeFieldRef: RefObject<TextInput>;
+  supplyBalanceUnderlying: string;
+  type: string;
 }) {
+  const { inputCurrency } = useSwapInputOutputTokens();
   const [isMax, setIsMax] = useState(false);
-  const [inputAmount, setInputAmount] = useState(null);
-  const [inputAmountDisplay, setInputAmountDisplay] = useState(null);
+  const [inputAmount, setInputAmount] = useState<string | null>(null);
+  const [inputAmountDisplay, setInputAmountDisplay] = useState<string | null>(
+    null
+  );
   const [inputAsExactAmount, setInputAsExactAmount] = useState(true);
   const [isSufficientBalance, setIsSufficientBalance] = useState(true);
-  const [nativeAmount, setNativeAmount] = useState(null);
-  const [outputAmount, setOutputAmount] = useState(null);
-  const [outputAmountDisplay, setOutputAmountDisplay] = useState(null);
+  const [nativeAmount, setNativeAmount] = useState<string | null>(null);
+  const [outputAmount, setOutputAmount] = useState<string | null>(null);
+  const [outputAmountDisplay, setOutputAmountDisplay] = useState<string | null>(
+    null
+  );
 
   const updateInputAmount = useCallback(
     (
@@ -41,12 +54,7 @@ export default function useSwapInputs({
       setInputAmountDisplay(newAmountDisplay || newInputAmount);
       setIsMax(!!newInputAmount && newIsMax);
 
-      if (
-        (nativeFieldRef &&
-          nativeFieldRef.current &&
-          !nativeFieldRef.current.isFocused()) ||
-        newIsMax
-      ) {
+      if (!nativeFieldRef?.current?.isFocused() || newIsMax) {
         let newNativeAmount = null;
 
         const isInputZero = isZero(newInputAmount);

--- a/src/hooks/useUniswapCalls.ts
+++ b/src/hooks/useUniswapCalls.ts
@@ -3,17 +3,16 @@ import { filter, flatMap, map, toLower, uniqBy } from 'lodash';
 import { useMemo } from 'react';
 import { getTokenForCurrency } from '../handlers/uniswap';
 import useAccountSettings from './useAccountSettings';
-import { Asset } from '@rainbow-me/entities';
+import useSwapInputOutputTokens from './useSwapInputOutputTokens';
+
 import {
   PAIR_GET_RESERVES_CALL_DATA,
   UNISWAP_V2_BASES,
 } from '@rainbow-me/references';
 
-export default function useUniswapCalls(
-  inputCurrency: Asset | null,
-  outputCurrency: Asset | null
-) {
+export default function useUniswapCalls() {
   const { chainId } = useAccountSettings();
+  const { inputCurrency, outputCurrency } = useSwapInputOutputTokens();
 
   const inputToken: Token | null = useMemo(() => {
     if (!inputCurrency) return null;

--- a/src/hooks/useUniswapCurrencies.js
+++ b/src/hooks/useUniswapCurrencies.js
@@ -48,7 +48,6 @@ const createMissingAsset = (asset, underlyingPrice, priceOfEther) => {
 };
 
 export default function useUniswapCurrencies({
-  category,
   defaultInputAsset,
   inputHeaderTitle,
   isDeposit,
@@ -188,7 +187,6 @@ export default function useUniswapCurrencies({
       }
 
       analytics.track('Switched input asset', {
-        category,
         defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
         from: get(previousInputCurrency, 'symbol', ''),
         label: get(newInputCurrency, 'symbol', ''),
@@ -196,7 +194,6 @@ export default function useUniswapCurrencies({
       });
     },
     [
-      category,
       defaultChosenInputItem,
       defaultInputAddress,
       defaultInputAsset,
@@ -245,7 +242,6 @@ export default function useUniswapCurrencies({
       }
 
       analytics.track('Switched output asset', {
-        category,
         defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
         from: get(previousOutputCurrency, 'symbol', ''),
         label: get(newOutputCurrency, 'symbol', ''),
@@ -253,7 +249,6 @@ export default function useUniswapCurrencies({
       });
     },
     [
-      category,
       defaultInputAsset,
       inputCurrency,
       previousOutputCurrency,
@@ -269,7 +264,6 @@ export default function useUniswapCurrencies({
       setParams({ focused: false });
       delayNext();
       navigate(Routes.CURRENCY_SELECT_SCREEN, {
-        category,
         headerTitle: inputHeaderTitle,
         onSelectCurrency: updateInputCurrency,
         restoreFocusOnSwapModal: () => setParams({ focused: true }),
@@ -279,7 +273,6 @@ export default function useUniswapCurrencies({
     });
   }, [
     blockInteractions,
-    category,
     dangerouslyGetParent,
     inputHeaderTitle,
     navigate,
@@ -293,7 +286,6 @@ export default function useUniswapCurrencies({
       dangerouslyGetParent().dangerouslyGetState().index = 0;
       delayNext();
       navigate(Routes.CURRENCY_SELECT_SCREEN, {
-        category,
         headerTitle: 'Receive',
         onSelectCurrency: updateOutputCurrency,
         restoreFocusOnSwapModal: () => setParams({ focused: true }),
@@ -303,7 +295,6 @@ export default function useUniswapCurrencies({
     });
   }, [
     blockInteractions,
-    category,
     dangerouslyGetParent,
     navigate,
     setParams,

--- a/src/hooks/useUniswapMarketDetails.ts
+++ b/src/hooks/useUniswapMarketDetails.ts
@@ -11,6 +11,7 @@ import {
 } from '../helpers/utilities';
 import { logger } from '../utils';
 import useAccountSettings from './useAccountSettings';
+import useSwapInputOutputTokens from './useSwapInputOutputTokens';
 import useUniswapPairs from './useUniswapPairs';
 import { Asset } from '@rainbow-me/entities';
 
@@ -21,14 +22,12 @@ export default function useUniswapMarketDetails({
   extraTradeDetails,
   inputAmount,
   inputAsExactAmount,
-  inputCurrency,
   inputFieldRef,
   isDeposit,
   isWithdrawal,
   maxInputBalance,
   nativeCurrency,
   outputAmount,
-  outputCurrency,
   outputFieldRef,
   setIsSufficientBalance,
   setSlippage,
@@ -40,14 +39,12 @@ export default function useUniswapMarketDetails({
   extraTradeDetails: { outputPriceValue: string };
   inputAmount: string;
   inputAsExactAmount: boolean;
-  inputCurrency: Asset;
   inputFieldRef: RefObject<TextInput>;
   isDeposit: boolean;
   isWithdrawal: boolean;
   maxInputBalance: string;
   nativeCurrency: string;
   outputAmount: string;
-  outputCurrency: Asset;
   outputFieldRef: RefObject<TextInput>;
   setIsSufficientBalance: (isSufficientBalance: boolean) => void;
   setSlippage: (slippage: number) => void;
@@ -69,14 +66,13 @@ export default function useUniswapMarketDetails({
     newInputAsExactAmount?: boolean
   ) => void;
 }) {
+  const { inputCurrency, outputCurrency } = useSwapInputOutputTokens();
+
   const [isSufficientLiquidity, setIsSufficientLiquidity] = useState(true);
   const [tradeDetails, setTradeDetails] = useState<Trade | null>(null);
   const { chainId } = useAccountSettings();
 
-  const { allPairs, doneLoadingResults } = useUniswapPairs(
-    inputCurrency,
-    outputCurrency
-  );
+  const { allPairs, doneLoadingResults } = useUniswapPairs();
   const swapNotNeeded = useMemo(() => {
     return (
       (isDeposit || isWithdrawal) &&

--- a/src/hooks/useUniswapPairs.ts
+++ b/src/hooks/useUniswapPairs.ts
@@ -3,20 +3,13 @@ import { compact } from 'lodash';
 import { useMemo } from 'react';
 import useMulticall from './useMulticall';
 import useUniswapCalls from './useUniswapCalls';
-import { Asset } from '@rainbow-me/entities';
 import {
   PAIR_GET_RESERVES_FRAGMENT,
   PAIR_INTERFACE,
 } from '@rainbow-me/references';
 
-export default function useUniswapPairs(
-  inputCurrency: Asset,
-  outputCurrency: Asset
-) {
-  const { allPairCombinations, calls } = useUniswapCalls(
-    inputCurrency,
-    outputCurrency
-  );
+export default function useUniswapPairs() {
+  const { allPairCombinations, calls } = useUniswapCalls();
 
   const { multicallResults } = useMulticall(
     calls,

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -306,7 +306,6 @@ const INITIAL_STATE = {
   selectedGasPrice: {},
   selectedGasPriceOption: NORMAL,
   txFees: {},
-  useShortGasFormat: true,
 };
 
 export default (state = INITIAL_STATE, action) => {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -20,6 +20,7 @@ import raps from './raps';
 import requests from './requests';
 import settings from './settings';
 import showcaseTokens from './showcaseTokens';
+import swap from './swap';
 import uniqueTokens from './uniqueTokens';
 import uniswap from './uniswap';
 import uniswapLiquidity from './uniswapLiquidity';
@@ -46,6 +47,7 @@ export default combineReducers({
   requests,
   settings,
   showcaseTokens,
+  swap,
   uniqueTokens,
   uniswap,
   uniswapLiquidity,

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -1,0 +1,25 @@
+import { AnyAction } from 'redux';
+import { AppDispatch } from '@rainbow-me/redux/store';
+
+// -- Constants --------------------------------------- //
+const SWAP_CLEAR_STATE = 'swap/SWAP_CLEAR_STATE';
+
+// -- Actions ---------------------------------------- //
+export const swapResetState = () => (dispatch: AppDispatch) => {
+  dispatch({ type: SWAP_CLEAR_STATE });
+};
+
+// -- Reducer ----------------------------------------- //
+const INITIAL_STATE = {};
+
+export default (state = INITIAL_STATE, action: AnyAction) => {
+  switch (action.type) {
+    case SWAP_CLEAR_STATE:
+      return {
+        ...state,
+        ...INITIAL_STATE,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -1,19 +1,52 @@
 import { AnyAction } from 'redux';
+import { Asset } from '@rainbow-me/entities';
 import { AppDispatch } from '@rainbow-me/redux/store';
 
+interface SwapState {
+  inputCurrency: Asset | null;
+  outputCurrency: Asset | null;
+}
+
 // -- Constants --------------------------------------- //
+const SWAP_UPDATE_INPUT_CURRENCY = 'swap/SWAP_UPDATE_INPUT_CURRENCY';
+const SWAP_UPDATE_OUTPUT_CURRENCY = 'swap/SWAP_UPDATE_OUTPUT_CURRENCY';
 const SWAP_CLEAR_STATE = 'swap/SWAP_CLEAR_STATE';
 
 // -- Actions ---------------------------------------- //
-export const swapResetState = () => (dispatch: AppDispatch) => {
+export const updateSwapInputCurrency = (newInputCurrency: Asset) => (
+  dispatch: AppDispatch
+) => {
+  dispatch({ payload: newInputCurrency, type: SWAP_UPDATE_INPUT_CURRENCY });
+};
+
+export const updateSwapOutputCurrency = (newOutputCurrency: Asset) => (
+  dispatch: AppDispatch
+) => {
+  dispatch({ payload: newOutputCurrency, type: SWAP_UPDATE_OUTPUT_CURRENCY });
+};
+
+export const swapClearState = () => (dispatch: AppDispatch) => {
   dispatch({ type: SWAP_CLEAR_STATE });
 };
 
 // -- Reducer ----------------------------------------- //
-const INITIAL_STATE = {};
+const INITIAL_STATE: SwapState = {
+  inputCurrency: null,
+  outputCurrency: null,
+};
 
 export default (state = INITIAL_STATE, action: AnyAction) => {
   switch (action.type) {
+    case SWAP_UPDATE_OUTPUT_CURRENCY:
+      return {
+        ...state,
+        outputCurrency: action.payload,
+      };
+    case SWAP_UPDATE_INPUT_CURRENCY:
+      return {
+        ...state,
+        inputCurrency: action.payload,
+      };
     case SWAP_CLEAR_STATE:
       return {
         ...state,

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -68,7 +68,6 @@ export default function CurrencySelectModal() {
   const { navigate, dangerouslyGetState } = useNavigation();
   const {
     params: {
-      category,
       onSelectCurrency,
       restoreFocusOnSwapModal,
       setPointerEvents,
@@ -201,7 +200,6 @@ export default function CurrencySelectModal() {
         [asset.address]: isFavorited,
       }));
       analytics.track('Toggled an asset as Favorited', {
-        category,
         isFavorited,
         name: asset.name,
         symbol: asset.symbol,
@@ -209,7 +207,7 @@ export default function CurrencySelectModal() {
         type,
       });
     },
-    [category, type]
+    [type]
   );
 
   const handleSelectAsset = useCallback(
@@ -218,7 +216,6 @@ export default function CurrencySelectModal() {
       onSelectCurrency(item);
       if (searchQueryForSearch) {
         analytics.track('Selected a search result in Swap', {
-          category,
           name: item.name,
           searchQueryForSearch,
           symbol: item.symbol,
@@ -236,7 +233,6 @@ export default function CurrencySelectModal() {
       searchQueryForSearch,
       dangerouslyGetState,
       navigate,
-      category,
       type,
     ]
   );

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -26,12 +26,8 @@ import SwapInfo from '../components/exchange/SwapInfo';
 import { FloatingPanel, FloatingPanels } from '../components/floating-panels';
 import { GasSpeedButton } from '../components/gas';
 import { Centered, KeyboardFixedOpenLayout } from '../components/layout';
-import ExchangeModalTypes from '../helpers/exchangeModalTypes';
-import isKeyboardOpen from '../helpers/isKeyboardOpen';
-import { loadWallet } from '../model/wallet';
-import { useNavigation } from '../navigation/Navigation';
-import { multicallClearState } from '../redux/multicall';
-import ethUnits from '../references/ethereum-units.json';
+import ExchangeModalTypes from '@rainbow-me/helpers/exchangeModalTypes';
+import isKeyboardOpen from '@rainbow-me/helpers/isKeyboardOpen';
 import {
   useAccountSettings,
   useBlockPolling,
@@ -39,16 +35,21 @@ import {
   useMaxInputBalance,
   usePrevious,
   useSwapDetails,
+  useSwapInputOutputTokens,
   useSwapInputRefs,
   useSwapInputs,
   useUniswapCurrencies,
   useUniswapMarketDetails,
 } from '@rainbow-me/hooks';
+import { loadWallet } from '@rainbow-me/model/wallet';
+import { useNavigation } from '@rainbow-me/navigation/Navigation';
 import { executeRap } from '@rainbow-me/raps';
+import { multicallClearState } from '@rainbow-me/redux/multicall';
+import { swapClearState } from '@rainbow-me/redux/swap';
+import { ethUnits } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 import { colors, position } from '@rainbow-me/styles';
 import { backgroundTask, isNewValueForPath } from '@rainbow-me/utils';
-
 import logger from 'logger';
 
 const AnimatedFloatingPanels = Animated.createAnimatedComponent(FloatingPanels);
@@ -86,6 +87,7 @@ export default function ExchangeModal({
     : ethUnits.basic_swap;
 
   const dispatch = useDispatch();
+
   const {
     isSufficientGas,
     selectedGasPrice,
@@ -115,10 +117,8 @@ export default function ExchangeModal({
 
   const {
     defaultInputAddress,
-    inputCurrency,
     navigateToSelectInputCurrency,
     navigateToSelectOutputCurrency,
-    outputCurrency,
     previousInputCurrency,
   } = useUniswapCurrencies({
     defaultInputAsset,
@@ -129,16 +129,15 @@ export default function ExchangeModal({
     underlyingPrice,
   });
 
+  const { inputCurrency, outputCurrency } = useSwapInputOutputTokens();
+
   const {
     handleFocus,
     inputFieldRef,
     lastFocusedInputHandle,
     nativeFieldRef,
     outputFieldRef,
-  } = useSwapInputRefs({
-    inputCurrency,
-    outputCurrency,
-  });
+  } = useSwapInputRefs();
 
   const {
     inputAmount,
@@ -155,7 +154,6 @@ export default function ExchangeModal({
     updateOutputAmount,
   } = useSwapInputs({
     defaultInputAsset,
-    inputCurrency,
     isWithdrawal,
     maxInputBalance,
     nativeFieldRef,
@@ -196,14 +194,12 @@ export default function ExchangeModal({
     extraTradeDetails,
     inputAmount,
     inputAsExactAmount,
-    inputCurrency,
     inputFieldRef,
     isDeposit,
     isWithdrawal,
     maxInputBalance,
     nativeCurrency,
     outputAmount,
-    outputCurrency,
     outputFieldRef,
     setIsSufficientBalance,
     setSlippage,
@@ -246,6 +242,7 @@ export default function ExchangeModal({
   useEffect(() => {
     return () => {
       dispatch(multicallClearState());
+      dispatch(swapClearState());
     };
   }, [dispatch]);
 

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -78,7 +78,6 @@ export default function ExchangeModal({
 
   const isDeposit = type === ExchangeModalTypes.deposit;
   const isWithdrawal = type === ExchangeModalTypes.withdrawal;
-  const category = isDeposit || isWithdrawal ? 'savings' : 'swap';
 
   const defaultGasLimit = isDeposit
     ? ethUnits.basic_deposit
@@ -122,7 +121,6 @@ export default function ExchangeModal({
     outputCurrency,
     previousInputCurrency,
   } = useUniswapCurrencies({
-    category,
     defaultInputAsset,
     inputHeaderTitle,
     isDeposit,
@@ -158,7 +156,6 @@ export default function ExchangeModal({
   } = useSwapInputs({
     defaultInputAsset,
     inputCurrency,
-    isDeposit,
     isWithdrawal,
     maxInputBalance,
     nativeFieldRef,
@@ -300,13 +297,7 @@ export default function ExchangeModal({
 
   // Liten to gas prices, Uniswap reserves updates
   useEffect(() => {
-    updateDefaultGasLimit(
-      isDeposit
-        ? ethUnits.basic_deposit
-        : isWithdrawal
-        ? ethUnits.basic_withdrawal
-        : ethUnits.basic_swap
-    );
+    updateDefaultGasLimit(defaultGasLimit);
     startPollingGasPrices();
     initWeb3Listener();
     return () => {
@@ -314,9 +305,8 @@ export default function ExchangeModal({
       stopWeb3Listener();
     };
   }, [
+    defaultGasLimit,
     initWeb3Listener,
-    isDeposit,
-    isWithdrawal,
     startPollingGasPrices,
     stopPollingGasPrices,
     stopWeb3Listener,
@@ -348,7 +338,6 @@ export default function ExchangeModal({
   useEffect(() => {
     if (isSlippageWarningVisible && !prevIsSlippageWarningVisible) {
       analytics.track('Showing high slippage warning in Swap', {
-        category,
         name: outputCurrency.name,
         slippage,
         symbol: outputCurrency.symbol,
@@ -357,7 +346,6 @@ export default function ExchangeModal({
       });
     }
   }, [
-    category,
     isSlippageWarningVisible,
     outputCurrency,
     prevIsSlippageWarningVisible,
@@ -371,14 +359,12 @@ export default function ExchangeModal({
       maxBalance = supplyBalanceUnderlying;
     }
     analytics.track('Selected max balance', {
-      category,
       defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
       type,
       value: Number(maxBalance.toString()),
     });
     return updateInputAmount(maxBalance, maxBalance, true, true);
   }, [
-    category,
     defaultInputAsset,
     isWithdrawal,
     maxInputBalance,
@@ -390,7 +376,6 @@ export default function ExchangeModal({
   const handleSubmit = useCallback(() => {
     backgroundTask.execute(async () => {
       analytics.track(`Submitted ${type}`, {
-        category,
         defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
         isSlippageWarningVisible,
         name: get(outputCurrency, 'name', ''),
@@ -428,7 +413,6 @@ export default function ExchangeModal({
         await executeRap(wallet, rap);
         logger.log('[exchange - handle submit] executed rap!');
         analytics.track(`Completed ${type}`, {
-          category,
           defaultInputAsset: get(defaultInputAsset, 'symbol', ''),
           type,
         });
@@ -441,7 +425,6 @@ export default function ExchangeModal({
     });
   }, [
     type,
-    category,
     defaultInputAsset,
     isSlippageWarningVisible,
     outputCurrency,
@@ -481,8 +464,6 @@ export default function ExchangeModal({
         type: 'swap_details',
       });
       analytics.track('Opened Swap Details modal', {
-        category,
-
         name: get(outputCurrency, 'name', ''),
         symbol: get(outputCurrency, 'symbol', ''),
         tokenAddress: get(outputCurrency, 'address', ''),
@@ -493,7 +474,6 @@ export default function ExchangeModal({
       ? internalNavigate()
       : Keyboard.addListener('keyboardDidHide', internalNavigate);
   }, [
-    category,
     extraTradeDetails,
     inputCurrency,
     inputFieldRef,


### PR DESCRIPTION
In the interest of not having a massive PR with lots of changes, I have created a swap redux and only moved the input and output currencies to the redux.

We will be able to move over pieces of state one by one in this manner.

I also updated some of the hooks to use Typescript.

Testing:
- Confirm that Compound deposit / withdrawals will display the correct input currency as expected
- Confirm that the swap modal interactions (choosing currencies, flipping input and output currencies, etc) all work