### PR TITLE
Truncate long dapp names

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -104,6 +104,7 @@ import {
   SIGN_TYPED_DATA_V4,
 } from '@rainbow-me/utils/signingMethods';
 import logger from 'logger';
+import { truncateText } from '@rainbow-me/utils/truncateText';
 
 const springConfig = {
   damping: 500,
@@ -1065,14 +1066,16 @@ export default function TransactionConfirmationScreen() {
                   network={currentNetwork}
                 />
                 <Row marginBottom={android ? -6 : 5}>
-                  <Row marginBottom={android ? 16 : 8}>
+                  <Row marginBottom={android ? 16 : 8} marginHorizontal={32}>
                     <Text
                       align="center"
                       color="secondary80"
                       size="18px"
                       weight="bold"
                     >
-                      {isAuthenticated ? dappName : formattedDappUrl}
+                      {isAuthenticated
+                        ? truncateText(dappName)
+                        : formattedDappUrl}
                     </Text>
                   </Row>
                 </Row>

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -39,6 +39,7 @@ import { Navigation, useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import styled from '@rainbow-me/styled-components';
 import { ethereumUtils } from '@rainbow-me/utils';
+import { truncateText } from '@rainbow-me/utils/truncateText';
 
 const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(
   ({ theme: { colors } }) => ({
@@ -325,7 +326,9 @@ export default function WalletConnectApprovalSheet() {
                   weight="semibold"
                 >
                   <Text color="primary" size="23px" weight="heavy">
-                    {dappName}
+                    {truncateText(
+                      'Portion.io | The 21st Century Auction House | Launch your own NFT auctions | Collect Rare, High-End NFT Art, Music, and Collectibles in our Curated Drops'
+                    )}
                   </Text>{' '}
                   {type === WalletConnectApprovalSheetType.connect
                     ? `wants to connect to your wallet`

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -326,9 +326,7 @@ export default function WalletConnectApprovalSheet() {
                   weight="semibold"
                 >
                   <Text color="primary" size="23px" weight="heavy">
-                    {truncateText(
-                      'Portion.io | The 21st Century Auction House | Launch your own NFT auctions | Collect Rare, High-End NFT Art, Music, and Collectibles in our Curated Drops'
-                    )}
+                    {truncateText(dappName)}
                   </Text>{' '}
                   {type === WalletConnectApprovalSheetType.connect
                     ? `wants to connect to your wallet`

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,0 +1,7 @@
+export function truncateText(text: string) {
+  if (text.length > 40) {
+    return text.substring(0, 32) + '…';
+  }
+
+  return text;
+}

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,6 +1,8 @@
+const LIMIT = 32;
+
 export function truncateText(text: string) {
-  if (text.length > 40) {
-    return text.substring(0, 32) + '…';
+  if (text.length > LIMIT) {
+    return text.substring(0, LIMIT) + '…';
   }
 
   return text;


### PR DESCRIPTION
Fixes RNBW-1606

This PR adds a util that forcibly truncates too long dapp names. Applies to both WC approval sheet and all operations from https://example.walletconnect.org.

## What changed (plus any additional context for devs)

## PoW (screenshots / screen recordings)

![IMG_1FDAAFE72C37-1](https://user-images.githubusercontent.com/5769281/168067115-bb98d43f-4367-4b7f-8c27-4fc17ec6a44a.jpeg)

![IMG_65C133F1463B-1](https://user-images.githubusercontent.com/5769281/168067133-6326f5c3-96a4-4954-9635-cb1bd24f482f.jpeg)

![photo_2022-05-12 14 42 50](https://user-images.githubusercontent.com/5769281/168067181-fb75f169-82fd-41f7-8855-b94613578edc.jpeg)

![photo_2022-05-12 14 42 49](https://user-images.githubusercontent.com/5769281/168067203-331110ca-b9f7-46f6-8e25-70ac397f4a4f.jpeg)


## Dev checklist for QA: what to test

Play with https://example.walletconnect.org for example. Observe dapp names in the sheets.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why **Just visual change**
- [x] If you added new files, did you update the CODEOWNERS file?
