### PR TITLE
update uniswap graph url

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -22,7 +22,7 @@ export const uniswapClient = new ApolloClient({
   cache: new InMemoryCache(),
   defaultOptions,
   link: new HttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2',
+    uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswapv2',
   }),
 });
 


### PR DESCRIPTION
This is what uniswap.info is currently using.

Fixes the issues of 24h volume not showing on some tokens like REP or Staked Ether.