### PR TITLE
Fix provider recursion bug, provider function types

### DIFF
--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -172,7 +172,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
         ? await getFlashbotsProvider()
         : getCachedProviderForNetwork(network);
     const providerUrl = provider?.connection?.url;
-    const connectedToHardhat = isHardHat(providerUrl);
+    const connectedToHardhat = !!providerUrl && isHardHat(providerUrl);
 
     const selectedGas = getSelectedGas(parameters.chainId);
     if (!selectedGas) {

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -164,13 +164,8 @@ const isNetworkEnum = (network: Network | string): network is Network => {
  * @return A promise that resolves with an Ethers Network when the provider is ready.
  */
 export const web3SetHttpProvider = async (network: Network | string): Promise<EthersNetwork> => {
-  const provider = await getProviderForNetwork(network);
-  if (!provider) {
-    throw new RainbowError('Provider not found');
-  }
-  await provider.ready;
-  web3Provider = provider;
-  return provider.ready;
+  web3Provider = await getProviderForNetwork(network);
+  return web3Provider.ready;
 };
 
 /**

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -37,15 +37,14 @@ import { ethereumUtils } from '@/utils';
 import { logger, RainbowError } from '@/logger';
 import { IS_IOS, RPC_PROXY_API_KEY, RPC_PROXY_BASE_URL } from '@/env';
 import { getNetworkObj } from '@/networks';
+import store from '@/redux/store';
 
 export enum TokenStandard {
   ERC1155 = 'ERC1155',
   ERC721 = 'ERC721',
 }
 
-export const networkProviders: {
-  [network in Network]?: StaticJsonRpcProvider;
-} = {};
+export const networkProviders = new Map<Network, StaticJsonRpcProvider>();
 
 /**
  * Creates an rpc endpoint for a given chain id using the Rainbow rpc proxy.
@@ -165,8 +164,13 @@ const isNetworkEnum = (network: Network | string): network is Network => {
  * @return A promise that resolves with an Ethers Network when the provider is ready.
  */
 export const web3SetHttpProvider = async (network: Network | string): Promise<EthersNetwork> => {
-  web3Provider = await getProviderForNetwork(network);
-  return web3Provider.ready;
+  const provider = await getProviderForNetwork(network);
+  if (!provider) {
+    throw new RainbowError('Provider not found');
+  }
+  await provider.ready;
+  web3Provider = provider;
+  return provider.ready;
 };
 
 /**
@@ -207,8 +211,12 @@ export const getFlashbotsProvider = async () => {
   );
 };
 
-export const getCachedProviderForNetwork = (network: Network = Network.mainnet) => {
-  return networkProviders[network]!;
+export const getCachedProviderForNetwork = (network: Network = Network.mainnet): StaticJsonRpcProvider | undefined => {
+  const cachedProvider = networkProviders.get(network);
+  if (cachedProvider) {
+    return cachedProvider;
+  }
+  return undefined;
 };
 
 /**
@@ -217,27 +225,37 @@ export const getCachedProviderForNetwork = (network: Network = Network.mainnet) 
  * @return The provider for the network.
  */
 export const getProviderForNetwork = async (network: Network | string = Network.mainnet): Promise<StaticJsonRpcProvider> => {
-  if (isNetworkEnum(network) && networkProviders[network]) {
-    return networkProviders[network]!;
+  const isSupportedNetwork = isNetworkEnum(network);
+  const cachedProvider = isSupportedNetwork ? networkProviders.get(network) : undefined;
+
+  if (isSupportedNetwork && cachedProvider) {
+    return cachedProvider;
   }
 
-  if (!isNetworkEnum(network)) {
+  if (!isSupportedNetwork) {
     const provider = new StaticJsonRpcProvider(network, Network.mainnet);
-    networkProviders[Network.mainnet] = provider;
+    networkProviders.set(Network.mainnet, provider);
     return provider;
   } else {
-    const chainId = getNetworkObj(network).id;
-    const provider = new StaticJsonRpcProvider(getNetworkObj(network).rpc, chainId);
-    if (!networkProviders[network]) {
-      networkProviders[network] = provider;
-    }
-    await provider.ready;
+    const provider = new StaticJsonRpcProvider(getNetworkObj(network).rpc(), getNetworkObj(network).id);
+    networkProviders.set(network, provider);
     return provider;
   }
 };
 
 /**
- * @desc Sends an arbitrary RCP call using a given provider, or the default
+ * @desc Checks if the active network is Hardhat.
+ * @returns boolean: `true` if connected to Hardhat.
+ */
+export const getIsHardhatConnected = (): boolean => {
+  const currentNetwork = store.getState().settings.network;
+  const currentProviderUrl = getCachedProviderForNetwork(currentNetwork)?.connection?.url;
+  const connectedToHardhat = !!currentProviderUrl && isHardHat(currentProviderUrl);
+  return connectedToHardhat;
+};
+
+/**
+ * @desc Sends an arbitrary RPC call using a given provider, or the default
  * cached provider.
  * @param payload The payload, including a method and parameters, based on
  * the Ethers.js `StaticJsonRpcProvider.send` arguments.
@@ -248,10 +266,10 @@ export const getProviderForNetwork = async (network: Network | string = Network.
 export const sendRpcCall = async (
   payload: {
     method: string;
-    params: any[];
+    params: unknown[];
   },
   provider: StaticJsonRpcProvider | null = null
-): Promise<any> => (provider || web3Provider)?.send(payload.method, payload.params);
+): Promise<unknown> => (provider || web3Provider)?.send(payload.method, payload.params);
 
 /**
  * @desc check if hex string
@@ -359,9 +377,9 @@ export const estimateGas = async (
 export async function estimateGasWithPadding(
   txPayload: TransactionRequest,
   contractCallEstimateGas: Contract['estimateGas'][string] | null = null,
-  callArguments: any[] | null = null,
+  callArguments: unknown[] | null = null,
   provider: StaticJsonRpcProvider | null = null,
-  paddingFactor: number = 1.1
+  paddingFactor = 1.1
 ): Promise<string | null> {
   try {
     const p = provider || web3Provider;
@@ -383,16 +401,16 @@ export async function estimateGasWithPadding(
     const code = to ? await p.getCode(to) : undefined;
     // 2 - if it's not a contract AND it doesn't have any data use the default gas limit
     if ((!contractCallEstimateGas && !to) || (to && !data && (!code || code === '0x'))) {
-      logger.info('⛽ Skipping estimates, using default', {
+      logger.debug('⛽ Skipping estimates, using default', {
         ethUnits: ethUnits.basic_tx.toString(),
       });
       return ethUnits.basic_tx.toString();
     }
 
-    logger.info('⛽ Calculating safer gas limit for last block');
+    logger.debug('⛽ Calculating safer gas limit for last block');
     // 3 - If it is a contract, call the RPC method `estimateGas` with a safe value
     const saferGasLimit = fraction(gasLimit.toString(), 19, 20);
-    logger.info('⛽ safer gas limit for last block is', { saferGasLimit });
+    logger.debug('⛽ safer gas limit for last block is', { saferGasLimit });
 
     txPayloadToEstimate[contractCallEstimateGas ? 'gasLimit' : 'gas'] = toHex(saferGasLimit);
 
@@ -404,7 +422,7 @@ export async function estimateGasWithPadding(
 
     const lastBlockGasLimit = addBuffer(gasLimit.toString(), 0.9);
     const paddedGas = addBuffer(estimatedGas.toString(), paddingFactor.toString());
-    logger.info('⛽ GAS CALCULATIONS!', {
+    logger.debug('⛽ GAS CALCULATIONS!', {
       estimatedGas: estimatedGas.toString(),
       gasLimit: gasLimit.toString(),
       lastBlockGasLimit: lastBlockGasLimit,
@@ -413,26 +431,24 @@ export async function estimateGasWithPadding(
 
     // If the safe estimation is above the last block gas limit, use it
     if (greaterThan(estimatedGas.toString(), lastBlockGasLimit)) {
-      logger.info('⛽ returning orginal gas estimation', {
+      logger.debug('⛽ returning orginal gas estimation', {
         esimatedGas: estimatedGas.toString(),
       });
       return estimatedGas.toString();
     }
     // If the estimation is below the last block gas limit, use the padded estimate
     if (greaterThan(lastBlockGasLimit, paddedGas)) {
-      logger.info('⛽ returning padded gas estimation', { paddedGas });
+      logger.debug('⛽ returning padded gas estimation', { paddedGas });
       return paddedGas;
     }
     // otherwise default to the last block gas limit
-    logger.info('⛽ returning last block gas limit', { lastBlockGasLimit });
+    logger.debug('⛽ returning last block gas limit', { lastBlockGasLimit });
     return lastBlockGasLimit;
-  } catch (e: any) {
+  } catch (e) {
     /*
      * Reported ~400x per day, but if it's not actionable it might as well be a warning.
      */
-    logger.warn('Error calculating gas limit with padding', {
-      message: e.message,
-    });
+    logger.warn('Error calculating gas limit with padding', { message: e instanceof Error ? e.message : 'Unknown error' });
     return null;
   }
 }
@@ -522,7 +538,7 @@ export const resolveUnstoppableDomain = async (domain: string): Promise<string |
     .then((address: string) => {
       return address;
     })
-    .catch((error: any) => {
+    .catch(error => {
       logger.error(new RainbowError(`resolveUnstoppableDomain error`), {
         message: error.message,
       });
@@ -779,7 +795,7 @@ export const estimateGasLimit = async (
     recipient: string;
     amount: number;
   },
-  addPadding: boolean = false,
+  addPadding = false,
   provider: StaticJsonRpcProvider | null = null,
   network: Network = Network.mainnet
 ): Promise<string | null> => {

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -212,11 +212,7 @@ export const getFlashbotsProvider = async () => {
 };
 
 export const getCachedProviderForNetwork = (network: Network = Network.mainnet): StaticJsonRpcProvider | undefined => {
-  const cachedProvider = networkProviders.get(network);
-  if (cachedProvider) {
-    return cachedProvider;
-  }
-  return undefined;
+  return networkProviders.get(network);
 };
 
 /**

--- a/src/hooks/useRefreshAccountData.ts
+++ b/src/hooks/useRefreshAccountData.ts
@@ -2,8 +2,7 @@ import { captureException } from '@sentry/react-native';
 import delay from 'delay';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { getCachedProviderForNetwork, isHardHat } from '@/handlers/web3';
-import NetworkTypes from '../helpers/networkTypes';
+import { getIsHardhatConnected } from '@/handlers/web3';
 import { walletConnectLoadState } from '../redux/walletconnect';
 import { fetchWalletENSAvatars, fetchWalletNames } from '../redux/wallets';
 import useAccountSettings from './useAccountSettings';
@@ -16,14 +15,12 @@ import { positionsQueryKey } from '@/resources/defi/PositionsQuery';
 
 export default function useRefreshAccountData() {
   const dispatch = useDispatch();
-  const { accountAddress, network, nativeCurrency } = useAccountSettings();
+  const { accountAddress, nativeCurrency } = useAccountSettings();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const profilesEnabled = useExperimentalFlag(PROFILES);
 
   const fetchAccountData = useCallback(async () => {
-    const provider = getCachedProviderForNetwork(network);
-    const providerUrl = provider?.connection?.url;
-    const connectedToHardhat = isHardHat(providerUrl);
+    const connectedToHardhat = getIsHardhatConnected();
 
     queryClient.invalidateQueries({
       queryKey: nftsQueryKey({ address: accountAddress }),
@@ -57,7 +54,7 @@ export default function useRefreshAccountData() {
       captureException(error);
       throw error;
     }
-  }, [accountAddress, dispatch, nativeCurrency, network, profilesEnabled]);
+  }, [accountAddress, dispatch, nativeCurrency, profilesEnabled]);
 
   const refresh = useCallback(async () => {
     if (isRefreshing) return;

--- a/src/networks/arbitrum.ts
+++ b/src/networks/arbitrum.ts
@@ -24,8 +24,8 @@ export const getArbitrumNetworkObject = (): NetworkProperties => {
       address: ARBITRUM_ETH_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(arbitrum.id),
-    getProvider: getProviderForNetwork(Network.arbitrum),
+    rpc: () => proxyRpcEndpoint(arbitrum.id),
+    getProvider: () => getProviderForNetwork(Network.arbitrum),
     balanceCheckerAddress: '0x54A4E5800345c01455a7798E0D96438364e22723',
 
     // features

--- a/src/networks/avalanche.ts
+++ b/src/networks/avalanche.ts
@@ -25,8 +25,8 @@ export const getAvalancheNetworkObject = (): NetworkProperties => {
       address: AVAX_AVALANCHE_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(avalanche.id),
-    getProvider: getProviderForNetwork(Network.avalanche),
+    rpc: () => proxyRpcEndpoint(avalanche.id),
+    getProvider: () => getProviderForNetwork(Network.avalanche),
     // need to find balance checker address
     balanceCheckerAddress: '',
 

--- a/src/networks/base.ts
+++ b/src/networks/base.ts
@@ -25,8 +25,8 @@ export const getBaseNetworkObject = (): NetworkProperties => {
       address: BASE_ETH_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(base.id),
-    getProvider: getProviderForNetwork(Network.base),
+    rpc: () => proxyRpcEndpoint(base.id),
+    getProvider: () => getProviderForNetwork(Network.base),
     balanceCheckerAddress: '0x1C8cFdE3Ba6eFc4FF8Dd5C93044B9A690b6CFf36',
 
     // features

--- a/src/networks/blast.ts
+++ b/src/networks/blast.ts
@@ -30,8 +30,8 @@ export const getBlastNetworkObject = (): NetworkProperties => {
     },
 
     balanceCheckerAddress: '',
-    rpc: proxyRpcEndpoint(BLAST_CHAIN_ID),
-    getProvider: getProviderForNetwork(Network.blast),
+    rpc: () => proxyRpcEndpoint(BLAST_CHAIN_ID),
+    getProvider: () => getProviderForNetwork(Network.blast),
 
     // features
     features: {

--- a/src/networks/bsc.ts
+++ b/src/networks/bsc.ts
@@ -27,8 +27,8 @@ export const getBSCNetworkObject = (): NetworkProperties => {
     },
 
     // this should be refactored to have less deps
-    rpc: proxyRpcEndpoint(bsc.id),
-    getProvider: getProviderForNetwork(Network.bsc),
+    rpc: () => proxyRpcEndpoint(bsc.id),
+    getProvider: () => getProviderForNetwork(Network.bsc),
     balanceCheckerAddress: '0x400A9f1Bb1Db80643C33710C2232A0D74EF5CFf1',
 
     // features

--- a/src/networks/degen.ts
+++ b/src/networks/degen.ts
@@ -27,8 +27,8 @@ export const getDegenNetworkObject = (): NetworkProperties => {
       address: DEGEN_CHAIN_DEGEN_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(degen.id),
-    getProvider: getProviderForNetwork(Network.degen),
+    rpc: () => proxyRpcEndpoint(degen.id),
+    getProvider: () => getProviderForNetwork(Network.degen),
     // need to find balance checker address
     balanceCheckerAddress: '',
 

--- a/src/networks/gnosis.ts
+++ b/src/networks/gnosis.ts
@@ -23,8 +23,8 @@ export const getGnosisNetworkObject = (): NetworkProperties => {
       address: ETH_ADDRESS,
     },
 
-    rpc: '',
-    getProvider: getProviderForNetwork(Network.optimism),
+    rpc: () => '',
+    getProvider: () => getProviderForNetwork(Network.optimism),
     balanceCheckerAddress: '',
 
     // features

--- a/src/networks/goerli.ts
+++ b/src/networks/goerli.ts
@@ -25,8 +25,8 @@ export const getGoerliNetworkObject = (): NetworkProperties => {
     },
 
     // this should be refactored to have less deps
-    getProvider: getProviderForNetwork(Network.goerli),
-    rpc: proxyRpcEndpoint(goerli.id),
+    getProvider: () => getProviderForNetwork(Network.goerli),
+    rpc: () => proxyRpcEndpoint(goerli.id),
     balanceCheckerAddress: '0xf3352813b612a2d198e437691557069316b84ebe',
 
     // features

--- a/src/networks/index.ts
+++ b/src/networks/index.ts
@@ -38,6 +38,10 @@ export const RainbowNetworks = [
  */
 export function getNetworkObj(network: Network): NetworkProperties {
   switch (network) {
+    // Mainnet
+    case Network.mainnet:
+      return getMainnetNetworkObject();
+
     // L2s
     case Network.arbitrum:
       return getArbitrumNetworkObject();
@@ -63,7 +67,7 @@ export function getNetworkObj(network: Network): NetworkProperties {
     case Network.goerli:
       return getGoerliNetworkObject();
 
-    // Mainnet
+    // Fallback
     default:
       return getMainnetNetworkObject();
   }

--- a/src/networks/mainnet.ts
+++ b/src/networks/mainnet.ts
@@ -25,8 +25,8 @@ export const getMainnetNetworkObject = (): NetworkProperties => {
     },
 
     // this should be refactored to have less deps
-    getProvider: getProviderForNetwork(Network.mainnet),
-    rpc: proxyRpcEndpoint(mainnet.id),
+    getProvider: () => getProviderForNetwork(Network.mainnet),
+    rpc: () => proxyRpcEndpoint(mainnet.id),
     balanceCheckerAddress: '0x4dcf4562268dd384fe814c00fad239f06c2a0c2b',
 
     // features

--- a/src/networks/optimism.ts
+++ b/src/networks/optimism.ts
@@ -25,8 +25,8 @@ export const getOptimismNetworkObject = (): NetworkProperties => {
       address: OPTIMISM_ETH_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(optimism.id),
-    getProvider: getProviderForNetwork(Network.optimism),
+    rpc: () => proxyRpcEndpoint(optimism.id),
+    getProvider: () => getProviderForNetwork(Network.optimism),
     balanceCheckerAddress: '0x1C8cFdE3Ba6eFc4FF8Dd5C93044B9A690b6CFf36',
 
     // features

--- a/src/networks/polygon.ts
+++ b/src/networks/polygon.ts
@@ -26,9 +26,9 @@ export const getPolygonNetworkObject = (): NetworkProperties => {
       mainnetAddress: MATIC_MAINNET_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(polygon.id),
-    getProvider: getProviderForNetwork(Network.polygon),
-    balanceCheckerAddress: '0x54A4E5800345c01455a7798E0D96438364e22723',
+    rpc: () => proxyRpcEndpoint(polygon.id),
+    getProvider: () => getProviderForNetwork(Network.polygon),
+    balanceCheckerAddress: '0x54A4E5800345c01455a77798E0D96438364e22723',
 
     // features
     features: {

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -37,8 +37,8 @@ export interface NetworkProperties extends Chain {
     mainnetAddress?: string;
   };
 
-  rpc: string;
-  getProvider: Promise<StaticJsonRpcProvider>;
+  rpc: () => string;
+  getProvider: () => Promise<StaticJsonRpcProvider>;
   balanceCheckerAddress: EthereumAddress;
 
   // feature flags

--- a/src/networks/zora.ts
+++ b/src/networks/zora.ts
@@ -25,8 +25,8 @@ export const getZoraNetworkObject = (): NetworkProperties => {
       address: ZORA_ETH_ADDRESS,
     },
 
-    rpc: proxyRpcEndpoint(zora.id),
-    getProvider: getProviderForNetwork(Network.zora),
+    rpc: () => proxyRpcEndpoint(zora.id),
+    getProvider: () => getProviderForNetwork(Network.zora),
     balanceCheckerAddress: '0x1C8cFdE3Ba6eFc4FF8Dd5C93044B9A690b6CFf36',
 
     // features

--- a/src/resources/assets/useSortedUserAssets.ts
+++ b/src/resources/assets/useSortedUserAssets.ts
@@ -1,13 +1,11 @@
-import { getCachedProviderForNetwork, isHardHat } from '@/handlers/web3';
+import { getIsHardhatConnected } from '@/handlers/web3';
 import { useAccountSettings } from '@/hooks';
 import { selectSortedUserAssets } from '@/resources/assets/assetSelectors';
 import { useUserAssets } from '@/resources/assets/UserAssetsQuery';
 
 export function useSortedUserAssets() {
-  const { accountAddress, nativeCurrency, network: currentNetwork } = useAccountSettings();
-  const provider = getCachedProviderForNetwork(currentNetwork);
-  const providerUrl = provider?.connection?.url;
-  const connectedToHardhat = isHardHat(providerUrl);
+  const { accountAddress, nativeCurrency } = useAccountSettings();
+  const connectedToHardhat = getIsHardhatConnected();
 
   return useUserAssets(
     {

--- a/src/resources/assets/useUserAsset.ts
+++ b/src/resources/assets/useUserAsset.ts
@@ -1,13 +1,11 @@
-import { getCachedProviderForNetwork, isHardHat } from '@/handlers/web3';
+import { getIsHardhatConnected } from '@/handlers/web3';
 import { useAccountSettings } from '@/hooks';
 import { selectUserAssetWithUniqueId } from '@/resources/assets/assetSelectors';
 import { useUserAssets } from '@/resources/assets/UserAssetsQuery';
 
 export function useUserAsset(uniqueId: string) {
-  const { accountAddress, nativeCurrency, network: currentNetwork } = useAccountSettings();
-  const provider = getCachedProviderForNetwork(currentNetwork);
-  const providerUrl = provider?.connection?.url;
-  const connectedToHardhat = isHardHat(providerUrl);
+  const { accountAddress, nativeCurrency } = useAccountSettings();
+  const connectedToHardhat = getIsHardhatConnected();
 
   return useUserAssets(
     {

--- a/src/resources/assets/useUserAssetCount.ts
+++ b/src/resources/assets/useUserAssetCount.ts
@@ -1,4 +1,4 @@
-import { getCachedProviderForNetwork, isHardHat } from '@/handlers/web3';
+import { getIsHardhatConnected } from '@/handlers/web3';
 import { useAccountSettings } from '@/hooks';
 import { useUserAssets } from '@/resources/assets/UserAssetsQuery';
 import { RainbowAddressAssets } from './types';
@@ -6,10 +6,8 @@ import { RainbowAddressAssets } from './types';
 const countSelector = (accountAssets: RainbowAddressAssets) => accountAssets?.length;
 
 export function useUserAssetCount() {
-  const { accountAddress, nativeCurrency, network: currentNetwork } = useAccountSettings();
-  const provider = getCachedProviderForNetwork(currentNetwork);
-  const providerUrl = provider?.connection?.url;
-  const connectedToHardhat = isHardHat(providerUrl);
+  const { accountAddress, nativeCurrency } = useAccountSettings();
+  const connectedToHardhat = getIsHardhatConnected();
 
   return useUserAssets(
     {

--- a/src/screens/NFTSingleOfferSheet/index.tsx
+++ b/src/screens/NFTSingleOfferSheet/index.tsx
@@ -185,7 +185,7 @@ export function NFTSingleOfferSheet() {
         // @ts-ignore
         account: accountAddress,
         chain: networkObj,
-        transport: http(networkObj.rpc),
+        transport: http(networkObj.rpc()),
       });
       getClient()?.actions.acceptOffer({
         items: [
@@ -285,7 +285,7 @@ export function NFTSingleOfferSheet() {
     const signer = createWalletClient({
       account,
       chain: networkObj,
-      transport: http(networkObj.rpc),
+      transport: http(networkObj.rpc()),
     });
     const nonce = await getNextNonce({ address: accountAddress, network });
     try {

--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -251,7 +251,7 @@ const MintSheet = () => {
       const signer = createWalletClient({
         account: accountAddress,
         chain: networkObj,
-        transport: http(networkObj.rpc),
+        transport: http(networkObj.rpc()),
       });
       try {
         await getClient()?.actions.mintToken({
@@ -360,7 +360,7 @@ const MintSheet = () => {
     const signer = createWalletClient({
       account,
       chain: networkObj,
-      transport: http(networkObj.rpc),
+      transport: http(networkObj.rpc()),
     });
 
     const feeAddress = getRainbowFeeAddress(currentNetwork);

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -24,7 +24,7 @@ import {
   SelectedGasFee,
 } from '@/entities';
 import { getOnchainAssetBalance } from '@/handlers/assets';
-import { getCachedProviderForNetwork, getProviderForNetwork, isHardHat, isTestnetNetwork, toHex } from '@/handlers/web3';
+import { getIsHardhatConnected, getProviderForNetwork, isTestnetNetwork, toHex } from '@/handlers/web3';
 import { Network } from '@/helpers/networkTypes';
 import { convertRawAmountToDecimalFormat, fromWei, greaterThan, isZero, subtract, add } from '@/helpers/utilities';
 import { Navigation } from '@/navigation';
@@ -112,12 +112,11 @@ const getAsset = (accountAssets: Record<string, ParsedAddressAsset>, uniqueId: E
 };
 
 const getUserAssetFromCache = (uniqueId: string) => {
-  const { accountAddress, nativeCurrency, network } = store.getState().settings;
+  const { accountAddress, nativeCurrency } = store.getState().settings;
+  const connectedToHardhat = getIsHardhatConnected();
 
   const cache = queryClient.getQueryCache();
-  const provider = getCachedProviderForNetwork(network);
-  const providerUrl = provider?.connection?.url;
-  const connectedToHardhat = isHardHat(providerUrl);
+
   const cachedAddressAssets = (cache.find(
     userAssetsQueryKey({
       address: accountAddress,


### PR DESCRIPTION
Fixes APP-1567

## What changed (plus any additional context for devs)
- Fixes an issue where `getProviderForNetwork` was being repeatedly called throughout the app, for every network, due to the `getProvider` function within the network objects being invoked any time `getNetworkObj` or `getXNetworkObj` was invoked
  - Additionally, when `getProviderForNetwork` was called for a not-yet-cached network, the calling of `getNetworkObj` from within `getProviderForNetwork` would then again call `getProviderForNetwork` due to `getProvider` within the network object being invoked, leading to a recursive loop that would run until the provider eventually made it into the cache
- Fixes the return types of the `getProviderForNetwork` and `getCachedProviderForNetwork` functions
- Adds a `getIsHardhatConnected` helper function

## Screen recordings / screenshots


## What to test

