### PR TITLE
🐛 fix telegram link

### DIFF
--- a/src/hooks/useENSRecordDisplayProperties.tsx
+++ b/src/hooks/useENSRecordDisplayProperties.tsx
@@ -46,7 +46,7 @@ const links = {
   [ENS_RECORDS.github]: 'https://github.com/',
   [ENS_RECORDS.instagram]: 'https://instagram.com/',
   [ENS_RECORDS.reddit]: 'https://reddit.com/',
-  [ENS_RECORDS.telegram]: 'https://telegram.com/',
+  [ENS_RECORDS.telegram]: 'https://t.me/',
 } as { [key: string]: string };
 
 export default function useENSRecordDisplayProperties({


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

Until now, if someone had registered a telegram account in his ENS records, the front-end displayed a button that redirected anyone who clicked on it to the telegram newspaper. This commit fixes the link to redirect the user to the expected Telegram profile (the messaging app).

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

**Before**

https://user-images.githubusercontent.com/33158502/185438704-dc43eca1-9a21-40d6-9859-962e69cc2a81.mov

**After**

https://user-images.githubusercontent.com/33158502/185438739-a1feb8cc-1117-4812-9172-8094e1033a3d.mov

## What to test
<!-- 

- Go to https://rainbow.me/qdqdqd.eth
- Click on the Telegram button
- If you are redirected to `t.me`, it works as expected

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
