### PR TITLE
feat: handle signing requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@ethersproject/units": "5.6.1",
     "@ethersproject/wallet": "5.6.2",
     "@gorhom/bottom-sheet": "4.4.3",
+    "@json-rpc-tools/utils": "1.7.6",
     "@lavamoat/preinstall-always-fail": "1.0.0",
     "@metamask/eth-sig-util": "4.0.0",
     "@notifee/react-native": "5.6.0",

--- a/src/parsers/requests.js
+++ b/src/parsers/requests.js
@@ -17,6 +17,7 @@ import {
   SIGN,
   SIGN_TRANSACTION,
 } from '@/utils/signingMethods';
+import { isAddress } from '@ethersproject/address';
 
 export const getRequestDisplayDetails = (
   payload,
@@ -53,12 +54,12 @@ export const getRequestDisplayDetails = (
     );
   }
   if (payload.method === SIGN) {
-    const message = payload?.params?.[1];
+    const message = payload?.params?.find(p => !isAddress(p));
     const result = getMessageDisplayDetails(message, timestampInMs);
     return result;
   }
   if (payload.method === PERSONAL_SIGN) {
-    let message = payload?.params?.[0];
+    let message = payload?.params?.find(p => !isAddress(p));
     try {
       if (isHexString(message)) {
         message = convertHexToUtf8(message);

--- a/src/redux/requests.ts
+++ b/src/redux/requests.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux';
+import { SignClientTypes } from '@walletconnect/types';
 import { AppGetState } from './store';
 import { maybeSignUri } from '@/handlers/imgix';
 import {
@@ -14,7 +15,7 @@ import logger from '@/utils/logger';
 
 // -- Constants --------------------------------------- //
 
-const REQUESTS_UPDATE_REQUESTS_TO_APPROVE =
+export const REQUESTS_UPDATE_REQUESTS_TO_APPROVE =
   'requests/REQUESTS_UPDATE_REQUESTS_TO_APPROVE';
 const REQUESTS_CLEAR_STATE = 'requests/REQUESTS_CLEAR_STATE';
 
@@ -71,6 +72,16 @@ export interface RequestData {
    * The payload for the request.
    */
   payload: any;
+
+  /**
+   * Adds additional data to the request and serves as a notice that this
+   * request originated from a WC v2 session
+   */
+  walletConnectV2RequestValues?: {
+    sessionRequestEvent: SignClientTypes.EventArguments['session_request'];
+    address: string;
+    chainId: number;
+  };
 }
 
 /**

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -4,6 +4,8 @@ import { getSdkError, parseUri } from '@walletconnect/utils';
 import { WC_PROJECT_ID } from 'react-native-dotenv';
 import { NavigationContainerRef } from '@react-navigation/native';
 import Minimizer from 'react-native-minimizer';
+import { utils as ethersUtils } from 'ethers';
+import { formatJsonRpcResult, formatJsonRpcError } from '@json-rpc-tools/utils';
 
 import { logger, RainbowError } from '@/logger';
 import { WalletconnectApprovalSheetRouteParams } from '@/redux/walletconnect';
@@ -15,6 +17,21 @@ import { maybeSignUri } from '@/handlers/imgix';
 import { dappLogoOverride, dappNameOverride } from '@/helpers/dappNameHandler';
 import { Alert } from '@/components/alerts';
 import * as lang from '@/languages';
+import {
+  isSigningMethod,
+  isTransactionDisplayType,
+} from '@/utils/signingMethods';
+import store from '@/redux/store';
+import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
+import WalletTypes from '@/helpers/walletTypes';
+import { ethereumUtils } from '@/utils';
+import { getRequestDisplayDetails } from '@/parsers';
+import {
+  RequestData,
+  REQUESTS_UPDATE_REQUESTS_TO_APPROVE,
+  removeRequest,
+} from '@/redux/requests';
+import { saveLocalRequests } from '@/handlers/localstorage/walletconnectRequests';
 
 /**
  * Indicates that the app should redirect or go back after the next action
@@ -49,6 +66,48 @@ const signClient = Promise.resolve(
     },
   })
 );
+
+/**
+ * For RPC requests that have [address, message] tuples (order may change),
+ * return { address, message } and JSON.parse the value if it's from a typed
+ * data request
+ */
+function parseRPCParams({
+  method,
+  params,
+}: {
+  method: string;
+  params: string[];
+}) {
+  if (method === 'eth_sign' || method === 'personal_sign') {
+    const [address, message] = params.sort(a =>
+      ethersUtils.isAddress(a) ? -1 : 1
+    );
+    const isHexString = ethersUtils.isHexString(message);
+
+    const decodedMessage = isHexString
+      ? ethersUtils.toUtf8String(message)
+      : message;
+
+    return {
+      address,
+      message: decodedMessage,
+    };
+  }
+
+  if (method === 'eth_signTypedData' || method === 'eth_signTypedData_v4') {
+    const [address, message] = params.sort(a =>
+      ethersUtils.isAddress(a) ? -1 : 1
+    );
+
+    return {
+      address,
+      message: JSON.parse(message),
+    };
+  }
+
+  return {};
+}
 
 export async function pair({ uri }: { uri: string }) {
   logger.debug(`WC v2: pair`, { uri });
@@ -108,7 +167,10 @@ export async function pair({ uri }: { uri: string }) {
 export async function initListeners() {
   const client = await signClient;
 
+  logger.debug(`WC v2: signClient initialized, initListeners`);
+
   client.on('session_proposal', onSessionProposal);
+  client.on('session_request', onSessionRequest);
 }
 
 export function onSessionProposal(
@@ -118,10 +180,8 @@ export function onSessionProposal(
 
   const receivedTimestamp = Date.now();
   const {
-    id,
     proposer,
-    expiry,
-    pairingTopic,
+    expiry, // TODO do we need to do anything with this?
     requiredNamespaces,
   } = proposal.params;
 
@@ -144,7 +204,7 @@ export function onSessionProposal(
     meta: {
       chainId,
       dappName,
-      dappScheme: peerMeta.url || 'Unknown URL', // TODO
+      dappScheme: 'unused in WC v2', // only used for deeplinks from WC v1
       dappUrl: peerMeta.url || 'Unknown URL',
       imageUrl: maybeSignUri(
         dappLogoOverride(peerMeta?.url) || peerMeta?.icons?.[0]
@@ -260,4 +320,170 @@ export function onSessionProposal(
     routeParams,
     getActiveRoute()?.name === Routes.WALLET_CONNECT_APPROVAL_SHEET
   );
+}
+
+export async function onSessionRequest(
+  event: SignClientTypes.EventArguments['session_request']
+) {
+  const client = await signClient;
+
+  logger.debug(`WC v2: session_request`, { event });
+
+  const { id, topic } = event;
+  const { method, params } = event.params.request;
+
+  if (isSigningMethod(method)) {
+    // transactions aren't a `[address, message]` tuple
+    const isTransactionMethod = isTransactionDisplayType(method);
+    let { address, message } = parseRPCParams({ method, params });
+    const allWallets = store.getState().wallets.wallets;
+
+    if (!isTransactionMethod) {
+      if (!address || !message) {
+        logger.error(
+          new RainbowError(
+            `WC v2: session_request exited, no address or messsage`
+          ),
+          {
+            address,
+            message,
+          }
+        );
+
+        await client.respond({
+          topic,
+          response: formatJsonRpcError(id, `Invalid RPC params`),
+        });
+
+        return;
+      }
+
+      // for TS only, should never happen
+      if (!allWallets) {
+        logger.error(new RainbowError(`WC v2: allWallets is null`));
+        return;
+      }
+
+      const selectedWallet = findWalletWithAccount(allWallets, address);
+
+      if (!selectedWallet || selectedWallet?.type === WalletTypes.readOnly) {
+        logger.debug(
+          `WC v2: session_request exited, selectedWallet was falsy or read only`
+        );
+
+        await client.respond({
+          topic,
+          response: formatJsonRpcError(id, `Wallet is read-only`),
+        });
+
+        return;
+      }
+    } else {
+      address = params[0].from;
+    }
+
+    const session = client.session.get(topic);
+    const { nativeCurrency, network } = store.getState().settings;
+    const chainId = Number(event.params.chainId.split(':')[1]);
+    const dappNetwork = ethereumUtils.getNetworkFromChainId(chainId);
+    const displayDetails = getRequestDisplayDetails(
+      event.params.request,
+      nativeCurrency,
+      dappNetwork
+    );
+    const peerMeta = session.peer.metadata;
+    const request: RequestData = {
+      clientId: session.topic, // I don't think this is used
+      peerId: session.topic, // I don't think this is used
+      requestId: event.id,
+      dappName:
+        dappNameOverride(peerMeta.name) || peerMeta.name || 'Unknown Dapp',
+      dappScheme: 'unused in WC v2', // only used for deeplinks from WC v1
+      dappUrl: peerMeta.url || 'Unknown URL',
+      displayDetails,
+      imageUrl: maybeSignUri(
+        dappLogoOverride(peerMeta.url) || peerMeta.icons[0]
+      ),
+      payload: event.params.request,
+      walletConnectV2RequestValues: {
+        sessionRequestEvent: event,
+        // @ts-ignore we assign address above
+        address, // required by screen
+        chainId, // required by screen
+      },
+    };
+
+    logger.debug(`request`, { request });
+
+    const { requests: pendingRequests } = store.getState().requests;
+
+    if (!pendingRequests[request.requestId]) {
+      const updatedRequests = {
+        ...pendingRequests,
+        [request.requestId]: request,
+      };
+      store.dispatch({
+        payload: updatedRequests,
+        type: REQUESTS_UPDATE_REQUESTS_TO_APPROVE,
+      });
+      saveLocalRequests(updatedRequests, address, network);
+
+      logger.debug(`WC v2: navigating to CONFIRM_REQUEST sheet`);
+
+      Navigation.handleAction(Routes.CONFIRM_REQUEST, {
+        openAutomatically: true,
+        transactionDetails: request,
+      });
+
+      analytics.track('Showing Walletconnect signing request', {
+        dappName: request.dappName,
+        dappUrl: request.dappUrl,
+      });
+    }
+  } else {
+    logger.info(`utils/walletConnectV2: received unsupported session_request`);
+
+    await client.respond({
+      topic,
+      response: formatJsonRpcError(id, `Unsupported RPC method`),
+    });
+  }
+}
+
+/**
+ * Handles the result created on our confirmation screen and sends it along to the dapp via WC
+ */
+export async function handleSessionRequestResponse(
+  {
+    sessionRequestEvent,
+  }: {
+    sessionRequestEvent: SignClientTypes.EventArguments['session_request'];
+  },
+  { result, error }: { result: string; error: any }
+) {
+  logger.debug(`WC v2: handleSessionRequestResponse`, { result, error });
+  logger.info(`WC v2: handleSessionRequestResponse`, {
+    success: Boolean(result),
+  });
+
+  const client = await signClient;
+  const { topic, id } = sessionRequestEvent;
+
+  if (result) {
+    const payload = {
+      topic,
+      response: formatJsonRpcResult(id, result),
+    };
+    logger.debug(`WC v2: handleSessionRequestResponse success`, { payload });
+    await client.respond(payload);
+  } else {
+    const payload = {
+      topic,
+      response: formatJsonRpcError(id, error),
+    };
+    logger.debug(`WC v2: handleSessionRequestResponse reject`, { payload });
+    await client.respond(payload);
+  }
+
+  store.dispatch(removeRequest(sessionRequestEvent.id));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2522,6 +2522,21 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@json-rpc-tools/types@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@json-rpc-tools/types/-/types-1.7.6.tgz#5abd5fde01364a130c46093b501715bcce5bdc0e"
+  integrity sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==
+  dependencies:
+    keyvaluestorage-interface "^1.0.0"
+
+"@json-rpc-tools/utils@1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@json-rpc-tools/utils/-/utils-1.7.6.tgz#67f04987dbaa2e7adb6adff1575367b75a9a9ba1"
+  integrity sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==
+  dependencies:
+    "@json-rpc-tools/types" "^1.7.6"
+    "@pedrouid/environment" "^1.0.1"
+
 "@lavamoat/aa@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@lavamoat/aa/-/aa-3.1.0.tgz#28df51a17f529a5b04d6a3b6e5a727aefc8e474a"
@@ -2622,6 +2637,11 @@
     "@npmcli/promise-spawn" "^1.3.2"
     node-gyp "^7.1.0"
     read-package-json-fast "^2.0.1"
+
+"@pedrouid/environment@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pedrouid/environment/-/environment-1.0.1.tgz#858f0f8a057340e0b250398b75ead77d6f4342ec"
+  integrity sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==
 
 "@pkgr/utils@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Once paired with a dapp, handles signing and transaction requests using our existing UI. Basically just event plumbing.

## What to test
See #4443 for testing details. Once enabled, you can use the V2 test dapp to send requests to your connection.

