### PR TITLE
dont use account key

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -79,13 +79,13 @@ platform :ios do
       export_method: "app-store",
     )
 
-    api_key = app_store_connect_api_key(
-      key_id: "B6RRSJG6H6",
-      issuer_id: "95830311-9e99-47b0-95ac-d628a3e4215e",
-      key_filepath: "./AuthKey_B6RRSJG6H6.p8",
-      duration: 1200, # optional
-      in_house: false, # optional but may be required if using match/sigh
-    )
+    # api_key = app_store_connect_api_key(
+    #   key_id: "B6RRSJG6H6",
+    #   issuer_id: "95830311-9e99-47b0-95ac-d628a3e4215e",
+    #   key_filepath: "fastlane/AuthKey_B6RRSJG6H6.p8",
+    #   duration: 1200, # optional
+    #   in_house: false, # optional but may be required if using match/sigh
+    # )
 
     pilot(
       app_identifier: "me.rainbow",


### PR DESCRIPTION
Added the env var `SPACESHIP_SKIP_2FA_UPGRADE` to CI so we don't need this for now