### PR TITLE
handle empty deeplinks

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -89,14 +89,16 @@ export default async function handleDeeplink(
         break;
       }
       default: {
-        const addressOrENS = urlObj.pathname?.split('/')?.[1] || '';
-        const isValid = await checkIsValidAddressOrDomain(addressOrENS);
-        if (isValid) {
-          return Navigation.handleAction(Routes.SHOWCASE_SHEET, {
-            address: addressOrENS,
-          });
-        } else {
-          Alert.alert('Uh oh! We couldn’t recognize this URL!');
+        const addressOrENS = urlObj.pathname?.split('/')?.[1];
+        if (addressOrENS) {
+          const isValid = await checkIsValidAddressOrDomain(addressOrENS);
+          if (isValid) {
+            return Navigation.handleAction(Routes.SHOWCASE_SHEET, {
+              address: addressOrENS,
+            });
+          } else {
+            Alert.alert('Uh oh! We couldn’t recognize this URL!');
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

If we receive an "empty" deeplink like  https://rnbwapp.com we try to validate for an ENS or address aven tho there's nothing to validate and since is an empty string it will show an alert saying the deeplink is invalid. https://twitter.com/dwr/status/1483907093144817666
 
This pr removes this validation of empty params if deeplink doesn't contain ENS or address

## PoW (screenshots / screen recordings)

after https://recordit.co/3Vkto1c8lw

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
