### PR TITLE
Release: Fix SVG rendering bug

### DIFF
--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -91,7 +91,7 @@ class SvgImage extends Component {
           const res = await fetch(uri);
           const text = await res.text();
           if (text.toLowerCase().indexOf('<svg') !== -1) {
-            // TODO more thorough investigatation into if/why foreignObject images aren't supported
+            // TODO APP-526 more thorough investigatation into if/why foreignObject images aren't supported
             if (text.match(/<foreignObject[\s\S]*?<\/foreignObject>/)) {
               logger.log('foreignObject tag not supported', { text, uri });
               // return w/o error so we can fallback to png

--- a/src/components/svg/SvgImage.js
+++ b/src/components/svg/SvgImage.js
@@ -91,6 +91,12 @@ class SvgImage extends Component {
           const res = await fetch(uri);
           const text = await res.text();
           if (text.toLowerCase().indexOf('<svg') !== -1) {
+            // TODO more thorough investigatation into if/why foreignObject images aren't supported
+            if (text.match(/<foreignObject[\s\S]*?<\/foreignObject>/)) {
+              logger.log('foreignObject tag not supported', { text, uri });
+              // return w/o error so we can fallback to png
+              return;
+            }
             this.mounted &&
               this.setState({ fetchingUrl: uri, svgContent: text });
           } else {


### PR DESCRIPTION
Fixes APP-523

## What changed (plus any additional context for devs)
The bug: Some svgs aren't rendering properly in the nft expanded state

After some research, it appears that svgs that contain `foreignObject` tags containing other images are the affected group. The svg itself will render, but these nested images do not. The only known examples are all NFTs in this collection: https://opensea.io/collection/toadstoolz. Here's an example svg provided by simplehash https://cdn.simplehash.com/assets/bc47ebcd09dbd93ac932a5fcf0c69625bf23422a2f540fde7f3f7b4f3697038c.svg

I've also tested this with trivial svgs I created and found the same result.

The fix until I investigate further: 
If the svg html contains a foreignObject tag, fallback to displaying the nft as a png.

Created a follow-up ticket: https://linear.app/rainbow/issue/APP-526/some-svgs-not-rendering-properly-in-nft-expanded-state

## Screen recordings / screenshots
![Simulator Screen Shot - iPhone 14 - 2023-03-30 at 18 00 53](https://user-images.githubusercontent.com/15272675/228973830-1d3d64c8-a640-401d-b895-bb98db8ab235.png)


## What to test

