### PR TITLE
Profiles: fix `addDisplay`

### DIFF
--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -153,9 +153,9 @@ export const add = (numberOne: BigNumberish, numberTwo: BigNumberish): string =>
   new BigNumber(numberOne).plus(numberTwo).toFixed();
 
 export const addDisplay = (numberOne: string, numberTwo: string): string => {
-  const template = numberOne.split(/\d+\.\d+/);
+  const template = numberOne.split(/^(\D*)(.*)/);
   const display = currency(numberOne, { symbol: '' }).add(numberTwo).format();
-  return template.map(item => (item === '' ? `${display}` : item)).join('');
+  return [template[1], display].join('');
 };
 
 export const multiply = (


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Fix `addDisplay` utility method

for numbers like `'$1,059.67'` the split with `/\d+\.\d+/` was returning `[ '$1,', '' ]` so we were appending `'$1,'` at the beginning instead of `'$'`. For number like `'$50'` the split with `/\d+\.\d+/` was returning `[ '$50,', '' ]` so it was a similar problem

with the regex `/^(\D*)(.*)/`, for `'$1,059.67'`we get `[ '', '$', '1,059.67', '' ]`, for `'$159.67'` we get `[ '', '$', '159.67', '' ]` so the currency symbol is always in the same place, and we can join this string with the currency `add` result


## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
