### PR TITLE
Memo for BalanceCoinRow

### DIFF
--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -14,6 +14,7 @@ import CoinCheckButton from './CoinCheckButton';
 import CoinName from './CoinName';
 import CoinRow from './CoinRow';
 import { useIsCoinListEditedSharedValue } from '@rainbow-me/helpers/SharedValuesContext';
+import { buildAssetUniqueIdentifier } from '@rainbow-me/helpers/assets';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 
@@ -96,6 +97,13 @@ const TopRow = ({ name, native, nativeCurrencySymbol }) => {
       </PriceContainer>
     </TopRowContainer>
   );
+};
+
+const arePropsEqual = (prev, next) => {
+  const itemIdentifier = buildAssetUniqueIdentifier(prev.item);
+  const nextItemIdentifier = buildAssetUniqueIdentifier(next.item);
+  const isSameItem = itemIdentifier === nextItemIdentifier;
+  return isSameItem;
 };
 
 const BalanceCoinRow = ({
@@ -183,4 +191,4 @@ const BalanceCoinRow = ({
   );
 };
 
-export default React.memo(BalanceCoinRow);
+export default React.memo(BalanceCoinRow, arePropsEqual);

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -10,7 +10,6 @@ import { LayoutAnimation, View } from 'react-native';
 import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import useAdditionalAssetData from '../../../hooks/useAdditionalAssetData';
 import { ModalContext } from '../../../react-native-cool-modals/NativeStackView';
 import L2Disclaimer from '../../L2Disclaimer';
 import { ButtonPressAnimation } from '../../animations';
@@ -41,6 +40,7 @@ import { isL2Network } from '@rainbow-me/handlers/web3';
 import AssetInputTypes from '@rainbow-me/helpers/assetInputTypes';
 import {
   useAccountSettings,
+  useAdditionalAssetData,
   useChartThrottledPoints,
   useDelayedValueWithLayoutAnimation,
   useDimensions,

--- a/src/hooks/charts/useChartData.js
+++ b/src/hooks/charts/useChartData.js
@@ -9,7 +9,6 @@ import { disableCharts } from '../../config/debug';
 import { DEFAULT_CHART_TYPE } from '../../redux/charts';
 import { emitChartsRequest } from '../../redux/explorer';
 import { daysFromTheFirstTx } from '../../utils/ethereumUtils';
-import useAsset from '../useAsset';
 import { useNavigation } from '@rainbow-me/navigation';
 
 const formatChartData = chart => {
@@ -44,7 +43,7 @@ export default function useChartData(asset, secondStore) {
   const {
     params: { chartType = DEFAULT_CHART_TYPE },
   } = useRoute();
-  const { address, price: priceObject } = useAsset(asset);
+  const { address, price: priceObject } = asset;
 
   const { value: price } = priceObject || {};
 


### PR DESCRIPTION
Update BalanceCoinRow to use the assetUniqueIdentifier that it used to use as part of its equality check.

The old BalanceCoinRow used to have additional checks for pinned and hidden items - this is now part of the hook itself instead of props so will still update if the underlying data updates.

Also: remove `useAsset` call in `useChartData` hook. This reduces the number of calls to `useAsset` when opening up the ChartExpandedState.