### PR TITLE
fix: bump cross chain gas explainer height

### DIFF
--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -591,7 +591,7 @@ export const explainers = (params, colors) => ({
     ),
   },
   crossChainGas: {
-    extraHeight: 20,
+    extraHeight: 40,
     title: lang.t('explain.cross_chain_swap.title'),
     text: lang.t('explain.cross_chain_swap.text'),
     logo: (


### PR DESCRIPTION
## What changed (plus any additional context for devs)
while looking into another issue I noticed this sheet height was too low, ive bumped it so it looks better


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Shot-2022-11-10-13-20-41.67.png


## What to test
screen shot 

