### PR TITLE
Remove the screen under wallet screen after navigating after creating a wallet from seeds

### DIFF
--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -30,7 +30,6 @@ import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import { WalletLoadingStates } from '@rainbow-me/helpers/walletLoadingStates';
 import { walletInit } from '@rainbow-me/model/wallet';
 import { Navigation, useNavigation } from '@rainbow-me/navigation';
-import { useRemoveFirst } from '@rainbow-me/navigation/useRemoveFirst';
 import { walletsLoadState } from '@rainbow-me/redux/wallets';
 import Routes from '@rainbow-me/routes';
 import { ethereumUtils, sanitizeSeedPhrase } from '@rainbow-me/utils';
@@ -237,7 +236,6 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
   );
 
   const dispatch = useDispatch();
-  const removeFirst = useRemoveFirst();
 
   useEffect(() => {
     if (!wasImporting && isImporting) {
@@ -292,7 +290,6 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
                     InteractionManager.runAfterInteractions(() =>
                       setIsWalletLoading(null)
                     );
-                    removeFirst();
                   }
 
                   setTimeout(() => {
@@ -367,7 +364,6 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
     dispatch,
     showImportModal,
     profilesEnabled,
-    removeFirst,
     setIsWalletLoading,
   ]);
 

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -1,5 +1,4 @@
 import { useRoute } from '@react-navigation/core';
-import { useIsFocused } from '@react-navigation/native';
 import { compact, isEmpty, keys } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import Animated from 'react-native-reanimated';
@@ -41,6 +40,7 @@ import {
   emitChartsRequest,
   emitPortfolioRequest,
 } from '@rainbow-me/redux/explorer';
+import Routes from '@rainbow-me/routes';
 import styled from '@rainbow-me/styled-components';
 import { position } from '@rainbow-me/styles';
 
@@ -92,16 +92,17 @@ export default function WalletScreen() {
     isEmpty: isSectionsEmpty,
     briefSectionsData: walletBriefSectionsData,
   } = useWalletSectionsData();
-  const isFocused = useIsFocused();
 
   useEffect(() => {
-    // This is the fix for Android wallet creation bug.
-    if (ios || !isFocused) {
+    // This is the fix for Android wallet creation problem.
+    // We need to remove the welcome screen from the stack.
+    if (ios) {
       return;
     }
-    const numberOfRoutes = dangerouslyGetParent().dangerouslyGetState().routes
-      .length;
-    if (numberOfRoutes === 2) {
+    const isWelcomeScreen =
+      dangerouslyGetParent().dangerouslyGetState().routes[0].name ===
+      Routes.WELCOME_SCREEN;
+    if (isWelcomeScreen) {
       removeFirst();
     }
   }, [dangerouslyGetParent, dangerouslyGetState, removeFirst]);

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -14,6 +14,7 @@ import {
   ScanHeaderButton,
 } from '../components/header';
 import { Page, RowWithMargins } from '../components/layout';
+import { useRemoveFirst } from '@/navigation/useRemoveFirst';
 import useExperimentalFlag, {
   PROFILES,
 } from '@rainbow-me/config/experimentalHooks';
@@ -58,7 +59,12 @@ const WalletPage = styled(Page)({
 
 export default function WalletScreen() {
   const { params } = useRoute();
-  const { setParams } = useNavigation();
+  const {
+    setParams,
+    dangerouslyGetState,
+    dangerouslyGetParent,
+  } = useNavigation();
+  const removeFirst = useRemoveFirst();
   const [initialized, setInitialized] = useState(!!params?.initialized);
   const [portfoliosFetched, setPortfoliosFetched] = useState(false);
   const [fetchedCharts, setFetchedCharts] = useState(false);
@@ -85,6 +91,17 @@ export default function WalletScreen() {
     isEmpty: isSectionsEmpty,
     briefSectionsData: walletBriefSectionsData,
   } = useWalletSectionsData();
+
+  useEffect(() => {
+    if (ios) {
+      return;
+    }
+    const numberOfRoutes = dangerouslyGetParent().dangerouslyGetState().routes
+      .length;
+    if (numberOfRoutes === 2) {
+      removeFirst();
+    }
+  }, [dangerouslyGetParent, dangerouslyGetState, removeFirst]);
 
   const { isEmpty: isAccountEmpty } = useAccountEmptyState(isSectionsEmpty);
 

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -1,4 +1,5 @@
 import { useRoute } from '@react-navigation/core';
+import { useIsFocused } from '@react-navigation/native';
 import { compact, isEmpty, keys } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import Animated from 'react-native-reanimated';
@@ -91,9 +92,11 @@ export default function WalletScreen() {
     isEmpty: isSectionsEmpty,
     briefSectionsData: walletBriefSectionsData,
   } = useWalletSectionsData();
+  const isFocused = useIsFocused();
 
   useEffect(() => {
-    if (ios) {
+    // This is the fix for Android wallet creation bug.
+    if (ios || !isFocused) {
       return;
     }
     const numberOfRoutes = dangerouslyGetParent().dangerouslyGetState().routes


### PR DESCRIPTION
Fixes RNBW-4201
Figma link (if any):

I changed the way we remove the stack so this is not vulnerable to the race condition while creating the wallet. Previously this was possible that we wanted to remove the Welcome screen before having a new screen set up. Here, I moved the logic to the wallet component so this is 100% that the other component exists and we can remove the one beneath. 


## What changed (plus any additional context for devs)


https://user-images.githubusercontent.com/25709300/183224801-e8400fde-149c-42f4-a2a8-e3bc8389f31d.mov



## What to test
Create a wallet from seeds, try to "dismiss" the wallet sheen (see if there's a welcome screen below), and check if the navigation is generally not broken. 