### PR TITLE
feat: rename new `Explain` sheet to `Portal`

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -74,7 +74,7 @@ import { HardwareWalletTxNavigator } from './HardwareWalletTxNavigator';
 import { RewardsSheet } from '@/screens/rewards/RewardsSheet';
 import { SettingsSheet } from '@/screens/SettingsSheet';
 import { CUSTOM_MARGIN_TOP_ANDROID } from '@/screens/SettingsSheet/constants';
-import { Explain } from '@/screens/Explain';
+import { Portal } from '@/screens/Portal';
 
 const Stack = createStackNavigator();
 const OuterStack = createStackNavigator();
@@ -318,8 +318,8 @@ function BSNavigator() {
         options={bottomSheetPreset}
       />
       <BSStack.Screen
-        component={Explain}
-        name={Routes.EXPLAIN}
+        component={Portal}
+        name={Routes.PORTAL}
         options={({ route: { params = {} } }) => {
           return {
             ...bottomSheetPreset,

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -65,7 +65,7 @@ import {
   transactionDetailsConfig,
   addWalletNavigatorConfig,
   opRewardsSheetConfig,
-  explainSheetV2Config,
+  portalSheetConfig,
 } from './config';
 import {
   addCashSheet,
@@ -88,7 +88,7 @@ import { TransactionDetails } from '@/screens/transaction-details/TransactionDet
 import { AddWalletNavigator } from './AddWalletNavigator';
 import { HardwareWalletTxNavigator } from './HardwareWalletTxNavigator';
 import { RewardsSheet } from '@/screens/rewards/RewardsSheet';
-import { Explain } from '@/screens/Explain';
+import { Portal } from '@/screens/Portal';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();
@@ -371,9 +371,9 @@ function NativeStackNavigator() {
         {...addWalletNavigatorConfig}
       />
       <NativeStack.Screen
-        component={Explain}
-        name={Routes.EXPLAIN}
-        {...explainSheetV2Config}
+        component={Portal}
+        name={Routes.PORTAL}
+        {...portalSheetConfig}
       />
       {profilesEnabled && (
         <>

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -365,7 +365,7 @@ export const basicSheetConfig = {
   }),
 };
 
-export const explainSheetV2Config = {
+export const portalSheetConfig = {
   options: ({ route: { params = {} } }) => ({
     ...buildCoolModalConfig({
       ...params,

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -28,7 +28,7 @@ const Routes = {
   EXPANDED_ASSET_SHEET: 'ExpandedAssetSheet',
   EXPANDED_ASSET_SHEET_POOLS: 'ExpandedAssetSheetPools',
   EXPLAIN_SHEET: 'ExplainSheet',
-  EXPLAIN: 'Explain',
+  PORTAL: 'Portal',
   EXTERNAL_LINK_WARNING_SHEET: 'ExternalLinkWarningSheet',
   IMPORT_SCREEN: 'ImportScreen',
   IMPORT_OR_WATCH_WALLET_SHEET: 'ImportOrWatchWalletSheet',

--- a/src/screens/Explain/README.md
+++ b/src/screens/Explain/README.md
@@ -6,9 +6,12 @@ components for consistent explainer sheets.
 ```tsx
 import * as explain from '@/screens/Explain';
 
-explain.open(() => (
-  <>
-    <explain.Title>Pre-built title comonent</explain.Title>
-  </>
-), { sheetHeight: 400 });
+explain.open(
+  () => (
+    <>
+      <explain.Title>Pre-built title comonent</explain.Title>
+    </>
+  ),
+  { sheetHeight: 400 }
+);
 ```

--- a/src/screens/Explain/README.md
+++ b/src/screens/Explain/README.md
@@ -1,0 +1,14 @@
+# Explain sheet
+
+A wrapper around our `@/screens/Portal` primitive that provides prebuilt
+components for consistent explainer sheets.
+
+```tsx
+import * as explain from '@/screens/Explain';
+
+explain.open(() => (
+  <>
+    <explain.Title>Pre-built title comonent</explain.Title>
+  </>
+), { sheetHeight: 400 });
+```

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -168,7 +168,12 @@ export function Explain() {
 
   return (
     <SimpleSheet backgroundColor="white" scrollEnabled={false}>
-      <Box paddingVertical="44px" paddingHorizontal="32px">
+      <Box
+        paddingVertical="44px"
+        paddingHorizontal="32px"
+        height="full"
+        background="surfaceSecondary"
+      >
         {params.children({})}
       </Box>
     </SimpleSheet>
@@ -195,7 +200,7 @@ export function useExplainSheet() {
     ) => {
       navigate(Routes.EXPLAIN, {
         children,
-        sheetHeight: options.sheetHeight,
+        ...options,
       });
     },
     []
@@ -216,6 +221,6 @@ export function openExplainSheet(
 ) {
   Navigation.handleAction(Routes.EXPLAIN, {
     children,
-    sheetHeight: options.sheetHeight,
+    ...options,
   });
 }

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+
+import {
+  Box,
+  Text,
+  TextProps,
+  AccentColorProvider,
+  Stack,
+} from '@/design-system';
+import { ImgixImage } from '@/components/images';
+import SheetActionButton from '@/components/sheet/sheet-action-buttons/SheetActionButton';
+
+export { open, useOpen } from '@/screens/Portal';
+
+/**
+ * Proxy for `SheetActionButton` with no changes to API.
+ *
+ * TODO This is proxied because eventually I'd like to replace this.
+ */
+export const Button = SheetActionButton;
+
+/**
+ * Image icon component for use within the Portal sheet.
+ *
+ *   `import * as p from '@/screens/Portal';`
+ *
+ *   `<p.Logo accentColor={...} source={require('...')} />`
+ */
+export function Logo({
+  accentColor,
+  source,
+  size = 64,
+}: {
+  accentColor: string;
+  source: StaticImageData;
+  size?: number;
+}) {
+  return (
+    <Box
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="center"
+      paddingBottom="20px"
+    >
+      <AccentColorProvider color={accentColor}>
+        {/* @ts-expect-error Box doesn't like ImgixImage */}
+        <Box
+          as={ImgixImage}
+          source={source}
+          size={size}
+          width={{ custom: size }}
+          height={{ custom: size }}
+          shadow="18px accent"
+        />
+      </AccentColorProvider>
+    </Box>
+  );
+}
+
+/**
+ * Emoji "logo" for use within the Portal sheet.
+ */
+export function Emoji({ children }: { children: string }) {
+  return (
+    <Box paddingBottom="20px">
+      <Text
+        containsEmoji
+        color="accent"
+        align="center"
+        size="44pt"
+        weight="bold"
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * Title text for use within the Portal sheet.
+ */
+export function Title({
+  children,
+  color,
+  size,
+  weight,
+  ...props
+}: Omit<Partial<TextProps>, 'children'> & { children: string }) {
+  return (
+    <Box paddingBottom="36px">
+      <Text
+        color={color || 'label'}
+        weight={weight || 'heavy'}
+        size={size || '26pt'}
+        align="center"
+        {...props}
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * Body text for use within the Portal sheet.
+ */
+export function Body({
+  children,
+  size,
+  color,
+  ...props
+}: Omit<Partial<TextProps>, 'children'> & { children: string }) {
+  return (
+    <Box paddingBottom="20px">
+      <Text
+        color={color || 'labelSecondary'}
+        size={size || '17pt / 135%'}
+        align="center"
+        {...props}
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * A wrapper for any buttons you might want to add to the Portal sheet.
+ * Multiple buttons are automatically spaced apart.
+ *
+ * TODO eventually this should be sticky to the bottom of the sheet to match
+ * designs.
+ */
+export function Footer({
+  children,
+}: {
+  children: React.ReactNode | React.ReactNodeArray;
+}) {
+  return (
+    <Box paddingTop="12px">
+      <Stack space="16px">{children}</Stack>
+    </Box>
+  );
+}

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
 
+import { Navigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import {
   Box,
@@ -203,4 +204,18 @@ export function useExplainSheet() {
   return {
     open,
   };
+}
+
+/**
+ * Use `useExplainSheet` where possible. This util exists for limited use
+ * outside a React component.
+ */
+export function openExplainSheet(
+  children: React.FC,
+  options: Omit<ExplainSheetRouteProps, 'children'> = {}
+) {
+  Navigation.handleAction(Routes.EXPLAIN, {
+    children,
+    sheetHeight: options.sheetHeight,
+  });
 }

--- a/src/screens/Portal/README.md
+++ b/src/screens/Portal/README.md
@@ -1,0 +1,87 @@
+# Portal
+
+A low-level primitive for building new sheets that appear on top of other
+content.
+
+## Usage
+
+```tsx
+import * as portal from '@/screens/Portal';
+
+export function Comp() {
+  const { open } = portal.useOpen();
+
+  const handlePress = () => {
+    open(() => (
+      <>
+        <Box>
+          <Text>Hello world</Text>
+        </Box>
+      </>
+    ), { sheetHeight: 400 });
+  }
+
+  return (
+    <Button onPress={handlePress}>
+      Show some sheet
+    </Button>
+  )
+}
+```
+
+There's also an API for use outside a React component, but try to use the hook
+where possible.
+
+```tsx
+import * as portal from '@/screens/Portal';
+
+portal.open(() => <>...</>, { ...options });
+```
+
+## Extension
+
+We extend this primitive in some cases, like our `@/screens/Explain` sheet.
+There, we re-export `useOpen` and `open`, as well as provide some pre-built
+components that can be used to make consistent explainer sheets.
+
+```tsx
+import * as explain from '@/screens/Explain'
+
+explain.open(() => (
+  <>
+    <explain.Emoji>💰</explain.Emoji>
+    <explain.Title>This is a title</explain.Title>
+    <explain.Body>And this is body text</explain.Body>
+  </>
+), { sheetHeight: 640 });
+```
+
+## Creating navigable routes
+
+**All portals are rendered on the `Routes.PORTAL` route.** If you need to create
+a separate route, maybe to deeplink to, then you'll need to create a new
+`@/screens/<screen>`, assign it a separate route name in
+`@/navigation/routeNames`, and add the new route to `Routes.ios.js` and
+`Routes.android.js`.
+
+You can use the `Portal` sheet wrapper as a starting point, though (it just uses
+our `SimpleSheet` under the hood:
+
+```tsx
+export function Portal() {
+  const { params } = useRoute<RouteProp<NavigationRouteParams, 'MyRoute'>>();
+
+  return (
+    <SimpleSheet backgroundColor="white" scrollEnabled={false}>
+      <Box
+        paddingVertical="44px"
+        paddingHorizontal="32px"
+        height="full"
+        background="surfaceSecondary"
+      >
+        ...
+      </Box>
+    </SimpleSheet>
+  );
+}
+```

--- a/src/screens/Portal/README.md
+++ b/src/screens/Portal/README.md
@@ -12,20 +12,19 @@ export function Comp() {
   const { open } = portal.useOpen();
 
   const handlePress = () => {
-    open(() => (
-      <>
-        <Box>
-          <Text>Hello world</Text>
-        </Box>
-      </>
-    ), { sheetHeight: 400 });
-  }
+    open(
+      () => (
+        <>
+          <Box>
+            <Text>Hello world</Text>
+          </Box>
+        </>
+      ),
+      { sheetHeight: 400 }
+    );
+  };
 
-  return (
-    <Button onPress={handlePress}>
-      Show some sheet
-    </Button>
-  )
+  return <Button onPress={handlePress}>Show some sheet</Button>;
 }
 ```
 
@@ -45,15 +44,18 @@ There, we re-export `useOpen` and `open`, as well as provide some pre-built
 components that can be used to make consistent explainer sheets.
 
 ```tsx
-import * as explain from '@/screens/Explain'
+import * as explain from '@/screens/Explain';
 
-explain.open(() => (
-  <>
-    <explain.Emoji>💰</explain.Emoji>
-    <explain.Title>This is a title</explain.Title>
-    <explain.Body>And this is body text</explain.Body>
-  </>
-), { sheetHeight: 640 });
+explain.open(
+  () => (
+    <>
+      <explain.Emoji>💰</explain.Emoji>
+      <explain.Title>This is a title</explain.Title>
+      <explain.Body>And this is body text</explain.Body>
+    </>
+  ),
+  { sheetHeight: 640 }
+);
 ```
 
 ## Creating navigable routes

--- a/src/screens/Portal/index.tsx
+++ b/src/screens/Portal/index.tsx
@@ -187,10 +187,10 @@ export function Portal() {
  *
  *    `import * as p from '@/screens/Portal';`
  *
- *    `const { open } = p.usePortalSheet()`
+ *    `const { open } = p.useOpen()`
  *    `open(() => <p.Title>...</p.Title>, { ...options })`
  */
-export function usePortalSheet() {
+export function useOpen() {
   const { navigate } = useNavigation();
 
   const open = React.useCallback(
@@ -209,10 +209,10 @@ export function usePortalSheet() {
 }
 
 /**
- * Use `usePortalSheet` where possible. This util exists for limited use
+ * Use `useOpen` where possible. This util exists for limited use
  * outside a React component.
  */
-export function openPortalSheet(
+export function open(
   children: React.FC,
   options: Omit<PortalSheetProps, 'children'> = {}
 ) {

--- a/src/screens/Portal/index.tsx
+++ b/src/screens/Portal/index.tsx
@@ -3,16 +3,8 @@ import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
 
 import { Navigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
-import {
-  Box,
-  Text,
-  TextProps,
-  AccentColorProvider,
-  Stack,
-} from '@/design-system';
+import { Box } from '@/design-system';
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
-import { ImgixImage } from '@/components/images';
-import SheetActionButton from '@/components/sheet/sheet-action-buttons/SheetActionButton';
 
 type PortalSheetProps = {
   sheetHeight?: number;
@@ -22,137 +14,6 @@ type PortalSheetProps = {
 type NavigationRouteParams = {
   Portal: PortalSheetProps;
 };
-
-/**
- * Proxy for `SheetActionButton` with no changes to API.
- *
- * TODO This is proxied because eventually I'd like to replace this.
- */
-export const Button = SheetActionButton;
-
-/**
- * Image icon component for use within the Portal sheet.
- *
- *   `import * as p from '@/screens/Portal';`
- *
- *   `<p.Logo accentColor={...} source={require('...')} />`
- */
-export function Logo({
-  accentColor,
-  source,
-  size = 64,
-}: {
-  accentColor: string;
-  source: StaticImageData;
-  size?: number;
-}) {
-  return (
-    <Box
-      flexDirection="row"
-      alignItems="center"
-      justifyContent="center"
-      paddingBottom="20px"
-    >
-      <AccentColorProvider color={accentColor}>
-        {/* @ts-expect-error Box doesn't like ImgixImage */}
-        <Box
-          as={ImgixImage}
-          source={source}
-          size={size}
-          width={{ custom: size }}
-          height={{ custom: size }}
-          shadow="18px accent"
-        />
-      </AccentColorProvider>
-    </Box>
-  );
-}
-
-/**
- * Emoji "logo" for use within the Portal sheet.
- */
-export function Emoji({ children }: { children: string }) {
-  return (
-    <Box paddingBottom="20px">
-      <Text
-        containsEmoji
-        color="accent"
-        align="center"
-        size="44pt"
-        weight="bold"
-      >
-        {children}
-      </Text>
-    </Box>
-  );
-}
-
-/**
- * Title text for use within the Portal sheet.
- */
-export function Title({
-  children,
-  color,
-  size,
-  weight,
-  ...props
-}: Omit<Partial<TextProps>, 'children'> & { children: string }) {
-  return (
-    <Box paddingBottom="36px">
-      <Text
-        color={color || 'label'}
-        weight={weight || 'heavy'}
-        size={size || '26pt'}
-        align="center"
-        {...props}
-      >
-        {children}
-      </Text>
-    </Box>
-  );
-}
-
-/**
- * Body text for use within the Portal sheet.
- */
-export function Body({
-  children,
-  size,
-  color,
-  ...props
-}: Omit<Partial<TextProps>, 'children'> & { children: string }) {
-  return (
-    <Box paddingBottom="20px">
-      <Text
-        color={color || 'labelSecondary'}
-        size={size || '17pt / 135%'}
-        align="center"
-        {...props}
-      >
-        {children}
-      </Text>
-    </Box>
-  );
-}
-
-/**
- * A wrapper for any buttons you might want to add to the Portal sheet.
- * Multiple buttons are automatically spaced apart.
- *
- * TODO eventually this should be sticky to the bottom of the sheet to match
- * designs.
- */
-export function Footer({
-  children,
-}: {
-  children: React.ReactNode | React.ReactNodeArray;
-}) {
-  return (
-    <Box paddingTop="12px">
-      <Stack space="16px">{children}</Stack>
-    </Box>
-  );
-}
 
 /**
  * The core Portal sheet

--- a/src/screens/Portal/index.tsx
+++ b/src/screens/Portal/index.tsx
@@ -14,13 +14,13 @@ import { SimpleSheet } from '@/components/sheet/SimpleSheet';
 import { ImgixImage } from '@/components/images';
 import SheetActionButton from '@/components/sheet/sheet-action-buttons/SheetActionButton';
 
-type ExplainSheetRouteProps = {
+type PortalSheetProps = {
   sheetHeight?: number;
   children: React.FC;
 };
 
 type NavigationRouteParams = {
-  Explain: ExplainSheetRouteProps;
+  Portal: PortalSheetProps;
 };
 
 /**
@@ -31,11 +31,11 @@ type NavigationRouteParams = {
 export const Button = SheetActionButton;
 
 /**
- * Image icon component for use within the Explain sheet.
+ * Image icon component for use within the Portal sheet.
  *
- *   `import * as ex from '@/screens/Explain';`
+ *   `import * as p from '@/screens/Portal';`
  *
- *   `<ex.Logo accentColor={...} source={require('...')} />`
+ *   `<p.Logo accentColor={...} source={require('...')} />`
  */
 export function Logo({
   accentColor,
@@ -69,7 +69,7 @@ export function Logo({
 }
 
 /**
- * Emoji "logo" for use within the Explain sheet.
+ * Emoji "logo" for use within the Portal sheet.
  */
 export function Emoji({ children }: { children: string }) {
   return (
@@ -88,7 +88,7 @@ export function Emoji({ children }: { children: string }) {
 }
 
 /**
- * Title text for use within the Explain sheet.
+ * Title text for use within the Portal sheet.
  */
 export function Title({
   children,
@@ -113,7 +113,7 @@ export function Title({
 }
 
 /**
- * Body text for use within the Explain sheet.
+ * Body text for use within the Portal sheet.
  */
 export function Body({
   children,
@@ -136,7 +136,7 @@ export function Body({
 }
 
 /**
- * A wrapper for any buttons you might want to add to the Explain sheet.
+ * A wrapper for any buttons you might want to add to the Portal sheet.
  * Multiple buttons are automatically spaced apart.
  *
  * TODO eventually this should be sticky to the bottom of the sheet to match
@@ -155,11 +155,11 @@ export function Footer({
 }
 
 /**
- * The core Explain sheet
+ * The core Portal sheet
  */
-export function Explain() {
+export function Portal() {
   const { goBack } = useNavigation();
-  const { params } = useRoute<RouteProp<NavigationRouteParams, 'Explain'>>();
+  const { params } = useRoute<RouteProp<NavigationRouteParams, 'Portal'>>();
 
   if (!params) {
     goBack();
@@ -181,24 +181,21 @@ export function Explain() {
 }
 
 /**
- * Returns a util used to navigate to and render components within the Explain
+ * Returns a util used to navigate to and render components within the Portal
  * sheet. This file also exports components that should be used for the sheet's
  * children.
  *
- *    `import * as ex from '@/screens/Explain'`
+ *    `import * as p from '@/screens/Portal';`
  *
- *    `const { open } = ex.useExplainSheet()`
- *    `open(() => <ex.Title>...</ex.Title>, { ...options })`
+ *    `const { open } = p.usePortalSheet()`
+ *    `open(() => <p.Title>...</p.Title>, { ...options })`
  */
-export function useExplainSheet() {
+export function usePortalSheet() {
   const { navigate } = useNavigation();
 
   const open = React.useCallback(
-    (
-      children: React.FC,
-      options: Omit<ExplainSheetRouteProps, 'children'> = {}
-    ) => {
-      navigate(Routes.EXPLAIN, {
+    (children: React.FC, options: Omit<PortalSheetProps, 'children'> = {}) => {
+      navigate(Routes.PORTAL, {
         children,
         ...options,
       });
@@ -212,14 +209,14 @@ export function useExplainSheet() {
 }
 
 /**
- * Use `useExplainSheet` where possible. This util exists for limited use
+ * Use `usePortalSheet` where possible. This util exists for limited use
  * outside a React component.
  */
-export function openExplainSheet(
+export function openPortalSheet(
   children: React.FC,
-  options: Omit<ExplainSheetRouteProps, 'children'> = {}
+  options: Omit<PortalSheetProps, 'children'> = {}
 ) {
-  Navigation.handleAction(Routes.EXPLAIN, {
+  Navigation.handleAction(Routes.PORTAL, {
     children,
     ...options,
   });


### PR DESCRIPTION
Renames `Explain` to `Portal`, adds a non-hook way to open a Portal, and ensures that new DS components show up correctly within it i.e. dark/light mode.

```typescript
import * as portal from '@/screens/Portal'

portal.open(() => <>...</>, {...options}) // new non-hook API
```

