### PR TITLE
Add Flashbots Protect row to swaps details

### DIFF
--- a/src/components/Pill.js
+++ b/src/components/Pill.js
@@ -4,6 +4,7 @@ import { useTheme } from '../theme/ThemeContext';
 import { TruncatedText } from './text';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
+import { Box, Text } from '@/design-system';
 
 const Gradient = styled(RadialGradient).attrs(
   ({ theme: { colors }, borderRadius = 10.5 }) => ({
@@ -20,7 +21,7 @@ export default function Pill({ children, textColor, ...props }) {
   const { colors } = useTheme();
 
   return (
-    <Gradient {...props}>
+    <Gradient {...props} justifyContent="center" alignItems="center">
       <TruncatedText
         align="center"
         color={textColor || colors.alpha(colors.blueGreyDark, 0.5)}

--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -10,6 +10,7 @@ import SwapDetailsRow, { SwapDetailsValue } from './SwapDetailsRow';
 import { AccentColorProvider, Box, Rows, Separator } from '@/design-system';
 import { isNativeAsset } from '@/handlers/assets';
 import {
+  useAccountSettings,
   useColorForAsset,
   useSwapAdjustedAmounts,
   useSwapCurrencies,
@@ -35,6 +36,7 @@ export default function SwapDetailsContent({
   const { amountReceivedSold, receivedSoldLabel } = useSwapAdjustedAmounts(
     tradeDetails
   );
+  const { flashbotsEnabled } = useAccountSettings();
   const inputAsExact = useSelector(
     state => state.swap.independentField !== SwapModalField.output
   );
@@ -74,6 +76,17 @@ export default function SwapDetailsContent({
               testID="swaps-details-fee-row"
               tradeDetails={tradeDetails}
             />
+          )}
+          {flashbotsEnabled && (
+            <SwapDetailsRow
+              labelPress={() => {}}
+              label={`${lang.t('expanded_state.swap.flashbots_protect')} 􀅵`}
+              testID="swaps-details-flashbots-row"
+            >
+              <SwapDetailsValue letterSpacing="roundedTight">
+                {`${lang.t('expanded_state.swap.on')} 􀞜`}
+              </SwapDetailsValue>
+            </SwapDetailsRow>
           )}
           {!detailsExpanded && (
             <Box

--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -9,6 +9,7 @@ import SwapDetailsPriceRow from './SwapDetailsPriceRow';
 import SwapDetailsRow, { SwapDetailsValue } from './SwapDetailsRow';
 import { AccentColorProvider, Box, Rows, Separator } from '@/design-system';
 import { isNativeAsset } from '@/handlers/assets';
+import Routes from '@/navigation/routesNames';
 import {
   useAccountSettings,
   useColorForAsset,
@@ -19,6 +20,7 @@ import { SwapModalField } from '@/redux/swap';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import { ethereumUtils } from '@/utils';
+import { useNavigation } from '@/navigation';
 
 const Container = styled(Box).attrs({
   flex: 1,
@@ -36,6 +38,7 @@ export default function SwapDetailsContent({
   const { amountReceivedSold, receivedSoldLabel } = useSwapAdjustedAmounts(
     tradeDetails
   );
+  const { navigate } = useNavigation();
   const { flashbotsEnabled } = useAccountSettings();
   const inputAsExact = useSelector(
     state => state.swap.independentField !== SwapModalField.output
@@ -79,7 +82,11 @@ export default function SwapDetailsContent({
           )}
           {flashbotsEnabled && (
             <SwapDetailsRow
-              labelPress={() => {}}
+              labelPress={() =>
+                navigate(Routes.EXPLAIN_SHEET, {
+                  type: 'flashbots',
+                })
+              }
               label={`${lang.t('expanded_state.swap.flashbots_protect')} 􀅵`}
               testID="swaps-details-flashbots-row"
             >

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -12,7 +12,6 @@ import {
   Columns,
   Cover,
   Inline,
-  Rows,
   Stack,
   Text,
   useForegroundColor,
@@ -166,12 +165,7 @@ export default function SwapDetailsExchangeRow({ protocols, testID }) {
 
   if (protocols?.length > 1) {
     return (
-      <Box
-        style={{
-          // enlarge tap target
-          marginVertical: -10,
-        }}
-      >
+      <Bleed vertical="8px">
         <ButtonPressAnimation
           onPress={nextStep}
           scaleTo={1.06}
@@ -180,77 +174,71 @@ export default function SwapDetailsExchangeRow({ protocols, testID }) {
             paddingVertical: 8,
           }}
         >
-          <Box>
-            <Rows>
-              <Columns
-                alignHorizontal="right"
-                alignVertical="center"
-                space="4px"
+          <Columns alignHorizontal="right" alignVertical="center" space="4px">
+            <Column>
+              <SwapDetailsLabel>
+                {lang.t('expanded_state.swap.swapping_via')}
+              </SwapDetailsLabel>
+            </Column>
+            <Column width="content">
+              <Box
+                style={{
+                  top: android ? -1.5 : 0,
+                }}
               >
-                <Column>
-                  <SwapDetailsLabel>
-                    {lang.t('expanded_state.swap.swapping_via')}
-                  </SwapDetailsLabel>
-                </Column>
-                <Column width="content">
-                  <Box
+                <Bleed vertical="10px">
+                  <ExchangeIconStack protocols={steps[step]} />
+                </Bleed>
+              </Box>
+            </Column>
+            <Column width="content">
+              <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
+            </Column>
+            {steps?.[step]?.part && (
+              <Column width="content">
+                <Bleed right="5px (Deprecated)" vertical="6px">
+                  <Pill
+                    height={20}
                     style={{
-                      top: android ? -1.5 : 0,
+                      lineHeight: android && 18,
+                      top: android ? -1 : 0,
                     }}
+                    textColor={defaultColor}
                   >
-                    <ExchangeIconStack protocols={steps[step]} />
-                  </Box>
-                </Column>
-                <Column width="content">
-                  <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
-                </Column>
-                {steps?.[step]?.part && (
-                  <Column width="content">
-                    <Bleed right="5px (Deprecated)" vertical="6px">
-                      <Pill
-                        height={20}
-                        style={{
-                          lineHeight: android && 18,
-                          top: android ? -1 : 0,
-                        }}
-                        textColor={defaultColor}
-                      >
-                        {steps[step].part}
-                      </Pill>
-                    </Bleed>
-                  </Column>
-                )}
-              </Columns>
-            </Rows>
-          </Box>
+                    {steps[step].part}
+                  </Pill>
+                </Bleed>
+              </Column>
+            )}
+          </Columns>
         </ButtonPressAnimation>
-      </Box>
+      </Bleed>
     );
   } else if (protocols?.length > 0) {
     return (
-      <Rows testID={testID}>
-        <Columns alignVertical="center" space="4px">
-          <Column>
-            <SwapDetailsLabel>
-              {lang.t('expanded_state.swap.swapping_via')}
-            </SwapDetailsLabel>
-          </Column>
-          <Column width="content">
+      <Columns alignVertical="center" space="4px" testID={testID}>
+        <Column>
+          <SwapDetailsLabel>
+            {lang.t('expanded_state.swap.swapping_via')}
+          </SwapDetailsLabel>
+        </Column>
+        <Column width="content">
+          <Bleed vertical="10px">
             <ExchangeIcon
               icon={getExchangeIconUrl(parseExchangeName(protocols[0].name))}
               protocol={parseExchangeName(protocols[0].name)}
             />
-          </Column>
-          <Column width="content">
-            <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
-          </Column>
-          <Column width="content">
-            <Bleed right="6px" vertical="6px">
-              <Pill textColor={defaultColor}>{`${protocols[0].part}%`}</Pill>
-            </Bleed>
-          </Column>
-        </Columns>
-      </Rows>
+          </Bleed>
+        </Column>
+        <Column width="content">
+          <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
+        </Column>
+        <Column width="content">
+          <Bleed right="6px" vertical="6px">
+            <Pill textColor={defaultColor}>{`${protocols[0].part}%`}</Pill>
+          </Bleed>
+        </Column>
+      </Columns>
     );
   }
   return null;

--- a/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsExchangeRow.js
@@ -223,19 +223,31 @@ export default function SwapDetailsExchangeRow({ protocols, testID }) {
           </SwapDetailsLabel>
         </Column>
         <Column width="content">
-          <Bleed vertical="10px">
-            <ExchangeIcon
-              icon={getExchangeIconUrl(parseExchangeName(protocols[0].name))}
-              protocol={parseExchangeName(protocols[0].name)}
-            />
-          </Bleed>
+          <Box
+            style={{
+              top: android ? -1.5 : 0,
+            }}
+          >
+            <Bleed vertical="10px">
+              <ExchangeIcon
+                icon={getExchangeIconUrl(parseExchangeName(protocols[0].name))}
+                protocol={parseExchangeName(protocols[0].name)}
+              />
+            </Bleed>
+          </Box>
         </Column>
         <Column width="content">
           <SwapDetailsValue>{steps[step].label}</SwapDetailsValue>
         </Column>
         <Column width="content">
-          <Bleed right="6px" vertical="6px">
-            <Pill textColor={defaultColor}>{`${protocols[0].part}%`}</Pill>
+          <Bleed right="6px" vertical="12px">
+            <Pill
+              height={20}
+              style={{
+                lineHeight: android && 18,
+              }}
+              textColor={defaultColor}
+            >{`${protocols[0].part}%`}</Pill>
           </Bleed>
         </Column>
       </Columns>

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -486,7 +486,9 @@
         "us_except": "United States (except Texas and New York)"
       },
       "swap": {
+        "flashbots_protect": "Flashbots Protect",
         "losing": "Losing",
+        "on": "On",
         "price_impact": "Price impact",
         "price_row_per_token": "per",
         "slippage_message": "This is a small market, so you’re getting a bad price. Try a smaller trade!",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -486,7 +486,9 @@
       },
       "swap": {
         "copy_contract_address": "Copy Contract Address :)",
+        "flashbots_protect": "Flashbots Protect :)",
         "losing": "Losing :)",
+        "on": "On :)",
         "price_impact": "Price impact :)",
         "price_row_per_token": "per :)",
         "slippage_message": "This is a small market, so you’re getting a bad price. Try a smaller trade! :)",


### PR DESCRIPTION
Fixes TEAM2-502
Figma link (if any): https://www.figma.com/file/SFfYzRoHlapEecS0LTLwhQ/Swap-Aggregator-V2?node-id=57%3A25694

## What changed (plus any additional context for devs)
- fixed row sizing/spacing in swap details sheet
- add "flashbots protect" row when flashbots are enabled

## Screen recordings / screenshots
![Simulator Screen Shot - iPhone 14 Plus - 2022-09-27 at 14 47 14](https://user-images.githubusercontent.com/15272675/192642235-0a0f97c4-3183-4770-81ae-8bd7338c4cf8.png)

![Screenshot_20220927_161422](https://user-images.githubusercontent.com/15272675/192653728-3915f234-cf00-45e2-a9cb-2434354cee07.png)

https://user-images.githubusercontent.com/15272675/192642239-9cd66685-949d-4c30-b9ac-403fd084c057.mp4


## What to test
- flashbots protect row only appears when flashbots are enabled
- tapping leads to correct explain sheet
- rows are equally spaced
- tapping "swapping via" row still works well when there are multiple LPs


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
