### PR TITLE
QR scanner navigation fix

### DIFF
--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -85,12 +85,12 @@ export default function useScanner(enabled) {
       // First navigate to wallet screen
       navigate(Routes.WALLET_SCREEN);
 
-      // And then navigate to Send sheet
-      setTimeout(() => {
+      // And then navigate to Showcase sheet
+      InteractionManager.runAfterInteractions(() => {
         Navigation.handleAction(Routes.SHOWCASE_SHEET, {
           address: address,
         });
-      }, 100);
+      });
 
       setTimeout(enableScanning, 2500);
     },
@@ -107,11 +107,13 @@ export default function useScanner(enabled) {
       if (checkIsValidAddressOrDomain(addressOrENS)) {
         // First navigate to wallet screen
         navigate(Routes.WALLET_SCREEN);
-        setTimeout(() => {
+
+        // And then navigate to Showcase sheet
+        InteractionManager.runAfterInteractions(() => {
           Navigation.handleAction(Routes.SHOWCASE_SHEET, {
             address: addressOrENS,
           });
-        }, 100);
+        });
       }
       setTimeout(enableScanning, 2500);
     },

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -88,7 +88,7 @@ export default function useScanner(enabled) {
       // And then navigate to Showcase sheet
       InteractionManager.runAfterInteractions(() => {
         Navigation.handleAction(Routes.SHOWCASE_SHEET, {
-          address: address,
+          address,
         });
       });
 

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -86,9 +86,11 @@ export default function useScanner(enabled) {
       navigate(Routes.WALLET_SCREEN);
 
       // And then navigate to Send sheet
-      Navigation.handleAction(Routes.SHOWCASE_SHEET, {
-        address: address,
-      });
+      setTimeout(() => {
+        Navigation.handleAction(Routes.SHOWCASE_SHEET, {
+          address: address,
+        });
+      }, 100);
 
       setTimeout(enableScanning, 2500);
     },
@@ -105,9 +107,11 @@ export default function useScanner(enabled) {
       if (checkIsValidAddressOrDomain(addressOrENS)) {
         // First navigate to wallet screen
         navigate(Routes.WALLET_SCREEN);
-        Navigation.handleAction(Routes.SHOWCASE_SHEET, {
-          address: addressOrENS,
-        });
+        setTimeout(() => {
+          Navigation.handleAction(Routes.SHOWCASE_SHEET, {
+            address: addressOrENS,
+          });
+        }, 100);
       }
       setTimeout(enableScanning, 2500);
     },


### PR DESCRIPTION
The issue with the QR scanner repeatedly scanning seems to be due to back-to-back navigation calls.  For some reason firing two navigation calls simultaneously does not update the `isFocused` flag in `QRScannerScreen.js` (from the `useIsFocused` hook coming from `@react-navigation`). This kept the QR Code camera open after navigating away from Discover page.

A tiny delay between navigation calls seems to allow the camera to close out.