### PR TITLE
Debounce fetch quote after updating slippage

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -74,6 +74,7 @@ export function useSwapInputsController({
   outputProgress,
   quote,
   sliderXPosition,
+  slippage,
 }: {
   focusedInput: SharedValue<inputKeys>;
   inputProgress: SharedValue<number>;
@@ -86,6 +87,7 @@ export function useSwapInputsController({
   outputProgress: SharedValue<number>;
   quote: SharedValue<Quote | CrosschainQuote | QuoteError | null>;
   sliderXPosition: SharedValue<number>;
+  slippage: SharedValue<string>;
 }) {
   const { initialInputAmount, initialInputNativeValue } = getInitialInputValues(initialSelectedInputAsset);
   const { nativeCurrency: currentCurrency } = useAccountSettings();
@@ -622,6 +624,23 @@ export function useSwapInputsController({
     },
     300,
     { leading: false, trailing: true }
+  );
+
+  const debouncedFetchQuote = useDebouncedCallback(
+    () => {
+      runOnUI(fetchQuoteAndAssetPrices)();
+    },
+    300,
+    { leading: false, trailing: true }
+  );
+
+  useAnimatedReaction(
+    () => slippage.value,
+    (slippage, prevSlippage) => {
+      if (prevSlippage && slippage !== prevSlippage) {
+        runOnJS(debouncedFetchQuote)();
+      }
+    }
   );
 
   /**

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -173,6 +173,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     isFetching,
     isQuoteStale,
     sliderXPosition,
+    slippage: SwapSettings.slippage,
     quote,
   });
 


### PR DESCRIPTION
Fixes APP-1619

## What changed (plus any additional context for devs)
Issue: in the Review Panel when you update slippage, it wasn't immediately triggering a quote refetch and would update the minimum received / max sold only at the next interval of fetching.
This triggers a debounced quote refetch on updates to slippage.

## What to test
Update slippage in the review panel - you should see the actual quote update as well as the minimum received / maximum sold amount for input-based and output-based trades.

## Screen recordings / screenshots
https://github.com/rainbow-me/rainbow/assets/1285228/0067acbd-3a2f-4e95-b760-9c9251f279a8



