### PR TITLE
Fix image cache after introduction of images from Cloudinary

### DIFF
--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -87,8 +87,10 @@ const saveToMemory = async () => {
     const values = [];
 
     for (let [key, value] of staticSignatureLRU.entries()) {
-      keys.push(key);
-      values.push(value);
+      if (!key.includes(SEPARATOR) && !value.includes(SEPARATOR)) {
+        keys.push(key);
+        values.push(value);
+      }
     }
 
     imgixCacheStorage.set(ATTRIBUTES.KEYS, keys.join(SEPARATOR));

--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -55,6 +55,7 @@ const staticImgixClient = shouldCreateImgixClient();
 //       This might be conditional based upon either the runtime
 //       hardware or the number of unique tokens a user may have.
 const capacity = 1024;
+const SEPARATOR = '>';
 export let staticSignatureLRU: LRUCache<string, string> = new LRUCache(
   capacity
 );
@@ -64,10 +65,10 @@ const maybeReadCacheFromMemory = async (): Promise<
 > => {
   try {
     const cache = new LRUCache<string, string>(capacity);
-    const keys = imgixCacheStorage.getString(ATTRIBUTES.KEYS)?.split(',') ?? [];
+    const keys =
+      imgixCacheStorage.getString(ATTRIBUTES.KEYS)?.split(SEPARATOR) ?? [];
     const values =
-      imgixCacheStorage.getString(ATTRIBUTES.VALUES)?.split(',') ?? [];
-
+      imgixCacheStorage.getString(ATTRIBUTES.VALUES)?.split(SEPARATOR) ?? [];
     for (let i = 0; i < keys.length; i++) {
       cache.set(keys[i], values[i]);
     }
@@ -90,8 +91,8 @@ const saveToMemory = async () => {
       values.push(value);
     }
 
-    imgixCacheStorage.set(ATTRIBUTES.KEYS, keys.join(','));
-    imgixCacheStorage.set(ATTRIBUTES.VALUES, values.join(','));
+    imgixCacheStorage.set(ATTRIBUTES.KEYS, keys.join(SEPARATOR));
+    imgixCacheStorage.set(ATTRIBUTES.VALUES, values.join(SEPARATOR));
   } catch (error) {
     logger.error(`Failed to persist IMGIX cache: ${error}`);
   }


### PR DESCRIPTION
Fixes RNBW-####

Comma character `,` was used as a separator in cache of images. Turns out that:
1. No one realized it is a legal URL character.
2. We didn't have any URLs using it.
3. Cloudinary does.

## What changed (plus any additional context for devs)

Image cache should work properly again.

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

Check that images you see in the app are the ones you are supposed to see. You will immediately notice if they are wrong.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
