### PR TITLE
Fix NFT capping issue

### DIFF
--- a/src/components/asset-list/RecyclerAssetList/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList/index.tsx
@@ -215,7 +215,7 @@ function RecyclerAssetList({
           section.data.forEach((item, index) => {
             if (
               item.isHeader ||
-              openFamilyTabs[item.familyName + showcase ? '-showcase' : '']
+              openFamilyTabs[item.familyName + (showcase ? '-showcase' : '')]
             ) {
               ctx.push({
                 familySectionIndex: index,

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -205,7 +205,7 @@ export const buildUniqueTokenList = (uniqueTokens, selectedShowcaseTokens) => {
       }
     }
     let tokens = compact(tokensRow);
-    tokens = chunk(tokens, tokens.length > 25 ? 4 : 25);
+    tokens = chunk(tokens, 50); // cap NFT cards per family at 100
     // eslint-disable-next-line no-loop-func
     tokens.forEach((tokenChunk, index) => {
       const id = tokensRow[0]

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -205,7 +205,7 @@ export const buildUniqueTokenList = (uniqueTokens, selectedShowcaseTokens) => {
       }
     }
     let tokens = compact(tokensRow);
-    tokens = chunk(tokens, 50); // cap NFT cards per family at 100
+    tokens = chunk(tokens, tokens.length > 25 ? 4 : 25);
     // eslint-disable-next-line no-loop-func
     tokens.forEach((tokenChunk, index) => {
       const id = tokensRow[0]


### PR DESCRIPTION
Any NFT family with more than 25 token rows (so 50 token cards, each row is 2 token cards) would get chunked to 4 rows, meaning only 8 token cards would get displayed. I've explanded this to chunk all families regardless of size by 50, meaning a max of 100 token cards will be displayed under a family. Assume this is a sensible number to use -- unsure of the downstream performance implications of this change, but it was not noticeable at all in simulator testing. I did see a *lot* of jumping around in the dev wallet with both the tokens and the ENS NFTs expanded.

fixes RNBW-1339