### PR TITLE
NFT sort cleanup

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/WrappedCollectiblesHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedCollectiblesHeader.tsx
@@ -1,73 +1,69 @@
 import React from 'react';
 import { Box, Inline, Text } from '@/design-system';
 import * as i18n from '@/languages';
-
 import { ListHeaderMenu } from '@/components/list/ListHeaderMenu';
-
 import useNftSort, { CollectibleSortByOptions } from '@/hooks/useNFTsSortBy';
 
-const TokenFamilyHeaderHeight = 44;
+const TokenFamilyHeaderHeight = 48;
+
+const getIconForSortType = (selected: string) => {
+  switch (selected) {
+    case CollectibleSortByOptions.ABC:
+      return '􀋲';
+    case CollectibleSortByOptions.FLOOR_PRICE:
+      return '􀅺';
+    case CollectibleSortByOptions.MOST_RECENT:
+      return '􀐫';
+  }
+  return '';
+};
+
+const getMenuItemIcon = (value: CollectibleSortByOptions) => {
+  switch (value) {
+    case CollectibleSortByOptions.ABC:
+      return 'list.bullet';
+    case CollectibleSortByOptions.FLOOR_PRICE:
+      return 'plus.forwardslash.minus';
+    case CollectibleSortByOptions.MOST_RECENT:
+      return 'clock';
+  }
+  return '';
+};
 
 const CollectiblesHeader = () => {
   const { nftSort, updateNFTSort } = useNftSort();
-
-  const getIconForSortType = (selected: string) => {
-    switch (selected) {
-      case CollectibleSortByOptions.ABC:
-        return '􀋲';
-      case CollectibleSortByOptions.FLOOR_PRICE:
-        return '􀅺';
-      case CollectibleSortByOptions.MOST_RECENT:
-        return '􀐫';
-    }
-    return '';
-  };
-
-  const getMenuItemIcon = (value: CollectibleSortByOptions) => {
-    switch (value) {
-      case CollectibleSortByOptions.ABC:
-        return 'list.bullet';
-      case CollectibleSortByOptions.FLOOR_PRICE:
-        return 'plus.forwardslash.minus';
-      case CollectibleSortByOptions.MOST_RECENT:
-        return 'clock';
-    }
-    return '';
-  };
   return (
-    <>
-      <Box
-        height={{ custom: TokenFamilyHeaderHeight }}
-        paddingHorizontal={'19px (Deprecated)'}
-        justifyContent="center"
-        key={`collectibles_${nftSort}`}
-        testID={`collectibles-list-header`}
-      >
-        <Inline alignHorizontal="justify">
-          <Text size="22pt" color={'label'} weight="heavy">
-            {i18n.t(i18n.l.account.tab_collectibles)}
-          </Text>
+    <Box
+      height={{ custom: TokenFamilyHeaderHeight }}
+      paddingBottom="2px"
+      paddingHorizontal={'19px (Deprecated)'}
+      justifyContent="flex-end"
+      key={`collectibles_${nftSort}`}
+      testID={`collectibles-list-header`}
+    >
+      <Inline alignHorizontal="justify" alignVertical="center">
+        <Text size="22pt" color={'label'} weight="heavy">
+          {i18n.t(i18n.l.account.tab_collectibles)}
+        </Text>
 
-          <ListHeaderMenu
-            selected={nftSort}
-            menuItems={Object.entries(CollectibleSortByOptions).map(
-              ([key, value]) => ({
-                actionKey: value,
-                actionTitle: i18n.t(i18n.l.nfts.sort[value]),
-                icon: { iconType: 'SYSTEM', iconValue: getMenuItemIcon(value) },
-                menuState: nftSort === key ? 'on' : 'off',
-              })
-            )}
-            selectItem={string =>
-              updateNFTSort(string as CollectibleSortByOptions)
-            }
-            text={`${getIconForSortType(nftSort)} ${i18n.t(
-              i18n.l.nfts.sort[nftSort]
-            )}`}
-          />
-        </Inline>
-      </Box>
-    </>
+        <ListHeaderMenu
+          selected={nftSort}
+          menuItems={Object.entries(CollectibleSortByOptions).map(
+            ([key, value]) => ({
+              actionKey: value,
+              actionTitle: i18n.t(i18n.l.nfts.sort[value]),
+              icon: { iconType: 'SYSTEM', iconValue: getMenuItemIcon(value) },
+              menuState: nftSort === key ? 'on' : 'off',
+            })
+          )}
+          selectItem={string =>
+            updateNFTSort(string as CollectibleSortByOptions)
+          }
+          icon={getIconForSortType(nftSort)}
+          text={i18n.t(i18n.l.nfts.sort[nftSort])}
+        />
+      </Inline>
+    </Box>
   );
 };
 

--- a/src/components/asset-list/RecyclerAssetList2/WrappedPositionsListHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedPositionsListHeader.tsx
@@ -10,7 +10,7 @@ import * as i18n from '@/languages';
 const AnimatedImgixImage = Animated.createAnimatedComponent(Image);
 
 const TokenFamilyHeaderAnimationDuration = 200;
