### PR TITLE
Fix BackupSheet shadow & fix Discover btn padding

### DIFF
--- a/src/components/backup/BackupSheetSection.js
+++ b/src/components/backup/BackupSheetSection.js
@@ -15,7 +15,7 @@ import { padding } from '@rainbow-me/styles';
 const Footer = styled(ColumnWithMargins).attrs({
   margin: 19,
 })({
-  ...padding.object(19, 15, 21),
+  ...padding.object(19, 15, 32),
   width: '100%',
 });
 

--- a/src/components/header/DiscoverHeaderButton.js
+++ b/src/components/header/DiscoverHeaderButton.js
@@ -37,6 +37,7 @@ const DiscoverButtonContent = styled(RowWithMargins).attrs({
   alignItems: 'center',
   justifyContent: 'center',
   ...padding.object(2, 10, 7.5),
+  ...(android && { paddingRight: 12 }),
   height: 34,
   zIndex: 2,
 });
@@ -74,7 +75,7 @@ export default function DiscoverHeaderButton() {
           shadows={shadows}
           {...(android && {
             height: 34,
-            width: 120,
+            width: 126,
           })}
         >
           <BackgroundFill />


### PR DESCRIPTION
Fixes RNBW-2736

## What changed (plus any additional context for devs)
Visual changes only.

- "Back up manually" button no longer has its shadow clipped at the bottom on Android.
- "Discover" button no longer has a collapsed padding on the right side on Android.

## PoW (screenshots / screen recordings)
| iOS  | Android  |
|---|---|
| ![Simulator Screen Shot - iPhone 11 - 2022-03-08 at 01 30 05](https://user-images.githubusercontent.com/6843656/157143869-0c8b8eaf-5022-47c1-9a91-d3028f40f589.png) | ![Screenshot_20220308-013000](https://user-images.githubusercontent.com/6843656/157143894-28f10e6f-799c-4500-a877-e609a3c01c08.png) |

## Dev checklist for QA: what to test
Opening the app for the first time and looking at the bottom sheet. Looking at the "Discover" button in the header.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
