### PR TITLE
Fix layout on seed backup sheets

### DIFF
--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -4,7 +4,7 @@ import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
-import { Column } from '../layout';
+import { Column, Row } from '../layout';
 import { SecretDisplaySection } from '../secret-display';
 import { SheetActionButton } from '../sheet';
 import { Nbsp, Text } from '../text';
@@ -23,7 +23,7 @@ const Content = styled(Column).attrs({
 })`
   flex-grow: 1;
   flex-shrink: 0;
-  padding-top: ${({ isTallPhone }) => (android ? 30 : isTallPhone ? 65 : 15)};
+  padding-top: ${({ isTallPhone }) => (android ? 30 : isTallPhone ? 45 : 25)};
 `;
 
 const Footer = styled(Column).attrs({
@@ -38,15 +38,13 @@ const Footer = styled(Column).attrs({
 const Masthead = styled(Column).attrs({
   align: 'center',
   justify: 'start',
-})`
-  padding-top: 18;
-`;
+})``;
 
 const MastheadDescription = styled(Text).attrs(({ theme: { colors } }) => ({
   align: 'center',
   color: colors.alpha(colors.blueGreyDark, 0.6),
   lineHeight: 'looser',
-  size: 'large',
+  size: 'lmedium',
 }))`
   max-width: 291;
 `;
@@ -54,16 +52,23 @@ const MastheadDescription = styled(Text).attrs(({ theme: { colors } }) => ({
 const MastheadIcon = styled(Text).attrs({
   align: 'center',
   color: 'appleBlue',
-  size: 43,
-  weight: 'semibold',
+  size: 21,
+  weight: 'heavy',
 })``;
 
 const MastheadTitle = styled(Text).attrs({
   align: 'center',
-  size: 'big',
+  size: 'larger',
   weight: 'bold',
 })`
-  ${padding(15, 0, 12)};
+  ${padding(8)};
+`;
+
+const MastheadTitleRow = styled(Row).attrs({
+  align: 'center',
+  justify: 'start',
+})`
+  padding-top: 18;
 `;
 
 export default function BackupManualStep() {
@@ -97,8 +102,10 @@ export default function BackupManualStep() {
   return (
     <Fragment>
       <Masthead>
-        <MastheadIcon>􀉆</MastheadIcon>
-        <MastheadTitle>Back up manually</MastheadTitle>
+        <MastheadTitleRow>
+          <MastheadIcon>􀉆</MastheadIcon>
+          <MastheadTitle>Back up manually</MastheadTitle>
+        </MastheadTitleRow>
         <MastheadDescription>
           <MastheadDescription weight="semibold">
             {type === WalletTypes.privateKey

--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -104,7 +104,7 @@ export default function BackupManualStep() {
       <Masthead>
         <MastheadTitleRow>
           <MastheadIcon>􀉆</MastheadIcon>
-          <MastheadTitle>Back up manually</MastheadTitle>
+          <MastheadTitle>Your secret phrase</MastheadTitle>
         </MastheadTitleRow>
         <MastheadDescription>
           <MastheadDescription weight="semibold">

--- a/src/components/secret-display/SecretDisplaySection.js
+++ b/src/components/secret-display/SecretDisplaySection.js
@@ -22,19 +22,21 @@ import logger from 'logger';
 
 const Title = styled(Text).attrs({
   align: 'center',
-  size: 'larger',
+  size: 'lmedium',
   weight: 'bold',
 })`
   padding-top: 20;
 `;
 const DescriptionText = styled(Text).attrs(({ theme: { colors } }) => ({
   align: 'center',
-  color: colors.alpha(colors.blueGreyDark, 0.5),
-  lineHeight: 'loosest',
-  size: 'large',
+  color: colors.alpha(colors.blueGreyDark, 0.6),
+  lineHeight: 'loose',
+  size: 'lmedium',
+  weight: 'semibold',
 }))`
   margin-bottom: 42;
-  padding-horizontal: 23;
+  margin-top: 5;
+  padding-horizontal: 3;
 `;
 
 const AuthenticationText = styled(Text).attrs({
@@ -67,7 +69,7 @@ const CopyButtonText = styled(Text).attrs(({ theme: { colors } }) => ({
   color: colors.appleBlue,
   letterSpacing: 'roundedMedium',
   lineHeight: 19,
-  size: 'large',
+  size: 'lmedium',
   weight: 'bold',
 }))``;
 
@@ -128,7 +130,7 @@ export default function SecretDisplaySection({
     <ColumnWithMargins
       align="center"
       justify="center"
-      margin={24}
+      margin={16}
       paddingHorizontal={30}
     >
       {visible ? (
@@ -141,12 +143,13 @@ export default function SecretDisplaySection({
                   <CopyButtonText>Copy to clipboard</CopyButtonText>
                 </CopyButtonRow>
               </CopyFloatingEmojis>
-              <SecretDisplayCard seed={seed} type={type} />
               <Column>
-                <Title>⚠️ Reminder:</Title>
+                <SecretDisplayCard seed={seed} type={type} />
+              </Column>
+              <Column>
+                <Title>👆For your eyes only 👆</Title>
                 <DescriptionText>
-                  These words are for your eyes only. Your secret phrase gives
-                  access to your entire wallet. Be very careful with it.
+                  Anyone who has these words can access your entire wallet!
                 </DescriptionText>
               </Column>
             </Fragment>


### PR DESCRIPTION
Fix issues with privkey backup sheet overflowing on different devices. Fixes RNBW-1397.

Before: 
<img width="404" alt="Screen Shot 2021-07-20 at 9 38 19 AM" src="https://user-images.githubusercontent.com/16931094/127412246-0f829331-d6c2-4c0c-97be-4769bebfadfd.png">

After:
iphone 12
![Simulator Screen Shot - iPhone 12 - 2021-07-28 at 20 13 26](https://user-images.githubusercontent.com/16931094/127412262-df75eef8-4613-41b6-9c04-311793462276.png)

iphone 8
![Simulator Screen Shot - iPhone 8 - 2021-07-28 at 20 13 33](https://user-images.githubusercontent.com/16931094/127412266-cc5004d0-eaea-46a6-9bb4-bebd28f2c537.png)
