### PR TITLE
Profiles: Refactor & fix opening ENS NFTs

### DIFF
--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -1,8 +1,5 @@
-import { useRoute } from '@react-navigation/core';
 import React, { Fragment, useCallback, useState } from 'react';
-import { InteractionManager } from 'react-native';
 import { Switch } from 'react-native-gesture-handler';
-import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '../../../navigation/Navigation';
 import { useTheme } from '../../../theme/ThemeContext';
@@ -10,10 +7,13 @@ import { ShimmerAnimation } from '../../animations';
 import ButtonPressAnimation from '../../animations/ButtonPressAnimation';
 import { Icon } from '../../icons';
 import { ImagePreviewOverlayTarget } from '../../images/ImagePreviewOverlay';
-import { UniqueAsset } from '@/entities';
-import { useENSAddress } from '@/hooks';
-import { uniqueTokensQueryKey } from '@/hooks/useFetchUniqueTokens';
-import { isENSNFTRecord, parseENSNFTRecord } from '@/utils';
+import {
+  useAccountSettings,
+  useENSAddress,
+  useFetchUniqueTokens,
+  useOpenENSNFTHandler,
+} from '@/hooks';
+import { AppState } from '@/redux/store';
 import {
   Bleed,
   Box,
@@ -24,7 +24,6 @@ import {
   useForegroundColor,
 } from '@rainbow-me/design-system';
 import { ImgixImage } from '@rainbow-me/images';
-import { AppState } from '@rainbow-me/redux/store';
 import Routes from '@rainbow-me/routes';
 
 export function InfoRowSkeleton() {
@@ -201,63 +200,23 @@ function ImageValue({
   url?: string;
   value?: string;
 }) {
-  const isNFTImage = isENSNFTRecord(value);
-  const {
-    params: { external },
-  } = useRoute<any>();
+  const { accountAddress } = useAccountSettings();
 
-  const enableZoomOnPress = !isNFTImage;
+  const { data: address } = useENSAddress(ensName || '');
 
-  const { data: profileAddress } = useENSAddress(ensName || '');
-
-  const uniqueTokens = useSelector(
+  const uniqueTokensAccount = useSelector(
     ({ uniqueTokens }: AppState) => uniqueTokens.uniqueTokens
   );
-  const { data: uniqueTokensProfile } = useQuery<UniqueAsset[]>(
-    uniqueTokensQueryKey({ address: profileAddress || '' }),
-    // We just want to watch for changes in the query key,
-    // so just supplying a noop function & staleTime of Infinity.
-    async () => [],
-    { staleTime: Infinity }
-  );
+  const { data: uniqueTokensProfile } = useFetchUniqueTokens({
+    address: address ?? '',
+    // Don't want to refetch tokens if we already have them.
+    staleTime: Infinity,
+  });
+  const isSelf = address === accountAddress;
+  const uniqueTokens = isSelf ? uniqueTokensAccount : uniqueTokensProfile;
 
-  const { goBack, navigate } = useNavigation();
-  const onPress = useCallback(() => {
-    if (!isNFTImage || !value) return;
-
-    const { contractAddress, tokenId } = parseENSNFTRecord(value);
-    const localUniqueTokens = external ? uniqueTokensProfile : uniqueTokens;
-    const uniqueToken = localUniqueTokens?.find(token => {
-      return (
-        token.asset_contract.address?.toLowerCase() ===
-          contractAddress?.toLowerCase() &&
-        token.id?.toLowerCase() === tokenId?.toLowerCase()
-      );
-    });
-
-    if (!uniqueToken) return;
-    goBack();
-    InteractionManager.runAfterInteractions(() => {
-      navigate(Routes.EXPANDED_ASSET_SHEET, {
-        asset: uniqueToken,
-        backgroundOpacity: 1,
-        cornerRadius: 'device',
-        external: true,
-        springDamping: 1,
-        topOffset: 0,
-        transitionDuration: 0.25,
-        type: 'unique_token',
-      });
-    });
-  }, [
-    external,
-    goBack,
-    isNFTImage,
-    navigate,
-    uniqueTokens,
-    uniqueTokensProfile,
-    value,
-  ]);
+  const { onPress } = useOpenENSNFTHandler({ uniqueTokens, value });
+  const enableZoomOnPress = !onPress;
 
   if (!url) return null;
   return (

--- a/src/components/expanded-state/ens/ProfileInfoSection.tsx
+++ b/src/components/expanded-state/ens/ProfileInfoSection.tsx
@@ -33,14 +33,10 @@ export default function ProfileInfoSection({
 }) {
   const recordsArray = useMemo(
     () =>
-      Object.entries(records || {})
-        .filter(([key]) => !omitRecordKeys.includes(key as ENS_RECORDS))
-        .map(([key, value]) =>
-          key === 'avatar' || key === 'header'
-            ? [key, images?.[key]?.imageUrl as string]
-            : [key, value]
-        ),
-    [images, records]
+      Object.entries(records || {}).filter(
+        ([key]) => !omitRecordKeys.includes(key as ENS_RECORDS)
+      ),
+    [records]
   );
 
   const [topRecords, otherRecords] = useMemo(() => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -68,6 +68,7 @@ export { default as useENSRegistrationStepHandler } from './useENSRegistrationSt
 export { default as useENSRegistrationCosts } from './useENSRegistrationCosts';
 export { default as useENSRegistrationForm } from './useENSRegistrationForm';
 export { default as useENSSearch } from './useENSSearch';
+export { default as useENSUniqueToken } from './useENSUniqueToken';
 export { default as useExpandedStateNavigation } from './useExpandedStateNavigation';
 export { default as useExternalWalletSectionsData } from './useExternalWalletSectionsData';
 export { default as useFetchHiddenTokens } from './useFetchHiddenTokens';
@@ -97,6 +98,7 @@ export { default as useMagicAutofocus } from './useMagicAutofocus';
 export { default as useManageCloudBackups } from './useManageCloudBackups';
 export { default as useMaxInputBalance } from './useMaxInputBalance';
 export { default as useUniqueToken } from './useUniqueToken';
+export { default as useOpenENSNFTHandler } from './useOpenENSNFTHandler';
 export { default as useOpenInvestmentCards } from './useOpenInvestmentCards';
 export { default as useOpenSavings } from './useOpenSavings';
 export { default as useOpenSmallBalances } from './useOpenSmallBalances';

--- a/src/hooks/useENSUniqueToken.ts
+++ b/src/hooks/useENSUniqueToken.ts
@@ -1,0 +1,22 @@
+import { UniqueAsset } from '@/entities';
+import { isENSNFTRecord, parseENSNFTRecord } from '@/utils';
+
+/** @description Retrieves the unique token corresponding to an ENS NFT record. */
+export default function useENSUniqueToken({
+  uniqueTokens,
+  value,
+}: {
+  uniqueTokens?: UniqueAsset[];
+  value?: string;
+}) {
+  if (!value || !isENSNFTRecord(value)) return undefined;
+  const { contractAddress, tokenId } = parseENSNFTRecord(value);
+  const uniqueToken = uniqueTokens?.find(token => {
+    return (
+      token.asset_contract.address?.toLowerCase() ===
+        contractAddress?.toLowerCase() &&
+      token.id?.toLowerCase() === tokenId?.toLowerCase()
+    );
+  });
+  return uniqueToken;
+}

--- a/src/hooks/useExternalWalletSectionsData.ts
+++ b/src/hooks/useExternalWalletSectionsData.ts
@@ -7,16 +7,18 @@ import { buildBriefUniqueTokenList } from '@rainbow-me/helpers/assets';
 
 export default function useExternalWalletSectionsData({
   address,
+  infinite = false,
   type,
 }: {
   address?: string;
+  infinite?: boolean;
   type?: AssetListType;
 }) {
   const {
     data: uniqueTokens,
     isLoading: isUniqueTokensLoading,
     isSuccess: isUniqueTokensSuccess,
-  } = useFetchUniqueTokens({ address });
+  } = useFetchUniqueTokens({ address, infinite });
   const { data: hiddenTokens } = useFetchHiddenTokens({ address });
   const { data: showcaseTokens } = useFetchShowcaseTokens({ address });
 

--- a/src/hooks/useOpenENSNFTHandler.ts
+++ b/src/hooks/useOpenENSNFTHandler.ts
@@ -1,0 +1,39 @@
+import { useRoute } from '@react-navigation/core';
+import useENSUniqueToken from './useENSUniqueToken';
+import { UniqueAsset } from '@/entities';
+import { useNavigation } from '@/navigation';
+import Routes from '@rainbow-me/routes';
+
+/** @description Returns a press handler to open an ENS NFT in an expanded state sheet. */
+export default function useOpenENSNFTHandler({
+  uniqueTokens,
+  value,
+}: {
+  uniqueTokens?: UniqueAsset[];
+  value?: string;
+}) {
+  const { name } = useRoute();
+  const { goBack, navigate } = useNavigation();
+  const uniqueToken = useENSUniqueToken({
+    uniqueTokens,
+    value,
+  });
+  const onPress = uniqueToken
+    ? () => {
+        if (name === Routes.EXPANDED_ASSET_SHEET) goBack();
+        navigate(Routes.EXPANDED_ASSET_SHEET, {
+          asset: uniqueToken,
+          backgroundOpacity: 1,
+          cornerRadius: 'device',
+          external: true,
+          springDamping: 1,
+          topOffset: 0,
+          transitionDuration: 0.25,
+          type: 'unique_token',
+        });
+      }
+    : undefined;
+  return {
+    onPress,
+  };
+}

--- a/src/redux/uniqueTokens.ts
+++ b/src/redux/uniqueTokens.ts
@@ -345,7 +345,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
     timeAgo: { hours: 48 },
   });
   if (ensTokens.length > 0) {
-    uniqueTokens = uniqBy([...uniqueTokens, ...ensTokens], 'id');
+    uniqueTokens = uniqBy([...uniqueTokens, ...ensTokens], 'uniqueId');
   }
 
   // NFT Fetching clean up

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -62,6 +62,7 @@ export default function ProfileSheet() {
     briefSectionsData,
   } = useExternalWalletSectionsData({
     address: profileAddress || undefined,
+    infinite: true,
   });
 
   const colorIndex = useMemo(


### PR DESCRIPTION
Fixes TEAM2-387

## What changed (plus any additional context for devs)

This PR fixes an issue where pressing on ENS NFTs wouldn't open the expanded state (and instead open a zoomable preview instead). I also composed our usages of the logic to do this into a hook (since we were repeating a lot of code).

I also refactored `useFetchUniqueTokens` to be a bit more performant (we were previously fetching unnecessarily), and made it possible to only fetch tokens in-memory when needed (instead of infinite fetching every time). We can definitely make this hook better for infinite fetching, but we can rethink that for the Code Foundations project.


## Screen recordings / screenshots

https://www.loom.com/share/51502d82859d4c45974e3ce9f1e28b25


## What to test

- On the profile screen, ensure that NFT avatar/cover opens the NFT expanded state,
- On the profile screen, ensure that image avatar/cover opens a zoomable preview,
- On the ENS expanded state, ensure that NFT cover opens it's NFT expanded state,
- On the ENS expanded state, ensure that image cover opens a zoomable preview.

