### PR TITLE
swaps: remote slippage by network

### DIFF
--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -57,7 +57,7 @@ export interface RainbowConfig extends Record<string, any> {
   ethereum_ropsten_rpc?: string;
   optimism_mainnet_rpc?: string;
   polygon_mainnet_rpc?: string;
-  default_slippage_bips?: number;
+  default_slippage_bips?: string;
 }
 
 const DEFAULT_CONFIG = {
@@ -65,7 +65,12 @@ const DEFAULT_CONFIG = {
   data_api_key: DATA_API_KEY,
   data_endpoint: DATA_ENDPOINT || 'wss://api-v4.zerion.io',
   data_origin: DATA_ORIGIN,
-  default_slippage_bips: 100,
+  default_slippage_bips: JSON.stringify({
+    arbitrum: 200,
+    mainnet: 100,
+    optimism: 200,
+    polygon: 200,
+  }),
   ethereum_goerli_rpc: __DEV__ ? ETHEREUM_GOERLI_RPC_DEV : ETHEREUM_GOERLI_RPC,
   ethereum_kovan_rpc: __DEV__ ? ETHEREUM_KOVAN_RPC_DEV : ETHEREUM_KOVAN_RPC,
   ethereum_mainnet_rpc: __DEV__
@@ -105,7 +110,11 @@ const init = async () => {
     const parameters = remoteConfig().getAll();
     Object.entries(parameters).forEach($ => {
       const [key, entry] = $;
-      config[key] = entry.asString();
+      if (key === 'default_slippage_bips') {
+        config[key] = JSON.parse(entry.asString());
+      } else {
+        config[key] = entry.asString();
+      }
     });
   } catch (e) {
     Logger.sentry('error getting remote config', e);

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -344,7 +344,10 @@ export default function ExchangeModal({
   }, [addListener, dangerouslyGetParent, lastFocusedInputHandle]);
 
   useEffect(() => {
-    dispatch(updateSwapSlippage(config.default_slippage_bips));
+    dispatch(updateSwapSlippage(config.default_slippage_bips[currentNetwork]));
+  }, [currentNetwork, dispatch]);
+
+  useEffect(() => {
     return () => {
       dispatch(swapClearState());
       resetSwapInputs();


### PR DESCRIPTION
Fixes TEAM2-269
Figma link (if any):

## What changed (plus any additional context for devs)
edited config to return a json object for slippage by network. note it gets returned in a string so we have to parse when it comes in


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
remote config: https://cloud.skylarbarrera.com/Screen-Shot-2022-07-19-14-54-52.10.png
confirmed loaded from remote: https://cloud.skylarbarrera.com/Screen-Shot-2022-07-19-14-55-06.71.png
PoW: https://cloud.skylarbarrera.com/Screen-Recording-2022-07-19-14-56-00.mp4

values have been restored to 100 for mainnet, 200 for l2s

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
check slippage on mainnet is 2 


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
