### PR TITLE
swaps: adjust gas default logic

### DIFF
--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -287,13 +287,14 @@ export default function ExchangeModal({
     type,
   });
 
-  const basicSwap = ethereumUtils.getBasicSwapGasLimit(Number(chainId));
-
-  const defaultGasLimit = isDeposit
-    ? ethUnits.basic_deposit
-    : isWithdrawal
-    ? ethUnits.basic_withdrawal
-    : basicSwap;
+  const defaultGasLimit = useMemo(() => {
+    const basicSwap = ethereumUtils.getBasicSwapGasLimit(Number(chainId));
+    return isDeposit
+      ? ethUnits.basic_deposit
+      : isWithdrawal
+      ? ethUnits.basic_withdrawal
+      : basicSwap;
+  }, [chainId, isDeposit, isWithdrawal]);
 
   const getNextNonce = useCurrentNonce(accountAddress, currentNetwork);
 

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -386,15 +386,6 @@ export default function ExchangeModal({
 
   const updateGasLimit = useCallback(async () => {
     try {
-      if (
-        ((type === ExchangeModalTypes.swap ||
-          type === ExchangeModalTypes.deposit) &&
-          !(inputCurrency && outputCurrency)) ||
-        type === ExchangeModalTypes.withdraw ||
-        loading
-      ) {
-        return;
-      }
       const swapParams = {
         chainId,
         inputAmount,
@@ -438,10 +429,7 @@ export default function ExchangeModal({
     currentProvider,
     defaultGasLimit,
     inputAmount,
-    inputCurrency,
-    loading,
     outputAmount,
-    outputCurrency,
     tradeDetails,
     type,
     updateTxFee,


### PR DESCRIPTION
Fixes TEAM2-329
Figma link (if any):

## What changed (plus any additional context for devs)
there was some old logic from the first gen of swaps that was blocking gas being updated when only 1 token was selected, removed in the first commit. 

the second commit is my attempt to fix the layer2 gas showing layer 1 estimations, `defaultGasLimit` should update as expected per network


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
before: https://cloud.skylarbarrera.com/Screen-Recording-2022-08-01-17-29-48.mp4

after: https://cloud.skylarbarrera.com/Screen-Recording-2022-08-01-17-35-27.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
gas should update normal for swaps, & savings. switching networks should trigger an update in gas price


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
