### PR TITLE
Ledger: refactor error sheets

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -168,3 +168,5 @@ export { default as useLatestCallback } from './useLatestCallback';
 export { default as useHiddenTokens } from './useHiddenTokens';
 export { useSwappableUserAssets } from './useSwappableUserAssets';
 export { useAccountAccentColor } from './useAccountAccentColor';
+export { useLedgerConnect } from './useLedgerConnect';
+export { useLedgerImport } from './useLedgerImport';

--- a/src/navigation/HardwareWalletTxNavigator.tsx
+++ b/src/navigation/HardwareWalletTxNavigator.tsx
@@ -4,8 +4,9 @@ import Routes from '@/navigation/routesNames';
 import { BackgroundProvider } from '@/design-system';
 import { useDimensions } from '@/hooks';
 import { PairHardwareWalletAgainSheet } from '@/screens/hardware-wallets/PairHardwareWalletAgainSheet';
-import { PairHardwareWalletErrorSheet } from '@/screens/hardware-wallets/PairHardwareWalletErrorSheet';
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
+import { PairHardwareWalletEthAppErrorSheet } from '@/screens/hardware-wallets/PairHardwareWalletEthAppErrorSheet';
+import { PairHardwareWalletLockedErrorSheet } from '@/screens/hardware-wallets/PairHardwareWalletLockedErrorSheet';
 
 const Swipe = createMaterialTopTabNavigator();
 export const HARDWARE_WALLET_TX_NAVIGATOR_SHEET_HEIGHT = 534;
