### PR TITLE
fix l2 icons 

### DIFF
--- a/src/components/coin-icon/CoinIcon.js
+++ b/src/components/coin-icon/CoinIcon.js
@@ -36,7 +36,7 @@ const CoinIcon = ({
     <View>
       <StyledCoinIcon
         {...props}
-        address={address}
+        address={props.mainnet_address || address}
         color={color}
         fallbackRenderer={CoinIconFallback}
         forceFallback={forceFallback}


### PR DESCRIPTION
we we're not using the mainnet address to resolve icons, now we do 

 before: https://cloud.skylarbarrera.com/Screen-Shot-2021-08-12-15-59-12.93.png
 after:  https://cloud.skylarbarrera.com/Screen-Shot-2021-08-12-16-00-05.75.png