### PR TITLE
mints: l1fee + value fix

### DIFF
--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -334,18 +334,35 @@ const MintSheet = () => {
                 return;
               }
               step.items?.forEach(async item => {
+                const value = multiply(
+                  mintCollection.publicMintInfo?.price?.amount?.raw || '0',
+                  quantity
+                );
                 // could add safety here if unable to calc gas limit
                 const tx = {
                   to: item.data?.to,
                   from: item.data?.from,
                   data: item.data?.data,
-                  value: multiply(price.amount || '0', quantity),
+                  value,
                 };
 
                 const gas = await estimateGas(tx, provider);
+
+                let l1GasFeeOptimism = null;
+                // add l1Fee for OP Chains
+                if (getNetworkObj(currentNetwork).gas.OptimismTxFee) {
+                  l1GasFeeOptimism = await ethereumUtils.calculateL1FeeOptimism(
+                    tx,
+                    provider
+                  );
+                }
                 if (gas) {
                   setGasError(false);
-                  updateTxFee(gas, null);
+                  if (l1GasFeeOptimism) {
+                    updateTxFee(gas, null, l1GasFeeOptimism);
+                  } else {
+                    updateTxFee(gas, null);
+                  }
                 }
               });
             });


### PR DESCRIPTION
Fixes APP-886 APP-885

## What changed (plus any additional context for devs)

adds l1fee for OP networks that should have been there intially 

now we use the raw eth value for tx value 


## Screen recordings / screenshots

https://cloud.skylarbarrera.com/Screen-Shot-2023-10-26-10-04-13.33.png


## What to test
OP gas fee should be greater than $.01 

