### PR TITLE
[TEAM2-230] Token Expanded sheet Swap entry point bugs

### DIFF
--- a/src/components/sheet/sheet-action-buttons/SwapActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SwapActionButton.js
@@ -41,10 +41,10 @@ function SwapActionButton({
           params: {
             chainId: ethereumUtils.getChainIdFromType(asset.type),
             defaultOutputAsset: asset,
-            fromDiscover: true,
             onSelectCurrency: updateInputCurrency,
             params: {
               ...params,
+              fromDiscover: true,
               ignoreInitialTypeCheck: true,
               outputAsset: asset,
             },
@@ -61,13 +61,13 @@ function SwapActionButton({
           params: {
             chainId: ethereumUtils.getChainIdFromType(asset.type),
             defaultInputAsset: asset,
-            fromDiscover: true,
             onSelectCurrency: updateOutputCurrency,
             params: {
               ...params,
+              fromDiscover: true,
               ignoreInitialTypeCheck: true,
             },
-            title: lang.t('swap.modal_types.swap'),
+            title: lang.t('swap.modal_types.receive'),
             type: CurrencySelectionTypes.output,
           },
           screen: Routes.CURRENCY_SELECT_SCREEN,

--- a/src/components/sheet/sheet-action-buttons/SwapActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SwapActionButton.js
@@ -41,10 +41,10 @@ function SwapActionButton({
           params: {
             chainId: ethereumUtils.getChainIdFromType(asset.type),
             defaultOutputAsset: asset,
+            fromDiscover: true,
             onSelectCurrency: updateInputCurrency,
             params: {
               ...params,
-              fromDiscover: true,
               ignoreInitialTypeCheck: true,
               outputAsset: asset,
             },
@@ -64,7 +64,6 @@ function SwapActionButton({
             onSelectCurrency: updateOutputCurrency,
             params: {
               ...params,
-              fromDiscover: true,
               ignoreInitialTypeCheck: true,
             },
             title: lang.t('swap.modal_types.receive'),


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Fixed location of `fromDiscover` inside `goToSwap` fn.

## PoW (screenshots / screen recordings)
https://recordit.co/LoMa9YUjLH

## Dev checklist for QA: what to test
* go to swap from wallet, switch network, the input is cleared out
* you will see Swap as header if you're choosing input and receive if choosing output
* from discover, pressing "get token" it will send you to choose output with the title Get {token} with
## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
