### PR TITLE
hide flashbots protect detail row when swapping L2s

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsContent.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsContent.js
@@ -22,6 +22,7 @@ import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import { ethereumUtils } from '@/utils';
 import { useNavigation } from '@/navigation';
+import { Network } from '@/helpers';
 
 const Container = styled(Box).attrs({
   flex: 1,
@@ -91,7 +92,7 @@ export default function SwapDetailsContent({
               tradeDetails={tradeDetails}
             />
           )}
-          {flashbotsEnabled && (
+          {flashbotsEnabled && inputCurrencyNetwork === Network.mainnet && (
             <SwapDetailsRow
               labelPress={() =>
                 navigate(Routes.EXPLAIN_SHEET, {

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -428,7 +428,6 @@
       "slippage_tolerance": "Max Slippage",
       "source_picker": "Route Swaps via",
       "use_flashbots": "Use Flashbots",
-      "flashbots_protected": "Flashbots Protect enabled",
       "swapping_for_prefix": "Swapping for",
       "view_details": "View Details"
     },

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -716,6 +716,15 @@
         "title": "No %{networkName} %{gasToken} detected",
         "text": "You won’t be able to use %{networkName} without %{networkName} %{gasToken}. If you go through with this transaction, you won’t be able to swap, bridge or transfer your %{networkName} tokens without adding %{networkName} %{gasToken} to your wallet.",
         "button": "Adjust and add $3 of %{gasToken}"
+      },
+      "flashbots": {
+        "text": "Flashbots protects your transactions from frontrunning and sandwich attacks which might result in you getting a worse price or your transaction failing. :)",
+        "title": "Flashbots :)",
+        "still_curious": {
+          "fragment1": "Still curious? :)",
+          "fragment2": "Read more :)",
+          "fragment3": " about Flashbots and the protection it offers. :)"
+        }
       }
     },
     "fedora": {


### PR DESCRIPTION
Fixes RNBW-4621
Figma link (if any):

## What changed (plus any additional context for devs)
- hide flashbots protect detail row when swapping on L2s

## Screen recordings / screenshots

Uploading Simulator Screen Recording - iPhone 14 Plus - 2022-10-18 at 17.32.26.mp4…




## What to test
make sure it shows up for mainnet swaps but not for L2 swaps


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
