### PR TITLE
feat: use new logger in localstorage handlers

### DIFF
--- a/src/handlers/authentication.ts
+++ b/src/handlers/authentication.ts
@@ -1,11 +1,10 @@
-import { captureException } from '@sentry/react-native';
 import { RAINBOW_MASTER_KEY } from 'react-native-dotenv';
 import AesEncryptor from '../handlers/aesEncryption';
 import * as keychain from '../model/keychain';
 import { Navigation } from '../navigation';
 import { pinKey } from '../utils/keychainConstants';
 import Routes from '@/navigation/routesNames';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 
 const encryptor = new AesEncryptor();
 
@@ -29,9 +28,8 @@ export async function savePIN(pin: any) {
       // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 2.
       await keychain.saveString(pinKey, encryptedPin);
     }
-  } catch (e) {
-    logger.sentry('Error saving pin');
-    captureException(e);
+  } catch (e: any) {
+    logger.error(new RainbowError('savePin error'), { message: e.message });
   }
 }
 

--- a/src/handlers/dispersion.ts
+++ b/src/handlers/dispersion.ts
@@ -1,9 +1,7 @@
-import { captureException } from '@sentry/react-native';
 import { RainbowFetchClient } from '../rainbow-fetch';
 import { EthereumAddress, IndexToken, RainbowToken } from '@/entities';
 import UniswapAssetsCache from '@/utils/uniswapAssetsCache';
-import logger from '@/utils/logger';
-import { Network } from '@/helpers';
+import { logger, RainbowError } from '@/logger';
 
 const dispersionApi = new RainbowFetchClient({
   baseURL: 'https://metadata.p.rainbow.me',
@@ -28,9 +26,10 @@ export const getUniswapV2Tokens = async (
       UniswapAssetsCache.cache[key] = res?.data?.tokens;
       return res?.data?.tokens ?? null;
     }
-  } catch (error) {
-    logger.sentry(`Error fetching uniswap v2 tokens: ${error}`);
-    captureException(error);
+  } catch (e: any) {
+    logger.error(new RainbowError(`Error fetching uniswap v2 tokens`), {
+      message: e.message,
+    });
   }
   return null;
 };
@@ -42,9 +41,10 @@ export const getDPIBalance = async (): Promise<{
   try {
     const res = await dispersionApi.get('/dispersion/v1/dpi');
     return res?.data?.data ?? null;
-  } catch (error) {
-    logger.sentry(`Error fetching dpi balance: ${error}`);
-    captureException(error);
+  } catch (e: any) {
+    logger.error(new RainbowError(`Error fetching dpi balance`), {
+      message: e.message,
+    });
     return null;
   }
 };
@@ -55,9 +55,10 @@ export const getTrendingAddresses = async (): Promise<
   try {
     const res = await dispersionApi.get('/dispersion/v1/trending');
     return res?.data?.data?.trending ?? null;
-  } catch (error) {
-    logger.sentry(`Error fetching trending addresses: ${error}`);
-    captureException(error);
+  } catch (e: any) {
+    logger.error(new RainbowError(`Error fetching trending addresses`), {
+      message: e.message,
+    });
     return null;
   }
 };
@@ -71,9 +72,10 @@ export const getAdditionalAssetData = async (
       `/dispersion/v1/expanded/${chainId}/${address}`
     );
     return res?.data?.data ?? null;
-  } catch (error) {
-    logger.sentry(`Error fetching additional asset data: ${error}`);
-    captureException(error);
+  } catch (e: any) {
+    logger.error(new RainbowError(`Error fetching additional asset data`), {
+      message: e.message,
+    });
     return null;
   }
 };

