### PR TITLE
Swaps: Android layout fixes

### DIFF
--- a/src/components/exchange/ExchangeNotch.js
+++ b/src/components/exchange/ExchangeNotch.js
@@ -13,15 +13,15 @@ import styled from '@rainbow-me/styled-components';
 
 const notchHeight = 48;
 const notchSideWidth = 78;
+const ANDROID_NOTCH_OFFSET = 8;
 
 const Container = styled(Row).attrs({
   pointerEvents: 'none',
 })({
   height: notchHeight,
-  left: android ? -4.5 : 0,
+  left: 0,
   position: 'absolute',
   top: 132,
-  width: '100%',
 });
 
 const NotchMiddle = styled(FastImage).attrs(({ isDarkMode }) => ({
@@ -29,12 +29,14 @@ const NotchMiddle = styled(FastImage).attrs(({ isDarkMode }) => ({
   source: isDarkMode ? ExchangeNotchMiddleDark : ExchangeNotchMiddle,
 }))({
   height: notchHeight,
+  left: android ? -ANDROID_NOTCH_OFFSET : 0,
   width: ({ deviceWidth }) => deviceWidth - notchSideWidth * 2,
 });
 
 const NotchSide = styled(FastImage)({
-  height: notchHeight,
-  width: notchSideWidth,
+  height: android ? notchHeight + 2 : notchHeight,
+  left: android ? -ANDROID_NOTCH_OFFSET : 0,
+  width: android ? notchSideWidth + ANDROID_NOTCH_OFFSET : notchSideWidth,
 });
 
 export default function ExchangeNotch({ testID }) {

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -68,14 +68,22 @@ const ExchangeIcon = ({ index = 1, icon, protocol }) => {
             width={{ custom: 20 }}
           >
             <Cover alignHorizontal="center" alignVertical="center">
-              <Text
-                align="center"
-                color="secondary80"
-                size="14px"
-                weight="semibold"
+              <Box
+                style={
+                  android && {
+                    top: 1,
+                  }
+                }
               >
-                {protocol?.substring(0, 1)}
-              </Text>
+                <Text
+                  align="center"
+                  color="secondary80"
+                  size="14px"
+                  weight="semibold"
+                >
+                  {protocol?.substring(0, 1)}
+                </Text>
+              </Box>
             </Cover>
           </Box>
         </Stack>
@@ -157,15 +165,32 @@ export default function SwapDetailsExchangeRow(props) {
               </SwapDetailsLabel>
             </Column>
             <Column width="content">
-              <ExchangeIconStack protocols={steps[step]} />
+              <Box
+                style={{
+                  top: android ? -1.5 : 0,
+                }}
+              >
+                <ExchangeIconStack protocols={steps[step]} />
+              </Box>
             </Column>
             <Column width="content">
               <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
             </Column>
             {steps?.[step]?.part && (
               <Column width="content">
-                <Bleed right="6px" vertical="6px">
-                  <Pill textColor={defaultColor}>{steps[step].part}</Pill>
+                <Bleed right={android ? '5px' : '6px'} vertical="6px">
+                  <Pill
+                    height={android && 20}
+                    style={
+                      android && {
+                        lineHeight: 22,
+                        top: -1,
+                      }
+                    }
+                    textColor={defaultColor}
+                  >
+                    {steps[step].part}
+                  </Pill>
                 </Bleed>
               </Column>
             )}

--- a/src/components/expanded-state/swap-settings/SourcePicker.js
+++ b/src/components/expanded-state/swap-settings/SourcePicker.js
@@ -88,6 +88,7 @@ export default function SourcePicker({ onSelect, currentSource }) {
             paddingHorizontal="10px"
             paddingVertical="6px"
             shadow="21px light"
+            // shadow clipped on android by ButtonPressAnimation.android.tsx inside <ContextMenuButton>
           >
             <Inline alignVertical="center" horizontalSpace="4px">
               <ImgixImage

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -109,7 +109,7 @@ export default function SwapSettingsState({ asset }) {
       <FloatingPanel radius={android ? 30 : 39} testID="swap-settings">
         <ExchangeHeader />
         <Inset bottom="24px" horizontal="24px" top="10px">
-          <Stack backgroundColor="green" space="24px">
+          <Stack backgroundColor="body" space="24px">
             <SourcePicker
               currentSource={currentSource}
               onSelect={updateSource}


### PR DESCRIPTION
Fixes TEAM2-170

## What changed (plus any additional context for devs)
- Fixed: exchange % pill height
- Fixed: exchange icon stack not vertically aligned
- Fixed: swap screen input row has an offset margin instead of being edge-to-edge
- Fixed: exchange icon with no image text not vertically centered inside circle

## PoW (screenshots / screen recordings)

## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
