### PR TITLE
Profiles: Fix text line break in wait one minute ENS registration state

### DIFF
--- a/src/components/ens-registration/ConfirmContent/WaitENSConfirmationContent.tsx
+++ b/src/components/ens-registration/ConfirmContent/WaitENSConfirmationContent.tsx
@@ -12,45 +12,40 @@ import {
   Text,
 } from '@rainbow-me/design-system';
 import { ENS_SECONDS_WAIT } from '@rainbow-me/helpers/ens';
-import { useDimensions } from '@rainbow-me/hooks';
 
 const WaitENSConfirmationContent = ({
   seconds,
 }: {
   seconds: number | undefined;
-}) => {
-  const { isSmallPhone } = useDimensions();
-
-  return (
-    <>
-      <Box paddingTop="24px">
-        <StepIndicator currentStep={2} steps={3} />
-      </Box>
-      <Rows alignHorizontal="center">
-        <Row>
-          <Box flexGrow={1} justifyContent="center">
-            <Inset horizontal={isSmallPhone ? '34px' : '42px'}>
-              <Stack space="34px">
-                <LargeCountdownClock
-                  initialSeconds={ENS_SECONDS_WAIT}
-                  onFinished={() => {}}
-                  seconds={seconds || ENS_SECONDS_WAIT}
-                />
-                <Stack alignHorizontal="center" space="19px">
-                  <Heading size="23px">
-                    {lang.t('profiles.confirm.wait_one_minute')}
-                  </Heading>
-                  <Text align="center" color="secondary60" weight="semibold">
-                    {lang.t('profiles.confirm.wait_one_minute_description')}
-                  </Text>
-                </Stack>
+}) => (
+  <>
+    <Box paddingTop="24px">
+      <StepIndicator currentStep={2} steps={3} />
+    </Box>
+    <Rows alignHorizontal="center">
+      <Row>
+        <Box flexGrow={1} justifyContent="center">
+          <Inset horizontal="34px">
+            <Stack space="34px">
+              <LargeCountdownClock
+                initialSeconds={ENS_SECONDS_WAIT}
+                onFinished={() => {}}
+                seconds={seconds || ENS_SECONDS_WAIT}
+              />
+              <Stack alignHorizontal="center" space="19px">
+                <Heading size="23px">
+                  {lang.t('profiles.confirm.wait_one_minute')}
+                </Heading>
+                <Text align="center" color="secondary60" weight="semibold">
+                  {lang.t('profiles.confirm.wait_one_minute_description')}
+                </Text>
               </Stack>
-            </Inset>
-          </Box>
-        </Row>
-      </Rows>
-    </>
-  );
-};
+            </Stack>
+          </Inset>
+        </Box>
+      </Row>
+    </Rows>
+  </>
+);
 
 export default WaitENSConfirmationContent;


### PR DESCRIPTION
Fixes TEAM2-97

## What changed (plus any additional context for devs)
Removed the bigger phone spacing and left only one for all phones

## PoW (screenshots / screen recordings)
iPhone SE 3rd Gen (iPhone 8)
<img width="873" alt="Screenshot 2022-07-01 at 12 52 47" src="https://user-images.githubusercontent.com/16062886/176881675-b8514674-812c-4e4f-8332-a251d9b83e30.png">

iPhone 11 (size like 12, 13 Pro etc)
<img width="556" alt="Screenshot 2022-07-01 at 12 53 29" src="https://user-images.githubusercontent.com/16062886/176881722-1c6ed8cb-3cd4-4fdf-9290-eac7c294ceaf.png">

The one it was reproduced in (X, Xs, 11 Pro)
<img width="711" alt="Screenshot 2022-07-01 at 12 53 58" src="https://user-images.githubusercontent.com/16062886/176881784-aa84a475-4f8a-4e9a-9070-6d13828cdc0b.png">

## Dev checklist for QA: what to test
* Go to ENS profiles section, try to register ENS and go to the phase where you have to wait 1 minute, check if the text is wrapped properly without hanging "do" at the very bottom line.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why – not needed
- [x] If you added new files, did you update the CODEOWNERS file?
