### PR TITLE
disable l2 deeplink e2e

### DIFF
--- a/e2e/deeplinks.spec.js
+++ b/e2e/deeplinks.spec.js
@@ -64,12 +64,12 @@ describe('Deeplinks spec', () => {
     await testEthereumDeeplink(url);
   });
 
-  it('should be able to handle ethereum payments urls for ETH (arbitrum)', async () => {
+  xit('should be able to handle ethereum payments urls for ETH (arbitrum)', async () => {
     const url = 'ethereum:payment-brunobarbieri.eth@42161?value=1e15';
     await testEthereumDeeplink(url);
   });
 
-  it('should be able to handle ethereum payments urls for ETH (optimism)', async () => {
+  xit('should be able to handle ethereum payments urls for ETH (optimism)', async () => {
     const url = 'ethereum:payment-brunobarbieri.eth@10?value=1e15';
     await testEthereumDeeplink(url);
   });
@@ -80,13 +80,13 @@ describe('Deeplinks spec', () => {
     await testEthereumDeeplink(url);
   });
 
-  it('should be able to handle ethereum payments urls for DAI (optimism)', async () => {
+  xit('should be able to handle ethereum payments urls for DAI (optimism)', async () => {
     const url =
       'ethereum:0xda10009cbd5d07dd0cecc66161fc93d7c9000da1@10/transfer?address=brunobarbieri.eth&uint256=1e15';
     await testEthereumDeeplink(url);
   });
 
-  it('should be able to handle ethereum payments urls for MATIC (polygon)', async () => {
+  xit('should be able to handle ethereum payments urls for MATIC (polygon)', async () => {
     const url = 'ethereum:payment-brunobarbieri.eth@137?value=1e15';
     await testEthereumDeeplink(url);
   });


### PR DESCRIPTION
because covalent usually takes longer this tests are very flaky, so we're disabling it for now and will re-evaluate once l2 data  is coming from the backend.