--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -8,7 +8,7 @@ import {
 import { Source } from 'react-native-fast-image';
 import parse from 'url-parse';
 import { isCloudinaryStorageLink, signUrl } from '@/handlers/cloudinary';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 
 const shouldCreateImgixClient = (): ImgixClient | null => {
   if (
@@ -23,8 +23,10 @@ const shouldCreateImgixClient = (): ImgixClient | null => {
       secureURLToken,
     });
   }
-  logger.log(
-    '[Imgix] Image signing disabled. Please ensure you have specified both IMGIX_DOMAIN and IMGIX_TOKEN inside your .env.'
+  logger.error(
+    new RainbowError(
+      '[Imgix] Image signing disabled. Please ensure you have specified both IMGIX_DOMAIN and IMGIX_TOKEN inside your .env.'
+    )
   );
   return null;
 };
@@ -103,7 +105,10 @@ const shouldSignUri = (
       );
     }
   } catch (e: any) {
-    logger.log(`[Imgix]: Failed to sign "${externalImageUri}"! (${e.message})`);
+    logger.error(new RainbowError(`[Imgix]: Failed to sign`), {
+      externalImageUri,
+      message: e.message,
+    });
     // If something goes wrong, it is not safe to assume the image is valid.
     return undefined;
   }
@@ -120,9 +125,10 @@ const isPossibleToSignUri = (externalImageUri: string | undefined): boolean => {
       const { host } = parse(externalImageUri);
       return typeof host === 'string' && !!host.length;
     } catch (e: any) {
-      logger.log(
-        `[Imgix]: Failed to parse "${externalImageUri}"! (${e.message})`
-      );
+      logger.error(new RainbowError(`[Imgix]: Failed to parse`), {
+        externalImageUri,
+        message: e.message,
+      });
       return false;
     }
   }

--- a/src/handlers/localstorage/common.ts
+++ b/src/handlers/localstorage/common.ts
@@ -1,5 +1,5 @@
 /*global storage*/
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 
 const defaultVersion = '0.1.0';
 
@@ -27,7 +27,7 @@ export const saveLocal = async (
       key,
     });
   } catch (error) {
-    logger.log('Storage: error saving to local for key', key);
+    logger.error(new RainbowError('Storage: saveLocal error'));
   }
 };
 
@@ -53,7 +53,7 @@ export const getLocal = async (key = '', version = defaultVersion) => {
     }
     return null;
   } catch (error) {
-    logger.log('Storage: error getting from local for key', key);
+    logger.error(new RainbowError('Storage: getLocal error'));
     return null;
   }
 };
@@ -68,7 +68,7 @@ export const removeLocal = (key = '') => {
     // @ts-expect-error ts-migrate(2552) FIXME: Cannot find name 'storage'. Did you mean 'Storage'... Remove this comment to see the full error message
     storage.remove({ key });
   } catch (error) {
-    logger.log('Storage: error removing local with key', key);
+    logger.error(new RainbowError('Storage: removeLocal error'));
   }
 };
 

