### PR TITLE
Fix network switching issues with WC

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,6 +63,7 @@ import { analyticsUserIdentifier } from './utils/keychainConstants';
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 import { Portal } from 'react-native-cool-modals/Portal';
+import networkTypes from './helpers/networkTypes';
 
 const WALLETCONNECT_SYNC_DELAY = 500;
 
@@ -254,7 +255,7 @@ class App extends Component {
     Navigation.setTopLevelNavigator(navigatorRef);
 
   handleTransactionConfirmed = tx => {
-    const network = ethereumUtils.getNetworkFromChainId(tx.chainId);
+    const network = tx.network || Network.mainnet;
     const isL2 = isL2Network(network);
     const updateBalancesAfter = (timeout, isL2, network) => {
       setTimeout(() => {

--- a/src/App.js
+++ b/src/App.js
@@ -46,6 +46,7 @@ import handleDeeplink from './handlers/deeplinks';
 import { runWalletBackupStatusChecks } from './handlers/walletReadyEvents';
 import { isL2Network } from './handlers/web3';
 import RainbowContextWrapper from './helpers/RainbowContext';
+import networkTypes from './helpers/networkTypes';
 import { registerTokenRefreshListener, saveFCMToken } from './model/firebase';
 import * as keychain from './model/keychain';
 import { loadAddress } from './model/wallet';
@@ -58,12 +59,10 @@ import store from './redux/store';
 import { uniswapPairsInit } from './redux/uniswap';
 import { walletConnectLoadState } from './redux/walletconnect';
 import { rainbowTokenList } from './references';
-import { ethereumUtils } from './utils';
 import { analyticsUserIdentifier } from './utils/keychainConstants';
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 import { Portal } from 'react-native-cool-modals/Portal';
-import networkTypes from './helpers/networkTypes';
 
 const WALLETCONNECT_SYNC_DELAY = 500;
 
@@ -255,7 +254,7 @@ class App extends Component {
     Navigation.setTopLevelNavigator(navigatorRef);
 
   handleTransactionConfirmed = tx => {
-    const network = tx.network || Network.mainnet;
+    const network = tx.network || networkTypes.mainnet;
     const isL2 = isL2Network(network);
     const updateBalancesAfter = (timeout, isL2, network) => {
       setTimeout(() => {

--- a/src/components/walletconnect-list/WalletConnectListItem.js
+++ b/src/components/walletconnect-list/WalletConnectListItem.js
@@ -100,7 +100,7 @@ export default function WalletConnectListItem({
   }, [wallets, walletNames, network, account]);
 
   const connectionNetworkInfo = useMemo(() => {
-    const network = ethereumUtils.getNetworkFromChainId(chainId);
+    const network = ethereumUtils.getNetworkFromChainId(Number(chainId));
     return {
       chainId,
       color: colors.networkColors[network],

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -550,22 +550,6 @@ export const removeWalletConnector = peerId => (dispatch, getState) => {
   });
 };
 
-export const walletConnectUpdateSessions = () => (dispatch, getState) => {
-  const { accountAddress, chainId } = getState().settings;
-  const { walletConnectors } = getState().walletconnect;
-
-  Object.keys(walletConnectors).forEach(key => {
-    const connector = walletConnectors[key];
-    const newSessionData = {
-      accounts: [accountAddress],
-      chainId,
-    };
-    connector.updateSession(newSessionData);
-
-    saveWalletConnectSession(connector.peerId, connector.session);
-  });
-};
-
 export const walletConnectUpdateSessionConnectorByDappUrl = (
   dappUrl,
   accountAddress,

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -353,6 +353,7 @@ const listenOnNewMessages = walletConnector => (dispatch, getState) => {
                 accounts: [accountAddress],
                 chainId: numericChainId,
               });
+              dispatch(setWalletConnector(walletConnector));
               saveWalletConnectSession(
                 walletConnector.peerId,
                 walletConnector.session

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -343,7 +343,7 @@ export default function SendSheet(props) {
     if (isEmpty(selected)) return;
     if (currentProvider?._network?.chainId) {
       const currentProviderNetwork = ethereumUtils.getNetworkFromChainId(
-        currentProvider._network.chainId
+        Number(currentProvider._network.chainId)
       );
 
       const assetNetwork = isL2Asset(selected?.type) ? selected.type : network;
@@ -763,8 +763,8 @@ export default function SendSheet(props) {
   useEffect(() => {
     if (!currentProvider?._network?.chainId) return;
     const currentProviderNetwork = ethereumUtils.getNetworkFromChainId(
-      currentProvider._network.chainId
-    );
+      Number(currentProvider._network.chainId)
+      );
     const assetNetwork = isL2Asset(selected?.type) ? selected.type : network;
     if (
       assetNetwork === currentNetwork &&

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -764,7 +764,7 @@ export default function SendSheet(props) {
     if (!currentProvider?._network?.chainId) return;
     const currentProviderNetwork = ethereumUtils.getNetworkFromChainId(
       Number(currentProvider._network.chainId)
-      );
+    );
     const assetNetwork = isL2Asset(selected?.type) ? selected.type : network;
     if (
       assetNetwork === currentNetwork &&


### PR DESCRIPTION
Fixes [RNBW-2077](https://linear.app/rainbow/issue/RNBW-2077/wrong-chain-showed-in-connected-apps-after-chain-switching-is)

Dapps that ask for a wallet to switch chains are successful, but the change is not displayed visually in our "Connected Apps" sheet (we always show them connected to Ethereum Mainnet). When users initiate a transaction, they see the expected chain.

_Note: this shouldn't be confused with chain switching **within** Rainbow_

## What changed (plus any additional context for devs)

- `chainId`s need to be converted from strings to numbers for `ethereumUtils.getNetworkFromChainId`. We do this in some places, but not others.
- wallet connection changes needed to be persisted to redux when listening for wallet connect chain adding/switching events, this is important for dapps on L2s to reflect correct chain in our "connected apps".

## PoW (screenshots / screen recordings)

Video of broken version on current `develop` branch

https://user-images.githubusercontent.com/3009331/146468794-d1a6aeda-1e40-4b54-84e7-80aa02648fcc.mp4

Video of fixed version on `@bruno/fix-wc-network-display`

https://user-images.githubusercontent.com/3009331/146475133-956ecffb-1bcc-4150-96d4-1bd2a5504221.mp4

## Dev checklist for QA: what to test

1. Connect to L2 dapp like Hop (hop.exchange, see above video.)
2. Validate that you are connected to Mainnet
3. Initiate a transaction from L2 --> L1, i.e. Arbitrum to Mainnet.
4. Tap "Send" (in Hop)
5. Go to Rainbow, confirm chain switching. Message should show "Arbitrum One" in text.
6. Check your Connected Apps:
  - Expected: Hop will be connected to "Arbitrum"
  - Actual: Hop is connected to "Mainnet"
7. Go back to Hop. Tap "Send" again to bridge transfer.
8. Go back to Rainbow. See that the transaction is using the Expected Chain (meaning that only our Connected Apps list needs to be updated)

## Final checklist
- [x] Assigned individual reviewers?
- [x] Added labels?
