### PR TITLE
Design system color edits

### DIFF
--- a/src/design-system/color/palettes.ts
+++ b/src/design-system/color/palettes.ts
@@ -133,7 +133,7 @@ export const foregroundColors: Record<
   primary: {
     dark: colors.sky,
     darkTinted: colors.white,
-    light: colors.grey,
+    light: colors.greyDark,
     lightTinted: colors.greyDark,
   },
   secondary: {

--- a/src/design-system/color/palettes.ts
+++ b/src/design-system/color/palettes.ts
@@ -5,6 +5,7 @@ export const colors = {
   black: '#000000',
   blackTint: '#12131a',
   grey: 'rgb(60, 66, 66)',
+  grey06: 'rgba(60, 66, 66, 0.06)',
   grey10: 'rgba(60, 66, 66, 0.1)',
   grey20: 'rgba(60, 66, 66, 0.2)',
   grey30: 'rgba(60, 66, 66, 0.3)',
@@ -16,6 +17,7 @@ export const colors = {
   greyDark: '#25292E',
   paleBlue: '#579DFF',
   sky: 'rgb(224, 232, 255)',
+  sky06: 'rgb(224, 232, 255, 0.06)',
   sky10: 'rgba(224, 232, 255, 0.1)',
   sky20: 'rgba(224, 232, 255, 0.2)',
   sky30: 'rgba(224, 232, 255, 0.3)',
@@ -26,6 +28,7 @@ export const colors = {
   sky80: 'rgba(224, 232, 255, 0.8)',
   swapPurple: '#575CFF',
   white: '#FFFFFF',
+  white06: 'rgba(255, 255, 255, 0.06)',
   white10: 'rgba(255, 255, 255, 0.1)',
   white20: 'rgba(255, 255, 255, 0.2)',
   white30: 'rgba(255, 255, 255, 0.3)',
@@ -90,6 +93,7 @@ export type ForegroundColor =
   | 'divider80'
   | 'primary'
   | 'secondary'
+  | 'secondary06'
   | 'secondary10'
   | 'secondary20'
   | 'secondary30'
@@ -136,6 +140,11 @@ export const foregroundColors: Record<
     dark: colors.sky,
     darkTinted: colors.white90,
     light: colors.grey,
+  },
+  secondary06: {
+    dark: colors.sky06,
+    darkTinted: colors.white06,
+    light: colors.grey06,
   },
   secondary10: {
     dark: colors.sky10,


### PR DESCRIPTION
## What changed (plus any additional context for devs)

while testing profiles, noticed the light mode primary text color wasn't accurate in the design system

- changed the primary text color in light mode from `#3C4252` to `#25292E` to be consistent with the rest of the app
- added `secondary06` which we use relatively often as a button background color—lmk if there's a better way to add/use this color

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- no associated tests afaik
- [ ] If you added new files, did you update the CODEOWNERS file?
- n/a