### PR TITLE
Points: format large numbers in rank card

### DIFF
--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1253,7 +1253,7 @@
         "share_link": "Share Link",
         "next_drop": "Next Drop",
         "your_rank": "Your Rank",
-        "out_of_x": "Out of %{totalUsers}",
+        "of_x": "Of %{totalUsers}",
         "referrals": "Referrals",
         "streak": "Streak",
         "longest_yet": "Longest yet",

--- a/src/screens/points/components/InfoCard.tsx
+++ b/src/screens/points/components/InfoCard.tsx
@@ -14,7 +14,7 @@ export const InfoCard = ({
   title: string;
   subtitle: string;
   mainText: string;
-  icon: string;
+  icon?: string;
   accentColor: string;
 }) => {
   let mainTextFontSize: TextSize;
@@ -50,14 +50,16 @@ export const InfoCard = ({
           </Text>
         </Box>
         <Inline space="4px">
-          <Text
-            align="center"
-            weight="heavy"
-            size="12pt"
-            color={{ custom: accentColor }}
-          >
-            {icon}
-          </Text>
+          {icon && (
+            <Text
+              align="center"
+              weight="heavy"
+              size="12pt"
+              color={{ custom: accentColor }}
+            >
+              {icon}
+            </Text>
+          )}
           <Text weight="heavy" size="13pt" color={{ custom: accentColor }}>
             {subtitle}
           </Text>

--- a/src/screens/points/components/InfoCard.tsx
+++ b/src/screens/points/components/InfoCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Inline, Stack, Text } from '@/design-system';
+import { TextSize } from '@/design-system/components/Text/Text';
 
 export const InfoCard = ({
   // onPress,
@@ -15,41 +16,54 @@ export const InfoCard = ({
   mainText: string;
   icon: string;
   accentColor: string;
-}) => (
-  // <ButtonPressAnimation onPress={onPress} overflowMargin={50}>
-  <Box
-    padding="20px"
-    background="surfaceSecondaryElevated"
-    shadow="12px"
-    height={{ custom: 98 }}
-    borderRadius={18}
-  >
-    <Stack space="12px">
-      {/* <Inline space="4px" alignVertical="center"> */}
-      <Text color="labelSecondary" weight="bold" size="15pt">
-        {title}
-      </Text>
-      {/* <Text color="labelQuaternary" weight="heavy" size="13pt">
+}) => {
+  let mainTextFontSize: TextSize;
+  if (mainText.length > 10) {
+    mainTextFontSize = '17pt';
+  } else if (mainText.length > 9) {
+    mainTextFontSize = '20pt';
+  } else {
+    mainTextFontSize = '22pt';
+  }
+
+  return (
+    // <ButtonPressAnimation onPress={onPress} overflowMargin={50}>
+    <Box
+      padding="20px"
+      background="surfaceSecondaryElevated"
+      shadow="12px"
+      height={{ custom: 98 }}
+      borderRadius={18}
+    >
+      <Stack space="12px">
+        {/* <Inline space="4px" alignVertical="center"> */}
+        <Text color="labelSecondary" weight="bold" size="15pt">
+          {title}
+        </Text>
+        {/* <Text color="labelQuaternary" weight="heavy" size="13pt">
             􀅵
           </Text>
         </Inline> */}
-      <Text color="label" weight="heavy" size="22pt">
-        {mainText}
-      </Text>
-      <Inline space="4px">
-        <Text
-          align="center"
-          weight="heavy"
-          size="12pt"
-          color={{ custom: accentColor }}
-        >
-          {icon}
-        </Text>
-        <Text weight="heavy" size="13pt" color={{ custom: accentColor }}>
-          {subtitle}
-        </Text>
-      </Inline>
-    </Stack>
-  </Box>
-  // </ButtonPressAnimation>
-);
+        <Box height={{ custom: 15 }} justifyContent="flex-end">
+          <Text color="label" weight="heavy" size={mainTextFontSize}>
+            {mainText}
+          </Text>
+        </Box>
+        <Inline space="4px">
+          <Text
+            align="center"
+            weight="heavy"
+            size="12pt"
+            color={{ custom: accentColor }}
+          >
+            {icon}
+          </Text>
+          <Text weight="heavy" size="13pt" color={{ custom: accentColor }}>
+            {subtitle}
+          </Text>
+        </Inline>
+      </Stack>
+    </Box>
+    // </ButtonPressAnimation>
+  );
+};

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -33,10 +33,7 @@ import { useRecoilState } from 'recoil';
 import * as i18n from '@/languages';
 import { usePoints } from '@/resources/points';
 import { isNil } from 'lodash';
-import {
-  abbreviateNumber,
-  getFormattedTimeQuantity,
-} from '@/helpers/utilities';
+import { getFormattedTimeQuantity } from '@/helpers/utilities';
 import { address as formatAddress } from '@/utils/abbreviations';
 import { delay } from '@/utils/delay';
 import { Toast, ToastPositionContainer } from '@/components/toasts';
@@ -244,17 +241,10 @@ export default function PointsContent() {
                     <InfoCard
                       // onPress={() => {}}
                       title={i18n.t(i18n.l.points.points.your_rank)}
-                      mainText={`#${
-                        rank >= 1_000_000
-                          ? abbreviateNumber(rank, 2)
-                          : rank.toLocaleString('en-US')
-                      }`}
+                      mainText={`#${rank.toLocaleString('en-US')}`}
                       icon="􀉬"
                       subtitle={i18n.t(i18n.l.points.points.out_of_x, {
-                        totalUsers:
-                          totalUsers >= 1_000_000
-                            ? abbreviateNumber(totalUsers, 2)
-                            : totalUsers.toLocaleString('en-US'),
+                        totalUsers: totalUsers.toLocaleString('en-US'),
                       })}
                       accentColor={green}
                     />

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -25,7 +25,7 @@ import MaskedView from '@react-native-masked-view/masked-view';
 import BlurredRainbow from '@/assets/blurredRainbow.png';
 import Planet from '@/assets/planet.png';
 import LinearGradient from 'react-native-linear-gradient';
-import { safeAreaInsetValues } from '@/utils';
+import { deviceUtils, safeAreaInsetValues } from '@/utils';
 import { ButtonPressAnimation } from '@/components/animations';
 import { getHeaderHeight } from '@/navigation/SwipeNavigator';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
@@ -242,7 +242,11 @@ export default function PointsContent() {
                       // onPress={() => {}}
                       title={i18n.t(i18n.l.points.points.your_rank)}
                       mainText={`#${rank.toLocaleString('en-US')}`}
-                      icon="􀉬"
+                      icon={
+                        totalUsers >= 10_000_000 && deviceUtils.isSmallPhone
+                          ? undefined
+                          : '􀉬'
+                      }
                       subtitle={i18n.t(i18n.l.points.points.of_x, {
                         totalUsers: totalUsers.toLocaleString('en-US'),
                       })}

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -243,7 +243,7 @@ export default function PointsContent() {
                       title={i18n.t(i18n.l.points.points.your_rank)}
                       mainText={`#${rank.toLocaleString('en-US')}`}
                       icon="􀉬"
-                      subtitle={i18n.t(i18n.l.points.points.out_of_x, {
+                      subtitle={i18n.t(i18n.l.points.points.of_x, {
                         totalUsers: totalUsers.toLocaleString('en-US'),
                       })}
                       accentColor={green}


### PR DESCRIPTION
Fixes APP-1017

## What changed (plus any additional context for devs)
* change "out of" to "of"
* if small phone, don't show icon if 8 fig total users
* for user rank:
  * if 8 figs, size = "17pt"
  * if 7 figs, size = "20pt"
  * else, size = "22pt"

## Screen recordings / screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-12-14 at 10 37 47](https://github.com/rainbow-me/rainbow/assets/15272675/2623e34c-0192-4d0f-b984-6eeec86bda3c)
![Simulator Screenshot - iPhone 14 Pro - 2023-12-14 at 10 38 33](https://github.com/rainbow-me/rainbow/assets/15272675/10444555-434a-4cb3-8ca4-952e309197c5)
![Simulator Screenshot - iPhone 14 Pro - 2023-12-14 at 10 39 05](https://github.com/rainbow-me/rainbow/assets/15272675/b4758ad6-5a8e-444c-a5ee-bd588f999ac7)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-12-14 at 11 03 57](https://github.com/rainbow-me/rainbow/assets/15272675/e3e1d5c1-a5c3-424c-9be7-7cf786692fe6)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-12-14 at 11 04 15](https://github.com/rainbow-me/rainbow/assets/15272675/78a57495-85da-45a0-9ed5-32774fcca7e2)


## What to test

