### PR TITLE
Disable selecting text in SVG NFTs

### DIFF
--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -41,6 +41,7 @@ const getHTML = (svgContent, style) =>
         height: 100%;
         width: 100%;
         overflow: hidden;
+        user-select: none;
       }
     </style>
   </head>


### PR DESCRIPTION
Fixes RNBW-4097
Figma link (if any):

## What changed (plus any additional context for devs)

I disabled selecting text in SVGs showed in webviews. Might potentially affect more than just NFTs, but I think it's still ok?

## Screen recordings / screenshots

_* Imagine there's a screenshot of **before** with ENS NFT with selected text and then another one, **after**, which has no selected text highlight. *_

## What to test

Make sure that you are not able to select text in NFTs.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
