### PR TITLE
Scale for `Other amount` and `Copy address` buttons

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -2,7 +2,7 @@ import analytics from '@segment/analytics-react-native';
 import { captureMessage } from '@sentry/react-native';
 import lang from 'i18n-js';
 import React, { Fragment, useCallback } from 'react';
-import { Linking } from 'react-native';
+import { Linking, View } from 'react-native';
 import networkInfo from '../helpers/networkInfo';
 import networkTypes from '../helpers/networkTypes';
 import showWalletErrorAlert from '../helpers/support';
@@ -35,7 +35,11 @@ const Container = styled(Centered).attrs({ direction: 'column' })(
   })
 );
 
-const InterstitialButton = styled(ButtonPressAnimation).attrs(
+const InterstitialButton = styled(ButtonPressAnimation).attrs({
+  borderRadius: 23,
+})();
+
+const InterstitialButtonContent = styled(View).attrs(
   ({ theme: { colors } }) => ({
     backgroundColor: colors.alpha(colors.blueGreyDark, 0.06),
     borderRadius: 23,
@@ -55,10 +59,15 @@ const InterstitialDivider = styled(Divider).attrs(({ theme: { colors } }) => ({
   borderRadius: 1,
 });
 
-const CopyAddressButton = styled(ButtonPressAnimation).attrs(
+const CopyAddressButton = styled(ButtonPressAnimation).attrs({
+  borderRadius: 23,
+})();
+
+const CopyAddressButtonContent = styled(RowWithMargins).attrs(
   ({ theme: { colors } }) => ({
     backgroundColor: colors.alpha(colors.appleBlue, 0.06),
     borderRadius: 23,
+    margin: 6,
   })
 )({
   ...padding.object(10.5, 15, 14.5),
@@ -256,15 +265,17 @@ const AddFundsInterstitial = ({ network }) => {
           </Row>
           <InterstitialButtonRow>
             <InterstitialButton onPress={handlePressAmount} radiusAndroid={23}>
-              <Text
-                align="center"
-                color={colors.alpha(colors.blueGreyDark, 0.6)}
-                lineHeight="loose"
-                size="large"
-                weight="bold"
-              >
-                {` 􀍡 ${lang.t('wallet.add_cash.interstitial.other_amount')}`}
-              </Text>
+              <InterstitialButtonContent>
+                <Text
+                  align="center"
+                  color={colors.alpha(colors.blueGreyDark, 0.6)}
+                  lineHeight="loose"
+                  size="large"
+                  weight="bold"
+                >
+                  {` 􀍡 ${lang.t('wallet.add_cash.interstitial.other_amount')}`}
+                </Text>
+              </InterstitialButtonContent>
             </InterstitialButton>
           </InterstitialButtonRow>
           {!isSmallPhone && <InterstitialDivider />}
@@ -312,7 +323,7 @@ const AddFundsInterstitial = ({ network }) => {
         radiusAndroid={23}
         testID="copy-address-button"
       >
-        <RowWithMargins margin={6}>
+        <CopyAddressButtonContent>
           <Icon
             color={colors.appleBlue}
             marginTop={0.5}
@@ -328,7 +339,7 @@ const AddFundsInterstitial = ({ network }) => {
           >
             {lang.t('wallet.settings.copy_address')}
           </Text>
-        </RowWithMargins>
+        </CopyAddressButtonContent>
       </CopyAddressButton>
     </Container>
   );


### PR DESCRIPTION
Fixes RNBW-4036
Figma link (if any):

## What changed (plus any additional context for devs)
Fix button scale for android on wallet screen. See `... Other amount` and `Copy address`

## Screen recordings / screenshots
Before: https://user-images.githubusercontent.com/48593211/180956739-3474fcc6-d446-496f-911a-75b274ed8764.mp4

After: https://user-images.githubusercontent.com/48593211/180956790-81d1a7de-8178-4bc2-b9b3-b09bc1e6ae95.mp4




## What to test


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
