### PR TITLE
fun: add color to nft sends

### DIFF
--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -65,6 +65,7 @@ import { setHardwareTXError } from '@/navigation/HardwareWalletTxNavigator';
 import { Wallet } from '@ethersproject/wallet';
 import { getNetworkObj } from '@/networks';
 import { getNextNonce } from '@/state/nonces';
+import { usePersistentDominantColorFromImage } from '@/hooks/usePersistentDominantColorFromImage';
 
 const sheetHeight = deviceUtils.dimensions.height - (IS_ANDROID ? 30 : 10);
 const statusBarHeight = IS_IOS ? safeAreaInsetValues.top : StatusBar.currentHeight;
@@ -164,8 +165,10 @@ export default function SendSheet(props) {
   const isNft = selected?.type === AssetTypes.nft;
 
   let colorForAsset = useColorForAsset(selected, null, false, true);
+  const nftColor = usePersistentDominantColorFromImage(selected?.lowResUrl) ?? colors.appleBlue;
+
   if (isNft) {
-    colorForAsset = colors.appleBlue;
+    colorForAsset = nftColor;
   }
 
   const uniqueTokenType = isNft ? getUniqueTokenType(selected) : undefined;
@@ -868,6 +871,7 @@ export default function SendSheet(props) {
             txSpeedRenderer={
               <GasSpeedButton
                 asset={selected}
+                fallbackColor={colorForAsset}
                 currentNetwork={currentNetwork}
                 horizontalPadding={0}
                 marginBottom={17}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
erc20 sends have accent colors and nfts did not so im adding for funzies 

<img width="418" alt="Screenshot 2024-02-15 at 2 12 52 PM" src="https://github.com/rainbow-me/rainbow/assets/29204161/5d77c8fe-1e87-4450-9a9b-e7efff835ba5">



## Screen recordings / screenshots


## What to test

