### PR TITLE
notifications: general marketing

### DIFF
--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -6,6 +6,7 @@ import messaging, {
 } from '@react-native-firebase/messaging';
 import {
   FixedRemoteMessage,
+  MarketingNotificationData,
   MinimalNotification,
   NotificationTypes,
   TransactionNotificationData,
@@ -300,6 +301,19 @@ export const NotificationsHandler = ({ walletReady }: Props) => {
         `NotificationsHandler: handling wallet connect notification`,
         { notification }
       );
+    } else if (type === NotificationTypes.marketing) {
+      logger.info(`NotificationsHandler: handling marketing notification`, {
+        notification,
+      });
+      const data = (notification.data as unknown) as MarketingNotificationData;
+      if (data?.route) {
+        const parsedProps = JSON.parse(data?.routeProps || '{}');
+        Navigation.handleAction((Routes as any)[data.route], {
+          params: {
+            ...(parsedProps || {}),
+          },
+        });
+      }
     } else {
       logger.warn(`NotificationsHandler: received unknown notification`, {
         notification,

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -3,6 +3,7 @@ import { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 export const NotificationTypes = {
   transaction: 'transaction',
   walletConnect: 'wc',
+  marketing: 'marketing',
 } as const;
 
 export type NotificationTypesType = typeof NotificationTypes[keyof typeof NotificationTypes];
@@ -44,3 +45,9 @@ export const NotificationTransactionTypes = {
 } as const;
 
 export type NotificationTransactionTypesType = typeof NotificationTransactionTypes[keyof typeof NotificationTransactionTypes];
+
+export interface MarketingNotificationData {
+  type: 'marketing';
+  route?: string;
+  routeProps?: string;
+}


### PR DESCRIPTION
Fixes APP-934

## What changed (plus any additional context for devs)
added simple handling for marketing focused notifications, we already technically had support for them but now it allows us to navigate to different screens


## Screen recordings / screenshots
https://cloud.skylarbarrera.com/RPReplay_Final1701273411.MP4


## What to test

android, can't build locally atm 😮‍💨 

