### PR TITLE
Ensure gas readiness to be determined by price being available also

### DIFF
--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -148,11 +148,11 @@ const GasSpeedButton = ({
   const price = useMemo(() => {
     const gasPrice =
       selectedGasFee?.gasFee?.estimatedFee?.native?.value?.display;
-    const price = (isNil(gasPrice) ? '0.00' : gasPrice)
+    if (isNil(gasPrice)) return null;
+    return gasPrice
       .replace(',', '') // In case gas price is > 1k!
       .replace(nativeCurrencySymbol, '')
       .trim();
-    return price;
   }, [nativeCurrencySymbol, selectedGasFee]);
 
   const isL2 = useMemo(() => isL2Network(currentNetwork), [currentNetwork]);
@@ -181,10 +181,11 @@ const GasSpeedButton = ({
 
   const gasIsNotReady = useMemo(
     () =>
+      isNil(price) ||
       isEmpty(gasFeeParamsBySpeed) ||
       isEmpty(selectedGasFee?.gasFee) ||
       isSufficientGas === null,
-    [gasFeeParamsBySpeed, selectedGasFee, isSufficientGas]
+    [gasFeeParamsBySpeed, isSufficientGas, price, selectedGasFee]
   );
 
   const openCustomGasSheet = useCallback(() => {


### PR DESCRIPTION
Fixes RNBW-1945

This will now ensure that the `gasIsNotReady` flag is not set until the `price` is also ready
It was disjoint because `gasIsNotReady` is influenced by the existence of `selectedGasFee?.gasFee` while the `price` is influenced by `selectedGasFee?.gasFee?.estimatedFee` and there was a split second where the `estimatedFee` was missing, causing `gasIsNotReady` to be out of sync for a moment.

We should figure out why the `estimatedFee` was missing on the `selectedGasFee` object, but that can be addressed separately. 

PoW: https://recordit.co/GKUBRO2Prz
I have a screen recording of the custom menu gas speed button also behaving correctly, but it won't upload for some reason.
