### PR TITLE
add try catch to ens resolution

### DIFF
--- a/src/hooks/useImportingWallet.js
+++ b/src/hooks/useImportingWallet.js
@@ -142,9 +142,13 @@ export default function useImportingWallet() {
           return;
         }
       } else if (isValidAddress(input)) {
-        const ens = await web3Provider.lookupAddress(input);
-        if (ens && ens !== input) {
-          name = forceEmoji ? `${forceEmoji} ${ens}` : ens;
+        try {
+          const ens = await web3Provider.lookupAddress(input);
+          if (ens && ens !== input) {
+            name = forceEmoji ? `${forceEmoji} ${ens}` : ens;
+          }
+        } catch (e) {
+          logger.log(`Error resolving ENS during wallet import`, e);
         }
         showWalletProfileModal(name, guardedForceColor, input);
       } else {


### PR DESCRIPTION
importing wallets with an emoji in the ENS would get stuck on import. We fail gracefully for now but should use our firebase endpoint moving forward

PoW: https://cloud.skylarbarrera.com/Screen-Recording-2021-07-12-17-50-18.mp4