### PR TITLE
Align Prettier config with eslint-config-rainbow rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,8 +26,6 @@ module.exports = {
   extends: 'rainbow',
   settings: {
     'import/resolver': {
-      // eslint wants it to be `'node'` but prettier `node`
-      // prettier-ignore
       'node': {
         extensions: [
           '.js',

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,7 @@ module.exports = {
   arrowParens: 'avoid',
   bracketSpacing: true,
   bracketSameLine: false,
+  quoteProps: 'consistent',
   singleQuote: true,
   trailingComma: 'es5',
 };

--- a/src/design-system/components/Box/Box.tsx
+++ b/src/design-system/components/Box/Box.tsx
@@ -21,7 +21,7 @@ const widths = {
   '3/4': fraction(3, 4),
   '3/5': fraction(3, 5),
   '4/5': fraction(4, 5),
-  full: '100%', // eslint-disable-line prettier/prettier
+  'full': '100%',
 } as const;
 
 function resolveToken<TokenName extends string, TokenValue, CustomValue>(

--- a/src/design-system/docs/system/tokens.css.ts
+++ b/src/design-system/docs/system/tokens.css.ts
@@ -7,7 +7,7 @@ import {
 import { typeHierarchy } from './typography.css';
 
 export const space = {
-  none: '0', // eslint-disable-line prettier/prettier
+  'none': '0',
   '2px': '2px',
   '4px': '4px',
   '8px': '8px',
@@ -23,8 +23,8 @@ export const space = {
 export type Space = keyof typeof space;
 
 export const negativeSpace = {
-  auto: 'auto', // eslint-disable-line prettier/prettier
-  none: '0', // eslint-disable-line prettier/prettier
+  'auto': 'auto',
+  'none': '0',
   '-2px': '-2px',
   '-4px': '-4px',
   '-8px': '-8px',


### PR DESCRIPTION
## What changed (plus any additional context for devs)

The Prettier config in this repo doesn't match the rules embedded in eslint-config-rainbow (missing `quoteProps: 'consistent'`) making it impossible to pass both ESLint and Prettier checks unless disable/ignore comments are used on the offending lines. I ran into this issue when migrating RainbowKit to eslint-config-rainbow and realised that this project has the same problem.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
