### PR TITLE
Fix downloaded NFTs from Google User Content being low res

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -368,7 +368,7 @@ const UniqueTokenExpandedStateHeader = ({
         } else if (isPhotoDownloadAvailable ? idx === 3 : idx === 2) {
           setClipboard(asset.id);
         } else if (idx === 2) {
-          saveToCameraRoll(asset.image_url);
+          saveToCameraRoll(getFullResUrl(asset.image_url));
         }
       }
     );

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -36,6 +36,7 @@ import {
   magicMemo,
   showActionSheetWithOptions,
 } from '@rainbow-me/utils';
+import { getFullResUrl } from '@rainbow-me/utils/getFullResUrl';
 
 const AssetActionsEnum = {
   copyTokenID: 'copyTokenID',
@@ -259,7 +260,7 @@ const UniqueTokenExpandedStateHeader = ({
       } else if (actionKey === AssetActionsEnum.copyTokenID) {
         setClipboard(asset.id);
       } else if (actionKey === AssetActionsEnum.download) {
-        saveToCameraRoll(asset.image_url);
+        saveToCameraRoll(getFullResUrl(asset.image_url));
       }
     },
     [accountAddress, accountENS, asset, setClipboard]

--- a/src/utils/getFullResUrl.ts
+++ b/src/utils/getFullResUrl.ts
@@ -1,9 +1,11 @@
 export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
-const size = 5000;
+
+// List of params for Google Cloud Storage available here
+// https://github.com/albertcht/python-gcs-image
 
 export const getFullResUrl = (url: string | null | undefined) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
-    return `${url}=w${size}`;
+    return `${url}=s0`; // s0 gets the original size from google
   }
   return url;
 };

--- a/src/utils/getFullResUrl.ts
+++ b/src/utils/getFullResUrl.ts
@@ -1,0 +1,9 @@
+export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
+const size = 5000;
+
+export const getFullResUrl = (url: string | null | undefined) => {
+  if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
+    return `${url}=w${size}`;
+  }
+  return url;
+};

--- a/src/utils/getLowResUrl.ts
+++ b/src/utils/getLowResUrl.ts
@@ -7,7 +7,7 @@ const size = (Math.ceil(CardSize) * PixelRatio.get()) / 5;
 
 export const getLowResUrl = (url: string) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
-    return `${url}?w=${size}`;
+    return `${url}=w${size}`;
   }
   return imageToPng(url, size);
 };


### PR DESCRIPTION
Fixes RNBW-2344

## What changed (plus any additional context for devs)
- Function to get low res image URLs was not using Google's weird format. Fixed it to comply with their server-side scaling.
- Added an extra function to get full res image URLs from Google when saving NFTs to camera roll.

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/6843656/156679597-67559874-4c27-40c7-b272-f58b3e995b59.mp4

## Dev checklist for QA: what to test
Saving NFT photos.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
