### PR TITLE
Profiles: Fallback ENS avatar fetching to simplehash if OpenSea is down or collection is removed

### DIFF
--- a/src/components/images/ImagePreviewOverlay.tsx
+++ b/src/components/images/ImagePreviewOverlay.tsx
@@ -259,7 +259,8 @@ function ImagePreview({
     zIndex: progress.value > 0 ? index + 10 : index,
   }));
 
-  const ready = id && height > 0 && width > 0 && xOffset >= 0 && aspectRatio;
+  const ready =
+    id && imageUrl && height > 0 && width > 0 && xOffset >= 0 && aspectRatio;
 
   if (!ready) return null;
   return (

--- a/src/ens-avatar/src/specs/erc721.ts
+++ b/src/ens-avatar/src/specs/erc721.ts
@@ -4,6 +4,7 @@ import { BaseProvider } from '@ethersproject/providers';
 import { AvatarRequestOpts } from '..';
 import { resolveURI } from '../utils';
 import { apiGetUniqueTokenImage } from '@rainbow-me/handlers/opensea-api';
+import { getNFTByTokenId } from '@rainbow-me/handlers/simplehash';
 
 const abi = [
   'function tokenURI(uint256 tokenId) external view returns (string memory)',
@@ -42,10 +43,15 @@ export default class ERC721 {
       }
       return JSON.parse(_resolvedUri);
     }
-    const { image_url } = await apiGetUniqueTokenImage(
-      contractAddress,
-      tokenID
-    );
-    return { image: image_url };
+
+    let image;
+    try {
+      const data = await apiGetUniqueTokenImage(contractAddress, tokenID);
+      image = data.image_url;
+    } catch (error) {
+      const data = await getNFTByTokenId({ contractAddress, tokenId: tokenID });
+      image = data.previews?.image_medium_url;
+    }
+    return { image };
   }
 }

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -1,0 +1,41 @@
+import { captureException } from '@sentry/react-native';
+// @ts-expect-error
+import { SIMPLEHASH_API_KEY } from 'react-native-dotenv';
+import { RainbowFetchClient } from '../rainbow-fetch';
+import { logger } from '@rainbow-me/utils';
+
+const chains = {
+  ethereum: 'ethereum',
+} as const;
+type Chain = keyof typeof chains;
+
+const simplehashApi = new RainbowFetchClient({
+  baseURL: 'https://api.simplehash.com/api',
+});
+
+export async function getNFTByTokenId({
+  chain = chains.ethereum,
+  contractAddress,
+  tokenId,
+}: {
+  chain?: Chain;
+  contractAddress: string;
+  tokenId: string;
+}) {
+  try {
+    const response = await simplehashApi.get(
+      `/v0/nfts/${chain}/${contractAddress}/${tokenId}`,
+      {
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'x-api-key': SIMPLEHASH_API_KEY,
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    logger.sentry(`Error fetching simplehash NFT: ${error}`);
+    captureException(error);
+  }
+}


### PR DESCRIPTION
There is an edge case where the ENS NFT avatar/cover image resolution won't work if OpenSea is down or the collection is removed from OpenSea. This PR adds a fallback to fetch the NFT image from the simplehash API (we are using this in the notifications project).