### PR TITLE
Fix recovery phrase authentication button alignment

### DIFF
--- a/src/components/secret-display/SecretDisplaySection.js
+++ b/src/components/secret-display/SecretDisplaySection.js
@@ -128,14 +128,14 @@ export default function SecretDisplaySection({
 
   const { colors } = useTheme();
   return (
-    <ColumnWithMargins
-      align="center"
-      justify="center"
-      margin={16}
-      paddingHorizontal={30}
-    >
+    <>
       {visible ? (
-        <Fragment>
+        <ColumnWithMargins
+          align="center"
+          justify="center"
+          margin={16}
+          paddingHorizontal={30}
+        >
           {seed ? (
             <Fragment>
               <CopyFloatingEmojis textToCopy={seed}>
@@ -159,9 +159,9 @@ export default function SecretDisplaySection({
           ) : (
             <LoadingSpinner color={colors.blueGreyDark50} />
           )}
-        </Fragment>
+        </ColumnWithMargins>
       ) : (
-        <Fragment>
+        <ColumnWithMargins align="center" justify="center">
           <AuthenticationText>
             {`You need to authenticate in order to access your recovery ${typeLabel}`}
           </AuthenticationText>
@@ -172,8 +172,8 @@ export default function SecretDisplaySection({
               showIcon={!seed}
             />
           </ToggleSecretButton>
-        </Fragment>
+        </ColumnWithMargins>
       )}
-    </ColumnWithMargins>
+    </>
   );
 }


### PR DESCRIPTION
Fixes RNBW-1859

## What changed (plus any additional context for devs)

Fixes broken button alignment for "Show Recovery Phrase" button

## PoW (screenshots / screen recordings)

Before:

![d9082e65-219a-400b-b996-380597c9eeb5](https://user-images.githubusercontent.com/7336481/151739642-adde0783-3de5-462b-8cc0-3fc936b6e609.png)

After:

<img width="401" alt="Screen Shot 2022-01-31 at 3 30 42 pm" src="https://user-images.githubusercontent.com/7336481/151739658-cf3ae1fb-03cf-484c-872e-4a1294ed2075.png">

