### PR TITLE
crosschain swaps: handle transaction confirmation status

### DIFF
--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -36,7 +36,11 @@ import {
   convertRawAmountToBalance,
   convertRawAmountToNativeDisplay,
 } from '@/helpers/utilities';
-import { ethereumUtils, getTokenMetadata } from '@/utils';
+import { ethereumUtils, getTokenMetadata, isLowerCaseMatch } from '@/utils';
+import {
+  RAINBOW_ROUTER_CONTRACT_ADDRESS,
+  SOCKET_REGISTRY_CONTRACT_ADDRESSESS,
+} from '@rainbow-me/swaps';
 
 const LAST_TXN_HASH_BUFFER = 20;
 
@@ -285,6 +289,19 @@ const overrideTradeRefund = (txn: ZerionTransaction): ZerionTransaction => {
   };
 };
 
+const overrideSwap = (tx: ZerionTransaction): ZerionTransaction => {
+  if (
+    isLowerCaseMatch(
+      tx.address_to || '',
+      SOCKET_REGISTRY_CONTRACT_ADDRESSESS
+    ) ||
+    isLowerCaseMatch(tx.address_to || '', RAINBOW_ROUTER_CONTRACT_ADDRESS)
+  ) {
+    return { ...tx, type: TransactionType.trade };
+  }
+  return tx;
+};
+
 const parseTransactionWithEmptyChanges = async (
   txn: ZerionTransaction,
   nativeCurrency: keyof typeof supportedNativeCurrencies,
@@ -344,6 +361,7 @@ const parseTransaction = async (
   txn = overrideAuthorizations(txn);
   txn = overrideSelfWalletConnect(txn);
   txn = overrideTradeRefund(txn);
+  txn = overrideSwap(txn);
 
   if (txn.changes.length) {
     const internalTransactions = txn.changes.map(

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -915,6 +915,7 @@ export const transactionsReceived = (
     accountAddress,
     nativeCurrency,
     transactions,
+    pendingTransactions,
     purchaseTransactions,
     currentNetwork,
     appended


### PR DESCRIPTION
Fixes TEAM2-496
Figma link (if any):

## What changed (plus any additional context for devs)

Originally i thought the issue on the ticket was produced because we weren't parsing txs correctly for crosschain swaps but the issue on the ticket was produced because zerion txs were overwriting txs on state, so crosschain swaps happening from mainnet as source network 

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->

https://www.loom.com/share/93fae4714d5a453580a27aa11bb4f189

In the video you'll see a mainnet <> OP swap that is not bridged yet, so the tx is on "Swapping" state while the bridge is confirming
- i didn't add android since i'd have to pay for another swap on mainnet and this is only a data change

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

- send a mainnet <> L2 swap and you shouldn't see a "Sent Token" tx confirmed below the pending "Swapping" tx described on the ticket

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
