### PR TITLE
Swaps: Refactor favorites logic in CoinRow

### DIFF
--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ButtonPressAnimation } from '@/components/animations';
 import { Box, HitSlop, Inline, Stack, Text } from '@/design-system';
 import { TextColor } from '@/design-system/color/palettes';
@@ -8,8 +8,9 @@ import { CoinRowButton } from '@/__swaps__/screens/Swap/components/CoinRowButton
 import { BalancePill } from '@/__swaps__/screens/Swap/components/BalancePill';
 import { ChainId } from '@/__swaps__/types/chains';
 import { ethereumUtils } from '@/utils';
-import { toggleFavorite, useFavorites } from '@/resources/favorites';
+import { isFavorite, toggleFavorite } from '@/resources/favorites';
 import { ETH_ADDRESS } from '@/references';
+import { AddressZero } from '@ethersproject/constants';
 
 export const CoinRow = ({
   address,
@@ -39,15 +40,8 @@ export const CoinRow = ({
   symbol: string;
 }) => {
   const theme = useTheme();
-  const { favoritesMetadata } = useFavorites();
 
-  const favorites = Object.values(favoritesMetadata);
-
-  const isFavorite = (address: string) => {
-    return favorites.find(fav =>
-      fav.address === ETH_ADDRESS ? '0x0000000000000000000000000000000000000000' === address : fav.address === address
-    );
-  };
+  const [isFavorited, setIsFavorited] = useState<boolean>(isFavorite(address));
 
   const percentChange = useMemo(() => {
     if (isTrending) {
@@ -108,8 +102,10 @@ export const CoinRow = ({
             <Inline space="8px">
               <CoinRowButton icon="􀅳" outline size="icon 14px" />
               <CoinRowButton
-                color={isFavorite(address) ? '#FFCB0F' : undefined}
-                onPress={() => toggleFavorite(address)}
+                color={isFavorited ? '#FFCB0F' : undefined}
+                onPress={async () => {
+                  setIsFavorited(await toggleFavorite(address === AddressZero ? ETH_ADDRESS : address));
+                }}
                 icon="􀋃"
                 weight="black"
               />

--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -103,7 +103,7 @@ export const CoinRow = ({
               <CoinRowButton icon="􀅳" outline size="icon 14px" />
               <CoinRowButton
                 color={isFavorite ? '#FFCB0F' : undefined}
-                onPress={async () => toggleFavorite(address === AddressZero ? ETH_ADDRESS : address)}
+                onPress={() => toggleFavorite(address === AddressZero ? ETH_ADDRESS : address)}
                 icon="􀋃"
                 weight="black"
               />

--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { ButtonPressAnimation } from '@/components/animations';
 import { Box, HitSlop, Inline, Stack, Text } from '@/design-system';
 import { TextColor } from '@/design-system/color/palettes';
@@ -8,7 +8,7 @@ import { CoinRowButton } from '@/__swaps__/screens/Swap/components/CoinRowButton
 import { BalancePill } from '@/__swaps__/screens/Swap/components/BalancePill';
 import { ChainId } from '@/__swaps__/types/chains';
 import { ethereumUtils } from '@/utils';
-import { isFavorite, toggleFavorite } from '@/resources/favorites';
+import { toggleFavorite } from '@/resources/favorites';
 import { ETH_ADDRESS } from '@/references';
 import { AddressZero } from '@ethersproject/constants';
 
@@ -25,6 +25,7 @@ export const CoinRow = ({
   onPress,
   output,
   symbol,
+  isFavorite,
 }: {
   address: string;
   mainnetAddress: string;
@@ -38,10 +39,9 @@ export const CoinRow = ({
   onPress?: () => void;
   output?: boolean;
   symbol: string;
+  isFavorite?: boolean;
 }) => {
   const theme = useTheme();
-
-  const [isFavorited, setIsFavorited] = useState<boolean>(isFavorite(address));
 
   const percentChange = useMemo(() => {
     if (isTrending) {
@@ -102,10 +102,8 @@ export const CoinRow = ({
             <Inline space="8px">
               <CoinRowButton icon="􀅳" outline size="icon 14px" />
               <CoinRowButton
-                color={isFavorited ? '#FFCB0F' : undefined}
-                onPress={async () => {
-                  setIsFavorited(await toggleFavorite(address === AddressZero ? ETH_ADDRESS : address));
-                }}
+                color={isFavorite ? '#FFCB0F' : undefined}
+                onPress={async () => toggleFavorite(address === AddressZero ? ETH_ADDRESS : address)}
                 icon="􀋃"
                 weight="black"
               />

--- a/src/__swaps__/screens/Swap/components/TokenList/TokenToBuySection.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/TokenToBuySection.tsx
@@ -144,6 +144,7 @@ export const TokenToBuySection = ({ section }: { section: AssetToBuySection }) =
               nativeBalance={''}
               output
               symbol={item.symbol}
+              isFavorite={section.id === 'favorites'}
             />
           )}
         />

--- a/src/resources/favorites.ts
+++ b/src/resources/favorites.ts
@@ -127,29 +127,19 @@ export async function refreshFavorites() {
   return updatedMetadata;
 }
 
-export async function toggleFavorite(address: string): Promise<boolean> {
+export async function toggleFavorite(address: string) {
   const favorites = Object.keys(queryClient.getQueryData(favoritesQueryKey) ?? []);
   const lowercasedAddress = address.toLowerCase();
   let updatedFavorites;
-  let isFavorite;
   if (favorites.includes(lowercasedAddress)) {
     updatedFavorites = without(favorites, lowercasedAddress);
-    isFavorite = false;
   } else {
     updatedFavorites = [...favorites, lowercasedAddress];
-    isFavorite = true;
   }
 
   const metadata = await fetchMetadata(updatedFavorites);
 
   queryClient.setQueryData(favoritesQueryKey, metadata);
-  return isFavorite;
-}
-
-export function isFavorite(address: string) {
-  const favorites = Object.keys(queryClient.getQueryData(favoritesQueryKey) ?? []);
-  const lowercasedAddress = address.toLowerCase();
-  return favorites.includes(lowercasedAddress);
 }
 
 /**

--- a/src/resources/favorites.ts
+++ b/src/resources/favorites.ts
@@ -127,20 +127,29 @@ export async function refreshFavorites() {
   return updatedMetadata;
 }
 
-export async function toggleFavorite(address: string) {
+export async function toggleFavorite(address: string): Promise<boolean> {
   const favorites = Object.keys(queryClient.getQueryData(favoritesQueryKey) ?? []);
   const lowercasedAddress = address.toLowerCase();
   let updatedFavorites;
+  let isFavorite;
   if (favorites.includes(lowercasedAddress)) {
     updatedFavorites = without(favorites, lowercasedAddress);
+    isFavorite = false;
   } else {
     updatedFavorites = [...favorites, lowercasedAddress];
+    isFavorite = true;
   }
+
   const metadata = await fetchMetadata(updatedFavorites);
 
-  console.log(metadata);
-
   queryClient.setQueryData(favoritesQueryKey, metadata);
+  return isFavorite;
+}
+
+export function isFavorite(address: string) {
+  const favorites = Object.keys(queryClient.getQueryData(favoritesQueryKey) ?? []);
+  const lowercasedAddress = address.toLowerCase();
+  return favorites.includes(lowercasedAddress);
 }
 
 /**


### PR DESCRIPTION
Fixes APP-1352

## What changed (plus any additional context for devs)
* removes useFavorites hook usage from CoinRow
* pass in isFavorite as prop to CoinRow (based on section id) to eliminate state usage


## Screen recordings / screenshots


## What to test

