### PR TITLE
feat: add isAuthenticated util

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -402,7 +402,7 @@ function AuthNavigator() {
       <AuthStack.Screen
         component={PinAuthenticationScreen}
         name={Routes.PIN_AUTHENTICATION_SCREEN}
-        options={{ ...sheetPreset, gestureEnabled: false }}
+        options={{ ...sheetPreset, gestureEnabled: true }}
       />
     </AuthStack.Navigator>
   );

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -402,7 +402,7 @@ function AuthNavigator() {
       <AuthStack.Screen
         component={PinAuthenticationScreen}
         name={Routes.PIN_AUTHENTICATION_SCREEN}
-        options={{ ...sheetPreset, gestureEnabled: true }}
+        options={{ ...sheetPreset, gestureEnabled: false }}
       />
     </AuthStack.Navigator>
   );

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -19,10 +19,9 @@ async function maybeSaveFakeAuthKey() {
 }
 
 export async function isAuthenticated() {
-  await maybeSaveFakeAuthKey();
-  const options = await keychain.getPrivateAccessControlOptions();
-
   if (IS_IOS) {
+    await maybeSaveFakeAuthKey();
+    const options = await keychain.getPrivateAccessControlOptions();
     const value = await keychain.loadString(FAKE_LOCAL_AUTH_KEY, options);
     return Boolean(value === FAKE_LOCAL_AUTH_VALUE);
   } else {

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,0 +1,37 @@
+import { hasInternetCredentials } from 'react-native-keychain';
+
+import { IS_IOS } from '@/env';
+import * as keychain from '@/model/keychain';
+import { authenticateWithPIN, getExistingPIN } from '@/handlers/authentication';
+
+const FAKE_LOCAL_AUTH_KEY = `fake-local-auth-key`;
+const FAKE_LOCAL_AUTH_VALUE = `fake-local-auth-value`;
+
+// only for iOS
+async function maybeSaveFakeAuthKey() {
+  if (await hasInternetCredentials(FAKE_LOCAL_AUTH_KEY)) return;
+  const options = await keychain.getPrivateAccessControlOptions();
+  await keychain.saveString(
+    FAKE_LOCAL_AUTH_KEY,
+    FAKE_LOCAL_AUTH_VALUE,
+    options
+  );
+}
+
+export async function isAuthenticated() {
+  await maybeSaveFakeAuthKey();
+  const options = await keychain.getPrivateAccessControlOptions();
+
+  if (IS_IOS) {
+    const value = await keychain.loadString(FAKE_LOCAL_AUTH_KEY, options);
+    return Boolean(value === FAKE_LOCAL_AUTH_VALUE);
+  } else {
+    try {
+      const pin = await authenticateWithPIN();
+      return Boolean(pin === (await getExistingPIN()));
+    } catch (e) {
+      // authenticatePin will throw if user rejects pin screen
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Fixes APP-469

## What changed (plus any additional context for devs)
Adds a util to prompt and determine if a user is the controlling user (passes FaceID, or pin code on Android).

```typescript
import { isAuthenticated } from '@/utils/authentication';

const authed = await isAuthenticated() // => boolean
```

