### PR TITLE
Migrate uniswap pairs from redux to react query

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,7 +60,6 @@ import {
 } from './react-query';
 import { additionalDataUpdateL2AssetBalance } from './redux/additionalAssetsData';
 import store from './redux/store';
-import { uniswapPairsInit } from './redux/uniswap';
 import { walletConnectLoadState } from './redux/walletconnect';
 import { rainbowTokenList } from './references';
 import { userAssetsQueryKey } from '@/resources/assets/UserAssetsQuery';
@@ -86,6 +85,7 @@ import { initListeners as initWalletConnectListeners } from '@/walletConnect';
 import { saveFCMToken } from '@/notifications/tokens';
 import branch from 'react-native-branch';
 import { initializeReservoirClient } from '@/resources/nftOffers/utils';
+import { curatedTokensQueryKey } from './resources/curatedTokens';
 
 if (__DEV__) {
   reactNativeDisableYellowBox && LogBox.ignoreAllLogs();
@@ -196,7 +196,7 @@ class OldApp extends Component {
   };
 
   async handleTokenListUpdate() {
-    store.dispatch(uniswapPairsInit());
+    queryClient.invalidateQueries(curatedTokensQueryKey);
   }
 
   handleAppStateChange = async nextAppState => {

--- a/src/hooks/useInitializeWallet.ts
+++ b/src/hooks/useInitializeWallet.ts
@@ -12,7 +12,6 @@ import {
   settingsLoadNetwork,
   settingsUpdateAccountAddress,
 } from '../redux/settings';
-import { uniswapPairsInit } from '../redux/uniswap';
 import { walletsLoadState } from '../redux/wallets';
 import useAccountSettings from './useAccountSettings';
 import useHideSplashScreen from './useHideSplashScreen';
@@ -26,6 +25,8 @@ import { PROFILES, useExperimentalFlag } from '@/config';
 import { runKeychainIntegrityChecks } from '@/handlers/walletReadyEvents';
 import { checkPendingTransactionsOnInitialize } from '@/redux/data';
 import logger from '@/utils/logger';
+import { queryClient } from '@/react-query';
+import { curatedTokensQueryKey } from '@/resources/curatedTokens';
 
 export default function useInitializeWallet() {
   const dispatch = useDispatch();
@@ -149,7 +150,7 @@ export default function useInitializeWallet() {
         dispatch(appStateUpdate({ walletReady: true }));
 
         if (!switching) {
-          dispatch(uniswapPairsInit());
+          queryClient.invalidateQueries(curatedTokensQueryKey);
         }
 
         logger.sentry('💰 Wallet initialized');

--- a/src/hooks/useSwapCurrencyList.ts
+++ b/src/hooks/useSwapCurrencyList.ts
@@ -32,6 +32,7 @@ import useSwapCurrencies from '@/hooks/useSwapCurrencies';
 import { Network } from '@/helpers';
 import { CROSSCHAIN_SWAPS, useExperimentalFlag } from '@/config';
 import { IS_TEST } from '@/env';
+import { useCuratedTokens } from '@/resources/curatedTokens';
 
 const MAINNET_CHAINID = 1;
 type swapCurrencyListType =
@@ -41,7 +42,6 @@ type swapCurrencyListType =
   | 'favoriteAssets'
   | 'curatedAssets'
   | 'importedAssets';
-const uniswapCuratedTokensSelector = (state: AppState) => state.uniswap.pairs;
 const uniswapFavoriteMetadataSelector = (state: AppState) =>
   state.uniswap.favoritesMeta;
 const uniswapFavoritesSelector = (state: AppState): string[] =>
@@ -108,7 +108,7 @@ const useSwapCurrencyList = (
   );
   const dispatch = useDispatch();
 
-  const curatedMap = useSelector(uniswapCuratedTokensSelector);
+  const curatedMap = useCuratedTokens();
   const favoriteMap = useSelector(uniswapFavoriteMetadataSelector);
   const unfilteredFavorites = Object.values(favoriteMap);
   const favoriteAddresses = useSelector(uniswapFavoritesSelector);

--- a/src/redux/uniswap.ts
+++ b/src/redux/uniswap.ts
@@ -5,11 +5,7 @@ import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import { Dispatch } from 'redux';
 import { AppGetState } from './store';
-import {
-  EthereumAddress,
-  RainbowToken,
-  UniswapFavoriteTokenData,
-} from '@/entities';
+import { EthereumAddress, UniswapFavoriteTokenData } from '@/entities';
 import { getUniswapV2Tokens } from '@/handlers/dispersion';
 import {
   getUniswapFavorites,
@@ -17,13 +13,11 @@ import {
   saveUniswapFavorites,
   saveUniswapFavoritesMetadata,
 } from '@/handlers/localstorage/uniswap';
-import { getTestnetUniswapPairs } from '@/handlers/swap';
 import { Network } from '@/helpers/networkTypes';
 import {
   DefaultUniswapFavorites,
   DefaultUniswapFavoritesMeta,
   ETH_ADDRESS,
-  rainbowTokenList,
   WETH_ADDRESS,
 } from '@/references';
 import logger from '@/utils/logger';
@@ -33,8 +27,6 @@ import logger from '@/utils/logger';
 const UNISWAP_LOAD_REQUEST = 'uniswap/UNISWAP_LOAD_REQUEST';
 const UNISWAP_LOAD_SUCCESS = 'uniswap/UNISWAP_LOAD_SUCCESS';
 const UNISWAP_LOAD_FAILURE = 'uniswap/UNISWAP_LOAD_FAILURE';
-
-const UNISWAP_UPDATE_PAIRS = 'uniswap/UNISWAP_UPDATE_PAIRS';
 
 const UNISWAP_UPDATE_FAVORITES = 'uniswap/UNISWAP_UPDATE_FAVORITES';
 const UNISWAP_CLEAR_STATE = 'uniswap/UNISWAP_CLEAR_STATE';
@@ -59,11 +51,6 @@ interface UniswapState {
    * Whether or not data from Uniswap is currently being loaded.
    */
   loadingUniswap: boolean;
-
-  /**
-   * Data for Uniswap pairs as an object mapping addresses to tokens.
-   */
-  pairs: Record<string, RainbowToken>;
 }
 
 /**
@@ -73,7 +60,6 @@ type UniswapAction =
   | UniswapLoadRequestAction
   | UniswapLoadSuccessAction
   | UniswapLoadFailureAction
-  | UniswapUpdatePairsAction
   | UniswapUpdateFavoritesAction
   | UniswapClearStateAction;
 
@@ -100,14 +86,6 @@ interface UniswapLoadSuccessAction {
  */
 interface UniswapLoadFailureAction {
   type: typeof UNISWAP_LOAD_FAILURE;
-}
-
-/**
- * The action for updating Uniswap pair data.
- */
-interface UniswapUpdatePairsAction {
-  type: typeof UNISWAP_UPDATE_PAIRS;
-  payload: UniswapState['pairs'];
 }
 
 /**
@@ -154,25 +132,6 @@ export const uniswapLoadState = () => async (
   } catch (error) {
     dispatch({ type: UNISWAP_LOAD_FAILURE });
   }
-};
-
-/**
- * Updates state to use initial data for Uniswap pairs.
- */
-export const uniswapPairsInit = () => (
-  dispatch: Dispatch<UniswapUpdatePairsAction>,
-  getState: AppGetState
-) => {
-  const { network } = getState().settings;
-  const pairs =
-    network === Network.mainnet
-      ? rainbowTokenList.CURATED_TOKENS
-      : getTestnetUniswapPairs(network);
-  dispatch({
-    // @ts-expect-error
-    payload: pairs,
-    type: UNISWAP_UPDATE_PAIRS,
-  });
 };
 
 /**
@@ -266,9 +225,6 @@ export const INITIAL_UNISWAP_STATE: UniswapState = {
   favorites: DefaultUniswapFavorites[Network.mainnet],
   favoritesMeta: DefaultUniswapFavoritesMeta[Network.mainnet],
   loadingUniswap: false,
-  get pairs() {
-    return rainbowTokenList.CURATED_TOKENS;
-  },
 };
 
 export default (
@@ -279,9 +235,6 @@ export default (
     switch (action.type) {
       case UNISWAP_LOAD_REQUEST:
         draft.loadingUniswap = true;
-        break;
-      case UNISWAP_UPDATE_PAIRS:
-        draft.pairs = action.payload;
         break;
       case UNISWAP_LOAD_SUCCESS:
         draft.favorites = action.payload.favorites;

--- a/src/resources/curatedTokens.ts
+++ b/src/resources/curatedTokens.ts
@@ -1,0 +1,27 @@
+import { RainbowToken } from '@/entities';
+import { getTestnetUniswapPairs } from '@/handlers/swap';
+import { useAccountSettings } from '@/hooks';
+import { Network } from '@/networks/types';
+import { createQueryKey } from '@/react-query';
+import { rainbowTokenList } from '@/references';
+import { useQuery } from '@tanstack/react-query';
+
+export const curatedTokensQueryKey = createQueryKey('uniswapPairs', {});
+
+export function useCuratedTokens(): Record<string, RainbowToken> {
+  const { network } = useAccountSettings();
+  const query = useQuery(
+    curatedTokensQueryKey,
+    () =>
+      // this query is not async, but rainbowTokenList receives async updates
+      network === Network.mainnet
+        ? rainbowTokenList.CURATED_TOKENS
+        : getTestnetUniswapPairs(network),
+    {
+      staleTime: Infinity, // query will be invalidated & refreshed when rainbowTokenList receives updates (see App.js)
+    }
+  );
+
+  // @ts-ignore getTestnetUniswapPairs has wrong type
+  return query.data ?? {};
+}


### PR DESCRIPTION
Fixes APP-821

## What changed (plus any additional context for devs)
Migrated "uniswap pairs" from redux to react query. This can be found in `@/resources/curatedTokens`. Renamed uniswap pairs to curated tokens, because that seems like a more accurate name (tbh not actually sure why it was called uniswap pairs in the first place).

It's a bit strange that the react query "fetcher" in this scenario doesn't actually do an async fetch. The curated tokens are accessed synchronously from `rainbowTokenList`, which receives async updates periodically. IMO, this still makes sense with react query b/c we can still rely on its caching functionality in a useful way. When `rainbowTokenList` receives an update, we invalidate + refresh the query cache, which will automatically trigger rerenders in downstream components.

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbow/assets/15272675/27916204-9e7a-4480-bd96-80af6f43c1a0



## What to test
1. make sure that tokens show up both in swap select currency modal + discover search
2. double check in the code that the logic is correct w/ respect to propagating updates to `rainbowTokenList`
