### PR TITLE
Fix AddFundsInterstitial

### DIFF
--- a/src/components/asset-list/EmptyAssetList.js
+++ b/src/components/asset-list/EmptyAssetList.js
@@ -37,6 +37,7 @@ const EmptyAssetList = ({
 
   return (
     <ScrollView
+      contentContainerStyle={{ height: '100%' }}
       refreshControl={
         <RefreshControl onRefresh={refresh} refreshing={isRefreshing} />
       }


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
I noticed that sometimes (maybe when there was no content before?) the main screen is while instead of showing `AddFundsInterstitial`. This is especially visible on my Samsung S21.

## PoW (screenshots / screen recordings)

Before:
![image](https://user-images.githubusercontent.com/25709300/149912815-3e99f2c7-86d9-4549-bb98-381e8b236b40.png)
After:
![image](https://user-images.githubusercontent.com/25709300/149912770-7a792cf4-f7bf-4ba5-82d6-31c001435333.png)

## Dev checklist for QA: what to test
Try to add a new wallet, maybe kill the app, run again, try a few times. 

