### PR TITLE
swaps: token network fixes

### DIFF
--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -372,11 +372,13 @@ export default function ChartExpandedState({ asset }) {
         </SheetActionButtonRow>
       ) : (
         <SheetActionButtonRow paddingBottom={isL2 ? 19 : undefined}>
-          {hasBalance && <SwapActionButton
-            asset={ogAsset}
-            color={color}
-            inputType={AssetInputTypes.in}
-          />}
+          {hasBalance && (
+            <SwapActionButton
+              asset={ogAsset}
+              color={color}
+              inputType={AssetInputTypes.in}
+            />
+          )}
           {hasBalance ? (
             <SendActionButton
               asset={ogAsset}

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -42,7 +42,6 @@ import AssetInputTypes from '@rainbow-me/helpers/assetInputTypes';
 import {
   useAccountSettings,
   useAdditionalAssetData,
-  useAssetsInWallet,
   useChartThrottledPoints,
   useDelayedValueWithLayoutAnimation,
   useDimensions,
@@ -275,15 +274,6 @@ export default function ChartExpandedState({ asset }) {
     ),
   });
 
-  const assetsInWallet = useAssetsInWallet();
-  const showSwapButton = useMemo(
-    () =>
-      assetsInWallet.find(
-        assetInWallet => assetInWallet.address === assetWithPrice.address
-      ),
-    [assetWithPrice.address, assetsInWallet]
-  );
-
   const needsEth =
     asset?.address === ETH_ADDRESS && asset?.balance?.amount === '0';
 
@@ -382,13 +372,11 @@ export default function ChartExpandedState({ asset }) {
         </SheetActionButtonRow>
       ) : (
         <SheetActionButtonRow paddingBottom={isL2 ? 19 : undefined}>
-          {showSwapButton && (
-            <SwapActionButton
-              asset={ogAsset}
-              color={color}
-              inputType={AssetInputTypes.in}
-            />
-          )}
+          <SwapActionButton
+            asset={ogAsset}
+            color={color}
+            inputType={AssetInputTypes.in}
+          />
           {hasBalance ? (
             <SendActionButton
               asset={ogAsset}

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -372,11 +372,11 @@ export default function ChartExpandedState({ asset }) {
         </SheetActionButtonRow>
       ) : (
         <SheetActionButtonRow paddingBottom={isL2 ? 19 : undefined}>
-          <SwapActionButton
+          {hasBalance && <SwapActionButton
             asset={ogAsset}
             color={color}
             inputType={AssetInputTypes.in}
-          />
+          />}
           {hasBalance ? (
             <SendActionButton
               asset={ogAsset}

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -44,20 +44,22 @@ export default function SwapSettingsState({ asset }) {
     flashbotsEnabled,
     settingsChangeFlashbotsEnabled,
   } = useAccountSettings();
+  const {
+    params: { swapSupportsFlashbots = false },
+  } = useRoute();
   const { colors } = useTheme();
   const { setParams, goBack } = useNavigation();
-  useAndroidDisableGesturesOnFocus();
   const dispatch = useDispatch();
+  const keyboardHeight = useKeyboardHeight();
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(true);
+  const slippageRef = useRef(null);
+  const { updateSwapSource, source } = useSwapSettings();
+
+  useAndroidDisableGesturesOnFocus();
 
   const toggleFlashbotsEnabled = useCallback(async () => {
     await dispatch(settingsChangeFlashbotsEnabled(!flashbotsEnabled));
   }, [dispatch, flashbotsEnabled, settingsChangeFlashbotsEnabled]);
-
-  const keyboardHeight = useKeyboardHeight();
-  const [isKeyboardOpen, setIsKeyboardOpen] = useState(true);
-
-  const slippageRef = useRef(null);
-  const { updateSwapSource, source } = useSwapSettings();
 
   useEffect(() => {
     const keyboardDidShow = () => {
@@ -86,7 +88,8 @@ export default function SwapSettingsState({ asset }) {
     [updateSwapSource]
   );
 
-  const sheetHeightWithoutKeyboard = android ? 275 : 245;
+  const sheetHeightWithoutKeyboard =
+    (android ? 225 : 195) + (swapSupportsFlashbots ? 55 : 0);
 
   const sheetHeightWithKeyboard =
     sheetHeightWithoutKeyboard +
@@ -127,7 +130,7 @@ export default function SwapSettingsState({ asset }) {
               colorForAsset={colorForAsset}
               ref={slippageRef}
             />
-            {asset?.type === 'token' && (
+            {swapSupportsFlashbots && (
               <Columns alignHorizontal="justify" alignVertical="center">
                 <Text color="primary" size="18px" weight="bold">
                   {lang.t('exchange.use_flashbots')}

--- a/src/components/layout/KeyboardFixedOpenLayout.js
+++ b/src/components/layout/KeyboardFixedOpenLayout.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react';
-import { KeyboardAvoidingView } from 'react-native';
 import { Transition, Transitioning } from 'react-native-reanimated';
 import { useSafeArea } from 'react-native-safe-area-context';
 import Centered from './Centered';

--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -79,7 +79,7 @@ export default function useSwapCurrencyHandlers({
       const defaultInputItemInWallet = defaultInputAsset
         ? {
             ...defaultInputAsset,
-            type: inputCurrency?.type ?? AssetType.token,
+            type: defaultInputAsset?.type ?? AssetType.token,
           }
         : null;
 

--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -106,7 +106,7 @@ export default function CurrencySelectModal() {
 
   const [currentChainId, setCurrentChainId] = useState(chainId);
   useEffect(() => {
-    if (chainId) {
+    if (chainId && typeof chainId === 'number') {
       setCurrentChainId(chainId);
     }
   }, [chainId]);

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -305,7 +305,8 @@ export default function ExchangeModal({
     loading
   );
 
-  const flashbots = currentNetwork === Network.mainnet && flashbotsEnabled;
+  const swapSupportsFlashbots = currentNetwork === Network.mainnet;
+  const flashbots = swapSupportsFlashbots && flashbotsEnabled;
 
   const isDismissing = useRef(false);
   useEffect(() => {
@@ -634,6 +635,7 @@ export default function ExchangeModal({
             (lastFocusedInputHandle.current = lastFocusedInputHandleTemporary);
           setParams({ focused: true });
         },
+        swapSupportsFlashbots,
         type: 'swap_settings',
       });
       analytics.track('Opened Swap Settings');
@@ -648,6 +650,7 @@ export default function ExchangeModal({
     navigate,
     outputCurrency,
     outputFieldRef,
+    swapSupportsFlashbots,
     setParams,
   ]);
 


### PR DESCRIPTION
Fixes TEAM2-107

## What changed (plus any additional context for devs)

- flashbots switch in settings is only available on mainnet swaps, the height of settings will act accordingly
- added swap button to owned assets in wallet screen
- currently when you select an L2 asset to swap from the wallet screen, or going to swap from the fab swap button, the network swap will default to mainnet even tho the output asset is on L2 (you can check the before video), this PR fixes it

## PoW (screenshots / screen recordings)

before

https://user-images.githubusercontent.com/12115171/174172089-9db95685-8116-443c-956b-e1db60650a58.mov


after
https://user-images.githubusercontent.com/12115171/174171399-4620f3a1-9e24-4545-9b76-daca95653172.mov



## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
