### PR TITLE
fix showcase NFT uid overlap

### DIFF
--- a/src/helpers/assets.js
+++ b/src/helpers/assets.js
@@ -344,7 +344,12 @@ export const buildBriefUniqueTokenList = (
     result.push({ name: 'Showcase', type: 'FAMILY_HEADER', uid: 'showcase' });
     for (let index = 0; index < uniqueTokensInShowcase.length; index++) {
       const uniqueId = uniqueTokensInShowcase[index];
-      result.push({ index, type: 'NFT', uid: uniqueId, uniqueId });
+      result.push({
+        index,
+        type: 'NFT',
+        uid: `showcase-${uniqueId}`,
+        uniqueId,
+      });
     }
 
     result.push({ type: 'NFT_SPACE_AFTER', uid: `showcase-space-after` });


### PR DESCRIPTION
Fixes RNBW-2307

## What changed (plus any additional context for devs)
uid's were the same as the elements in the family so the styling was getting overridden

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Shot-2022-01-20-at-3.24.46-PM.png

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
