### PR TITLE
mints: fix insufficient eth check

### DIFF
--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -235,7 +235,9 @@ const MintSheet = () => {
   const { result: aspectRatio } = usePersistentAspectRatio(imageUrl || '');
   // isMintingPublicSale handles if theres a time based mint, otherwise if there is a price we should be able to mint
   const isMintingAvailable =
-    !!mintCollection.publicMintInfo && (!gasError || insufficientEth);
+    !(isReadOnlyWallet || isHardwareWallet) &&
+    !!mintCollection.publicMintInfo &&
+    (!gasError || insufficientEth);
 
   const imageColor =
     usePersistentDominantColorFromImage(imageUrl) ?? colors.paleBlue;

--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -235,9 +235,7 @@ const MintSheet = () => {
   const { result: aspectRatio } = usePersistentAspectRatio(imageUrl || '');
   // isMintingPublicSale handles if theres a time based mint, otherwise if there is a price we should be able to mint
   const isMintingAvailable =
-    !(isReadOnlyWallet || isHardwareWallet) &&
-    !!mintCollection.publicMintInfo &&
-    !gasError;
+    !!mintCollection.publicMintInfo && (!gasError || insufficientEth);
 
   const imageColor =
     usePersistentDominantColorFromImage(imageUrl) ?? colors.paleBlue;
@@ -265,9 +263,14 @@ const MintSheet = () => {
             accountAddress
           )
         )?.balance?.amount ?? 0;
+
+      const totalMintPrice = multiply(price.amount, quantity);
+      if (greaterThanOrEqualTo(totalMintPrice, nativeBalance)) {
+        setInsufficientEth(true);
+        return;
+      }
       const txFee = getTotalGasPrice();
       const txFeeWithBuffer = multiply(txFee, 1.2);
-      const totalMintPrice = multiply(price.amount, quantity);
       // gas price + mint price
       setInsufficientEth(
         greaterThanOrEqualTo(
@@ -343,7 +346,6 @@ const MintSheet = () => {
                   value: item.data?.value,
                 };
                 const gas = await estimateGas(tx, provider);
-
                 let l1GasFeeOptimism = null;
                 // add l1Fee for OP Chains
                 if (getNetworkObj(currentNetwork).gas.OptimismTxFee) {
@@ -724,7 +726,6 @@ const MintSheet = () => {
                           plusAction={() => setQuantity(1)}
                           minusAction={() => setQuantity(-1)}
                           buttonColor={imageColor}
-                          disabled={!isMintingAvailable}
                           maxValue={Number(maxMintsPerWallet)}
                         />
                       </Stack>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
gas was erroring and overriding the insufficient balance state, this is fixed now 

I also removed the disabling of the quantity button as it was letting users get in a stuck state when a mint only supports minting 1 but we are unaware


## Screen recordings / screenshots


## What to test

