### PR TITLE
Guard analytics track with if to send perofrmance events only from prod apps

### DIFF
--- a/src/performance/tracking/index.ts
+++ b/src/performance/tracking/index.ts
@@ -1,6 +1,6 @@
 import analytics from '@segment/analytics-react-native';
 // @ts-ignore
-import { SENTRY_ENVIRONMENT } from 'react-native-dotenv';
+import { IS_TESTING, SENTRY_ENVIRONMENT } from 'react-native-dotenv';
 import { PerformanceMetricData } from './types/PerformanceMetricData';
 import { PerformanceMetricsType } from './types/PerformanceMetrics';
 import { PerformanceTagsType } from './types/PerformanceTags';
@@ -10,6 +10,8 @@ If we make breaking changes we will be able to take it into consideration when d
  */
 const performanceTrackingVersion = 1;
 const shouldLogToConsole = __DEV__ || SENTRY_ENVIRONMENT === 'LocalRelease';
+const shouldReportMeasurement =
+  !IS_TESTING && !__DEV__ && SENTRY_ENVIRONMENT !== 'LocalRelease';
 const logTag = '[PERFORMANCE]: ';
 
 function logDurationIfAppropriate(
@@ -48,11 +50,13 @@ function logDirectly(
   additionalParams?: AdditionalParams
 ) {
   logDurationIfAppropriate(metric, durationInMs);
-  analytics.track(metric, {
-    durationInMs,
-    performanceTrackingVersion,
-    ...additionalParams,
-  });
+  if (shouldReportMeasurement) {
+    analytics.track(metric, {
+      durationInMs,
+      performanceTrackingVersion,
+      ...additionalParams,
+    });
+  }
 }
 
 /**
@@ -97,12 +101,14 @@ function finishMeasuring(
   const finishTime = performance.now();
   const durationInMs = finishTime - savedEntry.startTimestamp;
 
-  analytics.track(metric, {
-    durationInMs,
-    performanceTrackingVersion,
-    ...savedEntry.additionalParams,
-    ...additionalParams,
-  });
+  if (shouldReportMeasurement) {
+    analytics.track(metric, {
+      durationInMs,
+      performanceTrackingVersion,
+      ...savedEntry.additionalParams,
+      ...additionalParams,
+    });
+  }
   logDurationIfAppropriate(metric, durationInMs);
   currentlyTrackedMetrics.delete(metric);
   return true;
@@ -136,11 +142,13 @@ export function withPerformanceTracking<Fn extends (...args: any[]) => any>(
 
     const durationInMs = performance.now() - startTime;
     logDurationIfAppropriate(metric, durationInMs);
-    analytics.track(metric, {
-      durationInMs,
-      performanceTrackingVersion,
-      ...additionalParams,
-    });
+    if (shouldReportMeasurement) {
+      analytics.track(metric, {
+        durationInMs,
+        performanceTrackingVersion,
+        ...additionalParams,
+      });
+    }
 
     return res;
   };


### PR DESCRIPTION
Fixes RNBW-3913

## What changed (plus any additional context for devs)

* Added a flag to track performance metrics only in prod apps

## Dev checklist for QA: what to test
* Check the code

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
