### PR TITLE
swap - fix derived values behavior

### DIFF
--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -56,7 +56,7 @@ export default function ExchangeInputField({
       <NativeFieldRow>
         <ExchangeNativeField
           address={inputCurrencyAddress}
-          editable
+          editable={editable}
           height={64}
           nativeAmount={nativeAmount}
           nativeCurrency={nativeCurrency}

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -32,6 +32,7 @@ import Logger from '@rainbow-me/utils/logger';
 enum DisplayValue {
   input = 'inputAmountDisplay',
   output = 'outputAmountDisplay',
+  native = 'nativeAmountDisplay',
 }
 
 const getInputAmount = async (
@@ -238,6 +239,7 @@ const derivedValues: { [key in SwapModalField]: string | null } = {
 const displayValues: { [key in DisplayValue]: string | null } = {
   [DisplayValue.input]: null,
   [DisplayValue.output]: null,
+  [DisplayValue.native]: null,
 };
 
 export default function useSwapDerivedOutputs(chainId: number) {
@@ -297,6 +299,26 @@ export default function useSwapDerivedOutputs(chainId: number) {
     const getTradeDetails = async () => {
       let tradeDetails = null;
 
+      if (independentValue === '0.') {
+        switch (independentField) {
+          case SwapModalField.input:
+            displayValues[DisplayValue.input] = independentValue;
+            break;
+          case SwapModalField.output:
+            displayValues[DisplayValue.output] = independentValue;
+            break;
+          case SwapModalField.native:
+            displayValues[DisplayValue.native] = independentValue;
+            break;
+        }
+        setResult({
+          derivedValues,
+          displayValues,
+          tradeDetails,
+        });
+        return;
+      }
+
       if (isZero(independentValue) || !independentValue) {
         resetSwapInputs();
         return;
@@ -326,6 +348,8 @@ export default function useSwapDerivedOutputs(chainId: number) {
           : null;
 
         derivedValues[SwapModalField.native] = nativeValue;
+        displayValues[DisplayValue.native] = nativeValue;
+
         const {
           outputAmount,
           outputAmountDisplay,
@@ -365,6 +389,7 @@ export default function useSwapDerivedOutputs(chainId: number) {
         }
 
         derivedValues[SwapModalField.native] = independentValue;
+        displayValues[DisplayValue.native] = independentValue;
         derivedValues[SwapModalField.input] = inputAmount;
 
         const inputAmountDisplay =
@@ -429,6 +454,7 @@ export default function useSwapDerivedOutputs(chainId: number) {
             : null;
 
         derivedValues[SwapModalField.native] = nativeValue;
+        displayValues[DisplayValue.native] = nativeValue;
       }
 
       const data = {

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -296,7 +296,13 @@ export default function useSwapDerivedOutputs(chainId: number) {
   useEffect(() => {
     const getTradeDetails = async () => {
       let tradeDetails = null;
-      if (!independentValue || !inputCurrency) {
+
+      if (isZero(independentValue) || !independentValue) {
+        resetSwapInputs();
+        return;
+      }
+
+      if (!inputCurrency || !outputCurrency) {
         setInsufficientLiquidity(false);
         setResult({
           derivedValues,
@@ -305,6 +311,7 @@ export default function useSwapDerivedOutputs(chainId: number) {
         });
         return;
       }
+
       setLoading(true);
       const inputToken = inputCurrency;
       const outputToken = outputCurrency;
@@ -314,10 +321,9 @@ export default function useSwapDerivedOutputs(chainId: number) {
         derivedValues[SwapModalField.input] = independentValue;
         displayValues[DisplayValue.input] = independentValue;
 
-        const nativeValue =
-          inputPrice && !isZero(independentValue)
-            ? convertAmountToNativeAmount(independentValue, inputPrice)
-            : null;
+        const nativeValue = inputPrice
+          ? convertAmountToNativeAmount(independentValue, inputPrice)
+          : null;
 
         derivedValues[SwapModalField.native] = nativeValue;
         const {
@@ -341,7 +347,7 @@ export default function useSwapDerivedOutputs(chainId: number) {
           outputAmountDisplay?.toString() || null;
       } else if (independentField === SwapModalField.native) {
         const inputAmount =
-          independentValue && !isZero(independentValue) && inputPrice
+          independentValue && inputPrice
             ? convertAmountFromNativeValue(
                 independentValue,
                 inputPrice,
@@ -349,18 +355,17 @@ export default function useSwapDerivedOutputs(chainId: number) {
               )
             : null;
 
-        derivedValues[SwapModalField.native] = independentValue;
-        derivedValues[SwapModalField.input] = inputAmount;
-
         // The quote is the same
         if (
           derivedValuesFromRedux &&
-          derivedValues[SwapModalField.native] ===
-            derivedValuesFromRedux[SwapModalField.native]
+          independentValue === derivedValuesFromRedux[SwapModalField.native]
         ) {
           setLoading(false);
           return;
         }
+
+        derivedValues[SwapModalField.native] = independentValue;
+        derivedValues[SwapModalField.input] = inputAmount;
 
         const inputAmountDisplay =
           inputAmount && inputPrice

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -236,7 +236,11 @@ export default function ExchangeModal({
   const {
     result: {
       derivedValues: { inputAmount, nativeAmount, outputAmount },
-      displayValues: { inputAmountDisplay, outputAmountDisplay },
+      displayValues: {
+        inputAmountDisplay,
+        outputAmountDisplay,
+        nativeAmountDisplay,
+      },
       tradeDetails,
     },
     loading,
@@ -714,7 +718,7 @@ export default function ExchangeModal({
               inputCurrencyAssetType={inputCurrency?.type}
               inputCurrencySymbol={inputCurrency?.symbol}
               inputFieldRef={inputFieldRef}
-              nativeAmount={nativeAmount}
+              nativeAmount={nativeAmountDisplay}
               nativeCurrency={nativeCurrency}
               nativeFieldRef={nativeFieldRef}
               onFocus={handleFocus}


### PR DESCRIPTION
Fixes a few issues regarding input values.

the first is a bug where `useSwapDerivedOutputs` would return because the new quote was the same as the last quote when in fact they were different, I moved some logic around and it works as expected now

another is the handling of the prepending 0 scenario which was not working previously.

the last was handling zero/null values properly so that they clear the other inputs when the focused input is cleared

also passed the editable prop to native input to match the expected behavior

## What changed (plus any additional context for devs)

## PoW (screenshots / screen recordings)

https://cloud.skylarbarrera.com/Screen-Recording-2022-05-24-00-53-49.mp4

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
