### PR TITLE
swaps: handle flashbot miner tip from review sheet

### DIFF
--- a/src/components/expanded-state/SwapDetailsState.js
+++ b/src/components/expanded-state/SwapDetailsState.js
@@ -86,7 +86,9 @@ export default function SwapDetailsState({
   restoreFocusOnSwapModal,
 }) {
   const { setParams } = useNavigation();
-  const { params: { longFormHeight, currentNetwork } = {} } = useRoute();
+  const {
+    params: { longFormHeight, currentNetwork, flashbotTransaction } = {},
+  } = useRoute();
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
 
   const {
@@ -189,6 +191,7 @@ export default function SwapDetailsState({
           <GasSpeedButton
             asset={outputCurrency}
             currentNetwork={currentNetwork}
+            flashbotTransaction={flashbotTransaction}
             testID="swap-details-gas"
             theme="light"
           />

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -781,6 +781,7 @@ export default function ExchangeModal({
       navigate(Routes.SWAP_DETAILS_SHEET, {
         confirmButtonProps,
         currentNetwork,
+        flashbotTransaction: flashbots,
         restoreFocusOnSwapModal: () => {
           android &&
             (lastFocusedInputHandle.current = lastFocusedInputHandleTemporary);
@@ -804,6 +805,7 @@ export default function ExchangeModal({
   }, [
     confirmButtonProps,
     currentNetwork,
+    flashbots,
     inputCurrency?.address,
     inputCurrency?.name,
     inputCurrency?.symbol,


### PR DESCRIPTION
Fixes TEAM2-313
Figma link (if any):

## What changed (plus any additional context for devs)

going to edit custom gas from the exhange modal was using the flashbots miner tip correctly but going to the review sheet and trying to modify the custom gas wasn't using the flashbots miner tip

now if flashbots is enabled we'll use the flashbots miner tip for review sheet as well


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->




https://user-images.githubusercontent.com/12115171/181303965-6ea8aaf4-b134-4715-b458-95176142a7e2.mp4



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [x] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
