### PR TITLE
@nico/sync send sheet contact info with wallet

### DIFF
--- a/src/components/contacts/ImageAvatar.js
+++ b/src/components/contacts/ImageAvatar.js
@@ -19,6 +19,14 @@ const sizeConfigs = colors => ({
     ],
     textSize: 'bigger',
   },
+  lmedium: {
+    dimensions: 50,
+    shadow: [
+      [0, 4, 12, colors.shadow, 0.12],
+      [0, 1, 3, colors.shadow, 0.08],
+    ],
+    textSize: 28,
+  },
   medium: {
     dimensions: 40,
     shadow: [

--- a/src/screens/SendConfirmationSheet.js
+++ b/src/screens/SendConfirmationSheet.js
@@ -25,12 +25,10 @@ import {
   addressHashedEmoji,
 } from '../utils/profileUtils';
 import { isL2Network } from '@rainbow-me/handlers/web3';
-import { getAccountProfileInfo } from '@rainbow-me/helpers/accountInfo';
 import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
 } from '@rainbow-me/helpers/emojiHandler';
-import { findWalletWithAccount } from '@rainbow-me/helpers/findWalletWithAccount';
 import { convertAmountToNativeDisplay } from '@rainbow-me/helpers/utilities';
 import { isENSAddressFormat } from '@rainbow-me/helpers/validators';
 import {
@@ -40,7 +38,6 @@ import {
   useContacts,
   useDimensions,
   useUserAccounts,
-  useWallets,
 } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
@@ -176,7 +173,6 @@ export default function SendConfirmationSheet() {
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const insets = useSafeArea();
   const { contacts } = useContacts();
-  const { wallets, walletNames } = useWallets();
 
   useEffect(() => {
     android && Keyboard.dismiss();

--- a/src/screens/SendConfirmationSheet.js
+++ b/src/screens/SendConfirmationSheet.js
@@ -225,24 +225,6 @@ export default function SendConfirmationSheet() {
     }
   }, [isSendingToUserAccount, network, toAddress, transactions]);
 
-  const existingAccount = useMemo(() => {
-    let existingAcct = null;
-    if (toAddress) {
-      const allAccounts = [...userAccounts, ...watchedAccounts].filter(
-        acct => acct.visible
-      );
-      for (const account of allAccounts) {
-        if (
-          toChecksumAddress(account.address) === toChecksumAddress(toAddress)
-        ) {
-          existingAcct = account;
-          break;
-        }
-      }
-    }
-    return existingAcct;
-  }, [userAccounts, watchedAccounts, toAddress]);
-
   const contact = useMemo(() => {
     return get(contacts, `${[toLower(to)]}`);
   }, [contacts, to]);
@@ -328,19 +310,35 @@ export default function SendConfirmationSheet() {
     };
   }, [wallets, toAddress, network, walletNames]);
 
+  const watchedAccount = useMemo(() => {
+    let existingAcct = null;
+    if (toAddress) {
+      const allAccounts = [...watchedAccounts].filter(acct => acct.visible);
+      for (const account of allAccounts) {
+        if (
+          toChecksumAddress(account.address) === toChecksumAddress(toAddress)
+        ) {
+          existingAcct = account;
+          break;
+        }
+      }
+    }
+    return existingAcct;
+  }, [watchedAccounts, toAddress]);
+
   const avatarName =
-    removeFirstEmojiFromString(existingAccount?.label || contact?.nickname) ||
+    removeFirstEmojiFromString(watchedAccount?.label || contact?.nickname) ||
     accountProfile?.accountName ||
     (isENSAddressFormat(to) ? to : address(to, 4, 6));
 
-  const avatarValue = existingAccount
-    ? returnStringFirstEmoji(existingAccount.label)
+  const avatarValue = watchedAccount
+    ? returnStringFirstEmoji(watchedAccount.label)
     : contact?.nickname ||
       accountProfile?.accountSymbol ||
       addressHashedEmoji(toAddress);
 
-  const avatarColor = existingAccount
-    ? existingAccount.color
+  const avatarColor = watchedAccount
+    ? watchedAccount.color
     : contact?.color == null
     ? accountProfile?.accountColor == null
       ? addressHashedColorIndex(toAddress)
@@ -354,6 +352,8 @@ export default function SendConfirmationSheet() {
   if (!isL2) {
     realSheetHeight -= 80;
   }
+
+  const accountImage = accountProfile?.accountImage || watchedAccount?.image;
 
   const contentHeight = realSheetHeight - (isL2 ? 50 : 30);
   return (
@@ -490,8 +490,8 @@ export default function SendConfirmationSheet() {
                 </Row>
               </Column>
               <Column align="end" justify="center">
-                {existingAccount?.image ? (
-                  <ImageAvatar image={existingAccount.image} size="lmedium" />
+                {accountImage ? (
+                  <ImageAvatar image={accountImage} size="lmedium" />
                 ) : (
                   <ContactAvatar
                     color={avatarColor}

--- a/src/screens/SendConfirmationSheet.js
+++ b/src/screens/SendConfirmationSheet.js
@@ -243,8 +243,6 @@ export default function SendConfirmationSheet() {
     return existingAcct;
   }, [userAccounts, watchedAccounts, toAddress]);
 
-  console.log('existingAccount', existingAccount);
-
   const contact = useMemo(() => {
     return get(contacts, `${[toLower(to)]}`);
   }, [contacts, to]);
@@ -493,7 +491,7 @@ export default function SendConfirmationSheet() {
               </Column>
               <Column align="end" justify="center">
                 {existingAccount?.image ? (
-                  <ImageAvatar image={existingAccount.image} size="medium" />
+                  <ImageAvatar image={existingAccount.image} size="lmedium" />
                 ) : (
                   <ContactAvatar
                     color={avatarColor}

--- a/src/screens/SendConfirmationSheet.js
+++ b/src/screens/SendConfirmationSheet.js
@@ -297,23 +297,12 @@ export default function SendConfirmationSheet() {
     }
   }, [callback, canSubmit]);
 
-  const accountProfile = useMemo(() => {
-    const selectedWallet = findWalletWithAccount(wallets, toAddress);
-    const approvalAccountInfo = getAccountProfileInfo(
-      selectedWallet,
-      network,
-      walletNames,
-      toAddress
-    );
-    return {
-      ...approvalAccountInfo,
-    };
-  }, [wallets, toAddress, network, walletNames]);
-
-  const watchedAccount = useMemo(() => {
+  const existingAccount = useMemo(() => {
     let existingAcct = null;
     if (toAddress) {
-      const allAccounts = [...watchedAccounts].filter(acct => acct.visible);
+      const allAccounts = [...userAccounts, ...watchedAccounts].filter(
+        acct => acct.visible
+      );
       for (const account of allAccounts) {
         if (
           toChecksumAddress(account.address) === toChecksumAddress(toAddress)
@@ -324,26 +313,21 @@ export default function SendConfirmationSheet() {
       }
     }
     return existingAcct;
-  }, [watchedAccounts, toAddress]);
+  }, [toAddress, userAccounts, watchedAccounts]);
 
   const avatarName =
-    removeFirstEmojiFromString(watchedAccount?.label || contact?.nickname) ||
-    accountProfile?.accountName ||
+    removeFirstEmojiFromString(existingAccount?.label || contact?.nickname) ||
     (isENSAddressFormat(to) ? to : address(to, 4, 6));
 
-  const avatarValue = watchedAccount
-    ? returnStringFirstEmoji(watchedAccount.label)
-    : contact?.nickname ||
-      accountProfile?.accountSymbol ||
-      addressHashedEmoji(toAddress);
+  const avatarValue =
+    returnStringFirstEmoji(existingAccount?.label) ||
+    contact?.nickname ||
+    addressHashedEmoji(toAddress);
 
-  const avatarColor = watchedAccount
-    ? watchedAccount.color
-    : contact?.color == null
-    ? accountProfile?.accountColor == null
-      ? addressHashedColorIndex(toAddress)
-      : accountProfile?.accountColor
-    : contact?.color;
+  const avatarColor =
+    existingAccount?.color ||
+    contact?.color ||
+    addressHashedColorIndex(toAddress);
 
   let realSheetHeight = !shouldShowChecks
     ? SendConfirmationSheetHeight - 150
@@ -353,7 +337,7 @@ export default function SendConfirmationSheet() {
     realSheetHeight -= 80;
   }
 
-  const accountImage = accountProfile?.accountImage || watchedAccount?.image;
+  const accountImage = existingAccount?.image;
 
   const contentHeight = realSheetHeight - (isL2 ? 50 : 30);
   return (


### PR DESCRIPTION
When passing an address to the Send Sheet confirmation, pull info from current wallets before defaulting to hashed defaults. Fixes RNBW-1457.