### PR TITLE
fix saving nft images

### DIFF
--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -344,7 +344,7 @@ const UniqueTokenExpandedStateHeader = ({
       } else if (actionKey === AssetActionsEnum.copyTokenID) {
         setClipboard(asset.id);
       } else if (actionKey === AssetActionsEnum.download) {
-        saveToCameraRoll(getFullResUrl(asset.image_original_url));
+        saveToCameraRoll(getFullResUrl(asset.image_url));
       } else if (actionKey === AssetActionsEnum.hide) {
         if (isHiddenAsset) {
           removeHiddenToken(asset);

--- a/src/components/expanded-state/unique-token/saveToCameraRoll.js
+++ b/src/components/expanded-state/unique-token/saveToCameraRoll.js
@@ -1,4 +1,4 @@
-import CameraRoll from '@react-native-camera-roll/camera-roll';
+import { CameraRoll } from '@react-native-camera-roll/camera-roll';
 import lang from 'i18n-js';
 import { PermissionsAndroid, Platform } from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';

--- a/src/utils/getFullResUrl.ts
+++ b/src/utils/getFullResUrl.ts
@@ -5,7 +5,7 @@ export const GOOGLE_USER_CONTENT_URL = 'https://lh3.googleusercontent.com/';
 
 export const getFullResUrl = (url: string | null | undefined) => {
   if (url?.startsWith?.(GOOGLE_USER_CONTENT_URL)) {
-    return `${url}=s0`; // s0 gets the original size from google
+    return url.replace(/=s\d+$/, '=s0'); // s0 gets the original size from google
   }
   return url;
 };


### PR DESCRIPTION
Fixes APP-101, APP-428

## What changed (plus any additional context for devs)
* update import from camera roll package
* switch unique asset image url that was being saved. before, some ipfs uris were sneaking thru

## Screen recordings / screenshots


## What to test
need to test on android still
