### PR TITLE
Fixes for activity list coin icons and migrating some components to network instead of assetType

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
@@ -140,7 +140,7 @@ const MemoizedBalanceCoinRow = React.memo(
           <View style={[sx.container]}>
             <FastCoinIcon
               address={item.address}
-              assetType={item.type}
+              network={item.network}
               mainnetAddress={item.mainnet_address}
               symbol={item.symbol}
               theme={theme}

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinBadge.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinBadge.tsx
@@ -12,52 +12,52 @@ import ZoraBadge from '@/assets/badges/zoraBadge.png';
 import ZoraBadgeDark from '@/assets/badges/zoraBadgeDark.png';
 import BaseBadge from '@/assets/badges/baseBadge.png';
 import BaseBadgeDark from '@/assets/badges/baseBadgeDark.png';
-import { AssetType } from '@/entities';
+import { Network } from '@/networks/types';
 
 interface FastChainBadgeProps {
-  assetType: AssetType;
+  network: Network;
   theme: any;
 }
 
 const AssetIconsByTheme: {
-  [key in AssetType]?: {
+  [key in Network]?: {
     dark: ImageSourcePropType;
     light: ImageSourcePropType;
   };
 } = {
-  [AssetType.arbitrum]: {
+  [Network.arbitrum]: {
     dark: ArbitrumBadgeDark,
     light: ArbitrumBadge,
   },
-  [AssetType.optimism]: {
+  [Network.optimism]: {
     dark: OptimismBadgeDark,
     light: OptimismBadge,
   },
-  [AssetType.polygon]: {
+  [Network.polygon]: {
     dark: PolygonBadgeDark,
     light: PolygonBadge,
   },
-  [AssetType.bsc]: {
+  [Network.bsc]: {
     dark: BscBadgeDark,
     light: BscBadge,
   },
-  [AssetType.zora]: {
+  [Network.zora]: {
     dark: ZoraBadgeDark,
     light: ZoraBadge,
   },
-  [AssetType.base]: {
+  [Network.base]: {
     dark: BaseBadgeDark,
     light: BaseBadge,
   },
 };
 
 export const FastChainBadge = React.memo(function FastChainBadge({
-  assetType,
+  network,
   theme,
 }: FastChainBadgeProps) {
   const { isDarkMode } = theme;
 
-  const source = AssetIconsByTheme[assetType]?.[isDarkMode ? 'dark' : 'light'];
+  const source = AssetIconsByTheme[network]?.[isDarkMode ? 'dark' : 'light'];
 
   if (!source) return null;
 

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
@@ -6,15 +6,11 @@ import { FastChainBadge } from './FastCoinBadge';
 import { FastFallbackCoinIconImage } from './FastFallbackCoinIconImage';
 import ContractInteraction from '@/assets/contractInteraction.png';
 import EthIcon from '@/assets/eth-icon.png';
-import { AssetType } from '@/entities';
 import { useColorForAsset } from '@/hooks';
+import { Network } from '@/networks/types';
 import { borders, fonts } from '@/styles';
 import { ThemeContextProps } from '@/theme';
-import {
-  FallbackIcon as CoinIconTextFallback,
-  getTokenMetadata,
-  isETH,
-} from '@/utils';
+import { FallbackIcon as CoinIconTextFallback, isETH } from '@/utils';
 
 const fallbackTextStyles = {
   fontFamily: fonts.family.SFProRounded,
@@ -38,55 +34,54 @@ function formatSymbol(symbol: string) {
 /**
  * If mainnet asset is available, get the token under /ethereum/ (token) url.
  * Otherwise let it use whatever type it has
- * @param param0 - optional mainnetAddress, address and optional assetType
+ * @param param0 - optional mainnetAddress, address and network
  * @returns a proper type and address to use for the url
  */
-function resolveTypeAndAddress({
-  mainnetAddress,
+function resolveNetworkAndAddress({
   address,
-  assetType,
+  mainnetAddress,
+  network,
 }: {
   mainnetAddress?: string;
   address: string;
-  assetType?: AssetType;
+  network: Network;
 }) {
   if (mainnetAddress) {
     return {
       resolvedAddress: mainnetAddress,
-      resolvedType: AssetType.token,
+      resolvedNetwork: Network.mainnet,
     };
   }
 
   return {
     resolvedAddress: address,
-    resolvedType: assetType,
+    resolvedNetwork: network,
   };
 }
 
 export default React.memo(function FastCoinIcon({
   address,
   mainnetAddress,
+  network,
   symbol,
-  assetType,
   theme,
 }: {
   address: string;
   mainnetAddress?: string;
+  network: Network;
   symbol: string;
-  assetType?: AssetType;
   theme: ThemeContextProps;
 }) {
   const { colors } = theme;
 
-  const { resolvedType, resolvedAddress } = resolveTypeAndAddress({
+  const { resolvedNetwork, resolvedAddress } = resolveNetworkAndAddress({
     address,
-    assetType,
     mainnetAddress,
+    network,
   });
 
   const fallbackIconColor = useColorForAsset({
     address: resolvedAddress,
-    type: resolvedType,
   });
 
   const shadowColor = theme.isDarkMode ? colors.shadow : fallbackIconColor;
@@ -133,7 +128,7 @@ export default React.memo(function FastCoinIcon({
       ) : (
         <FastFallbackCoinIconImage
           address={resolvedAddress}
-          assetType={resolvedType}
+          network={resolvedNetwork}
           shadowColor={shadowColor}
           symbol={symbol}
           theme={theme}
@@ -151,7 +146,7 @@ export default React.memo(function FastCoinIcon({
         </FastFallbackCoinIconImage>
       )}
 
-      {assetType && <FastChainBadge assetType={assetType} theme={theme} />}
+      {network && <FastChainBadge network={network} theme={theme} />}
     </View>
   );
 });

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// @ts-expect-error // no declaration for this yet
-import * as CoinIconsImages from 'react-coin-icon/lib/pngs';
 import { Image, StyleSheet, View } from 'react-native';
 import { FastChainBadge } from './FastCoinBadge';
 import { FastFallbackCoinIconImage } from './FastFallbackCoinIconImage';
@@ -24,12 +22,6 @@ const fallbackIconStyle = {
   ...borders.buildCircleAsObject(40),
   position: 'absolute',
 };
-
-function formatSymbol(symbol: string) {
-  return symbol
-    ? symbol.charAt(0).toUpperCase() + symbol.slice(1).toLowerCase()
-    : '';
-}
 
 /**
  * If mainnet asset is available, get the token under /ethereum/ (token) url.
@@ -85,14 +77,7 @@ export default React.memo(function FastCoinIcon({
   });
 
   const shadowColor = theme.isDarkMode ? colors.shadow : fallbackIconColor;
-
   const eth = isETH(resolvedAddress);
-
-  const formattedSymbol = formatSymbol(symbol);
-
-  const shouldRenderFallback = !eth;
-  const shouldRenderLocalCoinIconImage =
-    !shouldRenderFallback && !!CoinIconsImages[formattedSymbol];
   const shouldRenderContract = symbol === 'contract';
 
   return (
@@ -107,21 +92,6 @@ export default React.memo(function FastCoinIcon({
           ]}
         >
           <Image source={EthIcon} style={sx.coinIconFallback} />
-        </View>
-      ) : shouldRenderLocalCoinIconImage ? (
-        <View
-          style={[
-            sx.coinIconFallback,
-            sx.reactCoinIconContainer,
-            sx.withShadow,
-            { shadowColor },
-          ]}
-        >
-          <Image
-            resizeMode="contain"
-            source={CoinIconsImages[formattedSymbol]}
-            style={sx.reactCoinIconImage}
-          />
         </View>
       ) : shouldRenderContract ? (
         <Image source={ContractInteraction} style={sx.contract} />
@@ -171,10 +141,6 @@ const sx = StyleSheet.create({
   reactCoinIconContainer: {
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  reactCoinIconImage: {
-    height: '100%',
-    width: '100%',
   },
   withShadow: {
     elevation: 6,

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -14,7 +14,7 @@ import FastCoinIcon from './FastCoinIcon';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Text } from '@/design-system';
 import { isNativeAsset } from '@/handlers/assets';
-import { Network } from '@/helpers';
+import { Network } from '@/networks/types';
 import { useAccountAsset } from '@/hooks';
 import { colors, fonts, fontWithWidth, getFontSize } from '@/styles';
 import { deviceUtils, ethereumUtils } from '@/utils';
@@ -151,7 +151,7 @@ export default React.memo(function FastCurrencySelectionRow({
         <View style={sx.rootContainer}>
           <FastCoinIcon
             address={address || item?.address}
-            assetType={type ?? item?.type}
+            network={network}
             mainnetAddress={mainnet_address ?? item?.mainnet_address}
             symbol={symbol ?? item?.symbol}
             theme={theme}

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { AssetType } from '@/entities';
+import { Network } from '@/networks/types';
 import { useForceUpdate } from '@/hooks';
 import { ImageWithCachedMetadata, ImgixImage } from '@/components/images';
 import { ThemeContextProps } from '@/theme';
@@ -17,7 +17,7 @@ const imagesCache: { [imageUrl: string]: keyof typeof ImageState } = {};
 export const FastFallbackCoinIconImage = React.memo(
   function FastFallbackCoinIconImage({
     address,
-    assetType,
+    network,
     symbol,
     shadowColor,
     theme,
@@ -25,13 +25,13 @@ export const FastFallbackCoinIconImage = React.memo(
   }: {
     theme: ThemeContextProps;
     address: string;
-    assetType?: AssetType;
+    network: Network;
     symbol: string;
     shadowColor: string;
     children: () => React.ReactNode;
   }) {
     const { colors } = theme;
-    const imageUrl = getUrlForTrustIconFallback(address, assetType)!;
+    const imageUrl = getUrlForTrustIconFallback(address, network)!;
 
     const key = `${symbol}-${imageUrl}`;
 

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Network } from '@/networks/types';
-import { useForceUpdate } from '@/hooks';
 import { ImageWithCachedMetadata, ImgixImage } from '@/components/images';
 import { ThemeContextProps } from '@/theme';
 import { getUrlForTrustIconFallback } from '@/utils';
@@ -35,22 +34,19 @@ export const FastFallbackCoinIconImage = React.memo(
 
     const key = `${symbol}-${imageUrl}`;
 
-    const shouldShowImage = imagesCache[key] !== ImageState.NOT_FOUND;
-    const isLoaded = imagesCache[key] === ImageState.LOADED;
+    const [cacheStatus, setCacheStatus] = useState(imagesCache[key]);
 
-    // we store data inside the object outside the component
-    // so we can share it between component instances
-    // but we still want the component to pick up new changes
-    const forceUpdate = useForceUpdate();
+    const shouldShowImage = cacheStatus !== ImageState.NOT_FOUND;
+    const isLoaded = cacheStatus === ImageState.LOADED;
 
     const onLoad = useCallback(() => {
-      if (imagesCache[key] === ImageState.LOADED) {
+      if (isLoaded) {
         return;
       }
-
       imagesCache[key] = ImageState.LOADED;
-      forceUpdate();
-    }, [key, forceUpdate]);
+      setCacheStatus(ImageState.LOADED);
+    }, [key, isLoaded]);
+
     const onError = useCallback(
       // @ts-expect-error passed to an untyped JS component
       err => {
@@ -58,15 +54,14 @@ export const FastFallbackCoinIconImage = React.memo(
           ? ImageState.NOT_FOUND
           : ImageState.ERROR;
 
-        if (imagesCache[key] === newError) {
+        if (cacheStatus === newError) {
           return;
-        } else {
-          imagesCache[key] = newError;
         }
 
-        forceUpdate();
+        imagesCache[key] = newError;
+        setCacheStatus(newError);
       },
-      [key, forceUpdate]
+      [cacheStatus, key]
     );
 
     return (

--- a/src/components/coin-icon/CoinIcon.tsx
+++ b/src/components/coin-icon/CoinIcon.tsx
@@ -8,7 +8,12 @@ import { Network } from '@/networks/types';
 import { useColorForAsset } from '@/hooks';
 import { ImgixImage } from '@/components/images';
 import styled from '@/styled-thing';
-import { isETH, magicMemo, CoinIcon as ReactCoinIcon } from '@/utils';
+import {
+  ethereumUtils,
+  isETH,
+  magicMemo,
+  CoinIcon as ReactCoinIcon,
+} from '@/utils';
 import { ChainBadgeType } from '@/components/coin-icon/ChainBadgeSizeConfigs';
 
 export const CoinIconSize = 40;
@@ -62,6 +67,12 @@ const CoinIcon: React.FC<Props> = ({
 
   const theme = useTheme();
 
+  const network = mainnet_address
+    ? Network.mainnet
+    : type
+    ? ethereumUtils.getNetworkFromType(type)
+    : Network.mainnet;
+
   return (
     <View>
       {isNotContractInteraction ? (
@@ -78,7 +89,7 @@ const CoinIcon: React.FC<Props> = ({
           }
           size={size}
           symbol={symbol}
-          network={mainnet_address ? Network.mainnet : type}
+          network={network}
           theme={theme}
         />
       ) : (

--- a/src/components/coin-icon/CoinIcon.tsx
+++ b/src/components/coin-icon/CoinIcon.tsx
@@ -1,20 +1,14 @@
-import { isNil } from 'lodash';
 import React, { useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 import ContractInteraction from '../../assets/contractInteraction.png';
 import { useTheme } from '../../theme/ThemeContext';
 import ChainBadge from './ChainBadge';
 import { CoinIconFallback } from './CoinIconFallback';
-import { AssetTypes } from '@/entities';
+import { Network } from '@/networks/types';
 import { useColorForAsset } from '@/hooks';
 import { ImgixImage } from '@/components/images';
 import styled from '@/styled-thing';
-import {
-  getTokenMetadata,
-  isETH,
-  magicMemo,
-  CoinIcon as ReactCoinIcon,
-} from '@/utils';
+import { isETH, magicMemo, CoinIcon as ReactCoinIcon } from '@/utils';
 import { ChainBadgeType } from '@/components/coin-icon/ChainBadgeSizeConfigs';
 
 export const CoinIconSize = 40;
@@ -59,7 +53,6 @@ const CoinIcon: React.FC<Props> = ({
 }) => {
   const color = useColorForAsset({
     address: mainnet_address || address,
-    type: mainnet_address ? AssetTypes.token : type,
   });
   const { colors, isDarkMode } = useTheme();
   const forceFallback = !isETH(mainnet_address || address);
@@ -85,8 +78,7 @@ const CoinIcon: React.FC<Props> = ({
           }
           size={size}
           symbol={symbol}
-          type={mainnet_address ? AssetTypes.token : type}
-          assetType={mainnet_address ? AssetTypes.token : type}
+          network={mainnet_address ? Network.mainnet : type}
           theme={theme}
         />
       ) : (

--- a/src/components/coin-icon/CoinIconFallback.js
+++ b/src/components/coin-icon/CoinIconFallback.js
@@ -31,8 +31,8 @@ const fallbackIconStyle = size => {
 export const CoinIconFallback = fallbackProps => {
   const {
     address,
-    assetType,
     height,
+    network,
     symbol,
     shadowColor,
     theme,
@@ -41,7 +41,7 @@ export const CoinIconFallback = fallbackProps => {
   } = fallbackProps;
 
   const { colors } = theme;
-  const imageUrl = getUrlForTrustIconFallback(address, assetType);
+  const imageUrl = getUrlForTrustIconFallback(address, network);
 
   const key = `${symbol}-${imageUrl}`;
 
@@ -50,7 +50,6 @@ export const CoinIconFallback = fallbackProps => {
 
   const fallbackIconColor = useColorForAsset({
     address,
-    assetType,
   });
 
   // we store data inside the object outside the component

--- a/src/components/coin-row/FastTransactionCoinRow.tsx
+++ b/src/components/coin-row/FastTransactionCoinRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { ButtonPressAnimation } from '../animations';
 import FastCoinIcon from '../asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon';
@@ -154,7 +154,7 @@ export default React.memo(function TransactionCoinRow({
           ) : (
             <FastCoinIcon
               address={mainnetAddress || item.address}
-              assetType={item.network}
+              network={item.network}
               mainnetAddress={mainnetAddress}
               symbol={item.symbol}
               theme={theme}

--- a/src/components/exchange/ExchangeTokenRow.tsx
+++ b/src/components/exchange/ExchangeTokenRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import isEqual from 'react-fast-compare';
 import { Box, Column, Columns, Inline, Stack, Text } from '@/design-system';
 import { isNativeAsset } from '@/handlers/assets';
-import { Network } from '@/helpers';
+import { Network } from '@/networks/types';
 import { useAccountAsset, useDimensions } from '@/hooks';
 import { ethereumUtils } from '@/utils';
 import FastCoinIcon from '../asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon';
@@ -69,7 +69,7 @@ export default React.memo(function ExchangeTokenRow({
               <Box
                 as={FastCoinIcon}
                 address={address || item?.address}
-                assetType={type ?? item?.type}
+                network={network}
                 mainnetAddress={mainnet_address ?? item?.mainnet_address}
                 symbol={symbol ?? item?.symbol}
                 theme={theme}

--- a/src/utils/getUrlForTrustIconFallback.ts
+++ b/src/utils/getUrlForTrustIconFallback.ts
@@ -1,16 +1,21 @@
-import { AssetType, EthereumAddress } from '@/entities';
+import { EthereumAddress } from '@/entities';
+import { Network } from '@/networks/types';
 
 export default function getUrlForTrustIconFallback(
   address: EthereumAddress,
-  type?: AssetType
+  network: Network
 ): string | null {
   if (!address) return null;
-  let network = 'ethereum';
-  if (type && type !== AssetType.token) {
-    network = type;
+  let networkPath = 'ethereum';
+  switch (network) {
+    case Network.mainnet:
+      networkPath = 'ethereum';
+      break;
+    case Network.bsc:
+      networkPath = 'smartchain';
+      break;
+    default:
+      networkPath = network;
   }
-  if (type && type === AssetType.bsc) {
-    network = 'smartchain';
-  }
-  return `https://rainbowme-res.cloudinary.com/image/upload/assets/${network}/${address}.png`;
+  return `https://rainbowme-res.cloudinary.com/image/upload/assets/${networkPath}/${address}.png`;
 }


### PR DESCRIPTION
Fixes APP-872

* Fixes coin icons on the Activity screen that were falling back to text instead of icon images
* Migrates some components to start using network instead of assetType

What to test is mentioned in Linear ticket