### PR TITLE
Bump iOS target to iOS 13 and remove version checks

### DIFF
--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1360,7 +1360,7 @@
 				INFOPLIST_FILE = ImageNotification/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ImageNotification;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Rainbow. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -1409,7 +1409,7 @@
 				INFOPLIST_FILE = ImageNotification/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ImageNotification;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Rainbow. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
@@ -1457,7 +1457,7 @@
 				INFOPLIST_FILE = ImageNotification/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ImageNotification;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Rainbow. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
@@ -1505,7 +1505,7 @@
 				INFOPLIST_FILE = ImageNotification/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ImageNotification;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Rainbow. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
@@ -1568,7 +1568,7 @@
 				);
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = "Objective-C";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1633,7 +1633,7 @@
 				);
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = "Objective-C";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1694,7 +1694,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
@@ -1742,7 +1742,7 @@
 				);
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = "Objective-C";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1804,7 +1804,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
@@ -1852,7 +1852,7 @@
 				);
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				INTENTS_CODEGEN_LANGUAGE = "Objective-C";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1918,7 +1918,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
@@ -1963,7 +1963,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INTENTS_CODEGEN_LANGUAGE = Swift;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";

--- a/ios/ThemeModule.m
+++ b/ios/ThemeModule.m
@@ -20,10 +20,8 @@
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(setMode:(NSString *)mode) {
-  if (@available(iOS 13.0, *)) {
-    ((AppDelegate*) UIApplication.sharedApplication.delegate).window.overrideUserInterfaceStyle =
-    [mode isEqualToString:@"dark"] ? UIUserInterfaceStyleDark : UIUserInterfaceStyleLight;
-  }
+  ((AppDelegate*) UIApplication.sharedApplication.delegate).window.overrideUserInterfaceStyle =
+  [mode isEqualToString:@"dark"] ? UIUserInterfaceStyleDark : UIUserInterfaceStyleLight;
 }
 
 @end

--- a/src/components/ens-profile/ActionButtons/SendButton.tsx
+++ b/src/components/ens-profile/ActionButtons/SendButton.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback } from 'react';
 import ActionButton from './ActionButton';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
