### PR TITLE
fix: wrapped network name

### DIFF
--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -184,7 +184,7 @@ const NetworkPill = ({ chainIds }) => {
               })}
             </>
           ) : (
-            <Inline alignVertical="center">
+            <Inline alignVertical="center" wrap={false}>
               {availableNetworks[0] !== Network.mainnet ? (
                 <ChainBadge
                   assetType={availableNetworks[0]}


### PR DESCRIPTION
Fixes APP-610

## What changed (plus any additional context for devs)
Network pill was wrapping to two lines previously.

<img width="576" alt="Screen Shot 2023-06-12 at 12 01 13 PM" src="https://github.com/rainbow-me/rainbow/assets/4732330/d961c31d-d2be-4b42-898b-bc73692054a1">
<img width="576" alt="Screen Shot 2023-06-12 at 12 01 02 PM" src="https://github.com/rainbow-me/rainbow/assets/4732330/7174279f-df90-4fee-ac13-84b062f7e855">


