### PR TITLE
swaps hardcoded Unstoppable TLDs with updatable npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/react-redux": "7.1.9",
     "@types/url-join": "4.0.1",
     "@unstoppabledomains/resolution": "7.1.4",
+    "@unstoppabledomains/tldsresolverkeys": "2.1.1",
     "@walletconnect/client": "1.8.0",
     "@walletconnect/legacy-utils": "2.0.0-rc.0",
     "@walletconnect/react-native-compat": "2.1.4",

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -9,20 +9,12 @@ import {
   resolveUnstoppableDomain,
 } from '@/handlers/web3';
 import { sanitizeSeedPhrase } from '@/utils';
+// @ts-ignore
+import {udTlds} from '@unstoppabledomains/tldsresolverkeys'
+
 
 // Currently supported Top Level Domains from Unstoppable Domains
-const supportedUnstoppableDomains = [
-  '888',
-  'bitcoin',
-  'blockchain',
-  'coin',
-  'crypto',
-  'dao',
-  'nft',
-  'wallet',
-  'x',
-  'zil',
-];
+const supportedUnstoppableDomains = udTlds;
 
 /**
  * @desc validate email

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,6 +4465,11 @@
     js-sha256 "^0.9.0"
     js-sha3 "^0.8.0"
 
+"@unstoppabledomains/tldsresolverkeys@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/tldsresolverkeys/-/tldsresolverkeys-2.1.1.tgz#f25f86ea3b8770a8e78b1c0a2573af10d2d19aad"
+  integrity sha512-NrGtQ92yUcq4sBYSGiMGZZB5s9w2kjEBnYY9EblhyCsnyXg0vNmDZ9z1JH8H/u2uEiceo+N1enO1uExRAgyGzg==
+
 "@vibrant/color@^3.2.1-alpha.1":
   version "3.2.1-alpha.1"
   resolved "https://registry.yarnpkg.com/@vibrant/color/-/color-3.2.1-alpha.1.tgz#1bcee4545d2276d36f9a1acb42ab3485a9b489ec"


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Added a NPM package - [@unstoppabledomains/tldsresolverkeys](https://www.npmjs.com/package/@unstoppabledomains/tldsresolverkeys)
Removed Hardcoded Unstoppable TLDs

Long story short as Unstoppable Domains adds new TLDs, all you'll need to do is update this package and you'll be able to resolve the new TLDs as we release them

## Screen recordings / screenshots


## What to test
Should work with our old TLDs (.crypto, .blockchain, etc) 
Should work with our newer TLDs  (.hi, .klever)

feel free to test with jim-unstoppable.hi & jim-unstoppable.klever


Let me know if there are any questions or other requirements :)
-Ben from Unstoppable Domains
