### PR TITLE
Profiles: records and gas fee panel updates

### DIFF
--- a/src/hooks/useENSModifiedRegistration.ts
+++ b/src/hooks/useENSModifiedRegistration.ts
@@ -89,8 +89,6 @@ export default function useENSModifiedRegistration({
         ...profileQuery.data?.records,
         ...profileQuery.data?.coinAddresses,
       } as Records;
-      // delete ETH since we don't show it in the ENS form
-      delete initialRecords.ETH;
       dispatch(ensRedux.setInitialRecords(accountAddress, initialRecords));
     }
   }, [

--- a/src/hooks/useENSRegistrationCosts.ts
+++ b/src/hooks/useENSRegistrationCosts.ts
@@ -34,7 +34,7 @@ import {
   multiply,
 } from '@rainbow-me/helpers/utilities';
 import { ethUnits, timeUnits } from '@rainbow-me/references';
-import { ethereumUtils } from '@rainbow-me/utils';
+import { ethereumUtils, gasUtils } from '@rainbow-me/utils';
 
 enum QUERY_KEYS {
   GET_COMMIT_GAS_LIMIT = 'GET_COMMIT_GAS_LIMIT',
@@ -46,6 +46,7 @@ enum QUERY_KEYS {
 }
 
 const QUERY_STALE_TIME = 15000;
+const { NORMAL } = gasUtils;
 
 export default function useENSRegistrationCosts({
   name: inputName,
@@ -72,6 +73,7 @@ export default function useENSRegistrationCosts({
     isSufficientGas: useGasIsSufficientGas,
     isValidGas: useGasIsValidGas,
     gasLimit: useGasGasLimit,
+    selectedGasFeeOption,
   } = useGas();
 
   const [gasFeeParams, setGasFeeParams] = useState({
@@ -313,7 +315,8 @@ export default function useENSRegistrationCosts({
     const formattedEstimatedNetworkFee = formatEstimatedNetworkFee(
       estimatedGasLimit,
       currentBaseFee?.gwei,
-      gasFeeParamsBySpeed?.normal?.maxPriorityFeePerGas?.gwei,
+      gasFeeParamsBySpeed?.[selectedGasFeeOption || NORMAL]
+        ?.maxPriorityFeePerGas?.gwei,
       nativeCurrency,
       nativeAssetPrice
     );
@@ -322,16 +325,17 @@ export default function useENSRegistrationCosts({
       estimatedGasLimit,
       estimatedNetworkFee: formattedEstimatedNetworkFee,
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    commitGasLimit,
-    hasReverseRecord,
-    nativeCurrency,
-    renewGasLimit,
-    setNameGasLimit,
-    setRecordsGasLimit,
-    registerRapGasLimit,
+    gasFeeParams,
     step,
+    nativeCurrency,
+    commitGasLimit,
+    setRecordsGasLimit,
+    hasReverseRecord,
+    setNameGasLimit,
+    renewGasLimit,
+    registerRapGasLimit,
+    selectedGasFeeOption,
   ]);
 
   useEffect(() => {

--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -223,7 +223,7 @@ export default function useENSRegistrationForm({
   useEffect(() => {
     if (mode === REGISTRATION_MODES.EDIT) {
       if (profileQuery.isSuccess || !isEmpty(values)) {
-        setTimeout(() => setIsLoading(false), 50);
+        setTimeout(() => setIsLoading(false), 200);
       } else {
         setIsLoading(true);
       }

--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -1,6 +1,5 @@
 import { isEmpty, omit } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { InteractionManager } from 'react-native';
 import { atom, useRecoilState } from 'recoil';
 import { useENSModifiedRegistration, useENSRegistration } from '.';
 import { Records } from '@rainbow-me/entities';
@@ -224,9 +223,7 @@ export default function useENSRegistrationForm({
   useEffect(() => {
     if (mode === REGISTRATION_MODES.EDIT) {
       if (profileQuery.isSuccess || !isEmpty(values)) {
-        InteractionManager.runAfterInteractions(() => {
-          setTimeout(() => setIsLoading(false), 10);
-        });
+        setTimeout(() => setIsLoading(false), 50);
       } else {
         setIsLoading(true);
       }

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useRoute } from '@react-navigation/core';
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { InteractionManager, Keyboard } from 'react-native';
+import { Keyboard } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -248,9 +248,8 @@ export function ENSAssignRecordsBottomActions({
     onRemoveField,
     submit,
     values,
-    isLoading,
   } = useENSRegistrationForm();
-
+  const { profileQuery } = useENSModifiedRegistration();
   const handlePressBack = useCallback(() => {
     delayNext();
     navigate(fromRoute);
@@ -290,13 +289,11 @@ export function ENSAssignRecordsBottomActions({
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     if (mode === REGISTRATION_MODES.EDIT) {
-      InteractionManager.runAfterInteractions(() => {
-        setVisible(!isLoading);
-      });
+      setTimeout(() => setVisible(profileQuery.isSuccess), 50);
     } else {
       setVisible(defaultVisible);
     }
-  }, [defaultVisible, mode, isLoading]);
+  }, [defaultVisible, mode, profileQuery.isSuccess]);
 
   const bottomActionHeight = isSmallPhone
     ? BottomActionHeightSmall

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useRoute } from '@react-navigation/core';
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Keyboard } from 'react-native';
+import { InteractionManager, Keyboard } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -93,13 +93,13 @@ export default function ENSAssignRecordsSheet() {
       ].map(fieldName => textRecordFields[fieldName] as TextRecordField),
     []
   );
-  const { profileQuery } = useENSRegistrationForm({
+  const { profileQuery, isLoading } = useENSRegistrationForm({
     defaultFields,
     initializeForm: true,
   });
 
   const displayTitleLabel =
-    params.mode !== REGISTRATION_MODES.EDIT || profileQuery.isSuccess;
+    params.mode !== REGISTRATION_MODES.EDIT || !isLoading;
   const isEmptyProfile = isEmpty(profileQuery.data?.records);
 
   useENSRegistrationCosts({
@@ -239,7 +239,6 @@ export function ENSAssignRecordsBottomActions({
   const { colors } = useTheme();
   const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
   const { mode } = useENSRegistration();
-  const { profileQuery } = useENSModifiedRegistration();
   const [fromRoute, setFromRoute] = useState(previousRouteName);
   const {
     disabled,
@@ -249,6 +248,7 @@ export function ENSAssignRecordsBottomActions({
     onRemoveField,
     submit,
     values,
+    isLoading,
   } = useENSRegistrationForm();
 
   const handlePressBack = useCallback(() => {
@@ -290,11 +290,13 @@ export function ENSAssignRecordsBottomActions({
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     if (mode === REGISTRATION_MODES.EDIT) {
-      setTimeout(() => setVisible(profileQuery.isSuccess), 200);
+      InteractionManager.runAfterInteractions(() => {
+        setVisible(!isLoading);
+      });
     } else {
       setVisible(defaultVisible);
     }
-  }, [defaultVisible, mode, profileQuery.isSuccess]);
+  }, [defaultVisible, mode, isLoading]);
 
   const bottomActionHeight = isSmallPhone
     ? BottomActionHeightSmall

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -289,7 +289,7 @@ export function ENSAssignRecordsBottomActions({
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     if (mode === REGISTRATION_MODES.EDIT) {
-      setTimeout(() => setVisible(profileQuery.isSuccess), 50);
+      setTimeout(() => setVisible(profileQuery.isSuccess), 200);
     } else {
       setVisible(defaultVisible);
     }


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

Gas updates now update the fee registration panel. If the estimated fee changes because the user selects a new speed or the estimated fee gets updated from backend, the fees panel will update accordingly for new registrations and registration extension

https://user-images.githubusercontent.com/12115171/169664190-7c720714-439c-41a9-b5ea-609f70ae1279.mov

ENS edition show different form depending on the records the ENS has. Until now if the user had one record set, as the avatar, the form will be empty so no label / inputs would be shown, only an empty ENS would show the form. Now the last case will remain, but if the user only has an avatar and / or cover, the default form will be displayed as well (case for scamdog.eth and eminolar.eth in the video), if the user has some record different than avatar or cover the form will only show that record (case for estebanmino.eth in the video)

https://user-images.githubusercontent.com/12115171/169664330-75e3f84b-43eb-4082-b0e1-601b0ebf13ed.mov



## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
