### PR TITLE
[TEAM2-500] Filter User Assets By Socket Support In Currency Select Modal

### DIFF
--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -7,6 +7,7 @@ import {
   TokenSearchUniswapAssetKey,
 } from '@/entities';
 import logger from '@/utils/logger';
+import { EthereumAddress } from '@rainbow-me/swaps';
 
 const tokenSearchApi = new RainbowFetchClient({
   baseURL: 'https://token-search.rainbow.me/v2',
@@ -17,7 +18,7 @@ const tokenSearchApi = new RainbowFetchClient({
   timeout: 30000,
 });
 
-const tokenSearch = async (searchParams: {
+export const tokenSearch = async (searchParams: {
   chainId: number;
   fromChainId?: number | '';
   keys: TokenSearchUniswapAssetKey[];
@@ -56,4 +57,24 @@ const tokenSearch = async (searchParams: {
   }
 };
 
-export default tokenSearch;
+export const walletFilter = async (params: {
+  addresses: EthereumAddress[];
+  departureChainId: number;
+  destinationChainId: number;
+}) => {
+  try {
+    const { addresses, destinationChainId, departureChainId } = params;
+    const filteredAddresses = await tokenSearchApi.post(
+      `/${departureChainId}`,
+      {
+        addresses,
+        toChainId: destinationChainId,
+      }
+    );
+    return filteredAddresses?.data?.data || [];
+  } catch (e) {
+    logger.error(
+      `An error occurred while filter wallet addresses: destinationChainId: ${params.destinationChainId} -> departureChainId: ${params.departureChainId}: ${e}`
+    );
+  }
+};

--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -73,5 +73,6 @@ export const walletFilter = async (params: {
     logger.error(
       `An error occurred while filter wallet addresses: toChainId: ${params.toChainId} -> fromChainId: ${params.fromChainId}: ${e}`
     );
+    throw e;
   }
 };

--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -59,22 +59,19 @@ export const tokenSearch = async (searchParams: {
 
 export const walletFilter = async (params: {
   addresses: EthereumAddress[];
-  departureChainId: number;
-  destinationChainId: number;
+  fromChainId: number;
+  toChainId: number;
 }) => {
   try {
-    const { addresses, destinationChainId, departureChainId } = params;
-    const filteredAddresses = await tokenSearchApi.post(
-      `/${departureChainId}`,
-      {
-        addresses,
-        toChainId: destinationChainId,
-      }
-    );
+    const { addresses, fromChainId, toChainId } = params;
+    const filteredAddresses = await tokenSearchApi.post(`/${fromChainId}`, {
+      addresses,
+      toChainId,
+    });
     return filteredAddresses?.data?.data || [];
   } catch (e) {
     logger.error(
-      `An error occurred while filter wallet addresses: destinationChainId: ${params.destinationChainId} -> departureChainId: ${params.departureChainId}: ${e}`
+      `An error occurred while filter wallet addresses: toChainId: ${params.toChainId} -> fromChainId: ${params.fromChainId}: ${e}`
     );
   }
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -168,3 +168,4 @@ export { default as useWalletENSAvatar } from './useWalletENSAvatar';
 export { default as useImagePicker } from './useImagePicker';
 export { default as useLatestCallback } from './useLatestCallback';
 export { default as useHiddenTokens } from './useHiddenTokens';
+export { useSwappableUserAssets } from './useSwappableUserAssets';

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -14,7 +14,7 @@ import {
   RainbowToken as RT,
   TokenSearchTokenListId,
 } from '@/entities';
-import tokenSearch from '@/handlers/tokenSearch';
+import { tokenSearch } from '@/handlers/tokenSearch';
 import { addHexPrefix, getProviderForNetwork } from '@/handlers/web3';
 import tokenSectionTypes from '@/helpers/tokenSectionTypes';
 import {

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -371,6 +371,8 @@ const useSwapCurrencyList = (
           slowSearch();
         } else {
           await search();
+          setLowLiquidityAssets([]);
+          setHighLiquidityAssets([]);
           setLoading(false);
         }
       } else {

--- a/src/hooks/useSwappableUserAssets.ts
+++ b/src/hooks/useSwappableUserAssets.ts
@@ -42,11 +42,6 @@ export const useSwappableUserAssets = (params: {
           outputCurrency.type !== 'token'
             ? outputCurrency.type
             : Network.mainnet;
-        const addresses = filteredAssetsInWallet.map(asset =>
-          asset?.address === ETH_ADDRESS
-            ? ETH_ADDRESS_AGGREGATORS
-            : asset?.address
-        );
         if (outputNetwork !== network) {
           const swappableAddresses = (await walletFilter({
             addresses,
@@ -64,7 +59,7 @@ export const useSwappableUserAssets = (params: {
         }
       }
     },
-    [filteredAssetsInWallet, outputCurrency]
+    [outputCurrency]
   );
 
   const getSwappableAddressesInWallet = useCallback(async () => {

--- a/src/hooks/useSwappableUserAssets.ts
+++ b/src/hooks/useSwappableUserAssets.ts
@@ -37,26 +37,30 @@ export const useSwappableUserAssets = (params: {
 
   const getSwappableAddressesForNetwork = useCallback(
     async (addresses: EthereumAddress[], network: Network) => {
-      if (outputCurrency) {
-        const outputNetwork =
-          outputCurrency.type !== 'token'
-            ? outputCurrency.type
-            : Network.mainnet;
-        if (outputNetwork !== network) {
-          const swappableAddresses = (await walletFilter({
-            addresses,
-            fromChainId: ethereumUtils.getChainIdFromNetwork(network),
-            toChainId: ethereumUtils.getChainIdFromNetwork(
-              outputNetwork as Network
-            ),
-          })) as string[];
-          setSwappableAssets(state => ({
-            ...state,
-            [network]: swappableAddresses,
-          }));
-        } else {
-          setSwappableAssets(state => ({ ...state, [network]: addresses }));
+      try {
+        if (outputCurrency) {
+          const outputNetwork =
+            outputCurrency.type !== 'token'
+              ? outputCurrency.type
+              : Network.mainnet;
+          if (outputNetwork !== network) {
+            const swappableAddresses = (await walletFilter({
+              addresses,
+              fromChainId: ethereumUtils.getChainIdFromNetwork(network),
+              toChainId: ethereumUtils.getChainIdFromNetwork(
+                outputNetwork as Network
+              ),
+            })) as string[];
+            setSwappableAssets(state => ({
+              ...state,
+              [network]: swappableAddresses,
+            }));
+          } else {
+            setSwappableAssets(state => ({ ...state, [network]: addresses }));
+          }
         }
+      } catch (e) {
+        setSwappableAssets(state => ({ ...state, [network]: addresses }));
       }
     },
     [outputCurrency]

--- a/src/hooks/useSwappableUserAssets.ts
+++ b/src/hooks/useSwappableUserAssets.ts
@@ -45,8 +45,8 @@ export const useSwappableUserAssets = (params: {
         if (outputNetwork !== network) {
           const swappableAddresses = (await walletFilter({
             addresses,
-            departureChainId: ethereumUtils.getChainIdFromNetwork(network),
-            destinationChainId: ethereumUtils.getChainIdFromNetwork(
+            fromChainId: ethereumUtils.getChainIdFromNetwork(network),
+            toChainId: ethereumUtils.getChainIdFromNetwork(
               outputNetwork as Network
             ),
           })) as string[];

--- a/src/hooks/useSwappableUserAssets.ts
+++ b/src/hooks/useSwappableUserAssets.ts
@@ -105,6 +105,24 @@ export const useSwappableUserAssets = (params: {
     [filteredAssetsInWallet, swappableAssets]
   );
 
+  const unswappableUserAssets = useMemo(
+    () =>
+      filteredAssetsInWallet.filter(asset => {
+        const assetNetwork = asset?.network || (Network.mainnet as Network);
+        const assetAddress =
+          asset?.address === ETH_ADDRESS
+            ? ETH_ADDRESS_AGGREGATORS
+            : asset?.address;
+        // we place our testnets (goerli) in the Network type which creates this type issue
+        // @ts-ignore
+        const isNotSwappable = !swappableAssets[assetNetwork]?.includes(
+          assetAddress
+        );
+        return isNotSwappable;
+      }),
+    [filteredAssetsInWallet, swappableAssets]
+  );
+
   useEffect(() => {
     getSwappableAddressesInWallet();
   }, [getSwappableAddressesInWallet]);
@@ -112,10 +130,12 @@ export const useSwappableUserAssets = (params: {
   if (!outputCurrency) {
     return {
       swappableUserAssets: filteredAssetsInWallet,
+      unswappableUserAssets: [],
     };
   }
 
   return {
     swappableUserAssets,
+    unswappableUserAssets,
   };
 };

--- a/src/hooks/useSwappableUserAssets.ts
+++ b/src/hooks/useSwappableUserAssets.ts
@@ -1,0 +1,126 @@
+import { SwappableAsset } from '@/entities';
+import { walletFilter } from '@/handlers/tokenSearch';
+import { Network } from '@/helpers';
+import { useAssetsInWallet, useCoinListEditOptions } from '@/hooks';
+import { ETH_ADDRESS } from '@/references';
+import {
+  EthereumAddress,
+  ETH_ADDRESS as ETH_ADDRESS_AGGREGATORS,
+} from '@rainbow-me/swaps';
+import { ethereumUtils } from '@/utils';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type SwappableAddresses = {
+  [Network.mainnet]: EthereumAddress[];
+  [Network.optimism]: EthereumAddress[];
+  [Network.polygon]: EthereumAddress[];
+  [Network.arbitrum]: EthereumAddress[];
+};
+
+export const useSwappableUserAssets = (params: {
+  outputCurrency: SwappableAsset;
+}) => {
+  const { outputCurrency } = params;
+  const assetsInWallet = useAssetsInWallet() as SwappableAsset[];
+  const { hiddenCoinsObj } = useCoinListEditOptions();
+  const [swappableAssets, setSwappableAssets] = useState<SwappableAddresses>({
+    [Network.mainnet]: [],
+    [Network.optimism]: [],
+    [Network.polygon]: [],
+    [Network.arbitrum]: [],
+  });
+
+  const filteredAssetsInWallet = useMemo(
+    () => assetsInWallet.filter(asset => !hiddenCoinsObj[asset.uniqueId]),
+    [assetsInWallet, hiddenCoinsObj]
+  );
+
+  const getSwappableAddressesForNetwork = useCallback(
+    async (addresses: EthereumAddress[], network: Network) => {
+      if (outputCurrency) {
+        const outputNetwork =
+          outputCurrency.type !== 'token'
+            ? outputCurrency.type
+            : Network.mainnet;
+        const addresses = filteredAssetsInWallet.map(asset =>
+          asset?.address === ETH_ADDRESS
+            ? ETH_ADDRESS_AGGREGATORS
+            : asset?.address
+        );
+        if (outputNetwork !== network) {
+          const swappableAddresses = (await walletFilter({
+            addresses,
+            departureChainId: ethereumUtils.getChainIdFromNetwork(network),
+            destinationChainId: ethereumUtils.getChainIdFromNetwork(
+              outputNetwork as Network
+            ),
+          })) as string[];
+          setSwappableAssets(state => ({
+            ...state,
+            [network]: swappableAddresses,
+          }));
+        } else {
+          setSwappableAssets(state => ({ ...state, [network]: addresses }));
+        }
+      }
+    },
+    [filteredAssetsInWallet, outputCurrency]
+  );
+
+  const getSwappableAddressesInWallet = useCallback(async () => {
+    const networks = [
+      Network.mainnet,
+      Network.optimism,
+      Network.polygon,
+      Network.arbitrum,
+    ];
+    const walletFilterRequests: Promise<void>[] = [];
+    networks.forEach(network => {
+      const assetsAddressesOnChain = filteredAssetsInWallet
+        .filter(asset => (asset?.network || Network.mainnet) === network)
+        .map(asset =>
+          asset?.address === ETH_ADDRESS
+            ? ETH_ADDRESS_AGGREGATORS
+            : asset?.address
+        );
+      if (assetsAddressesOnChain.length) {
+        walletFilterRequests.push(
+          getSwappableAddressesForNetwork(assetsAddressesOnChain, network)
+        );
+      }
+    });
+    await Promise.all(walletFilterRequests);
+  }, [filteredAssetsInWallet, getSwappableAddressesForNetwork]);
+
+  const swappableUserAssets = useMemo(
+    () =>
+      filteredAssetsInWallet.filter(asset => {
+        const assetNetwork = asset?.network || (Network.mainnet as Network);
+        const assetAddress =
+          asset?.address === ETH_ADDRESS
+            ? ETH_ADDRESS_AGGREGATORS
+            : asset?.address;
+        // we place our testnets (goerli) in the Network type which creates this type issue
+        // @ts-ignore
+        const isSwappable = swappableAssets[assetNetwork]?.includes(
+          assetAddress
+        );
+        return isSwappable;
+      }),
+    [filteredAssetsInWallet, swappableAssets]
+  );
+
+  useEffect(() => {
+    getSwappableAddressesInWallet();
+  }, [getSwappableAddressesInWallet]);
+
+  if (!outputCurrency) {
+    return {
+      swappableUserAssets: filteredAssetsInWallet,
+    };
+  }
+
+  return {
+    swappableUserAssets,
+  };
+};

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -4,7 +4,6 @@ import { fetchAssetPrices } from './explorer';
 import { SwappableAsset } from '@/entities';
 import { ExchangeModalTypes } from '@/helpers';
 import { AppDispatch, AppGetState } from '@/redux/store';
-import { logger } from '@/utils';
 
 export interface SwapAmount {
   display: string | null;

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -130,7 +130,6 @@ export const updateSwapInputCurrency = (
   newInputCurrency: SwappableAsset | null,
   ignoreTypeCheck = false
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
-  logger.debug('UPDATE SWAP INPUT CURRENCY');
   const {
     depositCurrency,
     independentField,
@@ -175,7 +174,6 @@ export const updateSwapOutputCurrency = (
   newOutputCurrency: SwappableAsset | null,
   ignoreTypeCheck = false
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
-  logger.debug('UPDATE SWAP OUTPUT CURRENCY');
   const { independentField, inputCurrency, type } = getState().swap;
   if (
     newOutputCurrency?.address === inputCurrency?.address &&

--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -4,6 +4,7 @@ import { fetchAssetPrices } from './explorer';
 import { SwappableAsset } from '@/entities';
 import { ExchangeModalTypes } from '@/helpers';
 import { AppDispatch, AppGetState } from '@/redux/store';
+import { logger } from '@/utils';
 
 export interface SwapAmount {
   display: string | null;
@@ -129,6 +130,7 @@ export const updateSwapInputCurrency = (
   newInputCurrency: SwappableAsset | null,
   ignoreTypeCheck = false
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
+  logger.debug('UPDATE SWAP INPUT CURRENCY');
   const {
     depositCurrency,
     independentField,
@@ -173,6 +175,7 @@ export const updateSwapOutputCurrency = (
   newOutputCurrency: SwappableAsset | null,
   ignoreTypeCheck = false
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
+  logger.debug('UPDATE SWAP OUTPUT CURRENCY');
   const { independentField, inputCurrency, type } = getState().swap;
   if (
     newOutputCurrency?.address === inputCurrency?.address &&

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -39,6 +39,7 @@ import {
   usePrevious,
   useSwapCurrencies,
   useSwapCurrencyList,
+  useSwappableUserAssets,
 } from '@/hooks';
 import { delayNext } from '@/hooks/useMagicAutofocus';
 import { getActiveRoute, useNavigation } from '@/navigation/Navigation';
@@ -156,6 +157,7 @@ export default function CurrencySelectModal() {
 
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
 
+  // TODO: remove this value when crosschain swaps is released
   const filteredAssetsInWallet = useMemo(() => {
     if (type === CurrencySelectionTypes.input) {
       let filteredAssetsInWallet = assetsInWallet?.filter(
@@ -188,6 +190,8 @@ export default function CurrencySelectModal() {
     swapCurrencyListLoading,
     updateFavorites,
   } = useSwapCurrencyList(searchQueryForSearch, currentChainId);
+
+  const { swappableUserAssets } = useSwappableUserAssets({ outputCurrency });
 
   const checkForSameNetwork = useCallback(
     (newAsset, selectAsset, type) => {
@@ -230,18 +234,27 @@ export default function CurrencySelectModal() {
   }, []);
 
   const getWalletCurrencyList = useCallback(() => {
+    const listToUse = crosschainSwapsEnabled
+      ? swappableUserAssets
+      : filteredAssetsInWallet;
     if (type === CurrencySelectionTypes.input) {
       if (searchQueryForSearch !== '') {
         const searchResults = searchWalletCurrencyList(
-          filteredAssetsInWallet,
+          listToUse,
           searchQueryForSearch
         );
         return headerlessSection(searchResults);
       } else {
-        return headerlessSection(filteredAssetsInWallet);
+        return headerlessSection(listToUse);
       }
     }
-  }, [filteredAssetsInWallet, searchQueryForSearch, type]);
+  }, [
+    filteredAssetsInWallet,
+    searchQueryForSearch,
+    type,
+    crosschainSwapsEnabled,
+    swappableUserAssets,
+  ]);
 
   const currencyList = useMemo(() => {
     let list = (type === CurrencySelectionTypes.input

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -141,10 +141,8 @@ export default function CurrencySelectModal() {
   ]);
   const assetsInWallet = useAssetsInWallet() as SwappableAsset[];
   const { hiddenCoinsObj } = useCoinListEditOptions();
-  const crosschainEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
 
   const [currentChainId, setCurrentChainId] = useState(chainId);
-
   const crosschainSwapsEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
   const NetworkSwitcher = !crosschainSwapsEnabled
     ? NetworkSwitcherv1
@@ -235,7 +233,7 @@ export default function CurrencySelectModal() {
   }, []);
 
   const getWalletCurrencyList = useCallback(() => {
-    const listToUse = crosschainEnabled
+    const listToUse = crosschainSwapsEnabled
       ? swappableUserAssets
       : filteredAssetsInWallet;
     if (type === CurrencySelectionTypes.input) {
@@ -253,7 +251,7 @@ export default function CurrencySelectModal() {
     filteredAssetsInWallet,
     searchQueryForSearch,
     type,
-    crosschainEnabled,
+    crosschainSwapsEnabled,
     swappableUserAssets,
   ]);
 

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -45,7 +45,7 @@ import { delayNext } from '@/hooks/useMagicAutofocus';
 import { getActiveRoute, useNavigation } from '@/navigation/Navigation';
 import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
 import Routes from '@/navigation/routesNames';
-import { ethereumUtils, filterList, logger } from '@/utils';
+import { ethereumUtils, filterList } from '@/utils';
 import NetworkSwitcherv2 from '@/components/exchange/NetworkSwitcherv2';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
 import { SwappableAsset } from '@/entities';

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -45,7 +45,7 @@ import { delayNext } from '@/hooks/useMagicAutofocus';
 import { getActiveRoute, useNavigation } from '@/navigation/Navigation';
 import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
 import Routes from '@/navigation/routesNames';
-import { ethereumUtils, filterList } from '@/utils';
+import { ethereumUtils, filterList, logger } from '@/utils';
 import NetworkSwitcherv2 from '@/components/exchange/NetworkSwitcherv2';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
 import { SwappableAsset } from '@/entities';
@@ -500,9 +500,14 @@ export default function CurrencySelectModal() {
 
   const handleBackButton = useCallback(() => {
     setSearchQuery('');
-    setCurrentChainId(currentChainId);
+    InteractionManager.runAfterInteractions(() => {
+      const inputChainId = ethereumUtils.getChainIdFromType(
+        inputCurrency?.type
+      );
+      setCurrentChainId(inputChainId);
+    });
     setIsTransitioning(true); // continue to display list while transitiong back
-  }, [currentChainId]);
+  }, [inputCurrency?.type]);
 
   const shouldUpdateFavoritesRef = useRef(false);
   useEffect(() => {

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -500,9 +500,9 @@ export default function CurrencySelectModal() {
 
   const handleBackButton = useCallback(() => {
     setSearchQuery('');
-    setCurrentChainId(chainId);
+    setCurrentChainId(currentChainId);
     setIsTransitioning(true); // continue to display list while transitiong back
-  }, [chainId]);
+  }, [currentChainId]);
 
   const shouldUpdateFavoritesRef = useRef(false);
   useEffect(() => {

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -141,10 +141,11 @@ export default function CurrencySelectModal() {
   ]);
   const assetsInWallet = useAssetsInWallet() as SwappableAsset[];
   const { hiddenCoinsObj } = useCoinListEditOptions();
+  const crosschainEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
 
   const [currentChainId, setCurrentChainId] = useState(chainId);
-  const crosschainSwapsEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
 
+  const crosschainSwapsEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
   const NetworkSwitcher = !crosschainSwapsEnabled
     ? NetworkSwitcherv1
     : NetworkSwitcherv2;
@@ -234,7 +235,7 @@ export default function CurrencySelectModal() {
   }, []);
 
   const getWalletCurrencyList = useCallback(() => {
-    const listToUse = crosschainSwapsEnabled
+    const listToUse = crosschainEnabled
       ? swappableUserAssets
       : filteredAssetsInWallet;
     if (type === CurrencySelectionTypes.input) {
@@ -252,7 +253,7 @@ export default function CurrencySelectModal() {
     filteredAssetsInWallet,
     searchQueryForSearch,
     type,
-    crosschainSwapsEnabled,
+    crosschainEnabled,
     swappableUserAssets,
   ]);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
When a destination network can be determined based on output token selection

## Screen recordings / screenshots
https://recordit.co/avBPAe34ie


## What to test
The team 2 wallet contains a currency (Pikatic) that does not currently possess on supported cross chain routes. This is the most accessible test case. You can also use the curl example below to verify which tokens are supported for a given chain combination, swap for something unsupported, and attempt the flow I illustrated above with Pikatic.

```
curl --location --request GET 'https://api.socket.tech/v2/token-lists/from-token-list?fromChainId=10&toChainId=1' --header 'API-KEY: 645b2c8c-5825-4930-baf3-d9b997fcd88c'
```
This request returns tokens that can be swapped from optimism (10) to mainnet (1).



## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
