### PR TITLE
fix: provide redirect metadata to core client

### DIFF
--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -109,6 +109,10 @@ export const web3WalletClient = Web3Wallet.init({
     description: 'Rainbow makes exploring Ethereum fun and accessible 🌈',
     url: 'https://rainbow.me',
     icons: ['https://avatars2.githubusercontent.com/u/48327834?s=200&v=4'],
+    redirect: {
+      native: 'rainbow://wc',
+      universal: 'https://rnbwapp.com/wc',
+    },
   },
 });
 


### PR DESCRIPTION
Opensea let us know that these redirect fields are necessary for dapps to correctly send users to their wallet app. So updated these to match what's in the WC dashboard.

