### PR TITLE
fix: rm chain specific metadata 

### DIFF
--- a/src/entities/tokens.ts
+++ b/src/entities/tokens.ts
@@ -114,3 +114,14 @@ export interface RainbowToken extends Asset {
 export interface IndexToken extends Asset {
   amount: string;
 }
+
+export interface TokenMetadata {
+  address: EthereumAddress;
+  name: string;
+  color?: string;
+  isRainbowCurated?: boolean;
+  isVerified?: boolean;
+  shadowColor?: string;
+  chainId?: number;
+  decimals?: number;
+}

--- a/src/entities/tokens.ts
+++ b/src/entities/tokens.ts
@@ -118,6 +118,7 @@ export interface IndexToken extends Asset {
 export interface TokenMetadata {
   address: EthereumAddress;
   name: string;
+  symbol: string;
   color?: string;
   isRainbowCurated?: boolean;
   isVerified?: boolean;

--- a/src/parsers/accounts.js
+++ b/src/parsers/accounts.js
@@ -69,8 +69,8 @@ export const parseAsset = ({ asset_code: address, ...asset } = {}) => {
       : AssetTypes.token;
 
   const parsedAsset = {
-    ...metadata,
     ...asset,
+    ...metadata,
     address,
     isNativeAsset: isNativeAsset(
       address,

--- a/src/parsers/accounts.js
+++ b/src/parsers/accounts.js
@@ -69,8 +69,8 @@ export const parseAsset = ({ asset_code: address, ...asset } = {}) => {
       : AssetTypes.token;
 
   const parsedAsset = {
-    ...asset,
     ...metadata,
+    ...asset,
     address,
     isNativeAsset: isNativeAsset(
       address,

--- a/src/utils/getTokenMetadata.ts
+++ b/src/utils/getTokenMetadata.ts
@@ -1,9 +1,16 @@
-import { RainbowToken } from '@/entities';
+import { TokenMetadata } from '@/entities/tokens';
 import { rainbowTokenList } from '@/references';
 
 export default function getTokenMetadata(
   tokenAddress: string | undefined
-): RainbowToken | undefined {
+): TokenMetadata | undefined {
   if (!tokenAddress) return undefined;
-  return rainbowTokenList.RAINBOW_TOKEN_LIST[tokenAddress.toLowerCase()];
+  const metadata: TokenMetadata =
+    rainbowTokenList.RAINBOW_TOKEN_LIST[tokenAddress.toLowerCase()];
+
+  // delete chain specific metadata
+  delete metadata?.decimals;
+  delete metadata?.chainId;
+
+  return metadata;
 }

--- a/src/utils/getTokenMetadata.ts
+++ b/src/utils/getTokenMetadata.ts
@@ -3,7 +3,7 @@ import { rainbowTokenList } from '@/references';
 
 export default function getTokenMetadata(
   tokenAddress: string | undefined
-): TokenMetadata | undefined {
+): Omit<TokenMetadata, 'decimals' | 'chainId'> | undefined {
   if (!tokenAddress) return undefined;
   const metadata: TokenMetadata =
     rainbowTokenList.RAINBOW_TOKEN_LIST[tokenAddress.toLowerCase()];


### PR DESCRIPTION
Fixes APP-191

## What changed (plus any additional context for devs)
we have a token list that gives us metadata on tokens that looks like this: https://cloud.skylarbarrera.com/Screen-Shot-2022-11-14-10-57-19.09.png

previously we were allowing this to overwrite data we get for the backend, this was affecting our balance calculations for L2 assets when the decimals didnt match.

ex: USDT on mainnet has 6 decimals of precision, on bsc it has 18(standard), we use this to calculated balance value so things were looking funky for BSC USDT. 

should be a no op, we're just removing chain specific metadata now (which are unneeded since we have this data already)

## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2022-11-14-11-02-23.mp4



## What to test

https://cloud.skylarbarrera.com/Screen-Recording-2022-11-14-11-02-23.mp4

