### PR TITLE
Fix NFT Offers card bug

### DIFF
--- a/src/components/cards/NFTOffersCard/Offer.tsx
+++ b/src/components/cards/NFTOffersCard/Offer.tsx
@@ -119,6 +119,16 @@ export const Offer = ({ offer }: { offer: NftOffer }) => {
     }
   }, [offer.validUntil]);
 
+  useEffect(
+    () =>
+      setTimeRemaining(
+        offer.validUntil
+          ? Math.max(offer.validUntil * 1000 - Date.now(), 0)
+          : undefined
+      ),
+    [offer.validUntil]
+  );
+
   const cryptoAmount = handleSignificantDecimals(
     offer.grossAmount.decimal,
     18,

--- a/src/screens/mints/PoapSheet.tsx
+++ b/src/screens/mints/PoapSheet.tsx
@@ -137,7 +137,7 @@ const PoapSheet = () => {
       secret: poapEvent.secret,
     });
     await delay(1000);
-    console.log(response.claimPoapByQrHash);
+
     const isSuccess = response.claimPoapByQrHash?.success;
     const errorCode = response.claimPoapByQrHash?.error;
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Problem:
* when offers RQ cache is updated, offers shown in the card sometimes display outdated/incorrect time until expiration
* to make things more confusing for the user, when they click one of these offers, the expanded state shows correct data

Cause:
* Since `Offer` (the offer component of the discover screen card) is recycled by `FlashList` where the key equals the uniqueId of the underlying NFT, `Offer` **does not unmount** as long as the NFT remains present in the list of offers. It just rerenders based on its updated props.
* Since `timeRemaining` is stored in state, it does not get re-initialized based on the new offer
* The effect of this is
  1. expiring `Offer`s don't update to reflect new data until at least 1 minute later (according to pre-existing countdown timer)
  2. expired `Offer`s will never update, since the countdown timer that updates state is no longer active

Solution:
* If the offer passed into `Offer` changes, reset `timeRemaining` based on this new data.

## Screen recordings / screenshots


## What to test

