### PR TITLE
Improvements to L2 explorers

### DIFF
--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -15,6 +15,7 @@ import NetworkTypes from '@rainbow-me/helpers/networkTypes';
 import {
   balanceCheckerContractAbi,
   chainAssets,
+  COVALENT_ETH_ADDRESS,
   ETH_ADDRESS,
   ETH_COINGECKO_ID,
   migratedTokens,
@@ -36,7 +37,6 @@ const FALLBACK_EXPLORER_SET_LATEST_TX_BLOCK_NUMBER =
 
 const ETHEREUM_ADDRESS_FOR_BALANCE_CONTRACT =
   '0x0000000000000000000000000000000000000000';
-const COVALENT_ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
 const UPDATE_BALANCE_AND_PRICE_FREQUENCY = 10000;
 const DISCOVER_NEW_ASSETS_FREQUENCY = 13000;

--- a/src/redux/optimismExplorer.js
+++ b/src/redux/optimismExplorer.js
@@ -1,4 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { toLower } from 'lodash';
 import isEqual from 'react-fast-compare';
@@ -83,30 +82,28 @@ export const optimismExplorerInit = () => async (dispatch, getState) => {
       return;
     }
 
-    const tokenAddresses = assets.map(
-      ({ asset: { asset_code } }) => asset_code
+    const tokenAddresses = assets.map(({ asset: { asset_code } }) =>
+      toLower(asset_code)
     );
 
     const balances = await fetchAssetBalances(
-      assets.map(({ asset: { asset_code } }) => asset_code),
+      tokenAddresses,
       accountAddress,
       network
     );
 
-    let total = BigNumber.from(0);
-
+    let updatedAssets = assets;
     if (balances) {
-      Object.keys(balances).forEach(key => {
-        for (let i = 0; i < assets.length; i++) {
-          if (assets[i].asset.asset_code.toLowerCase() === key.toLowerCase()) {
-            assets[i].quantity = balances[key];
-            break;
-          }
-        }
-        total = total.add(balances[key]);
+      updatedAssets = assets.map(assetAndQuantity => {
+        const assetCode = toLower(assetAndQuantity.asset.asset_code);
+        return {
+          ...assetAndQuantity,
+          quantity: balances?.[assetCode],
+        };
       });
     }
-    const assetsWithBalance = assets.filter(asset => asset.quantity > 0);
+
+    const assetsWithBalance = updatedAssets.filter(asset => asset.quantity > 0);
 
     if (assetsWithBalance.length) {
       dispatch(emitAssetRequest(tokenAddresses));

--- a/src/redux/optimismExplorer.js
+++ b/src/redux/optimismExplorer.js
@@ -97,7 +97,9 @@ export const optimismExplorerInit = () => async (dispatch, getState) => {
       updatedAssets = assets.map(assetAndQuantity => {
         const assetCode = toLower(assetAndQuantity.asset.asset_code);
         return {
-          ...assetAndQuantity,
+          asset: {
+            ...assetAndQuantity.asset,
+          },
           quantity: balances?.[assetCode],
         };
       });

--- a/src/redux/polygonExplorer.js
+++ b/src/redux/polygonExplorer.js
@@ -1,5 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber';
-import { Contract } from '@ethersproject/contracts';
 import { toLower } from 'lodash';
 import isEqual from 'react-fast-compare';
 // eslint-disable-next-line import/no-cycle
@@ -9,17 +7,14 @@ import { emitAssetRequest, emitChartsRequest } from './explorer';
 import { AssetTypes } from '@rainbow-me/entities';
 //import networkInfo from '@rainbow-me/helpers/networkInfo';
 import { getAssetsFromCovalent } from '@rainbow-me/handlers/covalent';
-import { getProviderForNetwork } from '@rainbow-me/handlers/web3';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
 import networkTypes from '@rainbow-me/helpers/networkTypes';
 import {
-  balanceCheckerContractAbi,
-  chainAssets,
+  COVALENT_ETH_ADDRESS,
   MATIC_MAINNET_ADDRESS,
   MATIC_POLYGON_ADDRESS,
   WETH_ADDRESS,
 } from '@rainbow-me/references';
-
 import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
@@ -93,10 +88,7 @@ const getPolygonAssetsFromCovalent = async (
       };
 
       // Overrides
-      if (
-        toLower(mainnetAddress) ===
-        toLower('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE')
-      ) {
+      if (toLower(mainnetAddress) === toLower(COVALENT_ETH_ADDRESS)) {
         mainnetAddress = WETH_ADDRESS;
         coingeckoId = 'ethereum';
       } else if (
@@ -142,39 +134,6 @@ const getPolygonAssetsFromCovalent = async (
   return null;
 };
 
-const fetchAssetBalances = async (tokens, address) => {
-  const abi = balanceCheckerContractAbi;
-
-  const contractAddress = networkInfo[network].balance_checker_contract_address;
-  const polygonProvider = await getProviderForNetwork(network);
-
-  const balanceCheckerContract = new Contract(
-    contractAddress,
-    abi,
-    polygonProvider
-  );
-
-  try {
-    const values = await balanceCheckerContract.balances([address], tokens);
-    const balances = {};
-    [address].forEach((addr, addrIdx) => {
-      balances[addr] = {};
-      tokens.forEach((tokenAddr, tokenIdx) => {
-        const balance = values[addrIdx * tokens.length + tokenIdx];
-        balances[addr][tokenAddr] = balance.toString();
-      });
-    });
-    return balances[address];
-  } catch (e) {
-    logger.log(
-      'Error fetching balances from balanceCheckerContract',
-      network,
-      e
-    );
-    return null;
-  }
-};
-
 export const polygonExplorerInit = () => async (dispatch, getState) => {
   if (networkInfo[networkTypes.polygon]?.disabled) return;
   const { accountAddress, nativeCurrency } = getState().settings;
@@ -182,79 +141,6 @@ export const polygonExplorerInit = () => async (dispatch, getState) => {
   const { coingeckoIds } = getState().additionalAssetsData;
   const formattedNativeCurrency = toLower(nativeCurrency);
   tokenMapping = await fetchAssetsMapping();
-
-  const fetchAssetsBalancesAndPricesFallback = async () => {
-    const assets = chainAssets[network];
-    const tokenAddresses = assets.map(
-      ({ asset: { asset_code } }) => asset_code
-    );
-
-    dispatch(emitAssetRequest(tokenAddresses));
-    dispatch(emitChartsRequest(tokenAddresses));
-
-    const prices = await fetchAssetPricesWithCoingecko(
-      assets.map(({ asset: { coingecko_id } }) => coingecko_id),
-      formattedNativeCurrency
-    );
-
-    if (prices) {
-      Object.keys(prices).forEach(key => {
-        for (let i = 0; i < assets.length; i++) {
-          if (toLower(assets[i].asset.coingecko_id) === toLower(key)) {
-            const asset =
-              ethereumUtils.getAsset(
-                allAssets,
-                toLower(assets[i].asset.mainnet_address)
-              ) || genericAssets[toLower(assets[i].asset.mainnet_address)];
-            assets[i].asset.network = networkTypes.polygon;
-            assets[i].asset.price = asset?.price || {
-              changed_at: prices[key].last_updated_at,
-              relative_change_24h:
-                prices[key][`${formattedNativeCurrency}_24h_change`],
-              value: prices[key][`${formattedNativeCurrency}`],
-            };
-            break;
-          }
-        }
-      });
-    }
-    const balances = await fetchAssetBalances(
-      assets.map(({ asset: { asset_code } }) => asset_code),
-      accountAddress,
-      network
-    );
-
-    let total = BigNumber.from(0);
-
-    if (balances) {
-      Object.keys(balances).forEach(key => {
-        for (let i = 0; i < assets.length; i++) {
-          if (assets[i].asset.asset_code.toLowerCase() === key.toLowerCase()) {
-            assets[i].quantity = balances[key];
-            break;
-          }
-        }
-        total = total.add(balances[key]);
-      });
-    }
-
-    dispatch(
-      addressAssetsReceived(
-        {
-          meta: {
-            address: accountAddress,
-            currency: nativeCurrency,
-            status: 'ok',
-          },
-          payload: { assets },
-        },
-        false,
-        false,
-        false,
-        networkTypes.polygon
-      )
-    );
-  };
 
   const fetchAssetsBalancesAndPrices = async () => {
     const chainId = ethereumUtils.getChainIdFromNetwork(network);
@@ -267,11 +153,6 @@ export const polygonExplorerInit = () => async (dispatch, getState) => {
       allAssets,
       genericAssets
     );
-
-    if (assets === null) {
-      fetchAssetsBalancesAndPricesFallback();
-      return;
-    }
 
     if (!assets || !assets.length) {
       // Try again in one minute

--- a/src/references/index.ts
+++ b/src/references/index.ts
@@ -72,6 +72,9 @@ export const MATIC_MAINNET_ADDRESS =
   '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0';
 export const MATIC_POLYGON_ADDRESS =
   '0x0000000000000000000000000000000000001010';
+export const COVALENT_ETH_ADDRESS =
+  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
 export const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 export const CDAI_CONTRACT = '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643';
 export const SAI_ADDRESS = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';


### PR DESCRIPTION
Optimism:
PoW: https://recordit.co/CyeyGd4mEY

After the initial loading of Optimism data, we were doing superficial copies of the asset data in a global const - causing the underlying values to be overwritten and then failing to detect a "change" (thereby skipping to write the new data to redux)

**Testing checklist:**
Send an asset on Optimism. The balance should update after 10 seconds of the txn confirming.
Loading and sending assets on polygon should still work.