### PR TITLE
Profiles: fix expanded state in name with strange characters

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -255,7 +255,8 @@ const UniqueTokenExpandedState = ({
   const isNFT = uniqueTokenType === UniqueTokenType.NFT;
 
   // Fetch the ENS profile if the unique token is an ENS name.
-  const ensProfile = useENSProfile(uniqueId, { enabled: isENS });
+  const cleanENSName = isENS ? uniqueId.split(' ')?.[0] : uniqueId;
+  const ensProfile = useENSProfile(cleanENSName, { enabled: isENS });
   const ensData = ensProfile.data;
 
   const {

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -408,7 +408,7 @@ const UniqueTokenExpandedStateHeader = ({
   return (
     <Stack space="15px">
       <Columns space="24px">
-        <Heading size="23px" weight="heavy">
+        <Heading containsEmoji size="23px" weight="heavy">
           {buildUniqueTokenName(asset)}
         </Heading>
         <Column width="content">


### PR DESCRIPTION
Fixes RNBW-3040

## What changed (plus any additional context for devs)

The API is sending ` ⚠️` in addition to the ENS name so the `useProfile` hook wasn't working as expected
## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
