### PR TITLE
Points: Fix total points not updating when switching wallets [ANDROID]

### DIFF
--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -157,6 +157,7 @@ export default function PointsContent() {
                         height: 51,
                         maxWidth: deviceWidth - 60 - 20 - 20,
                       }}
+                      androidRenderingMode="software"
                       maskElement={
                         <Box paddingVertical="10px">
                           <Text color="label" size="44pt" weight="black">


### PR DESCRIPTION
Fixes APP-993

## What changed (plus any additional context for devs)
Apparently the `maskElement` prop of `MaskedView` does not rerender on android unless the `androidRenderingMode` prop is set to `"software"`. This was causing the total points display to not _immediately_ update when switching wallets. If you switch tabs and return to the points tab, it displays the correct amount.

see: https://github.com/react-native-masked-view/masked-view/issues/132

## Screen recordings / screenshots
https://www.loom.com/share/4aae0f4d260f41ffadb53cabc9038d24

## What to test

