### PR TITLE
[APP-839] Offers `HoldToAuthorizeButton` to use correct gas unit

### DIFF
--- a/src/screens/NFTSingleOfferSheet/index.tsx
+++ b/src/screens/NFTSingleOfferSheet/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import lang from 'i18n-js';
 import { Linking, View } from 'react-native';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { useRoute } from '@react-navigation/native';
@@ -810,9 +811,10 @@ export function NFTSingleOfferSheet() {
                     hideInnerBorder
                     label={
                       insufficientEth
-                        ? i18n.t(
-                            i18n.l.button.confirm_exchange.insufficient_eth
-                          )
+                        ? lang.t('button.confirm_exchange.insufficient_token', {
+                            tokenName: getNetworkObj(offer.network as Network)
+                              .nativeCurrency.symbol,
+                          })
                         : i18n.t(
                             i18n.l.nft_offers.single_offer_sheet.hold_to_sell
                           )


### PR DESCRIPTION
Fixes APP-839

## What changed (plus any additional context for devs)
`i18n.t(i18n.l.button.confirm_exchange.insufficient_eth)` >>> `lang.t('button.confirm_exchange.insufficient_token', {tokenName: getNetworkObj(offer.network as Network).nativeCurrency.symbol,})`

