### PR TITLE
Disable animations and gradients on ListSections for e2e

### DIFF
--- a/src/components/discover-sheet/ListsSection.js
+++ b/src/components/discover-sheet/ListsSection.js
@@ -116,7 +116,7 @@ export default function ListSection() {
 
   const handleSwitchList = useCallback(
     (id, index) => {
-      if (IS_TESTING !== 'false') {
+      if (IS_TESTING !== 'true') {
         LayoutAnimation.configureNext(
           LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
         );

--- a/src/components/discover-sheet/ListsSection.js
+++ b/src/components/discover-sheet/ListsSection.js
@@ -9,6 +9,7 @@ import React, {
   useRef,
 } from 'react';
 import { FlatList, LayoutAnimation } from 'react-native';
+import { IS_TESTING } from 'react-native-dotenv';
 import { useDispatch, useSelector } from 'react-redux';
 import { emitAssetRequest, emitChartsRequest } from '../../redux/explorer';
 import { DefaultTokenLists } from '../../references';
@@ -115,9 +116,11 @@ export default function ListSection() {
 
   const handleSwitchList = useCallback(
     (id, index) => {
-      LayoutAnimation.configureNext(
-        LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
-      );
+      if (IS_TESTING !== 'false') {
+        LayoutAnimation.configureNext(
+          LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
+        );
+      }
       setSelectedList(id);
       listRef.current?.scrollToIndex({
         animated: true,
@@ -265,10 +268,10 @@ export default function ListSection() {
             showsHorizontalScrollIndicator={false}
             testID={`lists-section-${selectedList}`}
           />
-          <EdgeFade />
+          {IS_TESTING !== 'true' && <EdgeFade />}
         </Column>
         <Column>
-          {!ready ? (
+          {!ready && IS_TESTING !== 'true' ? (
             times(2, index => (
               <AssetListItemSkeleton
                 animated


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
Took me a while to track down a crash that happens very often when running detox, which was caused by these things on the DiscoverSheet section list.

- LayoutAnimation
- Gradients

Both are known for not playing well with Detox and we already disabled it on most places.

## PoW (screenshots / screen recordings)
e2e test are green

## Dev checklist for QA: what to test
Nothing really, doesn't change behavior, only disables certain animations on e2e.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
