### PR TITLE
Add lang template literal support

### DIFF
--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -45,14 +45,15 @@ export const updateLanguageLocale = (code: Language) => {
 };
 
 /**
- * Returns a i18n string for a given object-keypath or string.
+ * Returns a i18n string for a given object-keypath or string
+ * and optional template literal args.
  *   `import * as i18n from '@/languages'`
  *
  * Type-safe usage:
- *   `i18n.t(i18n.l.account.hide)`
+ *   `i18n.t(i18n.l.account.hide, { accountName: 'myAccount' })`
  *
  * Alternative standard usage:
- *   `i18n.t('account.hide')`
+ *   `i18n.t('account.hide', { accountName: 'myAccount' })`
  */
 export function t(keypath: string, args?: { [key: string]: string }) {
   // if it's anything truthy, try __keypath__ or fall back to the value

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -54,11 +54,11 @@ export const updateLanguageLocale = (code: Language) => {
  * Alternative standard usage:
  *   `i18n.t('account.hide')`
  */
-export function t(keypath: string) {
+export function t(keypath: string, args?: { [key: string]: string }) {
   // if it's anything truthy, try __keypath__ or fall back to the value
   // otherwise let falsy values fall through
   // @ts-expect-error
-  return lang.t(keypath ? keypath.__keypath__ || keypath : keypath);
+  return lang.t(keypath ? keypath.__keypath__ || keypath : keypath, args);
 }
 
 /**


### PR DESCRIPTION
Fixes APP-257

## What changed (plus any additional context for devs)
- added support for template literals in `@/languages`

## Screen recordings / screenshots


## What to test

