### PR TITLE
fix: only enable Dependabot for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     commit-message:
       prefix: "fix(actions)"
     target-branch: "develop"
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
     reviewers:
       - "rainbow-me/app-admin"
 
@@ -19,5 +21,7 @@ updates:
     commit-message:
       prefix: "fix(npm)"
     target-branch: "develop"
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
     reviewers:
       - "rainbow-me/app-admin"


### PR DESCRIPTION
My bad, learned that I need to disable version updates (with [this strange config](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file)) in order to ONLY get security updates. As it is, it's going to get very noisy, and we don't need that right now.