### PR TITLE
Profiles: Fix nft upload flash when editing profile

### DIFF
--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -21,6 +21,7 @@ import { UniqueAsset } from '@rainbow-me/entities';
 import { UploadImageReturnData } from '@rainbow-me/handlers/pinata';
 import {
   useENSModifiedRegistration,
+  useENSRegistration,
   useENSRegistrationForm,
   useSelectImageMenu,
 } from '@rainbow-me/hooks';
@@ -56,6 +57,7 @@ const RegistrationAvatar = ({
     onRemoveField,
     setDisabled,
   } = useENSRegistrationForm();
+  const { name } = useENSRegistration();
   const { navigate } = useNavigation();
 
   const [avatarUpdateAllowed, setAvatarUpdateAllowed] = useState(true);
@@ -74,9 +76,7 @@ const RegistrationAvatar = ({
   }, [initialAvatarUrl, avatarUpdateAllowed]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // We want to allow avatar state update when the screen is first focussed.
-  useEffect(() => {
-    setAvatarUpdateAllowed(true);
-  }, [setAvatarUpdateAllowed]);
+  useEffect(() => setAvatarUpdateAllowed(true), [setAvatarUpdateAllowed, name]);
 
   const setAvatarMetadata = useSetRecoilState(avatarMetadataAtom);
 

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -1,4 +1,3 @@
-import { useFocusEffect } from '@react-navigation/core';
 import ConditionalWrap from 'conditional-wrap';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
@@ -75,7 +74,9 @@ const RegistrationAvatar = ({
   }, [initialAvatarUrl, avatarUpdateAllowed]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // We want to allow avatar state update when the screen is first focussed.
-  useFocusEffect(useCallback(() => setAvatarUpdateAllowed(true), []));
+  useEffect(() => {
+    setAvatarUpdateAllowed(true);
+  }, [setAvatarUpdateAllowed]);
 
   const setAvatarMetadata = useSetRecoilState(avatarMetadataAtom);
 

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -94,9 +94,6 @@ const RegistrationAvatar = ({
       setAvatarUrl(
         image?.tmpPath || asset?.lowResUrl || asset?.image_thumbnail_url || ''
       );
-      // We want to disallow future avatar state changes (i.e. when upload successful)
-      // to avoid avatar flashing (from temp URL to uploaded URL).
-      setAvatarUpdateAllowed(false);
       onChangeAvatarUrl(
         image?.path || asset?.lowResUrl || asset?.image_thumbnail_url || ''
       );
@@ -113,6 +110,9 @@ const RegistrationAvatar = ({
           }),
         });
       } else if (image?.tmpPath) {
+        // We want to disallow future avatar state changes (i.e. when upload successful)
+        // to avoid avatar flashing (from temp URL to uploaded URL).
+        setAvatarUpdateAllowed(false);
         onBlurField({
           key: 'avatar',
           value: image.tmpPath,

--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -1,7 +1,6 @@
-import { useFocusEffect } from '@react-navigation/core';
 import ConditionalWrap from 'conditional-wrap';
 import lang from 'i18n-js';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { Image } from 'react-native-image-crop-picker';
 import RadialGradient from 'react-native-radial-gradient';
@@ -53,7 +52,7 @@ const RegistrationCover = ({
   }, [initialCoverUrl, coverUpdateAllowed, values, coverUrl]);
 
   // We want to allow cover state update when the screen is first focussed.
-  useFocusEffect(useCallback(() => setCoverUpdateAllowed(true), []));
+  useEffect(() => setCoverUpdateAllowed(true), [setCoverUpdateAllowed]);
 
   const accentColor = useForegroundColor('accent');
 
@@ -77,7 +76,13 @@ const RegistrationCover = ({
       // to avoid avatar flashing (from temp URL to uploaded URL).
       setCoverUpdateAllowed(false);
       setCoverMetadata(image);
-      setCoverUrl(image?.tmpPath);
+      setCoverUrl(
+        image?.tmpPath ||
+          asset?.image_url ||
+          asset?.lowResUrl ||
+          asset?.image_thumbnail_url ||
+          ''
+      );
 
       if (asset) {
         const standard = asset.asset_contract?.schema_name || '';

--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -73,9 +73,6 @@ const RegistrationCover = ({
       asset?: UniqueAsset;
       image?: Image & { tmpPath?: string };
     }) => {
-      // We want to disallow future avatar state changes (i.e. when upload successful)
-      // to avoid avatar flashing (from temp URL to uploaded URL).
-      setCoverUpdateAllowed(false);
       setCoverMetadata(image);
       setCoverUrl(
         image?.tmpPath ||
@@ -98,6 +95,9 @@ const RegistrationCover = ({
           }),
         });
       } else if (image?.tmpPath) {
+        // We want to disallow future avatar state changes (i.e. when upload successful)
+        // to avoid avatar flashing (from temp URL to uploaded URL).
+        setCoverUpdateAllowed(false);
         onBlurField({
           key: 'cover',
           value: image.tmpPath,

--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -12,6 +12,7 @@ import { UniqueAsset } from '@rainbow-me/entities';
 import { UploadImageReturnData } from '@rainbow-me/handlers/pinata';
 import {
   useENSModifiedRegistration,
+  useENSRegistration,
   useENSRegistrationForm,
   useSelectImageMenu,
 } from '@rainbow-me/hooks';
@@ -40,7 +41,7 @@ const RegistrationCover = ({
     setDisabled,
     values,
   } = useENSRegistrationForm();
-
+  const { name } = useENSRegistration();
   const [coverUpdateAllowed, setCoverUpdateAllowed] = useState(true);
   const [coverUrl, setCoverUrl] = useState(initialCoverUrl || values?.cover);
   useEffect(() => {
@@ -52,7 +53,7 @@ const RegistrationCover = ({
   }, [initialCoverUrl, coverUpdateAllowed, values, coverUrl]);
 
   // We want to allow cover state update when the screen is first focussed.
-  useEffect(() => setCoverUpdateAllowed(true), [setCoverUpdateAllowed]);
+  useEffect(() => setCoverUpdateAllowed(true), [setCoverUpdateAllowed, name]);
 
   const accentColor = useForegroundColor('accent');
 


### PR DESCRIPTION
Fixes TEAM2-126

## What changed (plus any additional context for devs)
- useFocusEffect was getting called after avatarUrl was already updated in onChangeImage, which caused avatarUrl to get updated a second time. i changed useFocusEffect to useEffect to make sure it only executed `setAvatarUpdateAllowed(true)` on the initial render.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
