### PR TITLE
Fix context menu post prop rename

### DIFF
--- a/src/components/change-wallet/AddressRow.js
+++ b/src/components/change-wallet/AddressRow.js
@@ -251,9 +251,9 @@ export default function AddressRow({
         {editMode &&
           (android ? (
             <ContextMenuButton
-              handlePressMenuItem={handlePressMenuItem}
               isAnchoredToRight
               menuConfig={editMode ? menuConfig : emptyMenu}
+              onPressMenuItem={handlePressMenuItem}
             >
               <OptionsIcon onPress={NOOP} />
             </ContextMenuButton>

--- a/src/components/coin-row/FastTransactionCoinRow.tsx
+++ b/src/components/coin-row/FastTransactionCoinRow.tsx
@@ -122,8 +122,8 @@ export default React.memo(function TransactionCoinRow({
 
   return (
     <ContextMenuButton
-      handlePressMenuItem={android ? onPressAndroidCallback : noop}
       menuConfig={menuItems}
+      onPressMenuItem={android ? onPressAndroidCallback : noop}
     >
       <ButtonPressAnimation
         onPress={ios ? onPressIOSCallback : noop}


### PR DESCRIPTION
Fixes RNBW-4197
Figma link (if any):

## What changed (plus any additional context for devs)

Prop name changed but it wasn't reflected in PRs that followed the change.

## Screen recordings / screenshots

Before: crash. After: no crash.

## What to test

Context menu in transactions (speed up etc.) and editing wallets in switch wallet sheet.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
