### PR TITLE
fix swap/savings rap types

### DIFF
--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -35,7 +35,6 @@ import {
   estimateENSSetNameGasLimit,
   estimateENSSetRecordsGasLimit,
 } from '@rainbow-me/handlers/ens';
-import ExchangeModalTypes from '@rainbow-me/helpers/exchangeModalTypes';
 import logger from 'logger';
 
 const {
@@ -165,9 +164,9 @@ const createSwapRapByType = (
   swapParameters: SwapActionParameters
 ) => {
   switch (type) {
-    case ExchangeModalTypes.deposit:
+    case RapActionTypes.depositCompound:
       return createSwapAndDepositCompoundRap(swapParameters);
-    case ExchangeModalTypes.withdrawal:
+    case RapActionTypes.withdrawCompound:
       return createWithdrawFromCompoundRap(swapParameters);
     default:
       return createUnlockAndSwapRap(swapParameters);
@@ -198,11 +197,11 @@ export const getSwapRapEstimationByType = (
   swapParameters: SwapActionParameters
 ) => {
   switch (type) {
-    case ExchangeModalTypes.deposit:
+    case RapActionTypes.depositCompound:
       return estimateSwapAndDepositCompound(swapParameters);
-    case ExchangeModalTypes.swap:
+    case RapActionTypes.swap:
       return estimateUnlockAndSwap(swapParameters);
-    case ExchangeModalTypes.withdrawal:
+    case RapActionTypes.withdrawCompound:
       return estimateWithdrawFromCompound();
     default:
       return null;

--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -35,6 +35,7 @@ import {
   estimateENSSetNameGasLimit,
   estimateENSSetRecordsGasLimit,
 } from '@rainbow-me/handlers/ens';
+import { ExchangeModalTypes } from '@rainbow-me/helpers';
 import logger from 'logger';
 
 const {
@@ -157,6 +158,18 @@ export const RapActionTypes = {
   swap: 'swap' as RapActionType,
   unlock: 'unlock' as RapActionType,
   withdrawCompound: 'withdrawCompound' as RapActionType,
+};
+
+export const getSwapRapTypeByExchangeType = (type: string) => {
+  switch (type) {
+    case ExchangeModalTypes.withdrawal:
+      return RapActionTypes.withdrawCompound;
+    case ExchangeModalTypes.deposit:
+      return RapActionTypes.depositCompound;
+
+    default:
+      return RapActionTypes.swap;
+  }
 };
 
 const createSwapRapByType = (

--- a/src/raps/index.ts
+++ b/src/raps/index.ts
@@ -7,7 +7,11 @@ export {
   estimateWithdrawFromCompound,
   createWithdrawFromCompoundRap,
 } from './withdrawFromCompound';
-export { executeRap, getSwapRapEstimationByType } from './common';
+export {
+  executeRap,
+  getSwapRapEstimationByType,
+  getSwapRapTypeByExchangeType,
+} from './common';
 export {
   createRegisterENSRap,
   createCommitENSRap,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -33,6 +33,7 @@ import {
 import { FloatingPanel } from '../components/floating-panels';
 import { GasSpeedButton } from '../components/gas';
 import { Centered, KeyboardFixedOpenLayout } from '../components/layout';
+import { RapActionTypes } from '../raps/common';
 import { ExchangeModalTypes, isKeyboardOpen } from '@rainbow-me/helpers';
 import { divide, greaterThan, multiply } from '@rainbow-me/helpers/utilities';
 import {
@@ -259,7 +260,22 @@ export default function ExchangeModal({
         outputAmount,
         tradeDetails,
       };
-      const gasLimit = await getSwapRapEstimationByType(type, swapParameters);
+      let rapType = type;
+      switch (type) {
+        case ExchangeModalTypes.withdrawal:
+          rapType = RapActionTypes.withdrawCompound;
+          break;
+        case ExchangeModalTypes.deposit:
+          rapType = RapActionTypes.depositCompound;
+          break;
+        default:
+          rapType = RapActionTypes.swap;
+          break;
+      }
+      const gasLimit = await getSwapRapEstimationByType(
+        rapType,
+        swapParameters
+      );
       if (gasLimit) {
         updateTxFee(gasLimit);
       }
@@ -420,7 +436,19 @@ export default function ExchangeModal({
         outputAmount,
         tradeDetails,
       };
-      await executeRap(wallet, type, swapParameters, callback);
+      let rapType = type;
+      switch (type) {
+        case ExchangeModalTypes.withdrawal:
+          rapType = RapActionTypes.withdrawCompound;
+          break;
+        case ExchangeModalTypes.deposit:
+          rapType = RapActionTypes.depositCompound;
+          break;
+        default:
+          rapType = RapActionTypes.swap;
+          break;
+      }
+      await executeRap(wallet, rapType, swapParameters, callback);
       logger.log('[exchange - handle submit] executed rap!');
       analytics.track(`Completed ${type}`, {
         amountInUSD,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -33,7 +33,6 @@ import {
 import { FloatingPanel } from '../components/floating-panels';
 import { GasSpeedButton } from '../components/gas';
 import { Centered, KeyboardFixedOpenLayout } from '../components/layout';
-import { RapActionTypes } from '../raps/common';
 import { ExchangeModalTypes, isKeyboardOpen } from '@rainbow-me/helpers';
 import { divide, greaterThan, multiply } from '@rainbow-me/helpers/utilities';
 import {
@@ -52,7 +51,11 @@ import {
 } from '@rainbow-me/hooks';
 import { loadWallet } from '@rainbow-me/model/wallet';
 import { useNavigation } from '@rainbow-me/navigation';
-import { executeRap, getSwapRapEstimationByType } from '@rainbow-me/raps';
+import {
+  executeRap,
+  getSwapRapEstimationByType,
+  getSwapRapTypeByExchangeType,
+} from '@rainbow-me/raps';
 import { multicallClearState } from '@rainbow-me/redux/multicall';
 import { swapClearState, updateSwapTypeDetails } from '@rainbow-me/redux/swap';
 import { ETH_ADDRESS, ethUnits } from '@rainbow-me/references';
@@ -260,18 +263,8 @@ export default function ExchangeModal({
         outputAmount,
         tradeDetails,
       };
-      let rapType = type;
-      switch (type) {
-        case ExchangeModalTypes.withdrawal:
-          rapType = RapActionTypes.withdrawCompound;
-          break;
-        case ExchangeModalTypes.deposit:
-          rapType = RapActionTypes.depositCompound;
-          break;
-        default:
-          rapType = RapActionTypes.swap;
-          break;
-      }
+
+      const rapType = getSwapRapTypeByExchangeType(type);
       const gasLimit = await getSwapRapEstimationByType(
         rapType,
         swapParameters
@@ -436,18 +429,7 @@ export default function ExchangeModal({
         outputAmount,
         tradeDetails,
       };
-      let rapType = type;
-      switch (type) {
-        case ExchangeModalTypes.withdrawal:
-          rapType = RapActionTypes.withdrawCompound;
-          break;
-        case ExchangeModalTypes.deposit:
-          rapType = RapActionTypes.depositCompound;
-          break;
-        default:
-          rapType = RapActionTypes.swap;
-          break;
-      }
+      const rapType = getSwapRapTypeByExchangeType(type);
       await executeRap(wallet, rapType, swapParameters, callback);
       logger.log('[exchange - handle submit] executed rap!');
       analytics.track(`Completed ${type}`, {


### PR DESCRIPTION
Fixes TEAM2-202

## What changed (plus any additional context for devs)
mapping between swap modal types & rap types was not set up correctly. I added some logic to change before we submit estimations + raps since I don't want to mess with the swap modal types

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-06-28-13-30-15.mp4

## Dev checklist for QA: what to test

withdraw + savings should work now

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
