### PR TITLE
show real data in price widget preview

### DIFF
--- a/ios/PriceWidget/PriceWidget.swift
+++ b/ios/PriceWidget/PriceWidget.swift
@@ -35,14 +35,16 @@ struct PriceWidgetProvider: IntentTimelineProvider {
   }
   
   func getSnapshot(for configuration: SelectTokenIntent, in context: Context, completion: @escaping (CustomTokenEntry) -> Void) {
+    let tokenDetails = lookupTokenDetails(for: configuration)
     let currency = lookupCurrency(for: configuration)
     
-    let priceChangePlaceholder = 9.99
-    let pricePlaceholder = 9999.99
+    let priceData = priceDataProvider.getPriceData(token: tokenDetails.coinGeckoId!)
+    let priceChange = priceData?.marketData.priceChangePercentage24h
+    let price = getPrice(data: priceData, currency: currency)
     
     let icon = iconProvider.getTokenIcon(token: defaultToken.symbol!, address: defaultToken.address!)
     
-    let tokenData = TokenData(tokenDetails: defaultToken, priceChange: priceChangePlaceholder, price: pricePlaceholder, icon: icon, currency: currency)
+    let tokenData = TokenData(tokenDetails: priceData != nil ? tokenDetails : nil, priceChange: priceChange, price: price, icon: icon, currency: currency)
     let entry = CustomTokenEntry(date: Date(), tokenData: tokenData)
     
     completion(entry)


### PR DESCRIPTION
## What changed (plus any additional context for devs)
When adding a new price widget, the preview now shows real data instead of placeholders.

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/15272675/147617108-230cfe46-8805-4210-b801-cc5830fd41b2.mp4

## Dev checklist for QA: what to test
- make sure that price widget displays real data when trying to add new widget
