### PR TITLE
Support rendering markdown from OpenSea API

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "react-native-level-fs": "^3.0.1",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-mail": "^4.1.0",
+    "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-os": "software-mansion-labs/react-native-os#41a08e45260b8c1c53c77ad00e13ae954cb9337c",
     "react-native-permissions": "^2.0.9",
     "react-native-qrcode-svg": "mikedemarais/react-native-qrcode-svg#c0302a698ea4fa0bb9b506a11ef39905674f2221",

--- a/src/components/expanded-state/UniqueTokenExpandedState.js
+++ b/src/components/expanded-state/UniqueTokenExpandedState.js
@@ -1,4 +1,5 @@
 import React, { Fragment, useCallback, useMemo } from 'react';
+import Markdown from 'react-native-markdown-display';
 import styled from 'styled-components';
 import Link from '../Link';
 import { Column, ColumnWithDividers } from '../layout';
@@ -99,7 +100,7 @@ const UniqueTokenExpandedState = ({ asset }) => {
                   lineHeight="paragraphSmall"
                   size="lmedium"
                 >
-                  {familyDescription}
+                  <Markdown>{familyDescription}</Markdown>
                 </Text>
                 {familyLink && <Link url={familyLink} />}
               </Column>

--- a/src/components/expanded-state/UniqueTokenExpandedState.js
+++ b/src/components/expanded-state/UniqueTokenExpandedState.js
@@ -1,5 +1,4 @@
 import React, { Fragment, useCallback, useMemo } from 'react';
-import Markdown from 'react-native-markdown-display';
 import styled from 'styled-components';
 import Link from '../Link';
 import { Column, ColumnWithDividers } from '../layout';
@@ -10,7 +9,7 @@ import {
   SheetDivider,
   SlackSheet,
 } from '../sheet';
-import { Text } from '../text';
+import { MarkdownText } from '../text';
 import { ToastPositionContainer, ToggleStateToast } from '../toasts';
 import { UniqueTokenAttributes } from '../unique-token';
 import ExpandedStateSection from './ExpandedStateSection';
@@ -95,13 +94,13 @@ const UniqueTokenExpandedState = ({ asset }) => {
           {!!familyDescription && (
             <ExpandedStateSection title={`About ${familyName}`}>
               <Column>
-                <Text
+                <MarkdownText
                   color={colors.alpha(colors.blueGreyDark, 0.5)}
                   lineHeight="paragraphSmall"
                   size="lmedium"
                 >
-                  <Markdown>{familyDescription}</Markdown>
-                </Text>
+                  {familyDescription}
+                </MarkdownText>
                 {familyLink && <Link url={familyLink} />}
               </Column>
             </ExpandedStateSection>

--- a/src/components/text/MarkdownText.js
+++ b/src/components/text/MarkdownText.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Markdown from 'react-native-markdown-display';
+import Text from './Text';
+
+const MarkdownText = ({ children, ...props }) => {
+  const MarkdownBody = (node, markdownChildren, _parent, styles) => (
+    <Text key={node.key} style={{ ...styles, marginBottom: 36 }} {...props}>
+      {markdownChildren}
+    </Text>
+  );
+
+  return (
+    <Markdown
+      rules={{
+        paragraph: MarkdownBody,
+      }}
+    >
+      {children}
+    </Markdown>
+  );
+};
+
+MarkdownText.propTypes = {};
+
+export default MarkdownText;

--- a/src/components/text/index.js
+++ b/src/components/text/index.js
@@ -9,6 +9,7 @@ export { default as ErrorText } from './ErrorText';
 export { default as GradientText } from './GradientText';
 export { default as H1 } from './H1';
 export { default as Label } from './Label';
+export { default as MarkdownText } from './MarkdownText';
 export { default as Monospace } from './Monospace';
 export { default as Nbsp } from './Nbsp';
 export { default as PlaceholderText } from './PlaceholderText';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6026,7 +6026,7 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-entities@^2.0.0:
+entities@^2.0.0, entities@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
@@ -9336,6 +9336,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 lint-staged@^10.0.7:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.4.0.tgz#d18628f737328e0bbbf87d183f4020930e9a984e"
@@ -9723,6 +9730,17 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-table@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
@@ -9775,6 +9793,11 @@ mdn-data@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
   integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 mem@^4.0.0:
   version "4.3.0"
@@ -12032,6 +12055,13 @@ react-native-fast-image@^8.3.4:
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.3.4.tgz#79edca177e30311b19d59ff335625bcbe22650d7"
   integrity sha512-LpzAdjUphihUpVEBn5fEv5AILe55rHav0YiZroPZ1rumKDhAl4u2cG01ku2Pb7l8sayjTsNu7FuURAlXUUDsow==
 
+react-native-fit-image@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz#c660d1ad74b9dcaa1cba27a0d9c23837e000226c"
+  integrity sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-fs@^2.16.6:
   version "2.16.6"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.16.6.tgz#2901789a43210a35a0ef0a098019bbef3af395fd"
@@ -12128,6 +12158,16 @@ react-native-mail@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/react-native-mail/-/react-native-mail-4.1.0.tgz#2ebe2df2211a84862a3aea77316736189e23435b"
   integrity sha512-3IHQmUQJwFFV7HwDONeIEahhaEvK9u23liqIUQajPy7frk/AoIGhkdKf4FVSTeq+VlUx97qls4uNizP7hBXIIw==
+
+react-native-markdown-display@^7.0.0-alpha.2:
+  version "7.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-7.0.0-alpha.2.tgz#a48a70d3cb5c510a52ecf7f1509a4a3d14d728aa"
+  integrity sha512-Od1a4wJEcVGwO1bh02sHivsEkKKpu99+ew/OtmVTPRmfT8V3B0aTut7k7ICV0Vej9F4ZjylRHvm28/maYUBeGw==
+  dependencies:
+    css-to-react-native "^3.0.0"
+    markdown-it "^10.0.0"
+    prop-types "^15.7.2"
+    react-native-fit-image "^1.5.5"
 
 react-native-os@software-mansion-labs/react-native-os#41a08e45260b8c1c53c77ad00e13ae954cb9337c:
   version "1.2.8"
@@ -14534,6 +14574,11 @@ ua-parser-js@^0.7.18:
   version "0.7.22"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
   integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-es@^3.1.9:
   version "3.3.9"


### PR DESCRIPTION
hey frens - this is a super tiny thing that was bothering me, and since it's open source I figured I'd work on it myself!!

There are possibly other places this could be useful, but without much familiarity with the codebase this is what I did for now.

I also think some more thought should go into thing like styling markdown headers etc.,  but didn't want to go too far without putting this in front of the team.


| before: |  after: |
|---|---|
| ![before](https://user-images.githubusercontent.com/923033/117037942-137e7c00-acd5-11eb-9b35-b0d9bbf97544.png) | ![after](https://user-images.githubusercontent.com/923033/117037977-1bd6b700-acd5-11eb-9371-b271b6358b0a.png) |
