### PR TITLE
zustand: use smol subscriptions

### DIFF
--- a/src/hooks/useAccountTransactions.ts
+++ b/src/hooks/useAccountTransactions.ts
@@ -17,7 +17,7 @@ export const NOE_PAGE = 30;
 export default function useAccountTransactions() {
   const { accountAddress, nativeCurrency } = useAccountSettings();
 
-  const { pendingTransactions: storePendingTransactions } = usePendingTransactionsStore();
+  const storePendingTransactions = usePendingTransactionsStore(state => state.pendingTransactions);
 
   const pendingTransactions = useMemo(() => {
     const txs = storePendingTransactions[accountAddress] || [];

--- a/src/hooks/usePendingTransactions.ts
+++ b/src/hooks/usePendingTransactions.ts
@@ -6,7 +6,7 @@ import useAccountSettings from './useAccountSettings';
 
 export default function usePendingTransactions() {
   const { accountAddress } = useAccountSettings();
-  const { pendingTransactions: storePendingTransactions } = usePendingTransactionsStore();
+  const storePendingTransactions = usePendingTransactionsStore(state => state.pendingTransactions);
 
   const pendingTransactions = useMemo(() => storePendingTransactions[accountAddress] || [], [accountAddress, storePendingTransactions]);
   const getPendingTransactionByHash = useCallback(

--- a/src/hooks/useWatchPendingTxs.ts
+++ b/src/hooks/useWatchPendingTxs.ts
@@ -16,8 +16,12 @@ import { useNonceStore } from '@/state/nonces';
 export const useWatchPendingTransactions = ({ address }: { address: string }) => {
   //const { swapRefreshAssets } = useSwapRefreshAssets();
 
-  const { pendingTransactions: storePendingTransactions, setPendingTransactions } = usePendingTransactionsStore();
-  const { setNonce } = useNonceStore();
+  const { storePendingTransactions, setPendingTransactions } = usePendingTransactionsStore(state => ({
+    storePendingTransactions: state.pendingTransactions,
+    setPendingTransactions: state.setPendingTransactions,
+  }));
+
+  const setNonce = useNonceStore(state => state.setNonce);
 
   const pendingTransactions = useMemo(() => storePendingTransactions[address] || [], [address, storePendingTransactions]);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
using smoller state subscriptions for current zustand stores outside of the browser

## Screen recordings / screenshots


## What to test

