### PR TITLE
feat: configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "fix(Github Actions)"
+      prefix: "fix(actions)"
     target-branch: "develop"
     reviewers:
       - "rainbow-me/app-admin"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       prefix: "fix(Github Actions)"
     target-branch: "develop"
     reviewers:
-      - "rainbow-dot-me/admins"
+      - "rainbow-me/app-admin"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -20,4 +20,4 @@ updates:
       prefix: "fix(npm)"
     target-branch: "develop"
     reviewers:
-      - "rainbow-dot-me/admins"
+      - "rainbow-me/app-admin"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
 
@@ -9,10 +10,6 @@ updates:
       prefix: "fix(Github Actions)"
     target-branch: "develop"
     reviewers:
-      - "estrattonbailey"
-      - "osdnk"
-      - "brunobar79"
-      - "estebanmino"
       - "rainbow-dot-me/admins"
 
   - package-ecosystem: "npm"
@@ -23,8 +20,4 @@ updates:
       prefix: "fix(npm)"
     target-branch: "develop"
     reviewers:
-      - "estrattonbailey"
-      - "osdnk"
-      - "brunobar79"
-      - "estebanmino"
       - "rainbow-dot-me/admins"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix(Github Actions)"
+    target-branch: "develop"
+    reviewers:
+      - "estrattonbailey"
+      - "osdnk"
+      - "brunobar79"
+      - "estebanmino"
+      - "rainbow-dot-me/admins"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix(npm)"
+    target-branch: "develop"
+    reviewers:
+      - "estrattonbailey"
+      - "osdnk"
+      - "brunobar79"
+      - "estebanmino"
+      - "rainbow-dot-me/admins"


### PR DESCRIPTION
See [discussion in Slack](https://rainbowhaus.slack.com/archives/CGUDDJYNL/p1664524373501989), and related PRs #4251 and #4187.

**Why add Dependabot?**

Our current workflow with `audit-ci` only alerts us to issues, it doesn't help us fix them. Also, `yarn audit fix` doesn't exist. So Dependabot can help fill this gap and open PRs with lockfile patches for vulnerabilities.

If a dependency vuln is deemed acceptable, we can close the PR and ask Dependabot to ignore it. If it's something we need to fix, then we've got a PR ready to go for testing.

Our workflow otherwise stays the same, and `audit-ci` will block merging PRs until we either merge an Dependabot PR to fix it, or ignore it in the `audit-ci.jsonc` config file.