### PR TITLE
Points: UI for "unranked" users

### DIFF
--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -254,6 +254,10 @@ query simulateMessage(
 
 query getPointsDataForWallet($address: String!) {
   points(address: $address) {
+    error {
+      message
+      type
+    }
     meta {
       distribution {
         next
@@ -282,31 +286,10 @@ query getPointsDataForWallet($address: String!) {
       }
       stats {
         position {
-          current
           unranked
+          current
         }
       }
-      onboarding {
-        earnings {
-          total
-        }
-        categories {
-          data {
-            usd_amount
-            total_collections
-            owned_collections
-          }
-          type
-          display_type
-          earnings {
-            total
-          }
-        }
-      }
-    }
-    error {
-      message
-      type
     }
   }
 }
@@ -321,6 +304,10 @@ mutation onboardPoints(
   $referral: String
 ) {
   onboardPoints(address: $address, signature: $signature, referral: $referral) {
+    error {
+      message
+      type
+    }
     meta {
       distribution {
         next
@@ -329,9 +316,9 @@ mutation onboardPoints(
     }
     leaderboard {
       stats {
-        rank_cutoff
         total_users
         total_points
+        rank_cutoff
       }
       accounts {
         address
@@ -349,31 +336,10 @@ mutation onboardPoints(
       }
       stats {
         position {
-          current
           unranked
+          current
         }
       }
-      onboarding {
-        earnings {
-          total
-        }
-        categories {
-          data {
-            usd_amount
-            total_collections
-            owned_collections
-          }
-          type
-          display_type
-          earnings {
-            total
-          }
-        }
-      }
-    }
-    error {
-      message
-      type
     }
   }
 }

--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -254,10 +254,6 @@ query simulateMessage(
 
 query getPointsDataForWallet($address: String!) {
   points(address: $address) {
-    error {
-      message
-      type
-    }
     meta {
       distribution {
         next
@@ -268,6 +264,7 @@ query getPointsDataForWallet($address: String!) {
       stats {
         total_users
         total_points
+        rank_cutoff
       }
       accounts {
         address
@@ -286,8 +283,30 @@ query getPointsDataForWallet($address: String!) {
       stats {
         position {
           current
+          unranked
         }
       }
+      onboarding {
+        earnings {
+          total
+        }
+        categories {
+          data {
+            usd_amount
+            total_collections
+            owned_collections
+          }
+          type
+          display_type
+          earnings {
+            total
+          }
+        }
+      }
+    }
+    error {
+      message
+      type
     }
   }
 }
@@ -310,6 +329,7 @@ mutation onboardPoints(
     }
     leaderboard {
       stats {
+        rank_cutoff
         total_users
         total_points
       }
@@ -330,6 +350,7 @@ mutation onboardPoints(
       stats {
         position {
           current
+          unranked
         }
       }
       onboarding {

--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -340,6 +340,23 @@ mutation onboardPoints(
           current
         }
       }
+      onboarding {
+        earnings {
+          total
+        }
+        categories {
+          data {
+            usd_amount
+            total_collections
+            owned_collections
+          }
+          type
+          display_type
+          earnings {
+            total
+          }
+        }
+      }
     }
   }
 }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1278,7 +1278,9 @@
         "referral_code_copied": "Referral code copied",
         "earn_points_for_referring": "Earn points when your referrals swap $100 through Rainbow, plus earn 10% of the points your referrals earn",
         "already_claimed_points": "Sorry! You have already claimed your points.",
-        "now": "Now"
+        "now": "Now",
+        "unranked": "Unranked",
+        "points_to_rank": "750 points to rank"
       },
       "console": {
         "claim_bonus_paragraph": "You'll receive an additional 100 points once you swap at least $100 through Rainbow",

--- a/src/screens/points/components/InfoCard.tsx
+++ b/src/screens/points/components/InfoCard.tsx
@@ -9,6 +9,7 @@ export const InfoCard = ({
   mainText,
   icon,
   accentColor,
+  mainTextColor = 'primary',
 }: {
   // onPress: () => void;
   title: string;
@@ -16,6 +17,7 @@ export const InfoCard = ({
   mainText: string;
   icon?: string;
   accentColor: string;
+  mainTextColor?: 'primary' | 'secondary';
 }) => {
   let mainTextFontSize: TextSize;
   if (mainText.length > 10) {
@@ -45,7 +47,11 @@ export const InfoCard = ({
           </Text>
         </Inline> */}
         <Box height={{ custom: 15 }} justifyContent="flex-end">
-          <Text color="label" weight="heavy" size={mainTextFontSize}>
+          <Text
+            color={mainTextColor === 'primary' ? 'label' : 'labelTertiary'}
+            weight="heavy"
+            size={mainTextFontSize}
+          >
             {mainText}
           </Text>
         </Box>

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -116,6 +116,7 @@ export default function PointsContent() {
 
   const totalUsers = data?.points?.leaderboard.stats.total_users;
   const rank = data?.points?.user.stats.position.current;
+  const isUnranked = !!data?.points?.user?.stats?.position?.unranked;
 
   const canDisplayTotalPoints = !isNil(data?.points?.user.earnings.total);
   const canDisplayNextRewardCard = !isNil(nextDistributionSeconds);
@@ -240,16 +241,27 @@ export default function PointsContent() {
                   {canDisplayRankCard ? (
                     <InfoCard
                       // onPress={() => {}}
-                      title={i18n.t(i18n.l.points.points.your_rank)}
+                      title={
+                        isUnranked
+                          ? i18n.t(i18n.l.points.points.unranked)
+                          : i18n.t(i18n.l.points.points.your_rank)
+                      }
                       mainText={`#${rank.toLocaleString('en-US')}`}
                       icon={
-                        totalUsers >= 10_000_000 && deviceUtils.isSmallPhone
+                        (totalUsers >= 10_000_000 &&
+                          deviceUtils.isSmallPhone) ||
+                        isUnranked
                           ? undefined
                           : '􀉬'
                       }
-                      subtitle={i18n.t(i18n.l.points.points.of_x, {
-                        totalUsers: totalUsers.toLocaleString('en-US'),
-                      })}
+                      subtitle={
+                        isUnranked
+                          ? i18n.t(i18n.l.points.points.points_to_rank)
+                          : i18n.t(i18n.l.points.points.of_x, {
+                              totalUsers: totalUsers.toLocaleString('en-US'),
+                            })
+                      }
+                      mainTextColor={isUnranked ? 'secondary' : 'primary'}
                       accentColor={green}
                     />
                   ) : (

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -241,12 +241,12 @@ export default function PointsContent() {
                   {canDisplayRankCard ? (
                     <InfoCard
                       // onPress={() => {}}
-                      title={
+                      title={i18n.t(i18n.l.points.points.your_rank)}
+                      mainText={
                         isUnranked
                           ? i18n.t(i18n.l.points.points.unranked)
-                          : i18n.t(i18n.l.points.points.your_rank)
+                          : `#${rank.toLocaleString('en-US')}`
                       }
-                      mainText={`#${rank.toLocaleString('en-US')}`}
                       icon={
                         (totalUsers >= 10_000_000 &&
                           deviceUtils.isSmallPhone) ||

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -481,8 +481,14 @@ export default function PointsContent() {
                             : formatAddress(accountAddress, 4, 5)}
                         </Text>
                       </Box>
-                      <Text color="label" size="17pt" weight="heavy">
-                        {`#${rank.toLocaleString('en-US')}`}
+                      <Text
+                        color={isUnranked ? 'labelQuaternary' : 'label'}
+                        size="17pt"
+                        weight="heavy"
+                      >
+                        {isUnranked
+                          ? i18n.t(i18n.l.points.points.unranked)
+                          : `#${rank.toLocaleString('en-US')}`}
                       </Text>
                     </Box>
                   </Box>


### PR DESCRIPTION
Fixes APP-1031

## What changed (plus any additional context for devs)
* display that user is "unranked" if points < 750. `unranked` is a property provided by backend so app doesn't actually check the user's point count.
* see figma here
<img width="349" alt="Screenshot 2023-12-19 at 10 31 49 AM" src="https://github.com/rainbow-me/rainbow/assets/15272675/af260722-b4aa-40b4-be29-5c0a637b9575">


## Screen recordings / screenshots
![Simulator Screenshot - iPhone 14 Pro - 2023-12-19 at 10 31 11](https://github.com/rainbow-me/rainbow/assets/15272675/5a78856d-6155-4d71-9039-bbb34d2a4bfa)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-12-19 at 10 30 58](https://github.com/rainbow-me/rainbow/assets/15272675/8054d55a-d5f7-4cf9-9ca3-e305b5000cdd)


## What to test

