### PR TITLE
fix scanning QRs and adding wallets issue

### DIFF
--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -153,7 +153,9 @@ export function Header() {
   const { handleSetSeedPhrase, handlePressImportButton } = useImportingWallet();
 
   const onWatchAddress = useCallback(() => {
-    contextValue?.setIsSearchModeEnabled(false);
+    if (contextValue?.setIsSearchModeEnabled) {
+      contextValue?.setIsSearchModeEnabled(false);
+    }
     handleSetSeedPhrase(contextValue.address);
     handlePressImportButton(
       color,

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -154,7 +154,7 @@ export function Header() {
 
   const onWatchAddress = useCallback(() => {
     if (contextValue?.setIsSearchModeEnabled) {
-      contextValue?.setIsSearchModeEnabled(false);
+      contextValue.setIsSearchModeEnabled(false);
     }
     handleSetSeedPhrase(contextValue.address);
     handlePressImportButton(


### PR DESCRIPTION
Fixes RNBW-2468, RNBW-2628

## What changed (plus any additional context for devs)
Check that the function `contextValue?.setIsSearchModeEnabled` exists before invoking it. This function doesn't exist if the wallet doesn't have an ens, which is what was causing the bug.

## PoW (screenshots / screen recordings)
https://user-images.githubusercontent.com/15272675/155228346-6ca2a46b-c972-49e2-b96a-6822272a27f9.mp4

## Dev checklist for QA: what to test
Make sure that wallets that don't have ens names can be watched.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
