### PR TITLE
Keeping slippage fixed at 50 bips

### DIFF
--- a/src/handlers/uniswap.ts
+++ b/src/handlers/uniswap.ts
@@ -67,9 +67,6 @@ enum SwapType {
 
 const UniswapPageSize = 1000;
 
-const DefaultMaxSlippageInBips = 200;
-const SlippageBufferInBips = 100;
-
 // default allowed slippage, in bips
 const INITIAL_ALLOWED_SLIPPAGE = 50;
 // 20 minutes, denominated in seconds
@@ -347,20 +344,13 @@ const getContractExecutionDetails = ({
   providerOrSigner: Provider | Signer;
   tradeDetails: Trade;
 }) => {
-  const priceImpact = tradeDetails?.priceImpact?.toFixed(2).toString();
-  const slippage = Number(priceImpact) * 100;
-  const maxSlippage = Math.max(
-    slippage + SlippageBufferInBips,
-    DefaultMaxSlippageInBips
-  );
   const { methodArguments, methodNames, value } = getExecutionDetails(
     accountAddress,
     chainId,
     inputCurrency,
     outputCurrency,
     tradeDetails,
-    providerOrSigner,
-    maxSlippage
+    providerOrSigner
   );
 
   const exchange = new Contract(


### PR DESCRIPTION
Previously we were not being precise about the concepts of price impact and slippage.

We should keep the slippage fixed at the same default Uniswap uses (0.5% or 50 bips). In the future, we may include UI to allow users to update the slippage they are comfortable with.

Please note that this is separate from "price impact" which is taken into account in the execution price we provide to the user.