### PR TITLE
swaps - extra height android explainers

### DIFF
--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -423,6 +423,7 @@ export const explainers = (params, colors) => ({
     }),
   },
   flashbots: {
+    extraHeight: android ? 20 : 0,
     emoji: '🤖',
     stillCurious: (
       <Text {...getBodyTextPropsWithColor(colors)}>
@@ -448,6 +449,7 @@ export const explainers = (params, colors) => ({
     title: lang.t('explain.flashbots.title'),
   },
   routeSwaps: {
+    extraHeight: android ? 20 : 0,
     emoji: '🔀',
     stillCurious: (
       <Text {...getBodyTextPropsWithColor(colors)}>


### PR DESCRIPTION
Fixes TEAM2-178

## What changed (plus any additional context for devs)

note that these are gonna look weird on some android devices due to the inset issues 


## PoW (screenshots / screen recordings)

samsung: 

https://user-images.githubusercontent.com/29204161/176067554-29dc05cd-9ede-4200-9eac-2615090a7dd4.mov



pixel: 

https://user-images.githubusercontent.com/29204161/176067573-1dbb4026-1506-4edb-97a5-ef472e6ea4ab.mov



## Dev checklist for QA: what to test

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
