### PR TITLE
[RNBW-3293] User couldn't create queued pending transactions - Nonce management

### DIFF
--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -13,6 +13,7 @@ import {
 import { parseEther } from '@ethersproject/units';
 import UnstoppableResolution from '@unstoppabledomains/resolution';
 import { startsWith } from 'lodash';
+import { EthereumAddress } from '../entities/wallet';
 import { RainbowConfig } from '../model/config';
 import {
   AssetType,
@@ -68,7 +69,7 @@ type GasParamsInput = { gasPrice: BigNumberish } & {
  */
 type TransactionDetailsInput = Pick<
   NewTransactionNonNullable,
-  'from' | 'to' | 'data' | 'gasLimit' | 'network'
+  'from' | 'to' | 'data' | 'gasLimit' | 'network' | 'nonce'
 > &
   Pick<NewTransaction, 'amount'> &
   GasParamsInput;
@@ -83,6 +84,7 @@ type TransactionDetailsReturned = {
   network?: Network | string;
   to?: TransactionRequest['to'];
   value?: TransactionRequest['value'];
+  nonce?: TransactionRequest['nonce'];
 } & GasParamsReturned;
 
 /**
@@ -460,17 +462,29 @@ export const getTxDetails = async (
   const gasLimit = transaction.gasLimit
     ? toHex(transaction.gasLimit)
     : undefined;
-  const baseTx = {
+  const baseTx: {
+    data?: string;
+    gasLimit?: string | undefined;
+    to: EthereumAddress;
+    value: BigNumberish;
+    nonce?: number;
+  } = {
     data,
     gasLimit,
     to,
     value,
   };
+
+  if (transaction?.nonce) {
+    baseTx.nonce = transaction.nonce;
+  }
+
   const gasParams = getTransactionGasParams(transaction);
   const tx = {
     ...baseTx,
     ...gasParams,
   };
+
   return tx;
 };
 

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1463,7 +1463,7 @@ export const dataAddNewTransaction = (
     });
     saveLocalPendingTransactions(_pendingTransactions, accountAddress, network);
     if (parsedTransaction.from && parsedTransaction.nonce) {
-      await dispatch(
+      dispatch(
         incrementNonce(
           parsedTransaction.from,
           parsedTransaction.nonce,

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -940,9 +940,8 @@ export const transactionsReceived = (
   if (appended) {
     dispatch(checkForConfirmedSavingsActions(transactionData));
   }
-  if (transactionData.length) {
-    dispatch(checkForUpdatedNonce(transactionData));
-  }
+
+  dispatch(checkForUpdatedNonce(transactionData));
 
   const { accountAddress, nativeCurrency } = getState().settings;
   const { purchaseTransactions } = getState().addCash;

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -36,6 +36,7 @@ import { uniqueTokensRefreshState } from './uniqueTokens';
 import { uniswapUpdateLiquidityTokens } from './uniswapLiquidity';
 import {
   AssetTypes,
+  EthereumAddress,
   NativeCurrencyKeys,
   NewTransactionOrAddCashTransaction,
   ParsedAddressAsset,
@@ -857,15 +858,15 @@ const checkForConfirmedSavingsActions = (
 const checkForUpdatedNonce = (transactionData: ZerionTransaction[]) => (
   dispatch: ThunkDispatch<AppState, unknown, never>
 ) => {
-  const txSortedByDescendingNonce = transactionData.sort(
-    ({ nonce: n1 }, { nonce: n2 }) => (n2 ?? 0) - (n1 ?? 0)
-  );
-  const [latestTx] = txSortedByDescendingNonce;
-  // @ts-expect-error `ZerionTransaction` doesn't have a `network` field, but
-  // the undefined network is defaulted to mainnet later.
-  const { address_from, network, nonce } = latestTx;
-  if (nonce) {
-    dispatch(incrementNonce(address_from!, nonce, network));
+  if (transactionData.length) {
+    const txSortedByDescendingNonce = transactionData.sort(
+      ({ nonce: n1 }, { nonce: n2 }) => (n2 ?? 0) - (n1 ?? 0)
+    );
+    const [latestTx] = txSortedByDescendingNonce;
+    const { address_from, nonce } = latestTx;
+    if (nonce) {
+      dispatch(incrementNonce(address_from!, nonce));
+    }
   }
 };
 
@@ -875,17 +876,18 @@ const checkForUpdatedNonce = (transactionData: ZerionTransaction[]) => (
  *
  * @param removedTransactions Removed transaction data.
  */
-const checkForRemovedNonce = (removedTransactions: ZerionTransaction[]) => (
-  dispatch: ThunkDispatch<AppState, unknown, never>
-) => {
-  const txSortedByAscendingNonce = removedTransactions.sort(
-    ({ nonce: n1 }, { nonce: n2 }) => (n1 ?? 0) - (n2 ?? 0)
-  );
-  const [lowestNonceTx] = txSortedByAscendingNonce;
-  // @ts-expect-error `ZerionTransaction` doesn't have a `network` field, but
-  // the undefined network is defaulted to mainnet later.
-  const { address_from, network, nonce } = lowestNonceTx;
-  dispatch(decrementNonce(address_from!, nonce!, network));
+const checkForRemovedNonce = (
+  removedTransactions: RainbowTransaction[],
+  accountAddress: EthereumAddress
+) => (dispatch: ThunkDispatch<AppState, unknown, never>) => {
+  if (removedTransactions.length) {
+    const txSortedByAscendingNonce = removedTransactions.sort(
+      ({ nonce: n1 }, { nonce: n2 }) => (n1 ?? 0) - (n2 ?? 0)
+    );
+    const [lowestNonceTx] = txSortedByAscendingNonce;
+    const { nonce } = lowestNonceTx;
+    dispatch(decrementNonce(accountAddress, nonce!));
+  }
 };
 
 /**
@@ -938,7 +940,9 @@ export const transactionsReceived = (
   if (appended) {
     dispatch(checkForConfirmedSavingsActions(transactionData));
   }
-  await dispatch(checkForUpdatedNonce(transactionData));
+  if (transactionData.length) {
+    dispatch(checkForUpdatedNonce(transactionData));
+  }
 
   const { accountAddress, nativeCurrency } = getState().settings;
   const { purchaseTransactions } = getState().addCash;
@@ -1035,12 +1039,7 @@ export const transactionsRemoved = (
     type: DATA_LOAD_TRANSACTIONS_SUCCESS,
   });
 
-  // In this case `removedTransactions` is an array of `RainbowTransaction`s,
-  // while `checkForRemovedNonce` wants `ZerionTransaction`s. However,
-  // `RainbowTransaction` doesn't have the `address_from` field used in
-  // `checkForRemovedNonce`. Therefore, this likely does not work as intended,
-  // but is being kept for later review!
-  dispatch(checkForRemovedNonce(removedTransactions as any));
+  dispatch(checkForRemovedNonce(removedTransactions, accountAddress));
   saveLocalTransactions(updatedTransactions, accountAddress, network);
 };
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
`createSignableTransaction` was ignoring the nonce supplied in transaction details. This prevented sending subsequent transactions after a slow transaction was queued.

## PoW (screenshots / screen recordings)
https://user-images.githubusercontent.com/14877580/166506973-47b5d5fd-9f4a-4d2e-a73e-21fcf6b68c71.mp4

## Dev checklist for QA: what to test
Queue up several slow transactions, ensure that you can still speed them up without seeing a failure message.

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why ---> I did not add any new functionality
- [ ] If you added new files, did you update the CODEOWNERS file?
