### PR TITLE
fix: helpers/utilities tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,6 @@ module.exports = {
   testPathIgnorePatterns: ['node_modules', 'e2e'],
   transform: {
     '\\.tsx?$': 'ts-jest',
-    '\\.json?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   testPathIgnorePatterns: ['node_modules', 'e2e'],
   transform: {
     '\\.tsx?$': 'ts-jest',
+    '\\.json?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/src/helpers/__tests__/utilities.test.ts
+++ b/src/helpers/__tests__/utilities.test.ts
@@ -57,7 +57,6 @@ it('convertBipsToPercentage, 10 bips to 1 decimal', () => {
 });
 
 it('convertBipsToPercentage, returns 0 when given nullish value', () => {
-  // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const result = convertBipsToPercentage(null, 1);
   expect(result).toBe('0');
 });

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -159,9 +159,12 @@ export const add = (numberOne: BigNumberish, numberTwo: BigNumberish): string =>
   new BigNumber(numberOne).plus(numberTwo).toFixed();
 
 export const addDisplay = (numberOne: string, numberTwo: string): string => {
-  const template = numberOne.split(/^(\D*)(.*)/);
-  const display = currency(numberOne, { symbol: '' }).add(numberTwo).format();
-  return [template[1], display].join('');
+  const unit = numberOne.replace(/[\d.-]/g, '');
+  const leftAlignedUnit = numberOne.indexOf(unit) === 0;
+  return currency(0, { symbol: unit, pattern: leftAlignedUnit ? '!#' : '#!' })
+    .add(numberOne)
+    .add(numberTwo)
+    .format();
 };
 
 export const multiply = (
@@ -375,9 +378,12 @@ export const convertAmountToPercentageDisplayWithThreshold = (
  * @desc convert from bips amount to percentage format
  */
 export const convertBipsToPercentage = (
-  value: BigNumberish,
+  value: BigNumberish | null,
   decimals: number = 2
-): string => new BigNumber(value || 0).shiftedBy(-2).toFixed(decimals);
+): string => {
+  if (value === null) return '0';
+  return new BigNumber(value || 0).shiftedBy(-2).toFixed(decimals);
+};
 
 /**
  * @desc convert from amount value to display formatted string


### PR DESCRIPTION
Fixes RNBW-4474

## What changed (plus any additional context for devs)
According to the unit tests defined here, two utils were broken: `addDisplay` and `convertBipsToPercentage`. This PR fixes those two implementations to match the unit tests. If this is incorrect behavior, we need to update the implementation and the unit tests to reflect that.

## What to test
Run `yarn test src/helpers/__tests__/utilities.ts`

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
