### PR TITLE
Fix scrolling to top on Discover page

### DIFF
--- a/src/components/discover-sheet/ListsSection.js
+++ b/src/components/discover-sheet/ListsSection.js
@@ -290,6 +290,7 @@ export default function ListSection() {
               keyExtractor={item => item.id}
               ref={listRef}
               renderItem={renderItem}
+              scrollsToTop={false}
               showsHorizontalScrollIndicator={false}
             />
             <EdgeFade />

--- a/src/components/discover-sheet/UniswapPoolsSection.js
+++ b/src/components/discover-sheet/UniswapPoolsSection.js
@@ -169,6 +169,7 @@ export default function UniswapPools() {
             keyExtractor={item => item.id}
             ref={listRef}
             renderItem={renderItem}
+            scrollsToTop={false}
             showsHorizontalScrollIndicator={false}
           />
           <EdgeFade />

--- a/src/components/exchange/ExchangeAssetList.js
+++ b/src/components/exchange/ExchangeAssetList.js
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native';
 import React, {
   forwardRef,
   useCallback,
@@ -154,6 +155,8 @@ const ExchangeAssetList = (
     []
   );
 
+  const isFocused = useIsFocused();
+
   return (
     <ExchangeAssetSectionList
       keyboardDismissMode={keyboardDismissMode}
@@ -161,6 +164,7 @@ const ExchangeAssetList = (
       ref={sectionListRef}
       renderItem={renderItemCallback}
       renderSectionHeader={ExchangeAssetSectionListHeader}
+      scrollsToTop={isFocused}
       sections={items.map(createItem)}
     />
   );


### PR DESCRIPTION
Closes: https://linear.app/rainbow/issue/RNBW-1019/tapping-the-status-bar-to-scroll-to-top-is-broken-everywhere-except-in