### PR TITLE
fix settings StatusIcon shadows on android

### DIFF
--- a/src/components/settings-menu/components/MenuItem.tsx
+++ b/src/components/settings-menu/components/MenuItem.tsx
@@ -92,13 +92,15 @@ const StatusIcon = ({ status }: StatusIconProps) => {
       backgroundColor={statusColors[status]}
       color={statusColors[status]}
       colors={colors}
+      borderRadius={status !== 'warning' ? 6 : undefined}
       fillColor={colors.white}
       shadowColor={isDarkMode ? colors.shadow : statusColors[status]}
       shadowOffset={{
         height: 4,
         width: 0,
       }}
-      shadowOpacity={0.4}
+      elevation={12}
+      shadowOpacity={ios ? 0.4 : 1}
       shadowRadius={6}
     />
   );

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -13,6 +13,7 @@ export const REVIEW_ANDROID = 'reviewAndroid';
 export const PROFILES = 'ENS Profiles';
 export const L2_TXS = 'L2 Transactions';
 export const FLASHBOTS_WC = 'Flashbots for WC';
+export const CROSSCHAIN_SWAPS = 'Crosschain Swaps';
 
 export const defaultConfig = {
   // this flag is not reactive. We use this in a static context
@@ -22,6 +23,7 @@ export const defaultConfig = {
   [NOTIFICATIONS]: { needsRestart: true, settings: true, value: false },
   [PROFILES]: { settings: true, value: true },
   [REVIEW_ANDROID]: { settings: false, value: false },
+  [CROSSCHAIN_SWAPS]: { settings: true, value: false },
 };
 
 const storageKey = 'config';


### PR DESCRIPTION
Fixes RNBW-4415
Figma link (if any):

## What changed (plus any additional context for devs)
- added elevation prop to icons to make shadows visible on android

## Screen recordings / screenshots

https://www.loom.com/share/8349080853bd40fb93242e1d23bfc8a5

## What to test
- just make sure the shadows look alright!


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
