### PR TITLE
Fix Android chart label

### DIFF
--- a/src/components/value-chart/ExtremeLabels.js
+++ b/src/components/value-chart/ExtremeLabels.js
@@ -1,24 +1,15 @@
 import { get } from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
+import { View } from 'react-native';
 import { formatNative } from '../expanded-state/chart/chart-data-labels/ChartPriceLabel';
-import { Text } from '../text';
 import { useChartData } from '@rainbow-me/animated-charts';
+import { Text } from '@rainbow-me/design-system';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { supportedNativeCurrencies } from '@rainbow-me/references';
-import styled from '@rainbow-me/styled-components';
-import { fonts } from '@rainbow-me/styles';
 
 function trim(val) {
   return Math.min(Math.max(val, 0.05), 0.95);
 }
-
-const Label = styled(Text)({
-  fontSize: fonts.size.smedium,
-  fontWeight: fonts.weight.bold,
-  letterSpacing: fonts.letterSpacing.roundedTighter,
-  position: 'absolute',
-  textAlign: 'center',
-});
 
 const CenteredLabel = ({ position, style, width, ...props }) => {
   const [componentWidth, setWidth] = useState(0);
@@ -47,15 +38,19 @@ const CenteredLabel = ({ position, style, width, ...props }) => {
     [componentWidth, position, width]
   );
   return (
-    <Label
-      {...props}
+    <View
       onLayout={onLayout}
       style={{
         ...style,
         left,
         opacity: componentWidth ? 1 : 0,
+        position: 'absolute',
       }}
-    />
+    >
+      <Text color={{ custom: props.color }} size="14px" weight="bold">
+        {props.children}
+      </Text>
+    </View>
   );
 };
 


### PR DESCRIPTION
Fixes RNBW-3821

## What changed (plus any additional context for devs)

## PoW (screenshots / screen recordings)

Before:

https://user-images.githubusercontent.com/5769281/172926780-4d304e5e-d0be-43fd-bec3-f5fefeb3f3c4.mp4

After:

https://user-images.githubusercontent.com/5769281/172926793-4cbf3712-a71d-4ffb-b343-07f6328dc604.mp4

## Dev checklist for QA: what to test

Check if the extreme labels (the small number over the maximum and minimum points) have correct font, appear in correct moment and work correctly on iOS and Android. 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
