### PR TITLE
feat: restrict Ramp to supported networks

### DIFF
--- a/src/screens/AddCash/providers/Ramp/index.tsx
+++ b/src/screens/AddCash/providers/Ramp/index.tsx
@@ -99,6 +99,7 @@ export function Ramp({ accountAddress }: { accountAddress: string }) {
           hostApiKey: RAMP_HOST_API_KEY,
           userAddress: accountAddress,
           defaultAsset: 'ETH',
+          swapAsset: 'ETH_*,MATIC_*,ARBITRUM_*,BSC_*,OPTIMISM_*',
           finalUrl: `https://rnbw.app/f2c?provider=${FiatProviderName.Ramp}&sessionId=${sessionId}`,
         });
         const uri = `${host}/?${params}`;


### PR DESCRIPTION
Fixes APP-468

## What changed (plus any additional context for devs)
Just configures [swapAsset](https://docs.ramp.network/configuration#swapasset) for Ramp URL, restricts purchasers to only networks we support for now.

