### PR TITLE
Profiles: make hidden nfts work with profiles

### DIFF
--- a/e2e/hiddenTokensFlow.spec.js
+++ b/e2e/hiddenTokensFlow.spec.js
@@ -17,7 +17,7 @@ describe('Hidden tokens flow', () => {
   it('NFT is hideable', async () => {
     // open ENS and tap on our ENS NFT
     await Helpers.swipe('wallet-screen', 'up', 'slow');
-    await Helpers.tapByText('ENS');
+    await Helpers.tap('token-family-header-ENS');
     await Helpers.swipe('wallet-screen', 'up', 'slow');
     await Helpers.waitAndTap('wrapped-nft-rainbowtestwallet.eth');
     await Helpers.waitAndTap('unique-token-expanded-state-context-menu-button');

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -1,6 +1,7 @@
 import lang from 'i18n-js';
 import { chunk, compact, groupBy, isEmpty, slice, sortBy } from 'lodash';
 import { add, convertAmountToNativeDisplay, greaterThan } from './utilities';
+import { AssetListType } from '@/components/asset-list/RecyclerAssetList2';
 import store from '@rainbow-me/redux/store';
 import {
   ETH_ADDRESS,
@@ -325,7 +326,7 @@ export const buildBriefUniqueTokenList = (
   selectedShowcaseTokens: any,
   sellingTokens: any[] = [],
   hiddenTokens: string[] = [],
-  listType: any
+  listType: AssetListType = 'wallet'
 ) => {
   const hiddenUniqueTokensIds = uniqueTokens
     .filter(({ fullUniqueId }: any) => hiddenTokens.includes(fullUniqueId))
@@ -414,7 +415,7 @@ export const buildBriefUniqueTokenList = (
 
     result.push({ type: 'NFT_SPACE_AFTER', uid: `${family}-space-after` });
   }
-  if (hiddenUniqueTokensIds.length > 0) {
+  if (hiddenUniqueTokensIds.length > 0 && listType === 'wallet') {
     result.push({
       // @ts-expect-error "name" does not exist in type.
       name: lang.t('button.hidden'),

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -70,6 +70,7 @@ export { default as useENSRegistrationForm } from './useENSRegistrationForm';
 export { default as useENSSearch } from './useENSSearch';
 export { default as useExpandedStateNavigation } from './useExpandedStateNavigation';
 export { default as useExternalWalletSectionsData } from './useExternalWalletSectionsData';
+export { default as useFetchHiddenTokens } from './useFetchHiddenTokens';
 export { default as useFetchUniqueTokens } from './useFetchUniqueTokens';
 export { default as useENSFirstTransactionTimestamp } from './useENSFirstTransactionTimestamp';
 export { default as useGas } from './useGas';

--- a/src/hooks/useExternalWalletSectionsData.ts
+++ b/src/hooks/useExternalWalletSectionsData.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { AssetListType } from '../components/asset-list/RecyclerAssetList2';
+import useFetchHiddenTokens from './useFetchHiddenTokens';
 import useFetchShowcaseTokens from './useFetchShowcaseTokens';
 import useFetchUniqueTokens from './useFetchUniqueTokens';
 import { buildBriefUniqueTokenList } from '@rainbow-me/helpers/assets';
@@ -16,6 +17,7 @@ export default function useExternalWalletSectionsData({
     isLoading: isUniqueTokensLoading,
     isSuccess: isUniqueTokensSuccess,
   } = useFetchUniqueTokens({ address });
+  const { data: hiddenTokens } = useFetchHiddenTokens({ address });
   const { data: showcaseTokens } = useFetchShowcaseTokens({ address });
 
   const sellingTokens = useMemo(
@@ -30,11 +32,11 @@ export default function useExternalWalletSectionsData({
             uniqueTokens,
             showcaseTokens,
             sellingTokens,
-            [],
+            hiddenTokens,
             type
           )
         : [],
-    [uniqueTokens, showcaseTokens, sellingTokens, type]
+    [uniqueTokens, showcaseTokens, sellingTokens, hiddenTokens, type]
   );
 
   return {

--- a/src/hooks/useFetchHiddenTokens.ts
+++ b/src/hooks/useFetchHiddenTokens.ts
@@ -1,0 +1,39 @@
+import { useQuery } from 'react-query';
+import useAccountSettings from './useAccountSettings';
+import { getHiddenTokens } from '@rainbow-me/handlers/localstorage/accountLocal';
+import { getPreference } from '@rainbow-me/model/preferences';
+
+export const hiddenTokensQueryKey = ({ address }: { address?: string }) => [
+  'hidden-tokens',
+  address,
+];
+
+export default function useFetchHiddenTokens({
+  address,
+}: {
+  address?: string;
+}) {
+  const { network } = useAccountSettings();
+
+  return useQuery(
+    hiddenTokensQueryKey({ address }),
+    async () => {
+      if (!address) return;
+      let hiddenTokens = await getHiddenTokens(address, network);
+      const hiddenTokensFromCloud = (await getPreference('hidden', address)) as
+        | any
+        | undefined;
+      if (
+        hiddenTokensFromCloud?.hidden?.ids &&
+        hiddenTokensFromCloud?.hidden?.ids.length > 0
+      ) {
+        hiddenTokens = hiddenTokensFromCloud.hidden.ids;
+      }
+
+      return hiddenTokens as string[];
+    },
+    {
+      enabled: Boolean(address),
+    }
+  );
+}


### PR DESCRIPTION
Fixes TEAM2-389

## What changed (plus any additional context for devs)

This PR makes Hidden NFTs work with profiles. Since we don't use redux for data fetching on the profiles screen, need to add interop. Obviously having duplicate code in 2 diff places is not good, but we will need to refactor this in Code Foundations to be universal.

## Screen recordings / screenshots

https://user-images.githubusercontent.com/7336481/183329744-cf4a3386-625e-4636-84c7-055ea80fcae5.mp4

## What to test

Hide an NFT in a wallet, and ensure that it is hidden on the profiles screen.
