### PR TITLE
Bump gas estimation padding for swaps

### DIFF
--- a/src/handlers/uniswap.ts
+++ b/src/handlers/uniswap.ts
@@ -55,7 +55,7 @@ export enum Field {
 const MAX_GAS_LIMIT = 460000;
 const GAS_LIMIT_INCREMENT = 50000;
 const EXTRA_GAS_PADDING = 1.5;
-const SWAP_GAS_PADDING = 1.05;
+const SWAP_GAS_PADDING = 1.1;
 const CHAIN_IDS_WITH_TRACE_SUPPORT = [ChainId.mainnet];
 
 export const getDefaultGasLimitForTrade = (


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
bumping from 5% to 10% with the hope of preventing this kind of failures https://etherscan.io/tx/0x4985c95b3a8803c96971aaf8369ca0f29f39e375916b37a6fb8114ec45708014

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
None

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
Shouldn't be any noticeable change. We're just bumping the const that's the padding multiplier.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
