### PR TITLE
Swaps: Slippage fix

### DIFF
--- a/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
+++ b/src/components/expanded-state/swap-settings/MaxToleranceInput.tsx
@@ -22,8 +22,8 @@ import {
 } from '@rainbow-me/design-system';
 import {
   add,
+  convertNumberToString,
   greaterThan,
-  toFixedDecimals,
 } from '@rainbow-me/helpers/utilities';
 import { useMagicAutofocus, useSwapSettings } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
@@ -67,10 +67,10 @@ export const MaxToleranceInput = forwardRef(
     const updateSlippage = useCallback(
       increment => {
         const newSlippage = add(slippageValue, increment);
-        const newSlippageValue = toFixedDecimals(newSlippage, 2);
+        const newSlippageValue = convertNumberToString(newSlippage);
         if (greaterThan(0, newSlippageValue)) return;
 
-        updateSwapSlippage(convertPercentToBips(parseInt(newSlippageValue)));
+        updateSwapSlippage(convertPercentToBips(parseFloat(newSlippageValue)));
         setSlippageValue(newSlippageValue);
       },
       [slippageValue, updateSwapSlippage]


### PR DESCRIPTION
Fixes TEAM2-243
Figma link (if any):

## What changed (plus any additional context for devs)
- using +/- buttons to adjust slippage didn't work for non-integer percentages

## Screen recordings / screenshots

https://user-images.githubusercontent.com/15272675/178395398-4dff6837-9ca8-4b01-8735-fce6b5a7ba05.mp4


## What to test
- make sure that slippage modifications always persist and that there are no rounding/display issues or inconsistencies


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
