### PR TITLE
Fix trace calls block number

### DIFF
--- a/src/handlers/uniswap.ts
+++ b/src/handlers/uniswap.ts
@@ -1,5 +1,5 @@
 import { BigNumberish } from '@ethersproject/bignumber';
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Block, StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import {
   ALLOWS_PERMIT,
@@ -30,6 +30,7 @@ import {
   toHex,
   toHexNoLeadingZeros,
 } from './web3';
+import config from '@/model/config';
 import { Asset } from '@rainbow-me/entities';
 import {
   add,
@@ -89,6 +90,9 @@ export const getStateDiff = async (
   const fromAddr = tradeDetails.from;
   const toAddr = RAINBOW_ROUTER_CONTRACT_ADDRESS;
   const tokenContract = new ethers.Contract(tokenAddress, erc20ABI, provider);
+  const {
+    number: blockNumber,
+  } = await (provider.getBlock as () => Promise<Block>)();
 
   // Get data
   const { data } = await tokenContract.populateTransaction.approve(
@@ -105,7 +109,7 @@ export const getStateDiff = async (
       value: '0x0',
     },
     ['stateDiff'],
-    'latest',
+    blockNumber - Number(config.trace_call_block_number_offset),
   ];
 
   const trace = await provider.send('trace_call', callParams);

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -59,6 +59,7 @@ export interface RainbowConfig extends Record<string, any> {
   op_nft_network?: string;
   optimism_mainnet_rpc?: string;
   polygon_mainnet_rpc?: string;
+  trace_call_block_number_offset?: number;
 }
 
 const DEFAULT_CONFIG = {
@@ -86,6 +87,7 @@ const DEFAULT_CONFIG = {
   op_nft_network: 'op-mainnet',
   optimism_mainnet_rpc: OPTIMISM_MAINNET_RPC,
   polygon_mainnet_rpc: POLYGON_MAINNET_RPC,
+  trace_call_block_number_offset: 20,
 };
 
 // Initialize with defaults in case firebase doesn't respond


### PR DESCRIPTION
Fixes TEAM2-323
Figma link (if any):

## What changed (plus any additional context for devs)
Used current block - 20 for trace calls. Added to firebase config in case we have to tweak it.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

Look at the logs for gas estimations  with swaps with approvals. Shouldn't fail


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
