### PR TITLE
Reuse rows of recycler list instead of remounting them (attempt 2)

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -36,7 +36,7 @@ function CellDataProvider({
 
 function rowRenderer(type: CellType, { uid }: { uid: string }) {
   return (
-    <CellDataProvider key={uid} uid={uid}>
+    <CellDataProvider uid={uid}>
       {data => {
         switch (type) {
           case CellType.ASSETS_HEADER_SPACE_AFTER:

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -22,8 +22,7 @@ class ImgixImage extends React.PureComponent<
   MergedImgixImageProps,
   ImgixImageProps
 > {
-  constructor(props: MergedImgixImageProps) {
-    super(props);
+  static getDerivedStateFromProps(props: MergedImgixImageProps) {
     const { source, size, fm } = props;
     const options = {
       ...(fm && { fm: fm }),
@@ -32,35 +31,15 @@ class ImgixImage extends React.PureComponent<
         w: size,
       }),
     };
-    this.state = {
+
+    return {
       source:
         !!source && typeof source === 'object'
           ? maybeSignSource(source, options)
           : source,
     };
   }
-  componentDidUpdate(prevProps: ImgixImageProps) {
-    const { source: prevSource } = prevProps;
-    const { source, size, fm } = this.props;
-    if (prevSource !== source) {
-      // If the source has changed and looks signable, attempt to sign it.
-      if (!!source && typeof source === 'object') {
-        const options = {
-          ...(fm && { fm: fm }),
-          ...(size && {
-            h: size,
-            w: size,
-          }),
-        };
-        Object.assign(this.state, {
-          source: maybeSignSource(source, options),
-        });
-      } else {
-        // Else propagate the source as normal.
-        Object.assign(this.state, { source });
-      }
-    }
-  }
+
   render() {
     const { Component: maybeComponent, ...props } = this.props;
     // Use the local state as the signing source, as opposed to the prop directly.


### PR DESCRIPTION
Fixes RNBW-3354

## What changed (plus any additional context for devs)

Previous PR was reverted due to duplicates of NFTs in the list. Found a cause for this.
Imgix class was mutating state, but it was actually doing it in componentDidUpdate that runs after the render, so it would only be applied on the next rerender (maybe, since it was mutating the state, there is no confidence in this).
I used the proper React API to update the state based on props - getDerivedStateFromProps.

There won't be noticeable performance improvements for the asset list after this change, but it's essential for future improvements.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

- Wallet screen should look the same

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
