### PR TITLE
Failed L2 swaps don't display Failed transaction activity state

### DIFF
--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1599,7 +1599,7 @@ export const dataWatchPendingTransactions = (
           txStatusesDidChange = true;
           let receipt;
           try {
-            if (!nonceAlreadyIncluded) {
+            if (txObj) {
               receipt = await txObj.wait();
             }
           } catch (e: any) {

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1599,7 +1599,9 @@ export const dataWatchPendingTransactions = (
           txStatusesDidChange = true;
           let receipt;
           try {
-            receipt = await txObj.wait();
+            if (!nonceAlreadyIncluded) {
+              receipt = await txObj.wait();
+            }
           } catch (e: any) {
             // https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse
             if (e.transaction) {

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1597,8 +1597,28 @@ export const dataWatchPendingTransactions = (
           }
           const minedAt = Math.floor(Date.now() / 1000);
           txStatusesDidChange = true;
-          // @ts-expect-error `txObj` is not typed as having a `status` field.
-          if (txObj && !isZero(txObj.status)) {
+          let receipt;
+          try {
+            receipt = await txObj.wait();
+          } catch (e: any) {
+            // https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse
+            if (e.transaction) {
+              // if a transaction field exists, it was confirmed but failed
+              updatedPending.status = TransactionStatus.failed;
+            } else {
+              // cancelled or replaced
+              updatedPending.status = TransactionStatus.cancelled;
+            }
+            const title = getTitle({
+              protocol: tx.protocol,
+              status: updatedPending.status,
+              type: tx.type,
+            });
+            updatedPending.title = title;
+            updatedPending.pending = false;
+            updatedPending.minedAt = minedAt;
+          }
+          if (txObj && !isZero(receipt?.status || 0)) {
             const isSelf = tx?.from!.toLowerCase() === tx?.to!.toLowerCase();
             const newStatus = getTransactionLabel({
               direction: isSelf

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1609,16 +1609,9 @@ export const dataWatchPendingTransactions = (
               // cancelled or replaced
               updatedPending.status = TransactionStatus.cancelled;
             }
-            const title = getTitle({
-              protocol: tx.protocol,
-              status: updatedPending.status,
-              type: tx.type,
-            });
-            updatedPending.title = title;
-            updatedPending.pending = false;
-            updatedPending.minedAt = minedAt;
           }
-          if (txObj && !isZero(receipt?.status || 0)) {
+          const status = receipt?.status || 0;
+          if (!isZero(status)) {
             const isSelf = tx?.from!.toLowerCase() === tx?.to!.toLowerCase();
             const newStatus = getTransactionLabel({
               direction: isSelf


### PR DESCRIPTION
Fixes [TEAM2-237]
Transaction.status doesn't exist on the transaction confirmation object anymore. We now invoke txConfirmationObject.wait() to inspect the transaction receipt to determine the status.
https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse

Screen recordings / screenshots
https://recordit.co/WMGFxVEjH6

## What to test
https://github.com/rainbow-me/rainbow/tree/%40derHowie/check-tx-receipts-test-branch
The branch above cuts `gasLimit` in half on swaps and enabled the transaction watcher so that mainnet swaps will fail and we will see the changes in the pending transaction logic execute.

* ensure failed transactions appear correctly in the tx list on the branch above
* ensure successful transactions behave normally on the branch that isn't broken (@derHowie/check-tx-receipts)


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
