### PR TITLE
Fix key for cloud backup description.

### DIFF
--- a/src/screens/BackupSheet.js
+++ b/src/screens/BackupSheet.js
@@ -157,7 +157,9 @@ export default function BackupSheet() {
         return (
           //TODO: ADD CloudPlatform to back_up.description
           <BackupSheetSection
-            descriptionText={lang.t('modal.back_up.imported.description')}
+            descriptionText={lang.t('modal.back_up.imported.description', {
+              cloudPlatformName: cloudPlatform,
+            })}
             onPrimaryAction={onIcloudBackup}
             onSecondaryAction={goBack}
             primaryLabel={`􀙶 ${lang.t('modal.back_up.imported.button.back_up', {
@@ -180,7 +182,9 @@ export default function BackupSheet() {
       default:
         return (
           <BackupSheetSection
-            descriptionText={lang.t('modal.back_up.default.description')}
+            descriptionText={lang.t('modal.back_up.default.description', {
+              cloudPlatformName: cloudPlatform,
+            })}
             onPrimaryAction={onIcloudBackup}
             onSecondaryAction={onManualBackup}
             primaryLabel={`􀙶 ${lang.t('modal.back_up.default.button.cloud', {


### PR DESCRIPTION
## What changed (plus any additional context for devs)

This fixes the missing `cloudPlatformName` key on the backup screen.

Before:

<img width="200" alt="Before" src=https://user-images.githubusercontent.com/17259768/149216477-3637961d-79ae-47ab-bd7d-257828bbc67b.png />

## PoW (screenshots / screen recordings)

After:

<img width="200" alt="After" src="https://user-images.githubusercontent.com/17259768/149216709-039843cb-189f-4e23-9312-506c635b64c3.png" />
