### PR TITLE
Decrease interval for meteorology gas data

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -57,6 +57,7 @@ import { ethereumUtils, gasUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
 const { CUSTOM, NORMAL, URGENT, GAS_PRICE_SOURCES } = gasUtils;
+const GAS_PRICE_INTERVAL = 5000; // 5 seconds
 
 let gasPricesHandle: NodeJS.Timeout | null = null;
 
@@ -414,7 +415,7 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
     } finally {
       gasPricesHandle = setTimeout(() => {
         watchGasPrices(network);
-      }, 15000); // 15 secs
+      }, GAS_PRICE_INTERVAL);
     }
   };
 


### PR DESCRIPTION
Fixes RNBW-1949

Meteorology updates every 10 seconds, our client will update every 5 seconds. Previously, we were updating every 15 seconds.

PoW: https://recordit.co/RxikOGZd0c
The longer gaps can take around 15 seconds depending on timing