### PR TITLE
Profiles: Use ens avatars in backup sheet

### DIFF
--- a/src/components/contacts/ImageAvatar.js
+++ b/src/components/contacts/ImageAvatar.js
@@ -45,6 +45,11 @@ const sizeConfigs = (colors, isDarkMode) => ({
     dimensions: 20,
     textSize: 'small',
   },
+  smedium: {
+    dimensions: 36,
+    shadow: [[0, 4, android ? 5 : 12, colors.shadow, 0.4]],
+    textSize: 'large',
+  },
 });
 
 const Avatar = styled(ImgixImage)(({ dimensions }) => ({

--- a/src/components/settings-menu/BackupSection/WalletSelectionView.js
+++ b/src/components/settings-menu/BackupSection/WalletSelectionView.js
@@ -7,6 +7,7 @@ import Divider from '../../Divider';
 import { ButtonPressAnimation } from '../../animations';
 import { BottomRowText } from '../../coin-row';
 import { ContactAvatar } from '../../contacts';
+import ImageAvatar from '../../contacts/ImageAvatar';
 import { Icon } from '../../icons';
 import { Centered, Column, ColumnWithMargins, Row } from '../../layout';
 import { Text, TruncatedAddress } from '../../text';
@@ -124,7 +125,7 @@ const WalletSelectionView = () => {
           const visibleAccounts = wallet.addresses.filter(a => a.visible);
           const account = visibleAccounts[0];
           const totalAccounts = visibleAccounts.length;
-          const { color, label, index, address } = account;
+          const { color, image, label, index, address } = account;
           if (wallet.backupType === WalletBackupTypes.cloud) {
             cloudBackedUpWallets += 1;
           }
@@ -145,13 +146,22 @@ const WalletSelectionView = () => {
               >
                 <Row height={56}>
                   <Row alignSelf="center" flex={1} marginLeft={15}>
-                    <ContactAvatar
-                      alignSelf="center"
-                      color={color}
-                      marginRight={10}
-                      size="smedium"
-                      value={labelOrName || `${index + 1}`}
-                    />
+                    {image ? (
+                      <ImageAvatar
+                        alignSelf="center"
+                        image={image}
+                        marginRight={10}
+                        size="smedium"
+                      />
+                    ) : (
+                      <ContactAvatar
+                        alignSelf="center"
+                        color={color}
+                        marginRight={10}
+                        size="smedium"
+                        value={labelOrName || `${index + 1}`}
+                      />
+                    )}
                     <ColumnWithMargins margin={3} marginBottom={0.5}>
                       <Row>
                         {labelOrName ? (


### PR DESCRIPTION
Fixes TEAM2-26

## What changed (plus any additional context for devs)
- use ens avatars in backup sheet
- ImageAvatar shadows for size "smedium" are copy/pasted from ContactAvatar
- the other issues you see (incorrect wallet labels and non-ens avatars) are fixed in https://github.com/rainbow-me/rainbow/pull/3464

## PoW (screenshots / screen recordings)
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-14 at 16 53 39](https://user-images.githubusercontent.com/15272675/173702454-3c497e01-b18d-4186-af0d-03d484e470dc.png)

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
