### PR TITLE
BACK-200: Use the same field on l1/l2s for transaction history

### DIFF
--- a/src/entities/transactions/zerionTransaction.ts
+++ b/src/entities/transactions/zerionTransaction.ts
@@ -41,7 +41,6 @@ export interface ZerionTransaction {
   id: string;
   meta: ZerionTransactionMeta | null;
   mined_at: number;
-  signed_at?: number; // L2
   nonce: number | null;
   protocol: ProtocolType;
   status: ZerionTransactionStatus;

--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -299,7 +299,7 @@ const parseTransactionWithEmptyChanges = async (
       description: methodName || 'Signed',
       from: txn.address_from,
       hash: `${txn.hash}-${0}`,
-      minedAt: txn.mined_at || txn.signed_at!,
+      minedAt: txn.mined_at,
       name: methodName || 'Signed',
       native: nativeDisplay,
       network,
@@ -384,7 +384,7 @@ const parseTransaction = async (
           description,
           from: internalTxn.address_from ?? txn.address_from,
           hash: `${txn.hash}-${index}`,
-          minedAt: txn.mined_at || txn.signed_at!,
+          minedAt: txn.mined_at,
           name: updatedAsset.name,
           native: isL2Network(network)
             ? { amount: '', display: '' }


### PR DESCRIPTION
This change is to remove field fragmentation created in #3032. The backend was updated to use the same field as l1 instead of introducing a new field.

![2022-08-23-174600_598x1075_scrot](https://user-images.githubusercontent.com/677680/186273129-271dec59-3c0e-4fe6-bde9-74beb9cb9cc1.png)
