### PR TITLE
Fix ripple on Android 13

### DIFF
--- a/android/app/src/main/java/com/swmansion/gesturehandler/react/RNZoomableButtonManager.java
+++ b/android/app/src/main/java/com/swmansion/gesturehandler/react/RNZoomableButtonManager.java
@@ -203,4 +203,12 @@ public class RNZoomableButtonManager extends
             view.pivotY = (float) transformOrigin.getDouble(1);
         }
     }
+
+    @Override
+    protected void onAfterUpdateTransaction(ButtonViewGroup view) {
+        // Ripple effect is broken in GH 1.10.3 on Android 13
+        // It appears all the time on press even when the color is transparent
+        // So we disable any feedback completely since we have our own animation
+        // So this is NOOP
+    }
 }


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

Our scale animation button, which uses GH 1.10.3, was showing a ripple effect for some reason on press events, even though we used transparent color for it. This PR disables all kinds of feedback except for our own animation.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

Before:

https://user-images.githubusercontent.com/7809008/192878323-7009fb11-543a-4327-bc1e-850b41208709.mov

After:

https://user-images.githubusercontent.com/7809008/192878376-f78c792c-49da-4b31-89b5-6735f86bc280.mov



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

All the buttons should still have scale animations.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
