### PR TITLE
Set custom depth of the scroll view in Exchange modal in RNCM

### DIFF
--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -256,7 +256,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen
         component={ExchangeModalNavigator}
         name={Routes.EXCHANGE_MODAL}
-        options={{ ...nativeStackDefaultConfig, interactWithScrollView: false }}
+        options={{ ...nativeStackDefaultConfig, relevantScrollViewDepth: 2 }}
       />
       <NativeStack.Screen
         component={ExpandedAssetSheet}

--- a/src/react-native-cool-modals/NativeStackView.js
+++ b/src/react-native-cool-modals/NativeStackView.js
@@ -40,6 +40,7 @@ function ScreenView({ colors, descriptors, navigation, route, state, hidden }) {
     springDamping,
     stackAnimation,
     stackPresentation = 'push',
+    relevantScrollViewDepth,
     startFromShortForm,
     topOffset,
     transitionDuration,
@@ -124,6 +125,7 @@ function ScreenView({ colors, descriptors, navigation, route, state, hidden }) {
         onTouchTop={onTouchTop}
         onWillDismiss={onWillDismiss}
         ref={ref}
+        relevantScrollViewDepth={relevantScrollViewDepth}
         shortFormHeight={shortFormHeight}
         showDragIndicator={showDragIndicator}
         springDamping={springDamping}

--- a/src/react-native-cool-modals/ios/RNCMScreen.h
+++ b/src/react-native-cool-modals/ios/RNCMScreen.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @property (nonatomic) BOOL disableShortFormAfterTransitionToLongForm;
 @property (nonatomic) NSNumber* topOffset;
 @property (nonatomic) NSNumber* cornerRadius;
+@property (nonatomic) NSNumber* relevantScrollViewDepth;
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 

--- a/src/react-native-cool-modals/ios/RNCMScreen.m
+++ b/src/react-native-cool-modals/ios/RNCMScreen.m
@@ -53,6 +53,7 @@
     _interactWithScrollView = true;
     _hidden = false;
     _disableShortFormAfterTransitionToLongForm = false;
+    _relevantScrollViewDepth = @1;
   }
   
   return self;
@@ -478,6 +479,7 @@ RCT_EXPORT_VIEW_PROPERTY(backgroundOpacity, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(longFormHeight, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(headerHeight, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(shortFormHeight, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(relevantScrollViewDepth, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(isShortFormEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(blocksBackgroundTouches, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(anchorModalToLongForm, BOOL)

--- a/src/react-native-cool-modals/ios/UIViewController+slack.swift
+++ b/src/react-native-cool-modals/ios/UIViewController+slack.swift
@@ -135,6 +135,7 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
   var isHapticFeedbackEnabled: Bool = false
 
   func findChildScrollViewDFS(view: UIView)-> UIScrollView? {
+    var foundScrollViews = 0
     if panScrollableCache != nil {
       return panScrollableCache
     }
@@ -143,8 +144,11 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
       let last = viewsToTraverse.last!
       viewsToTraverse.removeLast()
       if last is UIScrollView {
-        panScrollableCache = last as? UIScrollView
-        return last as? UIScrollView
+        foundScrollViews += 1
+        if foundScrollViews == relevantScrollViewDepth {
+          panScrollableCache = last as? UIScrollView
+          return last as? UIScrollView
+        }
       }
       last.subviews.forEach { subview in
         viewsToTraverse.append(subview)
@@ -191,6 +195,10 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
 
   var anchorModalToLongForm: Bool {
     return self.config?.anchorModalToLongForm ?? false
+  }
+  
+  var relevantScrollViewDepth: Int {
+    return self.config?.relevantScrollViewDepth.intValue ?? 1
   }
 
   var panModalBackgroundColor: UIColor {

--- a/src/react-native-cool-modals/ios/UIViewController+slack.swift
+++ b/src/react-native-cool-modals/ios/UIViewController+slack.swift
@@ -135,10 +135,10 @@ class PanModalViewController: UIViewController, PanModalPresentable, UILayoutSup
   var isHapticFeedbackEnabled: Bool = false
 
   func findChildScrollViewDFS(view: UIView)-> UIScrollView? {
-    var foundScrollViews = 0
     if panScrollableCache != nil {
       return panScrollableCache
     }
+    var foundScrollViews = 0
     var viewsToTraverse = [view]
     while !viewsToTraverse.isEmpty {
       let last = viewsToTraverse.last!


### PR DESCRIPTION
Fixes TEAM2-216
Figma link (if any):

## What changed (plus any additional context for devs)

In the exchange, modals there are two scrollviews - outer for the horizontal animation (not interactive with a gesture) and inner for the vertical scroll. Obviously, we want ot attach the logic to the inner. 

I added a small trick to let developers specify which scroll view ot use in the order of DFS traversing. In this case, this is the second, not the first one.  


In the preview it looks like this: 


outer: 
![Pasted Graphic 1](https://user-images.githubusercontent.com/25709300/178957364-c18fd22f-7a4f-4ee9-9898-208bd3986139.png)

inner: 

![Pasted Graphic 2](https://user-images.githubusercontent.com/25709300/178957376-022fd974-bfa0-46fb-9ff4-ec5f54279af2.png)




So i added an option `relevantScrollViewDepth`. 


## Screen recordings / screenshots
The behavior is expected: https://streamable.com/634wyp



To test changes, please open the Exchange modal and observe interactions. If they are ok, it's ok. You may check also other modals, e.g., switch wallet sheet or setting screen (or small phones), but I don't expect this is serious. I checked it all and it's fine 