### PR TITLE
ledger: holdToAuthorizeButton

### DIFF
--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -1,4 +1,3 @@
-import lang from 'i18n-js';
 import React, {
   Fragment,
   PropsWithChildren,
@@ -36,11 +35,12 @@ import {
   getButtonShadows,
 } from './helpers/buttonStyleValues';
 import { HoldToAuthorizeBaseProps } from './types/HoldToAuthorizeBaseProps';
-import styled from '@/styled-thing';
-import { padding, position } from '@/styles';
-import { ThemeContextProps } from '@/theme';
-import { haptics } from '@/utils';
-import ShadowStack from '@/react-native-shadow-stack';
+import styled from '@rainbow-me/styled-components';
+import { padding, position } from '@rainbow-me/styles';
+import { ThemeContextProps } from '@rainbow-me/theme';
+import { haptics } from '@rainbow-me/utils';
+import ShadowStack from 'react-native-shadow-stack';
+import * as lang from '@/languages';
 
 const { ACTIVE, BEGAN, END, FAILED } = GestureHandlerState;
 
@@ -103,6 +103,7 @@ function HoldToAuthorizeButtonContent2({
   disableShimmerAnimation = false,
   enableLongPress,
   hideInnerBorder,
+  ledger,
   label,
   parentHorizontalPadding,
   shadows,
@@ -224,6 +225,17 @@ function HoldToAuthorizeButtonContent2({
       }
     }
   };
+
+  let buttonLabel = label;
+  if (isAuthorizing) {
+    if (ledger) {
+      buttonLabel = lang.t(
+        lang.l.button.hold_to_authorize.confirming_on_ledger
+      );
+    } else {
+      buttonLabel = lang.t(lang.l.button.hold_to_authorize.authorizing);
+    }
+  }
   return (
     <TapGestureHandler enabled={!disabled} onHandlerStateChange={onTapChange}>
       <LongPressGestureHandler
@@ -261,11 +273,7 @@ function HoldToAuthorizeButtonContent2({
                     <LoadingSpinner />
                   )}
                   <Label
-                    label={
-                      isAuthorizing
-                        ? lang.t('button.hold_to_authorize.authorizing')
-                        : label
-                    }
+                    label={buttonLabel}
                     showIcon={showBiometryIcon && !isAuthorizing}
                     smallButton={smallButton}
                     testID={testID}

--- a/src/components/buttons/hold-to-authorize/types/HoldToAuthorizeBaseProps.ts
+++ b/src/components/buttons/hold-to-authorize/types/HoldToAuthorizeBaseProps.ts
@@ -13,6 +13,7 @@ export interface HoldToAuthorizeBaseProps {
   hideInnerBorder: boolean;
   isAuthorizing: boolean;
   label: string;
+  ledger?: boolean;
   onLongPress: () => void;
   parentHorizontalPadding: number;
   shadows: [number, number, number, string, number][];

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -214,6 +214,7 @@
       "hide": "Hide",
       "hold_to_authorize": {
         "authorizing": "Authorizing",
+        "confirming_on_ledger": "Confirming on Ledger",
         "hold_keyword": "Hold",
         "tap_keyword": "Tap"
       },

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -214,6 +214,7 @@
       "hide": "Cacher",
       "hold_to_authorize": {
         "authorizing": "Authorizing :)",
+        "confirming_on_ledger": "Confirming on Ledger :)",
         "hold_keyword": "Tenir",
         "tap_keyword": "Tap :)"
       },


### PR DESCRIPTION
Fixes APP-304

## What changed (plus any additional context for devs)
adds ledger text handling to the holdToAuthorizeButton, will prob end up using this prop for extra handling in the future


## Screen recordings / screenshots
nit 


## What to test
nit

