### PR TITLE
Fix welcome screen getting cutoff on smaller phones

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -30,7 +30,7 @@ const ContainerWidth = 261;
 const Container = styled(Centered).attrs({ direction: 'column' })`
   position: absolute;
   top: 60;
-  bottom: 60;
+  bottom: ${props => props.isSmallScreen && 80};
   width: ${ContainerWidth};
 `;
 
@@ -170,7 +170,7 @@ const AmountButton = ({ amount, backgroundColor, color, onPress }) => {
 };
 
 const AddFundsInterstitial = ({ network }) => {
-  const { isSmallPhone } = useDimensions();
+  const { isSmallPhone, isTinyPhone } = useDimensions();
   const { navigate } = useNavigation();
   const { isDamaged } = useWallets();
   const { accountAddress } = useAccountSettings();
@@ -220,7 +220,7 @@ const AddFundsInterstitial = ({ network }) => {
   }, [navigate, isDamaged]);
 
   return (
-    <Container>
+    <Container isSmallScreen={isSmallPhone || isTinyPhone}>
       {network === networkTypes.mainnet ? (
         <Fragment>
           <Title>

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -30,7 +30,7 @@ const ContainerWidth = 261;
 const Container = styled(Centered).attrs({ direction: 'column' })`
   position: absolute;
   top: 60;
-  bottom: ${props => props.isSmallScreen && 80};
+  bottom: ${({ isSmallPhone }) => isSmallPhone && 80};
   width: ${ContainerWidth};
 `;
 
@@ -220,7 +220,7 @@ const AddFundsInterstitial = ({ network }) => {
   }, [navigate, isDamaged]);
 
   return (
-    <Container isSmallScreen={isSmallPhone || isTinyPhone}>
+    <Container isSmallPhone={isSmallPhone}>
       {network === networkTypes.mainnet ? (
         <Fragment>
           <Title>

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -30,6 +30,7 @@ const ContainerWidth = 261;
 const Container = styled(Centered).attrs({ direction: 'column' })`
   position: absolute;
   top: 60;
+  bottom: 60;
   width: ${ContainerWidth};
 `;
 


### PR DESCRIPTION
Fixes RNBW-1590

## What changed (plus any additional context for devs)
- Conditionally added bottom margin to container view depending on phone size (tiny/small)

## PoW (screenshots / screen recordings)
[Comparison of iPhone 13 Pro and iPhone SE](https://drive.google.com/file/d/1gOnN5GsRRuAxGyamDo62dl5U95Xk9fXt/view?usp=sharing)