### PR TITLE
chore: deprecate `@/utils/logger` and `@/utils/sentry`

### DIFF
--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -3,6 +3,55 @@
 The main log handler of the Rainbow app, with support for log levels, debug
 contexts, and separate transports for production, dev, and test mode.
 
+<details>
+  <summary><strong>Coming from <code>@/utils/logger</code>?</strong> Here's a cheatsheet:</summary>
+
+  Methods `debug` and `warn` are the same, use them as you have been.
+  `prettyLog` is deprecated, just use one of the other methods.
+
+  The old `Logger.log` is now `logger.info`.
+
+  The old `Logger.sentry` and `Logger.error` should now look like this (see
+  below for more info):
+
+  ```typescript
+  import { logger, RainbowError } from '@/logger';
+
+  try {
+    // some async code
+  } catch (e) {
+    const error = new RainbowError('Descriptive error message');
+    logger.error(error, { ...metadata });
+  }
+  ```
+</details>
+
+<details>
+  <summary><strong>Coming from <code>@/utils/sentry</code>?</strong> Peep this:</summary>
+
+  All `addBreadcrumb` utils can be replicated with `logger.info`. Essentially,
+  this:
+
+  ```typescript
+  addDataBreadcrumb('Message', { clicked: true })
+  ```
+
+  Becomes this:
+
+  ```typescript
+  import { logger } from '@/logger';
+
+  logger.info(`Message`, { clicked: true });
+  ```
+
+  And for specific types of breadcrumbs, we can now use the built-in Sentry types
+  (see source file for options) like this:
+
+  ```typescript
+  logger.info(`From ${prevRoute} to ${nextRoute}`, { type: 'nav' });
+  ```
+</details>
+
 ## At a Glance
 
 The basic interface looks like this:

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -6,50 +6,52 @@ contexts, and separate transports for production, dev, and test mode.
 <details>
   <summary><strong>Coming from <code>@/utils/logger</code>?</strong> Here's a cheatsheet:</summary>
 
-  Methods `debug` and `warn` are the same, use them as you have been.
-  `prettyLog` is deprecated, just use one of the other methods.
+Methods `debug` and `warn` are the same, use them as you have been.
+`prettyLog` is deprecated, just use one of the other methods.
 
-  The old `Logger.log` is now `logger.info`.
+The old `Logger.log` is now `logger.info`.
 
-  The old `Logger.sentry` and `Logger.error` should now look like this (see
-  below for more info):
+The old `Logger.sentry` and `Logger.error` should now look like this (see
+below for more info):
 
-  ```typescript
-  import { logger, RainbowError } from '@/logger';
+```typescript
+import { logger, RainbowError } from '@/logger';
 
-  try {
-    // some async code
-  } catch (e) {
-    const error = new RainbowError('Descriptive error message');
-    logger.error(error, { ...metadata });
-  }
-  ```
+try {
+  // some async code
+} catch (e) {
+  const error = new RainbowError('Descriptive error message');
+  logger.error(error, { ...metadata });
+}
+```
+
 </details>
 
 <details>
   <summary><strong>Coming from <code>@/utils/sentry</code>?</strong> Peep this:</summary>
 
-  All `addBreadcrumb` utils can be replicated with `logger.info`. Essentially,
-  this:
+All `addBreadcrumb` utils can be replicated with `logger.info`. Essentially,
+this:
 
-  ```typescript
-  addDataBreadcrumb('Message', { clicked: true })
-  ```
+```typescript
+addDataBreadcrumb('Message', { clicked: true });
+```
 
-  Becomes this:
+Becomes this:
 
-  ```typescript
-  import { logger } from '@/logger';
+```typescript
+import { logger } from '@/logger';
 
-  logger.info(`Message`, { clicked: true });
-  ```
+logger.info(`Message`, { clicked: true });
+```
 
-  And for specific types of breadcrumbs, we can now use the built-in Sentry types
-  (see source file for options) like this:
+And for specific types of breadcrumbs, we can now use the built-in Sentry types
+(see source file for options) like this:
 
-  ```typescript
-  logger.info(`From ${prevRoute} to ${nextRoute}`, { type: 'nav' });
-  ```
+```typescript
+logger.info(`From ${prevRoute} to ${nextRoute}`, { type: 'nav' });
+```
+
 </details>
 
 ## At a Glance

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,13 @@
 import { captureException } from '@sentry/react-native';
 import sentryUtils from './sentry';
 
+/**
+ * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+ */
 const Logger = {
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   debug(...args: any[]) {
     if (__DEV__) {
       const date = new Date().toLocaleTimeString();
@@ -10,12 +16,18 @@ const Logger = {
     }
   },
 
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   error(...args: any[]) {
     if (__DEV__) {
       console.error(...args); // eslint-disable-line no-console
     }
   },
 
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   log(...args: any[]) {
     if (__DEV__) {
       const date = new Date().toLocaleTimeString();
@@ -24,6 +36,9 @@ const Logger = {
     }
   },
 
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   prettyLog() {
     if (__DEV__) {
       const allArgs = Array.prototype.slice.call(arguments).map(arg => {
@@ -40,6 +55,10 @@ const Logger = {
       console.log(allArgs.length > 0 ? allArgs : allArgs[0]); // eslint-disable-line no-console
     }
   },
+
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   sentry(...args: any[]) {
     if (__DEV__) {
       const date = new Date().toLocaleTimeString();
@@ -54,6 +73,10 @@ const Logger = {
       sentryUtils.addDataBreadcrumb(args[0], safeData);
     }
   },
+
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   warn(...args: any[]) {
     if (__DEV__) {
       console.warn(...args); // eslint-disable-line no-console

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -23,8 +23,20 @@ const addNavBreadcrumb = (prevRoute: any, nextRoute: any, data: any) =>
     message: `From ${prevRoute} to ${nextRoute}`,
   });
 
+/**
+ * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+ */
 export default {
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   addDataBreadcrumb,
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   addInfoBreadcrumb,
+  /**
+   * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
+   */
   addNavBreadcrumb,
 };


### PR DESCRIPTION
Deprecates the old `@/utils/logger` and `@/utils/sentry` utils in favor of the new `@/logger`. No runtime code has been edited in this PR.

I've also added some collapsible sections to the logger docs to help with this transition.