### PR TITLE
swaps: fix press disabled confirm

### DIFF
--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -225,7 +225,7 @@ function HoldToAuthorizeButtonContent2({
     }
   };
   return (
-    <TapGestureHandler onHandlerStateChange={onTapChange}>
+    <TapGestureHandler enabled={!disabled} onHandlerStateChange={onTapChange}>
       <LongPressGestureHandler
         enabled={enableLongPress}
         minDurationMs={LONG_PRESS_DURATION_IN_MS}


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

@benisgold found a bug, pressing the swaps confirm button when is disabled is sometime crashing the app. It also behaves differently than other places where we use the button, it animates on every place even when is disabled

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://www.loom.com/share/79b3b8463f0f457ba2d24bc1f366231f

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- send confirm button, when is disabled and enabled
- swap confirm button, when is disabled and enabled


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
