### PR TITLE
RNBW-1830: Don't blow up on polygon assets that don't have a contract name in covalent

### DIFF
--- a/src/redux/polygonExplorer.js
+++ b/src/redux/polygonExplorer.js
@@ -131,7 +131,7 @@ const getAssetsFromCovalent = async (
           decimals: item.contract_decimals,
           icon_url: item.logo_url,
           mainnet_address: mainnetAddress,
-          name: item.contract_name.replace(' (PoS)', ''),
+          name: item.contract_name?.replace(' (PoS)', ''),
           network: networkTypes.polygon,
           price: {
             value: item.quote_rate || 0,


### PR DESCRIPTION
We are currently blowing up when covalent doesn't have the contract name for a polygon token so no polygon assets are displayed in the wallet. 

One example of such a token is https://polygonscan.com/token/0x4259Abc22981480D81075b0E8C4Bb0b142be8EF8?a=0x3B3525F60eeea4a1eF554df5425912c2a532875D

```
{"balance": "999000000000000000000000000",
 "balance_24h": "999000000000000000000000000",
 "contract_address": "0x4259abc22981480d81075b0e8c4bb0b142be8ef8",
 "contract_decimals": 0,
 "contract_name": null,
 "contract_ticker_symbol": null,
 "last_transferred_at": "2021-11-01T15:22:59Z",
 "logo_url": "https://logos.covalenthq.com/tokens/137/0x4259abc22981480d81075b0e8c4bb0b142be8ef8.png",
 "nft_data": null,
 "quote": 0,
 "quote_24h": null,
 "quote_rate": null,
 "quote_rate_24h": null,
 "supports_erc": ["erc20"],
 "type": "cryptocurrency"}
```

---

Before:
![1636426028413](https://user-images.githubusercontent.com/677680/140853376-08b012d6-e7fb-46d9-aa9b-85272ebb5d4e.jpg)

After:
![1636426047262](https://user-images.githubusercontent.com/677680/140853381-9c3f9fcf-1d8c-40ac-a08a-b6527fd9919c.jpg)

The malformed token will show up as `Unknown Token`:
![1636426114937](https://user-images.githubusercontent.com/677680/140853425-7ed88208-deef-4022-91fd-516ec99acf4f.jpg)
