### PR TITLE
Fix: Notifications not unsubscribing when clearing storage + crashing

### DIFF
--- a/src/components/settings-menu/DevSection.tsx
+++ b/src/components/settings-menu/DevSection.tsx
@@ -49,6 +49,7 @@ import Routes from '@/navigation/routesNames';
 import { ethereumUtils } from '@/utils';
 import logger from '@/utils/logger';
 import {
+  addDefaultNotificationGroupSettings,
   removeNotificationSettingsForWallet,
   useAllNotificationSettingsFromStorage,
 } from '@/notifications/settings';
@@ -214,11 +215,13 @@ const DevSection = () => {
     clearAllNotificationSettings();
     await AsyncStorage.clear();
     clearAllStorages();
+    addDefaultNotificationGroupSettings();
   }, [clearAllNotificationSettings]);
 
   const clearMMKVStorage = useCallback(async () => {
     clearAllNotificationSettings();
     clearAllStorages();
+    addDefaultNotificationGroupSettings();
   }, [clearAllNotificationSettings]);
 
   return (

--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -14,6 +14,7 @@ import { useAccountSettings, useAppState, useWallets } from '@/hooks';
 import { requestPermission } from '@/notifications/permissions';
 import profileUtils from '@/utils/profileUtils';
 import {
+  addDefaultNotificationSettingsForWallet,
   NotificationRelationship,
   updateSettingsForWallets,
   useAllNotificationSettingsFromStorage,
@@ -223,28 +224,12 @@ const NotificationsSection = () => {
     });
   }, [ownerEnabled, updateGroupSettings]);
 
-  const toggleAllOwnedNotificationsFromWallet = useCallback(() => {
-    updateGroupSettings({
-      [NotificationRelationship.OWNER]: !ownerEnabled
-        ? !ownerEnabled
-        : ownerEnabled,
-    });
-  }, [ownerEnabled, updateGroupSettings]);
-
   const toggleAllWatchedNotifications = useCallback(() => {
     updateSettingsForWallets(NotificationRelationship.WATCHER, {
       enabled: !watcherEnabled,
     });
     updateGroupSettings({
       [NotificationRelationship.WATCHER]: !watcherEnabled,
-    });
-  }, [updateGroupSettings, watcherEnabled]);
-
-  const toggleAllWatchedNotificationsFromWallet = useCallback(() => {
-    updateGroupSettings({
-      [NotificationRelationship.WATCHER]: !watcherEnabled
-        ? !watcherEnabled
-        : watcherEnabled,
     });
   }, [updateGroupSettings, watcherEnabled]);
 
@@ -272,7 +257,31 @@ const NotificationsSection = () => {
 
   useEffect(() => {
     checkPermissions();
-  }, [checkPermissions, justBecameActive]);
+    // populate notification settings if they
+    // have been cleared from dev settings to prevent a crash
+    // when going to the notification settings screen for a wallet
+    if (notificationSettings.length === 0) {
+      ownedWallets.forEach(wallet => {
+        addDefaultNotificationSettingsForWallet(
+          wallet.address,
+          NotificationRelationship.OWNER
+        );
+      });
+
+      watchedWallets.forEach(wallet => {
+        addDefaultNotificationSettingsForWallet(
+          wallet.address,
+          NotificationRelationship.WATCHER
+        );
+      });
+    }
+  }, [
+    checkPermissions,
+    justBecameActive,
+    notificationSettings,
+    ownedWallets,
+    watchedWallets,
+  ]);
 
   return (
     <Box>

--- a/src/model/mmkv.ts
+++ b/src/model/mmkv.ts
@@ -1,5 +1,4 @@
 import { MMKV } from 'react-native-mmkv';
-import { addDefaultNotificationGroupSettings } from '@/notifications/settings';
 
 export const STORAGE_IDS = {
   ACCOUNT: 'ACCOUNT',
@@ -23,10 +22,4 @@ export const clearAllStorages = () => {
 
   const defaultStorage = new MMKV();
   defaultStorage.clearAll();
-
-  // set default notification group settings
-  // to prevent crashing & weird state
-  // if the user does not restart the app
-  // after clearing all storages
-  addDefaultNotificationGroupSettings();
 };

--- a/src/model/mmkv.ts
+++ b/src/model/mmkv.ts
@@ -1,4 +1,5 @@
 import { MMKV } from 'react-native-mmkv';
+import { addDefaultNotificationGroupSettings } from '@/notifications/settings';
 
 export const STORAGE_IDS = {
   ACCOUNT: 'ACCOUNT',
@@ -22,4 +23,10 @@ export const clearAllStorages = () => {
 
   const defaultStorage = new MMKV();
   defaultStorage.clearAll();
+
+  // set default notification group settings
+  // to prevent crashing & weird state
+  // if the user does not restart the app
+  // after clearing all storages
+  addDefaultNotificationGroupSettings();
 };


### PR DESCRIPTION
Fixes TEAM2-511

## What changed (plus any additional context for devs)
- Notification settings reset to a default state like on first app launch after clearing them from Dev Settings.
- Prevented the app from crashing when going to Notification settings for a wallet after clearing storage / MMKV.
- Fixed app not unsubscribing from notifications when clearing storage / MMKV.
- Fixed toggles in `Settings → Notifications` showing wrong state after clearing storage / MMKV.
- Removed some leftover functions from https://github.com/rainbow-me/rainbow/pull/4165


## Screen recordings / screenshots
No visual changes.


## What to test
### Flow 1
1. Clearing local storage as a normal user and checking if notification settings are reset to default (owned ON, watched OFF) and correctly displayed.
2. Checking if notifications arrive properly based on selected settings.
3. Changing settings for wallets and checking if everything works properly.
----
### Flow 2
1. Clearing async storage as a developer and checking if notification settings are intact.
2. Checking if notifications arrive properly based on selected settings.
3. Changing settings for wallets and checking if everything works properly.
----
### Flow 3
1. Clearing MMKV storage as a developer and checking if notification settings are reset to default (owned ON, watched OFF) and correctly displayed.
2. Checking if notifications arrive properly based on selected settings.
3. Changing settings for wallets and checking if everything works properly.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
