### PR TITLE
Show Fetching Details when reserves still loading

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -34,6 +34,7 @@ const Container = styled(Centered)`
 
 export default function ConfirmExchangeButton({
   disabled,
+  doneLoadingReserves,
   inputAmount,
   isHighPriceImpact,
   onPressViewDetails,
@@ -43,7 +44,10 @@ export default function ConfirmExchangeButton({
   ...props
 }) {
   const isSufficientBalance = useSwapIsSufficientBalance(inputAmount);
-  const isSufficientLiquidity = useSwapIsSufficientLiquidity(tradeDetails);
+  const isSufficientLiquidity = useSwapIsSufficientLiquidity(
+    doneLoadingReserves,
+    tradeDetails
+  );
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
   const asset = outputCurrency ?? inputCurrency;
   const { isSufficientGas } = useGas();
@@ -109,10 +113,13 @@ export default function ConfirmExchangeButton({
     label = isSwapDetailsRoute ? 'Swap Anyway' : '􀕹 View Details';
   } else if (disabled) {
     label = 'Enter an Amount';
+  } else if (!doneLoadingReserves) {
+    label = 'Fetching Details...';
   }
 
   const isDisabled =
     disabled ||
+    !doneLoadingReserves ||
     !isSufficientBalance ||
     !isSufficientGas ||
     !isSufficientLiquidity;

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -84,7 +84,7 @@ export default function useSwapDerivedOutputs() {
   const outputPrice = genericAssets[outputCurrency?.address]?.price?.value;
 
   const { chainId } = useAccountSettings();
-  const { allPairs } = useUniswapPairs();
+  const { allPairs, doneLoadingReserves } = useUniswapPairs();
 
   return useMemo(() => {
     let tradeDetails = null;
@@ -100,7 +100,12 @@ export default function useSwapDerivedOutputs() {
     };
 
     if (!independentValue || !inputCurrency) {
-      return { derivedValues, displayValues, tradeDetails };
+      return {
+        derivedValues,
+        displayValues,
+        doneLoadingReserves,
+        tradeDetails,
+      };
     }
 
     const inputToken = getTokenForCurrency(inputCurrency, chainId);
@@ -164,7 +169,12 @@ export default function useSwapDerivedOutputs() {
       displayValues[DisplayValue.output] = outputAmountDisplay;
     } else {
       if (!outputToken || !inputToken || isEmpty(allPairs)) {
-        return { derivedValues, displayValues, tradeDetails };
+        return {
+          derivedValues,
+          displayValues,
+          doneLoadingReserves,
+          tradeDetails,
+        };
       }
       derivedValues[SwapModalField.output] = independentValue;
       displayValues[DisplayValue.output] = independentValue;
@@ -202,10 +212,11 @@ export default function useSwapDerivedOutputs() {
 
       derivedValues[SwapModalField.native] = nativeValue;
     }
-    return { derivedValues, displayValues, tradeDetails };
+    return { derivedValues, displayValues, doneLoadingReserves, tradeDetails };
   }, [
     allPairs,
     chainId,
+    doneLoadingReserves,
     independentField,
     independentValue,
     inputCurrency,

--- a/src/hooks/useSwapIsSufficientLiquidity.ts
+++ b/src/hooks/useSwapIsSufficientLiquidity.ts
@@ -5,6 +5,7 @@ import { AppState } from '@rainbow-me/redux/store';
 import { greaterThan } from '@rainbow-me/utilities';
 
 export default function useSwapIsSufficientLiquidity(
+  doneLoadingReserves: boolean,
   tradeDetails: Trade | null
 ) {
   const independentValue = useSelector(
@@ -22,8 +23,9 @@ export default function useSwapIsSufficientLiquidity(
     const hasUserInput = greaterThan(independentValue, 0);
     const userHasSpecifiedInputOutput =
       inputCurrencyAddress && outputCurrencyAddress && hasUserInput;
-    return !(noRoute && userHasSpecifiedInputOutput);
+    return !(doneLoadingReserves && noRoute && userHasSpecifiedInputOutput);
   }, [
+    doneLoadingReserves,
     independentValue,
     inputCurrencyAddress,
     outputCurrencyAddress,

--- a/src/hooks/useUniswapPairs.ts
+++ b/src/hooks/useUniswapPairs.ts
@@ -17,14 +17,14 @@ export default function useUniswapPairs() {
     PAIR_GET_RESERVES_FRAGMENT
   );
 
-  const { allPairs, doneLoadingResults } = useMemo(() => {
-    let doneLoadingResults = true;
+  const { allPairs, doneLoadingReserves } = useMemo(() => {
+    let doneLoadingReserves = true;
     const viablePairs = multicallResults.map((result, i) => {
       const { result: reserves, loading } = result;
       const tokenA = allPairCombinations[i][0];
       const tokenB = allPairCombinations[i][1];
       if (loading) {
-        doneLoadingResults = false;
+        doneLoadingReserves = false;
       }
 
       if (loading || !reserves || !tokenA || !tokenB) return null;
@@ -37,14 +37,15 @@ export default function useUniswapPairs() {
         new TokenAmount(token1, reserve1.toString())
       );
     });
+
     return {
       allPairs: compact(viablePairs),
-      doneLoadingResults,
+      doneLoadingReserves,
     };
   }, [allPairCombinations, multicallResults]);
 
   return {
     allPairs,
-    doneLoadingResults,
+    doneLoadingReserves,
   };
 }

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -172,6 +172,7 @@ export default function ExchangeModal({
   const {
     derivedValues: { inputAmount, nativeAmount, outputAmount },
     displayValues: { inputAmountDisplay, outputAmountDisplay },
+    doneLoadingReserves,
     tradeDetails,
   } = useSwapDerivedOutputs();
 
@@ -344,6 +345,7 @@ export default function ExchangeModal({
   const confirmButtonProps = useMemoOne(
     () => ({
       disabled: !Number(inputAmount),
+      doneLoadingReserves,
       inputAmount,
       isAuthorizing,
       isHighPriceImpact,
@@ -352,6 +354,7 @@ export default function ExchangeModal({
       type,
     }),
     [
+      doneLoadingReserves,
       handleSubmit,
       inputAmount,
       isAuthorizing,


### PR DESCRIPTION
We were flashing Insufficient Funds when switching pairs and fetching the reserve details. Now we show "Fetching Details..." 

Also fixed the flashing of "Insufficient Funds" at the very beginning when selecting your first pair.

Recording:
https://recordit.co/7pYxBe9omW