### PR TITLE
Profiles: Make cover NFTs open NFT expanded state

### DIFF
--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -239,16 +239,7 @@ function ImageValue({
         type: 'unique_token',
       });
     });
-  }, [
-    ensName,
-    external,
-    goBack,
-    isNFTImage,
-    navigate,
-    profileAddress,
-    uniqueTokens,
-    value,
-  ]);
+  }, [goBack, isNFTImage, navigate, uniqueTokens, value]);
 
   if (!url) return null;
   return (

--- a/src/components/expanded-state/ens/ProfileInfoSection.tsx
+++ b/src/components/expanded-state/ens/ProfileInfoSection.tsx
@@ -11,6 +11,10 @@ const omitRecordKeys = [ENS_RECORDS.avatar];
 const topRecordKeys = [ENS_RECORDS.cover, ENS_RECORDS.description];
 
 type ImageSource = { imageUrl?: string | null };
+type ENSImages = {
+  avatar?: ImageSource;
+  cover?: ImageSource;
+};
 
 export default function ProfileInfoSection({
   allowEdit,
@@ -23,23 +27,16 @@ export default function ProfileInfoSection({
   allowEdit?: boolean;
   coinAddresses?: { [key: string]: string };
   ensName?: string;
-  images?: {
-    avatar?: ImageSource;
-    cover?: ImageSource;
-  };
+  images?: ENSImages;
   isLoading?: boolean;
   records?: Partial<Records>;
 }) {
   const recordsArray = useMemo(
     () =>
-      Object.entries(records || {})
-        .filter(([key]) => !omitRecordKeys.includes(key as ENS_RECORDS))
-        .map(([key, value]) =>
-          key === 'avatar' || key === 'cover'
-            ? [key, images?.[key]?.imageUrl as string]
-            : [key, value]
-        ),
-    [images, records]
+      Object.entries(records || {}).filter(
+        ([key]) => !omitRecordKeys.includes(key as ENS_RECORDS)
+      ),
+    [records]
   );
 
   const [topRecords, otherRecords] = useMemo(() => {
@@ -72,6 +69,7 @@ export default function ProfileInfoSection({
               <ProfileInfoRow
                 allowEdit={allowEdit}
                 ensName={ensName}
+                images={images}
                 key={recordKey}
                 recordKey={recordKey}
                 recordValue={recordValue}
@@ -112,12 +110,14 @@ export default function ProfileInfoSection({
 function ProfileInfoRow({
   allowEdit,
   ensName,
+  images,
   recordKey,
   recordValue,
   type,
 }: {
   allowEdit?: boolean;
   ensName?: string;
+  images?: ENSImages;
   recordKey: string;
   recordValue: string;
   type: 'address' | 'record';
@@ -132,6 +132,7 @@ function ProfileInfoRow({
   } = useENSRecordDisplayProperties({
     allowEdit,
     ensName,
+    images,
     key: recordKey,
     type,
     value: recordValue,
@@ -142,7 +143,8 @@ function ProfileInfoRow({
       icon={icon}
       isImage={isImageValue}
       label={label}
-      value={isImageValue ? url : value}
+      url={url}
+      value={value}
       wrapValue={children =>
         !isImageValue ? (
           <ContextMenuButton>

--- a/src/components/expanded-state/ens/ProfileInfoSection.tsx
+++ b/src/components/expanded-state/ens/ProfileInfoSection.tsx
@@ -140,6 +140,7 @@ function ProfileInfoRow({
 
   return (
     <InfoRow
+      ensName={ensName}
       icon={icon}
       isImage={isImageValue}
       label={label}

--- a/src/hooks/useENSRecordDisplayProperties.tsx
+++ b/src/hooks/useENSRecordDisplayProperties.tsx
@@ -16,6 +16,12 @@ import Routes from '@rainbow-me/routes';
 import { showActionSheetWithOptions } from '@rainbow-me/utils';
 import { formatAddressForDisplay } from '@rainbow-me/utils/abbreviations';
 
+type ImageSource = { imageUrl?: string | null };
+type ENSImages = {
+  avatar?: ImageSource;
+  cover?: ImageSource;
+};
+
 const imageKeyMap = {
   [ENS_RECORDS.avatar]: 'avatarUrl',
   [ENS_RECORDS.cover]: 'coverUrl',
@@ -47,12 +53,14 @@ const links = {
 export default function useENSRecordDisplayProperties({
   allowEdit,
   ensName,
+  images,
   key: recordKey,
   value: recordValue,
   type,
 }: {
   allowEdit?: boolean;
   ensName?: string;
+  images?: ENSImages;
   key: string;
   value: string;
   type: 'address' | 'record';
@@ -70,6 +78,9 @@ export default function useENSRecordDisplayProperties({
   const isUrlValue = useMemo(() => recordValue.match(/^http/), [recordValue]);
 
   const url = useMemo(() => {
+    if (isImageValue) {
+      return images?.[recordKey as 'avatar' | 'cover']?.imageUrl || undefined;
+    }
     if (isUrlValue || isUrlRecord) {
       return recordValue.match(/^http/)
         ? recordValue
@@ -78,7 +89,7 @@ export default function useENSRecordDisplayProperties({
     if (links[recordKey]) {
       return `${links[recordKey]}${recordValue.replace('@', '')}`;
     }
-  }, [isUrlRecord, isUrlValue, recordKey, recordValue]);
+  }, [images, isImageValue, isUrlRecord, isUrlValue, recordKey, recordValue]);
 
   const { displayUrl, displayUrlUsername } = useMemo(() => {
     const urlObj = url ? new URL(url) : { hostname: '', pathname: '' };

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -44,8 +44,8 @@ export function getENSNFTAvatarUrl(
   return avatarUrl;
 }
 
-export function isENSNFTRecord(avatar: string) {
-  return avatar.includes('eip155:1');
+export function isENSNFTRecord(avatar?: string) {
+  return avatar?.includes('eip155:1');
 }
 
 export function normalizeENS(name: string) {


### PR DESCRIPTION
Fixes RNBW-4191
Fixes RNBW-4190

## What changed (plus any additional context for devs)

This PR opens the NFT expanded state for NFT cover photos.


## Screen recordings / screenshots

Android:
https://www.loom.com/share/0334e8e55ebf44ba9b26cabebaf69bd4

iOS:
https://www.loom.com/share/785ce1fa7d3c46959b80f88f109cfafa


## What to test

- Ensure that NFT cover photos open up the NFT expanded state of the cover NFT.
- Ensure that normal cover images are still zoomable.

