### PR TITLE
[e2e] rerun only failed tests

### DIFF
--- a/scripts/run-retry-tests.sh
+++ b/scripts/run-retry-tests.sh
@@ -2,16 +2,38 @@
 
 max_retries="$1"
 count=0
+failed_tests=""
+
+run_tests() {
+    if [ -z "$failed_tests" ]; then
+        ./node_modules/.bin/detox test -c ios.sim.release --maxWorkers 2 -- --forceExit --bail 1
+    else
+        ./node_modules/.bin/detox test -c ios.sim.release --maxWorkers 2 -f "$failed_tests" -- --forceExit --bail 1
+    fi
+}
 
 until (( count >= max_retries ))
 do
-  ./node_modules/.bin/detox test -c ios.sim.release --maxWorkers 2 -- --forceExit --bail 1
-  ret_val=$?
-  if [ $ret_val -eq 0 ]; then
-    exit 0
-  fi
-  ((count++))
-  echo "Test failed, attempt $count/$max_retries..."
+    if [ $count -eq 0 ]; then
+        run_tests | tee output.log
+    else
+        run_tests
+    fi
+    
+    ret_val=$?
+    if [ $ret_val -eq 0 ]; then
+        echo "All tests passed."
+        exit 0
+    fi
+    
+    if [ $count -eq 0 ]; then
+        failed_tests=$(grep -oP '(?<=at )[^ ]+\.spec\.ts(?=:)' output.log | sort -u | tr '\n' '|' | sed 's/|$//')
+        rm output.log
+    fi
+    
+    ((count++))
+    echo "Test failed, attempt $count/$max_retries..."
+    echo "Rerunning failed tests: $failed_tests"
 done
 
 echo "Tests failed after $max_retries attempts."


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- we were previously rerunning the whole suite if a test failed
- this runs all tests then keeps a note of the failed ones
- it then reruns the failed ones up to the amount of retries set.

