### PR TITLE
Rewards explainer sheets

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1306,7 +1306,29 @@
       "all_rewards_claimed": "All rewards have been claimed this week",
       "rainbow_users_claimed": "Rainbow users claimed %{amount}",
       "refreshes_in_with_days": "Refreshes in %{days} days %{hours} hours",
-      "refreshes_in_without_days": "Refreshes in %{hours} hours"
+      "refreshes_in_without_days": "Refreshes in %{hours} hours",
+      "op": {
+        "airdrop_timing": {
+          "title": "Airdrops Every Week",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+        },
+        "amount_distributed": {
+          "title": "30,000 OP Every Week",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+        },
+        "bridge": {
+          "title": "Bridge To Optimism",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+        },
+        "swap": {
+          "title": "Swap On Optimism",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+        },
+        "position": {
+          "title": "Your Position",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+        }
+      }
     },
     "savings": {
       "deposit": "Deposit",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1315,19 +1315,19 @@
         },
         "amount_distributed": {
           "title": "30,000 OP Every Week",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+          "text": "Up to 30,000 OP in rewards will be distributed every week. If weekly rewards run out, rewards will temporarily pause and resume the following week."
         },
         "bridge": {
-          "title": "Bridge To Optimism",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+          "title": "Earn 0.125% on Bridging",
+          "text": "While rewards are live, bridging verified tokens to Optimism will earn you approximately 0.125% back in OP.\n\nStats update periodically throughout the day. Check back soon if you don’t see your recent bridging reflected here."
         },
         "swap": {
-          "title": "Swap On Optimism",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+          "title": "Earn 0.425% on Swaps",
+          "text": "While rewards are live, swapping verified tokens on Optimism will earn you approximately 0.425% back in OP.\n\nStats update periodically throughout the day. Check back soon if you don’t see your recent swaps reflected here."
         },
         "position": {
-          "title": "Your Position",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet."
+          "title": "Leaderboard Position",
+          "text": "The more OP you earn by swapping and bridging, the higher you’ll climb on the leaderboard. If you’re in the top 100 at the end of the contest, you’ll get bonus rewards of up to 8,000 OP."
         }
       }
     },

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1307,6 +1307,7 @@
       "rainbow_users_claimed": "Rainbow users claimed %{amount}",
       "refreshes_in_with_days": "Refreshes in %{days} days %{hours} hours",
       "refreshes_in_without_days": "Refreshes in %{hours} hours",
+      "percent": "%{percent}% reward",
       "op": {
         "airdrop_timing": {
           "title": "Airdrops Every Week",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1316,19 +1316,19 @@
         },
         "amount_distributed": {
           "title": "30,000 OP Every Week :)",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+          "text": "Up to 30,000 OP in rewards will be distributed every week. If weekly rewards run out, rewards will temporarily pause and resume the following week. :)"
         },
         "bridge": {
-          "title": "Bridge To Optimism :)",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+          "title": "Earn 0.125% on Bridging :)",
+          "text": "While rewards are live, bridging verified tokens to Optimism will earn you approximately 0.125% back in OP.\n\nStats update periodically throughout the day. Check back soon if you don’t see your recent bridging reflected here. :)"
         },
         "swap": {
-          "title": "Swap On Optimism :)",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+          "title": "Earn 0.425% on Swaps :)",
+          "text": "While rewards are live, swapping verified tokens on Optimism will earn you approximately 0.425% back in OP.\n\nStats update periodically throughout the day. Check back soon if you don’t see your recent swaps reflected here. :)"
         },
         "position": {
-          "title": "Your Position :)",
-          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+          "title": "Leaderboard Position :)",
+          "text": "The more OP you earn by swapping and bridging, the higher you’ll climb on the leaderboard. If you’re in the top 100 at the end of the contest, you’ll get bonus rewards of up to 8,000 OP. :)"
         }
       }
     },

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1308,6 +1308,7 @@
       "rainbow_users_claimed": "Rainbow users claimed %{amount} :)",
       "refreshes_in_with_days": "Refreshes in %{days} days %{hours} hours :)",
       "refreshes_in_without_days": "Refreshes in %{hours} hours :)",
