### PR TITLE
Reduce rerenders on ChartExpandedState + Fix crash

### DIFF
--- a/src/components/sheet/sheet-action-buttons/BuyActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/BuyActionButton.js
@@ -7,7 +7,7 @@ import { useExpandedStateNavigation, useWallets } from '@rainbow-me/hooks';
 
 import Routes from '@rainbow-me/routes';
 
-export default function BuyActionButton({ color: givenColor, ...props }) {
+function BuyActionButton({ color: givenColor, ...props }) {
   const { colors } = useTheme();
   const color = givenColor || colors.paleBlue;
   const navigate = useExpandedStateNavigation();
@@ -41,3 +41,5 @@ export default function BuyActionButton({ color: givenColor, ...props }) {
     />
   );
 }
+
+export default React.memo(BuyActionButton);

--- a/src/components/sheet/sheet-action-buttons/SendActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.js
@@ -4,11 +4,7 @@ import SheetActionButton from './SheetActionButton';
 import { useExpandedStateNavigation } from '@rainbow-me/hooks';
 import Routes from '@rainbow-me/routes';
 
-export default function SendActionButton({
-  asset,
-  color: givenColor,
-  ...props
-}) {
+function SendActionButton({ asset, color: givenColor, ...props }) {
   const { colors } = useTheme();
   const color = givenColor || colors.paleBlue;
   const navigate = useExpandedStateNavigation();
@@ -37,3 +33,5 @@ export default function SendActionButton({
     />
   );
 }
+
+export default React.memo(SendActionButton);

--- a/src/components/sheet/sheet-action-buttons/SwapActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SwapActionButton.js
@@ -4,7 +4,7 @@ import SheetActionButton from './SheetActionButton';
 import { useExpandedStateNavigation } from '@rainbow-me/hooks';
 import Routes from '@rainbow-me/routes';
 
-export default function SwapActionButton({
+function SwapActionButton({
   color: givenColor,
   inputType,
   label,
@@ -15,6 +15,7 @@ export default function SwapActionButton({
 }) {
   const { colors } = useTheme();
   const color = givenColor || colors.swapPurple;
+
   const navigate = useExpandedStateNavigation(inputType);
   const goToSwap = useCallback(() => {
     navigate(Routes.EXCHANGE_MODAL, params => ({
@@ -57,3 +58,5 @@ export default function SwapActionButton({
     />
   );
 }
+
+export default React.memo(SwapActionButton);

--- a/src/hooks/useAsset.js
+++ b/src/hooks/useAsset.js
@@ -1,7 +1,6 @@
-import { find, matchesProperty } from 'lodash';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import useAccountAsset from './useAccountAsset';
+import useCollectible from './useCollectible';
 import useGenericAsset from './useGenericAsset';
 import { AssetTypes } from '@rainbow-me/entities';
 
@@ -9,11 +8,7 @@ import { AssetTypes } from '@rainbow-me/entities';
 // generic assets, and uniqueTokens
 export default function useAsset(asset) {
   const accountAsset = useAccountAsset(asset?.uniqueId);
-
-  const uniqueTokens = useSelector(
-    ({ uniqueTokens: { uniqueTokens } }) => uniqueTokens
-  );
-
+  const uniqueToken = useCollectible(asset);
   const genericAsset = useGenericAsset(
     asset?.mainnet_address || asset?.address
   );
@@ -25,12 +20,9 @@ export default function useAsset(asset) {
     if (asset.type === AssetTypes.token) {
       matched = accountAsset ?? genericAsset;
     } else if (asset.type === AssetTypes.nft) {
-      matched = find(
-        uniqueTokens,
-        matchesProperty('uniqueId', asset?.uniqueId)
-      );
+      matched = uniqueToken;
     }
 
     return matched || asset;
-  }, [accountAsset, asset, uniqueTokens, genericAsset]);
+  }, [accountAsset, asset, genericAsset, uniqueToken]);
 }

--- a/src/hooks/useCollectible.js
+++ b/src/hooks/useCollectible.js
@@ -10,7 +10,7 @@ export default function useCollectible(asset) {
   return useMemo(() => {
     let matched = find(
       uniqueTokens,
-      matchesProperty('uniqueId', asset.uniqueId)
+      matchesProperty('uniqueId', asset?.uniqueId)
     );
     return matched || asset;
   }, [asset, uniqueTokens]);

--- a/src/redux/optimismExplorer.js
+++ b/src/redux/optimismExplorer.js
@@ -26,15 +26,15 @@ const OPTIMISM_EXPLORER_SET_HANDLERS =
 
 const UPDATE_BALANCE_AND_PRICE_FREQUENCY = 60000;
 
-const network = networkTypes.optimism;
+const optimismNetwork = networkTypes.optimism;
 
 const fetchAssetBalances = async (tokens, address) => {
   try {
     const abi = balanceCheckerContractAbiOVM;
 
     const contractAddress =
-      networkInfo[network].balance_checker_contract_address;
-    const optimismProvider = await getProviderForNetwork(networkTypes.optimism);
+      networkInfo[optimismNetwork].balance_checker_contract_address;
+    const optimismProvider = await getProviderForNetwork(optimismNetwork);
 
     const balanceCheckerContract = new Contract(
       contractAddress,
@@ -54,7 +54,7 @@ const fetchAssetBalances = async (tokens, address) => {
   } catch (e) {
     logger.sentry(
       'Error fetching balances from balanceCheckerContract',
-      network,
+      optimismNetwork,
       e
     );
     captureException(new Error('fallbackExplorer::balanceChecker failure'));
@@ -63,15 +63,15 @@ const fetchAssetBalances = async (tokens, address) => {
 };
 
 export const optimismExplorerInit = () => async (dispatch, getState) => {
-  if (networkInfo[networkTypes.optimism]?.disabled) return;
+  if (networkInfo[optimismNetwork]?.disabled) return;
   const { genericAssets } = getState().data;
   const { accountAddress, nativeCurrency } = getState().settings;
   const formattedNativeCurrency = toLower(nativeCurrency);
 
   const fetchAssetsBalancesAndPrices = async () => {
     const assets = keyBy(
-      chainAssets[network],
-      asset => `${asset.asset.asset_code}_${network}`
+      chainAssets[optimismNetwork],
+      asset => `${asset.asset.asset_code}_${optimismNetwork}`
     );
 
     const tokenAddresses = map(assets, ({ asset: { asset_code } }) =>
@@ -81,7 +81,7 @@ export const optimismExplorerInit = () => async (dispatch, getState) => {
     const balances = await fetchAssetBalances(
       tokenAddresses,
       accountAddress,
-      network
+      optimismNetwork
     );
 
     let updatedAssets = assets;
@@ -122,7 +122,6 @@ export const optimismExplorerInit = () => async (dispatch, getState) => {
               ...assetWithBalance,
               asset: {
                 ...assetWithBalance.asset,
-                network: networkTypes.optimism,
                 price: asset?.price || {
                   changed_at: prices[assetCoingeckoId].last_updated_at,
                   relative_change_24h:
@@ -154,7 +153,7 @@ export const optimismExplorerInit = () => async (dispatch, getState) => {
             false,
             false,
             false,
-            networkTypes.optimism
+            optimismNetwork
           )
         );
         lastUpdatePayload = newPayload;

--- a/src/references/chain-assets.json
+++ b/src/references/chain-assets.json
@@ -160,6 +160,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/ETH.png",
           "name": "Ether",
+          "network": "optimism",
           "price": {
             "changed_at": 1582568575,
             "relative_change_24h": -4.586615622469276,
@@ -178,6 +179,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/DAI_mcd.png",
           "name": "Dai",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -196,6 +198,7 @@
           "decimals": 8,
           "icon_url": "https://s3.amazonaws.com/icons.assets/USDC.png",
           "name": "USD Coin",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.01,
@@ -214,6 +217,7 @@
           "decimals": 8,
           "icon_url": "https://s3.amazonaws.com/icons.assets/USDT.png",
           "name": "Tether USD",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -232,6 +236,7 @@
           "decimals": 8,
           "icon_url": "https://s3.amazonaws.com/icons.assets/SNX.png",
           "name": "Synthetix",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -250,6 +255,7 @@
           "decimals": 8,
           "icon_url": "https://s3.amazonaws.com/icons.assets/WBTC.png",
           "name": "Wrapped Bitcoin",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -268,6 +274,7 @@
           "decimals": 8,
           "icon_url": "https://ethereum-optimism.github.io/logos/0xBTC.png",
           "name": "0xBitcoin",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -286,6 +293,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/SUSD.png",
           "name": "Synthetic USD",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -304,6 +312,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/SETH.png",
           "name": "Synthetic Ether",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -322,6 +331,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/SBTC.png",
           "name": "Synthetic Bitcoin",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -340,6 +350,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/SLINK.png",
           "name": "Synthetic Chainlink",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -358,6 +369,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/LUSD.png",
           "name": "LUSD Stablecoin",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -376,6 +388,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/RGT.png",
           "name": "Rari Governance Token",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -394,6 +407,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/RAI.png",
           "name": "Rai Reflex Index",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -412,6 +426,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/RETH.png",
           "name": "Rocket Pool ETH",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -430,6 +445,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/UNI.png",
           "name": "Uniswap",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -448,6 +464,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/LINK.png",
           "name": "Chainlink",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,
@@ -466,6 +483,7 @@
           "decimals": 18,
           "icon_url": "https://s3.amazonaws.com/icons.assets/LINK.png",
           "name": "Ethereum Name Service",
+          "network": "optimism",
           "price": {
             "changed_at": 1582562452,
             "relative_change_24h": 0.8470466197462612,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
1. We weren't memo-izing some important objects inside of the ChartExpandedState.
This and the combo of not memo-izing the internal Send/Swap/BuyActionButtons were causing those buttons to re-render many times unnecessarily.

2. This PR also includes a small cleanup in useAsset for it to use the new useCollectible hook.

3. Fixes this crash: https://sentry.io/organizations/rainbow-me/issues/2882560935/?project=1855565&referrer=slack. Details in the commit.

The easiest way to review this PR is to follow the commit history.

## PoW (screenshots / screen recordings)
Here are some before and afters with logs inside the respective Send/SwapActionButtons:

Before:
<img width="281" alt="Screen Shot 2021-12-23 at 8 51 07 PM" src="https://user-images.githubusercontent.com/1285228/147327788-235ca288-97cf-42b0-b17e-4d433932744e.png">

After:
<img width="323" alt="Screen Shot 2021-12-23 at 9 16 44 PM" src="https://user-images.githubusercontent.com/1285228/147327822-7b651095-f019-4841-8e31-4b415eb1e02d.png">

## Dev checklist for QA: what to test
There should be no changes

## Final checklist
[X] Assigned individual reviewers?
[X] Added labels?
