### PR TITLE
Notifications: Feature flag

### DIFF
--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -8,6 +8,7 @@ import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
  */
 
 export const LANGUAGE_SETTINGS = 'languageSettings';
+export const NOTIFICATIONS = 'Notifications';
 export const REVIEW_ANDROID = 'reviewAndroid';
 export const PROFILES = 'ENS Profiles';
 export const L2_TXS = 'L2 Transactions';
@@ -15,6 +16,7 @@ export const L2_TXS = 'L2 Transactions';
 export const defaultConfig = {
   [L2_TXS]: { needsRestart: true, settings: true, value: false }, // this flag is not reactive. We use this in a static context
   [LANGUAGE_SETTINGS]: { settings: false, value: false },
+  [NOTIFICATIONS]: { needsRestart: true, settings: true, value: false },
   [PROFILES]: { settings: true, value: false },
   [REVIEW_ANDROID]: { settings: false, value: false },
 };

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -64,6 +64,7 @@ import { onNavigationStateChange } from './onNavigationStateChange';
 import Routes from './routesNames';
 import { ExchangeModalNavigator } from './index';
 import useExperimentalFlag, {
+  NOTIFICATIONS,
   PROFILES,
 } from '@rainbow-me/config/experimentalHooks';
 
@@ -298,6 +299,8 @@ function MainOuterNavigator() {
 }
 
 function BSNavigator() {
+  const notificationsEnabled = useExperimentalFlag(NOTIFICATIONS);
+
   return (
     <BSStack.Navigator>
       <BSStack.Screen
@@ -372,6 +375,13 @@ function BSNavigator() {
         name={Routes.SETTINGS_SHEET}
         options={{ ...bottomSheetPreset, height: '97%' }}
       />
+      {notificationsEnabled && (
+        <BSStack.Screen
+          component={SettingsSheet}
+          name={Routes.SETTINGS_SHEET_V2}
+          options={{ ...bottomSheetPreset, height: '97%' }}
+        />
+      )}
     </BSStack.Navigator>
   );
 }

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -25,6 +25,7 @@ import SelectUniqueTokenSheet from '../screens/SelectUniqueTokenSheet';
 import SendConfirmationSheet from '../screens/SendConfirmationSheet';
 import SendSheet from '../screens/SendSheet';
 import SettingsSheet from '../screens/SettingsSheet';
+import SettingsSheetV2 from '../screens/SettingsSheetV2';
 import ShowcaseScreen from '../screens/ShowcaseSheet';
 import SpeedUpAndCancelSheet from '../screens/SpeedUpAndCancelSheet';
 import TransactionConfirmationScreen from '../screens/TransactionConfirmationScreen';
@@ -70,6 +71,7 @@ import { onNavigationStateChange } from './onNavigationStateChange';
 import Routes from './routesNames';
 import { ExchangeModalNavigator } from './index';
 import useExperimentalFlag, {
+  NOTIFICATIONS,
   PROFILES,
 } from '@rainbow-me/config/experimentalHooks';
 import isNativeStackAvailable from '@rainbow-me/helpers/isNativeStackAvailable';
@@ -235,6 +237,7 @@ const MainStack = isNativeStackAvailable
 function NativeStackNavigator() {
   const { colors, isDarkMode } = useTheme();
   const profilesEnabled = useExperimentalFlag(PROFILES);
+  const notificationsEnabled = useExperimentalFlag(NOTIFICATIONS);
 
   return (
     <NativeStack.Navigator {...nativeStackConfig}>
@@ -253,6 +256,13 @@ function NativeStackNavigator() {
         name={Routes.SETTINGS_SHEET}
         {...settingsSheetConfig}
       />
+      {notificationsEnabled && (
+        <NativeStack.Screen
+          component={SettingsSheetV2}
+          name={Routes.SETTINGS_SHEET_V2}
+          {...settingsSheetConfig}
+        />
+      )}
       <NativeStack.Screen
         component={ExchangeModalNavigator}
         name={Routes.EXCHANGE_MODAL}

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -52,6 +52,7 @@ const Routes = {
   SEND_SHEET: 'SendSheet',
   SEND_SHEET_NAVIGATOR: 'SendSheetNavigator',
   SETTINGS_SHEET: 'SettingsSheet',
+  SETTINGS_SHEET_V2: 'SettingsSheetV2',
   SHOWCASE_SHEET: 'ShowcaseSheet',
   SPEED_UP_AND_CANCEL_SHEET: 'SpeedUpAndCancelSheet',
   STACK: 'Stack',
@@ -72,6 +73,7 @@ const Routes = {
 export const NATIVE_ROUTES = [
   Routes.RECEIVE_MODAL,
   Routes.SETTINGS_SHEET,
+  Routes.SETTINGS_SHEET_V2,
   Routes.EXCHANGE_MODAL,
   Routes.EXPANDED_ASSET_SHEET,
   Routes.TOKEN_INDEX_SHEET,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -11,6 +11,7 @@ import useNativeTransactionListAvailable from '../helpers/isNativeTransactionLis
 import NetworkTypes from '../helpers/networkTypes';
 import { useNavigation } from '../navigation/Navigation';
 import { useTheme } from '../theme/ThemeContext';
+import { NOTIFICATIONS, useExperimentalFlag } from '@rainbow-me/config';
 import {
   useAccountSettings,
   useAccountTransactions,
@@ -62,9 +63,14 @@ export default function ProfileScreen({ navigation }) {
     navigate,
   ]);
 
-  const onPressSettings = useCallback(() => navigate(Routes.SETTINGS_SHEET), [
-    navigate,
-  ]);
+  const notificationsEnabled = useExperimentalFlag(NOTIFICATIONS);
+  const onPressSettings = useCallback(
+    () =>
+      notificationsEnabled
+        ? navigate(Routes.SETTINGS_SHEET_V2)
+        : navigate(Routes.SETTINGS_SHEET),
+    [navigate, notificationsEnabled]
+  );
 
   const onChangeWallet = useCallback(() => {
     navigate(Routes.CHANGE_WALLET_SHEET);

--- a/src/screens/SettingsSheetV2.tsx
+++ b/src/screens/SettingsSheetV2.tsx
@@ -1,0 +1,257 @@
+import { useRoute } from '@react-navigation/native';
+import {
+  createStackNavigator,
+  StackCardInterpolationProps,
+} from '@react-navigation/stack';
+import lang from 'i18n-js';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { Animated, InteractionManager, View } from 'react-native';
+import ModalHeaderButton from '../components/modal/ModalHeaderButton';
+import {
+  CurrencySection,
+  DevNotificationsSection,
+  DevSection,
+  LanguageSection,
+  NetworkSection,
+  PrivacySection,
+  SettingsSection,
+  UserDevSection,
+} from '../components/settings-menu';
+import SettingsBackupView from '../components/settings-menu/BackupSection/SettingsBackupView';
+import ShowSecretView from '../components/settings-menu/BackupSection/ShowSecretView';
+import WalletSelectionView from '../components/settings-menu/BackupSection/WalletSelectionView';
+import WalletTypes from '../helpers/walletTypes';
+import { settingsOptions } from '../navigation/config';
+import { useTheme } from '../theme/ThemeContext';
+import { Box } from '@rainbow-me/design-system';
+import isTestFlight from '@rainbow-me/helpers/isTestFlight';
+import { useWallets } from '@rainbow-me/hooks';
+import { useNavigation } from '@rainbow-me/navigation';
+
+function cardStyleInterpolator({
+  current,
+  next,
+  inverted,
+  layouts: { screen },
+}: StackCardInterpolationProps) {
+  const translateFocused = Animated.multiply(
+    current.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [screen.width, 0],
+    }),
+    inverted
+  );
+  const translateUnfocused = next
+    ? Animated.multiply(
+        next.progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [0, -screen.width],
+        }),
+        inverted
+      )
+    : 0;
+
+  return {
+    cardStyle: {
+      transform: [
+        {
+          translateX: Animated.add(translateFocused, translateUnfocused),
+        },
+      ],
+    },
+  };
+}
+
+const SettingsPages = {
+  backup: {
+    component: View,
+    getTitle: () => lang.t('settings.backup'),
+    key: 'BackupSection',
+  },
+  currency: {
+    component: CurrencySection,
+    getTitle: () => lang.t('settings.currency'),
+    key: 'CurrencySection',
+  },
+  default: {
+    component: null,
+    getTitle: () => lang.t('settings.label'),
+    key: 'SettingsSection',
+  },
+  dev: {
+    component: IS_DEV || isTestFlight ? DevSection : UserDevSection,
+    getTitle: () => lang.t('settings.dev'),
+    key: 'DevSection',
+  },
+  language: {
+    component: LanguageSection,
+    getTitle: () => lang.t('settings.language'),
+    key: 'LanguageSection',
+  },
+  network: {
+    component: NetworkSection,
+    getTitle: () => lang.t('settings.network'),
+    key: 'NetworkSection',
+  },
+  privacy: {
+    component: PrivacySection,
+    getTitle: () => lang.t('settings.privacy'),
+    key: 'PrivacySection',
+  },
+};
+
+const Stack = createStackNavigator();
+
+export default function SettingsSheet() {
+  const { goBack, navigate } = useNavigation();
+  const { wallets, selectedWallet } = useWallets();
+  const { params } = useRoute<any>();
+  const { colors } = useTheme();
+
+  const getRealRoute = useCallback(
+    key => {
+      let route = key;
+      let paramsToPass: { imported?: boolean; type?: string } = {};
+      if (key === SettingsPages.backup.key) {
+        const walletId = params?.walletId;
+        if (
+          !walletId &&
+          Object.keys(wallets).filter(
+            key => wallets[key].type !== WalletTypes.readOnly
+          ).length > 1
+        ) {
+          route = 'WalletSelectionView';
+        } else {
+          if (Object.keys(wallets).length === 1 && selectedWallet.imported) {
+            paramsToPass.imported = true;
+            paramsToPass.type = 'AlreadyBackedUpView';
+          }
+          route = 'SettingsBackupView';
+        }
+      }
+      return { params: { ...params, ...paramsToPass }, route };
+    },
+    [params, selectedWallet.imported, wallets]
+  );
+
+  const onPressSection = useCallback(
+    section => () => {
+      const { params, route } = getRealRoute(section.key);
+      navigate(route, params);
+    },
+    [getRealRoute, navigate]
+  );
+
+  const renderHeaderRight = useCallback(
+    () =>
+      ios ? (
+        <ModalHeaderButton
+          label={lang.t('settings.done')}
+          onPress={goBack}
+          side="right"
+        />
+      ) : null,
+    [goBack]
+  );
+
+  useEffect(() => {
+    if (params?.initialRoute) {
+      const { route, params: routeParams } = getRealRoute(params?.initialRoute);
+      InteractionManager.runAfterInteractions(() => {
+        navigate(route, routeParams);
+      });
+    }
+  }, [getRealRoute, navigate, params]);
+
+  const memoSettingsOptions = useMemo(() => settingsOptions(colors), [colors]);
+  return (
+    <Box
+      background="body"
+      flexGrow={1}
+      testID="settings-sheet"
+      {...(android && { borderTopRadius: 30 })}
+    >
+      <Stack.Navigator
+        // @ts-expect-error
+        screenOptions={{
+          ...memoSettingsOptions,
+          headerRight: renderHeaderRight,
+        }}
+      >
+        <Stack.Screen
+          name="SettingsSection"
+          options={{
+            cardStyleInterpolator,
+            title: lang.t('settings.label'),
+          }}
+        >
+          {() => (
+            /** @ts-expect-error – JS component */
+            <SettingsSection
+              onCloseModal={goBack}
+              onPressBackup={onPressSection(SettingsPages.backup)}
+              onPressCurrency={onPressSection(SettingsPages.currency)}
+              onPressDev={onPressSection(SettingsPages.dev)}
+              onPressLanguage={onPressSection(SettingsPages.language)}
+              onPressNetwork={onPressSection(SettingsPages.network)}
+              onPressPrivacy={onPressSection(SettingsPages.privacy)}
+            />
+          )}
+        </Stack.Screen>
+        {Object.values(SettingsPages).map(
+          ({ component, getTitle, key }) =>
+            component && (
+              <Stack.Screen
+                component={component}
+                key={key}
+                name={key}
+                options={{
+                  cardStyleInterpolator,
+                  title: getTitle(),
+                }}
+                // @ts-expect-error
+                title={getTitle()}
+              />
+            )
+        )}
+
+        <Stack.Screen
+          component={WalletSelectionView}
+          name="WalletSelectionView"
+          options={{
+            cardStyle: { backgroundColor: colors.white, marginTop: 6 },
+            cardStyleInterpolator,
+            title: lang.t('settings.backup'),
+          }}
+        />
+        <Stack.Screen
+          component={DevNotificationsSection}
+          name="DevNotificationsSection"
+          options={{
+            cardStyle: { backgroundColor: colors.white, marginTop: 6 },
+            cardStyleInterpolator,
+            title: lang.t('developer_settings.notifications_debug'),
+          }}
+        />
+        <Stack.Screen
+          component={SettingsBackupView}
+          name="SettingsBackupView"
+          options={({ route }) => ({
+            cardStyleInterpolator,
+            // @ts-expect-error
+            title: route.params?.title || lang.t('settings.backup'),
+          })}
+        />
+        <Stack.Screen
+          component={ShowSecretView}
+          name="ShowSecretView"
+          options={({ route }) => ({
+            cardStyleInterpolator,
+            // @ts-expect-error
+            title: route.params?.title || lang.t('settings.backup'),
+          })}
+        />
+      </Stack.Navigator>
+    </Box>
+  );
+}


### PR DESCRIPTION
Fixes TEAM2-245

## What changed (plus any additional context for devs)

This PR adds a feature flag to hide all the upcoming notifications work. Since the upcoming work implements the new settings sheet designs (that we don't want to release yet), we are going to dupe the `SettingsSheet` component into a v2 variant, and then once the notifications feature flag is removed, we will prune the original components.

## What to test

- When the feature flag is off, ensure that `SettingsSheet` is pushed to navigation stack
- When the feature flag is on, ensure that `SettingsSheetV2` is pushed to navigation stack


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
