### PR TITLE
tx sim: error handling for unknown urls

### DIFF
--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -220,9 +220,13 @@ export const SignTransactionSheet = () => {
     null
   );
   const formattedDappUrl = useMemo(() => {
-    const { hostname } = new URL(transactionDetails?.dappUrl);
-    return hostname;
-  }, [transactionDetails?.dappUrl]);
+    try {
+      const { hostname } = new URL(transactionDetails?.dappUrl);
+      return hostname;
+    } catch {
+      return transactionDetails?.dappUrl;
+    }
+  }, [transactionDetails]);
 
   const {
     gasLimit,


### PR DESCRIPTION
Fixes APP-937

## What changed (plus any additional context for devs)
some apps dont have a url in the peerMeta so we fall back to Unknown Dapp which throws and error when trying to create a URL since its invalid

can be repro'd by connecting to hop and trying a tx

## Screen recordings / screenshots


## What to test

