### PR TITLE
Swaps: 

### DIFF
--- a/src/components/expanded-state/swap-settings/InputPill.js
+++ b/src/components/expanded-state/swap-settings/InputPill.js
@@ -6,7 +6,7 @@ import { Text } from '../../text';
 import styled from '@rainbow-me/styled-components';
 import { buildTextStyles, margin, padding } from '@rainbow-me/styles';
 
-const ANDROID_EXTRA_LINE_HEIGHT = 6;
+const ANDROID_EXTRA_LINE_HEIGHT = 8;
 
 const PillGradient = styled(LinearGradient).attrs(({ theme: { colors } }) => ({
   colors: colors.gradients.lightGreyTransparent,
@@ -63,7 +63,8 @@ const Label = styled(Text).attrs(() => ({
     android ? -ANDROID_EXTRA_LINE_HEIGHT : 0,
     0
   ),
-  ...(ios ? { right: 40, top: 9 } : {}),
+  ...(ios ? { right: 40 } : {}),
+  top: android ? -0.5 : 8.5,
 });
 
 function InputPill(

--- a/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
+++ b/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
@@ -122,7 +122,23 @@ export const MaxToleranceInput: React.FC<{
   return (
     <Columns alignVertical="center">
       <Stack space="10px">
-        <ButtonPressAnimation onPress={openExplainer}>
+        <ButtonPressAnimation
+          contentContainerStyle={
+            android && {
+              // bigger tap area otherwise touch events can get ignored
+              marginVertical: -10,
+              paddingVertical: 20,
+            }
+          }
+          onPress={openExplainer}
+          style={
+            ios && {
+              // bigger tap area otherwise touch events can get ignored
+              marginVertical: -20,
+              paddingVertical: 20,
+            }
+          }
+        >
           <Inline alignVertical="center" space="2px">
             <Text size="16px" weight="bold">
               {`${lang.t('exchange.slippage_tolerance')} `}

--- a/src/components/expanded-state/swap-settings/SourcePicker.js
+++ b/src/components/expanded-state/swap-settings/SourcePicker.js
@@ -83,7 +83,23 @@ export default function SourcePicker({ onSelect, currentSource }) {
   return (
     <Columns alignHorizontal="justify" alignVertical="center">
       <Column width="content">
-        <ButtonPressAnimation onPress={openExplainer}>
+        <ButtonPressAnimation
+          contentContainerStyle={
+            android && {
+              // bigger tap area otherwise touch events can get ignored
+              marginVertical: -10,
+              paddingVertical: 20,
+            }
+          }
+          onPress={openExplainer}
+          style={
+            ios && {
+              // bigger tap area otherwise touch events can get ignored
+              marginVertical: -20,
+              paddingVertical: 20,
+            }
+          }
+        >
           <Text size="16px" weight="bold">
             {lang.t('exchange.source_picker')}
             <Text color="secondary30" size="16px" weight="bold">

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -143,7 +143,23 @@ export default function SwapSettingsState({ asset }) {
             />
             {swapSupportsFlashbots && (
               <Columns alignHorizontal="justify" alignVertical="center">
-                <ButtonPressAnimation onPress={openExplainer}>
+                <ButtonPressAnimation
+                  contentContainerStyle={
+                    android && {
+                      // bigger tap area otherwise touch events can get ignored
+                      marginVertical: -10,
+                      paddingVertical: 20,
+                    }
+                  }
+                  onPress={openExplainer}
+                  style={
+                    ios && {
+                      // bigger tap area otherwise touch events can get ignored
+                      marginVertical: -20,
+                      paddingVertical: 20,
+                    }
+                  }
+                >
                   <Text color="primary" size="16px" weight="bold">
                     {lang.t('exchange.use_flashbots')}
                     <Text color="secondary30" size="16px" weight="bold">


### PR DESCRIPTION
Fixes TEAM2-177 TEAM2-169

## What changed (plus any additional context for devs)
- Added additional padding/negative margins for explainer buttons so that they're easier to tap on Android and iOS. They required specific use of `style` and `contentContainerStyle` per platform.
- Fixed `%` alignment inside slippage input on Android.

## PoW (screenshots / screen recordings)
![image](https://user-images.githubusercontent.com/6843656/176328468-2f8f241e-e844-49a9-b64f-4099dcbb3f31.png)


## Dev checklist for QA: what to test
Accessing explainers in the swap settings sheet and adjusting max slippage.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
