### PR TITLE
@jin/price impact native

### DIFF
--- a/src/components/exchange/ExchangeDetailsRow.js
+++ b/src/components/exchange/ExchangeDetailsRow.js
@@ -10,11 +10,7 @@ import styled from 'styled-components';
 import { Centered, Row } from '../layout';
 import ExchangeDetailsButton from './ExchangeDetailsButton';
 import PriceImpactWarning from './PriceImpactWarning';
-import {
-  usePrevious,
-  useSwapCurrencies,
-  useSwapIsSufficientBalance,
-} from '@rainbow-me/hooks';
+import { usePrevious, useSwapCurrencies } from '@rainbow-me/hooks';
 import { padding, position } from '@rainbow-me/styles';
 
 const defaultPriceImpactScale = 1.15;
@@ -68,10 +64,8 @@ export default function ExchangeDetailsRow({
     transform: [{ scale: priceImpactScale.value }],
   }));
 
-  const isSufficientBalance = useSwapIsSufficientBalance(inputAmount);
-
   const isPriceImpactWarningVisible =
-    isSufficientBalance && !!inputAmount && !!outputAmount && isHighPriceImpact;
+    !!inputAmount && !!outputAmount && isHighPriceImpact;
   const prevIsPriceImpactWarningVisible = usePrevious(
     isPriceImpactWarningVisible
   );
