### PR TITLE
Fix: hide shadows for disabled wallets in Notifications list

### DIFF
--- a/src/components/contacts/ContactAvatar.js
+++ b/src/components/contacts/ContactAvatar.js
@@ -79,6 +79,11 @@ const sizeConfigs = colors => ({
     dimensions: 36,
     textSize: 'large',
   },
+  small_shadowless: {
+    dimensions: 36,
+    textSize: 'large',
+    shadow: [[0, 0, 0, colors.shadow, 0]],
+  },
   // TODO: remove `legacySmall` size once rainbow home screen revamp is released
   legacySmall: {
     dimensions: 34,

--- a/src/components/contacts/ImageAvatar.js
+++ b/src/components/contacts/ImageAvatar.js
@@ -50,6 +50,11 @@ const sizeConfigs = (colors, isDarkMode) => ({
     shadow: [[0, 4, android ? 5 : 12, colors.shadow, 0.4]],
     textSize: 'large',
   },
+  smedium_shadowless: {
+    dimensions: 36,
+    shadow: [[0, 0, 0, colors.shadow, 0]],
+    textSize: 'large',
+  },
 });
 
 const Avatar = styled(ImgixImage)(({ dimensions }) => ({

--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -151,11 +151,14 @@ const WalletRow = ({
           }}
         >
           {wallet.image ? (
-            <ImageAvatar image={wallet.image} size="smedium" />
+            <ImageAvatar
+              image={wallet.image}
+              size={rowEnabled ? 'smedium' : 'smedium_shadowless'}
+            />
           ) : (
             <ContactAvatar
               color={wallet.color}
-              size="small"
+              size={rowEnabled ? 'small' : 'small_shadowless'}
               value={
                 returnStringFirstEmoji(wallet.label) ||
                 profileUtils.addressHashedEmoji(wallet.address)


### PR DESCRIPTION
RNBW-4562

## What changed (plus any additional context for devs)
- Added a new style to `ContactAvatar` and `ImageAvatar` that renders without shadows.


## Screen recordings / screenshots
| iOS | Android |
| --- | ------- |
| ![CleanShot 2022-10-06 at 12 03 32 AM@2x](https://user-images.githubusercontent.com/6843656/194173247-5a5a6913-6848-4ea9-b564-96d5685bb831.png) | ![image](https://user-images.githubusercontent.com/6843656/194173274-059179eb-810c-4282-aeb1-ccac648165d8.png) |



## What to test
Check if disabled wallets don't have a shadow in `Settings → Notifications`.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
