### PR TITLE
[RNBW-3529] Wrong Value Shown After Currency Switch: UniqueTokenExpandedState

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -209,7 +209,7 @@ const UniqueTokenExpandedState = ({
 
   const [floorPrice, setFloorPrice] = useState<string | null>(null);
   const [priceOfEth, setPriceOfEth] = useState<number>(
-    ethereumUtils.getEthPriceUnit()
+    () => ethereumUtils.getEthPriceUnit()
   );
   const [showCurrentPriceInEth, setShowCurrentPriceInEth] = useState(true);
   const [showFloorInEth, setShowFloorInEth] = useState(true);

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -208,8 +208,8 @@ const UniqueTokenExpandedState = ({
   } = useShowcaseTokens();
 
   const [floorPrice, setFloorPrice] = useState<string | null>(null);
-  const [priceOfEth, setPriceOfEth] = useState<number>(
-    () => ethereumUtils.getEthPriceUnit()
+  const [priceOfEth, setPriceOfEth] = useState<number>(() =>
+    ethereumUtils.getEthPriceUnit()
   );
   const [showCurrentPriceInEth, setShowCurrentPriceInEth] = useState(true);
   const [showFloorInEth, setShowFloorInEth] = useState(true);

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -208,6 +208,9 @@ const UniqueTokenExpandedState = ({
   } = useShowcaseTokens();
 
   const [floorPrice, setFloorPrice] = useState<string | null>(null);
+  const [priceOfEth, setPriceOfEth] = useState<number>(
+    ethereumUtils.getEthPriceUnit()
+  );
   const [showCurrentPriceInEth, setShowCurrentPriceInEth] = useState(true);
   const [showFloorInEth, setShowFloorInEth] = useState(true);
   const [
@@ -245,7 +248,6 @@ const UniqueTokenExpandedState = ({
         ? `< 0.001 ${lastSalePaymentToken}`
         : `${lastPrice} ${lastSalePaymentToken}`
       : 'None';
-  const priceOfEth = ethereumUtils.getEthPriceUnit() as number;
 
   const textColor = useMemo(() => {
     const contrastWithWhite = c.contrast(imageColor, colors.whiteLabel);
@@ -264,6 +266,10 @@ const UniqueTokenExpandedState = ({
         setFloorPrice(result);
       });
   }, [asset.network, isPoap, network, urlSuffixForAsset]);
+
+  useEffect(() => {
+    setPriceOfEth(ethereumUtils.getEthPriceUnit());
+  }, [nativeCurrency]);
 
   const handlePressCollectionFloor = useCallback(() => {
     navigate(Routes.EXPLAIN_SHEET, {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We are now updating `priceOfEth` when `UniqueTokenExpandedState` detects a change in `nativeCurrency`

## Dev checklist for QA: what to test
Generally ensure that the floor price and last sale price appropriately reflect the chosen native currency in `UniqueTokenExpandedState`.

To reproduce the issue in production:
* open up `UniqueTokenExpandedState` by tapping on an NFT (ensure the NFT you use has a floor price)
* tap on the floor price to toggle display from ETH to native currency (do not tap twice, you must leave the native currency displaying)
* close the modal and navigate to setting to change your selected native currency
* return to `UniqueTokenExpandedState`, when tapping on the floor price you should see the appropriate symbol but a value calculated based on your last native currency selection.

You may need to do the above twice to see the issue, but I never had to do more than that.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
