### PR TITLE
profiles: improve photo removal

### DIFF
--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -141,7 +141,7 @@ const RegistrationAvatar = ({
       setDisabled(false);
       setTimeout(() => {
         setAvatarUrl('');
-      }, 500);
+      }, 100);
     },
     onUploadError: () => {
       onBlurField({ key: 'avatar', value: '' });

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -136,10 +136,12 @@ const RegistrationAvatar = ({
     onChangeImage,
     onRemoveImage: () => {
       onRemoveField({ key: 'avatar' });
-      setAvatarUrl('');
       onChangeAvatarUrl('');
       setAvatarMetadata(undefined);
       setDisabled(false);
+      setTimeout(() => {
+        setAvatarUrl('');
+      }, 500);
     },
     onUploadError: () => {
       onBlurField({ key: 'avatar', value: '' });

--- a/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
+++ b/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx
@@ -120,9 +120,11 @@ const RegistrationCover = ({
     onChangeImage: onChangeImage,
     onRemoveImage: () => {
       onRemoveField({ key: 'header' });
-      setCoverUrl('');
       setCoverMetadata(undefined);
       setDisabled(false);
+      setTimeout(() => {
+        setCoverUrl('');
+      }, 100);
     },
     onUploadError: () => {
       onBlurField({ key: 'header', value: '' });


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)


fixing this issue
https://linear.app/rainbow/issue/TEAM2-403#comment-5e59da70

https://github.com/rainbow-me/rainbow/blob/develop/src/components/ens-registration/RegistrationCover/RegistrationCover.tsx#L58  is being triggered right after removing the image with the old url


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
