### PR TITLE
Remove unnecessary updateTxFee calls in SendSheet

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -587,7 +587,7 @@ export const gasUpdateTxFee = (
     (txNetwork === Network.optimism && l1GasFeeOptimism === null)
   ) {
     // if fee prices not ready, we need to store the gas limit for future calculations
-    // // the rest is as the initial state value
+    // the rest is as the initial state value
     if (updatedGasLimit) {
       dispatch({
         payload: updatedGasLimit,

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -88,6 +88,7 @@ interface GasState {
 // -- Constants ------------------------------------------------------------- //
 // const GAS_MULTIPLIER = 1.101;
 const GAS_UPDATE_DEFAULT_GAS_LIMIT = 'gas/GAS_UPDATE_DEFAULT_GAS_LIMIT';
+const GAS_UPDATE_GAS_LIMIT = 'gas/GAS_UPDATE_GAS_LIMIT';
 const GAS_PRICES_SUCCESS = 'gas/GAS_PRICES_SUCCESS';
 const GAS_FEES_SUCCESS = 'gas/GAS_FEES_SUCCESS';
 const GAS_PRICES_CUSTOM_UPDATE = 'gas/GAS_PRICES_CUSTOM_UPDATE';
@@ -587,15 +588,10 @@ export const gasUpdateTxFee = (
     (txNetwork === Network.optimism && l1GasFeeOptimism === null)
   ) {
     // if fee prices not ready, we need to store the gas limit for future calculations
-    // the rest is as the initial state value
+    // // the rest is as the initial state value
     dispatch({
-      payload: {
-        gasFeesBySpeed: {},
-        gasLimit: _gasLimit,
-        isSufficientGas: null,
-        selectedGasFee: {},
-      },
-      type: GAS_UPDATE_TX_FEE,
+      payload: _gasLimit,
+      type: GAS_UPDATE_GAS_LIMIT,
     });
   } else {
     const _selectedGasFeeOption =
@@ -658,6 +654,11 @@ export default (
       return {
         ...state,
         defaultGasLimit: action.payload,
+      };
+    case GAS_UPDATE_GAS_LIMIT:
+      return {
+        ...state,
+        gasLimit: action.payload,
       };
     case GAS_PRICES_SUCCESS:
       return {

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -581,7 +581,6 @@ export const gasUpdateTxFee = (
   } = getState().gas;
   const { assets } = getState().data;
   const { nativeCurrency } = getState().settings;
-  const _gasLimit = updatedGasLimit || gasLimit || defaultGasLimit;
 
   if (
     isEmpty(gasFeeParamsBySpeed) ||
@@ -589,13 +588,16 @@ export const gasUpdateTxFee = (
   ) {
     // if fee prices not ready, we need to store the gas limit for future calculations
     // // the rest is as the initial state value
-    dispatch({
-      payload: _gasLimit,
-      type: GAS_UPDATE_GAS_LIMIT,
-    });
+    if (updatedGasLimit) {
+      dispatch({
+        payload: updatedGasLimit,
+        type: GAS_UPDATE_GAS_LIMIT,
+      });
+    }
   } else {
     const _selectedGasFeeOption =
       overrideGasOption || selectedGasFee.option || NORMAL;
+    const _gasLimit = updatedGasLimit || gasLimit || defaultGasLimit;
 
     const {
       isSufficientGas,

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -580,41 +580,52 @@ export const gasUpdateTxFee = (
   } = getState().gas;
   const { assets } = getState().data;
   const { nativeCurrency } = getState().settings;
+  const _gasLimit = updatedGasLimit || gasLimit || defaultGasLimit;
 
   if (
     isEmpty(gasFeeParamsBySpeed) ||
     (txNetwork === Network.optimism && l1GasFeeOptimism === null)
-  )
-    return;
+  ) {
+    // if fee prices not ready, we need to store the gas limit for future calculations
+    // the rest is as the initial state value
+    dispatch({
+      payload: {
+        gasFeesBySpeed: {},
+        gasLimit: _gasLimit,
+        isSufficientGas: null,
+        selectedGasFee: {},
+      },
+      type: GAS_UPDATE_TX_FEE,
+    });
+  } else {
+    const _selectedGasFeeOption =
+      overrideGasOption || selectedGasFee.option || NORMAL;
 
-  const _selectedGasFeeOption =
-    overrideGasOption || selectedGasFee.option || NORMAL;
-  const _gasLimit = updatedGasLimit || gasLimit || defaultGasLimit;
-
-  const {
-    isSufficientGas,
-    selectedGasFee: updatedSelectedGasFee,
-    gasFeesBySpeed,
-  } = getUpdatedGasFeeParams(
-    assets,
-    currentBlockParams,
-    gasFeeParamsBySpeed,
-    _gasLimit,
-    nativeCurrency,
-    _selectedGasFeeOption,
-    txNetwork,
-    l1GasFeeOptimism
-  );
-
-  dispatch({
-    payload: {
-      gasFeesBySpeed,
-      gasLimit: _gasLimit,
+    const {
       isSufficientGas,
       selectedGasFee: updatedSelectedGasFee,
-    },
-    type: GAS_UPDATE_TX_FEE,
-  });
+      gasFeesBySpeed,
+    } = getUpdatedGasFeeParams(
+      assets,
+      currentBlockParams,
+      gasFeeParamsBySpeed,
+      _gasLimit,
+      nativeCurrency,
+      _selectedGasFeeOption,
+      txNetwork,
+      l1GasFeeOptimism
+    );
+
+    dispatch({
+      payload: {
+        gasFeesBySpeed,
+        gasLimit: _gasLimit,
+        isSufficientGas,
+        selectedGasFee: updatedSelectedGasFee,
+      },
+      type: GAS_UPDATE_TX_FEE,
+    });
+  }
 };
 
 export const gasPricesStopPolling = () => (dispatch: AppDispatch) => {

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -40,7 +40,6 @@ import {
   useColorForAsset,
   useContacts,
   useCurrentNonce,
-  useEffectDebugger,
   useGas,
   useMagicAutofocus,
   useMaxInputBalance,
@@ -759,7 +758,7 @@ export default function SendSheet(props) {
     checkAddress(recipient);
   }, [checkAddress, recipient]);
 
-  useEffectDebugger(() => {
+  useEffect(() => {
     if (!currentProvider?._network?.chainId) return;
     const currentProviderNetwork = ethereumUtils.getNetworkFromChainId(
       currentProvider._network.chainId

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -40,6 +40,7 @@ import {
   useColorForAsset,
   useContacts,
   useCurrentNonce,
+  useEffectDebugger,
   useGas,
   useMagicAutofocus,
   useMaxInputBalance,
@@ -758,7 +759,7 @@ export default function SendSheet(props) {
     checkAddress(recipient);
   }, [checkAddress, recipient]);
 
-  useEffect(() => {
+  useEffectDebugger(() => {
     if (!currentProvider?._network?.chainId) return;
     const currentProviderNetwork = ethereumUtils.getNetworkFromChainId(
       currentProvider._network.chainId
@@ -768,8 +769,7 @@ export default function SendSheet(props) {
       assetNetwork === currentNetwork &&
       currentProviderNetwork === currentNetwork &&
       isValidAddress &&
-      !isEmpty(selected) &&
-      !isEmpty(gasFeeParamsBySpeed)
+      !isEmpty(selected)
     ) {
       estimateGasLimit(
         {
@@ -806,7 +806,6 @@ export default function SendSheet(props) {
     updateTxFee,
     updateTxFeeForOptimism,
     network,
-    gasFeeParamsBySpeed,
   ]);
 
   return (


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Removing the `gasFeeParamsBySpeed` dep in useEffect which was triggering the gas limit estimation on new params, it was already there before EIP1559 https://github.com/rainbow-me/rainbow/blob/0f845d0bfffb6e9087289c26c101b2cd7bc154ec/src/screens/SendSheet.js#L781 but we don't need it anymore since we're checking for empty params inside the redux action https://github.com/rainbow-me/rainbow/blob/develop/src/redux/gas.ts#L585

## PoW (screenshots / screen recordings)

now the gas limit estimation doesn't depend on new gas price data https://recordit.co/yFFfMC5kap

## Dev checklist for QA: what to test

- gas prices still updating

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
