### PR TITLE
fix: optional chain ensTokens to avoid NFT issues

### DIFF
--- a/src/redux/uniqueTokens.ts
+++ b/src/redux/uniqueTokens.ts
@@ -344,7 +344,7 @@ export const fetchUniqueTokens = (showcaseAddress?: string) => async (
       address: accountAddress,
       timeAgo: { hours: 48 },
     });
-    if (ensTokens.length > 0) {
+    if (ensTokens?.length > 0) {
       uniqueTokens = uniqBy([...uniqueTokens, ...ensTokens], 'uniqueId');
     }
   }


### PR DESCRIPTION
Fixes RNBW-4326

## What changed (plus any additional context for devs)
added optional chain check on the `ensTokens` array at the end of the `fetchUniqueTokens` function


## What to test
check that all Arbitrum NFTs are now correctly displayed in a watched wallet - can use 0xa49E47bD311596a30E440d46671cE50A83a0bd85 as an example, whose arbitrum NFTs can be viewed here: https://stratosnft.io/0xa49e47bd311596a30e440d46671ce50a83a0bd85


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
