### PR TITLE
[TEAM2-53] @rainbow-swaps / use route name to continue showing currency list

### DIFF
--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -38,7 +38,10 @@ import {
   useSwapCurrencyList,
 } from '@rainbow-me/hooks';
 import { delayNext } from '@rainbow-me/hooks/useMagicAutofocus';
-import { useNavigation } from '@rainbow-me/navigation/Navigation';
+import {
+  getActiveRoute,
+  useNavigation,
+} from '@rainbow-me/navigation/Navigation';
 import { emitChartsRequest } from '@rainbow-me/redux/explorer';
 import Routes from '@rainbow-me/routes';
 import styled from '@rainbow-me/styled-components';
@@ -120,6 +123,12 @@ export default function CurrencySelectModal() {
     swapCurrencyListLoading,
     updateFavorites,
   } = useSwapCurrencyList(searchQueryForSearch, currentChainId);
+
+  const routeName = getActiveRoute()?.name;
+  const showList = useMemo(() => {
+    const viewingExplainer = routeName === Routes.EXPLAIN_SHEET;
+    return isFocused || viewingExplainer;
+  }, [isFocused, routeName]);
 
   const getWalletCurrencyList = useCallback(() => {
     if (type === CurrencySelectionTypes.input) {
@@ -364,7 +373,7 @@ export default function CurrencySelectModal() {
                 listItems={currencyList}
                 loading={swapCurrencyListLoading}
                 query={searchQueryForSearch}
-                showList={isFocused}
+                showList={showList}
                 testID="currency-select-list"
                 type={type}
               />


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I see almost no precedent for using route name in view logic like this. Let me know if I'm doing something dumb or unaware of a different helper/hook.

I altered the `showList` prop to also take `activeRouteName` into account.

## PoW (screenshots / screen recordings)
http://g.recordit.co/s5SAE4tfFW.gif

## Dev checklist for QA: what to test
click that verified thingy -> observe intact list rendering behind the verified explainer 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why -> **no additional functionality**
- [x] If you added new files, did you update the CODEOWNERS file? -> **n/a**
