### PR TITLE
fix: redux patch use require

### DIFF
--- a/patches/react-redux+7.2.1.patch
+++ b/patches/react-redux+7.2.1.patch
@@ -6,7 +6,7 @@ index c93b377..347b366 100644
  exports.createSelectorHook = createSelectorHook;
  exports.useSelector = void 0;
  
-+import isEqual from "react-fast-compare"
++const isEqual = require("react-fast-compare");
 +
  var _react = require("react");
  


### PR DESCRIPTION
Jest is choking on this `import` since we aren't transpiling `node_modules` and it's patched into a commonjs transpiled file.

I'm not familiar enough with Metro to say why this has been working for us, but I think we should fix this patch to use commonjs `require` syntax instead since that's a more technically correct patch to this file.