### PR TITLE
Fix linebreak in 'Owner'

### DIFF
--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { Fragment, useCallback, useState } from 'react';
 import { Switch } from 'react-native-gesture-handler';
 import { useNavigation } from '../../../navigation/Navigation';
 import { useTheme } from '../../../theme/ThemeContext';
@@ -93,6 +93,14 @@ export default function InfoRow({
     navigate(Routes.EXPLAIN_SHEET, { type: explainSheetType });
   }, [explainSheetType, navigate]);
 
+  const explainer = explainSheetType ? (
+    <ButtonPressAnimation onPress={handlePressExplain}>
+      <Text color="secondary25" size="16px" weight="bold">
+        􀅵
+      </Text>
+    </ButtonPressAnimation>
+  ) : null;
+
   return (
     <Inline alignHorizontal="justify" horizontalSpace="24px" wrap={false}>
       <Box style={{ minWidth: 60, opacity: show ? 1 : 0 }}>
@@ -100,14 +108,9 @@ export default function InfoRow({
           <Inline space="4px">
             <Text color="secondary60" size="16px" weight="bold">
               {label}
+              {android && <Fragment> {explainer}</Fragment>}
             </Text>
-            {explainSheetType && (
-              <ButtonPressAnimation onPress={handlePressExplain}>
-                <Text color="secondary25" size="16px" weight="bold">
-                  􀅵
-                </Text>
-              </ButtonPressAnimation>
-            )}
+            {ios && explainer}
           </Inline>
         </Inset>
       </Box>


### PR DESCRIPTION
Fixes RNBW-4031
Figma link (if any):

## What changed (plus any additional context for devs)

A hack to convince Android text layout to stay in one line.

Is it ugly? Hell yea.

Is it a hack? Quite, uhm, yea, it's a dirty hack.

Am I proud of it? No.

Have I spent 3h trying all different crazy ways to fix it? Yes.

## Screen recordings / screenshots

||Before|After|
|--|--|--|
|iOS|![IMG_0A63099A7D6C-1](https://user-images.githubusercontent.com/5769281/181508913-12b51af7-56e4-4812-b2a4-8634c17ba786.jpeg)|![IMG_8E91AA6ADA74-1](https://user-images.githubusercontent.com/5769281/181508905-03580f34-8233-464f-9774-84a397004e27.jpeg)|
|Android|![Screenshot_20220728-154757_Rainbow](https://user-images.githubusercontent.com/5769281/181508889-d87c0fa8-3ae3-436c-a401-6cb2670db0ed.jpg)|![Screenshot_20220728-154625_Rainbow](https://user-images.githubusercontent.com/5769281/181508895-ea58fb57-cc88-4ac9-8baf-2f537a924977.jpg)|

## What to test

Expanded sheet of any ENS token. On Android, preferably on multiple phones. iOS is worth checking that it still works the same way, otherwise code changes shouldn't really affect it.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
