### PR TITLE
chore: Update flashbots protect RPC to include all builders

### DIFF
--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -174,7 +174,7 @@ export const isTestnetNetwork = (network: Network): boolean => {
 // shoudl figure out better way to include this in networks
 export const getFlashbotsProvider = async () => {
   return new StaticJsonRpcProvider(
-    'https://rpc.flashbots.net',
+    'https://rpc.flashbots.net/?hint=hash&builder=flashbots&builder=f1b.io&builder=rsync&builder=beaverbuild.org&builder=builder0x69&builder=titan&builder=eigenphi&builder=boba-builder',
     Network.mainnet
   );
 };


### PR DESCRIPTION
Shea from Flashbots confirmed that this will not have any side effects on the Flashbots Transaction Status API. Including all builders while only exposing the hash should allow for generally faster inclusion when the transaction is valid.