### PR TITLE
feat: wc v2 connected dapps, ui polish

### DIFF
--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -131,7 +131,6 @@ export function WalletConnectV2ListItem({
   }, [session]);
 
   const availableNetworks = useMemo(() => {
-    // we dont want to show mainnet
     return chainIds
       .map(network => ethereumUtils.getNetworkFromChainId(Number(network)))
       .sort(network => (network === Network.mainnet ? -1 : 1));

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -302,7 +302,6 @@ export function WalletConnectV2ListItem({
                             size="small"
                           />
                         ) : (
-                          /* @ts-expect-error */
                           <CoinIcon
                             address={ETH_ADDRESS}
                             size={20}

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -7,17 +7,13 @@ import { ContactAvatar } from '../contacts';
 import ImageAvatar from '../contacts/ImageAvatar';
 import { ContextMenuButton } from '../context-menu';
 import { Centered, ColumnWithMargins, Row } from '../layout';
-import { Text, TruncatedText } from '../text';
+import { TruncatedText } from '../text';
 import { analytics } from '@/analytics';
 import { getAccountProfileInfo } from '@/helpers/accountInfo';
 import { dappLogoOverride, dappNameOverride } from '@/helpers/dappNameHandler';
 import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
-import {
-  changeConnectionMenuItems,
-  NETWORK_MENU_ACTION_KEY_FILTER,
-  networksMenuItems,
-} from '@/helpers/walletConnectNetworks';
-import { useWalletConnectConnections, useWallets } from '@/hooks';
+import { changeConnectionMenuItems } from '@/helpers/walletConnectNetworks';
+import { useWallets } from '@/hooks';
 import { Navigation, useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import styled from '@/styled-thing';
@@ -34,12 +30,10 @@ import { ETH_ADDRESS, ETH_SYMBOL } from '@/references';
 import { AssetType } from '@/entities';
 import { Network } from '@/helpers';
 
-const ContainerPadding = 15;
-const VendorLogoIconSize = 50;
-export const WalletConnectListItemHeight =
-  VendorLogoIconSize + ContainerPadding * 2;
-
-const networksAvailable = networksMenuItems();
+const CONTAINER_PADDING = 15;
+const VENDOR_LOGO_ICON_SIZE = 50;
+export const WALLET_CONNECT_LIST_ITEM_HEIGHT =
+  VENDOR_LOGO_ICON_SIZE + CONTAINER_PADDING * 2;
 
 const androidContextMenuActions = [
   lang.t('walletconnect.switch_wallet'),
@@ -52,10 +46,10 @@ const SessionRow = styled(Row)({
 });
 
 const rowStyle = padding.object(
-  ContainerPadding,
-  ContainerPadding,
-  ContainerPadding + 10,
-  ContainerPadding
+  CONTAINER_PADDING,
+  CONTAINER_PADDING,
+  CONTAINER_PADDING + 10,
+  CONTAINER_PADDING
 );
 
 const columnStyle = padding.object(0, 10, 0, 12);
@@ -209,14 +203,14 @@ export function WalletConnectV2ListItem({
       onPressAndroid={onPressAndroid}
       onPressMenuItem={handleOnPressMenuItem}
     >
-      <Row align="center" height={WalletConnectListItemHeight}>
+      <Row align="center" height={WALLET_CONNECT_LIST_ITEM_HEIGHT}>
         <Row align="center" flex={1} style={rowStyle}>
           {/* @ts-expect-error */}
           <RequestVendorLogoIcon
             backgroundColor={colors.white}
             dappName={dappName}
             imageUrl={dappLogo}
-            size={VendorLogoIconSize}
+            size={VENDOR_LOGO_ICON_SIZE}
           />
           <ColumnWithMargins
             flex={1}

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -46,14 +46,6 @@ const androidContextMenuActions = [
   lang.t('walletconnect.disconnect'),
 ];
 
-if (networksAvailable.length > 1) {
-  androidContextMenuActions.splice(
-    0,
-    0,
-    lang.t('walletconnect.switch_network')
-  );
-}
-
 const SessionRow = styled(Row)({
   alignItems: 'center',
   justifyContent: 'flex-start',
@@ -177,17 +169,9 @@ export function WalletConnectV2ListItem({
         title: dappName,
       },
       async (index: number) => {
-        if (index === 0 && networksAvailable.length > 1) {
-          // TODO
-        } else if (
-          (index === 0 && networksAvailable.length === 1) ||
-          index === 1
-        ) {
+        if (index === 0) {
           handlePressChangeWallet();
-        } else if (
-          (index === 1 && networksAvailable.length === 1) ||
-          index === 2
-        ) {
+        } else if (index === 1) {
           await disconnectSession(session);
           reload();
           analytics.track(
@@ -213,8 +197,6 @@ export function WalletConnectV2ListItem({
         });
       } else if (actionKey === 'switch-account') {
         handlePressChangeWallet();
-      } else if (actionKey.indexOf(NETWORK_MENU_ACTION_KEY_FILTER) !== -1) {
-        // TODO
       }
     },
     [address, dappName, dappUrl, handlePressChangeWallet]

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -1,0 +1,342 @@
+import React, { useCallback, useMemo } from 'react';
+import { SessionTypes } from '@walletconnect/types';
+import RadialGradient from 'react-native-radial-gradient';
+
+import { RequestVendorLogoIcon } from '../coin-icon';
+import { ContactAvatar } from '../contacts';
+import ImageAvatar from '../contacts/ImageAvatar';
+import { ContextMenuButton } from '../context-menu';
+import { Centered, ColumnWithMargins, Row } from '../layout';
+import { Text, TruncatedText } from '../text';
+import { analytics } from '@/analytics';
+import { getAccountProfileInfo } from '@/helpers/accountInfo';
+import { dappLogoOverride, dappNameOverride } from '@/helpers/dappNameHandler';
+import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
+import {
+  changeConnectionMenuItems,
+  NETWORK_MENU_ACTION_KEY_FILTER,
+  networksMenuItems,
+} from '@/helpers/walletConnectNetworks';
+import { useWalletConnectConnections, useWallets } from '@/hooks';
+import { Navigation, useNavigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
+import styled from '@/styled-thing';
+import { padding, position } from '@/styles';
+import { ethereumUtils, showActionSheetWithOptions } from '@/utils';
+import * as lang from '@/languages';
+import { useTheme } from '@/theme';
+import { logger, RainbowError } from '@/logger';
+import { updateSession, disconnectSession } from '@/utils/walletConnect';
+import { Box, Inline } from '@/design-system';
+import ChainBadge from '@/components/coin-icon/ChainBadge';
+import { CoinIcon } from '@/components/coin-icon';
+import { ETH_ADDRESS, ETH_SYMBOL } from '@/references';
+import { AssetType } from '@/entities';
+import { Network } from '@/helpers';
+
+const ContainerPadding = 15;
+const VendorLogoIconSize = 50;
+export const WalletConnectListItemHeight =
+  VendorLogoIconSize + ContainerPadding * 2;
+
+const networksAvailable = networksMenuItems();
+
+const androidContextMenuActions = [
+  lang.t('walletconnect.switch_wallet'),
+  lang.t('walletconnect.disconnect'),
+];
+
+if (networksAvailable.length > 1) {
+  androidContextMenuActions.splice(
+    0,
+    0,
+    lang.t('walletconnect.switch_network')
+  );
+}
+
+const SessionRow = styled(Row)({
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+});
+
+const rowStyle = padding.object(
+  ContainerPadding,
+  ContainerPadding,
+  ContainerPadding + 10,
+  ContainerPadding
+);
+
+const columnStyle = padding.object(0, 10, 0, 12);
+
+export function WalletConnectV2ListItem({
+  session,
+  reload,
+}: {
+  session: SessionTypes.Struct;
+  reload(): void;
+}) {
+  const { goBack } = useNavigation();
+  const { colors } = useTheme();
+  const { wallets, walletNames } = useWallets();
+
+  const radialGradientProps = {
+    center: [0, 1],
+    colors: colors.gradients.lightGreyWhite,
+    pointerEvents: 'none',
+    style: {
+      ...position.coverAsObject,
+      overflow: 'hidden',
+    },
+  };
+
+  const {
+    dappName,
+    dappUrl,
+    dappLogo,
+    address,
+    chainIds,
+  } = React.useMemo(() => {
+    const { namespaces, requiredNamespaces, peer } = session;
+    const { metadata } = peer;
+    const { chains } = requiredNamespaces.eip155;
+    const eip155Account = namespaces.eip155?.accounts?.[0] || undefined;
+
+    if (!eip155Account) {
+      const e = new RainbowError(
+        `WalletConnectV2ListItem: unsupported namespace`
+      );
+      logger.error(e);
+
+      // defensive, just for types, should never happen
+      throw e;
+    }
+
+    const [ns, rawChainId, address] = eip155Account?.split(':') as [
+      string,
+      string,
+      string
+    ];
+    const chainIds = chains.map(chain => parseInt(chain.split(':')[1]));
+
+    if (!address) {
+      const e = new RainbowError(
+        `WalletConnectV2ListItem: could not parse address`
+      );
+      logger.error(e);
+
+      // defensive, just for types, should never happen
+      throw e;
+    }
+
+    return {
+      dappName:
+        dappNameOverride(metadata.url) || metadata.name || 'Unknown Dapp',
+      dappUrl: metadata.url || 'Unknown URL',
+      dappLogo: dappLogoOverride(metadata.url) || metadata.icons[0],
+      address,
+      chainIds,
+    };
+  }, [session]);
+
+  const availableNetworks = useMemo(() => {
+    // we dont want to show mainnet
+    return chainIds
+      .map(network => ethereumUtils.getNetworkFromChainId(Number(network)))
+      .sort(network => (network === Network.mainnet ? -1 : 1));
+  }, [chainIds]);
+
+  const approvalAccountInfo = useMemo(() => {
+    const selectedWallet = findWalletWithAccount(wallets!, address);
+    const approvalAccountInfo = getAccountProfileInfo(
+      selectedWallet,
+      walletNames,
+      address
+    );
+    return {
+      ...approvalAccountInfo,
+    };
+  }, [wallets, walletNames, address]);
+
+  const handlePressChangeWallet = useCallback(() => {
+    Navigation.handleAction(Routes.CHANGE_WALLET_SHEET, {
+      currentAccountAddress: address,
+      onChangeWallet: async (address: string) => {
+        await updateSession(session, { address });
+        reload();
+        goBack();
+      },
+      watchOnly: true,
+    });
+  }, [session, address, dappUrl, goBack]);
+
+  const onPressAndroid = useCallback(() => {
+    showActionSheetWithOptions(
+      {
+        options: androidContextMenuActions,
+        showSeparators: true,
+        title: dappName,
+      },
+      async (index: number) => {
+        if (index === 0 && networksAvailable.length > 1) {
+          // TODO
+        } else if (
+          (index === 0 && networksAvailable.length === 1) ||
+          index === 1
+        ) {
+          handlePressChangeWallet();
+        } else if (
+          (index === 1 && networksAvailable.length === 1) ||
+          index === 2
+        ) {
+          await disconnectSession(session);
+          reload();
+          analytics.track(
+            'Manually disconnected from WalletConnect connection',
+            {
+              dappName,
+              dappUrl,
+            }
+          );
+        }
+      }
+    );
+  }, [session, address, dappName, dappUrl, handlePressChangeWallet]);
+
+  const handleOnPressMenuItem = useCallback(
+    async ({ nativeEvent: { actionKey } }) => {
+      if (actionKey === 'disconnect') {
+        await disconnectSession(session);
+        reload();
+        analytics.track('Manually disconnected from WalletConnect connection', {
+          dappName,
+          dappUrl,
+        });
+      } else if (actionKey === 'switch-account') {
+        handlePressChangeWallet();
+      } else if (actionKey.indexOf(NETWORK_MENU_ACTION_KEY_FILTER) !== -1) {
+        // TODO
+      }
+    },
+    [address, dappName, dappUrl, handlePressChangeWallet]
+  );
+
+  return (
+    <ContextMenuButton
+      testID="wallet_connect_v2_list_item"
+      menuItems={changeConnectionMenuItems({ isWalletConnectV2: true })}
+      menuTitle={dappName}
+      onPressAndroid={onPressAndroid}
+      onPressMenuItem={handleOnPressMenuItem}
+    >
+      <Row align="center" height={WalletConnectListItemHeight}>
+        <Row align="center" flex={1} style={rowStyle}>
+          {/* @ts-expect-error */}
+          <RequestVendorLogoIcon
+            backgroundColor={colors.white}
+            dappName={dappName}
+            imageUrl={dappLogo}
+            size={VendorLogoIconSize}
+          />
+          <ColumnWithMargins
+            flex={1}
+            margin={android ? -4 : 5}
+            style={columnStyle}
+          >
+            <Row width="95%">
+              <TruncatedText size="lmedium" weight="heavy">
+                {dappName || lang.t('walletconnect.unknown_application')}
+              </TruncatedText>
+            </Row>
+
+            <SessionRow>
+              <Centered
+                style={{
+                  paddingLeft: 10,
+                }}
+              >
+                {approvalAccountInfo.accountImage ? (
+                  <ImageAvatar
+                    image={approvalAccountInfo.accountImage}
+                    size="smaller"
+                  />
+                ) : (
+                  <ContactAvatar
+                    color={
+                      isNaN(approvalAccountInfo.accountColor)
+                        ? colors.skeleton
+                        : approvalAccountInfo.accountColor
+                    }
+                    size="smaller"
+                    value={approvalAccountInfo.accountSymbol}
+                  />
+                )}
+                <TruncatedText
+                  size="medium"
+                  style={{
+                    color: colors.alpha(colors.blueGreyDark, 0.6),
+                    paddingLeft: 5,
+                    paddingRight: 19,
+                    width: '100%',
+                  }}
+                  weight="bold"
+                >
+                  {approvalAccountInfo.accountName}
+                </TruncatedText>
+              </Centered>
+            </SessionRow>
+          </ColumnWithMargins>
+
+          <Box
+            borderRadius={99}
+            paddingVertical="8px"
+            paddingHorizontal="12px"
+            justifyContent="center"
+          >
+            <RadialGradient
+              {...radialGradientProps}
+              // @ts-expect-error overloaded props RadialGradient
+              borderRadius={99}
+              radius={600}
+            />
+            <Inline alignVertical="center" alignHorizontal="justify">
+              <Inline alignVertical="center">
+                <Box style={{ flexDirection: 'row' }}>
+                  {availableNetworks?.map((network, index) => {
+                    return (
+                      <Box
+                        background="body (Deprecated)"
+                        key={`availableNetwork-${network}`}
+                        marginLeft={{ custom: index > 0 ? -4 : 0 }}
+                        style={{
+                          backgroundColor: colors.transparent,
+                          zIndex: availableNetworks?.length - index,
+                          borderRadius: 30,
+                        }}
+                      >
+                        {network !== Network.mainnet ? (
+                          <ChainBadge
+                            assetType={network}
+                            position="relative"
+                            size="small"
+                          />
+                        ) : (
+                          /* @ts-expect-error */
+                          <CoinIcon
+                            address={ETH_ADDRESS}
+                            size={20}
+                            symbol={ETH_SYMBOL}
+                            type={AssetType.token}
+                          />
+                        )}
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </Inline>
+            </Inline>
+          </Box>
+        </Row>
+      </Row>
+    </ContextMenuButton>
+  );
+}

--- a/src/helpers/walletConnectNetworks.ts
+++ b/src/helpers/walletConnectNetworks.ts
@@ -36,7 +36,9 @@ export const networksMenuItems = () => {
 
 const networksAvailable = networksMenuItems();
 
-export const changeConnectionMenuItems = () => {
+export const changeConnectionMenuItems = ({
+  isWalletConnectV2,
+}: { isWalletConnectV2?: boolean } = {}) => {
   const baseOptions = [
     {
       actionKey: 'disconnect',
@@ -57,7 +59,7 @@ export const changeConnectionMenuItems = () => {
     },
   ];
 
-  if (networksAvailable.length > 1) {
+  if (networksAvailable.length > 1 && !isWalletConnectV2) {
     return [
       ...baseOptions,
       {

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1757,7 +1757,9 @@
       "failed_to_connect_to": "Failed to connect to %{appName}",
       "go_back": "Go back",
       "requesting_network": "Requesting %{num} network",
-      "requesting_networks": "Requesting %{num} networks"
+      "requesting_networks": "Requesting %{num} networks",
+      "unknown_dapp": "Unknown Dapp",
+      "unknown_url": "Unknown URL"
     },
     "warning": {
       "user_is_offline": "Connection offline, please check your internet connection",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1755,7 +1755,9 @@
       "unknown_application": "Unknown Application",
       "connection_failed": "Connection failed",
       "failed_to_connect_to": "Failed to connect to %{appName}",
-      "go_back": "Go back"
+      "go_back": "Go back",
+      "requesting_network": "Requesting %{num} network",
+      "requesting_networks": "Requesting %{num} networks"
     },
     "warning": {
       "user_is_offline": "Connection offline, please check your internet connection",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1755,7 +1755,9 @@
       "unknown_application": "Unknown Application :)",
       "connection_failed": "Connection failed :)",
       "failed_to_connect_to": "Failed to connect to %{appName} :)",
-      "go_back": "Go back :)"
+      "go_back": "Go back :)",
+      "requesting_network": "Requesting %{num} network :)",
+      "requesting_networks": "Requesting %{num} networks :)"
     },
     "warning": {
       "user_is_offline": "Hors connexion, veuillez vérifier votre connexion Internet",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1757,7 +1757,9 @@
       "failed_to_connect_to": "Failed to connect to %{appName} :)",
       "go_back": "Go back :)",
       "requesting_network": "Requesting %{num} network :)",
-      "requesting_networks": "Requesting %{num} networks :)"
+      "requesting_networks": "Requesting %{num} networks :)",
+      "unknown_dapp": "Unknown Dapp :)",
+      "unknown_url": "Unknown URL :)"
     },
     "warning": {
       "user_is_offline": "Hors connexion, veuillez vérifier votre connexion Internet",

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -149,6 +149,8 @@ export interface WalletconnectApprovalSheetRouteParams {
   receivedTimestamp: number;
   meta?: {
     chainId: number;
+    chainIds?: number[];
+    isWalletConnectV2?: boolean;
   } & Pick<
     RequestData,
     'dappName' | 'dappScheme' | 'dappUrl' | 'imageUrl' | 'peerId'

--- a/src/screens/ConnectedDappsSheet.js
+++ b/src/screens/ConnectedDappsSheet.js
@@ -39,6 +39,9 @@ export default function ConnectedDappsSheet() {
 
   const numOfRows = mostRecentWalletConnectors.length + sessions.length;
 
+  /**
+   * Load and reload functionality
+   */
   React.useEffect(() => {
     function load() {
       const sessions = getAllActiveSessionsSync();
@@ -49,6 +52,11 @@ export default function ConnectedDappsSheet() {
     if (loadSessions) load();
   }, [loadSessions, setLoadSessions, setSessions]);
 
+  /**
+   * Listen for disconnected sessions and remove from list. Really only needed
+   * if the list is already opened, since we otherwise lazily check for
+   * sessions when the user clicks on the overflow menu button.
+   */
   React.useEffect(() => {
     async function listen() {
       const client = await signClient;

--- a/src/screens/ConnectedDappsSheet.js
+++ b/src/screens/ConnectedDappsSheet.js
@@ -1,10 +1,9 @@
 import lang from 'i18n-js';
 import React, { useEffect } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-
-import Divider from '../components/Divider';
-import { Row } from '../components/layout';
-import { Sheet, SheetHandleFixedToTop, SheetTitle } from '../components/sheet';
+import Divider from '@/components/Divider';
+import { Row } from '@/components/layout';
+import { Sheet, SheetHandleFixedToTop, SheetTitle } from '@/components/sheet';
 import WalletConnectListItem, {
   WalletConnectListItemHeight,
 } from '@/components/walletconnect-list/WalletConnectListItem';

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -252,8 +252,6 @@ export default function WalletConnectApprovalSheet() {
   );
   const isWalletConnectV2 = meta.isWalletConnectV2;
 
-  console.log({ chainIds });
-
   const { dappName, dappUrl, dappScheme, imageUrl, peerId } = meta;
 
   const checkIfScam = useCallback(
@@ -477,7 +475,7 @@ export default function WalletConnectApprovalSheet() {
                   {type === WalletConnectApprovalSheetType.connect
                     ? `wants to connect to your wallet`
                     : `wants to connect to the ${ethereumUtils.getNetworkNameFromChainId(
-                        Number(chainId) // TODO
+                        Number(chainId)
                       )} network`}
                 </Text>
               </Column>

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -1,5 +1,4 @@
 import { useRoute } from '@react-navigation/native';
-import lang from 'i18n-js';
 import React, {
   useCallback,
   useEffect,
@@ -7,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import RadialGradient from 'react-native-radial-gradient';
 import { ActivityIndicator, InteractionManager } from 'react-native';
 import { ContextMenuButton } from 'react-native-ios-context-menu';
 import ChainLogo from '../components/ChainLogo';
@@ -24,7 +24,6 @@ import {
   SheetActionButtonRow,
 } from '../components/sheet';
 import { analytics } from '@/analytics';
-import { Text } from '@/design-system';
 import { getAccountProfileInfo } from '@/helpers/accountInfo';
 import { getDappHostname } from '@/helpers/dappNameHandler';
 import networkInfo from '@/helpers/networkInfo';
@@ -39,6 +38,14 @@ import { Navigation, useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import styled from '@/styled-thing';
 import { ethereumUtils } from '@/utils';
+import { Network } from '@/helpers';
+import { Box, Inline, Text } from '@/design-system';
+import ChainBadge from '@/components/coin-icon/ChainBadge';
+import { CoinIcon } from '@/components/coin-icon';
+import { position } from '@/styles';
+import * as lang from '@/languages';
+import { ETH_ADDRESS, ETH_SYMBOL } from '@/references';
+import { AssetType } from '@/entities';
 
 const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(
   ({ theme: { colors } }) => ({
@@ -90,6 +97,132 @@ const SwitchText = ({ children, ...props }) => {
   );
 };
 
+const NetworkPill = ({ chainIds }) => {
+  const { colors } = useTheme();
+
+  const radialGradientProps = {
+    center: [0, 1],
+    colors: colors.gradients.lightGreyWhite,
+    pointerEvents: 'none',
+    style: {
+      ...position.coverAsObject,
+      overflow: 'hidden',
+    },
+  };
+
+  const availableNetworks = useMemo(() => {
+    // we dont want to show mainnet
+    return chainIds
+      .map(network => ethereumUtils.getNetworkFromChainId(Number(network)))
+      .sort(network => (network === Network.mainnet ? -1 : 1));
+  }, [chainIds]);
+
+  const networkMenuItems = useMemo(() => {
+    return Object.values(networkInfo)
+      .filter(
+        ({ exchange_enabled, value }) =>
+          exchange_enabled &&
+          chainIds.includes(ethereumUtils.getChainIdFromNetwork(value))
+      )
+      .map(netInfo => ({
+        actionKey: netInfo.value,
+        actionTitle: netInfo.name,
+        icon: {
+          iconType: 'ASSET',
+          iconValue: `${
+            netInfo.layer2 ? `${netInfo.value}BadgeNoShadow` : 'ethereumBadge'
+          }`,
+        },
+      }));
+  }, [chainIds]);
+
+  if (availableNetworks.length === 0) return null;
+
+  return (
+    <ContextMenuButton
+      // @ts-expect-error overloaded props ContextMenuButton
+      menuConfig={{ menuItems: networkMenuItems, menuTitle: '' }}
+      isMenuPrimaryAction
+      onPressMenuItem={() => {}}
+      useActionSheetFallback={false}
+      width="100%"
+    >
+      <Box
+        as={ButtonPressAnimation}
+        // @ts-expect-error overloaded props ButtonPressAnimation
+        scaleTo={0.96}
+        onPress={() => {}}
+        testID={'available-networks-v2'}
+      >
+        <Box
+          borderRadius={99}
+          paddingVertical="8px"
+          paddingHorizontal="12px"
+          justifyContent="center"
+        >
+          <RadialGradient
+            {...radialGradientProps}
+            // @ts-expect-error overloaded props RadialGradient
+            borderRadius={99}
+            radius={600}
+          />
+          <Inline alignVertical="center" width="100%">
+            <Box style={{ flexDirection: 'row' }}>
+              {availableNetworks?.map((network, index) => {
+                return (
+                  <Box
+                    background="body (Deprecated)"
+                    key={`availableNetwork-${network}`}
+                    marginLeft={{ custom: index > 0 ? -4 : 0 }}
+                    style={{
+                      backgroundColor: colors.transparent,
+                      zIndex: availableNetworks?.length - index,
+                      borderRadius: 30,
+                    }}
+                  >
+                    {network !== Network.mainnet ? (
+                      <ChainBadge
+                        assetType={network}
+                        position="relative"
+                        size="small"
+                      />
+                    ) : (
+                      <CoinIcon
+                        address={ETH_ADDRESS}
+                        size={20}
+                        symbol={ETH_SYMBOL}
+                        type={AssetType.token}
+                      />
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            <Box paddingHorizontal="12px">
+              <Text
+                color="secondary60 (Deprecated)"
+                size="14px / 19px (Deprecated)"
+                weight="semibold"
+                numberOfLines={2}
+              >
+                {lang.t(
+                  availableNetworks.length > 1
+                    ? lang.l.walletconnect.requesting_networks
+                    : lang.l.walletconnect.requesting_network,
+                  {
+                    num: availableNetworks?.length,
+                  }
+                )}
+              </Text>
+            </Box>
+          </Inline>
+        </Box>
+      </Box>
+    </ContextMenuButton>
+  );
+};
+
 export default function WalletConnectApprovalSheet() {
   const { colors } = useTheme();
   const { goBack } = useNavigation();
@@ -112,10 +245,14 @@ export default function WalletConnectApprovalSheet() {
   const receivedTimestamp = params?.receivedTimestamp;
   const timedOut = params?.timedOut;
   const chainId = meta?.chainId || params?.chainId || 1;
+  const chainIds = meta.chainIds;
   const currentNetwork = params?.currentNetwork;
   const [approvalNetwork, setApprovalNetwork] = useState(
     currentNetwork || network
   );
+  const isWalletConnectV2 = meta.isWalletConnectV2;
+
+  console.log({ chainIds });
 
   const { dappName, dappUrl, dappScheme, imageUrl, peerId } = meta;
 
@@ -340,7 +477,7 @@ export default function WalletConnectApprovalSheet() {
                   {type === WalletConnectApprovalSheetType.connect
                     ? `wants to connect to your wallet`
                     : `wants to connect to the ${ethereumUtils.getNetworkNameFromChainId(
-                        Number(chainId)
+                        Number(chainId) // TODO
                       )} network`}
                 </Text>
               </Column>
@@ -374,96 +511,106 @@ export default function WalletConnectApprovalSheet() {
               weight="heavy"
             />
           </SheetActionButtonRow>
-          <Row
-            justify="space-between"
-            paddingBottom={21}
-            paddingHorizontal={24}
-          >
-            <Column style={{ flex: 1, marginRight: 16 }}>
+          <Row justify="space-between" paddingBottom={8} paddingHorizontal={24}>
+            <Column
+              style={{ flex: 1, marginRight: isWalletConnectV2 ? 0 : 16 }}
+            >
               <SwitchText>{lang.t('wallet.wallet_title')}</SwitchText>
               <ButtonPressAnimation
                 onPress={handlePressChangeWallet}
                 style={{
                   alignItems: 'center',
                   flexDirection: 'row',
+                  justifyContent: 'space-between',
                   height: 38,
                 }}
               >
-                <AvatarWrapper>
-                  {approvalAccountInfo.accountImage ? (
-                    <ImageAvatar
-                      image={approvalAccountInfo.accountImage}
-                      size="smaller"
-                    />
-                  ) : (
-                    <ContactAvatar
-                      color={
-                        isNaN(approvalAccountInfo.accountColor)
-                          ? colors.skeleton
-                          : approvalAccountInfo.accountColor
-                      }
-                      size="smaller"
-                      value={approvalAccountInfo.accountSymbol}
-                    />
-                  )}
-                </AvatarWrapper>
-                <Flex direction="row" flexShrink={1}>
-                  <LabelText>{approvalAccountInfo.accountLabel}</LabelText>
+                <Flex direction="row" align="center">
+                  <AvatarWrapper>
+                    {approvalAccountInfo.accountImage ? (
+                      <ImageAvatar
+                        image={approvalAccountInfo.accountImage}
+                        size="smaller"
+                      />
+                    ) : (
+                      <ContactAvatar
+                        color={
+                          isNaN(approvalAccountInfo.accountColor)
+                            ? colors.skeleton
+                            : approvalAccountInfo.accountColor
+                        }
+                        size="smaller"
+                        value={approvalAccountInfo.accountSymbol}
+                      />
+                    )}
+                  </AvatarWrapper>
+                  <LabelText position="relative">
+                    {approvalAccountInfo.accountLabel}
+                  </LabelText>
                 </Flex>
                 {type === WalletConnectApprovalSheetType.connect && (
                   <LabelText> 􀁰</LabelText>
                 )}
               </ButtonPressAnimation>
             </Column>
-            <Column>
-              <Flex justify="end">
-                <SwitchText align="right">
-                  {lang.t('wallet.network_title')}
-                </SwitchText>
-              </Flex>
-              <NetworkSwitcherParent
-                activeOpacity={0}
-                isMenuPrimaryAction
-                {...(android ? { onPress: onPressAndroid } : {})}
-                menuConfig={{
-                  menuItems,
-                  menuTitle: lang.t('walletconnect.available_networks'),
-                }}
-                onPressMenuItem={handleOnPressNetworksMenuItem}
-                useActionSheetFallback={false}
-                wrapNativeComponent={false}
-              >
-                <ButtonPressAnimation
-                  style={{
-                    alignItems: 'center',
-                    flexDirection: 'row',
-                    height: 38,
+            {isWalletConnectV2 ? null : (
+              <Column>
+                <Flex justify="end">
+                  <SwitchText align="right">
+                    {lang.t('wallet.network_title')}
+                  </SwitchText>
+                </Flex>
+                <NetworkSwitcherParent
+                  activeOpacity={0}
+                  isMenuPrimaryAction
+                  {...(android ? { onPress: onPressAndroid } : {})}
+                  menuConfig={{
+                    menuItems,
+                    menuTitle: lang.t('walletconnect.available_networks'),
                   }}
+                  onPressMenuItem={handleOnPressNetworksMenuItem}
+                  useActionSheetFallback={false}
+                  wrapNativeComponent={false}
                 >
-                  <Centered marginRight={5}>
-                    <ChainLogo
-                      network={
-                        type === WalletConnectApprovalSheetType.connect
-                          ? approvalNetworkInfo.value
-                          : ethereumUtils.getNetworkFromChainId(Number(chainId))
-                      }
-                    />
-                  </Centered>
-                  <LabelText align="right" numberOfLines={1}>
-                    {type === WalletConnectApprovalSheetType.connect
-                      ? approvalNetworkInfo.name
-                      : ethereumUtils.getNetworkNameFromChainId(
-                          Number(chainId)
-                        )}
-                  </LabelText>
-                  {type === WalletConnectApprovalSheetType.connect &&
-                    menuItems.length > 1 && (
-                      <LabelText align="right"> 􀁰</LabelText>
-                    )}
-                </ButtonPressAnimation>
-              </NetworkSwitcherParent>
-            </Column>
+                  <ButtonPressAnimation
+                    style={{
+                      alignItems: 'center',
+                      flexDirection: 'row',
+                      height: 38,
+                    }}
+                  >
+                    <Centered marginRight={5}>
+                      <ChainLogo
+                        network={
+                          type === WalletConnectApprovalSheetType.connect
+                            ? approvalNetworkInfo.value
+                            : ethereumUtils.getNetworkFromChainId(
+                                Number(chainId)
+                              )
+                        }
+                      />
+                    </Centered>
+                    <LabelText align="right" numberOfLines={1}>
+                      {type === WalletConnectApprovalSheetType.connect
+                        ? approvalNetworkInfo.name
+                        : ethereumUtils.getNetworkNameFromChainId(
+                            Number(chainId)
+                          )}
+                    </LabelText>
+                    {type === WalletConnectApprovalSheetType.connect &&
+                      menuItems.length > 1 && (
+                        <LabelText align="right"> 􀁰</LabelText>
+                      )}
+                  </ButtonPressAnimation>
+                </NetworkSwitcherParent>
+              </Column>
+            )}
           </Row>
+          {isWalletConnectV2 && (
+            <Row paddingBottom={21} paddingHorizontal={24}>
+              <NetworkPill chainIds={chainIds} />
+            </Row>
+          )}
         </Flex>
       )}
     </Sheet>

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -188,11 +188,7 @@ export function onSessionProposal(
   logger.debug(`WC v2: session_proposal`);
 
   const receivedTimestamp = Date.now();
-  const {
-    proposer,
-    expiry, // TODO do we need to do anything with this?
-    requiredNamespaces,
-  } = proposal.params;
+  const { proposer, requiredNamespaces } = proposal.params;
 
   /**
    * Trying to be defensive here, but I'm not sure we support this anyway so
@@ -247,8 +243,6 @@ export function onSessionProposal(
             events: value.events,
           };
 
-          // TODO do we support connecting to multiple chains at the same time?
-          // The sheet def doesn't, only shows one
           for (const chain of value.chains) {
             const chainId = parseInt(chain.split(`${key}:`)[1]);
             namespaces[key].accounts.push(
@@ -496,15 +490,25 @@ export async function handleSessionRequestResponse(
   store.dispatch(removeRequest(sessionRequestEvent.id));
 }
 
+/**
+ * Returns all active settings in a type-safe manner.
+ */
 export async function getAllActiveSessions() {
   const client = await signClient;
   return client?.session?.values || [];
 }
 
+/**
+ * Synchronous version of `getAllActiveSessions`. Returns all active settings
+ * in a type-safe manner.
+ */
 export function getAllActiveSessionsSync() {
   return syncSignClient?.session?.values || [];
 }
 
+/**
+ * Updates an existing session with new values
+ */
 export async function updateSession(
   session: SessionTypes.Struct,
   { address }: { address?: string }
@@ -520,7 +524,6 @@ export async function updateSession(
       events: value.events,
     };
 
-    // TODO do we support connecting to multiple chains at the same time?
     for (const chain of value.chains) {
       const chainId = parseInt(chain.split(`${key}:`)[1]);
       namespaces[key].accounts.push(`${key}:${chainId}:${address}`);
@@ -533,6 +536,10 @@ export async function updateSession(
   });
 }
 
+/**
+ * Initiates a disconnect from the app-end of the connection. Disconnection
+ * within a dapp is handled internally by WC v2.
+ */
 export async function disconnectSession(session: SessionTypes.Struct) {
   const client = await signClient;
 

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -202,7 +202,9 @@ export function onSessionProposal(
   const chainIds = chains.map(chain => parseInt(chain.split('eip155:')[1]));
   const peerMeta = proposer.metadata;
   const dappName =
-    dappNameOverride(peerMeta.url) || peerMeta.name || 'Unknown Dapp';
+    dappNameOverride(peerMeta.url) ||
+    peerMeta.name ||
+    lang.t(lang.l.walletconnect.unknown_dapp);
 
   const routeParams: WalletconnectApprovalSheetRouteParams = {
     receivedTimestamp,
@@ -211,7 +213,7 @@ export function onSessionProposal(
       chainIds,
       dappName,
       dappScheme: 'unused in WC v2', // only used for deeplinks from WC v1
-      dappUrl: peerMeta.url || 'Unknown URL',
+      dappUrl: peerMeta.url || lang.t(lang.l.walletconnect.unknown_url),
       imageUrl: maybeSignUri(
         dappLogoOverride(peerMeta?.url) || peerMeta?.icons?.[0]
       ),

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -57,9 +57,7 @@ export function setHasPendingDeeplinkPendingRedirect(value: boolean) {
 /**
  * MAY BE UNDEFINED if WC v2 hasn't been instantiated yet
  */
-export let syncSignClient:
-  | Awaited<ReturnType<typeof SignClient.init>>
-  | undefined;
+export let syncSignClient: SignClient | undefined;
 
 export const signClient = Promise.resolve(
   SignClient.init({


### PR DESCRIPTION
## What changed (plus any additional context for devs)
This PR shows the active WC v2 sessions in the ConnectedDappsSheet. It allows for updating the wallet, but not the chain, since WC v2 doesn't support chain switching. Instead, you connect to multiple chains from the dapp.

This PR required a new way to display multiple networks, so we borrowed the networks pill from the token expanded state. I used it in the ConnectedDappsSheet, as well as in the WalletConnectApprovalSheet.

## What to test
See #4443 for details. New things:
- dapps sheet should show both v1 and v2 sessions
  - note the different handling of switch networks
- overflow menu on homescreen should only show "Connected Dapps" if there are active sessions
  - should hide if none
  - even when viewing the list of dapps, if you disconnect in a v2 dapp, it should update
- session approval sheet should support multiple networks
- should be able to switch wallet and disconnect sessions

## Screen recordings / screenshots
Session request
![IMG_0842](https://user-images.githubusercontent.com/4732330/207454526-1ce871fb-47bc-471c-8d17-e6fd1a9d2901.PNG)

Session request, upon click of the networks
![IMG_0843](https://user-images.githubusercontent.com/4732330/207454545-e78609b5-0be5-457e-a97e-94e3854ff232.PNG)

Connected dapps with a v2 session
![IMG_0844](https://user-images.githubusercontent.com/4732330/207454587-23b21347-ee8b-42cf-b9d0-f514cc7f1491.PNG)

Connected dapps, v2 click
![IMG_0850](https://user-images.githubusercontent.com/4732330/207454706-8fbd5142-02eb-4add-9693-54872d166b1b.PNG)

Connected dapps with a v2 and v1
![IMG_0845](https://user-images.githubusercontent.com/4732330/207454629-80b49861-7359-4184-a470-cc5429690ae7.PNG)

v1 click (hasn't changed)
![IMG_0852](https://user-images.githubusercontent.com/4732330/207454769-656c7a83-7b89-418d-be56-db68261eedec.PNG)

v1 click on network (hasn't changed)
![IMG_0853](https://user-images.githubusercontent.com/4732330/207454804-78b2a23b-8171-4b3d-9875-7892c692c203.PNG)
