### PR TITLE
add iOS bundle url schemes

### DIFF
--- a/ios/Rainbow/Info.plist
+++ b/ios/Rainbow/Info.plist
@@ -30,8 +30,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>rainbow</string>
-				<string>ethereum</string>
-				<string>dapp</string>
 				<string>wc</string>
 			</array>
 		</dict>

--- a/ios/Rainbow/Info.plist
+++ b/ios/Rainbow/Info.plist
@@ -30,6 +30,9 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>rainbow</string>
+				<string>ethereum</string>
+				<string>dapp</string>
+				<string>wc</string>
 			</array>
 		</dict>
 	</array>

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -1,6 +1,6 @@
-import qs from 'qs';
 import analytics from '@segment/analytics-react-native';
 import lang from 'i18n-js';
+import qs from 'qs';
 import { useCallback, useEffect, useState } from 'react';
 import { InteractionManager } from 'react-native';
 import { PERMISSIONS, request } from 'react-native-permissions';
@@ -163,11 +163,14 @@ export default function useScanner(enabled) {
       const address = await addressUtils.getEthereumAddressFromQRCodeData(data);
       if (address) return handleScanAddress(address);
       if (data.startsWith('wc:')) return handleScanWalletConnect(data);
-    
+
       const urlObj = new URL(data);
-      if (urlObj?.protocol === 'https:' && urlObj?.pathname?.split('/')?.[1] === 'wc') {
+      if (
+        urlObj?.protocol === 'https:' &&
+        urlObj?.pathname?.split('/')?.[1] === 'wc'
+      ) {
         const { uri } = qs.parse(urlObj.query.substring(1));
-        return handleScanWalletConnect(uri)
+        return handleScanWalletConnect(uri);
       }
 
       if (data.startsWith(RAINBOW_PROFILES_BASE_URL)) {

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -1,3 +1,4 @@
+import qs from 'qs';
 import analytics from '@segment/analytics-react-native';
 import lang from 'i18n-js';
 import { useCallback, useEffect, useState } from 'react';
@@ -162,8 +163,14 @@ export default function useScanner(enabled) {
       const address = await addressUtils.getEthereumAddressFromQRCodeData(data);
       if (address) return handleScanAddress(address);
       if (data.startsWith('wc:')) return handleScanWalletConnect(data);
+    
+      const urlObj = new URL(data);
+      if (urlObj?.protocol === 'https:' && urlObj?.pathname?.split('/')?.[1] === 'wc') {
+        const { uri } = qs.parse(urlObj.query.substring(1));
+        return handleScanWalletConnect(uri)
+      }
+
       if (data.startsWith(RAINBOW_PROFILES_BASE_URL)) {
-        if (data.contains('wc:')) return handleScanWalletConnect(data);
         return handleScanRainbowProfile(data);
       }
       return handleScanInvalid(data);

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -163,6 +163,7 @@ export default function useScanner(enabled) {
       if (address) return handleScanAddress(address);
       if (data.startsWith('wc:')) return handleScanWalletConnect(data);
       if (data.startsWith(RAINBOW_PROFILES_BASE_URL)) {
+        if (data.contains('wc:')) return handleScanWalletConnect(data);
         return handleScanRainbowProfile(data);
       }
       return handleScanInvalid(data);


### PR DESCRIPTION
Adding:

wc

URIs formatted as `rainbow.me/wc:...` weren't handling wallet connect deeplinks, instead were going to watch address section of the app, so added that support with the intent of using it from rainbow button an be able to scan the QR code from camera and be sent to the app instead of other apps supporting the `wc` url scheme