### PR TITLE
swaps: revert entry point

### DIFF
--- a/src/components/sheet/sheet-action-buttons/SwapActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SwapActionButton.js
@@ -33,41 +33,24 @@ function SwapActionButton({
       if (params.outputAsset) {
         return {
           params: {
-            chainId: ethereumUtils.getChainIdFromType(asset.type),
             defaultOutputAsset: asset,
-            fromDiscover: true,
-            onSelectCurrency: updateInputCurrency,
             params: {
-              ...params,
-              ignoreInitialTypeCheck: true,
               outputAsset: asset,
             },
-            showCoinIcon: true,
-            title: lang.t('swap.modal_types.get_symbol_with', {
-              symbol: params?.outputAsset?.symbol,
-            }),
-            type: CurrencySelectionTypes.input,
           },
-          screen: Routes.CURRENCY_SELECT_SCREEN,
+          screen: Routes.MAIN_EXCHANGE_SCREEN,
         };
       } else {
+        console.log(asset);
         return {
           params: {
-            chainId: ethereumUtils.getChainIdFromType(asset.type),
             defaultInputAsset: asset,
-            onSelectCurrency: updateOutputCurrency,
-            params: {
-              ...params,
-              ignoreInitialTypeCheck: true,
-            },
-            title: lang.t('swap.modal_types.receive'),
-            type: CurrencySelectionTypes.output,
           },
-          screen: Routes.CURRENCY_SELECT_SCREEN,
+          screen: Routes.MAIN_EXCHANGE_SCREEN,
         };
       }
     });
-  }, [asset, navigate, updateInputCurrency, updateOutputCurrency]);
+  }, [asset, navigate]);
 
   return (
     <SheetActionButton

--- a/src/screens/ExchangeModal.tsx
+++ b/src/screens/ExchangeModal.tsx
@@ -274,6 +274,7 @@ export default function ExchangeModal({
     crosschainSwapsEnabled,
     inputCurrency?.symbol,
     inputCurrency?.type,
+    network,
     outputCurrency?.symbol,
     outputCurrency?.type,
   ]);


### PR DESCRIPTION
Fixes APP-956 APP-954

## What changed (plus any additional context for devs)
changes the swap entry point to be the main swap screen instead of the currency select modal 

3 cases -> swap button, swap existing asset, swap to a new asset(discover)

added subtitle only to the receive current select list as well

## Screen recordings / screenshots


https://cloud.skylarbarrera.com/Screen-Recording-2023-12-12-15-00-55.mp4


## What to test
 cases
