### PR TITLE
Profiles: tweak isLoading conditions in useENSRegistrationForm

### DIFF
--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -198,7 +198,7 @@ export default function useENSRegistrationForm({
   }, [updateRecords, values]);
 
   const [isLoading, setIsLoading] = useState(
-    mode === REGISTRATION_MODES.EDIT && isEmpty(values)
+    mode === REGISTRATION_MODES.EDIT && !profileQuery.isSuccess
   );
 
   useEffect(() => {

--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -198,7 +198,8 @@ export default function useENSRegistrationForm({
   }, [updateRecords, values]);
 
   const [isLoading, setIsLoading] = useState(
-    mode === REGISTRATION_MODES.EDIT && !profileQuery.isSuccess
+    mode === REGISTRATION_MODES.EDIT &&
+      (!profileQuery.isSuccess || isEmpty(values))
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes RNBW-3370

## What changed (plus any additional context for devs)
-` isLoading` in useENSRegistrationForm will be true until `profileQuery.isSuccess` is true

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/15272675/164789457-1b610cf3-08bd-487b-ab5f-e1a020f320eb.mp4

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
