### PR TITLE
Disable welcome screen animations when IS_TESTING

### DIFF
--- a/src/screens/WelcomeScreen/index.tsx
+++ b/src/screens/WelcomeScreen/index.tsx
@@ -84,9 +84,16 @@ export default function WelcomeScreen() {
 
   useEffect(() => {
     const initialize = async () => {
+      if (IS_TEST) {
+        logger.log('Skipping animations because IS_TEST is true');
+        contentAnimation.value = 1;
+        createWalletButtonAnimation.value = 1;
+        colorAnimation.value = 0;
+        return;
+      }
+
       hideSplashScreen();
       shouldAnimateRainbows.value = true;
-
       const initialDuration = 120;
 
       contentAnimation.value = withSequence(
@@ -101,56 +108,56 @@ export default function WelcomeScreen() {
         })
       );
 
-      // We need to disable looping animations
-      // There's no way to disable sync yet
-      // See https://stackoverflow.com/questions/47391019/animated-button-block-the-detox
-      if (!IS_TEST) {
-        createWalletButtonAnimation.value = withDelay(
-          initialDuration,
-          withTiming(1.02, { duration: 1000 }, () => {
-            createWalletButtonAnimation.value = withRepeat(
-              withTiming(0.98, {
-                duration: 1000,
-              }),
-              -1,
-              true
-            );
-          })
-        );
-        colorAnimation.value = withRepeat(
-          withTiming(5, {
-            duration: 2500,
-            easing: Easing.linear,
-          }),
-          -1
-        );
-      }
+      createWalletButtonAnimation.value = withDelay(
+        initialDuration,
+        withTiming(1.02, { duration: 1000 }, () => {
+          createWalletButtonAnimation.value = withRepeat(
+            withTiming(0.98, {
+              duration: 1000,
+            }),
+            -1,
+            true
+          );
+        })
+      );
 
-      if (IS_TEST) {
-        logger.log('Disabled loop animations in WelcomeScreen due to .env var IS_TESTING === "true"');
-      }
+      colorAnimation.value = withRepeat(
+        withTiming(5, {
+          duration: 2500,
+          easing: Easing.linear,
+        }),
+        -1
+      );
     };
 
     initialize();
 
     return () => {
+      // Reset all animations to their initial state
       createWalletButtonAnimation.value = 1;
       contentAnimation.value = 1;
+      colorAnimation.value = 0; // Ensure this is reset if it was running
     };
   }, [colorAnimation, contentAnimation, createWalletButtonAnimation, hideSplashScreen, shouldAnimateRainbows]);
 
-  const buttonStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: createWalletButtonAnimation.value }],
-    zIndex: 10,
-  }));
+  const buttonStyle = useAnimatedStyle(() => {
+    if (IS_TEST) {
+      return { transform: [{ scale: 1 }], zIndex: 10 };
+    }
+    return {
+      transform: [{ scale: createWalletButtonAnimation.value }],
+      zIndex: 10,
+    };
+  }, []);
 
-  const contentStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        scale: contentAnimation.value,
-      },
-    ],
-  }));
+  const contentStyle = useAnimatedStyle(() => {
+    if (IS_TEST) {
+      return { transform: [{ scale: 1 }] };
+    }
+    return {
+      transform: [{ scale: contentAnimation.value }],
+    };
+  }, []);
 
   const textStyle = useAnimatedStyle(() => ({
     backgroundColor: calculatedColor.value,

--- a/src/screens/WelcomeScreen/index.tsx
+++ b/src/screens/WelcomeScreen/index.tsx
@@ -108,6 +108,9 @@ export default function WelcomeScreen() {
         })
       );
 
+      // We need to disable looping animations
+      // There's no way to disable sync yet
+      // See https://stackoverflow.com/questions/47391019/animated-button-block-the-detox
       createWalletButtonAnimation.value = withDelay(
         initialDuration,
         withTiming(1.02, { duration: 1000 }, () => {
@@ -133,10 +136,9 @@ export default function WelcomeScreen() {
     initialize();
 
     return () => {
-      // Reset all animations to their initial state
       createWalletButtonAnimation.value = 1;
       contentAnimation.value = 1;
-      colorAnimation.value = 0; // Ensure this is reset if it was running
+      colorAnimation.value = 0;
     };
   }, [colorAnimation, contentAnimation, createWalletButtonAnimation, hideSplashScreen, shouldAnimateRainbows]);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- I built with `IS_TESTING=false` and the screen worked fine
- I built with flag on and animations were gone
- can confirm this is not the behavior on current develop
- this change is what fixed CI-8 i believe

