### PR TITLE
[RNBW-2220] Return Map when Fetching Uniswap V2 Tokens

### DIFF
--- a/src/handlers/dispersion.ts
+++ b/src/handlers/dispersion.ts
@@ -36,7 +36,7 @@ export const getUniswapV2Pools = async (
 
 export const getUniswapV2Tokens = async (
   addresses: EthereumAddress[]
-): Promise<RainbowToken[]> => {
+): Promise<Record<EthereumAddress, RainbowToken>> => {
   try {
     const key = addresses.join(',');
     if (UniswapAssetsCache.cache[key]) {
@@ -45,14 +45,14 @@ export const getUniswapV2Tokens = async (
       const res = await dispersionApi.post('/dispersion/v1/tokens/uniswap/v2', {
         addresses,
       });
-      UniswapAssetsCache.cache[key] = [...res?.data?.tokens];
+      UniswapAssetsCache.cache[key] = res?.data?.tokens;
       return res?.data?.tokens;
     }
   } catch (error) {
     logger.sentry(`Error fetching uniswap v2 tokens: ${error}`);
     captureException(error);
   }
-  return [];
+  return {};
 };
 
 export const getDPIBalance = async (): Promise<

--- a/src/hooks/useAdditionalAssetData.ts
+++ b/src/hooks/useAdditionalAssetData.ts
@@ -58,7 +58,7 @@ export default function useAdditionalAssetData(
     const id =
       address?.toLowerCase() === 'eth' ? WETH_ADDRESS : address.toLowerCase();
     const uniswapData = await getUniswapV2Tokens([id]);
-    const token = uniswapData?.[0];
+    const token = uniswapData?.[id];
     setTotalLiqudity(token?.totalLiquidity);
   }, [address]);
   const dispatch = useDispatch();

--- a/src/hooks/useUniswapAssetsInWallet.js
+++ b/src/hooks/useUniswapAssetsInWallet.js
@@ -18,7 +18,7 @@ const useUniswapAssetsInWallet = () => {
       const uniswapData = await getUniswapV2Tokens(
         sortedAssets.map(({ address }) => address)
       );
-      uniswapAssets = uniswapData || [];
+      uniswapAssets = Object.values(uniswapData) || [];
     } else {
       uniswapAssets = sortedAssets;
     }

--- a/src/hooks/useUniswapCurrencyList.ts
+++ b/src/hooks/useUniswapCurrencyList.ts
@@ -94,7 +94,7 @@ const useUniswapCurrencyList = (searchQuery: string) => {
         })
       ),
     {
-      onSuccess: res => handleFavoritesResponse(res),
+      onSuccess: res => handleFavoritesResponse(Object.values(res)),
     }
   );
 

--- a/src/utils/uniswapAssetsCache.ts
+++ b/src/utils/uniswapAssetsCache.ts
@@ -1,6 +1,6 @@
-import { RainbowToken } from '@rainbow-me/entities';
+import { EthereumAddress, RainbowToken } from '@rainbow-me/entities';
 
-const cache: Record<string, RainbowToken[]> = {};
+const cache: Record<string, Record<EthereumAddress, RainbowToken>> = {};
 
 const UniswapAssetsCache = {
   cache,


### PR DESCRIPTION
Fixes RNBW-2220

Blocked by: https://github.com/rainbow-me/dispersion/pull/11

## What changed (plus any additional context for devs)
`/dispersion/v1/tokens/uniswap/v2` currently returns an array. We would like to start returning a map. This ticket requires small tweaks to dispersion and the app.

## PoW (screenshots / screen recordings)

<img width="430" alt="Screen Shot 2022-01-14 at 7 46 43 AM" src="https://user-images.githubusercontent.com/14877580/149579699-23259c74-c628-4098-adeb-b5e6a9fe0173.png">

## Dev checklist for QA: what to test

Make sure discover search and chart expanded state behave normally.

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
