### PR TITLE
Fix wrong my stats cards titles

### DIFF
--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -1299,6 +1299,8 @@
       "next_airdrop": "Next Airdrop",
       "last_airdrop": "Last Airdrop",
       "my_stats": "My Stats",
+      "swapped": "Swapped",
+      "bridged": "Bridged",
       "position": "Position",
       "leaderboard": "Leaderboard",
       "leaderboard_data_refresh_notice": "Updates periodically throughout the day. Check back soon if your recent activity isn’t reflected.",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -1300,6 +1300,8 @@
       "next_airdrop": "Next Airdrop :)",
       "last_airdrop": "Last Airdrop :)",
       "my_stats": "My Stats :)",
+      "swapped": "Swapped :)",
+      "bridged": "Bridged :)",
       "position": "Position :)",
       "leaderboard": "Leaderboard :)",
       "leaderboard_data_refresh_notice": "Updates periodically throughout the day. Check back soon if your recent activity isn’t reflected. :)",

--- a/src/screens/rewards/components/RewardsStats.tsx
+++ b/src/screens/rewards/components/RewardsStats.tsx
@@ -19,6 +19,7 @@ import { AppState } from '@/redux/store';
 import { analyticsV2 } from '@/analytics';
 import { TextColor } from '@/design-system/color/palettes';
 import { CustomColor } from '@/design-system/color/useForegroundColor';
+import { STATS_TITLES } from '@/screens/rewards/constants';
 
 const getPositionChangeSymbol = (positionChange: number) => {
   if (positionChange > 0) {
@@ -131,7 +132,7 @@ export const RewardsStats: React.FC<Props> = ({
                 return (
                   <RewardsStatsCard
                     key={action.type}
-                    title={capitalize(action.type)}
+                    title={STATS_TITLES[action.type]}
                     value={value}
                     secondaryValue={i18n.t(i18n.l.rewards.percent, {
                       percent: action.rewardPercent,

--- a/src/screens/rewards/constants.ts
+++ b/src/screens/rewards/constants.ts
@@ -1,3 +1,6 @@
+import { RewardStatsActionType } from '@/graphql/__generated__/metadata';
+import * as i18n from '@/languages';
+
 export const RANK_SYMBOLS: Record<string, string> = {
   '1': '🥇',
   '2': '🥈',
@@ -58,3 +61,7 @@ export const DARK_RANK_3_GRADIENT_COLORS = ['#DE8F38', '#AE5F25'];
 export const LIGHT_RANK_1_GRADIENT_COLORS = ['#E2B730', '#CF9500'];
 export const LIGHT_RANK_2_GRADIENT_COLORS = ['#ABAFB6', '#81858B'];
 export const LIGHT_RANK_3_GRADIENT_COLORS = ['#D48834', '#AA5820'];
+export const STATS_TITLES = {
+  [RewardStatsActionType.Swap]: i18n.t(i18n.l.rewards.swapped),
+  [RewardStatsActionType.Bridge]: i18n.t(i18n.l.rewards.bridged),
+};


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Fixed improper names on stats cards – Swap -> Swapped , Bridge -> Bridged

## PoW
<img width="653" alt="CleanShot 2023-02-15 at 13 53 28@2x" src="https://user-images.githubusercontent.com/16062886/219032567-d69039a8-efc8-4db1-9b5c-412573ab876b.png">
