### PR TITLE
Fix bug that reduces 300 uniswap calls

### DIFF
--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -59,7 +59,7 @@ async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
           fetchPolicy: 'no-cache',
           query: UNISWAP_PAIRS_HISTORICAL_BULK_QUERY,
           variables: {
-            block,
+            block: Number(block),
             pairs: pairList,
           },
         });
@@ -310,11 +310,8 @@ export default function useUniswapPools(sortField, sortDirection, token) {
       );
   }, [pairs, dispatch]);
 
-  const { genericAssets } = useSelector(
-    ({ data: { assets, genericAssets } }) => ({
-      assets,
-      genericAssets,
-    })
+  const genericAssets = useSelector(
+    ({ data: { genericAssets } }) => genericAssets
   );
 
   const { data: idsData, error } = useQuery(


### PR DESCRIPTION
Issue: `UNISWAP_PAIRS_HISTORICAL_BULK_QUERY` was returning empty data with an error message complaining about the block being passed in as a string instead of a number. Since this query was not returning any data, we were triggering 3 requests for every pair (for a total of 300 requests) to fetch for the missing historical data.

Confirmed via logs that the total additional requests for historical data that need to be done went from 300 down to 2.

QA: Please confirm how performance feels on Android.
