### PR TITLE
Revert "Fix deps"

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,6 +1,15 @@
 {
   "low": true,
   "package-manager": "auto",
-  "allowlist": [],
+  "allowlist": [
+    1007507,
+    1007549,
+    1028407,
+    1028449,
+    1033673, 
+    1033631,
+    1038897,
+    1038855
+  ],
   "registry": "https://registry.npmjs.org"
 }

--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "**/node-fetch": "2.6.7",
     "**/web3": "1.6.1",
     "**/underscore": "1.12.1",
-    "**/socket.io-parser": "3.3.2",
+    "**/socket.io-parser": "3.3.1",
     "**/bl": "2.2.1",
     "**/browserslist": "4.17.6",
     "**/elliptic": "6.5.4",
@@ -365,8 +365,7 @@
     "**/@ethersproject/**": "5.4.0",
     "**/follow-redirects": "1.14.8",
     "**/markdown-it": "12.3.2",
-    "**/simple-get": "4.0.1",
-    "**/ws": "6.2.2"
+    "**/simple-get": "4.0.1"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13557,6 +13557,10 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+options@>=0.0.5:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
+
 ora@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
@@ -16032,10 +16036,9 @@ socket.io-client@2.3.1:
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
-socket.io-parser@3.3.2, socket.io-parser@~3.3.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
-  integrity sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
+socket.io-parser@3.3.1, socket.io-parser@~3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.1.tgz#f07d9c8cb3fb92633aa93e76d98fd3a334623199"
   dependencies:
     component-emitter "~1.3.0"
     debug "~3.1.0"
@@ -17135,6 +17138,14 @@ uglify-es@^3.1.9:
     commander "~2.13.0"
     source-map "~0.6.1"
 
+ultron@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
+
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -17899,10 +17910,48 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@6.2.2, ws@7.4.6, ws@7.5.3, ws@^1.1.0, ws@^1.1.5, ws@^3.0.0, ws@^5.1.1, ws@^6.1.4, ws@^7, ws@^7.0.0, ws@^7.4.6, ws@~6.1.0:
+ws@7.4.6, ws@^7, ws@^7.0.0:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+
+ws@7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+
+ws@^1.1.0, ws@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
+ws@^3.0.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
+ws@^5.1.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.1.4:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
-  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^7.4.6:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
+
+ws@~6.1.0:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Reverts rainbow-me/rainbow#3022

This breaks the bundler 

```
 BUNDLE  ./index.js

/Users/bruno/repos/rainbow/node_modules/metro-hermes-compiler/src/emhermesc.js:77
          throw ex;
          ^

RuntimeError: abort(TypeError: Cannot read property 'url' of undefined). Build with -s ASSERTIONS=1 for more info.
    at process.abort (/Users/bruno/repos/rainbow/node_modules/metro-hermes-compiler/src/emhermesc.js:440:13)
    at process.emit (events.js:412:35)
    at processPromiseRejections (internal/process/promises.js:245:33)
    at processTicksAndRejections (internal/process/task_queues.js:96:32)
error Command failed with exit code 7.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
➜  rainbow git:(develop) ✗ git log
```