### PR TITLE
[TEAM2-138] Switching to [network] sheet: sometimes the network is undefined

### DIFF
--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -156,10 +156,10 @@ export default function useSwapCurrencyHandlers({
         newInputCurrency?.type !== outputCurrency?.type &&
         !hasShownWarning
       ) {
+        android && Keyboard.dismiss();
         InteractionManager.runAfterInteractions(() => {
-          android && Keyboard.dismiss();
           Navigation.handleAction(Routes.EXPLAIN_SHEET, {
-            network: newInputCurrency?.type,
+            network: newInputCurrency?.type || Network.mainnet,
             onClose: () => {
               InteractionManager.runAfterInteractions(() => {
                 setTimeout(() => {
@@ -195,9 +195,10 @@ export default function useSwapCurrencyHandlers({
         newOutputCurrency?.type !== inputCurrency?.type &&
         !hasShownWarning
       ) {
+        android && Keyboard.dismiss();
         InteractionManager.runAfterInteractions(() => {
           Navigation.handleAction(Routes.EXPLAIN_SHEET, {
-            network: newOutputCurrency?.type,
+            network: newOutputCurrency?.type || Network.mainnet,
             onClose: () => {
               InteractionManager.runAfterInteractions(() => {
                 setTimeout(() => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Mainnet should be the implicit default whenever we do not see a network value on a token. We weren't supply a default, which caused this issue when switching to from L2 -> mainnet.
This flow also had some keyboard issues. I think the `InteractionManager` code block should wait for the keyboard to dismiss so I pulled it out.

## Dev checklist for QA: what to test
Initiate swap flow with an L2 asset then attempt to swap it for a mainnet asset. 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
