### PR TITLE
profiles: turn off search -> renable interactions

### DIFF
--- a/src/components/ens-profile/ActionButtons/MoreButton.tsx
+++ b/src/components/ens-profile/ActionButtons/MoreButton.tsx
@@ -1,3 +1,4 @@
+import { useRoute } from '@react-navigation/core';
 import lang from 'i18n-js';
 import React, { useCallback, useMemo } from 'react';
 import { Keyboard, Share } from 'react-native';
@@ -40,7 +41,9 @@ export default function MoreButton({
   const { navigate } = useNavigation();
   const { setClipboard } = useClipboard();
   const { contacts, onRemoveContact } = useContacts();
-
+  const {
+    params: { setIsSearchModeEnabled },
+  } = useRoute<any>();
   const isSelectedWallet = useMemo(() => {
     const visibleWallet = selectedWallet.addresses.find(
       (wallet: { visible: boolean }) => wallet.visible
@@ -115,6 +118,7 @@ export default function MoreButton({
     async ({ nativeEvent: { actionKey } }) => {
       if (actionKey === ACTIONS.OPEN_WALLET) {
         if (!isSelectedWallet) {
+          setIsSearchModeEnabled?.(false);
           switchToWalletWithAddress(address);
         }
         navigate(Routes.WALLET_SCREEN);
@@ -156,6 +160,7 @@ export default function MoreButton({
       navigate,
       onRemoveContact,
       setClipboard,
+      setIsSearchModeEnabled,
       switchToWalletWithAddress,
     ]
   );


### PR DESCRIPTION
Fixes TEAM2-384
Figma link (if any):

## What changed (plus any additional context for devs)
Discover Search blocks interactions, so when we navigate off of it we need to tell it to turn tf off

I had added this for the showcase sheet, just needed to add to the new one 


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://cloud.skylarbarrera.com/Screen-Recording-2022-08-04-18-09-05.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
try to open wallet from search, try to open from anywhere else -> get to swipin


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
