### PR TITLE
fix button long press

### DIFF
--- a/android/app/src/main/java/com/swmansion/gesturehandler/react/RNZoomableButtonManager.java
+++ b/android/app/src/main/java/com/swmansion/gesturehandler/react/RNZoomableButtonManager.java
@@ -1,5 +1,6 @@
 package com.swmansion.gesturehandler.react;
 import android.content.Context;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.animation.Animation;
 import android.view.animation.Interpolator;
@@ -26,6 +27,7 @@ public class RNZoomableButtonManager extends
         int mDuration = 160;
         float pivotX = 0.5f;
         float pivotY = 0.5f;
+        boolean shouldLongPressEndPress = false;
 
 
         public ZoomableButtonViewGroup(Context context) {
@@ -71,6 +73,9 @@ public class RNZoomableButtonManager extends
                 }
                 mLongPressTimer.cancel();
                 mLongPressTimer = new Timer();
+                if (shouldLongPressEndPress) {
+                    animate(false);
+                }
             }
 
             return super.onTouchEvent(ev);
@@ -89,7 +94,9 @@ public class RNZoomableButtonManager extends
                         mIsTaskScheduled = false;
                         mIsLongTaskScheduled = true;
                         onReceivePressEvent(true);
-                        animate(false);
+                        if (!shouldLongPressEndPress) {
+                            animate(false);
+                        }
                     }
                 }, mMinLongPressDuration);
             }
@@ -151,6 +158,11 @@ public class RNZoomableButtonManager extends
     @ReactProp(name = "scaleTo")
     public void setScaleTo(ZoomableButtonViewGroup view, float scaleTo) {
         view.mScaleTo = scaleTo;
+    }
+
+    @ReactProp(name = "shouldLongPressEndPress")
+    public void setShouldLongPressEndPress(ZoomableButtonViewGroup view, boolean shouldLongPressEndPress) {
+        view.shouldLongPressEndPress = shouldLongPressEndPress;
     }
 
     @ReactProp(name = "duration")

--- a/ios/Button.swift
+++ b/ios/Button.swift
@@ -89,7 +89,11 @@ class Button : RCTView {
       scale: scaleTo,
       useHaptic: useLateHaptic ? nil : hapticType
     )
