### PR TITLE
wc: handle hex tx types

### DIFF
--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -99,6 +99,7 @@ import {
   estimateGasWithPadding,
   getFlashbotsProvider,
   getProviderForNetwork,
+  isHexString,
   toHex,
 } from '@/handlers/web3';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
@@ -140,6 +141,7 @@ import { RPCMethod } from '@/walletConnect/types';
 import { isAddress } from '@ethersproject/address';
 import { methodRegistryLookupAndParse } from '@/utils/methodRegistry';
 import { sanitizeTypedData } from '@/utils/signingUtils';
+import { hexToNumber, isHex } from 'viem';
 
 const COLLAPSED_CARD_HEIGHT = 56;
 const MAX_CARD_HEIGHT = 176;
@@ -262,6 +264,9 @@ export const SignTransactionSheet = () => {
   const calculateGasLimit = useCallback(async () => {
     calculatingGasLimit.current = true;
     const txPayload = req;
+    if (isHex(txPayload?.type)) {
+      txPayload.type = hexToNumber(txPayload?.type);
+    }
     // use the default
     let gas = txPayload.gasLimit || txPayload.gas;
 
@@ -281,7 +286,6 @@ export const SignTransactionSheet = () => {
         { gas },
         logger.DebugContext.walletconnect
       );
-
       // safety precaution: we want to ensure these properties are not used for gas estimation
       const cleanTxPayload = omitFlatten(txPayload, [
         'gas',
@@ -907,6 +911,9 @@ export const SignTransactionSheet = () => {
         return;
       }
       if (sendInsteadOfSign) {
+        if (isHex(txPayloadUpdated?.type)) {
+          txPayloadUpdated.type = hexToNumber(txPayloadUpdated?.type);
+        }
         response = await sendTransaction({
           existingWallet: existingWallet,
           provider,


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Some dapps using ethers are sending us tx types as a hex value but ethers doesn't like this and throws and error: 
https://cloud.skylarbarrera.com/Screen-Shot-2023-11-30-15-39-54.82.png

added handling to convert if we run into them 

## Screen recordings / screenshots


## What to test

