### PR TITLE
fix validation of ENS names by removing TLD check

### DIFF
--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -7,9 +7,6 @@ import {
 } from '@rainbow-me/handlers/web3';
 import { sanitizeSeedPhrase } from '@rainbow-me/utils';
 
-// Currently supported Top Level Domains from ENS
-const supportedTLDs = ['eth', 'test', 'xyz', 'luxe', 'kred', 'club', 'art'];
-
 /**
  * @desc validate email
  * @param  {String}  email
@@ -22,11 +19,7 @@ export const isValidEmail = email =>
 
 export const isENSAddressFormat = address => {
   const parts = address && address.split('.');
-  if (
-    !parts ||
-    parts.length === 1 ||
-    !supportedTLDs.includes(parts[parts.length - 1])
-  ) {
+  if (!parts || parts.length === 1) {
     return false;
   }
   return true;


### PR DESCRIPTION
as far as i know, it's possible to register an ENS for many TLDs, not just a whitelist. this pull request removes the TLD check for ENS names to enable the whole wide world of ENS names!