### PR TITLE
Android: Fix non-centered buttons in ENS reg

### DIFF
--- a/src/components/ens-registration/TextRecordsForm/SelectableButton.tsx
+++ b/src/components/ens-registration/TextRecordsForm/SelectableButton.tsx
@@ -42,7 +42,11 @@ export default function SelectableButton({
           height={`${height}px`}
           justifyContent="center"
           paddingHorizontal="8px"
-          style={{ borderColor: borderColor, borderWidth: 2 }}
+          style={{
+            borderColor: borderColor,
+            borderWidth: 2,
+            paddingBottom: android ? 2 : 0,
+          }}
         >
           <Text align="center" color="accent" size="16px" weight="heavy">
             {children}

--- a/src/components/inputs/InlineField.tsx
+++ b/src/components/inputs/InlineField.tsx
@@ -143,7 +143,7 @@ export default function InlineField({
       <Column>
         <Inline alignVertical="center" space="2px" wrap={false}>
           {startsWith && (
-            <Inset top={ios ? '2px' : undefined}>
+            <Inset top={ios ? '2px' : '1px'}>
               <Text color="secondary30" weight="heavy">
                 {startsWith}
               </Text>

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -461,9 +461,11 @@ function HideKeyboardButton({ color }: { color: string }) {
             width={{ custom: 30 }}
           >
             <Cover alignHorizontal="center" alignVertical="center">
-              <Text align="center" color="primary" size="14px" weight="heavy">
-                􀆈
-              </Text>
+              <Box paddingTop={android ? '4px' : '2px'}>
+                <Text align="center" color="primary" size="14px" weight="heavy">
+                  􀆈
+                </Text>
+              </Box>
             </Cover>
           </Box>
         </AccentColorProvider>


### PR DESCRIPTION
Fixes RNBW-4185

## What changed (plus any additional context for devs)
- Fixed alignment of the dismiss keyboard button in ENS text records form on Android & iOS
- Fixed alignment of buttons for choosing ENS text records in the form on Android
- Tweaked vertical alignment of @ and input on both iOS and Android

Did not manage to fix the `Name` and `Bio` inputs shifting when going from placeholder to text. It requires a bigger design system change that touches all inputs, so I made a different ticket for that issue in Linear to do after release.


## What to test
ENS registration text records form.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
