### PR TITLE
WC use connection request chain id

### DIFF
--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -184,7 +184,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
           captureException(error);
           throw error;
         }
-        const { peerId, peerMeta } = payload.params[0];
+        const { peerId, peerMeta, chainId } = payload.params[0];
 
         const imageUrl =
           dappLogoOverride(peerMeta.url) || get(peerMeta, 'icons[0]');
@@ -196,6 +196,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
           dappUrl,
         });
         meta = {
+          chainId,
           dappName,
           dappScheme,
           dappUrl,

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -101,12 +101,12 @@ export default function WalletConnectApprovalSheet() {
   });
 
   const type = params?.type || WalletConnectApprovalSheetType.connect;
-  const chainId = params?.chainId || 1;
 
   const meta = params?.meta || {};
   const callback = params?.callback;
   const receivedTimestamp = params?.receivedTimestamp;
   const timedOut = params?.timedOut;
+  const chainId = meta?.chainId || 1;
   const { dappName, dappUrl, dappScheme, imageUrl, peerId } = meta;
 
   const checkIfScam = useCallback(
@@ -208,6 +208,15 @@ export default function WalletConnectApprovalSheet() {
       dappUrl,
     ]
   );
+
+  useEffect(() => {
+    if (meta?.chainId) {
+      const network = ethereumUtils.getNetworkFromChainId(
+        Number(meta?.chainId || 1)
+      );
+      setApprovalNetwork(network);
+    }
+  }, [meta?.chainId]);
 
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => {


### PR DESCRIPTION
On `session_request` we weren't used the connection chainId, so every connection happening was showing Mainnet as network.

https://recordit.co/8u33kLgvRi