### PR TITLE
Add logic to log user out properly when trying to restore backups while having no wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "react-native-camera": "4.2.1",
     "react-native-change-icon": "4.0.0",
     "react-native-circular-progress": "1.3.6",
-    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#6e2086b5e35515fb06abf6f37bfd682d23921481",
+    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#c5bcc4699e9725ffe1160c635c9f19db92e82f9f",
     "react-native-code-push": "7.0.4",
     "react-native-crypto": "2.2.0",
     "react-native-dark-mode": "0.2.2",

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -24,7 +24,7 @@ export const CLOUD_BACKUP_ERRORS = {
 };
 
 export function logoutFromGoogleDrive() {
-  android && RNCloudFs.logout();
+  IS_ANDROID && RNCloudFs.logout();
 }
 
 // This is used for dev purposes only!

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -6,6 +6,7 @@ import { RAINBOW_MASTER_KEY } from 'react-native-dotenv';
 import RNFS from 'react-native-fs';
 import AesEncryptor from '../handlers/aesEncryption';
 import { logger } from '../utils';
+import { IS_ANDROID } from '@/env';
 const REMOTE_BACKUP_WALLET_DIR = 'rainbow.me/wallet-backups';
 const USERDATA_FILE = 'UserData.json';
 const encryptor = new AesEncryptor();
@@ -126,7 +127,7 @@ export function syncCloud() {
 }
 
 export async function getDataFromCloud(backupPassword: any, filename = null) {
-  if (android) {
+  if (IS_ANDROID) {
     await RNCloudFs.loginIfNeeded();
   }
 

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -7,7 +7,7 @@ import React, { useMemo, useRef } from 'react';
 import * as i18n from '@/languages';
 import { HARDWARE_WALLETS, PROFILES, useExperimentalFlag } from '@/config';
 import { analytics, analyticsV2 } from '@/analytics';
-import { InteractionManager, View } from 'react-native';
+import { InteractionManager } from 'react-native';
 import { createAccountForWallet, walletsLoadState } from '@/redux/wallets';
 import WalletBackupTypes from '@/helpers/walletBackupTypes';
 import { createWallet, RainbowWallet } from '@/model/wallet';
@@ -19,14 +19,13 @@ import {
   backupUserDataIntoCloud,
   fetchUserDataFromCloud,
   isCloudBackupAvailable,
+  logoutFromGoogleDrive,
 } from '@/handlers/cloudBackup';
 import showWalletErrorAlert from '@/helpers/support';
 import { WalletLoadingStates } from '@/helpers/walletLoadingStates';
 import { cloudPlatform } from '@/utils/platform';
 import { IS_ANDROID, IS_IOS } from '@/env';
 import { RouteProp, useRoute } from '@react-navigation/native';
-// @ts-ignore ts is complaining about this import
-import RNCloudFs from 'react-native-cloud-fs';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { useInitializeWallet, useWallets } from '@/hooks';
 
@@ -241,7 +240,7 @@ export const AddWalletSheet = () => {
       type: 'seed',
     });
     if (IS_ANDROID) {
-      await RNCloudFs.logout();
+      await logoutFromGoogleDrive();
       const isAvailable = await isCloudBackupAvailable();
       if (isAvailable) {
         let proceed = false;

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -241,6 +241,7 @@ export const AddWalletSheet = () => {
       type: 'seed',
     });
     if (IS_ANDROID) {
+      await RNCloudFs.logout();
       const isAvailable = await isCloudBackupAvailable();
       if (isAvailable) {
         let proceed = false;
@@ -268,7 +269,6 @@ export const AddWalletSheet = () => {
               i18n.t(TRANSLATIONS.options.cloud.no_backups),
               i18n.t(TRANSLATIONS.options.cloud.no_google_backups)
             );
-            await RNCloudFs.logout();
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13475,9 +13475,9 @@ react-native-circular-progress@1.3.6:
   dependencies:
     prop-types "^15.7.2"
 
-react-native-cloud-fs@rainbow-me/react-native-cloud-fs#6e2086b5e35515fb06abf6f37bfd682d23921481:
+react-native-cloud-fs@rainbow-me/react-native-cloud-fs#c5bcc4699e9725ffe1160c635c9f19db92e82f9f:
   version "2.5.0"
-  resolved "https://codeload.github.com/rainbow-me/react-native-cloud-fs/tar.gz/6e2086b5e35515fb06abf6f37bfd682d23921481"
+  resolved "https://codeload.github.com/rainbow-me/react-native-cloud-fs/tar.gz/c5bcc4699e9725ffe1160c635c9f19db92e82f9f"
 
 react-native-code-push@7.0.4:
   version "7.0.4"


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Patched the `react-native-cloud-fs` library to properly handle logout
* Added a logout call to be the first thing to do when user clicks on restore from backup button
