### PR TITLE
[TEAM2-113] Swap token list sheet: no tokens on [network] explainer sheet is missing

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -584,6 +584,9 @@
       "obtain_l2_asset": {
         "text": "You'll need to get other tokens on %{networkName} to swap for %{networkName} %{tokenName}. Bridging tokens to %{networkName} is easy using a bridge like Hop.",
         "title": "No Tokens on %{networkName}"
+      },
+      "go_to_hop_with_icon": {
+        "text": "Go to the Hop Bridge 􀮶"
       }
     },
     "fields": {

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -572,6 +572,7 @@
         "title": "What's Polygon?"
       },
       "read_more": "Read More",
+      "learn_more": "Learn More",
       "sending_to_contract": {
         "text": "The address you entered is for a smart contract.\n\nExcept for rare situations, you probably shouldn't do this. You could lose your assets or they might go to the wrong place.\n\nDouble check the address, verify it with the recipient, or contact support first.",
         "title": "Hold your horses!"
@@ -579,6 +580,10 @@
       "verified": {
         "text": "Tokens with a verified badge mean they have appeared on at least 3 other outside token lists.\n\nAlways do your own research to ensure you are interacting with a token you trust.",
         "title": "Verified Tokens"
+      },
+      "obtain_l2_asset": {
+        "text": "You'll need to get other tokens on %{networkName} to swap for %{networkName} %{tokenName}. Bridging tokens to %{networkName} is easy using a bridge like Hop.",
+        "title": "No Tokens on %{networkName}"
       }
     },
     "fields": {

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -11,7 +11,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Linking, StatusBar } from 'react-native';
+import { Keyboard, Linking, StatusBar } from 'react-native';
 import { IS_TESTING } from 'react-native-dotenv';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useDispatch } from 'react-redux';
