### PR TITLE
Fix Low Liquidity header in ExchangeAssetList

### DIFF
--- a/src/components/exchange/ExchangeAssetList.js
+++ b/src/components/exchange/ExchangeAssetList.js
@@ -4,8 +4,7 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { Alert } from 'react-native';
-import { SectionList } from 'react-native-gesture-handler';
+import { Alert, SectionList } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import styled from 'styled-components';
 import { usePrevious } from '../../hooks';


### PR DESCRIPTION
We don't need this imported from RNGH and changing this fixes the issue