### PR TITLE
improve wc requests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -219,11 +219,7 @@ class App extends Component {
 
   handleAppStateChange = async nextAppState => {
     // Restore WC connectors when going from BG => FG
-    if (
-      ios &&
-      this.state.appState === 'background' &&
-      nextAppState === 'active'
-    ) {
+    if (this.state.appState === 'background' && nextAppState === 'active') {
       store.dispatch(walletConnectLoadState());
     }
     this.setState({ appState: nextAppState });

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -420,25 +420,38 @@ const listenOnNewMessages = walletConnector => (dispatch, getState) => {
 };
 
 export const walletConnectLoadState = () => async (dispatch, getState) => {
+  while (!getState().walletconnect.walletConnectors) {
+    await delay(300);
+  }
   const { walletConnectors } = getState().walletconnect;
   let newWalletConnectors = {};
   try {
-    if (!isEmpty(walletConnectors)) {
-      // Clear the event listeners before reconnecting
-      // to prevent having the same callbacks
-      Object.keys(walletConnectors).forEach(key => {
-        const connector = walletConnectors[key];
-        connector._eventManager = null;
-      });
-    }
-
+    // if (!isEmpty(walletConnectors)) {
+    //   // Clear the event listeners before reconnecting
+    //   // to prevent having the same callbacks
+    //   Object.keys(walletConnectors).forEach(key => {
+    //     const connector = walletConnectors[key];
+    //     connector._eventManager = null;
+    //   });
+    // }
     const allSessions = await getAllValidWalletConnectSessions();
 
     const { clientMeta, push } = await getNativeOptions();
 
     newWalletConnectors = mapValues(allSessions, session => {
-      const walletConnector = new WalletConnect({ clientMeta, session }, push);
-      return dispatch(listenOnNewMessages(walletConnector));
+      const connector = walletConnectors[session.peerId];
+      const connectorConnected = connector?._transport.connected;
+      if (!connectorConnected) {
+        if (connector?._eventManager) {
+          connector._eventManager = null;
+        }
+        const walletConnector = new WalletConnect(
+          { clientMeta, session },
+          push
+        );
+        return dispatch(listenOnNewMessages(walletConnector));
+      }
+      return connector;
     });
   } catch (error) {
     analytics.track('Error on walletConnectLoadState', {

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -426,16 +426,7 @@ export const walletConnectLoadState = () => async (dispatch, getState) => {
   const { walletConnectors } = getState().walletconnect;
   let newWalletConnectors = {};
   try {
-    // if (!isEmpty(walletConnectors)) {
-    //   // Clear the event listeners before reconnecting
-    //   // to prevent having the same callbacks
-    //   Object.keys(walletConnectors).forEach(key => {
-    //     const connector = walletConnectors[key];
-    //     connector._eventManager = null;
-    //   });
-    // }
     const allSessions = await getAllValidWalletConnectSessions();
-
     const { clientMeta, push } = await getNativeOptions();
 
     newWalletConnectors = mapValues(allSessions, session => {


### PR DESCRIPTION
this PR attempts to improve the interaction of wallet connect requests with the app by only recreating the WC `connectors` that are disconnected on `appStateChange` rather than recreating all connectors every time going from `background` to `active`

1 .requests lost going to the app, signing sheets not being displayed
2. requests lost on the app going to background (last part on before video)
3. dapps not reacting to signing interactions of the user on rainbow (sec 12 on before video)

videos on linear
https://linear.app/rainbow/issue/RNBW-1562/improve-requests-handlingresponse-time

Fixes RNBW-1562