### PR TITLE
Sync balances after tx sooner

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -255,23 +255,23 @@ class App extends Component {
     Navigation.setTopLevelNavigator(navigatorRef);
 
   handleTransactionConfirmed = tx => {
-    logger.log('reloading explorer data in 10');
     const network = ethereumUtils.getNetworkFromChainId(tx.chainId);
     const isL2 = isL2Network(network);
-    setTimeout(
-      () => {
+    const updateBalancesAfter = (timeout, isL2, network) => {
+      setTimeout(() => {
+        logger.log('Reloading balances for network', network);
         if (isL2) {
-          logger.log('Reloading all data from L2 explorers!');
           store.dispatch(explorerInitL2(network));
         } else {
-          logger.log('fetching onchain balances NOW!');
           store.dispatch(
             fetchOnchainBalances({ keepPolling: false, withPrices: false })
           );
         }
-      },
-      isL2 ? 10000 : 5000
-    );
+      }, timeout);
+    };
+    logger.log('reloading balances soon...');
+    updateBalancesAfter(2000, isL2, network);
+    updateBalancesAfter(isL2 ? 10000 : 5000, isL2, network);
   };
 
   render = () => (


### PR DESCRIPTION
First try at 2 seconds
Second try at 5 seconds or 10 seconds if L2.

QA Instructions:

- After sending a transaction on mainnet balance should be updated in < 6 seconds (ideally in less than 3)
- After sending an l2 tx balances should be updated in less than 11 seconds (ideally in less than 3)

Fixes RNBW-1913

