### PR TITLE
Cancel build in progress when new commits are pushed to the same branch

### DIFF
--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -11,7 +11,7 @@ jobs:
   ios-e2e:
     # The type of runner that the job will run on
     runs-on: ["self-hosted"]
-    # Cancel current builds if there's a newer commit
+    # Cancel current builds if there's a newer commit on the same branch
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
Didn't realize older builds were still running. This will let us use resources wisely and make sure every dev doesn't use more than 1 instance per PR

## PoW (screenshots / screen recordings)
Here's proof that this is working correctly. Pu
<img width="858" alt="Screen Shot 2022-06-22 at 12 36 44 PM" src="https://user-images.githubusercontent.com/1247834/175089927-cff0d636-13e0-4d60-b5fd-11a26d03944c.png">
shed a commit 2 minutes later and previous build was cancelled.

## Dev checklist for QA: what to test
Nothing

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
