### PR TITLE
Gas padding

### DIFF
--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -122,7 +122,7 @@ export const estimateGasWithPadding = async (
     const { to, data } = txPayloadToEstimate;
     // 1 - Check if the receiver is a contract
     const code = to ? await web3Provider.getCode(to) : undefined;
-    // 2 - if it's not a contract or it doesn't have any data use the default gas limit
+    // 2 - if it's not a contract AND it doesn't have any data use the default gas limit
     if (!to || (to && !data && (!code || code === '0x'))) {
       logger.log(
         '⛽ Skipping estimates, using default',

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -11,13 +11,17 @@ import { INFURA_PROJECT_ID, INFURA_PROJECT_ID_DEV } from 'react-native-dotenv';
 import AssetTypes from '../helpers/assetTypes';
 import NetworkTypes from '../helpers/networkTypes';
 import {
+  addBuffer,
   convertAmountToRawAmount,
   convertStringToHex,
+  fraction,
+  greaterThan,
   handleSignificantDecimals,
   multiply,
 } from '../helpers/utilities';
 import smartContractMethods from '../references/smartcontract-methods.json';
 import { ethereumUtils } from '../utils';
+import { ethUnits } from '@rainbow-me/references';
 import logger from 'logger';
 
 const infuraProjectId = __DEV__ ? INFURA_PROJECT_ID_DEV : INFURA_PROJECT_ID;
@@ -104,6 +108,59 @@ export const estimateGas = async estimateGasData => {
     const gasLimit = await web3Provider.estimateGas(estimateGasData);
     return gasLimit.toString();
   } catch (error) {
+    return null;
+  }
+};
+
+export const estimateGasWithPadding = async (
+  txPayload,
+  paddingFactor = 1.1
+) => {
+  try {
+    const txPayloadToEstimate = { ...txPayload };
+    const { gasLimit } = await web3Provider.getBlock();
+    const { to, data } = txPayloadToEstimate;
+    // 1 - Check if the receiver is a contract
+    const code = to ? await web3Provider.getCode(to) : undefined;
+    // 2 - if it's not a contract or it doesn't have any data use the default gas limit
+    if (!to || (to && !data && (!code || code === '0x'))) {
+      logger.log(
+        '⛽ Skipping estimates, using default',
+        ethUnits.basic_tx.toString()
+      );
+      return ethUnits.basic_tx.toString();
+    }
+    logger.log('⛽ Calculating safer gas limit for last block');
+    // 3 - If it is a contract, call the RPC method `estimateGas` with a safe value
+    const saferGasLimit = fraction(gasLimit.toString(), 19, 20);
+    logger.log('⛽ safer gas limit for last block is', saferGasLimit);
+
+    txPayloadToEstimate.gas = toHex(saferGasLimit);
+    const estimatedGas = await web3Provider.estimateGas(txPayloadToEstimate);
+
+    const lastBlockGasLimit = addBuffer(gasLimit.toString(), 0.9);
+    const paddedGas = addBuffer(estimatedGas.toString(), paddingFactor);
+    logger.log('⛽ GAS CALCULATIONS!', {
+      estimatedGas: estimatedGas.toString(),
+      gasLimit: gasLimit.toString(),
+      lastBlockGasLimit: lastBlockGasLimit,
+      paddedGas: paddedGas,
+    });
+    // If the safe estimation is above the last block gas limit, use it
+    if (greaterThan(estimatedGas, lastBlockGasLimit)) {
+      logger.log('⛽ USING orginal gas estimation', estimatedGas.toString());
+      return estimatedGas.toString();
+    }
+    // If the estimation is below the last block gas limit, use the padded estimate
+    if (greaterThan(lastBlockGasLimit, paddedGas)) {
+      logger.log('⛽ USING padded gas estimation', paddedGas);
+      return paddedGas;
+    }
+    // otherwise default to the last block gas limit
+    logger.log('⛽ USING last block gas limit', lastBlockGasLimit);
+    return lastBlockGasLimit;
+  } catch (error) {
+    logger.error('Error calculating gas limit with padding', error);
     return null;
   }
 };
@@ -296,12 +353,10 @@ export const getDataForNftTransfer = (from, to, asset) => {
  * @param {Object} [{selected, address, recipient, amount, gasPrice}]
  * @return {String}
  */
-export const estimateGasLimit = async ({
-  asset,
-  address,
-  recipient,
-  amount,
-}) => {
+export const estimateGasLimit = async (
+  { asset, address, recipient, amount },
+  addPadding = false
+) => {
   const _amount =
     amount && Number(amount)
       ? convertAmountToRawAmount(amount, asset.decimals)
@@ -331,5 +386,9 @@ export const estimateGasLimit = async ({
       value: '0x0',
     };
   }
-  return estimateGas(estimateGasData);
+  if (addPadding) {
+    return estimateGasWithPadding(estimateGasData);
+  } else {
+    return estimateGas(estimateGasData);
+  }
 };

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -139,7 +139,10 @@ export const estimateGasWithPadding = async (
     const estimatedGas = await web3Provider.estimateGas(txPayloadToEstimate);
 
     const lastBlockGasLimit = addBuffer(gasLimit.toString(), 0.9);
-    const paddedGas = addBuffer(estimatedGas.toString(), paddingFactor);
+    const paddedGas = addBuffer(
+      estimatedGas.toString(),
+      paddingFactor.toString()
+    );
     logger.log('⛽ GAS CALCULATIONS!', {
       estimatedGas: estimatedGas.toString(),
       gasLimit: gasLimit.toString(),
@@ -148,16 +151,19 @@ export const estimateGasWithPadding = async (
     });
     // If the safe estimation is above the last block gas limit, use it
     if (greaterThan(estimatedGas, lastBlockGasLimit)) {
-      logger.log('⛽ USING orginal gas estimation', estimatedGas.toString());
+      logger.log(
+        '⛽ returning orginal gas estimation',
+        estimatedGas.toString()
+      );
       return estimatedGas.toString();
     }
     // If the estimation is below the last block gas limit, use the padded estimate
     if (greaterThan(lastBlockGasLimit, paddedGas)) {
-      logger.log('⛽ USING padded gas estimation', paddedGas);
+      logger.log('⛽ returning padded gas estimation', paddedGas);
       return paddedGas;
     }
     // otherwise default to the last block gas limit
-    logger.log('⛽ USING last block gas limit', lastBlockGasLimit);
+    logger.log('⛽ returning last block gas limit', lastBlockGasLimit);
     return lastBlockGasLimit;
   } catch (error) {
     logger.error('Error calculating gas limit with padding', error);

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -168,7 +168,7 @@ export const fraction = (
   numerator: BigNumberish,
   denominator: BigNumberish
 ): string => {
-  if (!(target || numerator || denominator)) return '0';
+  if (!target || !numerator || !denominator) return '0';
   return new BigNumber(target)
     .times(numerator)
     .dividedBy(denominator)

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -163,6 +163,18 @@ export const divide = (
   return new BigNumber(numberOne).dividedBy(numberTwo).toFixed();
 };
 
+export const fraction = (
+  target: BigNumberish,
+  numerator: BigNumberish,
+  denominator: BigNumberish
+): string => {
+  if (!(target || numerator || denominator)) return '0';
+  return new BigNumber(target)
+    .times(numerator)
+    .dividedBy(denominator)
+    .toFixed(0);
+};
+
 /**
  * @desc convert to asset amount units from native price value units
  * @param  {String}   value

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -305,12 +305,16 @@ export default function SendSheet(props) {
     // Attempt to update gas limit before sending ERC20 / ERC721
     if (selected?.address !== ETH_ADDRESS) {
       try {
-        updatedGasLimit = await estimateGasLimit({
-          address: accountAddress,
-          amount: amountDetails.assetAmount,
-          asset: selected,
-          recipient,
-        });
+        // Estimate the tx with gas limit padding before sending
+        updatedGasLimit = await estimateGasLimit(
+          {
+            address: accountAddress,
+            amount: amountDetails.assetAmount,
+            asset: selected,
+            recipient,
+          },
+          true
+        );
         logger.log('gasLimit updated before sending', {
           after: updatedGasLimit,
           before: gasLimit,

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -42,7 +42,7 @@ import {
   MessageSigningSection,
   TransactionConfirmationSection,
 } from '../components/transaction';
-import { estimateGas, toHex } from '../handlers/web3';
+import { estimateGas, estimateGasWithPadding, toHex } from '../handlers/web3';
 import { isDappAuthenticated } from '../helpers/dappNameHandler';
 import {
   convertAmountToNativeDisplay,
@@ -418,7 +418,8 @@ const TransactionConfirmationScreen = () => {
 
     if (isNil(gas) && isNil(gasLimitFromPayload)) {
       try {
-        const rawGasLimit = await estimateGas(txPayload);
+        // Estimate the tx with gas limit padding before sending
+        const rawGasLimit = await estimateGasWithPadding(txPayload);
         gas = toHex(rawGasLimit);
       } catch (error) {
         logger.log('error estimating gas', error);

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -436,10 +436,7 @@ const TransactionConfirmationScreen = () => {
         (isNil(gas) && isNil(gasLimitFromPayload)) ||
         (!isNil(gas) && greaterThan(rawGasLimit, convertHexToString(gas))) ||
         (!isNil(gasLimitFromPayload) &&
-          greaterThanOrEqualTo(
-            rawGasLimit,
-            convertHexToString(gasLimitFromPayload)
-          ))
+          greaterThan(rawGasLimit, convertHexToString(gasLimitFromPayload)))
       ) {
         logger.log('⛽ using padded estimation!', rawGasLimit.toString());
         gas = toHex(rawGasLimit);

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -42,7 +42,6 @@ import {
   MessageSigningSection,
   TransactionConfirmationSection,
 } from '../components/transaction';
-import { estimateGas, estimateGasWithPadding, toHex } from '../handlers/web3';
 import { isDappAuthenticated } from '../helpers/dappNameHandler';
 import {
   convertAmountToNativeDisplay,
@@ -72,6 +71,11 @@ import {
   SIGN,
   SIGN_TYPED_DATA,
 } from '../utils/signingMethods';
+import {
+  estimateGas,
+  estimateGasWithPadding,
+  toHex,
+} from '@rainbow-me/handlers/web3';
 import {
   useAccountAssets,
   useAccountProfile,

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -418,13 +418,14 @@ const TransactionConfirmationScreen = () => {
     }
 
     try {
-      // Estimate the tx with gas limit padding before sending
       logger.log('⛽ gas suggested by dapp', {
         gas: convertHexToString(gas),
         gasLimitFromPayload: convertHexToString(gasLimitFromPayload),
       });
 
+      // Estimate the tx with gas limit padding before sending
       const rawGasLimit = await estimateGasWithPadding(txPayload);
+
       // If the estimation with padding is higher or gas limit was missing,
       // let's use the higher value
       if (


### PR DESCRIPTION
Before sending a tx, attempt to estimate gas and add 10% padding (WC & Send ERC20 / Collectibles)
For WC: If a dapp suggested a price, use whichever is higher.

Note: This doesn't affect the estimate that we show to the user
