### PR TITLE
feat: async init App

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,4 +26,4 @@ require('react-native-gesture-handler');
 require('./shim');
 require('./src/model/config');
 
-require('./src/App');
+require('./src/init');

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/react-native';
 import { nanoid } from 'nanoid/non-secure';
 import React, { Component, createRef } from 'react';
 import {
-  AppRegistry,
   AppState,
   Dimensions,
   InteractionManager,
@@ -363,6 +362,6 @@ const PlaygroundWithReduxStore = () => (
   </ReduxProvider>
 );
 
-AppRegistry.registerComponent('Rainbow', () =>
-  designSystemPlaygroundEnabled ? PlaygroundWithReduxStore : RootWithCodePush
-);
+export const Application = designSystemPlaygroundEnabled
+  ? PlaygroundWithReduxStore
+  : RootWithCodePush;

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,9 @@
+import { AppRegistry } from 'react-native';
+
+async function initializeApplication() {
+  const { Application } = require('@/App');
+
+  AppRegistry.registerComponent('Rainbow', () => Application);
+}
+
+initializeApplication();


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Prepping for some small updates to the initialization flow that will require a small amount of async (may be sync) work up front i.e. load device ID, init Sentry, init Segment, then run app.

Originally I was going to do this in a single file, but I want to make sure that as little code as possible runs prior to Sentry instantiation, so I pulled it out of `App.js`.

## What to test
Basically check if it runs.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`team1/team2`, `critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
