### PR TITLE
use MD5 through JSI with react-native-quick-md5

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -388,6 +388,8 @@ PODS:
   - react-native-palette-full (1.2.0):
     - React
     - SDWebImage (~> 5)
+  - react-native-quick-md5 (3.0.3):
+    - React-Core
   - react-native-randombytes (3.5.3):
     - React
   - react-native-restart (0.0.22):
@@ -658,6 +660,7 @@ DEPENDENCIES:
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-palette-full (from `../node_modules/react-native-palette-full`)
+  - react-native-quick-md5 (from `../node_modules/react-native-quick-md5`)
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
   - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -842,6 +845,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-palette-full:
     :path: "../node_modules/react-native-palette-full"
+  react-native-quick-md5:
+    :path: "../node_modules/react-native-quick-md5"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
   react-native-restart:
@@ -1036,6 +1041,7 @@ SPEC CHECKSUMS:
   react-native-mmkv: 27029f9f3a30dc798726cfc92775f4cbedcb7dd7
   react-native-netinfo: 250dc0ca126512f618a8a2ca6a936577e1f66586
   react-native-palette-full: 99a6fd796d16fab6a2d3770649070e31c2602fad
+  react-native-quick-md5: 20039aa5f718178ee370d523ca2918a2ccae097d
   react-native-randombytes: 3638d24759d67c68f6ccba60c52a7a8a8faa6a23
   react-native-restart: 733a51ad137f15b0f8dc34c4082e55af7da00979
   react-native-safe-area-context: 13004a45f3021328fdd9ee1f987c3131fb65928d

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "react-native-os": "brunobar79/react-native-os#41a08e45260b8c1c53c77ad00e13ae954cb9337c",
     "react-native-palette-full": "1.2.0",
     "react-native-permissions": "3.0.5",
+    "react-native-quick-md5": "https://github.com/craftzdog/react-native-quick-md5",
     "react-native-radial-gradient": "rainbow-me/react-native-radial-gradient#1266cd8f6ac3321bcf27357f8771bd088f9f27ef",
     "react-native-randombytes": "3.5.3",
     "react-native-reanimated": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "react-native-os": "brunobar79/react-native-os#41a08e45260b8c1c53c77ad00e13ae954cb9337c",
     "react-native-palette-full": "1.2.0",
     "react-native-permissions": "3.0.5",
-    "react-native-quick-md5": "https://github.com/craftzdog/react-native-quick-md5",
+    "react-native-quick-md5": "3.0.3",
     "react-native-radial-gradient": "rainbow-me/react-native-radial-gradient#1266cd8f6ac3321bcf27357f8771bd088f9f27ef",
     "react-native-randombytes": "3.5.3",
     "react-native-reanimated": "2.4.1",

--- a/patches/imgix-core-js+2.3.2.patch
+++ b/patches/imgix-core-js+2.3.2.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/imgix-core-js/dist/imgix-core-js.js b/node_modules/imgix-core-js/dist/imgix-core-js.js
+index 56398af..b237dcd 100644
+--- a/node_modules/imgix-core-js/dist/imgix-core-js.js
++++ b/node_modules/imgix-core-js/dist/imgix-core-js.js
+@@ -1,3 +1,5 @@
++import { stringMd5 } from 'react-native-quick-md5'
++
+ (function (global, factory) {
+   if (typeof define === 'function' && define.amd) {
+     define('Imgix', ['exports', 'md5', 'js-base64'], factory);
+@@ -134,7 +136,7 @@
+ 
+     ImgixClient.prototype._signParams = function(path, queryParams) {
+       var signatureBase = this.settings.secureURLToken + path + queryParams;
+-      var signature = md5(signatureBase);
++      var signature = stringMd5(signatureBase);
+ 
+       if (queryParams.length > 0) {
+         return queryParams = queryParams + "&s=" + signature;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14933,9 +14933,10 @@ react-native-permissions@3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.5.tgz#94542a343abdac801fa0a4593ea2c751cb45c41f"
 
-"react-native-quick-md5@https://github.com/craftzdog/react-native-quick-md5":
+react-native-quick-md5@3.0.3:
   version "3.0.3"
-  resolved "https://github.com/craftzdog/react-native-quick-md5#878ca7b0e290aec5b02983e75ac1eb36f954b4be"
+  resolved "https://registry.yarnpkg.com/react-native-quick-md5/-/react-native-quick-md5-3.0.3.tgz#f75f2fc3f9b62f312eb27a223f4505f9f57e3550"
+  integrity sha512-3rSZZZty/E6odfIh9uVwcxouISZbIcJmwmghlSc/EtYuY7e93ewh/+UxJBHF2LOM2I/YdhgA3qHR0IibD9kqyQ==
   dependencies:
     spark-md5 "^3.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14933,6 +14933,12 @@ react-native-permissions@3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.5.tgz#94542a343abdac801fa0a4593ea2c751cb45c41f"
 
+"react-native-quick-md5@https://github.com/craftzdog/react-native-quick-md5":
+  version "3.0.3"
+  resolved "https://github.com/craftzdog/react-native-quick-md5#878ca7b0e290aec5b02983e75ac1eb36f954b4be"
+  dependencies:
+    spark-md5 "^3.0.2"
+
 react-native-radial-gradient@rainbow-me/react-native-radial-gradient#1266cd8f6ac3321bcf27357f8771bd088f9f27ef:
   version "1.0.9"
   resolved "https://codeload.github.com/rainbow-me/react-native-radial-gradient/tar.gz/1266cd8f6ac3321bcf27357f8771bd088f9f27ef"
@@ -16309,6 +16315,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+spark-md5@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
+  integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
 spawn-wrap@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes RNBW-3325

## What changed (plus any additional context for devs)

I used the MD5 function through JSI

Methodology:![image](https://user-images.githubusercontent.com/25709300/164233158-c9263bf3-a37c-434d-b2cb-90cf10443714.jpeg)


results:
Android:
before:
![LOG TOTAL 66 72602987289429](https://user-images.githubusercontent.com/25709300/164230643-748d76da-d993-411c-92ae-c083722ec24d.png)

After
![TOTAL 14 525776863098145](https://user-images.githubusercontent.com/25709300/164230658-b6dee463-412e-40ba-aafe-329c65da1fd4.png)


iOS:
before:
![TOTAL 44 21558330953121](https://user-images.githubusercontent.com/25709300/164230695-7e96611a-f7eb-4835-b96c-037cd6ad3199.png)
After:
![TOTAL 5 143124938011169](https://user-images.githubusercontent.com/25709300/164230715-76b96a52-d205-4c5b-8398-0911004875e0.png)


## PoW (screenshots / screen recordings)

Should be no-op, images should load 
<img width="397" alt="Discover" src="https://user-images.githubusercontent.com/25709300/164230875-d18392ff-a12a-4690-867a-42dd3ca10d08.png">

<img width="397" alt="Discover" src="https://user-images.githubusercontent.com/25709300/164230920-44773ad7-c251-4357-bbe6-28c05d1dada1.png">



## Dev checklist for QA: what to test

Should be no-op

rel: https://github.com/rainbow-me/rainbow-scripts
