### PR TITLE
use imageUrl if animation url is null

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -75,17 +75,17 @@ const UniqueTokenExpandedStateImage = ({ asset }) => {
               posterUri={imageUrl}
               setLoading={setLoading}
               style={StyleSheet.absoluteFill}
-              uri={asset.animation_url}
+              uri={asset.animation_url || imageUrl}
             />
           ) : supports3d ? (
             <ModelView
               fallbackUri={imageUrl}
               loading={loading}
               setLoading={setLoading}
-              uri={asset.animation_url}
+              uri={asset.animation_url || imageUrl}
             />
           ) : supportsAudio ? (
-            <AudioPlayer uri={asset.animation_url} />
+            <AudioPlayer uri={asset.animation_url || imageUrl} />
           ) : (
             <UniqueTokenImage
               backgroundColor={asset.background}

--- a/src/hooks/useUniqueToken.ts
+++ b/src/hooks/useUniqueToken.ts
@@ -20,7 +20,8 @@ export default function useUniqueToken(
 ): useUniqueTokenResult {
   return React.useMemo((): useUniqueTokenResult => {
     if (typeof maybeUniqueToken === 'object' && !!maybeUniqueToken) {
-      const { animation_url } = maybeUniqueToken;
+      let { animation_url, image_url } = maybeUniqueToken;
+      animation_url = animation_url ? animation_url : image_url;
       const supports3d = isSupportedUriExtension(
         animation_url,
         supportedUriExtensions.SUPPORTED_3D_EXTENSIONS

--- a/src/hooks/useUniqueToken.ts
+++ b/src/hooks/useUniqueToken.ts
@@ -20,18 +20,18 @@ export default function useUniqueToken(
 ): useUniqueTokenResult {
   return React.useMemo((): useUniqueTokenResult => {
     if (typeof maybeUniqueToken === 'object' && !!maybeUniqueToken) {
-      let { animation_url, image_url } = maybeUniqueToken;
-      animation_url = animation_url ? animation_url : image_url;
+      const { animation_url, image_url } = maybeUniqueToken;
+      const assetUrl = animation_url ? animation_url : image_url;
       const supports3d = isSupportedUriExtension(
-        animation_url,
+        assetUrl,
         supportedUriExtensions.SUPPORTED_3D_EXTENSIONS
       );
       const supportsAudio = isSupportedUriExtension(
-        animation_url,
+        assetUrl,
         supportedUriExtensions.SUPPORTED_AUDIO_EXTENSIONS
       );
       const supportsVideo = isSupportedUriExtension(
-        animation_url,
+        assetUrl,
         supportedUriExtensions.SUPPORTED_VIDEO_EXTENSIONS
       );
       return { supports3d, supportsAudio, supportsVideo };

--- a/src/hooks/useUniqueToken.ts
+++ b/src/hooks/useUniqueToken.ts
@@ -21,7 +21,7 @@ export default function useUniqueToken(
   return React.useMemo((): useUniqueTokenResult => {
     if (typeof maybeUniqueToken === 'object' && !!maybeUniqueToken) {
       const { animation_url, image_url } = maybeUniqueToken;
-      const assetUrl = animation_url ? animation_url : image_url;
+      const assetUrl = animation_url || image_url;
       const supports3d = isSupportedUriExtension(
         assetUrl,
         supportedUriExtensions.SUPPORTED_3D_EXTENSIONS


### PR DESCRIPTION
We are currently checking multimedia types based on animation_url which is not in the 721 or 1155 spec but rather something that people add to get support via OpenSea(https://docs.opensea.io/docs/metadata-standards). 

There's a few projects that don't do this (Ex. Pillheads) so in this case if there is no animation_url, we check for support using image_url and use that instead.

Before: http://cloud.skylarbarrera.com/Screen-Recording-2021-03-10-17-31-10.mp4 
After: http://cloud.skylarbarrera.com/Screen-Recording-2021-03-10-17-30-39.mp4