### PR TITLE
Release: Fix floor price bug

### DIFF
--- a/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
+++ b/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
@@ -128,7 +128,9 @@ export default function NFTBriefTokenInfoRow({
         floorPrice === null
           ? floorPrice
           : convertAmountToNativeDisplay(
-              parseFloat(floorPrice) * priceOfEth,
+              parseFloat(
+                floorPrice?.[0] === '<' ? floorPrice.substring(2) : floorPrice
+              ) * priceOfEth,
               nativeCurrency
             )}
       </TokenInfoItem>


### PR DESCRIPTION
Fixes APP-522

## What changed (plus any additional context for devs)
* NFT floor price in app currency showed NaN if floor price value was "< 0.001 ETH"
* this occurred b/c parseFloat doesn't work if the string starts with a character that is not a number or whitespace

## Screen recordings / screenshots


## What to test

