### PR TITLE
Profiles: fix loading placeholder

### DIFF
--- a/src/components/ens-registration/RegistrationReviewRows/RegistrationReviewRows.tsx
+++ b/src/components/ens-registration/RegistrationReviewRows/RegistrationReviewRows.tsx
@@ -110,7 +110,7 @@ export default function RegistrationReviewRows({
 
   return (
     <Box>
-      <Stack space="34px">
+      <Stack space="30px">
         <Columns>
           <Column width="3/5">
             <Text size="16px" weight="heavy">
@@ -135,7 +135,7 @@ export default function RegistrationReviewRows({
                     type="decrement"
                   />
                 </Column>
-                <Box>
+                <Box height={{ custom: 16 }}>
                   <Text align="center" size="16px" weight="heavy">
                     {duration > 1
                       ? lang.t('profiles.confirm.duration_plural', {
@@ -180,13 +180,20 @@ export default function RegistrationReviewRows({
             </Text>
           </Column>
           <Column width="1/3">
-            {registrationFee ? (
-              <Text align="right" color="secondary80" size="16px" weight="bold">
-                {registrationFee}
-              </Text>
-            ) : (
-              <LoadingPlaceholder />
-            )}
+            <Box height={{ custom: 16 }}>
+              {registrationFee ? (
+                <Text
+                  align="right"
+                  color="secondary80"
+                  size="16px"
+                  weight="bold"
+                >
+                  {registrationFee}
+                </Text>
+              ) : (
+                <LoadingPlaceholder />
+              )}
+            </Box>
           </Column>
         </Columns>
 
@@ -197,13 +204,20 @@ export default function RegistrationReviewRows({
             </Text>
           </Column>
           <Column width="1/3">
-            {networkFee ? (
-              <Text align="right" color="secondary80" size="16px" weight="bold">
-                {networkFee}
-              </Text>
-            ) : (
-              <LoadingPlaceholder />
-            )}
+            <Box height={{ custom: 16 }}>
+              {networkFee ? (
+                <Text
+                  align="right"
+                  color="secondary80"
+                  size="16px"
+                  weight="bold"
+                >
+                  {networkFee}
+                </Text>
+              ) : (
+                <LoadingPlaceholder />
+              )}
+            </Box>
           </Column>
         </Columns>
 
@@ -215,18 +229,20 @@ export default function RegistrationReviewRows({
               </Text>
             </Column>
             <Column width="1/3">
-              {networkFee ? (
-                <Text
-                  align="right"
-                  color="secondary80"
-                  size="16px"
-                  weight="bold"
-                >
-                  {estimatedCostETH} ETH
-                </Text>
-              ) : (
-                <LoadingPlaceholder />
-              )}
+              <Box height={{ custom: 16 }}>
+                {networkFee ? (
+                  <Text
+                    align="right"
+                    color="secondary80"
+                    size="16px"
+                    weight="bold"
+                  >
+                    {estimatedCostETH} ETH
+                  </Text>
+                ) : (
+                  <LoadingPlaceholder />
+                )}
+              </Box>
             </Column>
           </Columns>
         )}
@@ -238,13 +254,15 @@ export default function RegistrationReviewRows({
             </Text>
           </Column>
           <Column width="1/3">
-            {totalCost ? (
-              <Text align="right" size="16px" weight="heavy">
-                {totalCost}
-              </Text>
-            ) : (
-              <LoadingPlaceholder />
-            )}
+            <Box height={{ custom: 16 }}>
+              {totalCost ? (
+                <Text align="right" size="16px" weight="heavy">
+                  {totalCost}
+                </Text>
+              ) : (
+                <LoadingPlaceholder />
+              )}
+            </Box>
           </Column>
         </Columns>
       </Stack>


### PR DESCRIPTION
Fixes RNBW-3679

## What changed (plus any additional context for devs)
- loading placeholder was getting cut off vertically on registration confirmation screen
- this fix seems pretty janky so lmk if you have another idea

## PoW (screenshots / screen recordings)
Before:
<img width="508" alt="Screen Shot 2022-05-26 at 5 38 15 PM" src="https://user-images.githubusercontent.com/15272675/170605858-a4fdde7c-3fbf-4055-a91b-a2029018f257.png">

After:
<img width="353" alt="Screen Shot 2022-05-26 at 5 37 51 PM" src="https://user-images.githubusercontent.com/15272675/170605836-1a17442c-daf0-4b5f-b019-116e9e778395.png">

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
