### PR TITLE
[RNBW-2189] Improve shadows on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "react-native-dark-mode": "0.2.2",
     "react-native-device-info": "5.3.1",
     "react-native-dotenv": "2.4.2",
+    "react-native-drop-shadow": "0.0.4",
     "react-native-dynamic": "1.0.0",
     "react-native-exit-app": "1.1.0",
     "react-native-extra-dimensions-android": "1.2.2",

--- a/src/components/buttons/MiniButton.js
+++ b/src/components/buttons/MiniButton.js
@@ -71,7 +71,6 @@ export default function MiniButton({
       disabled={disabled}
       onPress={onPress}
       opacity={isDarkMode && disabled ? 0.6 : 1}
-      radiusAndroid={borderRadius}
       scaleTo={scaleTo}
       {...props}
     >
@@ -79,11 +78,7 @@ export default function MiniButton({
         <ShadowStack
           {...position.coverAsObject}
           backgroundColor={
-            android
-              ? 'none'
-              : disabled
-              ? colors.lightGrey
-              : backgroundColor || colors.appleBlue
+            disabled ? colors.lightGrey : backgroundColor || colors.appleBlue
           }
           borderRadius={borderRadius}
           height={height}

--- a/src/components/buttons/TokenSelectionButton.js
+++ b/src/components/buttons/TokenSelectionButton.js
@@ -12,7 +12,6 @@ import { padding, position } from '@rainbow-me/styles';
 import ShadowStack from 'react-native-shadow-stack';
 
 const TokenSelectionButtonHeight = 46;
-const TokenSelectionButtonElevation = ios ? 0 : 8;
 
 const Content = styled(RowWithMargins).attrs({
   align: 'center',
@@ -59,8 +58,9 @@ export default function TokenSelectionButton({
     <ButtonPressAnimation
       borderRadius={borderRadius}
       contentContainerStyle={{
-        backgroundColor: colorForAsset,
+        backgroundColor: 'transparent',
         borderRadius,
+        paddingVertical: android ? 12 : 0,
       }}
       onPress={onPress}
       radiusAndroid={borderRadius}
@@ -70,8 +70,9 @@ export default function TokenSelectionButton({
         {...position.coverAsObject}
         backgroundColor={colorForAsset}
         borderRadius={borderRadius}
-        elevation={TokenSelectionButtonElevation}
+        height={TokenSelectionButtonHeight}
         shadows={shadowsForAsset}
+        width="100%"
       />
       <Content>
         <Text

--- a/src/components/discover-sheet/DiscoverSheetHeader.js
+++ b/src/components/discover-sheet/DiscoverSheetHeader.js
@@ -30,8 +30,8 @@ const ChildWrapperView = styled.View`
 `;
 
 export const FloatingActionButtonShadow = colors => [
-  [0, 10, 30, colors.shadow, 0.5],
-  [0, 5, 15, colors.shadow, 1],
+  [0, 10, 30, colors.shadow, android ? 0.25 : 0.5],
+  [0, 5, 15, colors.shadow, android ? 0.5 : 1],
 ];
 
 const BackgroundFill = styled(Centered).attrs({

--- a/src/components/discover-sheet/DiscoverSheetHeader.js
+++ b/src/components/discover-sheet/DiscoverSheetHeader.js
@@ -30,8 +30,8 @@ const ChildWrapperView = styled.View`
 `;
 
 export const FloatingActionButtonShadow = colors => [
-  [0, 10, android ? 0 : 30, colors.shadow, 0.5],
-  [0, 5, android ? 0 : 15, colors.shadow, 1],
+  [0, 10, 30, colors.shadow, 0.5],
+  [0, 5, 15, colors.shadow, 1],
 ];
 
 const BackgroundFill = styled(Centered).attrs({

--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -6,6 +6,7 @@ import ExchangeMaxButton from './ExchangeMaxButton';
 import ExchangeNativeField from './ExchangeNativeField';
 
 const Container = styled(ColumnWithMargins).attrs({ margin: 5 })`
+  padding-bottom: ${android ? 10 : 0};
   padding-top: 6;
   width: 100%;
   z-index: 1;
@@ -15,6 +16,7 @@ const NativeFieldRow = styled(Row).attrs({
   align: 'center',
   justify: 'space-between',
 })`
+  margin-top: ${android ? -4 : 0};
   height: ${android ? 16 : 32};
   padding-left: 19;
 `;

--- a/src/components/exchange/ExchangeNotch.js
+++ b/src/components/exchange/ExchangeNotch.js
@@ -13,13 +13,14 @@ import { useDimensions } from '@rainbow-me/hooks';
 
 const notchHeight = 48;
 const notchSideWidth = 78;
+const notchTopOffset = android ? 142 : 132;
 
 const Container = styled(Row).attrs({
   pointerEvents: 'none',
 })`
   height: ${notchHeight};
   position: absolute;
-  top: 132;
+  top: ${notchTopOffset};
   width: 100%;
 `;
 

--- a/src/components/exchange/ExchangeOutputField.js
+++ b/src/components/exchange/ExchangeOutputField.js
@@ -4,10 +4,11 @@ import { Row } from '../layout';
 import ExchangeField from './ExchangeField';
 
 const paddingTop = android ? 15 : 32;
+const paddingBottom = android ? 10 : 21;
 
 const Container = styled(Row).attrs({ align: 'center' })`
   overflow: hidden;
-  padding-bottom: 21;
+  padding-bottom: ${paddingBottom};
   padding-top: ${paddingTop};
   width: 100%;
 `;

--- a/src/components/fab/ExchangeFab.js
+++ b/src/components/fab/ExchangeFab.js
@@ -12,8 +12,8 @@ import Routes from '@rainbow-me/routes';
 import { magicMemo, watchingAlert } from '@rainbow-me/utils';
 
 const FabShadow = [
-  [0, 10, 30, lightModeThemeColors.shadow, 0.8],
-  [0, 5, 15, lightModeThemeColors.swapPurple, 1],
+  [0, 10, 30, lightModeThemeColors.shadow, android ? 0.4 : 0.8],
+  [0, 5, 15, lightModeThemeColors.swapPurple, android ? 0.5 : 1],
 ];
 
 const FabIcon = styled(Text).attrs(({ theme: { colors } }) => ({

--- a/src/components/fab/SearchFab.js
+++ b/src/components/fab/SearchFab.js
@@ -6,8 +6,8 @@ import { Text } from '../text';
 import FloatingActionButton from './FloatingActionButton';
 
 const FabShadow = [
-  [0, 10, 30, lightModeThemeColors.shadow, 0.6],
-  [0, 5, 15, lightModeThemeColors.blueGreyDark, 1],
+  [0, 10, 30, lightModeThemeColors.shadow, android ? 0.3 : 0.6],
+  [0, 5, 15, lightModeThemeColors.blueGreyDark, android ? 0.5 : 1],
 ];
 
 const SearchFab = ({ disabled, ...props }) => {

--- a/src/components/fab/SendFab.js
+++ b/src/components/fab/SendFab.js
@@ -10,8 +10,8 @@ import Routes from '@rainbow-me/routes';
 import { magicMemo, watchingAlert } from '@rainbow-me/utils';
 
 const FabShadow = [
-  [0, 10, 30, lightModeThemeColors.shadow, 0.8],
-  [0, 5, 15, lightModeThemeColors.paleBlue, 1],
+  [0, 10, 30, lightModeThemeColors.shadow, android ? 0.4 : 0.8],
+  [0, 5, 15, lightModeThemeColors.paleBlue, android ? 0.5 : 1],
 ];
 
 const FabIcon = styled(Text).attrs(({ theme: { colors } }) => ({

--- a/src/components/header/DiscoverHeaderButton.js
+++ b/src/components/header/DiscoverHeaderButton.js
@@ -59,7 +59,7 @@ export default function DiscoverHeaderButton() {
     <HeaderButton
       {...(__DEV__ ? { onLongPress } : {})}
       onPress={onPress}
-      paddingLeft={0}
+      paddingLeft={ios ? 0 : undefined}
       paddingRight={0}
       scaleTo={0.9}
       testID="discover-button"

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -52,12 +52,13 @@ export default function AvatarCircle({
   const shadows = useMemo(
     () => ({
       default: [
-        [0, 2, 5, isDarkMode ? colors.trueBlack : colors.dark, 0.2],
+        [0, 2, 5, isDarkMode ? colors.trueBlack : colors.dark, 0.08],
         [
           0,
           6,
           10,
           isDarkMode ? colors.trueBlack : colors.alpha(resolvedColor, 0.6),
+          0.2,
         ],
       ],
       overlay: [
@@ -81,7 +82,6 @@ export default function AvatarCircle({
         {...position.sizeAsObject(AvatarCircleSize)}
         backgroundColor={overlayStyles ? 'rgb(51, 54, 59)' : colors.white}
         borderRadius={AvatarCircleSize}
-        marginBottom={12}
         shadows={shadows[overlayStyles ? 'overlay' : 'default']}
         {...(android && {
           height: 64,

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -2,7 +2,6 @@ import Clipboard from '@react-native-community/clipboard';
 import analytics from '@segment/analytics-react-native';
 import lang from 'i18n-js';
 import React, { useCallback, useRef } from 'react';
-import { View } from 'react-native';
 import styled from 'styled-components';
 import Divider from '../Divider';
 import { ButtonPressAnimation } from '../animations';

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -2,6 +2,7 @@ import Clipboard from '@react-native-community/clipboard';
 import analytics from '@segment/analytics-react-native';
 import lang from 'i18n-js';
 import React, { useCallback, useRef } from 'react';
+import { View } from 'react-native';
 import styled from 'styled-components';
 import Divider from '../Divider';
 import { ButtonPressAnimation } from '../animations';
@@ -173,6 +174,7 @@ export default function ProfileMasthead({
         isAvatarPickerAvailable={isAvatarPickerAvailable}
         onPress={handlePressAvatar}
       />
+      <View style={{ height: 16 }} />
       <ButtonPressAnimation onPress={handlePressChangeWallet}>
         <Row>
           <AccountName deviceWidth={deviceWidth}>{accountName}</AccountName>

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -82,6 +82,10 @@ const ProfileMastheadDivider = styled(Divider).attrs(
   position: absolute;
 `;
 
+const Spacer = styled.View`
+  height: 12;
+`;
+
 export default function ProfileMasthead({
   addCashAvailable,
   recyclerListRef,
@@ -174,7 +178,7 @@ export default function ProfileMasthead({
         isAvatarPickerAvailable={isAvatarPickerAvailable}
         onPress={handlePressAvatar}
       />
-      <View style={{ height: 16 }} />
+      <Spacer />
       <ButtonPressAnimation onPress={handlePressChangeWallet}>
         <Row>
           <AccountName deviceWidth={deviceWidth}>{accountName}</AccountName>

--- a/src/react-native-shadow-stack/AndroidShadow.js
+++ b/src/react-native-shadow-stack/AndroidShadow.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { View } from 'react-native';
+import DropShadow from 'react-native-drop-shadow';
+
+const buildShadow = (
+  width = 0,
+  height = 0,
+  radius,
+  shadowColor = '#000000',
+  shadowOpacity = 0.4
+) => ({
+  shadowColor,
+  shadowOffset: {
+    height: height / 2,
+    width,
+  },
+  shadowOpacity: shadowOpacity / 1.5,
+  shadowRadius: radius / 4,
+});
+
+export default function AndroidShadow({
+  adjustHeightForRadius,
+  adjustWidthForRadius,
+  backgroundColor,
+  borderRadius,
+  shadows,
+  width,
+  radius,
+  opacity,
+  height,
+  index = 0,
+}) {
+  const noMoreShadowsToApply = index > shadows.length - 1;
+  if (noMoreShadowsToApply) {
+    return (
+      <View
+        style={[
+          {
+            backgroundColor: backgroundColor || '#ffffff',
+            borderRadius,
+            height,
+            opacity,
+            width,
+          },
+        ]}
+      />
+    );
+  }
+
+  const shadow = shadows[index];
+  return (
+    <DropShadow
+      style={[
+        {
+          alignItems: 'center',
+          borderRadius,
+          height: adjustHeightForRadius ? height + radius : height,
+          justifyContent: 'center',
+          opacity,
+          paddingHorizontal: !adjustHeightForRadius ? 4 : undefined,
+          position: 'absolute',
+          width: adjustWidthForRadius ? width + radius : width,
+          ...buildShadow(...shadow),
+        },
+      ]}
+    >
+      <AndroidShadow
+        backgroundColor={backgroundColor}
+        borderRadius={borderRadius}
+        height={height}
+        index={index + 1}
+        opacity={opacity}
+        radius={radius}
+        shadows={shadows}
+        width={width}
+      />
+    </DropShadow>
+  );
+}

--- a/src/react-native-shadow-stack/ShadowStack.android.js
+++ b/src/react-native-shadow-stack/ShadowStack.android.js
@@ -18,15 +18,10 @@ const ShadowStack = React.forwardRef(
     },
     ref
   ) => {
-    const radius = Math.max(...shadows.map(shadow => shadow[2]));
-
-    let width = widthProp;
-    if (typeof width !== 'number') {
-      width = '100%';
-    }
-
+    const width = typeof widthProp === 'number' ? widthProp : '100%';
     const adjustHeightForRadius = typeof height === 'number';
     const adjustWidthForRadius = typeof width === 'number';
+    const radius = Math.max(...shadows.map(shadow => shadow[2]));
 
     return (
       <View

--- a/src/react-native-shadow-stack/ShadowStack.android.js
+++ b/src/react-native-shadow-stack/ShadowStack.android.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import AndroidShadow from './AndroidShadow';
+
+const ShadowStack = React.forwardRef(
+  (
+    {
+      backgroundColor,
+      borderRadius,
+      children,
+      height,
+      hideShadow,
+      overflow = 'hidden',
+      shadows,
+      width: widthProp,
+      ...props
+    },
+    ref
+  ) => {
+    const radius = Math.max(...shadows.map(shadow => shadow[2]));
+
+    let width = widthProp;
+    if (typeof width !== 'number') {
+      width = '100%';
+    }
+
+    const adjustHeightForRadius = typeof height === 'number';
+    const adjustWidthForRadius = typeof width === 'number';
+
+    return (
+      <View
+        {...props}
+        borderRadius={borderRadius}
+        height={height}
+        ref={ref}
+        width={width}
+      >
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {
+              alignItems: 'center',
+              // Since shadows are sometimes cut off on Android, we need to
+              // account for the shadow radius when setting the size of the element.
+              height: adjustHeightForRadius ? height + radius : width,
+              justifyContent: 'center',
+              marginLeft: adjustWidthForRadius ? -(radius / 2) : undefined,
+              marginTop: adjustHeightForRadius ? -(radius / 2) : undefined,
+              width: adjustWidthForRadius ? width + radius : width,
+            },
+          ]}
+        >
+          <AndroidShadow
+            adjustHeightForRadius={adjustHeightForRadius}
+            adjustWidthForRadius={adjustWidthForRadius}
+            backgroundColor={backgroundColor}
+            borderRadius={borderRadius}
+            height={height}
+            opacity={hideShadow ? 0 : 1}
+            radius={radius}
+            shadows={shadows}
+            width={width}
+          />
+          <View
+            style={{
+              borderRadius,
+              height,
+              width,
+            }}
+          >
+            <View
+              {...props}
+              borderRadius={borderRadius}
+              overflow={overflow}
+              style={[{ backgroundColor, borderRadius, height, width }]}
+            >
+              {children}
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+  }
+);
+
+ShadowStack.displayName = 'ShadowStack';
+
+export default ShadowStack;

--- a/src/react-native-shadow-stack/ShadowStack.ios.js
+++ b/src/react-native-shadow-stack/ShadowStack.ios.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
+
 import ShadowItem from './ShadowItem';
 
 const ShadowStack = React.forwardRef(
@@ -8,7 +9,6 @@ const ShadowStack = React.forwardRef(
       backgroundColor,
       borderRadius,
       children,
-      elevation = 0,
       height,
       hideShadow,
       overflow = 'hidden',
@@ -24,7 +24,6 @@ const ShadowStack = React.forwardRef(
         <ShadowItem
           backgroundColor={backgroundColor}
           borderRadius={borderRadius}
-          elevation={elevation}
           height={height}
           key={`${shadow.join('-')}${index}`}
           opacity={hideShadow ? 0 : 1}
@@ -33,7 +32,7 @@ const ShadowStack = React.forwardRef(
           zIndex={index + 2}
         />
       ),
-      [backgroundColor, borderRadius, elevation, height, hideShadow, width]
+      [backgroundColor, borderRadius, height, hideShadow, width]
     );
 
     return (
@@ -51,10 +50,6 @@ const ShadowStack = React.forwardRef(
         <View
           {...props}
           borderRadius={borderRadius}
-          elevation={shadows.reduce(
-            (acc, curr) => acc + Math.min(6, curr[2]),
-            0
-          )}
           height={height}
           overflow={overflow}
           style={[StyleSheet.absoluteFill, { backgroundColor }]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14195,6 +14195,13 @@ react-native-dotenv@2.4.2:
   dependencies:
     dotenv "^8.0.0"
 
+react-native-drop-shadow@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-drop-shadow/-/react-native-drop-shadow-0.0.4.tgz#af2ceff6a3e1468b01cd5fb55941854cbe30dad6"
+  integrity sha512-45Bsq24dcc1rK9H+42H91xEYN/Ql5S0693FseQWdCKgri6D+4vkFeL9dgtrSD5Bg3+RffjMbPDD7BuNS9BZuvg==
+  dependencies:
+    logkitty "^0.7.1"
+
 react-native-dynamic@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dynamic/-/react-native-dynamic-1.0.0.tgz#d971618fd278cf66acb0add46536aa7a68fd8d4f"


### PR DESCRIPTION
Fixes RNBW-2189

## What changed (plus any additional context for devs)

There is an issue with using `elevation` in Android where it's value is not a reliable source of truth for the elevation of an element. It also seems that our shadows in Android weren't taking a shadow color either, so most shadows were black.

As you can see in the image below, the elevation of the last elements in the NFT family headers are more elevated than the first. This is because Android takes a central shadow origin point, then applies that globally to the elements that have elevation.

<img width="397" alt="Screen Shot 2022-01-11 at 9 37 53 am (1)" src="https://user-images.githubusercontent.com/7336481/149048558-df76db3a-fcff-4216-b3c0-18dbace8463a.png">

There are some existing workarounds of shadow on Android such as using `react-native-svg` too, however, it isn't as performant. But with the recent release of [React Native Skia](https://github.com/Shopify/react-native-skia), I thought it would be worth revisiting shadows painted on a vector canvas.

[`react-native-drop-shadow`](https://github.com/hoanglam10499/react-native-drop-shadow) seems like another interesting workaround which creates bitmap representations of shadows in Android.

After doing some benchmarking implementing shadows in React Native Skia & `react-native-drop-shadow`, it was observed that `react-native-drop-shadow` had similar performance to `elevation`:

| Time-to-paint | `elevation` | `react-native-drop-shadow` | React Native Skia | 
|---------------|-------------|----------------------------|-------------------|
| 100 elements  | ~50ms       | ~60ms                      | ~100ms            |   
| 500 elements  | ~100ms      | ~120ms                     | ~220ms            |   
| 1000 elements | ~130ms      | N/A                        | ~430ms            |   

This PR proposes usage of `react-native-drop-shadow` to replicate the shadow that we see on iOS (also open to ideas on other alternative implementations too).

There are a few tweaks for Android to make the shadow behave consistently for some components (to fix shadows being cut off by the component boundary) which involves tweaking of margins/padding, but once a shadow implementation is added to the design system, and layouts start utilising the design system, we shouldn't have this problem and shouldn't require any tweaking. This PR is aimed to be an interim solution until we have shadows in the design system.

## PoW (screenshots / screen recordings)

<img width="401" alt="Screen Shot 2022-01-12 at 12 03 15 pm" src="https://user-images.githubusercontent.com/7336481/149049958-89ec3a5e-e561-42dd-8138-b2cf768f8b87.png">

<img width="400" alt="Screen Shot 2022-01-12 at 12 04 51 pm" src="https://user-images.githubusercontent.com/7336481/149049960-7658e901-dcaf-4c45-a7bc-9ca0b29f2325.png">

<img width="399" alt="Screen Shot 2022-01-12 at 12 05 28 pm" src="https://user-images.githubusercontent.com/7336481/149049976-253dbd0e-c2b5-412b-a96a-efe311d98cd0.png">

<img width="401" alt="Screen Shot 2022-01-12 at 12 06 16 pm" src="https://user-images.githubusercontent.com/7336481/149049983-1968ff99-8119-43cd-81b7-5424a264859f.png">

<img width="394" alt="Screen Shot 2022-01-12 at 12 06 51 pm" src="https://user-images.githubusercontent.com/7336481/149050017-3fd65568-7265-4337-a8d9-e646a6c0e6d2.png">


## Dev checklist for QA: what to test

- Ensure shadows are still behaving correctly on elements on the following screens:
  - Wallet screen (inc. Add Funds Interstitial screen)
  - Profile screen
  - Send screen
  - Swap screen
  - Discover screen
  - Import wallet screen
  - Liquidity pool expanded state
  - NFT expanded state
  - Expand sheets
 

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
