### PR TITLE
feat: analytics docs, simplify events

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,7 +145,7 @@ class OldApp extends Component {
     PerformanceTracking.finishMeasuring(
       PerformanceMetrics.loadRootAppComponent
     );
-    analyticsV2.track(analyticsV2.event.generic.applicationDidMount);
+    analyticsV2.track(analyticsV2.event.applicationDidMount);
   }
 
   componentDidUpdate(prevProps) {
@@ -196,7 +196,7 @@ class OldApp extends Component {
     }
     this.setState({ appState: nextAppState });
 
-    analyticsV2.track(analyticsV2.event.generic.appStateChange, {
+    analyticsV2.track(analyticsV2.event.appStateChange, {
       category: 'app state',
       label: nextAppState,
     });
@@ -322,7 +322,7 @@ function Root() {
         } = Dimensions.get('screen');
 
         analyticsV2.identify({ screenHeight, screenWidth, screenScale });
-        analyticsV2.track(analyticsV2.event.generic.firstAppOpen);
+        analyticsV2.track(analyticsV2.event.firstAppOpen);
       }
 
       /**

--- a/src/analytics/README.md
+++ b/src/analytics/README.md
@@ -1,0 +1,79 @@
+# `@/analytics`
+
+Our Segment wrapper.
+
+```typescript
+import { analyticsV2 } from '@/analytics';
+
+analyticsV2.identify({
+    ...userProperties,
+})
+
+analyticsV2.track(analyticsV2.event.applicationDidMount)
+analyticsV2.track(analyticsV2.event.appStateChange, {
+    category: 'app state',
+    label: 'foo',
+})
+
+analyticsV2.screen(Routes.SWAPS_PROMO_SHEET, {
+    ...metadata,
+})
+```
+
+## Events
+
+Events are managed as const objects in `@/analytics/event` to reduce the possibility of developer
+error and help us strictly type their payloads where we can. Event names should
+adhere to a naming convention as much as possible. Rougly:
+
+```bash
+<name_or_category>.<action>
+```
+
+Here, `name_or_category` should be descriptive, can contain multiple `.` separated
+parts, and increase in specificity from left to right. For instance, swaps
+related events might start with `swaps`. But different features within swaps
+might warrant bucketing into separate sub-categories, like:
+
+```bash
+swaps.user_form
+swaps.backend_processing
+```
+
+Finally, the `action` should be the _past-tense_ action that occurred:
+
+```bash
+swaps.user_form.submitted
+swaps.backend_processing.network_failed
+```
+
+### Adding a new event
+
+Add to the `event` object in `@/analytics/event`. Use a camelCase value for the
+key, and the event name (following the convention above) as the value.
+
+```typescript
+export const event = {
+    swapsUserFormSubmitted: 'swaps.user_form.submitted',
+}
+```
+
+You'll also need to define the payload for the event on the `EventProperties` type. If your event doesn't have a payload, use `undefined` as its value. See the file for examples.
+
+### Updating old events
+
+**Important:** once an event name has been used in production, it should not be
+changed. What we _can_ do is rename the key to better suit where it's called, or
+the naming conventions we've evolved to use e.g.:
+
+```typescript
+export const event = {
+    // value stays the same
+    financeSwapsFormUserSubmitted: 'swaps.user_form.submitted',
+}
+```
+
+Also consider if we might just double-emit during a transition period. In this
+case, we continue to send the old events, but also send new events with new
+payloads. After a sufficient period of time has passed, we can remove the old
+event and rely entirely on the new one.

--- a/src/analytics/README.md
+++ b/src/analytics/README.md
@@ -6,18 +6,18 @@ Our Segment wrapper.
 import { analyticsV2 } from '@/analytics';
 
 analyticsV2.identify({
-    ...userProperties,
-})
+  ...userProperties,
+});
 
-analyticsV2.track(analyticsV2.event.applicationDidMount)
+analyticsV2.track(analyticsV2.event.applicationDidMount);
 analyticsV2.track(analyticsV2.event.appStateChange, {
-    category: 'app state',
-    label: 'foo',
-})
+  category: 'app state',
+  label: 'foo',
+});
 
 analyticsV2.screen(Routes.SWAPS_PROMO_SHEET, {
-    ...metadata,
-})
+  ...metadata,
+});
 ```
 
 ## Events
@@ -54,8 +54,8 @@ key, and the event name (following the convention above) as the value.
 
 ```typescript
 export const event = {
-    swapsUserFormSubmitted: 'swaps.user_form.submitted',
-}
+  swapsUserFormSubmitted: 'swaps.user_form.submitted',
+};
 ```
 
 You'll also need to define the payload for the event on the `EventProperties` type. If your event doesn't have a payload, use `undefined` as its value. See the file for examples.
@@ -68,9 +68,9 @@ the naming conventions we've evolved to use e.g.:
 
 ```typescript
 export const event = {
-    // value stays the same
-    financeSwapsFormUserSubmitted: 'swaps.user_form.submitted',
-}
+  // value stays the same
+  financeSwapsFormUserSubmitted: 'swaps.user_form.submitted',
+};
 ```
 
 Also consider if we might just double-emit during a transition period. In this

--- a/src/analytics/__tests__/index.test.ts
+++ b/src/analytics/__tests__/index.test.ts
@@ -18,12 +18,11 @@ describe('@/analytics', () => {
     const analytics = new Analytics();
 
     analytics.setCurrentWalletAddressHash('hash');
-    analytics.track(analytics.event.generic.pressedButton);
+    analytics.track(analytics.event.pressedButton);
 
     expect(analytics.client.track).toHaveBeenCalledWith(
-      analytics.event.generic.pressedButton,
+      analytics.event.pressedButton,
       {
-        category: 'generic',
         walletAddressHash: 'hash',
       }
     );
@@ -53,27 +52,12 @@ describe('@/analytics', () => {
     });
   });
 
-  test('Analytics.getTrackingEventCategory', () => {
-    const analytics = new Analytics();
-
-    expect(
-      analytics.getTrackingEventCategory(analytics.event.swap.submittedSwap)
-    ).toEqual('swap');
-    expect(
-      analytics.getTrackingEventCategory(analytics.event.generic.pressedButton)
-    ).toEqual('generic');
-    expect(
-      // @ts-expect-error Just testing JS case
-      analytics.getTrackingEventCategory(analytics.event.foo?.pressedButton)
-    ).toEqual(undefined);
-  });
-
   test('disablement', () => {
     const analytics = new Analytics();
 
     analytics.disable();
 
-    analytics.track(analytics.event.generic.pressedButton);
+    analytics.track(analytics.event.pressedButton);
     analytics.identify({ currency: 'USD' });
     analytics.screen(Routes.BACKUP_SHEET);
 

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1,67 +1,35 @@
 /**
- * Uncategorized events
+ * All events, used by `analytics.track()`
  */
-export const genericEvent = {
-  // old
+export const event = {
   firstAppOpen: 'First App Open',
   applicationDidMount: 'React component tree finished initial mounting',
   pressedButton: 'Pressed Button',
   appStateChange: 'State change',
-
-  // new
   analyticsTrackingDisabled: 'analytics_tracking.disabled',
   analyticsTrackingEnabled: 'analytics_tracking.enabled',
+  swapSubmitted: 'Submitted Swap',
 } as const;
 
 /**
- * Events relevant to or within the swaps product
+ * Properties corresponding to each event
  */
-export const swapEvent = {
-  submittedSwap: 'Submitted Swap',
-} as const;
-
-/**
- * A union of all event names. Use this when firing events via
- * `analytics.track`
- */
-export const event = {
-  generic: genericEvent,
-  swap: swapEvent,
-} as const;
-
-/**
- * Properties corresponding to our uncategorized event enum `GenericEvent`
- */
-type GenericEventProperties = {
-  // old
-  [event.generic.firstAppOpen]: undefined;
-  [event.generic.applicationDidMount]: undefined;
-  [event.generic.appStateChange]: {
+export type EventProperties = {
+  [event.firstAppOpen]: undefined;
+  [event.applicationDidMount]: undefined;
+  [event.appStateChange]: {
     category: 'app state';
     label: string;
   };
-  [event.generic.pressedButton]: {
+  [event.pressedButton]: {
     buttonName: string;
     action: string;
   };
-
-  // new
-  [event.generic.analyticsTrackingDisabled]: undefined;
-  [event.generic.analyticsTrackingEnabled]: undefined;
-};
-
-/**
- * Properties corresponding to our swaps event enum `GenericEvent`
- */
-type SwapEventProperties = {
-  [event.swap.submittedSwap]: {
+  [event.analyticsTrackingDisabled]: undefined;
+  [event.analyticsTrackingEnabled]: undefined;
+  [event.swapSubmitted]: {
     usdValue: number;
     inputCurrencySymbol: string;
     outputCurrencySymbol: string;
   };
 };
-
-/**
- * A union of all event properties, used by `analytics.track`
- */
-export type EventProperties = GenericEventProperties & SwapEventProperties;

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -60,9 +60,8 @@ export class Analytics {
     params?: EventProperties[T]
   ) {
     if (this.disabled) return;
-    const category = this.getTrackingEventCategory(event);
     const metadata = this.getDefaultMetadata();
-    this.client.track(event, { ...params, category, ...metadata });
+    this.client.track(event, { ...params, ...metadata });
   }
 
   private getDefaultMetadata() {
@@ -94,7 +93,7 @@ export class Analytics {
    */
   enable() {
     logger.debug(`Analytics tracking enabled`);
-    this.track(event.generic.analyticsTrackingEnabled);
+    this.track(event.analyticsTrackingEnabled);
     this.disabled = false;
   }
 
@@ -103,17 +102,8 @@ export class Analytics {
    */
   disable() {
     logger.debug(`Analytics tracking disabled`);
-    this.track(event.generic.analyticsTrackingDisabled);
+    this.track(event.analyticsTrackingDisabled);
     this.disabled = true;
-  }
-
-  getTrackingEventCategory<T extends keyof EventProperties>(ev: T) {
-    for (const category of Object.keys(event)) {
-      // @ts-expect-error We know the index type of `event`
-      for (const e of Object.values(event[category])) {
-        if (e === ev) return category;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Fixes APP-122

## What changed (plus any additional context for devs)
Consolidates event enums and replaces usages. Add usage docs.

Copied from docs:

```typescript
import { analyticsV2 } from '@/analytics';

analyticsV2.identify({
    ...userProperties,
})

analyticsV2.track(analyticsV2.event.applicationDidMount)
analyticsV2.track(analyticsV2.event.appStateChange, {
    category: 'app state',
    label: 'foo',
})

analyticsV2.screen(Routes.SWAPS_PROMO_SHEET, {
    ...metadata,
})
```

## What to test
Tests pass, app runs.

