### PR TITLE
fix: use getNetworkFromType in switch network explainer

### DIFF
--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -158,7 +158,9 @@ export default function useSwapCurrencyHandlers({
         android && Keyboard.dismiss();
         InteractionManager.runAfterInteractions(() => {
           Navigation.handleAction(Routes.EXPLAIN_SHEET, {
-            network: newInputCurrency?.type || Network.mainnet,
+            network: newInputCurrency?.type
+              ? ethereumUtils.getNetworkFromType(newInputCurrency?.type)
+              : Network.mainnet,
             onClose: () => {
               InteractionManager.runAfterInteractions(() => {
                 setTimeout(() => {
@@ -197,7 +199,9 @@ export default function useSwapCurrencyHandlers({
         android && Keyboard.dismiss();
         InteractionManager.runAfterInteractions(() => {
           Navigation.handleAction(Routes.EXPLAIN_SHEET, {
-            network: newOutputCurrency?.type || Network.mainnet,
+            network: newOutputCurrency?.type
+              ? ethereumUtils.getNetworkFromType(newOutputCurrency?.type)
+              : Network.mainnet,
             onClose: () => {
               InteractionManager.runAfterInteractions(() => {
                 setTimeout(() => {


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

we were still seeing some "Switching to undefined" instances of the network change explainer sheet, this PR uses `ethereumUtils.getNetworkFromType` to get the network to give it to the explainer sheet

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/12115171/175434313-445148d1-f1a6-4ae9-be58-56f6867ab941.mp4

## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
