### PR TITLE
add flashbots unknown type as failed

### DIFF
--- a/src/handlers/transactions.ts
+++ b/src/handlers/transactions.ts
@@ -80,7 +80,7 @@ export const getTransactionFlashbotStatus = async (
   transaction: RainbowTransaction,
   txHash: string
 ): Promise<{
-  flashbotsStatus: 'FAILED' | 'CANCELLED';
+  flashbotsStatus: 'FAILED' | 'CANCELLED' | 'UNKNOWN';
   status: 'failed';
   minedAt: number;
   title: string;
@@ -89,7 +89,7 @@ export const getTransactionFlashbotStatus = async (
     const fbStatus = await flashbotsApi.get<{ status: FlashbotsStatus }>(`/tx/${txHash}`);
     const flashbotsStatus = fbStatus.data.status;
     // Make sure it wasn't dropped after 25 blocks or never made it
-    if (flashbotsStatus === 'FAILED' || flashbotsStatus === 'CANCELLED') {
+    if (flashbotsStatus === 'FAILED' || flashbotsStatus === 'CANCELLED' || flashbotsStatus === 'UNKNOWN') {
       const status = 'failed';
       const minedAt = Math.floor(Date.now() / 1000);
       const title = `${transaction.type}.failed`;


### PR DESCRIPTION
Fixes RNBW-4748

## What changed (plus any additional context for devs)
I was testing #5869 and realized that when sending a transaction that gets rejected by the flashbots API (ex. gas=0) we still continue monitoring it as if it was received ok and we wait forever,  messing up nonces.

This PR considers tx status UKNOWN by the flashbots api as failed, which means the node never received the transaction.

## Screen recordings / screenshots
I've tested the whole flow and executed a swap https://etherscan.io/tx/0x6979ab9040f846e5d6b7df09c0fe7dd8314ca7ee05a247485c9935b0c3fa752b without any problems which is why I'm closing RNBW-4748

## What to test

