### PR TITLE
coin icon: pull out spacing

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
@@ -93,13 +93,15 @@ const MemoizedBalanceCoinRow = React.memo(
       <View style={sx.flex}>
         <ButtonPressAnimation onPress={handlePress} scaleTo={0.96} testID={`balance-coin-row-${item?.name}`}>
           <View style={[sx.container]}>
-            <FastCoinIcon
-              address={item?.address}
-              network={item?.network}
-              mainnetAddress={item?.mainnet_address}
-              symbol={item?.symbol}
-              theme={theme}
-            />
+            <View style={sx.iconContainer}>
+              <FastCoinIcon
+                address={item?.address}
+                network={item?.network}
+                mainnetAddress={item?.mainnet_address}
+                symbol={item?.symbol}
+                theme={theme}
+              />
+            </View>
 
             <View style={[sx.innerContainer, isHidden && sx.hiddenRow]}>
               <View style={sx.row}>
@@ -171,6 +173,12 @@ export default React.memo(function BalanceCoinRow({ uniqueId, extendedState }: {
 const sx = StyleSheet.create({
   bottom: {
     marginTop: 10,
+  },
+  iconContainer: {
+    elevation: 6,
+    height: 59,
+    overflow: 'visible',
+    paddingTop: 9,
   },
   checkboxContainer: {
     alignSelf: 'center',

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinBadge.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinBadge.tsx
@@ -66,7 +66,7 @@ export const FastChainBadge = React.memo(function FastChainBadge({ network, them
 
   const containerStyle: ViewStyle = {
     alignItems: 'center',
-    bottom: 14.5,
+    bottom: 5.5,
     elevation: 10,
     height: 28,
     left: -11.5,

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCoinIcon.tsx
@@ -116,9 +116,7 @@ const sx = StyleSheet.create({
   },
   container: {
     elevation: 6,
-    height: 59,
     overflow: 'visible',
-    paddingTop: 9,
   },
   contract: {
     height: 40,

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -123,13 +123,15 @@ export default React.memo(function FastCurrencySelectionRow({
         disabled={disabled}
       >
         <View style={sx.rootContainer}>
-          <FastCoinIcon
-            address={address || item?.address}
-            network={favorite ? Network.mainnet : network}
-            mainnetAddress={mainnet_address ?? item?.mainnet_address}
-            symbol={symbol ?? item?.symbol}
-            theme={theme}
-          />
+          <View style={sx.iconContainer}>
+            <FastCoinIcon
+              address={address || item?.address}
+              network={favorite ? Network.mainnet : network}
+              mainnetAddress={mainnet_address ?? item?.mainnet_address}
+              symbol={symbol ?? item?.symbol}
+              theme={theme}
+            />
+          </View>
           <View style={sx.innerContainer}>
             <View
               style={[
@@ -209,6 +211,12 @@ const sx = StyleSheet.create({
   addGradient: {
     paddingBottom: 3,
     paddingLeft: 1,
+  },
+  iconContainer: {
+    elevation: 6,
+    height: 59,
+    overflow: 'visible',
+    paddingTop: 9,
   },
   addText: {
     fontSize: 26,

--- a/src/components/coin-row/FastTransactionCoinRow.tsx
+++ b/src/components/coin-row/FastTransactionCoinRow.tsx
@@ -120,13 +120,15 @@ export default React.memo(function TransactionCoinRow({ item, theme }: { item: a
               {item.network !== Network.mainnet && <ChainBadge network={item.network} badgeYPosition={10} />}
             </View>
           ) : (
-            <FastCoinIcon
-              address={mainnetAddress || item.address}
-              network={item.network}
-              mainnetAddress={mainnetAddress}
-              symbol={item.symbol}
-              theme={theme}
-            />
+            <View style={sx.iconContainer}>
+              <FastCoinIcon
+                address={mainnetAddress || item.address}
+                network={item.network}
+                mainnetAddress={mainnetAddress}
+                symbol={item.symbol}
+                theme={theme}
+              />
+            </View>
           )}
         </View>
         <View style={sx.column}>
@@ -157,6 +159,12 @@ const sx = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-end',
     paddingLeft: 8,
+  },
+  iconContainer: {
+    elevation: 6,
+    height: 59,
+    overflow: 'visible',
+    paddingTop: 9,
   },
   bottomRow: {
     alignItems: 'flex-end',

--- a/src/components/exchange/ExchangeTokenRow.tsx
+++ b/src/components/exchange/ExchangeTokenRow.tsx
@@ -10,6 +10,7 @@ import { ButtonPressAnimation } from '../animations';
 import { FloatingEmojis } from '../floating-emojis';
 import { IS_IOS } from '@/env';
 import { FavStar, Info } from '../asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow';
+import { View } from 'react-native';
 
 interface ExchangeTokenRowProps {
   item: any;
@@ -58,14 +59,16 @@ export default React.memo(function ExchangeTokenRow({
         >
           <Columns alignVertical="center" space="10px">
             <Column width="content">
-              <Box
-                as={FastCoinIcon}
-                address={address || item?.address}
-                network={network || Network.mainnet}
-                mainnetAddress={mainnet_address ?? item?.mainnet_address}
-                symbol={symbol ?? item?.symbol}
-                theme={theme}
-              />
+              <View style={{ height: 59, paddingTop: 9 }}>
+                <Box
+                  as={FastCoinIcon}
+                  address={address || item?.address}
+                  network={network || Network.mainnet}
+                  mainnetAddress={mainnet_address ?? item?.mainnet_address}
+                  symbol={symbol ?? item?.symbol}
+                  theme={theme}
+                />
+              </View>
             </Column>
             <Column>
               <Stack space="8px">


### PR DESCRIPTION
## What changed (plus any additional context for devs)
the fast coin icon component was created to be used in certain coin rows, with that being the case there was extra spacing being added to the component that causes unforeseen formatting issues when used elsewhere

i've moved this out and added that spacing where it was intended to be 


## Screen recordings / screenshots


## What to test

