### PR TITLE
Organize MMKV storage IDs

### DIFF
--- a/src/components/settings-menu/DevSection.js
+++ b/src/components/settings-menu/DevSection.js
@@ -12,6 +12,7 @@ import { RainbowContext } from '@rainbow-me/helpers/RainbowContext';
 import networkTypes from '@rainbow-me/helpers/networkTypes';
 import { useWallets } from '@rainbow-me/hooks';
 import { wipeKeychain } from '@rainbow-me/model/keychain';
+import { clearAllStorages } from '@rainbow-me/model/mmkv';
 import { useNavigation } from '@rainbow-me/navigation/Navigation';
 import { explorerInit } from '@rainbow-me/redux/explorer';
 import { clearImageMetadataCache } from '@rainbow-me/redux/imageMetadata';
@@ -89,6 +90,10 @@ const DevSection = () => {
   return (
     <ScrollView testID="developer-settings-modal">
       <ListItem label="💥 Clear async storage" onPress={AsyncStorage.clear} />
+      <ListItem
+        label="💥 Clear MMKV storages"
+        onPress={() => clearAllStorages()}
+      />
       <ListItem
         label="📷️ Clear Image Metadata Cache"
         onPress={clearImageMetadataCache}

--- a/src/handlers/localstorage/accountLocal.ts
+++ b/src/handlers/localstorage/accountLocal.ts
@@ -1,5 +1,6 @@
 import { MMKV } from 'react-native-mmkv';
 import { getAccountLocal, getKey, saveAccountLocal } from './common';
+import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
 
 const accountAssetsDataVersion = '0.1.0';
 const assetPricesFromUniswapVersion = '0.1.0';
@@ -24,7 +25,7 @@ const HIDDEN_COINS = 'hiddenCoins';
 const WEB_DATA_ENABLED = 'webDataEnabled';
 
 const storage = new MMKV({
-  id: 'ACCOUNT',
+  id: STORAGE_IDS.ACCOUNT,
 });
 
 export const accountLocalKeys = [

--- a/src/hooks/usePersistentAspectRatio.ts
+++ b/src/hooks/usePersistentAspectRatio.ts
@@ -4,11 +4,10 @@ import { MMKV, useMMKVNumber } from 'react-native-mmkv';
 import { getLowResUrl } from '../utils/getLowResUrl';
 import { imageToPng } from '@rainbow-me/handlers/imgix';
 import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
-
-const id = 'ASPECT_RATIO';
+import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
 
 const storage = new MMKV({
-  id,
+  id: STORAGE_IDS.ASPECT_RATIO,
 });
 
 enum State {

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -3,9 +3,9 @@ import { MMKV, useMMKVString } from 'react-native-mmkv';
 import { getLowResUrl } from '../utils/getLowResUrl';
 import { imageToPng } from '@rainbow-me/handlers/imgix';
 import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
+import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
 import { getDominantColorFromImage } from '@rainbow-me/utils';
 
-const id = 'DOMINANT_COLOR';
 enum State {
   init,
   loading,
@@ -14,7 +14,7 @@ enum State {
 }
 
 const storage = new MMKV({
-  id,
+  id: STORAGE_IDS.DOMINANT_COLOR,
 });
 
 type Result = {

--- a/src/model/mmkv.ts
+++ b/src/model/mmkv.ts
@@ -1,0 +1,17 @@
+import { MMKV } from 'react-native-mmkv';
+
+export const STORAGE_IDS = {
+  ACCOUNT: 'ACCOUNT',
+  ASPECT_RATIO: 'ASPECT_RATIO',
+  DOMINANT_COLOR: 'DOMINANT_COLOR',
+};
+
+export const clearAllStorages = () => {
+  Object.keys(STORAGE_IDS).forEach(id => {
+    const storage = new MMKV({ id });
+    storage.clearAll();
+  });
+
+  const defaultStorage = new MMKV();
+  defaultStorage.clearAll();
+};


### PR DESCRIPTION
Fixes RNBW-2849

## What changed (plus any additional context for devs)

Currently we use several MMKV storages that go under different IDs. It is important for existing functionality to keep them separate, but we need a way for clearing all of them at once.

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
