### PR TITLE
Fix audit

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -10,6 +10,6 @@
     "GHSA-9vvw-cc9w-f27h", // https://github.com/advisories/GHSA-9vvw-cc9w-f27h
     "GHSA-p8p7-x288-28g6", // https://github.com/advisories/GHSA-p8p7-x288-28g6
     "GHSA-776f-qx25-q3cc", // https://github.com/advisories/GHSA-776f-qx25-q3cc
-    "GHSA-f9xv-q969-pqx4"  // https://github.com/advisories/GHSA-f9xv-q969-pqx4
+    "GHSA-f9xv-q969-pqx4" // https://github.com/advisories/GHSA-f9xv-q969-pqx4
   ]
 }

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -9,6 +9,7 @@
     "GHSA-hrpp-h998-j3pp", // https://github.com/advisories/GHSA-hrpp-h998-j3pp
     "GHSA-9vvw-cc9w-f27h", // https://github.com/advisories/GHSA-9vvw-cc9w-f27h
     "GHSA-p8p7-x288-28g6", // https://github.com/advisories/GHSA-p8p7-x288-28g6
-    "GHSA-776f-qx25-q3cc" // https://github.com/advisories/GHSA-776f-qx25-q3cc
+    "GHSA-776f-qx25-q3cc", // https://github.com/advisories/GHSA-776f-qx25-q3cc
+    "GHSA-f9xv-q969-pqx4"  // https://github.com/advisories/GHSA-f9xv-q969-pqx4
   ]
 }


### PR DESCRIPTION
Ignored the yaml vulnerability since we only use it in local dev environment git hooks and patch package and the version bump required is a one major version up which can break stuff.