### PR TITLE
Fix displaying currency symbols that appear after amount

### DIFF
--- a/src/components/coin-row/SendCoinRow.js
+++ b/src/components/coin-row/SendCoinRow.js
@@ -116,8 +116,10 @@ const SendCoinRow = magicMemo(
     const fiatValue = native?.balance?.display;
     const chopCents =
       fiatValue && fiatValue.split('.')[0].replace(/\D/g, '') > 100;
+    // TODO i18n: relying on dots and commas for currency separator does not
+    // scale to other locales than US-en.
     const fiatValueFormatted =
-      fiatValue && chopCents ? fiatValue.split('.')[0] : fiatValue;
+      !!fiatValue && chopCents ? fiatValue.replace(/\.\d+/, '') : fiatValue;
 
     const Wrapper = disablePressAnimation
       ? TouchableWithoutFeedback


### PR DESCRIPTION
Fixes RNBW-4010
Figma link (if any):

## What changed (plus any additional context for devs)


## Screen recordings / screenshots

|Before|After|
|--|--|
|![IMG_73DA1D34D485-1](https://user-images.githubusercontent.com/5769281/180438990-2b686791-4b54-4e0c-bc92-c1e29cdfa54b.jpeg)|![IMG_2015E53C5FA0-1](https://user-images.githubusercontent.com/5769281/180439014-02333599-97ec-42b3-b212-8ff955b8c2f2.jpeg)|



## What to test

Check if list of assets in the send sheet contains currency symbols when using currencies where symbol appear after the amount (for USD the format is `$1,000.00`, for other it might be `1,000.00X`).

The problem appeared only in amount `>100`, as we were truncating them.

Note that we are not dealing with proper number formatting here! So our usage of comma and dot is wrong for most locales, but we are not fixing it at the moment. See for more: [Currency formatting](https://docs.microsoft.com/en-us/globalization/locale/currency-formatting).


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
