### PR TITLE
[TEAM2-198][TEAM2-212] Favorite duplicates when searching for an address / Deprecate Imported category in Swap search

### DIFF
--- a/e2e/swapSheetFlow.spec.js
+++ b/e2e/swapSheetFlow.spec.js
@@ -297,8 +297,8 @@ describe('Swap Sheet Interaction Flow', () => {
 
   it('Should show Swap Settings State on Settings Button press', async () => {
     await Helpers.waitAndTap('exchange-settings-button');
-    await Helpers.checkIfVisible('swap-settings-container');
-    await Helpers.swipe('swap-settings-container', 'down', 'slow');
+    await Helpers.checkIfVisible('swap-settings-header');
+    await Helpers.swipe('swap-settings-header', 'down', 'slow');
   });
 
   it('Should show Insufficient Funds on input greater than balance', async () => {

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -6,12 +6,7 @@ import { darkModeThemeColors } from '../../styles/colors';
 import { HoldToAuthorizeButton } from '../buttons';
 import { Box, Row, Rows } from '@rainbow-me/design-system';
 import { ExchangeModalTypes, NetworkTypes } from '@rainbow-me/helpers';
-import {
-  useColorForAsset,
-  useGas,
-  useSwapCurrencies,
-  useSwapIsSufficientBalance,
-} from '@rainbow-me/hooks';
+import { useColorForAsset, useGas, useSwapCurrencies } from '@rainbow-me/hooks';
 import { ETH_ADDRESS } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 import { lightModeThemeColors } from '@rainbow-me/styles';
@@ -21,7 +16,6 @@ export default function ConfirmExchangeButton({
   currentNetwork,
   disabled,
   loading,
-  inputAmount,
   isHighPriceImpact,
   insufficientLiquidity,
   onPressViewDetails,
@@ -29,9 +23,9 @@ export default function ConfirmExchangeButton({
   testID,
   tradeDetails,
   type = ExchangeModalTypes.swap,
+  isSufficientBalance,
   ...props
 }) {
-  const isSufficientBalance = useSwapIsSufficientBalance(inputAmount);
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
   const asset = outputCurrency ?? inputCurrency;
   const { isSufficientGas, isValidGas } = useGas();

--- a/src/components/exchange/PriceImpactWarning.js
+++ b/src/components/exchange/PriceImpactWarning.js
@@ -2,17 +2,10 @@ import lang from 'i18n-js';
 import React from 'react';
 import Animated from 'react-native-reanimated';
 import { ButtonPressAnimation } from '../animations';
-import { Centered } from '../layout';
 import { Text } from '../text';
+import { Box, Inline } from '@rainbow-me/design-system';
 import styled from '@rainbow-me/styled-components';
-import { padding, position } from '@rainbow-me/styles';
-
-const Content = styled(Centered).attrs({
-  shrink: 0,
-})({
-  ...padding.object(android ? 14 : 19),
-  width: '100%',
-});
+import { position } from '@rainbow-me/styles';
 
 const Label = styled(Text).attrs(
   ({
@@ -41,18 +34,20 @@ export default function PriceImpactWarning({
     <Animated.View {...props} style={[style, position.coverAsObject]}>
       {isHighPriceImpact && (
         <ButtonPressAnimation onPress={onPress} scaleTo={0.94}>
-          <Content>
-            <Label color={priceImpactColor}>{`􀇿 `}</Label>
-            <Label color="whiteLabel">
-              {lang.t('exchange.price_impact.small_market')}
-            </Label>
-            <Label color={priceImpactColor}>{` • ${lang.t(
-              'exchange.price_impact.losing_prefix'
-            )} `}</Label>
-            <Label color={priceImpactColor} letterSpacing="roundedTight">
-              {headingValue}
-            </Label>
-          </Content>
+          <Box paddingHorizontal="19px" paddingTop="19px">
+            <Inline alignHorizontal="center">
+              <Label color={priceImpactColor}>{`􀇿 `}</Label>
+              <Label color="whiteLabel">
+                {lang.t('exchange.price_impact.small_market')}
+              </Label>
+              <Label color={priceImpactColor}>{` • ${lang.t(
+                'exchange.price_impact.losing_prefix'
+              )} `}</Label>
+              <Label color={priceImpactColor} letterSpacing="roundedTight">
+                {headingValue}
+              </Label>
+            </Inline>
+          </Box>
         </ButtonPressAnimation>
       )}
     </Animated.View>

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -131,7 +131,7 @@ export default function SwapSettingsState({ asset }) {
       testID="swap-settings-state"
     >
       <FloatingPanel radius={android ? 30 : 39} testID="swap-settings">
-        <ExchangeHeader />
+        <ExchangeHeader testID="swap-settings" />
         <Inset bottom="24px" horizontal="24px" top="10px">
           <Stack backgroundColor="body" space="24px">
             <Text align="center" color="primary" size="18px" weight="bold">

--- a/src/helpers/tokenSectionTypes.ts
+++ b/src/helpers/tokenSectionTypes.ts
@@ -1,6 +1,5 @@
 export default {
   favoriteTokenSection: '􀋃 Favorites',
-  importedTokenSection: '􀈄 Imported',
   lowLiquidityTokenSection: '􀇿 Low Liquidity',
   unverifiedTokenSection: '􀇿 Unverified',
   verifiedTokenSection: '􀇻 Rainbow Verified',

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -306,7 +306,7 @@ const useSwapCurrencyList = (
           verifiedAssetsWithImport = [importedAsset, ...verifiedAssets];
         } else {
           if (
-            highLiquidityAddresses.includes(
+            !highLiquidityAddresses.includes(
               importedAsset?.address.toLowerCase()
             )
           ) {

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -285,18 +285,25 @@ const useSwapCurrencyList = (
       const importedAsset = importedAssets?.[0];
       let verifiedAssetsWithImport = verifiedAssets;
       let highLiquidityAssetsWithImport = highLiquidityAssets;
+      let lowLiquidityAssetsWithoutImport = lowLiquidityAssets;
       const verifiedAddresses = verifiedAssets.map(({ address }) =>
         address.toLowerCase()
       );
       const highLiquidityAddresses = verifiedAssets.map(({ address }) =>
         address.toLowerCase()
       );
+      // this conditional prevents the imported token from jumping
+      // sections if verified/highliquidity search responds later
+      // than the contract checker in getImportedAsset
       if (importedAsset && !isFavorite(importedAsset?.address)) {
+        lowLiquidityAssetsWithoutImport = lowLiquidityAssets.filter(
+          ({ address }) => address.toLowerCase() !== importedAsset?.address
+        );
         if (
           importedAsset?.isVerified &&
           !verifiedAddresses.includes(importedAsset?.address.toLowerCase())
         ) {
-          verifiedAssetsWithImport = [...verifiedAssets, importedAsset];
+          verifiedAssetsWithImport = [importedAsset, ...verifiedAssets];
         } else {
           if (
             highLiquidityAddresses.includes(
@@ -304,8 +311,8 @@ const useSwapCurrencyList = (
             )
           ) {
             highLiquidityAssetsWithImport = [
-              ...highLiquidityAssets,
               importedAsset,
+              ...highLiquidityAssets,
             ];
           }
         }
@@ -335,7 +342,7 @@ const useSwapCurrencyList = (
       }
       if (lowLiquidityAssets?.length) {
         list.push({
-          data: lowLiquidityAssets,
+          data: lowLiquidityAssetsWithoutImport,
           key: 'lowLiqudiity',
           title: tokenSectionTypes.lowLiquidityTokenSection,
         });

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -300,7 +300,7 @@ export default function ExchangeModal({
   const isSufficientBalance = useSwapIsSufficientBalance(inputAmount);
 
   const {
-    isHighPriceImpact: useIsHighPriceImpact,
+    isHighPriceImpact,
     outputPriceValue,
     priceImpactColor,
     priceImpactNativeAmount,
@@ -313,7 +313,7 @@ export default function ExchangeModal({
     currentNetwork,
     loading
   );
-  const [isHighPriceImpact] = useDebounce(useIsHighPriceImpact, 500);
+  const [debouncedIsHighPriceImpact] = useDebounce(isHighPriceImpact, 500);
   const swapSupportsFlashbots = currentNetwork === Network.mainnet;
   const flashbots = swapSupportsFlashbots && flashbotsEnabled;
 
@@ -517,7 +517,7 @@ export default function ExchangeModal({
       analytics.track(`Submitted ${type}`, {
         amountInUSD,
         defaultInputAsset: defaultInputAsset?.symbol ?? '',
-        isHighPriceImpact,
+        isHighPriceImpact: debouncedIsHighPriceImpact,
         name: outputCurrency?.name ?? '',
         priceImpact: priceImpactPercentDisplay,
         symbol: outputCurrency?.symbol || '',
@@ -588,7 +588,7 @@ export default function ExchangeModal({
     getNextNonce,
     inputAmount,
     inputCurrency?.address,
-    isHighPriceImpact,
+    debouncedIsHighPriceImpact,
     nativeAmount,
     nativeCurrency,
     navigate,
@@ -613,7 +613,7 @@ export default function ExchangeModal({
       inputAmount,
       insufficientLiquidity,
       isAuthorizing,
-      isHighPriceImpact,
+      isHighPriceImpact: debouncedIsHighPriceImpact,
       isSufficientBalance,
       loading,
       onSubmit: handleSubmit,
@@ -626,7 +626,7 @@ export default function ExchangeModal({
       handleSubmit,
       inputAmount,
       isAuthorizing,
-      isHighPriceImpact,
+      debouncedIsHighPriceImpact,
       testID,
       tradeDetails,
       type,
@@ -799,7 +799,7 @@ export default function ExchangeModal({
             <DepositInfo
               amount={(inputAmount > 0 && outputAmount) || null}
               asset={outputCurrency}
-              isHighPriceImpact={isHighPriceImpact}
+              isHighPriceImpact={debouncedIsHighPriceImpact}
               onPress={navigateToSwapDetailsModal}
               priceImpactColor={priceImpactColor}
               priceImpactNativeAmount={priceImpactNativeAmount}
@@ -812,7 +812,7 @@ export default function ExchangeModal({
               isHighPriceImpact={
                 !confirmButtonProps.disabled &&
                 !confirmButtonProps.loading &&
-                isHighPriceImpact &&
+                debouncedIsHighPriceImpact &&
                 isSufficientBalance
               }
               onFlipCurrencies={loading ? NOOP : flipCurrencies}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
If a user imports a mainnet token by entering an address, the token data will either be replaced by its duplicate in the verified section or will appear in the unverified section. The imported section has been removed.

## PoW (screenshots / screen recordings)
Favorited + Verified + Imported behavior:
<img width="359" alt="Screen Shot 2022-07-01 at 5 26 01 AM" src="https://user-images.githubusercontent.com/14877580/176867509-27a4b3ee-4611-479b-9fb9-58a7af75d882.png">
Verified + Imported Behavior:
<img width="360" alt="Screen Shot 2022-07-01 at 5 27 47 AM" src="https://user-images.githubusercontent.com/14877580/176867648-2189df12-d32d-4116-8e47-69f2606824c8.png">

## Dev checklist for QA: what to test
Ensure you don't see duplicate token entries or the imported section.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
