### PR TITLE
swaps: compare assets with uniqueId

### DIFF
--- a/src/redux/swap.ts
+++ b/src/redux/swap.ts
@@ -137,7 +137,7 @@ export const updateSwapInputCurrency = (
   } = getState().swap;
   if (
     type === ExchangeModalTypes.swap &&
-    newInputCurrency?.address === outputCurrency?.address &&
+    newInputCurrency?.uniqueId === outputCurrency?.uniqueId &&
     newInputCurrency
   ) {
     dispatch(flipSwapCurrencies(false));
@@ -175,7 +175,7 @@ export const updateSwapOutputCurrency = (
 ) => (dispatch: AppDispatch, getState: AppGetState) => {
   const { independentField, inputCurrency, type } = getState().swap;
   if (
-    newOutputCurrency?.address === inputCurrency?.address &&
+    newOutputCurrency?.uniqueId === inputCurrency?.uniqueId &&
     newOutputCurrency
   ) {
     dispatch(flipSwapCurrencies(true));


### PR DESCRIPTION
Fixes APP-196

## What changed (plus any additional context for devs)
we were checking based on address but we want to check based on uniqueId since assets can have the same address on diff networks 

## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2022-11-09-19-53-13.mp4


## What to test
read the code and press the green button 🔫 
