### PR TITLE
Revert "Disable focusing on input on navigating to Currency Selection…

### DIFF
--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -78,7 +78,7 @@ export default function CurrencySelectModal() {
   const scrollPosition = usePagerPosition();
 
   const searchInputRef = useRef();
-  const { handleFocus } = useMagicAutofocus(searchInputRef);
+  const { handleFocus } = useMagicAutofocus(searchInputRef, undefined, true);
 
   const [assetsToFavoriteQueue, setAssetsToFavoriteQueue] = useState({});
   const [searchQuery, setSearchQuery] = useState('');
@@ -323,12 +323,9 @@ export default function CurrencySelectModal() {
               isFetching={loadingAllTokens}
               isSearching={isSearching}
               onChangeText={setSearchQuery}
+              onFocus={handleFocus}
               ref={searchInputRef}
               searchQuery={searchQuery}
-              {...(ios ? {
-                onFocus: handleFocus,
-                ref: searchInputRef,
-              } : {})}
               testID="currency-select-search"
             />
             {type === null || type === undefined ? null : (


### PR DESCRIPTION
… View from Swap flow (#2721)"

This reverts commit b868562180112797960d6bb610608c904309e2c6.

## What changed (plus any additional context for devs)
having the keyboard flash is still better than not having the input not focus at all

## PoW (screenshots / screen recordings)
current behavior: https://cloud.skylarbarrera.com/Screen-Recording-2021-12-19-12-36-45.mp4
reverted: https://cloud.skylarbarrera.com/Screen-Recording-2021-12-19-12-37-36.mp4

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
