### PR TITLE
feat: upgrading swap sdk to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@notifee/react-native": "5.6.0",
     "@rainbow-me/provider": "0.0.11",
     "@rainbow-me/react-native-animated-number": "0.0.2",
-    "@rainbow-me/swaps": "0.17.0",
+    "@rainbow-me/swaps": "0.19.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-camera-roll/camera-roll": "5.7.1",
     "@react-native-clipboard/clipboard": "1.13.2",

--- a/src/raps/unlockAndCrosschainSwap.ts
+++ b/src/raps/unlockAndCrosschainSwap.ts
@@ -25,7 +25,8 @@ export const estimateUnlockAndCrosschainSwap = async (swapParameters: Crosschain
     ETH_ADDRESS_AGGREGATOR.toLowerCase() === inputCurrency.address?.toLowerCase() ||
     isNativeAsset(inputCurrency.address, ethereumUtils.getNetworkFromChainId(Number(chainId)));
 
-  if (!nativeAsset && routeAllowanceTargetAddress) {
+  const shouldNotHaveApproval = tradeDetails.no_approval !== undefined && tradeDetails.no_approval;
+  if (!nativeAsset && routeAllowanceTargetAddress && !shouldNotHaveApproval) {
     swapAssetNeedsUnlocking = await assetNeedsUnlocking(accountAddress, inputAmount, inputCurrency, routeAllowanceTargetAddress, chainId);
     if (swapAssetNeedsUnlocking) {
       const unlockGasLimit = await estimateApprove(accountAddress, inputCurrency.address, routeAllowanceTargetAddress, chainId, false);
@@ -60,7 +61,8 @@ export const createUnlockAndCrosschainSwapRap = async (swapParameters: Crosschai
     isNativeAsset(inputCurrency?.address, ethereumUtils.getNetworkFromChainId(Number(chainId)));
 
   let swapAssetNeedsUnlocking = false;
-  if (!nativeAsset && routeAllowanceTargetAddress) {
+  const shouldNotHaveApproval = tradeDetails.no_approval !== undefined && tradeDetails.no_approval;
+  if (!nativeAsset && routeAllowanceTargetAddress && !shouldNotHaveApproval) {
     swapAssetNeedsUnlocking = await assetNeedsUnlocking(accountAddress, inputAmount, inputCurrency, routeAllowanceTargetAddress, chainId);
     if (swapAssetNeedsUnlocking) {
       const unlock = createNewAction(RapActionTypes.unlock, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3320,10 +3320,10 @@
   dependencies:
     react-merge-refs "^1.0.0"
 
-"@rainbow-me/swaps@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@rainbow-me/swaps/-/swaps-0.17.0.tgz#4db1c3807b1dd040c863dbd34de5f73c0489891b"
-  integrity sha512-iXGSfbs7fopZyFI5nUe4e6LO6z1ZnSY3SPH8tJXYxRpHOUgl9b27r46rLvDTKBFgrng9MQMeXzJkm0EMgisvzA==
+"@rainbow-me/swaps@0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@rainbow-me/swaps/-/swaps-0.19.0.tgz#c4b86a69d814f5d7c5b39b9eb190c949be9e4568"
+  integrity sha512-cBlks1Yx7emNfbdgvhK5d+cchL2e6kCMtzvjGbqrUGnhWv+IQmT0AAdKCZu6KlK+S+3lPbGcEjZ+mUUum42//w==
   dependencies:
     "@ethereumjs/util" "9.0.0"
     "@ethersproject/abi" "5.7.0"


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Upgraded sdk version to 0.19.0, now supporting reservoir relay instant bridges.

Supported networks:
* socket
    * mainnet
    * OP
    * BSC
    * Arbitrum
    * Polygon
    * Base
    * Avalanche
* relay
    *  mainnet: eth, usdc
    * OP: eth, usdc
    * Arbitrum: eth, usdc
    * Base: eth, usdc, degen
    * Blast: eth
    * Zora: eth
    * Degen: degen

## Screen recordings / screenshots

## What to test

Swaps, crosschain swap and bridges flows
* relay supports bridging eth <-> eth, usdc <-> usdc and degen <-> degen
    * For relay's ERC20 bridging, no approval tx is needed

## Notes

Need to publish new sdk version on [npm](https://www.npmjs.com/package/@rainbow-me/swaps)