### PR TITLE
fix: don't add back redirect to notifications handler

### DIFF
--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -300,7 +300,6 @@ export const NotificationsHandler = ({ walletReady }: Props) => {
         `NotificationsHandler: handling wallet connect notification`,
         { notification }
       );
-      setHasPendingDeeplinkPendingRedirect(true);
     } else {
       logger.warn(`NotificationsHandler: received unknown notification`, {
         notification,


### PR DESCRIPTION
Wayne noticed this. Since we don't have a reliable way of determining if the notification originated on desktop or mobile, we need to not assume. Setting the pending redirect is only needed for mobile dapp connections.

Deeplinks handling is correct since that only affects mobile.