### PR TITLE
fix: xc swap gas limit logic

### DIFF
--- a/src/handlers/swap.ts
+++ b/src/handlers/swap.ts
@@ -102,6 +102,9 @@ async function getClosestGasEstimate(
 const getCrosschainSwapDefaultGasLimit = (tradeDetails: CrosschainQuote) =>
   tradeDetails?.routes?.[0]?.userTxs?.[0]?.gasFees?.gasLimit;
 
+const getCrosschainSwapRainbowDefaultGasLimit = (chainId: ChainId) =>
+  ethereumUtils.getBasicSwapGasLimit(Number(chainId)) * EXTRA_GAS_PADDING;
+
 export const getCrosschainSwapServiceTime = (tradeDetails: CrosschainQuote) =>
   tradeDetails?.routes?.[0]?.serviceTime;
 
@@ -379,8 +382,7 @@ export const estimateCrosschainSwapGasLimit = async ({
       }
 
       const routeGasLimit = getCrosschainSwapDefaultGasLimit(tradeDetails);
-      const rainbowDefaultGasLimit = getDefaultGasLimitForTrade(
-        tradeDetails,
+      const rainbowDefaultGasLimit = getCrosschainSwapRainbowDefaultGasLimit(
         chainId
       );
       if (routeGasLimit && lessThan(rainbowDefaultGasLimit, routeGasLimit)) {
@@ -402,8 +404,7 @@ export const estimateCrosschainSwapGasLimit = async ({
       SWAP_GAS_PADDING
     );
     const routeGasLimit = getCrosschainSwapDefaultGasLimit(tradeDetails);
-    const rainbowDefaultGasLimit = getDefaultGasLimitForTrade(
-      tradeDetails,
+    const rainbowDefaultGasLimit = getCrosschainSwapRainbowDefaultGasLimit(
       chainId
     );
 
@@ -414,8 +415,7 @@ export const estimateCrosschainSwapGasLimit = async ({
     return gasLimit || fallbackGasLimit;
   } catch (error) {
     const routeGasLimit = getCrosschainSwapDefaultGasLimit(tradeDetails);
-    const rainbowDefaultGasLimit = getDefaultGasLimitForTrade(
-      tradeDetails,
+    const rainbowDefaultGasLimit = getCrosschainSwapRainbowDefaultGasLimit(
       chainId
     );
 


### PR DESCRIPTION
Fixes APP-240

## What changed (plus any additional context for devs)
sometimes socket's gas limit estimate fails and returns us a value of 120k which is very low, especially for L2s and when there may be a swap happening as well.

We now use our own network specific gas limits if its > than the value socket gives us. We over estimate by `1.5` so this should fix any issues

## Screen recordings / screenshots


## What to test
Bunch of xc swaps ig 
