### PR TITLE
Prevent discover search permanent rendering

### DIFF
--- a/src/components/discover-sheet/DiscoverSheetContent.js
+++ b/src/components/discover-sheet/DiscoverSheetContent.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components';
-import { ColumnWithMargins } from '../layout';
+import { ColumnWithMargins, FlexItem } from '../layout';
 import { Text } from '../text';
 import DiscoverHome from './DiscoverHome';
 import DiscoverSearch from './DiscoverSearch';
@@ -24,7 +24,7 @@ function Switcher({ showSearch, children }) {
   return (
     <>
       <View style={{ display: showSearch ? 'flex' : 'none' }}>
-        {children[0]}
+        {showSearch ? children[0] : <FlexItem />}
       </View>
       <View style={{ display: showSearch ? 'none' : 'flex' }}>
         {children[1]}


### PR DESCRIPTION
Everything works as before and the whole DiscoverSearch component is not rendered all the time anymore.

https://user-images.githubusercontent.com/1247834/129768080-361c9982-605b-4ff0-bd9b-3f9507b32094.MP4

