### PR TITLE
Swap improvements

### DIFF
--- a/src/components/exchange/ExchangeDetailsRow.js
+++ b/src/components/exchange/ExchangeDetailsRow.js
@@ -38,11 +38,9 @@ const AnimatedExchangeDetailsButtonRow = Animated.createAnimatedComponent(
 );
 
 export default function ExchangeDetailsRow({
-  inputAmount,
   isHighPriceImpact,
   onFlipCurrencies,
   onPressViewDetails,
-  outputAmount,
   priceImpactColor,
   priceImpactNativeAmount,
   priceImpactPercentDisplay,
@@ -64,13 +62,10 @@ export default function ExchangeDetailsRow({
     transform: [{ scale: priceImpactScale.value }],
   }));
 
-  const isPriceImpactWarningVisible =
-    !!inputAmount && !!outputAmount && isHighPriceImpact;
-  const prevIsPriceImpactWarningVisible = usePrevious(
-    isPriceImpactWarningVisible
-  );
+  const prevIsHighPriceImpact = usePrevious(isHighPriceImpact);
+
   useEffect(() => {
-    if (isPriceImpactWarningVisible && !prevIsPriceImpactWarningVisible) {
+    if (isHighPriceImpact && !prevIsHighPriceImpact) {
       analytics.track('Showing high price impact warning in Swap', {
         name: outputCurrency.name,
         priceImpact: priceImpactPercentDisplay,
@@ -80,15 +75,15 @@ export default function ExchangeDetailsRow({
       });
     }
   }, [
-    isPriceImpactWarningVisible,
+    isHighPriceImpact,
     outputCurrency,
-    prevIsPriceImpactWarningVisible,
+    prevIsHighPriceImpact,
     priceImpactPercentDisplay,
     type,
   ]);
 
   useEffect(() => {
-    if (isPriceImpactWarningVisible) {
+    if (isHighPriceImpact) {
       detailsRowOpacity.value = withTiming(0, timingConfig);
       priceImpactOpacity.value = withTiming(1, timingConfig);
       priceImpactScale.value = withTiming(1, timingConfig);
@@ -102,7 +97,7 @@ export default function ExchangeDetailsRow({
     }
   }, [
     detailsRowOpacity,
-    isPriceImpactWarningVisible,
+    isHighPriceImpact,
     priceImpactOpacity,
     priceImpactScale,
   ]);
@@ -110,15 +105,16 @@ export default function ExchangeDetailsRow({
   return (
     <Container {...props}>
       <PriceImpactWarning
+        isHighPriceImpact={isHighPriceImpact}
         onPress={onPressViewDetails}
-        pointerEvents={isPriceImpactWarningVisible ? 'auto' : 'none'}
+        pointerEvents={isHighPriceImpact ? 'auto' : 'none'}
         priceImpactColor={priceImpactColor}
         priceImpactNativeAmount={priceImpactNativeAmount}
         priceImpactPercentDisplay={priceImpactPercentDisplay}
         style={priceImpactAnimatedStyle}
       />
       <AnimatedExchangeDetailsButtonRow
-        pointerEvents={isPriceImpactWarningVisible ? 'none' : 'auto'}
+        pointerEvents={isHighPriceImpact ? 'none' : 'auto'}
         style={detailsRowAnimatedStyle}
       >
         <ExchangeDetailsButton

--- a/src/components/exchange/PriceImpactWarning.js
+++ b/src/components/exchange/PriceImpactWarning.js
@@ -35,8 +35,7 @@ export default function PriceImpactWarning({
   ...props
 }) {
   const heading = priceImpactNativeAmount ? 'Losing' : 'Price impact';
-  const headingValue =
-    priceImpactNativeAmount ?? `${priceImpactPercentDisplay}%`;
+  const headingValue = priceImpactNativeAmount ?? priceImpactPercentDisplay;
   return (
     <Animated.View {...props} style={[style, position.coverAsObject]}>
       <ButtonPressAnimation onPress={onPress} scaleTo={0.94}>

--- a/src/components/exchange/PriceImpactWarning.js
+++ b/src/components/exchange/PriceImpactWarning.js
@@ -28,6 +28,7 @@ const Label = styled(Text).attrs(
 
 export default function PriceImpactWarning({
   onPress,
+  isHighPriceImpact,
   priceImpactColor,
   priceImpactNativeAmount,
   priceImpactPercentDisplay,
@@ -38,16 +39,18 @@ export default function PriceImpactWarning({
   const headingValue = priceImpactNativeAmount ?? priceImpactPercentDisplay;
   return (
     <Animated.View {...props} style={[style, position.coverAsObject]}>
-      <ButtonPressAnimation onPress={onPress} scaleTo={0.94}>
-        <Content>
-          <Label color={priceImpactColor}>{`􀇿 `}</Label>
-          <Label color="whiteLabel">Small Market</Label>
-          <Label color={priceImpactColor}>{` • ${heading} `}</Label>
-          <Label color={priceImpactColor} letterSpacing="roundedTight">
-            {headingValue}
-          </Label>
-        </Content>
-      </ButtonPressAnimation>
+      {isHighPriceImpact && (
+        <ButtonPressAnimation onPress={onPress} scaleTo={0.94}>
+          <Content>
+            <Label color={priceImpactColor}>{`􀇿 `}</Label>
+            <Label color="whiteLabel">Small Market</Label>
+            <Label color={priceImpactColor}>{` • ${heading} `}</Label>
+            <Label color={priceImpactColor} letterSpacing="roundedTight">
+              {headingValue}
+            </Label>
+          </Content>
+        </ButtonPressAnimation>
+      )}
     </Animated.View>
   );
 }

--- a/src/components/expanded-state/SwapDetailsState.js
+++ b/src/components/expanded-state/SwapDetailsState.js
@@ -97,6 +97,7 @@ export default function SwapDetailsState({
 
   const {
     derivedValues: { inputAmount, outputAmount },
+    displayValues: { inputAmountDisplay, outputAmountDisplay },
     tradeDetails,
   } = useSwapDerivedOutputs();
   const {
@@ -182,9 +183,11 @@ export default function SwapDetailsState({
         </Header>
         <SwapDetailsMasthead
           inputAmount={inputAmount}
+          inputAmountDisplay={inputAmountDisplay}
           inputPriceValue={inputPriceValue}
           isHighPriceImpact={isHighPriceImpact}
           outputAmount={outputAmount}
+          outputAmountDisplay={outputAmountDisplay}
           outputPriceValue={outputPriceValue}
           priceImpactColor={priceImpactColor}
         />

--- a/src/components/expanded-state/swap-details/CurrencyTile.js
+++ b/src/components/expanded-state/swap-details/CurrencyTile.js
@@ -1,18 +1,14 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import RadialGradient from 'react-native-radial-gradient';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { CoinIcon } from '../../coin-icon';
 import { Centered, ColumnWithMargins, Row } from '../../layout';
 import { Text, TruncatedText } from '../../text';
-
-import {
-  convertAmountAndPriceToNativeDisplay,
-  updatePrecisionToDisplay,
-} from '@rainbow-me/helpers/utilities';
 import { useAccountSettings, useColorForAsset } from '@rainbow-me/hooks';
 import { SwapModalField } from '@rainbow-me/redux/swap';
 import { fonts, fontWithWidth, position } from '@rainbow-me/styles';
+import { convertAmountAndPriceToNativeDisplay } from '@rainbow-me/utilities';
 
 export const CurrencyTileHeight = 143;
 
@@ -59,6 +55,7 @@ const TruncatedAmountText = styled(AmountText).attrs({
 
 export default function CurrencyTile({
   amount,
+  amountDisplay,
   asset,
   isHighPriceImpact,
   priceImpactColor,
@@ -75,16 +72,11 @@ export default function CurrencyTile({
   const isOther =
     (inputAsExact && type === 'output') || (!inputAsExact && type === 'input');
 
-  const { amountDisplay, priceDisplay } = useMemo(() => {
-    const data = [amount, priceValue ?? 0];
-    return {
-      amountDisplay: updatePrecisionToDisplay(...data, true),
-      priceDisplay: convertAmountAndPriceToNativeDisplay(
-        ...data,
-        nativeCurrency
-      ).display,
-    };
-  }, [amount, nativeCurrency, priceValue]);
+  const priceDisplay = convertAmountAndPriceToNativeDisplay(
+    amount,
+    priceValue ?? 0,
+    nativeCurrency
+  ).display;
 
   return (
     <Container {...props}>

--- a/src/components/expanded-state/swap-details/CurrencyTile.js
+++ b/src/components/expanded-state/swap-details/CurrencyTile.js
@@ -72,11 +72,13 @@ export default function CurrencyTile({
   const isOther =
     (inputAsExact && type === 'output') || (!inputAsExact && type === 'input');
 
-  const priceDisplay = convertAmountAndPriceToNativeDisplay(
-    amount,
-    priceValue ?? 0,
-    nativeCurrency
-  ).display;
+  const priceDisplay = priceValue
+    ? convertAmountAndPriceToNativeDisplay(
+        amount,
+        priceValue ?? 0,
+        nativeCurrency
+      ).display
+    : '-';
 
   return (
     <Container {...props}>

--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -37,13 +37,17 @@ export default function SwapDetailsContent({
     tradeDetails
   );
 
+  const showPriceImpact =
+    (!isHighPriceImpact || priceImpactNativeAmount) &&
+    priceImpactPercentDisplay;
+
   return (
     <Container
       isHighPriceImpact={isHighPriceImpact}
       testID="swap-details-state"
       {...props}
     >
-      {(!isHighPriceImpact || priceImpactNativeAmount) && (
+      {showPriceImpact && (
         <SwapDetailsRow label="Price impact">
           <SwapDetailsValue
             color={priceImpactColor}

--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -53,7 +53,7 @@ export default function SwapDetailsContent({
             color={priceImpactColor}
             letterSpacing="roundedTight"
           >
-            {`${priceImpactPercentDisplay}%`}
+            {priceImpactPercentDisplay}
           </SwapDetailsValue>
         </SwapDetailsRow>
       )}

--- a/src/components/expanded-state/swap-details/SwapDetailsMasthead.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsMasthead.js
@@ -20,9 +20,11 @@ const Container = styled(RowWithMargins).attrs({
 
 export default function SwapDetailsMasthead({
   inputAmount,
+  inputAmountDisplay,
   inputPriceValue,
   isHighPriceImpact,
   outputAmount,
+  outputAmountDisplay,
   outputPriceValue,
   priceImpactColor,
   ...props
@@ -34,6 +36,7 @@ export default function SwapDetailsMasthead({
     <Container {...props}>
       <CurrencyTile
         amount={inputAmount}
+        amountDisplay={inputAmountDisplay}
         asset={inputCurrency}
         priceValue={inputPriceValue}
         type="input"
@@ -41,6 +44,7 @@ export default function SwapDetailsMasthead({
       <Icon color={colors.dark} name="doubleChevron" />
       <CurrencyTile
         amount={outputAmount}
+        amountDisplay={outputAmountDisplay}
         asset={outputCurrency}
         isHighPriceImpact={isHighPriceImpact}
         priceImpactColor={priceImpactColor}

--- a/src/components/expanded-state/swap-details/SwapDetailsSlippageMessage.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsSlippageMessage.js
@@ -34,8 +34,7 @@ export default function SwapDetailsSlippageMessage({
 }) {
   const { colors } = useTheme();
   const heading = priceImpactNativeAmount ? 'Losing ' : 'Price impact is ';
-  const headingValue =
-    priceImpactNativeAmount ?? `${priceImpactPercentDisplay}%`;
+  const headingValue = priceImpactNativeAmount ?? priceImpactPercentDisplay;
   return isHighPriceImpact ? (
     <Column align="center" {...props}>
       <Container>

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -331,6 +331,23 @@ export const convertAmountToPercentageDisplay = (
 };
 
 /**
+ * @desc convert from amount to display formatted string
+ * with a threshold percent
+ */
+export const convertAmountToPercentageDisplayWithThreshold = (
+  value: BigNumberish,
+  decimals: number = 2,
+  threshold: string = '0.0001'
+): string => {
+  if (lessThan(value, threshold)) {
+    return '< 0.01%';
+  } else {
+    const display = new BigNumber(value).times(100).toFixed(decimals);
+    return `${display}%`;
+  }
+};
+
+/**
  * @desc convert from bips amount to percentage format
  */
 export const convertBipsToPercentage = (

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -7,6 +7,9 @@ type BigNumberish = number | string | BigNumber;
 export const abs = (value: BigNumberish): string =>
   new BigNumber(value).abs().toFixed();
 
+export const isPositive = (value: BigNumberish): boolean =>
+  new BigNumber(value).isPositive();
+
 export const subtract = (
   numberOne: BigNumberish,
   numberTwo: BigNumberish

--- a/src/hooks/usePriceImpactDetails.ts
+++ b/src/hooks/usePriceImpactDetails.ts
@@ -7,6 +7,7 @@ import {
   convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeAmount,
   convertAmountToNativeDisplay,
+  convertAmountToPercentageDisplayWithThreshold,
   divide,
   greaterThanOrEqualTo,
   isPositive,
@@ -85,8 +86,10 @@ export default function usePriceImpactDetails(
     );
 
     if (isPositive(nativeAmountDifference)) {
-      priceImpactPercentDisplay = priceImpact?.toFixed();
       impact = divide(nativeAmountDifference, inputNativeAmount);
+      priceImpactPercentDisplay = convertAmountToPercentageDisplayWithThreshold(
+        impact
+      );
       priceImpactNativeAmount = convertAmountToNativeDisplay(
         nativeAmountDifference,
         nativeCurrency

--- a/src/hooks/usePriceImpactDetails.ts
+++ b/src/hooks/usePriceImpactDetails.ts
@@ -11,8 +11,6 @@ import {
   divide,
   greaterThanOrEqualTo,
   isPositive,
-  isZero,
-  multiply,
   subtract,
 } from '@rainbow-me/utilities';
 
@@ -36,64 +34,47 @@ export default function usePriceImpactDetails(
     (state: AppState) => state.data.genericAssets
   );
 
-  const priceImpact = tradeDetails?.priceImpact;
-
   let inputPriceValue = genericAssets[inputCurrencyAddress]?.price?.value;
   let outputPriceValue = genericAssets[outputCurrencyAddress]?.price?.value;
-
-  const executionRate = tradeDetails?.executionPrice?.toSignificant();
-
-  const originalOutputAmount = divide(
-    outputAmount ?? 0,
-    subtract(1, divide(priceImpact?.toSignificant() ?? 0, 100))
-  );
-
-  const realExecutionRate =
-    inputAmount && !isZero(inputAmount)
-      ? divide(originalOutputAmount, inputAmount)
-      : 0;
-  const realInverseExecutionRate =
-    inputAmount && originalOutputAmount && !isZero(originalOutputAmount)
-      ? divide(inputAmount, originalOutputAmount)
-      : 0;
-
-  if (!outputPriceValue && inputPriceValue && realInverseExecutionRate) {
-    outputPriceValue = multiply(inputPriceValue, realInverseExecutionRate);
-  }
-
-  if (!inputPriceValue && outputPriceValue && executionRate) {
-    inputPriceValue = multiply(outputPriceValue, realExecutionRate);
-  }
 
   let priceImpactNativeAmount = null;
   let impact = null;
   let priceImpactPercentDisplay = null;
-  if (inputAmount && outputAmount && inputPriceValue && outputPriceValue) {
-    const inputNativeAmount = convertAmountToNativeAmount(
-      inputAmount,
-      inputPriceValue
-    );
-
-    const outputNativeAmount = convertAmountAndPriceToNativeDisplay(
-      outputAmount,
-      outputPriceValue,
-      nativeCurrency
-    ).amount;
-
-    const nativeAmountDifference = subtract(
-      inputNativeAmount,
-      outputNativeAmount
-    );
-
-    if (isPositive(nativeAmountDifference)) {
-      impact = divide(nativeAmountDifference, inputNativeAmount);
-      priceImpactPercentDisplay = convertAmountToPercentageDisplayWithThreshold(
-        impact
+  if (inputAmount && outputAmount) {
+    if (inputPriceValue && outputPriceValue) {
+      const inputNativeAmount = convertAmountToNativeAmount(
+        inputAmount,
+        inputPriceValue
       );
-      priceImpactNativeAmount = convertAmountToNativeDisplay(
-        nativeAmountDifference,
+
+      const outputNativeAmount = convertAmountAndPriceToNativeDisplay(
+        outputAmount,
+        outputPriceValue,
         nativeCurrency
+      ).amount;
+
+      const nativeAmountDifference = subtract(
+        inputNativeAmount,
+        outputNativeAmount
       );
+
+      if (isPositive(nativeAmountDifference)) {
+        impact = divide(nativeAmountDifference, inputNativeAmount);
+        priceImpactPercentDisplay = convertAmountToPercentageDisplayWithThreshold(
+          impact
+        );
+        priceImpactNativeAmount = convertAmountToNativeDisplay(
+          nativeAmountDifference,
+          nativeCurrency
+        );
+      }
+    } else {
+      if (tradeDetails) {
+        impact = divide(tradeDetails.priceImpact.toFixed(), 100);
+        priceImpactPercentDisplay = convertAmountToPercentageDisplayWithThreshold(
+          impact
+        );
+      }
     }
   }
 

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -457,11 +457,9 @@ export default function ExchangeModal({
           )}
           {!isSavings && showConfirmButton && (
             <ExchangeDetailsRow
-              inputAmount={inputAmount}
               isHighPriceImpact={isHighPriceImpact}
               onFlipCurrencies={flipCurrencies}
               onPressViewDetails={navigateToSwapDetailsModal}
-              outputAmount={outputAmount}
               priceImpactColor={priceImpactColor}
               priceImpactNativeAmount={priceImpactNativeAmount}
               priceImpactPercentDisplay={priceImpactPercentDisplay}

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -171,6 +171,7 @@ export default function ExchangeModal({
 
   const {
     derivedValues: { inputAmount, nativeAmount, outputAmount },
+    displayValues: { inputAmountDisplay, outputAmountDisplay },
     tradeDetails,
   } = useSwapDerivedOutputs();
 
@@ -420,7 +421,7 @@ export default function ExchangeModal({
             <ExchangeHeader testID={testID} title={title} />
             <ExchangeInputField
               disableInputCurrencySelection={isWithdrawal}
-              inputAmount={inputAmount}
+              inputAmount={inputAmountDisplay}
               inputCurrencyAddress={inputCurrency?.address}
               inputCurrencySymbol={inputCurrency?.symbol}
               inputFieldRef={inputFieldRef}
@@ -438,7 +439,7 @@ export default function ExchangeModal({
               <ExchangeOutputField
                 onFocus={handleFocus}
                 onPressSelectOutputCurrency={navigateToSelectOutputCurrency}
-                outputAmount={outputAmount}
+                outputAmount={outputAmountDisplay}
                 outputCurrencyAddress={outputCurrency?.address}
                 outputCurrencySymbol={outputCurrency?.symbol}
                 outputFieldRef={outputFieldRef}


### PR DESCRIPTION
### Changes
- Calculate price impact based on native values and only display when the price impact is detrimental to the user
- Fixes rounding of derived values in swap
- Fixes flashing green when Price Impact Warning disappears
- If a price is missing for a currency, use a dash instead of $0.00 in the CurrencyTile in Swap details

PoW: https://recordit.co/HTFR9Nbb9a
PoW missing price in CurrencyTile: 
<img width="428" alt="Screen Shot 2021-03-14 at 3 29 17 PM" src="https://user-images.githubusercontent.com/1285228/111084966-b89d8500-84da-11eb-8621-dc4fc324f653.png">

### Note
- We can only calculate the native price impact when both input and output currency prices are available. If one or neither are available, then we fallback to using the Unsiwap SDK generated price impact
- The Uniswap SDK generated price impact is precise (for the given trade route and pair reserves) but can give unintuitive results when a trade route uses a very low liquidity pair. For instance, for ETH>YFI trade, if you only put in $1, the route ETH>DAI>YFI is given, where DAI>YFI has very low liquidity. Because of this, the price impact is huge, even though technically there is an arbitrage opportunity (Uniswap ignores this because the trade is so small, it would never make any real sense due to gas costs.) Previously, since we were relying on the price impact to display warnings, it would flash for scenarios like this.
- Because of the above, we no longer use the Uniswap SDK generated price impact (and execution rate) to populate the missing price of a currency based on the other currency, as it can give us very unreliable prices in certain situations.

### Extra note about Price Impact Warning animation
With these changes, I have it such that if isHighPriceImpact is false, then we won't display the Warning contents. This is a bit of a cheat. The details of the content change at the same time as the isHighPriceImpact flag, which controls the animation, so we were getting a bit of a green flash with partially undefined data when the Warning animates out. Given that the Warning is never mounted or unmounted (just opacity is changed) a component memoization control wasn't as possible. If anyone has a more ideal solution, please let me know.