### PR TITLE
Prevent crash when mainnet assets contain 'network' property

### DIFF
--- a/src/parsers/accounts.js
+++ b/src/parsers/accounts.js
@@ -71,7 +71,7 @@ export const parseAsset = ({ asset_code: address, ...asset } = {}) => {
     symbol,
     type,
     uniqueId: address
-      ? asset.network
+      ? asset.network && asset.network !== networkTypes.mainnet
         ? `${address}_${asset.network}`
         : address
       : name,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Typically asset data retrieved from mainnet doesn't contain a `network` property. When a network property is included for mainnet values, the app crashes. This is a small change to prevent `accountAssetsData` from returning `undefined` when attempting to access mainnet assets that haven't omitted the network property.

## Dev checklist for QA: what to test
Overwrite `config.data_endpoint` in `explorer.js` (line 87) to be `wss://refraction-1912.api.p.rainbow.me/`. Observe no crash on launch.
Check that the wallet screen displays normally when pointing to the actual `config.data_endpoint`.
## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
