### PR TITLE
Optimism and Arbitrum NFT support

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -230,7 +230,11 @@ const UniqueTokenExpandedState = ({
   const { isReadOnlyWallet } = useWallets();
 
   const {
-    collection: { description: familyDescription, external_url: familyLink },
+    collection: {
+      description: familyDescription,
+      external_url: familyLink,
+      slug,
+    },
     currentPrice,
     description,
     familyImage,
@@ -571,8 +575,8 @@ const UniqueTokenExpandedState = ({
                               <UniqueTokenAttributes
                                 {...asset}
                                 color={imageColor}
-                                hideNftMarketplaceAction={isPoap}
-                                slug={asset.collection.slug}
+                                hideNftMarketplaceAction={isPoap || !slug}
+                                slug={slug}
                               />
                             </Section>
                           ) : null}

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -52,7 +52,7 @@ import {
   Text,
   TextProps,
 } from '@rainbow-me/design-system';
-import { AssetTypes, UniqueAsset } from '@rainbow-me/entities';
+import { UniqueAsset } from '@rainbow-me/entities';
 import { Network } from '@rainbow-me/helpers';
 import { buildUniqueTokenName } from '@rainbow-me/helpers/assets';
 import { ENS_RECORDS, REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
@@ -230,6 +230,15 @@ const getIsSupportedOnRainbowWeb = network => {
   }
 };
 
+const getIsSaleInfoSupported = network => {
+  switch (network) {
+    case Network.mainnet:
+      return true;
+    default:
+      return false;
+  }
+};
+
 const UniqueTokenExpandedState = ({
   asset,
   external,
@@ -397,6 +406,7 @@ const UniqueTokenExpandedState = ({
   );
 
   const hideNftMarketplaceAction = isPoap || !slug;
+  const isSaleInfoSupported = getIsSaleInfoSupported(asset.network);
 
   return (
     <>
@@ -550,8 +560,7 @@ const UniqueTokenExpandedState = ({
                       separator={<Divider color="divider20" />}
                       space={sectionSpace}
                     >
-                      {(isNFT || isENS) &&
-                      asset.network !== AssetTypes.polygon ? (
+                      {(isNFT || isENS) && isSaleInfoSupported ? (
                         <Bleed // Manually crop surrounding space until TokenInfoItem uses design system components
                           bottom={android ? '15px' : '6px'}
                           top={android ? '10px' : '4px'}

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -220,10 +220,22 @@ interface UniqueTokenExpandedStateProps {
   external: boolean;
 }
 
+const getIsSupportedOnRainbowWeb = network => {
+  switch (network) {
+    case Network.mainnet:
+    case Network.polygon:
+      return true;
+    default:
+      return false;
+  }
+};
+
 const UniqueTokenExpandedState = ({
   asset,
   external,
 }: UniqueTokenExpandedStateProps) => {
+  const isSupportedOnRainbowWeb = getIsSupportedOnRainbowWeb(asset.network);
+
   const { accountAddress, accountENS } = useAccountProfile();
   const { height: deviceHeight, width: deviceWidth } = useDimensions();
   const { navigate } = useNavigation();
@@ -313,6 +325,8 @@ const UniqueTokenExpandedState = ({
     [showcaseTokens, uniqueId]
   );
 
+  const rainbowWebUrl = buildRainbowUrl(asset, accountENS, accountAddress);
+
   const imageColor =
     // @ts-expect-error image_url could be null or undefined?
     usePersistentDominantColorFromImage(asset.lowResUrl).result ||
@@ -342,14 +356,14 @@ const UniqueTokenExpandedState = ({
   }, [addShowcaseToken, isShowcaseAsset, removeShowcaseToken, uniqueId]);
 
   const handlePressShare = useCallback(() => {
+    const shareUrl = isSupportedOnRainbowWeb ? rainbowWebUrl : asset.permalink;
+
     Share.share({
-      message: android
-        ? buildRainbowUrl(asset, accountENS, accountAddress)
-        : undefined,
+      message: android ? shareUrl : undefined,
       title: `Share ${buildUniqueTokenName(asset)} Info`,
-      url: buildRainbowUrl(asset, accountENS, accountAddress),
+      url: shareUrl,
     });
-  }, [accountAddress, accountENS, asset]);
+  }, [asset, isSupportedOnRainbowWeb, rainbowWebUrl]);
 
   const { startRegistration } = useENSRegistration();
   const handlePressEdit = useCallback(() => {
@@ -462,13 +476,17 @@ const UniqueTokenExpandedState = ({
                                 'expanded_state.unique_expanded.showcase'
                               )}`}
                         </TextButton>
-                        <TextButton align="right" onPress={handlePressShare}>
-                          􀈂 {lang.t('button.share')}
-                        </TextButton>
+                        {isSupportedOnRainbowWeb || asset.permalink ? (
+                          <TextButton align="right" onPress={handlePressShare}>
+                            􀈂 {lang.t('button.share')}
+                          </TextButton>
+                        ) : null}
                       </Inline>
                       <UniqueTokenExpandedStateHeader
                         asset={asset}
                         hideNftMarketplaceAction={hideNftMarketplaceAction}
+                        isSupportedOnRainbowWeb={isSupportedOnRainbowWeb}
+                        rainbowWebUrl={rainbowWebUrl}
                       />
                     </Stack>
                     {isNFT || isENS ? (

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -326,7 +326,7 @@ const UniqueTokenExpandedState = ({
     }
   }, [colors.whiteLabel, imageColor]);
 
-  const handlePressOpensea = useCallback(
+  const handlePressMarketplaceName = useCallback(
     () => Linking.openURL(asset.permalink),
     [asset.permalink]
   );
@@ -492,7 +492,7 @@ const UniqueTokenExpandedState = ({
                                   )}`
                             }
                             nftShadows
-                            onPress={handlePressOpensea}
+                            onPress={handlePressMarketplaceName}
                             textColor={textColor}
                             weight="heavy"
                           />

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -53,6 +53,7 @@ import {
   TextProps,
 } from '@rainbow-me/design-system';
 import { AssetTypes, UniqueAsset } from '@rainbow-me/entities';
+import { Network } from '@rainbow-me/helpers';
 import { buildUniqueTokenName } from '@rainbow-me/helpers/assets';
 import { ENS_RECORDS, REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
 import {
@@ -514,10 +515,10 @@ const UniqueTokenExpandedState = ({
                         ) : null}
                       </Columns>
                     ) : null}
-                    {asset.network === AssetTypes.polygon ? (
+                    {asset.network !== Network.mainnet ? (
                       // @ts-expect-error JavaScript component
                       <L2Disclaimer
-                        assetType={AssetTypes.polygon}
+                        assetType={asset.network}
                         colors={colors}
                         hideDivider
                         isNft

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -242,6 +242,7 @@ const UniqueTokenExpandedState = ({
     isSendable,
     lastPrice,
     lastSalePaymentToken,
+    marketplaceName,
     traits,
     uniqueId,
     urlSuffixForAsset,
@@ -484,11 +485,12 @@ const UniqueTokenExpandedState = ({
                             // @ts-expect-error JavaScript component
                             label={
                               hasSendButton
-                                ? `􀮶 ${lang.t(
-                                    'expanded_state.unique_expanded.opensea'
-                                  )}`
+                                ? `􀮶 ${marketplaceName}`
                                 : `􀮶 ${lang.t(
-                                    'expanded_state.unique_expanded.view_on_opensea'
+                                    'expanded_state.unique_expanded.view_on_marketplace_name',
+                                    {
+                                      marketplaceName,
+                                    }
                                   )}`
                             }
                             nftShadows

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -571,7 +571,7 @@ const UniqueTokenExpandedState = ({
                               <UniqueTokenAttributes
                                 {...asset}
                                 color={imageColor}
-                                hideOpenSeaAction={isPoap}
+                                hideNftMarketplaceAction={isPoap}
                                 slug={asset.collection.slug}
                               />
                             </Section>

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -381,6 +381,8 @@ const UniqueTokenExpandedState = ({
     [familyLink]
   );
 
+  const hideNftMarketplaceAction = isPoap || !slug;
+
   return (
     <>
       {ios && (
@@ -463,7 +465,10 @@ const UniqueTokenExpandedState = ({
                           􀈂 {lang.t('button.share')}
                         </TextButton>
                       </Inline>
-                      <UniqueTokenExpandedStateHeader asset={asset} />
+                      <UniqueTokenExpandedStateHeader
+                        asset={asset}
+                        hideNftMarketplaceAction={hideNftMarketplaceAction}
+                      />
                     </Stack>
                     {isNFT || isENS ? (
                       <Columns space="15px">
@@ -577,7 +582,9 @@ const UniqueTokenExpandedState = ({
                               <UniqueTokenAttributes
                                 {...asset}
                                 color={imageColor}
-                                hideNftMarketplaceAction={isPoap || !slug}
+                                hideNftMarketplaceAction={
+                                  hideNftMarketplaceAction
+                                }
                                 slug={slug}
                               />
                             </Section>

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -220,7 +220,7 @@ interface UniqueTokenExpandedStateProps {
   external: boolean;
 }
 
-const getIsSupportedOnRainbowWeb = network => {
+const getIsSupportedOnRainbowWeb = (network: Network) => {
   switch (network) {
     case Network.mainnet:
     case Network.polygon:
@@ -230,7 +230,7 @@ const getIsSupportedOnRainbowWeb = network => {
   }
 };
 
-const getIsSaleInfoSupported = network => {
+const getIsSaleInfoSupported = (network: Network) => {
   switch (network) {
     case Network.mainnet:
       return true;

--- a/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
+++ b/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
@@ -11,6 +11,8 @@ import { useTheme } from '@rainbow-me/theme';
 import { convertAmountToNativeDisplay } from '@rainbow-me/utilities';
 import { ethereumUtils } from '@rainbow-me/utils';
 
+const NONE = 'None';
+
 export default function NFTBriefTokenInfoRow({
   currentPrice,
   lastPrice,
@@ -61,7 +63,7 @@ export default function NFTBriefTokenInfoRow({
       ? lastPrice === 0
         ? `< 0.001 ${lastSalePaymentToken}`
         : `${lastPrice} ${lastSalePaymentToken}`
-      : 'None';
+      : NONE;
   const priceOfEth = ethereumUtils.getEthPriceUnit() as number;
 
   return (
@@ -69,7 +71,7 @@ export default function NFTBriefTokenInfoRow({
       {/* @ts-expect-error JavaScript component */}
       <TokenInfoItem
         color={
-          lastSalePrice === 'None' && !currentPrice
+          lastSalePrice === NONE && !currentPrice
             ? colors.alpha(colors.whiteLabel, 0.5)
             : colors.whiteLabel
         }
@@ -82,7 +84,7 @@ export default function NFTBriefTokenInfoRow({
             ? `􀋢 ${lang.t('expanded_state.nft_brief_token_info.for_sale')}`
             : lang.t('expanded_state.nft_brief_token_info.last_sale')
         }
-        weight={lastSalePrice === 'None' && !currentPrice ? 'bold' : 'heavy'}
+        weight={lastSalePrice === NONE && !currentPrice ? 'bold' : 'heavy'}
       >
         {showCurrentPriceInEth || nativeCurrency === 'ETH' || !currentPrice
           ? currentPrice || lastSalePrice
@@ -96,11 +98,11 @@ export default function NFTBriefTokenInfoRow({
       <TokenInfoItem
         align="right"
         color={
-          floorPrice === 'None'
+          floorPrice === NONE
             ? colors.alpha(colors.whiteLabel, 0.5)
             : colors.whiteLabel
         }
-        enableHapticFeedback={floorPrice !== 'None'}
+        enableHapticFeedback={floorPrice !== NONE}
         isNft
         loading={!floorPrice}
         onInfoPress={handlePressCollectionFloor}
@@ -108,11 +110,11 @@ export default function NFTBriefTokenInfoRow({
         showInfoButton
         size="big"
         title="Floor price"
-        weight={floorPrice === 'None' ? 'bold' : 'heavy'}
+        weight={floorPrice === NONE ? 'bold' : 'heavy'}
       >
         {showFloorInEth ||
         nativeCurrency === 'ETH' ||
-        floorPrice === 'None' ||
+        floorPrice === NONE ||
         floorPrice === null
           ? floorPrice
           : convertAmountToNativeDisplay(

--- a/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
+++ b/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
@@ -32,7 +32,7 @@ export default function NFTBriefTokenInfoRow({
   currentPrice?: number | null;
   lastPrice?: number | null;
   lastSalePaymentToken?: string | null;
-  network?: string;
+  network: Network;
   urlSuffixForAsset: string;
 }) {
   const { colors } = useTheme();
@@ -45,17 +45,24 @@ export default function NFTBriefTokenInfoRow({
 
   useEffect(() => {
     const isFloorPriceSupported = getIsFloorPriceSupported(assetNetwork);
-    if (isFloorPriceSupported) {
-      apiGetUniqueTokenFloorPrice(network, urlSuffixForAsset)
-        .then(result => {
+
+    const fetchFloorPrice = async () => {
+      if (isFloorPriceSupported) {
+        try {
+          const result = await apiGetUniqueTokenFloorPrice(
+            network,
+            urlSuffixForAsset
+          );
           setFloorPrice(result);
-        })
-        .catch(_ => {
+        } catch (_) {
           setFloorPrice(NONE);
-        });
-    } else {
-      setFloorPrice(NONE);
-    }
+        }
+      } else {
+        setFloorPrice(NONE);
+      }
+    };
+
+    fetchFloorPrice();
   }, [assetNetwork, network, urlSuffixForAsset]);
 
   const [showCurrentPriceInEth, setShowCurrentPriceInEth] = useState(true);

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -97,7 +97,6 @@ const FamilyActions = {
   [FamilyActionsEnum.viewCollection]: {
     actionKey: FamilyActionsEnum.viewCollection,
     actionTitle: lang.t('expanded_state.unique_expanded.view_collection'),
-    discoverabilityTitle: lang.t('expanded_state.unique_expanded.opensea'),
     icon: {
       iconType: 'SYSTEM',
       iconValue: 'rectangle.grid.2x2.fill',
@@ -148,10 +147,12 @@ const FamilyImage = styled(ImgixImage)({
 
 interface UniqueTokenExpandedStateHeaderProps {
   asset: UniqueAsset;
+  hideNftMarketplaceAction: boolean;
 }
 
 const UniqueTokenExpandedStateHeader = ({
   asset,
+  hideNftMarketplaceAction,
 }: UniqueTokenExpandedStateHeaderProps) => {
   const { accountAddress, accountENS } = useAccountProfile();
   const { setClipboard } = useClipboard();
@@ -171,10 +172,11 @@ const UniqueTokenExpandedStateHeader = ({
   const familyMenuConfig = useMemo(() => {
     return {
       menuItems: [
-        ...(!asset?.isPoap
+        ...(!hideNftMarketplaceAction
           ? [
               {
                 ...FamilyActions[FamilyActionsEnum.viewCollection],
+                discoverabilityTitle: asset.marketplaceName,
               },
             ]
           : []),
@@ -208,7 +210,8 @@ const UniqueTokenExpandedStateHeader = ({
     asset.collection.external_url,
     asset.collection.twitter_username,
     asset.external_link,
-    asset?.isPoap,
+    asset.marketplaceName,
+    hideNftMarketplaceAction,
     formattedCollectionUrl,
   ]);
 
@@ -251,11 +254,7 @@ const UniqueTokenExpandedStateHeader = ({
   const handlePressFamilyMenuItem = useCallback(
     ({ nativeEvent: { actionKey } }) => {
       if (actionKey === FamilyActionsEnum.viewCollection) {
-        Linking.openURL(
-          'https://opensea.io/collection/' +
-            asset.collection.slug +
-            '?search[sortAscending]=true&search[sortBy]=PRICE&search[toggles][0]=BUY_NOW'
-        );
+        Linking.openURL(asset.marketplaceCollectionUrl);
       } else if (actionKey === FamilyActionsEnum.collectionWebsite) {
         // @ts-expect-error external_link and external_url could be null or undefined?
         Linking.openURL(asset.external_link || asset.collection.external_url);
@@ -321,11 +320,7 @@ const UniqueTokenExpandedStateHeader = ({
       },
       (idx: number) => {
         if (idx === 0) {
-          Linking.openURL(
-            'https://opensea.io/collection/' +
-              asset.collection.slug +
-              '?search[sortAscending]=true&search[sortBy]=PRICE&search[toggles][0]=BUY_NOW'
-          );
+          Linking.openURL(asset.marketplaceCollectionUrl);
         }
         if (idx === 1) {
           if (hasWebsite) {
@@ -365,6 +360,7 @@ const UniqueTokenExpandedStateHeader = ({
     asset.collection.slug,
     asset.collection.twitter_username,
     asset.external_link,
+    asset.marketplaceCollectionUrl,
   ]);
 
   const onPressAndroidAsset = useCallback(() => {

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -300,24 +300,26 @@ const UniqueTokenExpandedStateHeader = ({
   );
 
   const onPressAndroidFamily = useCallback(() => {
+    const hasCollection = !!asset.marketplaceCollectionUrl;
     const hasWebsite = !!(asset.external_link || asset.collection.external_url);
     const hasTwitter = !!asset.collection.twitter_username;
     const hasDiscord = !!asset.collection.discord_url;
-    const hasCollection = !!asset.collection.slug;
-    const baseActions = [
-      lang.t('expanded_state.unique_expanded.view_collection'),
-      lang.t('expanded_state.unique_expanded.collection_website'),
-      lang.t('expanded_state.unique_expanded.twitter'),
-      lang.t('expanded_state.unique_expanded.discord'),
-    ];
-    const websiteIndex = 1 - (!hasCollection ? 1 : 0);
-    const twitterIndex = 2 - (!hasWebsite ? 1 : 0);
-    const discordIndex = 3 - (!hasWebsite ? 1 : 0) - (!hasTwitter ? 1 : 0);
 
-    if (!hasCollection) baseActions.splice(1, 1);
-    if (!hasWebsite) baseActions.splice(websiteIndex, 1);
-    if (!hasTwitter) baseActions.splice(twitterIndex, 1);
-    if (!hasDiscord) baseActions.splice(discordIndex, 1);
+    const baseActions = [
+      ...(hasCollection
+        ? [lang.t('expanded_state.unique_expanded.view_collection')]
+        : []),
+      ...(hasWebsite
+        ? [lang.t('expanded_state.unique_expanded.collection_website')]
+        : []),
+      ...(hasTwitter ? [lang.t('expanded_state.unique_expanded.twitter')] : []),
+      ...(hasDiscord ? [lang.t('expanded_state.unique_expanded.discord')] : []),
+    ];
+
+    const collectionIndex = hasCollection ? 0 : -1;
+    const websiteIndex = hasWebsite ? collectionIndex + 1 : collectionIndex;
+    const twitterIndex = hasTwitter ? websiteIndex + 1 : websiteIndex;
+    const discordIndex = hasDiscord ? twitterIndex + 1 : twitterIndex;
 
     showActionSheetWithOptions(
       {
@@ -326,37 +328,18 @@ const UniqueTokenExpandedStateHeader = ({
         title: '',
       },
       (idx: number) => {
-        if (idx === 0) {
+        if (idx === collectionIndex) {
           Linking.openURL(asset.marketplaceCollectionUrl);
-        }
-        if (idx === 1) {
-          if (hasWebsite) {
-            Linking.openURL(
-              // @ts-expect-error external_link and external_url could be null or undefined?
-              asset.external_link || asset.collection.external_url
-            );
-          } else if (hasTwitter && twitterIndex === 1) {
-            Linking.openURL(
-              'https://twitter.com/' + asset.collection.twitter_username
-            );
-          } else if (hasDiscord && discordIndex === 1) {
-            Linking.openURL(
-              'https://twitter.com/' + asset.collection.twitter_username
-            );
-          }
-        }
-        if (idx === 2) {
-          if (hasTwitter && twitterIndex === 2) {
-            Linking.openURL(
-              'https://twitter.com/' + asset.collection.twitter_username
-            );
-          } else if (hasDiscord && discordIndex === 2) {
-            Linking.openURL(
-              'https://twitter.com/' + asset.collection.twitter_username
-            );
-          }
-        }
-        if (idx === 3 && asset.collection.discord_url) {
+        } else if (idx === websiteIndex) {
+          Linking.openURL(
+            // @ts-expect-error external_link and external_url could be null or undefined?
+            asset.external_link || asset.collection.external_url
+          );
+        } else if (idx === twitterIndex) {
+          Linking.openURL(
+            'https://twitter.com/' + asset.collection.twitter_username
+          );
+        } else if (idx === discordIndex) {
           Linking.openURL(asset.collection.discord_url);
         }
       }
@@ -364,7 +347,6 @@ const UniqueTokenExpandedStateHeader = ({
   }, [
     asset.collection.discord_url,
     asset.collection.external_url,
-    asset.collection.slug,
     asset.collection.twitter_username,
     asset.external_link,
     asset.marketplaceCollectionUrl,

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -353,20 +353,32 @@ const UniqueTokenExpandedStateHeader = ({
   ]);
 
   const onPressAndroidAsset = useCallback(() => {
-    const androidContractActions = [
-      ...(isSupportedOnRainbowWeb
-        ? lang.t('expanded_state.unique_expanded.view_on_web')
-        : []),
-      lang.t('expanded_state.unique_expanded.view_on_block_explorer', {
+    const blockExplorerActionName = lang.t(
+      'expanded_state.unique_expanded.view_on_block_explorer',
+      {
         blockExplorerName: startCase(
           ethereumUtils.getBlockExplorer(asset.network)
         ),
-      }),
+      }
+    );
+
+    const androidContractActions = [
+      ...(isSupportedOnRainbowWeb
+        ? [lang.t('expanded_state.unique_expanded.view_on_web')]
+        : []),
+      blockExplorerActionName,
       ...(isPhotoDownloadAvailable
         ? ([lang.t('expanded_state.unique_expanded.save_to_photos')] as const)
         : []),
       lang.t('expanded_state.unique_expanded.copy_token_id'),
     ] as const;
+
+    const rainbowWebIndex = isSupportedOnRainbowWeb ? 0 : -1;
+    const blockExplorerIndex = rainbowWebIndex + 1;
+    const photoDownloadIndex = isPhotoDownloadAvailable
+      ? blockExplorerIndex + 1
+      : blockExplorerIndex;
+    const copyTokenIndex = photoDownloadIndex + 1;
 
     showActionSheetWithOptions(
       {
@@ -375,19 +387,19 @@ const UniqueTokenExpandedStateHeader = ({
         title: '',
       },
       (idx: number) => {
-        if (idx === 0) {
+        if (idx === rainbowWebIndex) {
           Linking.openURL(rainbowWebUrl);
-        } else if (idx === 1) {
+        } else if (idx === blockExplorerIndex) {
           ethereumUtils.openNftInBlockExplorer(
             // @ts-expect-error address could be undefined?
             asset.asset_contract.address,
             asset.id,
             asset.network
           );
-        } else if (isPhotoDownloadAvailable ? idx === 3 : idx === 2) {
-          setClipboard(asset.id);
-        } else if (idx === 2) {
+        } else if (idx === photoDownloadIndex) {
           saveToCameraRoll(getFullResUrl(asset.image_original_url));
+        } else if (idx === copyTokenIndex) {
+          setClipboard(asset.id);
         }
       }
     );

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -20,17 +20,12 @@ import {
 } from '@rainbow-me/design-system';
 import { UniqueAsset } from '@rainbow-me/entities';
 import { Network } from '@rainbow-me/helpers';
-import {
-  useAccountProfile,
-  useClipboard,
-  useDimensions,
-} from '@rainbow-me/hooks';
+import { useClipboard, useDimensions } from '@rainbow-me/hooks';
 import { ImgixImage } from '@rainbow-me/images';
 import { ENS_NFT_CONTRACT_ADDRESS } from '@rainbow-me/references';
 import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
 import {
-  buildRainbowUrl,
   ethereumUtils,
   magicMemo,
   showActionSheetWithOptions,
@@ -148,27 +143,18 @@ const FamilyImage = styled(ImgixImage)({
 interface UniqueTokenExpandedStateHeaderProps {
   asset: UniqueAsset;
   hideNftMarketplaceAction: boolean;
+  isSupportedOnRainbowWeb: boolean;
+  rainbowWebUrl?: string;
 }
-
-const getIsSupportedOnRainbowWeb = network => {
-  switch (network) {
-    case Network.mainnet:
-    case Network.polygon:
-      return true;
-    default:
-      return false;
-  }
-};
 
 const UniqueTokenExpandedStateHeader = ({
   asset,
   hideNftMarketplaceAction,
+  isSupportedOnRainbowWeb,
+  rainbowWebUrl,
 }: UniqueTokenExpandedStateHeaderProps) => {
-  const { accountAddress, accountENS } = useAccountProfile();
   const { setClipboard } = useClipboard();
   const { width: deviceWidth } = useDimensions();
-
-  const isSupportedOnRainbowWeb = getIsSupportedOnRainbowWeb(asset.network);
 
   const formattedCollectionUrl = useMemo(() => {
     // @ts-expect-error external_link could be null or undefined?
@@ -303,14 +289,14 @@ const UniqueTokenExpandedStateHeader = ({
           asset.network
         );
       } else if (actionKey === AssetActionsEnum.rainbowWeb) {
-        Linking.openURL(buildRainbowUrl(asset, accountENS, accountAddress));
+        Linking.openURL(rainbowWebUrl);
       } else if (actionKey === AssetActionsEnum.copyTokenID) {
         setClipboard(asset.id);
       } else if (actionKey === AssetActionsEnum.download) {
         saveToCameraRoll(getFullResUrl(asset.image_original_url));
       }
     },
-    [accountAddress, accountENS, asset, setClipboard]
+    [asset, rainbowWebUrl, setClipboard]
   );
 
   const onPressAndroidFamily = useCallback(() => {
@@ -408,7 +394,7 @@ const UniqueTokenExpandedStateHeader = ({
       },
       (idx: number) => {
         if (idx === 0) {
-          Linking.openURL(buildRainbowUrl(asset, accountENS, accountAddress));
+          Linking.openURL(rainbowWebUrl);
         } else if (idx === 1) {
           ethereumUtils.openNftInBlockExplorer(
             // @ts-expect-error address could be undefined?
@@ -424,11 +410,10 @@ const UniqueTokenExpandedStateHeader = ({
       }
     );
   }, [
-    accountAddress,
-    accountENS,
     asset,
     isPhotoDownloadAvailable,
     isSupportedOnRainbowWeb,
+    rainbowWebUrl,
     setClipboard,
   ]);
 

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -144,7 +144,7 @@ interface UniqueTokenExpandedStateHeaderProps {
   asset: UniqueAsset;
   hideNftMarketplaceAction: boolean;
   isSupportedOnRainbowWeb: boolean;
-  rainbowWebUrl?: string;
+  rainbowWebUrl: string;
 }
 
 const UniqueTokenExpandedStateHeader = ({
@@ -174,7 +174,7 @@ const UniqueTokenExpandedStateHeader = ({
           ? [
               {
                 ...FamilyActions[FamilyActionsEnum.viewCollection],
-                discoverabilityTitle: asset.marketplaceName,
+                discoverabilityTitle: asset.marketplaceName ?? '',
               },
             ]
           : []),
@@ -260,7 +260,10 @@ const UniqueTokenExpandedStateHeader = ({
 
   const handlePressFamilyMenuItem = useCallback(
     ({ nativeEvent: { actionKey } }) => {
-      if (actionKey === FamilyActionsEnum.viewCollection) {
+      if (
+        actionKey === FamilyActionsEnum.viewCollection &&
+        asset.marketplaceCollectionUrl
+      ) {
         Linking.openURL(asset.marketplaceCollectionUrl);
       } else if (actionKey === FamilyActionsEnum.collectionWebsite) {
         // @ts-expect-error external_link and external_url could be null or undefined?
@@ -328,7 +331,7 @@ const UniqueTokenExpandedStateHeader = ({
         title: '',
       },
       (idx: number) => {
-        if (idx === collectionIndex) {
+        if (idx === collectionIndex && asset.marketplaceCollectionUrl) {
           Linking.openURL(asset.marketplaceCollectionUrl);
         } else if (idx === websiteIndex) {
           Linking.openURL(
@@ -339,7 +342,7 @@ const UniqueTokenExpandedStateHeader = ({
           Linking.openURL(
             'https://twitter.com/' + asset.collection.twitter_username
           );
-        } else if (idx === discordIndex) {
+        } else if (idx === discordIndex && asset.collection.discord_url) {
           Linking.openURL(asset.collection.discord_url);
         }
       }

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -19,7 +19,7 @@ const PropertyActionsEnum = {
   viewTraitOnOpensea: 'viewTraitOnOpensea',
 };
 
-const viewTraitOnOpenseaAction = {
+const viewTraitOnNftMarketplaceAction = {
   actionKey: PropertyActionsEnum.viewTraitOnOpensea,
   actionTitle: lang.t('expanded_state.unique_expanded.view_all_with_property'),
   discoverabilityTitle: 'OpenSea',
@@ -113,7 +113,7 @@ const Tag = ({
     const androidContractActions = [];
 
     if (!hideNftMarketplaceAction) {
-      androidContractActions.push(viewTraitOnOpenseaAction.actionTitle);
+      androidContractActions.push(viewTraitOnNftMarketplaceAction.actionTitle);
     }
 
     if (isURL) {
@@ -128,7 +128,8 @@ const Tag = ({
       },
       idx => {
         if (
-          androidContractActions[idx] === viewTraitOnOpenseaAction.actionTitle
+          androidContractActions[idx] ===
+          viewTraitOnNftMarketplaceAction.actionTitle
         ) {
           Linking.openURL(
             'https://opensea.io/collection/' +
@@ -152,7 +153,7 @@ const Tag = ({
     const menuItems = [];
 
     if (!hideNftMarketplaceAction) {
-      menuItems.push(viewTraitOnOpenseaAction);
+      menuItems.push(viewTraitOnNftMarketplaceAction);
     }
 
     if (isURL) {

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -83,7 +83,7 @@ const Tag = ({
   maxValue,
   originalValue,
   lowercase,
-  hideOpenSeaAction,
+  hideNftMarketplaceAction,
   ...props
 }) => {
   const { colors } = useTheme();
@@ -112,7 +112,7 @@ const Tag = ({
   const onPressAndroid = useCallback(() => {
     const androidContractActions = [];
 
-    if (!hideOpenSeaAction) {
+    if (!hideNftMarketplaceAction) {
       androidContractActions.push(viewTraitOnOpenseaAction.actionTitle);
     }
 
@@ -146,12 +146,12 @@ const Tag = ({
         }
       }
     );
-  }, [hideOpenSeaAction, isURL, slug, title, originalValue]);
+  }, [hideNftMarketplaceAction, isURL, slug, title, originalValue]);
 
   const menuConfig = useMemo(() => {
     const menuItems = [];
 
-    if (!hideOpenSeaAction) {
+    if (!hideNftMarketplaceAction) {
       menuItems.push(viewTraitOnOpenseaAction);
     }
 
@@ -163,7 +163,7 @@ const Tag = ({
       menuItems,
       menuTitle: '',
     };
-  }, [hideOpenSeaAction, isURL]);
+  }, [hideNftMarketplaceAction, isURL]);
 
   const textWithUpdatedCase = lowercase ? text : upperFirst(text);
 
@@ -221,5 +221,5 @@ export default magicMemo(Tag, [
   'title',
   'maxValue',
   'originalValue',
-  'hideOpenSeaAction',
+  'hideNftMarketplaceAction',
 ]);

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -16,11 +16,11 @@ const HairlineSpace = '\u200a';
 
 const PropertyActionsEnum = {
   openURL: 'openURL',
-  viewTraitOnOpensea: 'viewTraitOnOpensea',
+  viewTraitOnNftMarketplace: 'viewTraitOnNftMarketplace',
 };
 
 const viewTraitOnNftMarketplaceAction = {
-  actionKey: PropertyActionsEnum.viewTraitOnOpensea,
+  actionKey: PropertyActionsEnum.viewTraitOnNftMarketplace,
   actionTitle: lang.t('expanded_state.unique_expanded.view_all_with_property'),
   discoverabilityTitle: 'OpenSea',
   icon: {
@@ -93,7 +93,7 @@ const Tag = ({
 
   const handlePressMenuItem = useCallback(
     ({ nativeEvent: { actionKey } }) => {
-      if (actionKey === PropertyActionsEnum.viewTraitOnOpensea) {
+      if (actionKey === PropertyActionsEnum.viewTraitOnNftMarketplace) {
         Linking.openURL(
           'https://opensea.io/collection/' +
             slug +

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -19,14 +19,18 @@ const PropertyActionsEnum = {
   viewTraitOnNftMarketplace: 'viewTraitOnNftMarketplace',
 };
 
-const viewTraitOnNftMarketplaceAction = {
-  actionKey: PropertyActionsEnum.viewTraitOnNftMarketplace,
-  actionTitle: lang.t('expanded_state.unique_expanded.view_all_with_property'),
-  discoverabilityTitle: 'OpenSea',
-  icon: {
-    iconType: 'SYSTEM',
-    iconValue: 'magnifyingglass.circle.fill',
-  },
+const getViewTraitOnNftMarketplaceAction = (marketplaceName = 'OpenSea') => {
+  return {
+    actionKey: PropertyActionsEnum.viewTraitOnNftMarketplace,
+    actionTitle: lang.t(
+      'expanded_state.unique_expanded.view_all_with_property'
+    ),
+    discoverabilityTitle: marketplaceName,
+    icon: {
+      iconType: 'SYSTEM',
+      iconValue: 'magnifyingglass.circle.fill',
+    },
+  };
 };
 
 const openTraitURLInBrowserAction = {
@@ -74,12 +78,29 @@ const Title = styled(TextElement).attrs(({ color, theme: { colors } }) => ({
   marginBottom: 1,
 });
 
+const getNftTraitUrl = (
+  marketplaceName,
+  collectionId,
+  traitTitle,
+  traitValue
+) => {
+  switch (marketplaceName) {
+    case 'Stratos':
+      return `https://stratosnft.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
+    case 'Quixotic':
+      return `https://quixotic.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
+    default:
+      return `https://opensea.io/collection/${collectionId}?search[stringTraits][0][name]=${traitTitle}&search[stringTraits][0][values][0]=${traitValue}`;
+  }
+};
+
 const Tag = ({
   color,
   disableMenu,
   slug,
   text,
   title,
+  marketplaceName,
   maxValue,
   originalValue,
   lowercase,
@@ -91,22 +112,25 @@ const Tag = ({
     typeof originalValue === 'string' &&
     originalValue.toLowerCase().startsWith('https://');
 
+  const viewTraitOnNftMarketplaceAction = getViewTraitOnNftMarketplaceAction(
+    marketplaceName
+  );
+
   const handlePressMenuItem = useCallback(
     ({ nativeEvent: { actionKey } }) => {
       if (actionKey === PropertyActionsEnum.viewTraitOnNftMarketplace) {
-        Linking.openURL(
-          'https://opensea.io/collection/' +
-            slug +
-            '?search[stringTraits][0][name]=' +
-            title +
-            '&search[stringTraits][0][values][0]=' +
-            originalValue
+        const nftTraitUrl = getNftTraitUrl(
+          marketplaceName,
+          slug,
+          title,
+          originalValue
         );
+        Linking.openURL(nftTraitUrl);
       } else if (actionKey === PropertyActionsEnum.openURL) {
         Linking.openURL(originalValue);
       }
     },
-    [slug, originalValue, title]
+    [slug, originalValue, marketplaceName, title]
   );
 
   const onPressAndroid = useCallback(() => {
@@ -131,14 +155,13 @@ const Tag = ({
           androidContractActions[idx] ===
           viewTraitOnNftMarketplaceAction.actionTitle
         ) {
-          Linking.openURL(
-            'https://opensea.io/collection/' +
-              slug +
-              '?search[stringTraits][0][name]=' +
-              title +
-              '&search[stringTraits][0][values][0]=' +
-              originalValue
+          const nftTraitUrl = getNftTraitUrl(
+            marketplaceName,
+            slug,
+            title,
+            originalValue
           );
+          Linking.openURL(nftTraitUrl);
         } else if (
           androidContractActions[idx] ===
           openTraitURLInBrowserAction.actionTitle
@@ -147,7 +170,15 @@ const Tag = ({
         }
       }
     );
-  }, [hideNftMarketplaceAction, isURL, slug, title, originalValue]);
+  }, [
+    hideNftMarketplaceAction,
+    isURL,
+    slug,
+    title,
+    originalValue,
+    marketplaceName,
+    viewTraitOnNftMarketplaceAction.actionTitle,
+  ]);
 
   const menuConfig = useMemo(() => {
     const menuItems = [];
@@ -164,7 +195,7 @@ const Tag = ({
       menuItems,
       menuTitle: '',
     };
-  }, [hideNftMarketplaceAction, isURL]);
+  }, [hideNftMarketplaceAction, isURL, viewTraitOnNftMarketplaceAction]);
 
   const textWithUpdatedCase = lowercase ? text : upperFirst(text);
 
@@ -220,6 +251,7 @@ export default magicMemo(Tag, [
   'slug',
   'text',
   'title',
+  'marketplaceName',
   'maxValue',
   'originalValue',
   'hideNftMarketplaceAction',

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -19,7 +19,7 @@ const PropertyActionsEnum = {
   viewTraitOnNftMarketplace: 'viewTraitOnNftMarketplace',
 };
 
-const getViewTraitOnNftMarketplaceAction = (marketplaceName = 'OpenSea') => {
+const getViewTraitOnNftMarketplaceAction = marketplaceName => {
   return {
     actionKey: PropertyActionsEnum.viewTraitOnNftMarketplace,
     actionTitle: lang.t(

--- a/src/components/unique-token/UniqueTokenAttributes.tsx
+++ b/src/components/unique-token/UniqueTokenAttributes.tsx
@@ -10,15 +10,17 @@ import uniqueAssetTraitDisplayTypeCompareFunction from '@rainbow-me/helpers/uniq
 
 interface UniqueTokenAttributesProps {
   color: string;
-  slug: string;
   hideNftMarketplaceAction?: boolean;
+  marketplaceName?: string;
+  slug: string;
   traits: UniqueAsset['traits'];
 }
 
 const UniqueTokenAttributes = ({
   color,
-  slug,
   hideNftMarketplaceAction,
+  marketplaceName,
+  slug,
   traits,
 }: UniqueTokenAttributesProps) => {
   const sortedTraits = useMemo(
@@ -60,6 +62,7 @@ const UniqueTokenAttributes = ({
             hideNftMarketplaceAction={hideNftMarketplaceAction}
             key={`${type}${originalValue}`}
             lowercase={lowercase}
+            marketplaceName={marketplaceName}
             maxValue={maxValue}
             originalValue={originalValue}
             slug={slug}
@@ -72,4 +75,9 @@ const UniqueTokenAttributes = ({
   );
 };
 
-export default magicMemo(UniqueTokenAttributes, ['color', 'slug', 'traits']);
+export default magicMemo(UniqueTokenAttributes, [
+  'color',
+  'slug',
+  'marketplaceName',
+  'traits',
+]);

--- a/src/components/unique-token/UniqueTokenAttributes.tsx
+++ b/src/components/unique-token/UniqueTokenAttributes.tsx
@@ -11,14 +11,14 @@ import uniqueAssetTraitDisplayTypeCompareFunction from '@rainbow-me/helpers/uniq
 interface UniqueTokenAttributesProps {
   color: string;
   slug: string;
-  hideOpenSeaAction?: boolean;
+  hideNftMarketplaceAction?: boolean;
   traits: UniqueAsset['traits'];
 }
 
 const UniqueTokenAttributes = ({
   color,
   slug,
-  hideOpenSeaAction,
+  hideNftMarketplaceAction,
   traits,
 }: UniqueTokenAttributesProps) => {
   const sortedTraits = useMemo(
@@ -57,7 +57,7 @@ const UniqueTokenAttributes = ({
           <Tag
             color={color}
             disableMenu={disableMenu}
-            hideOpenSeaAction={hideOpenSeaAction}
+            hideNftMarketplaceAction={hideNftMarketplaceAction}
             key={`${type}${originalValue}`}
             lowercase={lowercase}
             maxValue={maxValue}

--- a/src/components/unique-token/UniqueTokenAttributes.tsx
+++ b/src/components/unique-token/UniqueTokenAttributes.tsx
@@ -10,8 +10,8 @@ import uniqueAssetTraitDisplayTypeCompareFunction from '@rainbow-me/helpers/uniq
 
 interface UniqueTokenAttributesProps {
   color: string;
-  hideNftMarketplaceAction?: boolean;
-  marketplaceName?: string;
+  hideNftMarketplaceAction: boolean;
+  marketplaceName?: string | null;
   slug: string;
   traits: UniqueAsset['traits'];
 }

--- a/src/entities/uniqueAssets.ts
+++ b/src/entities/uniqueAssets.ts
@@ -53,11 +53,13 @@ export interface UniqueAsset {
   lastSale: UniqueAssetLastSale | undefined;
   lastSalePaymentToken: string | undefined | null;
   lowResUrl: string | null;
+  marketplaceCollectionUrl?: string | null;
+  marketplaceName: string | null;
   type: AssetType;
   uniqueId: string;
   urlSuffixForAsset: string;
   isPoap?: boolean;
-  network?: Network;
+  network: Network;
 }
 
 export interface UniqueAssetTrait {

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -30,6 +30,7 @@ import {
   Records,
   UniqueAsset,
 } from '@rainbow-me/entities';
+import { Network } from '@rainbow-me/helpers';
 import {
   ENS_DOMAIN,
   ENS_RECORDS,
@@ -40,7 +41,10 @@ import {
 } from '@rainbow-me/helpers/ens';
 import { add } from '@rainbow-me/helpers/utilities';
 import { ImgixImage } from '@rainbow-me/images';
-import { handleAndSignImages } from '@rainbow-me/parsers';
+import {
+  getOpenSeaCollectionUrl,
+  handleAndSignImages,
+} from '@rainbow-me/parsers';
 import { queryClient } from '@rainbow-me/react-query/queryClient';
 import {
   ENS_NFT_CONTRACT_ADDRESS,
@@ -70,6 +74,7 @@ const buildEnsToken = ({
 }) => {
   // @ts-expect-error JavaScript function
   const { imageUrl, lowResUrl } = handleAndSignImages(imageUrl_);
+  const slug = 'ens';
   return {
     animation_url: null,
     asset_contract: {
@@ -93,7 +98,7 @@ const buildEnsToken = ({
         'https://lh3.googleusercontent.com/0cOqWoYA7xL9CkUjGlxsjreSYBdrUBE0c6EO1COG4XE8UeP-Z30ckqUNiL872zHQHQU5MUNMNhfDpyXIP17hRSC5HQ=s60',
       name: 'ENS: Ethereum Name Service',
       short_description: null,
-      slug: 'ens',
+      slug,
       twitter_username: 'ensdomains',
     },
     currentPrice: null,
@@ -113,7 +118,10 @@ const buildEnsToken = ({
     lastSale: undefined,
     lastSalePaymentToken: null,
     lowResUrl,
+    marketplaceCollectionUrl: getOpenSeaCollectionUrl(slug),
+    marketplaceName: 'OpenSea',
     name,
+    network: Network.mainnet,
     permalink: '',
     sell_orders: [],
     traits: [],

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -5,9 +5,12 @@ import { RainbowFetchClient } from '../rainbow-fetch';
 import { logger } from '@rainbow-me/utils';
 
 const chains = {
+  arbitrum: 'arbitrum',
   ethereum: 'ethereum',
+  optimism: 'optimism',
+  polygon: 'polygon',
 } as const;
-type Chain = keyof typeof chains;
+type SimpleHashChain = keyof typeof chains;
 
 const simplehashApi = new RainbowFetchClient({
   baseURL: 'https://api.simplehash.com/api',
@@ -18,7 +21,7 @@ export async function getNFTByTokenId({
   contractAddress,
   tokenId,
 }: {
-  chain?: Chain;
+  chain?: SimpleHashChain;
   contractAddress: string;
   tokenId: string;
 }) {
@@ -36,6 +39,29 @@ export async function getNFTByTokenId({
     return response.data;
   } catch (error) {
     logger.sentry(`Error fetching simplehash NFT: ${error}`);
+    captureException(error);
+  }
+}
+
+export async function getNftsByWalletAddress(walletAddress: string) {
+  try {
+    const chainParam: string = `${chains.arbitrum},${chains.optimism}`;
+    const response = await simplehashApi.get(`/v0/nfts/owners`, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'x-api-key': SIMPLEHASH_API_KEY,
+      },
+      params: {
+        chains: chainParam,
+        wallet_addresses: walletAddress,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    logger.sentry(
+      `Error fetching simplehash NFTs for wallet address: ${walletAddress} - ${error}`
+    );
     captureException(error);
   }
 }

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -5,6 +5,58 @@ import { RainbowFetchClient } from '../rainbow-fetch';
 import { parseSimplehashNfts } from '@rainbow-me/parsers';
 import { logger } from '@rainbow-me/utils';
 
+interface SimplehashMarketplace {
+  marketplace_name: string;
+  marketplace_collection_id: string;
+  collection_url: string;
+  verified: boolean;
+}
+
+interface SimplehashCollection {
+  collection_id: string;
+  name: string;
+  description: string;
+  image_url: string | null;
+  banner_image_url: string | null;
+  external_url: string | null;
+  twitter_username: string | null;
+  discord_url: string | null;
+  marketplace_pages: SimplehashMarketplace[];
+}
+
+interface SimplehashNft {
+  nft_id: string;
+  chain: string;
+  contract_address: string;
+  token_id: string;
+  name: string | null;
+  description: string | null;
+  image_url: string | null;
+  video_url: string | null;
+  audio_url: string | null;
+  model_url: string | null;
+  previews: {
+    image_small_url: string | null;
+    image_medium_url: string | null;
+    image_large_url: string | null;
+    image_opengraph_url: string | null;
+    blurhash: string | null;
+  };
+  background_color: string | null;
+  external_url: string | null;
+  created_date: string | null;
+  status: string;
+  token_count: number;
+  owner_count: number;
+  contract: {
+    type: string;
+    name: string;
+    symbol: string;
+  };
+  collection: SimplehashCollection;
+  extra_metadata: Record<string, string> | null;
+}
+
 const chains = {
   arbitrum: 'arbitrum',
   ethereum: 'ethereum',

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -2,6 +2,7 @@ import { captureException } from '@sentry/react-native';
 // @ts-expect-error
 import { SIMPLEHASH_API_KEY } from 'react-native-dotenv';
 import { RainbowFetchClient } from '../rainbow-fetch';
+import { parseSimplehashNfts } from '@rainbow-me/parsers';
 import { logger } from '@rainbow-me/utils';
 
 const chains = {
@@ -57,7 +58,7 @@ export async function getNftsByWalletAddress(walletAddress: string) {
         wallet_addresses: walletAddress,
       },
     });
-    return response.data;
+    return parseSimplehashNfts(response.data.nfts);
   } catch (error) {
     logger.sentry(
       `Error fetching simplehash NFTs for wallet address: ${walletAddress} - ${error}`

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -2,6 +2,7 @@ import { captureException } from '@sentry/react-native';
 // @ts-expect-error
 import { SIMPLEHASH_API_KEY } from 'react-native-dotenv';
 import { RainbowFetchClient } from '../rainbow-fetch';
+import { Network } from '@rainbow-me/helpers';
 import { parseSimplehashNfts } from '@rainbow-me/parsers';
 import { logger } from '@rainbow-me/utils';
 
@@ -101,7 +102,7 @@ export async function getNFTByTokenId({
 export async function getNftsByWalletAddress(walletAddress: string) {
   let rawResponseNfts: SimplehashNft[] = [];
   try {
-    const chainParam: string = `${chains.arbitrum},${chains.optimism}`;
+    const chainsParam: string = `${Network.arbitrum},${Network.optimism}`;
 
     let cursor = START_CURSOR;
     while (cursor) {
@@ -112,7 +113,7 @@ export async function getNftsByWalletAddress(walletAddress: string) {
           'x-api-key': SIMPLEHASH_API_KEY,
         },
         params: {
-          chains: chainParam,
+          chains: chainsParam,
           ...(cursor !== START_CURSOR && { cursor }),
           wallet_addresses: walletAddress,
         },

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -500,7 +500,7 @@
         "toast_added_to_showcase": "Added to showcase",
         "toast_removed_from_showcase": "Removed from showcase",
         "twitter": "Twitter",
-        "view_all_with_property": "View All With Property",
+        "view_all_with_property": "View All with Property",
         "view_collection": "View Collection",
         "view_on_block_explorer": "View on %{blockExplorerName}",
         "view_on_opensea": "View on Opensea",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -486,7 +486,6 @@
         "last_sale_price": "Last sale price",
         "manager": "Manager",
         "open_in_web_browser": "Open in Web Browser",
-        "opensea": "OpenSea",
         "owner": "Owner",
         "profile_info": "Profile Info",
         "properties": "Properties",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -465,8 +465,7 @@
           "image_download_permission": "Image Download Permission",
           "nft_image": "NFT image",
           "your_permission_is_required": "Your permission is required to save images to your device"
-        },
-        "view_on_opensea": "View on OpenSea"
+        }
       },
       "unique_expanded": {
         "about": "About %{assetFamilyName}",
@@ -503,7 +502,7 @@
         "view_all_with_property": "View All with Property",
         "view_collection": "View Collection",
         "view_on_block_explorer": "View on %{blockExplorerName}",
-        "view_on_opensea": "View on Opensea",
+        "view_on_marketplace_name": "View on %{marketplaceName}",
         "view_on_platform": "View on %{platform}",
         "view_on_web": "View on Web"
       }

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -468,8 +468,7 @@
           "image_download_permission": "Image Download Permission :)",
           "nft_image": "NFT image :)",
           "your_permission_is_required": "Your permission is required to save images to your device :)"
-        },
-        "view_on_opensea": "View on OpenSea :)"
+        }
       },
       "unique_expanded": {
         "about": "About %{assetFamilyName} :)",
@@ -506,7 +505,7 @@
         "view_all_with_property": "View All with Property :)",
         "view_collection": "View Collection :)",
         "view_on_block_explorer": "View on %{blockExplorerName} :)",
-        "view_on_opensea": "View on Opensea :)",
+        "view_on_marketplace_name": "View on %{marketplaceName} :)",
         "view_on_platform": "View on %{platform} :)",
         "view_on_web": "View on Web :)"
       }

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -503,7 +503,7 @@
         "toast_added_to_showcase": "Added to showcase :)",
         "toast_removed_from_showcase": "Removed from showcase :)",
         "twitter": "Twitter",
-        "view_all_with_property": "View All With Property :)",
+        "view_all_with_property": "View All with Property :)",
         "view_collection": "View Collection :)",
         "view_on_block_explorer": "View on %{blockExplorerName} :)",
         "view_on_opensea": "View on Opensea :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -489,7 +489,6 @@
         "last_sale_price": "Last sale price :)",
         "manager": "Manager :)",
         "open_in_web_browser": "Open in Web Browser :)",
-        "opensea": "OpenSea",
         "owner": "Owner :)",
         "profile_info": "Profile Info :)",
         "properties": "Properties :)",

--- a/src/navigation/useUntrustedUrlOpener.ts
+++ b/src/navigation/useUntrustedUrlOpener.ts
@@ -12,8 +12,10 @@ const trustedDomains = [
   'foundation.app',
   'instagram.com',
   'opensea.io',
+  'quixotic.io',
   'rainbow.me',
   'rarible.com',
+  'stratosnft.io',
   'twitter.com',
   'zora.co',
 ];

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -32,6 +32,7 @@ export {
 export {
   parseAccountUniqueTokens,
   parseAccountUniqueTokensPolygon,
+  parseSimplehashNfts,
   handleAndSignImages,
   getFamilies,
   dedupeUniqueTokens,

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -34,6 +34,7 @@ export {
   parseAccountUniqueTokensPolygon,
   parseSimplehashNfts,
   handleAndSignImages,
+  getOpenSeaCollectionUrl,
   getFamilies,
   dedupeUniqueTokens,
   dedupeAssetsWithFamilies,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -284,3 +284,58 @@ export const dedupeAssetsWithFamilies = (accountAssets, families) =>
     accountAssets,
     asset => !families?.find(family => family === asset?.address)
   );
+
+export const parseSimplehashNfts = nftData => {
+  const results = nftData?.map(simplehashNft => {
+    const collection = simplehashNft.collection;
+
+    const { imageUrl, lowResUrl } = handleAndSignImages(
+      simplehashNft.image_url,
+      simplehashNft.extra_metadata?.image_original_url,
+      simplehashNft.previews.image_small_url
+    );
+
+    const parsedNft = {
+      animation_url: simplehashNft.extra_metadata?.animation_original_url,
+      asset_contract: {
+        address: simplehashNft.contract_address,
+        name: simplehashNft.contract.name,
+        schema_name: simplehashNft.contract.type,
+        symbol: simplehashNft.contract.symbol,
+      },
+      background: simplehashNft.background_color,
+      collection: {
+        description: collection.description,
+        discord_url: collection.discord_url,
+        external_url: collection.external_url,
+        image_url: collection.image_url,
+        name: collection.name,
+        slug: collection.collection_id,
+        twitter_username: collection.twitter_username,
+      },
+      description: simplehashNft.description,
+      external_link: simplehashNft.external_url,
+      familyImage: collection.image_url,
+      familyName: collection.name,
+      id: simplehashNft.token_id,
+      image_original_url: simplehashNft.extra_metadata?.image_original_url,
+      image_preview_url: lowResUrl,
+      image_thumbnail_url: lowResUrl,
+      image_url: imageUrl,
+      isPoap: false,
+      isSendable: false,
+      lastPrice: parseLastSalePrice(simplehashNft.last_sale?.unit_price),
+      lastSalePaymentToken: simplehashNft.last_sale?.payment_token?.symbol,
+      lowResUrl,
+      name: simplehashNft.name,
+      network: simplehashNft.chain,
+      permalink: null, // TODO - simplehashNft.collection.marketplace_pages / token_id
+      traits: simplehashNft.extra_metadata?.attributes ?? [],
+      type: AssetTypes.nft,
+      uniqueId: `${simplehashNft.contract_address}_${simplehashNft.token_id}`,
+      urlSuffixForAsset: `${simplehashNft.contract_address}/${simplehashNft.token_id}`,
+    };
+    return parsedNft;
+  });
+  return results;
+};

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -134,6 +134,7 @@ export const parseAccountUniqueTokens = data => {
             ? asset.last_sale.payment_token?.symbol
             : null,
           lowResUrl,
+          marketplaceName: 'OpenSea',
           type: AssetTypes.nft,
           uniqueId:
             asset_contract.address === ENS_NFT_CONTRACT_ADDRESS
@@ -209,6 +210,7 @@ export const parseAccountUniqueTokensPolygon = data => {
           ? asset.last_sale.payment_token?.symbol
           : null,
         lowResUrl,
+        marketplaceName: 'OpenSea',
         network: Network.polygon,
         permalink: asset.permalink,
         type: AssetTypes.nft,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -21,6 +21,9 @@ const parseLastSalePrice = lastSale =>
       ) / 1000
     : null;
 
+const getOpenSeaCollectionUrl = slug =>
+  `https://opensea.io/collection/${slug}?search[sortAscending]=true&search[sortBy]=PRICE&search[toggles][0]=BUY_NOW`;
+
 /**
  * @desc signs and handles low res + full res images
  * @param  {Object}
@@ -134,6 +137,7 @@ export const parseAccountUniqueTokens = data => {
             ? asset.last_sale.payment_token?.symbol
             : null,
           lowResUrl,
+          marketplaceCollectionUrl: getOpenSeaCollectionUrl(collection.slug),
           marketplaceName: 'OpenSea',
           type: AssetTypes.nft,
           uniqueId:
@@ -210,6 +214,7 @@ export const parseAccountUniqueTokensPolygon = data => {
           ? asset.last_sale.payment_token?.symbol
           : null,
         lowResUrl,
+        marketplaceCollectionUrl: getOpenSeaCollectionUrl(collection.slug),
         marketplaceName: 'OpenSea',
         network: Network.polygon,
         permalink: asset.permalink,
@@ -293,6 +298,7 @@ const getSimplehashMarketplaceInfo = simplehashNft => {
 
   const marketplaceName = marketplace.marketplace_name;
   const collectionId = marketplace.marketplace_collection_id;
+  const collectionUrl = marketplace.collection_url;
   const tokenId = simplehashNft.token_id;
   let permalink = null;
   switch (marketplaceName) {
@@ -307,6 +313,7 @@ const getSimplehashMarketplaceInfo = simplehashNft => {
   }
   return {
     collectionId,
+    collectionUrl,
     marketplaceName,
     permalink,
   };
@@ -356,6 +363,7 @@ export const parseSimplehashNfts = nftData => {
       lastPrice: parseLastSalePrice(simplehashNft.last_sale?.unit_price),
       lastSalePaymentToken: simplehashNft.last_sale?.payment_token?.symbol,
       lowResUrl,
+      marketplaceCollectionUrl: marketplaceInfo?.collectionUrl,
       marketplaceName: marketplaceInfo?.marketplaceName,
       name: simplehashNft.name,
       network: simplehashNft.chain,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -285,6 +285,24 @@ export const dedupeAssetsWithFamilies = (accountAssets, families) =>
     asset => !families?.find(family => family === asset?.address)
   );
 
+const createSimplehashPermalink = simplehashNft => {
+  const marketplace = simplehashNft.collection.marketplace_pages?.[0];
+  if (!marketplace) return null;
+
+  const marketplaceName = marketplace.marketplace_name;
+  const collectionId = marketplace.marketplace_collection_id;
+  const tokenId = simplehashNft.token_id;
+  switch (marketplaceName) {
+    case 'Quixotic':
+      return `https://quixotic.io/asset/${collectionId}/${tokenId}`;
+    case 'Stratos':
+      return `https://stratosnft.io/asset/${collectionId}/${tokenId}`;
+    default: {
+      return null;
+    }
+  }
+};
+
 export const parseSimplehashNfts = nftData => {
   const results = nftData?.map(simplehashNft => {
     const collection = simplehashNft.collection;
@@ -329,7 +347,7 @@ export const parseSimplehashNfts = nftData => {
       lowResUrl,
       name: simplehashNft.name,
       network: simplehashNft.chain,
-      permalink: null, // TODO - simplehashNft.collection.marketplace_pages / token_id
+      permalink: createSimplehashPermalink(simplehashNft),
       traits: simplehashNft.extra_metadata?.attributes ?? [],
       type: AssetTypes.nft,
       uniqueId: `${simplehashNft.contract_address}_${simplehashNft.token_id}`,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -285,22 +285,29 @@ export const dedupeAssetsWithFamilies = (accountAssets, families) =>
     asset => !families?.find(family => family === asset?.address)
   );
 
-const createSimplehashPermalink = simplehashNft => {
+const getSimplehashMarketplaceInfo = simplehashNft => {
   const marketplace = simplehashNft.collection.marketplace_pages?.[0];
   if (!marketplace) return null;
 
   const marketplaceName = marketplace.marketplace_name;
   const collectionId = marketplace.marketplace_collection_id;
   const tokenId = simplehashNft.token_id;
+  let permalink = null;
   switch (marketplaceName) {
     case 'Quixotic':
-      return `https://quixotic.io/asset/${collectionId}/${tokenId}`;
+      permalink = `https://quixotic.io/asset/${collectionId}/${tokenId}`;
+      break;
     case 'Stratos':
-      return `https://stratosnft.io/asset/${collectionId}/${tokenId}`;
-    default: {
-      return null;
-    }
+      permalink = `https://stratosnft.io/asset/${collectionId}/${tokenId}`;
+      break;
+    default:
+      permalink = null;
   }
+  return {
+    collectionId,
+    marketplaceName,
+    permalink,
+  };
 };
 
 export const parseSimplehashNfts = nftData => {
@@ -312,6 +319,8 @@ export const parseSimplehashNfts = nftData => {
       simplehashNft.extra_metadata?.image_original_url,
       simplehashNft.previews.image_small_url
     );
+
+    const marketplaceInfo = getSimplehashMarketplaceInfo(simplehashNft);
 
     const parsedNft = {
       animation_url: simplehashNft.extra_metadata?.animation_original_url,
@@ -328,7 +337,7 @@ export const parseSimplehashNfts = nftData => {
         external_url: collection.external_url,
         image_url: collection.image_url,
         name: collection.name,
-        slug: collection.collection_id,
+        slug: marketplaceInfo?.collectionId,
         twitter_username: collection.twitter_username,
       },
       description: simplehashNft.description,
@@ -345,9 +354,10 @@ export const parseSimplehashNfts = nftData => {
       lastPrice: parseLastSalePrice(simplehashNft.last_sale?.unit_price),
       lastSalePaymentToken: simplehashNft.last_sale?.payment_token?.symbol,
       lowResUrl,
+      marketplaceName: marketplaceInfo?.marketplaceName,
       name: simplehashNft.name,
       network: simplehashNft.chain,
-      permalink: createSimplehashPermalink(simplehashNft),
+      permalink: marketplaceInfo?.permalink,
       traits: simplehashNft.extra_metadata?.attributes ?? [],
       type: AssetTypes.nft,
       uniqueId: `${simplehashNft.contract_address}_${simplehashNft.token_id}`,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -139,6 +139,7 @@ export const parseAccountUniqueTokens = data => {
           lowResUrl,
           marketplaceCollectionUrl: getOpenSeaCollectionUrl(collection.slug),
           marketplaceName: 'OpenSea',
+          network: Network.mainnet,
           type: AssetTypes.nft,
           uniqueId:
             asset_contract.address === ENS_NFT_CONTRACT_ADDRESS

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -21,7 +21,7 @@ const parseLastSalePrice = lastSale =>
       ) / 1000
     : null;
 
-const getOpenSeaCollectionUrl = slug =>
+export const getOpenSeaCollectionUrl = slug =>
   `https://opensea.io/collection/${slug}?search[sortAscending]=true&search[sortBy]=PRICE&search[toggles][0]=BUY_NOW`;
 
 /**

--- a/src/redux/uniqueTokens.ts
+++ b/src/redux/uniqueTokens.ts
@@ -22,6 +22,7 @@ import {
   UNIQUE_TOKENS_LIMIT_TOTAL,
 } from '@rainbow-me/handlers/opensea-api';
 import { fetchPoaps } from '@rainbow-me/handlers/poap';
+import { getNftsByWalletAddress } from '@rainbow-me/handlers/simplehash';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import { dedupeAssetsWithFamilies, getFamilies } from '@rainbow-me/parsers';
 
@@ -327,6 +328,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
   };
 
   await fetchNetwork(currentNetwork);
+
   // Only include poaps and L2 nft's on mainnet
   if (currentNetwork === Network.mainnet) {
     const poaps = (await fetchPoaps(accountAddress)) ?? [];
@@ -335,6 +337,14 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
       uniqueTokens = concat(uniqueTokens, poaps);
     }
     await fetchNetwork(Network.polygon);
+
+    // Fetch Optimism and Arbitrum NFTs
+    const optimismArbitrumNFTs = await getNftsByWalletAddress(accountAddress);
+
+    if (optimismArbitrumNFTs.length > 0) {
+      uniqueTokens = concat(uniqueTokens, optimismArbitrumNFTs);
+    }
+
     //we only care about analytics for mainnet + L2's
     analytics.identify(null, { NFTs: uniqueTokens.length });
   }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
This adds support for optimism and arbitrum NFTs.

The commit history is clean and is meant to be read in order.
Many items were tightly coupled with OpenSea, so many of the changes are nominal (name changes) or are updated to help the logic behave more generically.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
Example wallets used: vitalik.eth, misfitinternet.eth, 0x6F829Fd52DF9B664DDa4DA2D1ce200A404Ae0B80

Please test NFTs on mainnet, polygon, optimism, and arbitrum.
Please make sure our POAPs and ENS still work as expected
Please go through each item in the NFT expanded state.

Details about the expanded state:
* Rainbow web URLs are supported only for mainnet and polygon.
* The Share button should be the Rainbow web URL for mainnet and polygon; it should be the permalink for arbitrum and optimism when available. If the permalink is unavailable, the Share button should not be visible.
* The last sale and floor price section should not be visible for the L2s
* The block explorers are: Etherscan for mainnet and optimism; polygonscan and arbiscan
* The NFT marketplaces are: OpenSea for mainnet and polygon; Quixotic for optimism when available; Stratos for Arbitrum when available
* Please note that sometimes there is no marketplace link for the optimism and arbitrum NFTs
* There L2 disclaimers should be visible for any NFT on an L2
* When available, opening the NFT properties should direct you to the respective NFT marketplace
* Sending is currently unavailable for the L2s

Other changes:
* When tapping on the attributes, you should see "View All with Property" (with a lowercase "with" - previously it was "With")
* When you delete the app completely / clear cache and open a wallet for the first time, the NFT families should no longer load in batches


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
