### PR TITLE
Fix hook issue and prevent tx without to

### DIFF
--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -525,24 +525,25 @@ export default function SendSheet(props) {
         captureException(e);
         Alert.alert('Invalid transaction');
         submitSuccess = false;
-      }
-      const { result: txResult } = await sendTransaction({
-        provider: currentProvider,
-        transaction: signableTransaction,
-      });
-      const { hash, nonce } = txResult;
-      const { data, value } = signableTransaction;
-      if (!isEmpty(hash)) {
-        submitSuccess = true;
-        txDetails.hash = hash;
-        txDetails.nonce = nonce;
-        txDetails.network = currentNetwork;
-        txDetails.data = data;
-        txDetails.value = value;
-        txDetails.txTo = signableTransaction.to;
-        await dispatch(
-          dataAddNewTransaction(txDetails, null, false, currentProvider)
-        );
+      } else {
+        const { result: txResult } = await sendTransaction({
+          provider: currentProvider,
+          transaction: signableTransaction,
+        });
+        const { hash, nonce } = txResult;
+        const { data, value } = signableTransaction;
+        if (!isEmpty(hash)) {
+          submitSuccess = true;
+          txDetails.hash = hash;
+          txDetails.nonce = nonce;
+          txDetails.network = currentNetwork;
+          txDetails.data = data;
+          txDetails.value = value;
+          txDetails.txTo = signableTransaction.to;
+          await dispatch(
+            dataAddNewTransaction(txDetails, null, false, currentProvider)
+          );
+        }
       }
     } catch (error) {
       logger.sentry('TX Details', txDetails);


### PR DESCRIPTION
the useEffect was re-running with null recipient so it was "wiping" the `toAddress` [here](https://github.com/rainbow-me/rainbow/compare/@bruno/fix-sendsheet-params?expand=1#diff-b39e437ce6cbc2452da927c2ecd100de213cd594ec3fd802347c44d512043346R427)

Also added a check to prevent this from happening before submitting the transaction which shows an alert like this along with some tracking for sentry:

<img src="https://user-images.githubusercontent.com/1247834/143947091-7e0d9b0d-8875-4c8c-a169-06a9057ca224.PNG" data-canonical-src="https://user-images.githubusercontent.com/1247834/143947091-7e0d9b0d-8875-4c8c-a169-06a9057ca224.PNG" width="200" height="400" />

To test:

- Go to https://www.the-qrcode-generator.com/ , choose "free text" and enter in the text field to generate a qr code`ethereum:0x3Cb462CDC5F809aeD0558FBEe151eD5dC3D3f608?value=000002250000000000`
then submit the transaction and it should show as a normal send on etherscan (not a contract deployment)

- Same but entering the following text to generate another QR code:
`0x3Cb462CDC5F809aeD0558FBEe151eD5dC3D3f608`

Then click "Send", choose ETH and set the USD value to 0.01

then submit the transaction and it should show as a normal send on etherscan (not a contract deployment)