### PR TITLE
Remove DiscoverSheet XCode Group

### DIFF
--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -420,7 +420,6 @@
 			children = (
 				15C398772880DF82006033AC /* AppIcons */,
 				4D098C2C2811A95F006A801A /* RNStartTime */,
-				66F889D0260CEE0E00E27D6E /* DiscoverSheet */,
 				1539422B24C7CF7B00E4A9D1 /* Settings */,
 				66A1FEAE24AB63D600C3F539 /* RNCoolModals */,
 				15E531D7242DAB3500797B89 /* NSNotifications */,
@@ -577,13 +576,6 @@
 				66A1FEB124AB641100C3F539 /* UIViewController+slack.swift */,
 			);
 			name = RNCoolModals;
-			sourceTree = "<group>";
-		};
-		66F889D0260CEE0E00E27D6E /* DiscoverSheet */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = DiscoverSheet;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Removed `DiscoverSheet` group from XCode project. It was there in the PBXProj as a leftover from cleaning done some time ago

Extracted from https://github.com/rainbow-me/rainbow/pull/4641 to be a separate more granular PR