### PR TITLE
Don't pass source=rainbow to the backend

### DIFF
--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -42,6 +42,11 @@ enum DisplayValue {
   native = 'nativeAmountDisplay',
 }
 
+const getSource = (source: Source | null) => {
+  if (source === Source.AggregatorRainbow) return null;
+  return source;
+};
+
 const getInputAmount = async (
   outputAmount: string | null,
   inputToken: Token,
@@ -73,7 +78,7 @@ const getInputAmount = async (
       convertNumberToString(outputAmount),
       outputToken.decimals
     );
-
+    const realSource = getSource(source);
     const quoteParams = {
       buyAmount,
       buyTokenAddress,
@@ -82,7 +87,7 @@ const getInputAmount = async (
       sellTokenAddress,
       // Add 5% slippage for testing to prevent flaky tests
       slippage: IS_TESTING !== 'true' ? slippage : 5,
-      source: source,
+      source: realSource,
     };
 
     const rand = Math.floor(Math.random() * 100);
@@ -179,7 +184,7 @@ const getOutputAmount = async (
       convertNumberToString(inputAmount),
       inputToken.decimals
     );
-
+    const realSource = getSource(source);
     const quoteParams = {
       buyAmount: null || '0',
       buyTokenAddress,
@@ -189,7 +194,7 @@ const getOutputAmount = async (
       sellTokenAddress,
       // Add 5% slippage for testing to prevent flaky tests
       slippage: IS_TESTING !== 'true' ? slippage : 5,
-      source,
+      source: realSource,
     };
 
     const rand = Math.floor(Math.random() * 100);


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
Ignoring the source=rainbow so it doesn't get pass to the backend ( we only support 0x and 1inch)

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://recordit.co/8bSV2YDbUp

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
Switch sources and look at the logs. When "Auto" is selected there shouldn't be a source in the quote

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
