### PR TITLE
Remove input value typeof checks

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -32,7 +32,6 @@ import { queryClient } from '@/react-query';
 import { useAccountSettings } from '@/hooks';
 import { analyticsV2 } from '@/analytics';
 import { divWorklet, equalWorklet, greaterThanWorklet, isNumberStringWorklet, mulWorklet } from '@/__swaps__/safe-math/SafeMath';
-import { supportedNativeCurrencies } from '@/references';
 
 function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetWithColors | null) {
   const initialBalance = Number(initialSelectedInputAsset?.maxSwappableAmount) || 0;
@@ -51,17 +50,7 @@ function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetW
     isStablecoin,
   });
 
-  const nativeCurrency = store.getState().settings.nativeCurrency;
-  const decimals = Math.min(6, supportedNativeCurrencies[nativeCurrency].decimals);
-
-  const initialInputNativeValue = Number(mulWorklet(initialInputAmount, initialSelectedInputAsset?.price?.value ?? 0)).toLocaleString(
-    'en-US',
-    {
-      useGrouping: false,
-      minimumFractionDigits: nativeCurrency === 'ETH' ? undefined : decimals,
-      maximumFractionDigits: decimals,
-    }
-  );
+  const initialInputNativeValue = mulWorklet(initialInputAmount, initialSelectedInputAsset?.price?.value ?? 0);
 
   return {
     initialInputAmount,

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -103,7 +103,7 @@ export function useSwapInputsController({
     outputAmount: 0,
     outputNativeValue: 0,
   });
-  const inputMethod = useSharedValue<inputMethods>(initialSelectedInputAsset ? 'inputAmount' : 'slider');
+  const inputMethod = useSharedValue<inputMethods>('slider');
 
   const maxSwappableAmount = useDerivedValue(() => internalSelectedInputAsset.value?.maxSwappableAmount);
 

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -131,7 +131,7 @@ export function useSwapInputsController({
       return '0';
     }
 
-    if (inputMethod.value === 'inputAmount' || typeof inputValues.value.inputAmount === 'string') {
+    if (inputMethod.value === 'inputAmount') {
       return addCommasToNumber(inputValues.value.inputAmount, '0');
     }
 
@@ -182,7 +182,7 @@ export function useSwapInputsController({
       return '0';
     }
 
-    if (inputMethod.value === 'outputAmount' || typeof inputValues.value.outputAmount === 'string') {
+    if (inputMethod.value === 'outputAmount') {
       return addCommasToNumber(inputValues.value.outputAmount, '0');
     }
 
@@ -665,7 +665,7 @@ export function useSwapInputsController({
   useAnimatedReaction(
     () => ({ focusedInput: focusedInput.value }),
     (current, previous) => {
-      if (previous && current !== previous && typeof inputValues.value[previous.focusedInput] === 'string') {
+      if (previous && current !== previous) {
         const typedValue = inputValues.value[previous.focusedInput].toString();
         if (equalWorklet(typedValue, 0)) {
           inputValues.modify(values => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
1. Removed all places where we relied on `typeof` for the input value amounts. This was making things brittle / difficult to maintain / easy to get into scenarios you did not intend.
2. Updated the initial values for native currency to not need to worry about formatting since we have formattedNativeInput to handle that
3. Removed the conditional for the default input method to have it back to be slider based

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbow/assets/1285228/82b3f2df-9091-4bc2-a224-abeefa44cabc



