### PR TITLE
Profiles: Fix avatar/cover resolution issues

### DIFF
--- a/src/ens-avatar/src/specs/erc1155.ts
+++ b/src/ens-avatar/src/specs/erc1155.ts
@@ -5,6 +5,8 @@ import { AvatarRequestOpts } from '..';
 import { resolveURI } from '../utils';
 import { UniqueAsset } from '@rainbow-me/entities';
 import { apiGetAccountUniqueToken } from '@rainbow-me/handlers/opensea-api';
+import { getNFTByTokenId } from '@rainbow-me/handlers/simplehash';
+import svgToPngIfNeeded from '@rainbow-me/handlers/svgs';
 import { NetworkTypes } from '@rainbow-me/helpers';
 
 const abi = [
@@ -39,11 +41,19 @@ export default class ERC1155 {
       return JSON.parse(_resolvedUri);
     }
 
-    const data: UniqueAsset = await apiGetAccountUniqueToken(
-      NetworkTypes.mainnet,
-      contractAddress,
-      tokenID
-    );
-    return { image: data?.image_url || data?.lowResUrl };
+    let image;
+    try {
+      const data: UniqueAsset = await apiGetAccountUniqueToken(
+        NetworkTypes.mainnet,
+        contractAddress,
+        tokenID
+      );
+      image = svgToPngIfNeeded(data?.image_url, false) || data?.lowResUrl;
+    } catch (error) {
+      const data = await getNFTByTokenId({ contractAddress, tokenId: tokenID });
+      image = data?.previews?.image_medium_url;
+      if (!image) throw new Error('no image found');
+    }
+    return { image };
   }
 }

--- a/src/ens-avatar/src/specs/erc721.ts
+++ b/src/ens-avatar/src/specs/erc721.ts
@@ -6,6 +6,7 @@ import { resolveURI } from '../utils';
 import { UniqueAsset } from '@rainbow-me/entities';
 import { apiGetAccountUniqueToken } from '@rainbow-me/handlers/opensea-api';
 import { getNFTByTokenId } from '@rainbow-me/handlers/simplehash';
+import svgToPngIfNeeded from '@rainbow-me/handlers/svgs';
 import { NetworkTypes } from '@rainbow-me/helpers';
 
 const abi = [
@@ -53,10 +54,11 @@ export default class ERC721 {
         contractAddress,
         tokenID
       );
-      image = data?.image_url || data?.lowResUrl;
+      image = svgToPngIfNeeded(data?.image_url, false) || data?.lowResUrl;
     } catch (error) {
       const data = await getNFTByTokenId({ contractAddress, tokenId: tokenID });
       image = data?.previews?.image_medium_url;
+      if (!image) throw new Error('no image found');
     }
     return { image };
   }

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -24,6 +24,7 @@ import {
 } from '../apollo/queries';
 import { ensProfileImagesQueryKey } from '../hooks/useENSProfileImages';
 import { ENSActionParameters } from '../raps/common';
+import { getProfileImages } from './localstorage/ens';
 import { estimateGasWithPadding, getProviderForNetwork } from './web3';
 import {
   ENSRegistrationRecords,
@@ -328,8 +329,12 @@ export const fetchImages = async (ensName: string) => {
       ...(avatarUrl ? [{ uri: avatarUrl }] : []),
       ...(coverUrl ? [{ uri: coverUrl }] : []),
     ]);
-    // eslint-disable-next-line no-empty
-  } catch (err) {}
+  } catch (err) {
+    // Fallback to storage images
+    const images = await getProfileImages(ensName);
+    avatarUrl = images.avatarUrl;
+    coverUrl = images.coverUrl;
+  }
 
   return {
     avatarUrl,

--- a/src/hooks/useENSModifiedRegistration.ts
+++ b/src/hooks/useENSModifiedRegistration.ts
@@ -5,6 +5,7 @@ import useENSProfileRecords from './useENSProfileRecords';
 import useENSRegistration from './useENSRegistration';
 import { usePrevious } from '.';
 import { Records, UniqueAsset } from '@rainbow-me/entities';
+import svgToPngIfNeeded from '@rainbow-me/handlers/svgs';
 import { REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
 import * as ensRedux from '@rainbow-me/redux/ensRegistration';
 import { AppState } from '@rainbow-me/redux/store';
@@ -40,10 +41,10 @@ const getImageUrl = (
           token.asset_contract.address === contractAddress &&
           token.id === tokenId
       );
-      if (uniqueToken?.lowResUrl) {
+      if (uniqueToken?.image_url) {
+        imageUrl = svgToPngIfNeeded(uniqueToken?.image_url, false);
+      } else if (uniqueToken?.lowResUrl) {
         imageUrl = uniqueToken?.lowResUrl;
-      } else if (uniqueToken?.image_url) {
-        imageUrl = uniqueToken?.image_url;
       } else if (uniqueToken?.image_thumbnail_url) {
         imageUrl = uniqueToken?.image_thumbnail_url;
       }


### PR DESCRIPTION
Fixes RNBW-3787, RNBW-3784

## What changed (plus any additional context for devs)

This PR fixes a avatar/cover resolution issue found when repetitively opening a profile. Turns out this is because we were being rate-limited from OpenSea. I added a workaround to fetch the image from storage if the OpenSea API fetching fails. We also weren't using the simplehash fallback for 1155's, so I added that too.

I also fixed the issue where a user could see a blurry cover photo upon opening "edit profile".
