### PR TITLE
swaps: fix gas loading state

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -32,7 +32,7 @@ export default function ConfirmExchangeButton({
 }) {
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
   const asset = outputCurrency ?? inputCurrency;
-  const { isSufficientGas, isValidGas } = useGas();
+  const { isSufficientGas, isValidGas, isGasReady } = useGas();
   const { name: routeName } = useRoute();
   const { navigate } = useNavigation();
 
@@ -100,6 +100,8 @@ export default function ConfirmExchangeButton({
   ]);
 
   let label = '';
+  const loadingQuote = loading || (!loading && !isGasReady);
+
   if (type === ExchangeModalTypes.deposit) {
     label = lang.t('button.confirm_exchange.deposit');
   } else if (type === ExchangeModalTypes.swap) {
@@ -107,12 +109,11 @@ export default function ConfirmExchangeButton({
   } else if (type === ExchangeModalTypes.withdrawal) {
     label = lang.t('button.confirm_exchange.withdraw');
   }
-
-  if (loading) {
+  if (loadingQuote) {
     label = lang.t('button.confirm_exchange.fetching_quote');
   } else if (!isSufficientBalance) {
     label = lang.t('button.confirm_exchange.insufficient_funds');
-  } else if (isSufficientGas != null && !isSufficientGas) {
+  } else if (isValidGas && isSufficientGas !== null && !isSufficientGas) {
     label =
       currentNetwork === NetworkTypes.polygon
         ? lang.t('button.confirm_exchange.insufficient_matic')
@@ -157,7 +158,7 @@ export default function ConfirmExchangeButton({
             disabledBackgroundColor={disabledButtonColor}
             hideInnerBorder
             label={label}
-            loading={loading}
+            loading={loadingQuote}
             onLongPress={
               loading
                 ? NOOP

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -113,7 +113,7 @@ export default function ConfirmExchangeButton({
     label = lang.t('button.confirm_exchange.fetching_quote');
   } else if (!isSufficientBalance) {
     label = lang.t('button.confirm_exchange.insufficient_funds');
-  } else if (isValidGas && isSufficientGas !== null && !isSufficientGas) {
+  } else if (isSufficientGas != null && !isSufficientGas) {
     label =
       currentNetwork === NetworkTypes.polygon
         ? lang.t('button.confirm_exchange.insufficient_matic')

--- a/src/hooks/useGas.ts
+++ b/src/hooks/useGas.ts
@@ -51,8 +51,23 @@ const checkValidGas = (
   const gasValue = isL2
     ? (selectedGasParams as LegacyGasFeeParams)?.gasPrice
     : (selectedGasParams as GasFeeParams)?.maxFeePerGas;
-  const isValidGas = greaterThan(gasValue?.amount, 0);
+  const isValidGas = gasValue?.amount && greaterThan(gasValue?.amount, 0);
   return isValidGas;
+};
+
+const checkGasReady = (
+  txFee: LegacyGasFee | GasFee,
+  selectedGasParams: LegacyGasFeeParams | GasFeeParams,
+  network: Network
+) => {
+  const isL2 = isL2Network(network);
+  const gasValue = isL2
+    ? (selectedGasParams as LegacyGasFeeParams)?.gasPrice
+    : (selectedGasParams as GasFeeParams)?.maxFeePerGas;
+  const txFeeValue = isL2
+    ? (txFee as LegacyGasFee)?.estimatedFee
+    : (txFee as GasFee)?.maxFee;
+  return Boolean(gasValue?.amount) && Boolean(txFeeValue?.value?.amount);
 };
 
 export default function useGas({ nativeAsset }: { nativeAsset?: any } = {}) {
@@ -99,6 +114,20 @@ export default function useGas({ nativeAsset }: { nativeAsset?: any } = {}) {
     [gasData?.selectedGasFee, gasData?.txNetwork]
   );
 
+  const isGasReady = useMemo(
+    () =>
+      checkGasReady(
+        gasData?.selectedGasFee?.gasFee,
+        gasData?.selectedGasFee?.gasFeeParams,
+        gasData?.txNetwork
+      ),
+    [
+      gasData?.selectedGasFee?.gasFee,
+      gasData?.selectedGasFee?.gasFeeParams,
+      gasData?.txNetwork,
+    ]
+  );
+
   const startPollingGasFees = useCallback(
     (network = networkTypes.mainnet, flashbots = false) =>
       dispatch(gasPricesStartPolling(network, flashbots)),
@@ -134,6 +163,7 @@ export default function useGas({ nativeAsset }: { nativeAsset?: any } = {}) {
   );
 
   return {
+    isGasReady,
     isSufficientGas,
     isValidGas,
     prevSelectedGasFee,

--- a/src/hooks/useGas.ts
+++ b/src/hooks/useGas.ts
@@ -51,7 +51,8 @@ const checkValidGas = (
   const gasValue = isL2
     ? (selectedGasParams as LegacyGasFeeParams)?.gasPrice
     : (selectedGasParams as GasFeeParams)?.maxFeePerGas;
-  const isValidGas = gasValue?.amount && greaterThan(gasValue?.amount, 0);
+  const isValidGas =
+    Boolean(gasValue?.amount) && greaterThan(gasValue?.amount, 0);
   return isValidGas;
 };
 


### PR DESCRIPTION
Fixes TEAM2-265
Figma link (if any):

## What changed (plus any additional context for devs)

added a new state from `useGas` hook to know if the gas fee is ready to show a loading state in the confirm button when the gas is not calculated yet

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

pow https://www.loom.com/share/893760faa79a4c3b8175f95d659fd13a


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
