### PR TITLE
Fix nft expanded state blur overlay offset on android

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.js
+++ b/src/components/expanded-state/UniqueTokenExpandedState.js
@@ -206,28 +206,32 @@ const UniqueTokenExpandedState = ({ asset, external, lowResUrl }) => {
 
   return (
     <Fragment>
-      <BlurWrapper height={deviceHeight} width={deviceWidth}>
-        <BackgroundImage>
-          {isSVG ? (
-            <UniqueTokenImage
-              backgroundColor={asset.background}
-              imageUrl={lowResUrl}
-              item={asset}
-              size={deviceHeight}
-            />
-          ) : (
-            <ImgixImage
-              resizeMode="cover"
-              source={{ uri: lowResUrl }}
-              style={{ height: deviceHeight, width: deviceWidth }}
-            />
-          )}
-          <BackgroundBlur />
-        </BackgroundImage>
-      </BlurWrapper>
+      {ios && (
+        <BlurWrapper height={deviceHeight} width={deviceWidth}>
+          <BackgroundImage>
+            {isSVG ? (
+              <UniqueTokenImage
+                backgroundColor={asset.background}
+                imageUrl={lowResUrl}
+                item={asset}
+                size={deviceHeight}
+              />
+            ) : (
+              <ImgixImage
+                resizeMode="cover"
+                source={{ uri: lowResUrl }}
+                style={{ height: deviceHeight, width: deviceWidth }}
+              />
+            )}
+            <BackgroundBlur />
+          </BackgroundImage>
+        </BlurWrapper>
+      )}
       <SlackSheet
         backgroundColor={
-          isDarkMode ? 'rgba(22, 22, 22, 0.4)' : 'rgba(26, 26, 26, 0.4)'
+          isDarkMode
+            ? `rgba(22, 22, 22, ${ios ? 0.4 : 1})`
+            : `rgba(26, 26, 26, ${ios ? 0.4 : 1})`
         }
         bottomInset={42}
         hideHandle


### PR DESCRIPTION
Fixes RNBW-2068

Example of problem: https://drive.google.com/file/d/15fXEwrXsOOGaTi_7eoRdG67gY77NAiQv/view

## What changed (plus any additional context for devs)
I disabled the nft expanded state BlurWrapper for android since it was causing a weird overlay issue as seen in this linear ticket, and because it isn't working on android anyways. The remaining nft expanded slack sheet is translucent, so I configured it to be opaque on android to compensate for the missing blur wrapper.

## PoW (screenshots / screen recordings)

iPhone 13 Pro Max
https://user-images.githubusercontent.com/15272675/146632831-630010fe-6d99-49b6-8dd5-76d52e9f2694.mp4

Samsung Galaxy A52
https://user-images.githubusercontent.com/15272675/146632840-fcfdfb82-6865-460f-8fa0-b963d718f9a6.mp4
