### PR TITLE
Revert Unsupported Testnets To Mainnet

### DIFF
--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -101,10 +101,9 @@ export default function WalletScreen() {
   }, [dispatch, initializeAccountData, loadAccountData, resetAccountState]);
 
   useEffect(() => {
-    const revertFn = async () => await revertToMainnet();
     const supportedNetworks = [Network.mainnet, Network.goerli];
     if (!supportedNetworks.includes(network)) {
-      revertFn();
+      revertToMainnet();
     }
   }, [network, revertToMainnet]);
 

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -15,7 +15,9 @@ import {
   ScanHeaderButton,
 } from '../components/header';
 import { Page, RowWithMargins } from '../components/layout';
+import { Network } from '@/helpers';
 import { useRemoveFirst } from '@/navigation/useRemoveFirst';
+import { settingsUpdateNetwork } from '@/redux/settings';
 import useExperimentalFlag, {
   PROFILES,
 } from '@rainbow-me/config/experimentalHooks';
@@ -25,11 +27,14 @@ import {
   useAccountEmptyState,
   useAccountSettings,
   useCoinListEdited,
+  useInitializeAccountData,
   useInitializeDiscoverData,
   useInitializeWallet,
+  useLoadAccountData,
   useLoadAccountLateData,
   useLoadGlobalLateData,
   usePortfolios,
+  useResetAccountState,
   useTrackENSProfile,
   useUserAccounts,
   useWallets,
@@ -81,6 +86,27 @@ export default function WalletScreen() {
   const loadAccountLateData = useLoadAccountLateData();
   const loadGlobalLateData = useLoadGlobalLateData();
   const initializeDiscoverData = useInitializeDiscoverData();
+  const dispatch = useDispatch();
+  const resetAccountState = useResetAccountState();
+  const loadAccountData = useLoadAccountData();
+  const initializeAccountData = useInitializeAccountData();
+
+  const revertToMainnet = useCallback(async () => {
+    await resetAccountState();
+    await dispatch(settingsUpdateNetwork(Network.mainnet));
+    InteractionManager.runAfterInteractions(async () => {
+      await loadAccountData(Network.mainnet);
+      initializeAccountData();
+    });
+  }, [dispatch, initializeAccountData, loadAccountData, resetAccountState]);
+
+  useEffect(() => {
+    const revertFn = async () => await revertToMainnet();
+    const supportedNetworks = [Network.mainnet, Network.goerli];
+    if (!supportedNetworks.includes(network)) {
+      revertFn();
+    }
+  }, [network, revertToMainnet]);
 
   const walletReady = useSelector(
     ({ appState: { walletReady } }) => walletReady
@@ -109,8 +135,6 @@ export default function WalletScreen() {
   }, [dangerouslyGetParent, dangerouslyGetState, removeFirst]);
 
   const { isEmpty: isAccountEmpty } = useAccountEmptyState(isSectionsEmpty);
-
-  const dispatch = useDispatch();
 
   const { addressSocket, assetsSocket } = useSelector(
     ({ explorer: { addressSocket, assetsSocket } }) => ({


### PR DESCRIPTION
## What changed (plus any additional context for devs)
This PR is in support of #4001 : we want to handle situations where a user has a deprecated testnet set in state. This code gracefully reverts back to mainnet. I separated this onto its own branch for ease of testing.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
