### PR TITLE
Make sure QR code scanner is always enabled

### DIFF
--- a/src/components/qrcode-scanner/EmulatorPasteUriButton.js
+++ b/src/components/qrcode-scanner/EmulatorPasteUriButton.js
@@ -17,7 +17,7 @@ export default function EmulatorPasteUriButton() {
 
   const handlePressPasteSessionUri = useCallback(() => {
     Prompt({
-      callback: handlePastedUri,
+      buttons: [{ onPress: handlePastedUri, text: lang.t('button.confirm') }],
       message: lang.t('walletconnect.paste_uri.message'),
       title: lang.t('walletconnect.paste_uri.title'),
       type: 'plain-text',

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -112,7 +112,7 @@ export default function useScanner(enabled, onSuccess) {
       analytics.track('Scanned broken or unsupported QR code', { qrCodeData });
 
       Alert({
-        callback: () => enableScanning(),
+        buttons: [{ onPress: enableScanning, text: lang.t('button.okay') }],
         message: lang.t('wallet.unrecognized_qrcode'),
         title: lang.t('wallet.unrecognized_qrcode_title'),
       });


### PR DESCRIPTION
Fixes RNBW-2436

## What changed (plus any additional context for devs)

Noticed that when we scan a wrong QR code we don't show the alert - seems like the API to show an alert was changed in some version of React Native and we never noticed. I updated the code of showing that alert to use the new API.

In the original issue, the QR code scanner would not work after some time. This was the cause: wrong API usage didn't throw any errors but we never called enableScanner. So after the very first wrong QR code - it no longer works for the user until the app restart.

## PoW (screenshots / screen recordings)

https://drive.google.com/file/d/1PhiHQYKJotFWq4VZCy059xXepzlyIM57/view?usp=sharing

## Dev checklist for QA: what to test

Scan different qr codes. Expect to see the "Wrong QR code" alert on the scan of the QR code below. It should work after pressing "okay".

![image](https://user-images.githubusercontent.com/7809008/152380213-4019598b-67d7-4e37-b035-c71353ae9613.png)


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
