### PR TITLE
Profiles: Fix issue where a user could not see their NFTs

### DIFF
--- a/src/apollo/queries.ts
+++ b/src/apollo/queries.ts
@@ -226,16 +226,18 @@ export const ENS_REGISTRATIONS = gql`
   }
 `;
 
+export type EnsDomain = {
+  name: string;
+  labelhash: string;
+  owner: {
+    id: string;
+  };
+};
+
 export type EnsAccountRegistratonsData = {
-  account: {
-    registrations: {
-      domain: {
-        name: string;
-        labelhash: string;
-        owner: {
-          id: string;
-        };
-      };
+  account?: {
+    registrations?: {
+      domain: EnsDomain;
     }[];
   };
 };

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -204,16 +204,20 @@ export const fetchEnsTokens = async ({
         ).toString(),
       },
     });
-    return data?.account?.registrations?.map(registration => {
-      const tokenId = BigNumber.from(registration.domain.labelhash).toString();
-      const token = buildEnsToken({
-        contractAddress,
-        imageUrl: `https://metadata.ens.domains/mainnet/${contractAddress}/${tokenId}/image`,
-        name: registration.domain.name,
-        tokenId,
-      });
-      return token;
-    });
+    return (
+      data?.account?.registrations?.map(registration => {
+        const tokenId = BigNumber.from(
+          registration.domain.labelhash
+        ).toString();
+        const token = buildEnsToken({
+          contractAddress,
+          imageUrl: `https://metadata.ens.domains/mainnet/${contractAddress}/${tokenId}/image`,
+          name: registration.domain.name,
+          tokenId,
+        });
+        return token;
+      }) || []
+    );
   } catch (error) {
     logger.sentry('ENS: Error getting ENS unique tokens', error);
     captureException(new Error('ENS: Error getting ENS unique tokens'));

--- a/src/hooks/useAccountENSDomains.ts
+++ b/src/hooks/useAccountENSDomains.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useQuery } from 'react-query';
 import useAccountProfile from './useAccountProfile';
 import { prefetchENSAvatar } from './useENSAvatar';
-import { EnsAccountRegistratonsData } from '@rainbow-me/apollo/queries';
+import { EnsDomain } from '@rainbow-me/apollo/queries';
 import { fetchAccountRegistrations } from '@rainbow-me/handlers/ens';
 import {
   getENSDomains,
@@ -59,7 +59,7 @@ export default function useAccountENSDomains() {
   const { accountAddress, accountENS } = useAccountProfile();
 
   const { data: domains, isLoading, isFetched, isSuccess } = useQuery<
-    EnsAccountRegistratonsData['account']['registrations'][number]['domain'][]
+    EnsDomain[]
   >(
     queryKey({ accountAddress }),
     async () => fetchENSDomainsWithCache({ accountAddress }),


### PR DESCRIPTION
Fixes RNBW-4283
Figma link (if any):

## What changed (plus any additional context for devs)

There was a bug where some users who do not have any ENS NFTs would not see their NFT collections. Seems like the cause of this was due to 2 related issues:
1. `fetchEnsTokens` returning a nullish value even though TypeScript says it is not nullish (`UniqueAsset[]`).
2. Seems like the typings for the ENS subgraph were incorrect, as `account` can be nullish, which caused the above issue to arise as TypeScript thought it was always defined. We should probably find a way to automate type syncing (and [use something like this](https://www.graphql-code-generator.com/)) between a remote GraphQL schema & the app. I can add this to the Data Fetching subproject in Code Foundations.

I fixed the above TypeScript issue, and also ensured `fetchEnsTokens` returns either an empty array, or an array of unique tokens for consistency.


## Screen recordings / screenshots

<img width="392" alt="Screen Shot 2022-08-18 at 11 53 41 am" src="https://user-images.githubusercontent.com/7336481/185274961-8c55550b-80a9-4858-be16-cd0b05728854.png">

<img width="387" alt="Screen Shot 2022-08-18 at 11 53 54 am" src="https://user-images.githubusercontent.com/7336481/185274968-4dd48565-9a11-48cc-9ba1-16177148ec71.png">



## What to test

- On the wallet screen, ensure accounts without ENS NFTs load their NFT collection (mainnet & L2 NFTs) successfully
- On the wallet screen, ensure accounts with ENS NFTs load their NFT collection (mainnet & L2 NFTs) successfully
- On the profile screen (via QR scan), ensure accounts without ENS NFTs load their NFT collection (mainnet & L2 NFTs) successfully
- On the profile screen, ensure accounts with ENS NFTs load their NFT collection (mainnet & L2 NFTs) successfully

