### PR TITLE
Fix decimals override (BSC balances issue)

### DIFF
--- a/src/utils/getTokenMetadata.ts
+++ b/src/utils/getTokenMetadata.ts
@@ -1,4 +1,5 @@
 import { TokenMetadata } from '@/entities/tokens';
+import { omitFlatten } from '@/helpers/utilities';
 import { rainbowTokenList } from '@/references';
 
 export default function getTokenMetadata(
@@ -8,9 +9,6 @@ export default function getTokenMetadata(
   const metadata: TokenMetadata =
     rainbowTokenList.RAINBOW_TOKEN_LIST[tokenAddress.toLowerCase()];
 
-  // delete chain specific metadata
-  delete metadata?.decimals;
-  delete metadata?.chainId;
-
-  return metadata;
+  // delete chain  metadata
+  return omitFlatten(metadata, ['chainId', 'decimals']);
 }


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Fixes the issue where we were using incorrect decimal numbers for some BSC assets.
This wasn't a BSC specific issue but we only saw it there bc it's the only chain I know where the token decimals doesn't match the mainnet token decimals.

The problem
This wasn't working at all in production:
https://github.com/rainbow-me/rainbow/blob/develop/src/utils/getTokenMetadata.ts#L11-L13

causing all the token metadata to be overwritten, including chain specific data.

I believe it's because we're running JS in strict mode and some things are different but I'm not gonna spend more time figuring out why.

TLDR: Use `omitFlatten` if possible or return a new object instead of using delete in the future to avoid surprises

## Screen recordings / screenshots
Before:
<img width="448" alt="Screen Shot 2023-02-03 at 3 20 06 PM" src="https://user-images.githubusercontent.com/1247834/216722795-11721d78-9955-432d-aee0-f4c4e5256791.png">


After:
<img width="443" alt="Screen Shot 2023-02-03 at 5 25 59 PM" src="https://user-images.githubusercontent.com/1247834/216722804-79cd688f-e9d4-45a2-8a7f-a11c65a45be7.png">


## What to test
Make a testflight build and an android apk for this branch and confirm the balances for 0xtester.eth are showing correctly
