### PR TITLE
PIN confirmation skipping

### DIFF
--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -40,6 +40,7 @@ const PinAuthenticationScreen = () => {
 
   const [attemptsLeft, setAttemptsLeft] = useState(MAX_ATTEMPTS);
   const [value, setValue] = useState('');
+  const [isLoading, setLoading] = useState(false);
   const [initialPin, setInitialPin] = useState('');
   const [actionType, setActionType] = useState(
     params.validPin ? 'authentication' : 'creation'
@@ -165,6 +166,7 @@ const PinAuthenticationScreen = () => {
               }, 300);
             }
           } else if (actionType === 'creation') {
+            setLoading(true);
             // Ask for confirmation
             setActionType('confirmation');
             // Store the pin in state so we can compare with the conf.
@@ -173,9 +175,11 @@ const PinAuthenticationScreen = () => {
             // Clear the pin
             setTimeout(() => {
               setValue('');
+              setLoading(false);
               return;
             }, 300);
           } else {
+            if (isLoading) return '';
             // Confirmation
             const valid = initialPin === nextValue;
             if (!valid) {
@@ -193,7 +197,7 @@ const PinAuthenticationScreen = () => {
         return nextValue;
       });
     },
-    [actionType, attemptsLeft, goBack, initialPin, onShake, params]
+    [actionType, attemptsLeft, goBack, initialPin, onShake, params, isLoading]
   );
 
   const { colors } = useTheme();


### PR DESCRIPTION
Fixes RNBW-4093
Figma link (if any):

## What changed (plus any additional context for devs)
Due to the delay, we were skipping PIN confirmation. But Pin worked fine

https://linear.app/rainbow/issue/RNBW-4093/android-skipping-pin-confirmation

## Screen recordings / screenshots
Before: https://user-images.githubusercontent.com/48593211/183376678-d780d9ab-4cb6-42b9-850e-8148d793c634.mp4

After: https://user-images.githubusercontent.com/48593211/183376211-4e6ab3ce-fee9-402d-b6d6-3f557f1625d2.mp4


## What to test
Go to wallet creation and quick enter PIN, you should fill PIN and be able to confirm it


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
