### PR TITLE
Profiles: Fix description overflow

### DIFF
--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -150,6 +150,7 @@ export default function InfoRow({
                 : useAccentColor
                 ? accentColor + '10'
                 : 'rgba(255, 255, 255, 0.08)',
+              maxWidth: android ? 250 : undefined,
               opacity: show ? 1 : 0,
             }}
           >


### PR DESCRIPTION
Before:

<img width="397" alt="Screen Shot 2022-08-11 at 7 59 58 am" src="https://user-images.githubusercontent.com/7336481/184028224-560c743d-eef1-49e4-a297-c78cebe8bfb0.png">


After:

<img width="406" alt="Screen Shot 2022-08-11 at 7 59 47 am" src="https://user-images.githubusercontent.com/7336481/184028228-5f536a0a-12c0-4f42-af7e-1161848fbf4d.png">
