### PR TITLE
Fix native asset on tx screen

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -257,8 +257,8 @@ export default function TransactionConfirmationScreen() {
       );
       setNativeAsset(asset);
     };
-    !isMessageRequest && getNativeAsset();
-  }, [accountInfo.address, allAssets, isMessageRequest, network]);
+    getNativeAsset();
+  }, [accountInfo.address, allAssets, network]);
 
   const {
     gasLimit,
@@ -288,10 +288,10 @@ export default function TransactionConfirmationScreen() {
   ]);
 
   const request = useMemo(() => {
-    return nativeAsset
-      ? { ...displayDetails.request, asset: nativeAsset }
-      : displayDetails.request;
-  }, [displayDetails.request, nativeAsset]);
+    return isMessageRequest
+      ? { message: displayDetails.request }
+      : { ...displayDetails.request, asset: nativeAsset };
+  }, [displayDetails.request, nativeAsset, isMessageRequest]);
 
   const openAutomatically = routeParams?.openAutomatically;
 
@@ -672,6 +672,7 @@ export default function TransactionConfirmationScreen() {
     dappUrl,
     formattedDappUrl,
     isAuthenticated,
+    nativeAsset,
   ]);
 
   const handleSignMessage = useCallback(async () => {
@@ -818,7 +819,7 @@ export default function TransactionConfirmationScreen() {
     if (isMessageRequest) {
       return (
         <RowWithMargins css={padding(24, 0)}>
-          <MessageSigningSection message={request} method={method} />
+          <MessageSigningSection message={request.message} method={method} />
         </RowWithMargins>
       );
     }


### PR DESCRIPTION
For some reason we weren't getting the native asset when we get a message signature request making the app look like this
(check the balance section)

![image](https://user-images.githubusercontent.com/12115171/129746947-06e17760-5963-447e-a7e5-1ec9f3a359ba.png)

now is back to 

![image](https://user-images.githubusercontent.com/12115171/129746981-90cb33f7-fe71-41c4-9767-334c5b1c76de.png)
