### PR TITLE
Support RDS BackgroundColor in SlackSheet

### DIFF
--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -162,21 +162,19 @@ export default forwardRef(function SlackSheet(
   const { backgroundColors, colorMode } = useContext(ColorModeContext);
   const accentColorContextValue = useContext(AccentColorContext);
 
-  let bg = backgroundColor;
+  let bg = colors.white;
 
-  if (!backgroundColor) {
-    bg = colors.white;
-  } else if (
-    backgroundColor === 'accent' ||
-    backgroundColors[backgroundColor]
-  ) {
-    const accentColor =
-      accentColorContextValue ?? getDefaultAccentColorForColorMode(colorMode);
-    const colorObject =
-      backgroundColor === 'accent'
-        ? accentColor
-        : backgroundColors[backgroundColor];
-    bg = colorObject.color;
+  if (backgroundColor) {
+    bg = backgroundColor;
+    if (backgroundColor === 'accent' || backgroundColors[backgroundColor]) {
+      const accentColor =
+        accentColorContextValue ?? getDefaultAccentColorForColorMode(colorMode);
+      const colorObject =
+        backgroundColor === 'accent'
+          ? accentColor
+          : backgroundColors[backgroundColor];
+      bg = colorObject.color;
+    }
   }
 
   // callback upon closing the sheet

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -25,6 +25,9 @@ import { useNavigation } from '@/navigation';
 import styled from '@/styled-thing';
 import { position } from '@/styles';
 import { IS_ANDROID, IS_IOS } from '@/env';
+import { AccentColorContext } from '@/design-system/color/AccentColorContext';
+import { ColorModeContext } from '@/design-system/color/ColorMode';
+import { getDefaultAccentColorForColorMode } from '@/design-system/color/palettes';
 
 const AndroidBackground = styled.View({
   ...position.coverAsObject,
@@ -156,7 +159,25 @@ export default forwardRef(function SlackSheet(
     yPosition.value = event.contentOffset.y;
   });
 
-  const bg = backgroundColor || colors.white;
+  const { backgroundColors, colorMode } = useContext(ColorModeContext);
+  const accentColorContextValue = useContext(AccentColorContext);
+
+  let bg = backgroundColor;
+
+  if (!backgroundColor) {
+    bg = colors.white;
+  } else if (
+    backgroundColor === 'accent' ||
+    backgroundColors[backgroundColor]
+  ) {
+    const accentColor =
+      accentColorContextValue ?? getDefaultAccentColorForColorMode(colorMode);
+    const colorObject =
+      backgroundColor === 'accent'
+        ? accentColor
+        : backgroundColors[backgroundColor];
+    bg = colorObject.color;
+  }
 
   // callback upon closing the sheet
   useEffect(


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- now you can use regular hex colors or RDS `BackgroundColor`s in the SlackSheet `backgroundColor` prop

## Screen recordings / screenshots
https://www.loom.com/share/fb606fe59a784df8a6b5d6d99d7a969d

## What to test

