### PR TITLE
Add `save-exact=true` to pin dependencies by default

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 ignore-scripts true
+save-exact true


### PR DESCRIPTION
### What's changed

Just a quick PR to add the ability to pin dependencies by default on `yarn add ...` 