### PR TITLE
fix interpolation range to account for safe insets

### DIFF
--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -15,6 +15,7 @@ import CoinDividerAssetsValue from './CoinDividerAssetsValue';
 import CoinDividerEditButton from './CoinDividerEditButton';
 import CoinDividerOpenButton from './CoinDividerOpenButton';
 import EditAction from '@/helpers/EditAction';
+import { navbarHeight } from '@/components/navbar/Navbar';
 import {
   useAccountSettings,
   useCoinListEditOptions,
@@ -25,6 +26,7 @@ import {
 import { emitChartsRequest } from '@/redux/explorer';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export const CoinDividerHeight = 30;
 export const CoinDividerContainerHeight = CoinDividerHeight + 11;
@@ -61,6 +63,7 @@ const EditButtonWrapper = styled(Row).attrs({
 const useInterpolationRange = isCoinListEdited => {
   const position = useRecyclerAssetListPosition();
   const ref = useRef();
+  const { top: safeAreaInsetTop } = useSafeAreaInsets();
 
   const { scrollViewRef } = useContext(StickyHeaderContext) || {};
   const [range, setRanges] = useState([0, 0]);
@@ -72,7 +75,7 @@ const useInterpolationRange = isCoinListEdited => {
     ref.current?.measureLayout?.(
       nativeScrollRef,
       (_left, top) => {
-        setRanges([top - (ios ? 100 : 50), top]);
+        setRanges([top - (navbarHeight + safeAreaInsetTop), top]);
       },
       () => {}
     );


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Instead of hardcoding the interpolation range we needed to base it off the inset + navbar height

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbow/assets/6284525/b90b6435-c361-4c7c-ab42-ff2c6776c28e

https://github.com/rainbow-me/rainbow/assets/6284525/61b11077-8e27-4fed-80b2-0a82315e0cf4

