### PR TITLE
Fix crash on android release apk

### DIFF
--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -38,7 +38,7 @@ const OuterBorder = styled(Centered)`
     color || colors.alpha(colors.whiteLabel, 0.15)};
   border-radius: ${TagBorderRadius};
   border-width: 2;
-  flex: none;
+  flex: 0;
   overflow: hidden;
   z-index: 2;
 `;


### PR DESCRIPTION
Fixes https://sentry.io/organizations/rainbow-me/discover/rainbow-wallet:7617bfdc4ee045c5973f422bc1f57bf7/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&query=device.name%3AGoro&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29

## What changed (plus any additional context for devs)
- css property `flex` only accepts numbers in react native. 

## PoW (screenshots / screen recordings)
The app now doesn't crash in the wallet screen 
http://recordit.co/EOEPJowWhp

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
