### PR TITLE
Profiles: Fix ENS owner caching issue

### DIFF
--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -44,6 +44,11 @@ export const blockClient = new ApolloClient({
 export const ensClient = new ApolloClient({
   ...defaultOptions,
   cache: new InMemoryCache(),
+  defaultOptions: {
+    query: {
+      fetchPolicy: 'no-cache',
+    },
+  },
   link: new HttpLink({
     uri: 'https://api.thegraph.com/subgraphs/name/ensdomains/ens',
   }),


### PR DESCRIPTION
Fixes TEAM2-367

## What changed (plus any additional context for devs)

We are eagerly caching every The Graph ENS response in-memory via Apollo, however, we don't need to do this since we are already implementing in-memory caching via React Query for everything that uses the ENS client apollo instance, so the apollo cache is redundant. 