### PR TITLE
fix: only cache fully qualified WC URIs

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -278,28 +278,27 @@ function handleWalletConnect(uri: string) {
     parsedUri,
   });
 
-  if (uri && query && parsedUri && parsedUri.version === 1) {
+  if (uri && query && parsedUri) {
     // make sure we don't handle this again
     walletConnectURICache.add(cacheKey);
 
-    store.dispatch(walletConnectSetPendingRedirect());
-    store.dispatch(
-      walletConnectOnSessionRequest(uri, (status: any, dappScheme: any) => {
-        logger.debug(`walletConnectOnSessionRequest callback`, {
-          status,
-          dappScheme,
-        });
-        const type = status === 'approved' ? 'connect' : status;
-        store.dispatch(walletConnectRemovePendingRedirect(type, dappScheme));
-      })
-    );
-  } else if (uri && query && parsedUri && parsedUri.version === 2) {
-    // make sure we don't handle this again
-    walletConnectURICache.add(cacheKey);
-
-    logger.debug(`handleWalletConnect: handling v2`, { uri });
-    setHasPendingDeeplinkPendingRedirect(true);
-    pairWalletConnect({ uri });
+    if (parsedUri.version === 1) {
+      store.dispatch(walletConnectSetPendingRedirect());
+      store.dispatch(
+        walletConnectOnSessionRequest(uri, (status: any, dappScheme: any) => {
+          logger.debug(`walletConnectOnSessionRequest callback`, {
+            status,
+            dappScheme,
+          });
+          const type = status === 'approved' ? 'connect' : status;
+          store.dispatch(walletConnectRemovePendingRedirect(type, dappScheme));
+        })
+      );
+    } else if (parsedUri.version === 2) {
+      logger.debug(`handleWalletConnect: handling v2`, { uri });
+      setHasPendingDeeplinkPendingRedirect(true);
+      pairWalletConnect({ uri });
+    }
   } else {
     logger.debug(`handleWalletConnect: handling fallback`, { uri });
     // This is when we get focused by WC due to a signing request

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -253,6 +253,11 @@ export default async function handleDeeplink(
  * to a session that's either already active or expired. In WC v1, we handled
  * this using `walletConnectUris` state in Redux. We now handle this here,
  * before we even reach application code.
+ *
+ * Important: dapps also use deeplinks to re-focus the user to our app, where
+ * the socket connections then take over. So those URIs are always the same,
+ * and we DON'T want ignore those by caching them. So only cache URIs with query
+ * metadata include, other URIs are used merely for re-focusing.
  */
 const walletConnectURICache = new Set();
 
@@ -264,9 +269,6 @@ function handleWalletConnect(uri: string) {
     return;
   }
 
-  // make sure we don't handle this again
-  walletConnectURICache.add(cacheKey);
-
   const { query } = new URL(uri);
   const parsedUri = uri ? parseUri(uri) : null;
 
@@ -277,6 +279,9 @@ function handleWalletConnect(uri: string) {
   });
 
   if (uri && query && parsedUri && parsedUri.version === 1) {
+    // make sure we don't handle this again
+    walletConnectURICache.add(cacheKey);
+
     store.dispatch(walletConnectSetPendingRedirect());
     store.dispatch(
       walletConnectOnSessionRequest(uri, (status: any, dappScheme: any) => {
@@ -289,12 +294,16 @@ function handleWalletConnect(uri: string) {
       })
     );
   } else if (uri && query && parsedUri && parsedUri.version === 2) {
+    // make sure we don't handle this again
+    walletConnectURICache.add(cacheKey);
+
     logger.debug(`handleWalletConnect: handling v2`, { uri });
     setHasPendingDeeplinkPendingRedirect(true);
     pairWalletConnect({ uri });
   } else {
     logger.debug(`handleWalletConnect: handling fallback`, { uri });
     // This is when we get focused by WC due to a signing request
+    // Don't add this URI to cache
     setHasPendingDeeplinkPendingRedirect(true);
     store.dispatch(walletConnectSetPendingRedirect());
   }


### PR DESCRIPTION
Opensea noticed that we weren't always redirecting back to their mobile app after signing. This was because of the dedupe logic I added a while back to prevent trying to pair the same topic multiple times. We need to only dedupe fully qualified URLs, not the simple deeplinks that are used to send the user back to our app to sign.