### PR TITLE
Remove the old websocket notif subscription (pt 3)

### DIFF
--- a/src/migrations/__tests__/migrations-prod.test.txt
+++ b/src/migrations/__tests__/migrations-prod.test.txt
@@ -13,19 +13,6 @@ jest.mock('@/env', () => ({
   IS_PROD: true,
 }));
 
-/*
- * We need to mock below two mocks because one of the migrations has imported our redux store
- * which has a lot of module dependencies. We don't want to mock all of them so we mock the used redux files
- * since we are not testing them here.
- */
-jest.mock('@/redux/explorer', () => ({
-  notificationsSubscription: jest.fn(),
-}));
-
-jest.mock('@/redux/store', () => ({
-  dispatch: jest.fn(),
-}));
-
 describe(`@/migrations IS_PROD`, () => {
   const storage = new MMKV({ id: MIGRATIONS_STORAGE_ID });
 

--- a/src/migrations/__tests__/migrations.test.txt
+++ b/src/migrations/__tests__/migrations.test.txt
@@ -9,19 +9,6 @@ import {
   MIGRATIONS_STORAGE_ID,
 } from '@/migrations/types';
 
-/*
- * We need to mock below two mocks because one of the migrations has imported our redux store
- * which has a lot of module dependencies. We don't want to mock all of them so we mock the used redux files
- * since we are not testing them here.
- */
-jest.mock('@/redux/explorer', () => ({
-  notificationsSubscription: jest.fn(),
-}));
-
-jest.mock('@/redux/store', () => ({
-  dispatch: jest.fn(),
-}));
-
 InteractionManager.runAfterInteractions = jest.fn();
 
 describe(`@/migrations`, () => {

--- a/src/notifications/settings/__tests__/initialization.test.txt
+++ b/src/notifications/settings/__tests__/initialization.test.txt
@@ -28,18 +28,10 @@ const EMPTY_INIT_STATE = {
 };
 
 /*
- * We need to mock below three mocks because one of the migrations has imported our redux store
- * which has a lot of module dependencies and firebase which mocks aren't working as they should.
- * We don't want to mock all of them so we mock the used redux and firebase files, since we are not testing them here.
+ * We need to mock firebase below because one of the migrations imports
+ * firebase where mocks aren't working as they should.
+ * We don't want to mock all of them so we mock the firebase file, since we are not testing them here.
  */
-jest.mock('@/redux/explorer', () => ({
-  notificationsSubscription: jest.fn(),
-}));
-
-jest.mock('@/redux/store', () => ({
-  dispatch: jest.fn(),
-}));
-
 jest.mock('@/notifications/settings/firebase');
 
 describe('Notification settings initialization', () => {

--- a/src/notifications/settings/initialization.ts
+++ b/src/notifications/settings/initialization.ts
@@ -13,8 +13,6 @@ import {
   notificationSettingsStorage,
   setAllNotificationSettingsToStorage,
 } from '@/notifications/settings/storage';
-import { notificationsSubscription } from '@/redux/explorer';
-import store from '@/redux/store';
 import {
   subscribeWalletToAllEnabledTopics,
   unsubscribeWalletFromAllNotificationTopics,
@@ -114,7 +112,6 @@ export const _prepareSubscriptionQueueAndCreateInitialSettings = (
   const { alreadySaved, newSettings, subscriptionQueue } = initializationState;
   // preparing list of wallets that need to be subscribed
   addresses.forEach(entry => {
-    store.dispatch(notificationsSubscription(entry.address));
     const alreadySavedEntry = alreadySaved.get(entry.address);
     // handling a case where we import a seed phrase of a previously watched wallet
     if (

--- a/src/redux/explorer.ts
+++ b/src/redux/explorer.ts
@@ -191,31 +191,6 @@ const portfolioSubscription = (
 ];
 
 /**
- * Configures a notifications subscription.
- *
- * @param address The address to subscribe to.
- * @returns Arguments for an `emit` function call.
- */
-export const notificationsSubscription = (address: string) => (
-  _: Dispatch,
-  getState: AppGetState
-) => {
-  const { addressSocket } = getState().explorer;
-
-  const payload: SocketEmitArguments = [
-    'get',
-    {
-      payload: {
-        address,
-        action: 'subscribe',
-      },
-      scope: ['notifications'],
-    },
-  ];
-  addressSocket?.emit(...payload);
-};
-
-/**
  * Configures an asset price subscription.
  *
  * @param tokenAddresses The token addresses to watch.


### PR DESCRIPTION
Fixes APP-887

This PR is NOT a noop. It removes the old websocket subscription we had in redux explorer, which will be replaced with the new functionality in following PRs.

