### PR TITLE
Unblock detox

### DIFF
--- a/e2e/init.js
+++ b/e2e/init.js
@@ -3,10 +3,10 @@
 require('dotenv').config({ path: '.env' });
 
 beforeAll(async () => {
-  await device.launchApp({
-    launchArgs: {
-      detoxURLBlacklistRegex:
-        ' \\("https://api.thegraph.com/subgraphs/name/ianlapham/uniswapv2"\\)',
-    },
-  });
+  await device.launchApp();
+
+  await device.setURLBlacklist([
+    'api.thegraph.com\/subgraphs\/name\/ianlapham\/uniswapv2',
+    'raw.githubusercontent.com',
+  ]);
 });

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -3,5 +3,10 @@
 require('dotenv').config({ path: '.env' });
 
 beforeAll(async () => {
-  await device.launchApp();
+  await device.launchApp({
+    launchArgs: {
+      detoxURLBlacklistRegex:
+        ' \\("https://api.thegraph.com/subgraphs/name/ianlapham/uniswapv2"\\)',
+    },
+  });
 });

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 /* eslint-disable no-undef */
 // eslint-disable-next-line import/no-commonjs
 require('dotenv').config({ path: '.env' });
@@ -6,6 +7,7 @@ beforeAll(async () => {
   await device.launchApp();
 
   await device.setURLBlacklist([
+    // eslint-disable-next-line prettier/prettier
     'api.thegraph.com\/subgraphs\/name\/ianlapham\/uniswapv2',
     'raw.githubusercontent.com',
   ]);


### PR DESCRIPTION
This API call is one of the reasons the tests are taking forever. 
With this flag we're disabling synchronization for it, so it should run way faster