### PR TITLE
profiles: disable image overlay on android

### DIFF
--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -222,14 +222,15 @@ function ImageValue({
   const enableZoomOnPress = !onPress;
 
   if (!url) return null;
+  const ImageWrapper = android ? Box : ImagePreviewOverlayTarget;
   return (
-    <ImagePreviewOverlayTarget
+    <ImageWrapper
       aspectRatioType="cover"
       enableZoomOnPress={enableZoomOnPress}
       imageUrl={url}
       onPress={onPress}
     >
       <Box as={ImgixImage} height="full" source={{ uri: url }} />
-    </ImagePreviewOverlayTarget>
+    </ImageWrapper>
   );
 }

--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -222,15 +222,14 @@ function ImageValue({
   const enableZoomOnPress = !onPress;
 
   if (!url) return null;
-  const ImageWrapper = android ? Box : ImagePreviewOverlayTarget;
   return (
-    <ImageWrapper
+    <ImagePreviewOverlayTarget
       aspectRatioType="cover"
-      enableZoomOnPress={enableZoomOnPress}
+      enableZoomOnPress={ios && enableZoomOnPress}
       imageUrl={url}
       onPress={onPress}
     >
       <Box as={ImgixImage} height="full" source={{ uri: url }} />
-    </ImageWrapper>
+    </ImagePreviewOverlayTarget>
   );
 }


### PR DESCRIPTION
Fixes RNBW-4246
Figma link (if any):

## What changed (plus any additional context for devs)
disabling on android for now 


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


https://user-images.githubusercontent.com/29204161/183943102-0e4473f7-d66f-4f45-8417-6ef24fe74689.mov


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

try to press it 🔫 


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
