### PR TITLE
Support rainbow://ethereum as ethereum://

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -91,6 +91,12 @@ export default async function handleDeeplink(
        * Universal links from WC e.g. when initiating a pairing on mobile, you
        * tap "Rainbow" in Web3Modal and it hits this handler
        */
+      case 'ethereum': {
+         logger.info(`handleDeeplink: ethereum`);
+         const normalizedUrl = url.replace('rainbow://ethereum', 'ethereum:/');
+         ethereumUtils.parseEthereumUrl(normalizedUrl);
+         break; 
+      }
       case 'wc': {
         logger.info(`handleDeeplink: wc`);
         handleWalletConnect(query.uri, query.connector);

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -93,7 +93,7 @@ export default async function handleDeeplink(
        */
       case 'ethereum': {
          logger.info(`handleDeeplink: ethereum`);
-         const normalizedUrl = url.replace('rainbow://ethereum', 'ethereum:/');
+         const normalizedUrl = url.replace('rainbow://ethereum/', 'ethereum:');
          ethereumUtils.parseEthereumUrl(normalizedUrl);
          break; 
       }

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -88,8 +88,7 @@ export default async function handleDeeplink(
 
     switch (action) {
       /**
-       * Universal links from WC e.g. when initiating a pairing on mobile, you
-       * tap "Rainbow" in Web3Modal and it hits this handler
+       * Same as ethereum: but using rainbow:// prefix to avoid wallet collision
        */
       case 'ethereum': {
          logger.info(`handleDeeplink: ethereum`);
@@ -97,6 +96,10 @@ export default async function handleDeeplink(
          ethereumUtils.parseEthereumUrl(normalizedUrl);
          break; 
       }
+      /**
+       * Universal links from WC e.g. when initiating a pairing on mobile, you
+       * tap "Rainbow" in Web3Modal and it hits this handler
+       */
       case 'wc': {
         logger.info(`handleDeeplink: wc`);
         handleWalletConnect(query.uri, query.connector);


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Ex: 

We were supporting

  `ethereum:0xfb6916095ca1df60bb79Ce92ce3ea74c37c5d359?value=2.014e18`
  
 And now we also support
 
 `rainbow://ethereum/0xfb6916095ca1df60bb79Ce92ce3ea74c37c5d359?value=2.014e18`

## Screen recordings / screenshots


## What to test

