### PR TITLE
chore: use meteorology for polygon & bsc

### DIFF
--- a/src/entities/gas.ts
+++ b/src/entities/gas.ts
@@ -87,30 +87,6 @@ export interface GasPricesAPIData {
   urgentWait: Numberish;
 }
 
-export interface GasFeesPolygonGasStationData {
-  status: string;
-  message: string;
-  result: {
-    LastBlock: string;
-    SafeGasPrice: string;
-    ProposeGasPrice: string;
-    FastGasPrice: string;
-    UsdPrice: string;
-  };
-}
-
-export interface GasFeesBscGasStationData {
-  status: string;
-  message: string;
-  result: {
-    LastBlock: string;
-    SafeGasPrice: string;
-    ProposeGasPrice: string;
-    FastGasPrice: string;
-    UsdPrice: string;
-  };
-}
-
 export interface BlocksToConfirmationByPriorityFee {
   1: string;
   2: string;
@@ -145,6 +121,20 @@ export interface RainbowMeteorologyData {
     blocksToConfirmationByPriorityFee: BlocksToConfirmationByPriorityFee;
     blocksToConfirmationByBaseFee: BlocksToConfirmationByBaseFee;
     maxPriorityFeeSuggestions: MaxPriorityFeeSuggestions;
+  };
+  meta: {
+    blockNumber: number;
+    provider: string;
+  };
+}
+
+export interface RainbowMeteorologyLegacyData {
+  data: {
+    legacy: {
+      fastGasPrice: string;
+      proposeGasPrice: string;
+      safeGasPrice: string;
+    };
   };
   meta: {
     blockNumber: number;

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -11,7 +11,6 @@ export type {
   GasFeeParam,
   GasFeeParams,
   GasFeeParamsBySpeed,
-  GasFeesPolygonGasStationData,
   LegacyGasFee,
   LegacyGasFeeParams,
   LegacyGasFeeParamsBySpeed,
@@ -20,6 +19,7 @@ export type {
   MaxPriorityFeeSuggestions,
   TransactionGasParams,
   RainbowMeteorologyData,
+  RainbowMeteorologyLegacyData,
   SelectedGasFee,
 } from './gas';
 export { NativeCurrencyKeys } from './nativeCurrencyTypes';

--- a/src/handlers/gasFees.ts
+++ b/src/handlers/gasFees.ts
@@ -1,7 +1,4 @@
-import {
-  GasFeesBscGasStationData,
-  GasFeesPolygonGasStationData,
-} from '@/entities/gas';
+import { Network } from '@/helpers';
 import { RainbowFetchClient } from '../rainbow-fetch';
 
 const rainbowMeteorologyApi = new RainbowFetchClient({
@@ -13,50 +10,5 @@ const rainbowMeteorologyApi = new RainbowFetchClient({
   timeout: 30000, // 30 secs
 });
 
-export const rainbowMeteorologyGetData = () =>
-  rainbowMeteorologyApi.get(`/meteorology/v1/gas/mainnet`, {});
-
-/**
- * Configuration for Polygon GAS Station API
- * @type RainbowFetchClient instance
- */
-const polygonGasStationApi = new RainbowFetchClient({
-  baseURL: 'https://gpoly.blockscan.com',
-  headers: {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-  },
-  timeout: 30000, // 30 secs
-});
-
-/**
- * @desc get Polygon gas prices
- * @return {Promise}
- */
-export const polygonGasStationGetGasPrices = (): Promise<{
-  data: GasFeesPolygonGasStationData;
-}> => polygonGasStationApi.get(`/gasapi.ashx?apikey=key&method=gasoracle`);
-
-/**
- * Configuration for BSC GAS Station API
- * @type RainbowFetchClient instance
- */
-const bscGasStationApi = new RainbowFetchClient({
-  baseURL: 'https://api.bscscan.com/api',
-  headers: {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-  },
-  timeout: 30000, // 30 secs
-});
-
-/**
- * @desc get BSC gas prices
- * @return {Promise}
- */
-export const bscGasStationGetGasPrices = (): Promise<{
-  data: GasFeesBscGasStationData;
-}> =>
-  bscGasStationApi.get(
-    `?module=gastracker&action=gasoracle&apikey=YourApiKeyToken`
-  );
+export const rainbowMeteorologyGetData = (network: Network) =>
+  rainbowMeteorologyApi.get(`/meteorology/v1/gas/${network}`, {});

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -13,19 +13,15 @@ import {
   GasFeeParams,
   GasFeeParamsBySpeed,
   GasFeesBySpeed,
-  GasFeesPolygonGasStationData,
   LegacyGasFeeParamsBySpeed,
   LegacyGasFeesBySpeed,
   LegacySelectedGasFee,
   RainbowMeteorologyData,
+  RainbowMeteorologyLegacyData,
   SelectedGasFee,
 } from '@/entities';
 
-import {
-  bscGasStationGetGasPrices,
-  polygonGasStationGetGasPrices,
-  rainbowMeteorologyGetData,
-} from '@/handlers/gasFees';
+import { rainbowMeteorologyGetData } from '@/handlers/gasFees';
 import {
   getProviderForNetwork,
   isHardHat,
@@ -47,7 +43,6 @@ import {
 import { ethUnits, supportedNativeCurrencies } from '@/references';
 import { multiply } from '@/helpers/utilities';
 import { ethereumUtils, gasUtils } from '@/utils';
-import { GasFeesBscGasStationData } from '@/entities/gas';
 
 const { CUSTOM, FAST, NORMAL, SLOW, URGENT, FLASHBOTS_MIN_TIP } = gasUtils;
 
@@ -275,26 +270,28 @@ export const gasUpdateToCustomGasFee = (gasParams: GasFeeParams) => async (
 const getPolygonGasPrices = async () => {
   try {
     const {
-      data: { result },
-    }: {
-      data: GasFeesPolygonGasStationData;
-    } = await polygonGasStationGetGasPrices();
+      data: {
+        data: { legacy: result },
+      },
+    } = (await rainbowMeteorologyGetData(Network.polygon)) as {
+      data: RainbowMeteorologyLegacyData;
+    };
     const polygonGasPriceBumpFactor = 1.05;
 
     // Override required to make it compatible with other responses
     const polygonGasStationPrices = {
       fast: Math.ceil(
-        Number(multiply(result['ProposeGasPrice'], polygonGasPriceBumpFactor))
+        Number(multiply(result['proposeGasPrice'], polygonGasPriceBumpFactor))
       ),
       // 1 blocks, 2.5 - 3 secs
       fastWait: 0.05,
       normal: Math.ceil(
-        Number(multiply(result['SafeGasPrice'], polygonGasPriceBumpFactor))
+        Number(multiply(result['safeGasPrice'], polygonGasPriceBumpFactor))
       ),
       // 2 blocks, 6 secs
       normalWait: 0.1,
       urgent: Math.ceil(
-        Number(multiply(result['FastGasPrice'], polygonGasPriceBumpFactor))
+        Number(multiply(result['fastGasPrice'], polygonGasPriceBumpFactor))
       ),
       // 1 blocks, 2.5 - 3 secs
       urgentWait: 0.05,
@@ -309,27 +306,29 @@ const getPolygonGasPrices = async () => {
 const getBscGasPrices = async () => {
   try {
     const {
-      data: { result },
-    }: {
-      data: GasFeesBscGasStationData;
-    } = await bscGasStationGetGasPrices();
+      data: {
+        data: { legacy: result },
+      },
+    } = (await rainbowMeteorologyGetData(Network.bsc)) as {
+      data: RainbowMeteorologyLegacyData;
+    };
 
     const bscGasPriceBumpFactor = 1.05;
 
     // Override required to make it compatible with other responses
     const bscGasStationPrices = {
       fast: Math.ceil(
-        Number(multiply(result['ProposeGasPrice'], bscGasPriceBumpFactor))
+        Number(multiply(result['proposeGasPrice'], bscGasPriceBumpFactor))
       ),
       // 1 blocks, 2.5 - 3 secs
       fastWait: 0.05,
       normal: Math.ceil(
-        Number(multiply(result['SafeGasPrice'], bscGasPriceBumpFactor))
+        Number(multiply(result['safeGasPrice'], bscGasPriceBumpFactor))
       ),
       // 2 blocks, 6 secs
       normalWait: 0.1,
       urgent: Math.ceil(
-        Number(multiply(result['FastGasPrice'], bscGasPriceBumpFactor))
+        Number(multiply(result['fastGasPrice'], bscGasPriceBumpFactor))
       ),
       // 1 blocks, 2.5 - 3 secs
       urgentWait: 0.05,
@@ -376,7 +375,7 @@ const getOptimismGasPrices = async () => {
 };
 
 export const getEIP1559GasParams = async () => {
-  const { data } = (await rainbowMeteorologyGetData()) as {
+  const { data } = (await rainbowMeteorologyGetData(Network.mainnet)) as {
     data: RainbowMeteorologyData;
   };
   const {


### PR DESCRIPTION
Fixes APP-233

## What changed (plus any additional context for devs)
we were using free and ruggable endpoints for polygon and bsc gas, we now run through meteorology like we do for mainnet, which will allow us to fall back if we have any issues and avoid rate limiting. 


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Shot-2022-11-21-12-42-10.11.png


## What to test

if gas loads for polygon we're good 2 go since bsc isn't hooked up yet, shown in PoW

