### PR TITLE
Consolidate custom base fee and priority fee into a single state object.

### DIFF
--- a/src/components/expanded-state/custom-gas/FeesPanel.js
+++ b/src/components/expanded-state/custom-gas/FeesPanel.js
@@ -108,19 +108,19 @@ export default function FeesPanel({
   const { navigate, dangerouslyGetState } = useNavigation();
   const { isDarkMode } = useTheme();
 
-  const [customMaxPriorityFee, setCustomMaxPriorityFee] = useState(
-    gasFeeParamsBySpeed[CUSTOM]?.maxPriorityFeePerGas?.gwei
-  );
-
-  const [customMaxBaseFee, setCustomMaxBaseFee] = useState(
-    gasFeeParamsBySpeed[CUSTOM]?.maxFeePerGas?.gwei
-  );
+  const [customFees, setCustomFees] = useState({
+    customMaxBaseFee: gasFeeParamsBySpeed[CUSTOM]?.maxFeePerGas?.gwei,
+    customMaxPriorityFee:
+      gasFeeParamsBySpeed[CUSTOM]?.maxPriorityFeePerGas?.gwei,
+  });
 
   const [maxPriorityFeeWarning, setMaxPriorityFeeWarning] = useState(null);
   const [maxPriorityFeeError, setMaxPriorityFeeError] = useState(null);
 
   const [maxBaseFeeWarning, setMaxBaseFeeWarning] = useState(null);
   const [maxBaseFeeError, setMaxBaseFeeError] = useState(null);
+
+  const { customMaxBaseFee, customMaxPriorityFee } = customFees;
   const trendType = 'currentBaseFee' + upperFirst(currentGasTrend);
 
   const maxBaseWarningsStyle = useAnimatedStyle(() => {
@@ -263,8 +263,10 @@ export default function FeesPanel({
     const {
       gasFeeParams: { maxFeePerGas, maxPriorityFeePerGas },
     } = selectedGasFee;
-    setCustomMaxPriorityFee(maxPriorityFeePerGas?.gwei || 0);
-    setCustomMaxBaseFee(toFixedDecimals(maxFeePerGas?.gwei || 0, 0));
+    setCustomFees({
+      customMaxBaseFee: toFixedDecimals(maxFeePerGas?.gwei || 0, 0),
+      customMaxPriorityFee: maxPriorityFeePerGas?.gwei || 0,
+    });
   }, [onCustomGasFocus, handleOnInputFocus, selectedGasFee]);
 
   const handleCustomPriorityFeeFocus = useCallback(() => {
@@ -288,8 +290,10 @@ export default function FeesPanel({
 
       if (newMaxPriorityFeePerGas.amount < 0) return;
 
-      setCustomMaxPriorityFee(newMaxPriorityFeePerGas?.gwei || 0);
-      setCustomMaxBaseFee(selectedGasFee?.gasFeeParams?.maxFeePerGas?.gwei);
+      setCustomFees({
+        customMaxBaseFee: selectedGasFee?.gasFeeParams?.maxFeePerGas?.gwei,
+        customMaxPriorityFee: newMaxPriorityFeePerGas?.gwei || 0,
+      });
 
       const newGasParams = {
         ...selectedGasFee.gasFeeParams,
@@ -314,10 +318,11 @@ export default function FeesPanel({
 
       if (newMaxFeePerGas.amount < 0) return;
 
-      setCustomMaxBaseFee(newMaxFeePerGas?.gwei);
-      setCustomMaxPriorityFee(
-        selectedGasFee?.gasFeeParams?.maxPriorityFeePerGas?.gwei
-      );
+      setCustomFees({
+        customMaxBaseFee: newMaxFeePerGas?.gwei,
+        customMaxPriorityFee:
+          selectedGasFee?.gasFeeParams?.maxPriorityFeePerGas?.gwei,
+      });
 
       const newGasParams = {
         ...selectedGasFee.gasFeeParams,
@@ -351,10 +356,11 @@ export default function FeesPanel({
 
       if (greaterThan(0, maxFeePerGas.amount)) return;
 
-      setCustomMaxBaseFee(text);
-      setCustomMaxPriorityFee(
-        selectedGasFee.gasFeeParams.maxPriorityFeePerGas.gwei
-      );
+      setCustomFees({
+        customMaxBaseFee: text,
+        customMaxPriorityFee:
+          selectedGasFee.gasFeeParams.maxPriorityFeePerGas.gwei,
+      });
 
       const newGasParams = {
         ...selectedGasFee.gasFeeParams,
@@ -378,8 +384,10 @@ export default function FeesPanel({
 
       // we don't use the round number here, if we did
       // when users type "1." it will default to "1"
-      setCustomMaxPriorityFee(text);
-      setCustomMaxBaseFee(selectedGasFee?.gasFeeParams?.maxFeePerGas?.gwei);
+      setCustomFees({
+        customMaxBaseFee: selectedGasFee?.gasFeeParams?.maxFeePerGas?.gwei,
+        customMaxPriorityFee: text,
+      });
 
       const newGasParams = {
         ...selectedGasFee.gasFeeParams,
@@ -469,11 +477,7 @@ export default function FeesPanel({
     } else {
       setMaxPriorityFeeWarning(null);
     }
-  }, [
-    gasFeeParamsBySpeed?.[URGENT]?.maxPriorityFeePerGas?.gwei,
-    gasFeeParamsBySpeed?.[NORMAL]?.maxPriorityFeePerGas?.gwei,
-    maxPriorityFee,
-  ]);
+  }, [gasFeeParamsBySpeed, maxPriorityFee]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
Custom base fee and custom priority fee should always be updated together.
Instead of doing two separate setStates, we can consolidate into a single state object.
This helps prevent future changes from missing the fact that these need to be coupled and reduces rerenders.

PoW screen recording shows nothing has changed.
Will update once it uploads.