### PR TITLE
Revert to using updated react-native fork rebased from 0.68.1 to 0.68.5

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1020,7 +1020,7 @@ SPEC CHECKSUMS:
   CodePush: b51b7ac64c07d4eacfc8cc5750a1dd28adbf2528
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 2b47ff52037bd9ae07cc9b051c9975797814b736
-  FBReactNativeSpec: 0e0d384ef17a33b385f13f0c7f97702c7cd17858
+  FBReactNativeSpec: c297b3ebb8b22a19aebfa2c8d173dbc3cae15ce2
   Firebase: 7e8fe528c161b9271d365217a74c16aaf834578e
   FirebaseABTesting: aaa0e096c9fc9972ce6806d596e8fcc077d4371f
   FirebaseCore: b84a44ee7ba999e0f9f76d198a9c7f60a797b848

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "react-coin-icon": "rainbow-me/react-coin-icon#06464588a3d986f6ef3a7d7341b2d7ea0c5ac50b",
     "react-fast-compare": "2.0.4",
     "react-flatten-children": "1.1.2",
-    "react-native": "0.68.5",
+    "react-native": "rainbow-me/react-native#e4199f33b90914aeefcb638e02285711f45e422e",
     "react-native-action-sheet": "2.2.0",
     "react-native-actionsheet": "2.4.2",
     "react-native-aes-crypto": "rainbow-me/react-native-aes#65c49f7e70266615b2999eaa7db654d3fe4f2e3b",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14591,10 +14591,9 @@ react-native-widgetkit@1.0.9:
   resolved "https://registry.yarnpkg.com/react-native-widgetkit/-/react-native-widgetkit-1.0.9.tgz#aded1c12f7c7cfd18912b947228aac433c05ddc2"
   integrity sha512-WBwdUbcOzyL0LiqhRyd7gS9A1D0X5A/m2h0fAKTbxUAbp3r2D2pdjyPnVW/6q0otpq7RIyZFo6Ln1EDJ9gfhEg==
 
-react-native@0.68.5:
+react-native@rainbow-me/react-native#e4199f33b90914aeefcb638e02285711f45e422e:
   version "0.68.5"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.68.5.tgz#8ba7389e00b757c59b6ea23bf38303d52367d155"
-  integrity sha512-t3kiQ/gumFV+0r/NRSIGtYxanjY4da0utFqHgkMcRPJVwXFWC0Fr8YiOeRGYO1dp8EfrSsOjtfWic/inqVYlbQ==
+  resolved "https://codeload.github.com/rainbow-me/react-native/tar.gz/e4199f33b90914aeefcb638e02285711f45e422e"
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^7.0.3"


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* @brunobar79 I reverted to use the fork I would be grateful for a review of what I have there https://github.com/rainbow-me/react-native/commits/%40jkadamczyk/rebased-fixes-0.68.5
* Everyone else please test and try building the android app
