### PR TITLE
fix: gas context menu max fee

### DIFF
--- a/src/components/expanded-state/custom-gas/GweiInputPill.tsx
+++ b/src/components/expanded-state/custom-gas/GweiInputPill.tsx
@@ -36,6 +36,7 @@ const GweiNumberInput = styled(TextInputMask).attrs(
     timing: 'linear',
     weight: 'heavy',
     maxWidth: 80,
+    minWidth: 12,
   })
 )(
   // @ts-expect-error

--- a/src/components/gas/GasSpeedButton.js
+++ b/src/components/gas/GasSpeedButton.js
@@ -343,7 +343,7 @@ const GasSpeedButton = ({
   const menuConfig = useMemo(() => {
     const menuOptions = speedOptions.map(gasOption => {
       const totalGwei = add(
-        gasFeeParamsBySpeed[gasOption]?.maxFeePerGas?.gwei,
+        gasFeeParamsBySpeed[gasOption]?.maxBaseFee?.gwei,
         gasFeeParamsBySpeed[gasOption]?.maxPriorityFeePerGas?.gwei
       );
       const estimatedGwei = add(


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

with https://github.com/rainbow-me/rainbow/commit/da80e482226c785f52431bd3d44fcb122db6a637 i forgot to update the gas context menu to use `maxBaseFee` instead of `maxFeePerGas`

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/7913752e9037475db96a9a3ddd614b6f

- i also added this change https://github.com/rainbow-me/rainbow/compare/%40esteban/update-gas-context-menu-with-maxBaseFee?expand=1#diff-6d1386f1c8843e0be3c4181db6d938038e4b4c549c5f7d8cd6760bfc1d9e14d3R39 to see if it fixes the bug i showed on the loom video, for some reason is happening on TF but not on dev
- 
## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
