### PR TITLE
Fix scrollsToTop again

### DIFF
--- a/src/components/discover-sheet/UniswapPoolsSection.js
+++ b/src/components/discover-sheet/UniswapPoolsSection.js
@@ -255,6 +255,7 @@ export default function UniswapPools() {
           keyExtractor={item => item.address}
           removeClippedSubviews
           renderItem={renderUniswapPoolListRow}
+          scrollsToTop={false}
           windowSize={11}
         />
       ) : (


### PR DESCRIPTION
https://linear.app/rainbow/issue/RNBW-1019/tapping-the-status-bar-to-scroll-to-top-is-broken-everywhere-except-in

This issue became present again