### PR TITLE
Restore image_thumbnail_url

### DIFF
--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -104,6 +104,7 @@ const buildEnsToken = ({
     familyName: 'ENS',
     id: tokenId,
     image_original_url: imageUrl,
+    image_thumbnail_url: lowResUrl,
     image_url: imageUrl,
     isSendable: true,
     last_sale: null,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -117,6 +117,7 @@ export const parseAccountUniqueTokens = data => {
               : collection.name,
           id: token_id,
           image_original_url: asset.image_url,
+          image_thumbnail_url: lowResUrl,
           image_url: imageUrl,
           isSendable:
             asset_contract.nft_version === '1.0' ||
@@ -195,6 +196,7 @@ export const parseAccountUniqueTokensPolygon = data => {
             : collection.name,
         id: token_id,
         image_original_url: asset.image_url,
+        image_thumbnail_url: lowResUrl,
         image_url: imageUrl,
         isSendable: false,
         lastPrice: parseLastSalePrice(asset.last_sale),
@@ -236,6 +238,7 @@ export const applyENSMetadataFallbackToToken = async token => {
     return {
       ...token,
       image_preview_url: lowResUrl,
+      image_thumbnail_url: lowResUrl,
       image_url: imageUrl,
       lowResUrl,
       name,


### PR DESCRIPTION
Fixes RNBW-3851

Regression introduced here:
https://github.com/rainbow-me/rainbow/pull/3188/files

## What changed (plus any additional context for devs)

We lost `image_thumbnail_url` in the PR done by Skylar. I restore this and used `lowResUrl` we already have and should have cached from the main screen. 

## PoW (screenshots / screen recordings)

Before:
![image](https://user-images.githubusercontent.com/25709300/176446369-a8f0b9fe-c323-40f6-89db-3ac969f63f87.png)
After:
![image](https://user-images.githubusercontent.com/25709300/176446520-9be75efc-4fed-4fcd-850d-c07d58df59e7.png)


## Dev checklist for QA: what to test

Try to send NFTs. Check if there are no those weird letters. 

