### PR TITLE
Fix height of liquidity pools

### DIFF
--- a/src/components/expanded-state/LiquidityPoolExpandedState.js
+++ b/src/components/expanded-state/LiquidityPoolExpandedState.js
@@ -20,7 +20,7 @@ import { toChecksumAddress } from '@rainbow-me/handlers/web3';
 import { useChartThrottledPoints, useDimensions } from '@rainbow-me/hooks';
 import { magicMemo } from '@rainbow-me/utils';
 
-const heightWithoutChart = 373 + (android ? 20 - getSoftMenuBarHeight() : -153);
+const heightWithoutChart = 373 + (android ? 20 - getSoftMenuBarHeight() : 0);
 const heightWithChart = heightWithoutChart + 297;
 
 export const initialLiquidityPoolExpandedStateSheetHeight = heightWithChart;


### PR DESCRIPTION
Closes https://linear.app/rainbow/issue/RNBW-1027/pool-expanded-state-sheet-is-cut-off-if-you-own-the-pool-asset