### PR TITLE
Fix backup button regression

### DIFF
--- a/src/components/settings-menu/BackupSection/NeedsBackupView.js
+++ b/src/components/settings-menu/BackupSection/NeedsBackupView.js
@@ -19,7 +19,6 @@ import { fonts, padding } from '@rainbow-me/styles';
 
 const BackupButton = styled(RainbowButton).attrs({
   type: 'small',
-  width: ios ? 221 : 270,
 })({
   marginBottom: 19,
 });


### PR DESCRIPTION
Fixes TEAM1-104
Figma link (if any):

## What changed (plus any additional context for devs)

Button had small width specified.

## Screen recordings / screenshots

<img width="370" alt="Screenshot 2022-08-16 at 14 02 07" src="https://user-images.githubusercontent.com/5769281/184874904-bccc12e4-aef0-4b97-a82c-1e09d484e013.png">

## What to test
Check this and maybe other places where backup button is used (however this width setting is local so it shouldn't possibly affect anything else).


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
