### PR TITLE
translate Floating Emoji from Reanimated 1 to Reanimated 2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@ src/assets @skylarbarrera @christianbaroni
 
 # COMPONENTS
 src/components @osdnk @terrysahaidak
+src/components/floating-emojis @jkadamczyk
 
 # APP CONFIG
 src/config @osdnk @brunobar79 @skylarbarrera

--- a/src/components/floating-emojis/FloatingEmoji.js
+++ b/src/components/floating-emojis/FloatingEmoji.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import Animated, {
   Easing,
   interpolate,
@@ -7,7 +7,6 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
-import { useMemoOne } from 'use-memo-one';
 import { Emoji } from '../text';
 
 const FloatingEmoji = ({
@@ -29,10 +28,13 @@ const FloatingEmoji = ({
 }) => {
   const animation = useSharedValue(0);
 
-  animation.value = useMemoOne(
-    () => withTiming(1, { duration, easing: Easing.linear }),
-    []
-  );
+  useLayoutEffect(() => {
+    animation.value = withTiming(1, {
+      duration,
+      easing: Easing.linear,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const animatedStyle = useAnimatedStyle(() => {
     const progress = interpolate(animation.value, [0, 1], [0, distance]);

--- a/src/components/floating-emojis/FloatingEmoji.js
+++ b/src/components/floating-emojis/FloatingEmoji.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import Animated, { EasingNode } from 'react-native-reanimated';
-import { useMemoOne } from 'use-memo-one';
-import { interpolate, timing } from '../animations';
+import React, { useEffect } from 'react';
+import Animated, {
+  Easing,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { Emoji } from '../text';
-
-const { add, concat, multiply, sin } = Animated;
 
 const FloatingEmoji = ({
   centerVertically,
@@ -24,73 +26,81 @@ const FloatingEmoji = ({
   top,
   wiggleFactor,
 }) => {
-  const { opacity, rotate, scale, translateX, translateY } = useMemoOne(() => {
-    const animation = timing({ duration, easing: EasingNode.elastic() });
-    const progress = interpolate(animation, {
-      inputRange: [0, 1],
-      outputRange: [0, distance],
+  const animation = useSharedValue(0);
+
+  useEffect(() => {
+    animation.value = withTiming(1, {
+      duration,
+      easing: Easing.linear,
     });
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const progress = interpolate(animation.value, [0, 1], [0, distance]);
+
+    const opacity = interpolate(
+      progress,
+      [0, distance * (opacityThreshold ?? 0.5), distance - size],
+      [1, fadeOut ? 0.89 : 1, fadeOut ? 0 : 1]
+    );
+
+    const rotate =
+      interpolate(
+        progress,
+        [0, distance / 4, distance / 3, distance / 2, distance],
+        [0, -2, 0, 2, 0]
+      ) + 'deg';
+
+    const scale = interpolate(
+      progress,
+      [0, 15, 30, 50, distance],
+      [0, 1.2, 1.1, 1, scaleTo]
+    );
+
+    const everyThirdEmojiMultiplier = index % 3 === 0 ? 3 : 2;
+    const everySecondEmojiMultiplier = index % 2 === 0 ? -1 : 1;
+    const translateXComponentA =
+      animation.value *
+      size *
+      everySecondEmojiMultiplier *
+      everyThirdEmojiMultiplier;
+
+    const wiggleMultiplierA = Math.sin(progress * (distance / (350 / 15)));
+    const wiggleMultiplierB = interpolate(
+      progress,
+      [0, distance / 10, distance],
+      [10 * wiggleFactor, 6.9 * wiggleFactor, 4.2069 * wiggleFactor]
+    );
+    const translateXComponentB = wiggleMultiplierA * wiggleMultiplierB;
+
+    const translateX = disableHorizontalMovement
+      ? 0
+      : translateXComponentA + translateXComponentB;
+
+    const translateY = disableVerticalMovement ? 0 : -progress;
 
     return {
-      opacity: interpolate(progress, {
-        inputRange: [0, distance * opacityThreshold || 0.5, distance - size],
-        outputRange: [1, fadeOut ? 0.89 : 1, fadeOut ? 0 : 1],
-      }),
-      rotate: concat(
-        interpolate(progress, {
-          inputRange: [0, distance / 4, distance / 3, distance / 2, distance],
-          outputRange: [0, -2, 0, 2, 0],
-        }),
-        'deg'
-      ),
-      scale: interpolate(progress, {
-        inputRange: [0, 15, 30, 50, distance],
-        outputRange: [0, 1.2, 1.1, 1, scaleTo],
-      }),
-      translateX: add(
-        multiply(
-          animation,
-          size,
-          index % 3 === 0 ? 3 : 2,
-          index % 2 === 0 ? -1 : 1
-        ),
-        multiply(
-          sin(multiply(progress, distance / (350 / 15))), // i rly dont understand math plz help
-          interpolate(progress, {
-            inputRange: [0, distance / 10, distance],
-            outputRange: [
-              10 * wiggleFactor,
-              6.9 * wiggleFactor,
-              4.2069 * wiggleFactor,
-            ],
-          })
-        )
-      ),
-      translateY: multiply(animation, distance, -1),
+      opacity,
+      transform: [{ rotate }, { scale }, { translateX }, { translateY }],
     };
-  }, []);
+  });
 
   return (
     <Animated.View
-      style={{
-        left,
-        marginTop,
-        opacity,
-        position: 'absolute',
-        top: centerVertically ? null : top || size * -0.5,
-        transform: [
-          { rotate },
-          { scale },
-          disableHorizontalMovement ? null : { translateX },
-          disableVerticalMovement ? null : { translateY },
-        ],
-      }}
+      style={[
+        {
+          left,
+          marginTop,
+          position: 'absolute',
+          top: centerVertically ? null : top || size * -0.5,
+        },
+        animatedStyle,
+      ]}
     >
       <Emoji name={emoji} size={size} />
     </Animated.View>
   );
 };
-
 FloatingEmoji.propTypes = {
   centerVertically: PropTypes.bool,
   disableHorizontalMovement: PropTypes.bool,

--- a/src/components/floating-emojis/FloatingEmoji.js
+++ b/src/components/floating-emojis/FloatingEmoji.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import Animated, {
   Easing,
   interpolate,
@@ -28,7 +28,7 @@ const FloatingEmoji = ({
 }) => {
   const animation = useSharedValue(0);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     animation.value = withTiming(1, {
       duration,
       easing: Easing.linear,

--- a/src/components/floating-emojis/FloatingEmoji.js
+++ b/src/components/floating-emojis/FloatingEmoji.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import Animated, {
   Easing,
   interpolate,
@@ -7,6 +7,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { useMemoOne } from 'use-memo-one';
 import { Emoji } from '../text';
 
 const FloatingEmoji = ({
@@ -28,13 +29,10 @@ const FloatingEmoji = ({
 }) => {
   const animation = useSharedValue(0);
 
-  useLayoutEffect(() => {
-    animation.value = withTiming(1, {
-      duration,
-      easing: Easing.linear,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  animation.value = useMemoOne(
+    () => withTiming(1, { duration, easing: Easing.linear }),
+    []
+  );
 
   const animatedStyle = useAnimatedStyle(() => {
     const progress = interpolate(animation.value, [0, 1], [0, distance]);
@@ -66,11 +64,15 @@ const FloatingEmoji = ({
       everySecondEmojiMultiplier *
       everyThirdEmojiMultiplier;
 
-    const wiggleMultiplierA = Math.sin(progress * (distance / (350 / 15)));
+    /*
+    We don't really know why these concrete numbers are used there.
+    Original Author of these numbers: Mike Demarais
+     */
+    const wiggleMultiplierA = Math.sin(progress * (distance / 23.3));
     const wiggleMultiplierB = interpolate(
       progress,
       [0, distance / 10, distance],
-      [10 * wiggleFactor, 6.9 * wiggleFactor, 4.2069 * wiggleFactor]
+      [10 * wiggleFactor, 6.9 * wiggleFactor, 4.2137 * wiggleFactor]
     );
     const translateXComponentB = wiggleMultiplierA * wiggleMultiplierB;
 
@@ -84,7 +86,7 @@ const FloatingEmoji = ({
       opacity,
       transform: [{ rotate }, { scale }, { translateX }, { translateY }],
     };
-  });
+  }, []);
 
   return (
     <Animated.View

--- a/src/components/floating-emojis/FloatingEmoji.js
+++ b/src/components/floating-emojis/FloatingEmoji.js
@@ -33,6 +33,7 @@ const FloatingEmoji = ({
       duration,
       easing: Easing.linear,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const animatedStyle = useAnimatedStyle(() => {


### PR DESCRIPTION
Fixes RNBW-3392

## What changed (plus any additional context for devs)

* Rewrote FloatingEmoji animation code with Reanimated 2 preserving all settings it had with Reanimated 1

## PoW (screenshots / screen recordings)

Before:
https://streamable.com/93ul9w

After:
https://streamable.com/855urh

## Dev checklist for QA: what to test

* open app
* swipe left
* copy address and see if it works just like with Reanimate 1.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why – can't test animations that are psudeo-random
- [x] If you added new files, did you update the CODEOWNERS file?
