### PR TITLE
fix optimism gasprices updates

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -83,6 +83,7 @@ interface GasState {
   currentBlockParams: CurrentBlockParams;
   confirmationTimeByPriorityFee: ConfirmationTimeByPriorityFee;
   customGasFeeModifiedByUser: boolean;
+  l1GasFeeOptimism: BigNumber | null;
 }
 
 // -- Constants ------------------------------------------------------------- //
@@ -382,6 +383,10 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
           selectedGasFee,
           txNetwork,
           currentBlockParams,
+          isSufficientGas: lastIsSufficientGas,
+          selectedGasFee: lastSelectedGasFee,
+          gasFeesBySpeed: lastGasFeesBySpeed,
+          l1GasFeeOptimism,
         } = getState().gas;
         const { assets } = getState().data;
         const { nativeCurrency } = getState().settings;
@@ -406,27 +411,29 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
 
           const _selectedGasFeeOption = selectedGasFee.option || NORMAL;
           const _gasLimit = gasLimit || defaultGasLimit;
-
           const {
-            isSufficientGas,
-            selectedGasFee: updatedSelectedGasFee,
-            gasFeesBySpeed,
-          } = getUpdatedGasFeeParams(
-            assets,
-            currentBlockParams,
-            gasFeeParamsBySpeed,
-            _gasLimit,
-            nativeCurrency,
-            _selectedGasFeeOption,
-            txNetwork,
-            null
-          );
+            isSufficientGas: updatedIsSufficientGas = lastIsSufficientGas,
+            selectedGasFee: updatedSelectedGasFee = lastSelectedGasFee,
+            gasFeesBySpeed: updatedGasFeesBySpeed = lastGasFeesBySpeed,
+          } =
+            network === Network.optimism && l1GasFeeOptimism === null
+              ? {}
+              : getUpdatedGasFeeParams(
+                  assets,
+                  currentBlockParams,
+                  gasFeeParamsBySpeed,
+                  _gasLimit,
+                  nativeCurrency,
+                  _selectedGasFeeOption,
+                  txNetwork,
+                  l1GasFeeOptimism
+                );
 
           dispatch({
             payload: {
               gasFeeParamsBySpeed,
-              gasFeesBySpeed,
-              isSufficientGas: isSufficientGas,
+              gasFeesBySpeed: updatedGasFeesBySpeed,
+              isSufficientGas: updatedIsSufficientGas,
               selectedGasFee: updatedSelectedGasFee,
             },
             type: GAS_FEES_SUCCESS,
@@ -580,7 +587,6 @@ export const gasUpdateTxFee = (
   } = getState().gas;
   const { assets } = getState().data;
   const { nativeCurrency } = getState().settings;
-
   if (
     isEmpty(gasFeeParamsBySpeed) ||
     (txNetwork === Network.optimism && l1GasFeeOptimism === null)
@@ -611,6 +617,7 @@ export const gasUpdateTxFee = (
       gasFeesBySpeed,
       gasLimit: _gasLimit,
       isSufficientGas,
+      l1GasFeeOptimism,
       selectedGasFee: updatedSelectedGasFee,
     },
     type: GAS_UPDATE_TX_FEE,
@@ -634,6 +641,7 @@ const INITIAL_STATE: GasState = {
   gasFeesBySpeed: {},
   gasLimit: null,
   isSufficientGas: null,
+  l1GasFeeOptimism: null,
   selectedGasFee: {} as SelectedGasFee,
   txNetwork: null,
 };
@@ -678,6 +686,7 @@ export default (
         gasFeesBySpeed: action.payload.gasFeesBySpeed,
         gasLimit: action.payload.gasLimit,
         isSufficientGas: action.payload.isSufficientGas,
+        l1GasFeeOptimism: action.payload.l1GasFeeOptimism,
         selectedGasFee: action.payload.selectedGasFee,
       };
     case GAS_UPDATE_GAS_PRICE_OPTION:

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -391,7 +391,7 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
         const { assets } = getState().data;
         const { nativeCurrency } = getState().settings;
         const isL2 = isL2Network(network);
-
+        let dataIsReady = true;
         if (isL2) {
           let adjustedGasFees;
           if (network === Network.polygon) {
@@ -400,6 +400,7 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
             adjustedGasFees = await getArbitrumGasPrices();
           } else if (network === Network.optimism) {
             adjustedGasFees = await getOptimismGasPrices();
+            dataIsReady = l1GasFeeOptimism !== null;
           }
 
           const gasFeeParamsBySpeed = parseL2GasPrices(
@@ -412,22 +413,25 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
           const _selectedGasFeeOption = selectedGasFee.option || NORMAL;
           const _gasLimit = gasLimit || defaultGasLimit;
           const {
-            isSufficientGas: updatedIsSufficientGas = lastIsSufficientGas,
-            selectedGasFee: updatedSelectedGasFee = lastSelectedGasFee,
-            gasFeesBySpeed: updatedGasFeesBySpeed = lastGasFeesBySpeed,
-          } =
-            network === Network.optimism && l1GasFeeOptimism === null
-              ? {}
-              : getUpdatedGasFeeParams(
-                  assets,
-                  currentBlockParams,
-                  gasFeeParamsBySpeed,
-                  _gasLimit,
-                  nativeCurrency,
-                  _selectedGasFeeOption,
-                  txNetwork,
-                  l1GasFeeOptimism
-                );
+            isSufficientGas: updatedIsSufficientGas,
+            selectedGasFee: updatedSelectedGasFee,
+            gasFeesBySpeed: updatedGasFeesBySpeed,
+          } = dataIsReady
+            ? getUpdatedGasFeeParams(
+                assets,
+                currentBlockParams,
+                gasFeeParamsBySpeed,
+                _gasLimit,
+                nativeCurrency,
+                _selectedGasFeeOption,
+                txNetwork,
+                l1GasFeeOptimism
+              )
+            : {
+                gasFeesBySpeed: lastGasFeesBySpeed,
+                isSufficientGas: lastIsSufficientGas,
+                selectedGasFee: lastSelectedGasFee,
+              };
 
           dispatch({
             payload: {


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Since we're now updating gas fees on each new prices information we get to the app, according to each networks polling, for optimism we need to consolidate the optimism fee and the L1 fees that right now are in different parts of the app, we get optimism fee from redux and the L1 fee from the transaction confirmation and send screens. Because of this I added the `l1GasFeeOptimism` to redux, so now we can calculate the complete fee in one place, and if `l1GasFeeOptimism` is not defined yet (because it comes from other component and takes a bit of time) we don't show any fee at all.

I started to clean the code and ended up in a refactor that I wouldn't want to merge so close to a release.

## PoW (screenshots / screen recordings) https://recordit.co/2BZEzVm3DA

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
