### PR TITLE
Fix wrong line breaking in fee estimation

### DIFF
--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -101,6 +101,10 @@ const GasSpeedPagerCentered = styled(Centered).attrs(() => ({
   marginRight: 8,
 }))({});
 
+const TextContainer = styled(Column).attrs(() => ({
+  marginBottom: 11,
+}))({});
+
 const TransactionTimeLabel = ({ formatter, theme }) => {
   const { colors } = useTheme();
   return (
@@ -501,27 +505,25 @@ const GasSpeedButton = ({
                 symbol={nativeFeeCurrency.symbol}
               />
             </NativeCoinIconWrapper>
-            <Column>
-              <AnimateNumber
-                formatter={formatGasPrice}
-                interval={6}
-                renderContent={renderGasPriceText}
-                steps={6}
-                timing="linear"
-                value={price}
-              />
-            </Column>
-            <Column>
-              <Text letterSpacing="one" size="lmedium" weight="heavy">
-                {' '}
+            <TextContainer>
+              <Text>
+                <AnimateNumber
+                  formatter={formatGasPrice}
+                  interval={6}
+                  renderContent={renderGasPriceText}
+                  steps={6}
+                  timing="linear"
+                  value={price}
+                />
+                <Text letterSpacing="one" size="lmedium" weight="heavy">
+                  {' '}
+                </Text>
+                <TransactionTimeLabel
+                  formatter={formatTransactionTime}
+                  theme={theme}
+                />
               </Text>
-            </Column>
-            <Column>
-              <TransactionTimeLabel
-                formatter={formatTransactionTime}
-                theme={theme}
-              />
-            </Column>
+            </TextContainer>
           </Row>
           <Row justify="space-between">
             <Label

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -102,7 +102,7 @@ const GasSpeedPagerCentered = styled(Centered).attrs(() => ({
 }))({});
 
 const TextContainer = styled(Column).attrs(() => ({
-  marginBottom: 11,
+  marginBottom: ios ? 0 : 11,
 }))({});
 
 const TransactionTimeLabel = ({ formatter, theme }) => {


### PR DESCRIPTION
Fixes RNBW-3995
Figma link (if any):

## What changed (plus any additional context for devs)

Text formatting in `GasSpeedButton.js`.

## Screen recordings / screenshots

||Before|After|
|--|--|--|
|Android|![Screenshot_20220721-162242_Rainbow](https://user-images.githubusercontent.com/5769281/180224416-a38b2e5c-76db-4405-9b6a-3c4c487536e2.jpg)|![Screenshot_20220721-162308_Rainbow](https://user-images.githubusercontent.com/5769281/180224425-f0a11802-a408-442e-bfa8-114bf55f4136.jpg)|
|iOS|![IMG_0DF7BF950353-1](https://user-images.githubusercontent.com/5769281/180225831-f85c9ed1-0305-45b2-bbeb-3729dde0756e.jpeg)|![IMG_D3B93A2DDBB0-1](https://user-images.githubusercontent.com/5769281/180225816-d3862fc2-316c-40e6-bb95-e4b88def4810.jpeg)|

## What to test

The only change is the way text is formatted in the gas speed section.

This can affect how the price values there display on different screen sizes or with some extreme values.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
