### PR TITLE
Fix line height in send form bubble input

### DIFF
--- a/src/components/fields/BubbleField.js
+++ b/src/components/fields/BubbleField.js
@@ -11,13 +11,6 @@ const BubbleInput = styled(ExchangeInput).attrs(
     disableTabularNums: true,
     keyboardAppearance: isDarkMode ? 'dark' : 'light',
     letterSpacing: 'roundedTightest',
-    lineHeight: android
-      ? isTinyPhone
-        ? 27
-        : android || isSmallPhone
-        ? 31
-        : 38
-      : undefined,
     size: isTinyPhone ? 'big' : isSmallPhone ? 'bigger' : 'h3',
     weight: 'semibold',
   })


### PR DESCRIPTION
Fixes TEAM1-105
Figma link (if any):

## What changed (plus any additional context for devs)

Line height was specified here for Android but it seems to me that currently it behaves just ok without it while it causes problem when specified.

## Screen recordings / screenshots

https://user-images.githubusercontent.com/5769281/184876457-07041852-8330-4665-8ca7-48a2e7139b0b.mov

## What to test

If the bug from ticket is still present.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
