### PR TITLE
swaps: round max input

### DIFF
--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -282,6 +282,9 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   const independentValue = useSelector(
     (state: AppState) => state.swap.independentValue
   );
+  const maxInputUpdate = useSelector(
+    (state: AppState) => state.swap.maxInputUpdate
+  );
   const inputCurrency = useSelector(
     (state: AppState) => state.swap.inputCurrency
   );
@@ -371,7 +374,9 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
 
       if (independentField === SwapModalField.input) {
         derivedValues[SwapModalField.input] = independentValue;
-        displayValues[DisplayValue.input] = independentValue;
+        displayValues[DisplayValue.input] = maxInputUpdate
+          ? updatePrecisionToDisplay(independentValue, null, true)
+          : independentValue;
 
         const nativeValue = inputPrice
           ? convertAmountToNativeAmount(independentValue, inputPrice)
@@ -525,6 +530,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     source,
     derivedValuesFromRedux,
     isSavings,
+    maxInputUpdate,
   ]);
 
   return {

--- a/src/hooks/useSwapInputHandlers.ts
+++ b/src/hooks/useSwapInputHandlers.ts
@@ -37,7 +37,7 @@ export default function useSwapInputHandlers() {
     const inputCurrencyAddress = inputCurrency?.address;
     const inputCurrencyUniqueId = inputCurrency?.uniqueId;
     if (type === ExchangeModalTypes.withdrawal) {
-      dispatch(updateSwapInputAmount(supplyBalanceUnderlying));
+      dispatch(updateSwapInputAmount(supplyBalanceUnderlying, true));
     } else {
       const accountAsset = ethereumUtils.getAccountAsset(inputCurrencyUniqueId);
       const oldAmount = accountAsset?.balance?.amount ?? '0';
@@ -86,7 +86,7 @@ export default function useSwapInputHandlers() {
           return;
         }
       }
-      dispatch(updateSwapInputAmount(newAmount));
+      dispatch(updateSwapInputAmount(newAmount, true));
     }
   }, [
     dispatch,

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -34,6 +34,7 @@ interface SwapState {
   inputCurrency: SwappableAsset | null;
   independentField: SwapModalField;
   independentValue: string | null;
+  maxInputUpdate: boolean;
   slippageInBips: number;
   source: Source;
   type: string;
@@ -88,11 +89,12 @@ export const updateSwapSource = (newSource: Source) => (
   });
 };
 
-export const updateSwapInputAmount = (value: string | null) => (
-  dispatch: AppDispatch
-) => {
+export const updateSwapInputAmount = (
+  value: string | null,
+  maxInputUpdate = false
+) => (dispatch: AppDispatch) => {
   dispatch({
-    payload: { independentValue: value },
+    payload: { independentValue: value, maxInputUpdate },
     type: SWAP_UPDATE_INPUT_AMOUNT,
   });
 };
@@ -231,6 +233,7 @@ const INITIAL_STATE: SwapState = {
   independentField: SwapModalField.input,
   independentValue: null,
   inputCurrency: null,
+  maxInputUpdate: false,
   outputCurrency: null,
   slippageInBips: 100,
   source: Source.AggregatorRainbow,
@@ -269,6 +272,7 @@ export default (state = INITIAL_STATE, action: AnyAction) => {
         ...state,
         independentField: SwapModalField.input,
         independentValue: action.payload.independentValue,
+        maxInputUpdate: action.payload.maxInputUpdate,
       };
     case SWAP_UPDATE_NATIVE_AMOUNT:
       return {


### PR DESCRIPTION
Fixes RNBW-3506

## What changed (plus any additional context for devs)

when pressing max on input we were showing all decimals available for the token
this PR rounds up the number for the input value but the underlying input value is still the amount with all decimals
users can still add as many decimals as they want in the input

## PoW (screenshots / screen recordings)


https://user-images.githubusercontent.com/12115171/175422851-159e9118-0e3b-4249-a2c2-777cae720922.mp4


## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
