### PR TITLE
Change android accentColor to blue60, match color names with RDS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
       />
       <meta-data
         android:name="com.google.firebase.messaging.default_notification_color"
-        android:resource="@color/primary_dark"
+        android:resource="@color/blue100"
         tools:replace="android:resource"
       />
       <activity

--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -3,10 +3,10 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
 >
-    <ImageView 
+
+    <ImageView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scaleType="center"
-        android:background="@color/primary_dark"
-    />
+        android:background="@color/blue100"
+        android:scaleType="center" />
 </RelativeLayout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="primary_dark">#001E5A</color>
+    <color name="blue60">#0E76FD</color>
+    <color name="blue100">#001E59</color>
     <color name="bootsplash_background">#FFFFFF</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,13 +3,10 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowDisablePreview">true</item>
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
-    </style>
-    <style name="NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="colorPrimaryDark">@color/primary_dark</item>
-        <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="colorAccent">@color/blue60</item>
     </style>
     <style name="BootTheme" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/primary_dark</item>
+        <item name="windowSplashScreenBackground">@color/blue100</item>
         <item adjustViewBounds="true" name="windowSplashScreenAnimatedIcon">@mipmap/bootsplash_logo</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>
     </style>


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Change the accent color in the android app config to get rid of default teal color that we had before

Here's what it changes + will change that teal color in all other places it is used by default, like native time pickers etc.

![image](https://user-images.githubusercontent.com/16062886/225706579-46167c57-bc10-446e-a631-8a0f747ae469.png)
![image](https://user-images.githubusercontent.com/16062886/225706602-3d86ac8a-f28a-4f22-a4a8-8dd80af1de86.png)
