### PR TITLE
Account switching fixes

### DIFF
--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -119,7 +119,7 @@ export function createTransport<TPayload, TResponse>({ messenger, topic }: { mes
 const messengerProviderRequestFn = async (messenger: Messenger, request: ProviderRequestPayload) => {
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host: getDappHost(request.meta?.sender.url) || '' });
   const appSession =
-    hostSessions && hostSessions.sessions[hostSessions.activeSessionAddress]
+    hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]
       ? {
           address: hostSessions.activeSessionAddress,
           network: hostSessions.sessions[hostSessions.activeSessionAddress],
@@ -138,6 +138,7 @@ const messengerProviderRequestFn = async (messenger: Messenger, request: Provide
       dappName: dappData?.appName || request.meta?.sender.title || '',
       dappUrl: request.meta?.sender.url || '',
       chainId,
+      address: hostSessions?.activeSessionAddress || undefined,
     });
 
     useAppSessionsStore.getState().addSession({
@@ -175,7 +176,7 @@ const isSupportedChainId = (chainId: number | string) => {
 const getActiveSession = ({ host }: { host: string }): ActiveSession => {
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host });
   const appSession =
-    hostSessions && hostSessions.sessions[hostSessions.activeSessionAddress]
+    hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]
       ? {
           address: hostSessions.activeSessionAddress,
           network: hostSessions.sessions[hostSessions.activeSessionAddress],

--- a/src/components/DappBrowser/search-input/AccountIcon.tsx
+++ b/src/components/DappBrowser/search-input/AccountIcon.tsx
@@ -40,10 +40,6 @@ export const AccountIcon = React.memo(function AccountIcon() {
   // listens to the current active tab and sets the account
   useEffect(() => {
     if (activeTabHost || isOnHomepage) {
-      // if (!currentSession) {
-      //   return;
-      // }
-
       if (currentSession?.address) {
         setCurrentAddress(currentSession?.address);
       } else if (hostSessions?.activeSessionAddress) {

--- a/src/components/DappBrowser/search-input/AccountIcon.tsx
+++ b/src/components/DappBrowser/search-input/AccountIcon.tsx
@@ -26,10 +26,9 @@ export const AccountIcon = React.memo(function AccountIcon() {
   const activeTabHost = useBrowserStore(state => getDappHost(state.getActiveTabUrl() || DEFAULT_TAB_URL));
   const isOnHomepage = useBrowserStore(state => (state.getActiveTabUrl() || DEFAULT_TAB_URL) === RAINBOW_HOME);
   const hostSessions = useAppSessionsStore(state => state.getActiveSession({ host: activeTabHost }));
-
   const currentSession = useMemo(
     () =>
-      hostSessions && hostSessions.sessions[hostSessions.activeSessionAddress]
+      hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]
         ? {
             address: hostSessions.activeSessionAddress,
             network: hostSessions.sessions[hostSessions.activeSessionAddress],
@@ -41,17 +40,19 @@ export const AccountIcon = React.memo(function AccountIcon() {
   // listens to the current active tab and sets the account
   useEffect(() => {
     if (activeTabHost || isOnHomepage) {
-      if (!currentSession) {
-        return;
-      }
+      // if (!currentSession) {
+      //   return;
+      // }
 
       if (currentSession?.address) {
         setCurrentAddress(currentSession?.address);
+      } else if (hostSessions?.activeSessionAddress) {
+        setCurrentAddress(hostSessions.activeSessionAddress);
       } else {
         setCurrentAddress(accountAddress);
       }
     }
-  }, [accountAddress, activeTabHost, currentSession, isOnHomepage]);
+  }, [accountAddress, activeTabHost, currentSession, hostSessions?.activeSessionAddress, isOnHomepage]);
 
   const accountInfo = useMemo(() => {
     const selectedWallet = findWalletWithAccount(wallets || {}, currentAddress);
@@ -64,9 +65,8 @@ export const AccountIcon = React.memo(function AccountIcon() {
   const handleOnPress = useCallback(() => {
     navigate(Routes.DAPP_BROWSER_CONTROL_PANEL, {
       activeTabRef,
-      selectedAddress: currentAddress,
     });
-  }, [activeTabRef, currentAddress, navigate]);
+  }, [activeTabRef, navigate]);
 
   return (
     <Bleed space="8px">

--- a/src/redux/walletconnect.ts
+++ b/src/redux/walletconnect.ts
@@ -150,6 +150,7 @@ export interface WalletconnectApprovalSheetRouteParams {
     chainIds: number[];
     isWalletConnectV2?: boolean;
     proposedChainId?: number;
+    proposedAddress?: string;
   } & Pick<WalletconnectRequestData, 'dappName' | 'dappScheme' | 'dappUrl' | 'imageUrl' | 'peerId'>;
   timeout?: ReturnType<typeof setTimeout> | null;
   timedOut?: boolean;

--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -30,6 +30,7 @@ import { useDappMetadata } from '@/resources/metadata/dapp';
 import { DAppStatus } from '@/graphql/__generated__/metadata';
 import { InfoAlert } from '@/components/info-alert/info-alert';
 import { EthCoinIcon } from '@/components/coin-icon/EthCoinIcon';
+import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
 
 const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(({ theme: { colors } }) => ({
   color: colors.alpha(colors.blueGreyDark, 0.3),
@@ -152,16 +153,23 @@ const NetworkPill = ({ chainIds }) => {
 
 export default function WalletConnectApprovalSheet() {
   const { colors, isDarkMode } = useTheme();
-  const { goBack, getState } = useNavigation();
+  const { goBack } = useNavigation();
   const { params } = useRoute();
   const { network, accountAddress } = useAccountSettings();
   const { navigate } = useNavigation();
-  const { selectedWallet, walletNames } = useWallets();
+  const { selectedWallet, walletNames, wallets } = useWallets();
   const handled = useRef(false);
-  const [approvalAccount, setApprovalAccount] = useState({
-    address: accountAddress,
-    wallet: selectedWallet,
-  });
+  const initialApprovalAccount = useMemo(
+    () =>
+      params?.meta?.proposedAddress
+        ? { address: params.meta.proposedAddress, wallet: findWalletWithAccount(wallets, params.meta.proposedAddress) }
+        : {
+            address: accountAddress,
+            wallet: selectedWallet,
+          },
+    [accountAddress, params?.meta?.proposedAddress, selectedWallet, wallets]
+  );
+  const [approvalAccount, setApprovalAccount] = useState(initialApprovalAccount);
 
   const type = params?.type || WalletConnectApprovalSheetType.connect;
   const source = params?.source;

--- a/src/state/appSessions/index.ts
+++ b/src/state/appSessions/index.ts
@@ -50,7 +50,7 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
     addSession: ({ host, address, network, url }) => {
       const appSessions = get().appSessions;
       const existingSession = appSessions[host];
-      if (!existingSession) {
+      if (!existingSession || !existingSession.sessions) {
         appSessions[host] = {
           host,
           sessions: { [address]: network },
@@ -109,8 +109,7 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
     },
     updateActiveSession: ({ host, address }) => {
       const appSessions = get().appSessions;
-      const appSession = appSessions[host];
-      if (!appSession) return;
+      const appSession = appSessions[host] || {};
       set({
         appSessions: {
           ...appSessions,
@@ -123,8 +122,7 @@ export const useAppSessionsStore = createRainbowStore<AppSessionsStore<AppSessio
     },
     updateActiveSessionNetwork: ({ host, network }) => {
       const appSessions = get().appSessions;
-      const appSession = appSessions[host];
-      if (!appSession) return;
+      const appSession = appSessions[host] || {};
       set({
         appSessions: {
           ...appSessions,

--- a/src/utils/requestNavigationHandlers.ts
+++ b/src/utils/requestNavigationHandlers.ts
@@ -32,6 +32,7 @@ export interface DappConnectionData {
   dappUrl: string;
   imageUrl?: string;
   chainId?: number;
+  address?: string;
 }
 
 export const handleDappBrowserConnectionPrompt = (dappData: DappConnectionData): Promise<{ chainId: number; address: string } | Error> => {
@@ -49,6 +50,7 @@ export const handleDappBrowserConnectionPrompt = (dappData: DappConnectionData):
         peerId: '',
         dappScheme: null,
         proposedChainId: dappData.chainId,
+        proposedAddress: dappData.address,
       },
       source: 'browser',
       timedOut: false,


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Small refactor of account switching that solves the following issues:
- Switching accounts doesn't force connect anymore.
- Accounts can be switch even if not connected
- The account that's currently selected by the tab is what will be selected by default when the connect prompt shows up


## Screen recordings / screenshots


Account switching demo:

https://github.com/rainbow-me/rainbow/assets/1247834/f1761bc0-7be1-43f5-b4b8-dc9d552e3ab0


Select account respected on the connect flow


https://github.com/rainbow-me/rainbow/assets/1247834/5e20addd-29c9-4ca1-9d92-b8344e77a891


## What to test

