### PR TITLE
Fix possibility to scroll with scroll indicator on unique asset image preview

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -58,6 +58,7 @@ import { buildUniqueTokenName } from '@rainbow-me/helpers/assets';
 import {
   useAccountProfile,
   useAccountSettings,
+  useBooleanState,
   useDimensions,
   usePersistentDominantColorFromImage,
   useShowcaseTokens,
@@ -209,7 +210,11 @@ const UniqueTokenExpandedState = ({
   const [floorPrice, setFloorPrice] = useState<string | null>(null);
   const [showCurrentPriceInEth, setShowCurrentPriceInEth] = useState(true);
   const [showFloorInEth, setShowFloorInEth] = useState(true);
-  const [contentFocused, setContentFocused] = useState(false);
+  const [
+    contentFocused,
+    handleContentFocus,
+    handleContentBlur,
+  ] = useBooleanState();
   const animationProgress = useSharedValue(0);
   const opacityStyle = useAnimatedStyle(() => ({
     opacity: 1 - animationProgress.value,
@@ -288,14 +293,6 @@ const UniqueTokenExpandedState = ({
       url: buildRainbowUrl(asset, accountENS, accountAddress),
     });
   }, [accountAddress, accountENS, asset]);
-
-  const handleContentFocus = useCallback(() => {
-    setContentFocused(true);
-  }, []);
-
-  const handleContentBlur = useCallback(() => {
-    setContentFocused(false);
-  }, []);
 
   const toggleCurrentPriceDisplayCurrency = useCallback(
     () => setShowCurrentPriceInEth(!showCurrentPriceInEth),

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -209,6 +209,7 @@ const UniqueTokenExpandedState = ({
   const [floorPrice, setFloorPrice] = useState<string | null>(null);
   const [showCurrentPriceInEth, setShowCurrentPriceInEth] = useState(true);
   const [showFloorInEth, setShowFloorInEth] = useState(true);
+  const [contentFocused, setContentFocused] = useState(false);
   const animationProgress = useSharedValue(0);
   const opacityStyle = useAnimatedStyle(() => ({
     opacity: 1 - animationProgress.value,
@@ -288,6 +289,14 @@ const UniqueTokenExpandedState = ({
     });
   }, [accountAddress, accountENS, asset]);
 
+  const handleContentFocus = useCallback(() => {
+    setContentFocused(true);
+  }, []);
+
+  const handleContentBlur = useCallback(() => {
+    setContentFocused(false);
+  }, []);
+
   const toggleCurrentPriceDisplayCurrency = useCallback(
     () => setShowCurrentPriceInEth(!showCurrentPriceInEth),
     [showCurrentPriceInEth, setShowCurrentPriceInEth]
@@ -338,7 +347,8 @@ const UniqueTokenExpandedState = ({
           ? { height: '100%' }
           : { additionalTopPadding: true, contentHeight: deviceHeight })}
         ref={sheetRef}
-        scrollEnabled
+        scrollEnabled={!contentFocused}
+        showsVerticalScrollIndicator={!contentFocused}
         yPosition={yPosition}
       >
         <ColorModeProvider value="darkTinted">
@@ -356,8 +366,9 @@ const UniqueTokenExpandedState = ({
               asset={asset}
               horizontalPadding={24}
               imageColor={imageColor}
+              onContentBlur={handleContentBlur}
+              onContentFocus={handleContentFocus}
               // @ts-expect-error JavaScript component
-
               sheetRef={sheetRef}
               textColor={textColor}
               yPosition={yPosition}

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -347,7 +347,7 @@ const UniqueTokenExpandedState = ({
           ? { height: '100%' }
           : { additionalTopPadding: true, contentHeight: deviceHeight })}
         ref={sheetRef}
-        scrollEnabled={!contentFocused}
+        scrollEnabled
         showsVerticalScrollIndicator={!contentFocused}
         yPosition={yPosition}
       >

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -43,6 +43,8 @@ const UniqueTokenExpandedStateContent = ({
   textColor,
   disablePreview,
   yPosition,
+  onContentFocus,
+  onContentBlur,
 }) => {
   const { width: deviceWidth } = useDimensions();
 
@@ -87,6 +89,8 @@ const UniqueTokenExpandedStateContent = ({
       }
       horizontalPadding={horizontalPadding}
       isENS={isENS}
+      onZoomIn={onContentFocus}
+      onZoomOut={onContentBlur}
       yDisplacement={yPosition}
     >
       <View style={StyleSheet.absoluteFill}>

--- a/src/components/expanded-state/unique-token/ZoomableWrapper.android.js
+++ b/src/components/expanded-state/unique-token/ZoomableWrapper.android.js
@@ -73,6 +73,8 @@ export const ZoomableWrapper = ({
   aspectRatio,
   borderRadius,
   disableAnimations,
+  onZoomIn,
+  onZoomOut,
   yDisplacement: givenYDisplacement,
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -121,8 +123,10 @@ export const ZoomableWrapper = ({
   useEffect(() => {
     if (isZoomed) {
       StatusBar.setHidden(true);
+      onZoomIn?.();
     } else {
       StatusBar.setHidden(false);
+      onZoomOut?.();
     }
   }, [isZoomed]);
 

--- a/src/components/expanded-state/unique-token/ZoomableWrapper.js
+++ b/src/components/expanded-state/unique-token/ZoomableWrapper.js
@@ -75,6 +75,8 @@ export const ZoomableWrapper = ({
   aspectRatio,
   borderRadius,
   disableAnimations,
+  onZoomIn,
+  onZoomOut,
   yDisplacement: givenYDisplacement,
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -123,10 +125,12 @@ export const ZoomableWrapper = ({
   useEffect(() => {
     if (isZoomed) {
       StatusBar.setHidden(true);
+      onZoomIn?.();
     } else {
       StatusBar.setHidden(false);
+      onZoomOut?.();
     }
-  }, [isZoomed]);
+  }, [isZoomed, onZoomIn, onZoomOut]);
 
   const fullSizeHeight = Math.min(deviceHeight, deviceWidth / aspectRatio);
   const fullSizeWidth = Math.min(deviceWidth, deviceHeight * aspectRatio);

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -95,6 +95,8 @@ export default forwardRef(function SlackSheet(
     onContentSizeChange,
     renderHeader,
     scrollEnabled = true,
+    showsHorizontalScrollIndicator = true,
+    showsVerticalScrollIndicator = true,
     showBlur,
     testID,
     removeClippedSubviews = false,
@@ -189,6 +191,8 @@ export default forwardRef(function SlackSheet(
             removeTopPadding={removeTopPadding}
             scrollEnabled={scrollEnabled}
             scrollIndicatorInsets={scrollIndicatorInsets}
+            showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
+            showsVerticalScrollIndicator={showsVerticalScrollIndicator}
             {...(isInsideBottomSheet && android
               ? {
                   onScrollWorklet: scrollHandler,


### PR DESCRIPTION
Fixes RNBW-3057

## What changed (plus any additional context for devs)
* Added `onZoomIn` and `onZoomOut` callbacks to `ZoomableWrapper` component
* Added props `showsHorizontalScrollIndicator` and `showsVerticalScrollIndicator​` from ScrollView to `SlackSheet` component, props are passed to underlying `ScrollView` and `true` by default (like in ScrollView)
* Added state that replicates ZoomableWrapper zoomedIn state, which drives whether the scrollbars are visible or not + also drives whether scrolling is enabled (fixes pan scroll on the bottom of the zoom in overlay)

## PoW (screenshots / screen recordings)
Forgot to record mouse clicks, but the effect is still visible, first I'm using scroll bar which disappears after changes, and I'm trying to pan just above the Bottom iOS system navigation bar
Before it was like this:

https://user-images.githubusercontent.com/16062886/161756272-87161dd8-4c48-4c02-b7ca-57b4d6ac1f1c.mp4

After it is not possible to scroll it:

https://user-images.githubusercontent.com/16062886/161756658-a7bebd22-7d51-40c4-aca8-ebc898e92731.mp4

## Dev checklist for QA: what to test

* Grab the app from develop
* Go to NFT with an image (can use the one from my wallet jkadamczyk.eth)
* Scroll just enough to show the scroll indicator
* Quickly zoom NFT image
* Try catching the scroll indicator and scroll down with it
* Zoom out the preview and your content should be at the bottom and previously wasn't
* Scroll back to the top
* Scroll enough to just show the scrollbar
* Try panning just above the bottom navigation bar, it should scroll the content as well

Then,
* Grab the app from my branch and try to reproduce above

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why – didn't add because this is a very granular bug fix
- [x] If you added new files, did you update the CODEOWNERS file?
