### PR TITLE
Sort subgraph all tokens query by USD trade volume

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -60,7 +60,7 @@ export const UNISWAP_ALL_TOKENS = gql`
     tokens(
       first: $first
       skip: $skip
-      orderBy: totalLiquidity
+      orderBy: tradeVolumeUSD
       orderDirection: desc
       where: { id_not_in: $excluded, totalLiquidity_gt: 0 }
     ) {


### PR DESCRIPTION
Previously, when we were fetching all of the tokens with any liquidity, we were calculating the ETH value of the liquidity by multiplying liquidity * derivedETH. 
The orderBy totalLiquidity didn't matter that much since we were getting all the relevant assets and sorting them later.

Now, given the 5k skip limit, we should be a bit more selective about which assets we fetch via the orderBy, and USD trade volume seems to be the most accurate metric out of the fields available.