### PR TITLE
Reorder search groups to highlight profiles

### DIFF
--- a/src/components/discover-sheet/DiscoverSearch.js
+++ b/src/components/discover-sheet/DiscoverSearch.js
@@ -69,11 +69,7 @@ export default function DiscoverSearch() {
     // 4. unverified
     // 5. low liquidity
     let list = swapCurrencyList;
-    let listKeys = [];
-
-    list.map(item => {
-      return listKeys.push(item.key);
-    });
+    const listKeys = swapCurrencyList.map(item => item.key);
 
     const profilesSecond =
       (listKeys[0] === 'favorites' && listKeys[1] !== 'verified') ||

--- a/src/components/discover-sheet/DiscoverSearch.js
+++ b/src/components/discover-sheet/DiscoverSearch.js
@@ -62,7 +62,35 @@ export default function DiscoverSearch() {
     searchQueryForSearch
   );
   const currencyList = useMemo(() => {
-    let list = [...swapCurrencyList, ...ensResults];
+    // order:
+    // 1. favorites
+    // 2. verified
+    // 3. profiles
+    // 4. unverified
+    // 5. low liquidity
+    let list = swapCurrencyList;
+    let listKeys = [];
+
+    list.map(item => {
+      return listKeys.push(item.key);
+    });
+
+    const profilesSecond =
+      (listKeys[0] === 'favorites' && listKeys[1] !== 'verified') ||
+      listKeys[0] === 'verified';
+    const profilesThird =
+      listKeys[1] === 'verified' ||
+      listKeys[0] === 'unfilteredFavorites' ||
+      (listKeys[0] === 'favorites' && listKeys[1] === 'verified');
+
+    if (profilesSecond) {
+      list.splice(1, 0, ...ensResults);
+    } else if (profilesThird) {
+      list.splice(2, 0, ...ensResults);
+    } else {
+      list = [...ensResults, ...swapCurrencyList];
+    }
+
     // ONLY FOR e2e!!! Fake tokens with same symbols break detox e2e tests
     if (IS_TESTING === 'true') {
       let symbols = [];


### PR DESCRIPTION
Fixes TEAM2-356

## What changed (plus any additional context for devs)
Updated the order of search results based on feedback from @christianbaroni to include Profiles above _unverified_ and _low liquidity_ tokens.


## Screen recordings / screenshots
| Search | Search |
| ------ | ------ |
| ![CleanShot 2022-08-03 at 09 46 30 PM@2x](https://user-images.githubusercontent.com/6843656/182697191-15d24681-9a96-47e7-b01c-10e0111a7c60.png) | ![CleanShot 2022-08-03 at 09 46 49 PM@2x](https://user-images.githubusercontent.com/6843656/182697241-40873c62-85df-4246-8027-6792efe44cc8.png) |


## What to test
Searching and checking the results.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
