### PR TITLE
[APP-883]: Fix scroll issue on discover search

### DIFF
--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -64,7 +64,7 @@ const animationConfig = {
 
 const Swipe = createMaterialTopTabNavigator();
 
-const getHeaderHeight = () => {
+export const getHeaderHeight = () => {
   if (IS_IOS) {
     return 82;
   }

--- a/src/screens/discover/components/DiscoverSearch.js
+++ b/src/screens/discover/components/DiscoverSearch.js
@@ -38,6 +38,7 @@ import {
   getPoapAndOpenSheetWithSecretWord,
 } from '@/utils/poaps';
 import { navigateToMintCollection } from '@/resources/reservoir/mints';
+import { getHeaderHeight } from '@/navigation/SwipeNavigator';
 
 export const SearchContainer = styled(Row)({
   height: '100%',
@@ -61,6 +62,7 @@ export default function DiscoverSearch() {
 
   const { colors } = useTheme();
   const profilesEnabled = useExperimentalFlag(PROFILES);
+  const marginBottom = useMemo(() => getHeaderHeight(), []);
 
   const currencySelectionListRef = useRef();
   const [searchQueryForSearch] = useDebounce(searchQuery, 350);
@@ -277,7 +279,7 @@ export default function DiscoverSearch() {
   return (
     <View
       key={currencyListDataKey}
-      style={{ height: deviceUtils.dimensions.height - 140 }}
+      style={{ height: deviceUtils.dimensions.height - 140 - marginBottom }}
     >
       <SearchContainer>
         <CurrencySelectionList


### PR DESCRIPTION
Fixes APP-883

## What changed (plus any additional context for devs)
Fixes the height issue on the search component not accounting for the newly added bottom tab bar

## Screen recordings / screenshots
https://github.com/rainbow-me/rainbow/assets/6284525/b7d1bdc9-8a3e-4699-9414-363d126207fb



## What to test
- [ ] can you scroll to bottom of the search container?