### PR TITLE
Fix: [WalletConnect] add redirect for "eth_sendTransaction" request

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -274,6 +274,10 @@ const walletConnectURICache = new Set();
 
 function handleWalletConnect(uri?: string, connector?: string) {
   if (!uri) {
+    // On a "eth_sendTransaction" from wc2 the url is like
+    // rainbow://wc?requestId=anId&sessionTopic=aSessionTopic
+    setHasPendingDeeplinkPendingRedirect(true);
+
     logger.debug(`handleWalletConnect: skipping uri empty`, {});
     return;
   }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
When a dapp connected via WalletConnect2 send a request of type `eth_sendTransaction` the url received is like
```
rainbow://wc?requestId=anId&sessionTopic=aSessionTopic
```

This url doesn't contain an `uri` parameter so after the user reject or confirm the request no deep link back to the dapp was triggered.

## Screen recordings / screenshots


## What to test

