### PR TITLE
Profiles: set primary from expanded ens

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -257,7 +257,7 @@ const UniqueTokenExpandedState = ({
   const isNFT = uniqueTokenType === UniqueTokenType.NFT;
 
   // Fetch the ENS profile if the unique token is an ENS name.
-  const cleanENSName = isENS ? uniqueId.split(' ')?.[0] : uniqueId;
+  const cleanENSName = isENS ? uniqueId?.split(' ')?.[0] : uniqueId;
   const ensProfile = useENSProfile(cleanENSName, { enabled: isENS });
   const ensData = ensProfile.data;
 
@@ -608,6 +608,7 @@ const UniqueTokenExpandedState = ({
                               isLoading={ensProfile.isLoading}
                               isOwner={ensProfile?.isOwner}
                               isPrimary={ensData?.primary?.isPrimary}
+                              name={cleanENSName}
                               owner={ensData?.owner}
                               registrant={ensData?.registrant}
                             />

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -54,8 +54,10 @@ import {
   TextProps,
 } from '@rainbow-me/design-system';
 import { AssetTypes, UniqueAsset } from '@rainbow-me/entities';
+import svgToPngIfNeeded from '@rainbow-me/handlers/svgs';
 import { buildUniqueTokenName } from '@rainbow-me/helpers/assets';
 import { REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
+import isSupportedUriExtension from '@rainbow-me/helpers/isSupportedUriExtension';
 import {
   useAccountProfile,
   useBooleanState,
@@ -298,10 +300,12 @@ const UniqueTokenExpandedState = ({
     [showcaseTokens, uniqueId]
   );
 
+  const isSVG = isSupportedUriExtension(asset.image_url || '', ['.svg']);
+  const newImageUrl = svgToPngIfNeeded(asset.image_url, false);
+  const image = isENS && !isSVG ? `${asset.image_url}=s1` : newImageUrl;
+
   const imageColor =
-    // @ts-expect-error image_url could be null or undefined?
-    usePersistentDominantColorFromImage(asset.image_url).result ||
-    colors.paleBlue;
+    usePersistentDominantColorFromImage(image).result || colors.paleBlue;
 
   const textColor = useMemo(() => {
     const contrastWithWhite = c.contrast(imageColor, colors.whiteLabel);
@@ -602,6 +606,8 @@ const UniqueTokenExpandedState = ({
                           >
                             <ConfigurationSection
                               isLoading={ensProfile.isLoading}
+                              isOwner={ensProfile?.isOwner}
+                              isPrimary={ensData?.primary?.isPrimary}
                               owner={ensData?.owner}
                               registrant={ensData?.registrant}
                             />

--- a/src/components/expanded-state/ens/ConfigurationSection.tsx
+++ b/src/components/expanded-state/ens/ConfigurationSection.tsx
@@ -8,11 +8,16 @@ export default function ConfigurationSection({
   isLoading,
   owner,
   registrant,
+  isPrimary,
+  isOwner,
 }: {
   isLoading?: boolean;
   owner?: { name?: string; address?: string };
   registrant?: { name?: string; address?: string };
+  isPrimary?: boolean;
+  isOwner?: boolean;
 }) {
+  console.log('isPrimary', isPrimary, isOwner);
   return (
     <Stack space="15px">
       {isLoading ? (
@@ -22,6 +27,29 @@ export default function ConfigurationSection({
         </>
       ) : (
         <>
+          {/* <Box height="1/5">
+        <Inline alignHorizontal="justify" alignVertical="center">
+          <Text color="secondary80" size="16px" weight="bold">
+            {lang.t('profiles.confirm.set_ens_name')} 􀅵
+          </Text>
+          <Switch
+            disabled={!setSendReverseRecord}
+            onValueChange={() =>
+              setSendReverseRecord?.(sendReverseRecord => !sendReverseRecord)
+            }
+            testID="ens-reverse-record-switch"
+            trackColor={{ false: colors.white, true: accentColor }}
+            value={sendReverseRecord}
+          />
+        </Inline>
+      </Box> */}
+          <InfoRow
+            booleanDisabled={!isOwner}
+            booleanValue={isPrimary}
+            explainSheetType="ens_owner"
+            label={lang.t('expanded_state.unique_expanded.set_primary_name')}
+            useAccentColor
+          />
           {owner && (
             <InfoRow
               explainSheetType="ens_owner"

--- a/src/components/expanded-state/ens/ConfigurationSection.tsx
+++ b/src/components/expanded-state/ens/ConfigurationSection.tsx
@@ -1,7 +1,12 @@
+import { useNavigation } from '@react-navigation/core';
 import lang from 'i18n-js';
 import React from 'react';
+import { ENSConfirmUpdateSheetHeight } from '../../../screens/ENSConfirmRegisterSheet';
 import InfoRow, { InfoRowSkeleton } from './InfoRow';
 import { Stack } from '@rainbow-me/design-system';
+import { REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
+import { useENSRegistration } from '@rainbow-me/hooks';
+import Routes from '@rainbow-me/routes';
 import { formatAddressForDisplay } from '@rainbow-me/utils/abbreviations';
 
 export default function ConfigurationSection({
@@ -10,14 +15,18 @@ export default function ConfigurationSection({
   registrant,
   isPrimary,
   isOwner,
+  name,
 }: {
   isLoading?: boolean;
   owner?: { name?: string; address?: string };
   registrant?: { name?: string; address?: string };
   isPrimary?: boolean;
   isOwner?: boolean;
+  name: string;
 }) {
-  console.log('isPrimary', isPrimary, isOwner);
+  const { startRegistration } = useENSRegistration();
+  const { navigate } = useNavigation();
+
   return (
     <Stack space="15px">
       {isLoading ? (
@@ -27,27 +36,19 @@ export default function ConfigurationSection({
         </>
       ) : (
         <>
-          {/* <Box height="1/5">
-        <Inline alignHorizontal="justify" alignVertical="center">
-          <Text color="secondary80" size="16px" weight="bold">
-            {lang.t('profiles.confirm.set_ens_name')} 􀅵
-          </Text>
-          <Switch
-            disabled={!setSendReverseRecord}
-            onValueChange={() =>
-              setSendReverseRecord?.(sendReverseRecord => !sendReverseRecord)
-            }
-            testID="ens-reverse-record-switch"
-            trackColor={{ false: colors.white, true: accentColor }}
-            value={sendReverseRecord}
-          />
-        </Inline>
-      </Box> */}
           <InfoRow
-            booleanDisabled={!isOwner}
-            booleanValue={isPrimary}
             explainSheetType="ens_owner"
             label={lang.t('expanded_state.unique_expanded.set_primary_name')}
+            onSwitchChange={() => {
+              startRegistration(name, REGISTRATION_MODES.SET_NAME);
+              navigate(Routes.ENS_CONFIRM_REGISTER_SHEET, {
+                longFormHeight: ENSConfirmUpdateSheetHeight,
+                mode: REGISTRATION_MODES.SET_NAME,
+                name,
+              });
+            }}
+            switchDisabled={!isOwner}
+            switchValue={isPrimary}
             useAccentColor
           />
           {owner && (

--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { Switch } from 'react-native-gesture-handler';
 import { useTheme } from '../../../context/ThemeContext';
 import { useNavigation } from '../../../navigation/Navigation';
 import { ShimmerAnimation } from '../../animations';
@@ -10,6 +11,7 @@ import {
   Box,
   Inline,
   Inset,
+  Space,
   Text,
   useForegroundColor,
 } from '@rainbow-me/design-system';
@@ -62,6 +64,8 @@ export default function InfoRow({
   label,
   wrapValue = children => children,
   value = undefined,
+  booleanValue,
+  booleanDisabled,
   useAccentColor,
 }: {
   explainSheetType?: string;
@@ -70,6 +74,8 @@ export default function InfoRow({
   label: string;
   wrapValue?: (children: React.ReactNode) => React.ReactNode;
   value?: string;
+  booleanValue?: boolean;
+  booleanDisabled?: boolean;
   useAccentColor?: boolean;
 }) {
   const { colors } = useTheme();
@@ -77,6 +83,7 @@ export default function InfoRow({
 
   const [show, setShow] = useState(isImage);
   const [isMultiline, setIsMultiline] = useState(false);
+  const isBooleanValue = booleanValue !== undefined;
 
   const { navigate } = useNavigation();
   const handlePressExplain = useCallback(() => {
@@ -117,7 +124,13 @@ export default function InfoRow({
                 setIsMultiline(height > 40);
                 setShow(true);
               }}
-              padding={isMultiline ? '15px' : '10px'}
+              padding={
+                (isBooleanValue
+                  ? '0px'
+                  : isMultiline
+                  ? '15px'
+                  : '10px') as Space
+              }
               style={{
                 backgroundColor: useAccentColor
                   ? accentColor + '10'
@@ -144,6 +157,15 @@ export default function InfoRow({
                   >
                     {value}
                   </Text>
+                )}
+                {isBooleanValue && (
+                  <Switch
+                    disabled={booleanDisabled || booleanValue}
+                    onValueChange={() => null}
+                    testID="ens-reverse-record-switch"
+                    trackColor={{ false: colors.white, true: accentColor }}
+                    value={booleanValue}
+                  />
                 )}
               </Inline>
             </Box>

--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -64,9 +64,10 @@ export default function InfoRow({
   label,
   wrapValue = children => children,
   value = undefined,
-  booleanValue,
-  booleanDisabled,
+  switchValue,
+  switchDisabled,
   useAccentColor,
+  onSwitchChange,
 }: {
   explainSheetType?: string;
   icon?: string;
@@ -74,16 +75,16 @@ export default function InfoRow({
   label: string;
   wrapValue?: (children: React.ReactNode) => React.ReactNode;
   value?: string;
-  booleanValue?: boolean;
-  booleanDisabled?: boolean;
+  switchValue?: boolean;
+  switchDisabled?: boolean;
   useAccentColor?: boolean;
+  onSwitchChange?: () => void;
 }) {
   const { colors } = useTheme();
   const accentColor = useForegroundColor('accent');
 
   const [show, setShow] = useState(isImage);
   const [isMultiline, setIsMultiline] = useState(false);
-  const isBooleanValue = booleanValue !== undefined;
 
   const { navigate } = useNavigation();
   const handlePressExplain = useCallback(() => {
@@ -125,7 +126,7 @@ export default function InfoRow({
                 setShow(true);
               }}
               padding={
-                (isBooleanValue
+                (switchValue !== undefined
                   ? '0px'
                   : isMultiline
                   ? '15px'
@@ -158,13 +159,13 @@ export default function InfoRow({
                     {value}
                   </Text>
                 )}
-                {isBooleanValue && (
+                {switchValue !== undefined && (
                   <Switch
-                    disabled={booleanDisabled || booleanValue}
-                    onValueChange={() => null}
+                    disabled={switchDisabled || switchValue}
+                    onValueChange={onSwitchChange}
                     testID="ens-reverse-record-switch"
                     trackColor={{ false: colors.white, true: accentColor }}
-                    value={booleanValue}
+                    value={switchValue}
                   />
                 )}
               </Inline>

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -1,6 +1,8 @@
 import { useNavigation } from '@react-navigation/core';
 import { differenceInSeconds } from 'date-fns';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// @ts-expect-error
+import { IS_TESTING } from 'react-native-dotenv';
 import { Image } from 'react-native-image-crop-picker';
 import { useDispatch } from 'react-redux';
 import { useRecoilValue } from 'recoil';
@@ -86,7 +88,7 @@ export default function useENSRegistrationActionHandler(
   );
 
   const isTesting = useMemo(
-    () => IS_TESTING && isHardHat(web3Provider.connection.url),
+    () => IS_TESTING === 'true' && isHardHat(web3Provider.connection.url),
     []
   );
 

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -363,6 +363,7 @@
         "in_showcase": "In Showcase",
         "opensea": "Opensea",
         "owner": "Owner",
+        "set_primary_name": "Set as primary ENS name",
         "profile_info": "Profile Info",
         "properties": "Properties",
         "registrant": "Registrant",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -650,6 +650,8 @@
         "requesting_register": "Requesting to Register",
         "reserving_name": "Reserving Your Name",
         "confirm_registration": "Confirm Registration",
+        "set_name_registration": "Set as Primary Name",
+        "confirm_set_name": "Confirm Set Primary Name",
         "start_registration": "Start Registration",
         "confirm_update": "Confirm Update",
         "confirm_renew": "Hold to Extend",

--- a/src/navigation/RegisterENSNavigator.js
+++ b/src/navigation/RegisterENSNavigator.js
@@ -73,6 +73,10 @@ export default function RegisterENSNavigator() {
       startRegistration(ensName, mode);
       return Routes.ENS_ASSIGN_RECORDS_SHEET;
     }
+    if (mode === REGISTRATION_MODES.SET_NAME) {
+      startRegistration(ensName, mode);
+      return Routes.ENS_CONFIRM_REGISTER_SHEET;
+    }
     return Routes.ENS_INTRO_SHEET;
   }, [params, startRegistration]);
   const [currentRouteName, setCurrentRouteName] = useState(initialRouteName);

--- a/src/screens/ENSConfirmRegisterSheet.js
+++ b/src/screens/ENSConfirmRegisterSheet.js
@@ -172,6 +172,8 @@ export default function ENSConfirmRegisterSheet() {
       return lang.t('profiles.confirm.reserving_name');
     if (step === REGISTRATION_STEPS.REGISTER)
       return lang.t('profiles.confirm.confirm_registration');
+    if (step === REGISTRATION_STEPS.SET_NAME)
+      return lang.t('profiles.confirm.set_name_registration');
   }, [mode, step]);
 
   const isSufficientGasForStep = useMemo(
@@ -198,6 +200,7 @@ export default function ENSConfirmRegisterSheet() {
         />
       ),
       [REGISTRATION_STEPS.EDIT]: null,
+      [REGISTRATION_STEPS.SET_NAME]: null,
       [REGISTRATION_STEPS.RENEW]: (
         <RenewContent
           name={name}
@@ -281,6 +284,16 @@ export default function ENSConfirmRegisterSheet() {
           testID={step}
         />
       ),
+      [REGISTRATION_STEPS.SET_NAME]: (
+        <TransactionActionRow
+          accentColor={accentColor}
+          action={() => action(goToProfileScreen)}
+          isSufficientGas={isSufficientGasForStep}
+          isValidGas={isValidGas && Boolean(gasLimit)}
+          label={lang.t('profiles.confirm.confirm_set_name')}
+          testID={step}
+        />
+      ),
       [REGISTRATION_STEPS.WAIT_COMMIT_CONFIRMATION]: null,
       [REGISTRATION_STEPS.WAIT_ENS_COMMITMENT]: null,
     }),
@@ -313,6 +326,7 @@ export default function ENSConfirmRegisterSheet() {
       step === REGISTRATION_STEPS.COMMIT ||
       step === REGISTRATION_STEPS.REGISTER ||
       step === REGISTRATION_STEPS.EDIT ||
+      step === REGISTRATION_STEPS.SET_NAME ||
       step === REGISTRATION_STEPS.RENEW
     )
       startPollingGasFees();


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Add the option to set primary name from expanded state
also noticed that the expanded state accent color wasn't using the right color, it was using a broken link from opensea

## PoW (screenshots / screen recordings)


https://user-images.githubusercontent.com/12115171/163291788-6ef08dc2-b154-4511-8eea-41e7519361a8.mp4

waiting for https://github.com/rainbow-me/rainbow/pull/3191 to put it as ready since there's an explainer sheet i need here

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
