### PR TITLE
Bugfix: android pools sheet

### DIFF
--- a/src/components/expanded-state/LiquidityPoolExpandedState.js
+++ b/src/components/expanded-state/LiquidityPoolExpandedState.js
@@ -31,6 +31,7 @@ import {
   useAsset,
   useChartThrottledPoints,
   useColorForAsset,
+  useDimensions,
   usePoolDetails,
   useTotalFeeEarnedPerAsset,
 } from '@rainbow-me/hooks';
@@ -47,10 +48,7 @@ export const underlyingAssetsHeight = 70;
 const heightWithoutChart = 452 + (android ? 20 - getSoftMenuBarHeight() : 0);
 const heightWithChart = heightWithoutChart + 293;
 
-export const initialLiquidityPoolExpandedStateSheetHeight = Math.min(
-  deviceUtils.dimensions.height,
-  heightWithChart + underlyingAssetsHeight
-);
+export const initialLiquidityPoolExpandedStateSheetHeight = undefined;
 
 const formatTokenAddress = address => {
   if (!address || toLower(address) === ETH_ADDRESS) {
@@ -92,6 +90,7 @@ const LiquidityPoolExpandedState = () => {
   const { asset } = params;
   const { tokenNames, tokens, totalNativeDisplay, uniBalance } = asset;
   const dispatch = useDispatch();
+  const { height: screenHeight } = useDimensions();
 
   const tokenAddresses = useMemo(() => {
     return tokens?.map(token => formatTokenAddress(token.address));
@@ -192,8 +191,10 @@ const LiquidityPoolExpandedState = () => {
     <SlackSheet
       additionalTopPadding={android}
       contentHeight={liquidityPoolExpandedStateSheetHeight}
-      {...(ios && { height: '100%' })}
       scrollEnabled
+      {...(ios
+        ? { height: '100%' }
+        : { additionalTopPadding: true, contentHeight: screenHeight - 80 })}
     >
       <ChartPathProvider data={throttledData}>
         <Chart

--- a/src/components/investment-cards/UniswapPoolListRow.js
+++ b/src/components/investment-cards/UniswapPoolListRow.js
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { UniBalanceHeightDifference } from '../../hooks/charts/useChartThrottledPoints';
 import { useRemoveNextToLast } from '../../navigation/useRemoveNextToLast';
 import { ButtonPressAnimation } from '../animations';
 import { BottomRowText, CoinRow } from '../coin-row';

--- a/src/components/investment-cards/UniswapPoolListRow.js
+++ b/src/components/investment-cards/UniswapPoolListRow.js
@@ -67,10 +67,8 @@ export default function UniswapPoolListRow({ assetType, item, ...props }) {
   const { uniswap } = useSelector(readableUniswapSelector);
 
   const handleOpenExpandedState = useCallback(() => {
-    let inWallet = true;
     let poolAsset = uniswap.find(pool => pool.address === item.address);
     if (!poolAsset) {
-      inWallet = false;
       const genericPoolAsset = genericAssets[item.address];
       poolAsset = parseAssetsNative(
         [{ ...item, ...genericPoolAsset }],
@@ -85,10 +83,7 @@ export default function UniswapPoolListRow({ assetType, item, ...props }) {
       asset: poolAsset,
       dpi: true,
       fromDiscover: true,
-      longFormHeight: inWallet
-        ? initialLiquidityPoolExpandedStateSheetHeight
-        : initialLiquidityPoolExpandedStateSheetHeight -
-          UniBalanceHeightDifference,
+      longFormHeight: initialLiquidityPoolExpandedStateSheetHeight,
       type: assetType,
     });
   }, [


### PR DESCRIPTION
Liquidity pool sheets weren't scrollable and didn't fit the screen on lower end devices with minor screen scales. All of that was fixed following the styles we have on other sheets as `ChartExpandedState`.

I also introduced a change that I wasn't sure why that was there on src/components/investment-cards/UniswapPoolListRow.js the route defined a height that was blocking the UI to be scrollable.

Working https://recordit.co/RMwJgHogFl

Fixes RNBW-1283