### PR TITLE
Duplicate eth fix

### DIFF
--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -24,56 +24,6 @@ export const buildAssetUniqueIdentifier = (item: any) => {
   return compact([balance, nativePrice, uniqueId]).join('_');
 };
 
-const addEthPlaceholder = (
-  assets: any[],
-  includePlaceholder: any,
-  pinnedCoins: any,
-  nativeCurrency: any,
-  isLoadingAssets: boolean
-) => {
-  const hasEth = !!ethereumUtils.getAccountAsset(ETH_ADDRESS);
-
-  const { genericAssets } = store.getState().data;
-  if (includePlaceholder && !hasEth && assets.length > 0 && !isLoadingAssets) {
-    const { relative_change_24h, value } = genericAssets?.eth?.price || {};
-
-    const zeroEth = {
-      address: 'eth',
-      balance: {
-        amount: '0',
-        display: '0 ETH',
-      },
-      color: '#29292E',
-      decimals: 18,
-      icon_url: ETH_ICON_URL,
-      isCoin: true,
-      isPinned: pinnedCoins['eth'],
-      isSmall: false,
-      name: 'Ethereum',
-      native: {
-        balance: {
-          amount: '0.00',
-          display: convertAmountToNativeDisplay('0.00', nativeCurrency),
-        },
-        change: relative_change_24h ? `${relative_change_24h.toFixed(2)}%` : '',
-        price: {
-          amount: value || '0.00',
-          display: convertAmountToNativeDisplay(
-            value ? value : '0.00',
-            nativeCurrency
-          ),
-        },
-      },
-      price: value,
-      symbol: 'ETH',
-      type: 'token',
-      uniqueId: 'eth',
-    };
-    return { addedEth: true, assets: [zeroEth].concat(assets) };
-  }
-  return { addedEth: false, assets };
-};
-
 const getTotal = (assets: any) =>
   // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
   assets.reduce((acc, asset) => {
@@ -86,37 +36,23 @@ export const buildCoinsList = (
   nativeCurrency: any,
   isCoinListEdited: any,
   pinnedCoins: any,
-  hiddenCoins: any,
-  includePlaceholder = false,
-  isLoadingAssets: boolean
+  hiddenCoins: any
 ) => {
+  if (!sortedAssets.length) {
+    return {
+      assets: [],
+      smallBalancesValue: 0,
+      totalBalancesValue: 0,
+    };
+  }
+
   let standardAssets: any = [],
     pinnedAssets: any = [],
     smallAssets: any = [],
     hiddenAssets: any = [];
 
-  // const { addedEth, assets } = addEthPlaceholder(
-  //   sortedAssets,
-  //   includePlaceholder,
-  //   pinnedCoins,
-  //   nativeCurrency,
-  //   isLoadingAssets
-  // );
-
-  const addedEth = false;
-  const assets = sortedAssets;
-
-  // if (!assets.length) {
-  //   return {
-  //     addedEth,
-  //     assets,
-  //     smallBalancesValue: 0,
-  //     totalBalancesValue: 0,
-  //   };
-  // }
-
   // separate into standard, pinned, small balances, hidden assets
-  assets?.forEach(asset => {
+  sortedAssets?.forEach(asset => {
     if (!!hiddenCoins && hiddenCoins[asset.uniqueId]) {
       hiddenAssets.push({
         isCoin: true,
@@ -186,7 +122,6 @@ export const buildCoinsList = (
   }
 
   return {
-    addedEth,
     assets: allAssets,
     smallBalancesValue,
     totalBalancesValue,
@@ -199,18 +134,14 @@ export const buildBriefCoinsList = (
   nativeCurrency: any,
   isCoinListEdited: any,
   pinnedCoins: any,
-  hiddenCoins: any,
-  includePlaceholder = false,
-  isLoadingAssets: boolean
+  hiddenCoins: any
 ) => {
   const { assets, smallBalancesValue, totalBalancesValue } = buildCoinsList(
     sortedAssets,
     nativeCurrency,
     isCoinListEdited,
     pinnedCoins,
-    hiddenCoins,
-    includePlaceholder,
-    isLoadingAssets
+    hiddenCoins
   );
   const briefAssets = [];
   if (assets) {

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -95,22 +95,25 @@ export const buildCoinsList = (
     smallAssets: any = [],
     hiddenAssets: any = [];
 
-  const { addedEth, assets } = addEthPlaceholder(
-    sortedAssets,
-    includePlaceholder,
-    pinnedCoins,
-    nativeCurrency,
-    isLoadingAssets
-  );
+  // const { addedEth, assets } = addEthPlaceholder(
+  //   sortedAssets,
+  //   includePlaceholder,
+  //   pinnedCoins,
+  //   nativeCurrency,
+  //   isLoadingAssets
+  // );
 
-  if (!assets.length) {
-    return {
-      addedEth,
-      assets,
-      smallBalancesValue: 0,
-      totalBalancesValue: 0,
-    };
-  }
+  const addedEth = false;
+  const assets = sortedAssets;
+
+  // if (!assets.length) {
+  //   return {
+  //     addedEth,
+  //     assets,
+  //     smallBalancesValue: 0,
+  //     totalBalancesValue: 0,
+  //   };
+  // }
 
   // separate into standard, pinned, small balances, hidden assets
   assets?.forEach(asset => {

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -268,8 +268,7 @@ const coinEditContextMenu = (
   isCoinListEdited: any,
   isLoadingAssets: any,
   sortedAssetsCount: any,
-  totalValue: any,
-  addedEth: any
+  totalValue: any
 ) => {
   const noSmallBalances = !balanceSectionData.find(
     ({ smallBalancesContainer }: any) => smallBalancesContainer
@@ -293,7 +292,7 @@ const coinEditContextMenu = (
           }
         : undefined,
     title: null,
-    totalItems: isLoadingAssets ? 1 : (addedEth ? 1 : 0) + sortedAssetsCount,
+    totalItems: isLoadingAssets ? 1 : sortedAssetsCount,
     totalValue: totalValue,
   };
 };
@@ -314,14 +313,12 @@ const withBalanceSection = (
   uniswapTotal: any,
   collectibles: any
 ) => {
-  const { addedEth, assets, totalBalancesValue } = buildCoinsList(
+  const { assets, totalBalancesValue } = buildCoinsList(
     sortedAssets,
     nativeCurrency,
     isCoinListEdited,
     pinnedCoins,
-    hiddenCoins,
-    true,
-    isLoadingAssets
+    hiddenCoins
   );
 
   let balanceSectionData = [...assets];
@@ -357,8 +354,7 @@ const withBalanceSection = (
       isCoinListEdited,
       isLoadingAssets,
       sortedAssetsCount,
-      totalValue,
-      addedEth
+      totalValue
     ),
     name: 'balances',
     renderItem: isLoadingAssets
@@ -384,9 +380,7 @@ const withBriefBalanceSection = (
     nativeCurrency,
     isCoinListEdited,
     pinnedCoins,
-    hiddenCoins,
-    true,
-    isLoadingAssets
+    hiddenCoins
   );
 
   const savingsTotalValue = savingsSection?.find(


### PR DESCRIPTION
Fixes APP-264

## What changed (plus any additional context for devs)
- removed logic for adding a placeholder eth row (basically just a row that displays 0 balance for eth if the wallet has none)
- we don't need that anymore bc instead of a placeholder row we now show the eth chart if the user has no eth/erc20s

## Screen recordings / screenshots


## What to test
- switch to `develop`
- clear local storage
- repro issue on your wallet by changing this condition to `true` https://github.com/rainbow-me/rainbow/blob/a109fe54d0351dcf875bb5cb8c603f6302bab9a7/src/helpers/assets.ts#L37
- clear local storage
- switch to this branch
- say "let's fucking go" out loud
- profit

also if you want you can test that WalletScreen + SendSheet look normal for wallets w/ different kinds of assets (ie only nfts, only erc20s, no assets, etc.). i've already done this but feel free to double check
