### PR TITLE
Fix bottom row text

### DIFF
--- a/src/components/text/TruncatedText.js
+++ b/src/components/text/TruncatedText.js
@@ -2,13 +2,7 @@ import styled from 'styled-components';
 import Text from './Text';
 
 const TruncatedText = styled(Text).attrs(
-  ({
-    ellipsizeMode = 'tail',
-    numberOfLines = 1,
-    color,
-    theme: { colors },
-  }) => ({
-    color: color ? color : colors.dark,
+  ({ ellipsizeMode = 'tail', numberOfLines = 1 }) => ({
     ellipsizeMode,
     numberOfLines,
   })


### PR DESCRIPTION
before:
<img width="799" alt="Screen Shot 2021-02-01 at 3 21 52 PM" src="https://user-images.githubusercontent.com/7061887/106513778-614ed280-64a1-11eb-8c26-df47e3e330b1.png">

after:
<img width="795" alt="Screen Shot 2021-02-01 at 3 22 39 PM" src="https://user-images.githubusercontent.com/7061887/106513756-5b58f180-64a1-11eb-8dff-608c71e97443.png">
