### PR TITLE
[TEAM2-19] Wallet connect confirmation screen should use metadata service

### DIFF
--- a/src/utils/methodRegistry.ts
+++ b/src/utils/methodRegistry.ts
@@ -1,5 +1,4 @@
 import { Contract } from '@ethersproject/contracts';
-import { isEmpty } from 'lodash';
 import { web3Provider } from '../handlers/web3';
 import namesOverrides from '../references/method-names-overrides.json';
 import methodRegistryABI from '../references/method-registry-abi.json';
@@ -24,7 +23,7 @@ export const methodRegistryLookupAndParse = async (
     800
   );
 
-  if (!isEmpty(response?.data?.contractFunction?.text)) {
+  if (response?.data?.contractFunction?.text) {
     signature = response.data.contractFunction.text;
   } else {
     const registry = new Contract(

--- a/src/utils/methodRegistry.ts
+++ b/src/utils/methodRegistry.ts
@@ -56,15 +56,21 @@ export const methodRegistryLookupAndParse = async (
     parsedName = '';
   }
 
-  const match = signature.match(
-    new RegExp(rawName[1] + '\\(+([a-z1-9,()]+)\\)')
-  );
+  let args: { type: any }[] = [];
 
-  let args = [];
-  if (match) {
-    args = match[1].match(/[A-z1-9]+/g).map((arg: any) => {
-      return { type: arg };
-    });
+  if (rawName) {
+    const match = signature.match(
+      new RegExp(rawName[1] + '\\(+([a-z1-9,()]+)\\)')
+    );
+
+    if (match?.[1]) {
+      const argsMatch = match[1].match(/[A-z1-9]+/g);
+      if (argsMatch) {
+        args = argsMatch.map((arg: any) => {
+          return { type: arg };
+        });
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We changed the transactions list screen to use our metadata backend service in https://github.com/rainbow-me/rainbow/pull/2990, this PR extends the usage to the WC transaction confirmation screen. Still use the on-chain registry as a fallback, but should be rare to hit unless the backend is down/times out, backend also hits the on chain registry. This will allow us to more tightly control poor user experiences like this one:

![image](https://user-images.githubusercontent.com/98344978/176225271-45178a21-9359-4a84-9cf3-ec74d7a6f0a5.png)

## PoW (screenshots / screen recordings)
Tested manually, no UI change.

## Dev checklist for QA: what to test
Check that the function name on the WC confirmation screen is present. For some reason I can't always trigger the resolution, maybe sometimes the data passed in https://github.com/rainbow-me/rainbow/blob/68c2af6a019442bf3fe663eea723f321423bf763/src/screens/TransactionConfirmationScreen.js#L328 is empty? Not sure why. 