### PR TITLE
Improve LP charts

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -380,6 +380,7 @@ PODS:
     - React
     - RNInputMask
   - react-native-udp (2.7.0):
+    - CocoaAsyncSocket
     - React
   - react-native-version-number (0.3.6):
     - React
@@ -578,6 +579,7 @@ PODS:
     - React
   - SSZipArchive (2.2.3)
   - TcpSockets (3.3.2):
+    - CocoaAsyncSocket
     - React
   - TOCropViewController (2.5.5)
   - ToolTipMenu (5.2.1):
@@ -1001,7 +1003,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 13004a45f3021328fdd9ee1f987c3131fb65928d
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-text-input-mask: 07227297075f9653315f43b0424d596423a01736
-  react-native-udp: ff9d13e523f2b58e6bc5d4d32321ac60671b5dc9
+  react-native-udp: 96a517e5a121cfe69f4b05eeeafefe00c623debf
   react-native-version-number: b415bbec6a13f2df62bf978e85bc0d699462f37f
   react-native-video: 0bb76b6d6b77da3009611586c7dbf817b947f30e
   react-native-video-cache: 0f8b1b2195f234eabd507cfebdd91c2e82695008
@@ -1055,7 +1057,7 @@ SPEC CHECKSUMS:
   Shimmer: c5374be1c2b0c9e292fb05b339a513cf291cac86
   SRSRadialGradient: a372b4b3bc65a2f3b1a16b906485cff204e1db3e
   SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
-  TcpSockets: 14306fb79f9750ea7d2ddd02d8bed182abb01797
+  TcpSockets: bd31674146c0931a064fc254a59812dfd1a73ae0
   TOCropViewController: da59f531f8ac8a94ef6d6c0fc34009350f9e8bfe
   ToolTipMenu: 8ac61aded0fbc4acfe7e84a7d0c9479d15a9a382
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a

--- a/src/components/investment-cards/UniswapPoolListRow.js
+++ b/src/components/investment-cards/UniswapPoolListRow.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
 import { convertAmountToNativeDisplay } from '../../helpers/utilities';
+import { UniBalanceHeightDifference } from '../../hooks/charts/useChartThrottledPoints';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText, CoinRow } from '../coin-row';
 import CoinName from '../coin-row/CoinName';
@@ -154,8 +155,10 @@ export default function UniswapPoolListRow({ assetType, item, ...props }) {
   const { uniswap } = useSelector(readableUniswapSelector);
 
   const handleOpenExpandedState = useCallback(() => {
+    let inWallet = true;
     let poolAsset = uniswap.find(pool => pool.address === item.address);
     if (!poolAsset) {
+      inWallet = false;
       const genericPoolAsset = genericAssets[item.address];
       poolAsset = parseAssetsNative(
         [{ ...item, ...genericPoolAsset }],
@@ -165,7 +168,10 @@ export default function UniswapPoolListRow({ assetType, item, ...props }) {
     navigate(Routes.EXPANDED_ASSET_SHEET, {
       asset: poolAsset,
       fromDiscover: true,
-      longFormHeight: initialLiquidityPoolExpandedStateSheetHeight,
+      longFormHeight: inWallet
+        ? initialLiquidityPoolExpandedStateSheetHeight
+        : initialLiquidityPoolExpandedStateSheetHeight -
+          UniBalanceHeightDifference,
       type: assetType,
     });
   }, [assetType, genericAssets, item, nativeCurrency, navigate, uniswap]);

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -12,13 +12,16 @@ import {
   UNISWAP_PAIRS_ID_QUERY,
 } from '@rainbow-me/apollo/queries';
 import ChartTypes from '@rainbow-me/helpers/chartTypes';
-import { emitAssetRequest } from '@rainbow-me/redux/explorer';
+import {
+  emitAssetRequest,
+  emitChartsRequest,
+} from '@rainbow-me/redux/explorer';
 import { ETH_ADDRESS, WETH_ADDRESS } from '@rainbow-me/references';
 import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
 const UNISWAP_QUERY_INTERVAL = 1000 * 60 * 5; // 5 minutes
-const AMOUNT_OF_PAIRS_TO_DISPLAY = 40;
+const AMOUNT_OF_PAIRS_TO_DISPLAY = 30;
 
 export const SORT_DIRECTION = {
   ASC: 'asc',
@@ -462,6 +465,7 @@ export default function useUniswapPools(sortField, sortDirection) {
 
     const allLPTokens = sortedPairs.map(({ address }) => address);
     dispatch(emitAssetRequest(allLPTokens));
+    dispatch(emitChartsRequest(allLPTokens));
     return sortedPairs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, pairs, sortDirection, sortField]);


### PR DESCRIPTION
This make preload LP charts and also shortens the LP list from 40 to 30 to make up for the memory allocated in charts without causing impact.

Also fixes the initial sheet height. We were always animating to the height corresponding to the sheet when the asset is in the wallet, creating an undesired jump for LP that you are not part of.

Now both animations (LP tokens in wallet or not) are smooth. 
PoW: http://recordit.co/RlJNvUQHga

Also updated the pod.lockfile