### PR TITLE
swaps: handle price impact warnings

### DIFF
--- a/src/components/exchange/ExchangeDetailsRow.js
+++ b/src/components/exchange/ExchangeDetailsRow.js
@@ -42,6 +42,7 @@ export default function ExchangeDetailsRow({
   isHighPriceImpact,
   onFlipCurrencies,
   onPressSettings,
+  onPressImpactWarning,
   priceImpactColor,
   priceImpactNativeAmount,
   priceImpactPercentDisplay,
@@ -107,7 +108,7 @@ export default function ExchangeDetailsRow({
     <Container {...props}>
       <PriceImpactWarning
         isHighPriceImpact={isHighPriceImpact}
-        onPress={onPressSettings}
+        onPress={onPressImpactWarning}
         pointerEvents={isHighPriceImpact ? 'auto' : 'none'}
         priceImpactColor={priceImpactColor}
         priceImpactNativeAmount={priceImpactNativeAmount}

--- a/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
+++ b/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
@@ -7,7 +7,6 @@ import React, {
   useState,
 } from 'react';
 import { Keyboard } from 'react-native';
-import { useSelector } from 'react-redux';
 import { ButtonPressAnimation } from '../../animations';
 import { Icon } from '../../icons';
 import StepButtonInput from './StepButtonInput';
@@ -25,157 +24,133 @@ import {
   greaterThan,
   toFixedDecimals,
 } from '@rainbow-me/helpers/utilities';
-import {
-  useMagicAutofocus,
-  usePriceImpactDetails,
-  useSwapCurrencies,
-  useSwapSettings,
-} from '@rainbow-me/hooks';
+import { useMagicAutofocus, useSwapSettings } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
-import { AppState } from '@rainbow-me/redux/store';
 import Routes from '@rainbow-me/routes';
+import { colors } from '@rainbow-me/styles';
 
 const convertBipsToPercent = (bips: number) => (bips / 100).toString();
 const convertPercentToBips = (percent: number) => (percent * 100).toString();
 
 const SLIPPAGE_INCREMENT = 0.1;
 
-export const MaxToleranceInput: React.FC<{
-  colorForAsset: string;
-}> = forwardRef(({ colorForAsset }, ref) => {
-  const { slippageInBips, updateSwapSlippage } = useSwapSettings();
-  const { inputCurrency, outputCurrency } = useSwapCurrencies();
-  const { navigate } = useNavigation();
+// eslint-disable-next-line react/display-name
+export const MaxToleranceInput = forwardRef(
+  ({ colorForAsset }: { colorForAsset: string }, ref) => {
+    const { slippageInBips, updateSwapSlippage } = useSwapSettings();
+    const { navigate } = useNavigation();
 
-  const [slippageValue, setSlippageValue] = useState(
-    convertBipsToPercent(slippageInBips)
-  );
+    const [slippageValue, setSlippageValue] = useState(
+      convertBipsToPercent(slippageInBips)
+    );
 
-  const { derivedValues } = useSelector((state: AppState) => state.swap);
+    const slippageRef = useRef<{ blur: () => void; focus: () => void }>(null);
 
-  const { inputAmount, outputAmount } = derivedValues ?? {
-    inputAmount: 0,
-    outputAmount: 0,
-  };
-  const slippageRef = useRef<{ blur: () => void; focus: () => void }>(null);
+    const { handleFocus } = useMagicAutofocus(slippageRef, undefined, true);
 
-  const { handleFocus } = useMagicAutofocus(slippageRef, undefined, true);
+    useImperativeHandle(ref, () => ({
+      blur: () => {
+        slippageRef?.current?.blur();
+      },
+      reset: () => {
+        onSlippageChange(1);
+      },
+    }));
 
-  useImperativeHandle(ref, () => ({
-    blur: () => {
-      slippageRef?.current?.blur();
-    },
-    reset: () => {
-      onSlippageChange(1);
-    },
-  }));
+    const updateSlippage = useCallback(
+      increment => {
+        const newSlippage = add(slippageValue, increment);
+        const newSlippageValue = toFixedDecimals(newSlippage, 2);
+        if (greaterThan(0, newSlippageValue)) return;
 
-  const {
-    isHighPriceImpact,
-    isSeverePriceImpact,
-    priceImpactColor,
-    priceImpactNativeAmount,
-  } = usePriceImpactDetails(
-    inputAmount,
-    outputAmount,
-    inputCurrency,
-    outputCurrency
-  );
+        updateSwapSlippage(convertPercentToBips(parseInt(newSlippageValue)));
+        setSlippageValue(newSlippageValue);
+      },
+      [slippageValue, updateSwapSlippage]
+    );
 
-  const updateSlippage = useCallback(
-    increment => {
-      const newSlippage = add(slippageValue, increment);
-      const newSlippageValue = toFixedDecimals(newSlippage, 2);
-      if (greaterThan(0, newSlippageValue)) return;
+    const addSlippage = useCallback(() => {
+      updateSlippage(SLIPPAGE_INCREMENT);
+    }, [updateSlippage]);
 
-      updateSwapSlippage(convertPercentToBips(parseInt(newSlippageValue)));
-      setSlippageValue(newSlippageValue);
-    },
-    [slippageValue, updateSwapSlippage]
-  );
+    const minusSlippage = useCallback(() => {
+      updateSlippage(-SLIPPAGE_INCREMENT);
+    }, [updateSlippage]);
 
-  const addSlippage = useCallback(() => {
-    updateSlippage(SLIPPAGE_INCREMENT);
-  }, [updateSlippage]);
+    const onSlippageChange = useCallback(
+      value => {
+        updateSwapSlippage(convertPercentToBips(value));
+        setSlippageValue(value);
+      },
+      [updateSwapSlippage, setSlippageValue]
+    );
 
-  const minusSlippage = useCallback(() => {
-    updateSlippage(-SLIPPAGE_INCREMENT);
-  }, [updateSlippage]);
+    const hasPriceImpact = Number(slippageValue) > 3;
+    const priceImpactColor = Number(slippageValue) > 3 ? colors.orange : null;
 
-  const onSlippageChange = useCallback(
-    value => {
-      updateSwapSlippage(convertPercentToBips(value));
-      setSlippageValue(value);
-    },
-    [updateSwapSlippage, setSlippageValue]
-  );
+    const openExplainer = () => {
+      android && Keyboard.dismiss();
+      navigate(Routes.EXPLAIN_SHEET, {
+        type: 'slippage',
+      });
+    };
 
-  const hasPriceImpact = isHighPriceImpact || isSeverePriceImpact;
-
-  const openExplainer = () => {
-    android && Keyboard.dismiss();
-    navigate(Routes.EXPLAIN_SHEET, {
-      type: 'slippage',
-    });
-  };
-
-  return (
-    <Columns alignVertical="center">
-      <Stack space="10px">
-        <ButtonPressAnimation onPress={openExplainer}>
-          <Inline alignVertical="center" space="2px">
-            <Text size="16px" weight="bold">
-              {`${lang.t('exchange.slippage_tolerance')} `}
-              {!hasPriceImpact && (
-                <Text color="secondary30" size="16px" weight="bold">
-                  {' 􀅵'}
-                </Text>
+    return (
+      <Columns alignVertical="center">
+        <Stack space="10px">
+          <ButtonPressAnimation onPress={openExplainer}>
+            <Inline alignVertical="center" space="2px">
+              <Text size="16px" weight="bold">
+                {`${lang.t('exchange.slippage_tolerance')} `}
+                {!hasPriceImpact && (
+                  <Text color="secondary30" size="16px" weight="bold">
+                    {' 􀅵'}
+                  </Text>
+                )}
+              </Text>
+              {hasPriceImpact && (
+                <Box paddingTop={android ? '2px' : '1px'}>
+                  <Icon color={priceImpactColor} name="warning" size={18} />
+                </Box>
               )}
-            </Text>
-            {hasPriceImpact && (
-              <Box paddingTop={android ? '2px' : '1px'}>
-                <Icon color={priceImpactColor} name="warning" size={18} />
-              </Box>
-            )}
-          </Inline>
-        </ButtonPressAnimation>
-        {hasPriceImpact && (
-          <Box>
-            <Text size={android ? '12px' : '14px'}>
-              <AccentColorProvider color={priceImpactColor!}>
+            </Inline>
+          </ButtonPressAnimation>
+          {hasPriceImpact && (
+            <Box>
+              <Text size={android ? '12px' : '14px'}>
+                <AccentColorProvider color={priceImpactColor!}>
+                  <Text
+                    color="accent"
+                    size={android ? '12px' : '14px'}
+                    weight="bold"
+                  >
+                    {lang.t('exchange.high')}
+                  </Text>
+                </AccentColorProvider>
                 <Text
-                  color="accent"
+                  color="secondary50"
                   size={android ? '12px' : '14px'}
                   weight="bold"
-                >
-                  {lang.t('exchange.high')}
-                </Text>
-              </AccentColorProvider>
-              <Text
-                color="secondary50"
-                size={android ? '12px' : '14px'}
-                weight="bold"
-              >{` · ${lang.t(
-                'exchange.losing'
-              )} ${priceImpactNativeAmount}`}</Text>
-            </Text>
-          </Box>
-        )}
-      </Stack>
-      <Column width="content">
-        <StepButtonInput
-          buttonColor={colorForAsset}
-          inputLabel="%"
-          inputRef={slippageRef}
-          minusAction={minusSlippage}
-          onBlur={null}
-          onChange={onSlippageChange}
-          onFocus={handleFocus}
-          plusAction={addSlippage}
-          testID="swap-slippage-input"
-          value={slippageValue}
-        />
-      </Column>
-    </Columns>
-  );
-});
+                >{` · ${lang.t('exchange.price_impact.label')}`}</Text>
+              </Text>
+            </Box>
+          )}
+        </Stack>
+        <Column width="content">
+          <StepButtonInput
+            buttonColor={colorForAsset}
+            inputLabel="%"
+            inputRef={slippageRef}
+            minusAction={minusSlippage}
+            onBlur={null}
+            onChange={onSlippageChange}
+            onFocus={handleFocus}
+            plusAction={addSlippage}
+            testID="swap-slippage-input"
+            value={slippageValue}
+          />
+        </Column>
+      </Columns>
+    );
+  }
+);

--- a/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
+++ b/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
@@ -3,6 +3,7 @@ import React, {
   forwardRef,
   useCallback,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -48,6 +49,12 @@ export const MaxToleranceInput = forwardRef(
 
     const { handleFocus } = useMagicAutofocus(slippageRef, undefined, true);
 
+    const { hasPriceImpact, priceImpactColor } = useMemo(() => {
+      const hasPriceImpact = Number(slippageValue) >= 3;
+      const priceImpactColor = hasPriceImpact ? colors.orange : null;
+      return { hasPriceImpact, priceImpactColor };
+    }, [slippageValue]);
+
     useImperativeHandle(ref, () => ({
       blur: () => {
         slippageRef?.current?.blur();
@@ -84,9 +91,6 @@ export const MaxToleranceInput = forwardRef(
       },
       [updateSwapSlippage, setSlippageValue]
     );
-
-    const hasPriceImpact = Number(slippageValue) > 3;
-    const priceImpactColor = Number(slippageValue) > 3 ? colors.orange : null;
 
     const openExplainer = () => {
       android && Keyboard.dismiss();

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -349,7 +349,8 @@
       },
       "price_impact": {
         "losing_prefix": "Losing",
-        "small_market": "Small Market"
+        "small_market": "Small Market",
+        "label": "Price impact"
       },
       "source": {
         "rainbow": "Auto",
@@ -621,7 +622,7 @@
       },
       "flashbots": {
         "text": "Flashbots protects your transactions from frontrunning and sandwich attacks which might result in you getting a worse price or your transaction failing.",
-        "title": "Flashbots", 
+        "title": "Flashbots",
         "still_curious": {
           "fragment1": "Still Curious? ",
           "fragment2": "Read more",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -350,7 +350,7 @@
       "price_impact": {
         "losing_prefix": "Losing",
         "small_market": "Small Market",
-        "label": "Price impact"
+        "label": "Possible loss"
       },
       "source": {
         "rainbow": "Auto",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -350,7 +350,8 @@
       },
       "price_impact": {
         "losing_prefix": "Losing :)",
-        "small_market": "Small Market :)"
+        "small_market": "Small Market :)",
+        "label": "Price impact :)"
       },
       "source": {
         "rainbow": "Auto :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -351,7 +351,7 @@
       "price_impact": {
         "losing_prefix": "Losing :)",
         "small_market": "Small Market :)",
-        "label": "Price impact :)"
+        "label": "Possible loss :)"
       },
       "source": {
         "rainbow": "Auto :)",

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -800,6 +800,7 @@ export default function ExchangeModal({
             <ExchangeDetailsRow
               isHighPriceImpact={isHighPriceImpact}
               onFlipCurrencies={loading ? NOOP : flipCurrencies}
+              onPressImpactWarning={navigateToSwapDetailsModal}
               onPressSettings={navigateToSwapSettingsSheet}
               priceImpactColor={priceImpactColor}
               priceImpactNativeAmount={priceImpactNativeAmount}


### PR DESCRIPTION
Fixes TEAM2-201

## What changed (plus any additional context for devs)

- small market warning now sends you to the review sheet
- settings slippage above 3% shows a warning in settings when moving it manually

## PoW (screenshots / screen recordings)


https://user-images.githubusercontent.com/12115171/176331795-61535af1-4961-4bf2-b421-dfe34571df4f.mp4



## Dev checklist for QA: what to test

- try to get the small market warning, you can make it appear typing a really big ETH amount, it should send you to the review sheet with the button disabled
- going to settings and putting a value > 3 should show a warning

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
