### PR TITLE
chore: force asset types

### DIFF
--- a/src/resources/assets/assets.ts
+++ b/src/resources/assets/assets.ts
@@ -106,6 +106,7 @@ export function parseAddressAsset({
   return {
     ...parsedAsset,
     balance: convertRawAmountToBalance(quantity, asset),
+    type: asset.network === Network.mainnet ? AssetType.token : asset.network,
   };
 }
 


### PR DESCRIPTION
Fixes APP-1097

## What changed (plus any additional context for devs)
new balances endpoint is sending non compatible asset types which was causing issues. were not forcing the legacy types assumed by the codebase until we switch over all of those instances


## Screen recordings / screenshots


## What to test