--- a/src/handlers/localstorage/removeWallet.ts
+++ b/src/handlers/localstorage/removeWallet.ts
@@ -5,16 +5,16 @@ import { accountLocalKeys } from './accountLocal';
 import { getKey } from './common';
 import { uniswapAccountLocalKeys } from './uniswap';
 import { walletConnectAccountLocalKeys } from './walletconnectRequests';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 import { removeNotificationSettingsForWallet } from '@/notifications/settings';
 
 export const removeWalletData = async (accountAddress: any) => {
-  logger.log('[remove wallet]', accountAddress);
+  logger.debug('[remove wallet]', { accountAddress });
   const allPrefixes = accountLocalKeys.concat(
     uniswapAccountLocalKeys,
     walletConnectAccountLocalKeys
   );
-  logger.log('[remove wallet] - all prefixes', allPrefixes);
+  logger.debug('[remove wallet] - all prefixes', { allPrefixes });
   const networks = keys(NetworkTypes);
   const allKeysWithNetworks = allPrefixes.map(prefix =>
     networks.map(network => getKey(prefix, accountAddress, network))
@@ -23,7 +23,7 @@ export const removeWalletData = async (accountAddress: any) => {
   try {
     await AsyncStorage.multiRemove(allKeys);
   } catch (error) {
-    logger.log('Error removing wallet data from storage', error);
+    logger.error(new RainbowError('Error removing wallet data from storage'));
   }
   removeNotificationSettingsForWallet(accountAddress);
 };

--- a/src/handlers/opensea-api.ts
+++ b/src/handlers/opensea-api.ts
@@ -1,4 +1,3 @@
-import { captureException } from '@sentry/react-native';
 import PQueue from 'p-queue/dist';
 import {
   // @ts-ignore
@@ -13,7 +12,7 @@ import {
   parseAccountUniqueTokensPolygon,
 } from '@/parsers';
 import { handleSignificantDecimals } from '@/helpers/utilities';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 
 export const UNIQUE_TOKENS_LIMIT_PER_PAGE = 50;
 export const UNIQUE_TOKENS_LIMIT_TOTAL = 2000;
@@ -60,16 +59,15 @@ export const apiGetAccountUniqueTokens = async (
     );
 
     return parseAccountUniqueTokens(data);
-  } catch (error: any) {
+  } catch (e: any) {
     // opensea gives us an error if the account has no tokens on the network, we want to ignore this error
-    if (
-      error.responseBody[0]?.includes('does not exist for chain identifier')
-    ) {
+    if (e.responseBody[0]?.includes('does not exist for chain identifier')) {
       return [];
     } else {
-      logger.sentry('Error getting unique tokens', error);
-      captureException(new Error('Opensea: Error getting unique tokens'));
-      throw error;
+      logger.error(new RainbowError(`Opensea: Error getting unique tokens`), {
+        message: e.message,
+      });
+      throw e;
     }
   }
 };
@@ -106,10 +104,11 @@ export const apiGetAccountUniqueToken = async (
           data: { results: [data] },
         })?.[0]
       : parseAccountUniqueTokens({ data: { assets: [data] } })?.[0];
-  } catch (error) {
-    logger.sentry('Error getting unique token', error);
-    captureException(new Error('Opensea: Error getting unique token'));
-    throw error;
+  } catch (e: any) {
+    logger.error(new RainbowError(`Opensea: Error getting unique token`), {
+      message: e.message,
+    });
+    throw e;
   }
 };
 
@@ -156,9 +155,10 @@ export const apiGetUniqueTokenFloorPrice = async (
     const tempFloorPrice = handleSignificantDecimals(tempPrice, 5);
 
     return parseFloat(tempFloorPrice) + ' ETH';
-  } catch (error) {
-    logger.sentry('Error getting NFT floor price', error);
-    captureException(new Error('Opensea: Error getting NFT floor price'));
-    throw error;
+  } catch (e: any) {
+    logger.error(new RainbowError(`Opensea: Error getting NFT floor price`), {
+      message: e.message,
+    });
+    throw e;
   }
 };

--- a/src/handlers/poap.ts
+++ b/src/handlers/poap.ts
@@ -1,9 +1,8 @@
-import { captureException } from '@sentry/react-native';
 // @ts-ignore
 import { POAP_API_KEY } from 'react-native-dotenv';
 import { rainbowFetch } from '../rainbow-fetch';
 import { parsePoaps } from '@/parsers';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 
 export const fetchPoaps = async (address: string) => {
   try {
@@ -15,8 +14,9 @@ export const fetchPoaps = async (address: string) => {
       timeout: 10000, // 10 secs
     });
     return parsePoaps(data);
-  } catch (error) {
-    logger.log('Error getting POAPs', error);
-    captureException(error);
+  } catch (e: any) {
+    logger.error(new RainbowError('Error getting POAPs'), {
+      message: e.message,
+    });
   }
 };

