### PR TITLE
Fix cloudflare protection

### DIFF
--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -795,6 +795,7 @@ export const BrowserTab = React.memo(function BrowserTab({ tabId, tabIndex, inje
                         onLoadProgress={handleOnLoadProgress}
                         onMessage={handleOnMessage}
                         onNavigationStateChange={handleNavigationStateChange}
+                        originWhitelist={['*']}
                         ref={webViewRef}
                         source={{ uri: tabUrl || RAINBOW_HOME }}
                         style={styles.webViewStyle}


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Websites with cloudflare protection weren't working. for ex. dexscreener.com
This PR fixes this

## Screen recordings / screenshots



https://github.com/rainbow-me/rainbow/assets/1247834/f3fadea6-2559-441f-bebf-f822191fc628




## What to test

