### PR TITLE
Fix contact row avatar glitches

### DIFF
--- a/src/components/contacts/ContactAvatar.js
+++ b/src/components/contacts/ContactAvatar.js
@@ -103,11 +103,18 @@ const ContactAvatar = ({ color, size = 'medium', value, ...props }) => {
     colors,
   ]);
 
+  const backgroundColor =
+    typeof color === 'number'
+      ? // sometimes the color is gonna be missing so we fallback to white
+        // otherwise there will be only shadows without the the placeholder "circle"
+        colors.avatarBackgrounds[color] ?? 'white'
+      : color;
+
   return (
     <ShadowStack
       {...props}
       {...borders.buildCircleAsObject(dimensions)}
-      backgroundColor={colors.avatarBackgrounds[color] || color}
+      backgroundColor={backgroundColor}
       shadows={shadows}
     >
       <Centered flex={1}>


### PR DESCRIPTION
Fixes RNBW-4009
Figma link (if any):

## What changed (plus any additional context for devs)

We use shadow stack for many icons. When shadow stack is used to display text and there is no background color property - it will display this weird glitch.

I'm not sure what's causing the missing background color. But since we are gonna refactor this component (Contact Row) in the future anyway, I decided to fix it in place.


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

This is what was causing the glitch:


https://user-images.githubusercontent.com/7809008/186415458-8627a611-d344-4887-ba16-a591accbe69e.mov



This is how it will look like during "loading" states when we don't have the background color for the row:

<img width="574" alt="image" src="https://user-images.githubusercontent.com/7809008/186415167-3ecf8d41-5f72-4fbe-91f5-9f9f5fb67bdb.png">


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- Choose wallet sheet should have emojis with no glitches
- Contact row should have no glitches


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
