### PR TITLE
chore: amend `rewards_enabled` default

### DIFF
--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -168,7 +168,7 @@ export const DEFAULT_CONFIG: RainbowConfig = {
   dapp_browser: true,
   swaps_v2: false,
   idfa_check_enabled: true,
-  rewards_enabled: false,
+  rewards_enabled: true,
 };
 
 export async function fetchRemoteConfig(): Promise<RainbowConfig> {


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- turned `rewards_enabled` on by default to mitigate issues for users with VPNs that block Firebase APIs

## Screen recordings / screenshots


## What to test

