### PR TITLE
Revert "fix android square token icons (#1716)"

### DIFF
--- a/src/components/coin-icon/CoinIcon.js
+++ b/src/components/coin-icon/CoinIcon.js
@@ -12,7 +12,6 @@ export const CoinIconSize = 40;
 
 const StyledCoinIcon = styled(ReactCoinIcon)`
   opacity: ${({ isHidden }) => (isHidden ? 0.4 : 1)};
-  overflow: hidden;
 `;
 
 const CoinIcon = ({


### PR DESCRIPTION
This reverts commit 428d6e33af5486baee0e2afc3d23d8c92b1979ef.

Gonna move fix to coin-icon package