### PR TITLE
Eric/sh6

### DIFF
--- a/src/resources/nfts/simplehash/utils.ts
+++ b/src/resources/nfts/simplehash/utils.ts
@@ -339,68 +339,61 @@ export function simpleHashNFTToInternalNFT(nft: ValidatedSimpleHashNFT): NFT {
   // filter out unsupported marketplaces
   const marketplaces = nft.collection.marketplace_pages
     .filter(
-      marketplace =>
-        !!getInternalMarketplaceIdFromSimpleHashMarketplaceId(
-          marketplace.marketplace_id
-        )
+      m =>
+        !!getInternalMarketplaceIdFromSimpleHashMarketplaceId(m.marketplace_id)
     )
-    .map((marketplace: SimpleHashMarketplace) => {
-      const validatedMarketplace: NFTMarketplace = {
-        collectionId: marketplace?.marketplace_collection_id,
-        collectionUrl: marketplace?.collection_url,
+    .map((m: SimpleHashMarketplace) => {
+      const marketplace: NFTMarketplace = {
+        collectionId: m?.marketplace_collection_id,
+        collectionUrl: m?.collection_url,
         marketplaceId: getInternalMarketplaceIdFromSimpleHashMarketplaceId(
-          marketplace.marketplace_id
+          m.marketplace_id
         )!,
-        name: marketplace?.marketplace_name,
-        nftUrl: marketplace?.nft_url,
+        name: m?.marketplace_name,
+        nftUrl: m?.nft_url,
       };
 
-      return validatedMarketplace;
+      return marketplace;
     });
 
   // filter out traits that are missing key attributes
   const traits = nft.extra_metadata?.attributes
     ? nft.extra_metadata.attributes
-        .filter(
-          (trait: SimpleHashTrait) =>
-            !isNil(trait.trait_type) && !isNil(trait.value)
-        )
-        .map((trait: SimpleHashTrait) => {
-          const t: NFTTrait = {
-            displayType: trait.display_type!,
-            traitType: trait.trait_type,
-            value: trait.value,
+        .filter((t: SimpleHashTrait) => !isNil(t.trait_type) && !isNil(t.value))
+        .map((t: SimpleHashTrait) => {
+          const trait: NFTTrait = {
+            displayType: t.display_type!,
+            traitType: t.trait_type,
+            value: t.value,
           };
 
-          return t;
+          return trait;
         })
     : [];
 
   // filter out floor prices that are from unsupported marketplaces or have invalid payment tokens
   const floorPrices = collection.floor_prices
     .filter(
-      (floorPrice: SimpleHashFloorPrice) =>
-        getInternalMarketplaceIdFromSimpleHashMarketplaceId(
-          floorPrice.marketplace_id
-        ) &&
-        floorPrice.payment_token?.name &&
-        floorPrice.payment_token?.symbol
+      (f: SimpleHashFloorPrice) =>
+        getInternalMarketplaceIdFromSimpleHashMarketplaceId(f.marketplace_id) &&
+        f.payment_token?.name &&
+        f.payment_token?.symbol
     )
-    .map((floorPrice: SimpleHashFloorPrice) => {
-      const f: NFTFloorPrice = {
+    .map((f: SimpleHashFloorPrice) => {
+      const floorPrice: NFTFloorPrice = {
         marketplaceId: getInternalMarketplaceIdFromSimpleHashMarketplaceId(
-          floorPrice.marketplace_id
+          f.marketplace_id
         )!,
         paymentToken: {
-          address: floorPrice.payment_token.address,
-          decimals: floorPrice.payment_token.decimals,
-          name: floorPrice.payment_token.name!,
-          symbol: floorPrice.payment_token.symbol!,
+          address: f.payment_token.address,
+          decimals: f.payment_token.decimals,
+          name: f.payment_token.name!,
+          symbol: f.payment_token.symbol!,
         },
-        value: floorPrice.value,
+        value: f.value,
       };
 
-      return f;
+      return floorPrice;
     });
 
   return {

--- a/src/resources/nfts/simplehash/utils.ts
+++ b/src/resources/nfts/simplehash/utils.ts
@@ -107,34 +107,40 @@ export function filterSimpleHashNFTs(
   nfts: SimpleHashNFT[],
   polygonAllowlist?: PolygonAllowlist
 ): ValidatedSimpleHashNFT[] {
-  return nfts.filter(nft => {
-    const lowercasedContractAddress = nft.contract_address?.toLowerCase();
-    const network = getNetworkFromSimpleHashChain(nft.chain);
+  return nfts
+    .filter(nft => {
+      const lowercasedContractAddress = nft.contract_address?.toLowerCase();
+      const network = getNetworkFromSimpleHashChain(nft.chain);
 
-    const isMissingRequiredFields =
-      !nft.name ||
-      !nft.collection?.name ||
-      !nft.contract_address ||
-      !nft.token_id ||
-      !network;
-    const isPolygonAndNotAllowed =
-      polygonAllowlist &&
-      nft.chain === SimpleHashChain.Polygon &&
-      !polygonAllowlist[lowercasedContractAddress];
-    const isGnosisAndNotPOAP =
-      nft.chain === SimpleHashChain.Gnosis &&
-      lowercasedContractAddress !== POAP_NFT_ADDRESS;
+      const isMissingRequiredFields =
+        !nft.name ||
+        !nft.collection?.name ||
+        !nft.contract_address ||
+        !nft.token_id ||
+        !network;
+      const isPolygonAndNotAllowed =
+        polygonAllowlist &&
+        nft.chain === SimpleHashChain.Polygon &&
+        !polygonAllowlist[lowercasedContractAddress];
+      const isGnosisAndNotPOAP =
+        nft.chain === SimpleHashChain.Gnosis &&
+        lowercasedContractAddress !== POAP_NFT_ADDRESS;
 
-    if (
-      isMissingRequiredFields ||
-      isPolygonAndNotAllowed ||
-      isGnosisAndNotPOAP
-    ) {
-      return false;
-    }
+      if (
+        isMissingRequiredFields ||
+        isPolygonAndNotAllowed ||
+        isGnosisAndNotPOAP
+      ) {
+        return false;
+      }
 
-    return true;
-  }) as ValidatedSimpleHashNFT[];
+      return true;
+    })
+    .map(nft => ({
+      ...nft,
+      name: nft.name!,
+      token_id: nft.token_id!,
+    }));
 }
 
 /**

--- a/src/resources/nfts/simplehash/utils.ts
+++ b/src/resources/nfts/simplehash/utils.ts
@@ -359,21 +359,22 @@ export function simpleHashNFTToInternalNFT(nft: ValidatedSimpleHashNFT): NFT {
     });
 
   // filter out traits that are missing key attributes
-  const traits =
-    nft.extra_metadata?.attributes
-      ?.filter(
-        (trait: SimpleHashTrait) =>
-          !isNil(trait.trait_type) && !isNil(trait.value)
-      )
-      ?.map((trait: SimpleHashTrait) => {
-        const t: NFTTrait = {
-          displayType: trait.display_type!,
-          traitType: trait.trait_type,
-          value: trait.value,
-        };
+  const traits = nft.extra_metadata?.attributes
+    ? nft.extra_metadata.attributes
+        .filter(
+          (trait: SimpleHashTrait) =>
+            !isNil(trait.trait_type) && !isNil(trait.value)
+        )
+        .map((trait: SimpleHashTrait) => {
+          const t: NFTTrait = {
+            displayType: trait.display_type!,
+            traitType: trait.trait_type,
+            value: trait.value,
+          };
 
-        return t;
-      }) ?? [];
+          return t;
+        })
+    : [];
 
   // filter out floor prices that are from unsupported marketplaces or have invalid payment tokens
   const floorPrices = collection.floor_prices

--- a/src/resources/nfts/simplehash/utils.ts
+++ b/src/resources/nfts/simplehash/utils.ts
@@ -255,7 +255,7 @@ function handleImages(
   lowResPngUrl: string | undefined;
   fullResUrl: string | undefined;
 } {
-  if (typeof original !== 'string' || typeof preview !== 'string') {
+  if (!original && !preview) {
     return {
       fullResPngUrl: undefined,
       lowResPngUrl: undefined,
@@ -267,7 +267,7 @@ function handleImages(
     // simplehash previews are (supposedly) never svgs
     // they are (supposed to be) google cdn urls that are suffixed with an image size parameter
     // we need to trim off the size suffix to get the full size image
-    preview.startsWith(GOOGLE_USER_CONTENT_URL)
+    preview?.startsWith?.(GOOGLE_USER_CONTENT_URL)
       ? preview.replace(/=s\d+$/, '')
       : // fallback to the original image url if we don't have a preview url of the expected format
         svgToPngIfNeeded(original);

--- a/src/resources/nfts/simplehash/utils.ts
+++ b/src/resources/nfts/simplehash/utils.ts
@@ -249,18 +249,19 @@ function handleImages(
   lowResPngUrl: string | undefined;
   fullResUrl: string | undefined;
 } {
-  if (!original && !preview) {
+  if (typeof original !== 'string' || typeof preview !== 'string') {
     return {
       fullResPngUrl: undefined,
       lowResPngUrl: undefined,
       fullResUrl: undefined,
     };
   }
+
   const nonSVGUrl =
     // simplehash previews are (supposedly) never svgs
     // they are (supposed to be) google cdn urls that are suffixed with an image size parameter
     // we need to trim off the size suffix to get the full size image
-    preview?.startsWith?.(GOOGLE_USER_CONTENT_URL)
+    preview.startsWith(GOOGLE_USER_CONTENT_URL)
       ? preview.replace(/=s\d+$/, '')
       : // fallback to the original image url if we don't have a preview url of the expected format
         svgToPngIfNeeded(original);


### PR DESCRIPTION
Realized that `as` isn't great in these cases because if we change the casted type, then TS will think it satisfies when it might actually not. So rewrote this a bit to specify the type and only force the individual properties needed to satisfy it. Should be safer.