### PR TITLE
Center search icon on android discover

### DIFF
--- a/src/components/discover-sheet/DiscoverSearchInput.js
+++ b/src/components/discover-sheet/DiscoverSearchInput.js
@@ -52,7 +52,7 @@ const SearchIcon = styled(Text).attrs(({ theme: { colors } }) => ({
 }))({});
 
 const SearchIconWrapper = styled(Animated.View)({
-  marginTop: android ? 6 : 9,
+  marginTop: android ? 4 : 9,
 });
 
 const SearchInput = styled(Input).attrs(


### PR DESCRIPTION
Fixes RNBW-4051
Figma link (if any):

## What changed (plus any additional context for devs)


## Screen recordings / screenshots
![image](https://user-images.githubusercontent.com/25709300/182385619-6282b8a2-6bba-4cff-9fe6-3521836d7a9b.png)

see if it works, and is centered. 


I checked on many phones, but just on those narrow this is really noticeable 