### PR TITLE
Fix NFT audio mixing

### DIFF
--- a/src/components/video/SimpleVideo.tsx
+++ b/src/components/video/SimpleVideo.tsx
@@ -95,6 +95,7 @@ export default function SimpleVideo({
         <StyledBackground />
         <StyledVideo
           controls={controlsEnabled}
+          ignoreSilentSwitch="obey"
           onLoad={() => setLoading(false)}
           ref={ref}
           repeat


### PR DESCRIPTION
Fixes RNBW-3726, RNBW-2524

## What changed (plus any additional context for devs)

- fixed the issue where video NFTs interrupted audio from other apps. the [`mixWithOthers`](https://github.com/react-native-video/react-native-video/blob/master/API.md#mixWithOthers) options from react-native-video don't seem to have any effect, but setting [`ignoreSilentSwitch="obey"`](https://github.com/react-native-video/react-native-video/blob/master/API.md#ignoresilentswitch) achieves the same result ([more info](https://github.com/react-native-video/react-native-video/issues/1026#issuecomment-1108333427))

## Dev checklist for QA:

- on iOS, video NFTs should no longer interrupt music or audio from other apps
- android should be unaffected

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
