### PR TITLE
fix: ensure anisotropic transform sensitive to ts

### DIFF
--- a/metro.transform.js
+++ b/metro.transform.js
@@ -14,6 +14,9 @@ module.exports.transform = function applyRainbowTransform({
           '@react-native-community/clipboard': {},
           'react-native-keychain': {},
         },
+        madge: {
+          tsConfig: require.resolve('./tsconfig.json'),
+        },
       },
     },
   });


### PR DESCRIPTION
Update [`madge`](https://github.com/pahen/madge) options to ensure TypeScript files are processed by the anisotropic transform.