### PR TITLE
feat: add wallet hashing util

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,7 @@ src/navigation @jkadamczyk @skylarbarrera @estrattonbailey
 
 # analytics & logging
 src/analytics @estrattonbailey @skylarbarrera
+src/utils/walletAddressHash.ts @estrattonbailey @skylarbarrera
 
 # APP INFRA
 package.json @salman-rb @skylarbarrera @estrattonbailey

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -78,4 +78,5 @@ declare module 'react-native-dotenv' {
   export const RAINBOW_TOKEN_LIST_URL: string;
   export const LOG_LEVEL: 'debug' | 'info' | 'warn' | 'error';
   export const LOG_DEBUG: string;
+  export const WALLET_ADDRESS_HASH_KEY: string;
 }

--- a/src/entities/wallet.ts
+++ b/src/entities/wallet.ts
@@ -1,1 +1,2 @@
 export type EthereumAddress = string;
+export type EthereumAddressV2 = `0x${string}`;

--- a/src/utils/walletAddressHash.ts
+++ b/src/utils/walletAddressHash.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers';
 import { WALLET_ADDRESS_HASH_KEY } from 'react-native-dotenv';
-
-type WalletAddress = `0x${string}`;
+import { EthereumAddressV2 } from '@/entities/wallet';
 
 let currentWalletAddressHash: string | undefined = undefined;
 
@@ -13,7 +12,7 @@ function hash(value: string) {
   );
 }
 
-export function setCurrentWalletAddress(walletAddress: WalletAddress) {
+export function setCurrentWalletAddress(walletAddress: EthereumAddressV2) {
   currentWalletAddressHash = hash(walletAddress);
 }
 

--- a/src/utils/walletAddressHash.ts
+++ b/src/utils/walletAddressHash.ts
@@ -1,0 +1,22 @@
+import { ethers } from 'ethers';
+import { WALLET_ADDRESS_HASH_KEY } from 'react-native-dotenv';
+
+type WalletAddress = `0x${string}`;
+
+let currentWalletAddressHash: string | undefined = undefined;
+
+function hash(value: string) {
+  return ethers.utils.computeHmac(
+    ethers.utils.SupportedAlgorithm.sha256,
+    WALLET_ADDRESS_HASH_KEY,
+    value
+  );
+}
+
+export function setCurrentWalletAddress(walletAddress: WalletAddress) {
+  currentWalletAddressHash = hash(walletAddress);
+}
+
+export function getCurrentWalletAddress() {
+  return currentWalletAddressHash;
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I realized we're going to need to set this for Sentry as well as Segment, so it makes sense for it to be its own util.

My thinking is: the currently selected wallet will live on application state. When a user switches wallets, we set the hash here (not in state). Then we use the updated hash for Sentry/Segment.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
