### PR TITLE
Center avatar emoji on Android

### DIFF
--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -24,7 +24,7 @@ const FirstLetter = styled(Text).attrs(({ theme: { colors } }) => ({
   letterSpacing: 2,
   size: ios ? 38 : 30,
   weight: 'semibold',
-}))({});
+}))({ left: -1 });
 
 export default function AvatarCircle({
   isAvatarPickerAvailable,

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -22,12 +22,9 @@ const FirstLetter = styled(Text).attrs(({ theme: { colors } }) => ({
   align: 'center',
   color: colors.whiteLabel,
   letterSpacing: 2,
-  lineHeight: android ? 68 : 66,
   size: ios ? 38 : 30,
   weight: 'semibold',
-}))({
-  width: android ? 66 : 67,
-});
+}))({});
 
 export default function AvatarCircle({
   isAvatarPickerAvailable,

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -24,7 +24,7 @@ const FirstLetter = styled(Text).attrs(({ theme: { colors } }) => ({
   letterSpacing: 2,
   size: ios ? 38 : 30,
   weight: 'semibold',
-}))({ left: -1 });
+}))({ left: android ? -1 : 0 });
 
 export default function AvatarCircle({
   isAvatarPickerAvailable,


### PR DESCRIPTION
Fixes RNBW-4041
Figma link (if any):

## What changed (plus any additional context for devs)

I messed a bit with text alignment. Also it appears that on iOS this is part of the native list (or at least those changes seemed to not affect iOS at all).

## Screen recordings / screenshots

Old screenshots (still relevant; no changes):

|Before|After|
|--|--|
|![Screenshot_20220726-155244_Rainbow](https://user-images.githubusercontent.com/5769281/181010610-dac29272-3abb-40c5-8607-ee70b7cf754e.jpg)|![Screenshot_20220726-155217_Rainbow](https://user-images.githubusercontent.com/5769281/181010600-7a60d103-2964-4e33-b2df-6fe7c1893423.jpg)|

New screenshots (including iOS):

||Before|After|
|--|--|--|
|iOS|![IMG_0589F57927A1-1](https://user-images.githubusercontent.com/5769281/181242440-55be44b5-23e4-41db-80e5-06e70bcca5f2.jpeg)|![IMG_463602AA2BBA-1](https://user-images.githubusercontent.com/5769281/181242435-1a9a6a5a-3666-4d34-ad5f-b2a351bb614e.jpeg)|
|Android|![Screenshot_20220727-150359_Rainbow](https://user-images.githubusercontent.com/5769281/181242475-520469ab-4c71-4871-a291-df2e42e9ab54.jpg)|![Screenshot_20220727-150230_Rainbow](https://user-images.githubusercontent.com/5769281/181242489-6bc23e99-309c-4770-98dc-02a5a08fcecc.jpg)|

## What to test

Get the weirdest Android phone you have and check if emoji avatar appears to be more in the center.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
