### PR TITLE
bugfix: send scrollable asset list on android

### DIFF
--- a/src/navigation/bottom-sheet/types.d.ts
+++ b/src/navigation/bottom-sheet/types.d.ts
@@ -123,6 +123,7 @@ export type BottomSheetNavigationOptions = Partial<
   backdropOpacity?: number;
   backdropColor?: string;
   height?: number | string;
+  offsetY?: number;
 };
 
 export type BottomSheetNavigationConfig = {};

--- a/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
+++ b/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
@@ -38,6 +38,7 @@ const BottomSheetRoute = ({
     backdropColor = DEFAULT_BACKDROP_COLOR,
     backdropOpacity = DEFAULT_BACKDROP_OPACITY,
     height = DEFAULT_HEIGHT,
+    offsetY = android ? 20 : 3,
   } = options || {};
   //#endregion
 
@@ -147,7 +148,7 @@ const BottomSheetRoute = ({
   return (
     <BottomSheetNavigatorContext.Provider value={contextVariables}>
       <BottomSheet
-        activeOffsetY={[-3, 3]}
+        activeOffsetY={[-offsetY, offsetY]}
         animateOnMount
         animationDuration={DEFAULT_ANIMATION_DURATION}
         backdropComponent={renderBackdropComponent}


### PR DESCRIPTION
On current production I can't scroll down on the send asset lists on my android

https://recordit.co/CugpOG7njH

I was only able to do so using two fingers to scroll.

I changed the `offsetY` on `BottomSheetRoute` for android, and is working now, 3 wasn't enough for android, I tried several offsets and I put there the smoother one IMO.

Fixes RNBW-1302