### PR TITLE
Profiles polish

### DIFF
--- a/src/components/discover-sheet/RegisterENSSection.tsx
+++ b/src/components/discover-sheet/RegisterENSSection.tsx
@@ -16,7 +16,7 @@ import {
   Stack,
   Text,
 } from '@rainbow-me/design-system';
-import { useWallets } from '@rainbow-me/hooks';
+import { useAccountENSDomains, useWallets } from '@rainbow-me/hooks';
 import { ensIntroMarqueeNames } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 import { watchingAlert } from '@rainbow-me/utils';
@@ -25,6 +25,8 @@ export default function RegisterENSSection() {
   const { navigate } = useNavigation();
   const { colors } = useTheme();
   const { isReadOnlyWallet } = useWallets();
+
+  useAccountENSDomains();
 
   const handlePress = useCallback(() => {
     if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -69,6 +69,9 @@ export const fetchMetadata = async ({
   }
 };
 
+export const isUnknownOpenSeaENSDescription = (description?: string) =>
+  description?.includes('This is an unknown ENS name with the hash') || false;
+
 export const fetchSuggestions = async (
   recipient: any,
   setSuggestions: any,

--- a/src/hooks/useAccountENSDomains.ts
+++ b/src/hooks/useAccountENSDomains.ts
@@ -49,9 +49,7 @@ export default function useAccountENSDomains() {
   const { accountAddress } = useAccountSettings();
   return useQuery<
     EnsAccountRegistratonsData['account']['registrations'][number]['domain'][]
-  >(
-    queryKey({ accountAddress }),
-    async () => fetchAccountENSDomains({ accountAddress }),
-    { staleTime: 60000 }
+  >(queryKey({ accountAddress }), async () =>
+    fetchAccountENSDomains({ accountAddress })
   );
 }

--- a/src/hooks/useAccountENSDomains.ts
+++ b/src/hooks/useAccountENSDomains.ts
@@ -49,7 +49,9 @@ export default function useAccountENSDomains() {
   const { accountAddress } = useAccountSettings();
   return useQuery<
     EnsAccountRegistratonsData['account']['registrations'][number]['domain'][]
-  >(queryKey({ accountAddress }), async () =>
-    fetchAccountENSDomains({ accountAddress })
+  >(
+    queryKey({ accountAddress }),
+    async () => fetchAccountENSDomains({ accountAddress }),
+    { staleTime: 60000 }
   );
 }

--- a/src/screens/ExpandedAssetSheet.js
+++ b/src/screens/ExpandedAssetSheet.js
@@ -13,6 +13,7 @@ import {
 } from '../components/expanded-state';
 import { Centered } from '../components/layout';
 import { useTheme } from '@rainbow-me/context';
+import { isUnknownOpenSeaENSDescription } from '@rainbow-me/handlers/ens';
 import { useAsset, useDimensions } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import styled from '@rainbow-me/styled-components';
@@ -50,7 +51,9 @@ export default function ExpandedAssetSheet(props) {
   // We want to revalidate (ie. refresh OpenSea metadata) collectibles
   // to ensure the user can get the latest metadata of their collectible.
   const selectedAsset = useAsset(params.asset, {
-    revalidateCollectibleInBackground: true,
+    revalidateCollectibleInBackground: isUnknownOpenSeaENSDescription(
+      params?.asset?.description
+    ),
   });
 
   return (


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

https://github.com/rainbow-me/rainbow/commit/a411ad53d8b3a4c9d93350f2b21f6b1ec32fbdeb added stale time to the query and I put the hook in the ens card so we fetch that info before going to the intro screen and the data is ready

https://github.com/rainbow-me/rainbow/commit/7e5512ea83972a90d70254dca23ff7d25e42b87f  we'll be revalidating nft in background only for ens nft that are unknown for opensea (we are still using the fallback correctly for ens nfts), we're doing it for all nfts now, @christianbaroni idea in the future is to have this action in a button somewhere in the ui for the rest of nfts 

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
