### PR TITLE
Chore: Update React Query to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "react-native-widgetkit": "1.0.9",
     "react-navigation-backhandler": "2.0.1",
     "react-primitives": "0.8.1",
-    "react-query": "1.5.10",
+    "react-query": "3.34.15",
     "react-redux": "7.2.1",
     "react-style-proptype": "3.2.2",
     "readable-stream": "1.1.14",

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ import {
 import RNIOS11DeviceCheck from 'react-native-ios11-devicecheck';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { enableScreens } from 'react-native-screens';
+import { QueryClientProvider } from 'react-query';
 import { connect, Provider } from 'react-redux';
 import { RecoilRoot } from 'recoil';
 import PortalConsumer from './components/PortalConsumer';
@@ -54,6 +55,7 @@ import * as keychain from './model/keychain';
 import { loadAddress } from './model/wallet';
 import { Navigation } from './navigation';
 import RoutesComponent from './navigation/Routes';
+import { queryClient } from './react-query/queryClient';
 import { explorerInitL2 } from './redux/explorer';
 import { fetchOnchainBalances } from './redux/fallbackExplorer';
 import { requestsForTopic } from './redux/requests';
@@ -289,23 +291,25 @@ class App extends Component {
         <ErrorBoundary>
           <Portal>
             <SafeAreaProvider>
-              <Provider store={store}>
-                <RecoilRoot>
-                  <SharedValuesProvider>
-                    <View style={containerStyle}>
-                      {this.state.initialRoute && (
-                        <InitialRouteContext.Provider
-                          value={this.state.initialRoute}
-                        >
-                          <RoutesComponent ref={this.handleNavigatorRef} />
-                          <PortalConsumer />
-                        </InitialRouteContext.Provider>
-                      )}
-                      <OfflineToast />
-                    </View>
-                  </SharedValuesProvider>
-                </RecoilRoot>
-              </Provider>
+              <QueryClientProvider client={queryClient}>
+                <Provider store={store}>
+                  <RecoilRoot>
+                    <SharedValuesProvider>
+                      <View style={containerStyle}>
+                        {this.state.initialRoute && (
+                          <InitialRouteContext.Provider
+                            value={this.state.initialRoute}
+                          >
+                            <RoutesComponent ref={this.handleNavigatorRef} />
+                            <PortalConsumer />
+                          </InitialRouteContext.Provider>
+                        )}
+                        <OfflineToast />
+                      </View>
+                    </SharedValuesProvider>
+                  </RecoilRoot>
+                </Provider>
+              </QueryClientProvider>
             </SafeAreaProvider>
           </Portal>
         </ErrorBoundary>

--- a/src/hooks/useDPI.ts
+++ b/src/hooks/useDPI.ts
@@ -24,10 +24,9 @@ export default function useDPI() {
     return defiPulseData;
   }, [dispatch]);
 
-  const { data } = useQuery(
-    !isEmpty(genericAssets) && ['defiPulse'],
-    fetchDPIData
-  );
+  const { data } = useQuery(['defiPulse'], fetchDPIData, {
+    enabled: !isEmpty(genericAssets),
+  });
 
   return data;
 }

--- a/src/hooks/useLoadGlobalLateData.js
+++ b/src/hooks/useLoadGlobalLateData.js
@@ -1,16 +1,16 @@
 import { useCallback } from 'react';
-import { queryCache } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   getWalletBalances,
   WALLET_BALANCES_FROM_STORAGE,
 } from '@rainbow-me/handlers/localstorage/walletBalances';
