### PR TITLE
feat: always sync hidden NFTs to remote db

### DIFF
--- a/src/hooks/useWebData.ts
+++ b/src/hooks/useWebData.ts
@@ -93,7 +93,6 @@ export default function useWebData() {
   const wipeWebData = useCallback(async () => {
     if (!webDataEnabled) return;
     await setPreference(PreferenceActionType.wipe, 'showcase', accountAddress);
-    await setPreference(PreferenceActionType.wipe, 'hidden', accountAddress);
     await setPreference(PreferenceActionType.wipe, 'profile', accountAddress);
     dispatch(updateWebDataEnabled(false, accountAddress));
   }, [accountAddress, dispatch, webDataEnabled]);
@@ -149,7 +148,6 @@ export default function useWebData() {
 
   const updateWebHidden = useCallback(
     async assetIds => {
-      if (!webDataEnabled) return;
       const response = await getPreference('hidden', accountAddress);
       // If the showcase is populated, just updated it
       // @ts-expect-error
@@ -171,7 +169,7 @@ export default function useWebData() {
         logger.log('hidden initialized!');
       }
     },
-    [accountAddress, webDataEnabled]
+    [accountAddress]
   );
 
   const initializeShowcaseIfNeeded = useCallback(async () => {


### PR DESCRIPTION
Fixes TEAM1-87

## What changed (plus any additional context for devs)
We have a toggle in Privacy Settings that enables sync of a user's showcased NFTs to their public ENS profiles. This was also controlling whether or not hidden NFTs were synced to public ENS profiles.

This PR updates that functionality so that hidden NFTs are always synced i.e. even if the toggle in Privacy Settings is disabled, if a user hides and NFT it will be hidden from their ENS profile.

## What to test
Disable showcase toggle and hide an NFT. Check your web profile to see if it's there.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
