### PR TITLE
support new ENS images

### DIFF
--- a/src/components/unique-token/UniqueTokenImage.js
+++ b/src/components/unique-token/UniqueTokenImage.js
@@ -55,17 +55,22 @@ const UniqueTokenImage = ({
   const { isTinyPhone } = useDimensions();
   const isENS =
     toLower(item.asset_contract.address) === toLower(ENS_NFT_CONTRACT_ADDRESS);
-  const image = isENS ? `${item.image_url}=s1` : imageUrl;
+  const isSVG = isSupportedUriExtension(imageUrl, ['.svg']);
+  const image = isENS && !isSVG ? `${item.image_url}=s1` : imageUrl;
   const [error, setError] = useState(null);
   const handleError = useCallback(error => setError(error), [setError]);
   const { isDarkMode, colors } = useTheme();
-  const isSVG = isSupportedUriExtension(imageUrl, ['.svg']);
   const [loadedImg, setLoadedImg] = useState(false);
   const onLoad = useCallback(() => setLoadedImg(true), [setLoadedImg]);
   const remoteSvgStyle = useMemo(() => {
     // I know... This shit is mad weird :|
-    return { height: size + 0.1, width: size + 0.1 };
-  }, [size]);
+    // I know... This shit even weirder but it's ENS's fault :/
+    const style =
+      isENS && isSVG
+        ? { height: size * 1.1 + 0.1, width: size * 1.1 + 0.1 }
+        : { height: size + 0.1, width: size + 0.1 };
+    return style;
+  }, [isENS, isSVG, size]);
 
   return (
     <Centered backgroundColor={backgroundColor} style={position.coverAsObject}>
@@ -84,7 +89,7 @@ const UniqueTokenImage = ({
             source={{ uri: image }}
             style={position.coverAsObject}
           >
-            {isENS && (
+            {isENS && !isSVG && (
               <ENSText isTinyPhone={isTinyPhone} small={small}>
                 {item.name}
               </ENSText>


### PR DESCRIPTION
the plan is to show the new images if they exist but otherwise we show our fallback

also the ENS svg's have formatting issues so we zoom them in so they don't look like 💩

PoW
<img width="403" alt="Screen Shot 2021-10-13 at 4 41 37 PM" src="https://user-images.githubusercontent.com/29204161/137223004-af72d369-db51-4d55-bac5-574232141626.png">
<img width="416" alt="Screen Shot 2021-10-13 at 4 41 44 PM" src="https://user-images.githubusercontent.com/29204161/137223014-75bb6413-4774-4e63-bec6-900e9f66c8f6.png">


non-ENS svg's
<img width="403" alt="Screen Shot 2021-10-13 at 4 42 58 PM" src="https://user-images.githubusercontent.com/29204161/137223043-e5fb9060-33b5-4e73-b7b4-335532c084ca.png">


