### PR TITLE
bump react-coin-icons dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "querystring-es3": "^0.2.1",
     "rainbow-token-list": "^1.2.1",
     "react": "16.11.0",
-    "react-coin-icon": "^0.1.36",
+    "react-coin-icon": "^0.1.37",
     "react-fast-compare": "^2.0.4",
     "react-flatten-children": "^1.1.2",
     "react-native": "0.63.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11843,10 +11843,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-coin-icon@^0.1.36:
-  version "0.1.36"
-  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.36.tgz#38620f0f5f83d17e864de1f1468c4d84d685e18f"
-  integrity sha512-KBXlkVgvwbzU/nyXgS/eSJUCh9FrTphTkRsCzBJ5VqLa5p22o6ajzQUKo3uZ/ydkBQmjSdfbKufDQDghv4ySnA==
+react-coin-icon@^0.1.37:
+  version "0.1.37"
+  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.37.tgz#79af2930f213ef0ecf1e5f7e87876b26237950a8"
+  integrity sha512-0vcoOg6ertpbxEPAtVeGp6s+nGOf8taqoS6NhU4H4+w3mJ1cINi4wngrqqgeg/w3lGDmmNaXoiPqjHI6Yhrg/Q==
   dependencies:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"


### PR DESCRIPTION
update `react-coin-icons` to latest version which includes @osdnk's fix for shadows not getting updated https://github.com/mikedemarais/react-coin-icon/pull/12