### PR TITLE
swaps: exchange icons memos + error reset

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -18,9 +18,9 @@ import {
   useForegroundColor,
 } from '@rainbow-me/design-system';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
-import { useStepper } from '@rainbow-me/hooks';
+import { usePrevious, useStepper } from '@rainbow-me/hooks';
 import { ImgixImage } from '@rainbow-me/images';
-import { getExchangeIconUrl } from '@rainbow-me/utils';
+import { getExchangeIconUrl, magicMemo } from '@rainbow-me/utils';
 
 const parseExchangeName = name => {
   const networks = Object.keys(networkInfo).map(network =>
@@ -31,91 +31,98 @@ const parseExchangeName = name => {
     ? name.slice(name.indexOf('_') + 1, name.length)
     : name;
 };
+const ExchangeIcon = magicMemo(
+  function ExchangeIcon({ index = 1, icon, protocol }) {
+    const { colors } = useTheme();
+    const [error, setError] = useState(false);
+    const previousIcon = usePrevious(icon);
+    if (error && icon !== previousIcon) {
+      setError(false);
+    }
 
-const ExchangeIcon = ({ index = 1, icon, protocol }) => {
-  const { colors } = useTheme();
-  const [error, setError] = useState(false);
-
-  return (
-    <Fragment>
-      {icon && !error ? (
-        <ImgixImage
-          onError={() => setError(true)}
-          size={20}
-          source={{ uri: icon }}
-          style={{
-            borderColor: colors.white,
-            borderRadius: 10,
-            borderWidth: 1.5,
-            height: 20,
-            width: 20,
-            zIndex: index,
-          }}
-        />
-      ) : (
-        <Stack>
-          <Box
-            alignHorizontal="center"
-            alignVertical="center"
-            height={{ custom: 20 }}
+    return (
+      <Fragment>
+        {icon && !error ? (
+          <ImgixImage
+            onError={() => setError(true)}
+            size={20}
+            source={{ uri: icon }}
             style={{
-              backgroundColor: colors.exchangeFallback,
               borderColor: colors.white,
               borderRadius: 10,
               borderWidth: 1.5,
+              height: 20,
+              width: 20,
               zIndex: index,
             }}
-            width={{ custom: 20 }}
-          >
-            <Cover alignHorizontal="center" alignVertical="center">
-              <Box
-                style={
-                  android && {
-                    top: 1,
+          />
+        ) : (
+          <Stack>
+            <Box
+              alignHorizontal="center"
+              alignVertical="center"
+              height={{ custom: 20 }}
+              style={{
+                backgroundColor: colors.exchangeFallback,
+                borderColor: colors.white,
+                borderRadius: 10,
+                borderWidth: 1.5,
+                zIndex: index,
+              }}
+              width={{ custom: 20 }}
+            >
+              <Cover alignHorizontal="center" alignVertical="center">
+                <Box
+                  style={
+                    android && {
+                      top: 1,
+                    }
                   }
-                }
-              >
-                <Text
-                  align="center"
-                  color="secondary80"
-                  size="14px"
-                  weight="semibold"
                 >
-                  {protocol?.substring(0, 1)}
-                </Text>
-              </Box>
-            </Cover>
-          </Box>
-        </Stack>
-      )}
-    </Fragment>
-  );
-};
+                  <Text
+                    align="center"
+                    color="secondary80"
+                    size="14px"
+                    weight="semibold"
+                  >
+                    {protocol?.substring(0, 1)}
+                  </Text>
+                </Box>
+              </Cover>
+            </Box>
+          </Stack>
+        )}
+      </Fragment>
+    );
+  },
+  ['icon', 'protocol']
+);
 
-const ExchangeIconStack = ({ protocols }) => {
-  return (
-    <Inline>
-      {protocols?.icons?.map((icon, index) => {
-        return (
-          <Box
-            key={`protocol-icon-${index}`}
-            marginLeft={{ custom: -4 }}
-            zIndex={protocols?.icons?.length - index}
-          >
-            <ExchangeIcon
-              icon={icon}
-              protocol={protocols?.name || protocols.names[index]}
-            />
-          </Box>
-        );
-      })}
-    </Inline>
-  );
-};
+const ExchangeIconStack = magicMemo(
+  ({ protocols }) => {
+    return (
+      <Inline>
+        {protocols?.icons?.map((icon, index) => {
+          return (
+            <Box
+              key={`protocol-icon-${index}`}
+              marginLeft={{ custom: -4 }}
+              zIndex={protocols?.icons?.length - index}
+            >
+              <ExchangeIcon
+                icon={icon}
+                protocol={protocols?.name || protocols.names[index]}
+              />
+            </Box>
+          );
+        })}
+      </Inline>
+    );
+  },
+  ['protocols']
+);
 
-export default function SwapDetailsExchangeRow(props) {
-  const { protocols } = props;
-
+export default function SwapDetailsExchangeRow({ protocols }) {
   const steps = useMemo(() => {
     const sortedProtocols = protocols?.sort((a, b) => b.part - a.part);
     const defaultCase = {

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -111,7 +111,7 @@ const ExchangeIconStack = magicMemo(
             >
               <ExchangeIcon
                 icon={icon}
-                protocol={protocols?.name || protocols.names[index]}
+                protocol={protocols?.name ?? protocols.names[index]}
               />
             </Box>
           );


### PR DESCRIPTION
Fixes TEAM2-262
Figma link (if any):

## What changed (plus any additional context for devs)
I added some memo's and ensured that the error state is getting reset on a new url, seems to be working as expected. can't repro anymore


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

easiest on polygon to get multiple exchanges, open swap details and wait a bit for the quote to update. 


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
