### PR TITLE
chore: refactor initializeWallet function to accept object

### DIFF
--- a/src/components/backup/RestoreCloudStep.tsx
+++ b/src/components/backup/RestoreCloudStep.tsx
@@ -223,16 +223,9 @@ export default function RestoreCloudStep({
           const p1 = dispatch(walletsSetSelected(firstWallet));
           const p2 = dispatch(addressSetSelected(firstAddress));
           await Promise.all([p1, p2]);
-          await initializeWallet(
-            null,
-            null,
-            null,
-            false,
-            false,
-            null,
-            true,
-            null
-          );
+          await initializeWallet({
+            switching: true,
+          });
           if (fromSettings) {
             logger.info('Navigating to wallet');
             navigate(Routes.WALLET_SCREEN);

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -46,7 +46,6 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
   const {
     getParent: dangerouslyGetParent,
     navigate,
-    goBack,
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'replace' does not exist on type '{ dispa... Remove this comment to see the full error message
     replace,
     setParams,
@@ -294,17 +293,14 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
           handleSetImporting(false);
         } else {
           const previousWalletCount = keys(wallets).length;
-          initializeWallet(
-            input,
-            // @ts-expect-error Initialize wallet is not typed properly now, will be fixed with a refactoring. TODO: remove comment when changing intializeWallet
+          initializeWallet({
+            seedPhrase: input,
             color,
-            name ? name : '',
-            false,
-            false,
+            name: name ? name : '',
             checkedWallet,
-            undefined,
-            image
-          )
+            switching: false,
+            image,
+          })
             .then(success => {
               ios && handleSetImporting(false);
               if (success) {
@@ -364,8 +360,14 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
                 // Wait for error messages then refocus
                 setTimeout(() => {
                   inputRef.current?.focus();
-                  // @ts-expect-error ts-migrate(2554) FIXME: Expected 8-9 arguments, but got 0.
-                  initializeWallet();
+                  // TODO: Check if these parameters match up to OLD empty state
+                  try {
+                    initializeWallet({
+                      switching: false,
+                    });
+                  } catch (err) {
+                    logger.error('error initializing wallet: ', err);
+                  }
                 }, 100);
               }
             })
@@ -375,8 +377,15 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
               logger.error('error importing seed phrase: ', error);
               setTimeout(() => {
                 inputRef.current?.focus();
-                // @ts-expect-error ts-migrate(2554) FIXME: Expected 8-9 arguments, but got 0.
-                initializeWallet();
+
+                try {
+                  // TODO: Check if these parameters match up to OLD empty state
+                  initializeWallet({
+                    switching: false,
+                  });
+                } catch (err) {
+                  logger.error('error initializing wallet: ', err);
+                }
               }, 100);
             });
         }

--- a/src/hooks/useInitializeWallet.ts
+++ b/src/hooks/useInitializeWallet.ts
@@ -26,6 +26,18 @@ import { runKeychainIntegrityChecks } from '@/handlers/walletReadyEvents';
 import { checkPendingTransactionsOnInitialize } from '@/redux/data';
 import { logger } from '@/logger';
 
+type InitializeWalletParams = {
+  seedPhrase?: string | null;
+  color?: string | null;
+  name?: string | null;
+  shouldRunMigrations?: boolean;
+  overwrite?: boolean;
+  checkedWallet?: string | null;
+  switching?: boolean;
+  image?: string | null;
+  silent?: boolean;
+};
+
 export default function useInitializeWallet() {
   const dispatch = useDispatch();
   const resetAccountState = useResetAccountState();
@@ -51,20 +63,17 @@ export default function useInitializeWallet() {
   };
 
   const initializeWallet = useCallback(
-    async (
-      // @ts-expect-error This callback will be refactored to use a single object param with full TS typings
-      seedPhrase,
+    async ({
+      seedPhrase = null,
       color = null,
       name = null,
       shouldRunMigrations = false,
       overwrite = false,
       checkedWallet = null,
-      // @ts-expect-error This callback will be refactored to use a single object param with full TS typings
       switching,
-      // @ts-expect-error This callback will be refactored to use a single object param with full TS typings
-      image,
-      silent = false
-    ) => {
+      image = null,
+      silent = false,
+    }: InitializeWalletParams) => {
       try {
         PerformanceTracking.startMeasuring(
           PerformanceMetrics.useInitializeWallet

--- a/src/hooks/useWallets.ts
+++ b/src/hooks/useWallets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { findLatestBackUp } from '../model/backup';
@@ -69,8 +69,9 @@ export default function useWallets() {
     const p1 = dispatch(walletsSetSelected(wallets![walletKey]));
     const p2 = dispatch(addressSetSelected(toChecksumAddress(address)!));
     await Promise.all([p1, p2]);
-    // @ts-expect-error ts-migrate(2554) FIXME: Expected 8-9 arguments, but got 7.
-    return initializeWallet(null, null, null, false, false, null, true);
+    return initializeWallet({
+      switching: true,
+    });
   };
 
   return {

--- a/src/hooks/useWatchWallet.ts
+++ b/src/hooks/useWatchWallet.ts
@@ -47,8 +47,7 @@ export default function useWatchWallet({
         const p2 = dispatch(addressSetSelected(address));
         await Promise.all([p1, p2]);
 
-        // @ts-expect-error ts-migrate(2554) FIXME: Expected 8-9 arguments, but got 7.
-        initializeWallet(null, null, null, false, false, null, true);
+        initializeWallet({ switching: true });
       } catch (e) {
         logger.log('error while switching account', e);
       }

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -134,8 +134,7 @@ export const AddWalletSheet = () => {
                     const newWallets = await dispatch(
                       createAccountForWallet(primaryWalletKey, color, name)
                     );
-                    // @ts-ignore
-                    await initializeWallet();
+                    await initializeWallet({ switching: true });
                     // If this wallet was previously backed up to the cloud
                     // We need to update userData backup so it can be restored too
                     if (
@@ -163,8 +162,7 @@ export const AddWalletSheet = () => {
                       clearCallbackOnStartCreation: true,
                     });
                     await dispatch(walletsLoadState(profilesEnabled));
-                    // @ts-ignore
-                    await initializeWallet();
+                    await initializeWallet({ switching: true });
                   }
                 } catch (e) {
                   logger.error(e as RainbowError, {

--- a/src/screens/ChangeWalletSheet.tsx
+++ b/src/screens/ChangeWalletSheet.tsx
@@ -12,7 +12,7 @@ import { Centered, Column, Row } from '../components/layout';
 import { Sheet, SheetTitle } from '../components/sheet';
 import { Text } from '../components/text';
 import { removeWalletData } from '../handlers/localstorage/removeWallet';
-import { cleanUpWalletKeys, RainbowWallet } from '../model/wallet';
+import { cleanUpWalletKeys } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
 import {
   addressSetSelected,
@@ -166,8 +166,7 @@ export default function ChangeWalletSheet() {
         const p1 = dispatch(walletsSetSelected(wallet));
         const p2 = dispatch(addressSetSelected(address));
         await Promise.all([p1, p2]);
-        // @ts-ignore
-        initializeWallet(null, null, null, false, false, null, true);
+        initializeWallet({ switching: true });
         if (!fromDeletion) {
           goBack();
 
@@ -188,6 +187,7 @@ export default function ChangeWalletSheet() {
       onChangeWallet,
       wallets,
       watchOnly,
+      runChecks,
     ]
   );
 

--- a/src/screens/WalletScreen/index.tsx
+++ b/src/screens/WalletScreen/index.tsx
@@ -130,8 +130,10 @@ const WalletScreen: React.FC<any> = ({ navigation, route }) => {
 
   useEffect(() => {
     const initializeAndSetParams = async () => {
-      // @ts-expect-error messed up initializeWallet types
-      await initializeWallet(null, null, null, !params?.emptyWallet);
+      await initializeWallet({
+        shouldRunMigrations: !params?.emptyWallet,
+        switching: false,
+      });
       setInitialized(true);
       setParams({ emptyWallet: false });
     };


### PR DESCRIPTION
lots of calls to `initializeWallet` were super weird because the function accepted function args after optional args. This refactors it to accept an object instead.

