### PR TITLE
feat: enable react testing with jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,14 +6,14 @@ module.exports = {
   preset: 'react-native',
   setupFiles: ['./config/test/jest-setup.js'],
   testPathIgnorePatterns: ['node_modules', 'e2e'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
   transform: {
-    // https://kulshekhar.github.io/ts-jest/docs/guides/react-native
-    '\\.tsx?$': [
-      'ts-jest',
-      {
-        tsconfig: 'tsconfig.jest.json',
-      },
-    ],
+    // https://kulshekhar.github.io/ts-jest/docs/28.0/guides/react-native
+    '\\.tsx?$': 'ts-jest',
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,13 @@ module.exports = {
   setupFiles: ['./config/test/jest-setup.js'],
   testPathIgnorePatterns: ['node_modules', 'e2e'],
   transform: {
-    '\\.tsx?$': 'ts-jest',
+    // https://kulshekhar.github.io/ts-jest/docs/guides/react-native
+    '\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.jest.json',
+      },
+    ],
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|react-native-keyboard-area|@react-native(-community)?)/)',

--- a/package.json
+++ b/package.json
@@ -300,6 +300,7 @@
     "@lavamoat/allow-scripts": "2.0.3",
     "@nomiclabs/hardhat-ethers": "2.0.4",
     "@nomiclabs/hardhat-waffle": "2.0.1",
+    "@testing-library/react-native": "11.2.0",
     "@types/chroma-js": "2.1.3",
     "@types/d3-scale": "4.0.2",
     "@types/d3-shape": "3.0.2",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,6 +3647,13 @@
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
+"@jest/schemas@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
+  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/source-map@^28.1.2":
   version "28.1.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.1.2.tgz#7fe832b172b497d6663cdff6c13b0a920e139e24"
@@ -4968,6 +4975,13 @@
     "@tanstack/query-core" "^4.0.0-beta.1"
     "@types/use-sync-external-store" "^0.0.3"
     use-sync-external-store "^1.2.0"
+
+"@testing-library/react-native@11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-11.2.0.tgz#5408a745d71f87509763d73914c38db383094bdd"
+  integrity sha512-j3t78/htRkjPJjLlEjh9VxIAvcCJ85CG2L8mKH1mz9F3gyH65MH/JScOY2RHGOkTHGAGh5c+53Dw4u7J1WEJSA==
+  dependencies:
+    pretty-format "^29.0.3"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -15731,6 +15745,15 @@ pretty-format@^28.1.3:
   dependencies:
     "@jest/schemas" "^28.1.3"
     ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^29.0.3:
+  version "29.1.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.1.2.tgz#b1f6b75be7d699be1a051f5da36e8ae9e76a8e6a"
+  integrity sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 


### PR DESCRIPTION
Fixes RNBW-4513

Adds `@testing-library/react-native` and sets up a separate `tsconfig.jest.json` based on our root `tsconfig.json` so that we can test React code in Jest.

I extracted this PR from #4209 for easier reviewing.