### PR TITLE
Fix issue where scrolling down on switch wallet sheet wouldn't dismiss the sheet

### DIFF
--- a/src/components/asset-list/EmptyAssetList.js
+++ b/src/components/asset-list/EmptyAssetList.js
@@ -1,3 +1,4 @@
+import ConditionalWrap from 'conditional-wrap';
 import { times } from 'lodash';
 import React, { useMemo } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
@@ -36,11 +37,18 @@ const EmptyAssetList = ({
   const { refresh, isRefreshing } = useRefreshAccountData();
 
   return (
-    <ScrollView
-      contentContainerStyle={{ height: '100%' }}
-      refreshControl={
-        <RefreshControl onRefresh={refresh} refreshing={isRefreshing} />
-      }
+    <ConditionalWrap
+      condition={isWalletEthZero}
+      wrap={children => (
+        <ScrollView
+          contentContainerStyle={{ height: '100%' }}
+          refreshControl={
+            <RefreshControl onRefresh={refresh} refreshing={isRefreshing} />
+          }
+        >
+          {children}
+        </ScrollView>
+      )}
     >
       <Container {...props}>
         <Centered flex={1}>
@@ -66,7 +74,7 @@ const EmptyAssetList = ({
           )}
         </Centered>
       </Container>
-    </ScrollView>
+    </ConditionalWrap>
   );
 };
 


### PR DESCRIPTION
Fixes RNBW-2380

## What changed (plus any additional context for devs)

This PR fixes an issue where if the select wallet sheet overflowed, a user could not swipe down to dismiss the sheet.

## PoW (screenshots / screen recordings)

Before:

![Kapture 2022-02-01 at 12 38 22](https://user-images.githubusercontent.com/7336481/151901045-92f437f5-ab31-4010-ae4e-0d0a70e9b6ec.gif)

After:

![Kapture 2022-02-01 at 12 39 19](https://user-images.githubusercontent.com/7336481/151901032-84c7e9f9-6cf0-4a28-bf59-4c2158da93e7.gif)

## Dev checklist for QA: what to test

- On the select wallet sheet, when the wallet list overflows, ensure you can dismiss the sheet when you scroll down (after scrolling through the list)

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
