### PR TITLE
raps: fix 0 nonce scenario 

### DIFF
--- a/src/raps/common.ts
+++ b/src/raps/common.ts
@@ -490,7 +490,8 @@ export const executeRap = async (
       rapName,
       nonce
     );
-    if (baseNonce) {
+
+    if (typeof baseNonce === 'number') {
       for (let index = 1; index < actions.length; index++) {
         const action = actions[index];
         await executeAction(action, wallet, rap, index, rapName, baseNonce);


### PR DESCRIPTION
Fixes APP-272
## What changed (plus any additional context for devs)
our logic did not handle the scenario where a rap had a starting nonce of 0, if this was the case we wouldnt send the rest of the actions 


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2023-02-27-11-47-38.mp4


## What to test
create a new wallet, send assets, try to do a swap 

