### PR TITLE
l2s default speeds and polling times

### DIFF
--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -316,7 +316,7 @@ const GasSpeedButton = ({
         return [NORMAL, FAST, URGENT];
       case networkTypes.optimism:
       case networkTypes.arbitrum:
-        return [FAST];
+        return [NORMAL];
       default:
         return GasSpeedOrder;
     }
@@ -352,13 +352,6 @@ const GasSpeedButton = ({
     speedOptions,
   ]);
 
-  const defaultSelectedGasFeeOption = useMemo(() => {
-    const fastByDefault =
-      currentNetwork === networkTypes.arbitrum ||
-      currentNetwork === networkTypes.optimism;
-    return fastByDefault ? FAST : NORMAL;
-  }, [currentNetwork]);
-
   const onDonePress = useCallback(() => {
     goBack();
   }, [goBack]);
@@ -392,7 +385,7 @@ const GasSpeedButton = ({
         }
         currentNetwork={currentNetwork}
         dropdownEnabled={gasOptionsAvailable}
-        label={selectedGasFeeOption ?? defaultSelectedGasFeeOption}
+        label={selectedGasFeeOption ?? NORMAL}
         showGasOptions={showGasOptions}
         showPager
         theme={theme}
@@ -417,7 +410,6 @@ const GasSpeedButton = ({
     colorForAsset,
     colors,
     currentNetwork,
-    defaultSelectedGasFeeOption,
     gasIsNotReady,
     gasOptionsAvailable,
     handlePressMenuItem,
@@ -433,15 +425,9 @@ const GasSpeedButton = ({
     const currentSpeedIndex = gasOptions?.indexOf(selectedGasFeeOption);
     // If the option isn't available anymore, we need to reset it
     if (currentSpeedIndex === -1) {
-      handlePressSpeedOption(defaultSelectedGasFeeOption);
+      handlePressSpeedOption(NORMAL);
     }
-  }, [
-    handlePressSpeedOption,
-    speeds,
-    selectedGasFeeOption,
-    isL2,
-    defaultSelectedGasFeeOption,
-  ]);
+  }, [handlePressSpeedOption, speeds, selectedGasFeeOption, isL2]);
 
   // had to do this hack because calling it directly from `onPress`
   // would make the expanded sheet come up with too much force

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -136,21 +136,6 @@ export const web3SetHttpProvider = async (
 };
 
 /**
- * @desc returns true if the given network is EIP1559 supported
- * @param network The network to check.
- */
-export const isEIP1559LegacyNetwork = (network: Network | string): boolean => {
-  switch (network) {
-    case Network.arbitrum:
-    case Network.optimism:
-    case Network.polygon:
-      return true;
-    default:
-      return false;
-  }
-};
-
-/**
  * @desc Checks if the given network is a Layer 2.
  * @param network The network to check.
  * @return Whether or not the network is a L2 network.
@@ -448,7 +433,7 @@ export const getTransactionCount = async (
 export const getTransactionGasParams = (
   transaction: Pick<NewTransactionNonNullable, 'network'> & GasParamsInput
 ): GasParamsReturned => {
-  return isEIP1559LegacyNetwork(transaction.network)
+  return isL2Network(transaction.network)
     ? {
         gasPrice: toHex(transaction.gasPrice),
       }

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -46,7 +46,7 @@ export const getFallbackGasPrices = () => ({
   [URGENT]: defaultGasPriceFormat(URGENT, '0.5', '200'),
 });
 
-const parseL2GasPrices = (data: GasPricesAPIData) => ({
+const parseOtherL2GasPrices = (data: GasPricesAPIData) => ({
   [CUSTOM]: null,
   [FAST]: defaultGasPriceFormat(FAST, data.avgWait, data.average),
   [NORMAL]: defaultGasPriceFormat(NORMAL, data.avgWait, data.average),
@@ -207,7 +207,7 @@ export const parseLegacyGasPrices = (
     case Network.arbitrum:
     case Network.optimism:
     default:
-      return parseL2GasPrices(data);
+      return parseOtherL2GasPrices(data);
   }
 };
 

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -168,20 +168,6 @@ export const parseRainbowMeteorologyData = (
   };
 };
 
-const parseGasPricesEthGasStation = (data: GasPricesAPIData) => ({
-  [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(FAST, data.fastWait, Number(data.fast) / 10),
-  [NORMAL]: defaultGasPriceFormat(
-    NORMAL,
-    data.avgWait,
-    Number(data.average) / 10
-  ),
-  [URGENT]: defaultGasPriceFormat(
-    URGENT,
-    data.fastestWait,
-    Number(data.fastest) / 10
-  ),
-});
 const parseGasPricesPolygonGasStation = (data: GasPricesAPIData) => {
   const polygonGasPriceBumpFactor = 1.05;
   return {
@@ -215,8 +201,6 @@ export const parseGasPrices = (
 ) => {
   if (!data) return getFallbackGasPrices();
   switch (source) {
-    case gasUtils.GAS_PRICE_SOURCES.ETH_GAS_STATION:
-      return parseGasPricesEthGasStation(data);
     case gasUtils.GAS_PRICE_SOURCES.POLYGON_GAS_STATION:
       return parseGasPricesPolygonGasStation(data);
     default:

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -196,10 +196,7 @@ const parseGasPricesPolygonGasStation = (data: GasPricesAPIData) => {
  * @param {Object} data
  * @param {String} network
  */
-export const parseLegacyGasPrices = (
-  data: GasPricesAPIData,
-  network: Network
-) => {
+export const parseL2GasPrices = (data: GasPricesAPIData, network: Network) => {
   if (!data) return getFallbackGasPrices();
   switch (network) {
     case Network.polygon:

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -195,7 +195,7 @@ const parseGasPricesPolygonGasStation = (data: GasPricesAPIData) => {
  * @param {Object} data
  * @param {String} source
  */
-export const parseGasPrices = (
+export const parseLegacyGasPrices = (
   data: GasPricesAPIData,
   source = gasUtils.GAS_PRICE_SOURCES.ETHERSCAN
 ) => {

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -28,10 +28,11 @@ import {
   SelectedGasFee,
 } from '@rainbow-me/entities';
 import { toHex } from '@rainbow-me/handlers/web3';
+import { Network } from '@rainbow-me/helpers/networkTypes';
 
 type BigNumberish = number | string | BigNumber;
 
-const { CUSTOM, FAST, NORMAL, URGENT, GasSpeedOrder } = gasUtils;
+const { CUSTOM, FAST, GasSpeedOrder, NORMAL, URGENT } = gasUtils;
 
 /**
  * @desc parse ether gas prices
@@ -193,16 +194,18 @@ const parseGasPricesPolygonGasStation = (data: GasPricesAPIData) => {
 /**
  * @desc parse ether gas prices
  * @param {Object} data
- * @param {String} source
+ * @param {String} network
  */
 export const parseLegacyGasPrices = (
   data: GasPricesAPIData,
-  source = gasUtils.GAS_PRICE_SOURCES.ETHERSCAN
+  network: Network
 ) => {
   if (!data) return getFallbackGasPrices();
-  switch (source) {
-    case gasUtils.GAS_PRICE_SOURCES.POLYGON_GAS_STATION:
+  switch (network) {
+    case Network.polygon:
       return parseGasPricesPolygonGasStation(data);
+    case Network.arbitrum:
+    case Network.optimism:
     default:
       return parseL2GasPrices(data);
   }

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -45,10 +45,10 @@ export const getFallbackGasPrices = () => ({
   [URGENT]: defaultGasPriceFormat(URGENT, '0.5', '200'),
 });
 
-const parseGasPricesEtherscan = (data: GasPricesAPIData) => ({
+const parseL2GasPrices = (data: GasPricesAPIData) => ({
   [CUSTOM]: null,
   [FAST]: defaultGasPriceFormat(FAST, data.avgWait, data.average),
-  [NORMAL]: defaultGasPriceFormat(NORMAL, data.safeLowWait, data.safeLow),
+  [NORMAL]: defaultGasPriceFormat(NORMAL, data.avgWait, data.average),
   [URGENT]: defaultGasPriceFormat(URGENT, data.fastWait, data.fast),
 });
 
@@ -220,7 +220,7 @@ export const parseGasPrices = (
     case gasUtils.GAS_PRICE_SOURCES.POLYGON_GAS_STATION:
       return parseGasPricesPolygonGasStation(data);
     default:
-      return parseGasPricesEtherscan(data);
+      return parseL2GasPrices(data);
   }
 };
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -8,7 +8,7 @@ export {
 } from './accounts';
 export {
   getFallbackGasPrices,
-  parseLegacyGasPrices,
+  parseL2GasPrices,
   parseGasFeesBySpeed,
   defaultGasPriceFormat,
   parseLegacyGasFeesBySpeed,

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -8,7 +8,7 @@ export {
 } from './accounts';
 export {
   getFallbackGasPrices,
-  parseGasPrices,
+  parseLegacyGasPrices,
   parseGasFeesBySpeed,
   defaultGasPriceFormat,
   parseLegacyGasFeesBySpeed,

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -56,7 +56,7 @@ import { fromWei, greaterThanOrEqualTo, multiply } from '@rainbow-me/utilities';
 import { ethereumUtils, gasUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
-const { CUSTOM, NORMAL, URGENT, GAS_PRICE_SOURCES } = gasUtils;
+const { CUSTOM, NORMAL, URGENT } = gasUtils;
 
 const getGasPricePollingInterval = (network: Network): number => {
   switch (network) {
@@ -333,20 +333,16 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
 
         if (isLegacy) {
           let adjustedGasFees;
-          let source = GAS_PRICE_SOURCES.ETHERSCAN;
           if (network === networkTypes.polygon) {
-            source = GAS_PRICE_SOURCES.POLYGON_GAS_STATION;
             adjustedGasFees = await getPolygonGasPrices();
           } else if (network === networkTypes.arbitrum) {
-            source = GAS_PRICE_SOURCES.ARBITRUM_NODE;
             adjustedGasFees = await getArbitrumGasPrices();
           } else if (network === networkTypes.optimism) {
-            source = GAS_PRICE_SOURCES.OPTIMISM_NODE;
             adjustedGasFees = await getOptimismGasPrices();
           }
           const gasFeeParamsBySpeed = parseLegacyGasPrices(
             adjustedGasFees,
-            source
+            network
           );
           if (existingGasFees[CUSTOM] !== null) {
             // Preserve custom values while updating prices

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -57,7 +57,17 @@ import { ethereumUtils, gasUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
 const { CUSTOM, NORMAL, URGENT, GAS_PRICE_SOURCES } = gasUtils;
-const GAS_PRICE_INTERVAL = 5000; // 5 seconds
+
+const getGasPricePollingInterval = (network: Network) => {
+  switch (network) {
+    case networkTypes.polygon:
+      return 2000;
+    case networkTypes.arbitrum:
+      return 3000;
+    default:
+      return 5000;
+  }
+};
 
 let gasPricesHandle: NodeJS.Timeout | null = null;
 
@@ -415,7 +425,7 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
     } finally {
       gasPricesHandle = setTimeout(() => {
         watchGasPrices(network);
-      }, GAS_PRICE_INTERVAL);
+      }, getGasPricePollingInterval(network));
     }
   };
 

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -40,8 +40,8 @@ import {
   parseGasFeeParam,
   parseGasFees,
   parseGasFeesBySpeed,
+  parseL2GasPrices,
   parseLegacyGasFeesBySpeed,
-  parseLegacyGasPrices,
   parseRainbowMeteorologyData,
   weiToGwei,
 } from '@rainbow-me/parsers';
@@ -341,7 +341,7 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
           } else if (network === Network.optimism) {
             adjustedGasFees = await getOptimismGasPrices();
           }
-          const gasFeeParamsBySpeed = parseLegacyGasPrices(
+          const gasFeeParamsBySpeed = parseL2GasPrices(
             adjustedGasFees,
             network
           );

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -32,7 +32,7 @@ import {
   isHardHat,
   web3Provider,
 } from '@rainbow-me/handlers/web3';
-import networkTypes, { Network } from '@rainbow-me/helpers/networkTypes';
+import { Network } from '@rainbow-me/helpers/networkTypes';
 import {
   defaultGasParamsFormat,
   getFallbackGasPrices,
@@ -60,9 +60,9 @@ const { CUSTOM, NORMAL, URGENT } = gasUtils;
 
 const getGasPricePollingInterval = (network: Network): number => {
   switch (network) {
-    case networkTypes.polygon:
+    case Network.polygon:
       return 2000;
-    case networkTypes.arbitrum:
+    case Network.arbitrum:
       return 3000;
     default:
       return 5000;
@@ -100,13 +100,13 @@ const GAS_UPDATE_TRANSACTION_NETWORK = 'gas/GAS_UPDATE_TRANSACTION_NETWORK';
 const getNetworkNativeAsset = (assets: any[], network: Network) => {
   let nativeAssetAddress;
   switch (network) {
-    case networkTypes.polygon:
+    case Network.polygon:
       nativeAssetAddress = MATIC_POLYGON_ADDRESS;
       break;
-    case networkTypes.arbitrum:
+    case Network.arbitrum:
       nativeAssetAddress = ARBITRUM_ETH_ADDRESS;
       break;
-    case networkTypes.optimism:
+    case Network.optimism:
       nativeAssetAddress = OPTIMISM_ETH_ADDRESS;
       break;
     default:
@@ -199,8 +199,9 @@ export const gasUpdateToCustomGasFee = (gasParams: GasFeeParams) => async (
   const { assets } = getState().data;
   const { nativeCurrency } = getState().settings;
   const _gasLimit = gasLimit || defaultGasLimit;
+
   const nativeTokenPriceUnit =
-    txNetwork !== networkTypes.polygon
+    txNetwork !== Network.polygon
       ? ethereumUtils.getEthPriceUnit()
       : ethereumUtils.getMaticPriceUnit();
 
@@ -240,7 +241,7 @@ export const gasUpdateToCustomGasFee = (gasParams: GasFeeParams) => async (
   });
 };
 
-export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
+export const gasPricesStartPolling = (network = Network.mainnet) => async (
   dispatch: AppDispatch,
   getState: AppGetState
 ) => {
@@ -265,7 +266,7 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
   };
 
   const getArbitrumGasPrices = async () => {
-    const provider = await getProviderForNetwork(networkTypes.arbitrum);
+    const provider = await getProviderForNetwork(Network.arbitrum);
     const baseGasPrice = await provider.getGasPrice();
     const baseGasPriceGwei = weiToGwei(baseGasPrice.toString());
 
@@ -287,7 +288,7 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
   };
 
   const getOptimismGasPrices = async () => {
-    const provider = await getProviderForNetwork(networkTypes.optimism);
+    const provider = await getProviderForNetwork(Network.optimism);
     const baseGasPrice = await provider.getGasPrice();
     const gasPriceGwei = Number(weiToGwei(baseGasPrice.toString()));
 
@@ -333,11 +334,11 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
 
         if (isLegacy) {
           let adjustedGasFees;
-          if (network === networkTypes.polygon) {
+          if (network === Network.polygon) {
             adjustedGasFees = await getPolygonGasPrices();
-          } else if (network === networkTypes.arbitrum) {
+          } else if (network === Network.arbitrum) {
             adjustedGasFees = await getArbitrumGasPrices();
-          } else if (network === networkTypes.optimism) {
+          } else if (network === Network.optimism) {
             adjustedGasFees = await getOptimismGasPrices();
           }
           const gasFeeParamsBySpeed = parseLegacyGasPrices(
@@ -367,7 +368,7 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
             // Set a really gas estimate to guarantee that we're gonna be over
             // the basefee at the time we fork mainnet during our hardhat tests
             let baseFee = baseFeePerGas;
-            if (network === networkTypes.mainnet && IS_TESTING === 'true') {
+            if (network === Network.mainnet && IS_TESTING === 'true') {
               const providerUrl = (
                 web3Provider ||
                 ({} as {
@@ -491,13 +492,13 @@ export const gasUpdateTxFee = (
   const _selectedGasFeeOption =
     overrideGasOption || selectedGasFee.option || NORMAL;
   const nativeTokenPriceUnit =
-    txNetwork !== networkTypes.polygon
+    txNetwork !== Network.polygon
       ? ethereumUtils.getEthPriceUnit()
       : ethereumUtils.getMaticPriceUnit();
 
   if (
     isEmpty(gasFeeParamsBySpeed) ||
-    (txNetwork === networkTypes.optimism && l1GasFeeOptimism === null)
+    (txNetwork === Network.optimism && l1GasFeeOptimism === null)
   )
     return;
 

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -40,8 +40,8 @@ import {
   parseGasFeeParam,
   parseGasFees,
   parseGasFeesBySpeed,
-  parseGasPrices,
   parseLegacyGasFeesBySpeed,
+  parseLegacyGasPrices,
   parseRainbowMeteorologyData,
   weiToGwei,
 } from '@rainbow-me/parsers';
@@ -344,7 +344,10 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
             source = GAS_PRICE_SOURCES.OPTIMISM_NODE;
             adjustedGasFees = await getOptimismGasPrices();
           }
-          const gasFeeParamsBySpeed = parseGasPrices(adjustedGasFees, source);
+          const gasFeeParamsBySpeed = parseLegacyGasPrices(
+            adjustedGasFees,
+            source
+          );
           if (existingGasFees[CUSTOM] !== null) {
             // Preserve custom values while updating prices
             gasFeeParamsBySpeed[CUSTOM] = existingGasFees[CUSTOM];

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -58,7 +58,7 @@ import logger from 'logger';
 
 const { CUSTOM, NORMAL, URGENT, GAS_PRICE_SOURCES } = gasUtils;
 
-const getGasPricePollingInterval = (network: Network) => {
+const getGasPricePollingInterval = (network: Network): number => {
   switch (network) {
     case networkTypes.polygon:
       return 2000;
@@ -417,19 +417,20 @@ export const gasPricesStartPolling = (network = networkTypes.mainnet) => async (
       }
     });
 
-  const watchGasPrices = async (network: Network) => {
+  const watchGasPrices = async (network: Network, pollingInterval: number) => {
     try {
       await getGasPrices(network);
       // eslint-disable-next-line no-empty
     } catch (e) {
     } finally {
       gasPricesHandle = setTimeout(() => {
-        watchGasPrices(network);
-      }, getGasPricePollingInterval(network));
+        watchGasPrices(network, pollingInterval);
+      }, pollingInterval);
     }
   };
 
-  watchGasPrices(network);
+  const pollingInterval = getGasPricePollingInterval(network);
+  watchGasPrices(network, pollingInterval);
 };
 
 export const gasUpdateGasFeeOption = (

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -28,8 +28,8 @@ import {
 } from '@rainbow-me/handlers/gasFees';
 import {
   getProviderForNetwork,
-  isEIP1559LegacyNetwork,
   isHardHat,
+  isL2Network,
   web3Provider,
 } from '@rainbow-me/handlers/web3';
 import { Network } from '@rainbow-me/helpers/networkTypes';
@@ -330,9 +330,9 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
           gasFeeParamsBySpeed: existingGasFees,
           customGasFeeModifiedByUser,
         } = getState().gas;
-        const isLegacy = isEIP1559LegacyNetwork(network);
+        const isL2 = isL2Network(network);
 
-        if (isLegacy) {
+        if (isL2) {
           let adjustedGasFees;
           if (network === Network.polygon) {
             adjustedGasFees = await getPolygonGasPrices();
@@ -502,9 +502,9 @@ export const gasUpdateTxFee = (
   )
     return;
 
-  const isLegacyNetwork = isEIP1559LegacyNetwork(txNetwork);
+  const isL2 = isL2Network(txNetwork);
 
-  const gasFeesBySpeed = isLegacyNetwork
+  const gasFeesBySpeed = isL2
     ? parseLegacyGasFeesBySpeed(
         gasFeeParamsBySpeed,
         _gasLimit,

--- a/src/screens/SpeedUpAndCancelSheet.js
+++ b/src/screens/SpeedUpAndCancelSheet.js
@@ -28,7 +28,7 @@ import { Emoji, Text } from '../components/text';
 import { GasFeeTypes, TransactionStatusTypes } from '@rainbow-me/entities';
 import {
   getProviderForNetwork,
-  isEIP1559LegacyNetwork,
+  isL2Network,
   toHex,
 } from '@rainbow-me/handlers/web3';
 import { greaterThan } from '@rainbow-me/helpers/utilities';
@@ -328,7 +328,7 @@ export default function SpeedUpAndCancelSheet() {
           setData(hexData);
           setTo(tx.txTo);
           setGasLimit(hexGasLimit);
-          if (!isEIP1559LegacyNetwork(tx.network)) {
+          if (!isL2Network(tx.network)) {
             setTxType(GasFeeTypes.eip1559);
             const hexMaxPriorityFeePerGas = toHex(
               tx.maxPriorityFeePerGas.toString()

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -8,13 +8,6 @@ const SLOW = 'slow';
 
 const GasSpeedOrder = [NORMAL, FAST, URGENT, CUSTOM];
 
-const GAS_PRICE_SOURCES = {
-  ARBITRUM_NODE: 'arbitrumNode',
-  ETHERSCAN: 'etherscan',
-  OPTIMISM_NODE: 'optimismNode',
-  POLYGON_GAS_STATION: 'polygonGasStation',
-};
-
 const GAS_ICONS = {
   [CUSTOM]: 'gear',
   [FAST]: 'rocket',
@@ -33,7 +26,6 @@ export default {
   CUSTOM,
   FAST,
   GAS_ICONS,
-  GAS_PRICE_SOURCES,
   GAS_TRENDS,
   GasSpeedOrder,
   NORMAL,

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -10,7 +10,6 @@ const GasSpeedOrder = [NORMAL, FAST, URGENT, CUSTOM];
 
 const GAS_PRICE_SOURCES = {
   ARBITRUM_NODE: 'arbitrumNode',
-  ETH_GAS_STATION: 'ethGasStation',
   ETHERSCAN: 'etherscan',
   OPTIMISM_NODE: 'optimismNode',
   POLYGON_GAS_STATION: 'polygonGasStation',


### PR DESCRIPTION
Fixes RNBW-1984
Fixes RNBW-1985

## What changed (plus any additional context for devs)

- Specific network gas polling times
- Arbitrum and optimism default to NORMAL speed. In order to do this I had to update `parseL2GasPrices` since I was using the average price before.
- Changed `parseGasPricesEtherscan` to `parseL2GasPrices` just to be clear we don't user etherscan
- removed parse eth gas station
- 
## PoW (screenshots / screen recordings) https://recordit.co/jdi2MrGASb

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
