### PR TITLE
Fix zoomable wrappers issues

### DIFF
--- a/src/components/expanded-state/unique-token/ZoomableWrapper.js
+++ b/src/components/expanded-state/unique-token/ZoomableWrapper.js
@@ -172,7 +172,7 @@ export const ZoomableWrapper = ({
     ctx.prevTranslateX = 0;
     ctx.prevTranslateY = 0;
     // if zoom state was entered by pinching, adjust targetScale to account for new image dimensions
-    let targetScale = isZoomed
+    let targetScale = isZoomedValue.value
       ? Math.min(scale.value, MAX_IMAGE_SCALE)
       : Math.min(
           scale.value * (containerWidth / fullSizeWidth),
@@ -186,6 +186,7 @@ export const ZoomableWrapper = ({
       breakingScaleX = deviceWidth / containerWidth;
       breakingScaleY = deviceHeight / containerHeight;
     }
+    const zooming = fullSizeHeight / containerHeightValue.value;
 
     const maxDisplacementX =
       (deviceWidth * (Math.max(1, targetScale / breakingScaleX) - 1)) /

--- a/src/utils/getLowResUrl.ts
+++ b/src/utils/getLowResUrl.ts
@@ -3,7 +3,7 @@ import { CardSize } from '../components/unique-token/CardSize';
 import { imageToPng } from '@rainbow-me/handlers/imgix';
 
 export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
-const size = (Math.ceil(CardSize) * PixelRatio.get()) / 5;
+const size = Math.floor((Math.ceil(CardSize) * PixelRatio.get()) / 5);
 
 export const getLowResUrl = (url: string) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {


### PR DESCRIPTION
Fixes RNBW-2813 RNBW-2834 RNBW-2833

Fixed link. currently this was possible to have a non-integer value in the Google storage link. This is fixing nfts ratio, ens colors.

Also, fixed zoomable wrapper to respect changes in the newest reanimated.



## What changed (plus any additional context for devs)
https://streamable.com/wvr14l


## Dev checklist for QA: what to test

Wipe everything (including mmkv, see tomek's newest PR) and try to repro bugs. 


