### PR TITLE
Fix NFT token family icon size

### DIFF
--- a/src/components/token-family/TokenFamilyHeaderIcon.tsx
+++ b/src/components/token-family/TokenFamilyHeaderIcon.tsx
@@ -24,7 +24,7 @@ const sx = StyleSheet.create({
   },
 });
 
-const circleStyle = borders.buildCircleAsObject(40);
+const circleStyle = borders.buildCircleAsObject(30);
 
 export default React.memo(function TokenFamilyHeaderIcon({
   familyImage,
@@ -61,7 +61,7 @@ export default React.memo(function TokenFamilyHeaderIcon({
       style={style}
     >
       {familyImage ? (
-        <ImgixImage size={40} source={source} style={circleStyle} />
+        <ImgixImage source={source} style={circleStyle} />
       ) : (
         // @ts-expect-error FallbackIcon is not migrated to TS.
         <FallbackIcon {...circleStyle} symbol={symbol} />


### PR DESCRIPTION
## What changed (plus any additional context for devs)
https://github.com/rainbow-me/rainbow/pull/3547 introduced a regression that increased the size of the NFT family icon from 30px to 40px

this returns it back to 30px

before/after:
<img width="940" alt="Screen Shot 2022-07-09 at 3 28 36 PM" src="https://user-images.githubusercontent.com/7061887/178120038-51cc7e86-95e8-49dd-bd16-4b97526fa42e.png">

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
