### PR TITLE
fix: extract App.js providers, fix redux usage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ import RNIOS11DeviceCheck from 'react-native-ios11-devicecheck';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { enableScreens } from 'react-native-screens';
 import VersionNumber from 'react-native-version-number';
-import { connect, Provider as ReduxProvider } from 'react-redux';
+import { connect, Provider as ReduxProvider, useSelector } from 'react-redux';
 import { RecoilRoot } from 'recoil';
 import { runCampaignChecks } from './campaigns/campaignChecks';
 import PortalConsumer from './components/PortalConsumer';
@@ -144,7 +144,7 @@ enableScreens();
 
 const containerStyle = { flex: 1 };
 
-class App extends Component {
+class OldApp extends Component {
   state = { appState: AppState.currentState, initialRoute: null };
 
   async componentDidMount() {
@@ -319,9 +319,13 @@ class App extends Component {
   );
 }
 
-const AppWithRedux = connect(state => ({
+const OldAppWithRedux = connect(state => ({
   walletReady: state.appState.walletReady,
-}))(App);
+}))(OldApp);
+
+function App() {
+  return <OldAppWithRedux />;
+}
 
 function Root() {
   return (
@@ -336,7 +340,7 @@ function Root() {
               <RainbowContextWrapper>
                 <SharedValuesProvider>
                   <ErrorBoundary>
-                    <AppWithRedux />
+                    <App />
                   </ErrorBoundary>
                 </SharedValuesProvider>
               </RainbowContextWrapper>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I'm doing some research into our app initialization **so that we can unlock some soon-to-happen state updates,** like bootstrapping initial application state.

This is a first of a few PRs. All it does is extract the context providers into a new component, and re-wrap with instrumentation. The order of components in this tree should be loosely:

1. State, like Redux, Recoil, Jotai, and React Query
2. Library context, like `SafeAreaProvider` or something that _might_ depend on application state
3. Internal context, like `MainThemeProvider` — again may depend on state, and needs to wrap `ErrorBoundary` and other UI
4. `ErrorBoundary` — handles UI errors, needs to be further down the tree in order to reference context
5. UI components

**A few reasons for this PR:**

First, we need to be able to init some things immediately before we render, like Sentry, Segment, feature flags, initial application state from local storage, etc. A new high-level component gives us a clean slate to do this. The plan would be to replace the functionality of the `App` component either in new components/utils, or in `Root`. **Think of `Root` as what loads context and provides it to the app, and `App` as our UI that renders as a result of `Root`.**

Second, the incorrect Redux usage here was a good example of how we should really set up context first, then render data. This clarifies the relationship.

Third, we're probably going to run into testing issues where we need to wrap tests in some or all providers. Modularizing this file may help with that. TBD!

**Future Plans:**
- load base state needed for app e.g. current wallet address
- extract `handleTransactionConfirmed` into either a component or a separate util
- extract `rainbowTokenList` also
- refactor CodePush metadata loading, load up front and use to initialize telemetry

## What to test
Just make sure it works. There shouldn't be any race conditions with these providers since they just handle context.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