@@ -120,6 +114,7 @@ export default function ExchangeDetailsRow({
         pointerEvents={isPriceImpactWarningVisible ? 'auto' : 'none'}
         priceImpactColor={priceImpactColor}
         priceImpactNativeAmount={priceImpactNativeAmount}
+        priceImpactPercentDisplay={priceImpactPercentDisplay}
         style={priceImpactAnimatedStyle}
       />
       <AnimatedExchangeDetailsButtonRow

--- a/src/components/exchange/PriceImpactWarning.js
+++ b/src/components/exchange/PriceImpactWarning.js
@@ -14,7 +14,7 @@ const Content = styled(Centered).attrs({
 `;
 
 const Label = styled(Text).attrs(
-  ({ theme: { colors }, color = colors.white, letterSpacing }) => ({
+  ({ theme: { colors }, color = colors.blueGreyDark80, letterSpacing }) => ({
     color,
     letterSpacing,
     size: 'large',
@@ -26,18 +26,22 @@ export default function PriceImpactWarning({
   onPress,
   priceImpactColor,
   priceImpactNativeAmount,
+  priceImpactPercentDisplay,
   style,
   ...props
 }) {
+  const heading = priceImpactNativeAmount ? 'Losing' : 'Price impact';
+  const headingValue =
+    priceImpactNativeAmount ?? `${priceImpactPercentDisplay}%`;
   return (
     <Animated.View {...props} style={[style, position.coverAsObject]}>
       <ButtonPressAnimation onPress={onPress} scaleTo={1.06}>
         <Content>
           <Label color={priceImpactColor}>{`􀇿 `}</Label>
           <Label>Small Market</Label>
-          <Label color={priceImpactColor}>{` • Losing `}</Label>
+          <Label color={priceImpactColor}>{` • ${heading} `}</Label>
           <Label color={priceImpactColor} letterSpacing="roundedTight">
-            {priceImpactNativeAmount}
+            {headingValue}
           </Label>
         </Content>
       </ButtonPressAnimation>

--- a/src/components/expanded-state/SwapDetailsState.js
+++ b/src/components/expanded-state/SwapDetailsState.js
@@ -96,7 +96,7 @@ export default function SwapDetailsState({
   const insets = useSafeArea();
 
   const {
-    derivedValues: { inputAmount, outputAmount },
+    derivedValues: { inputAmount, nativeAmount, outputAmount },
     tradeDetails,
   } = useSwapDerivedOutputs();
   const {
@@ -104,7 +104,7 @@ export default function SwapDetailsState({
     priceImpactColor,
     priceImpactNativeAmount,
     priceImpactPercentDisplay,
-  } = usePriceImpactDetails(outputAmount, tradeDetails);
+  } = usePriceImpactDetails(nativeAmount, outputAmount, tradeDetails);
 
   const {
     copiedText,
@@ -189,12 +189,14 @@ export default function SwapDetailsState({
           onLayout={setSlippageMessageHeight}
           priceImpactColor={priceImpactColor}
           priceImpactNativeAmount={priceImpactNativeAmount}
+          priceImpactPercentDisplay={priceImpactPercentDisplay}
         />
         <SwapDetailsContent
           isHighPriceImpact={isHighPriceImpact}
           onCopySwapDetailsText={onCopySwapDetailsText}
           onLayout={setContentHeight}
           priceImpactColor={priceImpactColor}
+          priceImpactNativeAmount={priceImpactNativeAmount}
           priceImpactPercentDisplay={priceImpactPercentDisplay}
           tradeDetails={tradeDetails}
         />

--- a/src/components/expanded-state/SwapDetailsState.js
+++ b/src/components/expanded-state/SwapDetailsState.js
@@ -100,7 +100,9 @@ export default function SwapDetailsState({
     tradeDetails,
   } = useSwapDerivedOutputs();
   const {
+    inputPriceValue,
     isHighPriceImpact,
+    outputPriceValue,
     priceImpactColor,
     priceImpactNativeAmount,
     priceImpactPercentDisplay,
@@ -180,8 +182,10 @@ export default function SwapDetailsState({
         </Header>
         <SwapDetailsMasthead
           inputAmount={inputAmount}
+          inputPriceValue={inputPriceValue}
           isHighPriceImpact={isHighPriceImpact}
           outputAmount={outputAmount}
+          outputPriceValue={outputPriceValue}
           priceImpactColor={priceImpactColor}
         />
         <SwapDetailsSlippageMessage

--- a/src/components/expanded-state/SwapDetailsState.js
+++ b/src/components/expanded-state/SwapDetailsState.js
@@ -96,7 +96,7 @@ export default function SwapDetailsState({
   const insets = useSafeArea();
 
   const {
-    derivedValues: { inputAmount, nativeAmount, outputAmount },
+    derivedValues: { inputAmount, outputAmount },
     tradeDetails,
   } = useSwapDerivedOutputs();
   const {
@@ -104,7 +104,7 @@ export default function SwapDetailsState({
     priceImpactColor,
     priceImpactNativeAmount,
     priceImpactPercentDisplay,
-  } = usePriceImpactDetails(nativeAmount, outputAmount, tradeDetails);
+  } = usePriceImpactDetails(inputAmount, outputAmount, tradeDetails);
 
   const {
     copiedText,

--- a/src/components/expanded-state/swap-details/CurrencyTile.js
+++ b/src/components/expanded-state/swap-details/CurrencyTile.js
@@ -10,6 +10,7 @@ import {
   updatePrecisionToDisplay,
 } from '@rainbow-me/helpers/utilities';
 import { useAccountSettings, useColorForAsset } from '@rainbow-me/hooks';
+import { SwapModalField } from '@rainbow-me/redux/swap';
 import { position } from '@rainbow-me/styles';
 
 export const CurrencyTileHeight = 143;
@@ -62,10 +63,15 @@ export default function CurrencyTile({
   ...props
 }) {
   const genericAssets = useSelector(state => state.data.genericAssets);
+  const inputAsExact = useSelector(
+    state => state.swap.independentField !== SwapModalField.output
+  );
   const { nativeCurrency } = useAccountSettings();
   const colorForAsset = useColorForAsset(asset);
   const { address, symbol } = asset;
   const priceValue = genericAssets[address]?.price?.value ?? 0;
+  const isOther =
+    (inputAsExact && type === 'output') || (!inputAsExact && type === 'input');
 
   const { amountDisplay, priceDisplay } = useMemo(() => {
     const data = [amount, priceValue];
@@ -92,7 +98,7 @@ export default function CurrencyTile({
           </NativePriceText>
           <Row align="center">
             <TruncatedAmountText>
-              {`${type === 'output' ? '~' : ''}${amountDisplay}`}
+              {`${isOther ? '~' : ''}${amountDisplay}`}
             </TruncatedAmountText>
             <AmountText>{` ${symbol}`}</AmountText>
           </Row>

--- a/src/components/expanded-state/swap-details/CurrencyTile.js
+++ b/src/components/expanded-state/swap-details/CurrencyTile.js
@@ -59,22 +59,21 @@ export default function CurrencyTile({
   asset,
   isHighPriceImpact,
   priceImpactColor,
+  priceValue,
   type = 'input',
   ...props
 }) {
-  const genericAssets = useSelector(state => state.data.genericAssets);
   const inputAsExact = useSelector(
     state => state.swap.independentField !== SwapModalField.output
   );
   const { nativeCurrency } = useAccountSettings();
   const colorForAsset = useColorForAsset(asset);
   const { address, symbol } = asset;
-  const priceValue = genericAssets[address]?.price?.value ?? 0;
   const isOther =
     (inputAsExact && type === 'output') || (!inputAsExact && type === 'input');
 
   const { amountDisplay, priceDisplay } = useMemo(() => {
-    const data = [amount, priceValue];
+    const data = [amount, priceValue ?? 0];
     return {
       amountDisplay: updatePrecisionToDisplay(...data, true),
       priceDisplay: convertAmountAndPriceToNativeDisplay(

--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -27,6 +27,7 @@ export default function SwapDetailsContent({
   isHighPriceImpact,
   onCopySwapDetailsText,
   priceImpactColor,
+  priceImpactNativeAmount,
   priceImpactPercentDisplay,
   tradeDetails,
   ...props
@@ -42,11 +43,16 @@ export default function SwapDetailsContent({
       testID="swap-details-state"
       {...props}
     >
-      <SwapDetailsRow label="Price impact">
-        <SwapDetailsValue color={priceImpactColor} letterSpacing="roundedTight">
-          {`${priceImpactPercentDisplay}%`}
-        </SwapDetailsValue>
-      </SwapDetailsRow>
+      {(!isHighPriceImpact || priceImpactNativeAmount) && (
+        <SwapDetailsRow label="Price impact">
+          <SwapDetailsValue
+            color={priceImpactColor}
+            letterSpacing="roundedTight"
+          >
+            {`${priceImpactPercentDisplay}%`}
+          </SwapDetailsValue>
+        </SwapDetailsRow>
+      )}
       <SwapDetailsRow label={receivedSoldLabel}>
         <SwapDetailsValue letterSpacing="roundedTight">
           {amountReceivedSold}

--- a/src/components/expanded-state/swap-details/SwapDetailsMasthead.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsMasthead.js
@@ -20,8 +20,10 @@ const Container = styled(RowWithMargins).attrs({
 
 export default function SwapDetailsMasthead({
   inputAmount,
+  inputPriceValue,
   isHighPriceImpact,
   outputAmount,
+  outputPriceValue,
   priceImpactColor,
   ...props
 }) {
@@ -30,13 +32,19 @@ export default function SwapDetailsMasthead({
 
   return (
     <Container {...props}>
-      <CurrencyTile amount={inputAmount} asset={inputCurrency} type="input" />
+      <CurrencyTile
+        amount={inputAmount}
+        asset={inputCurrency}
+        priceValue={inputPriceValue}
+        type="input"
+      />
       <Icon color={colors.dark} name="doubleChevron" />
       <CurrencyTile
         amount={outputAmount}
         asset={outputCurrency}
         isHighPriceImpact={isHighPriceImpact}
         priceImpactColor={priceImpactColor}
+        priceValue={outputPriceValue}
         type="output"
       />
     </Container>

--- a/src/components/expanded-state/swap-details/SwapDetailsSlippageMessage.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsSlippageMessage.js
@@ -29,20 +29,24 @@ export default function SwapDetailsSlippageMessage({
   isHighPriceImpact,
   priceImpactColor,
   priceImpactNativeAmount,
+  priceImpactPercentDisplay,
   ...props
 }) {
   const { colors } = useTheme();
+  const heading = priceImpactNativeAmount ? 'Losing ' : 'Price impact is ';
+  const headingValue =
+    priceImpactNativeAmount ?? `${priceImpactPercentDisplay}%`;
   return isHighPriceImpact ? (
     <Column align="center" {...props}>
       <Container>
         <Row align="center">
-          <Heading color={priceImpactColor}>{`Losing `}</Heading>
+          <Heading color={priceImpactColor}>{heading}</Heading>
           <Heading
             color={priceImpactColor}
             letterSpacing="roundedTight"
             weight="heavy"
           >
-            {priceImpactNativeAmount}
+            {headingValue}
           </Heading>
           <Emoji size="larger">🥵</Emoji>
         </Row>

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -4,6 +4,9 @@ import { supportedNativeCurrencies } from '@rainbow-me/references';
 
 type BigNumberish = number | string | BigNumber;
 
+export const abs = (value: BigNumberish): string =>
+  new BigNumber(value).abs().toFixed();
+
 export const subtract = (
   numberOne: BigNumberish,
   numberTwo: BigNumberish

--- a/src/hooks/usePriceImpactDetails.ts
+++ b/src/hooks/usePriceImpactDetails.ts
@@ -99,7 +99,9 @@ export default function usePriceImpactDetails(
   }
 
   return {
+    inputPriceValue,
     isHighPriceImpact,
+    outputPriceValue,
     priceImpactColor,
     priceImpactNativeAmount,
     priceImpactPercentDisplay: priceImpact?.toFixed(),

--- a/src/hooks/usePriceImpactDetails.ts
+++ b/src/hooks/usePriceImpactDetails.ts
@@ -8,6 +8,7 @@ import {
   convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeAmount,
   convertAmountToNativeDisplay,
+  divide,
   multiply,
   subtract,
 } from '@rainbow-me/utilities';
@@ -52,6 +53,16 @@ export default function usePriceImpactDetails(
   const executionRate = tradeDetails?.executionPrice?.toSignificant();
 
   let inverseExecutionRate = null;
+
+  const originalOutputAmount = divide(
+    outputAmount ?? 0,
+    subtract(1, divide(priceImpact?.toSignificant() ?? 0, 100))
+  );
+
+  const realExecutionRate = inputAmount
+    ? divide(originalOutputAmount, inputAmount)
+    : 0;
+
   if (tradeDetails && !tradeDetails?.executionPrice?.equalTo('0')) {
     inverseExecutionRate = tradeDetails?.executionPrice
       ?.invert()
@@ -63,11 +74,10 @@ export default function usePriceImpactDetails(
   }
 
   if (!inputPriceValue && outputPriceValue && executionRate) {
-    inputPriceValue = multiply(outputPriceValue, executionRate);
+    inputPriceValue = multiply(outputPriceValue, realExecutionRate);
   }
 
   let priceImpactNativeAmount = null;
-
   if (inputAmount && inputPriceValue && outputPriceValue) {
     const nativeAmount = convertAmountToNativeAmount(
       inputAmount,

--- a/src/hooks/usePriceImpactDetails.ts
+++ b/src/hooks/usePriceImpactDetails.ts
@@ -9,6 +9,7 @@ import {
   convertAmountToNativeAmount,
   convertAmountToNativeDisplay,
   divide,
+  isZero,
   multiply,
   subtract,
 } from '@rainbow-me/utilities';
@@ -52,25 +53,22 @@ export default function usePriceImpactDetails(
 
   const executionRate = tradeDetails?.executionPrice?.toSignificant();
 
-  let inverseExecutionRate = null;
-
   const originalOutputAmount = divide(
     outputAmount ?? 0,
     subtract(1, divide(priceImpact?.toSignificant() ?? 0, 100))
   );
 
-  const realExecutionRate = inputAmount
-    ? divide(originalOutputAmount, inputAmount)
-    : 0;
+  const realExecutionRate =
+    inputAmount && !isZero(inputAmount)
+      ? divide(originalOutputAmount, inputAmount)
+      : 0;
+  const realInverseExecutionRate =
+    inputAmount && originalOutputAmount && !isZero(originalOutputAmount)
+      ? divide(inputAmount, originalOutputAmount)
+      : 0;
 
-  if (tradeDetails && !tradeDetails?.executionPrice?.equalTo('0')) {
-    inverseExecutionRate = tradeDetails?.executionPrice
-      ?.invert()
-      ?.toSignificant();
-  }
-
-  if (!outputPriceValue && inputPriceValue && inverseExecutionRate) {
-    outputPriceValue = multiply(inputPriceValue, inverseExecutionRate);
+  if (!outputPriceValue && inputPriceValue && realInverseExecutionRate) {
+    outputPriceValue = multiply(inputPriceValue, realInverseExecutionRate);
   }
 
   if (!inputPriceValue && outputPriceValue && executionRate) {

--- a/src/hooks/usePriceImpactDetails.ts
+++ b/src/hooks/usePriceImpactDetails.ts
@@ -4,8 +4,9 @@ import useAccountSettings from './useAccountSettings';
 import { useTheme } from '@rainbow-me/context';
 import { AppState } from '@rainbow-me/redux/store';
 import {
+  abs,
   convertAmountAndPriceToNativeDisplay,
-  divide,
+  convertAmountToNativeDisplay,
   subtract,
 } from '@rainbow-me/utilities';
 
@@ -13,6 +14,7 @@ const PriceImpactWarningThreshold = new Fraction('5', '100');
 const SeverePriceImpactThreshold = new Fraction('10', '100');
 
 export default function usePriceImpactDetails(
+  nativeAmount: string | null,
   outputAmount: string | null,
   tradeDetails: Trade
 ) {
@@ -41,19 +43,19 @@ export default function usePriceImpactDetails(
 
   const outputPriceValue =
     genericAssets[outputCurrencyAddress]?.price?.value ?? 0;
-  const originalOutputAmount = divide(
+
+  const outputNativeAmount = convertAmountAndPriceToNativeDisplay(
     outputAmount ?? 0,
-    subtract(1, divide(priceImpact?.toSignificant() ?? 0, 100))
-  );
-  const outputAmountDifference = subtract(
-    originalOutputAmount,
-    outputAmount ?? 0
-  );
-  const {
-    display: priceImpactNativeAmount,
-  } = convertAmountAndPriceToNativeDisplay(
-    outputAmountDifference,
     outputPriceValue,
+    nativeCurrency
+  ).amount;
+
+  const nativeAmountDifference = abs(
+    subtract(nativeAmount ?? 0, outputNativeAmount)
+  );
+
+  const priceImpactNativeAmount = convertAmountToNativeDisplay(
+    nativeAmountDifference,
     nativeCurrency
   );
 

--- a/src/hooks/useSwapAdjustedAmounts.ts
+++ b/src/hooks/useSwapAdjustedAmounts.ts
@@ -18,13 +18,12 @@ export default function useSwapAdjustedAmounts(tradeDetails: Trade) {
   const outputCurrency = useSelector(
     (state: AppState) => state.swap.outputCurrency
   );
-  const independentField = useSelector(
-    (state: AppState) => state.swap.independentField
+  const inputAsExact = useSelector(
+    (state: AppState) => state.swap.independentField !== SwapModalField.output
   );
   const slippageInBips = useSelector(
     (state: AppState) => state.swap.slippageInBips
   );
-  const inputAsExact = independentField !== SwapModalField.output;
   const receivedSoldLabel = inputAsExact ? 'Minimum received' : 'Maximum sold';
   const adjustedAmounts = computeSlippageAdjustedAmounts(
     tradeDetails,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -165,7 +165,7 @@ export default function ExchangeModal({
     priceImpactColor,
     priceImpactNativeAmount,
     priceImpactPercentDisplay,
-  } = usePriceImpactDetails(outputAmount, tradeDetails);
+  } = usePriceImpactDetails(nativeAmount, outputAmount, tradeDetails);
 
   const isDismissing = useRef(false);
   useEffect(() => {

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -165,7 +165,7 @@ export default function ExchangeModal({
     priceImpactColor,
     priceImpactNativeAmount,
     priceImpactPercentDisplay,
-  } = usePriceImpactDetails(nativeAmount, outputAmount, tradeDetails);
+  } = usePriceImpactDetails(inputAmount, outputAmount, tradeDetails);
 
   const isDismissing = useRef(false);
   useEffect(() => {


### PR DESCRIPTION
- If price impact is unavailable (because neither the input or output native prices can be found), then adjust the price impact message displayed to use the percentage instead of the native dollar amount lost
- Fix the tilda in the CurrencyTiles to match what is the estimated value (based on input being exact vs output being exact)
- For native price impact calculation, fill in the missing price if we have the other native price
