### PR TITLE
Analytics Tapped Push Notification event

### DIFF
--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -54,6 +54,7 @@ import {
   NotificationRelationship,
 } from './settings';
 import walletTypes from '@/helpers/walletTypes';
+import { trackTappedPushNotification } from '@/notifications/analytics';
 
 type Callback = () => void;
 
@@ -150,6 +151,7 @@ export const NotificationsHandler = ({ children, walletReady }: Props) => {
     if (!notification) {
       return;
     }
+    trackTappedPushNotification(notification);
     // Need to call getState() directly, because the event handler
     // has the old value reference in its closure
     if (!store.getState().appState.walletReady) {

--- a/src/notifications/analytics.ts
+++ b/src/notifications/analytics.ts
@@ -1,0 +1,13 @@
+import { analytics } from '@/analytics';
+import { MinimalNotification } from '@/notifications/types';
+
+export const trackTappedPushNotification = (
+  notification: MinimalNotification | undefined
+) => {
+  analytics.track('Tapped Push Notification', {
+    campaign: {
+      name: notification?.data?.type ?? 'default',
+      medium: 'Push',
+    },
+  });
+};


### PR DESCRIPTION
Fixes TEAM2-514
Figma link (if any):

## What changed (plus any additional context for devs)
* Implemented a new analytics event that fires when users tap on push notifications called "Tapped Push Notification"

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

* Make sure you have notifications feature flag enabled
* Send a transaction that will trigger a new push notification
* Once you have the push notification, go to segment debugger
* Press on a notification when the app:
	* Is in foreground
	* Is in background
	* Is killed
* Try to catch that event in the debugger

Use the dev mode so that the dev source is used in segment

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
