### PR TITLE
share NFT via Rainbow Profiles

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.js
@@ -8,6 +8,8 @@ import Pill from '../../Pill';
 import { ContextCircleButton } from '../../context-menu';
 import { ColumnWithMargins, FlexItem, Row, RowWithMargins } from '../../layout';
 import { Text } from '../../text';
+import { useAccountProfile } from '@rainbow-me/hooks';
+import { RAINBOW_PROFILES_BASE_URL } from '@rainbow-me/references';
 import { padding } from '@rainbow-me/styles';
 
 const contextButtonOptions = [
@@ -35,19 +37,33 @@ const HeadingColumn = styled(ColumnWithMargins).attrs({
 `;
 
 const UniqueTokenExpandedStateHeader = ({ asset }) => {
+  const { accountAddress, accountENS } = useAccountProfile();
+
+  const buildRainbowUrl = useCallback(
+    asset => {
+      const address = accountENS || accountAddress;
+      const family = asset.familyName;
+      const assetId = asset.uniqueId;
+
+      const url = `${RAINBOW_PROFILES_BASE_URL}/${address}?family=${family}&nft=${assetId}`;
+      return url;
+    },
+    [accountAddress, accountENS]
+  );
+
   const handleActionSheetPress = useCallback(
     buttonIndex => {
       if (buttonIndex === 0) {
         Share.share({
           title: `Share ${buildUniqueTokenName(asset)} Info`,
-          url: asset.permalink,
+          url: buildRainbowUrl(asset),
         });
-      } else if (buttonIndex === 1) {
+      } else if (buttonIndex === 2) {
         // View on OpenSea
         Linking.openURL(asset.permalink);
       }
     },
-    [asset]
+    [asset, buildRainbowUrl]
   );
 
   const { colors } = useTheme();


### PR DESCRIPTION
switches the sharing link to use web profiles

PoW: https://cloud.skylarbarrera.com/Screen-Recording-2021-06-23-11-32-16.mp4

links work the same as above, i removed the view on rainbow option as it triggers back to app via deep links