### PR TITLE
Disable auto-scrolling for AssetList

### DIFF
--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -184,6 +184,7 @@ export default function WalletScreen() {
           </Header>
         </HeaderOpacityToggler>
         <AssetList
+          disableAutoScrolling
           fetchData={refreshAccountData}
           isEmpty={isAccountEmpty || !!params?.emptyWallet}
           isWalletEthZero={isWalletEthZero}


### PR DESCRIPTION
Turn off auto-scrolling to avoid jumping around when tapping the NFT contract families.