### PR TITLE
Fix incorrect aspect ratio calculating after MMKV bump

### DIFF
--- a/src/hooks/usePersistentAspectRatio.ts
+++ b/src/hooks/usePersistentAspectRatio.ts
@@ -21,9 +21,7 @@ type Result = {
 
 export default function usePersistentAspectRatio(url: string): Result {
   const [ratio, setAspectRatio] = useMMKVNumber((url || '') as string, storage);
-  const [state, setState] = useState<State>(
-    ratio !== 0 ? State.loaded : State.init
-  );
+  const [state, setState] = useState<State>(ratio ? State.loaded : State.init);
   useEffect(() => {
     if (state === State.init && url) {
       setState(State.loading);


### PR DESCRIPTION
Fixes RNBW-3729


## What changed (plus any additional context for devs)

After the MMKV bump (that happened together with bumping RN), the behavior changes so the default value of `useMMKVNumber` is not `0`, but `undefined`. I adjust the logic for that. 

## PoW (screenshots / screen recordings)

![image](https://user-images.githubusercontent.com/25709300/170982616-8122e756-93fd-4c04-b40c-dfce5e96804f.png)


## Dev checklist for QA: what to test

Reset everything (MMKV, local storage, image cache) and try to open some non-square NFT e.g. BlockCities. 

