### PR TITLE
feat: more error handling for invalid RPC or failed pairing

### DIFF
--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -7,7 +7,7 @@ import { ContactAvatar } from '../contacts';
 import ImageAvatar from '../contacts/ImageAvatar';
 import { ContextMenuButton } from '../context-menu';
 import { Centered, ColumnWithMargins, Row } from '../layout';
-import { TruncatedText } from '../text';
+import { Text, TruncatedText } from '../text';
 import { analytics } from '@/analytics';
 import { getAccountProfileInfo } from '@/helpers/accountInfo';
 import { dappLogoOverride, dappNameOverride } from '@/helpers/dappNameHandler';

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -689,6 +689,10 @@
         "text": "Uh oh, something went wrong! The site may be experiencing a connection outage. Please try again later or contact the site’s team for more details.",
         "title": "Connection failed"
       },
+      "failed_wc_invalid_methods": {
+        "text": "Uh oh, something went wrong! The dapp requested wallet signing methods that are unsupported by Rainbow.",
+        "title": "Connection failed"
+      },
       "floor_price": {
         "text": "A collection's floor price is the lowest asking price across all the items currently for sale in a collection.",
         "title": "Collection floor price"

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -690,7 +690,7 @@
         "title": "Connection failed"
       },
       "failed_wc_invalid_methods": {
-        "text": "Uh oh, something went wrong! The dapp requested wallet signing methods that are unsupported by Rainbow.",
+        "text": "The dapp requested wallet signing (RPC) methods that are unsupported by Rainbow.",
         "title": "Connection failed"
       },
       "floor_price": {

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -692,6 +692,10 @@
         "text": "Uh oh, something went wrong! The site may be experiencing a connection outage. Please try again later or contact the site’s team for more details.",
         "title": "Connection failed"
       },
+      "failed_wc_invalid_methods": {
+        "text": "Uh oh, something went wrong! The dapp requested wallet signing methods that are unsupported by Rainbow. :)",
+        "title": "Connection failed :)"
+      },
       "floor_price": {
         "text": "A collection's floor price is the lowest asking price across all the items currently for sale in a collection.",
         "title": "Collection floor price"

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -693,7 +693,7 @@
         "title": "Connection failed"
       },
       "failed_wc_invalid_methods": {
-        "text": "Uh oh, something went wrong! The dapp requested wallet signing methods that are unsupported by Rainbow. :)",
+        "text": "The dapp requested wallet signing (RPC) methods that are unsupported by Rainbow. :)",
         "title": "Connection failed :)"
       },
       "floor_price": {

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -157,6 +157,7 @@ export interface WalletconnectApprovalSheetRouteParams {
   >;
   timeout?: ReturnType<typeof setTimeout> | null;
   timedOut?: boolean;
+  failureExplainSheetVariant?: string;
 }
 
 /**

--- a/src/screens/ConnectedDappsSheet.js
+++ b/src/screens/ConnectedDappsSheet.js
@@ -1,9 +1,9 @@
 import lang from 'i18n-js';
 import React, { useEffect } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Divider from '@/components/Divider';
-import { Row } from '@/components/layout';
-import { Sheet, SheetHandleFixedToTop, SheetTitle } from '@/components/sheet';
+import Divider from '../components/Divider';
+import { Row } from '../components/layout';
+import { Sheet, SheetHandleFixedToTop, SheetTitle } from '../components/sheet';
 import WalletConnectListItem, {
   WalletConnectListItemHeight,
 } from '@/components/walletconnect-list/WalletConnectListItem';

--- a/src/screens/ConnectedDappsSheet.js
+++ b/src/screens/ConnectedDappsSheet.js
@@ -1,9 +1,9 @@
 import lang from 'i18n-js';
 import React, { useEffect } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Divider from '../components/Divider';
-import { Row } from '../components/layout';
-import { Sheet, SheetHandleFixedToTop, SheetTitle } from '../components/sheet';
+import Divider from '@/components/Divider';
+import { Row } from '@/components/layout';
+import { Sheet, SheetHandleFixedToTop, SheetTitle } from '@/components/sheet';
 import WalletConnectListItem, {
   WalletConnectListItemHeight,
 } from '@/components/walletconnect-list/WalletConnectListItem';

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -600,6 +600,12 @@ export const explainers = (params, colors) => ({
     text: lang.t('explain.failed_walletconnect.text'),
     title: lang.t('explain.failed_walletconnect.title'),
   },
+  failed_wc_invalid_methods: {
+    emoji: '😵',
+    extraHeight: -50,
+    text: lang.t('explain.failed_wc_invalid_methods.text'),
+    title: lang.t('explain.failed_wc_invalid_methods.title'),
+  },
   backup: {
     emoji: '🔐',
     extraHeight: 20,

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -244,6 +244,7 @@ export default function WalletConnectApprovalSheet() {
   const callback = params?.callback;
   const receivedTimestamp = params?.receivedTimestamp;
   const timedOut = params?.timedOut;
+  const failureExplainSheetVariant = params?.failureExplainSheetVariant;
   const chainId = meta?.chainId || params?.chainId || 1;
   const chainIds = meta.chainIds;
   const currentNetwork = params?.currentNetwork;
@@ -417,7 +418,7 @@ export default function WalletConnectApprovalSheet() {
     if (!timedOut) return;
     goBack();
     navigate(Routes.EXPLAIN_SHEET, {
-      type: 'failed_wc_connection',
+      type: failureExplainSheetVariant || 'failed_wc_connection',
     });
     return;
   }, [goBack, navigate, timedOut]);

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -475,7 +475,7 @@ export default function WalletConnectApprovalSheet() {
                   {type === WalletConnectApprovalSheetType.connect
                     ? `wants to connect to your wallet`
                     : `wants to connect to the ${ethereumUtils.getNetworkNameFromChainId(
-                        Number(chainId) // TODO
+                        Number(chainId)
                       )} network`}
                 </Text>
               </Column>

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -475,7 +475,7 @@ export default function WalletConnectApprovalSheet() {
                   {type === WalletConnectApprovalSheetType.connect
                     ? `wants to connect to your wallet`
                     : `wants to connect to the ${ethereumUtils.getNetworkNameFromChainId(
-                        Number(chainId)
+                        Number(chainId) // TODO
                       )} network`}
                 </Text>
               </Column>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Adds some additional logging and error handling e.g. TIL `pairing.pair()` throws if it fails, and that we should restrict the RPC methods to only those we support. The latter is obvious in hindsight, but wasn't possible at the time of our original v1 implementation, and wasn't clear from the v2 docs.

Only visual change is adding another explainer to the `ExplainSheet` so that we can show the user different error messages.

## What to test
I manually threw some errors here and there to simulate these. Nothing in this PR should be evident when testing it locally.

## Screen recordings / screenshots
New error screen. Need some copy feedback.
![IMG_0854](https://user-images.githubusercontent.com/4732330/207670571-53e15ea6-70ab-46f0-bbda-f3015b9eb66b.PNG)

