### PR TITLE
Fix ENS transactions bug, missing network parameter in RainbowTransaction

### DIFF
--- a/src/raps/actions/ens.ts
+++ b/src/raps/actions/ens.ts
@@ -564,6 +564,7 @@ const ensAction = async (
     nonce: tx?.nonce,
     to: tx?.to,
     value: toHex(tx.value),
+    network: NetworkTypes.mainnet,
   };
   logger.log(`[${actionName}] adding new txn`, newTransaction);
   // @ts-expect-error Since src/redux/data.js is not typed yet, `accountAddress`


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* added a hardcoded NetworkType.mainnet to temporary RainbowTransactio before we have upstream data

![CleanShot 2023-01-13 at 14 42 17](https://user-images.githubusercontent.com/16062886/212333699-8b28533d-fbf5-482c-a826-68cf21d1c6a1.png)
