### PR TITLE
[TEAM2-154][RNBW-3894] Tokens list goes to loading state when going from token list to swap screen

### DIFF
--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -126,11 +126,12 @@ export default function CurrencySelectModal() {
     updateFavorites,
   } = useSwapCurrencyList(searchQueryForSearch, currentChainId);
 
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const routeName = getActiveRoute()?.name;
   const showList = useMemo(() => {
     const viewingExplainer = routeName === Routes.EXPLAIN_SHEET;
-    return isFocused || viewingExplainer;
-  }, [isFocused, routeName]);
+    return isFocused || viewingExplainer || isTransitioning;
+  }, [isFocused, routeName, isTransitioning]);
 
   const linkToHop = useCallback(() => {
     Linking.openURL('https://app.hop.exchange/#/send');
@@ -299,6 +300,7 @@ export default function CurrencySelectModal() {
       if (checkForRequiredAssets(item)) return;
       dispatch(emitChartsRequest(item.mainnet_address || item.address));
       const isMainnet = currentChainId === 1;
+      setIsTransitioning(true); // continue to display list during transition
 
       onSelectCurrency(
         isMainnet && type === CurrencySelectionTypes.output
@@ -354,6 +356,9 @@ export default function CurrencySelectModal() {
       if (!isFocused && prevIsFocused) {
         handleApplyFavoritesQueue();
         restoreFocusOnSwapModal?.();
+        setTimeout(() => {
+          setIsTransitioning(false); // hide list now that we have arrived on main exchange modal
+        }, 750);
       }
     }
   }, [
@@ -371,6 +376,7 @@ export default function CurrencySelectModal() {
   const handleBackButton = useCallback(() => {
     setSearchQuery('');
     setCurrentChainId(chainId);
+    setIsTransitioning(true); // continue to display list while transitiong back
   }, [chainId]);
 
   const shouldUpdateFavoritesRef = useRef(false);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I added an additional value: `isTransitioning` to determine whether the currency selection modal's list should show. This is an incredibly hacky solution, but I spent far too much time looking for an elegant way to do this.

## Dev checklist for QA: what to test
ensure you do not see the skeleton loader appear in place of the currency list when navigating away from the currency selection modal

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
