### PR TITLE
Use graphql ens key everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ coverage-ts
 src/languages/types-generated.d.ts
 __generated__/
 
+# graphql codegen
+src/graphql/config.js
+
 # Test Coverage
 coverage
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "android:load-apk": "adb install android/app/build/outputs/apk/release/app-release.apk",
     "android-all:load-apk": "yarn adb-all install android/app/build/outputs/apk/release/app-release.apk",
     "graphql-codegen:install": "yarn install --cwd src/graphql",
+    "graphql-prepare": "./scripts/graph-ens-key.sh",
     "graphql-codegen": "cd src/graphql && yarn codegen",
     "check-lockfile": "./scripts/check-lockfile.sh",
     "clean:android": "yarn uninstall:android && rm -rf android/build && yarn gradle clean && rm -rf ~/.gradle/caches",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "android-all:load-apk": "yarn adb-all install android/app/build/outputs/apk/release/app-release.apk",
     "graphql-codegen:install": "yarn install --cwd src/graphql",
     "graphql-prepare": "./scripts/graph-ens-key.sh",
-    "graphql-codegen": "cd src/graphql && yarn codegen",
+    "graphql-codegen": "yarn graphql-prepare && cd src/graphql && yarn codegen",
     "check-lockfile": "./scripts/check-lockfile.sh",
     "clean:android": "yarn uninstall:android && rm -rf android/build && yarn gradle clean && rm -rf ~/.gradle/caches",
     "clean:ios": "rm -rf ios/build && cd ios && pod deintegrate",

--- a/scripts/graph-ens-key.sh
+++ b/scripts/graph-ens-key.sh
@@ -1,0 +1,4 @@
+source .env
+GRAPHQL_CONFIG_FILE="src/graphql/config.js"
+
+sed -i '' "s|url: 'https://api.thegraph.com/subgraphs/name/ensdomains/ens',|url: 'https://gateway-arbitrum.network.thegraph.com/api/$GRAPH_ENS_API_KEY/subgraphs/id/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH',|" "$GRAPHQL_CONFIG_FILE"

--- a/src/graphql/utils/getFetchRequester.ts
+++ b/src/graphql/utils/getFetchRequester.ts
@@ -2,7 +2,7 @@ import { rainbowFetch, RainbowFetchRequestOpts } from '@/rainbow-fetch';
 import { DocumentNode } from 'graphql';
 import { resolveRequestDocument } from 'graphql-request';
 import { buildGetQueryParams } from '@/graphql/utils/buildGetQueryParams';
-import { ARC_GRAPHQL_API_KEY, METADATA_GRAPHQL_API_KEY, GRAPH_ENS_API_KEY } from 'react-native-dotenv';
+import { ARC_GRAPHQL_API_KEY, METADATA_GRAPHQL_API_KEY } from 'react-native-dotenv';
 
 const allowedOperations = ['mutation', 'query'];
 
@@ -52,18 +52,7 @@ const additionalConfig: {
   },
 };
 
-const urlOverrides: {
-  [__name: string]: string;
-} = {
-  ens: `https://gateway-arbitrum.network.thegraph.com/api/${GRAPH_ENS_API_KEY}/subgraphs/id/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH`,
-};
-
 export function getFetchRequester(config: Config) {
-  // Because the API KEY is part of the URL for the graph hosted service, we need to replace it here
-  if (urlOverrides[config.__name]) {
-    config.schema.url = urlOverrides[config.__name];
-  }
-
   const { url, method = 'POST' } = config.schema;
 
   return async function requester<TResponse = unknown, TVariables = Record<string, unknown>>(


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Added a script to override the URL of the new ENS graph and use our API key.
This will work on CI and locally and will prevent us from getting rate limited for using the public url.
Also removed the old url override since the url is the correct one at the config level

## Screen recordings / screenshots


## What to test

