### PR TITLE
Spam score filtering + use new polygon allowlist endpoint

### DIFF
--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -115,3 +115,9 @@ query reverseResolveENSProfile(
     }
   }
 }
+
+query getNFTAllowlist($chainID: Int!) {
+  nftAllowlist(chainID: $chainID) {
+    addresses
+  }
+}

--- a/src/resources/nfts/index.ts
+++ b/src/resources/nfts/index.ts
@@ -10,11 +10,12 @@ import {
   filterSimpleHashNFTs,
   simpleHashNFTToUniqueAsset,
 } from '@/resources/nfts/simplehash/utils';
-import { rainbowFetch } from '@/rainbow-fetch';
 import { useSelector } from 'react-redux';
 import { AppState } from '@/redux/store';
 import { Network } from '@/helpers';
+import { metadataClient } from '@/graphql';
 
+const POLYGON_CHAIN_ID = 137;
 const NFTS_LIMIT = 2000;
 const NFTS_STALE_TIME = 300000; // 5 minutes
 const NFTS_CACHE_TIME_EXTERNAL = 3600000; // 1 hour
@@ -39,14 +40,13 @@ function fetchPolygonAllowlist() {
     ['polygon-allowlist'],
     async () => {
       const polygonAllowlistAddresses = (
-        await rainbowFetch(
-          'https://metadata.p.rainbow.me/token-list/137-allowlist.json',
-          { method: 'get' }
-        )
-      ).data.data.addresses;
+        await metadataClient.getNFTAllowlist({
+          chainID: POLYGON_CHAIN_ID,
+        })
+      )?.nftAllowlist?.addresses;
 
       const polygonAllowlist: PolygonAllowlist = {};
-      polygonAllowlistAddresses.forEach((address: string) => {
+      polygonAllowlistAddresses?.forEach((address: string) => {
         polygonAllowlist[address] = true;
       });
 

--- a/src/resources/nfts/simplehash/utils.ts
+++ b/src/resources/nfts/simplehash/utils.ts
@@ -13,6 +13,8 @@ import { convertRawAmountToRoundedDecimal } from '@/helpers/utilities';
 import { PolygonAllowlist } from '../types';
 import { ERC1155, ERC721 } from '@/handlers/web3';
 
+const SPAM_SCORE_THRESHOLD = 85;
+
 /**
  * Returns a `SimpleHashChain` from a given `Network`. Can return undefined if
  * a `Network` has no counterpart in SimpleHash.
@@ -77,7 +79,8 @@ export function getPriceFromLastSale(
 
 /**
  * This function filters out NFTs that do not have a name, collection name,
- * contract address, or token id. It also filters out Polygon NFTs that are
+ * contract address, or token id. It also filters out non-Polygon NFTs with
+ * a spam score greater than or equal to 85, Polygon NFTs that are
  * not whitelisted by our allowlist, as well as Gnosis NFTs that are not POAPs.
  *
  * @param nfts array of SimpleHashNFTs
@@ -95,6 +98,14 @@ export function filterSimpleHashNFTs(
       !nft.collection?.name ||
       !nft.contract_address ||
       !nft.token_id
+    ) {
+      return false;
+    }
+    if (
+      // fallback to spam score if polygon allowlist is not provided
+      (nft.chain !== SimpleHashChain.Polygon || !polygonAllowlist) &&
+      nft.collection?.spam_score &&
+      nft.collection.spam_score >= SPAM_SCORE_THRESHOLD
     ) {
       return false;
     }


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- filter out all nfts that have a spam score of 85 or higher
  * if the polygon allowlist is provided, we don't use spam score filtering for Polygon nfts (it should always be provided unless fetching the allowlist fails)
- migrate to new polygon allowlist endpoint


## Screen recordings / screenshots


## What to test

