### PR TITLE
Improve ‘more details’ tap target area for swaps

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -74,22 +74,33 @@ export default function SwapDetailsContent({
             />
           )}
           {!detailsExpanded && (
-            <ButtonPressAnimation
-              onPress={() => setDetailsExpanded(!detailsExpanded)}
-              scaleTo={1.06}
+            <Box
+              style={{
+                // cancel out the extra padding below
+                marginVertical: -18,
+              }}
             >
-              <SwapDetailsRow
-                label={
-                  detailsExpanded
-                    ? lang.t('expanded_state.swap_details.hide_details')
-                    : lang.t('expanded_state.swap_details.show_details')
-                }
+              <ButtonPressAnimation
+                onPress={() => setDetailsExpanded(!detailsExpanded)}
+                scaleTo={1.06}
+                style={{
+                  // enlarge tap target for details button
+                  paddingVertical: 18,
+                }}
               >
-                <SwapDetailsValue>
-                  {detailsExpanded ? '􀁮' : '􀁰'}
-                </SwapDetailsValue>
-              </SwapDetailsRow>
-            </ButtonPressAnimation>
+                <SwapDetailsRow
+                  label={
+                    detailsExpanded
+                      ? lang.t('expanded_state.swap_details.hide_details')
+                      : lang.t('expanded_state.swap_details.show_details')
+                  }
+                >
+                  <SwapDetailsValue>
+                    {detailsExpanded ? '􀁮' : '􀁰'}
+                  </SwapDetailsValue>
+                </SwapDetailsRow>
+              </ButtonPressAnimation>
+            </Box>
           )}
           {detailsExpanded && (
             <Rows space="24px">

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -166,45 +166,65 @@ export default function SwapDetailsExchangeRow({ protocols }) {
 
   if (protocols?.length > 1) {
     return (
-      <ButtonPressAnimation onPress={nextStep} scaleTo={1.06}>
-        <Rows>
-          <Columns alignHorizontal="right" alignVertical="center" space="4px">
-            <Column>
-              <SwapDetailsLabel>
-                {lang.t('expanded_state.swap.swapping_via')}
-              </SwapDetailsLabel>
-            </Column>
-            <Column width="content">
-              <Box
-                style={{
-                  top: android ? -1.5 : 0,
-                }}
+      <Box
+        style={{
+          // enlarge tap target
+          marginVertical: -10,
+        }}
+      >
+        <ButtonPressAnimation
+          onPress={nextStep}
+          scaleTo={1.06}
+          style={{
+            // enlarge tap target
+            paddingVertical: 8,
+          }}
+        >
+          <Box>
+            <Rows>
+              <Columns
+                alignHorizontal="right"
+                alignVertical="center"
+                space="4px"
               >
-                <ExchangeIconStack protocols={steps[step]} />
-              </Box>
-            </Column>
-            <Column width="content">
-              <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
-            </Column>
-            {steps?.[step]?.part && (
-              <Column width="content">
-                <Bleed right="5px" vertical="6px">
-                  <Pill
-                    height={20}
+                <Column>
+                  <SwapDetailsLabel>
+                    {lang.t('expanded_state.swap.swapping_via')}
+                  </SwapDetailsLabel>
+                </Column>
+                <Column width="content">
+                  <Box
                     style={{
-                      lineHeight: android && 18,
-                      top: android ? -1 : 0,
+                      top: android ? -1.5 : 0,
                     }}
-                    textColor={defaultColor}
                   >
-                    {steps[step].part}
-                  </Pill>
-                </Bleed>
-              </Column>
-            )}
-          </Columns>
-        </Rows>
-      </ButtonPressAnimation>
+                    <ExchangeIconStack protocols={steps[step]} />
+                  </Box>
+                </Column>
+                <Column width="content">
+                  <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
+                </Column>
+                {steps?.[step]?.part && (
+                  <Column width="content">
+                    <Bleed right="5px" vertical="6px">
+                      <Pill
+                        height={20}
+                        style={{
+                          lineHeight: android && 18,
+                          top: android ? -1 : 0,
+                        }}
+                        textColor={defaultColor}
+                      >
+                        {steps[step].part}
+                      </Pill>
+                    </Bleed>
+                  </Column>
+                )}
+              </Columns>
+            </Rows>
+          </Box>
+        </ButtonPressAnimation>
+      </Box>
     );
   } else if (protocols?.length > 0) {
     return (


### PR DESCRIPTION
Fixes TEAM2-414

## What changed (plus any additional context for devs)
- Added invisible padding around the `More details` button in swap review sheet to make it easier to tap with your finger.


## What to test
Going into swap review sheet and tapping on `More details` on Android and iOS.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
