### PR TITLE
walletconnect connector attribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
     "babel-plugin-rewire": "1.2.0",
     "babel-plugin-styled-components": "1.11.1",
     "babel-plugin-transform-remove-console": "6.9.4",
-  "chai": "4.2.0",
+    "chai": "4.2.0",
     "detox": "19.12.1",
     "dotenv": "8.2.0",
     "eslint": "8.22.0",

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -65,6 +65,8 @@ export const event = {
   rewardsPressedBridgedCard: 'rewards.pressed_bridged_card',
   rewardsPressedLeaderboardItem: 'rewards.pressed_leaderboard_item',
 
+  wcNewPairing: 'New WalletConnect pairing',
+  wcNewPairingTimeout: 'New WalletConnect pairing time out',
   wcNewSessionTimeout: 'New WalletConnect session time out',
   wcNewSessionRejected: 'Rejected new WalletConnect session',
   wcNewSessionApproved: 'Approved new WalletConnect session',
@@ -214,6 +216,12 @@ export type EventProperties = {
   [event.rewardsPressedBridgedCard]: undefined;
   [event.rewardsPressedLeaderboardItem]: { ens?: string };
 
+  [event.wcNewPairing]: {
+    dappName: string;
+    dappUrl: string;
+    connector?: string;
+  };
+  [event.wcNewPairingTimeout]: undefined;
   [event.wcNewSessionApproved]: {
     dappName: string;
     dappUrl: string;

--- a/src/handlers/__tests__/deeplinks.test.ts
+++ b/src/handlers/__tests__/deeplinks.test.ts
@@ -145,6 +145,15 @@ test(`handles https:// protocol for WalletConnect`, async () => {
   expect(pair).toHaveBeenCalledTimes(1);
 });
 
+test(`handles https:// protocol for WalletConnect with &connector`, async () => {
+  const uri = encodeURIComponent(generateWCUri({ version: 2 }));
+  await handleDeepLink(
+    `https://rnbwapp.com/wc?uri=${uri}&connector=rainbowkit`
+  );
+  expect(setHasPendingDeeplinkPendingRedirect).toHaveBeenCalledTimes(1);
+  expect(pair).toHaveBeenCalledTimes(1);
+});
+
 test(`handles rainbow:// protocol for WalletConnect`, async () => {
   const uri = encodeURIComponent(generateWCUri({ version: 1 }));
   await handleDeepLink(`rainbow://wc?uri=${uri}`);

--- a/src/handlers/__tests__/deeplinks.test.ts
+++ b/src/handlers/__tests__/deeplinks.test.ts
@@ -158,6 +158,13 @@ test(`handles rainbow:// protocol for WalletConnect v2`, async () => {
   expect(pair).toHaveBeenCalledTimes(1);
 });
 
+test(`handles rainbow:// protocol for WalletConnect v2 with &connector`, async () => {
+  const uri = encodeURIComponent(generateWCUri({ version: 2 }));
+  await handleDeepLink(`rainbow://wc?uri=${uri}&connector=rainbowkit`);
+  expect(setHasPendingDeeplinkPendingRedirect).toHaveBeenCalledTimes(1);
+  expect(pair).toHaveBeenCalledTimes(1);
+});
+
 test(`handles https:// protocol for tokens, found asset`, async () => {
   // @ts-ignore just need a truthy value
   mocked(ethereumUtils.getAssetFromAllAssets).mockReturnValueOnce({});

--- a/src/handlers/__tests__/deeplinks.test.ts
+++ b/src/handlers/__tests__/deeplinks.test.ts
@@ -125,6 +125,19 @@ test(`handles wc:// protocol`, async () => {
   expect(pair).toHaveBeenCalledTimes(1);
 });
 
+test(`handles wc:// protocol with &connector`, async () => {
+  const uri = generateWCUri({ version: 2 }) + '&connector=rainbowkit';
+
+  await handleDeepLink(uri);
+  expect(setHasPendingDeeplinkPendingRedirect).toHaveBeenCalledTimes(1);
+  expect(pair).toHaveBeenCalledTimes(1);
+
+  // call again with same URI, still only called once
+  await handleDeepLink(uri);
+  expect(setHasPendingDeeplinkPendingRedirect).toHaveBeenCalledTimes(1);
+  expect(pair).toHaveBeenCalledTimes(1);
+});
+
 test(`handles https:// protocol for WalletConnect`, async () => {
   const uri = encodeURIComponent(generateWCUri({ version: 2 }));
   await handleDeepLink(`https://rnbwapp.com/wc?uri=${uri}`);

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -290,19 +290,25 @@ function handleWalletConnect(uri?: string, connector?: string) {
     if (parsedUri.version === 1) {
       store.dispatch(walletConnectSetPendingRedirect());
       store.dispatch(
-        walletConnectOnSessionRequest(uri, (status: any, dappScheme: any) => {
-          logger.debug(`walletConnectOnSessionRequest callback`, {
-            status,
-            dappScheme,
-          });
-          const type = status === 'approved' ? 'connect' : status;
-          store.dispatch(walletConnectRemovePendingRedirect(type, dappScheme));
-        })
+        walletConnectOnSessionRequest(
+          uri,
+          connector,
+          (status: any, dappScheme: any) => {
+            logger.debug(`walletConnectOnSessionRequest callback`, {
+              status,
+              dappScheme,
+            });
+            const type = status === 'approved' ? 'connect' : status;
+            store.dispatch(
+              walletConnectRemovePendingRedirect(type, dappScheme)
+            );
+          }
+        )
       );
     } else if (parsedUri.version === 2) {
       logger.debug(`handleWalletConnect: handling v2`, { uri });
       setHasPendingDeeplinkPendingRedirect(true);
-      pairWalletConnect({ uri });
+      pairWalletConnect({ uri, connector });
     }
   } else {
     logger.debug(`handleWalletConnect: handling fallback`, { uri });

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -237,7 +237,7 @@ export default async function handleDeeplink(
     // Android uses normal deeplinks
   } else if (protocol === 'wc:') {
     logger.info(`handleDeeplink: wc:// protocol`);
-    handleWalletConnect(query.uri, query.connector);
+    handleWalletConnect(url, query.connector);
   }
 }
 

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -87,7 +87,7 @@ export default async function handleDeeplink(
        */
       case 'wc': {
         logger.info(`handleDeeplink: wc`);
-        handleWalletConnect(query.uri as string);
+        handleWalletConnect(query.uri, query.connector);
         break;
       }
 
@@ -237,7 +237,7 @@ export default async function handleDeeplink(
     // Android uses normal deeplinks
   } else if (protocol === 'wc:') {
     logger.info(`handleDeeplink: wc:// protocol`);
-    handleWalletConnect(url);
+    handleWalletConnect(query.uri, query.connector);
   }
 }
 
@@ -261,7 +261,12 @@ export default async function handleDeeplink(
  */
 const walletConnectURICache = new Set();
 
-function handleWalletConnect(uri: string) {
+function handleWalletConnect(uri?: string, connector?: string) {
+  if (!uri) {
+    logger.debug(`handleWalletConnect: skipping uri empty`, {});
+    return;
+  }
+
   const cacheKey = JSON.stringify({ uri });
 
   if (walletConnectURICache.has(cacheKey)) {

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -178,10 +178,10 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
         urlObj?.pathname?.split('/')?.[1] === 'wc'
       ) {
         // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-        const { uri } = qs.parse(urlObj.query.substring(1));
+        const { uri, connector } = qs.parse(urlObj.query.substring(1));
         onSuccess();
         // @ts-expect-error The QS type is very broad. We could narrow it down but it's not worth it to not break current functionality
-        return handleScanWalletConnect(uri);
+        return handleScanWalletConnect(uri, connector);
       }
       // Rainbow profile QR code
       if (data.startsWith(RAINBOW_PROFILES_BASE_URL)) {

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -112,18 +112,18 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
   );
 
   const handleScanWalletConnect = useCallback(
-    async (qrCodeData: string) => {
+    async (uri: string, connector?: string) => {
       haptics.notificationSuccess();
       analytics.track('Scanned WalletConnect QR code');
       await checkPushNotificationPermissions();
       goBack();
       onSuccess();
       try {
-        const { version } = parseUri(qrCodeData);
+        const { version } = parseUri(uri);
         if (version === 1) {
-          await walletConnectOnSessionRequest(qrCodeData, () => {});
+          await walletConnectOnSessionRequest(uri, connector, () => {});
         } else if (version === 2) {
-          await pairWalletConnect({ uri: qrCodeData });
+          await pairWalletConnect({ uri, connector });
         }
       } catch (e) {
         logger.log('walletConnectOnSessionRequest exception', e);

--- a/src/hooks/useWalletConnectConnections.ts
+++ b/src/hooks/useWalletConnectConnections.ts
@@ -56,8 +56,11 @@ export default function useWalletConnectConnections() {
   );
 
   const walletConnectOnSessionRequest = useCallback(
-    (uri: string, callback?: WalletconnectRequestCallback) =>
-      dispatch(rawWalletConnectOnSessionRequest(uri, callback)),
+    (
+      uri: string,
+      connector?: string,
+      callback?: WalletconnectRequestCallback
+    ) => dispatch(rawWalletConnectOnSessionRequest(uri, connector, callback)),
     [dispatch]
   );
 

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -296,6 +296,7 @@ export const walletConnectRemovePendingRedirect = (
  */
 export const walletConnectOnSessionRequest = (
   uri: string,
+  connector?: string,
   callback?: WalletconnectRequestCallback
 ) => async (
   dispatch: ThunkDispatch<StoreAppState, unknown, never>,
@@ -357,6 +358,7 @@ export const walletConnectOnSessionRequest = (
             analytics.track('Approved new WalletConnect session', {
               dappName,
               dappUrl,
+              connector,
             });
           } else if (!timedOut) {
             await dispatch(
@@ -366,6 +368,7 @@ export const walletConnectOnSessionRequest = (
             analytics.track('Rejected new WalletConnect session', {
               dappName,
               dappUrl,
+              connector,
             });
           } else {
             callback?.('timedOut', dappScheme);
@@ -376,6 +379,7 @@ export const walletConnectOnSessionRequest = (
               bridge,
               dappName,
               dappUrl,
+              connector,
             });
           }
         },
@@ -406,6 +410,7 @@ export const walletConnectOnSessionRequest = (
         analytics.track('Showing Walletconnect session request', {
           dappName,
           dappUrl,
+          connector,
         });
 
         meta = {
@@ -567,7 +572,6 @@ const listenOnNewMessages = (walletConnector: WalletConnect) => (
               analytics.track('Approved WalletConnect network switch', {
                 chainId,
                 dappName,
-                // @ts-ignore
                 dappUrl,
               });
               dispatch(walletConnectRemovePendingRedirect('connect'));
@@ -578,7 +582,6 @@ const listenOnNewMessages = (walletConnector: WalletConnect) => (
               });
               analytics.track('Rejected new WalletConnect chain request', {
                 dappName,
-                // @ts-ignore
                 dappUrl,
               });
             }
@@ -644,7 +647,6 @@ const listenOnNewMessages = (walletConnector: WalletConnect) => (
         InteractionManager.runAfterInteractions(() => {
           analytics.track('Showing Walletconnect signing request', {
             dappName,
-            // @ts-ignore
             dappUrl,
           });
         });


### PR DESCRIPTION
## What changed 
- new `wcNewPairing` and `wcNewPairingTimeout` tracking events
- added `connector` param to existing walletconnect tracking events
- improved typing for `handleWalletConnect` `uri`, skipping missing uris, and debug logging
- refactor `handleScanWalletConnect` to more clearly describe the expected params
- parsing optional `connector` query param from deep link, https, and qr data uris
- passing optional `connector` param through walletconnect tree
- tests for `&connector=` addition to walletconnect uris
- removed unnecessary `@ts-ignore` on `dappUrl` tracking events

## What to test
- WalletConnect v1 and v2 on iOS and Android
- Deep link, https, and wc: uris were modified
