### PR TITLE
Remove undocumented usage of WC request payload ID as timestamp

### DIFF
--- a/src/parsers/requests.js
+++ b/src/parsers/requests.js
@@ -23,10 +23,7 @@ export const getRequestDisplayDetails = (
   nativeCurrency,
   dappNetwork
 ) => {
-  let timestampInMs = Date.now();
-  if (payload.id) {
-    timestampInMs = getTimestampFromPayload(payload);
-  }
+  const timestampInMs = Date.now();
   if (
     payload.method === SEND_TRANSACTION ||
     payload.method === SIGN_TRANSACTION
@@ -190,6 +187,3 @@ const getTransactionDisplayDetails = (
 
   return null;
 };
-
-const getTimestampFromPayload = payload =>
-  parseInt(payload?.id.toString().slice(0, -3), 10);


### PR DESCRIPTION
Fixes RNBW-3963
Figma link (if any): N/A

## What changed (plus any additional context for devs)
The usage of the payload ID as timestamp is not officially supported
or documented in WalletConnect.

The timestamp is used on the clientside to be able to remove older
requests that have not been interacted with, so this does not
impact anything with the WC protocol.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
Please see the test path details in the Linear ticket which has the corresponding OpenSea APK to test against.

## Final checklist

- [X] Assigned individual reviewers?
- [X] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [X] Did you test both iOS and Android?
- [X] If your changes are visual, did you check both the light and dark themes?
- [X] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
