### PR TITLE
Match logic of balance badge to format max input value

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -18,7 +18,11 @@ import { CrosschainQuote, Quote, QuoteError, SwapType, getCrosschainQuote, getQu
 import { useAnimatedInterval } from '@/hooks/reanimated/useAnimatedInterval';
 import store from '@/redux/store';
 import { swapsStore } from '@/state/swaps/swapsStore';
-import { convertAmountToNativeDisplayWorklet, convertRawAmountToDecimalFormat } from '@/__swaps__/utils/numbers';
+import {
+  convertAmountToNativeDisplayWorklet,
+  convertRawAmountToDecimalFormat,
+  handleSignificantDecimalsWorklet,
+} from '@/__swaps__/utils/numbers';
 import { NavigationSteps } from './useSwapNavigation';
 import { RainbowError, logger } from '@/logger';
 import {
@@ -134,14 +138,7 @@ export function useSwapInputsController({
     }
 
     if (equalWorklet(inputValues.value.inputAmount, internalSelectedInputAsset.value.maxSwappableAmount)) {
-      const formattedAmount = valueBasedDecimalFormatter({
-        amount: inputValues.value.inputAmount,
-        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
-        nativePrice: inputNativePrice.value,
-        roundingMode: 'none',
-        stripSeparators: false,
-      });
-
+      const formattedAmount = handleSignificantDecimalsWorklet(inputValues.value.inputAmount, internalSelectedInputAsset.value.decimals);
       return formattedAmount;
     } else {
       return addCommasToNumber(inputValues.value.inputAmount, '0');


### PR DESCRIPTION
Fixes APP-1627

## What changed (plus any additional context for devs)
1. The formatting for max input value was using the `valueBasedDecimalFormatter` which is slightly different from the logic that the balance badge uses. This PR ports over the essential logic of the balance badge into a worklet and uses that for formatting.
2. This also fixes an issue with the non-worklet `handleSignificantDecimals` function that was copied over from helpers/utilities. A comment is added inline below describing the issue.

## What to test
- Tap max on various input assets (native and non-native) across multiple networks. 
- For non-native assets, the max formatted input value should match the balance badge.
- For native assets, the max formatted input value should look similarly formatted to the balance badge, though the max input amount will be slightly less than what is shown in the balance badge since it needs to account for gas + some buffer.

## Screen recordings / screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-06-27 at 22 54 32](https://github.com/rainbow-me/rainbow/assets/1285228/3198107d-a161-40e8-a02f-cdd28ab3cfc6)
![Simulator Screenshot - iPhone 15 Pro - 2024-06-27 at 22 54 04](https://github.com/rainbow-me/rainbow/assets/1285228/733dbcfc-6afc-47ad-8706-2470847fc799)
![Simulator Screenshot - iPhone 15 Pro - 2024-06-27 at 22 53 28](https://github.com/rainbow-me/rainbow/assets/1285228/eb5dbd68-2583-416d-a489-6cccfaf9b807)
![Simulator Screenshot - iPhone 15 Pro - 2024-06-27 at 22 53 14](https://github.com/rainbow-me/rainbow/assets/1285228/76aa34e3-c8f3-4897-9339-144491addab0)


