### PR TITLE
Truncate long leaderboard ENS names

### DIFF
--- a/src/design-system/components/Text/Text.tsx
+++ b/src/design-system/components/Text/Text.tsx
@@ -23,6 +23,7 @@ export function selectTextSizes<SelectedTextSizes extends readonly TextSize[]>(
 export type TextProps = {
   align?: 'center' | 'left' | 'right';
   color: TextColor | CustomColor;
+  ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip' | undefined;
   numberOfLines?: number;
   size: TextSize;
   tabularNumbers?: boolean;
@@ -39,16 +40,17 @@ export type TextProps = {
 export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
   function Text(
     {
-      numberOfLines,
-      containsEmoji: containsEmojiProp = false,
-      children,
-      testID,
       align,
+      children,
       color,
+      containsEmoji: containsEmojiProp = false,
+      ellipsizeMode,
+      numberOfLines,
       size,
-      weight,
       tabularNumbers,
+      testID,
       uppercase,
+      weight,
     },
     ref
   ) {
@@ -85,6 +87,7 @@ export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
       <NativeText
         allowFontScaling={false}
         numberOfLines={numberOfLines}
+        ellipsizeMode={ellipsizeMode}
         ref={ref}
         style={textStyle}
         testID={testID}

--- a/src/screens/rewards/components/RewardsLeaderboardItem.tsx
+++ b/src/screens/rewards/components/RewardsLeaderboardItem.tsx
@@ -118,7 +118,14 @@ export const RewardsLeaderboardItem: React.FC<Props> = ({
             </Box>
           </Column>
           <Stack space="8px">
-            <Text color="label" size="15pt" weight="semibold">
+            <Text
+              color="label"
+              ellipsizeMode="middle"
+              numberOfLines={1}
+              size="15pt"
+              weight="semibold"
+              containsEmoji
+            >
               {ens ?? `${address.slice(0, 6)}...${address.slice(-4)}`}
             </Text>
             <Text size="13pt" color="labelTertiary" weight="semibold">


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Truncating long ens names int the leaderboard

## PoW

<img width="653" alt="CleanShot 2023-02-15 at 13 45 21@2x" src="https://user-images.githubusercontent.com/16062886/219030804-9f694a98-3aad-4f78-8ade-e4f789f6858f.png">
