### PR TITLE
Fix crashes resulting from react-native-screens Activity restart on Android

### DIFF
--- a/android/app/src/main/java/me/rainbow/MainActivity.java
+++ b/android/app/src/main/java/me/rainbow/MainActivity.java
@@ -10,7 +10,6 @@ import io.branch.rnbranch.*;
 import me.rainbow.NativeModules.RNBackHandler.RNBackHandlerPackage;
 import me.rainbow.NativeModules.Internals.*;
 import android.webkit.WebView;
-import com.facebook.react.ReactActivityDelegate;
 import com.zoontek.rnbootsplash.RNBootSplash;
 
 import android.content.Intent;
@@ -19,7 +18,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
+      super.onCreate(null);
       WebView.setWebContentsDebuggingEnabled(false);
   }
 


### PR DESCRIPTION
As per the react-native-screens documentation on Android setup: Discards any Activity state persisted during the Activity restart process, to avoid inconsistencies that lead to crashes.

Linear ticket has broader context

Fixes APP-850

Requires this update to android preinstall hook: https://github.com/rainbow-me/rainbow-scripts/pull/133