### PR TITLE
Fix exchange modal gas estimations

### DIFF
--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -269,19 +269,19 @@ export default function ExchangeModal({
     updateTxFee,
   ]);
 
-  // Update gas limit
-  useEffect(() => {
-    if (!isEmpty(gasPrices)) {
-      updateGasLimit();
-    }
-  }, [gasPrices, updateGasLimit]);
-
   // Set default gas limit
   useEffect(() => {
     if (isEmpty(prevGasPrices) && !isEmpty(gasPrices)) {
       updateTxFee(defaultGasLimit);
     }
   }, [gasPrices, defaultGasLimit, updateTxFee, prevGasPrices]);
+
+  // Update gas limit
+  useEffect(() => {
+    if (!isEmpty(gasPrices)) {
+      updateGasLimit();
+    }
+  }, [gasPrices, updateGasLimit]);
 
   // Liten to gas prices, Uniswap reserves updates
   useEffect(() => {

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -1,4 +1,5 @@
 import analytics from '@segment/analytics-react-native';
+import { isEmpty } from 'lodash';
 import React, {
   Fragment,
   useCallback,
@@ -37,6 +38,7 @@ import {
   useAccountSettings,
   useBlockPolling,
   useGas,
+  usePrevious,
   usePriceImpactDetails,
   useSwapCurrencies,
   useSwapCurrencyHandlers,
@@ -132,6 +134,7 @@ export default function ExchangeModal({
     : ethUnits.basic_swap;
 
   const {
+    gasPrices,
     selectedGasPrice,
     startPollingGasPrices,
     stopPollingGasPrices,
@@ -143,6 +146,8 @@ export default function ExchangeModal({
   const { nativeCurrency, network } = useAccountSettings();
 
   const [isAuthorizing, setIsAuthorizing] = useState(false);
+
+  const prevGasPrices = usePrevious(gasPrices);
 
   useAndroidBackHandler(() => {
     navigate(Routes.WALLET_SCREEN);
@@ -266,15 +271,17 @@ export default function ExchangeModal({
 
   // Update gas limit
   useEffect(() => {
-    updateGasLimit();
-  }, [updateGasLimit]);
+    if (!isEmpty(gasPrices)) {
+      updateGasLimit();
+    }
+  }, [gasPrices, updateGasLimit]);
 
   // Set default gas limit
   useEffect(() => {
-    setTimeout(() => {
+    if (isEmpty(prevGasPrices) && !isEmpty(gasPrices)) {
       updateTxFee(defaultGasLimit);
-    }, 1000);
-  }, [defaultGasLimit, updateTxFee]);
+    }
+  }, [gasPrices, defaultGasLimit, updateTxFee, prevGasPrices]);
 
   // Liten to gas prices, Uniswap reserves updates
   useEffect(() => {


### PR DESCRIPTION
During the L2 changes I've introduced a race condition where the fees are calculated before having the gas prices, which results in the "loading..." state.  I've fixed it for the send flow but I forgot to do it on the exchange modal.

PoW: https://recordit.co/rwE0tDOxvx