### PR TITLE
Fixes for review button states

### DIFF
--- a/src/__swaps__/screens/Swap/__tests__/NiceIncrementerFormatter.test.ts
+++ b/src/__swaps__/screens/Swap/__tests__/NiceIncrementerFormatter.test.ts
@@ -4,7 +4,6 @@ import { SLIDER_WIDTH } from '../constants';
 type TestCase = {
   incrementDecimalPlaces: number;
   inputAssetBalance: number | string;
-  assetBalanceDisplay: string;
   inputAssetNativePrice: number;
   niceIncrement: number | string;
   percentageToSwap: number;
@@ -20,7 +19,6 @@ const TEST_CASES: TestCase[] = [
   {
     incrementDecimalPlaces: 0,
     inputAssetBalance: 45.47364224817269,
-    assetBalanceDisplay: '45.47364225',
     inputAssetNativePrice: 0.9995363790000001,
     niceIncrement: '1',
     percentageToSwap: 0.5,
@@ -33,7 +31,6 @@ const TEST_CASES: TestCase[] = [
   {
     incrementDecimalPlaces: 2,
     inputAssetBalance: 100,
-    assetBalanceDisplay: '100.00',
     inputAssetNativePrice: 10,
     niceIncrement: '0.1',
     percentageToSwap: 0,
@@ -46,7 +43,6 @@ const TEST_CASES: TestCase[] = [
   {
     incrementDecimalPlaces: 2,
     inputAssetBalance: 100,
-    assetBalanceDisplay: '100.00',
     inputAssetNativePrice: 10,
     niceIncrement: '0.1',
     percentageToSwap: 1,
@@ -59,7 +55,6 @@ const TEST_CASES: TestCase[] = [
   {
     incrementDecimalPlaces: 2,
     inputAssetBalance: 123.456,
-    assetBalanceDisplay: '123.46',
     inputAssetNativePrice: 1,
     niceIncrement: '0.05',
     percentageToSwap: 0.25,
@@ -72,7 +67,6 @@ const TEST_CASES: TestCase[] = [
   {
     incrementDecimalPlaces: 0,
     inputAssetBalance: '1000',
-    assetBalanceDisplay: '1,000',
     inputAssetNativePrice: 0.5,
     niceIncrement: '100',
     percentageToSwap: 0.75,

--- a/src/__swaps__/screens/Swap/hooks/useEstimatedGasFee.ts
+++ b/src/__swaps__/screens/Swap/hooks/useEstimatedGasFee.ts
@@ -47,7 +47,7 @@ export function useEstimatedGasFee({
     const feeFormatted = formatUnits(safeBigInt(fee), nativeNetworkAsset.decimals).toString();
     const feeInUserCurrency = multiply(networkAssetPrice, feeFormatted);
 
-    return convertAmountToNativeDisplayWorklet(feeInUserCurrency, nativeCurrency);
+    return convertAmountToNativeDisplayWorklet(feeInUserCurrency, nativeCurrency, true);
   }, [gasLimit, gasSettings, nativeCurrency, nativeNetworkAsset?.decimals, nativeNetworkAsset?.price]);
 }
 

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { SharedValue, runOnJS, runOnUI, useAnimatedReaction, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useDebouncedCallback } from 'use-debounce';
-import { SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
+import { MAXIMUM_SIGNIFICANT_DECIMALS, SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
 import { RequestNewQuoteParams, inputKeys, inputMethods, inputValuesType } from '@/__swaps__/types/swap';
 import {
   addCommasToNumber,
@@ -144,18 +144,20 @@ export function useSwapInputsController({
       });
     }
 
-    const balance = internalSelectedInputAsset.value?.maxSwappableAmount || 0;
-    const isStablecoin = internalSelectedInputAsset.value?.type === 'stablecoin' ?? false;
+    if (percentageToSwap.value === 1) {
+      const formattedAmount = valueBasedDecimalFormatter({
+        amount: inputValues.value.inputAmount,
+        nativePrice: inputNativePrice.value,
+        roundingMode: 'up',
+        precisionAdjustment: -1,
+        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
+        stripSeparators: false,
+      });
 
-    return niceIncrementFormatter({
-      incrementDecimalPlaces: incrementDecimalPlaces.value,
-      inputAssetBalance: balance,
-      inputAssetNativePrice: inputNativePrice.value,
-      niceIncrement: niceIncrement.value,
-      percentageToSwap: percentageToSwap.value,
-      sliderXPosition: sliderXPosition.value,
-      isStablecoin,
-    });
+      return formattedAmount;
+    } else {
+      return addCommasToNumber(inputValues.value.inputAmount, '0');
+    }
   });
 
   const formattedInputNativeValue = useDerivedValue(() => {

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -36,7 +36,6 @@ import { supportedNativeCurrencies } from '@/references';
 
 function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetWithColors | null) {
   const initialBalance = Number(initialSelectedInputAsset?.maxSwappableAmount) || 0;
-  const assetBalanceDisplay = initialSelectedInputAsset?.balance.display ?? '';
   const initialNiceIncrement = findNiceIncrement(initialBalance);
   const initialDecimalPlaces = countDecimalPlaces(initialNiceIncrement);
   const isStablecoin = initialSelectedInputAsset?.type === 'stablecoin';
@@ -45,7 +44,6 @@ function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetW
     incrementDecimalPlaces: initialDecimalPlaces,
     inputAssetBalance: initialBalance,
     inputAssetNativePrice: initialSelectedInputAsset?.price?.value ?? 0,
-    assetBalanceDisplay,
     niceIncrement: initialNiceIncrement,
     percentageToSwap: 0.5,
     sliderXPosition: SLIDER_WIDTH / 2,
@@ -135,13 +133,10 @@ export function useSwapInputsController({
       return addCommasToNumber(inputValues.value.inputAmount, '0');
     }
 
-    const assetBalanceDisplay = internalSelectedInputAsset.value.balance.display ?? '';
-
     if (inputMethod.value === 'outputAmount') {
       return valueBasedDecimalFormatter({
         amount: inputValues.value.inputAmount,
         nativePrice: inputNativePrice.value,
-        assetBalanceDisplay,
         roundingMode: 'up',
         precisionAdjustment: -1,
         isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
@@ -156,7 +151,6 @@ export function useSwapInputsController({
       incrementDecimalPlaces: incrementDecimalPlaces.value,
       inputAssetBalance: balance,
       inputAssetNativePrice: inputNativePrice.value,
-      assetBalanceDisplay,
       niceIncrement: niceIncrement.value,
       percentageToSwap: percentageToSwap.value,
       sliderXPosition: sliderXPosition.value,
@@ -188,12 +182,9 @@ export function useSwapInputsController({
       return addCommasToNumber(inputValues.value.outputAmount, '0');
     }
 
-    const assetBalanceDisplay = internalSelectedOutputAsset.value.balance.display ?? '';
-
     return valueBasedDecimalFormatter({
       amount: inputValues.value.outputAmount,
       nativePrice: outputNativePrice.value,
-      assetBalanceDisplay,
       roundingMode: 'down',
       precisionAdjustment: -1,
       isStablecoin: internalSelectedOutputAsset.value?.type === 'stablecoin' ?? false,
@@ -730,13 +721,10 @@ export function useSwapInputsController({
               return;
             }
 
-            const assetBalanceDisplay = internalSelectedInputAsset.value.balance.display;
-
             const inputAmount = niceIncrementFormatter({
               incrementDecimalPlaces: incrementDecimalPlaces.value,
               inputAssetBalance: balance,
               inputAssetNativePrice: inputNativePrice.value,
-              assetBalanceDisplay,
               niceIncrement: niceIncrement.value,
               percentageToSwap: percentageToSwap.value,
               sliderXPosition: sliderXPosition.value,
@@ -896,13 +884,10 @@ export function useSwapInputsController({
             sliderXPosition.value = withSpring(SLIDER_WIDTH / 2, snappySpringConfig);
           }
 
-          const assetBalanceDisplay = internalSelectedInputAsset.value?.balance.display ?? '';
-
           const inputAmount = niceIncrementFormatter({
             incrementDecimalPlaces: incrementDecimalPlaces.value,
             inputAssetBalance: balance,
             inputAssetNativePrice: inputNativePrice.value,
-            assetBalanceDisplay,
             niceIncrement: niceIncrement.value,
             percentageToSwap: didInputAssetChange ? 0.5 : percentageToSwap.value,
             sliderXPosition: didInputAssetChange ? SLIDER_WIDTH / 2 : sliderXPosition.value,
@@ -925,14 +910,11 @@ export function useSwapInputsController({
           const inputNativePrice = internalSelectedInputAsset.value?.nativePrice || internalSelectedInputAsset.value?.price?.value || 0;
           const outputNativePrice = internalSelectedOutputAsset.value?.nativePrice || internalSelectedOutputAsset.value?.price?.value || 0;
 
-          const assetBalanceDisplay = internalSelectedInputAsset.value?.balance.display ?? '';
-
           const inputAmount = Number(
             valueBasedDecimalFormatter({
               amount:
                 inputNativePrice > 0 ? divWorklet(inputValues.value.inputNativeValue, inputNativePrice) : inputValues.value.outputAmount,
               nativePrice: inputNativePrice,
-              assetBalanceDisplay,
               roundingMode: 'up',
               precisionAdjustment: -1,
               isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -367,12 +367,7 @@ export function niceIncrementFormatter({
     });
   }
   if (percentageToSwap === 1) {
-    return valueBasedDecimalFormatter({
-      amount: inputAssetBalance,
-      nativePrice: inputAssetNativePrice,
-      roundingMode: 'up',
-      isStablecoin,
-    });
+    return inputAssetBalance;
   }
 
   const decimals = isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : incrementDecimalPlaces;

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -14,7 +14,7 @@ import {
 } from '@/__swaps__/screens/Swap/constants';
 import { chainNameFromChainId, chainNameFromChainIdWorklet } from '@/__swaps__/utils/chains';
 import { ChainId, ChainName } from '@/__swaps__/types/chains';
-import { isLowerCaseMatch, isLowerCaseMatchWorklet } from '@/__swaps__/utils/strings';
+import { isLowerCaseMatchWorklet } from '@/__swaps__/utils/strings';
 import { TokenColors } from '@/graphql/__generated__/metadata';
 import { RainbowConfig } from '@/model/remoteConfig';
 import { userAssetsStore } from '@/state/assets/userAssets';
@@ -246,21 +246,17 @@ export function precisionBasedOffMagnitude(amount: number | string, isStablecoin
 export function valueBasedDecimalFormatter({
   amount,
   nativePrice,
-  assetBalanceDisplay,
   roundingMode,
   precisionAdjustment,
   isStablecoin,
   stripSeparators = true,
-  isMaxAmount = false,
 }: {
   amount: number | string;
   nativePrice: number;
-  assetBalanceDisplay?: string;
   roundingMode?: 'up' | 'down';
   precisionAdjustment?: number;
   isStablecoin?: boolean;
   stripSeparators?: boolean;
-  isMaxAmount?: boolean;
 }): string {
   'worklet';
 
@@ -295,20 +291,6 @@ export function valueBasedDecimalFormatter({
   }
 
   const maximumFractionDigits = () => {
-    // if we're selling max amount, we want to match what's displayed on the balance badge
-    // let's base the decimal places based on that (capped at 6)
-    if (isMaxAmount && assetBalanceDisplay) {
-      const decimals = assetBalanceDisplay.split('.');
-      if (decimals.length > 1) {
-        const [, decimalPlacesFromDisplay] = decimals;
-        if (decimalPlacesFromDisplay.length < STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS && isStablecoin) {
-          return STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS;
-        }
-
-        return Math.min(decimalPlacesFromDisplay.length, MAXIMUM_SIGNIFICANT_DECIMALS);
-      }
-    }
-
     if (!isNaN(decimalPlaces)) {
       return isStablecoin && decimalPlaces < STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS
         ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS
@@ -335,7 +317,6 @@ export function niceIncrementFormatter({
   incrementDecimalPlaces,
   inputAssetBalance,
   inputAssetNativePrice,
-  assetBalanceDisplay,
   niceIncrement,
   percentageToSwap,
   sliderXPosition,
@@ -345,7 +326,6 @@ export function niceIncrementFormatter({
   incrementDecimalPlaces: number;
   inputAssetBalance: number | string;
   inputAssetNativePrice: number;
-  assetBalanceDisplay: string;
   niceIncrement: number | string;
   percentageToSwap: number;
   sliderXPosition: number;
@@ -360,7 +340,6 @@ export function niceIncrementFormatter({
     return valueBasedDecimalFormatter({
       nativePrice: inputAssetNativePrice,
       amount,
-      assetBalanceDisplay,
       roundingMode: 'up',
       precisionAdjustment: precisionBasedOffMagnitude(amount, isStablecoin),
       isStablecoin,
@@ -372,7 +351,6 @@ export function niceIncrementFormatter({
     return valueBasedDecimalFormatter({
       nativePrice: inputAssetNativePrice,
       amount,
-      assetBalanceDisplay,
       roundingMode: 'up',
       precisionAdjustment,
       isStablecoin,
@@ -383,7 +361,6 @@ export function niceIncrementFormatter({
     return valueBasedDecimalFormatter({
       nativePrice: inputAssetNativePrice,
       amount,
-      assetBalanceDisplay,
       roundingMode: 'up',
       precisionAdjustment: precisionBasedOffMagnitude(amount, isStablecoin),
       isStablecoin,
@@ -394,9 +371,7 @@ export function niceIncrementFormatter({
       amount: inputAssetBalance,
       nativePrice: inputAssetNativePrice,
       roundingMode: 'up',
-      assetBalanceDisplay,
       isStablecoin,
-      isMaxAmount: true,
     });
   }
 

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -260,9 +260,9 @@ export function valueBasedDecimalFormatter({
 }): string {
   'worklet';
 
-  function calculateDecimalPlaces(usdTokenPrice: number): number {
-    const fallbackDecimalPlaces = STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS;
-    if (usdTokenPrice <= 0) {
+  function calculateDecimalPlaces(): number {
+    const fallbackDecimalPlaces = MAXIMUM_SIGNIFICANT_DECIMALS;
+    if (nativePrice === 0) {
       return fallbackDecimalPlaces;
     }
     const unitsForOneCent = 0.01 / nativePrice;
@@ -275,7 +275,7 @@ export function valueBasedDecimalFormatter({
     );
   }
 
-  const decimalPlaces = calculateDecimalPlaces(nativePrice);
+  const decimalPlaces = calculateDecimalPlaces();
 
   let roundedAmount;
   const factor = Math.pow(10, decimalPlaces) || 1; // Prevent division by 0
@@ -290,25 +290,12 @@ export function valueBasedDecimalFormatter({
     roundedAmount = divWorklet(roundWorklet(mulWorklet(amount, factor)), factor);
   }
 
-  const maximumFractionDigits = () => {
-    if (!isNaN(decimalPlaces)) {
-      return isStablecoin && decimalPlaces < STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS
-        ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS
-        : decimalPlaces;
-    }
-
-    // default to 6 precision if we have no calculation
-    return MAXIMUM_SIGNIFICANT_DECIMALS;
-  };
-
   // Format the number to add separators and trim trailing zeros
   const numberFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
-    maximumFractionDigits: maximumFractionDigits(),
-    useGrouping: true,
+    maximumFractionDigits: decimalPlaces,
+    useGrouping: !stripSeparators,
   });
-
-  if (stripSeparators) return stripCommas(numberFormatter.format(Number(roundedAmount)));
 
   return numberFormatter.format(Number(roundedAmount));
 }


### PR DESCRIPTION
NOTE:
Please see the comments inline of the code to better map out where each of the fixes below correspond in the code.

NOTE: will attach screen recordings / screenshots in comments below so as not to blow up this description section.

Fixes in this branch:
1. typing in an input amount that causes insufficient funds and then deleting the input amount to 0 still displays Insufficient Funds
2. relying on the quote as a source of truth for the sell amount can cause the button to flicker because the quote can still technically have a value / not have an error, even though it is now out of date
3. previously: the `sellAmount` calculation was returning two different orders of magnitude in the response which was incorrect. e.g, when there's a quote error, it would return the input amount (like "1.234") but if there's a quote, it would return the raw sell amount (like "12340") which we were using later for comparisons against another raw amount
4. Fixes APP-1601: gas button can display a fee of $0.00 instead of proper handling of amounts below $0.01
5. updated logic for "Enter Amount" label (please review)
6. updated the ordering to also reduce flickering of the button

WHAT STILL NEEDS TO BE FIXED:
1. (IN PROGRESS) incorporating Ben's final max swappable input changes: currently max input can incorrectly show insufficient funds; we will need the `maxSwappableAmount` to stop being updated on every gas update
2. (IN PROGRESS FROM GREGS) "tap to swap" button no longer has haptic feedback
3. (IN PROGRESS FROM GREGS) neither the review button nor the confirm swap button have press states (they should scale down on press)
