### PR TITLE
Profiles: Fix issue where expanding an NFT would sometimes produce a duplicate

### DIFF
--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -122,11 +122,19 @@ const buildEnsToken = ({
   } as UniqueAsset;
 };
 
-export const isUnknownOpenSeaENS = (asset?: any) =>
-  asset?.description?.includes('This is an unknown ENS name with the hash') ||
-  !asset?.uniqueId?.includes('.eth') ||
-  !asset?.image_url ||
-  false;
+export const isUnknownOpenSeaENS = (asset?: any) => {
+  const isENS =
+    asset?.asset_contract?.address.toLowerCase() ===
+    ENS_NFT_CONTRACT_ADDRESS.toLowerCase();
+  return (
+    isENS &&
+    (asset?.description?.includes(
+      'This is an unknown ENS name with the hash'
+    ) ||
+      !asset?.uniqueId?.includes('.eth') ||
+      !asset?.image_url)
+  );
+};
 
 export const fetchMetadata = async ({
   contractAddress = ENS_NFT_CONTRACT_ADDRESS,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -262,7 +262,7 @@ export const applyENSMetadataFallbackToTokens = async data => {
   return await Promise.all(
     data.map(async token => {
       try {
-        return applyENSMetadataFallbackToToken(token);
+        return await applyENSMetadataFallbackToToken(token);
       } catch {
         return token;
       }


### PR DESCRIPTION
Fixes RNBW-3748

## What changed (plus any additional context for devs)

It seems that when expanding an NFT, it would sometimes produce a duplicate.

Turns out this was an unexpected side-effect when revalidating a collectible. Revalidating collectibles should only happen for ENS NFTs only, and not all NFTs. 

The flag to enable revalidation was not guarding against non-ENS NFTs, so I have fixed the `isUnknownOpenSeaENS` function to filter out non-ENS NFTs.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
