### PR TITLE
Fix missing active sale price in NFT expanded sheet

### DIFF
--- a/src/entities/uniqueAssets.ts
+++ b/src/entities/uniqueAssets.ts
@@ -11,7 +11,6 @@ interface UniqueAssetLastSale {
 
 export interface UniqueAsset {
   animation_url?: string | null;
-  current_price?: string | null;
   description?: string | null;
   external_link?: string | null;
   image_original_url?: string | null;
@@ -21,12 +20,6 @@ export interface UniqueAsset {
   last_sale?: UniqueAssetLastSale | null;
   name: string;
   permalink: string;
-  sell_orders?: {
-    current_price: string;
-    payment_token_contract?: {
-      symbol: string;
-    };
-  }[];
   traits: UniqueAssetTrait[];
   asset_contract: AssetContract;
   background: string | null;
@@ -64,6 +57,7 @@ export interface UniqueAsset {
   urlSuffixForAsset: string;
   isPoap?: boolean;
   network: Network;
+  seaport_sell_orders?: SeaportOrder[];
 }
 
 export interface UniqueAssetTrait {
@@ -71,4 +65,64 @@ export interface UniqueAssetTrait {
   value: string | number | null | undefined;
   display_type: string;
   max_value: string | number | null | undefined;
+}
+
+export interface SeaportOrder {
+  created_date: string;
+  closing_date: string | null;
+  listing_time: number;
+  expiration_time: number;
+  order_hash: string | null;
+  protocol_data: {
+    parameters: {
+      offerer: string;
+      zone: string;
+      zone_hash: string;
+      start_time: number;
+      end_time: number;
+      order_type: number;
+      salt: string;
+      conduitKey: string;
+      nonce: string;
+      offer: {
+        itemType: number;
+        token: string;
+        identifier_or_criteria: string;
+        startAmount: string;
+        endAmount: string;
+      }[];
+      consideration: {
+        itemType: number;
+        token: string;
+        identifier_or_criteria: string;
+        startAmount: string;
+        endAmount: string;
+        recipient: string;
+      }[];
+    };
+  };
+  protocol_address: string | null;
+  maker: SeaportAccount;
+  taker: SeaportAccount | null;
+  current_price: string;
+  maker_fees: SeaportFees;
+  taker_fees: SeaportFees;
+  side: number;
+  order_type: number;
+  canceled: boolean;
+  finalized: boolean;
+  marked_invalid: boolean;
+  client_signature: string | null;
+}
+
+interface SeaportAccount {
+  user: string;
+  profile_img_url: string;
+  address: string;
+  config: string;
+}
+
+interface SeaportFees {
+  account: SeaportAccount;
+  basis_points: string;
 }

--- a/src/handlers/opensea-api.ts
+++ b/src/handlers/opensea-api.ts
@@ -41,6 +41,7 @@ export const apiGetAccountUniqueTokens = async (
           },
           method: 'get',
           params: {
+            include_orders: 'true',
             // @ts-expect-error ts-migrate(2322) FIXME: Type '{ limit: number; offset: number; owner: any;... Remove this comment to see the full error message
             limit: UNIQUE_TOKENS_LIMIT_PER_PAGE,
             // @ts-expect-error ts-migrate(2322) FIXME: Type '{ limit: number; offset: number; owner: any;... Remove this comment to see the full error message

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -79,14 +79,13 @@ export const parseAccountUniqueTokens = data => {
         return {
           ...pickShallow(asset, [
             'animation_url',
-            'current_price',
             'description',
             'external_link',
             'last_sale',
             'name',
             'permalink',
-            'sell_orders',
             'traits',
+            'seaport_sell_orders',
           ]),
           asset_contract: pickShallow(asset_contract, [
             'address',
@@ -110,10 +109,11 @@ export const parseAccountUniqueTokens = data => {
             'twitter_username',
             'wiki_link',
           ]),
-          currentPrice: asset.sell_orders
+          currentPrice: asset.seaport_sell_orders
             ? `${
-                Number(asset.sell_orders[0].current_price) / 1000000000000000000
-              } ${asset.sell_orders[0].payment_token_contract.symbol}`
+                Number(asset.seaport_sell_orders[0].current_price) /
+                1000000000000000000
+              } ${asset.seaport_sell_orders[0].payment_token_contract.symbol}`
             : null,
           familyImage: collection.image_url,
           familyName:
@@ -199,10 +199,11 @@ export const parseAccountUniqueTokensPolygon = data => {
           'twitter_username',
           'wiki_link',
         ]),
-        currentPrice: asset.sell_orders
+        currentPrice: asset.seaport_sell_orders
           ? `${
-              Number(asset.sell_orders[0].current_price) / 1000000000000000000
-            } ${asset.sell_orders[0].payment_token_contract.symbol}`
+              Number(asset.seaport_sell_orders[0].current_price) /
+              1000000000000000000
+            } ${asset.seaport_sell_orders[0].payment_token_contract.symbol}`
           : null,
         familyImage: collection.image_url,
         familyName:

--- a/src/references/opensea/index.ts
+++ b/src/references/opensea/index.ts
@@ -1,0 +1,1 @@
+export { default as OpenseaPaymentTokens } from './opensea-payment-tokens.json';

--- a/src/references/opensea/opensea-payment-tokens.json
+++ b/src/references/opensea/opensea-payment-tokens.json
@@ -1,0 +1,82 @@
+[
+  {
+    "symbol": "APE",
+    "address": "0x4d224452801aced8b2f0aebe155379bb5d594381",
+    "decimals": 18
+  },
+  {
+    "symbol": "VOLT",
+    "address": "0xffbf315f70e458e49229654dea4ce192d26f9b25",
+    "decimals": 18
+  },
+  {
+    "symbol": "ASH",
+    "address": "0x64d91f12ece7362f91a6f8e7940cd55f05060b92",
+    "decimals": 18
+  },
+  {
+    "symbol": "NCT",
+    "address": "0x8a9c4dfe8b9d8962b31e4e16f8321c44d48e246e",
+    "decimals": 18
+  },
+  {
+    "symbol": "GALA",
+    "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
+    "decimals": 8
+  },
+  {
+    "symbol": "UNI",
+    "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+    "decimals": 18
+  },
+  {
+    "symbol": "REVV",
+    "address": "0x557b933a7c2c45672b610f8954a3deb39a51a8ca",
+    "decimals": 18
+  },
+  {
+    "symbol": "LINK",
+    "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+    "decimals": 18
+  },
+  {
+    "symbol": "MANA",
+    "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+    "decimals": 18
+  },
+  {
+    "symbol": "CUBE",
+    "address": "0xdf801468a808a32656d2ed2d2d80b72a129739f4",
+    "decimals": 8
+  },
+  {
+    "symbol": "BAT",
+    "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+    "decimals": 18
+  },
+  {
+    "symbol": "USDC",
+    "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "decimals": 6
+  },
+  {
+    "symbol": "WETH",
+    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+    "decimals": 18
+  },
+  {
+    "symbol": "DAI",
+    "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+    "decimals": 18
+  },
+  {
+    "symbol": "ETH",
+    "address": "0x0000000000000000000000000000000000000000",
+    "decimals": 18
+  },
+  {
+    "symbol": "SAND",
+    "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+    "decimals": 18
+  }
+]


### PR DESCRIPTION
Fixes TEAM2-340
Figma link (if any):

## What changed (plus any additional context for devs)
Since the release of Seaport the OS api now returns active listings in a `seaport_sell_orders` object on the api response, this PR adds seaport order data to the api response and then also uses current_price from within the object to set the `currentPrice` property that is returned in the `UniqueAsset` type. 
This now means active listings should appear in the Expanded NFT sheet.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
Find an actively listed NFT on ETh & Polygon and look to see if the NFT in the app displays sale price rather than "Last sold". 
Check that the correct amount is displayed and that the correct token symbol is used e.g ETH or DAI.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
