### PR TITLE
browser: fix android card images

### DIFF
--- a/src/components/DappBrowser/Homepage.tsx
+++ b/src/components/DappBrowser/Homepage.tsx
@@ -95,12 +95,15 @@ const Card = ({ site, showMenuButton, goToUrl }: { showMenuButton?: boolean; sit
             <ColorModeProvider value="dark">
               {(site.screenshot || dappIconUrl) && (
                 <Cover>
-                  <ImgixImage
-                    enableFasterImage
-                    source={{ uri: site.screenshot || dappIconUrl }}
-                    size={CARD_SIZE}
-                    style={{ width: CARD_SIZE, height: 137 }}
-                  />
+                  <Cover style={{ overflow: 'hidden', borderRadius: 24 }}>
+                    <ImgixImage
+                      enableFasterImage
+                      source={{ uri: site.screenshot || dappIconUrl }}
+                      size={CARD_SIZE}
+                      style={{ width: '100%', height: '100%' }}
+                    />
+                  </Cover>
+
                   <Cover>
                     <LinearGradient
                       colors={['rgba(0, 0, 0, 0.6)', 'rgba(0, 0, 0, 0.6)', '#000']}


### PR DESCRIPTION
Fixes APP-1339

## What changed (plus any additional context for devs)
fixes android card overflow



## Screen recordings / screenshots
<img width="833" alt="Screenshot 2024-04-22 at 1 13 09 PM" src="https://github.com/rainbow-me/rainbow/assets/29204161/3a76ffd0-987d-41f8-8a63-13745605d964">


## What to test

