### PR TITLE
Expose Dev section to TF users

### DIFF
--- a/src/components/settings-menu/DevSection.js
+++ b/src/components/settings-menu/DevSection.js
@@ -4,8 +4,10 @@ import { Alert, ScrollView } from 'react-native';
 import { HARDHAT_URL_ANDROID, HARDHAT_URL_IOS } from 'react-native-dotenv';
 import Restart from 'react-native-restart';
 import { useDispatch } from 'react-redux';
+import { defaultConfig } from '../../config/experimental';
 import { ListFooter, ListItem } from '../list';
 import { RadioListItem } from '../radio-list';
+import UserDevSection from './UserDevSection';
 import { deleteAllBackups } from '@rainbow-me/handlers/cloudBackup';
 import { web3SetHttpProvider } from '@rainbow-me/handlers/web3';
 import { RainbowContext } from '@rainbow-me/helpers/RainbowContext';
@@ -116,10 +118,12 @@ const DevSection = () => {
         testID="hardhat-section"
       />
       <ListItem label="‍🏖️ Alert" onPress={checkAlert} testID="alert-section" />
-      <ListFooter />
+
+      <UserDevSection scrollEnabled={false} />
 
       {Object.keys(config)
         .sort()
+        .filter(key => defaultConfig[key].settings)
         .map(key => (
           <RadioListItem
             key={key}
@@ -128,6 +132,7 @@ const DevSection = () => {
             selected={!!config[key]}
           />
         ))}
+      <ListFooter />
     </ScrollView>
   );
 };

--- a/src/components/settings-menu/NetworkSection.js
+++ b/src/components/settings-menu/NetworkSection.js
@@ -15,7 +15,7 @@ import {
 
 const networks = values(networkInfo).filter(network => !network.layer2);
 
-const NetworkSection = () => {
+const NetworkSection = props => {
   const { network, testnetsEnabled } = useAccountSettings();
   const resetAccountState = useResetAccountState();
   const loadAccountData = useLoadAccountData();
@@ -50,6 +50,7 @@ const NetworkSection = () => {
       onChange={onNetworkChange}
       renderItem={RadioListItem}
       value={network}
+      {...props}
     />
   );
 };

--- a/src/components/settings-menu/UserDevSection.js
+++ b/src/components/settings-menu/UserDevSection.js
@@ -46,7 +46,7 @@ const UserDevSection = props => {
   ]);
 
   return (
-    <ScrollView {...props} testID="developer-settings-modal">
+    <ScrollView {...props}>
       <ListItem
         label="🕹️ Enable Testnets"
         onPress={toggleTestnetsEnabled}

--- a/src/components/settings-menu/UserDevSection.js
+++ b/src/components/settings-menu/UserDevSection.js
@@ -14,7 +14,7 @@ import {
   useResetAccountState,
 } from '@rainbow-me/hooks';
 
-const UserDevSection = () => {
+const UserDevSection = props => {
   const dispatch = useDispatch();
 
   const {
@@ -46,7 +46,7 @@ const UserDevSection = () => {
   ]);
 
   return (
-    <ScrollView testID="developer-settings-modal">
+    <ScrollView testID="developer-settings-modal" {...props}>
       <ListItem
         label="🕹️ Enable Testnets"
         onPress={toggleTestnetsEnabled}
@@ -59,7 +59,7 @@ const UserDevSection = () => {
           />
         </Column>
       </ListItem>
-      {testnetsEnabled && <NetworkSection />}
+      {testnetsEnabled && <NetworkSection {...props} />}
       <ListFooter />
     </ScrollView>
   );

--- a/src/components/settings-menu/UserDevSection.js
+++ b/src/components/settings-menu/UserDevSection.js
@@ -46,7 +46,7 @@ const UserDevSection = props => {
   ]);
 
   return (
-    <ScrollView testID="developer-settings-modal" {...props}>
+    <ScrollView {...props} testID="developer-settings-modal">
       <ListItem
         label="🕹️ Enable Testnets"
         onPress={toggleTestnetsEnabled}

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -6,10 +6,10 @@
 
 export const LANGUAGE_SETTINGS = 'languageSettings';
 export const REVIEW_ANDROID = 'reviewAndroid';
-export const PROFILES = 'profiles';
+export const PROFILES = 'ENS Profiles';
 
 export const defaultConfig = {
-  [LANGUAGE_SETTINGS]: false,
-  [PROFILES]: false,
-  [REVIEW_ANDROID]: false,
+  [LANGUAGE_SETTINGS]: { settings: false, value: false },
+  [PROFILES]: { settings: true, value: false },
+  [REVIEW_ANDROID]: { settings: false, value: false },
 };

--- a/src/config/experimentalHooks.ts
+++ b/src/config/experimentalHooks.ts
@@ -9,7 +9,7 @@ const useExperimentalFlag = (name: any) => {
     return useContext(RainbowContext).config[name];
   } else {
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    return defaultConfig[name];
+    return defaultConfig[name].value;
   }
 };
 export default useExperimentalFlag;

--- a/src/helpers/RainbowContext.js
+++ b/src/helpers/RainbowContext.js
@@ -21,7 +21,12 @@ export default function RainbowContextWrapper({ children }) {
   // This value is hold here to prevent JS VM from shutting down
   // on unmounting all shared values.
   useSharedValue(0);
-  const [config, setConfig] = useState(defaultConfig);
+  const [config, setConfig] = useState(
+    Object.entries(defaultConfig).reduce(
+      (acc, [key, { value }]) => ({ ...acc, [key]: value }),
+      {}
+    )
+  );
   const [globalState, updateGlobalState] = useState({});
 
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -63,8 +63,9 @@ function cardStyleInterpolator({
   };
 }
 
-const { RNTestFlight } = NativeModules;
-const { isTestFlight } = RNTestFlight.getConstants();
+let isTestFlight = ios
+  ? NativeModules.RNTestFlight.getConstants().isTestFlight
+  : false;
 
 const SettingsPages = {
   backup: {

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -2,7 +2,12 @@ import { useRoute } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import lang from 'i18n-js';
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Animated, InteractionManager, View } from 'react-native';
+import {
+  Animated,
+  InteractionManager,
+  NativeModules,
+  View,
+} from 'react-native';
 import { Modal } from '../components/modal';
 import ModalHeaderButton from '../components/modal/ModalHeaderButton';
 import {
@@ -58,6 +63,9 @@ function cardStyleInterpolator({
   };
 }
 
+const { RNTestFlight } = NativeModules;
+const { isTestFlight } = RNTestFlight.getConstants();
+
 const SettingsPages = {
   backup: {
     component: View,
@@ -75,7 +83,7 @@ const SettingsPages = {
     key: 'SettingsSection',
   },
   dev: {
-    component: IS_DEV ? DevSection : UserDevSection,
+    component: IS_DEV || isTestFlight ? DevSection : UserDevSection,
     getTitle: () => lang.t('settings.dev'),
     key: 'DevSection',
   },


### PR DESCRIPTION
Fixes RNBW-2825

## What changed (plus any additional context for devs)
1. Exposed experimental section
2. Added Network toggler in the section (previously this was only in "prod" dev section so this is necessary not block testnets for TF users
3. Added params in which experimental options should be exposed to users. Currently, this is only "ENS Profiles"
4. Used nicer wording. 

## PoW (screenshots / screen recordings)
![image](https://user-images.githubusercontent.com/25709300/158618054-09c82c6b-c1f0-4527-b4bc-4b14adb09e0d.png)


## Dev checklist for QA: what to test

Run in DEV mode and see what will happen. To make sure this works in TF the only 100% guarantee will be to actually make a TF release. 
