### PR TITLE
swaps: scroll up when changing networks 

### DIFF
--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -12,7 +12,14 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { InteractionManager, Keyboard, Linking, TextInput } from 'react-native';
+import {
+  DefaultSectionT,
+  InteractionManager,
+  Keyboard,
+  Linking,
+  SectionList,
+  TextInput,
+} from 'react-native';
 import { MMKV } from 'react-native-mmkv';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useDispatch } from 'react-redux';
@@ -52,7 +59,6 @@ import { SwappableAsset } from '@/entities';
 import { Box, Row, Rows } from '@/design-system';
 import { useTheme } from '@/theme';
 import { IS_TEST } from '@/env';
-import tokenSectionTypes from '@/helpers/tokenSectionTypes';
 import DiscoverSearchInput from '@/components/discover/DiscoverSearchInput';
 
 export interface EnrichedExchangeAsset extends SwappableAsset {
@@ -134,6 +140,8 @@ export default function CurrencySelectModal() {
     },
   } = useRoute<RouteProp<ParamList, 'Currency'>>();
 
+  const listRef = useRef<SectionList<any, DefaultSectionT>>(null);
+
   const scrollPosition = (usePagerPosition() as unknown) as { value: number };
 
   const searchInputRef = useRef<TextInput>(null);
@@ -151,6 +159,8 @@ export default function CurrencySelectModal() {
   const { hiddenCoinsObj } = useCoinListEditOptions();
 
   const [currentChainId, setCurrentChainId] = useState(chainId);
+  const prevChainId = usePrevious(currentChainId);
+
   const crosschainSwapsEnabled = useExperimentalFlag(CROSSCHAIN_SWAPS);
   const NetworkSwitcher = crosschainSwapsEnabled
     ? NetworkSwitcherv2
@@ -164,6 +174,18 @@ export default function CurrencySelectModal() {
       setCurrentChainId(chainId);
     }
   }, [chainId]);
+
+  useEffect(() => {
+    if (currentChainId !== prevChainId) {
+      listRef?.current?.scrollToLocation({
+        animated: false,
+        itemIndex: 0,
+        sectionIndex: 0,
+        viewOffset: 0,
+        viewPosition: 0,
+      });
+    }
+  }, [currentChainId, prevChainId]);
 
   const { inputCurrency, outputCurrency } = useSwapCurrencies();
 
@@ -649,6 +671,7 @@ export default function CurrencySelectModal() {
             )}
             {type === null || type === undefined ? null : (
               <CurrencySelectionList
+                ref={listRef}
                 isExchangeList={crosschainSwapsEnabled}
                 onL2={searchingOnL2Network}
                 footerSpacer={android}


### PR DESCRIPTION
Fixes APP-205

## What changed (plus any additional context for devs)
behavior was a lil off, now we reset the list to the top when a user switches networks 


## Screen recordings / screenshots
note the following PoW is animated, I disabled that so the behavior is a lot quicker than shown.

https://cloud.skylarbarrera.com/Screen-Recording-2022-11-10-16-42-54.mp4



## What to test
N/A

