### PR TITLE
Remove unused Animated.Code call

### DIFF
--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -2,8 +2,6 @@ import { useRoute } from '@react-navigation/core';
 import { compact, isEmpty, keys } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { InteractionManager } from 'react-native';
-import Animated from 'react-native-reanimated';
-import { useValue } from 'react-native-redash/src/v1';
 import { useDispatch, useSelector } from 'react-redux';
 import { OpacityToggler } from '../components/animations';
 import { AssetList } from '../components/asset-list';
@@ -72,7 +70,6 @@ export default function WalletScreen() {
   const [fetchedCharts, setFetchedCharts] = useState(false);
   const initializeWallet = useInitializeWallet();
   const { isCoinListEdited } = useCoinListEdited();
-  const scrollViewTracker = useValue(0);
   const { isReadOnlyWallet } = useWallets();
   const { trackENSProfile } = useTrackENSProfile();
   const { network, accountAddress } = useAccountSettings();
@@ -231,9 +228,6 @@ export default function WalletScreen() {
 
   return (
     <WalletPage testID="wallet-screen">
-      {/* Line below appears to be needed for having scrollViewTracker persistent while
-      reattaching of react subviews */}
-      <Animated.Code exec={scrollViewTracker} />
       <FabWrapper
         disabled={isAccountEmpty || !!params?.emptyWallet}
         fabs={fabs}
@@ -255,7 +249,6 @@ export default function WalletScreen() {
           isLoading={android && isLoadingAssets}
           isWalletEthZero={isWalletEthZero}
           network={network}
-          scrollViewTracker={scrollViewTracker}
           walletBriefSectionsData={walletBriefSectionsData}
         />
       </FabWrapper>


### PR DESCRIPTION
Fixes RNBW-4055
Figma link (if any):

## What changed (plus any additional context for devs)
Removed unused Animated.Code tag and Animated.Value
It was left out after some refactorings of RecyclerAssetList and is not used anymore. Confirmed the old usage in history of RecyclerAssetList, pre TypeScript migration migration.

Check revision 130c0b80a08c1654191bff3c517b5853e2a6354b for reference

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
* Check if recycling still works the same in wallets like `vitalik.eth` or `dom.eth` for the asset list

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
