### PR TITLE
Android view pager set page on mount

### DIFF
--- a/src/navigation/ViewPagerAdapter.js
+++ b/src/navigation/ViewPagerAdapter.js
@@ -10,7 +10,10 @@ const { event, add } = Animated;
 const ViewPagerWrapper = forwardRef((props, fref) => {
   const ref = React.useRef();
   useEffect(
-    () => android && ref?.current?.getNode().setPageWithoutAnimation(props.page)
+    () =>
+      android && ref?.current?.getNode().setPageWithoutAnimation(props.page),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
   React.useImperativeHandle(fref, () => ref.current);
   return <AnimatedViewPager ref={ref} {...props} />;


### PR DESCRIPTION
On android I was experience some lagginess moving between screens, I was even seeing this https://linear.app/rainbow/issue/RNBW-1505/android-swipes-between-screens-by-itself most of the time.

Turns out we were calling `setPageWithoutAnimation` on top of the `ViewPager` swipe event on every swipe.

Fixes RNBW-1505