### PR TITLE
[TEAM2-237] Failed L2 swaps don't display "Failed" transaction activity state

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1594,8 +1594,13 @@ export const dataWatchPendingTransactions = (
           let receipt;
           try {
             receipt = await txObj.wait();
-          } catch (e) {
-            updatedPending.status = TransactionStatus.failed;
+          } catch (e: any) {
+            // https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse
+            if (e.transaction) {
+              updatedPending.status = TransactionStatus.failed;
+            } else {
+              updatedPending.status = TransactionStatus.cancelled;
+            }
             const title = getTitle({
               protocol: tx.protocol,
               status: updatedPending.status,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Transaction.status doesn't exist on the transaction confirmation object anymore. We now invoke `txConfirmationObject.wait()` to inspect the transaction receipt to determine the status.
https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse

## Screen recordings / screenshots
https://recordit.co/WMGFxVEjH6

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