+      "percent": "%{percent}% reward :)",
       "op": {
         "airdrop_timing": {
           "title": "Airdrops Every Week :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1307,7 +1307,29 @@
       "all_rewards_claimed": "All rewards have been claimed this week :)",
       "rainbow_users_claimed": "Rainbow users claimed %{amount} :)",
       "refreshes_in_with_days": "Refreshes in %{days} days %{hours} hours :)",
-      "refreshes_in_without_days": "Refreshes in %{hours} hours :)"
+      "refreshes_in_without_days": "Refreshes in %{hours} hours :)",
+      "op": {
+        "airdrop_timing": {
+          "title": "Airdrops Every Week :)",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+        },
+        "amount_distributed": {
+          "title": "30,000 OP Every Week :)",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+        },
+        "bridge": {
+          "title": "Bridge To Optimism :)",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+        },
+        "swap": {
+          "title": "Swap On Optimism :)",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+        },
+        "position": {
+          "title": "Your Position :)",
+          "text": "Swap on Optimism or bridge to Optimism to earn OP rewards. At the end of each week, the rewards you’ve earned will be airdropped to your wallet. :)"
+        }
+      }
     },
     "savings": {
       "deposit": "Dépôt",

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -293,43 +293,32 @@ export const explainers = (params, colors) => ({
     emoji: '📦',
     title: i18n.t(i18n.l.rewards.op.airdrop_timing.title),
     text: i18n.t(i18n.l.rewards.op.airdrop_timing.text),
-    extraHeight: IS_ANDROID ? -65 : 0,
-    readMoreLink:
-      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+    extraHeight: IS_ANDROID ? -65 : 10,
+    readMoreLink: 'https://learn.rainbow.me/OP-rewards-with-Rainbow',
   },
   op_rewards_amount_distributed: {
     emoji: '💰',
     title: i18n.t(i18n.l.rewards.op.amount_distributed.title),
     text: i18n.t(i18n.l.rewards.op.amount_distributed.text),
-    extraHeight: IS_ANDROID ? -65 : 0,
-
-    readMoreLink:
-      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+    extraHeight: IS_ANDROID ? -110 : -65,
   },
   op_rewards_bridge: {
     emoji: '🌉',
     title: i18n.t(i18n.l.rewards.op.bridge.title),
     text: i18n.t(i18n.l.rewards.op.bridge.text),
-    extraHeight: IS_ANDROID ? -65 : 0,
-
-    readMoreLink:
-      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+    extraHeight: IS_ANDROID ? -65 : 10,
   },
   op_rewards_swap: {
-    emoji: '🔃',
+    emoji: '🔀',
     title: i18n.t(i18n.l.rewards.op.swap.title),
     text: i18n.t(i18n.l.rewards.op.swap.text),
-    extraHeight: IS_ANDROID ? -65 : 0,
-    readMoreLink:
-      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+    extraHeight: IS_ANDROID ? -65 : 10,
   },
   op_rewards_position: {
     emoji: '🏆',
     title: i18n.t(i18n.l.rewards.op.position.title),
     text: i18n.t(i18n.l.rewards.op.position.text),
-    extraHeight: IS_ANDROID ? -65 : 0,
-    readMoreLink:
-      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+    extraHeight: IS_ANDROID ? -110 : -65,
   },
   optimism_app_icon: {
     logo: <OptimismAppIcon />,

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -293,6 +293,7 @@ export const explainers = (params, colors) => ({
     emoji: '📦',
     title: i18n.t(i18n.l.rewards.op.airdrop_timing.title),
     text: i18n.t(i18n.l.rewards.op.airdrop_timing.text),
+    extraHeight: IS_ANDROID ? -65 : 0,
     readMoreLink:
       'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
   },
@@ -300,6 +301,8 @@ export const explainers = (params, colors) => ({
     emoji: '💰',
     title: i18n.t(i18n.l.rewards.op.amount_distributed.title),
     text: i18n.t(i18n.l.rewards.op.amount_distributed.text),
+    extraHeight: IS_ANDROID ? -65 : 0,
+
     readMoreLink:
       'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
   },
@@ -307,6 +310,8 @@ export const explainers = (params, colors) => ({
     emoji: '🌉',
     title: i18n.t(i18n.l.rewards.op.bridge.title),
     text: i18n.t(i18n.l.rewards.op.bridge.text),
+    extraHeight: IS_ANDROID ? -65 : 0,
+
     readMoreLink:
       'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
   },
@@ -314,6 +319,7 @@ export const explainers = (params, colors) => ({
     emoji: '🔃',
     title: i18n.t(i18n.l.rewards.op.swap.title),
     text: i18n.t(i18n.l.rewards.op.swap.text),
+    extraHeight: IS_ANDROID ? -65 : 0,
     readMoreLink:
       'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
   },
@@ -321,6 +327,7 @@ export const explainers = (params, colors) => ({
     emoji: '🏆',
     title: i18n.t(i18n.l.rewards.op.position.title),
     text: i18n.t(i18n.l.rewards.op.position.text),
+    extraHeight: IS_ANDROID ? -65 : 0,
     readMoreLink:
       'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
   },

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -41,6 +41,7 @@ import { cloudPlatformAccountName } from '@/utils/platform';
 import { useTheme } from '@/theme';
 import { isL2Network } from '@/handlers/web3';
 import { IS_ANDROID } from '@/env';
+import * as i18n from '@/languages';
 
 const { GAS_TRENDS } = gasUtils;
 const APP_ICON_SIZE = 64;
@@ -288,6 +289,41 @@ const navigateToAppIconSettings = async (navigate, goBack) => {
 };
 
 export const explainers = (params, colors) => ({
+  op_rewards_airdrop_timing: {
+    emoji: '📦',
+    title: i18n.t(i18n.l.rewards.op.airdrop_timing.title),
+    text: i18n.t(i18n.l.rewards.op.airdrop_timing.text),
+    readMoreLink:
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+  },
+  op_rewards_amount_distributed: {
+    emoji: '💰',
+    title: i18n.t(i18n.l.rewards.op.amount_distributed.title),
+    text: i18n.t(i18n.l.rewards.op.amount_distributed.text),
+    readMoreLink:
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+  },
+  op_rewards_bridge: {
+    emoji: '🌉',
+    title: i18n.t(i18n.l.rewards.op.bridge.title),
+    text: i18n.t(i18n.l.rewards.op.bridge.text),
+    readMoreLink:
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+  },
+  op_rewards_swap: {
+    emoji: '🔃',
+    title: i18n.t(i18n.l.rewards.op.swap.title),
+    text: i18n.t(i18n.l.rewards.op.swap.text),
+    readMoreLink:
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+  },
+  op_rewards_position: {
+    emoji: '🏆',
+    title: i18n.t(i18n.l.rewards.op.position.title),
+    text: i18n.t(i18n.l.rewards.op.position.text),
+    readMoreLink:
+      'https://learn.rainbow.me/a-beginners-guide-to-layer-2-networks',
+  },
   optimism_app_icon: {
     logo: <OptimismAppIcon />,
     extraHeight: -35,

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -1,4 +1,4 @@
-import { useRoute } from '@react-navigation/core';
+import { useRoute } from '@react-navigation/native';
 import { compact, isEmpty, keys } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { InteractionManager } from 'react-native';

--- a/src/screens/rewards/RewardsSheet.tsx
+++ b/src/screens/rewards/RewardsSheet.tsx
@@ -5,7 +5,7 @@ import { BackgroundProvider, Box } from '@/design-system';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RewardsContent } from '@/screens/rewards/components/RewardsContent';
 import { RewardsFakeContent } from '@/screens/rewards/components/RewardsFakeContent';
-import { IS_ANDROID } from '@/env';
+import { IS_ANDROID, IS_IOS } from '@/env';
 import { StatusBar } from 'react-native';
 import { useRewards } from '@/resources/rewards/rewardsQuery';
 import { useSelector } from 'react-redux';
@@ -32,9 +32,9 @@ export const RewardsSheet: React.FC = () => {
         // @ts-expect-error JS component
         <SlackSheet
           backgroundColor={backgroundColor}
-          height="100%"
-          contentHeight={height - top}
           additionalTopPadding={IS_ANDROID ? StatusBar.currentHeight : false}
+          {...(IS_IOS && { height: '100%' })}
+          contentHeight={height - top}
           scrollEnabled
         >
           <Box padding="20px">

--- a/src/screens/rewards/components/RewardsAvailable.tsx
+++ b/src/screens/rewards/components/RewardsAvailable.tsx
@@ -8,12 +8,11 @@ import {
   addDays,
   differenceInDays,
   differenceInHours,
-  formatDuration,
   fromUnixTime,
-  intervalToDuration,
-  sub,
 } from 'date-fns';
 import { ButtonPressAnimation } from '@/components/animations';
+import { useNavigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
 
 type Props = {
   totalAvailableRewards: number;
@@ -29,6 +28,7 @@ export const RewardsAvailable: React.FC<Props> = ({
   color,
 }) => {
   const infoIconColor = useInfoIconColor();
+  const { navigate } = useNavigation();
 
   if (remainingRewards <= 0) {
     const formattedTotalAvailableRewards = totalAvailableRewards.toLocaleString(
@@ -80,10 +80,16 @@ export const RewardsAvailable: React.FC<Props> = ({
     const progress = remainingRewards / totalAvailableRewards;
     const roundedProgressPercent = Math.round(progress * 10) * 10;
 
+    const navigateToAmountsExplainer = () => {
+      navigate(Routes.EXPLAIN_SHEET, { type: 'op_rewards_amount_distributed' });
+    };
+
     return (
       <Box paddingBottom="36px">
-        {/* TODO: Add explainer sheet navigation to on press here */}
-        <ButtonPressAnimation onPress={() => {}} scaleTo={0.96}>
+        <ButtonPressAnimation
+          onPress={navigateToAmountsExplainer}
+          scaleTo={0.96}
+        >
           <RewardsSectionCard>
             <Stack space="16px">
               <Stack space="12px">

--- a/src/screens/rewards/components/RewardsAvailable.tsx
+++ b/src/screens/rewards/components/RewardsAvailable.tsx
@@ -89,6 +89,7 @@ export const RewardsAvailable: React.FC<Props> = ({
         <ButtonPressAnimation
           onPress={navigateToAmountsExplainer}
           scaleTo={0.96}
+          overflowMargin={50}
         >
           <RewardsSectionCard>
             <Stack space="16px">

--- a/src/screens/rewards/components/RewardsContent.tsx
+++ b/src/screens/rewards/components/RewardsContent.tsx
@@ -7,6 +7,8 @@ import { RewardsStats } from './RewardsStats';
 import { RewardsLeaderboard } from '@/screens/rewards/components/RewardsLeaderboard';
 import { RewardsDuneLogo } from '@/screens/rewards/components/RewardsDuneLogo';
 import { ButtonPressAnimation } from '@/components/animations';
+import { useNavigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
 
 const LEADERBOARD_ITEMS_TRESHOLD = 50;
 
@@ -22,17 +24,14 @@ export const RewardsContent: React.FC<Props> = ({ data }) => {
     <>
       <RewardsTitle text={data.meta.title} />
       {data.earnings && (
-        // TODO: Add explainer sheet navigation to on press here
-        <ButtonPressAnimation onPress={() => {}} scaleTo={0.96}>
-          <RewardsEarnings
-            totalEarnings={data.earnings.total}
-            tokenImageUrl={data.meta.token.asset.iconURL ?? ''}
-            tokenSymbol={data.meta.token.asset.symbol}
-            pendingEarningsToken={data.earnings?.pending.token ?? 0}
-            nextAirdropTimestamp={data.meta.distribution.next}
-            color={data.meta.color}
-          />
-        </ButtonPressAnimation>
+        <RewardsEarnings
+          totalEarnings={data.earnings.total}
+          tokenImageUrl={data.meta.token.asset.iconURL ?? ''}
+          tokenSymbol={data.meta.token.asset.symbol}
+          pendingEarningsToken={data.earnings?.pending.token ?? 0}
+          nextAirdropTimestamp={data.meta.distribution.next}
+          color={data.meta.color}
+        />
       )}
       <RewardsAvailable
         totalAvailableRewards={data.meta.distribution.total}

--- a/src/screens/rewards/components/RewardsContent.tsx
+++ b/src/screens/rewards/components/RewardsContent.tsx
@@ -6,9 +6,6 @@ import { Rewards } from '@/graphql/__generated__/metadata';
 import { RewardsStats } from './RewardsStats';
 import { RewardsLeaderboard } from '@/screens/rewards/components/RewardsLeaderboard';
 import { RewardsDuneLogo } from '@/screens/rewards/components/RewardsDuneLogo';
-import { ButtonPressAnimation } from '@/components/animations';
-import { useNavigation } from '@/navigation';
-import Routes from '@/navigation/routesNames';
 
 const LEADERBOARD_ITEMS_TRESHOLD = 50;
 

--- a/src/screens/rewards/components/RewardsDuneLogo.tsx
+++ b/src/screens/rewards/components/RewardsDuneLogo.tsx
@@ -9,7 +9,7 @@ import { useTheme } from '@/theme';
 export const RewardsDuneLogo: React.FC = () => {
   const { isDarkMode } = useTheme();
   return (
-    <Box paddingBottom="36px" justifyContent="center" alignItems="center">
+    <Box paddingBottom="28px" justifyContent="center" alignItems="center">
       <Inline space="8px" alignVertical="center">
         <Text size="13pt" color="labelQuaternary" weight="semibold">
           {i18n.t(i18n.l.rewards.data_powered_by)}

--- a/src/screens/rewards/components/RewardsEarnings.tsx
+++ b/src/screens/rewards/components/RewardsEarnings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Image } from 'react-native';
 import { RewardsSectionCard } from '@/screens/rewards/components/RewardsSectionCard';
 import {
@@ -20,6 +20,9 @@ import {
   isPast,
 } from 'date-fns';
 import { useInfoIconColor } from '@/screens/rewards/hooks/useInfoIconColor';
+import { useNavigation } from '@/navigation';
+import { ButtonPressAnimation } from '@/components/animations';
+import Routes from '@/navigation/routesNames';
 
 type Props = {
   tokenImageUrl: string;
@@ -40,117 +43,155 @@ export const RewardsEarnings: React.FC<Props> = ({
   totalEarnings,
   nextAirdropTimestamp,
 }) => {
+  const { navigate } = useNavigation();
   const infoIconColor = useInfoIconColor();
-  const formattedPendingEarnings = formatTokenDisplayValue(
+
+  const {
+    formattedPendingEarnings,
+    formattedTotalEarningsToken,
+    formattedTotalEarningsNative,
+    airdropTitle,
+    airdropTime,
+  } = useMemo(() => {
+    const formattedPendingEarnings = formatTokenDisplayValue(
+      pendingEarningsToken,
+      tokenSymbol
+    );
+    const formattedTotalEarningsToken = formatTokenDisplayValue(
+      totalEarnings.token,
+      tokenSymbol
+    );
+
+    const formattedTotalEarningsNative = totalEarnings.usd.toLocaleString(
+      'en-US',
+      {
+        style: 'currency',
+        currency: 'USD',
+      }
+    );
+
+    const today = new Date();
+    const dayOfNextDistribution = fromUnixTime(nextAirdropTimestamp);
+    const days = differenceInDays(dayOfNextDistribution, today);
+    const hours = differenceInHours(
+      dayOfNextDistribution,
+      addDays(today, days)
+    );
+
+    const airdropTitle = isPast(dayOfNextDistribution)
+      ? i18n.t(i18n.l.rewards.last_airdrop)
+      : i18n.t(i18n.l.rewards.next_airdrop);
+    const airdropTime = `${Math.abs(days)}d ${Math.abs(hours)}h`;
+
+    return {
+      formattedPendingEarnings,
+      formattedTotalEarningsNative,
+      formattedTotalEarningsToken,
+      airdropTitle,
+      airdropTime,
+    };
+  }, [
     pendingEarningsToken,
-    tokenSymbol
-  );
-  const formattedTotalEarningsToken = formatTokenDisplayValue(
+    tokenSymbol,
     totalEarnings.token,
-    tokenSymbol
-  );
+    totalEarnings.usd,
+    nextAirdropTimestamp,
+  ]);
 
-  const formattedTotalEarningsNative = totalEarnings.usd.toLocaleString(
-    'en-US',
-    {
-      style: 'currency',
-      currency: 'USD',
-    }
-  );
-
-  const today = new Date();
-  const dayOfNextDistribution = fromUnixTime(nextAirdropTimestamp);
-  const days = differenceInDays(dayOfNextDistribution, today);
-  const hours = differenceInHours(dayOfNextDistribution, addDays(today, days));
-
-  const airdropTitle = isPast(dayOfNextDistribution)
-    ? i18n.t(i18n.l.rewards.last_airdrop)
-    : i18n.t(i18n.l.rewards.next_airdrop);
-  const airdropTime = `${Math.abs(days)}d ${Math.abs(hours)}h`;
+  const navigateToTimingExplainer = () => {
+    navigate(Routes.EXPLAIN_SHEET, {
+      type: 'op_rewards_airdrop_timing',
+    });
+  };
 
   return (
     <AccentColorProvider color={color}>
       <Box paddingBottom="12px">
-        <RewardsSectionCard>
-          <Columns>
-            <Stack space="32px" alignHorizontal="left">
-              <Stack space="12px">
-                <Text color="labelSecondary" size="15pt" weight="semibold">
-                  {i18n.t(i18n.l.rewards.pending_earnings)}
-                </Text>
-                <Inline space="6px" alignVertical="center">
-                  <Box
-                    as={Image}
-                    source={{
-                      uri: tokenImageUrl,
-                    }}
-                    width={{ custom: TOKEN_IMAGE_SIZE }}
-                    height={{ custom: TOKEN_IMAGE_SIZE }}
-                    borderRadius={8}
-                    background="surfaceSecondaryElevated"
-                    shadow="12px"
-                  />
-                  <Text color="label" size="22pt" weight="heavy">
-                    {formattedPendingEarnings}
-                  </Text>
-                </Inline>
-              </Stack>
-              <Stack space="12px">
-                <Text color="labelSecondary" size="15pt" weight="semibold">
-                  {i18n.t(i18n.l.rewards.total_earnings)}
-                </Text>
-                <Inline space="6px" alignVertical="center">
-                  <Box
-                    as={Image}
-                    source={{
-                      uri: tokenImageUrl,
-                    }}
-                    width={{ custom: TOKEN_IMAGE_SIZE }}
-                    height={{ custom: TOKEN_IMAGE_SIZE }}
-                    borderRadius={8}
-                    background="surfaceSecondaryElevated"
-                    shadow="12px"
-                  />
-                  <Text color="labelSecondary" size="22pt" weight="heavy">
-                    {formattedTotalEarningsToken}
-                  </Text>
-                </Inline>
-              </Stack>
-            </Stack>
-            <Stack space="32px" alignHorizontal="right">
-              <Stack space="12px" alignHorizontal="right">
-                <Inline space="4px" alignVertical="center">
+        <ButtonPressAnimation
+          onPress={navigateToTimingExplainer}
+          scaleTo={0.96}
+        >
+          <RewardsSectionCard>
+            <Columns>
+              <Stack space="32px" alignHorizontal="left">
+                <Stack space="12px">
                   <Text color="labelSecondary" size="15pt" weight="semibold">
-                    {airdropTitle}
+                    {i18n.t(i18n.l.rewards.pending_earnings)}
                   </Text>
-                  <Text
-                    color={{ custom: infoIconColor }}
-                    size="13pt"
-                    weight="heavy"
-                  >
-                    􀅵
+                  <Inline space="6px" alignVertical="center">
+                    <Box
+                      as={Image}
+                      source={{
+                        uri: tokenImageUrl,
+                      }}
+                      width={{ custom: TOKEN_IMAGE_SIZE }}
+                      height={{ custom: TOKEN_IMAGE_SIZE }}
+                      borderRadius={8}
+                      background="surfaceSecondaryElevated"
+                      shadow="12px"
+                    />
+                    <Text color="label" size="22pt" weight="heavy">
+                      {formattedPendingEarnings}
+                    </Text>
+                  </Inline>
+                </Stack>
+                <Stack space="12px">
+                  <Text color="labelSecondary" size="15pt" weight="semibold">
+                    {i18n.t(i18n.l.rewards.total_earnings)}
                   </Text>
-                </Inline>
-                <Inline space="6px" alignVertical="center">
-                  <Text color="label" size="17pt" weight="semibold">
-                    􀧞
-                  </Text>
-                  <Text color="label" size="22pt" weight="semibold">
-                    {airdropTime}
-                  </Text>
-                </Inline>
+                  <Inline space="6px" alignVertical="center">
+                    <Box
+                      as={Image}
+                      source={{
+                        uri: tokenImageUrl,
+                      }}
+                      width={{ custom: TOKEN_IMAGE_SIZE }}
+                      height={{ custom: TOKEN_IMAGE_SIZE }}
+                      borderRadius={8}
+                      background="surfaceSecondaryElevated"
+                      shadow="12px"
+                    />
+                    <Text color="labelSecondary" size="22pt" weight="heavy">
+                      {formattedTotalEarningsToken}
+                    </Text>
+                  </Inline>
+                </Stack>
               </Stack>
-              <Stack space="12px" alignHorizontal="right">
-                <Text color="labelSecondary" size="15pt" weight="semibold">
-                  {i18n.t(i18n.l.rewards.current_value)}
-                </Text>
-                <Text color="labelSecondary" size="22pt" weight="heavy">
-                  {formattedTotalEarningsNative}
-                </Text>
+              <Stack space="32px" alignHorizontal="right">
+                <Stack space="12px" alignHorizontal="right">
+                  <Inline space="4px" alignVertical="center">
+                    <Text color="labelSecondary" size="15pt" weight="semibold">
+                      {airdropTitle}
+                    </Text>
+                    <Text
+                      color={{ custom: infoIconColor }}
+                      size="13pt"
+                      weight="heavy"
+                    >
+                      􀅵
+                    </Text>
+                  </Inline>
+                  <Inline space="6px" alignVertical="center">
+                    <Text color="label" size="17pt" weight="semibold">
+                      􀧞
+                    </Text>
+                    <Text color="label" size="22pt" weight="semibold">
+                      {airdropTime}
+                    </Text>
+                  </Inline>
+                </Stack>
+                <Stack space="12px" alignHorizontal="right">
+                  <Text color="labelSecondary" size="15pt" weight="semibold">
+                    {i18n.t(i18n.l.rewards.current_value)}
+                  </Text>
+                  <Text color="labelSecondary" size="22pt" weight="heavy">
+                    {formattedTotalEarningsNative}
+                  </Text>
+                </Stack>
               </Stack>
-            </Stack>
-          </Columns>
-        </RewardsSectionCard>
+            </Columns>
+          </RewardsSectionCard>
+        </ButtonPressAnimation>
       </Box>
     </AccentColorProvider>
   );

--- a/src/screens/rewards/components/RewardsEarnings.tsx
+++ b/src/screens/rewards/components/RewardsEarnings.tsx
@@ -110,6 +110,7 @@ export const RewardsEarnings: React.FC<Props> = ({
         <ButtonPressAnimation
           onPress={navigateToTimingExplainer}
           scaleTo={0.96}
+          overflowMargin={50}
         >
           <RewardsSectionCard>
             <Columns>

--- a/src/screens/rewards/components/RewardsStats.tsx
+++ b/src/screens/rewards/components/RewardsStats.tsx
@@ -74,7 +74,9 @@ export const RewardsStats: React.FC<Props> = ({
                     style: 'currency',
                     currency: 'USD',
                   })}
-                  secondaryValue={`${action.rewardPercent}% reward`}
+                  secondaryValue={i18n.t(i18n.l.rewards.percent, {
+                    percent: action.rewardPercent,
+                  })}
                   secondaryValueIcon="􀐚"
                   secondaryValueColor={{
                     custom: color,

--- a/src/screens/rewards/components/RewardsStats.tsx
+++ b/src/screens/rewards/components/RewardsStats.tsx
@@ -4,8 +4,12 @@ import * as i18n from '@/languages';
 import { ScrollView } from 'react-native';
 import { RewardsStatsCard } from './RewardsStatsCard';
 import { capitalize } from 'lodash';
-import { convertAmountToNativeDisplay } from '@/helpers/utilities';
-import { RewardStatsAction } from '@/graphql/__generated__/metadata';
+import {
+  RewardStatsAction,
+  RewardStatsActionType,
+} from '@/graphql/__generated__/metadata';
+import { useNavigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
 
 type Props = {
   position: number;
@@ -19,53 +23,69 @@ export const RewardsStats: React.FC<Props> = ({
   position,
   positionChange,
   color,
-}) => (
-  <Box paddingBottom="12px">
-    <Stack space="8px">
-      <Text size="20pt" color="label" weight="heavy">
-        {i18n.t(i18n.l.rewards.my_stats)}
-      </Text>
-      <Bleed horizontal="20px">
-        <ScrollView
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={{
-            paddingTop: 8,
-            paddingHorizontal: 20,
-            paddingBottom: 24,
-          }}
-          horizontal
-        >
-          <Inline space="12px">
-            <RewardsStatsCard
-              key="Position"
-              title={i18n.t(i18n.l.rewards.position)}
-              value={`#${position}`}
-              secondaryValue={positionChange.toString()}
-              secondaryValueColor={positionChange > 0 ? 'green' : 'red'}
-              secondaryValueIcon={positionChange > 0 ? '􀑁' : '􁘳'}
-              // TODO: Add explainer sheet navigation to on press here
-              onPress={() => {}}
-            />
-            {actions.map(action => (
+}) => {
+  const { navigate } = useNavigation();
+  const navigateToPositionExplainer = () => {
+    navigate(Routes.EXPLAIN_SHEET, { type: 'op_rewards_position' });
+  };
+  const getPressHandlerForType = (type: RewardStatsActionType) => {
+    switch (type) {
+      case RewardStatsActionType.Bridge:
+        return () =>
+          navigate(Routes.EXPLAIN_SHEET, { type: 'op_rewards_bridge' });
+      case RewardStatsActionType.Swap:
+        return () =>
+          navigate(Routes.EXPLAIN_SHEET, { type: 'op_rewards_swap' });
+      default:
+        return () => {};
+    }
+  };
+  return (
+    <Box paddingBottom="12px">
+      <Stack space="8px">
+        <Text size="20pt" color="label" weight="heavy">
+          {i18n.t(i18n.l.rewards.my_stats)}
+        </Text>
+        <Bleed horizontal="20px">
+          <ScrollView
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{
+              paddingTop: 8,
+              paddingHorizontal: 20,
+              paddingBottom: 24,
+            }}
+            horizontal
+          >
+            <Inline space="12px">
               <RewardsStatsCard
-                key={action.type}
-                title={capitalize(action.type)}
-                value={action.amount.usd.toLocaleString('en-US', {
-                  style: 'currency',
-                  currency: 'USD',
-                })}
-                secondaryValue={`${action.rewardPercent}% reward`}
-                secondaryValueIcon="􀐚"
-                secondaryValueColor={{
-                  custom: color,
-                }}
-                // TODO: Add explainer sheet navigation to on press here
-                onPress={() => {}}
+                key="Position"
+                title={i18n.t(i18n.l.rewards.position)}
+                value={`#${position}`}
+                secondaryValue={positionChange.toString()}
+                secondaryValueColor={positionChange > 0 ? 'green' : 'red'}
+                secondaryValueIcon={positionChange > 0 ? '􀑁' : '􁘳'}
+                onPress={navigateToPositionExplainer}
               />
-            ))}
-          </Inline>
-        </ScrollView>
-      </Bleed>
-    </Stack>
-  </Box>
-);
+              {actions.map(action => (
+                <RewardsStatsCard
+                  key={action.type}
+                  title={capitalize(action.type)}
+                  value={action.amount.usd.toLocaleString('en-US', {
+                    style: 'currency',
+                    currency: 'USD',
+                  })}
+                  secondaryValue={`${action.rewardPercent}% reward`}
+                  secondaryValueIcon="􀐚"
+                  secondaryValueColor={{
+                    custom: color,
+                  }}
+                  onPress={getPressHandlerForType(action.type)}
+                />
+              ))}
+            </Inline>
+          </ScrollView>
+        </Bleed>
+      </Stack>
+    </Box>
+  );
+};

--- a/src/screens/rewards/components/RewardsStatsCard.tsx
+++ b/src/screens/rewards/components/RewardsStatsCard.tsx
@@ -26,8 +26,7 @@ export const RewardsStatsCard: React.FC<Props> = ({
   const infoIconColor = useInfoIconColor();
 
   return (
-    // TODO: Add explainer sheet navigation to on press here
-    <ButtonPressAnimation onPress={onPress} scaleTo={0.96}>
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.96} overflowMargin={50}>
       <RewardsSectionCard>
         <Stack space="12px">
           <Inline space="4px" alignVertical="center" wrap={false}>


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Fixed Android shadows after adding button press animation
* Added explainer sheets with temporary content to all cards with i marks
* Exmplainer sheets will work only for OP rewards and are hardcoded

More in LInear