### PR TITLE
fix bug that caused synchronous api lag to break widget config when s…

### DIFF
--- a/ios/PriceWidget/Providers/TokenProvider.swift
+++ b/ios/PriceWidget/Providers/TokenProvider.swift
@@ -14,6 +14,12 @@ final class TokenProvider {
   
   static let shared = TokenProvider()
   
+  private var storedTokens = TokenListBundle(allTokens: [:], topTokens: [], otherTokens: [])
+  
+  private init() {
+    getTokens()
+  }
+  
   struct TokenListBundle {
     let allTokens: [String: TokenDetails]
     let topTokens: [TokenDetails]
@@ -25,8 +31,11 @@ final class TokenProvider {
       self.otherTokens = otherTokens
     }
   }
-
   
+  public func getStoredTokens() -> TokenListBundle {
+    return self.storedTokens
+  }
+
   public func getTokens() -> TokenListBundle {
     var rainbowAddressTokenMap = [String: TokenDetails]()
     var finalAddressTokenMap = [String: TokenDetails]()
@@ -62,8 +71,13 @@ final class TokenProvider {
         }
       }
     }
-    finalAddressTokenMap[Constants.eth.address!] = Constants.eth
-    return TokenListBundle(allTokens: finalAddressTokenMap, topTokens: topTokens, otherTokens: otherTokens)
+    
+    if (!finalAddressTokenMap.isEmpty) {
+      finalAddressTokenMap[Constants.eth.address!] = Constants.eth
+    }
+    
+    self.storedTokens = TokenListBundle(allTokens: finalAddressTokenMap, topTokens: topTokens, otherTokens: otherTokens)
+    return self.storedTokens
   }
 
   private func getCoinGeckoTokenList() -> [CoinGeckoToken]? {

--- a/ios/SelectTokenIntent/IntentHandler.swift
+++ b/ios/SelectTokenIntent/IntentHandler.swift
@@ -14,7 +14,7 @@ class IntentHandler: INExtension, SelectTokenIntentHandling {
     var topTokenItems = [Token]()
     var otherTokenItems = [Token]()
     let tokenProvider = TokenProvider.shared
-    let tokens = tokenProvider.getTokens()
+    let tokens = tokenProvider.getStoredTokens()
     let topTokens = Constants.topTokenAddresses
 
     topTokenItems = tokens.topTokens.map { token in


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Before, it would make api calls to fetch widget token list on demand (when user taps Choose Token button). The resulting latency caused the token list to break when the user spam clicks the Choose Token button. I changed this logic to fetch an updated token list passively, at the same cadence that the widget updates price data (once every 10 min). This fixes this bug, and also greatly reduces lag when the user clicks the Choose Token button.

## PoW (screenshots / screen recordings)
BEFORE: 
https://user-images.githubusercontent.com/15272675/147797752-39bb5f90-9b54-489a-8ef1-f170d95a836d.MP4

AFTER: 
https://user-images.githubusercontent.com/15272675/147797759-3d0ec35a-1c84-4ffa-8aff-7204a08d7812.mp4

## Dev checklist for QA: what to test
Check that nothing is broken