### PR TITLE
Fix backup explainer platform name.

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -47,6 +47,9 @@
       }
     },
     "back_up": {
+      "explainers": {
+        "backup": "Don't forget this password! It is separate from your %{cloudPlatformName} password, and you should save it in a secure location.\n\nYou will need it in order to restore your wallet from the backup in the future."
+      },
       "manual": {
         "label": "Your secret phrase",
         "pkey": {

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -46,6 +46,9 @@
       }
     },
     "back_up": {
+      "explainers": {
+        "backup": "Don't forget this password! It is separate from your %{cloudPlatformName} password, and you should save it in a secure location.\n\nYou will need it in order to restore your wallet from the backup in the future. :)"
+      },
       "manual": {
         "label": "Back up manually :)",
         "pkey": {

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -1,5 +1,6 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { useRoute } from '@react-navigation/native';
+import lang from 'i18n-js';
 import React, { useCallback } from 'react';
 import { Linking, StatusBar } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
@@ -14,6 +15,7 @@ import { toFixedDecimals } from '@rainbow-me/helpers/utilities';
 import { useDimensions } from '@rainbow-me/hooks';
 import { fonts, fontWithWidth, padding, position } from '@rainbow-me/styles';
 import { gasUtils } from '@rainbow-me/utils';
+import { cloudPlatformAccountName } from '@rainbow-me/utils/platform';
 
 const { GAS_TRENDS } = gasUtils;
 export const ExplainSheetHeight = android ? 454 : 434;
@@ -94,9 +96,9 @@ const POLYGON_EXPLAINER = `Polygon is a sidechain, a distinct network that runs 
 
 It allows for cheaper and faster transactions, but unlike Layer 2 networks, Polygon has its own security and consensus mechanisms that differ from Ethereum.`;
 
-const BACKUP_EXPLAINER = `Don't forget this password! It is separate from your Apple iCloud password, and you should save it in a secure location. 
-
-You will need it in order to restore your wallet from the backup in the future.`;
+const BACKUP_EXPLAINER = lang.t('back_up.explainers.backup', {
+  cloudPlatformName: cloudPlatformAccountName,
+});
 
 export const explainers = network => ({
   floor_price: {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,1 +1,2 @@
 export const cloudPlatform = ios ? 'iCloud' : 'Google Drive';
+export const cloudPlatformAccountName = ios ? 'Apple iCloud' : 'Google';


### PR DESCRIPTION
Fixes RNBW-2276.

## What changed (plus any additional context for devs)

Adds a new i18n key for the `BACKUP_EXPLAINER` text, with a variable to insert the correct platform name.

(There are some more strings in `ExplainerSheet` that I'll move into i18n in the next PR, but those are the same regardless of platform, so I'm using this smaller PR for the iOS/Android change.)

## PoW (screenshots / screen recordings)

On iOS, the text uses "Apple iCloud":

<img width="200" alt="Screen Shot 2022-01-20 at 4 35 12 PM" src="https://user-images.githubusercontent.com/17259768/150444831-28347f71-f24e-4122-b317-1c87122d3005.png">

Someone who is able to build for Android should ensure that the text says "Google." This should work though, since manually changing `ios` to `false` led to the Google text.

## Dev checklist for QA: what to test

- Ensure that text reads "... Google password..." instead of referencing iCloud.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
