### PR TITLE
improve approve+swap gas estimation algo

### DIFF
--- a/src/handlers/uniswap.ts
+++ b/src/handlers/uniswap.ts
@@ -97,7 +97,7 @@ async function getClosestGasEstimate(estimationFn: Function) {
       (highestFailedGuess !== null &&
         highestFailedGuess + 1 === lowestSuccessfulGuess) ||
       lowestSuccessfulGuess === 0 ||
-      (lowestSuccessfulGuess != null &&
+      (lowestSuccessfulGuess !== null &&
         lowestFailureGuess === lowestSuccessfulGuess - 1)
     ) {
       return gasEstimates[lowestSuccessfulGuess];

--- a/src/handlers/uniswap.ts
+++ b/src/handlers/uniswap.ts
@@ -52,11 +52,62 @@ export enum Field {
   OUTPUT = 'OUTPUT',
 }
 
-const MAX_GAS_LIMIT = 460000;
 const GAS_LIMIT_INCREMENT = 50000;
 const EXTRA_GAS_PADDING = 1.5;
 const SWAP_GAS_PADDING = 1.05;
 const CHAIN_IDS_WITH_TRACE_SUPPORT = [ChainId.mainnet];
+
+async function getClosestGasEstimate(estimationFn: Function) {
+  // From 200k to 1M
+  const gasEstimates = Array.from(Array(21).keys())
+    .filter(x => x > 3)
+    .map(x => x * GAS_LIMIT_INCREMENT);
+
+  let start = 0;
+  let end = gasEstimates.length - 1;
+
+  let highestFailedGuess = null;
+  let lowestSuccessfulGuess = null;
+  let lowestFailureGuess = null;
+  //guess is typically middle of array
+  let guessIndex = Math.floor((end - start) / 2);
+  while (end > start) {
+    const gasEstimationSucceded = await estimationFn(gasEstimates[guessIndex]);
+    if (gasEstimationSucceded) {
+      if (!lowestSuccessfulGuess || guessIndex < lowestSuccessfulGuess) {
+        lowestSuccessfulGuess = guessIndex;
+      }
+      end = guessIndex;
+      guessIndex = Math.max(
+        Math.floor((end + start) / 2) - 1,
+        highestFailedGuess || 0
+      );
+    } else if (!gasEstimationSucceded) {
+      if (!highestFailedGuess || guessIndex > highestFailedGuess) {
+        highestFailedGuess = guessIndex;
+      }
+      if (!lowestFailureGuess || guessIndex < lowestFailureGuess) {
+        lowestFailureGuess = guessIndex;
+      }
+      start = guessIndex;
+      guessIndex = Math.ceil((end + start) / 2);
+    }
+
+    if (
+      (highestFailedGuess !== null &&
+        highestFailedGuess + 1 === lowestSuccessfulGuess) ||
+      lowestSuccessfulGuess === 0 ||
+      (lowestSuccessfulGuess != null &&
+        lowestFailureGuess === lowestSuccessfulGuess - 1)
+    ) {
+      return gasEstimates[lowestSuccessfulGuess];
+    }
+
+    if (highestFailedGuess === gasEstimates.length - 1) {
+      return -1;
+    }
+  }
+}
 
 export const getDefaultGasLimitForTrade = (
   tradeDetails: Quote,
@@ -137,7 +188,7 @@ export const getSwapGasLimitWithFakeApproval = async (
   provider: StaticJsonRpcProvider,
   tradeDetails: Quote
 ): Promise<number> => {
-  let stateDiff;
+  let stateDiff: any;
 
   try {
     stateDiff = await getStateDiff(provider, tradeDetails);
@@ -152,11 +203,7 @@ export const getSwapGasLimitWithFakeApproval = async (
       params
     );
 
-    for (
-      let gas = ethUnits.basic_swap;
-      gas < MAX_GAS_LIMIT;
-      gas += GAS_LIMIT_INCREMENT
-    ) {
+    const gasLimit = await getClosestGasEstimate(async (gas: number) => {
       const callParams = [
         {
           data,
@@ -172,12 +219,18 @@ export const getSwapGasLimitWithFakeApproval = async (
       try {
         await provider.send('eth_call', [...callParams, stateDiff]);
         logger.log(`Estimate worked with gasLimit: `, gas);
-        return gas;
+        return true;
       } catch (e) {
         logger.log(
-          `Estimate failed with gasLimit ${gas}. Might retry with higher amounts...`
+          `Estimate failed with gasLimit ${gas}. Trying with different amounts...`
         );
+        return false;
       }
+    });
+    if (gasLimit && gasLimit >= ethUnits.basic_swap) {
+      return gasLimit;
+    } else {
+      logger.log('Could not find a gas estimate');
     }
   } catch (e) {
     logger.log(`Blew up trying to get state diff. Falling back to defaults`, e);


### PR DESCRIPTION
Fixes TEAM2-335
Figma link (if any):

## What changed (plus any additional context for devs)
Use binary search to find out the ideal gas estimation for approve + swap scenarios using trace_call.
We were only going up to 450k gas before and now we go up to 1M with the same amount (or less requests)

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://recordit.co/SCeP50PbCz

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

Test any approval + swap and you should see something similar to my PoW. Other types of swaps are not affected.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
