### PR TITLE
property should be theme.isDarkMode

### DIFF
--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -661,7 +661,7 @@ export const SendConfirmationSheet = () => {
           </SendButtonWrapper>
           {isENS && (
             /* @ts-expect-error JavaScript component */
-            <GasSpeedButton currentNetwork={network} theme={isDarkMode ? 'dark' : 'light'} />
+            <GasSpeedButton currentNetwork={network} theme={theme.isDarkMode ? 'dark' : 'light'} />
           )}
         </Column>
       </SlackSheet>


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- property should be theme.isDarkMode
- error was hidden by the comment in the above line
- only impacted ens confirmation screen

