### PR TITLE
smol android fixes

### DIFF
--- a/src/components/coin-icon/CoinIconFallback.js
+++ b/src/components/coin-icon/CoinIconFallback.js
@@ -23,6 +23,8 @@ const fallbackTextStyles = {
 };
 
 const FallbackImage = styled(ImageWithCachedMetadata)`
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
   ${position.cover};
   ${({
     shadowColor: color,

--- a/src/components/expanded-state/UniqueTokenExpandedState.js
+++ b/src/components/expanded-state/UniqueTokenExpandedState.js
@@ -192,15 +192,12 @@ const UniqueTokenExpandedState = ({ asset, external, lowResUrl }) => {
   }, [accountAddress, accountENS, asset]);
 
   const toggleCurrentPriceDisplayCurrency = useCallback(
-    () =>
-      showCurrentPriceInEth
-        ? setShowCurrentPriceInEth(false)
-        : setShowCurrentPriceInEth(true),
+    () => setShowCurrentPriceInEth(!showCurrentPriceInEth),
     [showCurrentPriceInEth, setShowCurrentPriceInEth]
   );
 
   const toggleFloorDisplayCurrency = useCallback(
-    () => (showFloorInEth ? setShowFloorInEth(false) : setShowFloorInEth(true)),
+    () => setShowFloorInEth(!showFloorInEth),
     [showFloorInEth, setShowFloorInEth]
   );
 

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -273,7 +273,7 @@ function BSNavigator() {
         component={ShowcaseSheet}
         name={Routes.SHOWCASE_SHEET}
         options={{
-          height: '90%',
+          height: '95%',
         }}
       />
       <BSStack.Screen

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -97,7 +97,7 @@ function addHiddenCoins(coins, dispatch, address) {
   storage.set(storageKey, JSON.stringify(newList));
 }
 
-const BACKUP_SHEET_DELAY_MS = 3000;
+const BACKUP_SHEET_DELAY_MS = android ? 10000 : 3000;
 
 let pendingTransactionsHandle = null;
 let genericAssetsHandle = null;


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Adjusted back up sheet timer ~ android loads/imports a lot slower than ios so the sheet was popping up way too soon
fix eth logo ~ added sizing ~ we need to add dimensions since we're using a larger image
improved the code regarding showing eth or usd for NFT priced
tweaked the height of the showcase sheet to better match ios

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
