### PR TITLE
swaps: input clearing + loading state

### DIFF
--- a/e2e/swapSheetFlow.spec.js
+++ b/e2e/swapSheetFlow.spec.js
@@ -180,13 +180,16 @@ describe('Swap Sheet Interaction Flow', () => {
     );
     await Helpers.checkIfVisible('exchange-modal-input');
     await Helpers.typeText('exchange-modal-input', '246', true);
-    await Helpers.delay(2000);
     await Helpers.clearField('exchange-modal-input-246');
     await Helpers.checkIfVisible('exchange-modal-output');
     await Helpers.typeText('exchange-modal-output', '246', true);
-    await Helpers.delay(2000);
     await Helpers.clearField('exchange-modal-output-246');
     await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.typeText('exchange-modal-input-native', '246\n', true);
+    await Helpers.clearField('exchange-modal-input-native-246');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.checkIfVisible('exchange-modal-output');
+
     if (device.getPlatform() === 'android') {
       await device.pressBack();
     } else {
@@ -205,12 +208,16 @@ describe('Swap Sheet Interaction Flow', () => {
     await Helpers.tap('currency-select-list-exchange-coin-row-OP-optimism');
     await Helpers.checkIfVisible('exchange-modal-input');
     await Helpers.typeText('exchange-modal-input', '246\n', false);
-    await Helpers.clearField('exchange-modal-input-246', '\n', false);
+    await Helpers.clearField('exchange-modal-input-246');
     await Helpers.checkIfVisible('exchange-modal-output');
     await Helpers.typeText('exchange-modal-output', '246\n', false);
-    await Helpers.clearField('exchange-modal-output-246', '\n', false);
+    await Helpers.clearField('exchange-modal-output-246');
     await Helpers.checkIfVisible('exchange-modal-input');
     await Helpers.checkForElementByLabel('Enter an Amount');
+    await Helpers.typeText('exchange-modal-input-native', '246\n', false);
+    await Helpers.clearField('exchange-modal-input-native-246');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.checkIfVisible('exchange-modal-output');
 
     if (device.getPlatform() === 'android') {
       await device.pressBack();
@@ -228,9 +235,12 @@ describe('Swap Sheet Interaction Flow', () => {
     await Helpers.tap('currency-select-list-exchange-coin-row-DAI-arbitrum');
     await Helpers.checkIfVisible('exchange-modal-input');
     await Helpers.typeText('exchange-modal-input', '246\n', false);
-    await Helpers.clearField('exchange-modal-input-246', '\n', false);
+    await Helpers.clearField('exchange-modal-input-246');
     await Helpers.checkIfVisible('exchange-modal-output');
-
+    await Helpers.typeText('exchange-modal-input-native', '246\n', false);
+    await Helpers.clearField('exchange-modal-input-native-246');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.checkIfVisible('exchange-modal-output');
     if (device.getPlatform() === 'android') {
       await device.pressBack();
     } else {
@@ -247,13 +257,15 @@ describe('Swap Sheet Interaction Flow', () => {
     await Helpers.tap('currency-select-list-exchange-coin-row-MATIC-polygon');
     await Helpers.checkIfVisible('exchange-modal-input');
     await Helpers.typeText('exchange-modal-input', '246\n', false);
-    await Helpers.clearField('exchange-modal-input-246', '\n', false);
+    await Helpers.clearField('exchange-modal-input-246');
     await Helpers.checkIfVisible('exchange-modal-output');
     await Helpers.typeText('exchange-modal-output', '246\n', false);
-    await Helpers.clearField('exchange-modal-output-246', '\n', false);
+    await Helpers.clearField('exchange-modal-output-246');
     await Helpers.checkIfVisible('exchange-modal-input');
-    await Helpers.checkForElementByLabel('Enter an Amount');
-
+    await Helpers.typeText('exchange-modal-input-native', '246\n', false);
+    await Helpers.clearField('exchange-modal-input-native-246');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.checkIfVisible('exchange-modal-output');
     if (device.getPlatform() === 'android') {
       await device.pressBack();
     } else {

--- a/e2e/swapSheetFlow.spec.js
+++ b/e2e/swapSheetFlow.spec.js
@@ -150,6 +150,117 @@ describe('Swap Sheet Interaction Flow', () => {
     }
   });
 
+  it('Should clear inputs when typing a number in inputs and the clearing it', async () => {
+    await Helpers.waitAndTap('exchange-fab');
+    await Helpers.checkIfVisible('currency-select-list');
+    await Helpers.tap('currency-select-list-exchange-coin-row-ETH-token');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.tap('exchange-modal-output-selection-button');
+    await Helpers.checkIfVisible('currency-select-list');
+    await Helpers.typeText('currency-select-search-input', 'DAI\n', true);
+    await Helpers.checkIfVisible(
+      'currency-select-list-exchange-coin-row-DAI-token'
+    );
+    await Helpers.waitAndTap(
+      'currency-select-list-exchange-coin-row-DAI-token'
+    );
+    await Helpers.waitAndTap('exchange-modal-input-selection-button');
+    await Helpers.checkIfVisible('currency-select-list');
+    await Helpers.waitAndTap(
+      'currency-select-list-exchange-coin-row-DAI-token'
+    );
+
+    await Helpers.checkIfElementHasString(
+      'exchange-modal-input-selection-button-text',
+      'DAI'
+    );
+    await Helpers.checkIfElementHasString(
+      'exchange-modal-output-selection-button-text',
+      'ETH'
+    );
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.typeText('exchange-modal-input', '246', true);
+    await Helpers.delay(2000);
+    await Helpers.clearField('exchange-modal-input-246');
+    await Helpers.checkIfVisible('exchange-modal-output');
+    await Helpers.typeText('exchange-modal-output', '246', true);
+    await Helpers.delay(2000);
+    await Helpers.clearField('exchange-modal-output-246');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    if (device.getPlatform() === 'android') {
+      await device.pressBack();
+    } else {
+      await Helpers.swipe('exchange-modal-notch', 'down', 'slow');
+    }
+  });
+
+  it('Should clear inputs when typing a number in inputs and the clearing it optimism', async () => {
+    await Helpers.waitAndTap('exchange-fab');
+    await Helpers.checkIfVisible('currency-select-list');
+    await Helpers.typeText('currency-select-search-input', 'ETH\n', true);
+    await Helpers.tap('currency-select-list-exchange-coin-row-ETH-optimism');
+
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.tap('exchange-modal-output-selection-button');
+    await Helpers.tap('currency-select-list-exchange-coin-row-OP-optimism');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.typeText('exchange-modal-input', '246\n', false);
+    await Helpers.clearField('exchange-modal-input-246', '\n', false);
+    await Helpers.checkIfVisible('exchange-modal-output');
+    await Helpers.typeText('exchange-modal-output', '246\n', false);
+    await Helpers.clearField('exchange-modal-output-246', '\n', false);
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.checkForElementByLabel('Enter an Amount');
+
+    if (device.getPlatform() === 'android') {
+      await device.pressBack();
+    } else {
+      await Helpers.swipe('exchange-modal-notch', 'down', 'slow');
+    }
+  });
+
+  it('Should clear inputs when typing a number in inputs and the clearing it arbitrum', async () => {
+    await Helpers.waitAndTap('exchange-fab');
+    await Helpers.checkIfVisible('currency-select-list');
+    await Helpers.typeText('currency-select-search-input', 'ETH\n', true);
+    await Helpers.tap('currency-select-list-exchange-coin-row-ETH-arbitrum');
+    await Helpers.tap('exchange-modal-output-selection-button');
+    await Helpers.tap('currency-select-list-exchange-coin-row-DAI-arbitrum');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.typeText('exchange-modal-input', '246\n', false);
+    await Helpers.clearField('exchange-modal-input-246', '\n', false);
+    await Helpers.checkIfVisible('exchange-modal-output');
+
+    if (device.getPlatform() === 'android') {
+      await device.pressBack();
+    } else {
+      await Helpers.swipe('exchange-modal-notch', 'down', 'slow');
+    }
+  });
+
+  it('Should clear inputs when typing a number in inputs and the clearing it polygon', async () => {
+    await Helpers.waitAndTap('exchange-fab');
+    await Helpers.checkIfVisible('currency-select-list');
+    await Helpers.typeText('currency-select-search-input', 'WETH\n', true);
+    await Helpers.tap('currency-select-list-exchange-coin-row-WETH-polygon');
+    await Helpers.tap('exchange-modal-output-selection-button');
+    await Helpers.tap('currency-select-list-exchange-coin-row-MATIC-polygon');
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.typeText('exchange-modal-input', '246\n', false);
+    await Helpers.clearField('exchange-modal-input-246', '\n', false);
+    await Helpers.checkIfVisible('exchange-modal-output');
+    await Helpers.typeText('exchange-modal-output', '246\n', false);
+    await Helpers.clearField('exchange-modal-output-246', '\n', false);
+    await Helpers.checkIfVisible('exchange-modal-input');
+    await Helpers.checkForElementByLabel('Enter an Amount');
+
+    if (device.getPlatform() === 'android') {
+      await device.pressBack();
+    } else {
+      await Helpers.swipe('exchange-modal-notch', 'down', 'slow');
+    }
+  });
+
   it('Should swap input & output and clear form on ETH -> ERC20 when selecting ETH as output', async () => {
     await Helpers.waitAndTap('exchange-fab');
     await Helpers.checkIfVisible('currency-select-list');
@@ -524,7 +635,7 @@ describe('Swap Sheet Interaction Flow', () => {
 
   afterAll(async () => {
     // Reset the app state
-    await device.clearKeychain();
+    // await device.clearKeychain();
     await exec('kill $(lsof -t -i:8545)');
   });
 });

--- a/e2e/swapSheetFlow.spec.js
+++ b/e2e/swapSheetFlow.spec.js
@@ -635,7 +635,7 @@ describe('Swap Sheet Interaction Flow', () => {
 
   afterAll(async () => {
     // Reset the app state
-    // await device.clearKeychain();
+    await device.clearKeychain();
     await exec('kill $(lsof -t -i:8545)');
   });
 });

--- a/e2e/swapSheetFlow.spec.js
+++ b/e2e/swapSheetFlow.spec.js
@@ -150,7 +150,7 @@ describe('Swap Sheet Interaction Flow', () => {
     }
   });
 
-  it('Should clear inputs when typing a number in inputs and the clearing it', async () => {
+  it('Should clear inputs when typing a number in inputs and then clearing it', async () => {
     await Helpers.waitAndTap('exchange-fab');
     await Helpers.checkIfVisible('currency-select-list');
     await Helpers.tap('currency-select-list-exchange-coin-row-ETH-token');
@@ -194,7 +194,7 @@ describe('Swap Sheet Interaction Flow', () => {
     }
   });
 
-  it('Should clear inputs when typing a number in inputs and the clearing it optimism', async () => {
+  it('Should clear inputs when typing a number in inputs and then clearing it optimism', async () => {
     await Helpers.waitAndTap('exchange-fab');
     await Helpers.checkIfVisible('currency-select-list');
     await Helpers.typeText('currency-select-search-input', 'ETH\n', true);
@@ -219,7 +219,7 @@ describe('Swap Sheet Interaction Flow', () => {
     }
   });
 
-  it('Should clear inputs when typing a number in inputs and the clearing it arbitrum', async () => {
+  it('Should clear inputs when typing a number in inputs and then clearing it arbitrum', async () => {
     await Helpers.waitAndTap('exchange-fab');
     await Helpers.checkIfVisible('currency-select-list');
     await Helpers.typeText('currency-select-search-input', 'ETH\n', true);
@@ -238,7 +238,7 @@ describe('Swap Sheet Interaction Flow', () => {
     }
   });
 
-  it('Should clear inputs when typing a number in inputs and the clearing it polygon', async () => {
+  it('Should clear inputs when typing a number in inputs and then clearing it polygon', async () => {
     await Helpers.waitAndTap('exchange-fab');
     await Helpers.checkIfVisible('currency-select-list');
     await Helpers.typeText('currency-select-search-input', 'WETH\n', true);

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -32,7 +32,7 @@ export default function ConfirmExchangeButton({
 }) {
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
   const asset = outputCurrency ?? inputCurrency;
-  const { isSufficientGas, isValidGas } = useGas();
+  const { isSufficientGas, isValidGas, isGasReady } = useGas();
   const { name: routeName } = useRoute();
   const { navigate } = useNavigation();
   const [isSwapSubmitting, setIsSwapSubmitting] = useState(false);
@@ -101,6 +101,7 @@ export default function ConfirmExchangeButton({
   ]);
 
   let label = '';
+  const loadingQuote = loading || (!loading && !isGasReady);
 
   if (type === ExchangeModalTypes.deposit) {
     label = lang.t('button.confirm_exchange.deposit');
@@ -109,7 +110,7 @@ export default function ConfirmExchangeButton({
   } else if (type === ExchangeModalTypes.withdrawal) {
     label = lang.t('button.confirm_exchange.withdraw');
   }
-  if (loading) {
+  if (loadingQuote) {
     label = lang.t('button.confirm_exchange.fetching_quote');
   } else if (!isSufficientBalance) {
     label = lang.t('button.confirm_exchange.insufficient_funds');
@@ -175,7 +176,7 @@ export default function ConfirmExchangeButton({
             hideInnerBorder
             isAuthorizing={isSwapSubmitting}
             label={label}
-            loading={loading || isSwapSubmitting}
+            loading={loadingQuote || isSwapSubmitting}
             onLongPress={
               loading || isSwapSubmitting
                 ? NOOP

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -101,7 +101,6 @@ export default function ConfirmExchangeButton({
   ]);
 
   let label = '';
-  const loadingQuote = loading || (!loading && !isGasReady);
 
   if (type === ExchangeModalTypes.deposit) {
     label = lang.t('button.confirm_exchange.deposit');
@@ -110,7 +109,7 @@ export default function ConfirmExchangeButton({
   } else if (type === ExchangeModalTypes.withdrawal) {
     label = lang.t('button.confirm_exchange.withdraw');
   }
-  if (loadingQuote) {
+  if (loading) {
     label = lang.t('button.confirm_exchange.fetching_quote');
   } else if (!isSufficientBalance) {
     label = lang.t('button.confirm_exchange.insufficient_funds');
@@ -119,7 +118,7 @@ export default function ConfirmExchangeButton({
       currentNetwork === NetworkTypes.polygon
         ? lang.t('button.confirm_exchange.insufficient_matic')
         : lang.t('button.confirm_exchange.insufficient_eth');
-  } else if (!isValidGas) {
+  } else if (!isValidGas && isGasReady) {
     label = lang.t('button.confirm_exchange.invalid_fee');
   } else if (isSwapDetailsRoute) {
     if (isSwapSubmitting) {
@@ -176,7 +175,7 @@ export default function ConfirmExchangeButton({
             hideInnerBorder
             isAuthorizing={isSwapSubmitting}
             label={label}
-            loading={loadingQuote || isSwapSubmitting}
+            loading={loading || isSwapSubmitting}
             onLongPress={
               loading || isSwapSubmitting
                 ? NOOP

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -32,7 +32,7 @@ export default function ConfirmExchangeButton({
 }) {
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
   const asset = outputCurrency ?? inputCurrency;
-  const { isSufficientGas, isValidGas, isGasReady } = useGas();
+  const { isSufficientGas, isValidGas } = useGas();
   const { name: routeName } = useRoute();
   const { navigate } = useNavigation();
   const [isSwapSubmitting, setIsSwapSubmitting] = useState(false);
@@ -101,7 +101,6 @@ export default function ConfirmExchangeButton({
   ]);
 
   let label = '';
-  const loadingQuote = loading || (!loading && !isGasReady);
 
   if (type === ExchangeModalTypes.deposit) {
     label = lang.t('button.confirm_exchange.deposit');
@@ -110,7 +109,7 @@ export default function ConfirmExchangeButton({
   } else if (type === ExchangeModalTypes.withdrawal) {
     label = lang.t('button.confirm_exchange.withdraw');
   }
-  if (loadingQuote) {
+  if (loading) {
     label = lang.t('button.confirm_exchange.fetching_quote');
   } else if (!isSufficientBalance) {
     label = lang.t('button.confirm_exchange.insufficient_funds');
@@ -176,7 +175,7 @@ export default function ConfirmExchangeButton({
             hideInnerBorder
             isAuthorizing={isSwapSubmitting}
             label={label}
-            loading={loadingQuote || isSwapSubmitting}
+            loading={loading || isSwapSubmitting}
             onLongPress={
               loading || isSwapSubmitting
                 ? NOOP

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -363,6 +363,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
         },
       };
     }
+
     if (!independentValue) {
       return resetSwapInputs();
     }
@@ -539,6 +540,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     independentValue,
     inputCurrency,
     inputPrice,
+    maxInputUpdate,
     outputCurrency,
     outputPrice,
     resetSwapInputs,
@@ -548,6 +550,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   ]);
   const { data, isLoading } = useQuery({
     cacheTime: IS_TESTING !== 'true' ? 0 : 10000,
+    enabled: !!debouncedIndependentValue,
     queryFn: getTradeDetails,
     queryKey: [
       'getTradeDetails',
@@ -571,9 +574,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
 
   return {
     insufficientLiquidity: data?.insufficientLiquidity || false,
-    loading: Boolean(
-      isLoading && (Boolean(independentValue) || independentValue !== '')
-    ),
+    loading: isLoading && Boolean(independentValue),
     resetSwapInputs,
     result: data?.result || {
       derivedValues,

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -363,7 +363,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
         },
       };
     }
-
     if (!independentValue) {
       return resetSwapInputs();
     }
@@ -540,7 +539,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     independentValue,
     inputCurrency,
     inputPrice,
-    maxInputUpdate,
     outputCurrency,
     outputPrice,
     resetSwapInputs,
@@ -550,7 +548,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   ]);
   const { data, isLoading } = useQuery({
     cacheTime: IS_TESTING !== 'true' ? 0 : 10000,
-    enabled: !!debouncedIndependentValue,
     queryFn: getTradeDetails,
     queryKey: [
       'getTradeDetails',
@@ -574,7 +571,9 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
 
   return {
     insufficientLiquidity: data?.insufficientLiquidity || false,
-    loading: isLoading && Boolean(independentValue),
+    loading: Boolean(
+      isLoading && (Boolean(independentValue) || independentValue !== '')
+    ),
     resetSwapInputs,
     result: data?.result || {
       derivedValues,

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -11,7 +11,6 @@ import { useCallback, useMemo } from 'react';
 import { IS_APK_BUILD, IS_TESTING } from 'react-native-dotenv';
 import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
-import { useDebounce } from 'use-debounce/lib';
 import { Token } from '../entities/tokens';
 import useAccountSettings from './useAccountSettings';
 import { EthereumAddress } from '@rainbow-me/entities';
@@ -292,10 +291,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     (state: AppState) => state.swap.slippageInBips
   );
 
-  const [debouncedIndependentValue] = useDebounce(
-    independentValue,
-    IS_TESTING !== 'true' ? 300 : 500
-  );
   const source = useSelector((state: AppState) => state.swap.source);
 
   const genericAssets = useSelector(
@@ -540,7 +535,6 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     independentValue,
     inputCurrency,
     inputPrice,
-    maxInputUpdate,
     outputCurrency,
     outputPrice,
     resetSwapInputs,
@@ -550,12 +544,11 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   ]);
   const { data, isLoading } = useQuery({
     cacheTime: IS_TESTING !== 'true' ? 0 : 10000,
-    enabled: !!debouncedIndependentValue,
     queryFn: getTradeDetails,
     queryKey: [
       'getTradeDetails',
       independentField,
-      debouncedIndependentValue,
+      independentValue,
       derivedValues[SwapModalField.output],
       derivedValues[SwapModalField.input],
       derivedValues[SwapModalField.native],

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -218,6 +218,7 @@ export default function ExchangeModal({
     updateDefaultGasLimit,
     updateTxFee,
     txNetwork,
+    isGasReady,
   } = useGas();
   const {
     accountAddress,
@@ -454,20 +455,24 @@ export default function ExchangeModal({
 
   // Set default gas limit
   useEffect(() => {
-    if (isEmpty(prevGasFeesParamsBySpeed) && !isEmpty(gasFeeParamsBySpeed)) {
+    if (
+      (isEmpty(prevGasFeesParamsBySpeed) && !isEmpty(gasFeeParamsBySpeed)) ||
+      !isGasReady
+    ) {
       updateTxFee(defaultGasLimit);
     }
   }, [
     defaultGasLimit,
     gasFeeParamsBySpeed,
+    isGasReady,
     prevGasFeesParamsBySpeed,
     updateTxFee,
   ]);
-
   // Update gas limit
   useEffect(() => {
     if (
-      txNetwork !== prevTxNetwork ||
+      !isGasReady ||
+      (!prevTxNetwork && txNetwork !== prevTxNetwork) ||
       (!isEmpty(gasFeeParamsBySpeed) &&
         !isEqual(gasFeeParamsBySpeed, prevGasFeesParamsBySpeed))
     ) {
@@ -475,6 +480,7 @@ export default function ExchangeModal({
     }
   }, [
     gasFeeParamsBySpeed,
+    isGasReady,
     prevGasFeesParamsBySpeed,
     prevTxNetwork,
     txNetwork,

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -1,7 +1,7 @@
 import { useRoute } from '@react-navigation/native';
 import analytics from '@segment/analytics-react-native';
 import lang from 'i18n-js';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty } from 'lodash';
 import React, {
   useCallback,
   useEffect,
@@ -464,13 +464,10 @@ export default function ExchangeModal({
 
   // Update gas limit
   useEffect(() => {
-    if (
-      !isEmpty(gasFeeParamsBySpeed) &&
-      !isEqual(gasFeeParamsBySpeed, prevGasFeesParamsBySpeed)
-    ) {
+    if (!isEmpty(gasFeeParamsBySpeed)) {
       updateGasLimit();
     }
-  }, [gasFeeParamsBySpeed, prevGasFeesParamsBySpeed, updateGasLimit]);
+  }, [gasFeeParamsBySpeed, updateGasLimit]);
 
   // Liten to gas prices, Uniswap reserves updates
   useEffect(() => {

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -1,7 +1,7 @@
 import { useRoute } from '@react-navigation/native';
 import analytics from '@segment/analytics-react-native';
 import lang from 'i18n-js';
-import { isEmpty } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 import React, {
   useCallback,
   useEffect,
@@ -464,10 +464,13 @@ export default function ExchangeModal({
 
   // Update gas limit
   useEffect(() => {
-    if (!isEmpty(gasFeeParamsBySpeed)) {
+    if (
+      !isEmpty(gasFeeParamsBySpeed) &&
+      !isEqual(gasFeeParamsBySpeed, prevGasFeesParamsBySpeed)
+    ) {
       updateGasLimit();
     }
-  }, [gasFeeParamsBySpeed, updateGasLimit]);
+  }, [gasFeeParamsBySpeed, prevGasFeesParamsBySpeed, updateGasLimit]);
 
   // Liten to gas prices, Uniswap reserves updates
   useEffect(() => {

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -217,6 +217,7 @@ export default function ExchangeModal({
     stopPollingGasFees,
     updateDefaultGasLimit,
     updateTxFee,
+    txNetwork,
   } = useGas();
   const {
     accountAddress,
@@ -228,6 +229,7 @@ export default function ExchangeModal({
   const [currentProvider, setCurrentProvider] = useState(null);
 
   const prevGasFeesParamsBySpeed = usePrevious(gasFeeParamsBySpeed);
+  const prevTxNetwork = usePrevious(txNetwork);
 
   useAndroidBackHandler(() => {
     navigate(Routes.WALLET_SCREEN);
@@ -465,12 +467,19 @@ export default function ExchangeModal({
   // Update gas limit
   useEffect(() => {
     if (
-      !isEmpty(gasFeeParamsBySpeed) &&
-      !isEqual(gasFeeParamsBySpeed, prevGasFeesParamsBySpeed)
+      txNetwork !== prevTxNetwork ||
+      (!isEmpty(gasFeeParamsBySpeed) &&
+        !isEqual(gasFeeParamsBySpeed, prevGasFeesParamsBySpeed))
     ) {
       updateGasLimit();
     }
-  }, [gasFeeParamsBySpeed, prevGasFeesParamsBySpeed, updateGasLimit]);
+  }, [
+    gasFeeParamsBySpeed,
+    prevGasFeesParamsBySpeed,
+    prevTxNetwork,
+    txNetwork,
+    updateGasLimit,
+  ]);
 
   // Liten to gas prices, Uniswap reserves updates
   useEffect(() => {

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -455,10 +455,7 @@ export default function ExchangeModal({
 
   // Set default gas limit
   useEffect(() => {
-    if (
-      (isEmpty(prevGasFeesParamsBySpeed) && !isEmpty(gasFeeParamsBySpeed)) ||
-      !isGasReady
-    ) {
+    if (isEmpty(prevGasFeesParamsBySpeed) && !isEmpty(gasFeeParamsBySpeed)) {
       updateTxFee(defaultGasLimit);
     }
   }, [

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -461,7 +461,6 @@ export default function ExchangeModal({
   }, [
     defaultGasLimit,
     gasFeeParamsBySpeed,
-    isGasReady,
     prevGasFeesParamsBySpeed,
     updateTxFee,
   ]);


### PR DESCRIPTION
Fixes TEAM2-302
Fixes TEAM2-301
Figma link (if any):

## What changed (plus any additional context for devs)

bug videos in tickets 

- when you delete the value in one of the inputs, the other inputs’ state isn’t reliably cleared
- on optimism, ‘fetching quote’ is shown before typing any amounts
- added e2e to address the cases where the user clears an input 

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
