### PR TITLE
Profiles: remove videos from nft selection

### DIFF
--- a/src/hooks/useAccountTransactions.ts
+++ b/src/hooks/useAccountTransactions.ts
@@ -75,7 +75,7 @@ export default function useAccountTransactions(
   const theme = useTheme();
   const { navigate } = useNavigation();
   const onTransactionPress = useCallback(
-    () => transactionPressBuilder({ navigate }),
+    transactionPressBuilder({ navigate }),
     [navigate]
   );
 

--- a/src/hooks/useAccountTransactions.ts
+++ b/src/hooks/useAccountTransactions.ts
@@ -75,7 +75,7 @@ export default function useAccountTransactions(
   const theme = useTheme();
   const { navigate } = useNavigation();
   const onTransactionPress = useCallback(
-    transactionPressBuilder({ navigate }),
+    () => transactionPressBuilder({ navigate }),
     [navigate]
   );
 

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -43,8 +43,10 @@ export default function useWalletSectionsData({
 
   const { isCoinListEdited } = useCoinListEdited();
 
+  const isImage = (uniqueToken: any) => !uniqueToken.animation_url;
+
   const uniqueImageTokens = useMemo(
-    () => allUniqueTokens.filter(uniqueToken => !uniqueToken.animation_url),
+    () => allUniqueTokens.filter((uniqueToken: any) => isImage(uniqueToken)),
     [allUniqueTokens]
   );
 

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -14,10 +14,14 @@ import {
 } from '@rainbow-me/helpers/buildWalletSections';
 import { readableUniswapSelector } from '@rainbow-me/helpers/uniswapLiquidityTokenInfoSelector';
 
+interface Props {
+  type?: string;
+  withVideos?: boolean;
+}
 export default function useWalletSectionsData({
-  type = undefined,
+  type,
   withVideos = true,
-} = {}) {
+}: Props = {}) {
   const sortedAccountData = useSortedAccountAssets();
   const isWalletEthZero = useIsWalletEthZero();
 

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -5,7 +5,6 @@ import useCoinListEditOptions from './useCoinListEditOptions';
 import useCoinListEdited from './useCoinListEdited';
 import useIsWalletEthZero from './useIsWalletEthZero';
 import useSavingsAccount from './useSavingsAccount';
-import useSendableUniqueTokens from './useSendableUniqueTokens';
 import useShowcaseTokens from './useShowcaseTokens';
 import useSortedAccountAssets from './useSortedAccountAssets';
 import { AppState } from '@/redux/store';
@@ -16,14 +15,13 @@ import {
 import { readableUniswapSelector } from '@rainbow-me/helpers/uniswapLiquidityTokenInfoSelector';
 
 export default function useWalletSectionsData({
-  // @ts-expect-error
-  type,
+  type = undefined,
+  withVideos = true,
 } = {}) {
   const sortedAccountData = useSortedAccountAssets();
   const isWalletEthZero = useIsWalletEthZero();
 
   const { language, network, nativeCurrency } = useAccountSettings();
-  const sendableUniqueTokens = useSendableUniqueTokens();
   const allUniqueTokens = useSelector(
     (state: AppState) => state.uniqueTokens.uniqueTokens
   );
@@ -41,6 +39,11 @@ export default function useWalletSectionsData({
 
   const { isCoinListEdited } = useCoinListEdited();
 
+  const uniqueImageTokens = useMemo(
+    () => allUniqueTokens.filter(uniqueToken => !uniqueToken.animation_url),
+    [allUniqueTokens]
+  );
+
   const walletSections = useMemo(() => {
     const accountInfo = {
       hiddenCoins,
@@ -50,8 +53,8 @@ export default function useWalletSectionsData({
       network,
       pinnedCoins,
       savings,
+      uniqueTokens: withVideos ? allUniqueTokens : uniqueImageTokens,
       ...sortedAccountData,
-      ...sendableUniqueTokens,
       ...uniswap,
       // @ts-expect-error ts-migrate(2698) FIXME: Spread types may only be created from object types... Remove this comment to see the full error message
       ...isWalletEthZero,
@@ -86,8 +89,9 @@ export default function useWalletSectionsData({
     showcaseTokens,
     sortedAccountData,
     type,
-    sendableUniqueTokens,
+    uniqueImageTokens,
     uniswap,
+    withVideos,
   ]);
   return walletSections;
 }

--- a/src/screens/SelectUniqueTokenSheet.tsx
+++ b/src/screens/SelectUniqueTokenSheet.tsx
@@ -23,9 +23,9 @@ export default function SelectUniqueTokenSheet() {
     },
     [goBack, params]
   );
-  const {
-    briefSectionsData: walletBriefSectionsData,
-  } = useWalletSectionsData();
+  const { briefSectionsData: walletBriefSectionsData } = useWalletSectionsData({
+    withVideos: false,
+  });
 
   return (
     <Box background="body" height="full" paddingTop="34px">


### PR DESCRIPTION
Fixes TEAM2-180
Figma link (if any):

## What changed (plus any additional context for devs)
- remove videos from profile avatar/cover nft selection
- also random unrelated lint

## Screen recordings / screenshots


https://user-images.githubusercontent.com/15272675/182487811-47540538-8c43-46b1-8a12-ee9314b8c349.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
