### PR TITLE
Profiles: Add more E2E test coverage for view/edit profile

### DIFF
--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -292,7 +292,6 @@ describe('Register ENS Flow', () => {
     await Helpers.typeText('ens-text-record-description', RECORD_BIO, false);
     await Helpers.clearField('ens-text-record-me.rainbow.displayName');
     await Helpers.waitAndTap('use-select-image-avatar');
-    await Helpers.tapByText('Choose an NFT');
     await Helpers.tapByText('CryptoKitties');
     await Helpers.tapByText('Arun Cattybinky');
     await Helpers.checkIfVisible('ens-assign-records-review-action-button');

--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -474,7 +474,6 @@ describe('Register ENS Flow', () => {
     // Fill "Website" field
     await Helpers.checkIfVisible('ens-text-record-url');
     await Helpers.typeText('ens-text-record-url', 'abc', false);
-    await Helpers.tapByText('Got it');
     await Helpers.waitAndTap('ens-text-record-url-error');
     await Helpers.checkIfElementByTextToExist('Invalid URL');
     await Helpers.tapByText('OK');

--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -22,8 +22,21 @@ const RAINBOW_WALLET_NAME = 'rainbowwallet.eth';
 const RAINBOW_WALLET_ADDRESS = '0x7a3d05c70581bD345fe117c06e45f9669205384f';
 const RECORD_BIO = 'my bio';
 const RECORD_NAME = 'random';
+const RECORD_TWITTER = 'twitter123';
+const RECORD_EMAIL = 'abc@abc.com';
+const RECORD_INSTAGRAM = 'insta123';
+const RECORD_DISCORD = 'abc#8133';
+const RECORD_GITHUB = 'github123';
+const RECORD_SNAPCHAT = 'snapchat123';
+const RECORD_TELEGRAM = 'telegram123';
+const RECORD_REDDIT = 'reddit123';
+const RECORD_PRONOUNS = 'they/them';
+const RECORD_NOTICE = 'notice123';
+const RECORD_KEYWORDS = 'keywords123';
+const RECORD_URL = 'abc123.com';
 const EIP155_FORMATTED_AVATAR_RECORD =
   'eip155:1/erc721:0x06012c8cf97bead5deae237070f9587f8e7a266d/1368227';
+const WALLET_AVATAR_COORDS = { x: 210, y: 125 };
 
 const address = (address, start, finish) =>
   [
@@ -61,13 +74,47 @@ const getRecords = async ensName => {
     provider
   );
   const hashName = hash(ensName);
-  const description = await publicResolver.text(hashName, 'description');
-  const displayName = await publicResolver.text(
-    hashName,
-    'me.rainbow.displayName'
-  );
-  const avatar = await publicResolver.text(hashName, 'avatar');
-  return { avatar, description, displayName };
+  const [
+    avatar,
+    description,
+    displayName,
+    url,
+    twitter,
+    email,
+    instagram,
+    discord,
+    github,
+    snapchat,
+    telegram,
+    reddit,
+  ] = await Promise.all([
+    publicResolver.text(hashName, 'avatar'),
+    publicResolver.text(hashName, 'description'),
+    publicResolver.text(hashName, 'me.rainbow.displayName'),
+    publicResolver.text(hashName, 'url'),
+    publicResolver.text(hashName, 'com.twitter'),
+    publicResolver.text(hashName, 'email'),
+    publicResolver.text(hashName, 'com.instagram'),
+    publicResolver.text(hashName, 'com.discord'),
+    publicResolver.text(hashName, 'com.github'),
+    publicResolver.text(hashName, 'com.snapchat'),
+    publicResolver.text(hashName, 'org.telegram'),
+    publicResolver.text(hashName, 'com.reddit'),
+  ]);
+  return {
+    avatar,
+    description,
+    discord,
+    displayName,
+    email,
+    github,
+    instagram,
+    reddit,
+    snapchat,
+    telegram,
+    twitter,
+    url,
+  };
 };
 
 const resolveName = async ensName => {
@@ -170,6 +217,7 @@ describe('Register ENS Flow', () => {
   });
 
   it('Should show Hardhat Toast after pressing Connect To Hardhat', async () => {
+    await Helpers.swipe('developer-settings-sheet', 'up', 'slow');
     await Helpers.waitAndTap('hardhat-section');
     await Helpers.checkIfVisible('testnet-toast-Hardhat');
   });
@@ -244,6 +292,7 @@ describe('Register ENS Flow', () => {
     await Helpers.typeText('ens-text-record-description', RECORD_BIO, false);
     await Helpers.clearField('ens-text-record-me.rainbow.displayName');
     await Helpers.waitAndTap('use-select-image-avatar');
+    await Helpers.tapByText('Choose an NFT');
     await Helpers.tapByText('CryptoKitties');
     await Helpers.tapByText('Arun Cattybinky');
     await Helpers.checkIfVisible('ens-assign-records-review-action-button');
@@ -350,10 +399,258 @@ describe('Register ENS Flow', () => {
       `change-wallet-address-row-label-${RAINBOW_TEST_WALLET_NAME}`
     );
     await Helpers.swipe('change-wallet-sheet-title', 'down', 'slow');
-    await Helpers.swipe('profile-screen', 'left', 'slow');
+  });
+
+  it('Should open the View Profile Sheet after tapping "View Profile"', async () => {
+    await Helpers.tapAtPoint('profile-screen', WALLET_AVATAR_COORDS);
+    await Helpers.checkIfExistsByText('View Profile');
+    await Helpers.tapByText('View Profile');
+    await Helpers.checkIfExists('profile-sheet');
+    await Helpers.checkIfExistsByText('rainbowtestwallet.eth');
+    await Helpers.checkIfExistsByText('Test2');
+    await Helpers.swipe('profile-sheet', 'down');
+  });
+
+  it('Should open the Edit Profile Sheet after tapping "Edit Profile"', async () => {
+    await Helpers.tapAtPoint('profile-screen', WALLET_AVATAR_COORDS);
+    await Helpers.checkIfExistsByText('Edit Profile');
+    await Helpers.tapByText('Edit Profile');
+    await Helpers.checkIfExists('ens-edit-records-sheet');
+    await Helpers.checkIfExistsByText('rainbowtestwallet.eth');
+    await Helpers.checkIfExistsByText('Name');
+    await Helpers.checkIfExistsByText('Bio');
+  });
+
+  it('Should select ENS attributes in the Edit Profile Sheet', async () => {
+    // Select all the attributes
+    await Helpers.waitAndTap('ens-selectable-attribute-website');
+    await Helpers.waitAndTap('ens-selectable-attribute-twitter');
+    await Helpers.waitAndTap('ens-selectable-attribute-email');
+    await Helpers.waitAndTap('ens-selectable-attribute-instagram');
+    await Helpers.waitAndTap('ens-selectable-attribute-discord');
+    await Helpers.waitAndTap('ens-selectable-attribute-github');
+    await Helpers.waitAndTap('ens-selectable-attribute-btc');
+    await Helpers.waitAndTap('ens-selectable-attribute-dots');
+    await Helpers.waitAndTap('ens-selectable-attribute-snapchat');
+    await Helpers.waitAndTap('ens-selectable-attribute-telegram');
+    await Helpers.waitAndTap('ens-selectable-attribute-reddit');
+    await Helpers.waitAndTap('ens-selectable-attribute-pronouns');
+    await Helpers.waitAndTap('ens-selectable-attribute-notice');
+    await Helpers.waitAndTap('ens-selectable-attribute-keywords');
+    await Helpers.waitAndTap('ens-selectable-attribute-ltc');
+    await Helpers.waitAndTap('ens-selectable-attribute-doge');
+    await Helpers.waitAndTap('ens-selectable-attribute-content');
+
+    // Dismiss the bottom attribute sheet
+    await Helpers.swipe('ens-additional-records-sheet', 'down');
+
+    // Validate that the fields are there
+    await Helpers.checkIfExistsByText('Website');
+    await Helpers.checkIfExistsByText('Twitter');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Email');
+    await Helpers.checkIfExistsByText('Instagram');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Discord');
+    await Helpers.checkIfExistsByText('GitHub');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Bitcoin');
+    await Helpers.checkIfExistsByText('Snapchat');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Telegram');
+    await Helpers.checkIfExistsByText('Reddit');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Pronouns');
+    await Helpers.checkIfExistsByText('Notice');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Keywords');
+    await Helpers.checkIfExistsByText('Litecoin');
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.checkIfExistsByText('Dogecoin');
+    await Helpers.checkIfExistsByText('Content');
+    await Helpers.swipe('ens-edit-records-sheet', 'down');
+  });
+
+  it('Should fill & validate the fields', async () => {
+    // Fill "Website" field
+    await Helpers.checkIfVisible('ens-text-record-url');
+    await Helpers.typeText('ens-text-record-url', 'abc', false);
+    await Helpers.tapByText('Got it');
+    await Helpers.waitAndTap('ens-text-record-url-error');
+    await Helpers.checkIfElementByTextToExist('Invalid URL');
+    await Helpers.tapByText('OK');
+    await Helpers.typeText('ens-text-record-url', '123.com', false);
+    await Helpers.delay(1000);
+    await Helpers.checkIfNotVisible('ens-text-record-url-error');
+
+    // Fill "Twitter" field
+    await Helpers.typeText(
+      'ens-text-record-com.twitter',
+      RECORD_TWITTER,
+      false
+    );
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+
+    // Fill "Email" field
+    await Helpers.typeText(
+      'ens-text-record-email',
+      RECORD_EMAIL.slice(0, 3),
+      false
+    );
+    await Helpers.waitAndTap('ens-text-record-email-error');
+    await Helpers.checkIfElementByTextToExist('Invalid email');
+    await Helpers.tapByText('OK');
+    await Helpers.typeText(
+      'ens-text-record-email',
+      RECORD_EMAIL.slice(3),
+      false
+    );
+    await Helpers.delay(1000);
+    await Helpers.checkIfNotVisible('ens-text-record-email-error');
+
+    // Fill "Instagram" field
+    await Helpers.typeText(
+      'ens-text-record-com.instagram',
+      RECORD_INSTAGRAM,
+      false
+    );
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+
+    // Fill "Discord" field
+    await Helpers.typeText(
+      'ens-text-record-com.discord',
+      RECORD_DISCORD.slice(0, 3),
+      false
+    );
+    await Helpers.waitAndTap('ens-text-record-com.discord-error');
+    await Helpers.checkIfElementByTextToExist('Invalid Discord username');
+    await Helpers.tapByText('OK');
+    await Helpers.typeText(
+      'ens-text-record-com.discord',
+      RECORD_DISCORD.slice(3),
+      false
+    );
+    await Helpers.delay(1000);
+    await Helpers.checkIfNotVisible('ens-text-record-com.discord-error');
+
+    // Fill "GitHub" field
+    await Helpers.typeText('ens-text-record-com.github', RECORD_GITHUB, false);
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+  });
+
+  it('Should fill & validate the fields 2', async () => {
+    // Fill "Bitcoin" field
+    await Helpers.typeText('ens-text-record-BTC', '1F1', false);
+    await Helpers.waitAndTap('ens-text-record-BTC-error');
+    await Helpers.checkIfElementByTextToExist('Invalid BTC address');
+    await Helpers.tapByText('OK');
+    await Helpers.typeText(
+      'ens-text-record-BTC',
+      'tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX',
+      false
+    );
+    await Helpers.delay(3000);
+    await Helpers.checkIfNotVisible('ens-text-record-BTC-error');
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+
+    // Fill "Snapchat" field
+    await Helpers.typeText(
+      'ens-text-record-com.snapchat',
+      RECORD_SNAPCHAT,
+      false
+    );
+
+    // Fill "Telegram" field
+    await Helpers.typeText(
+      'ens-text-record-org.telegram',
+      RECORD_TELEGRAM,
+      false
+    );
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+
+    // Fill "Reddit" field
+    await Helpers.typeText('ens-text-record-com.reddit', RECORD_REDDIT, false);
+
+    // Fill "Pronouns" field
+    await Helpers.typeText('ens-text-record-pronouns', RECORD_PRONOUNS, false);
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+
+    // Fill "Notice" field
+    await Helpers.typeText('ens-text-record-notice', RECORD_NOTICE, false);
+
+    // Fill "Keywords" field
+    await Helpers.typeText('ens-text-record-keywords', RECORD_KEYWORDS, false);
+
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+    await Helpers.swipe('ens-edit-records-sheet', 'up', 'slow', 0.15);
+
+    // Fill "Litecoin" field
+    await Helpers.typeText('ens-text-record-LTC', 'MGx', false);
+    await Helpers.waitAndTap('ens-text-record-LTC-error');
+    await Helpers.checkIfElementByTextToExist('Invalid LTC address');
+    await Helpers.tapByText('OK');
+    await Helpers.typeText(
+      'ens-text-record-LTC',
+      'NPPB7eBoWPUaprtX9v9CXJZoD2465zN',
+      false
+    );
+    await Helpers.delay(3000);
+    await Helpers.checkIfNotVisible('ens-text-record-LTC-error');
+  });
+
+  it('Should unselect a field', async () => {
+    await Helpers.swipe('ens-edit-records-sheet', 'down');
+    await Helpers.waitAndTap('ens-selectable-attribute-bio');
+    await Helpers.checkIfNotVisible('ens-text-record-description');
+  });
+
+  it('Should submit updated fields', async () => {
+    await Helpers.checkIfVisible('ens-assign-records-review-action-button');
+    await Helpers.waitAndTap('ens-assign-records-review-action-button');
+    await Helpers.checkIfVisible(`ens-transaction-action-EDIT`);
+    await Helpers.waitAndTap(`ens-transaction-action-EDIT`);
+  });
+
+  it('Should confirm the update was successful', async () => {
+    const {
+      description,
+      discord,
+      email,
+      github,
+      instagram,
+      reddit,
+      snapchat,
+      telegram,
+      twitter,
+      url,
+    } = await getRecords(RAINBOW_TEST_WALLET_NAME);
+    if (description) throw new Error('description should be empty');
+    if (discord !== RECORD_DISCORD)
+      throw new Error('discord is incorrect.', discord);
+    if (email !== RECORD_EMAIL) throw new Error('email is incorrect.', email);
+    if (github !== RECORD_GITHUB)
+      throw new Error('github is incorrect.', github);
+    if (instagram !== RECORD_INSTAGRAM)
+      throw new Error('instagram is incorrect.', instagram);
+    if (reddit !== RECORD_REDDIT)
+      throw new Error('reddit is incorrect.', reddit);
+    if (snapchat !== RECORD_SNAPCHAT)
+      throw new Error('snapchat is incorrect.', snapchat);
+    if (telegram !== RECORD_TELEGRAM)
+      throw new Error('telegram is incorrect.', telegram);
+    if (twitter !== RECORD_TWITTER)
+      throw new Error('twitter is incorrect.', twitter);
+    if (url !== RECORD_URL) throw new Error('url is incorrect.', url);
   });
 
   it('Should navigate to the Wallet screen to renew', async () => {
+    await Helpers.swipe('profile-screen', 'left', 'slow');
     await Helpers.checkIfVisible('wallet-screen');
   });
 

--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -406,7 +406,7 @@ describe('Register ENS Flow', () => {
     await Helpers.tapByText('View Profile');
     await Helpers.checkIfExists('profile-sheet');
     await Helpers.checkIfExistsByText('rainbowtestwallet.eth');
-    await Helpers.checkIfExistsByText('Test2');
+    await Helpers.checkIfExistsByText('Test 2');
     await Helpers.swipe('profile-sheet', 'down');
   });
 

--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -602,12 +602,6 @@ describe('Register ENS Flow', () => {
     await Helpers.checkIfNotVisible('ens-text-record-LTC-error');
   });
 
-  it('Should unselect a field', async () => {
-    await Helpers.swipe('ens-edit-records-sheet', 'down');
-    await Helpers.waitAndTap('ens-selectable-attribute-bio');
-    await Helpers.checkIfNotVisible('ens-text-record-description');
-  });
-
   it('Should submit updated fields', async () => {
     await Helpers.checkIfVisible('ens-assign-records-review-action-button');
     await Helpers.waitAndTap('ens-assign-records-review-action-button');
@@ -617,7 +611,6 @@ describe('Register ENS Flow', () => {
 
   it('Should confirm the update was successful', async () => {
     const {
-      description,
       discord,
       email,
       github,
@@ -628,7 +621,6 @@ describe('Register ENS Flow', () => {
       twitter,
       url,
     } = await getRecords(RAINBOW_TEST_WALLET_NAME);
-    if (description) throw new Error('description should be empty');
     if (discord !== RECORD_DISCORD)
       throw new Error('discord is incorrect.', discord);
     if (email !== RECORD_EMAIL) throw new Error('email is incorrect.', email);

--- a/e2e/registerENSFlow.spec.js
+++ b/e2e/registerENSFlow.spec.js
@@ -602,6 +602,22 @@ describe('Register ENS Flow', () => {
     await Helpers.checkIfNotVisible('ens-text-record-LTC-error');
   });
 
+  it('Should unselect a field', async () => {
+    await Helpers.swipe('ens-edit-records-sheet', 'down');
+    await Helpers.waitAndTap('hide-keyboard-button');
+    await Helpers.waitAndTap('ens-selectable-attribute-bio');
+    await Helpers.checkIfNotVisible('ens-text-record-description');
+  });
+
+  it('Should update a field', async () => {
+    await Helpers.typeText(
+      'ens-text-record-me.rainbow.displayName',
+      ' Guy',
+      false
+    );
+    await Helpers.waitAndTap('hide-keyboard-button');
+  });
+
   it('Should submit updated fields', async () => {
     await Helpers.checkIfVisible('ens-assign-records-review-action-button');
     await Helpers.waitAndTap('ens-assign-records-review-action-button');
@@ -611,6 +627,7 @@ describe('Register ENS Flow', () => {
 
   it('Should confirm the update was successful', async () => {
     const {
+      description,
       discord,
       email,
       github,
@@ -621,6 +638,7 @@ describe('Register ENS Flow', () => {
       twitter,
       url,
     } = await getRecords(RAINBOW_TEST_WALLET_NAME);
+    if (description) throw new Error('description should be empty');
     if (discord !== RECORD_DISCORD)
       throw new Error('discord is incorrect.', discord);
     if (email !== RECORD_EMAIL) throw new Error('email is incorrect.', email);

--- a/src/components/ens-profile/ActionButtons/EditButton.tsx
+++ b/src/components/ens-profile/ActionButtons/EditButton.tsx
@@ -21,7 +21,11 @@ export default function WatchButton({ ensName }: { ensName?: string }) {
   }, [ensName, navigate, startRegistration]);
 
   return (
-    <ActionButton onPress={handlePressEdit} variant="outlined">
+    <ActionButton
+      onPress={handlePressEdit}
+      testID="edit-profile-button"
+      variant="outlined"
+    >
       {lang.t('profiles.actions.edit_profile')}
     </ActionButton>
   );

--- a/src/components/inputs/InlineField.tsx
+++ b/src/components/inputs/InlineField.tsx
@@ -124,7 +124,10 @@ export default function InlineField({
             </Text>
             {errorMessage && (
               <Bleed space="10px">
-                <ButtonPressAnimation onPress={() => Alert.alert(errorMessage)}>
+                <ButtonPressAnimation
+                  onPress={() => Alert.alert(errorMessage)}
+                  testID={`${testID}-error`}
+                >
                   <Inset space="10px">
                     <Text
                       color={{ custom: colors.red }}

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -208,7 +208,7 @@ export const textRecordFields = {
       message: lang.t('profiles.create.invalid_username', {
         app: lang.t('profiles.create.discord'),
       }),
-      validator: value => /^([\w#.])*$/.test(value),
+      validator: value => /^(\w)+#[0-9]{4}$/.test(value),
     },
   },
   [ENS_RECORDS.github]: {

--- a/src/screens/ENSAdditionalRecordsSheet.tsx
+++ b/src/screens/ENSAdditionalRecordsSheet.tsx
@@ -53,7 +53,7 @@ export default function ENSAdditionalRecordsSheet() {
           paddingHorizontal="19px"
           paddingVertical="24px"
           style={boxStyle}
-          testID="ens-confirm-register-sheet"
+          testID="ens-additional-records-sheet"
         >
           <Inline space="10px">
             {Object.values(textRecordFields).map((textRecordField, i) => {

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -471,7 +471,11 @@ function HideKeyboardButton({ color }: { color: string }) {
 
   return (
     <Box as={Animated.View} style={style}>
-      <ButtonPressAnimation onPress={() => Keyboard.dismiss()} scaleTo={0.8}>
+      <ButtonPressAnimation
+        onPress={() => Keyboard.dismiss()}
+        scaleTo={0.8}
+        testID="hide-keyboard-button"
+      >
         <AccentColorProvider color={color}>
           <Box
             background="accent"


### PR DESCRIPTION
Fixes RNBW-4107
Fixes RNBW-4115


## What changed (plus any additional context for devs)

This PR adds more E2E coverage for profiles, including:

- Validating the "View Profile" sheet,
- Validating the "Edit Profile" sheet,
- Validating addition of more records updates the UI on the "Edit Profile" sheet,
- Validating that the field validations of inputs works on the "Edit Profile" sheet,
- Validating that adding, updating and removing records replicates changes on the blockchain on the "Edit Profile" sheet.