### PR TITLE
Profiles: darken track color of switch on android

### DIFF
--- a/src/components/ens-registration/ConfirmContent/EditContent.tsx
+++ b/src/components/ens-registration/ConfirmContent/EditContent.tsx
@@ -64,7 +64,10 @@ const EditContent = ({
               }
               testID="ens-reverse-record-switch"
               thumbColor={colors.white}
-              trackColor={{ false: colors.white, true: accentColor }}
+              trackColor={{
+                false: android ? colors.lightGrey : colors.white,
+                true: accentColor,
+              }}
               value={sendReverseRecord}
             />
           </Inline>

--- a/src/components/ens-registration/ConfirmContent/RegisterContent.tsx
+++ b/src/components/ens-registration/ConfirmContent/RegisterContent.tsx
@@ -85,7 +85,10 @@ const RegisterContent = ({
                 }
                 testID="ens-reverse-record-switch"
                 thumbColor={colors.white}
-                trackColor={{ false: colors.white, true: accentColor }}
+                trackColor={{
+                  false: android ? colors.lightGrey : colors.white,
+                  true: accentColor,
+                }}
                 value={sendReverseRecord}
               />
             </Inline>

--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -179,7 +179,10 @@ export default function InfoRow({
                   disabled={switchDisabled || switchValue}
                   onValueChange={onSwitchChange}
                   testID="ens-reverse-record-switch"
-                  trackColor={{ false: colors.white, true: accentColor }}
+                  trackColor={{
+                    false: android ? colors.lightGrey : colors.white,
+                    true: accentColor,
+                  }}
                   value={switchValue}
                 />
               )}


### PR DESCRIPTION
Fixes TEAM2-415

Making it so we can actually see the toggle on light mode.