### PR TITLE
Fixed E2E test DiscoverSheetFlow

### DIFF
--- a/e2e/discoverSheetFlow.spec.js
+++ b/e2e/discoverSheetFlow.spec.js
@@ -51,7 +51,7 @@ describe('Discover Screen Flow', () => {
   });
 
   it('Should navigate to the Profile screen after swiping left', async () => {
-    await Helpers.swipe('discover-home', 'left', 'slow');
+    await Helpers.waitAndTap('tab-bar-icon-ProfileScreen');
     await Helpers.checkIfVisible('profile-screen');
   });
 

--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -283,6 +283,7 @@ const TabBar = ({
                         width="full"
                         justifyContent="flex-start"
                         paddingTop="6px"
+                        testID={`tab-bar-icon-${route.name}`}
                       >
                         <ButtonPressAnimation
                           onPress={onPress}


### PR DESCRIPTION
Added TestID to SwipeNavigator tabs, which allowed us to use tapping navigation for a test that was freezing the App while attempting to swipe out of Discover screen.