### PR TITLE
Add a second keychain loadString read attempt

### DIFF
--- a/src/model/keychain.ts
+++ b/src/model/keychain.ts
@@ -77,6 +77,37 @@ export async function loadString(
     if (err.toString() === 'Error: Wrapped error: User not authenticated') {
       return -2;
     }
+    if (
+      err.toString() ===
+      'Error: The user name or passphrase you entered is not correct.'
+    ) {
+      // Try reading from keychain once more
+      captureMessage('Keychain read first attempt failed');
+      await delay(1000);
+      try {
+        const credentials = await getInternetCredentials(key, options);
+        if (credentials) {
+          logger.log(
+            `Keychain: loaded string for key on second attempt: ${key}`
+          );
+          return credentials.password;
+        }
+        logger.sentry(`Keychain: string does not exist for key: ${key}`);
+      } catch (e) {
+        if (err.toString() === 'Error: User canceled the operation.') {
+          return -1;
+        }
+        if (err.toString() === 'Error: Wrapped error: User not authenticated') {
+          return -2;
+        }
+        captureMessage('Keychain write second attempt failed');
+        logger.sentry(
+          `Keychain: failed to load string for key: ${key} error: ${err}`
+        );
+        captureException(err);
+      }
+      return null;
+    }
     logger.sentry(
       `Keychain: failed to load string for key: ${key} error: ${err}`
     );


### PR DESCRIPTION
Keychain is intermittently failing on the [`getInternetCredentials` function](https://github.com/oblador/react-native-keychain#getinternetcredentialsserver--authenticationprompt-) where we read from secure storage. @brunobar79 mentioned he had similar issues with the `setInternetCredentials` function and solution that fixed it was doing a second request on that specific failure.