### PR TITLE
Fix discover doesn't reliably scroll to top when entering search mode

### DIFF
--- a/src/components/discover-sheet/DiscoverSheet.js
+++ b/src/components/discover-sheet/DiscoverSheet.js
@@ -174,7 +174,7 @@ function DiscoverSheetIOS(_, forwardedRef) {
   useImperativeHandle(forwardedRef, () => value);
 
   useEffect(() => {
-    sheet.current.scrollTo({ x: 0, y: 0 });
+    sheet.current.scrollTo({ animated: false, x: 0, y: 0 });
   }, [headerButtonsHandlers.isSearchModeEnabled]);
 
   // noinspection JSConstructorReturnsPrimitive


### PR DESCRIPTION
Closes https://linear.app/rainbow/issue/RNBW-1023/discover-doesnt-reliably-scroll-to-top-when-entering-search-mode

Basically, animated scrolling can be interrupted by some rerenders. However, here this change does not to be explicitly animated since we are animating things with  `LayoutAnimations` here 