### PR TITLE
image handling fixes + refactor

### DIFF
--- a/src/components/3d/SimpleModelView.tsx
+++ b/src/components/3d/SimpleModelView.tsx
@@ -77,7 +77,6 @@ const getSource = ({ alt, uri }: { alt?: string; uri: string }) =>
 export default function ModelViewer({
   loading,
   setLoading,
-  size,
   style,
   uri,
   alt,
@@ -135,7 +134,6 @@ export default function ModelViewer({
         style={{ opacity }}
       >
         <ImgixImage
-          size={size}
           source={{ uri: fallbackUri }}
           style={StyleSheet.absoluteFill}
         />

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -236,7 +236,7 @@ const UniqueTokenExpandedState = ({
 
   const imageColor =
     // @ts-expect-error image_url could be null or undefined?
-    usePersistentDominantColorFromImage(asset.image_url).result ||
+    usePersistentDominantColorFromImage(asset.lowResUrl).result ||
     colors.paleBlue;
 
   const lastSalePrice =

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -321,8 +321,8 @@ const UniqueTokenExpandedState = ({
         <BlurWrapper height={deviceHeight} width={deviceWidth}>
           <BackgroundImage>
             <UniqueTokenImage
-              backgroundColor={asset.background}
-              imageUrl={asset.image_url}
+              backgroundColor={asset.background || imageColor}
+              imageUrl={asset.lowResUrl}
               item={asset}
               resizeMode="cover"
               size={CardSize}

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -1,6 +1,6 @@
 import { toLower } from 'lodash';
 import React, { useMemo } from 'react';
-import { ActivityIndicator, PixelRatio, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { ENS_NFT_CONTRACT_ADDRESS } from '../../../references';
 import { magicMemo } from '../../../utils';
 import { SimpleModelView } from '../../3d';
@@ -8,19 +8,9 @@ import { AudioPlayer } from '../../audio';
 import { UniqueTokenImage } from '../../unique-token';
 import { SimpleVideo } from '../../video';
 import { ZoomableWrapper } from './ZoomableWrapper';
-import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
-import {
-  useDimensions,
-  usePersistentAspectRatio,
-  useUniqueToken,
-} from '@rainbow-me/hooks';
+import { usePersistentAspectRatio, useUniqueToken } from '@rainbow-me/hooks';
 import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
-
-const pixelRatio = PixelRatio.get();
-
-const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
-const MAX_IMAGE_SCALE = 4;
 
 const ModelView = styled(SimpleModelView)(position.sizeAsObject('100%'));
 
@@ -46,26 +36,12 @@ const UniqueTokenExpandedStateContent = ({
   onContentFocus,
   onContentBlur,
 }) => {
-  const { width: deviceWidth } = useDimensions();
-
-  const maxImageWidth = deviceWidth - horizontalPadding * 2;
   const isENS =
     toLower(asset.asset_contract.address) === toLower(ENS_NFT_CONTRACT_ADDRESS);
-  const isSVG = isSupportedUriExtension(asset.image_url, ['.svg']);
-  const imageUrl = isSVG
-    ? asset.image_preview_url
-    : asset.image_url ||
-      asset.image_original_url ||
-      asset.image_preview_url ||
-      asset.image_thumbnail_url;
-  const size = deviceWidth * pixelRatio;
   const url = useMemo(() => {
-    if (asset.image_url?.startsWith?.(GOOGLE_USER_CONTENT_URL) && size > 0) {
-      return `${asset.image_url}=w${size * MAX_IMAGE_SCALE}`;
-    }
     if (asset.isPoap) return asset.animation_url;
     return asset.image_url;
-  }, [asset.animation_url, asset.image_url, asset.isPoap, size]);
+  }, [asset.animation_url, asset.image_url, asset.isPoap]);
 
   const { supports3d, supportsVideo, supportsAudio } = useUniqueToken(asset);
 
@@ -97,33 +73,30 @@ const UniqueTokenExpandedStateContent = ({
         {supportsVideo ? (
           <SimpleVideo
             loading={loading}
-            posterUri={imageUrl}
+            posterUri={url}
             setLoading={setLoading}
-            size={maxImageWidth}
             style={StyleSheet.absoluteFill}
-            uri={asset.animation_url || imageUrl}
+            uri={asset.animation_url || url}
           />
         ) : supports3d ? (
           <ModelView
-            fallbackUri={imageUrl}
+            fallbackUri={url}
             loading={loading}
             setLoading={setLoading}
-            size={maxImageWidth}
-            uri={asset.animation_url || imageUrl}
+            uri={asset.animation_url || url}
           />
         ) : supportsAudio ? (
           <AudioPlayer
             fontColor={textColor}
             imageColor={imageColor}
-            uri={asset.animation_url || imageUrl}
+            uri={asset.animation_url || url}
           />
         ) : (
           <UniqueTokenImage
             backgroundColor={asset.background}
-            imageUrl={isSVG ? asset.image_url : url}
+            imageUrl={url}
             item={asset}
             resizeMode={resizeMode}
-            size={maxImageWidth}
             transformSvgs={false}
           />
         )}

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -47,7 +47,7 @@ const UniqueTokenExpandedStateContent = ({
 
   const supportsAnythingExceptImageAnd3d = supportsVideo || supportsAudio;
 
-  const aspectRatio = usePersistentAspectRatio(asset.image_url);
+  const aspectRatio = usePersistentAspectRatio(asset.lowResUrl);
   const aspectRatioWithFallback =
     supports3d || supportsAudio ? 0.88 : aspectRatio.result || 1;
 

--- a/src/components/unique-token/UniqueTokenCard.js
+++ b/src/components/unique-token/UniqueTokenCard.js
@@ -3,6 +3,7 @@ import { ButtonPressAnimation } from '../animations';
 import { InnerBorder } from '../layout';
 import { CardSize } from './CardSize';
 import UniqueTokenImage from './UniqueTokenImage';
+import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
 import {
   usePersistentAspectRatio,
   usePersistentDominantColorFromImage,
@@ -41,6 +42,8 @@ const UniqueTokenCard = ({
   usePersistentAspectRatio(item.image_url);
   usePersistentDominantColorFromImage(item.image_url);
 
+  const isSVG = isSupportedUriExtension(item.image_url, ['.svg']);
+
   const handlePress = useCallback(() => {
     if (onPress) {
       onPress(item);
@@ -65,7 +68,7 @@ const UniqueTokenCard = ({
       <Content {...props} height={size} style={style} width={size}>
         <UniqueTokenImage
           backgroundColor={item.background || colors.lightestGrey}
-          imageUrl={item.image_url}
+          imageUrl={isSVG ? item.lowResUrl : item.image_url}
           isCard
           item={item}
           resizeMode={resizeMode}

--- a/src/components/unique-token/UniqueTokenCard.js
+++ b/src/components/unique-token/UniqueTokenCard.js
@@ -39,8 +39,8 @@ const UniqueTokenCard = ({
   style = undefined,
   ...props
 }) => {
-  usePersistentAspectRatio(item.image_url);
-  usePersistentDominantColorFromImage(item.image_url);
+  usePersistentAspectRatio(item.lowResUrl);
+  usePersistentDominantColorFromImage(item.lowResUrl);
 
   const isSVG = isSupportedUriExtension(item.image_url, ['.svg']);
 

--- a/src/components/unique-token/UniqueTokenImage.js
+++ b/src/components/unique-token/UniqueTokenImage.js
@@ -1,21 +1,14 @@
-import { toLower } from 'lodash';
 import React, { Fragment, useCallback, useState } from 'react';
 import { useTheme } from '../../context/ThemeContext';
 import { buildUniqueTokenName } from '../../helpers/assets';
-import { ENS_NFT_CONTRACT_ADDRESS } from '../../references';
 import { Centered } from '../layout';
 import RemoteSvg from '../svg/RemoteSvg';
-import { Monospace, Text } from '../text';
+import { Monospace } from '../text';
 import svgToPngIfNeeded from '@rainbow-me/handlers/svgs';
 import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
-import {
-  useDimensions,
-  usePersistentDominantColorFromImage,
-} from '@rainbow-me/hooks';
 import { ImgixImage } from '@rainbow-me/images';
 import styled from '@rainbow-me/styled-components';
-import { fonts, fontWithWidth, position } from '@rainbow-me/styles';
-import { getLowResUrl } from '@rainbow-me/utils/getLowResUrl';
+import { position } from '@rainbow-me/styles';
 
 const FallbackTextColorVariants = (darkMode, colors) => ({
   dark: darkMode
@@ -35,18 +28,6 @@ const ImageTile = styled(ImgixImage)({
   justifyContent: 'center',
 });
 
-const ENSText = styled(Text).attrs(
-  ({ isTinyPhone, small, theme: { colors } }) => ({
-    color: colors.whiteLabel,
-    letterSpacing: 'roundedMedium',
-    size: small ? 'smedium' : isTinyPhone ? 'large' : 'bigger',
-  })
-)({
-  padding: 8,
-  textAlign: 'center',
-  ...fontWithWidth(fonts.weight.heavy),
-});
-
 const UniqueTokenImage = ({
   backgroundColor: givenBackgroundColor,
   imageUrl,
@@ -54,70 +35,49 @@ const UniqueTokenImage = ({
   isCard = false,
   resizeMode = ImgixImage.resizeMode.cover,
   size,
-  small = false,
   transformSvgs = true,
 }) => {
-  const { isTinyPhone } = useDimensions();
-  const isENS =
-    toLower(item.asset_contract.address) === toLower(ENS_NFT_CONTRACT_ADDRESS);
   const isSVG = isSupportedUriExtension(imageUrl, ['.svg']);
-  const newImageUrl = transformSvgs ? svgToPngIfNeeded(imageUrl) : imageUrl;
-  const image = isENS && !isSVG ? `${item.image_url}=s1` : newImageUrl;
-  const lowResUrl = isSVG ? newImageUrl : getLowResUrl(image);
   const [error, setError] = useState(null);
   const handleError = useCallback(error => setError(error), [setError]);
   const { isDarkMode, colors } = useTheme();
   const [loadedImg, setLoadedImg] = useState(false);
   const onLoad = useCallback(() => setLoadedImg(true), [setLoadedImg]);
   let backgroundColor = givenBackgroundColor;
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    item.image_url
-  );
 
-  const isOldENS = isENS && !isSVG;
-
-  if (isOldENS && dominantColor) {
-    backgroundColor = dominantColor;
-  }
   return (
     <Centered backgroundColor={backgroundColor} style={position.coverAsObject}>
       {isSVG && !transformSvgs && !error ? (
         <RemoteSvg
           fallbackIfNonAnimated
           fallbackUri={svgToPngIfNeeded(imageUrl, true)}
-          lowResFallbackUri={svgToPngIfNeeded(imageUrl)}
+          lowResFallbackUri={item.lowResUrl}
           onError={handleError}
           resizeMode={resizeMode}
           style={position.coverAsObject}
           uri={item.image_url}
         />
       ) : imageUrl && !error ? (
-        isOldENS ? (
-          <ENSText isTinyPhone={isTinyPhone} small={small}>
-            {item.name}
-          </ENSText>
-        ) : (
-          <Fragment>
+        <Fragment>
+          <ImageTile
+            {...(isCard && { fm: 'png' })}
+            onError={handleError}
+            onLoad={onLoad}
+            resizeMode={ImgixImage.resizeMode[resizeMode]}
+            size={size}
+            source={{ uri: imageUrl }}
+            style={position.coverAsObject}
+          />
+          {!loadedImg && (
             <ImageTile
-              {...(isCard && { fm: 'png' })}
-              onError={handleError}
-              onLoad={onLoad}
+              fm="png"
+              playing={false}
               resizeMode={ImgixImage.resizeMode[resizeMode]}
-              size={size}
-              source={{ uri: image }}
+              source={{ uri: item.lowResUrl }}
               style={position.coverAsObject}
             />
-            {!loadedImg && lowResUrl && (
-              <ImageTile
-                fm="png"
-                playing={false}
-                resizeMode={ImgixImage.resizeMode[resizeMode]}
-                source={{ uri: lowResUrl }}
-                style={position.coverAsObject}
-              />
-            )}
-          </Fragment>
-        )
+          )}
+        </Fragment>
       ) : (
         <Monospace
           align="center"

--- a/src/components/video/SimpleVideo.tsx
+++ b/src/components/video/SimpleVideo.tsx
@@ -21,7 +21,6 @@ import { position } from '@rainbow-me/styles';
 import logger from 'logger';
 
 export type SimpleVideoProps = {
-  readonly size: number;
   readonly style?: ViewStyle;
   readonly uri: string;
   readonly posterUri?: string;
@@ -51,7 +50,6 @@ const styles = StyleSheet.create({
 });
 
 export default function SimpleVideo({
-  size,
   style,
   uri,
   posterUri,
@@ -107,7 +105,7 @@ export default function SimpleVideo({
           pointerEvents={loading ? 'auto' : 'none'}
           style={{ opacity }}
         >
-          <StyledImgixImage size={size} source={{ uri: posterUri }} />
+          <StyledImgixImage source={{ uri: posterUri }} />
         </StyledPosterContainer>
       </View>
     </TouchableWithoutFeedback>

--- a/src/entities/uniqueAssets.ts
+++ b/src/entities/uniqueAssets.ts
@@ -56,6 +56,7 @@ export interface UniqueAsset {
   lastPriceUsd: string | undefined | null;
   lastSale: UniqueAssetLastSale | undefined;
   lastSalePaymentToken: string | undefined | null;
+  lowResUrl: string | null;
   type: AssetType;
   uniqueId: string;
   urlSuffixForAsset: string;

--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -58,15 +58,19 @@ const shouldSignUri = (
     if (staticImgixClient) {
       // Attempt to sign the image.
       let updatedOptions: ImgOptions = {};
-      if (options?.w && options?.h) {
-        updatedOptions = {
-          h: PixelRatio.getPixelSizeForLayoutSize(options.h),
+
+      updatedOptions = {
+        ...(options?.w && {
           w: PixelRatio.getPixelSizeForLayoutSize(options.w),
-        };
-      }
-      if (options?.fm) {
-        updatedOptions.fm = options.fm;
-      }
+        }),
+        ...(options?.h && {
+          h: PixelRatio.getPixelSizeForLayoutSize(options.h),
+        }),
+        ...(options?.fm && {
+          fm: options.fm,
+        }),
+      };
+
       const signedExternalImageUri = staticImgixClient.buildURL(
         externalImageUri,
         updatedOptions
@@ -148,5 +152,5 @@ export const maybeSignSource = (source: Source, options?: {}): Source => {
 };
 
 export const imageToPng = (url: string, w: number) => {
-  return maybeSignUri(url, { w });
+  return maybeSignUri(url, { fm: 'png', w });
 };

--- a/src/hooks/usePersistentAspectRatio.ts
+++ b/src/hooks/usePersistentAspectRatio.ts
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Image } from 'react-native';
 import { MMKV, useMMKVNumber } from 'react-native-mmkv';
-import { getLowResUrl } from '../utils/getLowResUrl';
-import { imageToPng } from '@rainbow-me/handlers/imgix';
-import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
 import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
 
 const storage = new MMKV({
@@ -23,21 +20,15 @@ type Result = {
 };
 
 export default function usePersistentAspectRatio(url: string): Result {
-  const isSVG = isSupportedUriExtension(url, ['.svg']);
-  const nonSvgUrl = isSVG ? imageToPng(url, 200) : url;
-  const [ratio, setAspectRatio] = useMMKVNumber(
-    (nonSvgUrl || '') as string,
-    storage
-  );
+  const [ratio, setAspectRatio] = useMMKVNumber((url || '') as string, storage);
   const [state, setState] = useState<State>(
     ratio !== 0 ? State.loaded : State.init
   );
   useEffect(() => {
-    if (state === State.init && nonSvgUrl) {
-      const lowResUrl = getLowResUrl(nonSvgUrl) as string;
+    if (state === State.init && url) {
       setState(State.loading);
       Image.getSize(
-        lowResUrl,
+        url,
         (width, height) => {
           setAspectRatio(width / height);
           setState(State.loaded);
@@ -45,7 +36,7 @@ export default function usePersistentAspectRatio(url: string): Result {
         () => setState(State.failed)
       );
     }
-  }, [setAspectRatio, state, nonSvgUrl]);
+  }, [setAspectRatio, state, url]);
   return {
     result: ratio,
     state,

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -1,8 +1,5 @@
 import { useEffect, useState } from 'react';
 import { MMKV, useMMKVString } from 'react-native-mmkv';
-import { getLowResUrl } from '../utils/getLowResUrl';
-import { imageToPng } from '@rainbow-me/handlers/imgix';
-import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
 import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
 import { getDominantColorFromImage } from '@rainbow-me/utils';
 
@@ -26,25 +23,22 @@ export default function usePersistentDominantColorFromImage(
   url: string,
   colorToMeasureAgainst: string = '#333333'
 ): Result {
-  const isSVG = isSupportedUriExtension(url, ['.svg']);
-  const nonSvgUrl = isSVG ? imageToPng(url, 200) : url;
   const [dominantColor, setPersistentDominantColor] = useMMKVString(
-    url || '',
+    (url || '') as string,
     storage
   );
   const [state, setState] = useState<State>(
     dominantColor ? State.loaded : State.init
   );
   useEffect(() => {
-    if (state === State.init && nonSvgUrl) {
-      const lowResUrl = getLowResUrl(nonSvgUrl) as string;
+    if (state === State.init && url) {
       setState(State.loading);
-      getDominantColorFromImage(lowResUrl, colorToMeasureAgainst).then(color =>
+      getDominantColorFromImage(url, colorToMeasureAgainst).then(color =>
         // @ts-ignore
         setPersistentDominantColor(color)
       );
     }
-  }, [colorToMeasureAgainst, setPersistentDominantColor, state, nonSvgUrl]);
+  }, [colorToMeasureAgainst, setPersistentDominantColor, state, url]);
 
   return {
     result: dominantColor,

--- a/src/parsers/poap.js
+++ b/src/parsers/poap.js
@@ -40,6 +40,7 @@ export const parsePoaps = data => {
       isSendable: false,
       lastPrice: null,
       lastSalePaymentToken: null,
+      lowResUrl: imageToPng(event.image_url, 300),
       name: event.name,
       permalink: event.event_url,
       traits: [

--- a/src/parsers/poap.js
+++ b/src/parsers/poap.js
@@ -35,11 +35,11 @@ export const parsePoaps = data => {
         'https://lh3.googleusercontent.com/FwLriCvKAMBBFHMxcjqvxjTlmROcDIabIFKRp87NS3u_QfSLxcNThgAzOJSbphgQqnyZ_v2fNgMZQkdCYHUliJwH-Q=s60',
       familyName: 'POAP',
       id: event.id,
+      image_url: imageToPng(event.image_url, 300),
       isPoap: true,
       isSendable: false,
       lastPrice: null,
       lastSalePaymentToken: null,
-      lowResUrl: imageToPng(event.image_url, 300),
       name: event.name,
       permalink: event.event_url,
       traits: [

--- a/src/parsers/poap.js
+++ b/src/parsers/poap.js
@@ -35,11 +35,11 @@ export const parsePoaps = data => {
         'https://lh3.googleusercontent.com/FwLriCvKAMBBFHMxcjqvxjTlmROcDIabIFKRp87NS3u_QfSLxcNThgAzOJSbphgQqnyZ_v2fNgMZQkdCYHUliJwH-Q=s60',
       familyName: 'POAP',
       id: event.id,
-      image_url: imageToPng(event.image_url, 300),
       isPoap: true,
       isSendable: false,
       lastPrice: null,
       lastSalePaymentToken: null,
+      lowResUrl: imageToPng(event.image_url, 300),
       name: event.name,
       permalink: event.event_url,
       traits: [

--- a/src/utils/getFullSizeUrl.ts
+++ b/src/utils/getFullSizeUrl.ts
@@ -1,0 +1,16 @@
+import { PixelRatio } from 'react-native';
+import { maybeSignUri } from '@rainbow-me/handlers/imgix';
+import { deviceUtils } from '@rainbow-me/utils';
+
+export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
+const pixelRatio = PixelRatio.get();
+const deviceWidth = deviceUtils.dimensions.width;
+const size = deviceWidth * pixelRatio;
+const MAX_IMAGE_SCALE = 3;
+
+export const getFullSizeUrl = (url: string) => {
+  if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
+    return `${url}=w${size * MAX_IMAGE_SCALE}`;
+  }
+  return maybeSignUri(url, { w: size * MAX_IMAGE_SCALE });
+};

--- a/src/utils/getLowResUrl.ts
+++ b/src/utils/getLowResUrl.ts
@@ -3,7 +3,7 @@ import { CardSize } from '../components/unique-token/CardSize';
 import { imageToPng } from '@rainbow-me/handlers/imgix';
 
 export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
-const size = Math.floor((Math.ceil(CardSize) * PixelRatio.get()) / 5);
+const size = Math.floor((Math.ceil(CardSize) * PixelRatio.get()) / 3);
 
 export const getLowResUrl = (url: string) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {


### PR DESCRIPTION
Fixes RNBW-2730 RNBW-2917

## What changed (plus any additional context for devs)
fixes some regressions from https://github.com/rainbow-me/rainbow/commit/3eac3a97f1980b61bb0380889c820ddd780a36b4 (low res image handling/progressive loading, certain NFTs not animating properly) 

as well as refactors image/svg handling/signing so its all in one place and is handled upfront rather than in 4 diff spots of the app 

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

all NFTs in `skillet.eth` (aside from genesis bags) should load on asset screen, and when opening the expanded state should open with the image already preloaded, colors & aspect ratios should be correct

few edge cases we want to check:
Loot in `dame.eth`
Max Pain in `0x58A4368a73196921e236f663388A96A209b64EE5`
Peaceful in `jdelman.eth`
## Final checklist

- [x] Assigned individual reviewers?
- [] Added labels?
- [x] Added e2e tests? if not please specify why: just bug fixes
- [] If you added new files, did you update the CODEOWNERS file? 
