### PR TITLE
feat: set up initial WC v2 pairing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,6 +80,8 @@ import {
 import { logger as loggr, RainbowError } from '@/logger';
 import * as ls from '@/storage';
 import { migrate } from '@/migrations';
+import { initListeners as initWalletConnectListeners } from '@/utils/walletConnect';
+import { getExperimetalFlag, WC_V2 } from '@/config/experimental';
 
 const FedoraToastRef = createRef();
 
@@ -147,6 +149,10 @@ class OldApp extends Component {
       PerformanceMetrics.loadRootAppComponent
     );
     analyticsV2.track(analyticsV2.event.applicationDidMount);
+
+    if (getExperimetalFlag(WC_V2)) {
+      initWalletConnectListeners();
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -15,6 +15,7 @@ export const PROFILES = 'ENS Profiles';
 export const L2_TXS = 'L2 Transactions';
 export const FLASHBOTS_WC = 'Flashbots for WC';
 export const CROSSCHAIN_SWAPS = 'Crosschain Swaps';
+export const WC_V2 = 'Wallet Connect v2';
 
 export const defaultConfig = {
   // this flag is not reactive. We use this in a static context
@@ -26,6 +27,7 @@ export const defaultConfig = {
   [PROFILES]: { settings: true, value: true },
   [REVIEW_ANDROID]: { settings: false, value: false },
   [CROSSCHAIN_SWAPS]: { settings: true, value: true },
+  [WC_V2]: { settings: true, value: false },
 };
 
 const storageKey = 'config';

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -2,6 +2,7 @@ import { captureException } from '@sentry/react-native';
 import lang from 'i18n-js';
 import qs from 'qs';
 import URL from 'url-parse';
+import { parseUri } from '@walletconnect/utils';
 import { initialChartExpandedStateSheetHeight } from '../components/expanded-state/asset/ChartExpandedState';
 import store from '../redux/store';
 import {
@@ -11,7 +12,11 @@ import {
 } from '../redux/walletconnect';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { fetchReverseRecordWithRetry } from '@/utils/profileUtils';
-import { defaultConfig } from '@/config/experimental';
+import {
+  defaultConfig,
+  getExperimetalFlag,
+  WC_V2,
+} from '@/config/experimental';
 import { PROFILES } from '@/config/experimentalHooks';
 import { setDeploymentKey } from '@/handlers/fedora';
 import { delay } from '@/helpers/utilities';
@@ -25,6 +30,8 @@ import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
 import { ETH_ADDRESS } from '@/references';
 import Routes from '@/navigation/routesNames';
 import { ethereumUtils } from '@/utils';
+import { logger } from '@/logger';
+import { pair as pairWalletConnect } from '@/utils/walletConnect';
 
 // initial research into refactoring deep links
 //                         eip      native deeplink  rainbow.me profiles
@@ -145,16 +152,31 @@ export default async function handleDeeplink(
 }
 
 function handleWalletConnect(uri: any) {
-  const { dispatch } = store;
-  dispatch(walletConnectSetPendingRedirect());
   const { query } = new URL(uri);
-  if (uri && query) {
-    dispatch(
+  const parsedUri = parseUri(uri);
+
+  logger.debug(`handleWalletConnect`, { uri, query, parsedUri });
+
+  if (uri && query && parsedUri.version === 1) {
+    store.dispatch(walletConnectSetPendingRedirect());
+    store.dispatch(
       walletConnectOnSessionRequest(uri, (status: any, dappScheme: any) => {
+        logger.debug(`walletConnectOnSessionRequest callback`, {
+          status,
+          dappScheme,
+        });
         const type = status === 'approved' ? 'connect' : status;
-        dispatch(walletConnectRemovePendingRedirect(type, dappScheme));
+        store.dispatch(walletConnectRemovePendingRedirect(type, dappScheme));
       })
     );
+  } else if (
+    uri &&
+    query &&
+    parsedUri.version === 2 &&
+    getExperimetalFlag(WC_V2)
+  ) {
+    pairWalletConnect({ uri });
+    // TODO remove pending redirect?
   } else {
     // This is when we get focused by WC due to a signing request
   }

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -31,7 +31,10 @@ import { ETH_ADDRESS } from '@/references';
 import Routes from '@/navigation/routesNames';
 import { ethereumUtils } from '@/utils';
 import { logger } from '@/logger';
-import { pair as pairWalletConnect } from '@/utils/walletConnect';
+import {
+  pair as pairWalletConnect,
+  setHasPendingDeeplinkPendingRedirect,
+} from '@/utils/walletConnect';
 
 // initial research into refactoring deep links
 //                         eip      native deeplink  rainbow.me profiles
@@ -175,8 +178,8 @@ function handleWalletConnect(uri: any) {
     parsedUri.version === 2 &&
     getExperimetalFlag(WC_V2)
   ) {
+    setHasPendingDeeplinkPendingRedirect(true);
     pairWalletConnect({ uri });
-    // TODO remove pending redirect?
   } else {
     // This is when we get focused by WC due to a signing request
   }

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1752,7 +1752,10 @@
         "transaction_canceled": "Transaction canceled!",
         "transaction_sent": "Transaction sent!"
       },
-      "unknown_application": "Unknown Application"
+      "unknown_application": "Unknown Application",
+      "connection_failed": "Connection failed",
+      "failed_to_connect_to": "Failed to connect to %{appName}",
+      "go_back": "Go back"
     },
     "warning": {
       "user_is_offline": "Connection offline, please check your internet connection",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1752,7 +1752,10 @@
         "transaction_canceled": "Transaction canceled! :)",
         "transaction_sent": "Transaction sent! :)"
       },
-      "unknown_application": "Unknown Application :)"
+      "unknown_application": "Unknown Application :)",
+      "connection_failed": "Connection failed",
+      "failed_to_connect_to": "Failed to connect to %{appName}",
+      "go_back": "Go back"
     },
     "warning": {
       "user_is_offline": "Hors connexion, veuillez vérifier votre connexion Internet",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1753,9 +1753,9 @@
         "transaction_sent": "Transaction sent! :)"
       },
       "unknown_application": "Unknown Application :)",
-      "connection_failed": "Connection failed",
-      "failed_to_connect_to": "Failed to connect to %{appName}",
-      "go_back": "Go back"
+      "connection_failed": "Connection failed :)",
+      "failed_to_connect_to": "Failed to connect to %{appName} :)",
+      "go_back": "Go back :)"
     },
     "warning": {
       "user_is_offline": "Hors connexion, veuillez vérifier votre connexion Internet",

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -136,7 +136,7 @@ type WalletconnectResultType =
 /**
  * Route parameters sent to a WalletConnect approval sheet.
  */
-interface WalletconnectApprovalSheetRouteParams {
+export interface WalletconnectApprovalSheetRouteParams {
   callback: (
     approved: boolean,
     chainId: number,

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -1,0 +1,189 @@
+import SignClient from '@walletconnect/sign-client';
+import { SignClientTypes } from '@walletconnect/types';
+import { getSdkError, parseUri } from '@walletconnect/utils';
+import { WC_PROJECT_ID } from 'react-native-dotenv';
+import { NavigationContainerRef } from '@react-navigation/native';
+
+import { logger, RainbowError } from '@/logger';
+import { WalletconnectApprovalSheetRouteParams } from '@/redux/walletconnect';
+import { Navigation } from '@/navigation';
+import { getActiveRoute } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { analytics } from '@/analytics';
+
+const signClient = Promise.resolve(
+  SignClient.init({
+    projectId: WC_PROJECT_ID,
+    // relayUrl: "<YOUR RELAY URL>",
+    metadata: {
+      name: '🌈 Rainbow',
+      description: 'Rainbow makes exploring Ethereum fun and accessible 🌈',
+      url: 'https://rainbow.me',
+      icons: ['https://avatars2.githubusercontent.com/u/48327834?s=200&v=4'],
+    },
+  })
+);
+
+export async function pair({ uri }: { uri: string }) {
+  logger.debug(`WC v2: pair`, { uri });
+
+  // show loading state as feedback for user
+  Navigation.handleAction(Routes.WALLET_CONNECT_APPROVAL_SHEET, {});
+
+  const receivedTimestamp = Date.now();
+  const { topic } = parseUri(uri);
+  const client = await signClient;
+
+  await client.core.pairing.pair({ uri });
+
+  const timeout = setTimeout(() => {
+    const route: ReturnType<
+      NavigationContainerRef['getCurrentRoute']
+    > = getActiveRoute();
+
+    if (!route) return;
+
+    /**
+     * If user is still looking at the approval sheet, show them the failure
+     * state. Otherwise, do nothing
+     */
+    if (route.name === Routes.WALLET_CONNECT_APPROVAL_SHEET) {
+      const routeParams: WalletconnectApprovalSheetRouteParams = {
+        receivedTimestamp,
+        timedOut: true,
+        async callback() {
+          logger.debug(`callback`);
+        },
+      };
+
+      // end load state with `timedOut` and provide failure callback
+      Navigation.handleAction(
+        Routes.WALLET_CONNECT_APPROVAL_SHEET,
+        routeParams,
+        true
+      );
+    }
+
+    analytics.track('New WalletConnect session time out');
+  }, 20_000);
+
+  function handler(
+    proposal: SignClientTypes.EventArguments['session_proposal']
+  ) {
+    // listen for THIS topic pairing, and clear timeout if received
+    if (proposal.params.pairingTopic === topic) {
+      client.off('session_proposal', handler);
+      clearTimeout(timeout);
+    }
+  }
+
+  client.on('session_proposal', handler);
+}
+
+// TODO ignore expired requests?
+export async function initListeners() {
+  const client = await signClient;
+
+  client.on('session_proposal', onSessionProposal);
+}
+
+export function onSessionProposal(
+  proposal: SignClientTypes.EventArguments['session_proposal']
+) {
+  logger.debug(`WC v2: session_proposal`, { event: proposal });
+
+  const receivedTimestamp = Date.now();
+  const {
+    id,
+    proposer,
+    expiry,
+    pairingTopic,
+    requiredNamespaces,
+  } = proposal.params;
+
+  // TODO what if eip155 namespace doesn't exist
+  // TODO do I need to check for existing sessions? WC v2 might do this for us
+
+  const { chains } = requiredNamespaces.eip155;
+  const chainId = parseInt(chains[0].split('eip155:')[1]);
+
+  const routeParams: WalletconnectApprovalSheetRouteParams = {
+    receivedTimestamp,
+    meta: {
+      chainId,
+      dappName: proposer.metadata.name,
+      dappScheme: '', // TODO
+      dappUrl: proposer.metadata.url,
+      imageUrl: proposer.metadata.icons[0],
+      peerId: proposer.publicKey,
+    },
+    timedOut: false,
+    callback: async (approved, chainId, accountAddress) => {
+      const client = await signClient;
+      const { id, proposer, requiredNamespaces } = proposal.params;
+
+      if (approved) {
+        logger.debug(`WC v2: session approved`, {
+          approved,
+          chainId,
+          accountAddress,
+        });
+
+        const namespaces = Object.keys(requiredNamespaces).reduce<
+          Parameters<typeof client.approve>[0]['namespaces']
+        >((ns, key) => {
+          ns[key] = {
+            accounts: [`${key}:${chainId}:${accountAddress}`],
+            methods: requiredNamespaces.eip155.methods,
+            events: requiredNamespaces.eip155.events,
+          };
+          return ns;
+        }, {});
+
+        /**
+         * This is equivalent handling of setPendingRequest and
+         * walletConnectApproveSession, since setPendingRequest is only used
+         * within the /redux/walletconnect handlers
+         *
+         * WC v2 stores existing _pairings_ itself, so we don't need to persist
+         * ourselves
+         */
+        const { acknowledged } = await client.approve({
+          id,
+          namespaces,
+        });
+        const session = await acknowledged();
+
+        logger.debug(`WC v2: session created`, { session });
+
+        analytics.track('Approved new WalletConnect session', {
+          dappName: proposer.metadata.name,
+          dappUrl: proposer.metadata.url,
+        });
+      } else if (!approved) {
+        logger.debug(`WC v2: session approval denied`, {
+          approved,
+          chainId,
+          accountAddress,
+        });
+
+        await client.reject({ id, reason: getSdkError('USER_REJECTED') });
+
+        analytics.track('Rejected new WalletConnect session', {
+          dappName: proposer.metadata.name,
+          dappUrl: proposer.metadata.url,
+        });
+      }
+    },
+  };
+
+  /**
+   * We might see this at any point in the app, so only use `replace`
+   * sometimes if the user is already looking at the approval sheet.
+   */
+  Navigation.handleAction(
+    Routes.WALLET_CONNECT_APPROVAL_SHEET,
+    routeParams,
+    getActiveRoute()?.name === Routes.WALLET_CONNECT_APPROVAL_SHEET
+  );
+}

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -13,6 +13,7 @@ import { analytics } from '@/analytics';
 import { maybeSignUri } from '@/handlers/imgix';
 import { dappLogoOverride, dappNameOverride } from '@/helpers/dappNameHandler';
 import { Alert } from '@/components/alerts';
+import * as lang from '@/languages';
 
 const signClient = Promise.resolve(
   SignClient.init({
@@ -189,11 +190,13 @@ export function onSessionProposal(
             buttons: [
               {
                 style: 'cancel',
-                text: `Go back`,
+                text: lang.t(lang.l.walletconnect.go_back),
               },
             ],
-            message: `Failed to connect to ${dappName}`,
-            title: `Uh oh!`,
+            message: lang.t(lang.l.walletconnect.failed_to_connect_to, {
+              appName: dappName,
+            }),
+            title: lang.t(lang.l.walletconnect.connection_failed),
           });
 
           logger.error(new RainbowError(`WC v2: session approval failed`), {

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -33,8 +33,13 @@ let hasDeeplinkPendingRedirect = false;
  * listeners. BE CAREFUL WITH THIS.
  */
 export function setHasPendingDeeplinkPendingRedirect(value: boolean) {
+  logger.info(`setHasPendingDeeplinkPendingRedirect`, { value });
   hasDeeplinkPendingRedirect = value;
 }
+
+setInterval(() => {
+  logger.debug(`hasDeeplinkPendingRedirect`, { hasDeeplinkPendingRedirect });
+}, 5000);
 
 const signClient = Promise.resolve(
   SignClient.init({
@@ -212,6 +217,8 @@ export function onSessionProposal(
             dappUrl: proposer.metadata.url,
           });
         } catch (e) {
+          setHasPendingDeeplinkPendingRedirect(false);
+
           Alert({
             buttons: [
               {
@@ -230,6 +237,8 @@ export function onSessionProposal(
           });
         }
       } else if (!approved) {
+        setHasPendingDeeplinkPendingRedirect(false);
+
         logger.debug(`WC v2: session approval denied`, {
           approved,
           chainId,

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -37,10 +37,6 @@ export function setHasPendingDeeplinkPendingRedirect(value: boolean) {
   hasDeeplinkPendingRedirect = value;
 }
 
-setInterval(() => {
-  logger.debug(`hasDeeplinkPendingRedirect`, { hasDeeplinkPendingRedirect });
-}, 5000);
-
 const signClient = Promise.resolve(
   SignClient.init({
     projectId: WC_PROJECT_ID,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Now that #4439 is in, the next step is to enable pairing with WC v2 dapps. All of this is behind a flag that's toggle-able in Developer Settings.

This PR enables you to scan the QR code and connect. It doesn't do anything else.

## What to test
First, enable WC v2 in dev settings. Make sure you have `WC_PROJECT_ID` in your env.

Then use the [v2 test dapp](https://react-app.walletconnect.com/). Test on mobile too!
- When connected, you should see the buttons for things like `personal_sign`. These don't do anything right now.
- Try disconnecting, then reconnecting using the existing connection you just created.

Use the [v1 test dapp](https://example.walletconnect.org/) to test the existing flows. Nothing should have changed there.

