### PR TITLE
swaps: fix native input cursor color

### DIFF
--- a/src/components/exchange/ExchangeInputField.js
+++ b/src/components/exchange/ExchangeInputField.js
@@ -67,12 +67,14 @@ export default function ExchangeInputField({
           editable={editable}
           height={64}
           loading={loading}
+          mainnetAddress={inputCurrencyMainnetAddress}
           nativeAmount={nativeAmount}
           nativeCurrency={nativeCurrency}
           onFocus={onFocus}
           ref={nativeFieldRef}
           setNativeAmount={setNativeAmount}
           testID={testID + '-native'}
+          type={inputCurrencyAssetType}
           updateOnFocus={updateAmountOnFocus}
         />
         <ExchangeMaxButton

--- a/src/components/exchange/ExchangeNativeField.js
+++ b/src/components/exchange/ExchangeNativeField.js
@@ -35,11 +35,17 @@ const ExchangeNativeField = (
     onFocus,
     setNativeAmount,
     updateOnFocus,
+    mainnetAddress,
+    type,
     testID,
   },
   ref
 ) => {
-  const colorForAsset = useColorForAsset({ address });
+  const colorForAsset = useColorForAsset({
+    address,
+    mainnet_address: mainnetAddress,
+    type,
+  });
   const [value, setValue] = useState(nativeAmount);
 
   const { mask, placeholder, symbol } = supportedNativeCurrencies[


### PR DESCRIPTION
Fixes TEAM2-489
Figma link (if any):

## What changed (plus any additional context for devs)
noticed the native input cursor color was wrong, this fixes it 


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

after: https://cloud.skylarbarrera.com/Screen-Shot-2022-08-31-15-22-28.91.png


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

check the native input cursor color for l2 assets


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
