### PR TITLE
swaps: filter input tokens for discover assets

### DIFF
--- a/src/screens/CurrencySelectModal.js
+++ b/src/screens/CurrencySelectModal.js
@@ -124,20 +124,41 @@ export default function CurrencySelectModal() {
     }
   }, [chainId]);
 
+  const { inputCurrency, outputCurrency } = useSwapCurrencies();
+
   const filteredAssetsInWallet = useMemo(() => {
     if (type === CurrencySelectionTypes.input) {
-      return assetsInWallet?.filter(asset => !hiddenCoinsObj[asset.uniqueId]);
+      let filteredAssetsInWallet = assetsInWallet?.filter(
+        asset => !hiddenCoinsObj[asset.uniqueId]
+      );
+      if (fromDiscover && outputCurrency?.implementations) {
+        const outputTokenNetworks = Object.keys(
+          outputCurrency?.implementations
+        );
+
+        filteredAssetsInWallet = filteredAssetsInWallet.filter(asset => {
+          const network = ethereumUtils.getNetworkFromType(asset.type);
+          return outputTokenNetworks.includes(
+            network === Network.mainnet ? 'ethereum' : network
+          );
+        });
+      }
+      return filteredAssetsInWallet;
     }
     return [];
-  }, [type, assetsInWallet, hiddenCoinsObj]);
+  }, [
+    type,
+    assetsInWallet,
+    outputCurrency?.implementations,
+    fromDiscover,
+    hiddenCoinsObj,
+  ]);
 
   const {
     swapCurrencyList,
     swapCurrencyListLoading,
     updateFavorites,
   } = useSwapCurrencyList(searchQueryForSearch, currentChainId);
-
-  const { inputCurrency, outputCurrency } = useSwapCurrencies();
 
   const checkForSameNetwork = useCallback(
     (newAsset, selectAsset, type) => {


### PR DESCRIPTION
Fixes TEAM2-330
Figma link (if any):

## What changed (plus any additional context for devs)
we not filter the input tokens based on the supported networks for the token u want to get

every other flow stays the same


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
new flow w filtering: https://cloud.skylarbarrera.com/Screen-Recording-2022-08-15-14-28-15.mp4

standard flow: https://cloud.skylarbarrera.com/Screen-Recording-2022-08-15-14-35-15.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
swaps from all entry points, only ones from discover for tokens u dont have should filter inputs


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [] Added e2e tests? If not, please specify why
- x ] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
