### PR TITLE
Preliminary work: Update formatter functions to take in object params

### DIFF
--- a/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
+++ b/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
@@ -85,27 +85,27 @@ export const ExchangeRateBubble = () => {
 
       switch (rotatingIndex.value) {
         case 0: {
-          const formattedRate = valueBasedDecimalFormatter(
-            inputAssetPrice / outputAssetPrice,
-            outputAssetPrice,
-            'up',
-            -1,
-            isOutputAssetStablecoin,
-            false
-          );
+          const formattedRate = valueBasedDecimalFormatter({
+            amount: inputAssetPrice / outputAssetPrice,
+            usdTokenPrice: outputAssetPrice,
+            roundingMode: 'up',
+            precisionAdjustment: -1,
+            isStablecoin: isOutputAssetStablecoin,
+            stripSeparators: false,
+          });
           fromAssetText.value = `1 ${inputAssetSymbol}`;
           toAssetText.value = `${formattedRate} ${outputAssetSymbol}`;
           break;
         }
         case 1: {
-          const formattedRate = valueBasedDecimalFormatter(
-            outputAssetPrice / inputAssetPrice,
-            inputAssetPrice,
-            'up',
-            -1,
-            isInputAssetStablecoin,
-            false
-          );
+          const formattedRate = valueBasedDecimalFormatter({
+            amount: outputAssetPrice / inputAssetPrice,
+            usdTokenPrice: inputAssetPrice,
+            roundingMode: 'up',
+            precisionAdjustment: -1,
+            isStablecoin: isInputAssetStablecoin,
+            stripSeparators: false,
+          });
           fromAssetText.value = `1 ${outputAssetSymbol}`;
           toAssetText.value = `${formattedRate} ${inputAssetSymbol}`;
           break;

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -97,14 +97,14 @@ export function useSwapInputsController({
 
     const balance = Number(internalSelectedInputAsset.value?.balance.amount || 0);
 
-    return niceIncrementFormatter(
-      incrementDecimalPlaces.value,
-      balance,
-      internalSelectedInputAsset.value.nativePrice,
-      niceIncrement.value,
-      percentageToSwap.value,
-      sliderXPosition.value
-    );
+    return niceIncrementFormatter({
+      incrementDecimalPlaces: incrementDecimalPlaces.value,
+      inputAssetBalance: balance,
+      inputAssetUsdPrice: internalSelectedInputAsset.value.nativePrice,
+      niceIncrement: niceIncrement.value,
+      percentageToSwap: percentageToSwap.value,
+      sliderXPosition: sliderXPosition.value,
+    });
   });
 
   const formattedInputNativeValue = useDerivedValue(() => {
@@ -572,15 +572,15 @@ export function useSwapInputsController({
         }
 
         // If the change set the slider position to > 0
-        const inputAmount = niceIncrementFormatter(
-          incrementDecimalPlaces.value,
-          balance,
-          internalSelectedInputAsset.value?.nativePrice,
-          niceIncrement.value,
-          percentageToSwap.value,
-          sliderXPosition.value,
-          true
-        );
+        const inputAmount = niceIncrementFormatter({
+          incrementDecimalPlaces: incrementDecimalPlaces.value,
+          inputAssetBalance: balance,
+          inputAssetUsdPrice: internalSelectedInputAsset.value?.nativePrice,
+          niceIncrement: niceIncrement.value,
+          percentageToSwap: percentageToSwap.value,
+          sliderXPosition: sliderXPosition.value,
+          stripSeparators: true,
+        });
         const inputNativeValue = Number(inputAmount) * internalSelectedInputAsset.value?.nativePrice;
         inputValues.modify(values => {
           return {
@@ -603,15 +603,15 @@ export function useSwapInputsController({
         if (!current.assetToSell?.nativePrice || !current.assetToBuy?.nativePrice) return;
 
         const balance = Number(current.assetToSell.balance.amount);
-        const inputAmount = niceIncrementFormatter(
-          incrementDecimalPlaces.value,
-          balance,
-          current.assetToSell.nativePrice,
-          niceIncrement.value,
-          percentageToSwap.value,
-          sliderXPosition.value,
-          true
-        );
+        const inputAmount = niceIncrementFormatter({
+          incrementDecimalPlaces: incrementDecimalPlaces.value,
+          inputAssetBalance: balance,
+          inputAssetUsdPrice: current.assetToSell.nativePrice,
+          niceIncrement: niceIncrement.value,
+          percentageToSwap: percentageToSwap.value,
+          sliderXPosition: sliderXPosition.value,
+          stripSeparators: true,
+        });
 
         const inputNativeValue = Number(inputAmount) * current.assetToSell.nativePrice;
         const outputAmount = (inputNativeValue / current.assetToBuy.nativePrice) * (1 - SWAP_FEE); // TODO: Implement swap fee
@@ -662,15 +662,15 @@ export function useSwapInputsController({
             }
 
             // If the change set the slider position to > 0
-            const inputAmount = niceIncrementFormatter(
-              incrementDecimalPlaces.value,
-              balance,
-              current.assetToSell.nativePrice,
-              niceIncrement.value,
-              percentageToSwap.value,
-              sliderXPosition.value,
-              true
-            );
+            const inputAmount = niceIncrementFormatter({
+              incrementDecimalPlaces: incrementDecimalPlaces.value,
+              inputAssetBalance: balance,
+              inputAssetUsdPrice: current.assetToSell.nativePrice,
+              niceIncrement: niceIncrement.value,
+              percentageToSwap: percentageToSwap.value,
+              sliderXPosition: sliderXPosition.value,
+              stripSeparators: true,
+            });
             const inputNativeValue = Number(inputAmount) * current.assetToSell.nativePrice;
             inputValues.modify(values => {
               return {

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -85,14 +85,14 @@ export function useSwapInputsController({
     }
 
     if (inputMethod.value === 'outputAmount') {
-      return valueBasedDecimalFormatter(
-        inputValues.value.inputAmount,
-        internalSelectedInputAsset.value.nativePrice,
-        'up',
-        -1,
-        internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
-        false
-      );
+      return valueBasedDecimalFormatter({
+        amount: inputValues.value.inputAmount,
+        usdTokenPrice: internalSelectedInputAsset.value.nativePrice,
+        roundingMode: 'up',
+        precisionAdjustment: -1,
+        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
+        stripSeparators: false,
+      });
     }
 
     const balance = Number(internalSelectedInputAsset.value?.balance.amount || 0);
@@ -132,14 +132,14 @@ export function useSwapInputsController({
       return addCommasToNumber(inputValues.value.outputAmount);
     }
 
-    return valueBasedDecimalFormatter(
-      inputValues.value.outputAmount,
-      internalSelectedOutputAsset.value.nativePrice,
-      'down',
-      -1,
-      internalSelectedOutputAsset.value?.type === 'stablecoin' ?? false,
-      false
-    );
+    return valueBasedDecimalFormatter({
+      amount: inputValues.value.outputAmount,
+      usdTokenPrice: internalSelectedOutputAsset.value.nativePrice,
+      roundingMode: 'down',
+      precisionAdjustment: -1,
+      isStablecoin: internalSelectedOutputAsset.value?.type === 'stablecoin' ?? false,
+      stripSeparators: false,
+    });
   });
 
   const formattedOutputNativeValue = useDerivedValue(() => {

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -190,14 +190,21 @@ export function trimTrailingZeros(value: string) {
   return withTrimmedZeros.endsWith('.') ? withTrimmedZeros.slice(0, -1) : withTrimmedZeros;
 }
 
-export function valueBasedDecimalFormatter(
-  amount: number,
-  usdTokenPrice: number,
-  roundingMode?: 'up' | 'down',
-  precisionAdjustment?: number,
-  isStablecoin?: boolean,
-  stripSeparators = true
-): string {
+export function valueBasedDecimalFormatter({
+  amount,
+  usdTokenPrice,
+  roundingMode,
+  precisionAdjustment,
+  isStablecoin,
+  stripSeparators = true,
+}: {
+  amount: number;
+  usdTokenPrice: number;
+  roundingMode?: 'up' | 'down';
+  precisionAdjustment?: number;
+  isStablecoin?: boolean;
+  stripSeparators?: boolean;
+}): string {
   'worklet';
 
   function calculateDecimalPlaces(usdTokenPrice: number, precisionAdjustment?: number): number {
@@ -258,10 +265,33 @@ export function niceIncrementFormatter({
 }) {
   'worklet';
   if (percentageToSwap === 0) return '0';
-  if (percentageToSwap === 0.25) return valueBasedDecimalFormatter(inputAssetBalance * 0.25, inputAssetUsdPrice, 'up', -3);
-  if (percentageToSwap === 0.5) return valueBasedDecimalFormatter(inputAssetBalance * 0.5, inputAssetUsdPrice, 'up', -3);
-  if (percentageToSwap === 0.75) return valueBasedDecimalFormatter(inputAssetBalance * 0.75, inputAssetUsdPrice, 'up', -3);
-  if (percentageToSwap === 1) return valueBasedDecimalFormatter(inputAssetBalance, inputAssetUsdPrice, 'up');
+  if (percentageToSwap === 0.25)
+    return valueBasedDecimalFormatter({
+      amount: inputAssetBalance * 0.25,
+      usdTokenPrice: inputAssetUsdPrice,
+      roundingMode: 'up',
+      precisionAdjustment: -3,
+    });
+  if (percentageToSwap === 0.5)
+    return valueBasedDecimalFormatter({
+      amount: inputAssetBalance * 0.5,
+      usdTokenPrice: inputAssetUsdPrice,
+      roundingMode: 'up',
+      precisionAdjustment: -3,
+    });
+  if (percentageToSwap === 0.75)
+    return valueBasedDecimalFormatter({
+      amount: inputAssetBalance * 0.75,
+      usdTokenPrice: inputAssetUsdPrice,
+      roundingMode: 'up',
+      precisionAdjustment: -3,
+    });
+  if (percentageToSwap === 1)
+    return valueBasedDecimalFormatter({
+      amount: inputAssetBalance,
+      usdTokenPrice: inputAssetUsdPrice,
+      roundingMode: 'up',
+    });
 
   const exactIncrement = inputAssetBalance / 100;
   const isIncrementExact = niceIncrement === exactIncrement;

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -239,15 +239,23 @@ export function valueBasedDecimalFormatter(
   return numberFormatter.format(roundedAmount);
 }
 
-export function niceIncrementFormatter(
-  incrementDecimalPlaces: number,
-  inputAssetBalance: number,
-  inputAssetUsdPrice: number,
-  niceIncrement: number,
-  percentageToSwap: number,
-  sliderXPosition: number,
-  stripSeparators?: boolean
-) {
+export function niceIncrementFormatter({
+  incrementDecimalPlaces,
+  inputAssetBalance,
+  inputAssetUsdPrice,
+  niceIncrement,
+  percentageToSwap,
+  sliderXPosition,
+  stripSeparators,
+}: {
+  incrementDecimalPlaces: number;
+  inputAssetBalance: number;
+  inputAssetUsdPrice: number;
+  niceIncrement: number;
+  percentageToSwap: number;
+  sliderXPosition: number;
+  stripSeparators?: boolean;
+}) {
   'worklet';
   if (percentageToSwap === 0) return '0';
   if (percentageToSwap === 0.25) return valueBasedDecimalFormatter(inputAssetBalance * 0.25, inputAssetUsdPrice, 'up', -3);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
This is preliminary work to make life easier (and more readable) for later. 
This updates 2 formatter util functions: `valueBasedDecimalFormatter` and `niceIncrementFormatter` to switch from using a list of params to an object with named params.
It also updates all places these functions are used.

Expected behavior is that is a no-op.

Commits can be read in order for easier review (first commit updates `niceIncrementFormatter` and the second commit updates `valueBasedDecimalFormatter`)

## What to test
- Test in the swap flow that the formatting of the input values, output values, exchange rate bubble and slider still behave as expected.
- How I tested: had simulator with my code and the existing testflight on my physical device and compared the input / output / slider / exchange rate bubbles for various inputs (via input, output, slider controls) and confirmed that they behaved the same.

