### PR TITLE
Get shadows to display

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
@@ -9,6 +9,7 @@ import EthIcon from '@rainbow-me/assets/eth-icon.png';
 import { AssetType } from '@rainbow-me/entities';
 import { useColorForAsset } from '@rainbow-me/hooks';
 import { borders, fonts } from '@rainbow-me/styles';
+import { ThemeContextProps } from '@rainbow-me/theme';
 import {
   FallbackIcon as CoinIconTextFallback,
   getTokenMetadata,
@@ -73,8 +74,10 @@ export default React.memo(function FastCoinIcon({
   mainnetAddress?: string;
   symbol: string;
   assetType?: AssetType;
-  theme: any;
+  theme: ThemeContextProps;
 }) {
+  const { colors } = theme;
+
   const { resolvedType, resolvedAddress } = resolveTypeAndAddress({
     address,
     assetType,
@@ -89,7 +92,7 @@ export default React.memo(function FastCoinIcon({
   });
 
   const shadowColor = theme.isDarkMode
-    ? theme.colors.shadow
+    ? colors.shadow
     : tokenMetadata?.shadowColor ?? fallbackIconColor;
 
   const eth = isETH(resolvedAddress);
@@ -98,13 +101,22 @@ export default React.memo(function FastCoinIcon({
 
   const shouldRenderFallback = !eth && !tokenMetadata;
   const shouldRenderLocalCoinIconImage =
-    !shouldRenderFallback && CoinIconsImages[formattedSymbol];
+    !shouldRenderFallback && !!CoinIconsImages[formattedSymbol];
   const shouldRenderContract = symbol === 'contract';
 
   return (
     <View style={sx.container}>
       {eth ? (
-        <Image source={EthIcon} style={sx.coinIconFallback} />
+        <View
+          style={[
+            sx.coinIconFallback,
+            sx.reactCoinIconContainer,
+            sx.withShadow,
+            { shadowColor },
+          ]}
+        >
+          <Image source={EthIcon} style={sx.coinIconFallback} />
+        </View>
       ) : shouldRenderLocalCoinIconImage ? (
         <View
           style={[

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
@@ -68,8 +68,8 @@ export const FastFallbackCoinIconImage = React.memo(
       <View
         style={[
           sx.coinIconContainer,
-          { shadowColor },
           isLoaded && sx.withShadow,
+          { shadowColor },
         ]}
       >
         {shouldShowImage && (
@@ -92,11 +92,10 @@ export const FastFallbackCoinIconImage = React.memo(
 const sx = StyleSheet.create({
   coinIconContainer: {
     alignItems: 'center',
-    backgroundColor: 'transparent',
     borderRadius: 20,
     height: 40,
     justifyContent: 'center',
-    overflow: 'hidden',
+    overflow: 'visible',
     width: 40,
   },
   coinIconFallback: {

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
@@ -101,7 +101,7 @@ const sx = StyleSheet.create({
   coinIconFallback: {
     borderRadius: 20,
     height: 40,
-    overflow: 'visible',
+    overflow: 'hidden',
     width: 40,
   },
   container: {


### PR DESCRIPTION
Fixes RNBW-3946

There was a visual regression introduced with merge of balanced coin row refactor: some coin shadows were gone.

## What changed (plus any additional context for devs)

ETH icon shadow should be back together with some others (shiba inu for example).

## PoW (screenshots / screen recordings)

> **NOTE:** as of now, those screenshots should be accurate as there were no code changes. However, they might turn out to be inaccurate because of human error (I messed up something while pasting) or some glitch (bundler not updating when switching branches). Use at your own risk.

||Before|Develop|Fix|
|--|--|--|--|
|Android light|![an_before_light](https://user-images.githubusercontent.com/5769281/177577186-cf8fd74e-b408-48fd-af7c-d8eb57fbd2b7.jpg)|![an_develop_light](https://user-images.githubusercontent.com/5769281/177577203-9564d6a5-b527-4889-8321-81178ccf3b10.jpg)|![an_now_light](https://user-images.githubusercontent.com/5769281/177577191-f81b5056-f236-4bf6-a0bd-5f447be3b217.jpg)|
|Android dark|![an_before_dark](https://user-images.githubusercontent.com/5769281/177577174-d77988b9-5be8-4e15-b53c-2dbb383a6020.jpg)|![an_develop_dark](https://user-images.githubusercontent.com/5769281/177577200-f0b9f105-d1a8-4530-9b82-9d55cafbd34c.jpg)|![an_now_dark](https://user-images.githubusercontent.com/5769281/177577195-72d9204e-d72f-40cf-a7d7-6f0bc6d834e6.jpg)|
|iPhone light|![ip_before_light](https://user-images.githubusercontent.com/5769281/177577231-cf01fe67-ee10-4f0f-b3c0-983931d0b6f5.jpeg)|![ip_develop_light](https://user-images.githubusercontent.com/5769281/177577208-518071a9-c4bc-4150-8c66-8ad74fcabd45.jpeg)|![ip_now_light](https://user-images.githubusercontent.com/5769281/177577212-d93c24ef-a815-48de-b444-f60fd9fc57b5.jpeg)|
|iPhone dark|![ip_before_dark](https://user-images.githubusercontent.com/5769281/177577223-53bccd67-f422-44ad-a99e-142eb9c64cd1.jpeg)|![ip_develop_dark](https://user-images.githubusercontent.com/5769281/177577205-00c6fe9b-fe3b-499a-a436-7dc8bc6b3222.jpeg)|![ip_now_dark](https://user-images.githubusercontent.com/5769281/177577218-292bb1bb-b865-4542-9366-54a15fb70a87.jpeg)|

## Dev checklist for QA: what to test

Shadows under coin icons. Presumably develop state is wrong, target state is the one from before (but I can be wrong).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels?
- [x] Added e2e tests? if not please specify why
- [x] If you added new files, did you update the CODEOWNERS file?
