### PR TITLE
chore: e2e -> hide gwei label for testing

### DIFF
--- a/src/components/expanded-state/custom-gas/GweiInputPill.js
+++ b/src/components/expanded-state/custom-gas/GweiInputPill.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { IS_TESTING } from 'react-native-dotenv';
 import LinearGradient from 'react-native-linear-gradient';
 import TextInputMask from 'react-native-text-input-mask';
 import { Row } from '../../../components/layout';
@@ -113,7 +114,7 @@ function GweiInputPill(
             testID={testID}
             value={value}
           />
-          <GweiLabel> Gwei</GweiLabel>
+          {IS_TESTING !== 'true' && <GweiLabel> Gwei</GweiLabel>}
         </Row>
       </GweiPill>
     </ButtonPressAnimation>


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

Gwei input was covering part of the text input, detox gets really mad when components are covered
https://cloud.skylarbarrera.com/Screen-Shot-2022-08-17-13-41-37.25.png

ive stopped rendering it and we passing now
https://cloud.skylarbarrera.com/Screen-Shot-2022-08-17-13-44-31.74.png

this is what it looks like after the change: https://cloud.skylarbarrera.com/Screen-Shot-2022-08-17-13-41-55.33.png


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

green = gucci


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
