### PR TITLE
nft fetching error check

### DIFF
--- a/src/redux/uniqueTokens.ts
+++ b/src/redux/uniqueTokens.ts
@@ -244,6 +244,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
   const { uniqueTokens: existingUniqueTokens } = getState().uniqueTokens;
   const shouldUpdateInBatches = isEmpty(existingUniqueTokens);
   let uniqueTokens: UniqueAsset[] = [];
+  let errorCheck = false;
 
   const fetchNetwork = async (network: Network) => {
     let shouldStopFetching = false;
@@ -307,8 +308,9 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
         type: UNIQUE_TOKENS_GET_UNIQUE_TOKENS_FAILURE,
       });
       captureException(error);
-      // stop fetching if there is an error
+      // stop fetching if there is an error & dont save results
       shouldStopFetching = true;
+      errorCheck = true;
     }
     return shouldStopFetching;
   };
@@ -333,7 +335,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
   if (!showcaseAddress && isCurrentAccountAddress) {
     saveUniqueTokens(uniqueTokens, accountAddress, currentNetwork);
   }
-  if (!shouldUpdateInBatches && isCurrentAccountAddress) {
+  if (!shouldUpdateInBatches && isCurrentAccountAddress && !errorCheck) {
     dispatch({
       payload: uniqueTokens,
       showcase: !!showcaseAddress,

--- a/src/redux/uniqueTokens.ts
+++ b/src/redux/uniqueTokens.ts
@@ -332,7 +332,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
   // check that the account address to fetch for has not changed while fetching before updating state
   const isCurrentAccountAddress =
     accountAddress === (showcaseAddress || getState().settings.accountAddress);
-  if (!showcaseAddress && isCurrentAccountAddress) {
+  if (!showcaseAddress && isCurrentAccountAddress && !errorCheck) {
     saveUniqueTokens(uniqueTokens, accountAddress, currentNetwork);
   }
   if (!shouldUpdateInBatches && isCurrentAccountAddress && !errorCheck) {


### PR DESCRIPTION
Fixes RNBW-2391

## What changed (plus any additional context for devs)
we we're saving and overwriting NFT data if we ran into an error fetching from OS, now we only save data if there are no errors

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test
to test you can rm the `!errorCheck` on line 338 and throw an error in fetchPage

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
