### PR TITLE
Fix ENS registration keyboard popping up in sheet

### DIFF
--- a/src/components/ens-registration/SearchInput/SearchInput.tsx
+++ b/src/components/ens-registration/SearchInput/SearchInput.tsx
@@ -43,8 +43,8 @@ const SearchInput = ({
     undefined,
     // On Android, should show keyboard upon navigation focus.
     true,
-    // On iOS, defer keyboard display until interactions finished (screen transition).
-    ios
+    // On iOS, don’t defer keyboard display until interactions finished (screen transition).
+    false
   );
 
   const height = 64;


### PR DESCRIPTION
Fixes RNBW-4223

## What changed (plus any additional context for devs)
Removed the `showAfterInteractions` option for iOS which was causing keyboard issues when bottom sheets in the ENS registration flow popped up.


## Screen recordings / screenshots

https://user-images.githubusercontent.com/6843656/183540155-2ff70f1a-ced4-4ae8-a0b8-b98c31860d5b.mp4




## What to test
Trying to finish ENS registration.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
