### PR TITLE
[TEAM2-520] Allow Crosschain Token Selection in Get $ASSET Expanded State Flow

### DIFF
--- a/src/screens/ExchangeModal.tsx
+++ b/src/screens/ExchangeModal.tsx
@@ -271,12 +271,6 @@ export default function ExchangeModal({
   const defaultOutputAssetOverride = useMemo(() => {
     const newOutput = defaultOutputAsset;
 
-    // just let this pass through if crosschain swaps are enabled
-    // TODO: remove this memoized value when crosschain swaps is released
-    if (crosschainSwapsEnabled) {
-      return newOutput;
-    }
-
     if (
       defaultInputAsset &&
       defaultOutputAsset &&
@@ -288,18 +282,19 @@ export default function ExchangeModal({
             ? 'ethereum'
             : defaultInputAsset?.type
         ]?.address;
-      if (crosschainImplementation) {
-        if (defaultInputAsset.type !== Network.mainnet) {
-          newOutput.mainnet_address = defaultOutputAsset.address;
+      if (crosschainImplementation || crosschainSwapsEnabled) {
+        if (!crosschainSwapsEnabled) {
+          newOutput.address =
+            crosschainImplementation || defaultOutputAsset.address;
+          if (defaultInputAsset.type !== Network.mainnet) {
+            newOutput.mainnet_address = defaultOutputAsset.address;
+          }
+          newOutput.type = defaultInputAsset.type;
         }
-        newOutput.address =
-          crosschainImplementation || defaultOutputAsset.address;
-        newOutput.type = defaultInputAsset.type;
         newOutput.uniqueId =
           newOutput.type === Network.mainnet
             ? defaultOutputAsset?.address
             : `${defaultOutputAsset?.address}_${defaultOutputAsset?.type}`;
-        logger.debug('new output confirmed: ', newOutput);
         return newOutput;
       } else {
         return null;

--- a/src/screens/ExchangeModal.tsx
+++ b/src/screens/ExchangeModal.tsx
@@ -276,16 +276,18 @@ export default function ExchangeModal({
       defaultOutputAsset &&
       defaultInputAsset.type !== defaultOutputAsset.type
     ) {
-      const crosschainImplementation =
+      // find address for output asset on the input's network
+      // TODO: this value can be removed after the crosschain swaps flag is no longer necessary
+      const inputNetworkImplementationAddress =
         defaultOutputAsset?.implementations?.[
           defaultInputAsset?.type === AssetType.token
             ? 'ethereum'
             : defaultInputAsset?.type
         ]?.address;
-      if (crosschainImplementation || crosschainSwapsEnabled) {
+      if (inputNetworkImplementationAddress || crosschainSwapsEnabled) {
         if (!crosschainSwapsEnabled) {
           newOutput.address =
-            crosschainImplementation || defaultOutputAsset.address;
+            inputNetworkImplementationAddress || defaultOutputAsset.address;
           if (defaultInputAsset.type !== Network.mainnet) {
             newOutput.mainnet_address = defaultOutputAsset.address;
           }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
The 'Get ${asset}' flow from expanded state did not previously support crosschain selections and would clear the output in the ExchangeModal. This now works.

## Screen recordings / screenshots
Bridge Case: https://recordit.co/MWdPKfXc9n
Crosschain: https://recordit.co/yh6i0iZXxS
Single chain: https://recordit.co/Fd9VGmxVHt


## What to test
Ensure the cases above behave appropriately and swaps are possible in each case after proceeding through the 'Get ${asset}' flow.


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
