### PR TITLE
add animated coin icons and text fallbacks

### DIFF
--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -69,7 +69,13 @@ export function SwapScreen() {
           <SwapInputAsset />
           <FlipButton />
           <SwapOutputAsset />
-          <Box width="full" position="absolute" bottom="0px">
+          <Box
+            as={Animated.View}
+            width="full"
+            position="absolute"
+            bottom="0px"
+            style={AnimatedSwapStyles.hideWhenInputsExpandedOrPriceImpact}
+          >
             <SliderAndKeyboard />
             <SwapBottomPanel />
           </Box>

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -22,7 +22,6 @@ import { AddressZero } from '@ethersproject/constants';
 import { ETH_ADDRESS } from '@/references';
 
 const networkBadges = {
-  [ChainId.mainnet]: EthereumBadge,
   [ChainId.polygon]: PolygonBadge,
   [ChainId.optimism]: OptimismBadge,
   [ChainId.arbitrum]: ArbitrumBadge,
@@ -75,8 +74,8 @@ export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<Ex
       return base;
     }
 
-    // TODO: How can we reference local static pngs here?+
-    base.source.url = `file://${networkBadges[asset.value.chainId]}`;
+    // TODO: How can we reference local static pngs here?
+    console.log(networkBadges[asset.value.chainId]);
     return base;
   });
 

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -75,8 +75,7 @@ export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<Ex
       return base;
     }
 
-    // fallback to static network badge data
-    // TODO: How can we reference local static pngs here?
+    // TODO: How can we reference local static pngs here?+
     base.source.url = `file://${networkBadges[asset.value.chainId]}`;
     return base;
   });

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo } from 'react';
+import { Image, ImageSourcePropType, StyleSheet, View } from 'react-native';
+
+import { IS_IOS } from '@/env';
+import { Network } from '@/helpers';
+
+import ArbitrumBadge from '@/assets/badges/arbitrum.png';
+import BaseBadge from '@/assets/badges/base.png';
+import BscBadge from '@/assets/badges/bsc.png';
+import EthereumBadge from '@/assets/badges/ethereum.png';
+import OptimismBadge from '@/assets/badges/optimism.png';
+import PolygonBadge from '@/assets/badges/polygon.png';
+import ZoraBadge from '@/assets/badges/zora.png';
+import AvalancheBadge from '@/assets/badges/avalanche.png';
+import BlastBadge from '@/assets/badges/blast.png';
+import DegenBadge from '@/assets/badges/degen.png';
+import { ChainId } from '@/__swaps__/types/chains';
+import { SharedValue, useAnimatedProps } from 'react-native-reanimated';
+import { AddressOrEth, ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import { AnimatedFasterImage } from '@/components/AnimatedComponents/AnimatedFasterImage';
+import { DEFAULT_FASTER_IMAGE_CONFIG } from '@/components/images/ImgixImage';
+import { globalColors } from '@/design-system';
+import { customChainIdsToAssetNames } from '@/__swaps__/utils/chains';
+import { AddressZero } from '@ethersproject/constants';
+import { ETH_ADDRESS } from '@/references';
+
+const networkBadges = {
+  [ChainId.mainnet]: EthereumBadge,
+  [ChainId.polygon]: PolygonBadge,
+  [ChainId.optimism]: OptimismBadge,
+  [ChainId.arbitrum]: ArbitrumBadge,
+  [ChainId.base]: BaseBadge,
+  [ChainId.zora]: ZoraBadge,
+  [ChainId.bsc]: BscBadge,
+  [ChainId.avalanche]: AvalancheBadge,
+  [ChainId.sepolia]: EthereumBadge,
+  [ChainId.holesky]: EthereumBadge,
+  [ChainId.optimismSepolia]: OptimismBadge,
+  [ChainId.bscTestnet]: BscBadge,
+  [ChainId.polygonAmoy]: PolygonBadge,
+  [ChainId.arbitrumSepolia]: ArbitrumBadge,
+  [ChainId.baseSepolia]: BaseBadge,
+  [ChainId.zoraSepolia]: ZoraBadge,
+  [ChainId.avalancheFuji]: AvalancheBadge,
+  [ChainId.blast]: BlastBadge,
+  [ChainId.blastSepolia]: BlastBadge,
+  [ChainId.degen]: DegenBadge,
+};
+
+export const getCustomChainIconUrlWorklet = (chainId: ChainId, address: AddressOrEth) => {
+  'worklet';
+
+  if (!chainId || !customChainIdsToAssetNames[chainId]) return '';
+  const baseUrl = 'https://raw.githubusercontent.com/rainbow-me/assets/master/blockchains/';
+
+  if (address === AddressZero || address === ETH_ADDRESS) {
+    return `${baseUrl}${customChainIdsToAssetNames[chainId]}/info/logo.png`;
+  } else {
+    return `${baseUrl}${customChainIdsToAssetNames[chainId]}/assets/${address}/logo.png`;
+  }
+};
+
+export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<ExtendedAnimatedAssetWithColors | null>; size?: number }) {
+  const animatedIconSource = useAnimatedProps(() => {
+    const base = {
+      source: {
+        ...DEFAULT_FASTER_IMAGE_CONFIG,
+        url: '',
+      },
+    };
+    if (!asset?.value) {
+      return base;
+    }
+
+    const url = getCustomChainIconUrlWorklet(asset.value.chainId, asset.value.address);
+    console.log(url);
+    if (url) {
+      base.source.url = url;
+      return base;
+    }
+
+    // fallback to static network badge data
+    base.source.url = `file://${networkBadges[asset.value.chainId]}`;
+
+    console.log(base);
+    return base;
+  });
+
+  return (
+    <View style={sx.badge}>
+      {/* @ts-expect-error source prop is missing */}
+      <AnimatedFasterImage style={{ width: size, height: size }} animatedProps={animatedIconSource} />
+    </View>
+  );
+}
+
+const sx = StyleSheet.create({
+  badge: {
+    bottom: -0,
+    left: -8,
+    position: 'absolute',
+    shadowColor: globalColors.grey100,
+    shadowOffset: {
+      height: 4,
+      width: 0,
+    },
+    shadowRadius: 6,
+    shadowOpacity: 0.2,
+  },
+});

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -76,9 +76,8 @@ export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<Ex
     }
 
     // fallback to static network badge data
