### PR TITLE
Profiles: fix .eth.eth issue

### DIFF
--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -161,11 +161,11 @@ export const fetchMetadata = async ({
           labelhash,
         },
       });
-      name = data.domains[0].labelName;
+      name = `${data.domains[0].labelName}.eth`;
     }
 
     const image_url = `https://metadata.ens.domains/mainnet/${contractAddress}/${tokenId}/image`;
-    return { image_url, name: `${name}.eth` };
+    return { image_url, name };
   } catch (error) {
     logger.sentry('ENS: Error getting ENS metadata', error);
     captureException(new Error('ENS: Error getting ENS metadata'));


### PR DESCRIPTION
Fixes TEAM2-235

## What changed (plus any additional context for devs)

Seems that we were adding an unnessesary `".eth"` to the cached name.