### PR TITLE
Fix settings modal cut on narrow phones

### DIFF
--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -70,7 +70,6 @@ const Container = styled(Column).attrs({})({
   backgroundColor: ({ backgroundColor }) => backgroundColor,
 });
 
-const scrollContainerStyle = { flex: 1 };
 const ScrollContainer = styled(ScrollView).attrs({
   scrollEventThrottle: 32,
 })({});
@@ -144,7 +143,7 @@ export default function SettingsSection({
   const isReviewAvailable = false;
   const { wallets, isReadOnlyWallet } = useWallets();
   const { language, nativeCurrency, network } = useAccountSettings();
-  const { isSmallPhone } = useDimensions();
+  const { isNarrowPhone } = useDimensions();
   const isLanguageSelectionEnabled = useExperimentalFlag(LANGUAGE_SETTINGS);
 
   const { colors, isDarkMode, setTheme, colorScheme } = useTheme();
@@ -205,10 +204,7 @@ export default function SettingsSection({
 
   return (
     <Container backgroundColor={colors.white}>
-      <ScrollContainer
-        contentContainerStyle={!isSmallPhone && scrollContainerStyle}
-        scrollEnabled={isSmallPhone}
-      >
+      <ScrollContainer>
         <ColumnWithDividers dividerRenderer={ListItemDivider} marginTop={7}>
           {canBeBackedUp && (
             <ListItem
@@ -322,7 +318,9 @@ export default function SettingsSection({
           />
           <ListItem
             icon={<Emoji name="brain" />}
-            label={lang.t('settings.learn')}
+            label={lang.t(
+              isNarrowPhone ? 'settings.learn_short' : 'settings.learn'
+            )}
             onPress={onPressLearn}
             testID="learn-section"
             value={SettingsExternalURLs.rainbowLearn}

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -579,6 +579,7 @@
       "label": "Settings",
       "language": "Language",
       "learn": "Learn about Rainbow and Ethereum",
+      "learn_short": "Learn about Rainbow :)",
       "network": "Network",
       "privacy": "Privacy",
       "review": "Review Rainbow",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -562,6 +562,7 @@
       "label": "Réglages",
       "language": "Langue",
       "learn": "Learn about Rainbow and Ethereum :)",
+      "learn_short": "Learn about Rainbow :)",
       "network": "Réseau",
       "privacy": "Privacy :)",
       "review": "Review Rainbow :)",


### PR DESCRIPTION
Fixes RNBW-2257

## What changed (plus any additional context for devs)

## PoW (screenshots / screen recordings)

![photo_2022-02-23 15 45 37](https://user-images.githubusercontent.com/5769281/155332107-ec874e27-eaa1-4242-be94-c8bcf60594e8.jpeg)

## Dev checklist for QA: what to test

Check settings on two kinds of screen size. It should be intact on big screen and on small screen a) scrolling should be available b) _Learn about Rainbow and Ethereum :)_ should become _Learn about Rainbow :)_

Note: make sure that settings modal is dismissable on bigger Android screen where is not big enough to "enable" scroll.
## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
