### PR TITLE
feat: add falsy test cases to logger metadata

### DIFF
--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -63,6 +63,35 @@ describe('general functionality', () => {
     expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, 'message', extra);
   });
 
+  test('supports nullish/falsy metadata', () => {
+    const logger = new Logger({ enabled: true });
+
+    const mockTransport = jest.fn();
+
+    const remove = logger.addTransport(mockTransport);
+
+    // @ts-expect-error testing the JS case
+    logger.warn('a', null);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, 'a', {});
+
+    // @ts-expect-error testing the JS case
+    logger.warn('b', false);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, 'b', {});
+
+    // @ts-expect-error testing the JS case
+    logger.warn('c', 0);
+    expect(mockTransport).toHaveBeenCalledWith(LogLevel.Warn, 'c', {});
+
+    remove();
+
+    logger.addTransport((level, message, metadata) => {
+      expect(typeof metadata).toEqual('object');
+    });
+
+    // @ts-expect-error testing the JS case
+    logger.warn('message', null);
+  });
+
   test('logger.error expects a RainbowError', () => {
     const logger = new Logger({ enabled: true });
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -234,13 +234,14 @@ export class Logger {
   protected transport(
     level: LogLevel,
     message: string | RainbowError,
-    metadata: Metadata
+    metadata: Metadata = {}
   ) {
     if (!this.enabled) return;
     if (!enabledLogLevels[this.level].includes(level)) return;
 
     for (const transport of this.transports) {
-      transport(level, message, metadata);
+      // metadata fallback accounts for JS usage
+      transport(level, message, metadata || {});
     }
   }
 }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
@brunobar79 brought up a good point that JS code without type-guards might unintentionally pass in nullish/falsy values and we'll end up with thrown errors. This adds fallbacks and test cases to ensure we don't regress in the future.

## Final checklist

- [x] Assigned individual reviewers?
- [x] Added labels? (`critical path`, `release`, `dev QA`)
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
- [x] If no `dev QA` label, did you add the PR to the QA Queue?
