### PR TITLE
[Android] Fix: ButtonPressAnimation not stopping tap event propagation

### DIFF
--- a/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.tsx
+++ b/src/components/animations/ButtonPressAnimation/ButtonPressAnimation.android.tsx
@@ -294,7 +294,7 @@ export default function ButtonPressAnimation({
   wrapperStyle,
   hapticType = 'selection',
   enableHapticFeedback = true,
-  disallowInterruption = false,
+  disallowInterruption = true,
 }: Props) {
   const normalizedTransformOrigin = useMemo(
     () => normalizeTransformOrigin(transformOrigin),


### PR DESCRIPTION
Fixes APP-867

## What changed (plus any additional context for devs)
Changed the default prop for `<ButtonPressAnimation />` => `disallowInterruption` on Android to `true`. This prevents the tap event passing through to anything underneath it.
