### PR TITLE
🏛 [RNBW-4394] Add a warning about importing directly from react-navigation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,4 +27,18 @@ module.exports = {
     project: ['./tsconfig.json'],
   },
   globals: globalVars,
+  rules: {
+    'no-restricted-imports': [
+      'warn',
+      {
+        patterns: [
+          {
+            group: ['@react-navigation/core'],
+            message:
+              'You probably want to use @/navigation instead, to ensure that all of our customizations are applied.',
+          },
+        ],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Fixes RNBW-4394

## What changed (plus any additional context for devs)

This PR adds a warning when someone imports directly from `react-navigation`. We do a lot of customizations in the navigation code, and I am not sure if everyone is always aware of that.

As you can see, imports of `useNavigation` look a bit random:

<img width="406" alt="Screenshot 2022-08-26 at 13 54 05" src="https://user-images.githubusercontent.com/5769281/186941789-ab476931-53dd-41f8-bc82-230b2554e8c0.png">

**Q: Why to this repo and not to our shared eslint config?**

A: This is specific to the app.

**Q: Why warning and not error?**

A: I think we will want to make it an error, but I just wanted to start discussion first. Maybe it's not really needed, maybe it's not as dangerous to mix those import as I think.

## Screen recordings / screenshots

This is how this warning looks in VSCode:

<img width="589" alt="Screenshot 2022-08-26 at 17 37 32" src="https://user-images.githubusercontent.com/5769281/186942202-6e44a120-d177-44eb-a16b-dc5c65e92b5a.png">

## What to test

-

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
