### PR TITLE
Make Chart Labels faster to render

### DIFF
--- a/src/components/expanded-state/chart/ChartExpandedStateHeader.js
+++ b/src/components/expanded-state/chart/ChartExpandedStateHeader.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import React, { useMemo } from 'react';
+import Animated from 'react-native-reanimated';
 import styled from 'styled-components';
 import { useCallbackOne } from 'use-memo-one';
 import { CoinIcon, CoinIconGroup } from '../../coin-icon';

--- a/src/components/expanded-state/chart/ChartExpandedStateHeader.js
+++ b/src/components/expanded-state/chart/ChartExpandedStateHeader.js
@@ -1,3 +1,4 @@
+import { invert } from 'lodash';
 import React, { useMemo } from 'react';
 import Animated from 'react-native-reanimated';
 import styled from 'styled-components';
@@ -12,6 +13,8 @@ import {
   ChartPercentChangeLabel,
   ChartPriceLabel,
 } from './chart-data-labels';
+import { useChartData } from '@rainbow-me/animated-charts';
+import ChartTypes from '@rainbow-me/helpers/chartTypes';
 import { convertAmountToNativeDisplay } from '@rainbow-me/helpers/utilities';
 import { useAccountSettings, useBooleanState } from '@rainbow-me/hooks';
 import { padding } from '@rainbow-me/styles';
