### PR TITLE
feat: enhance useAppState

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,14 +6,14 @@ module.exports = {
   preset: 'react-native',
   setupFiles: ['./config/test/jest-setup.js'],
   testPathIgnorePatterns: ['node_modules', 'e2e'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
   transform: {
-    // https://kulshekhar.github.io/ts-jest/docs/guides/react-native
-    '\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: 'tsconfig.jest.json',
-      },
-    ],
+    // https://kulshekhar.github.io/ts-jest/docs/28.0/guides/react-native
+    '\\.tsx?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   setupFiles: ['./config/test/jest-setup.js'],
   testPathIgnorePatterns: ['node_modules', 'e2e'],
   transform: {
-    '\\.tsx?$': 'ts-jest',
+    // https://kulshekhar.github.io/ts-jest/docs/guides/react-native
+    '\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.jest.json',
+      },
+    ],
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/package.json
+++ b/package.json
@@ -300,6 +300,7 @@
     "@lavamoat/allow-scripts": "2.0.3",
     "@nomiclabs/hardhat-ethers": "2.0.4",
     "@nomiclabs/hardhat-waffle": "2.0.1",
+    "@testing-library/react-native": "11.2.0",
     "@types/chroma-js": "2.1.3",
     "@types/d3-scale": "4.0.2",
     "@types/d3-shape": "3.0.2",

--- a/src/hooks/__tests__/useAppState.test.tsx
+++ b/src/hooks/__tests__/useAppState.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { AppState, AppStateStatus } from 'react-native';
+
+import useAppState from '@/hooks/useAppState';
+
+type AppStateEventHandler = (state: AppStateStatus) => void;
+
+/**
+ * Class mock is defined inline so that it is also hoisted to top of this scope
+ * by Jest
+ */
+jest.mock('react-native', () => ({
+  AppState: new (class MockAppState {
+    events: AppStateEventHandler[] = [];
+    currentState: AppStateStatus = 'unknown';
+
+    addEventListener(_: string, cb: AppStateEventHandler) {
+      this.events.push(cb);
+      return {
+        remove: () => {
+          this.events.splice(this.events.indexOf(cb), 1);
+        },
+      };
+    }
+
+    setCurrentState(state: AppStateStatus) {
+      this.currentState = state;
+      this.events.forEach(cb => cb(this.currentState));
+    }
+  })(),
+}));
+
+/**
+ * Just fixes type errors for us in this file
+ */
+const ProxyAppState = AppState as typeof AppState & {
+  setCurrentState(state: AppStateStatus): void;
+};
+
+/**
+ * Be sure to reset to the initial app state value
+ */
+beforeEach(() => {
+  ProxyAppState.setCurrentState('unknown');
+});
+
+test('returns correct values', () => {
+  const spy = jest.spyOn(ProxyAppState, 'addEventListener');
+  const reporter = jest.fn();
+
+  function Comp() {
+    const { appState, justBecameActive } = useAppState();
+    reporter({ appState, justBecameActive });
+    return null;
+  }
+
+  const app = render(<Comp />);
+
+  expect(spy).toHaveBeenCalled();
+  expect(reporter).toHaveBeenCalledWith({
+    appState: 'unknown',
+    justBecameActive: false,
+  });
+
+  act(() => {
+    ProxyAppState.setCurrentState('active');
+  });
+
+  app.rerender(<Comp />);
+
+  expect(reporter).toHaveBeenCalledWith({
+    appState: 'active',
+    justBecameActive: true,
+  });
+});
+
+test('runs callbacks', () => {
+  const onChange = jest.fn();
+  const onActive = jest.fn();
+  const onBackground = jest.fn();
+
+  function Comp() {
+    useAppState({
+      onChange,
+      onActive,
+      onBackground,
+    });
+    return null;
+  }
+
+  render(<Comp />);
+
+  act(() => {
+    ProxyAppState.setCurrentState('active');
+  });
+
+  expect(onChange).toHaveBeenCalledWith('active');
+  expect(onActive).toHaveBeenCalled();
+
+  act(() => {
+    ProxyAppState.setCurrentState('background');
+  });
+
+  expect(onChange).toHaveBeenCalledWith('background');
+  expect(onBackground).toHaveBeenCalled();
+});
+
+test('does not run callbacks more than needed', () => {
+  const onChange = jest.fn();
+  const onActive = jest.fn();
+  const onBackground = jest.fn();
+
+  function Comp() {
+    useAppState({
+      onChange,
+      onActive,
+      onBackground,
+    });
+    return null;
+  }
+
+  render(<Comp />);
+
+  act(() => {
+    ProxyAppState.setCurrentState('active');
+  });
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onActive).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    ProxyAppState.setCurrentState('active');
+  });
+
+  // still just one call
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onActive).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    ProxyAppState.setCurrentState('background');
+  });
+
+  // 2 calls now
+  expect(onChange).toHaveBeenCalledTimes(2);
+  expect(onBackground).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    ProxyAppState.setCurrentState('background');
+  });
+
+  // still 2 calls
+  expect(onChange).toHaveBeenCalledTimes(2);
+  // still just one call
+  expect(onBackground).toHaveBeenCalledTimes(1);
+});

