### PR TITLE
fix sushi dapp data

### DIFF
--- a/src/helpers/dappNameHandler.js
+++ b/src/helpers/dappNameHandler.js
@@ -141,8 +141,8 @@ const DisplayDappNames = Object.freeze({
     uri: buildAssetUrl('rarible.com'),
   },
   'sushi.com': {
-    name: 'SushiSwap',
-    uri: buildAssetUrl('sushi.com'),
+    name: 'Sushi',
+    uri: null,
   },
   'swerve.fi': {
     name: 'Swerve',


### PR DESCRIPTION
We were pulling an asset that doesnt exist, now we use the image they pass via WC.

PoW: https://cloud.skylarbarrera.com/Screen-Shot-2021-08-05-10-12-22.88.png