### PR TITLE
only add the url to message on android

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.js
+++ b/src/components/expanded-state/UniqueTokenExpandedState.js
@@ -184,7 +184,7 @@ const UniqueTokenExpandedState = ({ asset, external, lowResUrl }) => {
 
   const handlePressShare = useCallback(() => {
     Share.share({
-      message: buildRainbowUrl(asset, accountENS, accountAddress),
+      message: android && buildRainbowUrl(asset, accountENS, accountAddress),
       title: `Share ${buildUniqueTokenName(asset)} Info`,
       url: buildRainbowUrl(asset, accountENS, accountAddress),
     });


### PR DESCRIPTION
iOS was copying the url twice, now we only add to message on android.  fixes RNBW-1889

PoW iOS: https://cloud.skylarbarrera.com/Screen-Recording-2021-11-28-16-44-42.mp4
PoW 🤖 : https://cloud.skylarbarrera.com/Screen-Recording-2021-11-28-16-43-26.mp4