### PR TITLE
kill session only if  we are the ones disconnecting

### DIFF
--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -467,7 +467,9 @@ const listenOnNewMessages = walletConnector => (dispatch, getState) => {
     if (error) {
       throw error;
     }
-    dispatch(walletConnectDisconnectAllByDappUrl(walletConnector.peerMeta.url));
+    dispatch(
+      walletConnectDisconnectAllByDappUrl(walletConnector.peerMeta.url, false)
+    );
   });
   return walletConnector;
 };
@@ -632,10 +634,10 @@ export const walletConnectRejectSession = (
   dispatch(removePendingRequest(peerId));
 };
 
-export const walletConnectDisconnectAllByDappUrl = dappUrl => async (
-  dispatch,
-  getState
-) => {
+export const walletConnectDisconnectAllByDappUrl = (
+  dappUrl,
+  killSession = true
+) => async (dispatch, getState) => {
   const { walletConnectors } = getState().walletconnect;
   const matchingWalletConnectors = values(
     pickBy(
@@ -651,7 +653,9 @@ export const walletConnectDisconnectAllByDappUrl = dappUrl => async (
       )
     );
     await removeWalletConnectSessions(peerIds);
-    forEach(matchingWalletConnectors, connector => connector?.killSession());
+    if (killSession) {
+      forEach(matchingWalletConnectors, connector => connector?.killSession());
+    }
     dispatch({
       payload: omitBy(
         walletConnectors,


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
Meta reported that they were getting a disconnect event when THEY kill the session. This is a mistake from our end because we were using the same function whenever WE kill the session.

Added a flag to make sure we only do it when needed

## PoW (screenshots / screen recordings)
e2e coverage is enough in this case

## Dev checklist for QA: what to test
WC flow on android & ios

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why - we have tests already
- [ ] If you added new files, did you update the CODEOWNERS file?
