### PR TITLE
Fix "hide NFT" icon

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -276,7 +276,7 @@ const UniqueTokenExpandedStateHeader = ({
                   : lang.t('expanded_state.unique_expanded.hide'),
                 icon: {
                   ...AssetActions[AssetActionsEnum.hide].icon,
-                  iconValue: isHiddenAsset ? 'eye.slash' : 'eye',
+                  iconValue: isHiddenAsset ? 'eye' : 'eye.slash',
                 },
               },
             ]


### PR DESCRIPTION
Fixes APP-172

## What changed (plus any additional context for devs)
- eye icons for hide/unhide were reversed

## Screen recordings / screenshots
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-08 at 17 41 09](https://user-images.githubusercontent.com/15272675/200716039-bcc5e5c5-bdd1-47d3-9d14-e18da8cefd8d.png)
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-08 at 17 41 19](https://user-images.githubusercontent.com/15272675/200716055-f17377aa-9487-48ec-ba7a-d9aa56e7bfc7.png)


## What to test
- see ticket for figma
