### PR TITLE
Fix favorite button on swap list on Android

### DIFF
--- a/src/components/coin-row/ExchangeCoinRow.js
+++ b/src/components/coin-row/ExchangeCoinRow.js
@@ -129,7 +129,7 @@ const ExchangeCoinRow = ({
       {showFavoriteButton && android && (
         <CoinRowFavoriteButton
           isFavorited={localFavorite}
-          onPress={() => toggleFavorite}
+          onPress={toggleFavorite}
         />
       )}
       {showAddButton && (


### PR DESCRIPTION
Fixes RNBW-2575

## What changed (plus any additional context for devs)

We have separate code for this button on iOS and on Android. On Android tap handler was passed incorrectly and in result it was never called.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

1. Tap on swap button.
2. Tap on `Choose Token`.
3. Try to add/remove a favorite on the list.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
