### PR TITLE
fix search: add discover check

### DIFF
--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -97,7 +97,8 @@ const searchCurrencyList = async (searchParams: {
 
 const useSwapCurrencyList = (
   searchQuery: string,
-  searchChainId = MAINNET_CHAINID
+  searchChainId = MAINNET_CHAINID,
+  isDiscover = false
 ) => {
   const previousChainId = usePrevious(searchChainId);
 
@@ -143,11 +144,12 @@ const useSwapCurrencyList = (
     if (
       inputChainId &&
       inputChainId !== searchChainId &&
-      crosschainSwapsEnabled
+      crosschainSwapsEnabled &&
+      !isDiscover
     ) {
       return true;
     }
-  }, [searchChainId, inputChainId, crosschainSwapsEnabled]);
+  }, [inputChainId, searchChainId, crosschainSwapsEnabled, isDiscover]);
 
   const isFavorite = useCallback(
     (address: EthereumAddress) =>

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -210,7 +210,7 @@ export default function CurrencySelectModal() {
     swapCurrencyList,
     swapCurrencyListLoading,
     updateFavorites,
-  } = useSwapCurrencyList(searchQueryForSearch, currentChainId);
+  } = useSwapCurrencyList(searchQueryForSearch, currentChainId, false);
 
   const {
     swappableUserAssets,

--- a/src/screens/discover/components/DiscoverSearch.js
+++ b/src/screens/discover/components/DiscoverSearch.js
@@ -32,6 +32,7 @@ import Routes from '@/navigation/routesNames';
 import styled from '@/styled-thing';
 import { useTheme } from '@/theme';
 import { ethereumUtils } from '@/utils';
+import { Network } from '@/helpers';
 
 export const SearchContainer = styled(Row)({
   height: '100%',
@@ -59,7 +60,9 @@ export default function DiscoverSearch() {
   const [searchQueryForSearch] = useDebounce(searchQuery, 350);
   const [ensResults, setEnsResults] = useState([]);
   const { swapCurrencyList, swapCurrencyListLoading } = useSwapCurrencyList(
-    searchQueryForSearch
+    searchQueryForSearch,
+    ethereumUtils.getChainIdFromNetwork(Network.mainnet),
+    true
   );
   const currencyList = useMemo(() => {
     // order:


### PR DESCRIPTION


## What changed (plus any additional context for devs)

we were showing bridging on discover search because we use the same hook to generate the list. ive added variable to check if its from discover. we should revisit this and seperate the logic


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2022-12-01-12-57-32.mp4

## What to test
open l2 asset other than eth, go to discover search

