### PR TITLE
update arbitrum gas prices

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -310,12 +310,9 @@ export const gasPricesStartPolling = (network = Network.mainnet) => async (
     const provider = await getProviderForNetwork(Network.arbitrum);
     const baseGasPrice = await provider.getGasPrice();
     const baseGasPriceGwei = weiToGwei(baseGasPrice.toString());
-
-    // Node price is super inflated (50%+)
-    const fastGasPriceAdjusted = multiply(baseGasPriceGwei, '0.7');
-    // Their node adds 10% buffer so -9.9% it's the safe low
-    const normalGasPriceAdjusted = multiply(baseGasPriceGwei, '0.5');
-    const safeLowGasPriceWithBuffer = multiply(baseGasPriceGwei, '0.4');
+    const fastGasPriceAdjusted = multiply(baseGasPriceGwei, '1.2');
+    const normalGasPriceAdjusted = multiply(baseGasPriceGwei, '1');
+    const safeLowGasPriceWithBuffer = multiply(baseGasPriceGwei, '0.8');
     const priceData = {
       average: Number(normalGasPriceAdjusted),
       avgWait: 0.5,


### PR DESCRIPTION
Fixes RNBW-2129

## What changed (plus any additional context for devs)

We're sending many arbitrum tx that ends up failing because of `gas price too low` because we're using half of the gwei coming from the provider for the gas price value.

Watching txs in arbitrum seems like all txs are using the value that's coming from the provider, which is the double of what we're currently using, ending up paying around 85% of that value. For ex, gas price from provider is 1.2 gwei and the paid gas price is 0.96 gwei, in which case we'd be sending txs with 0.6 gwei, so our users are sending txs with a gas price that will never confirm the tx.

I'm changing the gas price to just use the plain value coming from the provider. If we want to cut a bit of that value we could use between 80% to 85% to be sure the txs will go through. 

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
