### PR TITLE
Fix crash in animated numbers

### DIFF
--- a/ios/RainbowText.m
+++ b/ios/RainbowText.m
@@ -145,8 +145,8 @@
   return self;
 }
 
-- (void) willMoveToSuperview: (UIView *) newSuperview{
-    if(newSuperview == nil){
+- (void) willMoveToSuperview: (UIView *) newSuperview {
+    if (newSuperview == nil) {
       [_timer invalidate];
       _timer = nil;
     }

--- a/ios/RainbowText.m
+++ b/ios/RainbowText.m
@@ -66,7 +66,7 @@
   float g = ((rgbValue & 0xFF00) >> 8)/255.0 - startG;
   float b = (rgbValue & 0xFF)/255.0 - startB;
   self.textColor = _darkMode ? [UIColor colorWithRed:0.878 green:0.91 blue:1.00 alpha:1.00] : [UIColor colorWithRed:0.145 green:0.161 blue:0.18 alpha:1.0];
-  
+
   _colorsMap = [NSMutableArray new];
   for (int i = _duration; i > 0; i--) {
     float factor = i / (float)_duration;
@@ -143,6 +143,13 @@
   }
 
   return self;
+}
+
+- (void) willMoveToSuperview: (UIView *) newSuperview{
+    if(newSuperview == nil){
+      [_timer invalidate];
+      _timer = nil;
+    }
 }
 
 @end

--- a/src/components/savings/SavingsListRow.js
+++ b/src/components/savings/SavingsListRow.js
@@ -178,6 +178,7 @@ const SavingsListRow = ({
               <SavingsListRowAnimatedNumber
                 initialValue={initialValue}
                 interval={ANIMATE_NUMBER_INTERVAL}
+                key={initialValue + 'savings'}
                 steps={steps}
                 symbol={underlying.symbol}
                 value={displayValue}


### PR DESCRIPTION
Fixes RNBW-2136

## What changed (plus any additional context for devs)

I noticed that timer was not invalidated and after some remounting that happens initially while loading. This was causing a crash. Now it's fixed.

## PoW (screenshots / screen recordings)

(https://streamable.com/y61x4y
## Dev checklist for QA: what to test

1. Open the wallet, open the section with savings, close the wallet, open the wallet, switch wallets - should not crash

2. Open the wallet, open the savings section, (leave it open), and then switch to another wallet - should not crash