### PR TITLE
[TEAM2-18] Polygon custom gas choice in speed up tries to use EIP1559 and crashes

### DIFF
--- a/src/screens/SpeedUpAndCancelSheet.js
+++ b/src/screens/SpeedUpAndCancelSheet.js
@@ -7,6 +7,7 @@ import React, {
   Fragment,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -150,6 +151,7 @@ export default function SpeedUpAndCancelSheet() {
   const [nonce, setNonce] = useState(null);
   const [to, setTo] = useState(tx.to);
   const [value, setValue] = useState(null);
+  const isL2 = isL2Network(tx.network);
 
   const getNewTransactionGasParams = useCallback(() => {
     if (txType === GasFeeTypes.eip1559) {
@@ -333,7 +335,7 @@ export default function SpeedUpAndCancelSheet() {
           setData(hexData);
           setTo(tx.txTo);
           setGasLimit(hexGasLimit);
-          if (!isL2Network(tx.network)) {
+          if (!isL2) {
             setTxType(GasFeeTypes.eip1559);
             const hexMaxPriorityFeePerGas = toHex(
               tx.maxPriorityFeePerGas.toString()
@@ -383,6 +385,7 @@ export default function SpeedUpAndCancelSheet() {
     currentNetwork,
     currentProvider,
     goBack,
+    isL2,
     network,
     tx,
     tx.gasLimit,
@@ -432,6 +435,13 @@ export default function SpeedUpAndCancelSheet() {
     : null;
 
   const { colors, isDarkMode } = useTheme();
+  const speeds = useMemo(() => {
+    const defaultSpeeds = [URGENT];
+    if (!isL2) {
+      defaultSpeeds.push(CUSTOM);
+    }
+    return defaultSpeeds;
+  }, [isL2]);
 
   return (
     <SheetKeyboardAnimation
@@ -561,7 +571,7 @@ export default function SpeedUpAndCancelSheet() {
                     <GasSpeedButton
                       asset={{ color: accentColor }}
                       currentNetwork={currentNetwork}
-                      speeds={[URGENT, CUSTOM]}
+                      speeds={speeds}
                       theme={isDarkMode ? 'dark' : 'light'}
                     />
                   </GasSpeedButtonContainer>


### PR DESCRIPTION
Figma link (if any):

## What changed (plus any additional context for devs)
The `CUSTOM` gas speed is only available for mainnet transactions now.

## Screen recordings / screenshots
Example of speeding up a polygon transaction, that doesn't show custom option: https://recordit.co/X9ydyOYUYz
Example of speeding up a mainnet transaction, that continues to show a custom option: https://recordit.co/hqBZ4gSoRP

## What to test
Ensure that you cannot navigate to the custom fees panel when attempting to speed up an L2 transaction. Also make sure that mainnet transactions can still leverage the custom fees panel.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
