### PR TITLE
Default wallet emoji

### DIFF
--- a/src/components/change-wallet/AddressRow.js
+++ b/src/components/change-wallet/AddressRow.js
@@ -2,10 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useTheme } from '../../context/ThemeContext';
-import {
-  removeFirstEmojiFromString,
-  returnStringFirstEmoji,
-} from '../../helpers/emojiHandler';
 import { deviceUtils } from '../../utils';
 import { addressHashedEmoji } from '../../utils/defaultProfileUtils';
 import { ButtonPressAnimation } from '../animations';
@@ -16,6 +12,10 @@ import ImageAvatar from '../contacts/ImageAvatar';
 import { Icon } from '../icons';
 import { Centered, Column, ColumnWithMargins, Row } from '../layout';
 import { TruncatedAddress, TruncatedText } from '../text';
+import {
+  removeFirstEmojiFromString,
+  returnStringFirstEmoji,
+} from '@rainbow-me/helpers/emojiHandler';
 import { fonts, getFontSize } from '@rainbow-me/styles';
 
 const maxAccountLabelWidth = deviceUtils.dimensions.width - 88;

--- a/src/components/change-wallet/AddressRow.js
+++ b/src/components/change-wallet/AddressRow.js
@@ -2,8 +2,12 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useTheme } from '../../context/ThemeContext';
-import { removeFirstEmojiFromString } from '../../helpers/emojiHandler';
+import {
+  removeFirstEmojiFromString,
+  returnStringFirstEmoji,
+} from '../../helpers/emojiHandler';
 import { deviceUtils } from '../../utils';
+import { addressHashedEmoji } from '../../utils/defaultProfileUtils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import CoinCheckButton from '../coin-row/CoinCheckButton';
@@ -93,7 +97,6 @@ export default function AddressRow({ data, editMode, onPress, onEditWallet }) {
     color: accountColor,
     ens,
     image: accountImage,
-    index,
     isSelected,
     isReadOnly,
     label,
@@ -150,7 +153,12 @@ export default function AddressRow({ data, editMode, onPress, onEditWallet }) {
                 color={accountColor}
                 marginRight={10}
                 size="medium"
-                value={label || ens || `${index + 1}`}
+                value={
+                  returnStringFirstEmoji(label) ||
+                  addressHashedEmoji(address) ||
+                  label ||
+                  ens
+                }
               />
             )}
             <ColumnWithMargins margin={3}>

--- a/src/components/change-wallet/AddressRow.js
+++ b/src/components/change-wallet/AddressRow.js
@@ -2,8 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useTheme } from '../../context/ThemeContext';
-import { deviceUtils } from '../../utils';
-import { addressHashedEmoji } from '../../utils/defaultProfileUtils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import CoinCheckButton from '../coin-row/CoinCheckButton';
@@ -17,6 +15,7 @@ import {
   returnStringFirstEmoji,
 } from '@rainbow-me/helpers/emojiHandler';
 import { fonts, getFontSize } from '@rainbow-me/styles';
+import { defaultProfileUtils, deviceUtils } from '@rainbow-me/utils';
 
 const maxAccountLabelWidth = deviceUtils.dimensions.width - 88;
 const NOOP = () => undefined;
@@ -155,7 +154,7 @@ export default function AddressRow({ data, editMode, onPress, onEditWallet }) {
                 size="medium"
                 value={
                   returnStringFirstEmoji(label) ||
-                  addressHashedEmoji(address) ||
+                  defaultProfileUtils.addressHashedEmoji(address) ||
                   label ||
                   ens
                 }

--- a/src/components/contacts/ContactAvatar.js
+++ b/src/components/contacts/ContactAvatar.js
@@ -18,7 +18,7 @@ const buildShadows = (color, size, darkMode, colors) => {
         10,
         darkMode
           ? darkModeThemeColors.shadow
-          : darkModeThemeColors.avatarColor[color] || color,
+          : darkModeThemeColors.avatarBackgrounds[color] || color,
         0.2,
       ],
     ];
@@ -28,7 +28,7 @@ const buildShadows = (color, size, darkMode, colors) => {
         0,
         4,
         android ? 5 : 12,
-        darkMode ? colors.shadow : colors.avatarColor[color] || color,
+        darkMode ? colors.shadow : colors.avatarBackgrounds[color] || color,
         0.4,
       ],
     ];
