### PR TITLE
WC - convert hex chainId

### DIFF
--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -48,6 +48,7 @@ import {
   estimateGas,
   estimateGasWithPadding,
   getProviderForNetwork,
+  isHexString,
   isL2Network,
   isTestnetNetwork,
   toHex,
@@ -622,6 +623,11 @@ export default function TransactionConfirmationScreen() {
       ...gasParams,
       nonce,
     };
+    if (isHexString(txPayloadUpdated?.chainId)) {
+      txPayloadUpdated.chainId = Number(
+        convertHexToString(txPayloadUpdated.chainId)
+      );
+    }
     if (calculatedGasLimit) {
       txPayloadUpdated.gasLimit = calculatedGasLimit;
     }


### PR DESCRIPTION
Fixes TEAM2-168

## What changed (plus any additional context for devs)
mint.fun is passing us a hex chainId in the tx payload which is causing an error, this adds a precaution against that scenario 

## PoW (screenshots / screen recordings)
👇 

## Dev checklist for QA: what to test
not gonna mint another NFT but u can try to mint anything on mint.fun and it should work now

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
