### PR TITLE
🚨🚨 Fix dependency audits 🚨🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "**/node-fetch": "2.6.7",
     "**/web3": "1.6.1",
     "**/underscore": "1.12.1",
-    "**/socket.io-parser": "3.3.1",
+    "**/socket.io-parser": "3.3.2",
     "**/bl": "2.2.1",
     "**/browserslist": "4.17.6",
     "**/elliptic": "6.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15605,9 +15605,10 @@ socket.io-client@2.3.1:
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
-socket.io-parser@3.3.1, socket.io-parser@~3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.1.tgz#f07d9c8cb3fb92633aa93e76d98fd3a334623199"
+socket.io-parser@3.3.2, socket.io-parser@~3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
+  integrity sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
   dependencies:
     component-emitter "~1.3.0"
     debug "~3.1.0"


### PR DESCRIPTION
Updating `socket.io-parser` to `3.3.2` to resolve dependency audits