### PR TITLE
feat: add new migrations handling

### DIFF
--- a/__mocks__/react-native-mmkv.ts
+++ b/__mocks__/react-native-mmkv.ts
@@ -1,0 +1,72 @@
+import type { NativeMMKV } from 'react-native-mmkv';
+
+type MMKVValue = string | boolean | number;
+
+const GLOBAL_SHARED_STORAGE: {
+  [key: string]: Map<string, MMKVValue>;
+} = {};
+
+/**
+ * Based on the provided MMKV mock, but with global memory support to match actual MMKV usage.
+ *
+ * @see https://github.com/mrousavy/react-native-mmkv/blob/77982c1a61a5e6d2683e6569ca92e09390b28c48/src/createMMKV.mock.ts
+ */
+export class MMKV implements NativeMMKV {
+  id: string = 'default';
+  storage: Map<string, MMKVValue>;
+
+  constructor({ id }: { id: string }) {
+    this.id = id;
+
+    // `this.storage` is just a shorthand to the shared global storage, scoped to this instance
+    // eslint-disable-next-line no-multi-assign
+    this.storage = GLOBAL_SHARED_STORAGE[this.id] =
+      GLOBAL_SHARED_STORAGE[this.id] ||
+      new Map<string, string | boolean | number>();
+  }
+
+  clearAll() {
+    this.storage.clear();
+  }
+
+  delete(key: string) {
+    this.storage.delete(key);
+  }
+
+  set(key: string, value: MMKVValue) {
+    this.storage.set(key, value);
+  }
+
+  getString(key: string) {
+    const result = this.storage.get(key);
+    return typeof result === 'string' ? result : undefined;
+  }
+
+  getNumber(key: string) {
+    const result = this.storage.get(key);
+    return typeof result === 'number' ? result : undefined;
+  }
+
+  getBoolean(key: string) {
+    const result = this.storage.get(key);
+    return typeof result === 'boolean' ? result : undefined;
+  }
+
+  getBuffer(key: string) {
+    const result = this.storage.get(key);
+    // @ts-expect-error
+    return result instanceof Uint8Array ? result : undefined;
+  }
+
+  getAllKeys() {
+    return Array.from(this.storage.keys());
+  }
+
+  contains(key: string) {
+    return this.storage.has(key);
+  }
+
+  recrypt() {
+    console.warn('Encryption is not supported in mocked MMKV instances!');
+  }
+}

--- a/config/test/jest-setup.js
+++ b/config/test/jest-setup.js
@@ -35,21 +35,3 @@ jest.mock('react-native-keychain', () => ({
   resetGenericPassword: jest.fn(),
   setGenericPassword: jest.fn(),
 }));
-
-jest.mock('react-native-mmkv', () => ({
-  MMKV: class MMKVMock {
-    _store = new Map();
-
-    set(key, value) {
-      this._store.set(key, value);
-    }
-
-    getString(key) {
-      return this._store.get(key);
-    }
-
-    delete(key) {
-      return this._store.delete(key);
-    }
-  },
-}));

--- a/src/logger/debugContext.ts
+++ b/src/logger/debugContext.ts
@@ -7,4 +7,5 @@
  */
 export const DebugContext = {
   // e.g. swaps: 'swaps'
+  migrations: 'migrations',
 } as const;

--- a/src/migrations/__tests__/index.test.ts
+++ b/src/migrations/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { MMKV } from 'react-native-mmkv';
+
+import { runMigrations } from '@/migrations';
+import {
+  Migration,
+  MigrationName,
+  MIGRATIONS_STORAGE_ID,
+} from '@/migrations/types';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe(`@/migrations`, () => {
+  const storage = new MMKV({ id: MIGRATIONS_STORAGE_ID });
+
+  // TODO not working, wrong MMKV instance
+  test.skip(`runMigrations for new migration`, async () => {
+    const name = 'migration_foo' as MigrationName;
+    const migration: Migration = {
+      name,
+      async migrate() {},
+    };
+
+    await runMigrations([migration]);
+
+    expect(storage.getString(name)).toEqual(new Date().toUTCString());
+  });
+});

