### PR TITLE
fix: pull in Trove marketplace URL

### DIFF
--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -89,6 +89,8 @@ const getNftTraitUrl = (
       return `https://stratosnft.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
     case 'Quixotic':
       return `https://quixotic.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
+    case 'Trove':
+      return `https://trove.treasure.lol/collection/${collectionId}?trait%5B%5D=${traitTitle}%3A${traitValue}`;
     default:
       return `https://opensea.io/collection/${collectionId}?search[stringTraits][0][name]=${traitTitle}&search[stringTraits][0][values][0]=${traitValue}`;
   }

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -337,6 +337,9 @@ const getSimplehashMarketplaceInfo = simplehashNft => {
     case 'Stratos':
       permalink = `https://stratosnft.io/asset/${collectionId}/${tokenId}`;
       break;
+    case 'Trove':
+      permalink = `https://trove.treasure.lol/collection/${collectionId}/${tokenId}`;
+      break;
     default:
       permalink = null;
   }


### PR DESCRIPTION
Fixes TEAM1-100
Figma link (if any): N/A

## What changed (plus any additional context for devs)

Arbitrum NFTs that have Trove as their main marketplace will now show "View in Trove" in the action button on the NFT detail sheet. Their properties will also link to Trove's site with appropriate filters.

## Screen recordings / screenshots

<img width="490" alt="Screen Shot 2022-08-11 at 6 57 11 PM" src="https://user-images.githubusercontent.com/16931094/184256069-4e3c388e-f560-49ca-a8dc-9c2eee1b81db.png">

https://user-images.githubusercontent.com/16931094/184255723-e1b3b2dd-b9e8-473a-873d-9507e51d1c54.mov

## What to test

^^ can use frannyverse.eth, and collection "Arbitrum Odyssey NFT"

open the NFT details sheet on an Arbitrum NFT that has Trove as main marketplace. you should see "View on Trove" as the button, and it should take you to the NFT's detail page on trove.treasure.lol. If the NFT has properties, you can check those direct you to Trove's site with the correct filters turned on.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
