### PR TITLE
Add react-devtools-core resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,7 +364,8 @@
     "**/markdown-it": "12.3.2",
     "**/simple-get": "4.0.1",
     "**/plist": "3.0.5",
-    "**/minimist": "1.2.6"
+    "**/minimist": "1.2.6",
+    "react-native/react-devtools-core": "4.24.0"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14652,9 +14652,10 @@ react-coin-icon@0.1.43:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"
 
-react-devtools-core@^4.13.0:
-  version "4.20.2"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.20.2.tgz#0be500c80e09b640a2ee57f5ad5407e53bff6651"
+react-devtools-core@4.24.0, react-devtools-core@^4.13.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.24.0.tgz#7daa196bdc64f3626b3f54f2ff2b96f7c4fdf017"
+  integrity sha512-Rw7FzYOOzcfyUPaAm9P3g0tFdGqGq2LLiAI+wjYcp6CsF3DeeMrRS3HZAho4s273C29G/DJhx0e8BpRE/QZNGg==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

In this PR I added a proper version of `react-devtools-core` to use with React Native.
The `react-devtools-core` package is part of `react-native` package. But the version included with the current version is out of date. This is why we specifically used the newer version that works with new versions of react-devtools.

The version used in this PR works properly with `react-devtools@4.24.1`.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

- React devtools running using `npx react-devtools@4.24.1` should connect to the app in Dev

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
