### PR TITLE
feat: new Explain sheet

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -320,7 +320,13 @@ function BSNavigator() {
       <BSStack.Screen
         component={Explain}
         name={Routes.EXPLAIN}
-        options={bottomSheetPreset}
+        options={({ route }) => {
+          const hasSheetHeight = route.params && route.params.sheetHeight;
+          return {
+            ...bottomSheetPreset,
+            height: hasSheetHeight ? route.params.sheetHeight : undefined,
+          };
+        }}
       />
       <BSStack.Screen
         component={ExternalLinkWarningSheet}

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -320,11 +320,10 @@ function BSNavigator() {
       <BSStack.Screen
         component={Explain}
         name={Routes.EXPLAIN}
-        options={({ route }) => {
-          const hasSheetHeight = route.params && route.params.sheetHeight;
+        options={({ route: { params = {} } }) => {
           return {
             ...bottomSheetPreset,
-            height: hasSheetHeight ? route.params.sheetHeight : undefined,
+            height: params.sheetHeight,
           };
         }}
       />

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -74,6 +74,7 @@ import { HardwareWalletTxNavigator } from './HardwareWalletTxNavigator';
 import { RewardsSheet } from '@/screens/rewards/RewardsSheet';
 import { SettingsSheet } from '@/screens/SettingsSheet';
 import { CUSTOM_MARGIN_TOP_ANDROID } from '@/screens/SettingsSheet/constants';
+import { Explain } from '@/screens/Explain';
 
 const Stack = createStackNavigator();
 const OuterStack = createStackNavigator();
@@ -314,6 +315,11 @@ function BSNavigator() {
       <BSStack.Screen
         component={ExplainSheet}
         name={Routes.EXPLAIN_SHEET}
+        options={bottomSheetPreset}
+      />
+      <BSStack.Screen
+        component={Explain}
+        name={Routes.EXPLAIN}
         options={bottomSheetPreset}
       />
       <BSStack.Screen

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -65,6 +65,7 @@ import {
   transactionDetailsConfig,
   addWalletNavigatorConfig,
   opRewardsSheetConfig,
+  explainSheetV2Config,
 } from './config';
 import {
   addCashSheet,
@@ -87,6 +88,7 @@ import { TransactionDetails } from '@/screens/transaction-details/TransactionDet
 import { AddWalletNavigator } from './AddWalletNavigator';
 import { HardwareWalletTxNavigator } from './HardwareWalletTxNavigator';
 import { RewardsSheet } from '@/screens/rewards/RewardsSheet';
+import { Explain } from '@/screens/Explain';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();
@@ -367,6 +369,11 @@ function NativeStackNavigator() {
         component={AddWalletNavigator}
         name={Routes.ADD_WALLET_NAVIGATOR}
         {...addWalletNavigatorConfig}
+      />
+      <NativeStack.Screen
+        component={Explain}
+        name={Routes.EXPLAIN}
+        {...explainSheetV2Config}
       />
       {profilesEnabled && (
         <>

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -368,8 +368,8 @@ export const basicSheetConfig = {
 export const explainSheetV2Config = {
   options: ({ route: { params = {} } }) => ({
     ...buildCoolModalConfig({
-      longFormHeight: params.sheetHeight,
       ...params,
+      longFormHeight: params.sheetHeight,
     }),
   }),
 };

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -365,6 +365,15 @@ export const basicSheetConfig = {
   }),
 };
 
+export const explainSheetV2Config = {
+  options: ({ route: { params = {} } }) => ({
+    ...buildCoolModalConfig({
+      longFormHeight: params.sheetHeight,
+      ...params,
+    }),
+  }),
+};
+
 export const stackNavigationConfig = {
   headerMode: 'none',
   keyboardHandlingEnabled: ios,

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -28,6 +28,7 @@ const Routes = {
   EXPANDED_ASSET_SHEET: 'ExpandedAssetSheet',
   EXPANDED_ASSET_SHEET_POOLS: 'ExpandedAssetSheetPools',
   EXPLAIN_SHEET: 'ExplainSheet',
+  EXPLAIN: 'Explain',
   EXTERNAL_LINK_WARNING_SHEET: 'ExternalLinkWarningSheet',
   IMPORT_SCREEN: 'ImportScreen',
   IMPORT_OR_WATCH_WALLET_SHEET: 'ImportOrWatchWalletSheet',

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+
+import Routes from '@/navigation/routesNames';
+import {
+  Box,
+  Text,
+  TextProps,
+  AccentColorProvider,
+  Stack,
+} from '@/design-system';
+import { SimpleSheet } from '@/components/sheet/SimpleSheet';
+import { ImgixImage } from '@/components/images';
+import SheetActionButton from '@/components/sheet/sheet-action-buttons/SheetActionButton';
+
+type ExplainSheetRouteProps = {
+  sheetHeight?: number;
+  children: React.FC;
+};
+
+type NavigationRouteParams = {
+  Explain: ExplainSheetRouteProps;
+};
+
+/**
+ * Proxy for `SheetActionButton` with no changes to API.
+ *
+ * TODO This is proxied because eventually I'd like to replace this.
+ */
+export const Button = SheetActionButton;
+
+/**
+ * Image icon component for use within the Explain sheet.
+ *
+ *   `import * as ex from '@/screens/Explain';`
+ *
+ *   `<ex.Logo accentColor={...} source={require('...')} />`
+ */
+export function Logo({
+  accentColor,
+  source,
+  size = 64,
+}: {
+  accentColor: string;
+  source: StaticImageData;
+  size?: number;
+}) {
+  return (
+    <Box
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="center"
+      paddingBottom="20px"
+    >
+      <AccentColorProvider color={accentColor}>
+        {/* @ts-expect-error Box doesn't like ImgixImage */}
+        <Box
+          as={ImgixImage}
+          source={source}
+          size={size}
+          width={{ custom: size }}
+          height={{ custom: size }}
+          shadow="18px accent"
+        />
+      </AccentColorProvider>
+    </Box>
+  );
+}
+
+/**
+ * Emoji "logo" for use within the Explain sheet.
+ */
+export function Emoji({ children }: { children: string }) {
+  return (
+    <Box paddingBottom="20px">
+      <Text
+        containsEmoji
+        color="accent"
+        align="center"
+        size="44pt"
+        weight="bold"
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * Title text for use within the Explain sheet.
+ */
+export function Title({
+  children,
+  color,
+  size,
+  weight,
+  ...props
+}: Omit<Partial<TextProps>, 'children'> & { children: string }) {
+  return (
+    <Box paddingBottom="36px">
+      <Text
+        color={color || 'label'}
+        weight={weight || 'heavy'}
+        size={size || '26pt'}
+        align="center"
+        {...props}
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * Body text for use within the Explain sheet.
+ */
+export function Body({
+  children,
+  size,
+  color,
+  ...props
+}: Omit<Partial<TextProps>, 'children'> & { children: string }) {
+  return (
+    <Box paddingBottom="20px">
+      <Text
+        color={color || 'labelSecondary'}
+        size={size || '17pt / 135%'}
+        align="center"
+        {...props}
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * A wrapper for any buttons you might want to add to the Explain sheet.
+ * Multiple buttons are automatically spaced apart.
+ *
+ * TODO eventually this should be sticky to the bottom of the sheet to match
+ * designs.
+ */
+export function Footer({
+  children,
+}: {
+  children: React.ReactNode | React.ReactNodeArray;
+}) {
+  return (
+    <Box paddingTop="12px">
+      <Stack space="16px">{children}</Stack>
+    </Box>
+  );
+}
+
+/**
+ * The core Explain sheet
+ */
+export function Explain() {
+  const { goBack } = useNavigation();
+  const { params } = useRoute<RouteProp<NavigationRouteParams, 'Explain'>>();
+
+  if (!params) {
+    goBack();
+    return null;
+  }
+
+  return (
+    <SimpleSheet
+      backgroundColor="white"
+      scrollEnabled={false}
+      customHeight={params.sheetHeight || undefined}
+      style={{
+        borderTopLeftRadius: 40,
+        borderTopRightRadius: 40,
+      }}
+    >
+      <Box paddingVertical="44px" paddingHorizontal="32px" height="full">
+        {params.children({})}
+      </Box>
+    </SimpleSheet>
+  );
+}
+
+/**
+ * Returns a util used to navigate to and render components within the Explain
+ * sheet. This file also exports components that should be used for the sheet's
+ * children.
+ *
+ *    `import * as ex from '@/screens/Explain'`
+ *
+ *    `const { open } = ex.useExplainSheet()`
+ *    `open(() => <ex.Title>...</ex.Title>, { ...options })`
+ */
+export function useExplainSheet() {
+  const { navigate } = useNavigation();
+
+  const open = React.useCallback(
+    (
+      children: React.FC,
+      options: Omit<ExplainSheetRouteProps, 'children'> = {}
+    ) => {
+      navigate(Routes.EXPLAIN, {
+        children,
+        sheetHeight: options.sheetHeight,
+      });
+    },
+    []
+  );
+
+  return {
+    open,
+  };
+}

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -170,10 +170,6 @@ export function Explain() {
       backgroundColor="white"
       scrollEnabled={false}
       customHeight={params.sheetHeight || undefined}
-      style={{
-        borderTopLeftRadius: 40,
-        borderTopRightRadius: 40,
-      }}
     >
       <Box paddingVertical="44px" paddingHorizontal="32px" height="full">
         {params.children({})}

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -166,12 +166,8 @@ export function Explain() {
   }
 
   return (
-    <SimpleSheet
-      backgroundColor="white"
-      scrollEnabled={false}
-      customHeight={params.sheetHeight || undefined}
-    >
-      <Box paddingVertical="44px" paddingHorizontal="32px" height="full">
+    <SimpleSheet backgroundColor="white" scrollEnabled={false}>
+      <Box paddingVertical="44px" paddingHorizontal="32px">
         {params.children({})}
       </Box>
     </SimpleSheet>


### PR DESCRIPTION
Fixes APP-512

## What changed (plus any additional context for devs)
New Explain sheet. Usage:

```tsx
import * as ex from '@/screens/Explain';

const { open } = ex.useExplainSheet();

open(() => (
  <>
    <ex.Title>This is the title component</ex.Title>
    ...etc
  </>
), { sheetHeight: 400, ...options });
```

## What to test
I've been pasta-ing this into `ProfileActionButtonsRow` when clicking on the `BuyButton`.
```tsx
    open(() => (
      <>
        <ex.Emoji>👋</ex.Emoji>
        <ex.Title>New Sheet Who Dis</ex.Title>
        <ex.Body>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sed ex id lacus tempor hendrerit eu sit amet dolor. Curabitur arcu nisl, aliquam nec risus id, laoreet consequat magna.</ex.Body>
        <ex.Body>Etiam pharetra nulla non est finibus, ut luctus nisi viverra. Nunc id sem sit amet ipsum posuere pharetra ut id nisl. Pellentesque a suscipit nisl.</ex.Body>
        <ex.Footer>
          <ex.Button label='Click Me' />
        </ex.Footer>
      </>
    ), { sheetHeight: 450 });
```

## Screen recordings / screenshots
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-03 at 16 34 48](https://user-images.githubusercontent.com/4732330/229633379-6ebacdcb-1a93-4a73-8d3e-c7a0ec1a59f0.png)
![Screenshot_20230403_163858](https://user-images.githubusercontent.com/4732330/229633434-866f21a9-5ef3-491b-a7cf-8785cf01155c.png)
