### PR TITLE
chore: migrate pinned + hidden tokens

### DIFF
--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -11,6 +11,7 @@ import { prepareDefaultNotificationGroupSettingsState } from '@/migrations/migra
 import { changeLanguageKeys } from './migrations/changeLanguageKeys';
 import { fixHiddenUSDC } from './migrations/fixHiddenUSDC';
 import { purgeWcConnectionsWithoutAccounts } from './migrations/purgeWcConnectionsWithoutAccounts';
+import { migratePinnedAndHiddenTokenUniqueIds } from './migrations/migratePinnedAndHiddenTokenUniqueIds';
 
 /**
  * Local storage for migrations only. Should not be exported.
@@ -33,6 +34,7 @@ const migrations: Migration[] = [
   changeLanguageKeys(),
   fixHiddenUSDC(),
   purgeWcConnectionsWithoutAccounts(),
+  migratePinnedAndHiddenTokenUniqueIds(),
 ];
 
 /**

--- a/src/migrations/migrations/migratePinnedAndHiddenTokenUniqueIds.ts
+++ b/src/migrations/migrations/migratePinnedAndHiddenTokenUniqueIds.ts
@@ -1,0 +1,43 @@
+import { BooleanMap } from '@/hooks/useCoinListEditOptions';
+import { Migration, MigrationName } from '@/migrations/types';
+import { loadAddress } from '@/model/wallet';
+import { Network } from '@/networks/types';
+import { getUniqueId } from '@/utils/ethereumUtils';
+import { MMKV } from 'react-native-mmkv';
+
+const mmkv = new MMKV();
+
+export function migratePinnedAndHiddenTokenUniqueIds(): Migration {
+  return {
+    name: MigrationName.migratePinnedAndHiddenTokenUniqueIds,
+    async defer() {
+      const address = await loadAddress();
+      const hiddenCoinsKey = 'hidden-coins-obj-' + address;
+      const pinnedCoinsKey = 'pinned-coins-obj-' + address;
+      const hiddenCoinsString = mmkv.getString(hiddenCoinsKey);
+      const pinnedCoinsString = mmkv.getString(pinnedCoinsKey);
+      const hiddenCoinsKeys = Object.keys(hiddenCoinsString ? JSON.parse(hiddenCoinsString) : {});
+      const pinnedCoinsKeys = Object.keys(pinnedCoinsString ? JSON.parse(pinnedCoinsString) : {});
+      const newHiddenCoins = hiddenCoinsKeys.reduce((acc, curr) => {
+        if (!curr.includes('_')) {
+          acc[getUniqueId(curr, Network.mainnet)] = true;
+          return acc;
+        }
+        acc[curr] = true;
+        return acc;
+      }, {} as BooleanMap);
+
+      const newPinnedCoins = pinnedCoinsKeys.reduce((acc, curr) => {
+        if (!curr.includes('_')) {
+          acc[getUniqueId(curr, Network.mainnet)] = true;
+          return acc;
+        }
+        acc[curr] = true;
+        return acc;
+      }, {} as BooleanMap);
+
+      mmkv.set('hidden-coins-obj-' + address, JSON.stringify(newHiddenCoins));
+      mmkv.set('pinned-coins-obj-' + address, JSON.stringify(newPinnedCoins));
+    },
+  };
+}

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -14,6 +14,7 @@ export enum MigrationName {
   changeLanguageKeys = 'migration_changeLanguageKeys',
   fixHiddenUSDC = 'migration_fixHiddenUSDC',
   purgeWcConnectionsWithoutAccounts = 'migration_purgeWcConnectionsWithoutAccounts',
+  migratePinnedAndHiddenTokenUniqueIds = 'migration_migratePinnedAndHiddenTokenUniqueIds',
 }
 
 export type Migration = {


### PR DESCRIPTION
Fixes APP-1166

## What changed (plus any additional context for devs)
uniqueIds for mainnet are not `address_network` instead of just `address`


## Screen recordings / screenshots


## What to test

