### PR TITLE
Skip unnecessary generic assets fallback

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -341,7 +341,7 @@ const genericAssetsFallback = () => async (dispatch, getState) => {
   }, GENERIC_ASSETS_REFRESH_INTERVAL);
 };
 
-const disableGenericAssetsFallbackIfNeeded = () => {
+export const disableGenericAssetsFallbackIfNeeded = () => {
   if (genericAssetsHandle) {
     clearTimeout(genericAssetsHandle);
   }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
When switching wallets, often we do not need to re-emit generic assets as they are handled in the TokensListenedCache. When switching wallets however, we were still triggering the generic assets fallback even when no new asset prices were actually requested.

## PoW (screenshots / screen recordings)
Locally ran logs where `ZERION IS DOWN! ENABLING GENERIC ASSETS FALLBACK` would show up after every wallet switch, and now it does not after the first wallet load.

## Dev checklist for QA: what to test
N/A

## Final checklist
[X] Assigned individual reviewers?
[X] Added labels?