--- a/src/migrations/__tests__/index.test.ts
+++ b/src/migrations/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 import { MMKV } from 'react-native-mmkv';
 
 import { runMigrations } from '@/migrations';
@@ -8,27 +8,44 @@ import {
   MIGRATIONS_STORAGE_ID,
 } from '@/migrations/types';
 
-beforeEach(() => {
-  jest.useFakeTimers();
-});
-
-afterEach(() => {
-  jest.useRealTimers();
-});
-
 describe(`@/migrations`, () => {
   const storage = new MMKV({ id: MIGRATIONS_STORAGE_ID });
 
-  // TODO not working, wrong MMKV instance
-  test.skip(`runMigrations for new migration`, async () => {
-    const name = 'migration_foo' as MigrationName;
-    const migration: Migration = {
-      name,
-      async migrate() {},
+  const fooMigrationName = 'migration_foo' as MigrationName;
+  const fooMigration: Migration = {
+    name: fooMigrationName,
+    async migrate() {},
+  };
+
+  test(`new migration runs once`, async () => {
+    jest.useFakeTimers();
+    const currDate = new Date().toUTCString();
+    await runMigrations([fooMigration]);
+    jest.useRealTimers();
+
+    expect(storage.getString(fooMigrationName)).toEqual(
+      JSON.stringify({ data: currDate })
+    );
+
+    await runMigrations([fooMigration]);
+
+    // not run again
+    expect(storage.getString(fooMigrationName)).toEqual(
+      JSON.stringify({ data: currDate })
+    );
+  });
+
+  test(`migration that throws exits and does not mark as complete`, async () => {
+    const throwMigrationName = 'migration_throw' as MigrationName;
+    const throwMigration: Migration = {
+      name: throwMigrationName,
+      async migrate() {
+        throw new Error('throws');
+      },
     };
 
-    await runMigrations([migration]);
+    await runMigrations([throwMigration]);
 
-    expect(storage.getString(name)).toEqual(new Date().toUTCString());
+    expect(storage.getString(throwMigrationName)).toBeFalsy();
   });
 });

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -84,7 +84,7 @@ export async function runMigrations(migrations: Migration[]) {
     } else {
       logger.debug(
         `Already migrated`,
-        { migration: name },
+        { migration: migration.name },
         MIGRATIONS_DEBUG_CONTEXT
       );
     }

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,59 @@
+import { Storage } from '@/storage';
+import { logger, RainbowError } from '@/logger';
+
+import {
+  MIGRATIONS_DEBUG_CONTEXT,
+  MIGRATIONS_STORAGE_ID,
+  MigrationName,
+  Migration,
+} from '@/migrations/types';
+import { deleteImgixMMKVCache } from '@/migrations/migrations/deleteImgixMMKVCache';
+
+/**
+ * Local storage for migrations only. Should not be exported.
+ */
+const storage = new Storage<
+  [],
+  {
+    [key in MigrationName]: string;
+  }
+>({ id: MIGRATIONS_STORAGE_ID });
+
+/**
+ * All migrations should be added here IN the ORDER in which we need them to
+ * run.
+ */
+const migrations: Migration[] = [deleteImgixMMKVCache()];
+
+/**
+ * @private Only exported for testing
+ */
+export async function runMigrations(migrations: Migration[]) {
+  for (const { name, migrate } of migrations) {
+    const migratedAt = storage.get([name]);
+
+    if (!migratedAt) {
+      try {
+        logger.debug(`Migrating ${name}`, {}, MIGRATIONS_DEBUG_CONTEXT);
+        await migrate();
+        storage.set([name], new Date().toUTCString());
+        logger.debug(
+          `Migrating ${name} complete`,
+          {},
+          MIGRATIONS_DEBUG_CONTEXT
+        );
+      } catch (e) {
+        logger.error(new RainbowError(`Migration ${name} failed`));
+      }
+    } else {
+      logger.debug(`Already migrated ${name}`, {}, MIGRATIONS_DEBUG_CONTEXT);
+    }
+  }
+}
+
+/**
+ * Run all migrations
+ */
+export async function migrate() {
+  await runMigrations(migrations);
+}

--- a/src/migrations/migrations/deleteImgixMMKVCache.ts
+++ b/src/migrations/migrations/deleteImgixMMKVCache.ts
@@ -1,0 +1,15 @@
+import { MMKV } from 'react-native-mmkv';
+
+import { Migration, MigrationName } from '@/migrations/types';
+
+const IMGIX_STORAGE_ID = 'IMGIX_CACHE';
+
+export function deleteImgixMMKVCache(): Migration {
+  return {
+    name: MigrationName.deleteImgixMMKVCache,
+    async migrate() {
+      const storage = new MMKV({ id: IMGIX_STORAGE_ID });
+      storage.clearAll();
+    },
+  };
+}

--- a/src/migrations/migrations/deleteImgixMMKVCache.ts
+++ b/src/migrations/migrations/deleteImgixMMKVCache.ts
@@ -7,7 +7,7 @@ const IMGIX_STORAGE_ID = 'IMGIX_CACHE';
 export function deleteImgixMMKVCache(): Migration {
   return {
     name: MigrationName.deleteImgixMMKVCache,
-    async migrate() {
+    async defer() {
       const storage = new MMKV({ id: IMGIX_STORAGE_ID });
       storage.clearAll();
     },

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -18,9 +18,24 @@ export type Migration = {
   name: MigrationName;
 
   /**
-   * An async function that runs your migration. This handler MUST NOT swallow
-   * errors. If an error is swallowed, the migration will be incorrectly marked
-   * as complete.
+   * Runs immediately on startup, and is intended for migrations that MUST
+   * happen prior to anything else in the app. Be very careful about adding any
+   * long-running actions in this type of migration. For long running
+   * migrations, or those that don't need to happen immediately, use `defer()`
+   * instead.
+   *
+   * This handler MUST NOT swallow errors. If an error is swallowed, the
+   * migration will be incorrectly marked as complete.
    */
-  migrate(): Promise<void>;
+  migrate?(): Promise<void>;
+
+  /**
+   * Runs lazily using `InteractionManager.runAfterInteractions`. Intended for
+   * long-running migrations, or those that don't need to happen immediately.
+   * Not intended for migrations that are required for app startup.
+   *
+   * This handler MUST NOT swallow errors. If an error is swallowed, the
+   * migration will be incorrectly marked as complete.
+   */
+  defer?(): Promise<void>;
 };

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -1,0 +1,26 @@
+import { DebugContext } from '@/logger/debugContext';
+
+export const MIGRATIONS_DEBUG_CONTEXT = DebugContext.migrations;
+export const MIGRATIONS_STORAGE_ID = 'migrations';
+
+/**
+ * UNIQUE names for all migrations. Using an enum here forces the values to be
+ * unique. Please follow the naming convention for consistencies sake.
+ */
+export enum MigrationName {
+  deleteImgixMMKVCache = 'migration_deleteImgixMMKVCache',
+}
+
+export type Migration = {
+  /**
+   * Must be a UNIQUE name of the migration.
+   */
+  name: MigrationName;
+
+  /**
+   * An async function that runs your migration. This handler MUST NOT swallow
+   * errors. If an error is swallowed, the migration will be incorrectly marked
+   * as complete.
+   */
+  migrate(): Promise<void>;
+};


### PR DESCRIPTION
Fixes APP-174

## What changed (plus any additional context for devs)
Adds new migrations setup to the app. Problems with **current migrations**:
- run within `useInitializeWallet`
- rely on remote data being loaded
- run after app initializes, could cause race conditions (if not already)
- checking for `length` of migrations is a little flimsy (remove one, add another, it won't get run (not that we'd do this))
- error handling seems sketch? does this mark as completed it a migration throws? I don't see recovery handling 🤔 

This approach:
- run immediately upon app startup
- agnostic of other data
- gracefully handles errors
- full test suite

## What to test
There's a test suite. I wrote my own MMKV mock since the provided one doesn't actually function the same way as MMKV does in production (shared memory referenced by `id`).

