### PR TITLE
fix: slippage selection color android

### DIFF
--- a/src/components/expanded-state/swap-settings/InputPill.js
+++ b/src/components/expanded-state/swap-settings/InputPill.js
@@ -99,6 +99,10 @@ function InputPill(
           style={{ color: colors.dark }}
           testID={testID}
           value={value}
+          {...(android &&
+            color && {
+              selectionColor: colors.alpha(color, 0.4),
+            })}
         />
         <Label>{label}</Label>
       </Row>


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

did the same than @skylarbarrera here https://github.com/rainbow-me/rainbow/pull/3545

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

before 
![image](https://user-images.githubusercontent.com/12115171/180096927-3cf0c58f-f5b8-4e79-ad95-d3b11b571611.png)

after
![image](https://user-images.githubusercontent.com/12115171/180096948-8f4dd506-ba30-42dd-87dc-0f9346558c71.png)
![image](https://user-images.githubusercontent.com/12115171/180096960-596023f7-7d72-48d6-9bf0-ee7f2f75341d.png)

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
