### PR TITLE
swaps: fix crosschain chainID in seach

### DIFF
--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -462,7 +462,8 @@ export default function CurrencySelectModal() {
           ? { ...item, type: 'token' }
           : {
               ...item,
-              decimals: item?.networks?.[chainId]?.decimals || item.decimals,
+              decimals:
+                item?.networks?.[currentChainId]?.decimals || item.decimals,
             };
 
       const selectAsset = () => {


### PR DESCRIPTION
Fixes APP-746

## What changed (plus any additional context for devs)

we were using the wrong chainID to set the decimals, was using the input instead of the output. now we use the correct one and quotes are 💯


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Shot-2023-10-19-12-13-12.56.png


## What to test

