### PR TITLE
feat: add QUIET_OLD_LOGGER, fix analytics debug

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -79,4 +79,5 @@ declare module 'react-native-dotenv' {
   export const RAINBOW_TOKEN_LIST_URL: string;
   export const LOG_LEVEL: 'debug' | 'info' | 'warn' | 'error';
   export const LOG_DEBUG: string;
+  export const QUIET_OLD_LOGGER: string;
 }

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -19,7 +19,9 @@ export class Analytics {
 
   constructor() {
     this.client = createClient({
-      debug: Boolean(LOG_DEBUG) || LOG_LEVEL === LogLevel.Debug,
+      debug:
+        (LOG_DEBUG || '').includes(logger.DebugContext.analytics) ||
+        LOG_LEVEL === LogLevel.Debug,
       trackAppLifecycleEvents: true,
       trackDeepLinks: true,
       writeKey: REACT_APP_SEGMENT_API_WRITE_KEY,

--- a/src/logger/debugContext.ts
+++ b/src/logger/debugContext.ts
@@ -8,4 +8,5 @@
 export const DebugContext = {
   // e.g. swaps: 'swaps'
   migrations: 'migrations',
+  analytics: 'analytics',
 } as const;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import { captureException } from '@sentry/react-native';
+import { QUIET_OLD_LOGGER } from 'react-native-dotenv';
 import sentryUtils from './sentry';
 
 /**
@@ -9,6 +10,7 @@ const Logger = {
    * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
    */
   debug(...args: any[]) {
+    if (QUIET_OLD_LOGGER) return;
     if (__DEV__) {
       const date = new Date().toLocaleTimeString();
       Array.prototype.unshift.call(args, `[${date}] ⚡⚡⚡ `);
@@ -20,6 +22,7 @@ const Logger = {
    * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
    */
   error(...args: any[]) {
+    if (QUIET_OLD_LOGGER) return;
     if (__DEV__) {
       console.error(...args); // eslint-disable-line no-console
     }
@@ -29,6 +32,7 @@ const Logger = {
    * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
    */
   log(...args: any[]) {
+    if (QUIET_OLD_LOGGER) return;
     if (__DEV__) {
       const date = new Date().toLocaleTimeString();
       Array.prototype.unshift.call(args, `[${date}]`);
@@ -40,6 +44,7 @@ const Logger = {
    * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
    */
   prettyLog() {
+    if (QUIET_OLD_LOGGER) return;
     if (__DEV__) {
       const allArgs = Array.prototype.slice.call(arguments).map(arg => {
         try {
@@ -60,6 +65,7 @@ const Logger = {
    * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
    */
   sentry(...args: any[]) {
+    if (QUIET_OLD_LOGGER) return;
     if (__DEV__) {
       const date = new Date().toLocaleTimeString();
       Array.prototype.unshift.call(args, `[${date}]`);
@@ -78,6 +84,7 @@ const Logger = {
    * @deprecated use `@/logger` instead, and see `@/logger/README` for documentation
    */
   warn(...args: any[]) {
+    if (QUIET_OLD_LOGGER) return;
     if (__DEV__) {
       console.warn(...args); // eslint-disable-line no-console
     }


### PR DESCRIPTION
Adds `QUIET_OLD_LOGGER` to silence our old console logs. Does not affect new logger.

Also fixes issue where any debug context (i.e. `LOG_DEBUG=migrations`) specified would trigger debug mode in the Segment analyticsv2 instance, which was additional noise we don't need. Now you have to pass either `LOG_LEVEL=debug` or `LOG_DEBUG=analytics` explicitly.

