### PR TITLE
lint - optional txTo

### DIFF
--- a/src/entities/transactions/transaction.ts
+++ b/src/entities/transactions/transaction.ts
@@ -36,7 +36,7 @@ export interface RainbowTransaction {
   title: string;
   to: EthereumAddress | null;
   transferId?: string; // for purchases
-  txTo: EthereumAddress | null;
+  txTo?: EthereumAddress | null;
   type: TransactionType;
   value?: BigNumberish; // for pending tx
 }


### PR DESCRIPTION
txTo is required but not being used everywhere, ex: https://github.com/rainbow-me/rainbow/blob/0c28ee21dacabda78023bfb9af64bb5ad500469c/src/parsers/transactions.ts#L413

seems chill due to this comment: https://github.com/rainbow-me/rainbow/pull/2586#discussion_r756569460