### PR TITLE
Create `nativeCurrencyTypes` TS module for native currency keys like "USD."

### DIFF
--- a/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Row } from '../../../layout';
 import ChartHeaderTitle from './ChartHeaderTitle';
 import { ChartYLabel } from '@rainbow-me/animated-charts';
+import { NativeCurrencyKeys } from '@rainbow-me/helpers/nativeCurrencyTypes';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { supportedNativeCurrencies } from '@rainbow-me/references';
 import { fonts, fontWithWidth } from '@rainbow-me/styles';
@@ -54,7 +55,7 @@ export function formatNative(value, priceSharedValue, nativeSelected) {
       : 2;
 
   let res = `${Number(value).toFixed(decimals).toLocaleString('en-US', {
-    currency: 'USD',
+    currency: NativeCurrencyKeys.USD,
   })}`;
   res =
     nativeSelected?.alignment === 'left'

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Row } from '../../../layout';
 import ChartHeaderTitle from './ChartHeaderTitle';
 import { ChartYLabel } from '@rainbow-me/animated-charts';
-import { NativeCurrencyKeys } from '@rainbow-me/helpers/nativeCurrencyTypes';
+import { NativeCurrencyKeys } from '@rainbow-me/entities/nativeCurrencyTypes';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { supportedNativeCurrencies } from '@rainbow-me/references';
 import { fonts, fontWithWidth } from '@rainbow-me/styles';

--- a/src/entities/nativeCurrencyTypes.ts
+++ b/src/entities/nativeCurrencyTypes.ts
@@ -1,16 +1,16 @@
+import { mapValues } from 'lodash';
 import nativeCurrencyReference from '../references/native-currencies.json';
 
 type NativeCurrencyKey = keyof typeof nativeCurrencyReference;
-type NativeCurrencyKeysMap = { [key in NativeCurrencyKey]: NativeCurrencyKey };
+type NativeCurrencyKeysMap = { [Key in NativeCurrencyKey]: Key };
 
 // We can't dynamically generate an enum from the JSON data, but we can
 // generate this type-checked object, which is nicer than using strings directly.
-const nativeKeys: Partial<NativeCurrencyKeysMap> = {};
-for (let key of Object.keys(nativeCurrencyReference) as NativeCurrencyKey[]) {
-  nativeKeys[key] = key;
-}
 
 /**
  * An enum of native currencies such as "USD" or "ETH".
  */
-export const NativeCurrencyKeys: NativeCurrencyKeysMap = nativeKeys as NativeCurrencyKeysMap;
+export const NativeCurrencyKeys = mapValues(
+  nativeCurrencyReference,
+  (_value, key) => key
+) as NativeCurrencyKeysMap;

--- a/src/entities/nativeCurrencyTypes.ts
+++ b/src/entities/nativeCurrencyTypes.ts
@@ -10,4 +10,7 @@ for (let key of Object.keys(nativeCurrencyReference) as NativeCurrencyKey[]) {
   nativeKeys[key] = key;
 }
 
+/**
+ * An enum of native currencies such as "USD" or "ETH".
+ */
 export const NativeCurrencyKeys: NativeCurrencyKeysMap = nativeKeys as NativeCurrencyKeysMap;

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -1,5 +1,5 @@
 import { getGlobal, saveGlobal } from './common';
-import { NativeCurrencyKeys } from '@rainbow-me/helpers/nativeCurrencyTypes';
+import { NativeCurrencyKeys } from '@rainbow-me/entities/nativeCurrencyTypes';
 import networkTypes from '@rainbow-me/helpers/networkTypes';
 
 export const IMAGE_METADATA = 'imageMetadata';

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -1,4 +1,5 @@
 import { getGlobal, saveGlobal } from './common';
+import { NativeCurrencyKeys } from '@rainbow-me/helpers/nativeCurrencyTypes';
 import networkTypes from '@rainbow-me/helpers/networkTypes';
 
 export const IMAGE_METADATA = 'imageMetadata';
@@ -39,7 +40,8 @@ export const getKeyboardHeight = () => getGlobal(KEYBOARD_HEIGHT, null);
 
 export const setKeyboardHeight = height => saveGlobal(KEYBOARD_HEIGHT, height);
 
-export const getNativeCurrency = () => getGlobal(NATIVE_CURRENCY, 'USD');
+export const getNativeCurrency = () =>
+  getGlobal(NATIVE_CURRENCY, NativeCurrencyKeys.USD);
 
 export const saveNativeCurrency = nativeCurrency =>
   saveGlobal(NATIVE_CURRENCY, nativeCurrency);

--- a/src/helpers/nativeCurrencyTypes.ts
+++ b/src/helpers/nativeCurrencyTypes.ts
@@ -1,0 +1,13 @@
+import nativeCurrencyReference from '../references/native-currencies.json';
+
+type NativeCurrencyKey = keyof typeof nativeCurrencyReference;
+type NativeCurrencyKeysMap = { [key in NativeCurrencyKey]: NativeCurrencyKey };
+
+// We can't dynamically generate an enum from the JSON data, but we can
+// generate this type-checked object, which is nicer than using strings directly.
+const nativeKeys: Partial<NativeCurrencyKeysMap> = {};
+for (let key of Object.keys(nativeCurrencyReference) as NativeCurrencyKey[]) {
+  nativeKeys[key] = key;
+}
+
+export const NativeCurrencyKeys: NativeCurrencyKeysMap = nativeKeys as NativeCurrencyKeysMap;

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -6,6 +6,7 @@ import {
   saveNetwork,
 } from '../handlers/localstorage/globalSettings';
 import { web3SetHttpProvider } from '../handlers/web3';
+import { NativeCurrencyKeys } from '../helpers/nativeCurrencyTypes';
 import networkTypes from '../helpers/networkTypes';
 import { updateLanguage } from '../languages';
 
@@ -106,7 +107,7 @@ export const INITIAL_STATE = {
   accountAddress: '',
   chainId: 1,
   language: 'en',
-  nativeCurrency: 'USD',
+  nativeCurrency: NativeCurrencyKeys.USD,
   network: networkTypes.mainnet,
 };
 

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -1,3 +1,4 @@
+import { NativeCurrencyKeys } from '../entities/nativeCurrencyTypes';
 import {
   getNativeCurrency,
   getNetwork,
@@ -6,7 +7,6 @@ import {
   saveNetwork,
 } from '../handlers/localstorage/globalSettings';
 import { web3SetHttpProvider } from '../handlers/web3';
-import { NativeCurrencyKeys } from '../helpers/nativeCurrencyTypes';
 import networkTypes from '../helpers/networkTypes';
 import { updateLanguage } from '../languages';
 


### PR DESCRIPTION
This is a short PR to create a TypeScript module for typing currency keys, such as "USD," instead of typing out the strings directly. #2498 can then be updated to use this type.

Since the currencies are sourced from a JSON file, I couldn't find an easy way to generate a proper TypeScript `enum`. The options (I think) are therefore to define a type using the keys from that JSON (but still use literal strings) or generate an object that behaves like an enum. 

This works by creating an object with each key mapped to itself, and then using `NativeCurrencyKeys.USD` or similar instead of using a "USD" literal.