### PR TITLE
profiles: view on web ens name

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -240,7 +240,7 @@ const UniqueTokenExpandedState = ({
 }: UniqueTokenExpandedStateProps) => {
   const isSupportedOnRainbowWeb = getIsSupportedOnRainbowWeb(asset.network);
 
-  const { accountAddress, accountENS } = useAccountProfile();
+  const { accountAddress } = useAccountProfile();
   const { height: deviceHeight, width: deviceWidth } = useDimensions();
   const { navigate, setOptions } = useNavigation();
   const { colors, isDarkMode } = useTheme();
@@ -343,7 +343,7 @@ const UniqueTokenExpandedState = ({
     [showcaseTokens, uniqueId]
   );
 
-  const rainbowWebUrl = buildRainbowUrl(asset, accountENS, accountAddress);
+  const rainbowWebUrl = buildRainbowUrl(asset, cleanENSName, accountAddress);
 
   const imageColor =
     // @ts-expect-error image_url could be null or undefined?

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -350,13 +350,14 @@ const UniqueTokenExpandedStateHeader = ({
     },
     [
       asset,
+      rainbowWebUrl,
       setClipboard,
-      addHiddenToken,
-      removeHiddenToken,
-      removeShowcaseToken,
       isHiddenAsset,
-      isShowcaseAsset,
       goBack,
+      removeHiddenToken,
+      addHiddenToken,
+      isShowcaseAsset,
+      removeShowcaseToken,
     ]
   );
 


### PR DESCRIPTION
Fixes TEAM2-402
Figma link (if any):

## What changed (plus any additional context for devs)

we were using `accountENS` by default to "View on web" links, now we use `cleanENSName` to open the ens name according to the NFT

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/c6c986fd3bba404fae55eba3116c4a28

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


- watch account a.eth
- go and search for b.eth profile
- go to an ENS NFT and press "View on web", on android choose a browser and the app to open the link, both should open the ENS profile

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
