### PR TITLE
bump react-coin-icons to 0.1.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "querystring-es3": "^0.2.1",
     "rainbow-token-list": "^1.2.1",
     "react": "16.11.0",
-    "react-coin-icon": "^0.1.37",
+    "react-coin-icon": "^0.1.38",
     "react-fast-compare": "^2.0.4",
     "react-flatten-children": "^1.1.2",
     "react-native": "0.63.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11843,10 +11843,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-coin-icon@^0.1.37:
-  version "0.1.37"
-  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.37.tgz#79af2930f213ef0ecf1e5f7e87876b26237950a8"
-  integrity sha512-0vcoOg6ertpbxEPAtVeGp6s+nGOf8taqoS6NhU4H4+w3mJ1cINi4wngrqqgeg/w3lGDmmNaXoiPqjHI6Yhrg/Q==
+react-coin-icon@^0.1.38:
+  version "0.1.38"
+  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.38.tgz#4e6bc92faa7793ca923fb4acb8b6f3f3d984aa79"
+  integrity sha512-Y65h4KNCV72a8d2JrgTmqUhx+qYO9g57ApD5TR77ii5Ca3q+CEM5j3txpfBRPKI4DwLRKkeGrgUm65RmCr9K6A==
   dependencies:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"


### PR DESCRIPTION
bumps react-coin-icons dep to 0.1.38 which includes new icons for YFI, NFTX, and RGT