### PR TITLE
Disable campaings in e2e and fix testID of PromoSheet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -208,10 +208,17 @@ class App extends Component {
       runWalletBackupStatusChecks();
 
       InteractionManager.runAfterInteractions(() => {
-        setTimeout(
-          () => (ios ? runFeatureAndCampaignChecks() : runCampaignChecks()),
-          2000
-        );
+        setTimeout(() => {
+          if (IS_TESTING === 'true') {
+            return;
+          }
+
+          if (ios) {
+            runFeatureAndCampaignChecks();
+          } else {
+            runCampaignChecks();
+          }
+        }, 2000);
       });
     }
   }

--- a/src/components/promos/PromoSheet.tsx
+++ b/src/components/promos/PromoSheet.tsx
@@ -106,7 +106,7 @@ const PromoSheet = ({
         <Box
           background="accent"
           style={{ height: contentHeight }}
-          testID="ens-intro-sheet"
+          testID={campaignKey}
         >
           {/* @ts-ignore */}
           <Box as={ImgixImage} height="full" source={backgroundImage}>

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -1,3 +1,4 @@
+import { IS_TESTING } from 'react-native-dotenv';
 import { useRoute } from '@react-navigation/core';
 import { captureException } from '@sentry/react-native';
 import lang from 'i18n-js';
@@ -168,11 +169,14 @@ export default function ChangeWalletSheet() {
         initializeWallet(null, null, null, false, false, null, true);
         if (!fromDeletion) {
           goBack();
-          InteractionManager.runAfterInteractions(() => {
-            setTimeout(async () => {
-              await runCampaignChecks();
-            }, 5000);
-          });
+
+          if (IS_TESTING !== 'true') {
+            InteractionManager.runAfterInteractions(() => {
+              setTimeout(async () => {
+                await runCampaignChecks();
+              }, 5000);
+            });
+          }
         }
       } catch (e) {
         logger.log('error while switching account', e);


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

This PR disables campaigns for tests so they don't accidentally break e2e tests in CI. The assumption is that campaigns are temporary and we prefer to avoid adjusting e2e for them all the time.

## Screen recordings / screenshots


## What to test


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
