### PR TITLE
wallet: rm xtra personal sign logic

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -466,11 +466,7 @@ export const signPersonalMessage = async (
     }
     try {
       if (!wallet) return null;
-      const result = await wallet.signMessage(
-        typeof message === 'string' && isHexString(addHexPrefix(message))
-          ? arrayify(addHexPrefix(message))
-          : message
-      );
+      const result = await wallet.signMessage(message);
       return { result };
     } catch (error) {
       if (isHardwareWallet) {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
we had some very old logic for hex signatures that was handling personal signs differently than a dapp would expect, this removes that logic

## Screen recordings / screenshots


## What to test

