### PR TITLE
Fix stuck on authorizing bug in swap

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@ethersproject/constants": "^5.0.7",
     "@ethersproject/contracts": "^5.0.8",
     "@ethersproject/hdnode": "^5.0.7",
+    "@ethersproject/logger": "^5.1.0",
     "@ethersproject/providers": "^5.0.17",
     "@ethersproject/random": "^5.0.6",
     "@ethersproject/shims": "^5.0.10",

--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@ethersproject/logger';
 import { Wallet } from '@ethersproject/wallet';
 import analytics from '@segment/analytics-react-native';
 import { captureException } from '@sentry/react-native';
@@ -60,6 +61,15 @@ export interface Rap {
   actions: RapAction[];
 }
 
+interface RapActionResponse {
+  baseNonce?: number | null;
+  errorMessage: string | null;
+}
+
+interface EthersError extends Error {
+  code?: string | null;
+}
+
 const NOOP = () => null;
 
 export const RapActionTypes = {
@@ -119,6 +129,18 @@ const getRapFullName = (actions: RapAction[]) => {
   return join(actionTypes, ' + ');
 };
 
+const parseError = (error: EthersError): string => {
+  const errorCode = error?.code;
+  switch (errorCode) {
+    case Logger.errors.UNPREDICTABLE_GAS_LIMIT:
+      return 'Oh no! We were unable to estimate the gas limit. Please try again.';
+    case Logger.errors.INSUFFICIENT_FUNDS:
+      return 'Oh no! The gas price changed and you no longer have enough funds for this transaction. Please try again with a lower amount.';
+    default:
+      return 'Oh no! There was a problem submitting the transaction. Please try again.';
+  }
+};
+
 const executeAction = async (
   action: RapAction,
   wallet: Wallet,
@@ -126,7 +148,7 @@ const executeAction = async (
   index: number,
   rapName: string,
   baseNonce?: number
-) => {
+): Promise<RapActionResponse> => {
   logger.log('[1 INNER] index', index);
   const { parameters, type } = action;
   const actionPromise = findActionByType(type);
@@ -139,7 +161,7 @@ const executeAction = async (
       parameters,
       baseNonce
     );
-    return nonce;
+    return { baseNonce: nonce, errorMessage: null };
   } catch (error) {
     logger.sentry('[3 INNER] error running action');
     captureException(error);
@@ -148,7 +170,13 @@ const executeAction = async (
       failed_action: type,
       label: rapName,
     });
-    return null;
+    // If the first action failed, return an error message
+    if (index === 0) {
+      const errorMessage = parseError(error);
+      logger.log('[4 INNER] displaying error message', errorMessage);
+      return { baseNonce: null, errorMessage };
+    }
+    return { baseNonce: null, errorMessage: null };
   }
 };
 
@@ -156,7 +184,7 @@ export const executeRap = async (
   wallet: Wallet,
   type: string,
   swapParameters: SwapActionParameters,
-  callback: () => void
+  callback: (success?: boolean, errorMessage?: string | null) => void
 ) => {
   const rap: Rap = await createRapByType(type, swapParameters);
   const { actions } = rap;
@@ -168,16 +196,24 @@ export const executeRap = async (
   });
 
   logger.log('[common - executing rap]: actions', actions);
-  let baseNonce = null;
   if (actions.length) {
     const firstAction = actions[0];
-    baseNonce = await executeAction(firstAction, wallet, rap, 0, rapName);
+    const { baseNonce, errorMessage } = await executeAction(
+      firstAction,
+      wallet,
+      rap,
+      0,
+      rapName
+    );
     if (baseNonce) {
       for (let index = 1; index < actions.length; index++) {
         const action = actions[index];
         await executeAction(action, wallet, rap, index, rapName, baseNonce);
       }
       callback();
+    } else {
+      // Callback with failure state
+      callback(false, errorMessage);
     }
   }
 

--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -163,7 +163,7 @@ const executeAction = async (
     );
     return { baseNonce: nonce, errorMessage: null };
   } catch (error) {
-    logger.sentry('[3 INNER] error running action');
+    logger.sentry('[3 INNER] error running action, code:', error?.code);
     captureException(error);
     analytics.track('Rap failed', {
       category: 'raps',

--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -210,7 +210,7 @@ export const executeRap = async (
         const action = actions[index];
         await executeAction(action, wallet, rap, index, rapName, baseNonce);
       }
-      callback();
+      callback(true);
     } else {
       // Callback with failure state
       callback(false, errorMessage);

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -304,7 +304,7 @@ export default function ExchangeModal({
           return;
         }
 
-        const callback = (success = true, errorMessage = null) => {
+        const callback = (success = false, errorMessage = null) => {
           setIsAuthorizing(false);
           if (success) {
             setParams({ focused: false });

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Keyboard } from 'react-native';
+import { Alert, Keyboard } from 'react-native';
 import { useAndroidBackHandler } from 'react-navigation-backhandler';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
@@ -304,10 +304,14 @@ export default function ExchangeModal({
           return;
         }
 
-        const callback = () => {
+        const callback = (success = true, errorMessage = null) => {
           setIsAuthorizing(false);
-          setParams({ focused: false });
-          navigate(Routes.PROFILE_SCREEN);
+          if (success) {
+            setParams({ focused: false });
+            navigate(Routes.PROFILE_SCREEN);
+          } else if (errorMessage) {
+            Alert.alert(errorMessage);
+          }
         };
         logger.log('[exchange - handle submit] rap');
         const swapParameters = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,11 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.9.tgz#0e6a0b3ecc938713016954daf4ac7967467aa763"
   integrity sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw==
 
+"@ethersproject/logger@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.1.0.tgz#4cdeeefac029373349d5818f39c31b82cc6d9bbf"
+  integrity sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw==
+
 "@ethersproject/networks@^5.0.3":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.0.4.tgz#6d320a5e15a0cda804f5da88be0ba846156f6eec"


### PR DESCRIPTION
- Parse errors from ethers.js in rap execution and provide more meaningful alerts on failure (especially for INSUFFICIENT_FUNDS and UNPREDICTABLE_GAS_LIMIT errors)
- Add the error code explicitly in sentry logging because the error details gets cut off

Added some screenshots from "fake error throws" so you can see what it'll look like if it fails. Instead of navigating to the Profile Screen or getting stuck on authorizing, it will now display the alerts below:

<img width="430" alt="Screen Shot 2021-04-15 at 8 16 42 AM" src="https://user-images.githubusercontent.com/1285228/114894787-2c79c880-9dcc-11eb-9c72-e6e408d7d439.png">
<img width="430" alt="Screen Shot 2021-04-15 at 8 19 34 AM" src="https://user-images.githubusercontent.com/1285228/114894802-2edc2280-9dcc-11eb-9fd7-c59eeda38121.png">
