### PR TITLE
chore: remove com.polidea.reactnativeble.BlePackage import

### DIFF
--- a/android/app/src/main/java/me/rainbow/MainApplication.java
+++ b/android/app/src/main/java/me/rainbow/MainApplication.java
@@ -29,7 +29,6 @@ import me.rainbow.NativeModules.RNTextAnimatorPackage.RNTextAnimatorPackage;
 import me.rainbow.NativeModules.RNZoomableButton.RNZoomableButtonPackage;
 import com.microsoft.codepush.react.CodePush;
 import com.facebook.react.config.ReactFeatureFlags;
-import com.polidea.reactnativeble.BlePackage;
 
 class RainbowJSIModulePackage extends ReanimatedJSIModulePackage {
     @Override

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "react-native-actionsheet": "2.4.2",
     "react-native-aes-crypto": "rainbow-me/react-native-aes#65c49f7e70266615b2999eaa7db654d3fe4f2e3b",
     "react-native-android-keyboard-adjust": "1.2.0",
+    "react-native-ble-plx": "2.0.3",
     "react-native-bootsplash": "4.3.2",
     "react-native-branch": "5.3.1",
     "react-native-camera": "4.2.1",


### PR DESCRIPTION
fixes android builds, dep is unneeded and unused with the latest of the BLEpackage
## What changed (plus any additional context for devs)


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Shot-2023-01-04-16-07-14.20.png

## What to test

