### PR TITLE
Add scroll enabled back and disable status icon for short phones

### DIFF
--- a/src/screens/transaction-details/TransactionDetails.tsx
+++ b/src/screens/transaction-details/TransactionDetails.tsx
@@ -59,7 +59,6 @@ export const TransactionDetails: React.FC<Props> = ({ navigation, route }) => {
           backgroundColor={backgroundColor}
           height={IS_ANDROID ? sheetHeight : '100%'}
           deferredHeight={IS_ANDROID}
-          scrollEnabled={false}
           showsVerticalScrollIndicator={false}
         >
           <Box

--- a/src/screens/transaction-details/TransactionDetails.tsx
+++ b/src/screens/transaction-details/TransactionDetails.tsx
@@ -14,6 +14,7 @@ import * as i18n from '@/languages';
 import { TransactionDetailsStatusActionsAndTimestampSection } from '@/screens/transaction-details/components/TransactionDetailsStatusActionsAndTimestampSection';
 import { useTransactionDetailsToasts } from '@/screens/transaction-details/hooks/useTransactionDetailsToasts';
 import { LayoutChangeEvent } from 'react-native';
+import { useDimensions } from '@/hooks';
 
 type RouteParams = {
   TransactionDetails: {
@@ -31,7 +32,9 @@ export const TransactionDetails: React.FC<Props> = ({ navigation, route }) => {
   const { setParams } = navigation;
   const { transaction } = route.params;
   const [sheetHeight, setSheetHeight] = useState(0);
+  const [statusIconHidden, setStatusIconHidden] = useState(false);
   const { presentedToast, presentToastFor } = useTransactionDetailsToasts();
+  const { height: deviceHeight } = useDimensions();
 
   // Dynamic sheet height based on content height
   useEffect(() => setParams({ longFormHeight: sheetHeight }), [
@@ -39,8 +42,13 @@ export const TransactionDetails: React.FC<Props> = ({ navigation, route }) => {
     sheetHeight,
   ]);
 
-  const onSheetContentLayout = (event: LayoutChangeEvent) =>
-    setSheetHeight(event.nativeEvent.layout.height);
+  const onSheetContentLayout = (event: LayoutChangeEvent) => {
+    const contentHeight = event.nativeEvent.layout.height;
+    if (contentHeight > deviceHeight) {
+      setStatusIconHidden(true);
+    }
+    setSheetHeight(contentHeight);
+  };
 
   const presentAddressToast = useCallback(() => {
     presentToastFor('address');
@@ -67,6 +75,7 @@ export const TransactionDetails: React.FC<Props> = ({ navigation, route }) => {
             onLayout={onSheetContentLayout}
           >
             <TransactionDetailsStatusActionsAndTimestampSection
+              hideIcon={statusIconHidden}
               transaction={transaction}
             />
             <TransactionDetailsFromToSection

--- a/src/screens/transaction-details/components/TransactionDetailsStatusActionsAndTimestampSection.tsx
+++ b/src/screens/transaction-details/components/TransactionDetailsStatusActionsAndTimestampSection.tsx
@@ -19,10 +19,12 @@ const SIZE = 40;
 
 type Props = {
   transaction: RainbowTransaction;
+  hideIcon?: boolean;
 };
 
 export const TransactionDetailsStatusActionsAndTimestampSection: React.FC<Props> = ({
   transaction,
+  hideIcon,
 }) => {
   const { minedAt, status, pending, from } = transaction;
   const { navigate } = useNavigation();
@@ -127,7 +129,7 @@ export const TransactionDetailsStatusActionsAndTimestampSection: React.FC<Props>
       </Box>
       <Box paddingBottom="24px">
         <Stack alignHorizontal="center" space="16px">
-          {status && (
+          {status && !hideIcon && (
             <Box borderRadius={30} style={{ overflow: 'hidden' }}>
               <RadialGradient
                 style={{


### PR DESCRIPTION
Fixes APP-310

## What changed (plus any additional context for devs)

* There is a rare case where for tx details for failed swaps, under the condition that we have all of the data for that transaction, on small devices like iPhone SE there's not enough space for everything. In order to be able to show all the data in one go on iPhone SE we will disable the status Icon and leave just text (this will work this way only for such large sheets)
* Scroll will also be enabled, it will be scrollable only when the content is larger than the device height, so it is handling another edge case where a device is smaller than iPhone SE
* This case is so rare that it almost never happens because for transactions we dispatch from the app, there's usually gas data missing, but just in case there is everything we have to make it scrollable in some way to be able to get to all of the content


![CleanShot 2023-01-05 at 12 22 18](https://user-images.githubusercontent.com/16062886/210768886-86353187-1a0a-40a8-814d-c5e581253fb2.png)

