### PR TITLE
lean restrictions on branch name for Android e2e runner on CI

### DIFF
--- a/.github/workflows/macstadium-android-e2e.yml
+++ b/.github/workflows/macstadium-android-e2e.yml
@@ -9,7 +9,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   # This workflow contains a single job called "android-e2e"
   android-e2e:
-    if: github.head_ref == '@tchayen/android-detox'
+    if: startsWith(github.head_ref, 'android-ci')
     # The type of runner that the job will run on
     runs-on: ["self-hosted", "ci-5"]
     # Cancel current builds if there's a newer commit on the same branch


### PR DESCRIPTION
This is just allowing running android CI from more branches and this will unblock our work on  android e2e