### PR TITLE
fix: Use `useCameraDevice`

### DIFF
--- a/src/components/qrcode-scanner/QRCodeScanner.tsx
+++ b/src/components/qrcode-scanner/QRCodeScanner.tsx
@@ -1,6 +1,6 @@
 import lang from 'i18n-js';
 import React, { useCallback } from 'react';
-import { Camera, CodeScanner } from 'react-native-vision-camera';
+import { Camera, CodeScanner, useCameraDevice } from 'react-native-vision-camera';
 import Animated from 'react-native-reanimated';
 import { ErrorText } from '../text';
 import QRCodeScannerNeedsAuthorization from './QRCodeScannerNeedsAuthorization';
@@ -33,8 +33,7 @@ export const QRCodeScanner: React.FC<QRCodeScannerProps> = ({
   hasPermission,
   requestPermission,
 }) => {
-  const devices = Camera.getAvailableCameraDevices();
-  const device = devices.find(d => d.position === 'back');
+  const device = useCameraDevice('back');
   const customHeightValue = deviceHeight + androidSoftMenuHeight;
 
   useFocusEffect(


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Uses the `useCameraDevice` hook instead of manually getting all devices then iterating through them.

This effectively does two things:

1. Memoize the Device and offer a tinnnnnnnnyy performance benefit (will not be noticeable at all, lol)
2. Consistently choose a 'wide-angle' Camera device. Previously, it simply selected the first back Camera, which could be an ultra-wide, telephoto, or even a triple Camera. This now means that
    1. zoom is always as expected
    2. the Camera starts up faster if it chose a different device previously (e.g. dual or triple camera)

## Screen recordings / screenshots


## What to test

