### PR TITLE
Fix not loading icons fro cloudinary on some phones

### DIFF
--- a/src/handlers/cloudinary.ts
+++ b/src/handlers/cloudinary.ts
@@ -33,7 +33,7 @@ export const signUrl = memoFn(
       internalAddress = internalAddress.split('.')[0] + '.' + format;
     }
 
-    let { width } = widthAndHeight;
+    const { width } = widthAndHeight;
 
     const directory = internalAddress.split('/')[0];
 

--- a/src/handlers/cloudinary.ts
+++ b/src/handlers/cloudinary.ts
@@ -7,7 +7,7 @@ import { memoFn } from '@rainbow-me/utils/memoFn';
 type CloudinaryConfig = {
   width: number;
   height: number;
-  format?: string;
+  format: string;
 };
 
 const PixelRatios = [1, 1.5, 2, 2.625, 2.75, 3, 3.5]; // popular ratios.
@@ -26,7 +26,7 @@ const supportedSizeTransformations = {
 // NOTE: currently, we assume that width and height are always equal and provided.
 // We use this storage only for assets.
 export const signUrl = memoFn(
-  (url: string, config: CloudinaryConfig) => {
+  (url: string, config: Partial<CloudinaryConfig>) => {
     const { format, ...widthAndHeight } = config;
     let internalAddress = url.split('/upload/')[1];
     if (format) {


### PR DESCRIPTION
Fixes https://rainbowhaus.slack.com/archives/C01GD1F2ZTL/p1655913852370269

## What changed (plus any additional context for devs)

Looks like my list of ratios was not exhaustive (cause docs lie). I added a bit more "popular" ratios +  rounding for the remaining. Rounding should not happen very often - probably on some weird phone, but we cannot support everything perfectly. 


## PoW (screenshots / screen recordings)

![image](https://user-images.githubusercontent.com/25709300/175178633-fef3cc0f-feb3-4ed6-9e82-e70ea01b4015.png)


## Dev checklist for QA: what to test

Check on Pixel 3, Pixel 5, just compare different phones. 
