### PR TITLE
Fix center avatar emoji

### DIFF
--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -24,7 +24,11 @@ const FirstLetter = styled(Text).attrs(({ theme: { colors } }) => ({
   letterSpacing: 2,
   size: ios ? 38 : 30,
   weight: 'semibold',
-}))({ left: android ? -1 : 0 });
+  ...(ios && { lineHeight: 66 }),
+}))({
+  ...(android && { left: -1 }),
+  ...(ios && { width: 67 }),
+});
 
 export default function AvatarCircle({
   isAvatarPickerAvailable,


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

Somehow I didn't push the last commit I made for #3827, which added very important part that prevented breaking current iOS.

The change affected emoji picker.

## Screen recordings / screenshots

|Current develop|With this branch|
|--|--|
|![IMG_BA2C0699F9B4-1](https://user-images.githubusercontent.com/5769281/181524214-2124b214-dbf9-46a3-b524-c6719a48bfed.jpeg)|![IMG_D2F88D1E37C0-1](https://user-images.githubusercontent.com/5769281/181524225-a047884c-8ba1-44a1-a05b-6249d4f9b399.jpeg)|

## What to test

Check emoji avatar and emoji picker.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
