### PR TITLE
Do not show swap button on expanded state while using testnets

### DIFF
--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -37,7 +37,7 @@ import { Chart } from '../../value-chart';
 import ExpandedStateSection from '../ExpandedStateSection';
 import SocialLinks from './SocialLinks';
 import { ChartPathProvider } from '@rainbow-me/animated-charts';
-import { isL2Network } from '@rainbow-me/handlers/web3';
+import { isL2Network, isTestnetNetwork } from '@rainbow-me/handlers/web3';
 import AssetInputTypes from '@rainbow-me/helpers/assetInputTypes';
 import {
   useAccountSettings,
@@ -187,7 +187,7 @@ export default function ChartExpandedState({ asset }) {
   } = useRoute();
 
   const [carouselHeight, setCarouselHeight] = useState(defaultCarouselHeight);
-  const { nativeCurrency } = useAccountSettings();
+  const { nativeCurrency, network } = useAccountSettings();
   const [additionalContentHeight, setAdditionalContentHeight] = useState(0);
 
   // If we don't have a balance for this asset
@@ -200,6 +200,7 @@ export default function ChartExpandedState({ asset }) {
       ? ethereumUtils.formatGenericAsset(genericAsset, nativeCurrency)
       : { ...asset };
   }, [asset, genericAsset, hasBalance, nativeCurrency]);
+  const isTestNet = isTestnetNetwork(network);
 
   if (assetWithPrice?.mainnet_address) {
     assetWithPrice.l2Address = assetWithPrice.address;
@@ -372,7 +373,7 @@ export default function ChartExpandedState({ asset }) {
         </SheetActionButtonRow>
       ) : (
         <SheetActionButtonRow paddingBottom={isL2 ? 19 : undefined}>
-          {hasBalance && (
+          {hasBalance && !isTestNet && (
             <SwapActionButton
               asset={ogAsset}
               color={color}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We are not going to show the swap button while using testnets on the asset expanded state.

## Screen recordings / screenshots
https://recordit.co/sHwcbDjpLH

## What to test
Make sure the swap button on expanded state doesn't show when on a testnet.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
