### PR TITLE
Fixed critical UX issue related to the bottom sheets

### DIFF
--- a/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
+++ b/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
@@ -108,10 +108,8 @@ const BottomSheetRoute = ({
   //#endregion
 
   //#region callbacks
-  const handleOnChange = useCallback((index: number) => {
-    if (index === -1) {
+  const handleOnClose = useCallback(() => {
       onDismiss(routeKey, removingRef.current);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   //#endregion
@@ -158,7 +156,7 @@ const BottomSheetRoute = ({
         enablePanDownToClose
         handleComponent={null}
         index={index}
-        onChange={handleOnChange}
+        onClose={handleOnClose}
         ref={ref}
         simultaneousHandlers={[]}
         snapPoints={snapPoints}


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Fixed critical UX issue related to the bottom sheets IOS/Android that is quite easy for the user to reproduce when using the application normally

## Steps to reproduce in previous rainbow's builds
1) Press on item that opens BS modal
2) Close the BS modal before it fully opens. (You can press on backdrop to close the modal or by swiping it down)
The main thing is to quickly close the modal

Also you can trigger goBack event to remove BS modal from navigation stack

## Screen recordings / screenshots
https://user-images.githubusercontent.com/52937225/206871586-9f58a16a-33ef-4c51-8001-1b76549b189a.mp4


## What to test
Bottom sheet modal correct behavior after quick close

