### PR TITLE
Include generic assets and placeholder ETH fallback logic in useAccountAsset

### DIFF
--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -350,10 +350,10 @@ export default function ChartExpandedState({ asset }) {
               <TokenInfoBalanceValue asset={asset} />
             </TokenInfoItem>
             <TokenInfoItem
-              title={asset?.native?.balance.display ? 'Value' : ' '}
+              title={asset?.native?.balance?.display ? 'Value' : ' '}
               weight="bold"
             >
-              {asset?.native?.balance.display || ' '}
+              {asset?.native?.balance?.display || ' '}
             </TokenInfoItem>
           </TokenInfoRow>
         </TokenInfoSection>

--- a/src/hooks/useAccountAsset.js
+++ b/src/hooks/useAccountAsset.js
@@ -3,7 +3,30 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import useAccountSettings from './useAccountSettings';
+import useGenericAsset from './useGenericAsset';
+import { AssetType } from '@rainbow-me/entities';
 import { parseAssetNative } from '@rainbow-me/parsers';
+import { ETH_ADDRESS, ETH_ICON_URL } from '@rainbow-me/references';
+
+const getZeroEth = () => {
+  return {
+    address: ETH_ADDRESS,
+    balance: {
+      amount: '0',
+      display: '0 ETH',
+    },
+    color: '#29292E',
+    decimals: 18,
+    icon_url: ETH_ICON_URL,
+    isCoin: true,
+    isPlaceholder: true,
+    isSmall: false,
+    name: 'Ethereum',
+    symbol: 'ETH',
+    type: AssetType.token,
+    uniqueId: ETH_ADDRESS,
+  };
+};
 
 const accountAssetsDataSelector = state => state.data.accountAssetsData;
 const assetPricesFromUniswapSelector = state =>
@@ -45,14 +68,27 @@ const makeAccountAssetSelector = () =>
   );
 
 // this is meant to be used for assets under balances
+// with a fallback for generic assets
+// and an ETH placeholder
 // NFTs are not included in this hook
 export default function useAccountAsset(uniqueId) {
   const { nativeCurrency } = useAccountSettings();
   const selectAccountAsset = useMemo(makeAccountAssetSelector, []);
-  const asset = useSelector(state => selectAccountAsset(state, uniqueId));
-  const assetWithPrice = useMemo(
-    () => parseAssetNative(asset, nativeCurrency),
-    [asset, nativeCurrency]
+  const accountAsset = useSelector(state =>
+    selectAccountAsset(state, uniqueId)
   );
-  return assetWithPrice;
+  const genericAssetBackup = useGenericAsset(uniqueId);
+
+  if (accountAsset) {
+    return parseAssetNative(accountAsset, nativeCurrency);
+  } else if (uniqueId === ETH_ADDRESS) {
+    const result = parseAssetNative(genericAssetBackup, nativeCurrency);
+    const placeholderEth = {
+      ...getZeroEth(),
+      ...result,
+    };
+    return placeholderEth;
+  } else {
+    return genericAssetBackup;
+  }
 }

--- a/src/hooks/useAsset.js
+++ b/src/hooks/useAsset.js
@@ -1,28 +1,25 @@
 import { useMemo } from 'react';
 import useAccountAsset from './useAccountAsset';
 import useCollectible from './useCollectible';
-import useGenericAsset from './useGenericAsset';
 import { AssetTypes } from '@rainbow-me/entities';
 
 // To fetch an asset from account assets,
 // generic assets, and uniqueTokens
 export default function useAsset(asset) {
-  const accountAsset = useAccountAsset(asset?.uniqueId);
-  const uniqueToken = useCollectible(asset);
-  const genericAsset = useGenericAsset(
-    asset?.mainnet_address || asset?.address
+  const accountAsset = useAccountAsset(
+    asset?.uniqueId || asset?.mainnet_address || asset?.address
   );
-
+  const uniqueToken = useCollectible(asset);
   return useMemo(() => {
     if (!asset) return null;
 
     let matched = null;
     if (asset.type === AssetTypes.token) {
-      matched = accountAsset ?? genericAsset;
+      matched = accountAsset;
     } else if (asset.type === AssetTypes.nft) {
       matched = uniqueToken;
     }
 
     return matched || asset;
-  }, [accountAsset, asset, genericAsset, uniqueToken]);
+  }, [accountAsset, asset, uniqueToken]);
 }


### PR DESCRIPTION
Fixes RNBW-2145

## What changed (plus any additional context for devs)
ETH is the single asset that may not exist in account assets data but still be displayed to the user in the WalletScreen. The `WrapperBalanceCoinRow` previously relied on the `useAccountAsset` hook, which would not find the 0 balance ETH asset. We therefore need to do a fallback in this particular scenario to the generic assets data formatted as an account asset data.

I've updated the `useAccountAsset` hook itself to return the account asset if found, or the generic asset fallback, or the ETH placeholder fallback. I know that `useAccountAsset` is now a bit of a misnomer, but I updated the description for now until I think of a better name for this hook.

## PoW (screenshots / screen recordings)
<img width="379" alt="Screen Shot 2022-01-05 at 9 36 22 PM" src="https://user-images.githubusercontent.com/1285228/148331475-ac498934-c618-4ab1-94bb-1d8b7964b99b.png">
<img width="369" alt="Screen Shot 2022-01-05 at 10 17 53 PM" src="https://user-images.githubusercontent.com/1285228/148332317-675c3bf2-257b-4b90-83ff-0fdd01a60d20.png">



## Dev checklist for QA: what to test
Add the poopcoin.eth wallet using the seedphrase and switch to one of the empty ETH (but with other asset) wallets. There should be no crash.
You should see the 0 ETH placeholder with all expected pricing and balance data.
You should be able to expand the chart for this and see all expected data.
You should be able to open up all other assets (in wallet balances as well as generic assets in Discover) without any issues.

Please also confirm that this does not negatively impact WalletScreen performance (even with small balances opened)

## Final checklist
[X] Assigned individual reviewers?
[X] Added labels?
