### PR TITLE
Profiles: Fix issue where sending L2 asset on intro screen profile causes white screen

### DIFF
--- a/src/hooks/useENSRegistrationCosts.ts
+++ b/src/hooks/useENSRegistrationCosts.ts
@@ -369,9 +369,10 @@ export default function useENSRegistrationCosts({
   useEffect(() => {
     if (
       !isEmpty(useGasGasFeeParamsBySpeed) &&
-      gasFeeParams.gasFeeParamsBySpeed !== useGasGasFeeParamsBySpeed &&
-      gasFeeParams.currentBaseFee !== useGasCurrentBlockParams.baseFeePerGas &&
-      useGasCurrentBlockParams.baseFeePerGas
+      gasFeeParams?.gasFeeParamsBySpeed !== useGasGasFeeParamsBySpeed &&
+      gasFeeParams?.currentBaseFee !==
+        useGasCurrentBlockParams?.baseFeePerGas &&
+      useGasCurrentBlockParams?.baseFeePerGas
     ) {
       setGasFeeParams({
         currentBaseFee: useGasCurrentBlockParams.baseFeePerGas,


### PR DESCRIPTION
Fixes TEAM2-1

## What changed (plus any additional context for devs)

This PR fixes an issue where sending an L2 asset to an intro screen profile wallet would cause a blank screen in the app. Turns out there were some undefined values floating around.