### PR TITLE
Remove filtering of assetToSell from search currency lists

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -29,29 +29,21 @@ const MAX_VERIFIED_RESULTS = 48;
 const filterAssetsFromBridgeAndAssetToSell = ({
   assets,
   filteredBridgeAssetAddress,
-  assetToSellAddress,
 }: {
   assets: SearchAsset[] | undefined;
   filteredBridgeAssetAddress: string | undefined;
-  assetToSellAddress: string | undefined;
-}): SearchAsset[] =>
-  assets?.filter(
-    curatedAsset =>
-      !isLowerCaseMatch(curatedAsset?.address, filteredBridgeAssetAddress) && !isLowerCaseMatch(curatedAsset?.address, assetToSellAddress)
-  ) || [];
+}): SearchAsset[] => assets?.filter(curatedAsset => !isLowerCaseMatch(curatedAsset?.address, filteredBridgeAssetAddress)) || [];
 
 const filterAssetsFromFavoritesBridgeAndAssetToSell = ({
   assets,
   favoritesList,
   filteredBridgeAssetAddress,
-  assetToSellAddress,
 }: {
   assets: SearchAsset[] | undefined;
   favoritesList: SearchAsset[] | undefined;
   filteredBridgeAssetAddress: string | undefined;
-  assetToSellAddress: string | undefined;
 }): SearchAsset[] =>
-  filterAssetsFromBridgeAndAssetToSell({ assets, filteredBridgeAssetAddress, assetToSellAddress })?.filter(
+  filterAssetsFromBridgeAndAssetToSell({ assets, filteredBridgeAssetAddress })?.filter(
     curatedAsset => !favoritesList?.some(({ address }) => curatedAsset.address === address || curatedAsset.mainnetAddress === address)
   ) || [];
 
@@ -65,9 +57,7 @@ const buildListSectionsData = ({
   combinedData,
   favoritesList,
   filteredBridgeAssetAddress,
-  assetToSellAddress,
 }: {
-  assetToSellAddress: string | undefined;
   combinedData: {
     bridgeAsset?: SearchAsset;
     verifiedAssets?: SearchAsset[];
@@ -94,7 +84,6 @@ const buildListSectionsData = ({
     const filteredFavorites = filterAssetsFromBridgeAndAssetToSell({
       assets: favoritesList,
       filteredBridgeAssetAddress,
-      assetToSellAddress,
     });
     addSection('favorites', filteredFavorites);
   }
@@ -104,7 +93,6 @@ const buildListSectionsData = ({
       assets: combinedData.verifiedAssets,
       favoritesList,
       filteredBridgeAssetAddress,
-      assetToSellAddress,
     });
     addSection('verified', filteredVerified);
   }
@@ -114,7 +102,6 @@ const buildListSectionsData = ({
       assets: combinedData.crosschainExactMatches,
       favoritesList,
       filteredBridgeAssetAddress,
-      assetToSellAddress,
     });
     addSection('other_networks', filteredCrosschain);
   }
@@ -124,7 +111,6 @@ const buildListSectionsData = ({
       assets: combinedData.unverifiedAssets,
       favoritesList,
       filteredBridgeAssetAddress,
-      assetToSellAddress,
     });
     addSection('unverified', filteredUnverified);
   }
@@ -150,7 +136,6 @@ export function useSearchCurrencyLists() {
   const query = useSwapsStore(state => state.outputSearchQuery.trim().toLowerCase());
 
   const [state, setState] = useState({
-    assetToSellAddress: assetToSell.value?.[assetToSell.value?.chainId === ChainId.mainnet ? 'mainnetAddress' : 'address'],
     fromChainId: assetToSell.value ? assetToSell.value.chainId ?? ChainId.mainnet : undefined,
     isCrosschainSearch: assetToSell.value ? assetToSell.value.chainId !== selectedOutputChainId.value : false,
     toChainId: selectedOutputChainId.value ?? ChainId.mainnet,
@@ -168,7 +153,6 @@ export function useSearchCurrencyLists() {
     (current, previous) => {
       if (previous && (current.isCrosschainSearch !== previous.isCrosschainSearch || current.toChainId !== previous.toChainId)) {
         runOnJS(debouncedStateSet)({
-          assetToSellAddress: assetToSell.value?.[assetToSell.value?.chainId === ChainId.mainnet ? 'mainnetAddress' : 'address'],
           fromChainId: assetToSell.value ? assetToSell.value.chainId ?? ChainId.mainnet : undefined,
           isCrosschainSearch: current.isCrosschainSearch,
           toChainId: current.toChainId,
@@ -314,7 +298,6 @@ export function useSearchCurrencyLists() {
 
     return {
       results: buildListSectionsData({
-        assetToSellAddress: state.assetToSellAddress,
         combinedData: {
           bridgeAsset: bridgeResult,
           crosschainExactMatches: crosschainMatches,
@@ -334,7 +317,6 @@ export function useSearchCurrencyLists() {
     memoizedData.filteredBridgeAsset,
     query,
     selectedOutputChainId.value,
-    state.assetToSellAddress,
     unverifiedAssets,
     verifiedAssets,
   ]);


### PR DESCRIPTION
Fixes APP-1663

## What changed (plus any additional context for devs)
We decided to remove the filtering out of the assetToSell from the currency lists. This makes it more convenient for when you want to switch the default input asset over to the output asset without having to first select a different asset and then flip.

## What to test
- if you open the Swap flow from the main wallet screen and have a default asset of ETH, change the input asset to an ERC20. You should still be able to see ETH as an option in the output asset.
- flip back and forth, select ETH as the output asset, etc - this should behave as expected while keeping the assetToSell still showing up as an option in the output currency list.

## Screen recordings / screenshots
https://github.com/rainbow-me/rainbow/assets/1285228/ee8b3efa-4b93-49c8-991e-95f19a4efa2d


