### PR TITLE
update learn links 

### DIFF
--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -48,7 +48,7 @@ const { RainbowRequestReview, RNReview } = NativeModules;
 
 export const SettingsExternalURLs = {
   rainbowHomepage: 'https://rainbow.me',
-  rainbowLearn: 'https://rainbow.me/learn',
+  rainbowLearn: 'https://learn.rainbow.me',
   review:
     'itms-apps://itunes.apple.com/us/app/appName/id1457119021?mt=8&action=write-review',
   twitterDeepLink: 'twitter://user?screen_name=rainbowdotme',

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -176,7 +176,7 @@ export const explainers = network => ({
       />
     ),
     readMoreLink:
-      'https://rainbow.me/learn/a-beginners-guide-to-layer-2-networks',
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
     text: OPTIMISM_EXPLAINER,
     title: `What's Optimism?`,
   },
@@ -192,7 +192,7 @@ export const explainers = network => ({
       />
     ),
     readMoreLink:
-      'https://rainbow.me/learn/a-beginners-guide-to-layer-2-networks',
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
     text: ARBITRUM_EXPLAINER,
     title: `What's Arbitrum?`,
   },
@@ -208,7 +208,7 @@ export const explainers = network => ({
       />
     ),
     readMoreLink:
-      'https://rainbow.me/learn/a-beginners-guide-to-layer-2-networks',
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
     text: POLYGON_EXPLAINER,
     title: `What's Polygon?`,
   },


### PR DESCRIPTION
Fixes RNBW-2226

## What changed (plus any additional context for devs)
when we moved to notion we changed the url from rainbow.me/learn -> learn.rainbow.me

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test
check links

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
