### PR TITLE
fix remaining l2 color/icon issues

### DIFF
--- a/src/screens/AddTokenSheet.js
+++ b/src/screens/AddTokenSheet.js
@@ -107,7 +107,12 @@ export default function AddTokenSheet() {
       >
         <Centered direction="column" testID="add-token-sheet">
           <Column marginTop={16}>
-            <CoinIcon address={item.address} size={50} symbol={item.symbol} />
+            <CoinIcon
+              address={item.address}
+              size={50}
+              symbol={item.symbol}
+              type={item.type}
+            />
           </Column>
           <Column marginBottom={4} marginTop={12}>
             <Text

--- a/src/screens/SendConfirmationSheet.js
+++ b/src/screens/SendConfirmationSheet.js
@@ -27,6 +27,7 @@ import {
 import useExperimentalFlag, {
   PROFILES,
 } from '@rainbow-me/config/experimentalHooks';
+import { AssetTypes } from '@rainbow-me/entities';
 import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
@@ -283,6 +284,7 @@ export default function SendConfirmationSheet() {
 
   let color = useColorForAsset({
     address: asset.mainnet_address || asset.address,
+    type: asset?.mainnet_address ? AssetTypes.token : asset?.type,
   });
 
   if (isNft) {


### PR DESCRIPTION
Fixes RNBW-3928
Figma link (if any):

## What changed (plus any additional context for devs)
we missed a few spots for l2 icons, this fixes. I went through and tried to find more but I think this should cover the rest

1. send confirmation sheet needed the type to calculate the proper color
2. add token sheet needed the type to get the proper icon


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
1. https://cloud.skylarbarrera.com/Screen-Shot-2022-07-14-15-42-20.21.png
2. https://cloud.skylarbarrera.com/Screen-Shot-2022-07-14-15-44-32.49.png


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
the above


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
