### PR TITLE
Make hardhat related tests less flaky

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,6 +10,7 @@ module.exports = {
   networks: {
     hardhat: {
       chainId: 1,
+      initialBaseFeePerGas: 100000000, // 0.1 gwei
     },
   },
   solidity: '0.8.4',


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
The e2e flow e2e/hardhatTransactionFlow.spec.js has been flaky since day one in the scenarios where the gas goes down since the test start.

We start with base fee of Y when we fork mainnet and then we keep getting updates from meteorology with real amounts (lower) so we underpay and txs fails, making the whole test fail and adding a few extra minutes. This PR fixes it.

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
This only affects e2e so if it's green it's good.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
