### PR TITLE
Profiles: Make ordering of action buttons match order of fields

### DIFF
--- a/src/components/discover-sheet/RegisterENSSection.tsx
+++ b/src/components/discover-sheet/RegisterENSSection.tsx
@@ -27,11 +27,11 @@ export default function RegisterENSSection() {
   const { isReadOnlyWallet } = useWallets();
 
   const handlePress = useCallback(() => {
-    if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
-      navigate(Routes.REGISTER_ENS_NAVIGATOR);
-    } else {
-      watchingAlert();
-    }
+    navigate(Routes.REGISTER_ENS_NAVIGATOR);
+    // if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+    // } else {
+    //   watchingAlert();
+    // }
   }, [isReadOnlyWallet, navigate]);
 
   useEffect(() => {

--- a/src/components/discover-sheet/RegisterENSSection.tsx
+++ b/src/components/discover-sheet/RegisterENSSection.tsx
@@ -27,11 +27,11 @@ export default function RegisterENSSection() {
   const { isReadOnlyWallet } = useWallets();
 
   const handlePress = useCallback(() => {
-    navigate(Routes.REGISTER_ENS_NAVIGATOR);
-    // if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
-    // } else {
-    //   watchingAlert();
-    // }
+    if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+      navigate(Routes.REGISTER_ENS_NAVIGATOR);
+    } else {
+      watchingAlert();
+    }
   }, [isReadOnlyWallet, navigate]);
 
   useEffect(() => {

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -103,7 +103,6 @@ export const textRecordFields = {
     inputProps: {
       maxLength: 50,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.displayName,
     label: lang.t('profiles.create.name'),
     placeholder: lang.t('profiles.create.name_placeholder'),
@@ -114,26 +113,22 @@ export const textRecordFields = {
       maxLength: 100,
       multiline: true,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.description,
     label: lang.t('profiles.create.bio'),
     placeholder: lang.t('profiles.create.bio_placeholder'),
   },
-  [ENS_RECORDS.email]: {
-    id: 'email',
+  [ENS_RECORDS.twitter]: {
+    id: 'twitter',
     inputProps: {
-      maxLength: 50,
+      maxLength: 16,
     },
-    isPrimaryDisplayRecord: true,
-    key: ENS_RECORDS.email,
-    label: lang.t('profiles.create.email'),
-    placeholder: lang.t('profiles.create.email_placeholder'),
+    key: ENS_RECORDS.twitter,
+    label: lang.t('profiles.create.twitter'),
+    placeholder: lang.t('profiles.create.username_placeholder'),
+    startsWith: '@',
     validations: {
-      onSubmit: {
-        match: {
-          message: lang.t('profiles.create.email_submit_message'),
-          value: /^\S+@\S+\.\S+$/,
-        },
+      onChange: {
+        match: /^\w*$/,
       },
     },
   },
@@ -146,19 +141,20 @@ export const textRecordFields = {
     label: lang.t('profiles.create.pronouns'),
     placeholder: lang.t('profiles.create.pronouns_placeholder'),
   },
-  [ENS_RECORDS.twitter]: {
-    id: 'twitter',
+  [ENS_RECORDS.email]: {
+    id: 'email',
     inputProps: {
-      maxLength: 16,
+      maxLength: 50,
     },
-    isPrimaryDisplayRecord: true,
-    key: ENS_RECORDS.twitter,
-    label: lang.t('profiles.create.twitter'),
-    placeholder: lang.t('profiles.create.username_placeholder'),
-    startsWith: '@',
+    key: ENS_RECORDS.email,
+    label: lang.t('profiles.create.email'),
+    placeholder: lang.t('profiles.create.email_placeholder'),
     validations: {
-      onChange: {
-        match: /^\w*$/,
+      onSubmit: {
+        match: {
+          message: lang.t('profiles.create.email_submit_message'),
+          value: /^\S+@\S+\.\S+$/,
+        },
       },
     },
   },
@@ -168,7 +164,6 @@ export const textRecordFields = {
       keyboardType: 'url',
       maxLength: 100,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.url,
     label: lang.t('profiles.create.website'),
     placeholder: lang.t('profiles.create.website_placeholder'),
@@ -186,7 +181,6 @@ export const textRecordFields = {
     inputProps: {
       maxLength: 20,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.github,
     label: lang.t('profiles.create.github'),
     placeholder: lang.t('profiles.create.username_placeholder'),
@@ -196,7 +190,6 @@ export const textRecordFields = {
     inputProps: {
       maxLength: 30,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.instagram,
     label: lang.t('profiles.create.instagram'),
     placeholder: lang.t('profiles.create.username_placeholder'),
@@ -212,7 +205,6 @@ export const textRecordFields = {
     inputProps: {
       maxLength: 16,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.snapchat,
     label: lang.t('profiles.create.snapchat'),
     placeholder: lang.t('profiles.create.username_placeholder'),
@@ -228,7 +220,6 @@ export const textRecordFields = {
     inputProps: {
       maxLength: 50,
     },
-    isPrimaryDisplayRecord: true,
     key: ENS_RECORDS.discord,
     label: lang.t('profiles.create.discord'),
     placeholder: lang.t('profiles.create.username_placeholder'),

--- a/src/screens/ENSAdditionalRecordsSheet.js
+++ b/src/screens/ENSAdditionalRecordsSheet.js
@@ -64,7 +64,9 @@ export default function ENSAdditionalRecordsSheet() {
                       onRemoveField(fieldToRemove, newFields);
                     } else {
                       const fieldToAdd = textRecordField;
-                      onAddField(fieldToAdd, [...selectedFields, fieldToAdd]);
+                      const newSelectedFields = [...selectedFields];
+                      newSelectedFields.splice(i, 0, fieldToAdd);
+                      onAddField(fieldToAdd, newSelectedFields);
                     }
                   }}
                   testID={`ens-selectable-attribute-${textRecordField.id}`}

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -76,8 +76,8 @@ export default function ENSAssignRecordsSheet() {
     defaultFields: [
       ENS_RECORDS.displayName,
       ENS_RECORDS.description,
-      ENS_RECORDS.email,
       ENS_RECORDS.twitter,
+      ENS_RECORDS.pronouns,
     ].map(fieldName => textRecordFields[fieldName]),
   });
 
@@ -400,6 +400,8 @@ function Shadow() {
   );
 }
 
+const MAX_DISPLAY_BUTTONS = 9;
+
 function SelectableAttributesButtons({
   selectedFields,
   onAddField,
@@ -408,7 +410,7 @@ function SelectableAttributesButtons({
 }) {
   const dotsButtonIsSelected = useMemo(() => {
     const nonPrimaryRecordsIds = Object.values(textRecordFields)
-      .filter(({ isPrimaryDisplayRecord }) => !isPrimaryDisplayRecord)
+      .slice(MAX_DISPLAY_BUTTONS)
       .map(({ id }) => id);
     const dotsSelected = selectedFields.some(field =>
       nonPrimaryRecordsIds.includes(field.id)
@@ -419,7 +421,7 @@ function SelectableAttributesButtons({
   return (
     <Inline space="10px">
       {Object.values(textRecordFields)
-        .filter(record => record.isPrimaryDisplayRecord)
+        .slice(0, MAX_DISPLAY_BUTTONS)
         .map((textRecordField, i) => {
           const isSelected = selectedFields.some(
             field => field.id === textRecordField.id
@@ -439,7 +441,9 @@ function SelectableAttributesButtons({
                   onRemoveField(fieldToRemove, newFields);
                 } else {
                   const fieldToAdd = textRecordField;
-                  onAddField(fieldToAdd, [...selectedFields, fieldToAdd]);
+                  const newSelectedFields = [...selectedFields];
+                  newSelectedFields.splice(i, 0, fieldToAdd);
+                  onAddField(fieldToAdd, newSelectedFields);
                 }
               }}
               testID={`ens-selectable-attribute-${textRecordField.id}`}


### PR DESCRIPTION
Fixes RNBW-3197

## What changed (plus any additional context for devs)

This PR ensures that the ordering of the selectable text records buttons matches the order of the text fields. 

I have also refactored to omit the `isPrimaryDisplayRecord` flag and instead take the first 9 records from `textRecordFields`. This ensures that if we chose to remove or add a field as a primary display button, then it wont affect the layout (button overflow or lack of buttons to display)

