### PR TITLE
Clear timeout when connect sheet is dismissed

### DIFF
--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -207,7 +207,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
         // We need navigate to the same route with the updated params
         // which now includes the meta
         if (navigated && !timedOut) {
-          routeParams = { ...routeParams, meta };
+          routeParams = { ...routeParams, meta, timeout };
           Navigation.handleAction(
             Routes.WALLET_CONNECT_APPROVAL_SHEET,
             routeParams

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -103,6 +103,7 @@ export default function WalletConnectApprovalSheet() {
   const type = params?.type || WalletConnectApprovalSheetType.connect;
 
   const meta = params?.meta || {};
+  const timeout = params?.timeout;
   const callback = params?.callback;
   const receivedTimestamp = params?.receivedTimestamp;
   const timedOut = params?.timedOut;
@@ -137,6 +138,12 @@ export default function WalletConnectApprovalSheet() {
     },
     [setScam]
   );
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [timeout]);
 
   const isAuthenticated = useMemo(() => {
     return isDappAuthenticated(dappUrl);


### PR DESCRIPTION
If you dismiss the WC connect sheet while it's still loading, the connection failed sheet will show up 30 seconds later because we were not clearing the timeout