### PR TITLE
fix: universal link scanning

### DIFF
--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -165,7 +165,8 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
       }
       // Walletconnect via universal link
       const urlObj = new URL(data);
-      if (urlObj?.protocol === 'https:' && urlObj?.searchParams !== null) {
+      if (urlObj?.protocol === 'https:' && 
+      urlObj?.searchParams !== null) {
         // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         const { uri } = urlObj?.searchParams?.get('uri');
         if (uri?.startsWith('wc:')) {

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -166,7 +166,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
       // Walletconnect via universal link
       const urlObj = new URL(data);
       if (urlObj?.protocol === 'https:' && urlObj?.searchParams !== null) {
-        // eslint-disable-next-line no-unsafe-optional-chaining
+        // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         const { uri } = urlObj?.searchParams?.get('uri');
         if (uri?.startsWith('wc:')) {
           onSuccess();

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -167,13 +167,14 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
       const urlObj = new URL(data);
       if (
         urlObj?.protocol === 'https:' &&
-        urlObj?.pathname?.split('/')?.[1] === 'wc'
+        urlObj?.searchParams?.get('uri').startsWith('wc:')
       ) {
         // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         const { uri } = qs.parse(urlObj.query.substring(1));
         onSuccess();
         return handleScanWalletConnect(uri);
       }
+
       // Rainbow profile QR code
       if (data.startsWith(RAINBOW_PROFILES_BASE_URL)) {
         return handleScanRainbowProfile(data);

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -165,14 +165,13 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
       }
       // Walletconnect via universal link
       const urlObj = new URL(data);
-      if (
-        urlObj?.protocol === 'https:' &&
-        urlObj?.searchParams?.get('uri').startsWith('wc:')
-      ) {
-        // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-        const { uri } = qs.parse(urlObj.query.substring(1));
-        onSuccess();
-        return handleScanWalletConnect(uri);
+      if (urlObj?.protocol === 'https:' && urlObj?.searchParams !== null) {
+        // eslint-disable-next-line no-unsafe-optional-chaining
+        const { uri } = urlObj?.searchParams?.get('uri');
+        if (uri?.startsWith('wc:')) {
+          onSuccess();
+          return handleScanWalletConnect(uri);
+        }
       }
 
       // Rainbow profile QR code


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
Current Universal Link scanning can be fragile if the order of the params is different than expected (i.e. if `uri` is not the first parameter)

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 
Scan a QR code encoding: `https://rnbwapp.com/wc?uri=wc%3Acedabb93-88bc-4df5-a2d5-9e87f471ecfc%401%3Fbridge%3Dhttps%253A%252F%252Fl.bridge.walletconnect.org%26key%3Dff3937eb054a2e9c23dfc41203a2e750a68a852472417d1c3859c14dd6264302` for Android and iOS


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
