### PR TITLE
Removing unused calculations for pools related hooks

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -55,7 +55,6 @@ export const UNISWAP_PAIR_DATA_QUERY = (pairAddress, block) => {
       totalSupply
       trackedReserveETH
       volumeUSD
-      untrackedVolumeUSD
   }
   query pairs {
     pairs(${
@@ -109,7 +108,6 @@ export const UNISWAP_PAIRS_BULK_QUERY = gql`
     totalSupply
     trackedReserveETH
     volumeUSD
-    untrackedVolumeUSD
   }
   query pairs($allPairs: [Bytes]!) {
     pairs(
@@ -144,7 +142,6 @@ export const UNISWAP_PAIRS_HISTORICAL_BULK_QUERY = gql`
       token1 {
         derivedETH
       }
-      untrackedVolumeUSD
     }
   }
 `;

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -31,19 +31,17 @@ export const SORT_DIRECTION = {
 
 const getTimestampsForChanges = () => {
   const t1 = getUnixTime(startOfMinute(sub(Date.now(), { days: 1 })));
-  const t2 = getUnixTime(startOfMinute(sub(Date.now(), { days: 2 })));
-  const t3 = getUnixTime(startOfMinute(sub(Date.now(), { months: 1 })));
-  return [t1, t2, t3];
+  const t2 = getUnixTime(startOfMinute(sub(Date.now(), { months: 1 })));
+  return [t1, t2];
 };
 
 async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
   try {
-    const [t1, t2, t3] = getTimestampsForChanges();
-    const [
-      { number: b1 },
-      { number: b2 },
-      { number: b3 },
-    ] = await getBlocksFromTimestamps([t1, t2, t3]);
+    const [t1, t2] = getTimestampsForChanges();
+    const [{ number: b1 }, { number: b2 }] = await getBlocksFromTimestamps([
+      t1,
+      t2,
+    ]);
 
     const current = await uniswapClient.query({
       fetchPolicy: 'no-cache',
@@ -53,8 +51,8 @@ async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
       },
     });
 
-    const [oneDayResult, twoDayResult, oneMonthResult] = await Promise.all(
-      [b1, b2, b3].map(async block => {
+    const [oneDayResult, oneMonthResult] = await Promise.all(
+      [b1, b2].map(async block => {
         const result = uniswapClient.query({
           fetchPolicy: 'no-cache',
           query: UNISWAP_PAIRS_HISTORICAL_BULK_QUERY,
@@ -68,10 +66,6 @@ async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
     );
 
     const oneDayData = oneDayResult?.data?.pairs.reduce((obj, cur) => {
-      return { ...obj, [cur.id]: cur };
-    }, {});
-
-    const twoDayData = twoDayResult?.data?.pairs.reduce((obj, cur) => {
       return { ...obj, [cur.id]: cur };
     }, {});
 
@@ -91,19 +85,11 @@ async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
             });
             oneDayHistory = newData?.data?.pairs[0];
           }
-          let twoDayHistory = twoDayData?.[pair.id];
-          if (!twoDayHistory) {
-            const newData = await uniswapClient.query({
-              fetchPolicy: 'no-cache',
-              query: UNISWAP_PAIR_DATA_QUERY(pair.id, b2),
-            });
-            twoDayHistory = newData?.data?.pairs[0];
-          }
           let oneMonthHistory = oneMonthData?.[pair.id];
           if (!oneMonthHistory) {
             const newData = await uniswapClient.query({
               fetchPolicy: 'no-cache',
-              query: UNISWAP_PAIR_DATA_QUERY(pair.id, b3),
+              query: UNISWAP_PAIR_DATA_QUERY(pair.id, b2),
             });
             oneMonthHistory = newData?.data?.pairs[0];
           }
@@ -111,7 +97,6 @@ async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
           data = parseData(
             data,
             oneDayHistory,
-            twoDayHistory,
             oneMonthHistory,
             ethPrice,
             ethPriceOneMonthAgo,
@@ -129,7 +114,6 @@ async function getBulkPairData(pairList, ethPrice, ethPriceOneMonthAgo) {
 function parseData(
   data,
   oneDayData,
-  twoDayData,
   oneMonthData,
   ethPrice,
   ethPriceOneMonthAgo,

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -142,13 +142,6 @@ function parseData(
     oneDayData?.volumeUSD ? oneDayData.volumeUSD : 0,
     twoDayData?.volumeUSD ? twoDayData.volumeUSD : 0
   );
-  const [oneDayVolumeUntracked, volumeChangeUntracked] = get2DayPercentChange(
-    newData?.untrackedVolumeUSD,
-    oneDayData?.untrackedVolumeUSD
-      ? parseFloat(oneDayData?.untrackedVolumeUSD)
-      : 0,
-    twoDayData?.untrackedVolumeUSD ? twoDayData?.untrackedVolumeUSD : 0
-  );
 
   newData.profit30d = calculateProfit30d(
     data,
@@ -160,8 +153,6 @@ function parseData(
   // set volume properties
   newData.oneDayVolumeUSD = parseFloat(oneDayVolumeUSD);
   newData.volumeChangeUSD = volumeChangeUSD;
-  newData.oneDayVolumeUntracked = oneDayVolumeUntracked;
-  newData.volumeChangeUntracked = volumeChangeUntracked;
 
   // set liquidity properties
   newData.trackedReserveUSD = newData.trackedReserveETH * ethPrice;

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -174,32 +174,6 @@ function parseData(
 export const getOneDayVolume = (valueNow, value24HoursAgo) =>
   parseFloat(valueNow) - parseFloat(value24HoursAgo);
 
-/**
- * gets the amoutn difference plus the % change in change itself (second order change)
- * @param {*} valueNow
- * @param {*} value24HoursAgo
- * @param {*} value48HoursAgo
- */
-export const get2DayPercentChange = (
-  valueNow,
-  value24HoursAgo,
-  value48HoursAgo
-) => {
-  // get volume info for both 24 hour periods
-  const currentChange = parseFloat(valueNow) - parseFloat(value24HoursAgo);
-  const previousChange =
-    parseFloat(value24HoursAgo) - parseFloat(value48HoursAgo);
-
-  const adjustedPercentChange =
-    (parseFloat(currentChange - previousChange) / parseFloat(previousChange)) *
-    100;
-
-  if (isNaN(adjustedPercentChange) || !isFinite(adjustedPercentChange)) {
-    return [currentChange, 0];
-  }
-  return [currentChange, adjustedPercentChange];
-};
-
 export const calculateProfit30d = (
   data,
   valueOneMonthAgo,

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -137,10 +137,9 @@ function parseData(
 ) {
   const newData = { ...data };
   // get volume changes
-  const [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
+  const oneDayVolumeUSD = getOneDayVolume(
     newData?.volumeUSD,
-    oneDayData?.volumeUSD ? oneDayData.volumeUSD : 0,
-    twoDayData?.volumeUSD ? twoDayData.volumeUSD : 0
+    oneDayData?.volumeUSD ? oneDayData.volumeUSD : 0
   );
 
   newData.profit30d = calculateProfit30d(
@@ -152,7 +151,6 @@ function parseData(
 
   // set volume properties
   newData.oneDayVolumeUSD = parseFloat(oneDayVolumeUSD);
-  newData.volumeChangeUSD = volumeChangeUSD;
 
   // set liquidity properties
   newData.trackedReserveUSD = newData.trackedReserveETH * ethPrice;

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -198,6 +198,9 @@ function parseData(
   };
 }
 
+export const getOneDayVolume = (valueNow, value24HoursAgo) =>
+  parseFloat(valueNow) - parseFloat(value24HoursAgo);
+
 /**
  * gets the amoutn difference plus the % change in change itself (second order change)
  * @param {*} valueNow


### PR DESCRIPTION
It looks like there were multiple places where we were using `get2DayPercentChange` but didn't actually need the entire function calculated.

For testing: confirming that nothing breaks for pools related data (expanded state, Discover, etc)