### PR TITLE
Remove deprecated InstallListener in Android manifest which is causing a ClassNotFoundException crash for Android users

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -247,11 +247,6 @@
       <!-- Branch init -->
       <meta-data android:name="io.branch.sdk.BranchKey" android:value="${BRANCH_KEY}" />
       <meta-data android:name="io.branch.sdk.TestMode" android:value="false" />
-      <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
-        <intent-filter>
-          <action android:name="com.android.vending.INSTALL_REFERRER" />
-        </intent-filter>
-      </receiver>
     </application>
 
 </manifest>


### PR DESCRIPTION
Fixes APP-851

Additional context in Linear ticket. 

What to test: deeplinking still working as expected