### PR TITLE
fix android tx list menu

### DIFF
--- a/src/components/transaction-list/TransactionList.js
+++ b/src/components/transaction-list/TransactionList.js
@@ -224,11 +224,11 @@ export default function TransactionList({
                   type: 'cancel',
                 });
                 break;
-              case TransactionActions.close:
-                return;
-              default: {
+              case blockExplorerAction:
                 ethereumUtils.openTransactionInBlockExplorer(hash, network);
                 break;
+              default: {
+                return;
               }
             }
           }


### PR DESCRIPTION
Fixes RNBW-2016

## What changed (plus any additional context for devs)

our default case was to open the block explorer which is no good, we want to close the sheet for this case and only open the block explorer when its pressed

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2021-12-10-12-45-57.mp4

## Dev checklist for QA: what to test
menu items for tx list should work as expected

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
