### PR TITLE
[TEAM2-443] Disable Flashbots Post Merge (temporarily)

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,6 +323,7 @@
     "ethers": "5.6.8",
     "graphql": "15.3.0",
     "hardhat": "2.9.1",
+    "husky": "8.0.1",
     "image-size": "1.0.0",
     "jest": "26.6.3",
     "jest-circus": "26.6.3",
@@ -335,8 +336,7 @@
     "schedule": "0.5.0",
     "ts-migrate": "0.1.26",
     "typescript": "4.4.4",
-    "typescript-coverage-report": "0.6.1",
-    "husky": "8.0.1"
+    "typescript-coverage-report": "0.6.1"
   },
   "resolutions": {
     "**/async": "2.6.4",

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -39,6 +39,7 @@ export interface RainbowConfig extends Record<string, any> {
   data_endpoint?: string;
   data_origin?: string;
   default_slippage_bips?: string;
+  flashbots_enabled?: boolean;
   ethereum_goerli_rpc?: string;
   ethereum_mainnet_rpc?: string;
   op_nft_network?: string;
@@ -62,6 +63,7 @@ const DEFAULT_CONFIG = {
   ethereum_mainnet_rpc: __DEV__
     ? ETHEREUM_MAINNET_RPC_DEV
     : ETHEREUM_MAINNET_RPC,
+  flashbots_enabled: true,
   op_nft_network: 'op-mainnet',
   optimism_mainnet_rpc: OPTIMISM_MAINNET_RPC,
   polygon_mainnet_rpc: POLYGON_MAINNET_RPC,

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -96,6 +96,8 @@ const init = async () => {
       const [key, entry] = $;
       if (key === 'default_slippage_bips') {
         config[key] = JSON.parse(entry.asString());
+      } else if (key === 'flashbots_enabled') {
+        config[key] = entry.asBoolean();
       } else {
         config[key] = entry.asString();
       }

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -34,7 +34,7 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 import { analytics } from '@rainbow-me/analytics';
 import { Box, Row, Rows } from '@rainbow-me/design-system';
 import { AssetType } from '@rainbow-me/entities';
-import { getProviderForNetwork } from '@rainbow-me/handlers/web3';
+import { getHasMerged, getProviderForNetwork } from '@rainbow-me/handlers/web3';
 import {
   ExchangeModalTypes,
   isKeyboardOpen,
@@ -361,7 +361,12 @@ export default function ExchangeModal({
     loading
   );
   const [debouncedIsHighPriceImpact] = useDebounce(isHighPriceImpact, 1000);
-  const swapSupportsFlashbots = currentNetwork === Network.mainnet;
+  // For a limited period after the merge we need to block the use of flashbots.
+  // This line should be removed after reenabling flashbots in remote config.
+  const hideFlashbotsPostMerge =
+    getHasMerged(currentNetwork) && !config.flashbots_enabled;
+  const swapSupportsFlashbots =
+    currentNetwork === Network.mainnet && !hideFlashbotsPostMerge;
   const flashbots = swapSupportsFlashbots && flashbotsEnabled;
 
   const isDismissing = useRef(false);

--- a/src/screens/TransactionConfirmationScreen.js
+++ b/src/screens/TransactionConfirmationScreen.js
@@ -46,12 +46,14 @@ import { FLASHBOTS_WC } from '../config/experimental';
 import useExperimentalFlag from '../config/experimentalHooks';
 import { lightModeThemeColors } from '../styles/colors';
 import { WrappedAlert as Alert } from '@/helpers/alert';
+import config from '@/model/config';
 import { analytics } from '@rainbow-me/analytics';
 import { Text } from '@rainbow-me/design-system';
 import {
   estimateGas,
   estimateGasWithPadding,
   getFlashbotsProvider,
+  getHasMerged,
   getProviderForNetwork,
   isL2Network,
   isTestnetNetwork,
@@ -245,7 +247,10 @@ export default function TransactionConfirmationScreen() {
 
   const isTestnet = isTestnetNetwork(currentNetwork);
   const isL2 = isL2Network(currentNetwork);
-  const flashbotsEnabled = useExperimentalFlag(FLASHBOTS_WC);
+  const disableFlashbotsPostMerge =
+    getHasMerged(currentNetwork) && !config.flashbots_enabled;
+  const flashbotsEnabled =
+    useExperimentalFlag(FLASHBOTS_WC) && !disableFlashbotsPostMerge;
 
   useEffect(() => {
     setCurrentNetwork(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7188,8 +7188,8 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
 
 caniuse-lite@^1.0.30001274:
-  version "1.0.30001274"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz#26ca36204d15b17601ba6fc35dbdad950a647cc7"
+  version "1.0.30001382"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz"
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I have added `flashbots_enabled` to remote config. Prior the merge we should have this set to `false` because we expect transactions using flashbots to fail for a brief period after moving to proof of stake. After receiving confirmation that things are back in order we should set this back to true and promptly remove the code added in this PR.

## Screen recordings / screenshots
scenario 1 (flashbots_enabled: true && pre merge): https://recordit.co/ZsMQfQNid7
scenario 2 (flashbots_enabled: false && post merge): https://recordit.co/EhtoTvVxXm

## What to test
Ensure that the flashbots setting still works as usual on this build. Unfortunately, because we do not support swaps on Goerli, the post-merge scenario must be tested via hardcoding.

Here is an example of the code I used to simulate a post-merge scenario (inserted at this line: https://github.com/rainbow-me/rainbow/blob/%40derHowie/the-merge/flashbots-config/src/screens/ExchangeModal.js#L366):
<img width="585" alt="Screen Shot 2022-08-24 at 8 40 21 PM" src="https://user-images.githubusercontent.com/14877580/186554437-5d2b2c6b-4737-481a-8488-2a7f3b55e3ea.png">


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
