### PR TITLE
@bruno/fix darkmode sticky headers android

### DIFF
--- a/src/components/list/ListHeader.js
+++ b/src/components/list/ListHeader.js
@@ -65,7 +65,7 @@ export default function ListHeader({
   totalValue,
 }) {
   const deviceDimensions = useDimensions();
-  const { colors } = useTheme();
+  const { colors, isDarkMode } = useTheme();
   const { isReadOnlyWallet } = useWallets();
   const { accountAddress } = useAccountSettings();
   const { accountENS } = useAccountProfile();
@@ -123,7 +123,15 @@ export default function ListHeader({
           )}
           {children}
         </Content>
-        {showDivider && <Divider color={colors.rowDividerLight} />}
+        {
+          /* 
+           The divider shows up as a white line in dark mode (android)
+           so we won't render it till we figure it out why
+          */
+          showDivider && !(android && isDarkMode) && (
+            <Divider color={colors.rowDividerLight} />
+          )
+        }
         <StickyBackgroundBlocker
           deviceDimensions={deviceDimensions}
           isEditMode={isCoinListEdited}


### PR DESCRIPTION
Fixes RNBW-2089

## What changed (plus any additional context for devs)
Disabled sticky header dividers on android + darkmode bc it was showing as a white border.

## PoW (screenshots / screen recordings)

Before:
<img width="373" alt="Screen Shot 2021-12-19 at 5 27 56 PM" src="https://user-images.githubusercontent.com/1247834/146693083-2e435b72-b2b4-429b-b499-d52fc424c961.png">


After:
<img width="372" alt="Screen Shot 2021-12-19 at 4 59 46 PM" src="https://user-images.githubusercontent.com/1247834/146693051-a29b330f-cf1f-4e76-93be-e291d6e60761.png">

## Dev checklist for QA: what to test
Sticky headers shouldn't have any white border when in dark mode (android)


## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
