### PR TITLE
Profiles: Fix ENS Registration Intro screen blank section

### DIFF
--- a/src/navigation/RegisterENSNavigator.tsx
+++ b/src/navigation/RegisterENSNavigator.tsx
@@ -157,6 +157,7 @@ export default function RegisterENSNavigator() {
         <Box
           style={{
             height: wrapperHeight,
+            overflow: 'hidden',
           }}
         >
           <Swipe.Navigator


### PR DESCRIPTION
Fixes TEAM2-36

## What changed (plus any additional context for devs)
Added an `overflow: hidden` to the container to prevent an unthemed blank area under that view when going back.

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/6843656/173150415-f2b6f524-b047-4e33-b666-c0b02bc11ea6.mp4



## Dev checklist for QA: what to test
Profiles editing/registration to make sure nothing else has been broken in the flow.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
