### PR TITLE
Fix fontSize android crash on SwapDetailsSlippageMessage component

### DIFF
--- a/src/components/expanded-state/swap-details/SwapDetailsSlippageMessage.js
+++ b/src/components/expanded-state/swap-details/SwapDetailsSlippageMessage.js
@@ -55,8 +55,8 @@ export default function SwapDetailsSlippageMessage({
       ) : (
         <Container>
           <Row align="center">
-            <Text weight="bold" size="17pt" color={{ custom: priceImpactColor }}>{`􀇿 `}</Text>
-            <Text weight="bold" size="17pt" color="primary (Deprecated)">
+            <Text weight="bold" size="bmedium" color={{ custom: priceImpactColor }}>{`􀇿 `}</Text>
+            <Text weight="bold" size="bmedium" color="primary (Deprecated)">
               {impactMsg}
             </Text>
           </Row>


### PR DESCRIPTION
Fixes APP-1385

## What changed (plus any additional context for devs)
- Using 17pt caused the old text component to crash on Android due to not being able to set the font size.

## Screen recordings / screenshots


## What to test

