### PR TITLE
fix fast coin icon regression

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
@@ -143,8 +143,9 @@ const MemoizedBalanceCoinRow = React.memo(
         >
           <View style={[cx.container]}>
             <FastCoinIcon
-              address={item.mainnet_address ?? item.address}
+              address={item.address}
               assetType={item.type}
+              mainnetAddress={item.mainnet_address}
               symbol={item.symbol}
               theme={theme}
             />

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
@@ -103,18 +103,20 @@ const CoinIconWithBackground = React.memo(function CoinIconWithBackground({
 
 export default React.memo(function FastCoinIcon({
   address,
+  mainnetAddress,
   symbol,
-  assetType,
+  assetType = AssetType.token,
   theme,
 }: {
   address: string;
+  mainnetAddress: string;
   symbol: string;
   assetType?: AssetType;
   theme: any;
 }) {
   const imageUrl = getUrlForTrustIconFallback(
-    address,
-    assetType ?? AssetType.token
+    mainnetAddress ?? address,
+    mainnetAddress ? AssetType.token : assetType
   )!;
 
   const fallbackIconColor = useColorForAsset({
@@ -136,6 +138,7 @@ export default React.memo(function FastCoinIcon({
         {/* @ts-ignore */}
         <CoinIcon
           address={address}
+          mainnet_address={mainnetAddress}
           size={40}
           symbol={symbol}
           type={assetType}


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)
we weren't handling props and passing them correctly to handle L2 icons properly

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Shot-2022-06-23-15-47-41.13.png

## Dev checklist for QA: what to test
uniswap icon on L2  should show up and no other icons should have regressions

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
