### PR TITLE
fix e2e: add existence check

### DIFF
--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -536,8 +536,12 @@ export const explainers = (params, colors) => ({
   swapResetInputs: {
     button: {
       label: `Continue with ${networkInfo[params?.network]?.name}`,
-      bgColor: colors?.alpha(colors?.networkColors[params?.network], 0.06),
-      textColor: colors?.networkColors[params?.network],
+      bgColor:
+        colors?.networkColors[params?.network] &&
+        colors?.alpha(colors?.networkColors[params?.network], 0.06),
+      textColor:
+        colors?.networkColors[params?.network] &&
+        colors?.networkColors?.[params?.network],
     },
     emoji: '🔐',
     extraHeight: -90,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
fixes e2e 😅 

thought this https://github.com/rainbow-me/rainbow/pull/4310 has passed e2e other than slack previously I was mistaken 


this is sad but follows the pattern here until we can refactor this 🧶 
https://github.com/rainbow-me/rainbow/blob/0ae3218255baef535b1e15fb218614b9a75f1477/src/screens/ExplainSheet.js#L868

## Screen recordings / screenshots
<!-- Screen recordings can also be helpful for showing reviewers what to test for.  -->


## What to test
<!-- 

Please be thorough about what to test to help reviewers.
You might want to emphasize potential regressions to check for.
If your code relies on a feature flag for checking both paths of the feature flag, other parts of the code that may have been impacted by your changes, etc.

Don't know what to write here? List all the steps you did to test the changes. This might help QA better understand what/how to test.

-->

e2e should pass


## Final checklist

- [ ] Assigned individual reviewers?
- [ ] Added labels? (`critical path`, `release`, `dev QA`)
- [ ] Did you test both iOS and Android?
- [ ] If your changes are visual, did you check both the light and dark themes?
- [ ] Added e2e tests? If not, please specify why
- [ ] If you added new critical path files, did you update the CODEOWNERS file?
- [ ] If no `dev QA` label, did you add the PR to the QA Queue?
