### PR TITLE
Fix seed import shadow glitch

### DIFF
--- a/src/components/buttons/MiniButton.js
+++ b/src/components/buttons/MiniButton.js
@@ -73,6 +73,35 @@ export default function MiniButton({
 
   const shadows = isDarkMode ? shadowsDark : shadowLight;
 
+  const content = (
+    <Content
+      backgroundColor={
+        android
+          ? disabled
+            ? colors.lightGrey
+            : backgroundColor || colors.appleBlue
+          : 'none'
+      }
+      disablePadding={disablePadding}
+      hasLeadingIcon={hasLeadingIcon}
+      height={height ? height : small ? 27 : 30}
+    >
+      {typeof children === 'string' ? (
+        <Text
+          align="center"
+          color={color || colors.whiteLabel}
+          letterSpacing={letterSpacing}
+          lineHeight={android ? 19 : null}
+          weight={weight || 'bold'}
+        >
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
+    </Content>
+  );
+
   return (
     <ButtonPressAnimation
       disabled={disabled}
@@ -84,7 +113,7 @@ export default function MiniButton({
     >
       <View style={{ borderRadius }}>
         <ShadowStack
-          {...position.coverAsObject}
+          {...(ios ? position.coverAsObject : {})}
           backgroundColor={
             android
               ? 'none'
@@ -102,33 +131,10 @@ export default function MiniButton({
               : shadows.default
           }
           width={width}
-        />
-        <Content
-          backgroundColor={
-            android
-              ? disabled
-                ? colors.lightGrey
-                : backgroundColor || colors.appleBlue
-              : 'none'
-          }
-          disablePadding={disablePadding}
-          hasLeadingIcon={hasLeadingIcon}
-          height={height ? height : small ? 27 : 30}
         >
-          {typeof children === 'string' ? (
-            <Text
-              align="center"
-              color={color || colors.whiteLabel}
-              letterSpacing={letterSpacing}
-              lineHeight={android ? 19 : null}
-              weight={weight || 'bold'}
-            >
-              {children}
-            </Text>
-          ) : (
-            children
-          )}
-        </Content>
+          {android && content}
+        </ShadowStack>
+        {ios && content}
       </View>
     </ButtonPressAnimation>
   );


### PR DESCRIPTION
Fixes RNBW-4052
Figma link (if any):

## What changed (plus any additional context for devs)

Button in seed phrase import modal.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

||Before|After|
|--|--|--|
|iOS|![IMG_5AD24E48C6B0-1](https://user-images.githubusercontent.com/5769281/181565978-f1991a7a-9a74-4bd7-a960-b671e535a7dd.jpeg)|![IMG_28656440579E-1](https://user-images.githubusercontent.com/5769281/181565981-79debda9-9019-4c43-b62c-8f0c2e4c9b62.jpeg)|
|Android|![Screenshot_20220728-174712_Rainbow](https://user-images.githubusercontent.com/5769281/181565969-cbc461d5-a97b-4af9-88a6-fd614a9de531.jpg)|![Screenshot_20220728-174552_Rainbow](https://user-images.githubusercontent.com/5769281/181565976-70f4e0cd-2cb7-4933-bc4d-057ddb73224c.jpg)|

## What to test

Check out button in seed phrase import modal.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
