### PR TITLE
Profiles: Handle image picker permissions

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,3 @@
 export * from './debug';
 export * from './experimental';
 export { default as useExperimentalFlag } from './experimentalHooks';
-

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -139,3 +139,4 @@ export {
 } from './useHardwareBack';
 export { default as useUniswapCurrencyList } from './useUniswapCurrencyList';
 export { default as useWalletENSAvatar } from './useWalletENSAvatar';
+export { default as useImagePicker } from './useImagePicker';

--- a/src/hooks/useImagePicker.tsx
+++ b/src/hooks/useImagePicker.tsx
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { Linking } from 'react-native';
+import ImagePicker, { Options } from 'react-native-image-crop-picker';
+import { Alert } from '../components/alerts';
+
+export default function useImagePicker() {
+  const openPicker = useCallback(async (options: Options) => {
+    let image = null;
+    try {
+      image = await ImagePicker.openPicker(options);
+    } catch (e: any) {
+      if (e?.message === 'User did not grant library permission.') {
+        Alert({
+          buttons: [
+            { style: 'cancel', text: 'Cancel' },
+            { onPress: Linking.openSettings, text: 'Enable library access' },
+          ],
+          message: 'This allows Rainbow to use your photos from your library',
+          title: 'Allow to access your photos',
+        });
+      }
+    }
+    return image;
+  }, []);
+
+  return {
+    openPicker,
+  };
+}

--- a/src/hooks/useImagePicker.tsx
+++ b/src/hooks/useImagePicker.tsx
@@ -1,3 +1,4 @@
+import lang from 'i18n-js';
 import { useCallback } from 'react';
 import { Linking } from 'react-native';
 import ImagePicker, { Options } from 'react-native-image-crop-picker';
@@ -12,11 +13,14 @@ export default function useImagePicker() {
       if (e?.message === 'User did not grant library permission.') {
         Alert({
           buttons: [
-            { style: 'cancel', text: 'Cancel' },
-            { onPress: Linking.openSettings, text: 'Enable library access' },
+            { style: 'cancel', text: lang.t('image_picker.cancel') },
+            {
+              onPress: Linking.openSettings,
+              text: lang.t('image_picker.confirm'),
+            },
           ],
-          message: 'This allows Rainbow to use your photos from your library',
-          title: 'Allow to access your photos',
+          message: lang.t('image_picker.message'),
+          title: lang.t('image_picker.title'),
         });
       }
     }

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -1,16 +1,19 @@
 import { toLower } from 'lodash';
 import { useCallback, useMemo } from 'react';
 import { Linking } from 'react-native';
-import ImagePicker from 'react-native-image-crop-picker';
 import { useDispatch } from 'react-redux';
 import { RainbowAccount } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
 import useAccountProfile from './useAccountProfile';
-import { enableActionsOnReadOnlyWallet } from '@rainbow-me/config';
 import useENSProfile from './useENSProfile';
+import useImagePicker from './useImagePicker';
 import useUpdateEmoji from './useUpdateEmoji';
 import useWallets from './useWallets';
-import { PROFILES, useExperimentalFlag } from '@rainbow-me/config';
+import {
+  enableActionsOnReadOnlyWallet,
+  PROFILES,
+  useExperimentalFlag,
+} from '@rainbow-me/config';
 import { walletsSetSelected, walletsUpdate } from '@rainbow-me/redux/wallets';
 import Routes from '@rainbow-me/routes';
 import { buildRainbowUrl, showActionSheetWithOptions } from '@rainbow-me/utils';
@@ -30,6 +33,7 @@ export default () => {
   const ensProfile = useENSProfile(accountENS, {
     enabled: Boolean(accountENS),
   });
+  const { openPicker } = useImagePicker();
 
   const onAvatarRemovePhoto = useCallback(async () => {
     const newWallets = {
@@ -80,12 +84,13 @@ export default () => {
     });
   }, [accountColor, accountName, navigate]);
 
-  const onAvatarChooseImage = useCallback(() => {
-    ImagePicker.openPicker({
+  const onAvatarChooseImage = useCallback(async () => {
+    const image = await openPicker({
       cropperCircleOverlay: true,
       cropping: true,
-    }).then(processPhoto);
-  }, [processPhoto]);
+    });
+    processPhoto(image);
+  }, [openPicker, processPhoto]);
 
   const onAvatarCreateProfile = useCallback(() => {
     navigate(Routes.REGISTER_ENS_NAVIGATOR);

--- a/src/hooks/useSelectImageMenu.tsx
+++ b/src/hooks/useSelectImageMenu.tsx
@@ -1,8 +1,9 @@
 import lang from 'i18n-js';
 import React, { useCallback } from 'react';
-import ImagePicker, { Image, Options } from 'react-native-image-crop-picker';
+import { Image, Options } from 'react-native-image-crop-picker';
 import { ContextMenuButton } from 'react-native-ios-context-menu';
 import { useMutation } from 'react-query';
+import { useImagePicker } from '.';
 import { UniqueAsset } from '@rainbow-me/entities';
 import {
   uploadImage,
@@ -67,18 +68,19 @@ export default function useSelectImageMenu({
   uploadToIPFS?: boolean;
 } = {}) {
   const { navigate } = useNavigation();
-
+  const { openPicker } = useImagePicker();
   const { isLoading: isUploading, mutateAsync: upload } = useMutation(
     'ensImageUpload',
     uploadImage
   );
 
   const handleSelectImage = useCallback(async () => {
-    const image = await ImagePicker.openPicker({
+    const image = await openPicker({
       ...imagePickerOptions,
       includeBase64: true,
       mediaType: 'photo',
     });
+    if (!image) return;
     const stringIndex = image?.path.indexOf('/tmp');
     const tmpPath = `~${image?.path.slice(stringIndex)}`;
 
@@ -103,6 +105,7 @@ export default function useSelectImageMenu({
     onUploadError,
     onUploadSuccess,
     onUploading,
+    openPicker,
     upload,
     uploadToIPFS,
   ]);

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -441,6 +441,12 @@
       "private_key": "Private Key",
       "recipient_address": "Recipient Address"
     },
+    "image_picker": {
+      "title": "Allow to access your photos",
+      "message": "This allows Rainbow to use your photos from your library",
+      "confirm": "Enable library access",
+      "cancel": "Cancel"
+    },
     "message": {
       "click_to_copy_to_clipboard": "Click to copy to clipboard",
       "coming_soon": "Coming soon...",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -442,7 +442,7 @@
       "recipient_address": "Recipient Address"
     },
     "image_picker": {
-      "title": "Allow to access your photos",
+      "title": "Rainbow would like to access your photos",
       "message": "This allows Rainbow to use your photos from your library",
       "confirm": "Enable library access",
       "cancel": "Cancel"


### PR DESCRIPTION
Fixes RNBW-2742

## What changed (plus any additional context for devs)

Added a hook in charge of open the image picker, if there are no permission because user rejected it, it will show an alert directing them to settings

## PoW (screenshots / screen recordings)

https://www.loom.com/share/8d73b52c7b544a1e9b41b9a8f6361773

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