@@ -23,7 +24,7 @@ export const HardwareWalletTxNavigator = () => {
         >
           <Swipe.Navigator
             initialLayout={{ width, height }}
-            initialRouteName={Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET}
+            initialRouteName={Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET}
             swipeEnabled={false}
             sceneContainerStyle={{ backgroundColor: backgroundColor }}
             tabBar={() => null}
@@ -33,8 +34,12 @@ export const HardwareWalletTxNavigator = () => {
               name={Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET}
             />
             <Swipe.Screen
-              component={PairHardwareWalletErrorSheet}
-              name={Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET}
+              component={PairHardwareWalletEthAppErrorSheet}
+              name={Routes.PAIR_HARDWARE_WALLET_ETH_APP_ERROR_SHEET}
+            />
+            <Swipe.Screen
+              component={PairHardwareWalletLockedErrorSheet}
+              name={Routes.PAIR_HARDWARE_WALLET_LOCKED_ERROR_SHEET}
             />
           </Swipe.Navigator>
         </SimpleSheet>

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -44,8 +44,10 @@ const Routes = {
   NOTIFICATIONS_PROMO_SHEET: 'NotificationsPromoSheet',
   OP_REWARDS_SHEET: 'OpRewardsSheet',
   PAIR_HARDWARE_WALLET_AGAIN_SHEET: 'PairHardwareWalletAgainSheet',
-  PAIR_HARDWARE_WALLET_ERROR_SHEET: 'PairHardwareWalletErrorSheet',
+  PAIR_HARDWARE_WALLET_ETH_APP_ERROR_SHEET:
+    'PairHardwareWalletEthAppErrorSheet',
   PAIR_HARDWARE_WALLET_INTRO_SHEET: 'PairHardwareWalletIntroSheet',
+  PAIR_HARDWARE_WALLET_LOCKED_ERROR_SHEET: 'PairHardwareWalletLockedErrorSheet',
   PAIR_HARDWARE_WALLET_NAVIGATOR: 'PairHardwareWalletNavigator',
   PAIR_HARDWARE_WALLET_SEARCH_SHEET: 'PairHardwareWalletSearchSheet',
   PAIR_HARDWARE_WALLET_SIGNING_SHEET: 'PairHardwareWalletSigningSheet',

--- a/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
@@ -1,5 +1,5 @@
 import * as i18n from '@/languages';
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Inline, Inset, Stack, Text } from '@/design-system';
 import { ImgixImage } from '@/components/images';
 import ledgerNano from '@/assets/ledger-nano.png';
@@ -17,19 +17,30 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
-// import { CancelButton } from '@/screens/hardware-wallets/components/CancelButton';
 import gridDotsLight from '@/assets/dot-grid-light.png';
 import gridDotsDark from '@/assets/dot-grid-dark.png';
 import { useTheme } from '@/theme';
 import { IS_IOS } from '@/env';
 import { Layout } from '@/screens/hardware-wallets/components/Layout';
 import { TRANSLATIONS } from '@/screens/hardware-wallets/constants';
+import { useSetRecoilState } from 'recoil';
+import { LedgerImportDeviceIdAtom } from '@/navigation/PairHardwareWalletNavigator';
+import { useLedgerImport } from '@/hooks';
 
 const INDICATOR_SIZE = 7;
 
 export const PairHardwareWalletAgainSheet = () => {
   const { isDarkMode } = useTheme();
-  const connected = false;
+  const setDeviceId = useSetRecoilState(LedgerImportDeviceIdAtom);
+  const [isConnected, setIsConnected] = useState(false);
+
+  useLedgerImport({
+    successCallback: deviceId => {
+      setDeviceId(deviceId);
+      setIsConnected(true);
+      // TODO: add delay to make sure the animation is finished
+    },
+  });
 
   const indicatorOpacity = useDerivedValue(() =>
     withRepeat(
@@ -101,7 +112,7 @@ export const PairHardwareWalletAgainSheet = () => {
                   Nano X 7752
                 </Text>
                 <Box>
-                  {!connected && (
+                  {!isConnected && (
                     <Animated.View
                       style={{
                         alignItems: 'center',
@@ -109,7 +120,7 @@ export const PairHardwareWalletAgainSheet = () => {
                         height: INDICATOR_SIZE,
                         width: INDICATOR_SIZE,
                         borderRadius: INDICATOR_SIZE / 2,
-                        ...(!connected ? indicatorAnimation : {}),
+                        ...(!isConnected ? indicatorAnimation : {}),
                       }}
                     >
                       <Box
@@ -126,8 +137,8 @@ export const PairHardwareWalletAgainSheet = () => {
                     width={{ custom: INDICATOR_SIZE }}
                     height={{ custom: INDICATOR_SIZE }}
                     style={{ zIndex: -1 }}
-                    background={connected ? 'green' : 'surfaceSecondary'}
-                    shadow={connected && IS_IOS ? '30px green' : undefined}
+                    background={isConnected ? 'green' : 'surfaceSecondary'}
+                    shadow={isConnected && IS_IOS ? '30px green' : undefined}
                     borderRadius={INDICATOR_SIZE / 2}
                   />
                 </Box>

--- a/src/screens/hardware-wallets/PairHardwareWalletEthAppErrorSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletEthAppErrorSheet.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { LEDGER_ERROR_CODES } from '@/utils/ledger';
-import { ErrorSheet } from './components/ErrorSheet';
+import { ErrorSheet, ErrorSheetRouteParams } from './components/ErrorSheet';
+import { RouteProp, useRoute } from '@react-navigation/core';
 
-export const PairHardwareWalletEthAppErrorSheet = () => (
-  <ErrorSheet type={LEDGER_ERROR_CODES.NO_ETH_APP} />
-);
+export const PairHardwareWalletEthAppErrorSheet = () => {
+  const route = useRoute<RouteProp<ErrorSheetRouteParams, 'ErrorSheetProps'>>();
+  return (
+    <ErrorSheet
+      deviceId={route?.params?.deviceId}
+      type={LEDGER_ERROR_CODES.NO_ETH_APP}
+    />
+  );
+};

--- a/src/screens/hardware-wallets/PairHardwareWalletEthAppErrorSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletEthAppErrorSheet.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { LEDGER_ERROR_CODES } from '@/utils/ledger';
+import { ErrorSheet } from './components/ErrorSheet';
+
+export const PairHardwareWalletEthAppErrorSheet = () => (
+  <ErrorSheet type={LEDGER_ERROR_CODES.NO_ETH_APP} />
+);

--- a/src/screens/hardware-wallets/PairHardwareWalletLockedErrorSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletLockedErrorSheet.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { LEDGER_ERROR_CODES } from '@/utils/ledger';
-import { ErrorSheet } from './components/ErrorSheet';
+import { ErrorSheet, ErrorSheetRouteParams } from './components/ErrorSheet';
+import { RouteProp, useRoute } from '@react-navigation/core';
 
-export const PairHardwareWalletLockedErrorSheet = () => (
-  <ErrorSheet type={LEDGER_ERROR_CODES.OFF_OR_LOCKED} />
-);
+export const PairHardwareWalletLockedErrorSheet = () => {
+  const route = useRoute<RouteProp<ErrorSheetRouteParams, 'ErrorSheetProps'>>();
+  return (
+    <ErrorSheet
+      deviceId={route?.params?.deviceId}
+      type={LEDGER_ERROR_CODES.OFF_OR_LOCKED}
+    />
+  );
+};

--- a/src/screens/hardware-wallets/PairHardwareWalletLockedErrorSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletLockedErrorSheet.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { LEDGER_ERROR_CODES } from '@/utils/ledger';
+import { ErrorSheet } from './components/ErrorSheet';
+
+export const PairHardwareWalletLockedErrorSheet = () => (
+  <ErrorSheet type={LEDGER_ERROR_CODES.OFF_OR_LOCKED} />
+);

--- a/src/screens/hardware-wallets/PairHardwareWalletSearchSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletSearchSheet.tsx
@@ -1,19 +1,19 @@
 import * as i18n from '@/languages';
-import React from 'react';
+import React, { useState } from 'react';
 import { Inset, Stack, Text } from '@/design-system';
 import { Layout } from '@/screens/hardware-wallets/components/Layout';
 import { TRANSLATIONS } from '@/screens/hardware-wallets/constants';
 import { useSetRecoilState } from 'recoil';
-import { useLedgerImport } from '@/hooks/useLedgerImport';
 import Routes from '@/navigation/routesNames';
 import { useNavigation } from '@/navigation';
 import { LedgerImportDeviceIdAtom } from '@/navigation/PairHardwareWalletNavigator';
 import { ActionButton } from '@/screens/hardware-wallets/components/ActionButton';
+import { useLedgerImport } from '@/hooks';
 
 export const PairHardwareWalletSearchSheet = () => {
   const { navigate } = useNavigation();
   const setDeviceId = useSetRecoilState(LedgerImportDeviceIdAtom);
-  const [isConnected, setIsConnected] = React.useState(false);
+  const [isConnected, setIsConnected] = useState(false);
 
   useLedgerImport({
     successCallback: deviceId => {

--- a/src/screens/hardware-wallets/PairHardwareWalletSigningSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletSigningSheet.tsx
@@ -143,14 +143,17 @@ export function PairHardwareWalletSigningSheet() {
 
   const errorCallback = useCallback(
     (errorType: LEDGER_ERROR_CODES) => {
-      if (
-        errorType === LEDGER_ERROR_CODES.NO_ETH_APP ||
-        errorType === LEDGER_ERROR_CODES.OFF_OR_LOCKED
-      ) {
+      if (errorType === LEDGER_ERROR_CODES.NO_ETH_APP) {
         navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, {
-          screen: Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET,
+          screen: Routes.PAIR_HARDWARE_WALLET_ETH_APP_ERROR_SHEET,
           params: {
-            errorType,
+            deviceId,
+          },
+        });
+      } else if (errorType === LEDGER_ERROR_CODES.OFF_OR_LOCKED) {
+        navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, {
+          screen: Routes.PAIR_HARDWARE_WALLET_LOCKED_ERROR_SHEET,
+          params: {
             deviceId,
           },
         });

--- a/src/screens/hardware-wallets/components/ErrorSheet.tsx
+++ b/src/screens/hardware-wallets/components/ErrorSheet.tsx
@@ -10,20 +10,27 @@ import { ImgixImage } from '@/components/images';
 import { TRANSLATIONS } from '@/screens/hardware-wallets/constants';
 import { LEDGER_ERROR_CODES } from '@/utils/ledger';
 import { useNavigation } from '@/navigation';
-import { useRecoilValue } from 'recoil';
-import { LedgerImportDeviceIdAtom } from '@/navigation/PairHardwareWalletNavigator';
 import Routes from '@/navigation/routesNames';
 import { Alert } from 'react-native';
 
 const IMAGE_ASPECT_RATIO = 1.547;
 const IMAGE_LEFT_OFFSET = 36;
 
+type ErrorSheetProps = {
+  deviceId?: string;
+};
+
+export type ErrorSheetRouteParams = {
+  ErrorSheetProps: ErrorSheetProps;
+};
+
 export const ErrorSheet = ({
+  deviceId,
   type,
 }: {
+  deviceId?: string;
   type: LEDGER_ERROR_CODES.OFF_OR_LOCKED | LEDGER_ERROR_CODES.NO_ETH_APP;
 }) => {
-  const deviceId = useRecoilValue(LedgerImportDeviceIdAtom);
   const { dangerouslyGetParent, navigate } = useNavigation();
   const { width: deviceWidth } = useDimensions();
 
@@ -32,19 +39,23 @@ export const ErrorSheet = ({
 
   const successCallback = useCallback(() => {
     dangerouslyGetParent()?.goBack(); // to blind signing sheet
-    // or nav to tx details (?) if confirming a tx}, [])
-  }, []);
+    // or nav to tx details (?) if confirming a tx
+  }, [dangerouslyGetParent]);
 
   const errorCallback = useCallback(
     (errorType: LEDGER_ERROR_CODES) => {
       console.log('error callback', errorType);
       if (errorType === LEDGER_ERROR_CODES.OFF_OR_LOCKED) {
         if (type === LEDGER_ERROR_CODES.NO_ETH_APP) {
-          navigate(Routes.PAIR_HARDWARE_WALLET_LOCKED_ERROR_SHEET);
+          navigate(Routes.PAIR_HARDWARE_WALLET_LOCKED_ERROR_SHEET, {
+            params: deviceId,
+          });
         }
       } else if (errorType === LEDGER_ERROR_CODES.NO_ETH_APP) {
         if (type === LEDGER_ERROR_CODES.OFF_OR_LOCKED) {
-          navigate(Routes.PAIR_HARDWARE_WALLET_ETH_APP_ERROR_SHEET);
+          navigate(Routes.PAIR_HARDWARE_WALLET_ETH_APP_ERROR_SHEET, {
+            params: deviceId,
+          });
         }
       } else {
         console.log('unhandled errorType', errorType);
@@ -56,7 +67,7 @@ export const ErrorSheet = ({
 
   useLedgerConnect({
     readyForPolling: !!deviceId,
-    deviceId: deviceId,
+    deviceId: deviceId || '',
     successCallback: successCallback,
     errorCallback,
   });


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
split up `PairHardwareWalletErrorSheet` into two new sheets, 1 for each error.

why? currently, if the error type switches (which is very possible/common), there is no transition animation. the text/image on the error sheet will just suddenly rerender as a new error type is fed to the generic sheet. by splitting the error sheet into two sheets, when a new error state needs to be displayed, you can visibly see that you're being shown something new thanks to the navigation animation, as opposed to the text/image on the sheet instantaneously changing.

## Screen recordings / screenshots


## What to test

