### PR TITLE
Improve error messages when revealing seed phrase fails

### DIFF
--- a/src/components/backup/BackupManualStep.js
+++ b/src/components/backup/BackupManualStep.js
@@ -4,7 +4,6 @@ import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { useTheme } from '../../theme/ThemeContext';
 import { Column, Row } from '../layout';
-import { SecretDisplaySection } from '../secret-display';
 import { SheetActionButton } from '../sheet';
 import { Nbsp, Text } from '../text';
 import { analytics } from '@/analytics';
@@ -13,6 +12,7 @@ import { useDimensions, useWalletManualBackup, useWallets } from '@/hooks';
 import { useNavigation } from '@/navigation';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
+import { SecretDisplaySection } from '@/components/secret-display/SecretDisplaySection';
 
 const Content = styled(Column).attrs({
   align: 'center',

--- a/src/components/secret-display/SecretDisplayCard.tsx
+++ b/src/components/secret-display/SecretDisplayCard.tsx
@@ -1,74 +1,15 @@
 import lang from 'i18n-js';
-import React, { useMemo } from 'react';
+import React from 'react';
 import CopyTooltip from '../copy-tooltip';
-import { Centered, ColumnWithMargins, Row, RowWithMargins } from '../layout';
+import { Centered } from '../layout';
 import { Text } from '../text';
 import { Box, Inset } from '@/design-system';
-import { times } from '@/helpers/utilities';
 import WalletTypes, { EthereumWalletType } from '@/helpers/walletTypes';
-import styled from '@/styled-thing';
-import { fonts } from '@/styles';
-import { useTheme } from '@/theme';
-
-const GridItem = styled(Row).attrs({
-  align: 'center',
-})({
-  height: fonts.lineHeight.looser,
-});
-
-const GridText = styled(Text).attrs(({ weight = 'semibold' }) => ({
-  lineHeight: 'looser',
-  size: 'lmedium',
-  weight,
-}))({});
-
-interface SeedWordGridProps {
-  seed: string;
-}
-
-function SeedWordGrid({ seed }: SeedWordGridProps) {
-  const columns = useMemo(() => {
-    const words = seed.split(' ');
-    return [words.slice(0, words.length / 2), words.slice(words.length / 2)];
-  }, [seed]);
-
-  const { colors } = useTheme();
-
-  return (
-    <RowWithMargins margin={24}>
-      {columns.map((wordColumn, colIndex) => (
-        <RowWithMargins key={wordColumn.join('')} margin={6}>
-          <ColumnWithMargins margin={9}>
-            {times(wordColumn.length, index => {
-              const number = Number(index + 1 + colIndex * wordColumn.length);
-              return (
-                <GridItem justify="end" key={`grid_number_${number}`}>
-                  <GridText
-                    align="right"
-                    color={colors.alpha(colors.appleBlue, 0.6)}
-                  >
-                    {number}
-                  </GridText>
-                </GridItem>
-              );
-            })}
-          </ColumnWithMargins>
-          <ColumnWithMargins margin={9}>
-            {wordColumn.map((word, index) => (
-              <GridItem key={`${word}${index}`}>
-                <GridText weight="bold">{word}</GridText>
-              </GridItem>
-            ))}
-          </ColumnWithMargins>
-        </RowWithMargins>
-      ))}
-    </RowWithMargins>
-  );
-}
+import { SeedWordGrid } from '@/components/secret-display/SeedWordGrid';
 
 interface SecretDisplayCardProps {
   seed: string;
-  type: EthereumWalletType;
+  type?: EthereumWalletType;
 }
 
 export default function SecretDisplayCard({
@@ -95,7 +36,14 @@ export default function SecretDisplayCard({
                 <SeedWordGrid seed={seed} />
               )}
               {seed && type === WalletTypes.privateKey && (
-                <GridText align="center">{seed}</GridText>
+                <Text
+                  align="center"
+                  weight="semibold"
+                  lineHeight="looser"
+                  size="lmedium"
+                >
+                  {seed}
+                </Text>
               )}
             </Box>
           </CopyTooltip>

--- a/src/components/secret-display/SecretDisplayError.tsx
+++ b/src/components/secret-display/SecretDisplayError.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box, Text } from '@/design-system';
+
+interface Props {
+  message: string;
+}
+
+export function SecretDisplayError({ message }: Props) {
+  return (
+    <Box alignItems="center" justifyContent="center" paddingHorizontal="60px">
+      <Text
+        align="center"
+        color="secondary60 (Deprecated)"
+        size="16px / 22px (Deprecated)"
+      >
+        {message}
+      </Text>
+    </Box>
+  );
+}

--- a/src/components/secret-display/SecretDisplaySection.tsx
+++ b/src/components/secret-display/SecretDisplaySection.tsx
@@ -163,7 +163,7 @@ export function SecretDisplaySection({
     default:
       logger.error(
         new RainbowError(
-          'Secret display section tires to present an unknown state'
+          'Secret display section tries to present an unknown state'
         )
       );
       return null;

--- a/src/components/secret-display/SecretDisplaySection.tsx
+++ b/src/components/secret-display/SecretDisplaySection.tsx
@@ -24,7 +24,7 @@ import {
   SecretDisplayStatesType,
 } from '@/components/secret-display/states';
 import { SecretDisplayError } from '@/components/secret-display/SecretDisplayError';
-import { StyleSheet } from 'react-native';
+import { InteractionManager, StyleSheet } from 'react-native';
 
 const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
 
@@ -94,14 +94,10 @@ export function SecretDisplaySection({
   }, [onSecretLoaded, onWalletTypeIdentified, walletId]);
 
   useEffect(() => {
-    // Android doesn't like to show the faceID prompt
-    // while the view isn't fully visible
-    // so we have to add a timeout to prevent the app from freezing
-    IS_ANDROID
-      ? setTimeout(() => {
-          loadSeed();
-        }, 300)
-      : loadSeed();
+    // We need to run this after interactions since there were issues on Android
+    InteractionManager.runAfterInteractions(() => {
+      loadSeed();
+    });
   }, [loadSeed]);
 
   switch (sectionState) {

--- a/src/components/secret-display/SecretDisplaySection.tsx
+++ b/src/components/secret-display/SecretDisplaySection.tsx
@@ -1,89 +1,94 @@
 import { useRoute } from '@react-navigation/native';
 import { captureException } from '@sentry/react-native';
 import lang from 'i18n-js';
-import { upperFirst } from 'lodash';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import {
   createdWithBiometricError,
   identifyWalletType,
   loadSeedPhraseAndMigrateIfNeeded,
-} from '../../model/wallet';
+} from '@/model/wallet';
 import ActivityIndicator from '../ActivityIndicator';
 import Spinner from '../Spinner';
-import { BiometricButtonContent, Button } from '../buttons';
 import { CopyFloatingEmojis } from '../floating-emojis';
 import { Icon } from '../icons';
 import SecretDisplayCard from './SecretDisplayCard';
 import { Box, Inline, Stack, Text } from '@/design-system';
 import WalletTypes, { EthereumWalletType } from '@/helpers/walletTypes';
 import { useWallets } from '@/hooks';
-import styled from '@/styled-thing';
-import { margin, position, shadow } from '@/styles';
+import { position } from '@/styles';
 import { useTheme } from '@/theme';
-import logger from '@/utils/logger';
+import { logger, RainbowError } from '@/logger';
+import { IS_ANDROID } from '@/env';
+import {
+  SecretDisplayStates,
+  SecretDisplayStatesType,
+} from '@/components/secret-display/states';
+import { SecretDisplayError } from '@/components/secret-display/SecretDisplayError';
+import { StyleSheet } from 'react-native';
 
-const ErrorStates = {
-  noSeed: 'noSeed',
-  securedWithBiometrics: 'securedWithBiometrics',
-} as const;
+const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
 
-const CopyButtonIcon = styled(Icon).attrs(({ theme: { colors } }: any) => ({
-  color: colors.appleBlue,
-  name: 'copy',
-}))({
-  ...position.sizeAsObject(16),
-  marginTop: 0.5,
-});
+type WrapperProps = {
+  children?: ReactNode;
+};
 
-const ToggleSecretButton = styled(Button)(({ theme: { colors } }: any) => ({
-  ...margin.object(0, 20),
-  ...shadow.buildAsObject(0, 5, 15, colors.purple, 0.3),
-  backgroundColor: colors.appleBlue,
-}));
-
-const LoadingSpinner = android ? Spinner : ActivityIndicator;
-
-interface SecretDisplaySectionProps {
-  onSecretLoaded?: (seedExists: boolean) => void;
-  onWalletTypeIdentified?: (walletType: EthereumWalletType) => void;
+function Wrapper({ children }: WrapperProps) {
+  return (
+    <Box
+      alignItems="center"
+      justifyContent="center"
+      paddingBottom="30px (Deprecated)"
+      paddingHorizontal={{ custom: 46 }}
+    >
+      {children}
+    </Box>
+  );
 }
 
-export default function SecretDisplaySection({
+type Props = {
+  onSecretLoaded?: (seedExists: boolean) => void;
+  onWalletTypeIdentified?: (walletType: EthereumWalletType) => void;
+};
+
+export function SecretDisplaySection({
   onSecretLoaded,
   onWalletTypeIdentified,
-}: SecretDisplaySectionProps) {
+}: Props) {
+  const { colors } = useTheme();
   const { params } = useRoute();
   const { selectedWallet, wallets } = useWallets();
   const walletId = (params as any)?.walletId || selectedWallet.id;
   const currentWallet = wallets?.[walletId];
-  const [visible, setVisible] = useState(true);
-  const [errorState, setErrorState] = useState<
-    keyof typeof ErrorStates | undefined
-  >();
+  const [sectionState, setSectionState] = useState<SecretDisplayStatesType>(
+    SecretDisplayStates.loading
+  );
   const [seed, setSeed] = useState<string | null>(null);
-  const [type, setType] = useState(currentWallet?.type);
+  const [walletType, setWalletType] = useState(currentWallet?.type);
 
   const loadSeed = useCallback(async () => {
     try {
-      const s = await loadSeedPhraseAndMigrateIfNeeded(walletId);
-      if (s) {
-        const walletType = identifyWalletType(s);
-        setType(walletType);
+      const seedPhrase = await loadSeedPhraseAndMigrateIfNeeded(walletId);
+      if (seedPhrase) {
+        const walletType = identifyWalletType(seedPhrase);
+        setWalletType(walletType);
         onWalletTypeIdentified?.(walletType);
-        setSeed(s);
+        setSeed(seedPhrase);
+        setSectionState(SecretDisplayStates.revealed);
+      } else {
+        setSectionState(SecretDisplayStates.noSeed);
       }
-      setVisible(!!s);
-      onSecretLoaded?.(!!s);
-      if (!s) {
-        setErrorState(ErrorStates.noSeed);
-      }
-    } catch (e: any) {
-      logger.sentry('Error while trying to reveal secret', e);
-      if (e?.message === createdWithBiometricError) {
-        setErrorState(ErrorStates.securedWithBiometrics);
-      }
-      captureException(e);
-      setVisible(false);
+      onSecretLoaded?.(!!seedPhrase);
+    } catch (error) {
+      const message = (error as Error)?.message;
+      logger.error(new RainbowError('Error while trying to reveal secret'), {
+        error: message,
+      });
+      setSectionState(
+        message === createdWithBiometricError
+          ? SecretDisplayStates.securedWithBiometrics
+          : SecretDisplayStates.noSeed
+      );
+      captureException(error);
       onSecretLoaded?.(false);
     }
   }, [onSecretLoaded, onWalletTypeIdentified, walletId]);
@@ -92,119 +97,86 @@ export default function SecretDisplaySection({
     // Android doesn't like to show the faceID prompt
     // while the view isn't fully visible
     // so we have to add a timeout to prevent the app from freezing
-    android
+    IS_ANDROID
       ? setTimeout(() => {
           loadSeed();
         }, 300)
       : loadSeed();
   }, [loadSeed]);
 
-  const typeLabel = type === WalletTypes.privateKey ? 'key' : 'phrase';
-
-  const { colors } = useTheme();
-
-  const renderStepNoSeeds = useCallback(() => {
-    if (errorState) {
+  switch (sectionState) {
+    case SecretDisplayStates.loading:
       return (
-        <Box
-          alignItems="center"
-          justifyContent="center"
-          paddingHorizontal="60px"
-        >
-          <Text
-            align="center"
-            color="secondary60 (Deprecated)"
-            size="16px / 22px (Deprecated)"
-          >
-            {errorState === ErrorStates.securedWithBiometrics &&
-              lang.t('back_up.secret.biometrically_secured')}
-            {errorState === ErrorStates.noSeed &&
-              lang.t('back_up.secret.no_seed_phrase')}
-          </Text>
-        </Box>
+        <Wrapper>
+          <LoadingSpinner color={colors.blueGreyDark50} />
+        </Wrapper>
       );
-    }
-    return (
-      <Box alignItems="center" justifyContent="center" paddingHorizontal="60px">
-        <Stack space="10px">
-          <Text
-            align="center"
-            color="secondary (Deprecated)"
-            size="18px / 27px (Deprecated)"
-            weight="regular"
-          >
-            {lang.t('back_up.secret.you_need_to_authenticate', {
-              typeName: typeLabel,
-            })}
-          </Text>
-          <ToggleSecretButton onPress={loadSeed}>
-            {/* @ts-ignore */}
-            <BiometricButtonContent
-              color={colors.white}
-              label={lang.t('back_up.secret.show_recovery', {
-                typeName: upperFirst(typeLabel),
-              })}
-              showIcon={!seed}
-            />
-          </ToggleSecretButton>
-        </Stack>
-      </Box>
-    );
-  }, [errorState, typeLabel, loadSeed, colors.white, seed]);
-  return (
-    <>
-      {visible ? (
-        <Box
-          alignItems="center"
-          justifyContent="center"
-          paddingBottom="30px (Deprecated)"
-          paddingHorizontal={{ custom: 46 }}
-        >
-          {seed ? (
-            <>
-              <Box paddingBottom="19px (Deprecated)">
-                {/* @ts-ignore */}
-                <CopyFloatingEmojis textToCopy={seed}>
-                  <Inline alignVertical="center" space="6px">
-                    <CopyButtonIcon />
-                    <Text
-                      color="action (Deprecated)"
-                      size="16px / 22px (Deprecated)"
-                      weight="bold"
-                    >
-                      {lang.t('back_up.secret.copy_to_clipboard')}
-                    </Text>
-                  </Inline>
-                </CopyFloatingEmojis>
-              </Box>
-              <Stack alignHorizontal="center" space="19px (Deprecated)">
-                {/* @ts-ignore */}
-                <SecretDisplayCard seed={seed} type={type} />
+    case SecretDisplayStates.noSeed:
+      return (
+        <SecretDisplayError message={lang.t('back_up.secret.no_seed_phrase')} />
+      );
+    case SecretDisplayStates.securedWithBiometrics:
+      return (
+        <SecretDisplayError
+          message={lang.t('back_up.secret.biometrically_secured')}
+        />
+      );
+    case SecretDisplayStates.revealed:
+      return (
+        <Wrapper>
+          <Box paddingBottom="19px (Deprecated)">
+            {/* @ts-expect-error JS component*/}
+            <CopyFloatingEmojis textToCopy={seed}>
+              <Inline alignVertical="center" space="6px">
+                <Icon
+                  name="copy"
+                  color={colors.appleBlue}
+                  style={styles.copyIcon}
+                />
                 <Text
-                  containsEmoji
-                  color="primary (Deprecated)"
+                  color="action (Deprecated)"
                   size="16px / 22px (Deprecated)"
                   weight="bold"
                 >
-                  👆{lang.t('back_up.secret.for_your_eyes_only')} 👆
+                  {lang.t('back_up.secret.copy_to_clipboard')}
                 </Text>
-                <Text
-                  align="center"
-                  color="secondary60 (Deprecated)"
-                  size="16px / 22px (Deprecated)"
-                  weight="semibold"
-                >
-                  {lang.t('back_up.secret.anyone_who_has_these')}
-                </Text>
-              </Stack>
-            </>
-          ) : (
-            <LoadingSpinner color={colors.blueGreyDark50} />
-          )}
-        </Box>
-      ) : (
-        renderStepNoSeeds()
-      )}
-    </>
-  );
+              </Inline>
+            </CopyFloatingEmojis>
+          </Box>
+          <Stack alignHorizontal="center" space="19px (Deprecated)">
+            <SecretDisplayCard seed={seed ?? ''} type={walletType} />
+            <Text
+              containsEmoji
+              color="primary (Deprecated)"
+              size="16px / 22px (Deprecated)"
+              weight="bold"
+            >
+              👆{lang.t('back_up.secret.for_your_eyes_only')} 👆
+            </Text>
+            <Text
+              align="center"
+              color="secondary60 (Deprecated)"
+              size="16px / 22px (Deprecated)"
+              weight="semibold"
+            >
+              {lang.t('back_up.secret.anyone_who_has_these')}
+            </Text>
+          </Stack>
+        </Wrapper>
+      );
+    default:
+      logger.error(
+        new RainbowError(
+          'Secret display section tires to present an unknown state'
+        )
+      );
+      return null;
+  }
 }
+
+const styles = StyleSheet.create({
+  copyIcon: {
+    ...position.sizeAsObject(16),
+    marginTop: 0.5,
+  },
+});

--- a/src/components/secret-display/SeedWordGrid.tsx
+++ b/src/components/secret-display/SeedWordGrid.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '@/theme';
+import { ColumnWithMargins, Row, RowWithMargins } from '@/components/layout';
+import { times } from '@/helpers/utilities';
+import { fonts } from '@/styles';
+import { Text } from '@/components/text';
+
+interface Props {
+  seed: string;
+}
+
+export function SeedWordGrid({ seed }: Props) {
+  const columns = useMemo(() => {
+    const words = seed.split(' ');
+    return [words.slice(0, words.length / 2), words.slice(words.length / 2)];
+  }, [seed]);
+
+  const { colors } = useTheme();
+
+  return (
+    <RowWithMargins margin={24}>
+      {columns.map((wordColumn, colIndex) => (
+        <RowWithMargins key={wordColumn.join('')} margin={6}>
+          <ColumnWithMargins margin={9}>
+            {times(wordColumn.length, index => {
+              const number = Number(index + 1 + colIndex * wordColumn.length);
+              return (
+                <Row
+                  style={styles.gridItem}
+                  align="center"
+                  justify="end"
+                  key={`grid_number_${number}`}
+                >
+                  <Text
+                    lineHeight="looser"
+                    size="lmedium"
+                    weight="semibold"
+                    align="right"
+                    color={colors.alpha(colors.appleBlue, 0.6)}
+                  >
+                    {number}
+                  </Text>
+                </Row>
+              );
+            })}
+          </ColumnWithMargins>
+          <ColumnWithMargins margin={9}>
+            {wordColumn.map((word, index) => (
+              <Row
+                style={styles.gridItem}
+                align="center"
+                key={`${word}${index}`}
+              >
+                <Text size="lmedium" lineHeight="looser" weight="bold">
+                  {word}
+                </Text>
+              </Row>
+            ))}
+          </ColumnWithMargins>
+        </RowWithMargins>
+      ))}
+    </RowWithMargins>
+  );
+}
+
+const styles = StyleSheet.create({
+  gridItem: {
+    height: fonts.lineHeight.looser,
+  },
+});

--- a/src/components/secret-display/index.ts
+++ b/src/components/secret-display/index.ts
@@ -1,2 +1,0 @@
-export { default as SecretDisplayCard } from './SecretDisplayCard';
-export { default as SecretDisplaySection } from './SecretDisplaySection';

--- a/src/components/secret-display/states.ts
+++ b/src/components/secret-display/states.ts
@@ -1,0 +1,9 @@
+export const SecretDisplayStates = {
+  loading: 'loading',
+  revealed: 'revealed',
+  hidden: 'hidden',
+  noSeed: 'noSeed',
+  securedWithBiometrics: 'securedWithBiometrics',
+} as const;
+
+export type SecretDisplayStatesType = typeof SecretDisplayStates[keyof typeof SecretDisplayStates];

--- a/src/components/secret-display/states.ts
+++ b/src/components/secret-display/states.ts
@@ -1,7 +1,6 @@
 export const SecretDisplayStates = {
   loading: 'loading',
   revealed: 'revealed',
-  hidden: 'hidden',
   noSeed: 'noSeed',
   securedWithBiometrics: 'securedWithBiometrics',
 } as const;

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -153,7 +153,7 @@
       "secret": {
         "anyone_who_has_these": "Anyone who has these words can access your entire wallet!",
         "biometrically_secured": "Your account has been secured with biometric data, like fingerprint or face identification. To see your recovery phrase, turn on biometrics in your phone’s settings.",
-        "no_seed_phrase": "We're sorry, we couldn't retrieve your seed phrase. Please ensure you've properly authenticated using biometric data, such as your fingerprint or face identification, or entered your PIN code correctly.",
+        "no_seed_phrase": "We couldn't retrieve your seed phrase. Please ensure you've properly authenticated using biometric data, such as your fingerprint or face identification, or entered your PIN code correctly.",
         "copy_to_clipboard": "Copy to clipboard",
         "for_your_eyes_only": "For your eyes only",
         "private_key_title": "Private Key",

--- a/src/languages/_english.json
+++ b/src/languages/_english.json
@@ -153,6 +153,7 @@
       "secret": {
         "anyone_who_has_these": "Anyone who has these words can access your entire wallet!",
         "biometrically_secured": "Your account has been secured with biometric data, like fingerprint or face identification. To see your recovery phrase, turn on biometrics in your phone’s settings.",
+        "no_seed_phrase": "We're sorry, we couldn't retrieve your seed phrase. Please ensure you've properly authenticated using biometric data, such as your fingerprint or face identification, or entered your PIN code correctly.",
         "copy_to_clipboard": "Copy to clipboard",
         "for_your_eyes_only": "For your eyes only",
         "private_key_title": "Private Key",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -153,7 +153,7 @@
       "secret": {
         "anyone_who_has_these": "Anyone who has these words can access your entire wallet! :)",
         "biometrically_secured": "Your account has been secured with biometric data, like fingerprint or face identification. To see your recovery phrase, turn on biometrics in your phone’s settings. :)",
-        "no_seed_phrase": "We're sorry, we couldn't retrieve your seed phrase. Please ensure you've properly authenticated using biometric data, such as your fingerprint or face identification, or entered your PIN code correctly. :)",
+        "no_seed_phrase": "We couldn't retrieve your seed phrase. Please ensure you've properly authenticated using biometric data, such as your fingerprint or face identification, or entered your PIN code correctly. :)",
         "copy_to_clipboard": "Copy to clipboard :)",
         "for_your_eyes_only": "For your eyes only :)",
         "private_key_title": "Private Key :)",

--- a/src/languages/_french.json
+++ b/src/languages/_french.json
@@ -153,6 +153,7 @@
       "secret": {
         "anyone_who_has_these": "Anyone who has these words can access your entire wallet! :)",
         "biometrically_secured": "Your account has been secured with biometric data, like fingerprint or face identification. To see your recovery phrase, turn on biometrics in your phone’s settings. :)",
+        "no_seed_phrase": "We're sorry, we couldn't retrieve your seed phrase. Please ensure you've properly authenticated using biometric data, such as your fingerprint or face identification, or entered your PIN code correctly. :)",
         "copy_to_clipboard": "Copy to clipboard :)",
         "for_your_eyes_only": "For your eyes only :)",
         "private_key_title": "Private Key :)",

--- a/src/screens/SettingsSheet/components/ShowSecretView.tsx
+++ b/src/screens/SettingsSheet/components/ShowSecretView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
-import { Centered } from '../../../components/layout';
-import { ModalHeaderHeight } from '../../../components/modal';
-import SecretDisplaySection from '../../../components/secret-display/SecretDisplaySection';
+import { Centered } from '@/components/layout';
+import { ModalHeaderHeight } from '@/components/modal';
 import { analytics } from '@/analytics';
+import { SecretDisplaySection } from '@/components/secret-display/SecretDisplaySection';
 
 export default function ShowSecretView() {
   useEffect(() => {
@@ -13,7 +13,6 @@ export default function ShowSecretView() {
 
   return (
     <Centered flex={1} paddingBottom={ModalHeaderHeight}>
-      {/* @ts-ignore */}
       <SecretDisplaySection />
     </Centered>
   );


### PR DESCRIPTION
## What changed (plus any additional context for devs)

* Added a new message that is shown in case there's any issue retrieving seed. That takes care of the issue that we always displayed a message that the seed was secured with biometrics.
* Refactored the whole secret display section to be easier to reason about, now it has clear states instead of multiple booleans that then make the state
* Broke it down into smaller components
* Refactored styles to not use styled components
* Removed a state that was unreachable, that was essentially dead code