### PR TITLE
Separate out explorer init for L2

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,7 +47,7 @@ import * as keychain from './model/keychain';
 import { loadAddress } from './model/wallet';
 import { Navigation } from './navigation';
 import RoutesComponent from './navigation/Routes';
-import { explorerInit } from './redux/explorer';
+import { explorerInitL2 } from './redux/explorer';
 import { requestsForTopic } from './redux/requests';
 import store from './redux/store';
 import { walletConnectLoadState } from './redux/walletconnect';
@@ -238,7 +238,7 @@ class App extends Component {
     logger.log('Reloading all data from zerion in 10!');
     setTimeout(() => {
       logger.log('Reloading all data from zerion NOW!');
-      store.dispatch(explorerInit());
+      store.dispatch(explorerInitL2());
     }, 10000);
   };
 

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -410,7 +410,18 @@ const listenOnAssetMessages = socket => dispatch => {
   });
 };
 
-const listenOnAddressMessages = socket => (dispatch, getState) => {
+export const explorerInitL2 = () => (dispatch, getState) => {
+  if (getState().settings.network === NetworkTypes.mainnet) {
+    // Start watching arbitrum assets
+    dispatch(arbitrumExplorerInit());
+    // Start watching optimism assets
+    dispatch(optimismExplorerInit());
+    // Start watching polygon assets
+    dispatch(polygonExplorerInit());
+  }
+};
+
+const listenOnAddressMessages = socket => dispatch => {
   socket.on(messages.ADDRESS_PORTFOLIO.RECEIVED, message => {
     dispatch(portfolioReceived(message));
   });
@@ -442,14 +453,7 @@ const listenOnAddressMessages = socket => (dispatch, getState) => {
         '😬 Cancelling fallback data provider listener. Zerion is good!'
       );
       dispatch(disableFallbackIfNeeded());
-      if (getState().settings.network === NetworkTypes.mainnet) {
-        // Start watching arbitrum assets
-        dispatch(arbitrumExplorerInit());
-        // Start watching optimism assets
-        dispatch(optimismExplorerInit());
-        // Start watching polygon assets
-        dispatch(polygonExplorerInit());
-      }
+      dispatch(explorerInitL2());
     }
   });
 


### PR DESCRIPTION
In App.js, we have a `transactionConfirmed` event that gets triggered on pending transactions getting confirmed which was calling `explorerInit` - however we only need this triggered for fetching L2 balances, so now we are splitting L2 explorer init vs regular explorer init.