### PR TITLE
Points: some number formatting

### DIFF
--- a/src/screens/points/constants.ts
+++ b/src/screens/points/constants.ts
@@ -92,9 +92,13 @@ export const buildTwitterIntentMessage = (
     const rainbows = RAINBOWS_STRING_GENERATOR(3);
 
     let text = rainbows;
-    text += `\n\nI just had ${
+    text += `\n\nI just had ${(
       ONBOARDING_TOTAL_POINTS - METAMASK_POINTS
-    } Rainbow Points dropped into my wallet — plus an extra ${METAMASK_POINTS} Points as a bonus for migrating my MetaMask wallet into Rainbow 🦊 🔫\n\nEverybody has at least 100 points waiting for them, but you might have more! Claim your drop: https://rainbow.me/points?ref=${referralCode}\n\n`;
+    ).toLocaleString(
+      'en-US'
+    )} Rainbow Points dropped into my wallet — plus an extra ${METAMASK_POINTS.toLocaleString(
+      'en-US'
+    )} Points as a bonus for migrating my MetaMask wallet into Rainbow 🦊 🔫\n\nEverybody has at least 100 points waiting for them, but you might have more! Claim your drop: https://rainbow.me/points?ref=${referralCode}\n\n`;
     text += rainbows;
 
     return BASE_URL + text;
@@ -103,7 +107,9 @@ export const buildTwitterIntentMessage = (
   const rainbows = RAINBOWS_STRING_GENERATOR(17);
 
   let text = rainbows;
-  text += `\n\nI just had ${ONBOARDING_TOTAL_POINTS} Rainbow Points dropped into my wallet — everybody has at least 100 points waiting for them, but you might have more!\n\nClaim your drop: https://rainbow.me/points?ref=${referralCode}\n\n`;
+  text += `\n\nI just had ${ONBOARDING_TOTAL_POINTS.toLocaleString(
+    'en-US'
+  )} Rainbow Points dropped into my wallet — everybody has at least 100 points waiting for them, but you might have more!\n\nClaim your drop: https://rainbow.me/points?ref=${referralCode}\n\n`;
   text += rainbows;
 
   return BASE_URL + text;

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -231,7 +231,9 @@ export default function PointsContent() {
                     <InfoCard
                       // onPress={() => {}}
                       title={i18n.t(i18n.l.points.points.your_rank)}
-                      mainText={`#${data?.points?.user?.stats?.position?.current}`}
+                      mainText={`#${data?.points?.user?.stats?.position?.current.toLocaleString(
+                        'en-US'
+                      )}`}
                       icon="􀉬"
                       subtitle={i18n.t(i18n.l.points.points.out_of_x, {
                         totalUsers: (data?.points?.leaderboard?.stats


### PR DESCRIPTION
Fixes APP-1006, APP-999

## What changed (plus any additional context for devs)
- add commas to rank card rank in points tab
- add commas to # of pts distributed in tweet intent

## Screen recordings / screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-12-12 at 17 04 03](https://github.com/rainbow-me/rainbow/assets/15272675/1d45e2b8-8c32-4135-994b-e7fa991c541c)
![Simulator Screenshot - iPhone 14 Pro - 2023-12-12 at 16 56 18](https://github.com/rainbow-me/rainbow/assets/15272675/51624233-d9be-47a4-b0cb-c62eff394933)

## What to test

