### PR TITLE
Improve decimal formatter functions

### DIFF
--- a/src/__swaps__/safe-math/SafeMath.ts
+++ b/src/__swaps__/safe-math/SafeMath.ts
@@ -202,6 +202,32 @@ export function modWorklet(num1: string | number, num2: string | number): string
   return formatResultWorklet(result);
 }
 
+// return significant decimals in fractional portion of number
+export function significantDecimalsWorklet(num: string | number): number {
+  'worklet';
+  if (num === 0) {
+    return 0;
+  }
+
+  // Convert the number to a string to handle large numbers and fractional parts
+  const numStr = num.toString();
+
+  // Split the number into integer and fractional parts
+  const [_, fractionalPart] = numStr.split('.');
+
+  // Handle fractional parts
+  if (fractionalPart) {
+    // Find the first non-zero digit in the fractional part
+    for (let i = 0; i < fractionalPart.length; i++) {
+      if (fractionalPart[i] !== '0') {
+        return i + 1;
+      }
+    }
+  }
+
+  return 0;
+}
+
 export function orderOfMagnitudeWorklet(num: string | number): number {
   'worklet';
   if (num === 0) {

--- a/src/__swaps__/screens/Swap/__tests__/NiceIncrementerFormatter.test.disabled.ts
+++ b/src/__swaps__/screens/Swap/__tests__/NiceIncrementerFormatter.test.disabled.ts
@@ -4,7 +4,6 @@ import { SLIDER_WIDTH } from '../constants';
 type TestCase = {
   inputAssetBalance: number | string;
   inputAssetNativePrice: number;
-  niceIncrement: number | string;
   percentageToSwap: number;
   sliderXPosition: number;
   stripSeparators?: boolean;
@@ -18,7 +17,6 @@ const TEST_CASES: TestCase[] = [
   {
     inputAssetBalance: 45.47364224817269,
     inputAssetNativePrice: 0.9995363790000001,
-    niceIncrement: '1',
     percentageToSwap: 0.5,
     sliderXPosition: SLIDER_WIDTH / 2,
     stripSeparators: true,
@@ -29,7 +27,6 @@ const TEST_CASES: TestCase[] = [
   {
     inputAssetBalance: 100,
     inputAssetNativePrice: 10,
-    niceIncrement: '0.1',
     percentageToSwap: 0,
     sliderXPosition: 0,
     stripSeparators: false,
@@ -40,7 +37,6 @@ const TEST_CASES: TestCase[] = [
   {
     inputAssetBalance: 100,
     inputAssetNativePrice: 10,
-    niceIncrement: '0.1',
     percentageToSwap: 1,
     sliderXPosition: SLIDER_WIDTH,
     stripSeparators: false,
@@ -51,7 +47,6 @@ const TEST_CASES: TestCase[] = [
   {
     inputAssetBalance: 123.456,
     inputAssetNativePrice: 1,
-    niceIncrement: '0.05',
     percentageToSwap: 0.25,
     sliderXPosition: SLIDER_WIDTH / 4,
     stripSeparators: true,
@@ -62,7 +57,6 @@ const TEST_CASES: TestCase[] = [
   {
     inputAssetBalance: '1000',
     inputAssetNativePrice: 0.5,
-    niceIncrement: '100',
     percentageToSwap: 0.75,
     sliderXPosition: (3 * SLIDER_WIDTH) / 4,
     stripSeparators: false,

--- a/src/__swaps__/screens/Swap/__tests__/NiceIncrementerFormatter.test.disabled.ts
+++ b/src/__swaps__/screens/Swap/__tests__/NiceIncrementerFormatter.test.disabled.ts
@@ -2,7 +2,6 @@ import { niceIncrementFormatter } from '@/__swaps__/utils/swaps';
 import { SLIDER_WIDTH } from '../constants';
 
 type TestCase = {
-  incrementDecimalPlaces: number;
   inputAssetBalance: number | string;
   inputAssetNativePrice: number;
   niceIncrement: number | string;
@@ -17,7 +16,6 @@ type TestCase = {
 
 const TEST_CASES: TestCase[] = [
   {
-    incrementDecimalPlaces: 0,
     inputAssetBalance: 45.47364224817269,
     inputAssetNativePrice: 0.9995363790000001,
     niceIncrement: '1',
@@ -29,7 +27,6 @@ const TEST_CASES: TestCase[] = [
     expectedResult: '22.74',
   },
   {
-    incrementDecimalPlaces: 2,
     inputAssetBalance: 100,
     inputAssetNativePrice: 10,
     niceIncrement: '0.1',
@@ -41,7 +38,6 @@ const TEST_CASES: TestCase[] = [
     expectedResult: '0.00',
   },
   {
-    incrementDecimalPlaces: 2,
     inputAssetBalance: 100,
     inputAssetNativePrice: 10,
     niceIncrement: '0.1',
@@ -53,7 +49,6 @@ const TEST_CASES: TestCase[] = [
     expectedResult: '100.00',
   },
   {
-    incrementDecimalPlaces: 2,
     inputAssetBalance: 123.456,
     inputAssetNativePrice: 1,
     niceIncrement: '0.05',
@@ -65,7 +60,6 @@ const TEST_CASES: TestCase[] = [
     expectedResult: '30.86',
   },
   {
-    incrementDecimalPlaces: 0,
     inputAssetBalance: '1000',
     inputAssetNativePrice: 0.5,
     niceIncrement: '100',

--- a/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
+++ b/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
@@ -4,7 +4,8 @@ import Animated, { useAnimatedReaction, useAnimatedStyle, useSharedValue, withDe
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { AnimatedText, Box, Inline, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
 import { LIGHT_SEPARATOR_COLOR, SEPARATOR_COLOR, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
-import { opacity, valueBasedDecimalFormatter } from '@/__swaps__/utils/swaps';
+import { valueBasedDecimalFormatter } from '@/__swaps__/utils/decimalFormatter';
+import { opacity } from '@/__swaps__/utils/swaps';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { IS_IOS } from '@/env';
 import { AddressZero } from '@ethersproject/constants';

--- a/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
+++ b/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
@@ -74,8 +74,8 @@ export const ExchangeRateBubble = () => {
       const { symbol: inputAssetSymbol, nativePrice: inputAssetPrice, type: inputAssetType } = internalSelectedInputAsset.value;
       const { symbol: outputAssetSymbol, nativePrice: outputAssetPrice, type: outputAssetType } = internalSelectedOutputAsset.value;
 
-      const isInputAssetStablecoin = inputAssetType === 'stablecoin' ?? false;
-      const isOutputAssetStablecoin = outputAssetType === 'stablecoin' ?? false;
+      const isInputAssetStablecoin = inputAssetType === 'stablecoin';
+      const isOutputAssetStablecoin = outputAssetType === 'stablecoin';
 
       const inputAssetEthTransform =
         internalSelectedInputAsset.value?.address === ETH_ADDRESS ? AddressZero : internalSelectedInputAsset.value?.address;

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -4,14 +4,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
 import { RequestNewQuoteParams, inputKeys, inputMethods, inputValuesType } from '@/__swaps__/types/swap';
 import { valueBasedDecimalFormatter } from '@/__swaps__/utils/decimalFormatter';
-import {
-  addCommasToNumber,
-  buildQuoteParams,
-  clamp,
-  findNiceIncrement,
-  niceIncrementFormatter,
-  trimTrailingZeros,
-} from '@/__swaps__/utils/swaps';
+import { addCommasToNumber, buildQuoteParams, clamp, niceIncrementFormatter, trimTrailingZeros } from '@/__swaps__/utils/swaps';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { CrosschainQuote, Quote, QuoteError, SwapType, getCrosschainQuote, getQuote } from '@rainbow-me/swaps';
 import { useAnimatedInterval } from '@/hooks/reanimated/useAnimatedInterval';
@@ -38,13 +31,11 @@ import { divWorklet, equalWorklet, greaterThanWorklet, isNumberStringWorklet, mu
 
 function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetWithColors | null) {
   const initialBalance = Number(initialSelectedInputAsset?.maxSwappableAmount) || 0;
-  const initialNiceIncrement = findNiceIncrement(initialBalance);
   const isStablecoin = initialSelectedInputAsset?.type === 'stablecoin';
 
   const initialInputAmount = niceIncrementFormatter({
     inputAssetBalance: initialBalance,
     inputAssetNativePrice: initialSelectedInputAsset?.price?.value ?? 0,
-    niceIncrement: initialNiceIncrement,
     percentageToSwap: 0.5,
     sliderXPosition: SLIDER_WIDTH / 2,
     stripSeparators: true,
@@ -99,11 +90,6 @@ export function useSwapInputsController({
 
   const percentageToSwap = useDerivedValue(() => {
     return Math.round(clamp((sliderXPosition.value - SCRUBBER_WIDTH / SLIDER_WIDTH) / SLIDER_WIDTH, 0, 1) * 100) / 100;
-  });
-
-  const niceIncrement = useDerivedValue(() => {
-    if (!internalSelectedInputAsset.value?.maxSwappableAmount) return 0.1;
-    return findNiceIncrement(internalSelectedInputAsset.value?.maxSwappableAmount);
   });
 
   const inputNativePrice = useDerivedValue(() => {
@@ -747,7 +733,6 @@ export function useSwapInputsController({
             const inputAmount = niceIncrementFormatter({
               inputAssetBalance: balance,
               inputAssetNativePrice: inputNativePrice.value,
-              niceIncrement: niceIncrement.value,
               percentageToSwap: percentageToSwap.value,
               sliderXPosition: sliderXPosition.value,
               stripSeparators: true,
@@ -909,7 +894,6 @@ export function useSwapInputsController({
           const inputAmount = niceIncrementFormatter({
             inputAssetBalance: balance,
             inputAssetNativePrice: inputNativePrice.value,
-            niceIncrement: niceIncrement.value,
             percentageToSwap: didInputAssetChange ? 0.5 : percentageToSwap.value,
             sliderXPosition: didInputAssetChange ? SLIDER_WIDTH / 2 : sliderXPosition.value,
             stripSeparators: true,
@@ -969,7 +953,6 @@ export function useSwapInputsController({
     formattedOutputNativeValue,
     inputMethod,
     inputValues,
-    niceIncrement,
     onChangedPercentage,
     percentageToSwap,
     quoteFetchingInterval,

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -3,6 +3,7 @@ import { SharedValue, runOnJS, runOnUI, useAnimatedReaction, useDerivedValue, us
 import { useDebouncedCallback } from 'use-debounce';
 import { SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
 import { RequestNewQuoteParams, inputKeys, inputMethods, inputValuesType } from '@/__swaps__/types/swap';
+import { valueBasedDecimalFormatter } from '@/__swaps__/utils/decimalFormatter';
 import {
   addCommasToNumber,
   buildQuoteParams,
@@ -11,7 +12,6 @@ import {
   findNiceIncrement,
   niceIncrementFormatter,
   trimTrailingZeros,
-  valueBasedDecimalFormatter,
 } from '@/__swaps__/utils/swaps';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { CrosschainQuote, Quote, QuoteError, SwapType, getCrosschainQuote, getQuote } from '@rainbow-me/swaps';

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -8,7 +8,6 @@ import {
   addCommasToNumber,
   buildQuoteParams,
   clamp,
-  countDecimalPlaces,
   findNiceIncrement,
   niceIncrementFormatter,
   trimTrailingZeros,
@@ -40,11 +39,9 @@ import { divWorklet, equalWorklet, greaterThanWorklet, isNumberStringWorklet, mu
 function getInitialInputValues(initialSelectedInputAsset: ExtendedAnimatedAssetWithColors | null) {
   const initialBalance = Number(initialSelectedInputAsset?.maxSwappableAmount) || 0;
   const initialNiceIncrement = findNiceIncrement(initialBalance);
-  const initialDecimalPlaces = countDecimalPlaces(initialNiceIncrement);
   const isStablecoin = initialSelectedInputAsset?.type === 'stablecoin';
 
   const initialInputAmount = niceIncrementFormatter({
-    incrementDecimalPlaces: initialDecimalPlaces,
     inputAssetBalance: initialBalance,
     inputAssetNativePrice: initialSelectedInputAsset?.price?.value ?? 0,
     niceIncrement: initialNiceIncrement,
@@ -108,7 +105,6 @@ export function useSwapInputsController({
     if (!internalSelectedInputAsset.value?.maxSwappableAmount) return 0.1;
     return findNiceIncrement(internalSelectedInputAsset.value?.maxSwappableAmount);
   });
-  const incrementDecimalPlaces = useDerivedValue(() => countDecimalPlaces(niceIncrement.value));
 
   const inputNativePrice = useDerivedValue(() => {
     return internalSelectedInputAsset.value?.nativePrice || internalSelectedInputAsset.value?.price?.value || 0;
@@ -749,7 +745,6 @@ export function useSwapInputsController({
             }
 
             const inputAmount = niceIncrementFormatter({
-              incrementDecimalPlaces: incrementDecimalPlaces.value,
               inputAssetBalance: balance,
               inputAssetNativePrice: inputNativePrice.value,
               niceIncrement: niceIncrement.value,
@@ -912,7 +907,6 @@ export function useSwapInputsController({
           }
 
           const inputAmount = niceIncrementFormatter({
-            incrementDecimalPlaces: incrementDecimalPlaces.value,
             inputAssetBalance: balance,
             inputAssetNativePrice: inputNativePrice.value,
             niceIncrement: niceIncrement.value,
@@ -973,7 +967,6 @@ export function useSwapInputsController({
     formattedInputNativeValue,
     formattedOutputAmount,
     formattedOutputNativeValue,
-    incrementDecimalPlaces,
     inputMethod,
     inputValues,
     niceIncrement,

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -115,8 +115,7 @@ export function useSwapInputsController({
         amount: inputValues.value.inputAmount,
         nativePrice: inputNativePrice.value,
         roundingMode: 'up',
-        precisionAdjustment: -1,
-        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
+        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin',
         stripSeparators: false,
       });
     }
@@ -157,8 +156,7 @@ export function useSwapInputsController({
       amount: inputValues.value.outputAmount,
       nativePrice: outputNativePrice.value,
       roundingMode: 'down',
-      precisionAdjustment: -1,
-      isStablecoin: internalSelectedOutputAsset.value?.type === 'stablecoin' ?? false,
+      isStablecoin: internalSelectedOutputAsset.value?.type === 'stablecoin',
       stripSeparators: false,
     });
   });
@@ -921,7 +919,6 @@ export function useSwapInputsController({
                 inputNativePrice > 0 ? divWorklet(inputValues.value.inputNativeValue, inputNativePrice) : inputValues.value.outputAmount,
               nativePrice: inputNativePrice,
               roundingMode: 'up',
-              precisionAdjustment: -1,
               isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin' ?? false,
               stripSeparators: true,
             })

--- a/src/__swaps__/utils/__tests__/decimalFormatter.test.ts
+++ b/src/__swaps__/utils/__tests__/decimalFormatter.test.ts
@@ -1,0 +1,153 @@
+import { valueBasedDecimalFormatter } from '../decimalFormatter';
+
+// amounts
+const VERY_SMALL_AMOUNT = '0.0000000123456789';
+const SMALL_AMOUNT = '0.123456789';
+const REGULAR_AMOUNT = '1.123456789';
+const REGULAR_AMOUNT_1_WITH_SIGS = '1.000000123';
+const REGULAR_AMOUNT_10 = '12.123456789';
+const REGULAR_AMOUNT_100 = '123.123456789';
+const REGULAR_AMOUNT_100_WITH_SIGS = '123.000000123456789';
+const REGULAR_AMOUNT_1000 = '1234.123456789';
+const LARGE_AMOUNT = '12345.123456789';
+const VERY_LARGE_AMOUNT = '123456.123456789';
+const VERY_LARGE_AMOUNT_WITH_SIGS = '123456.00000001234';
+const VERY_VERY_LARGE_AMOUNT = '1234567.123456789';
+
+// nativePrices
+const NO_PRICE = 0;
+const VERY_SMALL_PRICE = 0.00000002;
+const REGULAR_PRICE_1 = 1.12345;
+const REGULAR_PRICE_10 = 12.12345;
+const REGULAR_PRICE_1000 = 1234.12345;
+const LARGE_PRICE = 12345.12345;
+const VERY_LARGE_PRICE = 123456.12345;
+
+const testCases = [
+  // very large price: ~$100k
+  { amount: VERY_SMALL_AMOUNT, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '0.1234568' },
+  { amount: REGULAR_AMOUNT, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '1.1234568' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '12.123457' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '123.12346' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '123.00001' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '1234.1235' },
+  { amount: LARGE_AMOUNT, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '12345.124' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '123456.13' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '123456.01' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: VERY_LARGE_PRICE, isStablecoin: false, expected: '1234567.2' },
+
+  // large price: ~$10k
+  { amount: VERY_SMALL_AMOUNT, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '0.123457' },
+  { amount: REGULAR_AMOUNT, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '1.123457' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '12.12346' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '123.1235' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '123.0001' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '1234.124' },
+  { amount: LARGE_AMOUNT, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '12345.13' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '123456.2' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '123456.1' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: LARGE_PRICE, isStablecoin: false, expected: '1234568' },
+
+  // regular price: ~$1000
+  { amount: VERY_SMALL_AMOUNT, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '0.12346' },
+  { amount: REGULAR_AMOUNT, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '1.12346' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '12.1235' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '123.124' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '123.001' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '1234.13' },
+  { amount: LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '12345.2' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '123457' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '123457' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1000, isStablecoin: false, expected: '1234568' },
+
+  // regular price: ~$10
+  { amount: VERY_SMALL_AMOUNT, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '0.124' },
+  { amount: REGULAR_AMOUNT, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '1.124' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '12.13' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '123.13' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '123.01' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '1235' },
+  { amount: LARGE_AMOUNT, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '12346' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '123457' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '123457' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_10, isStablecoin: false, expected: '1234568' },
+
+  // regular price: ~$1 (non-stablecoin)
+  { amount: VERY_SMALL_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '0.13' },
+  { amount: REGULAR_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '1.13' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '12.13' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '123.13' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '123.01' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '1235' },
+  { amount: LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '12346' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '123457' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '123457' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: false, expected: '1234568' },
+
+  // stablecoin tests
+  { amount: VERY_SMALL_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '0.13' },
+  { amount: REGULAR_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '1.13' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '12.13' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '123.13' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '123.01' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '1234.13' },
+  { amount: LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '12345.13' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '123456.13' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '123456.01' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: REGULAR_PRICE_1, isStablecoin: true, expected: '1234567.13' },
+
+  // very small price
+  { amount: VERY_SMALL_AMOUNT, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '0.13' },
+  { amount: REGULAR_AMOUNT, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '1.13' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '12.13' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '123.13' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '123.01' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '1235' },
+  { amount: LARGE_AMOUNT, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '12346' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '123457' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '123457' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: VERY_SMALL_PRICE, isStablecoin: false, expected: '1234568' },
+
+  // no price
+  { amount: VERY_SMALL_AMOUNT, nativePrice: NO_PRICE, isStablecoin: false, expected: '0.000000013' },
+  { amount: SMALL_AMOUNT, nativePrice: NO_PRICE, isStablecoin: false, expected: '0.123457' },
+  { amount: REGULAR_AMOUNT, nativePrice: NO_PRICE, isStablecoin: false, expected: '1.123457' },
+  { amount: REGULAR_AMOUNT_1_WITH_SIGS, nativePrice: NO_PRICE, isStablecoin: false, expected: '1.00000013' },
+  { amount: REGULAR_AMOUNT_10, nativePrice: NO_PRICE, isStablecoin: false, expected: '12.12346' },
+  { amount: REGULAR_AMOUNT_100, nativePrice: NO_PRICE, isStablecoin: false, expected: '123.1235' },
+  { amount: REGULAR_AMOUNT_100_WITH_SIGS, nativePrice: NO_PRICE, isStablecoin: false, expected: '123.0001' },
+  { amount: REGULAR_AMOUNT_1000, nativePrice: NO_PRICE, isStablecoin: false, expected: '1234.124' },
+  { amount: LARGE_AMOUNT, nativePrice: NO_PRICE, isStablecoin: false, expected: '12345.13' },
+  { amount: VERY_LARGE_AMOUNT, nativePrice: NO_PRICE, isStablecoin: false, expected: '123456.2' },
+  { amount: VERY_LARGE_AMOUNT_WITH_SIGS, nativePrice: NO_PRICE, isStablecoin: false, expected: '123456.1' },
+  { amount: VERY_VERY_LARGE_AMOUNT, nativePrice: NO_PRICE, isStablecoin: false, expected: '1234568' },
+];
+
+describe('convertAmountToNativeDisplayWorklet', () => {
+  testCases.forEach(({ amount, nativePrice, isStablecoin, expected }) => {
+    it(`should format correctly`, () => {
+      return expect(
+        valueBasedDecimalFormatter({
+          amount,
+          nativePrice,
+          roundingMode: 'up',
+          isStablecoin,
+        })
+      ).toBe(expected);
+    });
+  });
+});

--- a/src/__swaps__/utils/decimalFormatter.ts
+++ b/src/__swaps__/utils/decimalFormatter.ts
@@ -1,0 +1,97 @@
+import {
+  ceilWorklet,
+  divWorklet,
+  floorWorklet,
+  mulWorklet,
+  roundWorklet,
+  toFixedWorklet,
+  orderOfMagnitudeWorklet,
+} from '../safe-math/SafeMath';
+
+const STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS = 2;
+
+export function valueBasedDecimalFormatter({
+  amount,
+  nativePrice,
+  roundingMode,
+  precisionAdjustment,
+  isStablecoin,
+  stripSeparators = true,
+}: {
+  amount: number | string;
+  nativePrice: number;
+  roundingMode?: 'up' | 'down' | 'none';
+  precisionAdjustment?: number;
+  isStablecoin?: boolean;
+  stripSeparators?: boolean;
+}): string {
+  'worklet';
+
+  function calculateDecimalPlaces(): {
+    minimumDecimalPlaces: number;
+    maximumDecimalPlaces: number;
+  } {
+    const orderOfMagnitude = orderOfMagnitudeWorklet(amount);
+    const decimalsBasedOnMagnitude = orderOfMagnitude > 0 ? 7 - orderOfMagnitude : -(orderOfMagnitude + 1);
+
+    if (nativePrice === 0) {
+      return {
+        minimumDecimalPlaces: Math.max(-orderOfMagnitude, isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0),
+        maximumDecimalPlaces: decimalsBasedOnMagnitude, // MAXIMUM_SIGNIFICANT_DECIMALS
+      };
+    }
+
+    // for when it has prices, it doesn't need to be much MORE than the $0.01 granularity
+    const significantDigits = 0;
+    const minimumDecimalPlaces = Math.max(significantDigits, isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0);
+
+    // for when it has a super tiny price...can we treat it the same as when it has no price?
+    let minDecimalsForOneCent = 0;
+    const unitsForOneCent = 0.01 / nativePrice;
+    if (unitsForOneCent >= 1) {
+      return {
+        minimumDecimalPlaces: 0,
+        maximumDecimalPlaces: 0,
+      };
+    } else {
+      // asset nativePrice > 0.01
+      minDecimalsForOneCent = Math.ceil(Math.log10(1 / unitsForOneCent));
+    }
+    // when precisionAdjustment is negative, it means that the order of magnitude is large
+    // when precisionAdjustment is positive, it means that there are significant digits
+    const maximumDecimalPlaces = Math.max(
+      minDecimalsForOneCent + (precisionAdjustment ?? 0), // Math.ceil(Math.log10(1 / unitsForOneCent)) + (precisionAdjustment ?? 0),
+      isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0
+    );
+
+    return {
+      minimumDecimalPlaces,
+      maximumDecimalPlaces, // TODO JIN - asset.decimals
+    };
+  }
+
+  const { minimumDecimalPlaces, maximumDecimalPlaces } = calculateDecimalPlaces();
+
+  let roundedAmount;
+  const factor = Math.pow(10, maximumDecimalPlaces) || 1; // Prevent division by 0
+
+  // Apply rounding based on the specified rounding mode
+  if (roundingMode === 'up') {
+    roundedAmount = divWorklet(ceilWorklet(mulWorklet(amount, factor)), factor);
+  } else if (roundingMode === 'down') {
+    roundedAmount = divWorklet(floorWorklet(mulWorklet(amount, factor)), factor);
+  } else if (roundingMode === 'none') {
+    roundedAmount = toFixedWorklet(amount, maximumDecimalPlaces);
+  } else {
+    // Default to normal rounding if no rounding mode is specified
+    roundedAmount = divWorklet(roundWorklet(mulWorklet(amount, factor)), factor);
+  }
+  // Format the number to add separators and trim trailing zeros
+  const numberFormatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: minimumDecimalPlaces,
+    maximumFractionDigits: maximumDecimalPlaces,
+    useGrouping: !stripSeparators,
+  });
+
+  return numberFormatter.format(Number(roundedAmount));
+}

--- a/src/__swaps__/utils/decimalFormatter.ts
+++ b/src/__swaps__/utils/decimalFormatter.ts
@@ -42,23 +42,23 @@ export function valueBasedDecimalFormatter({
 
     let minimumDecimalPlaces = 0;
     let maximumDecimalPlaces = MAXIMUM_SIGNIFICANT_DECIMALS;
+    const stablecoinMin = isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0;
 
+    const minBasedOnOrderOfMag = orderOfMagnitude > 2 ? 0 : 2;
     if (orderOfMagnitude < 1) {
-      minimumDecimalPlaces = Math.max(isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0, significantDecimals);
-      maximumDecimalPlaces = Math.max(Math.max(minDecimalsForOneCent, 2), significantDecimals + 1, minimumDecimalPlaces);
-    } else if (orderOfMagnitude >= 0 && orderOfMagnitude <= 2) {
-      minimumDecimalPlaces = Math.max(isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0, significantDecimals);
-      maximumDecimalPlaces = Math.max(minDecimalsForOneCent - orderOfMagnitude, significantDecimals + 1, minimumDecimalPlaces);
+      minimumDecimalPlaces = Math.max(stablecoinMin, significantDecimals);
+      maximumDecimalPlaces = Math.max(minBasedOnOrderOfMag, minDecimalsForOneCent, significantDecimals + 1);
     } else {
-      minimumDecimalPlaces = isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0;
-      maximumDecimalPlaces = Math.max(0, minDecimalsForOneCent - orderOfMagnitude, minimumDecimalPlaces);
+      minimumDecimalPlaces = stablecoinMin;
+      maximumDecimalPlaces = Math.max(minBasedOnOrderOfMag, minDecimalsForOneCent - orderOfMagnitude);
     }
 
     return {
       minimumDecimalPlaces,
       maximumDecimalPlaces: Math.max(
         maximumDecimalPlaces + (precisionAdjustment ?? 0),
-        niceIncrementMinimumDecimals ? niceIncrementMinimumDecimals + 1 : 0
+        niceIncrementMinimumDecimals ? niceIncrementMinimumDecimals + 1 : 0,
+        minimumDecimalPlaces
       ),
     };
   }

--- a/src/__swaps__/utils/decimalFormatter.ts
+++ b/src/__swaps__/utils/decimalFormatter.ts
@@ -14,17 +14,19 @@ const STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS = 2;
 
 export function valueBasedDecimalFormatter({
   amount,
-  nativePrice,
-  roundingMode,
-  precisionAdjustment,
   isStablecoin,
+  nativePrice,
+  niceIncrementMinimumDecimals,
+  precisionAdjustment,
+  roundingMode,
   stripSeparators = true,
 }: {
   amount: number | string;
-  nativePrice: number;
-  roundingMode?: 'up' | 'down' | 'none';
-  precisionAdjustment?: number;
   isStablecoin?: boolean;
+  nativePrice: number;
+  niceIncrementMinimumDecimals?: number;
+  precisionAdjustment?: number;
+  roundingMode?: 'up' | 'down' | 'none';
   stripSeparators?: boolean;
 }): string {
   'worklet';
@@ -54,7 +56,10 @@ export function valueBasedDecimalFormatter({
 
     return {
       minimumDecimalPlaces,
-      maximumDecimalPlaces: maximumDecimalPlaces + (precisionAdjustment ?? 0),
+      maximumDecimalPlaces: Math.max(
+        maximumDecimalPlaces + (precisionAdjustment ?? 0),
+        niceIncrementMinimumDecimals ? niceIncrementMinimumDecimals + 1 : 0
+      ),
     };
   }
 

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -233,7 +233,6 @@ export function trimTrailingZeros(value: string) {
 }
 
 export function niceIncrementFormatter({
-  incrementDecimalPlaces,
   inputAssetBalance,
   inputAssetNativePrice,
   niceIncrement,
@@ -242,7 +241,6 @@ export function niceIncrementFormatter({
   stripSeparators,
   isStablecoin = false,
 }: {
-  incrementDecimalPlaces: number;
   inputAssetBalance: number | string;
   inputAssetNativePrice: number;
   niceIncrement: number | string;
@@ -285,6 +283,7 @@ export function niceIncrementFormatter({
     return inputAssetBalance;
   }
 
+  const incrementDecimalPlaces = countDecimalPlaces(niceIncrement);
   const decimals = isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : incrementDecimalPlaces;
   const exactIncrement = divWorklet(inputAssetBalance, 100);
   const isIncrementExact = equalWorklet(niceIncrement, exactIncrement);

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -249,12 +249,14 @@ export function niceIncrementFormatter({
 }) {
   'worklet';
   const niceIncrement = findNiceIncrement(inputAssetBalance);
+  const incrementDecimalPlaces = countDecimalPlaces(niceIncrement);
 
   if (percentageToSwap === 0 || equalWorklet(niceIncrement, 0)) return '0';
   if (percentageToSwap === 0.25) {
     const amount = mulWorklet(inputAssetBalance, 0.25);
     return valueBasedDecimalFormatter({
       nativePrice: inputAssetNativePrice,
+      niceIncrementMinimumDecimals: incrementDecimalPlaces,
       amount,
       roundingMode: 'up',
       isStablecoin,
@@ -264,6 +266,7 @@ export function niceIncrementFormatter({
     const amount = mulWorklet(inputAssetBalance, 0.5);
     return valueBasedDecimalFormatter({
       nativePrice: inputAssetNativePrice,
+      niceIncrementMinimumDecimals: incrementDecimalPlaces,
       amount,
       roundingMode: 'up',
       isStablecoin,
@@ -273,6 +276,7 @@ export function niceIncrementFormatter({
     const amount = mulWorklet(inputAssetBalance, 0.75);
     return valueBasedDecimalFormatter({
       nativePrice: inputAssetNativePrice,
+      niceIncrementMinimumDecimals: incrementDecimalPlaces,
       amount,
       roundingMode: 'up',
       isStablecoin,
@@ -282,12 +286,10 @@ export function niceIncrementFormatter({
     return inputAssetBalance;
   }
 
-  const incrementDecimalPlaces = countDecimalPlaces(niceIncrement);
   const decimals = isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : incrementDecimalPlaces;
   const exactIncrement = divWorklet(inputAssetBalance, 100);
   const isIncrementExact = equalWorklet(niceIncrement, exactIncrement);
   const numberOfIncrements = divWorklet(inputAssetBalance, niceIncrement);
-  // TODO JIN - to work on next
   const incrementStep = divWorklet(1, numberOfIncrements);
   const percentage = isIncrementExact
     ? percentageToSwap

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -304,13 +304,13 @@ export function niceIncrementFormatter({
 
   const amountToFixedDecimals = toFixedWorklet(rawAmount, decimals);
 
-  const formattedAmount = `${Number(amountToFixedDecimals).toLocaleString('en-US', {
-    useGrouping: !stripSeparators,
+  const numberFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
     maximumFractionDigits: MAXIMUM_SIGNIFICANT_DECIMALS,
-  })}`;
+    useGrouping: !stripSeparators,
+  });
 
-  return formattedAmount;
+  return numberFormatter.format(Number(amountToFixedDecimals));
 }
 
 export const opacityWorklet = (color: string, opacity: number) => {

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -235,7 +235,6 @@ export function trimTrailingZeros(value: string) {
 export function niceIncrementFormatter({
   inputAssetBalance,
   inputAssetNativePrice,
-  niceIncrement,
   percentageToSwap,
   sliderXPosition,
   stripSeparators,
@@ -243,13 +242,13 @@ export function niceIncrementFormatter({
 }: {
   inputAssetBalance: number | string;
   inputAssetNativePrice: number;
-  niceIncrement: number | string;
   percentageToSwap: number;
   sliderXPosition: number;
   stripSeparators?: boolean;
   isStablecoin?: boolean;
 }) {
   'worklet';
+  const niceIncrement = findNiceIncrement(inputAssetBalance);
 
   if (percentageToSwap === 0 || equalWorklet(niceIncrement, 0)) return '0';
   if (percentageToSwap === 0.25) {

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -24,12 +24,11 @@ import { CrosschainQuote, ETH_ADDRESS as ETH_ADDRESS_AGGREGATOR, Quote, QuotePar
 import { swapsStore } from '../../state/swaps/swapsStore';
 import { AddressOrEth, ExtendedAnimatedAssetWithColors, ParsedSearchAsset } from '../types/assets';
 import { inputKeys } from '../types/swap';
+import { valueBasedDecimalFormatter } from './decimalFormatter';
 import { convertAmountToRawAmount } from './numbers';
 import {
-  ceilWorklet,
   divWorklet,
   equalWorklet,
-  floorWorklet,
   lessThanOrEqualToWorklet,
   mulWorklet,
   powWorklet,
@@ -231,92 +230,6 @@ export function trimTrailingZeros(value: string) {
   'worklet';
   const withTrimmedZeros = value.replace(/0+$/, '');
   return withTrimmedZeros.endsWith('.') ? withTrimmedZeros.slice(0, -1) : withTrimmedZeros;
-}
-
-export function valueBasedDecimalFormatter({
-  amount,
-  nativePrice,
-  roundingMode,
-  precisionAdjustment,
-  isStablecoin,
-  stripSeparators = true,
-}: {
-  amount: number | string;
-  nativePrice: number;
-  roundingMode?: 'up' | 'down' | 'none';
-  precisionAdjustment?: number;
-  isStablecoin?: boolean;
-  stripSeparators?: boolean;
-}): string {
-  'worklet';
-
-  function calculateDecimalPlaces(): {
-    minimumDecimalPlaces: number;
-    maximumDecimalPlaces: number;
-  } {
-    const orderOfMagnitude = orderOfMagnitudeWorklet(amount);
-    const decimalsBasedOnMagnitude = orderOfMagnitude > 0 ? 7 - orderOfMagnitude : -(orderOfMagnitude + 1);
-
-    if (nativePrice === 0) {
-      return {
-        minimumDecimalPlaces: Math.max(-orderOfMagnitude, isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0),
-        maximumDecimalPlaces: decimalsBasedOnMagnitude, // MAXIMUM_SIGNIFICANT_DECIMALS
-      };
-    }
-
-    // for when it has prices, it doesn't need to be much MORE than the $0.01 granularity
-    const significantDigits = 0;
-    const minimumDecimalPlaces = Math.max(significantDigits, isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0);
-
-    // for when it has a super tiny price...can we treat it the same as when it has no price?
-    let minDecimalsForOneCent = 0;
-    const unitsForOneCent = 0.01 / nativePrice;
-    if (unitsForOneCent >= 1) {
-      return {
-        minimumDecimalPlaces: 0,
-        maximumDecimalPlaces: 0,
-      };
-    } else {
-      // asset nativePrice > 0.01
-      minDecimalsForOneCent = Math.ceil(Math.log10(1 / unitsForOneCent));
-    }
-    // when precisionAdjustment is negative, it means that the order of magnitude is large
-    // when precisionAdjustment is positive, it means that there are significant digits
-    const maximumDecimalPlaces = Math.max(
-      minDecimalsForOneCent + (precisionAdjustment ?? 0), // Math.ceil(Math.log10(1 / unitsForOneCent)) + (precisionAdjustment ?? 0),
-      isStablecoin ? STABLECOIN_MINIMUM_SIGNIFICANT_DECIMALS : 0
-    );
-
-    return {
-      minimumDecimalPlaces,
-      maximumDecimalPlaces, // TODO JIN - asset.decimals
-    };
-  }
-
-  const { minimumDecimalPlaces, maximumDecimalPlaces } = calculateDecimalPlaces();
-
-  let roundedAmount;
-  const factor = Math.pow(10, maximumDecimalPlaces) || 1; // Prevent division by 0
-
-  // Apply rounding based on the specified rounding mode
-  if (roundingMode === 'up') {
-    roundedAmount = divWorklet(ceilWorklet(mulWorklet(amount, factor)), factor);
-  } else if (roundingMode === 'down') {
-    roundedAmount = divWorklet(floorWorklet(mulWorklet(amount, factor)), factor);
-  } else if (roundingMode === 'none') {
-    roundedAmount = toFixedWorklet(amount, maximumDecimalPlaces);
-  } else {
-    // Default to normal rounding if no rounding mode is specified
-    roundedAmount = divWorklet(roundWorklet(mulWorklet(amount, factor)), factor);
-  }
-  // Format the number to add separators and trim trailing zeros
-  const numberFormatter = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: minimumDecimalPlaces,
-    maximumFractionDigits: maximumDecimalPlaces,
-    useGrouping: !stripSeparators,
-  });
-
-  return numberFormatter.format(Number(roundedAmount));
 }
 
 export function niceIncrementFormatter({


### PR DESCRIPTION
## What changed (plus any additional context for devs)
1. The `valueBasedDecimalFormatter` now takes into account the magnitude of the asset amount by default. It balances between significant decimals, value-based decimals, and magnitude.
2. Moved out the `valueBasedDecimalFormatter` into a separate file to make it easier to test
3. Added test cases for the `valueBasedDecimalFormatter` for various asset amounts and asset prices, no prices, stablecoins, etc
4. Added an optional param to `valueBasedDecimalFormatter` that the `niceIncrementFormatter` can pass in such that it guarantees that the `valueBasedDecimalFormatter` is always at least +1 more than the `niceIncrementFormatter` number of decimals. This helps resolve scenarios where the "jumps" between increments might end up rounding funnily on the snapping points.
5. Removed `incrementDecimalPlaces` and `niceIncrement` params to the `niceIncrementFormatter` since we can calculate this within the formatter function itself and don't use it elsewhere.

## What to test
- updating input amount, slider, output amount behaves as expected (just with nicer formatting)
- typing in "0.0000..." and trying to type "0000" behaves the same (where "0000" just stays as "0" and "0.0000" is left as is)
- for assets with super small balances, there shouldn't be any weird jumps in number when going from 49% -> 50% -> 51% (which was possible before)

## Screen recordings / screenshots
Example of weird jumps in value using slider on assets with super small balances BEFORE this PR:
https://github.com/rainbow-me/rainbow/assets/1285228/35393188-3552-4a68-867e-3853bdc69dd9


Example of smooth values using slider on assets with super small balances BEFORE this PR:
https://github.com/rainbow-me/rainbow/assets/1285228/8a891544-e92f-4487-ad41-c999ecd4d7b5



Example of formatting BEFORE this PR:
![IMG_7431](https://github.com/rainbow-me/rainbow/assets/1285228/a31e357b-814d-42b6-98bb-d991aa8ae8cb)
![IMG_7429](https://github.com/rainbow-me/rainbow/assets/1285228/dfc26e5a-540e-4178-ac02-4676834357d3)
![IMG_7430](https://github.com/rainbow-me/rainbow/assets/1285228/513b2219-fc6e-488c-85db-335646b83324)


Example of formatting AFTER this PR:
![eth=25](https://github.com/rainbow-me/rainbow/assets/1285228/401e7d1b-e677-4224-bf9a-aa06ee45940d)
![eth-50](https://github.com/rainbow-me/rainbow/assets/1285228/41793c46-8bcc-410b-a838-47df702daf31)
![eth-75](https://github.com/rainbow-me/rainbow/assets/1285228/1c3e661e-449a-4c49-ab05-87362c374dce)



