### PR TITLE
Add asset values for l2 networks

### DIFF
--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -36,6 +36,8 @@ export interface UserProperties {
   polygon_assets_value?: number;
   optimism_assets_value?: number;
   arbitrum_assets_value?: number;
+  nft_floor_price_value?: number;
+  nft_last_price_value?: number;
   avalanche_assets_value?: number;
   xdai_assets_value?: number;
   locked_value?: number;

--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -36,6 +36,8 @@ export interface UserProperties {
   polygon_assets_value?: number;
   optimism_assets_value?: number;
   arbitrum_assets_value?: number;
+  avalanche_assets_value?: number;
+  xdai_assets_value?: number;
   locked_value?: number;
   staked_value?: number;
   total_value?: number;

--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -34,6 +34,8 @@ export interface UserProperties {
   bsc_assets_value?: number;
   deposited_value?: number;
   polygon_assets_value?: number;
+  optimism_assets_value?: number;
+  arbitrum_assets_value?: number;
   locked_value?: number;
   staked_value?: number;
   total_value?: number;

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -19,6 +19,8 @@ export default function usePortfolios() {
       bsc_assets_value: 0,
       deposited_value: 0,
       locked_value: 0,
+      nft_floor_price_value: 0,
+      nft_last_price_value: 0,
       optimism_assets_value: 0,
       polygon_assets_value: 0,
       staked_value: 0,

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -12,11 +12,13 @@ export default function usePortfolios() {
 
   const trackPortfolios = useCallback(() => {
     const total = {
+      arbitrum_assets_value: 0,
       assets_value: 0,
       borrowed_value: 0,
       bsc_assets_value: 0,
       deposited_value: 0,
       locked_value: 0,
+      optimism_assets_value: 0,
       polygon_assets_value: 0,
       staked_value: 0,
       total_value: 0,

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -1,7 +1,7 @@
 import { isNil, keys } from 'lodash';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
 import { AppState } from '@/redux/store';
 import logger from '@/utils/logger';
 
@@ -37,7 +37,7 @@ export default function usePortfolios() {
     logger.log('💰 wallet totals', JSON.stringify(total, null, 2));
     keys(total).forEach(key => {
       const data = { [key]: total[key as keyof typeof total] };
-      analytics.identify(undefined, data);
+      analyticsV2.identify(data);
     });
   }, [portfolios]);
 

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -14,6 +14,7 @@ export default function usePortfolios() {
     const total = {
       arbitrum_assets_value: 0,
       assets_value: 0,
+      avalanche_assets_value: 0,
       borrowed_value: 0,
       bsc_assets_value: 0,
       deposited_value: 0,
@@ -22,6 +23,7 @@ export default function usePortfolios() {
       polygon_assets_value: 0,
       staked_value: 0,
       total_value: 0,
+      xdai_assets_value: 0,
     };
     keys(portfolios).forEach(address => {
       keys(portfolios[address]).forEach(key => {

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -362,6 +362,17 @@ interface CoingeckoApiResponseWithLastUpdate {
  * https://docs.zerion.io/websockets/models#portfolio for details.
  */
 interface ZerionPortfolio {
+  arbitrum_assets_value: number;
+  aurora_assets_value: number;
+  avalanche_assets_value: number;
+  ethereum_assets_value: number;
+  fantom_assets_value: number;
+  loopring_assets_value: number;
+  nft_floor_price_value: number;
+  nft_last_price_value: number;
+  optimism_assets_value: number;
+  solana_assets_value: number;
+  xdai_assets_value: number;
   assets_value: number;
   deposited_value: number;
   borrowed_value: number;


### PR DESCRIPTION
Fixes APP-187

## What changed (plus any additional context for devs)
- updated `trackPortfolios` callback from `usePortfolios` hook to include asset values for optimism and arbitrum
- updated `ZerionPortfolio` object (we use this to map zerion api response)

## Screen recordings / screenshots

sample zerion response

<img width="366" alt="Screenshot 2022-11-07 at 2 47 39 PM" src="https://user-images.githubusercontent.com/15272675/200431707-ab0a6b82-4022-42d8-9b22-8d2bc5cd601b.png">


## What to test

