### PR TITLE
gas: l1 optimism fee estimation

### DIFF
--- a/src/parsers/gas.ts
+++ b/src/parsers/gas.ts
@@ -277,7 +277,8 @@ export const parseGasFees = (
   baseFeePerGas: GasFeeParam,
   gasLimit: BigNumberish,
   priceUnit: BigNumberish,
-  nativeCurrency: NativeCurrencyKey
+  nativeCurrency: NativeCurrencyKey,
+  l1GasFeeOptimism: BigNumber | null = null
 ) => {
   const { maxPriorityFeePerGas, maxBaseFee } = gasFeeParams || {};
   const priorityFee = maxPriorityFeePerGas?.amount || 0;
@@ -296,13 +297,15 @@ export const parseGasFees = (
     add(maxFeePerGasAmount, priorityFee),
     gasLimit,
     priceUnit,
-    nativeCurrency
+    nativeCurrency,
+    l1GasFeeOptimism
   );
   const estimatedFee = getTxFee(
     add(estimatedFeePerGas, priorityFee),
     gasLimit,
     priceUnit,
-    nativeCurrency
+    nativeCurrency,
+    l1GasFeeOptimism
   );
   return {
     estimatedFee,
@@ -315,7 +318,8 @@ export const parseGasFeesBySpeed = (
   baseFeePerGas: GasFeeParam,
   gasLimit: BigNumberish,
   priceUnit: BigNumberish,
-  nativeCurrency: NativeCurrencyKey
+  nativeCurrency: NativeCurrencyKey,
+  l1GasFeeOptimism: BigNumber | null = null
 ): GasFeesBySpeed => {
   const gasFeesBySpeed = GasSpeedOrder.map(speed =>
     parseGasFees(
@@ -323,7 +327,8 @@ export const parseGasFeesBySpeed = (
       baseFeePerGas,
       gasLimit,
       priceUnit,
-      nativeCurrency
+      nativeCurrency,
+      l1GasFeeOptimism
     )
   );
   return zipObject(GasSpeedOrder, gasFeesBySpeed);

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -163,7 +163,8 @@ const getUpdatedGasFeeParams = (
         currentBaseFee,
         gasLimit,
         nativeTokenPriceUnit,
-        nativeCurrency
+        nativeCurrency,
+        l1GasFeeOptimism
       );
   const selectedGasParams = getSelectedGasFee(
     gasFeeParamsBySpeed,

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -26,7 +26,6 @@ import { rainbowMeteorologyGetData } from '@/handlers/gasFees';
 import {
   getProviderForNetwork,
   isHardHat,
-  isL2Network,
   toHex,
   web3Provider,
 } from '@/handlers/web3';
@@ -42,7 +41,7 @@ import {
   parseRainbowMeteorologyData,
   weiToGwei,
 } from '@/parsers';
-import { ethUnits, supportedNativeCurrencies } from '@/references';
+import { ethUnits } from '@/references';
 import { multiply } from '@/helpers/utilities';
 import { ethereumUtils, gasUtils } from '@/utils';
 import { getNetworkObj } from '@/networks';
@@ -215,6 +214,7 @@ export const gasUpdateToCustomGasFee = (gasParams: GasFeeParams) => async (
     currentBlockParams,
     blocksToConfirmation,
     secondsPerNewBlock,
+    l1GasFeeOptimism,
   } = getState().gas;
 
   const { nativeCurrency } = getState().settings;
@@ -239,7 +239,8 @@ export const gasUpdateToCustomGasFee = (gasParams: GasFeeParams) => async (
     currentBlockParams?.baseFeePerGas,
     _gasLimit,
     nativeTokenPriceUnit,
-    nativeCurrency
+    nativeCurrency,
+    l1GasFeeOptimism
   );
   const newGasFeesBySpeed = { ...gasFeesBySpeed };
   const newGasFeeParamsBySpeed = { ...gasFeeParamsBySpeed };
@@ -586,7 +587,7 @@ export const gasPricesStartPolling = (
                   nativeCurrency,
                   _selectedGasFeeOption,
                   txNetwork,
-                  null
+                  l1GasFeeOptimism
                 );
 
                 dispatch({


### PR DESCRIPTION
Fixes APP-799

## What changed (plus any additional context for devs)
we were not adding the l1 fee to 1559 gas estimations since this code was initially only for mainnet 

now we add it 


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Shot-2023-09-26-14-47-56.04.png


## What to test
gas should match p close with the bx for op chain gas estimations 
