### PR TITLE
Fix `bottom` styling type issue for AddFundsInterstitial & Row compatibility

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -30,8 +30,8 @@ const ContainerWidth = 261;
 const Container = styled(Centered).attrs({ direction: 'column' })`
   position: absolute;
   top: 60;
-  bottom: ${({ isSmallPhone }) => (isSmallPhone ? 80 : 0)};
   width: ${ContainerWidth};
+  ${({ isSmallPhone }) => (isSmallPhone ? 'bottom: 80' : '')};
 `;
 
 const InterstitialButton = styled(ButtonPressAnimation).attrs(

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -30,7 +30,7 @@ const ContainerWidth = 261;
 const Container = styled(Centered).attrs({ direction: 'column' })`
   position: absolute;
   top: 60;
-  bottom: ${({ isSmallPhone }) => isSmallPhone && 80};
+  bottom: ${({ isSmallPhone }) => (isSmallPhone ? 80 : 0)};
   width: ${ContainerWidth};
 `;
 
@@ -170,7 +170,7 @@ const AmountButton = ({ amount, backgroundColor, color, onPress }) => {
 };
 
 const AddFundsInterstitial = ({ network }) => {
-  const { isSmallPhone, isTinyPhone } = useDimensions();
+  const { isSmallPhone } = useDimensions();
   const { navigate } = useNavigation();
   const { isDamaged } = useWallets();
   const { accountAddress } = useAccountSettings();

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -8,7 +8,7 @@ import { magicMemo, showActionSheetWithOptions } from '../utils';
 import { ButtonPressAnimation } from './animations';
 import { Centered, Column } from './layout';
 import { Text as TextElement } from './text';
-import { Row } from '@rainbow-me/design-system';
+import { Inline } from '@rainbow-me/design-system';
 import { padding } from '@rainbow-me/styles';
 
 const HairlineSpace = '\u200a';
@@ -132,7 +132,7 @@ const Tag = ({ color, disableMenu, slug, text, title, maxValue, ...props }) => {
         <OuterBorder {...props} color={color}>
           <Container>
             <Title color={color}>{upperCase(title)}</Title>
-            <Row>
+            <Inline wrap={false}>
               <Text>{upperFirst(text)}</Text>
               {maxValue && (
                 <Text>
@@ -142,7 +142,7 @@ const Tag = ({ color, disableMenu, slug, text, title, maxValue, ...props }) => {
                   {maxValue}
                 </Text>
               )}
-            </Row>
+            </Inline>
           </Container>
         </OuterBorder>
       </ButtonPressAnimation>


### PR DESCRIPTION
### What changed (plus any additional context for devs)

This PR fixes an issue where the app was crashing on the AddFundsInterstitial screen after #2849, as well as fixing compatibility with the design system `Row` after #2891.
