### PR TITLE
Fix yarn:android:bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "setup": "yarn install && yarn allow-scripts && yarn postinstall",
     "android": "yarn uninstall:android && react-native run-android",
-    "android:apk": "yarn update-tokens && yarn gradle assembleRelease && yarn uninstall:android && yarn android:load-apk",
-    "android:bundle": "./scripts/check-env.sh && yarn gradle bundleRelease && open android/app/build/outputs/bundle/release/",
+    "android:apk": "yarn gradle assembleRelease && yarn uninstall:android && yarn android:load-apk",
+    "android:bundle": "./scripts/check-env.sh && yarn update-tokens && yarn gradle bundleRelease && open android/app/build/outputs/bundle/release/",
     "android:load-apk": "adb install android/app/build/outputs/apk/release/app-release.apk",
     "clean:android": "yarn uninstall:android && yarn gradle clean",
     "detox:android": "detox build -c android.emu.debug && detox test -R 1 -c android.emu.debug --loglevel verbose",


### PR DESCRIPTION
We don't wanna run the token list update script every time we generate an APK. 
We need to do it only when we generate the bundle, which is the artifact we release.