### PR TITLE
fix estimated fee calculation when max fee is set below of current base fee

### DIFF
--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -323,22 +323,27 @@ export const parseGasFees = (
   priceUnit: BigNumberish,
   nativeCurrency: string
 ) => {
-  const {
-    maxPriorityFeePerGas: maxPriorityFeePerGasGwei,
-    maxFeePerGas: maxFeePerGasGwei,
-  } = gasFeeParams || {};
-
-  const priorityFee = maxPriorityFeePerGasGwei?.amount || 0;
-  const maxFeePerGasAmount = maxFeePerGasGwei?.amount || 0;
+  const { maxPriorityFeePerGas, maxFeePerGas } = gasFeeParams || {};
+  const priorityFee = maxPriorityFeePerGas?.amount || 0;
+  const maxFeePerGasAmount = maxFeePerGas?.amount || 0;
   const baseFeePerGasAmount = baseFeePerGas?.amount || 0;
+
+  // if user sets the max base fee to lower than the current base fee
+  const estimatedFeePerGas = greaterThan(
+    maxFeePerGasAmount,
+    baseFeePerGasAmount
+  )
+    ? baseFeePerGasAmount
+    : maxFeePerGasAmount;
+
   const maxFee = getTxFee(
-    Number(maxFeePerGasAmount) + Number(priorityFee),
+    add(maxFeePerGasAmount, priorityFee),
     gasLimit,
     priceUnit,
     nativeCurrency
   );
   const estimatedFee = getTxFee(
-    Number(baseFeePerGasAmount) + Number(priorityFee),
+    add(estimatedFeePerGas, priorityFee),
     gasLimit,
     priceUnit,
     nativeCurrency


### PR DESCRIPTION
Fixes RNBW-1974

## What changed (plus any additional context for devs)

Fix it taking the minimum between the max fee per gas and the current fee per gas to do this calculation

## PoW (screenshots / screen recordings)

https://recordit.co/LWYEG3a6cy

## Dev checklist for QA: what to test

Move the max fee to below the current base fee, the estimated fee should be the same to the max transaction fee. If the max base fee is above the current base fee, max transaction fee should be greater than the estimated fee

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
