### PR TITLE
fix send max ETH with getBalanceAmount

### DIFF
--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -325,10 +325,12 @@ export default function CurrencySelectModal() {
               onChangeText={setSearchQuery}
               ref={searchInputRef}
               searchQuery={searchQuery}
-              {...(ios ? {
-                onFocus: handleFocus,
-                ref: searchInputRef,
-              } : {})}
+              {...(ios
+                ? {
+                    onFocus: handleFocus,
+                    ref: searchInputRef,
+                  }
+                : {})}
               testID="currency-select-search"
             />
             {type === null || type === undefined ? null : (

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -34,9 +34,11 @@ import { useSelector } from 'react-redux';
 import URL from 'url-parse';
 import {
   EthereumAddress,
+  GasFee,
   LegacySelectedGasFee,
   ParsedAddressAsset,
   RainbowTransaction,
+  SelectedGasFee,
 } from '@rainbow-me/entities';
 import { getOnchainAssetBalance } from '@rainbow-me/handlers/assets';
 import {
@@ -189,7 +191,7 @@ const getEthPriceUnit = () => getAssetPrice();
 const getMaticPriceUnit = () => getAssetPrice(MATIC_MAINNET_ADDRESS);
 
 const getBalanceAmount = (
-  selectedGasFee: LegacySelectedGasFee,
+  selectedGasFee: SelectedGasFee | LegacySelectedGasFee,
   selected: ParsedAddressAsset
 ) => {
   const { assets } = store.getState().data;
@@ -200,7 +202,9 @@ const getBalanceAmount = (
 
   if (selected?.isNativeAsset) {
     if (!isEmpty(selectedGasFee)) {
-      const txFeeRaw = selectedGasFee?.gasFee?.estimatedFee?.value.amount;
+      const gasFee = selectedGasFee?.gasFee as GasFee;
+      const txFeeRaw =
+        gasFee?.maxFee?.value.amount || gasFee?.estimatedFee?.value.amount;
       const txFeeAmount = fromWei(txFeeRaw);
       const remaining = subtract(amount, txFeeAmount);
       amount = greaterThan(remaining, 0) ? remaining : '0';


### PR DESCRIPTION
Fixes RNBW-2084

## What changed (plus any additional context for devs)

`getBalanceAmount` was only taking the estimated params to calculate a max ETH value, so when you pressed max the tx wouldn't even leave the app because of not having enough balance

## PoW (screenshots / screen recordings)

before https://recordit.co/RMfoBg8DSN
after https://recordit.co/X2Tc6tSMJG

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
