### PR TITLE
fix poaps: gnosis dummy network

### DIFF
--- a/src/helpers/networkTypes.ts
+++ b/src/helpers/networkTypes.ts
@@ -6,6 +6,7 @@ export enum Network {
   polygon = 'polygon',
   bsc = 'bsc',
   zora = 'zora',
+  gnosis = 'gnosis',
 }
 
 // We need to keep this one until
@@ -18,4 +19,5 @@ export default {
   polygon: 'polygon' as Network,
   bsc: 'bsc' as Network,
   zora: 'zora' as Network,
+  gnosis: 'gnosis' as Network,
 };

--- a/src/networks/gnosis.ts
+++ b/src/networks/gnosis.ts
@@ -1,0 +1,67 @@
+import { getProviderForNetwork } from '@/handlers/web3';
+import { Network, NetworkProperties } from './types';
+import { gasUtils } from '@/utils';
+import { gnosis } from '@wagmi/chains';
+import { ETH_ADDRESS } from '@/references';
+import { getOptimismGasPrices } from '@/redux/gas';
+import config from '@/model/config';
+
+export const GnosisNetworkObject: NetworkProperties = {
+  // wagmi chain data
+  ...gnosis,
+
+  // network related data
+  enabled: false,
+  name: 'Gnosis',
+  longName: 'Gnosis',
+  value: Network.gnosis,
+  networkType: 'layer1',
+  blockTimeInMs: 5_000,
+
+  nativeCurrency: {
+    ...gnosis.nativeCurrency,
+    address: ETH_ADDRESS,
+  },
+
+  rpc: '',
+  getProvider: getProviderForNetwork(Network.optimism),
+  balanceCheckerAddress: '',
+
+  // features
+  features: {
+    txHistory: false,
+    flashbots: false,
+    walletconnect: false,
+    swaps: false,
+    nfts: true,
+    savings: false,
+    pools: false,
+    txs: false,
+  },
+
+  gas: {
+    speeds: [gasUtils.NORMAL],
+
+    // ?
+    gasType: 'legacy',
+    roundGasDisplay: true,
+    OptimismTxFee: true,
+
+    // this prob can just be blockTime,
+    pollingIntervalInMs: 5_000,
+
+    getGasPrices: getOptimismGasPrices,
+  },
+
+  swaps: {
+    defaultSlippage: 200,
+  },
+
+  nfts: {},
+
+  // design tings
+  colors: {
+    light: '#FF4040',
+    dark: '#FF6A6A',
+  },
+};

--- a/src/networks/index.ts
+++ b/src/networks/index.ts
@@ -6,6 +6,7 @@ import { OptimismNetworkObject } from './optimism';
 import { PolygonNetworkObject } from './polygon';
 import { Network, NetworkProperties } from './types';
 import { ZoraNetworkObject } from './zora';
+import { GnosisNetworkObject } from './gnosis';
 
 /**
  * Array of all Rainbow Networks
@@ -17,6 +18,7 @@ export const RainbowNetworks = [
   OptimismNetworkObject,
   PolygonNetworkObject,
   ZoraNetworkObject,
+  GnosisNetworkObject,
 
   // Testnets
   GoerliNetworkObject,
@@ -41,6 +43,8 @@ export function getNetworkObj(network: Network): NetworkProperties {
       return PolygonNetworkObject;
     case Network.zora:
       return ZoraNetworkObject;
+    case Network.gnosis:
+      return GnosisNetworkObject;
 
     // Testnets
     case Network.goerli:

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -11,6 +11,7 @@ export enum Network {
   polygon = 'polygon',
   bsc = 'bsc',
   zora = 'zora',
+  gnosis = 'gnosis',
 }
 
 export type NetworkTypes = 'layer1' | 'layer2' | 'testnet';

--- a/src/screens/ExchangeModal.tsx
+++ b/src/screens/ExchangeModal.tsx
@@ -111,6 +111,7 @@ export const DEFAULT_SLIPPAGE_BIPS = {
   [Network.optimism]: 200,
   [Network.arbitrum]: 200,
   [Network.goerli]: 100,
+  [Network.gnosis]: 200,
   [Network.zora]: 200,
 };
 

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -197,6 +197,7 @@ const getColorsByTheme = (darkMode?: boolean) => {
   let networkColors = {
     arbitrum: '#2D374B',
     goerli: '#f6c343',
+    gnosis: '#f6c343',
     mainnet: '#25292E',
     optimism: '#FF4040',
     polygon: '#8247E5',
@@ -380,6 +381,7 @@ const getColorsByTheme = (darkMode?: boolean) => {
     networkColors = {
       arbitrum: '#ADBFE3',
       goerli: '#f6c343',
+      gnosis: '#f6c343',
       mainnet: '#E0E8FF',
       optimism: '#FF6A6A',
       polygon: '#A275EE',

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -197,7 +197,7 @@ const getColorsByTheme = (darkMode?: boolean) => {
   let networkColors = {
     arbitrum: '#2D374B',
     goerli: '#f6c343',
-    gnosis: '#f6c343',
+    gnosis: '#479E9C',
     mainnet: '#25292E',
     optimism: '#FF4040',
     polygon: '#8247E5',
@@ -381,7 +381,7 @@ const getColorsByTheme = (darkMode?: boolean) => {
     networkColors = {
       arbitrum: '#ADBFE3',
       goerli: '#f6c343',
-      gnosis: '#f6c343',
+      gnosis: '#479E9C',
       mainnet: '#E0E8FF',
       optimism: '#FF6A6A',
       polygon: '#A275EE',


### PR DESCRIPTION
## What changed (plus any additional context for devs)

realized I broke poaps with my network refactor, this adds a gnosis network obj with everything disabled except for NFTs to fix the issue 


## Screen recordings / screenshots


## What to test

