### PR TITLE
disable swap button after pressed once

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -35,7 +35,7 @@ export default function ConfirmExchangeButton({
   const { isSufficientGas, isValidGas } = useGas();
   const { name: routeName } = useRoute();
   const { navigate } = useNavigation();
-  const [swapSubmitted, submitSwap] = useReducer(() => true, false);
+  const [swapSubmitted, setSwapSubmitted] = useReducer(() => true, false);
 
   const isSavings =
     type === ExchangeModalTypes.withdrawal ||
@@ -146,6 +146,11 @@ export default function ConfirmExchangeButton({
     !isValidGas ||
     !isSufficientGas;
 
+  const onSwap = useCallback(() => {
+    onSubmit();
+    setSwapSubmitted();
+  }, [onSubmit, setSwapSubmitted]);
+
   return (
     <Box>
       <Rows alignHorizontal="center" alignVertical="bottom" space="8px">
@@ -166,10 +171,7 @@ export default function ConfirmExchangeButton({
                 ? handleShowLiquidityExplainer
                 : shouldOpenSwapDetails
                 ? onPressViewDetails
-                : () => {
-                    onSubmit();
-                    submitSwap();
-                  }
+                : onSwap
             }
             shadows={
               isSwapDetailsRoute

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -1,7 +1,7 @@
 import { useRoute } from '@react-navigation/native';
 import lang from 'i18n-js';
 import makeColorMoreChill from 'make-color-more-chill';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useReducer } from 'react';
 import { Keyboard } from 'react-native';
 import { darkModeThemeColors } from '../../styles/colors';
 import { HoldToAuthorizeButton } from '../buttons';
@@ -35,6 +35,7 @@ export default function ConfirmExchangeButton({
   const { isSufficientGas, isValidGas } = useGas();
   const { name: routeName } = useRoute();
   const { navigate } = useNavigation();
+  const [swapSubmitted, submitSwap] = useReducer(() => true, false);
 
   const isSavings =
     type === ExchangeModalTypes.withdrawal ||
@@ -159,13 +160,16 @@ export default function ConfirmExchangeButton({
             label={label}
             loading={loading}
             onLongPress={
-              loading
+              loading || swapSubmitted
                 ? NOOP
                 : insufficientLiquidity
                 ? handleShowLiquidityExplainer
                 : shouldOpenSwapDetails
                 ? onPressViewDetails
-                : onSubmit
+                : () => {
+                    onSubmit();
+                    submitSwap();
+                  }
             }
             shadows={
               isSwapDetailsRoute


### PR DESCRIPTION
Fixes TEAM2-268

## What changed (plus any additional context for devs)
- prevent user from clicking swap button more than once

## Screen recordings / screenshots

https://user-images.githubusercontent.com/15272675/179844781-1c3bbf78-bda2-480a-b58d-45756a6f2a63.mp4


## What to test
make sure you can't make duplicate tx's by spam clicking swap button


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
