### PR TITLE
Fix supported chains bugs

### DIFF
--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -1,5 +1,6 @@
 import { Messenger } from '@/browserMessaging/AppMessenger';
 import { AddEthereumChainProposedChain, RequestArguments, RequestResponse, handleProviderRequest } from '@rainbow-me/provider';
+import * as lang from '@/languages';
 
 import { Provider } from '@ethersproject/providers';
 
@@ -164,7 +165,7 @@ const messengerProviderRequestFn = async (messenger: Messenger, request: Provide
   return response;
 };
 
-const isSupportedChainId = (chainId: number) => {
+const isSupportedChainId = (chainId: number | string) => {
   const numericChainId = BigNumber.from(chainId).toNumber();
   return !!RainbowNetworks.find(network => Number(network.id) === numericChainId);
 };
@@ -308,11 +309,13 @@ export const handleProviderRequestApp = ({ messenger, data, meta }: { messenger:
     callbackOptions?: CallbackOptions;
   }) => {
     const { chainId } = proposedChain;
-    const supportedChains = RainbowNetworks.filter(network => network.features.walletconnect).map(network => network.id.toString());
-    const numericChainId = convertHexToString(chainId);
-    const supportedChainId = supportedChains.includes(numericChainId);
-    alert('Chain Id not supported');
-    console.warn('PROVIDER TODO: TODO SEND NOTIFICATION');
+    const supportedChain = isSupportedChainId(chainId);
+    if (!supportedChain) {
+      alert(lang.t(lang.l.dapp_browser.provider_error.unsupported_chain));
+    } else {
+      alert(lang.t(lang.l.dapp_browser.provider_error.no_active_session));
+    }
+    // console.warn('PROVIDER TODO: TODO SEND NOTIFICATION');
     // TODO SEND NOTIFICATION
     // inpageMessenger?.send('rainbow_ethereumChainEvent', {
     //     chainId: proposedChainId,

--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -15,6 +15,7 @@ import { handleDappBrowserConnectionPrompt, handleDappBrowserRequest } from '@/u
 import { Tab } from '@rainbow-me/provider/dist/references/messengers';
 import { getDappMetadata } from '@/resources/metadata/dapp';
 import { useAppSessionsStore } from '@/state/appSessions';
+import { BigNumber } from '@ethersproject/bignumber';
 
 export type ProviderRequestPayload = RequestArguments & {
   id: number;
@@ -163,7 +164,10 @@ const messengerProviderRequestFn = async (messenger: Messenger, request: Provide
   return response;
 };
 
-const isSupportedChainId = (chainId: number) => !!RainbowNetworks.find(network => Number(network.id) === chainId);
+const isSupportedChainId = (chainId: number) => {
+  const numericChainId = BigNumber.from(chainId).toNumber();
+  !!RainbowNetworks.find(network => Number(network.id) === numericChainId);
+};
 const getActiveSession = ({ host }: { host: string }): ActiveSession => {
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host });
   const appSession =

--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -166,7 +166,7 @@ const messengerProviderRequestFn = async (messenger: Messenger, request: Provide
 
 const isSupportedChainId = (chainId: number) => {
   const numericChainId = BigNumber.from(chainId).toNumber();
-  !!RainbowNetworks.find(network => Number(network.id) === numericChainId);
+  return !!RainbowNetworks.find(network => Number(network.id) === numericChainId);
 };
 const getActiveSession = ({ host }: { host: string }): ActiveSession => {
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host });

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -2809,6 +2809,10 @@
         "title": "Ooops!",
         "description": "Seems like you're trying to connect to this dapp via WalletConnect. This is no longer necessary with Rainbow's in-app browser. Go back and choose \"MetaMask\" and everything should work just fine.",
         "cta": "Got it"
+      },
+      "provider_error": {
+        "unsupported_chain": "Unsupported Chain",
+        "no_active_session": "You need to connect to the dapp before attempting to switch chains"
       }
     }
   }


### PR DESCRIPTION
Fixes APP-1409

## What changed (plus any additional context for devs)
- We were not accepting chainIds in hex format (etherscan does that) which was causing the incorrect "unsupported chain id" message.
- Match the behavior with the BX where we ask the user to start a session first before we're able to switch chains.

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbow/assets/1247834/4d2ccf5d-9231-4674-83ad-1de902918e73



## What to test

