### PR TITLE
🏛 fix: quiet logs when linting in CI

### DIFF
--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -46,7 +46,7 @@ jobs:
         run:  yarn audit-ci --moderate --config audit-ci.json
 
       - name: Lint
-        run: yarn lint
+        run: yarn lint:ts && yarn lint:js --quiet
         
       - name: Install Pods
         run: cd ios && pod install && cd ..


### PR DESCRIPTION
Fixes RNBW-4331

## What changed (plus any additional context for devs)
With the new ESLint setup, we have >4k warnings. These only useful when commiting changes locally via the `lint-staged` `pre-commit` git hook. In CI, we should only surface errors. This is what the `--quiet` option does.

Since yarn's handling of passed arguments to npm scripts might not be clear to everyone, I opted to spell out the whole command in the GitHub Action instead of `yarn lint --quiet`.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
