### PR TITLE
Restore emoji categories on Android in avatar picker

### DIFF
--- a/src/components/avatar-builder/Categories.android.ts
+++ b/src/components/avatar-builder/Categories.android.ts
@@ -1,6 +1,8 @@
 import lang from 'i18n-js';
 import { EmojiCategory } from './types';
 
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+
 // `name` is used for filtering Emoji, while `getTitle` is used to render the
 // title shown to users. Therefore, `name` fields do not use i18n while
 // `getTitle` fields do.
@@ -12,4 +14,55 @@ export const Categories: Record<string, EmojiCategory> = {
     name: 'Smileys & People',
     width: 138,
   },
+  nature: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.animals'),
+    icon: 'emojiAnimals',
+    index: 1,
+    name: 'Animals & Nature',
+    width: 143,
+  },
+  food: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.food'),
+    icon: 'emojiFood',
+    index: 2,
+    name: 'Food & Drink',
+    width: 109,
+  },
+  activities: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.activities'),
+    icon: 'emojiActivities',
+    index: 3,
+    name: 'Activities',
+    width: 87,
+  },
+  places: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.travel'),
+    icon: 'emojiTravel',
+    index: 4,
+    name: 'Travel & Places',
+    width: 132,
+  },
+  objects: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.objects'),
+    icon: 'emojiObjects',
+    index: 5,
+    name: 'Objects',
+    width: 75,
+  },
+  icons: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.symbols'),
+    icon: 'emojiSymbols',
+    index: 6,
+    name: 'Symbols',
+    width: 79,
+  },
+  flags: {
+    getTitle: () => lang.t('avatar_builder.emoji_categories.flags'),
+    icon: 'emojiFlags',
+    index: 7,
+    name: 'Flags',
+    width: 57,
+  },
 };
+
+/* eslint-enable sort-keys-fix/sort-keys-fix */

--- a/src/components/avatar-builder/Categories.android.ts
+++ b/src/components/avatar-builder/Categories.android.ts
@@ -1,8 +1,6 @@
 import lang from 'i18n-js';
 import { EmojiCategory } from './types';
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
-
 // `name` is used for filtering Emoji, while `getTitle` is used to render the
 // title shown to users. Therefore, `name` fields do not use i18n while
 // `getTitle` fields do.
@@ -14,55 +12,4 @@ export const Categories: Record<string, EmojiCategory> = {
     name: 'Smileys & People',
     width: 138,
   },
-  nature: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.animals'),
-    icon: 'emojiAnimals',
-    index: 1,
-    name: 'Animals & Nature',
-    width: 143,
-  },
-  food: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.food'),
-    icon: 'emojiFood',
-    index: 2,
-    name: 'Food & Drink',
-    width: 109,
-  },
-  activities: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.activities'),
-    icon: 'emojiActivities',
-    index: 3,
-    name: 'Activities',
-    width: 87,
-  },
-  places: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.travel'),
-    icon: 'emojiTravel',
-    index: 4,
-    name: 'Travel & Places',
-    width: 132,
-  },
-  objects: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.objects'),
-    icon: 'emojiObjects',
-    index: 5,
-    name: 'Objects',
-    width: 75,
-  },
-  icons: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.symbols'),
-    icon: 'emojiSymbols',
-    index: 6,
-    name: 'Symbols',
-    width: 79,
-  },
-  flags: {
-    getTitle: () => lang.t('avatar_builder.emoji_categories.flags'),
-    icon: 'emojiFlags',
-    index: 7,
-    name: 'Flags',
-    width: 57,
-  },
 };
-
-/* eslint-enable sort-keys-fix/sort-keys-fix */

--- a/src/components/avatar-builder/EmojiSelector.tsx
+++ b/src/components/avatar-builder/EmojiSelector.tsx
@@ -97,7 +97,7 @@ export const EmojiSelector = ({
             dim.height = Math.floor(entry.data.length / columns + 1) * cellSize;
             dim.width = deviceUtils.dimensions.width;
           } else if (type === HEADER_ROW) {
-            dim.height = 34.7;
+            dim.height = Object.keys(Categories).length > 1 ? 34.7 : 0;
             dim.width = deviceUtils.dimensions.width;
           } else if (type === OVERLAY) {
             dim.height = i === 0 ? 0.1 : 100;
@@ -336,7 +336,10 @@ export const EmojiSelector = ({
                 // @ts-expect-error
                 rowRenderer={renderItem}
                 scrollIndicatorInsets={[15, 0, 15, 0]}
-                style={sx.listStyle}
+                style={[
+                  sx.listStyle,
+                  Object.keys(Categories).length === 1 && { paddingTop: 16 },
+                ]}
               />
             </StickyContainer>
           </View>


### PR DESCRIPTION
Fixes RNBW-4001
Figma link (if any):

## What changed (plus any additional context for devs)
This PR enables all emoji categories specified for iOS.

## Screen recordings / screenshots

Both are scrolled to the top.

|Android|iOS|
|--|--|
|![Screenshot_20220728-194220_Rainbow](https://user-images.githubusercontent.com/5769281/181592707-88e30d5f-d548-4e49-8426-20c038504d4a.jpg)|![IMG_B54444CB44FC-1](https://user-images.githubusercontent.com/5769281/181592726-45158f81-151e-452d-b508-0062310c29fc.jpeg)|

## What to test

- Make sure there's no regression for iOS.
- List looks and feels ok (or at least not worse than before) on Android.
- No missing emojis, no extremely ugly emojis (to the extent possible on Android).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
