### PR TITLE
Profiles: Fix edit profile infinite loading state

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -1,6 +1,5 @@
 import { captureException } from '@sentry/react-native';
 import { toLower } from 'lodash';
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'qs'.... Remove this comment to see the full error message
 import qs from 'qs';
 import { Alert } from 'react-native';
 import URL from 'url-parse';
@@ -52,7 +51,7 @@ export default async function handleDeeplink(
         const { dispatch } = store;
         // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         const { addr } = qs.parse(urlObj.query?.substring(1));
-        const address = toLower(addr);
+        const address = toLower(addr as string);
         if (address && address.length > 0) {
           // @ts-expect-error FIXME: Property 'assets' does not exist on type...
           const { assets: allAssets, genericAssets } = store.getState().data;

--- a/src/navigation/RegisterENSNavigator.js
+++ b/src/navigation/RegisterENSNavigator.js
@@ -76,11 +76,11 @@ export default function RegisterENSNavigator() {
   const initialRouteName = useMemo(() => {
     const { ensName, mode } = params || { mode: REGISTRATION_MODES.CREATE };
     if (mode === REGISTRATION_MODES.EDIT) {
-      startRegistration(ensName, mode);
+      startRegistration(ensName, REGISTRATION_MODES.EDIT);
       return Routes.ENS_ASSIGN_RECORDS_SHEET;
     }
     if (mode === REGISTRATION_MODES.SET_NAME) {
-      startRegistration(ensName, mode);
+      startRegistration(ensName, REGISTRATION_MODES.SET_NAME);
       return Routes.ENS_CONFIRM_REGISTER_SHEET;
     }
     return Routes.ENS_INTRO_SHEET;
@@ -180,6 +180,7 @@ export default function RegisterENSNavigator() {
               component={ENSAssignRecordsSheet}
               initialParams={{
                 autoFocusKey: params?.autoFocusKey,
+                mode: params?.mode,
                 sheetRef,
               }}
               listeners={{

--- a/src/redux/ensRegistration.ts
+++ b/src/redux/ensRegistration.ts
@@ -154,7 +154,7 @@ export const ensRegistrationsLoadState = () => async (
 export const startRegistration = (
   accountAddress: EthereumAddress,
   name: string,
-  mode: keyof typeof REGISTRATION_MODES = REGISTRATION_MODES.CREATE
+  mode: keyof typeof REGISTRATION_MODES
 ) => async (dispatch: AppDispatch, getState: AppGetState) => {
   const {
     ensRegistration: { registrations },

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -194,7 +194,12 @@ export default function ENSAssignRecordsSheet() {
                 <Text align="center" color="accent" size="16px" weight="heavy">
                   {displayTitleLabel
                     ? lang.t(
-                        `profiles.${isEmptyProfile ? 'create' : 'edit'}.label`
+                        `profiles.${
+                          isEmptyProfile &&
+                          params.mode !== REGISTRATION_MODES.EDIT
+                            ? 'create'
+                            : 'edit'
+                        }.label`
                       )
                     : ''}
                 </Text>

--- a/src/screens/ENSAssignRecordsSheet.js
+++ b/src/screens/ENSAssignRecordsSheet.js
@@ -96,11 +96,12 @@ export default function ENSAssignRecordsSheet() {
     initializeForm: true,
   });
 
-  const displayTitleLabel = useMemo(() => !profileQuery.isLoading, [
-    profileQuery.isLoading,
-  ]);
-  const isEmptyProfile = useMemo(() => isEmpty(initialRecords), [
-    initialRecords,
+  const displayTitleLabel = useMemo(
+    () => params.mode !== REGISTRATION_MODES.EDIT || profileQuery.isSuccess,
+    [params.mode, profileQuery.isSuccess]
+  );
+  const isEmptyProfile = useMemo(() => isEmpty(profileQuery.data?.records), [
+    profileQuery.data?.records,
   ]);
 
   useENSRegistrationCosts({
@@ -194,12 +195,7 @@ export default function ENSAssignRecordsSheet() {
                 <Text align="center" color="accent" size="16px" weight="heavy">
                   {displayTitleLabel
                     ? lang.t(
-                        `profiles.${
-                          isEmptyProfile &&
-                          params.mode !== REGISTRATION_MODES.EDIT
-                            ? 'create'
-                            : 'edit'
-                        }.label`
+                        `profiles.${isEmptyProfile ? 'create' : 'edit'}.label`
                       )
                     : ''}
                 </Text>

--- a/src/screens/ENSSearchSheet.js
+++ b/src/screens/ENSSearchSheet.js
@@ -80,7 +80,7 @@ export default function ENSSearchSheet() {
 
   useFocusEffect(
     useCallback(() => {
-      debouncedSearchQuery.length > 3 &&
+      debouncedSearchQuery.length >= 3 &&
         startRegistration(
           `${debouncedSearchQuery}${ENS_DOMAIN}`,
           REGISTRATION_MODES.CREATE

--- a/src/screens/ENSSearchSheet.js
+++ b/src/screens/ENSSearchSheet.js
@@ -1,5 +1,6 @@
+import { useFocusEffect } from '@react-navigation/core';
 import lang from 'i18n-js';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Keyboard } from 'react-native';
 import { useDebounce } from 'use-debounce';
 import dice from '../assets/dice.png';
@@ -72,18 +73,20 @@ export default function ENSSearchSheet() {
   }, [isAvailable, isInvalid, isRegistered]);
 
   const handlePressContinue = useCallback(() => {
-    startRegistration(`${searchQuery}${ENS_DOMAIN}`);
+    startRegistration(`${searchQuery}${ENS_DOMAIN}`, REGISTRATION_MODES.CREATE);
     Keyboard.dismiss();
     navigate(Routes.ENS_ASSIGN_RECORDS_SHEET);
   }, [navigate, searchQuery, startRegistration]);
 
-  useEffect(() => {
-    debouncedSearchQuery.length > 3 &&
-      startRegistration(
-        `${debouncedSearchQuery}${ENS_DOMAIN}`,
-        REGISTRATION_MODES.CREATE
-      );
-  }, [debouncedSearchQuery, startRegistration]);
+  useFocusEffect(
+    useCallback(() => {
+      debouncedSearchQuery.length > 3 &&
+        startRegistration(
+          `${debouncedSearchQuery}${ENS_DOMAIN}`,
+          REGISTRATION_MODES.CREATE
+        );
+    }, [debouncedSearchQuery, startRegistration])
+  );
 
   return (
     <Box

--- a/src/utils/branch.ts
+++ b/src/utils/branch.ts
@@ -1,6 +1,5 @@
 // @ts-expect-error ts-migrate(2305) FIXME: Could not find a declaration file for module 'pako... Remove this comment to see the full error message
 import pako from 'pako';
-// @ts-expect-error ts-migrate(2305) FIXME: Could not find a declaration file for module 'qs'.
 import qs from 'qs';
 import branch from 'react-native-branch';
 // @ts-expect-error ts-migrate(2305) FIXME: Module '"react-native-dotenv"' has no exported mem... Remove this comment to see the full error message
@@ -72,7 +71,7 @@ export const branchListener = (handleOpenLinkingURL: (url: any) => void) =>
 const decodeBranchUrl = (source: string) => {
   const query = source.split('?')[1];
   const queryParam = qs.parse(query)['_branch_referrer'];
-  const base64Url = decodeURIComponent(queryParam);
+  const base64Url = decodeURIComponent(queryParam as string);
   const ascii = Buffer.from(base64Url, 'base64');
 
   const originalUniversalUrl = pako.inflate(ascii, { to: 'string' });


### PR DESCRIPTION
Fixed an issue where upon opening the edit profile sheet, it would show the loading skeleton placeholder indefinitely. 

Turns out we were using a `useEffect` in `ENSSearchSheet` that was setting the registration to a "create" state & since the ENS navigator is not lazy, it will invoke the `useEffect` on mount. Fixed by replacing with `useFocusEffect`.

Also fixed a couple of TS errors too.