### PR TITLE
Update traits type on UniqueAsset to be an array of trait objects

### DIFF
--- a/src/entities/uniqueAssets.ts
+++ b/src/entities/uniqueAssets.ts
@@ -30,7 +30,7 @@ export interface UniqueAsset {
     trait_type: string;
     value: string | number;
     display_type: string;
-  };
+  }[];
   asset_contract: AssetContract;
   background: string | null;
   collection: {


### PR DESCRIPTION
## What changed (plus any additional context for devs)

The `traits` property on `UniqueAsset` is currently defined as a single object when it's actually an array of these objects. You can see this in practice in the usage of prop-types in [`UniqueTokenAttributes`](https://github.com/rainbow-me/rainbow/blob/2cc33c0d511ec5c0d80c146ea6224cf16077b0bb/src/components/unique-token/UniqueTokenAttributes.js#L46-L51).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
