### PR TITLE
fix NFT gas button rm touchable + elevation

### DIFF
--- a/src/components/send/SendAssetFormCollectible.js
+++ b/src/components/send/SendAssetFormCollectible.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Keyboard, TouchableWithoutFeedback } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { OpacityToggler } from '../animations';
 import { UniqueTokenExpandedStateContent } from '../expanded-state/unique-token';
@@ -16,7 +15,7 @@ const ButtonWrapper = styled(Column).attrs({
   ...padding.object(0, 19, 15),
   marginBottom: 21,
   width: '100%',
-  ...(ios ? { zIndex: 3 } : {}),
+  ...(ios ? { zIndex: 3 } : { elevation: 3 }),
 });
 
 const Footer = styled(Column).attrs({ justify: 'end' })({
@@ -108,32 +107,30 @@ export default function SendAssetFormCollectible({
   );
 
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <Column align="end" flex={1} width="100%">
-        <NFTWrapper onLayout={handleLayout}>
-          {!!containerHeight && !!containerWidth && (
-            <UniqueTokenExpandedStateContent
-              {...props}
-              asset={asset}
-              borderRadius={20}
-              disablePreview
-              height={imageHeight}
-              horizontalPadding={24}
-              resizeMode="cover"
-              width={imageWidth}
-            />
-          )}
-        </NFTWrapper>
-        <Footer>
-          <ButtonWrapper isTallPhone={isTallPhone}>
-            {buttonRenderer}
-            {txSpeedRenderer}
-          </ButtonWrapper>
-          <GradientToggler isVisible={!isGradientVisible}>
-            <Gradient isTallPhone={isTallPhone} />
-          </GradientToggler>
-        </Footer>
-      </Column>
-    </TouchableWithoutFeedback>
+    <Column align="end" flex={1} width="100%">
+      <NFTWrapper onLayout={handleLayout}>
+        {!!containerHeight && !!containerWidth && (
+          <UniqueTokenExpandedStateContent
+            {...props}
+            asset={asset}
+            borderRadius={20}
+            disablePreview
+            height={imageHeight}
+            horizontalPadding={24}
+            resizeMode="cover"
+            width={imageWidth}
+          />
+        )}
+      </NFTWrapper>
+      <Footer>
+        <ButtonWrapper isTallPhone={isTallPhone}>
+          {buttonRenderer}
+          {txSpeedRenderer}
+        </ButtonWrapper>
+        <GradientToggler isVisible={!isGradientVisible}>
+          <Gradient isTallPhone={isTallPhone} />
+        </GradientToggler>
+      </Footer>
+    </Column>
   );
 }


### PR DESCRIPTION
Fixes TEAM2-397
Figma link (if any):

## What changed (plus any additional context for devs)
regression from https://github.com/rainbow-me/rainbow/pull/3829 , missed during dev QA. menu pkg doesn't play well with touchables + we needed to add elevation.


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


https://user-images.githubusercontent.com/29204161/183689811-1cf3250c-6405-4c65-bee8-716be74a47d0.mov



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

open the gas speed menu for erc20 + NFT on both platforms


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
