### PR TITLE
Fix swap button presses, adjust button state logic

### DIFF
--- a/src/__swaps__/screens/Swap/components/SwapActionButton.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapActionButton.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
 import { StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-native';
-import Animated, { DerivedValue, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
+import Animated, { DerivedValue, useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated';
 
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import { AnimatedText, Box, Column, Columns, globalColors, useColorMode, useForegroundColor } from '@/design-system';
 import { GestureHandlerV1Button } from './GestureHandlerV1Button';
+import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 
 export const SwapActionButton = ({
   asset,
@@ -84,7 +85,7 @@ export const SwapActionButton = ({
       },
       shadowOpacity: isDarkMode ? 0.2 : small ? 0.2 : 0.36,
       shadowRadius: isDarkMode ? 26 : small ? 9 : 15,
-      opacity: opacity?.value ?? (disabled?.value ? 0.6 : 1),
+      opacity: withTiming(opacity?.value ?? (disabled?.value ? 0.6 : 1), TIMING_CONFIGS.slowerFadeConfig),
     };
   });
 

--- a/src/__swaps__/screens/Swap/components/SwapActionButton.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapActionButton.tsx
@@ -1,14 +1,12 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { StyleProp, StyleSheet, TextStyle, ViewProps, ViewStyle } from 'react-native';
-import Animated, { DerivedValue, useAnimatedProps, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
+import { StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-native';
+import Animated, { DerivedValue, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
 
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import { AnimatedText, Box, Column, Columns, globalColors, useColorMode, useForegroundColor } from '@/design-system';
 import { GestureHandlerV1Button } from './GestureHandlerV1Button';
-
-const AnimatedGestureHandlerV1Button = Animated.createAnimatedComponent(GestureHandlerV1Button);
 
 export const SwapActionButton = ({
   asset,
@@ -90,6 +88,12 @@ export const SwapActionButton = ({
     };
   });
 
+  const disabledWrapper = useAnimatedStyle(() => {
+    return {
+      pointerEvents: disabled && disabled?.value ? 'none' : 'auto',
+    };
+  });
+
   const iconValue = useDerivedValue(() => {
     if (typeof icon === 'string') return icon;
     return icon?.value || '';
@@ -104,53 +108,47 @@ export const SwapActionButton = ({
     return rightIcon;
   });
 
-  const buttonAnimatedProps = useAnimatedProps(() => {
-    return {
-      pointerEvents: (disabled?.value ? 'none' : 'box-only') as ViewProps['pointerEvents'],
-      disableButtonPressWrapper: disabled?.value,
-      scaleTo: scaleTo || (hugContent ? undefined : 0.925),
-    };
-  });
-
   return (
-    <AnimatedGestureHandlerV1Button
-      animatedProps={buttonAnimatedProps}
-      onPressWorklet={onPressWorklet}
-      onPressJS={onPressJS}
-      style={[hugContent && feedActionButtonStyles.buttonWrapper, style]}
-    >
-      <Box
-        as={Animated.View}
-        paddingHorizontal={{ custom: small ? 14 : 20 - (outline ? 2 : 0) }}
-        paddingLeft={small && icon ? '10px' : undefined}
-        paddingRight={small && rightIcon ? '10px' : undefined}
-        style={[feedActionButtonStyles.button, outline && feedActionButtonStyles.outlineButton, buttonWrapperStyles]}
+    <Animated.View style={disabledWrapper}>
+      <GestureHandlerV1Button
+        onPressWorklet={onPressWorklet}
+        onPressJS={onPressJS}
+        scaleTo={scaleTo || (hugContent ? undefined : 0.925)}
+        style={[hugContent && feedActionButtonStyles.buttonWrapper, style]}
       >
-        <Columns alignHorizontal="center" alignVertical="center" space="6px">
-          {icon && (
-            <Column width="content">
-              <AnimatedText align="center" size={small ? '15pt' : '17pt'} style={[iconStyle, textStyles]} weight="heavy">
-                {iconValue}
-              </AnimatedText>
-            </Column>
-          )}
-          {typeof label !== 'undefined' && (
-            <Column width="content">
-              <AnimatedText align="center" style={textStyles} numberOfLines={1} size={small ? '17pt' : '20pt'} weight="heavy">
-                {labelValue}
-              </AnimatedText>
-            </Column>
-          )}
-          {rightIcon && (
-            <Column width="content">
-              <AnimatedText align="center" style={[textStyles, secondaryTextStyles]} size={small ? '15pt' : '17pt'} weight="bold">
-                {rightIconValue}
-              </AnimatedText>
-            </Column>
-          )}
-        </Columns>
-      </Box>
-    </AnimatedGestureHandlerV1Button>
+        <Box
+          as={Animated.View}
+          paddingHorizontal={{ custom: small ? 14 : 20 - (outline ? 2 : 0) }}
+          paddingLeft={small && icon ? '10px' : undefined}
+          paddingRight={small && rightIcon ? '10px' : undefined}
+          style={[feedActionButtonStyles.button, outline && feedActionButtonStyles.outlineButton, buttonWrapperStyles]}
+        >
+          <Columns alignHorizontal="center" alignVertical="center" space="6px">
+            {icon && (
+              <Column width="content">
+                <AnimatedText align="center" size={small ? '15pt' : '17pt'} style={[iconStyle, textStyles]} weight="heavy">
+                  {iconValue}
+                </AnimatedText>
+              </Column>
+            )}
+            {typeof label !== 'undefined' && (
+              <Column width="content">
+                <AnimatedText align="center" style={textStyles} numberOfLines={1} size={small ? '17pt' : '20pt'} weight="heavy">
+                  {labelValue}
+                </AnimatedText>
+              </Column>
+            )}
+            {rightIcon && (
+              <Column width="content">
+                <AnimatedText align="center" style={[textStyles, secondaryTextStyles]} size={small ? '15pt' : '17pt'} weight="bold">
+                  {rightIconValue}
+                </AnimatedText>
+              </Column>
+            )}
+          </Columns>
+        </Box>
+      </GestureHandlerV1Button>
+    </Animated.View>
   );
 };
 

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { SharedValue, runOnJS, runOnUI, useAnimatedReaction, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useDebouncedCallback } from 'use-debounce';
-import { MAXIMUM_SIGNIFICANT_DECIMALS, SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
+import { SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
 import { RequestNewQuoteParams, inputKeys, inputMethods, inputValuesType } from '@/__swaps__/types/swap';
 import {
   addCommasToNumber,
@@ -103,7 +103,7 @@ export function useSwapInputsController({
     outputAmount: 0,
     outputNativeValue: 0,
   });
-  const inputMethod = useSharedValue<inputMethods>('slider');
+  const inputMethod = useSharedValue<inputMethods>(initialSelectedInputAsset ? 'inputAmount' : 'slider');
 
   const percentageToSwap = useDerivedValue(() => {
     return Math.round(clamp((sliderXPosition.value - SCRUBBER_WIDTH / SLIDER_WIDTH) / SLIDER_WIDTH, 0, 1) * 100) / 100;

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -61,6 +61,7 @@ const review = i18n.t(i18n.l.swap.actions.review);
 const fetchingPrices = i18n.t(i18n.l.swap.actions.fetching_prices);
 const selectToken = i18n.t(i18n.l.swap.actions.select_token);
 const insufficientFunds = i18n.t(i18n.l.swap.actions.insufficient_funds);
+const quoteError = i18n.t(i18n.l.swap.actions.quote_error);
 
 interface SwapContextType {
   isFetching: SharedValue<boolean>;
@@ -659,7 +660,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     }
 
     if (isQuoteError) {
-      return { icon: '􀕹', label: review, disabled: true };
+      return { icon: isReviewSheetOpen ? undefined : '􀕹', label: isReviewSheetOpen ? quoteError : review, disabled: true };
     }
 
     if (!hasEnoughFundsForGas.value) {

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -655,7 +655,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     const isReviewSheetOpen = configProgress.value === NavigationSteps.SHOW_REVIEW;
 
     if ((isFetching.value || isLoadingGas) && !isQuoteError) {
-      return { label: fetchingPrices, disabled: isReviewSheetOpen && isFetching.value };
+      return { label: fetchingPrices, disabled: (isReviewSheetOpen && isFetching.value) || !quote.value };
     }
 
     if (isQuoteError) {

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -51,6 +51,7 @@ import { Address } from 'viem';
 import { getGasSettingsBySpeed, getSelectedGas, getSelectedGasSpeed } from '../hooks/useSelectedGas';
 import { useSwapOutputQuotesDisabled } from '../hooks/useSwapOutputQuotesDisabled';
 import { SyncGasStateToSharedValues, SyncQuoteSharedValuesToState } from './SyncSwapStateAndSharedValues';
+import { IS_IOS } from '@/env';
 
 const swapping = i18n.t(i18n.l.swap.actions.swapping);
 const tapToSwap = i18n.t(i18n.l.swap.actions.tap_to_swap);
@@ -72,7 +73,7 @@ interface SwapContextType {
   // TODO: Combine navigation progress steps into a single shared value
   inputProgress: SharedValue<number>;
   outputProgress: SharedValue<number>;
-  configProgress: SharedValue<number>;
+  configProgress: SharedValue<NavigationSteps>;
 
   sliderXPosition: SharedValue<number>;
   sliderPressProgress: SharedValue<number>;
@@ -153,7 +154,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
   const outputProgress = useSharedValue(
     initialSelectedOutputAsset ? NavigationSteps.INPUT_ELEMENT_FOCUSED : NavigationSteps.TOKEN_LIST_FOCUSED
   );
-  const configProgress = useSharedValue(NavigationSteps.INPUT_ELEMENT_FOCUSED);
+  const configProgress = useSharedValue<NavigationSteps>(NavigationSteps.INPUT_ELEMENT_FOCUSED);
 
   const SwapSettings = useSwapSettings({
     inputAsset: internalSelectedInputAsset,
@@ -181,7 +182,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     parameters: Omit<RapSwapActionParameters<typeof type>, 'gasParams' | 'gasFeeParamsBySpeed' | 'selectedGasFee'>;
   }) => {
     try {
-      const NotificationManager = ios ? NativeModules.NotificationManager : null;
+      const NotificationManager = IS_IOS ? NativeModules.NotificationManager : null;
       NotificationManager?.postNotification('rapInProgress');
 
       const network = ethereumUtils.getNetworkFromChainId(parameters.chainId);
@@ -613,10 +614,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       return { label: swapping, disabled: true };
     }
 
-    if (configProgress.value === NavigationSteps.SHOW_REVIEW) {
-      return { icon: '􀎽', label: tapToSwap, disabled: false };
-    }
-
     if (configProgress.value === NavigationSteps.SHOW_GAS) {
       return { icon: '􀆅', label: save, disabled: false };
     }
@@ -655,16 +652,22 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
 
     const isQuoteError = quote.value && 'error' in quote.value;
     const isLoadingGas = !isQuoteError && hasEnoughFundsForGas.value === undefined;
-    if (isFetching.value || isLoadingGas) {
-      return { label: fetchingPrices, disabled: true, opacity: 1 };
+    const isReviewSheetOpen = configProgress.value === NavigationSteps.SHOW_REVIEW;
+
+    if ((isFetching.value || isLoadingGas) && !isQuoteError) {
+      return { label: fetchingPrices, disabled: isReviewSheetOpen && isFetching.value };
+    }
+
+    if (isQuoteError) {
+      return { icon: '􀕹', label: review, disabled: true };
     }
 
     if (!hasEnoughFundsForGas.value) {
       return { label: insufficientFunds, disabled: true };
     }
 
-    if (isQuoteError) {
-      return { icon: '􀕹', label: review, disabled: true };
+    if (isReviewSheetOpen) {
+      return { icon: '􀎽', label: tapToSwap, disabled: false };
     }
 
     return { icon: '􀕹', label: review, disabled: false };

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1942,7 +1942,8 @@
         "fetching_prices": "Fetching",
         "swapping": "Swapping",
         "select_token": "Select Token",
-        "insufficient_funds": "Insufficient Funds"
+        "insufficient_funds": "Insufficient Funds",
+        "quote_error": "Quote Error"
       },
       "aggregators": {
         "rainbow": "Rainbow"


### PR DESCRIPTION
Fixes APP-1614

## What changed (plus any additional context for devs)
- Fixes the missing swap button press animations and haptic feedback
- Adjusts the review button state logic to allow entering the review sheet when `isFetching.value === true`, except for the first quote fetch
  - When the review sheet is open, if a new quote is being fetched, the `tapToSwap` button now becomes disabled until the new quote is applied
- Moves the `tapToSwap` button state condition further down so that if assets are flipped while in the review sheet, or gas conditions change, the `tapToSwap` button can become disabled

Also:
- Switches the initial `inputMethod` to `inputAmount` if an input asset is selected on mount, which fixes a bug that was causing the input values to change when the swap screen was first opened (very likely due to the animated reaction that manages the input values hitting the `inputMethod === 'slider'` logic path)

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbow/assets/7061887/833720a3-954e-4193-9cc0-8fda1c457da2

## What to test

