### PR TITLE
sort native network token to top of list

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -1,20 +1,20 @@
-import { rankings } from 'match-sorter';
-import { useCallback, useMemo, useState } from 'react';
-import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 import { TokenSearchResult, useTokenSearch } from '@/__swaps__/screens/Swap/resources/search';
+import { AddressOrEth } from '@/__swaps__/types/assets';
 import { ChainId } from '@/__swaps__/types/chains';
 import { SearchAsset, TokenSearchAssetKey, TokenSearchThreshold } from '@/__swaps__/types/search';
 import { addHexPrefix } from '@/__swaps__/utils/hex';
 import { isLowerCaseMatch } from '@/__swaps__/utils/strings';
-import { filterList } from '@/utils';
-import { useFavorites } from '@/resources/favorites';
-import { isAddress } from '@ethersproject/address';
-import { useSwapContext } from '../providers/swap-provider';
-import { useDebouncedCallback } from 'use-debounce';
-import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { getStandardizedUniqueIdWorklet } from '@/__swaps__/utils/swaps';
-import { AddressOrEth } from '@/__swaps__/types/assets';
+import { useFavorites } from '@/resources/favorites';
+import { useSwapsStore } from '@/state/swaps/swapsStore';
+import { filterList } from '@/utils';
+import { isAddress } from '@ethersproject/address';
+import { rankings } from 'match-sorter';
+import { useCallback, useMemo, useState } from 'react';
+import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
+import { useDebouncedCallback } from 'use-debounce';
 import { TokenToBuyListItem } from '../components/TokenList/TokenToBuyList';
+import { useSwapContext } from '../providers/swap-provider';
 
 export type AssetToBuySectionId = 'bridge' | 'favorites' | 'verified' | 'unverified' | 'other_networks';
 
@@ -210,7 +210,7 @@ export function useSearchCurrencyLists() {
   const { data: verifiedAssets } = useTokenSearch(
     {
       list: 'verifiedAssets',
-      chainId: isAddress(query) ? state.toChainId : undefined,
+      chainId: state.toChainId,
       keys: isAddress(query) ? ['address'] : ['name', 'symbol'],
       threshold: isAddress(query) ? 'CASE_SENSITIVE_EQUAL' : 'CONTAINS',
       query: query.length > 0 ? query : undefined,

--- a/src/__swaps__/screens/Swap/resources/search/index.ts
+++ b/src/__swaps__/screens/Swap/resources/search/index.ts
@@ -61,7 +61,7 @@ export type TokenSearchArgs = {
 // Query Key
 
 const tokenSearchQueryKey = ({ chainId, fromChainId, keys, list, threshold, query }: TokenSearchArgs) =>
-  createQueryKey('TokenSearch', { chainId, fromChainId, keys, list, threshold, query }, { persisterVersion: 1 });
+  createQueryKey('TokenSearch', { chainId, fromChainId, keys, list, threshold, query }, { persisterVersion: 2 });
 
 type TokenSearchQueryKey = ReturnType<typeof tokenSearchQueryKey>;
 

--- a/src/__swaps__/screens/Swap/resources/search/index.ts
+++ b/src/__swaps__/screens/Swap/resources/search/index.ts
@@ -1,32 +1,32 @@
 /* eslint-disable no-nested-ternary */
-import { isAddress } from '@ethersproject/address';
-import { useQuery } from '@tanstack/react-query';
-import qs from 'qs';
+import { ChainId } from '@/__swaps__/types/chains';
+import { SearchAsset, TokenSearchAssetKey, TokenSearchListId, TokenSearchThreshold } from '@/__swaps__/types/search';
+import { RainbowError, logger } from '@/logger';
+import { RainbowFetchClient } from '@/rainbow-fetch';
 import { QueryConfigWithSelect, QueryFunctionArgs, QueryFunctionResult, createQueryKey, queryClient } from '@/react-query';
 import {
   ARBITRUM_ETH_ADDRESS,
   AVAX_AVALANCHE_ADDRESS,
   BASE_ETH_ADDRESS,
   BLAST_ETH_ADDRESS,
-  BNB_MAINNET_ADDRESS,
+  BNB_BSC_ADDRESS,
   DEGEN_CHAIN_DEGEN_ADDRESS,
   ETH_ADDRESS,
-  MATIC_MAINNET_ADDRESS,
+  MATIC_POLYGON_ADDRESS,
   OPTIMISM_ETH_ADDRESS,
   ZORA_ETH_ADDRESS,
 } from '@/references';
-import { ChainId } from '@/__swaps__/types/chains';
-import { SearchAsset, TokenSearchAssetKey, TokenSearchListId, TokenSearchThreshold } from '@/__swaps__/types/search';
-import { RainbowFetchClient } from '@/rainbow-fetch';
-import { RainbowError, logger } from '@/logger';
+import { isAddress } from '@ethersproject/address';
+import { useQuery } from '@tanstack/react-query';
+import qs from 'qs';
 import { Address } from 'viem';
 
 const NATIVE_ASSET_UNIQUE_IDS = new Set([
   `${ETH_ADDRESS}_${ChainId.mainnet}`,
   `${OPTIMISM_ETH_ADDRESS}_${ChainId.optimism}`,
   `${ARBITRUM_ETH_ADDRESS}_${ChainId.arbitrum}`,
-  `${BNB_MAINNET_ADDRESS}_${ChainId.bsc}`,
-  `${MATIC_MAINNET_ADDRESS}_${ChainId.polygon}`,
+  `${BNB_BSC_ADDRESS}_${ChainId.bsc}`,
+  `${MATIC_POLYGON_ADDRESS}_${ChainId.polygon}`,
   `${BASE_ETH_ADDRESS}_${ChainId.base}`,
   `${ZORA_ETH_ADDRESS}_${ChainId.zora}`,
   `${AVAX_AVALANCHE_ADDRESS}_${ChainId.avalanche}`,


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

the polygon and bsc native assets uniqueIds where wrong (?)

pow native network tokens on top of lists (avax was good already)

<img width="200" alt="Screenshot 2024-07-01 at 14 25 37" src="https://github.com/rainbow-me/rainbow/assets/6232729/e9cbac22-4bdd-4fe7-a764-1ceb0dee1c56">
<img width="200" alt="Screenshot 2024-07-01 at 14 25 44" src="https://github.com/rainbow-me/rainbow/assets/6232729/5ce3cbd5-f75a-47e2-8110-b4e6ff379fd2">
<img width="200" alt="Screenshot 2024-07-01 at 14 25 53" src="https://github.com/rainbow-me/rainbow/assets/6232729/d8b956ee-987c-44d5-9836-5548354f37d8">
  
  
should we also sort it to top on input token?

<img width="374" alt="Screenshot 2024-07-01 at 14 26 28" src="https://github.com/rainbow-me/rainbow/assets/6232729/f545388f-0ba6-446c-9ef7-a54cc2b2f601">

## Screen recordings / screenshots


## What to test

