### PR TITLE
feat: local storage interface for MMKV

### DIFF
--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -1,0 +1,120 @@
+# `@/storage`
+
+We use MMKV for offline local storage on user's devices, and instead of many
+instances of MMKV, we have only a few. They're each intended for differently
+"scoped" data i.e. some data is specific to a single device, and other data is
+specific to a single wallet or network.
+
+## Usage
+
+Import the correctly scoped store from `@/storage`. Each instance of `Storage`
+(the base class, not to be used directly), has the following interface:
+
+- `set([...scope, key], value)`
+- `get([...scope, key])`
+- `remove([...scope, key])`
+- `removeMany([...scope], [...keys])`
+
+For example, using our `device` store looks like this, since it's scoped to the
+device (the most base level scope):
+
+```typescript
+import * as storage from '@/storage'
+
+storage.device.set(['doNotTrack'], true)
+storage.device.get(['doNotTrack'])
+storage.device.remove(['doNotTrack'])
+storage.device.removeMany([], ['doNotTrack'])
+```
+
+## TypeScript
+
+Stores are strongly typed, and when setting a given value, it will need to
+conform to the schemas defined in `@/storage/schemas`. When getting a value, it
+will be returned to you as the type defined in its schema.
+
+## Scoped Stores
+
+Some stores are (will be) scoped to either network, wallet, or both. In this
+case, storage instances are created with type-guards, like this:
+
+```typescript
+type NetworkAndWalletSchema = {
+   contacts: Contact[]
+}
+
+enum Network {
+   Mainnet = 'mainnet',
+   Optimism = 'optimism',
+}
+
+type WalletAddress = `Ox${string}`
+
+const networkAndWallet = new Storage<[Network, WalletAddress], NetworkAndWalletSchema>({
+   id: 'networkAndWallet'
+})
+
+networkAndWallet.set([Network.Mainnet, '0x12345', 'contacts'], [
+   { name: 'rainbow.eth', address: '0x67890' }
+])
+
+const contacts: Contact[] = networkAndWallet.get([Network.Mainnet, '0x12345', 'contacts'])
+```
+
+Here, if `[Network.Mainnet, '0x12345']` are not supplied along with the key of
+`contacts`, type checking will fail. If used in JavaScript, *it will return undefined.*
+
+## Future Work
+
+For storage instances that require scopes, it may be useful in the future to
+define wrappers around `Storage` that can cache references to the current
+network and/or wallet. That way, we don't have to pass in the `Network` and
+`WalletAddress` every time.
+
+That would look something like this:
+
+```typescript
+import { Storage } from '@/storage'
+
+class NetworkAndWalletStorage<Schema> {
+  walletAddress?: WalletAddress
+  network?: Network
+  storage: Storage<[Network, WalletAddress], Schema>
+
+  constructor() {
+    this.storage = new Storage<[Network, WalletAddress], Schema>({
+       id: 'networkAndWallet'
+    })
+  }
+
+  setWalletAddress(walletAddress: string) {
+    this.walletAddress = walletAddress
+  }
+
+  setNetwork(network: string) {
+    this.network = network
+  }
+
+  set<Key extends keyof Schema>(key: Key, data: Schema[Key]): void {
+    if (!this.network || !this.walletAddress) {
+      throw new Error(`ScopedStorage requires both network and walletAddress`)
+    }
+
+    this.storage.set([this.network, this.walletAddress, key], data)
+  }
+
+  ...etc...
+}
+
+export networkAndWallet = new NetworkAndWalletStorage()
+```
+
+Then, we could set/get values by key only:
+
+```typescript
+import { networkAndWallet } from '@/storage/networkAndWallet'
+
+networkAndWallet.set('contacts', [
+   { name: 'rainbow.eth', address: '0x67890' }
+])
+```

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -19,12 +19,12 @@ For example, using our `device` store looks like this, since it's scoped to the
 device (the most base level scope):
 
 ```typescript
-import * as storage from '@/storage'
+import * as storage from '@/storage';
 
-storage.device.set(['doNotTrack'], true)
-storage.device.get(['doNotTrack'])
-storage.device.remove(['doNotTrack'])
-storage.device.removeMany([], ['doNotTrack'])
+storage.device.set(['doNotTrack'], true);
+storage.device.get(['doNotTrack']);
+storage.device.remove(['doNotTrack']);
+storage.device.removeMany([], ['doNotTrack']);
 ```
 
 ## TypeScript
