### PR TITLE
[RNBW-4408] Remove unsafe access to networkInfo

### DIFF
--- a/src/components/AvailableNetworks.js
+++ b/src/components/AvailableNetworks.js
@@ -121,7 +121,7 @@ const AvailableNetworks = ({
                     availableNetworks: availableNetworks?.length,
                   })
                 : lang.t('expanded_state.asset.available_network', {
-                    availableNetwork: networkInfo[availableNetworks?.[0]].name,
+                    availableNetwork: networkInfo[availableNetworks?.[0]]?.name,
                   })}
             </Text>
           </Column>

--- a/src/components/exchange/NetworkSwitcher.js
+++ b/src/components/exchange/NetworkSwitcher.js
@@ -121,7 +121,7 @@ const NetworkSwitcher = ({
                 network:
                   networkInfo[
                     ethereumUtils.getNetworkFromChainId(currentChainId)
-                  ].name,
+                  ]?.name,
               })}
             </Text>
           </Column>

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -14,11 +14,7 @@ import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { isL2Network } from '@/handlers/web3';
 import networkInfo from '@/helpers/networkInfo';
 import networkTypes from '@/helpers/networkTypes';
-import {
-  add,
-  greaterThan,
-  toFixedDecimals,
-} from '@/helpers/utilities';
+import { add, greaterThan, toFixedDecimals } from '@/helpers/utilities';
 import {
   useAccountSettings,
   useColorForAsset,
@@ -311,7 +307,7 @@ const GasSpeedButton = ({
   const openGasHelper = useCallback(() => {
     Keyboard.dismiss();
     const network = currentNetwork ?? networkTypes.mainnet;
-    const networkName = networkInfo[network].name;
+    const networkName = networkInfo[network]?.name;
     navigate(Routes.EXPLAIN_SHEET, { network: networkName, type: 'gas' });
   }, [currentNetwork, navigate]);
 

--- a/src/components/toasts/TestnetToast.js
+++ b/src/components/toasts/TestnetToast.js
@@ -10,7 +10,7 @@ import { useInternetStatus } from '@/hooks';
 const TestnetToast = ({ network, web3Provider }) => {
   const isConnected = useInternetStatus();
   const providerUrl = web3Provider?.connection?.url;
-  const { name, color } = networkInfo[network];
+  const { name, color } = networkInfo[network] || {};
   const [visible, setVisible] = useState(!network === networkTypes.mainnet);
   const [networkName, setNetworkName] = useState(name);
 

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -133,7 +133,7 @@ const gasExplainer = network =>
 
 const availableNetworksExplainer = (tokenSymbol, networks) => {
   const readableNetworks = networks
-    ?.map(network => networkInfo[network].name)
+    ?.map(network => networkInfo[network]?.name)
     ?.join(', ');
 
   return lang.t('explain.available_networks.text', {

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -339,7 +339,8 @@ const getNetworkFromChainId = (chainId: number): Network => {
  */
 const getNetworkNameFromChainId = (chainId: number): string | undefined => {
   const networkData = chains.find(chain => chain.chain_id === chainId);
-  const networkName = networkInfo[networkData?.network ?? Network.mainnet].name;
+  const networkName =
+    networkInfo[networkData?.network ?? Network.mainnet]?.name;
   return networkName;
 };
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
There are a few places in the app where we confidently access `networkInfo[network].someStuff`. This wasn't an issue until `networkInfo` was mutated and certain keys were no longer accessible. This prevents a crash when switching to an app with fewer testnet options when having selected a deprecated testnet on the previous build.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
