### PR TITLE
swaps: handle sdk errors + no quotes explainer

### DIFF
--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -22,7 +22,7 @@ export default function ConfirmExchangeButton({
   disabled,
   loading,
   isHighPriceImpact,
-  errorCode,
+  qouteError,
   onPressViewDetails,
   onSubmit,
   testID,
@@ -73,7 +73,7 @@ export default function ConfirmExchangeButton({
     : darkModeThemeColors.blueGreyDark04;
 
   const { buttonColor, shadowsForAsset } = useMemo(() => {
-    const color = errorCode
+    const color = qouteError
       ? disabledButtonColor
       : asset.address === ETH_ADDRESS
       ? colors.appleBlue
@@ -96,7 +96,7 @@ export default function ConfirmExchangeButton({
     colorForAsset,
     colors,
     disabledButtonColor,
-    errorCode,
+    qouteError,
     isDarkMode,
     isSwapDetailsRoute,
   ]);
@@ -134,8 +134,8 @@ export default function ConfirmExchangeButton({
     label = lang.t('button.confirm_exchange.enter_amount');
   }
 
-  if (errorCode) {
-    const error = handleSwapErrorCodes(errorCode);
+  if (qouteError) {
+    const error = handleSwapErrorCodes(qouteError);
     label = error.buttonLabel;
     explainerType = error.explainerType;
   }
@@ -169,12 +169,12 @@ export default function ConfirmExchangeButton({
           <HoldToAuthorizeButton
             backgroundColor={buttonColor}
             disableLongPress={
-              (shouldOpenSwapDetails && !errorCode) ||
+              (shouldOpenSwapDetails && !qouteError) ||
               loading ||
               isSwapSubmitting
             }
-            disableShimmerAnimation={errorCode}
-            disabled={isDisabled && !errorCode}
+            disableShimmerAnimation={qouteError}
+            disabled={isDisabled && !qouteError}
             disabledBackgroundColor={
               isSwapSubmitting ? buttonColor : disabledButtonColor
             }
@@ -193,7 +193,7 @@ export default function ConfirmExchangeButton({
             }
             shadows={
               isSwapDetailsRoute
-                ? isDisabled || errorCode
+                ? isDisabled || qouteError
                   ? shadows.disabled
                   : shadowsForAsset
                 : shadows.default

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -143,9 +143,11 @@ export default function ConfirmExchangeButton({
   const handleExplainer = useCallback(() => {
     android && Keyboard.dismiss();
     navigate(Routes.EXPLAIN_SHEET, {
+      inputCurrency,
+      outputCurrency,
       type: explainerType,
     });
-  }, [explainerType, navigate]);
+  }, [explainerType, inputCurrency, navigate, outputCurrency]);
 
   const isDisabled =
     disabled ||

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -5,6 +5,7 @@ import React, { useCallback, useMemo } from 'react';
 import { Keyboard } from 'react-native';
 import { darkModeThemeColors } from '../../styles/colors';
 import { HoldToAuthorizeButton } from '../buttons';
+import handleSwapErrorCodes from '@/utils/exchangeErrorCodes';
 import { Box, Row, Rows } from '@rainbow-me/design-system';
 import { ExchangeModalTypes, NetworkTypes } from '@rainbow-me/helpers';
 import { useColorForAsset, useGas, useSwapCurrencies } from '@rainbow-me/hooks';
@@ -101,6 +102,7 @@ export default function ConfirmExchangeButton({
   ]);
 
   let label = '';
+  let explainerType = null;
 
   if (type === ExchangeModalTypes.deposit) {
     label = lang.t('button.confirm_exchange.deposit');
@@ -133,15 +135,17 @@ export default function ConfirmExchangeButton({
   }
 
   if (errorCode) {
-    label = lang.t('button.confirm_exchange.insufficient_liquidity');
+    const error = handleSwapErrorCodes(errorCode);
+    label = error.buttonLabel;
+    explainerType = error.explainerType;
   }
 
-  const handleShowLiquidityExplainer = useCallback(() => {
+  const handleExplainer = useCallback(() => {
     android && Keyboard.dismiss();
     navigate(Routes.EXPLAIN_SHEET, {
-      type: 'insufficientLiquidity',
+      type: explainerType,
     });
-  }, [navigate]);
+  }, [explainerType, navigate]);
 
   const isDisabled =
     disabled ||
@@ -179,8 +183,8 @@ export default function ConfirmExchangeButton({
             onLongPress={
               loading || isSwapSubmitting
                 ? NOOP
-                : errorCode
-                ? handleShowLiquidityExplainer
+                : explainerType
+                ? handleExplainer
                 : shouldOpenSwapDetails
                 ? onPressViewDetails
                 : onSwap

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -21,7 +21,7 @@ export default function ConfirmExchangeButton({
   disabled,
   loading,
   isHighPriceImpact,
-  insufficientLiquidity,
+  errorCode,
   onPressViewDetails,
   onSubmit,
   testID,
@@ -72,7 +72,7 @@ export default function ConfirmExchangeButton({
     : darkModeThemeColors.blueGreyDark04;
 
   const { buttonColor, shadowsForAsset } = useMemo(() => {
-    const color = insufficientLiquidity
+    const color = errorCode
       ? disabledButtonColor
       : asset.address === ETH_ADDRESS
       ? colors.appleBlue
@@ -95,7 +95,7 @@ export default function ConfirmExchangeButton({
     colorForAsset,
     colors,
     disabledButtonColor,
-    insufficientLiquidity,
+    errorCode,
     isDarkMode,
     isSwapDetailsRoute,
   ]);
@@ -132,7 +132,7 @@ export default function ConfirmExchangeButton({
     label = lang.t('button.confirm_exchange.enter_amount');
   }
 
-  if (insufficientLiquidity) {
+  if (errorCode) {
     label = lang.t('button.confirm_exchange.insufficient_liquidity');
   }
 
@@ -163,12 +163,12 @@ export default function ConfirmExchangeButton({
           <HoldToAuthorizeButton
             backgroundColor={buttonColor}
             disableLongPress={
-              (shouldOpenSwapDetails && !insufficientLiquidity) ||
+              (shouldOpenSwapDetails && !errorCode) ||
               loading ||
               isSwapSubmitting
             }
-            disableShimmerAnimation={insufficientLiquidity}
-            disabled={isDisabled && !insufficientLiquidity}
+            disableShimmerAnimation={errorCode}
+            disabled={isDisabled && !errorCode}
             disabledBackgroundColor={
               isSwapSubmitting ? buttonColor : disabledButtonColor
             }
@@ -179,7 +179,7 @@ export default function ConfirmExchangeButton({
             onLongPress={
               loading || isSwapSubmitting
                 ? NOOP
-                : insufficientLiquidity
+                : errorCode
                 ? handleShowLiquidityExplainer
                 : shouldOpenSwapDetails
                 ? onPressViewDetails
@@ -187,7 +187,7 @@ export default function ConfirmExchangeButton({
             }
             shadows={
               isSwapDetailsRoute
-                ? isDisabled || insufficientLiquidity
+                ? isDisabled || errorCode
                   ? shadows.disabled
                   : shadowsForAsset
                 : shadows.default

--- a/src/components/exchange/ConfirmExchangeButton.js
+++ b/src/components/exchange/ConfirmExchangeButton.js
@@ -22,7 +22,7 @@ export default function ConfirmExchangeButton({
   disabled,
   loading,
   isHighPriceImpact,
-  qouteError,
+  quoteError,
   onPressViewDetails,
   onSubmit,
   testID,
@@ -73,7 +73,7 @@ export default function ConfirmExchangeButton({
     : darkModeThemeColors.blueGreyDark04;
 
   const { buttonColor, shadowsForAsset } = useMemo(() => {
-    const color = qouteError
+    const color = quoteError
       ? disabledButtonColor
       : asset.address === ETH_ADDRESS
       ? colors.appleBlue
@@ -96,7 +96,7 @@ export default function ConfirmExchangeButton({
     colorForAsset,
     colors,
     disabledButtonColor,
-    qouteError,
+    quoteError,
     isDarkMode,
     isSwapDetailsRoute,
   ]);
@@ -134,8 +134,8 @@ export default function ConfirmExchangeButton({
     label = lang.t('button.confirm_exchange.enter_amount');
   }
 
-  if (qouteError) {
-    const error = handleSwapErrorCodes(qouteError);
+  if (quoteError) {
+    const error = handleSwapErrorCodes(quoteError);
     label = error.buttonLabel;
     explainerType = error.explainerType;
   }
@@ -169,12 +169,12 @@ export default function ConfirmExchangeButton({
           <HoldToAuthorizeButton
             backgroundColor={buttonColor}
             disableLongPress={
-              (shouldOpenSwapDetails && !qouteError) ||
+              (shouldOpenSwapDetails && !quoteError) ||
               loading ||
               isSwapSubmitting
             }
-            disableShimmerAnimation={qouteError}
-            disabled={isDisabled && !qouteError}
+            disableShimmerAnimation={quoteError}
+            disabled={isDisabled && !quoteError}
             disabledBackgroundColor={
               isSwapSubmitting ? buttonColor : disabledButtonColor
             }
@@ -193,7 +193,7 @@ export default function ConfirmExchangeButton({
             }
             shadows={
               isSwapDetailsRoute
-                ? isDisabled || qouteError
+                ? isDisabled || quoteError
                   ? shadows.disabled
                   : shadowsForAsset
                 : shadows.default

--- a/src/components/icons/DoubleChevron.tsx
+++ b/src/components/icons/DoubleChevron.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { RowWithMargins } from '../layout';
+import { Bleed, Cover, Text } from '@rainbow-me/design-system';
+const DoubleChevron = () => (
+  <Cover alignHorizontal="center" alignVertical="center">
+    <RowWithMargins>
+      <Text color="secondary60" weight="semibold">
+        􀯻
+      </Text>
+      <Bleed left="6px">
+        <Text color="secondary40" weight="semibold">
+          􀯻
+        </Text>
+      </Bleed>
+    </RowWithMargins>
+  </Cover>
+);
+
+export default DoubleChevron;

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -1,2 +1,3 @@
 export { default as Icon } from './Icon';
 export { default as Svg, AnimatedSvg } from './Svg';
+export { default as DoubleChevron } from './DoubleChevron';

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -390,7 +390,7 @@ const useSwapCurrencyList = (
       if (lowLiquidityAssetsWithoutImport?.length) {
         list.push({
           data: lowLiquidityAssetsWithoutImport,
-          key: 'lowLiqudiity',
+          key: 'lowLiquidity',
           title: tokenSectionTypes.lowLiquidityTokenSection,
         });
       }

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -556,8 +556,8 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   });
 
   return {
-    errorCode: data?.quoteError || null,
     loading: isLoading && Boolean(independentValue),
+    quoteError: data?.quoteError || null,
     resetSwapInputs,
     result: data?.result || {
       derivedValues,

--- a/src/hooks/useSwapDerivedOutputs.ts
+++ b/src/hooks/useSwapDerivedOutputs.ts
@@ -104,9 +104,9 @@ const getInputAmount = async (
           msg: quoteError.message,
         });
         return {
-          errorCode: quoteError,
           inputAmount: null,
           inputAmountDisplay: null,
+          quoteError: quoteError,
           tradeDetails: null,
         };
       }
@@ -204,9 +204,9 @@ const getOutputAmount = async (
           msg: quoteError.message,
         });
         return {
-          errorCode: quoteError,
           outputAmount: null,
           outputAmountDisplay: null,
+          quoteError,
           tradeDetails: null,
         };
       }
@@ -305,12 +305,12 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       updateSwapQuote({
         derivedValues,
         displayValues,
-        errorCode: null,
+        quoteError: null,
         tradeDetails: null,
       })
     );
     return {
-      errorCode: null,
+      quoteError: null,
       result: { derivedValues, displayValues, tradeDetails: null },
     };
   }, [dispatch]);
@@ -338,7 +338,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       }
 
       return {
-        errorCode: null,
+        quoteError: null,
         result: {
           derivedValues,
           displayValues,
@@ -353,7 +353,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
     const inputToken = inputCurrency;
     const outputToken = outputCurrency;
     const slippagePercentage = slippageInBips / 100;
-    let errorCode: QuoteError | undefined;
+    let quoteError: QuoteError | undefined;
 
     if (independentField === SwapModalField.input) {
       derivedValues[SwapModalField.input] = independentValue;
@@ -372,7 +372,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
         outputAmount,
         outputAmountDisplay,
         tradeDetails: newTradeDetails,
-        errorCode: newErrorCode,
+        quoteError: newQuoteError,
       } = await getOutputAmount(
         independentValue,
         inputToken,
@@ -387,7 +387,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       if (derivedValues[SwapModalField.input] !== independentValue) return;
 
       tradeDetails = newTradeDetails;
-      errorCode = newErrorCode;
+      quoteError = newQuoteError;
       derivedValues[SwapModalField.output] = outputAmount;
       // @ts-ignore next-line
       displayValues[DisplayValue.output] = outputAmount
@@ -421,7 +421,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
         outputAmount,
         outputAmountDisplay,
         tradeDetails: newTradeDetails,
-        errorCode: newErrorCode,
+        quoteError: newQuoteError,
       } = await getOutputAmount(
         inputAmount,
         inputToken,
@@ -436,14 +436,14 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       if (derivedValues[SwapModalField.native] !== independentValue) return;
 
       tradeDetails = newTradeDetails;
-      errorCode = newErrorCode;
+      quoteError = newQuoteError;
       derivedValues[SwapModalField.output] = outputAmount;
       displayValues[DisplayValue.output] =
         outputAmountDisplay?.toString() || null;
     } else {
       if (!outputToken || !inputToken) {
         return {
-          errorCode: null,
+          quoteError: null,
           result: {
             derivedValues,
             displayValues,
@@ -459,7 +459,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
         inputAmount,
         inputAmountDisplay,
         tradeDetails: newTradeDetails,
-        errorCode: newErrorCode,
+        quoteError: newQuoteError,
       } = await getInputAmount(
         independentValue,
         inputToken,
@@ -472,7 +472,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       );
       // if original value changed, ignore new quote
       if (derivedValues[SwapModalField.output] !== independentValue) return;
-      errorCode = newErrorCode;
+      quoteError = newQuoteError;
 
       tradeDetails = newTradeDetails;
       derivedValues[SwapModalField.input] = inputAmount || '0';
@@ -491,7 +491,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       derivedValues,
       displayValues,
       doneLoadingReserves: true,
-      errorCode,
+      quoteError,
       tradeDetails,
     };
 
@@ -517,7 +517,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
       type,
     });
 
-    return { errorCode, result: data };
+    return { quoteError, result: data };
   }, [
     accountAddress,
     chainId,
@@ -556,7 +556,7 @@ export default function useSwapDerivedOutputs(chainId: number, type: string) {
   });
 
   return {
-    errorCode: data?.errorCode || null,
+    errorCode: data?.quoteError || null,
     loading: isLoading && Boolean(independentValue),
     resetSwapInputs,
     result: data?.result || {

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -657,7 +657,7 @@
       },
       "no_quote": {
         "title": "No quote available",
-        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the  token is implemented."
+        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the token is implemented."
       },
       "go_to_hop_with_icon": {
         "text": "Go to the Hop Bridge 􀮶"

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -198,7 +198,7 @@
         "invalid_fee": "Invalid Fee",
         "invalid_fee_lowercase": "Invalid fee",
         "loading": "Loading...",
-        "no_quote_available": "No Quote Available",
+        "no_quote_available": "􀅵 No Quote Available",
         "review": "Review",
         "submitting": "Submitting",
         "swap": "Hold to Swap",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -198,6 +198,7 @@
         "invalid_fee": "Invalid Fee",
         "invalid_fee_lowercase": "Invalid fee",
         "loading": "Loading...",
+        "no_quote_available": "No Quote Available",
         "review": "Review",
         "submitting": "Submitting",
         "swap": "Hold to Swap",
@@ -653,6 +654,10 @@
         "fragment2": "Read more",
         "fragment3": " about AMMs and token liquidity.",
         "title": "Insufficient Liquidity"
+      },
+      "no_quote": {
+        "title": "No quote available",
+        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the  token is implemented."
       },
       "go_to_hop_with_icon": {
         "text": "Go to the Hop Bridge 􀮶"

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -657,7 +657,7 @@
       },
       "no_quote": {
         "title": "No quote available",
-        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the token is implemented."
+        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liquidity to swap or problems with how the token is implemented."
       },
       "go_to_hop_with_icon": {
         "text": "Go to the Hop Bridge 􀮶"

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -643,7 +643,7 @@
       },
       "no_quote": {
         "title": "No quote available",
-        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the  token is implemented."
+        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the token is implemented."
       },
       "unverified": {
         "fragment1": "Rainbow surfaces as many tokens as possible, but anyone can create a token, or claim to represent a project with a fake contract. \n\n Please review the :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -643,7 +643,7 @@
       },
       "no_quote": {
         "title": "No quote available",
-        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the token is implemented."
+        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liquidity to swap or problems with how the token is implemented."
       },
       "unverified": {
         "fragment1": "Rainbow surfaces as many tokens as possible, but anyone can create a token, or claim to represent a project with a fake contract. \n\n Please review the :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -197,6 +197,7 @@
         "invalid_fee": "Frais Non Valides",
         "invalid_fee_lowercase": "Frais non valides",
         "loading": "Loading... :)",
+        "no_quote_available": "No Quote Available :)",
         "review": "Review :)",
         "submitting": "Submitting :)",
         "swap": "Tenir pour Swap",
@@ -639,6 +640,10 @@
         "fragment2": "Read more :)",
         "fragment3": " about AMMs and token liquidity. :)",
         "title": "Insufficient Liquidity :)"
+      },
+      "no_quote": {
+        "title": "No quote available",
+        "text": "We couldn’t find quotes for this swap. This could be because there isn’t enough liqudity to swap or problems with how the  token is implemented."
       },
       "unverified": {
         "fragment1": "Rainbow surfaces as many tokens as possible, but anyone can create a token, or claim to represent a project with a fake contract. \n\n Please review the :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -197,7 +197,7 @@
         "invalid_fee": "Frais Non Valides",
         "invalid_fee_lowercase": "Frais non valides",
         "loading": "Loading... :)",
-        "no_quote_available": "No Quote Available :)",
+        "no_quote_available": "􀅵 No Quote Available :)",
         "review": "Review :)",
         "submitting": "Submitting :)",
         "swap": "Tenir pour Swap",

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -1,4 +1,4 @@
-import { Quote } from '@rainbow-me/swaps';
+import { Quote, QuoteError } from '@rainbow-me/swaps';
 import { AnyAction } from 'redux';
 import { fetchAssetPrices } from './explorer';
 import { SwappableAsset } from '@rainbow-me/entities';
@@ -31,6 +31,7 @@ interface SwapState {
   derivedValues: any;
   displayValues: any;
   depositCurrency: SwappableAsset | null;
+  errorCode: QuoteError | null;
   inputCurrency: SwappableAsset | null;
   independentField: SwapModalField;
   independentValue: string | null;
@@ -236,6 +237,7 @@ const INITIAL_STATE: SwapState = {
   depositCurrency: null,
   derivedValues: null,
   displayValues: null,
+  errorCode: null,
   flipCurrenciesUpdate: false,
   independentField: SwapModalField.input,
   independentValue: null,
@@ -256,6 +258,7 @@ export default (state = INITIAL_STATE, action: AnyAction) => {
         ...state,
         derivedValues: action.payload.derivedValues,
         displayValues: action.payload.displayValues,
+        errorCode: action.payload.errorCode,
         tradeDetails: action.payload.tradeDetails,
       };
     case SWAP_UPDATE_TYPE_DETAILS:

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -31,7 +31,7 @@ interface SwapState {
   derivedValues: any;
   displayValues: any;
   depositCurrency: SwappableAsset | null;
-  errorCode: QuoteError | null;
+  quoteError: QuoteError | null;
   inputCurrency: SwappableAsset | null;
   independentField: SwapModalField;
   independentValue: string | null;
@@ -237,13 +237,13 @@ const INITIAL_STATE: SwapState = {
   depositCurrency: null,
   derivedValues: null,
   displayValues: null,
-  errorCode: null,
   flipCurrenciesUpdate: false,
   independentField: SwapModalField.input,
   independentValue: null,
   inputCurrency: null,
   maxInputUpdate: false,
   outputCurrency: null,
+  quoteError: null,
   slippageInBips: 100,
   source: Source.AggregatorRainbow,
   tradeDetails: null,
@@ -258,7 +258,7 @@ export default (state = INITIAL_STATE, action: AnyAction) => {
         ...state,
         derivedValues: action.payload.derivedValues,
         displayValues: action.payload.displayValues,
-        errorCode: action.payload.errorCode,
+        quoteError: action.payload.quoteError,
         tradeDetails: action.payload.tradeDetails,
       };
     case SWAP_UPDATE_TYPE_DETAILS:

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -340,7 +340,7 @@ export default function ExchangeModal({
     },
     loading,
     resetSwapInputs,
-    insufficientLiquidity,
+    errorCode,
   } = useSwapDerivedOutputs(chainId, type);
 
   const lastTradeDetails = usePrevious(tradeDetails);
@@ -725,8 +725,8 @@ export default function ExchangeModal({
       currentNetwork,
       disabled:
         !Number(inputAmount) || (!loading && !tradeDetails && !isSavings),
+      errorCode,
       inputAmount,
-      insufficientLiquidity,
       isAuthorizing,
       isHighPriceImpact: debouncedIsHighPriceImpact,
       isSufficientBalance,
@@ -745,7 +745,7 @@ export default function ExchangeModal({
       testID,
       tradeDetails,
       type,
-      insufficientLiquidity,
+      errorCode,
       isSufficientBalance,
     ]
   );

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -340,7 +340,7 @@ export default function ExchangeModal({
     },
     loading,
     resetSwapInputs,
-    errorCode,
+    quoteError,
   } = useSwapDerivedOutputs(chainId, type);
 
   const lastTradeDetails = usePrevious(tradeDetails);
@@ -725,13 +725,13 @@ export default function ExchangeModal({
       currentNetwork,
       disabled:
         !Number(inputAmount) || (!loading && !tradeDetails && !isSavings),
-      errorCode,
       inputAmount,
       isAuthorizing,
       isHighPriceImpact: debouncedIsHighPriceImpact,
       isSufficientBalance,
       loading,
       onSubmit: handleSubmit,
+      quoteError,
       tradeDetails,
       type,
     }),
@@ -745,7 +745,7 @@ export default function ExchangeModal({
       testID,
       tradeDetails,
       type,
-      errorCode,
+      quoteError,
       isSufficientBalance,
     ]
   );

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -5,10 +5,17 @@ import React, { useCallback, useMemo } from 'react';
 import { Linking, StatusBar } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
 import { ChainBadge, CoinIcon } from '../components/coin-icon';
-import { Centered, Column, ColumnWithMargins, Row } from '../components/layout';
+import {
+  Centered,
+  Column,
+  ColumnWithMargins,
+  Row,
+  RowWithMargins,
+} from '../components/layout';
 import { SheetActionButton, SheetTitle, SlackSheet } from '../components/sheet';
 import { Emoji, GradientText, Text } from '../components/text';
 import { useNavigation } from '../navigation/Navigation';
+import { DoubleChevron } from '@/components/icons';
 import { Box } from '@/design-system';
 import AppIconOptimism from '@rainbow-me/assets/appIconOptimism.png';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
@@ -474,6 +481,19 @@ export const explainers = (params, colors) => ({
         </Text>
         {lang.t('explain.insufficient_liquidity.fragment3')}
       </Text>
+    ),
+  },
+  noQuote: {
+    extraHeight: -90,
+    emoji: '🏦',
+    title: lang.t('explain.no_quote.title'),
+    text: lang.t('explain.no_quote.text'),
+    logo: (
+      <RowWithMargins justify="center" margin={35} marginBottom={10}>
+        <CoinIcon size={40} {...params?.inputCurrency} />
+        <DoubleChevron />
+        <CoinIcon size={40} {...params?.outputCurrency} />
+      </RowWithMargins>
     ),
   },
   availableNetworks: {

--- a/src/utils/exchangeErrorCodes.ts
+++ b/src/utils/exchangeErrorCodes.ts
@@ -1,32 +1,34 @@
 import { QuoteError } from '@rainbow-me/swaps';
 import lang from 'i18n-js';
 
-export interface ExchangeErrorCode extends QuoteError {
+export interface ExchangeQuoteError extends QuoteError {
   buttonLabel: string;
-  explainer: string;
+  explainerType: string;
 }
 
-export default function handleSwapErrorCodes(error: QuoteError) {
-  const { error_code: errorCode } = error;
+export default function handleSwapErrorCodes(
+  quoteError: QuoteError
+): ExchangeQuoteError {
+  const { error_code: errorCode } = quoteError;
   switch (errorCode) {
     case 501:
       return {
         buttonLabel: lang.t('button.confirm_exchange.no_quote_available'),
         explainerType: 'noQuote',
-        ...error,
+        ...quoteError,
       };
     case 502:
       return {
         buttonLabel: lang.t('button.confirm_exchange.insufficient_liquidity'),
         explainerType: 'insufficientLiquidity',
-        ...error,
+        ...quoteError,
       };
 
     default:
       return {
         buttonLabel: lang.t('button.confirm_exchange.no_quote_available'),
         explainerType: 'noQuote',
-        ...error,
+        ...quoteError,
       };
   }
 }

--- a/src/utils/exchangeErrorCodes.ts
+++ b/src/utils/exchangeErrorCodes.ts
@@ -1,0 +1,32 @@
+import { QuoteError } from '@rainbow-me/swaps';
+import lang from 'i18n-js';
+
+export interface ExchangeErrorCode extends QuoteError {
+  buttonLabel: string;
+  explainer: string;
+}
+
+export default function handleSwapErrorCodes(error: QuoteError) {
+  const { error_code: errorCode } = error;
+  switch (errorCode) {
+    case 501:
+      return {
+        buttonLabel: lang.t('button.confirm_exchange.no_quote_available'),
+        explainerType: 'noQuote',
+        ...error,
+      };
+    case 502:
+      return {
+        buttonLabel: lang.t('button.confirm_exchange.insufficient_liquidity'),
+        explainerType: 'insufficientLiquidity',
+        ...error,
+      };
+
+    default:
+      return {
+        buttonLabel: lang.t('button.confirm_exchange.no_quote_available'),
+        explainerType: 'noQuote',
+        ...error,
+      };
+  }
+}


### PR DESCRIPTION
Fixes TEAM2-327
Figma link (if any):

## What changed (plus any additional context for devs)
I added a helper to handle all error cases from the sdk, piped up the no quotes explainer and set it as the default so it acts as a catch all if the client doesn't have an up to date mapping


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://cloud.skylarbarrera.com/Screen-Recording-2022-08-18-11-57-29.mp4


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

best way to trigger no quotes naturally is to try to sell stETh

normal swap inputs + quotes should be unaffected 


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
