### PR TITLE
fix: re-add dog nft to reference

### DIFF
--- a/src/references/index.ts
+++ b/src/references/index.ts
@@ -95,6 +95,7 @@ export const SUSD_ADDRESS = '0x57ab1ec28d129707052df4df418d58a2d46d5f51';
 export const GUSD_ADDRESS = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
 export const SOCKS_ADDRESS = '0x23b608675a2b2fb1890d3abbd85c5775c51691d5';
 export const WBTC_ADDRESS = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599';
+export const DOG_ADDRESS = '0xbaac2b4491727d78d2b78815144570b9f2fe8899';
 
 export const TRANSFER_EVENT_TOPIC_LENGTH = 3;
 export const TRANSFER_EVENT_KECCAK =


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
dog Easter eggs were built off of develop where DOG_ADDRESS existed, because the dog favorite revert took so long to get merged I missed the scenario where there is no DOG_ADDRESS

so this just adds back the reference 

🙃 


## Screen recordings / screenshots

https://cloud.skylarbarrera.com/Screen-Recording-2022-10-25-13-18-42.mp4


## What to test

