### PR TITLE
Review Alert blocks E2E tests, disabling when IS_TESTING=true

### DIFF
--- a/src/utils/reviewAlert.ts
+++ b/src/utils/reviewAlert.ts
@@ -5,6 +5,7 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 import { ReviewPromptAction } from '@/storage/schema';
 import { IS_IOS } from '@/env';
 import { logger } from '@/logger';
+import { IS_TESTING } from 'react-native-dotenv';
 
 const { RainbowRequestReview, RNReview } = NativeModules;
 
@@ -31,6 +32,10 @@ export const numberOfTimesBeforePrompt: {
 
 export const handleReviewPromptAction = async (action: ReviewPromptAction) => {
   logger.info(`handleReviewPromptAction: ${action}`);
+
+  if (IS_TESTING === 'true') {
+    return;
+  }
 
   if (action === ReviewPromptAction.UserPrompt) {
     promptForReview();


### PR DESCRIPTION
Review alert blocks E2E tests. Turning the popup off when IS_TESTING=true.
