### PR TITLE
chore: replace charts websocket with our metadata endpoint

### DIFF
--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -53,10 +53,6 @@ export const EthCard = () => {
   const { name: routeName } = useRoute();
   const cardType = 'stretch';
 
-  useEffect(() => {
-    emitChartsRequest([ETH_ADDRESS], chartTypes.day, nativeCurrency);
-  }, [nativeCurrency]);
-
   const handlePressBuy = useCallback(
     (e: ButtonPressAnimationTouchEvent) => {
       if (e && 'stopPropagation' in e) {

--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -32,8 +32,6 @@ import { AssetType } from '@/entities';
 import Labels from '../value-chart/ExtremeLabels';
 import showWalletErrorAlert from '@/helpers/support';
 import { IS_IOS } from '@/env';
-import { emitChartsRequest } from '@/redux/explorer';
-import chartTypes from '@/helpers/chartTypes';
 import Spinner from '../Spinner';
 import Skeleton, { FakeText } from '../skeleton/Skeleton';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';

--- a/src/components/coin-divider/CoinDivider.js
+++ b/src/components/coin-divider/CoinDivider.js
@@ -1,11 +1,5 @@
 import lang from 'i18n-js';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useRef, useState } from 'react';
 import { Animated, LayoutAnimation, View } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRecyclerAssetListPosition } from '../asset-list/RecyclerAssetList2/core/Contexts';
@@ -23,7 +17,6 @@ import {
   useDimensions,
   useOpenSmallBalances,
 } from '@/hooks';
-import { emitChartsRequest } from '@/redux/explorer';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -108,10 +101,7 @@ export default function CoinDivider({
   const { isCoinListEdited, setIsCoinListEdited } = extendedState;
   const interpolation = useInterpolationRange(isCoinListEdited);
   const { nativeCurrency } = useAccountSettings();
-  const dispatch = useDispatch();
-  const assets = useSelector(({ data: { assets } }) => assets);
 
-  const [fetchedCharts, setFetchedCharts] = useState(false);
   const { width: deviceWidth } = useDimensions();
 
   const { clearSelectedCoins } = useCoinListEditOptions();
@@ -126,20 +116,6 @@ export default function CoinDivider({
     isSmallBalancesOpen,
     toggleOpenSmallBalances,
   } = useOpenSmallBalances();
-
-  useEffect(() => {
-    if (isSmallBalancesOpen && !fetchedCharts) {
-      const assetCodes = assets?.map(asset => asset.address);
-      dispatch(emitChartsRequest(assetCodes ?? []));
-      setFetchedCharts(true);
-    }
-  }, [
-    assets,
-    dispatch,
-    fetchedCharts,
-    isSmallBalancesOpen,
-    toggleOpenSmallBalances,
-  ]);
 
   const handlePressEdit = useCallback(() => {
     setIsCoinListEdited(prev => !prev);

--- a/src/components/expanded-state/TokenIndexExpandedState.js
+++ b/src/components/expanded-state/TokenIndexExpandedState.js
@@ -162,7 +162,6 @@ export default function TokenIndexExpandedState({ asset }) {
       >
         <ChartPathProvider data={throttledData}>
           <Chart
-            {...chartData}
             {...initialChartDataLabels}
             asset={assetWithPrice}
             chart={chart}

--- a/src/components/expanded-state/TokenIndexExpandedState.js
+++ b/src/components/expanded-state/TokenIndexExpandedState.js
@@ -128,7 +128,7 @@ export default function TokenIndexExpandedState({ asset }) {
 
   const {
     chart,
-    chartData,
+    updateChartType,
     chartType,
     color,
     fetchingCharts,
@@ -163,6 +163,7 @@ export default function TokenIndexExpandedState({ asset }) {
         <ChartPathProvider data={throttledData}>
           <Chart
             {...initialChartDataLabels}
+            updateChartType={updateChartType}
             asset={assetWithPrice}
             chart={chart}
             chartType={chartType}

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -262,6 +262,7 @@ export default function ChartExpandedState({ asset }) {
     chartType,
     color,
     fetchingCharts,
+    updateChartType,
     initialChartDataLabels,
     showChart,
     throttledData,
@@ -345,6 +346,7 @@ export default function ChartExpandedState({ asset }) {
       <ChartPathProvider data={throttledData}>
         <Chart
           {...initialChartDataLabels}
+          updateChartType={updateChartType}
           asset={assetWithPrice}
           chart={chart}
           chartType={chartType}

--- a/src/components/expanded-state/asset/ChartExpandedState.js
+++ b/src/components/expanded-state/asset/ChartExpandedState.js
@@ -259,7 +259,6 @@ export default function ChartExpandedState({ asset }) {
 
   const {
     chart,
-    chartData,
     chartType,
     color,
     fetchingCharts,
@@ -345,7 +344,6 @@ export default function ChartExpandedState({ asset }) {
     >
       <ChartPathProvider data={throttledData}>
         <Chart
-          {...chartData}
           {...initialChartDataLabels}
           asset={assetWithPrice}
           chart={chart}

--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -400,3 +400,33 @@ mutation redeemCodeForPoints($address: String!, $redemptionCode: String!) {
     }
   }
 }
+
+query priceChart(
+  $chainId: Int!
+  $address: String!
+  $day: Boolean!
+  $hour: Boolean!
+  $week: Boolean!
+  $month: Boolean!
+  $year: Boolean!
+) {
+  token(chainID: $chainId, address: $address) {
+    priceCharts {
+      day @include(if: $day) {
+        points
+      }
+      hour @include(if: $hour) {
+        points
+      }
+      week @include(if: $week) {
+        points
+      }
+      month @include(if: $month) {
+        points
+      }
+      year @include(if: $year) {
+        points
+      }
+    }
+  }
+}

--- a/src/handlers/__tests__/deeplinks.test.ts.skip
+++ b/src/handlers/__tests__/deeplinks.test.ts.skip
@@ -25,7 +25,6 @@ jest.mock('@/redux/data', () => ({
 }));
 jest.mock('@/redux/explorer', () => ({
   emitAssetRequest: jest.fn(),
-  emitChartsRequest: jest.fn(),
 }));
 jest.mock('@/utils/profileUtils', () => ({
   fetchReverseRecordWithRetry: jest.fn(),

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -8,7 +8,7 @@ import {
   walletConnectSetPendingRedirect,
 } from '@/redux/walletconnect';
 import { scheduleActionOnAssetReceived } from '@/redux/data';
-import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
+import { emitAssetRequest } from '@/redux/explorer';
 import { fetchReverseRecordWithRetry } from '@/utils/profileUtils';
 import { defaultConfig } from '@/config/experimental';
 import { PROFILES } from '@/config/experimentalHooks';
@@ -130,7 +130,6 @@ export default async function handleDeeplink(
               _action(asset);
             } else {
               dispatch(emitAssetRequest(address));
-              dispatch(emitChartsRequest(address));
               scheduleActionOnAssetReceived(address, _action);
             }
           }, 50);

--- a/src/helpers/chartTypes.ts
+++ b/src/helpers/chartTypes.ts
@@ -1,10 +1,10 @@
 const chartTypes = {
-  hour: 'h',
-  day: 'd',
-  week: 'w',
-  month: 'm',
-  year: 'y',
-  max: 'a',
+  hour: 'hour',
+  day: 'day',
+  week: 'week',
+  month: 'month',
+  year: 'year',
+  max: 'all',
 } as const;
 
 export default chartTypes;

--- a/src/hooks/charts/index.ts
+++ b/src/hooks/charts/index.ts
@@ -1,3 +1,2 @@
 export { default as useChartDataLabels } from './useChartDataLabels';
-export { default as useChartInfo } from './useChartInfo';
 export { default as useChartThrottledPoints } from './useChartThrottledPoints';

--- a/src/hooks/charts/useChartInfo.ts
+++ b/src/hooks/charts/useChartInfo.ts
@@ -7,9 +7,6 @@ import { createSelector } from 'reselect';
 import { useCallbackOne } from 'use-memo-one';
 import { disableCharts } from '../../config/debug';
 import { DEFAULT_CHART_TYPE } from '../../redux/charts';
-import { emitChartsRequest } from '../../redux/explorer';
-import { useNavigation } from '@/navigation';
-import chartTypes, { ChartType } from '@/helpers/chartTypes';
 import { metadataClient } from '@/graphql';
 import { useQuery } from '@tanstack/react-query';
 import { createQueryKey } from '@/react-query';
@@ -47,92 +44,28 @@ export const usePriceChart = ({
   mainnetAddress,
   address,
   network,
-  time,
 }: {
   mainnetAddress?: string;
   address: string;
   network: Network;
-  time: ChartTime;
 }) => {
-  const chainId = getNetworkObj(network).id;
-  const mainnetChainId = getNetworkObj(Network.mainnet).id;
-  return useQuery({
-    queryFn: async () => {
-      const chart = await fetchPriceChart(time, chainId, address);
-      if (!chart && mainnetAddress)
-        return fetchPriceChart(time, mainnetChainId, mainnetAddress);
-      return chart || null;
-    },
-    queryKey: createQueryKey('price chart', { address, chainId, time }),
-    keepPreviousData: true,
-    staleTime: 1 * 60 * 1000, // 1min
-  });
-};
-const formatChartData = (chart: any) => {
-  if (!chart || isEmpty(chart)) return null;
-  // @ts-expect-error ts-migrate(7031) FIXME: Binding element 'x' implicitly has an 'any' type.
-  return chart.map(([x, y]) => ({ x, y }));
-};
-
-const chartSelector = createSelector(
-  ({ charts: { charts, fetchingCharts } }) => ({
-    charts,
-    fetchingCharts,
-  }),
-  (_: any, address: any) => address,
-  (state, { address, chartType }) => {
-    const { charts, fetchingCharts } = state;
-    const chartsForAsset = {
-      ...charts?.[address],
-    };
-    return {
-      chart: formatChartData(chartsForAsset?.[chartType]),
-      chartsForAsset,
-      fetchingCharts,
-    };
-  }
-);
-
-export default function useChartInfo(asset: any) {
-  const dispatch = useDispatch();
-  const { setParams } = useNavigation();
-
   const { params } = useRoute<{
     key: string;
     name: string;
     params: any;
   }>();
-  const { address } = asset;
-
   const chartType = params?.chartType ?? DEFAULT_CHART_TYPE;
-
-  const { chart, chartsForAsset, fetchingCharts } = useSelector(
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: never) => { chart: any; ... Remove this comment to see the full error message
-    useCallbackOne(state => chartSelector(state, { address, chartType }), [
-      address,
-      chartType,
-    ]),
-    isEqual
-  );
-
-  useEffect(() => {
-    if (!disableCharts) {
-      dispatch(emitChartsRequest(address, chartType));
-    }
-  }, [address, chartType, dispatch]);
-
-  const updateChartType = useCallback(
-    (type: any) => {
-      setParams({ chartType: type });
+  const chainId = getNetworkObj(network).id;
+  const mainnetChainId = getNetworkObj(Network.mainnet).id;
+  return useQuery({
+    queryFn: async () => {
+      const chart = await fetchPriceChart(chartType, chainId, address);
+      if (!chart && mainnetAddress)
+        return fetchPriceChart(chartType, mainnetChainId, mainnetAddress);
+      return chart || null;
     },
-    [setParams]
-  );
-
-  return {
-    chart,
-    charts: chartsForAsset,
-    chartType,
-    fetchingCharts,
-    updateChartType,
-  };
-}
+    queryKey: createQueryKey('price chart', { address, chainId, chartType }),
+    keepPreviousData: true,
+    staleTime: 1 * 60 * 1000, // 1min
+  });
+};

--- a/src/hooks/charts/useChartInfo.ts
+++ b/src/hooks/charts/useChartInfo.ts
@@ -1,4 +1,4 @@
-import { useRoute } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { isEmpty } from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 import isEqual from 'react-fast-compare';
@@ -49,6 +49,13 @@ export const usePriceChart = ({
   address: string;
   network: Network;
 }) => {
+  const { setParams } = useNavigation();
+  const updateChartType = useCallback(
+    (type: any) => {
+      setParams({ chartType: type });
+    },
+    [setParams]
+  );
   const { params } = useRoute<{
     key: string;
     name: string;
@@ -57,7 +64,7 @@ export const usePriceChart = ({
   const chartType = params?.chartType ?? DEFAULT_CHART_TYPE;
   const chainId = getNetworkObj(network).id;
   const mainnetChainId = getNetworkObj(Network.mainnet).id;
-  return useQuery({
+  const query = useQuery({
     queryFn: async () => {
       const chart = await fetchPriceChart(chartType, chainId, address);
       if (!chart && mainnetAddress)
@@ -68,4 +75,5 @@ export const usePriceChart = ({
     keepPreviousData: true,
     staleTime: 1 * 60 * 1000, // 1min
   });
+  return { updateChartType, ...query };
 };

--- a/src/hooks/charts/useChartThrottledPoints.ts
+++ b/src/hooks/charts/useChartThrottledPoints.ts
@@ -7,11 +7,15 @@ import {
   useChartInfo,
   useColorForAsset,
 } from '@/hooks';
+import { useRoute } from '@react-navigation/native';
 
 import { useNavigation } from '@/navigation';
 import { ETH_ADDRESS } from '@/references';
 
 import { ModalContext } from '@/react-native-cool-modals/NativeStackView';
+import { Network } from '@/helpers';
+import { DEFAULT_CHART_TYPE } from '@/redux/charts';
+import { usePriceChart } from './useChartInfo';
 
 export const UniBalanceHeightDifference = 100;
 
@@ -103,10 +107,18 @@ export default function useChartThrottledPoints({
 
   const [isFetchingInitially, setIsFetchingInitially] = useState(true);
 
-  const { chart, chartType, fetchingCharts, ...chartData } = useChartInfo(
-    asset
-  );
-
+  const chartData = useChartInfo(asset);
+  const { params } = useRoute<{
+    key: string;
+    name: string;
+    params: any;
+  }>();
+  const chartType = params?.chartType ?? DEFAULT_CHART_TYPE;
+  const { data: chart = [], isLoading: fetchingCharts } = usePriceChart({
+    address: asset.address,
+    time: chartType,
+    network: asset.network,
+  });
   const [throttledPoints, setThrottledPoints] = useState(() =>
     traverseData({ nativePoints: [], points: [] }, chart)
   );

--- a/src/hooks/charts/useChartThrottledPoints.ts
+++ b/src/hooks/charts/useChartThrottledPoints.ts
@@ -4,7 +4,6 @@ import { monotoneCubicInterpolation } from '@/react-native-animated-charts/src';
 import {
   useAccountSettings,
   useChartDataLabels,
-  useChartInfo,
   useColorForAsset,
 } from '@/hooks';
 import { useRoute } from '@react-navigation/native';
@@ -107,7 +106,6 @@ export default function useChartThrottledPoints({
 
   const [isFetchingInitially, setIsFetchingInitially] = useState(true);
 
-  const chartData = useChartInfo(asset);
   const { params } = useRoute<{
     key: string;
     name: string;
@@ -188,7 +186,6 @@ export default function useChartThrottledPoints({
 
   return {
     chart,
-    chartData,
     chartType,
     color,
     fetchingCharts,

--- a/src/hooks/charts/useChartThrottledPoints.ts
+++ b/src/hooks/charts/useChartThrottledPoints.ts
@@ -112,9 +112,12 @@ export default function useChartThrottledPoints({
     params: any;
   }>();
   const chartType = params?.chartType ?? DEFAULT_CHART_TYPE;
-  const { data: chart = [], isLoading: fetchingCharts } = usePriceChart({
+  const {
+    data: chart = [],
+    isLoading: fetchingCharts,
+    updateChartType,
+  } = usePriceChart({
     address: asset.address,
-    time: chartType,
     network: asset.network,
   });
   const [throttledPoints, setThrottledPoints] = useState(() =>
@@ -187,6 +190,7 @@ export default function useChartThrottledPoints({
   return {
     chart,
     chartType,
+    updateChartType,
     color,
     fetchingCharts,
     initialChartDataLabels,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,8 +1,4 @@
-export {
-  useChartDataLabels,
-  useChartInfo,
-  useChartThrottledPoints,
-} from './charts';
+export { useChartDataLabels, useChartThrottledPoints } from './charts';
 export { default as useDelayedValueWithLayoutAnimation } from './useDelayedValueWithLayoutAnimation';
 export { default as useAccountAsset } from './useAccountAsset';
 export { default as useFrameDelayedValue } from './useFrameDelayedValue';

--- a/src/redux/explorer.ts
+++ b/src/redux/explorer.ts
@@ -404,14 +404,6 @@ export const explorerInit = () => async (
 
     // we want to get ETH info ASAP
     dispatch(emitAssetRequest(ETH_ADDRESS));
-
-    if (!disableCharts) {
-      // We need this for Uniswap Pools profit calculation
-      dispatch(emitChartsRequest([ETH_ADDRESS, DPI_ADDRESS], ChartTypes.month));
-      dispatch(
-        emitChartsRequest([ETH_ADDRESS], ChartTypes.day, currencyTypes.usd)
-      );
-    }
   });
 };
 
@@ -472,27 +464,6 @@ export const emitAssetRequest = (assetAddress: string | string[]) => (
     setTimeout(() => emitAssetRequest(assetAddress), 100);
   }
   return false;
-};
-
-/**
- * Emits a chart information request for an asset or assets. The result
- * is handled by a listener in `listenOnAssetMessages`.
- *
- * @param assetAddress The asset address or addresses.
- * @param chartType The `ChartType` to request.
- * @param givenNativeCurrency The currency to use.
- */
-export const emitChartsRequest = (
-  assetAddress: string | string[],
-  chartType: ChartType = DEFAULT_CHART_TYPE,
-  givenNativeCurrency?: string | undefined
-) => (_: Dispatch, getState: AppGetState) => {
-  const nativeCurrency =
-    givenNativeCurrency || getState().settings.nativeCurrency;
-  const { assetsSocket } = getState().explorer;
-  const assetCodes = Array.isArray(assetAddress)
-    ? assetAddress
-    : [assetAddress];
 };
 
 /**

--- a/src/redux/explorer.ts
+++ b/src/redux/explorer.ts
@@ -292,32 +292,6 @@ const l2AddressTransactionHistoryRequest = (
 ];
 
 /**
- * Configures a chart retrieval request for assets.
- *
- * @param assetCodes The asset addresses.
- * @param currency The currency to use.
- * @param chartType The `ChartType` to use.
- * @param action The request action.
- * @returns Arguments for an `emit` function call.
- */
-const chartsRetrieval = (
-  assetCodes: string[],
-  currency: string,
-  chartType: ChartType,
-  action: SocketGetActionType = 'get'
-): SocketEmitArguments => [
-  action,
-  {
-    payload: {
-      asset_codes: assetCodes,
-      charts_type: chartType,
-      currency: toLower(currency),
-    },
-    scope: ['charts'],
-  },
-];
-
-/**
  * Emits an asset price request. The result is handled by a listener in
  * `listenOnAssetMessages`.
  *
@@ -519,11 +493,6 @@ export const emitChartsRequest = (
   const assetCodes = Array.isArray(assetAddress)
     ? assetAddress
     : [assetAddress];
-  if (!isEmpty(assetCodes)) {
-    assetsSocket?.emit(
-      ...chartsRetrieval(assetCodes, nativeCurrency, chartType)
-    );
-  }
 };
 
 /**

--- a/src/screens/CurrencySelectModal.tsx
+++ b/src/screens/CurrencySelectModal.tsx
@@ -48,7 +48,7 @@ import {
 } from '@/hooks';
 import { delayNext } from '@/hooks/useMagicAutofocus';
 import { getActiveRoute, useNavigation } from '@/navigation/Navigation';
-import { emitAssetRequest, emitChartsRequest } from '@/redux/explorer';
+import { emitAssetRequest } from '@/redux/explorer';
 import Routes from '@/navigation/routesNames';
 import { ethereumUtils, filterList } from '@/utils';
 import NetworkSwitcherv2 from '@/components/exchange/NetworkSwitcherv2';
@@ -435,7 +435,6 @@ export default function CurrencySelectModal() {
             };
 
       const selectAsset = () => {
-        dispatch(emitChartsRequest(item.mainnet_address || item.address));
         dispatch(emitAssetRequest(item.mainnet_address || item.address));
         setIsTransitioning(true); // continue to display list during transition
         callback?.();


### PR DESCRIPTION
Fixes APP-801

## What changed (plus any additional context for devs)
charts should still work the same

## Screen recordings / screenshots
![image](https://github.com/rainbow-me/rainbow/assets/6868432/87d5b806-62cd-4d12-8ea5-73e1ead7755e)
still there! lol

## What to test
charts i guess
