### PR TITLE
[TEAM2-499] Currency Select Modal Crosschain Search

### DIFF
--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -40,16 +40,12 @@ const tokenSearch = async (searchParams: {
   if (searchParams.fromChainId) {
     queryParams.fromChainId = searchParams.fromChainId;
   }
-  // if (searchParams.query) {
-  //   queryParams.query = searchParams.query;
-  // }
   try {
     if (isAddress(searchParams.query) && !searchParams.fromChainId) {
       // @ts-ignore
       params.keys = `networks.${params.chainId}.address`;
     }
     const url = `/${searchParams.chainId}/?${qs.stringify(queryParams)}`;
-    logger.debug('URL: ', url);
     const tokenSearch = await tokenSearchApi.get(url);
     return tokenSearch.data?.data;
   } catch (e) {

--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -17,33 +17,46 @@ const tokenSearchApi = new RainbowFetchClient({
   timeout: 30000,
 });
 
-const tokenSearch = async (
-  list: TokenSearchTokenListId,
-  query: string,
-  chainId: number,
-  keys: TokenSearchUniswapAssetKey[],
-  threshold: TokenSearchThreshold
-) => {
+const tokenSearch = async (searchParams: {
+  chainId: number;
+  fromChainId?: number | '';
+  keys: TokenSearchUniswapAssetKey[];
+  list: TokenSearchTokenListId;
+  threshold: TokenSearchThreshold;
+  query: string;
+}) => {
+  const queryParams: {
+    keys: TokenSearchUniswapAssetKey[];
+    list: TokenSearchTokenListId;
+    threshold: TokenSearchThreshold;
+    query?: string;
+    fromChainId?: number;
+  } = {
+    keys: searchParams.keys,
+    list: searchParams.list,
+    threshold: searchParams.threshold,
+    query: searchParams.query,
+  };
+  if (searchParams.fromChainId) {
+    queryParams.fromChainId = searchParams.fromChainId;
+  }
+  // if (searchParams.query) {
+  //   queryParams.query = searchParams.query;
+  // }
   try {
-    const data = {
+    if (isAddress(searchParams.query) && !searchParams.fromChainId) {
       // @ts-ignore
-      keys,
-      list,
-      query,
-      threshold,
-    };
-    if (query) {
-      data.query = query;
-      if (isAddress(query)) {
-        // @ts-ignore
-        data.keys = `networks.${chainId}.address`;
-      }
+      params.keys = `networks.${params.chainId}.address`;
     }
-    const url = `/${chainId}/?${qs.stringify(data)}`;
+    const url = `/${searchParams.chainId}/?${qs.stringify(queryParams)}`;
+    logger.debug('URL: ', url);
     const tokenSearch = await tokenSearchApi.get(url);
     return tokenSearch.data?.data;
   } catch (e) {
-    logger.error(`An error occurred while searching for query: ${query}.`, e);
+    logger.error(
+      `An error occurred while searching for query: ${searchParams.query}.`,
+      e
+    );
   }
 };
 

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -30,6 +30,7 @@ import {
 import { ethereumUtils, filterList, logger } from '@/utils';
 import useSwapCurrencies from '@/hooks/useSwapCurrencies';
 import { Network } from '@/helpers';
+import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
 
 const MAINNET_CHAINID = 1;
 type swapCurrencyListType =
@@ -106,14 +107,18 @@ const useSwapCurrencyList = (
   const [verifiedAssets, setVerifiedAssets] = useState<RT[]>([]);
 
   const { inputCurrency } = useSwapCurrencies();
-  const inputChainId =
-    inputCurrency?.network &&
-    ethereumUtils.getChainIdFromNetwork(inputCurrency?.network as Network);
+  const crosschainSwapsEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
+  const inputChainId = useMemo(
+    () =>
+      inputCurrency?.network &&
+      ethereumUtils.getChainIdFromNetwork(inputCurrency?.network as Network),
+    [inputCurrency?.network]
+  );
   const isCrosschainSearch = useMemo(() => {
-    if (inputChainId && inputChainId !== chainId) {
+    if (inputChainId && inputChainId !== chainId && crosschainSwapsEnabled) {
       return true;
     }
-  }, [chainId, inputChainId]);
+  }, [chainId, inputChainId, crosschainSwapsEnabled]);
 
   const isFavorite = useCallback(
     (address: EthereumAddress) =>

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -3,7 +3,6 @@ import { ChainId, EthereumAddress } from '@rainbow-me/swaps';
 import { Contract, ethers } from 'ethers';
 import { rankings } from 'match-sorter';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { IS_TESTING } from 'react-native-dotenv';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from '../redux/store';
 import { uniswapUpdateFavorites } from '../redux/uniswap';
@@ -31,6 +30,7 @@ import { ethereumUtils, filterList, logger } from '@/utils';
 import useSwapCurrencies from '@/hooks/useSwapCurrencies';
 import { Network } from '@/helpers';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
+import { IS_TEST } from '@/env';
 
 const MAINNET_CHAINID = 1;
 type swapCurrencyListType =
@@ -434,7 +434,7 @@ const useSwapCurrencyList = (
           data: verifiedAssetsWithImport,
           key: 'verified',
           title: tokenSectionTypes.verifiedTokenSection,
-          useGradientText: IS_TESTING !== 'true',
+          useGradientText: !IS_TEST,
         });
       }
       if (highLiquidityAssetsWithImport?.length) {
@@ -467,7 +467,7 @@ const useSwapCurrencyList = (
             data: curatedAssets,
             key: 'curated',
             title: tokenSectionTypes.verifiedTokenSection,
-            useGradientText: IS_TESTING !== 'true',
+            useGradientText: !IS_TEST,
           });
         }
       }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Crosschain searches now provide a `fromChainId` query param. This filters the resulting list based on Socket's available routes.


## Screen recordings / screenshots
[This](https://recordit.co/BpFFLcY2xI) is an example of a crosschain search for 'aave'. Aave is a good test case because it has a lot of token derivates, many of which have low liquidity and are not supported by Socket. You'll notice in the video that L2 search UI contain mainnet's results for tokens outside of `verifiedAssets`. This is not related to my changes, but rather an existing issue with the feature branch we will need to address. I addressed it [here](https://github.com/rainbow-me/rainbow/pull/4221/files#r982904122).


## What to test
We should ensure that search functionality and the swap modals themselves still behave as they have in the past. Helping to verify that tokens not supported by Socket are not returned for a given chain combination will also help, however there are numerous cases to test and it would be impractical to do this exhaustively.

The filtering mechanism used is based on lists generated by [this ](https://api.socket.tech/v2/swagger/#/Token%20Lists/TokenListController_getToTokenList)endpoint.

When verifying whether a token should be included in a search, you can leverage the following request:
```
curl --location --request GET 'https://api.socket.tech/v2/token-lists/to-token-list?fromChainId=10&toChainId=1' --header 'API-KEY: 645b2c8c-5825-4930-baf3-d9b997fcd88c'
```
This curl example will return tokens supported by Socket when swapping from optimism (10) to mainnet (1).

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
