### PR TITLE
Note about ProfileMasthead being used by Android

### DIFF
--- a/src/components/profile/ProfileMasthead.js
+++ b/src/components/profile/ProfileMasthead.js
@@ -23,6 +23,11 @@ import Routes from '@rainbow-me/routes';
 import styled from '@rainbow-me/styled-components';
 import { abbreviations } from '@rainbow-me/utils';
 
+// NOTE:
+// If you’re trying to edit this file for iOS and you’re not seeing any changes,
+// that’s because iOS is using the Swift version — TransactionListViewHeader.
+// Only Android is using this file at the moment.
+
 const dropdownArrowWidth = 21;
 
 const FloatingEmojisRegion = styled(FloatingEmojis).attrs({


### PR DESCRIPTION
Adding a note about this view in case anyone ends up wasting a bunch of hours wondering why nothing is happening on iOS when you make changes to this file. Related to TEAM2-418.