### PR TITLE
feat: Token expanded state should show additional asset data on L2s/sidechains

### DIFF
--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -227,7 +227,7 @@ export default function ChartExpandedState({ asset }) {
   } = useAdditionalAssetData(
     asset?.address,
     assetWithPrice?.price?.value,
-    assetWithPrice?.type
+    ethereumUtils.getChainIdFromNetwork(assetWithPrice?.type)
   );
 
   // This one includes the original l2 address if exists

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -224,12 +224,16 @@ export default function ChartExpandedState({ asset }) {
     loading: additionalAssetDataLoading,
     links,
     networks,
-  } = useAdditionalAssetData(asset?.address, assetWithPrice?.price?.value);
+  } = useAdditionalAssetData(
+    asset?.address,
+    assetWithPrice?.price?.value,
+    assetWithPrice?.type
+  );
 
   // This one includes the original l2 address if exists
   const ogAsset = useMemo(() => {
     if (networks) {
-      let mappedNetworks = {};
+      const mappedNetworks = {};
       Object.keys(networks).forEach(
         chainId =>
           (mappedNetworks[
@@ -438,40 +442,38 @@ export default function ChartExpandedState({ asset }) {
           <AvailableNetworks asset={assetWithPrice} networks={networks} />
         </Box>
       )}
-      {!isL2 && (
-        <CarouselWrapper
-          isAnyItemLoading={additionalAssetDataLoading}
-          isAnyItemVisible={!!(totalVolume || totalLiquidity || marketCap)}
-          setCarouselHeight={setCarouselHeight}
-        >
-          <Carousel>
-            <CarouselItem
-              loading={additionalAssetDataLoading}
-              showDivider
-              title={lang.t('expanded_state.asset.volume_24_hours')}
-              weight="bold"
-            >
-              {totalVolume}
-            </CarouselItem>
-            <CarouselItem
-              loading={additionalAssetDataLoading}
-              showDivider
-              title={lang.t('expanded_state.asset.uniswap_liquidity')}
-              weight="bold"
-            >
-              {totalLiquidity}
-            </CarouselItem>
-            <CarouselItem
-              loading={additionalAssetDataLoading}
-              title={lang.t('expanded_state.asset.market_cap')}
-              weight="bold"
-            >
-              {marketCap}
-            </CarouselItem>
-          </Carousel>
-          <EdgeFade />
-        </CarouselWrapper>
-      )}
+      <CarouselWrapper
+        isAnyItemLoading={additionalAssetDataLoading}
+        isAnyItemVisible={!!(totalVolume || totalLiquidity || marketCap)}
+        setCarouselHeight={setCarouselHeight}
+      >
+        <Carousel>
+          <CarouselItem
+            loading={additionalAssetDataLoading}
+            showDivider
+            title={lang.t('expanded_state.asset.volume_24_hours')}
+            weight="bold"
+          >
+            {totalVolume}
+          </CarouselItem>
+          <CarouselItem
+            loading={additionalAssetDataLoading}
+            showDivider
+            title={lang.t('expanded_state.asset.uniswap_liquidity')}
+            weight="bold"
+          >
+            {totalLiquidity}
+          </CarouselItem>
+          <CarouselItem
+            loading={additionalAssetDataLoading}
+            title={lang.t('expanded_state.asset.market_cap')}
+            weight="bold"
+          >
+            {marketCap}
+          </CarouselItem>
+        </Carousel>
+        <EdgeFade />
+      </CarouselWrapper>
       <AdditionalContentWrapper
         onLayout={({
           nativeEvent: {

--- a/src/handlers/dispersion.ts
+++ b/src/handlers/dispersion.ts
@@ -85,25 +85,8 @@ export const getTrendingAddresses = async (): Promise<
 
 export const getAdditionalAssetData = async (
   address: EthereumAddress,
-  network: Network | string
+  chainId = 1
 ) => {
-  let chainId: number;
-
-  switch (network) {
-    case Network.arbitrum:
-      chainId = 42161;
-      break;
-    case Network.optimism:
-      chainId = 10;
-      break;
-    case Network.polygon:
-      chainId = 137;
-      break;
-    default:
-      chainId = 1;
-      break;
-  }
-
   try {
     const res = await dispersionApi.get(
       `/dispersion/v1/expanded/${chainId}/${address}`

--- a/src/handlers/dispersion.ts
+++ b/src/handlers/dispersion.ts
@@ -8,6 +8,7 @@ import {
 } from '@/entities';
 import UniswapAssetsCache from '@/utils/uniswapAssetsCache';
 import logger from '@/utils/logger';
+import { Network } from '@/helpers';
 
 const dispersionApi = new RainbowFetchClient({
   baseURL: 'https://metadata.p.rainbow.me',
@@ -82,9 +83,31 @@ export const getTrendingAddresses = async (): Promise<
   }
 };
 
-export const getAdditionalAssetData = async (address: EthereumAddress) => {
+export const getAdditionalAssetData = async (
+  address: EthereumAddress,
+  network: Network | string
+) => {
+  let chainId: number;
+
+  switch (network) {
+    case Network.arbitrum:
+      chainId = 42161;
+      break;
+    case Network.optimism:
+      chainId = 10;
+      break;
+    case Network.polygon:
+      chainId = 137;
+      break;
+    default:
+      chainId = 1;
+      break;
+  }
+
   try {
-    const res = await dispersionApi.get(`/dispersion/v1/expanded/1/${address}`);
+    const res = await dispersionApi.get(
+      `/dispersion/v1/expanded/${chainId}/${address}`
+    );
     return res?.data?.data ?? null;
   } catch (error) {
     logger.sentry(`Error fetching additional asset data: ${error}`);

--- a/src/hooks/useAdditionalAssetData.ts
+++ b/src/hooks/useAdditionalAssetData.ts
@@ -13,7 +13,7 @@ import { Network } from '@/helpers';
 export default function useAdditionalAssetData(
   rawAddress: EthereumAddress,
   tokenPrice = 0,
-  network: Network | string = Network.mainnet
+  chainId = 1
 ): {
   description?: string;
   loading: boolean;
@@ -25,7 +25,7 @@ export default function useAdditionalAssetData(
 } {
   const address = rawAddress === ETH_ADDRESS ? WETH_ADDRESS : rawAddress;
   const { data } = useQuery(['additionalAssetData', address], () =>
-    getAdditionalAssetData(address, network)
+    getAdditionalAssetData(address, chainId)
   );
   const { nativeCurrency } = useAccountSettings();
   const format = useCallback(

--- a/src/hooks/useAdditionalAssetData.ts
+++ b/src/hooks/useAdditionalAssetData.ts
@@ -8,10 +8,12 @@ import { bigNumberFormat } from '@/helpers/bigNumberFormat';
 import { greaterThanOrEqualTo, multiply } from '@/helpers/utilities';
 import { ETH_ADDRESS, WETH_ADDRESS } from '@/references';
 import { implementation } from '@/entities/dispersion';
+import { Network } from '@/helpers';
 
 export default function useAdditionalAssetData(
   rawAddress: EthereumAddress,
-  tokenPrice = 0
+  tokenPrice = 0,
+  network: Network | string = Network.mainnet
 ): {
   description?: string;
   loading: boolean;
@@ -23,7 +25,7 @@ export default function useAdditionalAssetData(
 } {
   const address = rawAddress === ETH_ADDRESS ? WETH_ADDRESS : rawAddress;
   const { data } = useQuery(['additionalAssetData', address], () =>
-    getAdditionalAssetData(address)
+    getAdditionalAssetData(address, network)
   );
   const { nativeCurrency } = useAccountSettings();
   const format = useCallback(


### PR DESCRIPTION
Fixes BACK-286

## What changed (plus any additional context for devs)
The token expanded state will now show the following data if availablle for tokens on L2/sidechains:
- 24h volume
- Market cap
- Description
- Socials

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->
<img src="https://user-images.githubusercontent.com/677680/196545371-bd531c5c-32c4-45b3-9c0f-5a84416b060b.png" width=45% /> <img src="https://user-images.githubusercontent.com/677680/196545374-3a568f54-9296-4dd9-922a-7b3bf828529d.png" width=45% /> 
<img src="https://user-images.githubusercontent.com/677680/196545381-c117c7bc-0319-4ea6-afea-a209359d0df0.png" width=45% /><img src="https://user-images.githubusercontent.com/677680/196545387-c0b30984-ae26-466c-871a-e5ac4e1d49e8.png" width=45% />


## What to test
The code I touched only affects token expanded state so look at tokens on different networks.

## Final checklist

- [x] Assigned individual reviewers?
- [ ] Added labels? (`critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
