### PR TITLE
filter out pools from covalent

### DIFF
--- a/src/handlers/localstorage/accountLocal.ts
+++ b/src/handlers/localstorage/accountLocal.ts
@@ -1,6 +1,6 @@
 import { getAccountLocal, saveAccountLocal } from './common';
 
-const accountAssetsDataVersion = '0.1.0';
+const accountAssetsDataVersion = '0.1.1';
 const accountEmptyVersion = '0.1.0';
 const assetPricesFromUniswapVersion = '0.1.0';
 const assetsVersion = '0.2.0';


### PR DESCRIPTION
Fixes RNBW-2227 & RNBW-2228

## What changed (plus any additional context for devs)

we were not filtering pools form covalent so they were still showing up

we may want to do this filtering upstream but for now i'm handling the same as hidden tokens.

## PoW (screenshots / screen recordings)

before asset list: https://cloud.skylarbarrera.com/Screen-Recording-2022-01-16-02-49-26.mp4
after asset list: https://cloud.skylarbarrera.com/Screen-Recording-2022-01-16-02-48-46.mp4

before swap: https://cloud.skylarbarrera.com/Screen-Recording-2022-01-16-01-50-00.mp4
after swap: https://cloud.skylarbarrera.com/Screen-Recording-2022-01-16-01-49-35.mp4

## Dev checklist for QA: what to test

## Final checklist
[x] Assigned individual reviewers?
[x] Added labels?
