### PR TITLE
fix swaps: load the correct provider when loading wallet

### DIFF
--- a/src/screens/ExchangeModal.tsx
+++ b/src/screens/ExchangeModal.tsx
@@ -647,7 +647,9 @@ export default function ExchangeModal({
         ? NativeModules.NotificationManager
         : null;
       try {
-        let wallet = await loadWallet();
+        // load the correct network provider for the wallet
+        const provider = await getProviderForNetwork(currentNetwork);
+        let wallet = await loadWallet(accountAddress, false, provider);
         if (!wallet) {
           setIsAuthorizing(false);
           logger.sentry(`aborting ${type} due to missing wallet`);


### PR DESCRIPTION
Fixes APP-311

## What changed (plus any additional context for devs) 
logic was changes in https://github.com/rainbow-me/rainbow/commit/38d23b6c15682d43388ead25017cb313b0f69b5b , this is the missing piece to ensure the `Signer` is on the current network for the transactions



## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2023-01-11-12-18-38.mp4


## What to test

