### PR TITLE
Add wallet statuses `new` `imported` and `old` to wallet initialize time tracking

### DIFF
--- a/src/hooks/useInitializeWallet.ts
+++ b/src/hooks/useInitializeWallet.ts
@@ -39,6 +39,19 @@ export default function useInitializeWallet() {
   const { setIsSmallBalancesOpen } = useOpenSmallBalances();
   const profilesEnabled = useExperimentalFlag(PROFILES);
 
+  const getWalletStatusForPerformanceMetrics = (
+    isNew: boolean,
+    isImporting: boolean
+  ): string => {
+    if (isNew) {
+      return 'new';
+    } else if (isImporting) {
+      return 'imported';
+    } else {
+      return 'old';
+    }
+  };
+
   const initializeWallet = useCallback(
     async (
       seedPhrase,
@@ -138,7 +151,13 @@ export default function useInitializeWallet() {
 
         logger.sentry('💰 Wallet initialized');
         PerformanceTracking.finishMeasuring(
-          PerformanceMetrics.useInitializeWallet
+          PerformanceMetrics.useInitializeWallet,
+          {
+            walletStatus: getWalletStatusForPerformanceMetrics(
+              isNew,
+              isImporting
+            ),
+          }
         );
 
         dispatch(checkPendingTransactionsOnInitialize(walletAddress));


### PR DESCRIPTION
Fixes RNBW-3959
Figma link (if any):

## What changed (plus any additional context for devs)
- Added a new parameter to wallet initialize time tracking, that adds three statuses to wallet
  - `old` – Wallet was already there
  - `new` – Wallet is newly created from scratch
  - `imported` – Wallet imported from seed phrase


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
- Check if all the possible combinations for old new and imported wallets are logged properly in segment console

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
