### PR TITLE
Swaps: Fix android layout shift on the swap screen

### DIFF
--- a/src/components/layout/KeyboardFixedOpenLayout.js
+++ b/src/components/layout/KeyboardFixedOpenLayout.js
@@ -3,6 +3,7 @@ import { KeyboardAvoidingView } from 'react-native';
 import { Transition, Transitioning } from 'react-native-reanimated';
 import { useSafeArea } from 'react-native-safe-area-context';
 import Centered from './Centered';
+import keyboardTypes from '@rainbow-me/helpers/keyboardTypes';
 import { useDimensions, useKeyboardHeight } from '@rainbow-me/hooks';
 import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
@@ -27,12 +28,15 @@ const transition = (
 
 export default function KeyboardFixedOpenLayout({
   additionalPadding = 0,
+  keyboardType = keyboardTypes.default,
   position = android ? 'relative' : 'absolute',
   ...props
 }) {
   const insets = useSafeArea();
   const { height: screenHeight } = useDimensions();
-  const keyboardHeight = useKeyboardHeight();
+  const keyboardHeight = useKeyboardHeight({
+    keyboardType,
+  });
   const ref = useRef();
 
   const containerHeight = screenHeight - keyboardHeight - additionalPadding;
@@ -47,9 +51,7 @@ export default function KeyboardFixedOpenLayout({
       ref={ref}
       transition={transition}
     >
-      <KeyboardAvoidingView behavior="height" enabled={!!keyboardHeight}>
-        <InnerWrapper {...props} insets={insets} />
-      </KeyboardAvoidingView>
+      <InnerWrapper {...props} insets={insets} />
     </Container>
   );
 }

--- a/src/helpers/keyboardTypes.ts
+++ b/src/helpers/keyboardTypes.ts
@@ -1,10 +1,15 @@
 export enum KeyboardType {
   default = 'default',
+  numpad = 'numpad',
   password = 'password',
 }
 
 // This must be kept until everywhere using this file updates to TypeScript.
 export default {
-  default: 'default', // any keyboard without any accessory bar or autofill/autocomplete bar
-  password: 'password', // keyboard with the "password" autofill bar above it
+  // any keyboard without any accessory bar or autofill/autocomplete bar
+  default: 'default',
+  // keyboard with numpad
+  numpad: 'numpad',
+  // keyboard with the "password" autofill bar above it
+  password: 'password',
 };

--- a/src/hooks/useKeyboardHeight.js
+++ b/src/hooks/useKeyboardHeight.js
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/core';
 import { useCallback, useEffect } from 'react';
 import { Keyboard } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,11 +17,18 @@ export default function useKeyboardHeight(options = {}) {
   const cachedKeyboardHeights = useSelector(keyboardHeightsSelector);
   const heightForKeyboardType = cachedKeyboardHeights?.[keyboardType];
 
+  const isFocused = useIsFocused();
+
   const handleKeyboardDidShow = useCallback(
     event => {
       const newHeight = Math.floor(event.endCoordinates.height);
 
-      if (!heightForKeyboardType || newHeight !== heightForKeyboardType) {
+      if (
+        // We don't want to set the height cache when the screen is out of focus.
+        isFocused &&
+        // Only update if there is no existing height in the cache.
+        (!heightForKeyboardType || newHeight !== heightForKeyboardType)
+      ) {
         dispatch(
           setKeyboardHeight({
             height: newHeight,
@@ -30,7 +38,7 @@ export default function useKeyboardHeight(options = {}) {
         Keyboard.scheduleLayoutAnimation(event);
       }
     },
-    [dispatch, heightForKeyboardType, keyboardType]
+    [dispatch, heightForKeyboardType, isFocused, keyboardType]
   );
 
   useEffect(() => {

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -43,6 +43,7 @@ import {
   isKeyboardOpen,
   Network,
 } from '@rainbow-me/helpers';
+import KeyboardTypes from '@rainbow-me/helpers/keyboardTypes';
 import { divide, greaterThan, multiply } from '@rainbow-me/helpers/utilities';
 import {
   useAccountSettings,
@@ -709,7 +710,7 @@ export default function ExchangeModal({
     : !!inputCurrency && !!outputCurrency;
 
   return (
-    <Wrapper>
+    <Wrapper keyboardType={KeyboardTypes.numpad}>
       <InnerWrapper isSmallPhone={isSmallPhone}>
         <FloatingPanels>
           <FloatingPanel


### PR DESCRIPTION
Fixes TEAM2-124

## What changed (plus any additional context for devs)

This PR fixes an issue where navigating from the currency select screen back to the swap screen would cause a pretty horrid layout shift on Android. This layout shift was being caused from the keyboard height cache setting a stale height when the screen was out of focus.

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/7336481/173997803-bf91c76f-f822-44f3-8b58-c444d0760021.mp4


