### PR TITLE
Coin edit improvements

### DIFF
--- a/src/components/asset-list/RecyclerAssetList.js
+++ b/src/components/asset-list/RecyclerAssetList.js
@@ -759,7 +759,6 @@ class RecyclerAssetList extends Component {
       <AssetListHeader {...data} isSticky />
       {this.state.showCoinListEditor ? (
         <CoinDivider
-          assetsAmount={this.renderList.length}
           balancesSum={0}
           isSticky
           nativeCurrency={this.props.nativeCurrency}

--- a/src/components/asset-list/RecyclerAssetList.js
+++ b/src/components/asset-list/RecyclerAssetList.js
@@ -11,15 +11,15 @@ import {
 } from 'recyclerlistview';
 import StickyContainer from 'recyclerlistview/dist/reactnative/core/StickyContainer';
 import { withThemeContext } from '../../context/ThemeContext';
-import {
-  deviceUtils,
-  isNewValueForPath,
-  safeAreaInsetValues,
-} from '../../utils';
 import { CoinDivider } from '../coin-divider';
 import { CoinRowHeight } from '../coin-row';
 import AssetListHeader, { AssetListHeaderHeight } from './AssetListHeader';
 import { firstCoinRowMarginTop, ViewTypes } from './RecyclerViewTypes';
+import {
+  deviceUtils,
+  isNewValueForPath,
+  safeAreaInsetValues,
+} from '@rainbow-me/utils';
 
 const NOOP = () => undefined;
 let globalDeviceDimensions = 0;
@@ -633,7 +633,7 @@ class RecyclerAssetList extends Component {
     }
 
     if (row.item && row.item.smallBalancesContainer) {
-      return `balance_${row.item.stableId}`;
+      return `smallBalancesContainer`;
     }
 
     if (row.item && row.item.coinDivider) {

--- a/src/components/asset-list/RecyclerViewTypes.js
+++ b/src/components/asset-list/RecyclerViewTypes.js
@@ -78,7 +78,6 @@ export const ViewTypes = {
       const { item = {} } = data;
       return (
         <CoinDivider
-          assetsAmount={item.assetsAmount}
           balancesSum={item.value}
           isCoinListEdited={isCoinListEdited}
           nativeCurrency={nativeCurrency}

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -2,17 +2,17 @@ import React, { useCallback, useEffect } from 'react';
 import { LayoutAnimation, View } from 'react-native';
 import styled from 'styled-components';
 import { withThemeContext } from '../../context/ThemeContext';
-import EditOptions from '../../helpers/editOptionTypes';
+import { Row, RowWithMargins } from '../layout';
+import CoinDividerAssetsValue from './CoinDividerAssetsValue';
+import CoinDividerEditButton from './CoinDividerEditButton';
+import CoinDividerOpenButton from './CoinDividerOpenButton';
+import EditOptions from '@rainbow-me/helpers/editOptionTypes';
 import {
   useCoinListEdited,
   useCoinListEditOptions,
   useDimensions,
   useOpenSmallBalances,
-} from '../../hooks';
-import { Row, RowWithMargins } from '../layout';
-import CoinDividerAssetsValue from './CoinDividerAssetsValue';
-import CoinDividerEditButton from './CoinDividerEditButton';
-import CoinDividerOpenButton from './CoinDividerOpenButton';
+} from '@rainbow-me/hooks';
 import { padding } from '@rainbow-me/styles';
 
 export const CoinDividerHeight = 30;
@@ -122,12 +122,16 @@ export default function CoinDivider({
         />
         <EditButtonWrapper
           pointerEvents={
-            isSmallBalancesOpen || assetsAmount === 0 ? 'auto' : 'none'
+            isCoinListEdited || isSmallBalancesOpen || assetsAmount === 0
+              ? 'auto'
+              : 'none'
           }
         >
           <CoinDividerEditButton
             isActive={isCoinListEdited}
-            isVisible={isSmallBalancesOpen || assetsAmount === 0}
+            isVisible={
+              isCoinListEdited || isSmallBalancesOpen || assetsAmount === 0
+            }
             onPress={handlePressEdit}
             text={isCoinListEdited ? 'Done' : 'Edit'}
             textOpacityAlwaysOn

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -45,7 +45,6 @@ const EditButtonWrapper = styled(Row).attrs({
 `;
 
 export default function CoinDivider({
-  assetsAmount,
   balancesSum,
   isSticky,
   nativeCurrency,
@@ -84,15 +83,11 @@ export default function CoinDivider({
   return (
     <Container deviceWidth={deviceWidth} isSticky={isSticky}>
       <Row>
-        <View
-          pointerEvents={
-            isCoinListEdited || assetsAmount === 0 ? 'none' : 'auto'
-          }
-        >
+        <View pointerEvents={isCoinListEdited ? 'none' : 'auto'}>
           <CoinDividerOpenButton
             coinDividerHeight={CoinDividerHeight}
             isSmallBalancesOpen={isSmallBalancesOpen}
-            isVisible={isCoinListEdited || assetsAmount === 0}
+            isVisible={isCoinListEdited}
             onPress={toggleOpenSmallBalances}
           />
         </View>
@@ -115,23 +110,18 @@ export default function CoinDivider({
       </Row>
       <Row justify="end">
         <CoinDividerAssetsValue
-          assetsAmount={assetsAmount}
           balancesSum={balancesSum}
           nativeCurrency={nativeCurrency}
           openSmallBalances={isSmallBalancesOpen}
         />
         <EditButtonWrapper
           pointerEvents={
-            isCoinListEdited || isSmallBalancesOpen || assetsAmount === 0
-              ? 'auto'
-              : 'none'
+            isCoinListEdited || isSmallBalancesOpen ? 'auto' : 'none'
           }
         >
           <CoinDividerEditButton
             isActive={isCoinListEdited}
-            isVisible={
-              isCoinListEdited || isSmallBalancesOpen || assetsAmount === 0
-            }
+            isVisible={isCoinListEdited || isSmallBalancesOpen}
             onPress={handlePressEdit}
             text={isCoinListEdited ? 'Done' : 'Edit'}
             textOpacityAlwaysOn

--- a/src/components/coin-divider/CoinDividerAssetsValue.js
+++ b/src/components/coin-divider/CoinDividerAssetsValue.js
@@ -20,12 +20,11 @@ const ValueText = withThemeContext(styled(Text).attrs(({ colors }) => ({
 `);
 
 const CoinDividerAssetsValue = ({
-  assetsAmount,
   balancesSum,
   nativeCurrency,
   openSmallBalances,
 }) => (
-  <Container isVisible={openSmallBalances || assetsAmount === 0}>
+  <Container isVisible={openSmallBalances}>
     <ValueText>
       {convertAmountToNativeDisplay(balancesSum, nativeCurrency)}
     </ValueText>

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -11,8 +11,10 @@ import {
 } from 'lodash';
 import { add, convertAmountToNativeDisplay } from './utilities';
 import store from '@rainbow-me/redux/store';
-import { supportedNativeCurrencies } from '@rainbow-me/references';
-import { ETH_ICON_URL } from '@rainbow-me/utils';
+import {
+  ETH_ICON_URL,
+  supportedNativeCurrencies,
+} from '@rainbow-me/references';
 
 export const amountOfShowedCoins = 5;
 

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -137,15 +137,18 @@ export const buildCoinsList = (
     }
   });
 
+  // decide which assets to show above or below the coin divider
   const nonHidden = concat(pinnedAssets, standardAssets, smallAssets);
   const dividerIndex = Math.max(pinnedAssets.length, COINS_TO_SHOW);
   const assetsAboveDivider = slice(nonHidden, 0, dividerIndex);
   let assetsBelowDivider = slice(nonHidden, dividerIndex);
 
+  // calculate small balance and overall totals
   const smallBalancesValue = getTotal(assetsBelowDivider);
   const bigBalancesValue = getTotal(assetsAboveDivider);
   const totalBalancesValue = add(bigBalancesValue, smallBalancesValue);
 
+  // include hidden assets if in edit mode
   if (isCoinListEdited) {
     assetsBelowDivider = concat(assetsBelowDivider, hiddenAssets);
   }

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -7,6 +7,7 @@ import {
   get,
   groupBy,
   includes,
+  isEmpty,
   reduce,
   slice,
   sortBy,
@@ -138,10 +139,19 @@ export const buildCoinsList = (
   });
 
   // decide which assets to show above or below the coin divider
-  const nonHidden = concat(pinnedAssets, standardAssets, smallAssets);
+  const nonHidden = concat(pinnedAssets, standardAssets);
   const dividerIndex = Math.max(pinnedAssets.length, COINS_TO_SHOW);
-  const assetsAboveDivider = slice(nonHidden, 0, dividerIndex);
-  let assetsBelowDivider = slice(nonHidden, dividerIndex);
+
+  let assetsAboveDivider = slice(nonHidden, 0, dividerIndex);
+  let assetsBelowDivider = [];
+
+  if (isEmpty(assetsAboveDivider)) {
+    assetsAboveDivider = slice(smallAssets, 0, COINS_TO_SHOW);
+    assetsBelowDivider = slice(smallAssets, COINS_TO_SHOW);
+  } else {
+    const remainderBelowDivider = slice(nonHidden, dividerIndex);
+    assetsBelowDivider = concat(remainderBelowDivider, smallAssets);
+  }
 
   // calculate small balance and overall totals
   const smallBalancesValue = getTotal(assetsBelowDivider);

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -18,12 +18,6 @@ import {
 
 export const amountOfShowedCoins = 5;
 
-export const buildAssetHeaderUniqueIdentifier = ({
-  title,
-  totalItems,
-  totalValue,
-}) => compact([title, totalItems, totalValue]).join('_');
-
 export const buildAssetUniqueIdentifier = item => {
   const balance = get(item, 'balance.amount', '');
   const nativePrice = get(item, 'native.price.display', '');

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -194,13 +194,7 @@ export const buildCoinsList = (
       .concat(smallBalances.assets);
   }
 
-  if (
-    smallBalances.assets.length > 0 ||
-    (hiddenAssets.length > 0 && assetsLength > amountOfShowedCoins) ||
-    (pinnedAssetsLength === allAssetsLength &&
-      allAssetsLength > amountOfShowedCoins) ||
-    isCoinListEdited
-  ) {
+  if (smallBalances.assets.length > 0 || isCoinListEdited) {
     allAssets.push({
       assetsAmount: smallBalances.assets.length,
       coinDivider: true,

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -16,7 +16,7 @@ import {
   supportedNativeCurrencies,
 } from '@rainbow-me/references';
 
-export const amountOfShowedCoins = 5;
+const amountOfShowedCoins = 5;
 
 export const buildAssetUniqueIdentifier = item => {
   const balance = get(item, 'balance.amount', '');

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -196,7 +196,6 @@ export const buildCoinsList = (
 
   if (smallBalances.assets.length > 0 || isCoinListEdited) {
     allAssets.push({
-      assetsAmount: smallBalances.assets.length,
       coinDivider: true,
       value: smallBalancesValue,
     });

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -25,8 +25,9 @@ import {
 import networkTypes from './networkTypes';
 import { add, convertAmountToNativeDisplay, multiply } from './utilities';
 import { ImgixImage } from '@rainbow-me/images';
+import { ETH_ICON_URL } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
-import { ETH_ICON_URL, ethereumUtils } from '@rainbow-me/utils';
+import { ethereumUtils } from '@rainbow-me/utils';
 
 const allAssetsSelector = state => state.allAssets;
 const allAssetsCountSelector = state => state.allAssetsCount;

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -1,5 +1,13 @@
 import lang from 'i18n-js';
-import { compact, flattenDeep, get, groupBy, map, property } from 'lodash';
+import {
+  compact,
+  find,
+  flattenDeep,
+  get,
+  groupBy,
+  map,
+  property,
+} from 'lodash';
 import React from 'react';
 import { LayoutAnimation } from 'react-native';
 import { compose, withHandlers } from 'recompact';
@@ -208,15 +216,8 @@ const coinEditContextMenu = (
   allAssetsCount,
   totalValue
 ) => {
-  const noSmallBalances =
-    !balanceSectionData.length ||
-    !(
-      balanceSectionData[balanceSectionData.length - 1]
-        .smallBalancesContainer ||
-      (balanceSectionData.length > 1 &&
-        balanceSectionData[balanceSectionData.length - 2]
-          .smallBalancesContainer)
-    );
+  const noSmallBalances = !find(balanceSectionData, 'smallBalancesContainer');
+
   return {
     contextMenuOptions:
       allAssets.length > 0 && noSmallBalances

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -8,23 +8,14 @@ import { AssetListItemSkeleton } from '../components/asset-list';
 import { BalanceCoinRow } from '../components/coin-row';
 import { UniswapInvestmentRow } from '../components/investment-cards';
 import { CollectibleTokenFamily } from '../components/token-family';
-import EditOptions from '../helpers/editOptionTypes';
 import { withNavigation } from '../navigation/Navigation';
-import {
-  setHiddenCoins,
-  setIsCoinListEdited,
-  setPinnedCoins,
-} from '../redux/editOptions';
-import { setOpenSmallBalances } from '../redux/openStateSettings';
-import store from '../redux/store';
-import {
-  amountOfShowedCoins,
-  buildCoinsList,
-  buildUniqueTokenList,
-} from './assets';
+import { buildCoinsList, buildUniqueTokenList } from './assets';
 import networkTypes from './networkTypes';
 import { add, convertAmountToNativeDisplay, multiply } from './utilities';
 import { ImgixImage } from '@rainbow-me/images';
+import { setIsCoinListEdited } from '@rainbow-me/redux/editOptions';
+import { setOpenSmallBalances } from '@rainbow-me/redux/openStateSettings';
+import store from '@rainbow-me/redux/store';
 import { ETH_ICON_URL } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 import { ethereumUtils } from '@rainbow-me/utils';
@@ -228,41 +219,19 @@ const coinEditContextMenu = (
     );
   return {
     contextMenuOptions:
-      allAssets.length <= amountOfShowedCoins &&
-      allAssets.length > 0 &&
-      noSmallBalances
+      allAssets.length > 0 && noSmallBalances
         ? {
             cancelButtonIndex: 0,
             dynamicOptions: () => {
-              return isCoinListEdited && currentAction !== EditOptions.none
-                ? [
-                    'Cancel',
-                    currentAction !== EditOptions.unpin ? 'Pin' : 'Unpin',
-                    currentAction !== EditOptions.unhide ? 'Hide' : 'Unhide',
-                    'Finish',
-                  ]
-                : ['Cancel', isCoinListEdited ? 'Finish' : 'Edit'];
+              return ['Cancel', 'Edit'];
             },
             onPressActionSheet: async index => {
-              if (isCoinListEdited && currentAction !== EditOptions.none) {
-                if (index === 3) {
-                  store.dispatch(setIsCoinListEdited(!isCoinListEdited));
-                } else if (index === 1) {
-                  store.dispatch(setPinnedCoins());
-                } else if (index === 2) {
-                  store.dispatch(setHiddenCoins());
-                  store.dispatch(setOpenSmallBalances(true));
-                }
+              if (index === 1) {
+                store.dispatch(setIsCoinListEdited(!isCoinListEdited));
+                store.dispatch(setOpenSmallBalances(true));
                 LayoutAnimation.configureNext(
                   LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
                 );
-              } else {
-                if (index === 1) {
-                  store.dispatch(setIsCoinListEdited(!isCoinListEdited));
-                  LayoutAnimation.configureNext(
-                    LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
-                  );
-                }
               }
             },
           }

--- a/src/references/index.ts
+++ b/src/references/index.ts
@@ -24,6 +24,8 @@ export { default as ethUnits } from './ethereum-units.json';
 export { default as supportedNativeCurrencies } from './native-currencies.json';
 export { default as shitcoins } from './shitcoins.json';
 
+export const ETH_ICON_URL = 'https://s3.amazonaws.com/token-icons/eth.png';
+
 export const ETH_ADDRESS = 'eth';
 export const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 export const CDAI_CONTRACT = '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -37,7 +37,6 @@ export { default as sentryUtils } from './sentry';
 export { default as showActionSheetWithOptions } from './actionsheet';
 export { default as simplifyChartData } from './simplifyChartData';
 export { default as statusBar } from './statusBar';
-export { default as urlConstants } from './urlConstants';
 export { filterList, filterScams } from './search';
 export {
   getFirstGrapheme,

--- a/src/utils/urlConstants.js
+++ b/src/utils/urlConstants.js
@@ -1,1 +1,0 @@
-export const ETH_ICON_URL = 'https://s3.amazonaws.com/token-icons/eth.png';


### PR DESCRIPTION
* Fixed getting stuck in the edit button flow
* Simplified the logic for handling pinned, standard, small balance, hidden assets (and fixed some inconsistencies during edit mode)
* Removed the pin / unpin / hide states of the coinEditContextMenu (it is now only used to enter the edit mode if needed, but the regular coin divider edit row shows up) 

Recording with various scenarios:
https://recordit.co/x0lInSUq7a