### PR TITLE
swaps - auto adjust max for native assets

### DIFF
--- a/e2e/swapSheetFlow.spec.js
+++ b/e2e/swapSheetFlow.spec.js
@@ -81,10 +81,6 @@ describe('Swap Sheet Interaction Flow', () => {
     await Helpers.waitAndTap('exchange-modal-input-max');
   });
 
-  it('Should display token depletion alert after tapping the Max Button', async () => {
-    await Helpers.tapAlertWithButton('No thanks');
-  });
-
   it('Should display Swap Asset List after tapping Input Section Button', async () => {
     await Helpers.waitAndTap('exchange-modal-input-selection-button');
     await Helpers.checkIfVisible('currency-select-list');

--- a/src/hooks/useSwapInputHandlers.ts
+++ b/src/hooks/useSwapInputHandlers.ts
@@ -54,24 +54,7 @@ export default function useSwapInputHandlers() {
         );
 
         if (greaterThan(newAmountMinusFee, 0)) {
-          Alert({
-            buttons: [
-              {
-                style: 'cancel',
-                text: lang.t('expanded_state.swap.swap_max_alert.no_thanks'),
-              },
-              {
-                onPress: () => {
-                  dispatch(updateSwapInputAmount(newAmountMinusFee));
-                },
-                text: lang.t('expanded_state.swap.swap_max_alert.auto_adjust'),
-              },
-            ],
-            message: lang.t('expanded_state.swap.swap_max_alert.message', {
-              inputCurrencyAddress: inputCurrencyAddress.toUpperCase(),
-            }),
-            title: lang.t('expanded_state.swap.swap_max_alert.title'),
-          });
+          dispatch(updateSwapInputAmount(newAmountMinusFee));
         } else {
           Alert({
             message: lang.t(

--- a/src/hooks/useSwapInputHandlers.ts
+++ b/src/hooks/useSwapInputHandlers.ts
@@ -2,6 +2,7 @@ import lang from 'i18n-js';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert } from '../components/alerts';
+import { isNativeAsset } from '@rainbow-me/handlers/assets';
 import { ExchangeModalTypes } from '@rainbow-me/helpers';
 import {
   greaterThan,
@@ -16,7 +17,6 @@ import {
   updateSwapNativeAmount,
   updateSwapOutputAmount,
 } from '@rainbow-me/redux/swap';
-import { ETH_ADDRESS } from '@rainbow-me/references';
 import { ethereumUtils } from '@rainbow-me/utils';
 
 export default function useSwapInputHandlers() {
@@ -36,13 +36,20 @@ export default function useSwapInputHandlers() {
   const updateMaxInputAmount = useCallback(() => {
     const inputCurrencyAddress = inputCurrency?.address;
     const inputCurrencyUniqueId = inputCurrency?.uniqueId;
+    const inputCurrencyNetwork = ethereumUtils.getNetworkFromType(
+      inputCurrency?.type
+    );
+
     if (type === ExchangeModalTypes.withdrawal) {
       dispatch(updateSwapInputAmount(supplyBalanceUnderlying, true));
     } else {
       const accountAsset = ethereumUtils.getAccountAsset(inputCurrencyUniqueId);
       const oldAmount = accountAsset?.balance?.amount ?? '0';
       let newAmount = oldAmount;
-      if (inputCurrencyAddress === ETH_ADDRESS && accountAsset) {
+      if (
+        isNativeAsset(inputCurrencyAddress, inputCurrencyNetwork) &&
+        accountAsset
+      ) {
         newAmount = toFixedDecimals(
           ethereumUtils.getBalanceAmount(selectedGasFee, accountAsset),
           6
@@ -74,6 +81,7 @@ export default function useSwapInputHandlers() {
   }, [
     dispatch,
     inputCurrency?.address,
+    inputCurrency?.type,
     inputCurrency?.uniqueId,
     selectedGasFee,
     supplyBalanceUnderlying,


### PR DESCRIPTION
Fixes TEAM2-209

## What changed (plus any additional context for devs)
we removed the alert and auto adjust automagically, I also added support for all native assets instead of just for mainnet

## PoW (screenshots / screen recordings)
https://cloud.skylarbarrera.com/Screen-Recording-2022-06-29-15-01-20.mp4

## Dev checklist for QA: what to test
auto adjusting should work on all networks 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
