### PR TITLE
Fix empty txn history regression

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -885,7 +885,10 @@ const checkForUpdatedNonce = (transactionData: ZerionTransaction[]) => (
   if (transactionData.length) {
     const { accountAddress, network } = getState().settings;
     const txSortedByDescendingNonce = transactionData
-      .filter(({ address_from }) => address_from === accountAddress)
+      .filter(
+        ({ address_from }) =>
+          address_from?.toLowerCase() === accountAddress.toLowerCase()
+      )
       .sort(({ nonce: n1 }, { nonce: n2 }) => (n2 ?? 0) - (n1 ?? 0));
     const [latestTx] = txSortedByDescendingNonce;
     const { address_from, nonce } = latestTx;


### PR DESCRIPTION
## What changed (plus any additional context for devs)

We have been seeing a regression from [this change](https://github.com/rainbow-me/rainbow/pull/3293/files#diff-3568b4eaf1ead5c20262106d9a20b6660576efe9097055edf9214b647742ccedR888) where addresses were not being lowercased before comparison, causing an empty transaction history if a user did not have a cached history. This PR just fixes up that issue.

Maybe we should spin up the app from a clear cache during QA?

## PoW (screenshots / screen recordings)

Before:

<img width="321" alt="Screen Shot 2022-06-13 at 11 18 03 am" src="https://user-images.githubusercontent.com/7336481/173263259-fe81c91d-a2af-4bba-b372-1c163ff5b21a.png">

After:

<img width="325" alt="Screen Shot 2022-06-13 at 11 18 28 am" src="https://user-images.githubusercontent.com/7336481/173263270-bf45fe6c-452a-400d-9ab0-13f5739c142c.png">

## Dev checklist for QA: what to test

1. Open the app with a clear cache
2. Import a wallet and check if the txn history populated

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?

