### PR TITLE
swaps gas: use allowanceTarget

### DIFF
--- a/src/handlers/swap.ts
+++ b/src/handlers/swap.ts
@@ -210,7 +210,9 @@ export const getSwapGasLimitWithFakeApproval = async (
           from: tradeDetails.from,
           gas: toHexNoLeadingZeros(gas),
           gasPrice: toHexNoLeadingZeros(`100000000000`),
-          to: RAINBOW_ROUTER_CONTRACT_ADDRESS,
+          to:
+            (tradeDetails as CrosschainQuote)?.allowanceTarget ||
+            RAINBOW_ROUTER_CONTRACT_ADDRESS,
           value: '0x0', // 100 gwei
         },
         'latest',


### PR DESCRIPTION
Fixes APP-609

## What changed (plus any additional context for devs)

we not use the allowance target and fallback to the rainbow router contract if there is no allowance target (regular swaps)


## Screen recordings / screenshots
n/a 

## What to test

