### PR TITLE
Profiles: improve registrations fetch

### DIFF
--- a/src/components/discover-sheet/RegisterENSSection.tsx
+++ b/src/components/discover-sheet/RegisterENSSection.tsx
@@ -16,7 +16,7 @@ import {
   Stack,
   Text,
 } from '@rainbow-me/design-system';
-import { useAccountENSDomains, useWallets } from '@rainbow-me/hooks';
+import { useWallets } from '@rainbow-me/hooks';
 import { ensIntroMarqueeNames } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 import { watchingAlert } from '@rainbow-me/utils';
@@ -25,8 +25,6 @@ export default function RegisterENSSection() {
   const { navigate } = useNavigation();
   const { colors } = useTheme();
   const { isReadOnlyWallet } = useWallets();
-
-  useAccountENSDomains();
 
   const handlePress = useCallback(() => {
     if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {

--- a/src/handlers/localstorage/ens.ts
+++ b/src/handlers/localstorage/ens.ts
@@ -4,6 +4,7 @@ const ensProfileVersion = '0.1.0';
 
 const ensProfileKey = (key: string) => `ensProfile.${key}`;
 const ensResolveNameKey = (key: string) => `ensResolveName.${key}`;
+const ensDomains = (key: string) => `ensDomains-${key}`;
 const ensSeenOnchainDataDisclaimerKey = 'ensProfile.seenOnchainDisclaimer';
 
 export const getProfile = async (key: string) => {
@@ -25,3 +26,14 @@ export const getSeenOnchainDataDisclaimer = () =>
 
 export const saveSeenOnchainDataDisclaimer = (value: boolean) =>
   saveGlobal(ensResolveNameKey(ensSeenOnchainDataDisclaimerKey), value);
+
+export const getENSDomains = (key: string) => getGlobal(ensDomains(key), []);
+
+export const setENSDomains = (
+  key: string,
+  value: {
+    name: string;
+    owner: { id: string };
+    images: { avatarUrl?: string | null; coverUrl?: string | null };
+  }[]
+) => saveGlobal(ensDomains(key), value);

--- a/src/handlers/localstorage/ens.ts
+++ b/src/handlers/localstorage/ens.ts
@@ -4,7 +4,7 @@ const ensProfileVersion = '0.1.0';
 
 const ensProfileKey = (key: string) => `ensProfile.${key}`;
 const ensResolveNameKey = (key: string) => `ensResolveName.${key}`;
-const ensDomains = (key: string) => `ensDomains-${key}`;
+const ensDomains = (key: string) => `ensDomains.${key}`;
 const ensSeenOnchainDataDisclaimerKey = 'ensProfile.seenOnchainDisclaimer';
 
 export const getProfile = async (key: string) => {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,7 +8,10 @@ export { default as useAccountAsset } from './useAccountAsset';
 export { default as useSortedAccountAssets } from './useSortedAccountAssets';
 export { default as useFrameDelayedValue } from './useFrameDelayedValue';
 export { default as useAccountEmptyState } from './useAccountEmptyState';
-export { default as useAccountENSDomains } from './useAccountENSDomains';
+export {
+  default as useAccountENSDomains,
+  prefetchAccountENSDomains,
+} from './useAccountENSDomains';
 export { default as useAccountProfile } from './useAccountProfile';
 export { default as useAccountSettings } from './useAccountSettings';
 export { default as useAccountTransactions } from './useAccountTransactions';

--- a/src/hooks/useAccountENSDomains.tsx
+++ b/src/hooks/useAccountENSDomains.tsx
@@ -93,7 +93,8 @@ export default function useAccountENSDomains() {
 
   useEffect(() => {
     getInitialDomains();
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     data,

--- a/src/hooks/useAccountENSDomains.tsx
+++ b/src/hooks/useAccountENSDomains.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from 'react-query';
 import useAccountSettings from './useAccountSettings';
+import { EnsAccountRegistratonsData } from '@rainbow-me/apollo/queries';
 import {
   fetchAccountRegistrations,
   fetchImages,
@@ -13,7 +14,7 @@ const queryKey = ({ accountAddress }: { accountAddress: string }) => [
 
 const imagesQueryKey = ({ name }: { name: string }) => ['domainImages', name];
 
-export async function fetchAccountENSDomains({
+async function fetchAccountENSDomains({
   accountAddress,
 }: {
   accountAddress: string;
@@ -45,7 +46,7 @@ export async function prefetchAccountENSDomains({
   );
 }
 
-export async function fetchAccountENSImages(name: string) {
+async function fetchAccountENSImages(name: string) {
   return queryClient.fetchQuery(
     imagesQueryKey({ name }),
     async () => await fetchImages(name),
@@ -57,7 +58,9 @@ export async function fetchAccountENSImages(name: string) {
 
 export default function useAccountENSDomains() {
   const { accountAddress } = useAccountSettings();
-  return useQuery<any>(queryKey({ accountAddress }), async () =>
+  return useQuery<
+    EnsAccountRegistratonsData['account']['registrations'][number]['domain'][]
+  >(queryKey({ accountAddress }), async () =>
     fetchAccountENSDomains({ accountAddress })
   );
 }

--- a/src/screens/ENSIntroSheet.tsx
+++ b/src/screens/ENSIntroSheet.tsx
@@ -54,7 +54,7 @@ export default function ENSIntroSheet() {
 
   const { ownedDomains, primaryDomain, nonPrimaryDomains } = useMemo(() => {
     const ownedDomains = domains?.filter(
-      ({ owner }) => owner.id?.toLowerCase() === accountAddress.toLowerCase()
+      ({ owner }) => owner?.id?.toLowerCase() === accountAddress.toLowerCase()
     );
     return {
       nonPrimaryDomains:

--- a/src/screens/SelectENSSheet.tsx
+++ b/src/screens/SelectENSSheet.tsx
@@ -31,7 +31,7 @@ const rowHeight = 40;
 const maxListHeight = deviceHeight - 220;
 
 export default function SelectENSSheet() {
-  const { data: domains, isSuccess } = useAccountENSDomains();
+  const { data: accountENSDomains, isSuccess } = useAccountENSDomains();
   const { accountAddress } = useAccountSettings();
   const { accountENS } = useAccountProfile();
   const accentColor = useForegroundColor('action');
@@ -47,16 +47,24 @@ export default function SelectENSSheet() {
     [goBack, params]
   );
 
-  const nonPrimaryDomains = useMemo(() => {
-    const ownedDomains = domains
+  const ownedDomains = useMemo(() => {
+    const domains = accountENSDomains
       ?.filter(
-        ({ owner }) => owner?.id?.toLowerCase() === accountAddress.toLowerCase()
+        ({ owner, name }) =>
+          owner?.id?.toLowerCase() === accountAddress.toLowerCase() &&
+          accountENS !== name
       )
       ?.sort((a, b) => (a.name > b.name ? 1 : -1));
-    return ownedDomains?.filter(({ name }) => accountENS !== name) || [];
-  }, [accountAddress, accountENS, domains]);
 
-  let listHeight = (rowHeight + 40) * (nonPrimaryDomains?.length || 0);
+    const primaryDomain = accountENSDomains?.find(
+      ({ name }) => accountENS === name
+    );
+    if (primaryDomain) domains?.unshift(primaryDomain);
+
+    return domains;
+  }, [accountAddress, accountENS, accountENSDomains]);
+
+  let listHeight = (rowHeight + 40) * (ownedDomains?.length || 0);
   let scrollEnabled = false;
   if (listHeight > maxListHeight) {
     listHeight = maxListHeight;
@@ -128,7 +136,7 @@ export default function SelectENSSheet() {
                 ItemSeparatorComponent={() => <Box height={{ custom: 15 }} />}
                 as={FlatList}
                 contentContainerStyle={{ paddingBottom: 40, paddingTop: 15 }}
-                data={nonPrimaryDomains}
+                data={ownedDomains}
                 height={{ custom: listHeight }}
                 keyExtractor={({ domain }: { domain: string }) => domain}
                 renderItem={renderItem}

--- a/src/screens/SelectENSSheet.tsx
+++ b/src/screens/SelectENSSheet.tsx
@@ -48,9 +48,11 @@ export default function SelectENSSheet() {
   );
 
   const nonPrimaryDomains = useMemo(() => {
-    const ownedDomains = domains?.filter(
-      ({ owner }) => owner.id?.toLowerCase() === accountAddress.toLowerCase()
-    );
+    const ownedDomains = domains
+      ?.filter(
+        ({ owner }) => owner?.id?.toLowerCase() === accountAddress.toLowerCase()
+      )
+      ?.sort((a, b) => (a.name > b.name ? 1 : -1));
     return ownedDomains?.filter(({ name }) => accountENS !== name) || [];
   }, [accountAddress, accountENS, domains]);
 


### PR DESCRIPTION
Fixes RNBW-3411

Fixes RNBW-3412

## What changed (plus any additional context for devs)

Improving registration fetch

- images are now cached, before we were querying for avatar and cover images all the time

before: fetchImages was being called every time `fetchAccountENSDomains` is called, even tho that fetch was being cached 
https://recordit.co/L8os83EF1R

now we're saving those values to avoid unnecessary requests
https://recordit.co/F4ZwZ8idxC

- saving registration to local storage so we can use it as default while getting all the ens names of a wallet in the intro screen

in the video you can see at the beginning the data used to load the screen is the one saved in local storage, then data comes from subgraph and we use it instead
https://recordit.co/f8Pk5AWS7U

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
