### PR TITLE
Fix showcase deeplinks on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,14 +46,15 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="https" android:host="rnbwapp.com" />
-          <data android:scheme="https" android:host="rainbow-web.vercel.app" />
-          <data android:scheme="https" android:host="rainbow.me" />
-          <data android:scheme="https" android:host="rnbw.app" />
-          <data android:scheme="https" android:host="rainbowdotme.app.link" />
-          <data android:scheme="https" android:host="rnbwappdotcom.app.link" />
-          <data android:scheme="https" android:host="rainbowdotme-alternate.app.link" />
-          <data android:scheme="https" android:host="rnbwappdotcom-alternate.app.link" />
+          <data android:scheme="https" />
+          <data android:host="rnbwapp.com" />
+          <data android:host="rainbow-web.vercel.app" />
+          <data android:host="rainbow.me" />
+          <data android:host="rnbw.app" />
+          <data android:host="rainbowdotme.app.link" />
+          <data android:host="rnbwappdotcom.app.link" />
+          <data android:host="rainbowdotme-alternate.app.link" />
+          <data android:host="rnbwappdotcom-alternate.app.link" />
         </intent-filter>
         <intent-filter>
           <data android:scheme="ethereum" />
@@ -72,13 +73,6 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-        </intent-filter>
-        <!-- Branch App Links (optional) -->
-        <intent-filter android:autoVerify="true">
-          <action android:name="android.intent.action.VIEW" />
-          <category android:name="android.intent.category.DEFAULT" />
-          <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="https" android:host="rnbwapp.com" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />


### PR DESCRIPTION
Fixes RNBW-2032

## What changed (plus any additional context for devs)

Once another PR is merged (see link in the [issue comment](https://linear.app/rainbow/issue/RNBW-2032#comment-806bea74)), we will start serving `assetlinks.json` on the main domain. A file which Android uses for verification that our app is allowed to 'hijack' the domain.

To be honest the changes in this PR are more of a cleanup, but I wanted to leave a mark in the app repo too.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

See [this comment](https://linear.app/rainbow/issue/RNBW-2631#comment-0dd7a604) in the issue.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
