### PR TITLE
swaps: team2-293

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -35,7 +35,7 @@ export default function ConfirmExchangeButton({
   const { isSufficientGas, isValidGas, isGasReady } = useGas();
   const { name: routeName } = useRoute();
   const { navigate } = useNavigation();
-  const [swapSubmitted, setSwapSubmitted] = useState(false);
+  const [isSwapSubmitting, setIsSwapSubmitting] = useState(false);
 
   const isSavings =
     type === ExchangeModalTypes.withdrawal ||
@@ -122,7 +122,7 @@ export default function ConfirmExchangeButton({
   } else if (!isValidGas) {
     label = lang.t('button.confirm_exchange.invalid_fee');
   } else if (isSwapDetailsRoute) {
-    if (swapSubmitted) {
+    if (isSwapSubmitting) {
       label = lang.t('button.confirm_exchange.submitting');
     } else {
       label = isHighPriceImpact
@@ -150,12 +150,13 @@ export default function ConfirmExchangeButton({
     !isSufficientGas ||
     !isValidGas ||
     !isSufficientGas ||
-    swapSubmitted;
+    isSwapSubmitting;
 
   const onSwap = useCallback(async () => {
+    ios && setIsSwapSubmitting(true);
     const submitted = await onSubmit();
-    setSwapSubmitted(submitted);
-  }, [onSubmit, setSwapSubmitted]);
+    setIsSwapSubmitting(submitted);
+  }, [onSubmit]);
 
   return (
     <Box>
@@ -164,16 +165,18 @@ export default function ConfirmExchangeButton({
           <HoldToAuthorizeButton
             backgroundColor={buttonColor}
             disableLongPress={
-              (shouldOpenSwapDetails && !insufficientLiquidity) || loading
+              (shouldOpenSwapDetails && !insufficientLiquidity) ||
+              loading ||
+              isSwapSubmitting
             }
             disableShimmerAnimation={insufficientLiquidity}
             disabled={isDisabled && !insufficientLiquidity}
             disabledBackgroundColor={
-              swapSubmitted ? buttonColor : disabledButtonColor
+              isSwapSubmitting ? buttonColor : disabledButtonColor
             }
             hideInnerBorder
             label={label}
-            loading={loadingQuote || swapSubmitted}
+            loading={loadingQuote || isSwapSubmitting}
             onLongPress={
               loading
                 ? NOOP
@@ -190,7 +193,7 @@ export default function ConfirmExchangeButton({
                   : shadowsForAsset
                 : shadows.default
             }
-            showBiometryIcon={isSwapDetailsRoute && !swapSubmitted}
+            showBiometryIcon={isSwapDetailsRoute && !isSwapSubmitting}
             testID={testID}
             {...props}
             parentHorizontalPadding={19}

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -533,7 +533,7 @@ export default function ExchangeModal({
         if (!wallet) {
           setIsAuthorizing(false);
           logger.sentry(`aborting ${type} due to missing wallet`);
-          return;
+          return false;
         }
 
         const callback = (success = false, errorMessage = null) => {
@@ -577,11 +577,13 @@ export default function ExchangeModal({
         // Tell iOS we finished running a rap (for tracking purposes)
         NotificationManager &&
           NotificationManager.postNotification('rapCompleted');
+        return true;
       } catch (error) {
         setIsAuthorizing(false);
         logger.log('[exchange - handle submit] error submitting swap', error);
         setParams({ focused: false });
         navigate(Routes.WALLET_SCREEN);
+        return false;
       }
     },
     [
@@ -656,8 +658,11 @@ export default function ExchangeModal({
     if (cancelTransaction) {
       return false;
     }
-    submit(amountInUSD);
-    return true;
+    try {
+      return await submit(amountInUSD);
+    } catch (e) {
+      return false;
+    }
   }, [
     outputPriceValue,
     outputAmount,


### PR DESCRIPTION
Fixes TEAM2-293
Figma link (if any):

## What changed (plus any additional context for devs)

we weren't awaiting for the tx to be sent, including the unlocking of the wallet so it was crashing, and also if the biometrics failed or the user pressed Cancel on android dialog it would be stuck in "submitting" state even tho the tx wasn't submitted at all


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/83f3793e3cc1440dafbd0e89d15e42ab

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
