### PR TITLE
Fix issue where sending NFT would show error

### DIFF
--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -364,6 +364,19 @@ const fetchTxWithAlwaysCache = async (address: EthereumAddress) => {
   return txTime;
 };
 
+export const fetchContractABI = async (address: EthereumAddress) => {
+  const url = `https://api.etherscan.io/api?module=contract&action=getabi&address=${address}&apikey=${ETHERSCAN_API_KEY}`;
+  const cachedAbi = await AsyncStorage.getItem(`abi-${address}`);
+  if (cachedAbi) {
+    return cachedAbi;
+  }
+  const response = await fetch(url);
+  const parsedResponse = await response.json();
+  const abi = parsedResponse.result;
+  AsyncStorage.setItem(`abi-${address}`, abi);
+  return abi;
+};
+
 export const daysFromTheFirstTx = (address: EthereumAddress) => {
   return new Promise(async resolve => {
     try {


### PR DESCRIPTION
Fixes TEAM2-49

## What changed (plus any additional context for devs)

It seems that when sending some NFTs, the app would error displaying "Failed to send transaction". Upon further investigation, it seems that some of the newer OpenSea NFT collections do not have an `nft_version` populated (we rely on `nft_version === "3.0"` to perform a `transferFrom`). 

The solution I came up with is to fetch the contract ABI and determine if the correct transfer method _actually_ exists on the contract. Thought it would be better to query Etherscan for the ABI instead of relying on an OpenSea attribute – however, open to other ideas if this is not the most ideal solution.

## Dev checklist for QA: what to test

- Sending older NFTs (that use `transfer(address,uint256)`) should work
- Sending newer NFTs (that use `transferFrom(address,address,uint256)`) should work

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
