### PR TITLE
Fix unnecessary line break in 'Other amount'

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -273,7 +273,7 @@ const AddFundsInterstitial = ({ network }) => {
                   size="large"
                   weight="bold"
                 >
-                  {` 􀍡 ${lang.t('wallet.add_cash.interstitial.other_amount')}`}
+                  {`􀍡 ${lang.t('wallet.add_cash.interstitial.other_amount')}`}
                 </Text>
               </InterstitialButtonContent>
             </InterstitialButton>


### PR DESCRIPTION
Fixes RNBW-4056
Figma link (if any):

## What changed (plus any additional context for devs)

I removed a space in front of the 'Other amount' string. As a bonus it removes extra space on iOS which looks odd if you look at it closely.

## Screen recordings / screenshots

||Before|After|
|--|--|--|
|iOS|![IMG_2BAFEBC4165F-1](https://user-images.githubusercontent.com/5769281/181504422-4c227b5a-2b29-4a88-8a1b-12f5769889ad.jpeg)|![IMG_16A75C1FF92D-1](https://user-images.githubusercontent.com/5769281/181504439-311a7f05-e2aa-43fd-8fa1-53c84fe3e75f.jpeg)|
|Android|![Screenshot_20220728-152227_Rainbow](https://user-images.githubusercontent.com/5769281/181504454-bceb3a80-3263-4b45-87d4-04bbb9e4ceb9.jpg)|![Screenshot_20220728-152138_Rainbow](https://user-images.githubusercontent.com/5769281/181504456-5ab095bd-f491-467e-9dbd-da05f3dcbbf2.jpg)|

## What to test

'Other amount' button looks good.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
