### PR TITLE
Fix import wallet modal padding

### DIFF
--- a/src/components/floating-panels/FloatingPanel.tsx
+++ b/src/components/floating-panels/FloatingPanel.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { FlexStyle, ViewStyle } from 'react-native';
+import { FlexStyle, StyleProp, ViewStyle } from 'react-native';
 import { Box, Space } from '@/design-system';
 
 type FloatingPanelProps = {
@@ -7,7 +7,7 @@ type FloatingPanelProps = {
   children: ReactNode;
   overflow: FlexStyle['overflow'];
   paddingBottom: Space;
-  style: ViewStyle;
+  style: StyleProp<ViewStyle>;
   testID: string;
 };
 
@@ -24,7 +24,7 @@ const FloatingPanel = ({
       background="body (Deprecated)"
       borderRadius={borderRadius}
       paddingBottom={paddingBottom}
-      style={{ ...style, overflow, zIndex: 1 }}
+      style={[style, { overflow, zIndex: 1 }]}
       testID={testID + '-container'}
       {...props}
     />


### PR DESCRIPTION
Fixes RNBW-4497

## What changed (plus any additional context for devs)

I updated the `style` prop in `FloatingPanel.tsx` so that it can support arrays of styles. Previously it was being spread into a single style object, but this breaks if an array is passed in.

## Screen recordings / screenshots

### iOS

Before:

<img width="476" alt="Screen Shot 2022-09-16 at 7 41 41 am" src="https://user-images.githubusercontent.com/696693/190514020-3f3f2bc8-f414-4540-b144-0c4b41f06472.png">

After:

<img width="477" alt="Screen Shot 2022-09-16 at 7 41 52 am" src="https://user-images.githubusercontent.com/696693/190514044-b8167043-eca4-43e0-ae77-493a1c0e044b.png">

### Android

Before:

<img width="655" alt="Screen Shot 2022-09-16 at 7 25 45 am" src="https://user-images.githubusercontent.com/696693/190512536-acee38da-df84-4707-a2c0-b2238054de1f.png">

After:

<img width="656" alt="Screen Shot 2022-09-16 at 7 25 16 am" src="https://user-images.githubusercontent.com/696693/190512564-51d21667-27b0-4d43-8910-0f540a22e137.png">


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
