### PR TITLE
Profiles: Fix & refactor `address` value in RAL context

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/Contexts.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/Contexts.ts
@@ -7,7 +7,7 @@ import { UniqueAsset } from '@rainbow-me/entities';
 
 export const RecyclerAssetListContext = React.createContext<{
   additionalData: Record<string, CellTypes>;
-  address?: string;
+  externalAddress?: string;
   onPressUniqueToken?: (asset: UniqueAsset) => void;
 }>({ additionalData: {}, onPressUniqueToken: undefined });
 
@@ -16,12 +16,12 @@ export const RecyclerAssetListScrollPositionContext = React.createContext<
 >(undefined);
 
 export function useAdditionalRecyclerAssetListData(uid: string) {
-  const { additionalData, address, onPressUniqueToken } = useContext(
+  const { additionalData, externalAddress, onPressUniqueToken } = useContext(
     RecyclerAssetListContext
   );
   return useDeepCompareMemo(
-    () => ({ ...additionalData[uid], address, onPressUniqueToken }),
-    [additionalData[uid], address, onPressUniqueToken]
+    () => ({ ...additionalData[uid], externalAddress, onPressUniqueToken }),
+    [additionalData[uid], externalAddress, onPressUniqueToken]
   );
 }
 

--- a/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
@@ -26,13 +26,13 @@ const FILTER_TYPES = {
 } as { [key in AssetListType]: CellType[] };
 
 export default function useMemoBriefSectionData({
-  address,
+  externalAddress,
   type,
-}: { address?: string; type?: AssetListType } = {}) {
-  const { briefSectionsData }: { briefSectionsData: any[] } = address
-    ? // `address` is a static prop, so hooks will always execute in order.
+}: { externalAddress?: string; type?: AssetListType } = {}) {
+  const { briefSectionsData }: { briefSectionsData: any[] } = externalAddress
+    ? // `externalAddress` is a static prop, so hooks will always execute in order.
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      useExternalWalletSectionsData({ address })
+      useExternalWalletSectionsData({ address: externalAddress })
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       useWalletSectionsData();
   const { isSmallBalancesOpen, stagger } = useOpenSmallBalances();

--- a/src/components/asset-list/RecyclerAssetList2/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/index.tsx
@@ -12,22 +12,23 @@ import useMemoBriefSectionData from './core/useMemoBriefSectionData';
 export type AssetListType = 'wallet' | 'ens-profile' | 'select-nft';
 
 function RecyclerAssetList({
-  address,
+  externalAddress,
   type = 'wallet',
 }: {
-  address?: string;
+  /** An "external address" is an address that is not the current account address. */
+  externalAddress?: string;
   type?: AssetListType;
 }) {
   const {
     memoizedResult: briefSectionsData,
     additionalData,
-  } = useMemoBriefSectionData({ address, type });
+  } = useMemoBriefSectionData({ externalAddress, type });
 
   const position = useMemoOne(() => new RNAnimated.Value(0), []);
 
-  const value = useMemo(() => ({ additionalData, address }), [
+  const value = useMemo(() => ({ additionalData, externalAddress }), [
     additionalData,
-    address,
+    externalAddress,
   ]);
 
   return (

--- a/src/hooks/useCollectible.js
+++ b/src/hooks/useCollectible.js
@@ -13,18 +13,22 @@ export default function useCollectible(asset) {
 
   // Retrieve the unique tokens belonging to the targeted asset list account
   // (e.g. viewing another persons ENS profile via `ProfileSheet`)
-  // "External" unique tokens are tokens that belong to another address.
-  const { address } = useAdditionalRecyclerAssetListData(0);
+  // "External" unique tokens are tokens that belong to another address (not the current account address).
+  const { externalAddress } = useAdditionalRecyclerAssetListData(0);
   const queryClient = useQueryClient();
   const externalUniqueTokens = useMemo(() => {
-    return queryClient.getQueryData(uniqueTokensQueryKey({ address })) || [];
-  }, [queryClient, address]);
+    return (
+      queryClient.getQueryData(
+        uniqueTokensQueryKey({ address: externalAddress })
+      ) || []
+    );
+  }, [queryClient, externalAddress]);
 
   // Use the appropriate tokens based on if the user is viewing the
   // current accounts tokens, or external tokens (e.g. ProfileSheet)
   const uniqueTokens = useMemo(
-    () => (address ? externalUniqueTokens : selfUniqueTokens),
-    [address, externalUniqueTokens, selfUniqueTokens]
+    () => (externalAddress ? externalUniqueTokens : selfUniqueTokens),
+    [externalAddress, externalUniqueTokens, selfUniqueTokens]
   );
 
   return useMemo(() => {

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -75,7 +75,10 @@ export default function ProfileSheet() {
               <PlaceholderList />
             </Stack>
           ) : (
-            <RecyclerAssetList2 address={profileAddress} type="ens-profile" />
+            <RecyclerAssetList2
+              externalAddress={profileAddress}
+              type="ens-profile"
+            />
           )}
         </Box>
       </Box>


### PR DESCRIPTION
Fixing an issue where the `address` value we were passing to the RAL context was overriding the `address` value in `additionalData`. I renamed `address` to `externalAddress` to be more clear that this address is not the current account address coming from redux state.