### PR TITLE
Profiles: Fix incorrect "Confirm Registration" placeholder

### DIFF
--- a/src/screens/ENSConfirmRegisterSheet.js
+++ b/src/screens/ENSConfirmRegisterSheet.js
@@ -155,7 +155,7 @@ function TransactionActionRow({
   isSufficientGas,
   testID,
 }) {
-  const insufficientEth = !isSufficientGas && isValidGas;
+  const insufficientEth = isSufficientGas === false && isValidGas;
   return (
     <Box>
       <Box>


### PR DESCRIPTION
Fixes RNBW-3130

## What changed (plus any additional context for devs)

This PR fixes an issue where the "Confirm Registration" button was displaying "Insufficient ETH" when not ready.

Added stricter equality to the `insufficientEth` condition.
