### PR TITLE
swaps: fix l2 imported assets

### DIFF
--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -274,7 +274,7 @@ const useSwapCurrencyList = (
             'verifiedAssets',
             'importedAssets',
           ]
-        : ['verifiedAssets'];
+        : ['verifiedAssets', 'importedAssets'];
     setLoading(true);
     await Promise.all(
       categories.map(assetType => getResultsForAssetType(assetType))
@@ -372,7 +372,7 @@ const useSwapCurrencyList = (
           title: tokenSectionTypes.favoriteTokenSection,
         });
       }
-      if (verifiedAssets?.length) {
+      if (verifiedAssetsWithImport?.length) {
         list.push({
           data: verifiedAssetsWithImport,
           key: 'verified',
@@ -380,14 +380,14 @@ const useSwapCurrencyList = (
           useGradientText: IS_TESTING === 'true' ? false : true,
         });
       }
-      if (highLiquidityAssets?.length) {
+      if (highLiquidityAssetsWithImport?.length) {
         list.push({
           data: highLiquidityAssetsWithImport,
           key: 'highLiquidity',
           title: tokenSectionTypes.unverifiedTokenSection,
         });
       }
-      if (lowLiquidityAssets?.length) {
+      if (lowLiquidityAssetsWithoutImport?.length) {
         list.push({
           data: lowLiquidityAssetsWithoutImport,
           key: 'lowLiqudiity',


### PR DESCRIPTION
Fixes TEAM2-297
Figma link (if any):

## What changed (plus any additional context for devs)
we were not adding imported assets on L2's now we do and I adjusted the filtering checks to include them


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

note I hard coded address since pasting is broken on sim
https://cloud.skylarbarrera.com/Screen-Recording-2022-07-25-14-13-35.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

try to import a token address on an L2

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
