### PR TITLE
swaps: use native display value for swap details

### DIFF
--- a/src/components/expanded-state/swap-details/CurrencyTile.js
+++ b/src/components/expanded-state/swap-details/CurrencyTile.js
@@ -12,7 +12,10 @@ import {
 import { SwapModalField } from '@rainbow-me/redux/swap';
 import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
-import { convertAmountAndPriceToNativeDisplay } from '@rainbow-me/utilities';
+import {
+  convertAmountAndPriceToNativeDisplay,
+  convertAmountToNativeDisplay,
+} from '@rainbow-me/utilities';
 
 export const CurrencyTileHeight = android ? 153 : 143;
 
@@ -67,18 +70,24 @@ export default function CurrencyTile({
   const inputAsExact = useSelector(
     state => state.swap.independentField !== SwapModalField.output
   );
+  const {
+    displayValues: { nativeAmountDisplay },
+  } = useSelector(state => state.swap);
   const { nativeCurrency } = useAccountSettings();
   const colorForAsset = useColorForAsset(asset);
   const { address, mainnet_address, symbol, type: assetType } = asset;
   const isOther =
     (inputAsExact && type === 'output') || (!inputAsExact && type === 'input');
 
+  //console.log('native amount display: ', nativeAmountDisplay);
   const priceDisplay = priceValue
-    ? convertAmountAndPriceToNativeDisplay(
-        amount,
-        priceValue ?? 0,
-        nativeCurrency
-      ).display
+    ? type === 'input'
+      ? convertAmountToNativeDisplay(nativeAmountDisplay, nativeCurrency)
+      : convertAmountAndPriceToNativeDisplay(
+          amount,
+          priceValue ?? 0,
+          nativeCurrency
+        ).display
     : '-';
 
   return (

--- a/src/components/expanded-state/swap-details/CurrencyTile.js
+++ b/src/components/expanded-state/swap-details/CurrencyTile.js
@@ -79,7 +79,6 @@ export default function CurrencyTile({
   const isOther =
     (inputAsExact && type === 'output') || (!inputAsExact && type === 'input');
 
-  //console.log('native amount display: ', nativeAmountDisplay);
   const priceDisplay = priceValue
     ? type === 'input'
       ? convertAmountToNativeDisplay(nativeAmountDisplay, nativeCurrency)


### PR DESCRIPTION
Fixes TEAM2-296
Figma link (if any):

## What changed (plus any additional context for devs)
we not use the native display value for the input value price


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

bad wifi rn can't upload, will post later

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

check swap details input price to match the native input value


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