+import { IS_IOS } from '@/env';
 
 export default function SendButton({ ensName }: { ensName?: string }) {
   const { navigate } = useNavigation();
   const handlePressSend = useCallback(async () => {
-    if (isNativeStackAvailable) {
+    if (IS_IOS) {
       navigate(Routes.SEND_FLOW, {
         params: {
           address: ensName,

--- a/src/components/expanded-state/SupportedCountriesExpandedState.js
+++ b/src/components/expanded-state/SupportedCountriesExpandedState.js
@@ -5,16 +5,16 @@ import { FloatingEmojisTapper } from '../floating-emojis';
 import { AssetPanel, FloatingPanels } from '../floating-panels';
 import { Centered } from '../layout';
 import { Text } from '../text';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import { useDimensions } from '@/hooks';
 import { wyreSupportedCountries } from '@/references';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import { neverRerender } from '@/utils';
+import { IS_IOS } from '@/env';
 
 const Panel = styled(FloatingPanels)(
   ({ deviceDimensions: { isTallPhone, width } }) => ({
-    marginBottom: (isTallPhone ? 90 : 45) + (isNativeStackAvailable ? 10 : 0),
+    marginBottom: (isTallPhone ? 90 : 45) + (IS_IOS ? 10 : 0),
     maxWidth: Math.min(270, width - 100),
   })
 );

--- a/src/components/expanded-state/profile/ProfileModalContainer.js
+++ b/src/components/expanded-state/profile/ProfileModalContainer.js
@@ -1,10 +1,10 @@
 import { useRoute } from '@react-navigation/native';
 import React from 'react';
-import isNativeStackAvailable from '../../../helpers/isNativeStackAvailable';
 import TouchableBackdrop from '../../TouchableBackdrop';
 import { AssetPanel, FloatingPanels } from '../../floating-panels';
 import { KeyboardFixedOpenLayout } from '../../layout';
 import { useDimensions } from '@/hooks';
+import { IS_IOS } from '@/env';
 
 export default function ProfileModalContainer({ onPressBackdrop, ...props }) {
   const { width: deviceWidth } = useDimensions();
@@ -12,9 +12,7 @@ export default function ProfileModalContainer({ onPressBackdrop, ...props }) {
 
   return (
     <KeyboardFixedOpenLayout
-      additionalPadding={
-        params?.additionalPadding && isNativeStackAvailable ? 80 : 0
-      }
+      additionalPadding={params?.additionalPadding && IS_IOS ? 80 : 0}
       position="absolute"
     >
       <TouchableBackdrop onPress={onPressBackdrop} />

--- a/src/components/sheet/sheet-action-buttons/SendActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.js
@@ -1,9 +1,9 @@
 import lang from 'i18n-js';
 import React, { useCallback } from 'react';
-import isNativeStackAvailable from '../../../helpers/isNativeStackAvailable';
 import SheetActionButton from './SheetActionButton';
 import { useExpandedStateNavigation } from '@/hooks';
 import Routes from '@/navigation/routesNames';
+import { IS_IOS } from '@/env';
 
 function SendActionButton({ asset, color: givenColor, ...props }) {
   const { colors } = useTheme();
@@ -13,7 +13,7 @@ function SendActionButton({ asset, color: givenColor, ...props }) {
     () =>
       navigate(Routes.SEND_FLOW, params => {
         const updatedParams = { ...params, asset };
-        return isNativeStackAvailable
+        return IS_IOS
           ? {
               params: updatedParams,
               screen: Routes.SEND_SHEET,

--- a/src/components/showcase/ShowcaseHeader.js
+++ b/src/components/showcase/ShowcaseHeader.js
@@ -10,7 +10,6 @@ import {
 import { Text, TruncatedAddress } from '../text';
 import { getContacts } from '@/handlers/localstorage/contacts';
 import { isHexString } from '@/handlers/web3';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import { useImportingWallet, useWallets } from '@/hooks';
 import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
@@ -137,18 +136,12 @@ export function Header() {
 
   const onSend = useCallback(async () => {
     goBack();
-    if (isNativeStackAvailable || android) {
-      navigate(Routes.SEND_FLOW, {
-        params: {
-          address: contextValue?.addressOrDomain || contextValue?.address,
-        },
-        screen: Routes.SEND_SHEET,
-      });
-    } else {
-      navigate(Routes.SEND_FLOW, {
+    navigate(Routes.SEND_FLOW, {
+      params: {
         address: contextValue?.addressOrDomain || contextValue?.address,
-      });
-    }
+      },
+      screen: Routes.SEND_SHEET,
+    });
   }, [contextValue?.address, contextValue?.addressOrDomain, goBack, navigate]);
 
   const { handleSetSeedPhrase, handlePressImportButton } = useImportingWallet();

--- a/src/helpers/isNativeStackAvailable.ts
+++ b/src/helpers/isNativeStackAvailable.ts
@@ -1,4 +1,0 @@
-import { Platform } from 'react-native';
-
-// @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'ios'.
-export default ios && parseFloat(Platform.Version) >= 13;

--- a/src/hooks/useMagicAutofocus.ts
+++ b/src/hooks/useMagicAutofocus.ts
@@ -1,9 +1,9 @@
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import { useCallback, useRef } from 'react';
 import { InteractionManager, TextInput } from 'react-native';
-import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
-import { setListener } from '../navigation/nativeStackHelpers';
+import { setListener } from '@/navigation/nativeStackHelpers';
 import useInteraction from './useInteraction';
+import { IS_ANDROID } from '@/env';
 
 const { currentlyFocusedInput, focusTextInput } = TextInput.State;
 
@@ -102,7 +102,7 @@ export default function useMagicAutofocus(
             delay = false;
           }, 200);
         });
-      } else if (!isNativeStackAvailable) {
+      } else if (IS_ANDROID) {
         // We need to do this in order to assure that the input gets focused
         // when using fallback stacks.
         InteractionManager.runAfterInteractions(fallbackRefocusLastInput);

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -75,7 +75,6 @@ import Routes from './routesNames';
 import { ExchangeModalNavigator } from './index';
 import { StatusBarHelper } from '@/helpers';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import { omitFlatten } from '@/helpers/utilities';
 import createNativeStackNavigator from '@/react-native-cool-modals/createNativeStackNavigator';
 import QRScannerScreen from '@/screens/QRScannerScreen';
@@ -171,7 +170,7 @@ function MainNavigator() {
   );
 }
 
-function MainNavigatorWrapper() {
+function MainStack() {
   return (
     <Stack.Navigator
       initialRouteName={Routes.MAIN_NAVIGATOR_WRAPPER}
@@ -185,58 +184,6 @@ function MainNavigatorWrapper() {
     </Stack.Navigator>
   );
 }
-
-function NativeStackFallbackNavigator() {
-  return (
-    <Stack.Navigator
-      initialRouteName={Routes.MAIN_NAVIGATOR}
-      {...stackNavigationConfig}
-      screenOptions={defaultScreenStackOptions}
-    >
-      <Stack.Screen component={MainNavigator} name={Routes.MAIN_NAVIGATOR} />
-      <Stack.Screen
-        component={ImportSeedPhraseSheet}
-        name={Routes.IMPORT_SEED_PHRASE_SHEET}
-        options={{
-          ...sheetPreset,
-          onTransitionStart: StatusBarHelper.setLightContent,
-        }}
-      />
-      <Stack.Screen
-        component={AddCashSheet}
-        name={Routes.ADD_CASH_SHEET}
-        options={sheetPreset}
-      />
-      <Stack.Screen
-        component={ModalScreen}
-        name={Routes.MODAL_SCREEN}
-        options={overlayExpandedPreset}
-      />
-      <Stack.Screen
-        component={SendSheet}
-        name={Routes.SEND_SHEET}
-        options={{
-          ...omitFlatten(sheetPreset, 'gestureResponseDistance'),
-          onTransitionStart: StatusBarHelper.setLightContent,
-        }}
-      />
-      <Stack.Screen
-        component={ModalScreen}
-        name={Routes.SUPPORTED_COUNTRIES_MODAL_SCREEN}
-        options={overlayExpandedPreset}
-      />
-      <Stack.Screen
-        component={ExchangeModalNavigator}
-        name={Routes.EXCHANGE_MODAL}
-        options={exchangePreset}
-      />
-    </Stack.Navigator>
-  );
-}
-
-const MainStack = isNativeStackAvailable
-  ? MainNavigatorWrapper
-  : NativeStackFallbackNavigator;
 
 function NativeStackNavigator() {
   const { colors, isDarkMode } = useTheme();
@@ -467,28 +414,18 @@ function NativeStackNavigator() {
           />
         </>
       )}
-      {isNativeStackAvailable ? (
-        <>
-          <NativeStack.Screen
-            component={SendFlowNavigator}
-            name={Routes.SEND_SHEET_NAVIGATOR}
-          />
-          <NativeStack.Screen
-            component={ImportSeedPhraseFlowNavigator}
-            name={Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR}
-          />
-          <NativeStack.Screen
-            component={AddCashFlowNavigator}
-            name={Routes.ADD_CASH_SCREEN_NAVIGATOR}
-          />
-        </>
-      ) : (
-        <NativeStack.Screen
-          component={ImportSeedPhraseFlowNavigator}
-          name={Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR}
-          options={{ customStack: true }}
-        />
-      )}
+      <NativeStack.Screen
+        component={SendFlowNavigator}
+        name={Routes.SEND_SHEET_NAVIGATOR}
+      />
+      <NativeStack.Screen
+        component={ImportSeedPhraseFlowNavigator}
+        name={Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR}
+      />
+      <NativeStack.Screen
+        component={AddCashFlowNavigator}
+        name={Routes.ADD_CASH_SCREEN_NAVIGATOR}
+      />
       <NativeStack.Screen
         component={WalletConnectApprovalSheet}
         name={Routes.WALLET_CONNECT_APPROVAL_SHEET}

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -99,7 +99,7 @@ export const NATIVE_ROUTES = [
     : []),
 ];
 
-const RoutesWithNativeStackAvailability = {
+const RoutesWithPlatformDifferences = {
   ...Routes,
   ADD_CASH_FLOW: IS_IOS
     ? Routes.ADD_CASH_SCREEN_NAVIGATOR
@@ -110,4 +110,4 @@ const RoutesWithNativeStackAvailability = {
   SEND_FLOW: Routes.SEND_SHEET_NAVIGATOR,
 };
 
-export default RoutesWithNativeStackAvailability;
+export default RoutesWithPlatformDifferences;

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -1,4 +1,4 @@
-import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
+import { IS_IOS } from '@/env';
 
 const Routes = {
   ADD_CASH_SCREEN_NAVIGATOR: 'AddCashSheetNavigator',
@@ -90,7 +90,7 @@ export const NATIVE_ROUTES = [
   Routes.SAVINGS_SHEET,
   Routes.SAVINGS_WITHDRAW_MODAL,
   Routes.SAVINGS_DEPOSIT_MODAL,
-  ...(isNativeStackAvailable
+  ...(IS_IOS
     ? [
         Routes.SEND_SHEET_NAVIGATOR,
         Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR,
@@ -101,16 +101,13 @@ export const NATIVE_ROUTES = [
 
 const RoutesWithNativeStackAvailability = {
   ...Routes,
-  ADD_CASH_FLOW: isNativeStackAvailable
+  ADD_CASH_FLOW: IS_IOS
     ? Routes.ADD_CASH_SCREEN_NAVIGATOR
     : Routes.ADD_CASH_SHEET,
-  IMPORT_SEED_PHRASE_FLOW: isNativeStackAvailable
+  IMPORT_SEED_PHRASE_FLOW: IS_IOS
     ? Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR
     : Routes.IMPORT_SEED_PHRASE_SHEET,
-  SEND_FLOW:
-    isNativeStackAvailable || android
-      ? Routes.SEND_SHEET_NAVIGATOR
-      : Routes.SEND_SHEET,
+  SEND_FLOW: Routes.SEND_SHEET_NAVIGATOR,
 };
 
 export default RoutesWithNativeStackAvailability;

--- a/src/react-native-cool-modals/ios/RNCMPortal.m
+++ b/src/react-native-cool-modals/ios/RNCMPortal.m
@@ -76,9 +76,7 @@ RCT_EXPORT_VIEW_PROPERTY(blockTouches, BOOL)
 
 -(void)removeFromSuperview {
   [self.window setHidden:YES];
-  if (@available(iOS 13.0, *)) {
-    self.window.windowScene = nil;
-  }
+  self.window.windowScene = nil;
   if (self.reactSubviews.count != 0) {
     [self.window.rootViewController.view removeReactSubview:self.reactSubviews[0]];
   }
@@ -89,9 +87,7 @@ RCT_EXPORT_VIEW_PROPERTY(blockTouches, BOOL)
 
 -(void)removeReactSubview:(UIView *)subview {
   [self.window setHidden:YES];
-  if (@available(iOS 13.0, *)) {
-    self.window.windowScene = nil;
-  }
+  self.window.windowScene = nil;
   [self.window.rootViewController.view removeReactSubview:subview];
   self.window = nil;
   [super removeReactSubview:subview];

--- a/src/react-native-cool-modals/ios/RNCMScreen.m
+++ b/src/react-native-cool-modals/ios/RNCMScreen.m
@@ -143,15 +143,7 @@
 {
   switch (stackPresentation) {
     case RNSScreenStackPresentationModal:
-#ifdef __IPHONE_13_0
-      if (@available(iOS 13.0, *)) {
-        _controller.modalPresentationStyle = UIModalPresentationAutomatic;
-      } else {
-        _controller.modalPresentationStyle = UIModalPresentationFullScreen;
-      }
-#else
-      _controller.modalPresentationStyle = UIModalPresentationFullScreen;
-#endif
+      _controller.modalPresentationStyle = UIModalPresentationAutomatic;
       if (_controller.transDelegate != nil) {
         _controller.modalPresentationStyle = UIModalPresentationCustom;
       }
@@ -210,12 +202,7 @@
 
 - (void)setGestureEnabled:(BOOL)gestureEnabled
 {
-#ifdef __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    _controller.modalInPresentation = !gestureEnabled;
-  }
-#endif
-  
+  _controller.modalInPresentation = !gestureEnabled;
   _gestureEnabled = gestureEnabled;
 }
 

--- a/src/screens/AddCashSheet.js
+++ b/src/screens/AddCashSheet.js
@@ -9,7 +9,6 @@ import {
   SheetSubtitleCycler,
   SheetTitle,
 } from '../components/sheet';
-import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
 import { deviceUtils } from '../utils';
 import {
   useAddCashLimits,
@@ -21,21 +20,22 @@ import {
 import styled from '@/styled-thing';
 import { borders } from '@/styles';
 import { useTheme } from '@/theme';
+import { IS_IOS } from '@/env';
 
 const deviceHeight = deviceUtils.dimensions.height;
 const statusBarHeight = getStatusBarHeight(true);
 const sheetHeight =
   deviceHeight -
   statusBarHeight -
-  (isNativeStackAvailable ? (deviceHeight >= 812 ? 10 : 20) : 0);
+  (IS_IOS ? (deviceHeight >= 812 ? 10 : 20) : 0);
 
 const subtitleInterval = 3000;
 
 const SheetContainer = styled(Column)({
-  ...borders.buildRadiusAsObject('top', isNativeStackAvailable ? 0 : 16),
+  ...borders.buildRadiusAsObject('top', IS_IOS ? 0 : 16),
   backgroundColor: ({ colors }) => colors.white,
-  height: isNativeStackAvailable ? deviceHeight : sheetHeight,
-  top: isNativeStackAvailable ? 0 : statusBarHeight,
+  height: IS_IOS ? deviceHeight : sheetHeight,
+  top: IS_IOS ? 0 : statusBarHeight,
   width: '100%',
 });
 
@@ -94,7 +94,7 @@ export default function AddCashSheet() {
     <SheetContainer colors={colors}>
       <Column
         align="center"
-        height={isNativeStackAvailable ? sheetHeight : '100%'}
+        height={IS_IOS ? sheetHeight : '100%'}
         paddingBottom={isNarrowPhone ? 15 : insets.bottom + 11}
       >
         <Column align="center" paddingVertical={6}>
@@ -102,7 +102,7 @@ export default function AddCashSheet() {
           <ColumnWithMargins
             align="center"
             margin={4}
-            paddingTop={isNativeStackAvailable ? 7 : 5}
+            paddingTop={IS_IOS ? 7 : 5}
           >
             <SheetTitle>{lang.t('button.add_cash')}</SheetTitle>
             <SheetSubtitleCycler

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -13,7 +13,6 @@ import {
   ToastPositionContainer,
 } from '../components/toasts';
 import { useTheme } from '../theme/ThemeContext';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import { isValidWallet } from '@/helpers/validators';
 import {
   useAccountSettings,
@@ -27,15 +26,15 @@ import { sheetVerticalOffset } from '@/navigation/effects';
 import styled from '@/styled-thing';
 import { borders, padding } from '@/styles';
 import { deviceUtils } from '@/utils';
-import { IS_TEST } from '@/env';
+import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
 
 const sheetBottomPadding = 19;
 
 const Container = styled.View({
   flex: 1,
-  paddingTop: android ? 0 : isNativeStackAvailable ? 0 : sheetVerticalOffset,
+  paddingTop: 0,
 
-  ...(android
+  ...(IS_ANDROID
     ? {
         backgroundColor: ({ theme: { colors } }) => colors.transparent,
         marginTop: sheetVerticalOffset,
@@ -51,7 +50,7 @@ const Footer = styled(Row).attrs({
   position: 'relative',
   right: 0,
   width: '100%',
-  ...(android
+  ...(IS_ANDROID
     ? {
         marginRight: 18,
         top: ({ isSmallPhone }) => (isSmallPhone ? sheetBottomPadding * 2 : 0),
@@ -59,12 +58,12 @@ const Footer = styled(Row).attrs({
     : {}),
 });
 
-const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs({
+const LoadingSpinner = styled(IS_ANDROID ? Spinner : ActivityIndicator).attrs({
   color: 'white',
   size: 15,
 })({
   marginRight: 5,
-  marginTop: android ? 0 : 2,
+  marginTop: IS_ANDROID ? 0 : 2,
 });
 
 const FooterButton = styled(MiniButton).attrs({
@@ -84,7 +83,7 @@ const SecretTextArea = styled(Input).attrs({
   autoFocus: true,
   dataDetectorTypes: 'none',
   enablesReturnKeyAutomatically: true,
-  keyboardType: android ? 'visible-password' : 'default',
+  keyboardType: IS_ANDROID ? 'visible-password' : 'default',
   lineHeight: 'looser',
   multiline: true,
   numberOfLines: 3,
@@ -95,8 +94,8 @@ const SecretTextArea = styled(Input).attrs({
   textContentType: 'none',
   weight: 'semibold',
 })({
-  marginBottom: android ? 55 : 0,
-  minHeight: android ? 100 : 50,
+  marginBottom: IS_ANDROID ? 55 : 0,
+  minHeight: IS_ANDROID ? 100 : 50,
   width: '100%',
 });
 
@@ -109,7 +108,7 @@ const Sheet = styled(Column).attrs({
   align: 'center',
   flex: 1,
 })({
-  ...borders.buildRadiusAsObject('top', isNativeStackAvailable ? 0 : 16),
+  ...borders.buildRadiusAsObject('top', IS_IOS ? 0 : 16),
   ...padding.object(0, 15, sheetBottomPadding),
   backgroundColor: ({ theme: { colors } }) => colors.white,
   zIndex: 1,
@@ -186,7 +185,7 @@ export default function ImportSeedPhraseSheet() {
             <FooterButton
               disabled={!isSecretValid}
               hasLeadingIcon
-              {...(android && { height: 30, overflowMargin: 15, width: 89 })}
+              {...(IS_ANDROID && { height: 30, overflowMargin: 15, width: 89 })}
               onPress={handlePressImportButton}
             >
               <Row>
@@ -209,7 +208,7 @@ export default function ImportSeedPhraseSheet() {
             </FooterButton>
           ) : (
             <FooterButton
-              {...(android && { height: 30, overflowMargin: 15, width: 63 })}
+              {...(IS_ANDROID && { height: 30, overflowMargin: 15, width: 63 })}
               disabled={!isClipboardValidSecret}
               onPress={handlePressPasteButton}
             >

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -38,7 +38,6 @@ import {
   resolveNameOrAddress,
   web3Provider,
 } from '@/handlers/web3';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import Network from '@/helpers/networkTypes';
 import {
   checkIsValidAddressOrDomain,
@@ -81,14 +80,15 @@ import {
 } from '@/helpers/utilities';
 import { deviceUtils, ethereumUtils, getUniqueTokenType } from '@/utils';
 import logger from '@/utils/logger';
+import { IS_ANDROID, IS_IOS } from '@/env';
 
-const sheetHeight = deviceUtils.dimensions.height - (android ? 30 : 10);
+const sheetHeight = deviceUtils.dimensions.height - (IS_ANDROID ? 30 : 10);
 const statusBarHeight = getStatusBarHeight(true);
 
 const Container = styled.View({
   backgroundColor: ({ theme: { colors } }) => colors.transparent,
   flex: 1,
-  paddingTop: isNativeStackAvailable ? 0 : statusBarHeight,
+  paddingTop: IS_IOS ? 0 : statusBarHeight,
   width: '100%',
 });
 
@@ -96,9 +96,9 @@ const SheetContainer = styled(Column).attrs({
   align: 'center',
   flex: 1,
 })({
-  ...borders.buildRadiusAsObject('top', isNativeStackAvailable ? 0 : 16),
+  ...borders.buildRadiusAsObject('top', IS_IOS ? 0 : 16),
   backgroundColor: ({ theme: { colors } }) => colors.white,
-  height: isNativeStackAvailable || android ? sheetHeight : '100%',
+  height: sheetHeight,
   width: '100%',
 });
 

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -40,7 +40,6 @@ import {
   isTestnetNetwork,
   toHex,
 } from '@/handlers/web3';
-import isNativeStackAvailable from '@/helpers/isNativeStackAvailable';
 import networkInfo from '@/helpers/networkInfo';
 import { Network } from '@/helpers/networkTypes';
 import {
@@ -81,6 +80,7 @@ import {
 } from '@/references';
 import Routes from '@/navigation/routesNames';
 import logger from '@/utils/logger';
+import { IS_IOS } from '@/env';
 
 const { RNBip39 } = NativeModules;
 
@@ -663,7 +663,7 @@ async function parseEthereumUrl(data: string) {
 
   InteractionManager.runAfterInteractions(() => {
     const params = { address, asset: assetWithPrice, nativeAmount };
-    if (isNativeStackAvailable) {
+    if (IS_IOS) {
       Navigation.handleAction(Routes.SEND_FLOW, {
         params,
         screen: Routes.SEND_SHEET,


### PR DESCRIPTION
Fixes APP-76
## What changed (plus any additional context for devs)

* Bumped iOS Deployment target from 11 to 13 on all Xcode Targets
* Removed `isNativeStackAvailable` variable and removed its usages or replaced it with `IS_IOS`
* Removed `@available(iOS 13.0)` checks in native iOS code (we always have minimum iOS 13 now so it's not needed) 

## Final checklist

- [x] Assigned individual reviewers?
- [x] Did you test both iOS and Android?
- [x] If your changes are visual, did you check both the light and dark themes?
- [x] Added e2e tests? If not, please specify why
- [x] If you added new critical path files, did you update the CODEOWNERS file?