-const TokenFamilyHeaderHeight = 44;
+const TokenFamilyHeaderHeight = 48;
 
 const PositionListHeader = ({ total, ...props }: { total: string }) => {
   const { colors } = useTheme();

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -241,15 +241,6 @@ const getIsSupportedOnRainbowWeb = (network: Network) => {
   }
 };
 
-const getIsSaleInfoSupported = (network: Network) => {
-  switch (network) {
-    case Network.mainnet:
-      return true;
-    default:
-      return false;
-  }
-};
-
 const UniqueTokenExpandedState = ({
   asset,
   external,
@@ -649,7 +640,7 @@ const UniqueTokenExpandedState = ({
                       separator={<Separator color="divider20 (Deprecated)" />}
                       space={sectionSpace}
                     >
-                      {(isNFT || isENS) && isSaleInfoSupported ? (
+                      {isNFT || isENS ? (
                         <Bleed // Manually crop surrounding space until TokenInfoItem uses design system components
                           bottom={android ? '15px (Deprecated)' : '6px'}
                           top={android ? '10px' : '4px'}

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -455,7 +455,6 @@ const UniqueTokenExpandedState = ({
   );
 
   const hideNftMarketplaceAction = isPoap || !slug;
-  const isSaleInfoSupported = getIsSaleInfoSupported(asset.network);
 
   return (
     <>

--- a/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
+++ b/src/components/expanded-state/unique-token/NFTBriefTokenInfoRow.tsx
@@ -43,14 +43,22 @@ export default function NFTBriefTokenInfoRow({
 
   useEffect(() => {
     const fetchFloorPrice = async () => {
-      const result = await fetchReservoirNFTFloorPrice(asset);
-      if (result) {
-        setFloorPrice(result);
-      } else {
-        setFloorPrice(formatPrice(asset?.floorPriceEth, 'ETH'));
+      try {
+        const result = await fetchReservoirNFTFloorPrice(asset);
+        if (result !== undefined) {
+          setFloorPrice(result);
+        } else {
+          setFloorPrice(NONE);
+        }
+      } catch (error) {
+        setFloorPrice(NONE);
       }
     };
-    fetchFloorPrice();
+    if (asset?.floorPriceEth) {
+      setFloorPrice(formatPrice(asset?.floorPriceEth, 'ETH'));
+    } else {
+      fetchFloorPrice();
+    }
   }, [asset]);
 
   const { data: listing } = useNFTListing({

--- a/src/components/list/ListHeader.js
+++ b/src/components/list/ListHeader.js
@@ -20,7 +20,7 @@ import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import * as i18n from '@/languages';
 
-export const ListHeaderHeight = 50;
+export const ListHeaderHeight = 48;
 
 const ShareCollectiblesBPA = styled(ButtonPressAnimation)({
   backgroundColor: ({ theme: { colors } }) =>

--- a/src/components/list/ListHeaderMenu.tsx
+++ b/src/components/list/ListHeaderMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { ButtonPressAnimation } from '@/components/animations';
-import { Inline, Inset, Text } from '@/design-system';
+import { Bleed, Box, Inline, Text, useForegroundColor } from '@/design-system';
 import { haptics } from '@/utils';
 import { CollectibleSortByOptions } from '@/hooks/useNFTsSortBy';
 
@@ -15,14 +15,18 @@ type ListHeaderMenuProps = {
   selected: CollectibleSortByOptions;
   menuItems: MenuItem[];
   selectItem: (item: string) => void;
+  icon: string;
   text: string;
 };
 
 export function ListHeaderMenu({
   menuItems,
   selectItem,
+  icon,
   text,
 }: ListHeaderMenuProps) {
+  const separatorTertiary = useForegroundColor('separatorTertiary');
+
   const menuConfig = {
     menuTitle: '',
     menuItems: menuItems,
@@ -38,24 +42,51 @@ export function ListHeaderMenu({
   };
 
   return (
-    <ContextMenuButton
-      menuConfig={menuConfig}
-      onPressMenuItem={onPressMenuItem}
-    >
-      <ButtonPressAnimation>
-        <Inset top="2px">
-          <Inline alignVertical="center" space={{ custom: 5 }}>
-            <Inline alignVertical="center" horizontalSpace={'2px'}>
-              <Text color="label" size="17pt" weight="semibold">
-                {text}
-              </Text>
-              <Text color="label" size="15pt" weight="semibold">
-                􀆈
-              </Text>
-            </Inline>
-          </Inline>
-        </Inset>
-      </ButtonPressAnimation>
-    </ContextMenuButton>
+    <Bleed space="10px">
+      <ContextMenuButton
+        menuConfig={menuConfig}
+        onPressMenuItem={onPressMenuItem}
+      >
+        <ButtonPressAnimation style={{ padding: 10 }}>
+          <Bleed bottom="2px">
+            <Box
+              alignItems="center"
+              borderRadius={15}
+              height={{ custom: 30 }}
+              justifyContent="center"
+              paddingHorizontal="8px"
+              style={{ borderColor: separatorTertiary, borderWidth: 1.5 }}
+            >
+              <Inline alignVertical="center" space={{ custom: 5 }} wrap={false}>
+                <Text
+                  align="center"
+                  color="labelQuaternary"
+                  size="icon 13px"
+                  weight="bold"
+                >
+                  {icon}
+                </Text>
+                <Text
+                  align="center"
+                  color="labelTertiary"
+                  size="15pt"
+                  weight="bold"
+                >
+                  {text}
+                </Text>
+                <Text
+                  align="center"
+                  color="labelQuaternary"
+                  size="icon 13px"
+                  weight="bold"
+                >
+                  􀆏
+                </Text>
+              </Inline>
+            </Box>
+          </Bleed>
+        </ButtonPressAnimation>
+      </ContextMenuButton>
+    </Bleed>
   );
 }

--- a/src/handlers/ens.ts
+++ b/src/handlers/ens.ts
@@ -68,6 +68,7 @@ const buildEnsToken = ({
     mimeType: MimeType.SVG,
   });
   return {
+    acquisition_date: undefined,
     animation_url: null,
     asset_contract: {
       address: contractAddress,

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -309,7 +309,7 @@ export const buildBriefUniqueTokenList = (
   hiddenTokens: string[] = [],
   listType: AssetListType = 'wallet',
   isReadOnlyWallet = false,
-  nftSort: string
+  nftSort: string = CollectibleSortByOptions.MOST_RECENT
 ) => {
   const hiddenUniqueTokensIds = uniqueTokens
     .filter(({ fullUniqueId }: any) => hiddenTokens.includes(fullUniqueId))

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -285,26 +285,17 @@ const sortCollectibles = (
       );
     case CollectibleSortByOptions.FLOOR_PRICE:
       return families.sort((a, b) => {
-        const maxPriceA = Math.max(
+        const minPriceA = Math.min(
           ...assetsByName[a].map(asset =>
-            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -Infinity
+            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -1
           )
         );
-        const maxPriceB = Math.max(
+        const minPriceB = Math.min(
           ...assetsByName[b].map(asset =>
-            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -Infinity
+            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -1
           )
         );
-
-        if (maxPriceA === -Infinity && maxPriceB === -Infinity) {
-          return 0;
-        } else if (maxPriceA === -Infinity) {
-          return 1;
-        } else if (maxPriceB === -Infinity) {
-          return -1;
-        } else {
-          return maxPriceB - maxPriceA;
-        }
+        return minPriceB - minPriceA;
       });
     default:
       return families;
@@ -318,7 +309,7 @@ export const buildBriefUniqueTokenList = (
   hiddenTokens: string[] = [],
   listType: AssetListType = 'wallet',
   isReadOnlyWallet = false,
-  nftSort: string = CollectibleSortByOptions.MOST_RECENT
+  nftSort: string
 ) => {
   const hiddenUniqueTokensIds = uniqueTokens
     .filter(({ fullUniqueId }: any) => hiddenTokens.includes(fullUniqueId))

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -285,17 +285,26 @@ const sortCollectibles = (
       );
     case CollectibleSortByOptions.FLOOR_PRICE:
       return families.sort((a, b) => {
-        const minPriceA = Math.min(
+        const maxPriceA = Math.max(
           ...assetsByName[a].map(asset =>
-            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -1
+            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -Infinity
           )
         );
-        const minPriceB = Math.min(
+        const maxPriceB = Math.max(
           ...assetsByName[b].map(asset =>
-            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -1
+            asset.floorPriceEth !== undefined ? asset.floorPriceEth : -Infinity
           )
         );
-        return minPriceB - minPriceA;
+
+        if (maxPriceA === -Infinity && maxPriceB === -Infinity) {
+          return 0;
+        } else if (maxPriceA === -Infinity) {
+          return 1;
+        } else if (maxPriceB === -Infinity) {
+          return -1;
+        } else {
+          return maxPriceB - maxPriceA;
+        }
       });
     default:
       return families;
@@ -309,7 +318,7 @@ export const buildBriefUniqueTokenList = (
   hiddenTokens: string[] = [],
   listType: AssetListType = 'wallet',
   isReadOnlyWallet = false,
-  nftSort: string
+  nftSort: string = CollectibleSortByOptions.MOST_RECENT
 ) => {
   const hiddenUniqueTokensIds = uniqueTokens
     .filter(({ fullUniqueId }: any) => hiddenTokens.includes(fullUniqueId))

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1174,8 +1174,8 @@
     "nfts": {
       "selling": "Selling",
       "sort": {
-        "abc": "Abc",
-        "most_recent": "Most Recent",
+        "abc": "Alphabetical",
+        "most_recent": "Recent",
         "floor_price": "Floor Price"
       }
     },


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Sort UI polish
- Enables last sale/floor price for all networks
- Now only fetching Reservoir floor price when necessary, as a fallback, to align the floor price in the expanded state with the sorted floor prices

## Screen recordings / screenshots

<img width="751" alt="Screenshot 2023-12-18 at 2 47 45 PM" src="https://github.com/rainbow-me/rainbow/assets/7061887/f47d29b4-a88d-4641-b6fa-8c3691d82506">