### PR TITLE
swaps: fix explainers inputs focus

### DIFF
--- a/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
+++ b/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
@@ -93,7 +93,7 @@ export const MaxToleranceInput = forwardRef(
     );
 
     const openExplainer = () => {
-      android && Keyboard.dismiss();
+      Keyboard.dismiss();
       navigate(Routes.EXPLAIN_SHEET, {
         type: 'slippage',
       });

--- a/src/components/expanded-state/swap-settings/SourcePicker.js
+++ b/src/components/expanded-state/swap-settings/SourcePicker.js
@@ -74,7 +74,7 @@ export default function SourcePicker({ onSelect, currentSource }) {
   }, [onSelect]);
 
   const openExplainer = () => {
-    android && Keyboard.dismiss();
+    Keyboard.dismiss();
     navigate(Routes.EXPLAIN_SHEET, {
       type: 'routeSwaps',
     });

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -114,7 +114,7 @@ export default function SwapSettingsState({ asset }) {
   }, [settingsChangeFlashbotsEnabled, updateSource]);
 
   const openExplainer = () => {
-    android && Keyboard.dismiss();
+    Keyboard.dismiss();
     navigate(Routes.EXPLAIN_SHEET, {
       type: 'flashbots',
     });

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -294,7 +294,7 @@ const GasSpeedButton = ({
   }, [gasPriceReady, selectedGasFee?.estimatedTime?.display]);
 
   const openGasHelper = useCallback(() => {
-    android && Keyboard.dismiss();
+    Keyboard.dismiss();
     const network = currentNetwork ?? networkTypes.mainnet;
     const networkName = networkInfo[network].name;
     navigate(Routes.EXPLAIN_SHEET, { network: networkName, type: 'gas' });


### PR DESCRIPTION
Fixes TEAM2-176

## What changed (plus any additional context for devs)

We need to call `Keyboard.dismiss()` on ios as well

## PoW (screenshots / screen recordings)

https://www.loom.com/share/5cf9b77036d140428b4259e7afeb1b44?from_recorder=1&focus_title=1

## Dev checklist for QA: what to test

- press estimated fee explainer 
- go to swaps settings and press explainers

for both, when an explainer is closed, the last input focused should be focused again

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels?
- [ ] Added e2e tests? if not please specify why
- [ ] If you added new files, did you update the CODEOWNERS file?
