### PR TITLE
Profiles: Fix edit mode default state race condition

### DIFF
--- a/src/hooks/useENSRegistrationForm.ts
+++ b/src/hooks/useENSRegistrationForm.ts
@@ -141,8 +141,6 @@ export default function useENSRegistrationForm({
         };
       }, {});
       updateRecords(records);
-    } else if (mode === REGISTRATION_MODES.EDIT && !isEmpty(defaultRecords)) {
-      updateRecords(defaultRecords);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEmpty(defaultRecords), updateRecords]);


### PR DESCRIPTION
## What changed (plus any additional context for devs)

This PR fixes a race condition which could end up not populating the avatar/cover records when editing a profile. It turns out we are initially setting the initial records twice (and the one which is removed in this PR was setting the wrong values).

## PoW (screenshots / screen recordings)

Before:

https://user-images.githubusercontent.com/7336481/173284626-a4d285eb-f349-48da-8029-7243c2459fb7.MP4

After:

https://user-images.githubusercontent.com/7336481/173284635-d953bda8-2946-4e5b-a01b-2f19edcfdbfa.MP4
