### PR TITLE
feat: align approval sheet navigation params

### DIFF
--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -148,8 +148,13 @@ export interface WalletconnectApprovalSheetRouteParams {
   ) => Promise<unknown>;
   receivedTimestamp: number;
   meta?: {
-    chainId: number;
-    chainIds?: number[];
+    /**
+     * WC v2 introduced multi-chain support, while v1 only supported a single
+     * chain at a time. To avoid confusion, we now send both as an array
+     * `chainIds`. WC v1 will always be an array with length `1`, while v2 can
+     * have more than one.
+     */
+    chainIds: number[];
     isWalletConnectV2?: boolean;
   } & Pick<
     RequestData,
@@ -405,7 +410,7 @@ export const walletConnectOnSessionRequest = (
         });
 
         meta = {
-          chainId,
+          chainIds: [chainId],
           dappName,
           dappScheme,
           dappUrl,
@@ -569,9 +574,9 @@ const listenOnNewMessages = (walletConnector: WalletConnect) => (
               });
             }
           },
-          chainId: Number(numericChainId),
           currentNetwork,
           meta: {
+            chainIds: [Number(numericChainId)],
             dappName,
             dappUrl,
             imageUrl,

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -239,14 +239,18 @@ export default function WalletConnectApprovalSheet() {
 
   const type = params?.type || WalletConnectApprovalSheetType.connect;
 
+  /**
+   * CAN BE UNDEFINED if we navigated here with no data. This is how we show a
+   * loading state.
+   */
   const meta = params?.meta || {};
   const timeout = params?.timeout;
   const callback = params?.callback;
   const receivedTimestamp = params?.receivedTimestamp;
   const timedOut = params?.timedOut;
   const failureExplainSheetVariant = params?.failureExplainSheetVariant;
-  const chainId = meta?.chainId || params?.chainId || 1;
-  const chainIds = meta.chainIds;
+  const chainIds = meta?.chainIds; // WC v2 supports multi-chain
+  const chainId = chainIds?.[0] || 1; // WC v1 only supports 1
   const currentNetwork = params?.currentNetwork;
   const [approvalNetwork, setApprovalNetwork] = useState(
     currentNetwork || network
@@ -303,6 +307,12 @@ export default function WalletConnectApprovalSheet() {
     };
   }, [walletNames, approvalAccount.wallet, approvalAccount.address]);
 
+  /**
+   * In WC v1 this was the network the dapp was requesting, which was editable
+   * by the end-user on this approval screen. In v2, the dapp choses one or
+   * more networks and the user can't change. So this data isn't applicable in
+   * v2.
+   */
   const approvalNetworkInfo = useMemo(() => {
     const value = networkInfo[approvalNetwork]?.value;
     return {

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -228,7 +228,6 @@ export async function onSessionProposal(
   }
 
   const { chains, methods } = requiredNamespaces.eip155;
-  const chainId = parseInt(chains[0].split('eip155:')[1]);
   const chainIds = chains.map(chain => parseInt(chain.split('eip155:')[1]));
   const peerMeta = proposer.metadata;
   const dappName =
@@ -247,7 +246,6 @@ export async function onSessionProposal(
   const routeParams: WalletconnectApprovalSheetRouteParams = {
     receivedTimestamp,
     meta: {
-      chainId,
       chainIds,
       dappName,
       dappScheme: 'unused in WC v2', // only used for deeplinks from WC v1


### PR DESCRIPTION
## What changed (plus any additional context for devs)
From a [comment from Ben](https://github.com/rainbow-me/rainbow/pull/4476#discussion_r1049006205), it makes sense to align these props now.

## What to test
This would affect v1 connections moreso than v2. Here's [the v1 example dapp.](https://example.walletconnect.org/)

