### PR TITLE
only disable touch events for video NFTs

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -67,8 +67,6 @@ const UniqueTokenExpandedStateContent = ({
 
   const { supports3d, supportsVideo, supportsAudio } = useUniqueToken(asset);
 
-  const supportsAnythingExceptImage =
-    supports3d || supportsVideo || supportsAudio;
   const aspectRatio = usePersistentAspectRatio(asset.image_url);
   const aspectRatioWithFallback =
     supports3d || supportsAudio ? 0.88 : aspectRatio.result || 1;
@@ -81,7 +79,7 @@ const UniqueTokenExpandedStateContent = ({
       animationProgress={animationProgress}
       aspectRatio={aspectRatioWithFallback}
       borderRadius={borderRadius}
-      disableAnimations={disablePreview || supportsAnythingExceptImage}
+      disableAnimations={disablePreview || supportsVideo}
       horizontalPadding={horizontalPadding}
       isENS={isENS}
       yDisplacement={yPosition}


### PR DESCRIPTION
Fixes RNBW-2571

## What changed (plus any additional context for devs)

we had disabled touch events for audio , video & 3d NFTs since the zoomableWrapper doesn't support them properly and we wanted to ship.  audio + 3d nft's work fine.There's more issues with videos atm so i'm fixing the easy ones for now 

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/RPReplay_Final1645569203.MP4

## Dev checklist for QA: what to test
should work fine.  asset examples are in PoW

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
