### PR TITLE
check native currency before updating assets 

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1358,25 +1358,29 @@ export const assetPricesChanged = (
   dispatch: Dispatch<DataUpdateGenericAssetsAction>,
   getState: AppGetState
 ) => {
-  const price = message?.payload?.prices?.[0]?.price;
-  const assetAddress = message?.meta?.asset_code;
-  if (isNil(price) || isNil(assetAddress)) return;
-  const { genericAssets } = getState().data;
-  const genericAsset = {
-    ...get(genericAssets, assetAddress),
-    price,
-  };
-  const updatedAssets = {
-    ...genericAssets,
-    [assetAddress]: genericAsset,
-  } as {
-    [address: string]: ParsedAddressAsset;
-  };
+  const { nativeCurrency } = getState().settings;
 
-  dispatch({
-    payload: updatedAssets,
-    type: DATA_UPDATE_GENERIC_ASSETS,
-  });
+  if (toLower(nativeCurrency) === message?.meta?.currency) {
+    const price = message?.payload?.prices?.[0]?.price;
+    const assetAddress = message?.meta?.asset_code;
+    if (isNil(price) || isNil(assetAddress)) return;
+    const { genericAssets } = getState().data;
+    const genericAsset = {
+      ...get(genericAssets, assetAddress),
+      price,
+    };
+    const updatedAssets = {
+      ...genericAssets,
+      [assetAddress]: genericAsset,
+    } as {
+      [address: string]: ParsedAddressAsset;
+    };
+
+    dispatch({
+      payload: updatedAssets,
+      type: DATA_UPDATE_GENERIC_ASSETS,
+    });
+  }
 };
 
 /**

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1355,15 +1355,16 @@ export const assetPricesReceived = (
 export const assetPricesChanged = (
   message: AssetPricesChangedMessage | undefined
 ) => (
-  dispatch: Dispatch<DataUpdateGenericAssetsAction>,
+  dispatch: Dispatch<DataUpdateGenericAssetsAction | DataUpdateEthUsdAction>,
   getState: AppGetState
 ) => {
   const { nativeCurrency } = getState().settings;
 
+  const price = message?.payload?.prices?.[0]?.price;
+  const assetAddress = message?.meta?.asset_code;
+  if (isNil(price) || isNil(assetAddress)) return;
+
   if (toLower(nativeCurrency) === message?.meta?.currency) {
-    const price = message?.payload?.prices?.[0]?.price;
-    const assetAddress = message?.meta?.asset_code;
-    if (isNil(price) || isNil(assetAddress)) return;
     const { genericAssets } = getState().data;
     const genericAsset = {
       ...get(genericAssets, assetAddress),
@@ -1379,6 +1380,13 @@ export const assetPricesChanged = (
     dispatch({
       payload: updatedAssets,
       type: DATA_UPDATE_GENERIC_ASSETS,
+    });
+  }
+
+  if (message?.meta?.currency === 'usd' && assetAddress === ETH_ADDRESS) {
+    dispatch({
+      payload: price?.value,
+      type: DATA_UPDATE_ETH_USD,
     });
   }
 };

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -38,6 +38,7 @@ import { uniqueTokensRefreshState } from './uniqueTokens';
 import { uniswapUpdateLiquidityTokens } from './uniswapLiquidity';
 import {
   AssetTypes,
+  NativeCurrencyKeys,
   NewTransactionOrAddCashTransaction,
   ParsedAddressAsset,
   RainbowTransaction,
@@ -1338,7 +1339,11 @@ export const assetPricesReceived = (
       type: DATA_UPDATE_GENERIC_ASSETS,
     });
   }
-  if (message?.meta?.currency === 'usd' && newAssetPrices[ETH_ADDRESS]) {
+  if (
+    message?.meta?.currency?.toLowerCase() ===
+      NativeCurrencyKeys.USD.toLowerCase() &&
+    newAssetPrices[ETH_ADDRESS]
+  ) {
     const value = newAssetPrices[ETH_ADDRESS]?.price?.value;
     dispatch({
       payload: value,
@@ -1364,7 +1369,7 @@ export const assetPricesChanged = (
   const assetAddress = message?.meta?.asset_code;
   if (isNil(price) || isNil(assetAddress)) return;
 
-  if (toLower(nativeCurrency) === message?.meta?.currency) {
+  if (nativeCurrency?.toLowerCase() === message?.meta?.currency) {
     const { genericAssets } = getState().data;
     const genericAsset = {
       ...get(genericAssets, assetAddress),
@@ -1382,8 +1387,11 @@ export const assetPricesChanged = (
       type: DATA_UPDATE_GENERIC_ASSETS,
     });
   }
-
-  if (message?.meta?.currency === 'usd' && assetAddress === ETH_ADDRESS) {
+  if (
+    message?.meta?.currency?.toLowerCase() ===
+      NativeCurrencyKeys.USD.toLowerCase() &&
+    assetAddress === ETH_ADDRESS
+  ) {
     dispatch({
       payload: price?.value,
       type: DATA_UPDATE_ETH_USD,


### PR DESCRIPTION
Fixes RNBW-3407

## What changed (plus any additional context for devs)

noticed we intermittently had the eth price revert back to USD when using a diff native currency. We subscribe to USD prices at the same time to keep the eth price in USD up to date which I imagine is causing this issue. 

We already do this check for `assetPricesReceived` 

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test
change native currency to rupees, open swap eth -> dai.
in develop eventually it will revert and gas should show usd value
in this branch im unable to repro

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
