### PR TITLE
Fix access on potentially null image url

### DIFF
--- a/src/components/unique-token/UniqueTokenImage.js
+++ b/src/components/unique-token/UniqueTokenImage.js
@@ -49,7 +49,7 @@ const UniqueTokenImage = ({
   const [error, setError] = useState(null);
   const handleError = useCallback(error => setError(error), [setError]);
   const { isDarkMode, colors } = useTheme();
-  const isSVG = imageUrl.substr(-4) === '.svg';
+  const isSVG = imageUrl?.substr(-4) === '.svg';
 
   return (
     <Centered backgroundColor={backgroundColor} style={position.coverAsObject}>


### PR DESCRIPTION
Crash caused by substr on null imageUrl when checking if it's a svg.
Example: dame.eth wallet, expanding the state for the Zora family (particularly, the Zora item with just the couch / lamp emojis), it would crash.

Before: https://recordit.co/nuMQrzDVHD
After: https://recordit.co/wCAHLukHcL