### PR TITLE
Fix description crash

### DIFF
--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -468,7 +468,7 @@ export default function ChartExpandedState({ asset }) {
               assetName: asset?.name,
             })}
           >
-            <Description text={description} />
+            <Description text={delayedDescriptions} />
           </ExpandedStateSection>
         )}
         <SocialLinks

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -468,7 +468,7 @@ export default function ChartExpandedState({ asset }) {
               assetName: asset?.name,
             })}
           >
-            <Description text={delayedDescriptions} />
+            <Description text={description || delayedDescriptions} />
           </ExpandedStateSection>
         )}
         <SocialLinks

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -135,10 +135,10 @@ const Spacer = styled.View({
 
 // truncate after the first paragraph or 4th dot
 function truncate(text) {
-  const firstParagraph = text?.split('\n')[0];
-  const first4Sentences = text?.split('.').slice(0, 4).join('.') + '.';
+  const firstParagraph = text.split('\n')[0];
+  const first4Sentences = text.split('.').slice(0, 4).join('.') + '.';
   const shorterOne =
-    first4Sentences?.length < firstParagraph?.length
+    first4Sentences.length < firstParagraph?.length
       ? first4Sentences
       : firstParagraph;
   // If there is not much to expand, return the whole text
@@ -149,7 +149,7 @@ function truncate(text) {
   return shorterOne;
 }
 
-function Description({ text }) {
+function Description({ text = '' }) {
   const truncatedText = truncate(text);
   const needToTruncate = truncatedText.length !== text.length;
   const [truncated, setTruncated] = useState(true);


### PR DESCRIPTION
Fixes RNBW-3103

This is weird that this error is happening. Looks like this is possible that `delayedDescription` is defined and `description` is undefined. Otherwise, this logic should block the rendering of the component 
![image](https://user-images.githubusercontent.com/25709300/161259350-e1576881-fd4c-4fcd-881c-d2c625f5bec6.png)

Maybe this is happening when the store is updated (and then some error is occurring or the description was removed by the provider)? 

Regardless of the issue, I now use `delayedDescription` if `description` is not defined. For extra safety, I default `text` prop to an empty string ( I guess this should never happen, but costs us nothing to make it)   

## PoW (screenshots / screen recordings)

![image](https://user-images.githubusercontent.com/25709300/161259844-ec7cc1f1-da7c-4f15-9e72-bceb0909b0e3.png)


## Dev checklist for QA: what to test
Set `text` to `undefined` and see if it's not breaking. 
