### PR TITLE
Make icons work again!

### DIFF
--- a/ios/TransactionListViewCell.swift
+++ b/ios/TransactionListViewCell.swift
@@ -106,7 +106,7 @@ class TransactionListViewCell: TransactionListBaseCell {
     }
     
     if transaction.symbol != nil {
-      if let img = UIImage.init(named: transaction.symbol.lowercased()) {
+      if let img = UIImage.init(named: "coinIcons/\(transaction.symbol.lowercased())") {
         coinImage.image = img
       } else if transaction.address != nil {
         let url = URL(string: "https://raw.githubusercontent.com/rainbow-me/assets/master/blockchains/ethereum/assets/\(transaction.address!)/logo.png");


### PR DESCRIPTION
Fixes RNBW-2327

## What changed (plus any additional context for devs)

The icons on the transaction list broke. This change adds the correct prefixing to the assets.

## PoW (screenshots / screen recordings)

<img width="374" alt="Screen Shot 2022-01-25 at 9 58 47 am" src="https://user-images.githubusercontent.com/7336481/150879233-af1c652d-c5fa-4812-ac0c-c53b6670125b.png">

## Dev checklist for QA: what to test

- Make sure the coin icons are working on the transaction list

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
