### PR TITLE
Profiles: fix header removal crash

### DIFF
--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -191,7 +191,7 @@ const RegistrationCover = ({
             </Text>
           )}
         </Box>
-        {coverUrl && !isUploading && (
+        {!!coverUrl && !isUploading && (
           <Cover>
             <Box
               as={ImgixImage}

--- a/src/hooks/useSelectImageMenu.tsx
+++ b/src/hooks/useSelectImageMenu.tsx
@@ -176,6 +176,7 @@ export default function useSelectImageMenu({
   const handlePressMenuItem = useCallback(
     ({ nativeEvent: { actionKey } }) => {
       if (actionKey === 'library') {
+        isRemoved.current = false;
         handleSelectImage();
       }
       if (actionKey === 'nft') {
@@ -200,6 +201,7 @@ export default function useSelectImageMenu({
       },
       async (buttonIndex: Number) => {
         if (buttonIndex === 0) {
+          isRemoved.current = false;
           handleSelectImage();
         } else if (buttonIndex === 1) {
           handleSelectNFT();


### PR DESCRIPTION
Fixes RNBW-4251
Figma link (if any):

## What changed (plus any additional context for devs)
- `coverUrl` is set to the empty string when the image is removed. this is a false-y value which caused the condition on the modified line to fail fast, with `coverUrl` as the return value. as a result, this string was trying to render as a RN component which caused the crash.
- @estebanmino found a bug that prevented cover images from uploading after removing a previous cover image. this is because `isRemoved.current` was set to true after any cover photo removal, with the intended goal of preventing `onUploadSuccess` from being called if the image was removed while being uploaded. to fix this, i set `isRemoved.current` to false upon selecting a new image.

## Screen recordings / screenshots

https://user-images.githubusercontent.com/15272675/184008435-508a58f6-e90b-479a-9ca7-a237ff58740f.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
