### PR TITLE
Fix send sheet layout again

### DIFF
--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -47,7 +47,7 @@ const FormContainer = styled(Column).attrs(
     : {}
 )(({ isNft }) => ({
   ...(isNft ? padding.object(0) : padding.object(0, 19)),
-  flex: 1,
+  ...(ios || isNft ? { flex: 1 } : {}),
 }));
 
 const KeyboardSizeView = styled(KeyboardArea)({


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

#3785 fixed a layout problem on Android, but broke NFT sending. #3911 reintroduced the problem.

The whole issue is that Android in send sheet shouldn't have `flex: 1`, iOS needs `flex: 1` always.

I haven't tested iOS right now because of issue with certs, but I am somewhat confident that the `ios` var will work.

## Screen recordings / screenshots

No.

## What to test

Send sheet layout for Android, iOS, sending token, sending NFT.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
