### PR TITLE
[APP-998]: Fix for leaderboard formatting issue

### DIFF
--- a/src/screens/points/components/LeaderboardRow.tsx
+++ b/src/screens/points/components/LeaderboardRow.tsx
@@ -233,7 +233,7 @@ export const LeaderboardRow = ({
             />
           )}
           <Stack space="8px">
-            <Box style={{ maxWidth: 145 }}>
+            <Box style={{ maxWidth: rank <= 3 ? 120 : 140 }}>
               <Text
                 color="label"
                 weight="bold"
@@ -244,14 +244,6 @@ export const LeaderboardRow = ({
                 {ens ? ens : formattedAddress}
               </Text>
             </Box>
-            {/* <Inline space="2px" alignVertical="center">
-              <Text color="labelQuaternary" size="11pt" weight="bold">
-                􀙬
-              </Text>
-              <Text color="labelQuaternary" size="13pt" weight="semibold">
-                {`40 ${i18n.t(i18n.l.points.points.days)}`}
-              </Text>
-            </Inline> */}
           </Stack>
         </Inline>
         <Inline space="8px" alignVertical="center">


### PR DESCRIPTION
Fixes APP-998

## What changed (plus any additional context for devs)
- just had to change the max width on the ens name to account for mask view on rank 3 and below

## Screen recordings / screenshots


## What to test

