### PR TITLE
Fix `NativeCurrencyKeys` to follow export pattern.

### DIFF
--- a/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Row } from '../../../layout';
 import ChartHeaderTitle from './ChartHeaderTitle';
 import { ChartYLabel } from '@rainbow-me/animated-charts';
-import { NativeCurrencyKeys } from '@rainbow-me/entities/nativeCurrencyTypes';
+import { NativeCurrencyKeys } from '@rainbow-me/entities';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { supportedNativeCurrencies } from '@rainbow-me/references';
 import { fonts, fontWithWidth } from '@rainbow-me/styles';

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -20,7 +20,7 @@ export type {
   RainbowMeteorologyData,
   SelectedGasFee,
 } from './gas';
-export type { NativeCurrencyKeys } from './nativeCurrencyTypes';
+export { NativeCurrencyKeys } from './nativeCurrencyTypes';
 export type Numberish = string | number;
 export type { NonceManager } from './nonce';
 export { default as ProtocolTypeNames, ProtocolType } from './protocolTypes';

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -20,6 +20,7 @@ export type {
   RainbowMeteorologyData,
   SelectedGasFee,
 } from './gas';
+export type { NativeCurrencyKeys } from './nativeCurrencyTypes';
 export type Numberish = string | number;
 export type { NonceManager } from './nonce';
 export { default as ProtocolTypeNames, ProtocolType } from './protocolTypes';

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -1,5 +1,5 @@
 import { getGlobal, saveGlobal } from './common';
-import { NativeCurrencyKeys } from '@rainbow-me/entities/nativeCurrencyTypes';
+import { NativeCurrencyKeys } from '@rainbow-me/entities';
 import networkTypes from '@rainbow-me/helpers/networkTypes';
 
 export const IMAGE_METADATA = 'imageMetadata';

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -1,19 +1,18 @@
 import analytics from '@segment/analytics-react-native';
-import { NativeCurrencyKeys } from '../entities/nativeCurrencyTypes';
+import { updateLanguage } from '../languages';
+import { NativeCurrencyKeys } from '@rainbow-me/entities';
 import {
   getNativeCurrency,
   getNetwork,
   saveLanguage,
   saveNativeCurrency,
   saveNetwork,
-} from '../handlers/localstorage/globalSettings';
-import { web3SetHttpProvider } from '../handlers/web3';
-import networkTypes from '../helpers/networkTypes';
-import { updateLanguage } from '../languages';
-
-import { ethereumUtils } from '../utils';
-import { dataResetState } from './data';
-import { explorerClearState, explorerInit } from './explorer';
+} from '@rainbow-me/handlers/localstorage/globalSettings';
+import { web3SetHttpProvider } from '@rainbow-me/handlers/web3';
+import networkTypes from '@rainbow-me/helpers/networkTypes';
+import { dataResetState } from '@rainbow-me/redux/data';
+import { explorerClearState, explorerInit } from '@rainbow-me/redux/explorer';
+import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
 // -- Constants ------------------------------------------------------------- //


### PR DESCRIPTION
This is a small fix to the exports and imports of the `NativeCurrencyKeys` type to make it fall more in line with how other types are exported from `entities`. Other entities are exported from `src/entities/index` and subsequently imported from `@rainbow-me/entities` instead of referencing their specific file.