-    const path = Image.resolveAssetSource(networkBadges[asset.value.chainId]).uri;
-    console.log({ path });
-    base.source.url = `file://${path}`;
+    // TODO: How can we reference local static pngs here?
+    base.source.url = `file://${networkBadges[asset.value.chainId]}`;
     return base;
   });
 

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -1,8 +1,5 @@
-import React, { useMemo } from 'react';
-import { Image, ImageSourcePropType, StyleSheet, View } from 'react-native';
-
-import { IS_IOS } from '@/env';
-import { Network } from '@/helpers';
+import React from 'react';
+import { Image, StyleSheet, View } from 'react-native';
 
 import ArbitrumBadge from '@/assets/badges/arbitrum.png';
 import BaseBadge from '@/assets/badges/base.png';
@@ -73,16 +70,15 @@ export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<Ex
     }
 
     const url = getCustomChainIconUrlWorklet(asset.value.chainId, asset.value.address);
-    console.log(url);
     if (url) {
       base.source.url = url;
       return base;
     }
 
     // fallback to static network badge data
-    base.source.url = `file://${networkBadges[asset.value.chainId]}`;
-
-    console.log(base);
+    const path = Image.resolveAssetSource(networkBadges[asset.value.chainId]).uri;
+    console.log({ path });
+    base.source.url = `file://${path}`;
     return base;
   });
 

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -22,25 +22,25 @@ import { AddressZero } from '@ethersproject/constants';
 import { ETH_ADDRESS } from '@/references';
 
 const networkBadges = {
-  [ChainId.polygon]: PolygonBadge,
-  [ChainId.optimism]: OptimismBadge,
-  [ChainId.arbitrum]: ArbitrumBadge,
-  [ChainId.base]: BaseBadge,
-  [ChainId.zora]: ZoraBadge,
-  [ChainId.bsc]: BscBadge,
-  [ChainId.avalanche]: AvalancheBadge,
-  [ChainId.sepolia]: EthereumBadge,
-  [ChainId.holesky]: EthereumBadge,
-  [ChainId.optimismSepolia]: OptimismBadge,
-  [ChainId.bscTestnet]: BscBadge,
-  [ChainId.polygonAmoy]: PolygonBadge,
-  [ChainId.arbitrumSepolia]: ArbitrumBadge,
-  [ChainId.baseSepolia]: BaseBadge,
-  [ChainId.zoraSepolia]: ZoraBadge,
-  [ChainId.avalancheFuji]: AvalancheBadge,
-  [ChainId.blast]: BlastBadge,
-  [ChainId.blastSepolia]: BlastBadge,
-  [ChainId.degen]: DegenBadge,
+  [ChainId.polygon]: Image.resolveAssetSource(PolygonBadge).uri,
+  [ChainId.optimism]: Image.resolveAssetSource(OptimismBadge).uri,
+  [ChainId.arbitrum]: Image.resolveAssetSource(ArbitrumBadge).uri,
+  [ChainId.base]: Image.resolveAssetSource(BaseBadge).uri,
+  [ChainId.zora]: Image.resolveAssetSource(ZoraBadge).uri,
+  [ChainId.bsc]: Image.resolveAssetSource(BscBadge).uri,
+  [ChainId.avalanche]: Image.resolveAssetSource(AvalancheBadge).uri,
+  [ChainId.sepolia]: Image.resolveAssetSource(EthereumBadge).uri,
+  [ChainId.holesky]: Image.resolveAssetSource(EthereumBadge).uri,
+  [ChainId.optimismSepolia]: Image.resolveAssetSource(OptimismBadge).uri,
+  [ChainId.bscTestnet]: Image.resolveAssetSource(BscBadge).uri,
+  [ChainId.polygonAmoy]: Image.resolveAssetSource(PolygonBadge).uri,
+  [ChainId.arbitrumSepolia]: Image.resolveAssetSource(ArbitrumBadge).uri,
+  [ChainId.baseSepolia]: Image.resolveAssetSource(BaseBadge).uri,
+  [ChainId.zoraSepolia]: Image.resolveAssetSource(ZoraBadge).uri,
+  [ChainId.avalancheFuji]: Image.resolveAssetSource(AvalancheBadge).uri,
+  [ChainId.blast]: Image.resolveAssetSource(BlastBadge).uri,
+  [ChainId.blastSepolia]: Image.resolveAssetSource(BlastBadge).uri,
+  [ChainId.degen]: Image.resolveAssetSource(DegenBadge).uri,
 };
 
 export const getCustomChainIconUrlWorklet = (chainId: ChainId, address: AddressOrEth) => {
@@ -61,6 +61,7 @@ export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<Ex
     const base = {
       source: {
         ...DEFAULT_FASTER_IMAGE_CONFIG,
+        borderRadius: size / 2,
         url: '',
       },
     };
@@ -74,15 +75,16 @@ export function AnimatedChainImage({ asset, size = 20 }: { asset: SharedValue<Ex
       return base;
     }
 
-    // TODO: How can we reference local static pngs here?
-    console.log(networkBadges[asset.value.chainId]);
+    if (networkBadges[asset.value.chainId]) {
+      base.source.url = networkBadges[asset.value.chainId];
+    }
     return base;
   });
 
   return (
-    <View style={sx.badge}>
+    <View style={[sx.badge, { borderRadius: size / 2, width: size, height: size }]}>
       {/* @ts-expect-error source prop is missing */}
-      <AnimatedFasterImage style={{ width: size, height: size }} animatedProps={animatedIconSource} />
+      <AnimatedFasterImage style={{ borderRadius: size / 2, width: size, height: size }} animatedProps={animatedIconSource} />
     </View>
   );
 }

