### PR TITLE
Profiles: (Android) Fix issue when attempting to edit ENS profile

### DIFF
--- a/src/components/ens-profile/ActionButtons/EditButton.tsx
+++ b/src/components/ens-profile/ActionButtons/EditButton.tsx
@@ -3,18 +3,23 @@ import React, { useCallback } from 'react';
 import GradientOutlineButton from '../GradientOutlineButton/GradientOutlineButton';
 import { useTheme } from '@rainbow-me/context';
 import { ColorModeProvider } from '@rainbow-me/design-system';
+import { useENSRegistration } from '@rainbow-me/hooks';
 import Routes from '@rainbow-me/routes';
 
 export default function WatchButton({ ensName }: { ensName?: string }) {
   const { colors } = useTheme();
   const { navigate } = useNavigation();
+  const { startRegistration } = useENSRegistration();
 
   const handlePressEdit = useCallback(() => {
-    navigate(Routes.REGISTER_ENS_NAVIGATOR, {
-      ensName,
-      mode: 'edit',
-    });
-  }, [ensName, navigate]);
+    if (ensName) {
+      startRegistration(ensName, 'edit');
+      navigate(Routes.REGISTER_ENS_NAVIGATOR, {
+        ensName,
+        mode: 'edit',
+      });
+    }
+  }, [ensName, navigate, startRegistration]);
 
   return (
     <ColorModeProvider value="darkTinted">

--- a/src/components/ens-registration/TextRecordsForm/TextRecordsForm.tsx
+++ b/src/components/ens-registration/TextRecordsForm/TextRecordsForm.tsx
@@ -120,7 +120,7 @@ function Field({ defaultValue, ...props }: InlineFieldProps) {
           props.onChangeText(text);
           setValue(text);
         }}
-        value={value}
+        value={value || defaultValue}
       />
     </>
   );

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -63,6 +63,7 @@ import {
   useAccountProfile,
   useDimensions,
   useENSProfile,
+  useENSRegistration,
   usePersistentDominantColorFromImage,
   useShowcaseTokens,
 } from '@rainbow-me/hooks';
@@ -322,14 +323,16 @@ const UniqueTokenExpandedState = ({
     });
   }, [accountAddress, accountENS, asset]);
 
+  const { startRegistration } = useENSRegistration();
   const handlePressEdit = useCallback(() => {
     if (isENS) {
+      startRegistration(uniqueId, 'edit');
       navigate(Routes.REGISTER_ENS_NAVIGATOR, {
         ensName: uniqueId,
         mode: 'edit',
       });
     }
-  }, [isENS, navigate, uniqueId]);
+  }, [isENS, navigate, startRegistration, uniqueId]);
 
   const sheetRef = useRef();
   const yPosition = useSharedValue(0);

--- a/src/components/inputs/InlineField.tsx
+++ b/src/components/inputs/InlineField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Alert, TextInputProps } from 'react-native';
 import { useTheme } from '../../context/ThemeContext';
 import ButtonPressAnimation from '../animations/ButtonPressAnimation';
