### PR TITLE
dont update backup meta when restoring

### DIFF
--- a/src/components/backup/RestoreCloudStep.js
+++ b/src/components/backup/RestoreCloudStep.js
@@ -187,7 +187,8 @@ export default function RestoreCloudStep({
                   setWalletBackedUp(
                     walletId,
                     walletBackupTypes.cloud,
-                    backupSelected?.name
+                    backupSelected?.name,
+                    false
                   )
                 );
               })

--- a/src/redux/wallets.ts
+++ b/src/redux/wallets.ts
@@ -287,7 +287,8 @@ export const setIsWalletLoading = (val: WalletsState['isWalletLoading']) => (
 export const setWalletBackedUp = (
   walletId: RainbowWallet['id'],
   method: RainbowWallet['backupType'],
-  backupFile: RainbowWallet['backupFile'] = null
+  backupFile: RainbowWallet['backupFile'] = null,
+  updateUserMetadata: boolean = true
 ) => async (
   dispatch: ThunkDispatch<AppState, unknown, never>,
   getState: AppGetState
@@ -313,7 +314,7 @@ export const setWalletBackedUp = (
     dispatch(setIsWalletLoading(null));
   }, 1000);
 
-  if (method === WalletBackupTypes.cloud) {
+  if (method === WalletBackupTypes.cloud && updateUserMetadata) {
     try {
       await backupUserDataIntoCloud({ wallets: newWallets });
     } catch (e) {


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
We were updating the backup meta after restoring. This is no longer necessary.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
See slack msg


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
