### PR TITLE
fix: bt permissions signTypeData

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -482,7 +482,7 @@ export const signTypedDataMessage = async (
       }
 
       // Hardware wallets
-      if (wallet instanceof LedgerSigner) {
+      if (!(wallet instanceof Wallet)) {
         const result = await (wallet as LedgerSigner).signTypedDataMessage(
           parsedData,
           version === 'v1'


### PR DESCRIPTION
Fixes APP-417

## What changed (plus any additional context for devs)
instanceof check was using a file with BT lib imports which is what triggers permissions, now just checking if the opposite is true 


## Screen recordings / screenshots
n/a


## What to test

no BT permission request
