### PR TITLE
swap fix

### DIFF
--- a/src/screens/ExchangeModal.tsx
+++ b/src/screens/ExchangeModal.tsx
@@ -255,11 +255,9 @@ export default function ExchangeModal({
     const chainId =
       network === Network.goerli
         ? getNetworkObj(Network.goerli).id
-        : inputCurrency?.type || outputCurrency?.type
-        ? ethereumUtils.getChainIdFromType(
-            inputCurrency?.type ?? outputCurrency?.type
-          )
-        : 1;
+        : inputCurrency?.chainId ||
+          outputCurrency?.chainId ||
+          getNetworkObj(Network.mainnet).id;
 
     const currentNetwork = ethereumUtils.getNetworkFromChainId(chainId);
     const isCrosschainSwap =


### PR DESCRIPTION
Fixes APP-1097

## What changed (plus any additional context for devs)
Currently, the app infers a coin asset's network from its `type` attribute. This is bad because the backend does not directly equate the two. Instead, we should be using the `network` attribute. Context in this thread: https://rainbowhaus.slack.com/archives/C02C2FVC6N6/p1706047871608269

The bug described in this ticket was caused by one such faulty inference. I fixed this specific issue, however I realized there are many other similar bugs. The ones I saw were relatively minor, however it's possible there are bigger ones hiding somewhere.

## Screen recordings / screenshots


## What to test
swaps
