### PR TITLE
[TEAM2-476][TEAM2-472] Display Crosschain Exact Matches and Add Bridge Asset Section

### DIFF
--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -48,6 +48,7 @@ export const tokenSearch = async (searchParams: {
     }
     const url = `/${searchParams.chainId}/?${qs.stringify(queryParams)}`;
     const tokenSearch = await tokenSearchApi.get(url);
+    logger.debug('URL: ', url);
     return tokenSearch.data?.data;
   } catch (e) {
     logger.error(

--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -48,7 +48,6 @@ export const tokenSearch = async (searchParams: {
     }
     const url = `/${searchParams.chainId}/?${qs.stringify(queryParams)}`;
     const tokenSearch = await tokenSearchApi.get(url);
-    logger.debug('URL: ', url);
     return tokenSearch.data?.data;
   } catch (e) {
     logger.error(

--- a/src/helpers/tokenSectionTypes.ts
+++ b/src/helpers/tokenSectionTypes.ts
@@ -1,4 +1,5 @@
 export default {
+  bridgeTokenSection: '􀊝 Bridge',
   crosschainMatchSection: '􀤆 On other networks',
   favoriteTokenSection: '􀋃 Favorites',
   lowLiquidityTokenSection: '􀇿 Low Liquidity',

--- a/src/helpers/tokenSectionTypes.ts
+++ b/src/helpers/tokenSectionTypes.ts
@@ -1,4 +1,5 @@
 export default {
+  crosschainMatchSection: '􀤆 On other networks',
   favoriteTokenSection: '􀋃 Favorites',
   lowLiquidityTokenSection: '􀇿 Low Liquidity',
   unverifiedTokenSection: '􀇿 Unverified',

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -195,20 +195,12 @@ const useSwapCurrencyList = (
         const aIsRanked = rankA > -1;
         const bIsRanked = rankB > -1;
         if (aIsRanked) {
-          return bIsRanked
-            ? // compare rank within list
-              rankA < rankB
-              ? -1
-              : 1
-            : // only t1 is ranked
-              -1;
-        } else {
-          return bIsRanked
-            ? // only t2 is ranked
-              1
-            : // sort unranked by abc
-              name1?.localeCompare(name2);
+          if (bIsRanked) {
+            return rankA > rankB ? -1 : 1;
+          }
+          return -1;
         }
+        return bIsRanked ? 1 : name1?.localeCompare(name2);
       });
   }, [curatedMap, favoriteAddresses]);
 

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -546,7 +546,7 @@ const useSwapCurrencyList = (
   ]);
 
   const crosschainExactMatches = useMemo(() => {
-    if (!currencyList.length) return [];
+    if (currencyList.length) return [];
     if (!searchQuery) return [];
     const exactMatches: RT[] = [];
     Object.keys(crosschainVerifiedAssets).forEach(network => {
@@ -557,7 +557,7 @@ const useSwapCurrencyList = (
         // including goerli in our networks type is causing this type issue
         // @ts-ignore
         const exactMatch = crosschainVerifiedAssets[network as Network].find(
-          asset => {
+          (asset: RT) => {
             const symbolMatch =
               asset?.symbol.toLowerCase() === searchQuery.toLowerCase();
             const nameMatch =
@@ -566,7 +566,7 @@ const useSwapCurrencyList = (
           }
         );
         if (exactMatch) {
-          exactMatches.push(exactMatch);
+          exactMatches.push({ ...exactMatch, network });
         }
       }
     });

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -514,13 +514,7 @@ const useSwapCurrencyList = (
       if (favoriteAssets?.length && searchChainId === MAINNET_CHAINID) {
         list.push({
           color: colors.yellowFavorite,
-          data: abcSort(
-            favoriteAssets.filter(
-              asset =>
-                asset?.name.toLowerCase() !== bridgeAsset?.name.toLowerCase()
-            ),
-            'name'
-          ),
+          data: abcSort(favoriteAssets, 'name'),
           key: 'favorites',
           title: tokenSectionTypes.favoriteTokenSection,
         });

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -71,7 +71,11 @@ const searchCurrencyList = async (searchParams: {
   const formattedQuery = isAddress ? addHexPrefix(query).toLowerCase() : query;
   if (typeof searchList === 'string') {
     const threshold = isAddress ? 'CASE_SENSITIVE_EQUAL' : 'CONTAINS';
-    if (chainId === MAINNET_CHAINID && !formattedQuery) {
+    if (
+      chainId === MAINNET_CHAINID &&
+      !formattedQuery &&
+      searchList !== 'verifiedAssets'
+    ) {
       return [];
     }
     return tokenSearch({
@@ -270,6 +274,7 @@ const useSwapCurrencyList = (
 
   const getCrosschainVerifiedAssetsForNetwork = useCallback(
     async (network: Network) => {
+      logger.debug('CHAIN ID: ', ethereumUtils.getChainIdFromNetwork(network));
       const results = await searchCurrencyList({
         searchList: 'verifiedAssets',
         query: '',
@@ -562,7 +567,18 @@ const useSwapCurrencyList = (
         }
       }
     });
-    return exactMatches;
+    if (exactMatches?.length) {
+      logger.debug('EXACT MATCHES: ', JSON.stringify(exactMatches, null, 2));
+      return [
+        {
+          data: exactMatches,
+          key: 'verified',
+          title: tokenSectionTypes.crosschainMatchSection,
+          useGradientText: !IS_TEST,
+        },
+      ];
+    }
+    return [];
   }, [
     crosschainVerifiedAssets,
     currencyList.length,

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -26,7 +26,7 @@ import {
   WBTC_ADDRESS,
   WETH_ADDRESS,
 } from '@/references';
-import { ethereumUtils, filterList, logger } from '@/utils';
+import { ethereumUtils, filterList, isLowerCaseMatch, logger } from '@/utils';
 import useSwapCurrencies from '@/hooks/useSwapCurrencies';
 import { Network } from '@/helpers';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
@@ -457,9 +457,8 @@ const useSwapCurrencyList = (
   const currencyList = useMemo(() => {
     const list = [];
     let bridgeAsset = isCrosschainSearch
-      ? verifiedAssets.find(
-          asset =>
-            asset?.name.toLowerCase() === inputCurrency?.name.toLowerCase()
+      ? verifiedAssets.find(asset =>
+          isLowerCaseMatch(asset?.name, inputCurrency?.name)
         )
       : null;
     if (searching) {
@@ -607,10 +606,8 @@ const useSwapCurrencyList = (
         // @ts-ignore
         const exactMatch = crosschainVerifiedAssets[network as Network].find(
           (asset: RT) => {
-            const symbolMatch =
-              asset?.symbol.toLowerCase() === searchQuery.toLowerCase();
-            const nameMatch =
-              asset?.name.toLowerCase() === searchQuery.toLowerCase();
+            const symbolMatch = isLowerCaseMatch(asset?.symbol, searchQuery);
+            const nameMatch = isLowerCaseMatch(asset?.name, searchQuery);
             return symbolMatch || nameMatch;
           }
         );

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -457,8 +457,10 @@ const useSwapCurrencyList = (
   const currencyList = useMemo(() => {
     const list = [];
     let bridgeAsset = isCrosschainSearch
-      ? verifiedAssets.find(asset =>
-          isLowerCaseMatch(asset?.name, inputCurrency?.name)
+      ? verifiedAssets.find(
+          asset =>
+            isLowerCaseMatch(asset?.name, inputCurrency?.name) &&
+            asset?.type !== inputCurrency?.type
         )
       : null;
     if (searching) {

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -129,8 +129,9 @@ const useSwapCurrencyList = (
     [Network.arbitrum]: [],
   });
 
-  const { inputCurrency } = useSwapCurrencies();
   const crosschainSwapsEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
+  const { inputCurrency } = useSwapCurrencies();
+  const previousInputCurrencyType = usePrevious(inputCurrency?.type);
   const inputChainId = useMemo(
     () => ethereumUtils.getChainIdFromType(inputCurrency?.type),
     [inputCurrency?.type]
@@ -425,7 +426,8 @@ const useSwapCurrencyList = (
       if (
         (searching && !wasSearching) ||
         (searching && previousSearchQuery !== searchQuery) ||
-        searchChainId !== previousChainId
+        searchChainId !== previousChainId ||
+        inputCurrency?.type !== previousInputCurrencyType
       ) {
         if (searchChainId === MAINNET_CHAINID) {
           search();
@@ -442,7 +444,13 @@ const useSwapCurrencyList = (
     };
     doSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searching, searchQuery, searchChainId, isCrosschainSearch]);
+  }, [
+    searching,
+    searchQuery,
+    searchChainId,
+    isCrosschainSearch,
+    inputCurrency?.type,
+  ]);
 
   const { colors } = useTheme();
 
@@ -491,14 +499,6 @@ const useSwapCurrencyList = (
         }
       }
       if (inputCurrency?.name && verifiedAssets.length) {
-        if (searchChainId === MAINNET_CHAINID && isCrosschainSearch) {
-          if (!bridgeAsset) {
-            bridgeAsset = favoriteAssets.find(
-              asset =>
-                asset?.name.toLowerCase() === inputCurrency.name.toLowerCase()
-            );
-          }
-        }
         if (bridgeAsset) {
           list.push({
             color:

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -45,7 +45,7 @@ import { delayNext } from '@/hooks/useMagicAutofocus';
 import { getActiveRoute, useNavigation } from '@/navigation/Navigation';
 import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
 import Routes from '@/navigation/routesNames';
-import { ethereumUtils, filterList } from '@/utils';
+import { ethereumUtils, filterList, logger } from '@/utils';
 import NetworkSwitcherv2 from '@/components/exchange/NetworkSwitcherv2';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
 import { SwappableAsset } from '@/entities';
@@ -185,6 +185,7 @@ export default function CurrencySelectModal() {
   ]);
 
   const {
+    crosschainExactMatches,
     swapCurrencyList,
     swapCurrencyListLoading,
     updateFavorites,

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -287,21 +287,21 @@ export default function CurrencySelectModal() {
     });
 
     // ONLY FOR e2e!!! Fake tokens with same symbols break detox e2e tests
-    // if (IS_TESTING === 'true' && type === CurrencySelectionTypes.output) {
-    //   let symbols: string[] = [];
-    //   list = list?.map(section => {
-    //     // Remove dupes
-    //     section.data = uniqBy(section?.data, 'symbol');
-    //     // Remove dupes across sections
-    //     section.data = section?.data?.filter(
-    //       token => !symbols.includes(token?.symbol)
-    //     );
-    //     const sectionSymbols = section?.data?.map(token => token?.symbol);
-    //     symbols = symbols.concat(sectionSymbols);
+    if (IS_TESTING === 'true' && type === CurrencySelectionTypes.output) {
+      let symbols: string[] = [];
+      list = list?.map(section => {
+        // Remove dupes
+        section.data = uniqBy(section?.data, 'symbol');
+        // Remove dupes across sections
+        section.data = section?.data?.filter(
+          token => !symbols.includes(token?.symbol)
+        );
+        const sectionSymbols = section?.data?.map(token => token?.symbol);
+        symbols = symbols.concat(sectionSymbols);
 
-    //     return section;
-    //   });
-    // }
+        return section;
+      });
+    }
     return list.filter(section => section.data.length > 0);
   }, [activeSwapCurrencyList, getWalletCurrencyList, type]);
 

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -258,7 +258,6 @@ export default function CurrencySelectModal() {
 
   const activeSwapCurrencyList = useMemo(() => {
     if (crosschainExactMatches.length) {
-      // logger.debug('CROSS CHAIN EXACT MATCHES: ', JSON.stringify(crosschainExactMatches[0].data, null, 2));
       return crosschainExactMatches;
     }
     return swapCurrencyList;
@@ -288,21 +287,21 @@ export default function CurrencySelectModal() {
     });
 
     // ONLY FOR e2e!!! Fake tokens with same symbols break detox e2e tests
-    if (IS_TESTING === 'true' && type === CurrencySelectionTypes.output) {
-      let symbols: string[] = [];
-      list = list?.map(section => {
-        // Remove dupes
-        section.data = uniqBy(section?.data, 'symbol');
-        // Remove dupes across sections
-        section.data = section?.data?.filter(
-          token => !symbols.includes(token?.symbol)
-        );
-        const sectionSymbols = section?.data?.map(token => token?.symbol);
-        symbols = symbols.concat(sectionSymbols);
+    // if (IS_TESTING === 'true' && type === CurrencySelectionTypes.output) {
+    //   let symbols: string[] = [];
+    //   list = list?.map(section => {
+    //     // Remove dupes
+    //     section.data = uniqBy(section?.data, 'symbol');
+    //     // Remove dupes across sections
+    //     section.data = section?.data?.filter(
+    //       token => !symbols.includes(token?.symbol)
+    //     );
+    //     const sectionSymbols = section?.data?.map(token => token?.symbol);
+    //     symbols = symbols.concat(sectionSymbols);
 
-        return section;
-      });
-    }
+    //     return section;
+    //   });
+    // }
     return list.filter(section => section.data.length > 0);
   }, [activeSwapCurrencyList, getWalletCurrencyList, type]);
 

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -45,10 +45,10 @@ import { delayNext } from '@/hooks/useMagicAutofocus';
 import { getActiveRoute, useNavigation } from '@/navigation/Navigation';
 import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
 import Routes from '@/navigation/routesNames';
-import { ethereumUtils, filterList, logger } from '@/utils';
+import { ethereumUtils, filterList } from '@/utils';
 import NetworkSwitcherv2 from '@/components/exchange/NetworkSwitcherv2';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
-import { RainbowToken, SwappableAsset } from '@/entities';
+import { SwappableAsset } from '@/entities';
 import { Box, Row, Rows } from '@/design-system';
 import { useTheme } from '@/theme';
 

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -48,7 +48,7 @@ import Routes from '@/navigation/routesNames';
 import { ethereumUtils, filterList, logger } from '@/utils';
 import NetworkSwitcherv2 from '@/components/exchange/NetworkSwitcherv2';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
-import { SwappableAsset } from '@/entities';
+import { RainbowToken, SwappableAsset } from '@/entities';
 import { Box, Row, Rows } from '@/design-system';
 import { useTheme } from '@/theme';
 
@@ -256,10 +256,21 @@ export default function CurrencySelectModal() {
     swappableUserAssets,
   ]);
 
+  const activeSwapCurrencyList = useMemo(() => {
+    if (crosschainExactMatches.length) {
+      // logger.debug('CROSS CHAIN EXACT MATCHES: ', JSON.stringify(crosschainExactMatches[0].data, null, 2));
+      return crosschainExactMatches;
+    }
+    return swapCurrencyList;
+  }, [crosschainExactMatches, swapCurrencyList]);
+
   const currencyList = useMemo(() => {
     let list = (type === CurrencySelectionTypes.input
       ? getWalletCurrencyList()
-      : swapCurrencyList) as { data: EnrichedExchangeAsset[]; title: string }[];
+      : activeSwapCurrencyList) as {
+      data: EnrichedExchangeAsset[];
+      title: string;
+    }[];
 
     // Remove tokens that show up in two lists and empty sections
     let uniqueIds: string[] = [];
@@ -293,7 +304,7 @@ export default function CurrencySelectModal() {
       });
     }
     return list.filter(section => section.data.length > 0);
-  }, [getWalletCurrencyList, type, swapCurrencyList]);
+  }, [activeSwapCurrencyList, getWalletCurrencyList, type]);
 
   const handleFavoriteAsset = useCallback(
     (asset, isFavorited) => {


### PR DESCRIPTION
Figma link (if any):
https://www.figma.com/file/SFfYzRoHlapEecS0LTLwhQ/Swap-Aggregator-V2?node-id=898%3A56888
https://www.figma.com/file/SFfYzRoHlapEecS0LTLwhQ/Swap-Aggregator-V2?node-id=28%3A28566

## What changed (plus any additional context for devs)
The currency select modal will now display exact matches on other networks when no applicable results are returned for the current network selection. Additionally, we now display a 'bridge' section when a verified asset is selected as the input and the selected network's results contain the corresponding bridged version of the asset in the verified section.

## Screen recordings / screenshots
iOS PoW
https://recordit.co/rxuKudh6ov
https://recordit.co/fjxphs6IFH
Android PoW
http://recordit.co/mVuqNV9blJ


## What to test
Confirm that network's with verified assets in common display the bridge asset section when applicable.
Confirm that crosschain exact matches display when a token is not available on the currently selected network but is present on others.

## e2e
I did not add e2e for this change because crosschain swap search results vary based on liquidity at the time of the search request. I am open to solutions for this issue if we deem additional testing necessary.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
