### PR TITLE
Fix button press animation, scroll indicators

### DIFF
--- a/patches/react-native+0.72.0.patch
+++ b/patches/react-native+0.72.0.patch
@@ -10,6 +10,22 @@ index 26961d7..ee5943d 100644
  } else if (!global.nativeExtensions) {
    const bridgeConfig = global.__fbBatchedBridgeConfig;
    invariant(
+diff --git a/node_modules/react-native/React/Views/RCTView.m b/node_modules/react-native/React/Views/RCTView.m
+index 619509f..a9477e5 100644
+--- a/node_modules/react-native/React/Views/RCTView.m
++++ b/node_modules/react-native/React/Views/RCTView.m
+@@ -831,6 +831,11 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
+     layer.backgroundColor = backgroundColor;
+     layer.contents = nil;
+     layer.needsDisplayOnBoundsChange = NO;
++    if (@available(iOS 13.0, *)) {
++      if (layer.cornerRadius < MIN(self.bounds.size.height, self.bounds.size.width) / 2) {
++        layer.cornerCurve = kCACornerCurveContinuous;
++      }
++    }
+     layer.mask = nil;
+     return;
+   }
 diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h b/node_modules/react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h
 new file mode 100644
 index 0000000..37b7d8d

--- a/patches/react-native-pager-view+5.4.24.patch
+++ b/patches/react-native-pager-view+5.4.24.patch
@@ -10,3 +10,16 @@ index 81070b2..2f1d2b9 100644
      vp.adapter = ViewPagerAdapter()
      //https://github.com/callstack/react-native-viewpager/issues/183
      vp.isSaveEnabled = false
+diff --git a/node_modules/react-native-pager-view/ios/ReactNativePageView.m b/node_modules/react-native-pager-view/ios/ReactNativePageView.m
+index 9f8ed5b..9a1f8c9 100644
+--- a/node_modules/react-native-pager-view/ios/ReactNativePageView.m
++++ b/node_modules/react-native-pager-view/ios/ReactNativePageView.m
+@@ -107,7 +107,7 @@
+         if([subview isKindOfClass:UIScrollView.class]){
+             ((UIScrollView *)subview).delegate = self;
+             ((UIScrollView *)subview).keyboardDismissMode = _dismissKeyboard;
+-            ((UIScrollView *)subview).delaysContentTouches = YES;
++            ((UIScrollView *)subview).delaysContentTouches = NO;
+             self.scrollView = (UIScrollView *)subview;
+         }
+     }

--- a/src/components/activity-list/ActivityList.js
+++ b/src/components/activity-list/ActivityList.js
@@ -15,6 +15,7 @@ import RecyclerActivityList from './RecyclerActivityList';
 import styled from '@/styled-thing';
 import { useTheme } from '@/theme';
 import { useSectionListScrollToTopContext } from '@/navigation/SectionListScrollToTopContext';
+import { safeAreaInsetValues } from '@/utils';
 
 const sx = StyleSheet.create({
   sectionHeader: {
@@ -162,6 +163,9 @@ const ActivityList = ({
           keyExtractor={keyExtractor}
           removeClippedSubviews
           renderSectionHeader={renderSectionHeaderWithTheme}
+          scrollIndicatorInsets={{
+            bottom: safeAreaInsetValues.bottom + 14,
+          }}
           sections={sections}
         />
       );

--- a/src/components/asset-list/RecyclerAssetList2/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/index.tsx
@@ -70,7 +70,10 @@ function RecyclerAssetList({
           briefSectionsData={briefSectionsData}
           disablePullDownToRefresh={!!disablePullDownToRefresh}
           extendedState={extendedState}
-          scrollIndicatorInsets={{ bottom: 40, top: 132 }}
+          scrollIndicatorInsets={{
+            bottom: insets.bottom + 14,
+            top: 132,
+          }}
           type={type}
         />
       </StickyHeaderManager>

--- a/src/screens/discover/DiscoverScreen.tsx
+++ b/src/screens/discover/DiscoverScreen.tsx
@@ -103,7 +103,7 @@ export default function DiscoverScreen() {
           scrollEnabled={!isSearchModeEnabled}
           bounces={!isSearchModeEnabled}
           removeClippedSubviews
-          scrollIndicatorInsets={{ bottom: safeAreaInsetValues.bottom + 197 }}
+          scrollIndicatorInsets={{ bottom: safeAreaInsetValues.bottom + 167 }}
           testID="discover-sheet"
         >
           <DiscoverScreenContent />


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Sets `delaysContentTouches = NO` on the scroll view underlying `SwipeNavigator`, which fixes button press animations within tabs on iOS
- Fixes scroll indicator positioning
- Brings back smooth rounded corners