### PR TITLE
NFT Offers: crash fix

### DIFF
--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -23,8 +23,8 @@ export interface UserProperties {
   // nft offers
   nftOffersAmount?: number;
   nftOffersUSDValue?: number;
-  nftOffersMeanOfferVariance?: number;
-  nftOffersMedianOfferVariance?: number;
+  nftOffersMedianFloorDifferencePercentage?: number;
+  nftOffersMeanFloorDifferencePercentage?: number;
 
   // mint.fun
   numberOfMints?: number;

--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -23,8 +23,8 @@ export interface UserProperties {
   // nft offers
   nftOffersAmount?: number;
   nftOffersUSDValue?: number;
-  nftOffersMedianFloorDifferencePercentage?: number;
-  nftOffersMeanFloorDifferencePercentage?: number;
+  nftOffersMeanOfferVariance?: number;
+  nftOffersMedianOfferVariance?: number;
 
   // mint.fun
   numberOfMints?: number;

--- a/src/resources/reservoir/nftOffersQuery.ts
+++ b/src/resources/reservoir/nftOffersQuery.ts
@@ -117,8 +117,8 @@ export function useNFTOffers({ walletAddress }: { walletAddress: string }) {
     analyticsV2.identify({
       nftOffersAmount: nftOffers.length,
       nftOffersUSDValue: totalUSDValue,
-      nftOffersMedianFloorDifferencePercentage: medianFloorDifferencePercentage,
-      nftOffersMeanFloorDifferencePercentage: meanFloorDifferencePercentage,
+      nftOffersMedianOfferVariance: medianFloorDifferencePercentage,
+      nftOffersMeanOfferVariance: meanFloorDifferencePercentage,
     });
   }, [query.data?.nftOffers]);
 

--- a/src/resources/reservoir/nftOffersQuery.ts
+++ b/src/resources/reservoir/nftOffersQuery.ts
@@ -98,23 +98,27 @@ export function useNFTOffers({ walletAddress }: { walletAddress: string }) {
     const offerVarianceArray = nftOffers.map(offer => offer.floorDifferencePercentage / 100);
     offerVarianceArray.sort((a, b) => a - b);
 
-    // calculate median offer variance
+    // calculate median floor difference percentage
     const middleIndex = Math.floor(offerVarianceArray.length / 2);
-    let medianVariance;
-    if (offerVarianceArray.length % 2 === 0) {
-      medianVariance = (offerVarianceArray[middleIndex - 1] + offerVarianceArray[middleIndex]) / 2;
-    } else {
-      medianVariance = offerVarianceArray[middleIndex];
+    let medianFloorDifferencePercentage;
+    if (offerVarianceArray.length) {
+      if (offerVarianceArray.length % 2 === 0) {
+        medianFloorDifferencePercentage = (offerVarianceArray[middleIndex - 1] + offerVarianceArray[middleIndex]) / 2;
+      } else {
+        medianFloorDifferencePercentage = offerVarianceArray[middleIndex];
+      }
     }
 
-    // calculate mean offer variance
-    const meanVariance = offerVarianceArray.reduce((acc, cur) => acc + cur, 0) / offerVarianceArray.length;
+    // calculate mean floor difference percentage
+    const meanFloorDifferencePercentage = offerVarianceArray.length
+      ? offerVarianceArray.reduce((acc, cur) => acc + cur, 0) / offerVarianceArray.length
+      : undefined;
 
     analyticsV2.identify({
       nftOffersAmount: nftOffers.length,
       nftOffersUSDValue: totalUSDValue,
-      nftOffersMedianOfferVariance: medianVariance,
-      nftOffersMeanOfferVariance: meanVariance,
+      nftOffersMedianFloorDifferencePercentage: medianFloorDifferencePercentage,
+      nftOffersMeanFloorDifferencePercentage: meanFloorDifferencePercentage,
     });
   }, [query.data?.nftOffers]);
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
* fixes this crash https://rainbowhaus.slack.com/archives/C0468CDBE75/p1710885267376909
* the crash was occurring when NaN values were being passed into `analytics.identify`. segment apparently didn't complain, but rudderstack does NOT like this
* in the nft offers hook, the mean/median floor difference percentage is calculated for all offers. this involves accessing arrays and dividing those accessed values by other numbers. the problem occurred when there were no NFT offers - trying to access an empty array yields undefined, and dividing undefined by a number yields NaN
* the fix: added some length checks to the array before trying to access + utilize its values. also renamed some analytics properties bc they were confusing

## Screen recordings / screenshots

BEFORE:

https://github.com/rainbow-me/rainbow/assets/15272675/d8433990-f132-4d89-ad72-8a95b1a4e528

AFTER:

https://github.com/rainbow-me/rainbow/assets/15272675/89e34486-6290-47c9-b959-93a55097783e



## What to test

