### PR TITLE
[Chore] Add root `@/*` alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "target": "esnext",
     "baseUrl": ".",
     "paths": {
+      "@/*": ["./src/*"],
       "@rainbow-me/apollo": ["./src/apollo"],
       "@rainbow-me/apollo/*": ["./src/apollo/*"],
       "@rainbow-me/assets": ["./src/assets"],


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Adds a single alias to replace the many aliases we already have. **Why?** Because:
- it's less to maintain
- `@rainbow-me/*` looks like a real npm package like `@rainbow-me/rainbowkit`, which makes code harder to grok/skim
- because it looks like a real npm package, we have to add a new alias for each new directory we add under `./src` so that eslint doesn't think it's a real npm package and sort it to the top
- I want to improve import ordering
  - we could just have prettier [fix it for us automatically](https://github.com/trivago/prettier-plugin-sort-imports), why spend time linting it first
  - currently we sort by separating external libraries and internal modules, and then alphabetically, but that's not very helpful imo
  - I'd like to propose we sort and group by order of specificity:
    - external libraries
    - helpers/utils/constants/etc
    - maybe data fetching and similar
    - components
    - layouts maybe?
    - screens

### Background
Love that we have aliases in place, but we could be more consistent, and we should encourage all imports in every file to use aliases so that when moving and reorganizing files we don't have to update imports.

Also, the pattern `@/*` I believe came from [Vue](https://vuejs.org/). I've also seen `~/*`, which makes sense for unix users but some IDEs think it's a real system path, which makes autocomplete a little wonky sometimes. But also a good option, and visually very different from an npm library.

## Screen recordings / screenshots
N/A

## What to test
Nothing to test, just adding an alias that we can start using.

## Final checklist
- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