--- a/src/hooks/__tests__/useAppState.test.tsx
+++ b/src/hooks/__tests__/useAppState.test.tsx
@@ -35,6 +35,10 @@ jest.mock('react-native', () => ({
  * Just fixes type errors for us in this file
  */
 const ProxyAppState = AppState as typeof AppState & {
+  /**
+   * This method is NOT natively part of `AppState`, but we add it here as a
+   * backdoor for testing purposes.
+   */
   setCurrentState(state: AppStateStatus): void;
 };
 
@@ -63,6 +67,7 @@ test('returns correct values', () => {
     justBecameActive: false,
   });
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('active');
   });
@@ -91,6 +96,7 @@ test('runs callbacks', () => {
 
   render(<Comp />);
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('active');
   });
@@ -98,6 +104,7 @@ test('runs callbacks', () => {
   expect(onChange).toHaveBeenCalledWith('active');
   expect(onActive).toHaveBeenCalled();
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('background');
   });
@@ -122,6 +129,7 @@ test('does not run callbacks more than needed', () => {
 
   render(<Comp />);
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('active');
   });
@@ -129,6 +137,7 @@ test('does not run callbacks more than needed', () => {
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onActive).toHaveBeenCalledTimes(1);
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('active');
   });
@@ -137,6 +146,7 @@ test('does not run callbacks more than needed', () => {
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onActive).toHaveBeenCalledTimes(1);
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('background');
   });
@@ -145,6 +155,7 @@ test('does not run callbacks more than needed', () => {
   expect(onChange).toHaveBeenCalledTimes(2);
   expect(onBackground).toHaveBeenCalledTimes(1);
 
+  // always call act() when doing something that will change React state
   act(() => {
     ProxyAppState.setCurrentState('background');
   });

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,6 +3647,13 @@
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
+"@jest/schemas@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
+  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/source-map@^28.1.2":
   version "28.1.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.1.2.tgz#7fe832b172b497d6663cdff6c13b0a920e139e24"
@@ -4968,6 +4975,13 @@
     "@tanstack/query-core" "^4.0.0-beta.1"
     "@types/use-sync-external-store" "^0.0.3"
     use-sync-external-store "^1.2.0"
+
+"@testing-library/react-native@11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-11.2.0.tgz#5408a745d71f87509763d73914c38db383094bdd"
+  integrity sha512-j3t78/htRkjPJjLlEjh9VxIAvcCJ85CG2L8mKH1mz9F3gyH65MH/JScOY2RHGOkTHGAGh5c+53Dw4u7J1WEJSA==
+  dependencies:
+    pretty-format "^29.0.3"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -15731,6 +15745,15 @@ pretty-format@^28.1.3:
   dependencies:
     "@jest/schemas" "^28.1.3"
     ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^29.0.3:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.1.2.tgz#b1f6b75be7d699be1a051f5da36e8ae9e76a8e6a"
+  integrity sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 


### PR DESCRIPTION
Contributes to RNBW-4513

### What changed?

This PR adds some optional params to `useAppState`: `onChange`, `onActive`, and `onBackground`. We're doing this type of thing in a few places, and I think this reduces the boilerplate. This PR **does not change the return of this hook,** meaning it's backwards compatible with our current usage.

I implemented this within `App.js` as an example of how this should work. This same pattern should work for `useBiometryType`, `useClipboard`, and others. Example below.

I also added some tests, which can serve as one small example of how to mock and set up tests for React.

### Alternatives considered

I was considering putting `AppState` into Jotai state (next Foundations project), but decided it would be redundant. What we have here is the same same, and we don't ever want to update `AppState` ourselves, which Jotai would technically enable, unless we wrote some "read only atom" adapter. But yeah, I think this hook is fine as is.

### Usage example

```typescript
import useAppState from '@/hooks/useAppState'

const { appState, justBecameActive } = useAppState({
  onChange(state) {
    analytics.track('State change', {
      category: 'app state',
      label: state,
    });
  },
  onActive() {
    store.dispatch(walletConnectLoadState());
    InteractionManager.runAfterInteractions(() => {
      rainbowTokenList.update();
    });
  },
});
```