### PR TITLE
profiles: resize + sign cover photo

### DIFF
--- a/src/components/ens-profile/ProfileSheetHeader.tsx
+++ b/src/components/ens-profile/ProfileSheetHeader.tsx
@@ -22,6 +22,7 @@ import {
   Stack,
 } from '@rainbow-me/design-system';
 import { UniqueAsset } from '@rainbow-me/entities';
+import { maybeSignUri } from '@rainbow-me/handlers/imgix';
 import { ENS_RECORDS } from '@rainbow-me/helpers/ens';
 import {
   useENSAddress,
@@ -119,7 +120,7 @@ export default function ProfileSheetHeader({
     };
   }, [enableZoomableImages, getUniqueToken, handleSelectNFT, records?.avatar]);
 
-  const coverUrl = cover?.imageUrl;
+  const coverUrl = maybeSignUri(cover?.imageUrl || undefined, { w: 400 });
 
   const { enableZoomOnPressCover, onPressCover } = useMemo(() => {
     const cover = records?.cover;


### PR DESCRIPTION
Fixes RNBW-4134
Figma link (if any):

## What changed (plus any additional context for devs)
we now resize the cover image, looks like it gets used in a p smol view so 400 should still look crisp


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://cloud.skylarbarrera.com/Screen-Recording-2022-08-03-18-45-55.mp4

^ note example is at width of 200 so it looks kinda blurry

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
load up brdy.eth and make sure cover loads fast asf


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
