### PR TITLE
Browser: fix ref assignment, back/forward navigation

### DIFF
--- a/src/components/DappBrowser/BrowserContext.tsx
+++ b/src/components/DappBrowser/BrowserContext.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useLayoutEffect, useRef, useState } from 'react';
 import { TextInput } from 'react-native';
 import isEqual from 'react-fast-compare';
 import { MMKV, useMMKVObject } from 'react-native-mmkv';
@@ -37,6 +37,7 @@ export const BrowserTabViewProgressContextProvider = ({ children }: { children: 
 
 interface BrowserContextType {
   activeTabIndex: number;
+  activeTabRef: React.MutableRefObject<WebView | null>;
   animatedActiveTabIndex: SharedValue<number> | undefined;
   closeTab: (tabId: string) => void;
   goBack: () => void;
@@ -81,6 +82,7 @@ const DEFAULT_TAB_STATE: TabState[] = [
 
 const DEFAULT_BROWSER_CONTEXT: BrowserContextType = {
   activeTabIndex: 0,
+  activeTabRef: { current: null },
   animatedActiveTabIndex: undefined,
   closeTab: () => {
     return;
@@ -154,6 +156,7 @@ export const BrowserContextProvider = ({ children }: { children: React.ReactNode
   const searchInputRef = useRef<TextInput>(null);
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>();
   const webViewRefs = useRef<WebView[]>([]);
+  const activeTabRef = useRef<WebView | null>(null);
 
   const loadProgress = useSharedValue(0);
   const searchViewProgress = useSharedValue(0);
@@ -241,30 +244,36 @@ export const BrowserContextProvider = ({ children }: { children: React.ReactNode
   );
 
   const goBack = useCallback(() => {
-    const activeWebview = webViewRefs.current[activeTabIndex];
-    if (activeWebview && tabStates?.[activeTabIndex]?.canGoBack) {
-      activeWebview.goBack();
+    if (activeTabRef.current && tabStates?.[activeTabIndex]?.canGoBack) {
+      activeTabRef.current.goBack();
     }
-  }, [activeTabIndex, tabStates, webViewRefs]);
+  }, [activeTabIndex, activeTabRef, tabStates]);
 
   const goForward = useCallback(() => {
-    const activeWebview = webViewRefs.current[activeTabIndex];
-    if (activeWebview && tabStates?.[activeTabIndex]?.canGoForward) {
-      activeWebview.goForward();
+    if (activeTabRef.current && tabStates?.[activeTabIndex]?.canGoForward) {
+      activeTabRef.current.goForward();
     }
-  }, [activeTabIndex, tabStates, webViewRefs]);
+  }, [activeTabIndex, activeTabRef, tabStates]);
 
   const onRefresh = useCallback(() => {
-    const activeWebview = webViewRefs.current[activeTabIndex];
-    if (activeWebview) {
-      activeWebview.reload();
+    if (activeTabRef.current) {
+      activeTabRef.current.reload();
     }
+  }, [activeTabRef]);
+
+  // useLayoutEffect seems to more reliably assign the ref correctly
+  useLayoutEffect(() => {
+    if (activeTabRef.current !== webViewRefs.current?.[activeTabIndex]) {
+      activeTabRef.current = webViewRefs.current?.[activeTabIndex] || null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabIndex, webViewRefs]);
 
   return (
     <BrowserContext.Provider
       value={{
         activeTabIndex,
+        activeTabRef,
         animatedActiveTabIndex,
         closeTab,
         goBack,

--- a/src/components/DappBrowser/search-input/SearchInput.tsx
+++ b/src/components/DappBrowser/search-input/SearchInput.tsx
@@ -145,8 +145,6 @@ export const SearchInput = ({
               actionTitle: 'Forward',
               icon: {
                 iconType: 'SYSTEM',
-                // iconValue: 'arrow.uturn.right',
-                // iconValue: 'arrow.right',
                 iconValue: 'arrowshape.forward',
               },
             }
@@ -157,8 +155,6 @@ export const SearchInput = ({
               actionTitle: 'Back',
               icon: {
                 iconType: 'SYSTEM',
-                // iconValue: 'arrow.uturn.left',
-                // iconValue: 'arrow.left',
                 iconValue: 'arrowshape.backward',
               },
             }

--- a/src/components/DappBrowser/search-input/SearchInput.tsx
+++ b/src/components/DappBrowser/search-input/SearchInput.tsx
@@ -38,6 +38,7 @@ export const SearchInput = ({
   isFocusedValue,
   logoUrl,
   canGoBack,
+  canGoForward,
 }: {
   inputRef: RefObject<TextInput>;
   formattedInputValue: { value: string; tabIndex: number };
@@ -51,8 +52,9 @@ export const SearchInput = ({
   isFocusedValue: SharedValue<boolean>;
   logoUrl: string | undefined | null;
   canGoBack: boolean;
+  canGoForward: boolean;
 }) => {
-  const { animatedActiveTabIndex, goBack, onRefresh, tabViewProgress } = useBrowserContext();
+  const { animatedActiveTabIndex, goBack, goForward, onRefresh, tabViewProgress } = useBrowserContext();
   const { isFavorite, addFavorite, removeFavorite } = useFavoriteDappsStore();
   const { isDarkMode } = useColorMode();
 
@@ -137,28 +139,48 @@ export const SearchInput = ({
               },
             }
           : {},
+        canGoForward
+          ? {
+              actionKey: 'forward',
+              actionTitle: 'Forward',
+              icon: {
+                iconType: 'SYSTEM',
+                // iconValue: 'arrow.uturn.right',
+                // iconValue: 'arrow.right',
+                iconValue: 'arrowshape.forward',
+              },
+            }
+          : {},
         canGoBack
           ? {
               actionKey: 'back',
               actionTitle: 'Back',
               icon: {
                 iconType: 'SYSTEM',
-                iconValue: 'arrow.uturn.left',
+                // iconValue: 'arrow.uturn.left',
+                // iconValue: 'arrow.left',
+                iconValue: 'arrowshape.backward',
               },
             }
           : {},
       ],
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [canGoBack, isFavorite(formattedUrl), isGoogleSearch]
+    [canGoBack, canGoForward, isFavorite(formattedUrl), isGoogleSearch]
   );
 
-  const onPressMenuItem = async ({ nativeEvent: { actionKey } }: { nativeEvent: { actionKey: 'share' | 'favorite' | 'back' } }) => {
+  const onPressMenuItem = async ({
+    nativeEvent: { actionKey },
+  }: {
+    nativeEvent: { actionKey: 'share' | 'favorite' | 'back' | 'forward' };
+  }) => {
     haptics.selection();
     if (actionKey === 'favorite') {
       handleFavoritePress();
     } else if (actionKey === 'back') {
       goBack();
+    } else if (actionKey === 'forward') {
+      goForward();
     } else if (inputValue) {
       handleShareUrl(inputValue);
     }

--- a/src/components/DappBrowser/search/SearchBar.tsx
+++ b/src/components/DappBrowser/search/SearchBar.tsx
@@ -39,6 +39,7 @@ export const SearchBar = () => {
   const isHome = url === RAINBOW_HOME;
   const isGoogleSearch = url?.startsWith(GOOGLE_SEARCH_URL);
   const canGoBack = tabStates?.[activeTabIndex]?.canGoBack;
+  const canGoForward = tabStates?.[activeTabIndex]?.canGoForward;
 
   const formattedInputValue = useMemo(() => {
     if (isHome) {
@@ -162,6 +163,7 @@ export const SearchBar = () => {
         <Box paddingRight="12px" style={{ flex: 1 }}>
           <SearchInput
             canGoBack={canGoBack}
+            canGoForward={canGoForward}
             onPressWorklet={onAddressInputPressWorklet}
             isFocused={isFocused}
             isFocusedValue={isFocusedValue}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- This fixes the issues causing the link to the active tab ref to break in certain cases, particularly when going from the homepage to a URL
  - The ref (with a null value) was being set in webViewRefs in certain cases before the WebView was mounted, for instance when going from the homepage to a website
- Added a forward button to the context menu
- Reloading should now always work
- Back/forward buttons should now show and work correctly, and persist through reloads and tab switches

## What to test

