### PR TITLE
handling appstate Event subscription correctly

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -104,8 +104,6 @@ class OldApp extends Component {
     eventSubscription: null,
   };
 
-  subscription;
-
   /**
    * There's a race condition in Branch's RN SDK. From a cold start, Branch
    * doesn't always handle an initial URL, so we need to check for it here and

--- a/src/App.js
+++ b/src/App.js
@@ -98,7 +98,13 @@ enableScreens();
 const containerStyle = { flex: 1 };
 
 class OldApp extends Component {
-  state = { appState: AppState.currentState, initialRoute: null };
+  state = {
+    appState: AppState.currentState,
+    initialRoute: null,
+    eventSubscription: null,
+  };
+
+  subscription;
 
   /**
    * There's a race condition in Branch's RN SDK. From a cold start, Branch
@@ -143,7 +149,11 @@ class OldApp extends Component {
     InteractionManager.runAfterInteractions(() => {
       rainbowTokenList.update();
     });
-    AppState?.addEventListener('change', this?.handleAppStateChange);
+    const eventSub = AppState?.addEventListener(
+      'change',
+      this?.handleAppStateChange
+    );
+    this.setState({ eventSubscription: eventSub });
     rainbowTokenList.on('update', this.handleTokenListUpdate);
     appEvents.on('transactionConfirmed', this.handleTransactionConfirmed);
 
@@ -183,9 +193,9 @@ class OldApp extends Component {
   }
 
   componentWillUnmount() {
-    AppState?.removeEventListener('change', this?.handleAppStateChange);
-    rainbowTokenList?.off?.('update', this.handleTokenListUpdate);
-    this.branchListener?.();
+    this.state.eventSubscription.remove();
+    rainbowTokenList.off('update', this.handleTokenListUpdate);
+    this.branchListener();
   }
 
   identifyFlow = async () => {


### PR DESCRIPTION
Method removeEventListener was removed from AppState in ReactNative v0.71

The OldApp component needs to keep EventSubscription in it's state, and then call remove method on in componentWIllUnmount.

This PR will stop the TypeError in componentWillUnmount crashes.