### PR TITLE
Profiles: intro screen jump fix

### DIFF
--- a/src/navigation/RegisterENSNavigator.js
+++ b/src/navigation/RegisterENSNavigator.js
@@ -34,21 +34,6 @@ const renderPager = props => (
   />
 );
 
-const defaultScreenOptions = {
-  [Routes.ENS_ASSIGN_RECORDS_SHEET]: {
-    scrollEnabled: true,
-    useAccentAsSheetBackground: true,
-  },
-  [Routes.ENS_INTRO_SHEET]: {
-    scrollEnabled: false,
-    useAccentAsSheetBackground: false,
-  },
-  [Routes.ENS_SEARCH_SHEET]: {
-    scrollEnabled: true,
-    useAccentAsSheetBackground: false,
-  },
-};
-
 export default function RegisterENSNavigator() {
   const { params } = useRoute();
 
@@ -88,32 +73,11 @@ export default function RegisterENSNavigator() {
   const [currentRouteName, setCurrentRouteName] = useState(initialRouteName);
   const previousRouteName = usePrevious(currentRouteName);
 
-  const screenOptions = useMemo(() => defaultScreenOptions[currentRouteName], [
-    currentRouteName,
-  ]);
-
-  const [scrollEnabled, setScrollEnabled] = useState(
-    screenOptions.scrollEnabled
-  );
-
-  useEffect(() => {
-    if (previousRouteName) {
-      // Wait 500ms to prevent transition lag
-      setTimeout(() => {
-        setScrollEnabled(screenOptions.scrollEnabled);
-      }, 500);
-    }
-  }, [previousRouteName, screenOptions.scrollEnabled]);
+  const [wrapperStyle, setWrapperStyle] = useState({ height: contentHeight });
 
   useEffect(() => () => clearCurrentRegistrationName(), [
     clearCurrentRegistrationName,
   ]);
-
-  useEffect(() => {
-    if (!screenOptions.scrollEnabled) {
-      sheetRef.current.scrollTo({ animated: false, x: 0, y: 0 });
-    }
-  }, [screenOptions.scrollEnabled]);
 
   useEffect(
     () => () => {
@@ -136,10 +100,17 @@ export default function RegisterENSNavigator() {
   const isBottomActionsVisible =
     currentRouteName === Routes.ENS_ASSIGN_RECORDS_SHEET;
 
-  const wrapperStyle = useMemo(
-    () => (!scrollEnabled ? { height: contentHeight } : {}),
-    [contentHeight, scrollEnabled]
-  );
+  useEffect(() => {
+    const isENSAssignRecordsSheet =
+      currentRouteName === Routes.ENS_ASSIGN_RECORDS_SHEET;
+    setTimeout(
+      () =>
+        setWrapperStyle(
+          isENSAssignRecordsSheet ? {} : { height: contentHeight }
+        ),
+      isENSAssignRecordsSheet ? 200 : 0
+    );
+  }, [contentHeight, currentRouteName]);
 
   return (
     <>

--- a/src/navigation/RegisterENSNavigator.js
+++ b/src/navigation/RegisterENSNavigator.js
@@ -34,6 +34,21 @@ const renderPager = props => (
   />
 );
 
+const defaultScreenOptions = {
+  [Routes.ENS_ASSIGN_RECORDS_SHEET]: {
+    scrollEnabled: true,
+    useAccentAsSheetBackground: true,
+  },
+  [Routes.ENS_INTRO_SHEET]: {
+    scrollEnabled: false,
+    useAccentAsSheetBackground: false,
+  },
+  [Routes.ENS_SEARCH_SHEET]: {
+    scrollEnabled: true,
+    useAccentAsSheetBackground: false,
+  },
+};
+
 export default function RegisterENSNavigator() {
   const { params } = useRoute();
 
@@ -75,6 +90,10 @@ export default function RegisterENSNavigator() {
 
   const [wrapperStyle, setWrapperStyle] = useState({ height: contentHeight });
 
+  const screenOptions = useMemo(() => defaultScreenOptions[currentRouteName], [
+    currentRouteName,
+  ]);
+
   useEffect(() => () => clearCurrentRegistrationName(), [
     clearCurrentRegistrationName,
   ]);
@@ -101,16 +120,20 @@ export default function RegisterENSNavigator() {
     currentRouteName === Routes.ENS_ASSIGN_RECORDS_SHEET;
 
   useEffect(() => {
-    const isENSAssignRecordsSheet =
-      currentRouteName === Routes.ENS_ASSIGN_RECORDS_SHEET;
     setTimeout(
       () =>
         setWrapperStyle(
-          isENSAssignRecordsSheet ? {} : { height: contentHeight }
+          screenOptions.scrollEnabled ? {} : { height: contentHeight }
         ),
-      isENSAssignRecordsSheet ? 200 : 0
+      screenOptions.scrollEnabled ? 200 : 0
     );
-  }, [contentHeight, currentRouteName]);
+  }, [contentHeight, screenOptions.scrollEnabled]);
+
+  useEffect(() => {
+    if (!screenOptions.scrollEnabled?.scrollEnabled) {
+      sheetRef.current.scrollTo({ animated: false, x: 0, y: 0 });
+    }
+  }, [screenOptions.scrollEnabled]);
 
   return (
     <>

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -1,4 +1,4 @@
-import { useRoute } from '@react-navigation/core';
+import { useFocusEffect, useRoute } from '@react-navigation/core';
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -68,7 +68,7 @@ export const BottomActionHeight = ios ? 281 : 250;
 export default function ENSAssignRecordsSheet() {
   const { params } = useRoute();
   const { colors } = useTheme();
-  const { name, mode } = useENSRegistration();
+  const { name, initialRecords } = useENSRegistration();
   const {
     images: { avatarUrl: initialAvatarUrl },
   } = useENSModifiedRegistration({
@@ -91,7 +91,7 @@ export default function ENSAssignRecordsSheet() {
       ].map(fieldName => textRecordFields[fieldName]),
     []
   );
-  const { values, profileQuery } = useENSRegistrationForm({
+  const { profileQuery } = useENSRegistrationForm({
     defaultFields,
     initializeForm: true,
   });
@@ -99,7 +99,9 @@ export default function ENSAssignRecordsSheet() {
   const displayTitleLabel = useMemo(() => !profileQuery.isLoading, [
     profileQuery.isLoading,
   ]);
-  const isEmptyProfile = useMemo(() => isEmpty(values), [values]);
+  const isEmptyProfile = useMemo(() => isEmpty(initialRecords), [
+    initialRecords,
+  ]);
 
   useENSRegistrationCosts({
     name,
@@ -117,7 +119,7 @@ export default function ENSAssignRecordsSheet() {
     avatarImage
   );
 
-  useEffect(() => {
+  useFocusEffect(() => {
     if (dominantColor || (!dominantColor && !avatarImage)) {
       setAccentColor(dominantColor || colors.purple);
     }
@@ -192,11 +194,7 @@ export default function ENSAssignRecordsSheet() {
                 <Text align="center" color="accent" size="16px" weight="heavy">
                   {displayTitleLabel
                     ? lang.t(
-                        `profiles.${
-                          mode === REGISTRATION_MODES.EDIT && !isEmptyProfile
-                            ? 'edit'
-                            : 'create'
-                        }.label`
+                        `profiles.${isEmptyProfile ? 'create' : 'edit'}.label`
                       )
                     : ''}
                 </Text>


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

same logic than before but i'm updating the wrapper style when going to a sheet with scroll enabled, if returning to a screen without scroll enabled i'm updating the state right away

for [72ec70ad92002264bcb99b3d4710187166917122](https://github.com/rainbow-me/rainbow/pull/3302/commits/72ec70ad92002264bcb99b3d4710187166917122) we're now using `initialRecords` to see if there's any record in the profile so we display `Edit` or `Create` + `your Profile`, together with that I added a useFocusEffect to set the correct accent color, this is useful when navigating through intro sheet and assign records sheet


## PoW (screenshots / screen recordings)

before 

https://user-images.githubusercontent.com/12115171/166814401-90d09d26-b04c-4f66-90f5-5b8a12c711c5.mp4

after


https://user-images.githubusercontent.com/12115171/166814565-43604957-a949-47bc-b21f-6fab4baca2ff.mp4


## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
