### PR TITLE
Use nonce manager with WC session address

### DIFF
--- a/src/handlers/localstorage/nonceManager.ts
+++ b/src/handlers/localstorage/nonceManager.ts
@@ -2,12 +2,13 @@ import { getGlobal, saveGlobal } from './common';
 import { NonceManager } from '@rainbow-me/entities';
 
 export const NONCE_MANAGER = 'nonceManager';
+const noncesVersion = '0.0.2';
 
 export const getNonceManager = async (): Promise<NonceManager> => {
-  const nonceManager = await getGlobal(NONCE_MANAGER, {});
+  const nonceManager = await getGlobal(NONCE_MANAGER, {}, noncesVersion);
 
   return nonceManager;
 };
 
 export const saveNonceManager = (nonceManager: NonceManager) =>
-  saveGlobal(NONCE_MANAGER, nonceManager);
+  saveGlobal(NONCE_MANAGER, nonceManager, noncesVersion);

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -166,7 +166,6 @@ export default function TransactionConfirmationScreen() {
   const { wallets, walletNames, switchToWalletWithAddress } = useWallets();
   const balances = useWalletBalances(wallets);
   const { accountAddress, nativeCurrency } = useAccountSettings();
-  const getNextNonce = useCurrentNonce(accountAddress, currentNetwork);
   const keyboardHeight = useKeyboardHeight();
   const dispatch = useDispatch();
   const { params: routeParams } = useRoute();
@@ -218,6 +217,8 @@ export default function TransactionConfirmationScreen() {
       address,
     };
   }, [currentNetwork, walletConnector?._accounts, walletNames, wallets]);
+
+  const getNextNonce = useCurrentNonce(accountInfo.address, currentNetwork);
 
   const isL2 = useMemo(() => {
     return isL2Network(currentNetwork);


### PR DESCRIPTION
Fixes RNBW-2125

## What changed (plus any additional context for devs)

We're using the account settings address instead of the wallet connect session address in `TransactionConfirmationScreen`, so the nonce manager is getting another nonce if those addresses are different. Changed it to use `accountInfo.address` instead.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
