### PR TITLE
Fix jelly selector on Android

### DIFF
--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.js
@@ -168,6 +168,7 @@ const SimpleScaleButton = ({
   onLongPressEnded,
   shouldLongPressHoldPress,
   isLongPress,
+  onLayout,
   onPress,
   overflowMargin,
   scaleTo,
@@ -190,6 +191,7 @@ const SimpleScaleButton = ({
 
   return (
     <View
+      onLayout={onLayout}
       style={[
         {
           backgroundColor,
@@ -246,6 +248,7 @@ export default function ButtonPressAnimation({
   duration = 160,
   hitSlop,
   minLongPressDuration = 500,
+  onLayout,
   onLongPress,
   onLongPressEnded,
   shouldLongPressHoldPress,
@@ -268,7 +271,9 @@ export default function ButtonPressAnimation({
 
   const ButtonElement = reanimatedButton ? ScaleButton : SimpleScaleButton;
   return disabled ? (
-    <Content style={style}>{children}</Content>
+    <Content onLayout={onLayout} style={style}>
+      {children}
+    </Content>
   ) : (
     <ButtonElement
       backgroundColor={backgroundColor}
@@ -278,6 +283,7 @@ export default function ButtonPressAnimation({
       hitSlop={hitSlop}
       isLongPress={!!onLongPress}
       minLongPressDuration={minLongPressDuration}
+      onLayout={onLayout}
       onLongPress={onLongPress}
       onLongPressEnded={onLongPressEnded}
       onPress={onPress}

--- a/src/components/jelly-selector/JellySelector.js
+++ b/src/components/jelly-selector/JellySelector.js
@@ -81,7 +81,7 @@ const JellySelector = ({
       setSelectorVisible(true);
 
       positions[index] = Math.floor(itemX) - Math.floor(itemWidth / 2);
-      widths[index] = Math.floor(itemWidth);
+      widths[index] = Math.ceil(itemWidth);
       calculatedItemWidths++;
 
       if (items.length === calculatedItemWidths) {


### PR DESCRIPTION
Fixes RNBW-1521

## What changed (plus any additional context for devs)

it works. `onLayout` as not working with BPA on android. 


## PoW (screenshots / screen recordings)

<img width="354" alt="image" src="https://user-images.githubusercontent.com/25709300/159333763-9ac23147-6704-40d1-834e-c59fc1d5beab.png">


## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
