### PR TITLE
swaps: improve flipping

### DIFF
--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -62,6 +62,7 @@ export default function useSwapCurrencyHandlers({
     updateNativeAmount,
     updateOutputAmount,
   } = useSwapInputHandlers();
+
   const { defaultInputItemInWallet, defaultOutputItem } = useMemo(() => {
     if (type === ExchangeModalTypes.withdrawal) {
       return {
@@ -146,7 +147,6 @@ export default function useSwapCurrencyHandlers({
   const flipCurrencies = useCallback(() => {
     if (currentNetwork === Network.arbitrum) {
       updateOutputAmount(null);
-      updateInputAmount(null);
       flipSwapCurrenciesWithTimeout(
         nativeFieldRef.current === currentlyFocusedInput()
           ? nativeFieldRef

--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -11,7 +11,11 @@ import {
   Network,
 } from '@rainbow-me/helpers';
 import { updatePrecisionToDisplay } from '@rainbow-me/helpers/utilities';
-import { useSwapCurrencies, useSwapDerivedValues } from '@rainbow-me/hooks';
+import {
+  useSwapCurrencies,
+  useSwapDerivedValues,
+  useSwapInputHandlers,
+} from '@rainbow-me/hooks';
 import { Navigation, useNavigation } from '@rainbow-me/navigation';
 import { emitAssetRequest } from '@rainbow-me/redux/explorer';
 import {
@@ -53,6 +57,11 @@ export default function useSwapCurrencyHandlers({
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
   const { derivedValues } = useSwapDerivedValues();
 
+  const {
+    updateInputAmount,
+    updateNativeAmount,
+    updateOutputAmount,
+  } = useSwapInputHandlers();
   const { defaultInputItemInWallet, defaultOutputItem } = useMemo(() => {
     if (type === ExchangeModalTypes.withdrawal) {
       return {
@@ -136,8 +145,8 @@ export default function useSwapCurrencyHandlers({
 
   const flipCurrencies = useCallback(() => {
     if (currentNetwork === Network.arbitrum) {
-      outputFieldRef.current?.clear();
-      inputFieldRef.current?.clear();
+      updateOutputAmount(null);
+      updateInputAmount(null);
       flipSwapCurrenciesWithTimeout(
         nativeFieldRef.current === currentlyFocusedInput()
           ? nativeFieldRef
@@ -146,23 +155,23 @@ export default function useSwapCurrencyHandlers({
         updatePrecisionToDisplay(derivedValues?.outputAmount)
       );
     } else if (nativeFieldRef.current === currentlyFocusedInput()) {
-      inputFieldRef.current?.clear();
-      nativeFieldRef.current?.clear();
+      updateOutputAmount(null);
+      updateNativeAmount(null);
       flipSwapCurrenciesWithTimeout(
         outputFieldRef,
         true,
         updatePrecisionToDisplay(derivedValues?.inputAmount)
       );
     } else if (inputFieldRef.current === currentlyFocusedInput()) {
-      inputFieldRef.current?.clear();
-      nativeFieldRef.current?.clear();
+      updateNativeAmount(null);
+      updateInputAmount(null);
       flipSwapCurrenciesWithTimeout(
         outputFieldRef,
         true,
         updatePrecisionToDisplay(derivedValues?.inputAmount)
       );
     } else if (outputFieldRef.current === currentlyFocusedInput()) {
-      outputFieldRef.current?.clear();
+      updateOutputAmount(null);
       flipSwapCurrenciesWithTimeout(
         inputFieldRef,
         false,
@@ -174,9 +183,12 @@ export default function useSwapCurrencyHandlers({
     nativeFieldRef,
     inputFieldRef,
     outputFieldRef,
+    updateOutputAmount,
+    updateInputAmount,
     flipSwapCurrenciesWithTimeout,
     derivedValues?.outputAmount,
     derivedValues?.inputAmount,
+    updateNativeAmount,
   ]);
 
   const updateInputCurrency = useCallback(


### PR DESCRIPTION
Fixes TEAM2-179

## What changed (plus any additional context for devs)

instead of using input fields to clear values when flipping i changed it to state actions that do the same in the state level instead

## PoW (screenshots / screen recordings)

https://www.loom.com/share/3167005e31c94523b434df6088c7dc56

ios working as before
android is improved, inputs are correctly updated and cleared when flipping

## Dev checklist for QA: what to test

- flip from input, output and native fields in mainnet, optimism, arbitrum and polygon

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
