### PR TITLE
fix fasterimage border radius android

### DIFF
--- a/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { StyleSheet, View, ViewStyle } from 'react-native';
+import { PixelRatio, StyleSheet, View, ViewStyle } from 'react-native';
 import { borders } from '@/styles';
 import { useTheme } from '@/theme';
 import Animated, { SharedValue, useAnimatedProps, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
@@ -11,7 +11,9 @@ import { AnimatedChainImage } from './AnimatedChainImage';
 import { fadeConfig } from '../constants';
 import { SwapCoinIconTextFallback } from './SwapCoinIconTextFallback';
 import { Box } from '@/design-system';
-import { IS_ANDROID } from '@/env';
+import { IS_ANDROID, IS_IOS } from '@/env';
+
+const PIXEL_RATIO = PixelRatio.get();
 
 const fallbackIconStyle = {
   ...borders.buildCircleAsObject(32),
@@ -49,7 +51,7 @@ export const AnimatedSwapCoinIcon = React.memo(function FeedCoinIcon({
     return {
       source: {
         ...DEFAULT_FASTER_IMAGE_CONFIG,
-        borderRadius: IS_ANDROID ? size / 2 : undefined,
+        borderRadius: IS_ANDROID ? (size / 2) * PIXEL_RATIO : undefined,
         transitionDuration: 0,
         url: asset.value?.icon_url ?? '',
       },
@@ -118,7 +120,7 @@ export const AnimatedSwapCoinIcon = React.memo(function FeedCoinIcon({
             style={[
               sx.coinIcon,
               {
-                borderRadius: size / 2,
+                borderRadius: IS_IOS ? size / 2 : undefined,
                 height: size,
                 width: size,
               },

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -1,8 +1,9 @@
 import { FasterImageView, ImageOptions } from '@candlefinance/faster-image';
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { PixelRatio, StyleSheet } from 'react-native';
 import FastImage, { FastImageProps, Source } from 'react-native-fast-image';
 import { maybeSignSource } from '../../handlers/imgix';
+import { IS_IOS } from '@/env';
 
 export type ImgixImageProps = FastImageProps & {
   readonly Component?: React.ElementType;
@@ -29,6 +30,8 @@ type HiddenImgixImageProps = {
 };
 type MergedImgixImageProps = ImgixImageProps & HiddenImgixImageProps;
 
+const PIXEL_RATIO = PixelRatio.get();
+
 // ImgixImage must be a class Component to support Animated.createAnimatedComponent.
 class ImgixImage extends React.PureComponent<MergedImgixImageProps, ImgixImageProps & { retryCount: number }> {
   static getDerivedStateFromProps(props: MergedImgixImageProps) {
@@ -49,7 +52,8 @@ class ImgixImage extends React.PureComponent<MergedImgixImageProps, ImgixImagePr
         ? {
             source: {
               ...DEFAULT_FASTER_IMAGE_CONFIG,
-              borderRadius: fasterImageStyle?.borderRadius,
+              borderRadius:
+                !fasterImageStyle?.borderRadius || IS_IOS ? fasterImageStyle?.borderRadius : fasterImageStyle.borderRadius * PIXEL_RATIO,
               resizeMode: resizeMode && resizeMode !== 'stretch' ? resizeMode : DEFAULT_FASTER_IMAGE_CONFIG.resizeMode,
               ...fasterImageConfig,
               url: !!source && typeof source === 'object' ? maybeSignSource(source, options)?.uri : source,


### PR DESCRIPTION
Fixes APP-1534

## What changed (plus any additional context for devs)
borderRadius supplied to FasterImage needs to be multiplied by the device's pixel ratio on android

## Screen recordings / screenshots
![IMG_8547](https://github.com/rainbow-me/rainbow/assets/15272675/0a250525-0699-4623-a178-930d8879d634)
![IMG_8548](https://github.com/rainbow-me/rainbow/assets/15272675/20c7bde4-c533-4359-b357-026f30c06240)
![Simulator Screenshot - iPhone 15 Pro - 2024-06-04 at 17 48 30](https://github.com/rainbow-me/rainbow/assets/15272675/ba887493-385c-445e-b62b-5c3c4805a73c)
![Simulator Screenshot - iPhone 15 Pro - 2024-06-04 at 17 48 33](https://github.com/rainbow-me/rainbow/assets/15272675/cc35208a-96da-44d9-9cac-439443aabf97)


## What to test

