### PR TITLE
fix: patch qs, ignore others

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -5,6 +5,7 @@
     "GHSA-6fc8-4gx4-v693", // https://github.com/advisories/GHSA-6fc8-4gx4-v693
     "GHSA-2j79-8pqc-r7x6", // https://github.com/advisories/GHSA-2j79-8pqc-r7x6
     "GHSA-9pgh-qqpf-7wqj", // https://github.com/advisories/GHSA-9pgh-qqpf-7wqj
-    "GHSA-w573-4hg7-7wgq" // https://github.com/advisories/GHSA-w573-4hg7-7wgq
+    "GHSA-w573-4hg7-7wgq", // https://github.com/advisories/GHSA-w573-4hg7-7wgq
+    "GHSA-hrpp-h998-j3pp" // https://github.com/advisories/GHSA-hrpp-h998-j3pp
   ]
 }

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "prop-types": "15.7.2",
     "punycode": "1.4.1",
     "qrcode": "1.4.4",
-    "qs": "6.9.4",
+    "qs": "6.9.7",
     "querystring-es3": "0.2.1",
     "react": "17.0.2",
     "react-coin-icon": "rainbow-me/react-coin-icon#06464588a3d986f6ef3a7d7341b2d7ea0c5ac50b",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14426,10 +14426,12 @@ qrcode@1.4.4:
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@6.9.4:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
 qs@^6.5.2, qs@^6.7.0, qs@^6.9.4:
   version "6.10.3"
@@ -14439,8 +14441,9 @@ qs@^6.5.2, qs@^6.7.0, qs@^6.9.4:
     side-channel "^1.0.4"
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@6.13.5:
   version "6.13.5"


### PR DESCRIPTION
Fixes APP-276

Patched our version and ignored for sub-deps.

