### PR TITLE
Profiles: Prevent temp image paths from being included in ens registration

### DIFF
--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -55,6 +55,7 @@ const RegistrationAvatar = ({
     values,
     onBlurField,
     onRemoveField,
+    setDisabled,
   } = useENSRegistrationForm();
   const { navigate } = useNavigation();
 
@@ -132,13 +133,16 @@ const RegistrationAvatar = ({
       setAvatarUrl('');
       onChangeAvatarUrl('');
       setAvatarMetadata(undefined);
+      setDisabled(false);
     },
     onUploadError: () => {
       onBlurField({ key: 'avatar', value: '' });
       setAvatarUrl('');
     },
+    onUploading: () => setDisabled(true),
     onUploadSuccess: ({ data }: { data: UploadImageReturnData }) => {
       onBlurField({ key: 'avatar', value: data.url });
+      setDisabled(false);
     },
     showRemove: Boolean(avatarUrl),
     testID: 'avatar',

--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -38,6 +38,7 @@ const RegistrationCover = ({
     isLoading,
     onBlurField,
     onRemoveField,
+    setDisabled,
     values,
   } = useENSRegistrationForm();
 
@@ -101,9 +102,12 @@ const RegistrationCover = ({
       onRemoveField({ key: 'cover' });
       setCoverUrl('');
       setCoverMetadata(undefined);
+      setDisabled(false);
     },
+    onUploading: () => setDisabled(true),
     onUploadSuccess: ({ data }: { data: UploadImageReturnData }) => {
       onBlurField({ key: 'cover', value: data.url });
+      setDisabled(false);
     },
     showRemove: Boolean(coverUrl),
     testID: 'cover',


### PR DESCRIPTION
Fixes TEAM2-99

## What changed (plus any additional context for devs)
- if you start a registration too soon after uploading an avatar/cover image to your ens profile, the temporary image path gets saved to the ens registration instead of the pinata url. this can cause the images to disappear, because these temporary image paths are not guaranteed to persist. 
- the fix: disable the "Review" button until the image has fully uploaded

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
