### PR TITLE
fix clipped subheader on Backup sheets

### DIFF
--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -191,11 +191,7 @@ export default function SettingsSheet() {
         screenOptions={{
           ...memoSettingsOptions,
           headerRight: renderHeaderRight,
-          headerStyle: {
-            ...memoSettingsOptions.headerStyle,
-            // ios MenuContainer scroll fix
-            ...(ios && { backgroundColor: colors.cardBackdrop }),
-          },
+          headerStyle: memoSettingsOptions.headerStyle,
         }}
       >
         <Stack.Screen
@@ -229,6 +225,11 @@ export default function SettingsSheet() {
                 options={{
                   cardStyleInterpolator,
                   title: getTitle(),
+                  headerStyle: {
+                    ...memoSettingsOptions.headerStyle,
+                    // ios MenuContainer scroll fix
+                    ...(ios && { backgroundColor: colors.cardBackdrop }),
+                  },
                 }}
                 // @ts-ignore
                 title={getTitle()}


### PR DESCRIPTION
Fixes RNBW-4339
Figma link (if any):

## What changed (plus any additional context for devs)
- fixed clipped subheader (subheader is text that says "Backed up manually" in screenshots below)
- kind of a bandaid fix, since it only works on nav screens that aren't scrollable– currently we don't have any settings screens that are scrollable AND have a subheader. i'm slowly working on a redesign of the settings nav architecture on another branch, so i think the bandaid is ok for now.

## Screen recordings / screenshots

iPhone 13 Pro
![Simulator Screen Shot - iPhone 13 Pro - 2022-08-29 at 09 45 40](https://user-images.githubusercontent.com/15272675/187252067-a8aea457-391c-444a-a480-5ff5ef66f16a.png)

Pixel 2
![Screenshot_20220829_094612](https://user-images.githubusercontent.com/15272675/187252163-08aeaf52-62d1-4c97-bb64-566deb47ac59.png)


## What to test
- android & ios
- double check there aren't any cases where a screen is scrollable AND has a subheader, since this fix wouldn't work in that case

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
