### PR TITLE
Refactor useSavingsAccount 

### DIFF
--- a/src/hooks/useGenericAsset.js
+++ b/src/hooks/useGenericAsset.js
@@ -13,16 +13,15 @@ const makeGenericAssetSelector = () =>
     (genericAssets, address) => genericAssets?.[address]
   );
 
-const genericManyAssetsSelector = () =>
-  createSelector(
-    genericAssetsSelector,
-    addressesSelector,
-    (genericAssets, addresses) =>
-      addresses.reduce((acc, address) => {
-        acc[address] = genericAssets?.[address];
-        return acc;
-      }, {})
-  );
+const genericManyAssetsSelector = createSelector(
+  genericAssetsSelector,
+  addressesSelector,
+  (genericAssets, addresses) =>
+    addresses?.reduce((acc, address) => {
+      acc[address] = genericAssets?.[address];
+      return acc;
+    }, {})
+);
 
 export default function useGenericAsset(address) {
   const selectGenericAsset = useMemo(makeGenericAssetSelector, []);

--- a/src/hooks/useGenericAsset.js
+++ b/src/hooks/useGenericAsset.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 
 const genericAssetsSelector = state => state.data.genericAssets;
 const addressSelector = (_, address) => address;
+const addressesSelector = (_, addresses) => addresses;
 
 const makeGenericAssetSelector = () =>
   createSelector(
@@ -12,8 +13,26 @@ const makeGenericAssetSelector = () =>
     (genericAssets, address) => genericAssets?.[address]
   );
 
+const genericManyAssetsSelector = () =>
+  createSelector(
+    genericAssetsSelector,
+    addressesSelector,
+    (genericAssets, addresses) =>
+      addresses.reduce((acc, address) => {
+        acc[address] = genericAssets?.[address];
+        return acc;
+      }, {})
+  );
+
 export default function useGenericAsset(address) {
   const selectGenericAsset = useMemo(makeGenericAssetSelector, []);
   const asset = useSelector(state => selectGenericAsset(state, address));
   return asset;
+}
+
+export function useGenericAssets(addresses) {
+  const assets = useSelector(state =>
+    genericManyAssetsSelector(state, addresses)
+  );
+  return assets;
 }

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -26,8 +26,7 @@ import {
   DAI_ADDRESS,
   ETH_ADDRESS,
 } from '@rainbow-me/references';
-import { getTokenMetadata } from '@rainbow-me/utils';
-import { getAccountAsset } from '@rainbow-me/utils/ethereumUtils';
+import { ethereumUtils, getTokenMetadata } from '@rainbow-me/utils';
 
 const COMPOUND_QUERY_INTERVAL = 120000; // 120 seconds
 
@@ -87,7 +86,7 @@ const getUnderlyingPrice = (token, genericAssets) => {
   const genericAsset = genericAssets?.[address];
   const genericPrice = genericAsset?.price?.value;
   const underlyingPrice =
-    genericPrice || getAccountAsset(address)?.price?.value || 0;
+    genericPrice || ethereumUtils.getAccountAsset(address)?.price?.value || 0;
 
   const underlyingBalanceNativeValue =
     underlyingPrice && token.supplyBalanceUnderlying

--- a/src/hooks/useWalletSectionsData.js
+++ b/src/hooks/useWalletSectionsData.js
@@ -29,7 +29,7 @@ export default function useWalletSectionsData() {
     true
   );
 
-  const isCoinListEdited = useCoinListEdited();
+  const { isCoinListEdited } = useCoinListEdited();
 
   const walletSections = useMemo(() => {
     const accountInfo = {

--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -371,15 +371,19 @@ export const emitAssetRequest = assetAddress => (dispatch, getState) => {
     if (!TokensListenedCache?.[nativeCurrency]) {
       TokensListenedCache[nativeCurrency] = {};
     }
-    TokensListenedCache[nativeCurrency][code] = true;
+    assetsSocket && (TokensListenedCache[nativeCurrency][code] = true);
   });
 
-  if (newAssetsCodes.length > 0) {
-    assetsSocket?.emit(
-      ...assetPricesSubscription(newAssetsCodes, nativeCurrency)
-    );
-    assetsSocket?.emit(...ethUSDSubscription);
-    return true;
+  if (assetsSocket) {
+    if (newAssetsCodes.length > 0) {
+      assetsSocket.emit(
+        ...assetPricesSubscription(newAssetsCodes, nativeCurrency)
+      );
+      assetsSocket.emit(...ethUSDSubscription);
+      return true;
+    }
+  } else {
+    setTimeout(() => emitAssetRequest(assetAddress), 100);
   }
   return false;
 };

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -152,7 +152,7 @@ const getAsset = (
   return accountAssets[loweredUniqueId];
 };
 
-export const getAccountAsset = (
+const getAccountAsset = (
   uniqueId: EthereumAddress
 ): ParsedAddressAsset | undefined => {
   const loweredUniqueId = toLower(uniqueId);

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -152,7 +152,7 @@ const getAsset = (
   return accountAssets[loweredUniqueId];
 };
 
-const getAccountAsset = (
+export const getAccountAsset = (
   uniqueId: EthereumAddress
 ): ParsedAddressAsset | undefined => {
   const loweredUniqueId = toLower(uniqueId);


### PR DESCRIPTION
Partially fixes RNBW-2120



## What changed (plus any additional context for devs)

I got rid of additional rerender because of `useEffect`. Additionally, I used mmkv for caching to avoid rerendering because of async local storage.
This function is still called a lot of times, because of `useWalletSelectionData` hook that should be done better (was 170, is 110).

Additionally, I fixed the usage of `useCoinListEdited` in `useWalletSelectionData`. This was cause rerenderns  

## PoW (screenshots / screen recordings)

None

## Dev checklist for QA: what to test
Make sure that the Savings section (total balances as well as expanded savings states) show correct price information (instead of just $0.00) when first opening the app or switching wallets.

## Final checklist
[X] Assigned individual reviewers?
[X] Added labels?
