### PR TITLE
Optimize usePersistentDominantColorFromImage hook

### DIFF
--- a/patches/react-native-palette-full+1.2.0.patch
+++ b/patches/react-native-palette-full+1.2.0.patch
@@ -14,10 +14,33 @@ index 1cfd46e..020d4e4 100644
  
  import com.facebook.common.executors.CallerThreadExecutor;
 diff --git a/node_modules/react-native-palette-full/ios/RNPalette.m b/node_modules/react-native-palette-full/ios/RNPalette.m
-index fc6704d..577fa35 100644
+index fc6704d..eaa5868 100644
 --- a/node_modules/react-native-palette-full/ios/RNPalette.m
 +++ b/node_modules/react-native-palette-full/ios/RNPalette.m
-@@ -162,7 +162,7 @@ - (void)getAllSwatchesFromImage:(UIImage *)image
+@@ -115,6 +115,11 @@ RCT_REMAP_METHOD(getNamedSwatches,
+   
+   //NSURL * urlImage = [NSURL URLWithString: url];
+   UIImage * image = [UIImage imageWithContentsOfFile:url];
++  if (image == nil) {
++    reject(@"500", @"Error image", nil);
++    return;
++  }
++    
+   [self getNamedSwatchesFromImage:image resolver:resolve rejecter:reject];
+   
+ }
+@@ -130,6 +135,10 @@ RCT_REMAP_METHOD(getAllSwatches,
+   
+   //NSURL * urlImage = [NSURL URLWithString: url];
+   UIImage * image = [UIImage imageWithContentsOfFile:url];
++  if (image == nil) {
++    reject(@"500", @"Error image", nil);
++    return;
++  }
+   [self getAllSwatchesFromImage:image resolver:resolve rejecter:reject];
+   
+ }
+@@ -162,7 +171,7 @@ RCT_REMAP_METHOD(getAllSwatches,
      if ([[allModeColorDic objectForKey:@"vibrant"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * vibrant = (PaletteColorModel *)[allModeColorDic objectForKey:@"vibrant"];
        [data addObject:@{
@@ -26,7 +49,7 @@ index fc6704d..577fa35 100644
            @"color":[vibrant  imageColorString],
            @"population" : [NSNumber numberWithInteger:[vibrant population]],
            @"percentage":[NSNumber numberWithFloat:[vibrant percentage]],
-@@ -171,7 +171,7 @@ - (void)getAllSwatchesFromImage:(UIImage *)image
+@@ -171,7 +180,7 @@ RCT_REMAP_METHOD(getAllSwatches,
      if ([[allModeColorDic objectForKey:@"dark_vibrant"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * dark_vibrant = (PaletteColorModel *)[allModeColorDic objectForKey:@"dark_vibrant"];
        [data addObject:@{
@@ -35,7 +58,7 @@ index fc6704d..577fa35 100644
            @"color":[dark_vibrant  imageColorString],
            @"population" : [NSNumber numberWithInteger:[dark_vibrant population]],
            @"percentage":[NSNumber numberWithFloat:[dark_vibrant percentage]],
-@@ -180,7 +180,7 @@ - (void)getAllSwatchesFromImage:(UIImage *)image
+@@ -180,7 +189,7 @@ RCT_REMAP_METHOD(getAllSwatches,
      if ([[allModeColorDic objectForKey:@"light_vibrant"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * light_vibrant = (PaletteColorModel *)[allModeColorDic objectForKey:@"light_vibrant"];
        [data addObject:@{
@@ -44,7 +67,7 @@ index fc6704d..577fa35 100644
            @"color":[light_vibrant  imageColorString],
            @"population" : [NSNumber numberWithInteger:[light_vibrant population]],
            @"percentage":[NSNumber numberWithFloat:[light_vibrant percentage]],
-@@ -189,7 +189,7 @@ - (void)getAllSwatchesFromImage:(UIImage *)image
+@@ -189,7 +198,7 @@ RCT_REMAP_METHOD(getAllSwatches,
      if ([[allModeColorDic objectForKey:@"muted"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * muted = (PaletteColorModel *)[allModeColorDic objectForKey:@"muted"];
        [data addObject:@{
@@ -53,7 +76,7 @@ index fc6704d..577fa35 100644
            @"color":[muted imageColorString],
            @"population" : [NSNumber numberWithInteger:[muted population]],
            @"percentage":[NSNumber numberWithFloat:[muted percentage]],
-@@ -198,7 +198,7 @@ - (void)getAllSwatchesFromImage:(UIImage *)image
+@@ -198,7 +207,7 @@ RCT_REMAP_METHOD(getAllSwatches,
      if ([[allModeColorDic objectForKey:@"dark_muted"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * dark_muted = (PaletteColorModel *)[allModeColorDic objectForKey:@"dark_muted"];
        [data addObject:@{
@@ -62,7 +85,7 @@ index fc6704d..577fa35 100644
            @"color":[dark_muted imageColorString],
            @"population" : [NSNumber numberWithInteger:[dark_muted population]],
            @"percentage":[NSNumber numberWithFloat:[dark_muted percentage]],
-@@ -207,7 +207,7 @@ - (void)getAllSwatchesFromImage:(UIImage *)image
+@@ -207,7 +216,7 @@ RCT_REMAP_METHOD(getAllSwatches,
      if ([[allModeColorDic objectForKey:@"light_muted"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * light_muted = (PaletteColorModel *)[allModeColorDic objectForKey:@"light_muted"];
        [data addObject:@{
@@ -71,7 +94,7 @@ index fc6704d..577fa35 100644
            @"color":[light_muted imageColorString],
            @"population" : [NSNumber numberWithInteger:[light_muted population]],
            @"percentage":[NSNumber numberWithFloat:[light_muted percentage]],
-@@ -244,7 +244,7 @@ - (void)getNamedSwatchesFromImage:(UIImage *)image
+@@ -244,7 +253,7 @@ RCT_REMAP_METHOD(getAllSwatches,
          @"color":[vibrant imageColorString],
          @"population":[NSNumber numberWithInteger:[vibrant population]],
          @"percentage":[NSNumber numberWithFloat:[vibrant percentage]]
@@ -80,7 +103,7 @@ index fc6704d..577fa35 100644
      }
      if ([[allModeColorDic objectForKey:@"dark_vibrant"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * dark_vibrant = (PaletteColorModel *)[allModeColorDic objectForKey:@"dark_vibrant"];
-@@ -252,7 +252,7 @@ - (void)getNamedSwatchesFromImage:(UIImage *)image
+@@ -252,7 +261,7 @@ RCT_REMAP_METHOD(getAllSwatches,
          @"color":[dark_vibrant imageColorString],
          @"population":[NSNumber numberWithInteger:[dark_vibrant population]],
          @"percentage":[NSNumber numberWithFloat:[dark_vibrant percentage]]
@@ -89,7 +112,7 @@ index fc6704d..577fa35 100644
  
      }
      if ([[allModeColorDic objectForKey:@"light_vibrant"] isKindOfClass:[PaletteColorModel class]]){
-@@ -261,7 +261,7 @@ - (void)getNamedSwatchesFromImage:(UIImage *)image
+@@ -261,7 +270,7 @@ RCT_REMAP_METHOD(getAllSwatches,
          @"color":[light_vibrant imageColorString],
          @"population":[NSNumber numberWithInteger:[light_vibrant population]],
          @"percentage":[NSNumber numberWithFloat:[light_vibrant percentage]],
@@ -98,7 +121,7 @@ index fc6704d..577fa35 100644
      }
      if ([[allModeColorDic objectForKey:@"muted"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * muted = (PaletteColorModel *)[allModeColorDic objectForKey:@"muted"];
-@@ -269,7 +269,7 @@ - (void)getNamedSwatchesFromImage:(UIImage *)image
+@@ -269,7 +278,7 @@ RCT_REMAP_METHOD(getAllSwatches,
          @"color":[muted imageColorString],
          @"population":[NSNumber numberWithInteger:[muted population]],
          @"percentage":[NSNumber numberWithFloat:[muted percentage]]
@@ -107,7 +130,7 @@ index fc6704d..577fa35 100644
      }
      if ([[allModeColorDic objectForKey:@"dark_muted"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * dark_muted = (PaletteColorModel *)[allModeColorDic objectForKey:@"dark_muted"];
-@@ -277,7 +277,7 @@ - (void)getNamedSwatchesFromImage:(UIImage *)image
+@@ -277,7 +286,7 @@ RCT_REMAP_METHOD(getAllSwatches,
          @"color":[dark_muted imageColorString],
          @"population":[NSNumber numberWithInteger:[dark_muted population]],
          @"percentage":[NSNumber numberWithFloat:[dark_muted percentage]]
@@ -116,7 +139,7 @@ index fc6704d..577fa35 100644
      }
      if ([[allModeColorDic objectForKey:@"light_muted"] isKindOfClass:[PaletteColorModel class]]){
        PaletteColorModel * light_muted = (PaletteColorModel *)[allModeColorDic objectForKey:@"light_muted"];
-@@ -285,7 +285,7 @@ - (void)getNamedSwatchesFromImage:(UIImage *)image
+@@ -285,7 +294,7 @@ RCT_REMAP_METHOD(getAllSwatches,
          @"color":[light_muted imageColorString],
          @"population":[NSNumber numberWithInteger:[light_muted population]],
          @"percentage":[NSNumber numberWithFloat:[light_muted percentage]]

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -11,7 +11,6 @@ import { ButtonPressAnimation } from '@/components/animations';
 import { ImgixImage } from '@/components/images';
 import Skeleton from '@/components/skeleton/Skeleton';
 import { AccentColorProvider, Box, Cover, useColorMode } from '@/design-system';
-import { maybeSignUri } from '@/handlers/imgix';
 import {
   useAccountProfile,
   useLatestCallback,
@@ -47,7 +46,10 @@ export function ProfileAvatarRow({
   } = useOnAvatarPress({ screenType: 'wallet' });
 
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    maybeSignUri(accountImage ?? '', { w: 200 }) ?? ''
+    accountImage,
+    {
+      signUrl: true,
+    }
   );
 
   // ////////////////////////////////////////////////////

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -15,7 +15,6 @@ import {
   useAccountProfile,
   useLatestCallback,
   useOnAvatarPress,
-  usePersistentDominantColorFromImage,
 } from '@/hooks';
 import { useTheme } from '@/theme';
 import { getFirstGrapheme } from '@/utils';
@@ -24,6 +23,7 @@ import { useRecyclerAssetListPosition } from '../core/Contexts';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { navbarHeight } from '@/components/navbar/Navbar';
 import { IS_ANDROID } from '@/env';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 export const ProfileAvatarRowHeight = 80;
 export const ProfileAvatarRowTopInset = 24;
@@ -45,12 +45,9 @@ export function ProfileAvatarRow({
     onSelectionCallback,
   } = useOnAvatarPress({ screenType: 'wallet' });
 
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    accountImage,
-    {
-      signUrl: true,
-    }
-  );
+  const { dominantColor } = usePersistentDominantColorFromImage({
+    url: accountImage,
+  });
 
   // ////////////////////////////////////////////////////
   // Context Menu

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -45,9 +45,7 @@ export function ProfileAvatarRow({
     onSelectionCallback,
   } = useOnAvatarPress({ screenType: 'wallet' });
 
-  const { dominantColor } = usePersistentDominantColorFromImage({
-    url: accountImage,
-  });
+  const { dominantColor } = usePersistentDominantColorFromImage(accountImage);
 
   // ////////////////////////////////////////////////////
   // Context Menu

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -45,7 +45,7 @@ export function ProfileAvatarRow({
     onSelectionCallback,
   } = useOnAvatarPress({ screenType: 'wallet' });
 
-  const { dominantColor } = usePersistentDominantColorFromImage(accountImage);
+  const dominantColor = usePersistentDominantColorFromImage(accountImage);
 
   // ////////////////////////////////////////////////////
   // Context Menu
@@ -68,7 +68,7 @@ export function ProfileAvatarRow({
 
   let accentColor = colors.skeleton;
   if (accountImage) {
-    accentColor = dominantColor || colors.skeleton;
+    accentColor = dominantColor || colors.appleBlue;
   } else if (typeof accountColor === 'number') {
     accentColor = colors.avatarBackgrounds[accountColor];
   }

--- a/src/components/ens-profile/ProfileCover/ProfileCover.tsx
+++ b/src/components/ens-profile/ProfileCover/ProfileCover.tsx
@@ -33,7 +33,6 @@ export default function ProfileCover({
   const showSkeleton = isLoading || !isFetched;
   const showRadialGradient = ios && !coverUrl && isFetched && !isLoading;
 
-  console.log('coverUrl: ', coverUrl);
   return (
     <>
       {showSkeleton && (

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -6,7 +6,6 @@ import { useTheme } from '../../theme/ThemeContext';
 import { magicMemo } from '../../utils';
 import ProfileModal from './profile/ProfileModal';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import { maybeSignUri } from '@/handlers/imgix';
 import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
@@ -85,7 +84,10 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    maybeSignUri(avatarUrl || '', { w: 200 }) || ''
+    avatarUrl,
+    {
+      signUrl: true,
+    }
   );
 
   const accentColor =

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -10,16 +10,12 @@ import {
   removeFirstEmojiFromString,
   returnStringFirstEmoji,
 } from '@/helpers/emojiHandler';
-import {
-  useAccountSettings,
-  useContacts,
-  useENSAvatar,
-  usePersistentDominantColorFromImage,
-} from '@/hooks';
+import { useAccountSettings, useContacts, useENSAvatar } from '@/hooks';
 import {
   addressHashedColorIndex,
   addressHashedEmoji,
 } from '@/utils/profileUtils';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const profilesEnabled = useExperimentalFlag(PROFILES);
@@ -83,12 +79,9 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const { data: avatar } = useENSAvatar(ens, { enabled: Boolean(ens) });
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarUrl,
-    {
-      signUrl: true,
-    }
-  );
+  const { dominantColor } = usePersistentDominantColorFromImage({
+    url: avatarUrl,
+  });
 
   const accentColor =
     dominantColor || color || colors.avatarBackgrounds[colorIndex || 0];

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -79,7 +79,7 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const { data: avatar } = useENSAvatar(ens, { enabled: Boolean(ens) });
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
-  const { dominantColor } = usePersistentDominantColorFromImage(avatarUrl);
+  const dominantColor = usePersistentDominantColorFromImage(avatarUrl);
 
   const accentColor =
     dominantColor || color || colors.avatarBackgrounds[colorIndex || 0];

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -79,9 +79,7 @@ const ContactProfileState = ({ address, color, contact, ens, nickname }) => {
   const { data: avatar } = useENSAvatar(ens, { enabled: Boolean(ens) });
   const avatarUrl = profilesEnabled ? avatar?.imageUrl : undefined;
 
-  const { dominantColor } = usePersistentDominantColorFromImage({
-    url: avatarUrl,
-  });
+  const { dominantColor } = usePersistentDominantColorFromImage(avatarUrl);
 
   const accentColor =
     dominantColor || color || colors.avatarBackgrounds[colorIndex || 0];

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -63,7 +63,6 @@ import {
   useENSProfile,
   useENSRegistration,
   useHiddenTokens,
-  usePersistentDominantColorFromImage,
   useShowcaseTokens,
 } from '@/hooks';
 import { useNavigation, useUntrustedUrlOpener } from '@/navigation';
@@ -77,6 +76,7 @@ import {
   magicMemo,
   safeAreaInsetValues,
 } from '@/utils';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 const BackgroundBlur = styled(BlurView).attrs({
   blurAmount: 100,
@@ -358,8 +358,9 @@ const UniqueTokenExpandedState = ({
   const rainbowWebUrl = buildRainbowUrl(asset, cleanENSName, accountAddress);
 
   const imageColor =
-    usePersistentDominantColorFromImage(asset.lowResUrl).result ||
-    colors.paleBlue;
+    usePersistentDominantColorFromImage({
+      url: asset.lowResUrl,
+    }).dominantColor ?? colors.paleBlue;
 
   const textColor = useMemo(() => {
     const contrastWithWhite = c.contrast(imageColor, colors.whiteLabel);

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -358,8 +358,7 @@ const UniqueTokenExpandedState = ({
   const rainbowWebUrl = buildRainbowUrl(asset, cleanENSName, accountAddress);
 
   const imageColor =
-    usePersistentDominantColorFromImage(asset.lowResUrl).dominantColor ??
-    colors.paleBlue;
+    usePersistentDominantColorFromImage(asset.lowResUrl) ?? colors.paleBlue;
 
   const textColor = useMemo(() => {
     const contrastWithWhite = c.contrast(imageColor, colors.whiteLabel);

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -358,7 +358,6 @@ const UniqueTokenExpandedState = ({
   const rainbowWebUrl = buildRainbowUrl(asset, cleanENSName, accountAddress);
 
   const imageColor =
-    // @ts-expect-error image_url could be null or undefined?
     usePersistentDominantColorFromImage(asset.lowResUrl).result ||
     colors.paleBlue;
 

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -358,9 +358,8 @@ const UniqueTokenExpandedState = ({
   const rainbowWebUrl = buildRainbowUrl(asset, cleanENSName, accountAddress);
 
   const imageColor =
-    usePersistentDominantColorFromImage({
-      url: asset.lowResUrl,
-    }).dominantColor ?? colors.paleBlue;
+    usePersistentDominantColorFromImage(asset.lowResUrl).dominantColor ??
+    colors.paleBlue;
 
   const textColor = useMemo(() => {
     const contrastWithWhite = c.contrast(imageColor, colors.whiteLabel);

--- a/src/components/unique-token/UniqueTokenCard.js
+++ b/src/components/unique-token/UniqueTokenCard.js
@@ -38,7 +38,7 @@ const UniqueTokenCard = ({
   ...props
 }) => {
   usePersistentAspectRatio(item.lowResUrl);
-  usePersistentDominantColorFromImage({ url: item.lowResUrl });
+  usePersistentDominantColorFromImage(item.lowResUrl);
 
   const isSVG = isSVGImage(item.image_url);
 

--- a/src/components/unique-token/UniqueTokenCard.js
+++ b/src/components/unique-token/UniqueTokenCard.js
@@ -3,13 +3,11 @@ import { ButtonPressAnimation } from '../animations';
 import { InnerBorder } from '../layout';
 import { CardSize } from './CardSize';
 import UniqueTokenImage from './UniqueTokenImage';
-import {
-  usePersistentAspectRatio,
-  usePersistentDominantColorFromImage,
-} from '@/hooks';
+import { usePersistentAspectRatio } from '@/hooks';
 import styled from '@/styled-thing';
 import { shadow as shadowUtil } from '@/styles';
 import isSVGImage from '@/utils/isSVG';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 const UniqueTokenCardBorderRadius = 20;
 const UniqueTokenCardShadowFactory = colors => [0, 2, 6, colors.shadow, 0.08];
@@ -40,7 +38,7 @@ const UniqueTokenCard = ({
   ...props
 }) => {
   usePersistentAspectRatio(item.lowResUrl);
-  usePersistentDominantColorFromImage(item.lowResUrl);
+  usePersistentDominantColorFromImage({ url: item.lowResUrl });
 
   const isSVG = isSVGImage(item.image_url);
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -155,7 +155,6 @@ export { default as useTotalFeeEarnedPerAsset } from './useTotalFeeEarnedPerAsse
 export { default as useImportingWallet } from './useImportingWallet';
 export { default as useCurrentNonce } from './useCurrentNonce';
 export { default as usePersistentAspectRatio } from './usePersistentAspectRatio';
-export { default as usePersistentDominantColorFromImage } from './usePersistentDominantColorFromImage';
 export { default as useFeesPanelInputRefs } from './useFeesPanelInputRefs';
 export {
   default as useHardwareBack,

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -5,9 +5,7 @@ import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDomina
 export function useAccountAccentColor() {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
-  const { dominantColor, loading } = usePersistentDominantColorFromImage(
-    accountImage
-  );
+  const dominantColor = usePersistentDominantColorFromImage(accountImage);
 
   const { colors } = useTheme();
   let accentColor = colors.appleBlue;
@@ -17,7 +15,7 @@ export function useAccountAccentColor() {
     accentColor = colors.avatarBackgrounds[accountColor];
   }
 
-  const hasLoaded = accountImage || accountSymbol || !loading;
+  const hasLoaded = accountImage || accountSymbol;
 
   return {
     accentColor,

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -1,18 +1,13 @@
 import { useTheme } from '@/theme';
-import {
-  useAccountProfile,
-  usePersistentDominantColorFromImage,
-} from '@/hooks';
+import { useAccountProfile } from '@/hooks';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 export function useAccountAccentColor() {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
-  const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    accountImage,
-    {
-      signUrl: true,
-    }
-  );
+  const { dominantColor, loading } = usePersistentDominantColorFromImage({
+    url: accountImage,
+  });
 
   const { colors } = useTheme();
   let accentColor = colors.appleBlue;
@@ -22,8 +17,7 @@ export function useAccountAccentColor() {
     accentColor = colors.avatarBackgrounds[accountColor];
   }
 
-  const hasImageColorLoaded = state === 2 || state === 3;
-  const hasLoaded = accountImage || accountSymbol || hasImageColorLoaded;
+  const hasLoaded = accountImage || accountSymbol || !loading;
 
   return {
     accentColor,

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -1,4 +1,3 @@
-import { maybeSignUri } from '@/handlers/imgix';
 import { useTheme } from '@/theme';
 import {
   useAccountProfile,
@@ -9,7 +8,10 @@ export function useAccountAccentColor() {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
   const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    maybeSignUri(accountImage ?? '', { w: 200 }) ?? ''
+    accountImage,
+    {
+      signUrl: true,
+    }
   );
 
   const { colors } = useTheme();

--- a/src/hooks/useAccountAccentColor.ts
+++ b/src/hooks/useAccountAccentColor.ts
@@ -5,9 +5,9 @@ import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDomina
 export function useAccountAccentColor() {
   const { accountColor, accountImage, accountSymbol } = useAccountProfile();
 
-  const { dominantColor, loading } = usePersistentDominantColorFromImage({
-    url: accountImage,
-  });
+  const { dominantColor, loading } = usePersistentDominantColorFromImage(
+    accountImage
+  );
 
   const { colors } = useTheme();
   let accentColor = colors.appleBlue;

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -12,32 +12,25 @@ const COLOR_TO_MEASURE_AGAINST = '#333333';
 const SIZE_FOR_COLOR_CALCULATION = 40;
 
 export function usePersistentDominantColorFromImage(url?: string | null) {
-  // Will update if `url` changes
   const cachedColor = useMemo(
     () => (url ? storage.getString(url) : undefined),
     [url]
   );
   const [color, setColor] = useState(cachedColor);
-  // Will update if `url` changes
   const externalUrl = useMemo(
     () =>
       url ? maybeSignUri(url, { w: SIZE_FOR_COLOR_CALCULATION }) || url : url,
     [url]
   );
 
-  // console.log(externalUrl, cachedColor);
-
-  // Only Runs if `url`/`externalUrl` changes
   useEffect(() => {
     if (!cachedColor && externalUrl && url) {
       getDominantColorFromImage(externalUrl, COLOR_TO_MEASURE_AGAINST)
         .then(color => {
-          console.log('FINISHED GETTING COLOR: ', color);
           setColor(color);
           storage.set(url, color);
         })
         .catch(() => {
-          console.log('ERROR SETTING TO UNDEFINED');
           setColor(undefined);
         });
     } else {

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -1,96 +1,49 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { MMKV } from 'react-native-mmkv';
 import { STORAGE_IDS } from '@/model/mmkv';
 import { getDominantColorFromImage } from '@/utils';
 import { maybeSignUri } from '@/handlers/imgix';
-import usePrevious from './usePrevious';
 
-const DEFAULT_MMKV_KEY = 'DEFAULT_MMKV_KEY';
-const NOT_DEFINED_MMKV_VALUE = 'NOT_DEFINED';
 const storage = new MMKV({
   id: STORAGE_IDS.DOMINANT_COLOR,
 });
-// settings a default value to easily check against it instead of just undefined and to make the value be always a string
-storage.set(DEFAULT_MMKV_KEY, NOT_DEFINED_MMKV_VALUE);
 
-const DEFAULT_COLOR_TO_MEASURE_AGAINST = '#333333';
-const DEFAULT_SIZE_FOR_COLOR_PROBING = 80;
+const COLOR_TO_MEASURE_AGAINST = '#333333';
+const SIZE_FOR_COLOR_CALCULATION = 40;
 
-export function usePersistentDominantColorFromImage(
-  url: string | undefined | null,
-  colorToMeasureAgainst = DEFAULT_COLOR_TO_MEASURE_AGAINST
-) {
-  const previousUrl = usePrevious(url);
-  const didInitialize = useRef(false);
-  const externalUrl = useMemo(() => {
-    if (url) {
-      return maybeSignUri(url, { w: DEFAULT_SIZE_FOR_COLOR_PROBING });
-    }
-    return undefined;
-  }, [url]);
-  const currentCachedValue = storage.getString(url || DEFAULT_MMKV_KEY);
-  const [dominantColor, setDominantColor] = useState(
-    currentCachedValue !== NOT_DEFINED_MMKV_VALUE
-      ? currentCachedValue
-      : undefined
+export function usePersistentDominantColorFromImage(url?: string | null) {
+  // Will update if `url` changes
+  const cachedColor = useMemo(
+    () => (url ? storage.getString(url) : undefined),
+    [url]
   );
-  const [loading, setLoading] = useState(currentCachedValue === undefined);
+  const [color, setColor] = useState(cachedColor);
+  // Will update if `url` changes
+  const externalUrl = useMemo(
+    () =>
+      url ? maybeSignUri(url, { w: SIZE_FOR_COLOR_CALCULATION }) || url : url,
+    [url]
+  );
 
-  const checkIfCacheExistsAndSetColor = useCallback((): boolean => {
-    if (currentCachedValue && currentCachedValue !== NOT_DEFINED_MMKV_VALUE) {
-      setDominantColor(currentCachedValue);
-      setLoading(false);
-      return true;
-    }
-    return false;
-  }, [currentCachedValue]);
+  // console.log(externalUrl, cachedColor);
 
-  const fetchAndSetColor = useCallback(() => {
-    if (!url || !externalUrl) {
-      setDominantColor(undefined);
-      setLoading(false);
-      return;
-    }
-    setLoading(true);
-    getDominantColorFromImage(externalUrl, colorToMeasureAgainst)
-      .then(color => {
-        setDominantColor(color);
-        setLoading(false);
-        // We use original URL as a cache key
-        storage.set(url, color);
-      })
-      .catch(() => {
-        setDominantColor(undefined);
-        setLoading(false);
-      });
-  }, [colorToMeasureAgainst, externalUrl, url]);
-
+  // Only Runs if `url`/`externalUrl` changes
   useEffect(() => {
-    if (!url || !externalUrl) {
-      setDominantColor(undefined);
-      setLoading(false);
-      return;
+    if (!cachedColor && externalUrl && url) {
+      getDominantColorFromImage(externalUrl, COLOR_TO_MEASURE_AGAINST)
+        .then(color => {
+          console.log('FINISHED GETTING COLOR: ', color);
+          setColor(color);
+          storage.set(url, color);
+        })
+        .catch(() => {
+          console.log('ERROR SETTING TO UNDEFINED');
+          setColor(undefined);
+        });
+    } else {
+      setColor(cachedColor);
     }
-    if (!didInitialize.current || url !== previousUrl) {
-      didInitialize.current = true;
-      const alreadyCached = checkIfCacheExistsAndSetColor();
-      if (!alreadyCached) {
-        fetchAndSetColor();
-      }
-    }
-  }, [
-    checkIfCacheExistsAndSetColor,
-    externalUrl,
-    fetchAndSetColor,
-    previousUrl,
-    url,
-  ]);
+  }, [setColor, cachedColor, externalUrl, url]);
 
-  return useMemo(
-    () => ({
-      dominantColor,
-      loading,
-    }),
-    [dominantColor, loading]
-  );
+  return color;
 }

--- a/src/hooks/usePersistentDominantColorFromImage.ts
+++ b/src/hooks/usePersistentDominantColorFromImage.ts
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { MMKV, useMMKVString } from 'react-native-mmkv';
 import { STORAGE_IDS } from '@/model/mmkv';
 import { getDominantColorFromImage } from '@/utils';
+import { maybeSignUri } from '@/handlers/imgix';
+import usePrevious from './usePrevious';
 
 enum State {
   init,
@@ -10,52 +12,86 @@ enum State {
   failed,
 }
 
+const DEFAULT_MMKV_KEY = 'DEFAULT_MMKV_KEY';
+const NOT_DEFINED_MMKV_VALUE = 'NOT_DEFINED';
 const storage = new MMKV({
   id: STORAGE_IDS.DOMINANT_COLOR,
 });
+// settings a default value to easily check against it instead of just undefined and to make the value be always a string
+storage.set(DEFAULT_MMKV_KEY, NOT_DEFINED_MMKV_VALUE);
+
+const DEFAULT_COLOR_TO_MEASURE_AGAINST = '#333333';
+const DEFAULT_SIZE_FOR_COLOR_PROBING = 80;
 
 type Result = {
-  state: State;
   result: string | undefined;
+  state: State;
 };
 
+type ConfigOptions = {
+  colorToMeasureAgainst?: string;
+  signUrl?: boolean;
+};
 export default function usePersistentDominantColorFromImage(
-  url: string,
-  colorToMeasureAgainst: string = '#333333'
+  url: string | undefined | null,
+  options: ConfigOptions = {
+    colorToMeasureAgainst: DEFAULT_COLOR_TO_MEASURE_AGAINST,
+    signUrl: false,
+  }
 ): Result {
+  const previousUrl = usePrevious(url);
+  const { colorToMeasureAgainst: passedColor, signUrl } = options;
+  const externalUrl = useMemo(
+    () =>
+      signUrl && url
+        ? maybeSignUri(url, { w: DEFAULT_SIZE_FOR_COLOR_PROBING })
+        : url,
+    [signUrl, url]
+  );
+  const colorToMeasureAgainst = passedColor ?? DEFAULT_COLOR_TO_MEASURE_AGAINST;
   const [dominantColor, setPersistentDominantColor] = useMMKVString(
-    (url || '') as string,
+    url || DEFAULT_MMKV_KEY,
     storage
   );
-
+  // This is the most recent value saved in MMKV store, we can't use the value from the hook
+  // because it's updated a cycle behind due to onChange listener and useState usage
+  const currentStoreValue = storage.getString(url || DEFAULT_MMKV_KEY);
   const [state, setState] = useState<State>(
-    dominantColor ? State.loaded : url ? State.loading : State.init
+    currentStoreValue !== NOT_DEFINED_MMKV_VALUE ? State.loaded : State.init
   );
-  useEffect(() => {
-    if (!dominantColor) {
-      if (url) {
-        setState(State.loading);
-      } else {
-        setState(State.init);
-      }
-    }
-  }, [dominantColor, url]);
 
   useEffect(() => {
-    if ((state === State.loading || state === State.init) && url) {
+    if (
+      currentStoreValue !== NOT_DEFINED_MMKV_VALUE &&
+      currentStoreValue !== undefined
+    ) {
+      setState(State.loaded);
+    } else if (externalUrl && (state === State.init || url !== previousUrl)) {
       setState(State.loading);
-      getDominantColorFromImage(url, colorToMeasureAgainst)
+      getDominantColorFromImage(externalUrl, colorToMeasureAgainst)
         .then(color => {
           setPersistentDominantColor(color);
-        })
-        .finally(() => {
           setState(State.loaded);
+        })
+        .catch(() => {
+          setState(State.failed);
         });
     }
-  }, [colorToMeasureAgainst, setPersistentDominantColor, state, url]);
-
-  return {
-    result: dominantColor,
+  }, [
+    colorToMeasureAgainst,
+    externalUrl,
+    setPersistentDominantColor,
     state,
-  };
+    url,
+    previousUrl,
+  ]);
+
+  return useMemo(
+    () => ({
+      result:
+        dominantColor === NOT_DEFINED_MMKV_VALUE ? undefined : dominantColor,
+      state,
+    }),
+    [state, dominantColor]
+  );
 }

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -70,10 +70,10 @@ import {
   useENSRegistrationStepHandler,
   useENSSearch,
   useKeyboardHeight,
-  usePersistentDominantColorFromImage,
   useWalletSectionsData,
 } from '@/hooks';
 import Routes from '@/navigation/routesNames';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 const BottomActionHeight = ios ? 281 : 250;
 const BottomActionHeightSmall = 215;
@@ -133,12 +133,9 @@ export default function ENSAssignRecordsSheet() {
 
   const avatarImage =
     avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarImage,
-    {
-      signUrl: true,
-    }
-  );
+  const { dominantColor } = usePersistentDominantColorFromImage({
+    url: avatarImage,
+  });
 
   const bottomActionHeight = isSmallPhone
     ? BottomActionHeightSmall

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -134,7 +134,10 @@ export default function ENSAssignRecordsSheet() {
   const avatarImage =
     avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || '';
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarImage
+    avatarImage,
+    {
+      signUrl: true,
+    }
   );
 
   const bottomActionHeight = isSmallPhone

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -133,9 +133,7 @@ export default function ENSAssignRecordsSheet() {
 
   const avatarImage =
     avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { dominantColor } = usePersistentDominantColorFromImage({
-    url: avatarImage,
-  });
+  const { dominantColor } = usePersistentDominantColorFromImage(avatarImage);
 
   const bottomActionHeight = isSmallPhone
     ? BottomActionHeightSmall

--- a/src/screens/ENSAssignRecordsSheet.tsx
+++ b/src/screens/ENSAssignRecordsSheet.tsx
@@ -133,7 +133,7 @@ export default function ENSAssignRecordsSheet() {
 
   const avatarImage =
     avatarUrl || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { dominantColor } = usePersistentDominantColorFromImage(avatarImage);
+  const dominantColor = usePersistentDominantColorFromImage(avatarImage);
 
   const bottomActionHeight = isSmallPhone
     ? BottomActionHeightSmall

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -125,9 +125,7 @@ export default function ENSConfirmRegisterSheet() {
 
   const avatarImage =
     avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { dominantColor } = usePersistentDominantColorFromImage({
-    url: avatarImage,
-  });
+  const { dominantColor } = usePersistentDominantColorFromImage(avatarImage);
 
   useEffect(() => {
     if (dominantColor || (!dominantColor && !avatarImage)) {

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -126,7 +126,10 @@ export default function ENSConfirmRegisterSheet() {
   const avatarImage =
     avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
   const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarImage
+    avatarImage,
+    {
+      signUrl: true,
+    }
   );
 
   useEffect(() => {

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -45,13 +45,13 @@ import {
   useENSRegistrationForm,
   useENSRegistrationStepHandler,
   useENSSearch,
-  usePersistentDominantColorFromImage,
   useWallets,
 } from '@/hooks';
 import { ImgixImage } from '@/components/images';
 import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import { colors } from '@/styles';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 export const ENSConfirmRegisterSheetHeight = 600;
 export const ENSConfirmRenewSheetHeight = 560;
@@ -125,12 +125,9 @@ export default function ENSConfirmRegisterSheet() {
 
   const avatarImage =
     avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { result: dominantColor } = usePersistentDominantColorFromImage(
-    avatarImage,
-    {
-      signUrl: true,
-    }
-  );
+  const { dominantColor } = usePersistentDominantColorFromImage({
+    url: avatarImage,
+  });
 
   useEffect(() => {
     if (dominantColor || (!dominantColor && !avatarImage)) {

--- a/src/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/screens/ENSConfirmRegisterSheet.tsx
@@ -125,7 +125,7 @@ export default function ENSConfirmRegisterSheet() {
 
   const avatarImage =
     avatarMetadata?.path || initialAvatarUrl || params?.externalAvatarUrl || '';
-  const { dominantColor } = usePersistentDominantColorFromImage(avatarImage);
+  const dominantColor = usePersistentDominantColorFromImage(avatarImage);
 
   useEffect(() => {
     if (dominantColor || (!dominantColor && !avatarImage)) {

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -69,10 +69,7 @@ export default function ProfileSheet() {
     [profileAddress]
   );
 
-  const {
-    dominantColor,
-    loading: dominantColorLoading,
-  } = usePersistentDominantColorFromImage(avatar?.imageUrl);
+  const dominantColor = usePersistentDominantColorFromImage(avatar?.imageUrl);
 
   const wrapperStyle = useMemo(() => ({ height: contentHeight }), [
     contentHeight,
@@ -81,7 +78,7 @@ export default function ProfileSheet() {
   const accentColor =
     // Set accent color when ENS images have fetched & dominant
     // color is not loading.
-    isAvatarFetched && !dominantColorLoading && typeof colorIndex === 'number'
+    isAvatarFetched && typeof colorIndex === 'number'
       ? dominantColor ||
         colors.avatarBackgrounds[colorIndex] ||
         colors.appleBlue

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -14,7 +14,6 @@ import {
   Inset,
   Stack,
 } from '@/design-system';
-import { maybeSignUri } from '@/handlers/imgix';
 import {
   useAccountSettings,
   useDimensions,
@@ -71,7 +70,10 @@ export default function ProfileSheet() {
   );
 
   const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    maybeSignUri(avatar?.imageUrl ?? '', { w: 200 }) ?? ''
+    avatar?.imageUrl,
+    {
+      signUrl: true,
+    }
   );
 
   const wrapperStyle = useMemo(() => ({ height: contentHeight }), [

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -72,9 +72,7 @@ export default function ProfileSheet() {
   const {
     dominantColor,
     loading: dominantColorLoading,
-  } = usePersistentDominantColorFromImage({
-    url: avatar?.imageUrl,
-  });
+  } = usePersistentDominantColorFromImage(avatar?.imageUrl);
 
   const wrapperStyle = useMemo(() => ({ height: contentHeight }), [
     contentHeight,

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -19,7 +19,6 @@ import {
   useDimensions,
   useENSAvatar,
   useExternalWalletSectionsData,
-  usePersistentDominantColorFromImage,
 } from '@/hooks';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
 import Routes from '@/navigation/routesNames';
@@ -27,6 +26,7 @@ import { useTheme } from '@/theme';
 import { addressHashedColorIndex } from '@/utils/profileUtils';
 import { useFirstTransactionTimestamp } from '@/resources/transactions/firstTransactionTimestampQuery';
 import { useENSAddress } from '@/resources/ens/ensAddressQuery';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 export const ProfileSheetConfigContext = createContext<{
   enableZoomableImages: boolean;
@@ -69,12 +69,12 @@ export default function ProfileSheet() {
     [profileAddress]
   );
 
-  const { result: dominantColor, state } = usePersistentDominantColorFromImage(
-    avatar?.imageUrl,
-    {
-      signUrl: true,
-    }
-  );
+  const {
+    dominantColor,
+    loading: dominantColorLoading,
+  } = usePersistentDominantColorFromImage({
+    url: avatar?.imageUrl,
+  });
 
   const wrapperStyle = useMemo(() => ({ height: contentHeight }), [
     contentHeight,
@@ -83,7 +83,7 @@ export default function ProfileSheet() {
   const accentColor =
     // Set accent color when ENS images have fetched & dominant
     // color is not loading.
-    isAvatarFetched && state !== 1 && typeof colorIndex === 'number'
+    isAvatarFetched && !dominantColorLoading && typeof colorIndex === 'number'
       ? dominantColor ||
         colors.avatarBackgrounds[colorIndex] ||
         colors.appleBlue


### PR DESCRIPTION
Fixes APP-437

## What changed (plus any additional context for devs)

* Changed hook code, to run in a more optimized way and cause less component re-renders.
* Problems stemmed mostly from the way `useMMKVString` works, it updates its internal state exactly one render after, which caused double effect calls, that then caused double expensive color calculation. On top of that it wasn't grabbing the initial state from MMKV properly causing to alwasy run color logic on first render. Right now it should run once and be saved in MMKV forever for an instance of a passed URL.
* Added option to sign urls inside the hook instead of having to remember to pass a signed url to the hook
* Left signing as an option because we sometimes use public urls with low resolution that don't need to be resigned.