### PR TITLE
Remove default balance title that was hiding wallet selector

### DIFF
--- a/e2e/importPrivateKeyFlow.spec.js
+++ b/e2e/importPrivateKeyFlow.spec.js
@@ -55,11 +55,7 @@ describe('Import from private key flow', () => {
 
   it('without 0x - Should say "TKEY" in the Profile Screen header', async () => {
     await Helpers.swipe('wallet-screen', 'right');
-    if (device.getPlatform() === 'android') {
-      await Helpers.checkIfExistsByText('TKEY');
-    } else {
-      await Helpers.checkIfElementByTextIsVisible('TKEY');
-    }
+    await Helpers.checkIfExistsByText('TKEY');
   });
 
   afterAll(async () => {

--- a/e2e/importPrivateKeyFlow0x.spec.js
+++ b/e2e/importPrivateKeyFlow0x.spec.js
@@ -52,11 +52,7 @@ describe('Import from private key flow', () => {
 
   it('with 0x - Should say "PKEY" in the Profile Screen header', async () => {
     await Helpers.swipe('wallet-screen', 'right');
-    if (device.getPlatform() === 'android') {
-      await Helpers.checkIfExistsByText('PKEY');
-    } else {
-      await Helpers.checkIfElementByTextIsVisible('PKEY');
-    }
+    await Helpers.checkIfExistsByText('PKEY');
   });
 
   afterAll(async () => {

--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -52,7 +52,6 @@ function rowRenderer(type: CellType, { uid }: { uid: string }) {
           case CellType.ASSETS_HEADER:
             return (
               <AssetListHeader
-                title="Balances"
                 totalValue={(data as AssetsHeaderExtraData).value}
               />
             );


### PR DESCRIPTION
## What changed (plus any additional context for devs)
The `title` used to not be sent for the regular use of `AssetListHeader`.
With the asset list changes, we've started sending it as "Balances" but that caused the wallet selector to not appear.

Code of interest: https://github.com/rainbow-me/rainbow/blob/develop/src/components/asset-list/AssetListHeader.js#L134

The only place that was using the "Balances" title was the EmptyAssetList (and it still is) as can be seen here: https://github.com/rainbow-me/rainbow/blob/develop/src/components/asset-list/AssetList.js#L32

## PoW (screenshots / screen recordings)
Before:
![IMG_0129](https://user-images.githubusercontent.com/1285228/146308671-e5cf9c93-5f73-49c9-ba5d-e20e349b126b.jpg)

After:
<img width="186" alt="Screen Shot 2021-12-15 at 8 22 12 PM" src="https://user-images.githubusercontent.com/1285228/146308692-5d397b7c-1d5f-47f4-a4b8-6d143ba26e8b.png">


## Dev checklist for QA: what to test
Confirm that the wallet screen shows the drop down wallet selector

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
