### PR TITLE
imgix: use size everywhere

### DIFF
--- a/src/components/3d/SimpleModelView.tsx
+++ b/src/components/3d/SimpleModelView.tsx
@@ -10,6 +10,7 @@ import { WebView } from 'react-native-webview';
 import { ImgixImage } from '@/components/images';
 import styled from '@/styled-thing';
 import { padding, position } from '@/styles';
+import { FULL_NFT_IMAGE_SIZE } from '@/utils/getFullSizeUrl';
 
 export type ModelViewerProps = {
   readonly setLoading: (loading: boolean) => void;
@@ -136,6 +137,7 @@ export default function ModelViewer({
         <ImgixImage
           source={{ uri: fallbackUri }}
           style={StyleSheet.absoluteFill}
+          size={FULL_NFT_IMAGE_SIZE}
         />
       </ProgressIndicatorContainer>
     </View>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -43,6 +43,7 @@ const Spinner = ({
             source={SpinnerImageSource as any}
             style={style}
             tintColor={color || colors.whiteLabel}
+            size={30}
           />
         </SpinAnimation>
       )}

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -47,7 +47,7 @@ export function ProfileAvatarRow({
   } = useOnAvatarPress({ screenType: 'wallet' });
 
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    maybeSignUri(accountImage ?? '') ?? ''
+    maybeSignUri(accountImage ?? '', { w: 200 }) ?? ''
   );
 
   // ////////////////////////////////////////////////////
@@ -227,6 +227,7 @@ export function ProfileAvatarRow({
                         height={{ custom: size }}
                         source={{ uri: accountImage }}
                         width={{ custom: size }}
+                        size={200}
                       />
                     ) : (
                       <EmojiAvatar size={size} />

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -227,7 +227,7 @@ export function ProfileAvatarRow({
                         height={{ custom: size }}
                         source={{ uri: accountImage }}
                         width={{ custom: size }}
-                        size={200}
+                        size={100}
                       />
                     ) : (
                       <EmojiAvatar size={size} />

--- a/src/components/backup/BackupSheetSection.js
+++ b/src/components/backup/BackupSheetSection.js
@@ -40,6 +40,7 @@ const MastheadIcon = styled(ImgixImage).attrs({
   height: 74,
   marginBottom: -1,
   width: 75,
+  size: 75,
 });
 
 export default function BackupSheetSection({

--- a/src/components/buttons/TokenSelectionButton.js
+++ b/src/components/buttons/TokenSelectionButton.js
@@ -29,6 +29,7 @@ const CaretIcon = styled(ImgixImage).attrs(({ theme: { colors } }) => ({
   resizeMode: ImgixImage.resizeMode.contain,
   source: CaretImageSource,
   tintColor: colors.whiteLabel,
+  size: 30,
 }))({
   height: 18,
   top: 0.5,

--- a/src/components/buttons/rainbow-button/RainbowButton.js
+++ b/src/components/buttons/rainbow-button/RainbowButton.js
@@ -17,6 +17,7 @@ import ShadowView from '@/react-native-shadow-stack/ShadowView';
 const AddCashIcon = styled(ImgixImage).attrs({
   resizeMode: ImgixImage.resizeMode.contain,
   source: AddCashIconSource,
+  size: 45,
 })({
   ...position.sizeAsObject(45),
   marginTop: 7.5,

--- a/src/components/cards/ENSCreateProfileCard.tsx
+++ b/src/components/cards/ENSCreateProfileCard.tsx
@@ -73,13 +73,6 @@ export const ENSCreateProfileCard = () => {
     }
   }, [uniqueDomain]);
 
-  useEffect(() => {
-    // Preload intro screen preview marquee ENS images
-    ImgixImage.preload(
-      ensIntroMarqueeNames.map(name => ({ uri: ensAvatarUrl(name) }))
-    );
-  }, []);
-
   return (
     <ColorModeProvider value="lightTinted">
       <GenericCard

--- a/src/components/coin-divider/CoinDividerOpenButton.js
+++ b/src/components/coin-divider/CoinDividerOpenButton.js
@@ -21,6 +21,7 @@ const openWidth = 78;
 const CaretIcon = styled(ImgixImage).attrs(({ theme: { colors } }) => ({
   source: Caret,
   tintColor: colors.blueGreyDark,
+  size: 30,
 }))({
   height: 18,
   width: 8,

--- a/src/components/coin-icon/RequestVendorLogoIcon.js
+++ b/src/components/coin-icon/RequestVendorLogoIcon.js
@@ -75,6 +75,7 @@ export default function RequestVendorLogoIcon({
               onError={setError}
               source={imageSource}
               style={position.sizeAsObject('100%')}
+              size={200}
             />
           ) : (
             <Text

--- a/src/components/contacts/ImageAvatar.js
+++ b/src/components/contacts/ImageAvatar.js
@@ -103,6 +103,7 @@ const ImageAvatar = ({
           source={{
             uri: image,
           }}
+          size={200}
         />
       </Centered>
     </ShadowStack>

--- a/src/components/contacts/ImageAvatar.js
+++ b/src/components/contacts/ImageAvatar.js
@@ -103,7 +103,7 @@ const ImageAvatar = ({
           source={{
             uri: image,
           }}
-          size={200}
+          size={100}
         />
       </Centered>
     </ShadowStack>

--- a/src/components/contacts/SwipeableContactRow.js
+++ b/src/components/contacts/SwipeableContactRow.js
@@ -35,7 +35,11 @@ const RightAction = ({ onPress, progress, text, x }) => {
       style={{ transform: [{ translateX }] }}
     >
       <ButtonPressAnimation onPress={onPress} scaleTo={0.9}>
-        <ImgixImage source={isEdit ? EditIcon : DeleteIcon} style={styles} />
+        <ImgixImage
+          source={isEdit ? EditIcon : DeleteIcon}
+          style={styles}
+          size={30}
+        />
         <Text
           align="center"
           color={colors.alpha(colors.blueGreyDark, 0.4)}

--- a/src/components/discover/DiscoverSearchInput.js
+++ b/src/components/discover/DiscoverSearchInput.js
@@ -92,6 +92,7 @@ const SearchSpinner = styled(ImgixImage).attrs(({ theme: { colors } }) => ({
   resizeMode: ImgixImage.resizeMode.contain,
   source: Spinner,
   tintColor: colors.alpha(colors.blueGreyDark, 0.6),
+  size: 30,
 }))({
   height: 20,
   width: 20,

--- a/src/components/ens-profile/ProfileAvatar/ProfileAvatar.tsx
+++ b/src/components/ens-profile/ProfileAvatar/ProfileAvatar.tsx
@@ -86,7 +86,7 @@ export default function ProfileAvatar({
                   onLoadEnd={onLoadEnd}
                   source={{ uri: avatarUrl }}
                   width={{ custom: size }}
-                  size={200}
+                  size={100}
                 />
               ) : (
                 <Box

--- a/src/components/ens-profile/ProfileAvatar/ProfileAvatar.tsx
+++ b/src/components/ens-profile/ProfileAvatar/ProfileAvatar.tsx
@@ -86,6 +86,7 @@ export default function ProfileAvatar({
                   onLoadEnd={onLoadEnd}
                   source={{ uri: avatarUrl }}
                   width={{ custom: size }}
+                  size={200}
                 />
               ) : (
                 <Box

--- a/src/components/ens-profile/ProfileCover/ProfileCover.tsx
+++ b/src/components/ens-profile/ProfileCover/ProfileCover.tsx
@@ -8,6 +8,7 @@ import { Box, useForegroundColor } from '@/design-system';
 import { useFadeImage } from '@/hooks';
 import { ImgixImage } from '@/components/images';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
+import { CardSize } from '@/components/unique-token/CardSize';
 
 const imagePreviewOverlayTopOffset = ios ? 68 + sharedCoolModalTopOffset : 107;
 
@@ -84,6 +85,7 @@ export default function ProfileCover({
               height="126px"
               onLoadEnd={onLoadEnd}
               source={{ uri: coverUrl || '' }}
+              size={CardSize}
             />
           </ImagePreviewOverlayTarget>
         </Box>

--- a/src/components/ens-profile/ProfileCover/ProfileCover.tsx
+++ b/src/components/ens-profile/ProfileCover/ProfileCover.tsx
@@ -33,6 +33,7 @@ export default function ProfileCover({
   const showSkeleton = isLoading || !isFetched;
   const showRadialGradient = ios && !coverUrl && isFetched && !isLoading;
 
+  console.log('coverUrl: ', coverUrl);
   return (
     <>
       {showSkeleton && (
@@ -85,7 +86,7 @@ export default function ProfileCover({
               height="126px"
               onLoadEnd={onLoadEnd}
               source={{ uri: coverUrl || '' }}
-              size={CardSize}
+              size={200}
             />
           </ImagePreviewOverlayTarget>
         </Box>

--- a/src/components/ens-profile/ProfileSheetHeader.tsx
+++ b/src/components/ens-profile/ProfileSheetHeader.tsx
@@ -83,7 +83,6 @@ export default function ProfileSheetHeader({
   });
   const enableZoomOnPressAvatar = enableZoomableImages && !onPressAvatar;
 
-  const coverUrl = getLowResUrl(cover?.imageUrl || '', { w: 400 });
   const { onPress: onPressCover } = useOpenENSNFTHandler({
     uniqueTokens,
     value: records?.header,
@@ -106,7 +105,7 @@ export default function ProfileSheetHeader({
     >
       <Stack space={{ custom: 18 }}>
         <ProfileCover
-          coverUrl={coverUrl}
+          coverUrl={cover?.imageUrl}
           enableZoomOnPress={enableZoomOnPressCover}
           handleOnPress={onPressCover}
           isFetched={isImagesFetched}

--- a/src/components/ens-registration/ConfirmContent/CommitContent.tsx
+++ b/src/components/ens-registration/ConfirmContent/CommitContent.tsx
@@ -33,6 +33,7 @@ const CommitContent = ({
             <ImgixImage
               source={brain as Source}
               style={{ height: 20, width: 20 }}
+              size={30}
             />
           </Box>
           <Text

--- a/src/components/ens-registration/IntroMarquee/IntroMarquee.tsx
+++ b/src/components/ens-registration/IntroMarquee/IntroMarquee.tsx
@@ -117,6 +117,7 @@ function ENSAvatarPlaceholder({
             shadow="15px light (Deprecated)"
             source={{ uri: ensAvatarUrl(name) }}
             width={{ custom: 80 }}
+            size={200}
           />
           <Text
             align="center"

--- a/src/components/ens-registration/IntroMarquee/IntroMarquee.tsx
+++ b/src/components/ens-registration/IntroMarquee/IntroMarquee.tsx
@@ -117,7 +117,7 @@ function ENSAvatarPlaceholder({
             shadow="15px light (Deprecated)"
             source={{ uri: ensAvatarUrl(name) }}
             width={{ custom: 80 }}
-            size={200}
+            size={100}
           />
           <Text
             align="center"

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -211,6 +211,7 @@ const RegistrationAvatar = ({
                     height={{ custom: size }}
                     source={{ uri: avatarUrl }}
                     width={{ custom: size }}
+                    size={200}
                   />
                 ) : (
                   <AccentColorProvider color={accentColor}>

--- a/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
+++ b/src/components/ens-registration/RegistrationAvatar/RegistrationAvatar.tsx
@@ -211,7 +211,7 @@ const RegistrationAvatar = ({
                     height={{ custom: size }}
                     source={{ uri: avatarUrl }}
                     width={{ custom: size }}
-                    size={200}
+                    size={100}
                   />
                 ) : (
                   <AccentColorProvider color={accentColor}>

--- a/src/components/exchange/ExchangeSearch.tsx
+++ b/src/components/exchange/ExchangeSearch.tsx
@@ -249,6 +249,7 @@ const ExchangeSearch: ForwardRefRenderFunction<
                 source={Spinner as Source}
                 tintColor={colors.alpha(colors.blueGreyDark, 0.6)}
                 style={{ height: 20, width: 20 }}
+                size={20}
               />
             </Box>
           </>

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -85,7 +85,7 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    maybeSignUri(avatarUrl || '') || ''
+    maybeSignUri(avatarUrl || '', { w: 200 }) || ''
   );
 
   const accentColor =

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -173,6 +173,7 @@ const Section = ({
                 height={{ custom: 24 }}
                 source={{ uri: titleImageUrl }}
                 width={{ custom: 24 }}
+                size={30}
               />
             </Bleed>
           )}

--- a/src/components/expanded-state/ens/InfoRow.tsx
+++ b/src/components/expanded-state/ens/InfoRow.tsx
@@ -25,6 +25,7 @@ import {
 import { ImgixImage } from '@/components/images';
 import Routes from '@/navigation/routesNames';
 import { useENSAddress } from '@/resources/ens/ensAddressQuery';
+import { CardSize } from '@/components/unique-token/CardSize';
 
 export function InfoRowSkeleton() {
   const { colors } = useTheme();
@@ -243,7 +244,12 @@ function ImageValue({
       imageUrl={url}
       onPress={onPress}
     >
-      <Box as={ImgixImage} height="full" source={{ uri: url }} />
+      <Box
+        as={ImgixImage}
+        height="full"
+        source={{ uri: url }}
+        size={CardSize}
+      />
     </ImagePreviewOverlayTarget>
   );
 }

--- a/src/components/expanded-state/swap-details/SwapDetailsRefuelRow.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsRefuelRow.js
@@ -16,6 +16,7 @@ const CaretIcon = styled(ImgixImage).attrs(({ theme: { colors } }) => ({
   resizeMode: ImgixImage.resizeMode.contain,
   source: CaretImageSource,
   tintColor: colors.blueGreyDark,
+  size: 30,
 }))({
   height: 11,
   top: 0,

--- a/src/components/expanded-state/swap-settings/SourcePicker.js
+++ b/src/components/expanded-state/swap-settings/SourcePicker.js
@@ -131,6 +131,7 @@ export default function SourcePicker({ onSelect, currentSource }) {
                   width: 20,
                 }}
                 width={20}
+                size={30}
               />
               <Text
                 color="primary (Deprecated)"

--- a/src/components/floating-emojis/DOGConfetti.js
+++ b/src/components/floating-emojis/DOGConfetti.js
@@ -118,7 +118,11 @@ export const DOGConfetti = () => {
                 {key % 2 === 0 ? (
                   <Emoji name="rainbow" style={styles.confetti} />
                 ) : (
-                  <ImgixImage source={dogSunglasses} style={styles.confetti} />
+                  <ImgixImage
+                    source={dogSunglasses}
+                    style={styles.confetti}
+                    size={30}
+                  />
                 )}
               </Animated.View>
             </React.Fragment>

--- a/src/components/icons/UniswapLogo.js
+++ b/src/components/icons/UniswapLogo.js
@@ -10,7 +10,7 @@ const Container = styled(Centered).attrs(({ theme: { colors } }) => ({
 
 const UniswapLogo = ({ imageStyle, ...props }) => (
   <Container {...props}>
-    <ImgixImage source={UniswapLogoImage} style={imageStyle} />
+    <ImgixImage source={UniswapLogoImage} style={imageStyle} size={100} />
   </Container>
 );
 

--- a/src/components/images/ImagePreviewOverlay.tsx
+++ b/src/components/images/ImagePreviewOverlay.tsx
@@ -45,6 +45,7 @@ import { useDimensions, usePersistentAspectRatio } from '@/hooks';
 import { ImgixImage } from '@/components/images';
 import { colors, position } from '@/styles';
 import { safeAreaInsetValues } from '@/utils';
+import { FULL_NFT_IMAGE_SIZE } from '@/utils/getFullSizeUrl';
 
 const idsAtom = atom<string[]>({
   default: [],
@@ -332,6 +333,7 @@ function ImagePreview({
                       height="full"
                       source={{ uri: imageUrl }}
                       width="full"
+                      size={FULL_NFT_IMAGE_SIZE}
                     />
                     <Box
                       as={BlurView}

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -5,7 +5,7 @@ import { maybeSignSource } from '../../handlers/imgix';
 
 export type ImgixImageProps = FastImageProps & {
   readonly Component?: React.ElementType;
-  readonly size?: number;
+  readonly size: number;
 };
 
 // Here we're emulating the pattern used in react-native-fast-image:
@@ -14,7 +14,7 @@ type HiddenImgixImageProps = {
   forwardedRef: React.Ref<any>;
   maxRetries?: number;
   retryOnError?: boolean;
-  size?: number;
+  size: number;
   fm?: string;
 };
 type MergedImgixImageProps = ImgixImageProps & HiddenImgixImageProps;

--- a/src/components/qrcode-scanner/ConnectedDapps.tsx
+++ b/src/components/qrcode-scanner/ConnectedDapps.tsx
@@ -42,6 +42,7 @@ function ConnectedDapps() {
                   source={rainbowIconCircle as Source}
                   height={{ custom: 28 }}
                   width={{ custom: 28 }}
+                  size={30}
                 />
                 <Text color="label" weight="bold" size="17pt">
                   {walletConnectorsByDappName.length === 1

--- a/src/components/savings/SavingsListHeader.js
+++ b/src/components/savings/SavingsListHeader.js
@@ -127,6 +127,7 @@ const SavingsListHeader = ({
             source={CaretImageSource}
             style={imageAnimatedStyles}
             tintColor={colors.dark}
+            size={30}
           />
         </RowWithMargins>
       </Row>

--- a/src/components/settings-menu/AppIconSection.tsx
+++ b/src/components/settings-menu/AppIconSection.tsx
@@ -144,6 +144,7 @@ const AppIconSection = () => {
                       height: 36,
                       width: 36,
                     }}
+                    size={30}
                   />
                 </Box>
               }

--- a/src/components/settings-menu/components/MenuItem.tsx
+++ b/src/components/settings-menu/components/MenuItem.tsx
@@ -24,6 +24,7 @@ const ImageIcon = ({ size = 60, source }: ImageIconProps) => (
     marginTop={{ custom: 8 }}
     source={source as Source}
     width={{ custom: size }}
+    size={size}
   />
 );
 
@@ -223,6 +224,7 @@ const MenuItem = ({
                 source={Caret as Source}
                 tintColor={colors.blueGreyDark60}
                 width={{ custom: 7 }}
+                size={30}
               />
             )}
             {hasChevron && (
@@ -232,6 +234,7 @@ const MenuItem = ({
                 source={Chevron as Source}
                 tintColor={colors.blueGreyDark60}
                 width={{ custom: 16 }}
+                size={30}
               />
             )}
           </Inline>

--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -5,6 +5,7 @@ import { ImgixImage } from '@/components/images';
 import styled from '@/styled-thing';
 import { position } from '@/styles';
 import logger from '@/utils/logger';
+import { CardSize } from '../unique-token/CardSize';
 
 const ImageTile = styled(ImgixImage)({
   alignItems: 'center',
@@ -152,6 +153,7 @@ class SvgImage extends Component {
             resizeMode={ImgixImage.resizeMode.cover}
             source={{ uri: props.lowResFallbackUri }}
             style={position.coverAsObject}
+            size={CardSize}
           />
         )}
         {!this.state.trulyLoaded && props.fallbackUri && (
@@ -160,6 +162,7 @@ class SvgImage extends Component {
             resizeMode={ImgixImage.resizeMode.cover}
             source={{ uri: props.fallbackUri }}
             style={position.coverAsObject}
+            size={CardSize}
           />
         )}
         <WebView

--- a/src/components/token-family/TokenFamilyHeaderIcon.tsx
+++ b/src/components/token-family/TokenFamilyHeaderIcon.tsx
@@ -86,6 +86,7 @@ export default React.memo(function TokenFamilyHeaderIcon({
           source={eyeSlash as Source}
           style={{ height: 17, width: 25 }}
           tintColor={colors.blueGreyDark60}
+          size={30}
         />
       </View>
     );

--- a/src/components/unique-token/UniqueTokenImage.js
+++ b/src/components/unique-token/UniqueTokenImage.js
@@ -14,6 +14,7 @@ import { ENS_NFT_CONTRACT_ADDRESS } from '@/references';
 import styled from '@/styled-thing';
 import { position } from '@/styles';
 import isSVGImage from '@/utils/isSVG';
+import { CardSize } from './CardSize';
 
 const FallbackTextColorVariants = (darkMode, colors) => ({
   dark: darkMode
@@ -96,6 +97,7 @@ const UniqueTokenImage = ({
               resizeMode={ImgixImage.resizeMode[resizeMode]}
               source={{ uri: item.lowResUrl }}
               style={position.coverAsObject}
+              size={CardSize}
             />
           )}
         </Fragment>

--- a/src/components/value-chart/Chart.js
+++ b/src/components/value-chart/Chart.js
@@ -46,6 +46,7 @@ const ChartSpinner = styled(ImgixImage).attrs(({ color }) => ({
   resizeMode: ImgixImage.resizeMode.contain,
   source: Spinner,
   tintColor: color,
+  size: 30,
 }))({
   height: 28,
   width: 28,
@@ -72,6 +73,7 @@ const InnerDot = styled.View({
 const DogeDot = styled(ImgixImage).attrs({
   resizeMode: ImgixImage.resizeMode.contain,
   source: dogSunglasses,
+  size: 30,
 })({
   ...position.sizeAsObject(35),
 });

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -359,7 +359,7 @@ export const fetchImage = async (
       allowNonOwnerNFTs: true,
       type: imageType,
     });
-    ImgixImage.preload([...(imageUrl ? [{ uri: imageUrl }] : [])], 200);
+    ImgixImage.preload([...(imageUrl ? [{ uri: imageUrl }] : [])], 100);
     saveENSData(imageType, ensName, { imageUrl });
   } catch (err) {
     // Fallback to storage images

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -359,7 +359,7 @@ export const fetchImage = async (
       allowNonOwnerNFTs: true,
       type: imageType,
     });
-    ImgixImage.preload([...(imageUrl ? [{ uri: imageUrl }] : [])]);
+    ImgixImage.preload([...(imageUrl ? [{ uri: imageUrl }] : [])], 200);
     saveENSData(imageType, ensName, { imageUrl });
   } catch (err) {
     // Fallback to storage images

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -9,7 +9,7 @@ export function useAccountAccentColor() {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
   const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    maybeSignUri(accountImage ?? '') ?? ''
+    maybeSignUri(accountImage ?? '', { w: 200 }) ?? ''
   );
 
   const { colors } = useTheme();

--- a/src/hooks/useFadeImage.ts
+++ b/src/hooks/useFadeImage.ts
@@ -20,15 +20,6 @@ export default function useFadeImage({
 
   const opacity = useSharedValue(1);
 
-  useEffect(() => {
-    (async () => {
-      if (source) {
-        const cachedPath = await ImgixImage.getCachePath(source);
-        setIsLoading(!cachedPath);
-      }
-    })();
-  }, [source]);
-
   const style = useAnimatedStyle(() => {
     return {
       opacity: withTiming(opacity.value, {

--- a/src/redux/requests.ts
+++ b/src/redux/requests.ts
@@ -200,7 +200,7 @@ export const addRequestToApprove = (
   }
   const unsafeImageUrl =
     dappLogoOverride(peerMeta?.url) || peerMeta?.icons?.[0];
-  const imageUrl = maybeSignUri(unsafeImageUrl);
+  const imageUrl = maybeSignUri(unsafeImageUrl, { w: 200 });
   const dappName =
     dappNameOverride(peerMeta?.url) || peerMeta?.name || 'Unknown Dapp';
   const dappUrl = peerMeta?.url || 'Unknown Url';

--- a/src/references/ens-intro-marquee-names.json
+++ b/src/references/ens-intro-marquee-names.json
@@ -11,7 +11,6 @@
   "nick.eth",
   "ped.eth",
   "maaria.eth",
-  "cantino.eth",
   "jstn.eth",
   "notben.eth",
   "sarahguo.eth",

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -428,6 +428,7 @@ export default function ENSConfirmRegisterSheet() {
                         height={{ custom: avatarSize }}
                         source={{ uri: avatarUrl }}
                         width={{ custom: avatarSize }}
+                        size={200}
                       />
                     </Box>
                   )}

--- a/src/screens/ENSSearchSheet.tsx
+++ b/src/screens/ENSSearchSheet.tsx
@@ -164,6 +164,7 @@ export default function ENSSearchSheet() {
                   <ImgixImage
                     source={dice as Source}
                     style={{ height: 20, top: -0.5, width: 20 }}
+                    size={30}
                   />
                 </Box>
                 <Text

--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -100,6 +100,7 @@ const OptimismAppIcon = () => {
       <Box
         as={ImgixImage}
         source={AppIconOptimism}
+        size={APP_ICON_SIZE}
         width={{ custom: APP_ICON_SIZE }}
         height={{ custom: APP_ICON_SIZE }}
         shadow="18px accent"
@@ -115,6 +116,7 @@ const GoldDogeAppIcon = () => {
       <Box
         as={ImgixImage}
         source={AppIconGoldDoge}
+        size={APP_ICON_SIZE}
         width={{ custom: APP_ICON_SIZE }}
         height={{ custom: APP_ICON_SIZE }}
         shadow="18px accent"
@@ -130,6 +132,7 @@ const RainDogeAppIcon = () => {
       <Box
         as={ImgixImage}
         source={AppIconRainDoge}
+        size={APP_ICON_SIZE}
         width={{ custom: APP_ICON_SIZE }}
         height={{ custom: APP_ICON_SIZE }}
         shadow="18px accent"
@@ -145,6 +148,7 @@ const SmolAppIcon = () => {
       <Box
         as={ImgixImage}
         source={AppIconSmol}
+        size={APP_ICON_SIZE}
         width={{ custom: APP_ICON_SIZE }}
         height={{ custom: APP_ICON_SIZE }}
         shadow="18px accent"
@@ -160,6 +164,7 @@ const ZoraAppIcon = () => {
       <Box
         as={ImgixImage}
         source={AppIconZora}
+        size={APP_ICON_SIZE}
         width={{ custom: APP_ICON_SIZE }}
         height={{ custom: APP_ICON_SIZE }}
         shadow="18px accent"
@@ -176,6 +181,7 @@ const TheMergeIcon = () => {
       }}
     >
       <ImgixImage
+        size={50}
         source={TheMergePng}
         style={{
           width: 53,

--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -23,6 +23,7 @@ import { haptics } from '@/utils';
 
 const Logo = styled(ImgixImage).attrs({
   source: RainbowLogo,
+  size: 80,
 })({
   height: 80,
   width: 80,

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -71,7 +71,7 @@ export default function ProfileSheet() {
   );
 
   const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    maybeSignUri(avatar?.imageUrl ?? '') ?? ''
+    maybeSignUri(avatar?.imageUrl ?? '', { w: 200 }) ?? ''
   );
 
   const wrapperStyle = useMemo(() => ({ height: contentHeight }), [

--- a/src/screens/SelectENSSheet.tsx
+++ b/src/screens/SelectENSSheet.tsx
@@ -170,6 +170,7 @@ function ENSAvatar({ name }: { name: string }) {
         height={{ custom: rowHeight }}
         source={{ uri: avatar?.imageUrl }}
         width={{ custom: rowHeight }}
+        size={200}
       />
     );
   }

--- a/src/screens/SelectENSSheet.tsx
+++ b/src/screens/SelectENSSheet.tsx
@@ -170,7 +170,7 @@ function ENSAvatar({ name }: { name: string }) {
         height={{ custom: rowHeight }}
         source={{ uri: avatar?.imageUrl }}
         width={{ custom: rowHeight }}
-        size={200}
+        size={100}
       />
     );
   }

--- a/src/utils/getDominantColorFromImage.ts
+++ b/src/utils/getDominantColorFromImage.ts
@@ -7,7 +7,6 @@ export default async function getDominantColorFromImage(
   imageUrl: string,
   colorToMeasureAgainst: string
 ) {
-  if (IS_TESTING === 'true') return undefined;
   let colors: IPalette;
   if (/^http/.test(imageUrl)) {
     colors = await Palette.getNamedSwatchesFromUrl(imageUrl);

--- a/src/utils/getFullSizeUrl.ts
+++ b/src/utils/getFullSizeUrl.ts
@@ -8,9 +8,11 @@ const deviceWidth = deviceUtils.dimensions.width;
 const size = deviceWidth * pixelRatio;
 const MAX_IMAGE_SCALE = 3;
 
+export const FULL_NFT_IMAGE_SIZE = size * MAX_IMAGE_SCALE;
+
 export const getFullSizeUrl = (url: string) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
-    return `${url}=w${size * MAX_IMAGE_SCALE}`;
+    return `${url}=w${FULL_NFT_IMAGE_SIZE}`;
   }
-  return maybeSignUri(url, { w: size * MAX_IMAGE_SCALE });
+  return maybeSignUri(url, { w: FULL_NFT_IMAGE_SIZE });
 };

--- a/src/utils/walletConnect.ts
+++ b/src/utils/walletConnect.ts
@@ -307,7 +307,8 @@ export async function onSessionProposal(
       dappScheme: 'unused in WC v2', // only used for deeplinks from WC v1
       dappUrl: peerMeta.url || lang.t(lang.l.walletconnect.unknown_url),
       imageUrl: maybeSignUri(
-        dappLogoOverride(peerMeta?.url) || peerMeta?.icons?.[0]
+        dappLogoOverride(peerMeta?.url) || peerMeta?.icons?.[0],
+        { w: 200 }
       ),
       peerId: proposer.publicKey,
       isWalletConnectV2: true,
@@ -506,7 +507,8 @@ export async function onSessionRequest(
       dappUrl: peerMeta.url || 'Unknown URL',
       displayDetails,
       imageUrl: maybeSignUri(
-        dappLogoOverride(peerMeta.url) || peerMeta.icons[0]
+        dappLogoOverride(peerMeta.url) || peerMeta.icons[0],
+        { w: 200 }
       ),
       payload: event.params.request,
       walletConnectV2RequestValues: {


### PR DESCRIPTION
Fixes APP-444

## What changed (plus any additional context for devs)

Made the size prop mandatory in `ImgixImage` as a quick stop gap against loading unnecessarily large images

rest of the changes are me adding the prop where its missing. 

more context in the ticket

note: this does not affect rending at all but only the resizing that happens for remote images

mikey's wallet now loads fast AF, there are also some perf improvements noticed in the `ChangeWalletList`


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2023-02-09-13-56-48.mp4



## What to test
light QA pass making sure images are loading in properly and arnt grainy 