@@ -87,7 +87,7 @@ const ContactAvatar = ({ color, size = 'medium', value, ...props }) => {
     <ShadowStack
       {...props}
       {...borders.buildCircleAsObject(dimensions)}
-      backgroundColor={colors.avatarColor[color] || color}
+      backgroundColor={colors.avatarBackgrounds[color] || color}
       shadows={shadows}
     >
       <Centered flex={1}>

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -1,7 +1,14 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import { removeFirstEmojiFromString } from '../../helpers/emojiHandler';
+import {
+  removeFirstEmojiFromString,
+  returnStringFirstEmoji,
+} from '../../helpers/emojiHandler';
 import { abbreviations, magicMemo } from '../../utils';
+import {
+  addressHashedEmoji,
+  isEthAddress,
+} from '../../utils/defaultProfileUtils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import { Column, RowWithMargins } from '../layout';
@@ -46,7 +53,7 @@ const ContactName = styled(TruncatedText).attrs({
 const ContactRow = ({ address, color, nickname, ...props }, ref) => {
   const { width: deviceWidth } = useDimensions();
   const { colors } = useTheme();
-  const { accountType, image, label, balance, ens, index, onPress } = props;
+  const { accountType, image, label, balance, ens, onPress } = props;
   let cleanedUpBalance = balance;
   if (balance === '0.00') {
     cleanedUpBalance = '0';
@@ -76,7 +83,11 @@ const ContactRow = ({ address, color, nickname, ...props }, ref) => {
             color={color}
             marginRight={10}
             size="medium"
-            value={nickname || label || ens || `${index + 1}`}
+            value={
+              isEthAddress(address)
+                ? returnStringFirstEmoji(label) || addressHashedEmoji(address)
+                : nickname || label || ens
+            }
           />
         )}
         <Column justify={ios ? 'space-between' : 'center'}>

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -1,14 +1,8 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import {
-  removeFirstEmojiFromString,
-  returnStringFirstEmoji,
-} from '../../helpers/emojiHandler';
+import { removeFirstEmojiFromString } from '../../helpers/emojiHandler';
 import { abbreviations, magicMemo } from '../../utils';
-import {
-  addressHashedEmoji,
-  isEthAddress,
-} from '../../utils/defaultProfileUtils';
+import {} from '../../utils/defaultProfileUtils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import { Column, RowWithMargins } from '../layout';
@@ -83,11 +77,7 @@ const ContactRow = ({ address, color, nickname, ...props }, ref) => {
             color={color}
             marginRight={10}
             size="medium"
-            value={
-              isEthAddress(address)
-                ? returnStringFirstEmoji(label) || addressHashedEmoji(address)
-                : nickname || label || ens
-            }
+            value={nickname || label || ens}
           />
         )}
         <Column justify={ios ? 'space-between' : 'center'}>

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import { removeFirstEmojiFromString } from '../../helpers/emojiHandler';
 import { abbreviations, magicMemo } from '../../utils';
-import {} from '../../utils/defaultProfileUtils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import { Column, RowWithMargins } from '../layout';

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -1,7 +1,10 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import { removeFirstEmojiFromString } from '../../helpers/emojiHandler';
-import { abbreviations, magicMemo } from '../../utils';
+import {
+  removeFirstEmojiFromString,
+  returnStringFirstEmoji,
+} from '../../helpers/emojiHandler';
+import { abbreviations, magicMemo, defaultProfileUtils } from '../../utils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import { Column, RowWithMargins } from '../layout';
@@ -52,6 +55,13 @@ const ContactRow = ({ address, color, nickname, ...props }, ref) => {
     cleanedUpBalance = '0';
   }
 
+  // show avatar for contact rows that are accounts, not contacts
+  const avatar =
+    accountType !== 'contacts'
+      ? returnStringFirstEmoji(label) ||
+        defaultProfileUtils.addressHashedEmoji(address)
+      : null;
+
   let cleanedUpLabel = null;
   if (label) {
     cleanedUpLabel = removeFirstEmojiFromString(label).join('');
@@ -76,7 +86,7 @@ const ContactRow = ({ address, color, nickname, ...props }, ref) => {
             color={color}
             marginRight={10}
             size="medium"
-            value={nickname || label || ens}
+            value={avatar || nickname || label || ens}
           />
         )}
         <Column justify={ios ? 'space-between' : 'center'}>

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -4,7 +4,7 @@ import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
 } from '../../helpers/emojiHandler';
-import { abbreviations, magicMemo, defaultProfileUtils } from '../../utils';
+import { abbreviations, defaultProfileUtils, magicMemo } from '../../utils';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText } from '../coin-row';
 import { Column, RowWithMargins } from '../layout';

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -46,7 +46,7 @@ const ContactName = styled(TruncatedText).attrs({
 const ContactRow = ({ address, color, nickname, ...props }, ref) => {
   const { width: deviceWidth } = useDimensions();
   const { colors } = useTheme();
-  const { accountType, image, label, balance, ens, onPress } = props;
+  const { accountType, balance, ens, image, label, onPress } = props;
   let cleanedUpBalance = balance;
   if (balance === '0.00') {
     cleanedUpBalance = '0';

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -21,7 +21,10 @@ import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { margin, padding, position } from '@rainbow-me/styles';
 import { abbreviations } from '@rainbow-me/utils';
-import { addressHashedEmoji } from '@rainbow-me/utils/defaultProfileUtils';
+import {
+  addressHashedColorIndex,
+  addressHashedEmoji,
+} from '@rainbow-me/utils/defaultProfileUtils';
 
 const WalletProfileAddressText = styled(TruncatedAddress).attrs(
   ({ theme: { colors } }) => ({
@@ -78,7 +81,10 @@ export default function WalletProfileState({
   profile,
   forceColor,
 }) {
-  const nameEmoji = returnStringFirstEmoji(profile?.name);
+  const nameEmoji = isNewProfile
+    ? addressHashedEmoji(address)
+    : returnStringFirstEmoji(profile?.name) || addressHashedEmoji(address);
+
   const { goBack, navigate } = useNavigation();
   const { accountImage } = useAccountProfile();
 
@@ -86,7 +92,9 @@ export default function WalletProfileState({
 
   const indexOfForceColor = colors.avatarBackgrounds.indexOf(forceColor);
   const color =
-    profile.color !== null
+    isNewProfile && address
+      ? addressHashedColorIndex(address)
+      : profile.color !== null
       ? profile.color
       : isNewProfile
       ? null
@@ -137,10 +145,10 @@ export default function WalletProfileState({
         ) : (
           // hide avatar if creating new wallet since we
           // don't know what emoji / color it will be (determined by address)
-          !isNewProfile && (
+          (!isNewProfile || address) && (
             <AvatarCircle
-              accountColor={color}
-              accountSymbol={nameEmoji || addressHashedEmoji(address)}
+              showcaseAccountColor={color}
+              showcaseAccountSymbol={nameEmoji}
             />
           )
         )}

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -8,8 +8,9 @@ import { BiometricButtonContent } from '../buttons';
 import ImageAvatar from '../contacts/ImageAvatar';
 import CopyTooltip from '../copy-tooltip';
 import { Centered, ColumnWithDividers } from '../layout';
+import { AvatarCircle } from '../profile';
 import { Text, TruncatedAddress } from '../text';
-import { ProfileAvatarButton, ProfileModal, ProfileNameInput } from './profile';
+import { ProfileModal, ProfileNameInput } from './profile';
 import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
@@ -21,7 +22,6 @@ import Routes from '@rainbow-me/routes';
 import { margin, padding, position } from '@rainbow-me/styles';
 import { abbreviations } from '@rainbow-me/utils';
 import { addressHashedEmoji } from '@rainbow-me/utils/defaultProfileUtils';
-import { AvatarCircle } from '../profile';
 
 const WalletProfileAddressText = styled(TruncatedAddress).attrs(
   ({ theme: { colors } }) => ({

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -1,4 +1,3 @@
-import { isString } from 'lodash';
 import React, { useCallback, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
@@ -116,7 +115,7 @@ export default function WalletProfileState({
 
   const handleSubmit = useCallback(() => {
     onCloseModal({
-      color: isString(color) ? colorHexToIndex(color) : color,
+      color: typeof color === 'string' ? colorHexToIndex(color) : color,
       name: nameEmoji ? `${nameEmoji} ${value}` : value,
     });
     goBack();

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -88,6 +88,8 @@ export default function WalletProfileState({
   const color =
     profile.color !== null
       ? profile.color
+      : isNewProfile
+      ? null
       : (indexOfForceColor !== -1 && indexOfForceColor) || getRandomColor();
   const [value, setValue] = useState(
     profile?.name ? removeFirstEmojiFromString(profile.name).join('') : ''

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -21,6 +21,7 @@ import Routes from '@rainbow-me/routes';
 import { margin, padding, position } from '@rainbow-me/styles';
 import { abbreviations } from '@rainbow-me/utils';
 import { addressHashedEmoji } from '@rainbow-me/utils/defaultProfileUtils';
+import { AvatarCircle } from '../profile';
 
 const WalletProfileAddressText = styled(TruncatedAddress).attrs(
   ({ theme: { colors } }) => ({
@@ -137,16 +138,10 @@ export default function WalletProfileState({
           // hide avatar if creating new wallet since we
           // don't know what emoji / color it will be (determined by address)
           !isNewProfile && (
-            <>
-              <ProfileAvatarButton
-                color={color}
-                marginBottom={0}
-                radiusAndroid={32}
-                setColor={setColor}
-                value={nameEmoji || addressHashedEmoji(address)}
-              />
-              <Spacer />
-            </>
+            <AvatarCircle
+              accountColor={color}
+              accountSymbol={nameEmoji || addressHashedEmoji(address)}
+            />
           )
         )}
         {isNewProfile && <Spacer />}

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -158,7 +158,7 @@ export default function WalletProfileState({
             />
           )
         )}
-        {isNewProfile && <Spacer />}
+        {isNewProfile && !address && <Spacer />}
         <ProfileNameInput
           onChange={setValue}
           onSubmitEditing={handleSubmit}

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -85,12 +85,10 @@ export default function WalletProfileState({
   const { colors } = useTheme();
 
   const indexOfForceColor = colors.avatarBackgrounds.indexOf(forceColor);
-  const [color, setColor] = useState(
+  const color =
     profile.color !== null
       ? profile.color
-      : (indexOfForceColor !== -1 && indexOfForceColor) || getRandomColor()
-  );
-
+      : (indexOfForceColor !== -1 && indexOfForceColor) || getRandomColor();
   const [value, setValue] = useState(
     profile?.name ? removeFirstEmojiFromString(profile.name).join('') : ''
   );

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -20,6 +20,7 @@ import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { margin, padding, position } from '@rainbow-me/styles';
 import { abbreviations } from '@rainbow-me/utils';
+import { addressHashedEmoji } from '@rainbow-me/utils/defaultProfileUtils';
 
 const WalletProfileAddressText = styled(TruncatedAddress).attrs(
   ({ theme: { colors } }) => ({
@@ -82,11 +83,11 @@ export default function WalletProfileState({
 
   const { colors } = useTheme();
 
-  const indexOfForceColor = colors.avatarColor.indexOf(forceColor);
+  const indexOfForceColor = colors.avatarBackgrounds.indexOf(forceColor);
   const [color, setColor] = useState(
-    (profile.color !== null && profile.color) ||
-      (indexOfForceColor !== -1 && indexOfForceColor) ||
-      getRandomColor()
+    profile.color !== null
+      ? profile.color
+      : (indexOfForceColor !== -1 && indexOfForceColor) || getRandomColor()
   );
 
   const [value, setValue] = useState(
@@ -133,17 +134,22 @@ export default function WalletProfileState({
         {accountImage ? (
           <ProfileImage image={accountImage} size="large" />
         ) : (
-          <>
-            <ProfileAvatarButton
-              color={color}
-              marginBottom={0}
-              radiusAndroid={32}
-              setColor={setColor}
-              value={nameEmoji || value}
-            />
-            <Spacer />
-          </>
+          // hide avatar if creating new wallet since we
+          // don't know what emoji / color it will be (determined by address)
+          !isNewProfile && (
+            <>
+              <ProfileAvatarButton
+                color={color}
+                marginBottom={0}
+                radiusAndroid={32}
+                setColor={setColor}
+                value={nameEmoji || addressHashedEmoji(address)}
+              />
+              <Spacer />
+            </>
+          )
         )}
+        {isNewProfile && <Spacer />}
         <ProfileNameInput
           onChange={setValue}
           onSubmitEditing={handleSubmit}

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -20,12 +20,7 @@ import { useAccountProfile } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { margin, padding, position } from '@rainbow-me/styles';
-import { abbreviations } from '@rainbow-me/utils';
-import {
-  addressHashedColorIndex,
-  addressHashedEmoji,
-  colorHexToIndex,
-} from '@rainbow-me/utils/defaultProfileUtils';
+import { abbreviations, defaultProfileUtils } from '@rainbow-me/utils';
 const WalletProfileAddressText = styled(TruncatedAddress).attrs(
   ({ theme: { colors } }) => ({
     align: 'center',
@@ -83,8 +78,9 @@ export default function WalletProfileState({
 }) {
   const nameEmoji =
     isNewProfile && !forceColor
-      ? addressHashedEmoji(address)
-      : returnStringFirstEmoji(profile?.name) || addressHashedEmoji(address);
+      ? defaultProfileUtils.addressHashedEmoji(address)
+      : returnStringFirstEmoji(profile?.name) ||
+        defaultProfileUtils.addressHashedEmoji(address);
 
   const { goBack, navigate } = useNavigation();
   const { accountImage } = useAccountProfile();
@@ -95,7 +91,7 @@ export default function WalletProfileState({
   const color = forceColor
     ? forceColor
     : isNewProfile && address
-    ? addressHashedColorIndex(address)
+    ? defaultProfileUtils.addressHashedColorIndex(address)
     : profile.color !== null
     ? profile.color
     : isNewProfile
@@ -115,7 +111,10 @@ export default function WalletProfileState({
 
   const handleSubmit = useCallback(() => {
     onCloseModal({
-      color: typeof color === 'string' ? colorHexToIndex(color) : color,
+      color:
+        typeof color === 'string'
+          ? defaultProfileUtils.colorHexToIndex(color)
+          : color,
       name: nameEmoji ? `${nameEmoji} ${value}` : value,
     });
     goBack();

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -158,7 +158,7 @@ export default function WalletProfileState({
           onSubmitEditing={handleSubmit}
           placeholder="Name your wallet"
           ref={inputRef}
-          selectionColor={colors.avatarColor[color]}
+          selectionColor={colors.avatarBackgrounds[color]}
           testID="wallet-info-input"
           value={value}
         />

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -1,4 +1,3 @@
-import { isString } from 'lodash';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
@@ -46,7 +45,7 @@ export default function AvatarCircle({
   const accountSymbol = showcaseAccountSymbol || profileAccountSymbol;
   const resolvedColor =
     showcaseAccountColor != null
-      ? isString(showcaseAccountColor)
+      ? typeof showcaseAccountColor === 'string'
         ? showcaseAccountColor
         : colors.avatarBackgrounds[showcaseAccountColor]
       : colors.avatarBackgrounds[profileAccountColor || 0];

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -44,11 +44,12 @@ export default function AvatarCircle({
     accountSymbol: profileAccountSymbol,
   } = useAccountProfile();
   const accountSymbol = showcaseAccountSymbol || profileAccountSymbol;
-  const resolvedColor = showcaseAccountColor
-    ? isString(showcaseAccountColor)
-      ? showcaseAccountColor
-      : colors.avatarBackgrounds[showcaseAccountColor]
-    : colors.avatarBackgrounds[profileAccountColor || 0];
+  const resolvedColor =
+    showcaseAccountColor != null
+      ? isString(showcaseAccountColor)
+        ? showcaseAccountColor
+        : colors.avatarBackgrounds[showcaseAccountColor]
+      : colors.avatarBackgrounds[profileAccountColor || 0];
   const shadows = useMemo(
     () => ({
       default: [

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -44,7 +44,7 @@ export default function AvatarCircle({
   } = useAccountProfile();
   const accountSymbol = showcaseAccountSymbol || profileAccountSymbol;
   const resolvedColor =
-    showcaseAccountColor || colors.avatarColor[profileAccountColor || 0];
+    showcaseAccountColor || colors.avatarBackgrounds[profileAccountColor || 0];
   const shadows = useMemo(
     () => ({
       default: [

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -1,3 +1,4 @@
+import { isString } from 'lodash';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
@@ -44,7 +45,9 @@ export default function AvatarCircle({
   } = useAccountProfile();
   const accountSymbol = showcaseAccountSymbol || profileAccountSymbol;
   const resolvedColor = showcaseAccountColor
-    ? colors.avatarBackgrounds[showcaseAccountColor]
+    ? isString(showcaseAccountColor)
+      ? showcaseAccountColor
+      : colors.avatarBackgrounds[showcaseAccountColor]
     : colors.avatarBackgrounds[profileAccountColor || 0];
   const shadows = useMemo(
     () => ({

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -43,8 +43,9 @@ export default function AvatarCircle({
     accountSymbol: profileAccountSymbol,
   } = useAccountProfile();
   const accountSymbol = showcaseAccountSymbol || profileAccountSymbol;
-  const resolvedColor =
-    showcaseAccountColor || colors.avatarBackgrounds[profileAccountColor || 0];
+  const resolvedColor = showcaseAccountColor
+    ? colors.avatarBackgrounds[showcaseAccountColor]
+    : colors.avatarBackgrounds[profileAccountColor || 0];
   const shadows = useMemo(
     () => ({
       default: [

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -19,7 +19,12 @@ import {
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { padding } from '@rainbow-me/styles';
+import colors from '@rainbow-me/styles/colors';
 import { abbreviations } from '@rainbow-me/utils';
+import {
+  emojiColorIndexes,
+  popularEmojis,
+} from '@rainbow-me/utils/defaultProfileUtils';
 
 export const ShowcaseContext = createContext();
 
@@ -68,81 +73,7 @@ const ENSAddress = styled(Text).attrs(({ theme: { colors } }) => ({
   width: 100%;
 `;
 
-const popularEmojis = [
-  '🌶',
-  '🤑',
-  '🐙',
-  '🫐',
-  '🐳',
-  '🤶',
-  '🌲',
-  '🌞',
-  '🐒',
-  '🐵',
-  '🦊',
-  '🐼',
-  '🦄',
-  '🐷',
-  '🐧',
-  '🦩',
-  '👽',
-  '🎈',
-  '🍉',
-  '🎉',
-  '🐲',
-  '🌎',
-  '🍊',
-  '🐭',
-  '🍣',
-  '🐥',
-  '👾',
-  '🥦',
-  '👹',
-  '🙀',
-  '⛱',
-  '⛵️',
-  '🥳',
-  '🤯',
-  '🤠',
-];
-
-const avatarColor = [
-  '#FC5C54',
-  '#FFD95A',
-  '#E95D72',
-  '#6A87C8',
-  '#5FD0F3',
-  '#FC5C54',
-  '#75C06B',
-  '#FFDD86',
-  '#5FC6D4',
-  '#FF949A',
-  '#FF8024',
-  '#9BA1A4',
-  '#EC66FF',
-  '#FF8CBC',
-  '#FF9A23',
-  '#FF949A',
-  '#C5DADB',
-  '#FC5C54',
-  '#FF949A',
-  '#FFD95A',
-  '#A8CE63',
-  '#71ABFF',
-  '#FFE279',
-  '#B6B1B6',
-  '#FF6780',
-  '#FFD95A',
-  '#A575FF',
-  '#A8CE63',
-  '#FC5C54',
-  '#FFE279',
-  '#5FD0F3',
-  '#4D82FF',
-  '#FFE279',
-  '#FF949A',
-  '#FFB35A',
-];
+const avatarColor = emojiColorIndexes.map(idx => colors.avatarBackgrounds[idx]);
 
 function hashCode(text) {
   let hash = 0,

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -19,6 +19,7 @@ import {
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { padding } from '@rainbow-me/styles';
+import { abbreviations } from '@rainbow-me/utils';
 
 export const ShowcaseContext = createContext();
 
@@ -48,6 +49,7 @@ const ButtonSpacer = styled.View`
 const AddressText = styled(TruncatedAddress).attrs(({ theme: { colors } }) => ({
   align: 'center',
   color: colors.blueGreyDark,
+  firstSectionLength: abbreviations.defaultNumCharsPerSection,
   lineHeight: 'loosest',
   opacity: 0.6,
   size: 'large',

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -39,7 +39,7 @@ const HeaderWrapper = styled.View`
 const Footer = styled(ColumnWithMargins).attrs({
   margin: 19,
 })`
-  ${padding(19, 15, 21)};
+  ${padding(19, 0, 21)};
   width: 100%;
 `;
 

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -125,12 +125,12 @@ export function Header() {
       contact: currentContact || {
         address: contextValue?.address,
         color,
-        nickname: contextValue?.ensName,
+        nickname: contextValue?.data?.reverseEns,
         temporary: true,
       },
       type: 'contact_profile',
     });
-  }, [color, contextValue?.address, contextValue?.ensName, navigate]);
+  }, [color, contextValue?.address, contextValue?.data?.reverseEns, navigate]);
 
   const onSend = useCallback(async () => {
     goBack();
@@ -148,12 +148,17 @@ export function Header() {
 
   const onWatchAddress = useCallback(() => {
     handleSetSeedPhrase(contextValue.address);
-    handlePressImportButton(color, contextValue.address);
+    handlePressImportButton(
+      color,
+      contextValue.address,
+      contextValue?.data?.profile?.accountSymbol
+    );
   }, [
     color,
     contextValue.address,
     handlePressImportButton,
     handleSetSeedPhrase,
+    contextValue?.data?.profile?.accountSymbol,
   ]);
 
   const mainText =

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -18,13 +18,8 @@ import {
 } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
-import { padding } from '@rainbow-me/styles';
-import colors from '@rainbow-me/styles/colors';
-import { abbreviations } from '@rainbow-me/utils';
-import {
-  emojiColorIndexes,
-  popularEmojis,
-} from '@rainbow-me/utils/defaultProfileUtils';
+import { colors, padding } from '@rainbow-me/styles';
+import { abbreviations, defaultProfileUtils } from '@rainbow-me/utils';
 
 export const ShowcaseContext = createContext();
 
@@ -73,7 +68,9 @@ const ENSAddress = styled(Text).attrs(({ theme: { colors } }) => ({
   width: 100%;
 `;
 
-const avatarColor = emojiColorIndexes.map(idx => colors.avatarBackgrounds[idx]);
+const avatarColor = defaultProfileUtils.emojiColorIndexes.map(
+  idx => colors.avatarBackgrounds[idx]
+);
 
 function hashCode(text) {
   let hash = 0,
@@ -104,7 +101,7 @@ export function Header() {
     if (emojiFromContext) {
       return emojiFromContext;
     }
-    return popularEmojis[hash];
+    return defaultProfileUtils.popularEmojis[hash];
   }, [contextValue?.data?.profile?.accountSymbol, hash]);
 
   const color = useMemo(() => {

--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -274,7 +274,7 @@ export default function TransactionList({
     <Container>
       <Container
         accountAddress={accountName}
-        accountColor={colors.avatarColor[accountColor]}
+        accountColor={colors.avatarBackgrounds[accountColor]}
         accountImage={safeAccountImage}
         accountName={accountSymbol}
         addCashAvailable={addCashAvailable}

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -399,3 +399,17 @@ export const fromWei = (number: BigNumberish): string =>
 export const delay = (ms: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, ms));
 };
+
+/**
+ * @desc Array.prototype.some repurposed for async iteration
+ */
+export const asyncSome = async (
+  arr: any[],
+  callback: (element: any, index: number) => any
+) => {
+  if (!arr || !callback) return null;
+  for (let [index, element] of arr.entries()) {
+    if (await callback(element, index)) return true;
+  }
+  return false;
+};

--- a/src/hooks/useAccountProfile.js
+++ b/src/hooks/useAccountProfile.js
@@ -51,13 +51,14 @@ export function getAccountProfileInfo(
   }
   const { label, color, image } = selectedAccount;
 
-  const accountName = removeFirstEmojiFromString(
-    network === networkTypes.mainnet
-      ? label || accountENS || address(accountAddress, 4, 4)
-      : label === accountENS
-      ? address(accountAddress, 4, 4)
-      : label || address(accountAddress, 4, 4)
-  ).join('');
+  const accountName =
+    removeFirstEmojiFromString(
+      network === networkTypes.mainnet
+        ? label || accountENS || address(accountAddress, 4, 4)
+        : label === accountENS
+        ? address(accountAddress, 4, 4)
+        : label || address(accountAddress, 4, 4)
+    ).join('') || address(accountAddress, 4, 4);
 
   const emojiAvatar = returnStringFirstEmoji(label);
 

--- a/src/hooks/useAccountProfile.js
+++ b/src/hooks/useAccountProfile.js
@@ -1,8 +1,12 @@
 import GraphemeSplitter from 'grapheme-splitter';
-import { get, toUpper } from 'lodash';
-import { removeFirstEmojiFromString } from '../helpers/emojiHandler';
+import { get } from 'lodash';
+import {
+  removeFirstEmojiFromString,
+  returnStringFirstEmoji,
+} from '../helpers/emojiHandler';
 import networkTypes from '../helpers/networkTypes';
 import { address } from '../utils/abbreviations';
+import { addressHashedEmoji } from '../utils/defaultProfileUtils';
 import useAccountSettings from './useAccountSettings';
 import useWallets from './useWallets';
 
@@ -45,8 +49,7 @@ export function getAccountProfileInfo(
   if (!selectedAccount) {
     return {};
   }
-
-  const { label, color, index, image } = selectedAccount;
+  const { label, color, image } = selectedAccount;
 
   const accountName = removeFirstEmojiFromString(
     network === networkTypes.mainnet
@@ -56,14 +59,10 @@ export function getAccountProfileInfo(
       : label || address(accountAddress, 4, 4)
   ).join('');
 
-  const labelOrAccountName =
-    accountName === label ? toUpper(accountName) : label;
+  const emojiAvatar = returnStringFirstEmoji(label);
+
   const accountSymbol = new GraphemeSplitter().splitGraphemes(
-    network === networkTypes.mainnet
-      ? labelOrAccountName || toUpper(accountENS) || `${index + 1}`
-      : label === accountENS
-      ? toUpper(accountName)
-      : toUpper(label) || toUpper(accountName)
+    emojiAvatar || addressHashedEmoji(accountAddress)
   )[0];
   const accountColor = color;
   const accountImage = image;

--- a/src/hooks/useImportingWallet.js
+++ b/src/hooks/useImportingWallet.js
@@ -98,6 +98,12 @@ export default function useImportingWallet() {
 
   const handlePressImportButton = useCallback(
     async (forceColor, forceAddress, forceEmoji = null) => {
+      // guard against pressEvent coming in as forceColor if
+      // handlePressImportButton is used as onClick handler
+      let guardedForceColor =
+        typeof forceColor === 'string' || typeof forceColor === 'number'
+          ? forceColor
+          : null;
       if ((!isSecretValid || !seedPhrase) && !forceAddress) return null;
       const input = sanitizeSeedPhrase(seedPhrase || forceAddress);
       let name = null;
@@ -111,7 +117,7 @@ export default function useImportingWallet() {
           }
           setResolvedAddress(address);
           name = forceEmoji ? `${forceEmoji} ${input}` : input;
-          showWalletProfileModal(name, forceColor, address);
+          showWalletProfileModal(name, guardedForceColor, address);
         } catch (e) {
           Alert.alert(
             'Sorry, we cannot add this ENS name at this time. Please try again later!'
@@ -128,7 +134,7 @@ export default function useImportingWallet() {
           }
           setResolvedAddress(address);
           name = forceEmoji ? `${forceEmoji} ${input}` : input;
-          showWalletProfileModal(name, forceColor, address);
+          showWalletProfileModal(name, guardedForceColor, address);
         } catch (e) {
           Alert.alert(
             'Sorry, we cannot add this Unstoppable name at this time. Please try again later!'
@@ -140,7 +146,7 @@ export default function useImportingWallet() {
         if (ens && ens !== input) {
           name = forceEmoji ? `${forceEmoji} ${ens}` : ens;
         }
-        showWalletProfileModal(name, forceColor, input);
+        showWalletProfileModal(name, guardedForceColor, input);
       } else {
         try {
           setBusy(true);
@@ -154,7 +160,11 @@ export default function useImportingWallet() {
               name = forceEmoji ? `${forceEmoji} ${ens}` : ens;
             }
             setBusy(false);
-            showWalletProfileModal(name, forceColor, walletResult.address);
+            showWalletProfileModal(
+              name,
+              guardedForceColor,
+              walletResult.address
+            );
           }, 100);
         } catch (error) {
           logger.log('Error looking up ENS for imported HD type wallet', error);

--- a/src/hooks/useImportingWallet.js
+++ b/src/hooks/useImportingWallet.js
@@ -75,10 +75,11 @@ export default function useImportingWallet() {
   );
 
   const showWalletProfileModal = useCallback(
-    (name, forceColor) => {
+    (name, forceColor, address = null) => {
       navigate(Routes.MODAL_SCREEN, {
         actionType: 'Import',
         additionalPadding: true,
+        address,
         asset: [],
         forceColor,
         isNewProfile: true,
@@ -110,7 +111,7 @@ export default function useImportingWallet() {
           }
           setResolvedAddress(address);
           name = input;
-          showWalletProfileModal(name, forceColor);
+          showWalletProfileModal(name, forceColor, address);
         } catch (e) {
           Alert.alert(
             'Sorry, we cannot add this ENS name at this time. Please try again later!'
@@ -127,7 +128,7 @@ export default function useImportingWallet() {
           }
           setResolvedAddress(address);
           name = input;
-          showWalletProfileModal(name, forceColor);
+          showWalletProfileModal(name, forceColor, address);
         } catch (e) {
           Alert.alert(
             'Sorry, we cannot add this Unstoppable name at this time. Please try again later!'
@@ -139,7 +140,7 @@ export default function useImportingWallet() {
         if (ens && ens !== input) {
           name = ens;
         }
-        showWalletProfileModal(name, forceColor);
+        showWalletProfileModal(name, forceColor, input);
       } else {
         try {
           setBusy(true);
@@ -153,7 +154,7 @@ export default function useImportingWallet() {
               name = ens;
             }
             setBusy(false);
-            showWalletProfileModal(name, forceColor);
+            showWalletProfileModal(name, forceColor, walletResult.address);
           }, 100);
         } catch (error) {
           logger.log('Error looking up ENS for imported HD type wallet', error);

--- a/src/hooks/useImportingWallet.js
+++ b/src/hooks/useImportingWallet.js
@@ -97,7 +97,7 @@ export default function useImportingWallet() {
   );
 
   const handlePressImportButton = useCallback(
-    async (forceColor, forceAddress) => {
+    async (forceColor, forceAddress, forceEmoji = null) => {
       if ((!isSecretValid || !seedPhrase) && !forceAddress) return null;
       const input = sanitizeSeedPhrase(seedPhrase || forceAddress);
       let name = null;
@@ -110,7 +110,7 @@ export default function useImportingWallet() {
             return;
           }
           setResolvedAddress(address);
-          name = input;
+          name = forceEmoji ? `${forceEmoji} ${input}` : input;
           showWalletProfileModal(name, forceColor, address);
         } catch (e) {
           Alert.alert(
@@ -127,7 +127,7 @@ export default function useImportingWallet() {
             return;
           }
           setResolvedAddress(address);
-          name = input;
+          name = forceEmoji ? `${forceEmoji} ${input}` : input;
           showWalletProfileModal(name, forceColor, address);
         } catch (e) {
           Alert.alert(
@@ -138,7 +138,7 @@ export default function useImportingWallet() {
       } else if (isValidAddress(input)) {
         const ens = await web3Provider.lookupAddress(input);
         if (ens && ens !== input) {
-          name = ens;
+          name = forceEmoji ? `${forceEmoji} ${ens}` : ens;
         }
         showWalletProfileModal(name, forceColor, input);
       } else {
@@ -151,7 +151,7 @@ export default function useImportingWallet() {
             setCheckedWallet(walletResult);
             const ens = await web3Provider.lookupAddress(walletResult.address);
             if (ens && ens !== input) {
-              name = ens;
+              name = forceEmoji ? `${forceEmoji} ${ens}` : ens;
             }
             setBusy(false);
             showWalletProfileModal(name, forceColor, walletResult.address);

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -37,6 +37,7 @@ export default function useInitializeWallet() {
   const initializeWallet = useCallback(
     async (
       seedPhrase,
+      color = null,
       name = null,
       shouldRunMigrations = false,
       overwrite = false,
@@ -66,6 +67,7 @@ export default function useInitializeWallet() {
 
         const { isNew, walletAddress } = await walletInit(
           seedPhrase,
+          color,
           name,
           overwrite,
           checkedWallet,

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -37,7 +37,6 @@ export default function useInitializeWallet() {
   const initializeWallet = useCallback(
     async (
       seedPhrase,
-      color = null,
       name = null,
       shouldRunMigrations = false,
       overwrite = false,

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -67,7 +67,6 @@ export default function useInitializeWallet() {
 
         const { isNew, walletAddress } = await walletInit(
           seedPhrase,
-          color,
           name,
           overwrite,
           checkedWallet,

--- a/src/hooks/useWebData.js
+++ b/src/hooks/useWebData.js
@@ -56,14 +56,20 @@ export default function useWebData() {
         'profile',
         accountAddress,
         {
-          accountColor: colors.avatarColor[accountColor],
+          accountColor: colors.avatarBackgrounds[accountColor],
           accountSymbol: wipeNotEmoji(accountSymbol),
         }
       );
 
       dispatch(updateWebDataEnabled(true, accountAddress));
     },
-    [accountAddress, accountColor, accountSymbol, colors.avatarColor, dispatch]
+    [
+      accountAddress,
+      accountColor,
+      accountSymbol,
+      colors.avatarBackgrounds,
+      dispatch,
+    ]
   );
 
   const wipeWebData = useCallback(async () => {

--- a/src/model/migrations.js
+++ b/src/model/migrations.js
@@ -304,7 +304,7 @@ export default async function runMigrations() {
       const wallet = wallets[walletKeys[i]];
       const newAddresses = wallet.addresses.map(address => ({
         ...address,
-        color: newColorIndexes[address.color],
+        color: newColorIndexes[address.color] || 0,
       }));
       const newWallet = { ...wallet, addresses: newAddresses };
       updatedWallets[walletKeys[i]] = newWallet;

--- a/src/model/migrations.js
+++ b/src/model/migrations.js
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/react-native';
 import { findKey, isNumber, keys } from 'lodash';
 import { removeLocal } from '../handlers/localstorage/common';
 import { IMAGE_METADATA } from '../handlers/localstorage/globalSettings';
@@ -296,49 +297,55 @@ export default async function runMigrations() {
     logger.log('Start migration v9');
     // map from old color index to closest new color's index
     const newColorIndexes = [0, 4, 12, 21, 1, 20, 4, 9, 10];
-    const { selected, wallets } = store.getState().wallets;
-    if (!wallets) return;
-    const walletKeys = Object.keys(wallets);
-    let updatedWallets = { ...wallets };
-    for (let i = 0; i < walletKeys.length; i++) {
-      const wallet = wallets[walletKeys[i]];
-      const newAddresses = wallet.addresses.map(address => ({
-        ...address,
-        color: newColorIndexes[address.color] || 0,
-      }));
-      const newWallet = { ...wallet, addresses: newAddresses };
-      updatedWallets[walletKeys[i]] = newWallet;
-    }
-    logger.log('update wallets in store to index new colors');
-    await store.dispatch(walletsUpdate(updatedWallets));
+    try {
+      const { selected, wallets } = store.getState().wallets;
+      if (!wallets) return;
+      const walletKeys = Object.keys(wallets);
+      let updatedWallets = { ...wallets };
+      for (let i = 0; i < walletKeys.length; i++) {
+        const wallet = wallets[walletKeys[i]];
+        const newAddresses = wallet.addresses.map(address => ({
+          ...address,
+          color: newColorIndexes[address.color] || 0,
+        }));
+        const newWallet = { ...wallet, addresses: newAddresses };
+        updatedWallets[walletKeys[i]] = newWallet;
+      }
+      logger.log('update wallets in store to index new colors');
+      await store.dispatch(walletsUpdate(updatedWallets));
 
-    const selectedWalletId = selected?.id;
-    if (selectedWalletId) {
-      logger.log('update selected wallet to index new color');
-      await store.dispatch(
-        walletsSetSelected(updatedWallets[selectedWalletId])
-      );
-    }
+      const selectedWalletId = selected?.id;
+      if (selectedWalletId) {
+        logger.log('update selected wallet to index new color');
+        await store.dispatch(
+          walletsSetSelected(updatedWallets[selectedWalletId])
+        );
+      }
 
-    // migrate contacts to new color index
-    const contacts = await getContacts();
-    let updatedContacts = { ...contacts };
-    if (!contacts) return;
-    const contactKeys = Object.keys(contacts);
-    for (let j = 0; j < contactKeys.length; j++) {
-      const contact = contacts[contactKeys[j]];
-      updatedContacts[contactKeys[j]] = {
-        ...contact,
-        color: isNumber(contact.color)
-          ? newColorIndexes[contact.color]
-          : typeof contact.color === 'string' &&
-            colors.avatarBackgrounds.includes(contact.color)
-          ? colors.avatarBackgrounds.indexOf(contact.color)
-          : getRandomColor(),
-      };
+      // migrate contacts to new color index
+      const contacts = await getContacts();
+      let updatedContacts = { ...contacts };
+      if (!contacts) return;
+      const contactKeys = Object.keys(contacts);
+      for (let j = 0; j < contactKeys.length; j++) {
+        const contact = contacts[contactKeys[j]];
+        updatedContacts[contactKeys[j]] = {
+          ...contact,
+          color: isNumber(contact.color)
+            ? newColorIndexes[contact.color]
+            : typeof contact.color === 'string' &&
+              colors.avatarBackgrounds.includes(contact.color)
+            ? colors.avatarBackgrounds.indexOf(contact.color)
+            : getRandomColor(),
+        };
+      }
+      logger.log('update contacts to index new colors');
+      await saveContacts(updatedContacts);
+    } catch (error) {
+      logger.sentry('Migration v9 failed: ', error);
+      const migrationError = new Error('Migration 9 failed');
+      captureException(migrationError);
     }
-    logger.log('update contacts to index new colors');
-    await saveContacts(updatedContacts);
   };
 
   migrations.push(v9);

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -641,7 +641,7 @@ export const createWallet = async (
     logger.sentry('[createWallet] - saved private key');
 
     const colorIndexForWallet =
-      color !== null ? color : addressHashedColorIndex(walletAddress);
+      color !== null ? color : addressHashedColorIndex(walletAddress) || 0;
     addresses.push({
       address: walletAddress,
       avatar: null,
@@ -707,7 +707,8 @@ export const createWallet = async (
 
         // Remove any discovered wallets if they already exist
         // and copy over label and color if account was visible
-        let colorIndexForWallet = addressHashedColorIndex(nextWallet.address);
+        let colorIndexForWallet =
+          addressHashedColorIndex(nextWallet.address) || 0;
         let label = '';
 
         if (discoveredAccount && discoveredWalletId) {

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -189,6 +189,7 @@ export const publicAccessControlOptions = {
 
 export const walletInit = async (
   seedPhrase = null,
+  color = null,
   name = null,
   overwrite = false,
   checkedWallet = null,
@@ -200,6 +201,7 @@ export const walletInit = async (
   if (!isEmpty(seedPhrase)) {
     const wallet = await createWallet(
       seedPhrase,
+      color,
       name,
       overwrite,
       checkedWallet
@@ -490,6 +492,7 @@ export const identifyWalletType = (
 
 export const createWallet = async (
   seed: null | EthereumSeed = null,
+  color: null | number = null,
   name: null | string = null,
   overwrite: boolean = false,
   checkedWallet: null | EthereumWalletFromSeed = null
@@ -637,7 +640,8 @@ export const createWallet = async (
     }
     logger.sentry('[createWallet] - saved private key');
 
-    const colorIndexForWallet = addressHashedColorIndex(walletAddress);
+    const colorIndexForWallet =
+      color !== null ? color : addressHashedColorIndex(walletAddress);
     addresses.push({
       address: walletAddress,
       avatar: null,
@@ -799,7 +803,7 @@ export const createWallet = async (
     allWallets[id] = {
       addresses,
       backedUp: false,
-      color: 0,
+      color: color || 0,
       id,
       imported: isImported,
       name: walletName,

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -22,7 +22,7 @@ import { find, findKey, forEach, get, isEmpty } from 'lodash';
 import { Alert } from 'react-native';
 import { ACCESSIBLE, getSupportedBiometryType } from 'react-native-keychain';
 import { lightModeThemeColors } from '../styles/colors';
-import { addressHashedIndex } from '../utils/defaultProfileUtils';
+import { addressHashedColorIndex } from '../utils/defaultProfileUtils';
 import {
   addressKey,
   allWalletsKey,
@@ -637,7 +637,7 @@ export const createWallet = async (
     }
     logger.sentry('[createWallet] - saved private key');
 
-    const colorIndexForWallet = addressHashedIndex(walletAddress);
+    const colorIndexForWallet = addressHashedColorIndex(walletAddress);
     addresses.push({
       address: walletAddress,
       avatar: null,
@@ -703,7 +703,7 @@ export const createWallet = async (
 
         // Remove any discovered wallets if they already exist
         // and copy over label and color if account was visible
-        let colorIndexForWallet = addressHashedIndex(nextWallet.address);
+        let colorIndexForWallet = addressHashedColorIndex(nextWallet.address);
         let label = '';
 
         if (discoveredAccount && discoveredWalletId) {

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -24,6 +24,7 @@ import {
 } from '../model/wallet';
 import { settingsUpdateAccountAddress } from '../redux/settings';
 import { logger } from '../utils';
+import { addressHashedIndex } from '../utils/defaultProfileUtils';
 import {
   addressKey,
   privateKeyKey,
@@ -176,7 +177,7 @@ export const setWalletBackedUp = (
 
 export const addressSetSelected = address => () => saveAddress(address);
 
-export const createAccountForWallet = (id, color, name) => async (
+export const createAccountForWallet = (id, name) => async (
   dispatch,
   getState
 ) => {
@@ -188,17 +189,18 @@ export const createAccountForWallet = (id, color, name) => async (
   );
   const newIndex = index + 1;
   const account = await generateAccount(id, newIndex);
+  const walletColorIndex = addressHashedIndex(account.address);
   newWallets[id].addresses.push({
     address: account.address,
     avatar: null,
-    color,
+    color: walletColorIndex,
     index: newIndex,
     label: name,
     visible: true,
   });
 
   setPreference(PreferenceActionType.init, 'profile', account.address, {
-    accountColor: lightModeThemeColors.avatarColor[color],
+    accountColor: lightModeThemeColors.avatarBackgrounds[walletColorIndex],
   });
 
   await dispatch(updateWebDataEnabled(true, account.address));

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -24,7 +24,7 @@ import {
 } from '../model/wallet';
 import { settingsUpdateAccountAddress } from '../redux/settings';
 import { logger } from '../utils';
-import { addressHashedIndex } from '../utils/defaultProfileUtils';
+import { addressHashedColorIndex } from '../utils/defaultProfileUtils';
 import {
   addressKey,
   privateKeyKey,
@@ -189,7 +189,7 @@ export const createAccountForWallet = (id, name) => async (
   );
   const newIndex = index + 1;
   const account = await generateAccount(id, newIndex);
-  const walletColorIndex = addressHashedIndex(account.address);
+  const walletColorIndex = addressHashedColorIndex(account.address);
   newWallets[id].addresses.push({
     address: account.address,
     avatar: null,

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -177,7 +177,7 @@ export const setWalletBackedUp = (
 
 export const addressSetSelected = address => () => saveAddress(address);
 
-export const createAccountForWallet = (id, name) => async (
+export const createAccountForWallet = (id, color, name) => async (
   dispatch,
   getState
 ) => {
@@ -189,7 +189,8 @@ export const createAccountForWallet = (id, name) => async (
   );
   const newIndex = index + 1;
   const account = await generateAccount(id, newIndex);
-  const walletColorIndex = addressHashedColorIndex(account.address);
+  const walletColorIndex =
+    color !== null ? color : addressHashedColorIndex(account.address);
   newWallets[id].addresses.push({
     address: account.address,
     avatar: null,

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -120,12 +120,21 @@ const AvatarBuilder = ({ route: { params } }) => {
   const colorCircleTopPadding = 15;
   const colorCircleBottomPadding = 19;
 
-  const selectedOffset = useMemo(
-    () => ({
-      x: params.initialAccountColor * 39 - width / 2 + width ** 0.5 * 1.5, // curve to have selected color in middle of scrolling colorpicker
-    }),
-    [params.initialAccountColor, width]
-  );
+  const selectedOffset = useMemo(() => {
+    const maxOffset = colors.avatarBackgrounds.length * 39 - width + 20;
+    const rawOffset =
+      params.initialAccountColor * 39 - width / 2 + width ** 0.5 * 1.5;
+    let finalOffset = rawOffset;
+    if (rawOffset < 0) {
+      finalOffset = 0;
+    }
+    if (rawOffset > maxOffset) {
+      finalOffset = maxOffset;
+    }
+    return {
+      x: finalOffset, // curve to have selected color in middle of scrolling colorpicker
+    };
+  }, [params.initialAccountColor, width, colors.avatarBackgrounds.length]);
 
   return (
     <Container {...deviceUtils.dimensions}>

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -72,7 +72,7 @@ const AvatarBuilder = ({ route: { params } }) => {
         const destination = index * 39;
         springTo(translateX, destination);
         setCurrentAccountColor(color);
-        saveInfo(null, index);
+        saveInfo(null, colors.avatarBackgrounds.indexOf(color));
       }}
     />
   ));

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -125,6 +125,9 @@ const AvatarBuilder = ({ route: { params } }) => {
           width="100%"
         >
           <ScrollableColorPicker
+            contentOffset={{
+              x: params.initialAccountColor * 39,
+            }}
             horizontal
             showsHorizontalScrollIndicator={false}
           >

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { ScrollView } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useValues } from 'react-native-redash';
 import { useDispatch } from 'react-redux';
@@ -32,7 +31,7 @@ const SheetContainer = styled(Column)`
   width: 100%;
 `;
 
-const ScrollableColorPicker = styled(ScrollView)`
+const ScrollableColorPicker = styled.ScrollView`
   overflow: visible;
 `;
 

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -11,7 +11,7 @@ import { Column, Row } from '../components/layout';
 import { useNavigation } from '../navigation/Navigation';
 import { walletsSetSelected, walletsUpdate } from '../redux/wallets';
 import { deviceUtils } from '../utils';
-import { useWallets, useWebData } from '@rainbow-me/hooks';
+import { useDimensions, useWallets, useWebData } from '@rainbow-me/hooks';
 import useAccountSettings from '@rainbow-me/hooks/useAccountSettings';
 
 const AvatarCircleHeight = 65;
@@ -33,6 +33,7 @@ const SheetContainer = styled(Column)`
 
 const ScrollableColorPicker = styled.ScrollView`
   overflow: visible;
+  margin: 0px 10px;
 `;
 
 const SelectedColorRing = styled(Animated.View)`
@@ -58,6 +59,7 @@ const springTo = (node, toValue) =>
   }).start();
 
 const AvatarBuilder = ({ route: { params } }) => {
+  const { width } = useDimensions();
   const { wallets, selectedWallet } = useWallets();
   const { updateWebProfile } = useWebData();
   const [translateX] = useValues(params.initialAccountColor * 39);
@@ -136,7 +138,10 @@ const AvatarBuilder = ({ route: { params } }) => {
         >
           <ScrollableColorPicker
             contentOffset={{
-              x: params.initialAccountColor * 39,
+              x:
+                params.initialAccountColor * 39 -
+                width / 2 +
+                (width * 0.0063) ** 4, // curve to have selected color in middle of scrolling colorpicker
             }}
             horizontal
             showsHorizontalScrollIndicator={false}

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -100,7 +100,8 @@ const AvatarBuilder = ({ route: { params } }) => {
     updateWebProfile(
       accountAddress,
       name,
-      (color !== undefined && colors.avatarColor[color]) || currentAccountColor
+      (color !== undefined && colors.avatarBackgrounds[color]) ||
+        currentAccountColor
     );
   };
 

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -120,6 +120,13 @@ const AvatarBuilder = ({ route: { params } }) => {
   const colorCircleTopPadding = 15;
   const colorCircleBottomPadding = 19;
 
+  const selectedOffset = useMemo(
+    () => ({
+      x: params.initialAccountColor * 39 - width / 2 + width ** 0.5 * 1.5, // curve to have selected color in middle of scrolling colorpicker
+    }),
+    [params.initialAccountColor, width]
+  );
+
   return (
     <Container {...deviceUtils.dimensions}>
       <TouchableBackdrop onPress={goBack} />
@@ -131,18 +138,12 @@ const AvatarBuilder = ({ route: { params } }) => {
         <Row
           height={38 + colorCircleTopPadding + colorCircleBottomPadding}
           justify="center"
-          maxWidth={375}
           paddingBottom={colorCircleBottomPadding + 7}
           paddingTop={colorCircleTopPadding + 7}
           width="100%"
         >
           <ScrollableColorPicker
-            contentOffset={{
-              x:
-                params.initialAccountColor * 39 -
-                width / 2 +
-                (width * 0.0063) ** 4, // curve to have selected color in middle of scrolling colorpicker
-            }}
+            contentOffset={selectedOffset}
             horizontal
             showsHorizontalScrollIndicator={false}
           >

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -35,6 +35,17 @@ const ScrollableColorPicker = styled.ScrollView`
   overflow: visible;
 `;
 
+const SelectedColorRing = styled(Animated.View)`
+  height: 38;
+  width: 38;
+  border-radius: 19;
+  border-width: 3;
+  position: absolute;
+  align-self: center;
+  left: 0.75;
+  border-color: ${({ selectedColor }) => selectedColor};
+`;
+
 const springTo = (node, toValue) =>
   Animated.spring(node, {
     damping: 38,
@@ -130,18 +141,11 @@ const AvatarBuilder = ({ route: { params } }) => {
             horizontal
             showsHorizontalScrollIndicator={false}
           >
-            <Animated.View
-              alignSelf="center"
-              borderColor={currentAccountColor}
-              borderRadius={19}
-              borderWidth={3}
-              height={38}
-              left={0.75}
-              position="absolute"
+            <SelectedColorRing
+              selectedColor={currentAccountColor}
               style={{
                 transform: [{ translateX }],
               }}
-              width={38}
             />
             {avatarColors}
           </ScrollableColorPicker>

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ScrollView } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useValues } from 'react-native-redash';
 import { useDispatch } from 'react-redux';
@@ -31,6 +32,10 @@ const SheetContainer = styled(Column)`
   width: 100%;
 `;
 
+const ScrollableColorPicker = styled(ScrollView)`
+  overflow: visible;
+`;
+
 const springTo = (node, toValue) =>
   Animated.spring(node, {
     damping: 38,
@@ -45,12 +50,12 @@ const springTo = (node, toValue) =>
 const AvatarBuilder = ({ route: { params } }) => {
   const { wallets, selectedWallet } = useWallets();
   const { updateWebProfile } = useWebData();
-  const [translateX] = useValues((params.initialAccountColor - 4) * 39);
+  const [translateX] = useValues(params.initialAccountColor * 39);
   const { goBack } = useNavigation();
   const { accountAddress } = useAccountSettings();
   const { colors } = useTheme();
   const [currentAccountColor, setCurrentAccountColor] = useState(
-    colors.avatarColor[params.initialAccountColor]
+    colors.avatarBackgrounds[params.initialAccountColor]
   );
   const dispatch = useDispatch();
 
@@ -58,13 +63,13 @@ const AvatarBuilder = ({ route: { params } }) => {
     saveInfo(`${event} ${params.initialAccountName}`);
   };
 
-  const avatarColors = colors.avatarColor.map((color, index) => (
+  const avatarColors = colors.avatarBackgrounds.map((color, index) => (
     <ColorCircle
       backgroundColor={color}
       isSelected={index - 4 === 0}
       key={color}
       onPressColor={() => {
-        const destination = (index - 4) * 39;
+        const destination = index * 39;
         springTo(translateX, destination);
         setCurrentAccountColor(color);
         saveInfo(null, index);
@@ -118,22 +123,26 @@ const AvatarBuilder = ({ route: { params } }) => {
           paddingTop={colorCircleTopPadding + 7}
           width="100%"
         >
-          <Animated.View
-            alignSelf="center"
-            borderColor={currentAccountColor}
-            borderRadius={19}
-            borderWidth={3}
-            height={38}
-            position="absolute"
-            style={{
-              transform: [{ translateX }],
-            }}
-            top={colorCircleTopPadding}
-            width={38}
-          />
-          {avatarColors}
+          <ScrollableColorPicker
+            horizontal
+            showsHorizontalScrollIndicator={false}
+          >
+            <Animated.View
+              alignSelf="center"
+              borderColor={currentAccountColor}
+              borderRadius={19}
+              borderWidth={3}
+              height={38}
+              left={0.75}
+              position="absolute"
+              style={{
+                transform: [{ translateX }],
+              }}
+              width={38}
+            />
+            {avatarColors}
+          </ScrollableColorPicker>
         </Row>
-
         <SheetContainer>
           <EmojiSelector
             columns={7}

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -31,6 +31,7 @@ import {
   walletsSetSelected,
   walletsUpdate,
 } from '../redux/wallets';
+import { asyncSome } from '@rainbow-me/helpers/utilities';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
   useAccountSettings,
@@ -219,7 +220,8 @@ export default function ChangeWalletSheet() {
               if (args) {
                 const newWallets = { ...wallets };
                 if ('name' in args) {
-                  newWallets[walletId].addresses.some(
+                  asyncSome(
+                    newWallets[walletId].addresses,
                     async (account, index) => {
                       if (account.address === address) {
                         newWallets[walletId].addresses[index].label = args.name;

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -234,7 +234,7 @@ export default function ChangeWalletSheet() {
                         updateWebProfile(
                           address,
                           args.name,
-                          colors.avatarColor[args.color]
+                          colors.avatarBackgrounds[args.color]
                         );
                         return true;
                       }
@@ -261,7 +261,7 @@ export default function ChangeWalletSheet() {
       dispatch,
       currentSelectedWallet.id,
       updateWebProfile,
-      colors.avatarColor,
+      colors.avatarBackgrounds,
     ]
   );
 

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -371,6 +371,7 @@ export default function ChangeWalletSheet() {
               if (args) {
                 setIsWalletLoading(WalletLoadingStates.CREATING_WALLET);
                 const name = get(args, 'name', '');
+                const color = get(args, 'color', null);
                 // Check if the selected wallet is the primary
                 let primaryWalletKey = selectedWallet.primary
                   ? selectedWallet.id
@@ -409,7 +410,7 @@ export default function ChangeWalletSheet() {
                   // If we found it and it's not damaged use it to create the new account
                   if (primaryWalletKey && !wallets[primaryWalletKey].damaged) {
                     const newWallets = await dispatch(
-                      createAccountForWallet(primaryWalletKey, name)
+                      createAccountForWallet(primaryWalletKey, color, name)
                     );
                     await initializeWallet();
                     // If this wallet was previously backed up to the cloud
@@ -432,7 +433,7 @@ export default function ChangeWalletSheet() {
 
                     // If doesn't exist, we need to create a new wallet
                   } else {
-                    await createWallet(null, name);
+                    await createWallet(null, color, name);
                     await dispatch(walletsLoadState());
                     await initializeWallet();
                   }

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -31,7 +31,6 @@ import {
   walletsSetSelected,
   walletsUpdate,
 } from '../redux/wallets';
-import { getRandomColor } from '../styles/colors';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
   useAccountSettings,
@@ -372,7 +371,6 @@ export default function ChangeWalletSheet() {
               if (args) {
                 setIsWalletLoading(WalletLoadingStates.CREATING_WALLET);
                 const name = get(args, 'name', '');
-                const color = get(args, 'color', getRandomColor());
                 // Check if the selected wallet is the primary
                 let primaryWalletKey = selectedWallet.primary
                   ? selectedWallet.id
@@ -411,7 +409,7 @@ export default function ChangeWalletSheet() {
                   // If we found it and it's not damaged use it to create the new account
                   if (primaryWalletKey && !wallets[primaryWalletKey].damaged) {
                     const newWallets = await dispatch(
-                      createAccountForWallet(primaryWalletKey, color, name)
+                      createAccountForWallet(primaryWalletKey, name)
                     );
                     await initializeWallet();
                     // If this wallet was previously backed up to the cloud
@@ -434,7 +432,7 @@ export default function ChangeWalletSheet() {
 
                     // If doesn't exist, we need to create a new wallet
                   } else {
-                    await createWallet(null, color, name);
+                    await createWallet(null, name);
                     await dispatch(walletsLoadState());
                     await initializeWallet();
                   }

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -166,7 +166,7 @@ export default function ImportSeedPhraseSheet() {
             color={isSecretValid ? colors.appleBlue : colors.dark}
             onChangeText={handleSetSeedPhrase}
             onFocus={handleFocus}
-            onSubmitEditing={() => handlePressImportButton()}
+            onSubmitEditing={handlePressImportButton}
             placeholder="Secret phrase, private key, Ethereum address or ENS name"
             placeholderTextColor={colors.alpha(colors.blueGreyDark, 0.3)}
             ref={inputRef}
@@ -183,7 +183,7 @@ export default function ImportSeedPhraseSheet() {
               disabled={!isSecretValid}
               hasLeadingIcon
               {...(android && { height: 30, overflowMargin: 15, width: 89 })}
-              onPress={() => handlePressImportButton()}
+              onPress={handlePressImportButton}
             >
               <Row>
                 {busy ? (

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -166,7 +166,7 @@ export default function ImportSeedPhraseSheet() {
             color={isSecretValid ? colors.appleBlue : colors.dark}
             onChangeText={handleSetSeedPhrase}
             onFocus={handleFocus}
-            onSubmitEditing={handlePressImportButton}
+            onSubmitEditing={() => handlePressImportButton()}
             placeholder="Secret phrase, private key, Ethereum address or ENS name"
             placeholderTextColor={colors.alpha(colors.blueGreyDark, 0.3)}
             ref={inputRef}
@@ -183,7 +183,7 @@ export default function ImportSeedPhraseSheet() {
               disabled={!isSecretValid}
               hasLeadingIcon
               {...(android && { height: 30, overflowMargin: 15, width: 89 })}
-              onPress={handlePressImportButton}
+              onPress={() => handlePressImportButton()}
             >
               <Row>
                 {busy ? (

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -44,13 +44,12 @@ const darkModeColors = {
 const isHex = (color = '') => color.length >= 3 && color.charAt(0) === '#';
 const isRGB = (color = '') => toLower(color).substring(0, 3) === 'rgb';
 
-export const avatarBackgrounds = [
+const avatarBackgrounds = [
   '#FC5C54',
   '#FFD95A',
   '#E95D72',
   '#6A87C8',
   '#5FD0F3',
-  '#FC5C54',
   '#75C06B',
   '#FFDD86',
   '#5FC6D4',
@@ -60,25 +59,14 @@ export const avatarBackgrounds = [
   '#EC66FF',
   '#FF8CBC',
   '#FF9A23',
-  '#FF949A',
   '#C5DADB',
-  '#FC5C54',
-  '#FF949A',
-  '#FFD95A',
   '#A8CE63',
   '#71ABFF',
   '#FFE279',
   '#B6B1B6',
   '#FF6780',
-  '#FFD95A',
   '#A575FF',
-  '#A8CE63',
-  '#FC5C54',
-  '#FFE279',
-  '#5FD0F3',
   '#4D82FF',
-  '#FFE279',
-  '#FF949A',
   '#FFB35A',
 ];
 

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -43,6 +43,45 @@ const darkModeColors = {
 
 const isHex = (color = '') => color.length >= 3 && color.charAt(0) === '#';
 const isRGB = (color = '') => toLower(color).substring(0, 3) === 'rgb';
+
+export const avatarBackgrounds = [
+  '#FC5C54',
+  '#FFD95A',
+  '#E95D72',
+  '#6A87C8',
+  '#5FD0F3',
+  '#FC5C54',
+  '#75C06B',
+  '#FFDD86',
+  '#5FC6D4',
+  '#FF949A',
+  '#FF8024',
+  '#9BA1A4',
+  '#EC66FF',
+  '#FF8CBC',
+  '#FF9A23',
+  '#FF949A',
+  '#C5DADB',
+  '#FC5C54',
+  '#FF949A',
+  '#FFD95A',
+  '#A8CE63',
+  '#71ABFF',
+  '#FFE279',
+  '#B6B1B6',
+  '#FF6780',
+  '#FFD95A',
+  '#A575FF',
+  '#A8CE63',
+  '#FC5C54',
+  '#FFE279',
+  '#5FD0F3',
+  '#4D82FF',
+  '#FFE279',
+  '#FF949A',
+  '#FFB35A',
+];
+
 const getColorsByTheme = darkMode => {
   let base = {
     appleBlue: '#0E76FD', // '14, 118, 253'
@@ -222,6 +261,7 @@ const getColorsByTheme = darkMode => {
   return {
     alpha: buildRgba,
     assetIcon,
+    avatarBackgrounds,
     avatarColor,
     brighten,
     getFallbackTextColor,

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -2,6 +2,7 @@ export { default as borders } from './borders';
 export { default as buildFlexStyles } from './buildFlexStyles';
 export { default as buildTextStyles, fontWithWidth } from './buildTextStyles';
 export { default as calcDirectionToDegrees } from './calcDirectionToDegrees';
+export { default as colors } from './colors';
 export { lightModeThemeColors } from './colors';
 export { default as fonts } from './fonts';
 export { getFontSize } from './fonts';

--- a/src/utils/abbreviations.js
+++ b/src/utils/abbreviations.js
@@ -2,9 +2,8 @@ import {
   isENSAddressFormat,
   isUnstoppableAddressFormat,
 } from '../helpers/validators';
-import deviceUtils from './deviceUtils';
 
-const defaultNumCharsPerSection = deviceUtils.isNarrowPhone ? 8 : 10;
+const defaultNumCharsPerSection = 6;
 
 export function address(
   currentAddress,

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -58,12 +58,12 @@ export function hashCode(text: string) {
 }
 
 export function addressHashedIndex(address: string) {
-  if (address === null || address === undefined) return null;
+  if (address == null) return null;
   return Math.abs(hashCode(address.toLowerCase()) % emojiCount);
 }
 
 export function addressHashedColorIndex(address: string) {
-  if (address === null || address === undefined) return null;
+  if (address == null) return null;
   return emojiColorIndexes[
     Math.abs(hashCode(address.toLowerCase()) % emojiCount)
   ];
@@ -71,7 +71,7 @@ export function addressHashedColorIndex(address: string) {
 
 export function addressHashedEmoji(address: string) {
   const index = addressHashedIndex(address);
-  if (index === null || index === undefined) return null;
+  if (index == null) return null;
   return popularEmojis[index];
 }
 

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -1,40 +1,48 @@
-export const popularEmojis = [
-  '🌶',
-  '🤑',
-  '🐙',
-  '🫐',
-  '🐳',
-  '🤶',
-  '🌲',
-  '🌞',
-  '🐒',
-  '🐵',
-  '🦊',
-  '🐼',
-  '🦄',
-  '🐷',
-  '🐧',
-  '🦩',
-  '👽',
-  '🎈',
-  '🍉',
-  '🎉',
-  '🐲',
-  '🌎',
-  '🍊',
-  '🐭',
-  '🍣',
-  '🐥',
-  '👾',
-  '🥦',
-  '👹',
-  '🙀',
-  '⛱',
-  '⛵️',
-  '🥳',
-  '🤯',
-  '🤠',
-];
+/* eslint-disable sort-keys */
+
+// popularEmojisToColorIndex matches emojis to the index of their
+// color backgrounds in the `avatarBackgrounds` object in colors.js
+export const popularEmojisToColorIndex = {
+  '🌶': 0,
+  '🤑': 1,
+  '🐙': 2,
+  '🫐': 3,
+  '🐳': 4,
+  '🤶': 0,
+  '🌲': 5,
+  '🌞': 6,
+  '🐒': 7,
+  '🐵': 8,
+  '🦊': 9,
+  '🐼': 10,
+  '🦄': 11,
+  '🐷': 12,
+  '🐧': 13,
+  '🦩': 8,
+  '👽': 14,
+  '🎈': 0,
+  '🍉': 8,
+  '🎉': 1,
+  '🐲': 15,
+  '🌎': 16,
+  '🍊': 17,
+  '🐭': 18,
+  '🍣': 19,
+  '🐥': 1,
+  '👾': 20,
+  '🥦': 15,
+  '👹': 0,
+  '🙀': 17,
+  '⛱': 4,
+  '⛵️': 21,
+  '🥳': 17,
+  '🤯': 8,
+  '🤠': 22,
+};
+
+export const popularEmojis = Object.keys(popularEmojisToColorIndex);
+export const emojiColorIndexes = Object.values(popularEmojisToColorIndex);
+const emojiCount = Object.keys(popularEmojis).length;
 
 export function hashCode(text: string) {
   let hash = 0,
@@ -50,7 +58,13 @@ export function hashCode(text: string) {
 }
 
 export function addressHashedIndex(address: string) {
-  return Math.abs(hashCode(address.toLowerCase()) % 35);
+  return Math.abs(hashCode(address.toLowerCase()) % emojiCount);
+}
+
+export function addressHashedColorIndex(address: string) {
+  return emojiColorIndexes[
+    Math.abs(hashCode(address.toLowerCase()) % emojiCount)
+  ];
 }
 
 export function addressHashedEmoji(address: string) {
@@ -61,8 +75,3 @@ export function addressHashedEmoji(address: string) {
 export function isEthAddress(address: string | null) {
   return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
 }
-
-export default {
-  hashCode,
-  popularEmojis,
-};

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -1,0 +1,68 @@
+export const popularEmojis = [
+  '🌶',
+  '🤑',
+  '🐙',
+  '🫐',
+  '🐳',
+  '🤶',
+  '🌲',
+  '🌞',
+  '🐒',
+  '🐵',
+  '🦊',
+  '🐼',
+  '🦄',
+  '🐷',
+  '🐧',
+  '🦩',
+  '👽',
+  '🎈',
+  '🍉',
+  '🎉',
+  '🐲',
+  '🌎',
+  '🍊',
+  '🐭',
+  '🍣',
+  '🐥',
+  '👾',
+  '🥦',
+  '👹',
+  '🙀',
+  '⛱',
+  '⛵️',
+  '🥳',
+  '🤯',
+  '🤠',
+];
+
+export function hashCode(text: string) {
+  let hash = 0,
+    i,
+    chr;
+  if (text.length === 0) return hash;
+  for (i = 0; i < text.length; i++) {
+    chr = text.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
+  }
+  return hash;
+}
+
+export function addressHashedIndex(address: string) {
+  return Math.abs(hashCode(address.toLowerCase()) % 35);
+}
+
+export function addressHashedEmoji(address: string) {
+  const index = addressHashedIndex(address);
+  return popularEmojis[index];
+}
+
+export function isEthAddress(address: string | null) {
+  return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
+}
+
+export default {
+  hashCode,
+  popularEmojis,
+};

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -2,46 +2,47 @@
 
 import colors from '../styles/colors';
 
-// popularEmojisToColorIndex matches emojis to the index of their
-// color backgrounds in the `avatarBackgrounds` object in colors.js
-export const popularEmojisToColorIndex = {
-  '🌶': 0,
-  '🤑': 1,
-  '🐙': 2,
-  '🫐': 3,
-  '🐳': 4,
-  '🤶': 0,
-  '🌲': 5,
-  '🌞': 6,
-  '🐒': 7,
-  '🐵': 8,
-  '🦊': 9,
-  '🐼': 10,
-  '🦄': 11,
-  '🐷': 12,
-  '🐧': 13,
-  '🦩': 8,
-  '👽': 14,
-  '🎈': 0,
-  '🍉': 8,
-  '🎉': 1,
-  '🐲': 15,
-  '🌎': 16,
-  '🍊': 17,
-  '🐭': 18,
-  '🍣': 19,
-  '🐥': 1,
-  '👾': 20,
-  '🥦': 15,
-  '👹': 0,
-  '🙀': 17,
-  '⛱': 4,
-  '⛵️': 21,
-  '🥳': 17,
-  '🤯': 8,
-  '🤠': 22,
-};
+// avatars groups emojis with their respective color backgrounds in the `avatarBackgrounds` object in colors.js
+export const avatars = [
+  { emoji: '🌶', color: colors.avatarBackgrounds[0] },
+  { emoji: '🤑', color: colors.avatarBackgrounds[1] },
+  { emoji: '🐙', color: colors.avatarBackgrounds[2] },
+  { emoji: '🫐', color: colors.avatarBackgrounds[3] },
+  { emoji: '🐳', color: colors.avatarBackgrounds[4] },
+  { emoji: '🤶', color: colors.avatarBackgrounds[0] },
+  { emoji: '🌲', color: colors.avatarBackgrounds[5] },
+  { emoji: '🌞', color: colors.avatarBackgrounds[6] },
+  { emoji: '🐒', color: colors.avatarBackgrounds[7] },
+  { emoji: '🐵', color: colors.avatarBackgrounds[8] },
+  { emoji: '🦊', color: colors.avatarBackgrounds[9] },
+  { emoji: '🐼', color: colors.avatarBackgrounds[10] },
+  { emoji: '🦄', color: colors.avatarBackgrounds[11] },
+  { emoji: '🐷', color: colors.avatarBackgrounds[12] },
+  { emoji: '🐧', color: colors.avatarBackgrounds[13] },
+  { emoji: '🦩', color: colors.avatarBackgrounds[8] },
+  { emoji: '👽', color: colors.avatarBackgrounds[14] },
+  { emoji: '🎈', color: colors.avatarBackgrounds[0] },
+  { emoji: '🍉', color: colors.avatarBackgrounds[8] },
+  { emoji: '🎉', color: colors.avatarBackgrounds[1] },
+  { emoji: '🐲', color: colors.avatarBackgrounds[15] },
+  { emoji: '🌎', color: colors.avatarBackgrounds[16] },
+  { emoji: '🍊', color: colors.avatarBackgrounds[17] },
+  { emoji: '🐭', color: colors.avatarBackgrounds[18] },
+  { emoji: '🍣', color: colors.avatarBackgrounds[19] },
+  { emoji: '🐥', color: colors.avatarBackgrounds[1] },
+  { emoji: '👾', color: colors.avatarBackgrounds[20] },
+  { emoji: '🥦', color: colors.avatarBackgrounds[15] },
+  { emoji: '👹', color: colors.avatarBackgrounds[0] },
+  { emoji: '🙀', color: colors.avatarBackgrounds[17] },
+  { emoji: '⛱', color: colors.avatarBackgrounds[4] },
+  { emoji: '⛵️', color: colors.avatarBackgrounds[21] },
+  { emoji: '🥳', color: colors.avatarBackgrounds[17] },
+  { emoji: '🤯', color: colors.avatarBackgrounds[8] },
+  { emoji: '🤠', color: colors.avatarBackgrounds[22] },
+];
 
+// oldAvatarColorToAvatarBackgroundIndex maps old hex colors from showcase of webProfiles
+// to new colors in colors.avatarBackgrounds (index)
 const oldAvatarColorToAvatarBackgroundIndex: { [hex: string]: number } = {
   '#FF494A': 0,
   '#01D3FF': 4,
@@ -58,10 +59,11 @@ export function getOldAvatarColorToAvatarBackgroundIndex(colorHex: string) {
   if (!colorHex) return null;
   return oldAvatarColorToAvatarBackgroundIndex[colorHex] || 0;
 }
-
-export const popularEmojis = Object.keys(popularEmojisToColorIndex);
-export const emojiColorIndexes = Object.values(popularEmojisToColorIndex);
-const emojiCount = Object.keys(popularEmojis).length;
+export const popularEmojis = avatars.map(avatar => avatar.emoji);
+export const emojiColorIndexes = avatars.map(avatar =>
+  colors.avatarBackgrounds.indexOf(avatar.color)
+);
+const emojiCount = avatars.length;
 
 export function hashCode(text: string) {
   let hash = 0,

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -63,6 +63,7 @@ export function addressHashedIndex(address: string) {
 }
 
 export function addressHashedColorIndex(address: string) {
+  if (address === null || address === undefined) return null;
   return emojiColorIndexes[
     Math.abs(hashCode(address.toLowerCase()) % emojiCount)
   ];

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -96,10 +96,6 @@ export function addressHashedEmoji(address: string) {
   return popularEmojis[index];
 }
 
-export function isEthAddress(address: string | null) {
-  return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
-}
-
 export function colorHexToIndex(colorHex: string | null) {
   if (!colorHex) return 0;
   if (colors.avatarBackgrounds.includes(colorHex)) {
@@ -109,3 +105,21 @@ export function colorHexToIndex(colorHex: string | null) {
   }
   return 0;
 }
+
+export function isEthAddress(address: string | null) {
+  return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
+}
+
+export default {
+  avatars,
+  addressHashedIndex,
+  addressHashedColorIndex,
+  addressHashedEmoji,
+  colorHexToIndex,
+  emojiColorIndexes,
+  emojiCount,
+  getOldAvatarColorToAvatarBackgroundIndex,
+  hashCode,
+  popularEmojis,
+  isEthAddress,
+};

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -58,6 +58,7 @@ export function hashCode(text: string) {
 }
 
 export function addressHashedIndex(address: string) {
+  if (address === null || address === undefined) return null;
   return Math.abs(hashCode(address.toLowerCase()) % emojiCount);
 }
 
@@ -69,6 +70,7 @@ export function addressHashedColorIndex(address: string) {
 
 export function addressHashedEmoji(address: string) {
   const index = addressHashedIndex(address);
+  if (index === null || index === undefined) return null;
   return popularEmojis[index];
 }
 

--- a/src/utils/defaultProfileUtils.ts
+++ b/src/utils/defaultProfileUtils.ts
@@ -1,5 +1,7 @@
 /* eslint-disable sort-keys */
 
+import colors from '../styles/colors';
+
 // popularEmojisToColorIndex matches emojis to the index of their
 // color backgrounds in the `avatarBackgrounds` object in colors.js
 export const popularEmojisToColorIndex = {
@@ -40,6 +42,23 @@ export const popularEmojisToColorIndex = {
   '🤠': 22,
 };
 
+const oldAvatarColorToAvatarBackgroundIndex: { [hex: string]: number } = {
+  '#FF494A': 0,
+  '#01D3FF': 4,
+  '#FB60C4': 12,
+  '#3F6AFF': 21,
+  '#FFD963': 1,
+  '#B140FF': 20,
+  '#41EBC1': 4,
+  '#F46E38': 9,
+  '#6D7E8F': 10,
+};
+// function to support showcase of webProfiles that stored the old avatarColor hexes
+export function getOldAvatarColorToAvatarBackgroundIndex(colorHex: string) {
+  if (!colorHex) return null;
+  return oldAvatarColorToAvatarBackgroundIndex[colorHex] || 0;
+}
+
 export const popularEmojis = Object.keys(popularEmojisToColorIndex);
 export const emojiColorIndexes = Object.values(popularEmojisToColorIndex);
 const emojiCount = Object.keys(popularEmojis).length;
@@ -77,4 +96,14 @@ export function addressHashedEmoji(address: string) {
 
 export function isEthAddress(address: string | null) {
   return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
+}
+
+export function colorHexToIndex(colorHex: string | null) {
+  if (!colorHex) return 0;
+  if (colors.avatarBackgrounds.includes(colorHex)) {
+    return colors.avatarBackgrounds.indexOf(colorHex);
+  } else if (colors.avatarColor.includes(colorHex)) {
+    return getOldAvatarColorToAvatarBackgroundIndex(colorHex);
+  }
+  return 0;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,6 +10,7 @@ export { default as AllowancesCache } from './allowancesCache';
 export { default as TokensListenedCache } from './tokensListenedCache';
 export { default as checkTokenIsScam } from './checkTokenIsScam';
 export { default as deviceUtils } from './deviceUtils';
+export { default as defaultProfileUtils } from './defaultProfileUtils';
 export { default as dimensionsPropType } from './dimensionsPropType';
 export { default as directionPropType } from './directionPropType';
 export { default as ethereumUtils } from './ethereumUtils';


### PR DESCRIPTION
This feature started as just adding deterministic emojis for new wallets but given a few other fixes being adjacent, this PR ends up including:

Add deterministic emojis to new wallets
Add deterministic emoji preview to watched and imported wallets
Make the color options in the emoji picker be all the web profile colors
Make color picker horizontally scrollable
Update web profile data with correct colors on change
Remove avatar preview from a new wallet since we don't have an address yet (Plan is to soon add a replacement "empty" avatar you can tap to choose color/emoji before creating)
Remove ability to tap the preview avatar in the edit/rename wallet modal to toggle background color (wasn't saving anyways)
Fix sporadic problems with wallet names/nicknames during the editing and importing of wallets
Fix issue where wallet name change does not update wallet
Migration to move from old color indexes to new ones