### PR TITLE
Fix line break in get token button

### DIFF
--- a/src/components/sheet/sheet-action-buttons/SheetActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SheetActionButton.js
@@ -139,14 +139,12 @@ const SheetActionButton = ({
         {icon && <Icon color="white" height={18} name={icon} size={18} />}
         {label ? (
           <Text
-            // This is a random change to workaround Android text layout adding
-            // totally unpredictable line breaks (although interestingly
-            // consistent between different phone models).
-            adjustsFontSizeToFit={android}
             align="center"
             color={textColor}
+            lineHeight={size === 'big' ? 56 : 46}
             numberOfLines={truncate ? 1 : undefined}
             size={textSize ?? (size === 'big' ? 'larger' : 'large')}
+            style={{ width: '100%' }}
             weight={weight}
           >
             {label}

--- a/src/components/sheet/sheet-action-buttons/SheetActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SheetActionButton.js
@@ -139,6 +139,10 @@ const SheetActionButton = ({
         {icon && <Icon color="white" height={18} name={icon} size={18} />}
         {label ? (
           <Text
+            // This is a random change to workaround Android text layout adding
+            // totally unpredictable line breaks (although interestingly
+            // consistent between different phone models).
+            adjustsFontSizeToFit={android}
             align="center"
             color={textColor}
             numberOfLines={truncate ? 1 : undefined}


### PR DESCRIPTION
Fixes RNBW-4072
Figma link (if any):

## What changed (plus any additional context for devs)

Code for handling size and line height of text button.

## Screen recordings / screenshots

|Before|After|
|--|--|
|![Screenshot_20220802-002357_Rainbow](https://user-images.githubusercontent.com/5769281/182249539-c449fed7-385b-4a9e-a80c-c9568c0e7bc1.jpg)|![Screenshot_20220802-005142_Rainbow](https://user-images.githubusercontent.com/5769281/182252467-63d171b9-cc7d-47cb-9f77-c9adc612da84.jpg)|

## What to test

Check different tokens in token search and see if button breaks lines anywhere.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
