### PR TITLE
Crash when filled a lot of digits in the swap input 

### DIFF
--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -22,6 +22,11 @@ export const convertAmountToRawAmount = (
 ): string =>
   new BigNumber(value).times(new BigNumber(10).pow(decimals)).toFixed();
 
+export const toFixedDecimalsAndRoundHalfUp = (
+  value: BigNumberish,
+  decimals: number
+): string => new BigNumber(value).toFixed(decimals, BigNumber.ROUND_HALF_UP);
+
 export const isZero = (value: BigNumberish): boolean =>
   new BigNumber(value).isZero();
 

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -46,10 +46,15 @@ const getOutputAmount = (
     convertNumberToString(inputAmount),
     inputToken.decimals
   );
-  const amountIn = new TokenAmount(inputToken, rawInputAmount);
-  const tradeDetails = Trade.bestTradeExactIn(allPairs, amountIn, outputToken, {
-    maxNumResults: 1,
-  })[0];
+  let tradeDetails = null;
+  try {
+    const amountIn = new TokenAmount(inputToken, rawInputAmount);
+    tradeDetails = Trade.bestTradeExactIn(allPairs, amountIn, outputToken, {
+      maxNumResults: 1,
+    })[0];
+  } catch (err) {
+    // user trying to convert a currency with more decimal places than that currency can be split
+  }
   const outputAmount = tradeDetails?.outputAmount?.toFixed() ?? null;
   const outputAmountDisplay =
     outputAmount && outputPrice
@@ -59,7 +64,7 @@ const getOutputAmount = (
       : null;
   return {
     outputAmount,
-    outputAmountDisplay,
+    outputAmountDisplay: outputAmountDisplay ?? null,
     tradeDetails,
   };
 };
@@ -185,15 +190,19 @@ export default function useSwapDerivedOutputs() {
           convertNumberToString(independentValue),
           outputToken.decimals
         );
-        const amountOut = new TokenAmount(outputToken, outputRawAmount);
-        tradeDetails = Trade.bestTradeExactOut(
-          allPairs,
-          inputToken,
-          amountOut,
-          {
-            maxNumResults: 1,
-          }
-        )[0];
+        try {
+          const amountOut = new TokenAmount(outputToken, outputRawAmount);
+          tradeDetails = Trade.bestTradeExactOut(
+            allPairs,
+            inputToken,
+            amountOut,
+            {
+              maxNumResults: 1,
+            }
+          )[0];
+        } catch (e) {
+          // user trying to convert a currency with more decimal places than that currency can be split
+        }
       }
 
       const inputAmountExact = tradeDetails?.inputAmount?.toExact() ?? null;


### PR DESCRIPTION
Fixes RNBW-3575

## What changed (plus any additional context for devs)
The crash occurred after entering more digits than the coin can split.
Can be reproduced by entering 0.123456789 for Wrapped Bitcoin into swap inputs
- `Compound DAI ` - 8 decimals
- `Wrapped Bitcoin` - 8 decimals
- `Ethereum` - 18 decimals

## PoW (screenshots / screen recordings)
before: https://user-images.githubusercontent.com/48593211/168335446-1138146b-d161-4ded-8727-7b8082dcf502.mp4
after: https://user-images.githubusercontent.com/48593211/168335564-4c7314a4-d0ef-42dc-a1e7-1b7a118348e8.mp4


## Dev checklist for QA: what to test
swap inputs

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
