### PR TITLE
fix: getFCMToken handling, logging

### DIFF
--- a/src/notifications/tokens.ts
+++ b/src/notifications/tokens.ts
@@ -1,4 +1,5 @@
 import messaging from '@react-native-firebase/messaging';
+
 import { getLocal, saveLocal } from '@/handlers/localstorage/common';
 import { getPermissionStatus } from '@/notifications/permissions';
 import { logger, RainbowError } from '@/logger';
@@ -27,13 +28,13 @@ export const saveFCMToken = async () => {
   }
 };
 
-export const getFCMToken = async () => {
+export async function getFCMToken(): Promise<string | undefined> {
   const fcmTokenLocal = await getLocal('rainbowFcmToken');
+  const token = fcmTokenLocal?.data || undefined;
 
-  const fcmToken = fcmTokenLocal?.data ?? null;
-
-  if (!fcmToken) {
-    throw new Error('Push notification token unavailable.');
+  if (!token) {
+    logger.debug('getFCMToken: No FCM token found');
   }
-  return fcmToken;
-};
+
+  return token;
+}

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -31,6 +31,7 @@ import Routes from '@/navigation/routesNames';
 import { ethereumUtils, watchingAlert } from '@/utils';
 import { getFCMToken } from '@/notifications/tokens';
 import { logger, RainbowError } from '@/logger';
+import { IS_DEV } from '@/env';
 
 // -- Variables --------------------------------------- //
 let showRedirectSheetThreshold = 300;
@@ -198,15 +199,13 @@ const WALLETCONNECT_ADD_URI = 'walletconnect/WALLETCONNECT_ADD_URI';
  */
 const getNativeOptions = async () => {
   const language = 'en'; // TODO use lang from settings
-  let token = null;
-  try {
-    token = await getFCMToken();
-  } catch (error) {
+  const token = await getFCMToken();
+
+  if (!token && !IS_DEV) {
     logger.error(
       new RainbowError(
-        'WC: Error getting FCM token, ignoring token for WC connection'
-      ),
-      { error }
+        `WC: FCM token not found, push notifications will not be received`
+      )
     );
   }
 

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -3,7 +3,6 @@ import { parseWalletConnectUri } from '@walletconnect/legacy-utils';
 import lang from 'i18n-js';
 import { clone, isEmpty, mapValues, values } from 'lodash';
 import { AppState, InteractionManager, Linking } from 'react-native';
-import { IS_TESTING } from 'react-native-dotenv';
 import Minimizer from 'react-native-minimizer';
 import { Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -31,7 +30,7 @@ import Routes from '@/navigation/routesNames';
 import { ethereumUtils, watchingAlert } from '@/utils';
 import { getFCMToken } from '@/notifications/tokens';
 import { logger, RainbowError } from '@/logger';
-import { IS_DEV } from '@/env';
+import { IS_DEV, IS_TEST } from '@/env';
 
 // -- Variables --------------------------------------- //
 let showRedirectSheetThreshold = 300;
@@ -271,7 +270,7 @@ export const walletConnectRemovePendingRedirect = (
         Minimizer.goBack();
       }, 300);
     } else {
-      IS_TESTING !== 'true' && Minimizer.goBack();
+      !IS_TEST && Minimizer.goBack();
     }
     // If it's still active after showRedirectSheetThreshold
     // We need to show the redirect sheet cause the redirect
@@ -434,12 +433,12 @@ export const walletConnectOnSessionRequest = (
 
       let waitingFn: (callback: () => unknown, timeout: number) => unknown =
         InteractionManager.runAfterInteractions;
-      if (IS_TESTING === 'true') {
+      if (IS_TEST) {
         waitingFn = setTimeout;
       }
 
       waitingFn(async () => {
-        if (IS_TESTING !== 'true') {
+        if (IS_TEST) {
           // Wait until the app is idle so we can navigate
           // This usually happens only when coming from a cold start
           while (!getState().appState.walletReady) {


### PR DESCRIPTION
Just cleaning up local dev logs and updated `getFCMToken`.

I don't think `getFCMToken` should throw, I think we should handle the errors closer to call-site so we get better context on what happened.