### PR TITLE
Fix iOS change wallet sheet animations regression

### DIFF
--- a/src/components/change-wallet/WalletList.js
+++ b/src/components/change-wallet/WalletList.js
@@ -7,10 +7,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { StyleSheet } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
-  FadeOut,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -111,6 +111,7 @@ export default function WalletList({
   const scrollView = useRef(null);
   const { network } = useAccountSettings();
   const opacityAnimation = useSharedValue(0);
+  const emptyOpacityAnimation = useSharedValue(1);
 
   // Update the rows when allWallets changes
   useEffect(() => {
@@ -179,6 +180,10 @@ export default function WalletList({
     if (rows && rows.length && !ready) {
       setTimeout(() => {
         setReady(true);
+        emptyOpacityAnimation.value = withTiming(0, {
+          duration: transitionDuration,
+          easing: Easing.out(Easing.ease),
+        });
       }, 50);
     }
   }, [rows, ready]);
@@ -196,6 +201,10 @@ export default function WalletList({
 
   const opacityStyle = useAnimatedStyle(() => ({
     opacity: opacityAnimation.value,
+  }));
+
+  const emptyOpacityStyle = useAnimatedStyle(() => ({
+    opacity: emptyOpacityAnimation.value,
   }));
 
   const renderItem = useCallback(
@@ -223,43 +232,36 @@ export default function WalletList({
 
   return (
     <Container height={height}>
-      {ready ? (
-        <WalletsContainer style={opacityStyle}>
-          <WalletFlatList
-            data={rows}
-            initialNumToRender={rows.length}
-            ref={scrollView}
-            renderItem={renderItem}
-            scrollEnabled={scrollEnabled}
-            showDividers={showDividers}
-          />
-          {showDividers && <WalletListDivider />}
-          {!watchOnly && (
-            <WalletListFooter>
-              <WalletOption
-                editMode={editMode}
-                icon="arrowBack"
-                label={`􀁍 ${lang.t('wallet.action.create_new')}`}
-                onPress={onPressAddAccount}
-              />
-              <WalletOption
-                editMode={editMode}
-                icon="arrowBack"
-                label={`􀂍 ${lang.t('wallet.action.add_existing')}`}
-                onPress={onPressImportSeedPhrase}
-              />
-            </WalletListFooter>
-          )}
-        </WalletsContainer>
-      ) : (
-        <Animated.View
-          exiting={FadeOut.easing(Easing.out(Easing.ease)).duration(
-            transitionDuration
-          )}
-        >
-          <EmptyWalletList />
-        </Animated.View>
-      )}
+      <Animated.View style={[StyleSheet.absoluteFill, emptyOpacityStyle]}>
+        <EmptyWalletList />
+      </Animated.View>
+      <WalletsContainer style={opacityStyle}>
+        <WalletFlatList
+          data={rows}
+          initialNumToRender={rows.length}
+          ref={scrollView}
+          renderItem={renderItem}
+          scrollEnabled={scrollEnabled}
+          showDividers={showDividers}
+        />
+        {showDividers && <WalletListDivider />}
+        {!watchOnly && (
+          <WalletListFooter>
+            <WalletOption
+              editMode={editMode}
+              icon="arrowBack"
+              label={`􀁍 ${lang.t('wallet.action.create_new')}`}
+              onPress={onPressAddAccount}
+            />
+            <WalletOption
+              editMode={editMode}
+              icon="arrowBack"
+              label={`􀂍 ${lang.t('wallet.action.add_existing')}`}
+              onPress={onPressImportSeedPhrase}
+            />
+          </WalletListFooter>
+        )}
+      </WalletsContainer>
     </Container>
   );
 }


### PR DESCRIPTION
Fixes RNBW-4259
Figma link (if any):

## What changed (plus any additional context for devs)
* Rewrote some animations from `react-native-reanimated` layout animations to standard reanimated animations
* Changed the layout of `WalletList`, right now the loader UI and wallet entries are always rendered and what is visible is controlled with opacity animations

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
Before:

https://user-images.githubusercontent.com/16062886/184649290-256e5afc-c6df-4319-b021-2829f0a593fb.mov

After:

https://user-images.githubusercontent.com/16062886/184649362-ac8aae74-9e54-4927-9633-c8e0fd169558.mov


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
* Take a look how the loading shimmer to wallet list crossfade animation works
* Check basic functionality of wallet switcher

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
