### PR TITLE
Release: Fix POAP NFT expanded state bug

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -35,11 +35,6 @@ const UniqueTokenExpandedStateContent = ({
   onContentFocus,
   onContentBlur,
 }) => {
-  const url = useMemo(() => {
-    if (asset.isPoap) return asset.animation_url;
-    return asset.image_url;
-  }, [asset.animation_url, asset.image_url, asset.isPoap]);
-
   const { supports3d, supportsVideo, supportsAudio } = useUniqueToken(asset);
 
   const supportsAnythingExceptImageAnd3d = supportsVideo || supportsAudio;
@@ -70,28 +65,28 @@ const UniqueTokenExpandedStateContent = ({
         {supportsVideo ? (
           <SimpleVideo
             loading={loading}
-            posterUri={url}
+            posterUri={asset.image_url}
             setLoading={setLoading}
             style={StyleSheet.absoluteFill}
             uri={asset.animation_url || url}
           />
         ) : supports3d ? (
           <ModelView
-            fallbackUri={url}
+            fallbackUri={asset.image_url}
             loading={loading}
             setLoading={setLoading}
-            uri={asset.animation_url || url}
+            uri={asset.animation_url || asset.image_url}
           />
         ) : supportsAudio ? (
           <AudioPlayer
             fontColor={textColor}
             imageColor={imageColor}
-            uri={asset.animation_url || url}
+            uri={asset.animation_url || asset.image_url}
           />
         ) : (
           <UniqueTokenImage
             backgroundColor={asset.background}
-            imageUrl={url}
+            imageUrl={asset.image_url}
             item={asset}
             resizeMode={resizeMode}
             transformSvgs={false}

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.js
@@ -68,7 +68,7 @@ const UniqueTokenExpandedStateContent = ({
             posterUri={asset.image_url}
             setLoading={setLoading}
             style={StyleSheet.absoluteFill}
-            uri={asset.animation_url || url}
+            uri={asset.animation_url || asset.image_url}
           />
         ) : supports3d ? (
           <ModelView


### PR DESCRIPTION
Fixes APP-524

## What changed (plus any additional context for devs)
* when old, pre-simplehash poap data was transformed into a `UniqueAsset`, the nft image was assigned to the `animation_url` attribute. since this is no longer the case, nft expanded state was failing to find the poap image by checking `animation_url`.

## Screen recordings / screenshots
![simulator_screenshot_269EB052-EFA2-47AB-8155-6DDC5DB90A30](https://user-images.githubusercontent.com/15272675/228976022-7c56d4c4-a067-4e94-9fc8-191e2bad1a86.png)


## What to test

