### PR TITLE
Get rid of object_setClass in DS

### DIFF
--- a/ios/DiscoverSheet/SlackBottomSheet.h
+++ b/ios/DiscoverSheet/SlackBottomSheet.h
@@ -1,5 +1,46 @@
 #import <React/RCTBridgeModule.h>
+//#import "Rainbow-Swift.h"
 
 @interface SlackBottomSheet : NSObject <RCTBridgeModule>
 
+@end
+
+@class DiscoverSheetViewController;
+
+@interface HelperView : UIView
+- (void)setSpecialBounds:(CGRect)bounds;
+@property (nonatomic, nullable, weak) DiscoverSheetViewController *controller;
+@end
+
+@interface InvisibleView: RCTView
+- (void)jumpTo:(NSNumber*)longForm;
+@property (nonatomic, nonnull) NSNumber *topOffset;
+@property (nonatomic) BOOL isShortFormEnabled;
+@property (nonatomic, nullable) NSNumber *longFormHeight;
+@property (nonatomic, nonnull) NSNumber *cornerRadius;
+@property (nonatomic, nonnull) NSNumber *springDamping;
+@property (nonatomic, nonnull) NSNumber *transitionDuration;
+@property (nonatomic, nonnull) UIColor *backgroundColor;
+@property (nonatomic, nonnull) NSNumber *backgroundOpacity;
+@property (nonatomic) BOOL anchorModalToLongForm;
+@property (nonatomic) BOOL allowsDragToDismiss;
+@property (nonatomic) BOOL allowsTapToDismiss;
+@property (nonatomic) BOOL isUserInteractionEnabled;
+@property (nonatomic) BOOL isHapticFeedbackEnabled;
+@property (nonatomic) BOOL shouldRoundTopCorners;
+@property (nonatomic) BOOL showDragIndicator;
+@property (nonatomic) BOOL gestureEnabled;
+@property (nonatomic) BOOL blocksBackgroundTouches;
+@property (nonatomic) BOOL interactsWithOuterScrollView;
+@property (nonatomic) BOOL presentGlobally;
+@property (nonatomic) BOOL initialAnimation;
+@property (nonatomic) BOOL unmountAnimation;
+@property (nonatomic, nonnull) NSNumber *headerHeight;
+@property (nonatomic, nonnull) NSNumber *shortFormHeight;
+@property (nonatomic) BOOL startFromShortForm;
+@property (nonatomic) BOOL scrollsToTop;
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onWillTransition;
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onWillDismiss;
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onDidDismiss;
+@property (nonatomic, copy, nullable) RCTBubblingEventBlock onCrossMagicBorder;
 @end

--- a/ios/DiscoverSheet/SlackBottomSheet.h
+++ b/ios/DiscoverSheet/SlackBottomSheet.h
@@ -39,6 +39,7 @@
 @property (nonatomic, nonnull) NSNumber *shortFormHeight;
 @property (nonatomic) BOOL startFromShortForm;
 @property (nonatomic) BOOL scrollsToTop;
+@property (nonatomic, nullable) UIViewController *contoller;
 @property (nonatomic, copy, nullable) RCTBubblingEventBlock onWillTransition;
 @property (nonatomic, copy, nullable) RCTBubblingEventBlock onWillDismiss;
 @property (nonatomic, copy, nullable) RCTBubblingEventBlock onDidDismiss;

--- a/ios/DiscoverSheet/SlackBottomSheet.m
+++ b/ios/DiscoverSheet/SlackBottomSheet.m
@@ -8,9 +8,7 @@
 #import <React/RCTView.h>
 #import <objc/runtime.h>
 #import "Rainbow-Swift.h"
-
-@interface HelperView : UIView
-@end
+#import "SlackBottomSheet.h"
 
 @implementation HelperView {
   __weak RCTBridge *_bridge;
@@ -38,38 +36,6 @@
 }
 @end
 
