### PR TITLE
Move fetching of all swap tokens out of account data init

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -300,7 +300,7 @@ export const USER_POSITIONS = gql`
   }
 `;
 
-export const USER_MINTS_BUNRS_PER_PAIR = gql`
+export const USER_MINTS_BURNS_PER_PAIR = gql`
   query events($user: Bytes!, $pair: Bytes!) {
     mints(where: { to: $user, pair: $pair }) {
       amountUSD

--- a/src/hooks/useInitializeAccountData.js
+++ b/src/hooks/useInitializeAccountData.js
@@ -4,7 +4,6 @@ import { InteractionManager } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { explorerInit } from '../redux/explorer';
 import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
-import { uniswapGetAllExchanges, uniswapPairsInit } from '../redux/uniswap';
 import logger from 'logger';
 
 export default function useInitializeAccountData() {
@@ -15,12 +14,6 @@ export default function useInitializeAccountData() {
       InteractionManager.runAfterInteractions(() => {
         logger.sentry('Initialize account data');
         dispatch(explorerInit());
-      });
-
-      InteractionManager.runAfterInteractions(async () => {
-        logger.sentry('Initialize uniswapPairsInit & getAllExchanges');
-        dispatch(uniswapPairsInit());
-        await dispatch(uniswapGetAllExchanges());
       });
 
       InteractionManager.runAfterInteractions(async () => {

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -10,6 +10,7 @@ import {
   settingsLoadNetwork,
   settingsUpdateAccountAddress,
 } from '../redux/settings';
+import { uniswapGetAllExchanges, uniswapPairsInit } from '../redux/uniswap';
 import { walletsLoadState } from '../redux/wallets';
 import useAccountSettings from './useAccountSettings';
 import useHideSplashScreen from './useHideSplashScreen';
@@ -115,6 +116,8 @@ export default function useInitializeWallet() {
         }
 
         if (!switching) {
+          dispatch(uniswapPairsInit());
+          dispatch(uniswapGetAllExchanges());
           initializeDiscoverData();
           dispatch(additionalDataCoingeckoIds);
         }

--- a/src/redux/usersPositions.ts
+++ b/src/redux/usersPositions.ts
@@ -2,7 +2,7 @@ import { AnyAction } from 'redux';
 import { uniswapClient } from '../apollo/client';
 import {
   USER_HISTORY,
-  USER_MINTS_BUNRS_PER_PAIR,
+  USER_MINTS_BURNS_PER_PAIR,
   USER_POSITIONS,
 } from '../apollo/queries';
 import { AppDispatch, AppGetState } from '@rainbow-me/redux/store';
@@ -160,9 +160,9 @@ async function getPrincipalForUserPerPair(user: string, pairAddress: string) {
   let usd = 0;
   let amount0 = 0;
   let amount1 = 0;
-  // get all minst and burns to get principal amounts
+  // get all mints and burns to get principal amounts
   const results = await uniswapClient.query({
-    query: USER_MINTS_BUNRS_PER_PAIR,
+    query: USER_MINTS_BURNS_PER_PAIR,
     variables: {
       pair: pairAddress,
       user,


### PR DESCRIPTION
Also cleanup misspelling 

When switching wallets, we were fetching ALL of the Uniswap tokens again (many many pages worth of data).
Confirmed with logs that this no longer happens on switching wallets.

Just a note: we need to improve some logic regarding importing first time vs importing when adding new accounts / wallets (these actions will still trigger a refetch of all the Uniswap tokens). I'll make this improvement separately.