### PR TITLE
Implement tracking number of wallets with notifications enabled

### DIFF
--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -19,7 +19,7 @@ import {
   updateSettingsForWallets,
   useAllNotificationSettingsFromStorage,
   useWalletGroupNotificationSettings,
-  WalletNotificationSettingsType,
+  WalletNotificationSettings,
 } from '@/notifications/settings';
 import { abbreviations, deviceUtils } from '@/utils';
 import { Box } from '@/design-system';
@@ -35,12 +35,12 @@ type WalletRowProps = {
   isTestnet: boolean;
   wallet: RainbowAccount;
   ens: string;
-  notificationSettings: WalletNotificationSettingsType[];
+  notificationSettings: WalletNotificationSettings[];
 };
 
 type WalletRowLabelProps = {
   groupOff: boolean;
-  notifications?: WalletNotificationSettingsType;
+  notifications?: WalletNotificationSettings;
 };
 
 const DEVICE_WIDTH = deviceUtils.dimensions.width;
@@ -101,7 +101,7 @@ const WalletRow = ({
 }: WalletRowProps) => {
   const { navigate } = useNavigation();
   const notificationSetting = notificationSettings?.find(
-    (x: WalletNotificationSettingsType) => x.address === wallet.address
+    (x: WalletNotificationSettings) => x.address === wallet.address
   );
   const cleanedUpLabel = useMemo(
     () => removeFirstEmojiFromString(wallet.label),

--- a/src/notifications/analytics.ts
+++ b/src/notifications/analytics.ts
@@ -1,8 +1,14 @@
 import { analytics } from '@/analytics';
 import { MinimalNotification } from '@/notifications/types';
 import {
+  GroupSettings,
+  NotificationRelationship,
   NotificationRelationshipType,
+  notificationSettingsStorage,
   NotificationTopicType,
+  WALLET_GROUPS_STORAGE_KEY,
+  WALLET_TOPICS_STORAGE_KEY,
+  WalletNotificationSettings,
 } from './settings';
 import { getPermissionStatus } from '@/notifications/permissions';
 import messaging from '@react-native-firebase/messaging';
@@ -54,4 +60,99 @@ export const resolveAndTrackPushNotificationPermissionStatus = async () => {
   }
 
   trackPushNotificationPermissionStatus(statusToReport);
+};
+
+export const trackWalletsSubscribedForNotifications = () => {
+  const walletsStringValue = notificationSettingsStorage.getString(
+    WALLET_TOPICS_STORAGE_KEY
+  );
+  const groupsStringValue = notificationSettingsStorage.getString(
+    WALLET_GROUPS_STORAGE_KEY
+  );
+
+  if (!walletsStringValue || !groupsStringValue) return;
+
+  const wallets = JSON.parse(
+    walletsStringValue
+  ) as WalletNotificationSettings[];
+  const groups = JSON.parse(groupsStringValue) as GroupSettings;
+
+  const { imported, watched } = countWalletsWithNotificationsTurnedOn(wallets);
+
+  trackNumberOfWalletsWithNotificationsTurnedOn(
+    groups[NotificationRelationship.OWNER] ? imported : 0,
+    groups[NotificationRelationship.WATCHER] ? watched : 0
+  );
+};
+
+export type NotificationSubscriptionChangesListener = {
+  remove: () => void;
+};
+
+export const registerNotificationSubscriptionChangesListener = (): NotificationSubscriptionChangesListener => {
+  return notificationSettingsStorage.addOnValueChangedListener(key => {
+    if (key === WALLET_GROUPS_STORAGE_KEY) {
+      const stringValue = notificationSettingsStorage.getString(key);
+      if (stringValue) {
+        const value = JSON.parse(stringValue) as GroupSettings;
+        onGroupStateChange(value);
+      }
+    } else if (key === WALLET_TOPICS_STORAGE_KEY) {
+      const stringValue = notificationSettingsStorage.getString(key);
+      if (stringValue) {
+        const value = JSON.parse(stringValue);
+        onTopicsStateChange(value);
+      }
+    }
+  });
+};
+
+const onGroupStateChange = (state: GroupSettings) => {
+  const stringValue = notificationSettingsStorage.getString(
+    WALLET_TOPICS_STORAGE_KEY
+  );
+
+  if (!stringValue) return;
+
+  const wallets = JSON.parse(stringValue) as WalletNotificationSettings[];
+  const { imported, watched } = countWalletsWithNotificationsTurnedOn(wallets);
+
+  trackNumberOfWalletsWithNotificationsTurnedOn(
+    state[NotificationRelationship.OWNER] ? imported : 0,
+    state[NotificationRelationship.WATCHER] ? watched : 0
+  );
+};
+
+const onTopicsStateChange = (state: WalletNotificationSettings[]) => {
+  const { imported, watched } = countWalletsWithNotificationsTurnedOn(state);
+
+  trackNumberOfWalletsWithNotificationsTurnedOn(imported, watched);
+};
+
+const countWalletsWithNotificationsTurnedOn = (
+  wallets: WalletNotificationSettings[]
+) => {
+  let imported = 0;
+  let watched = 0;
+
+  wallets.forEach(entry => {
+    if (!entry.enabled) return;
+    if (entry.type === NotificationRelationship.OWNER) imported += 1;
+    else watched += 1;
+  });
+
+  return {
+    imported,
+    watched,
+  };
+};
+
+const trackNumberOfWalletsWithNotificationsTurnedOn = (
+  imported: number,
+  watched: number
+) => {
+  analytics.identify(undefined, {
+    numberOfImportedWalletsWithNotificationsTurnedOn: imported,
+    numberOfWatchedWalletsWithNotificationsTurnedOn: watched,
+  });
 };

--- a/src/notifications/settings.ts
+++ b/src/notifications/settings.ts
@@ -24,18 +24,22 @@ export const NotificationRelationship = {
 export type NotificationTopicType = typeof NotificationTopic[keyof typeof NotificationTopic];
 export type NotificationRelationshipType = typeof NotificationRelationship[keyof typeof NotificationRelationship];
 
-export type WalletNotificationSettingsType = {
+export type WalletNotificationSettings = {
   address: string;
   topics: { [key: NotificationTopicType]: boolean };
   enabled: boolean;
   type: NotificationRelationshipType;
 };
 
-const WALLET_TOPICS_STORAGE_KEY = 'notificationSettings';
-const WALLET_GROUPS_STORAGE_KEY = 'notificationGroupToggle';
+export type GroupSettings = {
+  [key: NotificationRelationshipType]: boolean;
+};
+
+export const WALLET_TOPICS_STORAGE_KEY = 'notificationSettings';
+export const WALLET_GROUPS_STORAGE_KEY = 'notificationGroupToggle';
 const NOTIFICATIONS_DEFAULT_CHAIN_ID = 1; // hardcoded mainnet until we get multi-chain support
 
-const storage = new MMKV({
+export const notificationSettingsStorage = new MMKV({
   id: STORAGE_IDS.NOTIFICATIONS,
 });
 
@@ -44,17 +48,17 @@ const storage = new MMKV({
   otherwise returns an empty array.
 */
 export const getAllNotificationSettingsFromStorage = () => {
-  const data = storage.getString(WALLET_TOPICS_STORAGE_KEY);
+  const data = notificationSettingsStorage.getString(WALLET_TOPICS_STORAGE_KEY);
 
   if (data) return JSON.parse(data);
   return [];
 };
 
 export const getExistingGroupSettingsFromStorage = () => {
-  const data = storage.getString(WALLET_GROUPS_STORAGE_KEY);
+  const data = notificationSettingsStorage.getString(WALLET_GROUPS_STORAGE_KEY);
 
   if (data) return JSON.parse(data);
-  return [];
+  return {};
 };
 
 /**
@@ -65,20 +69,23 @@ export const useAllNotificationSettingsFromStorage = () => {
   const existingGroupSettingsData = getExistingGroupSettingsFromStorage();
 
   const [notificationSettings, setNotificationSettings] = useState<
-    WalletNotificationSettingsType[]
+    WalletNotificationSettings[]
   >(data);
-  const [existingGroupSettings, setExistingGroupSettings] = useState<{
-    [key: NotificationRelationshipType]: boolean;
-  }>(existingGroupSettingsData);
-  const listener = storage.addOnValueChangedListener(changedKey => {
-    if (changedKey === WALLET_TOPICS_STORAGE_KEY) {
-      const newSettings = storage.getString(changedKey);
-      newSettings && setNotificationSettings(JSON.parse(newSettings));
-    } else if (changedKey === WALLET_GROUPS_STORAGE_KEY) {
-      const newSettings = storage.getString(changedKey);
-      newSettings && setExistingGroupSettings(JSON.parse(newSettings));
+  const [
+    existingGroupSettings,
+    setExistingGroupSettings,
+  ] = useState<GroupSettings>(existingGroupSettingsData);
+  const listener = notificationSettingsStorage.addOnValueChangedListener(
+    changedKey => {
+      if (changedKey === WALLET_TOPICS_STORAGE_KEY) {
+        const newSettings = notificationSettingsStorage.getString(changedKey);
+        newSettings && setNotificationSettings(JSON.parse(newSettings));
+      } else if (changedKey === WALLET_GROUPS_STORAGE_KEY) {
+        const newSettings = notificationSettingsStorage.getString(changedKey);
+        newSettings && setExistingGroupSettings(JSON.parse(newSettings));
+      }
     }
-  });
+  );
   useEffect(() => () => {
     listener.remove();
   });
@@ -91,7 +98,7 @@ export const useAllNotificationSettingsFromStorage = () => {
 export const walletHasNotificationSettings = (address: string) => {
   const data = getAllNotificationSettingsFromStorage();
   const settings = data.find(
-    (wallet: WalletNotificationSettingsType) => wallet.address === address
+    (wallet: WalletNotificationSettings) => wallet.address === address
   );
 
   return !!settings;
@@ -106,10 +113,10 @@ export const walletHasNotificationSettings = (address: string) => {
 export const removeNotificationSettingsForWallet = (address: string) => {
   const allSettings = getAllNotificationSettingsFromStorage();
   const settingsForWallet = allSettings.find(
-    (wallet: WalletNotificationSettingsType) => wallet.address === address
+    (wallet: WalletNotificationSettings) => wallet.address === address
   );
   const newSettings = allSettings.filter(
-    (wallet: WalletNotificationSettingsType) => wallet.address !== address
+    (wallet: WalletNotificationSettings) => wallet.address !== address
   );
 
   unsubscribeWalletFromAllNotificationTopics(
@@ -117,7 +124,10 @@ export const removeNotificationSettingsForWallet = (address: string) => {
     NOTIFICATIONS_DEFAULT_CHAIN_ID,
     address
   );
-  storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(newSettings));
+  notificationSettingsStorage.set(
+    WALLET_TOPICS_STORAGE_KEY,
+    JSON.stringify(newSettings)
+  );
 };
 
 /**
@@ -155,7 +165,10 @@ export const addDefaultNotificationSettingsForWallet = (
       },
     ];
 
-    storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(newSettings));
+    notificationSettingsStorage.set(
+      WALLET_TOPICS_STORAGE_KEY,
+      JSON.stringify(newSettings)
+    );
 
     if (notificationsEnabled) {
       // only auto-subscribe to topics for owned wallets
@@ -168,7 +181,7 @@ export const addDefaultNotificationSettingsForWallet = (
   } else {
     const settings = getAllNotificationSettingsFromStorage();
     const settingsForWallet = settings.find(
-      (wallet: WalletNotificationSettingsType) => wallet.address === address
+      (wallet: WalletNotificationSettings) => wallet.address === address
     );
 
     // handle case where user imports an already watched wallet which becomes owned
@@ -178,7 +191,7 @@ export const addDefaultNotificationSettingsForWallet = (
       );
 
       const settingsIndex = settings.findIndex(
-        (wallet: WalletNotificationSettingsType) => wallet.address === address
+        (wallet: WalletNotificationSettings) => wallet.address === address
       );
 
       unsubscribeWalletFromAllNotificationTopics(
@@ -196,7 +209,10 @@ export const addDefaultNotificationSettingsForWallet = (
       settings[settingsIndex].enabled = true;
       settings[settingsIndex].topics = defaultEnabledTopicSettings;
 
-      storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(settings));
+      notificationSettingsStorage.set(
+        WALLET_TOPICS_STORAGE_KEY,
+        JSON.stringify(settings)
+      );
     }
   }
 };
@@ -206,14 +222,17 @@ export const addDefaultNotificationSettingsForWallet = (
   and adds default values for them if they do not exist.
 */
 export const addDefaultNotificationGroupSettings = () => {
-  const data = storage.getString(WALLET_GROUPS_STORAGE_KEY);
+  const data = notificationSettingsStorage.getString(WALLET_GROUPS_STORAGE_KEY);
 
   if (!data) {
     const defaultSettings = {
       [NotificationRelationship.OWNER]: true,
       [NotificationRelationship.WATCHER]: false,
     };
-    storage.set(WALLET_GROUPS_STORAGE_KEY, JSON.stringify(defaultSettings));
+    notificationSettingsStorage.set(
+      WALLET_GROUPS_STORAGE_KEY,
+      JSON.stringify(defaultSettings)
+    );
   }
 };
 
@@ -233,22 +252,25 @@ addDefaultNotificationGroupSettings();
 export const useNotificationSettings = (address: string) => {
   const data = getAllNotificationSettingsFromStorage();
   const settingsForWallet = data.find(
-    (wallet: WalletNotificationSettingsType) => wallet.address === address
+    (wallet: WalletNotificationSettings) => wallet.address === address
   );
   const [notifications, setNotificationSettings] = useState(settingsForWallet);
 
   const updateSettings = useCallback(
     (options: object) => {
-      const newSettings = data.map((wallet: WalletNotificationSettingsType) => {
+      const newSettings = data.map((wallet: WalletNotificationSettings) => {
         if (wallet.address === address) {
           return { ...wallet, ...options };
         }
         return wallet;
       });
       const newSettingsForWallet = newSettings.find(
-        (wallet: WalletNotificationSettingsType) => wallet.address === address
+        (wallet: WalletNotificationSettings) => wallet.address === address
       );
-      storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(newSettings));
+      notificationSettingsStorage.set(
+        WALLET_TOPICS_STORAGE_KEY,
+        JSON.stringify(newSettings)
+      );
       setNotificationSettings(newSettingsForWallet);
     },
     [address, data]
@@ -262,13 +284,16 @@ export const updateSettingsForWallets = (
   options: object
 ) => {
   const data = getAllNotificationSettingsFromStorage();
-  const newSettings = data.map((wallet: WalletNotificationSettingsType) => {
+  const newSettings = data.map((wallet: WalletNotificationSettings) => {
     if (wallet.type === type) {
       return { ...wallet, ...options };
     }
     return wallet;
   });
-  storage.set(WALLET_TOPICS_STORAGE_KEY, JSON.stringify(newSettings));
+  notificationSettingsStorage.set(
+    WALLET_TOPICS_STORAGE_KEY,
+    JSON.stringify(newSettings)
+  );
 };
 
 /**
@@ -297,11 +322,11 @@ export const useWalletGroupNotificationSettings = () => {
     ownedWallets,
   } = useMemo(() => {
     const ownedWallets = notificationSettings.filter(
-      (wallet: WalletNotificationSettingsType) =>
+      (wallet: WalletNotificationSettings) =>
         wallet.type === NotificationRelationship.OWNER
     );
     const watchedWallets = notificationSettings.filter(
-      (wallet: WalletNotificationSettingsType) =>
+      (wallet: WalletNotificationSettings) =>
         wallet.type === NotificationRelationship.WATCHER
     );
     const allOwnedWalletsDisabled = ownedWallets.reduce(
@@ -331,7 +356,10 @@ export const useWalletGroupNotificationSettings = () => {
   const updateSectionSettings = useCallback(
     (options: object) => {
       const newSettings = { ...existingGroupSettings, ...options };
-      storage.set(WALLET_GROUPS_STORAGE_KEY, JSON.stringify(newSettings));
+      notificationSettingsStorage.set(
+        WALLET_GROUPS_STORAGE_KEY,
+        JSON.stringify(newSettings)
+      );
     },
     [existingGroupSettings]
   );
@@ -342,7 +370,10 @@ export const useWalletGroupNotificationSettings = () => {
       const newOwnerEnabled = newSettings[NotificationRelationship.OWNER];
       const newWatcherEnabled = newSettings[NotificationRelationship.WATCHER];
 
-      storage.set(WALLET_GROUPS_STORAGE_KEY, JSON.stringify(newSettings));
+      notificationSettingsStorage.set(
+        WALLET_GROUPS_STORAGE_KEY,
+        JSON.stringify(newSettings)
+      );
 
       if (newOwnerEnabled !== ownerEnabled) {
         toggleGroupNotifications(
@@ -394,13 +425,13 @@ export const useWalletGroupNotificationSettings = () => {
   when using the `Allow Notifications` switch in the wallet settings view.
 */
 export function toggleGroupNotifications(
-  wallets: WalletNotificationSettingsType[],
+  wallets: WalletNotificationSettings[],
   relationship: NotificationRelationshipType,
   enableNotifications: boolean
 ) {
   if (enableNotifications) {
     // loop through all owned wallets, loop through their topics, subscribe to enabled topics
-    wallets.forEach((wallet: WalletNotificationSettingsType) => {
+    wallets.forEach((wallet: WalletNotificationSettings) => {
       const { topics, address } = wallet;
       // when toggling a whole group, check if notifications
       // are specifically enabled for this wallet
@@ -419,7 +450,7 @@ export function toggleGroupNotifications(
     });
   } else {
     // loop through all owned wallets, unsubscribe from all topics
-    wallets.forEach((wallet: WalletNotificationSettingsType) => {
+    wallets.forEach((wallet: WalletNotificationSettings) => {
       unsubscribeWalletFromAllNotificationTopics(
         relationship,
         NOTIFICATIONS_DEFAULT_CHAIN_ID,


### PR DESCRIPTION
Fixes TEAM2-521
Figma link (if any):

## What changed (plus any additional context for devs)
* Added identify call which tracks the number of wallets for watched and imported that have notifications turned on and updates it every time something changes in the settings

## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
* Check if it works and causes no issues
* Observe if the identify calls make it to segment (with segment debugger)

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
