### PR TITLE
Fix network remote config stuff

### DIFF
--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -191,6 +191,8 @@ export async function fetchRemoteConfig(): Promise<RainbowConfig> {
         key === 'zora_tx_enabled' ||
         key === 'base_tx_enabled' ||
         key === 'degen_tx_enabled' ||
+        key === 'blast_tx_enabled' ||
+        key === 'avalanche_tx_enabled' ||
         key === 'op_chains_tx_enabled' ||
         key === 'goerli_tx_enabled' ||
         key === 'mainnet_enabled' ||
@@ -201,6 +203,8 @@ export async function fetchRemoteConfig(): Promise<RainbowConfig> {
         key === 'zora_enabled' ||
         key === 'base_enabled' ||
         key === 'degen_enabled' ||
+        key === 'blast_enabled' ||
+        key === 'avalanche_enabled' ||
         key === 'op_chains_enabled' ||
         key === 'goerli_enabled' ||
         key === 'base_swaps_enabled' ||


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
boolean remote config values need to be explicitly parsed as booleans. otherwise, they'll get parsed as strings. this is bad bc "true" and "false" are both truthy values

## Screen recordings / screenshots


## What to test

