### PR TITLE
Fix bad custom icon filepaths on android

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/smol.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/smol.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@mipmap/smolverse_background"/>
-    <foreground android:drawable="@mipmap/smolverse_foreground"/>
+    <background android:drawable="@mipmap/smol_background"/>
+    <foreground android:drawable="@mipmap/smol_foreground"/>
 </adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/smol_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/smol_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@mipmap/smolverse_background"/>
-    <foreground android:drawable="@mipmap/smolverse_foreground"/>
+    <background android:drawable="@mipmap/smol_background"/>
+    <foreground android:drawable="@mipmap/smol_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
https://github.com/rainbow-me/rainbow/pull/4059 broke android bc of bad filepaths

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
