### PR TITLE
[TEAM2-95] Swap review sheet -> more details: exchange row formatting

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -4,7 +4,7 @@ import React, { Fragment, useMemo } from 'react';
 import { convertAmountToPercentageDisplay } from '../../../helpers/utilities';
 import Pill from '../../Pill';
 import { ButtonPressAnimation } from '../../animations';
-import { SwapDetailsValue } from './SwapDetailsRow';
+import { SwapDetailsLabel, SwapDetailsValue } from './SwapDetailsRow';
 import {
   Bleed,
   Box,
@@ -152,9 +152,9 @@ export default function SwapDetailsExchangeRow(props) {
         <Rows>
           <Columns alignHorizontal="right" alignVertical="center" space="4px">
             <Column>
-              <Text color="secondary50" size="14px" weight="semibold">
+              <SwapDetailsLabel>
                 {lang.t('expanded_state.swap.swapping_via')}
-              </Text>
+              </SwapDetailsLabel>
             </Column>
             <Column width="content">
               <ExchangeIconStack protocols={steps[step]} />
@@ -164,7 +164,7 @@ export default function SwapDetailsExchangeRow(props) {
             </Column>
             {steps?.[step]?.part && (
               <Column width="content">
-                <Bleed right="6px" vertical="6px">
+                <Bleed right="4px" vertical="6px">
                   <Pill textColor={defaultColor}>{steps[step].part}</Pill>
                 </Bleed>
               </Column>
@@ -178,9 +178,9 @@ export default function SwapDetailsExchangeRow(props) {
       <Rows>
         <Columns alignVertical="center" space="4px">
           <Column>
-            <Text color="secondary50" size="14px" weight="semibold">
+            <SwapDetailsLabel>
               {lang.t('expanded_state.swap.swapping_via')}
-            </Text>
+            </SwapDetailsLabel>
           </Column>
           <Column width="content">
             <ExchangeIcon

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -164,7 +164,7 @@ export default function SwapDetailsExchangeRow(props) {
             </Column>
             {steps?.[step]?.part && (
               <Column width="content">
-                <Bleed right="4px" vertical="6px">
+                <Bleed right="6px" vertical="6px">
                   <Pill textColor={defaultColor}>{steps[step].part}</Pill>
                 </Bleed>
               </Column>

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -4,7 +4,7 @@ import React, { Fragment, useMemo } from 'react';
 import { convertAmountToPercentageDisplay } from '../../../helpers/utilities';
 import Pill from '../../Pill';
 import { ButtonPressAnimation } from '../../animations';
-import SwapDetailsRow, { SwapDetailsValue } from './SwapDetailsRow';
+import { SwapDetailsValue } from './SwapDetailsRow';
 import {
   Bleed,
   Box,
@@ -12,6 +12,7 @@ import {
   Columns,
   Cover,
   Inline,
+  Rows,
   Stack,
   Text,
   useForegroundColor,
@@ -148,32 +149,39 @@ export default function SwapDetailsExchangeRow(props) {
   if (protocols?.length > 1) {
     return (
       <ButtonPressAnimation onPress={nextStep} scaleTo={1.06}>
-        <SwapDetailsRow
-          label={lang.t('expanded_state.swap.swapping_via')}
-          truncated={false}
-        >
+        <Rows>
           <Columns alignHorizontal="right" alignVertical="center" space="4px">
+            <Column>
+              <Text color="secondary50" size="14px" weight="semibold">
+                {lang.t('expanded_state.swap.swapping_via')}
+              </Text>
+            </Column>
             <Column width="content">
               <ExchangeIconStack protocols={steps[step]} />
             </Column>
             <Column width="content">
               <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
             </Column>
-            {steps[step].part && (
+            {steps?.[step]?.part && (
               <Column width="content">
-                <Bleed style={{ marginLeft: 10 }}>
+                <Bleed right="6px" vertical="6px">
                   <Pill textColor={defaultColor}>{steps[step].part}</Pill>
                 </Bleed>
               </Column>
             )}
           </Columns>
-        </SwapDetailsRow>
+        </Rows>
       </ButtonPressAnimation>
     );
   } else if (protocols?.length > 0) {
     return (
-      <SwapDetailsRow label={lang.t('expanded_state.swap.swapping_via')}>
+      <Rows>
         <Columns alignVertical="center" space="4px">
+          <Column>
+            <Text color="secondary50" size="14px" weight="semibold">
+              {lang.t('expanded_state.swap.swapping_via')}
+            </Text>
+          </Column>
           <Column width="content">
             <ExchangeIcon
               icon={getExchangeIconUrl(parseExchangeName(protocols[0].name))}
@@ -183,12 +191,13 @@ export default function SwapDetailsExchangeRow(props) {
           <Column width="content">
             <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
           </Column>
-
           <Column width="content">
-            <Pill textColor={defaultColor}>{`${protocols[0].part}%`}</Pill>
+            <Bleed right="6px" vertical="6px">
+              <Pill textColor={defaultColor}>{`${protocols[0].part}%`}</Pill>
+            </Bleed>
           </Column>
         </Columns>
-      </SwapDetailsRow>
+      </Rows>
     );
   }
   return null;


### PR DESCRIPTION
## What changed (plus any additional context for devs)
* Fixed the `<Bleed />` props that wrap the `<Pill />`
* Removed use of `<SwapDetailsRow />` and made `<SwapDetailsLabel />` a direct sibling of the rest of the row's content. This fixes 2 issues:

The vertical alignment between the label and value in `<SwapDetailsRow />` does not appear to behave as intended, but looks correct in most cases because the line-height of the label and value are the same. But now that `<SwapDetailsLabel />` is a direct sibling of the rest of the row's columns, the vertical alignment applies correctly.

Toggling between DEX's was causing row height issues on Android. I believe this was caused by passing in `<Columns>{...}</Columns>` rather than a string as `props.children` to `<SwapDetailsRow />`. 

## PoW (screenshots / screen recordings)
https://user-images.githubusercontent.com/14877580/173995190-ecbfb8e3-55c0-4384-a0b3-db9052bc3871.mp4

## Dev checklist for QA: what to test
* attempt to toggle DEX's on the swap review sheet
* also check that the 'swapping via' row looks normal on a review sheet with only 1 DEX available

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why ---> no new functionality introduced
- [x] If you added new files, did you update the CODEOWNERS file?
