### PR TITLE
Background color on the 'continue with {network}' was wrong

### DIFF
--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -536,7 +536,7 @@ export const explainers = (params, colors) => ({
   swapResetInputs: {
     button: {
       label: `Continue with ${networkInfo[params?.network]?.name}`,
-      bgColor: colors?.networkColors[params?.network],
+      bgColor: colors?.secondary30,
     },
     emoji: '🔐',
     extraHeight: -90,


### PR DESCRIPTION
Fixes RNBW-####
Figma link (if any):

## What changed (plus any additional context for devs)

Button background is wrong on develop.

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