@@ -40,29 +40,37 @@ case, storage instances are created with type-guards, like this:
 
 ```typescript
 type NetworkAndWalletSchema = {
-   contacts: Contact[]
-}
+  contacts: Contact[];
+};
 
 enum Network {
-   Mainnet = 'mainnet',
-   Optimism = 'optimism',
+  Mainnet = 'mainnet',
+  Optimism = 'optimism',
 }
 
-type WalletAddress = `Ox${string}`
+type WalletAddress = `Ox${string}`;
 
-const networkAndWallet = new Storage<[Network, WalletAddress], NetworkAndWalletSchema>({
-   id: 'networkAndWallet'
-})
+const networkAndWallet = new Storage<
+  [Network, WalletAddress],
+  NetworkAndWalletSchema
+>({
+  id: 'networkAndWallet',
+});
 
-networkAndWallet.set([Network.Mainnet, '0x12345', 'contacts'], [
-   { name: 'rainbow.eth', address: '0x67890' }
-])
+networkAndWallet.set(
+  [Network.Mainnet, '0x12345', 'contacts'],
+  [{ name: 'rainbow.eth', address: '0x67890' }]
+);
 
-const contacts: Contact[] = networkAndWallet.get([Network.Mainnet, '0x12345', 'contacts'])
+const contacts: Contact[] = networkAndWallet.get([
+  Network.Mainnet,
+  '0x12345',
+  'contacts',
+]);
 ```
 
 Here, if `[Network.Mainnet, '0x12345']` are not supplied along with the key of
-`contacts`, type checking will fail. If used in JavaScript, *it will return undefined.*
+`contacts`, type checking will fail. If used in JavaScript, _it will return undefined._
 
 ## Future Work
 
@@ -112,9 +120,7 @@ export networkAndWallet = new NetworkAndWalletStorage()
 Then, we could set/get values by key only:
 
 ```typescript
-import { networkAndWallet } from '@/storage/networkAndWallet'
+import { networkAndWallet } from '@/storage/networkAndWallet';
 
-networkAndWallet.set('contacts', [
-   { name: 'rainbow.eth', address: '0x67890' }
-])
+networkAndWallet.set('contacts', [{ name: 'rainbow.eth', address: '0x67890' }]);
 ```

