### PR TITLE
Profiles: Fix ENS fallback when not available in subgraph yet

### DIFF
--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -24,7 +24,7 @@ import {
 } from '../apollo/queries';
 import { ensProfileImagesQueryKey } from '../hooks/useENSProfileImages';
 import { ENSActionParameters } from '../raps/common';
-import { getProfileImages } from './localstorage/ens';
+import { getNameFromLabelhash, getProfileImages } from './localstorage/ens';
 import { estimateGasWithPadding, getProviderForNetwork } from './web3';
 import {
   ENSRegistrationRecords,
@@ -123,9 +123,9 @@ const buildEnsToken = ({
   } as UniqueAsset;
 };
 
-export const isUnknownOpenSeaENS = (asset?: any) => {
+export const isUnknownOpenSeaENS = (asset?: UniqueAsset) => {
   const isENS =
-    asset?.asset_contract?.address.toLowerCase() ===
+    asset?.asset_contract?.address?.toLowerCase() ===
     ENS_NFT_CONTRACT_ADDRESS.toLowerCase();
   return (
     isENS &&
@@ -145,13 +145,19 @@ export const fetchMetadata = async ({
   tokenId: string;
 }) => {
   try {
-    const { data } = await ensClient.query<EnsGetNameFromLabelhash>({
-      query: ENS_GET_NAME_FROM_LABELHASH,
-      variables: {
-        labelhash: BigNumber.from(tokenId).toHexString(),
-      },
-    });
-    const name = data.domains[0].labelName;
+    const labelhash = BigNumber.from(tokenId).toHexString();
+
+    let name = await getNameFromLabelhash(labelhash);
+    if (!name) {
+      const { data } = await ensClient.query<EnsGetNameFromLabelhash>({
+        query: ENS_GET_NAME_FROM_LABELHASH,
+        variables: {
+          labelhash,
+        },
+      });
+      name = data.domains[0].labelName;
+    }
+
     const image_url = `https://metadata.ens.domains/mainnet/${contractAddress}/${tokenId}/image`;
     return { image_url, name: `${name}.eth` };
   } catch (error) {

--- a/src/handlers/localstorage/ens.ts
+++ b/src/handlers/localstorage/ens.ts
@@ -2,12 +2,25 @@ import { getGlobal, saveGlobal } from './common';
 
 const ensProfileVersion = '0.1.0';
 
+const ensLabelhashesKey = (key: string) => `ensLabelhashes.${key}`;
 const ensProfileKey = (key: string) => `ensProfile.${key}`;
 const ensProfileImagesKey = (key: string) => `ensProfileImages.${key}`;
 const ensProfileRecordsKey = (key: string) => `ensProfileRecords.${key}`;
 const ensResolveNameKey = (key: string) => `ensResolveName.${key}`;
 const ensDomains = (key: string) => `ensDomains.${key}`;
 const ensSeenOnchainDataDisclaimerKey = 'ensProfile.seenOnchainDisclaimer';
+
+export const getNameFromLabelhash = async (key: string) => {
+  const labelhash = await getGlobal(
+    ensLabelhashesKey(key),
+    null,
+    ensProfileVersion
+  );
+  return labelhash;
+};
+
+export const saveNameFromLabelhash = (key: string, value: Object) =>
+  saveGlobal(ensLabelhashesKey(key), value, ensProfileVersion);
 
 export const getProfile = async (key: string) => {
   const profile = await getGlobal(ensProfileKey(key), null, ensProfileVersion);

--- a/src/hooks/useENSRegistrationActionHandler.ts
+++ b/src/hooks/useENSRegistrationActionHandler.ts
@@ -10,6 +10,7 @@ import usePendingTransactions from './usePendingTransactions';
 import { useAccountSettings, useCurrentNonce, useENSRegistration } from '.';
 import { Records, RegistrationParameters } from '@rainbow-me/entities';
 import { fetchResolver } from '@rainbow-me/handlers/ens';
+import { saveNameFromLabelhash } from '@rainbow-me/handlers/localstorage/ens';
 import { uploadImage } from '@rainbow-me/handlers/pinata';
 import {
   ENS_DOMAIN,
@@ -22,7 +23,7 @@ import { executeRap } from '@rainbow-me/raps';
 import { saveCommitRegistrationParameters } from '@rainbow-me/redux/ensRegistration';
 import { timeUnits } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
-import { logger } from '@rainbow-me/utils';
+import { labelhash, logger } from '@rainbow-me/utils';
 
 const formatENSActionParams = (
   registrationParameters: RegistrationParameters
@@ -78,6 +79,11 @@ export default function useENSRegistrationActionHandler(
           duration
         ),
       ]);
+
+      const hash = labelhash(
+        registrationParameters.name.replace(ENS_DOMAIN, '')
+      );
+      await saveNameFromLabelhash(hash, registrationParameters.name);
 
       const commitEnsRegistrationParameters: ENSActionParameters = {
         ...formatENSActionParams(registrationParameters),


### PR DESCRIPTION
Fixes TEAM2-32

## What changed (plus any additional context for devs)

There are some cases where freshly registered ENS names will not be available in the subgraph yet. This PR implements a fallback to the device storage in order to get the freshly registered ENS name from a labelhash. We set this labelhash mapping upon commit.