### PR TITLE
Add address to ENS marquee

### DIFF
--- a/src/references/ens-intro-marquee-names.json
+++ b/src/references/ens-intro-marquee-names.json
@@ -16,5 +16,6 @@
   "notben.eth",
   "sarahguo.eth",
   "osdnk.eth",
-  "skillet.eth"
+  "skillet.eth",
+  "worm.eth"
 ]


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- adds popular ens name (and contributor to Rainbow github repo) to ENS marquee
