### PR TITLE
Points: rank card fixes

### DIFF
--- a/src/screens/points/components/LeaderboardRow.tsx
+++ b/src/screens/points/components/LeaderboardRow.tsx
@@ -242,7 +242,7 @@ export const LeaderboardRow = ({
                 numberOfLines={1}
                 containsEmoji
               >
-                {ens ?? formattedAddress ?? ''}
+                {ens || formattedAddress || ''}
               </Text>
             </Box>
           </Stack>

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -128,7 +128,8 @@ export default function PointsContent() {
 
   const totalUsers = points?.points?.leaderboard.stats.total_users;
   const rank = points?.points?.user.stats.position.current;
-  const lastWeekRank = points?.points?.user.stats.last_airdrop.position.current;
+  const lastWeekRank =
+    points?.points?.user.stats.last_airdrop?.position.current;
   const rankChange = rank && lastWeekRank ? rank - lastWeekRank : undefined;
   const isUnranked = !!points?.points?.user?.stats?.position?.unranked;
 
@@ -150,18 +151,26 @@ export default function PointsContent() {
 
     if (rankChange === 0) return '􁘶';
 
-    if (rankChange > 0) return '􀑁';
+    if (rankChange < 0) return '􀑁';
 
     return '􁘳';
   };
 
   const getRankChangeIconColor = () => {
-    if (rankChange === undefined || rankChange < 0) return colors.red;
+    if (rankChange === undefined || rankChange > 0) return colors.red;
 
     if (rankChange === 0) return colors.yellow;
 
     return colors.green;
   };
+
+  const getRankChangeText = () => {
+    if (rankChange !== undefined) {
+      return Math.abs(rankChange).toLocaleString('en-US');
+    }
+    return '';
+  };
+
   return (
     <Box height="full" background="surfacePrimary" as={Page} flex={1}>
       <ScrollView
@@ -288,7 +297,7 @@ export default function PointsContent() {
                       subtitle={
                         isUnranked
                           ? i18n.t(i18n.l.points.points.points_to_rank)
-                          : rankChange?.toString() || ''
+                          : getRankChangeText()
                       }
                       mainTextColor={isUnranked ? 'secondary' : 'primary'}
                       accentColor={


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
* if rank increases, should show red text with negative slope graph
* if rank decreases, should show green text with positive slope graph
* formatting for large rank changes (ex. 1234 -> 1,234)
* remove negative sign from rank change display in case of rank decrease
* also fixed an issue that is evident in screenshots below where neither the ens nor wallet address is displayed in the leaderboard row

## Screen recordings / screenshots
1. current rank - last week rank = 1234
2. current rank - last week rank = -1234
3. current rank - last week rank = 0
![Simulator Screenshot - iPhone 15 Pro - 2024-01-18 at 15 57 56](https://github.com/rainbow-me/rainbow/assets/15272675/6330afc4-cf4a-4a4a-b2fb-49c3ab5a147a)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-18 at 15 58 03](https://github.com/rainbow-me/rainbow/assets/15272675/feb67ed3-f31a-4a2b-b309-cc2e47c255ed)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-18 at 15 58 09](https://github.com/rainbow-me/rainbow/assets/15272675/a185b6d2-9f1c-454b-b59d-72f1bdf0fdab)


## What to test

