### PR TITLE
[TEAM2-322] Do Not Pass NaN into Segment Analytics

### DIFF
--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -512,6 +512,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
         tradeDetails: data.tradeDetails,
       })
     );
+    const slippage = slippageInBips / 100;
     analytics.track(`Updated ${type} details`, {
       aggregator: data.tradeDetails?.source || '',
       inputTokenAddress: inputToken?.address || '',
@@ -522,7 +523,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       outputTokenAddress: outputToken?.address || '',
       outputTokenName: outputToken?.name || '',
       outputTokenSymbol: outputToken?.symbol || '',
-      slippage: slippageInBips / 100,
+      slippage: isNaN(slippage) ? 'Error calculating slippage.' : slippage,
       type,
     });
 

--- a/src/performance/tracking/index.ts
+++ b/src/performance/tracking/index.ts
@@ -54,7 +54,7 @@ function logDirectly(
     analytics.track(metric, {
       durationInMs,
       performanceTrackingVersion,
-      ...additionalParams,
+      ...additionalParams, // wondering if we need to protect ourselves here
     });
   }
 }

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -569,6 +569,7 @@ export default function ExchangeModal({
         const rapType = getSwapRapTypeByExchangeType(type);
         await executeRap(wallet, rapType, swapParameters, callback);
         logger.log('[exchange - handle submit] executed rap!');
+        const slippage = slippageInBips / 100;
         analytics.track(`Completed ${type}`, {
           aggregator: tradeDetails?.source || '',
           amountInUSD,
@@ -582,7 +583,7 @@ export default function ExchangeModal({
           outputTokenName: outputCurrency?.name || '',
           outputTokenSymbol: outputCurrency?.symbol || '',
           priceImpact: priceImpactPercentDisplay,
-          slippage: slippageInBips / 100,
+          slippage: isNaN(slippage) ? 'Error calculating slippage.' : slippage,
           type,
         });
         // Tell iOS we finished running a rap (for tracking purposes)
@@ -644,6 +645,7 @@ export default function ExchangeModal({
     } catch (e) {
       logger.log('error getting the swap amount in USD price', e);
     } finally {
+      const slippage = slippageInBips / 100;
       analytics.track(`Submitted ${type}`, {
         aggregator: tradeDetails?.source || '',
         amountInUSD,
@@ -657,7 +659,7 @@ export default function ExchangeModal({
         outputTokenName: outputCurrency?.name || '',
         outputTokenSymbol: outputCurrency?.symbol || '',
         priceImpact: priceImpactPercentDisplay,
-        slippage: slippageInBips / 100,
+        slippage: isNaN(slippage) ? 'Error caclulating slippage.' : slippage,
         type,
       });
     }

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -267,11 +267,14 @@ export default function WalletConnectApprovalSheet() {
   }, [approvalAccount.address, goBack, type]);
 
   useEffect(() => {
+    const waitingTime = (Date.now() - receivedTimestamp) / 1000;
     InteractionManager.runAfterInteractions(() => {
       analytics.track('Received wc connection', {
         dappName,
         dappUrl,
-        waitingTime: (Date.now() - receivedTimestamp) / 1000,
+        waitingTime: isNaN(waitingTime)
+          ? 'Error calculating waiting time.'
+          : waitingTime,
       });
     });
   }, [dappName, dappUrl, receivedTimestamp]);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Fixes: https://sentry.io/organizations/rainbow-me/issues/2582111149/?project=1855565&referrer=slack (I think)
I looked through every segment call and these are the lines that could produce NaN then attempt to write to JSON within the native module.

## What to test
idk, please help


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
