### PR TITLE
fix stale L2 pricing 

### DIFF
--- a/src/redux/explorer.ts
+++ b/src/redux/explorer.ts
@@ -901,13 +901,10 @@ const l2AddressAssetsReceived = (
     | { asset: ZerionAsseWithL2Fields }[]
     | undefined = message?.payload?.assets?.map(asset => {
     const mainnetAddress = toLower(asset?.asset?.mainnet_address);
-    const uniqueId = `${asset?.asset?.asset_code}_${asset?.asset?.network}`;
     const fallbackAsset =
-      (mainnetAddress &&
-        (ethereumUtils.getAccountAsset(mainnetAddress) ||
-          genericAssets[mainnetAddress])) ||
-      ethereumUtils.getAccountAsset(uniqueId) ||
-      genericAssets[asset?.asset?.asset_code];
+      mainnetAddress &&
+      (ethereumUtils.getAccountAsset(mainnetAddress) ||
+        genericAssets[mainnetAddress]);
 
     if (fallbackAsset) {
       return {


### PR DESCRIPTION
Fixes APP-407

## What changed (plus any additional context for devs)
removed old logic that was preventing us from updating certain L2 token pricing info 

## Screen recordings / screenshots
no


## What to test
OP price should update after some time 

