### PR TITLE
Simplify account name calculation

### DIFF
--- a/src/hooks/useAccountProfile.js
+++ b/src/hooks/useAccountProfile.js
@@ -51,14 +51,14 @@ export function getAccountProfileInfo(
   }
   const { label, color, image } = selectedAccount;
 
+  const labelWithoutEmoji = removeFirstEmojiFromString(label).join('');
+
   const accountName =
-    removeFirstEmojiFromString(
-      network === networkTypes.mainnet
-        ? label || accountENS || address(accountAddress, 4, 4)
-        : label === accountENS
-        ? address(accountAddress, 4, 4)
-        : label || address(accountAddress, 4, 4)
-    ).join('') || address(accountAddress, 4, 4);
+    network === networkTypes.mainnet
+      ? labelWithoutEmoji || accountENS || address(accountAddress, 4, 4)
+      : labelWithoutEmoji === accountENS
+      ? address(accountAddress, 4, 4)
+      : labelWithoutEmoji || address(accountAddress, 4, 4);
 
   const emojiAvatar = returnStringFirstEmoji(label);
 

--- a/src/hooks/useAccountProfile.js
+++ b/src/hooks/useAccountProfile.js
@@ -51,7 +51,8 @@ export function getAccountProfileInfo(
   }
   const { label, color, image } = selectedAccount;
 
-  const labelWithoutEmoji = removeFirstEmojiFromString(label).join('');
+  const labelWithoutEmoji =
+    label && removeFirstEmojiFromString(label)?.join('');
 
   const accountName =
     network === networkTypes.mainnet


### PR DESCRIPTION
This PR brings back the ENS fallback for people without account names who have reverse ENS configured. There was an issue with wallets with emoji but no label falling through this check.