### PR TITLE
Delay tab rendering till injectedJS is in memory

### DIFF
--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -693,7 +693,7 @@ export const BrowserTab = React.memo(
                 <Freeze freeze={!isActiveTab}>
                   <DappBrowserWebview
                     webviewDebuggingEnabled={IS_DEV}
-                    injectedJavaScriptBeforeContentLoaded={injectedJS.current || ''}
+                    injectedJavaScriptBeforeContentLoaded={injectedJS || ''}
                     allowsInlineMediaPlayback
                     fraudulentWebsiteWarningEnabled
                     allowsBackForwardNavigationGestures

--- a/src/components/DappBrowser/types.ts
+++ b/src/components/DappBrowser/types.ts
@@ -36,7 +36,7 @@ export interface BrowserTabProps {
   tabId: string;
   nextTabId: string;
   tabsCount: number;
-  injectedJS: React.MutableRefObject<string | null>;
+  injectedJS: string;
   activeTabRef: React.MutableRefObject<WebView | null>;
   animatedActiveTabIndex: SharedValue<number>;
   closeTabWorklet?(tabId: string, tabIndex: number): void;


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Fixes the issue where there's no web3 provider injected on the current tab when doing an app cold start.

## Screen recordings / screenshots


## What to test

