### PR TITLE
Select updated cert for release mode

### DIFF
--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1296,7 +1296,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.rainbow;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore me.rainbow";
+				PROVISIONING_PROFILE_SPECIFIER = "me.rainbow AppStore";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
Updated project config to use the new certificate instead of the expired one. This won't affect CI, only allows you to build release mode without having to change config

## PoW (screenshots / screen recordings)
BEFORE:
<img width="624" alt="Screen Shot 2022-04-04 at 7 08 37 PM" src="https://user-images.githubusercontent.com/1247834/161647106-ac7550ca-53a7-4b82-8476-1673a3a44e61.png">

AFTER:
<img width="556" alt="Screen Shot 2022-04-04 at 7 08 42 PM" src="https://user-images.githubusercontent.com/1247834/161647285-3b6aa42e-8fdb-4ed5-b6c9-881c854c1536.png">


## Dev checklist for QA: what to test
CI should pass and testflight should work normally

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why - Not applicable
- [ ] If you added new files, did you update the CODEOWNERS file? - Not applicable
