### PR TITLE
Bump Kotlin version 1.6.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
             // Otherwise we default to the side-by-side NDK version from AGP.
             ndkVersion = "21.4.7075529"
         }
-        kotlin_version = "1.3.50"
+        kotlin_version = "1.6.10"
         kotlinVersion = "$kotlin_version"
         androidXCore = "1.6.0"
     }


### PR DESCRIPTION
## What changed (plus any additional context for devs)

I noticed in React Native docs, that with version 0.68 (we use it) Kotlin version was bumped to 1.6.10, we were still using an old version. I used the same version as in the docs, the app still builds fine.

https://reactnative.dev/blog/2022/03/30/version-068#breaking-changes-and-version-bumps