### PR TITLE
Profiles: fix swap estimation + opensea link for new ens

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -473,7 +473,7 @@ const UniqueTokenExpandedState = ({
                             textColor={textColor}
                             weight="heavy"
                           />
-                        ) : (
+                        ) : asset.permalink ? (
                           <SheetActionButton
                             color={imageColor}
                             // @ts-expect-error JavaScript component
@@ -491,7 +491,7 @@ const UniqueTokenExpandedState = ({
                             textColor={textColor}
                             weight="heavy"
                           />
-                        )}
+                        ) : null}
                         {hasSendButton ? (
                           <SendActionButton
                             asset={asset}

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -254,14 +254,12 @@ export default function ExchangeModal({
       ) {
         return;
       }
-      const swapParams = {
+      const swapParameters = {
         inputAmount,
         outputAmount,
         tradeDetails,
       };
-      const gasLimit = await getSwapRapEstimationByType(type, {
-        swapParameters: swapParams,
-      });
+      const gasLimit = await getSwapRapEstimationByType(type, swapParameters);
       if (gasLimit) {
         updateTxFee(gasLimit);
       }


### PR DESCRIPTION
Fixes RNBW-3639

If ens NFT is not in opensea yet (no link) don't show the "View on Opensea" button

## What changed (plus any additional context for devs)

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
