### PR TITLE
Use SimpleHash's nft_url and marketplace_id fields instead of matching on marketplace name

### DIFF
--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -79,20 +79,17 @@ const Title = styled(TextElement).attrs(({ color, theme: { colors } }) => ({
 });
 
 const getNftTraitUrl = (
-  marketplaceName,
+  marketplaceId,
   collectionId,
   traitTitle,
   traitValue
 ) => {
-  switch (marketplaceName) {
-    case 'Stratos':
+  switch (marketplaceId) {
+    case 'stratos':
       return `https://stratosnft.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
-    // TODO:: Remove after SimpleHash updates marketplace names
-    case 'Quixotic':
+    case 'quixotic':
       return `https://qx.app/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
-    case 'Quix':
-      return `https://qx.app/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
-    case 'Trove':
+    case 'trove':
       return `https://trove.treasure.lol/collection/${collectionId}?trait%5B%5D=${traitTitle}%3A${traitValue}`;
     default:
       return `https://opensea.io/collection/${collectionId}?search[stringTraits][0][name]=${traitTitle}&search[stringTraits][0][values][0]=${traitValue}`;
@@ -105,6 +102,7 @@ const Tag = ({
   slug,
   text,
   title,
+  marketplaceId,
   marketplaceName,
   maxValue,
   originalValue,
@@ -125,7 +123,7 @@ const Tag = ({
     ({ nativeEvent: { actionKey } }) => {
       if (actionKey === PropertyActionsEnum.viewTraitOnNftMarketplace) {
         const nftTraitUrl = getNftTraitUrl(
-          marketplaceName,
+          marketplaceId,
           slug,
           title,
           originalValue
@@ -135,7 +133,7 @@ const Tag = ({
         Linking.openURL(originalValue);
       }
     },
-    [slug, originalValue, marketplaceName, title]
+    [slug, originalValue, marketplaceId, title]
   );
 
   const onPressAndroid = useCallback(() => {
@@ -161,7 +159,7 @@ const Tag = ({
           viewTraitOnNftMarketplaceAction.actionTitle
         ) {
           const nftTraitUrl = getNftTraitUrl(
-            marketplaceName,
+            marketplaceId,
             slug,
             title,
             originalValue
@@ -181,7 +179,7 @@ const Tag = ({
     slug,
     title,
     originalValue,
-    marketplaceName,
+    marketplaceId,
     viewTraitOnNftMarketplaceAction.actionTitle,
   ]);
 
@@ -256,6 +254,7 @@ export default magicMemo(Tag, [
   'slug',
   'text',
   'title',
+  'marketplaceId',
   'marketplaceName',
   'maxValue',
   'originalValue',

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -87,8 +87,11 @@ const getNftTraitUrl = (
   switch (marketplaceName) {
     case 'Stratos':
       return `https://stratosnft.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
+    // TODO:: Remove after SimpleHash updates marketplace names
     case 'Quixotic':
-      return `https://quixotic.io/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
+      return `https://qx.app/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
+    case 'Quix':
+      return `https://qx.app/collection/${collectionId}?attributes=${traitTitle}:${traitValue}`;
     case 'Trove':
       return `https://trove.treasure.lol/collection/${collectionId}?trait%5B%5D=${traitTitle}%3A${traitValue}`;
     default:

--- a/src/components/unique-token/UniqueTokenAttributes.tsx
+++ b/src/components/unique-token/UniqueTokenAttributes.tsx
@@ -11,6 +11,7 @@ import uniqueAssetTraitDisplayTypeCompareFunction from '@/helpers/uniqueAssetTra
 interface UniqueTokenAttributesProps {
   color: string;
   hideNftMarketplaceAction: boolean;
+  marketplaceId?: string | null;
   marketplaceName?: string | null;
   slug: string;
   traits: UniqueAsset['traits'];
@@ -19,6 +20,7 @@ interface UniqueTokenAttributesProps {
 const UniqueTokenAttributes = ({
   color,
   hideNftMarketplaceAction,
+  marketplaceId,
   marketplaceName,
   slug,
   traits,
@@ -62,6 +64,7 @@ const UniqueTokenAttributes = ({
             hideNftMarketplaceAction={hideNftMarketplaceAction}
             key={`${type}${originalValue}`}
             lowercase={lowercase}
+            marketplaceId={marketplaceId}
             marketplaceName={marketplaceName}
             maxValue={maxValue}
             originalValue={originalValue}
@@ -78,6 +81,7 @@ const UniqueTokenAttributes = ({
 export default magicMemo(UniqueTokenAttributes, [
   'color',
   'slug',
+  'marketplaceId',
   'marketplaceName',
   'traits',
 ]);

--- a/src/entities/uniqueAssets.ts
+++ b/src/entities/uniqueAssets.ts
@@ -47,6 +47,7 @@ export interface UniqueAsset {
   lastSalePaymentToken: string | undefined | null;
   lowResUrl: string | null;
   marketplaceCollectionUrl?: string | null;
+  marketplaceId: string | null;
   marketplaceName: string | null;
   type: AssetType;
   uniqueId: string;

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -106,6 +106,7 @@ const buildEnsToken = ({
     lastSalePaymentToken: null,
     lowResUrl,
     marketplaceCollectionUrl: getOpenSeaCollectionUrl(slug),
+    marketplaceId: 'opensea',
     marketplaceName: 'OpenSea',
     name,
     network: Network.mainnet,

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -8,6 +8,7 @@ import { logger } from '@/utils';
 interface SimplehashMarketplace {
   marketplace_name: string;
   marketplace_collection_id: string;
+  nft_url: string;
   collection_url: string;
   verified: boolean;
 }
@@ -101,7 +102,7 @@ export async function getNFTByTokenId({
 export async function getNftsByWalletAddress(walletAddress: string) {
   let rawResponseNfts: SimplehashNft[] = [];
   try {
-    const chainsParam: string = `${Network.arbitrum},${Network.optimism}`;
+    const chainsParam = `${Network.arbitrum},${Network.optimism}`;
 
     let cursor = START_CURSOR;
     while (cursor) {

--- a/src/handlers/simplehash.ts
+++ b/src/handlers/simplehash.ts
@@ -6,6 +6,7 @@ import { parseSimplehashNfts } from '@/parsers';
 import { logger } from '@/utils';
 
 interface SimplehashMarketplace {
+  marketplace_id: string;
   marketplace_name: string;
   marketplace_collection_id: string;
   nft_url: string;

--- a/src/navigation/useUntrustedUrlOpener.ts
+++ b/src/navigation/useUntrustedUrlOpener.ts
@@ -13,9 +13,11 @@ const trustedDomains = [
   'instagram.com',
   'opensea.io',
   'quixotic.io',
+  'qx.app',
   'rainbow.me',
   'rarible.com',
   'stratosnft.io',
+  'trove.treasure.lol',
   'twitter.com',
   'zora.co',
 ];

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -325,21 +325,8 @@ const getSimplehashMarketplaceInfo = simplehashNft => {
   const marketplaceName = marketplace.marketplace_name;
   const collectionId = marketplace.marketplace_collection_id;
   const collectionUrl = marketplace.collection_url;
-  const tokenId = simplehashNft.token_id;
-  let permalink = null;
-  switch (marketplaceName) {
-    case 'Quixotic':
-      permalink = `https://quixotic.io/asset/${collectionId}/${tokenId}`;
-      break;
-    case 'Stratos':
-      permalink = `https://stratosnft.io/asset/${collectionId}/${tokenId}`;
-      break;
-    case 'Trove':
-      permalink = `https://trove.treasure.lol/collection/${collectionId}/${tokenId}`;
-      break;
-    default:
-      permalink = null;
-  }
+  const permalink = marketplace.nft_url;
+
   return {
     collectionId,
     collectionUrl,

--- a/src/parsers/uniqueTokens.js
+++ b/src/parsers/uniqueTokens.js
@@ -166,6 +166,7 @@ export const parseAccountUniqueTokens = data => {
             : null,
           lowResUrl,
           marketplaceCollectionUrl: getOpenSeaCollectionUrl(collection.slug),
+          marketplaceId: 'opensea',
           marketplaceName: 'OpenSea',
           network: Network.mainnet,
           type: AssetTypes.nft,
@@ -248,6 +249,7 @@ export const parseAccountUniqueTokensPolygon = data => {
           : null,
         lowResUrl,
         marketplaceCollectionUrl: getOpenSeaCollectionUrl(collection.slug),
+        marketplaceId: 'opensea',
         marketplaceName: 'OpenSea',
         network: Network.polygon,
         permalink: asset.permalink,
@@ -322,6 +324,7 @@ const getSimplehashMarketplaceInfo = simplehashNft => {
   const marketplace = simplehashNft.collection.marketplace_pages?.[0];
   if (!marketplace) return null;
 
+  const marketplaceId = marketplace.marketplace_id;
   const marketplaceName = marketplace.marketplace_name;
   const collectionId = marketplace.marketplace_collection_id;
   const collectionUrl = marketplace.collection_url;
@@ -330,6 +333,7 @@ const getSimplehashMarketplaceInfo = simplehashNft => {
   return {
     collectionId,
     collectionUrl,
+    marketplaceId,
     marketplaceName,
     permalink,
   };
@@ -381,6 +385,7 @@ export const parseSimplehashNfts = nftData => {
       lastSalePaymentToken: simplehashNft.last_sale?.payment_token?.symbol,
       lowResUrl,
       marketplaceCollectionUrl: marketplaceInfo?.collectionUrl,
+      marketplaceId: marketplaceInfo?.marketplaceId,
       marketplaceName: marketplaceInfo?.marketplaceName,
       name: simplehashNft.name,
       network: simplehashNft.chain,


### PR DESCRIPTION
Fixes RNBW-4478

## What changed (plus any additional context for devs)

Quixotic rebranded to Quix and we were matching on `marketplace_name` in two places to provide deeplinks for:
- The NFT's page on that marketplace
- The marketplace's results for a selected trait in that collection

SimpleHash introduced `nft_url` field so we don't have to match for this at all anymore and `marketplace_id` so we have a field guaranteed not to change to handle the selected trait search. Once this PR is merged, released, and propagates, SimpleHash will update Quixotic -> Quix and the correct marketplace name will be displayed.

## Screen recordings / screenshots
- Screen recording demonstrating that we continue to show a marketplace's name (`View on OpenSea`) and the link works: [nft-marketplace-urls.webm](https://user-images.githubusercontent.com/677680/190522481-5a030a6b-d907-49d7-b39a-c68b629d3c54.webm)

- Screen recording demonstrating that the selected trait search continues to work: [nft-marketplace-traits.webm](https://user-images.githubusercontent.com/677680/190522485-add13858-97c0-4321-b5f7-c959804f8077.webm)

## What to test
- Go into NFT expanded state for an NFT on arbitrum/optimism/mainnet and confirm that `View on X` marketplace states the correct marketplace
  - The link should go to the NFT's page on that marketplace
- Go into NFT expanded state for an NFT on arbitrum/optimism/mainnet and confirm that clicking a trait links you to the marketplace's results for a selected trait in that collection


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
