### PR TITLE
chore: hide testnet settings

### DIFF
--- a/e2e/discoverSheetFlow.spec.js
+++ b/e2e/discoverSheetFlow.spec.js
@@ -111,8 +111,8 @@ describe('Discover Screen Flow', () => {
     await Helpers.delay(3000);
     await Helpers.checkIfVisible('favorites-0');
     await Helpers.checkIfVisible('verified-1');
-    await Helpers.checkIfVisible('profiles-2');
-    await Helpers.checkIfVisible('highLiquidity-3');
+    await Helpers.checkIfExists('profiles-2');
+    await Helpers.checkIfExists('highLiquidity-3');
   });
 
   it('Should search and open Profile Sheet for rainbowwallet.eth', async () => {

--- a/src/screens/SettingsSheet/components/DevSection.android.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.android.tsx
@@ -309,7 +309,7 @@ const DevSection = () => {
             </Inline>
             <MenuContainer testID="developer-settings-sheet">
               <Menu header={IS_DEV || isTestFlight ? 'Normie Settings' : ''}>
-                <MenuItem
+                {/* <MenuItem
                   disabled
                   leftComponent={<MenuItem.TextIcon icon="🕹️" isEmoji />}
                   rightComponent={
@@ -326,7 +326,7 @@ const DevSection = () => {
                     />
                   }
                 />
-                {testnetsEnabled && <NetworkSection inDevSection />}
+                {testnetsEnabled && <NetworkSection inDevSection />} */}
                 <MenuItem
                   leftComponent={<MenuItem.TextIcon icon="💥" isEmoji />}
                   onPress={clearLocalStorage}

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -299,7 +299,7 @@ const DevSection = () => {
   return (
     <MenuContainer testID="developer-settings-sheet">
       <Menu header={IS_DEV || isTestFlight ? 'Normie Settings' : ''}>
-        <MenuItem
+        {/* <MenuItem
           disabled
           leftComponent={<MenuItem.TextIcon icon="🕹️" isEmoji />}
           rightComponent={
@@ -316,7 +316,7 @@ const DevSection = () => {
             />
           }
         />
-        {testnetsEnabled && <NetworkSection inDevSection />}
+        {testnetsEnabled && <NetworkSection inDevSection />} */}
         <MenuItem
           leftComponent={<MenuItem.TextIcon icon="💥" isEmoji />}
           onPress={clearLocalStorage}

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -290,7 +290,7 @@ const SettingsSection = ({
           testID="currency-section"
           titleComponent={<MenuItem.Title text={lang.t('settings.currency')} />}
         />
-        {(testnetsEnabled || IS_DEV) && (
+        {/* {(testnetsEnabled || IS_DEV) && (
           <MenuItem
             hasRightArrow
             leftComponent={
@@ -310,7 +310,7 @@ const SettingsSection = ({
               <MenuItem.Title text={lang.t('settings.network')} />
             }
           />
-        )}
+        )} */}
         <ContextMenuButton
           menuConfig={themeMenuConfig}
           {...(android ? { onPress: onPressThemeAndroidActions } : {})}


### PR DESCRIPTION
Fixes APP-890

## What changed (plus any additional context for devs)
removing testnet settings from user facing since its been rugged for like 6 months

keeping it all there in case we reprioritize it 

## Screen recordings / screenshots


## What to test

