### PR TITLE
Gas fix

### DIFF
--- a/src/components/gas/GasSpeedButton.android.js
+++ b/src/components/gas/GasSpeedButton.android.js
@@ -365,7 +365,19 @@ const GasSpeedButton = ({
       return;
     }
 
-    if (minGasPrice && Number(customGasPriceInput) < minGasPrice) {
+    const minGasPriceAllowed = Number(
+      gasPricesAvailable?.normal?.value?.amount || 0
+    );
+
+    // The minimum gas for the tx is the higher amount between:
+    // - 10% more than the submitted gas of the previous tx (If speeding up / cancelling)
+    // - The new "normal" gas price from our third party API
+
+    const minimumGasAcceptedForTx = minGasPrice
+      ? Math.max(minGasPrice, minGasPriceAllowed)
+      : minGasPriceAllowed;
+
+    if (minGasPrice && Number(customGasPriceInput) < minimumGasAcceptedForTx) {
       Alert({
         buttons: [
           {
@@ -373,16 +385,13 @@ const GasSpeedButton = ({
             text: 'OK',
           },
         ],
-        message: `The minimum gas price valid allowed is ${minGasPrice} GWEI`,
+        message: `The minimum gas price valid allowed is ${minimumGasAcceptedForTx} GWEI`,
         title: 'Gas Price Too Low',
       });
       return;
     }
 
     const priceInWei = gweiToWei(customGasPriceInput);
-    const minGasPriceAllowed = Number(
-      gasPricesAvailable?.normal?.value?.amount || 0
-    );
     const maxGasPriceFast = Number(
       gasPricesAvailable?.fast?.value?.amount || 0
     );

--- a/src/components/gas/GasSpeedButton.android.js
+++ b/src/components/gas/GasSpeedButton.android.js
@@ -26,7 +26,7 @@ import { fonts, fontWithWidth, margin, padding } from '@rainbow-me/styles';
 import { darkModeThemeColors } from '@rainbow-me/styles/colors';
 import { gasUtils, magicMemo } from '@rainbow-me/utils';
 
-const { GasSpeedOrder, CUSTOM, FAST, SLOW } = gasUtils;
+const { GasSpeedOrder, CUSTOM, FAST, NORMAL, SLOW } = gasUtils;
 
 const Container = styled(Row).attrs({
   justify: 'space-between',
@@ -365,8 +365,10 @@ const GasSpeedButton = ({
       return;
     }
 
+    const minKey = options.indexOf(SLOW) !== -1 ? SLOW : NORMAL;
+
     const minGasPriceAllowed = Number(
-      gasPricesAvailable?.normal?.value?.amount || 0
+      gasPricesAvailable?.[minKey]?.value?.amount || 0
     );
 
     // The minimum gas for the tx is the higher amount between:
@@ -424,9 +426,9 @@ const GasSpeedButton = ({
   }, [
     customGasPriceInput,
     inputFocused,
+    options,
+    gasPricesAvailable,
     minGasPrice,
-    gasPricesAvailable?.normal?.value?.amount,
-    gasPricesAvailable?.fast?.value?.amount,
     dontBlur,
     handleCustomGasBlur,
   ]);

--- a/src/components/gas/GasSpeedButton.android.js
+++ b/src/components/gas/GasSpeedButton.android.js
@@ -380,13 +380,13 @@ const GasSpeedButton = ({
     }
 
     const priceInWei = gweiToWei(customGasPriceInput);
-    const minGasPriceSlow = Number(
-      gasPricesAvailable?.slow?.value?.amount || 0
+    const minGasPriceAllowed = Number(
+      gasPricesAvailable?.normal?.value?.amount || 0
     );
     const maxGasPriceFast = Number(
       gasPricesAvailable?.fast?.value?.amount || 0
     );
-    let tooLow = priceInWei < minGasPriceSlow;
+    let tooLow = priceInWei < minGasPriceAllowed;
     let tooHigh = priceInWei > maxGasPriceFast * 2.5;
 
     if (tooLow || tooHigh) {
@@ -416,7 +416,7 @@ const GasSpeedButton = ({
     customGasPriceInput,
     inputFocused,
     minGasPrice,
-    gasPricesAvailable?.slow?.value?.amount,
+    gasPricesAvailable?.normal?.value?.amount,
     gasPricesAvailable?.fast?.value?.amount,
     dontBlur,
     handleCustomGasBlur,

--- a/src/components/gas/GasSpeedButton.ios.js
+++ b/src/components/gas/GasSpeedButton.ios.js
@@ -325,7 +325,19 @@ const GasSpeedButton = ({
       return;
     }
 
-    if (minGasPrice && Number(customGasPriceInput) < minGasPrice) {
+    const minGasPriceAllowed = Number(
+      gasPricesAvailable?.normal?.value?.amount || 0
+    );
+
+    // The minimum gas for the tx is the higher amount between:
+    // - 10% more than the submitted gas of the previous tx (If speeding up / cancelling)
+    // - The new "normal" gas price from our third party API
+
+    const minimumGasAcceptedForTx = minGasPrice
+      ? Math.max(minGasPrice, minGasPriceAllowed)
+      : minGasPriceAllowed;
+
+    if (minGasPrice && Number(customGasPriceInput) < minimumGasAcceptedForTx) {
       Alert({
         buttons: [
           {
@@ -333,16 +345,13 @@ const GasSpeedButton = ({
             text: 'OK',
           },
         ],
-        message: `The minimum gas price valid allowed is ${minGasPrice} GWEI`,
+        message: `The minimum gas price valid allowed is ${minimumGasAcceptedForTx} GWEI`,
         title: 'Gas Price Too Low',
       });
       return;
     }
 
     const priceInWei = gweiToWei(customGasPriceInput);
-    const minGasPriceAllowed = Number(
-      gasPricesAvailable?.normal?.value?.amount || 0
-    );
     const maxGasPriceFast = Number(
       gasPricesAvailable?.fast?.value?.amount || 0
     );

--- a/src/components/gas/GasSpeedButton.ios.js
+++ b/src/components/gas/GasSpeedButton.ios.js
@@ -340,13 +340,13 @@ const GasSpeedButton = ({
     }
 
     const priceInWei = gweiToWei(customGasPriceInput);
-    const minGasPriceSlow = Number(
-      gasPricesAvailable?.slow?.value?.amount || 0
+    const minGasPriceAllowed = Number(
+      gasPricesAvailable?.normal?.value?.amount || 0
     );
     const maxGasPriceFast = Number(
       gasPricesAvailable?.fast?.value?.amount || 0
     );
-    let tooLow = priceInWei < minGasPriceSlow;
+    let tooLow = priceInWei < minGasPriceAllowed;
     let tooHigh = priceInWei > maxGasPriceFast * 2.5;
 
     if (tooLow || tooHigh) {
@@ -376,7 +376,7 @@ const GasSpeedButton = ({
     customGasPriceInput,
     inputFocused,
     minGasPrice,
-    gasPricesAvailable?.slow?.value?.amount,
+    gasPricesAvailable?.normal?.value?.amount,
     gasPricesAvailable?.fast?.value?.amount,
     dontBlur,
     handleCustomGasBlur,

--- a/src/components/gas/GasSpeedButton.ios.js
+++ b/src/components/gas/GasSpeedButton.ios.js
@@ -24,7 +24,7 @@ import { gweiToWei, weiToGwei } from '@rainbow-me/parsers';
 import { padding } from '@rainbow-me/styles';
 import { gasUtils, magicMemo } from '@rainbow-me/utils';
 
-const { GasSpeedOrder, CUSTOM, FAST, SLOW } = gasUtils;
+const { GasSpeedOrder, CUSTOM, FAST, NORMAL, SLOW } = gasUtils;
 
 const Container = styled(Column).attrs({
   hapticType: 'impactHeavy',
@@ -325,8 +325,10 @@ const GasSpeedButton = ({
       return;
     }
 
+    const minKey = options.indexOf(SLOW) !== -1 ? SLOW : NORMAL;
+
     const minGasPriceAllowed = Number(
-      gasPricesAvailable?.normal?.value?.amount || 0
+      gasPricesAvailable?.[minKey]?.value?.amount || 0
     );
 
     // The minimum gas for the tx is the higher amount between:
@@ -384,9 +386,9 @@ const GasSpeedButton = ({
   }, [
     customGasPriceInput,
     inputFocused,
+    options,
+    gasPricesAvailable,
     minGasPrice,
-    gasPricesAvailable?.normal?.value?.amount,
-    gasPricesAvailable?.fast?.value?.amount,
     dontBlur,
     handleCustomGasBlur,
   ]);

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -148,7 +148,6 @@ export const gasPricesStartPolling = () => async (dispatch, getState) => {
           payload: fallbackGasPrices,
           type: GAS_PRICES_FAILURE,
         });
-        captureException(error);
         fetchReject(error);
       }
     });

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -115,7 +115,9 @@ export const gasPricesStartPolling = () => async (dispatch, getState) => {
           // Add gas estimates
           adjustedGasPrices = await etherscanGetGasEstimates(priceData);
         } catch (e) {
-          logger.log('falling back to eth gas station', e);
+          captureException(new Error('Etherscan gas estimates failed'));
+          logger.log('Etherscan gas estimates error:', e);
+          logger.log('falling back to eth gas station');
           source = 'ethGasStation';
           // Fallback to ETHGasStation if Etherscan fails
           const {
@@ -140,6 +142,8 @@ export const gasPricesStartPolling = () => async (dispatch, getState) => {
 
         fetchResolve(true);
       } catch (error) {
+        captureException(new Error('all gas estimates failed'));
+        logger.log('gas estimates error', error);
         dispatch({
           payload: fallbackGasPrices,
           type: GAS_PRICES_FAILURE,

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -116,8 +116,8 @@ export const gasPricesStartPolling = () => async (dispatch, getState) => {
           adjustedGasPrices = await etherscanGetGasEstimates(priceData);
         } catch (e) {
           captureException(new Error('Etherscan gas estimates failed'));
-          logger.log('Etherscan gas estimates error:', e);
-          logger.log('falling back to eth gas station');
+          logger.sentry('Etherscan gas estimates error:', e);
+          logger.sentry('falling back to eth gas station');
           source = 'ethGasStation';
           // Fallback to ETHGasStation if Etherscan fails
           const {
@@ -143,7 +143,7 @@ export const gasPricesStartPolling = () => async (dispatch, getState) => {
         fetchResolve(true);
       } catch (error) {
         captureException(new Error('all gas estimates failed'));
-        logger.log('gas estimates error', error);
+        logger.sentry('gas estimates error', error);
         dispatch({
           payload: fallbackGasPrices,
           type: GAS_PRICES_FAILURE,


### PR DESCRIPTION
We removed slow from the exchange modal but we never updated the logic for minimum accepted gas.

Anything below normal brings problems, so the new min. is the "normal' price

If updating (speeding up / cancelling) the new min will be the higher amount between:
 - 10% more than the submitted gas of the previous tx (required by the nodes!)
 - The new "normal" gas price from our third party API
 
(We should consolidate the logic for both android and iOS in the future)

Fixes RNBW-1096

Also added more logging to the gas estimates call (etherscan and gasstation) to see if we're getting rate limited