### PR TITLE
Fix L2 transaction icons

### DIFF
--- a/src/components/coin-row/FastTransactionCoinRow.tsx
+++ b/src/components/coin-row/FastTransactionCoinRow.tsx
@@ -92,7 +92,7 @@ export default React.memo(function TransactionCoinRow({
         <View style={sx.icon}>
           <FastCoinIcon
             address={mainnetAddress || item.address}
-            assetType={item.assetType}
+            assetType={item.network}
             symbol={item.symbol}
             theme={theme}
           />

--- a/src/components/coin-row/FastTransactionCoinRow.tsx
+++ b/src/components/coin-row/FastTransactionCoinRow.tsx
@@ -93,6 +93,7 @@ export default React.memo(function TransactionCoinRow({
           <FastCoinIcon
             address={mainnetAddress || item.address}
             assetType={item.network}
+            mainnetAddress={mainnetAddress}
             symbol={item.symbol}
             theme={theme}
           />


### PR DESCRIPTION
Fixes RNBW-4104
Figma link (if any):

## What changed (plus any additional context for devs)

This PR fixes L2 transaction icons in the refactored transaction list.

I found that `assetType` was missing in transaction items and @estebanmino suggested to use `network` instead.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

|Before|After|
|--|--|
|![Screenshot_20220801-191815_Rainbow](https://user-images.githubusercontent.com/5769281/182196221-a78582e1-e331-46bf-96d2-4cb594dc539e.jpg)|![Screenshot_20220801-191742_Rainbow](https://user-images.githubusercontent.com/5769281/182196251-196ccb04-06c9-41f7-9aba-df7924948115.jpg)|

## What to test

Enable L2 history in dev settings, go to `0xtester.eth` wallet and check that L2 transactions show up properly.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
