### PR TITLE
fix super sticky edit menu

### DIFF
--- a/src/components/asset-list/RecyclerAssetList/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList/index.tsx
@@ -421,9 +421,9 @@ function RecyclerAssetList({
 
   const onScroll = useCallback(
     (e: unknown, f: unknown, offsetY: number) => {
-      checkEditStickyHeader(offsetY);
+      isCoinListEdited && checkEditStickyHeader(offsetY);
     },
-    [checkEditStickyHeader]
+    [checkEditStickyHeader, isCoinListEdited]
   );
 
   const rowRenderer = React.useCallback(
@@ -710,6 +710,10 @@ function RecyclerAssetList({
   const lastOpenFamilyTabs = usePrevious(openFamilyTabs) || openFamilyTabs;
   const lastIsCoinListEdited =
     usePrevious(isCoinListEdited) || isCoinListEdited;
+
+  useEffect(() => {
+    lastIsCoinListEdited !== isCoinListEdited && checkEditStickyHeader(0);
+  }, [lastIsCoinListEdited, isCoinListEdited, checkEditStickyHeader]);
 
   useEffect(() => {
     let collectibles: RecyclerAssetListSection = {} as RecyclerAssetListSection;

--- a/src/components/asset-list/RecyclerAssetList/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList/index.tsx
@@ -421,9 +421,9 @@ function RecyclerAssetList({
 
   const onScroll = useCallback(
     (e: unknown, f: unknown, offsetY: number) => {
-      isCoinListEdited && checkEditStickyHeader(offsetY);
+      checkEditStickyHeader(offsetY);
     },
-    [isCoinListEdited, checkEditStickyHeader]
+    [checkEditStickyHeader]
   );
 
   const rowRenderer = React.useCallback(


### PR DESCRIPTION
we were only checking if we need header if isCoinListEdited === true, so it would remain indefinitely after switching it off

PoW: https://cloud.skylarbarrera.com/Screen-Recording-2021-08-09-00-45-30.mp4