### PR TITLE
fix: Use new endpoint for discovering wallets

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -546,10 +546,10 @@ export const createWallet = async (
   seed: null | EthereumSeed = null,
   color: null | number = null,
   name: null | string = null,
-  overwrite: boolean = false,
+  overwrite = false,
   checkedWallet: null | EthereumWalletFromSeed = null,
   image: null | string = null,
-  silent: boolean = false
+  silent = false
 ): Promise<null | EthereumWallet> => {
   const isImported = !!seed;
   logger.sentry('Creating wallet, isImported?', isImported);
@@ -557,7 +557,7 @@ export const createWallet = async (
     logger.sentry('Generating a new seed phrase');
   }
   const walletSeed = seed || generateMnemonic();
-  let addresses: RainbowAccount[] = [];
+  const addresses: RainbowAccount[] = [];
   try {
     const { dispatch } = store;
 
@@ -728,9 +728,9 @@ export const createWallet = async (
       logger.sentry('[createWallet] - isHDWallet && isImported');
       let index = 1;
       let lookup = true;
-      // Starting on index 1, we are gonna hit etherscan API and check the tx history
+      // Starting on index 1, we are gonna hit an API and check the tx history
       // for each account. If there's history we add it to the wallet.
-      //(We stop once we find the first one with no history)
+      // (We stop once we find the first one with no history)
       while (lookup) {
         const child = root.deriveChild(index);
         const walletObj = child.getWallet();
@@ -1217,7 +1217,7 @@ const migrateSecrets = async (): Promise<MigratedSecretsResult | null> => {
     }
 
     const selectedWalletData = await getSelectedWallet();
-    let wallet: undefined | RainbowWallet = selectedWalletData?.wallet;
+    const wallet: undefined | RainbowWallet = selectedWalletData?.wallet;
     if (!wallet) {
       return null;
     }

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -111,7 +111,7 @@ const getNativeAssetForNetwork = async (
 ): Promise<ParsedAddressAsset | undefined> => {
   const networkNativeAsset = getNetworkNativeAsset(network);
   const { accountAddress } = store.getState().settings;
-  let differentWallet =
+  const differentWallet =
     address?.toLowerCase() !== accountAddress?.toLowerCase();
   let nativeAsset = (!differentWallet && networkNativeAsset) || undefined;
 
@@ -269,7 +269,7 @@ const formatGenericAsset = (
 
 export const checkWalletEthZero = () => {
   const ethAsset = getAccountAsset(ETH_ADDRESS);
-  let amount = ethAsset?.balance?.amount ?? 0;
+  const amount = ethAsset?.balance?.amount ?? 0;
   return isZero(amount);
 };
 
@@ -425,6 +425,7 @@ export const daysFromTheFirstTx = (address: EthereumAddress) => {
     }
   });
 };
+
 /**
  * @desc Checks if a an address has previous transactions
  * @param  {String} address
@@ -435,16 +436,21 @@ const hasPreviousTransactions = (
 ): Promise<boolean> => {
   return new Promise(async resolve => {
     try {
-      const url = `https://api.etherscan.io/api?module=account&action=txlist&address=${address}&tag=latest&page=1&offset=1&apikey=${ETHERSCAN_API_KEY}`;
+      const url = `https://aha.rainbow.me/?address=${address}`;
       const response = await fetch(url);
-      const parsedResponse = await response.json();
-      // Timeout needed to avoid the 5 requests / second rate limit of etherscan API
-      setTimeout(() => {
-        if (parsedResponse.status !== '0' && parsedResponse.result.length > 0) {
-          resolve(true);
-        }
+
+      if (!response.ok) {
         resolve(false);
-      }, 260);
+        return;
+      }
+
+      const parsedResponse: {
+        data: {
+          addresses: Record<string, boolean>;
+        };
+      } = await response.json();
+
+      resolve(parsedResponse?.data?.addresses[address.toLowerCase()] === true);
     } catch (e) {
       resolve(false);
     }


### PR DESCRIPTION
Fixes TEAM2-141

## What changed (plus any additional context for devs)
When discovering wallets after importing the seed phrase, we currently use Etherscan, on a paid plan, that is still excessively rate limited. A new endpoint has been introduced by backend that can now be used for this purpose.

## What to test
- Import a seed phrase with multiple active addresses. It should pick them up.

## Final checklist

- [X] Assigned individual reviewers?
- [X] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
