### PR TITLE
gas speed button: load time and price at same time

### DIFF
--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -177,7 +177,7 @@ const GasSpeedButton = ({
       if (animatedValue === null || isNaN(animatedValue)) {
         return 0;
       }
-      setGasPriceReady(true);
+      !gasPriceReady && setGasPriceReady(true);
       // L2's are very cheap,
       // so let's default to the last 2 significant decimals
       if (isL2) {
@@ -195,7 +195,7 @@ const GasSpeedButton = ({
         }`;
       }
     },
-    [isL2, nativeCurrencySymbol, nativeCurrency]
+    [gasPriceReady, isL2, nativeCurrencySymbol, nativeCurrency]
   );
 
   const openCustomOptions = useCallback(focusTo => {

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -174,7 +174,7 @@ const GasSpeedButton = ({
 
   const formatGasPrice = useCallback(
     animatedValue => {
-      if (gasIsNotReady || animatedValue === null || isNaN(animatedValue)) {
+      if (animatedValue === null || isNaN(animatedValue)) {
         return 0;
       }
       setGasPriceReady(true);
@@ -195,7 +195,7 @@ const GasSpeedButton = ({
         }`;
       }
     },
-    [gasIsNotReady, isL2, nativeCurrencySymbol, nativeCurrency]
+    [isL2, nativeCurrencySymbol, nativeCurrency]
   );
 
   const openCustomOptions = useCallback(focusTo => {

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -138,6 +138,7 @@ const GasSpeedButton = ({
     updateToCustomGasFee,
   } = useGas();
 
+  const [gasPriceReady, setGasPriceReady] = useState(false);
   const [estimatedTimeValue, setEstimatedTimeValue] = useState(0);
   const [estimatedTimeUnit, setEstimatedTimeUnit] = useState('min');
   const [shouldOpenCustomGasSheet, setShouldOpenCustomGasSheet] = useState({
@@ -173,9 +174,10 @@ const GasSpeedButton = ({
 
   const formatGasPrice = useCallback(
     animatedValue => {
-      if (animatedValue === null || isNaN(animatedValue)) {
+      if (gasIsNotReady || animatedValue === null || isNaN(animatedValue)) {
         return 0;
       }
+      setGasPriceReady(true);
       // L2's are very cheap,
       // so let's default to the last 2 significant decimals
       if (isL2) {
@@ -193,7 +195,7 @@ const GasSpeedButton = ({
         }`;
       }
     },
-    [isL2, nativeCurrencySymbol, nativeCurrency]
+    [gasIsNotReady, isL2, nativeCurrencySymbol, nativeCurrency]
   );
 
   const openCustomOptions = useCallback(focusTo => {
@@ -260,6 +262,7 @@ const GasSpeedButton = ({
   );
 
   const formatTransactionTime = useCallback(() => {
+    if (!gasPriceReady) return '';
     const time = parseFloat(estimatedTimeValue || 0).toFixed(0);
     let timeSymbol = '~';
 
@@ -291,6 +294,7 @@ const GasSpeedButton = ({
     estimatedTimeUnit,
     estimatedTimeValue,
     gasFeesBySpeed,
+    gasPriceReady,
     selectedGasFeeOption,
   ]);
 


### PR DESCRIPTION
Fixes RNBW-2025

## What changed (plus any additional context for devs)

The time amount is now waiting for the animated number to render the price. Seems to be a delay inside the animation itself so I couldn't use `gasIsNotReady`

## PoW (screenshots / screen recordings)

https://recordit.co/riK4AhzAdV

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
