### PR TITLE
fix: ensure require types are always defined

### DIFF
--- a/src/resources/nfts/simplehash/types.ts
+++ b/src/resources/nfts/simplehash/types.ts
@@ -184,3 +184,12 @@ export type SimpleHashNFT = {
     attributes: SimpleHashTrait[] | null | undefined;
   };
 };
+
+export type ValidatedSimpleHashNFT = Omit<
+  SimpleHashNFT,
+  'name' | 'contract_address' | 'token_id'
+> & {
+  name: string;
+  contract_address: string;
+  token_id: string;
+};

--- a/src/resources/nfts/types.ts
+++ b/src/resources/nfts/types.ts
@@ -67,10 +67,10 @@ export type NFT = {
   isSendable: boolean;
   lastSale: NFTLastSale | undefined;
   marketplaces: NFTMarketplace[];
-  name: string | undefined;
+  name: string;
   network: Network;
   predominantColor: string | undefined;
-  tokenId: string | undefined;
+  tokenId: string;
   traits: NFTTrait[];
   type: AssetType;
   uniqueId: string;


### PR DESCRIPTION
Just noticed that we want NFT to have a valid `name` and `tokenId`, and do the work to filter out any NFTs that don't. So figured the `NFT` type should have those two fields required.