### PR TITLE
bugfix: android backup footer view

### DIFF
--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -119,7 +119,7 @@ export default function BackupManualStep() {
       </Content>
       <Footer>
         {secretLoaded && (
-          <View marginBottom={30} marginTop={30}>
+          <View marginTop={30}>
             <SheetActionButton
               color={colors.appleBlue}
               fullWidth

--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -32,6 +32,7 @@ const Footer = styled(Column).attrs({
 })`
   ${padding(0, 15, 21)};
   width: 100%;
+  margin-bottom: ${android ? 30 : 0};
 `;
 
 const Masthead = styled(Column).attrs({
@@ -118,7 +119,7 @@ export default function BackupManualStep() {
       </Content>
       <Footer>
         {secretLoaded && (
-          <View marginTop={30}>
+          <View marginBottom={30} marginTop={30}>
             <SheetActionButton
               color={colors.appleBlue}
               fullWidth


### PR DESCRIPTION
On current android prod I can't press the button at the bottom of the manually back up screen as described here https://linear.app/rainbow/issue/RNBW-1300/back-up-manually-doesnt-fit-screen now that is visible for android screens adidng a margin to the footer

Fixes RNBW-1300