### PR TITLE
don't allow WETH swaps

### DIFF
--- a/src/raps/unlockAndSwap.ts
+++ b/src/raps/unlockAndSwap.ts
@@ -1,3 +1,4 @@
+import { Linking } from 'react-native';
 import { concat, reduce } from 'lodash';
 import { assetNeedsUnlocking, estimateApprove } from './actions';
 import {
@@ -61,6 +62,16 @@ export const createUnlockAndSwapRap = async (
 ) => {
   const { inputAmount, tradeDetails } = swapParameters;
   const { inputCurrency } = store.getState().swap;
+
+  const inputSymbol = tradeDetails.route.input.symbol;
+  const outputSymbol = tradeDetails.route.output.symbol;
+  if (
+    (inputSymbol === 'ETH' && outputSymbol === 'WETH') ||
+    (inputSymbol === 'WETH' && outputSymbol === 'ETH')
+  ) {
+    Linking.openURL('https://app.uniswap.org/#/swap');
+    return;
+  }
 
   // create unlock rap
   const { accountAddress } = store.getState().settings;


### PR DESCRIPTION
## What changed (plus any additional context for devs)

This PR opens Uniswap's website if the trade attempted is ETH->WETH or WETH->ETH.

Currently this trade doesn't use the WETH deposit / withdraw functions, so users end up losing ETH and potentially resetting their cost basis since it typically uses stable pairs to go through. ([examples](https://etherscan.io/tx/0xd6c4be080d5438f932f099f98167316cde6f3d06d5e743a9f9da51e2d2ce3a8d) [here](https://etherscan.io/tx/0x77ee16dd84c35ccff1076161b15834c22e61d51b174679d6feba3b47e304cfa2)) This PR makes it more annoying for users but ensures they won't lose ETH