### PR TITLE
reset generic assets handle

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -315,6 +315,7 @@ export const dataResetState = () => (dispatch, getState) => {
     uniswapPricesSubscription.unsubscribe &&
     uniswapPricesSubscription.unsubscribe();
   pendingTransactionsHandle && clearTimeout(pendingTransactionsHandle);
+  genericAssetsHandle && clearTimeout(genericAssetsHandle);
   dispatch({ type: DATA_CLEAR_STATE });
 };
 


### PR DESCRIPTION
We were not resetting the generic assets handler so it keep polling forever and a new instance was created every time we switched accounts