### PR TITLE
Reduce bottom fab padding

### DIFF
--- a/src/components/fab/FabWrapper.js
+++ b/src/components/fab/FabWrapper.js
@@ -5,7 +5,7 @@ import ExchangeFab from './ExchangeFab';
 import SendFab from './SendFab';
 import styled from '@/styled-thing';
 
-export const FabWrapperBottomPosition = 21 + safeAreaInsetValues.bottom;
+export const FabWrapperBottomPosition = 8 + safeAreaInsetValues.bottom;
 export const FabWrapperItemMargin = 15;
 
 const FabWrapperRow = styled(RowWithMargins).attrs({ margin: 13 })({


### PR DESCRIPTION
Fixes RNBW-4554

## What changed (plus any additional context for devs)

This PR reduces the bottom padding of the FABs as seen in the Linear ticket.

I couldn't seem to reproduce the padded grey bottom area issue in that ticket – going to dig a bit deeper when I get the time tomorrow.


## Screen recordings / screenshots

### iOS

<img width="498" alt="Screenshot 2022-10-04 at 4 57 43 pm" src="https://user-images.githubusercontent.com/7336481/193745794-bc0ea54b-a32a-4b44-b348-258b3eb59e3c.png">


### Android

<img width="474" alt="Screenshot 2022-10-04 at 4 59 50 pm" src="https://user-images.githubusercontent.com/7336481/193745799-c489df46-1862-428f-9e90-a6320f9ca674.png">
