### PR TITLE
increase settings modal height

### DIFF
--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -162,7 +162,7 @@ export default function SettingsModal() {
   const memoSettingsOptions = useMemo(() => settingsOptions(colors), [colors]);
   return (
     <Modal
-      minHeight={isTinyPhone ? 500 : 600}
+      minHeight={isTinyPhone ? 650 : 750}
       onCloseModal={goBack}
       radius={18}
       showDoneButton={ios}


### PR DESCRIPTION
After we added "Privacy" the version stamp got pushed out of the screen.
This PR increases the height of the modal so it fits again.

<img width="434" alt="Screen Shot 2021-05-21 at 10 38 43 AM" src="https://user-images.githubusercontent.com/1247834/119155042-c1ea2700-ba20-11eb-8671-de5b9b9a5160.png">
