### PR TITLE
Change copy from View Contact to Edit Contact to avoid confusion

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1425,7 +1425,7 @@
         "copy_address": "Copy Address",
         "send": "Send",
         "add_contact": "Add to Contacts",
-        "view_contact": "View Contact"
+        "edit_contact": "Edit Contact"
       },
       "actions_menu": {
         "speed_up": "Speed Up",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1426,7 +1426,7 @@
         "copy_address": "Copy Address :)",
         "send": "Send :)",
         "add_contact": "Add to Contacts :)",
-        "view_contact": "View Contact :)"
+        "edit_contact": "Edit Contact :)"
       },
       "actions_menu": {
         "speed_up": "Speed Up :)",

--- a/src/screens/transaction-details/components/TransactionDetailsAddressRow.tsx
+++ b/src/screens/transaction-details/components/TransactionDetailsAddressRow.tsx
@@ -127,7 +127,7 @@ export const TransactionDetailsAddressRow: React.FC<Props> = ({
               {
                 actionKey: 'contact',
                 actionTitle: contact
-                  ? i18n.t(i18n.l.transaction_details.context_menu.view_contact)
+                  ? i18n.t(i18n.l.transaction_details.context_menu.edit_contact)
                   : i18n.t(i18n.l.transaction_details.context_menu.add_contact),
                 icon: {
                   iconType: 'SYSTEM',


### PR DESCRIPTION
Fixes APP-341

## What changed (plus any additional context for devs)

* Changed the copy from View Contact to Edit Contact in new transaction details when you already added an address to contacts

