### PR TITLE
chore: centralize arc client selection

### DIFF
--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -4,6 +4,7 @@ import { getSdk as getEnsSdk } from './__generated__/ens';
 import { getSdk as getMetadataSdk } from './__generated__/metadata';
 import { getSdk as getArcSdk } from './__generated__/arc';
 import { getSdk as getArcDevSdk } from './__generated__/arcDev';
+import { IS_PROD } from '@/env';
 
 export const ensClient = getEnsSdk(getFetchRequester(config.ens));
 export const metadataClient = getMetadataSdk(
@@ -12,5 +13,6 @@ export const metadataClient = getMetadataSdk(
 export const metadataPOSTClient = getMetadataSdk(
   getFetchRequester(config.metadataPOST)
 );
-export const arcClient = getArcSdk(getFetchRequester(config.arc));
-export const arcDevClient = getArcDevSdk(getFetchRequester(config.arcDev));
+export const arcClient = IS_PROD
+  ? getArcSdk(getFetchRequester(config.arc))
+  : getArcDevSdk(getFetchRequester(config.arcDev));

--- a/src/resources/cards/cardCollectionQuery.ts
+++ b/src/resources/cards/cardCollectionQuery.ts
@@ -8,7 +8,7 @@ import {
   QueryFunctionResult,
 } from '@/react-query';
 
-import { arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 import { CardFilter, CardOrder } from '@/graphql/__generated__/arc';
 import { noop } from 'lodash';
 
@@ -35,7 +35,7 @@ type CardCollectionQueryKey = ReturnType<typeof cardCollectionQueryKey>;
 async function cardCollectionQueryFunction({
   queryKey: [props],
 }: QueryFunctionArgs<typeof cardCollectionQueryKey>) {
-  const data = await arcDevClient.getCardCollection(props);
+  const data = await arcClient.getCardCollection(props);
   return data;
 }
 

--- a/src/resources/cards/cardQuery.ts
+++ b/src/resources/cards/cardQuery.ts
@@ -8,7 +8,7 @@ import {
   QueryFunctionResult,
 } from '@/react-query';
 
-import { arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 
 // Set a default stale time of 60 seconds so we don't over-fetch
 const defaultStaleTime = 60_000;
@@ -31,7 +31,7 @@ type CardQueryKey = ReturnType<typeof cardQueryKey>;
 async function cardQueryFunction({
   queryKey: [{ id }],
 }: QueryFunctionArgs<typeof cardQueryKey>) {
-  const data = await arcDevClient.getCard({ id });
+  const data = await arcClient.getCard({ id });
   return data;
 }
 

--- a/src/resources/mints.ts
+++ b/src/resources/mints.ts
@@ -1,8 +1,8 @@
 import { analyticsV2 } from '@/analytics';
 import { useCallback, useEffect, useMemo } from 'react';
 import { MINTS, useExperimentalFlag } from '@/config';
-import { IS_PROD, IS_TEST } from '@/env';
-import { arcClient, arcDevClient } from '@/graphql';
+import { IS_TEST } from '@/env';
+import { arcClient } from '@/graphql';
 import { GetMintableCollectionsQuery } from '@/graphql/__generated__/arc';
 import { createQueryKey } from '@/react-query';
 import { useQuery } from '@tanstack/react-query';
@@ -11,7 +11,6 @@ import { MMKV } from 'react-native-mmkv';
 import * as i18n from '@/languages';
 import { useRemoteConfig } from '@/model/remoteConfig';
 
-const graphqlClient = IS_PROD ? arcClient : arcDevClient;
 const mmkv = new MMKV();
 
 const MINTS_FILTER_MMKV_KEY = 'mintsFilter';
@@ -80,7 +79,7 @@ export function useMints({ walletAddress }: { walletAddress: string }) {
   const query = useQuery<GetMintableCollectionsQuery>(
     queryKey,
     async () =>
-      await graphqlClient.getMintableCollections({
+      await arcClient.getMintableCollections({
         walletAddress,
       }),
     {

--- a/src/resources/pointsTweetIntent/pointsTweetIntentCollectionQuery.ts
+++ b/src/resources/pointsTweetIntent/pointsTweetIntentCollectionQuery.ts
@@ -8,8 +8,8 @@ import {
   QueryFunctionResult,
 } from '@/react-query';
 
-import { arcDevClient } from '@/graphql';
 import { PointsTweetIntentOrder } from '@/graphql/__generated__/arc';
+import { arcClient } from '@/graphql';
 
 // Set a default stale time of 10 seconds so we don't over-fetch
 // (query will serve cached data & invalidate after 10s).
@@ -41,7 +41,7 @@ type PointsTweetIntentCollectionQueryKey = ReturnType<
 async function pointsTweetIntentCollectionQueryFunction({
   queryKey: [{ order }],
 }: QueryFunctionArgs<typeof pointsTweetIntentCollectionQueryKey>) {
-  const data = await arcDevClient.getPointsTweetIntentCollection({ order });
+  const data = await arcClient.getPointsTweetIntentCollection({ order });
   return data;
 }
 

--- a/src/resources/pointsTweetIntent/pointsTweetIntentQuery.ts
+++ b/src/resources/pointsTweetIntent/pointsTweetIntentQuery.ts
@@ -9,7 +9,7 @@ import {
   QueryFunctionResult,
 } from '@/react-query';
 
-import { arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 
 // Set a default stale time of 10 seconds so we don't over-fetch
 // (query will serve cached data & invalidate after 10s).
@@ -33,7 +33,7 @@ type PointsTweetIntentQueryKey = ReturnType<typeof pointsTweetIntentQueryKey>;
 async function pointsTweetIntentQueryFunction({
   queryKey: [{ id }],
 }: QueryFunctionArgs<typeof pointsTweetIntentQueryKey>) {
-  const data = await arcDevClient.getPointsTweetIntent({ id });
+  const data = await arcClient.getPointsTweetIntent({ id });
   return data;
 }
 

--- a/src/resources/promoSheet/promoSheetCollectionQuery.ts
+++ b/src/resources/promoSheet/promoSheetCollectionQuery.ts
@@ -8,8 +8,8 @@ import {
   QueryFunctionResult,
 } from '@/react-query';
 
-import { arcDevClient } from '@/graphql';
 import { PromoSheetOrder } from '@/graphql/__generated__/arc';
+import { arcClient } from '@/graphql';
 
 // Set a default stale time of 10 seconds so we don't over-fetch
 // (query will serve cached data & invalidate after 10s).
@@ -35,7 +35,7 @@ type PromoSheetCollectionQueryKey = ReturnType<
 async function promoSheetCollectionQueryFunction({
   queryKey: [{ order }],
 }: QueryFunctionArgs<typeof promoSheetCollectionQueryKey>) {
-  const data = await arcDevClient.getPromoSheetCollection({ order });
+  const data = await arcClient.getPromoSheetCollection({ order });
   return data;
 }
 

--- a/src/resources/promoSheet/promoSheetQuery.ts
+++ b/src/resources/promoSheet/promoSheetQuery.ts
@@ -8,7 +8,7 @@ import {
   QueryFunctionResult,
 } from '@/react-query';
 
-import { arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 
 // Set a default stale time of 10 seconds so we don't over-fetch
 // (query will serve cached data & invalidate after 10s).
@@ -32,7 +32,7 @@ type PromoSheetQueryKey = ReturnType<typeof promoSheetQueryKey>;
 async function promoSheetQueryFunction({
   queryKey: [{ id }],
 }: QueryFunctionArgs<typeof promoSheetQueryKey>) {
-  const data = await arcDevClient.getPromoSheet({ id });
+  const data = await arcClient.getPromoSheet({ id });
   return data;
 }
 

--- a/src/resources/reservoir/mints.ts
+++ b/src/resources/reservoir/mints.ts
@@ -1,15 +1,13 @@
 import { EthereumAddress } from '@/entities';
-import { arcDevClient, arcClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 import { getNetworkObj } from '@/networks';
 import { Navigation } from '@/navigation';
 import { Network } from '@/networks/types';
 import Routes from '@/navigation/routesNames';
-import { IS_DEV } from '@/env';
 import { logger } from '@/logger';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import * as lang from '@/languages';
 
-const client = IS_DEV ? arcDevClient : arcClient;
 const showAlert = () => {
   Alert.alert(
     lang.t(lang.l.minting.could_not_find_collection),
@@ -28,7 +26,7 @@ export const navigateToMintCollection = async (
   });
   try {
     const chainId = getNetworkObj(network).id;
-    const res = await client.getReservoirCollection({
+    const res = await arcClient.getReservoirCollection({
       contractAddress,
       chainId,
     });

--- a/src/resources/reservoir/nftOffersQuery.ts
+++ b/src/resources/reservoir/nftOffersQuery.ts
@@ -1,8 +1,7 @@
 import { analyticsV2 } from '@/analytics';
 import { nftOffersSortAtom } from '@/components/nft-offers/SortMenu';
 import { NFT_OFFERS, useExperimentalFlag } from '@/config';
-import { IS_PROD } from '@/env';
-import { arcClient, arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 import {
   GetNftOffersQuery,
   NftOffer,
@@ -17,8 +16,6 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
-
-const graphqlClient = IS_PROD ? arcClient : arcDevClient;
 
 export type NFTOffersArgs = {
   walletAddress: string;
@@ -66,7 +63,7 @@ type NFTOffersQueryKey = ReturnType<typeof nftOffersQueryKey>;
 async function nftOffersQueryFunction({
   queryKey: [{ walletAddress, sortBy }],
 }: QueryFunctionArgs<typeof nftOffersQueryKey>) {
-  const data = await graphqlClient.getNFTOffers({
+  const data = await arcClient.getNFTOffers({
     walletAddress,
     sortBy,
   });
@@ -81,7 +78,7 @@ export async function fetchNftOffers({
   walletAddress,
   sortBy = SortCriterion.TopBidValue,
 }: NFTOffersArgs) {
-  const data = await graphqlClient.getNFTOffers({
+  const data = await arcClient.getNFTOffers({
     walletAddress,
     // TODO: remove sortBy once the backend supports it
     sortBy: SortCriterion.TopBidValue,
@@ -111,7 +108,7 @@ export function useNFTOffers({ walletAddress }: { walletAddress: string }) {
   const query = useQuery<GetNftOffersQuery>(
     queryKey,
     async () =>
-      await graphqlClient.getNFTOffers({
+      await arcClient.getNFTOffers({
         walletAddress,
         // TODO: remove sortBy once the backend supports it
         sortBy: SortCriterion.TopBidValue,

--- a/src/screens/mints/PoapSheet.tsx
+++ b/src/screens/mints/PoapSheet.tsx
@@ -40,12 +40,12 @@ import { ButtonPressAnimation } from '@/components/animations';
 import { useFocusEffect, useRoute } from '@react-navigation/native';
 import { PoapEvent } from '@/graphql/__generated__/arcDev';
 import { format } from 'date-fns';
-import { arcClient, arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 import Spinner from '@/components/Spinner';
 import { delay } from '@/utils/delay';
 import { useLegacyNFTs } from '@/resources/nfts';
 import { UniqueAsset } from '@/entities';
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import { PoapMintError } from '@/utils/poaps';
 import { analyticsV2 } from '@/analytics';
@@ -129,9 +129,8 @@ const PoapSheet = () => {
       return;
     }
     setClaimStatus('claiming');
-    const client = IS_DEV ? arcDevClient : arcClient;
     if (!poapEvent.secret || !poapEvent.qrHash) return;
-    const response = await client.claimPoapByQrHash({
+    const response = await arcClient.claimPoapByQrHash({
       walletAddress: accountAddress,
       qrHash: poapEvent.qrHash,
       secret: poapEvent.secret,
@@ -172,9 +171,8 @@ const PoapSheet = () => {
     }
     if (!poapEvent.secretWord) return;
     setClaimStatus('claiming');
-    const client = IS_DEV ? arcDevClient : arcClient;
 
-    const response = await client.claimPoapBySecretWord({
+    const response = await arcClient.claimPoapBySecretWord({
       walletAddress: accountAddress,
       secretWord: poapEvent.secretWord,
     });

--- a/src/utils/poaps.ts
+++ b/src/utils/poaps.ts
@@ -1,7 +1,6 @@
-import { arcClient, arcDevClient } from '@/graphql';
+import { arcClient } from '@/graphql';
 import { Navigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
-import { IS_DEV } from '@/env';
 import { logger } from '@/logger';
 
 export type PoapMintError = 'LIMIT_EXCEEDED' | 'EVENT_EXPIRED' | 'UNKNOWN';
@@ -11,9 +10,7 @@ export const getPoapAndOpenSheetWithSecretWord = async (
   goBack: boolean
 ) => {
   try {
-    const client = IS_DEV ? arcDevClient : arcClient;
-
-    const event = await client.getPoapEventBySecretWord({
+    const event = await arcClient.getPoapEventBySecretWord({
       secretWord,
     });
 
@@ -35,9 +32,7 @@ export const getPoapAndOpenSheetWithQRHash = async (
   goBack: boolean
 ) => {
   try {
-    const client = IS_DEV ? arcDevClient : arcClient;
-
-    const event = await client.getPoapEventByQrHash({
+    const event = await arcClient.getPoapEventByQrHash({
       qrHash,
     });
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
I noticed that a bunch of places in the app use the incorrect arc client which is very dangerous. To fix this, and avoid this in the future, I centralized the arc client selection to one location that exports the proper client to use.

## Screen recordings / screenshots


## What to test

