### PR TITLE
Fix hardhat config

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,5 +7,10 @@ require('@nomiclabs/hardhat-waffle');
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
+  networks: {
+    hardhat: {
+      chainId: 1,
+    },
+  },
   solidity: '0.8.4',
 };


### PR DESCRIPTION
Without this change all hardhat txs are rejected with the error:

`  Trying to send an incompatible EIP-155 transaction, signed for another chain.`

because we're signing txs for mainnet but hardhat's default chainId it's different.  This was previously working when I did #2510  because the provider was set to `any`