### PR TITLE
pass hidden & pinned from balance row

### DIFF
--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -175,9 +175,9 @@ const BalanceCoinRow = ({
             <CoinRow
               bottomRowRender={BottomRow}
               containerStyles={containerStyles}
+              isFirstCoinRow={isFirstCoinRow}
               isHidden={isHidden}
               isPinned={isPinned}
-              isFirstCoinRow={isFirstCoinRow}
               onPress={handlePress}
               topRowRender={TopRow}
               {...item}

--- a/src/components/coin-row/BalanceCoinRow.js
+++ b/src/components/coin-row/BalanceCoinRow.js
@@ -175,6 +175,8 @@ const BalanceCoinRow = ({
             <CoinRow
               bottomRowRender={BottomRow}
               containerStyles={containerStyles}
+              isHidden={isHidden}
+              isPinned={isPinned}
               isFirstCoinRow={isFirstCoinRow}
               onPress={handlePress}
               topRowRender={TopRow}

--- a/src/components/coin-row/CoinRow.js
+++ b/src/components/coin-row/CoinRow.js
@@ -1,6 +1,5 @@
 import React, { createElement } from 'react';
 import styled from 'styled-components';
-import useCoinListEditOptions from '../../hooks/useCoinListEditOptions';
 import { CoinIcon, CoinIconGroup, CoinIconSize } from '../coin-icon';
 import { Column, Row } from '../layout';
 import { useAccountSettings } from '@rainbow-me/hooks';
@@ -37,6 +36,8 @@ export default function CoinRow({
   containerStyles,
   contentStyles,
   isFirstCoinRow,
+  isHidden,
+  isPinned,
   isPool,
   name,
   symbol,
@@ -46,9 +47,6 @@ export default function CoinRow({
   ...props
 }) {
   const { nativeCurrency, nativeCurrencySymbol } = useAccountSettings();
-  const { hiddenCoins, pinnedCoins } = useCoinListEditOptions();
-  const isPinned = pinnedCoins.includes(props.uniqueId);
-  const isHidden = hiddenCoins.includes(props.uniqueId);
   return (
     <Container css={containerStyles}>
       {isPool ? (

--- a/src/components/send/SendAssetList.js
+++ b/src/components/send/SendAssetList.js
@@ -61,7 +61,7 @@ export default class SendAssetList extends React.Component {
     const { assets } = buildCoinsList(
       sortedAssets,
       nativeCurrency,
-      true,
+      false,
       pinnedCoins,
       hiddenCoins
     );

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -25,6 +25,7 @@ import { usePagerPosition } from '../navigation/ScrollPositionContext';
 import { addHexPrefix } from '@rainbow-me/handlers/web3';
 import { CurrencySelectionTypes } from '@rainbow-me/helpers';
 import {
+  useCoinListEditOptions,
   useInteraction,
   useMagicAutofocus,
   usePrevious,
@@ -87,6 +88,16 @@ export default function CurrencySelectModal() {
     searchQuery,
   ]);
   const uniswapAssetsInWallet = useUniswapAssetsInWallet();
+  const { hiddenCoins } = useCoinListEditOptions();
+
+  const filteredUniswapAssetsInWallet = useMemo(
+    () =>
+      uniswapAssetsInWallet.filter(
+        ({ address }) => !hiddenCoins.includes(address)
+      ),
+    [uniswapAssetsInWallet, hiddenCoins]
+  );
+
   const {
     uniswapCurrencyList,
     uniswapCurrencyListLoading,
@@ -95,12 +106,12 @@ export default function CurrencySelectModal() {
   const getWalletCurrencyList = () => {
     if (searchQueryForSearch !== '') {
       const searchResults = searchWalletCurrencyList(
-        uniswapAssetsInWallet,
+        filteredUniswapAssetsInWallet,
         searchQueryForSearch
       );
       return headerlessSection(searchResults);
     } else {
-      return headerlessSection(uniswapAssetsInWallet);
+      return headerlessSection(filteredUniswapAssetsInWallet);
     }
   };
   const currencyList =

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -93,7 +93,7 @@ export default function CurrencySelectModal() {
   const filteredUniswapAssetsInWallet = useMemo(
     () =>
       uniswapAssetsInWallet.filter(
-        ({ address }) => !hiddenCoins.includes(address)
+        ({ uniqueId }) => !hiddenCoins.includes(uniqueId)
       ),
     [uniswapAssetsInWallet, hiddenCoins]
   );


### PR DESCRIPTION
Fixes RNBW-2198

## What changed (plus any additional context for devs)
RLV changes added isHIdden to every coin row, while we only care if its hidden for the BalanceCoinRow

added removing hidden tokens form swap & send (updated POW)

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-01-11-22-49-32.mp4

## Dev checklist for QA: what to test
hidden tokens in search or lists should be normal, should not be in send or swap

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
