### PR TITLE
fix charts

### DIFF
--- a/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
@@ -11,6 +11,8 @@ import { useRatio } from './useRatio';
 import { useChartData } from '@rainbow-me/animated-charts';
 import { fonts, fontWithWidth } from '@rainbow-me/styles';
 
+Animated.addWhitelistedNativeProps({ color: true });
+
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 const PercentLabel = styled(AnimatedTextInput)`

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
@@ -25,6 +25,20 @@ const PercentLabel = styled(AnimatedTextInput)`
   ${android && `margin-vertical: -19px;`}
 `;
 
+function formatNumber(num) {
+  'worklet';
+  const first = num.split('.');
+  const digits = first[0].split('').reverse();
+  const newDigits = [];
+  for (let i = 0; i < digits.length; i++) {
+    newDigits.push(digits[i]);
+    if ((i + 1) % 3 === 0 && i !== digits.length - 1) {
+      newDigits.push(',');
+    }
+  }
+  return newDigits.reverse().join('') + '.' + first[1];
+}
+
 export default function ChartPercentChangeLabel() {
   const { originalY, data } = useChartData();
   const { colors } = useTheme();
@@ -47,10 +61,7 @@ export default function ChartPercentChangeLabel() {
           return (
             (android ? '' : value > 0 ? '↑' : value < 0 ? '↓' : '') +
             ' ' +
-            Math.abs(value).toLocaleString(undefined, {
-              maximumFractionDigits: 2,
-              minimumFractionDigits: 2,
-            }) +
+            formatNumber(Math.abs(value).toFixed(2)) +
             '%'
           );
         })();
@@ -72,11 +83,7 @@ export default function ChartPercentChangeLabel() {
               return (
                 (android ? '' : value > 0 ? '↑' : value < 0 ? '↓' : '') +
                 ' ' +
-                Math.abs(value).toLocaleString(undefined, {
-                  maximumFractionDigits: 2,
-                  minimumFractionDigits: 2,
-                }) +
-                '%'
+                formatNumber(Math.abs(value).toFixed(2))
               );
             })()
           : '',

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
@@ -47,7 +47,10 @@ export default function ChartPercentChangeLabel() {
           return (
             (android ? '' : value > 0 ? '↑' : value < 0 ? '↓' : '') +
             ' ' +
-            Math.abs(value).toFixed(2) +
+            Math.abs(value).toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+              minimumFractionDigits: 2,
+            }) +
             '%'
           );
         })();
@@ -69,7 +72,10 @@ export default function ChartPercentChangeLabel() {
               return (
                 (android ? '' : value > 0 ? '↑' : value < 0 ? '↓' : '') +
                 ' ' +
-                Math.abs(value).toFixed(2) +
+                Math.abs(value).toLocaleString(undefined, {
+                  maximumFractionDigits: 2,
+                  minimumFractionDigits: 2,
+                }) +
                 '%'
               );
             })()

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
@@ -55,29 +55,25 @@ export default function ChartPercentChangeLabel() {
     lastValue.value = data?.points?.[data.points.length - 1]?.y;
   }, [data, firstValue, lastValue]);
 
-  const textProps = useAnimatedStyle(
-    () => {
-      return {
-        text:
-          firstValue.value === Number(firstValue.value) && firstValue.value
-            ? (() => {
-                const value =
-                  ((originalY.value || lastValue.value) / firstValue.value) *
-                    100 -
-                  100;
-                return (
-                  (android ? '' : value > 0 ? '↑' : value < 0 ? '↓' : '') +
-                  ' ' +
-                  Math.abs(value).toFixed(2) +
-                  '%'
-                );
-              })()
-            : '',
-      };
-    },
-    [],
-    'ChartPercentChangeLabelTextProps'
-  );
+  const textProps = useAnimatedStyle(() => {
+    return {
+      text:
+        firstValue.value === Number(firstValue.value) && firstValue.value
+          ? (() => {
+              const value =
+                ((originalY.value || lastValue.value) / firstValue.value) *
+                  100 -
+                100;
+              return (
+                (android ? '' : value > 0 ? '↑' : value < 0 ? '↓' : '') +
+                ' ' +
+                Math.abs(value).toFixed(2) +
+                '%'
+              );
+            })()
+          : '',
+    };
+  }, []);
 
   const ratio = useRatio();
 

--- a/src/components/expanded-state/chart/chart-data-labels/useRatio.js
+++ b/src/components/expanded-state/chart/chart-data-labels/useRatio.js
@@ -1,18 +1,24 @@
+import { useEffect } from 'react';
 import { useDerivedValue, useSharedValue } from 'react-native-reanimated';
 import { useChartData } from '@rainbow-me/animated-charts';
-
-export function useRatio(name) {
+function useReactiveSharedValue(prop) {
+  const sharedValue = useSharedValue(prop);
+  useEffect(() => {
+    sharedValue.value = prop;
+  }, [sharedValue, prop]);
+  return sharedValue;
+}
+export function useRatio() {
   const { originalY, data } = useChartData();
 
-  const firstValue = useSharedValue(data?.points?.[0]?.y);
-  const lastValue = useSharedValue(data?.points?.[data.points.length - 1]?.y);
+  const firstValue = useReactiveSharedValue(data?.points?.[0]?.y);
+  const lastValue = useReactiveSharedValue(
+    data?.points?.[data.points.length - 1]?.y
+  );
 
-  return useDerivedValue(
-    () =>
-      firstValue.value === Number(firstValue.value)
-        ? (originalY.value || lastValue.value) / firstValue.value
-        : 1,
-    [],
-    name ? 'ratio_' + name : undefined
+  return useDerivedValue(() =>
+    firstValue.value === Number(firstValue.value)
+      ? (originalY.value || lastValue.value) / firstValue.value
+      : 1
   );
 }

--- a/src/react-native-animated-charts/src/charts/linear/ChartLabels.js
+++ b/src/react-native-animated-charts/src/charts/linear/ChartLabels.js
@@ -11,22 +11,14 @@ const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 function ChartLabelFactory(style) {
   return function ChartLabel({ format, ...props }) {
     const { [style]: val = 0 } = useContext(ChartContext);
-    const formattedValue = useDerivedValue(
-      () => {
-        return format ? format(val.value) : val.value;
-      },
-      [],
-      style + 'formattedValue'
-    );
-    const textProps = useAnimatedStyle(
-      () => {
-        return {
-          text: formattedValue.value,
-        };
-      },
-      [],
-      style + 'textProps'
-    );
+    const formattedValue = useDerivedValue(() => {
+      return format ? format(val.value) : val.value;
+    }, []);
+    const textProps = useAnimatedStyle(() => {
+      return {
+        text: formattedValue.value,
+      };
+    }, []);
     return (
       <AnimatedTextInput
         {...props}

--- a/src/react-native-animated-charts/src/charts/linear/ChartPathProvider.js
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPathProvider.js
@@ -13,8 +13,7 @@ export default function ChartPathProvider({ data: providedData, children }) {
         { scale: values.dotScale.value },
       ],
     }),
-    [],
-    'dotStyle'
+    []
   );
   const [contextReanimatedValue, setContextValue] = useState({});
   const contextValue = useMemo(

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -289,8 +289,6 @@ export const emitAssetInfoRequest = () => (dispatch, getState) => {
   }, ASSET_INFO_TIMEOUT);
 };
 
-const chartsListened = {};
-
 export const emitChartsRequest = (
   assetAddress,
   chartType = DEFAULT_CHART_TYPE
@@ -311,13 +309,7 @@ export const emitChartsRequest = (
     assetCodes = concat(assetAddresses, lpTokenAddresses, DPI_ADDRESS);
   }
 
-  const newAssetsCodes = assetCodes.filter(code => !chartsListened[code]);
-  newAssetsCodes.forEach(code => (chartsListened[code] = true));
-  if (newAssetsCodes.length > 0) {
-    assetsSocket.emit(
-      ...chartsRetrieval(newAssetsCodes, nativeCurrency, chartType)
-    );
-  }
+  assetsSocket.emit(...chartsRetrieval(assetCodes, nativeCurrency, chartType));
 };
 
 const listenOnAssetMessages = socket => dispatch => {


### PR DESCRIPTION
Fix all charts-related issues

1. Loading state. Requests for charts shouldn't be throttled. It is not a WebSocket subscription (I was thinking that initially while making this change)

2. Fix charts in reanimated-charts. PReviously we were passing the 3rd argument, because of our hacks related to crashes. Now we removed the hack, but passing this is breaking charts.

3. Then removed this 3rd argument also from one label. It was causing a terrible performance drop.  

While reviewing, please hide whitespace changes: https://github.com/rainbow-me/rainbow/pull/1724/files?diff=split&w=1. My PR is actually not that severe as it may appear to be. 