### PR TITLE
fix: only show supported network icons in connected dapps sheet

### DIFF
--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -21,7 +21,11 @@ import { ethereumUtils, showActionSheetWithOptions } from '@/utils';
 import * as lang from '@/languages';
 import { useTheme } from '@/theme';
 import { logger, RainbowError } from '@/logger';
-import { changeAccount, disconnectSession } from '@/utils/walletConnect';
+import {
+  changeAccount,
+  disconnectSession,
+  isSupportedChain,
+} from '@/utils/walletConnect';
 import { Box, Inline } from '@/design-system';
 import ChainBadge from '@/components/coin-icon/ChainBadge';
 import { CoinIcon } from '@/components/coin-icon';
@@ -101,7 +105,9 @@ export function WalletConnectV2ListItem({
       string,
       string
     ];
-    const chainIds = chains.map(chain => parseInt(chain.split(':')[1]));
+    const chainIds = chains
+      .map(chain => parseInt(chain.split(':')[1]))
+      .filter(isSupportedChain);
 
     if (!address) {
       const e = new RainbowError(


### PR DESCRIPTION
Fixes APP-504

## What changed (plus any additional context for devs)
I fixed this. Requests to unsupported networks are rejected and the user is alerted. I don't think we need to show them here.
![IMG_A1D2C85C40C8-1](https://user-images.githubusercontent.com/4732330/227370709-bd187136-1a8c-4b14-a7e9-40e8bd419831.jpeg)
Looks like this now:
![IMG_2724F2533665-1](https://user-images.githubusercontent.com/4732330/227371215-e55a2112-71fd-4561-be01-63cab5b39e5a.jpeg)

