### PR TITLE
Repeat hiding CloseBtn in WyreWebview

### DIFF
--- a/src/screens/WyreWebview.js
+++ b/src/screens/WyreWebview.js
@@ -50,7 +50,9 @@ export default function WyreWebview() {
       {url ? (
         <StyledWebView
           injectedJavaScript={`
-            document.getElementsByClassName('CloseBtn')[0].style.display = 'none';
+            setInterval(() => {
+              document.getElementsByClassName('CloseBtn')[0].style.display = 'none';          
+            }, 10);
             setTimeout(() => {
               document.getElementById('amount').style.width = '${defaultInputWidth}px';
               document.getElementsByName('termsAndConditions')[0].click();


### PR DESCRIPTION
Fixes RNBW-2674

## What changed (plus any additional context for devs)

instead of removing the button once, we remove this in intervals to make it not possible to press it at any time 

## PoW (screenshots / screen recordings)
before: https://streamable.com/6u0v4j
after: https://streamable.com/le8tgi

## Dev checklist for QA: what to test
Try to repro the bug from the first recording 

