### PR TITLE
[TEAM2-331] Fix CHI token decimals from backend

### DIFF
--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -116,6 +116,9 @@ const useSwapCurrencyList = (
             }
             token.uniqueId = `${token.address}_${network}`;
           }
+          if (!token?.decimals) {
+            token.decimals = 0;
+          }
           return token;
         })
         .filter(({ address }) => !isFavorite(address));


### PR DESCRIPTION
## What changed (plus any additional context for devs)
`if (decimals === null) { decimals = 0 }` in token search response transforms

## Screen recordings / screenshots
https://recordit.co/WyO3bezwUV

## What to test
Check that CHI swaps are working (or any other known 0 decimal currency you'd like)

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
