### PR TITLE
Profiles: Tweak android padding

### DIFF
--- a/src/screens/ENSIntroSheet.tsx
+++ b/src/screens/ENSIntroSheet.tsx
@@ -150,6 +150,7 @@ export default function ENSIntroSheet() {
       background="body"
       paddingTop={{ custom: topPadding }}
       style={{ height: contentHeight }}
+      {...(android && { paddingBottom: { custom: 20 } })}
       testID="ens-intro-sheet"
     >
       <Inset top={isSmallPhone ? '15px' : '36px'}>


### PR DESCRIPTION
Fixes RNBW-4205
Figma link (if any):

## What changed (plus any additional context for devs)
- added extra bottom padding to ens intro sheet for android

## Screen recordings / screenshots

Pixel 3a sim:
![Screenshot_20220808_101939](https://user-images.githubusercontent.com/15272675/183477931-4348170e-36e8-4f16-b3bc-3899533d0de7.png)

Physical galaxy a52:
![Screenshot_20220808-102549_Rainbow](https://user-images.githubusercontent.com/15272675/183477946-8a9204ee-b2d2-464e-b692-b6ec1d14d17a.jpg)


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
