### PR TITLE
fix L2 WC balances

### DIFF
--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -129,9 +129,19 @@ const getNativeAssetForNetwork = async (
 
     const provider = await getProviderForNetwork(network);
     if (nativeAsset) {
-      if (network === Network.polygon) {
-        nativeAsset.mainnet_address = mainnetAddress;
-        nativeAsset.address = MATIC_POLYGON_ADDRESS;
+      switch (network) {
+        case Network.polygon:
+          nativeAsset.mainnet_address = mainnetAddress;
+          nativeAsset.address = MATIC_POLYGON_ADDRESS;
+          break;
+        case Network.optimism:
+          nativeAsset.mainnet_address = ETH_ADDRESS;
+          nativeAsset.address = OPTIMISM_ETH_ADDRESS;
+          break;
+        case Network.arbitrum:
+          nativeAsset.mainnet_address = ETH_ADDRESS;
+          nativeAsset.address = ARBITRUM_ETH_ADDRESS;
+          break;
       }
       const balance = await getOnchainAssetBalance(
         nativeAsset,


### PR DESCRIPTION
Fixes TEAM2-210
Figma link (if any):

## What changed (plus any additional context for devs)
fetching on chain balances was fetching 'eth' as the address


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
(https://cloud.skylarbarrera.com/Screen-Recording-2022-08-03-13-59-25.mp4)


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
connect to rainbow buttond dapp or hop exchange with a wallet that had L2 ETH, create a new wallet with 0 balances. while using the new wallet try to send a TX from the dapp, it should now fetch the balances for the connected wallet it was undefined previously 


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
