### PR TITLE
Fix layout of change sheet when keyboard is dismissed

### DIFF
--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -38,8 +38,16 @@ const Container = styled(Column)({
   flex: 1,
 });
 
-const FormContainer = styled(Column).attrs({})(({ isNft }) => ({
+const FormContainer = styled(Column).attrs(
+  ios
+    ? {
+        align: 'end',
+        justify: 'space-between',
+      }
+    : {}
+)(({ isNft }) => ({
   ...(isNft ? padding.object(0) : padding.object(0, 19)),
+  ...(ios ? { flex: 1 } : {}),
 }));
 
 const KeyboardSizeView = styled(KeyboardArea)({

--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -38,13 +38,8 @@ const Container = styled(Column)({
   flex: 1,
 });
 
-const FormContainer = styled(Column).attrs({
-  align: 'end',
-  justify: 'space-between',
-})(({ isNft }) => ({
+const FormContainer = styled(Column).attrs({})(({ isNft }) => ({
   ...(isNft ? padding.object(0) : padding.object(0, 19)),
-  flex: 1,
-  width: '100%',
 }));
 
 const KeyboardSizeView = styled(KeyboardArea)({


### PR DESCRIPTION
Fixes RNBW-4012

## What changed (plus any additional context for devs)

The way layout is calculated in send sheet _on Android_.

## Screen recordings / screenshots
|iOS|Android with keyboard|Android without|
|--|--|--|
|![IMG_EADD4259BDA9-1](https://user-images.githubusercontent.com/5769281/180429705-f733f9df-cb09-405d-87ea-4a250b9f948c.jpeg)|![Screenshot_20220722-142428_Rainbow](https://user-images.githubusercontent.com/5769281/180429748-0d1385dc-3bc8-4bc0-9e37-7e9254cf3423.jpg)|![Screenshot_20220722-142446_Rainbow](https://user-images.githubusercontent.com/5769281/180429744-a45c7167-b9ba-4647-a0db-90aac332d45c.jpg)|

## What to test

Try as many different Android phones. The goal is to make sure that:
- There is no regression in how it looks visually (for example on screenshot with keyboard you can see a light grey area, but this is how it looks on this phone on develop so I am not touching it).
- There is improvement in how layout behaves when keyboard is dismissed.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
