### PR TITLE
Profiles: 60 secs wait from COMMIT tx

### DIFF
--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -190,7 +190,7 @@ describe('Register ENS Flow', () => {
     await Helpers.checkIfVisible(
       `ens-confirm-register-label-WAIT_ENS_COMMITMENT`
     );
-    await Helpers.delay(70000);
+    await Helpers.delay(60000);
     await Helpers.enableSynchronization();
   });
 

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -349,10 +349,9 @@ export default function useENSRegistrationActionHandler(
         registrationParameters?.commitTransactionHash || ''
       );
       const block = await web3Provider.getBlock(tx.blockHash || '');
-      const blockTimestamp = block?.timestamp;
-      if (!shouldLoopForConfirmation.current && blockTimestamp) {
+      if (!shouldLoopForConfirmation.current && block?.timestamp) {
         const now = Date.now();
-        const msBlockTimestamp = blockTimestamp * 1000;
+        const msBlockTimestamp = getBlockMsTimestamp(block);
         // hardhat block timestamp is behind
         const timeDifference = isTesting ? now - msBlockTimestamp : 0;
         const commitTransactionConfirmedAt = msBlockTimestamp + timeDifference;
@@ -423,16 +422,15 @@ export default function useENSRegistrationActionHandler(
     const checkRegisterBlockTimestamp = async () => {
       try {
         const block = await web3Provider.getBlock('latest');
-        const msBlockTimestamp = block?.timestamp * 1000;
+        const msBlockTimestamp = getBlockMsTimestamp(block);
         const secs = differenceInSeconds(
           msBlockTimestamp,
           registrationParameters?.commitTransactionConfirmedAt ||
             msBlockTimestamp
         );
         if (secs > ENS_SECONDS_WAIT) setReadyToRegister(true);
-      } catch (e) {
-        //
-      }
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
     };
     if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT) {
       checkRegisterBlockTimestamp();

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -300,6 +300,7 @@ export default function useENSRegistrationActionHandler(
     if (!registrationParameters.commitTransactionConfirmedAt)
       return REGISTRATION_STEPS.WAIT_COMMIT_CONFIRMATION;
     // COMMIT tx was confirmed but 60 secs haven't passed yet
+    // or current block is not 60 secs ahead of COMMIT tx block
     if (secondsSinceCommitConfirmed < ENS_SECONDS_WAIT || !readyToRegister)
       return REGISTRATION_STEPS.WAIT_ENS_COMMITMENT;
     return REGISTRATION_STEPS.REGISTER;
@@ -429,7 +430,7 @@ export default function useENSRegistrationActionHandler(
         //
       }
     };
-    if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT && !isTesting) {
+    if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT) {
       checkRegisterBlockTimestamp();
     }
   }, [

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -35,7 +35,7 @@ import { timeUnits } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 
 // add waiting buffer
-const ENS_SECONDS_WAIT = 70;
+const ENS_SECONDS_WAIT = 60;
 
 const formatENSActionParams = (
   registrationParameters: RegistrationParameters

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -67,7 +67,9 @@ export default function useENSRegistrationActionHandler(
   const { navigate } = useNavigation();
   const { getTransactionByHash } = useTransactions();
   const [stepGasLimit, setStepGasLimit] = useState<string | null>(null);
-  const [readyToRegister, setReadyToRegister] = useState<boolean>(false);
+  const [readyToRegister, setReadyToRegister] = useState<boolean>(
+    IS_TESTING ? true : false
+  );
   const timeout = useRef<NodeJS.Timeout>();
 
   const [

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -414,26 +414,22 @@ export default function useENSRegistrationActionHandler(
 
   useEffect(() => {
     // we need to check from blocks if the time has passed or not
-    const checkBlockTimestamp = async () => {
-      const block = await web3Provider.getBlock('latest');
-      const msBlockTimestamp = block?.timestamp * 1000;
-      const commitTransactionConfirmedAt =
-        registrationParameters?.commitTransactionConfirmedAt;
-      if (!commitTransactionConfirmedAt) return;
-      const secs = differenceInSeconds(
-        msBlockTimestamp,
-        commitTransactionConfirmedAt
-      );
-      if (secs > ENS_SECONDS_WAIT) {
-        setReadyToRegister(true);
-      }
-    };
-    if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT) {
+    const checkRegisterBlockTimestamp = async () => {
       try {
-        checkBlockTimestamp();
+        const block = await web3Provider.getBlock('latest');
+        const msBlockTimestamp = block?.timestamp * 1000;
+        const secs = differenceInSeconds(
+          msBlockTimestamp,
+          registrationParameters?.commitTransactionConfirmedAt ||
+            msBlockTimestamp
+        );
+        if (secs > ENS_SECONDS_WAIT) setReadyToRegister(true);
       } catch (e) {
         //
       }
+    };
+    if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT) {
+      checkRegisterBlockTimestamp();
     }
   }, [
     registrationParameters?.commitTransactionConfirmedAt,

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -67,9 +67,7 @@ export default function useENSRegistrationActionHandler(
   const { navigate } = useNavigation();
   const { getTransactionByHash } = useTransactions();
   const [stepGasLimit, setStepGasLimit] = useState<string | null>(null);
-  const [readyToRegister, setReadyToRegister] = useState<boolean>(
-    IS_TESTING ? true : false
-  );
+
   const timeout = useRef<NodeJS.Timeout>();
 
   const [
@@ -88,6 +86,7 @@ export default function useENSRegistrationActionHandler(
     () => IS_TESTING === 'true' && isHardHat(web3Provider.connection.url),
     []
   );
+  const [readyToRegister, setReadyToRegister] = useState<boolean>(isTesting);
   // flag to wait 10 secs before we get the tx block, to be able to simulate not confirmed tx when testing
   const shouldLoopForConfirmation = useRef(isTesting);
 
@@ -430,10 +429,11 @@ export default function useENSRegistrationActionHandler(
         //
       }
     };
-    if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT) {
+    if (secondsSinceCommitConfirmed >= ENS_SECONDS_WAIT && !isTesting) {
       checkRegisterBlockTimestamp();
     }
   }, [
+    isTesting,
     registrationParameters?.commitTransactionConfirmedAt,
     registrationStep,
     secondsSinceCommitConfirmed,


### PR DESCRIPTION
Fixes RNBW-2909

## What changed (plus any additional context for devs)

Added an additional flag to the `useENSRegistrationActionHandler` hook to when waiting the 60 secs from COMMIT tx.

The logic right now is just waiting 60 secs from the block the `commit` tx got in, this could cause issues if we're trying to send the `registerWithConfig` tx in a block where 60 secs or less has passed from the `commit` tx block.

- Lets' say we have a block `0xA` where it's timestamp is `const t = Date.now()`, so 0 secs have passed yet. 
- Then we wait for 55 secs and another block `0xB` with timestamp `t + 55 secs` was just included
- Another 5 secs passed and we try to include the `registerWithConfig` tx, but there aren't confirmed blocks with `t + 60 secs` as timestamp so that tx is going to fail. In our case it was blocking the gas estimation, since the tx was being rejected when trying to estimate.  

so instead of waiting 60 secs from the block timestamp the COMMIT tx got in, we'll be checking those 60 secs between blocks timestamps waiting 60 secs and then checking the blocks timestamps

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
