### PR TITLE
Profiles: Only show ENS on-chain data warning once per user

### DIFF
--- a/src/handlers/localstorage/ens.ts
+++ b/src/handlers/localstorage/ens.ts
@@ -4,6 +4,7 @@ const ensProfileVersion = '0.1.0';
 
 const ensProfileKey = (key: string) => `ensProfile.${key}`;
 const ensResolveNameKey = (key: string) => `ensResolveName.${key}`;
+const ensSeenOnchainDataDisclaimerKey = 'ensProfile.seenOnchainDisclaimer';
 
 export const getProfile = async (key: string) => {
   const profile = await getGlobal(ensProfileKey(key), null, ensProfileVersion);
@@ -18,3 +19,9 @@ export const getResolveName = (key: string) =>
 
 export const saveResolveName = (key: string, value: string) =>
   saveGlobal(ensResolveNameKey(key), value);
+
+export const getSeenOnchainDataDisclaimer = () =>
+  getGlobal(ensResolveNameKey(ensSeenOnchainDataDisclaimerKey), null);
+
+export const saveSeenOnchainDataDisclaimer = (value: boolean) =>
+  saveGlobal(ensResolveNameKey(ensSeenOnchainDataDisclaimerKey), value);

--- a/src/handlers/localstorage/ens.ts
+++ b/src/handlers/localstorage/ens.ts
@@ -21,7 +21,7 @@ export const saveResolveName = (key: string, value: string) =>
   saveGlobal(ensResolveNameKey(key), value);
 
 export const getSeenOnchainDataDisclaimer = () =>
-  getGlobal(ensResolveNameKey(ensSeenOnchainDataDisclaimerKey), null);
+  getGlobal(ensResolveNameKey(ensSeenOnchainDataDisclaimerKey), false);
 
 export const saveSeenOnchainDataDisclaimer = (value: boolean) =>
   saveGlobal(ensResolveNameKey(ensSeenOnchainDataDisclaimerKey), value);

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -128,7 +128,7 @@ export default function ENSAssignRecordsSheet() {
         type: 'ensOnChainDataWarning',
       });
       setHasSeenExplainSheet(true);
-      await saveSeenOnchainDataDisclaimer(true);
+      saveSeenOnchainDataDisclaimer(true);
     }
   }, [hasSeenExplainSheet, navigate, setHasSeenExplainSheet]);
 

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -39,6 +39,10 @@ import {
   Text,
 } from '@rainbow-me/design-system';
 import {
+  getSeenOnchainDataDisclaimer,
+  saveSeenOnchainDataDisclaimer,
+} from '@rainbow-me/handlers/localstorage/ens';
+import {
   accentColorAtom,
   ENS_RECORDS,
   REGISTRATION_MODES,
@@ -109,14 +113,22 @@ export default function ENSAssignRecordsSheet() {
   );
 
   const [hasSeenExplainSheet, setHasSeenExplainSheet] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      setHasSeenExplainSheet(Boolean(await getSeenOnchainDataDisclaimer()));
+    })();
+  }, []);
+
   const { navigate } = useNavigation();
-  const handleFocus = useCallback(() => {
+  const handleFocus = useCallback(async () => {
     if (!hasSeenExplainSheet) {
       android && Keyboard.dismiss();
       navigate(Routes.EXPLAIN_SHEET, {
         type: 'ensOnChainDataWarning',
       });
       setHasSeenExplainSheet(true);
+      await saveSeenOnchainDataDisclaimer(true);
     }
   }, [hasSeenExplainSheet, navigate, setHasSeenExplainSheet]);
 


### PR DESCRIPTION
Fixes RNBW-3194

## What changed (plus any additional context for devs)

This PR adds functionality to only show the ENS on-chain data disclaimer warning once per user. 