### PR TITLE
Move swap input values to redux

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -63,6 +63,7 @@ export { default as useShowcaseTokens } from './useShowcaseTokens';
 export { default as useSwapDetails } from './useSwapDetails';
 export { default as useSwapInputRefs } from './useSwapInputRefs';
 export { default as useSwapInputs } from './useSwapInputs';
+export { default as useSwapInputValues } from './useSwapInputValues';
 export { default as useSwapInputOutputTokens } from './useSwapInputOutputTokens';
 export { default as useTimeout } from './useTimeout';
 export { default as useTopMovers } from './useTopMovers';

--- a/src/hooks/useSwapInputValues.ts
+++ b/src/hooks/useSwapInputValues.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { createSelector } from 'reselect';
+import { AppState } from '@rainbow-me/redux/store';
+import { SwapAmount, updateIsSufficientBalance } from '@rainbow-me/redux/swap';
+
+const isMaxSelector = (state: AppState) => state.swap.isMax;
+const inputAmountSelector = (state: AppState) => state.swap.inputAmount;
+const inputAsExactAmountSelector = (state: AppState) =>
+  state.swap.inputAsExactAmount;
+const isSufficientBalanceSelector = (state: AppState) =>
+  state.swap.isSufficientBalance;
+const nativeAmountSelector = (state: AppState) => state.swap.nativeAmount;
+const outputAmountSelector = (state: AppState) => state.swap.outputAmount;
+
+const withSwapInputValues = (
+  isMax: boolean,
+  inputAmount: SwapAmount,
+  inputAsExactAmount: boolean,
+  isSufficientBalance: boolean,
+  nativeAmount: string,
+  outputAmount: SwapAmount
+) => {
+  return {
+    inputAmount: inputAmount?.value,
+    inputAmountDisplay: inputAmount?.display,
+    inputAsExactAmount,
+    isMax,
+    isSufficientBalance,
+    nativeAmount,
+    outputAmount: outputAmount?.value,
+    outputAmountDisplay: outputAmount?.display,
+  };
+};
+
+const swapInputValuesSelector = createSelector(
+  [
+    isMaxSelector,
+    inputAmountSelector,
+    inputAsExactAmountSelector,
+    isSufficientBalanceSelector,
+    nativeAmountSelector,
+    outputAmountSelector,
+  ],
+  withSwapInputValues
+);
+
+export default function useSwapInputValues() {
+  const dispatch = useDispatch();
+  const inputValues = useSelector(swapInputValuesSelector);
+  const swapUpdateIsSufficientBalance = useCallback(
+    isSufficientBalance => {
+      dispatch(updateIsSufficientBalance(isSufficientBalance));
+    },
+    [dispatch]
+  );
+  return {
+    ...inputValues,
+    swapUpdateIsSufficientBalance,
+  };
+}

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -2,17 +2,83 @@ import { AnyAction } from 'redux';
 import { Asset } from '@rainbow-me/entities';
 import { AppDispatch } from '@rainbow-me/redux/store';
 
+export interface SwapAmount {
+  display: string | null;
+  value: string | null;
+}
+
 interface SwapState {
   inputCurrency: Asset | null;
+  inputAsExactAmount: boolean;
+  inputAmount: SwapAmount | null;
+  isMax: boolean;
+  isSufficientBalance: boolean;
+  nativeAmount: string | null;
+  outputAmount: SwapAmount | null;
   outputCurrency: Asset | null;
 }
 
 // -- Constants --------------------------------------- //
+const SWAP_UPDATE_IS_MAX = 'swap/SWAP_UPDATE_IS_MAX';
+const SWAP_UPDATE_IS_SUFFICIENT_BALANCE =
+  'swap/SWAP_UPDATE_IS_SUFFICIENT_BALANCE';
+const SWAP_UPDATE_NATIVE_AMOUNT = 'swap/SWAP_UPDATE_NATIVE_AMOUNT';
+const SWAP_UPDATE_INPUT_AMOUNT = 'swap/SWAP_UPDATE_INPUT_AMOUNT';
+const SWAP_UPDATE_OUTPUT_AMOUNT = 'swap/SWAP_UPDATE_OUTPUT_AMOUNT';
 const SWAP_UPDATE_INPUT_CURRENCY = 'swap/SWAP_UPDATE_INPUT_CURRENCY';
 const SWAP_UPDATE_OUTPUT_CURRENCY = 'swap/SWAP_UPDATE_OUTPUT_CURRENCY';
 const SWAP_CLEAR_STATE = 'swap/SWAP_CLEAR_STATE';
 
 // -- Actions ---------------------------------------- //
