### PR TITLE
add profiles to config and edit logic

### DIFF
--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -50,6 +50,7 @@ export interface RainbowConfig extends Record<string, any> {
   swagg_enabled?: boolean;
   trace_call_block_number_offset?: number;
   wyre_enabled?: boolean;
+  profiles_enabled?: boolean;
 }
 
 const DEFAULT_CONFIG = {
@@ -78,6 +79,7 @@ const DEFAULT_CONFIG = {
   swagg_enabled: true,
   trace_call_block_number_offset: 20,
   wyre_enabled: true,
+  profiles_enabled: true,
 };
 
 // Initialize with defaults in case firebase doesn't respond
@@ -111,7 +113,8 @@ const init = async () => {
         key === 'wyre_enabled' ||
         key === 'f2c_enabled' ||
         key === 'swagg_enabled' ||
-        key === 'op_rewards_enabled'
+        key === 'op_rewards_enabled' ||
+        key === 'profiles_enabled'
       ) {
         config[key] = entry.asBoolean();
       } else {

--- a/src/screens/discover/components/DiscoverHome.js
+++ b/src/screens/discover/components/DiscoverHome.js
@@ -7,9 +7,7 @@ import useExperimentalFlag, {
 import Lists from './ListsSection';
 import { isTestnetNetwork } from '@/handlers/web3';
 import { Inline, Inset, Stack } from '@/design-system';
-import { useAccountAsset, useAccountSettings } from '@/hooks';
-import { ETH_ADDRESS } from '@/references';
-import { isZero } from '@/helpers/utilities';
+import { useAccountSettings } from '@/hooks';
 import { ENSCreateProfileCard } from '@/components/cards/ENSCreateProfileCard';
 import { ENSSearchCard } from '@/components/cards/ENSSearchCard';
 import { DPICard } from '@/components/cards/DPICard';
@@ -26,7 +24,6 @@ import config from '@/model/config';
 
 export default function DiscoverHome() {
   const { network } = useAccountSettings();
-  const accountAsset = useAccountAsset(ETH_ADDRESS);
   const profilesEnabledLocalFlag = useExperimentalFlag(PROFILES);
   const profilesEnabledRemoteFlag = config.profiles_enabled;
   const hardwareWalletsEnabled = useExperimentalFlag(HARDWARE_WALLETS);

--- a/src/screens/discover/components/DiscoverHome.js
+++ b/src/screens/discover/components/DiscoverHome.js
@@ -27,28 +27,29 @@ import config from '@/model/config';
 export default function DiscoverHome() {
   const { network } = useAccountSettings();
   const accountAsset = useAccountAsset(ETH_ADDRESS);
-  const profilesEnabled = useExperimentalFlag(PROFILES);
+  const profilesEnabledLocalFlag = useExperimentalFlag(PROFILES);
+  const profilesEnabledRemoteFlag = config.profiles_enabled;
   const hardwareWalletsEnabled = useExperimentalFlag(HARDWARE_WALLETS);
   const opRewardsLocalFlag = useExperimentalFlag(OP_REWARDS);
   const opRewardsRemoteFlag = config.op_rewards_enabled;
   const testNetwork = isTestnetNetwork(network);
+  const isProfilesEnabled =
+    profilesEnabledLocalFlag && profilesEnabledRemoteFlag;
 
   return (
     <Inset top="20px" bottom={{ custom: 150 }}>
       <Stack space="20px">
         <Inset horizontal="20px">
-          {profilesEnabled &&
-          !testNetwork &&
-          !isZero(accountAsset.balance.amount) ? (
+          {!testNetwork ? (
             <Stack space="20px">
               <Inline space="20px">
                 <GasCard />
-                <ENSSearchCard />
+                {isProfilesEnabled && <ENSSearchCard />}
               </Inline>
               {/* We have both flags here to be able to override the remote flag and show the card anyway in Dev*/}
               {(opRewardsRemoteFlag || opRewardsLocalFlag) && <OpRewardsCard />}
               {hardwareWalletsEnabled && <LedgerCard />}
-              <ENSCreateProfileCard />
+              {isProfilesEnabled && <ENSCreateProfileCard />}
               <Inline space="20px">
                 <LearnCard cardDetails={backupsCard} type="square" />
                 <LearnCard cardDetails={avoidScamsCard} type="square" />


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
changes Discover screen logic to follow our remote config logic instead of on device balance checks 

had to add profiles to remote config as well 


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2023-02-13-15-41-44.mp4


## What to test
remote config 
