### PR TITLE
swaps: fix NaN rainbow fee

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsFeeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsFeeRow.js
@@ -17,14 +17,15 @@ export default function SwapDetailsUniswapRow(tradeDetails) {
     tradeDetails
   );
 
-  const rainbowFeeNativeDisplay = convertAmountToNativeDisplay(
-    rainbowFeeNative,
-    nativeCurrency
-  );
+  const rainbowFeeNativeDisplay =
+    rainbowFeeNative &&
+    convertAmountToNativeDisplay(rainbowFeeNative, nativeCurrency);
   const rainbowFeePercentageDisplay = convertAmountToPercentageDisplayWithThreshold(
     rainbowFeePercentage
   );
-  const steps = [rainbowFeeNativeDisplay, rainbowFeePercentageDisplay];
+  const steps = rainbowFeeNativeDisplay
+    ? [rainbowFeeNativeDisplay, rainbowFeePercentageDisplay]
+    : [rainbowFeePercentageDisplay];
   const [step, nextStep] = useStepper(steps.length);
 
   const handleLabelPress = useCallback(() => {


### PR DESCRIPTION
Fixes RNBW-####

## What changed (plus any additional context for devs)

sometimes the rainbow fee fiat value that we display in review sheet is `$NaN`, this is happening because `inputCurrency?.price && tradeDetails.sellAmount` in `useRainbowFee` if false so we default returning a `null` value, making  `rainbowFeeNativeDisplay` to be `$NaN`

in this PR i'm ignoring this case, since we don't know the native value so we'll only show the % rainbow fee
 
## PoW (screenshots / screen recordings)

before 
https://user-images.githubusercontent.com/12115171/176714575-15503538-821e-4e5c-a6ba-b8bc6a0b2da8.mp4

after

https://user-images.githubusercontent.com/12115171/176714759-4cc7658e-8694-41bc-9c63-0cca2f58695f.mp4

## Dev checklist for QA: what to test

- follow the video
- i've seen this in polygon tokens but doesn't always happen

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
