### PR TITLE
swaps: flipping behavior changes

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -111,6 +111,7 @@ export { default as useSwapInputHandlers } from './useSwapInputHandlers';
 export { default as useSwapIsSufficientBalance } from './useSwapIsSufficientBalance';
 export { default as useSwapSettings } from './useSwapSettings';
 export { default as useSwapDerivedOutputs } from './useSwapDerivedOutputs';
+export { default as useSwapDerivedValues } from './useSwapDerivedValues';
 export { default as useTimeout } from './useTimeout';
 export { default as useTopMovers } from './useTopMovers';
 export { default as useTransactionConfirmation } from './useTransactionConfirmation';

--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -13,6 +13,7 @@ import {
 import { updatePrecisionToDisplay } from '@rainbow-me/helpers/utilities';
 import { useSwapCurrencies, useSwapDerivedValues } from '@rainbow-me/hooks';
 import { Navigation, useNavigation } from '@rainbow-me/navigation';
+import { emitAssetRequest } from '@rainbow-me/redux/explorer';
 import {
   flipSwapCurrencies,
   updateSwapDepositCurrency,
@@ -178,6 +179,13 @@ export default function useSwapCurrencyHandlers({
           }
         : null;
 
+      const updateCurrency = () => {
+        dispatch(emitAssetRequest(newInputCurrency.mainnet_address));
+        dispatch(updateSwapInputCurrency(newInputCurrency));
+        setLastFocusedInputHandle?.(inputFieldRef);
+        handleNavigate?.(newInputCurrency);
+      };
+
       if (
         outputCurrency &&
         newInputCurrency?.type !== outputCurrency?.type &&
@@ -193,9 +201,7 @@ export default function useSwapCurrencyHandlers({
               InteractionManager.runAfterInteractions(() => {
                 setTimeout(() => {
                   setHasShownWarning();
-                  dispatch(updateSwapInputCurrency(newInputCurrency));
-                  setLastFocusedInputHandle?.(inputFieldRef);
-                  handleNavigate?.(newInputCurrency);
+                  updateCurrency();
                 }, 250);
               });
             },
@@ -203,9 +209,7 @@ export default function useSwapCurrencyHandlers({
           });
         });
       } else {
-        dispatch(updateSwapInputCurrency(newInputCurrency));
-        setLastFocusedInputHandle?.(inputFieldRef);
-        handleNavigate?.(newInputCurrency);
+        updateCurrency();
       }
     },
     [dispatch, inputFieldRef, outputCurrency, setLastFocusedInputHandle]
@@ -219,6 +223,12 @@ export default function useSwapCurrencyHandlers({
             type: outputCurrency?.type ?? AssetType.token,
           }
         : null;
+      const updateCurrency = () => {
+        dispatch(emitAssetRequest(newOutputCurrency.mainnet_address));
+        dispatch(updateSwapOutputCurrency(newOutputCurrency));
+        setLastFocusedInputHandle?.(inputFieldRef);
+        handleNavigate?.(newOutputCurrency);
+      };
       if (
         inputCurrency &&
         newOutputCurrency?.type !== inputCurrency?.type &&
@@ -234,9 +244,7 @@ export default function useSwapCurrencyHandlers({
               InteractionManager.runAfterInteractions(() => {
                 setTimeout(() => {
                   setHasShownWarning();
-                  dispatch(updateSwapOutputCurrency(newOutputCurrency));
-                  setLastFocusedInputHandle?.(inputFieldRef);
-                  handleNavigate?.(newOutputCurrency);
+                  updateCurrency();
                 }, 250);
               });
             },
@@ -244,9 +252,7 @@ export default function useSwapCurrencyHandlers({
           });
         });
       } else {
-        dispatch(updateSwapOutputCurrency(newOutputCurrency));
-        setLastFocusedInputHandle?.(inputFieldRef);
-        handleNavigate?.(newOutputCurrency);
+        updateCurrency();
       }
     },
     [dispatch, inputCurrency, inputFieldRef, setLastFocusedInputHandle]

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -332,6 +332,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   useEffect(() => {
     const getTradeDetails = async () => {
       let tradeDetails = null;
+      // let tradeIndependentValue = independentValue;
 
       if (independentValue === '0.') {
         switch (independentField) {

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -332,7 +332,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   useEffect(() => {
     const getTradeDetails = async () => {
       let tradeDetails = null;
-      // let tradeIndependentValue = independentValue;
 
       if (independentValue === '0.') {
         switch (independentField) {

--- a/src/hooks/useSwapDerivedValues.ts
+++ b/src/hooks/useSwapDerivedValues.ts
@@ -1,0 +1,13 @@
+import { useSelector } from 'react-redux';
+import { AppState } from '@rainbow-me/redux/store';
+import { SwapModalField } from '@rainbow-me/redux/swap';
+
+export default function useSwapCurrencies() {
+  const derivedValues: { [key in SwapModalField]: string | null } = useSelector(
+    (state: AppState) => state.swap.derivedValues
+  );
+
+  return {
+    derivedValues,
+  };
+}

--- a/src/hooks/useSwapDerivedValues.ts
+++ b/src/hooks/useSwapDerivedValues.ts
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import { AppState } from '@rainbow-me/redux/store';
 import { SwapModalField } from '@rainbow-me/redux/swap';
 
-export default function useSwapCurrencies() {
+export default function useSwapDerivedValues() {
   const derivedValues: { [key in SwapModalField]: string | null } = useSelector(
     (state: AppState) => state.swap.derivedValues
   );

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -138,7 +138,7 @@ export const updateSwapInputCurrency = (
     newInputCurrency?.address === outputCurrency?.address &&
     newInputCurrency
   ) {
-    dispatch(flipSwapCurrencies());
+    dispatch(flipSwapCurrencies(false));
   } else {
     dispatch({ payload: newInputCurrency, type: SWAP_UPDATE_INPUT_CURRENCY });
     if (
@@ -200,16 +200,17 @@ export const updateSwapOutputCurrency = (
   }
 };
 
-export const flipSwapCurrencies = (outputIndependentField?: Boolean) => (
-  dispatch: AppDispatch,
-  getState: AppGetState
-) => {
+export const flipSwapCurrencies = (
+  outputIndependentField: Boolean,
+  independentValue?: string | null
+) => (dispatch: AppDispatch, getState: AppGetState) => {
   const { inputCurrency, outputCurrency } = getState().swap;
   dispatch({
     payload: {
       independentField: outputIndependentField
         ? SwapModalField.output
         : SwapModalField.input,
+      independentValue,
       newInputCurrency: outputCurrency,
       newOutputCurrency: inputCurrency,
     },
@@ -308,6 +309,8 @@ export default (state = INITIAL_STATE, action: AnyAction) => {
       return {
         ...state,
         independentField: action.payload.independentField,
+        independentValue:
+          action.payload.independentValue ?? state.independentValue,
         inputCurrency: action.payload.newInputCurrency,
         outputCurrency: action.payload.newOutputCurrency,
       };

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -248,6 +248,7 @@ export default function ExchangeModal({
     ignoreInitialTypeCheck,
     inputFieldRef,
     lastFocusedInputHandle,
+    nativeFieldRef,
     outputFieldRef,
     setLastFocusedInputHandle,
     title,


### PR DESCRIPTION
Fixes TEAM2-200
Fixes TEAM2-185

## What changed (plus any additional context for devs)

- TEAM2-200: native values in L2s weren't always returning, i'm adding https://github.com/rainbow-me/rainbow/compare/%40bruno/rainbow-swaps...%40esteban/flipping-behavior?expand=1#diff-1e8dc0a8297e67895c041ebe3ad9c31b8464c49c22ed70d9f3a71e2ccf011f4cR183 which is the same that we have in the discover search for tokens, so we get the mainnet asset to fallback to
- TEAM2-185 arbitrum flipping as ticket describes
- we have a bug with no ticket. Pressing flip when the native input is focused, the flip would put the native input value in as the output value


## PoW (screenshots / screen recordings)


https://user-images.githubusercontent.com/12115171/176258474-d4839f36-d5b4-4e2a-b666-db04bef9606b.mp4



## Dev checklist for QA: what to test

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
