### PR TITLE
Not allow for keyboard dismissing in Discover sheet in search mode on Android

### DIFF
--- a/src/components/discover-sheet/DiscoverSheet.android.js
+++ b/src/components/discover-sheet/DiscoverSheet.android.js
@@ -115,6 +115,9 @@ const DiscoverSheet = (_, forwardedRef) => {
           animatedPosition={sheetPosition}
           animationDuration={300}
           backgroundComponent={CustomBackground}
+          enableContentPanningGesture={
+            !headerButtonsHandlers.isSearchModeEnabled
+          }
           failOffsetX={[-10, 10]}
           handleComponent={CustomHandle}
           index={1}


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
I noticed this is possible to close the discover sheet in the search mode. Now, this is fixed. 

## PoW (screenshots / screen recordings)

before: https://streamable.com/zn7qu1
after: https://streamable.com/2sq4vj

## Dev checklist for QA: what to test
Open the app on Android and try closing the discover sheet
