### PR TITLE
swaps: disable source picker on arbis

### DIFF
--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -11,6 +11,7 @@ import { SlackSheet } from '../../sheet';
 import { MaxToleranceInput } from './MaxToleranceInput';
 import SourcePicker from './SourcePicker';
 
+import { Network } from '@/helpers';
 import {
   Box,
   ColorModeProvider,
@@ -137,10 +138,12 @@ export default function SwapSettingsState({ asset }) {
             <Text align="center" color="primary" size="18px" weight="bold">
               {lang.t('exchange.settings')}
             </Text>
-            <SourcePicker
-              currentSource={currentSource}
-              onSelect={updateSource}
-            />
+            {network !== Network.arbitrum && (
+              <SourcePicker
+                currentSource={currentSource}
+                onSelect={updateSource}
+              />
+            )}
             {swapSupportsFlashbots && (
               <Columns alignHorizontal="justify" alignVertical="center">
                 <Column width="content">

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -138,7 +138,7 @@ export default function SwapSettingsState({ asset }) {
             <Text align="center" color="primary" size="18px" weight="bold">
               {lang.t('exchange.settings')}
             </Text>
-            {network !== Network.arbitrum && (
+            {network !== Network.optimism && (
               <SourcePicker
                 currentSource={currentSource}
                 onSelect={updateSource}

--- a/src/components/expanded-state/swap-settings/SwapSettingsState.js
+++ b/src/components/expanded-state/swap-settings/SwapSettingsState.js
@@ -138,7 +138,7 @@ export default function SwapSettingsState({ asset }) {
             <Text align="center" color="primary" size="18px" weight="bold">
               {lang.t('exchange.settings')}
             </Text>
-            {network !== Network.optimism && (
+            {network !== Network.arbitrum && (
               <SourcePicker
                 currentSource={currentSource}
                 onSelect={updateSource}


### PR DESCRIPTION
Fixes TEAM2-315
Figma link (if any):

## What changed (plus any additional context for devs)
doesn't make sense to have this on arbitrum atm


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://cloud.skylarbarrera.com/Screen-Recording-2022-07-27-14-33-59.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
source picker should show up in settings for every network except arbitrum


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
