### PR TITLE
Fix 30d profit race condition

### DIFF
--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -339,7 +339,6 @@ export const getPercentChange = (valueNow, value24HoursAgo) => {
       parseFloat(value24HoursAgo)) *
     100;
   if (isNaN(adjustedPercentChange) || !isFinite(adjustedPercentChange)) {
-    logger.log('');
     return 0;
   }
   return adjustedPercentChange;


### PR DESCRIPTION
We were trying to calculate 30d profit without checking if the price of eth 30d ago was available, and not recalculating after that. This fixes the bug where the column will show $0.00 for the entire column of the pool sections