### PR TITLE
Link brief small balances to the brief balances selector

### DIFF
--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -338,10 +338,16 @@ const withBriefBalanceSection = (
     !collectibles.length
   );
 
+  const savingsTotalValue = find(
+    savingsSection,
+    item => item.uid === 'savings-header'
+  );
+
   const totalBalanceWithSavingsValue = add(
     totalBalancesValue,
-    get(savingsSection, 'totalValue', 0)
+    savingsTotalValue?.value ?? 0
   );
+
   const totalBalanceWithAllSectionValues = add(
     totalBalanceWithSavingsValue,
     uniswapTotal
@@ -503,7 +509,7 @@ const briefBalanceSectionSelector = createSelector(
     pinnedCoinsSelector,
     hiddenCoinsSelector,
     uniqueTokensSelector,
-    balanceSavingsSectionSelector,
+    briefBalanceSavingsSectionSelector,
     uniswapTotalSelector,
   ],
   withBriefBalanceSection

--- a/src/hooks/useInitializeAccountData.js
+++ b/src/hooks/useInitializeAccountData.js
@@ -4,6 +4,7 @@ import { InteractionManager } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { explorerInit } from '../redux/explorer';
 import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
+import { updatePositions } from '@rainbow-me/redux/usersPositions';
 import logger from 'logger';
 
 export default function useInitializeAccountData() {
@@ -19,6 +20,11 @@ export default function useInitializeAccountData() {
       InteractionManager.runAfterInteractions(async () => {
         logger.sentry('Initialize uniqueTokens');
         await dispatch(uniqueTokensRefreshState());
+      });
+
+      InteractionManager.runAfterInteractions(async () => {
+        logger.sentry('Initialize pool positions');
+        dispatch(updatePositions());
       });
     } catch (error) {
       logger.sentry('Error initializing account data');

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -201,7 +201,6 @@ export default function WalletScreen() {
           isWalletEthZero={isWalletEthZero}
           network={network}
           scrollViewTracker={scrollViewTracker}
-          sections={sections}
         />
       </FabWrapper>
     </WalletPage>

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -16,7 +16,6 @@ import {
   ScanHeaderButton,
 } from '../components/header';
 import { Page, RowWithMargins } from '../components/layout';
-import { useEth } from '../utils/ethereumUtils';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
 import {
   useAccountEmptyState,
@@ -37,7 +36,6 @@ import {
   emitChartsRequest,
   emitPortfolioRequest,
 } from '@rainbow-me/redux/explorer';
-import { updatePositions } from '@rainbow-me/redux/usersPositions';
 import { position } from '@rainbow-me/styles';
 
 const HeaderOpacityToggler = styled(OpacityToggler).attrs(({ isVisible }) => ({
@@ -81,14 +79,7 @@ export default function WalletScreen() {
     shouldRefetchSavings,
   } = useWalletSectionsData();
 
-  const eth = useEth();
-  const numberOfPools = sections.find(({ pools }) => pools)?.data.length ?? 0;
-
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    eth?.price?.value && dispatch(updatePositions());
-  }, [dispatch, eth?.price?.value, numberOfPools]);
 
   const { addressSocket, assetsSocket } = useSelector(
     ({ explorer: { addressSocket, assetsSocket } }) => ({


### PR DESCRIPTION
## What changed (plus any additional context for devs)
In `buildWalletSections` we have two exports - one is the brief selector and the other is the original selector.

The brief selectors were mostly separate from the “old” selectors - except for one place, where a “brief” selector was still using an “old” selector

The commit history is clean - you can step through each commit, and it will be logically separate.

Other changes:
- moved the updating of pool positions to the "init account data" hook
- removed the passing along of "sections" data to the WalletScreen's asset list (as this is now using RAL2)