### PR TITLE
useAnimatedTime, useAnimatedInterval, useAnimatedTimeout

### DIFF
--- a/src/hooks/reanimated/useAnimatedInterval.ts
+++ b/src/hooks/reanimated/useAnimatedInterval.ts
@@ -1,0 +1,20 @@
+import { useAnimatedTime } from './useAnimatedTime';
+
+interface IntervalConfig {
+  autoStart?: boolean;
+  intervalMs: number;
+  onIntervalWorklet: () => void;
+}
+
+export function useAnimatedInterval(config: IntervalConfig) {
+  const { autoStart = true, intervalMs, onIntervalWorklet } = config;
+
+  const { reset, start, stop } = useAnimatedTime({
+    autoStart,
+    durationMs: intervalMs,
+    onEndWorklet: onIntervalWorklet,
+    shouldRepeat: true,
+  });
+
+  return { reset, start, stop };
+}

--- a/src/hooks/reanimated/useAnimatedTime.ts
+++ b/src/hooks/reanimated/useAnimatedTime.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect } from 'react';
+import { Easing, SharedValue, useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
+
+interface TimerConfig {
+  autoStart?: boolean;
+  durationMs?: number;
+  onEndWorklet?: () => void;
+  shouldRepeat?: boolean;
+}
+
+interface TimerResult {
+  reset: () => void;
+  start: () => void;
+  stop: () => void;
+  timeInSeconds: Readonly<SharedValue<number>>;
+}
+
+export function useAnimatedTime(config: TimerConfig = {}): TimerResult {
+  const { autoStart = false, durationMs = 1000, onEndWorklet, shouldRepeat = false } = config;
+
+  const timeInSeconds = useSharedValue(0);
+
+  const start = useCallback(() => {
+    'worklet';
+    if (timeInSeconds.value !== 0) timeInSeconds.value = 0;
+
+    timeInSeconds.value = withRepeat(
+      withTiming(durationMs / 1000, { duration: durationMs, easing: Easing.linear }, finished => {
+        if (finished && onEndWorklet) {
+          onEndWorklet();
+        }
+      }),
+      shouldRepeat ? -1 : 1,
+      false
+    );
+  }, [durationMs, onEndWorklet, shouldRepeat, timeInSeconds]);
+
+  const stop = useCallback(() => {
+    'worklet';
+    timeInSeconds.value = 0;
+  }, [timeInSeconds]);
+
+  const reset = useCallback(() => {
+    'worklet';
+    stop();
+    start();
+  }, [start, stop]);
+
+  useEffect(() => {
+    if (autoStart) {
+      start();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    reset,
+    start,
+    stop,
+    timeInSeconds,
+  };
+}

--- a/src/hooks/reanimated/useAnimatedTimeout.ts
+++ b/src/hooks/reanimated/useAnimatedTimeout.ts
@@ -1,0 +1,17 @@
+import { useAnimatedTime } from './useAnimatedTime';
+
+interface TimeoutConfig {
+  delayMs: number;
+  onTimeoutWorklet: () => void;
+}
+
+export function useAnimatedTimeout(config: TimeoutConfig) {
+  const { delayMs, onTimeoutWorklet } = config;
+
+  const { start } = useAnimatedTime({
+    durationMs: delayMs,
+    onEndWorklet: onTimeoutWorklet,
+  });
+
+  return { start };
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- New hooks for working with time in Reanimated
- `useAnimatedInterval` and `useAnimatedTimeout` are both built on top of `useAnimatedTime`

**Example:**

```
const { reset } = useAnimatedInterval({
  intervalMs: 5000,
  onIntervalWorklet: () => {
    'worklet';
    console.log('Logging once every 5 seconds');
  },
});

const onPress = () => {
  reset();
}
```

## Screen recordings / screenshots


## What to test

