### PR TITLE
Profiles: Image edge cases

### DIFF
--- a/src/components/ens-profile/ProfileAvatar/ProfileAvatar.tsx
+++ b/src/components/ens-profile/ProfileAvatar/ProfileAvatar.tsx
@@ -61,6 +61,7 @@ export default function ProfileAvatar({
           imageUrl={avatarUrl || ''}
           onPress={handleOnPress}
           topOffset={imagePreviewOverlayTopOffset}
+          zIndex={2}
         >
           <>
             {showSkeleton && (

--- a/src/components/ens-profile/ProfileCover/ProfileCover.tsx
+++ b/src/components/ens-profile/ProfileCover/ProfileCover.tsx
@@ -77,6 +77,7 @@ export default function ProfileCover({
             imageUrl={coverUrl || ''}
             onPress={handleOnPress}
             topOffset={imagePreviewOverlayTopOffset}
+            zIndex={1}
           >
             <Box
               as={ImgixImage}

--- a/src/components/ens-profile/ProfileSheetHeader.tsx
+++ b/src/components/ens-profile/ProfileSheetHeader.tsx
@@ -11,6 +11,7 @@ import RecordTags, {
   Placeholder as RecordTagsPlaceholder,
 } from './RecordTags/RecordTags';
 import { abbreviateEnsForDisplay } from '@/utils/abbreviations';
+import { getLowResUrl } from '@/utils/getLowResUrl';
 import { PROFILES, useExperimentalFlag } from '@rainbow-me/config';
 import {
   Bleed,
@@ -22,7 +23,6 @@ import {
   Inset,
   Stack,
 } from '@rainbow-me/design-system';
-import { maybeSignUri } from '@rainbow-me/handlers/imgix';
 import { ENS_RECORDS } from '@rainbow-me/helpers/ens';
 import {
   useENSAddress,
@@ -77,7 +77,7 @@ export default function ProfileSheetHeader({
   });
   const enableZoomOnPressAvatar = enableZoomableImages && !onPressAvatar;
 
-  const coverUrl = maybeSignUri(cover?.imageUrl || undefined, { w: 400 });
+  const coverUrl = getLowResUrl(cover?.imageUrl || '', { w: 400 });
   const { onPress: onPressCover } = useOpenENSNFTHandler({
     uniqueTokens,
     value: records?.header,

--- a/src/components/images/ImagePreviewOverlay.tsx
+++ b/src/components/images/ImagePreviewOverlay.tsx
@@ -103,6 +103,10 @@ const yOffsetAtom = atomFamily({
   default: 0,
   key: 'imagePreviewOverlay.yOffset',
 });
+const zIndexAtom = atomFamily({
+  default: 0,
+  key: 'imagePreviewOverlay.zIndex',
+});
 
 const ImageOverlayConfigContext = createContext<{
   enableZoom: boolean;
@@ -222,8 +226,10 @@ function ImagePreview({
   const width = useRecoilValue(widthAtom(id));
   const xOffset = useRecoilValue(xOffsetAtom(id));
   const yOffset = useRecoilValue(yOffsetAtom(id));
+  const zIndexOverride = useRecoilValue(zIndexAtom(id));
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const opacity = givenOpacity || useSharedValue(1);
+  const zIndex = zIndexOverride ?? index;
 
   const { colorMode } = useColorMode();
 
@@ -244,7 +250,7 @@ function ImagePreview({
   }, [progress]);
 
   const backgroundMaskStyle = useAnimatedStyle(() => ({
-    zIndex: progress.value > 0 ? index + 1 : index,
+    zIndex: progress.value > 0 ? zIndex + 1 : zIndex,
   }));
   const overlayStyle = useAnimatedStyle(() => ({
     opacity: 1 * progress.value,
@@ -254,10 +260,10 @@ function ImagePreview({
           yPosition.value - (hideStatusBar ? SheetHandleFixedToTopHeight : 0),
       },
     ],
-    zIndex: progress.value > 0 ? index + 2 : -2,
+    zIndex: progress.value > 0 ? zIndex + 2 : -2,
   }));
   const containerStyle = useAnimatedStyle(() => ({
-    zIndex: progress.value > 0 ? index + 10 : index,
+    zIndex: progress.value > 0 ? zIndex + 10 : zIndex,
   }));
 
   const ready =
@@ -411,6 +417,7 @@ export function ImagePreviewOverlayTarget({
   onPress,
   topOffset = 85,
   uri,
+  zIndex = 0,
 }: {
   backgroundMask?: 'avatar';
   borderRadius?: number;
@@ -424,6 +431,7 @@ export function ImagePreviewOverlayTarget({
   hideStatusBar?: boolean;
   imageUrl?: string;
   topOffset?: number;
+  zIndex?: number;
 } & (
   | {
       aspectRatioType?: never;
@@ -459,6 +467,7 @@ export function ImagePreviewOverlayTarget({
   const setImageUrl = useSetRecoilState(imageUrlAtom(id));
   const setXOffset = useSetRecoilState(xOffsetAtom(id));
   const setYOffset = useSetRecoilState(yOffsetAtom(id));
+  const setZIndex = useSetRecoilState(zIndexAtom(id));
 
   useEffect(() => {
     if (backgroundMask) {
@@ -471,11 +480,12 @@ export function ImagePreviewOverlayTarget({
     setHideStatusBar(hideStatusBar);
     setImageUrl(imageUrl);
     setIds(ids => [...ids, id]);
+    setZIndex(zIndex);
   }, [
     backgroundMask,
     borderRadius,
-    enableZoomOnPress,
     disableEnteringWithPinch,
+    enableZoomOnPress,
     hasShadow,
     hideStatusBar,
     id,
@@ -488,6 +498,8 @@ export function ImagePreviewOverlayTarget({
     setHideStatusBar,
     setIds,
     setImageUrl,
+    setZIndex,
+    zIndex,
   ]);
 
   // If we are not given an `aspectRatioType`, then we will need to

--- a/src/ens-avatar/src/specs/erc1155.ts
+++ b/src/ens-avatar/src/specs/erc1155.ts
@@ -29,6 +29,8 @@ export default class ERC1155 {
     ]);
     if (!opts?.allowNonOwnerNFTs && ownerAddress && balance.eq(0)) return null;
 
+    let image;
+
     const { uri: resolvedURI, isOnChain, isEncoded } = resolveURI(tokenURI);
     let _resolvedUri = resolvedURI;
     if (isOnChain) {
@@ -38,10 +40,10 @@ export default class ERC1155 {
           'base64'
         ).toString();
       }
-      return JSON.parse(_resolvedUri);
+      const data = JSON.parse(_resolvedUri);
+      image = svgToPngIfNeeded(data?.image, false);
     }
 
-    let image;
     try {
       const data: UniqueAsset = await apiGetAccountUniqueToken(
         NetworkTypes.mainnet,

--- a/src/ens-avatar/src/specs/erc721.ts
+++ b/src/ens-avatar/src/specs/erc721.ts
@@ -35,6 +35,8 @@ export default class ERC721 {
       return null;
     }
 
+    let image;
+
     const { uri: resolvedURI, isOnChain, isEncoded } = resolveURI(tokenURI);
     let _resolvedUri = resolvedURI;
     if (isOnChain) {
@@ -44,10 +46,10 @@ export default class ERC721 {
           'base64'
         ).toString();
       }
-      return JSON.parse(_resolvedUri);
+      const data = JSON.parse(_resolvedUri);
+      image = svgToPngIfNeeded(data?.image, false);
     }
 
-    let image;
     try {
       const data: UniqueAsset = await apiGetAccountUniqueToken(
         NetworkTypes.mainnet,
@@ -57,7 +59,7 @@ export default class ERC721 {
       image = svgToPngIfNeeded(data?.image_url, false) || data?.lowResUrl;
     } catch (error) {
       const data = await getNFTByTokenId({ contractAddress, tokenId: tokenID });
-      image = data?.previews?.image_medium_url;
+      image = svgToPngIfNeeded(data?.previews?.image_medium_url, false);
       if (!image) throw new Error('no image found');
     }
     return { image };

--- a/src/utils/getLowResUrl.ts
+++ b/src/utils/getLowResUrl.ts
@@ -3,22 +3,33 @@ import { CardSize } from '../components/unique-token/CardSize';
 import { imageToPng } from '@rainbow-me/handlers/imgix';
 
 export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
-const size = Math.floor((Math.ceil(CardSize) * PixelRatio.get()) / 3);
 
-const isValidCDNUrl = (url: string) => {
+const getCDNUrl = (url: string, { w }: { w: number }) => {
+  if (!url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) return null;
+
   const splitUrl = url?.split('/');
   const urlTail = splitUrl[splitUrl.length - 1] || '';
 
-  // check if the url does not already contain a modifier (e.g. `...=s128`)
-  if (urlTail.includes('=')) return false;
-
-  return url?.startsWith?.(GOOGLE_USER_CONTENT_URL);
+  if (!urlTail.includes('=')) {
+    // If the tail doesn't already include modifiers, we will add them.
+    return `${url}=w${w}`;
+  }
+  if (urlTail.includes('=w')) {
+    // If the tail includes a width modifier, we will modify it.
+    return url.replace(/=w\d+/, `=w${w}`);
+  }
+  return null;
 };
 
-export const getLowResUrl = (url: string) => {
-  // Check if it is from the given CDN.
-  if (isValidCDNUrl(url)) {
-    return `${url}=w${size}`;
-  }
-  return imageToPng(url, size);
+export const getLowResUrl = (
+  url: string,
+  lowResImageOptions?: { w: number }
+) => {
+  const w =
+    lowResImageOptions?.w ??
+    Math.floor((Math.ceil(CardSize) * PixelRatio.get()) / 3);
+
+  const lowResUrl = imageToPng(url, w);
+  const cdnUrl = getCDNUrl(url, { w });
+  return cdnUrl || lowResUrl;
 };


### PR DESCRIPTION
Fixes TEAM2-395
Fixes TEAM2-401
Fixes TEAM2-400

## What changed (plus any additional context for devs)

This PR fixes 3 bugs that were observed with large sized cover photos & SVG-based cover photos.

- Refactored `getLowResUrl` to better utilize CDN resizing (added in replacing the existing `=w` value)
- Use `getLowResUrl` instead of `maybeSignUri` to take advantage of google CDN resizing
- Convert ENS image SVGs to PNGs
- Fixed an issue where the cover photo would overlap the avatar on the profile sheet if it took longer to load.

## Screen recordings / screenshots

Android:
https://www.loom.com/share/773568badfb7427299ef18cf4300b97a

iOS:
https://www.loom.com/share/1c1f65815aa44d45aa85f5667970647a


## What to test

- Ensure avatar/cover photos still load and render properly
- Ensure SVG cover photos load properly
- Ensure large cover photos load properly

Good test wallets are 0xtester.eth and brdy.eth
