### PR TITLE
fix: animated svgs

### DIFF
--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -165,7 +165,7 @@ class SvgImage extends Component {
             style={position.coverAsObject}
           />
         )}
-        {(!props.fallbackIfNonAnimated || isSVGAnimated) && (
+        {
           <WebView
             onMessage={this.onLoad}
             originWhitelist={['*']}
@@ -175,13 +175,9 @@ class SvgImage extends Component {
             showsHorizontalScrollIndicator={false}
             showsVerticalScrollIndicator={false}
             source={{ html }}
-            style={[
-              styles,
-              props.style,
-              { display: this.state.loaded || android ? 'flex' : 'none' },
-            ]}
+            style={[styles, props.style]}
           />
-        )}
+        }
       </View>
     );
   }

--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -162,19 +162,17 @@ class SvgImage extends Component {
             style={position.coverAsObject}
           />
         )}
-        {
-          <WebView
-            onMessage={this.onLoad}
-            originWhitelist={['*']}
-            pointerEvents="none"
-            scalesPageToFit
-            scrollEnabled={false}
-            showsHorizontalScrollIndicator={false}
-            showsVerticalScrollIndicator={false}
-            source={{ html }}
-            style={[styles, props.style]}
-          />
-        }
+        <WebView
+          onMessage={this.onLoad}
+          originWhitelist={['*']}
+          pointerEvents="none"
+          scalesPageToFit
+          scrollEnabled={false}
+          showsHorizontalScrollIndicator={false}
+          showsVerticalScrollIndicator={false}
+          source={{ html }}
+          style={[styles, props.style]}
+        />
       </View>
     );
   }

--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -119,7 +119,6 @@ class SvgImage extends Component {
     const { svgContent } = this.state;
 
     let html;
-    let isSVGAnimated = false;
     if (svgContent) {
       const flattenedStyle = StyleSheet.flatten(props.style) || {};
       if (svgContent.includes('viewBox')) {
@@ -143,8 +142,6 @@ class SvgImage extends Component {
         }`;
         html = getHTML(patchedSvgContent, flattenedStyle);
       }
-
-      isSVGAnimated = html?.indexOf('<animate') !== -1;
     }
 
     return (


### PR DESCRIPTION
Fixes APP-229

## What changed (plus any additional context for devs)

our animated svg checks were pretty 💩. from here on out we will show a web view for SVG's on the expanded state so we can ensure things look like they should.

for any other preview images we already show the low res png's we generate so this wont impact perf at all. 


## Screen recordings / screenshots
in linear ticket since this is super top secret 


## What to test

in ticket 

