### PR TITLE
useUniswapAssetsInWallet performance improvement

### DIFF
--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -260,7 +260,7 @@ export default function ChartExpandedState({ asset }) {
     ),
   });
 
-  const { uniswapAssetsInWallet } = useUniswapAssetsInWallet();
+  const uniswapAssetsInWallet = useUniswapAssetsInWallet();
   const showSwapButton = find(uniswapAssetsInWallet, [
     'uniqueId',
     asset?.uniqueId,

--- a/src/hooks/useAsset.js
+++ b/src/hooks/useAsset.js
@@ -10,7 +10,7 @@ export default function useAsset(asset) {
   const genericAssets = useSelector(
     ({ data: { genericAssets } }) => genericAssets
   );
-  const { uniswapAssetsInWallet } = useUniswapAssetsInWallet();
+  const uniswapAssetsInWallet = useUniswapAssetsInWallet();
 
   return useMemo(() => {
     if (!asset) return null;

--- a/src/hooks/useUniswapAssetsInWallet.js
+++ b/src/hooks/useUniswapAssetsInWallet.js
@@ -9,12 +9,9 @@ const networkSelector = state => state.settings.network;
 
 const withUniswapAssetsInWallet = (network, assetData, uniswapAllPairs) => {
   const { allAssets } = assetData;
-  const uniswapAssetsInWallet =
-    network === NetworkTypes.mainnet
-      ? filter(allAssets, ({ address }) => uniswapAllPairs[address])
-      : allAssets;
-
-  return { uniswapAssetsInWallet };
+  return network === NetworkTypes.mainnet
+    ? filter(allAssets, ({ address }) => uniswapAllPairs[address])
+    : allAssets;
 };
 
 const withUniswapAssetsInWalletSelector = createSelector(

--- a/src/hooks/useUniswapAssetsInWallet.js
+++ b/src/hooks/useUniswapAssetsInWallet.js
@@ -1,4 +1,4 @@
-import { filter, keys } from 'lodash';
+import { filter } from 'lodash';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { sortAssetsByNativeAmountSelector } from '@rainbow-me/helpers/assetSelectors';
@@ -9,16 +9,13 @@ const networkSelector = state => state.settings.network;
 
 const filterUniswapAssetsByAvailability = uniswapAssetAddresses => ({
   address,
-}) => uniswapAssetAddresses.includes(address);
+}) => uniswapAssetAddresses[address];
 
 const withUniswapAssetsInWallet = (network, assetData, uniswapAllPairs) => {
   const { allAssets } = assetData;
   const uniswapAssetsInWallet =
     network === NetworkTypes.mainnet
-      ? filter(
-          allAssets,
-          filterUniswapAssetsByAvailability(keys(uniswapAllPairs))
-        )
+      ? filter(allAssets, filterUniswapAssetsByAvailability(uniswapAllPairs))
       : allAssets;
 
   return { uniswapAssetsInWallet };

--- a/src/hooks/useUniswapAssetsInWallet.js
+++ b/src/hooks/useUniswapAssetsInWallet.js
@@ -7,15 +7,11 @@ import NetworkTypes from '@rainbow-me/networkTypes';
 const uniswapAllTokensSelector = state => state.uniswap.allTokens;
 const networkSelector = state => state.settings.network;
 
-const filterUniswapAssetsByAvailability = uniswapAssetAddresses => ({
-  address,
-}) => uniswapAssetAddresses[address];
-
 const withUniswapAssetsInWallet = (network, assetData, uniswapAllPairs) => {
   const { allAssets } = assetData;
   const uniswapAssetsInWallet =
     network === NetworkTypes.mainnet
-      ? filter(allAssets, filterUniswapAssetsByAvailability(uniswapAllPairs))
+      ? filter(allAssets, ({ address }) => uniswapAllPairs[address])
       : allAssets;
 
   return { uniswapAssetsInWallet };

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -102,7 +102,7 @@ export default function CurrencySelectModal() {
     loadingAllTokens,
     updateFavorites,
   } = useUniswapAssets();
-  const { uniswapAssetsInWallet } = useUniswapAssetsInWallet();
+  const uniswapAssetsInWallet = useUniswapAssetsInWallet();
 
   const currencyList = useMemo(() => {
     let filteredList = [];


### PR DESCRIPTION
@jinchung noticed we were calling `includes` on the all assets list every time this hook was being called. 

doing that, `uniswapAssetsInWallet` was being returned in 100 ms, now is 0 - 1 ms

as we are calling that in many places, and more importantly being called a lot while the assets are being loaded (around 40 times) this should improve overall performance of the app

@jinchung  🐐 