### PR TITLE
set height of the sheet

### DIFF
--- a/src/components/discover-sheet/DiscoverSheet.js
+++ b/src/components/discover-sheet/DiscoverSheet.js
@@ -197,6 +197,7 @@ function DiscoverSheetIOS(_, forwardedRef) {
         presentGlobally={false}
         ref={ref}
         scrollsToTopOnTapStatusBar={isFocused}
+        shortFormHeight={260}
         showDragIndicator={false}
         topOffset={insets.top}
         unmountAnimation={false}


### PR DESCRIPTION
Now it looks slightly better (no "Lists" header visible) and on a small iPhone, it's not covering the scanner 

![image](https://user-images.githubusercontent.com/25709300/108510563-5bd9f080-72c7-11eb-8a1a-24e85a25ce96.png)
