### PR TITLE
Rewrite CoinDividerOpenButton to reanimated v2

### DIFF
--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -34,9 +34,9 @@ const Container = styled(Row).attrs({
   align: 'center',
   justify: 'space-between',
 })`
-  ${padding(5, 19, 6)};
-  background-color: ${({ isSticky, theme: { colors } }) =>
-    isSticky ? colors.white : colors.transparent};
+  ${padding(4, 19, 5, 0)};
+  background-color: ${({ isCoinListEdited, theme: { colors } }) =>
+    isCoinListEdited ? colors.white : colors.transparent};
   height: ${CoinDividerContainerHeight};
   width: ${({ deviceWidth }) => deviceWidth};
 `;
@@ -44,6 +44,8 @@ const Container = styled(Row).attrs({
 const CoinDividerButtonRow = styled(RowWithMargins).attrs(
   ({ isCoinListEdited }) => ({
     margin: 10,
+    paddingHorizontal: 19,
+    paddingVertical: 5,
     pointerEvents: isCoinListEdited ? 'auto' : 'none',
   })
 )`
@@ -83,15 +85,14 @@ const useInterpolationRange = () => {
     style: {
       transform: [
         {
-          translateY:
-            position?.interpolate({
-              extrapolateLeft: 'clamp',
-              extrapolateRight: 'extend',
-              inputRange: range,
-              outputRange: range.map(r =>
-                isCoinListEdited ? r - range[0] : 0
-              ),
-            }) ?? 0,
+          translateY: isCoinListEdited
+            ? position?.interpolate({
+                extrapolateLeft: 'clamp',
+                extrapolateRight: 'extend',
+                inputRange: range,
+                outputRange: range.map(r => r - range[0]),
+              })
+            : 0,
         },
       ],
     },
@@ -146,9 +147,12 @@ export default function CoinDivider({ balancesSum }) {
 
   return (
     <Animated.View {...interpolation}>
-      <Container deviceWidth={deviceWidth} isSticky>
+      <Container deviceWidth={deviceWidth} isCoinListEdited={isCoinListEdited}>
         <Row>
-          <View pointerEvents={isCoinListEdited ? 'none' : 'auto'}>
+          <View
+            opacity={isCoinListEdited ? 0 : 1}
+            pointerEvents={isCoinListEdited ? 'none' : 'auto'}
+          >
             <CoinDividerOpenButton
               coinDividerHeight={CoinDividerHeight}
               isSmallBalancesOpen={isSmallBalancesOpen}

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -44,10 +44,6 @@ const LabelText = styled(Text).attrs(({ theme: { colors } }) => ({
   weight: 'bold',
 }))``;
 
-const buttonPressAnimationStyle = {
-  flexDirection: 'row',
-};
-
 const CoinDividerOpenButton = ({
   coinDividerHeight,
   isSmallBalancesOpen,
@@ -84,7 +80,7 @@ const CoinDividerOpenButton = ({
   }));
 
   return (
-    <ButtonPressAnimation onPress={onPress} style={buttonPressAnimationStyle}>
+    <ButtonPressAnimation onPress={onPress}>
       <Content height={coinDividerHeight} style={wrapperStyle}>
         <LabelText>{isSmallBalancesOpen ? 'Less' : 'All'}</LabelText>
         <Animated.View style={style}>

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -27,7 +27,7 @@ const CaretIcon = styled(ImgixImage).attrs(({ theme: { colors } }) => ({
 
 const Content = styled(Animated.View).attrs({
   align: 'center',
-  flex: 'row',
+  flexDirection: 'row',
   justify: 'space-between',
 })`
   background-color: ${({ theme: { colors } }) => colors.blueGreyDarkLight};

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -36,12 +36,12 @@ const Content = styled(Animated.View).attrs({
   height: ${({ height }) => height};
 `;
 
-const LabelText = styled(Text).attrs(({ shareButton, theme: { colors } }) => ({
+const LabelText = styled(Text).attrs(({ theme: { colors } }) => ({
   color: colors.alpha(colors.blueGreyDark, 0.6),
   letterSpacing: 'roundedTight',
   lineHeight: 30,
   size: 'lmedium',
-  weight: shareButton ? 'heavy' : 'bold',
+  weight: 'bold',
 }))``;
 
 const buttonPressAnimationStyle = {
@@ -86,9 +86,7 @@ const CoinDividerOpenButton = ({
   return (
     <ButtonPressAnimation onPress={onPress} style={buttonPressAnimationStyle}>
       <Content height={coinDividerHeight} style={wrapperStyle}>
-        <LabelText color="secondary30" weight="bold">
-          {isSmallBalancesOpen ? 'Less' : 'All'}
-        </LabelText>
+        <LabelText>{isSmallBalancesOpen ? 'Less' : 'All'}</LabelText>
         <Animated.View style={style}>
           <CaretIcon />
         </Animated.View>

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -36,12 +36,12 @@ const Content = styled(Animated.View).attrs({
   height: ${({ height }) => height};
 `;
 
-const LabelText = styled(Text).attrs(({ theme: { colors } }) => ({
+const LabelText = styled(Text).attrs(({ shareButton, theme: { colors } }) => ({
   color: colors.alpha(colors.blueGreyDark, 0.6),
   letterSpacing: 'roundedTight',
   lineHeight: 30,
   size: 'lmedium',
-  weight: 'bold',
+  weight: shareButton ? 'heavy' : 'bold',
 }))``;
 
 const buttonPressAnimationStyle = {
@@ -86,7 +86,9 @@ const CoinDividerOpenButton = ({
   return (
     <ButtonPressAnimation onPress={onPress} style={buttonPressAnimationStyle}>
       <Content height={coinDividerHeight} style={wrapperStyle}>
-        <LabelText>{isSmallBalancesOpen ? 'Less' : 'All'}</LabelText>
+        <LabelText color="secondary30" weight="bold">
+          {isSmallBalancesOpen ? 'Less' : 'All'}
+        </LabelText>
         <Animated.View style={style}>
           <CaretIcon />
         </Animated.View>

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -44,10 +44,6 @@ const LabelText = styled(Text).attrs(({ shareButton, theme: { colors } }) => ({
   weight: shareButton ? 'heavy' : 'bold',
 }))``;
 
-const buttonPressAnimationStyle = {
-  flexDirection: 'row',
-};
-
 const CoinDividerOpenButton = ({
   coinDividerHeight,
   isSmallBalancesOpen,
@@ -84,16 +80,16 @@ const CoinDividerOpenButton = ({
   }));
 
   return (
-    <ButtonPressAnimation onPress={onPress} style={buttonPressAnimationStyle}>
-      <Content height={coinDividerHeight} style={wrapperStyle}>
+    <Content height={coinDividerHeight} style={wrapperStyle}>
+      <ButtonPressAnimation onPress={onPress} style={{ flexDirection: 'row' }}>
         <LabelText color="secondary30" weight="bold">
           {isSmallBalancesOpen ? 'Less' : 'All'}
         </LabelText>
         <Animated.View style={style}>
           <CaretIcon />
         </Animated.View>
-      </Content>
-    </ButtonPressAnimation>
+      </ButtonPressAnimation>
+    </Content>
   );
 };
 

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -44,6 +44,10 @@ const LabelText = styled(Text).attrs(({ shareButton, theme: { colors } }) => ({
   weight: shareButton ? 'heavy' : 'bold',
 }))``;
 
+const buttonPressAnimationStyle = {
+  flexDirection: 'row',
+};
+
 const CoinDividerOpenButton = ({
   coinDividerHeight,
   isSmallBalancesOpen,
@@ -80,16 +84,16 @@ const CoinDividerOpenButton = ({
   }));
 
   return (
-    <Content height={coinDividerHeight} style={wrapperStyle}>
-      <ButtonPressAnimation onPress={onPress} style={{ flexDirection: 'row' }}>
+    <ButtonPressAnimation onPress={onPress} style={buttonPressAnimationStyle}>
+      <Content height={coinDividerHeight} style={wrapperStyle}>
         <LabelText color="secondary30" weight="bold">
           {isSmallBalancesOpen ? 'Less' : 'All'}
         </LabelText>
         <Animated.View style={style}>
           <CaretIcon />
         </Animated.View>
-      </ButtonPressAnimation>
-    </Content>
+      </Content>
+    </ButtonPressAnimation>
   );
 };
 

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -44,6 +44,10 @@ const LabelText = styled(Text).attrs(({ theme: { colors } }) => ({
   weight: 'bold',
 }))``;
 
+const buttonPressAnimationStyle = {
+  flexDirection: 'row',
+};
+
 const CoinDividerOpenButton = ({
   coinDividerHeight,
   isSmallBalancesOpen,
@@ -80,7 +84,7 @@ const CoinDividerOpenButton = ({
   }));
 
   return (
-    <ButtonPressAnimation onPress={onPress}>
+    <ButtonPressAnimation onPress={onPress} style={buttonPressAnimationStyle}>
       <Content height={coinDividerHeight} style={wrapperStyle}>
         <LabelText>{isSmallBalancesOpen ? 'Less' : 'All'}</LabelText>
         <Animated.View style={style}>

--- a/src/components/coin-row/CoinName.js
+++ b/src/components/coin-row/CoinName.js
@@ -5,10 +5,11 @@ const CoinName = styled(TruncatedText).attrs(
   ({ color, size, theme: { colors } }) => ({
     color: color || colors.dark,
     letterSpacing: 'roundedMedium',
-    lineHeight: android ? 'normalTight' : 'normal',
+    lineHeight: 'normal',
     size: size || 'lmedium',
   })
 )`
+  margin-top: ${android ? 1.5 : 0};
   padding-right: ${({ paddingRight = 19 }) => paddingRight};
 `;
 

--- a/src/components/discover-sheet/UniswapPoolsSection.js
+++ b/src/components/discover-sheet/UniswapPoolsSection.js
@@ -29,7 +29,7 @@ const DefaultShowMoreButton = ({ backgroundColor, color, onPress }) => (
         <Text
           align="center"
           color={color}
-          lineHeight={30}
+          lineHeight={android ? 30 : 20}
           size="lmedium"
           weight="heavy"
         >
@@ -306,7 +306,6 @@ export default function UniswapPools({
                 backgroundColor={colors.alpha(colors.blueGreyDark, 0.06)}
                 color={colors.alpha(colors.blueGreyDark, 0.6)}
                 onPress={handleShowMorePress}
-                paddingTop={10}
               />
             )}
         </Fragment>

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -304,15 +304,14 @@ export default function ChartExpandedState({ asset }) {
 
   const MoreButton = useCallback(() => {
     return (
-      <CoinDividerOpenButton
-        coinDividerHeight={CoinDividerHeight}
-        isActive
-        isSendSheet
-        isSmallBalancesOpen={delayedMorePoolsVisible}
-        marginLeft={19}
-        marginTop={5}
-        onPress={() => setMorePoolsVisible(prev => !prev)}
-      />
+      <View marginTop={-10}>
+        <CoinDividerOpenButton
+          coinDividerHeight={CoinDividerHeight}
+          isActive
+          isSmallBalancesOpen={delayedMorePoolsVisible}
+          onPress={() => setMorePoolsVisible(prev => !prev)}
+        />
+      </View>
     );
   }, [delayedMorePoolsVisible]);
 

--- a/src/components/send/SendAssetList.js
+++ b/src/components/send/SendAssetList.js
@@ -31,12 +31,6 @@ const familyHeaderHeight = 49;
 const rowHeight = 59;
 const smallBalancesHeader = 42;
 
-const SendAssetListCoinDividerOpenButton = styled(CoinDividerOpenButton).attrs({
-  coinDividerHeight: 34,
-})`
-  margin-left: ${android ? 0 : 19};
-`;
-
 const SendAssetRecyclerListView = styled(RecyclerListView)`
   min-height: 1;
 `;
@@ -388,13 +382,18 @@ export default class SendAssetList extends React.Component {
     const { savings } = this.props;
     const { openShitcoins } = this.state;
     return (
-      <View marginTop={dividerMargin}>
-        <SendAssetListCoinDividerOpenButton
-          isSendSheet
-          isSmallBalancesOpen={openShitcoins}
-          onPress={this.changeOpenShitcoins}
-        />
-        {openShitcoins && this.mapShitcoins(item.assets)}
+      <View>
+        <View marginTop={android ? 0 : 5}>
+          <CoinDividerOpenButton
+            isSmallBalancesOpen={openShitcoins}
+            onPress={this.changeOpenShitcoins}
+          />
+        </View>
+        {openShitcoins && (
+          <View marginTop={android ? 1 : -4}>
+            {this.mapShitcoins(item.assets)}
+          </View>
+        )}
         {savings && savings.length > 0 ? null : <SendAssetListDivider />}
       </View>
     );


### PR DESCRIPTION
Fixes RNBW-2082

We are getting rid of all usages of reanimated v1. We find this an issue of the slowness of the Android app. 

## What changed (plus any additional context for devs)

The component is rewritten, waits for Christian polishes.

Doesn't block code review


## PoW (screenshots / screen recordings)
<img width="854" alt="$724 66" src="https://user-images.githubusercontent.com/25709300/146614303-81758e4a-2f9d-43bd-8394-358a61c9902e.png">


## Dev checklist for QA: what to test

Please observe the small `All / Less` in the main assets list + send sheet.

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
