### PR TITLE
Display 2 decimals at a minimum for stablecoins in valueBasedDecimalFormatter

### DIFF
--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -261,10 +261,7 @@ export function valueBasedDecimalFormatter({
   'worklet';
 
   function calculateDecimalPlaces(): number {
-    const fallbackDecimalPlaces = MAXIMUM_SIGNIFICANT_DECIMALS;
-    if (nativePrice === 0) {
-      return fallbackDecimalPlaces;
-    }
+    if (nativePrice === 0) return MAXIMUM_SIGNIFICANT_DECIMALS;
     const unitsForOneCent = 0.01 / nativePrice;
     if (unitsForOneCent >= 1) {
       return isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0;


### PR DESCRIPTION
Fixes APP-1613

## What changed (plus any additional context for devs)
* added comments inline below!
* issue: if the value of the output field is something like "123.00567", the output was displaying "123" instead of "123.00"
* this is because in the `valueBasedDecimalFormatter`, we only specified max decimals and not min decimals, and while the max decimals would be 2, in the instance where we round down for output based values, it was rounding to 123.00 and then just displaying 123
* this PR adds support for minimum and maximum decimals and will serve as a base for future improvements to our decimal formatting. 
* other than the stablecoin change, everything else should be a no-op.

## What to test
* decimal formatting should not be impacted except for stablecoins as output assets
* at various stablecoin output amounts, any value that is "XXX.00" should display with the 2 decimal spots instead of just "XXX"

## Screen recordings / screenshots
In the screenshot below, I "faked" an output value such as "676.00789" so I didn't have to keep messing with the input to get the output I wanted
![Simulator Screenshot - iPhone 15 Pro - 2024-06-28 at 11 39 19](https://github.com/rainbow-me/rainbow/assets/1285228/e29167be-0946-4e98-9a87-366fad5414b5)






