### PR TITLE
Add check that ENS suffix is not empty string

### DIFF
--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -57,7 +57,7 @@ export const isUnstoppableAddressFormat = memoFn(address => {
   if (
     !parts ||
     parts.length === 1 ||
-    parts[parts.length - 1].length === 0 ||
+    !parts[parts.length - 1] ||
     !supportedUnstoppableDomains.includes(parts[parts.length - 1].toLowerCase())
   ) {
     return false;

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -57,6 +57,7 @@ export const isUnstoppableAddressFormat = memoFn(address => {
   if (
     !parts ||
     parts.length === 1 ||
+    parts[parts.length - 1].length === 0 ||
     !supportedUnstoppableDomains.includes(parts[parts.length - 1].toLowerCase())
   ) {
     return false;


### PR DESCRIPTION
Fixes RNBW-2851
Figma link (if any):

## What changed (plus any additional context for devs)
When someone pressed `.` a new empty item was created in the array, the parseDomain function read this empty string as valid which would cause the validation to work. This PR adds a check that the ENS suffix string should have a length greater than 0. This also applies to the unstoppable domain validation for consistency.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
Add a new wallet to the app, when entering a ENS or unstoppable domain does the import button correctly become enabled after a valid domain is entered
Add a 0x address does this enable the import button
Add a seedphrase, does this enable the import button
Add a ENS name name does adding the `.` but nothing else enable the import button (it shouldnt)


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
