### PR TITLE
audit: ignore debug

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -7,6 +7,6 @@
     "GHSA-9pgh-qqpf-7wqj", // https://github.com/advisories/GHSA-9pgh-qqpf-7wqj
     "GHSA-w573-4hg7-7wgq", // https://github.com/advisories/GHSA-w573-4hg7-7wgq
     "GHSA-hrpp-h998-j3pp", // https://github.com/advisories/GHSA-hrpp-h998-j3pp
-    "GHSA-9vvw-cc9w-f27h"  // https://github.com/advisories/GHSA-9vvw-cc9w-f27h
+    "GHSA-9vvw-cc9w-f27h" // https://github.com/advisories/GHSA-9vvw-cc9w-f27h
   ]
 }

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -6,6 +6,7 @@
     "GHSA-2j79-8pqc-r7x6", // https://github.com/advisories/GHSA-2j79-8pqc-r7x6
     "GHSA-9pgh-qqpf-7wqj", // https://github.com/advisories/GHSA-9pgh-qqpf-7wqj
     "GHSA-w573-4hg7-7wgq", // https://github.com/advisories/GHSA-w573-4hg7-7wgq
-    "GHSA-hrpp-h998-j3pp" // https://github.com/advisories/GHSA-hrpp-h998-j3pp
+    "GHSA-hrpp-h998-j3pp", // https://github.com/advisories/GHSA-hrpp-h998-j3pp
+    "GHSA-9vvw-cc9w-f27h"  // https://github.com/advisories/GHSA-9vvw-cc9w-f27h
   ]
 }


### PR DESCRIPTION
ignore debug audit 

I tried to bump the package but then the audit-ci process hangs so opting to ignore since its low severity 
https://github.com/advisories/GHSA-9vvw-cc9w-f27h

## What changed (plus any additional context for devs)


## Screen recordings / screenshots


## What to test

