### PR TITLE
gas speed button: take the first speed or normal by default and height on smaller devices

### DIFF
--- a/src/components/expanded-state/CustomGasState.js
+++ b/src/components/expanded-state/CustomGasState.js
@@ -18,6 +18,7 @@ import {
 } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import { margin } from '@rainbow-me/styles';
+import { deviceUtils } from '@rainbow-me/utils';
 
 const FOOTER_HEIGHT = 76;
 const CONTENT_HEIGHT = 310;
@@ -58,7 +59,9 @@ export default function CustomGasState({ asset }) {
     CONTENT_HEIGHT + FOOTER_HEIGHT + (android ? 10 : 0);
 
   const sheetHeightWithKeyboard =
-    sheetHeightWithoutKeyboard + keyboardHeight + (android ? 0 : 0);
+    sheetHeightWithoutKeyboard +
+    keyboardHeight +
+    (deviceUtils.isSmallPhone ? 30 : 0);
 
   const currentGasTrend = useMemo(
     () => getTrendKey(currentBlockParams?.trend),

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -470,8 +470,9 @@ const GasSpeedButton = ({
     const gasOptions = speeds || GasSpeedOrder;
     const currentSpeedIndex = gasOptions?.indexOf(selectedGasFeeOption);
     // If the option isn't available anymore, we need to reset it
+    // take the first speed or normal by default
     if (currentSpeedIndex === -1) {
-      handlePressSpeedOption(NORMAL);
+      handlePressSpeedOption(gasOptions?.[0] || NORMAL);
     }
   }, [handlePressSpeedOption, speeds, selectedGasFeeOption, isL2]);
 


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Taking the first of the available speeds by default, this was causing to show NORMAL instead of urgent in speed ups and cancels

## PoW (screenshots / screen recordings)

https://recordit.co/9UVBwwdCFQ
ignore the pending swaps, i did a bunch on hardhat and they're still there

## Dev checklist for QA: what to test

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
