### PR TITLE
Rename surface colors, update usages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ import RNIOS11DeviceCheck from 'react-native-ios11-devicecheck';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { enableScreens } from 'react-native-screens';
 import VersionNumber from 'react-native-version-number';
-import { connect, Provider } from 'react-redux';
+import { connect, Provider as ReduxProvider } from 'react-redux';
 import { RecoilRoot } from 'recoil';
 import { runCampaignChecks } from './campaigns/campaignChecks';
 import PortalConsumer from './components/PortalConsumer';
@@ -300,7 +300,7 @@ class App extends Component {
 
   render = () => (
     <MainThemeProvider>
-      <Provider store={store}>
+      <ReduxProvider store={store}>
         <RainbowContextWrapper>
           <ErrorBoundary>
             <Portal>
@@ -337,7 +337,7 @@ class App extends Component {
             </Portal>
           </ErrorBoundary>
         </RainbowContextWrapper>
-      </Provider>
+      </ReduxProvider>
     </MainThemeProvider>
   );
 }
@@ -354,6 +354,12 @@ const codePushOptions = { checkFrequency: codePush.CheckFrequency.MANUAL };
 
 const AppWithCodePush = codePush(codePushOptions)(AppWithSentry);
 
+const PlaygroundWithReduxStore = () => (
+  <ReduxProvider store={store}>
+    <Playground />
+  </ReduxProvider>
+);
+
 AppRegistry.registerComponent('Rainbow', () =>
-  designSystemPlaygroundEnabled ? Playground : AppWithCodePush
+  designSystemPlaygroundEnabled ? PlaygroundWithReduxStore : AppWithCodePush
 );

--- a/src/design-system/color/palettes.docs.tsx
+++ b/src/design-system/color/palettes.docs.tsx
@@ -21,7 +21,7 @@ const BackgroundColors = ({ mode }: { mode: ColorMode }) => (
       {mode} mode
     </Text>
     <ColorModeProvider value={mode}>
-      <Box background="surface">
+      <Box background="surfacePrimary">
         {(Object.keys(
           backgroundColors
         ) as (keyof typeof backgroundColors)[]).map(

--- a/src/design-system/color/palettes.ts
+++ b/src/design-system/color/palettes.ts
@@ -172,12 +172,12 @@ export type ContextualColorValue<Value> = {
 };
 
 export type BackgroundColor =
-  | 'surface'
+  | 'surfacePrimary'
+  | 'surfacePrimaryElevated'
   | 'surfaceSecondary'
-  | 'surfaceTertiary'
+  | 'surfaceSecondaryElevated'
   | 'fill'
   | 'fillSecondary'
-  | 'fillTertiary'
   | 'blue'
   | 'green'
   | 'red'
@@ -200,7 +200,7 @@ export const backgroundColors: Record<
   BackgroundColor,
   BackgroundColorValue | ContextualColorValue<BackgroundColorValue>
 > = {
-  'surface': {
+  'surfacePrimary': {
     light: {
       color: globalColors.white100,
       mode: 'light',
@@ -210,7 +210,7 @@ export const backgroundColors: Record<
       mode: 'dark',
     },
   },
-  'surfaceSecondary': {
+  'surfacePrimaryElevated': {
     light: {
       color: globalColors.white100,
       mode: 'light',
@@ -220,13 +220,23 @@ export const backgroundColors: Record<
       mode: 'dark',
     },
   },
-  'surfaceTertiary': {
+  'surfaceSecondary': {
     light: {
       color: '#F0F1F5',
       mode: 'light',
     },
     dark: {
       color: globalColors.white10,
+      mode: 'dark',
+    },
+  },
+  'surfaceSecondaryElevated': {
+    light: {
+      color: globalColors.white100,
+      mode: 'light',
+    },
+    dark: {
+      color: globalColors.blueGrey100,
       mode: 'dark',
     },
   },
@@ -247,16 +257,6 @@ export const backgroundColors: Record<
     },
     dark: {
       color: globalColors.white20,
-      mode: 'dark',
-    },
-  },
-  'fillTertiary': {
-    light: {
-      color: globalColors.white100,
-      mode: 'light',
-    },
-    dark: {
-      color: globalColors.blueGrey100,
       mode: 'dark',
     },
   },
@@ -398,7 +398,6 @@ export type ForegroundColor =
   | 'yellow'
   | 'fill'
   | 'fillSecondary'
-  | 'fillTertiary'
   | 'scrim'
   | 'scrimSecondary'
   | 'scrimTertiary'
@@ -474,7 +473,6 @@ export const foregroundColors: Record<
   'yellow': selectBackgroundAsForeground('yellow'),
   'fill': selectBackgroundAsForeground('fill'),
   'fillSecondary': selectBackgroundAsForeground('fillSecondary'),
-  'fillTertiary': selectBackgroundAsForeground('fillTertiary'),
   'scrim': {
     light: 'rgba(0, 0, 0, 0.2)',
     dark: 'rgba(0, 0, 0, 0.4)',

--- a/src/design-system/components/Box/Box.docs.tsx
+++ b/src/design-system/components/Box/Box.docs.tsx
@@ -37,7 +37,7 @@ const docs: DocsType = {
           </Docs.Text>
           <Docs.Text>
             Below, you can see that the text color of{' '}
-            <Docs.Code>surface</Docs.Code> is dark, however, for{' '}
+            <Docs.Code>surfacePrimary</Docs.Code> is dark, however, for{' '}
             <Docs.Code>accent</Docs.Code> it is light.
           </Docs.Text>
         </>

--- a/src/design-system/components/Box/Box.examples.tsx
+++ b/src/design-system/components/Box/Box.examples.tsx
@@ -14,9 +14,14 @@ export const background: Example = {
   Example: () =>
     source(
       <>
-        <Box background="surface" padding="20px">
+        <Box background="surfacePrimary" padding="20px">
           <Text color="label" size="17pt" weight="bold">
-            surface
+            surfacePrimary
+          </Text>
+        </Box>
+        <Box background="surfacePrimaryElevated" padding="20px">
+          <Text color="label" size="17pt" weight="bold">
+            surfacePrimaryElevated
           </Text>
         </Box>
         <Box background="surfaceSecondary" padding="20px">
@@ -24,9 +29,9 @@ export const background: Example = {
             surfaceSecondary
           </Text>
         </Box>
-        <Box background="surfaceTertiary" padding="20px">
+        <Box background="surfaceSecondaryElevated" padding="20px">
           <Text color="label" size="17pt" weight="bold">
-            surfaceTertiary
+            surfaceSecondaryElevated
           </Text>
         </Box>
         <Box background="fill" padding="20px">
@@ -37,11 +42,6 @@ export const background: Example = {
         <Box background="fillSecondary" padding="20px">
           <Text color="label" size="17pt" weight="bold">
             fillSecondary
-          </Text>
-        </Box>
-        <Box background="fillTertiary" padding="20px">
-          <Text color="label" size="17pt" weight="bold">
-            fillTertiary
           </Text>
         </Box>
         <Box background="accent" padding="20px">
@@ -108,25 +108,25 @@ export const padding: Example = {
   Example: () =>
     source(
       <Stack space="12px">
-        <Box background="surface" padding="20px">
+        <Box background="surfacePrimary" padding="20px">
           <Placeholder />
         </Box>
-        <Box background="surface" paddingHorizontal="20px">
+        <Box background="surfacePrimary" paddingHorizontal="20px">
           <Placeholder />
         </Box>
-        <Box background="surface" paddingVertical="20px">
+        <Box background="surfacePrimary" paddingVertical="20px">
           <Placeholder />
         </Box>
-        <Box background="surface" paddingLeft="20px">
+        <Box background="surfacePrimary" paddingLeft="20px">
           <Placeholder />
         </Box>
-        <Box background="surface" paddingRight="20px">
+        <Box background="surfacePrimary" paddingRight="20px">
           <Placeholder />
         </Box>
-        <Box background="surface" paddingTop="20px">
+        <Box background="surfacePrimary" paddingTop="20px">
           <Placeholder />
         </Box>
-        <Box background="surface" paddingBottom="20px">
+        <Box background="surfacePrimary" paddingBottom="20px">
           <Placeholder />
         </Box>
       </Stack>
@@ -138,31 +138,31 @@ export const margin: Example = {
   Example: () =>
     source(
       <Stack space="12px">
-        <Box background="surface" margin="-20px">
+        <Box background="surfacePrimary" margin="-20px">
           <Placeholder />
         </Box>
         <Inset vertical="20px">
-          <Box background="surface" marginHorizontal="-20px">
+          <Box background="surfacePrimary" marginHorizontal="-20px">
             <Placeholder />
           </Box>
         </Inset>
-        <Box background="surface" marginVertical="-20px">
+        <Box background="surfacePrimary" marginVertical="-20px">
           <Placeholder />
         </Box>
         <Inset vertical="20px">
-          <Box background="surface" marginLeft="-20px">
+          <Box background="surfacePrimary" marginLeft="-20px">
             <Placeholder />
           </Box>
         </Inset>
-        <Box background="surface" marginRight="-20px">
+        <Box background="surfacePrimary" marginRight="-20px">
           <Placeholder />
         </Box>
         <Inset vertical="20px">
-          <Box background="surface" marginTop="-20px">
+          <Box background="surfacePrimary" marginTop="-20px">
             <Placeholder />
           </Box>
         </Inset>
-        <Box background="surface" marginBottom="-20px">
+        <Box background="surfacePrimary" marginBottom="-20px">
           <Placeholder />
         </Box>
       </Stack>
@@ -217,7 +217,9 @@ export const heights: Example = {
 export const shadows: Example = {
   name: 'Shadows',
   Example: () =>
-    source(<Box background="surface" padding="24px" shadow="30px light" />),
+    source(
+      <Box background="surfacePrimary" padding="24px" shadow="30px light" />
+    ),
 };
 
 export const shadowsWithSizes: Example = {
@@ -229,31 +231,55 @@ export const shadowsWithSizes: Example = {
         <Columns space="32px">
           <Column width="1/3" />
           <Column width="1/3">
-            <Box background="surface" padding="16px" shadow="9px medium" />
+            <Box
+              background="surfacePrimary"
+              padding="16px"
+              shadow="9px medium"
+            />
           </Column>
         </Columns>
         <Columns space="32px">
           <Column width="1/3" />
           <Column width="1/3">
-            <Box background="surface" padding="16px" shadow="12px medium" />
+            <Box
+              background="surfacePrimary"
+              padding="16px"
+              shadow="12px medium"
+            />
           </Column>
           <Column width="1/3">
-            <Box background="surface" padding="16px" shadow="12px heavy" />
+            <Box
+              background="surfacePrimary"
+              padding="16px"
+              shadow="12px heavy"
+            />
           </Column>
         </Columns>
         <Columns space="32px">
           <Column width="1/3">
-            <Box background="surface" padding="16px" shadow="21px light" />
+            <Box
+              background="surfacePrimary"
+              padding="16px"
+              shadow="21px light"
+            />
           </Column>
           <Column width="1/3" />
           <Column width="1/3">
-            <Box background="surface" padding="16px" shadow="21px heavy" />
+            <Box
+              background="surfacePrimary"
+              padding="16px"
+              shadow="21px heavy"
+            />
           </Column>
         </Columns>
         <Columns space="32px">
-          <Box background="surface" padding="16px" shadow="30px light" />
-          <Box background="surface" padding="16px" shadow="30px medium" />
-          <Box background="surface" padding="16px" shadow="30px heavy" />
+          <Box background="surfacePrimary" padding="16px" shadow="30px light" />
+          <Box
+            background="surfacePrimary"
+            padding="16px"
+            shadow="30px medium"
+          />
+          <Box background="surfacePrimary" padding="16px" shadow="30px heavy" />
         </Columns>
       </Stack>
     ),
@@ -265,14 +291,18 @@ export const shadowsWithColors: Example = {
   Example: () =>
     source(
       <Columns space="32px">
-        <Box background="surface" padding="16px" shadow="12px medium accent" />
         <Box
-          background="surface"
+          background="surfacePrimary"
+          padding="16px"
+          shadow="12px medium accent"
+        />
+        <Box
+          background="surfacePrimary"
           padding="16px"
           shadow="21px heavy swap (Deprecated)"
         />
         <Box
-          background="surface"
+          background="surfacePrimary"
           padding="16px"
           shadow="30px heavy action (Deprecated)"
         />
@@ -287,7 +317,7 @@ export const shadowsWithCustom: Example = {
     source(
       <Columns space="32px">
         <Box
-          background="surface"
+          background="surfacePrimary"
           padding="16px"
           shadow={{
             custom: {
@@ -311,7 +341,7 @@ export const shadowsWithCustom: Example = {
           }}
         />
         <Box
-          background="surface"
+          background="surfacePrimary"
           padding="16px"
           shadow={{
             custom: {

--- a/src/design-system/components/Separator/Separator.examples.tsx
+++ b/src/design-system/components/Separator/Separator.examples.tsx
@@ -10,7 +10,7 @@ export const basicUsage: Example = {
   name: 'Basic usage',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Separator color="separator" />
       </Box>
     ),
@@ -20,7 +20,7 @@ export const secondary: Example = {
   name: 'Secondary',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Separator color="separatorSecondary" />
       </Box>
     ),
@@ -30,7 +30,7 @@ export const divider80: Example = {
   name: 'Color: divider80 (Deprecated)',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Separator color="divider80 (Deprecated)" />
       </Box>
     ),
@@ -40,7 +40,7 @@ export const divider60: Example = {
   name: 'Color: divider60 (Deprecated)',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Separator color="divider60 (Deprecated)" />
       </Box>
     ),
@@ -50,7 +50,7 @@ export const divider40: Example = {
   name: 'Color: divider40 (Deprecated)',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Separator color="divider40 (Deprecated)" />
       </Box>
     ),
@@ -60,7 +60,7 @@ export const divider20: Example = {
   name: 'Color: divider20 (Deprecated)',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Separator color="divider20 (Deprecated)" />
       </Box>
     ),
@@ -70,7 +70,7 @@ export const vertical: Example = {
   name: 'Vertical',
   Example: () =>
     source(
-      <Box background="surface" borderRadius={8} padding="20px">
+      <Box background="surfacePrimary" borderRadius={8} padding="20px">
         <Inline space="20px" wrap={false}>
           <Placeholder width={20} />
           <Separator color="separator" direction="vertical" />

--- a/src/design-system/components/Text/Text.examples.tsx
+++ b/src/design-system/components/Text/Text.examples.tsx
@@ -152,7 +152,8 @@ export const withColor: Example = {
         <View>
           <View
             style={{
-              backgroundColor: palettes.dark.backgroundColors['surface'].color,
+              backgroundColor:
+                palettes.dark.backgroundColors['surfacePrimary'].color,
               padding: 24,
             }}
           >

--- a/src/design-system/docs/.playroom/FrameComponent.js
+++ b/src/design-system/docs/.playroom/FrameComponent.js
@@ -8,7 +8,7 @@ import { Box } from '../../components/Box/Box';
 export default ({ children, themeName }) => (
   <DesignSystemProvider colorMode={themeName}>
     <div id="root">
-      <Box background="surface">{children}</Box>
+      <Box background="surfacePrimary">{children}</Box>
     </div>
   </DesignSystemProvider>
 );

--- a/src/design-system/playground/BackgroundDemo.tsx
+++ b/src/design-system/playground/BackgroundDemo.tsx
@@ -9,7 +9,7 @@ export function BackgroundDemo() {
   const { backgroundColors } = useColorMode();
 
   return (
-    <Box background="surface">
+    <Box background="surfacePrimary">
       {(Object.keys(backgroundColors) as (keyof typeof backgroundColors)[]).map(
         color => (
           <Box background={color} key={color}>

--- a/src/screens/PairHardwareWalletIntroSheet.tsx
+++ b/src/screens/PairHardwareWalletIntroSheet.tsx
@@ -18,7 +18,7 @@ export function PairHardwareWalletIntroSheet() {
   }, [navigate]);
 
   return (
-    <Box background="surfaceTertiary" height="full">
+    <Box background="surfaceSecondary" height="full">
       <Layout
         header={
           <Inset horizontal="44px">

--- a/src/screens/PairHardwareWalletSearchSheet.tsx
+++ b/src/screens/PairHardwareWalletSearchSheet.tsx
@@ -12,7 +12,7 @@ export function PairHardwareWalletSearchSheet() {
   const { dangerouslyGetParent } = useNavigation();
 
   return (
-    <Box background="surfaceTertiary" height="full">
+    <Box background="surfaceSecondary" height="full">
       <Layout
         header={
           <Inset horizontal="44px">


### PR DESCRIPTION
Fixes TEAM1-138

## What changed (plus any additional context for devs)
Surfaces have been re-categorized into two tiers, each with a base color and an elevated color. This also means that the set of "fill" colors has been reduced from 3 to 2 since `fillTertiary` was really intended to be used as another surface color.

## What to test

The colors being modified have only recently been added and have only used on the Ledger Nano X connection sheet which is currently behind a feature flag.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
