### PR TITLE
Fix scrubbing

### DIFF
--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -39,18 +39,19 @@ function least(length: number, compare: (value: number) => number) {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     let pivot = Math.round(bound1 + (bound2 - bound1) / 2);
-    if (pivot === bound1) {
-      return bound1;
-    }
-    if (pivot === bound2) {
-      return bound2;
-    }
+    const areTwoLeft = bound2 === bound1 + 1;
     if (compare(pivot - 1) - compare(pivot) > 0) {
       // decreasing, dip on the right side decreasing, dip on the right side
+      if (areTwoLeft) {
+        return pivot;
+      }
       bound1 = pivot;
     } else {
       // non-increasing or dip, dip on the left side or in pivot non-increasing or dip, dip on the left side or in pivot
       bound2 = pivot;
+      if (areTwoLeft) {
+        return pivot - 1;
+      }
     }
   }
 }
@@ -226,17 +227,48 @@ export const ChartPath = React.memo(
 
         positionX.value = values.x;
 
-        // refer to this article for more defails about this code
+        // refer to this article for more details about this code
         // https://observablehq.com/@d3/multi-line-chart
         const index = least(currentPath.points.length, i => {
           if (typeof i === 'undefined' || values.x === null) {
             return 0;
           }
 
-          return Math.abs(currentPath.points[i].x - Math.floor(values.x));
+          return Math.abs(currentPath.points[i].x - values.x);
         });
 
-        setOriginData(currentPath, index);
+        const pointX = currentPath.points[index]?.originalX;
+
+        let adjustedPointX = pointX;
+        if (currentPath.points[index].x > values.x) {
+          const prevPointOriginalX = currentPath.points[index - 1]?.originalX;
+          if (prevPointOriginalX) {
+            const distance =
+              (currentPath.points[index].x - values.x) /
+              (currentPath.points[index].x - currentPath.points[index - 1].x);
+            adjustedPointX =
+              prevPointOriginalX * distance + pointX * (1 - distance);
+          }
+        } else {
+          const nextPointOriginalX = currentPath.points[index + 1]?.originalX;
+          if (nextPointOriginalX) {
+            const distance =
+              (values.x - currentPath.points[index].x) /
+              (currentPath.points[index + 1].x - currentPath.points[index].x);
+            adjustedPointX =
+              nextPointOriginalX * distance + pointX * (1 - distance);
+          }
+        }
+
+        const dataIndex = least(currentPath.data.length, i => {
+          if (typeof i === 'undefined' || values.x === null) {
+            return 0;
+          }
+
+          return Math.abs(currentPath.data[i].x - adjustedPointX);
+        });
+
+        setOriginData(currentPath, dataIndex);
       },
       [currentPath]
     );

--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -39,6 +39,9 @@ function least(length: number, compare: (value: number) => number) {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     let pivot = Math.round(bound1 + (bound2 - bound1) / 2);
+    if (bound1 === bound2) {
+      return bound1;
+    }
     const areTwoLeft = bound2 === bound1 + 1;
     if (compare(pivot - 1) - compare(pivot) > 0) {
       // decreasing, dip on the right side decreasing, dip on the right side

--- a/src/react-native-animated-charts/src/charts/linear/ChartPathProvider.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPathProvider.tsx
@@ -83,7 +83,7 @@ function createPath({ data, width, height, yRange }: CallbackType): PathData {
     };
   }
 
-  const points: Point[] = [];
+  const points: (Point & { originalX: number; originalY: number })[] = [];
 
   const { greatestY, smallestY } = findYExtremes(data.points) as {
     greatestY: Point;
@@ -94,6 +94,8 @@ function createPath({ data, width, height, yRange }: CallbackType): PathData {
 
   for (let point of data.points) {
     points.push({
+      originalX: point.x,
+      originalY: point.y,
       x: scaleX(point.x),
       y: scaleY(point.y),
     });

--- a/src/react-native-animated-charts/src/helpers/ChartContext.ts
+++ b/src/react-native-animated-charts/src/helpers/ChartContext.ts
@@ -33,7 +33,7 @@ export type CallbackType = {
 export interface PathData {
   path: string;
   parsed: null | Path;
-  points: Point[];
+  points: (Point & { originalY: number; originalX: number })[];
   data: Point[];
   smallestX?: Point;
   smallestY?: Point;


### PR DESCRIPTION
Fixes RNBW-2130
Fixes RNBW-2123

## What changed (plus any additional context for devs)

I fixed a few issues with scrubbing:

1. `least` was not working correctly. It was producing off-by-one error sometimes
2. Now we firstly get the index of the closest x point (from `points`), then obtain the original x (`originalX`) point that is connected to the input data.
3. After that we adjust this x original point interpolating with the next closest x point (from the `points` set). E.g. if the point user's touching is ideally between two, we get their mean. We use reversed weighted mean by the distance to each point.
4. Then we connect this point to the closest point in the original data set (from `data`). Effectively, w have more precise scrubbing cause we're not ignoring native points. 

This is matching the behaviors from the previous implementation. 
 

## PoW (screenshots / screen recordings)

https://streamable.com/ciwvlf

## Dev checklist for QA: what to test

Observe if the point we're touching is matching with labels. 
