### PR TITLE
Check for network and transaction id while estimating gas

### DIFF
--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -136,6 +136,8 @@ const GasSpeedButton = ({
     selectedGasFee,
     selectedGasFeeOption,
     updateToCustomGasFee,
+    txNetwork,
+    transactionIdentifier,
   } = useGas();
 
   const [estimatedTimeValue, setEstimatedTimeValue] = useState(0);
@@ -151,6 +153,12 @@ const GasSpeedButton = ({
   // (and leave the number only!)
   // which gets added later in the formatGasPrice function
   const price = useMemo(() => {
+    if (
+      txNetwork !== currentNetwork ||
+      asset?.uniqueId !== transactionIdentifier
+    ) {
+      return null;
+    }
     const gasPrice =
       selectedGasFee?.gasFee?.estimatedFee?.native?.value?.display;
     if (isNil(gasPrice)) return null;

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -137,7 +137,7 @@ const GasSpeedButton = ({
     selectedGasFeeOption,
     updateToCustomGasFee,
     txNetwork,
-    transactionIdentifier,
+    transactionUniqueId,
   } = useGas();
 
   const [estimatedTimeValue, setEstimatedTimeValue] = useState(0);
@@ -155,7 +155,7 @@ const GasSpeedButton = ({
   const price = useMemo(() => {
     if (
       txNetwork !== currentNetwork ||
-      asset?.uniqueId !== transactionIdentifier
+      asset?.uniqueId !== transactionUniqueId
     ) {
       return null;
     }

--- a/src/hooks/useGas.ts
+++ b/src/hooks/useGas.ts
@@ -26,7 +26,7 @@ export default function useGas() {
         gasLimit,
         isSufficientGas,
         selectedGasFee,
-        transactionIdentifier,
+        transactionUniqueId,
         txNetwork,
       },
     }: AppState) => ({
@@ -38,7 +38,7 @@ export default function useGas() {
       isSufficientGas,
       selectedGasFee,
       selectedGasFeeOption: selectedGasFee.option,
-      transactionIdentifier,
+      transactionUniqueId,
       txNetwork,
     })
   );

--- a/src/hooks/useGas.ts
+++ b/src/hooks/useGas.ts
@@ -26,6 +26,8 @@ export default function useGas() {
         gasLimit,
         isSufficientGas,
         selectedGasFee,
+        transactionIdentifier,
+        txNetwork,
       },
     }: AppState) => ({
       currentBlockParams,
@@ -36,6 +38,8 @@ export default function useGas() {
       isSufficientGas,
       selectedGasFee,
       selectedGasFeeOption: selectedGasFee.option,
+      transactionIdentifier,
+      txNetwork,
     })
   );
 
@@ -63,9 +67,14 @@ export default function useGas() {
   );
 
   const updateTxFee = useCallback(
-    (newGasLimit, overrideGasOption, l1GasFeeOptimism = null) => {
+    (
+      newGasLimit,
+      overrideGasOption,
+      l1GasFeeOptimism = null,
+      id: string | undefined = undefined
+    ) => {
       dispatch(
-        gasUpdateTxFee(newGasLimit, overrideGasOption, l1GasFeeOptimism)
+        gasUpdateTxFee(newGasLimit, overrideGasOption, l1GasFeeOptimism, id)
       );
     },
     [dispatch]

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -84,6 +84,7 @@ interface GasState {
   confirmationTimeByPriorityFee: ConfirmationTimeByPriorityFee;
   customGasFeeModifiedByUser: boolean;
   l1GasFeeOptimism: BigNumber | null;
+  transactionIdentifier: null | string;
 }
 
 // -- Constants ------------------------------------------------------------- //
@@ -580,7 +581,8 @@ export const gasUpdateDefaultGasLimit = (
 export const gasUpdateTxFee = (
   updatedGasLimit?: number,
   overrideGasOption?: string,
-  l1GasFeeOptimism: BigNumber | null = null
+  l1GasFeeOptimism: BigNumber | null = null,
+  id?: string 
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
   const {
     defaultGasLimit,
@@ -611,7 +613,6 @@ export const gasUpdateTxFee = (
 
     const {
       isSufficientGas,
-      l1GasFeeOptimism,
       selectedGasFee: updatedSelectedGasFee,
       gasFeesBySpeed,
     } = getUpdatedGasFeeParams(
@@ -631,6 +632,7 @@ export const gasUpdateTxFee = (
         gasLimit: _gasLimit,
         isSufficientGas,
         selectedGasFee: updatedSelectedGasFee,
+        transactionIdentifier: id,
       },
       type: GAS_UPDATE_TX_FEE,
     });
@@ -656,6 +658,7 @@ const INITIAL_STATE: GasState = {
   isSufficientGas: null,
   l1GasFeeOptimism: null,
   selectedGasFee: {} as SelectedGasFee,
+  transactionIdentifier: null,
   txNetwork: null,
 };
 
@@ -706,6 +709,7 @@ export default (
         isSufficientGas: action.payload.isSufficientGas,
         l1GasFeeOptimism: action.payload.l1GasFeeOptimism,
         selectedGasFee: action.payload.selectedGasFee,
+        transactionIdentifier: action.payload.transactionIdentifier,
       };
     case GAS_UPDATE_GAS_PRICE_OPTION:
       return {

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -84,7 +84,7 @@ interface GasState {
   confirmationTimeByPriorityFee: ConfirmationTimeByPriorityFee;
   customGasFeeModifiedByUser: boolean;
   l1GasFeeOptimism: BigNumber | null;
-  transactionIdentifier: null | string;
+  transactionUniqueId: null | string;
 }
 
 // -- Constants ------------------------------------------------------------- //
@@ -632,7 +632,7 @@ export const gasUpdateTxFee = (
         gasLimit: _gasLimit,
         isSufficientGas,
         selectedGasFee: updatedSelectedGasFee,
-        transactionIdentifier: id,
+        transactionUniqueId: id,
       },
       type: GAS_UPDATE_TX_FEE,
     });
@@ -658,7 +658,7 @@ const INITIAL_STATE: GasState = {
   isSufficientGas: null,
   l1GasFeeOptimism: null,
   selectedGasFee: {} as SelectedGasFee,
-  transactionIdentifier: null,
+  transactionUniqueId: null,
   txNetwork: null,
 };
 
@@ -709,7 +709,7 @@ export default (
         isSufficientGas: action.payload.isSufficientGas,
         l1GasFeeOptimism: action.payload.l1GasFeeOptimism,
         selectedGasFee: action.payload.selectedGasFee,
-        transactionIdentifier: action.payload.transactionIdentifier,
+        transactionUniqueId: action.payload.transactionUniqueId,
       };
     case GAS_UPDATE_GAS_PRICE_OPTION:
       return {

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -582,7 +582,7 @@ export const gasUpdateTxFee = (
   updatedGasLimit?: number,
   overrideGasOption?: string,
   l1GasFeeOptimism: BigNumber | null = null,
-  id?: string 
+  id?: string
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
   const {
     defaultGasLimit,
@@ -602,7 +602,10 @@ export const gasUpdateTxFee = (
     // the rest is as the initial state value
     if (updatedGasLimit) {
       dispatch({
-        payload: updatedGasLimit,
+        payload: {
+          gasLimit: updatedGasLimit,
+          transactionUniqueId: id,
+        },
         type: GAS_UPDATE_GAS_LIMIT,
       });
     }
@@ -676,7 +679,8 @@ export default (
     case GAS_UPDATE_GAS_LIMIT:
       return {
         ...state,
-        gasLimit: action.payload,
+        gasLimit: action.payload.gasLimit,
+        transactionUniqueId: action.payload.transactionUniqueId,
       };
     case GAS_PRICES_SUCCESS:
       return {

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -631,6 +631,7 @@ export const gasUpdateTxFee = (
         gasFeesBySpeed,
         gasLimit: _gasLimit,
         isSufficientGas,
+        l1GasFeeOptimism,
         selectedGasFee: updatedSelectedGasFee,
         transactionUniqueId: id,
       },

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -442,7 +442,7 @@ export default function SendSheet(props) {
         txData,
         currentProvider
       );
-      updateTxFee(updatedGasLimit, null, l1GasFeeOptimism);
+      updateTxFee(updatedGasLimit, null, l1GasFeeOptimism, selected?.uniqueId);
     },
     [
       accountAddress,
@@ -490,7 +490,7 @@ export default function SendSheet(props) {
           if (network === networkTypes.optimism) {
             updateTxFeeForOptimism(updatedGasLimit);
           } else {
-            updateTxFee(updatedGasLimit, null);
+            updateTxFee(updatedGasLimit, null, null, selected?.uniqueId);
           }
         }
         // eslint-disable-next-line no-empty
@@ -787,12 +787,12 @@ export default function SendSheet(props) {
           if (currentNetwork === networkTypes.optimism) {
             updateTxFeeForOptimism(gasLimit);
           } else {
-            updateTxFee(gasLimit, null);
+            updateTxFee(gasLimit, null, null, selected?.uniqueId);
           }
         })
         .catch(e => {
           logger.sentry('Error calculating gas limit', e);
-          updateTxFee(null, null);
+          updateTxFee(null, null, null, selected?.uniqueId);
         });
     }
   }, [


### PR DESCRIPTION
Fixes RNBW-1964

## What changed (plus any additional context for devs)

I noticed that in redux we have a single place for price estimation. So while switching the network and changing transactions we have old data for a while, then they're updated to a new. This is the reason for the weird initial animation (from the previous estimation to the current one). Also, this is the reason for the linked bug (data between L1 and L2 are not consistent I guess)

The ultimate solution would be to either not store those things in Redux or to have them keyed in such a way we won't need to deal with this issue.

However, I propose for now something simpler that doesn't require rethinking the redux's structure. Together with data, I allow for storing the transaction's identifier. In case of sending we're caring of now, this is just a token's unique id. Then, in the `GasSpeedButton` we ignore data unless the network and id are matching. 

This will not impact heavily all places where we're using this button, because outside of SendSheet, the transaction's id will still be `undefined`, what's good. However, we will check network consistency, what's also good.

 


## PoW (screenshots / screen recordings)

https://streamable.com/nekptg

## Dev checklist for QA: what to test

[ ] check all places we're using GasButton
[ ] Verify that the bug is gone 

## Final checklist
[ x ] Assigned individual reviewers?
[ x ] Added labels?
