### PR TITLE
[TEAM2-504] Spec swaps: Update CurrencySelectModal assets list UI when selecting input token

### DIFF
--- a/e2e/swapSheetFlow2.spec.js
+++ b/e2e/swapSheetFlow2.spec.js
@@ -74,9 +74,7 @@ describe('Swap Sheet Interaction Flow', () => {
 
   it('Should go to swap and try different cross chain swaps', async () => {
     await Helpers.waitAndTap('exchange-fab');
-    await Helpers.checkIfExists(
-      'currency-select-list-exchange-section-header-unswappableAssets'
-    );
+    await Helpers.checkIfExists('unswappableAssets');
     await Helpers.typeText('currency-select-search-input', 'DAI', true);
     await Helpers.tap('currency-select-list-exchange-coin-row-DAI-token');
 

--- a/e2e/swapSheetFlow2.spec.js
+++ b/e2e/swapSheetFlow2.spec.js
@@ -74,6 +74,9 @@ describe('Swap Sheet Interaction Flow', () => {
 
   it('Should go to swap and try different cross chain swaps', async () => {
     await Helpers.waitAndTap('exchange-fab');
+    await Helpers.checkIfExists(
+      'currency-select-list-exchange-section-header-unswappableAssets'
+    );
     await Helpers.typeText('currency-select-search-input', 'DAI', true);
     await Helpers.tap('currency-select-list-exchange-coin-row-DAI-token');
 

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -89,6 +89,7 @@ export default React.memo(function FastCurrencySelectionRow({
     name,
     testID,
     type,
+    disabled,
   },
 }: FastCurrencySelectionRowProps) {
   const { colors } = theme;
@@ -108,9 +109,10 @@ export default React.memo(function FastCurrencySelectionRow({
     <View style={sx.row}>
       <ButtonPressAnimation
         onPress={onPress}
-        style={sx.flex}
+        style={[sx.flex, disabled && { opacity: 0.5 }]}
         testID={rowTestID}
         wrapperStyle={sx.flex}
+        disabled={disabled}
       >
         <View style={sx.rootContainer}>
           <FastCoinIcon

--- a/src/components/exchange/ExchangeAssetList.tsx
+++ b/src/components/exchange/ExchangeAssetList.tsx
@@ -222,7 +222,10 @@ const ExchangeAssetList: ForwardRefRenderFunction<
         <Box paddingTop="10px" paddingBottom="2px" paddingLeft="20px">
           <HeaderBackground />
           <Box>
-            <TitleComponent color={section.color} testID={section.key}>
+            <TitleComponent
+              color={section.color}
+              testID={`currency-select-list-exchange-section-header-${section.key}`}
+            >
               {`${section.title}${isVerified ? '  􀅵' : ' '}`}
             </TitleComponent>
           </Box>

--- a/src/components/exchange/ExchangeAssetList.tsx
+++ b/src/components/exchange/ExchangeAssetList.tsx
@@ -222,10 +222,7 @@ const ExchangeAssetList: ForwardRefRenderFunction<
         <Box paddingTop="10px" paddingBottom="2px" paddingLeft="20px">
           <HeaderBackground />
           <Box>
-            <TitleComponent
-              color={section.color}
-              testID={`currency-select-list-exchange-section-header-${section.key}`}
-            >
+            <TitleComponent color={section.color} testID={section.key}>
               {`${section.title}${isVerified ? '  􀅵' : ' '}`}
             </TitleComponent>
           </Box>

--- a/src/helpers/tokenSectionTypes.ts
+++ b/src/helpers/tokenSectionTypes.ts
@@ -5,4 +5,5 @@ export default {
   lowLiquidityTokenSection: '􀇿 Low Liquidity',
   unverifiedTokenSection: '􀇿 Unverified',
   verifiedTokenSection: '􀇻 Rainbow Verified',
+  unswappableTokenSection: '􀘰 Not enough liquidity',
 };

--- a/src/helpers/tokenSectionTypes.ts
+++ b/src/helpers/tokenSectionTypes.ts
@@ -5,5 +5,5 @@ export default {
   lowLiquidityTokenSection: '􀇿 Low Liquidity',
   unverifiedTokenSection: '􀇿 Unverified',
   verifiedTokenSection: '􀇻 Rainbow Verified',
-  unswappableTokenSection: '􀘰 Not enough liquidity',
+  unswappableTokenSection: '􀘰 No trade routes',
 };

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -593,6 +593,7 @@ const useSwapCurrencyList = (
     inputCurrency?.name,
     colors.networkColors,
     isCrosschainSearch,
+    inputCurrency?.type,
   ]);
 
   const crosschainExactMatches = useMemo(() => {


### PR DESCRIPTION
Figma link (if any):  https://www.figma.com/file/SFfYzRoHlapEecS0LTLwhQ/Swap-Aggregator-V2?node-id=975%3A58443

## What changed (plus any additional context for devs)
This PR displays a disabled list with reduced opacity representing tokens the user holds that can not be swapped to the target network. We did not update designs to reflect the decision to move from grayscale to reduced opacity. Additionally the designs do not reflect the updated section header (I confirmed the copy with Daniel recently).
It's probably worth noting that we are not guaranteeing that a route is available for all tokens outside of the disabled list. We need to query the quotes endpoint after selection to confirm this, but they are at least swappable to the target network.

## Screen recordings / screenshots
https://recordit.co/h6EQoCyEZj


## What to test
Select an output token then navigate to the input selection screen and ensure the disabled list appears correctly. I would not worry too much about filtering accuracy, as this was dev QA'd in a previous ticket. This ticket just surfaces the unswappable tokens in the UI rather than completely filtering them.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
