### PR TITLE
Fix when append or change has removed the last LP token

### DIFF
--- a/src/redux/uniswapLiquidity.js
+++ b/src/redux/uniswapLiquidity.js
@@ -87,16 +87,17 @@ export const uniswapUpdateLiquidityInfo = () => async (dispatch, getState) => {
   const { pairs } = getState().uniswap;
   const { liquidityTokens } = getState().uniswapLiquidity;
 
-  if (isEmpty(liquidityTokens)) return;
-
   try {
-    const liquidityInfo = await getLiquidityInfo(
-      chainId,
-      accountAddress,
-      nativeCurrency,
-      liquidityTokens,
-      pairs
-    );
+    let liquidityInfo = {};
+    if (!isEmpty(liquidityTokens)) {
+      liquidityInfo = await getLiquidityInfo(
+        chainId,
+        accountAddress,
+        nativeCurrency,
+        liquidityTokens,
+        pairs
+      );
+    }
     saveLiquidityInfo(liquidityInfo, accountAddress, network);
     dispatch({
       payload: liquidityInfo,


### PR DESCRIPTION
My previous updates had handled the LP tokens removal but missed when the last LP is removed, the info also needs to be updated.