### PR TITLE
fix: empty input flipping behavior

### DIFF
--- a/src/hooks/useSwapCurrencyHandlers.js
+++ b/src/hooks/useSwapCurrencyHandlers.js
@@ -146,36 +146,42 @@ export default function useSwapCurrencyHandlers({
 
   const flipCurrencies = useCallback(() => {
     if (currentNetwork === Network.arbitrum) {
+      const outputAmount = derivedValues?.outputAmount;
       updateOutputAmount(null);
       flipSwapCurrenciesWithTimeout(
         nativeFieldRef.current === currentlyFocusedInput()
           ? nativeFieldRef
           : inputFieldRef,
         false,
-        updatePrecisionToDisplay(derivedValues?.outputAmount)
+        outputAmount ? updatePrecisionToDisplay(outputAmount) : null
       );
     } else if (nativeFieldRef.current === currentlyFocusedInput()) {
+      const inputAmount = derivedValues?.inputAmount;
       updateOutputAmount(null);
       updateNativeAmount(null);
       flipSwapCurrenciesWithTimeout(
         outputFieldRef,
         true,
-        updatePrecisionToDisplay(derivedValues?.inputAmount)
+        inputAmount ? updatePrecisionToDisplay(inputAmount) : null
       );
     } else if (inputFieldRef.current === currentlyFocusedInput()) {
+      const inputAmount = derivedValues?.inputAmount;
       updateNativeAmount(null);
       updateInputAmount(null);
       flipSwapCurrenciesWithTimeout(
         outputFieldRef,
         true,
-        updatePrecisionToDisplay(derivedValues?.inputAmount)
+        inputAmount ? updatePrecisionToDisplay(inputAmount) : null
       );
     } else if (outputFieldRef.current === currentlyFocusedInput()) {
+      const outputAmount = derivedValues?.outputAmount;
       updateOutputAmount(null);
       flipSwapCurrenciesWithTimeout(
         inputFieldRef,
         false,
-        updatePrecisionToDisplay(derivedValues?.outputAmount)
+        outputAmount
+          ? updatePrecisionToDisplay(derivedValues?.outputAmount)
+          : null
       );
     }
   }, [


### PR DESCRIPTION
Fixes TEAM2-261
Figma link (if any):

## What changed (plus any additional context for devs)

Flipping when the inputs are empty will add a `0` to the input is focused, video in ticket

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

fixed
https://www.loom.com/share/72f5536272d24cc98d5d82ce1d82e45d

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- press flip when both of the inputs are empty, they should remain empty after the flip


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
