### PR TITLE
Enable hermes transformer in metro rn babel preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "global": "4.4.0",
     "grapheme-splitter": "1.0.4",
     "graphql-tag": "2.11.0",
-    "hermes-engine": "0.9.0",
+    "hermes-engine": "0.11.0",
     "https-browserify": "0.0.1",
     "husky": "2.7.0",
     "i18n-js": "3.8.0",

--- a/patches/metro-react-native-babel-preset+0.68.0.patch
+++ b/patches/metro-react-native-babel-preset+0.68.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/metro-react-native-babel-preset/src/configs/main.js b/node_modules/metro-react-native-babel-preset/src/configs/main.js
+index edc8263..36310ec 100644
+--- a/node_modules/metro-react-native-babel-preset/src/configs/main.js
++++ b/node_modules/metro-react-native-babel-preset/src/configs/main.js
+@@ -44,7 +44,7 @@ const getPreset = (src, options) => {
+   // TODO(jsx): Restore check for transformProfile === 'hermes-canary'
+ 
+   const isHermesCanary = false;
+-  const isHermes = isHermesStable || isHermesCanary;
++  const isHermes = true;
+   const isNull = src == null;
+   const hasClass = isNull || src.indexOf("class") !== -1;
+   const hasForOf =

--- a/yarn.lock
+++ b/yarn.lock
@@ -10283,11 +10283,7 @@ heap@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
 
-hermes-engine@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.9.0.tgz#84d9cfe84e8f6b1b2020d6e71b350cec84ed982f"
-
-hermes-engine@~0.11.0:
+hermes-engine@0.11.0, hermes-engine@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.11.0.tgz#bb224730d230a02a5af02c4e090d1f52d57dd3db"
   integrity sha512-7aMUlZja2IyLYAcZ69NBnwJAR5ZOYlSllj0oMpx08a8HzxHOys0eKCzfphrf6D0vX1JGO1QQvVsQKe6TkYherw==


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Since we're running RN 0.68 we can use Hermes 0.11 which supports lots of cool es2015+ things without transformation into slower es5 code.

You can see all the `if (!isHermes)` blocks in the preset file.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
