### PR TITLE
Notification migrations (pt 5)

### DIFF
--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@/migrations/types';
 import { deleteImgixMMKVCache } from '@/migrations/migrations/deleteImgixMMKVCache';
 import { migrateNotificationSettingsToV2 } from '@/migrations/migrations/migrateNotificationSettingsToV2';
+import { migrateNotificationSettingsToV3 } from '@/migrations/migrations/migrateNotificationSettingsToV3';
 import { prepareDefaultNotificationGroupSettingsState } from '@/migrations/migrations/prepareDefaultNotificationGroupSettingsState';
 import { changeLanguageKeys } from './migrations/changeLanguageKeys';
 import { fixHiddenUSDC } from './migrations/fixHiddenUSDC';
@@ -36,6 +37,7 @@ const migrations: Migration[] = [
   migrateNotificationSettingsToV2(),
   changeLanguageKeys(),
   fixHiddenUSDC(),
+  migrateNotificationSettingsToV3(),
 ];
 
 /**

--- a/src/migrations/migrations/migrateNotificationSettingsToV3.ts
+++ b/src/migrations/migrations/migrateNotificationSettingsToV3.ts
@@ -1,0 +1,24 @@
+import { Migration, MigrationName } from '@/migrations/types';
+import {
+  getAllNotificationSettingsFromStorage,
+  setAllNotificationSettingsToStorage,
+} from '@/notifications/settings/storage';
+
+export function migrateNotificationSettingsToV3(): Migration {
+  return {
+    name: MigrationName.migrateNotificationSettingsToVersion3,
+    async migrate() {
+      const walletSettings = getAllNotificationSettingsFromStorage();
+
+      // reset successfullyFinishedInitialSubscription
+      if (walletSettings.length) {
+        const newSettings = walletSettings.map(wallet => ({
+          ...wallet,
+          successfullyFinishedInitialSubscription: false,
+        }));
+        setAllNotificationSettingsToStorage(newSettings);
+      }
+      return;
+    },
+  };
+}

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -13,6 +13,7 @@ export enum MigrationName {
   prepareDefaultNotificationGroupSettingsState = 'migration_addDefaultNotificationGroupSettings',
   changeLanguageKeys = 'migration_changeLanguageKeys',
   fixHiddenUSDC = 'migration_fixHiddenUSDC',
+  migrateNotificationSettingsToVersion3 = 'migration_migrateNotificationSettingsToVersion3',
 }
 
 export type Migration = {


### PR DESCRIPTION
Fixes APP-887

This migrates existing users to the new notifications endpoint by resetting the flag that determines if the settings state has been synced up