### PR TITLE
Profiles: Don't prefetch profile for non-ens NFTs

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -263,7 +263,11 @@ const UniqueTokenExpandedState = ({
   const isNFT = uniqueTokenType === UniqueTokenType.NFT;
 
   // Fetch the ENS profile if the unique token is an ENS name.
-  const cleanENSName = isENS && uniqueId ? uniqueId?.split(' ')?.[0] : uniqueId;
+  const cleanENSName = isENS
+    ? uniqueId
+      ? uniqueId?.split(' ')?.[0]
+      : uniqueId
+    : '';
   const ensProfile = useENSProfile(cleanENSName, { enabled: isENS });
   const ensData = ensProfile.data;
 


### PR DESCRIPTION
Fixes TEAM2-142

## What changed (plus any additional context for devs)
- nonexistent ens profiles were being prefetched (and stored) for non-ens NFTs
- now only called if NFT is an ens

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
