### PR TITLE
Browser: control panel fixes

### DIFF
--- a/src/components/DappBrowser/DappBrowser.tsx
+++ b/src/components/DappBrowser/DappBrowser.tsx
@@ -125,7 +125,8 @@ const TabViewBackground = () => {
       backgroundColor: interpolateColor(
         tabViewProgress.value,
         [0, 100],
-        [isDarkMode ? globalColors.grey100 : '#FBFCFD', isDarkMode ? '#0A0A0A' : '#F2F2F5']
+        // eslint-disable-next-line no-nested-ternary
+        [isDarkMode ? globalColors.grey100 : IS_ANDROID ? '#F2F2F5' : '#FBFCFD', isDarkMode ? '#0A0A0A' : '#F2F2F5']
       ),
     };
   });

--- a/src/components/DappBrowser/Homepage.tsx
+++ b/src/components/DappBrowser/Homepage.tsx
@@ -217,9 +217,9 @@ const Card = React.memo(function Card({
     const host = new URL(dappUrl).hostname;
     // 👇 TODO: Remove this once the Uniswap logo in the dapps metadata is fixed
     const isUniswap = host === 'uniswap.org' || host.endsWith('.uniswap.org');
-    const overrideFound = dapps.find(dapp => dapp.url.includes(host));
-    if (overrideFound?.iconUrl && !isUniswap) {
-      return overrideFound.iconUrl;
+    const dappOverride = dapps.find(dapp => dapp.urlDisplay === host);
+    if (dappOverride?.iconUrl && !isUniswap) {
+      return dappOverride.iconUrl;
     }
     return iconUrl;
   }, [dapps, site.image, site.url]);
@@ -396,15 +396,7 @@ export const Logo = React.memo(function Logo({ goToUrl, site }: { goToUrl: (url:
               style={{ width: LOGO_SIZE + LOGO_LABEL_SPILLOVER * 2 }}
             > */}
             <Box width={{ custom: LOGO_SIZE + LOGO_LABEL_SPILLOVER * 2 }}>
-              <Text
-                size="13pt"
-                numberOfLines={1}
-                ellipsizeMode="clip"
-                weight="bold"
-                color="labelSecondary"
-                align="center"
-                style={{ paddingVertical: 10 }}
-              >
+              <Text size="13pt" numberOfLines={1} weight="bold" color="labelSecondary" align="center" style={{ paddingVertical: 10 }}>
                 {site.name}
               </Text>
             </Box>

--- a/src/components/DappBrowser/ProgressBar.tsx
+++ b/src/components/DappBrowser/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import Animated, { useAnimatedStyle, withSpring, withTiming } from 'react-native-reanimated';
+import Animated, { useAnimatedReaction, useAnimatedStyle, withSpring, withTiming } from 'react-native-reanimated';
 import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useAccountAccentColor } from '@/hooks';
 import { deviceUtils } from '@/utils';
@@ -9,7 +9,7 @@ import { TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
 
 export const ProgressBar = () => {
   const { accentColor } = useAccountAccentColor();
-  const { loadProgress, tabViewVisible } = useBrowserContext();
+  const { animatedActiveTabIndex, loadProgress, tabViewVisible } = useBrowserContext();
 
   const progressBarStyle = useAnimatedStyle(() => ({
     // eslint-disable-next-line no-nested-ternary
@@ -20,6 +20,15 @@ export const ProgressBar = () => {
         : withSpring(1, SPRING_CONFIGS.snappierSpringConfig),
     width: loadProgress.value * deviceUtils.dimensions.width,
   }));
+
+  useAnimatedReaction(
+    () => animatedActiveTabIndex.value,
+    (current, previous) => {
+      if (current !== previous) {
+        loadProgress.value = 1;
+      }
+    }
+  );
 
   return (
     <View style={[styles.progressBarContainer, styles.centerAlign]}>

--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -119,7 +119,7 @@ export function createTransport<TPayload, TResponse>({ messenger, topic }: { mes
 const messengerProviderRequestFn = async (messenger: Messenger, request: ProviderRequestPayload) => {
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host: getDappHost(request.meta?.sender.url) || '' });
   const appSession =
-    hostSessions && hostSessions.sessions[hostSessions.activeSessionAddress]
+    hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]
       ? {
           address: hostSessions.activeSessionAddress,
           network: hostSessions.sessions[hostSessions.activeSessionAddress],
@@ -138,6 +138,7 @@ const messengerProviderRequestFn = async (messenger: Messenger, request: Provide
       dappName: dappData?.appName || request.meta?.sender.title || '',
       dappUrl: request.meta?.sender.url || '',
       chainId,
+      address: hostSessions?.activeSessionAddress || undefined,
     });
 
     useAppSessionsStore.getState().addSession({
@@ -175,7 +176,7 @@ const isSupportedChainId = (chainId: number | string) => {
 const getActiveSession = ({ host }: { host: string }): ActiveSession => {
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host });
   const appSession =
-    hostSessions && hostSessions.sessions[hostSessions.activeSessionAddress]
+    hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]
       ? {
           address: hostSessions.activeSessionAddress,
           network: hostSessions.sessions[hostSessions.activeSessionAddress],

--- a/src/components/DappBrowser/hooks/useAnimatedTab.ts
+++ b/src/components/DappBrowser/hooks/useAnimatedTab.ts
@@ -112,7 +112,7 @@ export function useAnimatedTab({ tabId }: { tabId: string }) {
 
   const expensiveAnimatedWebViewStyles = useAnimatedStyle(() => {
     const isTabBeingClosed = currentlyOpenTabIds.value.indexOf(tabId) === -1;
-    const animatedIsActiveTab = !isTabBeingClosed && animatedActiveTabIndex.value === animatedTabIndex.value;
+    const animatedIsActiveTab = animatedActiveTabIndex.value === animatedTabIndex.value;
 
     const borderRadius = interpolate(
       tabViewProgress.value,

--- a/src/components/DappBrowser/hooks/useSmoothScrollView.ts
+++ b/src/components/DappBrowser/hooks/useSmoothScrollView.ts
@@ -7,7 +7,7 @@ import { useBrowserContext } from '../BrowserContext';
 import { TAB_VIEW_ROW_HEIGHT } from '../Dimensions';
 
 /**
- * ### useSmoothScrollView
+ * ### `useSmoothScrollView`
  *
  * This hook corrects for the jitter that occurs on iOS within the animated browser ScrollView, most noticeably when
  * a tab is closed when the ScrollView is scrolled to the end.

--- a/src/components/DappBrowser/search-input/AccountIcon.tsx
+++ b/src/components/DappBrowser/search-input/AccountIcon.tsx
@@ -26,10 +26,9 @@ export const AccountIcon = React.memo(function AccountIcon() {
   const activeTabHost = useBrowserStore(state => getDappHost(state.getActiveTabUrl() || DEFAULT_TAB_URL));
   const isOnHomepage = useBrowserStore(state => (state.getActiveTabUrl() || DEFAULT_TAB_URL) === RAINBOW_HOME);
   const hostSessions = useAppSessionsStore(state => state.getActiveSession({ host: activeTabHost }));
-
   const currentSession = useMemo(
     () =>
-      hostSessions && hostSessions.sessions[hostSessions.activeSessionAddress]
+      hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]
         ? {
             address: hostSessions.activeSessionAddress,
             network: hostSessions.sessions[hostSessions.activeSessionAddress],
@@ -41,17 +40,15 @@ export const AccountIcon = React.memo(function AccountIcon() {
   // listens to the current active tab and sets the account
   useEffect(() => {
     if (activeTabHost || isOnHomepage) {
-      if (!currentSession) {
-        return;
-      }
-
       if (currentSession?.address) {
         setCurrentAddress(currentSession?.address);
+      } else if (hostSessions?.activeSessionAddress) {
+        setCurrentAddress(hostSessions.activeSessionAddress);
       } else {
         setCurrentAddress(accountAddress);
       }
     }
-  }, [accountAddress, activeTabHost, currentSession, isOnHomepage]);
+  }, [accountAddress, activeTabHost, currentSession, hostSessions?.activeSessionAddress, isOnHomepage]);
 
   const accountInfo = useMemo(() => {
     const selectedWallet = findWalletWithAccount(wallets || {}, currentAddress);
@@ -64,9 +61,8 @@ export const AccountIcon = React.memo(function AccountIcon() {
   const handleOnPress = useCallback(() => {
     navigate(Routes.DAPP_BROWSER_CONTROL_PANEL, {
       activeTabRef,
-      selectedAddress: currentAddress,
     });
-  }, [activeTabRef, currentAddress, navigate]);
+  }, [activeTabRef, navigate]);
 
   return (
     <Bleed space="8px">

--- a/src/components/DappBrowser/search-input/AccountIcon.tsx
+++ b/src/components/DappBrowser/search-input/AccountIcon.tsx
@@ -13,6 +13,7 @@ import { getDappHost } from '../handleProviderRequest';
 import { ButtonPressAnimation } from '@/components/animations';
 import { useBrowserStore } from '@/state/browser/browserStore';
 import { useBrowserContext } from '../BrowserContext';
+import { DEFAULT_TAB_URL, RAINBOW_HOME } from '../constants';
 
 export const AccountIcon = React.memo(function AccountIcon() {
   const { navigate } = useNavigation();
@@ -22,7 +23,8 @@ export const AccountIcon = React.memo(function AccountIcon() {
   const [currentAddress, setCurrentAddress] = useState<string>(accountAddress);
 
   const { activeTabRef } = useBrowserContext();
-  const activeTabHost = useBrowserStore(state => getDappHost(state.getActiveTabUrl()));
+  const activeTabHost = useBrowserStore(state => getDappHost(state.getActiveTabUrl() || DEFAULT_TAB_URL));
+  const isOnHomepage = useBrowserStore(state => (state.getActiveTabUrl() || DEFAULT_TAB_URL) === RAINBOW_HOME);
   const hostSessions = useAppSessionsStore(state => state.getActiveSession({ host: activeTabHost }));
 
   const currentSession = useMemo(
@@ -38,7 +40,7 @@ export const AccountIcon = React.memo(function AccountIcon() {
 
   // listens to the current active tab and sets the account
   useEffect(() => {
-    if (activeTabHost) {
+    if (activeTabHost || isOnHomepage) {
       if (!currentSession) {
         return;
       }
@@ -49,7 +51,7 @@ export const AccountIcon = React.memo(function AccountIcon() {
         setCurrentAddress(accountAddress);
       }
     }
-  }, [accountAddress, activeTabHost, currentSession]);
+  }, [accountAddress, activeTabHost, currentSession, isOnHomepage]);
 
   const accountInfo = useMemo(() => {
     const selectedWallet = findWalletWithAccount(wallets || {}, currentAddress);
@@ -62,8 +64,9 @@ export const AccountIcon = React.memo(function AccountIcon() {
   const handleOnPress = useCallback(() => {
     navigate(Routes.DAPP_BROWSER_CONTROL_PANEL, {
       activeTabRef,
+      selectedAddress: currentAddress,
     });
-  }, [activeTabRef, navigate]);
+  }, [activeTabRef, currentAddress, navigate]);
 
   return (
     <Bleed space="8px">

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -150,6 +150,7 @@ export interface WalletconnectApprovalSheetRouteParams {
     chainIds: number[];
     isWalletConnectV2?: boolean;
     proposedChainId?: number;
+    proposedAddress?: string;
   } & Pick<WalletconnectRequestData, 'dappName' | 'dappScheme' | 'dappUrl' | 'imageUrl' | 'peerId'>;
   timeout?: ReturnType<typeof setTimeout> | null;
   timedOut?: boolean;

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -30,6 +30,7 @@ import { useDappMetadata } from '@/resources/metadata/dapp';
 import { DAppStatus } from '@/graphql/__generated__/metadata';
 import { InfoAlert } from '@/components/info-alert/info-alert';
 import { EthCoinIcon } from '@/components/coin-icon/EthCoinIcon';
+import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
 
 const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(({ theme: { colors } }) => ({
   color: colors.alpha(colors.blueGreyDark, 0.3),
@@ -152,16 +153,23 @@ const NetworkPill = ({ chainIds }) => {
 
 export default function WalletConnectApprovalSheet() {
   const { colors, isDarkMode } = useTheme();
-  const { goBack, getState } = useNavigation();
+  const { goBack } = useNavigation();
   const { params } = useRoute();
   const { network, accountAddress } = useAccountSettings();
   const { navigate } = useNavigation();
-  const { selectedWallet, walletNames } = useWallets();
+  const { selectedWallet, walletNames, wallets } = useWallets();
   const handled = useRef(false);
-  const [approvalAccount, setApprovalAccount] = useState({
-    address: accountAddress,
-    wallet: selectedWallet,
-  });
+  const initialApprovalAccount = useMemo(
+    () =>
+      params?.meta?.proposedAddress
+        ? { address: params.meta.proposedAddress, wallet: findWalletWithAccount(wallets, params.meta.proposedAddress) }
+        : {
+            address: accountAddress,
+            wallet: selectedWallet,
+          },
+    [accountAddress, params?.meta?.proposedAddress, selectedWallet, wallets]
+  );
+  const [approvalAccount, setApprovalAccount] = useState(initialApprovalAccount);
 
   const type = params?.type || WalletConnectApprovalSheetType.connect;
   const source = params?.source;

--- a/src/state/appSessions/index.ts
+++ b/src/state/appSessions/index.ts
@@ -50,7 +50,7 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
     addSession: ({ host, address, network, url }) => {
       const appSessions = get().appSessions;
       const existingSession = appSessions[host];
-      if (!existingSession) {
+      if (!existingSession || !existingSession.sessions) {
         appSessions[host] = {
           host,
           sessions: { [address]: network },
@@ -109,8 +109,7 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
     },
     updateActiveSession: ({ host, address }) => {
       const appSessions = get().appSessions;
-      const appSession = appSessions[host];
-      if (!appSession) return;
+      const appSession = appSessions[host] || {};
       set({
         appSessions: {
           ...appSessions,
@@ -123,8 +122,7 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
     },
     updateActiveSessionNetwork: ({ host, network }) => {
       const appSessions = get().appSessions;
-      const appSession = appSessions[host];
-      if (!appSession) return;
+      const appSession = appSessions[host] || {};
       set({
         appSessions: {
           ...appSessions,

--- a/src/state/appSessions/index.ts
+++ b/src/state/appSessions/index.ts
@@ -80,14 +80,14 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
       const appSessions = get().appSessions;
       const appSession = appSessions[host];
       let newActiveSession = null;
-      if (appSession.sessions && Object.keys(appSession.sessions).length === 1) {
+      if (appSession?.sessions && Object.keys(appSession.sessions).length === 1) {
         delete appSessions[host];
         set({
           appSessions: {
             ...appSessions,
           },
         });
-      } else if (appSession.sessions) {
+      } else if (appSession?.sessions) {
         delete appSession.sessions[address];
         const newActiveSessionAddress = Object.keys(appSession.sessions)[0] as Address;
         appSession.activeSessionAddress = newActiveSessionAddress;

--- a/src/utils/requestNavigationHandlers.ts
+++ b/src/utils/requestNavigationHandlers.ts
@@ -32,6 +32,7 @@ export interface DappConnectionData {
   dappUrl: string;
   imageUrl?: string;
   chainId?: number;
+  address?: string;
 }
 
 export const handleDappBrowserConnectionPrompt = (dappData: DappConnectionData): Promise<{ chainId: number; address: string } | Error> => {
@@ -49,6 +50,7 @@ export const handleDappBrowserConnectionPrompt = (dappData: DappConnectionData):
         peerId: '',
         dappScheme: null,
         proposedChainId: dappData.chainId,
+        proposedAddress: dappData.address,
       },
       source: 'browser',
       timedOut: false,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Fixes a crash that occurred in the control panel caused by the `appSessions` store
- Fixes account selection logic to make the selected account consistent between the avatar and the control panel
- Fixes control panel account colors
- Adjusts account switching logic to only emit events to the dapp when connected to the dapp
- Fixes an issue where switching accounts when not connected would put the control panel in the connected state

## Screen recordings / screenshots


## What to test

