### PR TITLE
Profiles: Drop metadata.ens.domains fallback in favour of The Graph + ImgixImage

### DIFF
--- a/src/apollo/queries.ts
+++ b/src/apollo/queries.ts
@@ -340,3 +340,17 @@ export const CONTRACT_FUNCTION = gql`
     }
   }
 `;
+
+export type EnsGetNameFromLabelhash = {
+  domains: {
+    labelName: string;
+  }[];
+};
+
+export const ENS_GET_NAME_FROM_LABELHASH = gql`
+  query lookup($labelhash: String!) {
+    domains(first: 1, where: { labelhash: $labelhash }) {
+      labelName
+    }
+  }
+`;


### PR DESCRIPTION
Fixes RNBW-3278

## What changed (plus any additional context for devs)

This PR removes the dependency on fetching via `https://metadata.ens.domains` to retrieve the ENS NFT image + name, and instead rely on the graph to fetch an ENS name & fetching the image directly via `ImgixImage`.
