### PR TITLE
fix: initializing stuck state

### DIFF
--- a/src/hooks/useAccountProfile.ts
+++ b/src/hooks/useAccountProfile.ts
@@ -2,26 +2,15 @@ import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { EthereumAddress } from '@/entities';
 import { getAccountProfileInfo } from '@/helpers/accountInfo';
+import { AppState } from '@/redux/store';
 
-const walletSelector = createSelector(
-  ({ wallets: { selected = {}, walletNames } }) => ({
-    selectedWallet: selected as any,
-    walletNames,
-  }),
-  ({ selectedWallet, walletNames }) => ({
-    selectedWallet,
-    walletNames,
-  })
-);
-
-const settingsSelector = createSelector(
-  ({ settings: { accountAddress } }) => ({
-    accountAddress,
-  }),
-  ({ accountAddress }) => ({
-    accountAddress,
-  })
-);
+const walletSelector = (state: AppState) => ({
+  selectedWallet: state.wallets.selected || {},
+  walletNames: state.wallets.walletNames,
+});
+const settingsSelector = (state: AppState) => ({
+  accountAddress: state.settings.accountAddress,
+});
 
 const buildAccountProfile = (
   wallet: {
@@ -29,12 +18,13 @@ const buildAccountProfile = (
     walletNames: { [a: EthereumAddress]: string };
   },
   account: { accountAddress: string }
-) =>
-  getAccountProfileInfo(
+) => {
+  return getAccountProfileInfo(
     wallet.selectedWallet,
     wallet.walletNames,
     account.accountAddress
   );
+};
 
 export default function useAccountProfile() {
   const accountProfileSelector = createSelector(
@@ -49,7 +39,6 @@ export default function useAccountProfile() {
     accountImage,
     accountName,
     accountSymbol,
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'OutputParametricSelector<{ walle... Remove this comment to see the full error message
   } = useSelector(accountProfileSelector);
 
   return {

--- a/src/hooks/useAccountProfile.ts
+++ b/src/hooks/useAccountProfile.ts
@@ -3,9 +3,12 @@ import { createSelector } from 'reselect';
 import { EthereumAddress } from '@/entities';
 import { getAccountProfileInfo } from '@/helpers/accountInfo';
 import { AppState } from '@/redux/store';
+import { RainbowWallet } from '@/model/wallet';
+import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
 
 const walletSelector = (state: AppState) => ({
-  selectedWallet: state.wallets.selected || {},
+  wallets: state.wallets.wallets,
+  selectedWallet: state.wallets.selected || ({} as RainbowWallet),
   walletNames: state.wallets.walletNames,
 });
 const settingsSelector = (state: AppState) => ({
@@ -14,13 +17,18 @@ const settingsSelector = (state: AppState) => ({
 
 const buildAccountProfile = (
   wallet: {
-    selectedWallet: any;
+    wallets: { [id: string]: RainbowWallet } | null;
+    selectedWallet: RainbowWallet;
     walletNames: { [a: EthereumAddress]: string };
   },
   account: { accountAddress: string }
 ) => {
+  const selectedWallet = findWalletWithAccount(
+    wallet.wallets || {},
+    account.accountAddress
+  );
   return getAccountProfileInfo(
-    wallet.selectedWallet,
+    selectedWallet || wallet.selectedWallet,
     wallet.walletNames,
     account.accountAddress
   );

--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -121,7 +121,6 @@ export const NotificationsHandler = ({ children, walletReady }: Props) => {
     const notification = NotificationStorage.getDeferredNotification();
     if (notification) {
       // wait to wallet to load completely before opening
-      await delay(3000);
       performActionBasedOnOpenedNotificationType(notification);
       NotificationStorage.clearDeferredNotification();
     }

--- a/src/redux/wallets.ts
+++ b/src/redux/wallets.ts
@@ -473,7 +473,6 @@ export const getWalletENSAvatars = async (
     };
   });
   if (updatedWallets) {
-    // dispatch(walletsSetSelected(updatedWallets[selected!.id]));
     dispatch(walletsUpdate(updatedWallets));
   }
 };

--- a/src/redux/wallets.ts
+++ b/src/redux/wallets.ts
@@ -143,7 +143,7 @@ const WALLETS_SET_SELECTED = 'wallets/SET_SELECTED';
 /**
  * Loads wallet information from storage and updates state accordingly.
  */
-export const walletsLoadState = (profilesEnabled: boolean = false) => async (
+export const walletsLoadState = (profilesEnabled = false) => async (
   dispatch: ThunkDispatch<AppState, unknown, WalletsLoadAction>,
   getState: AppGetState
 ) => {
@@ -288,7 +288,7 @@ export const setWalletBackedUp = (
   walletId: RainbowWallet['id'],
   method: RainbowWallet['backupType'],
   backupFile: RainbowWallet['backupFile'] = null,
-  updateUserMetadata: boolean = true
+  updateUserMetadata = true
 ) => async (
   dispatch: ThunkDispatch<AppState, unknown, never>,
   getState: AppGetState
@@ -473,7 +473,7 @@ export const getWalletENSAvatars = async (
     };
   });
   if (updatedWallets) {
-    dispatch(walletsSetSelected(updatedWallets[selected!.id]));
+    // dispatch(walletsSetSelected(updatedWallets[selected!.id]));
     dispatch(walletsUpdate(updatedWallets));
   }
 };


### PR DESCRIPTION
Fixes RNBW-4468
Fixes TEAM2-508

Figma link (if any):

## What changed (plus any additional context for devs)

explanation in ticket video

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

video in ticket https://linear.app/rainbow/issue/RNBW-4468#comment-53e7f528

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

1. switch accounts flow: kill the app, open it and switch the account very quickly, before this PR you would be able to see the initialized bug but this  shouldn't be happening anymore
2. notifications flow: leave the app in wallet "A", kill the app, open a notification for another account (account B), you should see the app is switching accounts automatically and you don't get to this initializing state
3. ENS flow: kill the app, update ens avatar for the wallet from ens app, open the app again, you should see the new avatar correctly updated in your wallet


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
