### PR TITLE
Fix some i18n duplicate issues.

### DIFF
--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -157,7 +157,7 @@ const ContactProfileState = ({ address, color: colorProp, contact }) => {
         <CopyTooltip
           onHide={handleTriggerFocusInput}
           textToCopy={address}
-          tooltipText={lang.t('wallet.settings.copy_address')}
+          tooltipText={lang.t('wallet.settings.copy_address_capitalized')}
         >
           {isValidDomainFormat(address) ? (
             <ENSAbbreviation ens={address} />

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -175,7 +175,7 @@ export default function WalletProfileState({
           <CopyTooltip
             onHide={handleTriggerFocusInput}
             textToCopy={address}
-            tooltipText={lang.t('wallet.copy_address')}
+            tooltipText={lang.t('wallet.settings.copy_address_capitalized')}
           >
             <WalletProfileAddressText address={address} />
           </CopyTooltip>

--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -187,7 +187,7 @@ export default function ProfileMasthead({
           onPress={handlePressCopyAddress}
           radiusWrapperStyle={{ marginRight: 10, width: 150 }}
           scaleTo={0.88}
-          text={lang.t('wallet.settings.copy_address')}
+          text={lang.t('wallet.settings.copy_address_capitalized')}
           width={127}
           wrapperProps={{
             containerStyle: {

--- a/src/components/send/SendHeader.js
+++ b/src/components/send/SendHeader.js
@@ -141,7 +141,7 @@ export default function SendHeader({
         options: [
           lang.t('contacts.options.delete'), // <-- destructiveButtonIndex
           lang.t('contacts.options.edit'),
-          lang.t('wallet.settings.copy_address'),
+          lang.t('wallet.settings.copy_address_capitalized'),
           lang.t('contacts.options.cancel'), // <-- cancelButtonIndex
         ],
       },

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -72,9 +72,9 @@
         "enter_amount": "Enter an Amount",
         "fetching_details": "Fetching Details...",
         "insufficient_eth": "Insufficient ETH",
-        "invalid_fee": "Invalid Fee",
         "insufficient_funds": "Insufficient Funds",
         "insufficient_liquidity": "Insufficient Liquidity",
+        "invalid_fee": "Invalid Fee",
         "swap": "Hold to Swap",
         "swap_anyway": "Swap Anyway",
         "view_details": "View Details",
@@ -330,6 +330,7 @@
     "settings": {
       "backup": "Backup",
       "currency": "Currency",
+      "dev": "Dev",
       "developer": "Developer Settings",
       "done": "Done",
       "feedback_and_reports": "Feedback & Bug Reports",
@@ -540,7 +541,8 @@
         }
       },
       "settings": {
-        "copy_address": "Copy Address",
+        "copy_address": "Copy address",
+        "copy_address_capitalized": "Copy Address",
         "copy_seed_phrase": "Copy Secret Phrase",
         "hide_seed_phrase": "Hide Secret Phrase",
         "show_seed_phrase": "Show Secret Phrase"

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -72,9 +72,9 @@
         "enter_amount": "Entrez un Montant",
         "fetching_details": "Fetching Details... :)",
         "insufficient_eth": "ETH Insuffisants",
-        "invalid_fee": "Frais Non Valides",
         "insufficient_funds": "Fonds Insuffisants",
         "insufficient_liquidity": "Insufficient Liquidity :)",
+        "invalid_fee": "Frais Non Valides",
         "swap": "Tenir pour Swap",
         "swap_anyway": "Echanger quand Même",
         "view_details": "View Details :)",
@@ -312,6 +312,7 @@
       "back": "Retour",
       "backup": "Sauvegarder",
       "currency": "Devise",
+      "dev": "Dev :)",
       "developer": "Developer Settings :)",
       "done": "Terminé",
       "feedback_and_reports": "Feedback & Bug Reports :)",
@@ -530,6 +531,7 @@
       },
       "settings": {
         "copy_address": "Copier adresse",
+        "copy_address_capitalized": "Copier Adresse",
         "copy_seed_phrase": "Copier clé mnémonique",
         "hide_seed_phrase": "Cacher clé mnémonique",
         "show_seed_phrase": "Afficher clé mnémonique"

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -75,7 +75,7 @@ const SettingsPages = {
   },
   dev: {
     component: IS_DEV ? DevSection : null,
-    getTitle: () => lang.t('settings.developer'),
+    getTitle: () => lang.t('settings.dev'),
     key: 'DevSection',
   },
   language: {

--- a/src/screens/WelcomeScreen.js
+++ b/src/screens/WelcomeScreen.js
@@ -471,7 +471,7 @@ export default function WelcomeScreen() {
         borderWidth: ios ? 0 : 3,
         width: 230 + (ios ? 0 : 6),
       },
-      text: lang.t('wallet.new.create_wallet'),
+      text: lang.t('wallet.new.get_new_wallet'),
       textColor: colors.white,
     };
   }, [rValue]);


### PR DESCRIPTION
Another quick PR with some i18n tag fixes. In this case, there were a few instances where the same tag ID was used multiple times and the original text it was supposed to represent was replaced.

## What changed (plus any additional context for devs)

Adds a few new tags to fix re-used tag issues.

## PoW (screenshots / screen recordings)
<img width="200" alt="Screen Shot 2022-01-12 at 4 22 39 PM" src="https://user-images.githubusercontent.com/17259768/149243893-e6cad2dd-6eba-4bb3-8044-410dcec3ee41.png">

The above used to say "Create Wallet" since a tag was reused incorrectly.

```
yarn check-translations
yarn run v1.22.17
$ ./scripts/check-translations.sh ./src './src/languages/*.json' lang.t
Checking file "./src/languages/_english.json":
    ✅ No errors found for "./src/languages/_english.json".

Checking file "./src/languages/_french.json":
    ✅ No errors found for "./src/languages/_french.json".

Note, this script currently **does not** support interpolated translations such as `lang.t(`my.${variable}.based.${path}`).
    🔶 Manual check required for "lang.t(`time.${unit}.${length}.${plurality}`)".
```
