### PR TITLE
fix: add `--network-concurrency 1` to yarnrc

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
+network-concurrency 1
 ignore-scripts true


### PR DESCRIPTION
Initial Yarn install fails due to MetaMask issues, adding flag to yarnrc prevents having to supply this flag to the command line manually.

See:
https://github.com/MetaMask/metamask-mobile/issues/1805
https://github.com/yarnpkg/yarn/issues/6312