### PR TITLE
Fix maxSwappableAmount bugs, remaining string type check bugs

### DIFF
--- a/src/__swaps__/screens/Swap/components/SwapNumberPad.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapNumberPad.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Animated, {
   Easing,
+  SharedValue,
   interpolateColor,
   useAnimatedGestureHandler,
   useAnimatedReaction,
@@ -28,8 +29,23 @@ import { ButtonPressAnimation } from '@/components/animations';
 import { colors } from '@/styles';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { IS_IOS } from '@/env';
+import { inputKeys } from '@/__swaps__/types/swap';
 
 type numberPadCharacter = number | 'backspace' | '.';
+
+const getFormattedInputKey = (inputKey: inputKeys) => {
+  'worklet';
+  switch (inputKey) {
+    case 'inputAmount':
+      return 'formattedInputAmount';
+    case 'inputNativeValue':
+      return 'formattedInputNativeValue';
+    case 'outputAmount':
+      return 'formattedOutputAmount';
+    case 'outputNativeValue':
+      return 'formattedOutputNativeValue';
+  }
+};
 
 export const SwapNumberPad = () => {
   const { isDarkMode } = useColorMode();
@@ -47,7 +63,8 @@ export const SwapNumberPad = () => {
     SwapInputController.quoteFetchingInterval.stop();
 
     const inputKey = focusedInput.value;
-    const currentValue = SwapInputController.inputValues.value[inputKey].toString();
+    const currentValue = stripCommas(SwapInputController[getFormattedInputKey(inputKey)].value);
+
     const newValue = currentValue === '0' ? `${number}` : `${currentValue}${number}`;
 
     // For a uint256, the maximum value is:
@@ -64,18 +81,6 @@ export const SwapNumberPad = () => {
 
     if (SwapInputController.inputMethod.value !== inputKey) {
       SwapInputController.inputMethod.value = inputKey;
-
-      if (typeof SwapInputController.inputValues.value[inputKey] === 'number') {
-        SwapInputController.inputValues.modify(value => {
-          return {
-            ...value,
-            [inputKey]:
-              inputKey === 'inputAmount'
-                ? stripCommas(SwapInputController.formattedInputAmount.value)
-                : stripCommas(SwapInputController.formattedOutputAmount.value),
-          };
-        });
-      }
     }
 
     SwapInputController.inputValues.modify(value => {
@@ -89,20 +94,11 @@ export const SwapNumberPad = () => {
   const addDecimalPoint = () => {
     'worklet';
     const inputKey = focusedInput.value;
-    const currentValue = SwapInputController.inputValues.value[inputKey].toString();
+    const currentValue = stripCommas(SwapInputController[getFormattedInputKey(inputKey)].value);
+
     if (!currentValue.includes('.')) {
       if (SwapInputController.inputMethod.value !== inputKey) {
         SwapInputController.inputMethod.value = inputKey;
-
-        SwapInputController.inputValues.modify(values => {
-          return {
-            ...values,
-            [inputKey]:
-              inputKey === 'inputAmount'
-                ? stripCommas(SwapInputController.formattedInputAmount.value)
-                : stripCommas(SwapInputController.formattedOutputAmount.value),
-          };
-        });
       }
 
       const newValue = `${currentValue}.`;
@@ -127,19 +123,9 @@ export const SwapNumberPad = () => {
 
     if (SwapInputController.inputMethod.value !== inputKey) {
       SwapInputController.inputMethod.value = inputKey;
-
-      SwapInputController.inputValues.modify(values => {
-        return {
-          ...values,
-          [inputKey]:
-            inputKey === 'inputAmount'
-              ? stripCommas(SwapInputController.formattedInputAmount.value)
-              : stripCommas(SwapInputController.formattedOutputAmount.value),
-        };
-      });
     }
 
-    const currentValue = SwapInputController.inputValues.value[inputKey].toString();
+    const currentValue = stripCommas(SwapInputController[getFormattedInputKey(inputKey)].value);
     // Handle deletion, ensuring a placeholder zero remains if the entire number is deleted
     const newValue = currentValue.length > 1 ? currentValue.slice(0, -1) : 0;
 
@@ -221,7 +207,7 @@ const NumberPadKey = ({
   transparent,
 }: {
   char: numberPadCharacter;
-  longPressTimer?: Animated.SharedValue<number>;
+  longPressTimer?: SharedValue<number>;
   onPressWorklet: (number?: number) => void;
   small?: boolean;
   transparent?: boolean;

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -419,23 +419,23 @@ export const SwapSlider = ({
                   </Inline>
                 </Inline>
                 <Column width="content">
-                <GestureHandlerV1Button
+                  <GestureHandlerV1Button
                     onPressWorklet={() => {
                       'worklet';
                       SwapInputController.inputMethod.value = 'slider';
-                      
+
                       const currentInputValue = SwapInputController.inputValues.value.inputAmount;
                       const maxSwappableAmount = internalSelectedInputAsset.value?.maxSwappableAmount;
-                      
+
                       const isAlreadyMax = maxSwappableAmount ? equalWorklet(currentInputValue, maxSwappableAmount) : false;
                       const exceedsMax = maxSwappableAmount ? greaterThanWorklet(currentInputValue, maxSwappableAmount) : false;
-                      
+
                       if (isAlreadyMax) {
                         runOnJS(triggerHapticFeedback)('impactMedium');
                       } else {
                         SwapInputController.quoteFetchingInterval.stop();
                         if (exceedsMax) sliderXPosition.value = width * 0.999;
-                        
+
                         sliderXPosition.value = withSpring(width, SPRING_CONFIGS.snappySpringConfig, isFinished => {
                           if (isFinished) {
                             runOnJS(onChangeWrapper)(1);

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -175,7 +175,7 @@ export function useAnimatedSwapStyles({
           : opacityWorklet(outputAssetColor.value, 0.06),
         SPRING_CONFIGS.springConfig
       ),
-      borderRadius: withSpring(isReviewingOrConfiguringGas ? (IS_ANDROID ? 40 : 40) : 0, SPRING_CONFIGS.springConfig),
+      borderRadius: withSpring(isReviewingOrConfiguringGas ? 40 : 0, SPRING_CONFIGS.springConfig),
       bottom: withSpring(isReviewingOrConfiguringGas ? Math.max(safeAreaInsetValues.bottom, 28) : -2, SPRING_CONFIGS.springConfig),
       height: withSpring(heightForCurrentSheet, SPRING_CONFIGS.springConfig),
       left: withSpring(isReviewingOrConfiguringGas ? 12 : -2, SPRING_CONFIGS.springConfig),

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -133,7 +133,7 @@ export function useSwapInputsController({
       });
     }
 
-    if (inputValues.value.inputAmount === internalSelectedInputAsset.value.maxSwappableAmount) {
+    if (equalWorklet(inputValues.value.inputAmount, internalSelectedInputAsset.value.maxSwappableAmount)) {
       const formattedAmount = valueBasedDecimalFormatter({
         amount: inputValues.value.inputAmount,
         isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,

--- a/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx
+++ b/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx
@@ -25,7 +25,7 @@ import { useSelectedGas } from '../hooks/useSelectedGas';
 import { useSwapEstimatedGasLimit } from '../hooks/useSwapEstimatedGasLimit';
 import { useSwapContext } from './swap-provider';
 
-const BUFFER_RATIO = 0.25;
+const BUFFER_RATIO = 0.5;
 
 type InternalSyncedSwapState = {
   assetToBuy: ExtendedAnimatedAssetWithColors | undefined;
@@ -111,14 +111,15 @@ export function SyncGasStateToSharedValues() {
         gasFeeRange.value = null;
       } else if (currBuffer && (currBuffer !== prevBuffer || currInputAsset?.uniqueId !== prevInputAsset?.uniqueId)) {
         // update maxSwappableAmount when gas fee range is set and there is a change to input asset or gas fee range
-        internalSelectedInputAsset.modify(asset => {
-          'worklet';
-          if (!asset || !asset.isNativeAsset) return asset;
-          return {
-            ...asset,
-            maxSwappableAmount: subWorklet(asset.balance.amount, currBuffer),
-          };
-        });
+        if (currInputAsset?.isNativeAsset) {
+          internalSelectedInputAsset.modify(asset => {
+            if (!asset) return asset;
+            return {
+              ...asset,
+              maxSwappableAmount: subWorklet(asset.balance.amount, currBuffer),
+            };
+          });
+        }
       }
     }
   );

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -253,7 +253,7 @@ export function valueBasedDecimalFormatter({
 }: {
   amount: number | string;
   nativePrice: number;
-  roundingMode?: 'up' | 'down';
+  roundingMode?: 'up' | 'down' | 'none';
   precisionAdjustment?: number;
   isStablecoin?: boolean;
   stripSeparators?: boolean;
@@ -285,6 +285,8 @@ export function valueBasedDecimalFormatter({
     roundedAmount = divWorklet(ceilWorklet(mulWorklet(amount, factor)), factor);
   } else if (roundingMode === 'down') {
     roundedAmount = divWorklet(floorWorklet(mulWorklet(amount, factor)), factor);
+  } else if (roundingMode === 'none') {
+    roundedAmount = toFixedWorklet(amount, decimalPlaces);
   } else {
     // Default to normal rounding if no rounding mode is specified
     roundedAmount = divWorklet(roundWorklet(mulWorklet(amount, factor)), factor);
@@ -654,13 +656,14 @@ export const parseAssetAndExtend = ({
   });
 
   const uniqueId = getStandardizedUniqueIdWorklet({ address: asset.address, chainId: asset.chainId });
+  const balance = insertUserAssetBalance ? userAssetsStore.getState().getUserAsset(uniqueId)?.balance || asset.balance : asset.balance;
 
   return {
     ...asset,
     ...colors,
-    maxSwappableAmount: asset.balance.amount,
+    maxSwappableAmount: balance.amount,
     nativePrice: asset.price?.value,
-    balance: insertUserAssetBalance ? userAssetsStore.getState().getUserAsset(uniqueId)?.balance || asset.balance : asset.balance,
+    balance,
 
     // For some reason certain assets have a unique ID in the format of `${address}_mainnet` rather than
     // `${address}_${chainId}`, so at least for now we ensure consistency by reconstructing the unique ID here.


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Refactors the swap number pad logic to work without the old string vs. number checks, which are no longer reliable
  - This was causing a bug where if for example you dragged the slider, waited for the quote to fetch, and then typed into the output field, the amount in the input would switch to the unformatted, much longer number (the underlying input value)
- Increases the gas buffer from `+/- 0.25x` to `+/- 0.5x` — was changing a bit too often
- Improves the Max button and `formattedInputAmount` checks that determine whether max amount is being swapped, to explicitly check if the underlying input value is exactly the max swappable amount
- Fixes bugs causing the input amount to sometimes exceed the max available balance when swapping max
- Improves slider/max button logic in the case where the current input value exceeds your max swappable balance
  - You can now drag the slider to/beyond 100% to bring it down to your max swappable balance, and tapping the Max button does the same
- Adds `roundingMode: 'none'` to `valueBasedDecimalFormatter`
- Removes the `-1` `precisionAdjustment` in `formattedInputAmount` when swapping max

## Screen recordings / screenshots


## What to test

