### PR TITLE
Fix settings header

### DIFF
--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -468,7 +468,7 @@ export const settingsOptions = colors => ({
   headerBackTitle: ' ',
   headerStatusBarHeight: 0,
   headerStyle: {
-    backgroundColor: 'transparent',
+    backgroundColor: colors.cardBackdrop,
     elevation: 0,
     height: 60,
     shadowColor: 'transparent',

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -468,7 +468,7 @@ export const settingsOptions = colors => ({
   headerBackTitle: ' ',
   headerStatusBarHeight: 0,
   headerStyle: {
-    backgroundColor: colors.cardBackdrop,
+    backgroundColor: ios ? colors.cardBackdrop : 'transparent',
     elevation: 0,
     height: 60,
     shadowColor: 'transparent',

--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -216,11 +216,6 @@ export default function SettingsSheet() {
           options={{
             cardStyleInterpolator,
             title: lang.t('settings.label'),
-            headerStyle: {
-              ...memoSettingsOptions.headerStyle,
-              // ios MenuContainer scroll fix
-              ...(ios && { backgroundColor: colors.cardBackdrop }),
-            },
           }}
         >
           {() => (
@@ -247,11 +242,6 @@ export default function SettingsSheet() {
                 options={{
                   cardStyleInterpolator,
                   title: getTitle(),
-                  headerStyle: {
-                    ...memoSettingsOptions.headerStyle,
-                    // ios MenuContainer scroll fix
-                    ...(ios && { backgroundColor: colors.cardBackdrop }),
-                  },
                 }}
                 // @ts-ignore
                 title={getTitle()}
@@ -280,6 +270,12 @@ export default function SettingsSheet() {
           options={({ route }: any) => ({
             cardStyleInterpolator,
             title: route.params?.title || lang.t('settings.backup'),
+            headerStyle: {
+              ...memoSettingsOptions.headerStyle,
+              // only do this if sheet needs a header subtitle AND is not scrollable
+              // if it's scrollable we need a better fix
+              ...(ios && { backgroundColor: 'transparent' }),
+            },
           })}
         />
         <Stack.Screen

--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -117,7 +117,7 @@ const Stack = createStackNavigator();
 
 export default function SettingsSheet() {
   const { goBack, navigate } = useNavigation();
-  const { wallets, selectedWallet } = useWallets();
+  const { wallets } = useWallets();
   const { params } = useRoute<any>();
   const { colors } = useTheme();
 
@@ -216,6 +216,11 @@ export default function SettingsSheet() {
           options={{
             cardStyleInterpolator,
             title: lang.t('settings.label'),
+            headerStyle: {
+              ...memoSettingsOptions.headerStyle,
+              // ios MenuContainer scroll fix
+              ...(ios && { backgroundColor: colors.cardBackdrop }),
+            },
           }}
         >
           {() => (

--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -274,7 +274,7 @@ export default function SettingsSheet() {
               ...memoSettingsOptions.headerStyle,
               // only do this if sheet needs a header subtitle AND is not scrollable
               // if it's scrollable we need a better fix
-              ...(ios && { backgroundColor: 'transparent' }),
+              ...{ backgroundColor: 'transparent' },
             },
           })}
         />

--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -274,7 +274,7 @@ export default function SettingsSheet() {
               ...memoSettingsOptions.headerStyle,
               // only do this if sheet needs a header subtitle AND is not scrollable
               // if it's scrollable we need a better fix
-              ...{ backgroundColor: 'transparent' },
+              ...(ios && { backgroundColor: 'transparent' }),
             },
           })}
         />


### PR DESCRIPTION
Fixes RNBW-4541
Figma link (if any):

## What changed (plus any additional context for devs)
The main settings screen had a transparent header on ios, which caused text overlays while scrolling. I added a bg color to the header so this doesn't happen anymore.

## Screen recordings / screenshots
Before:
https://user-images.githubusercontent.com/15272675/192586933-1ea6ed9d-4042-446a-ab29-46e115d76b08.mp4

After: 
https://user-images.githubusercontent.com/15272675/192587083-4d20adb1-ce81-434f-8ca1-13418ea2c834.mp4



## What to test
- scrolling looks normal on main settings screen


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
