### PR TITLE
Fix send button not pre-filling address in ENS profile

### DIFF
--- a/src/components/ens-profile/ActionButtons/SendButton.tsx
+++ b/src/components/ens-profile/ActionButtons/SendButton.tsx
@@ -7,7 +7,7 @@ import Routes from '@rainbow-me/routes';
 export default function SendButton({ ensName }: { ensName?: string }) {
   const { navigate } = useNavigation();
   const handlePressSend = useCallback(async () => {
-    if (isNativeStackAvailable || android) {
+    if (isNativeStackAvailable) {
       navigate(Routes.SEND_FLOW, {
         params: {
           address: ensName,


### PR DESCRIPTION
Fixes RNBW-4235
Figma link (if any):

## What changed (plus any additional context for devs)

See file: `src/components/sheet/sheet-action-buttons/SendActionButton.js`

IMO the `if` should only check for `isNativeStackAvailable`.

I tested on Android and now it works.

## Screen recordings / screenshots

No visual differences, just behavior.


## What to test

Run on iOS and Android. Go to some ENS profile and press send button. On both platforms it should pre-fill the address of the profile.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