@@ -276,6 +276,7 @@ export default function CurrencySelectModal() {
             network && network?.toLowerCase() === currentL2Name?.toLowerCase()
         );
         if (currentL2WalletAssets?.length < 1) {
+          android && Keyboard.dismiss();
           navigate(Routes.EXPLAIN_SHEET, {
             assetName: item?.name,
             network: ethereumUtils.getNetworkFromChainId(currentChainId),

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -11,7 +11,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Keyboard, Linking, StatusBar } from 'react-native';
+import { InteractionManager, Keyboard, Linking, StatusBar } from 'react-native';
 import { IS_TESTING } from 'react-native-dotenv';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useDispatch } from 'react-redux';
@@ -277,12 +277,14 @@ export default function CurrencySelectModal() {
         );
         if (currentL2WalletAssets?.length < 1) {
           android && Keyboard.dismiss();
-          navigate(Routes.EXPLAIN_SHEET, {
-            assetName: item?.name,
-            network: ethereumUtils.getNetworkFromChainId(currentChainId),
-            networkName: currentL2Name,
-            onClose: linkToHop,
-            type: 'obtainL2Assets',
+          InteractionManager.runAfterInteractions(() => {
+            navigate(Routes.EXPLAIN_SHEET, {
+              assetName: item?.name,
+              network: ethereumUtils.getNetworkFromChainId(currentChainId),
+              networkName: currentL2Name,
+              onClose: linkToHop,
+              type: 'obtainL2Assets',
+            });
           });
           return true;
         }

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -1,7 +1,7 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { useRoute } from '@react-navigation/native';
 import lang from 'i18n-js';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Linking, StatusBar } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
 import { ChainBadge, CoinIcon } from '../components/coin-icon';
@@ -384,6 +384,28 @@ export const explainers = (params, colors) => ({
       </Row>
     ),
   },
+  obtainL2Assets: {
+    buttonText: 'Go to the Hop Bridge 􀮶',
+    buttonColor: colors?.networkColors[params?.network],
+    secondaryButtonText: lang.t('explain.learn_more'),
+    logo: (
+      <ChainBadge
+        assetType={params?.network}
+        marginBottom={8}
+        position="relative"
+        size="large"
+      />
+    ),
+    readMoreLink:
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+    text: lang.t('explain.obtain_l2_asset.text', {
+      tokenName: params?.assetName,
+      networkName: params?.networkName,
+    }),
+    title: lang.t('explain.obtain_l2_asset.title', {
+      networkName: params?.networkName,
+    }),
+  },
 });
 
 const ExplainSheet = () => {
@@ -425,6 +447,57 @@ const ExplainSheet = () => {
 
   const sheetHeight =
     ExplainSheetHeight + (explainSheetConfig?.extraHeight || 0);
+
+  const buttons = useMemo(() => {
+    const missingL2Assets = type === 'obtainL2Assets';
+    const secondaryButtonTextColor = missingL2Assets
+      ? 'primary'
+      : colors.blueGreyDark60;
+    const secondaryButton = explainSheetConfig.readMoreLink && (
+      <Column height={60}>
+        <SheetActionButton
+          color={colors.blueGreyDarkLight}
+          isTransparent
+          label={
+            explainSheetConfig.secondaryButtonText ||
+            lang.t('explain.read_more')
+          }
+          onPress={handleReadMore}
+          size="big"
+          textColor={secondaryButtonTextColor}
+          weight="heavy"
+        />
+      </Column>
+    );
+    const accentCta = (
+      <SheetActionButton
+        color={colors.alpha(
+          explainSheetConfig.buttonColor || colors.appleBlue,
+          0.04
+        )}
+        isTransparent
+        label={explainSheetConfig.buttonText || lang.t('button.got_it')}
+        onPress={handleClose}
+        size="big"
+        textColor={explainSheetConfig.buttonColor || colors.appleBlue}
+        weight="heavy"
+      />
+    );
+    const buttonArray = [secondaryButton, accentCta];
+    if (type === 'obtainL2Assets') {
+      buttonArray.reverse();
+    }
+    return buttonArray;
+  }, [
+    colors,
+    explainSheetConfig.buttonColor,
+    explainSheetConfig.buttonText,
+    explainSheetConfig.readMoreLink,
+    explainSheetConfig.secondaryButtonText,
+    handleClose,
+    handleReadMore,
+    type,
+  ]);
 
   return (
     <Container deviceHeight={deviceHeight} height={sheetHeight} insets={insets}>
@@ -484,31 +557,7 @@ const ExplainSheet = () => {
             >
               {explainSheetConfig.text}
             </Text>
-            {explainSheetConfig.readMoreLink && (
-              <Column height={60}>
-                <SheetActionButton
-                  color={colors.blueGreyDarkLight}
-                  isTransparent
-                  label={lang.t('explain.read_more')}
-                  onPress={handleReadMore}
-                  size="big"
-                  textColor={colors.blueGreyDark60}
-                  weight="heavy"
-                />
-              </Column>
-            )}
-            <SheetActionButton
-              color={colors.alpha(
-                explainSheetConfig.buttonColor || colors.appleBlue,
-                0.04
-              )}
-              isTransparent
-              label={explainSheetConfig.buttonText || lang.t('button.got_it')}
-              onPress={handleClose}
-              size="big"
-              textColor={explainSheetConfig.buttonColor || colors.appleBlue}
-              weight="heavy"
-            />
+            {buttons}
           </ColumnWithMargins>
         </Centered>
       </SlackSheet>

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -385,7 +385,7 @@ export const explainers = (params, colors) => ({
     ),
   },
   obtainL2Assets: {
-    buttonText: 'Go to the Hop Bridge 􀮶',
+    buttonText: lang.t('explain.go_to_hop_with_icon.text'),
     buttonColor: colors?.networkColors[params?.network],
     secondaryButtonText: lang.t('explain.learn_more'),
     logo: (
@@ -450,9 +450,6 @@ const ExplainSheet = () => {
 
   const buttons = useMemo(() => {
     const missingL2Assets = type === 'obtainL2Assets';
-    const secondaryButtonTextColor = missingL2Assets
-      ? 'primary'
-      : colors.blueGreyDark60;
     const secondaryButton = explainSheetConfig.readMoreLink && (
       <Column height={60}>
         <SheetActionButton
@@ -464,7 +461,7 @@ const ExplainSheet = () => {
           }
           onPress={handleReadMore}
           size="big"
-          textColor={secondaryButtonTextColor}
+          textColor={missingL2Assets ? 'primary' : colors.blueGreyDark60}
           weight="heavy"
         />
       </Column>

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -451,7 +451,10 @@ const ExplainSheet = () => {
   const buttons = useMemo(() => {
     const missingL2Assets = type === 'obtainL2Assets';
     const secondaryButton = explainSheetConfig.readMoreLink && (
-      <Column height={60}>
+      <Column
+        height={60}
+        style={android && missingL2Assets && { marginTop: 16 }}
+      >
         <SheetActionButton
           color={colors.blueGreyDarkLight}
           isTransparent


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Added additional explainer sheet when the user selects an L2 output they don't have currency to swap for.

## PoW (screenshots / screen recordings)
<img width="375" alt="Screen Shot 2022-06-16 at 11 54 57 AM" src="https://user-images.githubusercontent.com/14877580/174113636-0be16d24-2635-4d49-9a76-5b4d18302878.png">
<img width="363" alt="Screen Shot 2022-06-16 at 11 54 40 AM" src="https://user-images.githubusercontent.com/14877580/174113651-9845cafd-c0a5-41f4-8efb-fdc6e439140f.png">
<img width="365" alt="Screen Shot 2022-06-16 at 11 54 25 AM" src="https://user-images.githubusercontent.com/14877580/174113670-abbdaf2f-c255-47d1-9084-288dc50aabbe.png">

## Dev checklist for QA: what to test
Ensure the new explainer prevents the user from selecting an L2 asset as output when they do not own other assets on that chain. Probably best to check that the changes did not affect other explainer sheet use cases.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
