### PR TITLE
feat: new `@/logger` interface

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,4 @@ metro.config.js
 jest.config.js
 .detoxrc.js
 __generated__
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ coverage-ts
 # Generated TypeScript declarations
 src/languages/types-generated.d.ts
 __generated__/
+
+# Test Coverage
+coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ rainbow-scripts
 .next
 .vscode
 __generated__
+coverage

--- a/config/test/jest-setup.js
+++ b/config/test/jest-setup.js
@@ -2,6 +2,12 @@
 // needed to set up global translations
 import '../../src/languages';
 
+jest.mock('@/env', () => ({
+  IS_DEV: false,
+  IS_TEST: true,
+  IS_PROD: false,
+}));
+
 jest.mock('react-native-device-info', () => ({
   identify: () => null,
   reset: () => null,

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -76,4 +76,6 @@ declare module 'react-native-dotenv' {
   export const TEST_SEEDS: string;
   export const DEV_PKEY: string;
   export const RAINBOW_TOKEN_LIST_URL: string;
+  export const LOG_LEVEL: 'debug' | 'info' | 'warn' | 'error';
+  export const LOG_DEBUG: string;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,6 @@ module.exports = {
   testPathIgnorePatterns: ['node_modules', 'e2e'],
   transform: {
     '\\.tsx?$': 'ts-jest',
-    '\\.json?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   testPathIgnorePatterns: ['node_modules', 'e2e'],
   transform: {
     '\\.tsx?$': 'ts-jest',
+    '\\.json?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -16,6 +16,21 @@ logger.warn(message[, metadata])
 logger.error(error[, metadata])
 ```
 
+#### Usage Heuristics
+
+- Use `logger.error` for all exceptions, and always pass it a descriptive
+`RainbowError`.
+- Use `logger.warn` for anything that might be an exception now or in the future,
+or something we _need_ to know about, but isn't critical at the moment.
+- Use `logger.info` for anything you think would be helpful when tracing errors in
+Sentry. Think about what your coworkers might find helpful, and use these
+frequently.
+- Use `logger.debug` for noisy lower-level stuff that's only helpful locally when
+developing or debugging. We have the option to send these to Sentry, but by
+default they aren't, so use these frequently as you see fit.
+- Use `console.log` _locally only_. We strip these out when building for
+production.
+
 #### Modes
 
 The "modes" referred to here are inferred from the values exported from `@/env`.

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -37,7 +37,7 @@ sent to our reporting services.
 ## Usage
 
 ```typescript
-import { logger } from '@/logger'
+import { logger } from '@/logger';
 ```
 
 ### `logger.debug`
@@ -46,7 +46,7 @@ Debug level is for **local development only,** and is disabled by default. To
 enabled it, set `LOG_LEVEL=debug` before running the Metro server.
 
 ```typescript
-logger.debug(message)
+logger.debug(message);
 ```
 
 Inspired by [debug](https://www.npmjs.com/package/debug), when writing debug
@@ -63,7 +63,7 @@ For example, a debug log like this:
 
 ```typescript
 // src/components
-logger.debug(message, logger.DebugContext.swaps)
+logger.debug(message, logger.DebugContext.swaps);
 ```
 
 Would be logged to the console in dev mode if `LOG_LEVEL=debug`, _or_ if you
@@ -72,8 +72,8 @@ multiple contexts using commas like `LOG_DEBUG=swaps,ethers`, and _automatically
 sets the log level to `debug`, regardless of `LOG_LEVEL`._
 
 > For more advanced usage, you we can namespace our debug contexts i.e.
-`swaps:utils` or `swaps:forms`, which can then be targeted individually, or
-using a wildcard `LOG_LEVEL=swaps:*` to filter for all `swaps:` debug logs.
+> `swaps:utils` or `swaps:forms`, which can then be targeted individually, or
+> using a wildcard `LOG_LEVEL=swaps:*` to filter for all `swaps:` debug logs.
 
 ### `logger.info`
 
@@ -85,19 +85,18 @@ to Sentry as breadcrumbs.
 information from being sent in these logs.
 
 ```typescript
-logger.info(message)
+logger.info(message);
 ```
 
-`info`, along with `warn` and `error` support an additional parameter, `metadata:
-Record<string, unknown>`. Use this to provide values to the [Sentry
+`info`, along with `warn` and `error` support an additional parameter, `metadata: Record<string, unknown>`. Use this to provide values to the [Sentry
 breadcrumb](https://docs.sentry.io/platforms/react-native/enriching-events/breadcrumbs/#manual-breadcrumbs).
 The object will also be pretty printed to the console in dev mode if
 `LOG_LEVEL=info`.
 
 ```typescript
 logger.info(message, {
-   duration: '256ms'
-})
+  duration: '256ms',
+});
 ```
 
 ### `logger.warn`
@@ -114,7 +113,7 @@ These logs will also be sent as Sentry breadcrumbs, with a severity level of
 `warning`, and they also support the optional second parameter, `metadata`.
 
 ```typescript
-logger.warn(message, { ...metadata })
+logger.warn(message, { ...metadata });
 ```
 
 ### `logger.error`
@@ -133,7 +132,7 @@ be reported instead so that we can track down the incorrect usage.
 try {
   // some async code
 } catch (e) {
-  logger.error(e, { ...metadata })
+  logger.error(e, { ...metadata });
 }
 ```
 
@@ -141,12 +140,12 @@ The correct way to handle exceptions is to always create a new `RainbowError`
 with a descriptive message of what happened. Be sure to avoid any PII.
 
 ```typescript
-import { RainbowError } from '@/logger'
+import { RainbowError } from '@/logger';
 
 try {
-   // some async code
+  // some async code
 } catch (e) {
-   const error = new RainbowError('Descriptive error message')
-   logger.error(error, { ...metadata })
+  const error = new RainbowError('Descriptive error message');
+  logger.error(error, { ...metadata });
 }
 ```

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -19,17 +19,17 @@ logger.error(error[, metadata])
 #### Usage Heuristics
 
 - Use `logger.error` for all exceptions, and always pass it a descriptive
-`RainbowError`.
+  `RainbowError`.
 - Use `logger.warn` for anything that might be an exception now or in the future,
-or something we _need_ to know about, but isn't critical at the moment.
+  or something we _need_ to know about, but isn't critical at the moment.
 - Use `logger.info` for anything you think would be helpful when tracing errors in
-Sentry. Think about what your coworkers might find helpful, and use these
-frequently.
+  Sentry. Think about what your coworkers might find helpful, and use these
+  frequently.
 - Use `logger.debug` for noisy lower-level stuff that's only helpful locally when
-developing or debugging. We have the option to send these to Sentry, but by
-default they aren't, so use these frequently as you see fit.
+  developing or debugging. We have the option to send these to Sentry, but by
+  default they aren't, so use these frequently as you see fit.
 - Use `console.log` _locally only_. We strip these out when building for
-production.
+  production.
 
 #### Modes
 

--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -1,0 +1,202 @@
+import { nanoid } from 'nanoid';
+import { expect, test } from '@jest/globals';
+
+import { Logger, LogLevel } from '@/logger';
+
+describe('general functionality', () => {
+  test('default params', () => {
+    const logger = new Logger();
+    expect(logger.enabled).toBeFalsy();
+    expect(logger.level).toEqual(LogLevel.Warn);
+  });
+
+  test('can override default params', () => {
+    const logger = new Logger({
+      enabled: true,
+      level: LogLevel.Info,
+    });
+    expect(logger.enabled).toBeTruthy();
+    expect(logger.level).toEqual(LogLevel.Info);
+  });
+
+  test('disabled logger does not report', () => {
+    const logger = new Logger({
+      enabled: false,
+      level: LogLevel.Debug,
+    });
+
+    const mockTransport = jest.fn();
+
+    logger.addTransport(mockTransport);
+    logger.debug('message');
+
+    expect(mockTransport).not.toHaveBeenCalled();
+  });
+
+  test('passing debug contexts automatically enables debug mode', () => {
+    const logger = new Logger({ debug: 'specific' });
+    expect(logger.level).toEqual(LogLevel.Debug);
+  });
+
+  test('supports extra metadata', () => {
+    const logger = new Logger({ enabled: true });
+
+    const mockTransport = jest.fn();
+
+    logger.addTransport(mockTransport);
+
+    const extra = { foo: true };
+    logger.warn('message', extra);
+
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, 'message', extra);
+  });
+});
+
+describe('debug contexts', () => {
+  const mockTransport = jest.fn();
+
+  test('specific', () => {
+    const message = nanoid();
+    const logger = new Logger({
+      enabled: true,
+      debug: 'specific',
+    });
+
+    logger.addTransport(mockTransport);
+    logger.debug(message, 'specific');
+
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Debug, message, {});
+  });
+
+  test('namespaced', () => {
+    const message = nanoid();
+    const logger = new Logger({
+      enabled: true,
+      debug: 'namespace*',
+    });
+
+    logger.addTransport(mockTransport);
+    logger.debug(message, 'namespace');
+
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Debug, message, {});
+  });
+
+  test('by filepaths', () => {
+    const message = nanoid();
+    const logger = new Logger({
+      enabled: true,
+      debug: 'src/components/*',
+    });
+
+    logger.addTransport(mockTransport);
+    logger.debug(message, 'src/components/Divider.js');
+
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Debug, message, {});
+  });
+
+  test('ignores inactive', () => {
+    const message = nanoid();
+    const logger = new Logger({
+      enabled: true,
+      debug: 'src/components/*',
+    });
+
+    logger.addTransport(mockTransport);
+    logger.debug(message, 'src/utils/*');
+
+    expect(mockTransport).not.toHaveBeenCalledWith(LogLevel.Debug, message, {});
+  });
+});
+
+describe('supports levels', () => {
+  test('debug', () => {
+    const logger = new Logger({
+      enabled: true,
+      level: LogLevel.Debug,
+    });
+    const message = nanoid();
+    const mockTransport = jest.fn();
+
+    logger.addTransport(mockTransport);
+
+    logger.debug(message);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Debug, message, {});
+
+    logger.info(message);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Info, message, {});
+
+    logger.warn(message);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, message, {});
+
+    logger.error(new Error(message), 'custom message');
+    expect(mockTransport).toHaveBeenCalledWith(
+      LogLevel.Error,
+      'custom message',
+      {}
+    );
+  });
+
+  test('info', () => {
+    const logger = new Logger({
+      enabled: true,
+      level: LogLevel.Info,
+    });
+    const message = nanoid();
+    const mockTransport = jest.fn();
+
+    logger.addTransport(mockTransport);
+
+    logger.debug(message);
+    expect(mockTransport).not.toHaveBeenCalled();
+
+    logger.info(message);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Info, message, {});
+  });
+
+  test('warn', () => {
+    const logger = new Logger({
+      enabled: true,
+      level: LogLevel.Warn,
+    });
+    const message = nanoid();
+    const mockTransport = jest.fn();
+
+    logger.addTransport(mockTransport);
+
+    logger.debug(message);
+    expect(mockTransport).not.toHaveBeenCalled();
+
+    logger.info(message);
+    expect(mockTransport).not.toHaveBeenCalled();
+
+    logger.warn(message);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, message, {});
+  });
+
+  test('error', () => {
+    const logger = new Logger({
+      enabled: true,
+      level: LogLevel.Error,
+    });
+    const message = nanoid();
+    const mockTransport = jest.fn();
+
+    logger.addTransport(mockTransport);
+
+    logger.debug(message);
+    expect(mockTransport).not.toHaveBeenCalled();
+
+    logger.info(message);
+    expect(mockTransport).not.toHaveBeenCalled();
+
+    logger.warn(message);
+    expect(mockTransport).not.toHaveBeenCalled();
+
+    logger.error(new Error('original message'), 'custom message');
+    expect(mockTransport).toHaveBeenCalledWith(
+      LogLevel.Error,
+      'custom message',
+      {}
+    );
+  });
+});

