### PR TITLE
Round low res google photos image to full number

### DIFF
--- a/src/utils/getLowResUrl.ts
+++ b/src/utils/getLowResUrl.ts
@@ -3,7 +3,7 @@ import { CardSize } from '../components/unique-token/CardSize';
 import { imageToPng } from '@rainbow-me/handlers/imgix';
 
 export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
-const size = (Math.ceil(CardSize) * PixelRatio.get()) / 5;
+const size = Math.round((Math.ceil(CardSize) * PixelRatio.get()) / 5);
 
 export const getLowResUrl = (url: string) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {


### PR DESCRIPTION
Fixes RNBW-2813

## What changed (plus any additional context for devs)
The function to get low res size of an NFT preview was returning fractional numbers. Google's API does not support that. Now it rounds to the nearest full number.

## PoW (screenshots / screen recordings)
![Simulator Screen Shot - iPhone 11 Pro - 2022-03-17 at 17 35 48](https://user-images.githubusercontent.com/6843656/158849258-be62f635-ea31-4d63-8592-56093d3b1948.png)


## Dev checklist for QA: what to test
Browsing old ENS NFTs.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
