### PR TITLE
Use StaticJsonRpcProvider

### DIFF
--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -2,7 +2,7 @@ import { getAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
 import { isHexString as isEthersHexString } from '@ethersproject/bytes';
 import { isValidMnemonic as ethersIsValidMnemonic } from '@ethersproject/hdnode';
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { parseEther } from '@ethersproject/units';
 import UnstoppableResolution from '@unstoppabledomains/resolution';
 import { get, startsWith } from 'lodash';
@@ -55,14 +55,7 @@ export let web3Provider = null;
  * @param {String} network
  */
 export const web3SetHttpProvider = async network => {
-  if (network.startsWith('http://')) {
-    web3Provider = new JsonRpcProvider(network, 'any');
-    // override mainnet for hardhat
-    networkProviders[NetworkTypes.mainnet] = web3Provider;
-  } else {
-    web3Provider = new JsonRpcProvider(rpcEndpoints[network]);
-  }
-  return web3Provider.ready;
+  web3Provider = await getProviderForNetwork(network);
 };
 
 /**
@@ -105,9 +98,12 @@ export const getProviderForNetwork = async (network = NetworkTypes.mainnet) => {
     return networkProviders[network];
   }
   if (network.startsWith('http://')) {
-    return new JsonRpcProvider(network, NetworkTypes.mainnet);
+    const provider = new StaticJsonRpcProvider(network, NetworkTypes.mainnet);
+    networkProviders[NetworkTypes.mainnet] = provider;
+    return provider;
   } else {
-    const provider = new JsonRpcProvider(rpcEndpoints[network]);
+    const chainId = ethereumUtils.getChainIdFromNetwork(network);
+    const provider = new StaticJsonRpcProvider(rpcEndpoints[network], chainId);
     if (!networkProviders[network]) {
       networkProviders[network] = provider;
     }

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -8,7 +8,6 @@ import {
   isValidAddress,
   toChecksumAddress,
 } from 'ethereumjs-util';
-
 import { hdkey } from 'ethereumjs-wallet';
 import {
   find,
@@ -18,7 +17,6 @@ import {
   replace,
   toLower,
 } from 'lodash';
-
 import {
   Alert,
   InteractionManager,


### PR DESCRIPTION
Since we are using node providers (Infura/Alchemy) with separate endpoints for various networks and not switching networks on a single provider, we can use the StaticJsonRpcProvider and avoid the additional eth_chainId call that is used for safety.

This has been verified that the eth_chainId call is not being triggered using logs.

Context: eth_chainId is called with every call we do to Infura. By specifying a network, we can remove this eth_chainId call from happening. Previously these calls took up about half of our total Infura network requests load.