### PR TITLE
Fix: android disconnecting messages

### DIFF
--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -166,6 +166,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
       }
 
       walletConnector = new WalletConnect({ clientMeta, uri }, push);
+      let meta = false;
       let navigated = false;
       let timedOut = false;
       let routeParams = {
@@ -238,7 +239,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
           dappUrl,
         });
 
-        const meta = {
+        meta = {
           chainId,
           dappName,
           dappScheme,
@@ -276,7 +277,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
         // We need to add a timeout in case the bridge is down
         // to explain the user what's happening
         timeout = setTimeout(() => {
-          const meta = Navigation.getActiveRoute().params.meta;
+          meta = android ? Navigation.getActiveRoute().params.meta : meta;
           if (meta) return;
           timedOut = true;
           routeParams = { ...routeParams, timedOut };
@@ -287,7 +288,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
         }, 20000);
 
         // If we have the meta, send it
-        const meta = Navigation.getActiveRoute()?.params?.meta;
+        meta = android ? Navigation.getActiveRoute()?.params?.meta : meta;
         if (meta) {
           routeParams = { ...routeParams, meta };
         }

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -146,7 +146,6 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
   getState
 ) => {
   let timeout = null;
-  getState().appState;
   let walletConnector = null;
   const receivedTimestamp = Date.now();
   try {
@@ -167,7 +166,6 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
       }
 
       walletConnector = new WalletConnect({ clientMeta, uri }, push);
-      let meta = null;
       let navigated = false;
       let timedOut = false;
       let routeParams = {
@@ -240,7 +238,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
           dappUrl,
         });
 
-        meta = {
+        const meta = {
           chainId,
           dappName,
           dappScheme,
@@ -278,6 +276,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
         // We need to add a timeout in case the bridge is down
         // to explain the user what's happening
         timeout = setTimeout(() => {
+          const meta = Navigation.getActiveRoute().params.meta;
           if (meta) return;
           timedOut = true;
           routeParams = { ...routeParams, timedOut };
@@ -288,6 +287,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
         }, 20000);
 
         // If we have the meta, send it
+        const meta = Navigation.getActiveRoute()?.params?.meta;
         if (meta) {
           routeParams = { ...routeParams, meta };
         }

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -61,6 +61,7 @@ const WALLETCONNECT_SET_PENDING_REDIRECT =
   'walletconnect/WALLETCONNECT_SET_PENDING_REDIRECT';
 const WALLETCONNECT_REMOVE_PENDING_REDIRECT =
   'walletconnect/WALLETCONNECT_REMOVE_PENDING_REDIRECT';
+const WALLETCONNECT_ADD_URI = 'walletconnect/WALLETCONNECT_ADD_URI';
 
 // -- Actions ---------------------------------------- //
 const getNativeOptions = async () => {
@@ -145,6 +146,13 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
   dispatch,
   getState
 ) => {
+  // branch and linking are triggering this twice
+  // also branch trigger this when the app is coming back from background
+  // so this is a way to handle this case without persisting anything
+  const { walletConnectUris } = getState().walletconnect;
+  if (walletConnectUris.includes(uri)) return;
+  dispatch(saveWalletConnectUri(uri));
+
   let timeout = null;
   let walletConnector = null;
   const receivedTimestamp = Date.now();
@@ -154,6 +162,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
       // Don't initiate a new session if we have already established one using this walletconnect URI
       const allSessions = await getAllValidWalletConnectSessions();
       const wcUri = parseWalletConnectUri(uri);
+
       const alreadyConnected = Object.values(allSessions).some(session => {
         return (
           session.handshakeTopic === wcUri.handshakeTopic &&
@@ -277,7 +286,7 @@ export const walletConnectOnSessionRequest = (uri, callback) => async (
         // We need to add a timeout in case the bridge is down
         // to explain the user what's happening
         timeout = setTimeout(() => {
-          meta = android ? Navigation.getActiveRoute().params.meta : meta;
+          meta = android ? Navigation.getActiveRoute()?.params?.meta : meta;
           if (meta) return;
           timedOut = true;
           routeParams = { ...routeParams, timedOut };
@@ -681,11 +690,21 @@ export const walletConnectSendStatus = (peerId, requestId, response) => async (
   }
 };
 
+export const saveWalletConnectUri = uri => async (dispatch, getState) => {
+  const { walletConnectUris } = getState().walletconnect;
+  const newWalletConnectUris = [...walletConnectUris, uri];
+  dispatch({
+    payload: newWalletConnectUris,
+    type: WALLETCONNECT_ADD_URI,
+  });
+};
+
 // -- Reducer ----------------------------------------- //
 const INITIAL_STATE = {
   pendingRedirect: false,
   pendingRequests: {},
   walletConnectors: {},
+  walletConnectUris: [],
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -708,6 +727,8 @@ export default (state = INITIAL_STATE, action) => {
       return { ...state, pendingRedirect: true };
     case WALLETCONNECT_REMOVE_PENDING_REDIRECT:
       return { ...state, pendingRedirect: false };
+    case WALLETCONNECT_ADD_URI:
+      return { ...state, walletConnectUris: action.payload };
     default:
       return state;
   }

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -60,6 +60,7 @@ import {
   useAccountSettings,
   useCurrentNonce,
   useDimensions,
+  useEffectDebugger,
   useGas,
   useKeyboardHeight,
   useTransactionConfirmation,
@@ -440,7 +441,7 @@ export default function TransactionConfirmationScreen() {
 
   const onPressCancel = useCallback(() => onCancel(), [onCancel]);
 
-  useEffect(() => {
+  useEffectDebugger(() => {
     if (!peerId || !walletConnector) {
       Alert.alert(
         'Connection Expired',

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -60,7 +60,6 @@ import {
   useAccountSettings,
   useCurrentNonce,
   useDimensions,
-  useEffectDebugger,
   useGas,
   useKeyboardHeight,
   useTransactionConfirmation,
@@ -441,7 +440,7 @@ export default function TransactionConfirmationScreen() {
 
   const onPressCancel = useCallback(() => onCancel(), [onCancel]);
 
-  useEffectDebugger(() => {
+  useEffect(() => {
     if (!peerId || !walletConnector) {
       Alert.alert(
         'Connection Expired',


### PR DESCRIPTION
Fixes RNBW-3234

## What changed (plus any additional context for devs)

Wallet connect callback `session_request` is loosing context of the whole method, so the var `meta` is always null outside the callback, the wc callback tries to update it but outside it `meta` will be always null. for some strange reason this is only happening on android, on ios the setTimeout that sends you to the disconnected explainer sheet is cleared correctly inside the wc callback


## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
