### PR TITLE
Version bump 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Removed
 
+### Fixed
+
+## [1.9.0] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.0)
+
+### Added
+
+- Added back keyboard area #5000
+- Added the ability to accept NFT Offers #4965
+- Get NFT expanded state floor price from Reservoir if available #5006
+
+### Changed
+
+- React Native version bump #4955
+- Improved image performance #5001
+
+### Removed
+
+- Goerli support #4986
+
+### Fixed
+
+- Updated Base network icon #4992
+- ERC-20 charts haptics fix #5004
+- Fixed some crashes in appstate #5002
+- Fix WC app redirects #5005
+
 ## [1.8.28] (https://github.com/rainbow-me/rainbow/releases/tag/v1.8.28)
 
 ### Added

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,8 +152,8 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 183
-        versionName "1.8.29"
+        versionCode 184
+        versionName "1.9.0"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
         renderscriptSupportModeEnabled true

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1498,7 +1498,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.8.29;
+				MARKETING_VERSION = 1.9.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -1561,7 +1561,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.8.29;
+				MARKETING_VERSION = 1.9.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -1669,7 +1669,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.8.29;
+				MARKETING_VERSION = 1.9.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -1778,7 +1778,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.8.29;
+				MARKETING_VERSION = 1.9.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "1.8.29-1",
+  "version": "1.9.0-1",
   "private": true,
   "scripts": {
     "setup": "yarn install && yarn graphql-codegen:install && yarn ds:install && yarn allow-scripts && yarn postinstall && yarn graphql-codegen",


### PR DESCRIPTION
## [1.9.0] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.0)

### Added

- Added back keyboard area #5000
- Added the ability to accept NFT Offers #4965
- Get NFT expanded state floor price from Reservoir if available #5006

### Changed

- React Native version bump #4955
- Improved image performance #5001

### Removed

- Goerli support #4986

### Fixed

- Updated Base network icon #4992
- ERC-20 charts haptics fix #5004
- Fixed some crashes in appstate #5002
- Fix WC app redirects #5005