-    onPressStart([:])
+    if shouldLongPressEndPress {
+      onPress([:])
+    } else {
+      onPressStart([:])
+    }
   }
 
   override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -121,7 +125,9 @@ class Button : RCTView {
       if touchInRange(location: location, tolerance: self.touchMoveTolerance * 0.8) {
           let useHaptic = useLateHaptic && enableHapticFeedback ? hapticType : nil
           animator = animateTapEnd(duration: pressOutDuration == -1 ? duration : pressOutDuration, useHaptic: useHaptic)
-          onPress([:])
+          if shouldLongPressEndPress == false {
+            onPress([:])
+          }
           if throttle {
             blocked = true;
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
@@ -211,6 +211,7 @@ const SimpleScaleButton = ({
           onPress={onNativePress}
           rippleColor={processColor('transparent')}
           scaleTo={scaleTo}
+          shouldLongPressEndPress={shouldLongPressEndPress}
           style={{ overflow: 'visible' }}
           transformOrigin={transformOrigin}
         >

--- a/src/components/expanded-state/custom-gas/FeesGweiInput.js
+++ b/src/components/expanded-state/custom-gas/FeesGweiInput.js
@@ -10,7 +10,8 @@ import { usePrevious } from '@rainbow-me/hooks';
 
 const PLUS_ACTION_TYPE = 'plus';
 const MINUS_ACTION_TYPE = 'minus';
-const DELAY_THRESHOLD = 69;
+const LONG_PRESS_DELAY_THRESHOLD = 69;
+const MIN_LONG_PRESS_DELAY_THRESHOLD = 100;
 
 const Wrapper = styled(Row)``;
 
@@ -36,6 +37,7 @@ const GweiStepButton = ({
 }) => {
   return (
     <StepButtonWrapper
+      minLongPressDuration={MIN_LONG_PRESS_DELAY_THRESHOLD}
       onLongPress={onLongPress}
       onLongPressEnded={onLongPressEnded}
       onPress={onPress}
@@ -81,7 +83,7 @@ export default function FeesGweiInput({
   const onLongPressLoop = useCallback(async () => {
     setTrigger(true);
     setTrigger(false);
-    await delay(DELAY_THRESHOLD);
+    await delay(LONG_PRESS_DELAY_THRESHOLD);
     longPressHandle.current && onLongPressLoop();
   }, []);
 

--- a/src/components/expanded-state/custom-gas/FeesGweiInput.js
+++ b/src/components/expanded-state/custom-gas/FeesGweiInput.js
@@ -11,7 +11,7 @@ import { usePrevious } from '@rainbow-me/hooks';
 const PLUS_ACTION_TYPE = 'plus';
 const MINUS_ACTION_TYPE = 'minus';
 const LONG_PRESS_DELAY_THRESHOLD = 69;
-const MIN_LONG_PRESS_DELAY_THRESHOLD = 160;
+const MIN_LONG_PRESS_DELAY_THRESHOLD = 200;
 
 const Wrapper = styled(Row)``;
 

--- a/src/components/expanded-state/custom-gas/FeesGweiInput.js
+++ b/src/components/expanded-state/custom-gas/FeesGweiInput.js
@@ -38,7 +38,7 @@ const GweiStepButton = ({
     <StepButtonWrapper
       onLongPress={onLongPress}
       onLongPressEnded={onLongPressEnded}
-      onPressStart={onPress}
+      onPress={onPress}
       shouldLongPressEndPress={shouldLongPressEndPress}
       useLateHaptic={false}
     >
@@ -91,14 +91,16 @@ export default function FeesGweiInput({
   }, [onLongPressLoop]);
 
   const onPlusLongPress = useCallback(() => {
+    onPlusPress();
     setActionType(PLUS_ACTION_TYPE);
     onLongPress();
-  }, [onLongPress]);
+  }, [onLongPress, onPlusPress]);
 
   const onMinusLongPress = useCallback(() => {
+    onMinusPress();
     setActionType(MINUS_ACTION_TYPE);
     onLongPress();
-  }, [onLongPress]);
+  }, [onLongPress, onMinusPress]);
 
   const onInputPress = useCallback(() => {
     inputRef?.current?.focus();

--- a/src/components/expanded-state/custom-gas/FeesGweiInput.js
+++ b/src/components/expanded-state/custom-gas/FeesGweiInput.js
@@ -11,7 +11,7 @@ import { usePrevious } from '@rainbow-me/hooks';
 const PLUS_ACTION_TYPE = 'plus';
 const MINUS_ACTION_TYPE = 'minus';
 const LONG_PRESS_DELAY_THRESHOLD = 69;
-const MIN_LONG_PRESS_DELAY_THRESHOLD = 100;
+const MIN_LONG_PRESS_DELAY_THRESHOLD = 160;
 
 const Wrapper = styled(Row)``;
 
@@ -93,16 +93,14 @@ export default function FeesGweiInput({
   }, [onLongPressLoop]);
 
   const onPlusLongPress = useCallback(() => {
-    onPlusPress();
     setActionType(PLUS_ACTION_TYPE);
     onLongPress();
-  }, [onLongPress, onPlusPress]);
+  }, [onLongPress]);
 
   const onMinusLongPress = useCallback(() => {
-    onMinusPress();
     setActionType(MINUS_ACTION_TYPE);
     onLongPress();
-  }, [onLongPress, onMinusPress]);
+  }, [onLongPress]);
 
   const onInputPress = useCallback(() => {
     inputRef?.current?.focus();


### PR DESCRIPTION
Fixes RNBW-2044

## What changed (plus any additional context for devs)

Improved the usage of longPress in iOS and fixed it on android

- https://github.com/rainbow-me/rainbow/commit/2ff86aba295f80c82a1587506189e941d3552429 `GweiStepButton` is only using `onPress` now (not `onPressStart`) and now the callbacks calls will depend on `shouldLongPressEndPress` inside `Button.swift`. Having both was making the callback trigger twice, I saw that pattern in other places where `onPress` and `onPressStart` are different, but here I need one method dependent on `shouldLongPressEndPress`.
- https://github.com/rainbow-me/rainbow/commit/476fd0a12e67280954721eba5fbe8c3e3dbaa05a added a `minLongPressDuration` of 100 because it was taking too long to trigger the longPress event and 69 way to short, I found myself pressing it just once but the event triggering twice.
- https://github.com/rainbow-me/rainbow/commit/9c6f7624f4d61c1ecfa6b3eed6fad6eb7425d087 added a `longPress` animation situation, where if `shouldLongPressEndPress` is true the button will be scaled from the first press `ACTION_DOWN` until the button is released `ACTION_UP`

@christianbaroni  I also addressed your comment https://github.com/rainbow-me/rainbow/pull/2684#discussion_r769043608 here https://github.com/rainbow-me/rainbow/compare/@esteban/onlongpress-button?expand=1#diff-9a2ecfd54464c27930517caf06e6d3d32e8fa76dd7b5e81146199fe9b6061cf3R96 and https://github.com/rainbow-me/rainbow/compare/@esteban/onlongpress-button?expand=1#diff-9a2ecfd54464c27930517caf06e6d3d32e8fa76dd7b5e81146199fe9b6061cf3R102

## PoW (screenshots / screen recordings)

https://recordit.co/7MjPZKM25u

## Dev checklist for QA: what to test

- button being pressed and long pressed
- the only buttons with long press functionality should be the + / - in the fees panel
- 
## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
