### PR TITLE
fix NaN balances

### DIFF
--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -122,7 +122,7 @@ const withBalanceSavingsSection = savings => {
     } = asset;
     totalUnderlyingNativeValue = add(
       totalUnderlyingNativeValue,
-      underlyingBalanceNativeValue
+      underlyingBalanceNativeValue || 0
     );
     const lifetimeSupplyInterestAccruedNative = lifetimeSupplyInterestAccrued
       ? multiply(lifetimeSupplyInterestAccrued, underlyingPrice)


### PR DESCRIPTION
I was able to repro this on latest develop

https://github.com/rainbow-me/rainbow/compare/@esteban/fix-wallet-section?expand=1#diff-c4a5980e4dbe37999dd9bbabbf92f69e7d2a05fbf3b667f45abf662402858f44R120 is undefined on `asset` 

for ex.
``` 
{"cToken": {"address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643", "decimals": 8, "name": "Compound DAI", "symbol": "cDAI"}, "exchangeRate": "0.021539942964407968", "supplyRate": "0.0236141697234528", "underlying": {"address": "0x6b175474e89094c44da98b954eedeac495271d0f", "decimals": 18, "name": "Dai", "symbol": "DAI"}}
```
making https://github.com/rainbow-me/rainbow/compare/@esteban/fix-wallet-section?expand=1#diff-c4a5980e4dbe37999dd9bbabbf92f69e7d2a05fbf3b667f45abf662402858f44R213 resolve to NaN
