### PR TITLE
feat: add new device ID handling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,6 +36,9 @@ src/redux/nonceManager.ts @derHowie @skylarbarrera @estrattonbailey
 # navigation
 src/navigation @jkadamczyk @skylarbarrera @estrattonbailey
 
+# analytics & logging
+src/analytics @estrattonbailey @skylarbarrera
+
 # APP INFRA
 package.json @salman-rb @skylarbarrera @estrattonbailey
 .eslintignore @salman-rb @estrattonbailey @skylarbarrera

--- a/config/test/jest-setup.js
+++ b/config/test/jest-setup.js
@@ -41,4 +41,20 @@ jest.mock('react-native-keychain-android-new', () => ({
   setGenericPassword: jest.fn(),
 }));
 
-jest.mock('react-native-mmkv');
+jest.mock('react-native-mmkv', () => ({
+  MMKV: class MMKVMock {
+    _store = new Map();
+
+    set(key, value) {
+      this._store.set(key, value);
+    }
+
+    getString(key) {
+      return this._store.get(key);
+    }
+
+    delete(key) {
+      return this._store.delete(key);
+    }
+  },
+}));

--- a/src/analytics/__tests__/utils.test.ts
+++ b/src/analytics/__tests__/utils.test.ts
@@ -1,0 +1,41 @@
+import { expect, test, describe, beforeEach } from '@jest/globals';
+import * as Sentry from '@sentry/react-native';
+
+import * as ls from '@/storage';
+import { getDeviceId } from '@/analytics/utils';
+import * as keychain from '@/model/keychain';
+
+jest.mock('@/model/keychain', () => ({
+  loadString: jest.fn(),
+}));
+
+jest.mock('@sentry/react-native', () => ({
+  setUser: jest.fn(),
+}));
+
+beforeEach(() => {
+  ls.device.remove(['id']);
+});
+
+describe(`@/analytics/utils`, () => {
+  test(`Returns an ID from storage`, async () => {
+    ls.device.set(['id'], 'foo');
+    expect(await getDeviceId()).toEqual('foo');
+  });
+
+  test(`Returns value from keychain if nothing in storage`, async () => {
+    // @ts-ignore it's mocked above
+    keychain.loadString.mockImplementation(() => {
+      return 'keychain';
+    });
+
+    expect(await getDeviceId()).toEqual('keychain');
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'keychain' });
+  });
+
+  test(`Creates fresh ID if no other exists`, async () => {
+    // @ts-ignore it's mocked above
+    keychain.loadString.mockImplementation(() => {});
+    expect(await getDeviceId()).toBeTruthy();
+  });
+});

--- a/src/analytics/utils.ts
+++ b/src/analytics/utils.ts
@@ -1,0 +1,42 @@
+import { nanoid } from 'nanoid/async';
+import * as Sentry from '@sentry/react-native';
+
+import * as ls from '@/storage';
+import * as keychain from '@/model/keychain';
+import { analyticsUserIdentifier } from '@/utils/keychainConstants';
+import { logger } from '@/logger';
+
+/**
+ * Returns our custom device ID from local storage. If one isn't set, it
+ * generates a new ID, stores it, and returns it.
+ */
+export async function getDeviceId(): Promise<string> {
+  const deviceIdFromStorage = ls.device.get(['id']);
+
+  if (deviceIdFromStorage) {
+    // if we have a ID in storage, we've already migrated
+    return deviceIdFromStorage;
+  } else {
+    // load old ID if exists
+    const deviceIdFromKeychain = await keychain.loadString(
+      analyticsUserIdentifier
+    );
+    const hasExistingDeviceId = typeof deviceIdFromKeychain === 'string';
+    // prefer old ID, otherwise create a new one
+    const deviceId = hasExistingDeviceId
+      ? deviceIdFromKeychain
+      : await nanoid();
+    // set ID
+    ls.device.set(['id'], deviceId);
+
+    // update Sentry user immediately
+    Sentry.setUser({ id: deviceId });
+
+    // log to Sentry
+    if (hasExistingDeviceId) {
+      logger.info(`Migrating device ID from keychain to local storage`);
+    }
+
+    return deviceId;
+  }
+}

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -2,5 +2,6 @@
  * Device data that's specific to the device and does not vary based on network or active wallet
  */
 export type Device = {
+  id: string;
   doNotTrack: boolean;
 };


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Adds a util that:
1. Returns the device ID from local storage if it exists
2. If it doesn't exist, tries to load one from keychain (where we previously stored this)
3. If nothing else exists, it's a new user, and we create an fresh ID

We then identify the user in Sentry immediately, and in all cases, return the device ID.

## What to test
There's a test suite.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
