### PR TITLE
Fix flashbots tx status endpoint

### DIFF
--- a/src/handlers/transactions.ts
+++ b/src/handlers/transactions.ts
@@ -180,7 +180,7 @@ export const getTransactionFlashbotStatus = async (
   txHash: string
 ) => {
   try {
-    const fbStatus = await flashbotsApi.get(`/${txHash}`);
+    const fbStatus = await flashbotsApi.get(`/tx/${txHash}`);
     const flashbotStatus = fbStatus.data.status;
     // Make sure it wasn't dropped after 25 blocks or never made it
     if (flashbotStatus === 'FAILED' || flashbotStatus === 'CANCELLED') {


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
IDK when but the endpoint changed. See https://docs.flashbots.net/flashbots-protect/rpc/status-api
So this is currently broken and flashbots transaction are getting stuck for longer even if they were mined earlier.

## Screen recordings / screenshots
Before: https://protect.flashbots.net/0x4201de095d7bf8cefd521e387e40497222cfddfffec0a97c2fc617416347179f
After: https://protect.flashbots.net/tx/0x4201de095d7bf8cefd521e387e40497222cfddfffec0a97c2fc617416347179f

## What to test
Flashbots txs
