### PR TITLE
Fix issue where zoomable wrapper wasn't respecting scroll position on Android

### DIFF
--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -184,12 +184,18 @@ export default forwardRef(function SlackSheet(
             deviceHeight={deviceHeight}
             limitScrollViewContent={limitScrollViewContent}
             onContentSizeChange={onContentSizeChange}
-            onScroll={scrollHandler}
             ref={sheet}
             removeClippedSubviews={removeClippedSubviews}
             removeTopPadding={removeTopPadding}
             scrollEnabled={scrollEnabled}
             scrollIndicatorInsets={scrollIndicatorInsets}
+            {...(isInsideBottomSheet && android
+              ? {
+                  onScrollWorklet: scrollHandler,
+                }
+              : {
+                  onScroll: scrollHandler,
+                })}
           >
             {children}
             {!scrollEnabled && (


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Noticed that Android doesn't properly respect scroll position for the ZoomableWrapper in the NFT expanded state.

This is just a simple fix so that Android works properly with ZoomableWrapper.

## PoW (screenshots / screen recordings)

Before:

https://www.loom.com/share/1002bed341bc4d889a27d769dbc13c7f

After:

https://www.loom.com/share/a561a110c454462ba09df028f41d18eb

## Dev checklist for QA: what to test

- On Android, open the NFT expanded state and make sure the image expands to the center in all scroll positions

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
