### PR TITLE
fix: reference redux within `NotificationsHandler`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -311,25 +311,22 @@ class App extends Component {
                 <Provider store={store}>
                   <RecoilRoot>
                     <SharedValuesProvider>
-                      <NotificationsHandler
-                        walletReady={this.props.walletReady}
-                      >
-                        <View style={containerStyle}>
-                          {this.state.initialRoute && (
-                            <InitialRouteContext.Provider
-                              value={this.state.initialRoute}
-                            >
-                              <RoutesComponent
-                                onReady={this.handleSentryNavigationIntegration}
-                                ref={this.handleNavigatorRef}
-                              />
-                              <PortalConsumer />
-                            </InitialRouteContext.Provider>
-                          )}
-                          <OfflineToast />
-                          <FedoraToast ref={FedoraToastRef} />
-                        </View>
-                      </NotificationsHandler>
+                      <NotificationsHandler />
+                      <View style={containerStyle}>
+                        {this.state.initialRoute && (
+                          <InitialRouteContext.Provider
+                            value={this.state.initialRoute}
+                          >
+                            <RoutesComponent
+                              onReady={this.handleSentryNavigationIntegration}
+                              ref={this.handleNavigatorRef}
+                            />
+                            <PortalConsumer />
+                          </InitialRouteContext.Provider>
+                        )}
+                        <OfflineToast />
+                        <FedoraToast ref={FedoraToastRef} />
+                      </View>
                     </SharedValuesProvider>
                   </RecoilRoot>
                 </Provider>

--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useContacts, usePrevious, useWallets } from '@/hooks';
 import { setupAndroidChannels } from '@/notifications/setupAndroidChannels';
 import messaging, {
@@ -16,7 +16,7 @@ import {
   saveFCMToken,
 } from '@/notifications/tokens';
 import { WALLETCONNECT_SYNC_DELAY } from '@/notifications/constants';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { requestsForTopic } from '@/redux/requests';
 import { ThunkDispatch } from 'redux-thunk';
 import store, { AppState } from '@/redux/store';
@@ -45,9 +45,11 @@ import { mapNotificationTransactionType } from '@/notifications/mapTransactionsT
 
 type Callback = () => void;
 
-type Props = PropsWithChildren<{ walletReady: boolean }>;
-
-export const NotificationsHandler = ({ children, walletReady }: Props) => {
+export const NotificationsHandler = () => {
+  const { walletReady } = useSelector(state => ({
+    // @ts-expect-error
+    walletReady: state.appState.walletReady,
+  })) as { walletReady: boolean };
   const wallets = useWallets();
   const { contacts } = useContacts();
   const dispatch: ThunkDispatch<AppState, unknown, AnyAction> = useDispatch();
@@ -323,5 +325,5 @@ export const NotificationsHandler = ({ children, walletReady }: Props) => {
     }
   };
 
-  return children;
+  return null;
 };


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Bit of a nit-picky thing here, but we don't really need to wrap the whole app in this component. Two main reasons:
- once we refactor state, this _could_ have an impact on render performance i.e. more nesting, more state subscriptions, more renders
- I'd like to eventually remove our usage of `connect()` in `App.js`, and this would mean making this PR at that point

Super small, so figured I'd just push it up and see what you think :) 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
