### PR TITLE
Get rid of the reanimated button in edit mode

### DIFF
--- a/src/components/animations/RoundButtonSizeToggler.js
+++ b/src/components/animations/RoundButtonSizeToggler.js
@@ -37,7 +37,6 @@ const RoundButtonSizeToggler = ({
   color,
   endingWidth,
   isOpen,
-  isAbsolute,
   startingWidth,
 }) => {
   const animation = useSpringTransition(
@@ -82,7 +81,7 @@ const RoundButtonSizeToggler = ({
   const colorToUse = color || colors.blueGreyDarkLight;
 
   return (
-    <Container isAbsolute={isAbsolute}>
+    <Container>
       <Cap capDirection="left" color={colorToUse} />
       <Center>
         <AnimatedCenter color={colorToUse} style={centerStyle} />

--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -24,7 +24,7 @@ const formatPercentageString = percentString =>
   percentString ? percentString.split('-').join('- ') : '-';
 
 const BalanceCoinRowCoinCheckButton = styled(CoinCheckButton).attrs({
-  isAbsolute: true,
+  left: 9.5,
 })({
   top: 9,
 });

--- a/src/components/coin-row/CoinCheckButton.js
+++ b/src/components/coin-row/CoinCheckButton.js
@@ -10,14 +10,14 @@ import { borders, padding, position, shadow } from '@rainbow-me/styles';
 
 const Container = styled.View`
   ${position.size(CoinIconSize)};
-  position: ${({ isAbsolute }) => (isAbsolute ? 'absolute' : 'relative')};
+  position: relative;
   top: 0;
 `;
 
-const Content = styled(Row).attrs(({ isAbsolute }) => ({
+const Content = styled(Row).attrs({
   align: 'center',
-  justify: isAbsolute ? 'start' : 'center',
-}))`
+  justify: 'center',
+})`
   ${position.size('100%')};
 `;
 
@@ -36,11 +36,10 @@ const CheckmarkBackground = styled.View`
   ${({ theme: { isDarkMode, colors } }) =>
     shadow.build(0, 4, 12, isDarkMode ? colors.shadow : colors.appleBlue, 0.4)}
   background-color: ${({ theme: { colors } }) => colors.appleBlue};
-  left: ${({ left, isAbsolute }) => left || (isAbsolute ? 19 : 0)}};
+  left: ${({ left }) => left || 0};
 `;
 
 const CoinCheckButton = ({
-  isAbsolute,
   isHidden,
   isPinned,
   onPress,
@@ -53,19 +52,14 @@ const CoinCheckButton = ({
   const toggle = givenToggle || selectedItems.includes(uniqueId);
 
   return (
-    <Container {...props} isAbsolute={isAbsolute}>
-      <Content
-        as={ButtonPressAnimation}
-        isAbsolute={isAbsolute}
-        onPress={onPress}
-        opacityTouchable
-      >
+    <Container {...props}>
+      <Content as={ButtonPressAnimation} onPress={onPress} opacityTouchable>
         {isHidden || isPinned ? null : <CircleOutline />}
         {!toggle && (isHidden || isPinned) ? (
           <CoinIconIndicator isPinned={isPinned} />
         ) : null}
         <OpacityToggler friction={20} isVisible={!toggle} tension={1000}>
-          <CheckmarkBackground isAbsolute={isAbsolute} left={left}>
+          <CheckmarkBackground left={left}>
             <Icon color="white" name="checkmark" />
           </CheckmarkBackground>
         </OpacityToggler>

--- a/src/components/coin-row/CoinCheckButton.js
+++ b/src/components/coin-row/CoinCheckButton.js
@@ -36,7 +36,7 @@ const CheckmarkBackground = styled.View`
   ${({ theme: { isDarkMode, colors } }) =>
     shadow.build(0, 4, 12, isDarkMode ? colors.shadow : colors.appleBlue, 0.4)}
   background-color: ${({ theme: { colors } }) => colors.appleBlue};
-  left: ${({ isAbsolute }) => (isAbsolute ? 19 : 0)};
+  left: ${({ left, isAbsolute }) => left || (isAbsolute ? 19 : 0)}};
 `;
 
 const CoinCheckButton = ({
@@ -46,6 +46,7 @@ const CoinCheckButton = ({
   onPress,
   toggle: givenToggle,
   uniqueId,
+  left,
   ...props
 }) => {
   const { selectedItems } = useCoinListFinishEditingOptions();
@@ -58,14 +59,13 @@ const CoinCheckButton = ({
         isAbsolute={isAbsolute}
         onPress={onPress}
         opacityTouchable
-        reanimatedButton
       >
         {isHidden || isPinned ? null : <CircleOutline />}
         {!toggle && (isHidden || isPinned) ? (
           <CoinIconIndicator isPinned={isPinned} />
         ) : null}
         <OpacityToggler friction={20} isVisible={!toggle} tension={1000}>
-          <CheckmarkBackground isAbsolute={isAbsolute}>
+          <CheckmarkBackground isAbsolute={isAbsolute} left={left}>
             <Icon color="white" name="checkmark" />
           </CheckmarkBackground>
         </OpacityToggler>


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

This button has a poor performance. It got introduced in https://github.com/rainbow-me/rainbow/pull/2378
to fix: https://linear.app/rainbow/issue/RNBW-1538/edit-mode-checkboxes-are-not-pressable-on-android

I fix the original issue, by getting rid of `isAbsolute: true` and then adjusting relative size by `left: 9.5`

## PoW (screenshots / screen recordings)

https://streamable.com/g5zx4c

https://linear.app/rainbow/issue/RNBW-1538/edit-mode-checkboxes-are-not-pressable-on-android

## Dev checklist for QA: what to test

Open edit mode and try to select / unselect things 

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
