### PR TITLE
Remote config hack

### DIFF
--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -21,8 +21,9 @@ import {
   saveNetwork,
 } from '@/handlers/localstorage/globalSettings';
 import { web3SetHttpProvider } from '@/handlers/web3';
-
+import { useQuery } from '@tanstack/react-query';
 import Logger from '@/utils/logger';
+import { createQueryKey } from '@/react-query';
 
 export interface RainbowConfig
   extends Record<string, string | boolean | number> {
@@ -72,6 +73,8 @@ export interface RainbowConfig
   points_fully_enabled: boolean;
   rpc_proxy_enabled: boolean;
   remote_promo_enabled: boolean;
+  test_do_not_use: boolean;
+  test_do_not_use2: boolean;
 }
 
 const DEFAULT_CONFIG: RainbowConfig = {
@@ -135,10 +138,19 @@ const DEFAULT_CONFIG: RainbowConfig = {
   points_fully_enabled: true,
   rpc_proxy_enabled: true,
   remote_promo_enabled: false,
+  test_do_not_use: true,
+  test_do_not_use2: true,
 };
 
 // Initialize with defaults in case firebase doesn't respond
 const config: RainbowConfig = { ...DEFAULT_CONFIG };
+
+export function useConfig() {
+  const query = useQuery(createQueryKey('config', {}), async () => config, {
+    refetchInterval: 300,
+  });
+  return query?.data ?? config;
+}
 
 const init = async () => {
   try {
@@ -191,7 +203,9 @@ const init = async () => {
         key === 'points_enabled' ||
         key === 'points_fully_enabled' ||
         key === 'rpc_proxy_enabled' ||
-        key === 'remote_promo_enabled'
+        key === 'remote_promo_enabled' ||
+        key === 'test_do_not_use' ||
+        key === 'test_do_not_use2'
       ) {
         config[key] = entry.asBoolean();
       } else {

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -73,8 +73,6 @@ export interface RainbowConfig
   points_fully_enabled: boolean;
   rpc_proxy_enabled: boolean;
   remote_promo_enabled: boolean;
-  test_do_not_use: boolean;
-  test_do_not_use2: boolean;
 }
 
 const DEFAULT_CONFIG: RainbowConfig = {
@@ -138,15 +136,13 @@ const DEFAULT_CONFIG: RainbowConfig = {
   points_fully_enabled: true,
   rpc_proxy_enabled: true,
   remote_promo_enabled: false,
-  test_do_not_use: true,
-  test_do_not_use2: true,
 };
 
 // Initialize with defaults in case firebase doesn't respond
 const config: RainbowConfig = { ...DEFAULT_CONFIG };
 
 export function useConfig() {
-  const query = useQuery(createQueryKey('config', {}), async () => config, {
+  const query = useQuery(createQueryKey('config', {}), () => config, {
     refetchInterval: 300,
   });
   return query?.data ?? config;
@@ -203,9 +199,7 @@ const init = async () => {
         key === 'points_enabled' ||
         key === 'points_fully_enabled' ||
         key === 'rpc_proxy_enabled' ||
-        key === 'remote_promo_enabled' ||
-        key === 'test_do_not_use' ||
-        key === 'test_do_not_use2'
+        key === 'remote_promo_enabled'
       ) {
         config[key] = entry.asBoolean();
       } else {

--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -34,7 +34,7 @@ import RecyclerListViewScrollToTopProvider, {
 import { discoverOpenSearchFnRef } from '@/screens/discover/components/DiscoverSearchContainer';
 import { InteractionManager, View } from 'react-native';
 import { IS_ANDROID, IS_DEV, IS_IOS, IS_TEST } from '@/env';
-import config from '@/model/config';
+import { useConfig } from '@/model/config';
 import SectionListScrollToTopProvider, {
   useSectionListScrollToTopContext,
 } from './SectionListScrollToTopContext';
@@ -79,8 +79,9 @@ const TabBar = ({
 }) => {
   const { width: deviceWidth } = useDimensions();
   const { colors, isDarkMode } = useTheme();
+  const { points_enabled } = useConfig();
 
-  const showPointsTab = IS_DEV || IS_TEST || config.points_enabled;
+  const showPointsTab = IS_DEV || IS_TEST || points_enabled;
   const NUMBER_OF_TABS = showPointsTab ? 4 : 3;
 
   const tabWidth =
@@ -342,8 +343,9 @@ export function SwipeNavigator() {
   const { colors } = useTheme();
 
   const [lastPress, setLastPress] = useState();
+  const { points_enabled } = useConfig();
 
-  const showPointsTab = IS_DEV || IS_TEST || config.points_enabled;
+  const showPointsTab = IS_DEV || IS_TEST || points_enabled;
 
   // ////////////////////////////////////////////////////
   // Animations

--- a/src/resources/points.ts
+++ b/src/resources/points.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { POINTS, useExperimentalFlag } from '@/config';
 import { metadataPOSTClient } from '@/graphql';
 import { GetPointsDataForWalletQuery } from '@/graphql/__generated__/metadata';
-import config from '@/model/config';
+import { useConfig } from '@/model/config';
 import { createQueryKey } from '@/react-query';
 import { useQuery } from '@tanstack/react-query';
 
@@ -26,9 +26,9 @@ export function usePointsReferralCode() {
 
 let nextDropTimeout: NodeJS.Timeout | undefined;
 export function usePoints({ walletAddress }: { walletAddress: string }) {
+  const { points_fully_enabled, points_enabled } = useConfig();
   const pointsEnabled =
-    (useExperimentalFlag(POINTS) || config.points_fully_enabled) &&
-    config.points_enabled;
+    (useExperimentalFlag(POINTS) || points_fully_enabled) && points_enabled;
   const queryKey = pointsQueryKey({
     address: walletAddress,
   });

--- a/src/screens/points/PointsScreen.tsx
+++ b/src/screens/points/PointsScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@/navigation';
 import { Box } from '@/design-system';
 import { useAccountProfile } from '@/hooks';
 import { POINTS, useExperimentalFlag } from '@/config';
-import config from '@/model/config';
+import { useConfig } from '@/model/config';
 import { ContactAvatar } from '@/components/contacts';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { ButtonPressAnimation } from '@/components/animations';
@@ -36,8 +36,9 @@ export default function PointsScreen() {
     accountColor,
     accountSymbol,
   } = useAccountProfile();
+  const { points_fully_enabled } = useConfig();
   const pointsFullyEnabled =
-    useExperimentalFlag(POINTS) || config.points_fully_enabled;
+    useExperimentalFlag(POINTS) || points_fully_enabled;
   const { navigate } = useNavigation();
   const { data } = usePoints({
     walletAddress: accountAddress,


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
uses react query in a really dumb way to constantly provide remote config consumers with a fresh `config`. a *potentially* updated `config` is returned by the query every 300ms, however this will only trigger rerenders in consumers if `config` actually changes. the purpose of this is to mitigate the remote config race condition that is going on.

for this to work, it requires `points_enabled` to be true and `points_fully_enabled` to be false in firebase for app store review. this is because for some reason, the `SwipeNavigator` that encompasses the tab bar does not get properly rerendered when the points remote config value changes.

## Screen recordings / screenshots


## What to test
