### PR TITLE
swaps: add loading check to confirm button

### DIFF
--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -167,7 +167,7 @@ function HoldToAuthorizeButtonContent2({
   const onLongPressChange = ({
     nativeEvent: { state },
   }: HandlerStateChangeEvent) => {
-    if (state === ACTIVE && !disabled) {
+    if (state === ACTIVE && !disabled && !loading) {
       haptics.notificationSuccess();
       Keyboard.dismiss();
 
@@ -182,7 +182,7 @@ function HoldToAuthorizeButtonContent2({
   };
 
   const onTapChange = ({ nativeEvent: { state } }: HandlerStateChangeEvent) => {
-    if (disabled) {
+    if (disabled || loading) {
       if (state === END) {
         haptics.notificationWarning();
         buttonScale.value = withTiming(

--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -167,7 +167,7 @@ function HoldToAuthorizeButtonContent2({
   const onLongPressChange = ({
     nativeEvent: { state },
   }: HandlerStateChangeEvent) => {
-    if (state === ACTIVE && !disabled && !loading) {
+    if (state === ACTIVE && !disabled) {
       haptics.notificationSuccess();
       Keyboard.dismiss();
 
@@ -182,7 +182,7 @@ function HoldToAuthorizeButtonContent2({
   };
 
   const onTapChange = ({ nativeEvent: { state } }: HandlerStateChangeEvent) => {
-    if (disabled || loading) {
+    if (disabled) {
       if (state === END) {
         haptics.notificationWarning();
         buttonScale.value = withTiming(

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -157,7 +157,9 @@ export default function ConfirmExchangeButton({
         <Row height="content">
           <HoldToAuthorizeButton
             backgroundColor={buttonColor}
-            disableLongPress={shouldOpenSwapDetails && !insufficientLiquidity}
+            disableLongPress={
+              (shouldOpenSwapDetails && !insufficientLiquidity) || loading
+            }
             disableShimmerAnimation={insufficientLiquidity}
             disabled={isDisabled && !insufficientLiquidity}
             disabledBackgroundColor={disabledButtonColor}


### PR DESCRIPTION
Fixes TEAM2-264
Figma link (if any):

## What changed (plus any additional context for devs)
wasn't able to repro but from the logic it seems we needed some loading checks to be added to prevent authorizing to be set to true to early


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
