### PR TITLE
Swaps: gas icons, review sheet cleanup

### DIFF
--- a/src/__swaps__/screens/Swap/components/AnimatedSwitch.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwitch.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { AnimatedText, Box, Inline, globalColors, useColorMode, useForegroundColor } from '@/design-system';
+import { AnimatedText, Bleed, Box, Inline, globalColors, useColorMode, useForegroundColor } from '@/design-system';
 import Animated, { SharedValue, useAnimatedStyle, useDerivedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { opacityWorklet } from '@/__swaps__/utils/swaps';
 import { GestureHandlerButtonProps, GestureHandlerV1Button } from './GestureHandlerV1Button';
@@ -26,7 +26,7 @@ export function AnimatedSwitch({ value, onToggle, activeLabel, inactiveLabel, di
     return {
       backgroundColor: !value.value
         ? withTiming(opacityWorklet(inactiveBg, 0.12), TIMING_CONFIGS.fadeConfig)
-        : withTiming(opacityWorklet(activeBg, 0.64), TIMING_CONFIGS.fadeConfig),
+        : withTiming(opacityWorklet(activeBg, 0.72), TIMING_CONFIGS.fadeConfig),
       borderColor: opacityWorklet(border, 0.06),
       opacity: disabled ? 0.4 : 1,
     };
@@ -58,16 +58,20 @@ export function AnimatedSwitch({ value, onToggle, activeLabel, inactiveLabel, di
 
   if (labelItem.value) {
     return (
-      <GestureHandlerV1Button onPressWorklet={onToggle} {...props}>
-        <Inline alignVertical="center" horizontalSpace="6px">
-          <AnimatedText align="right" color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="heavy">
-            {labelItem}
-          </AnimatedText>
-          <Box as={Animated.View} style={[styles.containerStyles, containerStyles]}>
-            <Box style={[styles.circleStyles, circleStyles]} as={Animated.View} />
+      <Bleed horizontal="12px" vertical="8px">
+        <GestureHandlerV1Button onPressWorklet={onToggle} {...props}>
+          <Box paddingHorizontal="12px" paddingVertical="8px">
+            <Inline alignVertical="center" horizontalSpace="8px" wrap={false}>
+              <AnimatedText align="right" color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="bold">
+                {labelItem}
+              </AnimatedText>
+              <Box as={Animated.View} style={[styles.containerStyles, containerStyles]}>
+                <Box style={[styles.circleStyles, circleStyles]} as={Animated.View} />
+              </Box>
+            </Inline>
           </Box>
-        </Inline>
-      </GestureHandlerV1Button>
+        </GestureHandlerV1Button>
+      </Bleed>
     );
   }
 

--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -102,7 +102,9 @@ export const CoinRow = memo(function CoinRow({ isFavorite, onPress, output, uniq
 
   const onPressHandler = useCallback(
     (event: GestureResponderEvent) => {
-      event.stopPropagation();
+      if (event?.stopPropagation) {
+        event.stopPropagation();
+      }
 
       if (output) {
         return onPress();

--- a/src/__swaps__/screens/Swap/components/EstimatedSwapGasFee.tsx
+++ b/src/__swaps__/screens/Swap/components/EstimatedSwapGasFee.tsx
@@ -37,6 +37,7 @@ const GasFeeText = memo(function GasFeeText({
 }: { label: SharedValue<string> } & Pick<TextProps, 'align' | 'color' | 'size' | 'weight' | 'tabularNumbers'>) {
   const { isFetching } = useSwapContext();
 
+  const textColor = useForegroundColor(color);
   const labelTertiary = useForegroundColor('labelTertiary');
   const zeroAmountColor = opacity(labelTertiary, 0.3);
 
@@ -44,7 +45,7 @@ const GasFeeText = memo(function GasFeeText({
   const isLoading = useDerivedValue(() => isFetching.value || isFetchingDelayed.value);
 
   const animatedTextOpacity = useAnimatedStyle(() => ({
-    color: withTiming(isLoading.value ? zeroAmountColor : labelTertiary, TIMING_CONFIGS.slowFadeConfig),
+    color: withTiming(isLoading.value ? zeroAmountColor : textColor, TIMING_CONFIGS.slowFadeConfig),
     opacity: isLoading.value
       ? withRepeat(withSequence(withTiming(0.5, pulsingConfig), withTiming(1, pulsingConfig)), -1, true)
       : withSpring(1, sliderConfig),

--- a/src/__swaps__/screens/Swap/components/GasPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/GasPanel.tsx
@@ -1,8 +1,7 @@
 import * as i18n from '@/languages';
 import React, { PropsWithChildren, ReactNode, useCallback, useMemo } from 'react';
-import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, withDelay, withSpring } from 'react-native-reanimated';
 
-import { fadeConfig } from '@/__swaps__/screens/Swap/constants';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { ChainId } from '@/__swaps__/types/chains';
 import { GasSpeed } from '@/__swaps__/types/gas';
@@ -33,6 +32,8 @@ import { GasSettings, getCustomGasSettings, setCustomGasSettings, useCustomGasSt
 import { getSelectedGas, setSelectedGasSpeed, useSelectedGasSpeed } from '../hooks/useSelectedGas';
 import { EstimatedSwapGasFee, EstimatedSwapGasFeeSlot } from './EstimatedSwapGasFee';
 import { UnmountOnAnimatedReaction } from './UnmountOnAnimatedReaction';
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
+import { THICK_BORDER_WIDTH } from '../constants';
 
 const { GAS_TRENDS } = gasUtils;
 
@@ -434,17 +435,22 @@ export function onCloseGasPanel() {
 export function GasPanel() {
   const { configProgress } = useSwapContext();
 
+  const separator = useForegroundColor('separator');
+
   const styles = useAnimatedStyle(() => {
     return {
       display: configProgress.value !== NavigationSteps.SHOW_GAS ? 'none' : 'flex',
       pointerEvents: configProgress.value !== NavigationSteps.SHOW_GAS ? 'none' : 'auto',
-      opacity: configProgress.value === NavigationSteps.SHOW_GAS ? withTiming(1, fadeConfig) : withTiming(0, fadeConfig),
+      opacity:
+        configProgress.value === NavigationSteps.SHOW_GAS
+          ? withDelay(120, withSpring(1, SPRING_CONFIGS.springConfig))
+          : withSpring(0, SPRING_CONFIGS.springConfig),
       flex: 1,
     };
   });
 
   return (
-    <Box as={Animated.View} zIndex={12} style={styles} testID="gas-panel" width="full">
+    <Box as={Animated.View} paddingHorizontal="12px" zIndex={12} style={styles} testID="gas-panel" width="full">
       <Stack alignHorizontal="center" space="28px">
         <Text weight="heavy" color="label" size="20pt">
           {i18n.t(i18n.l.gas.gas_settings)}
@@ -459,7 +465,7 @@ export function GasPanel() {
             <EditableGasSettings />
           </Box>
 
-          <Separator color="separatorSecondary" />
+          <Separator color={{ custom: opacity(separator, 0.03) }} thickness={THICK_BORDER_WIDTH} />
 
           <MaxTransactionFee />
         </Box>

--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -2,7 +2,20 @@ import * as i18n from '@/languages';
 import React, { useCallback } from 'react';
 import { ReviewGasButton } from '@/__swaps__/screens/Swap/components/GasButton';
 import { ChainId, ChainNameDisplay } from '@/__swaps__/types/chains';
-import { AnimatedText, Bleed, Box, Inline, Separator, Stack, Text, globalColors, useColorMode } from '@/design-system';
+import {
+  AnimatedText,
+  Bleed,
+  Box,
+  Column,
+  Columns,
+  Inline,
+  Separator,
+  Stack,
+  Text,
+  TextIcon,
+  useColorMode,
+  useForegroundColor,
+} from '@/design-system';
 import { StyleSheet, View } from 'react-native';
 import Animated, {
   runOnJS,
@@ -10,9 +23,10 @@ import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-  withTiming,
+  withDelay,
+  withSpring,
 } from 'react-native-reanimated';
-import { fadeConfig } from '../constants';
+import { REVIEW_SHEET_ROW_HEIGHT, THICK_BORDER_WIDTH } from '../constants';
 import { NavigationSteps, useSwapContext } from '../providers/swap-provider';
 import { AnimatedSwitch } from './AnimatedSwitch';
 import { useAccountSettings } from '@/hooks';
@@ -33,6 +47,8 @@ import { getNativeAssetForNetwork } from '@/utils/ethereumUtils';
 import { useSelectedGas, useSelectedGasSpeed } from '../hooks/useSelectedGas';
 import { EstimatedSwapGasFee, EstimatedSwapGasFeeSlot } from './EstimatedSwapGasFee';
 import { UnmountOnAnimatedReaction } from './UnmountOnAnimatedReaction';
+import { opacity } from '@/__swaps__/utils/swaps';
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 
 const UNKNOWN_LABEL = i18n.t(i18n.l.swap.unknown);
 const REVIEW_LABEL = i18n.t(i18n.l.expanded_state.swap_details.review);
@@ -90,11 +106,15 @@ const RainbowFee = () => {
   );
 
   return (
-    <GestureHandlerV1Button onPressWorklet={swapIndex}>
-      <AnimatedText align="right" color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="heavy">
-        {feeToDisplay}
-      </AnimatedText>
-    </GestureHandlerV1Button>
+    <Bleed space="12px">
+      <GestureHandlerV1Button onPressWorklet={swapIndex}>
+        <Box padding="12px">
+          <AnimatedText align="right" color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="bold">
+            {feeToDisplay}
+          </AnimatedText>
+        </Box>
+      </GestureHandlerV1Button>
+    </Bleed>
   );
 };
 
@@ -139,6 +159,9 @@ export function ReviewPanel() {
   const { navigate } = useNavigation();
   const { isDarkMode } = useColorMode();
   const { configProgress, SwapSettings, SwapInputController, internalSelectedInputAsset, internalSelectedOutputAsset } = useSwapContext();
+
+  const labelTertiary = useForegroundColor('labelTertiary');
+  const separator = useForegroundColor('separator');
 
   const unknown = i18n.t(i18n.l.swap.unknown);
 
@@ -190,7 +213,10 @@ export function ReviewPanel() {
     return {
       display: configProgress.value !== NavigationSteps.SHOW_REVIEW ? 'none' : 'flex',
       pointerEvents: configProgress.value !== NavigationSteps.SHOW_REVIEW ? 'none' : 'auto',
-      opacity: configProgress.value === NavigationSteps.SHOW_REVIEW ? withTiming(1, fadeConfig) : withTiming(0, fadeConfig),
+      opacity:
+        configProgress.value === NavigationSteps.SHOW_REVIEW
+          ? withDelay(120, withSpring(1, SPRING_CONFIGS.springConfig))
+          : withSpring(0, SPRING_CONFIGS.springConfig),
       flex: 1,
     };
   });
@@ -203,32 +229,32 @@ export function ReviewPanel() {
   });
 
   return (
-    <Box as={Animated.View} zIndex={12} style={styles} testID="review-panel" width="full">
-      <Stack alignHorizontal="center" space="28px">
-        <Text weight="heavy" color="label" size="20pt">
+    <Box as={Animated.View} paddingHorizontal="12px" zIndex={12} style={styles} testID="review-panel" width="full">
+      <Stack alignHorizontal="center" space="24px">
+        <Text align="center" weight="heavy" color="label" size="20pt" style={{ paddingBottom: 4 }}>
           {REVIEW_LABEL}
         </Text>
 
         <Box gap={24} justifyContent="space-between" width="full">
           <Inline horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
             <Inline horizontalSpace="12px" alignVertical="center">
-              <Text color="labelTertiary" weight="bold" size="icon 13px">
+              <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
                 􀤆
-              </Text>
+              </TextIcon>
               <Text color="labelTertiary" weight="semibold" size="15pt">
                 {NETWORK_LABEL}
               </Text>
             </Inline>
 
-            <Inline alignVertical="center" horizontalSpace="6px">
-              <View style={sx.networkContainer}>
+            <Inline alignVertical="center" horizontalSpace="6px" wrap={false}>
+              <View style={sx.chainBadgeContainer}>
                 <AnimatedChainImage showMainnetBadge asset={internalSelectedInputAsset} size={16} />
               </View>
               <AnimatedText
                 align="right"
                 color={isDarkMode ? 'labelSecondary' : 'label'}
                 size="15pt"
-                weight="heavy"
+                weight="bold"
                 style={{ textTransform: 'capitalize' }}
               >
                 {chainName}
@@ -236,144 +262,173 @@ export function ReviewPanel() {
             </Inline>
           </Inline>
 
-          <Inline wrap={false} horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
-            <Inline wrap={false} horizontalSpace="12px" alignVertical="center">
-              <Text color="labelTertiary" weight="bold" size="icon 13px">
-                􀄩
-              </Text>
-              <Text color="labelTertiary" weight="semibold" size="15pt">
-                {MINIMUM_RECEIVED_LABEL}
-              </Text>
-            </Inline>
+          <Columns space="10px" alignVertical="center" alignHorizontal="justify">
+            <Column width="content">
+              <Box alignItems="center" flexDirection="row" gap={12}>
+                <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
+                  􀄩
+                </TextIcon>
+                <Text color="labelTertiary" weight="semibold" size="15pt">
+                  {MINIMUM_RECEIVED_LABEL}
+                </Text>
+              </Box>
+            </Column>
 
-            <Inline horizontalSpace="6px">
-              <AnimatedText align="right" color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="heavy">
+            <Column>
+              <AnimatedText align="right" color={isDarkMode ? 'labelSecondary' : 'label'} numberOfLines={1} size="15pt" weight="bold">
                 {minimumReceived}
               </AnimatedText>
-            </Inline>
-          </Inline>
+            </Column>
+          </Columns>
 
-          <Inline wrap={false} horizontalSpace="10px" alignHorizontal="justify">
-            <Inline wrap={false} horizontalSpace="12px" alignVertical="center">
-              <Text color="labelTertiary" weight="bold" size="icon 13px">
-                􀘾
-              </Text>
-              <Bleed horizontal="3px">
+          <Columns space="10px" alignVertical="center" alignHorizontal="justify">
+            <Column width="content">
+              <Box alignItems="center" flexDirection="row" gap={12}>
+                <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
+                  􀘾
+                </TextIcon>
                 <Text color="labelTertiary" weight="semibold" size="15pt">
                   {RAINBOW_FEE_LABEL}
                 </Text>
-              </Bleed>
-            </Inline>
+              </Box>
+            </Column>
 
-            <Inline wrap={false} horizontalSpace="6px">
+            <Column width="content">
               <RainbowFee />
-            </Inline>
-          </Inline>
+            </Column>
+          </Columns>
 
-          <Separator color="separatorSecondary" />
+          <Separator color={{ custom: opacity(separator, 0.03) }} thickness={THICK_BORDER_WIDTH} />
 
-          <Animated.View style={flashbotsVisibilityStyle}>
+          <Animated.View style={[flashbotsVisibilityStyle, { height: REVIEW_SHEET_ROW_HEIGHT, justifyContent: 'center' }]}>
             <Inline wrap={false} horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
               <Inline wrap={false} horizontalSpace="12px">
-                <Text color="labelTertiary" weight="bold" size="icon 13px">
+                <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
                   􀋦
-                </Text>
-                <ButtonPressAnimation onPress={openFlashbotsExplainer}>
-                  <Inline wrap={false} horizontalSpace="4px">
-                    <Text color="labelTertiary" weight="semibold" size="15pt">
-                      {FLASHBOTS_PROTECTION_LABEL}
-                    </Text>
-                    <Text color="labelTertiary" size="13pt" weight="bold">
-                      􀅴
-                    </Text>
-                  </Inline>
-                </ButtonPressAnimation>
+                </TextIcon>
+                <Inline wrap={false} horizontalSpace="4px">
+                  <Text color="labelTertiary" weight="semibold" size="15pt">
+                    {FLASHBOTS_PROTECTION_LABEL}
+                  </Text>
+                  <Bleed space="12px">
+                    <ButtonPressAnimation onPress={openFlashbotsExplainer} scaleTo={0.8}>
+                      <Text
+                        align="center"
+                        color={{ custom: opacity(labelTertiary, 0.24) }}
+                        size="icon 13px"
+                        style={{ padding: 12, top: 0.5 }}
+                        weight="semibold"
+                      >
+                        􀅴
+                      </Text>
+                    </ButtonPressAnimation>
+                  </Bleed>
+                </Inline>
               </Inline>
 
               <FlashbotsToggle />
             </Inline>
           </Animated.View>
 
-          <Inline wrap={false} horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
-            <Inline wrap={false} alignHorizontal="left" horizontalSpace="12px" alignVertical="center">
-              <Text color="labelTertiary" weight="bold" size="icon 13px">
-                􀘩
-              </Text>
-              <ButtonPressAnimation onPress={openSlippageExplainer}>
+          <Box height={{ custom: REVIEW_SHEET_ROW_HEIGHT }} justifyContent="center">
+            <Inline wrap={false} horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
+              <Inline wrap={false} alignHorizontal="left" horizontalSpace="12px" alignVertical="center">
+                <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
+                  􀘩
+                </TextIcon>
                 <Inline horizontalSpace="4px" alignVertical="center">
                   <Text color="labelTertiary" weight="semibold" size="15pt">
                     {MAX_SLIPPAGE_LABEL}
                   </Text>
-                  <Text color="labelTertiary" size="13pt" weight="bold">
-                    􀅴
-                  </Text>
+                  <Bleed space="12px">
+                    <ButtonPressAnimation onPress={openSlippageExplainer} scaleTo={0.8}>
+                      <Text
+                        align="center"
+                        color={{ custom: opacity(labelTertiary, 0.24) }}
+                        size="icon 13px"
+                        style={{ padding: 12, top: 0.5 }}
+                        weight="semibold"
+                      >
+                        􀅴
+                      </Text>
+                    </ButtonPressAnimation>
+                  </Bleed>
                 </Inline>
-              </ButtonPressAnimation>
-            </Inline>
-
-            <Inline wrap={false} horizontalSpace="8px" alignVertical="center">
-              <GestureHandlerV1Button onPressWorklet={handleDecrementSlippage}>
-                <Box
-                  style={{
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    borderWidth: 1,
-                    borderColor: isDarkMode ? globalColors.white10 : globalColors.grey100,
-                  }}
-                  height={{ custom: 16 }}
-                  width={{ custom: 20 }}
-                  borderRadius={100}
-                  background="fillSecondary" // TODO: 12% opacity
-                  paddingVertical="1px (Deprecated)"
-                  gap={10}
-                >
-                  {/* TODO: 56% opacity */}
-                  <Text weight="black" size="icon 10px" color="labelTertiary" align="center">
-                    􀅽
-                  </Text>
-                </Box>
-              </GestureHandlerV1Button>
-
-              <Inline space="2px">
-                <AnimatedText align="right" style={{ minWidth: 26 }} size="15pt" weight="bold" color="labelSecondary">
-                  {SwapSettings.slippage}
-                </AnimatedText>
-                <Text size="15pt" weight="bold" color="labelSecondary">
-                  %
-                </Text>
               </Inline>
 
-              <GestureHandlerV1Button onPressWorklet={handleIncrementSlippage}>
+              <Box alignItems="center" flexDirection="row">
+                <Bleed horizontal="12px" vertical="8px">
+                  <GestureHandlerV1Button onPressWorklet={handleDecrementSlippage}>
+                    <Box paddingHorizontal="12px" paddingVertical="8px">
+                      <Box
+                        style={{
+                          alignItems: 'center',
+                          borderColor: opacity(separator, 0.06),
+                          borderWidth: 1,
+                          justifyContent: 'center',
+                        }}
+                        height={{ custom: 16 }}
+                        width={{ custom: 20 }}
+                        borderRadius={8}
+                        background="fillSecondary"
+                      >
+                        <Text weight="black" size="icon 10px" color="labelTertiary" align="center">
+                          􀅽
+                        </Text>
+                      </Box>
+                    </Box>
+                  </GestureHandlerV1Button>
+                </Bleed>
+
                 <Box
-                  style={{
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    borderWidth: 1,
-                    borderColor: isDarkMode ? globalColors.white10 : globalColors.grey100,
-                  }}
-                  height={{ custom: 16 }}
-                  width={{ custom: 20 }}
-                  borderRadius={100}
-                  background="fillSecondary" // TODO: 12% opacity
-                  paddingVertical="1px (Deprecated)"
-                  gap={10}
+                  alignItems="center"
+                  flexDirection="row"
+                  gap={1}
+                  justifyContent="center"
+                  paddingHorizontal="8px"
+                  style={{ minWidth: 60, pointerEvents: 'none', zIndex: -1 }}
                 >
-                  {/* TODO: 56% opacity */}
-                  <Text weight="black" size="icon 10px" color="labelTertiary" align="center">
-                    􀅼
+                  <AnimatedText align="center" color="labelSecondary" size="15pt" weight="bold">
+                    {SwapSettings.slippage}
+                  </AnimatedText>
+                  <Text align="center" color="labelSecondary" size="15pt" weight="bold">
+                    %
                   </Text>
                 </Box>
-              </GestureHandlerV1Button>
-            </Inline>
-          </Inline>
 
-          <Separator color="separatorSecondary" />
+                <Bleed horizontal="12px" vertical="8px">
+                  <GestureHandlerV1Button onPressWorklet={handleIncrementSlippage}>
+                    <Box paddingHorizontal="12px" paddingVertical="8px">
+                      <Box
+                        style={{
+                          alignItems: 'center',
+                          borderWidth: 1,
+                          borderColor: opacity(separator, 0.06),
+                          justifyContent: 'center',
+                        }}
+                        height={{ custom: 16 }}
+                        width={{ custom: 20 }}
+                        borderRadius={8}
+                        background="fillSecondary"
+                      >
+                        <Text weight="black" size="icon 10px" color="labelTertiary" align="center">
+                          􀅼
+                        </Text>
+                      </Box>
+                    </Box>
+                  </GestureHandlerV1Button>
+                </Bleed>
+              </Box>
+            </Inline>
+          </Box>
+
+          <Separator color={{ custom: opacity(separator, 0.03) }} thickness={THICK_BORDER_WIDTH} />
 
           <Inline horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
-            <ButtonPressAnimation onPress={openGasExplainer}>
-              <Stack space="8px">
+            <ButtonPressAnimation onPress={openGasExplainer} scaleTo={0.925}>
+              <Stack space="10px">
                 <Inline alignVertical="center" horizontalSpace="6px">
-                  <View style={sx.gasContainer}>
+                  <View style={sx.chainBadgeContainer}>
                     <AnimatedChainImage showMainnetBadge asset={internalSelectedInputAsset} size={16} />
                   </View>
                   <UnmountOnAnimatedReaction
@@ -384,7 +439,7 @@ export function ReviewPanel() {
                     }}
                     placeholder={
                       <Inline horizontalSpace="4px">
-                        <EstimatedSwapGasFeeSlot text="--" align="left" color="label" size="15pt" weight="heavy" />
+                        <EstimatedSwapGasFeeSlot text="Loading…" align="left" color="label" size="15pt" weight="heavy" />
                         {null}
                       </Inline>
                     }
@@ -396,11 +451,11 @@ export function ReviewPanel() {
                   </UnmountOnAnimatedReaction>
                 </Inline>
 
-                <Inline wrap={false} alignHorizontal="left" alignVertical="bottom" horizontalSpace="4px">
+                <Inline wrap={false} alignHorizontal="left" alignVertical="center" horizontalSpace="4px">
                   <Text color="labelTertiary" size="13pt" weight="bold">
                     {ESTIMATED_NETWORK_FEE_LABEL}
                   </Text>
-                  <Text color="labelTertiary" size="icon 13px" weight="bold">
+                  <Text align="center" color={{ custom: opacity(labelTertiary, 0.24) }} size="icon 13px" weight="semibold">
                     􀅴
                   </Text>
                 </Inline>
@@ -418,16 +473,12 @@ export function ReviewPanel() {
 }
 
 const sx = StyleSheet.create({
-  gasContainer: {
-    top: 0,
-    height: 16,
-    width: 16,
+  chainBadgeContainer: {
+    alignItems: 'center',
+    height: 8,
     left: 8,
-    overflow: 'visible',
-  },
-  networkContainer: {
-    top: 2,
-    height: 12,
-    width: 6,
+    justifyContent: 'center',
+    top: 4,
+    width: 16,
   },
 });

--- a/src/__swaps__/screens/Swap/components/SearchInput.tsx
+++ b/src/__swaps__/screens/Swap/components/SearchInput.tsx
@@ -1,6 +1,5 @@
 import { LIGHT_SEPARATOR_COLOR, SEPARATOR_COLOR, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
-import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { opacity } from '@/__swaps__/utils/swaps';
 import { Input } from '@/components/inputs';
 import { AnimatedText, Bleed, Box, Column, Columns, Text, useColorMode, useForegroundColor } from '@/design-system';
@@ -10,7 +9,6 @@ import { useSwapsStore } from '@/state/swaps/swapsStore';
 import Clipboard from '@react-native-clipboard/clipboard';
 import React from 'react';
 import Animated, {
-  SharedValue,
   runOnJS,
   runOnUI,
   useAnimatedProps,
@@ -31,12 +29,10 @@ const CLOSE_LABEL = i18n.t(i18n.l.button.close);
 const PASTE_LABEL = i18n.t(i18n.l.button.paste);
 
 export const SearchInput = ({
-  asset,
   handleExitSearchWorklet,
   handleFocusSearchWorklet,
   output,
 }: {
-  asset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
   handleExitSearchWorklet: () => void;
   handleFocusSearchWorklet: () => void;
   output: boolean;

--- a/src/__swaps__/screens/Swap/components/SearchInput.tsx
+++ b/src/__swaps__/screens/Swap/components/SearchInput.tsx
@@ -68,12 +68,11 @@ export const SearchInput = ({
   });
 
   const buttonVisibilityStyle = useAnimatedStyle(() => {
-    const isInputSearchFocused =
-      inputProgress.value === NavigationSteps.SEARCH_FOCUSED || inputProgress.value === NavigationSteps.TOKEN_LIST_FOCUSED;
-    const noInputAssetSelected = !internalSelectedOutputAsset.value;
-    const isVisible = output || isInputSearchFocused || noInputAssetSelected;
+    const isInputSearchFocused = inputProgress.value === NavigationSteps.SEARCH_FOCUSED;
+    const isVisible = isInputSearchFocused || output || (!output && internalSelectedInputAsset.value);
 
     return {
+      display: isVisible ? 'flex' : 'none',
       opacity: isVisible ? 1 : 0,
       pointerEvents: isVisible ? 'auto' : 'none',
     };
@@ -218,9 +217,14 @@ export const SearchInput = ({
                 height={{ custom: 36 }}
                 justifyContent="center"
                 paddingHorizontal={{ custom: 12 - THICK_BORDER_WIDTH }}
-                style={
-                  output ? AnimatedSwapStyles.searchOutputAssetButtonWrapperStyle : AnimatedSwapStyles.searchInputAssetButtonWrapperStyle
-                }
+                style={[
+                  output ? AnimatedSwapStyles.searchOutputAssetButtonWrapperStyle : AnimatedSwapStyles.searchInputAssetButtonWrapperStyle,
+                  {
+                    borderCurve: 'continuous',
+                    borderWidth: THICK_BORDER_WIDTH,
+                    overflow: 'hidden',
+                  },
+                ]}
               >
                 <AnimatedText
                   align="center"

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
 import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, withSpring } from 'react-native-reanimated';
-
+import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { Box, Column, Columns, Separator, globalColors, useColorMode } from '@/design-system';
-import { safeAreaInsetValues } from '@/utils';
-
 import { LIGHT_SEPARATOR_COLOR, SEPARATOR_COLOR, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
-import { IS_ANDROID } from '@/env';
-
 import { opacity } from '@/__swaps__/utils/swaps';
-import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
+import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useBottomPanelGestureHandler } from '../hooks/useBottomPanelGestureHandler';
 import { GasButton } from './GasButton';
 import { GasPanel } from './GasPanel';
@@ -22,73 +16,93 @@ import { SwapActionButton } from './SwapActionButton';
 export function SwapBottomPanel() {
   const { isDarkMode } = useColorMode();
   const {
+    AnimatedSwapStyles,
+    SwapNavigation,
+    configProgress,
     confirmButtonIcon,
     confirmButtonIconStyle,
     confirmButtonLabel,
     internalSelectedOutputAsset,
-    AnimatedSwapStyles,
-    SwapNavigation,
-    configProgress,
   } = useSwapContext();
 
   const { swipeToDismissGestureHandler, gestureY } = useBottomPanelGestureHandler();
 
   const gestureHandlerStyles = useAnimatedStyle(() => {
     return {
-      transform: [
-        {
-          translateY:
-            gestureY.value > 0 ? withSpring(gestureY.value, SPRING_CONFIGS.springConfig) : withSpring(0, SPRING_CONFIGS.springConfig),
-        },
-      ],
+      transform: [{ translateY: gestureY.value }],
     };
   });
 
   const hiddenColumnStyles = useAnimatedStyle(() => {
     return {
-      display: configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'flex',
+      // display: configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'flex',
+      opacity: withTiming(
+        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 0 : 1,
+        TIMING_CONFIGS.fadeConfig
+      ),
+      pointerEvents:
+        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'auto',
+    };
+  });
+
+  const visibleColumnStyles = useAnimatedStyle(() => {
+    return {
+      // display: configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'flex' : 'none',
+      opacity: withTiming(
+        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 1 : 0,
+        TIMING_CONFIGS.fadeConfig
+      ),
+      pointerEvents:
+        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'auto' : 'none',
     };
   });
 
   return (
     // @ts-expect-error Property 'children' does not exist on type
     <PanGestureHandler maxPointers={1} onGestureEvent={swipeToDismissGestureHandler}>
-      <Box
-        as={Animated.View}
-        paddingBottom={{
-          custom: IS_ANDROID ? getSoftMenuBarHeight() - 32 : safeAreaInsetValues.bottom + 16,
-        }}
-        paddingHorizontal="20px"
+      <Animated.View
         style={[
-          AnimatedSwapStyles.swapActionWrapperStyle,
-          AnimatedSwapStyles.keyboardStyle,
-          gestureHandlerStyles,
           styles.swapActionsWrapper,
+          gestureHandlerStyles,
+          AnimatedSwapStyles.keyboardStyle,
+          AnimatedSwapStyles.swapActionWrapperStyle,
         ]}
-        width="full"
-        zIndex={15}
       >
         <ReviewPanel />
         <GasPanel />
-        <Columns alignVertical="center" space="12px">
-          <Column style={hiddenColumnStyles} width="content">
-            <GasButton />
-          </Column>
-          <Column style={hiddenColumnStyles} width="content">
-            <Box height={{ custom: 32 }}>
-              <Separator color={{ custom: isDarkMode ? SEPARATOR_COLOR : LIGHT_SEPARATOR_COLOR }} direction="vertical" thickness={1} />
-            </Box>
-          </Column>
-          <SwapActionButton
-            asset={internalSelectedOutputAsset}
-            icon={confirmButtonIcon}
-            iconStyle={confirmButtonIconStyle}
-            label={confirmButtonLabel}
-            onPressWorklet={SwapNavigation.handleSwapAction}
-            scaleTo={0.9}
-          />
-        </Columns>
-      </Box>
+        <Box zIndex={20}>
+          <Animated.View style={hiddenColumnStyles}>
+            <Columns alignVertical="center" space="12px">
+              <Column width="content">
+                <GasButton />
+              </Column>
+              <Column width="content">
+                <Box height={{ custom: 32 }}>
+                  <Separator color={{ custom: isDarkMode ? SEPARATOR_COLOR : LIGHT_SEPARATOR_COLOR }} direction="vertical" thickness={1} />
+                </Box>
+              </Column>
+              <SwapActionButton
+                asset={internalSelectedOutputAsset}
+                icon={confirmButtonIcon}
+                iconStyle={confirmButtonIconStyle}
+                label={confirmButtonLabel}
+                onPressWorklet={SwapNavigation.handleSwapAction}
+                scaleTo={0.9}
+              />
+            </Columns>
+          </Animated.View>
+          <Animated.View style={[visibleColumnStyles, { bottom: 0, height: 48, position: 'absolute', width: '100%' }]}>
+            <SwapActionButton
+              asset={internalSelectedOutputAsset}
+              icon={confirmButtonIcon}
+              iconStyle={confirmButtonIconStyle}
+              label={confirmButtonLabel}
+              onPressWorklet={SwapNavigation.handleSwapAction}
+              scaleTo={0.9}
+            />
+          </Animated.View>
+        </Box>
+      </Animated.View>
     </PanGestureHandler>
   );
 }
@@ -108,8 +122,11 @@ export const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   swapActionsWrapper: {
-    borderTopWidth: THICK_BORDER_WIDTH,
     borderCurve: 'continuous',
-    paddingBottom: IS_ANDROID ? getSoftMenuBarHeight() - 24 : safeAreaInsetValues.bottom + 16,
+    borderWidth: THICK_BORDER_WIDTH,
+    overflow: 'hidden',
+    paddingBottom: 16 - THICK_BORDER_WIDTH,
+    position: 'absolute',
+    zIndex: 15,
   },
 });

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
-import { Box, Column, Columns, Separator, globalColors, useColorMode } from '@/design-system';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import { Box, Separator, globalColors, useColorMode } from '@/design-system';
 import { LIGHT_SEPARATOR_COLOR, SEPARATOR_COLOR, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { opacity } from '@/__swaps__/utils/swaps';
-import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useBottomPanelGestureHandler } from '../hooks/useBottomPanelGestureHandler';
 import { GasButton } from './GasButton';
 import { GasPanel } from './GasPanel';
@@ -33,27 +32,9 @@ export function SwapBottomPanel() {
     };
   });
 
-  const hiddenColumnStyles = useAnimatedStyle(() => {
+  const gasButtonVisibilityStyle = useAnimatedStyle(() => {
     return {
-      // display: configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'flex',
-      opacity: withTiming(
-        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 0 : 1,
-        TIMING_CONFIGS.fadeConfig
-      ),
-      pointerEvents:
-        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'auto',
-    };
-  });
-
-  const visibleColumnStyles = useAnimatedStyle(() => {
-    return {
-      // display: configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'flex' : 'none',
-      opacity: withTiming(
-        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 1 : 0,
-        TIMING_CONFIGS.fadeConfig
-      ),
-      pointerEvents:
-        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'auto' : 'none',
+      display: configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'flex',
     };
   });
 
@@ -70,28 +51,27 @@ export function SwapBottomPanel() {
       >
         <ReviewPanel />
         <GasPanel />
-        <Box zIndex={20}>
-          <Animated.View style={hiddenColumnStyles}>
-            <Columns alignVertical="center" space="12px">
-              <Column width="content">
-                <GasButton />
-              </Column>
-              <Column width="content">
-                <Box height={{ custom: 32 }}>
-                  <Separator color={{ custom: isDarkMode ? SEPARATOR_COLOR : LIGHT_SEPARATOR_COLOR }} direction="vertical" thickness={1} />
-                </Box>
-              </Column>
-              <SwapActionButton
-                asset={internalSelectedOutputAsset}
-                icon={confirmButtonIcon}
-                iconStyle={confirmButtonIconStyle}
-                label={confirmButtonLabel}
-                onPressWorklet={SwapNavigation.handleSwapAction}
-                scaleTo={0.9}
-              />
-            </Columns>
+        <Box
+          alignItems="center"
+          flexDirection="row"
+          height={{ custom: 48 }}
+          justifyContent="center"
+          style={{ alignSelf: 'center' }}
+          width="full"
+          zIndex={20}
+        >
+          <Animated.View
+            style={[
+              gasButtonVisibilityStyle,
+              { alignItems: 'center', flexDirection: 'row', gap: 12, justifyContent: 'center', paddingRight: 12 },
+            ]}
+          >
+            <GasButton />
+            <Box height={{ custom: 32 }}>
+              <Separator color={{ custom: isDarkMode ? SEPARATOR_COLOR : LIGHT_SEPARATOR_COLOR }} direction="vertical" thickness={1} />
+            </Box>
           </Animated.View>
-          <Animated.View style={[visibleColumnStyles, { bottom: 0, height: 48, position: 'absolute', width: '100%' }]}>
+          <Box style={{ flex: 1 }}>
             <SwapActionButton
               asset={internalSelectedOutputAsset}
               icon={confirmButtonIcon}
@@ -100,7 +80,7 @@ export function SwapBottomPanel() {
               onPressWorklet={SwapNavigation.handleSwapAction}
               scaleTo={0.9}
             />
-          </Animated.View>
+          </Box>
         </Box>
       </Animated.View>
     </PanGestureHandler>
@@ -116,7 +96,7 @@ export const styles = StyleSheet.create({
     borderRadius: 40,
     borderColor: opacity(globalColors.darkGrey, 0.2),
     borderCurve: 'continuous',
-    borderWidth: 1.33,
+    borderWidth: THICK_BORDER_WIDTH,
     gap: 24,
     padding: 24,
     overflow: 'hidden',

--- a/src/__swaps__/screens/Swap/components/SwapInput.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInput.tsx
@@ -5,6 +5,7 @@ import { BASE_INPUT_WIDTH, INPUT_PADDING, THICK_BORDER_WIDTH } from '@/__swaps__
 import { useSwapInputStyles } from '@/__swaps__/screens/Swap/hooks/useSwapInputStyles';
 import { StyleSheet } from 'react-native';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import { IS_IOS } from '@/env';
 
 export const SwapInput = ({
   children,
@@ -44,7 +45,7 @@ export const styles = StyleSheet.create({
   staticInputStyles: {
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: THICK_BORDER_WIDTH,
+    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
     overflow: 'hidden',
     padding: INPUT_PADDING,
     width: BASE_INPUT_WIDTH,

--- a/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
@@ -13,7 +13,7 @@ import { SwapInput } from '@/__swaps__/screens/Swap/components/SwapInput';
 import { BalanceBadge } from '@/__swaps__/screens/Swap/components/BalanceBadge';
 import { TokenList } from '@/__swaps__/screens/Swap/components/TokenList/TokenList';
 import { BASE_INPUT_WIDTH, INPUT_INNER_WIDTH, INPUT_PADDING, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
-import { IS_ANDROID } from '@/env';
+import { IS_ANDROID, IS_IOS } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { AnimatedSwapCoinIcon } from './AnimatedSwapCoinIcon';
 import * as i18n from '@/languages';
@@ -134,7 +134,6 @@ export function SwapInputAsset() {
         width={{ custom: INPUT_INNER_WIDTH }}
       >
         <TokenList
-          asset={internalSelectedInputAsset}
           handleExitSearchWorklet={SwapNavigation.handleExitSearch}
           handleFocusSearchWorklet={SwapNavigation.handleFocusInputSearch}
           output={false}
@@ -189,7 +188,7 @@ export const styles = StyleSheet.create({
   staticInputStyles: {
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: THICK_BORDER_WIDTH,
+    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
     overflow: 'hidden',
     padding: INPUT_PADDING,
     width: BASE_INPUT_WIDTH,

--- a/src/__swaps__/screens/Swap/components/SwapNumberPad.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapNumberPad.tsx
@@ -27,6 +27,7 @@ import { LongPressGestureHandler, LongPressGestureHandlerGestureEvent } from 're
 import { ButtonPressAnimation } from '@/components/animations';
 import { colors } from '@/styles';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
+import { IS_IOS } from '@/env';
 
 type numberPadCharacter = number | 'backspace' | '.';
 
@@ -333,7 +334,7 @@ const NumberPadKey = ({
                 !transparent && {
                   borderColor: isDarkMode ? separatorTertiary : 'transparent',
                   borderCurve: 'continuous',
-                  borderWidth: THICK_BORDER_WIDTH,
+                  borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
                   shadowColor: isDarkMode ? 'transparent' : colors.dark,
                   shadowOffset: {
                     width: 0,

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -12,7 +12,7 @@ import { BalanceBadge } from '@/__swaps__/screens/Swap/components/BalanceBadge';
 import { AnimatedSwapCoinIcon } from '@/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon';
 import { TokenList } from '@/__swaps__/screens/Swap/components/TokenList/TokenList';
 import { BASE_INPUT_WIDTH, INPUT_INNER_WIDTH, INPUT_PADDING, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
-import { IS_ANDROID } from '@/env';
+import { IS_ANDROID, IS_IOS } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
@@ -163,7 +163,6 @@ export function SwapOutputAsset() {
         width={{ custom: INPUT_INNER_WIDTH }}
       >
         <TokenList
-          asset={internalSelectedOutputAsset}
           handleExitSearchWorklet={SwapNavigation.handleExitSearch}
           handleFocusSearchWorklet={SwapNavigation.handleFocusOutputSearch}
           output
@@ -218,7 +217,7 @@ export const styles = StyleSheet.create({
   staticInputStyles: {
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: THICK_BORDER_WIDTH,
+    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
     overflow: 'hidden',
     padding: INPUT_PADDING,
     width: BASE_INPUT_WIDTH,

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -308,24 +308,28 @@ export const SwapSlider = ({
         ),
         SPRING_CONFIGS.springConfig
       ),
-      borderWidth: interpolate(
-        xPercentage.value,
-        [0, (THICK_BORDER_WIDTH * 2) / width, (THICK_BORDER_WIDTH * 4) / width, 1],
-        [0, 0, THICK_BORDER_WIDTH, THICK_BORDER_WIDTH],
-        'clamp'
-      ),
+      borderWidth: IS_IOS
+        ? interpolate(
+            xPercentage.value,
+            [0, (THICK_BORDER_WIDTH * 2) / width, (THICK_BORDER_WIDTH * 4) / width, 1],
+            [0, 0, THICK_BORDER_WIDTH, THICK_BORDER_WIDTH],
+            'clamp'
+          )
+        : 0,
       width: `${uiXPercentage.value * 100}%`,
     };
   });
 
   const rightBarContainerStyle = useAnimatedStyle(() => {
     return {
-      borderWidth: interpolate(
-        xPercentage.value,
-        [0, 1 - (THICK_BORDER_WIDTH * 4) / width, 1 - (THICK_BORDER_WIDTH * 2) / width, 1],
-        [THICK_BORDER_WIDTH, THICK_BORDER_WIDTH, 0, 0],
-        'clamp'
-      ),
+      borderWidth: IS_IOS
+        ? interpolate(
+            xPercentage.value,
+            [0, 1 - (THICK_BORDER_WIDTH * 4) / width, 1 - (THICK_BORDER_WIDTH * 2) / width, 1],
+            [THICK_BORDER_WIDTH, THICK_BORDER_WIDTH, 0, 0],
+            'clamp'
+          )
+        : 0,
       backgroundColor: colors.value.inactiveColorRight,
       width: `${(1 - uiXPercentage.value - SCRUBBER_WIDTH / width) * 100}%`,
     };

--- a/src/__swaps__/screens/Swap/components/TokenList/TokenList.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/TokenList.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
-import { SharedValue } from 'react-native-reanimated';
 import { Box, Separator, Stack } from '@/design-system';
 import { EXPANDED_INPUT_HEIGHT } from '@/__swaps__/screens/Swap/constants';
 import { SearchInput } from '@/__swaps__/screens/Swap/components/SearchInput';
 import { TokenToSellList } from '@/__swaps__/screens/Swap/components/TokenList/TokenToSellList';
 import { TokenToBuyList } from '@/__swaps__/screens/Swap/components/TokenList/TokenToBuyList';
-import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 export const TokenList = ({
-  asset,
   handleExitSearchWorklet,
   handleFocusSearchWorklet,
   output,
 }: {
-  asset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
   handleExitSearchWorklet: () => void;
   handleFocusSearchWorklet: () => void;
   output: boolean;
@@ -23,7 +19,6 @@ export const TokenList = ({
     <Stack>
       <Stack space="20px">
         <SearchInput
-          asset={asset}
           handleExitSearchWorklet={handleExitSearchWorklet}
           handleFocusSearchWorklet={handleFocusSearchWorklet}
           output={output}

--- a/src/__swaps__/screens/Swap/constants.ts
+++ b/src/__swaps__/screens/Swap/constants.ts
@@ -13,8 +13,8 @@ export const NATIVE_KEYBOARD_HEIGHT = getDefaultKeyboardHeight();
 
 export const REVIEW_SHEET_ROW_HEIGHT = 10;
 export const REVIEW_SHEET_ROW_GAP = 24;
-export const REVIEW_SHEET_HEIGHT = 420;
-export const GAS_SHEET_HEIGHT = 308;
+export const REVIEW_SHEET_HEIGHT = 412;
+export const GAS_SHEET_HEIGHT = 274;
 export const BOTTOM_ACTION_BAR_HEIGHT = 114;
 export const BASE_INPUT_HEIGHT = 104;
 export const BASE_INPUT_WIDTH = deviceUtils.dimensions.width - 24;

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -247,17 +247,23 @@ export function useAnimatedSwapStyles({
         getColorValueForThemeWorklet(internalSelectedInputAsset.value?.highContrastColor, isDarkMode, true),
         isDarkMode ? 0.06 : 0.01
       ),
-      borderWidth: THICK_BORDER_WIDTH,
     };
   });
 
   const searchOutputAssetButtonWrapperStyle = useAnimatedStyle(() => {
     const color = isPasteMode.value ? foregroundColors.blue : internalSelectedOutputAsset.value?.highContrastColor;
 
+    const darkModeBorderOpacity = isPasteMode.value ? 0.08 : 0.06;
+    const lightModeBorderOpacity = isPasteMode.value ? 0.06 : 0.01;
+
     return {
-      backgroundColor: opacityWorklet(getColorValueForThemeWorklet(color, isDarkMode, true), isDarkMode ? 0.1 : 0.08),
-      borderColor: opacityWorklet(getColorValueForThemeWorklet(color, isDarkMode, true), isDarkMode ? 0.06 : 0.01),
-      borderWidth: isPasteMode.value ? 0 : THICK_BORDER_WIDTH,
+      backgroundColor: isPasteMode.value
+        ? 'transparent'
+        : opacityWorklet(getColorValueForThemeWorklet(color, isDarkMode, true), isDarkMode ? 0.1 : 0.08),
+      borderColor: opacityWorklet(
+        getColorValueForThemeWorklet(color, isDarkMode, true),
+        isDarkMode ? darkModeBorderOpacity : lightModeBorderOpacity
+      ),
     };
   });
 

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -9,14 +9,12 @@ import {
   REVIEW_SHEET_ROW_GAP,
   REVIEW_SHEET_ROW_HEIGHT,
   THICK_BORDER_WIDTH,
-  fadeConfig,
-  springConfig,
 } from '@/__swaps__/screens/Swap/constants';
 import { SwapWarningType, useSwapWarning } from '@/__swaps__/screens/Swap/hooks/useSwapWarning';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { getColorValueForThemeWorklet, opacityWorklet } from '@/__swaps__/utils/swaps';
 import { spinnerExitConfig } from '@/components/animations/AnimatedSpinner';
-import { globalColors, useColorMode } from '@/design-system';
+import { useColorMode } from '@/design-system';
 import { foregroundColors } from '@/design-system/color/palettes';
 import { IS_ANDROID } from '@/env';
 import { safeAreaInsetValues } from '@/utils';
@@ -24,13 +22,14 @@ import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
 import { SharedValue, interpolate, useAnimatedStyle, useDerivedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { NavigationSteps } from './useSwapNavigation';
 import { ChainId } from '@/__swaps__/types/chains';
+import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 
 const INSET_BOTTOM = IS_ANDROID ? getSoftMenuBarHeight() - 24 : safeAreaInsetValues.bottom + 16;
 const HEIGHT_FOR_PANEL: { [key in NavigationSteps]: number } = {
   [NavigationSteps.INPUT_ELEMENT_FOCUSED]: BOTTOM_ACTION_BAR_HEIGHT,
   [NavigationSteps.SEARCH_FOCUSED]: BOTTOM_ACTION_BAR_HEIGHT,
   [NavigationSteps.TOKEN_LIST_FOCUSED]: BOTTOM_ACTION_BAR_HEIGHT,
-  [NavigationSteps.SHOW_REVIEW]: REVIEW_SHEET_HEIGHT + INSET_BOTTOM,
+  [NavigationSteps.SHOW_REVIEW]: REVIEW_SHEET_HEIGHT,
   [NavigationSteps.SHOW_GAS]: GAS_SHEET_HEIGHT + INSET_BOTTOM,
 };
 
@@ -59,7 +58,7 @@ export function useAnimatedSwapStyles({
         {
           translateY: withSpring(
             interpolate(inputProgress.value, [0, 1, 2], [0, 0, EXPANDED_INPUT_HEIGHT - FOCUSED_INPUT_HEIGHT], 'clamp'),
-            springConfig
+            SPRING_CONFIGS.springConfig
           ),
         },
       ],
@@ -68,7 +67,10 @@ export function useAnimatedSwapStyles({
 
   const focusedSearchStyle = useAnimatedStyle(() => {
     return {
-      opacity: inputProgress.value === 2 || outputProgress.value === 2 ? withTiming(0, fadeConfig) : withTiming(1, fadeConfig),
+      opacity:
+        inputProgress.value === 2 || outputProgress.value === 2
+          ? withTiming(0, TIMING_CONFIGS.fadeConfig)
+          : withTiming(1, TIMING_CONFIGS.fadeConfig),
       pointerEvents: inputProgress.value === 2 || outputProgress.value === 2 ? 'none' : 'auto',
     };
   });
@@ -77,8 +79,8 @@ export function useAnimatedSwapStyles({
     return {
       opacity:
         SwapWarning.swapWarning.value.type === SwapWarningType.none || inputProgress.value > 0 || outputProgress.value > 0
-          ? withTiming(0, fadeConfig)
-          : withTiming(1, fadeConfig),
+          ? withTiming(0, TIMING_CONFIGS.fadeConfig)
+          : withTiming(1, TIMING_CONFIGS.fadeConfig),
       pointerEvents:
         SwapWarning.swapWarning.value.type === SwapWarningType.none || inputProgress.value > 0 || outputProgress.value > 0
           ? 'none'
@@ -88,7 +90,10 @@ export function useAnimatedSwapStyles({
 
   const hideWhenInputsExpanded = useAnimatedStyle(() => {
     return {
-      opacity: inputProgress.value > 0 || outputProgress.value > 0 ? withTiming(0, fadeConfig) : withTiming(1, fadeConfig),
+      opacity:
+        inputProgress.value > 0 || outputProgress.value > 0
+          ? withTiming(0, TIMING_CONFIGS.fadeConfig)
+          : withTiming(1, TIMING_CONFIGS.fadeConfig),
       pointerEvents: inputProgress.value > 0 || outputProgress.value > 0 ? 'none' : 'auto',
     };
   });
@@ -97,8 +102,8 @@ export function useAnimatedSwapStyles({
     return {
       opacity:
         SwapWarning.swapWarning.value.type !== SwapWarningType.none || inputProgress.value > 0 || outputProgress.value > 0
-          ? withTiming(0, fadeConfig)
-          : withTiming(1, fadeConfig),
+          ? withTiming(0, TIMING_CONFIGS.fadeConfig)
+          : withTiming(1, TIMING_CONFIGS.fadeConfig),
       pointerEvents:
         SwapWarning.swapWarning.value.type !== SwapWarningType.none || inputProgress.value > 0 || outputProgress.value > 0
           ? 'none'
@@ -108,14 +113,14 @@ export function useAnimatedSwapStyles({
 
   const inputStyle = useAnimatedStyle(() => {
     return {
-      opacity: withTiming(interpolate(inputProgress.value, [0, 1], [1, 0], 'clamp'), fadeConfig),
+      opacity: withTiming(interpolate(inputProgress.value, [0, 1], [1, 0], 'clamp'), TIMING_CONFIGS.fadeConfig),
       pointerEvents: inputProgress.value === 0 ? 'auto' : 'none',
     };
   });
 
   const inputTokenListStyle = useAnimatedStyle(() => {
     return {
-      opacity: withTiming(interpolate(inputProgress.value, [0, 1], [0, 1], 'clamp'), fadeConfig),
+      opacity: withTiming(interpolate(inputProgress.value, [0, 1], [0, 1], 'clamp'), TIMING_CONFIGS.fadeConfig),
       pointerEvents: inputProgress.value === 0 ? 'none' : 'auto',
     };
   });
@@ -124,28 +129,32 @@ export function useAnimatedSwapStyles({
     const progress = Math.min(inputProgress.value + outputProgress.value, 1);
 
     return {
-      opacity: withTiming(1 - progress, fadeConfig),
+      opacity: withTiming(1 - progress, TIMING_CONFIGS.fadeConfig),
       transform: [
         {
-          translateY: withSpring(progress * (EXPANDED_INPUT_HEIGHT - BASE_INPUT_HEIGHT), springConfig),
+          translateY: withSpring(progress * (EXPANDED_INPUT_HEIGHT - BASE_INPUT_HEIGHT), SPRING_CONFIGS.springConfig),
         },
-        { scale: withSpring(0.925 + (1 - progress) * 0.075, springConfig) },
+        { scale: withSpring(0.925 + (1 - progress) * 0.075, SPRING_CONFIGS.springConfig) },
       ],
     };
   });
 
   const outputStyle = useAnimatedStyle(() => {
     return {
-      opacity: withTiming(interpolate(outputProgress.value, [0, 1], [1, 0], 'clamp'), fadeConfig),
+      opacity: withTiming(interpolate(outputProgress.value, [0, 1], [1, 0], 'clamp'), TIMING_CONFIGS.fadeConfig),
       pointerEvents: outputProgress.value === 0 ? 'auto' : 'none',
     };
   });
 
   const outputTokenListStyle = useAnimatedStyle(() => {
     return {
-      opacity: withTiming(interpolate(outputProgress.value, [0, 1], [0, 1], 'clamp'), fadeConfig),
+      opacity: withTiming(interpolate(outputProgress.value, [0, 1], [0, 1], 'clamp'), TIMING_CONFIGS.fadeConfig),
       pointerEvents: outputProgress.value === 0 ? 'none' : 'auto',
     };
+  });
+
+  const outputAssetColor = useDerivedValue(() => {
+    return getColorValueForThemeWorklet(internalSelectedOutputAsset.value?.highContrastColor, isDarkMode, true);
   });
 
   const swapActionWrapperStyle = useAnimatedStyle(() => {
@@ -159,21 +168,20 @@ export function useAnimatedSwapStyles({
     }
 
     return {
-      position: isReviewingOrConfiguringGas ? 'absolute' : 'relative',
-      bottom: isReviewingOrConfiguringGas ? 0 : undefined,
-      height: withSpring(heightForCurrentSheet, springConfig),
-      borderTopLeftRadius: isReviewingOrConfiguringGas ? (IS_ANDROID ? 20 : 40) : 0,
-      borderTopRightRadius: isReviewingOrConfiguringGas ? (IS_ANDROID ? 20 : 40) : 0,
-      borderWidth: isReviewingOrConfiguringGas ? THICK_BORDER_WIDTH : 0,
-      borderColor: isReviewingOrConfiguringGas ? opacityWorklet(globalColors.darkGrey, 0.2) : undefined,
-      backgroundColor: opacityWorklet(
-        getColorValueForThemeWorklet(internalSelectedOutputAsset.value?.highContrastColor, isDarkMode, true),
-        0.03
+      backgroundColor: opacityWorklet(outputAssetColor.value, 0.06),
+      borderColor: withSpring(
+        configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS
+          ? opacityWorklet(outputAssetColor.value, 0.2)
+          : opacityWorklet(outputAssetColor.value, 0.06),
+        SPRING_CONFIGS.springConfig
       ),
-      borderTopColor: isReviewingOrConfiguringGas
-        ? opacityWorklet(globalColors.darkGrey, 0.2)
-        : opacityWorklet(getColorValueForThemeWorklet(internalSelectedOutputAsset.value?.highContrastColor, isDarkMode, true), 0.04),
-      paddingTop: isReviewingOrConfiguringGas ? 28 : 16 - THICK_BORDER_WIDTH,
+      borderRadius: withSpring(isReviewingOrConfiguringGas ? (IS_ANDROID ? 40 : 40) : 0, SPRING_CONFIGS.springConfig),
+      bottom: withSpring(isReviewingOrConfiguringGas ? Math.max(safeAreaInsetValues.bottom, 28) : -2, SPRING_CONFIGS.springConfig),
+      height: withSpring(heightForCurrentSheet, SPRING_CONFIGS.springConfig),
+      left: withSpring(isReviewingOrConfiguringGas ? 12 : -2, SPRING_CONFIGS.springConfig),
+      right: withSpring(isReviewingOrConfiguringGas ? 12 : -2, SPRING_CONFIGS.springConfig),
+      paddingHorizontal: withSpring((isReviewingOrConfiguringGas ? 16 : 18) - THICK_BORDER_WIDTH, SPRING_CONFIGS.springConfig),
+      paddingTop: withSpring((isReviewingOrConfiguringGas ? 28 : 16) - THICK_BORDER_WIDTH, SPRING_CONFIGS.springConfig),
     };
   });
 
@@ -230,8 +238,8 @@ export function useAnimatedSwapStyles({
     return {
       opacity:
         configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS
-          ? withTiming(0, fadeConfig)
-          : withTiming(1, fadeConfig),
+          ? withTiming(0, TIMING_CONFIGS.fadeConfig)
+          : withTiming(1, TIMING_CONFIGS.fadeConfig),
       pointerEvents:
         configProgress.value === NavigationSteps.SHOW_REVIEW || configProgress.value === NavigationSteps.SHOW_GAS ? 'none' : 'auto',
     };

--- a/src/__swaps__/screens/Swap/hooks/useBottomPanelGestureHandler.ts
+++ b/src/__swaps__/screens/Swap/hooks/useBottomPanelGestureHandler.ts
@@ -1,6 +1,7 @@
 import { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
-import { useAnimatedGestureHandler, useSharedValue } from 'react-native-reanimated';
+import { interpolate, useAnimatedGestureHandler, useSharedValue, withSpring } from 'react-native-reanimated';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 
 export const useBottomPanelGestureHandler = () => {
   const gestureY = useSharedValue(0);
@@ -8,22 +9,36 @@ export const useBottomPanelGestureHandler = () => {
 
   const swipeToDismissGestureHandler = useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
     onStart: (_, ctx: { startY?: number }) => {
+      if (configProgress.value !== NavigationSteps.SHOW_REVIEW && configProgress.value !== NavigationSteps.SHOW_GAS) {
+        return;
+      }
+
       if (ctx.startY) {
         ctx.startY = undefined;
       }
     },
     onActive: (e, ctx: { startY?: number }) => {
+      if (configProgress.value !== NavigationSteps.SHOW_REVIEW && configProgress.value !== NavigationSteps.SHOW_GAS) {
+        return;
+      }
+
       if (ctx.startY === undefined) {
         ctx.startY = e.absoluteY;
       }
 
       const yDelta = e.absoluteY - ctx.startY;
-      gestureY.value = yDelta;
+
+      const downwardMovement = yDelta > 0 ? yDelta : 0;
+      const upwardMovement = interpolate(yDelta, [-200, 0], [-200, 0], 'clamp');
+      const friction = interpolate(yDelta, [-200, 0], [10, 1], 'clamp');
+
+      gestureY.value = downwardMovement + upwardMovement / friction;
     },
     onEnd: (e, ctx: { startY?: number }) => {
       const yDelta = e.absoluteY - (ctx.startY || 0);
+      const yVelocity = e.velocityY;
 
-      const isBeyondDismissThreshold = yDelta > 80;
+      const isBeyondDismissThreshold = (yVelocity >= 0 && yDelta > 80) || yVelocity > 500;
       if (isBeyondDismissThreshold) {
         if (configProgress.value === NavigationSteps.SHOW_REVIEW) {
           SwapNavigation.handleDismissReview();
@@ -31,7 +46,7 @@ export const useBottomPanelGestureHandler = () => {
           SwapNavigation.handleDismissGas();
         }
       }
-      gestureY.value = 0;
+      gestureY.value = withSpring(0, SPRING_CONFIGS.springConfig);
     },
   });
 

--- a/src/__swaps__/utils/meteorology.ts
+++ b/src/__swaps__/utils/meteorology.ts
@@ -206,7 +206,7 @@ function selectEstimatedTime({ data }: MeteorologyResult, selectedGas: GasSettin
   const value = findClosestValue(selectedGas.maxPriorityFee, Object.values(data.confirmationTimeByPriorityFee));
   const [time] = Object.entries(data.confirmationTimeByPriorityFee).find(([, v]) => v === value) || [];
   if (!time) return undefined;
-  return `${+time >= 3600 ? '>' : '~'} ${getMinimalTimeUnitStringForMs(+time * 1000)}`;
+  return `${+time >= 3600 ? '> ' : '~'}${getMinimalTimeUnitStringForMs(+time * 1000)}`;
 }
 
 export function useEstimatedTime({ chainId, speed }: { chainId: ChainId; speed: GasSpeed }) {

--- a/src/references/index.ts
+++ b/src/references/index.ts
@@ -260,5 +260,5 @@ export const SUPPORTED_CHAINS = ({ testnetMode = false }: { testnetMode?: boolea
     return chainList;
   }, [] as Chain[]);
 
-export const SUPPORTED_CHAIN_IDS = ({ testnetMode = false }: { testnetMode?: boolean }) =>
+export const SUPPORTED_CHAIN_IDS = ({ testnetMode = false }: { testnetMode?: boolean }): ChainId[] =>
   SUPPORTED_CHAINS({ testnetMode }).map(chain => chain.id);

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -154,7 +154,10 @@ export const userAssetsStore = createRainbowStore<UserAssetsState>(
             asset =>
               (+asset.native?.balance?.amount ?? 0) > smallBalanceThreshold &&
               (!chainIdFilter || asset.chainId === chainIdFilter) &&
-              (!searchRegex || searchRegex.test(asset.name) || searchRegex.test(asset.symbol) || searchRegex.test(asset.address)),
+              (!searchRegex ||
+                searchRegex.test(asset.name) ||
+                searchRegex.test(asset.symbol) ||
+                asset.address.toLowerCase() === inputSearchQuery),
             filter
           )
         );

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -1,7 +1,9 @@
-import { colors } from '@/styles';
-import * as i18n from '@/languages';
-import { convertAmountToNativeDisplay } from '@/helpers/utilities';
+import { TextColor } from '@/design-system/color/palettes';
 import { NativeCurrencyKey } from '@/entities';
+import { IS_IOS } from '@/env';
+import { convertAmountToNativeDisplay } from '@/helpers/utilities';
+import * as i18n from '@/languages';
+import { colors } from '@/styles';
 
 const CUSTOM = 'custom';
 const URGENT = 'urgent';
@@ -25,10 +27,37 @@ const GAS_ICONS = {
   [URGENT]: 'policeCarLight',
 };
 
+interface SwapGasIcons {
+  [key: string]: { color: TextColor; icon: string; symbolName: string };
+}
+
+const SWAP_GAS_ICONS: SwapGasIcons = {
+  [CUSTOM]: {
+    color: 'labelSecondary',
+    icon: '􀣌',
+    symbolName: 'gearshape',
+  },
+  [FAST]: {
+    color: 'red',
+    icon: '􀙭',
+    symbolName: 'flame',
+  },
+  [NORMAL]: {
+    color: 'blue',
+    icon: '􀐫',
+    symbolName: 'clock',
+  },
+  [URGENT]: {
+    color: 'yellow',
+    icon: '􀋦',
+    symbolName: 'bolt',
+  },
+};
+
 const GAS_EMOJIS = {
   [CUSTOM]: '⚙️',
   [FAST]: '🚀',
-  [NORMAL]: ios ? '⏱' : '🕘',
+  [NORMAL]: IS_IOS ? '⏱' : '🕘',
   [URGENT]: '🚨',
 };
 
@@ -88,5 +117,6 @@ export default {
   GasTrends,
   NORMAL,
   SLOW,
+  SWAP_GAS_ICONS,
   URGENT,
 };


### PR DESCRIPTION
Fixes APP-1548

## What changed (plus any additional context for devs)
- Adds new gas icons
- Cleans up review sheet styles, hit boxes, gestures, and animations
- Fixes an issue in input asset search where token contract addresses were being searched no matter the query — now only returning exact address matches
- Fixes the input Close button visibility
- Disables some Android borders that weren't rendering correctly, minor Android style fixes
- Fixes paste button styles
- Fixes a crash that occurred on Android when selecting an asset, due to `event.stopPropagation` not existing
- Tested on both iOS and Android

## Screen recordings / screenshots

<img src="https://github.com/rainbow-me/rainbow/assets/7061887/047f1b11-a76d-4eca-9fb7-44af1e536f4c" width="375">
<img src="https://github.com/rainbow-me/rainbow/assets/7061887/07dbe36c-c32d-4d59-94ba-8dd94b7d5585" width="375">
<img src="https://github.com/rainbow-me/rainbow/assets/7061887/3474a78c-a503-4385-8391-b2d800806697" width="375">
<img src="https://github.com/rainbow-me/rainbow/assets/7061887/2db4be37-2767-49dd-a88f-c385d83cb553" width="375">

## What to test

