### PR TITLE
Fix FastBalanceCoinRow visual regressions

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
@@ -152,7 +152,7 @@ const MemoizedBalanceCoinRow = React.memo(
             <View style={[cx.innerContainer, isHidden && cx.hiddenRow]}>
               <View style={cx.row}>
                 <View style={cx.textWrapper}>
-                  <Text align="left" numberOfLines={1} size="16px">
+                  <Text numberOfLines={1} size="16px">
                     {item.name}
                   </Text>
                 </View>
@@ -166,7 +166,6 @@ const MemoizedBalanceCoinRow = React.memo(
               <View style={[cx.row, cx.bottom]}>
                 <View style={cx.textWrapper}>
                   <Text
-                    align="left"
                     color={{ custom: theme.colors.blueGreyDark50 }}
                     numberOfLines={1}
                     size="14px"

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
@@ -152,22 +152,12 @@ const MemoizedBalanceCoinRow = React.memo(
             <View style={[cx.innerContainer, isHidden && cx.hiddenRow]}>
               <View style={cx.row}>
                 <View style={cx.textWrapper}>
-                  <Text
-                    align="left"
-                    numberOfLines={1}
-                    size="16px"
-                    weight="medium"
-                  >
+                  <Text align="left" numberOfLines={1} size="16px">
                     {item.name}
                   </Text>
                 </View>
 
-                <Text
-                  align="left"
-                  color={{ custom: valueColor }}
-                  size="16px"
-                  weight="medium"
-                >
+                <Text align="right" color={{ custom: valueColor }} size="16px">
                   {item?.native?.balance?.display ??
                     `${nativeCurrencySymbol}0.00`}
                 </Text>
@@ -185,7 +175,7 @@ const MemoizedBalanceCoinRow = React.memo(
                   </Text>
                 </View>
 
-                <Text color={{ custom: changeColor }} size="14px">
+                <Text align="right" color={{ custom: changeColor }} size="14px">
                   {percentageChangeDisplay}
                 </Text>
               </View>
@@ -256,7 +246,7 @@ export default React.memo(function BalanceCoinRow({
 
 const cx = StyleSheet.create({
   bottom: {
-    marginTop: 11.5,
+    marginTop: 10,
   },
   checkboxContainer: {
     alignSelf: 'center',
@@ -289,8 +279,9 @@ const cx = StyleSheet.create({
     position: 'absolute',
   },
   container: {
+    alignItems: 'center',
     flexDirection: 'row',
-    marginRight: 18,
+    marginRight: 19,
     overflow: 'visible',
     paddingLeft: 9,
   },
@@ -302,8 +293,8 @@ const cx = StyleSheet.create({
   },
   innerContainer: {
     flex: 1,
+    marginBottom: 1,
     marginLeft: 10,
-    paddingTop: 14.5,
   },
   nonEditMode: {
     paddingLeft: 10,
@@ -311,7 +302,6 @@ const cx = StyleSheet.create({
   rootContainer: {
     flex: 1,
     flexDirection: 'row',
-    marginTop: -1,
     overflow: 'visible',
   },
   row: {
@@ -320,6 +310,6 @@ const cx = StyleSheet.create({
   },
   textWrapper: {
     flex: 1,
-    paddingRight: 20,
+    paddingRight: 19,
   },
 });

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
@@ -179,7 +179,6 @@ const cx = StyleSheet.create({
     height: 40,
     justifyContent: 'center',
     overflow: 'hidden',
-    // overflow: 'visible',
     width: 40,
   },
   coinIconFallback: {
@@ -190,9 +189,9 @@ const cx = StyleSheet.create({
   },
   container: {
     elevation: 6,
-    height: 60,
+    height: 59,
     overflow: 'visible',
-    paddingTop: 9.5,
+    paddingTop: 9,
   },
   fallbackWrapper: {
     left: 0,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
fixed a few visual regressions in the new coin rows

## PoW (screenshots / screen recordings)
![Simulator Screen Shot - iPhone 13 - 2022-06-20 at 16 36 45](https://user-images.githubusercontent.com/7061887/174674602-def495e1-4c89-4313-b04a-e5aefecfd8ea.png)

## Dev checklist for QA: what to test
- android coin row layout

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
