### PR TITLE
@benisgold/widget regression fixes

### DIFF
--- a/ios/PriceWidgetExtension.entitlements
+++ b/ios/PriceWidgetExtension.entitlements
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.application-groups</key>
-	<array/>
+	<array>
+		<string>group.rainbow.me</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)me.rainbow.sharedItems</string>

--- a/ios/Rainbow/Rainbow.entitlements
+++ b/ios/Rainbow/Rainbow.entitlements
@@ -32,6 +32,14 @@
 	<array>
 		<string>iCloud.me.rainbow</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)me.rainbow.sharedItems</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.rainbow.me</string>
+	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>

--- a/ios/Rainbow/RainbowDebug.entitlements
+++ b/ios/Rainbow/RainbowDebug.entitlements
@@ -33,7 +33,15 @@
 	<array>
 		<string>iCloud.me.rainbow</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)me.rainbow.sharedItems</string>
+	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.rainbow.me</string>
+	</array>
 </dict>
 </plist>

--- a/ios/Rainbow/RainbowRelease.entitlements
+++ b/ios/Rainbow/RainbowRelease.entitlements
@@ -33,7 +33,15 @@
 	<array>
 		<string>iCloud.me.rainbow</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)me.rainbow.sharedItems</string>
+	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+        <key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.rainbow.me</string>
+	</array>
 </dict>
 </plist>

--- a/ios/SelectTokenIntent/SelectTokenIntent.entitlements
+++ b/ios/SelectTokenIntent/SelectTokenIntent.entitlements
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.application-groups</key>
-	<array/>
+	<array>
+		<string>group.rainbow.me</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)me.rainbow.sharedItems</string>

--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -2,6 +2,7 @@ import analytics from '@segment/analytics-react-native';
 import { Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { updateLanguageLocale } from '../languages';
+import { saveString } from '../model/keychain';
 import { NativeCurrencyKeys } from '@rainbow-me/entities';
 import {
   getLanguage,
@@ -16,7 +17,6 @@ import {
 import { web3SetHttpProvider } from '@rainbow-me/handlers/web3';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import { dataResetState } from '@rainbow-me/redux/data';
-import { saveString } from '../model/keychain';
 import { explorerClearState, explorerInit } from '@rainbow-me/redux/explorer';
 import { AppState } from '@rainbow-me/redux/store';
 import { ethereumUtils } from '@rainbow-me/utils';

--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -16,6 +16,7 @@ import {
 import { web3SetHttpProvider } from '@rainbow-me/handlers/web3';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import { dataResetState } from '@rainbow-me/redux/data';
+import { saveString } from '../model/keychain';
 import { explorerClearState, explorerInit } from '@rainbow-me/redux/explorer';
 import { AppState } from '@rainbow-me/redux/store';
 import { ethereumUtils } from '@rainbow-me/utils';
@@ -214,6 +215,10 @@ export const settingsChangeNativeCurrency = (nativeCurrency: string) => async (
     });
     dispatch(explorerInit());
     saveNativeCurrency(nativeCurrency);
+    saveString('nativeCurrency', nativeCurrency, {
+      accessGroup: 'group.rainbow.me',
+      service: 'rainbow.me.currency',
+    });
     analytics.identify(null, { currency: nativeCurrency });
   } catch (error) {
     logger.log('Error changing native currency', error);


### PR DESCRIPTION
Fixes RNBW-2596

## What changed (plus any additional context for devs)
- widgets were unable to get currency setting from rainbow app. this rendered "default currency" option useless.

## PoW (screenshots / screen recordings)
https://user-images.githubusercontent.com/15272675/158868680-1cff93b3-8b7c-4a2d-a5dc-5e62efbb1485.MP4

## Dev checklist for QA: what to test
- make sure that widget's default currency option works, and switches immediately after the user changes the currency setting in the app.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
