### PR TITLE
Fix keyboard handling on dark mode on android

### DIFF
--- a/src/navigation/onNavigationStateChange.js
+++ b/src/navigation/onNavigationStateChange.js
@@ -83,19 +83,6 @@ export function onNavigationStateChange(currentState) {
           );
         }
 
-        if (
-          routeName === Routes.MAIN_EXCHANGE_SCREEN ||
-          routeName === Routes.SAVINGS_WITHDRAW_MODAL ||
-          routeName === Routes.SEND_SHEET ||
-          routeName === Routes.SWAP_DETAILS_SCREEN ||
-          routeName === Routes.SWAP_DETAILS_SHEET ||
-          routeName === Routes.QR_SCANNER_SCREEN
-        ) {
-          AndroidKeyboardAdjust.setAdjustPan();
-        } else {
-          AndroidKeyboardAdjust.setAdjustResize();
-        }
-
         if ([prevRouteName, routeName].includes(Routes.BACKUP_SHEET)) {
           StatusBar.setBarStyle(
             !isOnSwipeScreen(routeName) ? 'light-content' : 'dark-content',
@@ -121,6 +108,21 @@ export function onNavigationStateChange(currentState) {
           StatusBar.setBarStyle('dark-content', true);
         }
       }
+    }
+  }
+
+  if (android) {
+    if (
+      routeName === Routes.MAIN_EXCHANGE_SCREEN ||
+      routeName === Routes.SAVINGS_WITHDRAW_MODAL ||
+      routeName === Routes.SEND_SHEET ||
+      routeName === Routes.SWAP_DETAILS_SCREEN ||
+      routeName === Routes.SWAP_DETAILS_SHEET ||
+      routeName === Routes.QR_SCANNER_SCREEN
+    ) {
+      AndroidKeyboardAdjust.setAdjustPan();
+    } else {
+      AndroidKeyboardAdjust.setAdjustResize();
     }
   }
 


### PR DESCRIPTION
Fixes RNBW-2156

## What changed (plus any additional context for devs)

I realized that the code is used on light mode, should be obviously running in both dark and light mode. 

## PoW (screenshots / screen recordings)

I can post later, but I need QA this anyway 

## Dev checklist for QA: what to test

Test on both themes, navigate to swap and discover sheet a few times, play with a keyboard. 

