### PR TITLE
Throw an error when css strings is used with styled components

### DIFF
--- a/src/styled-thing/index.js
+++ b/src/styled-thing/index.js
@@ -97,6 +97,12 @@ export default function styled(Component) {
   }
 
   function StyledComponentFactory(styles) {
+    if (Array.isArray(styles)) {
+      throw new TypeError(
+        '@rainbow-me/styled-components only support object syntax.\nUse the function call with an object as an argument instead of template literal string, for example styled({}) instead of styled``\nSee https://github.com/rainbow-me/rainbow/pull/2730'
+      );
+    }
+
     let WrappedStyledComponent;
 
     let shouldForwardProp = StyledComponentFactory.shouldForwardProp;

--- a/src/styled-thing/index.js
+++ b/src/styled-thing/index.js
@@ -97,10 +97,12 @@ export default function styled(Component) {
   }
 
   function StyledComponentFactory(styles) {
-    if (Array.isArray(styles)) {
-      throw new TypeError(
-        '@rainbow-me/styled-components only support object syntax.\nUse the function call with an object as an argument instead of template literal string, for example styled({}) instead of styled``\nSee https://github.com/rainbow-me/rainbow/pull/2730'
-      );
+    if (__DEV__) {
+      if (Array.isArray(styles)) {
+        throw new TypeError(
+          '@rainbow-me/styled-components only support object syntax.\nUse the function call with an object as an argument instead of template literal string, for example styled({}) instead of styled``\nSee https://github.com/rainbow-me/rainbow/pull/2730'
+        );
+      }
     }
 
     let WrappedStyledComponent;


### PR DESCRIPTION
Fixes RNBW-2466

## What changed (plus any additional context for devs)

Since our own faster implementation of styled components doesn't support CSS strings - we should make sure no one is using it. So from now on, it will throw an error if template literal syntax is used.

So this won't work:
```
const Container = styled.View``;
```

And this will work
```
const Container = styled.View({});
```

When we call the function with template literals instead of parenthesis 
```
syled`` 
```

it passes the template string and all the string interpolations (`${}`) as an array. So I check for an array to detect if we used template literal.

## PoW (screenshots / screen recordings)

<img width="713" alt="image" src="https://user-images.githubusercontent.com/7809008/153049784-5b0a7d04-7e9f-461b-b1b9-1ca03e07a8e6.png">
<img width="362" alt="image" src="https://user-images.githubusercontent.com/7809008/153050050-fba40f23-9b8b-4a6a-b683-a83db5b369d2.png">



## Dev checklist for QA: what to test

It should not break anything

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
