### PR TITLE
swaps - truncate long token symbols 

### DIFF
--- a/src/components/buttons/TokenSelectionButton.js
+++ b/src/components/buttons/TokenSelectionButton.js
@@ -62,6 +62,8 @@ export default function TokenSelectionButton({
     [colorForAsset, colors.shadow, isDarkMode]
   );
 
+  const displaySymbol = symbol?.length < 6 ? symbol : `${symbol?.slice(0, 6)}…`;
+
   return (
     <ButtonPressAnimation
       borderRadius={borderRadius}
@@ -89,7 +91,7 @@ export default function TokenSelectionButton({
           testID={testID + '-text'}
           weight="bold"
         >
-          {symbol || lang.t('swap.choose_token')}
+          {symbol ? displaySymbol : lang.t('swap.choose_token')}
         </Text>
         <CaretIcon />
       </Content>

--- a/src/components/buttons/TokenSelectionButton.js
+++ b/src/components/buttons/TokenSelectionButton.js
@@ -70,7 +70,7 @@ export default function TokenSelectionButton({
         backgroundColor: colorForAsset,
         borderRadius,
       }}
-      maxWidth={TokenSelectionButtonMaxWidth}
+      {...(symbol && { maxWidth: TokenSelectionButtonMaxWidth })}
       onPress={onPress}
       radiusAndroid={borderRadius}
       testID={testID}

--- a/src/components/buttons/TokenSelectionButton.js
+++ b/src/components/buttons/TokenSelectionButton.js
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { useTheme } from '../../theme/ThemeContext';
 import { ButtonPressAnimation } from '../animations';
 import { InnerBorder, RowWithMargins } from '../layout';
-import { Text } from '../text';
+import { TruncatedText } from '../text';
 import CaretImageSource from '@rainbow-me/assets/family-dropdown-arrow.png';
 import { AssetType } from '@rainbow-me/entities';
 import { useColorForAsset } from '@rainbow-me/hooks';
@@ -13,6 +13,7 @@ import { padding, position } from '@rainbow-me/styles';
 import ShadowStack from 'react-native-shadow-stack';
 
 const TokenSelectionButtonHeight = 46;
+const TokenSelectionButtonMaxWidth = 130;
 const TokenSelectionButtonElevation = ios ? 0 : 8;
 
 const Content = styled(RowWithMargins).attrs({
@@ -62,8 +63,6 @@ export default function TokenSelectionButton({
     [colorForAsset, colors.shadow, isDarkMode]
   );
 
-  const displaySymbol = symbol?.length < 6 ? symbol : `${symbol?.slice(0, 6)}…`;
-
   return (
     <ButtonPressAnimation
       borderRadius={borderRadius}
@@ -71,6 +70,7 @@ export default function TokenSelectionButton({
         backgroundColor: colorForAsset,
         borderRadius,
       }}
+      maxWidth={TokenSelectionButtonMaxWidth}
       onPress={onPress}
       radiusAndroid={borderRadius}
       testID={testID}
@@ -83,7 +83,7 @@ export default function TokenSelectionButton({
         shadows={shadowsForAsset}
       />
       <Content>
-        <Text
+        <TruncatedText
           align="center"
           color={colors.whiteLabel}
           {...(android && { lineHeight: 21 })}
@@ -91,8 +91,8 @@ export default function TokenSelectionButton({
           testID={testID + '-text'}
           weight="bold"
         >
-          {symbol ? displaySymbol : lang.t('swap.choose_token')}
-        </Text>
+          {symbol ?? lang.t('swap.choose_token')}
+        </TruncatedText>
         <CaretIcon />
       </Content>
       <InnerBorder radius={borderRadius} />

--- a/src/components/exchange/ExchangeField.js
+++ b/src/components/exchange/ExchangeField.js
@@ -35,7 +35,7 @@ const FieldRow = styled(RowWithMargins).attrs({
   flex: 1,
   paddingLeft: ExchangeFieldPadding,
   paddingRight: ({ disableCurrencySelection }) =>
-    disableCurrencySelection ? ExchangeFieldPadding : 0,
+    disableCurrencySelection ? ExchangeFieldPadding : 6,
 });
 
 const Input = styled(ExchangeInput).attrs({


### PR DESCRIPTION
Fixes TEAM2-171
Figma link (if any): see ticket

## What changed (plus any additional context for devs)
we now truncate the symbol if its over 6 digits. we also added right padding to the inputs.


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://cloud.skylarbarrera.com/Screen-Shot-2022-07-11-11-53-39.60.png


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

check long symbol names (eth2xfli), otherwise text should be normal


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
