### PR TITLE
fix: bridging tx's statuses

### DIFF
--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -25,7 +25,7 @@ export const defaultConfig = {
   [NOTIFICATIONS]: { needsRestart: true, settings: true, value: true },
   [PROFILES]: { settings: true, value: true },
   [REVIEW_ANDROID]: { settings: false, value: false },
-  [CROSSCHAIN_SWAPS]: { settings: true, value: false },
+  [CROSSCHAIN_SWAPS]: { settings: true, value: true },
 };
 
 const storageKey = 'config';

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -25,7 +25,7 @@ export const defaultConfig = {
   [NOTIFICATIONS]: { needsRestart: true, settings: true, value: true },
   [PROFILES]: { settings: true, value: true },
   [REVIEW_ANDROID]: { settings: false, value: false },
-  [CROSSCHAIN_SWAPS]: { settings: true, value: true },
+  [CROSSCHAIN_SWAPS]: { settings: true, value: false },
 };
 
 const storageKey = 'config';

--- a/src/handlers/transactions.ts
+++ b/src/handlers/transactions.ts
@@ -410,6 +410,12 @@ export const getTransactionSocketStatus = async (
     }
   } catch (e) {
     logger.error(new RainbowError(`catch socket tx check failed: ${e}`));
+    if (IS_TEST) {
+      status = swap?.isBridge
+        ? TransactionStatus.bridged
+        : TransactionStatus.swapped;
+      pending = false;
+    }
   }
 
   const title = getTitle({

--- a/src/handlers/transactions.ts
+++ b/src/handlers/transactions.ts
@@ -48,6 +48,7 @@ import { swapMetadataStorage } from '@/raps/actions/swap';
 import { SwapMetadata } from '@/raps/common';
 import WalletTypes from '@/helpers/walletTypes';
 import { analytics } from '@/analytics';
+import { logger, RainbowError } from '@/logger';
 
 const flashbotsApi = new RainbowFetchClient({
   baseURL: 'https://protect.flashbots.net',
@@ -384,6 +385,7 @@ export const getTransactionSocketStatus = async (
     });
     const socketResponse = socketStatus.data;
     if (socketResponse.success) {
+      console.log('its a success!! ', socketResponse);
       if (socketResponse?.result?.sourceTxStatus === 'COMPLETED') {
         status = swap?.isBridge
           ? TransactionStatus.bridging
@@ -403,10 +405,13 @@ export const getTransactionSocketStatus = async (
         pending = false;
       }
     } else if (socketResponse.error) {
+      logger.debug('socket tx check failed: ', socketResponse.error);
       status = TransactionStatus.failed;
       pending = false;
     }
   } catch (e) {
+    logger.error(new RainbowError(`catch socket tx check failed: ${e}`));
+
     if (IS_TEST) {
       status = swap?.isBridge
         ? TransactionStatus.bridged

--- a/src/handlers/transactions.ts
+++ b/src/handlers/transactions.ts
@@ -404,12 +404,17 @@ export const getTransactionSocketStatus = async (
         pending = false;
       }
     } else if (socketResponse.error) {
-      logger.debug('socket tx check failed: ', socketResponse.error);
+      logger.warn(
+        'getTransactionSocketStatus transaction check failed',
+        socketResponse.error
+      );
       status = TransactionStatus.failed;
       pending = false;
     }
   } catch (e) {
-    logger.error(new RainbowError(`catch socket tx check failed: ${e}`));
+    logger.error(
+      new RainbowError('getTransactionSocketStatus transaction check caught')
+    );
     if (IS_TEST) {
       status = swap?.isBridge
         ? TransactionStatus.bridged

--- a/src/handlers/transactions.ts
+++ b/src/handlers/transactions.ts
@@ -385,7 +385,6 @@ export const getTransactionSocketStatus = async (
     });
     const socketResponse = socketStatus.data;
     if (socketResponse.success) {
-      console.log('its a success!! ', socketResponse);
       if (socketResponse?.result?.sourceTxStatus === 'COMPLETED') {
         status = swap?.isBridge
           ? TransactionStatus.bridging
@@ -411,16 +410,6 @@ export const getTransactionSocketStatus = async (
     }
   } catch (e) {
     logger.error(new RainbowError(`catch socket tx check failed: ${e}`));
-
-    if (IS_TEST) {
-      status = swap?.isBridge
-        ? TransactionStatus.bridged
-        : TransactionStatus.swapped;
-      pending = false;
-    } else {
-      status = TransactionStatus.failed;
-      pending = false;
-    }
   }
 
   const title = getTitle({

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1418,9 +1418,7 @@ export const dataWatchPendingTransactions = (
               updatedPendingTransaction,
               transactionStatus
             );
-            if (transactionStatus !== pendingTransactionData.status) {
-              txStatusesDidChange = true;
-            }
+            txStatusesDidChange = true;
           }
         } else if (tx.flashbots) {
           pendingTransactionData = await getTransactionFlashbotStatus(

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1434,11 +1434,12 @@ export const dataWatchPendingTransactions = (
             dispatch(decrementNonce(tx.from!, tx.nonce!, Network.mainnet));
           }
         }
-
-        updatedPendingTransaction.title = pendingTransactionData.title;
-        updatedPendingTransaction.status = pendingTransactionData.status;
-        updatedPendingTransaction.pending = pendingTransactionData.pending;
-        updatedPendingTransaction.minedAt = pendingTransactionData.minedAt;
+        if (pendingTransactionData) {
+          updatedPendingTransaction.title = pendingTransactionData.title;
+          updatedPendingTransaction.status = pendingTransactionData.status;
+          updatedPendingTransaction.pending = pendingTransactionData.pending;
+          updatedPendingTransaction.minedAt = pendingTransactionData.minedAt;
+        }
       } catch (error) {
         logger.log('Error watching pending txn', error);
       }

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1359,7 +1359,7 @@ export const dataWatchPendingTransactions = (
         status: TransactionStatus;
       } | null = {
         status: TransactionStatus.sending,
-        title: '',
+        title: pendingTransactionData?.title || TransactionStatus.sending,
         minedAt: null,
         pending: true,
       };
@@ -1406,14 +1406,11 @@ export const dataWatchPendingTransactions = (
             pendingTransactionData = await getTransactionSocketStatus(
               updatedPendingTransaction
             );
-            logger.debug('pending tx data: ', pendingTransactionData);
             if (!pendingTransactionData.pending) {
               appEvents.emit('transactionConfirmed', {
                 ...txObj,
                 internalType: tx.type,
               });
-            }
-            if (transactionStatus !== pendingTransactionData.status) {
               txStatusesDidChange = true;
             }
           } else {
@@ -1438,12 +1435,10 @@ export const dataWatchPendingTransactions = (
           }
         }
 
-        if (pendingTransactionData) {
-          updatedPendingTransaction.title = pendingTransactionData.title;
-          updatedPendingTransaction.status = pendingTransactionData.status;
-          updatedPendingTransaction.pending = pendingTransactionData.pending;
-          updatedPendingTransaction.minedAt = pendingTransactionData.minedAt;
-        }
+        updatedPendingTransaction.title = pendingTransactionData.title;
+        updatedPendingTransaction.status = pendingTransactionData.status;
+        updatedPendingTransaction.pending = pendingTransactionData.pending;
+        updatedPendingTransaction.minedAt = pendingTransactionData.minedAt;
       } catch (error) {
         logger.log('Error watching pending txn', error);
       }

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1359,7 +1359,7 @@ export const dataWatchPendingTransactions = (
         status: TransactionStatus;
       } | null = {
         status: TransactionStatus.sending,
-        title: pendingTransactionData?.title || TransactionStatus.sending,
+        title: tx?.title || TransactionStatus.sending,
         minedAt: null,
         pending: true,
       };

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1413,13 +1413,17 @@ export const dataWatchPendingTransactions = (
                 internalType: tx.type,
               });
             }
-            txStatusesDidChange = true;
+            if (transactionStatus !== pendingTransactionData.status) {
+              txStatusesDidChange = true;
+            }
           } else {
             pendingTransactionData = getPendingTransactionData(
               updatedPendingTransaction,
               transactionStatus
             );
-            txStatusesDidChange = true;
+            if (transactionStatus !== pendingTransactionData.status) {
+              txStatusesDidChange = true;
+            }
           }
         } else if (tx.flashbots) {
           pendingTransactionData = await getTransactionFlashbotStatus(
@@ -1433,6 +1437,7 @@ export const dataWatchPendingTransactions = (
             dispatch(decrementNonce(tx.from!, tx.nonce!, Network.mainnet));
           }
         }
+
         if (pendingTransactionData) {
           updatedPendingTransaction.title = pendingTransactionData.title;
           updatedPendingTransaction.status = pendingTransactionData.status;


### PR DESCRIPTION
Fixes APP-80

## What changed (plus any additional context for devs)

handling regarding bridge tx statuses was kinda wonky 👇 

1. we we're checking token approvals via the socket api, this isn't handled by them and was causing issues. now we just check like we do a normal tx
2. if we got any type of error from socket we were marking the tx as failed -> their api seems kinda wonky atm and would throw errors when it shouldn't. we should only mark as failed if socket explicitly tells us the tx failed, otherwise we should continue watching the tx status
^ ive kept the `IS_TEST` logic as this api wont work on e2e tests since they're simulated tx's


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2022-11-14-14-05-22.mp4


## What to test
imma let ibrahim do his thing on this one so code review is 👌 

