### PR TITLE
Fix balance update logic and fallbacks

### DIFF
--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -1,4 +1,5 @@
 import { Contract } from '@ethersproject/contracts';
+import { captureException } from '@sentry/react-native';
 import { get, toLower, uniqBy } from 'lodash';
 import isEqual from 'react-fast-compare';
 import { ETHERSCAN_API_KEY } from 'react-native-dotenv';
@@ -22,7 +23,6 @@ import {
 import { delay } from '@rainbow-me/utilities';
 import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
-import { captureException } from '@sentry/react-native';
 
 let lastUpdatePayload = null;
 // -- Constants --------------------------------------- //
@@ -60,7 +60,7 @@ const getMainnetAssetsFromCovalent = async (
   const data = await getAssetsFromCovalent(chainId, accountAddress, currency);
   if (data) {
     const updatedAt = new Date(data.updated_at).getTime();
-    const assets = data.items.map( item => {
+    const assets = data.items.map(item => {
       let contractAddress = item.contract_address;
       const isETH = toLower(contractAddress) === toLower(COVALENT_ETH_ADDRESS);
       if (isETH) {
@@ -280,7 +280,6 @@ const fetchAssetBalances = async (tokens, address, network) => {
     });
     return balances[address];
   } catch (e) {
-    
     logger.sentry(
       'Error fetching balances from balanceCheckerContract',
       network,
@@ -322,7 +321,7 @@ export const fetchOnchainBalances = ({
           )
         : mainnetAssets
       : chainAssets[network];
-  
+
   if (!assets.length && accountAssets.length) {
     assets = accountAssets.map(asset => ({
       asset: {
@@ -351,14 +350,12 @@ export const fetchOnchainBalances = ({
     return;
   }
 
-  
   const tokenAddresses = assets.map(({ asset: { asset_code } }) =>
     asset_code === ETH_ADDRESS
       ? ETHEREUM_ADDRESS_FOR_BALANCE_CONTRACT
       : toLower(asset_code)
   );
 
-  
   // Solution: we should return right here and prevent any (boken) state updates.
   const balances = await fetchAssetBalances(
     tokenAddresses,

--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -356,7 +356,6 @@ export const fetchOnchainBalances = ({
       : toLower(asset_code)
   );
 
-  // Solution: we should return right here and prevent any (boken) state updates.
   const balances = await fetchAssetBalances(
     tokenAddresses,
     accountAddress,

--- a/src/redux/optimismExplorer.js
+++ b/src/redux/optimismExplorer.js
@@ -14,6 +14,7 @@ import {
 } from '@rainbow-me/references';
 import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
+import { captureException } from '@sentry/react-native';
 
 let lastUpdatePayload = null;
 // -- Constants --------------------------------------- //
@@ -51,11 +52,12 @@ const fetchAssetBalances = async (tokens, address) => {
     });
     return balances[address];
   } catch (e) {
-    logger.log(
+    logger.sentry(
       'Error fetching balances from balanceCheckerContract',
       network,
       e
     );
+    captureException(new Error('fallbackExplorer::balanceChecker failure'));
     return null;
   }
 };
@@ -144,7 +146,7 @@ export const optimismExplorerInit = () => async (dispatch, getState) => {
 
       const newPayload = { assets: assetsWithBalance };
 
-      if (!isEqual(lastUpdatePayload, newPayload)) {
+      if (balances && !isEqual(lastUpdatePayload, newPayload)) {
         dispatch(
           addressAssetsReceived(
             {

--- a/src/redux/optimismExplorer.js
+++ b/src/redux/optimismExplorer.js
@@ -1,4 +1,5 @@
 import { Contract } from '@ethersproject/contracts';
+import { captureException } from '@sentry/react-native';
 import { toLower } from 'lodash';
 import isEqual from 'react-fast-compare';
 // eslint-disable-next-line import/no-cycle
@@ -14,7 +15,6 @@ import {
 } from '@rainbow-me/references';
 import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
-import { captureException } from '@sentry/react-native';
 
 let lastUpdatePayload = null;
 // -- Constants --------------------------------------- //


### PR DESCRIPTION
Fixes RNBW-1980  ( randomly showing ETH balance = 0 )

## What changed (plus any additional context for devs)
- Use covalent assets over mainnet assets (which have no balance / price)
- Prevent assets state updates when balance is missing on mainnet
- Prevent assets state updates when balance is missing on optimism

## PoW (screenshots / screen recordings)

Before: https://recordit.co/XvyI9hL2p3
After: http://recordit.co/UR6W9YiBqH

## Dev checklist for QA: what to test
- Pull to refresh / assets updating after sending txs
- set forceFallbackProvider = true and confirm asset balances work fine.

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
