### PR TITLE
[RNBW-2616] Cannot read property 'address_from' of undefined

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -940,9 +940,8 @@ export const transactionsReceived = (
   if (appended) {
     dispatch(checkForConfirmedSavingsActions(transactionData));
   }
-  if (transactionData.length) {
-    dispatch(checkForUpdatedNonce(transactionData));
-  }
+
+  dispatch(checkForUpdatedNonce(transactionData));
 
   const { accountAddress, nativeCurrency } = getState().settings;
   const { purchaseTransactions } = getState().addCash;

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -36,6 +36,7 @@ import { uniqueTokensRefreshState } from './uniqueTokens';
 import { uniswapUpdateLiquidityTokens } from './uniswapLiquidity';
 import {
   AssetTypes,
+  EthereumAddress,
   NativeCurrencyKeys,
   NewTransactionOrAddCashTransaction,
   ParsedAddressAsset,
@@ -857,15 +858,15 @@ const checkForConfirmedSavingsActions = (
 const checkForUpdatedNonce = (transactionData: ZerionTransaction[]) => (
   dispatch: ThunkDispatch<AppState, unknown, never>
 ) => {
-  const txSortedByDescendingNonce = transactionData.sort(
-    ({ nonce: n1 }, { nonce: n2 }) => (n2 ?? 0) - (n1 ?? 0)
-  );
-  const [latestTx] = txSortedByDescendingNonce;
-  // @ts-expect-error `ZerionTransaction` doesn't have a `network` field, but
-  // the undefined network is defaulted to mainnet later.
-  const { address_from, network, nonce } = latestTx;
-  if (nonce) {
-    dispatch(incrementNonce(address_from!, nonce, network));
+  if (transactionData.length) {
+    const txSortedByDescendingNonce = transactionData.sort(
+      ({ nonce: n1 }, { nonce: n2 }) => (n2 ?? 0) - (n1 ?? 0)
+    );
+    const [latestTx] = txSortedByDescendingNonce;
+    const { address_from, nonce } = latestTx;
+    if (nonce) {
+      dispatch(incrementNonce(address_from!, nonce));
+    }
   }
 };
 
@@ -875,17 +876,18 @@ const checkForUpdatedNonce = (transactionData: ZerionTransaction[]) => (
  *
  * @param removedTransactions Removed transaction data.
  */
-const checkForRemovedNonce = (removedTransactions: ZerionTransaction[]) => (
-  dispatch: ThunkDispatch<AppState, unknown, never>
-) => {
-  const txSortedByAscendingNonce = removedTransactions.sort(
-    ({ nonce: n1 }, { nonce: n2 }) => (n1 ?? 0) - (n2 ?? 0)
-  );
-  const [lowestNonceTx] = txSortedByAscendingNonce;
-  // @ts-expect-error `ZerionTransaction` doesn't have a `network` field, but
-  // the undefined network is defaulted to mainnet later.
-  const { address_from, network, nonce } = lowestNonceTx;
-  dispatch(decrementNonce(address_from!, nonce!, network));
+const checkForRemovedNonce = (
+  removedTransactions: RainbowTransaction[],
+  accountAddress: EthereumAddress
+) => (dispatch: ThunkDispatch<AppState, unknown, never>) => {
+  if (removedTransactions.length) {
+    const txSortedByAscendingNonce = removedTransactions.sort(
+      ({ nonce: n1 }, { nonce: n2 }) => (n1 ?? 0) - (n2 ?? 0)
+    );
+    const [lowestNonceTx] = txSortedByAscendingNonce;
+    const { nonce } = lowestNonceTx;
+    dispatch(decrementNonce(accountAddress, nonce!));
+  }
 };
 
 /**
@@ -938,7 +940,9 @@ export const transactionsReceived = (
   if (appended) {
     dispatch(checkForConfirmedSavingsActions(transactionData));
   }
-  await dispatch(checkForUpdatedNonce(transactionData));
+  if (transactionData.length) {
+    dispatch(checkForUpdatedNonce(transactionData));
+  }
 
   const { accountAddress, nativeCurrency } = getState().settings;
   const { purchaseTransactions } = getState().addCash;
@@ -1035,12 +1039,7 @@ export const transactionsRemoved = (
     type: DATA_LOAD_TRANSACTIONS_SUCCESS,
   });
 
-  // In this case `removedTransactions` is an array of `RainbowTransaction`s,
-  // while `checkForRemovedNonce` wants `ZerionTransaction`s. However,
-  // `RainbowTransaction` doesn't have the `address_from` field used in
-  // `checkForRemovedNonce`. Therefore, this likely does not work as intended,
-  // but is being kept for later review!
-  dispatch(checkForRemovedNonce(removedTransactions as any));
+  dispatch(checkForRemovedNonce(removedTransactions, accountAddress));
   saveLocalTransactions(updatedTransactions, accountAddress, network);
 };
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
`checkForUpdatedNonce` did not account for situations where `transactionsReceived` is called, but no transactions are present. I also did some small clean up based on some guidance from @marco in the comments.

## Dev checklist for QA: what to test
I don't know which situations would cause `transactionsReceived` to be called without transaction data. I could use some additional input on this. I think the changes are pretty minimal, though.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why --> I did not add any additional functionality
- [x] If you added new files, did you update the CODEOWNERS file?
