### PR TITLE
Points: Fix onboarding error

### DIFF
--- a/src/screens/points/contexts/PointsProfileContext.tsx
+++ b/src/screens/points/contexts/PointsProfileContext.tsx
@@ -24,7 +24,7 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 
 import { metadataPOSTClient } from '@/graphql';
 import { useAccountProfile, useWallets } from '@/hooks';
-import { signPersonalMessage } from '@/model/wallet';
+import { loadWallet, signPersonalMessage } from '@/model/wallet';
 import { RainbowError, logger } from '@/logger';
 import { queryClient } from '@/react-query';
 import { useNavigation } from '@/navigation';
@@ -166,9 +166,10 @@ export const PointsProfileProvider = ({
     const challenge = challengeResponse?.pointsOnboardChallenge;
     if (challenge) {
       const provider = await getProviderForNetwork(Network.mainnet);
+      const wallet = await loadWallet(accountAddress, true, provider);
       const signatureResponse = await signPersonalMessage(
         challenge,
-        undefined,
+        wallet,
         provider
       );
       if (signatureResponse && isHardwareWallet) {


### PR DESCRIPTION
Fixes APP-1001

## What changed (plus any additional context for devs)
When the user signs in, `signPersonalMessage` is called. This function calls `loadWallet` which calls `loadAddress`. The error was occurring because `loadAddress` was loading the wrong address. I investigated this, but wasn't able to get to the bottom of it. To circumvent this issue, the user's `accountAddress` (which is correct) is now passed into a call to `loadWallet` which is passed into `signPersonalMessage`.

Ticket for overarching issue:
https://linear.app/rainbow/issue/APP-1010/loadaddress-may-return-wrong-address-after-wallet-creation

## Screen recordings / screenshots
https://www.loom.com/share/02f23fa6cfcc4d7e82617ec903dd26cb

## What to test
To repro on `develop`:
1. switch to a watched wallet
2. create a new wallet
3. onboard to points
4. error should occur when signing in
