### PR TITLE
Fixes for comments on L2 backend update

### DIFF
--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -453,20 +453,35 @@ const fetchAssetsFromRefraction = () => (dispatch, getState) => {
 const l2AddressAssetsReceived = (message, network) => (dispatch, getState) => {
   const { assets: allAssets, genericAssets } = getState().data;
 
-  const updatedMessage = Object.assign({}, message);
-  updatedMessage.payload.assets = message?.payload?.assets?.map(asset => {
+  const newAssets = message?.payload?.assets?.map(asset => {
+    const mainnetAddress = toLower(asset?.asset?.mainnet_address);
     const fallbackAsset =
-      ethereumUtils.getAsset(allAssets, toLower(asset.asset.mainnet_address)) ||
-      genericAssets[toLower(asset.asset.mainnet_address)];
+      mainnetAddress &&
+      (ethereumUtils.getAsset(allAssets, mainnetAddress) ||
+        genericAssets[mainnetAddress]);
 
     if (fallbackAsset) {
-      asset.asset.price = {
-        ...asset.asset.price,
-        ...fallbackAsset.price,
+      return {
+        ...asset,
+        asset: {
+          ...asset?.asset,
+          price: {
+            ...asset?.asset?.price,
+            ...fallbackAsset.price,
+          },
+        },
       };
     }
     return asset;
   });
+
+  const updatedMessage = {
+    ...message,
+    payload: {
+      ...message?.payload,
+      assets: newAssets,
+    },
+  };
 
   dispatch(addressAssetsReceived(updatedMessage, network));
 };

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -430,6 +430,7 @@ export const explorerInitL2 = (network = null) => (dispatch, getState) => {
         break;
       default:
         // Start watching all L2 assets
+        dispatch(fetchAssetsFromRefraction());
         dispatch(optimismExplorerInit());
     }
   }

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -483,7 +483,7 @@ const l2AddressAssetsReceived = (message, network) => (dispatch, getState) => {
     },
   };
 
-  dispatch(addressAssetsReceived(updatedMessage, network));
+  dispatch(addressAssetsReceived(updatedMessage, false, false, false, network));
 };
 
 const listenOnAddressMessages = socket => dispatch => {

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -614,9 +614,11 @@ export default function SendSheet(props) {
       // Don't allow sending funds directly to known ERC20 contracts on L2
       if (isL2) {
         const currentChainAssets = chainAssets[currentNetwork];
-        const found = currentChainAssets.find(
-          item => toLower(item.asset?.asset_code) === toLower(toAddress)
-        );
+        const found =
+          currentChainAssets &&
+          currentChainAssets.find(
+            item => toLower(item.asset?.asset_code) === toLower(toAddress)
+          );
         if (found) {
           return false;
         }


### PR DESCRIPTION
These are in direct response to the comments I posted on the `@bruno/l2-backend` branch
Commit history can be read exactly in order - all commits are logically separate.

Here is a screenshot of the mainnet assets not being duplicated:
![IMG_37B2063713FF-1](https://user-images.githubusercontent.com/1285228/144736308-ac85428b-bec8-428e-879b-ff62dc38e102.jpeg)


Here is a video of the SendSheet review button working:
https://user-images.githubusercontent.com/1285228/144736009-7a078a62-df86-4eaf-a655-833a27e09286.MP4

 
