### PR TITLE
Profiles: improve ens search

### DIFF
--- a/src/apollo/queries.ts
+++ b/src/apollo/queries.ts
@@ -199,7 +199,9 @@ export const ENS_SUGGESTIONS = gql`
   query lookup($name: String!, $amount: Int!) {
     domains(
       first: $amount
-      where: { name_contains: $name, resolvedAddress_not: null }
+      where: { name_starts_with: $name, resolvedAddress_not: null }
+      orderBy: name
+      orderDirection: asc
     ) {
       name
       resolver {
@@ -214,7 +216,7 @@ export const ENS_SUGGESTIONS = gql`
 
 export const ENS_SEARCH = gql`
   query lookup($name: String!, $amount: Int!) {
-    domains(first: $amount, where: { name: $name }) {
+    domains(first: $amount, where: { name: $name }, first: 8) {
       name
       resolver {
         addr {

--- a/src/apollo/queries.ts
+++ b/src/apollo/queries.ts
@@ -203,6 +203,7 @@ export const ENS_SUGGESTIONS = gql`
     ) {
       name
       resolver {
+        texts
         addr {
           id
         }

--- a/src/apollo/queries.ts
+++ b/src/apollo/queries.ts
@@ -216,7 +216,7 @@ export const ENS_SUGGESTIONS = gql`
 
 export const ENS_SEARCH = gql`
   query lookup($name: String!, $amount: Int!) {
-    domains(first: $amount, where: { name: $name }, first: 8) {
+    domains(first: $amount, where: { name: $name }) {
       name
       resolver {
         addr {

--- a/src/components/discover-sheet/DiscoverSearch.js
+++ b/src/components/discover-sheet/DiscoverSearch.js
@@ -16,9 +16,7 @@ import { CurrencySelectionList } from '../exchange';
 import { initialChartExpandedStateSheetHeight } from '../expanded-state/asset/ChartExpandedState';
 import { Row } from '../layout';
 import DiscoverSheetContext from './DiscoverSheetContext';
-import useExperimentalFlag, {
-  PROFILES,
-} from '@rainbow-me/config/experimentalHooks';
+import { PROFILES, useExperimentalFlag } from '@rainbow-me/config';
 import { fetchSuggestions } from '@rainbow-me/handlers/ens';
 import {
   useHardwareBackOnFocus,
@@ -57,6 +55,7 @@ export default function DiscoverSearch() {
     uniswapCurrencyList,
     uniswapCurrencyListLoading,
   } = useUniswapCurrencyList(searchQueryForSearch);
+
   const currencyList = useMemo(() => [...uniswapCurrencyList, ...ensResults], [
     uniswapCurrencyList,
     ensResults,
@@ -143,7 +142,12 @@ export default function DiscoverSearch() {
       () => {
         setIsSearching(true);
         setSearchQueryForSearch(searchQuery);
-        fetchSuggestions(searchQuery, addEnsResults, setIsFetchingEns);
+        fetchSuggestions(
+          searchQuery,
+          addEnsResults,
+          setIsFetchingEns,
+          profilesEnabled
+        );
       },
       searchQuery === '' ? 1 : 500
     );

--- a/src/components/exchange/ExchangeAssetList.js
+++ b/src/components/exchange/ExchangeAssetList.js
@@ -202,6 +202,7 @@ const ExchangeAssetList = (
           accountType="contact"
           address={item.address}
           color={item.color}
+          image={item.image}
           nickname={item.nickname}
           onPress={itemProps.onPress}
           showcaseItem={item}

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -64,7 +64,7 @@ export const fetchSuggestions = async (
         result?.data?.domains.map(
           async (domain: { name: string; resolver: { texts: string[] } }) => {
             const hasAvatar = domain?.resolver?.texts?.find(
-              text => text === 'avatar'
+              text => text === ENS_RECORDS.avatar
             );
             if (hasAvatar) {
               try {

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -1,6 +1,5 @@
 import { formatsByCoinType } from '@ensdomains/address-encoder';
 import { debounce, isEmpty, sortBy } from 'lodash';
-import { PROFILES, useExperimentalFlag } from '../../config/experimentalHooks';
 import { ensClient } from '../apollo/client';
 import {
   ENS_DOMAINS,
@@ -39,7 +38,8 @@ const DUMMY_RECORDS = {
 export const fetchSuggestions = async (
   recipient: any,
   setSuggestions: any,
-  setIsFetching = (_unused: any) => {}
+  setIsFetching = (_unused: any) => {},
+  profilesEnabled = false
 ) => {
   if (recipient.length > 2) {
     let suggestions: {
@@ -67,7 +67,6 @@ export const fetchSuggestions = async (
             const hasAvatar = domain?.resolver?.texts?.find(
               text => text === ENS_RECORDS.avatar
             );
-            const profilesEnabled = useExperimentalFlag(PROFILES);
             if (hasAvatar && profilesEnabled) {
               try {
                 const images = await fetchImages(domain.name);
@@ -80,27 +79,22 @@ export const fetchSuggestions = async (
         )
       );
       const ensSuggestions = domains
-        .map((ensDomain: any) => {
-          return {
-            address: ensDomain?.resolver?.addr?.id || ensDomain?.name,
-
-            color: profileUtils.addressHashedColorIndex(
-              ensDomain?.resolver?.addr?.id || ensDomain.name
-            ),
-            ens: true,
-            image: ensDomain?.avatar,
-            network: 'mainnet',
-            nickname: ensDomain?.name,
-            uniqueId: ensDomain?.resolver?.addr?.id || ensDomain.name,
-          };
-        })
+        .map((ensDomain: any) => ({
+          address: ensDomain?.resolver?.addr?.id || ensDomain?.name,
+          color: profileUtils.addressHashedColorIndex(
+            ensDomain?.resolver?.addr?.id || ensDomain.name
+          ),
+          ens: true,
+          image: ensDomain?.avatar,
+          network: 'mainnet',
+          nickname: ensDomain?.name,
+          uniqueId: ensDomain?.resolver?.addr?.id || ensDomain.name,
+        }))
         .filter((domain: any) => !domain?.nickname?.includes?.('['));
-
       suggestions = sortBy(ensSuggestions, domain => domain.nickname.length, [
         'asc',
       ]);
     }
-
     setSuggestions(suggestions);
     setIsFetching(false);
 

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -55,7 +55,7 @@ export const fetchSuggestions = async (
     let result = await ensClient.query({
       query: ENS_SUGGESTIONS,
       variables: {
-        amount: 75,
+        amount: 8,
         name: recpt,
       },
     });
@@ -94,12 +94,9 @@ export const fetchSuggestions = async (
         })
         .filter((domain: any) => !domain?.nickname?.includes?.('['));
 
-      const sortedEnsSuggestions = sortBy(
-        ensSuggestions,
-        domain => domain.nickname.length,
-        ['asc']
-      );
-      suggestions = sortedEnsSuggestions.slice(0, 5);
+      suggestions = sortBy(ensSuggestions, domain => domain.nickname.length, [
+        'asc',
+      ]);
     }
 
     setSuggestions(suggestions);

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -1,5 +1,6 @@
 import { formatsByCoinType } from '@ensdomains/address-encoder';
 import { debounce, isEmpty, sortBy } from 'lodash';
+import { PROFILES, useExperimentalFlag } from '../../config/experimentalHooks';
 import { ensClient } from '../apollo/client';
 import {
   ENS_DOMAINS,
@@ -66,7 +67,8 @@ export const fetchSuggestions = async (
             const hasAvatar = domain?.resolver?.texts?.find(
               text => text === ENS_RECORDS.avatar
             );
-            if (hasAvatar) {
+            const profilesEnabled = useExperimentalFlag(PROFILES);
+            if (hasAvatar && profilesEnabled) {
               try {
                 const images = await fetchImages(domain.name);
                 return { ...domain, avatar: images.avatarUrl };

--- a/src/hooks/useFetchUniqueTokens.ts
+++ b/src/hooks/useFetchUniqueTokens.ts
@@ -31,11 +31,14 @@ export default function useFetchUniqueTokens({
   const [hasStoredTokens, setHasStoredTokens] = useState(false);
   useEffect(() => {
     (async () => {
-      const { hasStoredTokens } = await getStoredUniqueTokens({
-        address,
-        network,
-      });
-      setHasStoredTokens(hasStoredTokens);
+      try {
+        const { hasStoredTokens } = await getStoredUniqueTokens({
+          address,
+          network,
+        });
+        setHasStoredTokens(hasStoredTokens);
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
     })();
   }, [address, network]);
 


### PR DESCRIPTION
Fixes RNBW-2878

Fixes RNBW-3182

## What changed (plus any additional context for devs)

Improved the ens search by
- Search will now work getting up to 8 ens names, we were querying for 75 and then cutting the array result to 3
- Results would need to start with the search query, this was making some ens names to not appear
- Added ens avatar images resolver, wanted to know what you think about this @jxom since we'll add a bit more wait to get the avatar but I didn't want to show an emoji while waiting for the avatar to load
- The new profile screen shows a loader so the comment from christian in the card was solved before

## PoW (screenshots / screen recordings)

https://www.loom.com/share/67f28e772e924710b716b96636e82f46

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
