### PR TITLE
Add default slippage to remote config

### DIFF
--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -57,6 +57,7 @@ export interface RainbowConfig extends Record<string, any> {
   ethereum_ropsten_rpc?: string;
   optimism_mainnet_rpc?: string;
   polygon_mainnet_rpc?: string;
+  default_slippage_bips?: number;
 }
 
 const DEFAULT_CONFIG = {
@@ -64,6 +65,7 @@ const DEFAULT_CONFIG = {
   data_api_key: DATA_API_KEY,
   data_endpoint: DATA_ENDPOINT || 'wss://api-v4.zerion.io',
   data_origin: DATA_ORIGIN,
+  default_slippage_bips: 100,
   ethereum_goerli_rpc: __DEV__ ? ETHEREUM_GOERLI_RPC_DEV : ETHEREUM_GOERLI_RPC,
   ethereum_kovan_rpc: __DEV__ ? ETHEREUM_KOVAN_RPC_DEV : ETHEREUM_KOVAN_RPC,
   ethereum_mainnet_rpc: __DEV__

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -35,6 +35,7 @@ import { FloatingPanel } from '../components/floating-panels';
 import { GasSpeedButton } from '../components/gas';
 import { Column, KeyboardFixedOpenLayout } from '../components/layout';
 import { delayNext } from '../hooks/useMagicAutofocus';
+import config from '@/model/config';
 import { Box, Row, Rows } from '@rainbow-me/design-system';
 import { AssetType } from '@rainbow-me/entities';
 import { getProviderForNetwork } from '@rainbow-me/handlers/web3';
@@ -67,7 +68,11 @@ import {
   getSwapRapEstimationByType,
   getSwapRapTypeByExchangeType,
 } from '@rainbow-me/raps';
-import { swapClearState, updateSwapTypeDetails } from '@rainbow-me/redux/swap';
+import {
+  swapClearState,
+  updateSwapSlippage,
+  updateSwapTypeDetails,
+} from '@rainbow-me/redux/swap';
 import { ETH_ADDRESS, ethUnits } from '@rainbow-me/references';
 import Routes from '@rainbow-me/routes';
 import styled from '@rainbow-me/styled-components';
@@ -339,6 +344,7 @@ export default function ExchangeModal({
   }, [addListener, dangerouslyGetParent, lastFocusedInputHandle]);
 
   useEffect(() => {
+    dispatch(updateSwapSlippage(config.default_slippage_bips));
     return () => {
       dispatch(swapClearState());
       resetSwapInputs();


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
Added default slippage to remote config

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
Jumped on a call with @estebanmino to verify this works properly


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

You can change the value in the remote config, restart the app and it should be reflected in the slippage settings


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
