### PR TITLE
Rename flashbots feature flag

### DIFF
--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -12,11 +12,11 @@ export const NOTIFICATIONS = 'Notifications';
 export const REVIEW_ANDROID = 'reviewAndroid';
 export const PROFILES = 'ENS Profiles';
 export const L2_TXS = 'L2 Transactions';
-export const FLASHBOTS = 'Flashbots';
+export const FLASHBOTS_WC = 'Flashbots for WC';
 
 export const defaultConfig = {
   // this flag is not reactive. We use this in a static context
-  [FLASHBOTS]: { settings: true, value: false },
+  [FLASHBOTS_WC]: { settings: true, value: false },
   [L2_TXS]: { needsRestart: true, settings: true, value: false },
   [LANGUAGE_SETTINGS]: { settings: false, value: false },
   [NOTIFICATIONS]: { needsRestart: true, settings: true, value: false },

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -43,7 +43,7 @@ import {
   MessageSigningSection,
   TransactionConfirmationSection,
 } from '../components/transaction';
-import { FLASHBOTS } from '../config/experimental';
+import { FLASHBOTS_WC } from '../config/experimental';
 import useExperimentalFlag from '../config/experimentalHooks';
 import { lightModeThemeColors } from '../styles/colors';
 import { Text } from '@rainbow-me/design-system';
@@ -245,7 +245,7 @@ export default function TransactionConfirmationScreen() {
 
   const isTestnet = isTestnetNetwork(currentNetwork);
   const isL2 = isL2Network(currentNetwork);
-  const flashbotsEnabled = useExperimentalFlag(FLASHBOTS);
+  const flashbotsEnabled = useExperimentalFlag(FLASHBOTS_WC);
 
   useEffect(() => {
     setCurrentNetwork(


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
The name was missleading... This flag was only enabling Flashbots support for WC which is something that we haven't fully explored yet, so I'm renaming it to `Flashbots for WC`

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

<img width="323" alt="Screen Shot 2022-07-19 at 12 34 53 PM" src="https://user-images.githubusercontent.com/1247834/179802958-a1b146a9-f087-4ce3-854a-00d7164b173d.png">


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

Go to settings => dev settings and make sure it says "Flashbots for WC" instead of "Flashbots"


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
