### PR TITLE
Fix eth_sign

### DIFF
--- a/e2e/hardhatTransactionFlow.spec.js
+++ b/e2e/hardhatTransactionFlow.spec.js
@@ -289,7 +289,7 @@ describe('Hardhat Transaction Flow', () => {
     }
   });
 
-  it('Should be able to sign via eth_sign messages via WC', async () => {
+  it('Should be able to sign eth_sign messages via WC', async () => {
     const message = `My email is john@doe.com`;
     const hexMsg = convertUtf8ToHex(message);
     const msgParams = [account, hexMsg];

--- a/e2e/hardhatTransactionFlow.spec.js
+++ b/e2e/hardhatTransactionFlow.spec.js
@@ -5,6 +5,7 @@ import { exec } from 'child_process';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import WalletConnect from '@walletconnect/client';
+import { convertUtf8ToHex } from '@walletconnect/utils';
 import { ethers } from 'ethers';
 import * as Helpers from './helpers';
 
@@ -285,6 +286,26 @@ describe('Hardhat Transaction Flow', () => {
       '0x9b08221727750e582b43e14f50069083ac6d8a2670a9f28009f14cbef7e66ba16d3370330aed5b6744027bd6a0bef32cb97bb9da3db34c67ba2237b2ef5d1ec71b'
     ) {
       throw new Error('WC personal sign failed');
+    }
+  });
+
+  it('Should be able to sign via eth_sign messages via WC', async () => {
+    const message = `My email is john@doe.com`;
+    const hexMsg = convertUtf8ToHex(message);
+    const msgParams = [account, hexMsg];
+    const result = connector.signMessage(msgParams);
+    await Helpers.checkIfVisible('wc-request-sheet');
+    await Helpers.waitAndTap('wc-confirm-action-button');
+    await Helpers.delay(1000);
+
+    if (!result) throw new Error('WC Connection failed');
+    const signature = await result;
+    // verify signature
+    if (
+      signature !==
+      '0x141d62e1aaa2202ededb07f1684ef6d3d9958d334713010ea91df3831e3a3c99303a83f334d1e5e935c4edd7146a2f3f4301c5d509ccfeffd55f5db4e971958b1c'
+    ) {
+      throw new Error('WC eth_sign failed');
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -360,7 +360,8 @@
       "simulator": {
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 11 Pro Max"
+          "type": "iPhone 11 Pro Max",
+          "os": "13.7"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@ethersproject/providers": "5.4.0",
     "@ethersproject/random": "5.4.0",
     "@ethersproject/shims": "5.4.0",
-    "@ethersproject/signing-key": "5.4.0",
     "@ethersproject/solidity": "5.4.0",
     "@ethersproject/transactions": "5.4.0",
     "@ethersproject/units": "5.4.0",
@@ -361,8 +360,7 @@
       "simulator": {
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 11 Pro Max",
-          "os": "13.7"
+          "type": "iPhone 11 Pro Max"
         }
       }
     },

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -329,9 +329,8 @@ export const signMessage = async (
       existingWallet || (await loadWallet(undefined, true, provider));
     try {
       if (!wallet) return null;
-      const signingKey = new SigningKey(wallet.privateKey);
-      const sigParams = await signingKey.signDigest(arrayify(message));
-      return { result: joinSignature(sigParams) };
+      const result = await wallet.signMessage(arrayify(message));
+      return { result };
     } catch (error) {
       Alert.alert(lang.t('wallet.transaction.alert.failed_sign_message'));
       logger.sentry('Error', error);

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -1,13 +1,7 @@
 import { TransactionRequest } from '@ethersproject/abstract-provider';
-import {
-  arrayify,
-  BytesLike,
-  Hexable,
-  joinSignature,
-} from '@ethersproject/bytes';
+import { arrayify, BytesLike, Hexable } from '@ethersproject/bytes';
 import { HDNode } from '@ethersproject/hdnode';
 import { Provider } from '@ethersproject/providers';
-import { SigningKey } from '@ethersproject/signing-key';
 import { Transaction } from '@ethersproject/transactions';
 import { Wallet } from '@ethersproject/wallet';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,18 +1926,6 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/shims/-/shims-5.4.0.tgz#7c243cea96a8ffdbc04bb031cd55e7897431276b"
   integrity sha512-J/M1oudCBPw4T8pBoE8wO65dIJruGBSZ1HyKVSygO3rF95Sq1LasQFEfKNzJl2nJP20ni4eXTNlEdKFKoVxnpw==
 
-"@ethersproject/signing-key@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.4.0.tgz#2f05120984e81cf89a3d5f6dec5c68ee0894fbec"
-  integrity sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==
-  dependencies:
-    "@ethersproject/bytes" "^5.4.0"
-    "@ethersproject/logger" "^5.4.0"
-    "@ethersproject/properties" "^5.4.0"
-    bn.js "^4.11.9"
-    elliptic "6.5.4"
-    hash.js "1.1.7"
-
 "@ethersproject/signing-key@5.5.0", "@ethersproject/signing-key@^5.4.0", "@ethersproject/signing-key@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"


### PR DESCRIPTION
There was a breaking change on Ethers 5.5.0 ([source](https://github.com/ethers-io/ethers.js/issues/1544#issuecomment-947237697)) affecting `eth_sign`. This PR fixes it

PoW: http://recordit.co/TXct78bmbi

Included a new e2e covering this so it's safe to merge

For QA in release regression:
* Please test critical path testing for message signing (various dapps etc)