### PR TITLE
Fix issue with Collectibles not showing if opensea doesn't return consideration

### DIFF
--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -21,6 +21,10 @@ const parseLastSalePrice = lastSale =>
     : null;
 
 const getCurrentPrice = ({ currentPrice, token }) => {
+  if (!token || !currentPrice) {
+    return null;
+  }
+
   const paymentToken = OpenseaPaymentTokens.find(
     osToken => osToken.address.toLowerCase() === token.toLowerCase()
   );
@@ -87,6 +91,9 @@ export const parseAccountUniqueTokens = data => {
           asset.image_original_url,
           asset.image_preview_url
         );
+
+        const sellOrder = asset.seaport_sell_orders?.[0];
+
         return {
           ...pickShallow(asset, [
             'animation_url',
@@ -120,12 +127,12 @@ export const parseAccountUniqueTokens = data => {
             'twitter_username',
             'wiki_link',
           ]),
-          currentPrice: asset.seaport_sell_orders
+          currentPrice: sellOrder
             ? getCurrentPrice({
-                currentPrice: asset.seaport_sell_orders[0].current_price,
+                currentPrice: sellOrder?.current_price,
                 token:
-                  asset.seaport_sell_orders[0].protocol_data.parameters
-                    .consideration[0].token,
+                  sellOrder?.protocol_data?.parameters?.consideration?.[0]
+                    ?.token,
               })
             : null,
           familyImage: collection.image_url,


### PR DESCRIPTION
Fixes TEAM2-492
Figma link (if any):

## What changed (plus any additional context for devs)
Added more rigorous checks to check that the OS api returns enough data to construct the sale price. 

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
Please check wallets to see if the collectibles list appears/ disappear, see below for a list of known wallets with issues in prod are on linear


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
