### PR TITLE
profiles: fix da colors

### DIFF
--- a/src/navigation/RegisterENSNavigator.tsx
+++ b/src/navigation/RegisterENSNavigator.tsx
@@ -11,6 +11,7 @@ import ENSIntroSheet from '../screens/ENSIntroSheet';
 import ENSSearchSheet from '../screens/ENSSearchSheet';
 import ScrollPagerWrapper from './ScrollPagerWrapper';
 import { sharedCoolModalTopOffset } from './config';
+import { avatarMetadataAtom } from '@/components/ens-registration/RegistrationAvatar/RegistrationAvatar';
 import { Box } from '@rainbow-me/design-system';
 import { accentColorAtom, REGISTRATION_MODES } from '@rainbow-me/helpers/ens';
 import {
@@ -58,6 +59,7 @@ export default function RegisterENSNavigator() {
   const { height: deviceHeight, isSmallPhone } = useDimensions();
 
   const setAccentColor = useSetRecoilState(accentColorAtom);
+  const setAvatarMetadata = useSetRecoilState(avatarMetadataAtom);
 
   const { colors } = useTheme();
 
@@ -113,6 +115,7 @@ export default function RegisterENSNavigator() {
   useEffect(
     () => () => {
       removeRecordByKey('avatar');
+      setAvatarMetadata(undefined);
       setAccentColor(colors.purple);
       clearValues();
       clearCurrentRegistrationName();
@@ -123,6 +126,7 @@ export default function RegisterENSNavigator() {
       colors.purple,
       removeRecordByKey,
       setAccentColor,
+      setAvatarMetadata,
     ]
   );
 


### PR DESCRIPTION
Fixes RNBW-4158
Figma link (if any):

## What changed (plus any additional context for devs)
we were not reseting the avatarMetadata so the image was still being loaded in after resetting the navigator. now we reset


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://cloud.skylarbarrera.com/Screen-Recording-2022-08-05-13-50-08.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
issue was only works with images, NFTs were never broken. so follow the flow in the ticket 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
