### PR TITLE
Fix blank charts

### DIFF
--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -23,7 +23,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { getYForX } from 'react-native-redash';
 import Svg, { Path, PathProps } from 'react-native-svg';
-import { PathData } from '../../helpers/ChartContext';
+import { ChartData, PathData } from '../../helpers/ChartContext';
 import {
   requireOnWorklet,
   useWorkletValue,
@@ -106,6 +106,292 @@ function positionXWithMargin(x: number, margin: number, width: number) {
   }
 }
 
+const ChartPathInner = ({
+  hapticsEnabled,
+  hitSlop,
+  width,
+  height,
+  stroke,
+  selectedStrokeWidth,
+  strokeWidth,
+  gestureEnabled,
+  selectedOpacity,
+  timingFeedbackConfig,
+  timingAnimationConfig,
+  longPressGestureHandlerProps,
+  positionX,
+  positionY,
+  originalX,
+  originalY,
+  state,
+  isActive,
+  progress,
+  pathOpacity,
+  currentPath,
+  previousPath,
+  ...props
+}: ChartPathProps & Omit<ChartData, 'data' | 'dotScale'>) => {
+  const interpolatorWorklet = useWorkletValue();
+
+  const translationX = useSharedValue<number | null>(null);
+  const translationY = useSharedValue<number | null>(null);
+
+  const setOriginData = useWorkletCallback((path: PathData, index?: number) => {
+    if (!path.data.length) {
+      return;
+    }
+
+    if (typeof index === 'undefined') {
+      originalX.value = '';
+      originalY.value = '';
+      return;
+    }
+
+    originalX.value = path.data[index].x.toString();
+    originalY.value = path.data[index].y.toString();
+  }, []);
+
+  const resetGestureState = useWorkletCallback(() => {
+    originalX.value = '';
+    originalY.value = '';
+    positionY.value = -1;
+    isActive.value = false;
+    pathOpacity.value = withTiming(
+      1,
+      timingFeedbackConfig || timingFeedbackDefaultConfig
+    );
+    translationX.value = null;
+    translationY.value = null;
+  }, []);
+
+  useEffect(() => {
+    runOnUI(() => {
+      'worklet';
+      if (currentPath) {
+        setOriginData(currentPath);
+      }
+
+      if (currentPath?.path === previousPath?.path) {
+        return;
+      }
+
+      if (progress.value !== 0 && progress.value !== 1) {
+        cancelAnimation(progress);
+      }
+
+      // this stores an instance of d3-interpolate-path on worklet side
+      // it means that we don't cross threads with that function
+      // which makes it super fast
+      if (previousPath && currentPath) {
+        const d3Interpolate = requireOnWorklet('d3-interpolate-path');
+
+        interpolatorWorklet().value = d3Interpolate.interpolatePath(
+          previousPath.path,
+          currentPath.path
+        );
+
+        progress.value = 0;
+
+        progress.value = withDelay(
+          Platform.OS === 'ios' ? 0 : 100,
+          withTiming(1, timingAnimationConfig || timingAnimationDefaultConfig)
+        );
+      } else {
+        interpolatorWorklet().value = undefined;
+        progress.value = 1;
+      }
+    })();
+    // you don't need to change timingAnimationConfig that often
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPath?.path, previousPath?.path]);
+
+  useAnimatedReaction(
+    () => ({ x: translationX.value, y: translationY.value }),
+    values => {
+      if (
+        !currentPath ||
+        !currentPath.parsed ||
+        progress.value === 0 ||
+        values.x === null ||
+        values.y === null
+      ) {
+        return;
+      }
+
+      const yForX = getYForX(currentPath.parsed, Math.floor(values.x));
+
+      if (yForX !== null) {
+        positionY.value = yForX;
+      }
+
+      positionX.value = values.x;
+
+      // refer to this article for more details about this code
+      // https://observablehq.com/@d3/multi-line-chart
+      const index = least(currentPath.points.length, i => {
+        if (typeof i === 'undefined' || values.x === null) {
+          return 0;
+        }
+
+        return Math.abs(currentPath.points[i].x - values.x);
+      });
+
+      const pointX = currentPath.points[index]?.originalX;
+
+      let adjustedPointX = pointX;
+      if (currentPath.points[index].x > values.x) {
+        const prevPointOriginalX = currentPath.points[index - 1]?.originalX;
+        if (prevPointOriginalX) {
+          const distance =
+            (currentPath.points[index].x - values.x) /
+            (currentPath.points[index].x - currentPath.points[index - 1].x);
+          adjustedPointX =
+            prevPointOriginalX * distance + pointX * (1 - distance);
+        }
+      } else {
+        const nextPointOriginalX = currentPath.points[index + 1]?.originalX;
+        if (nextPointOriginalX) {
+          const distance =
+            (values.x - currentPath.points[index].x) /
+            (currentPath.points[index + 1].x - currentPath.points[index].x);
+          adjustedPointX =
+            nextPointOriginalX * distance + pointX * (1 - distance);
+        }
+      }
+
+      const dataIndex = least(currentPath.data.length, i => {
+        if (typeof i === 'undefined' || values.x === null) {
+          return 0;
+        }
+
+        return Math.abs(currentPath.data[i].x - adjustedPointX);
+      });
+
+      setOriginData(currentPath, dataIndex);
+    },
+    [currentPath]
+  );
+
+  const animatedProps = useAnimatedProps(() => {
+    const props: PathProps & ViewProps = {};
+
+    if (!currentPath) {
+      return {
+        d: '',
+      };
+    }
+
+    props.d = interpolatorWorklet().value
+      ? interpolatorWorklet().value(progress.value)
+      : currentPath.path;
+
+    props.strokeWidth =
+      pathOpacity.value * (Number(strokeWidth) - Number(selectedStrokeWidth)) +
+      Number(selectedStrokeWidth);
+
+    if (Platform.OS === 'ios') {
+      props.style = {
+        opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
+      };
+    }
+
+    return props;
+  }, [currentPath]);
+
+  const onGestureEvent = useAnimatedGestureHandler<LongPressGestureHandlerGestureEvent>(
+    {
+      onActive: event => {
+        if (!isActive.value) {
+          isActive.value = true;
+
+          pathOpacity.value = withTiming(
+            0,
+            timingFeedbackConfig || timingFeedbackDefaultConfig
+          );
+
+          if (hapticsEnabled) {
+            impactHeavy();
+          }
+        }
+
+        state.value = event.state;
+        translationX.value = positionXWithMargin(event.x, hitSlop, width);
+        translationY.value = event.y;
+      },
+      onCancel: event => {
+        state.value = event.state;
+        resetGestureState();
+      },
+      onEnd: event => {
+        state.value = event.state;
+        resetGestureState();
+
+        if (hapticsEnabled) {
+          impactHeavy();
+        }
+      },
+      onFail: event => {
+        state.value = event.state;
+        resetGestureState();
+      },
+      onStart: event => {
+        // WARNING: the following code does not run on using iOS, but it does on Android.
+        // I use the same code from onActive
+        // platform is for safety
+        if (Platform.OS === 'android') {
+          state.value = event.state;
+          isActive.value = true;
+          pathOpacity.value = withTiming(
+            0,
+            timingFeedbackConfig || timingFeedbackDefaultConfig
+          );
+
+          if (hapticsEnabled) {
+            impactHeavy();
+          }
+        }
+      },
+    },
+    [width, height, hapticsEnabled, hitSlop, timingFeedbackConfig]
+  );
+
+  const pathAnimatedStyles = useAnimatedStyle(() => {
+    return {
+      opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
+    };
+  });
+
+  return (
+    <LongPressGestureHandler
+      enabled={gestureEnabled}
+      maxDist={100000}
+      minDurationMs={0}
+      onGestureEvent={onGestureEvent}
+      shouldCancelWhenOutside={false}
+      {...longPressGestureHandlerProps}
+    >
+      <Animated.View>
+        <Svg
+          style={{
+            height: height + FIX_CLIPPED_PATH_MAGIC_NUMBER,
+            width,
+          }}
+          viewBox={`0 0 ${width} ${height}`}
+        >
+          <AnimatedPath
+            // @ts-expect-error
+            animatedProps={animatedProps}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            style={pathAnimatedStyles}
+            {...props}
+          />
+        </Svg>
+      </Animated.View>
+    </LongPressGestureHandler>
+  );
+};
+
 export const ChartPath = React.memo(
   ({
     hapticsEnabled,
@@ -135,268 +421,45 @@ export const ChartPath = React.memo(
       previousPath,
     } = useChartData();
 
-    const interpolatorWorklet = useWorkletValue();
+    let renderPath = null;
 
-    const translationX = useSharedValue<number | null>(null);
-    const translationY = useSharedValue<number | null>(null);
-
-    const setOriginData = useWorkletCallback(
-      (path: PathData, index?: number) => {
-        if (!path.data.length) {
-          return;
-        }
-
-        if (typeof index === 'undefined') {
-          originalX.value = '';
-          originalY.value = '';
-          return;
-        }
-
-        originalX.value = path.data[index].x.toString();
-        originalY.value = path.data[index].y.toString();
-      },
-      []
-    );
-
-    const resetGestureState = useWorkletCallback(() => {
-      originalX.value = '';
-      originalY.value = '';
-      positionY.value = -1;
-      isActive.value = false;
-      pathOpacity.value = withTiming(
-        1,
-        timingFeedbackConfig || timingFeedbackDefaultConfig
+    // this is workaround to avoid unnecessary rerenders of the path component
+    // and sometimes blank SvgPath the currentPath's path string is empty
+    // due to some broken logic in the Rainbow app
+    if (currentPath?.path) {
+      renderPath = (
+        <ChartPathInner
+          {...{
+            ...props,
+            currentPath,
+            gestureEnabled,
+            hapticsEnabled,
+            height,
+            hitSlop,
+            isActive,
+            longPressGestureHandlerProps,
+            originalX,
+            originalY,
+            pathOpacity,
+            positionX,
+            positionY,
+            previousPath,
+            progress,
+            selectedOpacity,
+            selectedStrokeWidth,
+            state,
+            stroke,
+            strokeWidth,
+            timingAnimationConfig,
+            timingFeedbackConfig,
+            width,
+          }}
+        />
       );
-      translationX.value = null;
-      translationY.value = null;
-    }, []);
+    }
 
-    useEffect(() => {
-      runOnUI(() => {
-        'worklet';
-        if (currentPath) {
-          setOriginData(currentPath);
-        }
-
-        if (currentPath?.path === previousPath?.path) {
-          return;
-        }
-
-        if (progress.value !== 0 && progress.value !== 1) {
-          cancelAnimation(progress);
-        }
-
-        // this stores an instance of d3-interpolate-path on worklet side
-        // it means that we don't cross threads with that function
-        // which makes it super fast
-        if (previousPath && currentPath) {
-          const d3Interpolate = requireOnWorklet('d3-interpolate-path');
-
-          interpolatorWorklet().value = d3Interpolate.interpolatePath(
-            previousPath.path,
-            currentPath.path
-          );
-
-          progress.value = 0;
-
-          progress.value = withDelay(
-            Platform.OS === 'ios' ? 0 : 100,
-            withTiming(1, timingAnimationConfig || timingAnimationDefaultConfig)
-          );
-        } else {
-          interpolatorWorklet().value = undefined;
-          progress.value = 1;
-        }
-      })();
-      // you don't need to change timingAnimationConfig that often
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [currentPath?.path, previousPath?.path]);
-
-    useAnimatedReaction(
-      () => ({ x: translationX.value, y: translationY.value }),
-      values => {
-        if (
-          !currentPath ||
-          !currentPath.parsed ||
-          progress.value === 0 ||
-          values.x === null ||
-          values.y === null
-        ) {
-          return;
-        }
-
-        const yForX = getYForX(currentPath.parsed, Math.floor(values.x));
-
-        if (yForX !== null) {
-          positionY.value = yForX;
-        }
-
-        positionX.value = values.x;
-
-        // refer to this article for more details about this code
-        // https://observablehq.com/@d3/multi-line-chart
-        const index = least(currentPath.points.length, i => {
-          if (typeof i === 'undefined' || values.x === null) {
-            return 0;
-          }
-
-          return Math.abs(currentPath.points[i].x - values.x);
-        });
-
-        const pointX = currentPath.points[index]?.originalX;
-
-        let adjustedPointX = pointX;
-        if (currentPath.points[index].x > values.x) {
-          const prevPointOriginalX = currentPath.points[index - 1]?.originalX;
-          if (prevPointOriginalX) {
-            const distance =
-              (currentPath.points[index].x - values.x) /
-              (currentPath.points[index].x - currentPath.points[index - 1].x);
-            adjustedPointX =
-              prevPointOriginalX * distance + pointX * (1 - distance);
-          }
-        } else {
-          const nextPointOriginalX = currentPath.points[index + 1]?.originalX;
-          if (nextPointOriginalX) {
-            const distance =
-              (values.x - currentPath.points[index].x) /
-              (currentPath.points[index + 1].x - currentPath.points[index].x);
-            adjustedPointX =
-              nextPointOriginalX * distance + pointX * (1 - distance);
-          }
-        }
-
-        const dataIndex = least(currentPath.data.length, i => {
-          if (typeof i === 'undefined' || values.x === null) {
-            return 0;
-          }
-
-          return Math.abs(currentPath.data[i].x - adjustedPointX);
-        });
-
-        setOriginData(currentPath, dataIndex);
-      },
-      [currentPath]
-    );
-
-    const animatedProps = useAnimatedProps(() => {
-      const props: PathProps & ViewProps = {};
-
-      if (!currentPath) {
-        return {
-          d: '',
-        };
-      }
-
-      props.d = interpolatorWorklet().value
-        ? interpolatorWorklet().value(progress.value)
-        : currentPath.path;
-
-      props.strokeWidth =
-        pathOpacity.value *
-          (Number(strokeWidth) - Number(selectedStrokeWidth)) +
-        Number(selectedStrokeWidth);
-
-      if (Platform.OS === 'ios') {
-        props.style = {
-          opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
-        };
-      }
-
-      return props;
-    }, [currentPath]);
-
-    const onGestureEvent = useAnimatedGestureHandler<LongPressGestureHandlerGestureEvent>(
-      {
-        onActive: event => {
-          if (!isActive.value) {
-            isActive.value = true;
-
-            pathOpacity.value = withTiming(
-              0,
-              timingFeedbackConfig || timingFeedbackDefaultConfig
-            );
-
-            if (hapticsEnabled) {
-              impactHeavy();
-            }
-          }
-
-          state.value = event.state;
-          translationX.value = positionXWithMargin(event.x, hitSlop, width);
-          translationY.value = event.y;
-        },
-        onCancel: event => {
-          state.value = event.state;
-          resetGestureState();
-        },
-        onEnd: event => {
-          state.value = event.state;
-          resetGestureState();
-
-          if (hapticsEnabled) {
-            impactHeavy();
-          }
-        },
-        onFail: event => {
-          state.value = event.state;
-          resetGestureState();
-        },
-        onStart: event => {
-          // WARNING: the following code does not run on using iOS, but it does on Android.
-          // I use the same code from onActive
-          // platform is for safety
-          if (Platform.OS === 'android') {
-            state.value = event.state;
-            isActive.value = true;
-            pathOpacity.value = withTiming(
-              0,
-              timingFeedbackConfig || timingFeedbackDefaultConfig
-            );
-
-            if (hapticsEnabled) {
-              impactHeavy();
-            }
-          }
-        },
-      },
-      [width, height, hapticsEnabled, hitSlop, timingFeedbackConfig]
-    );
-
-    const pathAnimatedStyles = useAnimatedStyle(() => ({
-      opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
-    }));
-
-    return (
-      <View style={{ height, width }}>
-        <LongPressGestureHandler
-          enabled={gestureEnabled}
-          maxDist={100000}
-          minDurationMs={0}
-          onGestureEvent={onGestureEvent}
-          shouldCancelWhenOutside={false}
-          {...longPressGestureHandlerProps}
-        >
-          <Animated.View>
-            <Svg
-              style={{
-                height: height + FIX_CLIPPED_PATH_MAGIC_NUMBER,
-                width,
-              }}
-              viewBox={`0 0 ${width} ${height}`}
-            >
-              <AnimatedPath
-                // @ts-expect-error
-                animatedProps={animatedProps}
-                stroke={stroke}
-                strokeWidth={strokeWidth}
-                style={pathAnimatedStyles}
-                {...props}
-              />
-            </Svg>
-          </Animated.View>
-        </LongPressGestureHandler>
-      </View>
-    );
+    return <View style={{ height, width }}>{renderPath}</View>;
   }
 );
+
+ChartPath.displayName = 'ChartPath';

--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -107,15 +107,17 @@ function positionXWithMargin(x: number, margin: number, width: number) {
 }
 
 const ChartPathInner = ({
+  hitSlop = 0,
+  stroke = 'black',
+  selectedStrokeWidth = 1,
+  strokeWidth = 1,
+  gestureEnabled = true,
+  selectedOpacity = 0.7,
   hapticsEnabled,
-  hitSlop,
+
   width,
   height,
-  stroke,
-  selectedStrokeWidth,
-  strokeWidth,
-  gestureEnabled,
-  selectedOpacity,
+
   timingFeedbackConfig,
   timingAnimationConfig,
   longPressGestureHandlerProps,
@@ -395,14 +397,14 @@ const ChartPathInner = ({
 export const ChartPath = React.memo(
   ({
     hapticsEnabled,
-    hitSlop = 0,
     width,
     height,
-    stroke = 'black',
-    selectedStrokeWidth = 1,
-    strokeWidth = 1,
-    gestureEnabled = true,
-    selectedOpacity = 0.7,
+    hitSlop,
+    stroke,
+    selectedStrokeWidth,
+    strokeWidth,
+    gestureEnabled,
+    selectedOpacity,
     timingFeedbackConfig,
     timingAnimationConfig,
     longPressGestureHandlerProps = {},

--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -106,293 +106,297 @@ function positionXWithMargin(x: number, margin: number, width: number) {
   }
 }
 
-const ChartPathInner = ({
-  hitSlop = 0,
-  stroke = 'black',
-  selectedStrokeWidth = 1,
-  strokeWidth = 1,
-  gestureEnabled = true,
-  selectedOpacity = 0.7,
-  hapticsEnabled,
+const ChartPathInner = React.memo(
+  ({
+    hitSlop = 0,
+    stroke = 'black',
+    selectedStrokeWidth = 1,
+    strokeWidth = 1,
+    gestureEnabled = true,
+    selectedOpacity = 0.7,
+    hapticsEnabled,
+    width,
+    height,
+    timingFeedbackConfig,
+    timingAnimationConfig,
+    longPressGestureHandlerProps,
+    positionX,
+    positionY,
+    originalX,
+    originalY,
+    state,
+    isActive,
+    progress,
+    pathOpacity,
+    currentPath,
+    previousPath,
+    ...props
+  }: ChartPathProps & Omit<ChartData, 'data' | 'dotScale'>) => {
+    const interpolatorWorklet = useWorkletValue();
 
-  width,
-  height,
+    const translationX = useSharedValue<number | null>(null);
+    const translationY = useSharedValue<number | null>(null);
 
-  timingFeedbackConfig,
-  timingAnimationConfig,
-  longPressGestureHandlerProps,
-  positionX,
-  positionY,
-  originalX,
-  originalY,
-  state,
-  isActive,
-  progress,
-  pathOpacity,
-  currentPath,
-  previousPath,
-  ...props
-}: ChartPathProps & Omit<ChartData, 'data' | 'dotScale'>) => {
-  const interpolatorWorklet = useWorkletValue();
+    const setOriginData = useWorkletCallback(
+      (path: PathData, index?: number) => {
+        if (!path.data.length) {
+          return;
+        }
 
-  const translationX = useSharedValue<number | null>(null);
-  const translationY = useSharedValue<number | null>(null);
+        if (typeof index === 'undefined') {
+          originalX.value = '';
+          originalY.value = '';
+          return;
+        }
 
-  const setOriginData = useWorkletCallback((path: PathData, index?: number) => {
-    if (!path.data.length) {
-      return;
-    }
+        originalX.value = path.data[index].x.toString();
+        originalY.value = path.data[index].y.toString();
+      },
+      []
+    );
 
-    if (typeof index === 'undefined') {
+    const resetGestureState = useWorkletCallback(() => {
       originalX.value = '';
       originalY.value = '';
-      return;
-    }
+      positionY.value = -1;
+      isActive.value = false;
+      pathOpacity.value = withTiming(
+        1,
+        timingFeedbackConfig || timingFeedbackDefaultConfig
+      );
+      translationX.value = null;
+      translationY.value = null;
+    }, []);
 
-    originalX.value = path.data[index].x.toString();
-    originalY.value = path.data[index].y.toString();
-  }, []);
+    useEffect(() => {
+      runOnUI(() => {
+        'worklet';
+        if (currentPath) {
+          setOriginData(currentPath);
+        }
 
-  const resetGestureState = useWorkletCallback(() => {
-    originalX.value = '';
-    originalY.value = '';
-    positionY.value = -1;
-    isActive.value = false;
-    pathOpacity.value = withTiming(
-      1,
-      timingFeedbackConfig || timingFeedbackDefaultConfig
+        if (currentPath?.path === previousPath?.path) {
+          return;
+        }
+
+        if (progress.value !== 0 && progress.value !== 1) {
+          cancelAnimation(progress);
+        }
+
+        // this stores an instance of d3-interpolate-path on worklet side
+        // it means that we don't cross threads with that function
+        // which makes it super fast
+        if (previousPath && currentPath) {
+          const d3Interpolate = requireOnWorklet('d3-interpolate-path');
+
+          interpolatorWorklet().value = d3Interpolate.interpolatePath(
+            previousPath.path,
+            currentPath.path
+          );
+
+          progress.value = 0;
+
+          progress.value = withDelay(
+            Platform.OS === 'ios' ? 0 : 100,
+            withTiming(1, timingAnimationConfig || timingAnimationDefaultConfig)
+          );
+        } else {
+          interpolatorWorklet().value = undefined;
+          progress.value = 1;
+        }
+      })();
+      // you don't need to change timingAnimationConfig that often
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentPath?.path, previousPath?.path]);
+
+    useAnimatedReaction(
+      () => ({ x: translationX.value, y: translationY.value }),
+      values => {
+        if (
+          !currentPath ||
+          !currentPath.parsed ||
+          progress.value === 0 ||
+          values.x === null ||
+          values.y === null
+        ) {
+          return;
+        }
+
+        const yForX = getYForX(currentPath.parsed, Math.floor(values.x));
+
+        if (yForX !== null) {
+          positionY.value = yForX;
+        }
+
+        positionX.value = values.x;
+
+        // refer to this article for more details about this code
+        // https://observablehq.com/@d3/multi-line-chart
+        const index = least(currentPath.points.length, i => {
+          if (typeof i === 'undefined' || values.x === null) {
+            return 0;
+          }
+
+          return Math.abs(currentPath.points[i].x - values.x);
+        });
+
+        const pointX = currentPath.points[index]?.originalX;
+
+        let adjustedPointX = pointX;
+        if (currentPath.points[index].x > values.x) {
+          const prevPointOriginalX = currentPath.points[index - 1]?.originalX;
+          if (prevPointOriginalX) {
+            const distance =
+              (currentPath.points[index].x - values.x) /
+              (currentPath.points[index].x - currentPath.points[index - 1].x);
+            adjustedPointX =
+              prevPointOriginalX * distance + pointX * (1 - distance);
+          }
+        } else {
+          const nextPointOriginalX = currentPath.points[index + 1]?.originalX;
+          if (nextPointOriginalX) {
+            const distance =
+              (values.x - currentPath.points[index].x) /
+              (currentPath.points[index + 1].x - currentPath.points[index].x);
+            adjustedPointX =
+              nextPointOriginalX * distance + pointX * (1 - distance);
+          }
+        }
+
+        const dataIndex = least(currentPath.data.length, i => {
+          if (typeof i === 'undefined' || values.x === null) {
+            return 0;
+          }
+
+          return Math.abs(currentPath.data[i].x - adjustedPointX);
+        });
+
+        setOriginData(currentPath, dataIndex);
+      },
+      [currentPath]
     );
-    translationX.value = null;
-    translationY.value = null;
-  }, []);
 
-  useEffect(() => {
-    runOnUI(() => {
-      'worklet';
-      if (currentPath) {
-        setOriginData(currentPath);
+    const animatedProps = useAnimatedProps(() => {
+      const props: PathProps & ViewProps = {};
+
+      if (!currentPath) {
+        return {
+          d: '',
+        };
       }
 
-      if (currentPath?.path === previousPath?.path) {
-        return;
+      props.d = interpolatorWorklet().value
+        ? interpolatorWorklet().value(progress.value)
+        : currentPath.path;
+
+      props.strokeWidth =
+        pathOpacity.value *
+          (Number(strokeWidth) - Number(selectedStrokeWidth)) +
+        Number(selectedStrokeWidth);
+
+      if (Platform.OS === 'ios') {
+        props.style = {
+          opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
+        };
       }
 
-      if (progress.value !== 0 && progress.value !== 1) {
-        cancelAnimation(progress);
-      }
+      return props;
+    }, [currentPath]);
 
-      // this stores an instance of d3-interpolate-path on worklet side
-      // it means that we don't cross threads with that function
-      // which makes it super fast
-      if (previousPath && currentPath) {
-        const d3Interpolate = requireOnWorklet('d3-interpolate-path');
+    const onGestureEvent = useAnimatedGestureHandler<LongPressGestureHandlerGestureEvent>(
+      {
+        onActive: event => {
+          if (!isActive.value) {
+            isActive.value = true;
 
-        interpolatorWorklet().value = d3Interpolate.interpolatePath(
-          previousPath.path,
-          currentPath.path
-        );
+            pathOpacity.value = withTiming(
+              0,
+              timingFeedbackConfig || timingFeedbackDefaultConfig
+            );
 
-        progress.value = 0;
+            if (hapticsEnabled) {
+              impactHeavy();
+            }
+          }
 
-        progress.value = withDelay(
-          Platform.OS === 'ios' ? 0 : 100,
-          withTiming(1, timingAnimationConfig || timingAnimationDefaultConfig)
-        );
-      } else {
-        interpolatorWorklet().value = undefined;
-        progress.value = 1;
-      }
-    })();
-    // you don't need to change timingAnimationConfig that often
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPath?.path, previousPath?.path]);
+          state.value = event.state;
+          translationX.value = positionXWithMargin(event.x, hitSlop, width);
+          translationY.value = event.y;
+        },
+        onCancel: event => {
+          state.value = event.state;
+          resetGestureState();
+        },
+        onEnd: event => {
+          state.value = event.state;
+          resetGestureState();
 
-  useAnimatedReaction(
-    () => ({ x: translationX.value, y: translationY.value }),
-    values => {
-      if (
-        !currentPath ||
-        !currentPath.parsed ||
-        progress.value === 0 ||
-        values.x === null ||
-        values.y === null
-      ) {
-        return;
-      }
+          if (hapticsEnabled) {
+            impactHeavy();
+          }
+        },
+        onFail: event => {
+          state.value = event.state;
+          resetGestureState();
+        },
+        onStart: event => {
+          // WARNING: the following code does not run on using iOS, but it does on Android.
+          // I use the same code from onActive
+          // platform is for safety
+          if (Platform.OS === 'android') {
+            state.value = event.state;
+            isActive.value = true;
+            pathOpacity.value = withTiming(
+              0,
+              timingFeedbackConfig || timingFeedbackDefaultConfig
+            );
 
-      const yForX = getYForX(currentPath.parsed, Math.floor(values.x));
+            if (hapticsEnabled) {
+              impactHeavy();
+            }
+          }
+        },
+      },
+      [width, height, hapticsEnabled, hitSlop, timingFeedbackConfig]
+    );
 
-      if (yForX !== null) {
-        positionY.value = yForX;
-      }
-
-      positionX.value = values.x;
-
-      // refer to this article for more details about this code
-      // https://observablehq.com/@d3/multi-line-chart
-      const index = least(currentPath.points.length, i => {
-        if (typeof i === 'undefined' || values.x === null) {
-          return 0;
-        }
-
-        return Math.abs(currentPath.points[i].x - values.x);
-      });
-
-      const pointX = currentPath.points[index]?.originalX;
-
-      let adjustedPointX = pointX;
-      if (currentPath.points[index].x > values.x) {
-        const prevPointOriginalX = currentPath.points[index - 1]?.originalX;
-        if (prevPointOriginalX) {
-          const distance =
-            (currentPath.points[index].x - values.x) /
-            (currentPath.points[index].x - currentPath.points[index - 1].x);
-          adjustedPointX =
-            prevPointOriginalX * distance + pointX * (1 - distance);
-        }
-      } else {
-        const nextPointOriginalX = currentPath.points[index + 1]?.originalX;
-        if (nextPointOriginalX) {
-          const distance =
-            (values.x - currentPath.points[index].x) /
-            (currentPath.points[index + 1].x - currentPath.points[index].x);
-          adjustedPointX =
-            nextPointOriginalX * distance + pointX * (1 - distance);
-        }
-      }
-
-      const dataIndex = least(currentPath.data.length, i => {
-        if (typeof i === 'undefined' || values.x === null) {
-          return 0;
-        }
-
-        return Math.abs(currentPath.data[i].x - adjustedPointX);
-      });
-
-      setOriginData(currentPath, dataIndex);
-    },
-    [currentPath]
-  );
-
-  const animatedProps = useAnimatedProps(() => {
-    const props: PathProps & ViewProps = {};
-
-    if (!currentPath) {
+    const pathAnimatedStyles = useAnimatedStyle(() => {
       return {
-        d: '',
-      };
-    }
-
-    props.d = interpolatorWorklet().value
-      ? interpolatorWorklet().value(progress.value)
-      : currentPath.path;
-
-    props.strokeWidth =
-      pathOpacity.value * (Number(strokeWidth) - Number(selectedStrokeWidth)) +
-      Number(selectedStrokeWidth);
-
-    if (Platform.OS === 'ios') {
-      props.style = {
         opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
       };
-    }
+    });
 
-    return props;
-  }, [currentPath]);
-
-  const onGestureEvent = useAnimatedGestureHandler<LongPressGestureHandlerGestureEvent>(
-    {
-      onActive: event => {
-        if (!isActive.value) {
-          isActive.value = true;
-
-          pathOpacity.value = withTiming(
-            0,
-            timingFeedbackConfig || timingFeedbackDefaultConfig
-          );
-
-          if (hapticsEnabled) {
-            impactHeavy();
-          }
-        }
-
-        state.value = event.state;
-        translationX.value = positionXWithMargin(event.x, hitSlop, width);
-        translationY.value = event.y;
-      },
-      onCancel: event => {
-        state.value = event.state;
-        resetGestureState();
-      },
-      onEnd: event => {
-        state.value = event.state;
-        resetGestureState();
-
-        if (hapticsEnabled) {
-          impactHeavy();
-        }
-      },
-      onFail: event => {
-        state.value = event.state;
-        resetGestureState();
-      },
-      onStart: event => {
-        // WARNING: the following code does not run on using iOS, but it does on Android.
-        // I use the same code from onActive
-        // platform is for safety
-        if (Platform.OS === 'android') {
-          state.value = event.state;
-          isActive.value = true;
-          pathOpacity.value = withTiming(
-            0,
-            timingFeedbackConfig || timingFeedbackDefaultConfig
-          );
-
-          if (hapticsEnabled) {
-            impactHeavy();
-          }
-        }
-      },
-    },
-    [width, height, hapticsEnabled, hitSlop, timingFeedbackConfig]
-  );
-
-  const pathAnimatedStyles = useAnimatedStyle(() => {
-    return {
-      opacity: pathOpacity.value * (1 - selectedOpacity) + selectedOpacity,
-    };
-  });
-
-  return (
-    <LongPressGestureHandler
-      enabled={gestureEnabled}
-      maxDist={100000}
-      minDurationMs={0}
-      onGestureEvent={onGestureEvent}
-      shouldCancelWhenOutside={false}
-      {...longPressGestureHandlerProps}
-    >
-      <Animated.View>
-        <Svg
-          style={{
-            height: height + FIX_CLIPPED_PATH_MAGIC_NUMBER,
-            width,
-          }}
-          viewBox={`0 0 ${width} ${height}`}
-        >
-          <AnimatedPath
-            // @ts-expect-error
-            animatedProps={animatedProps}
-            stroke={stroke}
-            strokeWidth={strokeWidth}
-            style={pathAnimatedStyles}
-            {...props}
-          />
-        </Svg>
-      </Animated.View>
-    </LongPressGestureHandler>
-  );
-};
+    return (
+      <LongPressGestureHandler
+        enabled={gestureEnabled}
+        maxDist={100000}
+        minDurationMs={0}
+        onGestureEvent={onGestureEvent}
+        shouldCancelWhenOutside={false}
+        {...longPressGestureHandlerProps}
+      >
+        <Animated.View>
+          <Svg
+            style={{
+              height: height + FIX_CLIPPED_PATH_MAGIC_NUMBER,
+              width,
+            }}
+            viewBox={`0 0 ${width} ${height}`}
+          >
+            <AnimatedPath
+              // @ts-expect-error
+              animatedProps={animatedProps}
+              stroke={stroke}
+              strokeWidth={strokeWidth}
+              style={pathAnimatedStyles}
+              {...props}
+            />
+          </Svg>
+        </Animated.View>
+      </LongPressGestureHandler>
+    );
+  }
+);
 
 export const ChartPath = React.memo(
   ({


### PR DESCRIPTION
Fixes RNBW-1115

## What changed (plus any additional context for devs)

Sometimes opening charts would result in an empty chart. It can be related to some changes to the Reanimated 2 Scheduler in the latest 2.4.1 version. After some debugging, I noticed that we rerender charts many times during the first render
the log looks like this:
```
 set path undefined
 LOG  1
 LOG  1
 LOG  set path undefined
 LOG  set path undefined
 LOG  set path string
 LOG  set path undefined
 LOG  1
 LOG  set path undefined
 LOG  1
 LOG  set path undefined
 LOG  [1:26:09 пп] 😬 FallbackExplorer:: fetchOnchainBalances
 LOG  set path string
 ```
where 1 is useAnimatedStyle with chart opacity
and set path - is useAnimatedProps

So we render chart many times and some of the renders with an empty chart path, so we pass `d: ''` as an animated prop. So since we pass an empty string and then the actual path right away Reanimated doesn't schedule the second update so we show the empty chart.

In this fix, I made sure we don't rerender the chart if we pass an empty string to render. So it renders only once and rerenders the path only if it changes to a new path.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

- go to search
- navigate to charts on at least 10 tokens

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