--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -168,28 +168,15 @@ describe('debug contexts', () => {
     expect(mockTransport).toHaveBeenCalledWith(LogLevel.Debug, message, {});
   });
 
-  test('by filepaths', () => {
-    const message = nanoid();
-    const logger = new Logger({
-      enabled: true,
-      debug: 'src/components/*',
-    });
-
-    logger.addTransport(mockTransport);
-    logger.debug(message, {}, 'src/components/Divider.js');
-
-    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Debug, message, {});
-  });
-
   test('ignores inactive', () => {
     const message = nanoid();
     const logger = new Logger({
       enabled: true,
-      debug: 'src/components/*',
+      debug: 'namespace:foo:*',
     });
 
     logger.addTransport(mockTransport);
-    logger.debug(message, {}, 'src/utils/*');
+    logger.debug(message, {}, 'namespace:bar:baz');
 
     expect(mockTransport).not.toHaveBeenCalledWith(LogLevel.Debug, message, {});
   });

--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -73,8 +73,8 @@ describe('general functionality', () => {
     logger.error(new Error());
 
     expect(mockTransport).toHaveBeenCalledWith(
-      LogLevel.Warn,
-      `logger.error was not provided a RainbowError so this exception will be ignored`,
+      LogLevel.Error,
+      new RainbowError(`logger.error was not provided a RainbowError`),
       {}
     );
   });

