### PR TITLE
fix: search override l2 decimals value

### DIFF
--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -487,7 +487,10 @@ export default function CurrencySelectModal() {
       const assetWithType =
         isMainnet && type === CurrencySelectionTypes.output
           ? { ...item, type: 'token' }
-          : item;
+          : {
+              ...item,
+              decimals: item?.networks?.[chainId]?.decimals || item.decimals,
+            };
 
       const selectAsset = () => {
         dispatch(emitChartsRequest(item.mainnet_address || item.address));
@@ -515,6 +518,7 @@ export default function CurrencySelectModal() {
       checkForRequiredAssets,
       currentChainId,
       type,
+      chainId,
       checkForSameNetwork,
       dispatch,
       callback,


### PR DESCRIPTION
Fixes APP-275

## What changed (plus any additional context for devs)
token search is still kinda fucked up after BACK-451 and this is a quicker fix, so i'm overriding the decimals value with the proper one 

## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2022-12-07-11-32-25.mp4


## What to test

