### PR TITLE
Fix logic for cTokens with explicit balance outside of wallet assets data

### DIFF
--- a/src/hooks/useMaxInputBalance.js
+++ b/src/hooks/useMaxInputBalance.js
@@ -12,7 +12,7 @@ export default function useMaxInputBalance() {
       // Update current balance
       const newInputBalance = ethereumUtils.getBalanceAmount(
         selectedGasPrice,
-        inputCurrency?.address
+        inputCurrency
       );
       setMaxInputBalance(newInputBalance);
       return newInputBalance;

--- a/src/hooks/useUpdateAssetOnchainBalance.js
+++ b/src/hooks/useUpdateAssetOnchainBalance.js
@@ -9,7 +9,7 @@ export default function useUpdateAssetOnchainBalance() {
   const { allAssets } = useAccountAssets();
   const dispatch = useDispatch();
 
-  const useUpdateAssetOnchainBalance = useCallback(
+  const updateAssetOnchainBalance = useCallback(
     async (assetToUpdate, accountAddress, successCallback) => {
       const balance = await getOnchainAssetBalance(
         assetToUpdate,
@@ -35,5 +35,5 @@ export default function useUpdateAssetOnchainBalance() {
     },
     [allAssets, dispatch]
   );
-  return useUpdateAssetOnchainBalance;
+  return updateAssetOnchainBalance;
 }

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -49,10 +49,14 @@ const getAssetPrice = (address = ETH_ADDRESS) => {
 
 const getEthPriceUnit = () => getAssetPrice();
 
-const getBalanceAmount = (selectedGasPrice, address) => {
+const getBalanceAmount = (selectedGasPrice, selected) => {
   const { assets } = store.getState().data;
-  let amount = getAsset(assets, address)?.balance?.amount || 0;
-  if (address === ETH_ADDRESS) {
+  let amount =
+    selected?.balance?.amount ??
+    getAsset(assets, selected?.address)?.balance?.amount ??
+    0;
+
+  if (selected?.address === ETH_ADDRESS) {
     if (!isEmpty(selectedGasPrice)) {
       const txFeeRaw = selectedGasPrice?.txFee?.value?.amount;
       const txFeeAmount = fromWei(txFeeRaw);


### PR DESCRIPTION
We treat cTokens a bit differently from regular assets.
The change to ethereumUtils was assuming that any assets with a balance we might be interested in would be in the wallet asset data. However, since cTokens are separate and removed from the regular asset data, and their balances are explicitly set on their token data, we need to keep the balance check on the selected item and use the wallet assets data as a fallback.

PoW: https://recordit.co/8YK9qlJkax