### PR TITLE
fix: restore add cash interstitial colors

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -258,7 +258,7 @@ const AddFundsInterstitial = ({ network }) => {
             <AmountButton
               amount={200}
               backgroundColor={colors.swapPurple}
-              color={colors.alpha(colors.blueGreyDark, 0.6)}
+              color={colors.neonSkyblue}
               onPress={handlePressAmount}
             />
             <AmountButton

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -251,19 +251,19 @@ const AddFundsInterstitial = ({ network }) => {
           <Row justify="space-between" marginVertical={30}>
             <AmountButton
               amount={100}
-              backgroundColor={colors.grey}
+              backgroundColor={colors.swapPurple}
               color={colors.neonSkyblue}
               onPress={handlePressAmount}
             />
             <AmountButton
               amount={200}
-              backgroundColor={colors.grey}
+              backgroundColor={colors.swapPurple}
               color={colors.alpha(colors.blueGreyDark, 0.6)}
               onPress={handlePressAmount}
             />
             <AmountButton
               amount={300}
-              backgroundColor={colors.grey}
+              backgroundColor={colors.purpleDark}
               color={colors.pinkLight}
               onPress={handlePressAmount}
             />


### PR DESCRIPTION
Fixes RNBW-4610
Figma link (if any):

## What changed (plus any additional context for devs)

regression from : https://github.com/rainbow-me/rainbow/commit/3ae8b949d8b9068c1b492501e94b0231a6b19ff5#diff-2449fdb4f4521419f1bfb0af536a96993ae87dedcb49e9295119813b548d7ccdR254


## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
https://cloud.skylarbarrera.com/Screen-Shot-2022-10-14-10-49-05.62.png


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
