### PR TITLE
Change audit to use package name instead of ID

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,7 +2,7 @@
   "low": true,
   "package-manager": "auto",
   "allowlist": [
-    1049360
+    "ws"
   ],
   "registry": "https://registry.npmjs.org"
 }


### PR DESCRIPTION
_This dev found one SIMPLE trick how to STOP socket.io from destroying CI. SEE HOW:_