### PR TITLE
feat: add debug mode to migrations

### DIFF
--- a/src/migrations/__tests__/migrations-prod.test.ts
+++ b/src/migrations/__tests__/migrations-prod.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from '@jest/globals';
+import { MMKV } from 'react-native-mmkv';
+
+import { logger, RainbowError } from '@/logger';
+import { runMigrations } from '@/migrations';
+import {
+  Migration,
+  MigrationName,
+  MIGRATIONS_STORAGE_ID,
+} from '@/migrations/types';
+
+jest.mock('@/env', () => ({
+  IS_PROD: true,
+}));
+
+describe(`@/migrations IS_PROD`, () => {
+  const storage = new MMKV({ id: MIGRATIONS_STORAGE_ID });
+
+  test(`migration in debug mode in prod exits early and logs`, async () => {
+    const spy = jest.fn();
+
+    const removeTransport = logger.addTransport(spy);
+
+    const name = 'migration_debug' as MigrationName;
+    const migration: Migration = {
+      debug: true,
+      name,
+      async migrate() {},
+    };
+
+    await runMigrations([migration]);
+
+    expect(storage.getString(name)).toBeFalsy();
+    expect(spy).toHaveBeenCalledWith(
+      logger.LogLevel.Error,
+      new RainbowError(`Migration is in debug mode`),
+      { migration: name }
+    );
+
+    removeTransport();
+  });
+});

--- a/src/migrations/__tests__/migrations.test.ts
+++ b/src/migrations/__tests__/migrations.test.ts
@@ -67,4 +67,17 @@ describe(`@/migrations`, () => {
 
     expect(storage.getString(throwMigrationName)).toBeFalsy();
   });
+
+  test(`migration in debug mode does not mark as complete`, async () => {
+    const throwMigrationName = 'migration_debug' as MigrationName;
+    const throwMigration: Migration = {
+      debug: true,
+      name: throwMigrationName,
+      async migrate() {},
+    };
+
+    await runMigrations([throwMigration]);
+
+    expect(storage.getString(throwMigrationName)).toBeFalsy();
+  });
 });

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,5 +1,6 @@
 import { InteractionManager } from 'react-native';
 
+import * as env from '@/env';
 import { Storage } from '@/storage';
 import { logger, RainbowError } from '@/logger';
 
@@ -30,7 +31,18 @@ const migrations: Migration[] = [deleteImgixMMKVCache()];
 /**
  * @private Only exported for testing
  */
-export async function runMigration({ name, migrate, defer }: Migration) {
+export async function runMigration({ debug, name, migrate, defer }: Migration) {
+  /**
+   * If we're in prod and a migration is in debug mode, that's a mistake and we
+   * should exit early
+   */
+  if (debug && env.IS_PROD) {
+    logger.error(new RainbowError(`Migration is in debug mode`), {
+      migration: name,
+    });
+    return;
+  }
+
   const handler = migrate || defer;
 
   if (handler) {
@@ -43,7 +55,7 @@ export async function runMigration({ name, migrate, defer }: Migration) {
         MIGRATIONS_DEBUG_CONTEXT
       );
       await handler();
-      storage.set([name], new Date().toUTCString());
+      if (!debug) storage.set([name], new Date().toUTCString());
       logger.debug(
         `Migrating complete`,
         {

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -13,6 +13,12 @@ export enum MigrationName {
 
 export type Migration = {
   /**
+   * Set to true to run the migration every time when writing your migration
+   * code
+   */
+  debug?: boolean;
+
+  /**
    * Must be a UNIQUE name of the migration.
    */
   name: MigrationName;

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -14,7 +14,8 @@ export enum MigrationName {
 export type Migration = {
   /**
    * Set to true to run the migration every time when writing your migration
-   * code
+   * code. DELETE THIS PROP or set to `false` before merging your code,
+   * otherwise your migration will not run in production.
    */
   debug?: boolean;
 


### PR DESCRIPTION
Realized that it's nice to have a way to test migrations as you're running them. Setting `debug: true` in the migration config allows it to run every time your local app refreshes.

To protect against accidentally merging a migration in debug mode, I added a check that exits early and sends an error to Sentry.

Have a look at the tests for more details.