### PR TITLE
fix swap button briefly flashing to 'insufficient eth'

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -109,18 +109,18 @@ export default function ConfirmExchangeButton({
     label = 'Hold to Withdraw';
   }
 
-  if (!isSufficientBalance) {
+  if (!doneLoadingReserves) {
+    label = 'Fetching Details...';
+  } else if (!isSufficientBalance) {
     label = 'Insufficient Funds';
   } else if (!isSufficientLiquidity) {
     label = 'Insufficient Liquidity';
-  } else if (!isSufficientGas) {
+  } else if (isSufficientGas != null && !isSufficientGas) {
     label = 'Insufficient ETH';
   } else if (isHighPriceImpact) {
     label = isSwapDetailsRoute ? 'Swap Anyway' : '􀕹 View Details';
   } else if (disabled) {
     label = 'Enter an Amount';
-  } else if (!doneLoadingReserves) {
-    label = 'Fetching Details...';
   }
 
   const isDisabled =


### PR DESCRIPTION
Fixes RNBW-2012

## What changed (plus any additional context for devs)
Token swap button would briefly flash to say "insufficient eth" when loading (see example in Linear ticket). I fixed this.

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/15272675/146874428-74e3d9e4-5bc2-48f0-8aa8-96faa03b8037.mp4
