### PR TITLE
fix reseting ENS results

### DIFF
--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -42,11 +42,11 @@ export const fetchSuggestions = async (
 
       const slicedSortedSuggestions = sortedEnsSuggestions.slice(0, 3);
       setSuggestions(slicedSortedSuggestions);
+    } else {
+      setSuggestions([]);
     }
-  } else {
-    setSuggestions([]);
+    setIsFetching(false);
   }
-  setIsFetching(false);
 };
 
 export const debouncedFetchSuggestions = debounce(fetchSuggestions, 200);


### PR DESCRIPTION
Fixes RNBW-2223

## What changed (plus any additional context for devs)

we we're reseting ENS results only if query length < 2 when we actually want to reset if there is no result

## PoW (screenshots / screen recordings)
can't really put a POW without https://github.com/rainbow-me/rainbow/pull/2827

code is pretty obvious tho

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
