### PR TITLE
profiles: header + avatar tweaks

### DIFF
--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -129,6 +129,8 @@ const RegistrationAvatar = ({
     imagePickerOptions: {
       cropperCircleOverlay: true,
       cropping: true,
+      height: 400,
+      width: 400,
     },
     menuItems: enableNFTs ? ['library', 'nft'] : ['library'],
     onChangeImage,

--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -1,6 +1,6 @@
 import ConditionalWrap from 'conditional-wrap';
 import lang from 'i18n-js';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { Image } from 'react-native-image-crop-picker';
 import RadialGradient from 'react-native-radial-gradient';
@@ -61,15 +61,8 @@ const RegistrationCover = ({
   const accentColor = useForegroundColor('accent');
 
   const setCoverMetadata = useSetRecoilState(coverMetadataAtom);
-
-  const { ContextMenu, handleSelectImage } = useSelectImageMenu({
-    imagePickerOptions: {
-      cropping: true,
-      height: 500,
-      width: 1500,
-    },
-    menuItems: enableNFTs ? ['library', 'nft'] : ['library'],
-    onChangeImage: ({
+  const onChangeImage = useCallback(
+    ({
       asset,
       image,
     }: {
@@ -107,11 +100,26 @@ const RegistrationCover = ({
         });
       }
     },
+    [onBlurField, setCoverMetadata]
+  );
+
+  const { ContextMenu, handleSelectImage } = useSelectImageMenu({
+    imagePickerOptions: {
+      cropping: true,
+      height: 500,
+      width: 1500,
+    },
+    menuItems: enableNFTs ? ['library', 'nft'] : ['library'],
+    onChangeImage: onChangeImage,
     onRemoveImage: () => {
       onRemoveField({ key: 'header' });
       setCoverUrl('');
       setCoverMetadata(undefined);
       setDisabled(false);
+    },
+    onUploadError: () => {
+      onBlurField({ key: 'header', value: '' });
+      setCoverUrl('');
     },
     onUploading: () => setDisabled(true),
     onUploadSuccess: ({ data }: { data: UploadImageReturnData }) => {


### PR DESCRIPTION
Fixes TEAM2-385
Figma link (if any):

## What changed (plus any additional context for devs)
adds image sizing for avatar uploads + moves fn to callback & adds error reset


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
header/avatar should upload normally


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
