### PR TITLE
Fix overly large touchable area in new cards preventing focusing discover search field

### DIFF
--- a/src/components/cards/GenericCard.tsx
+++ b/src/components/cards/GenericCard.tsx
@@ -38,6 +38,7 @@ export const GenericCard = ({
         disabled={disabled}
         scaleTo={0.96}
         overflowMargin={50}
+        skipTopMargin
       >
         {children}
       </ButtonPressAnimation>


### PR DESCRIPTION
Fixes APP-238

## What changed (plus any additional context for devs)

* Added `skipTopMargin` prop to `ButtonPressAnimation` which makes the top margin smaller, the shadows are small enough on top so that it works fine

## Screen recordings / screenshots
![image](https://user-images.githubusercontent.com/16062886/203814005-3ddb1baf-554a-4749-b33b-c78b09080abc.png)


## What to test
* check if you can press on discover search
