### PR TITLE
v bump 1.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+## [1.9.10] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.10)
+
+### Added
+
+- Tx Simulation
+- RPC Proxy updates
+- Remote promo sheet capabilities
+- ‘An error occurred’ popup changes
+
+### Changed
+
+- ‘An error occurred’ popup changes
+
+### Fixed
+
+- Android navigation bar now matches app theme
+- Infinite render on swaps modal bug fix
+
 ## [1.9.9] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.9)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - Tx Simulation (#5177)
 - RPC Proxy updates (#5169)
-- Remote promo sheet capabilities (#5140) 
+- Remote promo sheet capabilities (#5140)
 
 ### Changed
 
-- ‘An error occurred’ popup changes (#5187) 
+- ‘An error occurred’ popup changes (#5187)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Added
 
-- Tx Simulation
-- RPC Proxy updates
-- Remote promo sheet capabilities
-- ‘An error occurred’ popup changes
+- Tx Simulation (#5177)
+- RPC Proxy updates (#5169)
+- Remote promo sheet capabilities (#5140) 
 
 ### Changed
 
-- ‘An error occurred’ popup changes
+- ‘An error occurred’ popup changes (#5187) 
 
 ### Fixed
 
-- Android navigation bar now matches app theme
-- Infinite render on swaps modal bug fix
+- Android navigation bar now matches app theme (#5150)
+- Infinite render on swaps modal bug (#5191)
 
 ## [1.9.9] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.9)
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,8 +152,8 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 194
-        versionName "1.9.10"
+        versionCode 195
+        versionName "1.9.11"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
         renderscriptSupportModeEnabled true

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1517,7 +1517,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.10;
+				MARKETING_VERSION = 1.9.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -1580,7 +1580,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.10;
+				MARKETING_VERSION = 1.9.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -1688,7 +1688,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.10;
+				MARKETING_VERSION = 1.9.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -1797,7 +1797,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.10;
+				MARKETING_VERSION = 1.9.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "1.9.10-1",
+  "version": "1.9.11-1",
   "private": true,
   "scripts": {
     "setup": "yarn install && yarn graphql-codegen:install && yarn ds:install && yarn allow-scripts && yarn postinstall && yarn graphql-codegen",


### PR DESCRIPTION
## [1.9.10] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.10)

### Added

- Tx Simulation
- RPC Proxy updates
- Remote promo sheet capabilities
- ‘An error occurred’ popup changes

### Changed

- ‘An error occurred’ popup changes

### Fixed

- Android navigation bar now matches app theme
- Infinite render on swaps modal bug fix