### PR TITLE
fix android padding calc

### DIFF
--- a/src/__swaps__/screens/Swap/components/SliderAndKeyboard.tsx
+++ b/src/__swaps__/screens/Swap/components/SliderAndKeyboard.tsx
@@ -7,10 +7,18 @@ import { Box } from '@/design-system';
 import { SwapNumberPad } from '@/__swaps__/screens/Swap/components/SwapNumberPad';
 import { SwapSlider } from '@/__swaps__/screens/Swap/components/SwapSlider';
 import { IS_ANDROID } from '@/env';
-import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
+import { getSoftMenuBarHeight, isSoftMenuBarEnabled } from 'react-native-extra-dimensions-android';
 import { safeAreaInsetValues } from '@/utils';
 
-const BOTTOM_OFFSET = IS_ANDROID ? getSoftMenuBarHeight() - 24 : safeAreaInsetValues.bottom + 16;
+const getAndroidPadding = () => {
+  if (isSoftMenuBarEnabled()) {
+    return getSoftMenuBarHeight() - 24;
+  } else {
+    return safeAreaInsetValues.bottom + 34;
+  }
+};
+
+const BOTTOM_OFFSET = IS_ANDROID ? getAndroidPadding() : safeAreaInsetValues.bottom + 16;
 const HEIGHT_OF_BOTTOM_TAB = 64;
 
 export function SliderAndKeyboard() {


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
We were asumming all android phones have the softMenu enabled and that's not the case for my Pixel 4.
I've added a check and adjusted the padding accordingly.


## Screen recordings / screenshots
BEFORE
<img width="337" alt="Screenshot 2024-06-20 at 5 22 19 PM" src="https://github.com/rainbow-me/rainbow/assets/1247834/4d95c33e-5916-4ca6-a26c-023a04946e87">


AFTER
<img width="362" alt="Screenshot 2024-06-20 at 5 19 27 PM" src="https://github.com/rainbow-me/rainbow/assets/1247834/6dbf5c55-e93e-4cf2-b93c-c7f2da1847ac">



## What to test