@@ -87,6 +87,7 @@ export default function InlineField({
     [onChangeText, validations]
   );
 
+  const valueRef = useRef(value);
   const style = useMemo(
     () => ({
       ...textStyle,
@@ -100,7 +101,9 @@ export default function InlineField({
           ? 11
           : 15
         : android
-        ? 11
+        ? valueRef.current
+          ? 16
+          : 11
         : 0,
       textAlignVertical: 'top',
       width: startsWith
@@ -147,7 +150,7 @@ export default function InlineField({
         </Inset>
       </Column>
       <Column>
-        <Inline alignVertical="center" space="2px">
+        <Inline alignVertical="center" space="2px" wrap={false}>
           {startsWith && (
             <Inset top={ios ? '2px' : undefined}>
               <Text color="secondary30" weight="heavy">

--- a/src/hooks/useENSRecordDisplayProperties.tsx
+++ b/src/hooks/useENSRecordDisplayProperties.tsx
@@ -5,6 +5,7 @@ import { Linking } from 'react-native';
 import { ContextMenuButton } from 'react-native-ios-context-menu';
 import URL from 'url-parse';
 import useClipboard from './useClipboard';
+import useENSRegistration from './useENSRegistration';
 import { ENS_RECORDS, textRecordFields } from '@rainbow-me/helpers/ens';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
@@ -152,6 +153,7 @@ export default function useENSRecordDisplayProperties({
 
   const { navigate } = useNavigation();
   const { setClipboard } = useClipboard();
+  const { startRegistration } = useENSRegistration();
   const handlePressMenuItem = useCallback(
     ({ nativeEvent: { actionKey } }) => {
       if (actionKey === 'open-url' && url) {
@@ -160,7 +162,8 @@ export default function useENSRecordDisplayProperties({
       if (actionKey === 'copy') {
         setClipboard(recordValue);
       }
-      if (actionKey === 'edit') {
+      if (actionKey === 'edit' && ensName) {
+        startRegistration(ensName, 'edit');
         navigate(Routes.REGISTER_ENS_NAVIGATOR, {
           autoFocusKey: recordKey,
           ensName,
@@ -168,7 +171,15 @@ export default function useENSRecordDisplayProperties({
         });
       }
     },
-    [ensName, navigate, recordKey, recordValue, setClipboard, url]
+    [
+      ensName,
+      navigate,
+      recordKey,
+      recordValue,
+      setClipboard,
+      startRegistration,
+      url,
+    ]
   );
 
   const handleAndroidPress = useCallback(() => {

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -6,6 +6,7 @@ import { RainbowAccount } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
 import useAccountProfile from './useAccountProfile';
 import useENSProfile from './useENSProfile';
+import useENSRegistration from './useENSRegistration';
 import useImagePicker from './useImagePicker';
 import useUpdateEmoji from './useUpdateEmoji';
 import useWallets from './useWallets';
@@ -105,6 +106,8 @@ export default () => {
 
   const { setNextEmoji } = useUpdateEmoji();
 
+  const { startRegistration } = useENSRegistration();
+
   const onAvatarPress = useCallback(() => {
     if (android) {
       setNextEmoji();
@@ -137,6 +140,7 @@ export default () => {
             address: accountENS,
           });
         } else if (buttonIndex === 1 && !isReadOnlyWallet) {
+          startRegistration(accountENS, 'edit');
           navigate(Routes.REGISTER_ENS_NAVIGATOR, {
             ensName: accountENS,
             mode: 'edit',

--- a/src/navigation/RegisterENSNavigator.js
+++ b/src/navigation/RegisterENSNavigator.js
@@ -54,19 +54,15 @@ export default function RegisterENSNavigator() {
   const contentHeight =
     deviceHeight - SheetHandleFixedToTopHeight - sharedCoolModalTopOffset;
 
-  const {
-    startRegistration,
-    clearCurrentRegistrationName,
-  } = useENSRegistration();
+  const { clearCurrentRegistrationName } = useENSRegistration();
 
   const initialRouteName = useMemo(() => {
-    const { ensName, mode } = params || { mode: 'create' };
+    const { mode } = params || { mode: 'create' };
     if (mode === 'edit') {
-      startRegistration(ensName, mode);
       return Routes.ENS_ASSIGN_RECORDS_SHEET;
     }
     return Routes.ENS_SEARCH_SHEET;
-  }, [params, startRegistration]);
+  }, [params]);
   const [currentRouteName, setCurrentRouteName] = useState(initialRouteName);
   const previousRouteName = usePrevious(currentRouteName);
 
@@ -125,6 +121,7 @@ export default function RegisterENSNavigator() {
           <Swipe.Navigator
             initialLayout={deviceUtils.dimensions}
             initialRouteName={currentRouteName}
+            lazy={android}
             pager={renderPager}
             swipeEnabled={false}
             tabBar={renderTabBar}

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -107,6 +107,7 @@ export default function ENSAssignRecordsSheet() {
   const { navigate } = useNavigation();
   const handleFocus = useCallback(() => {
     if (!hasSeenExplainSheet) {
+      android && Keyboard.dismiss();
       navigate(Routes.EXPLAIN_SHEET, {
         type: 'ensOnChainDataWarning',
       });


### PR DESCRIPTION
Fixes RNBW-3118
Fixes RNBW-3119

## What changed (plus any additional context for devs)

This PR fixes an issue where Android was getting a [black screen](https://linear.app/rainbow/issue/RNBW-3118/qa-android-edit-from-ens-nft-has-weird-behavior) when attempting to edit an ENS profile. Previously, we started the registration process (`startRegistration` action) on initial mount of the screen, but now we are invoking it before transition to the screen.

Also fixed an issue where the [@ symbol](https://linear.app/rainbow/issue/RNBW-3119/android-in-records-is-misaligned) on the twitter field was misaligned on Android.