### PR TITLE
Refactor `createWallet` function to use object params structure

### DIFF
--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -318,7 +318,7 @@ async function restoreSpecificBackupIntoKeychain(
             }
           );
         }
-        await createWallet(processedSeedPhrase, null, null, true);
+        await createWallet({ seed: processedSeedPhrase, overwrite: true });
       }
     }
     return true;

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -255,15 +255,15 @@ export const walletInit = async (
 
   // Importing a seedphrase
   if (!isEmpty(seedPhrase)) {
-    const wallet = await createWallet(
-      seedPhrase,
+    const wallet = await createWallet({
+      seed: seedPhrase,
       color,
       name,
       overwrite,
       checkedWallet,
       image,
-      silent
-    );
+      silent,
+    });
     walletAddress = wallet?.address;
     return { isNew, walletAddress };
   }
@@ -271,7 +271,7 @@ export const walletInit = async (
   walletAddress = await loadAddress();
 
   if (!walletAddress) {
-    const wallet = await createWallet();
+    const wallet = await createWallet({});
     walletAddress = wallet?.address;
     isNew = true;
   }
@@ -674,16 +674,27 @@ export const identifyWalletType = (
   return EthereumWalletType.seed;
 };
 
-export const createWallet = async (
-  seed: null | EthereumSeed = null,
-  color: null | number = null,
-  name: null | string = null,
+type CreateWalletParams = {
+  seed?: null | EthereumSeed;
+  color?: null | number;
+  name?: null | string;
+  overwrite?: boolean;
+  checkedWallet?: null | EthereumWalletFromSeed;
+  image?: null | string;
+  silent?: boolean;
+  clearCallbackOnStartCreation?: boolean;
+};
+
+export const createWallet = async ({
+  seed = null,
+  color = null,
+  name = null,
   overwrite = false,
-  checkedWallet: null | EthereumWalletFromSeed = null,
-  image: null | string = null,
+  checkedWallet = null,
+  image = null,
   silent = false,
-  clearCallbackOnStartCreation = false
-): Promise<null | EthereumWallet> => {
+  clearCallbackOnStartCreation = false,
+}: CreateWalletParams): Promise<null | EthereumWallet> => {
   if (clearCallbackOnStartCreation) {
     callbackAfterSeeds?.();
     callbackAfterSeeds = null;

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -165,16 +165,11 @@ export const AddWalletSheet = () => {
 
                     // If doesn't exist, we need to create a new wallet
                   } else {
-                    await createWallet(
-                      null,
+                    await createWallet({
                       color,
                       name,
-                      false,
-                      null,
-                      null,
-                      false,
-                      true
-                    );
+                      clearCallbackOnStartCreation: true,
+                    });
                     await dispatch(walletsLoadState(profilesEnabled));
                     // @ts-ignore
                     await initializeWallet();


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Changed `createWallet` function to use an object to pass params instead of a chain of optional params.
* Updated its usages accordingly