### PR TITLE
Update TokenFamilyHeaderIcon.tsx

### DIFF
--- a/src/components/token-family/TokenFamilyHeaderIcon.tsx
+++ b/src/components/token-family/TokenFamilyHeaderIcon.tsx
@@ -61,7 +61,7 @@ export default React.memo(function TokenFamilyHeaderIcon({
       style={style}
     >
       {familyImage ? (
-        <ImgixImage source={source} style={circleStyle} />
+        <ImgixImage size={30} source={source} style={circleStyle} />
       ) : (
         // @ts-expect-error FallbackIcon is not migrated to TS.
         <FallbackIcon {...circleStyle} symbol={symbol} />


### PR DESCRIPTION
## What changed (plus any additional context for devs)

@christianbaroni is his recent changes, didn't add the proper size. We don't need the full size image here, 30 px is enough

## Screen recordings / screenshots

before:
![image](https://user-images.githubusercontent.com/25709300/178253361-1b105259-b374-49bb-8e93-22651d42a6e4.png)

after:
![image](https://user-images.githubusercontent.com/25709300/178253379-9ba504b0-1a24-42c0-8606-d530b2c68458.png)

<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
see headers images, should be the same.
