### PR TITLE
Always use curated list

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -56,13 +56,13 @@ export const UNISWAP_PRICES_QUERY = gql`
 `;
 
 export const UNISWAP_ALL_TOKENS = gql`
-  query tokens($first: Int!, $skip: Int!) {
+  query tokens($excluded: [String]!, $first: Int!, $skip: Int!) {
     tokens(
       first: $first
       skip: $skip
       orderBy: totalLiquidity
       orderDirection: desc
-      where: { totalLiquidity_gt: 0 }
+      where: { id_not_in: $excluded, totalLiquidity_gt: 0 }
     ) {
       id
       derivedETH

--- a/src/references/uniswap/rainbow-token-list.json
+++ b/src/references/uniswap/rainbow-token-list.json
@@ -1,11 +1,11 @@
 {
   "name": "Rainbow Token List",
-  "timestamp": "2021-01-11T20:28:47.371Z",
+  "timestamp": "2021-02-19T03:10:02.304Z",
   "logoURI": "https://avatars0.githubusercontent.com/u/48327834?s=200&v=4",
   "version": {
     "major": 1,
     "minor": 2,
-    "patch": 0
+    "patch": 1
   },
   "keywords": [
     "rainbow"
@@ -81,6 +81,8 @@
       "name": "1inch",
       "symbol": "1INCH",
       "extensions": {
+        "color": "#21324D",
+        "isRainbowCurated": true,
         "isVerified": true
       }
     },
@@ -245,6 +247,13 @@
       "symbol": "A18"
     },
     {
+      "address": "0xe8272210954eA85DE6D2Ae739806Ab593B5d9c51",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Alpha5",
+      "symbol": "A5T"
+    },
+    {
       "address": "0xFFC97d72E13E01096502Cb8Eb52dEe56f74DAD7B",
       "chainId": 1,
       "decimals": 18,
@@ -352,13 +361,6 @@
       "decimals": 18,
       "name": "ABPT Crypto",
       "symbol": "ABPT"
-    },
-    {
-      "address": "0xF4c05296c449EDcEe3E3f1524faC919510B168A2",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Absorber",
-      "symbol": "ABS"
     },
     {
       "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
@@ -520,7 +522,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Akropolis Delphi",
-      "symbol": "ADEL"
+      "symbol": "ADEL",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xE69a353b3152Dd7b706ff7dD40fe1d18b7802d31",
@@ -1000,7 +1005,7 @@
       "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
       "chainId": 1,
       "decimals": 18,
-      "name": "Alpha Finance",
+      "name": "Alpha Finance Lab",
       "symbol": "ALPHA",
       "extensions": {
         "isVerified": true
@@ -1293,7 +1298,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "API3",
-      "symbol": "API3"
+      "symbol": "API3",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x4C0fBE1BB46612915E7967d2C3213cd4d87257AD",
@@ -1455,7 +1463,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Arianee",
-      "symbol": "ARIA20"
+      "symbol": "ARIA20",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xA9248F8e40d4b9c3Ca8ebd8E07E9BCB942C616d8",
@@ -1466,6 +1477,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x1337DEF16F9B486fAEd0293eb623Dc8395dFE46a",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "ARMOR",
+      "symbol": "ARMOR"
     },
     {
       "address": "0xBA5F11b16B155792Cf3B2E6880E8706859A8AEB6",
@@ -1484,6 +1502,13 @@
       "decimals": 18,
       "name": "Aeron",
       "symbol": "ARNX"
+    },
+    {
+      "address": "0x1337DEF18C680aF1f9f45cBcab6309562975b1dD",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Armor NXM",
+      "symbol": "ARNXM"
     },
     {
       "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
@@ -1506,8 +1531,15 @@
       "address": "0x34612903Db071e888a4dADcaA416d3EE263a87b9",
       "chainId": 1,
       "decimals": 18,
-      "name": "ethArt",
+      "name": "Items",
       "symbol": "ARTE"
+    },
+    {
+      "address": "0x0E3cC2c4FB9252d17d07C67135E48536071735D9",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "ARTH",
+      "symbol": "ARTH"
     },
     {
       "address": "0x7705FaA34B16EB6d77Dfc7812be2367ba6B0248e",
@@ -1569,6 +1601,16 @@
         "color": "#25292E",
         "isVerified": true,
         "shadowColor": "#7285B2"
+      }
+    },
+    {
+      "address": "0xFA2562da1Bba7B954f26C74725dF51fb62646313",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "ASSY Index",
+      "symbol": "ASSY",
+      "extensions": {
+        "isVerified": true
       }
     },
     {
@@ -2021,6 +2063,13 @@
       "symbol": "AVA"
     },
     {
+      "address": "0x94d916873B22C9C1b53695f1c002F78537B9b3b2",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "AlgoVest",
+      "symbol": "AVS"
+    },
+    {
       "address": "0x0d88eD6E74bbFD96B831231638b66C05571e824F",
       "chainId": 1,
       "decimals": 18,
@@ -2198,11 +2247,25 @@
       "symbol": "AZUKI"
     },
     {
+      "address": "0xc4De189Abf94c57f396bD4c52ab13b954FebEfD8",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "B20",
+      "symbol": "B20"
+    },
+    {
       "address": "0x5d51FCceD3114A8bb5E90cDD0f9d682bCbCC5393",
       "chainId": 1,
       "decimals": 18,
       "name": "B2BX",
       "symbol": "B2BX"
+    },
+    {
+      "address": "0xC36824905dfF2eAAEE7EcC09fCC63abc0af5Abc5",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Basis Bond",
+      "symbol": "BAB"
     },
     {
       "address": "0x062e3Be6a7C56A395b1881A0cD69A4923Ade4fa2",
@@ -2272,6 +2335,13 @@
       "symbol": "BALI"
     },
     {
+      "address": "0xf56842Af3B56Fd72d17cB103f92d027bBa912e89",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "BambooDeFi",
+      "symbol": "BAMBOO"
+    },
+    {
       "address": "0x21F54372c07B930B79c5c2d9bb0EAACa86c3b298",
       "chainId": 1,
       "decimals": 18,
@@ -2335,7 +2405,7 @@
       "symbol": "BAS"
     },
     {
-      "address": "0xa7ED29B253D8B4E3109ce07c80fc570f81B63696",
+      "address": "0x106538CC16F938776c7c180186975BCA23875287",
       "chainId": 1,
       "decimals": 18,
       "name": "Basis Share",
@@ -2452,6 +2522,20 @@
       "decimals": 18,
       "name": "Bigbom",
       "symbol": "BBO"
+    },
+    {
+      "address": "0xbb0A009ba1EB20c5062C790432f080F6597662AF",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Bitbot Protocol",
+      "symbol": "BBP"
+    },
+    {
+      "address": "0x7671904eed7f10808B664fc30BB8693FD7237abF",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Bitberry Token",
+      "symbol": "BBR"
     },
     {
       "address": "0x70460c3Bb9AbcC0aA51f922c00d37816d6EDe4D7",
@@ -2596,13 +2680,6 @@
       "symbol": "BD"
     },
     {
-      "address": "0x6a4FFAafa8DD400676Df8076AD6c724867b0e2e8",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "bDAI",
-      "symbol": "BDAI"
-    },
-    {
       "address": "0x1961B3331969eD52770751fC718ef530838b6dEE",
       "chainId": 1,
       "decimals": 18,
@@ -2634,6 +2711,13 @@
       "symbol": "BDT"
     },
     {
+      "address": "0x7BCe667EF12023dc5f8577D015a2F09d99a5ef58",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Block Duelers",
+      "symbol": "BDT"
+    },
+    {
       "address": "0x016ee7373248a80BDe1fD6bAA001311d233b3CFa",
       "chainId": 1,
       "decimals": 18,
@@ -2645,7 +2729,17 @@
       "chainId": 1,
       "decimals": 4,
       "name": "arcane bear",
-      "symbol": "BEAR"
+      "symbol": "BEAR",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0xdBB2F12CB89Af05516768C2c69A771D92A25D17c",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Beast DAO",
+      "symbol": "BEAST"
     },
     {
       "address": "0x2Fb12bccF6f5Dd338b76Be784A93ade072425690",
@@ -2693,6 +2787,13 @@
       "symbol": "BEFX"
     },
     {
+      "address": "0xFBcECb002177e530695B8976638fBd18d2038C3C",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "Belifex",
+      "symbol": "BEFX"
+    },
+    {
       "address": "0xA91ac63D040dEB1b7A5E4d4134aD23eb0ba07e14",
       "chainId": 1,
       "decimals": 18,
@@ -2714,11 +2815,8 @@
       "address": "0xCF3C8Be2e2C42331Da80EF210e9B1b307C03d36A",
       "chainId": 1,
       "decimals": 18,
-      "name": "BetProtocol",
-      "symbol": "BEPRO",
-      "extensions": {
-        "isVerified": true
-      }
+      "name": "BEPRO Network",
+      "symbol": "BEPRO"
     },
     {
       "address": "0x6aEB95F06CDA84cA345c2dE0F3B7f96923a44f4c",
@@ -2796,7 +2894,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Bifrost",
-      "symbol": "BFC"
+      "symbol": "BFC",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x8E16bf47065Fe843A82f4399bAF5aBac4E0822B7",
@@ -2807,6 +2908,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0xf680429328caaaCabee69b7A9FdB21a71419c063",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Butterfly Protocol",
+      "symbol": "BFLY"
     },
     {
       "address": "0x244c5276Ea5bB927575417156038d7381b44Ab2c",
@@ -2854,13 +2962,6 @@
       "symbol": "BHR"
     },
     {
-      "address": "0x5b5bB9765eff8D26c24B9FF0DAa09838a3Cd78E9",
-      "chainId": 1,
-      "decimals": 4,
-      "name": "Bitanium",
-      "symbol": "BI"
-    },
-    {
       "address": "0x25e1474170c4c0aA64fa98123bdc8dB49D7802fa",
       "chainId": 1,
       "decimals": 18,
@@ -2873,6 +2974,16 @@
       "decimals": 18,
       "name": "DeFi Bids",
       "symbol": "BID"
+    },
+    {
+      "address": "0x2791BfD60D232150Bff86b39B7146c0eaAA2BA81",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "BiFi",
+      "symbol": "BIFI",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xa6E7dc135Bdf4b3FEe7183EAB2E87C0BB9684783",
@@ -2932,6 +3043,13 @@
       "decimals": 8,
       "name": "BITPARK",
       "symbol": "BITPARK"
+    },
+    {
+      "address": "0x9F9913853f749b3fE6D6D4e16a1Cc3C1656B6D51",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "BITToken",
+      "symbol": "BITT"
     },
     {
       "address": "0x55a290f08Bb4CAe8DcF1Ea5635A3FCfd4Da60456",
@@ -3028,6 +3146,20 @@
       "symbol": "BLC"
     },
     {
+      "address": "0x417fFdBc285dd2C4dC00937798ab901634137caA",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "BlackFisk",
+      "symbol": "BLFI"
+    },
+    {
+      "address": "0x50d2dE5397D7c657C3d424634a2dDf4e0D73d789",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Bliss",
+      "symbol": "BLISS"
+    },
+    {
       "address": "0xCA29db4221c111888a7e80b12eAc8a266Da3Ee0d",
       "chainId": 1,
       "decimals": 18,
@@ -3096,6 +3228,16 @@
       "symbol": "BLX (Iconomi)"
     },
     {
+      "address": "0xf8aD7dFe656188A23e89da09506Adf7ad9290D5d",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Blocery",
+      "symbol": "BLY",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
       "chainId": 1,
       "decimals": 18,
@@ -3118,6 +3260,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x725C263e32c72dDC3A19bEa12C5a0479a81eE688",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Bridge Mutual",
+      "symbol": "BMI"
     },
     {
       "address": "0x5913D0F34615923552ee913DBe809F9F348e706E",
@@ -3404,8 +3553,15 @@
       "address": "0x5bEaBAEBB3146685Dd74176f68a0721F91297D37",
       "chainId": 1,
       "decimals": 18,
-      "name": "Bounce Token",
+      "name": "Bounce",
       "symbol": "BOT"
+    },
+    {
+      "address": "0xf9FBE825BFB2bF3E387af0Dc18caC8d87F29DEa8",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Bot Ocean",
+      "symbol": "BOTS"
     },
     {
       "address": "0xC2C63F23ec5E97efbD7565dF9Ec764FDc7d4e91d",
@@ -3561,6 +3717,13 @@
       "symbol": "BRP"
     },
     {
+      "address": "0xF0ACF8949e705E0ebb6CB42c2164B0B986454223",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "Barter",
+      "symbol": "BRTR"
+    },
+    {
       "address": "0x3A4A0D5b8dfAcd651EE28ed4fFEBf91500345489",
       "chainId": 1,
       "decimals": 18,
@@ -3585,6 +3748,27 @@
       "symbol": "BSC"
     },
     {
+      "address": "0x003e0af2916e598Fa5eA5Cb2Da4EDfdA9aEd9Fde",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Basis Dollar",
+      "symbol": "BSD",
+      "extensions": {
+        "color": "#000000",
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x9f48b2f14517770F2d238c787356F3b961a6616F",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Basis Dollar Bond",
+      "symbol": "BSDB",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xF26ef5E0545384b7Dcc0f297F2674189586830DF",
       "chainId": 1,
       "decimals": 18,
@@ -3592,11 +3776,35 @@
       "symbol": "BSDC"
     },
     {
+      "address": "0xE7C9C188138f7D70945D420d75F8Ca7d8ab9c700",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Basis Dollar Share",
+      "symbol": "BSDS",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xA30189d8255322A2F8B2a77906B000aeB005570c",
       "chainId": 1,
       "decimals": 18,
       "name": "Buy Sell",
       "symbol": "BSE"
+    },
+    {
+      "address": "0xB34Ab2f65c6e4F764fFe740ab83F982021Faed6d",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Basis Gold",
+      "symbol": "BSG"
+    },
+    {
+      "address": "0xA9d232cC381715aE791417B624D7C4509D2c28DB",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Basis Gold Share",
+      "symbol": "BSGS"
     },
     {
       "address": "0x26946adA5eCb57f3A1F91605050Ce45c482C9Eb1",
@@ -3618,6 +3826,13 @@
       "decimals": 18,
       "name": "Bitsten Token",
       "symbol": "BST"
+    },
+    {
+      "address": "0x76c5449F4950f6338A393F53CdA8b53B0cd3Ca3a",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "BT Finance",
+      "symbol": "BT"
     },
     {
       "address": "0x06e0feB0D74106c7adA8497754074D222Ec6BCDf",
@@ -3944,6 +4159,13 @@
       "symbol": "BXIOT"
     },
     {
+      "address": "0x008377EB0C62cE8e0BA3D7Bb4A5638591f21588E",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "YFLink Bond",
+      "symbol": "bYFL"
+    },
+    {
       "address": "0x4375E7aD8A01B8eC3Ed041399f62D9Cd120e0063",
       "chainId": 1,
       "decimals": 18,
@@ -3975,6 +4197,16 @@
       }
     },
     {
+      "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+      "chainId": 1,
+      "decimals": 0,
+      "name": "CryptoPunks",
+      "symbol": "C",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x000C100050E98C91f9114fa5Dd75CE6869Bf4F53",
       "chainId": 1,
       "decimals": 18,
@@ -3997,13 +4229,6 @@
       "extensions": {
         "isVerified": true
       }
-    },
-    {
-      "address": "0xe2b8C4938A3103C1Ab5c19a6B93d07AB6f9dA2ba",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Convertible ACXT",
-      "symbol": "CACXT"
     },
     {
       "address": "0x7d4b8Cce0591C9044a22ee543533b72E976E36C3",
@@ -4065,7 +4290,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Cap",
-      "symbol": "CAP"
+      "symbol": "CAP",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xEDA6eFE5556e134Ef52f2F858aa1e81c84CDA84b",
@@ -4199,6 +4427,20 @@
       "symbol": "CATs (BitClave)_Old"
     },
     {
+      "address": "0x6E605c269E0C92e70BEeB85486f1fC550f9380BD",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Catex Token",
+      "symbol": "CATT"
+    },
+    {
+      "address": "0x24eA9c1cfD77A8DB3fB707F967309cF013CC1078",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Excavo Finance",
+      "symbol": "CAVO"
+    },
+    {
       "address": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
       "chainId": 1,
       "decimals": 8,
@@ -4214,7 +4456,7 @@
       "address": "0x26DB5439F651CAF491A87d48799dA81F191bDB6b",
       "chainId": 1,
       "decimals": 8,
-      "name": "CashBet Coin",
+      "name": "Casino Betting Coin",
       "symbol": "CBC"
     },
     {
@@ -4268,6 +4510,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x17aC188e09A7890a1844E5E65471fE8b0CcFadF3",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Cryptocurrency Top",
+      "symbol": "CC10"
     },
     {
       "address": "0xc166038705FFBAb3794185b3a9D925632A1DF37D",
@@ -4483,6 +4732,13 @@
       "symbol": "CFTY"
     },
     {
+      "address": "0xAdA0A1202462085999652Dc5310a7A9e2BF3eD42",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "CoinShares Gold and",
+      "symbol": "CGI"
+    },
+    {
       "address": "0xF5238462E7235c7B62811567E63Dd17d12C2EAA0",
       "chainId": 1,
       "decimals": 8,
@@ -4504,7 +4760,11 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Chai",
-      "symbol": "CHAI"
+      "symbol": "CHAI",
+      "extensions": {
+        "color": "#e74b58",
+        "isVerified": true
+      }
     },
     {
       "address": "0xC4C2614E694cF534D407Ee49F8E44D125E4681c4",
@@ -4609,13 +4869,6 @@
       "symbol": "CHSB"
     },
     {
-      "address": "0x792E0FC822Ac6ff5531E46425f13540f1F68A7A8",
-      "chainId": 1,
-      "decimals": 8,
-      "name": "CoinHot",
-      "symbol": "CHT"
-    },
-    {
       "address": "0x1460a58096d80a50a2F1f956DDA497611Fa4f165",
       "chainId": 1,
       "decimals": 18,
@@ -4692,7 +4945,7 @@
       "address": "0x3dC9a42fa7Afe57BE03c58fD7F4411b1E466C508",
       "chainId": 1,
       "decimals": 18,
-      "name": "Attention Mining",
+      "name": "CryptoLiveLeak",
       "symbol": "CLL"
     },
     {
@@ -4718,6 +4971,13 @@
       "decimals": 9,
       "name": "CryptoLending",
       "symbol": "CLP"
+    },
+    {
+      "address": "0x2001f2A0Cf801EcFda622f6C28fb6E10d803D969",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "CoinLoan",
+      "symbol": "CLT"
     },
     {
       "address": "0xa69f7a10dF90C4D6710588Bc18ad9bF08081f545",
@@ -4866,7 +5126,7 @@
       "symbol": "COC"
     },
     {
-      "address": "0x0C6f5F7D555E7518f6841a79436BD2b1Eef03381",
+      "address": "0xc4c7Ea4FAB34BD9fb9a5e1B1a98Df76E26E6407c",
       "chainId": 1,
       "decimals": 18,
       "name": "COCOS BCX",
@@ -4977,6 +5237,13 @@
       "symbol": "COMB"
     },
     {
+      "address": "0xfFffFffF2ba8F66D4e51811C5190992176930278",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Furucombo",
+      "symbol": "COMBO"
+    },
+    {
       "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
       "chainId": 1,
       "decimals": 18,
@@ -5007,7 +5274,7 @@
       "address": "0x74Fb9DA15d4f9a34D8C825798DA0Fa5c400DadE1",
       "chainId": 1,
       "decimals": 18,
-      "name": "Cord DeFi",
+      "name": "CORD Finance",
       "symbol": "CORD"
     },
     {
@@ -5122,13 +5389,6 @@
       "decimals": 8,
       "name": "Circuits of Value",
       "symbol": "COVAL"
-    },
-    {
-      "address": "0x5D8d9F5b96f4438195BE9b99eee6118Ed4304286",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Cover Protocol  old",
-      "symbol": "COVER"
     },
     {
       "address": "0x4688a8b1F292FDaB17E9a90c8Bc379dC1DBd8713",
@@ -5489,6 +5749,20 @@
       "symbol": "CST"
     },
     {
+      "address": "0x196c81385Bc536467433014042788Eb707703934",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "CryptoTask",
+      "symbol": "CTASK"
+    },
+    {
+      "address": "0xFD6C31bb6F05Fc8dB64F4b740Ab758605c271FD8",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Contracoin",
+      "symbol": "CTCN"
+    },
+    {
       "address": "0x4545750F39aF6Be4F237B6869D4EccA928Fd5A85",
       "chainId": 1,
       "decimals": 18,
@@ -5587,6 +5861,13 @@
       "symbol": "CUBE"
     },
     {
+      "address": "0x817bbDbC3e8A1204f3691d14bB44992841e3dB35",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Cudos",
+      "symbol": "CUDOS"
+    },
+    {
       "address": "0x35A18000230DA775CAc24873d00Ff85BccdeD550",
       "chainId": 1,
       "decimals": 8,
@@ -5628,6 +5909,13 @@
       "symbol": "CURE"
     },
     {
+      "address": "0xc2D3AE29c8309c14994D02Ecd228cf86f3Efde77",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "CurrySwap",
+      "symbol": "CURRY"
+    },
+    {
       "address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
       "chainId": 1,
       "decimals": 8,
@@ -5661,7 +5949,7 @@
       "chainId": 1,
       "decimals": 18,
       "name": "carVertical",
-      "symbol": "CV"
+      "symbol": "cV"
     },
     {
       "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
@@ -5693,8 +5981,18 @@
       "address": "0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
       "chainId": 1,
       "decimals": 18,
-      "name": "PowerPool Concentra",
-      "symbol": "CVP"
+      "name": "PowerPool Concentrated Voting Power",
+      "symbol": "CVP",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x3C03b4EC9477809072FF9CC9292C9B25d4A8e6c6",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Polkacover",
+      "symbol": "CVR"
     },
     {
       "address": "0xdB56448fE2635f7912287cd619E7eD3d93180f25",
@@ -5708,6 +6006,13 @@
       "chainId": 1,
       "decimals": 18,
       "name": "CyberVein",
+      "symbol": "CVT"
+    },
+    {
+      "address": "0x88930072F583936F506CE1f1d5Fe69290C2D6A2a",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Civitas Protocol",
       "symbol": "CVT"
     },
     {
@@ -5728,6 +6033,13 @@
       "decimals": 18,
       "name": "Token CWIOS",
       "symbol": "CWIOS"
+    },
+    {
+      "address": "0xaC0104Cca91D167873B8601d2e71EB3D4D8c33e0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Crowns",
+      "symbol": "CWS"
     },
     {
       "address": "0x2134057C0b461F898D375Cead652Acae62b59541",
@@ -5862,6 +6174,16 @@
       }
     },
     {
+      "address": "0x73D9E335669462Cbdd6aa3AdaFe9efeE86a37Fe9",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Daiquilibrium",
+      "symbol": "DAIQ",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x07D9e49Ea402194bf48A8276dAfB16E4eD633317",
       "chainId": 1,
       "decimals": 8,
@@ -5913,6 +6235,13 @@
       }
     },
     {
+      "address": "0xbE3c393Fb670f0A29C3F3E660FFB113200e36676",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Digital Antares Dol",
+      "symbol": "DANT"
+    },
+    {
       "address": "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413",
       "chainId": 1,
       "decimals": 1,
@@ -5920,10 +6249,17 @@
       "symbol": "DAO"
     },
     {
+      "address": "0x0f51bb10119727a7e5eA3538074fb341F56B09Ad",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "DAO Maker",
+      "symbol": "DAO"
+    },
+    {
       "address": "0xD82BB924a1707950903e2C0a619824024e254cD1",
       "chainId": 1,
       "decimals": 18,
-      "name": "DAOFi",
+      "name": "DAOfi",
       "symbol": "DAOFI"
     },
     {
@@ -6018,6 +6354,27 @@
       "symbol": "DBET"
     },
     {
+      "address": "0xaCbeD9726ffd232b59d3CA86a0F5c856E2abEf29",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Debunk",
+      "symbol": "DBNK"
+    },
+    {
+      "address": "0x0C7E25e15E9F6818Fa2770107B3Ba565470bC8c5",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Decentralized Bitco",
+      "symbol": "DBTC"
+    },
+    {
+      "address": "0xC6d19A604FbdB5C2eeB363255FD63c9EEA29288E",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "DarkBundles",
+      "symbol": "DBUND"
+    },
+    {
       "address": "0x386Faa4703a34a7Fdb19Bec2e14Fd427C9638416",
       "chainId": 1,
       "decimals": 18,
@@ -6086,6 +6443,13 @@
       "decimals": 18,
       "name": "DuckDaoDime",
       "symbol": "DDIM"
+    },
+    {
+      "address": "0xF9fbAefdE7112F78fA9BfE813341f0f49f888cB3",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "DDS Store",
+      "symbol": "DDS"
     },
     {
       "address": "0x56CdBbeec9828962cECB3f1b69517d430295D952",
@@ -6173,11 +6537,25 @@
       }
     },
     {
+      "address": "0xfa6de2697D59E88Ed7Fc4dFE5A33daC43565ea41",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "DEFI Top 5 Tokens I",
+      "symbol": "DEFI5"
+    },
+    {
       "address": "0x4eC2eFb9cBd374786A03261E46ffce1a67756f3B",
       "chainId": 1,
       "decimals": 18,
       "name": "Deflacoin",
       "symbol": "DEFL"
+    },
+    {
+      "address": "0x70D47Fd6C9497b11c1cAF0E2A84a5e7661E66C1d",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Defla",
+      "symbol": "DEFLA"
     },
     {
       "address": "0x3Aa5f749d4a6BCf67daC1091Ceb69d1F5D86fA53",
@@ -6232,7 +6610,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "DePay",
-      "symbol": "DEPAY"
+      "symbol": "DEPAY",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x7cF271966F36343Bf0150F25E5364f7961c58201",
@@ -6333,6 +6714,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x0020d80229877b495D2bf3269a4c13f6f1e1B9D3",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Dexmex",
+      "symbol": "DEXM"
     },
     {
       "address": "0x26CE25148832C04f3d7F26F32478a9fe55197166",
@@ -6557,11 +6945,14 @@
       "symbol": "DIE"
     },
     {
-      "address": "0x35a5cB585d51D836922b78A9bb1f5c04635c39b6",
+      "address": "0x798D1bE841a82a273720CE31c822C61a67a601C3",
       "chainId": 1,
-      "decimals": 8,
-      "name": "Decimated",
-      "symbol": "DIO"
+      "decimals": 9,
+      "name": "DIGG",
+      "symbol": "DIGG",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
@@ -6572,6 +6963,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x220B71671b649c03714dA9c621285943f3cbcDC6",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "TosDis",
+      "symbol": "DIS"
     },
     {
       "address": "0x4B4701f3f827E1331fb22FF8e2BEaC24b17Eb055",
@@ -6610,6 +7008,16 @@
       "decimals": 18,
       "name": "Draggin Karma Points",
       "symbol": "DKP"
+    },
+    {
+      "address": "0xcE1d3dA32e3a45d27dC841781f09E40C41CAC677",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Data Link Base",
+      "symbol": "DLB",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x6F3a5DCc36eEee5bd8B9B5Db3B6431187A8F1E17",
@@ -6837,7 +7245,7 @@
       }
     },
     {
-      "address": "0x82b0E50478eeaFde392D45D1259Ed1071B6fDa81",
+      "address": "0xef6344de1fcfC5F48c30234C16c1389e8CdC572C",
       "chainId": 1,
       "decimals": 18,
       "name": "EncrypGen",
@@ -6906,6 +7314,13 @@
       "decimals": 18,
       "name": "Dogeswap",
       "symbol": "DOGES"
+    },
+    {
+      "address": "0x9c405acf8688AfB61B3197421cDeeC1A266c6839",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "DogeYield",
+      "symbol": "DOGY"
     },
     {
       "address": "0x9cEB84f92A0561fa3Cc4132aB9c0b76A59787544",
@@ -6980,6 +7395,13 @@
       "decimals": 18,
       "name": "DOW",
       "symbol": "DOW"
+    },
+    {
+      "address": "0x875353Da48C4f9627c4D0b8B8c37B162fC43ce67",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Digipharm",
+      "symbol": "DPH"
     },
     {
       "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
@@ -7381,14 +7803,20 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Dynamic Supply",
-      "symbol": "DST"
+      "symbol": "DST",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x55696EfC7c9779d868Ac34aC6b4a4C5FeD61aC12",
       "chainId": 1,
       "decimals": 18,
-      "name": "Dynamic Supply Trac",
-      "symbol": "DSTR"
+      "name": "Dynamic Supply Tracker",
+      "symbol": "DSTR",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x3f344C88d823F180Fb8b44A3C7Cfc4edc92dFa35",
@@ -7559,8 +7987,11 @@
       "address": "0x92E187a03B6CD19CB6AF293ba17F2745Fd2357D5",
       "chainId": 1,
       "decimals": 18,
-      "name": "Unit Protocol New",
-      "symbol": "DUCK"
+      "name": "Unit Protocol",
+      "symbol": "DUCK",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x56e0B2C7694E6e10391E870774daA45cf6583486",
@@ -7594,6 +8025,13 @@
       "symbol": "DUST"
     },
     {
+      "address": "0x51e00a95748DBd2a3F47bC5c3b3E7B3F0fea666c",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "DAOventures",
+      "symbol": "DVG"
+    },
+    {
       "address": "0x10633216E7E8281e33c86F02Bf8e565a635D9770",
       "chainId": 1,
       "decimals": 18,
@@ -7620,6 +8058,16 @@
       "decimals": 18,
       "name": "DXdao",
       "symbol": "DXD",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x15Eabb7500E44B7Fdb6e4051cA8DecA430cF9FB8",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Dexfin",
+      "symbol": "DXF",
       "extensions": {
         "isVerified": true
       }
@@ -7703,6 +8151,13 @@
       "decimals": 18,
       "name": "EagleCoin",
       "symbol": "EAGLE"
+    },
+    {
+      "address": "0xB4742e2013f96850a5CeF850A3bB74cF63B9a5D5",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "EANTO",
+      "symbol": "EAN"
     },
     {
       "address": "0x900b4449236a7bb26b286601dD14d2bDe7a6aC6c",
@@ -7804,6 +8259,16 @@
       "decimals": 18,
       "name": "Omnitude",
       "symbol": "ECOM"
+    },
+    {
+      "address": "0xb052F8A33D8bb068414EaDE06AF6955199f9f010",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Ecoreal Estate",
+      "symbol": "ECOREAL",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x8869b1F9bC8B246a4D7220F834E56ddfdd8255E7",
@@ -7971,6 +8436,24 @@
       "symbol": "EL"
     },
     {
+      "address": "0xe6fd75ff38Adca4B97FBCD938c86b98772431867",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "ELA on Ethereum",
+      "symbol": "ELA",
+      "extensions": {
+        "color": "#3fbadf",
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x48bE867B240D2fFafF69e0746130F2c027d8d3d2",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Elevate",
+      "symbol": "ELE"
+    },
+    {
       "address": "0xD49ff13661451313cA1553fd6954BD1d9b6E02b9",
       "chainId": 1,
       "decimals": 18,
@@ -8010,6 +8493,13 @@
       "symbol": "ELT"
     },
     {
+      "address": "0x9048c33c7BaE0bbe9ad702b17B4453a83900D154",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Energy Ledger",
+      "symbol": "ELX"
+    },
+    {
       "address": "0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8",
       "chainId": 1,
       "decimals": 18,
@@ -8028,6 +8518,13 @@
       "chainId": 1,
       "decimals": 8,
       "name": "Emblem",
+      "symbol": "EMB"
+    },
+    {
+      "address": "0xdb0aCC14396D108b3C5574483aCB817855C9dc8d",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "Overline Emblem",
       "symbol": "EMB"
     },
     {
@@ -8370,7 +8867,7 @@
       "address": "0xb1CD6e4153B2a390Cf00A6556b0fC1458C4A5533",
       "chainId": 1,
       "decimals": 18,
-      "name": "Bancor ETH/BNT Liquidity Pool",
+      "name": "ETHBNT Liquidity Pool",
       "symbol": "ETHBNT"
     },
     {
@@ -8379,6 +8876,13 @@
       "decimals": 18,
       "name": "Ethereum Dark",
       "symbol": "ETHD"
+    },
+    {
+      "address": "0xFd09911130e6930Bf87F2B0554c44F400bD80D3e",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "EthicHub",
+      "symbol": "ETHIX"
     },
     {
       "address": "0xbF4a2DdaA16148a9D0fA2093FfAC450ADb7cd4aa",
@@ -8544,6 +9048,13 @@
       "symbol": "EVN"
     },
     {
+      "address": "0x9aF15D7B8776fa296019979E70a5BE53c714A7ec",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Evolution Finance",
+      "symbol": "EVN"
+    },
+    {
       "address": "0x442d985EFeBC633b8Bfd14fF99E860A5609a6484",
       "chainId": 1,
       "decimals": 18,
@@ -8705,6 +9216,13 @@
       "symbol": "FACT"
     },
     {
+      "address": "0xCda2f16C6Aa895D533506B426AFF827b709c87F5",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Fairum",
+      "symbol": "FAI"
+    },
+    {
       "address": "0x190e569bE071F40c704e15825F285481CB74B6cC",
       "chainId": 1,
       "decimals": 12,
@@ -8811,13 +9329,6 @@
       "symbol": "FAT"
     },
     {
-      "address": "0x35F82CAa11C2459E179Bc8102cCE439D77C8Ef25",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Friendcoin007",
-      "symbol": "FC007"
-    },
-    {
       "address": "0x4c6e796Bbfe5EB37F9E3E0f66C009C8Bf2A5f428",
       "chainId": 1,
       "decimals": 6,
@@ -8846,6 +9357,13 @@
       "symbol": "FDZ"
     },
     {
+      "address": "0x389999216860AB8E0175387A0c90E5c52522C945",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "FEG Token",
+      "symbol": "FEG"
+    },
+    {
       "address": "0x4E594479Fa417a1e9C5790a413575802D393010F",
       "chainId": 1,
       "decimals": 8,
@@ -8868,6 +9386,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0xe8E06a5613dC86D459bC8Fb989e173bB8b256072",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Feyorra",
+      "symbol": "FEY"
     },
     {
       "address": "0xca76BAa777d749De63Ca044853D22D56bC70bb47",
@@ -8943,6 +9468,13 @@
       "symbol": "FKX"
     },
     {
+      "address": "0xfFED56a180f23fD32Bc6A1d8d3c09c283aB594A8",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Freeliquid",
+      "symbol": "FL"
+    },
+    {
       "address": "0xB4467E8D621105312a914F1D42f10770C0Ffe3c8",
       "chainId": 1,
       "decimals": 18,
@@ -8993,13 +9525,6 @@
       "decimals": 18,
       "name": "Fire Lotto",
       "symbol": "FLOT"
-    },
-    {
-      "address": "0xC6e64729931f60D2c8Bc70A27D66D9E0c28D1BF9",
-      "chainId": 1,
-      "decimals": 9,
-      "name": "Flow Protocol",
-      "symbol": "FLOW"
     },
     {
       "address": "0x3a1Bda28AdB5B0a812a7CF10A1950c920F79BcD3",
@@ -9134,6 +9659,13 @@
       }
     },
     {
+      "address": "0xA8580F3363684d76055bdC6660CaeFe8709744e1",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Folder Protocol",
+      "symbol": "FOL"
+    },
+    {
       "address": "0x2a093BcF0C98Ef744Bb6F69D74f2F85605324290",
       "chainId": 1,
       "decimals": 8,
@@ -9242,13 +9774,6 @@
       "symbol": "FREE"
     },
     {
-      "address": "0x907cb97615b7cD7320Bc89bb7CDB46e37432eBe7",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Frens Community",
-      "symbol": "FRENS"
-    },
-    {
       "address": "0xE5CAeF4Af8780E59Df925470b050Fb23C43CA68C",
       "chainId": 1,
       "decimals": 6,
@@ -9261,13 +9786,6 @@
       "decimals": 18,
       "name": "FRMx Token",
       "symbol": "FRMX"
-    },
-    {
-      "address": "0xf938c9A22C6Fc9e6b81b24b68dB94B92dc4a7976",
-      "chainId": 1,
-      "decimals": 8,
-      "name": "Frinkcoin",
-      "symbol": "FRNK"
     },
     {
       "address": "0xf8C3527CC04340b208C854E985240c02F7B7793f",
@@ -9425,8 +9943,11 @@
       "address": "0xd559f20296FF4895da39b5bd9ADd54b442596a61",
       "chainId": 1,
       "decimals": 18,
-      "name": "FintruX",
-      "symbol": "FTX"
+      "name": "FintruX Network",
+      "symbol": "FTX",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x41875C2332B0877cDFAA699B641402b7D4642c32",
@@ -9517,6 +10038,13 @@
       "symbol": "FWT"
     },
     {
+      "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "f x  Coin",
+      "symbol": "FX"
+    },
+    {
       "address": "0x4a57E687b9126435a9B19E4A802113e266AdeBde",
       "chainId": 1,
       "decimals": 18,
@@ -9532,6 +10060,13 @@
       "decimals": 8,
       "name": "FUTURAX",
       "symbol": "FXC"
+    },
+    {
+      "address": "0x8a40c222996f9F3431f63Bf80244C36822060f12",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Finxflo",
+      "symbol": "FXF"
     },
     {
       "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
@@ -9582,6 +10117,13 @@
       }
     },
     {
+      "address": "0x19A2cF2A1B2f76e52E2b0c572bD80A95B4Fa8643",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Fyooz NFT",
+      "symbol": "FYZNFT"
+    },
+    {
       "address": "0xE5aeE163513119F4F750376C718766B40fA37A5F",
       "chainId": 1,
       "decimals": 18,
@@ -9629,6 +10171,13 @@
       "decimals": 18,
       "name": "GANA",
       "symbol": "GANA"
+    },
+    {
+      "address": "0xc58467b855401EF3FF8FdA9216F236e29f0d6277",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Gasgains",
+      "symbol": "GASG"
     },
     {
       "address": "0x687174f8C49ceb7729D925C3A961507ea4Ac7b28",
@@ -9705,6 +10254,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x15c303B84045f67156AcF6963954e4247B526717",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Gas Cash Back",
+      "symbol": "GCBN"
     },
     {
       "address": "0x1778fFfBD431be2AC3D69e64d1d819C786B2BEe0",
@@ -9840,6 +10396,13 @@
       }
     },
     {
+      "address": "0x9ad03c34aAb604A9e0Fde41dbF8E383E11c416c4",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Guarded Ether",
+      "symbol": "GETH"
+    },
+    {
       "address": "0x03282f2D7834a97369Cad58f888aDa19EeC46ab6",
       "chainId": 1,
       "decimals": 8,
@@ -9854,6 +10417,13 @@
       "symbol": "GFARM"
     },
     {
+      "address": "0x831091dA075665168E01898c6DAC004A867f1e1B",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Gains V2",
+      "symbol": "GFARM2"
+    },
+    {
       "address": "0x3930E4dDb4d24ef2F4CB54C1f009a3694b708428",
       "chainId": 1,
       "decimals": 8,
@@ -9866,6 +10436,13 @@
       "decimals": 18,
       "name": "GGCOIN",
       "symbol": "GGC"
+    },
+    {
+      "address": "0xFA99A87b14B02e2240C79240C5a20F945ca5EF76",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "GG Token",
+      "symbol": "GGTK"
     },
     {
       "address": "0x3b544e6fcf6C8dCE9D8B45A4FdF21C9B02f9fDa9",
@@ -9941,6 +10518,13 @@
       "symbol": "GLA"
     },
     {
+      "address": "0x038a68FF68c393373eC894015816e33Ad41BD564",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Glitch Protocol",
+      "symbol": "GLCH"
+    },
+    {
       "address": "0x47fd85128312ee72aA0E0382a531a8f848B8B2CB",
       "chainId": 1,
       "decimals": 18,
@@ -9970,6 +10554,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x9eb6bE354d88fD88795a04DE899a57A77C545590",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "GameStop Finance",
+      "symbol": "GME"
     },
     {
       "address": "0xb3Bd49E28f8F832b8d1E246106991e546c323502",
@@ -10041,11 +10632,29 @@
       "symbol": "GOF"
     },
     {
+      "address": "0x9a96E767bFCcE8E80370BE00821ED5BA283D4A17",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "GOGO Finance",
+      "symbol": "GOGO"
+    },
+    {
       "address": "0x150b0b96933B75Ce27af8b92441F8fB683bF9739",
       "chainId": 1,
       "decimals": 18,
       "name": "Dragonereum GOLD",
       "symbol": "GOLD"
+    },
+    {
+      "address": "0x40d1F63B5D2048e67E9bEdB1B4c2F1A9fb4b6817",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Golden Goose",
+      "symbol": "GOLD",
+      "extensions": {
+        "color": "#f1b32b",
+        "isVerified": true
+      }
     },
     {
       "address": "0xeAb43193CF0623073Ca89DB9B712796356FA7414",
@@ -10077,6 +10686,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0xeEAA40B28A2d1b0B08f6f97bB1DD4B75316c6107",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Govi",
+      "symbol": "GOVI"
     },
     {
       "address": "0xcE593a29905951E8Fc579bC092ecA72577dA575c",
@@ -10170,6 +10786,7 @@
       "name": "The Graph",
       "symbol": "GRT",
       "extensions": {
+        "color": "#4068C3",
         "isRainbowCurated": true,
         "isVerified": true
       }
@@ -10267,6 +10884,13 @@
       "decimals": 8,
       "name": "GULD ERC20",
       "symbol": "GULD"
+    },
+    {
+      "address": "0x4f5fa8f2d12e5eB780f6082Dd656C565C48E0f24",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Gourmet Galaxy",
+      "symbol": "GUM"
     },
     {
       "address": "0xf7B098298f7C69Fc14610bf71d5e02c60792894C",
@@ -10470,6 +11094,13 @@
       "decimals": 18,
       "name": "HBZ coin",
       "symbol": "HBZ"
+    },
+    {
+      "address": "0x60A995CEbCD44CA566Ae22A9666ed28c67B598A1",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Hardcore Finance",
+      "symbol": "HCORE"
     },
     {
       "address": "0x74faaB6986560fD1140508e4266D8a7b87274Ffd",
@@ -10748,7 +11379,7 @@
       "address": "0x39eAE99E685906fF1C11A962a743440d0a1A6e09",
       "chainId": 1,
       "decimals": 18,
-      "name": "Holyheld",
+      "name": "Holyheld  OLD",
       "symbol": "HOLY"
     },
     {
@@ -10793,6 +11424,13 @@
       "decimals": 18,
       "name": "High Performance Blockchain",
       "symbol": "HPB"
+    },
+    {
+      "address": "0xff744f2315C9d61d825B581C973576055C3da07E",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "HPLUS",
+      "symbol": "HPLUS"
     },
     {
       "address": "0x3E1d5A855aD9D948373aE68e4fe1f094612b1322",
@@ -10860,13 +11498,6 @@
       "chainId": 1,
       "decimals": 18,
       "name": "HOT",
-      "symbol": "HTX"
-    },
-    {
-      "address": "0x38A0df9a08d18dc06CD91Fc7Ec94a0AcdF28D994",
-      "chainId": 1,
-      "decimals": 2,
-      "name": "Huptex",
       "symbol": "HTX"
     },
     {
@@ -11007,6 +11638,16 @@
       "symbol": "HYVE"
     },
     {
+      "address": "0x176C674Ee533C6139B0dc8b458D72A93dCB3e705",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Inverse Aave",
+      "symbol": "iAAVE",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xC1E2097d788d33701BA3Cc2773BF67155ec93FC4",
       "chainId": 1,
       "decimals": 18,
@@ -11034,7 +11675,7 @@
       "address": "0xf6E9b246319ea30e8C2fA2d1540AAEBF6f9E1B89",
       "chainId": 1,
       "decimals": 18,
-      "name": "Synth Inverse Bitcoin Cash",
+      "name": "Synthetic Inverse Bitcoin Cash",
       "symbol": "iBCH",
       "extensions": {
         "isVerified": true
@@ -11077,6 +11718,16 @@
       "decimals": 18,
       "name": "Synth Inverse Bitcoin",
       "symbol": "iBTC",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x18240BD9C07fA6156Ce3F3f61921cC82b2619157",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Fulcrum BZRX iToken",
+      "symbol": "iBZRX",
       "extensions": {
         "isVerified": true
       }
@@ -11158,6 +11809,16 @@
       "symbol": "ICO"
     },
     {
+      "address": "0x6345728B1ccE16E6f8C509950b5c84FFF88530d9",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Inverse Compound",
+      "symbol": "iCOMP",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x014B50466590340D41307Cc54DCee990c8D58aa8",
       "chainId": 1,
       "decimals": 6,
@@ -11170,6 +11831,13 @@
       "decimals": 18,
       "name": "ICON",
       "symbol": "ICX"
+    },
+    {
+      "address": "0xEBd9D99A3982d547C5Bb4DB7E3b1F9F14b67Eb83",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Everest",
+      "symbol": "ID"
     },
     {
       "address": "0x6bC4375083D3aD563dE91caD8438F629841448a5",
@@ -11204,6 +11872,13 @@
       "chainId": 1,
       "decimals": 0,
       "name": "IDEA Token",
+      "symbol": "IDEA"
+    },
+    {
+      "address": "0x5d3a4F62124498092Ce665f865E0b38fF6F5FbEa",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Ideaology",
       "symbol": "IDEA"
     },
     {
@@ -11255,7 +11930,20 @@
       "chainId": 1,
       "decimals": 18,
       "name": "IDLE",
-      "symbol": "IDLE"
+      "symbol": "IDLE",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x46a97629C9C1F58De6EC18C7F536e7E6d6A6ecDe",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Inverse Polkadot",
+      "symbol": "iDOT",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x998FFE1E43fAcffb941dc337dD0468d52bA5b48A",
@@ -11371,6 +12059,13 @@
       "symbol": "IGI"
     },
     {
+      "address": "0xdE9d41a01bb11A9F41E709242824E54c3917084e",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Ignite",
+      "symbol": "IGN"
+    },
+    {
       "address": "0xaF1250fa68D7DECD34fD75dE8742Bc03B29BD58e",
       "chainId": 1,
       "decimals": 18,
@@ -11402,21 +12097,15 @@
       "address": "0x1cC9567EA2eB740824a45F8026cCF8e46973234D",
       "chainId": 1,
       "decimals": 18,
-      "name": "Fulcrum KNC iToken",
-      "symbol": "iKNC",
-      "extensions": {
-        "isVerified": true
-      }
+      "name": "bZx KNC iToken",
+      "symbol": "iKNC"
     },
     {
       "address": "0x1D496da96caf6b518b133736beca85D5C4F9cBc5",
       "chainId": 1,
       "decimals": 18,
-      "name": "Fulcrum LINK iToken",
-      "symbol": "iLINK",
-      "extensions": {
-        "isVerified": true
-      }
+      "name": "bZx LINK iToken",
+      "symbol": "iLINK"
     },
     {
       "address": "0x3DdF5dAd59F8F8e8f957709B044eE84e87B42e25",
@@ -11484,6 +12173,16 @@
       "symbol": "iMKR"
     },
     {
+      "address": "0x9189c499727f88F8eCC7dC4EEA22c828E6AaC015",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Fulcrum MKR iToken",
+      "symbol": "iMKR",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x48FF53777F747cFB694101222a944dE070c15D36",
       "chainId": 1,
       "decimals": 7,
@@ -11492,6 +12191,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x696C1De4E7F475D5231372c47A627E4Cd6cE555A",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Impulse By FDR",
+      "symbol": "IMPULSE"
     },
     {
       "address": "0x3c4030839708a20fd2fb379cf11810dde4888d93",
@@ -11516,6 +12222,13 @@
       "decimals": 0,
       "name": "IMT",
       "symbol": "IMT"
+    },
+    {
+      "address": "0x30647a72Dc82d7Fbb1123EA74716aB8A317Eac19",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "imUSD",
+      "symbol": "IMUSD"
     },
     {
       "address": "0x17Aa18A4B64A55aBEd7FA543F2Ba4E91f2dcE482",
@@ -11552,6 +12265,13 @@
       "decimals": 18,
       "name": "InfinitusTokens",
       "symbol": "INF"
+    },
+    {
+      "address": "0x159751323A9E0415DD3d6D42a1212fe9F4a0848C",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Insured Finance",
+      "symbol": "INFI"
     },
     {
       "address": "0x83d60E7aED59c6829fb251229061a55F35432c4d",
@@ -11654,7 +12374,7 @@
       "address": "0xA5a5DF41883Cdc00c4cCC6E8097130535399d9a3",
       "chainId": 1,
       "decimals": 18,
-      "name": "Synth Inverse Brent Crude Oil",
+      "name": "Synth Inverse Perpetual Oil Futures",
       "symbol": "iOIL",
       "extensions": {
         "isVerified": true
@@ -11683,7 +12403,11 @@
       "chainId": 1,
       "decimals": 18,
       "name": "IoTeX",
-      "symbol": "IOTX"
+      "symbol": "IOTX",
+      "extensions": {
+        "color": "#00d4d5",
+        "isVerified": true
+      }
     },
     {
       "address": "0x64CdF819d3E75Ac8eC217B3496d7cE167Be42e80",
@@ -11717,6 +12441,16 @@
       }
     },
     {
+      "address": "0x0fEd38108bdb8e62ef7b5680E8E0726E2F29e0De",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Inverse Ren",
+      "symbol": "iREN",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xBd56E9477Fc6997609Cf45F84795eFbDAC642Ff1",
       "chainId": 1,
       "decimals": 18,
@@ -11736,13 +12470,6 @@
         "color": "#0F6AD7",
         "isVerified": true
       }
-    },
-    {
-      "address": "0x42726d074BBa68Ccc15200442B72Afa2D495A783",
-      "chainId": 1,
-      "decimals": 4,
-      "name": "Isiklar Coin",
-      "symbol": "ISIKC"
     },
     {
       "address": "0xC642549743A93674cf38D6431f75d6443F88E3E2",
@@ -11831,14 +12558,23 @@
       "symbol": "ITT"
     },
     {
+      "address": "0x36A00FF9072570eF4B9292117850B8FE08d96cce",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Inverse Uniswap",
+      "symbol": "iUNI",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xF013406A0B1d544238083DF0B93ad0d2cBE0f65f",
       "chainId": 1,
       "decimals": 6,
       "name": "Fulcrum USDC",
       "symbol": "iUSDC",
       "extensions": {
-        "color": "#0F6AD7",
-        "isVerified": true
+        "color": "#0F6AD7"
       }
     },
     {
@@ -11862,11 +12598,8 @@
       "address": "0xBA9262578EFef8b3aFf7F60Cd629d6CC8859C8b5",
       "chainId": 1,
       "decimals": 8,
-      "name": "Fulcrum WBTC iToken",
-      "symbol": "iWBTC",
-      "extensions": {
-        "isVerified": true
-      }
+      "name": "bZx WBTC iToken",
+      "symbol": "iWBTC"
     },
     {
       "address": "0x4AdF728E2Df4945082cDD6053869f51278fae196",
@@ -11927,6 +12660,16 @@
       "symbol": "IYF"
     },
     {
+      "address": "0x592244301CeA952d6daB2fdC1fE6bd9E53917306",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Inverse yearn.finance",
+      "symbol": "iYFI",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xDf59C8BA19B4d1437d80836b45F1319D9A429EED",
       "chainId": 1,
       "decimals": 4,
@@ -11959,6 +12702,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "JasmyCoin",
+      "symbol": "JASMY"
     },
     {
       "address": "0x9A3619499825fbAe63329Aa8bCb3f10CD5958E1c",
@@ -12238,6 +12988,13 @@
       "symbol": "KATANA"
     },
     {
+      "address": "0xE6C3502997f97F9BDe34CB165fBce191065E068f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Klondike BTC",
+      "symbol": "KBTC"
+    },
+    {
       "address": "0x0D6DD9f68d24EC1d5fE2174f3EC8DAB52B52BaF5",
       "chainId": 1,
       "decimals": 18,
@@ -12321,7 +13078,10 @@
       "chainId": 1,
       "decimals": 6,
       "name": "KIRA Network",
-      "symbol": "KEX"
+      "symbol": "KEX",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
@@ -12421,6 +13181,13 @@
       "symbol": "KIWI"
     },
     {
+      "address": "0xB97D5cF2864FB0D08b34a484FF48d5492B2324A0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Klondike Finance",
+      "symbol": "KLON"
+    },
+    {
       "address": "0xc97A5cdF41BAfD51c8dBE82270097e704d748b92",
       "chainId": 1,
       "decimals": 7,
@@ -12513,13 +13280,6 @@
       "symbol": "KOMP"
     },
     {
-      "address": "0xA866F0198208Eb07c83081d5136BE7f775c2399e",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Kore",
-      "symbol": "KORE"
-    },
-    {
       "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
       "chainId": 1,
       "decimals": 18,
@@ -12601,13 +13361,6 @@
       "extensions": {
         "isVerified": true
       }
-    },
-    {
-      "address": "0x0f8b6440A1F7BE3354fe072638a5C0F500b044bE",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Katerium",
-      "symbol": "KTH"
     },
     {
       "address": "0x24E3794605C84E580EEA4972738D633E8a7127c8",
@@ -12716,11 +13469,24 @@
       "symbol": "LAMB"
     },
     {
+      "address": "0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d",
+      "chainId": 1,
+      "decimals": 0,
+      "name": "Decentraland LAND",
+      "symbol": "LAND",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x6226caA1857AFBc6DFB6ca66071Eb241228031A1",
       "chainId": 1,
       "decimals": 18,
       "name": "LinkArt",
-      "symbol": "LAR"
+      "symbol": "LAR",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x2f85E502a988AF76f7ee6D83b7db8d6c0A823bf9",
@@ -12802,11 +13568,28 @@
       "symbol": "LDC"
     },
     {
+      "address": "0x5479d565E549f3ECdBDe4aB836d02D86e0D6A8C7",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "LenDeFi Token",
+      "symbol": "LDFI"
+    },
+    {
+      "address": "0xb29663Aa4E2e81e425294193616c1B102B70a158",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Ludena Protocol",
+      "symbol": "LDN"
+    },
+    {
       "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
       "chainId": 1,
       "decimals": 18,
       "name": "Lido DAO",
-      "symbol": "LDO"
+      "symbol": "LDO",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x9eFa0e2387E4CBA02a6E4E6594b8f4Dd209a0b93",
@@ -13051,10 +13834,7 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Linear",
-      "symbol": "LINA",
-      "extensions": {
-        "isVerified": true
-      }
+      "symbol": "LINA"
     },
     {
       "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
@@ -13128,6 +13908,13 @@
       "symbol": "LIT"
     },
     {
+      "address": "0xb59490aB09A0f526Cc7305822aC65f2Ab12f9723",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Litentry",
+      "symbol": "LIT"
+    },
+    {
       "address": "0x24A77c1F17C547105E14813e517be06b0040aa76",
       "chainId": 1,
       "decimals": 18,
@@ -13188,6 +13975,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x3a73F6156C4fBC71B8fDF38090A9D99401163644",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Lottonation",
+      "symbol": "LNT"
     },
     {
       "address": "0xa883E72c12473DeD50A5FbfFA60E4000fa5FE3C8",
@@ -13273,6 +14067,13 @@
       "decimals": 18,
       "name": "NFTLootBox",
       "symbol": "LOOT"
+    },
+    {
+      "address": "0xb0dFd28d3CF7A5897C694904Ace292539242f858",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Lotto",
+      "symbol": "LOTTO"
     },
     {
       "address": "0x5a276Aeb77bCfDAc8Ac6f31BBC7416AE1A85eEF2",
@@ -13400,6 +14201,13 @@
       }
     },
     {
+      "address": "0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Wrapped Terra",
+      "symbol": "LUNA"
+    },
+    {
       "address": "0xc8Cac7672f4669685817cF332a33Eb249F085475",
       "chainId": 1,
       "decimals": 18,
@@ -13455,6 +14263,13 @@
       "symbol": "M-ETH"
     },
     {
+      "address": "0xd36932143F6eBDEDD872D5Fb0651f4B72Fd15a84",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored Apple",
+      "symbol": "MAAPL"
+    },
+    {
       "address": "0x5B09A0371C1DA44A8E24D36Bf5DEb1141a84d875",
       "chainId": 1,
       "decimals": 18,
@@ -13473,7 +14288,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "MahaDAO",
-      "symbol": "MAHA"
+      "symbol": "MAHA",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x270D09cb4be817c98e84fEffdE03D5CD45e30a27",
@@ -13516,6 +14334,13 @@
       "symbol": "MARK"
     },
     {
+      "address": "0x66C0DDEd8433c9EA86C8cf91237B14e10b4d70B7",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mars",
+      "symbol": "MARS"
+    },
+    {
       "address": "0xfdcc07Ab60660de533b5Ad26e1457b565a9D59Bd",
       "chainId": 1,
       "decimals": 18,
@@ -13528,6 +14353,13 @@
       "decimals": 18,
       "name": "MidasProtocol",
       "symbol": "MAS"
+    },
+    {
+      "address": "0x06F3C323f0238c72BF35011071f2b5B7F43A054c",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "MASQ",
+      "symbol": "MASQ"
     },
     {
       "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
@@ -13550,6 +14382,13 @@
         "isRainbowCurated": true,
         "isVerified": true
       }
+    },
+    {
+      "address": "0x56aA298a19C93c6801FDde870fA63EF75Cc0aF72",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored Alibaba",
+      "symbol": "MBABA"
     },
     {
       "address": "0x26cF82e4aE43D31eA51e72B663d26e26a75AF729",
@@ -13725,6 +14564,13 @@
       "symbol": "MDTL"
     },
     {
+      "address": "0x947AEb02304391f8fbE5B25D7D98D649b57b1788",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mandala Exchange To",
+      "symbol": "MDX"
+    },
+    {
       "address": "0xfd1e80508F243E64CE234eA88A5Fd2827c71D4b7",
       "chainId": 1,
       "decimals": 8,
@@ -13787,6 +14633,13 @@
       }
     },
     {
+      "address": "0x11003E410ca3FcD220765B3d2f343433A0b2bffd",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Farming Bad",
+      "symbol": "METH"
+    },
+    {
       "address": "0xFEF3884b603C33EF8eD4183346E093A173C94da6",
       "chainId": 1,
       "decimals": 18,
@@ -13813,6 +14666,13 @@
       "decimals": 18,
       "name": "Smart MFG",
       "symbol": "MFG"
+    },
+    {
+      "address": "0xAa4e3edb11AFa93c41db59842b29de64b72E355B",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Marginswap",
+      "symbol": "MFI"
     },
     {
       "address": "0xDF2C7238198Ad8B389666574f2d8bc411A4b7428",
@@ -13872,6 +14732,13 @@
       "decimals": 2,
       "name": "Maharlika Coin",
       "symbol": "MHLK"
+    },
+    {
+      "address": "0x1d350417d9787E000cc1b95d70E9536DcD91F373",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored iShares Go",
+      "symbol": "MIAU"
     },
     {
       "address": "0x3A1237D38D0Fb94513f85D61679cAd7F38507242",
@@ -14024,6 +14891,13 @@
       "symbol": "MM"
     },
     {
+      "address": "0x41BbEDd7286dAab5910a1f15d12CBda839852BD7",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored Microsoft",
+      "symbol": "MMSFT"
+    },
+    {
       "address": "0x1a95B271B0535D15fa49932Daba31BA612b52946",
       "chainId": 1,
       "decimals": 8,
@@ -14036,6 +14910,13 @@
       "decimals": 8,
       "name": "Minereum",
       "symbol": "MNE"
+    },
+    {
+      "address": "0xC8d674114bac90148d11D3C1d33C61835a0F9DCD",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored Netflix",
+      "symbol": "MNFLX"
     },
     {
       "address": "0xDB7eB3edE973665b1BB9F3016861E3255062E4ED",
@@ -14097,6 +14978,17 @@
       "chainId": 1,
       "decimals": 0,
       "name": "Modum",
+      "symbol": "MOD",
+      "extensions": {
+        "color": "#09547d",
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0xEA1ea0972fa092dd463f2968F9bB51Cc4c981D71",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Modefi",
       "symbol": "MOD"
     },
     {
@@ -14155,6 +15047,13 @@
       "symbol": "MOONS"
     },
     {
+      "address": "0x236ECfb32C2b496f942c86d43B8cA4F6Bd931e30",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Morph",
+      "symbol": "MORC"
+    },
+    {
       "address": "0x501262281B2Ba043e2fbf14904980689CDDB0C78",
       "chainId": 1,
       "decimals": 2,
@@ -14170,6 +15069,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x970b596EA3cb9864397f799902f0a579cDc3377B",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Morph Tracker",
+      "symbol": "MORT"
     },
     {
       "address": "0x784561B89A160990F46DE6dB19571Ca1B5F14bCE",
@@ -14193,6 +15099,13 @@
       "symbol": "MOZO"
     },
     {
+      "address": "0x018fb5Af9d015Af25592a014C4266a84143De7a0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "MP3",
+      "symbol": "MP3"
+    },
+    {
       "address": "0x6369c3DadfC00054A42BA8B2c09c48131dd4Aa38",
       "chainId": 1,
       "decimals": 18,
@@ -14207,10 +15120,7 @@
       "chainId": 1,
       "decimals": 18,
       "name": "88mph",
-      "symbol": "MPH",
-      "extensions": {
-        "isVerified": true
-      }
+      "symbol": "MPH"
     },
     {
       "address": "0x96c645D3D3706f793Ef52C19bBACe441900eD47D",
@@ -14218,6 +15128,13 @@
       "decimals": 0,
       "name": "Mt Pelerin Shares",
       "symbol": "MPS"
+    },
+    {
+      "address": "0x13B02c8dE71680e71F0820c996E4bE43c2F57d15",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored Invesco QQ",
+      "symbol": "MQQQ"
     },
     {
       "address": "0xf453B5B9d4E0B5c62ffB256BB2378cc2BC8e8a89",
@@ -14266,6 +15183,13 @@
       "decimals": 18,
       "name": "MRV",
       "symbol": "MRV"
+    },
+    {
+      "address": "0x9d1555d8cB3C846Bb4f7D5B1B1080872c3166676",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored iShares Si",
+      "symbol": "MSLV"
     },
     {
       "address": "0x68AA3F232dA9bdC2343465545794ef3eEa5209BD",
@@ -14391,6 +15315,13 @@
       "symbol": "MTRc"
     },
     {
+      "address": "0xEdb0414627E6f1e3F082DE65cD4F9C693D78CCA9",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored Twitter",
+      "symbol": "MTWTR"
+    },
+    {
       "address": "0x0AF44e2784637218dD1D32A322D44e603A8f0c6A",
       "chainId": 1,
       "decimals": 18,
@@ -14422,6 +15353,13 @@
       "symbol": "MUSE"
     },
     {
+      "address": "0x9C78EE466D6Cb57A4d01Fd887D2b5dFb2D46288f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Must",
+      "symbol": "MUST"
+    },
+    {
       "address": "0x515669d308f887Fd83a471C7764F5d084886D34D",
       "chainId": 1,
       "decimals": 18,
@@ -14441,6 +15379,13 @@
       "decimals": 0,
       "name": "Max",
       "symbol": "MVG"
+    },
+    {
+      "address": "0xf72FCd9DCF0190923Fadd44811E240Ef4533fc86",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Mirrored ProShares",
+      "symbol": "MVIXY"
     },
     {
       "address": "0xA849EaaE994fb86Afa73382e9Bd88c2B6b18Dc71",
@@ -14469,6 +15414,20 @@
       "decimals": 18,
       "name": "RED MWAT",
       "symbol": "MWAT"
+    },
+    {
+      "address": "0x3521c85C3000bff57Eac04489EB05BbD3193A531",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "MetaWhale BTC",
+      "symbol": "MWBTC"
+    },
+    {
+      "address": "0x45128CB743951121Fb70cb570c0784492732778A",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Metawhale Gold",
+      "symbol": "MWG"
     },
     {
       "address": "0x11eeF04c884E24d9B7B4760e7476D06ddF797f36",
@@ -14568,6 +15527,13 @@
       "symbol": "NAC"
     },
     {
+      "address": "0x2f7B618993cc3848d6C7ed9CdD5e835E4Fe22b98",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Nami Corporation To",
+      "symbol": "NAMI"
+    },
+    {
       "address": "0xA79e0012bb3379f8509a5ab49caB7e6Abb49701D",
       "chainId": 1,
       "decimals": 18,
@@ -14659,6 +15625,13 @@
       }
     },
     {
+      "address": "0x8A9c4dfe8b9D8962B31e4e16F8321C44d48e246E",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Name Changing Token",
+      "symbol": "NCT"
+    },
+    {
       "address": "0xA54ddC7B3CcE7FC8b1E3Fa0256D0DB80D2c10970",
       "chainId": 1,
       "decimals": 18,
@@ -14677,6 +15650,13 @@
       "chainId": 1,
       "decimals": 18,
       "name": "nDEX",
+      "symbol": "NDX"
+    },
+    {
+      "address": "0x86772b1409b61c639EaAc9Ba0AcfBb6E238e5F83",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Indexed Finance",
       "symbol": "NDX"
     },
     {
@@ -14773,10 +15753,7 @@
       "chainId": 1,
       "decimals": 18,
       "name": "NFTX",
-      "symbol": "NFTX",
-      "extensions": {
-        "isVerified": true
-      }
+      "symbol": "NFTX"
     },
     {
       "address": "0x1cBb83EbcD552D5EBf8131eF8c9CD9d9BAB342bC",
@@ -14805,6 +15782,13 @@
       "decimals": 18,
       "name": "Nice",
       "symbol": "NICE"
+    },
+    {
+      "address": "0x7e291890B01E5181f7ecC98D79ffBe12Ad23df9e",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Unifty",
+      "symbol": "NIF"
     },
     {
       "address": "0x7c8155909cd385F120A56eF90728dD50F9CcbE52",
@@ -14902,6 +15886,13 @@
       "symbol": "NOAHARK"
     },
     {
+      "address": "0x41b3F18c6384Dc9A39c33AFEcA60d9b8e61eAa9F",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Noah Decentralized",
+      "symbol": "NOAHP"
+    },
+    {
       "address": "0xF4FaEa455575354d2699BC209B0a65CA99F69982",
       "chainId": 1,
       "decimals": 18,
@@ -14950,6 +15941,20 @@
       "symbol": "NOODLE"
     },
     {
+      "address": "0x6e9730EcFfBed43fD876A264C982e254ef05a0DE",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Nord Finance",
+      "symbol": "NORD"
+    },
+    {
+      "address": "0x7061ee0896Ab2c1865078B6c91731f67A89eA6A4",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Nitrous Finance",
+      "symbol": "NOS"
+    },
+    {
       "address": "0x0027449Bf0887ca3E431D263FFDeFb244D95b555",
       "chainId": 1,
       "decimals": 18,
@@ -14992,7 +15997,11 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Pundi X",
-      "symbol": "NPXS"
+      "symbol": "NPXS",
+      "extensions": {
+        "color": "#f5d100",
+        "isVerified": true
+      }
     },
     {
       "address": "0x000000085824F23a070c2474442ED014c0e46B58",
@@ -15096,6 +16105,13 @@
       }
     },
     {
+      "address": "0x89bD2E7e388fAB44AE88BEf4e1AD12b4F1E0911c",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Peanut",
+      "symbol": "NUX"
+    },
+    {
       "address": "0x45e42D659D9f9466cD5DF622506033145a9b89Bc",
       "chainId": 1,
       "decimals": 3,
@@ -15117,13 +16133,6 @@
       "symbol": "NXX OLD"
     },
     {
-      "address": "0xC9cE70A381910D0a90B30d408CC9C7705ee882de",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Nyan Finance",
-      "symbol": "NYAN"
-    },
-    {
       "address": "0xbF4a9A37EcFc21825011285222c36aB35De51F14",
       "chainId": 1,
       "decimals": 18,
@@ -15143,6 +16152,16 @@
       "decimals": 18,
       "name": "OAK",
       "symbol": "OAK"
+    },
+    {
+      "address": "0x1788430620960F9a70e3DC14202a3A35ddE1A316",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "OpenAlexa Protocol",
+      "symbol": "OAP",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x701C244b988a513c945973dEFA05de933b23Fe1D",
@@ -15343,6 +16362,13 @@
       "symbol": "OLT"
     },
     {
+      "address": "0x6595b8fD9C920C81500dCa94e53Cdc712513Fb1f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Olyseum",
+      "symbol": "OLY"
+    },
+    {
       "address": "0x3593D125a4f7849a1B059E64F4517A86Dd60c95d",
       "chainId": 1,
       "decimals": 18,
@@ -15498,6 +16524,13 @@
       "decimals": 18,
       "name": "OPEN Governance Tok",
       "symbol": "OPEN"
+    },
+    {
+      "address": "0x888888888889C00c67689029D7856AAC1065eC11",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Opium",
+      "symbol": "OPIUM"
     },
     {
       "address": "0xF4c17Bc4979c1dc7b4CA50115358Dec58C67fD9d",
@@ -15796,6 +16829,13 @@
       "symbol": "PAI"
     },
     {
+      "address": "0x8c8687fC965593DFb2F0b4EAeFD55E9D8df348df",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "PAID Network",
+      "symbol": "PAID"
+    },
+    {
       "address": "0xfeDAE5642668f8636A11987Ff386bfd215F942EE",
       "chainId": 1,
       "decimals": 18,
@@ -15969,11 +17009,32 @@
       "symbol": "PAYT"
     },
     {
+      "address": "0x74c287AD5328dAca276C6a1c1f149415B12C148d",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Pazzy",
+      "symbol": "PAZZY"
+    },
+    {
+      "address": "0x44B537B6f94c73A54f7bF8a9b68f8125da3C330b",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Polkabase",
+      "symbol": "PBASE"
+    },
+    {
       "address": "0x55648De19836338549130B1af587F16beA46F66B",
       "chainId": 1,
       "decimals": 18,
       "name": "Pebbles",
       "symbol": "PBL"
+    },
+    {
+      "address": "0x0D6ae2a429df13e44A07Cd2969E085e4833f64A0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "PolkaBridge",
+      "symbol": "PBR"
     },
     {
       "address": "0xF4c07b1865bC326A3c01339492Ca7538FD038Cc0",
@@ -15991,6 +17052,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0xA8b12Cc90AbF65191532a12bb5394A714A46d358",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "pBTC35A",
+      "symbol": "PBTC35A"
     },
     {
       "address": "0xE3F4b4A5d91e5cB9435B947F090A319737036312",
@@ -16062,6 +17130,13 @@
       "symbol": "PEG"
     },
     {
+      "address": "0x88bd6eFe33bc82860278c044eFA33364c6285032",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "PegShares",
+      "symbol": "PEGS"
+    },
+    {
       "address": "0xBb0eF9e617FADdf54B8D16e29046F72B4D3ec77F",
       "chainId": 1,
       "decimals": 18,
@@ -16117,6 +17192,13 @@
       "symbol": "PETH"
     },
     {
+      "address": "0x6AD61128aBA16B9D4295e6cF8bdB57b70085C9c7",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "P Ethereum",
+      "symbol": "PETH"
+    },
+    {
       "address": "0xeC18f898B4076A3E18f1089D33376CC380BDe61D",
       "chainId": 1,
       "decimals": 18,
@@ -16138,18 +17220,18 @@
       "symbol": "PFARM"
     },
     {
+      "address": "0x7B69D465c0F9FB22AffAE56aa86149973e9B0966",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Protocol Finance",
+      "symbol": "PFI"
+    },
+    {
       "address": "0x2FA32a39fc1c399E0Cc7B2935868f5165De7cE97",
       "chainId": 1,
       "decimals": 8,
       "name": "Payfair",
       "symbol": "PFR"
-    },
-    {
-      "address": "0xF02DAB52205aFf6Bb3d47Cc7B21624a5064F9FBA",
-      "chainId": 1,
-      "decimals": 4,
-      "name": "Pyrrhos Gold Token",
-      "symbol": "PGOLD"
     },
     {
       "address": "0x931ad0628aa11791C26FF4d41ce23E40C31c5E4e",
@@ -16164,6 +17246,13 @@
       "decimals": 18,
       "name": "Polyient Games Gove",
       "symbol": "PGT"
+    },
+    {
+      "address": "0x98c36c0e953463BD5146C8783ce081CE1d187AcF",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Polyient Games Unit",
+      "symbol": "PGU"
     },
     {
       "address": "0x6c5bA91642F10282b576d91922Ae6448C9d52f4E",
@@ -16240,6 +17329,16 @@
       "symbol": "PIPT"
     },
     {
+      "address": "0x26607aC599266b21d13c7aCF7942c7701a8b699c",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Power Index Pool Token",
+      "symbol": "PIPT",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x834cE7aD163ab3Be0C5Fd4e0a81E67aC8f51E00C",
       "chainId": 1,
       "decimals": 18,
@@ -16268,13 +17367,6 @@
       "symbol": "PIX"
     },
     {
-      "address": "0xB53e08B97724126Bda6d237B94F766c0b81C90fE",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "PIXBY",
-      "symbol": "PIXBY"
-    },
-    {
       "address": "0x1e906717De2E4A4600F13b6909736b0346bDde3E",
       "chainId": 1,
       "decimals": 4,
@@ -16283,6 +17375,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x9318105460626e7fA58308FA4bcE40e4616F3565",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Pixie Dust",
+      "symbol": "PIXIE"
     },
     {
       "address": "0x61bc1F530AC6193D73aF1e1A6A14CB44b9C3f915",
@@ -16570,6 +17669,25 @@
       "symbol": "POOL"
     },
     {
+      "address": "0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "PoolTogether",
+      "symbol": "POOL",
+      "extensions": {
+        "color": "#6E3AF3",
+        "isRainbowCurated": true,
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x69A95185ee2a045CDC4bCd1b1Df10710395e4e23",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Poolz Finance",
+      "symbol": "POOLZ"
+    },
+    {
       "address": "0x5D858bcd53E085920620549214a8b27CE2f04670",
       "chainId": 1,
       "decimals": 18,
@@ -16689,6 +17807,13 @@
       "symbol": "PRE"
     },
     {
+      "address": "0x6399C842dD2bE3dE30BF99Bc7D1bBF6Fa3650E70",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Premia",
+      "symbol": "PREMIA"
+    },
+    {
       "address": "0x7728dFEF5aBd468669EB7f9b48A7f70a501eD29D",
       "chainId": 1,
       "decimals": 6,
@@ -16782,6 +17907,13 @@
       }
     },
     {
+      "address": "0x8642A849D0dcb7a15a974794668ADcfbe4794B56",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Prosper",
+      "symbol": "PROS"
+    },
+    {
       "address": "0x7641b2Ca9DDD58adDf6e3381c1F994Aac5f1A32f",
       "chainId": 1,
       "decimals": 18,
@@ -16841,6 +17973,20 @@
       "symbol": "PRT"
     },
     {
+      "address": "0xA36e59c08c9F251a6b7A9EB6bE6e32fd6157AcD0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Previse",
+      "symbol": "PRVS"
+    },
+    {
+      "address": "0x3C81D482172cC273c3b91dD9D8eb212023D00521",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Prophecy",
+      "symbol": "PRY"
+    },
+    {
       "address": "0x5F85c60187aB233Ca6e750731D15e7eFd061fBdE",
       "chainId": 1,
       "decimals": 18,
@@ -16853,6 +17999,13 @@
       "decimals": 18,
       "name": "Payship",
       "symbol": "PSHP"
+    },
+    {
+      "address": "0xD4Cb461eACe80708078450e465881599d2235f1A",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Passive Income",
+      "symbol": "PSI"
     },
     {
       "address": "0x1c5F43710a1776b0Ea7191b7Ead75D4B98D69858",
@@ -16952,6 +18105,13 @@
       "symbol": "PUC"
     },
     {
+      "address": "0x9cea2eD9e47059260C97d697f82b8A14EfA61EA5",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Punk",
+      "symbol": "PUNK"
+    },
+    {
       "address": "0xe25ff6Eb959BCE67975778e46A47750C243B6B99",
       "chainId": 1,
       "decimals": 18,
@@ -16964,6 +18124,13 @@
       "decimals": 8,
       "name": "PegNet pUSD",
       "symbol": "pUSD"
+    },
+    {
+      "address": "0x412e5a36BDE71AA2c38e1c0E26BAAf7F2f0Bc24a",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "PegsUSD",
+      "symbol": "PUSD"
     },
     {
       "address": "0xE277aC35F9D327A670c1A3F3eeC80a83022431e4",
@@ -17160,6 +18327,13 @@
       "symbol": "QTUM"
     },
     {
+      "address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Quickswap",
+      "symbol": "QUICK"
+    },
+    {
       "address": "0x264Dc2DedCdcbb897561A57CBa5085CA416fb7b4",
       "chainId": 1,
       "decimals": 18,
@@ -17202,6 +18376,13 @@
       "symbol": "R34P"
     },
     {
+      "address": "0x8C7424c3000942e5A93De4a01Ce2eC86c06333Cb",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "ROCK3T",
+      "symbol": "R3T"
+    },
+    {
       "address": "0xc22B30E4cce6b78aaaADae91E44E73593929a3e9",
       "chainId": 1,
       "decimals": 18,
@@ -17217,6 +18398,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Rai Reflex Index",
+      "symbol": "RAI"
     },
     {
       "address": "0x61cDb66e56FAD942a7b5cE3F419FfE9375E31075",
@@ -17311,6 +18499,13 @@
       "decimals": 18,
       "name": "ErcauX",
       "symbol": "RAUX"
+    },
+    {
+      "address": "0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Razor Network",
+      "symbol": "RAZOR"
     },
     {
       "address": "0xE8b251822d003a2b2466ee0E38391C2db2048739",
@@ -17474,6 +18669,13 @@
       "symbol": "REDC"
     },
     {
+      "address": "0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Reef Finance",
+      "symbol": "REEF"
+    },
+    {
       "address": "0x89303500a7Abfb178B274FD89F2469C264951e1f",
       "chainId": 1,
       "decimals": 8,
@@ -17547,11 +18749,44 @@
       }
     },
     {
+      "address": "0xe3Cb486f3f5C639e98cCBaF57d95369375687F80",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "renDGB",
+      "symbol": "renDGB",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x3832d2F059E55934220881F831bE501D180671A7",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "renDOGE",
+      "symbol": "renDOGE",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xD5147bc8e386d91Cc5DBE72099DAC6C9b99276F5",
       "chainId": 1,
       "decimals": 18,
       "name": "renFIL",
-      "symbol": "RENFIL"
+      "symbol": "renFIL",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x52d87F22192131636F93c5AB18d0127Ea52CB641",
+      "chainId": 1,
+      "decimals": 6,
+      "name": "renLUNA",
+      "symbol": "renLUNA",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2",
@@ -17728,11 +18963,8 @@
       "address": "0xD291E7a03283640FDc51b121aC401383A46cC623",
       "chainId": 1,
       "decimals": 18,
-      "name": "Rari Governance Token",
-      "symbol": "RGT",
-      "extensions": {
-        "isVerified": true
-      }
+      "name": "Rari Governance Tok",
+      "symbol": "RGT"
     },
     {
       "address": "0x47C0aD2aE6c0Ed4bcf7bc5b380D7205E89436e84",
@@ -17740,6 +18972,13 @@
       "decimals": 18,
       "name": "rHegic",
       "symbol": "RHEGIC"
+    },
+    {
+      "address": "0xAd7Ca17e23f13982796D27d1E6406366Def6eE5f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "rHEGIC2",
+      "symbol": "RHEGIC2"
     },
     {
       "address": "0x168296bb09e24A88805CB9c33356536B980D3fC5",
@@ -17754,6 +18993,13 @@
       "decimals": 18,
       "name": "RI Token",
       "symbol": "RI"
+    },
+    {
+      "address": "0x4cA0654f4fc1025cF1a17B7459c20aC0479522aD",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Rigel Finance",
+      "symbol": "RIGEL"
     },
     {
       "address": "0x86E56f3c89a14528858e58B3De48c074538BAf2c",
@@ -17778,6 +19024,13 @@
       "decimals": 8,
       "name": "RiptideCoin",
       "symbol": "RIPT"
+    },
+    {
+      "address": "0x3fa807B6F8d4c407e6E605368F4372d14658b38C",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Rise Protocol",
+      "symbol": "RISE"
     },
     {
       "address": "0x0b1724cc9FDA0186911EF6a75949e9c0d3F0f2F3",
@@ -17974,6 +19227,13 @@
       }
     },
     {
+      "address": "0xAd4f86a25bbc20FfB751f2FAC312A0B4d8F88c64",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "OptionRoom",
+      "symbol": "ROOM"
+    },
+    {
       "address": "0xCb5f72d37685C3D5aD0bB5F982443BC8FcdF570E",
       "chainId": 1,
       "decimals": 18,
@@ -18000,6 +19260,13 @@
       "decimals": 18,
       "name": "ROUND",
       "symbol": "ROUND"
+    },
+    {
+      "address": "0x16ECCfDbb4eE1A85A33f3A9B21175Cd7Ae753dB4",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Router Protocol",
+      "symbol": "ROUTE"
     },
     {
       "address": "0x7eaF9C89037e4814DC0d9952Ac7F888C784548DB",
@@ -18033,6 +19300,13 @@
         "isRainbowCurated": true,
         "isVerified": true
       }
+    },
+    {
+      "address": "0xa0Bb0027C28ade4Ac628b7f81e7b93Ec71b4E020",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Rug Proof",
+      "symbol": "RPT"
     },
     {
       "address": "0xea8b224eDD3e342DEb514C4176c2E72Bcce6fFF9",
@@ -18162,6 +19436,13 @@
       "symbol": "RUNE"
     },
     {
+      "address": "0x3155BA85D5F96b2d030a4966AF206230e46849cb",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "THORChain  ERC20",
+      "symbol": "RUNE"
+    },
+    {
       "address": "0x41f615E24fAbd2b097a320E9E6c1f448cb40521c",
       "chainId": 1,
       "decimals": 18,
@@ -18239,6 +19520,16 @@
       "decimals": 18,
       "name": "S4FE",
       "symbol": "S4F",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0xd2dF355C19471c8bd7D8A3aa27Ff4e26A21b4076",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Aave",
+      "symbol": "sAAVE",
       "extensions": {
         "isVerified": true
       }
@@ -18336,6 +19627,13 @@
       }
     },
     {
+      "address": "0xa12a00E73E4E7174AcC50A1c073e36Aa0c9cb305",
+      "chainId": 1,
+      "decimals": 4,
+      "name": "Swaap Stablecoin",
+      "symbol": "SAP"
+    },
+    {
       "address": "0x4C38D0e726B6C86F64c1B281348E725973542043",
       "chainId": 1,
       "decimals": 18,
@@ -18380,7 +19678,7 @@
       "address": "0x36a2422a863D5B950882190Ff5433E513413343a",
       "chainId": 1,
       "decimals": 18,
-      "name": "Synth Bitcoin Cash",
+      "name": "Synthetic Bitcoin Cash",
       "symbol": "sBCH",
       "extensions": {
         "isVerified": true
@@ -18445,13 +19743,6 @@
       "symbol": "SBTC"
     },
     {
-      "address": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "LP sBTC Curve",
-      "symbol": "SBTCCURVE"
-    },
-    {
       "address": "0x2579BB08387f0DE7Ab135edd6C2A985a3f577b6B",
       "chainId": 1,
       "decimals": 18,
@@ -18510,11 +19801,28 @@
       }
     },
     {
+      "address": "0xfDC4a3FC36df16a78edCAf1B837d3ACAaeDB2CB4",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Scifi Finance",
+      "symbol": "SCIFI"
+    },
+    {
       "address": "0xd7631787B4dCc87b1254cfd1e5cE48e96823dEe8",
       "chainId": 1,
       "decimals": 8,
       "name": "Sociall",
       "symbol": "SCL",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0xEb029507d3e043DD6C87F2917C4E82B902c35618",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Compound",
+      "symbol": "sCOMP",
       "extensions": {
         "isVerified": true
       }
@@ -18528,6 +19836,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x6Fa0952355607dFB2d399138B7fE10EB90F245e4",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Clash Token",
+      "symbol": "SCT"
     },
     {
       "address": "0xC25a3A3b969415c80451098fa907EC722572917F",
@@ -18559,6 +19874,33 @@
       "decimals": 18,
       "name": "Synth DeFi Index",
       "symbol": "sDEFI",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x1715AC0743102BF5Cd58EfBB6Cf2dC2685d967b6",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Polkadot",
+      "symbol": "sDOT",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
+      "address": "0x73968b9a57c6E53d41345FD57a6E6ae27d6CDB2F",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Stake DAO",
+      "symbol": "SDT"
+    },
+    {
+      "address": "0x041fdd6637eCfD96af8804278AC12660ac2D12c0",
+      "chainId": 1,
+      "decimals": 7,
+      "name": "SwapDEX",
+      "symbol": "SDX",
       "extensions": {
         "isVerified": true
       }
@@ -18695,6 +20037,13 @@
         "color": "#53b267",
         "isVerified": true
       }
+    },
+    {
+      "address": "0x04E0Af0af1b7f0023c6B12af5a94Df59B0e8cF59",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Sensitrust Token",
+      "symbol": "SETS"
     },
     {
       "address": "0x68473dc4B7A4b0867fd7C5b9A982Fea407DAD320",
@@ -18842,6 +20191,13 @@
       "symbol": "SGT"
     },
     {
+      "address": "0x84810bcF08744d5862B8181f12d17bfd57d3b078",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "SharedStake Governa",
+      "symbol": "SGT"
+    },
+    {
       "address": "0x6006FC2a849fEdABa8330ce36F5133DE01F96189",
       "chainId": 1,
       "decimals": 18,
@@ -18957,6 +20313,13 @@
       "decimals": 18,
       "name": "Spectiv Signal Token",
       "symbol": "SIG"
+    },
+    {
+      "address": "0xeb2C0E11aF20FB1c41C6e7ABe5ad214E48738514",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Sinelock",
+      "symbol": "SINE"
     },
     {
       "address": "0x4B1cE9C42A381CB2d74ffeF20103e502e2fc619C",
@@ -19317,8 +20680,11 @@
       "address": "0xfe9A29aB92522D14Fc65880d817214261D8479AE",
       "chainId": 1,
       "decimals": 18,
-      "name": "Snowswap",
-      "symbol": "SNOW"
+      "name": "SnowSwap",
+      "symbol": "SNOW",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
@@ -19376,6 +20742,13 @@
       "symbol": "SOAR"
     },
     {
+      "address": "0xBae5F2D8a1299E5c4963eaff3312399253f27Ccb",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "Soar",
+      "symbol": "SOAR"
+    },
+    {
       "address": "0x2d0E95bd4795D7aCe0da3C0Ff7b706a5970eb9D3",
       "chainId": 1,
       "decimals": 18,
@@ -19412,7 +20785,7 @@
       "address": "0x6d16cF3EC5F763d4d99cB0B0b110eefD93B11B56",
       "chainId": 1,
       "decimals": 18,
-      "name": "Synth Brent Crude Oil",
+      "name": "Synth Perpetual Oil Futures",
       "symbol": "sOIL",
       "extensions": {
         "isVerified": true
@@ -19464,9 +20837,9 @@
       "symbol": "SOUL"
     },
     {
-      "address": "0xF7623A0A44045b907D81AAD8479AA3c4A818211d",
+      "address": "0x9631483f28B7f5CBf7D435Ab249Be8f709215bC3",
       "chainId": 1,
-      "decimals": 18,
+      "decimals": 24,
       "name": "Sperax",
       "symbol": "SPA"
     },
@@ -19598,13 +20971,6 @@
       "symbol": "SPND"
     },
     {
-      "address": "0xa4Bad5d040d4464EC5CE130987731F2f428c9307",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Spore Finance",
-      "symbol": "SPORE"
-    },
-    {
       "address": "0x4b7aD3a56810032782Afce12d7d27122bDb96efF",
       "chainId": 1,
       "decimals": 8,
@@ -19631,6 +20997,16 @@
       "decimals": 6,
       "name": "SWAPCOINZ",
       "symbol": "SPZ"
+    },
+    {
+      "address": "0xD31533E8d0f3DF62060e94B3F1318137bB6E3525",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Ren",
+      "symbol": "sREN",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x0488401c3F535193Fa8Df029d9fFe615A06E74E6",
@@ -19846,6 +21222,13 @@
       }
     },
     {
+      "address": "0xDFe66B14D37C77F4E9b180cEb433d1b164f0281D",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "StakeHound Staked E",
+      "symbol": "STETH"
+    },
+    {
       "address": "0x160B1E5aaBFD70B2FC40Af815014925D71CEEd7E",
       "chainId": 1,
       "decimals": 8,
@@ -20034,6 +21417,16 @@
       }
     },
     {
+      "address": "0x918dA91Ccbc32B7a6A0cc4eCd5987bbab6E31e6D",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Tesla",
+      "symbol": "sTSLA",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0xaC9Bb427953aC7FDDC562ADcA86CF42D988047Fd",
       "chainId": 1,
       "decimals": 18,
@@ -20080,7 +21473,11 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Substratum",
-      "symbol": "SUB"
+      "symbol": "SUB",
+      "extensions": {
+        "color": "#e53431",
+        "isVerified": true
+      }
     },
     {
       "address": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7",
@@ -20088,6 +21485,16 @@
       "decimals": 18,
       "name": "SUKU",
       "symbol": "SUKU"
+    },
+    {
+      "address": "0x30635297E450b930f8693297eBa160D9e6c8eBcf",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth Uniswap",
+      "symbol": "sUNI",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x47935Edfb3CDd358C50F6c0Add1Cc24662e30F5f",
@@ -20107,7 +21514,7 @@
       "address": "0xb5a4ac5b04E777230bA3381195EfF6a60c3934F2",
       "chainId": 1,
       "decimals": 18,
-      "name": "inSure",
+      "name": "inSure DeFi",
       "symbol": "SURE"
     },
     {
@@ -20301,6 +21708,13 @@
       }
     },
     {
+      "address": "0x99fE3B1391503A1bC1788051347A1324bff41452",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "SportX",
+      "symbol": "SX"
+    },
+    {
       "address": "0x3A412043939d9F7e53373b64f858ecB870a92E50",
       "chainId": 1,
       "decimals": 18,
@@ -20410,11 +21824,28 @@
       "symbol": "SXUT"
     },
     {
+      "address": "0x992058B7DB08F9734d84485bfbC243C4ee6954A7",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Synth yearn.finance",
+      "symbol": "sYFI",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x322124122DF407b0d0D902cB713B3714FB2e2E1F",
       "chainId": 1,
       "decimals": 9,
       "name": "Soft Yearn",
       "symbol": "SYFI"
+    },
+    {
+      "address": "0x8282df223AC402d04B2097d16f758Af4F70e7Db0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "YFLink Synthetic",
+      "symbol": "sYFL"
     },
     {
       "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
@@ -20450,13 +21881,6 @@
       "decimals": 8,
       "name": "SyscoinToken",
       "symbol": "SYSX"
-    },
-    {
-      "address": "0xa7C71d444bf9aF4bfEd2adE75595d7512Eb4DD39",
-      "chainId": 1,
-      "decimals": 16,
-      "name": "Travel1Click",
-      "symbol": "T1C"
     },
     {
       "address": "0xE7775A6e9Bcf904eb39DA2b68c5efb4F9360e08C",
@@ -20500,11 +21924,21 @@
       "symbol": "TAN"
     },
     {
+      "address": "0x7f1F2D3dFa99678675ECE1C243d3f7bC3746db5D",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Tapmydata",
+      "symbol": "TAP"
+    },
+    {
       "address": "0xC567bca531992352166252ea5121e535432E81eD",
       "chainId": 1,
       "decimals": 8,
       "name": "Tartarus",
-      "symbol": "TAR"
+      "symbol": "TAR",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xcDd0A6B15B49A9eb3Ce011CCE22FAc2ccf09ecE6",
@@ -20665,13 +22099,6 @@
       "symbol": "TCORE"
     },
     {
-      "address": "0x0Cd1b0e93eBAAD374752af74FE44F877dd0438c0",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "TCS Token",
-      "symbol": "TCS"
-    },
-    {
       "address": "0x9910f4AeD4A7550A4120ad7da8dF8b56E91197Fa",
       "chainId": 1,
       "decimals": 0,
@@ -20817,6 +22244,13 @@
       "decimals": 8,
       "name": "TrueFlip",
       "symbol": "TFL"
+    },
+    {
+      "address": "0xaeF4F02E31CdbF007f8D98da4aE365188A0E9eCC",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "The Famous Token",
+      "symbol": "TFT"
     },
     {
       "address": "0xF8e06E4e4A80287FDCa5b02dcCecAa9D0954840F",
@@ -21027,6 +22461,13 @@
       "symbol": "TKLN"
     },
     {
+      "address": "0x2b5016CeA1C425f915E13727f7657025de3208Fe",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Tokemon",
+      "symbol": "TKMN"
+    },
+    {
       "address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
       "chainId": 1,
       "decimals": 8,
@@ -21092,6 +22533,13 @@
       "decimals": 8,
       "name": "Telex",
       "symbol": "TLX"
+    },
+    {
+      "address": "0xe13559cf6eDf84bD04bf679e251f285000B9305E",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "TMC NiftyGotchi",
+      "symbol": "TMC"
     },
     {
       "address": "0x6E742E29395Cf5736c358538f0f1372AB3dFE731",
@@ -21243,6 +22691,13 @@
       "symbol": "TOP"
     },
     {
+      "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Tornado Cash",
+      "symbol": "TORN"
+    },
+    {
       "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
       "chainId": 1,
       "decimals": 18,
@@ -21373,6 +22828,13 @@
       }
     },
     {
+      "address": "0x2eC75589856562646afE393455986CaD26c4Cc5f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Interop",
+      "symbol": "TROP"
+    },
+    {
       "address": "0xCb94be6f13A1182E4A4B6140cb7bf2025d28e41B",
       "chainId": 1,
       "decimals": 6,
@@ -21432,6 +22894,13 @@
       "symbol": "TRXC"
     },
     {
+      "address": "0xc12eCeE46ed65D970EE5C899FCC7AE133AfF9b03",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Try Finance",
+      "symbol": "TRY"
+    },
+    {
       "address": "0x2C537E5624e4af88A7ae4060C022609376C8D0EB",
       "chainId": 1,
       "decimals": 6,
@@ -21440,13 +22909,6 @@
       "extensions": {
         "isVerified": true
       }
-    },
-    {
-      "address": "0x23935765cDf2F7548F86042Ff053D16A22C4e240",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "TRADEZ",
-      "symbol": "TRZ"
     },
     {
       "address": "0x4846239FDF4D4C1AEB26729fa064B0205acA90e1",
@@ -21593,6 +23055,13 @@
       "symbol": "TXL"
     },
     {
+      "address": "0x888888877A18532b78d259577d00057054C50Dd8",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Universal Dollar",
+      "symbol": "U8D"
+    },
+    {
       "address": "0x01C0987E88F778DF6640787226bc96354E1a9766",
       "chainId": 1,
       "decimals": 18,
@@ -21692,13 +23161,6 @@
       "symbol": "UDOO"
     },
     {
-      "address": "0xa5a283557653f36cf9aA0d5cC74B1e30422349f2",
-      "chainId": 1,
-      "decimals": 8,
-      "name": "Useless Eth Token L",
-      "symbol": "UETL"
-    },
-    {
       "address": "0x995dE3D961b40Ec6CDee0009059D48768ccbdD48",
       "chainId": 1,
       "decimals": 8,
@@ -21710,7 +23172,10 @@
       "chainId": 1,
       "decimals": 18,
       "name": "Upfiring",
-      "symbol": "UFR"
+      "symbol": "UFR",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1",
@@ -21922,6 +23387,13 @@
       }
     },
     {
+      "address": "0x6fC13EACE26590B80cCCAB1ba5d51890577D83B2",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Umbrella Network",
+      "symbol": "UMB"
+    },
+    {
       "address": "0x105d97ef2E723f1cfb24519Bc6fF15a6D091a3F1",
       "chainId": 1,
       "decimals": 4,
@@ -21978,6 +23450,13 @@
       "decimals": 18,
       "name": "UniDexBot",
       "symbol": "UNDB"
+    },
+    {
+      "address": "0xA5959E9412d27041194c3c3bcBE855faCE2864F7",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "UniDexGas",
+      "symbol": "UNDG"
     },
     {
       "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -22171,7 +23650,7 @@
       "address": "0x9E78b8274e1D6a76a0dBbf90418894DF27cBCEb5",
       "chainId": 1,
       "decimals": 18,
-      "name": "Unifi",
+      "name": "Covenants",
       "symbol": "UNIFI"
     },
     {
@@ -23942,6 +25421,13 @@
       "symbol": "USDe"
     },
     {
+      "address": "0x2B4200A8D373d484993C37d63eE14AeE0096cd12",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "USDFreeLiquidity",
+      "symbol": "USDFL"
+    },
+    {
       "address": "0x1c48f86ae57291F7686349F12601910BD8D470bb",
       "chainId": 1,
       "decimals": 18,
@@ -24238,6 +25724,13 @@
       "symbol": "UWL"
     },
     {
+      "address": "0x9F801c1F02AF03cC240546DadEf8e56Cd46EA2E9",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Vaiot",
+      "symbol": "VAI"
+    },
+    {
       "address": "0xe88f8313e61A97cEc1871EE37fBbe2a8bf3ed1E4",
       "chainId": 1,
       "decimals": 18,
@@ -24460,7 +25953,7 @@
       "address": "0xe8Ff5C9c75dEb346acAc493C463C8950Be03Dfba",
       "chainId": 1,
       "decimals": 18,
-      "name": "VIBE Coin",
+      "name": "VIBE",
       "symbol": "VIBE"
     },
     {
@@ -24469,13 +25962,6 @@
       "decimals": 18,
       "name": "VIBEX Exchange Token",
       "symbol": "VIBEX"
-    },
-    {
-      "address": "0x53Db6b7fee89383435e424764A8478ACDA4DD2cD",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "Vibz8",
-      "symbol": "VIBS"
     },
     {
       "address": "0x2C9023bBc572ff8dc1228c7858A280046Ea8C9E5",
@@ -24669,6 +26155,16 @@
       "symbol": "VOLTS"
     },
     {
+      "address": "0x1BBf25e71EC48B84d773809B4bA55B6F4bE946Fb",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Vow",
+      "symbol": "VOW",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x12D102F06da35cC0111EB58017fd2Cd28537d0e1",
       "chainId": 1,
       "decimals": 18,
@@ -24721,11 +26217,11 @@
       "symbol": "VRS"
     },
     {
-      "address": "0x24e96809B4E720Ea911bc3De8341400E26d6E994",
+      "address": "0x87DE305311D5788e8da38D19bb427645b09CB4e5",
       "chainId": 1,
       "decimals": 18,
-      "name": "VINYL RECORDS TOKEN",
-      "symbol": "VRTN"
+      "name": "Verox",
+      "symbol": "VRX"
     },
     {
       "address": "0xBA3a79D758f19eFe588247388754b8e4d6EddA81",
@@ -24760,6 +26256,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Vesper Finance",
+      "symbol": "VSP"
     },
     {
       "address": "0xf0E3543744AFcEd8042131582f2A19b6AEb82794",
@@ -24896,6 +26399,13 @@
       "decimals": 18,
       "name": "YieldWars",
       "symbol": "WAR"
+    },
+    {
+      "address": "0xEd40834A13129509A89be39a9bE9C0E96A0DDd71",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Warp Finance",
+      "symbol": "WARP"
     },
     {
       "address": "0x829A4cA1303383F1082B6B1fB937116e4b3b5605",
@@ -25376,6 +26886,13 @@
       "symbol": "WORK"
     },
     {
+      "address": "0xBF494F02EE3FdE1F20BEE6242bCe2d1ED0c15e47",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "World Token",
+      "symbol": "WORLD"
+    },
+    {
       "address": "0x34950Ff2b487d9E5282c5aB342d08A2f712eb79F",
       "chainId": 1,
       "decimals": 18,
@@ -25435,6 +26952,13 @@
       "symbol": "WRLD"
     },
     {
+      "address": "0x2B89bF8ba858cd2FCee1faDa378D5cd6936968Be",
+      "chainId": 1,
+      "decimals": 6,
+      "name": "Secret  ERC20",
+      "symbol": "WSCRT"
+    },
+    {
       "address": "0x1d9a3CeF66B01D44003b9db0e00ec3fd44746988",
       "chainId": 1,
       "decimals": 18,
@@ -25475,6 +26999,13 @@
       "decimals": 18,
       "name": "Wrapped Virgin Gen",
       "symbol": "WVG0"
+    },
+    {
+      "address": "0xC237868a9c5729bdF3173dDDacaa336a0a5BB6e0",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "Wrapped Wagerr",
+      "symbol": "WWGR"
     },
     {
       "address": "0x8A91eEcd3F6b6B7833fD6961E7f654C3d016a068",
@@ -25750,6 +27281,13 @@
       }
     },
     {
+      "address": "0xE4E822C0d5b329E8BB637972467d2E313824eFA0",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Dfinance",
+      "symbol": "XFI"
+    },
+    {
       "address": "0x1fa21b20222076D7465fb901E5f459289c95F66a",
       "chainId": 1,
       "decimals": 18,
@@ -25879,6 +27417,13 @@
       "symbol": "xKLAY"
     },
     {
+      "address": "0x0bfEc35a1A3550Deed3F6fC76Dde7FC412729a91",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "xKNCa",
+      "symbol": "XKNCA"
+    },
+    {
       "address": "0x1d086b868d78040635CB8600bA733f12DB48cB42",
       "chainId": 1,
       "decimals": 18,
@@ -25908,6 +27453,13 @@
       "decimals": 18,
       "name": "MobileCoin MOBILECOIN Futures",
       "symbol": "xMOBILECOIN"
+    },
+    {
+      "address": "0x3aaDA3e213aBf8529606924d8D1c55CbDc70Bf74",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "XMON",
+      "symbol": "XMON"
     },
     {
       "address": "0x0f8c45B896784A1E408526B9300519ef8660209c",
@@ -26003,6 +27555,13 @@
       "symbol": "XPAY"
     },
     {
+      "address": "0xbC81BF5B3173BCCDBE62dba5f5b695522aD63559",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Transmute",
+      "symbol": "XPB"
+    },
+    {
       "address": "0xD7EFB00d12C2c13131FD319336Fdf952525dA2af",
       "chainId": 1,
       "decimals": 4,
@@ -26086,6 +27645,13 @@
       "symbol": "XSP"
     },
     {
+      "address": "0x91383A15C391c142b80045D8b4730C1c37ac0378",
+      "chainId": 1,
+      "decimals": 9,
+      "name": "XStable",
+      "symbol": "XST"
+    },
+    {
       "address": "0xC0E47007e084EEF3EE58eb33D777b3B4Ca98622f",
       "chainId": 1,
       "decimals": 18,
@@ -26122,6 +27688,13 @@
       "extensions": {
         "isVerified": true
       }
+    },
+    {
+      "address": "0x5Cc737A37A02a1B34ba8edf899aa6441765232A0",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "Burn Yield Burn",
+      "symbol": "XYX"
     },
     {
       "address": "0x0AaCfbeC6a24756c20D41914F2caba817C0d8521",
@@ -26255,8 +27828,11 @@
       "address": "0xb4bebD34f6DaaFd808f73De0d10235a92Fbb6c3D",
       "chainId": 1,
       "decimals": 18,
-      "name": "Yearn Ecosystem Tok",
-      "symbol": "YETI"
+      "name": "Yearn Ecosystem Token Index",
+      "symbol": "YETI",
+      "extensions": {
+        "isVerified": true
+      }
     },
     {
       "address": "0xf4CD3d3Fda8d7Fd6C5a500203e38640A70Bf9577",
@@ -26532,6 +28108,13 @@
       }
     },
     {
+      "address": "0x7b760D06E401f85545F3B50c44bf5B05308b7b62",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "YFLink USD",
+      "symbol": "YFLUSD"
+    },
+    {
       "address": "0x7aFaC1D878C66A47263DCe57976C371Ae2e74882",
       "chainId": 1,
       "decimals": 18,
@@ -26544,6 +28127,13 @@
       "decimals": 18,
       "name": "YFMoonshot",
       "symbol": "YFMS"
+    },
+    {
+      "address": "0xAc0C8dA4A4748d8d821A0973d00b157aA78C473D",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "YFIONE",
+      "symbol": "YFO"
     },
     {
       "address": "0xCd254568EBF88f088E40f456db9E17731243cb25",
@@ -26624,6 +28214,13 @@
       "decimals": 18,
       "name": "Toshify finance",
       "symbol": "YFT"
+    },
+    {
+      "address": "0x94F31aC896c9823D81cf9C2C93feCEeD4923218f",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "YFTether",
+      "symbol": "YFTE"
     },
     {
       "address": "0xbD301BE09eB78Df47019aa833D29eDc5D815D838",
@@ -26759,6 +28356,13 @@
       "symbol": "YOK"
     },
     {
+      "address": "0xAE1eaAE3F627AAca434127644371b67B18444051",
+      "chainId": 1,
+      "decimals": 8,
+      "name": "Yield Optimization",
+      "symbol": "YOP"
+    },
+    {
       "address": "0x3D371413dd5489F3A04C07c0C2CE369c20986ceb",
       "chainId": 1,
       "decimals": 10,
@@ -26771,6 +28375,13 @@
       "decimals": 18,
       "name": "YOYOW",
       "symbol": "YOYOW"
+    },
+    {
+      "address": "0x17525E4f4Af59fbc29551bC4eCe6AB60Ed49CE31",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "PieDAO Yearn Ecosys",
+      "symbol": "YPIE"
     },
     {
       "address": "0x40E7705254494a7E61D5b7c86da50225DDc3DaAE",
@@ -26903,6 +28514,13 @@
       }
     },
     {
+      "address": "0xc5bDdf9843308380375a611c18B50Fb9341f502A",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "veCRV DAO yVault",
+      "symbol": "YVE-CRVDAO"
+    },
+    {
       "address": "0xEC681F28f4561c2a9534799AA38E0d36A83Cf478",
       "chainId": 1,
       "decimals": 18,
@@ -26915,6 +28533,13 @@
       "decimals": 18,
       "name": "YYFI Protocol",
       "symbol": "YYFI"
+    },
+    {
+      "address": "0x75D1aA733920b14fC74c9F6e6faB7ac1EcE8482E",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "YFLink Staking Share",
+      "symbol": "yYFL"
     },
     {
       "address": "0x2cd9324bA13b77554592d453e6364086FbBa446a",
@@ -27051,6 +28676,16 @@
       "symbol": "ZERA"
     },
     {
+      "address": "0xF0939011a9bb95c3B791f0cb546377Ed2693a574",
+      "chainId": 1,
+      "decimals": 18,
+      "name": "Zero Exchange",
+      "symbol": "ZERO",
+      "extensions": {
+        "isVerified": true
+      }
+    },
+    {
       "address": "0x757703bD5B2c4BBCfde0BE2C0b0E7C2f31FCf4E9",
       "chainId": 1,
       "decimals": 18,
@@ -27166,7 +28801,7 @@
       }
     },
     {
-      "address": "0x42382F39e7C9F1ADD5fa5f0c6e24aa62f50be3b3",
+      "address": "0x5091aEd52Ad421969254E48d29aa1d1807E1870b",
       "chainId": 1,
       "decimals": 18,
       "name": "ZOM",
@@ -27202,13 +28837,6 @@
       "decimals": 9,
       "name": "Zoracles",
       "symbol": "ZORA"
-    },
-    {
-      "address": "0x045Eb7e34e94B28C7A3641BC5e1A1F61f225Af9F",
-      "chainId": 1,
-      "decimals": 18,
-      "name": "ZelaaPayAE",
-      "symbol": "ZPAE"
     },
     {
       "address": "0xb5b8F5616Fe42d5ceCA3e87F3FddbDd8F496d760",
@@ -27254,6 +28882,13 @@
       "symbol": "ZUM"
     },
     {
+      "address": "0xbf0f3cCB8fA385A287106FbA22e6BB722F94d686",
+      "chainId": 1,
+      "decimals": 6,
+      "name": "Zytara Dollar",
+      "symbol": "ZUSD"
+    },
+    {
       "address": "0x83F873388Cd14b83A9f47FabDe3C9850b5C74548",
       "chainId": 1,
       "decimals": 18,
@@ -27272,13 +28907,6 @@
       "extensions": {
         "isVerified": true
       }
-    },
-    {
-      "address": "0x1f6bd8766f8a8AA58F7441C8dd3709aFA3a56202",
-      "chainId": 1,
-      "decimals": 8,
-      "name": "Zyro",
-      "symbol": "ZYRO"
     },
     {
       "address": "0xc75F15AdA581219c95485c578E124df3985e4CE0",


### PR DESCRIPTION
Previously, we were relying on the Uniswap subgraph to return all the tokens, and we would mark them as curated if we found them in the curated list.

Now, we always use the curated list and exclude these from the initial subgraph query for all tokens.

Also added POOL token to the curated list (updated rainbow-token-list package)

PoW: https://recordit.co/1xinos8AFP
Tested: SOCKS, stETH, and POOL all work as expected