### PR TITLE
release: revert swap sdk bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@notifee/react-native": "5.6.0",
     "@rainbow-me/react-native-animated-number": "0.0.2",
     "@rainbow-me/react-native-payments": "1.1.5",
-    "@rainbow-me/swaps": "0.2.0",
+    "@rainbow-me/swaps": "0.1.7",
     "@react-native-async-storage/async-storage": "1.17.7",
     "@react-native-community/blur": "3.6.0",
     "@react-native-community/cameraroll": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,17 +1425,6 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
-"@ethersproject/abstract-signer@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
-  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.6.0"
-    "@ethersproject/bignumber" "^5.6.0"
-    "@ethersproject/bytes" "^5.6.0"
-    "@ethersproject/logger" "^5.6.0"
-    "@ethersproject/properties" "^5.6.0"
-
 "@ethersproject/abstract-signer@5.6.2", "@ethersproject/abstract-signer@^5.6.0", "@ethersproject/abstract-signer@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz#491f07fc2cbd5da258f46ec539664713950b0b33"
@@ -2921,13 +2910,12 @@
     uuid "3.3.2"
     validator "^7.0.0"
 
-"@rainbow-me/swaps@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@rainbow-me/swaps/-/swaps-0.2.0.tgz#544008fbb0cf9f9ac5e98753bb7847c86a6326ee"
-  integrity sha512-dvfKdRdsNE0jVrfE8YDfi449iDHLZgVykaJhiq0cAbuYi3jBnbxiGd5IkchsIrC9FYnaV2vtiN0PXC+7r9JDuA==
+"@rainbow-me/swaps@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@rainbow-me/swaps/-/swaps-0.1.7.tgz#3243a491f35c51493bd14f151e4047eb510053f9"
+  integrity sha512-xieYMUZ9tHhltHurwgKPDbFDZul7oH9gAUt3jJSrmeisFdujGNsp3+rD12FoFyAOPC8cwtqnJfjs11DpRZg/OA==
   dependencies:
     "@ethersproject/abi" "5.6.0"
-    "@ethersproject/abstract-signer" "5.6.0"
     "@ethersproject/bignumber" "5.6.0"
     "@ethersproject/bytes" "5.6.0"
     "@ethersproject/contracts" "5.6.0"


### PR DESCRIPTION
Fixes APP-311

## What changed (plus any additional context for devs)
some funky stuff happening for L2 networks in the swap sdk after moving to use `Signer`, assuming its coming from the permit logic, reverting to unblock as its not super necessary and we can cast the type until I look into the underlying issue


## Screen recordings / screenshots
l2 swaps should work


## What to test
l2 swaps