--- a/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
@@ -45,6 +45,7 @@ export const AmimatedSwapCoinIcon = React.memo(function FeedCoinIcon({
     return {
       source: {
         ...DEFAULT_FASTER_IMAGE_CONFIG,
+        borderRadius: (small ? 16 : large ? 36 : 32) / 2,
         url: asset.value?.icon_url ?? '',
       },
     };

--- a/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
@@ -109,7 +109,9 @@ export const AmimatedSwapCoinIcon = React.memo(function FeedCoinIcon({
           />
         </Animated.View>
 
-        <Animated.View style={[animatedFallbackStyles, sx.coinIconFallback]}>
+        <Animated.View
+          style={[animatedFallbackStyles, small ? sx.coinIconFallbackSmall : large ? sx.coinIconFallbackLarge : sx.coinIconFallback]}
+        >
           <SwapCoinIconTextFallback
             asset={asset}
             height={small ? 16 : large ? 36 : 32}

--- a/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
@@ -26,14 +26,16 @@ const smallFallbackIconStyle = {
   position: 'absolute' as ViewStyle['position'],
 };
 
-export const SwapCoinIcon = React.memo(function FeedCoinIcon({
+export const AmimatedSwapCoinIcon = React.memo(function FeedCoinIcon({
   asset,
   large,
   small,
+  showBadge = true,
 }: {
   asset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
   large?: boolean;
   small?: boolean;
+  showBadge?: boolean;
 }) {
   const { isDarkMode, colors } = useTheme();
 
@@ -117,7 +119,7 @@ export const SwapCoinIcon = React.memo(function FeedCoinIcon({
         </Animated.View>
       </Animated.View>
 
-      <AnimatedChainImage asset={asset} size={16} />
+      {showBadge && <AnimatedChainImage asset={asset} size={16} />}
     </View>
   );
 });

--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -10,6 +10,8 @@ import { ETH_ADDRESS } from '@/references';
 import Animated from 'react-native-reanimated';
 import { StyleSheet } from 'react-native';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
+import { SwapCoinIcon } from './SwapCoinIcon';
+import { ethereumUtils } from '@/utils';
 
 export const CoinRow = ({
   address,
@@ -73,24 +75,15 @@ export const CoinRow = ({
           width="full"
         >
           <Inline alignVertical="center" space="10px">
-            {/* TODO: Implement Coin Icons using reanimated values */}
-            <Box
-              as={Animated.View}
-              borderRadius={18}
-              height={{ custom: 36 }}
-              style={[styles.solidColorCoinIcon, AnimatedSwapStyles.assetToSellIconStyle]}
-              width={{ custom: 36 }}
-            />
-            {/* <SwapCoinIcon
+            <SwapCoinIcon
               iconUrl={iconUrl}
               address={address}
               mainnetAddress={mainnetAddress}
               large
               network={ethereumUtils.getNetworkFromChainId(chainId)}
               symbol={symbol}
-              theme={theme}
               color={color}
-            /> */}
+            />
             <Stack space="10px">
               <Text color="label" size="17pt" weight="semibold">
                 {name}

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -27,7 +27,6 @@ export function SwapBottomPanel() {
     AnimatedSwapStyles,
     SwapNavigation,
     configProgress,
-    isFetching,
   } = useSwapContext();
 
   const { swipeToDismissGestureHandler, gestureY } = useBottomPanelGestureHandler();

--- a/src/__swaps__/screens/Swap/components/SwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapCoinIcon.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import EthIcon from '@/assets/eth-icon.png';
+import { ChainImage } from '@/components/coin-icon/ChainImage';
+import { globalColors } from '@/design-system';
+import { Network } from '@/networks/types';
+import { borders, fonts } from '@/styles';
+import { useTheme } from '@/theme';
+import { FallbackIcon as CoinIconTextFallback, isETH } from '@/utils';
+import { FastFallbackCoinIconImage } from '@/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage';
+import Animated from 'react-native-reanimated';
+
+// TODO: Delete this and replace with RainbowCoinIcon
+// ⚠️ When replacing this component with RainbowCoinIcon, make sure
+// ⚠️ to exactly replicate the sizing and shadows defined below
+
+const fallbackTextStyles = {
+  fontFamily: fonts.family.SFProRounded,
+  fontWeight: fonts.weight.bold,
+  letterSpacing: fonts.letterSpacing.roundedTight,
+  marginBottom: 0.5,
+  textAlign: 'center',
+};
+
+const fallbackIconStyle = {
+  ...borders.buildCircleAsObject(32),
+  position: 'absolute',
+};
+
+const largeFallbackIconStyle = {
+  ...borders.buildCircleAsObject(36),
+  position: 'absolute',
+};
+
+const smallFallbackIconStyle = {
+  ...borders.buildCircleAsObject(16),
+  position: 'absolute',
+};
+
+/**
+ * If mainnet asset is available, get the token under /ethereum/ (token) url.
+ * Otherwise let it use whatever type it has
+ * @param param0 - optional mainnetAddress, address and network
+ * @returns a proper type and address to use for the url
+ */
+function resolveNetworkAndAddress({ address, mainnetAddress, network }: { mainnetAddress?: string; address: string; network: Network }) {
+  if (mainnetAddress) {
+    return {
+      resolvedAddress: mainnetAddress,
+      resolvedNetwork: Network.mainnet,
+    };
+  }
+
+  return {
+    resolvedAddress: address,
+    resolvedNetwork: network,
+  };
+}
+
+export const SwapCoinIcon = React.memo(function FeedCoinIcon({
+  address,
+  color,
+  iconUrl,
+  disableShadow,
+  forceDarkMode,
+  large,
+  mainnetAddress,
+  network,
+  small,
+  symbol,
+}: {
+  address: string;
+  color?: string;
+  iconUrl?: string;
+  disableShadow?: boolean;
+  forceDarkMode?: boolean;
+  large?: boolean;
+  mainnetAddress?: string;
+  network: Network;
+  small?: boolean;
+  symbol: string;
+}) {
+  const theme = useTheme();
+
+  const { resolvedNetwork, resolvedAddress } = resolveNetworkAndAddress({
+    address,
+    mainnetAddress,
+    network,
+  });
+
+  const fallbackIconColor = color ?? theme.colors.purpleUniswap;
+  const shadowColor = theme.isDarkMode || forceDarkMode ? theme.colors.shadow : color || fallbackIconColor;
+  const eth = isETH(resolvedAddress);
+
+  return (
+    <View style={small ? sx.containerSmall : large ? sx.containerLarge : sx.container}>
+      {eth ? (
+        <Animated.View
+          style={[
+            sx.reactCoinIconContainer,
+            small ? sx.coinIconFallbackSmall : large ? sx.coinIconFallbackLarge : sx.coinIconFallback,
+            small || disableShadow ? {} : sx.withShadow,
+            { shadowColor },
+          ]}
+        >
+          <Image source={EthIcon} style={small ? sx.coinIconFallbackSmall : large ? sx.coinIconFallbackLarge : sx.coinIconFallback} />
+        </Animated.View>
+      ) : (
+        <FastFallbackCoinIconImage
+          size={small ? 16 : large ? 36 : 32}
+          icon={iconUrl}
+          network={resolvedNetwork}
+          shadowColor={shadowColor}
+          symbol={symbol}
+          theme={theme}
+        >
+          {() => (
+            <CoinIconTextFallback
+              color={color}
+              height={small ? 16 : large ? 36 : 32}
+              style={small ? smallFallbackIconStyle : large ? largeFallbackIconStyle : fallbackIconStyle}
+              symbol={symbol}
+              textStyles={fallbackTextStyles}
+              width={small ? 16 : large ? 36 : 32}
+            />
+          )}
+        </FastFallbackCoinIconImage>
+      )}
+
+      {network && network !== Network.mainnet && !small && (
+        <View style={sx.badge}>
+          <ChainImage chain={network} size={16} />
+        </View>
+      )}
+    </View>
+  );
+});
+
+const sx = StyleSheet.create({
+  badge: {
+    bottom: -0,
+    left: -8,
+    position: 'absolute',
+    shadowColor: globalColors.grey100,
+    shadowOffset: {
+      height: 4,
+      width: 0,
+    },
+    shadowRadius: 6,
+    shadowOpacity: 0.2,
+  },
+  coinIconFallback: {
+    borderRadius: 16,
+    height: 32,
+    overflow: 'visible',
+    width: 32,
+  },
+  coinIconFallbackLarge: {
+    borderRadius: 18,
+    height: 36,
+    overflow: 'visible',
+    width: 36,
+  },
+  coinIconFallbackSmall: {
+    borderRadius: 8,
+    height: 16,
+    overflow: 'visible',
+    width: 16,
+  },
+  container: {
+    elevation: 6,
+    height: 32,
+    overflow: 'visible',
+  },
+  containerLarge: {
+    elevation: 6,
+    height: 36,
+    overflow: 'visible',
+  },
+  containerSmall: {
+    elevation: 6,
+    height: 16,
+    overflow: 'visible',
+  },
+  reactCoinIconContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  withShadow: {
+    elevation: 6,
+    shadowOffset: {
+      height: 4,
+      width: 0,
+    },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+  },
+});

--- a/src/__swaps__/screens/Swap/components/SwapCoinIconTextFallback.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapCoinIconTextFallback.tsx
@@ -1,0 +1,85 @@
+import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
+import { AnimatedText, useColorMode } from '@/design-system';
+import { fonts } from '@/styles';
+import React from 'react';
+import { StyleSheet, TextStyle, ViewStyle } from 'react-native';
+import Animated, { SharedValue, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
+
+const sx = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+function buildFallbackFontSize(symbol: string, width: number) {
+  'worklet';
+
+  if (!symbol) return 0;
+  else if (width < 30 || symbol.length > 4) return 8;
+  else if (symbol.length === 4) return 10;
+  else if (symbol.length === 1 || symbol.length === 2) return 13;
+  return 11;
+}
+
+function formatSymbol(symbol: string | undefined, width: number) {
+  'worklet';
+
+  if (!symbol) return '';
+
+  return symbol.replace(/[^a-zA-Z0-9]/g, '').substring(0, width < 30 ? 1 : 5);
+}
+
+type SwapCoinIconTextFallbackProps = {
+  asset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
+  height: number;
+  width: number;
+  style?: ViewStyle;
+  symbol?: string;
+};
+
+const defaultTextStyles = {
+  fontFamily: fonts.family.SFProRounded,
+  fontWeight: fonts.weight.bold as TextStyle['fontWeight'],
+  letterSpacing: fonts.letterSpacing.roundedTight,
+  marginBottom: 0.5,
+  textAlign: 'center' as TextStyle['textAlign'],
+};
+
+export const SwapCoinIconTextFallback = ({ asset, height, width, style }: SwapCoinIconTextFallbackProps) => {
+  const { isDarkMode } = useColorMode();
+
+  const backgroundColor = useAnimatedStyle(() => {
+    return {
+      backgroundColor: getColorValueForThemeWorklet(asset.value?.color, isDarkMode, true),
+    };
+  });
+
+  const formattedSymbol = useDerivedValue(() => {
+    return formatSymbol(asset.value?.symbol, width);
+  });
+
+  const animatedFontSize = useAnimatedStyle(() => {
+    return {
+      fontSize: buildFallbackFontSize(formattedSymbol.value, width),
+      color: getColorValueForThemeWorklet(asset.value?.textColor, isDarkMode, true),
+    };
+  });
+
+  return (
+    <Animated.View
+      style={[
+        sx.container,
+        {
+          height,
+          width,
+        },
+        style,
+        backgroundColor,
+      ]}
+    >
+      <AnimatedText size="11pt" style={[defaultTextStyles, animatedFontSize]} text={formattedSymbol} />
+    </Animated.View>
+  );
+};

--- a/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
@@ -17,6 +17,7 @@ import { IS_ANDROID } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { useAssetsToSell } from '@/__swaps__/screens/Swap/hooks/useAssetsToSell';
 import { isSameAssetWorklet } from '@/__swaps__/utils/assets';
+import { SwapCoinIcon } from './SwapCoinIcon';
 
 function SwapInputActionButton() {
   const { isDarkMode } = useColorMode();
@@ -69,18 +70,11 @@ function SwapInputAmount() {
 }
 
 function SwapInputIcon() {
-  const { AnimatedSwapStyles } = useSwapContext();
+  const { internalSelectedInputAsset } = useSwapContext();
 
   return (
     <Box paddingRight="10px">
-      {/* TODO: Implement Coin Icons using reanimated values */}
-      <Box
-        as={Animated.View}
-        borderRadius={18}
-        height={{ custom: 36 }}
-        style={[styles.solidColorCoinIcon, AnimatedSwapStyles.assetToSellIconStyle]}
-        width={{ custom: 36 }}
-      />
+      <SwapCoinIcon asset={internalSelectedInputAsset} />
     </Box>
   );
 }

--- a/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
@@ -17,7 +17,7 @@ import { IS_ANDROID } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { useAssetsToSell } from '@/__swaps__/screens/Swap/hooks/useAssetsToSell';
 import { isSameAssetWorklet } from '@/__swaps__/utils/assets';
-import { SwapCoinIcon } from './SwapCoinIcon';
+import { SwapCoinIcon } from './AnimatedSwapCoinIcon';
 
 function SwapInputActionButton() {
   const { isDarkMode } = useColorMode();

--- a/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
@@ -17,7 +17,7 @@ import { IS_ANDROID } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { useAssetsToSell } from '@/__swaps__/screens/Swap/hooks/useAssetsToSell';
 import { isSameAssetWorklet } from '@/__swaps__/utils/assets';
-import { SwapCoinIcon } from './AnimatedSwapCoinIcon';
+import { AmimatedSwapCoinIcon } from './AnimatedSwapCoinIcon';
 
 function SwapInputActionButton() {
   const { isDarkMode } = useColorMode();
@@ -74,7 +74,7 @@ function SwapInputIcon() {
 
   return (
     <Box paddingRight="10px">
-      <SwapCoinIcon asset={internalSelectedInputAsset} />
+      <AmimatedSwapCoinIcon asset={internalSelectedInputAsset} />
     </Box>
   );
 }

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -17,7 +17,7 @@ import { IS_ANDROID } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { isSameAssetWorklet } from '@/__swaps__/utils/assets';
 import { useAssetsToSell } from '@/__swaps__/screens/Swap/hooks/useAssetsToSell';
-import { SwapCoinIcon } from './SwapCoinIcon';
+import { SwapCoinIcon } from './AnimatedSwapCoinIcon';
 
 function SwapOutputActionButton() {
   const { isDarkMode } = useColorMode();

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -17,6 +17,7 @@ import { IS_ANDROID } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { isSameAssetWorklet } from '@/__swaps__/utils/assets';
 import { useAssetsToSell } from '@/__swaps__/screens/Swap/hooks/useAssetsToSell';
+import { SwapCoinIcon } from './SwapCoinIcon';
 
 function SwapOutputActionButton() {
   const { isDarkMode } = useColorMode();
@@ -69,18 +70,11 @@ function SwapOutputAmount() {
 }
 
 function SwapInputIcon() {
-  const { AnimatedSwapStyles } = useSwapContext();
+  const { internalSelectedOutputAsset } = useSwapContext();
 
   return (
     <Box paddingRight="10px">
-      {/* TODO: Implement Coin Icons using reanimated values */}
-      <Box
-        as={Animated.View}
-        borderRadius={18}
-        height={{ custom: 36 }}
-        style={[styles.solidColorCoinIcon, AnimatedSwapStyles.assetToBuyIconStyle]}
-        width={{ custom: 36 }}
-      />
+      <SwapCoinIcon asset={internalSelectedOutputAsset} />
     </Box>
   );
 }

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -17,7 +17,7 @@ import { IS_ANDROID } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { isSameAssetWorklet } from '@/__swaps__/utils/assets';
 import { useAssetsToSell } from '@/__swaps__/screens/Swap/hooks/useAssetsToSell';
-import { SwapCoinIcon } from './AnimatedSwapCoinIcon';
+import { AmimatedSwapCoinIcon } from './AnimatedSwapCoinIcon';
 
 function SwapOutputActionButton() {
   const { isDarkMode } = useColorMode();
@@ -74,7 +74,7 @@ function SwapInputIcon() {
 
   return (
     <Box paddingRight="10px">
-      <SwapCoinIcon asset={internalSelectedOutputAsset} />
+      <AmimatedSwapCoinIcon asset={internalSelectedOutputAsset} />
     </Box>
   );
 }

--- a/src/__swaps__/screens/Swap/components/SwapSheetGestureBlocker.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSheetGestureBlocker.tsx
@@ -3,8 +3,8 @@ import { ScrollView, View } from 'react-native';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 import { Box } from '@/design-system';
 import { IS_IOS } from '@/env';
-import { NavigationSteps, useSwapContext } from '../providers/swap-provider';
-import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
+// import { NavigationSteps, useSwapContext } from '../providers/swap-provider';
+// import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 
 export const SwapSheetGestureBlocker = ({
   children,
@@ -13,28 +13,28 @@ export const SwapSheetGestureBlocker = ({
   children: React.ReactNode;
   preventScrollViewDismissal?: boolean;
 }) => {
-  const { configProgress, inputProgress, outputProgress } = useSwapContext();
-  const [enabled, setEnabled] = useState<boolean>(false);
+  // const { configProgress, inputProgress, outputProgress } = useSwapContext();
+  // const [enabled, setEnabled] = useState<boolean>(false);
 
-  useAnimatedReaction(
-    () => ({
-      configProgress: configProgress.value,
-      inputProgress: inputProgress.value,
-      outputProgress: outputProgress.value,
-    }),
-    current => {
-      runOnJS(setEnabled)(
-        current.configProgress === NavigationSteps.SHOW_REVIEW ||
-          current.configProgress === NavigationSteps.SHOW_GAS ||
-          current.inputProgress !== NavigationSteps.INPUT_ELEMENT_FOCUSED ||
-          current.outputProgress !== NavigationSteps.INPUT_ELEMENT_FOCUSED
-      );
-    }
-  );
+  // useAnimatedReaction(
+  //   () => ({
+  //     configProgress: configProgress.value,
+  //     inputProgress: inputProgress.value,
+  //     outputProgress: outputProgress.value,
+  //   }),
+  //   current => {
+  //     runOnJS(setEnabled)(
+  //       current.configProgress === NavigationSteps.SHOW_REVIEW ||
+  //         current.configProgress === NavigationSteps.SHOW_GAS ||
+  //         current.inputProgress !== NavigationSteps.INPUT_ELEMENT_FOCUSED ||
+  //         current.outputProgress !== NavigationSteps.INPUT_ELEMENT_FOCUSED
+  //     );
+  //   }
+  // );
 
   return IS_IOS ? (
     // @ts-expect-error
-    <PanGestureHandler enabled={enabled}>
+    <PanGestureHandler enabled={false}>
       <View style={{ height: '100%', width: '100%' }}>
         <>
           {children}

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -76,8 +76,8 @@ export const SwapSlider = ({
 
   // Callback function to handle percentage change once slider is at rest
   const onChangeWrapper = useCallback(
-    (percentage: number) => {
-      SwapInputController.onChangedPercentage(percentage);
+    (percentage: number, setStale = true) => {
+      SwapInputController.onChangedPercentage(percentage, setStale);
     },
     [SwapInputController]
   );
@@ -373,7 +373,7 @@ export const SwapSlider = ({
       <Animated.View style={AnimatedSwapStyles.hideWhileReviewingOrConfiguringGas}>
         {/* @ts-expect-error */}
         <TapGestureHandler onGestureEvent={onPressDown} simultaneousHandlers={[panRef]}>
-          <Animated.View style={{ gap: 14, paddingBottom: 20, paddingHorizontal: 20, paddingTop: 16 }}>
+          <Animated.View style={{ gap: 14, paddingBottom: 20, paddingHorizontal: 20 }}>
             <View style={{ zIndex: 10 }}>
               <Columns alignHorizontal="justify" alignVertical="center">
                 <Inline alignVertical="center" space="6px" wrap={false}>
@@ -392,8 +392,10 @@ export const SwapSlider = ({
                     activeOpacity={0.4}
                     hitSlop={8}
                     onPress={() => {
+                      'worklet';
+
+                      SwapInputController.quoteFetchingInterval.stop();
                       SwapInputController.inputMethod.value = 'slider';
-                      isQuoteStale.value = 1;
                       setTimeout(() => {
                         sliderXPosition.value = withSpring(width, snappySpringConfig);
                         onChangeWrapper(1);

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/__swaps__/screens/Swap/constants';
 import { clamp, getColorValueForThemeWorklet, opacity, opacityWorklet } from '@/__swaps__/utils/swaps';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
+import { AmimatedSwapCoinIcon } from './AnimatedSwapCoinIcon';
 
 type SwapSliderProps = {
   dualColor?: boolean;
@@ -377,14 +378,7 @@ export const SwapSlider = ({
               <Columns alignHorizontal="justify" alignVertical="center">
                 <Inline alignVertical="center" space="6px" wrap={false}>
                   <Bleed vertical="4px">
-                    {/* TODO: Implement Coin Icons using reanimated values */}
-                    <Box
-                      as={Animated.View}
-                      borderRadius={18}
-                      height={{ custom: 16 }}
-                      style={[styles.solidColorCoinIcon, AnimatedSwapStyles.assetToBuyIconStyle]}
-                      width={{ custom: 16 }}
-                    />
+                    <AmimatedSwapCoinIcon showBadge={false} asset={internalSelectedInputAsset} small />
                   </Bleed>
                   <Inline alignVertical="bottom" wrap={false}>
                     <Text color={isDarkMode ? 'labelQuaternary' : 'labelTertiary'} size="15pt" style={{ marginRight: 3 }} weight="bold">


### PR DESCRIPTION
Fixes APP-1455

## What changed (plus any additional context for devs)
- converted swap coin icon to be use AnimatedFasterImage impl.
- coverted fallback to be an Animated.View

## Screen recordings / screenshots


## What is left
- [x] animated chain badge needs to use local png data or serve those from an API