+export const updateIsMax = (isMax: boolean) => (dispatch: AppDispatch) => {
+  dispatch({ payload: isMax, type: SWAP_UPDATE_IS_MAX });
+};
+
+export const updateIsSufficientBalance = (isSufficientBalance: boolean) => (
+  dispatch: AppDispatch
+) => {
+  dispatch({
+    payload: isSufficientBalance,
+    type: SWAP_UPDATE_IS_SUFFICIENT_BALANCE,
+  });
+};
+
+export const updateSwapInputAmount = (
+  value: string | null,
+  display: string | null,
+  inputAsExactAmount = true
+) => (dispatch: AppDispatch) => {
+  const inputAmount: SwapAmount = {
+    display,
+    value,
+  };
+  dispatch({
+    payload: { inputAmount, inputAsExactAmount },
+    type: SWAP_UPDATE_INPUT_AMOUNT,
+  });
+};
+
+export const updateSwapNativeAmount = (value: string | null) => (
+  dispatch: AppDispatch
+) => {
+  dispatch({ payload: value, type: SWAP_UPDATE_NATIVE_AMOUNT });
+};
+
+export const updateSwapOutputAmount = (
+  value: string | null,
+  display: string | null,
+  inputAsExactAmount = false
+) => (dispatch: AppDispatch) => {
+  const outputAmount: SwapAmount = {
+    display,
+    value,
+  };
+  dispatch({
+    payload: { inputAsExactAmount, outputAmount },
+    type: SWAP_UPDATE_OUTPUT_AMOUNT,
+  });
+};
+
 export const updateSwapInputCurrency = (newInputCurrency: Asset) => (
   dispatch: AppDispatch
 ) => {
@@ -31,12 +97,45 @@ export const swapClearState = () => (dispatch: AppDispatch) => {
 
 // -- Reducer ----------------------------------------- //
 const INITIAL_STATE: SwapState = {
+  inputAmount: null,
+  inputAsExactAmount: true,
   inputCurrency: null,
+  isMax: false,
+  isSufficientBalance: true,
+  nativeAmount: null,
+  outputAmount: null,
   outputCurrency: null,
 };
 
 export default (state = INITIAL_STATE, action: AnyAction) => {
   switch (action.type) {
+    case SWAP_UPDATE_IS_MAX:
+      return {
+        ...state,
+        isMax: action.payload,
+      };
+    case SWAP_UPDATE_IS_SUFFICIENT_BALANCE:
+      return {
+        ...state,
+        isSufficientBalance: action.payload,
+      };
+    case SWAP_UPDATE_NATIVE_AMOUNT:
+      return {
+        ...state,
+        nativeAmount: action.payload,
+      };
+    case SWAP_UPDATE_INPUT_AMOUNT:
+      return {
+        ...state,
+        inputAmount: action.payload.inputAmount,
+        inputAsExactAmount: action.payload.inputAsExactAmount,
+      };
+    case SWAP_UPDATE_OUTPUT_AMOUNT:
+      return {
+        ...state,
+        inputAsExactAmount: action.payload.inputAsExactAmount,
+        outputAmount: action.payload.outputAmount,
+      };
     case SWAP_UPDATE_OUTPUT_CURRENCY:
       return {
         ...state,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -38,6 +38,7 @@ import {
   useSwapInputOutputTokens,
   useSwapInputRefs,
   useSwapInputs,
+  useSwapInputValues,
   useUniswapCurrencies,
   useUniswapMarketDetails,
 } from '@rainbow-me/hooks';
@@ -140,15 +141,6 @@ export default function ExchangeModal({
   } = useSwapInputRefs();
 
   const {
-    inputAmount,
-    inputAmountDisplay,
-    inputAsExactAmount,
-    isMax,
-    isSufficientBalance,
-    nativeAmount,
-    outputAmount,
-    outputAmountDisplay,
-    setIsSufficientBalance,
     updateInputAmount,
     updateNativeAmount,
     updateOutputAmount,
@@ -160,6 +152,16 @@ export default function ExchangeModal({
     supplyBalanceUnderlying,
     type,
   });
+
+  const {
+    inputAmount,
+    inputAmountDisplay,
+    isSufficientBalance,
+    nativeAmount,
+    isMax,
+    outputAmount,
+    outputAmountDisplay,
+  } = useSwapInputValues();
 
   const isDismissing = useRef(false);
   useEffect(() => {
@@ -192,16 +194,12 @@ export default function ExchangeModal({
   const { isSufficientLiquidity, tradeDetails } = useUniswapMarketDetails({
     defaultInputAddress,
     extraTradeDetails,
-    inputAmount,
-    inputAsExactAmount,
     inputFieldRef,
     isDeposit,
     isWithdrawal,
     maxInputBalance,
     nativeCurrency,
-    outputAmount,
     outputFieldRef,
-    setIsSufficientBalance,
     setSlippage,
     updateExtraTradeDetails,
     updateInputAmount,


### PR DESCRIPTION
Moving the swap inputs (input, native input, output values) to redux state.

There will be proper improvements later, but for now I'm trying to make zero breaking changes.

Testing: all inputs (swap input, native input, output input) should work as expected and update each other as expected. Also, the inputs should respond fine on compound deposit / withdraw.