### PR TITLE
Bump sim version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "install-pods-fast": "cd ios && bundle exec pod install && cd ..",
     "install-pods-fast-jsc": "cd ios && bundle exec env USE_HERMES=NO pod install && cd ..",
     "install-pods-no-flipper": "cd ios && bundle exec env SKIP_FLIPPER=true pod install --repo-update && cd ..",
-    "ios": "react-native run-ios --simulator='iPhone 14 Pro'",
+    "ios": "react-native run-ios --simulator='iPhone 15 Pro'",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "yarn format:check && yarn lint:ts && yarn lint:js",


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Everyone should be using Xcode 15 which no longer has the 14 pro sim, but it has the 15 pro sim by default.

## Screen recordings / screenshots


## What to test

