### PR TITLE
Abstract  out PIN_AUTHENTICATION_SCREEN to a different stack

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -58,6 +58,7 @@ import { ExchangeModalNavigator } from './index';
 
 const Stack = createStackNavigator();
 const OuterStack = createStackNavigator();
+const AuthStack = createStackNavigator();
 const BSStack = createBottomSheetNavigator();
 
 function SendFlowNavigator() {
@@ -241,11 +242,6 @@ function MainOuterNavigator() {
         options={expandedPresetWithSmallGestureResponseDistance}
       />
       <OuterStack.Screen
-        component={PinAuthenticationScreen}
-        name={Routes.PIN_AUTHENTICATION_SCREEN}
-        options={{ ...sheetPreset, gestureEnabled: false }}
-      />
-      <OuterStack.Screen
         component={BackupSheet}
         name={Routes.BACKUP_SCREEN}
         options={expandedPreset}
@@ -314,9 +310,29 @@ function BSNavigator() {
   );
 }
 
+function AuthNavigator() {
+  return (
+    <AuthStack.Navigator
+      {...stackNavigationConfig}
+      initialRouteName={Routes.MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR}
+      screenOptions={defaultScreenStackOptions}
+    >
+      <AuthStack.Screen
+        component={BSNavigator}
+        name={Routes.MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR}
+      />
+      <AuthStack.Screen
+        component={PinAuthenticationScreen}
+        name={Routes.PIN_AUTHENTICATION_SCREEN}
+        options={{ ...sheetPreset, gestureEnabled: false }}
+      />
+    </AuthStack.Navigator>
+  );
+}
+
 const AppContainerWithAnalytics = React.forwardRef((props, ref) => (
   <NavigationContainer onStateChange={onNavigationStateChange} ref={ref}>
-    <BSNavigator />
+    <AuthNavigator />
   </NavigationContainer>
 ));
 


### PR DESCRIPTION
Fixes RNBW-2339

## What changed (plus any additional context for devs)

This is fixing the issue of navigating immediately to the main wallet. The reason was that the modal was opening in the main navigator that was underlying for the BS navigator, so while navigating there we had to dismiss the setting sheet. This needs to be done better because we cannot nest navigators on and on. The ultimate solution would be to another "underlying navigator" on top of this (with pin sheet navigated already as the initial screen of this navigator), but this is a task for a whole day we don't have. 

## PoW (screenshots / screen recordings)

After: https://streamable.com/fa80i6

## Dev checklist for QA: what to test

Init the wallet with no biometric (e.g., in the sim) and try to open seeds. Should be broken on develop, but working here. 
Test revealing seeds, signing transaction and creation of the first wallet 