### PR TITLE
Fix incorrect backup status after restoring backup from backups settings section

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1169,7 +1169,7 @@ SPEC CHECKSUMS:
   AppCenterReactNativeShared: f395caeabde0dc3a11609dbcb737d0f14cd40e79
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  Branch: c1b244bf1170b0ea5c5eefa897648de8d14ff0d2
+  Branch: d99436c6f3d5b2529ba948d273e47e732830f207
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CodePush: b51b7ac64c07d4eacfc8cc5750a1dd28adbf2528

--- a/src/components/backup/RestoreCloudStep.js
+++ b/src/components/backup/RestoreCloudStep.js
@@ -32,7 +32,7 @@ import {
 import { useNavigation } from '@/navigation';
 import {
   addressSetSelected,
-  setWalletBackedUp,
+  setAllWalletsWithIdsAsBackedUp,
   walletsLoadState,
   walletsSetSelected,
 } from '@/redux/wallets';
@@ -196,32 +196,28 @@ export default function RestoreCloudStep({
           if (!userData && backupSelected?.name) {
             goBack();
             logger.log('updating backup state of wallets');
-            await Promise.all(
-              Object.keys(wallets).map(walletId => {
-                logger.log('updating backup state of wallet', walletId);
-                logger.log('backupSelected?.name', backupSelected?.name);
-
-                let filename = backupSelected?.name;
-
-                if (IS_ANDROID && filename) {
-                  /**
-                   * We need to normalize the filename on Android, because sometimes
-                   * the filename is returned with the path used for Google Drive storage.
-                   * That is with REMOTE_BACKUP_WALLET_DIR included.
-                   */
-                  filename = normalizeAndroidBackupFilename(filename);
-                }
-
-                // Mark the wallet as backed up
-                return dispatch(
-                  setWalletBackedUp(
-                    walletId,
-                    walletBackupTypes.cloud,
-                    filename,
-                    false
-                  )
-                );
-              })
+            let filename = backupSelected?.name;
+            if (IS_ANDROID && filename) {
+              /**
+               * We need to normalize the filename on Android, because sometimes
+               * the filename is returned with the path used for Google Drive storage.
+               * That is with REMOTE_BACKUP_WALLET_DIR included.
+               */
+              filename = normalizeAndroidBackupFilename(filename);
+            }
+            const walletIdsToUpdate = Object.keys(wallets);
+            logger.log(
+              'updating backup state of wallets with ids',
+              JSON.stringify(walletIdsToUpdate)
+            );
+            logger.log('backupSelected?.name', backupSelected?.name);
+            await dispatch(
+              setAllWalletsWithIdsAsBackedUp(
+                walletIdsToUpdate,
+                walletBackupTypes.cloud,
+                filename,
+                false
+              )
             );
             logger.log('done updating backup state');
           }

--- a/src/redux/wallets.ts
+++ b/src/redux/wallets.ts
@@ -327,8 +327,12 @@ export const setAllWalletsWithIdsAsBackedUp = (
     try {
       await backupUserDataIntoCloud({ wallets: newWallets });
     } catch (e) {
-      legacyLogger.sentry('SAVING WALLET USERDATA FAILED');
-      captureException(e);
+      logger.error(
+        new RainbowError('Saving multiple wallets UserData to cloud failed.'),
+        {
+          message: (e as Error)?.message,
+        }
+      );
       throw e;
     }
   }
@@ -377,9 +381,12 @@ export const setWalletBackedUp = (
     try {
       await backupUserDataIntoCloud({ wallets: newWallets });
     } catch (e) {
-      logger.error(new RainbowError('SAVING WALLET USERDATA FAILED'), {
-        message: (e as Error)?.message,
-      });
+      logger.error(
+        new RainbowError('Saving wallet UserData to cloud failed.'),
+        {
+          message: (e as Error)?.message,
+        }
+      );
       throw e;
     }
   }

--- a/src/redux/wallets.ts
+++ b/src/redux/wallets.ts
@@ -327,7 +327,7 @@ export const setAllWalletsWithIdsAsBackedUp = (
     try {
       await backupUserDataIntoCloud({ wallets: newWallets });
     } catch (e) {
-      logger.sentry('SAVING WALLET USERDATA FAILED');
+      legacyLogger.sentry('SAVING WALLET USERDATA FAILED');
       captureException(e);
       throw e;
     }


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Fixed issue with wrong backup status for wallets when restoring specific backup (from backup section in settings). The issue was because we had a sort of race condition when dispatching redux thunks. When there were multiple wallets we dispatched all thinks in the same time with the same initial state, but inside only updated one wallet's data, which caused only the last wallet to be updated. I added a new thunk which takes an array of wallet IDs to update instead of dispatching multiple times for just one wallet ID