### PR TITLE
fix: `IS_TEST` assignment

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -19,5 +19,5 @@ export const IS_WEB = web;
 
 export const IS_DEV =
   (typeof __DEV__ === 'boolean' && __DEV__) || !!Number(ENABLE_DEV_MODE);
-export const IS_TEST = !!IS_TESTING;
+export const IS_TEST = IS_TESTING === 'true';
 export const IS_PROD = !IS_DEV && !IS_TEST;


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Terry pointed this out [in Slack the other day](https://rainbowhaus.slack.com/archives/C03SS7N997H/p1662728163927909) 👍 

Basically, `IS_TESTING` is an env var so it's always a string. Therefore, `!!IS_TESTING` will always be truthy. That's not the intention. This PR fixes that.

## Final checklist
- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
