### PR TITLE
WIP: Swap/exchange button transition states

### DIFF
--- a/src/components/buttons/BiometricButtonContent.js
+++ b/src/components/buttons/BiometricButtonContent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Animated, { FadeIn, FadeOut, Layout } from 'react-native-reanimated';
 import { Text } from '../text';
 import { BiometryTypes } from '@rainbow-me/helpers';
 import { useBiometryType } from '@rainbow-me/hooks';
@@ -50,12 +51,19 @@ export default function BiometricButtonContent({
 }) {
   const biometryIcon = useBiometryIconString(!android && showIcon);
   return (
-    <Label
-      testID={testID || label}
-      {...props}
-      {...(android && { lineHeight: 23 })}
+    <Animated.View
+      entering={FadeIn.duration(200).delay(100)}
+      exiting={FadeOut}
+      key={label}
+      layout={Layout}
     >
-      {`${biometryIcon}${label}`}
-    </Label>
+      <Label
+        testID={testID || label}
+        {...props}
+        {...(android && { lineHeight: 23 })}
+      >
+        {`${biometryIcon}${label}`}
+      </Label>
+    </Animated.View>
   );
 }

--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -14,6 +14,9 @@ import {
   TapGestureHandler,
 } from 'react-native-gesture-handler';
 import Animated, {
+  FadeIn,
+  FadeOut,
+  Layout,
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
@@ -42,6 +45,7 @@ import { ThemeContextProps } from '@rainbow-me/theme';
 import { haptics } from '@rainbow-me/utils';
 import ShadowStack from 'react-native-shadow-stack';
 
+const BUTTON_FADE_IN_ANIMATION = FadeIn.duration(200).delay(100);
 const { ACTIVE, BEGAN, END, FAILED } = GestureHandlerState;
 
 interface ButtonOptionParams {
@@ -253,24 +257,43 @@ function HoldToAuthorizeButtonContent2({
               {children ?? (
                 <Fragment>
                   {!android && !disabled && (
-                    <HoldToAuthorizeButtonIcon
-                      sharedValue={longPressProgress}
-                    />
+                    <Animated.View
+                      entering={BUTTON_FADE_IN_ANIMATION}
+                      exiting={FadeOut}
+                      layout={Layout}
+                    >
+                      <HoldToAuthorizeButtonIcon
+                        sharedValue={longPressProgress}
+                      />
+                    </Animated.View>
                   )}
                   {(loading || (android && isAuthorizing)) && (
-                    <LoadingSpinner />
+                    <Animated.View
+                      entering={BUTTON_FADE_IN_ANIMATION}
+                      exiting={FadeOut}
+                      layout={Layout}
+                    >
+                      <LoadingSpinner />
+                    </Animated.View>
                   )}
-                  <Label
-                    label={
-                      isAuthorizing
-                        ? lang.t('button.hold_to_authorize.authorizing')
-                        : label
-                    }
-                    showIcon={showBiometryIcon && !isAuthorizing}
-                    smallButton={smallButton}
-                    testID={testID}
-                    tinyButton={tinyButton}
-                  />
+                  <Animated.View
+                    entering={BUTTON_FADE_IN_ANIMATION}
+                    exiting={FadeOut}
+                    key={label}
+                    layout={Layout}
+                  >
+                    <Label
+                      label={
+                        isAuthorizing
+                          ? lang.t('button.hold_to_authorize.authorizing')
+                          : label
+                      }
+                      showIcon={showBiometryIcon && !isAuthorizing}
+                      smallButton={smallButton}
+                      testID={testID}
+                      tinyButton={tinyButton}
+                    />
+                  </Animated.View>
                 </Fragment>
               )}
               <ShimmerAnimation

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -144,6 +144,7 @@ export default function ConfirmExchangeButton({
   }, [navigate]);
 
   const isDisabled =
+    loading ||
     disabled ||
     !isSufficientBalance ||
     !isSufficientGas ||


### PR DESCRIPTION
Fixes TEAM2-260

## What changed (plus any additional context for devs)
- Added a disabled state when the exchange quote is being fetched.
- Added a classy fade transition between button states to make it look less jumpy.
- Fixed layout jank when the biometric lock icon suddenly appears in swap details sheet after the sheet is opened.


## Screen recordings / screenshots
![PixelSnap 2022-07-29 at 2 07 34 AM@2x](https://user-images.githubusercontent.com/6843656/181657269-e8ac2429-c12c-49a5-aa99-a42ae9539be9.png)


https://user-images.githubusercontent.com/6843656/181661363-9b200281-e34f-428d-8f0f-7965efb9e0bb.mp4

## What to test
Reviewing swap details, confirming swaps.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
