### PR TITLE
Android loading fix

### DIFF
--- a/src/components/asset-list/AssetList.js
+++ b/src/components/asset-list/AssetList.js
@@ -4,6 +4,8 @@ import { FabWrapperBottomPosition, FloatingActionButtonSize } from '../fab';
 import { ListFooter } from '../list';
 import RecyclerAssetList from './RecyclerAssetList';
 import RecyclerAssetList2 from './RecyclerAssetList2';
+import EmptyAssetList from './EmptyAssetList';
+import * as i18n from '@/languages';
 
 const FabSizeWithPadding =
   FloatingActionButtonSize + FabWrapperBottomPosition * 2;
@@ -21,7 +23,16 @@ const AssetList = ({
 }) => {
   const insets = useSafeAreaInsets();
 
-  return props.showcase ? (
+  return isLoading ? (
+    <EmptyAssetList
+      {...props}
+      hideHeader={hideHeader}
+      isLoading={isLoading}
+      isWalletEthZero={isWalletEthZero}
+      network={network}
+      title={i18n.t(i18n.l.account.tab_balances)}
+    />
+  ) : props.showcase ? (
     <RecyclerAssetList
       hideHeader={hideHeader}
       paddingBottom={


### PR DESCRIPTION
Fixes APP-255

## What changed (plus any additional context for devs)
- android wallet screen wasn't fully loading on app launch bc of some weird recycler asset list shit
- this fix prob isn't *ideal* but is fine given amount of work it would take to investigate asset list memoization
- this works bc it prevents the recycler asset list from rendering until all the assets are loaded in

## Screen recordings / screenshots
https://www.loom.com/share/ee3d9354ad574347af43b2dc407bf6ce

## What to test

