### PR TITLE
Profiles: Fix "Selling" NFTs alignment

### DIFF
--- a/src/components/token-family/TokenFamilyHeaderIcon.tsx
+++ b/src/components/token-family/TokenFamilyHeaderIcon.tsx
@@ -49,6 +49,16 @@ export default React.memo(function TokenFamilyHeaderIcon({
     );
   }
 
+  if (familyName === 'Selling') {
+    return (
+      <View style={sx.trophy}>
+        <Text align="center" containsEmoji size="16px">
+          💸
+        </Text>
+      </View>
+    );
+  }
+
   if (familyName === lang.t('button.hidden')) {
     return (
       <View

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -391,7 +391,7 @@ export const buildBriefUniqueTokenList = (
         // @ts-expect-error "index" does not exist in type.
         index,
         type: 'NFT',
-        uid: uniqueId,
+        uid: `selling-${uniqueId}`,
         uniqueId,
       });
     }


### PR DESCRIPTION
Fixes TEAM2-431

Figma: https://www.figma.com/file/O2iH8h2H00ycicwUHIfBah/profiles-spec?node-id=351%3A7681

## What changed (plus any additional context for devs)

- Fixing alignment of NFTs under the "Selling" row.
- Added the proper emoji for "Selling" as per the designs.


## Screen recordings / screenshots

<img width="389" alt="Screen Shot 2022-08-17 at 11 27 59 am" src="https://user-images.githubusercontent.com/7336481/185014566-b6e8d8ab-2068-4181-8f4d-688047c9e67d.png">