--- a/src/storage/__tests__/storage.test.ts
+++ b/src/storage/__tests__/storage.test.ts
@@ -1,0 +1,83 @@
+import { jest, test, expect, beforeEach } from '@jest/globals';
+import { Storage } from '@/storage';
+
+jest.mock('react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map();
+
+    set(key: string, value: unknown) {
+      this._store.set(key, value);
+    }
+
+    getString(key: string) {
+      return this._store.get(key);
+    }
+
+    delete(key: string) {
+      return this._store.delete(key);
+    }
+  },
+}));
+
+type Schema = {
+  boo: boolean;
+  str: string | null;
+  num: number;
+  obj: Record<string, unknown>;
+};
+
+// fancy string template type
+type Wallet = `0x${string}`;
+
+const wallet: Wallet = `0x12345`;
+const store = new Storage<[Wallet], Schema>({ id: 'test' });
+
+beforeEach(() => {
+  store.removeMany([wallet], ['boo', 'str', 'num', 'obj']);
+});
+
+test(`stores and retrieves data`, () => {
+  store.set([wallet, 'boo'], true);
+  store.set([wallet, 'str'], 'string');
+  store.set([wallet, 'num'], 1);
+  expect(store.get([wallet, 'boo'])).toEqual(true);
+  expect(store.get([wallet, 'str'])).toEqual('string');
+  expect(store.get([wallet, 'num'])).toEqual(1);
+});
+
+test(`removes data`, () => {
+  store.set([wallet, 'boo'], true);
+  expect(store.get([wallet, 'boo'])).toEqual(true);
+  store.remove([wallet, 'boo']);
+  expect(store.get([wallet, 'boo'])).toEqual(undefined);
+});
+
+test(`removes multiple keys at once`, () => {
+  store.set([wallet, 'boo'], true);
+  store.set([wallet, 'str'], 'string');
+  store.set([wallet, 'num'], 1);
+  store.removeMany([wallet], ['boo', 'str', 'num']);
+  expect(store.get([wallet, 'boo'])).toEqual(undefined);
+  expect(store.get([wallet, 'str'])).toEqual(undefined);
+  expect(store.get([wallet, 'num'])).toEqual(undefined);
+});
+
+test(`concatenates keys`, () => {
+  store.remove([wallet, 'str']);
+  store.set([wallet, 'str'], 'concat');
+  // @ts-ignore accessing these properties for testing purposes only
+  expect(store.store.getString(`${wallet}${store.sep}str`)).toBeTruthy();
+});
+
+test(`can store falsy values`, () => {
+  store.set([wallet, 'str'], null);
+  store.set([wallet, 'num'], 0);
+  expect(store.get([wallet, 'str'])).toEqual(null);
+  expect(store.get([wallet, 'num'])).toEqual(0);
+});
+
+test(`can store objects`, () => {
+  const obj = { foo: true };
+  store.set([wallet, 'obj'], obj);
+  expect(store.get([wallet, 'obj'])).toEqual(obj);
+});

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,72 @@
+import { MMKV } from 'react-native-mmkv';
+
+import { Device } from '@/storage/schema';
+
+/**
+ * Generic storage class. DO NOT use this directly. Instead, use the exported
+ * storage instances below.
+ */
+export class Storage<Scopes extends unknown[], Schema> {
+  protected sep = ':';
+  protected store: MMKV;
+
+  constructor({ id }: { id: string }) {
+    this.store = new MMKV({ id });
+  }
+
+  /**
+   * Store a value in storage based on scopes and/or keys
+   *
+   *   `set([key], value)`
+   *   `set([scope, key], value)`
+   */
+  set<Key extends keyof Schema>(
+    scopes: [...Scopes, Key],
+    data: Schema[Key]
+  ): void {
+    // stored as `{ data: <value> }` structure to ease stringification
+    this.store.set(scopes.join(this.sep), JSON.stringify({ data }));
+  }
+
+  /**
+   * Get a value from storage based on scopes and/or keys
+   *
+   *   `get([key])`
+   *   `get([scope, key])`
+   */
+  get<Key extends keyof Schema>(
+    scopes: [...Scopes, Key]
+  ): Schema[Key] | undefined {
+    const res = this.store.getString(scopes.join(this.sep));
+    if (!res) return undefined;
+    // parsed from storage structure `{ data: <value> }`
+    return JSON.parse(res).data;
+  }
+
+  /**
+   * Remove a value from storage based on scopes and/or keys
+   *
+   *   `remove([key])`
+   *   `remove([scope, key])`
+   */
+  remove<Key extends keyof Schema>(scopes: [...Scopes, Key]) {
+    this.store.delete(scopes.join(this.sep));
+  }
+
+  /**
+   * Remove many values from the same storage scope by keys
+   *
+   *   `removeMany([], [key])`
+   *   `removeMany([scope], [key])`
+   */
+  removeMany<Key extends keyof Schema>(scopes: [...Scopes], keys: Key[]) {
+    keys.forEach(key => this.remove([...scopes, key]));
+  }
+}
+
+/**
+ * Device data that's specific to the device and does not vary based on network or active wallet
+ *
+ *   `global.set(['doNotTrack'], true)`
+ */
+export const device = new Storage<[], Device>({ id: 'global' });

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -1,0 +1,6 @@
+/**
+ * Device data that's specific to the device and does not vary based on network or active wallet
+ */
+export type Device = {
+  doNotTrack: boolean;
+};


### PR DESCRIPTION
Fixes RNBW-4319

## What changed (plus any additional context for devs)

Adds a more standardized, _strongly typed_, local storage interface. See the [README](https://github.com/rainbow-me/rainbow/blob/9bfbba2089449da3a8a8541f77baa098231dd653/src/storage/README.md) for more info. Looks like this (similar to React Query):

- `set([...scope, key], value)`
- `get([...scope, key])`
- `remove([...scope, key])`
- `removeMany([...scope], [...keys])`

For example, using our `device` store looks like this, since it's scoped to the
device (the most base level scope):

```typescript
import * as storage from '@/storage'

storage.device.set(['doNotTrack'], true)
storage.device.get(['doNotTrack'])
storage.device.remove(['doNotTrack'])
storage.device.removeMany([], ['doNotTrack'])
```

## Questions
1. We can create scoped stores (see [README](https://github.com/rainbow-me/rainbow/blob/9bfbba2089449da3a8a8541f77baa098231dd653/src/storage/README.md)) for data that's specific to a wallet or network. I think this pattern should allow for this flexibility. Anyone have concerns?

## What to test

There's a Jest test suite.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
