### PR TITLE
WC - delay checking native asset balance

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -252,7 +252,7 @@ export default function TransactionConfirmationScreen() {
       );
       setNativeAsset(asset);
     };
-    getNativeAsset();
+    network && getNativeAsset();
   }, [accountInfo.address, allAssets, network]);
 
   const {


### PR DESCRIPTION
Fixes RNBW-1983

## What changed (plus any additional context for devs)

we now wait until we have set the network before checking the native balance for the request. 

## PoW (screenshots / screen recordings)
before: https://cloud.skylarbarrera.com/Screen-Shot-2021-12-12-17-40-06.85.png
after: https://cloud.skylarbarrera.com/Screen-Recording-2021-12-12-22-49-08.mp4

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
