### PR TITLE
[FEAT]: Initialize swaps v2 for follow-up work

### DIFF
--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1088,12 +1088,14 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Rainbow/Pods-Rainbow-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/__SWAPS_V2__/README.md
+++ b/src/__SWAPS_V2__/README.md
@@ -1,0 +1,9 @@
+### Swaps V2
+
+Please keep ALL code related to Swaps V2 inside of this folder. Here is the underlying process of how Swaps V2 work will proceed:
+1. We will develop Swaps V2 from the ground up with no overlap with the existing swaps flow.
+2. When you create a file inside of this folder, PLEASE copy the folder structure of how it will fit into the app.
+
+Please note: This entire folder will not be bundled into production.
+
+This folder is behind the `swaps_v2` feature flag which can be enabled via the developer settings. See [this file](https://github.com/rainbow-me/rainbow/blob/e9f1c0a13e6c221e252a02013a2ab2414fa6ed9e/src/screens/SettingsSheet/components/DevSection.tsx#L425-L438), which can be accessed via Settings => scroll to the bottom.

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -23,6 +23,7 @@ export const POINTS = 'Points';
 export const REMOTE_PROMO_SHEETS = 'RemotePromoSheets';
 export const REMOTE_CARDS = 'RemoteCards';
 export const POINTS_NOTIFICATIONS_TOGGLE = 'PointsNotificationsToggle';
+export const SWAPS_V2 = 'SwapsV2';
 
 /**
  * A developer setting that pushes log lines to an array in-memory so that
@@ -55,6 +56,7 @@ export const defaultConfig: Record<string, ExperimentalValue> = {
   [REMOTE_PROMO_SHEETS]: { settings: true, value: false },
   [REMOTE_CARDS]: { settings: true, value: false },
   [POINTS_NOTIFICATIONS_TOGGLE]: { settings: true, value: false },
+  [SWAPS_V2]: { settings: true, value: false },
 };
 
 const storageKey = 'config';

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -71,6 +71,7 @@ interface RainbowConfig extends Record<string, string | boolean | number> {
   remote_cards_enabled: boolean;
   remote_promo_enabled: boolean;
   points_notifications_toggle: boolean;
+  swaps_v2: boolean;
 }
 
 const DEFAULT_CONFIG: RainbowConfig = {
@@ -134,6 +135,7 @@ const DEFAULT_CONFIG: RainbowConfig = {
   remote_cards_enabled: false,
   remote_promo_enabled: false,
   points_notifications_toggle: true,
+  swaps_v2: false,
 };
 
 export async function fetchRemoteConfig(): Promise<RainbowConfig> {
@@ -177,7 +179,8 @@ export async function fetchRemoteConfig(): Promise<RainbowConfig> {
         key === 'rpc_proxy_enabled' ||
         key === 'remote_promo_enabled' ||
         key === 'remote_cards_enabled' ||
-        key === 'points_notifications_toggle'
+        key === 'points_notifications_toggle' ||
+        key === 'swaps_v2'
       ) {
         config[key] = entry.asBoolean();
       } else {


### PR DESCRIPTION
This branch sets up the barebones work needed to start building out the Swaps v2 functionality.

We will be building out each feature while keeping the parent branch as develop (vs. a feat branch). **It's important to not cross-over hooks, data-fetching, etc.**

We will also be scrubbing the entire `__SWAPS_V2__` folder when building for production, so we don't need to worry about functionality effecting current develop swaps functionality.