### PR TITLE
[TEAM2-321] Audio Player Color Crash

### DIFF
--- a/src/components/audio/AudioPlayer.js
+++ b/src/components/audio/AudioPlayer.js
@@ -14,7 +14,8 @@ const StyledWebView = styled(WebView)({
   marginTop: android ? 30 : 50,
 });
 
-const formatColor = color => color.replace('#', '');
+const formatColor = color =>
+  color && typeof color === 'string' ? color.replace('#', '') : null;
 
 const buildPlayerUrl = options => {
   let qsArray = [];


### PR DESCRIPTION
## What changed (plus any additional context for devs)
safer code
fixes: https://sentry.io/organizations/rainbow-me/issues/2801990037/events/c5b1d80e08754057ac44e81113e1fc8f/?project=1855565&referrer=slack#exception

## What to test
I'm not going to look into the why, but I fixed the how.


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
