### PR TITLE
fix: ReDoS Vulnerability in ua-parser-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,8 @@
     "**/d3-color": "3.1.0",
     "**/minimatch": "3.0.5",
     "**/@xmldom/xmldom": "0.7.7",
-    "**/json5": "2.2.2"
+    "**/json5": "2.2.2",
+    "**/ua-parser-js": "0.7.33"
   },
   "react-native": {
     "@tanstack/query-async-storage-persister": "@tanstack/query-async-storage-persister/build/esm/index",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17615,9 +17615,10 @@ typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
 
-ua-parser-js@^0.7.30:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
+ua-parser-js@0.7.33, ua-parser-js@^0.7.30:
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.33.tgz#1d04acb4ccef9293df6f70f2c3d22f3030d8b532"
+  integrity sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Fixes APP-399

## What changed (plus any additional context for devs)
See linked Linear ticket. This will resolve the Dependabot PRs as well.

