### PR TITLE
bump react coin icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "qs": "6.9.4",
     "querystring-es3": "0.2.1",
     "react": "17.0.2",
-    "react-coin-icon": "0.1.43",
+    "react-coin-icon": "0.1.44",
     "react-fast-compare": "2.0.4",
     "react-flatten-children": "1.1.2",
     "react-native": "0.66.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14642,10 +14642,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-coin-icon@0.1.43:
-  version "0.1.43"
-  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.43.tgz#e9e9672812ed470aa97709cabfd7904fa3c81409"
-  integrity sha512-DcB+3UPLG4Q3Zo9XdMpyZVm8EolgrtWA4uvyGTE73JW7k+fQjtkVlxRvTXBX2OQmeKhXNoTgfUP6y80NhxF4BQ==
+react-coin-icon@0.1.44:
+  version "0.1.44"
+  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.44.tgz#b8ed525d3a45fd47f32ceceacda1295b6d0f7f6d"
+  integrity sha512-0E4bfPXTK/Fu6kvZkHm8sFe/UUxX7auKBQRmhfqPniE9VdbJC0m1Wnc/aNXaPFqGG98zTggtxpFJUO5F0hS80Q==
   dependencies:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"


### PR DESCRIPTION
fixes RNBW-2324

## What changed (plus any additional context for devs)
removed the old Data logo from react coin icon package

## PoW (screenshots / screen recordings)
before: https://cloud.skylarbarrera.com/Screen-Shot-2022-05-02-15-08-05.28.png
after: https://cloud.skylarbarrera.com/Screen-Shot-2022-05-02-14-56-26.21.png

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
