### PR TITLE
Clean up isTestFlight helper to return a boolean

### DIFF
--- a/src/helpers/isTestFlight.ts
+++ b/src/helpers/isTestFlight.ts
@@ -1,12 +1,6 @@
 import { NativeModules } from 'react-native';
+
 const { RNTestFlight } = NativeModules;
-
-const isTestFlight = () => {
-  const { isTestFlight: testflightBoolean } = ios
-    ? RNTestFlight.getConstants().isTestFlight
-    : false;
-
-  return testflightBoolean;
-};
+const isTestFlight = ios ? RNTestFlight.getConstants().isTestFlight : false;
 
 export default isTestFlight;


### PR DESCRIPTION
Fixes RNBW-3753

## What changed (plus any additional context for devs)
Fixed the `isTestFlight` helper to return the correct boolean based on platform. Previously it was returning a function.

## Dev checklist for QA: what to test
Check if Android (non-dev build) only has `Enable Testnets` and `Clear local storage` in the Developer Settings menu.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
