### PR TITLE
[TEAM2-328] Optimism token disappearing from wallet balance after swap

### DIFF
--- a/src/redux/additionalAssetsData.ts
+++ b/src/redux/additionalAssetsData.ts
@@ -181,7 +181,9 @@ export const additionalDataUpdateL2AssetBalance = (tx: any) => async (
     ];
 
     // @ts-ignore
-    updatedAssets.forEach(asset => asset && dispatch(dataUpdateAsset(asset)));
+    updatedAssets
+      .filter(asset => asset?.mainnet_address)
+      .forEach(asset => asset && dispatch(dataUpdateAsset(asset)));
 
     const newL2AssetsToWatch = Object.entries(l2AssetsToWatch).reduce(
       (newData, [key, asset]) => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Historically for L2 assets, we store L2 generic asset data with a mainnet address. OP doesn't not have a mainnet address which prevents the current logic from finding a cached `price` value. The disappearance occurs because we do not render assets in the wallet when the price is `null || undefined`. The refraction response places the asset back in the wallet after a delay.

This fix simply doesn't try to manually update the asset balance for an L2 asset that doesn't possess a mainnet address. This disables the functionality we get from `getUpdatedL2AssetBalance` (https://github.com/rainbow-me/rainbow/blob/develop/src/redux/additionalAssetsData.ts#L115), however this is preferable to removing it from the user's wallet. And refraction responses will, albeit slightly slower, update the balance anyway.

I don't think a full fix is appropriate here for a couple reasons. The main issue is that this problem is symptomatic of conflating price and balance updates. In this case we really only care about updating the balance but then overwrite the price with nothing. Hacks to fix this will add complexity and may have unintended consequences elsewhere throughout the application. This shortfall of our current logic is known and is slated to be fixed during the code foundations/organization project.

If we do want to attempt to fix this in a more complete fashion (in another ticket). We could:
1. add a flag to `dataUpdateAsset` for ignoring the new price value
2. fetch price in another fashion rather than relying on generic assets inside `getUpdatedL2AssetBalance`

This, however, feels like a slippery slope and is probably best handled by the code foundations/organization team.

## Screen recordings / screenshots
https://recordit.co/1aOZUohFIP


## What to test
Ensure swapping tokens with no mainnet address doesn't cause them to temporarily drop from the wallet screen.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
