### PR TITLE
weekly earnings fix and leaderboard diff

### DIFF
--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -51,6 +51,7 @@ import {
   useRemoteCardContext,
 } from '@/components/cards/remote-cards';
 import { usePoints } from '@/resources/points';
+import { TextColor } from '@/design-system/color/palettes';
 
 export default function PointsContent() {
   const { colors } = useTheme();
@@ -127,6 +128,8 @@ export default function PointsContent() {
 
   const totalUsers = points?.points?.leaderboard.stats.total_users;
   const rank = points?.points?.user.stats.position.current;
+  const lastWeekRank = points?.points?.user.stats.last_airdrop.position.current;
+  const rankChange = rank && lastWeekRank ? rank - lastWeekRank : undefined;
   const isUnranked = !!points?.points?.user?.stats?.position?.unranked;
 
   const canDisplayTotalPoints = !isNil(points?.points?.user.earnings.total);
@@ -142,6 +145,24 @@ export default function PointsContent() {
     ? `https://www.rainbow.me/points?ref=${points.points.user.referralCode}`
     : undefined;
 
+  const getRankChangeIcon = () => {
+    if (rankChange === undefined || isUnranked) return '';
+
+    if (rankChange === 0) return '􁘶';
+
+    if (rankChange > 0) return '􀑁';
+
+    return '􁘳';
+  };
+
+  const getRankChangeIconColor = () => {
+    if (rankChange !== undefined) {
+      if (rankChange === 0) return colors.yellow;
+      else if (rankChange > 0) return green;
+    }
+
+    return colors.red;
+  };
   return (
     <Box height="full" background="surfacePrimary" as={Page} flex={1}>
       <ScrollView
@@ -264,22 +285,16 @@ export default function PointsContent() {
                           ? i18n.t(i18n.l.points.points.unranked)
                           : `#${rank.toLocaleString('en-US')}`
                       }
-                      icon={
-                        (totalUsers >= 10_000_000 &&
-                          deviceUtils.isSmallPhone) ||
-                        isUnranked
-                          ? undefined
-                          : '􀉬'
-                      }
+                      icon={getRankChangeIcon()}
                       subtitle={
                         isUnranked
                           ? i18n.t(i18n.l.points.points.points_to_rank)
-                          : i18n.t(i18n.l.points.points.of_x, {
-                              totalUsers: totalUsers.toLocaleString('en-US'),
-                            })
+                          : rankChange?.toString() || ''
                       }
                       mainTextColor={isUnranked ? 'secondary' : 'primary'}
-                      accentColor={green}
+                      accentColor={
+                        isUnranked ? green : getRankChangeIconColor()
+                      }
                     />
                   ) : (
                     <Skeleton height={98} width={(deviceWidth - 40 - 12) / 2} />

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -156,12 +156,11 @@ export default function PointsContent() {
   };
 
   const getRankChangeIconColor = () => {
-    if (rankChange !== undefined) {
-      if (rankChange === 0) return colors.yellow;
-      else if (rankChange > 0) return green;
-    }
+    if (rankChange === undefined || rankChange < 0) return colors.red;
 
-    return colors.red;
+    if (rankChange === 0) return colors.yellow;
+
+    return colors.green;
   };
   return (
     <Box height="full" background="surfacePrimary" as={Page} flex={1}>

--- a/src/screens/points/content/console/view-weekly-earnings.tsx
+++ b/src/screens/points/content/console/view-weekly-earnings.tsx
@@ -35,8 +35,7 @@ export const ViewWeeklyEarnings = () => {
   const accountName = (abbreviateEnsForDisplay(accountENS, 10) ||
     formatAddress(accountAddress, 4, 5)) as string;
 
-  const newTotalEarnings =
-    points?.points?.user.stats.last_airdrop.earnings.total;
+  const newTotalEarnings = points?.points?.user.earnings.total;
   const retroactive = points?.points?.user.stats.last_airdrop.differences?.find(
     difference => difference?.type === 'retroactive'
   );


### PR DESCRIPTION
Fixes APP-1081

## What changed (plus any additional context for devs)
fixes a weekly earnings bug i mentioned in [#backend](https://rainbowhaus.slack.com/archives/C02C8JQ313N) and adds https://linear.app/rainbow/issue/APP-1081/replace-total-points-users-w-change-in-rank-in-rank-card



## Screen recordings / screenshots
https://cloud.skylarbarrera.com/Screen-Recording-2024-01-18-12-39-28.mp4
unranked user: https://cloud.skylarbarrera.com/Screen-Shot-2024-01-18-12-44-49.31.png


## What to test

