### PR TITLE
Fix json5 vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -409,7 +409,8 @@
     "**/vm2": "3.9.11",
     "**/d3-color": "3.1.0",
     "**/minimatch": "3.0.5",
-    "**/@xmldom/xmldom": "0.7.7"
+    "**/@xmldom/xmldom": "0.7.7",
+    "**/json5": "2.2.2"
   },
   "react-native": {
     "@tanstack/query-async-storage-persister": "@tanstack/query-async-storage-persister/build/esm/index",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11800,20 +11800,10 @@ json5-writer@^0.1.8:
   dependencies:
     jscodeshift "^0.6.3"
 
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.1, json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@2.2.2, json5@^0.5.1, json5@^1.0.1, json5@^2.1.1, json5@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
+  integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
 jsonfile@^2.1.0:
   version "2.4.0"


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Added a new resolution to package.json which patches the json5 vulnerability.
* We used various versions of json5, looking at changelogs of json5 there were no breaking changes from the lowest version to the newest we used so we should probably be fine
* json5 is used by some TS compiler related packages and in babel related packages, so if it builds we are fine