### PR TITLE
[TEAM2-239] Sort swap currency list favorites alphabetically

### DIFF
--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -44,6 +44,12 @@ const uniswapFavoriteMetadataSelector = (state: AppState) =>
 const uniswapFavoritesSelector = (state: AppState): string[] =>
   state.uniswap.favorites;
 
+const abcSort = (list: any[], key?: string) => {
+  return list.sort((a, b) => {
+    return key ? a[key]?.localeCompare(b[key]) : a?.localeCompare(b);
+  });
+};
+
 const searchCurrencyList = async (
   searchList: RT[] | TokenSearchTokenListId,
   query: string,
@@ -361,7 +367,7 @@ const useSwapCurrencyList = (
       if (favoriteAssets?.length && chainId === MAINNET_CHAINID) {
         list.push({
           color: colors.yellowFavorite,
-          data: favoriteAssets,
+          data: abcSort(favoriteAssets, 'name'),
           key: 'favorites',
           title: tokenSectionTypes.favoriteTokenSection,
         });
@@ -392,7 +398,7 @@ const useSwapCurrencyList = (
       if (unfilteredFavorites?.length) {
         list.push({
           color: colors.yellowFavorite,
-          data: unfilteredFavorites,
+          data: abcSort(unfilteredFavorites, 'name'),
           key: 'unfilteredFavorites',
           title: tokenSectionTypes.favoriteTokenSection,
         });


### PR DESCRIPTION
## What changed (plus any additional context for devs)
sorting favorites by abc in `useSwapCurrencyList`

## Screen recordings / screenshots
### unfiltered aka no search query
<img width="354" alt="Screen Shot 2022-07-12 at 4 00 55 PM" src="https://user-images.githubusercontent.com/14877580/178585853-62473310-a49d-43b5-bdba-ba20e0d2d52a.png">

### with search query
<img width="354" alt="Screen Shot 2022-07-12 at 4 01 11 PM" src="https://user-images.githubusercontent.com/14877580/178585872-e556ce86-21c3-47f5-9358-22f298e047b2.png">

## What to test
Ensure whether searching or viewing the default favorites list on the currency selection modal that favorites remain sorted alphabetically.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
