### PR TITLE
fix: base blast swaps, dapp browser firebase defaults

### DIFF
--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -154,8 +154,8 @@ export const DEFAULT_CONFIG: RainbowConfig = {
 
   goerli_tx_enabled: true,
 
-  base_swaps_enabled: false,
-  blast_swaps_enabled: false,
+  base_swaps_enabled: true,
+  blast_swaps_enabled: true,
   mints_enabled: true,
   points_enabled: true,
   points_fully_enabled: true,
@@ -163,7 +163,7 @@ export const DEFAULT_CONFIG: RainbowConfig = {
   remote_cards_enabled: false,
   remote_promo_enabled: false,
   points_notifications_toggle: true,
-  dapp_browser: false,
+  dapp_browser: true,
   swaps_v2: false,
 };
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- enabled `base_swaps_enabled` by default
- enabled `blast_swaps_enabled` by default
- enabled `dapp_browser` by default


## Screen recordings / screenshots


## What to test

