### PR TITLE
Center text in buttons

### DIFF
--- a/src/components/sheet/sheet-action-buttons/SheetActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SheetActionButton.js
@@ -4,7 +4,7 @@ import { useTheme } from '../../../theme/ThemeContext';
 import { ButtonPressAnimation } from '../../animations';
 import { Icon } from '../../icons';
 import { Centered, InnerBorder, RowWithMargins } from '../../layout';
-import { Emoji, Text } from '../../text';
+import { Text } from '@rainbow-me/design-system';
 import { containsEmoji } from '@rainbow-me/helpers/strings';
 import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
@@ -19,12 +19,9 @@ const Button = styled(Centered)(({ isCharts, size }) => ({
 }));
 
 const Content = styled(RowWithMargins).attrs({
-  align: 'center',
   margin: 4,
 })({
-  height: ({ size }) => (size === 'big' ? 56 : 46),
   paddingBottom: ({ label }) => (label && containsEmoji(label) ? 2.5 : 1),
-  paddingHorizontal: 19,
   zIndex: 1,
 });
 
@@ -135,14 +132,18 @@ const SheetActionButton = ({
         )}
       </ShadowStack>
       <Content label={label} size={size}>
-        {emoji && <Emoji lineHeight={23} name={emoji} size="medium" />}
+        {emoji && (
+          <Text containsEmoji lineHeight={23} size="15px">
+            {emoji}
+          </Text>
+        )}
         {icon && <Icon color="white" height={18} name={icon} size={18} />}
         {label ? (
           <Text
             align="center"
-            color={textColor}
+            color={{ custom: textColor }}
             numberOfLines={truncate ? 1 : undefined}
-            size={textSize ?? (size === 'big' ? 'larger' : 'large')}
+            size={textSize ?? (size === 'big' ? '20px' : '18px')}
             weight={weight}
           >
             {label}


### PR DESCRIPTION
Fixes RNBW-3997
Figma link (if any):

## What changed (plus any additional context for devs)

**Currently waiting for a bit more discussion.**

The way text in buttons is rendered in couple of places will change. Now text component from DS will be used, so text will be centered based on vertical centering of the cap-size measured text boundaries. I discussed this with Jeremy.

## Screen recordings / screenshots

|iOS|Android|
|--|--|
|![IMG_CD61B5380964-1](https://user-images.githubusercontent.com/5769281/181252260-5d5ffceb-4b8b-4e41-8900-7acc53574da3.jpeg)|![Screenshot_20220727-155524_Rainbow](https://user-images.githubusercontent.com/5769281/181252244-1ed15f82-7c12-42a4-9ddd-8d6cf9f16dc8.jpg)|


## What to test

If text looks ok in button. Send sheet (both action buttons and social links), swap sheet etc.


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
