### PR TITLE
Remove useUniswapAssetsInWallet check in useAsset hook

### DIFF
--- a/src/hooks/useAsset.js
+++ b/src/hooks/useAsset.js
@@ -2,7 +2,6 @@ import { find, matchesProperty } from 'lodash';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import useAccountAssets from './useAccountAssets';
-import useUniswapAssetsInWallet from './useUniswapAssetsInWallet';
 import { AssetTypes } from '@rainbow-me/entities';
 import NetworkTypes from '@rainbow-me/helpers/networkTypes';
 import store from '@rainbow-me/redux/store';
@@ -58,24 +57,16 @@ export default function useAsset(asset) {
   const genericAssets = useSelector(
     ({ data: { genericAssets } }) => genericAssets
   );
-  const uniswapAssetsInWallet = useUniswapAssetsInWallet();
 
   return useMemo(() => {
     if (!asset) return null;
 
     let matched = null;
     if (asset.type === AssetTypes.token) {
-      const uniswapAsset = find(
-        uniswapAssetsInWallet,
+      matched = find(
+        allAssets,
         matchesProperty('address', asset.mainnet_address || asset.address)
       );
-
-      matched = uniswapAsset
-        ? uniswapAsset
-        : find(
-            allAssets,
-            matchesProperty('address', asset.mainnet_address || asset.address)
-          );
 
       if (!matched) {
         matched = find(allAssets, matchesProperty('uniqueId', asset.uniqueId));
@@ -92,5 +83,5 @@ export default function useAsset(asset) {
     }
 
     return matched || asset;
-  }, [allAssets, asset, collectibles, genericAssets, uniswapAssetsInWallet]);
+  }, [allAssets, asset, collectibles, genericAssets]);
 }

--- a/src/hooks/useAsset.js
+++ b/src/hooks/useAsset.js
@@ -63,14 +63,8 @@ export default function useAsset(asset) {
 
     let matched = null;
     if (asset.type === AssetTypes.token) {
-      matched = find(
-        allAssets,
-        matchesProperty('address', asset.mainnet_address || asset.address)
-      );
+      matched = find(allAssets, matchesProperty('uniqueId', asset.uniqueId));
 
-      if (!matched) {
-        matched = find(allAssets, matchesProperty('uniqueId', asset.uniqueId));
-      }
       if (!matched) {
         matched = genericAssets?.[asset.mainnet_address || asset.address];
       }


### PR DESCRIPTION
The `useAsset` hook first checks if assets are in `useUniswapAssetsInWallet` which is a subset of assets in `allAssets` so we don't need to do this.