### PR TITLE
Improvements for fetching charts

### DIFF
--- a/src/components/asset-list/RecyclerAssetList/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList/index.tsx
@@ -112,6 +112,12 @@ export type RecyclerAssetListReduxProps = {
     readonly openInvestmentCards: {
       readonly [key: string]: boolean;
     };
+    readonly openSavings: {
+      readonly [key: string]: boolean;
+    };
+    readonly openSmallBalances: {
+      readonly [key: string]: boolean;
+    };
   };
   readonly settings: {
     readonly nativeCurrency: string;

--- a/src/components/asset-list/RecyclerAssetList/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList/index.tsx
@@ -746,9 +746,12 @@ function RecyclerAssetList({
 export default connect(
   ({
     editOptions: { isCoinListEdited },
-    openSavings,
-    openSmallBalances,
-    openStateSettings: { openFamilyTabs, openInvestmentCards },
+    openStateSettings: {
+      openFamilyTabs,
+      openInvestmentCards,
+      openSavings,
+      openSmallBalances,
+    },
     settings: { nativeCurrency },
   }: RecyclerAssetListReduxProps) => ({
     isCoinListEdited,

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -1,6 +1,7 @@
+import { map } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import { LayoutAnimation, View } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { Row, RowWithMargins } from '../layout';
 import CoinDividerAssetsValue from './CoinDividerAssetsValue';
@@ -52,6 +53,8 @@ export default function CoinDivider({
   onEndEdit,
 }) {
   const dispatch = useDispatch();
+  const assets = useSelector(({ data: { assets } }) => assets);
+
   const [fetchedCharts, setFetchedCharts] = useState(false);
   const { width: deviceWidth } = useDimensions();
 
@@ -72,11 +75,18 @@ export default function CoinDivider({
 
   const toggleSmallBalances = useCallback(() => {
     if (!isSmallBalancesOpen && !fetchedCharts) {
-      dispatch(emitChartsRequest());
+      const assetCodes = map(assets, 'address');
+      dispatch(emitChartsRequest(assetCodes));
       setFetchedCharts(true);
     }
     toggleOpenSmallBalances();
-  }, [dispatch, fetchedCharts, isSmallBalancesOpen, toggleOpenSmallBalances]);
+  }, [
+    assets,
+    dispatch,
+    fetchedCharts,
+    isSmallBalancesOpen,
+    toggleOpenSmallBalances,
+  ]);
 
   const handlePressEdit = useCallback(() => {
     if (isCoinListEdited && onEndEdit) {

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { LayoutAnimation, View } from 'react-native';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { Row, RowWithMargins } from '../layout';
 import CoinDividerAssetsValue from './CoinDividerAssetsValue';
@@ -12,6 +13,7 @@ import {
   useDimensions,
   useOpenSmallBalances,
 } from '@rainbow-me/hooks';
+import { emitChartsRequest } from '@rainbow-me/redux/explorer';
 import { padding } from '@rainbow-me/styles';
 
 export const CoinDividerHeight = 30;
@@ -49,6 +51,7 @@ export default function CoinDivider({
   nativeCurrency,
   onEndEdit,
 }) {
+  const dispatch = useDispatch();
   const { width: deviceWidth } = useDimensions();
 
   const {
@@ -65,6 +68,13 @@ export default function CoinDivider({
     isSmallBalancesOpen,
     toggleOpenSmallBalances,
   } = useOpenSmallBalances();
+
+  const toggleSmallBalances = useCallback(() => {
+    if (!isSmallBalancesOpen) {
+      dispatch(emitChartsRequest());
+    }
+    toggleOpenSmallBalances();
+  }, [dispatch, isSmallBalancesOpen, toggleOpenSmallBalances]);
 
   const handlePressEdit = useCallback(() => {
     if (isCoinListEdited && onEndEdit) {
@@ -87,7 +97,7 @@ export default function CoinDivider({
             coinDividerHeight={CoinDividerHeight}
             isSmallBalancesOpen={isSmallBalancesOpen}
             isVisible={isCoinListEdited}
-            onPress={toggleOpenSmallBalances}
+            onPress={toggleSmallBalances}
           />
         </View>
         <CoinDividerButtonRow isCoinListEdited={isCoinListEdited}>

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { LayoutAnimation, View } from 'react-native';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
@@ -52,6 +52,7 @@ export default function CoinDivider({
   onEndEdit,
 }) {
   const dispatch = useDispatch();
+  const [fetchedCharts, setFetchedCharts] = useState(false);
   const { width: deviceWidth } = useDimensions();
 
   const {
@@ -70,11 +71,12 @@ export default function CoinDivider({
   } = useOpenSmallBalances();
 
   const toggleSmallBalances = useCallback(() => {
-    if (!isSmallBalancesOpen) {
+    if (!isSmallBalancesOpen && !fetchedCharts) {
       dispatch(emitChartsRequest());
+      setFetchedCharts(true);
     }
     toggleOpenSmallBalances();
-  }, [dispatch, isSmallBalancesOpen, toggleOpenSmallBalances]);
+  }, [dispatch, fetchedCharts, isSmallBalancesOpen, toggleOpenSmallBalances]);
 
   const handlePressEdit = useCallback(() => {
     if (isCoinListEdited && onEndEdit) {

--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -219,7 +219,10 @@ const arePropsEqual = (prev, next) => {
 const MemoizedBalanceCoinRow = React.memo(BalanceCoinRow, arePropsEqual);
 
 export default connect(
-  ({ editOptions: { recentlyPinnedCount }, openSmallBalances }) => ({
+  ({
+    editOptions: { recentlyPinnedCount },
+    openStateSettings: { openSmallBalances },
+  }) => ({
     openSmallBalances,
     recentlyPinnedCount,
   }),

--- a/src/handlers/localstorage/accountLocal.js
+++ b/src/handlers/localstorage/accountLocal.js
@@ -12,7 +12,6 @@ const ACCOUNT_INFO = 'accountInfo';
 const ACCOUNT_EMPTY = 'accountEmpty';
 const ASSET_PRICES_FROM_UNISWAP = 'assetPricesFromUniswap';
 const ASSETS = 'assets';
-const ACCOUNT_CHARTS = 'accountCharts';
 const OPEN_FAMILIES = 'openFamilies';
 const OPEN_INVESTMENT_CARDS = 'openInvestmentCards';
 const PURCHASE_TRANSACTIONS = 'purchaseTransactions';
@@ -29,7 +28,6 @@ export const accountLocalKeys = [
   ACCOUNT_INFO,
   ASSET_PRICES_FROM_UNISWAP,
   ASSETS,
-  ACCOUNT_CHARTS,
   OPEN_FAMILIES,
   OPEN_INVESTMENT_CARDS,
   PURCHASE_TRANSACTIONS,
@@ -176,24 +174,6 @@ export const savePurchaseTransactions = (
     network,
     purchaseTransactionsVersion
   );
-
-/**
- * @desc get charts
- * @param  {String}   [address]
- * @param  {String}   [network]
- * @return {Object}
- */
-export const getAccountCharts = (accountAddress, network) =>
-  getAccountLocal(ACCOUNT_CHARTS, accountAddress, network, {});
-
-/**
- * @desc save charts data
- * @param  {Object}   [charts]
- * @param  {String}   [address]
- * @param  {String}   [network]
- */
-export const saveAccountCharts = (charts, accountAddress, network) =>
-  saveAccountLocal(ACCOUNT_CHARTS, charts, accountAddress, network);
 
 /**
  * @desc get transactions

--- a/src/handlers/localstorage/accountLocal.js
+++ b/src/handlers/localstorage/accountLocal.js
@@ -15,7 +15,6 @@ const ASSETS = 'assets';
 const OPEN_FAMILIES = 'openFamilies';
 const OPEN_INVESTMENT_CARDS = 'openInvestmentCards';
 const PURCHASE_TRANSACTIONS = 'purchaseTransactions';
-const SMALL_BALANCE_TOGGLE = 'smallBalanceToggle';
 const SAVINGS = 'savings';
 const SAVINGS_TOGGLE = 'savingsToggle';
 const SHOWCASE_TOKENS = 'showcaseTokens';
@@ -31,7 +30,6 @@ export const accountLocalKeys = [
   OPEN_FAMILIES,
   OPEN_INVESTMENT_CARDS,
   PURCHASE_TRANSACTIONS,
-  SMALL_BALANCE_TOGGLE,
   SAVINGS,
   SAVINGS_TOGGLE,
   SHOWCASE_TOKENS,
@@ -233,33 +231,6 @@ export const saveUniqueTokens = (uniqueTokens, accountAddress, network) =>
     accountAddress,
     network,
     uniqueTokensVersion
-  );
-
-/**
- * @desc get open small balances
- * @param  {String}   [address]
- * @param  {String}   [network]
- * @return {Object}
- */
-export const getSmallBalanceToggle = (accountAddress, network) =>
-  getAccountLocal(SMALL_BALANCE_TOGGLE, accountAddress, network, false);
-
-/**
- * @desc save small balance toggle
- * @param  {String}   [address]
- * @param  {Boolean}    [small balance toggle]
- * @param  {String}   [network]
- */
-export const saveSmallBalanceToggle = (
-  openSmallBalances,
-  accountAddress,
-  network
-) =>
-  saveAccountLocal(
-    SMALL_BALANCE_TOGGLE,
-    openSmallBalances,
-    accountAddress,
-    network
   );
 
 /**

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -19,6 +19,7 @@ export const saveKeychainIntegrityState = state =>
 export const getAuthTimelock = () => getGlobal(AUTH_TIMELOCK, null);
 
 export const saveAuthTimelock = ts => saveGlobal(AUTH_TIMELOCK, ts);
+
 export const getPinAuthAttemptsLeft = () =>
   getGlobal(PIN_AUTH_ATTEMPTS_LEFT, null);
 

--- a/src/hooks/useOpenSavings.js
+++ b/src/hooks/useOpenSavings.js
@@ -5,7 +5,9 @@ import { setOpenSavings } from '../redux/openStateSettings';
 export default function useOpenSavings() {
   const dispatch = useDispatch();
 
-  const isSavingsOpen = useSelector(({ openSavings }) => openSavings);
+  const isSavingsOpen = useSelector(
+    ({ openStateSettings: { openSavings } }) => openSavings
+  );
 
   const toggleOpenSavings = useCallback(
     () => dispatch(setOpenSavings(!isSavingsOpen)),

--- a/src/hooks/useOpenSmallBalances.js
+++ b/src/hooks/useOpenSmallBalances.js
@@ -6,7 +6,7 @@ export default function useOpenSmallBalances() {
   const dispatch = useDispatch();
 
   const isSmallBalancesOpen = useSelector(
-    ({ openSmallBalances }) => openSmallBalances
+    ({ openStateSettings: { openSmallBalances } }) => openSmallBalances
   );
 
   const toggleOpenSmallBalances = useCallback(

--- a/src/redux/charts.js
+++ b/src/redux/charts.js
@@ -1,38 +1,13 @@
 import { get, mapValues, reverse } from 'lodash';
-import {
-  getAccountCharts,
-  saveAccountCharts,
-} from '../handlers/localstorage/accountLocal';
 import ChartTypes from '../helpers/chartTypes';
 
 // -- Constants --------------------------------------- //
 const CHARTS_UPDATE_CHART_TYPE = 'charts/CHARTS_UPDATE_CHART_TYPE';
-const CHARTS_LOAD_REQUEST = 'charts/CHARTS_LOAD_REQUEST';
-const CHARTS_LOAD_SUCCESS = 'charts/CHARTS_LOAD_SUCCESS';
-const CHARTS_LOAD_FAILURE = 'charts/CHARTS_LOAD_FAILURE';
 const CHARTS_UPDATE = 'charts/CHARTS_UPDATE';
-const CHARTS_CLEAR_STATE = 'charts/CHARTS_CLEAR_STATE';
 
 export const DEFAULT_CHART_TYPE = ChartTypes.day;
 
 // -- Actions ---------------------------------------- //
-export const chartsLoadState = () => async (dispatch, getState) => {
-  const { accountAddress, network } = getState().settings;
-  try {
-    dispatch({ type: CHARTS_LOAD_REQUEST });
-    const charts = await getAccountCharts(accountAddress, network);
-    dispatch({
-      payload: charts,
-      type: CHARTS_LOAD_SUCCESS,
-    });
-  } catch (error) {
-    dispatch({ type: CHARTS_LOAD_FAILURE });
-  }
-};
-
-export const chartsClearState = () => dispatch =>
-  dispatch({ type: CHARTS_CLEAR_STATE });
-
 export const chartsUpdateChartType = (chartType, dpi) => dispatch =>
   dispatch({
     dpi,
@@ -42,7 +17,6 @@ export const chartsUpdateChartType = (chartType, dpi) => dispatch =>
 
 export const assetChartsReceived = message => (dispatch, getState) => {
   const chartType = get(message, 'meta.charts_type');
-  const { accountAddress, network } = getState().settings;
   const { charts: existingCharts } = getState().charts;
   const assetCharts = get(message, 'payload.charts', {});
   const newChartData = mapValues(assetCharts, (chartData, address) => ({
@@ -53,7 +27,6 @@ export const assetChartsReceived = message => (dispatch, getState) => {
     ...existingCharts,
     ...newChartData,
   };
-  saveAccountCharts(updatedCharts, accountAddress, network);
   dispatch({
     payload: updatedCharts,
     type: CHARTS_UPDATE,
@@ -77,35 +50,12 @@ export default (state = INITIAL_STATE, action) => {
         [action.dpi ? 'chartTypeDPI' : 'chartType']: action.payload,
         [action.dpi ? 'fetchingChartsDPI' : 'fetchingCharts']: true,
       };
-    case CHARTS_LOAD_REQUEST:
-      return {
-        ...state,
-        fetchingCharts: true,
-      };
-    case CHARTS_LOAD_SUCCESS:
-      return {
-        ...state,
-        charts: action.payload,
-        fetchingCharts: false,
-        fetchingChartsDPI: false,
-      };
-    case CHARTS_LOAD_FAILURE:
-      return {
-        ...state,
-        fetchingCharts: false,
-        fetchingChartsDPI: false,
-      };
     case CHARTS_UPDATE:
       return {
         ...state,
         charts: action.payload,
         fetchingCharts: false,
         fetchingChartsDPI: false,
-      };
-    case CHARTS_CLEAR_STATE:
-      return {
-        ...state,
-        ...INITIAL_STATE,
       };
     default:
       return state;

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -29,6 +29,7 @@ import coingeckoIdsFallback from '../references/coingecko/ids.json';
 import { addCashUpdatePurchases } from './addCash';
 /* eslint-disable-next-line import/no-cycle */
 import { uniqueTokensRefreshState } from './uniqueTokens';
+/* eslint-disable-next-line import/no-cycle */
 import { uniswapUpdateLiquidityTokens } from './uniswapLiquidity';
 import {
   getAssetPricesFromUniswap,

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -1,4 +1,4 @@
-import { concat, get, isNil, keys, map, toLower } from 'lodash';
+import { concat, isEmpty, isNil, keys, map, toLower } from 'lodash';
 import { DATA_API_KEY, DATA_ORIGIN } from 'react-native-dotenv';
 import io from 'socket.io-client';
 import { assetChartsReceived, DEFAULT_CHART_TYPE } from './charts';
@@ -318,7 +318,11 @@ export const emitChartsRequest = (
     : assetAddress
     ? [assetAddress]
     : map(assets, 'address');
-  assetsSocket?.emit(...chartsRetrieval(assetCodes, nativeCurrency, chartType));
+  if (!isEmpty(assetCodes)) {
+    assetsSocket?.emit(
+      ...chartsRetrieval(assetCodes, nativeCurrency, chartType)
+    );
+  }
 };
 
 const listenOnAssetMessages = socket => dispatch => {
@@ -335,29 +339,29 @@ const listenOnAssetMessages = socket => dispatch => {
   });
 
   socket.on(messages.ASSET_CHARTS.RECEIVED, message => {
-    //logger.log('charts received', get(message, 'payload.charts', {}));
+    // logger.log('charts received', message?.payload?.charts);
     dispatch(assetChartsReceived(message));
   });
 };
 
 const listenOnAddressMessages = socket => dispatch => {
   socket.on(messages.ADDRESS_TRANSACTIONS.RECEIVED, message => {
-    // logger.log('txns received', get(message, 'payload.transactions', []));
+    // logger.log('txns received', message?.payload?.transactions);
     dispatch(transactionsReceived(message));
   });
 
   socket.on(messages.ADDRESS_TRANSACTIONS.APPENDED, message => {
-    logger.log('txns appended', get(message, 'payload.transactions', []));
+    logger.log('txns appended', message?.payload?.transactions);
     dispatch(transactionsReceived(message, true));
   });
 
   socket.on(messages.ADDRESS_TRANSACTIONS.CHANGED, message => {
-    logger.log('txns changed', get(message, 'payload.transactions', []));
+    logger.log('txns changed', message?.payload?.transactions);
     dispatch(transactionsReceived(message, true));
   });
 
   socket.on(messages.ADDRESS_TRANSACTIONS.REMOVED, message => {
-    logger.log('txns removed', get(message, 'payload.transactions', []));
+    logger.log('txns removed', message?.payload?.transactions);
     dispatch(transactionsRemoved(message));
   });
 

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -1,4 +1,4 @@
-import { concat, isEmpty, isNil, keys, map, toLower } from 'lodash';
+import { concat, isEmpty, isNil, keys, toLower } from 'lodash';
 import { DATA_API_KEY, DATA_ORIGIN } from 'react-native-dotenv';
 import io from 'socket.io-client';
 import { assetChartsReceived, DEFAULT_CHART_TYPE } from './charts';
@@ -307,17 +307,14 @@ export const emitAssetInfoRequest = () => (dispatch, getState) => {
 };
 
 export const emitChartsRequest = (
-  assetAddress = null,
+  assetAddress,
   chartType = DEFAULT_CHART_TYPE
 ) => (dispatch, getState) => {
   const { nativeCurrency } = getState().settings;
   const { assetsSocket } = getState().explorer;
-  const { assets } = getState().data;
   const assetCodes = Array.isArray(assetAddress)
     ? assetAddress
-    : assetAddress
-    ? [assetAddress]
-    : map(assets, 'address');
+    : [assetAddress];
   if (!isEmpty(assetCodes)) {
     assetsSocket?.emit(
       ...chartsRetrieval(assetCodes, nativeCurrency, chartType)

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -1,7 +1,8 @@
-import { concat, get, isNil, keys, toLower } from 'lodash';
+import { concat, get, isNil, keys, map, toLower } from 'lodash';
 import { DATA_API_KEY, DATA_ORIGIN } from 'react-native-dotenv';
 import io from 'socket.io-client';
 import { assetChartsReceived, DEFAULT_CHART_TYPE } from './charts';
+/* eslint-disable-next-line import/no-cycle */
 import {
   addressAssetsReceived,
   assetPricesChanged,
@@ -9,6 +10,7 @@ import {
   transactionsReceived,
   transactionsRemoved,
 } from './data';
+/* eslint-disable-next-line import/no-cycle */
 import {
   fallbackExplorerClearState,
   fallbackExplorerInit,
@@ -305,14 +307,17 @@ export const emitAssetInfoRequest = () => (dispatch, getState) => {
 };
 
 export const emitChartsRequest = (
-  assetAddress,
+  assetAddress = null,
   chartType = DEFAULT_CHART_TYPE
 ) => (dispatch, getState) => {
   const { nativeCurrency } = getState().settings;
   const { assetsSocket } = getState().explorer;
+  const { assets } = getState().data;
   const assetCodes = Array.isArray(assetAddress)
     ? assetAddress
-    : [assetAddress];
+    : assetAddress
+    ? [assetAddress]
+    : map(assets, 'address');
   assetsSocket?.emit(...chartsRetrieval(assetCodes, nativeCurrency, chartType));
 };
 

--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -10,6 +10,7 @@ import balanceCheckerContractAbi from '../references/balances-checker-abi.json';
 import coingeckoIdsFallback from '../references/coingecko/ids.json';
 import migratedTokens from '../references/migratedTokens.json';
 import testnetAssets from '../references/testnet-assets.json';
+/* eslint-disable-next-line import/no-cycle */
 import {
   addressAssetsReceived,
   COINGECKO_IDS_ENDPOINT,

--- a/src/redux/openStateSettings.js
+++ b/src/redux/openStateSettings.js
@@ -3,11 +3,9 @@ import {
   getOpenFamilies,
   getOpenInvestmentCards,
   getSavingsToggle,
-  getSmallBalanceToggle,
   saveOpenFamilies,
   saveOpenInvestmentCards,
   saveSavingsToggle,
-  saveSmallBalanceToggle,
 } from '../handlers/localstorage/accountLocal';
 
 // -- Constants ------------------------------------------------------------- //
@@ -26,22 +24,17 @@ const SET_OPEN_INVESTMENT_CARDS = 'openStateSettings/SET_OPEN_INVESTMENT_CARDS';
 export const openStateSettingsLoadState = () => async (dispatch, getState) => {
   try {
     const { accountAddress, network } = getState().settings;
-    const openSavings = await getSavingsToggle(accountAddress, network);
-    const openSmallBalances = await getSmallBalanceToggle(
-      accountAddress,
-      network
-    );
     const openInvestmentCards = await getOpenInvestmentCards(
       accountAddress,
       network
     );
     const openFamilyTabs = await getOpenFamilies(accountAddress, network);
+    const openSavings = await getSavingsToggle(accountAddress, network);
     dispatch({
       payload: {
         openFamilyTabs,
         openInvestmentCards,
         openSavings,
-        openSmallBalances,
       },
       type: OPEN_STATE_SETTINGS_LOAD_SUCCESS,
     });
@@ -59,14 +52,11 @@ export const setOpenSavings = payload => (dispatch, getState) => {
   });
 };
 
-export const setOpenSmallBalances = payload => (dispatch, getState) => {
-  const { accountAddress, network } = getState().settings;
-  saveSmallBalanceToggle(payload, accountAddress, network);
+export const setOpenSmallBalances = payload => dispatch =>
   dispatch({
     payload,
     type: SET_OPEN_SMALL_BALANCES,
   });
-};
 
 export const pushOpenFamilyTab = payload => dispatch =>
   dispatch({
@@ -106,6 +96,8 @@ export const resetOpenStateSettings = () => dispatch =>
 export const INITIAL_STATE = {
   openFamilyTabs: {},
   openInvestmentCards: {},
+  openSavings: false,
+  openSmallBalances: false,
 };
 
 export default (state = INITIAL_STATE, action) =>
@@ -113,31 +105,18 @@ export default (state = INITIAL_STATE, action) =>
     if (action.type === OPEN_STATE_SETTINGS_LOAD_SUCCESS) {
       draft.openFamilyTabs = action.payload.openFamilyTabs;
       draft.openInvestmentCards = action.payload.openInvestmentCards;
+      draft.openSavings = action.payload.openSavings;
     } else if (action.type === SET_OPEN_FAMILY_TABS) {
       draft.openFamilyTabs = action.payload;
     } else if (action.type === PUSH_OPEN_FAMILY_TAB) {
       draft.openFamilyTabs = action.payload;
     } else if (action.type === SET_OPEN_INVESTMENT_CARDS) {
       draft.openInvestmentCards = action.payload;
+    } else if (action.type === SET_OPEN_SAVINGS) {
+      draft.openSavings = action.payload;
+    } else if (action.type === SET_OPEN_SMALL_BALANCES) {
+      draft.openSmallBalances = action.payload;
     } else if (action.type === CLEAR_OPEN_STATE_SETTINGS) {
       return INITIAL_STATE;
     }
   });
-
-export const openSmallBalancesReducer = (state = false, action) => {
-  switch (action.type) {
-    case SET_OPEN_SMALL_BALANCES:
-      return action.payload;
-    default:
-      return state;
-  }
-};
-
-export const openSavingsReducer = (state = false, action) => {
-  switch (action.type) {
-    case SET_OPEN_SAVINGS:
-      return action.payload;
-    default:
-      return state;
-  }
-};

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -12,10 +12,7 @@ import gas from './gas';
 import imageMetadata from './imageMetadata';
 import keyboardHeight from './keyboardHeight';
 import multicall from './multicall';
-import openStateSettings, {
-  openSavingsReducer,
-  openSmallBalancesReducer,
-} from './openStateSettings';
+import openStateSettings from './openStateSettings';
 import requests from './requests';
 import settings from './settings';
 import showcaseTokens from './showcaseTokens';
@@ -41,8 +38,6 @@ export default combineReducers({
   imageMetadata,
   keyboardHeight,
   multicall,
-  openSavings: openSavingsReducer,
-  openSmallBalances: openSmallBalancesReducer,
   openStateSettings,
   requests,
   settings,

--- a/src/redux/showcaseTokens.js
+++ b/src/redux/showcaseTokens.js
@@ -3,7 +3,7 @@ import { concat, without } from 'lodash';
 import {
   getShowcaseTokens,
   saveShowcaseTokens,
-} from '../handlers/localstorage/accountLocal';
+} from '@rainbow-me/handlers/localstorage/accountLocal';
 
 // -- Constants --------------------------------------- //
 const SHOWCASE_TOKENS_LOAD_SUCCESS =
@@ -17,9 +17,9 @@ const REMOVE_SHOWCASE_TOKEN = 'showcaseTokens/REMOVE_SHOWCASE_TOKEN';
 export const showcaseTokensLoadState = () => async (dispatch, getState) => {
   try {
     const { accountAddress, network } = getState().settings;
-    const openSavings = await getShowcaseTokens(accountAddress, network);
+    const showcaseTokens = await getShowcaseTokens(accountAddress, network);
     dispatch({
-      payload: openSavings,
+      payload: showcaseTokens,
       type: SHOWCASE_TOKENS_LOAD_SUCCESS,
     });
   } catch (error) {

--- a/src/redux/uniswapLiquidity.js
+++ b/src/redux/uniswapLiquidity.js
@@ -1,12 +1,14 @@
 import produce from 'immer';
-import { concat, filter, isEmpty, uniqBy } from 'lodash';
+import { concat, filter, isEmpty, map, uniqBy } from 'lodash';
+/* eslint-disable-next-line import/no-cycle */
+import { emitChartsRequest } from './explorer';
 import {
   getLiquidity,
   getUniswapLiquidityInfo,
   saveLiquidity,
   saveLiquidityInfo,
-} from '../handlers/localstorage/uniswap';
-import { getLiquidityInfo } from '../handlers/uniswapLiquidity';
+} from '@rainbow-me/handlers/localstorage/uniswap';
+import { getLiquidityInfo } from '@rainbow-me/handlers/uniswapLiquidity';
 
 // -- Constants ------------------------------------------------------------- //
 const UNISWAP_UPDATE_LIQUIDITY_TOKEN_INFO =
@@ -58,6 +60,9 @@ export const uniswapUpdateLiquidityTokens = (
       ),
       token => !!Number(token?.balance?.amount ?? 0)
     );
+  } else {
+    const assetCodes = map(liquidityTokens, token => token.address);
+    dispatch(emitChartsRequest(assetCodes));
   }
   const { accountAddress, network } = getState().settings;
   dispatch({

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -1,10 +1,10 @@
 import { useRoute } from '@react-navigation/core';
-import { get } from 'lodash';
+import { compact, find, get, isEmpty, map } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { StatusBar } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useValue } from 'react-native-redash';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { OpacityToggler } from '../components/animations';
 import { AssetList } from '../components/asset-list';
@@ -15,8 +15,7 @@ import {
   ProfileHeaderButton,
 } from '../components/header';
 import { Page } from '../components/layout';
-import networkInfo from '../helpers/networkInfo';
-import { updateRefetchSavings } from '../redux/data';
+import networkInfo from '@rainbow-me/helpers/networkInfo';
 import {
   useAccountEmptyState,
   useAccountSettings,
@@ -27,6 +26,8 @@ import {
   useWalletSectionsData,
 } from '@rainbow-me/hooks';
 import { useCoinListEditedValue } from '@rainbow-me/hooks/useCoinListEdited';
+import { updateRefetchSavings } from '@rainbow-me/redux/data';
+import { emitChartsRequest } from '@rainbow-me/redux/explorer';
 import { position } from '@rainbow-me/styles';
 
 const HeaderOpacityToggler = styled(OpacityToggler).attrs(({ isVisible }) => ({
@@ -45,12 +46,13 @@ const WalletPage = styled(Page)`
 export default function WalletScreen() {
   const { params } = useRoute();
   const [initialized, setInitialized] = useState(!!params?.initialized);
+  const [fetchedCharts, setFetchedCharts] = useState(false);
   const initializeWallet = useInitializeWallet();
   const refreshAccountData = useRefreshAccountData();
   const { isCoinListEdited } = useCoinListEdited();
   const scrollViewTracker = useValue(0);
   const { isReadOnlyWallet } = useWallets();
-  const { isEmpty } = useAccountEmptyState();
+  const { isEmpty: isAccountEmpty } = useAccountEmptyState();
   const { network } = useAccountSettings();
   const {
     isWalletEthZero,
@@ -58,6 +60,11 @@ export default function WalletScreen() {
     sections,
     shouldRefetchSavings,
   } = useWalletSectionsData();
+
+  const assetsSocket = useSelector(
+    ({ explorer: { assetsSocket } }) => assetsSocket
+  );
+
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -77,6 +84,17 @@ export default function WalletScreen() {
       setInitialized(true);
     }
   }, [initializeWallet, initialized, params]);
+
+  useEffect(() => {
+    if (initialized && assetsSocket && !fetchedCharts) {
+      const balancesSection = find(sections, ({ name }) => name === 'balances');
+      const assetCodes = compact(map(balancesSection?.data, 'address'));
+      if (!isEmpty(assetCodes)) {
+        dispatch(emitChartsRequest(assetCodes));
+        setFetchedCharts(true);
+      }
+    }
+  }, [assetsSocket, dispatch, fetchedCharts, initialized, sections]);
 
   // Show the exchange fab only for supported networks
   // (mainnet & rinkeby)
@@ -100,7 +118,7 @@ export default function WalletScreen() {
       <Animated.View style={{ opacity: isCoinListEditedValue }} />
       <Animated.Code exec={scrollViewTracker} />
       <FabWrapper
-        disabled={isEmpty || !!params?.emptyWallet}
+        disabled={isAccountEmpty || !!params?.emptyWallet}
         fabs={fabs}
         isCoinListEdited={isCoinListEdited}
         isReadOnlyWallet={isReadOnlyWallet}
@@ -113,7 +131,7 @@ export default function WalletScreen() {
         </HeaderOpacityToggler>
         <AssetList
           fetchData={refreshAccountData}
-          isEmpty={isEmpty || !!params?.emptyWallet}
+          isEmpty={isAccountEmpty || !!params?.emptyWallet}
           isWalletEthZero={isWalletEthZero}
           network={network}
           scrollViewTracker={scrollViewTracker}


### PR DESCRIPTION
* Remove chart data from localstorage (and unused loading function from localstorage)
* Prefetch charts for only the top assets (anything that shows above the "All" button)
* Fetch all wallet charts when "All" button selected
* Clean up redux state for open state settings
* Fix the settings for savings open state (previously, it kept Savings closed even if you left it open and killed the app)

PoW: https://recordit.co/aC9ZZ26gdf