### PR TITLE
Hide + button in pool expanded state

### DIFF
--- a/src/components/expanded-state/chart/ChartExpandedStateHeader.js
+++ b/src/components/expanded-state/chart/ChartExpandedStateHeader.js
@@ -139,7 +139,7 @@ export default function ChartExpandedStateHeader({
         )}
 
         <Row>
-          {currentNetwork === Network.mainnet && (
+          {currentNetwork === Network.mainnet && !isPool && (
             <ChartAddToListButton asset={asset} />
           )}
           <ChartContextButton asset={asset} color={color} />


### PR DESCRIPTION
Fixes RNBW-4034
Figma link (if any):

## What changed (plus any additional context for devs)

That button doesn't make any sense since you can't add a pool to favorites.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

<img width="582" alt="image" src="https://user-images.githubusercontent.com/7809008/182163741-fdfd9afe-6788-47a5-b58f-9ae94f446ff9.png">



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- open any pool - there should be no "+" button
- open any token - there should be "+" button


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
