### PR TITLE
Fix pinning mode

### DIFF
--- a/src/hooks/useCoinListEditOptions.ts
+++ b/src/hooks/useCoinListEditOptions.ts
@@ -105,7 +105,7 @@ export function useCoinListFinishEditingOptions() {
   const setPinnedCoins = useCallback(() => {
     setPinnedCoinsArray((pinnedCoins: string[]) => {
       return [
-        ...pinnedCoins.filter(
+        ...(pinnedCoins ?? []).filter(
           i => !selectedItemsNonReactive.current!.includes(i)
         ),
         ...(currentActionNonReactive.current === EditAction.standard
@@ -121,7 +121,7 @@ export function useCoinListFinishEditingOptions() {
   const setHiddenCoins = useCallback(() => {
     setHiddenCoinsArray(hiddenCoins => {
       const newList = [
-        ...hiddenCoins.filter(
+        ...(hiddenCoins ?? []).filter(
           i => !selectedItemsNonReactive.current!.includes(i)
         ),
         ...(currentActionNonReactive.current === EditAction.standard


### PR DESCRIPTION
Fixes RNBW-2061

## What changed (plus any additional context for devs)

Due to my mistake and the fact the mmkv library is catching errors, I didn't figure out that this is possible that the previous value of the state can be undefined what was causing an exception. Effectively, the pinned coins were not updating. 

## PoW (screenshots / screen recordings)
![image](https://user-images.githubusercontent.com/25709300/146600818-87a06bde-7d1f-45bc-a891-9723fb1d620a.png)

## Dev checklist for QA: what to test

Open a wallet, try to pin coins

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
