### PR TITLE
Fix Keyboard dismiss and Expanded Asset Sheet hiding

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -1,4 +1,5 @@
 import { BlurView } from '@react-native-community/blur';
+import { useFocusEffect } from '@react-navigation/core';
 import c from 'chroma-js';
 import lang from 'i18n-js';
 import React, {
@@ -15,9 +16,7 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated';
 import URL from 'url-parse';
-import { CardSize } from '../../components/unique-token/CardSize';
 import useWallets from '../../hooks/useWallets';
-import { lightModeThemeColors } from '../../styles/colors';
 import L2Disclaimer from '../L2Disclaimer';
 import Link from '../Link';
 import { ButtonPressAnimation } from '../animations';
@@ -31,6 +30,7 @@ import {
 } from '../sheet';
 import { ToastPositionContainer, ToggleStateToast } from '../toasts';
 import { UniqueTokenAttributes, UniqueTokenImage } from '../unique-token';
+import { CardSize } from '../unique-token/CardSize';
 import ConfigurationSection from './ens/ConfigurationSection';
 import ProfileInfoSection from './ens/ProfileInfoSection';
 import {
@@ -73,7 +73,7 @@ import {
 import { useNavigation, useUntrustedUrlOpener } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import styled from '@rainbow-me/styled-components';
-import { position } from '@rainbow-me/styles';
+import { lightModeThemeColors, position } from '@rainbow-me/styles';
 import { useTheme } from '@rainbow-me/theme';
 import {
   buildRainbowUrl,
@@ -231,7 +231,7 @@ const UniqueTokenExpandedState = ({
 }: UniqueTokenExpandedStateProps) => {
   const { accountAddress, accountENS } = useAccountProfile();
   const { height: deviceHeight, width: deviceWidth } = useDimensions();
-  const { navigate } = useNavigation();
+  const { navigate, setOptions } = useNavigation();
   const { colors, isDarkMode } = useTheme();
   const { isReadOnlyWallet } = useWallets();
 
@@ -266,6 +266,14 @@ const UniqueTokenExpandedState = ({
   const cleanENSName = isENS && uniqueId ? uniqueId?.split(' ')?.[0] : uniqueId;
   const ensProfile = useENSProfile(cleanENSName, { enabled: isENS });
   const ensData = ensProfile.data;
+
+  useFocusEffect(
+    useCallback(() => {
+      if (uniqueTokenType === UniqueTokenType.ENS) {
+        setOptions({ limitActiveModals: false });
+      }
+    }, [setOptions, uniqueTokenType])
+  );
 
   useEffect(() => {
     if (cleanENSName) {


### PR DESCRIPTION
Fixes RNBW-3795

## What changed (plus any additional context for devs)
* Added a `useFocusEffect` call that adds screen option for ExpandedAssetSheet screen to not hide the screen. .This prevents it from disappearing when we open 4th modal – custom gas sheet

## PoW (screenshots / screen recordings)
Before:
https://streamable.com/qplqjm

After:
https://streamable.com/a0pfj8

## Dev checklist for QA: what to test
* Go to a normal ExpandedAssetSheet check if everything is cool
* Go to Expanded asset sheet and try to cycle through like uniswap pools, we capped the max amount of open sheets allowed to prevent too many sheets being open when cycling through uniswap pools
* Pick ENS and try the flow where you extend the registration, see if the custom gas sheet has the keyboard properly handled and if the expanded asset sheet isn't dismissed in the background.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why – no new features
- [x] If you added new files, did you update the CODEOWNERS file?
