### PR TITLE
images: use imagebackground where applicable

### DIFF
--- a/src/components/PromoSheet.tsx
+++ b/src/components/PromoSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useReducer } from 'react';
-import { ImageSourcePropType, StatusBar } from 'react-native';
+import { ImageSourcePropType, StatusBar, ImageBackground } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import MaskedView from '@react-native-masked-view/masked-view';
 import { SheetActionButton, SheetHandle, SlackSheet } from '@/components/sheet';
@@ -118,7 +118,7 @@ export function PromoSheet({
           testID={campaignKey}
         >
           {/* @ts-ignore */}
-          <Box as={ImgixImage} height="full" source={backgroundImage}>
+          <Box as={ImageBackground} height="full" source={backgroundImage}>
             <Rows>
               <Row>
                 <Stack space={{ custom: isSmallPhone ? 46 : 54 }}>
@@ -129,7 +129,7 @@ export function PromoSheet({
                     >
                       {/* @ts-ignore */}
                       <Box
-                        as={ImgixImage}
+                        as={ImageBackground}
                         height={{
                           custom: deviceWidth / headerImageAspectRatio,
                         }}

--- a/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/navigation/HardwareWalletTxNavigator';
 import { TryAgainButton } from './components/TryAgainButton';
 import { useMMKVBoolean } from 'react-native-mmkv';
+import { ImageBackground } from 'react-native';
 
 const INDICATOR_SIZE = 9;
 
@@ -124,24 +125,22 @@ export const PairHardwareWalletAgainSheet = () => {
           </Inset>
         </Box>
         <Box marginTop={{ custom: -70 }} style={{ zIndex: -99 }}>
-          <ImgixImage
-            source={(isDarkMode ? gridDotsDark : gridDotsLight) as Source}
+          <ImageBackground
+            source={isDarkMode ? gridDotsDark : gridDotsLight}
             style={{
               width: GRID_DOTS_SIZE,
               height: GRID_DOTS_SIZE,
               alignItems: 'center',
               justifyContent: 'center',
             }}
-            size={GRID_DOTS_SIZE}
           >
-            <ImgixImage
-              source={ledgerNano as Source}
+            <ImageBackground
+              source={ledgerNano}
               style={{
                 width: LEDGER_NANO_WIDTH,
                 height: LEDGER_NANO_HEIGHT,
                 alignItems: 'center',
               }}
-              size={LEDGER_NANO_HEIGHT}
             >
               <Box
                 height={{ custom: 36 }}
@@ -204,8 +203,8 @@ export const PairHardwareWalletAgainSheet = () => {
                   </Box>
                 </Inline>
               </Box>
-            </ImgixImage>
-          </ImgixImage>
+            </ImageBackground>
+          </ImageBackground>
         </Box>
         {hardwareTXError && (
           <Box position="absolute" bottom={{ custom: 20 }} width="full">


### PR DESCRIPTION
## What changed (plus any additional context for devs)
when we moved away from fast image we started using the vanilla RN image component everywhere
turns out it doesnt like having any children, in those cases we need to use ImageBackground  instead

## Screen recordings / screenshots


## What to test

