### PR TITLE
Profiles: Unable to swipe down on Profile Sheet on Android

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/core/ExternalENSProfileScrollView.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/ExternalENSProfileScrollView.tsx
@@ -18,6 +18,7 @@ import { ProfileSheetConfigContext } from '../../../../screens/ProfileSheet';
 import ProfileSheetHeader from '../../../ens-profile/ProfileSheetHeader';
 import ImagePreviewOverlay from '../../../images/ImagePreviewOverlay';
 import { StickyHeaderContext } from './StickyHeaders';
+import { useAndroidScrollViewGestureHandler } from '@/hooks';
 
 const extraPadding = { paddingBottom: 144 };
 const ExternalENSProfileScrollViewWithRef = React.forwardRef<
@@ -58,12 +59,15 @@ const ExternalENSProfileScrollViewWithRef = React.forwardRef<
     [yPosition]
   );
 
+  const { onScroll: onAndroidScroll } = useAndroidScrollViewGestureHandler();
+
   const handleScroll = useCallback(
     event => {
       onScroll(event);
+      android && onAndroidScroll(event);
       runOnUI(scrollHandler)(event.nativeEvent.contentOffset.y);
     },
-    [onScroll, scrollHandler]
+    [onAndroidScroll, onScroll, scrollHandler]
   );
 
   useImperativeHandle(ref, () => scrollViewRef.current!);

--- a/src/hooks/useAndroidScrollViewGestureHandler.ts
+++ b/src/hooks/useAndroidScrollViewGestureHandler.ts
@@ -10,7 +10,7 @@ export default function useAndroidScrollViewGestureHandler({
   navigation: navigationOverride,
 }: {
   navigation?: NavigationProp<any, any>;
-}) {
+} = {}) {
   const inferredNavigation = useNavigation();
   const navigation = navigationOverride || inferredNavigation;
 


### PR DESCRIPTION
Fixes TEAM2-357

## What changed (plus any additional context for devs)

This PR fixes an issue on Android where a user was unable to dismiss the profile sheet.


## Screen recordings / screenshots

https://www.loom.com/share/e2ad9aa71d57468ea5e269df47e623ab


## What to test

Make sure you can dismiss the profile sheet on Android & iOS