-@interface InvisibleView: RCTView
-- (void)jumpTo:(NSNumber*)longForm;
-@property (nonatomic, nonnull) NSNumber *topOffset;
-@property (nonatomic) BOOL isShortFormEnabled;
-@property (nonatomic, nullable) NSNumber *longFormHeight;
-@property (nonatomic, nonnull) NSNumber *cornerRadius;
-@property (nonatomic, nonnull) NSNumber *springDamping;
-@property (nonatomic, nonnull) NSNumber *transitionDuration;
-@property (nonatomic, nonnull) UIColor *backgroundColor;
-@property (nonatomic, nonnull) NSNumber *backgroundOpacity;
-@property (nonatomic) BOOL anchorModalToLongForm;
-@property (nonatomic) BOOL allowsDragToDismiss;
-@property (nonatomic) BOOL allowsTapToDismiss;
-@property (nonatomic) BOOL isUserInteractionEnabled;
-@property (nonatomic) BOOL isHapticFeedbackEnabled;
-@property (nonatomic) BOOL shouldRoundTopCorners;
-@property (nonatomic) BOOL showDragIndicator;
-@property (nonatomic) BOOL gestureEnabled;
-@property (nonatomic) BOOL blocksBackgroundTouches;
-@property (nonatomic) BOOL interactsWithOuterScrollView;
-@property (nonatomic) BOOL presentGlobally;
-@property (nonatomic) BOOL initialAnimation;
-@property (nonatomic) BOOL unmountAnimation;
-@property (nonatomic, nonnull) NSNumber *headerHeight;
-@property (nonatomic, nonnull) NSNumber *shortFormHeight;
-@property (nonatomic) BOOL startFromShortForm;
-@property (nonatomic) BOOL scrollsToTop;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onWillTransition;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onWillDismiss;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onDidDismiss;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onCrossMagicBorder;
-@end
 
 @implementation InvisibleView {
   __weak RCTBridge *_bridge;
@@ -209,6 +175,7 @@
       [(HelperView *)self->addedSubview setBridge: self->_bridge];
 
       self->_contoller = [rootViewController presentPanModalWithView:self->addedSubview config:self];
+      ((HelperView *)self->addedSubview).controller = self->_contoller;
       self->_modalPresented = YES;
     });
   } else {

--- a/ios/DiscoverSheet/SlackBottomSheet.m
+++ b/ios/DiscoverSheet/SlackBottomSheet.m
@@ -44,7 +44,6 @@
   BOOL _visible;
   BOOL _modalPresented;
   BOOL _isHiding;
-  UIViewController* _contoller;
 }
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
@@ -174,8 +173,7 @@
       object_setClass(self->addedSubview, [HelperView class]);
       [(HelperView *)self->addedSubview setBridge: self->_bridge];
 
