### PR TITLE
[TEAM2-267] WETH not appearing on search

### DIFF
--- a/src/redux/uniswap.ts
+++ b/src/redux/uniswap.ts
@@ -197,8 +197,10 @@ const getUniswapFavoritesMetadata = async (
         return address === ETH_ADDRESS ? WETH_ADDRESS : address.toLowerCase();
       })
     );
+    const ethIsFavorited = addresses.includes(ETH_ADDRESS);
+    const wethIsFavorited = addresses.includes(WETH_ADDRESS);
     if (newFavoritesMeta) {
-      if (newFavoritesMeta[WETH_ADDRESS]) {
+      if (newFavoritesMeta[WETH_ADDRESS] && ethIsFavorited) {
         const favorite = newFavoritesMeta[WETH_ADDRESS];
         newFavoritesMeta[ETH_ADDRESS] = {
           ...favorite,
@@ -209,7 +211,7 @@ const getUniswapFavoritesMetadata = async (
         };
       }
       Object.entries(newFavoritesMeta).forEach(([address, favorite]) => {
-        if (address !== WETH_ADDRESS) {
+        if (address !== WETH_ADDRESS || wethIsFavorited) {
           favoritesMetadata[address] = { ...favorite, favorite: true };
         }
       });


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We use the WETH address to get uniswap v2 metadata for ETH. We accommodated for ETH in this way but unintentionally prevented WETH from receiving appropriate metadata when favorited.

## Screen recordings / screenshots
<img width="357" alt="Screen Shot 2022-07-19 at 3 58 26 PM" src="https://user-images.githubusercontent.com/14877580/179847213-f675e9df-715e-40e8-b2cc-25ba8bfb895f.png">

## What to test
Make sure WETH appears in search even when favorited.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
