### PR TITLE
Do not rebuild unnecessarily wallet sections

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,9 @@ src/context @osdnk @terrysahaidak
 # NETWORK DEBUGGING
 src/debugging @brunobar79
 
+# Debugging
+src/debugging/useDependencyDebugger.ts @terrysahaidak
+
 # DESIGN SYSTEM
 src/design-system @markdalgleish @jxom
 

--- a/src/components/asset-list/AssetList.js
+++ b/src/components/asset-list/AssetList.js
@@ -19,6 +19,7 @@ const AssetList = ({
   network,
   scrollViewTracker,
   sections,
+  walletBriefSectionsData,
   ...props
 }) => {
   const insets = useSafeArea();
@@ -43,7 +44,7 @@ const AssetList = ({
       {...props}
     />
   ) : (
-    <RecyclerAssetList2 />
+    <RecyclerAssetList2 walletBriefSectionsData={walletBriefSectionsData} />
   );
 };
 

--- a/src/components/asset-list/AssetList.js
+++ b/src/components/asset-list/AssetList.js
@@ -1,7 +1,6 @@
 import lang from 'i18n-js';
 import React from 'react';
 import { useSafeArea } from 'react-native-safe-area-context';
-import { magicMemo } from '../../utils';
 import { FabWrapperBottomPosition, FloatingActionButtonSize } from '../fab';
 import { ListFooter } from '../list';
 import EmptyAssetList from './EmptyAssetList';
@@ -48,9 +47,4 @@ const AssetList = ({
   );
 };
 
-export default magicMemo(AssetList, [
-  'isEmpty',
-  'isLoading',
-  'isWalletEthZero',
-  'sections',
-]);
+export default React.memo(AssetList);

--- a/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
@@ -7,11 +7,9 @@ import {
   useOpenInvestmentCards,
   useOpenSavings,
   useOpenSmallBalances,
-  useWalletSectionsData,
 } from '@rainbow-me/hooks';
 
-export default function useMemoBriefSectionData() {
-  const { briefSectionsData } = useWalletSectionsData();
+export default function useMemoBriefSectionData(briefSectionsData: any[]) {
   const { isSmallBalancesOpen, stagger } = useOpenSmallBalances();
   const { isSavingsOpen } = useOpenSavings();
   const { isInvestmentCardsOpen } = useOpenInvestmentCards();

--- a/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useMemoBriefSectionData.ts
@@ -1,4 +1,6 @@
+import { useMemo } from 'react';
 import { useDeepCompareMemo } from 'use-deep-compare';
+import { useDependencyDebugger } from '../../../../debugging/useDependencyDebugger';
 import { CellType, CoinExtraData, NFTFamilyExtraData } from './ViewTypes';
 import {
   useCoinListEdited,
@@ -10,21 +12,21 @@ import {
 } from '@rainbow-me/hooks';
 
 export default function useMemoBriefSectionData(briefSectionsData: any[]) {
-  const { isSmallBalancesOpen, stagger } = useOpenSmallBalances();
+  const { isSmallBalancesOpen } = useOpenSmallBalances();
   const { isSavingsOpen } = useOpenSavings();
   const { isInvestmentCardsOpen } = useOpenInvestmentCards();
   const { isCoinListEdited } = useCoinListEdited();
   const { hiddenCoins } = useCoinListEditOptions();
   const { openFamilies } = useOpenFamilies();
 
-  const result = useDeepCompareMemo(() => {
+  const result = useMemo(() => {
     let afterDivider = false;
     let isGroupOpen = true;
     const stickyHeaders = [];
     let index = 0;
     let afterCoins = false;
     // load firstly 12, then the rest after 1 sec
-    let numberOfSmallBalancesAllowed = stagger ? 12 : briefSectionsData.length;
+    let numberOfSmallBalancesAllowed = briefSectionsData.length;
     const briefSectionsDataFiltered = briefSectionsData
       .filter((data, arrIndex, arr) => {
         if (
@@ -116,7 +118,7 @@ export default function useMemoBriefSectionData(briefSectionsData: any[]) {
     isInvestmentCardsOpen,
     isCoinListEdited,
     openFamilies,
-    stagger,
+    hiddenCoins,
   ]);
   const memoizedResult = useDeepCompareMemo(() => result, [result]);
   const additionalData = useDeepCompareMemo(

--- a/src/components/asset-list/RecyclerAssetList2/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/index.tsx
@@ -9,11 +9,15 @@ import RawMemoRecyclerAssetList from './core/RawRecyclerList';
 import { StickyHeaderManager } from './core/StickyHeaders';
 import useMemoBriefSectionData from './core/useMemoBriefSectionData';
 
-function RecyclerAssetList() {
+function RecyclerAssetList({
+  walletBriefSectionsData,
+}: {
+  walletBriefSectionsData: any[];
+}) {
   const {
     memoizedResult: briefSectionsData,
     additionalData,
-  } = useMemoBriefSectionData();
+  } = useMemoBriefSectionData(walletBriefSectionsData);
 
   const position = useMemoOne(() => new RNAnimated.Value(0), []);
 

--- a/src/debugging/useDependencyDebugger.ts
+++ b/src/debugging/useDependencyDebugger.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import { logger } from '../utils';
+
+const usePrevious = <T>(value: T, initialValue: T): T => {
+  const ref = useRef<T>(initialValue);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export const useDependencyDebugger = (
+  dependencies: unknown[],
+  dependencyNames: string[] = []
+) => {
+  const previousDeps = usePrevious(dependencies, []);
+
+  const changedDeps = dependencies.reduce<
+    Record<
+      string,
+      {
+        after: unknown;
+        before: unknown;
+      }
+    >
+  >((accum, dependency, index) => {
+    if (dependency !== previousDeps[index]) {
+      const keyName = dependencyNames[index] || index;
+      return {
+        ...accum,
+        [keyName]: {
+          after: dependency,
+          before: previousDeps[index],
+        },
+      };
+    }
+
+    return accum;
+  }, {});
+
+  if (Object.keys(changedDeps).length) {
+    logger.log('[use-memo-debugger] ', changedDeps);
+  }
+};

--- a/src/hooks/useAccountEmptyState.js
+++ b/src/hooks/useAccountEmptyState.js
@@ -5,11 +5,9 @@ import {
   saveAccountEmptyState,
 } from '../handlers/localstorage/accountLocal';
 import useAccountSettings from './useAccountSettings';
-import useWalletSectionsData from './useWalletSectionsData';
 
-export default function useAccountEmptyState() {
+export default function useAccountEmptyState(isSectionsEmpty) {
   const { network, accountAddress } = useAccountSettings();
-  const { isEmpty: isSectionsEmpty } = useWalletSectionsData();
   const isLoadingAssets = useSelector(state => state.data.isLoadingAssets);
   const isAccountEmptyInStorage = useMemo(
     () => getAccountEmptyState(accountAddress, network),

--- a/src/hooks/useOpenSmallBalances.js
+++ b/src/hooks/useOpenSmallBalances.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { atom, useRecoilState } from 'recoil';
 
 const areOpenSmallBalancesAtom = atom({
@@ -6,37 +6,20 @@ const areOpenSmallBalancesAtom = atom({
   key: 'areOpenSmallBalances',
 });
 
-const areOpenSmallBalancesStaggerAtom = atom({
-  default: false,
-  key: 'areOpenSmallBalancesStagger',
-});
-
 export default function useOpenSmallBalances() {
   const [isSmallBalancesOpen, setIsSmallBalancesOpen] = useRecoilState(
     areOpenSmallBalancesAtom
   );
 
-  const [stagger, setStagger] = useRecoilState(areOpenSmallBalancesStaggerAtom);
-
-  useEffect(() => {
-    if (stagger) {
-      setTimeout(() => setStagger(false), 700);
-    }
-  }, [setStagger, stagger]);
-
   const toggleOpenSmallBalances = useCallback(() => {
-    if (!isSmallBalancesOpen) {
-      setStagger(true);
-    }
     setIsSmallBalancesOpen(prev => {
       return !prev;
     });
-  }, [isSmallBalancesOpen, setIsSmallBalancesOpen, setStagger]);
+  }, [setIsSmallBalancesOpen]);
 
   return {
     isSmallBalancesOpen,
     setIsSmallBalancesOpen,
-    stagger,
     toggleOpenSmallBalances,
   };
 }

--- a/src/hooks/useSavingsAccount.js
+++ b/src/hooks/useSavingsAccount.js
@@ -230,9 +230,12 @@ export default function useSavingsAccount(includeDefaultDai) {
     return savings;
   }, [includeDefaultDai, result, genericAssets]);
 
+  // savings returns the same object with the new reference over and over
+  const memoizedSavings = useDeepCompareMemo(() => savings, [savings]);
+
   return {
     refetchSavings,
-    savings,
+    savings: memoizedSavings,
     shouldRefetchSavings,
   };
 }

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -69,7 +69,6 @@ export default function WalletScreen() {
   const { isCoinListEdited } = useCoinListEdited();
   const scrollViewTracker = useValue(0);
   const { isReadOnlyWallet } = useWallets();
-  const { isEmpty: isAccountEmpty } = useAccountEmptyState();
   const { network } = useAccountSettings();
   const { userAccounts } = useUserAccounts();
   const { portfolios, trackPortfolios } = usePortfolios();
@@ -83,7 +82,11 @@ export default function WalletScreen() {
     refetchSavings,
     sections,
     shouldRefetchSavings,
+    isEmpty: isSectionsEmpty,
+    briefSectionsData: walletBriefSectionsData,
   } = useWalletSectionsData();
+
+  const { isEmpty: isAccountEmpty } = useAccountEmptyState(isSectionsEmpty);
 
   const dispatch = useDispatch();
   const profilesEnabled = useExperimentalFlag(PROFILES);
@@ -209,6 +212,7 @@ export default function WalletScreen() {
           isWalletEthZero={isWalletEthZero}
           network={network}
           scrollViewTracker={scrollViewTracker}
+          walletBriefSectionsData={walletBriefSectionsData}
         />
       </FabWrapper>
     </WalletPage>


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

There are 3 changes in this PR:
1. Noticed that we use the same hook twice in different places in the tree so it just runs the same logic a few times. Moved it to the root component, to make sure that we pass dependencies as params instead of using the same hooks inside the hooks.
2. Savings was causing wallet sections to rebuild over and over, especially when you press "all" to show all the assets.
3. Added a hook that helped me to identify what dependency changes over the calls. Handy when some useEffect or useMemo calls randomly and not sure why.

## PoW (screenshots / screen recordings)

Before (look at how often the selector is called):

https://user-images.githubusercontent.com/7809008/169882515-be07d478-6bb3-4f35-afae-dc7c112eeb6d.mov


After:

https://user-images.githubusercontent.com/7809008/169882240-991b8d45-3723-40dc-90c3-32645f7a7c70.mov

## Dev checklist for QA: what to test
- The wallet sections should have no changes but can be a bit faster to show/hide all assets

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
