### PR TITLE
input fix

### DIFF
--- a/src/components/exchange/ExchangeInput.js
+++ b/src/components/exchange/ExchangeInput.js
@@ -61,7 +61,7 @@ const ExchangeInput = (
     event => {
       if (typeof value === 'string') {
         const parts = value.split('.');
-        if (parseFloat(parts.join()) === 0) {
+        if (parseFloat(parts.join('')) === 0) {
           ref?.current?.clear();
         } else if (parts[0].length > 1 && !Number(parts[0])) {
           onChangeText(`0.${parts[1]}`);

--- a/src/components/exchange/ExchangeInput.js
+++ b/src/components/exchange/ExchangeInput.js
@@ -61,7 +61,9 @@ const ExchangeInput = (
     event => {
       if (typeof value === 'string') {
         const parts = value.split('.');
-        if (parts[0].length > 1 && !Number(parts[0])) {
+        if (parseFloat(parts.join()) === 0) {
+          ref?.current?.clear();
+        } else if (parts[0].length > 1 && !Number(parts[0])) {
           onChangeText(`0.${parts[1]}`);
         }
       }
@@ -69,7 +71,7 @@ const ExchangeInput = (
       setIsTouched(false);
       onBlur?.(event);
     },
-    [onBlur, onChangeText, value]
+    [onBlur, onChangeText, ref, value]
   );
 
   const handleChange = useCallback(


### PR DESCRIPTION
Fixes TEAM2-199

## What changed (plus any additional context for devs)
- clear input on blur if value is equal to 0

## Screen recordings / screenshots

https://user-images.githubusercontent.com/15272675/179996979-6a6bf232-b5ed-430a-be91-344d104dc3d6.mp4

## What to test
- make sure input works as expected


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
