### PR TITLE
Fix instant screenshot setting

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,13 +11,13 @@ PODS:
     - React-Core
     - SSZipArchive (~> 2.2.2)
   - DoubleConversion (1.1.6)
-  - FasterImage (1.3.4):
-    - FasterImage/Nuke (= 1.3.4)
-    - FasterImage/NukeUI (= 1.3.4)
+  - FasterImage (1.4.3):
+    - FasterImage/Nuke (= 1.4.3)
+    - FasterImage/NukeUI (= 1.4.3)
     - React-Core
-  - FasterImage/Nuke (1.3.4):
+  - FasterImage/Nuke (1.4.3):
     - React-Core
-  - FasterImage/NukeUI (1.3.4):
+  - FasterImage/NukeUI (1.4.3):
     - React-Core
   - FBLazyVector (0.72.3)
   - FBReactNativeSpec (0.72.3):
@@ -1253,7 +1253,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CodePush: 9eddecce05cd10491e2673b259c85885a462be33
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FasterImage: 283258273b862374eb2ede3ef9576149fd83deb3
+  FasterImage: 60d0750ddbcefff0070c4c17309c2d1d6cc650f0
   FBLazyVector: 4cce221dd782d3ff7c4172167bba09d58af67ccb
   FBReactNativeSpec: c6bd9e179757b3c0ecf815864fae8032377903ef
   Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@bankify/react-native-animate-number": "0.2.1",
     "@bradgarropy/use-countdown": "1.4.1",
-    "@candlefinance/faster-image": "1.3.4",
+    "@candlefinance/faster-image": "1.4.3",
     "@capsizecss/core": "3.0.0",
     "@ensdomains/address-encoder": "0.2.16",
     "@ensdomains/content-hash": "2.5.7",

--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -810,7 +810,7 @@ export const BrowserTab = React.memo(function BrowserTab({ tabId, tabIndex, inje
                   )}
                 </View>
               </ViewShot>
-              <AnimatedFasterImage source={screenshotSource.value} style={[styles.screenshotContainerStyle, animatedScreenshotStyle]} />
+              <AnimatedFasterImage source={screenshotSource} style={[styles.screenshotContainerStyle, animatedScreenshotStyle]} />
               <WebViewBorder animatedTabIndex={animatedTabIndex} enabled={IS_IOS && isDarkMode && !isOnHomepage} />
               <CloseTabButton
                 animatedMultipleTabsOpen={animatedMultipleTabsOpen}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,10 +1382,10 @@
   dependencies:
     date-fns "^2.19.0"
 
-"@candlefinance/faster-image@1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@candlefinance/faster-image/-/faster-image-1.3.4.tgz#ebbc314dfb2d7901ebd2664d3f1d3f11555f5ed4"
-  integrity sha512-N19Q4Yd7BWWRiWTKPxzsOXdSuy5mqPVcKJ174Lg/tjoci3h0sGQ0l8vSQX+a0ckvR6Op09pWmAccJ5qeZhK7CA==
+"@candlefinance/faster-image@1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@candlefinance/faster-image/-/faster-image-1.4.3.tgz#f6f80da43d4bcfbd27c8b1391c196b591885911a"
+  integrity sha512-CmQuJhgM3+R8ZNlEB8tFt+0r3Ei0OnX5aLnT6rLCDM1KobHAfbIXF1W0WlanlGudfitsdLx+qrX9oolOf+9enA==
 
 "@capsizecss/core@3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Passing `screenshotSource.value` to the `source` prop rather than `screenshotSource` prevents the screenshot from being set immediately — this PR fixes that
- Also bumps faster-image from 1.3.4 to 1.4.3 for some Android fixes

## Screen recordings / screenshots


## What to test

