### PR TITLE
add wyre degradation explainer to buy action buttons

### DIFF
--- a/src/components/sheet/sheet-action-buttons/BuyActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/BuyActionButton.js
@@ -8,6 +8,8 @@ import {
   useExpandedStateNavigation,
   useWallets,
 } from '@/hooks';
+import config from '@/model/config';
+import { useNavigation } from '@/navigation';
 
 import Routes from '@/navigation/routesNames';
 
@@ -15,12 +17,18 @@ function BuyActionButton({ color: givenColor, ...props }) {
   const { colors } = useTheme();
   const color = givenColor || colors.paleBlue;
   const navigate = useExpandedStateNavigation();
+  const { navigate: appNavigate } = useNavigation();
   const { isDamaged } = useWallets();
   const { accountAddress } = useAccountSettings();
 
   const handlePress = useCallback(() => {
     if (isDamaged) {
       showWalletErrorAlert();
+      return;
+    }
+
+    if (!config.wyre_enabled) {
+      appNavigate(Routes.EXPLAIN_SHEET, { type: 'wyre_degradation' });
       return;
     }
 


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

Add wyre degradation navigation in expanded state "Buy more ETH"

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/3ae071afcf0546cfa91e5dae4ddcf19d

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

test on video https://www.loom.com/share/3ae071afcf0546cfa91e5dae4ddcf19d

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
