### PR TITLE
Fix weird swap sheet clipping on Android

### DIFF
--- a/src/components/exchange/ExchangeNotch.js
+++ b/src/components/exchange/ExchangeNotch.js
@@ -30,7 +30,7 @@ const NotchMiddle = styled(FastImage).attrs(({ isDarkMode }) => ({
 }))({
   height: notchHeight,
   left: android ? -ANDROID_NOTCH_OFFSET : 0,
-  width: ({ deviceWidth }) => deviceWidth - notchSideWidth * 2,
+  width: ({ deviceWidth }) => deviceWidth - notchSideWidth * 2.11,
 });
 
 const NotchSide = styled(FastImage)({

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -788,6 +788,11 @@ export default function ExchangeModal({
             overflow="visible"
             paddingBottom={showOutputField ? 0 : 26}
             radius={39}
+            style={
+              android && {
+                left: -1,
+              }
+            }
             testID={testID}
           >
             {showOutputField && <ExchangeNotch testID={testID} />}


### PR DESCRIPTION
Fixes RNBW-3987

## What changed (plus any additional context for devs)
Fixed glitched out `ExchangeModal` on Android

## Screen recordings / screenshots
| before  | after  |
|---------|--------|
| ![image](https://user-images.githubusercontent.com/6843656/180069535-6b1ae5e7-cebe-4984-a50f-e589cd26c3bc.png)  |  ![image](https://user-images.githubusercontent.com/6843656/180069562-639c0c14-60a2-43cf-b636-949edf65af43.png) |



## What to test
Check for any visual glitches on the swap sheet background on iOS and Android.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
