### PR TITLE
Prevent onChangeWrapper from firing for same percentage value

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -536,6 +536,7 @@ export function useSwapInputsController({
 
   const onChangedPercentage = useDebouncedCallback(
     (percentage: number) => {
+      if (percentageToSwap.value === percentage) return;
       lastTypedInput.value = 'inputAmount';
 
       if (percentage > 0) {


### PR DESCRIPTION
Fixes APP-1558

## What changed (plus any additional context for devs)


## Screen recordings / screenshots


## What to test

