### PR TITLE
Convert ExternalLinkWarningSheet styles to object syntax

### DIFF
--- a/src/screens/ExternalLinkWarningSheet.tsx
+++ b/src/screens/ExternalLinkWarningSheet.tsx
@@ -14,11 +14,12 @@ import { formatURLForDisplay } from '@rainbow-me/utils';
 
 export const ExternalLinkWarningSheetHeight = 380 + (android ? 20 : 0);
 
-const Container = styled(Centered).attrs({ direction: 'column' })`
-  ${position.cover};
-  ${({ deviceHeight, height }) =>
-    height ? `height: ${height + deviceHeight}` : null};
-`;
+const Container = styled(Centered).attrs({ direction: 'column' })(
+  ({ deviceHeight, height }) => ({
+    ...position.coverAsObject,
+    ...(height ? { height: height + deviceHeight } : {}),
+  })
+);
 
 const ExternalLinkWarningSheet = () => {
   const { height: deviceHeight } = useDimensions();


### PR DESCRIPTION
Fixes RNBW-2591

## What changed (plus any additional context for devs)

The app was crashing when tapping on links in the markdown sections in the NFT expanded state. Turns out it's because there was a usage of styled-components in `ExternalLinkWarningSheet` that hadn't been migrated to the object syntax after we switched over to our custom styled-components implementation.

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/696693/154574962-3ea111b4-3659-4d2a-af3d-1c5b9552deb0.mov

## Dev checklist for QA: what to test

External links open the warning sheet and don't crash the app. Note that this warning sheet doesn't show for URLs from our [list of trusted domains.](https://github.com/rainbow-me/rainbow/blob/develop/src/navigation/useUntrustedUrlOpener.ts)

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
