### PR TITLE
swaps: improve useSwapDerivedOutputs

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -157,7 +157,9 @@ export default function ConfirmExchangeButton({
             label={label}
             loading={loading}
             onLongPress={
-              insufficientLiquidity
+              loading
+                ? () => null
+                : insufficientLiquidity
                 ? handleShowLiquidityExplainer
                 : shouldOpenSwapDetails
                 ? onPressViewDetails

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -14,6 +14,8 @@ import Routes from '@rainbow-me/routes';
 import { lightModeThemeColors } from '@rainbow-me/styles';
 import { useTheme } from '@rainbow-me/theme';
 
+const NOOP = () => null;
+
 export default function ConfirmExchangeButton({
   currentNetwork,
   disabled,
@@ -158,7 +160,7 @@ export default function ConfirmExchangeButton({
             loading={loading}
             onLongPress={
               loading
-                ? () => null
+                ? NOOP
                 : insufficientLiquidity
                 ? handleShowLiquidityExplainer
                 : shouldOpenSwapDetails

--- a/src/components/exchange/ExchangeField.js
+++ b/src/components/exchange/ExchangeField.js
@@ -82,7 +82,6 @@ const ExchangeField = (
   const [editing, setEditing] = useState(false);
   const [debouncedValue] = useDebounce(value, 300);
   const [startTimeout, stopTimeout] = useTimeout();
-
   const handleBlur = useCallback(
     event => {
       onBlur?.(event);
@@ -92,11 +91,10 @@ const ExchangeField = (
   const handleFocus = useCallback(
     event => {
       if (updateOnFocus) {
-        setValue(amount);
         onFocus?.(event);
       }
     },
-    [amount, onFocus, updateOnFocus]
+    [onFocus, updateOnFocus]
   );
 
   useEffect(() => {

--- a/src/components/exchange/ExchangeNativeField.js
+++ b/src/components/exchange/ExchangeNativeField.js
@@ -56,11 +56,10 @@ const ExchangeNativeField = (
   const handleBlur = useCallback(() => setIsFocused(false), []);
   const handleFocus = useCallback(
     event => {
-      setValue(nativeAmount);
       setIsFocused(true);
       onFocus?.(event);
     },
-    [nativeAmount, onFocus]
+    [onFocus]
   );
   const { colors } = useTheme();
 

--- a/src/handlers/uniswap.ts
+++ b/src/handlers/uniswap.ts
@@ -295,7 +295,7 @@ export const computeSlippageAdjustedAmounts = (
 
     input = convertRawAmountToDecimalFormat(
       add(input, result),
-      trade.outputTokenDecimals
+      trade.inputTokenDecimals
     );
   }
 

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -32,7 +32,7 @@ import {
 import { ethereumUtils } from '@rainbow-me/utils';
 import Logger from '@rainbow-me/utils/logger';
 
-const SWAP_POLLING_INTERVAL = 20000;
+const SWAP_POLLING_INTERVAL = 10000;
 enum DisplayValue {
   input = 'inputAmountDisplay',
   output = 'outputAmountDisplay',

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -14,7 +14,6 @@ import { Token } from '../entities/tokens';
 import useAccountSettings from './useAccountSettings';
 import { EthereumAddress } from '@rainbow-me/entities';
 import { isNativeAsset } from '@rainbow-me/handlers/assets';
-// import { ExchangeModalTypes } from '@rainbow-me/helpers';
 import { AppState } from '@rainbow-me/redux/store';
 import {
   Source,

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -6,8 +6,11 @@ import {
 } from '@rainbow-me/swaps';
 import analytics from '@segment/analytics-react-native';
 import { useCallback, useMemo } from 'react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { NativeModules } from 'react-native';
 // @ts-expect-error ts-migrate(2305) FIXME: Module '"react-native-dotenv"' has no exported mem... Remove this comment to see the full error message
-import { IS_TESTING } from 'react-native-dotenv';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { IS_APK_BUILD, IS_TESTING } from 'react-native-dotenv';
 import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { Token } from '../entities/tokens';

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -262,18 +262,7 @@ const displayValues: { [key in DisplayValue]: string | null } = {
 
 export default function useSwapDerivedOutputs(chainId: number, type: string) {
   const dispatch = useDispatch();
-  // const [loading, setLoading] = useState(false);
-  // const [insufficientLiquidity, setInsufficientLiquidity] = useState(false);
-
-  // const isDeposit = type === ExchangeModalTypes.deposit;
-  // const isWithdrawal = type === ExchangeModalTypes.withdrawal;
-  // const isSavings = isDeposit || isWithdrawal;
-
-  // const [result, setResult] = useState({
-  //   derivedValues,
-  //   displayValues,
-  //   tradeDetails: null,
-  // });
+  const { accountAddress } = useAccountSettings();
 
   const independentField = useSelector(
     (state: AppState) => state.swap.independentField
@@ -296,9 +285,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
 
   const source = useSelector((state: AppState) => state.swap.source);
 
-  const derivedValuesFromRedux = useSelector(
-    (state: AppState) => state.swap.derivedValues
-  );
   const genericAssets = useSelector(
     (state: AppState) => state.data.genericAssets
   );
@@ -314,7 +300,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     genericAssets[outputCurrency?.mainnet_address || outputCurrency?.address]
       ?.price?.value;
 
-  const { accountAddress } = useAccountSettings();
   const resetSwapInputs = useCallback(() => {
     derivedValues[SwapModalField.input] = null;
     derivedValues[SwapModalField.output] = null;
@@ -411,15 +396,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
               inputCurrency.decimals
             )
           : null;
-
-      // The quote is the same
-      if (
-        derivedValuesFromRedux &&
-        independentValue === derivedValuesFromRedux[SwapModalField.native]
-      ) {
-        // setLoading(false);
-        return {};
-      }
 
       derivedValues[SwapModalField.native] = independentValue;
       displayValues[DisplayValue.native] = independentValue;
@@ -525,7 +501,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   }, [
     accountAddress,
     chainId,
-    derivedValuesFromRedux,
     dispatch,
     independentField,
     independentValue,
@@ -552,7 +527,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       slippageInBips,
       source,
     ],
-    () => getTradeDetails()
+    async () => await getTradeDetails()
   );
 
   return {

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -390,6 +390,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       insufficientLiquidity = !!noLiquidity;
       tradeDetails = newTradeDetails;
       derivedValues[SwapModalField.output] = outputAmount;
+      // @ts-ignore next-line
       displayValues[DisplayValue.output] = outputAmount
         ? outputAmountDisplay?.toString()
         : null;

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -311,7 +311,7 @@ export default function ExchangeModal({
     currentNetwork,
     loading
   );
-  const [debouncedIsHighPriceImpact] = useDebounce(isHighPriceImpact, 500);
+  const [debouncedIsHighPriceImpact] = useDebounce(isHighPriceImpact, 1000);
   const swapSupportsFlashbots = currentNetwork === Network.mainnet;
   const flashbots = swapSupportsFlashbots && flashbotsEnabled;
 
@@ -846,8 +846,7 @@ export default function ExchangeModal({
               isHighPriceImpact={
                 !confirmButtonProps.disabled &&
                 !confirmButtonProps.loading &&
-                debouncedIsHighPriceImpact &&
-                isSufficientBalance
+                debouncedIsHighPriceImpact
               }
               onFlipCurrencies={loading ? NOOP : flipCurrencies}
               onPressImpactWarning={navigateToSwapDetailsModal}

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -846,7 +846,8 @@ export default function ExchangeModal({
               isHighPriceImpact={
                 !confirmButtonProps.disabled &&
                 !confirmButtonProps.loading &&
-                debouncedIsHighPriceImpact
+                debouncedIsHighPriceImpact &&
+                isSufficientBalance
               }
               onFlipCurrencies={loading ? NOOP : flipCurrencies}
               onPressImpactWarning={navigateToSwapDetailsModal}


### PR DESCRIPTION
Fixes TEAM2-246
Figma link (if any):

## What changed (plus any additional context for devs)

The `useSwapDerivedOutputs` hook had a `useEffect` listening to changes on any swap param to call `getTradeDetails`, this was producing a race condition if `getOutputAmount` or `getInputAmount` takes longer for any reason. One scenario to easily reproduce it (and related to the issue 1. in ticket) is erase the input very fast while the quote is being fetched.


https://user-images.githubusercontent.com/12115171/178374233-5e98d134-2d0e-4b24-9672-26fdcac1fe71.MP4


in order to fix this race condition and avoid multiple unneeded calls to the hook this PR introduces `useQuery` to deal with this logic instead.

for issue 2. i removed this condition https://github.com/rainbow-me/rainbow/pull/3687/files#diff-d7555f0c12b00ac091459b5a69d184f5582cd342c0c77b2bfc1d42a18c315c29L358 that was making this behavior to happen

for 3. the useQuery change helps but i bumped the debounce to 1 sec to show price alerts

added a polling time for new quotes of 20 secs


fixed this wrong `Maximum sold` value


![image](https://user-images.githubusercontent.com/12115171/178397271-2dff3c0f-eacf-4485-b756-573345dc287b.png)


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/8c576b8535eb414abc3108eaf4c005ed?from_recorder=1&focus_title=1

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
 i listed the errors above and they're are detailed in linear tickets with videos
- race condition when editing the values too fast and going to an empty value
- typing 0 was acting weird
- price impact alert shouldn't appear while typing
- swapping ETH WBTC from the WBTC input field should display a correct `Minimum sold` value
- polling of new quotes every 20 secs

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
