### PR TITLE
swaps - input price fallback

### DIFF
--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -306,7 +306,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
 
   const inputPrice = useMemo(() => {
     const price = ethereumUtils.getAssetPrice(
-      inputCurrency?.mainnet_address || inputCurrency?.address
+      inputCurrency?.mainnet_address ?? inputCurrency?.address
     );
     return price !== 0 ? price : inputCurrency?.price?.value;
   }, [inputCurrency]);

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -4,7 +4,7 @@ import {
   Quote,
   QuoteError,
 } from '@rainbow-me/swaps';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { NativeModules } from 'react-native';
 // @ts-expect-error ts-migrate(2305) FIXME: Module '"react-native-dotenv"' has no exported mem... Remove this comment to see the full error message
@@ -304,9 +304,13 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     (state: AppState) => state.data.genericAssets
   );
 
-  const inputPrice = ethereumUtils.getAssetPrice(
-    inputCurrency?.mainnet_address || inputCurrency?.address
-  );
+  const inputPrice = useMemo(() => {
+    const price = ethereumUtils.getAssetPrice(
+      inputCurrency?.mainnet_address || inputCurrency?.address
+    );
+    return price !== 0 ? price : inputCurrency?.price?.value;
+  }, [inputCurrency]);
+
   const outputPrice =
     genericAssets[outputCurrency?.mainnet_address || outputCurrency?.address]
       ?.price?.value;


### PR DESCRIPTION
Fixes TEAM2-172

## What changed (plus any additional context for devs)
our current getAssetPrice function doesn't account for L2 specific assets where there is no asset price on mainnet, we have all of this data in the asset object so we're falling back and double checking if we can't find the price

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-06-27-09-50-44.mp4

## Dev checklist for QA: what to test

mainnet assets should work fine
L2 assets with mainnet matches should be fine
L2 assets not on mainnet should not have a price and fill the native input(most polygon tokens and OP)

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
