### PR TITLE
improve gas estimates

### DIFF
--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -336,6 +336,7 @@ export async function estimateGasWithPadding(
   provider: StaticJsonRpcProvider | null = null,
   paddingFactor: number = 1.1
 ): Promise<string | null> {
+  let estimatedGasLimit = ethUnits.basic_tx.toString();
   try {
     const p = provider || web3Provider;
     if (!p) {
@@ -367,6 +368,8 @@ export async function estimateGasWithPadding(
 
     logger.info('⛽ Calculating safer gas limit for last block');
     // 3 - If it is a contract, call the RPC method `estimateGas` with a safe value
+    const lastBlockGasLimit = addBuffer(gasLimit.toString(), 0.9);
+    estimatedGasLimit = lastBlockGasLimit.toString();
     const saferGasLimit = fraction(gasLimit.toString(), 19, 20);
     logger.info('⛽ safer gas limit for last block is', { saferGasLimit });
 
@@ -378,7 +381,6 @@ export async function estimateGasWithPadding(
       ? contractCallEstimateGas(...(callArguments ?? []), txPayloadToEstimate)
       : p.estimateGas(txPayloadToEstimate));
 
-    const lastBlockGasLimit = addBuffer(gasLimit.toString(), 0.9);
     const paddedGas = addBuffer(
       estimatedGas.toString(),
       paddingFactor.toString()
@@ -395,16 +397,16 @@ export async function estimateGasWithPadding(
       logger.info('⛽ returning orginal gas estimation', {
         esimatedGas: estimatedGas.toString(),
       });
-      return estimatedGas.toString();
+      estimatedGasLimit = estimatedGas.toString();
     }
     // If the estimation is below the last block gas limit, use the padded estimate
     if (greaterThan(lastBlockGasLimit, paddedGas)) {
       logger.info('⛽ returning padded gas estimation', { paddedGas });
-      return paddedGas;
+      estimatedGasLimit = paddedGas;
     }
     // otherwise default to the last block gas limit
     logger.info('⛽ returning last block gas limit', { lastBlockGasLimit });
-    return lastBlockGasLimit;
+    return estimatedGasLimit;
   } catch (e: any) {
     /*
      * Reported ~400x per day, but if it's not actionable it might as well be a warning.
@@ -412,7 +414,7 @@ export async function estimateGasWithPadding(
     logger.warn('Error calculating gas limit with padding', {
       message: e.message,
     });
-    return null;
+    return estimatedGasLimit;
   }
 }
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
we had a very small hardcoded gasLimit  that was causing failed txs when estimates fail and there is no limit give from the dapp

ive gone ahead and adjusted our gasEstimation logic to fallback to the latest blocks gas limit which seems to be standard practice, this should ensure we don't underestimate gas. see notes section here: https://docs.alchemy.com/reference/eth-estimategas

I also added logic to check which of the following gas limits is higher and use that one in the tx: out estimate & gas limits passed from the dapp


## Screen recordings / screenshots


## What to test

