### PR TITLE
add default edit button

### DIFF
--- a/src/components/asset-list/RecyclerAssetList/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList/index.tsx
@@ -813,7 +813,7 @@ function RecyclerAssetList({
           },
         ]}
       >
-        <CoinDivider balancesSum={0} />
+        <CoinDivider balancesSum={0} defaultToEditButton={false} />
       </View>
     </StyledContainer>
   );

--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -47,7 +47,12 @@ function rowRenderer(type: CellType, { uid }: { uid: string }) {
             return null;
           case CellType.COIN_DIVIDER:
             return (
-              <CoinDivider balancesSum={(data as CoinDividerExtraData).value} />
+              <CoinDivider
+                balancesSum={(data as CoinDividerExtraData).value}
+                defaultToEditButton={
+                  (data as CoinDividerExtraData).defaultToEditButton
+                }
+              />
             );
           case CellType.ASSETS_HEADER:
             return (

--- a/src/components/asset-list/RecyclerAssetList2/core/ViewTypes.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/ViewTypes.ts
@@ -38,6 +38,7 @@ export type UniswapPoolExtraData = {
 export type CoinDividerExtraData = {
   type: CellType.COIN_DIVIDER;
   value: number;
+  defaultToEditButton: boolean;
 };
 export type AssetsHeaderExtraData = {
   type: CellType.ASSETS_HEADER;

--- a/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
@@ -24,7 +24,6 @@ export default function useMemoBriefSectionData() {
     let isGroupOpen = true;
     const stickyHeaders = [];
     let index = 0;
-    let isAnyAssetBelowDivider = false;
     let afterCoins = false;
     // load firstly 12, then the rest after 1 sec
     let numberOfSmallBalancesAllowed = stagger ? 12 : briefSectionsData.length;
@@ -53,21 +52,13 @@ export default function useMemoBriefSectionData() {
           stickyHeaders.push(index);
         }
         if (
-          afterDivider &&
-          data.type === CellType.COIN &&
-          !hiddenCoins.includes((data as CoinExtraData).uniqueId)
-        ) {
-          isAnyAssetBelowDivider = true;
-        }
-
-        if (
           data.type === CellType.COIN &&
           !isSmallBalancesOpen &&
+          !isCoinListEdited &&
           afterDivider
         ) {
           return false;
         }
-
         if (
           data.type === CellType.COIN &&
           hiddenCoins.includes((data as CoinExtraData).uniqueId) &&
@@ -118,14 +109,7 @@ export default function useMemoBriefSectionData() {
         index++;
         return true;
       })
-      .filter(
-        ({ type }) =>
-          type !== CellType.COIN_DIVIDER ||
-          isAnyAssetBelowDivider ||
-          isCoinListEdited
-      )
       .map(({ uid, type }) => ({ type, uid }));
-
     return briefSectionsDataFiltered;
   }, [
     briefSectionsData,

--- a/src/components/asset-list/RecyclerViewTypes.js
+++ b/src/components/asset-list/RecyclerViewTypes.js
@@ -83,7 +83,12 @@ export const ViewTypes = {
     index: 2,
     renderComponent: ({ data }) => {
       const { item = {} } = data;
-      return <CoinDivider balancesSum={item.value} />;
+      return (
+        <CoinDivider
+          balancesSum={item.value}
+          defaultToEditButton={item.defaultToEditButton}
+        />
+      );
     },
     visibleDuringCoinEdit: true,
   },

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -100,7 +100,7 @@ const useInterpolationRange = () => {
   };
 };
 
-export default function CoinDivider({ balancesSum }) {
+export default function CoinDivider({ balancesSum, defaultToEditButton }) {
   const interpolation = useInterpolationRange();
   const { nativeCurrency } = useAccountSettings();
   const dispatch = useDispatch();
@@ -151,13 +151,15 @@ export default function CoinDivider({ balancesSum }) {
       <Container deviceWidth={deviceWidth} isCoinListEdited={isCoinListEdited}>
         <Row>
           <View
-            opacity={isCoinListEdited ? 0 : 1}
-            pointerEvents={isCoinListEdited ? 'none' : 'auto'}
+            opacity={defaultToEditButton || isCoinListEdited ? 0 : 1}
+            pointerEvents={
+              defaultToEditButton || isCoinListEdited ? 'none' : 'auto'
+            }
           >
             <CoinDividerOpenButton
               coinDividerHeight={CoinDividerHeight}
               isSmallBalancesOpen={isSmallBalancesOpen}
-              isVisible={isCoinListEdited}
+              isVisible={defaultToEditButton || isCoinListEdited}
               onPress={toggleOpenSmallBalances}
             />
           </View>
@@ -190,16 +192,20 @@ export default function CoinDivider({ balancesSum }) {
           <CoinDividerAssetsValue
             balancesSum={balancesSum}
             nativeCurrency={nativeCurrency}
-            openSmallBalances={isSmallBalancesOpen}
+            openSmallBalances={defaultToEditButton || isSmallBalancesOpen}
           />
           <EditButtonWrapper
             pointerEvents={
-              isCoinListEdited || isSmallBalancesOpen ? 'auto' : 'none'
+              defaultToEditButton || isCoinListEdited || isSmallBalancesOpen
+                ? 'auto'
+                : 'none'
             }
           >
             <CoinDividerEditButton
               isActive={isCoinListEdited}
-              isVisible={isCoinListEdited || isSmallBalancesOpen}
+              isVisible={
+                defaultToEditButton || isCoinListEdited || isSmallBalancesOpen
+              }
               onPress={handlePressEdit}
               text={
                 isCoinListEdited ? lang.t('button.done') : lang.t('button.edit')

--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -165,18 +165,20 @@ export const buildCoinsList = (
   const bigBalancesValue = getTotal(assetsAboveDivider);
   const totalBalancesValue = add(bigBalancesValue, smallBalancesValue);
 
+  const defaultToEditButton = assetsBelowDivider.length === 0;
   // include hidden assets if in edit mode
   if (isCoinListEdited) {
     assetsBelowDivider = concat(assetsBelowDivider, hiddenAssets);
   }
-
   const allAssets = assetsAboveDivider;
 
-  if (assetsBelowDivider.length > 0 || isCoinListEdited) {
-    allAssets.push({
-      coinDivider: true,
-      value: smallBalancesValue,
-    });
+  allAssets.push({
+    coinDivider: true,
+    defaultToEditButton: defaultToEditButton,
+    value: smallBalancesValue,
+  });
+
+  if (assetsBelowDivider.length > 0) {
     allAssets.push({
       assets: assetsBelowDivider,
       smallBalancesContainer: true,
@@ -215,6 +217,7 @@ export const buildBriefCoinsList = (
     for (let asset of assets) {
       if (asset.coinDivider) {
         briefAssets.push({
+          defaultToEditButton: asset.defaultToEditButton,
           type: 'COIN_DIVIDER',
           uid: 'coin-divider',
           value: smallBalancesValue,


### PR DESCRIPTION
Fixes RNBW-2050

## What changed (plus any additional context for devs)
added an edit button for < 5 asset wallets, removed any xtra handling for coin dividers that isn't needed now

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-01-18-10-51-32.mp4

## Dev checklist for QA: what to test
edit + hiding/pinning tokens should work as expected

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
