### PR TITLE
Implement identify call with notifications permission status

### DIFF
--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -54,7 +54,10 @@ import {
   NotificationRelationship,
 } from './settings';
 import walletTypes from '@/helpers/walletTypes';
-import { trackTappedPushNotification } from '@/notifications/analytics';
+import {
+  trackPushNotificationPermissionStatus,
+  trackTappedPushNotification,
+} from '@/notifications/analytics';
 
 type Callback = () => void;
 
@@ -345,6 +348,8 @@ export const NotificationsHandler = ({ children, walletReady }: Props) => {
     notifeeForegroundEventListener.current = notifee.onForegroundEvent(
       handleNotificationPressed
     );
+
+    trackPushNotificationPermissionStatus();
 
     return () => {
       onTokenRefreshListener.current?.();

--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -55,7 +55,7 @@ import {
 } from './settings';
 import walletTypes from '@/helpers/walletTypes';
 import {
-  trackPushNotificationPermissionStatus,
+  resolveAndTrackPushNotificationPermissionStatus,
   trackTappedPushNotification,
 } from '@/notifications/analytics';
 
@@ -349,7 +349,7 @@ export const NotificationsHandler = ({ children, walletReady }: Props) => {
       handleNotificationPressed
     );
 
-    trackPushNotificationPermissionStatus();
+    resolveAndTrackPushNotificationPermissionStatus();
 
     return () => {
       onTokenRefreshListener.current?.();

--- a/src/notifications/analytics.ts
+++ b/src/notifications/analytics.ts
@@ -32,17 +32,26 @@ export const trackChangedNotificationSettings = (
   });
 };
 
-export const trackPushNotificationPermissionStatus = async () => {
-  const permissionStatus = await getPermissionStatus();
-  let statusToReport = 'never asked';
+export const trackPushNotificationPermissionStatus = (
+  status: PushNotificationPermissionStatus
+) => {
+  analytics.identify(undefined, { notificationsPermissionStatus: status });
+};
 
-  if (permissionStatus === messaging.AuthorizationStatus.AUTHORIZED) {
+type PushNotificationPermissionStatus = 'enabled' | 'disabled' | 'never asked';
+
+export const resolveAndTrackPushNotificationPermissionStatus = async () => {
+  const permissionStatus = await getPermissionStatus();
+  let statusToReport: PushNotificationPermissionStatus = 'never asked';
+
+  if (
+    permissionStatus === messaging.AuthorizationStatus.AUTHORIZED ||
+    permissionStatus === messaging.AuthorizationStatus.PROVISIONAL
+  ) {
     statusToReport = 'enabled';
   } else if (permissionStatus === messaging.AuthorizationStatus.DENIED) {
     statusToReport = 'disabled';
   }
 
-  analytics.identify(undefined, {
-    notificationsPermissionStatus: statusToReport,
-  });
+  trackPushNotificationPermissionStatus(statusToReport);
 };

--- a/src/notifications/analytics.ts
+++ b/src/notifications/analytics.ts
@@ -4,6 +4,8 @@ import {
   NotificationRelationshipType,
   NotificationTopicType,
 } from './settings';
+import { getPermissionStatus } from '@/notifications/permissions';
+import messaging from '@react-native-firebase/messaging';
 
 export const trackTappedPushNotification = (
   notification: MinimalNotification | undefined
@@ -27,5 +29,20 @@ export const trackChangedNotificationSettings = (
     topic,
     type,
     action,
+  });
+};
+
+export const trackPushNotificationPermissionStatus = async () => {
+  const permissionStatus = await getPermissionStatus();
+  let statusToReport = 'never asked';
+
+  if (permissionStatus === messaging.AuthorizationStatus.AUTHORIZED) {
+    statusToReport = 'enabled';
+  } else if (permissionStatus === messaging.AuthorizationStatus.DENIED) {
+    statusToReport = 'disabled';
+  }
+
+  analytics.identify(undefined, {
+    notificationsPermissionStatus: statusToReport,
   });
 };

--- a/src/notifications/permissions.ts
+++ b/src/notifications/permissions.ts
@@ -4,10 +4,11 @@ import logger from 'logger';
 import { Alert } from '@/components/alerts';
 import lang from 'i18n-js';
 import { saveFCMToken } from '@/notifications/tokens';
+import { trackPushNotificationPermissionStatus } from '@/notifications/analytics';
 
 export const getPermissionStatus = () => messaging().hasPermission();
 
-export const requestPermission = () => {
+export const requestPermission = (): Promise<boolean> => {
   return new Promise((resolve, reject) => {
     requestNotifications(['alert', 'sound', 'badge'])
       .then(({ status }) => {
@@ -38,7 +39,10 @@ export const checkPushNotificationPermissions = async () => {
           {
             onPress: async () => {
               try {
-                await requestPermission();
+                const status = await requestPermission();
+                trackPushNotificationPermissionStatus(
+                  status ? 'enabled' : 'disabled'
+                );
                 await saveFCMToken();
               } catch (error) {
                 logger.log('ERROR while getting permissions', error);

--- a/src/notifications/settings.ts
+++ b/src/notifications/settings.ts
@@ -39,7 +39,7 @@ const storage = new MMKV({
   id: STORAGE_IDS.NOTIFICATIONS,
 });
 
-/* 
+/**
   Grabs notification settings for all wallets if they exist,
   otherwise returns an empty array.
 */
@@ -57,7 +57,7 @@ export const getExistingGroupSettingsFromStorage = () => {
   return [];
 };
 
-/* 
+/**
   Hook to constantly listen to notification settings.
 */
 export const useAllNotificationSettingsFromStorage = () => {
@@ -85,7 +85,7 @@ export const useAllNotificationSettingsFromStorage = () => {
   return { notificationSettings, existingGroupSettings };
 };
 
-/*
+/**
   Checks if notification settings exist for a wallet and returns a boolean.
 */
 export const walletHasNotificationSettings = (address: string) => {
@@ -97,7 +97,7 @@ export const walletHasNotificationSettings = (address: string) => {
   return !!settings;
 };
 
-/*
+/**
   1. Reads notification settings for all wallets from storage.
   2. Matches settings for the wallet with the given address.
   3. Excludes that wallet from the array and saves the new array.
@@ -120,7 +120,7 @@ export const removeNotificationSettingsForWallet = (address: string) => {
   storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(newSettings));
 };
 
-/* 
+/**
   1. Checks if notification settings already exist for the given address.
   2. Grabs all notification settings from storage.
   3. Appends default settings for the given address to the array.
@@ -201,7 +201,7 @@ export const addDefaultNotificationSettingsForWallet = (
   }
 };
 
-/* 
+/**
   Checks if group notification settings are present in storage
   and adds default values for them if they do not exist.
 */
@@ -220,8 +220,8 @@ export const addDefaultNotificationGroupSettings = () => {
 // Runs the above function when the app is loaded to make sure settings are always present.
 addDefaultNotificationGroupSettings();
 
-/*
-  * Hook for getting and setting notification settings for a single wallet.
+/**
+  Hook for getting and setting notification settings for a single wallet.
 
   Returns an object with the wallet address, enabled/disabled topics, relationship,
   and a main boolean for enabling/disabling all notifications for this wallet.
@@ -271,7 +271,7 @@ export const updateSettingsForWallets = (
   storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(newSettings));
 };
 
-/* 
+/**
   Hook for getting and setting notification settings for all wallets 
   in an owned/watched group.
 
@@ -388,7 +388,7 @@ export const useWalletGroupNotificationSettings = () => {
   };
 };
 
-/*
+/**
   Function for enabling/disabling all notifications for a group of wallets.
   Also used to batch toggle notifications for a single wallet 
   when using the `Allow Notifications` switch in the wallet settings view.
@@ -429,7 +429,7 @@ export function toggleGroupNotifications(
   }
 }
 
-/*
+/**
   Function for subscribing/unsubscribing a wallet to/from a single notification topic.  
 */
 export function toggleTopicForWallet(
@@ -455,7 +455,7 @@ export function toggleTopicForWallet(
   }
 }
 
-/*
+/**
   Firebase functions for subscribing/unsubscribing to topics.
 */
 const subscribeWalletToAllNotificationTopics = async (


### PR DESCRIPTION
Fixes TEAM2-522
Figma link (if any):

## What changed (plus any additional context for devs)
* Added an identify call that will update the user property for notification permission status on every app launch and whenever the user grants or denies push notification

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

* Check if the identify call makes it to segment properly

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
