### PR TITLE
Fix crash on double pressing add button

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -79,6 +79,7 @@ export default React.memo(function FastCurrencySelectionRow({
     nativeCurrencySymbol,
     favorite,
     toggleFavorite,
+    onAddPress,
     contextMenuProps,
     symbol,
     address,
@@ -223,7 +224,7 @@ export default React.memo(function FastCurrencySelectionRow({
               />
             ))}
           {showAddButton && (
-            <ButtonPressAnimation onPress={toggleFavorite}>
+            <ButtonPressAnimation onPress={onAddPress}>
               <SafeRadialGradient
                 center={[0, 15]}
                 colors={colors.gradients.lightestGrey}

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -170,6 +170,7 @@ export default React.memo(function FastCurrencySelectionRow({
             <ContextMenuButton
               activeOpacity={0}
               isMenuPrimaryAction
+              onPressMenuItem={contextMenuProps.handlePressMenuItem}
               useActionSheetFallback={false}
               wrapNativeComponent={false}
               {...contextMenuProps}

--- a/src/components/exchange/ExchangeAssetList.js
+++ b/src/components/exchange/ExchangeAssetList.js
@@ -250,6 +250,11 @@ const ExchangeAssetList = (
           ),
           nativeCurrency,
           nativeCurrencySymbol,
+          onAddPress: () => {
+            itemProps.onActionAsset(
+              store.getState().data.genericAssets?.[rowData.address] || rowData
+            );
+          },
           onCopySwapDetailsText,
           onPress: givenItem => {
             if (rowData.ens) {
@@ -280,11 +285,6 @@ const ExchangeAssetList = (
                 haptics.selection();
               }
 
-              itemProps.onActionAsset(
-                store.getState().data.genericAssets?.[rowData.address] ||
-                  rowData,
-                newValue
-              );
               return {
                 ...prev,
                 [rowData.address]: newValue,


### PR DESCRIPTION
Fixes https://rainbowhaus.slack.com/archives/C02C2FVC6N6/p1657701308401929

## What changed (plus any additional context for devs)
Looks like the previous logic "accidentally" worked - it was setting the favorite and opening sheet at the same time. For the second time, it was crashing because `onNewEmoji` was `undefined`. Now, I split this into two functions, and works ok! 

Another bug was not pressable buttons in the menu after pressing `i`  - incorrect prop name was used

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
After: https://streamable.com/pnr1sh
Before: See the linked message



## What to test
Check the Search list and all buttons, the do the same with the Selection list for input and output currency for swap (this is the same component) 

