### PR TITLE
Remove smile emoji from label

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -579,7 +579,7 @@
       "label": "Settings",
       "language": "Language",
       "learn": "Learn about Rainbow and Ethereum",
-      "learn_short": "Learn about Rainbow :)",
+      "learn_short": "Learn about Rainbow",
       "network": "Network",
       "privacy": "Privacy",
       "review": "Review Rainbow",


### PR DESCRIPTION
Michał pointed to me that I accidentally added smile to the English version of Rainbow that was not there before (I took it from French one).

## What changed (plus any additional context for devs)

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