+import { queryClient } from '@rainbow-me/react-query/queryClient';
 import { nonceManagerLoadState } from '@rainbow-me/redux/nonceManager';
 import { promiseUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
 const loadWalletBalanceNamesToCache = () =>
-  queryCache.prefetchQuery(WALLET_BALANCES_FROM_STORAGE, getWalletBalances);
+  queryClient.prefetchQuery(WALLET_BALANCES_FROM_STORAGE, getWalletBalances);
 
 export default function useLoadGlobalLateData() {
   const dispatch = useDispatch();

--- a/src/hooks/useUniswapPools.js
+++ b/src/hooks/useUniswapPools.js
@@ -182,9 +182,9 @@ export default function useUniswapPools(sortField, sortDirection, token) {
     ['pools/uniswap/v2', token],
     () => getUniswapV2Pools(token),
     {
+      enabled: walletReady,
       onError: () => logger.log('🦄🦄🦄 error getting pairs data', error),
       refetchInterval: REFETCH_INTERVAL,
-      skip: !walletReady,
     }
   );
 

--- a/src/hooks/useWalletBalances.js
+++ b/src/hooks/useWalletBalances.js
@@ -1,7 +1,7 @@
 import { Contract } from '@ethersproject/contracts';
 import { forEach, get, isEmpty, keys, values } from 'lodash';
 import { useCallback } from 'react';
-import { queryCache, useQuery } from 'react-query';
+import { useQuery } from 'react-query';
 import useAccountSettings from './useAccountSettings';
 import {
   saveWalletBalances,
@@ -9,6 +9,7 @@ import {
 } from '@rainbow-me/handlers/localstorage/walletBalances';
 import { web3Provider } from '@rainbow-me/handlers/web3';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
+import { queryClient } from '@rainbow-me/react-query/queryClient';
 import { balanceCheckerContractAbi } from '@rainbow-me/references';
 import { fromWei, handleSignificantDecimals } from '@rainbow-me/utilities';
 import logger from 'logger';
@@ -54,12 +55,11 @@ const useWalletBalances = wallets => {
     return walletBalances;
   }, [network, wallets]);
 
-  const { data } = useQuery(
-    !isEmpty(wallets) && ['walletBalances'],
-    fetchBalances
-  );
+  const { data } = useQuery(['walletBalances'], fetchBalances, {
+    enabled: !isEmpty(wallets),
+  });
 
-  const resultFromStorage = queryCache.getQueryData(
+  const resultFromStorage = queryClient.getQueryData(
     WALLET_BALANCES_FROM_STORAGE
   );
 

--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -1,0 +1,9 @@
+import { QueryClient } from 'react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      notifyOnChangeProps: 'tracked',
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,8 @@
       "@rainbow-me/networkTypes": ["./src/helpers/networkTypes"],
       "@rainbow-me/parsers": ["src/parsers"],
       "@rainbow-me/raps": ["src/raps"],
+      "@rainbow-me/react-query": ["./src/react-query"],
+      "@rainbow-me/react-query/*": ["./src/react-query/*"],
       "@rainbow-me/redux": ["src/redux"],
       "@rainbow-me/redux/*": ["src/redux/*"],
       "@rainbow-me/references": ["src/references"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,6 +1624,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.0.0", "@babel/template@^7.12.13", "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -3572,10 +3579,6 @@
     hosted-git-info "^2.6.0"
     path-browserify "^1.0.0"
     url "^0.11.0"
-
-"@scarf/scarf@^1.0.6":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.1.1.tgz#d8b9f20037b3a37dbf8dcdc4b3b72f9285bfce35"
 
 "@segment/analytics-react-native@1.5.0":
   version "1.5.0"
@@ -5927,6 +5930,11 @@ big-integer@1.6.x:
   version "1.6.50"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.50.tgz#299a4be8bd441c73dcc492ed46b7169c34e92e70"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -6063,6 +6071,20 @@ braces@^3.0.1, braces@~3.0.2:
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -7503,6 +7525,11 @@ detect-indent@^4.0.0:
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detective-amd@^3.0.1:
   version "3.1.0"
@@ -12156,6 +12183,14 @@ match-sorter@6.3.0:
     "@babel/runtime" "^7.12.5"
     remove-accents "0.4.2"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mcl-wasm@^0.7.1:
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.9.tgz#c1588ce90042a8700c3b60e40efb339fc07ab87f"
@@ -12618,6 +12653,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -12892,6 +12932,13 @@ nan@^2.14.0:
 nano-json-stream-parser@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@3.2.0, nanoid@^3.1.12, nanoid@^3.1.20, nanoid@^3.1.22, nanoid@^3.1.23:
   version "3.2.0"
@@ -13301,6 +13348,11 @@ obliterator@^1.6.1:
 obliterator@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-2.0.0.tgz#fdff649d1131a1a90b51cc97c865b5560dcb3dfa"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 oboe@2.1.5:
   version "2.1.5"
@@ -14842,12 +14894,14 @@ react-primitives@0.8.1, react-primitives@^0.8.1:
     prop-types "^15.7.2"
     react-timer-mixin "^0.13.4"
 
-react-query@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-1.5.10.tgz#9b23af061e8171e95503e1932cc07d0cebe806eb"
+react-query@3.34.15:
+  version "3.34.15"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.15.tgz#9e143b7d0aa39c515102a35120d5518ad91b10f6"
+  integrity sha512-dOhGLB5RT3p+wWj0rVdAompSg+R9t6oMRk+JhU8DP0tpJM2UyIv3r4Kk0zUkHSxT+QG34hFdrgdqxVWxgeNq4g==
   dependencies:
-    "@scarf/scarf" "^1.0.6"
-    ts-toolbelt "^6.9.4"
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
 
 react-redux@7.2.1:
   version "7.2.1"
@@ -15339,15 +15393,15 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   dependencies:
     glob "^7.1.3"
 
@@ -16762,10 +16816,6 @@ ts-object-utils@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/ts-object-utils/-/ts-object-utils-0.0.5.tgz#95361cdecd7e52167cfc5e634c76345e90a26077"
 
-ts-toolbelt@^6.9.4:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-
 tsconfig-paths@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
@@ -17026,6 +17076,14 @@ universalify@^1.0.0:
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unorm@^1.3.3:
   version "1.6.0"


### PR DESCRIPTION
Fixes RNBW-2545

## What changed (plus any additional context for devs)

This PR updates React Query from v1 to v3. The main motivation of updating React Query is because we are utilising it in the ENS profiles work for some async functions, and we would really benefit from certain features such as: deterministic boolean state variables (`isIdle`, `isLoading`, `isSuccess`, etc), and render optimisation (`notifyOnChangeProps`).

This PR also migrates existing instances of `useQuery` to the new v3 API. I have also added a global `notifyOnChangeProps` option (introduced in v3) to the query client which is set to `"tracked"`, so that queries only trigger a re-render whenever one of the tracked return values change. This will further improve the performance of current React Query usages as v1 triggered a re-render whenever any return value changed. [See more on this here](https://tkdodo.eu/blog/react-query-render-optimizations#tracked-queries).

## Dev checklist for QA: what to test

I think these changes are pretty low risk. But ensure that features which use `react-query` still work:
  - Wallet balances
  - Expanded asset chart data
  - Uniswap pool data
  - DefiPulse Index expanded state data

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
