### PR TITLE
Reorg and reduce ens related calls

### DIFF
--- a/src/components/cards/ENSCreateProfileCard.tsx
+++ b/src/components/cards/ENSCreateProfileCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import ENSAvatarGrid from '../../assets/ensAvatarGrid.png';
 import ENSIcon from '../../assets/ensIcon.png';
 import { useNavigation } from '../../navigation/Navigation';
@@ -33,8 +33,15 @@ export const ENSCreateProfileCard = () => {
   // 40 represents the horizontal padding outside the card
   const imageWidth = deviceWidth - 40;
 
-  const handlePress = () => {
+  const { uniqueDomain } = useAccountENSDomains();
+
+  const handlePress = useCallback(() => {
     if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+      if (uniqueDomain?.name) {
+        prefetchENSAvatar(uniqueDomain.name);
+        prefetchENSRecords(uniqueDomain.name);
+      }
+
       analyticsV2.track(analyticsV2.event.cardPressed, {
         cardName: 'ENSCreateProfileCard',
         routeName,
@@ -46,16 +53,7 @@ export const ENSCreateProfileCard = () => {
     } else {
       watchingAlert();
     }
-  };
-
-  const { uniqueDomain } = useAccountENSDomains();
-
-  useEffect(() => {
-    if (uniqueDomain?.name) {
-      prefetchENSAvatar(uniqueDomain.name);
-      prefetchENSRecords(uniqueDomain.name);
-    }
-  }, [uniqueDomain]);
+  }, [isReadOnlyWallet, navigate, routeName, uniqueDomain?.name]);
 
   return (
     <ColorModeProvider value="lightTinted">

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -54,14 +54,6 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
   const { startRegistration } = useENSRegistration();
   const { setNextEmoji } = useUpdateEmoji();
 
-  useEffect(() => {
-    if (accountENS) {
-      prefetchENSAvatar(accountENS);
-      prefetchENSCover(accountENS);
-      prefetchENSRecords(accountENS);
-    }
-  }, [accountENS]);
-
   const onAvatarRemovePhoto = useCallback(async () => {
     const newWallets: typeof wallets = {
       ...wallets,
@@ -256,6 +248,12 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
   }, [accountENS, navigate]);
 
   const onAvatarPress = useCallback(() => {
+    if (accountENS) {
+      prefetchENSAvatar(accountENS);
+      prefetchENSCover(accountENS);
+      prefetchENSRecords(accountENS);
+    }
+
     if (hasENSAvatar && accountENS) {
       onAvatarPressProfile();
     } else {

--- a/src/redux/wallets.ts
+++ b/src/redux/wallets.ts
@@ -207,8 +207,6 @@ export const walletsLoadState =
         type: WALLETS_LOAD,
       });
 
-      dispatch(fetchWalletNames());
-      profilesEnabled && dispatch(fetchWalletENSAvatars());
       return wallets;
     } catch (error) {
       logger.error(new RainbowError('Exception during walletsLoadState'), {


### PR DESCRIPTION
Fixes RNBW-4786

## What changed (plus any additional context for devs)

- Remove unnecessary fetchWalletNames  and fetchWalletENSAvatars calls from walletLoad
- Move ens prefetch calls inside `onPress` events instead of running every time with useEffect.
  This was happening  on `UseOnAvatarPress` and `ENSCreateProfileCard`



## Screen recordings / screenshots
WIth 3 wallets we used to have 88 requests on launch.

After the fix with the same 3 wallets we have 16 requests on launch

BEFORE:
<img width="2032" alt="Screenshot 2024-06-07 at 1 02 42 PM" src="https://github.com/rainbow-me/rainbow/assets/1247834/a7033e5d-fb3e-4ead-9684-25fb9d3c2b97">

AFTER:
<img width="1765" alt="Screenshot 2024-06-07 at 12 58 52 PM" src="https://github.com/rainbow-me/rainbow/assets/1247834/015dd883-e85f-42df-9d00-f89fc2242c50">




## What to test

