### PR TITLE
remove 'collectibles' header when wallet does not possess nfts

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
@@ -41,6 +41,10 @@ export default function useMemoBriefSectionData() {
           return false;
         }
 
+        if (data.type === CellType.NFTS_HEADER && !arr[arrIndex + 2]) {
+          return false;
+        }
+
         if (data.type === CellType.NFTS_HEADER && !arr[arrIndex + 1]) {
           return false;
         }

--- a/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
@@ -41,11 +41,8 @@ export default function useMemoBriefSectionData() {
           return false;
         }
 
+        // removes NFTS_HEADER if wallet doesn't have NFTs
         if (data.type === CellType.NFTS_HEADER && !arr[arrIndex + 2]) {
-          return false;
-        }
-
-        if (data.type === CellType.NFTS_HEADER && !arr[arrIndex + 1]) {
           return false;
         }
 


### PR DESCRIPTION
Fixes RNBW-2080

## What changed (plus any additional context for devs)
"Collectibles" header no longer appears if the wallet doesn't have any NFTs

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/15272675/146858402-a98dbbd1-91c7-4d02-8c1c-971569c5dd7b.mp4

