### PR TITLE
Fix dataFromLastTxHash when last confirmed tx is an l2 tx

### DIFF
--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -78,16 +78,20 @@ export const parseTransactions = async (
   const purchaseTransactionHashes = map(purchaseTransactions, txn =>
     ethereumUtils.getHash(txn)
   );
-  const allL2Transactions = existingTransactions.filter(tx =>
-    isL2Network(tx.network || '')
+
+  const [allL2Transactions, existingWithoutL2] = partition(
+    existingTransactions,
+    tx => isL2Network(tx.network || '')
   );
+
   const data = appended
     ? transactionData
-    : dataFromLastTxHash(transactionData, existingTransactions);
+    : dataFromLastTxHash(transactionData, existingWithoutL2);
 
   const newTransactionPromises = data.map(txn =>
     parseTransaction(txn, nativeCurrency, purchaseTransactionHashes, network)
   );
+
   const newTransactions = await Promise.all(newTransactionPromises);
   const parsedNewTransactions = flatten(newTransactions);
 


### PR DESCRIPTION
Bruno found us doing crazy amounts of unnecessary infura network calls on app launch:
When the last confirmed tx is from an L2 network, the dataFromLastTxHash would return all the existing txns and cause a re-parse of the txns list (causing unnecessary infura calls down the line during parsing).

This removes the L2 txns from "existing txns" when doing the dataFromLastTxHash check

Confirmed scenario from Bruno:
Have an L2 txn as a last confirmed txn, the getTransactionMethodName was not triggered on app launch