### PR TITLE
@cawfree/metro transform ci

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,3 +1,5 @@
+require('dotenv/config');
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 const blacklist = require('metro-config/src/defaults/blacklist');
 
@@ -12,17 +14,31 @@ const blacklistRE = blacklist([
   /patches\/reanimated\/.*/,
 ]);
 
-module.exports = {
-  resolver: {
-    blacklistRE,
-  },
-  transformer: {
-    babelTransformerPath: require.resolve('./metro.transform.js'),
+const createTransformer = ({ applyMetroTransform }) => {
+  const common = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: true,
         inlineRequires: true,
       },
     }),
+  };
+  if (applyMetroTransform) {
+    return {
+      ...common,
+      babelTransformerPath: require.resolve('./metro.transform.js'),
+    };
+  }
+  return common;
+};
+
+const { CI } = process.env;
+
+module.exports = {
+  resolver: {
+    blacklistRE,
   },
+  transformer: createTransformer({
+    applyMetroTransform: !!CI,
+  }),
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -39,6 +39,6 @@ module.exports = {
     blacklistRE,
   },
   transformer: createTransformer({
-    applyMetroTransform: !!CI,
+    applyMetroTransform: CI === 'true',
   }),
 };


### PR DESCRIPTION
Only applies the anisotropic transform when the [`CI` env variable](https://devcenter.bitrise.io/builds/available-environment-variables/) is set to ` 'true'`.

This avoids developers having to locally watch for erroneous dependency relationships on local machines, which which will drastically improve bundler time.