### PR TITLE
Fix swapping via exchanges alignment

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -113,9 +113,13 @@ const ExchangeIconStack = ({ protocols }) => {
   );
 };
 
-export default function SwapDetailsExchangeRow(props) {
-  const { protocols } = props;
-
+export default function SwapDetailsExchangeRow() {
+  // const { protocols } = props;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const protocols = [
+    { name: 'SushiSwap', part: 50 },
+    { name: 'UNISWAP_V2', part: 50 },
+  ];
   const steps = useMemo(() => {
     const sortedProtocols = protocols?.sort((a, b) => b.part - a.part);
     const defaultCase = {

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -185,7 +185,8 @@ export default function SwapDetailsExchangeRow(props) {
                   <Pill
                     height={20}
                     style={{
-                      top: 0,
+                      lineHeight: android && 18,
+                      top: android ? -1 : 0,
                     }}
                     textColor={defaultColor}
                   >

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -113,13 +113,9 @@ const ExchangeIconStack = ({ protocols }) => {
   );
 };
 
-export default function SwapDetailsExchangeRow() {
-  // const { protocols } = props;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const protocols = [
-    { name: 'SushiSwap', part: 50 },
-    { name: 'UNISWAP_V2', part: 50 },
-  ];
+export default function SwapDetailsExchangeRow(props) {
+  const { protocols } = props;
+
   const steps = useMemo(() => {
     const sortedProtocols = protocols?.sort((a, b) => b.part - a.part);
     const defaultCase = {

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -134,6 +134,7 @@ export default function SwapDetailsExchangeRow() {
     if (sortedProtocols.length === 1) {
       const protocol = sortedProtocols[0];
       const protocolName = parseExchangeName(protocol.name);
+
       return [
         {
           icons: [getExchangeIconUrl(protocolName)],
@@ -145,11 +146,13 @@ export default function SwapDetailsExchangeRow() {
     }
     const mappedExchanges = sortedProtocols.map(protocol => {
       const protocolName = parseExchangeName(protocol.name);
+      const part = convertAmountToPercentageDisplay(protocol.part, 0, 3, true);
+
       return {
         icons: [getExchangeIconUrl(protocolName)],
         label: capitalize(protocolName.replace('_', ' ')),
         name: protocolName,
-        part: convertAmountToPercentageDisplay(protocol.part),
+        part,
       };
     });
     return [defaultCase, ...mappedExchanges];
@@ -182,15 +185,12 @@ export default function SwapDetailsExchangeRow() {
             </Column>
             {steps?.[step]?.part && (
               <Column width="content">
-                <Bleed right={android ? '5px' : '6px'} vertical="6px">
+                <Bleed right="5px" vertical="6px">
                   <Pill
-                    height={android && 20}
-                    style={
-                      android && {
-                        lineHeight: 22,
-                        top: -1,
-                      }
-                    }
+                    height={20}
+                    style={{
+                      top: 0,
+                    }}
                     textColor={defaultColor}
                   >
                     {steps[step].part}

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -337,9 +337,15 @@ export const convertAmountToBalanceDisplay = (
 export const convertAmountToPercentageDisplay = (
   value: BigNumberish,
   decimals: number = 2,
-  buffer?: number
+  buffer?: number,
+  skipDecimals?: boolean
 ): string => {
-  const display = handleSignificantDecimals(value, decimals, buffer);
+  const display = handleSignificantDecimals(
+    value,
+    decimals,
+    buffer,
+    skipDecimals
+  );
   return `${display}%`;
 };
 


### PR DESCRIPTION
Fixes TEAM2-175

## What changed (plus any additional context for devs)

- Updated `convertAmountToPercentageDisplay` utility to support skip decimals option
- Updated margins and size of pill

## PoW (screenshots / screen recordings)

https://user-images.githubusercontent.com/296775/176491079-58336f2c-09b3-458d-9883-809f6b6acf57.mp4


## Dev checklist for QA: what to test

On the swap modal when more than one exchange is available: 
tap on the "Swapping via" row

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
