### PR TITLE
fix optimism fee

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -485,7 +485,11 @@ export const gasUpdateTxFee = (
       ? ethereumUtils.getEthPriceUnit()
       : ethereumUtils.getMaticPriceUnit();
 
-  if (isEmpty(gasFeeParamsBySpeed)) return;
+  if (
+    isEmpty(gasFeeParamsBySpeed) ||
+    (txNetwork === networkTypes.optimism && l1GasFeeOptimism === null)
+  )
+    return;
 
   const isLegacyNetwork = isEIP1559LegacyNetwork(txNetwork);
 

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -442,7 +442,7 @@ export default function SendSheet(props) {
         txData,
         currentProvider
       );
-      updateTxFee(updatedGasLimit, null, currentNetwork, l1GasFeeOptimism);
+      updateTxFee(updatedGasLimit, null, l1GasFeeOptimism);
     },
     [
       accountAddress,
@@ -490,7 +490,7 @@ export default function SendSheet(props) {
           if (network === networkTypes.optimism) {
             updateTxFeeForOptimism(updatedGasLimit);
           } else {
-            updateTxFee(updatedGasLimit, null, currentNetwork);
+            updateTxFee(updatedGasLimit, null);
           }
         }
         // eslint-disable-next-line no-empty
@@ -786,12 +786,12 @@ export default function SendSheet(props) {
           if (currentNetwork === networkTypes.optimism) {
             updateTxFeeForOptimism(gasLimit);
           } else {
-            updateTxFee(gasLimit, null, currentNetwork);
+            updateTxFee(gasLimit, null);
           }
         })
         .catch(e => {
           logger.sentry('Error getting optimism l1 fee', e);
-          updateTxFee(null, null, currentNetwork);
+          updateTxFee(null, null);
         });
     }
   }, [

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -467,9 +467,9 @@ export default function TransactionConfirmationScreen() {
           txPayload,
           provider
         );
-        updateTxFee(gas, null, network, l1GasFeeOptimism);
+        updateTxFee(gas, null, l1GasFeeOptimism);
       } else {
-        updateTxFee(gas, null, network);
+        updateTxFee(gas, null);
       }
     }
   }, [network, params, provider, updateTxFee]);


### PR DESCRIPTION
Fixes RNBW-1966

## What changed (plus any additional context for devs)

Missed the change of l1Optimism gas fee, probably when rebasing. Now I'm passing `l1GasFeeOptimism` correctly to be added to the fee,

## PoW (screenshots / screen recordings)

https://recordit.co/81or1niHbT

## Dev checklist for QA: what to test

qa later?

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
