### PR TITLE
Remove CodePush

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,30 +112,3 @@ project._
    ```shell
    yarn android
    ```
-
-## CodePush
-
-In order to use code push you must be logged into the correct Microsoft App Center account.
-
-### Prerequisites
-
-```
-npm install -g code-push
-code-push login
-```
-
-At this point you will be required to log into the account tied to the code push public keys in Info.plist
-
-### Deployment
-
-```
-code-push release-react RainbowWallet-iOS ios -d <DEPLOYMENT>
-```
-
-The deployment can either be `Staging` or `Production` depending on the mode of the application you wish to update was built in through XCode.
-
-### Local Builds
-
-In order to build the application in "release" mode but not use the code push distribution you must build the application using the scheme `LocalRelease`.
-
-Building the application with the `Staging` scheme or `Release` scheme will result in your bundle being replaced by the live code push deployment on resume of the application.


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Removes CodePush from `README.md`

CodePush isn't found in the rest of the codebase so this removes any confusion relating to CodePush.
