### PR TITLE
Remove toChecksumAddress for assets urls

### DIFF
--- a/src/utils/getUrlForTrustIconFallback.ts
+++ b/src/utils/getUrlForTrustIconFallback.ts
@@ -1,10 +1,9 @@
-import { toChecksumAddress } from '../handlers/web3';
 import { EthereumAddress } from '@rainbow-me/entities';
 
 export default function getUrlForTrustIconFallback(
   address: EthereumAddress
 ): string | null {
   if (!address) return null;
-  const checksummedAddress = toChecksumAddress(address);
-  return `https://raw.githubusercontent.com/rainbow-me/assets/master/blockchains/ethereum/assets/${checksummedAddress}/logo.png`;
+  const lowercasedAddress = address.toLowerCase();
+  return `https://raw.githubusercontent.com/rainbow-me/assets/develop/blockchains/ethereum/assets/${lowercasedAddress}/logo.png`;
 }

--- a/src/utils/getUrlForTrustIconFallback.ts
+++ b/src/utils/getUrlForTrustIconFallback.ts
@@ -5,5 +5,5 @@ export default function getUrlForTrustIconFallback(
 ): string | null {
   if (!address) return null;
   const lowercasedAddress = address.toLowerCase();
-  return `https://raw.githubusercontent.com/rainbow-me/assets/develop/blockchains/ethereum/assets/${lowercasedAddress}/logo.png`;
+  return `https://raw.githubusercontent.com/rainbow-me/assets/lowercase/blockchains/ethereum/assets/${lowercasedAddress}/logo.png`;
 }


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
Created a new (default) branch on the assets repo where all the addresses are lowercased so we don't have to call the expensive function  `toChecksumAddress`

## PoW (screenshots / screen recordings)
Before (checksummed): 
https://raw.githubusercontent.com/rainbow-me/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png

After (lowercase):
https://raw.githubusercontent.com/rainbow-me/assets/lowercase/blockchains/ethereum/assets/0x6b175474e89094c44da98b954eedeac495271d0f/logo.png

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why - Doesn't apply
- [ ] If you added new files, did you update the CODEOWNERS file? - No new files
