### PR TITLE
add `clearTimeout` to gasPricesHandle in redux gas

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -528,6 +528,7 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
       // eslint-disable-next-line no-empty
     } catch (e) {
     } finally {
+      gasPricesHandle && clearTimeout(gasPricesHandle);
       gasPricesHandle = setTimeout(() => {
         watchGasPrices(network, pollingInterval);
       }, pollingInterval);


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

clearTimeout to avoid having two threads running at the same time. Try to repro going to the send screen and changing the asset between networks many times, at some point the prices start to act strange.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
