### PR TITLE
remove L2 no price filtering

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -610,18 +610,6 @@ export const addressAssetsReceived = (
     property('uniqueId')
   );
   addHiddenCoins(assetsWithScamURL, dispatch, accountAddress);
-
-  // Hide coins with price = 0 that are currently not pinned
-  if (isL2) {
-    const assetsWithNoPrice = map(
-      filter(
-        parsedAssets,
-        asset => asset.price?.value === 0 && asset.network === assetsNetwork
-      ),
-      property('uniqueId')
-    );
-    addHiddenCoins(assetsWithNoPrice, dispatch, accountAddress);
-  }
 };
 
 const subscribeToMissingPrices = addresses => (dispatch, getState) => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)

we're removing the filtering for L2 assets with 0 price info as it was messing with showing new tokens.
instead we now rely on the scam token list to filter any out. 
I went through and added a bunch from my wallet, dame's and a few others, changes are live. 

note we are still auto-hiding url formatted token names on the app

## PoW (screenshots / screen recordings)
PoW(this was hidden before): https://cloud.skylarbarrera.com/Screen-Shot-2021-12-29-16-45-56.08.png


## Dev checklist for QA: what to test
L2 assets with pricing info should not be hidden, example Bsticks in dame.eth

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
