### PR TITLE
Fix "Remove Photo" avatar context menu option

### DIFF
--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -27,6 +27,7 @@ import { buildRainbowUrl, showActionSheetWithOptions } from '@/utils';
 import useAccountAsset from './useAccountAsset';
 import { ETH_ADDRESS } from '@/references';
 import { isZero } from '@/helpers/utilities';
+import { IS_IOS } from '@/env';
 
 type UseOnAvatarPressProps = {
   /** Is the avatar selection being used on the wallet or transaction screen? */
@@ -178,21 +179,21 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
         if (isReadOnly || isZeroETH) {
           if (buttonIndex === 0) onAvatarViewProfile();
           if (buttonIndex === 1) onAvatarChooseImage();
-          if (buttonIndex === 2) ios ? onAvatarPickEmoji() : setNextEmoji();
+          if (buttonIndex === 2) IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
         } else {
           if (buttonIndex === 0) onAvatarEditProfile();
           if (buttonIndex === 1) onAvatarViewProfile();
           if (buttonIndex === 2) onAvatarChooseImage();
-          if (buttonIndex === 3) ios ? onAvatarPickEmoji() : setNextEmoji();
+          if (buttonIndex === 3) IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
         }
       } else {
         if (isReadOnly || isZeroETH) {
           if (buttonIndex === 0) onAvatarChooseImage();
-          if (buttonIndex === 1) ios ? onAvatarPickEmoji() : setNextEmoji();
+          if (buttonIndex === 1) IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
         } else {
           if (buttonIndex === 0) onAvatarCreateProfile();
           if (buttonIndex === 1) onAvatarChooseImage();
-          if (buttonIndex === 2) ios ? onAvatarPickEmoji() : setNextEmoji();
+          if (buttonIndex === 2) IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
         }
       }
     },

--- a/src/hooks/useUpdateEmoji.ts
+++ b/src/hooks/useUpdateEmoji.ts
@@ -29,6 +29,9 @@ export default function useUpdateEmoji() {
                     ...singleAddress,
                     ...(name && { label: name }),
                     ...(color !== undefined && { color }),
+                    // We need to call this in order to make sure
+                    // the profile picture is removed in "Remove Photo" flow
+                    image: null,
                   }
                 : singleAddress
           ),


### PR DESCRIPTION
Fixes APP-144

## What changed (plus any additional context for devs)

Fixed the remove photo action by adding `image: null` to emoji selection action. This makes sure that when you press remove photo and avatar picker comes up, when you actually pick an emoji the photo is removed


**Screen recordings and test instructions in linear**
