### PR TITLE
Fix crashes while removing the last wallet

### DIFF
--- a/src/helpers/ScrollPager.js
+++ b/src/helpers/ScrollPager.js
@@ -191,7 +191,6 @@ export default class ScrollPager extends React.Component {
           }
           contentOffset={this.initialOffset}
           directionalLockEnabled
-          id={'AnimatedScrollViewPager' + this.props.id}
           keyboardShouldPersistTaps="always"
           onMomentumScrollEnd={this.handleMomentumScrollEnd}
           onScroll={this.onScroll}

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -240,7 +240,11 @@ function MainNavigator() {
         name={Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR}
         options={sheetPresetWithSmallGestureResponseDistance}
       />
-      <Stack.Screen component={WelcomeScreen} name={Routes.WELCOME_SCREEN} />
+      <Stack.Screen
+        component={WelcomeScreen}
+        name={Routes.WELCOME_SCREEN}
+        options={{ animationEnabled: false, gestureEnabled: false }}
+      />
       <Stack.Screen
         component={AddCashFlowNavigator}
         name={Routes.WYRE_WEBVIEW_NAVIGATOR}

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -126,7 +126,11 @@ function MainNavigator() {
       screenOptions={defaultScreenStackOptions}
     >
       <Stack.Screen component={SwipeNavigator} name={Routes.SWIPE_LAYOUT} />
-      <Stack.Screen component={WelcomeScreen} name={Routes.WELCOME_SCREEN} />
+      <Stack.Screen
+        component={WelcomeScreen}
+        name={Routes.WELCOME_SCREEN}
+        options={{ animationEnabled: false, gestureEnabled: false }}
+      />
       <Stack.Screen
         component={AvatarBuilder}
         name={Routes.AVATAR_BUILDER}

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -121,7 +121,7 @@ export default function ChangeWalletSheet() {
   const { colors } = useTheme();
   const { updateWebProfile } = useWebData();
 
-  const { goBack, navigate, replace } = useNavigation();
+  const { goBack, navigate } = useNavigation();
   const dispatch = useDispatch();
   const { accountAddress } = useAccountSettings();
   const initializeWallet = useInitializeWallet();
@@ -315,7 +315,7 @@ export default function ChangeWalletSheet() {
                   if (!isLastAvailableWallet) {
                     await cleanUpWalletKeys();
                     goBack();
-                    replace(Routes.WELCOME_SCREEN);
+                    navigate(Routes.WELCOME_SCREEN);
                   } else {
                     // If we're deleting the selected wallet
                     // we need to switch to another one
@@ -348,7 +348,7 @@ export default function ChangeWalletSheet() {
       goBack,
       onChangeAccount,
       renameWallet,
-      replace,
+      navigate,
       wallets,
     ]
   );

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -29,6 +29,7 @@ import {
   useWalletSectionsData,
 } from '@rainbow-me/hooks';
 import { useCoinListEditedValue } from '@rainbow-me/hooks/useCoinListEdited';
+import { useNavigation } from '@rainbow-me/navigation';
 import { updateRefetchSavings } from '@rainbow-me/redux/data';
 import {
   emitChartsRequest,
@@ -52,6 +53,7 @@ const WalletPage = styled(Page)`
 
 export default function WalletScreen() {
   const { params } = useRoute();
+  const { setParams } = useNavigation();
   const [initialized, setInitialized] = useState(!!params?.initialized);
   const [portfoliosFetched, setPortfoliosFetched] = useState(false);
   const [fetchedCharts, setFetchedCharts] = useState(false);
@@ -99,12 +101,13 @@ export default function WalletScreen() {
   }, [dispatch, refetchSavings, shouldRefetchSavings]);
 
   useEffect(() => {
-    if (!initialized) {
+    if (!initialized || (params?.emptyWallet && initialized)) {
       // We run the migrations only once on app launch
       initializeWallet(null, null, null, true);
       setInitialized(true);
+      setParams({ emptyWallet: false });
     }
-  }, [initializeWallet, initialized, params]);
+  }, [initializeWallet, initialized, params, setParams]);
 
   useEffect(() => {
     if (initialized && addressSocket && !portfoliosFetched) {

--- a/src/screens/WelcomeScreen.js
+++ b/src/screens/WelcomeScreen.js
@@ -9,6 +9,7 @@ import Reanimated, {
   timing,
 } from 'react-native-reanimated';
 import { useValue } from 'react-native-redash';
+import { useAndroidBackHandler } from 'react-navigation-backhandler';
 import styled from 'styled-components';
 import { useMemoOne } from 'use-memo-one';
 import RainbowGreyNeon from '../assets/rainbows/greyneon.png';
@@ -345,7 +346,7 @@ function colorAnimation(rValue, fromShadow) {
 
 export default function WelcomeScreen() {
   const { colors } = useTheme();
-  const { replace, navigate } = useNavigation();
+  const { replace, navigate, dangerouslyGetState } = useNavigation();
   const contentAnimation = useAnimatedValue(1);
   const hideSplashScreen = useHideSplashScreen();
   const createWalletButtonAnimation = useAnimatedValue(1);
@@ -441,11 +442,12 @@ export default function WelcomeScreen() {
   const backgroundColor = useMemoOne(() => colorAnimation(rValue, false), []);
 
   const onCreateWallet = useCallback(async () => {
-    replace(Routes.SWIPE_LAYOUT, {
+    const operation = dangerouslyGetState().index === 1 ? navigate : replace;
+    operation(Routes.SWIPE_LAYOUT, {
       params: { emptyWallet: true },
       screen: Routes.WALLET_SCREEN,
     });
-  }, [replace]);
+  }, [dangerouslyGetState, navigate, replace]);
 
   const createWalletButtonProps = useMemoOne(() => {
     const color = colorAnimation(rValue, true);
@@ -497,6 +499,10 @@ export default function WelcomeScreen() {
       backgroundColor,
     };
   }, [rValue]);
+
+  useAndroidBackHandler(() => {
+    return true;
+  });
 
   return (
     <Container testID="welcome-screen">


### PR DESCRIPTION
the reason why it was crashing is that discover sheet was unmounted. It is not that trivial to fix so I made something else - now we're actually pushing the welcome screen on the top of swipe-navigator. This solves the issue 

Fixes RNBW-1106