### PR TITLE
[TEAM2-285] Wallet pull to refresh is getting stuck

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/RefreshControl.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RefreshControl.tsx
@@ -14,10 +14,10 @@ export default function RefreshControlWrapped(
   const { refresh, isRefreshing } = useRefreshAccountData();
   const { colors } = useTheme();
 
-  return isLoadingAssets ? null : (
+  return (
     <RefreshControl
       {...props}
-      onRefresh={refresh}
+      onRefresh={() => (isLoadingAssets ? Function.prototype() : refresh())}
       progressViewOffset={android ? 30 : 0}
       refreshing={isRefreshing}
       tintColor={colors.alpha(colors.blueGreyDark, 0.4)}

--- a/src/components/asset-list/RecyclerAssetList2/core/RefreshControl.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RefreshControl.tsx
@@ -13,11 +13,12 @@ export default function RefreshControlWrapped(
   );
   const { refresh, isRefreshing } = useRefreshAccountData();
   const { colors } = useTheme();
+  const onRefresh = isLoadingAssets ? () => {} : refresh;
 
   return (
     <RefreshControl
       {...props}
-      onRefresh={() => (isLoadingAssets ? Function.prototype() : refresh())}
+      onRefresh={onRefresh}
       progressViewOffset={android ? 30 : 0}
       refreshing={isRefreshing}
       tintColor={colors.alpha(colors.blueGreyDark, 0.4)}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Conditionally rendering the refresh control seems to create a race condition, where the `refresh` function doesn't actually fire. Rather than rendering null in place of the refresh control, I am performing a NOOP if we see that assets are still loading.

## Screen recordings / screenshots
https://recordit.co/IkR0fpYfu0


## What to test
Switch wallets and attempt pull to refresh. If you're very fast, we may NOOP, but it will no longer get stuck if working appropriately.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
