### PR TITLE
fix: overflowing account name in approval sheet

### DIFF
--- a/src/design-system/components/Text/Text.tsx
+++ b/src/design-system/components/Text/Text.tsx
@@ -37,7 +37,7 @@ export type TextProps = {
     }
   | { containsEmoji?: false; children: ReactNode }
 ) & {
-    style: Record<string, unknown>;
+    style?: Record<string, unknown>;
   };
 export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
   function Text(
@@ -92,7 +92,7 @@ export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
         numberOfLines={numberOfLines}
         ellipsizeMode={ellipsizeMode}
         ref={ref}
-        style={[textStyle, style]}
+        style={[textStyle, style || {}]}
         testID={testID}
       >
         {ios && containsEmojiProp && nodeIsString(children)

--- a/src/design-system/components/Text/Text.tsx
+++ b/src/design-system/components/Text/Text.tsx
@@ -36,7 +36,9 @@ export type TextProps = {
       children: string | (string | null)[];
     }
   | { containsEmoji?: false; children: ReactNode }
-);
+) & {
+    style: Record<string, unknown>;
+  };
 export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
   function Text(
     {
@@ -51,6 +53,7 @@ export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
       testID,
       uppercase,
       weight,
+      style,
     },
     ref
   ) {
@@ -89,7 +92,7 @@ export const Text = forwardRef<ElementRef<typeof NativeText>, TextProps>(
         numberOfLines={numberOfLines}
         ellipsizeMode={ellipsizeMode}
         ref={ref}
-        style={textStyle}
+        style={[textStyle, style]}
         testID={testID}
       >
         {ios && containsEmojiProp && nodeIsString(children)

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -519,17 +519,17 @@ export default function WalletConnectApprovalSheet() {
                   )}
                   <Box
                     // avatar width (22) + avatar right margin (5)
-                    paddingLeft={{ custom: 27 }}
-                    position="absolute"
+                    paddingLeft={{ custom: 5 }}
                     width="full"
-                    justifyContent="center"
+                    flexDirection="row"
                   >
-                    <LabelText position="relative" ellipsizeMode="middle">
-                      {`${approvalAccountInfo.accountLabel} ${
-                        type === WalletConnectApprovalSheetType.connect
-                          ? '􀁰'
-                          : ''
-                      }`}
+                    <LabelText style={{ maxWidth: '80%' }}>
+                      {`${approvalAccountInfo.accountLabel}`}
+                    </LabelText>
+                    <LabelText>
+                      {type === WalletConnectApprovalSheetType.connect
+                        ? '􀁰'
+                        : ''}
                     </LabelText>
                   </Box>
                 </ButtonPressAnimation>


### PR DESCRIPTION
Fixes APP-610

## What changed (plus any additional context for devs)
This may have always been an issue for long account names, hard to say. Only way I could get it to work is to force it with a maxWidth and lose the middle elllipsis, which wasn't being calculated correctly (always overflowed).

<img width="576" alt="Screen Shot 2023-06-20 at 11 09 36 AM" src="https://github.com/rainbow-me/rainbow/assets/4732330/c9266014-b388-4542-be74-bba24d6e78be">


<img width="576" alt="Screen Shot 2023-06-20 at 11 09 36 AM" src="https://github.com/rainbow-me/rainbow/assets/4732330/541da9ee-6a3e-497a-a103-719348b29229">

