### PR TITLE
profiles: name validations

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1065,6 +1065,13 @@
         "and_create_ens_profile": "Search available .eth names",
         "register_name": "Create Your ENS Profile"
       },
+      "search_validation": {
+        "invalid_domain": "This is an invalid domain",
+        "tld_not_supported": "This TLD is not supported",
+        "subdomains_not_supported": "Subdomains are not supported",
+        "invalid_length": "Your name must be at least 3 characters",
+        "invalid_special_characters": "Your name cannot include special characters"
+      },
       "records": {
         "since": "Since"
       }

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -877,6 +877,13 @@
         "clear": "􀅉 Clear :)",
         "continue": "Continue 􀆊 :)"
       },
+      "search_validation": {
+        "invalid_domain": "This is an invalid domain :)",
+        "tld_not_supported": "This TLD is not supported :)",
+        "subdomains_not_supported": "Subdomains are not supported :)",
+        "invalid_length": "Your name must be at least 3 characters :)",
+        "invalid_special_characters": "Your name cannot include special characters :)"
+      },
       "confirm": {
         "confirm_registration": "Confirm Registration :)",
         "confirm_updates": "Confirm Updates :)",

--- a/src/utils/__tests__/ens.test.ts
+++ b/src/utils/__tests__/ens.test.ts
@@ -66,6 +66,17 @@ describe('invalid names', () => {
     `);
   });
 
+  it('domain with empty subdomain fails when `includeSubdomains` is falsy', () => {
+    expect(validateENS('.lol.eth', { includeSubdomains: false }))
+      .toMatchInlineSnapshot(`
+      Object {
+        "code": "subdomains-not-supported",
+        "hint": "Subdomains are not supported",
+        "valid": false,
+      }
+    `);
+  });
+
   it('domain with invalid length', () => {
     expect(validateENS('no.eth')).toMatchInlineSnapshot(`
       Object {

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -1,3 +1,4 @@
+import lang from 'i18n-js';
 import uts46 from 'idna-uts46-hx';
 import { UniqueAsset } from '@rainbow-me/entities';
 
@@ -117,7 +118,7 @@ export function validateENS(
   if (splitDomain.length < 2) {
     return {
       code: ERROR_CODES.INVALID_DOMAIN,
-      hint: 'This is an invalid domain',
+      hint: lang.t('profiles.search_validation.invalid_domain'),
       valid: false,
     };
   }
@@ -127,7 +128,7 @@ export function validateENS(
   if (!supportedTLDs.includes(tld)) {
     return {
       code: ERROR_CODES.INVALID_TLD,
-      hint: 'This TLD is not supported',
+      hint: lang.t('profiles.search_validation.tld_not_supported'),
       valid: false,
     };
   }
@@ -135,7 +136,7 @@ export function validateENS(
   if (!includeSubdomains && (subDomainName || subDomainName === '')) {
     return {
       code: ERROR_CODES.SUBDOMAINS_NOT_SUPPORTED,
-      hint: 'Subdomains are not supported',
+      hint: lang.t('profiles.search_validation.subdomains_not_supported'),
       valid: false,
     };
   }
@@ -143,17 +144,7 @@ export function validateENS(
   if (domainName.length < 3) {
     return {
       code: ERROR_CODES.INVALID_LENGTH,
-      hint: 'Your name must be at least 3 characters',
-      valid: false,
-    };
-  }
-
-  try {
-    uts46.toUnicode(domainName, { useStd3ASCII: true });
-  } catch (err) {
-    return {
-      code: ERROR_CODES.INVALID_DOMAIN_NAME,
-      hint: 'Your name cannot include special characters',
+      hint: lang.t('profiles.search_validation.invalid_length'),
       valid: false,
     };
   }
@@ -163,7 +154,7 @@ export function validateENS(
   if (!validDomainName) {
     return {
       code: ERROR_CODES.INVALID_SUBDOMAIN_NAME,
-      hint: 'Your subdomain cannot include special characters',
+      hint: lang.t('profiles.search_validation.invalid_special_characters'),
       valid: false,
     };
   }
@@ -173,7 +164,7 @@ export function validateENS(
     if (!validSubDomainName) {
       return {
         code: ERROR_CODES.INVALID_SUBDOMAIN_NAME,
-        hint: 'Your subdomain cannot include special characters',
+        hint: lang.t('profiles.search_validation.invalid_special_characters'),
         valid: false,
       };
     }


### PR DESCRIPTION
Fixes TEAM2-412
Figma link (if any):

## What changed (plus any additional context for devs)

added validation for empty subdomain and apostrophe
also added lang.t to that file

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/c55678d54d3d49b9a0ae45d7a644efd1

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
