### PR TITLE
fix: fail on unsupported methods, and reject thrown session builder errors

### DIFF
--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -445,13 +445,6 @@ export async function onSessionProposal(
     return;
   }
 
-  const peerMeta = proposer.metadata;
-  const dappName = peerMeta.name || lang.t(lang.l.walletconnect.unknown_dapp);
-
-  /**
-   * Log these, but it's OK if they list them now, we'll just ignore requests
-   * to use them later.
-   */
   const unsupportedMethods = methods.filter(
     method => !isSupportedMethod(method as RPCMethod)
   );
@@ -468,6 +461,9 @@ export async function onSessionProposal(
     });
     return;
   }
+
+  const peerMeta = proposer.metadata;
+  const dappName = peerMeta.name || lang.t(lang.l.walletconnect.unknown_dapp);
 
   const routeParams: WalletconnectApprovalSheetRouteParams = {
     receivedTimestamp,

--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -163,6 +163,40 @@ export function parseRPCParams({
   }
 }
 
+/**
+ * Better signature for this type of function
+ *
+ * @see https://docs.walletconnect.com/2.0/web/web3wallet/wallet-usage#-namespaces-builder-util
+ */
+export function getApprovedNamespaces(
+  props: Parameters<typeof buildApprovedNamespaces>[0]
+):
+  | {
+      success: true;
+      result: ReturnType<typeof buildApprovedNamespaces>;
+      error: undefined;
+    }
+  | {
+      success: false;
+      result: undefined;
+      error: Error;
+    } {
+  try {
+    const namespaces = buildApprovedNamespaces(props);
+    return {
+      success: true,
+      result: namespaces,
+      error: undefined,
+    };
+  } catch (e: any) {
+    return {
+      success: false,
+      result: undefined,
+      error: e,
+    };
+  }
+}
+
 const SUPPORTED_SIGNING_METHODS = [
   RPCMethod.Sign,
   RPCMethod.PersonalSign,
@@ -426,6 +460,13 @@ export async function onSessionProposal(
     logger.info(`WC v2: dapp requested unsupported RPC methods`, {
       methods: unsupportedMethods,
     });
+    await rejectProposal({ proposal, reason: 'UNSUPPORTED_METHODS' });
+    showErrorSheet({
+      onClose() {
+        maybeGoBackAndClearHasPendingRedirect();
+      },
+    });
+    return;
   }
 
   const routeParams: WalletconnectApprovalSheetRouteParams = {
@@ -459,8 +500,7 @@ export async function onSessionProposal(
         const requiredNamespace = requiredNamespaces.eip155;
         /** @see https://chainagnostic.org/CAIPs/caip-2 */
         const caip2ChainIds = SUPPORTED_EVM_CHAIN_IDS.map(id => `eip155:${id}`);
-        /** @see https://docs.walletconnect.com/2.0/web/web3wallet/wallet-usage#-namespaces-builder-util */
-        const namespaces = buildApprovedNamespaces({
+        const namespaces = getApprovedNamespaces({
           proposal: proposal.params,
           supportedNamespaces: {
             eip155: {
@@ -482,34 +522,47 @@ export async function onSessionProposal(
         );
 
         try {
-          /**
-           * This is equivalent handling of setPendingRequest and
-           * walletConnectApproveSession, since setPendingRequest is only used
-           * within the /redux/walletconnect handlers
-           *
-           * WC v2 stores existing _pairings_ itself, so we don't need to persist
-           * ourselves
-           */
-          await client.approveSession({
-            id,
-            namespaces,
-          });
+          if (namespaces.success) {
+            /**
+             * This is equivalent handling of setPendingRequest and
+             * walletConnectApproveSession, since setPendingRequest is only used
+             * within the /redux/walletconnect handlers
+             *
+             * WC v2 stores existing _pairings_ itself, so we don't need to persist
+             * ourselves
+             */
+            await client.approveSession({
+              id,
+              namespaces: namespaces.result,
+            });
 
-          // let the ConnectedDappsSheet know we've got a new one
-          events.emit('walletConnectV2SessionCreated');
+            // let the ConnectedDappsSheet know we've got a new one
+            events.emit('walletConnectV2SessionCreated');
 
-          maybeGoBackAndClearHasPendingRedirect();
+            logger.debug(
+              `WC v2: session created`,
+              {},
+              logger.DebugContext.walletconnect
+            );
 
-          logger.debug(
-            `WC v2: session created`,
-            {},
-            logger.DebugContext.walletconnect
-          );
+            analytics.track(analytics.event.wcNewSessionApproved, {
+              dappName: proposer.metadata.name,
+              dappUrl: proposer.metadata.url,
+            });
 
-          analytics.track(analytics.event.wcNewSessionApproved, {
-            dappName: proposer.metadata.name,
-            dappUrl: proposer.metadata.url,
-          });
+            maybeGoBackAndClearHasPendingRedirect();
+          } else {
+            await rejectProposal({
+              proposal,
+              reason: 'INVALID_SESSION_SETTLE_REQUEST',
+            });
+
+            showErrorSheet({
+              onClose() {
+                maybeGoBackAndClearHasPendingRedirect();
+              },
+            });
+          }
         } catch (e) {
           setHasPendingDeeplinkPendingRedirect(false);
 

--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -183,12 +183,20 @@ export function getApprovedNamespaces(
     } {
   try {
     const namespaces = buildApprovedNamespaces(props);
+
     return {
       success: true,
       result: namespaces,
       error: undefined,
     };
   } catch (e: any) {
+    logger.error(
+      new RainbowError(`WC v2: buildApprovedNamespaces threw an error`),
+      {
+        message: e.toString(),
+      }
+    );
+
     return {
       success: false,
       result: undefined,


### PR DESCRIPTION
Fixes APP-615

## What changed (plus any additional context for devs)
So v2 functionality wasn't actually broken. Previously, we allowed unsupported methods (even though listed as required) and then later rejected any requests to them. This was a decision made based on v1 functionality.

In v2, in the new `buildApprovedNamespaces` util from the WC team, unsupported required methods result in that utility method throwing an exception, which needs to be handled. **So what we saw when we couldn't connect to v2 was actually more strict validation of the session, which was throwing an exception that wasn't being handled** (bc it didn't need to be before). This isn't mentioned in the docs but I've requested the addition.

[WC doesn't throw specific errors](https://github.com/WalletConnect/walletconnect-monorepo/blob/1cbfa29ca0e27589b71efdfbcbfb5f98b01b75d4/packages/utils/src/namespaces.ts#L111), so the best I can do is catch and blanket-reject anything thrown from this util. To do this, I used a discriminated union instead of nesting try/catch, which is yuck.

So this PR updates our logic to 1) reject any sessions with unsupported methods, and 2) reject any sessions that result in a thrown error from `buildApprovedNamespaces`.

## Testing
Will post a TF in Slack. Use [this dapp](https://lab.web3modal.com/ManagedReact) for a success case, and [this dapp](https://react-app.walletconnect.com/) for a failure case.