### PR TITLE
implement TX Details playground with empty tx details entries

### DIFF
--- a/src/components/settings-menu/DevSection.tsx
+++ b/src/components/settings-menu/DevSection.tsx
@@ -53,6 +53,7 @@ import {
   removeNotificationSettingsForWallet,
   useAllNotificationSettingsFromStorage,
 } from '@/notifications/settings';
+import { IS_DEV } from '@/env';
 
 const DevSection = () => {
   const { navigate } = useNavigation();
@@ -224,6 +225,11 @@ const DevSection = () => {
     addDefaultNotificationGroupSettings();
   }, [clearAllNotificationSettings]);
 
+  // TODO: Remove after finishing work on APP-27
+  const navigateToTransactionDetailsPlayground = () => {
+    navigate('TransactionDetailsPlayground');
+  };
+
   return (
     <MenuContainer testID="developer-settings-sheet">
       <Menu header={IS_DEV || isTestFlight ? 'Normie Settings' : ''}>
@@ -372,7 +378,6 @@ const DevSection = () => {
                 <MenuItem.Title text={lang.t('developer_settings.alert')} />
               }
             />
-
             <MenuItem
               leftComponent={<MenuItem.TextIcon icon="⏩" isEmoji />}
               onPress={syncCodepush}
@@ -384,6 +389,15 @@ const DevSection = () => {
                 <MenuItem.Title
                   text={lang.t('developer_settings.sync_codepush')}
                 />
+              }
+            />
+            {/* TODO: Remove after finishing work on APP-27*/}
+            <MenuItem
+              leftComponent={<MenuItem.TextIcon icon="🛝" isEmoji />}
+              onPress={navigateToTransactionDetailsPlayground}
+              size={52}
+              titleComponent={
+                <MenuItem.Title text={'Transaction Details Playground'} />
               }
             />
           </Menu>

--- a/src/components/settings-menu/TransactionDetailsPlayground.tsx
+++ b/src/components/settings-menu/TransactionDetailsPlayground.tsx
@@ -2,15 +2,166 @@ import React from 'react';
 import Menu from './components/Menu';
 import MenuContainer from './components/MenuContainer';
 import MenuItem from './components/MenuItem';
-import { RainbowTransaction } from '@/entities';
+import {
+  ProtocolType,
+  RainbowTransaction,
+  TransactionStatus,
+  TransactionType,
+} from '@/entities';
+import { Network } from '@/helpers';
 
 const transactions: Record<string, RainbowTransaction> = {
-  'Sent': {},
-  'Received': {},
-  'Failed': {},
-  'Swapped': {},
-  'Contract Interaction': {},
-  'Savings': {},
+  'Sent': {
+    address: 'eth',
+    balance: {
+      amount: '0.00077111',
+      display: '0.000771 ETH',
+    },
+    description: 'Ethereum',
+    from: '0x5e087b61aad29559e31565079fcdabe384b44614',
+    hash:
+      '0x7b1a15f209f5850cf27e7fdf1d23815a4bcefe011dbd982f632442557076f228-0',
+    minedAt: 1666203035,
+    name: 'Ethereum',
+    native: {
+      amount: '1.0000371368',
+      display: '$1.00',
+    },
+    network: Network.mainnet,
+    nonce: 87,
+    pending: false,
+    status: TransactionStatus.sent,
+    symbol: 'ETH',
+    title: 'Sent',
+    to: '0xe0e0f2277752af0f797855be0c24d13c15e5a261',
+    type: TransactionType.send,
+  },
+  'Received': {
+    address: '0x23b608675a2b2fb1890d3abbd85c5775c51691d5',
+    balance: {
+      amount: '0.000101998237529782',
+      display: '0.000102 SOCKS',
+    },
+    description: 'Unisocks',
+    from: '0x00000000009726632680fb29d3f7a9734e3010e2',
+    hash:
+      '0x90511d67e92670242260cd49becbd59edadd2b8cf727dc8dafcf524dfd7259a3-1',
+    minedAt: 1666297559,
+    name: 'Unisocks',
+    native: {
+      amount: '2.60395150982855915008706328',
+      display: '$2.60',
+    },
+    network: Network.mainnet,
+    nonce: 1000,
+    pending: false,
+    status: TransactionStatus.received,
+    symbol: 'SOCKS',
+    title: 'Received',
+    to: '0x2e67869829c734ac13723a138a952f7a8b56e774',
+    type: TransactionType.receive,
+  },
+  'Failed': {
+    address: 'eth',
+    balance: {
+      amount: '0.003739995512004999',
+      display: '0.00374 ETH',
+    },
+    description: 'Ethereum',
+    from: '0x3c74d5d6e0f55d75cc850c9aee0dda99fbfd5415',
+    hash:
+      '0x6752a68c377e81ee63f2b3237b00e88f57d220b152743a063997d7e2ffdf37e3-0',
+    minedAt: 1665754055,
+    name: 'Ethereum',
+    native: {
+      amount: '5.00108459869796461281',
+      display: '$5.00',
+    },
+    network: Network.mainnet,
+    nonce: 56,
+    pending: false,
+    status: TransactionStatus.failed,
+    symbol: 'ETH',
+    title: 'Failed',
+    to: '0xc30141b657f4216252dc59af2e7cdb9d8792e1b0',
+    type: TransactionType.trade,
+  },
+  'Swapped': {
+    address: 'eth',
+    balance: {
+      amount: '0.00774887447598',
+      display: '0.00775 ETH',
+    },
+    description: 'Ethereum',
+    from: '0x5e087b61aad29559e31565079fcdabe384b44614',
+    hash:
+      '0x225be3f93d89fb2513c4362a956ec99041b06485a736242e69dd20d6e5bd8d9b-0',
+    minedAt: 1665510599,
+    name: 'Ethereum',
+    native: {
+      amount: '10.0020921961054644',
+      display: '$10.00',
+    },
+    network: Network.mainnet,
+    nonce: 86,
+    pending: false,
+    status: TransactionStatus.swapped,
+    symbol: 'ETH',
+    title: 'Swapped',
+    to: '0xc30141b657f4216252dc59af2e7cdb9d8792e1b0',
+    type: TransactionType.trade,
+  },
+  'Contract Interaction': {
+    address: 'eth',
+    balance: {
+      amount: '0',
+      display: '0.00 ETH',
+    },
+    description: 'Set Name',
+    from: '0x5e087b61aad29559e31565079fcdabe384b44614',
+    hash:
+      '0xef93c6e9702b16d9acd3d16417ca6b56ddf688f4978b68f30a8d9cb1e42b883d-0',
+    minedAt: 1661979911,
+    name: 'Set Name',
+    native: {
+      amount: '0',
+      display: '$0.00',
+    },
+    network: Network.mainnet,
+    nonce: 53,
+    pending: false,
+    status: TransactionStatus.contract_interaction,
+    symbol: 'contract',
+    title: 'Contract Interaction',
+    to: '0x084b1c3c81545d370f3634392de611caabff8148',
+    type: TransactionType.contract_interaction,
+  },
+  'Savings': {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    balance: {
+      amount: '10',
+      display: '10.00 DAI',
+    },
+    description: 'Withdrew Dai',
+    from: '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643',
+    hash:
+      '0x425d39c5b80b32f4278a408516459e5d2e2ec4462e1309f29debf53a7f2632cd-0',
+    minedAt: 1666125239,
+    name: 'Dai',
+    native: {
+      amount: '10.032490125',
+      display: '$10.03',
+    },
+    network: Network.mainnet,
+    nonce: 987,
+    pending: false,
+    protocol: ProtocolType.compound,
+    status: TransactionStatus.withdrew,
+    symbol: 'DAI',
+    title: 'Savings',
+    to: '0x2e67869829c734ac13723a138a952f7a8b56e774',
+    type: TransactionType.withdraw,
+  },
 };
 
 const TxItem: React.FC<{

--- a/src/components/settings-menu/TransactionDetailsPlayground.tsx
+++ b/src/components/settings-menu/TransactionDetailsPlayground.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Menu from './components/Menu';
+import MenuContainer from './components/MenuContainer';
+import MenuItem from './components/MenuItem';
+import { RainbowTransaction } from '@/entities';
+
+const transactions: Record<string, RainbowTransaction> = {
+  'Sent': {},
+  'Received': {},
+  'Failed': {},
+  'Swapped': {},
+  'Contract Interaction': {},
+  'Savings': {},
+};
+
+const TxItem: React.FC<{
+  title: string;
+  transactionDetails: RainbowTransaction;
+}> = ({ title, transactionDetails }) => {
+  const onPress = () => {
+    console.log(JSON.stringify(transactionDetails));
+  };
+
+  return (
+    <MenuItem
+      onPress={onPress}
+      size={52}
+      titleComponent={<MenuItem.Title text={title} />}
+    />
+  );
+};
+
+const TransactionDetailsPlayground = () => {
+  return (
+    <MenuContainer>
+      <Menu header={'Transactions by type'}>
+        {Object.entries(transactions).map(([key, tx]) => (
+          <TxItem key={key} title={key} transactionDetails={tx} />
+        ))}
+      </Menu>
+    </MenuContainer>
+  );
+};
+
+export default TransactionDetailsPlayground;

--- a/src/components/settings-menu/TransactionDetailsPlayground.tsx
+++ b/src/components/settings-menu/TransactionDetailsPlayground.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/entities';
 import { Network } from '@/helpers';
 
+// TODO: Remove this file after finishing work on APP-27
+
 const transactions: Record<string, RainbowTransaction> = {
   'Sent': {
     address: 'eth',

--- a/src/components/settings-menu/index.ts
+++ b/src/components/settings-menu/index.ts
@@ -6,5 +6,6 @@ export { default as NetworkSection } from './NetworkSection';
 export { default as NotificationsSection } from './NotificationsSection';
 export { default as PrivacySection } from './PrivacySection';
 export { default as SettingsSection } from './SettingsSection';
+// TODO: Remove below after finishing work on APP-27
 export { default as TransactionDetailsPlayground } from './TransactionDetailsPlayground';
 export { default as WalletNotificationsSettings } from './WalletNotificationsSettings';

--- a/src/components/settings-menu/index.ts
+++ b/src/components/settings-menu/index.ts
@@ -1,9 +1,10 @@
+export { default as AppIconSection } from './AppIconSection';
 export { default as CurrencySection } from './CurrencySection';
 export { default as DevSection } from './DevSection';
 export { default as LanguageSection } from './LanguageSection';
 export { default as NetworkSection } from './NetworkSection';
+export { default as NotificationsSection } from './NotificationsSection';
 export { default as PrivacySection } from './PrivacySection';
 export { default as SettingsSection } from './SettingsSection';
-export { default as NotificationsSection } from './NotificationsSection';
+export { default as TransactionDetailsPlayground } from './TransactionDetailsPlayground';
 export { default as WalletNotificationsSettings } from './WalletNotificationsSettings';
-export { default as AppIconSection } from './AppIconSection';

--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -17,6 +17,7 @@ import {
   PrivacySection,
   SettingsSection,
   WalletNotificationsSettings,
+  TransactionDetailsPlayground,
 } from '../components/settings-menu';
 import BackupSection from '../components/settings-menu/BackupSection/BackupSection';
 import SettingsBackupView from '../components/settings-menu/BackupSection/SettingsBackupView';
@@ -275,6 +276,14 @@ export default function SettingsSheet() {
           options={({ route }: any) => ({
             cardStyleInterpolator,
             title: route.params?.title || lang.t('settings.backup'),
+          })}
+        />
+        <Stack.Screen
+          component={TransactionDetailsPlayground}
+          name="TransactionDetailsPlayground"
+          options={({ route }: any) => ({
+            cardStyleInterpolator,
+            title: route.params?.title || 'Transaction Details Playground',
           })}
         />
       </Stack.Navigator>

--- a/src/screens/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet.tsx
@@ -278,6 +278,7 @@ export default function SettingsSheet() {
             title: route.params?.title || lang.t('settings.backup'),
           })}
         />
+        {/* TODO: Remove below screen after finishing work on APP-27*/}
         <Stack.Screen
           component={TransactionDetailsPlayground}
           name="TransactionDetailsPlayground"


### PR DESCRIPTION
Fixes APP-28

## What changed (plus any additional context for devs)
* Implementing playground for new transaction details development

## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
