### PR TITLE
Profiles: Defer image upload

### DIFF
--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -72,13 +72,6 @@ export default function useENSRegistrationActionHandler(
   const coverMetadata = useRecoilValue(coverMetadataAtom);
   const commitAction = useCallback(
     async (callback: () => void) => {
-      const changedRecords = await uploadRecordImages(
-        registrationParameters.changedRecords,
-        {
-          avatar: avatarMetadata,
-          cover: coverMetadata,
-        }
-      );
       const wallet = await loadWallet();
       if (!wallet) {
         return;
@@ -96,7 +89,7 @@ export default function useENSRegistrationActionHandler(
         duration,
         nonce,
         ownerAddress: accountAddress,
-        records: changedRecords,
+        records: registrationParameters.changedRecords,
         rentPrice: rentPrice.toString(),
         salt,
       };
@@ -108,14 +101,7 @@ export default function useENSRegistrationActionHandler(
         callback
       );
     },
-    [
-      registrationParameters,
-      avatarMetadata,
-      coverMetadata,
-      getNextNonce,
-      yearsDuration,
-      accountAddress,
-    ]
+    [registrationParameters, getNextNonce, yearsDuration, accountAddress]
   );
 
   const registerAction = useCallback(
@@ -123,8 +109,14 @@ export default function useENSRegistrationActionHandler(
       const {
         name,
         duration,
-        changedRecords,
       } = registrationParameters as RegistrationParameters;
+      const changedRecords = await uploadRecordImages(
+        registrationParameters.changedRecords,
+        {
+          avatar: avatarMetadata,
+          cover: coverMetadata,
+        }
+      );
       const wallet = await loadWallet();
       if (!wallet) {
         return;

--- a/src/hooks/useSelectImageMenu.tsx
+++ b/src/hooks/useSelectImageMenu.tsx
@@ -53,7 +53,7 @@ export default function useSelectImageMenu({
     image,
   }: {
     asset?: UniqueAsset;
-    image?: Image;
+    image?: Image & { tmpPath?: string };
   }) => void;
   onUploading?: ({ image }: { image: Image }) => void;
   onUploadSuccess?: ({
@@ -79,7 +79,10 @@ export default function useSelectImageMenu({
       includeBase64: true,
       mediaType: 'photo',
     });
-    onChangeImage?.({ image });
+    const stringIndex = image?.path.indexOf('/tmp');
+    const tmpPath = `~${image?.path.slice(stringIndex)}`;
+
+    onChangeImage?.({ image: { ...image, tmpPath } });
 
     if (uploadToIPFS) {
       onUploading?.({ image });


### PR DESCRIPTION
Fixes RNBW-2663

## What changed (plus any additional context for devs)

This PR implements a change where the user will no longer have to wait for the avatar/cover to be uploaded to continue with the registration process. Instead, it will upload in the background, and use the uploaded URL for the avatar/cover record if it has been uploaded by the time the user submits the form. If the photo has not been uploaded, then it will upload it at the time of form submission.