### PR TITLE
Prevent double auth on send flow

### DIFF
--- a/src/screens/SendConfirmationSheet.js
+++ b/src/screens/SendConfirmationSheet.js
@@ -290,7 +290,6 @@ export default function SendConfirmationSheet() {
       await callback();
     } catch (e) {
       logger.sentry('TX submit failed', e);
-    } finally {
       setIsAuthorizing(false);
     }
   }, [callback, canSubmit]);


### PR DESCRIPTION
We were resetting the "isAuthorizing" flag on failure AND success, so you could technically submit the same transaction twice if you tapped again before the sheet was dismissed.

Now we're only resetting on failure.

Fixes RNBW-1432
Fixes RNBW-1473