### PR TITLE
Disable font scaling on gas inputs

### DIFF
--- a/src/components/expanded-state/custom-gas/GweiInputPill.js
+++ b/src/components/expanded-state/custom-gas/GweiInputPill.js
@@ -96,6 +96,7 @@ function GweiInputPill(
       <GweiPill>
         <Row alignSelf="center" marginHorizontal={-40}>
           <GweiNumberInput
+            allowFontScaling={false}
             contextMenuHidden
             mask="[9999]{.}[999]"
             onBlur={onBlur}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
rainbow currently doesn't support dynamic text sizes via device setting. eventually it will, but for now we disable it in the few places it does work since it doesn't help much and tends to break the layout

it was enabled on the gas inputs, this PR disables it

## PoW (screenshots / screen recordings)
before:
<img width="957" alt="Screen Shot 2022-01-12 at 2 29 14 AM" src="https://user-images.githubusercontent.com/7061887/149083046-86e33499-8674-4c7c-86ae-f73a04887bac.png">

after:
<img width="956" alt="Screen Shot 2022-01-12 at 2 28 55 AM" src="https://user-images.githubusercontent.com/7061887/149083065-1ff12db0-f818-4d77-80be-90fc45a78512.png">

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
