### PR TITLE
Fix browser context menu not updating

### DIFF
--- a/src/components/DappBrowser/search-input/SearchInput.tsx
+++ b/src/components/DappBrowser/search-input/SearchInput.tsx
@@ -151,7 +151,7 @@ export const SearchInput = ({
       ],
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [/* canGoBack, */ isFavorite(formattedUrl)]
+    [/* canGoBack, */ isFavorite(formattedUrl), isGoogleSearch]
   );
 
   const onPressMenuItem = async ({ nativeEvent: { actionKey } }: { nativeEvent: { actionKey: 'share' | 'favorite' | 'back' } }) => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- menuConfig was missing the `isGoogleSearch` dependency
