### PR TITLE
update e2e - ganache flow

### DIFF
--- a/e2e/ganacheTransactionFlow.spec.js
+++ b/e2e/ganacheTransactionFlow.spec.js
@@ -158,7 +158,7 @@ describe('Ganache Transaction Flow', () => {
     await Helpers.delay(3000);
     await Helpers.tap('send-savings-cSAI');
     await Helpers.delay(3000);
-    await Helpers.typeText('selected-asset-field-input', '1', true);
+    await Helpers.typeText('selected-asset-field-input', '2', true);
     await Helpers.delay(5000);
     await Helpers.tapAndLongPress('Hold to Send');
     await Helpers.delay(10000);
@@ -199,7 +199,7 @@ describe('Ganache Transaction Flow', () => {
     await Helpers.delay(3000);
     await Helpers.tap('send-asset-BAT');
     await Helpers.delay(3000);
-    await Helpers.typeText('selected-asset-field-input', '2', true);
+    await Helpers.typeText('selected-asset-field-input', '1', true);
     await Helpers.delay(3000);
     await Helpers.tapAndLongPress('Hold to Send');
     await Helpers.delay(10000);
@@ -214,7 +214,7 @@ describe('Ganache Transaction Flow', () => {
     await Helpers.delay(3000);
     await Helpers.tap('send-asset-ETH');
     await Helpers.delay(3000);
-    await Helpers.typeText('selected-asset-field-input', '.001', true);
+    await Helpers.typeText('selected-asset-field-input', '.002', true);
     await Helpers.delay(3000);
     await Helpers.tapAndLongPress('Hold to Send');
     await Helpers.delay(10000);
@@ -244,33 +244,35 @@ describe('Ganache Transaction Flow', () => {
   });*/
   it('Should show completed send ERC20 (cSAI)', async () => {
     try {
-      await Helpers.checkIfVisible('Sent-Compound SAI');
+      await Helpers.checkIfVisible('Sent-Compound SAI-2.00 cSAI');
     } catch (e) {
-      await Helpers.checkIfVisible('Sending-Compound SAI');
+      await Helpers.checkIfVisible('Sending-Compound SAI-2.00 cSAI');
     }
   });
 
   it('Should show completed send NFT (Cryptokitties)', async () => {
     try {
-      await Helpers.checkIfVisible('Sent-Arun Cattybinky');
+      await Helpers.checkIfVisible('Sent-Arun Cattybinky-1.00 CryptoKitties');
     } catch (e) {
-      await Helpers.checkIfVisible('Sending-Arun Cattybinky');
+      await Helpers.checkIfVisible(
+        'Sending-Arun Cattybinky-1.00 CryptoKitties'
+      );
     }
   });
 
   it('Should show completed send ERC20 (BAT)', async () => {
     try {
-      await Helpers.checkIfVisible('Sent-Basic Attention Token');
+      await Helpers.checkIfVisible('Sent-Basic Attention Token-1.00 BAT');
     } catch (e) {
-      await Helpers.checkIfVisible('Sending-Basic Attention Token');
+      await Helpers.checkIfVisible('Sending-Basic Attention Token-1.00 BAT');
     }
   });
 
   it('Should show completed send ETH', async () => {
     try {
-      await Helpers.checkIfVisible('Sent-Ethereum');
+      await Helpers.checkIfVisible('Sent-Ethereum-0.002 ETH');
     } catch (e) {
-      await Helpers.checkIfVisible('Sending-Ethereum');
+      await Helpers.checkIfVisible('Sending-Ethereum-0.002 ETH');
     }
   });
 

--- a/ios/TransactionListViewCell.swift
+++ b/ios/TransactionListViewCell.swift
@@ -65,8 +65,8 @@ class TransactionListViewCell: TransactionListBaseCell {
     setIcon(transaction)
 
     transactionType.isAccessibilityElement = true;
-    if transaction.title != nil && transaction.transactionDescription != nil {
-      transactionType.accessibilityIdentifier = "\(transaction.title!)-\(transaction.transactionDescription!)";
+    if transaction.title != nil && transaction.transactionDescription != nil && transaction.balanceDisplay != nil {
+      transactionType.accessibilityIdentifier = "\(transaction.title!)-\(transaction.transactionDescription!)-\(transaction.balanceDisplay!)"
     }
 
     


### PR DESCRIPTION
We had an instance where ganache was not connected and the test suite sent the funds to our old dev wallet. I spent all morning trying to repro and running the tests locally. There is a situation where ganache fails to start/connect but the toast is still visible, We double check this by trying to send to an ENS domain which will not resolve in this state. Will keep an eye on it if this happens again but everything looks fine.

Code changes are so the tests don't fail due to duplicate testID's from the older transactions. 