### PR TITLE
tweak settings height

### DIFF
--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -105,7 +105,7 @@ export default function SettingsModal() {
   const { goBack, navigate } = useNavigation();
   const { wallets, selectedWallet } = useWallets();
   const { params } = useRoute();
-  const { isTinyPhone } = useDimensions();
+  const { height } = useDimensions();
   const { colors } = useTheme();
 
   const getRealRoute = useCallback(
@@ -162,7 +162,7 @@ export default function SettingsModal() {
   const memoSettingsOptions = useMemo(() => settingsOptions(colors), [colors]);
   return (
     <Modal
-      minHeight={isTinyPhone ? 650 : 750}
+      minHeight={height-100}
       onCloseModal={goBack}
       radius={18}
       showDoneButton={ios}

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -162,7 +162,7 @@ export default function SettingsModal() {
   const memoSettingsOptions = useMemo(() => settingsOptions(colors), [colors]);
   return (
     <Modal
-      minHeight={height-100}
+      minHeight={height - 100}
       onCloseModal={goBack}
       radius={18}
       showDoneButton={ios}


### PR DESCRIPTION
fixes RNBW-1254 : settings modal was overflowing on some smaller phones, now we calculate the height based on the phone's dimensions.

issue was reported on iphone 12 mini, now it is 👌 : https://cloud.skylarbarrera.com/Screen-Shot-2021-06-11-15-58-46.17.png


