### PR TITLE
@jin/tidy up

### DIFF
--- a/src/hooks/useCurrentNonce.ts
+++ b/src/hooks/useCurrentNonce.ts
@@ -8,13 +8,15 @@ import logger from 'logger';
 
 export default function useCurrentNonce(
   accountAddress: EthereumAddress,
-  network: Network
+  network?: Network
 ) {
   const nonceInState = useSelector((state: AppState) => {
+    if (!network) return undefined;
     return state.nonceManager[accountAddress.toLowerCase()]?.[network]?.nonce;
   });
   const getNextNonce = useCallback(async () => {
     try {
+      if (!network) return undefined;
       const provider = await getProviderForNetwork(network);
       const transactionCount = await provider.getTransactionCount(
         accountAddress,
@@ -38,7 +40,7 @@ export default function useCurrentNonce(
       return nextNonce;
     } catch (e) {
       logger.log('Error determining next nonce: ', e);
-      return null;
+      return undefined;
     }
   }, [accountAddress, network, nonceInState]);
 

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -157,7 +157,7 @@ export default function TransactionConfirmationScreen() {
   const { colors } = useTheme();
   const { allAssets } = useAccountAssets();
   const [provider, setProvider] = useState();
-  const [network, setNetwork] = useState();
+  const [currentNetwork, setCurrentNetwork] = useState();
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [methodName, setMethodName] = useState(null);
   const calculatingGasLimit = useRef(false);
@@ -168,7 +168,7 @@ export default function TransactionConfirmationScreen() {
   const { wallets, walletNames, switchToWalletWithAddress } = useWallets();
   const balances = useWalletBalances(wallets);
   const { accountAddress, nativeCurrency } = useAccountSettings();
-  const getNextNonce = useCurrentNonce(accountAddress, network);
+  const getNextNonce = useCurrentNonce(accountAddress, currentNetwork);
   const keyboardHeight = useKeyboardHeight();
   const dispatch = useDispatch();
   const { params: routeParams } = useRoute();
@@ -212,43 +212,45 @@ export default function TransactionConfirmationScreen() {
     const profileInfo = getAccountProfileInfo(
       selectedWallet,
       walletNames,
-      network,
+      currentNetwork,
       address
     );
     return {
       ...profileInfo,
       address,
     };
-  }, [network, walletConnector?._accounts, walletNames, wallets]);
+  }, [currentNetwork, walletConnector?._accounts, walletNames, wallets]);
 
   const isL2 = useMemo(() => {
-    return isL2Network(network);
-  }, [network]);
+    return isL2Network(currentNetwork);
+  }, [currentNetwork]);
 
   useEffect(() => {
-    setNetwork(
+    setCurrentNetwork(
       ethereumUtils.getNetworkFromChainId(Number(walletConnector?._chainId))
     );
   }, [walletConnector?._chainId]);
 
   useEffect(() => {
     const initProvider = async () => {
-      const p = isL2 ? await getProviderForNetwork(network) : web3Provider;
+      const p = isL2
+        ? await getProviderForNetwork(currentNetwork)
+        : web3Provider;
       setProvider(p);
     };
-    network && initProvider();
-  }, [isL2, network]);
+    currentNetwork && initProvider();
+  }, [isL2, currentNetwork]);
 
   useEffect(() => {
     const getNativeAsset = async () => {
       const asset = await ethereumUtils.getNativeAssetForNetwork(
-        network,
+        currentNetwork,
         accountInfo.address
       );
       setNativeAsset(asset);
     };
-    network && getNativeAsset();
-  }, [accountInfo.address, allAssets, network]);
+    currentNetwork && getNativeAsset();
+  }, [accountInfo.address, allAssets, currentNetwork]);
 
   const {
     gasLimit,
@@ -267,7 +269,7 @@ export default function TransactionConfirmationScreen() {
       isEmpty(selectedGasFee?.gasFee) ||
       isEmpty(gasFeeParamsBySpeed) ||
       !nativeAsset ||
-      !network ||
+      !currentNetwork ||
       isSufficientGasChecked
     )
       return;
@@ -277,7 +279,7 @@ export default function TransactionConfirmationScreen() {
     isSufficientGas,
     isSufficientGasChecked,
     nativeAsset,
-    network,
+    currentNetwork,
     selectedGasFee,
     selectedGasFeeOption,
     updateGasFeeOption,
@@ -303,9 +305,9 @@ export default function TransactionConfirmationScreen() {
 
   const handleL2DisclaimerPress = useCallback(() => {
     navigate(Routes.EXPLAIN_SHEET, {
-      type: network,
+      type: currentNetwork,
     });
-  }, [navigate, network]);
+  }, [navigate, currentNetwork]);
 
   const fetchMethodName = useCallback(
     async data => {
@@ -336,9 +338,9 @@ export default function TransactionConfirmationScreen() {
       ReactNativeHapticFeedback.trigger('notificationSuccess');
     }
     InteractionManager.runAfterInteractions(() => {
-      if (network) {
+      if (currentNetwork) {
         if (!isMessageRequest) {
-          startPollingGasFees(network);
+          startPollingGasFees(currentNetwork);
           fetchMethodName(params[0].data);
         } else {
           setMethodName(lang.t('wallet.message_signing.request'));
@@ -351,7 +353,7 @@ export default function TransactionConfirmationScreen() {
     fetchMethodName,
     isMessageRequest,
     method,
-    network,
+    currentNetwork,
     openAutomatically,
     params,
     startPollingGasFees,
@@ -457,7 +459,7 @@ export default function TransactionConfirmationScreen() {
     } finally {
       logger.log('Setting gas limit to', convertHexToString(gas));
 
-      if (network === networkTypes.optimism) {
+      if (currentNetwork === networkTypes.optimism) {
         const l1GasFeeOptimism = await ethereumUtils.calculateL1FeeOptimism(
           txPayload,
           provider
@@ -467,7 +469,7 @@ export default function TransactionConfirmationScreen() {
         updateTxFee(gas, null);
       }
     }
-  }, [network, params, provider, updateTxFee]);
+  }, [currentNetwork, params, provider, updateTxFee]);
 
   useEffect(() => {
     if (
@@ -544,7 +546,7 @@ export default function TransactionConfirmationScreen() {
     isMessageRequest,
     isSufficientGas,
     method,
-    network,
+    currentNetwork,
     params,
     selectedGasFee,
     walletBalance.amount,
@@ -561,7 +563,7 @@ export default function TransactionConfirmationScreen() {
         gasLimitFromPayload: convertHexToString(gasLimitFromPayload),
       });
 
-      if (network === networkTypes.mainnet) {
+      if (currentNetwork === networkTypes.mainnet) {
         // Estimate the tx with gas limit padding before sending
         const rawGasLimit = await estimateGasWithPadding(
           txPayload,
@@ -647,7 +649,7 @@ export default function TransactionConfirmationScreen() {
           from: displayDetails?.request?.from,
           gasLimit,
           hash: result.hash,
-          network,
+          network: currentNetwork,
           nonce: result.nonce,
           to: displayDetails?.request?.to,
           value: result.value.toString(),
@@ -701,7 +703,7 @@ export default function TransactionConfirmationScreen() {
     method,
     params,
     selectedGasFee,
-    network,
+    currentNetwork,
     gasLimit,
     provider,
     accountInfo.address,
@@ -872,7 +874,7 @@ export default function TransactionConfirmationScreen() {
 
     if (isTransactionDisplayType(method) && request?.asset) {
       const priceOfNativeAsset = ethereumUtils.getPriceOfNativeAssetForNetwork(
-        network
+        currentNetwork
       );
       const amount = request?.value ?? '0.00';
       const nativeAmount = multiply(priceOfNativeAsset, amount);
@@ -900,7 +902,7 @@ export default function TransactionConfirmationScreen() {
         value={request?.value}
       />
     );
-  }, [isMessageRequest, method, nativeCurrency, network, request]);
+  }, [isMessageRequest, method, nativeCurrency, currentNetwork, request]);
 
   const offset = useSharedValue(0);
   const sheetOpacity = useSharedValue(1);
@@ -958,7 +960,7 @@ export default function TransactionConfirmationScreen() {
     if (
       request?.asset &&
       walletBalance &&
-      network &&
+      currentNetwork &&
       provider &&
       nativeAsset &&
       !isEmpty(selectedGasFee)
@@ -967,7 +969,7 @@ export default function TransactionConfirmationScreen() {
     }
   }, [
     nativeAsset,
-    network,
+    currentNetwork,
     provider,
     ready,
     request?.asset,
@@ -1023,7 +1025,7 @@ export default function TransactionConfirmationScreen() {
                 <DappLogo
                   dappName={dappName || ''}
                   imageUrl={imageUrl || ''}
-                  network={network}
+                  network={currentNetwork}
                 />
                 <Row marginBottom={android ? -6 : 5}>
                   <Text
@@ -1073,7 +1075,7 @@ export default function TransactionConfirmationScreen() {
                   <Column margin={android ? 24 : 0} width="100%">
                     <Row height={android ? 0 : 19} />
                     <L2Disclaimer
-                      assetType={network}
+                      assetType={currentNetwork}
                       colors={colors}
                       hideDivider
                       onPress={handleL2DisclaimerPress}
@@ -1126,7 +1128,7 @@ export default function TransactionConfirmationScreen() {
             )}
           </AnimatedSheet>
           {!isMessageRequest && (
-            <GasSpeedButton currentNetwork={network} theme="dark" />
+            <GasSpeedButton network={currentNetwork} theme="dark" />
           )}
         </Column>
       </SlackSheet>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
This is a tidy up PR to rename `network` to `currentNetwork` in the `TransactionConfirmationScreen`. This is for clarity as `network` is often used to describe the general app-wide `network` (such as mainnet or testnets), while `currentNetwork` is transaction specific and can support L2s.

Also updated `useCurrentNonce` to return `undefined` when the `currentNetwork` is not passed, as can be the case initially when the `currentNetwork` has not been set.
