### PR TITLE
Browser: remove webviewRefs

### DIFF
--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -193,7 +193,6 @@ export const BrowserTab = React.memo(function BrowserTab({ tabId, tabIndex, inje
     tabViewVisible,
     toggleTabViewWorklet,
     updateActiveTabState,
-    webViewRefs,
   } = useBrowserContext();
   const { isDarkMode } = useColorMode();
   const { width: deviceWidth } = useDimensions();
@@ -410,17 +409,10 @@ export const BrowserTab = React.memo(function BrowserTab({ tabId, tabIndex, inje
   // useLayoutEffect seems to more reliably assign the ref correctly
   useLayoutEffect(() => {
     if (webViewRef.current !== null && isActiveTab) {
-      webViewRefs.current[tabIndex] = webViewRef.current;
       activeTabRef.current = webViewRef.current;
     }
-
-    const currentWebviewRef = webViewRefs.current;
-
-    return () => {
-      currentWebviewRef[tabIndex] = null;
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isActiveTab, isOnHomepage, tabId, tabIndex, webViewRefs]);
+  }, [isActiveTab, isOnHomepage, tabId]);
 
   const saveScreenshotToFileSystem = useCallback(
     async (tempUri: string, tabId: string, timestamp: number, url: string) => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Deletes `webViewRefs` entirely — no reason to hold all of the refs in the context as far as I can tell
- `activeTabRef` takes its place and is assigned the correct ref from the tab itself when that tab becomes active
- This is cleaner and faster and should work equally

## Screen recordings / screenshots


## What to test

