### PR TITLE
fix polygon OS images

### DIFF
--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -152,9 +152,9 @@ export const parseAccountUniqueTokensPolygon = data => {
   erc721s = erc721s
     .map(({ asset_contract, collection, token_id, metadata, ...asset }) => {
       const { imageUrl, lowResUrl } = handleAndSignImages(
-        asset.image_url,
-        asset.image_original_url,
-        asset.image_preview_url
+        metadata.image_url,
+        metadata.image_original_url,
+        metadata.image_preview_url
       );
       return {
         ...pickShallow(metadata, [


### PR DESCRIPTION
Fixes TEAM2-251 RNBW-3645
Figma link (if any):

## What changed (plus any additional context for devs)
polygon images stopped working in the app ~2 months ago, we had a ticket that should have made us aware but it got lost in triage handoff.

tldr: opensea only sends asset images under `metadata` now on the v2 endpoint


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://cloud.skylarbarrera.com/Screen-Recording-2022-07-14-18-03-18.mp4



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

visitors + 100t images should show up
misfitinternet.eth + skillet.eth 


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
