### PR TITLE
android disco tweaks

### DIFF
--- a/src/components/discover-sheet/DiscoverSheet.android.js
+++ b/src/components/discover-sheet/DiscoverSheet.android.js
@@ -26,7 +26,7 @@ function useAreHeaderButtonVisible() {
   return [{ isSearchModeEnabled, setIsSearchModeEnabled }, isSearchModeEnabled];
 }
 
-const snapPoints = ['25%', '90%'];
+const snapPoints = ['35%', '100%'];
 
 const AndroidWrapper = styled.View.attrs({
   pointerEvents: 'box-none',

--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -83,7 +83,7 @@ export default function ChartExpandedState({ asset }) {
     ios || showChart ? heightWithChart : heightWithoutChart;
 
   if (android && !hasBalance) {
-    ChartExpandedStateSheetHeight -= 68;
+    ChartExpandedStateSheetHeight -= 60;
   }
 
   return (

--- a/src/components/qrcode-scanner/ConnectedDapps.js
+++ b/src/components/qrcode-scanner/ConnectedDapps.js
@@ -10,7 +10,7 @@ import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 
 const LabelText = styled(Text)`
-  margin-top: -3px;
+  margin-top: ${android ? 0 : -3};
 `;
 
 const Overlay = styled(Centered)`

--- a/src/screens/QRScannerScreen.js
+++ b/src/screens/QRScannerScreen.js
@@ -78,15 +78,17 @@ export default function QRScannerScreen() {
             )}
           </CameraDimmer>
           {android ? <DiscoverSheet ref={dsRef} /> : null}
-          <ScannerHeader>
-            <BackButton
-              color={colors.whiteLabel}
-              direction="left"
-              onPress={handlePressBackButton}
-              testID="goToBalancesFromScanner"
-            />
-            <EmulatorPasteUriButton />
-          </ScannerHeader>
+          {cameraVisible && (
+            <ScannerHeader>
+              <BackButton
+                color={colors.whiteLabel}
+                direction="left"
+                onPress={handlePressBackButton}
+                testID="goToBalancesFromScanner"
+              />
+              <EmulatorPasteUriButton />
+            </ScannerHeader>
+          )}
         </ScannerContainer>
       </View>
       <FabWrapper

--- a/src/screens/RestoreSheet.js
+++ b/src/screens/RestoreSheet.js
@@ -87,7 +87,7 @@ export default function RestoreSheet() {
   }, [goBack, navigate]);
 
   const wrapperHeight =
-    deviceHeight + longFormHeight + (android ? getSoftMenuBarHeight() : 0);
+    deviceHeight + longFormHeight + (android ? getSoftMenuBarHeight() / 2 : 0);
 
   return (
     <Column height={wrapperHeight}>

--- a/src/screens/SavingsSheet.js
+++ b/src/screens/SavingsSheet.js
@@ -35,7 +35,9 @@ import Routes from '@rainbow-me/routes';
 import { position } from '@rainbow-me/styles';
 
 export const SavingsSheetEmptyHeight = 313;
-export const SavingsSheetHeight = android ? 424 - getSoftMenuBarHeight() : 352;
+export const SavingsSheetHeight = android
+  ? 424 - getSoftMenuBarHeight() / 2
+  : 352;
 
 const Container = styled(Centered).attrs({ direction: 'column' })`
   ${position.cover};


### PR DESCRIPTION
Tweaked sheet heights for restore sheet, savings sheet, & chart expanded state

fixed Connected apps text alignment on android  

Updated android discover sheet snap points to mimic iOS 
before: http://cloud.skylarbarrera.com/Screen-Recording-2021-03-15-20-13-26.mp4
after: http://cloud.skylarbarrera.com/Screen-Recording-2021-03-15-20-16-58.mp4

note: I've decided to just not show the ScannerHeader as it overlaps on top of android discover sheet and there is no need for it if its hidden
