### PR TITLE
fix: tweak scanner logic

### DIFF
--- a/src/components/qrcode-scanner/QRCodeScanner.tsx
+++ b/src/components/qrcode-scanner/QRCodeScanner.tsx
@@ -15,7 +15,7 @@ import { deviceUtils } from '@/utils';
 import { Box, Cover, Rows, Row } from '@/design-system';
 import { useNavigation } from '@/navigation';
 import { CameraMaskSvg } from '../svg/CameraMaskSvg';
-import { IS_ANDROID } from '@/env';
+import { IS_ANDROID, IS_IOS } from '@/env';
 // @ts-ignore
 import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
 
@@ -63,8 +63,7 @@ export default function QRCodeScanner() {
 
   const hideCamera = useCallback(() => {
     setEnabled(false);
-    goBack();
-  }, [goBack]);
+  }, []);
 
   const { onScan } = useScanner(
     cameraState === CameraState.Scanning,
@@ -76,7 +75,7 @@ export default function QRCodeScanner() {
 
   const askForPermissions = useCallback(async () => {
     try {
-      const permission = ios
+      const permission = IS_IOS
         ? PERMISSIONS.IOS.CAMERA
         : PERMISSIONS.ANDROID.CAMERA;
 

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -23,7 +23,7 @@ import logger from '@/utils/logger';
 import { checkPushNotificationPermissions } from '@/notifications/permissions';
 
 export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
-  const { navigate } = useNavigation();
+  const { navigate, goBack } = useNavigation();
   const { walletConnectOnSessionRequest } = useWalletConnectConnections();
   const profilesEnabled = useExperimentalFlag(PROFILES);
   // @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'useRef'.
@@ -116,7 +116,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
       haptics.notificationSuccess();
       analytics.track('Scanned WalletConnect QR code');
       await checkPushNotificationPermissions();
-
+      goBack();
       onSuccess();
       try {
         await walletConnectOnSessionRequest(qrCodeData, () => {});
@@ -124,7 +124,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
         logger.log('walletConnectOnSessionRequest exception', e);
       }
     },
-    [walletConnectOnSessionRequest, onSuccess]
+    [goBack, onSuccess, walletConnectOnSessionRequest]
   );
 
   const handleScanInvalid = useCallback(


### PR DESCRIPTION
???
Figma link (if any):

## What changed (plus any additional context for devs)
new Scanner doesn't need to goBack() on any calls, i've  removed that logic entirely and added it to the only place needed. 

you can see in develop that when u scan a profile code it will navigate correctly and then run onSuccess, which then called goBack(), dismissing the sheet



added a follow up ticket to combine scan/deeplink handling: https://linear.app/rainbow/issue/APP-89/standardize-scanner-deeplink-logic

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->



## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->
