### PR TITLE
fix: adjust background gradient in ExchangeAssetList headers

### DIFF
--- a/src/components/exchange/ExchangeAssetList.tsx
+++ b/src/components/exchange/ExchangeAssetList.tsx
@@ -47,7 +47,7 @@ const HeaderBackground = styled(LinearGradient).attrs(
   ({ theme: { colors } }: { theme: { colors: Colors } }) => ({
     colors: [colors.white, colors.alpha(colors.white, 0)],
     end: { x: 0.5, y: 1 },
-    locations: [0.55, 1],
+    locations: [0.65, 1],
     start: { x: 0.5, y: 0 },
   })
 )({
@@ -219,7 +219,11 @@ const ExchangeAssetList: ForwardRefRenderFunction<
         onPress={openVerifiedExplainer}
         scaleTo={0.96}
       >
-        <Box paddingTop="10px" paddingBottom="2px" paddingLeft="20px">
+        <Box
+          paddingTop={section.useGradientText ? '10px' : { custom: 14 }}
+          paddingBottom="4px"
+          paddingLeft="20px"
+        >
           <HeaderBackground />
           <Box>
             <TitleComponent color={section.color} testID={section.key}>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Makes a couple adjustments to the section headers in the swaps selection list view:
- gradient text was sitting lower than non-gradient, so I added a little extra padding to the top for non-gradient text
- gradient was overlaying first list item in default state
  - moved gradient start further down
  - shortening the gradient itself started to look bad, so added a little bottom padding to give it room so that it doesn't overlay the first list item


## 
<img width="459" alt="Screen Shot 2022-10-13 at 4 30 45 PM" src="https://user-images.githubusercontent.com/4732330/195715065-1195f8dc-d938-4393-b617-3fa2abce8111.png">
Screen recordings / screenshots

<img width="200" alt="Screen Shot 2022-10-13 at 4 30 23 PM" src="https://user-images.githubusercontent.com/4732330/195715074-e0044517-611b-44c1-b836-192ed3557abe.png">

<img width="225" alt="Screen Shot 2022-10-13 at 4 30 32 PM" src="https://user-images.githubusercontent.com/4732330/195715086-5724139c-2632-42ec-9f9a-0106f9ab32aa.png">

## What to test
I don't think this should affect anything else.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
