### PR TITLE
fix navbar not being transparent on android gesture mode

### DIFF
--- a/src/helpers/statusBarHelper.ts
+++ b/src/helpers/statusBarHelper.ts
@@ -45,5 +45,5 @@ export const isUsingButtonNavigation = () => {
   const deviceHeight = Dimensions.get('screen').height;
   const windowHeight = Dimensions.get('window').height;
   const bottomNavBarHeight = deviceHeight - windowHeight;
-  return bottomNavBarHeight > 24;
+  return bottomNavBarHeight > 70;
 };


### PR DESCRIPTION
Android navigation bar was set to match the theme color in gesture mode which made all pop-up sheets contain (most of the time) the wrong color. This sets it to transparent if using the gesture mode which should use the color of the background of whatever sheet is underneath it.