### PR TITLE
Rework StepIndicator to stop crashing on Android

### DIFF
--- a/src/components/step-indicator/StepIndicator.tsx
+++ b/src/components/step-indicator/StepIndicator.tsx
@@ -21,7 +21,7 @@ type StepIndicatorProps = {
 
 const StepIndicator = ({ steps, currentStep }: StepIndicatorProps) => {
   const { width: screenWidth } = useDimensions();
-  const stepWidth = screenWidth / steps - STEP_SPACING * (steps - 1);
+  const stepWidth = screenWidth / steps - STEP_SPACING;
   const accentColor = useForegroundColor('accent');
   const accentColorTint = accentColor + '25';
 
@@ -41,7 +41,7 @@ const StepIndicator = ({ steps, currentStep }: StepIndicatorProps) => {
       withSequence(
         withTiming(-stepWidth, { duration: PULSE_STEP_DURATION }),
         withTiming(-stepWidth, { duration: PULSE_STEP_DURATION }),
-        withTiming(0, { duration: PULSE_STEP_DURATION })
+        withTiming(5, { duration: PULSE_STEP_DURATION })
       ),
       -1
     )

--- a/src/components/step-indicator/StepIndicator.tsx
+++ b/src/components/step-indicator/StepIndicator.tsx
@@ -8,9 +8,11 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Box, Columns, useForegroundColor } from '@rainbow-me/design-system';
+import { useDimensions } from '@rainbow-me/hooks';
 import { magicMemo } from '@rainbow-me/utils';
 
 const PULSE_STEP_DURATION = 1000;
+const STEP_SPACING = 9;
 
 type StepIndicatorProps = {
   steps: number; // 1 indexed
@@ -18,6 +20,8 @@ type StepIndicatorProps = {
 };
 
 const StepIndicator = ({ steps, currentStep }: StepIndicatorProps) => {
+  const { width: screenWidth } = useDimensions();
+  const stepWidth = screenWidth / steps - STEP_SPACING * (steps - 1);
   const accentColor = useForegroundColor('accent');
   const accentColorTint = accentColor + '25';
 
@@ -35,8 +39,8 @@ const StepIndicator = ({ steps, currentStep }: StepIndicatorProps) => {
   const pulseStepTranslate = useDerivedValue(() =>
     withRepeat(
       withSequence(
-        withTiming(-100, { duration: PULSE_STEP_DURATION }),
-        withTiming(-100, { duration: PULSE_STEP_DURATION }),
+        withTiming(-stepWidth, { duration: PULSE_STEP_DURATION }),
+        withTiming(-stepWidth, { duration: PULSE_STEP_DURATION }),
         withTiming(0, { duration: PULSE_STEP_DURATION })
       ),
       -1
@@ -51,8 +55,8 @@ const StepIndicator = ({ steps, currentStep }: StepIndicatorProps) => {
   );
 
   const animatedPulseStyle = useAnimatedStyle(() => ({
-    ...(ios ? { left: `${pulseStepTranslate?.value}%` } : {}),
     opacity: pulseStepOpacity?.value,
+    transform: [{ translateX: pulseStepTranslate.value }],
   }));
 
   const animatedFinishedStyle = useAnimatedStyle(() => ({
@@ -61,7 +65,7 @@ const StepIndicator = ({ steps, currentStep }: StepIndicatorProps) => {
 
   return (
     <Box padding="10px" width="full">
-      <Columns space={{ custom: 9 }}>
+      <Columns space={{ custom: STEP_SPACING }}>
         {Array.from({ length: steps }).map((_, index) => {
           const stepIndex = index + 1;
           const isCurrentStep = stepIndex === currentStep;


### PR DESCRIPTION
Fixes RNBW-3744

## What changed (plus any additional context for devs)
Changed the animation to use `translateX` based on screen dimensions rather than relative percentages with `left`.

## Dev checklist for QA: what to test
@estebanmino & @ibrahimtaveras00  Please test the ENS registration flow on your Android devices because I couldn't repro the initial crash on a Pixel 6.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
