### PR TITLE
Swaps: Align swap layout to spec

### DIFF
--- a/src/components/exchange/AnimatedExchangeFloatingPanels.js
+++ b/src/components/exchange/AnimatedExchangeFloatingPanels.js
@@ -10,6 +10,8 @@ export default function AnimatedExchangeFloatingPanels(props) {
   const scrollPosition = usePagerPosition();
   const style = useAnimatedStyle(() => {
     return {
+      flexGrow: 1,
+      justifyContent: 'center',
       opacity: 1 - (scrollPosition.value || 0),
       transform: [
         { scale: 1 - scrollPosition.value / 10 },

--- a/src/components/exchange/ExchangeFloatingPanels.js
+++ b/src/components/exchange/ExchangeFloatingPanels.js
@@ -1,18 +1,15 @@
 import React from 'react';
 import { Column } from '../layout';
 
-const ExchangeFloatingPanels = React.forwardRef(
-  ({ paddingTop = 24, ...props }, ref) => (
-    <Column
-      {...props}
-      justify="center"
-      paddingTop={paddingTop}
-      pointerEvents="box-none"
-      ref={ref}
-      style={props.style}
-    />
-  )
-);
+const ExchangeFloatingPanels = React.forwardRef(({ ...props }, ref) => (
+  <Column
+    {...props}
+    justify="center"
+    pointerEvents="box-none"
+    ref={ref}
+    style={props.style}
+  />
+));
 
 ExchangeFloatingPanels.displayName = 'ExchangeFloatingPanels';
 

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -35,7 +35,7 @@ import { FloatingPanel } from '../components/floating-panels';
 import { GasSpeedButton } from '../components/gas';
 import { Column, KeyboardFixedOpenLayout } from '../components/layout';
 import { delayNext } from '../hooks/useMagicAutofocus';
-import { Box } from '@rainbow-me/design-system';
+import { Box, Row, Rows } from '@rainbow-me/design-system';
 import { AssetType } from '@rainbow-me/entities';
 import { getProviderForNetwork } from '@rainbow-me/handlers/web3';
 import {
@@ -76,16 +76,9 @@ const FloatingPanels = AnimatedExchangeFloatingPanels;
 
 const Wrapper = KeyboardFixedOpenLayout;
 
-const InnerWrapper = styled(Column).attrs(props => ({
+const InnerWrapper = styled(Column).attrs({
   direction: 'column',
-  ...(props.isSmallPhone
-    ? {
-        paddingTop: 8,
-      }
-    : {
-        justify: 'center',
-      }),
-}))({
+})({
   ...position.sizeAsObject('100%'),
 });
 
@@ -813,25 +806,32 @@ export default function ExchangeModal({
           )}
 
           {isWithdrawal && <Spacer />}
-
-          {showConfirmButton && (
-            <ConfirmExchangeButton
-              {...confirmButtonProps}
-              onPressViewDetails={loading ? NOOP : navigateToSwapDetailsModal}
-              testID={`${testID}-confirm-button`}
-            />
-          )}
         </FloatingPanels>
-        <Box bottom="0px" position="absolute" width="full">
-          <GasSpeedButton
-            asset={outputCurrency}
-            currentNetwork={currentNetwork}
-            dontBlur
-            marginBottom={0}
-            marginTop={0}
-            onCustomGasBlur={handleCustomGasBlur}
-            testID={`${testID}-gas`}
-          />
+        <Box height="content">
+          <Rows alignVertical="bottom" space="19px">
+            <Row height="content">
+              {showConfirmButton && (
+                <ConfirmExchangeButton
+                  {...confirmButtonProps}
+                  onPressViewDetails={
+                    loading ? NOOP : navigateToSwapDetailsModal
+                  }
+                  testID={`${testID}-confirm-button`}
+                />
+              )}
+            </Row>
+            <Row height="content">
+              <GasSpeedButton
+                asset={outputCurrency}
+                currentNetwork={currentNetwork}
+                dontBlur
+                marginBottom={0}
+                marginTop={0}
+                onCustomGasBlur={handleCustomGasBlur}
+                testID={`${testID}-gas`}
+              />
+            </Row>
+          </Rows>
         </Box>
       </InnerWrapper>
     </Wrapper>

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -35,7 +35,7 @@ import { FloatingPanel } from '../components/floating-panels';
 import { GasSpeedButton } from '../components/gas';
 import { Column, KeyboardFixedOpenLayout } from '../components/layout';
 import { delayNext } from '../hooks/useMagicAutofocus';
-import { Row, Rows } from '@rainbow-me/design-system';
+import { Box } from '@rainbow-me/design-system';
 import { AssetType } from '@rainbow-me/entities';
 import { getProviderForNetwork } from '@rainbow-me/handlers/web3';
 import {
@@ -76,10 +76,16 @@ const FloatingPanels = AnimatedExchangeFloatingPanels;
 
 const Wrapper = KeyboardFixedOpenLayout;
 
-const InnerWrapper = styled(Column).attrs({
+const InnerWrapper = styled(Column).attrs(props => ({
   direction: 'column',
-  justify: 'space-between',
-})({
+  ...(props.isSmallPhone
+    ? {
+        paddingTop: 8,
+      }
+    : {
+        justify: 'center',
+      }),
+}))({
   ...position.sizeAsObject('100%'),
 });
 
@@ -725,12 +731,10 @@ export default function ExchangeModal({
 
   return (
     <Wrapper keyboardType={KeyboardTypes.numpad}>
-      <InnerWrapper>
-        <FloatingPanels
-          {...((isSmallPhone || (android && isSmallAndroidPhone)) && {
-            paddingTop: 0,
-          })}
-        >
+      <InnerWrapper
+        isSmallPhone={isSmallPhone || (android && isSmallAndroidPhone)}
+      >
+        <FloatingPanels>
           <FloatingPanel
             overflow="visible"
             paddingBottom={showOutputField ? 0 : 26}
@@ -809,29 +813,26 @@ export default function ExchangeModal({
           )}
 
           {isWithdrawal && <Spacer />}
-        </FloatingPanels>
-        <Rows alignVertical="bottom" height="content" space="19px">
-          <Row height="content">
-            {showConfirmButton && (
-              <ConfirmExchangeButton
-                {...confirmButtonProps}
-                onPressViewDetails={loading ? NOOP : navigateToSwapDetailsModal}
-                testID={`${testID}-confirm-button`}
-              />
-            )}
-          </Row>
-          <Row height="content">
-            <GasSpeedButton
-              asset={outputCurrency}
-              currentNetwork={currentNetwork}
-              dontBlur
-              marginBottom={0}
-              marginTop={0}
-              onCustomGasBlur={handleCustomGasBlur}
-              testID={`${testID}-gas`}
+
+          {showConfirmButton && (
+            <ConfirmExchangeButton
+              {...confirmButtonProps}
+              onPressViewDetails={loading ? NOOP : navigateToSwapDetailsModal}
+              testID={`${testID}-confirm-button`}
             />
-          </Row>
-        </Rows>
+          )}
+        </FloatingPanels>
+        <Box bottom="0px" position="absolute" width="full">
+          <GasSpeedButton
+            asset={outputCurrency}
+            currentNetwork={currentNetwork}
+            dontBlur
+            marginBottom={0}
+            marginTop={0}
+            onCustomGasBlur={handleCustomGasBlur}
+            testID={`${testID}-gas`}
+          />
+        </Box>
       </InnerWrapper>
     </Wrapper>
   );


### PR DESCRIPTION
Fixes TEAM2-184

## What changed (plus any additional context for devs)

This PR aligns the swap screen layout to what is seen in production right now.

## PoW (screenshots / screen recordings)

### iOS

Small screens:

<img width="375" alt="Screen Shot 2022-06-29 at 12 29 02 pm" src="https://user-images.githubusercontent.com/7336481/176338497-1d3839f2-3cb2-4e1f-93db-8e819c331dab.png">

<img width="373" alt="Screen Shot 2022-06-29 at 12 29 13 pm" src="https://user-images.githubusercontent.com/7336481/176338500-ea248c12-ae84-4570-8874-5987d5c7c034.png">

Large screens: 

<img width="372" alt="Screen Shot 2022-06-29 at 12 26 14 pm" src="https://user-images.githubusercontent.com/7336481/176338442-0077df91-fdf6-47bd-9c88-2e181e58511c.png">

<img width="375" alt="Screen Shot 2022-06-29 at 12 26 21 pm" src="https://user-images.githubusercontent.com/7336481/176338453-71cbf2af-1081-42a1-8e44-94af90fe9632.png">

### Android

<img width="408" alt="Screen Shot 2022-06-29 at 12 38 04 pm" src="https://user-images.githubusercontent.com/7336481/176339228-fcac790b-b2c4-41d8-b068-7eac9c0663d1.png">

