### PR TITLE
chore: run lint and Prettier on all branches in CI, apply fixes

### DIFF
--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -46,7 +46,7 @@ jobs:
         run:  yarn audit-ci --moderate --config audit-ci.json
 
       - name: Lint
-        run: yarn lint:ts && yarn lint:js --quiet
+        run: yarn lint:ci
         
       - name: Install Pods
         run: cd ios && pod install && cd ..

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ ios
 patches
 rainbow-scripts
 .type-coverage
+.next
+.vscode
+__generated__

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,7 +39,7 @@ workflows:
     steps:
       - yarn@0.1.1:
           inputs:
-            - command: lint
+            - command: lint:ci
           title: Linting for Errors
   detox_tests:
     before_run: []
@@ -88,6 +88,7 @@ workflows:
     before_run:
       - generate_dot_env_testflight
       - build_setup
+      - lint
       - pods_setup
     steps:
       - certificate-and-profile-installer@1.10.3: {}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "yarn format:check && yarn lint:ts && yarn lint:js",
+    "lint:ci": "yarn format:check && yarn lint:ts && yarn lint:js --quiet",
     "lint:js": "eslint --cache .",
     "lint:ts": "yarn tsc --skipLibCheck --noEmit",
     "postinstall": "./scripts/postinstall.sh",

--- a/src/components/expanded-state/custom-gas/FeesPanel.tsx
+++ b/src/components/expanded-state/custom-gas/FeesPanel.tsx
@@ -11,7 +11,6 @@ import {
   Keyboard,
   KeyboardAvoidingView,
 } from 'react-native';
-// @ts-expect-error
 import { IS_TESTING } from 'react-native-dotenv';
 import { Alert } from '../../alerts';
 import { useTheme } from '../../../theme/ThemeContext';
@@ -752,7 +751,7 @@ export default function FeesPanel({
                 )}
                 {renderWarning(maxBaseFeeError, maxBaseFeeWarning)}
               </Box>
-              <Box marginRight="-5px">
+              <Box marginRight="-5px (Deprecated)">
                 <FeesGweiInput
                   buttonColor={colorForAsset}
                   inputRef={maxBaseFieldRef}
@@ -782,7 +781,7 @@ export default function FeesPanel({
                 )}
                 {renderWarning(maxPriorityFeeError, maxPriorityFeeWarning)}
               </Box>
-              <Box marginRight="-5px">
+              <Box marginRight="-5px (Deprecated)">
                 <FeesGweiInput
                   buttonColor={colorForAsset}
                   editable={!flashbotTransaction}

--- a/src/components/expanded-state/custom-gas/FeesPanelTabs.tsx
+++ b/src/components/expanded-state/custom-gas/FeesPanelTabs.tsx
@@ -42,7 +42,7 @@ const TabPill = ({
       onPress={handleOnPress}
       scaleTo={0.8}
       testID={testID}
-      paddingHorizontal="5px"
+      paddingHorizontal="5px (Deprecated)"
     >
       <AccentColorProvider
         color={

--- a/src/components/expanded-state/custom-gas/GweiInputPill.tsx
+++ b/src/components/expanded-state/custom-gas/GweiInputPill.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-// @ts-expect-error
 import { IS_TESTING } from 'react-native-dotenv';
 import LinearGradient from 'react-native-linear-gradient';
 // @ts-expect-error

--- a/src/graphql/README.md
+++ b/src/graphql/README.md
@@ -48,10 +48,10 @@ Ensure you are in the root directory of the `rainbow` repository.
 #### 3. Consume!
 
 ```tsx
-import { ensClient } from '@/graphql'
+import { ensClient } from '@/graphql';
 
 function fetchDomain(id: string) {
-  return ensClient.getDomain({ id })
+  return ensClient.getDomain({ id });
 }
 ```
 
@@ -119,13 +119,9 @@ export const metadataClient = getMetadataSdk(
 #### 5. Consume!
 
 ```tsx
-import { exampleClient } from '@/graphql'
+import { exampleClient } from '@/graphql';
 
 function fetchUsers() {
-  return exampleClient.getUsers()
+  return exampleClient.getUsers();
 }
 ```
-
-
-
-

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -687,7 +687,7 @@
         "still_curious": {
           "fragment1": "This is a precautionary step to ensure accurate pricing and the safety of user funds. Still curious? ",
           "fragment2": "Learn more",
-          "fragment3": "" 
+          "fragment3": ""
         }
       },
       "slippage": {

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -511,7 +511,7 @@
         "still_curious": {
           "fragment1": "Still curious? ",
           "fragment2": "Learn more",
-          "fragment3": " about \"The Merge\". :)" 
+          "fragment3": " about \"The Merge\". :)"
         }
       },
       "swap_details": {


### PR DESCRIPTION
Fixes RNBW-4482

## What changed (plus any additional context for devs)

Right now we have a couple of related issues in CI:

- Prettier isn't being run in CI even though it's included in the `yarn lint` script.
- The Prettier/ESLint/TypeScript checks aren't running against develop which means that breakages can slip through if a PR is lagging behind develop but doesn't have any merge conflicts, e.g. the PR is depending on an earlier version of types defined elsewhere in the codebase, causing type errors when merged.

This PR ensures that all lint steps are run against PRs and develop in CI.

I've also included some fixes for issues that were causing lint failures.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
