### PR TITLE
Remove PIN input while importing wallet in watch-only mode

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -558,6 +558,7 @@ export const createWallet = async (
     } =
       checkedWallet ||
       (await ethereumUtils.deriveAccountFromWalletInput(walletSeed));
+    const isReadOnlyType = type === EthereumWalletType.readOnly;
     let pkey = walletSeed;
     if (!walletResult) return null;
     const walletAddress = address;
@@ -600,8 +601,7 @@ export const createWallet = async (
       if (
         !overwrite &&
         alreadyExistingWallet &&
-        (type === EthereumWalletType.readOnly ||
-          isPrivateKeyOverwritingSeedMnemonic)
+        (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)
       ) {
         setTimeout(
           () =>
@@ -621,7 +621,7 @@ export const createWallet = async (
 
     // Android users without biometrics need to secure their keys with a PIN
     let userPIN = null;
-    if (android) {
+    if (android && !isReadOnlyType) {
       const hasBiometricsEnabled = await getSupportedBiometryType();
       // Fallback to custom PIN
       if (!hasBiometricsEnabled) {


### PR DESCRIPTION
Fixes RNBW-2898

## What changed (plus any additional context for devs)
This bug is reproducible only for androids and only when biometrics is turned off.
When importing a wallet to monitor it, a pin is required. The watch wallet must be added without a pin

When creating a wallet, I validate its type on `readOnly` These wallets do not need a password. So in the following steps, we avoid  encrypting the seeds, we don't need to encrypt the private key for that wallet too


## PoW (screenshots / screen recordings)
Before: https://streamable.com/2u9iat
After:  
- https://streamable.com/axr51e
- https://streamable.com/eqokwq

## Dev checklist for QA: what to test
importing a watch wallets

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
