### PR TITLE
Fix BackButton crash on long press

### DIFF
--- a/src/components/header/BackButton.js
+++ b/src/components/header/BackButton.js
@@ -4,7 +4,6 @@ import Icon from '../icons/Icon';
 import { Row } from '../layout';
 import Text from '../text/Text';
 import HeaderButton from './HeaderButton';
-import Routes from '@/navigation/routesNames';
 import styled from '@/styled-thing';
 import { fonts, fontWithWidth } from '@/styles';
 
@@ -42,13 +41,6 @@ export default function BackButton({
 
   return (
     <HeaderButton
-      {...(__DEV__
-        ? {
-            onLongPress() {
-              navigation.navigate(Routes.EXPLAIN_SHEET);
-            },
-          }
-        : {})}
       onPress={handlePress}
       opacityTouchable={false}
       radiusAndroid={42}


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)
- app crashes if you long press the back button in the currency select modal (see video below)

## Screen recordings / screenshots
crash example:
https://user-images.githubusercontent.com/15272675/192890645-a8100ab0-d4fa-4d66-9bae-c97814005b4e.mp4

fix:
https://user-images.githubusercontent.com/15272675/192890700-c02d6b3d-0ebb-4348-9fc9-6b0e6ebd08c3.mp4


## What to test
crash doesn't happen anymore

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
