### PR TITLE
fix gas button network in txConfirmationScreen

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -1136,7 +1136,7 @@ export default function TransactionConfirmationScreen() {
             )}
           </AnimatedSheet>
           {!isMessageRequest && (
-            <GasSpeedButton network={currentNetwork} theme="dark" />
+            <GasSpeedButton currentNetwork={currentNetwork} theme="dark" />
           )}
         </Column>
       </SlackSheet>


### PR DESCRIPTION
Fixes:
https://rainbowhaus.slack.com/archives/C02LPE7TYTX/p1642030157005900
Fixes RNBW-2212


## What changed (plus any additional context for devs)

Wrong key was being used for the gas button, it was using `network` instead of `currentNetwork`

Seems like it was broken here https://github.com/rainbow-me/rainbow/pull/2706/files#diff-f2aec906d3575ac26f0daf12a43661c34a7e0b1a4cdc082ca4c56ec0ad7bf404R1131

## PoW (screenshots / screen recordings)

https://recordit.co/PPkfUbfQbk

## Dev checklist for QA: what to test
Repeat steps Ibrahim took:
1. I went to https://rainbow-me.github.io/rainbow-button/
2. tapped on Optimism and connected
3. selected sendTransaction
4. on the sheet expand the gas options

## Final checklist
[ ] Assigned individual reviewers?
[ ] Added labels?
