### PR TITLE
[RNBW-2458][RNBW-2140][RNBW-2873] UI is mixing up my wallet balances

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1039,7 +1039,9 @@ export const addressAssetsReceived = (
 ) => {
   const isValidMeta = dispatch(checkMeta(message));
   if (!isValidMeta) return;
-  const { accountAddress, network } = getState().settings;
+  const { settings } = getState();
+  const { network } = settings;
+  const accountAddress = message?.meta?.address || settings.accountAddress;
   const { uniqueTokens } = getState().uniqueTokens;
   const newAssets = message?.payload?.assets ?? {};
   let updatedAssets = pickBy(


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We now make sure to use the account address received in the response when persisting asset data.

## Dev checklist for QA: what to test
You will need to watch a wallet with a lot of tokens in it (dame.eth worked well for me). Then quickly switch back and forth on the wallet screen between the heavy wallet and a nearly empty one. In prod you will eventually see assets from the heavy wallet make their way onto the other wallet's screen.
## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
