### PR TITLE
Capture Sentry message on web preference API failures

### DIFF
--- a/src/model/preferences.ts
+++ b/src/model/preferences.ts
@@ -65,7 +65,8 @@ export async function setPreference(
     return responseData?.success;
   } catch (e) {
     Sentry.captureException(
-      new Error(`Preferences API failed to set preference`)
+      new Error(`Preferences API failed to set preference`),
+      { extra: { preferenceKey: key } }
     );
     logger.log('☁️  error setting pref', e);
     return false;
@@ -88,7 +89,8 @@ export async function getPreference(
     return responseData?.data || null;
   } catch (e) {
     Sentry.captureException(
-      new Error(`Preferences API failed to get preference`)
+      new Error(`Preferences API failed to get preference`),
+      { extra: { preferenceKey: key } }
     );
     logger.log('☁️  error getting pref', e);
     return null;

--- a/src/model/preferences.ts
+++ b/src/model/preferences.ts
@@ -64,9 +64,8 @@ export async function setPreference(
     });
     return responseData?.success;
   } catch (e) {
-    Sentry.captureMessage(
-      `Preferences API failed to set preference`,
-      Sentry.Severity.Error
+    Sentry.captureException(
+      new Error(`Preferences API failed to set preference`)
     );
     logger.log('☁️  error setting pref', e);
     return false;
@@ -88,9 +87,8 @@ export async function getPreference(
     });
     return responseData?.data || null;
   } catch (e) {
-    Sentry.captureMessage(
-      `Preferences API failed to get preference`,
-      Sentry.Severity.Error
+    Sentry.captureException(
+      new Error(`Preferences API failed to get preference`)
     );
     logger.log('☁️  error getting pref', e);
     return null;

--- a/src/model/preferences.ts
+++ b/src/model/preferences.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { RainbowFetchClient } from '../rainbow-fetch';
 import { EthereumAddress } from '@rainbow-me/entities';
 import {
@@ -63,6 +64,10 @@ export async function setPreference(
     });
     return responseData?.success;
   } catch (e) {
+    Sentry.captureMessage(
+      `Preferences API failed to set preference`,
+      Sentry.Severity.Error
+    );
     logger.log('☁️  error setting pref', e);
     return false;
   }
@@ -83,6 +88,10 @@ export async function getPreference(
     });
     return responseData?.data || null;
   } catch (e) {
+    Sentry.captureMessage(
+      `Preferences API failed to get preference`,
+      Sentry.Severity.Error
+    );
     logger.log('☁️  error getting pref', e);
     return null;
   }


### PR DESCRIPTION
See Slack: https://rainbowhaus.slack.com/archives/CGUDDJYNL/p1660078639708399?thread_ts=1660078216.499479&cid=CGUDDJYNL

## What changed (plus any additional context for devs)
Sends two new messages to Sentry with `Error` level severity.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