-      self->_contoller = [rootViewController presentPanModalWithView:self->addedSubview config:self];
-      ((HelperView *)self->addedSubview).controller = self->_contoller;
+      [rootViewController presentPanModalWithView:self->addedSubview config:self];
       self->_modalPresented = YES;
     });
   } else {

--- a/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
+++ b/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
@@ -39,10 +39,17 @@ extension Collection {
 
 extension UIView {
   
+  func getHelperView() -> HelperView? {
+    if self.subviews.count > 1 && self.subviews[1].subviews.count > 0 && self.subviews[1].subviews[0] is HelperView && (self.subviews[1].subviews[0] as! HelperView).controller != nil {
+      return (self.subviews[1].subviews[0] as! HelperView);
+    }
+    return nil;
+  }
+  
   @objc func betterHitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    if self.subviews.count > 1 && self.subviews[1].subviews.count > 0 && self.subviews[1].subviews[0] is HelperView {
-      let helperView: HelperView = self.subviews[1].subviews[0] as! HelperView;
-      let config = helperView.controller!.config
+    let helperView = getHelperView()
+    if helperView != nil {
+      let config = helperView!.controller!.config
       let blocksBackgroundTocuhes = config?.blocksBackgroundTouches;
       if (blocksBackgroundTocuhes! || self.subviews[1].frame.contains(point)) {
         return self.betterHitTest(point, with: event)
@@ -54,29 +61,28 @@ extension UIView {
   
   @objc func betterLayoutSubviews() {
     self.betterLayoutSubviews()
-    if self.subviews[1].subviews[0] is HelperView {
+    let helperView = getHelperView()
+    if helperView != nil {
       
-      
-      let helperView: HelperView = self.subviews[1].subviews[0] as! HelperView;
-      let config = helperView.controller!.config
+      let controller = helperView!.controller!
+      let config = controller.config
       
       let outerView = config?.value(forKey: "outerView") as? UIView
       if (!(config!.presentGlobally)) {
-        if helperView.controller!.moved {
+        if controller.moved {
           return
         }
-        helperView.controller!.moved = true
+        controller.moved = true
         removeFromSuperview()
-        let helperView: HelperView = self.subviews[1].subviews[0] as! HelperView;
         let bounds = outerView!.bounds
-        let topOffset:CGFloat = (helperView.controller!.topLayoutGuide.length ?? 0) + CGFloat(truncating: config?.topOffset as! NSNumber)
+        let topOffset:CGFloat = (controller.topLayoutGuide.length ?? 0) + CGFloat(truncating: config?.topOffset as! NSNumber)
         let newBounds = CGRect.init(x: bounds.minX, y: bounds.minY, width: bounds.width, height: bounds.height - topOffset)
-        helperView.setSpecialBounds(newBounds)
+        helperView!.setSpecialBounds(newBounds)
         outerView?.addSubview(self)
         
         let gr: UIGestureRecognizer = self.gestureRecognizers![0]
-        helperView.controller!.grdelegate = BetterGestureRecognizerDelegateAdapter.init(grd: gr.delegate!, config: config!)
-        gr.delegate = helperView.controller!.grdelegate
+        controller.grdelegate = BetterGestureRecognizerDelegateAdapter.init(grd: gr.delegate!, config: config!)
+        gr.delegate = controller.grdelegate
       }
     }
     

--- a/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
+++ b/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
@@ -29,7 +29,6 @@ class BetterGestureRecognizerDelegateAdapter: NSObject, UIGestureRecognizerDeleg
   }
 }
 
-var swizzled = false;
 
 extension Collection {
   subscript (safe index: Index) -> Element? {
@@ -290,6 +289,8 @@ class DiscoverSheetViewController: UIViewController, PanModalPresentable {
   }
 }
 
+var swizzled = false;
+
 func swizzle(uiTransitionView: UIView?) {
   if uiTransitionView == nil {
     return;
@@ -308,13 +309,13 @@ func swizzle(uiTransitionView: UIView?) {
 
 extension UIViewController {
   @objc public func presentPanModal(view: HelperView, config: InvisibleView) {
-    if self.presentedViewController != nil {
+    if self.presentedViewController != nil || !swizzled {
+      swizzle(uiTransitionView: config.window?.rootViewController?.view.superview?.superview)
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
         self.presentPanModal(view: view, config: config)
       }
     } else {
       let viewControllerToPresent: UIViewController & PanModalPresentable = DiscoverSheetViewController(config: config)
-      swizzle(uiTransitionView: config.window?.rootViewController?.view.superview?.superview)
       viewControllerToPresent.view = view
       let sourceView: UIView? = nil, sourceRect: CGRect = .zero
       self.presentPanModal(viewControllerToPresent, sourceView: sourceView, sourceRect: sourceRect)

--- a/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
+++ b/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
@@ -4,8 +4,8 @@ import PanModal
 
 class BetterGestureRecognizerDelegateAdapter: NSObject, UIGestureRecognizerDelegate {
   var grd: UIGestureRecognizerDelegate
-  var config: NSObject
-  required init(grd: UIGestureRecognizerDelegate, config: NSObject) {
+  var config: InvisibleView
+  required init(grd: UIGestureRecognizerDelegate, config: InvisibleView) {
     self.grd = grd
     self.config = config
     super.init()
@@ -13,84 +13,73 @@ class BetterGestureRecognizerDelegateAdapter: NSObject, UIGestureRecognizerDeleg
   public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
     return self.grd.gestureRecognizer!(gestureRecognizer, shouldBeRequiredToFailBy: otherGestureRecognizer)
   }
-
+  
   public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
     return self.grd.gestureRecognizer!(gestureRecognizer, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer)
   }
-
+  
   public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-
+    
     if (String(describing: type(of: otherGestureRecognizer))
-      == "UIScrollViewPanGestureRecognizer"
-      && (grd as? UIPresentationController)?.presentedViewController is PanModalPresentable && otherGestureRecognizer.view != ((grd as? UIPresentationController)?.presentedViewController as? PanModalPresentable)?.panScrollable) {
-      return self.config.value(forKey: "interactsWithOuterScrollView") as! Bool
+          == "UIScrollViewPanGestureRecognizer"
+          && (grd as? UIPresentationController)?.presentedViewController is PanModalPresentable && otherGestureRecognizer.view != ((grd as? UIPresentationController)?.presentedViewController as? PanModalPresentable)?.panScrollable) {
+      return self.config.interactsWithOuterScrollView
     }
     return false
   }
 }
 
-var moved = false
+var swizzled = false;
 
-class PossiblyTouchesPassableUIView: UIView {
-  var grdelegate: UIGestureRecognizerDelegate?
-  var config: NSObject?
-  var topLayoutGuideLength: CGFloat?
-  var oldClass: AnyClass?
-  var justModifiedClass: NSNumber?
-
-
-  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    let blocksBackgroundTocuhes = self.config?.value(forKey: "blocksBackgroundTouches") as! Bool
-    if (blocksBackgroundTocuhes || self.subviews[1].frame.contains(point)) {
-      return super.hitTest(point, with: event)
-    }
-    return nil
+extension Collection {
+  subscript (safe index: Index) -> Element? {
+    return indices.contains(index) ? self[index] : nil
   }
-  //  // I don't really want to talk about it
-  override func layoutSubviews() {
-    super.layoutSubviews()
+}
 
-    let outerView = self.config?.value(forKey: "outerView") as? UIView
-    if (!(self.config!.value(forKey: "presentGlobally") as! Bool)) {
-      if moved {
-        return
+extension UIView {
+  
+  @objc func betterHitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    if self.subviews.count > 1 && self.subviews[1].subviews.count > 0 && self.subviews[1].subviews[0] is HelperView {
+      let helperView: HelperView = self.subviews[1].subviews[0] as! HelperView;
+      let config = helperView.controller!.config
+      let blocksBackgroundTocuhes = config?.blocksBackgroundTouches;
+      if (blocksBackgroundTocuhes! || self.subviews[1].frame.contains(point)) {
+        return self.betterHitTest(point, with: event)
       }
-      moved = true
-      removeFromSuperview()
-      let helperView: UIView = self.subviews[1].subviews[0]
+      return nil
+    }
+    return self.betterHitTest(point, with: event)
+  }
+  
+  @objc func betterLayoutSubviews() {
+    self.betterLayoutSubviews()
+    if self.subviews[1].subviews[0] is HelperView {
+      
+      
+      let helperView: HelperView = self.subviews[1].subviews[0] as! HelperView;
+      let config = helperView.controller!.config
+      
+      let outerView = config?.value(forKey: "outerView") as? UIView
+      if (!(config!.presentGlobally)) {
+        if helperView.controller!.moved {
+          return
+        }
+        helperView.controller!.moved = true
+        removeFromSuperview()
+        let helperView: HelperView = self.subviews[1].subviews[0] as! HelperView;
         let bounds = outerView!.bounds
-        let topOffset:CGFloat = (topLayoutGuideLength ?? 0) + CGFloat(truncating: self.config?.value(forKey: "topOffset") as! NSNumber)
-
+        let topOffset:CGFloat = (helperView.controller!.topLayoutGuide.length ?? 0) + CGFloat(truncating: config?.topOffset as! NSNumber)
         let newBounds = CGRect.init(x: bounds.minX, y: bounds.minY, width: bounds.width, height: bounds.height - topOffset)
-        helperView.setValue(newBounds, forKeyPath: "specialBounds")
-      outerView?.addSubview(self)
-    }
-    let gr: UIGestureRecognizer = self.gestureRecognizers![0]
-    grdelegate = BetterGestureRecognizerDelegateAdapter.init(grd: gr.delegate!, config: config!)
-    gr.delegate = grdelegate
-    if outerView == nil {
-      makeOldClass()
-    }
-  }
-
-  @objc func makeOldClass() {
-    if self.oldClass != nil {
-      let oldClassMem: AnyClass = self.oldClass!
-      self.oldClass = nil
-      object_setClass(self, oldClassMem)
-    }
-  }
-
-  override func didMoveToWindow() {
-    if self.window == nil {
-      if (justModifiedClass?.isEqual(to: true))! {
-        justModifiedClass = NSNumber.init(value: false)
-        super.didMoveToWindow()
-        return
+        helperView.setSpecialBounds(newBounds)
+        outerView?.addSubview(self)
+        
+        let gr: UIGestureRecognizer = self.gestureRecognizers![0]
+        helperView.controller!.grdelegate = BetterGestureRecognizerDelegateAdapter.init(grd: gr.delegate!, config: config!)
+        gr.delegate = helperView.controller!.grdelegate
       }
-      makeOldClass()
     }
-    super.didMoveToWindow()
+    
   }
 }
 
@@ -98,15 +87,15 @@ var PossiblyTouchesPassableUITransitionView: AnyClass?  = nil;
 
 class DiscoverSheetViewController: UIViewController, PanModalPresentable {
   func hide() {
-
+    
   }
-
+  
   func unhackParent() {
-
+    
   }
-
+  
   var observation: NSKeyValueObservation?
-
+  
   @objc func jumpTo(long: NSNumber) {
     self.panModalSetNeedsLayoutUpdate()
     if (long.boolValue) {
@@ -116,27 +105,30 @@ class DiscoverSheetViewController: UIViewController, PanModalPresentable {
     }
     self.panModalSetNeedsLayoutUpdate()
   }
-
-  var config: NSObject?
+  
+  var config: InvisibleView?
+  var grdelegate: UIGestureRecognizerDelegate?
+  var topLayoutGuideLength: CGFloat?
+  var moved = false;
   var scrollView: UIScrollView?
-  convenience init(config: NSObject) {
+  convenience init(config: InvisibleView) {
     self.init()
     self.config = config
   }
-
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     hack()
   }
-
+  
   @objc func panModalSetNeedsLayoutUpdateWrapper() {
     panModalSetNeedsLayoutUpdate()
   }
-
+  
   override var preferredStatusBarStyle: UIStatusBarStyle {
     return .lightContent
   }
-
+  
   func findChildScrollViewDFS(view: UIView)-> UIScrollView? {
     var viewsToTraverse = [view]
     while !viewsToTraverse.isEmpty {
@@ -144,7 +136,7 @@ class DiscoverSheetViewController: UIViewController, PanModalPresentable {
       viewsToTraverse.removeLast()
       if last is UIScrollView {
         scrollView = (last as! UIScrollView);
-        scrollView!.scrollsToTop = self.config?.value(forKey: "scrollsToTop") as! Bool
+        scrollView!.scrollsToTop = self.config?.scrollsToTop as! Bool
         return last as? UIScrollView
       }
       last.subviews.forEach { subview in
@@ -153,138 +145,140 @@ class DiscoverSheetViewController: UIViewController, PanModalPresentable {
     }
     return nil
   }
-
+  
   @objc func setScrollsToTop(scrollsToTop: NSNumber) {
     scrollView?.scrollsToTop = scrollsToTop.boolValue;
   }
-
+  
   var panScrollable: UIScrollView? {
     return findChildScrollViewDFS(view: self.view!)
   }
-
+  
   var shortFormHeight: PanModalHeight {
-    let height: CGFloat = CGFloat(truncating: self.config?.value(forKey: "shortFormHeight") as! NSNumber)
+    let height: CGFloat = CGFloat(truncating: self.config?.shortFormHeight ?? 0)
     return isShortFormEnabled ? .contentHeight(height) : longFormHeight
   }
-
+  
   var topOffset: CGFloat {
-    let topOffset: CGFloat = CGFloat(truncating: self.config?.value(forKey: "topOffset") as! NSNumber)
+    let topOffset: CGFloat = CGFloat(truncating: self.config?.topOffset ?? 0)
     return topLayoutGuide.length + topOffset
   }
-
+  
   var isShortFormEnabledInternal = 2
   var isShortFormEnabled: Bool {
-    let startFromShortForm = self.config?.value(forKey: "startFromShortForm") as! Bool
+    let startFromShortForm = self.config?.startFromShortForm ?? false
     if isShortFormEnabledInternal > 0 && !startFromShortForm {
       isShortFormEnabledInternal -= 1
       return false
     }
-    return self.config?.value(forKey: "isShortFormEnabled") as! Bool
+    return self.config?.isShortFormEnabled ?? false
   }
-
+  
   var longFormHeight: PanModalHeight {
-    if self.config?.value(forKey: "longFormHeight") == nil {
+    if self.config?.longFormHeight == nil {
       return .maxHeight
     }
-    return .contentHeight(CGFloat(truncating: self.config?.value(forKey: "longFormHeight") as! NSNumber))
+    return .contentHeight(CGFloat(truncating: self.config?.longFormHeight ?? 0))
   }
-
+  
   var cornerRadius: CGFloat {
-    return CGFloat(truncating: self.config?.value(forKey: "cornerRadius") as! NSNumber)
+    return CGFloat(truncating: self.config?.cornerRadius ?? 0)
   }
-
+  
   var springDamping: CGFloat {
-    return CGFloat(truncating: self.config?.value(forKey: "springDamping") as! NSNumber)
+    return CGFloat(truncating: self.config?.springDamping ?? 0)
   }
-
+  
   var isInitialAnimation = 3
-
+  
   var transitionDuration: Double {
-    if isInitialAnimation > 0 && !(self.config?.value(forKey: "initialAnimation") as! Bool)
+    if isInitialAnimation > 0 && !(self.config?.initialAnimation ?? false)
     {
       isInitialAnimation -= 1
       return 0.0
     }
-    return Double(truncating: self.config?.value(forKey: "transitionDuration") as! NSNumber)
+    return Double(truncating: self.config?.transitionDuration ?? 0)
   }
-
+  
   var panModalBackgroundColor: UIColor {
-    return UIColor.black.withAlphaComponent(CGFloat(truncating: self.config?.value(forKey: "backgroundOpacity") as! NSNumber))
-
+    return UIColor.black.withAlphaComponent(CGFloat(truncating: self.config?.backgroundOpacity ?? 0))
+    
   }
   var anchorModalToLongForm: Bool {
-    return self.config?.value(forKey: "anchorModalToLongForm") as! Bool
+    return self.config?.anchorModalToLongForm ?? false
   }
-
+  
   var allowsDragToDismiss: Bool {
-    return self.config?.value(forKey: "allowsDragToDismiss") as! Bool
+    return self.config?.allowsDragToDismiss ?? false
   }
-
+  
   var allowsTapToDismiss: Bool {
-    return self.config?.value(forKey: "allowsTapToDismiss") as! Bool
+    return self.config?.allowsTapToDismiss ?? false
   }
-
+  
   var isUserInteractionEnabled: Bool {
-    return self.config?.value(forKey: "isUserInteractionEnabled") as! Bool  }
-
+    return self.config?.isUserInteractionEnabled ?? false  }
+  
   var isHapticFeedbackEnabled: Bool {
-    return self.config?.value(forKey: "isHapticFeedbackEnabled") as! Bool  }
-
+    return self.config?.isHapticFeedbackEnabled ?? false  }
+  
   var shouldRoundTopCorners: Bool {
     hack()
-    return self.config?.value(forKey: "shouldRoundTopCorners") as! Bool
+    return self.config?.shouldRoundTopCorners ?? false
   }
-
+  
   override func viewDidLayoutSubviews() {
     hack()
   }
-
+  
   func updatePostion(position: CGFloat, newPostion: CGFloat) {
     if (position < 80.0 && newPostion >= 80.0) {
       self.config?.performSelector(inBackground: Selector.init(("callOnCrossMagicBoderFromBottom")), with: nil)
     }
-
+    
     if (position >= 80.0 && newPostion < 80.0) {
       self.config?.performSelector(inBackground: Selector.init(("callOnCrossMagicBoderFromTop")), with: nil)
     }
   }
-
+  
   var hacked = false
-
+  
   public func hack() {
     let pview = view.superview!.superview!
-    if !(pview is PossiblyTouchesPassableUIView && !hacked) {
-      let oldClass: AnyClass = type(of: pview)
-      object_setClass(pview, PossiblyTouchesPassableUIView.self)
-      hacked = true;
-      (pview as! PossiblyTouchesPassableUIView).config = self.config
-      (pview as! PossiblyTouchesPassableUIView).topLayoutGuideLength = self.topLayoutGuide.length
-      (pview as! PossiblyTouchesPassableUIView).oldClass = oldClass
-      (pview as! PossiblyTouchesPassableUIView).justModifiedClass = NSNumber.init(value: true)
+    let oldClass: AnyClass = type(of: pview)
+    if !swizzled {
+      swizzled = true;
+      let originalMethodLS = class_getInstanceMethod(oldClass, #selector(UIView.layoutSubviews))
+      let swizzledMethodLS = class_getInstanceMethod(oldClass, #selector(UIView.betterLayoutSubviews))
+      method_exchangeImplementations(originalMethodLS!, swizzledMethodLS!)
+      let originalMethodHT = class_getInstanceMethod(oldClass, #selector(UIView.hitTest(_:with:)))
+      let swizzledMethodHT = class_getInstanceMethod(oldClass, #selector(UIView.betterHitTest(_:with:)))
+      method_exchangeImplementations(originalMethodHT!, swizzledMethodHT!)
+    }
+    if !hacked {
       observation = (self.presentationController as! PanModalPresentationController).observe(\.yPosition, options: [.old, .new]) { object, change in
-        self.updatePostion(position: change.oldValue!, newPostion: change.newValue!)
-      }
+        self.updatePostion(position: change.oldValue!, newPostion: change.newValue!) }
     }
   }
-
+  
   var showDragIndicator: Bool {
-    return self.config?.value(forKey: "showDragIndicator") as! Bool
+    return self.config?.showDragIndicator ?? false
   }
-
+  
   var scrollIndicatorInsets: UIEdgeInsets {
     let bottomOffset = presentingViewController?.bottomLayoutGuide.length ?? 0
     return UIEdgeInsets(top: 0, left: 0, bottom: bottomOffset, right: 0)
   }
-
-
+  
+  
   func shouldPrioritize(panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
-    let headerHeight: CGFloat = CGFloat(truncating: self.config?.value(forKey: "headerHeight") as! NSNumber)
+    let headerHeight: CGFloat = CGFloat(truncating: self.config?.headerHeight ?? 0)
     let location = panModalGestureRecognizer.location(in: view)
     return location.y < headerHeight
   }
-
+  
   func willTransition(to state: PanModalPresentationController.PresentationState) {
-    if self.config?.value(forKey: "onWillTransition") != nil {
+    if self.config?.onWillTransition != nil {
       if state == .longForm {
         self.config?.performSelector(inBackground: Selector.init(("callWillTransitionLong")), with: nil)
       } else {
@@ -292,15 +286,15 @@ class DiscoverSheetViewController: UIViewController, PanModalPresentable {
       }
     }
   }
-
+  
   func panModalWillDismiss() {
-    if self.config?.value(forKey: "onWillDismiss") != nil {
+    if self.config?.onWillDismiss != nil {
       self.config?.performSelector(inBackground: Selector.init(("callWillDismiss")), with: nil)
     }
   }
-
+  
   func panModalDidDismiss() {
-    if self.config?.value(forKey: "onDidDismiss") != nil {
+    if self.config?.onDidDismiss != nil {
       self.config?.performSelector(inBackground: Selector.init(("callDidDismiss")), with: nil)
     }
   }
@@ -309,13 +303,12 @@ class DiscoverSheetViewController: UIViewController, PanModalPresentable {
 
 extension UIViewController {
   @objc public func presentPanModal(view: UIView, config: UIView) -> UIViewController? {
-    moved = false;
     if self.presentedViewController != nil {
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
         self.presentPanModal(view: view, config: config)
       }
     } else {
-      let viewControllerToPresent: UIViewController & PanModalPresentable = DiscoverSheetViewController(config: config)
+      let viewControllerToPresent: UIViewController & PanModalPresentable = DiscoverSheetViewController(config: config as! InvisibleView)
       viewControllerToPresent.view = view
       let sourceView: UIView? = nil, sourceRect: CGRect = .zero
       self.presentPanModal(viewControllerToPresent, sourceView: sourceView, sourceRect: sourceRect)

--- a/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
+++ b/ios/DiscoverSheet/UIViewController+PanModalPresenter.swift
@@ -39,7 +39,10 @@ extension Collection {
 extension UIView {
   
   func getHelperView() -> HelperView? {
-    if self.subviews.count > 1 && self.subviews[1].subviews.count > 0 && self.subviews[1].subviews[0] is HelperView && (self.subviews[1].subviews[0] as! HelperView).controller != nil {
+    if self.subviews.count > 1 &&
+        self.subviews[1].subviews.count > 0 &&
+        self.subviews[1].subviews[0] is HelperView &&
+        (self.subviews[1].subviews[0] as! HelperView).controller != nil {
       return (self.subviews[1].subviews[0] as! HelperView);
     }
     return nil;

--- a/ios/TransactionListView.swift
+++ b/ios/TransactionListView.swift
@@ -40,8 +40,8 @@ class TransactionListView: UIView, UITableViewDelegate, UITableViewDataSource {
   func activelyWaitToPresentDiscoverSheetBack(controller: DiscoverSheetViewController) {
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
       if (self.window?.rootViewController?.presentedViewController == nil) {
+        controller.moved = false;
         controller.hacked = false;
-        moved = false;
         self.window?.rootViewController?.present(controller, animated: true)
       } else {
         self.activelyWaitToPresentDiscoverSheetBack(controller: controller)

--- a/src/react-native-cool-modals/ios/RNCMScreenStack.m
+++ b/src/react-native-cool-modals/ios/RNCMScreenStack.m
@@ -241,9 +241,9 @@
   UIViewController *someViewController = changeRootController.presentedViewController;
   while (someViewController != nil) {
     UIView *view = someViewController.view.superview.superview;
-    if ([view isKindOfClass: PossiblyTouchesPassableUIView.class]) {
-      [((PossiblyTouchesPassableUIView*) view) makeOldClass];
-    }
+//    if ([view isKindOfClass: PossiblyTouchesPassableUIView.class]) {
+//    //  [((PossiblyTouchesPassableUIView*) view) makeOldClass];
+//    }
     someViewController = someViewController.presentedViewController;
   }
   

--- a/src/react-native-cool-modals/ios/RNCMScreenStack.m
+++ b/src/react-native-cool-modals/ios/RNCMScreenStack.m
@@ -241,9 +241,6 @@
   UIViewController *someViewController = changeRootController.presentedViewController;
   while (someViewController != nil) {
     UIView *view = someViewController.view.superview.superview;
-//    if ([view isKindOfClass: PossiblyTouchesPassableUIView.class]) {
-//    //  [((PossiblyTouchesPassableUIView*) view) makeOldClass];
-//    }
     someViewController = someViewController.presentedViewController;
   }
   


### PR DESCRIPTION
This commit should be conceptually no-op.

What do I do?
- clean-up. I got rid of many selectors (value for key) in favor of regular properties access. This should be better in type safety and probably allow for some performance enhancements. 
- Get rid of `object_setClass`. This is most likely the most reason for `NSInternalInconsistencyException` crashes. 
Currently, we use `object_setClass` for setting a new class for `UITransitionView`. This class is not public in UIKit. so `PossiblyTouchesPassableUIView` is not inheriting from `UITransitionView` and that is why we have this error. In order to fix this, I was initially trying to remove this change quickly in runtime but looks like this was not sufficient.
In this PR I decided to use a bit different approach. Instead of using `object_setClass`, I used method swizzling that is replacing the implementation for whole `UIView` (however, making this no-op in every other use-case except Discover Sheet). As the result, we should not have `NSInternalInconsistencyException`.