### PR TITLE
Restrict app resizing for android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
       android:theme="@style/BootTheme"
       android:networkSecurityConfig="@xml/network_security_config"
       android:requestLegacyExternalStorage="true"
+      android:resizeableActivity="false"
     >
       <meta-data
         android:name="com.google.firebase.messaging.default_notification_icon"
@@ -35,7 +36,7 @@
         android:label="@string/app_name"
         android:screenOrientation="portrait"
         android:exported="true"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>


### PR DESCRIPTION
Fixes RNBW-4069
Figma link (if any):

## What changed (plus any additional context for devs)
Disable screen splitting. Restrict changes that can be triggered by devices such as foldable phones

## Screen recordings / screenshots
Before: https://rainbowhaus.slack.com/files/US31KAK8R/F03RVB2EDH6/nagranie_z_ekranu_2022-07-27_o_09.39.00.mov

After: https://rainbowhaus.slack.com/files/US31KAK8R/F03R60RR946/image_from_ios.mov


## What to test
- Use any foldable phone. Start the app in a folded state and then unfold a phone. The app shouldn't resize to full screen automatically.
- Try to split the screen. It should be unavailable

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
