### PR TITLE
Disable frame processor for vision camera 

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -46,4 +46,5 @@ hermesEnabled=true
 # jvmargs
 org.gradle.jvmargs=-Xmx4608m
 
-
+# Fix build failure for react-native-vision-camera:buildCMakeDebug[arm64-v8a]
+VisionCamera_disableFrameProcessors=true


### PR DESCRIPTION
This enables me to now build Android on release and debug mode

Did a sanity check on QR code scanning (payment request, rainbow profile and WC) and all looked good!
