### PR TITLE
Points: Tweak rank card formatting

### DIFF
--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -274,7 +274,7 @@ export const abbreviateBigNumber = (
  * Abbreviates number like 1,200,000 to "1.2m", 1,000 to "1k", etc.
  * Rounds to 1 decimal place, stripping trailing zeros.
  */
-export const abbreviateNumber = (number: number): string => {
+export const abbreviateNumber = (number: number, decimals = 1): string => {
   let prefix = number;
   let suffix = '';
   if (number >= 1_000_000_000) {
@@ -287,7 +287,7 @@ export const abbreviateNumber = (number: number): string => {
     prefix = number / 1000;
     suffix = 'k';
   }
-  return prefix.toFixed(1).replace(/\.0$/, '') + suffix;
+  return prefix.toFixed(decimals).replace(/\.0$/, '') + suffix;
 };
 
 export const handleSignificantDecimals = (

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -110,15 +110,15 @@ export default function PointsContent() {
   );
   const totalPointsMaskSize = 60 * Math.max(totalPointsString?.length ?? 0, 4);
 
-  const totalUsers = data?.points?.leaderboard?.stats?.total_users;
-  const rank = data?.points?.user?.stats?.position.current;
+  const totalUsers = data?.points?.leaderboard.stats.total_users;
+  const rank = data?.points?.user.stats.position.current;
 
-  const canDisplayTotalPoints = !isNil(data?.points?.user?.earnings?.total);
+  const canDisplayTotalPoints = !isNil(data?.points?.user.earnings.total);
   const canDisplayNextRewardCard = !isNil(nextDistributionSeconds);
   const canDisplayCurrentRank = !!rank;
   const canDisplayRankCard = canDisplayCurrentRank && !!totalUsers;
 
-  const canDisplayLeaderboard = !!data?.points?.leaderboard?.accounts;
+  const canDisplayLeaderboard = !!data?.points?.leaderboard.accounts;
 
   const shouldDisplayError = !isFetching && !data?.points;
 

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -28,7 +28,10 @@ import { useRecoilState } from 'recoil';
 import * as i18n from '@/languages';
 import { usePoints } from '@/resources/points';
 import { isNil } from 'lodash';
-import { getFormattedTimeQuantity } from '@/helpers/utilities';
+import {
+  abbreviateNumber,
+  getFormattedTimeQuantity,
+} from '@/helpers/utilities';
 import { address as formatAddress } from '@/utils/abbreviations';
 import { delay } from '@/utils/delay';
 import { Toast, ToastPositionContainer } from '@/components/toasts';
@@ -107,11 +110,13 @@ export default function PointsContent() {
   );
   const totalPointsMaskSize = 60 * Math.max(totalPointsString?.length ?? 0, 4);
 
+  const totalUsers = data?.points?.leaderboard?.stats?.total_users;
+  const rank = data?.points?.user?.stats?.position.current;
+
   const canDisplayTotalPoints = !isNil(data?.points?.user?.earnings?.total);
   const canDisplayNextRewardCard = !isNil(nextDistributionSeconds);
-  const canDisplayCurrentRank = !!data?.points?.user?.stats?.position.current;
-  const canDisplayRankCard =
-    canDisplayCurrentRank && !!data?.points?.leaderboard?.stats?.total_users;
+  const canDisplayCurrentRank = !!rank;
+  const canDisplayRankCard = canDisplayCurrentRank && !!totalUsers;
 
   const canDisplayLeaderboard = !!data?.points?.leaderboard?.accounts;
 
@@ -231,11 +236,17 @@ export default function PointsContent() {
                     <InfoCard
                       // onPress={() => {}}
                       title={i18n.t(i18n.l.points.points.your_rank)}
-                      mainText={`#${data?.points?.user?.stats?.position?.current}`}
+                      mainText={`#${
+                        rank >= 1_000_000
+                          ? abbreviateNumber(rank, 2)
+                          : rank.toLocaleString('en-US')
+                      }`}
                       icon="􀉬"
                       subtitle={i18n.t(i18n.l.points.points.out_of_x, {
-                        totalUsers: (data?.points?.leaderboard?.stats
-                          ?.total_users as number).toLocaleString('en-US'),
+                        totalUsers:
+                          totalUsers >= 1_000_000
+                            ? abbreviateNumber(totalUsers, 2)
+                            : totalUsers.toLocaleString('en-US'),
                       })}
                       accentColor={green}
                     />
@@ -451,9 +462,7 @@ export default function PointsContent() {
                         </Text>
                       </Box>
                       <Text color="label" size="17pt" weight="heavy">
-                        {`#${data?.points?.user?.stats?.position.current.toLocaleString(
-                          'en-US'
-                        )}`}
+                        {`#${rank.toLocaleString('en-US')}`}
                       </Text>
                     </Box>
                   </Box>


### PR DESCRIPTION
Fixes APP-1015

## What changed (plus any additional context for devs)
abbreviate total users and rank (in rank card only) if x >= 1,000,000

ex. 1,234,567 => 1.23m

## Screen recordings / screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-12-13 at 22 02 43](https://github.com/rainbow-me/rainbow/assets/15272675/579259c2-820d-475b-8aa2-c30d9c7a79c0)


## What to test

