### PR TITLE
Fix wallet screen startup freeze

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,6 +307,7 @@
     "@lavamoat/allow-scripts": "2.0.3",
     "@nomiclabs/hardhat-ethers": "2.0.4",
     "@nomiclabs/hardhat-waffle": "2.0.1",
+    "@testing-library/react": "13.4.0",
     "@testing-library/react-native": "11.2.0",
     "@types/chroma-js": "2.1.3",
     "@types/d3-scale": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -307,7 +307,6 @@
     "@lavamoat/allow-scripts": "2.0.3",
     "@nomiclabs/hardhat-ethers": "2.0.4",
     "@nomiclabs/hardhat-waffle": "2.0.1",
-    "@testing-library/react": "13.4.0",
     "@testing-library/react-native": "11.2.0",
     "@types/chroma-js": "2.1.3",
     "@types/d3-scale": "4.0.2",

--- a/src/components/asset-list/RecyclerAssetList2/core/RawRecyclerList.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RawRecyclerList.tsx
@@ -73,7 +73,11 @@ const RawMemoRecyclerAssetList = React.memo(function RawRecyclerAssetList({
     [briefSectionsData]
   );
 
-  const { accountAddress } = useAccountSettings();
+  const {
+    nativeCurrencySymbol,
+    nativeCurrency,
+    accountAddress,
+  } = useAccountSettings();
 
   const topMarginRef = useRef<number>(0);
 
@@ -115,7 +119,6 @@ const RawMemoRecyclerAssetList = React.memo(function RawRecyclerAssetList({
   const layoutItemAnimator = useLayoutItemAnimator(ref, topMarginRef);
 
   const theme = useTheme();
-  const { nativeCurrencySymbol, nativeCurrency } = useAccountSettings();
   const {
     hiddenCoinsObj: hiddenCoins,
     pinnedCoinsObj: pinnedCoins,

--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -17,6 +17,9 @@ import {
   NFTExtraData,
   NFTFamilyExtraData,
   PoolsHeaderExtraData,
+  ProfileActionButtonsExtraData,
+  ProfileAvatarExtraData,
+  ProfileNameExtraData,
   SavingExtraData,
   SavingsHeaderExtraData,
   UniswapPoolExtraData,
@@ -92,7 +95,13 @@ function rowRenderer(
         </CardRowWrapper>
       );
     case CellType.PROFILE_STICKY_HEADER:
-      return <ProfileStickyHeader />;
+      return (
+        <ProfileStickyHeader
+          accountName={(data as ProfileNameExtraData).accountName}
+          accountAddress={(data as ProfileNameExtraData).accountAddress}
+          accountENS={(data as ProfileNameExtraData).accountENS}
+        />
+      );
     case CellType.COIN:
       return (
         <FastBalanceCoinRow
@@ -116,13 +125,20 @@ function rowRenderer(
     case CellType.PROFILE_ACTION_BUTTONS_ROW:
       return (
         <ProfileRowWrapper>
-          <ProfileActionButtonsRow />
+          <ProfileActionButtonsRow
+            accountColor={(data as ProfileActionButtonsExtraData).accountColor}
+            accountImage={(data as ProfileActionButtonsExtraData).accountImage}
+          />
         </ProfileRowWrapper>
       );
     case CellType.PROFILE_AVATAR_ROW:
       return (
         <ProfileRowWrapper>
-          <ProfileAvatarRow />
+          <ProfileAvatarRow
+            accountColor={(data as ProfileAvatarExtraData).accountColor}
+            accountImage={(data as ProfileAvatarExtraData).accountImage}
+            accountSymbol={(data as ProfileAvatarExtraData).accountSymbol}
+          />
         </ProfileRowWrapper>
       );
     case CellType.PROFILE_BALANCE_ROW:
@@ -136,7 +152,12 @@ function rowRenderer(
     case CellType.PROFILE_NAME_ROW:
       return (
         <ProfileRowWrapper>
-          <ProfileNameRow testIDPrefix="profile-name" />
+          <ProfileNameRow
+            testIDPrefix="profile-name"
+            accountName={(data as ProfileNameExtraData).accountName}
+            accountAddress={(data as ProfileNameExtraData).accountAddress}
+            accountENS={(data as ProfileNameExtraData).accountENS}
+          />
         </ProfileRowWrapper>
       );
     case CellType.UNISWAP_POOL:

--- a/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/RowRenderer.tsx
@@ -126,8 +126,13 @@ function rowRenderer(
       return (
         <ProfileRowWrapper>
           <ProfileActionButtonsRow
-            accountColor={(data as ProfileActionButtonsExtraData).accountColor}
-            accountImage={(data as ProfileActionButtonsExtraData).accountImage}
+            accountAccentColor={
+              (data as ProfileActionButtonsExtraData).accountAccentColor
+            }
+            hasAccountAccentColorLoaded={
+              (data as ProfileActionButtonsExtraData)
+                .hasAccountAccentColorLoaded
+            }
           />
         </ProfileRowWrapper>
       );
@@ -135,7 +140,12 @@ function rowRenderer(
       return (
         <ProfileRowWrapper>
           <ProfileAvatarRow
-            accountColor={(data as ProfileAvatarExtraData).accountColor}
+            accountAccentColor={
+              (data as ProfileAvatarExtraData).accountAccentColor
+            }
+            hasAccountAccentColorLoaded={
+              (data as ProfileAvatarExtraData).hasAccountAccentColorLoaded
+            }
             accountImage={(data as ProfileAvatarExtraData).accountImage}
             accountSymbol={(data as ProfileAvatarExtraData).accountSymbol}
           />

--- a/src/components/asset-list/RecyclerAssetList2/core/ViewTypes.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/ViewTypes.ts
@@ -36,6 +36,7 @@ export enum CellType {
   BIG_EMPTY_WALLET_SPACER = 'BIG_EMPTY_WALLET_SPACER',
   EMPTY_ROW = 'EMPTY_ROW',
 }
+
 export type RecyclerListViewRef = RecyclerListView<
   RecyclerListViewProps,
   RecyclerListViewState
@@ -89,12 +90,14 @@ export type ProfileNameExtraData = {
 export type ProfileAvatarExtraData = {
   type: CellType.PROFILE_AVATAR_ROW;
   accountSymbol?: string | boolean;
-  accountColor?: number;
+  accountAccentColor: string;
   accountImage?: string | null;
+  hasAccountAccentColorLoaded?: boolean;
 };
 
 export type ProfileActionButtonsExtraData = {
-  accountColor?: number;
+  accountAccentColor?: string;
+  hasAccountAccentColorLoaded?: boolean;
   accountImage?: string | null;
 };
 

--- a/src/components/asset-list/RecyclerAssetList2/core/ViewTypes.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/ViewTypes.ts
@@ -79,6 +79,25 @@ export type NFTFamilyExtraData = {
   image?: string;
 };
 
+export type ProfileNameExtraData = {
+  type: CellType.PROFILE_NAME_ROW | CellType.PROFILE_STICKY_HEADER;
+  accountName?: string;
+  accountENS?: string;
+  accountAddress?: string;
+};
+
+export type ProfileAvatarExtraData = {
+  type: CellType.PROFILE_AVATAR_ROW;
+  accountSymbol?: string | boolean;
+  accountColor?: number;
+  accountImage?: string | null;
+};
+
+export type ProfileActionButtonsExtraData = {
+  accountColor?: number;
+  accountImage?: string | null;
+};
+
 export type CellExtraData =
   | { type: CellType.NFTS_HEADER }
   | { type: CellType.LOADING_ASSETS }
@@ -90,6 +109,9 @@ export type CellExtraData =
   | CoinExtraData
   | NFTExtraData
   | AssetsHeaderExtraData
-  | PoolsHeaderExtraData;
+  | PoolsHeaderExtraData
+  | ProfileNameExtraData
+  | ProfileAvatarExtraData
+  | ProfileActionButtonsExtraData;
 
 export type CellTypes = BaseCellType & CellExtraData;

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -33,46 +33,82 @@ import { addressCopiedToastAtom } from '@/screens/wallet/WalletScreen';
 import config from '@/model/config';
 import { getAllActiveSessionsSync } from '@/utils/walletConnect';
 import { useTheme } from '@/theme';
+import Animated, {
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withSpring,
+  WithSpringConfig,
+} from 'react-native-reanimated';
+import { useLayoutEffect } from 'react';
 
 export const ProfileActionButtonsRowHeight = 80;
+const SPRING_CONFIG: WithSpringConfig = {
+  damping: 12,
+  restDisplacementThreshold: 0.001,
+  restSpeedThreshold: 0.001,
+  stiffness: 280,
+};
 
 type Props = {
-  accountColor?: number;
-  accountImage?: string | null;
+  accountAccentColor?: string;
+  hasAccountAccentColorLoaded?: boolean;
 };
 
 export const ProfileActionButtonsRow: React.FC<Props> = ({
-  accountColor,
-  accountImage,
+  accountAccentColor,
+  hasAccountAccentColorLoaded,
 }) => {
   const { colors } = useTheme();
-  const accentColor =
-    accountImage || accountColor === undefined
-      ? colors.appleBlue
-      : colors.avatarBackgrounds[accountColor];
+
+  const scale = useSharedValue(hasAccountAccentColorLoaded ? 1 : 0.9);
+  const expandStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        scale: scale.value,
+      },
+    ],
+  }));
+
+  useLayoutEffect(() => {
+    scale.value = withSpring(
+      hasAccountAccentColorLoaded ? 1 : 0.9,
+      SPRING_CONFIG
+    );
+  }, [hasAccountAccentColorLoaded, scale]);
+
+  if (!hasAccountAccentColorLoaded) return null;
+
   const addCashEnabled = config.f2c_enabled;
   const swapEnabled = config.swagg_enabled;
-
   return (
     <Box width="full">
       <Inset horizontal={{ custom: 17 }}>
-        <AccentColorProvider color={accentColor}>
+        <AccentColorProvider color={accountAccentColor ?? colors.skeleton}>
           <Columns>
             {addCashEnabled && (
               <Column>
-                <BuyButton />
+                <Animated.View style={[expandStyle]}>
+                  <BuyButton />
+                </Animated.View>
               </Column>
             )}
             {swapEnabled && (
               <Column>
-                <SwapButton />
+                <Animated.View style={[expandStyle]}>
+                  <SwapButton />
+                </Animated.View>
               </Column>
             )}
             <Column>
-              <SendButton />
+              <Animated.View style={[expandStyle]}>
+                <SendButton />
+              </Animated.View>
             </Column>
             <Column>
-              <MoreButton />
+              <Animated.View style={[expandStyle]}>
+                <MoreButton />
+              </Animated.View>
             </Column>
           </Columns>
         </AccentColorProvider>

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -2,11 +2,6 @@ import Clipboard from '@react-native-community/clipboard';
 import lang from 'i18n-js';
 import * as React from 'react';
 import { PressableProps } from 'react-native';
-import Animated, {
-  useAnimatedStyle,
-  useDerivedValue,
-  withSpring,
-} from 'react-native-reanimated';
 import { ButtonPressAnimation } from '@/components/animations';
 import { enableActionsOnReadOnlyWallet } from '@/config';
 import {
@@ -36,30 +31,25 @@ import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { useRecoilState } from 'recoil';
 import { addressCopiedToastAtom } from '@/screens/wallet/WalletScreen';
 import config from '@/model/config';
-import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import { getAllActiveSessionsSync } from '@/utils/walletConnect';
+import { useTheme } from '@/theme';
 
 export const ProfileActionButtonsRowHeight = 80;
 
-export function ProfileActionButtonsRow() {
-  const { accentColor, loaded: accentColorLoaded } = useAccountAccentColor();
+type Props = {
+  accountColor?: number;
+  accountImage?: string | null;
+};
 
-  const scale = useDerivedValue(() => (accentColorLoaded ? 1 : 0.9));
-  const expandStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        scale: withSpring(scale.value, {
-          damping: 12,
-          restDisplacementThreshold: 0.001,
-          restSpeedThreshold: 0.001,
-          stiffness: 280,
-        }),
-      },
-    ],
-  }));
-
-  if (!accentColorLoaded) return null;
-
+export const ProfileActionButtonsRow: React.FC<Props> = ({
+  accountColor,
+  accountImage,
+}) => {
+  const { colors } = useTheme();
+  const accentColor =
+    accountImage || accountColor === undefined
+      ? colors.appleBlue
+      : colors.avatarBackgrounds[accountColor];
   const addCashEnabled = config.f2c_enabled;
   const swapEnabled = config.swagg_enabled;
 
@@ -70,34 +60,26 @@ export function ProfileActionButtonsRow() {
           <Columns>
             {addCashEnabled && (
               <Column>
-                <Animated.View style={[expandStyle]}>
-                  <BuyButton />
-                </Animated.View>
+                <BuyButton />
               </Column>
             )}
             {swapEnabled && (
               <Column>
-                <Animated.View style={[expandStyle]}>
-                  <SwapButton />
-                </Animated.View>
+                <SwapButton />
               </Column>
             )}
             <Column>
-              <Animated.View style={[expandStyle]}>
-                <SendButton />
-              </Animated.View>
+              <SendButton />
             </Column>
             <Column>
-              <Animated.View style={[expandStyle]}>
-                <MoreButton />
-              </Animated.View>
+              <MoreButton />
             </Column>
           </Columns>
         </AccentColorProvider>
       </Inset>
     </Box>
   );
-}
+};
 
 function ActionButton({
   children,

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -27,14 +27,16 @@ export const ProfileAvatarSize = 80;
 type Props = {
   size?: number;
   accountSymbol?: string | boolean;
-  accountColor?: number;
+  accountAccentColor: string;
   accountImage?: string | null;
+  hasAccountAccentColorLoaded?: boolean;
 };
 
 export const ProfileAvatarRow: React.FC<Props> = ({
   size = ProfileAvatarSize,
   accountSymbol,
-  accountColor,
+  accountAccentColor,
+  hasAccountAccentColorLoaded,
   accountImage,
 }) => {
   const {
@@ -53,15 +55,12 @@ export const ProfileAvatarRow: React.FC<Props> = ({
   const { colors } = useTheme();
   const { colorMode } = useColorMode();
 
-  const accentColor =
-    accountImage || accountColor === undefined
-      ? colors.black
-      : colors.avatarBackgrounds[accountColor];
+  const accentColor = hasAccountAccentColorLoaded
+    ? accountAccentColor
+    : colors.skeleton;
 
   const insets = useSafeAreaInsets();
   const position = useRecyclerAssetListPosition();
-
-  const hasLoaded = accountSymbol || accountImage;
 
   const animatedStyle = React.useMemo(
     () => ({
@@ -98,7 +97,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
   );
 
   const opacity = useDerivedValue(() => {
-    return hasLoaded ? 1 : 0;
+    return hasAccountAccentColorLoaded ? 1 : 0;
   });
   const fadeInStyle = useAnimatedStyle(() => {
     return {
@@ -110,7 +109,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
   });
 
   const scale = useDerivedValue(() => {
-    return hasLoaded ? 1 : 0.9;
+    return hasAccountAccentColorLoaded ? 1 : 0.9;
   });
   const expandStyle = useAnimatedStyle(() => {
     return {
@@ -149,7 +148,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
                 height={{ custom: size }}
                 justifyContent="center"
                 shadow={
-                  hasLoaded
+                  hasAccountAccentColorLoaded
                     ? {
                         custom: {
                           ios: [
@@ -185,7 +184,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
                 width={{ custom: size }}
               >
                 <>
-                  {!hasLoaded && (
+                  {!hasAccountAccentColorLoaded && (
                     <Cover alignHorizontal="center">
                       <Box height={{ custom: size }} width="full">
                         <Skeleton animated>
@@ -210,7 +209,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
                       />
                     ) : (
                       <EmojiAvatar
-                        accountColor={accountColor}
+                        accountAccentColor={accountAccentColor}
                         accountSymbol={accountSymbol}
                         size={size}
                       />
@@ -228,22 +227,15 @@ export const ProfileAvatarRow: React.FC<Props> = ({
 
 export function EmojiAvatar({
   size,
-  accountColor,
+  accountAccentColor,
   accountSymbol,
 }: {
   size: number;
-  accountColor?: number;
+  accountAccentColor: string;
   accountSymbol?: string | boolean;
 }) {
-  const { colors } = useTheme();
-
-  const accentColor =
-    accountColor !== undefined
-      ? colors.avatarBackgrounds[accountColor]
-      : colors.skeleton;
-
   return (
-    <AccentColorProvider color={accentColor}>
+    <AccentColorProvider color={accountAccentColor}>
       <Box
         background="accent"
         borderRadius={size / 2}

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -206,6 +206,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
                         height={{ custom: size }}
                         source={{ uri: accountImage }}
                         width={{ custom: size }}
+                        size={size}
                       />
                     ) : (
                       <EmojiAvatar

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -11,7 +11,11 @@ import { ButtonPressAnimation } from '@/components/animations';
 import { ImgixImage } from '@/components/images';
 import Skeleton from '@/components/skeleton/Skeleton';
 import { AccentColorProvider, Box, Cover, useColorMode } from '@/design-system';
-import { useLatestCallback, useOnAvatarPress } from '@/hooks';
+import {
+  useAccountProfile,
+  useLatestCallback,
+  useOnAvatarPress,
+} from '@/hooks';
 import { useTheme } from '@/theme';
 import { getFirstGrapheme } from '@/utils';
 import ContextMenu from '@/components/native-context-menu/contextMenu';
@@ -209,11 +213,7 @@ export const ProfileAvatarRow: React.FC<Props> = ({
                         size={size}
                       />
                     ) : (
-                      <EmojiAvatar
-                        accountAccentColor={accountAccentColor}
-                        accountSymbol={accountSymbol}
-                        size={size}
-                      />
+                      <EmojiAvatar size={size} />
                     )}
                   </Animated.View>
                 </>
@@ -226,17 +226,16 @@ export const ProfileAvatarRow: React.FC<Props> = ({
   );
 };
 
-export function EmojiAvatar({
-  size,
-  accountAccentColor,
-  accountSymbol,
-}: {
-  size: number;
-  accountAccentColor: string;
-  accountSymbol?: string | boolean;
-}) {
+export function EmojiAvatar({ size }: { size: number }) {
+  const { colors } = useTheme();
+  const { accountColor, accountSymbol } = useAccountProfile();
+
+  const accentColor =
+    accountColor !== undefined
+      ? colors.avatarBackgrounds[accountColor]
+      : colors.skeleton;
   return (
-    <AccentColorProvider color={accountAccentColor}>
+    <AccentColorProvider color={accentColor}>
       <Box
         background="accent"
         borderRadius={size / 2}

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileNameRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileNameRow.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   useForegroundColor,
 } from '@/design-system';
-import { useAccountProfile, useDimensions } from '@/hooks';
+import { useDimensions } from '@/hooks';
 import { useNavigation } from '@/navigation';
 import { abbreviateEnsForDisplay } from '@/utils/abbreviations';
 import Routes from '@rainbow-me/routes';
@@ -19,36 +19,41 @@ import { addressCopiedToastAtom } from '@/screens/wallet/WalletScreen';
 import { FloatingEmojis } from '@/components/floating-emojis';
 import { haptics } from '@/utils';
 import { Space } from '@/design-system/docs/system/tokens.css';
+import { useCallback, useMemo, useRef } from 'react';
 
 export const ProfileNameRowHeight = 16;
 
-export function ProfileNameRow({
+const HORIZONTAL_INSET = 19;
+const ACCOUNT_NAME_LEFT_OFFSET = 15;
+const CARET_ICON_WIDTH = 22;
+
+type Props = {
+  accountAddress?: string;
+  accountName?: string;
+  accountENS?: string;
+  disableOnPress?: boolean;
+  testIDPrefix?: string;
+};
+
+export const ProfileNameRow: React.FC<Props> = ({
+  accountAddress,
+  accountName,
+  accountENS,
   disableOnPress,
   testIDPrefix,
-}: {
-  disableOnPress?: any;
-  testIDPrefix?: string;
-}) {
-  // ////////////////////////////////////////////////////
-  // Account
-  const { accountENS, accountName } = useAccountProfile();
-
-  const onNewEmoji = React.useRef<() => void>();
-
-  // ////////////////////////////////////////////////////
-  // Name & press handler
-
+}) => {
+  const onNewEmoji = useRef<() => void>();
   const { navigate } = useNavigation();
   const [isToastActive, setToastActive] = useRecoilState(
     addressCopiedToastAtom
   );
-  const { accountAddress } = useAccountProfile();
 
-  const onPressName = () => {
+  const onPressName = useCallback(() => {
     if (disableOnPress) return;
     navigate(Routes.CHANGE_WALLET_SHEET);
-  };
-  const onLongPressName = React.useCallback(() => {
+  }, [disableOnPress, navigate]);
+
+  const onLongPressName = useCallback(() => {
     if (disableOnPress) return;
     if (!isToastActive) {
       setToastActive(true);
@@ -61,27 +66,17 @@ export function ProfileNameRow({
     Clipboard.setString(accountAddress);
   }, [accountAddress, disableOnPress, isToastActive, setToastActive]);
 
-  const name = accountENS
-    ? abbreviateEnsForDisplay(accountENS, 20)
-    : accountName;
-
-  // ////////////////////////////////////////////////////
-  // Colors
-
+  const name = useMemo(
+    () => (accountENS ? abbreviateEnsForDisplay(accountENS, 20) : accountName),
+    [accountName, accountENS]
+  );
   const iconColor = useForegroundColor('secondary60 (Deprecated)');
-
-  // ////////////////////////////////////////////////////
-  // Spacings
-
   const { width: deviceWidth } = useDimensions();
 
-  const horizontalInset = 19;
-  const accountNameLeftOffset = 15;
-  const caretIconWidth = 22;
   const maxWidth =
     deviceWidth -
-    (caretIconWidth + accountNameLeftOffset) -
-    horizontalInset * 2;
+    (CARET_ICON_WIDTH + ACCOUNT_NAME_LEFT_OFFSET) -
+    HORIZONTAL_INSET * 2;
 
   const hitSlop: Space = '16px';
   return (
@@ -110,7 +105,7 @@ export function ProfileNameRow({
                   color={iconColor}
                   height={9}
                   name="caretDownIcon"
-                  width={caretIconWidth}
+                  width={CARET_ICON_WIDTH}
                 />
               </Inline>
             </Inset>
@@ -130,4 +125,4 @@ export function ProfileNameRow({
       />
     </Box>
   );
-}
+};

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileStickyHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileStickyHeader.tsx
@@ -8,7 +8,17 @@ import { useRecyclerAssetListPosition } from '../core/Contexts';
 export const ProfileStickyHeaderHeight = 52;
 const visiblePosition = ios ? navbarHeight : navbarHeight + 80;
 
-export function ProfileStickyHeader() {
+type Props = {
+  accountName?: string;
+  accountENS?: string;
+  accountAddress?: string;
+};
+
+export const ProfileStickyHeader: React.FC<Props> = ({
+  accountName,
+  accountENS,
+  accountAddress,
+}) => {
   const position = useRecyclerAssetListPosition();
 
   const [disabled, setDisabled] = React.useState(true);
@@ -33,8 +43,11 @@ export function ProfileStickyHeader() {
         <ProfileNameRow
           disableOnPress={disabled}
           testIDPrefix="profile-name-sticky"
+          accountName={accountName}
+          accountENS={accountENS}
+          accountAddress={accountAddress}
         />
       </Box>
     </StickyHeader>
   );
-}
+};

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -38,12 +38,10 @@ const isTesting = IS_TESTING === 'true';
 
 const RegistrationAvatar = ({
   hasSeenExplainSheet,
-  onChangeAvatarUrl,
   onShowExplainSheet,
   enableNFTs,
 }: {
   hasSeenExplainSheet: boolean;
-  onChangeAvatarUrl: (url: string) => void;
   onShowExplainSheet: () => void;
   enableNFTs: boolean;
 }) => {
@@ -70,7 +68,6 @@ const RegistrationAvatar = ({
           ? initialAvatarUrl
           : values?.avatar;
       setAvatarUrl(avatarUrl);
-      onChangeAvatarUrl(avatarUrl ?? '');
     }
   }, [initialAvatarUrl, avatarUpdateAllowed]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -92,9 +89,6 @@ const RegistrationAvatar = ({
       setAvatarMetadata(image);
       setAvatarUrl(
         image?.tmpPath || asset?.lowResUrl || asset?.image_thumbnail_url || ''
-      );
-      onChangeAvatarUrl(
-        image?.path || asset?.lowResUrl || asset?.image_thumbnail_url || ''
       );
       if (asset) {
         const standard = asset.asset_contract?.schema_name || '';
@@ -118,7 +112,7 @@ const RegistrationAvatar = ({
         });
       }
     },
-    [onBlurField, onChangeAvatarUrl, setAvatarMetadata]
+    [onBlurField, setAvatarMetadata]
   );
 
   const {
@@ -136,7 +130,6 @@ const RegistrationAvatar = ({
     onChangeImage,
     onRemoveImage: () => {
       onRemoveField({ key: 'avatar' });
-      onChangeAvatarUrl('');
       setAvatarMetadata(undefined);
       setDisabled(false);
       setTimeout(() => {

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -38,10 +38,12 @@ const isTesting = IS_TESTING === 'true';
 
 const RegistrationAvatar = ({
   hasSeenExplainSheet,
+  onChangeAvatarUrl,
   onShowExplainSheet,
   enableNFTs,
 }: {
   hasSeenExplainSheet: boolean;
+  onChangeAvatarUrl: (url: string) => void;
   onShowExplainSheet: () => void;
   enableNFTs: boolean;
 }) => {
@@ -68,6 +70,7 @@ const RegistrationAvatar = ({
           ? initialAvatarUrl
           : values?.avatar;
       setAvatarUrl(avatarUrl);
+      onChangeAvatarUrl(avatarUrl ?? '');
     }
   }, [initialAvatarUrl, avatarUpdateAllowed]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -89,6 +92,9 @@ const RegistrationAvatar = ({
       setAvatarMetadata(image);
       setAvatarUrl(
         image?.tmpPath || asset?.lowResUrl || asset?.image_thumbnail_url || ''
+      );
+      onChangeAvatarUrl(
+        image?.path || asset?.lowResUrl || asset?.image_thumbnail_url || ''
       );
       if (asset) {
         const standard = asset.asset_contract?.schema_name || '';
@@ -112,7 +118,7 @@ const RegistrationAvatar = ({
         });
       }
     },
-    [onBlurField, setAvatarMetadata]
+    [onChangeAvatarUrl, onBlurField, setAvatarMetadata]
   );
 
   const {
@@ -130,6 +136,7 @@ const RegistrationAvatar = ({
     onChangeImage,
     onRemoveImage: () => {
       onRemoveField({ key: 'avatar' });
+      onChangeAvatarUrl('');
       setAvatarMetadata(undefined);
       setDisabled(false);
       setTimeout(() => {

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -10,7 +10,12 @@ import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
 } from '@/helpers/emojiHandler';
-import { useAccountSettings, useContacts, useENSAvatar } from '@/hooks';
+import {
+  useAccountSettings,
+  useContacts,
+  useENSAvatar,
+  usePersistentDominantColorFromImage,
+} from '@/hooks';
 import {
   addressHashedColorIndex,
   addressHashedEmoji,
@@ -78,7 +83,12 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const { data: avatar } = useENSAvatar(ens, { enabled: Boolean(ens) });
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
-  const accentColor = color || colors.avatarBackgrounds[colorIndex || 0];
+  const {
+    result: dominantColor,
+  } = usePersistentDominantColorFromImage(avatarUrl || '', { signUrl: true });
+
+  const accentColor =
+    dominantColor || color || colors.avatarBackgrounds[colorIndex || 0];
 
   return (
     <ProfileModal

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -1,22 +1,16 @@
 import lang from 'i18n-js';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Keyboard } from 'react-native';
-import { useNavigation } from '../../navigation/Navigation';
-import { useTheme } from '../../theme/ThemeContext';
+import { useNavigation } from '@/navigation';
+import { useTheme } from '@/theme';
 import { magicMemo } from '../../utils';
 import ProfileModal from './profile/ProfileModal';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import { maybeSignUri } from '@/handlers/imgix';
 import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
 } from '@/helpers/emojiHandler';
-import {
-  useAccountSettings,
-  useContacts,
-  useENSAvatar,
-  usePersistentDominantColorFromImage,
-} from '@/hooks';
+import { useAccountSettings, useContacts, useENSAvatar } from '@/hooks';
 import {
   addressHashedColorIndex,
   addressHashedEmoji,
@@ -84,12 +78,7 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const { data: avatar } = useENSAvatar(ens, { enabled: Boolean(ens) });
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    maybeSignUri(avatarUrl || '', { w: 200 }) || ''
-  );
-
-  const accentColor =
-    dominantColor || color || colors.avatarBackgrounds[colorIndex || 0];
+  const accentColor = color || colors.avatarBackgrounds[colorIndex || 0];
 
   return (
     <ProfileModal

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -1,5 +1,5 @@
 import { BlurView } from '@react-native-community/blur';
-import { useFocusEffect } from '@react-navigation/core';
+import { useFocusEffect } from '@react-navigation/native';
 import c from 'chroma-js';
 import lang from 'i18n-js';
 import React, { ReactNode, useCallback, useMemo, useRef } from 'react';
@@ -57,7 +57,7 @@ import { Network } from '@/helpers';
 import { buildUniqueTokenName } from '@/helpers/assets';
 import { ENS_RECORDS, REGISTRATION_MODES } from '@/helpers/ens';
 import {
-  useAccountProfile,
+  useAccountSettings,
   useBooleanState,
   useDimensions,
   useENSProfile,
@@ -251,8 +251,7 @@ const UniqueTokenExpandedState = ({
   external,
 }: UniqueTokenExpandedStateProps) => {
   const isSupportedOnRainbowWeb = getIsSupportedOnRainbowWeb(asset.network);
-
-  const { accountAddress } = useAccountProfile();
+  const { accountAddress } = useAccountSettings();
   const { height: deviceHeight, width: deviceWidth } = useDimensions();
   const { navigate, setOptions } = useNavigation();
   const { colors, isDarkMode } = useTheme();
@@ -358,7 +357,6 @@ const UniqueTokenExpandedState = ({
   const rainbowWebUrl = buildRainbowUrl(asset, cleanENSName, accountAddress);
 
   const imageColor =
-    // @ts-expect-error image_url could be null or undefined?
     usePersistentDominantColorFromImage(asset.lowResUrl).result ||
     colors.paleBlue;
 

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -57,7 +57,7 @@ import { Network } from '@/helpers';
 import { buildUniqueTokenName } from '@/helpers/assets';
 import { ENS_RECORDS, REGISTRATION_MODES } from '@/helpers/ens';
 import {
-  useAccountSettings,
+  useAccountProfile,
   useBooleanState,
   useDimensions,
   useENSProfile,
@@ -251,7 +251,7 @@ const UniqueTokenExpandedState = ({
   external,
 }: UniqueTokenExpandedStateProps) => {
   const isSupportedOnRainbowWeb = getIsSupportedOnRainbowWeb(asset.network);
-  const { accountAddress } = useAccountSettings();
+  const { accountAddress } = useAccountProfile();
   const { height: deviceHeight, width: deviceWidth } = useDimensions();
   const { navigate, setOptions } = useNavigation();
   const { colors, isDarkMode } = useTheme();

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { SessionTypes } from '@walletconnect/types';
 import RadialGradient from 'react-native-radial-gradient';
 
-import { RequestVendorLogoIcon } from '../coin-icon';
+import { RequestVendorLogoIcon, CoinIcon } from '../coin-icon';
 import { ContactAvatar } from '../contacts';
 import ImageAvatar from '../contacts/ImageAvatar';
 import { ContextMenuButton } from '../context-menu';
@@ -25,7 +25,6 @@ import { logger, RainbowError } from '@/logger';
 import { updateSession, disconnectSession } from '@/utils/walletConnect';
 import { Box, Inline } from '@/design-system';
 import ChainBadge from '@/components/coin-icon/ChainBadge';
-import { CoinIcon } from '@/components/coin-icon';
 import { ETH_ADDRESS, ETH_SYMBOL } from '@/references';
 import { AssetType } from '@/entities';
 import { Network } from '@/helpers';
@@ -237,6 +236,7 @@ export function WalletConnectV2ListItem({
                 ) : (
                   <ContactAvatar
                     color={
+                      approvalAccountInfo.accountColor !== undefined &&
                       isNaN(approvalAccountInfo.accountColor)
                         ? colors.skeleton
                         : approvalAccountInfo.accountColor

--- a/src/entities/nativeCurrencyTypes.ts
+++ b/src/entities/nativeCurrencyTypes.ts
@@ -1,7 +1,7 @@
 import { mapValues } from 'lodash';
-import nativeCurrencyReference from '../references/native-currencies.json';
+import { supportedNativeCurrencies } from '@/references';
 
-export type NativeCurrencyKey = keyof typeof nativeCurrencyReference;
+export type NativeCurrencyKey = keyof typeof supportedNativeCurrencies;
 type NativeCurrencyKeysMap = { [Key in NativeCurrencyKey]: Key };
 
 // We can't dynamically generate an enum from the JSON data, but we can
@@ -11,6 +11,6 @@ type NativeCurrencyKeysMap = { [Key in NativeCurrencyKey]: Key };
  * An enum of native currencies such as "USD" or "ETH".
  */
 export const NativeCurrencyKeys = mapValues(
-  nativeCurrencyReference,
+  supportedNativeCurrencies,
   (_value, key) => key
 ) as NativeCurrencyKeysMap;

--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -93,3 +93,25 @@ query getRewardsDataForWallet($address: String!) {
     }
   }
 }
+
+query reverseResolveENSProfile(
+  $chainID: Int!
+  $address: String!
+  $fields: [String!]
+) {
+  reverseResolveENSProfile(
+    chainID: $chainID
+    address: $address
+    fields: $fields
+  ) {
+    name
+    address
+    resolverAddress
+    reverseResolverAddress
+    chainID
+    fields {
+      key
+      value
+    }
+  }
+}

--- a/src/helpers/accountInfo.ts
+++ b/src/helpers/accountInfo.ts
@@ -1,41 +1,42 @@
 import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
-} from '../helpers/emojiHandler';
-import { address } from '../utils/abbreviations';
-import { addressHashedEmoji, isValidImagePath } from '../utils/profileUtils';
+} from '@/helpers/emojiHandler';
+import { address } from '@/utils/abbreviations';
+import { addressHashedEmoji, isValidImagePath } from '@/utils/profileUtils';
+import { RainbowAccount, RainbowWallet } from '@/model/wallet';
 
 export function getAccountProfileInfo(
-  selectedWallet: any,
-  walletNames: any,
-  accountAddress: any
+  selectedWallet: RainbowWallet | undefined,
+  walletNames: { [p: string]: string },
+  accountAddress: string
 ) {
   if (!selectedWallet) {
-    return {};
-  }
-
-  if (!accountAddress) {
-    return {};
+    return {
+      accountAddress,
+    };
   }
 
   if (!selectedWallet?.addresses?.length) {
-    return {};
+    return { accountAddress };
   }
 
   const accountENS = walletNames?.[accountAddress];
 
   const selectedAccount = selectedWallet.addresses.find(
-    (account: any) => account.address === accountAddress
+    (account: RainbowAccount) => account.address === accountAddress
   );
 
   if (!selectedAccount) {
-    return {};
+    return {
+      accountAddress,
+    };
   }
   const { label, color, image } = selectedAccount;
 
   const labelWithoutEmoji = label && removeFirstEmojiFromString(label);
 
-  const accountName =
+  const accountName: string | undefined =
     labelWithoutEmoji || accountENS || address(accountAddress, 4, 4);
 
   const emojiAvatar = returnStringFirstEmoji(label);

--- a/src/helpers/bigNumberFormat.ts
+++ b/src/helpers/bigNumberFormat.ts
@@ -1,15 +1,15 @@
-import { memoFn } from '../utils/memoFn';
-import { supportedNativeCurrencies } from '@/references';
+import { memoFn } from '@/utils/memoFn';
 import {
   convertAmountToNativeDisplay,
   divide,
   greaterThan,
 } from '@/helpers/utilities';
+import { NativeCurrencyKey } from '@/entities';
 
 export const bigNumberFormat = memoFn(
   (
     value: string | number,
-    nativeCurrency: keyof typeof supportedNativeCurrencies,
+    nativeCurrency: NativeCurrencyKey,
     skipDecimals: boolean
   ) => {
     let ret;

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -49,6 +49,7 @@ const uniqueTokensSelector = (state: any) => state.uniqueTokens;
 const uniswapSelector = (state: any) => state.uniswap;
 const uniswapTotalSelector = (state: any) => state.uniswapTotal;
 const listTypeSelector = (state: any) => state.listType;
+const profileSelector = (state: any) => state.profile;
 
 const buildBriefWalletSections = (
   balanceSectionData: any,
@@ -148,7 +149,7 @@ const withBriefBalanceSection = (
   collectibles: any,
   savingsSection: any,
   uniswapTotal: any,
-  uniqueTokens: any
+  profile: any
 ) => {
   const { briefAssets, totalBalancesValue } = buildBriefCoinsList(
     sortedAssets,
@@ -187,7 +188,9 @@ const withBriefBalanceSection = (
     {
       type: 'PROFILE_STICKY_HEADER',
       uid: 'assets-profile-header-compact',
-      value: totalValue,
+      accountName: profile.accountName,
+      accountENS: profile.accountENS,
+      accountAddress: profile.accountAddress,
     },
     {
       type: 'PROFILE_AVATAR_ROW_SPACE_BEFORE',
@@ -196,6 +199,9 @@ const withBriefBalanceSection = (
     {
       type: 'PROFILE_AVATAR_ROW',
       uid: 'profile-avatar',
+      accountSymbol: profile.accountSymbol,
+      accountColor: profile.accountColor,
+      accountImage: profile.accountImage,
     },
     {
       type: 'PROFILE_AVATAR_ROW_SPACE_AFTER',
@@ -204,6 +210,9 @@ const withBriefBalanceSection = (
     {
       type: 'PROFILE_NAME_ROW',
       uid: 'profile-name',
+      accountName: profile.accountName,
+      accountENS: profile.accountENS,
+      accountAddress: profile.accountAddress,
     },
     {
       type: 'PROFILE_NAME_ROW_SPACE_AFTER',
@@ -225,6 +234,8 @@ const withBriefBalanceSection = (
     {
       type: 'PROFILE_ACTION_BUTTONS_ROW',
       uid: 'profile-action-buttons',
+      accountColor: profile.accountColor,
+      accountImage: profile.accountImage,
       value: totalValue,
     },
     hasTokens
@@ -298,6 +309,7 @@ const briefBalanceSectionSelector = createSelector(
     uniqueTokensSelector,
     briefBalanceSavingsSectionSelector,
     uniswapTotalSelector,
+    profileSelector,
   ],
   withBriefBalanceSection
 );

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -200,8 +200,9 @@ const withBriefBalanceSection = (
       type: 'PROFILE_AVATAR_ROW',
       uid: 'profile-avatar',
       accountSymbol: profile.accountSymbol,
-      accountColor: profile.accountColor,
       accountImage: profile.accountImage,
+      accountAccentColor: profile.accountAccentColor,
+      hasAccountAccentColorLoaded: profile.hasAccountAccentColorLoaded,
     },
     {
       type: 'PROFILE_AVATAR_ROW_SPACE_AFTER',
@@ -234,8 +235,9 @@ const withBriefBalanceSection = (
     {
       type: 'PROFILE_ACTION_BUTTONS_ROW',
       uid: 'profile-action-buttons',
-      accountColor: profile.accountColor,
       accountImage: profile.accountImage,
+      accountAccentColor: profile.accountAccentColor,
+      hasAccountAccentColorLoaded: profile.hasAccountAccentColorLoaded,
       value: totalValue,
     },
     hasTokens

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -710,7 +710,7 @@ const formatTotalRegistrationCost = (
   wei: string,
   nativeCurrency: any,
   nativeAssetPrice: any,
-  skipDecimals: boolean = false
+  skipDecimals = false
 ) => {
   const networkFeeInEth = fromWei(wei);
   const eth = handleSignificantDecimals(networkFeeInEth, 3);
@@ -794,11 +794,6 @@ const formatRentPrice = (
   };
 };
 
-const accentColorAtom = atom({
-  default: colors.purple,
-  key: 'ens.accentColor',
-});
-
 export {
   generateSalt,
   getENSRecordKeys,
@@ -816,5 +811,4 @@ export {
   formatEstimatedNetworkFee,
   formatTotalRegistrationCost,
   formatRentPrice,
-  accentColorAtom,
 };

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -794,6 +794,11 @@ const formatRentPrice = (
   };
 };
 
+const accentColorAtom = atom({
+  default: colors.purple,
+  key: 'ens.accentColor',
+});
+
 export {
   generateSalt,
   getENSRecordKeys,
@@ -811,4 +816,5 @@ export {
   formatEstimatedNetworkFee,
   formatTotalRegistrationCost,
   formatRentPrice,
+  accentColorAtom,
 };

--- a/src/helpers/uniswapLiquidityTokenInfoSelector.ts
+++ b/src/helpers/uniswapLiquidityTokenInfoSelector.ts
@@ -1,7 +1,7 @@
 import { ChainId, WRAPPED_ASSET } from '@rainbow-me/swaps';
 import { compact, isEmpty, orderBy, sumBy } from 'lodash';
 import { createSelector } from 'reselect';
-import { Asset, ParsedAddressAsset } from '@/entities';
+import { Asset, NativeCurrencyKey, ParsedAddressAsset } from '@/entities';
 import { parseAssetNative } from '@/parsers';
 import { AppState } from '@/redux/store';
 import { PositionsState, UniswapPosition } from '@/redux/usersPositions';
@@ -68,7 +68,7 @@ const switchWethToEth = (token: Token, chainId: ChainId): Token => {
 const transformPool = (
   liquidityToken: ParsedAddressAsset | undefined,
   position: UniswapPosition,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   chainId: ChainId
 ): UniswapPool | null => {
   if (isEmpty(position)) {
@@ -135,7 +135,7 @@ const transformPool = (
 const buildUniswapCards = (
   accountAddress: string,
   chainId: number,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   uniswapLiquidityTokens: ParsedAddressAsset[],
   allUniswapLiquidityPositions: PositionsState
 ): UniswapCard => {

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -30,7 +30,7 @@ export function useAccountAccentColor(): ReturnType {
   );
 
   return {
-    accentColor: accentColor,
+    accentColor,
     loaded: hasLoaded,
   };
 }

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -1,30 +1,22 @@
-import { maybeSignUri } from '@/handlers/imgix';
 import { useTheme } from '@/theme';
-import {
-  useAccountProfile,
-  usePersistentDominantColorFromImage,
-} from '@/hooks';
+import { useAccountProfile } from '@/hooks';
 
-export function useAccountAccentColor() {
+type ReturnType = {
+  accentColor: string;
+  loaded: boolean;
+};
+
+export function useAccountAccentColor(): ReturnType {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
-  const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    maybeSignUri(accountImage ?? '', { w: 200 }) ?? ''
-  );
-
   const { colors } = useTheme();
-  let accentColor = colors.appleBlue;
-  if (accountImage) {
-    accentColor = dominantColor || colors.appleBlue;
-  } else if (typeof accountColor === 'number') {
-    accentColor = colors.avatarBackgrounds[accountColor];
-  }
-
-  const hasImageColorLoaded = state === 2 || state === 3;
-  const hasLoaded = accountImage || accountSymbol || hasImageColorLoaded;
+  const hasLoaded = Boolean(accountImage || accountSymbol);
 
   return {
-    accentColor,
+    accentColor:
+      accountImage || accountColor === undefined
+        ? colors.appleBlue
+        : colors.avatarBackgrounds[accountColor],
     loaded: hasLoaded,
   };
 }

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -1,5 +1,8 @@
 import { useTheme } from '@/theme';
-import { useAccountProfile } from '@/hooks';
+import {
+  useAccountProfile,
+  usePersistentDominantColorFromImage,
+} from '@/hooks';
 
 type ReturnType = {
   accentColor: string;
@@ -9,14 +12,25 @@ type ReturnType = {
 export function useAccountAccentColor(): ReturnType {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
+  const {
+    result: dominantColor,
+    state,
+  } = usePersistentDominantColorFromImage(accountImage, { signUrl: true });
+
   const { colors } = useTheme();
-  const hasLoaded = Boolean(accountImage || accountSymbol);
+  let accentColor = colors.appleBlue;
+  if (accountImage) {
+    accentColor = dominantColor || colors.appleBlue;
+  } else if (typeof accountColor === 'number') {
+    accentColor = colors.avatarBackgrounds[accountColor];
+  }
+  const hasImageColorLoaded = state === 2 || state === 3;
+  const hasLoaded = Boolean(
+    accountImage || accountSymbol || hasImageColorLoaded
+  );
 
   return {
-    accentColor:
-      accountImage || accountColor === undefined
-        ? colors.appleBlue
-        : colors.avatarBackgrounds[accountColor],
+    accentColor: accentColor,
     loaded: hasLoaded,
   };
 }

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -4,12 +4,7 @@ import {
   usePersistentDominantColorFromImage,
 } from '@/hooks';
 
-type ReturnType = {
-  accentColor: string;
-  loaded: boolean;
-};
-
-export function useAccountAccentColor(): ReturnType {
+export function useAccountAccentColor() {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
   const {
@@ -21,7 +16,11 @@ export function useAccountAccentColor(): ReturnType {
   let accentColor = colors.appleBlue;
   if (accountImage) {
     accentColor = dominantColor || colors.appleBlue;
-  } else if (typeof accountColor === 'number') {
+  } else if (
+    typeof accountColor === 'number' &&
+    accountColor >= 0 &&
+    accountColor < colors.avatarBackgrounds.length
+  ) {
     accentColor = colors.avatarBackgrounds[accountColor];
   }
   const hasImageColorLoaded = state === 2 || state === 3;

--- a/src/hooks/useAccountSettings.ts
+++ b/src/hooks/useAccountSettings.ts
@@ -2,7 +2,7 @@ import lang from 'i18n-js';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
-import { updateLanguageLocale, Language } from '../languages';
+import { Language, updateLanguageLocale } from '@/languages';
 import {
   settingsChangeAppIcon as changeAppIcon,
   settingsChangeFlashbotsEnabled as changeFlashbotsEnabled,
@@ -12,6 +12,7 @@ import {
 } from '../redux/settings';
 import { AppState } from '@/redux/store';
 import { supportedNativeCurrencies } from '@/references';
+import { NativeCurrencyKey } from '@/entities';
 
 const languageSelector = (state: AppState) => state.settings.language;
 
@@ -46,36 +47,36 @@ export default function useAccountSettings() {
       language,
       nativeCurrency,
       nativeCurrencySymbol:
-        supportedNativeCurrencies[
-          nativeCurrency as keyof typeof supportedNativeCurrencies
-        ].symbol,
+        supportedNativeCurrencies[nativeCurrency as NativeCurrencyKey].symbol,
       network,
       testnetsEnabled,
     })
   );
 
   const settingsChangeLanguage = useCallback(
-    language => dispatch(changeLanguage(language)),
+    (language: string) => dispatch(changeLanguage(language)),
     [dispatch]
   );
 
   const settingsChangeAppIcon = useCallback(
-    appIcon => dispatch(changeAppIcon(appIcon)),
+    (appIcon: string) => dispatch(changeAppIcon(appIcon)),
     [dispatch]
   );
 
   const settingsChangeNativeCurrency = useCallback(
-    currency => dispatch(changeNativeCurrency(currency)),
+    (currency: NativeCurrencyKey) => dispatch(changeNativeCurrency(currency)),
     [dispatch]
   );
 
   const settingsChangeTestnetsEnabled = useCallback(
-    testnetsEnabled => dispatch(changeTestnetsEnabled(testnetsEnabled)),
+    (testnetsEnabled: boolean) =>
+      dispatch(changeTestnetsEnabled(testnetsEnabled)),
     [dispatch]
   );
 
   const settingsChangeFlashbotsEnabled = useCallback(
-    flashbotsEnabled => dispatch(changeFlashbotsEnabled(flashbotsEnabled)),
+    (flashbotsEnabled: boolean) =>
+      dispatch(changeFlashbotsEnabled(flashbotsEnabled)),
     [dispatch]
   );
 

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -7,17 +7,23 @@ import {
   UseQueryData,
 } from '@/react-query';
 
-export const ensAvatarQueryKey = (name: string) => ['ens-avatar', name];
+export const ensAvatarQueryKey = (name?: string) => [
+  'ens-avatar',
+  name ?? 'undefined',
+];
 
 const STALE_TIME = 10000;
 
 export async function fetchENSAvatar(
-  name: string,
+  name?: string,
   {
     cacheFirst,
     swallowError,
   }: { cacheFirst?: boolean; swallowError?: boolean } = {}
 ) {
+  if (name === undefined) {
+    return undefined;
+  }
   try {
     const cachedAvatar = await getENSData('avatar', name);
     if (cachedAvatar) {
@@ -45,7 +51,7 @@ export async function prefetchENSAvatar(
 }
 
 export default function useENSAvatar(
-  name: string,
+  name?: string,
   config?: QueryConfigDeprecated<typeof fetchENSAvatar>
 ) {
   return useQuery<UseQueryData<typeof fetchENSAvatar>>(

--- a/src/hooks/useENSOwner.ts
+++ b/src/hooks/useENSOwner.ts
@@ -8,11 +8,17 @@ import {
   UseQueryData,
 } from '@/react-query';
 
-export const ensOwnerQueryKey = (name: string) => ['ens-owner', name];
+export const ensOwnerQueryKey = (name?: string) => [
+  'ens-owner',
+  name ?? 'undefined',
+];
 
 const STALE_TIME = 10000;
 
-export async function fetchENSOwner(name: string) {
+export async function fetchENSOwner(name?: string) {
+  if (name === undefined) {
+    return undefined;
+  }
   const cachedOwner = await getENSData('owner', name);
   if (cachedOwner) {
     queryClient.setQueryData(ensOwnerQueryKey(name), cachedOwner);
@@ -31,7 +37,7 @@ export async function prefetchENSOwner(name: string) {
 }
 
 export default function useENSOwner(
-  name: string,
+  name?: string,
   config?: QueryConfigDeprecated<typeof fetchENSOwner>
 ) {
   const { accountAddress } = useAccountSettings();

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -142,6 +142,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
   }, [navigate]);
 
   const onAvatarWebProfile = useCallback(() => {
+    if (!accountENS) return;
     const rainbowURL = buildRainbowUrl(null, accountENS, accountAddress);
     if (rainbowURL) {
       Linking.openURL(rainbowURL);
@@ -161,6 +162,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
   }, [accountENS, navigate]);
 
   const onAvatarEditProfile = useCallback(() => {
+    if (!accountENS) return;
     startRegistration(accountENS, REGISTRATION_MODES.EDIT);
     navigate(Routes.REGISTER_ENS_NAVIGATOR, {
       ensName: accountENS,

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { MMKV, useMMKVString } from 'react-native-mmkv';
-import { STORAGE_IDS } from '@rainbow-me/model/mmkv';
-import { getDominantColorFromImage } from '@rainbow-me/utils';
+import { STORAGE_IDS } from '@/model/mmkv';
+import { getDominantColorFromImage } from '@/utils';
 import { maybeSignUri } from '@/handlers/imgix';
 import usePrevious from './usePrevious';
 

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -9,6 +9,7 @@ import useSavingsAccount from './useSavingsAccount';
 import useSendableUniqueTokens from './useSendableUniqueTokens';
 import useShowcaseTokens from './useShowcaseTokens';
 import useSortedAccountAssets from './useSortedAccountAssets';
+import useAccountProfile from './useAccountProfile';
 import useWallets from './useWallets';
 import { AppState } from '@/redux/store';
 import { buildBriefWalletSectionsSelector } from '@/helpers/buildWalletSections';
@@ -23,6 +24,7 @@ export default function useWalletSectionsData({
   const isWalletEthZero = useIsWalletEthZero();
 
   const { language, network, nativeCurrency } = useAccountSettings();
+  const profile = useAccountProfile();
   const sendableUniqueTokens = useSendableUniqueTokens();
   const allUniqueTokens = useSelector(
     (state: AppState) => state.uniqueTokens.uniqueTokens
@@ -51,6 +53,7 @@ export default function useWalletSectionsData({
       nativeCurrency,
       network,
       pinnedCoins,
+      profile,
       savings,
       ...sortedAccountData,
       ...sendableUniqueTokens,
@@ -87,13 +90,14 @@ export default function useWalletSectionsData({
     nativeCurrency,
     network,
     pinnedCoins,
+    profile,
     refetchSavings,
     savings,
+    sendableUniqueTokens,
     shouldRefetchSavings,
     showcaseTokens,
     sortedAccountData,
     type,
-    sendableUniqueTokens,
     uniswap,
   ]);
   return walletSections;

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -14,6 +14,7 @@ import useWallets from './useWallets';
 import { AppState } from '@/redux/store';
 import { buildBriefWalletSectionsSelector } from '@/helpers/buildWalletSections';
 import { readableUniswapSelector } from '@/helpers/uniswapLiquidityTokenInfoSelector';
+import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 
 export default function useWalletSectionsData({
   type,
@@ -25,6 +26,10 @@ export default function useWalletSectionsData({
 
   const { language, network, nativeCurrency } = useAccountSettings();
   const profile = useAccountProfile();
+  const {
+    loaded: hasAccountAccentColorLoaded,
+    accentColor: accountAccentColor,
+  } = useAccountAccentColor();
   const sendableUniqueTokens = useSendableUniqueTokens();
   const allUniqueTokens = useSelector(
     (state: AppState) => state.uniqueTokens.uniqueTokens
@@ -53,7 +58,11 @@ export default function useWalletSectionsData({
       nativeCurrency,
       network,
       pinnedCoins,
-      profile,
+      profile: {
+        ...profile,
+        accountAccentColor,
+        hasAccountAccentColorLoaded,
+      },
       savings,
       ...sortedAccountData,
       ...sendableUniqueTokens,

--- a/src/navigation/RegisterENSNavigator.tsx
+++ b/src/navigation/RegisterENSNavigator.tsx
@@ -13,7 +13,7 @@ import ScrollPagerWrapper from './ScrollPagerWrapper';
 import { sharedCoolModalTopOffset } from './config';
 import { avatarMetadataAtom } from '@/components/ens-registration/RegistrationAvatar/RegistrationAvatar';
 import { Box } from '@/design-system';
-import { REGISTRATION_MODES } from '@/helpers/ens';
+import { accentColorAtom, REGISTRATION_MODES } from '@/helpers/ens';
 import {
   useDimensions,
   useENSRegistration,
@@ -58,6 +58,7 @@ export default function RegisterENSNavigator() {
 
   const { height: deviceHeight, isSmallPhone } = useDimensions();
 
+  const setAccentColor = useSetRecoilState(accentColorAtom);
   const setAvatarMetadata = useSetRecoilState(avatarMetadataAtom);
 
   const { colors } = useTheme();
@@ -115,6 +116,7 @@ export default function RegisterENSNavigator() {
     () => () => {
       removeRecordByKey('avatar');
       setAvatarMetadata(undefined);
+      setAccentColor(colors.purple);
       clearValues();
       clearCurrentRegistrationName();
     },
@@ -123,6 +125,7 @@ export default function RegisterENSNavigator() {
       clearValues,
       colors.purple,
       removeRecordByKey,
+      setAccentColor,
       setAvatarMetadata,
     ]
   );

--- a/src/navigation/RegisterENSNavigator.tsx
+++ b/src/navigation/RegisterENSNavigator.tsx
@@ -1,4 +1,4 @@
-import { useRoute } from '@react-navigation/core';
+import { useRoute } from '@react-navigation/native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Dimensions, StatusBar } from 'react-native';
@@ -13,7 +13,7 @@ import ScrollPagerWrapper from './ScrollPagerWrapper';
 import { sharedCoolModalTopOffset } from './config';
 import { avatarMetadataAtom } from '@/components/ens-registration/RegistrationAvatar/RegistrationAvatar';
 import { Box } from '@/design-system';
-import { accentColorAtom, REGISTRATION_MODES } from '@/helpers/ens';
+import { REGISTRATION_MODES } from '@/helpers/ens';
 import {
   useDimensions,
   useENSRegistration,
@@ -58,7 +58,6 @@ export default function RegisterENSNavigator() {
 
   const { height: deviceHeight, isSmallPhone } = useDimensions();
 
-  const setAccentColor = useSetRecoilState(accentColorAtom);
   const setAvatarMetadata = useSetRecoilState(avatarMetadataAtom);
 
   const { colors } = useTheme();
@@ -116,7 +115,6 @@ export default function RegisterENSNavigator() {
     () => () => {
       removeRecordByKey('avatar');
       setAvatarMetadata(undefined);
-      setAccentColor(colors.purple);
       clearValues();
       clearCurrentRegistrationName();
     },
@@ -125,7 +123,6 @@ export default function RegisterENSNavigator() {
       clearValues,
       colors.purple,
       removeRecordByKey,
-      setAccentColor,
       setAvatarMetadata,
     ]
   );

--- a/src/navigation/effects.js
+++ b/src/navigation/effects.js
@@ -12,6 +12,7 @@ import {
   ProfileAvatarSize,
 } from '@/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow';
 import { HARDWARE_WALLET_TX_NAVIGATOR_SHEET_HEIGHT } from './HardwareWalletTxNavigator';
+import { useAccountProfile } from '@/hooks';
 
 const statusBarHeight = getStatusBarHeight(true);
 export const sheetVerticalOffset = statusBarHeight;

--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -13,13 +13,14 @@ import {
   LegacyGasFeesBySpeed,
   LegacySelectedGasFee,
   MaxPriorityFeeSuggestions,
+  NativeCurrencyKey,
   Numberish,
   RainbowMeteorologyData,
   SelectedGasFee,
 } from '@/entities';
 import { toHex } from '@/handlers/web3';
 import { getMinimalTimeUnitStringForMs } from '@/helpers/time';
-import { ethUnits, supportedNativeCurrencies, timeUnits } from '@/references';
+import { ethUnits, timeUnits } from '@/references';
 import {
   add,
   convertRawAmountToBalance,
@@ -240,7 +241,7 @@ export const parseLegacyGasFeesBySpeed = (
   legacyGasFees: LegacyGasFeeParamsBySpeed,
   gasLimit: BigNumberish,
   priceUnit: BigNumberish,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   l1GasFeeOptimism: BigNumber | null = null
 ): LegacyGasFeesBySpeed => {
   const gasFeesBySpeed = GasSpeedOrder.map(speed => {
@@ -264,7 +265,7 @@ export const parseGasFees = (
   baseFeePerGas: GasFeeParam,
   gasLimit: BigNumberish,
   priceUnit: BigNumberish,
-  nativeCurrency: keyof typeof supportedNativeCurrencies
+  nativeCurrency: NativeCurrencyKey
 ) => {
   const { maxPriorityFeePerGas, maxBaseFee } = gasFeeParams || {};
   const priorityFee = maxPriorityFeePerGas?.amount || 0;
@@ -302,7 +303,7 @@ export const parseGasFeesBySpeed = (
   baseFeePerGas: GasFeeParam,
   gasLimit: BigNumberish,
   priceUnit: BigNumberish,
-  nativeCurrency: keyof typeof supportedNativeCurrencies
+  nativeCurrency: NativeCurrencyKey
 ): GasFeesBySpeed => {
   const gasFeesBySpeed = GasSpeedOrder.map(speed =>
     parseGasFees(
@@ -320,7 +321,7 @@ const getTxFee = (
   gasPrice: BigNumberish,
   gasLimit: BigNumberish,
   priceUnit: BigNumberish,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   l1GasFeeOptimism: BigNumber | null = null
 ) => {
   let amount = multiply(gasPrice, gasLimit);

--- a/src/parsers/newTransaction.ts
+++ b/src/parsers/newTransaction.ts
@@ -1,12 +1,13 @@
 import { getDescription, getTitle } from './transactions';
 import {
+  NativeCurrencyKey,
   NewTransactionOrAddCashTransaction,
   RainbowTransaction,
   TransactionStatus,
   TransactionType,
 } from '@/entities';
 import { isL2Network } from '@/handlers/web3';
-import { ETH_ADDRESS, supportedNativeCurrencies } from '@/references';
+import { ETH_ADDRESS } from '@/references';
 import {
   convertAmountAndPriceToNativeDisplay,
   convertAmountToBalanceDisplay,
@@ -21,7 +22,7 @@ import { ethereumUtils } from '@/utils';
  */
 export const parseNewTransaction = async (
   txDetails: NewTransactionOrAddCashTransaction,
-  nativeCurrency: keyof typeof supportedNativeCurrencies
+  nativeCurrency: NativeCurrencyKey
 ): Promise<RainbowTransaction> => {
   let balance = null;
   const {

--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -69,7 +69,7 @@ const dataFromLastTxHash = (
 export const parseTransactions = async (
   transactionData: ZerionTransaction[],
   accountAddress: EthereumAddress,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   existingTransactions: RainbowTransaction[],
   pendingTransactions: RainbowTransaction[],
   purchaseTransactions: RainbowTransaction[],
@@ -311,7 +311,7 @@ const overrideSwap = (tx: ZerionTransaction): ZerionTransaction => {
 
 const parseTransactionWithEmptyChanges = async (
   txn: ZerionTransaction,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   network: Network
 ) => {
   const methodName = await getTransactionMethodName(txn);
@@ -361,7 +361,7 @@ const parseTransactionWithEmptyChanges = async (
 
 const parseTransaction = async (
   transaction: ZerionTransaction,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   purchaseTransactionsHashes: string[],
   network: Network
 ): Promise<RainbowTransaction[]> => {

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -16,6 +16,7 @@ import {
   LegacyGasFeeParamsBySpeed,
   LegacyGasFeesBySpeed,
   LegacySelectedGasFee,
+  NativeCurrencyKey,
   RainbowMeteorologyData,
   RainbowMeteorologyLegacyData,
   SelectedGasFee,
@@ -40,7 +41,7 @@ import {
   parseRainbowMeteorologyData,
   weiToGwei,
 } from '@/parsers';
-import { ethUnits, supportedNativeCurrencies } from '@/references';
+import { ethUnits } from '@/references';
 import { multiply } from '@/helpers/utilities';
 import { ethereumUtils, gasUtils } from '@/utils';
 
@@ -132,7 +133,7 @@ const getUpdatedGasFeeParams = (
   currentBaseFee: GasFeeParam,
   gasFeeParamsBySpeed: GasFeeParamsBySpeed | LegacyGasFeeParamsBySpeed,
   gasLimit: string,
-  nativeCurrency: keyof typeof supportedNativeCurrencies,
+  nativeCurrency: NativeCurrencyKey,
   selectedGasFeeOption: string,
   txNetwork: Network,
   l1GasFeeOptimism: BigNumber | null = null

--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -5,7 +5,6 @@ import { Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { updateLanguageLocale, Language } from '../languages';
 import { analytics } from '@/analytics';
-import { NativeCurrencyKeys } from '@/entities';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 
 import {
@@ -27,9 +26,9 @@ import { Network } from '@/helpers/networkTypes';
 import { dataResetState } from '@/redux/data';
 import { explorerClearState, explorerInit } from '@/redux/explorer';
 import { AppState } from '@/redux/store';
-import { supportedNativeCurrencies } from '@/references';
 import { ethereumUtils } from '@/utils';
 import logger from '@/utils/logger';
+import { NativeCurrencyKey, NativeCurrencyKeys } from '@/entities';
 
 // -- Constants ------------------------------------------------------------- //
 const SETTINGS_UPDATE_SETTINGS_ADDRESS =
@@ -60,7 +59,7 @@ interface SettingsState {
   chainId: number;
   flashbotsEnabled: boolean;
   language: string;
-  nativeCurrency: keyof typeof supportedNativeCurrencies;
+  nativeCurrency: NativeCurrencyKey;
   network: Network;
   testnetsEnabled: boolean;
 }
@@ -289,7 +288,7 @@ export const settingsChangeLanguage = (language: string) => async (
 };
 
 export const settingsChangeNativeCurrency = (
-  nativeCurrency: keyof typeof supportedNativeCurrencies
+  nativeCurrency: NativeCurrencyKey
 ) => async (
   dispatch: ThunkDispatch<
     AppState,

--- a/src/screens/ENSAdditionalRecordsSheet.tsx
+++ b/src/screens/ENSAdditionalRecordsSheet.tsx
@@ -4,10 +4,10 @@ import { useWindowDimensions } from 'react-native';
 import SelectableButton from '../components/ens-registration/TextRecordsForm/SelectableButton';
 import { SlackSheet } from '../components/sheet';
 import { AccentColorProvider, Box, Inline } from '@/design-system';
-import { textRecordFields } from '@/helpers/ens';
+import { accentColorAtom, textRecordFields } from '@/helpers/ens';
 import { useENSRegistrationForm } from '@/hooks';
 import { deviceUtils } from '@/utils';
-import { useTheme } from '@/theme';
+import { useRecoilState } from 'recoil';
 
 export const ENSAdditionalRecordsSheetHeight = 262;
 const recordLineHeight = 30;
@@ -21,8 +21,8 @@ export const getENSAdditionalRecordsSheetHeight = () => {
 };
 
 export default function ENSAdditionalRecordsSheet() {
-  const { colors } = useTheme();
   const { params } = useRoute<any>();
+  const [accentColor] = useRecoilState(accentColorAtom);
   const {
     selectedFields,
     onAddField,
@@ -38,7 +38,6 @@ export default function ENSAdditionalRecordsSheet() {
   );
 
   const androidTop = deviceHeight - boxStyle.height - recordLineHeight;
-  const accentColor = colors.purple;
 
   return (
     // @ts-expect-error JavaScript component

--- a/src/screens/ENSAdditionalRecordsSheet.tsx
+++ b/src/screens/ENSAdditionalRecordsSheet.tsx
@@ -1,13 +1,13 @@
 import { useRoute } from '@react-navigation/core';
 import React, { useMemo } from 'react';
 import { useWindowDimensions } from 'react-native';
-import { useRecoilState } from 'recoil';
 import SelectableButton from '../components/ens-registration/TextRecordsForm/SelectableButton';
 import { SlackSheet } from '../components/sheet';
 import { AccentColorProvider, Box, Inline } from '@/design-system';
-import { accentColorAtom, textRecordFields } from '@/helpers/ens';
+import { textRecordFields } from '@/helpers/ens';
 import { useENSRegistrationForm } from '@/hooks';
 import { deviceUtils } from '@/utils';
+import { useTheme } from '@/theme';
 
 export const ENSAdditionalRecordsSheetHeight = 262;
 const recordLineHeight = 30;
@@ -21,8 +21,8 @@ export const getENSAdditionalRecordsSheetHeight = () => {
 };
 
 export default function ENSAdditionalRecordsSheet() {
+  const { colors } = useTheme();
   const { params } = useRoute<any>();
-  const [accentColor] = useRecoilState(accentColorAtom);
   const {
     selectedFields,
     onAddField,
@@ -38,6 +38,7 @@ export default function ENSAdditionalRecordsSheet() {
   );
 
   const androidTop = deviceHeight - boxStyle.height - recordLineHeight;
+  const accentColor = colors.purple;
 
   return (
     // @ts-expect-error JavaScript component

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -1,6 +1,6 @@
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { BottomSheetContext } from '@gorhom/bottom-sheet/src/contexts/external';
-import { useFocusEffect, useRoute } from '@react-navigation/core';
+import { useRoute } from '@react-navigation/native';
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, {
@@ -17,7 +17,6 @@ import Animated, {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import { useRecoilState } from 'recoil';
 import { ButtonPressAnimation } from '../components/animations/';
 import TintButton from '../components/buttons/TintButton';
 import {
@@ -27,9 +26,9 @@ import {
 } from '../components/ens-registration';
 import SelectableButton from '../components/ens-registration/TextRecordsForm/SelectableButton';
 import { SheetActionButton, SheetActionButtonRow } from '../components/sheet';
-import { delayNext } from '../hooks/useMagicAutofocus';
-import { useNavigation } from '../navigation/Navigation';
-import { useTheme } from '../theme/ThemeContext';
+import { delayNext } from '@/hooks/useMagicAutofocus';
+import { useNavigation } from '@/navigation';
+import { useTheme } from '@/theme';
 import {
   ENSConfirmRegisterSheetHeight,
   ENSConfirmUpdateSheetHeight,
@@ -53,7 +52,6 @@ import {
   saveSeenOnchainDataDisclaimer,
 } from '@/handlers/localstorage/ens';
 import {
-  accentColorAtom,
   ENS_RECORDS,
   REGISTRATION_MODES,
   TextRecordField,
@@ -70,7 +68,6 @@ import {
   useENSRegistrationStepHandler,
   useENSSearch,
   useKeyboardHeight,
-  usePersistentDominantColorFromImage,
   useWalletSectionsData,
 } from '@/hooks';
 import Routes from '@/navigation/routesNames';
@@ -86,10 +83,9 @@ export default function ENSAssignRecordsSheet() {
   const { name } = useENSRegistration();
   const { hasNFTs } = useWalletSectionsData();
   const isInsideBottomSheet = !!useContext(BottomSheetContext);
+  const accentColor = colors.purple;
 
-  const {
-    images: { avatarUrl: initialAvatarUrl },
-  } = useENSModifiedRegistration({
+  useENSModifiedRegistration({
     modifyChangedRecords: true,
     setInitialRecordsWhenInEditMode: true,
   });
@@ -127,25 +123,9 @@ export default function ENSAssignRecordsSheet() {
     step,
     yearsDuration: 1,
   });
-
-  const [avatarUrl, setAvatarUrl] = useState(initialAvatarUrl);
-  const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
-
-  const avatarImage =
-    avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarImage
-  );
-
   const bottomActionHeight = isSmallPhone
     ? BottomActionHeightSmall
     : BottomActionHeight;
-
-  useFocusEffect(() => {
-    if (dominantColor || (!dominantColor && !avatarImage)) {
-      setAccentColor(dominantColor || colors.purple);
-    }
-  });
 
   const handleAutoFocusLayout = useCallback(
     ({
@@ -213,7 +193,6 @@ export default function ENSAssignRecordsSheet() {
               <RegistrationAvatar
                 enableNFTs={hasNFTs}
                 hasSeenExplainSheet={hasSeenExplainSheet}
-                onChangeAvatarUrl={setAvatarUrl}
                 onShowExplainSheet={handleFocus}
               />
             </Box>
@@ -280,7 +259,6 @@ export function ENSAssignRecordsBottomActions({
   const keyboardHeight = useKeyboardHeight();
   const { accountENS } = useAccountProfile();
   const { colors } = useTheme();
-  const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
   const { mode, name } = useENSRegistration();
   const [fromRoute, setFromRoute] = useState(previousRouteName);
   const {
@@ -298,8 +276,7 @@ export function ENSAssignRecordsBottomActions({
   const handlePressBack = useCallback(() => {
     delayNext();
     navigate(fromRoute);
-    setAccentColor(colors.purple);
-  }, [colors.purple, fromRoute, navigate, setAccentColor]);
+  }, [fromRoute, navigate]);
 
   const hasBackButton = useMemo(
     () =>
@@ -360,6 +337,8 @@ export function ENSAssignRecordsBottomActions({
     () => ({ bottom: keyboardHeight }),
     [keyboardHeight]
   );
+
+  const accentColor = colors.purple;
 
   return (
     <>

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -27,6 +27,7 @@ import {
   Text,
 } from '@/design-system';
 import {
+  accentColorAtom,
   ENS_DOMAIN,
   ENS_SECONDS_WAIT,
   REGISTRATION_MODES,
@@ -42,12 +43,15 @@ import {
   useENSRegistrationForm,
   useENSRegistrationStepHandler,
   useENSSearch,
+  usePersistentDominantColorFromImage,
   useWallets,
 } from '@/hooks';
 import { ImgixImage } from '@/components/images';
 import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import { colors } from '@/styles';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { avatarMetadataAtom } from '@/components/ens-registration/RegistrationAvatar/RegistrationAvatar';
 
 export const ENSConfirmRegisterSheetHeight = 600;
 export const ENSConfirmRenewSheetHeight = 560;
@@ -115,6 +119,22 @@ export default function ENSConfirmRegisterSheet() {
     images: { avatarUrl: initialAvatarUrl },
   } = useENSModifiedRegistration();
   const { isSmallPhone } = useDimensions();
+
+  const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
+  const avatarMetadata = useRecoilValue(avatarMetadataAtom);
+
+  const avatarImage =
+    avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
+  const {
+    result: dominantColor,
+  } = usePersistentDominantColorFromImage(avatarImage, { signUrl: true });
+
+  useEffect(() => {
+    if (dominantColor || (!dominantColor && !avatarImage)) {
+      setAccentColor(dominantColor || colors.purple);
+    }
+  }, [avatarImage, dominantColor, setAccentColor]);
+
   const [duration, setDuration] = useState(1);
   const { navigate, goBack } = useNavigation();
   const { blurFields, values } = useENSRegistrationForm();
@@ -177,8 +197,6 @@ export default function ENSConfirmRegisterSheet() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
-
-  const accentColor = colors.purple;
 
   const stepContent = useMemo(
     () => ({

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -1,10 +1,9 @@
-import { useFocusEffect, useRoute } from '@react-navigation/core';
+import { useFocusEffect, useRoute } from '@react-navigation/native';
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { InteractionManager, Keyboard } from 'react-native';
 import * as DeviceInfo from 'react-native-device-info';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { HoldToAuthorizeButton } from '../components/buttons';
 import {
   CommitContent,
@@ -14,7 +13,6 @@ import {
   WaitCommitmentConfirmationContent,
   WaitENSConfirmationContent,
 } from '../components/ens-registration';
-import { avatarMetadataAtom } from '../components/ens-registration/RegistrationAvatar/RegistrationAvatar';
 import { GasSpeedButton } from '../components/gas';
 import { SheetActionButtonRow, SlackSheet } from '../components/sheet';
 import { abbreviateEnsForDisplay } from '@/utils/abbreviations';
@@ -29,7 +27,6 @@ import {
   Text,
 } from '@/design-system';
 import {
-  accentColorAtom,
   ENS_DOMAIN,
   ENS_SECONDS_WAIT,
   REGISTRATION_MODES,
@@ -45,7 +42,6 @@ import {
   useENSRegistrationForm,
   useENSRegistrationStepHandler,
   useENSSearch,
-  usePersistentDominantColorFromImage,
   useWallets,
 } from '@/hooks';
 import { ImgixImage } from '@/components/images';
@@ -119,36 +115,15 @@ export default function ENSConfirmRegisterSheet() {
     images: { avatarUrl: initialAvatarUrl },
   } = useENSModifiedRegistration();
   const { isSmallPhone } = useDimensions();
-
-  const [accentColor, setAccentColor] = useRecoilState(accentColorAtom);
-  const avatarMetadata = useRecoilValue(avatarMetadataAtom);
-
-  const avatarImage =
-    avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarImage
-  );
-
-  useEffect(() => {
-    if (dominantColor || (!dominantColor && !avatarImage)) {
-      setAccentColor(dominantColor || colors.purple);
-    }
-  }, [avatarImage, dominantColor, setAccentColor]);
-
   const [duration, setDuration] = useState(1);
-
   const { navigate, goBack } = useNavigation();
-
   const { blurFields, values } = useENSRegistrationForm();
   const accountProfile = useAccountProfile();
-
   const avatarUrl = initialAvatarUrl || values.avatar;
-
   const name = ensName?.replace(ENS_DOMAIN, '');
   const { data: registrationData } = useENSSearch({
     name,
   });
-
   const [sendReverseRecord, setSendReverseRecord] = useState(
     accountProfile.accountENS !== ensName &&
       (!isEmpty(changedRecords) || mode === REGISTRATION_MODES.EDIT)
@@ -202,6 +177,8 @@ export default function ENSConfirmRegisterSheet() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
+
+  const accentColor = colors.purple;
 
   const stepContent = useMemo(
     () => ({

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -19,6 +19,7 @@ import {
   useDimensions,
   useENSAvatar,
   useExternalWalletSectionsData,
+  usePersistentDominantColorFromImage,
 } from '@/hooks';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
 import Routes from '@/navigation/routesNames';
@@ -63,6 +64,13 @@ export default function ProfileSheet() {
     infinite: true,
   });
 
+  const { result: dominantColor, state } = usePersistentDominantColorFromImage(
+    avatar?.imageUrl || '',
+    {
+      signUrl: true,
+    }
+  );
+
   const colorIndex = useMemo(
     () => (profileAddress ? addressHashedColorIndex(profileAddress) : 0),
     [profileAddress]
@@ -72,15 +80,14 @@ export default function ProfileSheet() {
     contentHeight,
   ]);
 
-  let accentColor = colors.appleBlue;
-  if (!isAvatarFetched) {
-    accentColor = colors.skeleton;
-  } else if (
-    (avatar === undefined || avatar.imageUrl === null) &&
-    colorIndex !== null
-  ) {
-    accentColor = colors.avatarBackgrounds[colorIndex];
-  }
+  const accentColor =
+    // Set accent color when ENS images have fetched & dominant
+    // color is not loading.
+    isAvatarFetched && state !== 1 && typeof colorIndex === 'number'
+      ? dominantColor ||
+        colors.avatarBackgrounds[colorIndex] ||
+        colors.appleBlue
+      : colors.skeleton;
 
   const enableZoomableImages = !isPreview;
 

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -14,13 +14,11 @@ import {
   Inset,
   Stack,
 } from '@/design-system';
-import { maybeSignUri } from '@/handlers/imgix';
 import {
   useAccountSettings,
   useDimensions,
   useENSAvatar,
   useExternalWalletSectionsData,
-  usePersistentDominantColorFromImage,
 } from '@/hooks';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
 import Routes from '@/navigation/routesNames';
@@ -70,22 +68,19 @@ export default function ProfileSheet() {
     [profileAddress]
   );
 
-  const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    maybeSignUri(avatar?.imageUrl ?? '', { w: 200 }) ?? ''
-  );
-
   const wrapperStyle = useMemo(() => ({ height: contentHeight }), [
     contentHeight,
   ]);
 
-  const accentColor =
-    // Set accent color when ENS images have fetched & dominant
-    // color is not loading.
-    isAvatarFetched && state !== 1 && typeof colorIndex === 'number'
-      ? dominantColor ||
-        colors.avatarBackgrounds[colorIndex] ||
-        colors.appleBlue
-      : colors.skeleton;
+  let accentColor = colors.appleBlue;
+  if (!isAvatarFetched) {
+    accentColor = colors.skeleton;
+  } else if (
+    (avatar === undefined || avatar.imageUrl === null) &&
+    colorIndex !== null
+  ) {
+    accentColor = colors.avatarBackgrounds[colorIndex];
+  }
 
   const enableZoomableImages = !isPreview;
 

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -24,6 +24,7 @@ import {
   EthereumAddress,
   GasFee,
   LegacySelectedGasFee,
+  NativeCurrencyKey,
   ParsedAddressAsset,
   RainbowToken,
   RainbowTransaction,
@@ -66,7 +67,6 @@ import {
   OVM_GAS_PRICE_ORACLE,
   POLYGON_BLOCK_EXPLORER_URL,
   BSC_BLOCK_EXPLORER_URL,
-  supportedNativeCurrencies,
   BNB_MAINNET_ADDRESS,
 } from '@/references';
 import Routes from '@/navigation/routesNames';
@@ -276,7 +276,7 @@ const getHash = (txn: RainbowTransaction) => txn.hash?.split('-').shift();
 
 const formatGenericAsset = (
   asset: ParsedAddressAsset,
-  nativeCurrency: keyof typeof supportedNativeCurrencies
+  nativeCurrency: NativeCurrencyKey
 ) => {
   return {
     ...asset,

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -115,7 +115,7 @@ export function isEthAddress(address: string | null) {
   return address?.match(/^(0x)?[0-9a-fA-F]{40}$/);
 }
 
-export function isValidImagePath(path: string | null) {
+export function isValidImagePath(path: string | null | undefined) {
   return path !== '~undefined';
 }
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* rugged `usePersistentDominantColorFromImage` in all Profile related components -> profile avatars are often too large to efficiently process the colors on iOS
* Fixed Typescript in a bunch of hooks -> safer types and less `any`
* Limited usage of hooks that call into redux by passing profile related data from brief wallet section data instead of fetching it in list elements. There's still more we can do to streamline data handling in WalletScreen but that is a good first step
* Some more minor TypeScript fixes