### PR TITLE
Update bottom padding on wallet screen

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/ExternalScrollView.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/ExternalScrollView.tsx
@@ -10,8 +10,9 @@ import BaseScrollView, {
 import { useMemoOne } from 'use-memo-one';
 import { useRecyclerAssetListPosition } from './Contexts';
 import { StickyHeaderContext } from './StickyHeaders';
+import { safeAreaInsetValues } from '@/utils';
 
-const extraPadding = { paddingBottom: 144 };
+const extraPadding = { paddingBottom: 100 + safeAreaInsetValues.bottom };
 const ExternalScrollViewWithRef = React.forwardRef<
   BaseScrollView,
   ScrollViewDefaultProps & { contentContainerStyle: ViewStyle }


### PR DESCRIPTION
Fixes RNBW-4032
Figma link (if any):

## What changed (plus any additional context for devs)
Decrease bottom padding on wallet screen

## Screen recordings / screenshots

Before: 
|iOS with notch|IOS without notch|Android|
|--|--|--|
|<img width="495" alt="Screenshot 2022-07-25 at 22 58 19" src="https://user-images.githubusercontent.com/48593211/180959791-c7d29994-fa18-4ccc-baf6-a3b642af99a4.png">|<img width="517" alt="Screenshot 2022-07-25 at 22 58 16" src="https://user-images.githubusercontent.com/48593211/180959905-d10db0fd-1e27-4518-acfa-72ad6dab317f.png">|![photo_2022-07-26 11 20 45](https://user-images.githubusercontent.com/48593211/180959993-d759dcb4-6e94-4f46-a48d-40113b5a3b9e.jpeg)|

After:
|iOS with notch|IOS without notch|Android|
|--|--|--|
|<img width="451" alt="Screenshot 2022-07-25 at 22 55 42" src="https://user-images.githubusercontent.com/48593211/180961600-763562f0-462c-457a-9846-01948dc59035.png">|<img width="561" alt="Screenshot 2022-07-25 at 22 55 49" src="https://user-images.githubusercontent.com/48593211/180961687-f86dfc8e-46dc-455a-ad84-3097dc912c0d.png">|![photo_2022-07-26 11 20 50](https://user-images.githubusercontent.com/48593211/180961752-cddd9f00-63c1-4c77-9d8f-8fb954bd6fd5.jpeg)|

## What to test




## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
