### PR TITLE
Add support for wallet_switchEthereumChain

### DIFF
--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -293,7 +293,10 @@ const listenOnNewMessages = walletConnector => (dispatch, getState) => {
     const dappName = dappNameOverride(peerMeta.url) || peerMeta.name;
     const dappUrl = peerMeta.url;
     const requestId = payload.id;
-    if (payload.method === 'wallet_addEthereumChain') {
+    if (
+      payload.method === 'wallet_addEthereumChain' ||
+      payload.method === `wallet_switchEthereumChain`
+    ) {
       const { chainId } = payload.params[0];
       const currentNetwork = ethereumUtils.getNetworkFromChainId(
         Number(walletConnector._chainId)


### PR DESCRIPTION
Since we don't really accept adding new chains, this is just an alias for `wallet_addEthereumChain`

https://ethereum-magicians.org/t/eip-3326-wallet-switchethereumchain/5471