### PR TITLE
Include pngs

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "qs": "6.9.4",
     "querystring-es3": "0.2.1",
     "react": "17.0.2",
-    "react-coin-icon": "osdnk/react-coin-icon#928a541f2001a819a8a89e93c91d8dcb67405f96",
+    "react-coin-icon": "osdnk/react-coin-icon#06464588a3d986f6ef3a7d7341b2d7ea0c5ac50b",
     "react-fast-compare": "2.0.4",
     "react-flatten-children": "1.1.2",
     "react-native": "0.68.1",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "qs": "6.9.4",
     "querystring-es3": "0.2.1",
     "react": "17.0.2",
-    "react-coin-icon": "osdnk/react-coin-icon#e2b2d079205116488d94e18b89b9a1c7a016833f",
+    "react-coin-icon": "osdnk/react-coin-icon#928a541f2001a819a8a89e93c91d8dcb67405f96",
     "react-fast-compare": "2.0.4",
     "react-flatten-children": "1.1.2",
     "react-native": "0.68.1",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "qs": "6.9.4",
     "querystring-es3": "0.2.1",
     "react": "17.0.2",
-    "react-coin-icon": "0.1.44",
+    "react-coin-icon": "osdnk/react-coin-icon#e2b2d079205116488d94e18b89b9a1c7a016833f",
     "react-fast-compare": "2.0.4",
     "react-flatten-children": "1.1.2",
     "react-native": "0.68.1",

--- a/src/utils/CoinIcons/CoinIcon.js
+++ b/src/utils/CoinIcons/CoinIcon.js
@@ -10,6 +10,10 @@ const sx = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  image: {
+    height: '100%',
+    width: '100%',
+  },
 });
 
 function formatSymbol(symbol) {
@@ -60,10 +64,7 @@ const CoinIcon = ({
         <Image
           resizeMode="contain"
           source={CoinIconsImages[formattedSymbol]}
-          style={{
-            height: '100%',
-            width: '100%',
-          }}
+          style={sx.image}
         />
       </View>
     );

--- a/src/utils/CoinIcons/CoinIcon.js
+++ b/src/utils/CoinIcons/CoinIcon.js
@@ -1,6 +1,8 @@
+/* eslint-disable import/namespace */
 import React, { useMemo } from 'react';
+import * as CoinIconsImages from 'react-coin-icon/lib/pngs';
+import { Image } from 'react-native';
 import { StyleSheet, View } from 'react-primitives';
-import CoinIcons from './CoinIcons';
 import FallbackIcon from './FallbackIcon';
 
 const sx = StyleSheet.create({
@@ -18,7 +20,7 @@ function formatSymbol(symbol) {
 
 const CoinIcon = ({
   color = '#3A3D51',
-  fallbackRenderer = FallbackIcon,
+  fallbackRenderer: Fallback = FallbackIcon,
   forceFallback,
   shadowColor,
   size = 32,
@@ -52,13 +54,24 @@ const CoinIcon = ({
     };
   }, [color, shadowColor, size]);
 
-  const CoinIconElement = forceFallback
-    ? fallbackRenderer
-    : CoinIcons[formattedSymbol] || fallbackRenderer;
+  if (!forceFallback && CoinIconsImages[formattedSymbol]) {
+    return (
+      <View {...circleProps} {...shadowProps} style={[sx.container, style]}>
+        <Image
+          resizeMode="contain"
+          source={CoinIconsImages[formattedSymbol]}
+          style={{
+            height: '100%',
+            width: '100%',
+          }}
+        />
+      </View>
+    );
+  }
 
   return (
     <View {...circleProps} style={[sx.container, style]}>
-      <CoinIconElement
+      <Fallback
         {...circleProps}
         {...shadowProps}
         color={color}

--- a/src/utils/CoinIcons/CoinIcons.android.js
+++ b/src/utils/CoinIcons/CoinIcons.android.js
@@ -1,1 +1,0 @@
-export default {};

--- a/src/utils/CoinIcons/CoinIcons.js
+++ b/src/utils/CoinIcons/CoinIcons.js
@@ -1,3 +1,0 @@
-import * as CoinIcons from 'react-coin-icon/lib/icons';
-
-export default CoinIcons;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15148,9 +15148,9 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-coin-icon@osdnk/react-coin-icon#928a541f2001a819a8a89e93c91d8dcb67405f96:
+react-coin-icon@osdnk/react-coin-icon#06464588a3d986f6ef3a7d7341b2d7ea0c5ac50b:
   version "0.1.44"
-  resolved "https://codeload.github.com/osdnk/react-coin-icon/tar.gz/928a541f2001a819a8a89e93c91d8dcb67405f96"
+  resolved "https://codeload.github.com/osdnk/react-coin-icon/tar.gz/06464588a3d986f6ef3a7d7341b2d7ea0c5ac50b"
   dependencies:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15148,10 +15148,9 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-coin-icon@0.1.44:
+react-coin-icon@osdnk/react-coin-icon#e2b2d079205116488d94e18b89b9a1c7a016833f:
   version "0.1.44"
-  resolved "https://registry.yarnpkg.com/react-coin-icon/-/react-coin-icon-0.1.44.tgz#b8ed525d3a45fd47f32ceceacda1295b6d0f7f6d"
-  integrity sha512-0E4bfPXTK/Fu6kvZkHm8sFe/UUxX7auKBQRmhfqPniE9VdbJC0m1Wnc/aNXaPFqGG98zTggtxpFJUO5F0hS80Q==
+  resolved "https://codeload.github.com/osdnk/react-coin-icon/tar.gz/e2b2d079205116488d94e18b89b9a1c7a016833f"
   dependencies:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15148,9 +15148,9 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-coin-icon@osdnk/react-coin-icon#e2b2d079205116488d94e18b89b9a1c7a016833f:
+react-coin-icon@osdnk/react-coin-icon#928a541f2001a819a8a89e93c91d8dcb67405f96:
   version "0.1.44"
-  resolved "https://codeload.github.com/osdnk/react-coin-icon/tar.gz/e2b2d079205116488d94e18b89b9a1c7a016833f"
+  resolved "https://codeload.github.com/osdnk/react-coin-icon/tar.gz/928a541f2001a819a8a89e93c91d8dcb67405f96"
   dependencies:
     "@svgr/cli" "^4.3.0"
     react-primitives "^0.8.1"


### PR DESCRIPTION
Fixes RNBW-3343

Please, read firstly this. After @mikedemarais will merge this, we will change the ref in `package.json`

https://github.com/mikedemarais/react-coin-icon/pull/21

## What changed (plus any additional context for devs)

I use pngs (100px width) instead of svgs. They are way faster on Android. This was particularly important because currently, we use fallback which might give inconsistencies between platforms and ugly icons on Android.

## PoW (screenshots / screen recordings)

<img width="137" alt="image" src="https://user-images.githubusercontent.com/25709300/172167919-f4ed8db5-7b6c-4ecc-b7b8-e5eb55bda190.png">
<img width="132" alt="image" src="https://user-images.githubusercontent.com/25709300/172168003-1ef49cdd-bcc6-46ad-95ff-a3be806592db.png">


## Dev checklist for QA: what to test

See if the icons look good. 
