### PR TITLE
fix: upgrade detox for iOS 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "babel-plugin-styled-components": "1.11.1",
     "babel-plugin-transform-remove-console": "6.9.4",
     "chai": "4.2.0",
-    "detox": "19.7.1",
+    "detox": "19.12.1",
     "dotenv": "8.2.0",
     "eslint": "8.22.0",
     "eslint-config-rainbow": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8887,10 +8887,10 @@ detective-typescript@^7.0.0:
     node-source-walk "^4.2.0"
     typescript "^3.9.7"
 
-detox@19.7.1:
-  version "19.7.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-19.7.1.tgz#1c4dfebbb024426118dfae97a0189a25021479fa"
-  integrity sha512-V0XwiaFX1LvIjLl+G4tzMZ0M4YqenQXAdTsw9kO2dVo6NC9RuYqOIsmT9M3CRN9PF22TKJ8pFdA6onYhH/zkiQ==
+detox@19.12.1:
+  version "19.12.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-19.12.1.tgz#6ad924f93c60dd9188ac62866222233435b53bd2"
+  integrity sha512-sh8xxWLSykJ8zH1zxP2nXV9iIcuwQ4Umn8LKCtkilrLen9K/EJqNN2miMfu7Mue63aTVt6KFLJ6y11yFuZ2LXQ==
   dependencies:
     ajv "^8.6.3"
     bunyan "^1.8.12"


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Fixes an issue I was having locally running Detox after macOS updated the simulators. More info [in the Detox repo.](https://github.com/wix/Detox/issues/3593)

<img width="796" alt="screen_shot_2022-09-19_at_2 03 08_pm" src="https://user-images.githubusercontent.com/4732330/191118156-2ce64036-422c-4148-ab26-2f826832beb0.png">

## What to test
Should have no effect.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
