### PR TITLE
Do not remount rows of RecyclerListView

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -36,7 +36,7 @@ function CellDataProvider({
 
 function rowRenderer(type: CellType, { uid }: { uid: string }) {
   return (
-    <CellDataProvider key={uid} uid={uid}>
+    <CellDataProvider uid={uid}>
       {data => {
         switch (type) {
           case CellType.ASSETS_HEADER_SPACE_AFTER:

--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -36,7 +36,7 @@ function CellDataProvider({
 
 function rowRenderer(type: CellType, { uid }: { uid: string }) {
   return (
-    <CellDataProvider key={uid} uid={uid}>
+    <CellDataProvider uid={uid}>
       {data => {
         switch (type) {
           case CellType.ASSETS_HEADER_SPACE_AFTER:
@@ -118,7 +118,6 @@ function rowRenderer(type: CellType, { uid }: { uid: string }) {
           case CellType.LOADING_ASSETS:
             return <AssetListItemSkeleton />;
         }
-        assertNever(type);
       }}
     </CellDataProvider>
   );

--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -36,7 +36,7 @@ function CellDataProvider({
 
 function rowRenderer(type: CellType, { uid }: { uid: string }) {
   return (
-    <CellDataProvider uid={uid}>
+    <CellDataProvider key={uid} uid={uid}>
       {data => {
         switch (type) {
           case CellType.ASSETS_HEADER_SPACE_AFTER:
@@ -118,6 +118,7 @@ function rowRenderer(type: CellType, { uid }: { uid: string }) {
           case CellType.LOADING_ASSETS:
             return <AssetListItemSkeleton />;
         }
+        assertNever(type);
       }}
     </CellDataProvider>
   );


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

[While reading the documentation](https://github.com/Flipkart/recyclerlistview/tree/master/docs/guides/performance#2-key-prop-is-not-needed) of the recyclerlistview library noticed that we should not provide the key to RowRenderer because rows are being reused (updated with new props) instead of remounted as FlatList does.

It can be easily verified by adding this hook to `WrapperBalanceCoinRow`:

```js
  useEffect(() => {
    return () => {
      console.log('Unmount');
    };
  }, []);
```

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

- it should not remount views

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
