### PR TITLE
Fix SVG image placeholder

### DIFF
--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -112,12 +112,15 @@ class SvgImage extends Component {
       setTimeout(() => this.setState({ trulyLoaded: true }), 1000);
     }
   };
+
   render() {
     const props = this.props;
     const { svgContent } = this.state;
+
+    let html;
+    let isSVGAnimated = false;
     if (svgContent) {
       const flattenedStyle = StyleSheet.flatten(props.style) || {};
-      let html;
       if (svgContent.includes('viewBox')) {
         html = getHTML(svgContent, flattenedStyle);
       } else {
@@ -140,51 +143,46 @@ class SvgImage extends Component {
         html = getHTML(patchedSvgContent, flattenedStyle);
       }
 
-      const isSVGAnimated = html?.indexOf('<animate') !== -1;
-
-      return (
-        <View style={[props.style, props.containerStyle]}>
-          {!this.state.trulyLoaded && props.lowResFallbackUri && (
-            <ImageTile
-              resizeMode={ImgixImage.resizeMode.cover}
-              source={{ uri: props.lowResFallbackUri }}
-              style={position.coverAsObject}
-            />
-          )}
-          {!this.state.trulyLoaded && props.fallbackUri && (
-            <ImageTile
-              resizeMode={ImgixImage.resizeMode.cover}
-              source={{ uri: props.fallbackUri }}
-              style={position.coverAsObject}
-            />
-          )}
-          {(!props.fallbackIfNonAnimated || isSVGAnimated) && (
-            <WebView
-              onMessage={this.onLoad}
-              originWhitelist={['*']}
-              pointerEvents="none"
-              scalesPageToFit
-              scrollEnabled={false}
-              showsHorizontalScrollIndicator={false}
-              showsVerticalScrollIndicator={false}
-              source={{ html }}
-              style={[
-                styles,
-                props.style,
-                { display: this.state.loaded || android ? 'flex' : 'none' },
-              ]}
-            />
-          )}
-        </View>
-      );
-    } else {
-      return (
-        <View
-          pointerEvents="none"
-          style={[props.containerStyle, props.style]}
-        />
-      );
+      isSVGAnimated = html?.indexOf('<animate') !== -1;
     }
+
+    return (
+      <View style={[props.containerStyle, props.style]}>
+        {!this.state.trulyLoaded && props.lowResFallbackUri && (
+          <ImageTile
+            fm="png"
+            resizeMode={ImgixImage.resizeMode.cover}
+            source={{ uri: props.lowResFallbackUri }}
+            style={position.coverAsObject}
+          />
+        )}
+        {!this.state.trulyLoaded && props.fallbackUri && (
+          <ImageTile
+            fm="png"
+            resizeMode={ImgixImage.resizeMode.cover}
+            source={{ uri: props.fallbackUri }}
+            style={position.coverAsObject}
+          />
+        )}
+        {(!props.fallbackIfNonAnimated || isSVGAnimated) && (
+          <WebView
+            onMessage={this.onLoad}
+            originWhitelist={['*']}
+            pointerEvents="none"
+            scalesPageToFit
+            scrollEnabled={false}
+            showsHorizontalScrollIndicator={false}
+            showsVerticalScrollIndicator={false}
+            source={{ html }}
+            style={[
+              styles,
+              props.style,
+              { display: this.state.loaded || android ? 'flex' : 'none' },
+            ]}
+          />
+        )}
+      </View>
+    );
   }
 }
 


### PR DESCRIPTION
Fixes RNBW-3468

## What changed (plus any additional context for devs)

This PR fixes an issue where the user would see a brief blank placeholder before the SVG content is loaded.

## Screen recordings / screenshots

Before:

https://www.loom.com/share/03c7f62f771f4e34b67b6fc2cdda52e1

After:

https://www.loom.com/share/649ef614925345b2b611f8e245d73e69

## What to test

- For SVG NFTs, ensure that no blank placeholder is seen before the image loads.
- For SVG NFTs, ensure that the image loads in the NFT expanded state.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
