### PR TITLE
Revert "round last sale price"

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -232,11 +232,7 @@ const UniqueTokenExpandedState = ({
     usePersistentDominantColorFromImage(asset.image_url).result ||
     colors.paleBlue;
 
-  const lastSalePrice = lastPrice
-    ? `${Number(parseFloat(lastPrice.split(' ')[0]).toPrecision(2))} ${
-        lastPrice.split(' ')[1]
-      }`
-    : 'None';
+  const lastSalePrice = lastPrice || 'None';
   const priceOfEth = ethereumUtils.getEthPriceUnit() as number;
 
   const textColor = useMemo(() => {


### PR DESCRIPTION
Reverts rainbow-me/rainbow#3024

after talking with @osdnk we decided there's too much inconsistency with this logic to display correct pricing.

<img width="501" alt="image" src="https://user-images.githubusercontent.com/6843656/159495222-9107e726-1ce0-411b-b033-9c118eab777e.png">

![image](https://user-images.githubusercontent.com/6843656/159495246-efa537e9-0146-4c0f-a9b6-3d0ce872c6d3.png)
