### PR TITLE
fix: quiet known storage errors

### DIFF
--- a/src/handlers/localstorage/common.ts
+++ b/src/handlers/localstorage/common.ts
@@ -52,8 +52,21 @@ export const getLocal = async (key = '', version = defaultVersion) => {
       return null;
     }
     return null;
-  } catch (error) {
-    logger.error(new RainbowError('Storage: getLocal error'));
+  } catch (error: any) {
+    /**
+     * react-native-storage throws errors when the key is not found or it's
+     * expired, and we don't need to send those to Sentry
+     *
+     * @see https://github.com/sunnylqm/react-native-storage/blob/96df43f0028a6afd08bc56e80d327fabb5fff583/README.md?plain=1#L107-L114
+     */
+    switch (error.name) {
+      case 'NotFoundError':
+      case 'ExpiredError':
+        break;
+      default:
+        logger.error(new RainbowError('Storage: getLocal error'));
+    }
+
     return null;
   }
 };


### PR DESCRIPTION
So I guess the reason were were swallowing errors before my recent changes was because most of them we don't need to report. But some we might.