### PR TITLE
Remove hardcoded fallback gas prices for L2 networks

### DIFF
--- a/src/components/expanded-state/custom-gas/FeesPanel.js
+++ b/src/components/expanded-state/custom-gas/FeesPanel.js
@@ -169,7 +169,6 @@ export default function FeesPanel({
     const currentBaseFee = currentBlockParams?.baseFeePerGas?.gwei || 0;
 
     let maxBaseFee;
-
     if (selectedOptionIsCustom) {
       // block more than 2 decimals on gwei value
       const decimals = Number(customMaxBaseFee) % 1;

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -33,18 +33,6 @@ type BigNumberish = number | string | BigNumber;
 
 const { CUSTOM, FAST, GasSpeedOrder, NORMAL, URGENT } = gasUtils;
 
-/**
- * @desc parse ether gas prices
- * @param {Object} data
- * @param {Boolean} short - use short format or not
- */
-export const getFallbackGasPrices = () => ({
-  [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(FAST, '2.5', '100'),
-  [NORMAL]: defaultGasPriceFormat(NORMAL, '2.5', '100'),
-  [URGENT]: defaultGasPriceFormat(URGENT, '0.5', '200'),
-});
-
 const parseOtherL2GasPrices = (data: GasPricesAPIData) => ({
   [CUSTOM]: null,
   [FAST]: defaultGasPriceFormat(FAST, data.avgWait, data.average),
@@ -196,7 +184,7 @@ const parseGasPricesPolygonGasStation = (data: GasPricesAPIData) => {
  * @param {String} network
  */
 export const parseL2GasPrices = (data: GasPricesAPIData, network: Network) => {
-  if (!data) return getFallbackGasPrices();
+  if (!data) return null;
   switch (network) {
     case Network.polygon:
       return parseGasPricesPolygonGasStation(data);

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -1,16 +1,5 @@
 import BigNumber from 'bignumber.js';
 import { map, zipObject } from 'lodash';
-import { getMinimalTimeUnitStringForMs } from '../helpers/time';
-import {
-  add,
-  convertRawAmountToBalance,
-  convertRawAmountToNativeDisplay,
-  divide,
-  greaterThan,
-  multiply,
-} from '../helpers/utilities';
-import ethUnits from '../references/ethereum-units.json';
-import timeUnits from '../references/time-units.json';
 import { gasUtils } from '../utils';
 import {
   ConfirmationTimeByPriorityFee,
@@ -29,6 +18,16 @@ import {
 } from '@rainbow-me/entities';
 import { toHex } from '@rainbow-me/handlers/web3';
 import { Network } from '@rainbow-me/helpers/networkTypes';
+import { getMinimalTimeUnitStringForMs } from '@rainbow-me/helpers/time';
+import { ethUnits, timeUnits } from '@rainbow-me/references';
+import {
+  add,
+  convertRawAmountToBalance,
+  convertRawAmountToNativeDisplay,
+  divide,
+  greaterThan,
+  multiply,
+} from '@rainbow-me/utilities';
 
 type BigNumberish = number | string | BigNumber;
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -7,7 +7,6 @@ export {
   parseAssetsNative,
 } from './accounts';
 export {
-  getFallbackGasPrices,
   parseL2GasPrices,
   parseGasFeesBySpeed,
   defaultGasPriceFormat,

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -346,10 +346,6 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
           );
 
           if (gasFeeParamsBySpeed) {
-            if (existingGasFees[CUSTOM] !== null) {
-              // Preserve custom values while updating prices
-              gasFeeParamsBySpeed[CUSTOM] = existingGasFees[CUSTOM];
-            }
             dispatch({
               payload: {
                 gasFeeParamsBySpeed,

--- a/src/references/index.ts
+++ b/src/references/index.ts
@@ -22,6 +22,7 @@ export { default as emojis } from './emojis.json';
 export { default as erc20ABI } from './erc20-abi.json';
 export { default as optimismGasOracleAbi } from './optimism-gas-oracle-abi.json';
 export { default as ethUnits } from './ethereum-units.json';
+export { default as timeUnits } from './time-units.json';
 export { DPI_ADDRESS } from './indexes';
 
 export { default as migratedTokens } from './migratedTokens.json';


### PR DESCRIPTION
Fixes RNBW-1989

## What changed (plus any additional context for devs)
We have fallback default gas prices in case we could not get updated gas prices from the network for L2s. This doesn't really make sense for our L2s.

## PoW (screenshots / screen recordings)
Will add

## Dev checklist for QA: what to test
Will add

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
