### PR TITLE
Fix crashing when switching wallets for first time

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -169,10 +169,13 @@ export const dataLoadState = () => async (dispatch, getState) =>
         accountAddress,
         network
       );
-      dispatch({
-        payload: accountAssetsData,
-        type: DATA_LOAD_ACCOUNT_ASSETS_DATA_SUCCESS,
-      });
+
+      if (!isEmpty(accountAssetsData)) {
+        dispatch({
+          payload: accountAssetsData,
+          type: DATA_LOAD_ACCOUNT_ASSETS_DATA_SUCCESS,
+        });
+      }
     } catch (error) {
       dispatch({ type: DATA_LOAD_ACCOUNT_ASSETS_DATA_FAILURE });
     }


### PR DESCRIPTION
Fixes RNBW-2122

## What changed (plus any additional context for devs)
On the very first load when switching from the older `assets` redux data to the new `accountAssetsData` version for the very first time, there is a point where we load an empty state from localstorage and set the `isLoadingAssets` flag as `false`. This was causing us to add on the empty ETH asset in `buildCoinsList` though it does not exist in `useAccountAsset`.
There is a further fix required to properly handle the situation when a user does not have ETH in their wallet, but this will be done in a follow up PR.
At least for now, it should not crash for this scenario.

## PoW (screenshots / screen recordings)
Please note that I had cleared the async storage cache right before running this PoW.
https://recordit.co/7wFBnCOLo7

## Dev checklist for QA: what to test
1. Delete the app
2. Switch between wallets multiple times
3. There should be no crashing or white screen

## Final checklist
[X] Assigned individual reviewers?
[X] Added labels?
