### PR TITLE
Revert to emoji shuffle on Android

### DIFF
--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -9,6 +9,7 @@ import useENSProfile from './useENSProfile';
 import { prefetchENSProfileImages } from './useENSProfileImages';
 import useENSRegistration from './useENSRegistration';
 import useImagePicker from './useImagePicker';
+import useUpdateEmoji from './useUpdateEmoji';
 import useWallets from './useWallets';
 import { analytics } from '@rainbow-me/analytics';
 import {
@@ -36,6 +37,7 @@ export default () => {
   const profileEnabled = Boolean(accountENS);
   const ensProfile = useENSProfile(accountENS, { enabled: profileEnabled });
   const { openPicker } = useImagePicker();
+  const { setNextEmoji } = useUpdateEmoji();
 
   const onAvatarRemovePhoto = useCallback(async () => {
     const newWallets = {
@@ -89,6 +91,10 @@ export default () => {
     });
   }, [accountColor, accountName, navigate]);
 
+  const onAvatarShuffleEmoji = useCallback(() => {
+    setNextEmoji();
+  }, [setNextEmoji]);
+
   const onAvatarChooseImage = useCallback(async () => {
     const image = await openPicker({
       cropperCircleOverlay: true,
@@ -140,7 +146,11 @@ export default () => {
           if (accountImage) {
             onAvatarRemovePhoto();
           } else {
-            onAvatarPickEmoji();
+            if (ios) {
+              onAvatarPickEmoji();
+            } else {
+              onAvatarShuffleEmoji();
+            }
           }
         } else if (buttonIndex === 2 && profilesEnabled) {
           onAvatarCreateProfile();
@@ -173,7 +183,9 @@ export default () => {
         : [
             lang.t('profiles.profile_avatar.choose_from_library'),
             !accountImage
-              ? lang.t('profiles.profile_avatar.pick_emoji')
+              ? android
+                ? lang.t('profiles.profile_avatar.shuffle_emoji')
+                : lang.t('profiles.profile_avatar.pick_emoji')
               : lang.t('profiles.profile_avatar.remove_photo'),
             profilesEnabled &&
               (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) &&

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -91,10 +91,6 @@ export default () => {
     });
   }, [accountColor, accountName, navigate]);
 
-  const onAvatarShuffleEmoji = useCallback(() => {
-    setNextEmoji();
-  }, [setNextEmoji]);
-
   const onAvatarChooseImage = useCallback(async () => {
     const image = await openPicker({
       cropperCircleOverlay: true,
@@ -149,7 +145,7 @@ export default () => {
             if (ios) {
               onAvatarPickEmoji();
             } else {
-              onAvatarShuffleEmoji();
+              setNextEmoji();
             }
           }
         } else if (buttonIndex === 2 && profilesEnabled) {
@@ -169,6 +165,7 @@ export default () => {
       onAvatarRemovePhoto,
       profilesEnabled,
       startRegistration,
+      setNextEmoji,
     ]
   );
 

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1013,6 +1013,7 @@
         "create_profile": "Create your Profile",
         "edit_profile": "Edit Profile",
         "pick_emoji": "Pick an Emoji",
+        "shuffle_emoji": "Shuffle Emoji",
         "remove_photo": "Remove Photo",
         "view_profile": "View Profile"
       },

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -958,6 +958,7 @@
         "create_profile": "Create your Profile :)",
         "edit_profile": "Edit Profile :)",
         "pick_emoji": "Pick an Emoji :)",
+        "shuffle_emoji": "Shuffle Emoji :)",
         "remove_photo": "Remove Photo :)",
         "view_profile": "View Profile :)"
       },


### PR DESCRIPTION
Fixes RNBW-4108
Figma link (if any):

## What changed (plus any additional context for devs)

On Android we revert back to emoji shuffle. Check linear ticket for more context.

## Screen recordings / screenshots

https://user-images.githubusercontent.com/5769281/182895113-2a8aee17-3013-4d82-9d7d-377ebb622055.mp4

iOS video coming tomorrow.

## What to test

Verify that emoji picker works on iOS and on Android is replaced with shuffle.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
