### PR TITLE
profiles: filter non owned ens

### DIFF
--- a/src/apollo/queries.ts
+++ b/src/apollo/queries.ts
@@ -210,6 +210,9 @@ export const ENS_SUGGESTIONS = gql`
           id
         }
       }
+      owner {
+        id
+      }
     }
   }
 `;


### PR DESCRIPTION
Fixes RNBW-3667

## What changed (plus any additional context for devs)

filtering out domains with no owner

eric.ethglobal.eth has no controller nor resolver but we were still showing it in the ens search
 
## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
