### PR TITLE
Fix: lookupAddress on wallet load

### DIFF
--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -29,7 +29,10 @@ import {
   privateKeyKey,
   seedPhraseKey,
 } from '../utils/keychainConstants';
-import { addressHashedColorIndex } from '../utils/profileUtils';
+import {
+  addressHashedColorIndex,
+  lookupAddressWithRetry,
+} from '../utils/profileUtils';
 import { updateWebDataEnabled } from './showcaseTokens';
 import { lightModeThemeColors } from '@rainbow-me/styles';
 
@@ -231,7 +234,10 @@ export const fetchWalletNames = () => async (dispatch, getState) => {
       const visibleAccounts = filter(wallet.addresses, 'visible');
       return map(visibleAccounts, async account => {
         try {
-          const ens = await web3Provider.lookupAddress(account.address);
+          const ens = await lookupAddressWithRetry(
+            web3Provider,
+            account.address
+          );
           if (ens && ens !== account.address) {
             updatedWalletNames[account.address] = ens;
           }

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -121,16 +121,12 @@ export async function lookupAddressWithRetry(
   web3Provider: Provider,
   address: EthereumAddress
 ) {
-  let count = 0;
-  while (count < 3) {
+  for (let i = 0; i < 3; i++) {
     try {
-      const ens = await web3Provider.lookupAddress(address);
-      return ens;
-    } catch (e) {
-      count += 1;
-    }
+      return await web3Provider.lookupAddress(address);
+      // eslint-disable-next-line no-empty
+    } catch {}
   }
-  return null;
 }
 
 export default {

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -127,6 +127,7 @@ export async function lookupAddressWithRetry(
       // eslint-disable-next-line no-empty
     } catch {}
   }
+  return null;
 }
 
 export default {

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -1,6 +1,8 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 
+import { Provider } from '@ethersproject/providers';
 import colors from '../styles/colors';
+import { EthereumAddress } from '@rainbow-me/entities';
 
 // avatars groups emojis with their respective color backgrounds in the `avatarBackgrounds` object in colors.js
 export const avatars = [
@@ -115,6 +117,22 @@ export function isEthAddress(address: string | null) {
   return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
 }
 
+export async function lookupAddressWithRetry(
+  web3Provider: Provider,
+  address: EthereumAddress
+) {
+  let count = 0;
+  while (count < 3) {
+    try {
+      const ens = await web3Provider.lookupAddress(address);
+      return ens;
+    } catch (e) {
+      count += 1;
+    }
+  }
+  return null;
+}
+
 export default {
   avatars,
   addressHashedIndex,
@@ -126,6 +144,7 @@ export default {
   getOldAvatarColorToAvatarBackgroundIndex,
   getNextEmojiWithColor,
   hashCode,
+  lookupAddressWithRetry,
   popularEmojis,
   isEthAddress,
 };


### PR DESCRIPTION
Fixes RNBW-3044

## What changed (plus any additional context for devs)

I couldn't really repro this issue but my guess is this is happening because the provider `lookupAddress` is failing on load, so the ens is not being resolved correctly.

This fix is just adding a retry logic to resolve the ens name in case of any failure.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
