### PR TITLE
Fix keyboard not dismissing when registering ENS

### DIFF
--- a/src/hooks/useENSPendingRegistrations.tsx
+++ b/src/hooks/useENSPendingRegistrations.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react';
-import { Keyboard } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useAccountSettings, useENSRegistration } from '.';
 import { ENSRegistrationState } from '@rainbow-me/entities';
@@ -71,7 +70,6 @@ export default function useENSPendingRegistrations() {
   const finishRegistration = useCallback(
     name => {
       startRegistration(name, REGISTRATION_MODES.CREATE);
-      android && Keyboard.dismiss();
       setTimeout(() => {
         navigate(Routes.ENS_CONFIRM_REGISTER_SHEET, {});
       }, 100);

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useRoute } from '@react-navigation/core';
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Keyboard } from 'react-native';
 import * as DeviceInfo from 'react-native-device-info';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { HoldToAuthorizeButton } from '../components/buttons';
@@ -372,6 +372,7 @@ export default function ENSConfirmRegisterSheet() {
 
   useFocusEffect(
     useCallback(() => {
+      Keyboard.dismiss();
       blurFields();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])


### PR DESCRIPTION
Fixes TEAM2-360

## What changed (plus any additional context for devs)
- Fixed the keyboard showing unexpectedly when you try to finish your ENS registration because it was trying to focus on the input below.

- Dismiss function was only scoped for Android — it's now being called on Android and iOS. 
- Dismiss function was running before navigation finished its thing, so the search input managed to catch focus and pull up the keyboard again while the sheet was being loaded. 
- It's now being called only after the navigation event happens and the sheet is properly loaded.


## Screen recordings / screenshots
https://user-images.githubusercontent.com/6843656/182961821-412c4cb8-a1c4-4c66-be02-8538daf51984.mp4












## What to test
1. Search for an available ENS and start registering.
2. Kill the app.
3. Launch the app and go back to the ENS search view from the card in Discover.
4. Tap on 'Finish' for your ENS that's in progress.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
