### PR TITLE
Network settings for notification subscription (pt1)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,7 +76,6 @@ import { logger, RainbowError } from '@/logger';
 import * as ls from '@/storage';
 import { migrate } from '@/migrations';
 import { initListeners as initWalletConnectListeners } from '@/walletConnect';
-import { saveFCMToken } from '@/notifications/tokens';
 import branch from 'react-native-branch';
 import { initializeReservoirClient } from '@/resources/reservoir/client';
 import { ReviewPromptAction } from '@/storage/schema';
@@ -157,11 +156,6 @@ class OldApp extends Component {
       PerformanceMetrics.loadRootAppComponent
     );
     analyticsV2.track(analyticsV2.event.applicationDidMount);
-
-    /**
-     * This must be saved in the store as early as possible
-     */
-    await saveFCMToken();
 
     /**
      * Needs to be called AFTER FCM token is loaded

--- a/src/networks/arbitrum.ts
+++ b/src/networks/arbitrum.ts
@@ -37,6 +37,7 @@ export const getArbitrumNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: true,
       savings: false,
       pools: false,
       txs: arbitrum_tx_enabled,

--- a/src/networks/base.ts
+++ b/src/networks/base.ts
@@ -41,6 +41,7 @@ export const getBaseNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: true,
       savings: false,
       pools: false,
       txs: base_tx_enabled && op_chains_tx_enabled,

--- a/src/networks/bsc.ts
+++ b/src/networks/bsc.ts
@@ -38,6 +38,7 @@ export const getBSCNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: false,
       savings: false,
       pools: false,
       txs: bsc_tx_enabled,

--- a/src/networks/gnosis.ts
+++ b/src/networks/gnosis.ts
@@ -34,6 +34,7 @@ export const getGnosisNetworkObject = (): NetworkProperties => {
       walletconnect: false,
       swaps: false,
       nfts: true,
+      notifications: false,
       savings: false,
       pools: false,
       txs: false,

--- a/src/networks/goerli.ts
+++ b/src/networks/goerli.ts
@@ -38,6 +38,7 @@ export const getGoerliNetworkObject = (): NetworkProperties => {
       walletconnect: false,
       swaps: false,
       nfts: false,
+      notifications: false,
       savings: true,
       pools: true,
       txs: goerli_tx_enabled,

--- a/src/networks/mainnet.ts
+++ b/src/networks/mainnet.ts
@@ -38,6 +38,7 @@ export const getMainnetNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: true,
       savings: true,
       pools: true,
       txs: mainnet_tx_enabled,

--- a/src/networks/optimism.ts
+++ b/src/networks/optimism.ts
@@ -41,6 +41,7 @@ export const getOptimismNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: true,
       savings: false,
       pools: false,
       txs: optimism_tx_enabled && op_chains_tx_enabled,

--- a/src/networks/polygon.ts
+++ b/src/networks/polygon.ts
@@ -37,6 +37,7 @@ export const getPolygonNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: true,
       savings: false,
       pools: false,
       txs: polygon_tx_enabled,

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -45,6 +45,7 @@ export interface NetworkProperties extends Chain {
     walletconnect: boolean;
     swaps: boolean;
     nfts: boolean;
+    notifications: boolean;
     savings: boolean;
     pools: boolean;
     txs: boolean;

--- a/src/networks/zora.ts
+++ b/src/networks/zora.ts
@@ -41,6 +41,7 @@ export const getZoraNetworkObject = (): NetworkProperties => {
       walletconnect: true,
       swaps: true,
       nfts: true,
+      notifications: false,
       savings: false,
       pools: false,
       txs: zora_tx_enabled && op_chains_tx_enabled,

--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -56,7 +56,6 @@ import {
 } from '@/notifications/settings';
 import { initializeNotificationSettingsForAllAddressesAndCleanupSettingsForRemovedWallets } from '@/notifications/settings/initialization';
 import { logger } from '@/logger';
-import { setHasPendingDeeplinkPendingRedirect } from '@/walletConnect';
 
 type Callback = () => void;
 


### PR DESCRIPTION
Fixes APP-887

This PR is a noop.
Includes:
- Initial setup of network-specific notification enabled settings
- Some cleanup of redundant / unused items

For reference: networks supported are: mainnet, arbitrum, polygon, optimism, base