--- a/src/logger/debugContext.ts
+++ b/src/logger/debugContext.ts
@@ -1,0 +1,10 @@
+/**
+ * *Do not import this directly.* Instead, use the shortcut reference `logger.DebugContext`.
+ *
+ * Add debug contexts here. Although convention typically calls for enums ito
+ * be capitalized, for parity with the `LOG_DEBUG` env var, please use all
+ * lowercase.
+ */
+export const DebugContext = {
+  // e.g. swaps: 'swaps'
+} as const;

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,0 +1,129 @@
+import { LOG_LEVEL, LOG_DEBUG } from 'react-native-dotenv';
+import format from 'date-fns/format';
+
+import * as env from '@/env';
+import { DebugContext } from '@/logger/debugContext';
+
+export enum LogLevel {
+  Debug = 'debug',
+  Info = 'info',
+  Warn = 'warn',
+  Error = 'error',
+}
+type Transport = (level: LogLevel, message: string, extra: Extra) => void;
+type Extra = Record<string, unknown>;
+
+const enabledLogLevels: {
+  [key in LogLevel]: LogLevel[];
+} = {
+  [LogLevel.Debug]: [
+    LogLevel.Debug,
+    LogLevel.Info,
+    LogLevel.Warn,
+    LogLevel.Error,
+  ],
+  [LogLevel.Info]: [LogLevel.Info, LogLevel.Warn, LogLevel.Error],
+  [LogLevel.Warn]: [LogLevel.Warn, LogLevel.Error],
+  [LogLevel.Error]: [LogLevel.Error],
+};
+
+/**
+ * Used in dev mode to nicely log to the console
+ */
+export function defaultTransport(
+  level: LogLevel,
+  message: string,
+  extra: Extra
+) {
+  const timestamp = format(new Date(), 'HH:mm:ss');
+  const metadata = Object.keys(extra).length
+    ? ' ' + JSON.stringify(extra, null, '  ')
+    : '';
+
+  console.log(`${timestamp} [${level.toUpperCase()}] ${message}${metadata}`);
+}
+
+/**
+ * Main class. Defaults are provided in the constructor so that subclasses are
+ * technically possible, if we need to go that route in the future.
+ */
+export class Logger {
+  LogLevel = LogLevel;
+  DebugContext = DebugContext;
+
+  enabled: boolean;
+  level: LogLevel;
+  transports: Transport[] = [];
+
+  protected debugContextRegexes: RegExp[] = [];
+
+  constructor({
+    enabled = !env.IS_TEST,
+    level = LOG_LEVEL as LogLevel,
+    debug = LOG_DEBUG || '',
+  }: {
+    enabled?: boolean;
+    level?: LogLevel;
+    debug?: string;
+  } = {}) {
+    this.enabled = enabled !== false;
+    this.level = debug ? LogLevel.Debug : level ?? LogLevel.Warn;
+    this.debugContextRegexes = (debug || '').split(',').map(context => {
+      return new RegExp(context.replace('/', '\\/').replace('*', '.*'));
+    });
+  }
+
+  debug(message: string, context?: string) {
+    if (context && !this.debugContextRegexes.find(reg => reg.test(context)))
+      return;
+    this.transport(LogLevel.Debug, message, {});
+  }
+
+  info(message: string, extra: Extra = {}) {
+    this.transport(LogLevel.Info, message, extra);
+  }
+
+  warn(message: string, extra: Extra = {}) {
+    this.transport(LogLevel.Warn, message, extra);
+  }
+
+  error(error: Error, message: string, extra: Extra = {}) {
+    this.transport(LogLevel.Error, message, extra);
+    if (error.stack && env.IS_DEV)
+      this.transport(LogLevel.Error, error.stack, {});
+  }
+
+  addTransport(transport: Transport) {
+    this.transports.push(transport);
+    return () => {
+      this.transports.splice(this.transports.indexOf(transport), 1);
+    };
+  }
+
+  protected transport(level: LogLevel, message: string, extra: Extra) {
+    if (!this.enabled) return;
+    if (!enabledLogLevels[this.level].includes(level)) return;
+
+    for (const transport of this.transports) {
+      transport(level, message, extra);
+    }
+  }
+}
+
+/**
+ * Rainbow's logger. See `@/logger/README` for docs.
+ *
+ * Basic usage:
+ *
+ *   `logger.debug(message[, debugContext])`
+ *   `logger.info(message[, extra])`
+ *   `logger.warn(message[, extra])`
+ *   `logger.error(error, message[, extra])`
+ */
+export const logger = new Logger();
+
+if (env.IS_DEV) {
+  logger.addTransport(defaultTransport);
+} else if (env.IS_PROD) {
+  // TODO sentry
+}

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -151,7 +151,7 @@ export class Logger {
     this.enabled = enabled !== false;
     this.level = debug ? LogLevel.Debug : level ?? LogLevel.Warn;
     this.debugContextRegexes = (debug || '').split(',').map(context => {
-      return new RegExp(context.replace('/', '\\/').replace('*', '.*'));
+      return new RegExp(context.replace(/\//g, '\\/').replace(/\*/g, '.*'));
     });
   }
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -151,7 +151,7 @@ export class Logger {
     this.enabled = enabled !== false;
     this.level = debug ? LogLevel.Debug : level ?? LogLevel.Warn;
     this.debugContextRegexes = (debug || '').split(',').map(context => {
-      return new RegExp(context.replace(/\//g, '\\/').replace(/\*/g, '.*'));
+      return new RegExp(context.replace(/[^\w:*]/, '').replace(/\*/g, '.*'));
     });
   }
 


### PR DESCRIPTION
Fixes RNBW-4477

## What changed (plus any additional context for devs)
This is the first pass at a new logger, [based on our spec](https://www.notion.so/rainbowdotme/Tracking-635a7da3d0cc413b9cf390f1c3c48f88#3952ebba01114a80a6366c5fc9272656).

**Features:**
- unified interface
- log levels: `debug`, `info`, `warn`, and `error`
- deeper integration with Sentry, automatic breadcrumbs, exception handling for errors
- differentiation between dev/test/prod modes
  - no logs in test mode by default
- filtered logs, no spamming of console
  - only see logs that are relevant to what you're working on
- documentation
- full test suite

**Key notes:**
- log level defaults to `warn` in dev (i.e. only `warn` or `error` are logged to console), and we should set it to `info` in prod to capture more breadcrumbs
- `debug`, `info`, and `warn` are all capable of being reported to Sentry as breadcrumbs, depending on log level
- `error` is always sent as `captureException`

**FAQ:**
> So should logger.debug be preferred over console.log?

Pretty much! I think using the logger is like saying "I want other devs to be able to see this too", like a more permanent approach. But I don't think we need to block the usage of `console.log` during dev. We should probably lint for console though, just to try and avoid some stray `console.log(privateKey)` ends up in Sentry.

**At a glance:**

```typescript
import { logger, RainbowError } from '@/logger'

logger.debug('Entering fetch block') // Enabled with LOG_LEVEL=debug
logger.debug('Computing estimated gas', { duration }, logger.DebugContext.swaps) // Enabled with LOG_LEVEL or LOG_DEBUG=swaps

logger.info('User has X preference enabled') // Enabled with LOG_LEVEL=info
logger.info('Response returned successfully', {
  duration: '123ms' // Additional data
})
logger.info(`User navigated from ${prevRoute} to ${nextRoute}`, {
  type: 'navigation' // Sentry convention
})

logger.warn('Zerion failed, trying N more times before fallback', {
  type: 'http', // Sentry convention
  attempts: 2 // Additional data
})

try {
  // some async code
} catch (e) {
  const error = new RainbowError('Request to Simplehash threw an error. Look for network issues.')
  logger.error(error, {
    tags: { ...tags } // Sentry convention
  })
}
```

## Screen recordings / screenshots
<img width="482" alt="Screen Shot 2022-09-15 at 2 08 37 PM" src="https://user-images.githubusercontent.com/4732330/190507212-d1a92161-6872-447a-a14e-3e17edef2efe.png">


## What to test
<img width="542" alt="Screen Shot 2022-09-15 at 3 03 49 PM" src="https://user-images.githubusercontent.com/4732330/190507224-98b286de-198f-4b1d-a59e-f98853a179fb.png">


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
