### PR TITLE
handle discover no charts scenario 

### DIFF
--- a/src/components/discover-sheet/PulseIndexSection.js
+++ b/src/components/discover-sheet/PulseIndexSection.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import React, { Fragment, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
@@ -8,7 +7,6 @@ import { ButtonPressAnimation } from '../animations';
 import { CoinIcon } from '../coin-icon';
 import { Column, Row } from '../layout';
 import { Text } from '../text';
-import ChartTypes from '@rainbow-me/helpers/chartTypes';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import { DPI_ADDRESS } from '@rainbow-me/references';
@@ -44,14 +42,6 @@ const PulseIndex = () => {
     genericAssets,
   }));
 
-  const charts = useSelector(({ charts: { charts } }) => charts);
-
-  const chartPriceDataForDPI = get(
-    charts,
-    `[${DPI_ADDRESS}][${ChartTypes.month}][0][1]`,
-    0
-  );
-
   const { nativeCurrency, nativeCurrencySymbol } = useAccountSettings();
   const item = useMemo(() => {
     const asset = genericAssets[DPI_ADDRESS];
@@ -82,7 +72,6 @@ const PulseIndex = () => {
   );
 
   if (!item) return null;
-  if (!chartPriceDataForDPI) return null;
 
   return (
     <Fragment>

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -320,7 +320,7 @@ export default function useUniswapPools(sortField, sortDirection, token) {
       client: uniswapClient,
       fetchPolicy: 'no-cache',
       pollInterval: UNISWAP_QUERY_INTERVAL,
-      skip: !priceOfEther || !ethereumPriceOneMonthAgo,
+      skip: !priceOfEther,
       variables: {
         address: token === ETH_ADDRESS ? WETH_ADDRESS : token,
       },
@@ -359,7 +359,7 @@ export default function useUniswapPools(sortField, sortDirection, token) {
   }, [ethereumPriceOneMonthAgo, pairsFromQuery, priceOfEther]);
 
   useEffect(() => {
-    if (pairsFromQuery && priceOfEther > 0 && ethereumPriceOneMonthAgo > 0) {
+    if (pairsFromQuery && priceOfEther > 0) {
       fetchPairsData();
     }
   }, [fetchPairsData, priceOfEther, ethereumPriceOneMonthAgo, pairsFromQuery]);


### PR DESCRIPTION
We are currently disabling DPI and pools info if we dont have chart info. We can still show both without. This also fixes CI if we arnt getting charts info 👼

DPI: shows without chart like the rest of the expanded states
Pools: we already had logic in place to handle removing the 30d movers section so we dont need to skip the query

before: https://cloud.skylarbarrera.com/Screen-Shot-2021-08-31-22-40-45.31.png
after: https://cloud.skylarbarrera.com/Screen-Recording-2021-08-31-23-34-47.mp4