### PR TITLE
Profiles: Fix undefined ENS NFT after registering an ENS

### DIFF
--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -408,5 +408,13 @@ export const buildBriefUniqueTokenList = (
   return result;
 };
 
-export const buildUniqueTokenName = ({ collection, id, name }: any) =>
-  name || `${collection?.name} #${id}`;
+export const buildUniqueTokenName = ({
+  collection,
+  id,
+  name,
+  uniqueId,
+}: any) => {
+  if (name) return name;
+  if (id) return `${collection?.name} #${id}`;
+  return uniqueId;
+};

--- a/src/hooks/useCollectible.ts
+++ b/src/hooks/useCollectible.ts
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from 'react';
-import { useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
-import useAccountSettings from './useAccountSettings';
 import { uniqueTokensQueryKey } from './useFetchUniqueTokens';
 import { revalidateUniqueToken } from '@rainbow-me/redux/uniqueTokens';
 
@@ -15,17 +14,14 @@ export default function useCollectible(
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'uniqueTokens' does not exist on type 'De... Remove this comment to see the full error message
     ({ uniqueTokens: { uniqueTokens } }) => uniqueTokens
   );
-  const { accountAddress } = useAccountSettings();
-  const queryClient = useQueryClient();
-  const externalUniqueTokens = useMemo(() => {
-    return (
-      queryClient.getQueryData(
-        uniqueTokensQueryKey({ address: externalAddress })
-      ) || []
-    );
-  }, [queryClient, externalAddress]);
-  const isExternal =
-    Boolean(externalAddress) && externalAddress !== accountAddress;
+  const { data: externalUniqueTokens } = useQuery(
+    uniqueTokensQueryKey({ address: externalAddress }),
+    // We just want to watch for changes in the query key,
+    // so just supplying a noop function & staleTime of Infinity.
+    async () => [],
+    { staleTime: Infinity }
+  );
+  const isExternal = Boolean(externalAddress);
   // Use the appropriate tokens based on if the user is viewing the
   // current accounts tokens, or external tokens (e.g. ProfileSheet)
   const uniqueTokens = useMemo(

--- a/src/redux/uniqueTokens.ts
+++ b/src/redux/uniqueTokens.ts
@@ -345,7 +345,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
     timeAgo: { hours: 48 },
   });
   if (ensTokens.length > 0) {
-    uniqueTokens = uniqBy([...uniqueTokens, ...ensTokens], 'uniqueId');
+    uniqueTokens = uniqBy([...uniqueTokens, ...ensTokens], 'id');
   }
 
   // NFT Fetching clean up


### PR DESCRIPTION
Fixes TEAM2-369
Fixes RNBW-4159

## What changed (plus any additional context for devs)

This PR fixes an issue where a user would see an "undefined #undefined" NFT just after registering their ENS.

Also fixes RNBW-4159 as we now use `id` as a unique identifier on the asset list.


## Screen recordings / screenshots

https://www.loom.com/share/c4c01e80728e4ce48c4c516a1d027dbf


## What to test

After registering an ENS, ensure that you correctly see your ENS NFT in your wallet, as well as in the profile sheet (when you search for your wallet)
