### PR TITLE
fix: maintain fn signature for loadAllKeys

### DIFF
--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -208,10 +208,17 @@ export async function remove(key: string) {
  * This method originates in a patch that we applied manually to the underlying
  * keychain library. Check out our patches directory for more info.
  */
-export async function getAllKeys(): Promise<UserCredentials[]> {
-  logger.debug(`keychain: getAllKeys`, {}, logger.DebugContext.keychain);
-  const res = await getAllInternetCredentials();
-  return res ? res.results : [];
+export async function getAllKeys(): Promise<UserCredentials[] | undefined> {
+  try {
+    logger.debug(`keychain: getAllKeys`, {}, logger.DebugContext.keychain);
+    const res = await getAllInternetCredentials();
+    return res ? res.results : [];
+  } catch (e: any) {
+    logger.error(new RainbowError(`keychain: getAllKeys() failed`), {
+      message: e.toString(),
+    });
+    return undefined;
+  }
 }
 
 /**
@@ -226,6 +233,8 @@ export async function clear() {
   cache.clearAll();
 
   const credentials = await getAllKeys();
+
+  if (!credentials) return;
 
   await Promise.all(
     credentials?.map(c => resetInternetCredentials(c.username))

--- a/src/model/keychain.ts
+++ b/src/model/keychain.ts
@@ -100,7 +100,7 @@ export async function remove(key: string): Promise<void> {
  *    await getAllKeys()
  */
 export async function loadAllKeys(): Promise<null | UserCredentials[]> {
-  return kc.getAllKeys();
+  return (await kc.getAllKeys()) || null;
 }
 
 /**


### PR DESCRIPTION
I noticed that I introduced a regression: `loadAllKeys` does need to be able to return a falsy value. For example, in backups, if a user cancels auth, that nullish value is what we're using to show an alert to the user. Edge case, but need to fix this.