### PR TITLE
Swaps: fix crashes, logic and UI fixes

### DIFF
--- a/src/__swaps__/safe-math/SafeMath.ts
+++ b/src/__swaps__/safe-math/SafeMath.ts
@@ -27,7 +27,7 @@ const removeDecimalWorklet = (num: string): [bigint, number] => {
   return [bigIntNum, decimalPlaces];
 };
 
-const isNumberStringWorklet = (value: string): boolean => {
+export const isNumberStringWorklet = (value: string): boolean => {
   'worklet';
   return /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/.test(value);
 };

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, PixelRatio, StyleSheet, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 
 import ArbitrumBadge from '@/assets/badges/arbitrum.png';
 import BaseBadge from '@/assets/badges/base.png';
@@ -21,6 +21,7 @@ import { customChainIdsToAssetNames } from '@/__swaps__/utils/chains';
 import { AddressZero } from '@ethersproject/constants';
 import { ETH_ADDRESS } from '@/references';
 import { IS_ANDROID } from '@/env';
+import { PIXEL_RATIO } from '@/utils/deviceUtils';
 
 const networkBadges = {
   [ChainId.mainnet]: Image.resolveAssetSource(EthereumBadge).uri,
@@ -44,8 +45,6 @@ const networkBadges = {
   [ChainId.blastSepolia]: Image.resolveAssetSource(BlastBadge).uri,
   [ChainId.degen]: Image.resolveAssetSource(DegenBadge).uri,
 };
-
-const PIXEL_RATIO = PixelRatio.get();
 
 export const getCustomChainIconUrlWorklet = (chainId: ChainId, address: AddressOrEth) => {
   'worklet';

--- a/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { PixelRatio, StyleSheet, View, ViewStyle } from 'react-native';
+import { StyleSheet, View, ViewStyle } from 'react-native';
 import { borders } from '@/styles';
 import { useTheme } from '@/theme';
 import Animated, { SharedValue, useAnimatedProps, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
@@ -12,8 +12,7 @@ import { fadeConfig } from '../constants';
 import { SwapCoinIconTextFallback } from './SwapCoinIconTextFallback';
 import { Box } from '@/design-system';
 import { IS_ANDROID, IS_IOS } from '@/env';
-
-const PIXEL_RATIO = PixelRatio.get();
+import { PIXEL_RATIO } from '@/utils/deviceUtils';
 
 const fallbackIconStyle = {
   ...borders.buildCircleAsObject(32),

--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -219,7 +219,6 @@ const InfoButton = ({ address, chainId }: { address: string; chainId: ChainId })
 
   return (
     <ContextMenuButton
-      activeOpacity={0}
       isMenuPrimaryAction
       // @ts-expect-error Types of property 'menuItems' are incompatible
       menuConfig={menuConfig}

--- a/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
+++ b/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
@@ -147,7 +147,6 @@ export const ExchangeRateBubble = () => {
 
   return (
     <GestureHandlerV1Button
-      // buttonPressWrapperStyleIOS={IS_IOS ? styles.buttonPressWrapper : undefined}
       buttonPressWrapperStyleIOS={IS_IOS ? styles.buttonPosition : undefined}
       onPressWorklet={onChangeIndex}
       scaleTo={0.9}

--- a/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
+++ b/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback } from 'react';
+import { StyleSheet } from 'react-native';
 import Animated, { useAnimatedReaction, useAnimatedStyle, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { AnimatedText, Box, Inline, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
 import { LIGHT_SEPARATOR_COLOR, SEPARATOR_COLOR, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { opacity, valueBasedDecimalFormatter } from '@/__swaps__/utils/swaps';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
+import { IS_IOS } from '@/env';
 import { AddressZero } from '@ethersproject/constants';
 import { ETH_ADDRESS } from '@/references';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { GestureHandlerV1Button } from './GestureHandlerV1Button';
 
 export const ExchangeRateBubble = () => {
@@ -81,10 +84,9 @@ export const ExchangeRateBubble = () => {
 
       if (isSameAssetOnDifferentChains) {
         fromAssetText.value = `1 ${inputAssetSymbol}`;
-        toAssetText.value = `$${inputAssetPrice.toLocaleString('en-US', {
-          useGrouping: true,
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
+        toAssetText.value = `${inputAssetPrice.toLocaleString('en-US', {
+          currency: 'USD',
+          style: 'currency',
         })}`;
         return;
       }
@@ -118,19 +120,17 @@ export const ExchangeRateBubble = () => {
         }
         case 2: {
           fromAssetText.value = `1 ${inputAssetSymbol}`;
-          toAssetText.value = `$${inputAssetPrice.toLocaleString('en-US', {
-            useGrouping: true,
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
+          toAssetText.value = `${inputAssetPrice.toLocaleString('en-US', {
+            currency: 'USD',
+            style: 'currency',
           })}`;
           break;
         }
         case 3: {
           fromAssetText.value = `1 ${outputAssetSymbol}`;
-          toAssetText.value = `$${outputAssetPrice.toLocaleString('en-US', {
-            useGrouping: true,
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
+          toAssetText.value = `${outputAssetPrice.toLocaleString('en-US', {
+            currency: 'USD',
+            style: 'currency',
           })}`;
           break;
         }
@@ -146,14 +146,18 @@ export const ExchangeRateBubble = () => {
   });
 
   return (
-    <GestureHandlerV1Button onPressWorklet={onChangeIndex} scaleTo={0.925}>
+    <GestureHandlerV1Button
+      // buttonPressWrapperStyleIOS={IS_IOS ? styles.buttonPressWrapper : undefined}
+      buttonPressWrapperStyleIOS={IS_IOS ? styles.buttonPosition : undefined}
+      onPressWorklet={onChangeIndex}
+      scaleTo={0.9}
+      style={IS_IOS ? undefined : styles.buttonPosition}
+    >
       <Box
         as={Animated.View}
         alignItems="center"
         justifyContent="center"
-        paddingHorizontal="24px"
-        paddingVertical="12px"
-        style={[AnimatedSwapStyles.hideWhenInputsExpandedOrPriceImpact, { alignSelf: 'center', position: 'absolute', top: 4 }]}
+        style={[AnimatedSwapStyles.hideWhenInputsExpandedOrPriceImpact, styles.buttonPadding]}
       >
         <Box
           alignItems="center"
@@ -191,3 +195,16 @@ export const ExchangeRateBubble = () => {
     </GestureHandlerV1Button>
   );
 };
+
+const styles = StyleSheet.create({
+  buttonPadding: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+  },
+  buttonPosition: {
+    alignSelf: 'center',
+    minWidth: DEVICE_WIDTH * 0.6,
+    position: 'absolute',
+    top: 4,
+  },
+});

--- a/src/__swaps__/screens/Swap/components/FlipButton.tsx
+++ b/src/__swaps__/screens/Swap/components/FlipButton.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-nested-ternary */
-import React, { useCallback } from 'react';
-import { StyleSheet } from 'react-native';
-import Animated, { useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated';
-import { ButtonPressAnimation } from '@/components/animations';
+import React, { useCallback, useRef } from 'react';
+import { InteractionManager, StyleSheet } from 'react-native';
+import Animated, { runOnJS, useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated';
+import { analyticsV2 } from '@/analytics';
 import { AnimatedSpinner } from '@/components/animations/AnimatedSpinner';
 import { Bleed, Box, IconContainer, Text, globalColors, useColorMode } from '@/design-system';
 import { SEPARATOR_COLOR } from '@/__swaps__/screens/Swap/constants';
@@ -12,27 +12,79 @@ import { AnimatedBlurView } from '@/__swaps__/screens/Swap/components/AnimatedBl
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { SwapAssetType } from '@/__swaps__/types/swap';
-import { analyticsV2 } from '@/analytics';
+import { GestureHandlerV1Button } from './GestureHandlerV1Button';
+import { useSwapsStore } from '@/state/swaps/swapsStore';
+import { ChainId } from '@/__swaps__/types/chains';
 
 export const FlipButton = () => {
   const { isDarkMode } = useColorMode();
 
-  const { AnimatedSwapStyles, internalSelectedInputAsset, internalSelectedOutputAsset, setAsset, SwapInputController } = useSwapContext();
+  const {
+    AnimatedSwapStyles,
+    SwapInputController,
+    handleProgressNavigation,
+    internalSelectedInputAsset,
+    internalSelectedOutputAsset,
+    selectedOutputChainId,
+  } = useSwapContext();
 
-  const handleSwapAssets = useCallback(() => {
-    if (internalSelectedInputAsset.value && internalSelectedOutputAsset.value) {
-      const assetTypeToSet = SwapAssetType.outputAsset;
-      const assetToSet = internalSelectedInputAsset.value;
+  const chainSetTimeoutId = useRef<NodeJS.Timeout | null>(null);
 
-      analyticsV2.track(analyticsV2.event.swapsFlippedAssets, {
-        inputAmount: SwapInputController.inputValues.value.inputAmount,
-        previousInputAsset: internalSelectedInputAsset.value,
-        previousOutputAsset: internalSelectedOutputAsset.value,
-      });
+  const flipStoreAssets = useCallback(() => {
+    const { inputAsset: newOutputAsset, outputAsset: newInputAsset } = useSwapsStore.getState();
 
-      setAsset({ type: assetTypeToSet, asset: assetToSet });
+    useSwapsStore.setState({
+      inputAsset: newInputAsset,
+      outputAsset: newOutputAsset,
+    });
+
+    const shouldUpdateSelectedOutputChainId = useSwapsStore.getState().selectedOutputChainId !== newInputAsset?.chainId;
+    const shouldUpdateAnimatedSelectedOutputChainId = selectedOutputChainId.value !== internalSelectedInputAsset.value?.chainId;
+
+    if (newInputAsset && (shouldUpdateSelectedOutputChainId || shouldUpdateAnimatedSelectedOutputChainId)) {
+      if (chainSetTimeoutId.current) {
+        clearTimeout(chainSetTimeoutId.current);
+      }
+
+      // This causes a heavy re-render in the output token list, so we delay updating the selected output chain until
+      // the animation is most likely complete.
+      chainSetTimeoutId.current = setTimeout(() => {
+        InteractionManager.runAfterInteractions(() => {
+          if (shouldUpdateSelectedOutputChainId) {
+            useSwapsStore.setState({
+              selectedOutputChainId: newInputAsset?.chainId ?? ChainId.mainnet,
+            });
+          }
+          if (shouldUpdateAnimatedSelectedOutputChainId) {
+            selectedOutputChainId.value = newInputAsset?.chainId ?? ChainId.mainnet;
+          }
+        });
+      }, 750);
     }
-  }, [SwapInputController.inputValues, internalSelectedInputAsset, internalSelectedOutputAsset, setAsset]);
+
+    analyticsV2.track(analyticsV2.event.swapsFlippedAssets, {
+      inputAmount: SwapInputController.inputValues.value.inputAmount,
+      previousInputAsset: internalSelectedInputAsset.value,
+      previousOutputAsset: internalSelectedOutputAsset.value,
+    });
+  }, [SwapInputController.inputValues, internalSelectedInputAsset, internalSelectedOutputAsset, selectedOutputChainId]);
+
+  const handleFlipAssets = useCallback(() => {
+    'worklet';
+    if (internalSelectedInputAsset.value || internalSelectedOutputAsset.value) {
+      const assetTypeToSet = internalSelectedInputAsset.value ? SwapAssetType.outputAsset : SwapAssetType.inputAsset;
+
+      // Flip shared value assets and navigate ahead of time because it's faster than waiting for setAsset
+      const newOutputAsset = internalSelectedInputAsset.value;
+      const newInputAsset = internalSelectedOutputAsset.value;
+
+      internalSelectedInputAsset.value = newInputAsset;
+      internalSelectedOutputAsset.value = newOutputAsset;
+      handleProgressNavigation({ type: assetTypeToSet });
+
+      runOnJS(flipStoreAssets)();
+    }
+  }, [flipStoreAssets, handleProgressNavigation, internalSelectedInputAsset, internalSelectedOutputAsset]);
 
   const flipButtonInnerStyles = useAnimatedStyle(() => {
     return {
@@ -64,7 +116,7 @@ export const FlipButton = () => {
           },
         ]}
       >
-        <ButtonPressAnimation onPress={handleSwapAssets} scaleTo={0.8} style={{ paddingHorizontal: 20, paddingVertical: 8 }}>
+        <GestureHandlerV1Button onPressWorklet={handleFlipAssets} scaleTo={0.8} style={{ paddingHorizontal: 20, paddingVertical: 8 }}>
           {/* TODO: Temp fix - rewrite to actually avoid type errors */}
           {/* @ts-expect-error The conditional as={} is causing type errors */}
           <Box
@@ -95,7 +147,7 @@ export const FlipButton = () => {
               </Box>
             </IconContainer>
           </Box>
-        </ButtonPressAnimation>
+        </GestureHandlerV1Button>
       </Box>
       <Box pointerEvents="none" position="absolute">
         <SpinnerComponent />

--- a/src/__swaps__/screens/Swap/components/GestureHandlerV1Button.tsx
+++ b/src/__swaps__/screens/Swap/components/GestureHandlerV1Button.tsx
@@ -69,7 +69,7 @@ export const GestureHandlerV1Button = React.forwardRef(function GestureHandlerV1
     scaleTo = 0.86,
     style,
   }: GestureHandlerButtonProps,
-  forwardedRef: React.LegacyRef<unknown> | undefined
+  ref: React.LegacyRef<unknown> | undefined
 ) {
   const pressHandler = useAnimatedGestureHandler<TapGestureHandlerGestureEvent>({
     onStart: () => {
@@ -91,7 +91,7 @@ export const GestureHandlerV1Button = React.forwardRef(function GestureHandlerV1
       )}
     >
       {/* @ts-expect-error Property 'children' does not exist on type */}
-      <TapGestureHandler enabled={!disabled} onGestureEvent={pressHandler} ref={forwardedRef}>
+      <TapGestureHandler enabled={!disabled} onGestureEvent={pressHandler} ref={ref}>
         <Animated.View accessible accessibilityRole="button" pointerEvents={pointerEvents} style={style}>
           {children}
         </Animated.View>

--- a/src/__swaps__/screens/Swap/components/SwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapCoinIcon.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { Image, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import EthIcon from '@/assets/eth-icon.png';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
 import { globalColors } from '@/design-system';
@@ -10,6 +10,7 @@ import { useTheme } from '@/theme';
 import { FallbackIcon as CoinIconTextFallback, isETH } from '@/utils';
 import { FastFallbackCoinIconImage } from '@/components/asset-list/RecyclerAssetList2/FastComponents/FastFallbackCoinIconImage';
 import Animated from 'react-native-reanimated';
+import FastImage, { Source } from 'react-native-fast-image';
 
 // TODO: Delete this and replace with RainbowCoinIcon
 // ⚠️ When replacing this component with RainbowCoinIcon, make sure
@@ -97,6 +98,7 @@ export const SwapCoinIcon = React.memo(function FeedCoinIcon({
     <View style={small ? sx.containerSmall : large ? sx.containerLarge : sx.container}>
       {eth ? (
         <Animated.View
+          key={`${resolvedAddress}-${eth}`}
           style={[
             sx.reactCoinIconContainer,
             small ? sx.coinIconFallbackSmall : large ? sx.coinIconFallbackLarge : sx.coinIconFallback,
@@ -104,7 +106,10 @@ export const SwapCoinIcon = React.memo(function FeedCoinIcon({
             { shadowColor },
           ]}
         >
-          <Image source={EthIcon} style={small ? sx.coinIconFallbackSmall : large ? sx.coinIconFallbackLarge : sx.coinIconFallback} />
+          <FastImage
+            source={EthIcon as Source}
+            style={small ? sx.coinIconFallbackSmall : large ? sx.coinIconFallbackLarge : sx.coinIconFallback}
+          />
         </Animated.View>
       ) : (
         <FastFallbackCoinIconImage

--- a/src/__swaps__/screens/Swap/components/SwapInput.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInput.tsx
@@ -19,7 +19,7 @@ export const SwapInput = ({
   otherInputProgress: SharedValue<number>;
   progress: SharedValue<number>;
 }) => {
-  const { containerStyle, inputStyle } = useSwapInputStyles({
+  const { containerStyle, inputHeight, inputStyle } = useSwapInputStyles({
     asset,
     bottomInput,
     otherInputProgress,
@@ -27,8 +27,8 @@ export const SwapInput = ({
   });
 
   return (
-    <Box as={Animated.View} style={[containerStyle, styles.staticInputContainerStyles]} width={{ custom: BASE_INPUT_WIDTH }}>
-      <Box as={Animated.View} style={[inputStyle, styles.staticInputStyles]}>
+    <Box as={Animated.View} style={[styles.staticInputContainerStyles, containerStyle]} width={{ custom: BASE_INPUT_WIDTH }}>
+      <Box as={Animated.View} style={[styles.staticInputStyles, inputStyle, { height: inputHeight }]}>
         {children}
       </Box>
     </Box>

--- a/src/__swaps__/screens/Swap/components/TokenList/ListEmpty.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/ListEmpty.tsx
@@ -1,31 +1,43 @@
-import React, { useMemo } from 'react';
-import * as i18n from '@/languages';
+import React, { memo, useMemo } from 'react';
+import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { Box, Stack, Text } from '@/design-system';
+import * as i18n from '@/languages';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { isL2Chain } from '@/__swaps__/utils/chains';
+import { EXPANDED_INPUT_HEIGHT, FOCUSED_INPUT_HEIGHT } from '../../constants';
+import { useSwapContext } from '../../providers/swap-provider';
+import { BUY_LIST_HEADER_HEIGHT } from './TokenToBuyList';
+import { SELL_LIST_HEADER_HEIGHT } from './TokenToSellList';
 
 type ListEmptyProps = {
   action?: 'swap' | 'bridge';
-  isSearchEmptyState?: boolean;
   output?: boolean;
 };
 
-export const ListEmpty = ({ action = 'swap', isSearchEmptyState, output = false }: ListEmptyProps) => {
-  // TODO: Might need to make this reactive instead of reading inline getState
+export const ListEmpty = memo(function ListEmpty({ action = 'swap', output = false }: ListEmptyProps) {
+  const { inputProgress, outputProgress } = useSwapContext();
+
   const isL2 = useMemo(() => {
     return output ? isL2Chain(swapsStore.getState().selectedOutputChainId) : false;
   }, [output]);
 
+  const containerHeight = useAnimatedStyle(() => {
+    const isFocused = output ? outputProgress.value === 2 : inputProgress.value === 2;
+    return {
+      height: withTiming(
+        (isFocused ? FOCUSED_INPUT_HEIGHT : EXPANDED_INPUT_HEIGHT) - 120 - (output ? BUY_LIST_HEADER_HEIGHT : SELL_LIST_HEADER_HEIGHT),
+        TIMING_CONFIGS.slowerFadeConfig
+      ),
+    };
+  });
+
   return (
-    <Box
-      alignItems="center"
-      height="full"
-      style={{ alignSelf: 'center', flexDirection: 'row', paddingVertical: isSearchEmptyState ? 40 : 120 }}
-    >
+    <Box alignItems="center" as={Animated.View} style={[{ alignSelf: 'center', flexDirection: 'row' }, containerHeight]}>
       <Box paddingHorizontal="44px">
         <Stack space="16px">
           <Text containsEmoji color="label" size="26pt" weight="bold" align="center">
-            {'👻'}
+            👻
           </Text>
 
           <Text color="labelTertiary" size="20pt" weight="semibold" align="center">
@@ -41,4 +53,4 @@ export const ListEmpty = ({ action = 'swap', isSearchEmptyState, output = false 
       </Box>
     </Box>
   );
-};
+});

--- a/src/__swaps__/screens/Swap/components/TokenList/TokenToBuyList.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/TokenToBuyList.tsx
@@ -22,7 +22,7 @@ import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { EXPANDED_INPUT_HEIGHT, FOCUSED_INPUT_HEIGHT } from '../../constants';
 import { ChainSelection } from './ChainSelection';
 
-const BUY_LIST_HEADER_HEIGHT = 20 + 10 + 8; // paddingTop + height + paddingBottom
+export const BUY_LIST_HEADER_HEIGHT = 20 + 10 + 8; // paddingTop + height + paddingBottom
 
 interface SectionHeaderProp {
   color: string | undefined;
@@ -126,7 +126,7 @@ export const TokenToBuyList = () => {
   return (
     <Box style={{ height: EXPANDED_INPUT_HEIGHT - 77, width: DEVICE_WIDTH - 24 }}>
       <FlashList
-        ListEmptyComponent={<ListEmpty isSearchEmptyState output />}
+        ListEmptyComponent={<ListEmpty output />}
         ListFooterComponent={<Animated.View style={[animatedListPadding, { width: '100%' }]} />}
         ListHeaderComponent={<ChainSelection output />}
         contentContainerStyle={{ paddingBottom: 16 }}

--- a/src/__swaps__/screens/Swap/components/TokenList/TokenToSellList.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/TokenToSellList.tsx
@@ -15,7 +15,7 @@ import { useDelayedMount } from '@/hooks/useDelayedMount';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { analyticsV2 } from '@/analytics';
 
-const SELL_LIST_HEADER_HEIGHT = 20 + 10 + 14; // paddingTop + height + paddingBottom
+export const SELL_LIST_HEADER_HEIGHT = 20 + 10 + 14; // paddingTop + height + paddingBottom
 
 const isInitialInputAssetNull = () => {
   return !swapsStore.getState().inputAsset;

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputStyles.ts
@@ -62,15 +62,15 @@ export const useSwapInputStyles = ({
 
   const containerStyle = useAnimatedStyle(() => {
     const getContainerStyleTranslateY = (progress: SharedValue<number>, bottomInput: boolean | undefined) => {
+      let yTranslation = 0;
       if (progress.value === NavigationSteps.SEARCH_FOCUSED) {
         if (bottomInput) {
-          return withSpring(-191, SPRING_CONFIGS.springConfig);
+          yTranslation = -191;
         } else {
-          return withSpring(-77, SPRING_CONFIGS.springConfig);
+          yTranslation = -77;
         }
       }
-
-      return withSpring(0, SPRING_CONFIGS.springConfig);
+      return yTranslation;
     };
 
     return {
@@ -81,11 +81,18 @@ export const useSwapInputStyles = ({
       shadowColor: isDarkMode ? 'transparent' : getColorValueForThemeWorklet(asset.value?.mixedShadowColor, isDarkMode, true),
       transform: [
         {
-          translateY: getContainerStyleTranslateY(progress, bottomInput),
+          translateY: withSpring(getContainerStyleTranslateY(progress, bottomInput), SPRING_CONFIGS.keyboardConfig),
         },
       ],
     };
   });
+
+  const inputHeight = useDerivedValue(() =>
+    withSpring(
+      interpolate(progress.value, [0, 1, 2], [BASE_INPUT_HEIGHT, EXPANDED_INPUT_HEIGHT, FOCUSED_INPUT_HEIGHT], 'clamp'),
+      SPRING_CONFIGS.springConfig
+    )
+  );
 
   const inputStyle = useAnimatedStyle(() => {
     return {
@@ -96,10 +103,6 @@ export const useSwapInputStyles = ({
       borderColor: withTiming(
         interpolateColor(progress.value, [0, 1], [strokeColor.value, expandedStrokeColor.value]),
         TIMING_CONFIGS.fadeConfig
-      ),
-      height: withSpring(
-        interpolate(progress.value, [0, 1, 2], [BASE_INPUT_HEIGHT, EXPANDED_INPUT_HEIGHT, FOCUSED_INPUT_HEIGHT], 'clamp'),
-        SPRING_CONFIGS.springConfig
       ),
       transform: [
         {
@@ -114,5 +117,5 @@ export const useSwapInputStyles = ({
     };
   });
 
-  return { containerStyle, inputStyle };
+  return { containerStyle, inputHeight, inputStyle };
 };

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -29,9 +29,15 @@ import {
 } from '@/resources/assets/externalAssetsQuery';
 import { ethereumUtils } from '@/utils';
 import { queryClient } from '@/react-query';
-import { userAssetsStore } from '@/state/assets/userAssets';
 import { analyticsV2 } from '@/analytics';
-import { divWorklet, equalWorklet, greaterThanWorklet, mulWorklet, toFixedWorklet } from '@/__swaps__/safe-math/SafeMath';
+import {
+  divWorklet,
+  equalWorklet,
+  greaterThanWorklet,
+  isNumberStringWorklet,
+  mulWorklet,
+  toFixedWorklet,
+} from '@/__swaps__/safe-math/SafeMath';
 
 function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetWithColors | null) {
   const initialBalance = Number(initialSelectedInputAsset?.balance.amount) || 0;
@@ -52,9 +58,7 @@ function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetW
     isStablecoin,
   });
 
-  const initialInputNativeValue = addCommasToNumber(
-    toFixedWorklet(mulWorklet(initialInputAmount, initialSelectedInputAsset?.price?.value ?? 0), 2)
-  );
+  const initialInputNativeValue = toFixedWorklet(mulWorklet(initialInputAmount, initialSelectedInputAsset?.price?.value ?? 0), 2);
 
   return {
     initialInputAmount,
@@ -155,14 +159,18 @@ export function useSwapInputsController({
   });
 
   const formattedInputNativeValue = useDerivedValue(() => {
-    if ((inputMethod.value === 'slider' && percentageToSwap.value === 0) || !inputValues.value.inputNativeValue) {
+    if (
+      (inputMethod.value === 'slider' && percentageToSwap.value === 0) ||
+      !inputValues.value.inputNativeValue ||
+      !isNumberStringWorklet(inputValues.value.inputNativeValue.toString()) ||
+      equalWorklet(inputValues.value.inputNativeValue, 0)
+    ) {
       return '$0.00';
     }
 
-    const nativeValue = `$${Number(inputValues.value.inputNativeValue).toLocaleString('en-US', {
-      useGrouping: true,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
+    const nativeValue = `${Number(inputValues.value.inputNativeValue).toLocaleString('en-US', {
+      currency: 'USD',
+      style: 'currency',
     })}`;
 
     return nativeValue || '$0.00';
@@ -193,14 +201,18 @@ export function useSwapInputsController({
   });
 
   const formattedOutputNativeValue = useDerivedValue(() => {
-    if ((inputMethod.value === 'slider' && percentageToSwap.value === 0) || !inputValues.value.outputNativeValue) {
+    if (
+      (inputMethod.value === 'slider' && percentageToSwap.value === 0) ||
+      !inputValues.value.outputNativeValue ||
+      !isNumberStringWorklet(inputValues.value.outputNativeValue.toString()) ||
+      equalWorklet(inputValues.value.outputNativeValue, 0)
+    ) {
       return '$0.00';
     }
 
-    const nativeValue = `$${Number(inputValues.value.outputNativeValue).toLocaleString('en-US', {
-      useGrouping: true,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
+    const nativeValue = `${Number(inputValues.value.outputNativeValue).toLocaleString('en-US', {
+      currency: 'USD',
+      style: 'currency',
     })}`;
     return nativeValue || '$0.00';
   });
@@ -585,8 +597,12 @@ export function useSwapInputsController({
           // we can derive the slider position directly from the entered amount.
           if (inputKey === 'inputAmount') {
             const inputAssetBalance = internalSelectedInputAsset.value?.balance.amount || '0';
-            const updatedSliderPosition = clamp(Number(divWorklet(amount, inputAssetBalance)) * SLIDER_WIDTH, 0, SLIDER_WIDTH);
-            sliderXPosition.value = withSpring(updatedSliderPosition, snappySpringConfig);
+            if (equalWorklet(inputAssetBalance, 0)) {
+              sliderXPosition.value = withSpring(0, snappySpringConfig);
+            } else {
+              const updatedSliderPosition = clamp(Number(divWorklet(amount, inputAssetBalance)) * SLIDER_WIDTH, 0, SLIDER_WIDTH);
+              sliderXPosition.value = withSpring(updatedSliderPosition, snappySpringConfig);
+            }
           }
           fetchQuoteAndAssetPrices();
         };
@@ -644,13 +660,16 @@ export function useSwapInputsController({
               [previous.focusedInput]: 0,
             };
           });
-        } else {
-          inputValues.modify(values => {
-            return {
-              ...values,
-              [previous.focusedInput]: trimTrailingZeros(typedValue),
-            };
-          });
+        } else if (typedValue.includes('.')) {
+          const trimmedValue = trimTrailingZeros(typedValue);
+          if (trimmedValue !== typedValue) {
+            inputValues.modify(values => {
+              return {
+                ...values,
+                [previous.focusedInput]: trimmedValue,
+              };
+            });
+          }
         }
       }
     }
@@ -773,13 +792,17 @@ export function useSwapInputsController({
             });
 
             const inputAssetBalance = internalSelectedInputAsset.value?.balance.amount || '0';
-            const updatedSliderPosition = clamp(
-              Number(divWorklet(current.values.inputAmount, inputAssetBalance)) * SLIDER_WIDTH,
-              0,
-              SLIDER_WIDTH
-            );
 
-            sliderXPosition.value = withSpring(updatedSliderPosition, snappySpringConfig);
+            if (equalWorklet(inputAssetBalance, 0)) {
+              sliderXPosition.value = withSpring(0, snappySpringConfig);
+            } else {
+              const updatedSliderPosition = clamp(
+                Number(divWorklet(current.values.inputAmount, inputAssetBalance)) * SLIDER_WIDTH,
+                0,
+                SLIDER_WIDTH
+              );
+              sliderXPosition.value = withSpring(updatedSliderPosition, snappySpringConfig);
+            }
 
             runOnJS(onTypedNumber)(Number(current.values.inputAmount), 'inputAmount', true);
           }
@@ -836,23 +859,19 @@ export function useSwapInputsController({
    */
   useAnimatedReaction(
     () => ({
-      assetToBuy: internalSelectedOutputAsset.value,
-      assetToSell: internalSelectedInputAsset.value,
+      assetToBuyId: internalSelectedOutputAsset.value?.uniqueId,
+      assetToSellId: internalSelectedInputAsset.value?.uniqueId,
     }),
     (current, previous) => {
-      const didInputAssetChange = current.assetToSell?.uniqueId !== previous?.assetToSell?.uniqueId;
-      const didOutputAssetChange = current.assetToBuy?.uniqueId !== previous?.assetToBuy?.uniqueId;
+      const didInputAssetChange = current.assetToSellId !== previous?.assetToSellId;
+      const didOutputAssetChange = current.assetToBuyId !== previous?.assetToBuyId;
 
       if (didInputAssetChange || didOutputAssetChange) {
-        const balance = Number(current.assetToSell?.balance?.amount);
+        const balance = Number(internalSelectedInputAsset.value?.balance?.amount);
 
-        const areBothAssetsSet = current.assetToSell && current.assetToBuy;
+        const areBothAssetsSet = internalSelectedInputAsset.value && internalSelectedOutputAsset.value;
         const didFlipAssets =
-          didInputAssetChange &&
-          didOutputAssetChange &&
-          areBothAssetsSet &&
-          previous &&
-          current.assetToSell?.uniqueId === previous.assetToBuy?.uniqueId;
+          didInputAssetChange && didOutputAssetChange && areBothAssetsSet && previous && current.assetToSellId === previous.assetToBuyId;
 
         if (!didFlipAssets) {
           // If either asset was changed but the assets were not flipped
@@ -900,7 +919,7 @@ export function useSwapInputsController({
           const inputNativePrice = internalSelectedInputAsset.value?.nativePrice || internalSelectedInputAsset.value?.price?.value || 0;
           const outputNativePrice = internalSelectedOutputAsset.value?.nativePrice || internalSelectedOutputAsset.value?.price?.value || 0;
 
-          const assetBalanceDisplay = current.assetToSell?.balance.display ?? '';
+          const assetBalanceDisplay = internalSelectedInputAsset.value?.balance.display ?? '';
 
           const inputAmount = Number(
             valueBasedDecimalFormatter({
@@ -910,7 +929,7 @@ export function useSwapInputsController({
               assetBalanceDisplay,
               roundingMode: 'up',
               precisionAdjustment: -1,
-              isStablecoin: current.assetToSell?.type === 'stablecoin' ?? false,
+              isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
               stripSeparators: true,
             })
           );
@@ -927,7 +946,7 @@ export function useSwapInputsController({
           });
         }
 
-        if (current.assetToSell && current.assetToBuy) {
+        if (internalSelectedInputAsset.value && internalSelectedOutputAsset.value) {
           fetchQuoteAndAssetPrices();
         }
       }

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -1,4 +1,4 @@
-import { Dimensions, Platform } from 'react-native';
+import { Dimensions, PixelRatio, Platform } from 'react-native';
 
 import { IS_IOS } from '@/env';
 
@@ -38,5 +38,6 @@ const deviceUtils = (function () {
 
 export const DEVICE_WIDTH = deviceUtils.dimensions.width;
 export const DEVICE_HEIGHT = deviceUtils.dimensions.height;
+export const PIXEL_RATIO = PixelRatio.get();
 
 export default deviceUtils;


### PR DESCRIPTION
Fixes APP-1538
Fixes APP-1552
Fixes APP-1582
Fixes APP-1583
Fixes APP-1591
Fixes RNBW-4755

## What changed (plus any additional context for devs)
- Fixes division by zero crashes
- Fixes exchange rate bubble button presses
- Removes hardcoded decimal places from stablecoin input amounts
- Fixes NaN issues (the `toLocaleString` changes are temporary and will be superseded by Ben's changes)
- Improves buy list data memoization (removes an unnecessary extra useMemo)
- Adds `PIXEL_RATIO` to `deviceUtils`
- Allows flipping when only one asset is selected and speeds up flipping (no longer using `setAsset` which adds a bit of duplicate code but prevents complicating `setAsset`
- Adjusts buy list sorting to ensure the chain's native asset is listed first
- Fixes buy list empty state layout
- Improves performance of the animated input styles, specifically the height style

## Screen recordings / screenshots


## What to test

