### PR TITLE
Fix wrong tracked identifier in Performance metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ PerformanceTracking.logDirectly(
   PerformanceMetrics.loadJSBundle,
   Date.now() - StartTime.START_TIME
 );
-PerformanceTracking.startMeasuring(PerformanceMetrics.loadJSBundle);
+PerformanceTracking.startMeasuring(PerformanceMetrics.loadRootAppComponent);
 PerformanceTracking.startMeasuring(PerformanceMetrics.timeToInteractive);
 
 /*


### PR DESCRIPTION
## What changed (plus any additional context for devs)
* Used wrong identifier to start measuring and never commited the identifier we actually wanted to track

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
