### PR TITLE
Profiles: fix records updates lag

### DIFF
--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -49,7 +49,7 @@ const RegistrationCover = ({
         typeof initialCoverUrl === 'string' ? initialCoverUrl : values?.cover
       );
     }
-  }, [initialCoverUrl, coverUpdateAllowed]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialCoverUrl, coverUpdateAllowed, values, coverUrl]);
 
   // We want to allow cover state update when the screen is first focussed.
   useFocusEffect(useCallback(() => setCoverUpdateAllowed(true), []));

--- a/src/components/ens-registration/TextRecordsForm/TextRecordsForm.tsx
+++ b/src/components/ens-registration/TextRecordsForm/TextRecordsForm.tsx
@@ -1,4 +1,3 @@
-import { useFocusEffect } from '@react-navigation/core';
 import { debounce, isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import { TextInputProps, ViewProps } from 'react-native';
@@ -92,6 +91,7 @@ export default function TextRecordsForm({
                   defaultValue={values[key]}
                   errorMessage={errors[key]}
                   inputProps={inputProps}
+                  key={key}
                   label={label}
                   onChangeText={debounce(
                     text => onChangeField({ key, value: text }),
@@ -120,12 +120,9 @@ function Field({ defaultValue, ...props }: InlineFieldProps) {
   const [value, setValue] = useState(defaultValue);
 
   // Set / clear values when the screen comes to focus / unfocus.
-  useFocusEffect(
-    useCallback(() => {
-      setValue(defaultValue);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
-  );
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [defaultValue]);
 
   return (
     <>
@@ -136,7 +133,7 @@ function Field({ defaultValue, ...props }: InlineFieldProps) {
           props.onChangeText(text);
           setValue(text);
         }}
-        value={value ?? defaultValue}
+        value={value}
       />
     </>
   );

--- a/src/components/inputs/InlineField.tsx
+++ b/src/components/inputs/InlineField.tsx
@@ -35,6 +35,7 @@ export type InlineFieldProps = {
   };
   value?: string;
   testID?: string;
+  key?: string;
 };
 
 export default function InlineField({

--- a/src/hooks/useENSRegistrationCosts.ts
+++ b/src/hooks/useENSRegistrationCosts.ts
@@ -45,6 +45,8 @@ enum QUERY_KEYS {
   GET_SET_RECORDS_GAS_LIMIT = 'GET_SET_RECORDS_GAS_LIMIT',
 }
 
+const QUERY_STALE_TIME = 15000;
+
 export default function useENSRegistrationCosts({
   name: inputName,
   rentPrice,
@@ -177,7 +179,7 @@ export default function useENSRegistrationCosts({
       enabled: step === REGISTRATION_STEPS.COMMIT && nameUpdated,
       queryFn: getCommitGasLimit,
       queryKey: [QUERY_KEYS.GET_COMMIT_GAS_LIMIT, name],
-      staleTime: Infinity,
+      staleTime: QUERY_STALE_TIME,
     },
     {
       enabled:
@@ -186,7 +188,7 @@ export default function useENSRegistrationCosts({
         nameUpdated,
       queryFn: getSetNameGasLimit,
       queryKey: [QUERY_KEYS.GET_SET_NAME_GAS_LIMIT, name],
-      staleTime: Infinity,
+      staleTime: QUERY_STALE_TIME,
     },
     {
       enabled:
@@ -197,7 +199,7 @@ export default function useENSRegistrationCosts({
         name,
         debouncedChangedRecords,
       ],
-      staleTime: Infinity,
+      staleTime: QUERY_STALE_TIME,
     },
     {
       enabled:
@@ -206,7 +208,7 @@ export default function useENSRegistrationCosts({
         nameUpdated,
       queryFn: getReverseRecord,
       queryKey: [QUERY_KEYS.GET_REVERSE_RECORD, name],
-      staleTime: Infinity,
+      staleTime: QUERY_STALE_TIME,
     },
     {
       enabled: step === REGISTRATION_STEPS.RENEW,
@@ -216,13 +218,18 @@ export default function useENSRegistrationCosts({
         registrationParameters?.name,
         duration,
       ],
-      staleTime: Infinity,
+      staleTime: QUERY_STALE_TIME,
     },
     {
       enabled: step === REGISTRATION_STEPS.REGISTER,
       queryFn: getRegisterRapGasLimit,
-      queryKey: [QUERY_KEYS.GET_REGISTER_RAP_GAS_LIMIT, sendReverseRecord],
-      staleTime: Infinity,
+      queryKey: [
+        QUERY_KEYS.GET_REGISTER_RAP_GAS_LIMIT,
+        sendReverseRecord,
+        nameUpdated,
+        step,
+      ],
+      staleTime: QUERY_STALE_TIME,
     },
   ]);
 
@@ -327,6 +334,7 @@ export default function useENSRegistrationCosts({
     renewGasLimit,
     setNameGasLimit,
     setRecordsGasLimit,
+    registerRapGasLimit,
     step,
   ]);
 

--- a/src/hooks/useENSRegistrationCosts.ts
+++ b/src/hooks/useENSRegistrationCosts.ts
@@ -227,7 +227,6 @@ export default function useENSRegistrationCosts({
         QUERY_KEYS.GET_REGISTER_RAP_GAS_LIMIT,
         sendReverseRecord,
         nameUpdated,
-        step,
       ],
       staleTime: QUERY_STALE_TIME,
     },

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -117,7 +117,7 @@ export default function ENSAssignRecordsSheet() {
   const [prevDominantColor, setPrevDominantColor] = useState(dominantColor);
 
   useEffect(() => {
-    setAccentColor(dominantColor || prevDominantColor || colors.purple);
+    setAccentColor(dominantColor || colors.purple);
     if (dominantColor) {
       setPrevDominantColor(dominantColor);
     }

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -114,14 +114,10 @@ export default function ENSAssignRecordsSheet() {
   const { result: dominantColor } = usePersistentDominantColorFromImage(
     avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || ''
   );
-  const [prevDominantColor, setPrevDominantColor] = useState(dominantColor);
 
   useEffect(() => {
     setAccentColor(dominantColor || colors.purple);
-    if (dominantColor) {
-      setPrevDominantColor(dominantColor);
-    }
-  }, [colors.purple, dominantColor, prevDominantColor, setAccentColor]);
+  }, [colors.purple, dominantColor, setAccentColor]);
 
   const handleAutoFocusLayout = useCallback(
     ({

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -111,13 +111,17 @@ export default function ENSAssignRecordsSheet() {
   const [avatarUrl, setAvatarUrl] = useState(initialAvatarUrl);
   const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
 
+  const avatarImage =
+    avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || '';
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || ''
+    avatarImage
   );
 
   useEffect(() => {
-    setAccentColor(dominantColor || colors.purple);
-  }, [colors.purple, dominantColor, setAccentColor]);
+    if (dominantColor || (!dominantColor && !avatarImage)) {
+      setAccentColor(dominantColor || colors.purple);
+    }
+  }, [avatarImage, colors.purple, dominantColor, setAccentColor]);
 
   const handleAutoFocusLayout = useCallback(
     ({

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -249,7 +249,8 @@ export function ENSAssignRecordsBottomActions({
   const hasBackButton = useMemo(
     () =>
       fromRoute === Routes.ENS_SEARCH_SHEET ||
-      fromRoute === Routes.ENS_INTRO_SHEET,
+      fromRoute === Routes.ENS_INTRO_SHEET ||
+      fromRoute === Routes.ENS_ASSIGN_RECORDS_SHEET,
     [fromRoute]
   );
 

--- a/src/screens/ENSConfirmRegisterSheet.js
+++ b/src/screens/ENSConfirmRegisterSheet.js
@@ -18,6 +18,7 @@ import {
   AccentColorProvider,
   Box,
   Heading,
+  Inset,
   Row,
   Rows,
   Stack,
@@ -366,7 +367,11 @@ export default function ENSConfirmRegisterSheet() {
                       />
                     </Box>
                   )}
-                  <Heading size="26px">{ensName}</Heading>
+                  <Inset horizontal="30px">
+                    <Heading align="center" size="26px">
+                      {ensName}
+                    </Heading>
+                  </Inset>
                   <Text
                     color="accent"
                     testID={`ens-confirm-register-label-${step}`}

--- a/src/screens/ENSConfirmRegisterSheet.js
+++ b/src/screens/ENSConfirmRegisterSheet.js
@@ -102,12 +102,16 @@ export default function ENSConfirmRegisterSheet() {
   const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
   const avatarMetadata = useRecoilValue(avatarMetadataAtom);
 
+  const avatarImage =
+    avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || ''
+    avatarImage
   );
   useEffect(() => {
-    setAccentColor(dominantColor || colors.purple);
-  }, [dominantColor, setAccentColor]);
+    if (dominantColor || (!dominantColor && !avatarImage)) {
+      setAccentColor(dominantColor || colors.purple);
+    }
+  }, [avatarImage, dominantColor, setAccentColor]);
 
   const [duration, setDuration] = useState(1);
 

--- a/src/screens/ENSSearchSheet.js
+++ b/src/screens/ENSSearchSheet.js
@@ -1,5 +1,5 @@
 import lang from 'i18n-js';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Keyboard } from 'react-native';
 import { useDebounce } from 'use-debounce';
 import dice from '../assets/dice.png';
@@ -20,7 +20,7 @@ import {
   Stack,
   Text,
 } from '@rainbow-me/design-system';
-import { ENS_DOMAIN } from '@rainbow-me/helpers/ens';
+import { ENS_DOMAIN, REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
 import {
   useENSRegistration,
   useENSRegistrationCosts,
@@ -76,6 +76,14 @@ export default function ENSSearchSheet() {
     Keyboard.dismiss();
     navigate(Routes.ENS_ASSIGN_RECORDS_SHEET);
   }, [navigate, searchQuery, startRegistration]);
+
+  useEffect(() => {
+    debouncedSearchQuery.length > 3 &&
+      startRegistration(
+        `${debouncedSearchQuery}${ENS_DOMAIN}`,
+        REGISTRATION_MODES.CREATE
+      );
+  }, [debouncedSearchQuery, startRegistration]);
 
   return (
     <Box


### PR DESCRIPTION
Fixes RNBW-3488

## What changed (plus any additional context for devs)

When you change the registration name that you're using or coming back from a "In Progress" registration you can see that there's small lag from the moment the records form, avatar and cover is being updated to the correct values, since we are updating it "on focus".

I updated it to maintain the records values, avatar and cover up to date when the name is being changed, so there's no lag and the values update correctly in background when there's another `currentRegistrationName` in state.

Same case was happening with `prevDominantColor`, if an avatar `A.png` was set in a name, then you change the name or go to a ens nft without an avatar to extend or set name, the `prevDominantColor` would stay the one set with `A.png` even tho they're not related.

I also changed the stale time for gas estimations since I was seeing no updates in gas estimations since there was no change in deps triggering the query. Seeing https://rainbowhaus.slack.com/archives/CGVRKQQ94/p1651521908133489 on the left simulator connected to hardhat


## PoW (screenshots / screen recordings)

before https://recordit.co/Aqe5dEU0Ty
after https://recordit.co/e107vZrq7K

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
