### PR TITLE
Fix keyboard not opening on Android during ENS registration

### DIFF
--- a/src/components/ens-registration/SearchInput/SearchInput.tsx
+++ b/src/components/ens-registration/SearchInput/SearchInput.tsx
@@ -128,7 +128,6 @@ const SearchInput = ({
             </Column>
             <Input
               autoCorrect={false}
-              autoFocus
               keyboardType={android ? 'visible-password' : 'default'}
               onChangeText={onChangeText}
               onFocus={handleFocus}

--- a/src/components/ens-registration/SearchInput/SearchInput.tsx
+++ b/src/components/ens-registration/SearchInput/SearchInput.tsx
@@ -158,4 +158,4 @@ const SearchInput = ({
   );
 };
 
-export default SearchInput;
+export default React.memo(SearchInput);

--- a/src/components/ens-registration/SearchInput/SearchInput.tsx
+++ b/src/components/ens-registration/SearchInput/SearchInput.tsx
@@ -128,6 +128,7 @@ const SearchInput = ({
             </Column>
             <Input
               autoCorrect={false}
+              autoFocus
               keyboardType={android ? 'visible-password' : 'default'}
               onChangeText={onChangeText}
               onFocus={handleFocus}


### PR DESCRIPTION
Fixes RNBW-4274
Figma link (if any):

## What changed (plus any additional context for devs)

Keyboard should now open automatically.

## Screen recordings / screenshots

https://user-images.githubusercontent.com/5769281/184613839-ee243fef-e000-4cd5-8a0c-920af86fb172.mov

## What to test

Keyboard in ENS registration.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
