### PR TITLE
fix setting account color to undefined

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -60,8 +60,6 @@ export function ProfileActionButtonsRow() {
     accentColor = dominantColor || colors.appleBlue;
   } else if (typeof accountColor === 'number') {
     accentColor = colors.avatarBackgrounds[accountColor];
-  } else {
-    accentColor = accountColor;
   }
 
   // ////////////////////////////////////////////////////


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Found out that the types for the color are only a number or undefined, so we were setting undefined as an accent color which could throw errors in some cases when we passed the color through chroma-js