### PR TITLE
deeplink route to profile sheet

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -11,6 +11,8 @@ import {
   walletConnectRemovePendingRedirect,
   walletConnectSetPendingRedirect,
 } from '../redux/walletconnect';
+import { defaultConfig } from '@rainbow-me/config/experimental';
+import { PROFILES } from '@rainbow-me/config/experimentalHooks';
 import { delay } from '@rainbow-me/helpers/utilities';
 import { checkIsValidAddressOrDomain } from '@rainbow-me/helpers/validators';
 import { Navigation } from '@rainbow-me/navigation';
@@ -94,9 +96,14 @@ export default async function handleDeeplink(
         if (addressOrENS) {
           const isValid = await checkIsValidAddressOrDomain(addressOrENS);
           if (isValid) {
-            return Navigation.handleAction(Routes.PROFILE_SHEET, {
-              address: addressOrENS,
-            });
+            return Navigation.handleAction(
+              defaultConfig[PROFILES]
+                ? Routes.PROFILE_SHEET
+                : Routes.SHOWCASE_SHEET,
+              {
+                address: addressOrENS,
+              }
+            );
           } else {
             const error = new Error('Invalid deeplink: ' + url);
             captureException(error);

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -94,7 +94,7 @@ export default async function handleDeeplink(
         if (addressOrENS) {
           const isValid = await checkIsValidAddressOrDomain(addressOrENS);
           if (isValid) {
-            return Navigation.handleAction(Routes.SHOWCASE_SHEET, {
+            return Navigation.handleAction(Routes.PROFILE_SHEET, {
               address: addressOrENS,
             });
           } else {


### PR DESCRIPTION
Fixes RNBW-3038

## What changed (plus any additional context for devs)
- Deeplinks to wallets with ens names now route to profile sheet instead of showcase sheet

## PoW (screenshots / screen recordings)
https://user-images.githubusercontent.com/15272675/161122088-fc07df1f-955f-467a-b306-b8e03d4b787e.mov

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
