### PR TITLE
Fix keyboard layout issues in SendSheet on Android

### DIFF
--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -46,13 +46,9 @@ const FormContainer = styled(Column).attrs(
       }
     : {}
 )(({ isNft }) => ({
+  flex: 1,
   ...(isNft ? padding.object(0) : padding.object(0, 19)),
-  ...(ios || isNft ? { flex: 1 } : {}),
 }));
-
-const KeyboardSizeView = styled(KeyboardArea)({
-  backgroundColor: ({ theme: { colors } }) => colors.lighterGrey,
-});
 
 export default function SendAssetForm({
   assetAmount,
@@ -168,9 +164,7 @@ export default function SendAssetForm({
               sendMaxBalance={sendMaxBalance}
               txSpeedRenderer={txSpeedRenderer}
             />
-            {ios ? (
-              <KeyboardSizeView initialHeight={keyboardHeight} isOpen />
-            ) : null}
+            <KeyboardArea initialHeight={keyboardHeight} isOpen />
           </Fragment>
         )}
       </FormContainer>

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -11,7 +11,6 @@ import React, {
 } from 'react';
 import { InteractionManager, Keyboard, StatusBar } from 'react-native';
 import { getStatusBarHeight } from 'react-native-iphone-x-helper';
-import { KeyboardArea } from 'react-native-keyboard-area';
 import { useDispatch } from 'react-redux';
 import { useDebounce } from 'use-debounce';
 import { GasSpeedButton } from '../components/gas';
@@ -103,12 +102,6 @@ const SheetContainer = styled(Column).attrs({
   ...borders.buildRadiusAsObject('top', isNativeStackAvailable ? 0 : 16),
   backgroundColor: ({ theme: { colors } }) => colors.white,
   height: isNativeStackAvailable || android ? sheetHeight : '100%',
-  width: '100%',
-});
-
-const KeyboardSizeView = styled(KeyboardArea)({
-  backgroundColor: ({ showAssetForm, theme: { colors } }) =>
-    showAssetForm ? colors.lighterGrey : colors.white,
   width: '100%',
 });
 
@@ -1024,9 +1017,6 @@ export default function SendSheet(props) {
             }
           />
         )}
-        {android && showAssetForm ? (
-          <KeyboardSizeView showAssetForm={showAssetForm} />
-        ) : null}
       </SheetContainer>
     </Container>
   );


### PR DESCRIPTION
Fixes RNBW-4241
Figma link (if any):

## What changed (plus any additional context for devs)

Context:

https://rainbowhaus.slack.com/archives/C01GD1F2ZTL/p1660083877054629

I changed the way keyboard is handled. I think it was done a bit weird, probably added separately for Android and iOS. After unifying it it seems to work better.

Another difference is that I restore `flex: 1` for Android token send sheet.

## Screen recordings / screenshots

(I checked on iOS and no changes there)

Before:

https://user-images.githubusercontent.com/5769281/183881188-037ede54-af34-4c64-8e3e-77283b5e83a8.mp4

After:

https://user-images.githubusercontent.com/5769281/183881147-f05cd8f5-72c7-4e47-9eaa-8698ca925b72.mp4

## What to test

Check send sheet on iOS, Android, sending NFT, sending token. The layout (placing of elements) should look ok. Both with keyboard on (both platforms) or dismissed (Android).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
