### PR TITLE
fix: run Jest tests in CI

### DIFF
--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lint
         run: yarn lint:ci
 
-      - name: Jest
+      - name: Unit tests
         run: yarn test
 
       - name: Install Pods

--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -41,19 +41,22 @@ jobs:
 
       - name: Check for frozen lockfile
         run: yarn check-lockfile
-        
+
       - name: Audit CI
         run:  yarn audit-ci --moderate --config audit-ci.json
 
       - name: Lint
         run: yarn lint:ci
-        
+
+      - name: Jest
+        run: yarn test
+
       - name: Install Pods
         run: cd ios && pod install && cd ..
 
       - name: Build the app in Release mode
         run: ./node_modules/.bin/detox build --configuration ios.sim.release
-      
+
       - name: Run iOS e2e tests
         run: ./node_modules/.bin/detox test -R 5 --configuration ios.sim.release --forceExit
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Runs `yarn test` in CI.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
