### PR TITLE
[TEAM2-328] Use Unique Id Pattern to Grab No Mainnet Addy Prices

### DIFF
--- a/src/raps/actions/swap.ts
+++ b/src/raps/actions/swap.ts
@@ -111,19 +111,9 @@ const swap = async (
     dispatch(
       additionalDataUpdateL2AssetToWatch({
         hash: swap?.hash || '',
-        inputCurrency: {
-          address: inputCurrency?.address,
-          decimals: inputCurrency?.decimals,
-          mainnetAddress: inputCurrency?.mainnet_address,
-          symbol: inputCurrency?.symbol,
-        },
+        inputCurrency,
         network: ethereumUtils.getNetworkFromChainId(Number(chainId)),
-        outputCurrency: {
-          address: outputCurrency?.address,
-          decimals: outputCurrency?.decimals,
-          mainnetAddress: outputCurrency?.mainnet_address,
-          symbol: outputCurrency?.symbol,
-        },
+        outputCurrency,
         userAddress: accountAddress,
       })
     );

--- a/src/redux/additionalAssetsData.ts
+++ b/src/redux/additionalAssetsData.ts
@@ -135,7 +135,9 @@ const getUpdatedL2AssetBalance = async (
   );
   const uniqueId = `${asset.address?.toLowerCase()}_${network}`;
   const fallbackAsset =
+    ethereumUtils.getAccountAsset(uniqueId) ||
     ethereumUtils.getAccountAsset(mainnet_address) ||
+    genericAssets[asset?.address] ||
     genericAssets[mainnet_address];
   return {
     ...fallbackAsset,

--- a/src/redux/additionalAssetsData.ts
+++ b/src/redux/additionalAssetsData.ts
@@ -1,7 +1,7 @@
 import { EthereumAddress } from '@rainbow-me/swaps';
 import { captureException } from '@sentry/react-native';
 import { dataUpdateAsset } from './data';
-import { ParsedAddressAsset } from '@rainbow-me/entities';
+import { ParsedAddressAsset, SwappableAsset } from '@rainbow-me/entities';
 import { getOnchainAssetBalance } from '@rainbow-me/handlers/assets';
 import { getCoingeckoIds } from '@rainbow-me/handlers/dispersion';
 import { getProviderForNetwork } from '@rainbow-me/handlers/web3';
@@ -38,18 +38,8 @@ type AdditionalAssetDataAction =
   | AdditionalAssetDataDeleteL2AssetToWatch;
 
 type L2AssetToWatch = {
-  inputCurrency: {
-    address: EthereumAddress;
-    decimals: number;
-    mainnetAddress: EthereumAddress;
-    symbol: string;
-  };
-  outputCurrency: {
-    address: EthereumAddress;
-    decimals: number;
-    mainnetAddress: EthereumAddress;
-    symbol: string;
-  };
+  inputCurrency: SwappableAsset;
+  outputCurrency: SwappableAsset;
   userAddress: string;
   network: Network;
   id: string;
@@ -82,18 +72,8 @@ export const additionalDataCoingeckoIds = async (
 };
 
 export const additionalDataUpdateL2AssetToWatch = (data: {
-  inputCurrency: {
-    address: EthereumAddress;
-    decimals: number;
-    mainnetAddress: EthereumAddress;
-    symbol: string;
-  };
-  outputCurrency: {
-    address: EthereumAddress;
-    decimals: number;
-    mainnetAddress: EthereumAddress;
-    symbol: string;
-  };
+  inputCurrency: SwappableAsset;
+  outputCurrency: SwappableAsset;
   userAddress: string;
   network: Network;
   hash: string;
@@ -113,19 +93,13 @@ export const additionalDataUpdateL2AssetToWatch = (data: {
 };
 
 const getUpdatedL2AssetBalance = async (
-  asset: {
-    address: string;
-    decimals: number;
-    mainnetAddress: EthereumAddress;
-    symbol: string;
-  },
+  asset: SwappableAsset,
   genericAssets: {
     [assetAddress: string]: ParsedAddressAsset;
   },
   network: Network,
   userAddress: EthereumAddress
 ) => {
-  const mainnet_address = asset.mainnetAddress?.toLowerCase();
   const provider = await getProviderForNetwork(network);
   const assetBalance = await getOnchainAssetBalance(
     asset,
@@ -136,9 +110,9 @@ const getUpdatedL2AssetBalance = async (
   const uniqueId = `${asset.address?.toLowerCase()}_${network}`;
   const fallbackAsset =
     ethereumUtils.getAccountAsset(uniqueId) ||
-    ethereumUtils.getAccountAsset(mainnet_address) ||
+    ethereumUtils.getAccountAsset(asset?.mainnet_address) ||
     genericAssets[asset?.address] ||
-    genericAssets[mainnet_address];
+    (asset?.mainnet_address && genericAssets[asset?.mainnet_address]);
   return {
     ...fallbackAsset,
     ...asset,
@@ -147,7 +121,6 @@ const getUpdatedL2AssetBalance = async (
       ...(assetBalance || {}),
     },
     id: asset.address,
-    mainnet_address: asset.mainnetAddress?.toLowerCase(),
     type: network,
     uniqueId,
   };

--- a/src/redux/explorer.ts
+++ b/src/redux/explorer.ts
@@ -872,9 +872,11 @@ const l2AddressAssetsReceived = (
     | undefined = message?.payload?.assets?.map(asset => {
     const mainnetAddress = toLower(asset?.asset?.mainnet_address);
     const fallbackAsset =
-      mainnetAddress &&
-      (ethereumUtils.getAccountAsset(mainnetAddress) ||
-        genericAssets[mainnetAddress]);
+      (mainnetAddress &&
+        (ethereumUtils.getAccountAsset(mainnetAddress) ||
+          genericAssets[mainnetAddress])) ||
+      ethereumUtils.getAccountAsset(asset?.asset?.asset_code) ||
+      genericAssets[asset?.asset?.asset_code];
 
     if (fallbackAsset) {
       return {

--- a/src/redux/explorer.ts
+++ b/src/redux/explorer.ts
@@ -871,11 +871,12 @@ const l2AddressAssetsReceived = (
     | { asset: ZerionAsseWithL2Fields }[]
     | undefined = message?.payload?.assets?.map(asset => {
     const mainnetAddress = toLower(asset?.asset?.mainnet_address);
+    const uniqueId = `${asset?.asset?.asset_code}_${asset?.asset?.network}`;
     const fallbackAsset =
       (mainnetAddress &&
         (ethereumUtils.getAccountAsset(mainnetAddress) ||
           genericAssets[mainnetAddress])) ||
-      ethereumUtils.getAccountAsset(asset?.asset?.asset_code) ||
+      ethereumUtils.getAccountAsset(uniqueId) ||
       genericAssets[asset?.asset?.asset_code];
 
     if (fallbackAsset) {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
OP+GMX do not have mainnet addresses. When updating L2 balances we now create a unique id to check account assets or generic assets for pricing information when adding the updated balance. I verified with @brunobar79 that this is, unfortunately for now, a common pattern within the app.

## Screen recordings / screenshots
Swapping for OP with an existing OP balance: https://recordit.co/NtihedGx0a
Swapping for OP without an OP balance: https://recordit.co/EPF3Cm3Yuf

## What to test
Test that OP/GMX do not disappear from the assets list when:
* Swapping OP on optimism (input and output)
* Swapping GMX on arbitrum (input and output)
* I included a video of swapping for OP without an existing OP balance to show that this logic doesn't mess with asset discovery, but we should probably check that too.

I opened this in favor of the previous PR: https://github.com/rainbow-me/rainbow/pull/3889 because I wanted to preserve the discussion there in case anyone wanted to reference it.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
