### PR TITLE
fix: no infinite cache in React Query

### DIFF
--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -3,10 +3,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 import { PersistQueryClientOptions } from '@tanstack/react-query-persist-client';
 
+const SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7;
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      cacheTime: 1000 * 60 * 60 * 24 * 7,
+      cacheTime: SEVEN_DAYS,
     },
   },
 });

--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -6,7 +6,7 @@ import { PersistQueryClientOptions } from '@tanstack/react-query-persist-client'
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      cacheTime: Infinity,
+      cacheTime: 1000 * 60 * 60 * 24 * 7,
     },
   },
 });


### PR DESCRIPTION
So we have `persisterVersion` which ensures that if we change data shape, we don't get old data from the cache. But we don't have a way to evict old data from the cache once it's there.

This PR changes the default cache from `Infinity` to one week, to ensure that even old data is garbage collected eventually.
