### PR TITLE
Profiles: last qa fixes

### DIFF
--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -102,9 +102,8 @@ const ContactRow = (
       : null;
 
   // if the accountType === 'suggestions', nickname will always be an ens or hex address, not a custom contact nickname
-  const [ensName, setENSName] = useState(
-    ens || (nickname?.includes(ENS_DOMAIN) ? nickname : undefined)
-  );
+  const initialENSName = nickname?.includes(ENS_DOMAIN) ? nickname : ens;
+  const [ensName, setENSName] = useState(initialENSName);
 
   useEffect(() => {
     if (profilesEnabled && accountType === 'contacts') {

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -102,8 +102,18 @@ const ContactRow = (
       : null;
 
   // if the accountType === 'suggestions', nickname will always be an ens or hex address, not a custom contact nickname
-  const initialENSName = nickname?.includes(ENS_DOMAIN) ? nickname : ens;
+  const initialENSName =
+    typeof ens === 'string'
+      ? ens
+      : nickname?.includes(ENS_DOMAIN)
+      ? nickname
+      : '';
+
   const [ensName, setENSName] = useState(initialENSName);
+
+  const { data: images } = useENSProfileImages(ensName, {
+    enabled: profilesEnabled && Boolean(ensName),
+  });
 
   useEffect(() => {
     if (profilesEnabled && accountType === 'contacts') {
@@ -134,10 +144,6 @@ const ContactRow = (
     setENSName,
   ]);
 
-  const { data: images } = useENSProfileImages(ensName, {
-    enabled: profilesEnabled && Boolean(ensName),
-  });
-
   let cleanedUpLabel = null;
   if (label) {
     cleanedUpLabel = removeFirstEmojiFromString(label);
@@ -147,13 +153,11 @@ const ContactRow = (
     if (showcaseItem) {
       onPress(showcaseItem, nickname);
     } else {
-      const label =
+      const recipient =
         accountType === 'suggestions' && isENSAddressFormat(nickname)
           ? nickname
-          : ensName
-          ? ensName
-          : address;
-      onPress(label, nickname);
+          : ensName || address;
+      onPress(recipient, nickname ?? recipient);
     }
   }, [accountType, address, ensName, nickname, onPress, showcaseItem]);
 

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -82,7 +82,7 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
     enabled: Boolean(ens),
   });
 
-  const avatarUrl = images?.avatarUrl;
+  const avatarUrl = profilesEnabled ? images?.avatarUrl : undefined;
 
   const { result: dominantColor } = usePersistentDominantColorFromImage(
     maybeSignUri(avatarUrl || '') || ''

--- a/src/components/fields/AddressField.js
+++ b/src/components/fields/AddressField.js
@@ -80,11 +80,11 @@ const AddressField = (
   const autofill = name || address;
 
   useEffect(() => {
-    if (!inputValue && autofill && autofill !== inputValue) {
-      setInputValue(autofill);
-      validateAddress(autofill);
+    if (name !== inputValue) {
+      setInputValue(name);
+      validateAddress(address);
     }
-  }, [autofill, inputValue, validateAddress]);
+  }, [address, autofill, editable, inputValue, name, validateAddress]);
 
   return (
     <Row flex={1}>

--- a/src/components/send/SendHeader.js
+++ b/src/components/send/SendHeader.js
@@ -126,7 +126,9 @@ export default function SendHeader({
     ? removeFirstEmojiFromString(contact?.nickname) || contact?.ens
     : removeFirstEmojiFromString(userWallet?.label || nickname);
 
-  const name = label.length ? label : userWallet?.ens ?? userWallet?.address;
+  const name = label.length
+    ? label
+    : userWallet?.ens ?? userWallet?.address ?? recipient;
 
   const handleNavigateToContact = useCallback(() => {
     let nickname = recipient;

--- a/src/components/send/SendHeader.js
+++ b/src/components/send/SendHeader.js
@@ -125,7 +125,8 @@ export default function SendHeader({
   const label = isPreExistingContact
     ? removeFirstEmojiFromString(contact?.nickname) || contact?.ens
     : removeFirstEmojiFromString(userWallet?.label || nickname);
-  const name = label ? label : userWallet?.ens;
+
+  const name = label.length ? label : userWallet?.ens ?? userWallet?.address;
 
   const handleNavigateToContact = useCallback(() => {
     let nickname = recipient;

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -512,17 +512,14 @@ export const estimateENSCommitGasLimit = async ({
   });
 
 export const estimateENSMulticallGasLimit = async ({
-  ownerAddress,
   name,
   records,
 }: {
-  ownerAddress?: string;
   name: string;
   records: ENSRegistrationRecords;
 }) =>
   estimateENSTransactionGasLimit({
     name,
-    ownerAddress,
     records,
     type: ENSRegistrationTransactionType.MULTICALL,
   });
@@ -580,16 +577,13 @@ export const estimateENSSetNameGasLimit = async ({
 
 export const estimateENSSetTextGasLimit = async ({
   name,
-  ownerAddress,
   records,
 }: {
   name: string;
-  ownerAddress?: string;
   records: ENSRegistrationRecords;
 }) =>
   estimateENSTransactionGasLimit({
     name,
-    ownerAddress,
     records,
     type: ENSRegistrationTransactionType.SET_TEXT,
   });
@@ -625,6 +619,7 @@ export const estimateENSTransactionGasLimit = async ({
     ...(ownerAddress ? { from: ownerAddress } : {}),
     ...(value ? { value } : {}),
   };
+
   const gasLimit = await estimateGasWithPadding(
     txPayload,
     contract?.estimateGas[type],
@@ -749,7 +744,6 @@ export const estimateENSRegisterSetRecordsAndNameGasLimit = async ({
 export const estimateENSSetRecordsGasLimit = async ({
   name,
   records,
-  ownerAddress,
 }:
   | { name: string; records: Records; ownerAddress?: string }
   | ENSActionParameters) => {
@@ -764,7 +758,6 @@ export const estimateENSSetRecordsGasLimit = async ({
       ? estimateENSMulticallGasLimit
       : estimateENSSetTextGasLimit)({
       ...{ name, records: ensRegistrationRecords },
-      ...(ownerAddress ? { ownerAddress } : {}),
     });
   }
   return gasLimit;

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -117,7 +117,7 @@ const buildEnsToken = ({
 
 export const isUnknownOpenSeaENS = (asset?: any) =>
   asset?.description?.includes('This is an unknown ENS name with the hash') ||
-  !asset.uniqueId.includes('.eth') ||
+  !asset?.uniqueId?.includes('.eth') ||
   !asset?.image_url ||
   false;
 

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -179,10 +179,7 @@ export default function useENSRegistrationActionHandler(
 
   const renewAction = useCallback(
     async (callback: () => void) => {
-      const {
-        name,
-        duration,
-      } = registrationParameters as RegistrationParameters;
+      const { name } = registrationParameters as RegistrationParameters;
 
       const wallet = await loadWallet();
       if (!wallet) {
@@ -209,7 +206,7 @@ export default function useENSRegistrationActionHandler(
         callback
       );
     },
-    [getNextNonce, registrationParameters]
+    [duration, getNextNonce, registrationParameters]
   );
 
   const setNameAction = useCallback(

--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -57,11 +57,8 @@ export default function useENSRegistrationForm({
   // The initial records will be the existing records belonging to the profile in "edit mode",
   // but will be all of the records in "create mode".
   const defaultRecords = useMemo(
-    () =>
-      mode === REGISTRATION_MODES.EDIT
-        ? profileQuery?.data?.records || initialRecords
-        : allRecords,
-    [allRecords, initialRecords, mode, profileQuery?.data?.records]
+    () => (mode === REGISTRATION_MODES.EDIT ? initialRecords : allRecords),
+    [allRecords, initialRecords, mode]
   );
 
   const [errors, setErrors] = useRecoilState(errorsAtom);

--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -96,7 +96,7 @@ export default function useENSRegistrationForm({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name, defaultRecords, isEmpty(defaultRecords)]);
+  }, [name, defaultRecords]);
 
   const [valuesMap, setValuesMap] = useRecoilState(valuesAtom);
   const values = useMemo(() => valuesMap[name] || {}, [name, valuesMap]);
@@ -109,7 +109,7 @@ export default function useENSRegistrationForm({
       }));
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [name, defaultRecords, isEmpty(defaultRecords)]
+    [name, defaultRecords]
   );
 
   // Set initial records in redux depending on user input (defaultFields)

--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -57,8 +57,11 @@ export default function useENSRegistrationForm({
   // The initial records will be the existing records belonging to the profile in "edit mode",
   // but will be all of the records in "create mode".
   const defaultRecords = useMemo(
-    () => (mode === REGISTRATION_MODES.EDIT ? initialRecords : allRecords),
-    [allRecords, initialRecords, mode]
+    () =>
+      mode === REGISTRATION_MODES.EDIT
+        ? profileQuery?.data?.records || initialRecords
+        : allRecords,
+    [allRecords, initialRecords, mode, profileQuery?.data?.records]
   );
 
   const [errors, setErrors] = useRecoilState(errorsAtom);
@@ -96,7 +99,7 @@ export default function useENSRegistrationForm({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name, isEmpty(defaultRecords)]);
+  }, [name, defaultRecords, isEmpty(defaultRecords)]);
 
   const [valuesMap, setValuesMap] = useRecoilState(valuesAtom);
   const values = useMemo(() => valuesMap[name] || {}, [name, valuesMap]);
@@ -109,7 +112,7 @@ export default function useENSRegistrationForm({
       }));
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [name, isEmpty(defaultRecords)]
+    [name, defaultRecords, isEmpty(defaultRecords)]
   );
 
   // Set initial records in redux depending on user input (defaultFields)

--- a/src/raps/actions/ens.ts
+++ b/src/raps/actions/ens.ts
@@ -243,10 +243,14 @@ const ensAction = async (
       type
     );
 
+    const setRecordsType =
+      type === ENSRegistrationTransactionType.MULTICALL ||
+      type === ENSRegistrationTransactionType.SET_TEXT;
+
     gasLimit = await estimateENSTransactionGasLimit({
       duration,
       name,
-      ownerAddress,
+      ownerAddress: setRecordsType ? undefined : ownerAddress,
       records: ensRegistrationRecords,
       rentPrice,
       salt,

--- a/src/raps/actions/ens.ts
+++ b/src/raps/actions/ens.ts
@@ -1,6 +1,10 @@
 import { Wallet } from '@ethersproject/wallet';
 import analytics from '@segment/analytics-react-native';
 import { captureException } from '@sentry/react-native';
+import {
+  // @ts-ignore
+  IS_TESTING,
+} from 'react-native-dotenv';
 import { Rap, RapActionTypes, RapENSActionParameters } from '../common';
 import { ENSRegistrationRecords } from '@rainbow-me/entities';
 import {
@@ -21,7 +25,6 @@ import {
 import store from '@rainbow-me/redux/store';
 import { ethereumUtils } from '@rainbow-me/utils';
 import logger from 'logger';
-
 const executeCommit = async (
   name?: string,
   duration?: number,
@@ -244,8 +247,9 @@ const ensAction = async (
     );
 
     const setRecordsType =
-      type === ENSRegistrationTransactionType.MULTICALL ||
-      type === ENSRegistrationTransactionType.SET_TEXT;
+      IS_TESTING !== 'true' &&
+      (type === ENSRegistrationTransactionType.MULTICALL ||
+        type === ENSRegistrationTransactionType.SET_TEXT);
 
     gasLimit = await estimateENSTransactionGasLimit({
       duration,

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -118,7 +118,7 @@ export default function ENSConfirmRegisterSheet() {
   const avatarMetadata = useRecoilValue(avatarMetadataAtom);
 
   const avatarImage =
-    avatarMetadata?.path || params?.externalAvatarUrl || initialAvatarUrl || '';
+    avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
   const { result: dominantColor } = usePersistentDominantColorFromImage(
     avatarImage
   );

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -118,10 +118,11 @@ export default function ENSConfirmRegisterSheet() {
   const avatarMetadata = useRecoilValue(avatarMetadataAtom);
 
   const avatarImage =
-    avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
+    avatarMetadata?.path || params?.externalAvatarUrl || initialAvatarUrl || '';
   const { result: dominantColor } = usePersistentDominantColorFromImage(
     avatarImage
   );
+
   useEffect(() => {
     if (dominantColor || (!dominantColor && !avatarImage)) {
       setAccentColor(dominantColor || colors.purple);


### PR DESCRIPTION
Fixes RNBW-3635

## What changed (plus any additional context for devs)

1. when updating a profile the new records were not getting t the app because we're only using the internal state, changes it to use the ens data coming from ens profile query
2.  there's an issue estimating gas for set records transaction where putting a `from` param would make the gas estimation to fail in mainnet, so i removed it for multicall and setText txs
3. extend registration wasn't picking the right duration\

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
