### PR TITLE
Fix: do not update balance if onchain fetch fails

### DIFF
--- a/src/hooks/useUpdateAssetOnchainBalance.js
+++ b/src/hooks/useUpdateAssetOnchainBalance.js
@@ -23,7 +23,7 @@ export default function useUpdateAssetOnchainBalance() {
         network,
         provider
       );
-      if (balance?.amount !== assetToUpdate?.balance?.amount) {
+      if (balance && balance?.amount !== assetToUpdate?.balance?.amount) {
         // Now we need to update the asset
         // First in the state
         successCallback({ ...assetToUpdate, balance });


### PR DESCRIPTION
## What changed (plus any additional context for devs)
If the onchain balance fetch fails or throws an error, the balance returned is null, and could slip through this check before updating the balance (resulting in NaN in some places)

## PoW (screenshots / screen recordings)
Will add

## Dev checklist for QA: what to test
This is just a safety check no op for instances when the on chain balance checker fails on us.
While we were having this arbitrum token mapping issue, when switching to "Arbitrum Eth" in send flow, gas price in the gas speed button would remain $NaN.

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
