### PR TITLE
imgix improvements

### DIFF
--- a/src/components/3d/SimpleModelView.tsx
+++ b/src/components/3d/SimpleModelView.tsx
@@ -1,3 +1,4 @@
+import styled from '@rainbow-me/styled-components';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Animated,
@@ -8,12 +9,12 @@ import {
 } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { ImgixImage } from '@rainbow-me/images';
-import styled from '@rainbow-me/styled-components';
 import { padding, position } from '@rainbow-me/styles';
 
 export type ModelViewerProps = {
   readonly setLoading: (loading: boolean) => void;
   readonly loading: boolean;
+  readonly size: number;
   readonly style?: ViewStyle;
   readonly uri: string;
   readonly alt?: string;
@@ -76,6 +77,7 @@ const getSource = ({ alt, uri }: { alt?: string; uri: string }) =>
 export default function ModelViewer({
   loading,
   setLoading,
+  size,
   style,
   uri,
   alt,
@@ -133,6 +135,7 @@ export default function ModelViewer({
         style={{ opacity }}
       >
         <ImgixImage
+          size={size}
           source={{ uri: fallbackUri }}
           style={StyleSheet.absoluteFill}
         />

--- a/src/components/asset-list/RecyclerAssetList2/WrappedNFT.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedNFT.tsx
@@ -16,13 +16,12 @@ export default React.memo(function WrappedNFT({
   const { navigate } = useNavigation();
 
   const handleItemPress = useCallback(
-    (asset, lowResUrl) =>
+    asset =>
       navigate(Routes.EXPANDED_ASSET_SHEET, {
         asset,
         backgroundOpacity: 1,
         cornerRadius: 'device',
         external: false,
-        lowResUrl,
         springDamping: 1,
         topOffset: 0,
         transitionDuration: 0.25,

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -1,3 +1,4 @@
+import styled from '@rainbow-me/styled-components';
 import { BlurView } from '@react-native-community/blur';
 import c from 'chroma-js';
 import lang from 'i18n-js';
@@ -16,6 +17,7 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated';
 import URL from 'url-parse';
+import { CardSize } from '../../components/unique-token/CardSize';
 import useWallets from '../../hooks/useWallets';
 import { lightModeThemeColors } from '../../styles/colors';
 import L2Disclaimer from '../L2Disclaimer';
@@ -54,7 +56,6 @@ import {
 import { AssetTypes, UniqueAsset } from '@rainbow-me/entities';
 import { apiGetUniqueTokenFloorPrice } from '@rainbow-me/handlers/opensea-api';
 import { buildUniqueTokenName } from '@rainbow-me/helpers/assets';
-import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
 import {
   useAccountProfile,
   useAccountSettings,
@@ -62,10 +63,8 @@ import {
   usePersistentDominantColorFromImage,
   useShowcaseTokens,
 } from '@rainbow-me/hooks';
-import { ImgixImage } from '@rainbow-me/images';
 import { useNavigation, useUntrustedUrlOpener } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
-import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
 import { convertAmountToNativeDisplay } from '@rainbow-me/utilities';
 import {
@@ -174,13 +173,11 @@ const Markdown = ({
 interface UniqueTokenExpandedStateProps {
   asset: UniqueAsset;
   external: boolean;
-  lowResUrl: string;
 }
 
 const UniqueTokenExpandedState = ({
   asset,
   external,
-  lowResUrl,
 }: UniqueTokenExpandedStateProps) => {
   const { accountAddress, accountENS } = useAccountProfile();
   const { nativeCurrency, network } = useAccountSettings();
@@ -229,8 +226,6 @@ const UniqueTokenExpandedState = ({
     () => showcaseTokens.includes(uniqueId) as boolean,
     [showcaseTokens, uniqueId]
   );
-
-  const isSVG = isSupportedUriExtension(lowResUrl, ['.svg']);
 
   const imageColor =
     // @ts-expect-error image_url could be null or undefined?
@@ -313,20 +308,13 @@ const UniqueTokenExpandedState = ({
       {ios && (
         <BlurWrapper height={deviceHeight} width={deviceWidth}>
           <BackgroundImage>
-            {isSVG ? (
-              // @ts-expect-error JavaScript component
-              <UniqueTokenImage
-                backgroundColor={asset.background}
-                imageUrl={lowResUrl}
-                item={asset}
-              />
-            ) : (
-              <ImgixImage
-                resizeMode="cover"
-                source={{ uri: lowResUrl }}
-                style={{ height: deviceHeight, width: deviceWidth }}
-              />
-            )}
+            <UniqueTokenImage
+              backgroundColor={asset.background}
+              imageUrl={asset.image_url}
+              item={asset}
+              resizeMode="cover"
+              size={CardSize}
+            />
             <BackgroundBlur />
           </BackgroundImage>
         </BlurWrapper>
@@ -363,7 +351,7 @@ const UniqueTokenExpandedState = ({
               horizontalPadding={24}
               imageColor={imageColor}
               // @ts-expect-error JavaScript component
-              lowResUrl={lowResUrl}
+
               sheetRef={sheetRef}
               textColor={textColor}
               yPosition={yPosition}

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -3,7 +3,6 @@ import React, { useMemo } from 'react';
 import { ActivityIndicator, PixelRatio, StyleSheet, View } from 'react-native';
 import { ENS_NFT_CONTRACT_ADDRESS } from '../../../references';
 import { magicMemo } from '../../../utils';
-import { getLowResUrl } from '../../../utils/getLowResUrl';
 import { SimpleModelView } from '../../3d';
 import { AudioPlayer } from '../../audio';
 import { UniqueTokenImage } from '../../unique-token';
@@ -66,7 +65,6 @@ const UniqueTokenExpandedStateContent = ({
     return asset.image_url;
   }, [asset.animation_url, asset.image_url, asset.isPoap, size]);
 
-  const lowResUrl = isENS ? url : getLowResUrl(asset.image_url);
   const { supports3d, supportsVideo, supportsAudio } = useUniqueToken(asset);
 
   const supportsAnythingExceptImage =
@@ -94,6 +92,7 @@ const UniqueTokenExpandedStateContent = ({
             loading={loading}
             posterUri={imageUrl}
             setLoading={setLoading}
+            size={maxImageWidth}
             style={StyleSheet.absoluteFill}
             uri={asset.animation_url || imageUrl}
           />
@@ -102,6 +101,7 @@ const UniqueTokenExpandedStateContent = ({
             fallbackUri={imageUrl}
             loading={loading}
             setLoading={setLoading}
+            size={maxImageWidth}
             uri={asset.animation_url || imageUrl}
           />
         ) : supportsAudio ? (
@@ -115,7 +115,6 @@ const UniqueTokenExpandedStateContent = ({
             backgroundColor={asset.background}
             imageUrl={isSVG ? asset.image_url : url}
             item={asset}
-            lowResUrl={lowResUrl}
             resizeMode={resizeMode}
             size={maxImageWidth}
             transformSvgs={false}

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -5,6 +5,7 @@ import { maybeSignSource } from '../../handlers/imgix';
 
 export type ImgixImageProps = FastImageProps & {
   readonly Component?: React.ElementType;
+  readonly size?: Number;
 };
 
 // Here we're emulating the pattern used in react-native-fast-image:

--- a/src/components/unique-token/UniqueTokenCard.js
+++ b/src/components/unique-token/UniqueTokenCard.js
@@ -1,5 +1,5 @@
+import styled from '@rainbow-me/styled-components';
 import React, { useCallback, useMemo } from 'react';
-import { getLowResUrl } from '../../utils/getLowResUrl';
 import { ButtonPressAnimation } from '../animations';
 import { InnerBorder } from '../layout';
 import { CardSize } from './CardSize';
@@ -8,7 +8,6 @@ import {
   usePersistentAspectRatio,
   usePersistentDominantColorFromImage,
 } from '@rainbow-me/hooks';
-import styled from '@rainbow-me/styled-components';
 import { shadow as shadowUtil } from '@rainbow-me/styles';
 
 const UniqueTokenCardBorderRadius = 20;
@@ -29,27 +28,24 @@ const UniqueTokenCard = ({
   borderEnabled = true,
   disabled = false,
   enableHapticFeedback = true,
-  height = undefined,
   item,
   onPress,
   resizeMode = undefined,
   scaleTo = 0.96,
   shadow = undefined,
+  size = CardSize,
   smallENSName = true,
   style = undefined,
-  width = undefined,
   ...props
 }) => {
-  const lowResUrl = getLowResUrl(item.image_url);
-
   usePersistentAspectRatio(item.image_url);
   usePersistentDominantColorFromImage(item.image_url);
 
   const handlePress = useCallback(() => {
     if (onPress) {
-      onPress(item, lowResUrl);
+      onPress(item);
     }
-  }, [item, lowResUrl, onPress]);
+  }, [item, onPress]);
 
   const { colors } = useTheme();
 
@@ -66,14 +62,14 @@ const UniqueTokenCard = ({
       scaleTo={scaleTo}
       shadow={shadow || defaultShadow}
     >
-      <Content {...props} height={height} style={style} width={width}>
+      <Content {...props} height={size} style={style} width={size}>
         <UniqueTokenImage
           backgroundColor={item.background || colors.lightestGrey}
-          imageUrl={lowResUrl}
+          imageUrl={item.image_url}
           isCard
           item={item}
           resizeMode={resizeMode}
-          size={width}
+          size={size}
           small={smallENSName}
         />
         {borderEnabled && (

--- a/src/components/unique-token/UniqueTokenImage.js
+++ b/src/components/unique-token/UniqueTokenImage.js
@@ -1,3 +1,4 @@
+import styled from '@rainbow-me/styled-components';
 import { toLower } from 'lodash';
 import React, { Fragment, useCallback, useState } from 'react';
 import { useTheme } from '../../context/ThemeContext';
@@ -13,8 +14,8 @@ import {
   usePersistentDominantColorFromImage,
 } from '@rainbow-me/hooks';
 import { ImgixImage } from '@rainbow-me/images';
-import styled from '@rainbow-me/styled-components';
 import { fonts, fontWithWidth, position } from '@rainbow-me/styles';
+import { getLowResUrl } from '@rainbow-me/utils/getLowResUrl';
 
 const FallbackTextColorVariants = (darkMode, colors) => ({
   dark: darkMode
@@ -51,9 +52,9 @@ const UniqueTokenImage = ({
   imageUrl,
   item,
   isCard = false,
-  lowResUrl,
   resizeMode = ImgixImage.resizeMode.cover,
-  small,
+  size,
+  small = false,
   transformSvgs = true,
 }) => {
   const { isTinyPhone } = useDimensions();
@@ -62,6 +63,7 @@ const UniqueTokenImage = ({
   const isSVG = isSupportedUriExtension(imageUrl, ['.svg']);
   const newImageUrl = transformSvgs ? svgToPngIfNeeded(imageUrl) : imageUrl;
   const image = isENS && !isSVG ? `${item.image_url}=s1` : newImageUrl;
+  const lowResUrl = isSVG ? newImageUrl : getLowResUrl(image);
   const [error, setError] = useState(null);
   const handleError = useCallback(error => setError(error), [setError]);
   const { isDarkMode, colors } = useTheme();
@@ -77,7 +79,6 @@ const UniqueTokenImage = ({
   if (isOldENS && dominantColor) {
     backgroundColor = dominantColor;
   }
-
   return (
     <Centered backgroundColor={backgroundColor} style={position.coverAsObject}>
       {isSVG && !transformSvgs && !error ? (
@@ -102,12 +103,13 @@ const UniqueTokenImage = ({
               onError={handleError}
               onLoad={onLoad}
               resizeMode={ImgixImage.resizeMode[resizeMode]}
+              size={size}
               source={{ uri: image }}
               style={position.coverAsObject}
             />
             {!loadedImg && lowResUrl && (
               <ImageTile
-                {...(isCard && { fm: 'png' })}
+                fm="png"
                 playing={false}
                 resizeMode={ImgixImage.resizeMode[resizeMode]}
                 source={{ uri: lowResUrl }}

--- a/src/components/unique-token/UniqueTokenRow.js
+++ b/src/components/unique-token/UniqueTokenRow.js
@@ -31,14 +31,13 @@ const UniqueTokenRow = magicMemo(({ item, external = false }) => {
   const { navigate } = useNavigation();
 
   const handleItemPress = useCallback(
-    (asset, lowResUrl) =>
+    asset =>
       navigate(Routes.EXPANDED_ASSET_SHEET, {
         asset,
         backgroundOpacity: 1,
         cornerRadius: 'device',
         external,
         isReadOnlyWallet,
-        lowResUrl,
         springDamping: 1,
         topOffset: 0,
         transitionDuration: 0.25,

--- a/src/components/video/SimpleVideo.tsx
+++ b/src/components/video/SimpleVideo.tsx
@@ -21,6 +21,7 @@ import { position } from '@rainbow-me/styles';
 import logger from 'logger';
 
 export type SimpleVideoProps = {
+  readonly size: number;
   readonly style?: ViewStyle;
   readonly uri: string;
   readonly posterUri?: string;
@@ -50,6 +51,7 @@ const styles = StyleSheet.create({
 });
 
 export default function SimpleVideo({
+  size,
   style,
   uri,
   posterUri,
@@ -105,7 +107,7 @@ export default function SimpleVideo({
           pointerEvents={loading ? 'auto' : 'none'}
           style={{ opacity }}
         >
-          <StyledImgixImage source={{ uri: posterUri }} />
+          <StyledImgixImage size={size} source={{ uri: posterUri }} />
         </StyledPosterContainer>
       </View>
     </TouchableWithoutFeedback>

--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -72,7 +72,7 @@ const shouldSignUri = (
       // Check that the URL was signed as expected.
       if (typeof signedExternalImageUri === 'string') {
         // Buffer the signature into the LRU for future use.
-        const signature = `${externalImageUri}-${options?.w}-${options?.fm}`;
+        const signature = `${externalImageUri}-${options?.w}`;
         !staticSignatureLRU.has(signature) &&
           staticSignatureLRU.set(signature, signedExternalImageUri);
         // Return the signed image.
@@ -115,7 +115,7 @@ export const maybeSignUri = (
   skipCaching: boolean = false
 ): string | undefined => {
   // If the image has already been signed, return this quickly.
-  const signature = `${externalImageUri}-${options?.w}-${options?.fm}`;
+  const signature = `${externalImageUri}-${options?.w}`;
   if (
     typeof externalImageUri === 'string' &&
     staticSignatureLRU.has(signature as string) &&

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -16,7 +16,6 @@ import { BalanceCoinRow } from '../components/coin-row';
 import { UniswapInvestmentRow } from '../components/investment-cards';
 import { CollectibleTokenFamily } from '../components/token-family';
 import { withNavigation } from '../navigation/Navigation';
-import { getLowResUrl } from '../utils/getLowResUrl';
 import { compose, withHandlers } from '../utils/recompactAdapters';
 import {
   buildBriefCoinsList,
@@ -26,7 +25,6 @@ import {
 } from './assets';
 import networkTypes from './networkTypes';
 import { add, convertAmountToNativeDisplay, multiply } from './utilities';
-import svgToPngIfNeeded from '@rainbow-me/handlers/svgs';
 import { ImgixImage } from '@rainbow-me/images';
 import Routes from '@rainbow-me/routes';
 
@@ -408,7 +406,7 @@ const buildImagesToPreloadArray = (family, index, families) => {
       return {
         id: uniqueId,
         priority,
-        uri: svgToPngIfNeeded(getLowResUrl(image_url)),
+        uri: image_url,
       };
     });
 

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -37,7 +37,7 @@ export default function usePersistentDominantColorFromImage(
   );
   useEffect(() => {
     if (state === State.init && nonSvgUrl) {
-      const lowResUrl = getLowResUrl(nonSvgUrl);
+      const lowResUrl = getLowResUrl(nonSvgUrl) as string;
       setState(State.loading);
       getDominantColorFromImage(lowResUrl, colorToMeasureAgainst).then(color =>
         // @ts-ignore

--- a/src/utils/getLowResUrl.ts
+++ b/src/utils/getLowResUrl.ts
@@ -1,12 +1,9 @@
 import { PixelRatio } from 'react-native';
 import { CardSize } from '../components/unique-token/CardSize';
+import { imageToPng } from '@rainbow-me/handlers/imgix';
 
-export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
 const size = (Math.ceil(CardSize) * PixelRatio.get()) / 5;
 
 export const getLowResUrl = (url: string) => {
-  if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
-    return `${url}?w=${size}`;
-  }
-  return url;
+  return imageToPng(url, size);
 };


### PR DESCRIPTION
Fixes RNBW-2480

## What changed (plus any additional context for devs)
currently we are not using imgix for its intended use, to resize all NFT images( our main source of external images), this seems to have happened around the the NFT v2 changes. we noticed since the app crashes if you have a dead ringer (before: 64 mb image, now ~6.4-8 mb)

I've gone ahead and re-added the logic needed to do this along with the following changes

- converted `getLowResUrl` to use imgix under the hood, before this function only worked w/ images stored on google so this is a big improvement. I removed all unnecessary uses of this function as well
- changed the signature of the imgix signatures to include sizing info, before we would get the initial image with its corresponding sizes when in reality we want diff sizes for diff cases, ive bumped the cache size to allow for this better (not seeing any perf regressions atm)
- I also refactor the blur image wrapper logic as it was unneeded and im under the impression it wasn't working 100% of the time because of this

will make a testflight build so this is easier to test


## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-02-07-15-21-57.mp4

## Dev checklist for QA: what to test
all NFT images should load properly, app shouldn't crash on TestFlight with an open dead ringer

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