@@ -55,10 +58,10 @@ export default function ChartExpandedStateHeader({
   latestChange,
   latestPrice = noPriceData,
   priceRef,
-  chartTimeDefaultValue,
   showChart,
   testID,
   overrideValue = false,
+  chartType,
 }) {
   const { colors } = useTheme();
   const color = givenColors || colors.dark;
@@ -70,18 +73,46 @@ export default function ChartExpandedStateHeader({
 
   const isNoPriceData = latestPrice === noPriceData;
 
-  const price = useMemo(
-    () => convertAmountToNativeDisplay(latestPrice, nativeCurrency),
-    [latestPrice, nativeCurrency]
-  );
-
-  const defaultPriceValue = isNoPriceData ? '' : price;
-
   const title = isPool ? `${asset.tokenNames} Pool` : asset?.name;
 
   const titleOrNoPriceData = isNoPriceData ? noPriceData : title;
 
   const showPriceChange = !isNoPriceData && showChart && !isNaN(latestChange);
+
+  const timespan = invert(ChartTypes)[chartType];
+
+  const formattedTimespan =
+    timespan.charAt(0).toUpperCase() + timespan.slice(1);
+
+  const { data } = useChartData();
+
+  const defaultTimeValue = useMemo(() => {
+    if (chartType === ChartTypes.day) {
+      return 'Today';
+    } else if (chartType === ChartTypes.max) {
+      return 'All Time';
+    } else {
+      return `Past ${formattedTimespan}`;
+    }
+    // we need to make sure we recreate this value only when chart's data change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const price = useMemo(
+    () => convertAmountToNativeDisplay(latestPrice, nativeCurrency),
+    // we need to make sure we recreate this value only when chart's data change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data, latestPrice, nativeCurrency]
+  );
+
+  const defaultPriceValue = isNoPriceData ? '' : price;
+
+  const ratio = useMemo(() => {
+    const firstValue = data?.points?.[0]?.y;
+    const lastValue = data?.points?.[data.points.length - 1]?.y;
+
+    return firstValue === Number(firstValue) ? lastValue / firstValue : 1;
+  }, [data]);
 
   return (
     <Container showChart={showChart}>
@@ -128,6 +159,7 @@ export default function ChartExpandedStateHeader({
               isScrubbing={isScrubbing}
               latestChange={latestChange}
               overrideValue={overrideValue}
+              ratio={ratio}
               tabularNums={tabularNums}
             />
           )}
@@ -150,8 +182,9 @@ export default function ChartExpandedStateHeader({
           </ChartHeaderSubtitle>
           {showPriceChange && (
             <ChartDateLabel
-              chartTimeDefaultValue={chartTimeDefaultValue}
+              chartTimeDefaultValue={defaultTimeValue}
               dateRef={dateRef}
+              ratio={ratio}
             />
           )}
         </RowWithMargins>

--- a/src/components/expanded-state/chart/ChartExpandedStateHeader.js
+++ b/src/components/expanded-state/chart/ChartExpandedStateHeader.js
@@ -55,7 +55,7 @@ export default function ChartExpandedStateHeader({
   latestChange,
   latestPrice = noPriceData,
   priceRef,
-  chartTimeSharedValue,
+  chartTimeDefaultValue,
   showChart,
   testID,
   overrideValue = false,
@@ -75,16 +75,7 @@ export default function ChartExpandedStateHeader({
     [latestPrice, nativeCurrency]
   );
 
-  const priceSharedValue = useSharedValue('');
-
-  // TODO (terry): Try to use useImmediateEffect here
-  useEffect(() => {
-    if (isNoPriceData) {
-      priceSharedValue.value = '';
-    } else {
-      priceSharedValue.value = price;
-    }
-  }, [price, isNoPriceData, priceSharedValue]);
+  const defaultPriceValue = isNoPriceData ? '' : price;
 
   const title = isPool ? `${asset.tokenNames} Pool` : asset?.name;
 
@@ -124,7 +115,7 @@ export default function ChartExpandedStateHeader({
             isPool={isPool}
             isScrubbing={isScrubbing}
             priceRef={priceRef}
-            priceSharedValue={priceSharedValue}
+            priceValue={defaultPriceValue}
             tabularNums={tabularNums}
           />
           {showPriceChange && (
@@ -159,7 +150,7 @@ export default function ChartExpandedStateHeader({
           </ChartHeaderSubtitle>
           {showPriceChange && (
             <ChartDateLabel
-              chartTimeSharedValue={chartTimeSharedValue}
+              chartTimeDefaultValue={chartTimeDefaultValue}
               dateRef={dateRef}
             />
           )}

--- a/src/components/expanded-state/chart/chart-data-labels/ChartChangeDirectionArrow.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartChangeDirectionArrow.js
@@ -3,6 +3,7 @@ import React from 'react';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import styled from 'styled-components';
 import { Icon } from '../../../icons';
+import { useChartData } from '@rainbow-me/animated-charts';
 
 const AnimatedMaskedView = Animated.createAnimatedComponent(MaskedView);
 
@@ -11,26 +12,29 @@ const ArrowIcon = styled(Icon).attrs({
   name: 'fatArrow',
 })``;
 
-export default function ChartChangeDirectionArrow({ ratio }) {
+export default function ChartChangeDirectionArrow({ ratio, sharedRatio }) {
   const { colors } = useTheme();
+  const { isActive } = useChartData();
 
   const arrowWrapperStyle = useAnimatedStyle(() => {
+    const realRatio = isActive.value ? sharedRatio.value : ratio;
     return {
-      opacity: ratio.value === 1 ? 0 : 1,
-      transform: [{ rotate: ratio.value < 1 ? '180deg' : '0deg' }],
+      opacity: realRatio === 1 ? 0 : 1,
+      transform: [{ rotate: realRatio < 1 ? '180deg' : '0deg' }],
     };
-  }, []);
+  }, [ratio]);
 
   const arrowStyle = useAnimatedStyle(() => {
+    const realRatio = isActive.value ? sharedRatio.value : ratio;
     return {
       backgroundColor:
-        ratio.value === 1
+        realRatio === 1
           ? colors.blueGreyDark
-          : ratio.value < 1
+          : realRatio < 1
           ? colors.red
           : colors.green,
     };
-  });
+  }, [ratio]);
 
   return (
     <Animated.View style={arrowWrapperStyle}>

--- a/src/components/expanded-state/chart/chart-data-labels/ChartDateLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartDateLabel.js
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { useAnimatedStyle } from 'react-native-reanimated';
 import styled from 'styled-components';
 import { useRatio } from './useRatio';
-import { ChartXLabel } from '@rainbow-me/animated-charts';
+import { ChartXLabel, useChartData } from '@rainbow-me/animated-charts';
 import { fonts, fontWithWidth } from '@rainbow-me/styles';
 
 const Label = styled(ChartXLabel)`
@@ -81,20 +81,22 @@ function formatDatetime(value, chartTimeDefaultValue) {
   return res;
 }
 
-export default function ChartDateLabel({ chartTimeDefaultValue }) {
-  const ratio = useRatio('ChartDataLabel');
+export default function ChartDateLabel({ chartTimeDefaultValue, ratio }) {
+  const { isActive } = useChartData();
+  const sharedRatio = useRatio('ChartDataLabel');
   const { colors } = useTheme();
 
   const textStyle = useAnimatedStyle(() => {
+    const realRatio = isActive.value ? sharedRatio.value : ratio;
     return {
       color:
-        ratio.value === 1
+        realRatio === 1
           ? colors.blueGreyDark
-          : ratio.value < 1
+          : realRatio < 1
           ? colors.red
           : colors.green,
     };
-  });
+  }, [ratio]);
 
   return (
     <View style={{ overflow: 'hidden' }}>

--- a/src/components/expanded-state/chart/chart-data-labels/ChartDateLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartDateLabel.js
@@ -30,11 +30,11 @@ const MONTHS = [
   'Dec',
 ];
 
-function formatDatetime(value, chartTimeSharedValue) {
+function formatDatetime(value, chartTimeDefaultValue) {
   'worklet';
   // we have to do it manually due to limitations of reanimated
   if (value === '') {
-    return chartTimeSharedValue.value;
+    return chartTimeDefaultValue;
   }
 
   const date = new Date(Number(value) * 1000);
@@ -81,7 +81,7 @@ function formatDatetime(value, chartTimeSharedValue) {
   return res;
 }
 
-export default function ChartDateLabel({ chartTimeSharedValue }) {
+export default function ChartDateLabel({ chartTimeDefaultValue }) {
   const ratio = useRatio('ChartDataLabel');
   const { colors } = useTheme();
 
@@ -101,7 +101,7 @@ export default function ChartDateLabel({ chartTimeSharedValue }) {
       <Label
         format={value => {
           'worklet';
-          return formatDatetime(value, chartTimeSharedValue);
+          return formatDatetime(value, chartTimeDefaultValue);
         }}
         style={textStyle}
       />

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.js
@@ -58,13 +58,12 @@ const format = (originalY, data, latestChange) => {
     : '';
 };
 
-export default function ChartPercentChangeLabel({ latestChange }) {
+export default function ChartPercentChangeLabel({ ratio, latestChange }) {
   const { originalY, data, isActive } = useChartData();
   const { colors } = useTheme();
   const defaultValue = useMemo(() => format(originalY, data, latestChange), [
     originalY,
     data,
-    latestChange,
   ]);
 
   const textProps = useAnimatedStyle(
@@ -76,22 +75,26 @@ export default function ChartPercentChangeLabel({ latestChange }) {
     [originalY, data, latestChange, isActive]
   );
 
-  const ratio = useRatio();
+  const sharedRatio = useRatio();
 
   const textStyle = useAnimatedStyle(() => {
+    1;
+    const realRatio = isActive.value ? sharedRatio.value : ratio;
     return {
       color:
-        ratio.value === 1
+        realRatio === 1
           ? colors.blueGreyDark
-          : ratio.value < 1
+          : realRatio < 1
           ? colors.red
           : colors.green,
     };
-  });
+  }, [ratio]);
 
   return (
     <RowWithMargins align="center" margin={4}>
-      {android ? <ChartChangeDirectionArrow ratio={ratio} /> : null}
+      {android ? (
+        <ChartChangeDirectionArrow ratio={ratio} sharedRatio={sharedRatio} />
+      ) : null}
       <PercentLabel
         alignSelf="flex-end"
         animatedProps={textProps}

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.js
@@ -39,10 +39,10 @@ const AndroidCurrencySymbolLabel = styled(ChartYLabel)`
   top: ${PixelRatio.get() <= 2.625 ? 22 : 23};
 `;
 
-export function formatNative(value, priceSharedValue, nativeSelected) {
+export function formatNative(value, defaultPriceValue, nativeSelected) {
   'worklet';
   if (!value) {
-    return priceSharedValue?.value || '';
+    return defaultPriceValue || '';
   }
   if (value === 'undefined') {
     return nativeSelected?.alignment === 'left'
@@ -71,7 +71,7 @@ export function formatNative(value, priceSharedValue, nativeSelected) {
 export default function ChartPriceLabel({
   defaultValue,
   isNoPriceData,
-  priceSharedValue,
+  priceValue,
 }) {
   const { nativeCurrency } = useAccountSettings();
   const nativeSelected = get(supportedNativeCurrencies, `${nativeCurrency}`);
@@ -79,13 +79,13 @@ export default function ChartPriceLabel({
   const format = useWorkletCallback(
     value => {
       'worklet';
-      const formatted = formatNative(value, priceSharedValue, nativeSelected);
+      const formatted = formatNative(value, priceValue, nativeSelected);
       if (android) {
         return formatted.replace(/[^\d.,-]/g, '');
       }
       return formatted;
     },
-    [nativeSelected]
+    [nativeSelected, priceValue]
   );
 
   return isNoPriceData ? (

--- a/src/components/value-chart/Chart.js
+++ b/src/components/value-chart/Chart.js
@@ -130,7 +130,7 @@ export default function ChartWrapper({
   const { progress } = useChartData();
   const spinnerRotation = useSharedValue(0);
   const spinnerScale = useSharedValue(0);
-  const chartTimeSharedValue = useSharedValue('');
+
   const { colors } = useTheme();
 
   const { setOptions } = useNavigation();
@@ -190,22 +190,21 @@ export default function ChartWrapper({
   const formattedTimespan =
     timespan.charAt(0).toUpperCase() + timespan.slice(1);
 
-  useEffect(() => {
+  const defaultTimeValue = useMemo(() => {
     if (chartType === ChartTypes.day) {
-      chartTimeSharedValue && (chartTimeSharedValue.value = 'Today');
+      return 'Today';
     } else if (chartType === ChartTypes.max) {
-      chartTimeSharedValue && (chartTimeSharedValue.value = 'All Time');
+      return 'All Time';
     } else {
-      chartTimeSharedValue &&
-        (chartTimeSharedValue.value = `Past ${formattedTimespan}`);
+      return `Past ${formattedTimespan}`;
     }
-  }, [chartTimeSharedValue, chartType, formattedTimespan]);
+  }, [chartType, formattedTimespan]);
 
   return (
     <Container>
       <ChartExpandedStateHeader
         {...props}
-        chartTimeSharedValue={chartTimeSharedValue}
+        chartTimeDefaultValue={defaultTimeValue}
         color={color}
         isPool={isPool}
         overrideValue={overrideValue}

--- a/src/components/value-chart/Chart.js
+++ b/src/components/value-chart/Chart.js
@@ -1,4 +1,3 @@
-import { invert } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Dimensions } from 'react-native';
 import Animated, {
@@ -186,25 +185,11 @@ export default function ChartWrapper({
     };
   });
 
-  const timespan = invert(ChartTypes)[chartType];
-  const formattedTimespan =
-    timespan.charAt(0).toUpperCase() + timespan.slice(1);
-
-  const defaultTimeValue = useMemo(() => {
-    if (chartType === ChartTypes.day) {
-      return 'Today';
-    } else if (chartType === ChartTypes.max) {
-      return 'All Time';
-    } else {
-      return `Past ${formattedTimespan}`;
-    }
-  }, [chartType, formattedTimespan]);
-
   return (
     <Container>
       <ChartExpandedStateHeader
         {...props}
-        chartTimeDefaultValue={defaultTimeValue}
+        chartType={chartType}
         color={color}
         isPool={isPool}
         overrideValue={overrideValue}

--- a/src/react-native-animated-charts/src/charts/linear/ChartLabels.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartLabels.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { TextInput, TextInputProps } from 'react-native';
 import Animated, { useAnimatedProps } from 'react-native-reanimated';
 import { useChartData } from '../../helpers/useChartData';
@@ -11,21 +11,30 @@ interface ChartLabelProps extends TextInputProps {
 
 const ChartLabelFactory = (fieldName: 'originalX' | 'originalY') => {
   const ChartLabel = React.memo(({ format, ...props }: ChartLabelProps) => {
-    const chartData = useChartData();
+    const { isActive, data, ...chartData } = useChartData();
     const val = chartData[fieldName];
+
+    // we need to recreate defaultValue on data change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const defaultValue = useMemo(() => format?.(val.value) ?? val.value, [
+      format,
+      val,
+      data,
+    ]);
 
     const textProps = useAnimatedProps(
       () => ({
-        text: format?.(val.value) ?? val.value,
-        value: format?.(val.value) ?? val.value,
+        text: isActive.value ? format?.(val.value) ?? val.value : defaultValue,
+        value: isActive.value ? format?.(val.value) ?? val.value : defaultValue,
       }),
-      [chartData.data]
+      [data, defaultValue, isActive]
     );
 
     return (
       <AnimatedTextInput
         {...props}
         animatedProps={textProps}
+        defaultValue={defaultValue}
         editable={false}
       />
     );


### PR DESCRIPTION
Fixes RNBW-2065

## What changed (plus any additional context for devs)

Basically now we rely more on the JS thread instead. We run the code to format labels on the JS thread and only when scrubbing on the UI thread. Also, I used regular props for default values such as date label or initial price label. It did make it faster to render.

What has changed? Now we rely on real prop value. Previously it would be assigned to the shared value in useEffect. So now we have delay for that. And since UI Thread is busy rendering everything it's slower to appear.
But also this new change is the right implementation of this. Because there was no way to recreate worklet on some react-world value change. Now we can just add it as part of the worklet dependencies.

Also, another change i did in this PR - i optimized the re-render the chart labels to at the same-ish frame. So now ratio color, price, date are changing at the same time. It might feel "slower" but looks way "smoother".

## PoW (screenshots / screen recordings)

- [Old one](https://drive.google.com/file/d/1G-yIfJrN51TbgKi1FkcdT3Yv0AA0-lg7/view?usp=sharing) - pay attention to the date label. It's flickers on timeline change as well as it doesn't appear right away, but with some delay
- [New one](https://drive.google.com/file/d/1G2R5tlW8lN3yGBI0nuMGAvKD1oFiqft2/view?usp=sharing) - it's faster to appear now. Pretty much instantly with the chart. No flickering. Color changes pretty much at the same time as value. Price, date and ratio is synchronised now (as far as we can get it with async nature of react native)

## Dev checklist for QA: what to test

- Check charts expanded state in general
- Look for missing or with wrong data header labels 
- Check if switching tokens or timeline breaks something

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