--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -6,7 +6,7 @@ import {
   TokenSearchTokenListId,
   TokenSearchUniswapAssetKey,
 } from '@/entities';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 import { EthereumAddress } from '@rainbow-me/swaps';
 
 const tokenSearchApi = new RainbowFetchClient({
@@ -49,10 +49,13 @@ export const tokenSearch = async (searchParams: {
     const url = `/${searchParams.chainId}/?${qs.stringify(queryParams)}`;
     const tokenSearch = await tokenSearchApi.get(url);
     return tokenSearch.data?.data;
-  } catch (e) {
+  } catch (e: any) {
     logger.error(
-      `An error occurred while searching for query: ${searchParams.query}.`,
-      e
+      new RainbowError(`An error occurred while searching for query`),
+      {
+        query: searchParams.query,
+        message: e.message,
+      }
     );
   }
 };
@@ -69,9 +72,14 @@ export const walletFilter = async (params: {
       toChainId,
     });
     return filteredAddresses?.data?.data || [];
-  } catch (e) {
+  } catch (e: any) {
     logger.error(
-      `An error occurred while filter wallet addresses: toChainId: ${params.toChainId} -> fromChainId: ${params.fromChainId}: ${e}`
+      new RainbowError(`An error occurred while filter wallet addresses`),
+      {
+        toChainId: params.toChainId,
+        fromChainId: params.fromChainId,
+        message: e.message,
+      }
     );
     throw e;
   }

--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -16,7 +16,7 @@ import { Navigation } from '@/navigation';
 import store from '@/redux/store';
 import { checkKeychainIntegrity } from '@/redux/wallets';
 import Routes from '@/navigation/routesNames';
-import logger from '@/utils/logger';
+import { logger } from '@/logger';
 
 const BACKUP_SHEET_DELAY_MS = 3000;
 
@@ -52,19 +52,19 @@ export const runWalletBackupStatusChecks = () => {
 
   if (!rainbowWalletsNotBackedUp.length) return;
 
-  logger.log('there is a rainbow wallet not backed up');
+  logger.debug('there is a rainbow wallet not backed up');
+
   const hasSelectedWallet = rainbowWalletsNotBackedUp.find(
     notBackedUpWallet => notBackedUpWallet.id === selected!.id
   );
 
-  logger.log(
-    'rainbow wallet not backed up that is selected?',
-    hasSelectedWallet
-  );
+  logger.debug('rainbow wallet not backed up that is selected?', {
+    hasSelectedWallet,
+  });
 
   // if one of them is selected, show the default BackupSheet
   if (selected && hasSelectedWallet && IS_TESTING !== 'true') {
-    logger.log('showing default BackupSheet');
+    logger.debug('showing default BackupSheet');
     setTimeout(() => {
       triggerOnSwipeLayout(() =>
         Navigation.handleAction(Routes.BACKUP_SHEET, { single: true })
@@ -76,7 +76,7 @@ export const runWalletBackupStatusChecks = () => {
   // otherwise, show the BackupSheet redirecting to the WalletSelectionList
   IS_TESTING !== 'true' &&
     setTimeout(() => {
-      logger.log('showing BackupSheet with existing_user step');
+      logger.debug('showing BackupSheet with existing_user step');
       triggerOnSwipeLayout(() =>
         Navigation.handleAction(Routes.BACKUP_SHEET, {
           single: true,
@@ -107,11 +107,11 @@ export const runFeatureUnlockChecks = async (): Promise<boolean> => {
     }
   });
 
-  logger.log('WALLETS TO CHECK', walletsToCheck);
+  logger.debug('WALLETS TO CHECK', { walletsToCheck });
 
   if (!walletsToCheck.length) return false;
 
-  logger.log('Feature Unlocks: Running Checks');
+  logger.debug('Feature Unlocks: Running Checks');
 
   // short circuits once the first feature is unlocked
   for (const featureUnlockCheck of featureUnlockChecks) {

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -41,7 +41,7 @@ import {
 } from '@/helpers/utilities';
 import { ethereumUtils } from '@/utils';
 import { fetchContractABI } from '@/utils/ethereumUtils';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
 import { IS_IOS } from '@/env';
 
 export const networkProviders: {
@@ -366,17 +366,16 @@ export async function estimateGasWithPadding(
       (!contractCallEstimateGas && !to) ||
       (to && !data && (!code || code === '0x'))
     ) {
-      logger.sentry(
-        '⛽ Skipping estimates, using default',
-        ethUnits.basic_tx.toString()
-      );
+      logger.info('⛽ Skipping estimates, using default', {
+        ethUnits: ethUnits.basic_tx.toString(),
+      });
       return ethUnits.basic_tx.toString();
     }
 
-    logger.sentry('⛽ Calculating safer gas limit for last block');
+    logger.info('⛽ Calculating safer gas limit for last block');
     // 3 - If it is a contract, call the RPC method `estimateGas` with a safe value
     const saferGasLimit = fraction(gasLimit.toString(), 19, 20);
-    logger.sentry('⛽ safer gas limit for last block is', saferGasLimit);
+    logger.info('⛽ safer gas limit for last block is', { saferGasLimit });
 
     txPayloadToEstimate[contractCallEstimateGas ? 'gasLimit' : 'gas'] = toHex(
       saferGasLimit
@@ -391,7 +390,7 @@ export async function estimateGasWithPadding(
       estimatedGas.toString(),
       paddingFactor.toString()
     );
-    logger.sentry('⛽ GAS CALCULATIONS!', {
+    logger.info('⛽ GAS CALCULATIONS!', {
       estimatedGas: estimatedGas.toString(),
       gasLimit: gasLimit.toString(),
       lastBlockGasLimit: lastBlockGasLimit,
@@ -400,22 +399,23 @@ export async function estimateGasWithPadding(
 
     // If the safe estimation is above the last block gas limit, use it
     if (greaterThan(estimatedGas.toString(), lastBlockGasLimit)) {
-      logger.sentry(
-        '⛽ returning orginal gas estimation',
-        estimatedGas.toString()
-      );
+      logger.info('⛽ returning orginal gas estimation', {
+        esimatedGas: estimatedGas.toString(),
+      });
       return estimatedGas.toString();
     }
     // If the estimation is below the last block gas limit, use the padded estimate
     if (greaterThan(lastBlockGasLimit, paddedGas)) {
-      logger.sentry('⛽ returning padded gas estimation', paddedGas);
+      logger.info('⛽ returning padded gas estimation', { paddedGas });
       return paddedGas;
     }
     // otherwise default to the last block gas limit
-    logger.sentry('⛽ returning last block gas limit', lastBlockGasLimit);
+    logger.info('⛽ returning last block gas limit', { lastBlockGasLimit });
     return lastBlockGasLimit;
-  } catch (error) {
-    logger.debug('Error calculating gas limit with padding', error);
+  } catch (e: any) {
+    logger.error(new RainbowError('Error calculating gas limit with padding'), {
+      message: e.message,
+    });
     return null;
   }
 }
@@ -518,7 +518,11 @@ export const resolveUnstoppableDomain = async (
     .then((address: string) => {
       return address;
     })
-    .catch((error: any) => logger.error(error));
+    .catch((error: any) => {
+      logger.error(new RainbowError(`resolveUnstoppableDomain error`), {
+        message: error.message,
+      });
+    });
   return res;
 };
 


### PR DESCRIPTION
Actually, promoted this PR to update all logs in `@/handlers`. Basically tl;dr:
- caught errors should be `RainbowError`s, and give specific context, not just pass the `Error` object in
- old `logger.log` only works in dev, so most of those are `debug` now
- old `logger.sentry` is a breadcrumb, so those are `info` now, unless they were within a `catch` in which case `logger.error` also adds a breadcrumb in addition to the Sentry issue