### PR TITLE
Fix displaying pools shorter than 30 days

### DIFF
--- a/src/components/discover-sheet/UniswapPoolsSection.js
+++ b/src/components/discover-sheet/UniswapPoolsSection.js
@@ -118,7 +118,9 @@ export default function UniswapPools() {
   const pairRows = useMemo(() => {
     if (!pairs) return [];
 
-    let sortedPairs = sortBy(pairs, selectedList);
+    let sortedPairs = sortBy(pairs, selectedList).filter(
+      pair => selectedList !== 'profit30d' || pair.profit30d !== undefined
+    );
     if (sortDirection === 'desc') {
       sortedPairs = sortedPairs.reverse();
     }

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -306,6 +306,9 @@ export const calculateProfit30d = (
 ) => {
   const now = calculateLPTokenPrice(data, ethPriceNow);
 
+  if (valueOneMonthAgo === undefined) {
+    return undefined;
+  }
   const oneMonthAgo = calculateLPTokenPrice(
     valueOneMonthAgo,
     ethPriceOneMonthAgo


### PR DESCRIPTION
Look like it's breaking for pools shorter than 30 days (e.g. Interest Bearing ETH - USDC).
![image](https://user-images.githubusercontent.com/25709300/108182962-4079b480-7112-11eb-8b62-c95025c29dc5.png)

and then pools were not displayed at all for me.

So I believe for those pools there is no way to display them on this card. I set `profit30d` to `undefined` and I added logic for filtering them. 

![image](https://user-images.githubusercontent.com/25709300/108183597-e88f7d80-7112-11eb-8810-b6a4382a9024.png)




