### PR TITLE
Fix avatar placement in picker

### DIFF
--- a/src/navigation/effects.js
+++ b/src/navigation/effects.js
@@ -11,6 +11,8 @@ import { deviceUtils } from '@rainbow-me/utils';
 const statusBarHeight = getStatusBarHeight(true);
 export const sheetVerticalOffset = statusBarHeight;
 
+export const AVATAR_CIRCLE_TOP_MARGIN = android ? 10 : 0;
+
 const backgroundInterpolator = ({
   current: { progress: current },
   layouts: { screen },
@@ -306,9 +308,7 @@ export const emojiPreset = {
         <View
           style={{
             alignItems: 'center',
-            // See: src/components/profile/ProfileMasthead.js. <AvatarCircle />
-            // has marginTop: 10.
-            top: HeaderHeightWithStatusBar + (android ? 10 : 0),
+            top: HeaderHeightWithStatusBar + AVATAR_CIRCLE_TOP_MARGIN,
           }}
         >
           <AvatarCircle overlayStyles />

--- a/src/navigation/effects.js
+++ b/src/navigation/effects.js
@@ -306,7 +306,9 @@ export const emojiPreset = {
         <View
           style={{
             alignItems: 'center',
-            top: HeaderHeightWithStatusBar,
+            // See: src/components/profile/ProfileMasthead.js. <AvatarCircle />
+            // has marginTop: 10.
+            top: HeaderHeightWithStatusBar + (android ? 10 : 0),
           }}
         >
           <AvatarCircle overlayStyles />

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -13,6 +13,7 @@ import { Column, Row } from '../components/layout';
 import useUpdateEmoji from '../hooks/useUpdateEmoji';
 import { useNavigation } from '../navigation/Navigation';
 import { deviceUtils } from '../utils';
+import { AVATAR_CIRCLE_TOP_MARGIN } from '@/navigation/effects';
 import { useDimensions } from '@rainbow-me/hooks';
 import styled from '@rainbow-me/styled-components';
 import { useTheme } from '@rainbow-me/theme';
@@ -105,7 +106,7 @@ const AvatarBuilder = ({ route: { params } }) => {
       <Column
         align="center"
         pointerEvents="box-none"
-        top={AvatarBuilderTopPoint + (android ? 10 : 0)}
+        top={AvatarBuilderTopPoint + AVATAR_CIRCLE_TOP_MARGIN}
       >
         <Row justify="center" paddingBottom={16} paddingTop={15} width="100%">
           <ScrollableColorPicker

--- a/src/screens/AvatarBuilder.js
+++ b/src/screens/AvatarBuilder.js
@@ -105,7 +105,7 @@ const AvatarBuilder = ({ route: { params } }) => {
       <Column
         align="center"
         pointerEvents="box-none"
-        top={AvatarBuilderTopPoint}
+        top={AvatarBuilderTopPoint + (android ? 10 : 0)}
       >
         <Row justify="center" paddingBottom={16} paddingTop={15} width="100%">
           <ScrollableColorPicker


### PR DESCRIPTION
Fixes RNBW-4000
Figma link (if any):

## What changed (plus any additional context for devs)

Placement of avatar circle in avatar picker on Android.

## Screen recordings / screenshots

Before 

https://user-images.githubusercontent.com/5769281/182211025-fdcbf59d-14e3-46f1-b4cc-80e321d571b9.mp4

After

https://user-images.githubusercontent.com/5769281/182211057-2a058574-d6df-4966-a3ba-ffdd5fa916e7.mp4


## What to test

Avatar picker on Android and iOS (looking for regression).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
