### PR TITLE
Use same check for unique tokens on polygon as ETH mainnet

### DIFF
--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -190,6 +190,8 @@ export const parseAccountUniqueTokensPolygon = data => {
         metadata.image_original_url,
         metadata.image_preview_url
       );
+
+      const sellOrder = asset.seaport_sell_orders?.[0];
       return {
         ...pickShallow(metadata, [
           'animation_url',
@@ -219,12 +221,11 @@ export const parseAccountUniqueTokensPolygon = data => {
           'twitter_username',
           'wiki_link',
         ]),
-        currentPrice: asset.seaport_sell_orders
+        currentPrice: sellOrder
           ? getCurrentPrice({
-              currentPrice: asset.seaport_sell_orders[0].current_price,
+              currentPrice: sellOrder?.current_price,
               token:
-                asset.seaport_sell_orders[0].protocol_data.parameters
-                  .consideration[0].token,
+                sellOrder?.protocol_data?.parameters?.consideration?.[0]?.token,
             })
           : null,
         familyImage: collection.image_url,


### PR DESCRIPTION
Fixes RNBW-4479
Figma link (if any):

## What changed (plus any additional context for devs)
We switched out the logic for fetching currentPrice on ETH mainnet however we didnt copy that same logic over to Polygon tokens. This adds that same code, which should stop polygon NFTs dissappearing in the app.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
Find a wallet that has polygon NFTs that are for sale on OS and check to see if the NFT list loads


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
