### PR TITLE
fix: use colors from theme for favStar

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -32,7 +32,7 @@ interface FavStarProps {
 }
 
 function FavStar({ toggleFavorite, favorite, theme }: FavStarProps) {
-  const { isDarkMode } = theme;
+  const { isDarkMode, colors } = theme;
   return (
     <ButtonPressAnimation onPress={toggleFavorite}>
       <SafeRadialGradient


### PR DESCRIPTION
Fixes RNBW-3979
Figma link (if any):

## What changed (plus any additional context for devs)

just using colors from theme, before colors was being used from @rainbow-me/styles so wasn't working well

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/fa24d28403c3406f9d6d792bbd39774b?from_recorder=1&focus_title=1

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
