### PR TITLE
Fix empty pools still showing

### DIFF
--- a/src/hooks/useRefreshAccountData.js
+++ b/src/hooks/useRefreshAccountData.js
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 import NetworkTypes from '../helpers/networkTypes';
 import { explorerInit } from '../redux/explorer';
 import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
-import { uniswapUpdateLiquidityState } from '../redux/uniswapLiquidity';
+import { uniswapUpdateLiquidityInfo } from '../redux/uniswapLiquidity';
 import { fetchWalletNames } from '../redux/wallets';
 import useAccountSettings from './useAccountSettings';
 import useSavingsAccount from './useSavingsAccount';
@@ -30,7 +30,7 @@ export default function useRefreshAccountData() {
 
     try {
       const getWalletNames = dispatch(fetchWalletNames());
-      const getUniswapLiquidity = dispatch(uniswapUpdateLiquidityState());
+      const getUniswapLiquidity = dispatch(uniswapUpdateLiquidityInfo());
       const getUniqueTokens = dispatch(uniqueTokensRefreshState());
       const explorer = dispatch(explorerInit());
 


### PR DESCRIPTION
We were doing two things wrong:
1. On a fresh "assets received", if the pool tokens were empty (e.g, user exits out of all pools / out of their last pool), we were ignoring updates
2. On an "assets removed" scenario, we weren't correctly updating the pools list (now we will filter out pools with 0 balances)