### PR TITLE
Fix on press searchFab button action + add jumping to long form

### DIFF
--- a/src/components/discover-sheet/DiscoverSearchContainer.js
+++ b/src/components/discover-sheet/DiscoverSearchContainer.js
@@ -46,7 +46,12 @@ export default forwardRef(function DiscoverSearchContainer(
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const upperContext = useContext(DiscoverSheetContext);
-  const { setIsSearchModeEnabled, isSearchModeEnabled } = upperContext;
+  const {
+    setIsSearchModeEnabled,
+    isSearchModeEnabled,
+    jumpToLong,
+    onFabSearch,
+  } = upperContext;
   const {
     params: { setSwipeEnabled: setViewPagerSwipeEnabled },
   } = useRoute();
@@ -58,10 +63,16 @@ export default forwardRef(function DiscoverSearchContainer(
   const setIsInputFocused = useCallback(
     value => {
       setShowSearch(value);
+      jumpToLong();
       setIsSearchModeEnabled(value);
       setViewPagerSwipeEnabled(!value);
     },
-    [setIsSearchModeEnabled, setShowSearch, setViewPagerSwipeEnabled]
+    [
+      setIsSearchModeEnabled,
+      setShowSearch,
+      setViewPagerSwipeEnabled,
+      jumpToLong,
+    ]
   );
 
   const onTapSearch = useCallback(() => {
@@ -79,7 +90,7 @@ export default forwardRef(function DiscoverSearchContainer(
     }
   }, [isSearchModeEnabled, setIsInputFocused]);
 
-  upperContext.onFabSearch.current = onTapSearch;
+  onFabSearch.current = onTapSearch;
 
   useEffect(() => {
     if (!isSearchModeEnabled) {

--- a/src/screens/QRScannerScreen.js
+++ b/src/screens/QRScannerScreen.js
@@ -143,7 +143,7 @@ export default function QRScannerScreen() {
       </View>
       <FabWrapper
         fabs={[SearchFab]}
-        onPress={dsRef.current?.onFabSearch?.current}
+        onPress={() => dsRef.current?.onFabSearch?.current()}
       />
     </>
   );


### PR DESCRIPTION
closes https://linear.app/rainbow/issue/RNBW-1028/tapping-search-fab-in-search-mode-should-refocus-search-input