### PR TITLE
feat: replace old logger in `model/keychain`

### DIFF
--- a/src/model/keychain.ts
+++ b/src/model/keychain.ts
@@ -1,4 +1,3 @@
-import { captureException, captureMessage } from '@sentry/react-native';
 import isNil from 'lodash/isNil';
 import DeviceInfo from 'react-native-device-info';
 import { IS_TESTING } from 'react-native-dotenv';
@@ -19,7 +18,7 @@ import {
   UserCredentials,
 } from 'react-native-keychain';
 import { delay } from '../helpers/utilities';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 
 interface AnonymousKey {
   length: number;
@@ -39,11 +38,12 @@ export async function saveString(
   return new Promise(async (resolve, reject) => {
     try {
       await setInternetCredentials(key, key, value, accessControlOptions);
-      logger.sentry(`Keychain: saved string for key: ${key}`);
+      logger.info(`Keychain: saved string for key: ${key}`);
       resolve();
     } catch (e) {
-      logger.sentry(`Keychain: failed to save string for key: ${key}`, e);
-      captureMessage('Keychain write first attempt failed');
+      logger.warn(
+        `Keychain: first attempt failed to save string for key: ${key}`
+      );
       await delay(1000);
       try {
         let acOptions = accessControlOptions;
@@ -53,13 +53,12 @@ export async function saveString(
           acOptions.accessControl = undefined;
         }
         await setInternetCredentials(key, key, value, acOptions);
-        logger.sentry(
-          `Keychain: saved string for key: ${key} on second attempt`
-        );
+        logger.info(`Keychain: saved string for key: ${key} on second attempt`);
         resolve();
       } catch (e) {
-        logger.sentry(`Keychain: failed to save string for key: ${key}`, e);
-        captureMessage('Keychain write second attempt failed');
+        logger.error(
+          new RainbowError(`Keychain: failed to save string for key: ${key}`)
+        );
         reject(e);
       }
     }
@@ -73,52 +72,60 @@ export async function loadString(
   try {
     const credentials = await getInternetCredentials(key, options);
     if (credentials) {
-      logger.log(`Keychain: loaded string for key: ${key}`);
+      logger.info(`Keychain: loaded string for key: ${key}`);
       return credentials.password;
     }
-    logger.sentry(`Keychain: string does not exist for key: ${key}`);
+    logger.error(
+      new RainbowError(`Keychain: string does not exist for key: ${key}`)
+    );
   } catch (err: any) {
     if (err.toString() === 'Error: User canceled the operation.') {
+      logger.warn(`Keychain: user canceled the operation`);
       return -1;
     }
     if (err.toString() === 'Error: Wrapped error: User not authenticated') {
+      logger.warn(`Keychain: user not authenticated`);
       return -2;
     }
     if (
       err.toString() ===
       'Error: The user name or passphrase you entered is not correct.'
     ) {
-      // Try reading from keychain once more
-      captureMessage('Keychain read first attempt failed');
+      logger.warn('Keychain read first attempt failed');
       await delay(1000);
       try {
         const credentials = await getInternetCredentials(key, options);
         if (credentials) {
-          logger.log(
+          logger.info(
             `Keychain: loaded string for key on second attempt: ${key}`
           );
           return credentials.password;
         }
-        logger.sentry(`Keychain: string does not exist for key: ${key}`);
+        logger.error(
+          new RainbowError(`Keychain: string does not exist for key: ${key}`)
+        );
       } catch (e) {
         if (err.toString() === 'Error: User canceled the operation.') {
+          logger.warn(`Keychain: user canceled the operation`);
           return -1;
         }
         if (err.toString() === 'Error: Wrapped error: User not authenticated') {
+          logger.warn(`Keychain: user not authenticated`);
           return -2;
         }
-        captureMessage('Keychain read second attempt failed');
-        logger.sentry(
-          `Keychain: failed to load string for key: ${key} error: ${err}`
+        logger.error(
+          new RainbowError(
+            `Keychain: failed to load string for key: ${key} error: ${err}`
+          )
         );
-        captureException(err);
       }
       return null;
     }
-    logger.sentry(
-      `Keychain: failed to load string for key: ${key} error: ${err}`
+    logger.error(
+      new RainbowError(
+        `Keychain: failed to load string for key: ${key} error: ${err}`
+      )
     );
-    captureException(err);
   }
   return null;
 }
@@ -143,13 +150,14 @@ export async function loadObject(
   }
   try {
     const objectValue = JSON.parse(jsonValue);
-    logger.log(`Keychain: parsed object for key: ${key}`);
+    logger.info(`Keychain: parsed object for key: ${key}`);
     return objectValue;
   } catch (err) {
-    logger.sentry(
-      `Keychain: failed to parse object for key: ${key} error: ${err}`
+    logger.error(
+      new RainbowError(
+        `Keychain: failed to parse object for key: ${key} error: ${err}`
+      )
     );
-    captureException(err);
   }
   return null;
 }
@@ -157,12 +165,13 @@ export async function loadObject(
 export async function remove(key: string): Promise<void> {
   try {
     await resetInternetCredentials(key);
-    logger.log(`Keychain: removed value for key: ${key}`);
+    logger.info(`Keychain: removed value for key: ${key}`);
   } catch (err) {
-    logger.log(
-      `Keychain: failed to remove value for key: ${key} error: ${err}`
+    logger.error(
+      new RainbowError(
+        `Keychain: failed to remove value for key: ${key} error: ${err}`
+      )
     );
-    captureException(err);
   }
 }
 
@@ -173,8 +182,9 @@ export async function loadAllKeys(): Promise<null | UserCredentials[]> {
       return response.results;
     }
   } catch (err) {
-    logger.sentry(`Keychain: failed to loadAllKeys error: ${err}`);
-    captureException(err);
+    logger.error(
+      new RainbowError(`Keychain: failed to loadAllKeys error: ${err}`)
+    );
   }
   return null;
 }
@@ -199,8 +209,9 @@ export async function loadAllKeysOnly(): Promise<null | string[]> {
       return response.results;
     }
   } catch (err) {
-    logger.log(`Keychain: failed to loadAllKeys error: ${err}`);
-    captureException(err);
+    logger.error(
+      new RainbowError(`Keychain: failed to loadAllKeys error: ${err}`)
+    );
   }
   return null;
 }
@@ -210,10 +221,11 @@ export async function hasKey(key: string): Promise<boolean | Result> {
     const result = await hasInternetCredentials(key);
     return result;
   } catch (err) {
-    logger.sentry(
-      `Keychain: failed to check if key ${key} exists -  error: ${err}`
+    logger.error(
+      new RainbowError(
+        `Keychain: failed to check if key ${key} exists -  error: ${err}`
+      )
     );
-    captureException(err);
   }
   return false;
 }
@@ -225,11 +237,10 @@ export async function wipeKeychain(): Promise<void> {
       await Promise.all(
         results?.map(result => resetInternetCredentials(result.username))
       );
-      logger.log('keychain wiped!');
+      logger.info('Keychain: wiped');
     }
   } catch (e) {
-    logger.sentry('error while wiping keychain');
-    captureException(e);
+    logger.error(new RainbowError('Keychain: error while wiping keychain'));
   }
 }
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Started doing this to help debug a problem and figured I'd finish it up. Only logger/Sentry changes. Note the difference between `info` and `warn`, and that `error` in turn calls `captureException`.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
