### PR TITLE
Remove non-brief wallet sections data selector

### DIFF
--- a/src/helpers/assetSelectors.ts
+++ b/src/helpers/assetSelectors.ts
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
 import { createSelector } from 'reselect';
-import { parseAssetsNativeWithTotals } from '@/parsers';
+import { parseAssetsNative } from '@/parsers';
 
 const EMPTY_ARRAY: any = [];
 
@@ -16,14 +16,8 @@ const sortAssetsByNativeAmount = (
 ) => {
   let assetsNativePrices = Object.values(accountAssetsData);
 
-  let total = null;
   if (!isEmpty(assetsNativePrices)) {
-    const parsedAssets = parseAssetsNativeWithTotals(
-      assetsNativePrices,
-      nativeCurrency
-    );
-    assetsNativePrices = parsedAssets.assetsNativePrices;
-    total = parsedAssets.total;
+    assetsNativePrices = parseAssetsNative(assetsNativePrices, nativeCurrency);
   }
   const {
     hasValue = EMPTY_ARRAY,
@@ -47,11 +41,8 @@ const sortAssetsByNativeAmount = (
   const sortedAssets = sortedAssetsNoShitcoins.concat(sortedShitcoins);
 
   return {
-    assetsTotal: total,
-    isBalancesSectionEmpty: isEmpty(sortedAssets),
     isLoadingAssets,
     sortedAssets,
-    sortedAssetsCount: sortedAssets.length,
   };
 };
 

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -122,11 +122,12 @@ const buildWalletSections = (
 };
 
 const buildBriefWalletSections = (
-  balanceSection: any,
+  balanceSectionData: any,
   savings: any,
   uniqueTokenFamiliesSection: any,
   uniswapSection: any
 ) => {
+  const { balanceSection, isEmpty } = balanceSectionData;
   const sections = [
     balanceSection,
     savings,
@@ -137,7 +138,11 @@ const buildBriefWalletSections = (
   const filteredSections = sections
     .filter(section => section.length !== 0)
     .flat(1);
-  return filteredSections;
+
+  return {
+    briefSectionsData: filteredSections,
+    isEmpty,
+  };
 };
 
 const withUniswapSection = (
@@ -473,7 +478,10 @@ const withBriefBalanceSection = (
     content = EMPTY_WALLET_CONTENT;
   }
 
-  return [...header, ...content];
+  return {
+    balanceSection: [...header, ...content],
+    isEmpty,
+  };
 };
 
 const withUniqueTokenFamiliesSection = (uniqueTokens: any, data: any) => {

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -11,10 +11,7 @@ import useShowcaseTokens from './useShowcaseTokens';
 import useSortedAccountAssets from './useSortedAccountAssets';
 import useWallets from './useWallets';
 import { AppState } from '@/redux/store';
-import {
-  buildBriefWalletSectionsSelector,
-  buildWalletSectionsSelector,
-} from '@/helpers/buildWalletSections';
+import { buildBriefWalletSectionsSelector } from '@/helpers/buildWalletSections';
 import { readableUniswapSelector } from '@/helpers/uniswapLiquidityTokenInfoSelector';
 
 export default function useWalletSectionsData({
@@ -66,16 +63,17 @@ export default function useWalletSectionsData({
       showcaseTokens,
     };
 
-    const sectionsData = buildWalletSectionsSelector(accountInfo);
-    const briefSectionsData = buildBriefWalletSectionsSelector(accountInfo);
+    const { briefSectionsData, isEmpty } = buildBriefWalletSectionsSelector(
+      accountInfo
+    );
     const hasNFTs = allUniqueTokens.length > 0;
 
     return {
       hasNFTs,
+      isEmpty,
       isWalletEthZero,
       refetchSavings,
       shouldRefetchSavings,
-      ...sectionsData,
       briefSectionsData,
     };
   }, [

--- a/src/parsers/accounts.js
+++ b/src/parsers/accounts.js
@@ -5,7 +5,6 @@ import { AssetTypes } from '@/entities';
 import { isNativeAsset } from '@/handlers/assets';
 import networkTypes from '@/helpers/networkTypes';
 import {
-  add,
   convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeDisplay,
   convertAmountToPercentageDisplay,
@@ -88,22 +87,6 @@ export const parseAsset = ({ asset_code: address, ...asset } = {}) => {
   };
 
   return parsedAsset;
-};
-
-export const parseAssetsNativeWithTotals = (assets, nativeCurrency) => {
-  const assetsNative = parseAssetsNative(assets, nativeCurrency);
-
-  let totalAmount = 0;
-  for (const asset of assetsNative) {
-    totalAmount = add(totalAmount, asset.native?.balance?.amount ?? 0);
-  }
-
-  const totalDisplay = convertAmountToNativeDisplay(
-    totalAmount,
-    nativeCurrency
-  );
-  const total = { amount: totalAmount, display: totalDisplay };
-  return { assetsNativePrices: assetsNative, total };
 };
 
 export const parseAssetsNative = (assets, nativeCurrency) =>

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -4,7 +4,6 @@ export {
   parseAssetSymbol,
   parseAsset,
   parseAssetNative,
-  parseAssetsNativeWithTotals,
   parseAssetsNative,
 } from './accounts';
 export {

--- a/src/screens/ShowcaseSheet.js
+++ b/src/screens/ShowcaseSheet.js
@@ -4,16 +4,20 @@ import { useDispatch, useSelector } from 'react-redux';
 import ActivityIndicator from '../components/ActivityIndicator';
 import { AssetList } from '../components/asset-list';
 import { ShowcaseContext } from '../components/showcase/ShowcaseHeader';
+import { CollectibleTokenFamily } from '../components/token-family';
 import { PREFS_ENDPOINT } from '../model/preferences';
 import { rainbowFetch } from '../rainbow-fetch';
 import { ModalContext } from '../react-native-cool-modals/NativeStackView';
 import { resolveNameOrAddress } from '@/handlers/web3';
 import { buildUniqueTokenList } from '@/helpers/assets';
-import { tokenFamilyItem } from '@/helpers/buildWalletSections';
 import { useAccountSettings, useWallets } from '@/hooks';
 import { fetchUniqueTokens } from '@/redux/uniqueTokens';
 import styled from '@/styled-thing';
 import { useTheme } from '@/theme';
+
+const tokenFamilyItem = item => (
+  <CollectibleTokenFamily {...item} uniqueId={item.uniqueId} />
+);
 
 async function fetchShowcaseForAddress(address) {
   const response = await rainbowFetch(`${PREFS_ENDPOINT}/address`, {

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -110,7 +110,6 @@ export default function WalletScreen() {
   const {
     isWalletEthZero,
     refetchSavings,
-    sections,
     shouldRefetchSavings,
     isEmpty: isSectionsEmpty,
     briefSectionsData: walletBriefSectionsData,
@@ -194,20 +193,6 @@ export default function WalletScreen() {
       trackPortfolios();
     }
   }, [portfolios, portfoliosFetched, trackPortfolios, userAccounts.length]);
-
-  useEffect(() => {
-    if (initialized && assetsSocket && !fetchedCharts) {
-      const balancesSection = sections.find(({ name }) => name === 'balances');
-      const assetCodes = compact(
-        balancesSection?.data.map(({ address }) => address)
-      );
-
-      if (!isEmpty(assetCodes)) {
-        dispatch(emitChartsRequest(assetCodes));
-        setFetchedCharts(true);
-      }
-    }
-  }, [assetsSocket, dispatch, fetchedCharts, initialized, sections]);
 
   useEffect(() => {
     if (walletReady && assetsSocket) {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
* Back when we created RecyclerAssetList2, there were some constraints that caused us to keep around the original buildWalletSections logic (in addition to the new "brief" versions). After the profiles changes were finished, we decided we would clean it up. This is that cleanup finally.
* There are 2 pieces of info that needed to be taken care of by the new "brief" versions:
1. sections data used for prefetching chart data for the top above-the-fold assets (for now, I have just removed this functionality; I can follow up with a list of assets provided by the "brief" version)
2. isEmpty (which now just uses the "isEmpty" that was in one of the "brief" wallet data selectors)

## Screen recordings / screenshots


## What to test
* Test standard wallet data behaves as expected
* Test Showcase behaves as expected

