### PR TITLE
Fetch optimism data from the backend

### DIFF
--- a/src/redux/explorer.js
+++ b/src/redux/explorer.js
@@ -53,6 +53,7 @@ const messages = {
     CHANGED: 'changed address assets',
     RECEIVED: 'received address assets',
     RECEIVED_ARBITRUM: 'received address arbitrum-assets',
+    RECEIVED_OPTIMISM: 'received address optimism-assets',
     RECEIVED_POLYGON: 'received address polygon-assets',
     REMOVED: 'removed address assets',
   },
@@ -63,6 +64,7 @@ const messages = {
     APPENDED: 'appended address transactions',
     CHANGED: 'changed address transactions',
     RECEIVED: 'received address transactions',
+    RECEIVED_OPTIMISM: 'received address optimism-transactions',
     RECEIVED_ARBITRUM: 'received address arbitrum-transactions',
     RECEIVED_POLYGON: 'received address polygon-transactions',
     REMOVED: 'removed address transactions',
@@ -190,6 +192,7 @@ const l2AddressTransactionHistoryRequest = (address, currency) => [
     },
     scope: [
       `${NetworkTypes.arbitrum}-transactions`,
+      `${NetworkTypes.optimism}-transactions`,
       `${NetworkTypes.polygon}-transactions`,
     ],
   },
@@ -473,6 +476,8 @@ export const explorerInitL2 = (network = null) => (dispatch, getState) => {
         break;
       case NetworkTypes.optimism:
         // Start watching optimism assets
+        dispatch(fetchAssetsFromRefraction());
+        // Once covalent supports is official, we should get rid of the optimism explorer
         dispatch(optimismExplorerInit());
         break;
       default:
@@ -549,6 +554,11 @@ const listenOnAddressMessages = socket => dispatch => {
     dispatch(transactionsReceived(message));
   });
 
+  socket.on(messages.ADDRESS_TRANSACTIONS.RECEIVED_OPTIMISM, message => {
+    // logger.log('optimism txns received', message?.payload?.transactions);
+    dispatch(transactionsReceived(message));
+  });
+
   socket.on(messages.ADDRESS_TRANSACTIONS.RECEIVED_POLYGON, message => {
     // logger.log('polygon txns received', message?.payload?.transactions);
     dispatch(transactionsReceived(message));
@@ -580,6 +590,10 @@ const listenOnAddressMessages = socket => dispatch => {
 
   socket.on(messages.ADDRESS_ASSETS.RECEIVED_ARBITRUM, message => {
     dispatch(l2AddressAssetsReceived(message, NetworkTypes.arbitrum));
+  });
+  
+  socket.on(messages.ADDRESS_ASSETS.RECEIVED_OPTIMISM, message => {
+    dispatch(l2AddressAssetsReceived(message, NetworkTypes.optimism));
   });
 
   socket.on(messages.ADDRESS_ASSETS.RECEIVED_POLYGON, message => {


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
Wired up optimism to use backend. Covalent support is still not official so we're keeping the optimismExplorer too but we should deprecated it as soon as it's announced.

## PoW (screenshots / screen recordings)
- Will add shortly

## Dev checklist for QA: what to test
- Transaction History for optimism should show up (if the L2 transactions flags is enabled)
- All the optimism assets that you see in prod should show up
- $OP should show up inside rainbowwallet.eth balance (doesn't show in prod)

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why - Already covered
- [ ] If you added new files, did you update the CODEOWNERS file?
