### PR TITLE
Fix missing params passing to send sheet on Android

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -72,7 +72,7 @@ const OuterStack = createStackNavigator();
 const AuthStack = createStackNavigator();
 const BSStack = createBottomSheetNavigator();
 
-function SendFlowNavigator() {
+function SendFlowNavigator({ route: { params } }) {
   return (
     <Stack.Navigator
       {...stackNavigationConfig}
@@ -80,6 +80,7 @@ function SendFlowNavigator() {
     >
       <Stack.Screen
         component={SendSheet}
+        initialParams={params}
         name={Routes.SEND_SHEET}
         options={sheetPreset}
       />

--- a/src/navigation/onNavigationStateChange.js
+++ b/src/navigation/onNavigationStateChange.js
@@ -116,6 +116,7 @@ export function onNavigationStateChange(currentState) {
     if (
       routeName === Routes.MAIN_EXCHANGE_SCREEN ||
       routeName === Routes.SAVINGS_WITHDRAW_MODAL ||
+      routeName === Routes.SEND_SHEET ||
       routeName === Routes.SWAP_DETAILS_SCREEN ||
       routeName === Routes.SWAP_DETAILS_SHEET ||
       routeName === Routes.QR_SCANNER_SCREEN ||

--- a/src/navigation/onNavigationStateChange.js
+++ b/src/navigation/onNavigationStateChange.js
@@ -116,7 +116,6 @@ export function onNavigationStateChange(currentState) {
     if (
       routeName === Routes.MAIN_EXCHANGE_SCREEN ||
       routeName === Routes.SAVINGS_WITHDRAW_MODAL ||
-      routeName === Routes.SEND_SHEET ||
       routeName === Routes.SWAP_DETAILS_SCREEN ||
       routeName === Routes.SWAP_DETAILS_SHEET ||
       routeName === Routes.QR_SCANNER_SCREEN ||


### PR DESCRIPTION
Fixes RNBW-3879

## What changed (plus any additional context for devs)

Someone forgot to pass props from `SendFlowNavigator` to the screen. This resulted in a situation where SendSheet would never get the asset (or any other param) on Android.

## PoW (screenshots / screen recordings)

Before:

https://user-images.githubusercontent.com/5769281/175315156-844370d8-3ebf-46a5-b139-3278abffc4b1.mp4

After:

https://user-images.githubusercontent.com/5769281/175315172-b403954d-c8e3-49ae-b992-ddb297dbb6a3.mp4

## Dev checklist for QA: what to test

Try sending asset from expanded sheet.

On iOS it should look like it did in the past. No changes.

On Android it should now match iOS.

Because previously it didn't work on Android, there is a possibility that this fix uncovers another bug (see the After video, keyboard adjustment is very wrong; I am unsure if it was a temporary glitch or indeed a bug).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why – Fixing bug in existing functionality
- [x] If you added new files, did you update the CODEOWNERS file?
