### PR TITLE
swap focus fixes

### DIFF
--- a/src/components/exchange/ExchangeField.js
+++ b/src/components/exchange/ExchangeField.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { TouchableWithoutFeedback } from 'react-native';
 import styled from 'styled-components';
 import { TokenSelectionButton } from '../buttons';
@@ -48,13 +48,13 @@ const ExchangeField = (
     address,
     amount,
     disableCurrencySelection,
+    editable,
     onBlur,
     onFocus,
     onPressSelectCurrency,
     setAmount,
     symbol,
     testID,
-    autoFocus,
     useCustomAndroidMask = false,
     ...props
   },
@@ -63,9 +63,7 @@ const ExchangeField = (
   const colorForAsset = useColorForAsset({ address });
   const handleFocusField = useCallback(() => ref?.current?.focus(), [ref]);
   const { colors } = useTheme();
-  useEffect(() => {
-    autoFocus && handleFocusField();
-  }, [autoFocus, handleFocusField]);
+
   return (
     <Container {...props}>
       <TouchableWithoutFeedback onPress={handleFocusField}>
@@ -77,7 +75,7 @@ const ExchangeField = (
           )}
           <Input
             color={colorForAsset}
-            editable={!!symbol}
+            editable={editable}
             onBlur={onBlur}
             onChangeText={setAmount}
             onFocus={onFocus}

--- a/src/components/exchange/ExchangeInput.js
+++ b/src/components/exchange/ExchangeInput.js
@@ -129,7 +129,7 @@ const ExchangeInput = (
         value={value}
         weight={weight}
       />
-      {useCustomAndroidMask && !ref.current?.isFocused() && (
+      {useCustomAndroidMask && value > 0 && !ref.current?.isFocused() && (
         <AndroidMaskWrapper>
           <Text
             color={color}

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -40,8 +40,8 @@ export default function ExchangeInputField({
       <ExchangeField
         address={inputCurrencyAddress}
         amount={inputAmount}
-        autoFocus={android}
         disableCurrencySelection={disableInputCurrencySelection}
+        editable={!!inputCurrencySymbol}
         onFocus={onFocus}
         onPressSelectCurrency={onPressSelectInputCurrency}
         ref={inputFieldRef}

--- a/src/components/fab/ExchangeFab.js
+++ b/src/components/fab/ExchangeFab.js
@@ -1,8 +1,10 @@
 import React, { useCallback } from 'react';
 import { Alert } from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
+import { delayNext } from '../../hooks/useMagicAutofocus';
 import { useNavigation } from '../../navigation/Navigation';
 import { lightModeThemeColors } from '../../styles/colors';
+import { useEth } from '../../utils/ethereumUtils';
 import { Icon } from '../icons';
 import FloatingActionButton from './FloatingActionButton';
 import { enableActionsOnReadOnlyWallet } from '@rainbow-me/config/debug';
@@ -17,14 +19,24 @@ const FabShadow = [
 const ExchangeFab = ({ disabled, isReadOnlyWallet, ...props }) => {
   const { navigate } = useNavigation();
   const { colors } = useTheme();
+  const eth = useEth();
 
   const handlePress = useCallback(() => {
     if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
-      navigate(Routes.EXCHANGE_MODAL);
+      android && delayNext();
+      navigate(Routes.EXCHANGE_MODAL, {
+        params: {
+          params: {
+            inputAsset: eth,
+          },
+          screen: Routes.MAIN_EXCHANGE_SCREEN,
+        },
+        screen: Routes.MAIN_EXCHANGE_NAVIGATOR,
+      });
     } else {
       Alert.alert(`You need to import the wallet in order to do this`);
     }
-  }, [navigate, isReadOnlyWallet]);
+  }, [isReadOnlyWallet, navigate, eth]);
 
   return (
     <FloatingActionButton

--- a/src/hooks/useMagicAutofocus.js
+++ b/src/hooks/useMagicAutofocus.js
@@ -30,6 +30,10 @@ export default function useMagicAutofocus(
     lastFocusedInputHandle.current = target.getNativeRef();
   }, []);
 
+  const setLastFocusedInputHandle = useCallback(ref => {
+    lastFocusedInputHandle.current = ref.current;
+  }, []);
+
   const triggerFocus = useCallback(() => {
     if (!lastFocusedInputHandle.current) {
       return focusTextInput(defaultAutofocusInputRef.current);
@@ -92,6 +96,7 @@ export default function useMagicAutofocus(
   return {
     handleFocus,
     lastFocusedInputHandle,
+    setLastFocusedInputHandle,
     triggerFocus,
   };
 }

--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -33,6 +33,7 @@ export default function useSwapCurrencyHandlers({
   defaultInputAsset,
   defaultOutputAsset,
   inputFieldRef,
+  setLastFocusedInputHandle,
   outputFieldRef,
   title,
   type,
@@ -114,15 +115,17 @@ export default function useSwapCurrencyHandlers({
   const updateInputCurrency = useCallback(
     newInputCurrency => {
       dispatch(updateSwapInputCurrency(newInputCurrency));
+      setLastFocusedInputHandle(inputFieldRef);
     },
-    [dispatch]
+    [dispatch, inputFieldRef, setLastFocusedInputHandle]
   );
 
   const updateOutputCurrency = useCallback(
     newOutputCurrency => {
       dispatch(updateSwapOutputCurrency(newOutputCurrency));
+      setLastFocusedInputHandle(outputFieldRef);
     },
-    [dispatch]
+    [dispatch, outputFieldRef, setLastFocusedInputHandle]
   );
 
   const navigateToSelectInputCurrency = useCallback(() => {

--- a/src/hooks/useSwapInputRefs.ts
+++ b/src/hooks/useSwapInputRefs.ts
@@ -35,11 +35,11 @@ export default function useSwapInputRefs() {
     [inputCurrency, outputCurrency]
   );
 
-  const { handleFocus, lastFocusedInputHandle } = useMagicAutofocus(
-    inputFieldRef,
-    findNextInput,
-    true
-  );
+  const {
+    handleFocus,
+    lastFocusedInputHandle,
+    setLastFocusedInputHandle,
+  } = useMagicAutofocus(inputFieldRef, findNextInput, true);
 
   return {
     handleFocus,
@@ -47,5 +47,6 @@ export default function useSwapInputRefs() {
     lastFocusedInputHandle,
     nativeFieldRef,
     outputFieldRef,
+    setLastFocusedInputHandle,
   };
 }

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -155,6 +155,7 @@ export default function ExchangeModal({
     handleFocus,
     inputFieldRef,
     lastFocusedInputHandle,
+    setLastFocusedInputHandle,
     nativeFieldRef,
     outputFieldRef,
   } = useSwapInputRefs();
@@ -174,7 +175,9 @@ export default function ExchangeModal({
     defaultInputAsset,
     defaultOutputAsset,
     inputFieldRef,
+    lastFocusedInputHandle,
     outputFieldRef,
+    setLastFocusedInputHandle,
     title,
     type,
   });


### PR DESCRIPTION
fixes RNBW-1229 : Fixes 🤖 Initial focus on swap sheet 
- changed what makes the input editable and now we pass in ETH as the inputAsset
         - there is a slight lag otherwise that causes issues with 🤖
         
fixes RNBW-1247 : Input/Output currency select focus
- At some point we broke changing the focus if you just selected input/output asset
        - pretty sure this is expected behavior and there was a regression, lmk if not
 
 also changes the android mask to only show if there is a value to mask, it was overlapping with the input indicator 
 
 PoW:
 iOS:  https://cloud.skylarbarrera.com/Screen-Recording-2021-06-09-18-53-07.mp4
 android: https://cloud.skylarbarrera.com/androidfocus.mp4