### PR TITLE
Fix eth icon on android after removing ReactCoinIcon

### DIFF
--- a/src/components/coin-icon/CoinIconFallback.js
+++ b/src/components/coin-icon/CoinIconFallback.js
@@ -2,12 +2,14 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
 import { Centered } from '../layout';
+import EthIcon from '@rainbow-me/assets/eth-icon.png';
 import { useBooleanState, useColorForAsset } from '@rainbow-me/hooks';
 import { ImageWithCachedMetadata } from '@rainbow-me/images';
 import { borders, fonts, position, shadow } from '@rainbow-me/styles';
 import {
   FallbackIcon,
   getUrlForTrustIconFallback,
+  isETH,
   magicMemo,
 } from '@rainbow-me/utils';
 
@@ -77,6 +79,9 @@ const CoinIconFallback = fallbackProps => {
     address,
   ]);
 
+  const eth = isETH(address);
+  const url = eth ? EthIcon : imageUrl;
+
   return (
     <Centered height={height} width={width}>
       {!showImage && (
@@ -91,7 +96,7 @@ const CoinIconFallback = fallbackProps => {
       <FallbackImageElement
         {...fallbackProps}
         color={fallbackIconColor}
-        imageUrl={imageUrl}
+        imageUrl={url}
         onError={hideFallbackImage}
         onLoad={showFallbackImage}
         showImage={showImage}

--- a/src/components/images/ImageWithCachedMetadata.js
+++ b/src/components/images/ImageWithCachedMetadata.js
@@ -8,7 +8,10 @@ const ImageWithCachedMetadata = (
 ) => {
   const { onCacheImageMetadata } = useImageMetadata(imageUrl);
 
-  const source = useMemo(() => ({ cache, uri: imageUrl }), [cache, imageUrl]);
+  const source = useMemo(
+    () => (typeof imageUrl === 'number' ? imageUrl : { cache, uri: imageUrl }),
+    [cache, imageUrl]
+  );
 
   const handleLoad = useCallback(
     event => {


### PR DESCRIPTION
Fixes https://rainbowhaus.slack.com/archives/CU889KPME/p1639550798277100

## What changed (plus any additional context for devs)

use local eth asset. 
I modified slightly `ImageWithCachedMetadata` to allow for rendering local images.

## PoW (screenshots / screen recordings)

![image](https://user-images.githubusercontent.com/25709300/146161115-c907855f-7f3d-4b49-bfd4-958a8d498cfc.png)


## Dev checklist for QA: what to test

Open wallet on android 

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
