### PR TITLE
fix l2 txs

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -972,7 +972,12 @@ export const transactionsReceived = (
   if (appended) {
     dispatch(checkForConfirmedSavingsActions(transactionData));
   }
-  if (transactionData.length) {
+
+  let { network } = getState().settings;
+  if (network === Network.mainnet && message?.meta?.chain_id) {
+    network = message?.meta?.chain_id;
+  }
+  if (transactionData.length && network === Network.mainnet) {
     dispatch(checkForUpdatedNonce(transactionData));
   }
 
@@ -981,10 +986,6 @@ export const transactionsReceived = (
   const { pendingTransactions, transactions } = getState().data;
   const { selected } = getState().wallets;
 
-  let { network } = getState().settings;
-  if (network === Network.mainnet && message?.meta?.chain_id) {
-    network = message?.meta?.chain_id;
-  }
   const {
     parsedTransactions,
     potentialNftTransaction,

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -973,11 +973,12 @@ export const transactionsReceived = (
     dispatch(checkForConfirmedSavingsActions(transactionData));
   }
 
-  let { network } = getState().settings;
-  if (network === Network.mainnet && message?.meta?.chain_id) {
-    network = message?.meta?.chain_id;
+  const { network } = getState().settings;
+  let currentNetwork = network;
+  if (currentNetwork === Network.mainnet && message?.meta?.chain_id) {
+    currentNetwork = message?.meta?.chain_id;
   }
-  if (transactionData.length && network === Network.mainnet) {
+  if (transactionData.length && currentNetwork === Network.mainnet) {
     dispatch(checkForUpdatedNonce(transactionData));
   }
 
@@ -995,7 +996,7 @@ export const transactionsReceived = (
     nativeCurrency,
     transactions,
     purchaseTransactions,
-    network,
+    currentNetwork,
     appended
   );
   if (appended && potentialNftTransaction) {


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
l2 txs were getting stuck sorting in update nonce, I added a mainnet check. I also moved to using currentNetwork for the local network.

this also fixes an issue where the updated txs were being saved to local storage with L2 network types which will never get loaded. they are now saved under the global network as expected


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://cloud.skylarbarrera.com/Screen-Shot-2022-07-14-21-42-47.11.png


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

enable L2 txs, switch wallets and check persisting data


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
