### PR TITLE
fix: confirmation screen height

### DIFF
--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -40,7 +40,7 @@ import useExperimentalFlag, {
   PROFILES,
 } from '@rainbow-me/config/experimentalHooks';
 import { Box, Inset, Stack, Text } from '@rainbow-me/design-system';
-import { AssetTypes, UniqueAsset } from '@rainbow-me/entities';
+import { AssetTypes } from '@rainbow-me/entities';
 import {
   estimateENSReclaimGasLimit,
   estimateENSSetAddressGasLimit,
@@ -116,7 +116,7 @@ const isRegistrant = (ensProfile?: ENSProfile) => ensProfile?.isRegistrant;
 const gasOffset = 120;
 const checkboxOffset = 44;
 
-function getDefaultCheckboxes({
+export function getDefaultCheckboxes({
   isENS,
   ensProfile,
   network,
@@ -176,41 +176,22 @@ function getDefaultCheckboxes({
 }
 
 export function getSheetHeight({
-  asset,
-  ensProfile,
-  profilesEnabled,
   shouldShowChecks,
   isL2,
-  toAddress,
+  isENS,
+  checkboxes,
 }: {
-  asset?: UniqueAsset;
-  ensProfile?: ENSProfile;
-  profilesEnabled: boolean;
   shouldShowChecks: boolean;
   isL2: boolean;
-  toAddress: string;
+  isENS: boolean;
+  checkboxes: Checkbox[];
 }) {
-  let height = android ? 440 : 377;
-  if (shouldShowChecks) height = height + 104;
-  if (isL2) height = height + 59;
-  if (profilesEnabled && asset && getUniqueTokenType(asset) === 'ENS') {
-    height = height + gasOffset;
-    if (!hasClearProfileInfo(ensProfile) && ensProfile?.isOwner) {
-      height = height + checkboxOffset;
-    }
-    if (
-      !doesNamePointToRecipient(ensProfile, toAddress) &&
-      ensProfile?.isOwner
-    ) {
-      height = height + checkboxOffset;
-    }
-    if (
-      isRegistrant(ensProfile) &&
-      ensProfile?.data?.owner?.address?.toLowerCase() !==
-        toAddress.toLowerCase()
-    ) {
-      height = height + checkboxOffset;
-    }
+  let height = android ? 400 : 377;
+  if (isL2) height = height + 70;
+  if (shouldShowChecks) height = height + 80;
+  if (isENS) {
+    height = height + gasOffset + 20;
+    height = height + checkboxes?.length * checkboxOffset || 0;
   }
   return height;
 }
@@ -545,20 +526,12 @@ export default function SendConfirmationSheet() {
     true
   );
 
-  let contentHeight =
-    getSheetHeight({
-      ensProfile,
-      isL2,
-      profilesEnabled,
-      shouldShowChecks,
-      toAddress,
-    }) - 30;
-  if (shouldShowChecks) contentHeight = contentHeight + 150;
-  if (isL2) contentHeight = contentHeight + 60;
-  if (isENS) {
-    contentHeight =
-      contentHeight + checkboxes.length * checkboxOffset + gasOffset;
-  }
+  const contentHeight = getSheetHeight({
+    checkboxes,
+    isENS,
+    isL2,
+    shouldShowChecks,
+  });
 
   return (
     <Container

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -23,6 +23,7 @@ import {
   SendHeader,
 } from '../components/send';
 import { SheetActionButton } from '../components/sheet';
+import { getDefaultCheckboxes } from './SendConfirmationSheet';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { analytics } from '@rainbow-me/analytics';
 import { PROFILES, useExperimentalFlag } from '@rainbow-me/config';
@@ -776,12 +777,21 @@ export default function SendSheet(props) {
       });
       return;
     }
-
+    const uniqueTokenType = getUniqueTokenType(selected);
+    const isENS = uniqueTokenType === 'ENS';
+    const checkboxes = getDefaultCheckboxes({
+      ensProfile,
+      isENS: true,
+      network,
+      toAddress: recipient,
+    });
     navigate(Routes.SEND_CONFIRMATION_SHEET, {
       amountDetails: amountDetails,
       asset: selected,
       callback: submitTransaction,
+      checkboxes,
       ensProfile,
+      isENS,
       isL2,
       isNft,
       network: currentNetwork,
@@ -799,6 +809,7 @@ export default function SendSheet(props) {
     isNft,
     nativeCurrencyInputRef,
     navigate,
+    network,
     profilesEnabled,
     recipient,
     selected,


### PR DESCRIPTION
Fixes RNBW-4244
Figma link (if any):

## What changed (plus any additional context for devs)

consolidated the confirmation screen height in one method `getSheetHeight`

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/b938a874173e4dd1a770c684d0962a1d

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- send mainnet token
- send L2 token to a wallet you own
- send L2 token to a wallet you don't own, you should see a checklist here
- send ens
- send nft



## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
