### PR TITLE
[TEAM2-238] Pinned tokens in mainnet swap search

### DIFF
--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -19,7 +19,15 @@ import {
 import tokenSearch from '@rainbow-me/handlers/tokenSearch';
 import { addHexPrefix, getProviderForNetwork } from '@rainbow-me/handlers/web3';
 import tokenSectionTypes from '@rainbow-me/helpers/tokenSectionTypes';
-import { erc20ABI, rainbowTokenList } from '@rainbow-me/references';
+import {
+  DAI_ADDRESS,
+  erc20ABI,
+  ETH_ADDRESS,
+  rainbowTokenList,
+  USDC_ADDRESS,
+  WBTC_ADDRESS,
+  WETH_ADDRESS,
+} from '@rainbow-me/references';
 import { ethereumUtils, filterList, logger } from '@rainbow-me/utils';
 
 const MAINNET_CHAINID = 1;
@@ -117,10 +125,11 @@ const useSwapCurrencyList = (
         const { address: address1, name: name1 } = t1;
         const { address: address2, name: name2 } = t2;
         const mainnetPriorityTokens = [
-          'eth', // eth
-          '0x6b175474e89094c44da98b954eedeac495271d0f', // dai
-          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // usdc
-          '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', // wbtc
+          ETH_ADDRESS,
+          WETH_ADDRESS,
+          DAI_ADDRESS,
+          USDC_ADDRESS,
+          WBTC_ADDRESS,
         ];
         const rankA = mainnetPriorityTokens.findIndex(
           address => address === address1.toLowerCase()

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -111,9 +111,41 @@ const useSwapCurrencyList = (
 
   const getCurated = useCallback(() => {
     const addresses = favoriteAddresses.map(a => a.toLowerCase());
-    return Object.values(curatedMap).filter(
-      ({ address }) => !addresses.includes(address.toLowerCase())
-    );
+    return Object.values(curatedMap)
+      .filter(({ address }) => !addresses.includes(address.toLowerCase()))
+      .sort((t1, t2) => {
+        const { address: address1, name: name1 } = t1;
+        const { address: address2, name: name2 } = t2;
+        const mainnetPriorityTokens = [
+          'eth', // eth
+          '0x6b175474e89094c44da98b954eedeac495271d0f', // dai
+          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // usdc
+          '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', // wbtc
+        ];
+        const rankA = mainnetPriorityTokens.findIndex(
+          address => address === address1.toLowerCase()
+        );
+        const rankB = mainnetPriorityTokens.findIndex(
+          address => address === address2.toLowerCase()
+        );
+        const aIsRanked = rankA > -1;
+        const bIsRanked = rankB > -1;
+        if (aIsRanked) {
+          return bIsRanked
+            ? // compare rank within list
+              rankA < rankB
+              ? -1
+              : 1
+            : // only t1 is ranked
+              -1;
+        } else {
+          return bIsRanked
+            ? // only t2 is ranked
+              1
+            : // sort unranked by abc
+              name1?.localeCompare(name2);
+        }
+      });
   }, [curatedMap, favoriteAddresses]);
 
   const getFavorites = useCallback(async () => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I didn't catch this because I tested the API directly when evaluating mainnet token sorting, but we don't use that endpoint for the mainnet curated token list presented when the user hasn't provided a search query.

You won't see WETH prioritized in the curated list when no search query is present. This is because it's not currently classified as a 'curated' token. I added the WETH address into the sorting predicate in case we do decide to add it.

## PoW (screenshots / screen recordings)
https://recordit.co/jyCs0WzoyE

## Dev checklist for QA: what to test
Make sure these tokens are pinned at the top of the curated/verified sections when applicable: ETH, wETH, Dai, USDC, wBTC

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
