### PR TITLE
Fix flashing of dot in charts

### DIFF
--- a/src/react-native-animated-charts/src/charts/linear/ChartDot.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartDot.tsx
@@ -31,7 +31,7 @@ const ChartDot = React.memo(
       );
 
       return {
-        opacity: animation,
+        opacity: positionY.value === -1 ? 0 : animation,
         transform: [
           { translateX },
           { translateY },

--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -159,6 +159,7 @@ export const ChartPath = React.memo(
     const resetGestureState = useWorkletCallback(() => {
       originalX.value = '';
       originalY.value = '';
+      positionY.value = -1;
       isActive.value = false;
       pathOpacity.value = withTiming(
         1,

--- a/src/react-native-animated-charts/src/charts/linear/ChartPathProvider.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPathProvider.tsx
@@ -151,7 +151,7 @@ export const ChartPathProvider = React.memo<ChartPathProviderProps>(
 
     // position of the dot
     const positionX = useSharedValue(0);
-    const positionY = useSharedValue(0);
+    const positionY = useSharedValue(-1);
 
     // componentDidMount hack
     const initialized = useRef(false);


### PR DESCRIPTION
Fixes RNBW-2180
Fixes RNBW-2250

## What changed (plus any additional context for devs)

The dot was persisting the previous position. Now, I reset the position while the gesture ends and if it's not set, I do not show the dot at all (one frame).

## PoW (screenshots / screen recordings)
before: https://streamable.com/suvaht
after: https://streamable.com/npgb6g


## Dev checklist for QA: what to test

Try to observe if there's no dot in the previous position while starting the gesture.

