### PR TITLE
use uniqueId

### DIFF
--- a/src/hooks/useSwapInputHandlers.ts
+++ b/src/hooks/useSwapInputHandlers.ts
@@ -27,15 +27,17 @@ export default function useSwapInputHandlers() {
     (state: AppState) =>
       state.swap.typeSpecificParameters?.supplyBalanceUnderlying
   );
-  const inputCurrencyAddress = useSelector(
-    (state: AppState) => state.swap.inputCurrency?.address
+  const inputCurrency = useSelector(
+    (state: AppState) => state.swap.inputCurrency
   );
 
   const updateMaxInputAmount = useCallback(() => {
+    const inputCurrencyAddress = inputCurrency?.address;
+    const inputCurrencyUniqueId = inputCurrency?.uniqueId;
     if (type === ExchangeModalTypes.withdrawal) {
       dispatch(updateSwapInputAmount(supplyBalanceUnderlying));
     } else {
-      const accountAsset = ethereumUtils.getAccountAsset(inputCurrencyAddress);
+      const accountAsset = ethereumUtils.getAccountAsset(inputCurrencyUniqueId);
       const oldAmount = accountAsset?.balance?.amount ?? '0';
       let newAmount = oldAmount;
       if (inputCurrencyAddress === ETH_ADDRESS && accountAsset) {
@@ -69,7 +71,8 @@ Would you like to auto adjust the balance to leave some ${inputCurrencyAddress.t
     }
   }, [
     dispatch,
-    inputCurrencyAddress,
+    inputCurrency?.address,
+    inputCurrency?.uniqueId,
     selectedGasFee,
     supplyBalanceUnderlying,
     type,


### PR DESCRIPTION
## What changed (plus any additional context for devs)

needed to add proper handling for l2 assets to the max button, we now use the asset uid to get the account asset instead of using address

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-05-09-13-26-35.mp4

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
