### PR TITLE
profiles: handle resolver when editing profile

### DIFF
--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -243,7 +243,7 @@ export const fetchProfile = async (ensName: any) => {
     { registrant, registration },
     primary,
   ] = await Promise.all([
-    web3Provider.getResolver(ensName),
+    fetchResolver(ensName),
     fetchRecords(ensName),
     fetchCoinAddresses(ensName),
     fetchImages(ensName),
@@ -613,3 +613,6 @@ export const shouldUseMulticallTransaction = (
 
 export const fetchReverseRecord = async (address: string) =>
   (await web3Provider.lookupAddress(address)) || '';
+
+export const fetchResolver = async (ensName: string) =>
+  web3Provider.getResolver(ensName);

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -13,7 +13,7 @@ import {
   fromWei,
   multiply,
 } from './utilities';
-import { ENSRegistrationRecords } from '@rainbow-me/entities';
+import { ENSRegistrationRecords, EthereumAddress } from '@rainbow-me/entities';
 import { toHex, web3Provider } from '@rainbow-me/handlers/web3';
 import { gweiToWei } from '@rainbow-me/parsers';
 import {
@@ -224,9 +224,12 @@ const getENSRegistrarControllerContract = (
     wallet || web3Provider
   );
 };
-const getENSPublicResolverContract = (wallet?: Wallet) => {
+const getENSPublicResolverContract = (
+  wallet?: Wallet,
+  resolverAddress?: EthereumAddress
+) => {
   return new Contract(
-    ensPublicResolverAddress,
+    resolverAddress || ensPublicResolverAddress,
     ENSPublicResolverABI,
     wallet || web3Provider
   );
@@ -368,6 +371,7 @@ const getENSExecutionDetails = async ({
   duration,
   records,
   wallet,
+  resolverAddress,
 }: {
   name?: string;
   type: ENSRegistrationTransactionType;
@@ -377,6 +381,7 @@ const getENSExecutionDetails = async ({
   records?: ENSRegistrationRecords;
   wallet?: Wallet;
   salt?: string;
+  resolverAddress?: EthereumAddress;
 }): Promise<{
   methodArguments: any[] | null;
   value: BigNumberish | null;
@@ -422,12 +427,12 @@ const getENSExecutionDetails = async ({
       const record = records?.text[0];
       const namehash = hash(name);
       args = [namehash, record.key, record.value];
-      contract = getENSPublicResolverContract(wallet);
+      contract = getENSPublicResolverContract(wallet, resolverAddress);
       break;
     }
     case ENSRegistrationTransactionType.MULTICALL: {
       if (!name || !records) throw new Error('Bad arguments for multicall');
-      contract = getENSPublicResolverContract(wallet);
+      contract = getENSPublicResolverContract(wallet, resolverAddress);
       const data = setupMulticallRecords(name, records, contract) || [];
       args = [data];
       break;

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -8,6 +8,7 @@ import {
 } from '../raps/common';
 import { useAccountSettings, useCurrentNonce, useENSRegistration } from '.';
 import { RegistrationParameters } from '@rainbow-me/entities';
+import { fetchResolver } from '@rainbow-me/handlers/ens';
 import { web3Provider } from '@rainbow-me/handlers/web3';
 import {
   ENS_DOMAIN,
@@ -145,12 +146,13 @@ export default function useENSRegistrationActionHandler(
         return;
       }
       const nonce = await getNextNonce();
-
+      const resolver = await fetchResolver(registrationParameters.name);
       const setRecordsEnsRegistrationParameters: ENSActionParameters = {
         ...formatENSActionParams(registrationParameters),
         nonce,
         ownerAddress: accountAddress,
         records: registrationParameters.changedRecords,
+        resolverAddress: resolver.address,
       };
 
       await executeRap(

--- a/src/raps/actions/ens.ts
+++ b/src/raps/actions/ens.ts
@@ -249,7 +249,8 @@ const ensAction = async (
           wallet,
           nonce
         );
-        await dispatch(
+        dispatch(
+          // @ts-ignore
           saveCommitRegistrationParameters(ownerAddress, {
             commitTransactionHash: tx?.hash,
             duration,
@@ -274,7 +275,8 @@ const ensAction = async (
           wallet,
           nonce
         );
-        await dispatch(
+        dispatch(
+          // @ts-ignore
           updateTransactionRegistrationParameters(ownerAddress, {
             registerTransactionHash: tx?.hash,
           })

--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -12,6 +12,11 @@ import {
   withdrawCompound,
 } from './actions';
 import {
+  createCommitENSRap,
+  createRegisterENSRap,
+  createSetRecordsENSRap,
+} from './registerENS';
+import {
   createSwapAndDepositCompoundRap,
   estimateSwapAndDepositCompound,
 } from './swapAndDepositCompound';
@@ -20,11 +25,6 @@ import {
   createWithdrawFromCompoundRap,
   estimateWithdrawFromCompound,
 } from './withdrawFromCompound';
-import {
-  createCommitENSRap,
-  createRegisterENSRap,
-  createSetRecordsENSRap,
-} from '.';
 import { Asset, EthereumAddress, Records } from '@rainbow-me/entities';
 import {
   estimateENSCommitGasLimit,
@@ -94,6 +94,7 @@ export interface ENSActionParameters {
   salt: string;
   records?: Records;
   setReverseRecord?: boolean;
+  resolverAddress?: EthereumAddress;
 }
 
 export interface RapActionTransaction {


### PR DESCRIPTION
Fixes RNBW-2691

## What changed (plus any additional context for devs)

Added resolver address resolution for `setRecordsAction` which is the action triggered when editing profiles, we need to use the resolver that the ENS has. we still default to the public resolver when creating the profile.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
