### PR TITLE
fix: update GitHub username regex to allow hyphens

### DIFF
--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -224,7 +224,7 @@ export const textRecordFields = {
       message: lang.t('profiles.create.invalid_username', {
         app: lang.t('profiles.create.github'),
       }),
-      validator: value => /^([\w.])*$/.test(value),
+      validator: value => /^([\w.-])*$/.test(value),
     },
   },
   [ENS_RECORDS.BTC]: {


### PR DESCRIPTION
Fixes Issue #4405

## What changed (plus any additional context for devs)
Update GitHub username regex to allow hyphens

## Screen recordings / screenshots


## What to test

