### PR TITLE
Fix swaps token symbol/balance color

### DIFF
--- a/src/components/exchange/ExchangeTokenRow.tsx
+++ b/src/components/exchange/ExchangeTokenRow.tsx
@@ -89,7 +89,7 @@ export default React.memo(function ExchangeTokenRow({
                 {showBalance && item?.balance?.display && (
                   <Text
                     size="13pt"
-                    color="secondary (Deprecated)"
+                    color={{ custom: theme.colors.blueGreyDark50 }}
                     numberOfLines={1}
                     weight="medium"
                   >
@@ -99,7 +99,7 @@ export default React.memo(function ExchangeTokenRow({
                 {!showBalance && (
                   <Text
                     size="13pt"
-                    color="secondary (Deprecated)"
+                    color={{ custom: theme.colors.blueGreyDark50 }}
                     weight="medium"
                     numberOfLines={1}
                   >


### PR DESCRIPTION
Fixes RNBW-4649

## What changed (plus any additional context for devs)
fixed regression of token symbol/balance color in swaps

## Screen recordings / screenshots
![Simulator Screen Shot - iPhone 14 Plus - 2022-11-28 at 09 06 44](https://user-images.githubusercontent.com/15272675/204338617-a87031d3-8733-4659-b0d4-0ae5819c11bd.png)


## What to test

