### PR TITLE
fix haptics null issue

### DIFF
--- a/src/screens/points/constants.ts
+++ b/src/screens/points/constants.ts
@@ -73,7 +73,7 @@ export const generateRainbowColors = (
 };
 
 export const triggerHapticFeedback = (hapticType: HapticFeedbackType) =>
-  ReactNativeHapticFeedback.trigger(hapticType);
+  ReactNativeHapticFeedback?.trigger(hapticType);
 
 const BASE_URL = `https://twitter.com/intent/tweet?text=`;
 const NEWLINE_OR_SPACE = IS_IOS ? '\n\n' : ' ';


### PR DESCRIPTION
https://rainbow-me.sentry.io/issues/4709955399/?project=1855565&query=is:unresolved&statsPeriod=7d&stream_index=0

Fixes `TypeError: Cannot read property 'trigger' of null` flooding our Sentry logs.