### PR TITLE
Reorg account name calc

### DIFF
--- a/src/helpers/accountInfo.js
+++ b/src/helpers/accountInfo.js
@@ -37,14 +37,15 @@ export function getAccountProfileInfo(
   }
   const { label, color, image } = selectedAccount;
 
+  const labelWithoutEmoji =
+    label && removeFirstEmojiFromString(label)?.join('');
+
   const accountName =
-    removeFirstEmojiFromString(
-      network === networkTypes.mainnet
-        ? label || accountENS || address(accountAddress, 4, 4)
-        : label === accountENS
-        ? address(accountAddress, 4, 4)
-        : label || address(accountAddress, 4, 4)
-    ).join('') || address(accountAddress, 4, 4);
+    network === networkTypes.mainnet
+      ? labelWithoutEmoji || accountENS || address(accountAddress, 4, 4)
+      : labelWithoutEmoji === accountENS
+      ? address(accountAddress, 4, 4)
+      : labelWithoutEmoji || address(accountAddress, 4, 4);
 
   const emojiAvatar = returnStringFirstEmoji(label);
 


### PR DESCRIPTION
This shows the ENS handle if reverse ens is set up and the account has no label. This change got lost somewhere in the L2 branch (prob during rebasing).