### PR TITLE
swaps: fix max native check

### DIFF
--- a/src/hooks/useSwapInputHandlers.ts
+++ b/src/hooks/useSwapInputHandlers.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert } from '../components/alerts';
 import { isNativeAsset } from '@/handlers/assets';
-import { greaterThan, multiply, subtract, toFixedDecimals } from '@/helpers/utilities';
+import { greaterThan, toFixedDecimals } from '@/helpers/utilities';
 import { useGas } from '@/hooks';
 import { AppState } from '@/redux/store';
 import { updateSwapInputAmount, updateSwapNativeAmount, updateSwapOutputAmount } from '@/redux/swap';
@@ -11,7 +11,6 @@ import { ethereumUtils } from '@/utils';
 
 export default function useSwapInputHandlers() {
   const dispatch = useDispatch();
-  const type = useSelector((state: AppState) => state.swap.type);
 
   const { selectedGasFee, l1GasFeeOptimism } = useGas();
 
@@ -26,12 +25,11 @@ export default function useSwapInputHandlers() {
     const oldAmount = accountAsset?.balance?.amount ?? '0';
     let newAmount = oldAmount;
     if (isNativeAsset(inputCurrencyAddress, inputCurrencyNetwork) && accountAsset) {
+      // this subtracts gas from the balance of the asset
       newAmount = toFixedDecimals(ethereumUtils.getBalanceAmount(selectedGasFee, accountAsset, l1GasFeeOptimism), 6);
-      const transactionFee = subtract(oldAmount, newAmount);
-      const newAmountMinusFee = toFixedDecimals(subtract(newAmount, multiply(transactionFee, 1.5)), 6);
 
-      if (greaterThan(newAmountMinusFee, 0)) {
-        dispatch(updateSwapInputAmount(newAmountMinusFee));
+      if (greaterThan(newAmount, 0)) {
+        dispatch(updateSwapInputAmount(newAmount));
       } else {
         Alert({
           message: lang.t('expanded_state.swap.swap_max_insufficient_alert.message', { symbol: accountAsset.symbol }),


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Fixing max native swaps

we were subtracting gas 2.5 times so users would get the "not enough balance" error when they shouldnt be 

now we allow full max balance swaps

## Screen recordings / screenshots
<img width="452" alt="Screenshot 2024-02-09 at 12 55 00 PM" src="https://github.com/rainbow-me/rainbow/assets/29204161/5e407a0f-834e-4f19-a2c1-8811a07a0c91">



## What to test

