### PR TITLE
profiles: fix unwatch last wallet in app

### DIFF
--- a/src/hooks/useWatchWallet.ts
+++ b/src/hooks/useWatchWallet.ts
@@ -1,4 +1,6 @@
+import { useNavigation } from '@react-navigation/core';
 import { useCallback, useMemo } from 'react';
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { useDispatch } from 'react-redux';
 import {
   useAccountProfile,
@@ -7,10 +9,12 @@ import {
   useInitializeWallet,
   useWallets,
 } from '@rainbow-me/hooks';
+import { cleanUpWalletKeys } from '@rainbow-me/model/wallet';
 import {
   addressSetSelected,
   walletsSetSelected,
 } from '@rainbow-me/redux/wallets';
+import Routes from '@rainbow-me/routes';
 import { doesWalletsContainAddress, logger } from '@rainbow-me/utils';
 
 export default function useWatchWallet({
@@ -25,7 +29,7 @@ export default function useWatchWallet({
   showImportModal?: boolean;
 }) {
   const dispatch = useDispatch();
-
+  const { goBack, navigate } = useNavigation();
   const { wallets } = useWallets();
 
   const watchingWallet = useMemo(() => {
@@ -68,17 +72,37 @@ export default function useWatchWallet({
       handleSetSeedPhrase(ensName);
       handlePressImportButton(null, ensName, null, avatarUrl);
     } else {
-      deleteWallet();
-      // If we're deleting the selected wallet
-      // we need to switch to another one
-      if (primaryAddress && primaryAddress === accountAddress) {
-        const { wallet: foundWallet, key } =
-          doesWalletsContainAddress({
-            address: primaryAddress,
-            wallets,
-          }) || {};
-        if (foundWallet) {
-          await changeAccount(key, foundWallet.address);
+      // If there's more than 1 account
+      // it's deletable
+      const isLastAvailableWallet = Object.keys(wallets).find(key => {
+        const someWallet = wallets[key];
+        const otherAccount = someWallet.addresses.find(
+          (account: any) =>
+            account.visible && account.address !== accountAddress
+        );
+        if (otherAccount) {
+          return true;
+        }
+        return false;
+      });
+      await deleteWallet();
+      ReactNativeHapticFeedback.trigger('notificationSuccess');
+      if (!isLastAvailableWallet) {
+        await cleanUpWalletKeys();
+        goBack();
+        navigate(Routes.WELCOME_SCREEN);
+      } else {
+        // If we're deleting the selected wallet
+        // we need to switch to another one
+        if (primaryAddress && primaryAddress === accountAddress) {
+          const { wallet: foundWallet, key } =
+            doesWalletsContainAddress({
+              address: primaryAddress,
+              wallets,
+            }) || {};
+          if (foundWallet) {
+            await changeAccount(key, foundWallet.address);
+          }
         }
       }
     }
@@ -89,9 +113,11 @@ export default function useWatchWallet({
     handlePressImportButton,
     avatarUrl,
     deleteWallet,
+    wallets,
+    goBack,
+    navigate,
     primaryAddress,
     accountAddress,
-    wallets,
     changeAccount,
   ]);
 


### PR DESCRIPTION
Fixes TEAM2-421
Figma link (if any):

## What changed (plus any additional context for devs)

we weren't handle the case where you would only have a `watching` wallet and then you went to the profile and pressed unwatch
i followed what we're doing on the wallets sheet when deleting wallets, from here https://github.com/rainbow-me/rainbow/blob/develop/src/screens/ChangeWalletSheet.js#L327

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

ios https://www.loom.com/share/a65fc048302a4ea3b1956cd1c3b2a936
android https://www.loom.com/share/038bc343cf1a4360842864a4fb529d32

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- have only 1 wallet in watching mode
- go to profile and unwatch
- it should send you to the welcome screen as we normally do when deleting wallets

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
