### PR TITLE
Convert swap warning to derived value

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapWarning.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapWarning.ts
@@ -82,13 +82,13 @@ export const useSwapWarning = ({ inputAsset, outputAsset, inputValues, quote, is
     [label, orange, red]
   );
 
+  const NO_WARNING = { type: SwapWarningType.none, title: '', color: colorMap[SwapWarningType.none], icon: '', subtitle: '' };
+
   const swapWarning = useDerivedValue<SwapWarning>(() => {
-    const noWarning = { type: SwapWarningType.none, title: '', color: colorMap[SwapWarningType.none], icon: '', subtitle: '' };
-
     const doInputAndOutputAssetsExist = inputAsset.value && outputAsset.value;
-    if (!doInputAndOutputAssetsExist) return noWarning;
+    if (!doInputAndOutputAssetsExist) return NO_WARNING;
 
-    if (isQuoteStale.value || isFetching.value || !quote.value) return noWarning;
+    if (isQuoteStale.value || isFetching.value || !quote.value) return NO_WARNING;
 
     const inputNativeValue = inputValues.value.inputNativeValue;
     const outputNativeValue = inputValues.value.outputNativeValue;
@@ -155,7 +155,7 @@ export const useSwapWarning = ({ inputAsset, outputAsset, inputValues, quote, is
       };
     }
 
-    return noWarning;
+    return NO_WARNING;
   });
 
   return { swapWarning };

--- a/src/__swaps__/screens/Swap/hooks/useSwapWarning.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapWarning.ts
@@ -1,5 +1,5 @@
-import { useCallback, useMemo } from 'react';
-import { SharedValue, useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
+import { useMemo } from 'react';
+import { SharedValue, useDerivedValue } from 'react-native-reanimated';
 import * as i18n from '@/languages';
 import { useAccountSettings } from '@/hooks';
 import { useForegroundColor } from '@/design-system';
@@ -23,8 +23,6 @@ export enum SwapWarningType {
   no_route_found = 504,
 }
 
-export type NonErrorCodeTypes = 'unknown' | 'high' | 'severe' | 'none' | 'long_wait';
-
 export interface SwapWarning {
   icon: string;
   type: SwapWarningType;
@@ -33,28 +31,13 @@ export interface SwapWarning {
   color: string;
 }
 
-export interface SwapTimeEstimate {
-  isLongWait: boolean;
-  timeEstimate?: number;
-  timeEstimateDisplay: string;
-}
-
 type UsePriceImpactWarningProps = {
   inputAsset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
   inputValues: SharedValue<inputValuesType>;
   outputAsset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
   quote: SharedValue<Quote | CrosschainQuote | QuoteError | null>;
-  sliderXPosition: SharedValue<number>;
   isFetching: SharedValue<boolean>;
   isQuoteStale: SharedValue<number>;
-};
-
-type CurrentProps = {
-  inputNativeValue: string | number;
-  outputNativeValue: string | number;
-  quote: Quote | CrosschainQuote | QuoteError | null;
-  isFetching: boolean;
-  sliderXPosition: number;
 };
 
 const I18N_WARNINGS = {
@@ -76,24 +59,11 @@ const I18N_WARNINGS = {
   },
 };
 
-export const useSwapWarning = ({
-  inputAsset,
-  outputAsset,
-  inputValues,
-  quote,
-  isFetching,
-  isQuoteStale,
-  sliderXPosition,
-}: UsePriceImpactWarningProps) => {
+export const useSwapWarning = ({ inputAsset, outputAsset, inputValues, quote, isFetching, isQuoteStale }: UsePriceImpactWarningProps) => {
   const { nativeCurrency: currentCurrency } = useAccountSettings();
   const red = useForegroundColor('red');
   const orange = useForegroundColor('orange');
   const label = useForegroundColor('labelTertiary');
-
-  const swapWarning = useSharedValue<SwapWarning>({ type: SwapWarningType.none, title: '', color: label, icon: '', subtitle: '' });
-
-  // TODO: Can remove this if not needed elsewhere, but thought it might be useful.
-  const timeEstimate = useSharedValue<SwapTimeEstimate | null>(null);
 
   const colorMap: Record<string, string> = useMemo(
     () => ({
@@ -112,108 +82,81 @@ export const useSwapWarning = ({
     [label, orange, red]
   );
 
-  const updateWarningWorklet = useCallback(
-    (values: SwapWarning) => {
-      'worklet';
-      swapWarning.modify(prev => ({ ...prev, ...values }));
-    },
-    [swapWarning]
-  );
+  const swapWarning = useDerivedValue<SwapWarning>(() => {
+    const noWarning = { type: SwapWarningType.none, title: '', color: colorMap[SwapWarningType.none], icon: '', subtitle: '' };
 
-  const getWarningWorklet = useCallback(
-    ({ inputNativeValue, outputNativeValue, quote, isFetching }: CurrentProps) => {
-      'worklet';
+    const doInputAndOutputAssetsExist = inputAsset.value && outputAsset.value;
+    if (!doInputAndOutputAssetsExist) return noWarning;
 
-      const nativeAmountImpact = subWorklet(inputNativeValue, outputNativeValue);
-      const impactInPercentage = Number(inputNativeValue) === 0 ? '0' : divWorklet(nativeAmountImpact, inputNativeValue);
+    if (isQuoteStale.value || isFetching.value || !quote.value) return noWarning;
 
-      const priceImpactDisplay = convertAmountToNativeDisplayWorklet(nativeAmountImpact, currentCurrency);
-      const isSomeInputGreaterThanZero = Number(inputValues.value.inputAmount) > 0 || Number(inputValues.value.outputAmount) > 0;
+    const inputNativeValue = inputValues.value.inputNativeValue;
+    const outputNativeValue = inputValues.value.outputNativeValue;
+    const inputNativePrice = inputAsset.value?.nativePrice;
+    const outputNativePrice = outputAsset.value?.nativePrice;
 
-      if (!isFetching && (quote as QuoteError)?.error) {
-        const quoteError = quote as QuoteError;
-        const errorType: SwapWarningType = quoteError.error_code || SwapWarningType.no_quote_available;
-        const title = I18N_WARNINGS.titles[errorType];
-        updateWarningWorklet({ type: errorType, title, color: colorMap[errorType], icon: '􀇿', subtitle: '' });
-      } else if (
-        isSomeInputGreaterThanZero &&
-        !isFetching &&
-        !!quote &&
-        !(quote as QuoteError)?.error &&
-        (!inputNativeValue || !outputNativeValue)
-      ) {
-        updateWarningWorklet({
-          type: SwapWarningType.unknown,
-          icon: '􀇿',
-          title: I18N_WARNINGS.titles[SwapWarningType.unknown],
-          subtitle: I18N_WARNINGS.subtitles[SwapWarningType.unknown],
-          color: colorMap[SwapWarningType.unknown],
-        });
-      } else if (!isFetching && !!quote && greaterThanOrEqualToWorklet(impactInPercentage, severePriceImpactThreshold.toString())) {
-        updateWarningWorklet({
-          type: SwapWarningType.severe,
-          icon: '􀇿',
-          title: `${I18N_WARNINGS.titles[SwapWarningType.severe]} ${priceImpactDisplay}`,
-          subtitle: I18N_WARNINGS.subtitles[SwapWarningType.severe],
-          color: colorMap[SwapWarningType.severe],
-        });
-      } else if (!isFetching && !!quote && greaterThanOrEqualToWorklet(impactInPercentage, highPriceImpactThreshold.toString())) {
-        updateWarningWorklet({
-          type: SwapWarningType.high,
-          icon: '􀇿',
-          title: `${I18N_WARNINGS.titles[SwapWarningType.high]} ${priceImpactDisplay}`,
-          subtitle: I18N_WARNINGS.subtitles[SwapWarningType.high],
-          color: colorMap[SwapWarningType.high],
-        });
-      } else if (!!quote && !(quote as QuoteError)?.error) {
-        const serviceTime = getQuoteServiceTimeWorklet({ quote: quote as CrosschainQuote });
-        const estimatedTimeOfArrival = serviceTime ? getCrossChainTimeEstimateWorklet({ serviceTime }) : null;
-        if (estimatedTimeOfArrival?.isLongWait) {
-          updateWarningWorklet({
-            type: SwapWarningType.long_wait,
-            icon: '􀇿',
-            title: I18N_WARNINGS.titles[SwapWarningType.long_wait],
-            subtitle: `${I18N_WARNINGS.subtitles[SwapWarningType.long_wait]} ${estimatedTimeOfArrival.timeEstimateDisplay}`,
-            color: colorMap[SwapWarningType.long_wait],
-          });
-        } else {
-          updateWarningWorklet({ type: SwapWarningType.none, title: '', color: colorMap[SwapWarningType.none], icon: '', subtitle: '' });
-        }
-      } else {
-        updateWarningWorklet({ type: SwapWarningType.none, title: '', color: colorMap[SwapWarningType.none], icon: '', subtitle: '' });
-      }
-    },
-    [colorMap, currentCurrency, inputValues, updateWarningWorklet]
-  );
+    const nativeAmountImpact = subWorklet(inputNativeValue, outputNativeValue);
+    const impactInPercentage = Number(inputNativeValue) === 0 ? '0' : divWorklet(nativeAmountImpact, inputNativeValue);
 
-  useAnimatedReaction(
-    () => ({
-      isFetching: isFetching.value,
-      isQuoteStale: isQuoteStale.value,
-      quote: quote.value,
-      sliderXPosition: sliderXPosition.value,
-    }),
-    (current, previous) => {
-      const doInputAndOutputAssetsExist = inputAsset.value && outputAsset.value;
-      if (!doInputAndOutputAssetsExist) return;
+    const priceImpactDisplay = convertAmountToNativeDisplayWorklet(nativeAmountImpact, currentCurrency);
+    const isSomeInputGreaterThanZero = Number(inputValues.value.inputAmount) > 0 || Number(inputValues.value.outputAmount) > 0;
 
-      if (
-        (swapWarning.value.type !== SwapWarningType.none && current.isQuoteStale) ||
-        current.isFetching ||
-        (previous?.sliderXPosition && previous?.sliderXPosition !== current.sliderXPosition)
-      ) {
-        updateWarningWorklet({ type: SwapWarningType.none, title: '', color: colorMap[SwapWarningType.none], icon: '', subtitle: '' });
-      } else if (!current.isQuoteStale && !current.isFetching && previous?.sliderXPosition === current.sliderXPosition) {
-        getWarningWorklet({
-          inputNativeValue: inputValues.value.inputNativeValue,
-          outputNativeValue: inputValues.value.outputNativeValue,
-          quote: current.quote,
-          isFetching: current.isFetching,
-          sliderXPosition: current.sliderXPosition,
-        });
-      }
+    // quote error
+    const quoteError = quote.value as QuoteError;
+    if (quoteError.error) {
+      const errorType: SwapWarningType = quoteError.error_code || SwapWarningType.no_quote_available;
+      const title = I18N_WARNINGS.titles[errorType];
+      return { type: errorType, title, color: colorMap[errorType], icon: '􀇿', subtitle: '' };
     }
-  );
 
-  return { swapWarning, timeEstimate };
+    // missing asset native price
+    if (isSomeInputGreaterThanZero && (!inputNativePrice || !outputNativePrice)) {
+      return {
+        type: SwapWarningType.unknown,
+        icon: '􀇿',
+        title: I18N_WARNINGS.titles[SwapWarningType.unknown],
+        subtitle: I18N_WARNINGS.subtitles[SwapWarningType.unknown],
+        color: colorMap[SwapWarningType.unknown],
+      };
+    }
+
+    // severe price impact
+    if (greaterThanOrEqualToWorklet(impactInPercentage, severePriceImpactThreshold.toString())) {
+      return {
+        type: SwapWarningType.severe,
+        icon: '􀇿',
+        title: `${I18N_WARNINGS.titles[SwapWarningType.severe]} ${priceImpactDisplay}`,
+        subtitle: I18N_WARNINGS.subtitles[SwapWarningType.severe],
+        color: colorMap[SwapWarningType.severe],
+      };
+    }
+
+    // high price impact
+    if (greaterThanOrEqualToWorklet(impactInPercentage, highPriceImpactThreshold.toString())) {
+      return {
+        type: SwapWarningType.high,
+        icon: '􀇿',
+        title: `${I18N_WARNINGS.titles[SwapWarningType.high]} ${priceImpactDisplay}`,
+        subtitle: I18N_WARNINGS.subtitles[SwapWarningType.high],
+        color: colorMap[SwapWarningType.high],
+      };
+    }
+
+    // long wait
+    const serviceTime = getQuoteServiceTimeWorklet({ quote: quote.value as CrosschainQuote });
+    const estimatedTimeOfArrival = serviceTime ? getCrossChainTimeEstimateWorklet({ serviceTime }) : null;
+    if (estimatedTimeOfArrival?.isLongWait) {
+      return {
+        type: SwapWarningType.long_wait,
+        icon: '􀇿',
+        title: I18N_WARNINGS.titles[SwapWarningType.long_wait],
+        subtitle: `${I18N_WARNINGS.subtitles[SwapWarningType.long_wait]} ${estimatedTimeOfArrival.timeEstimateDisplay}`,
+        color: colorMap[SwapWarningType.long_wait],
+      };
+    }
+
+    return noWarning;
+  });
+
+  return { swapWarning };
 };

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -397,7 +397,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     inputValues: SwapInputController.inputValues,
     outputAsset: internalSelectedOutputAsset,
     quote,
-    sliderXPosition,
     isFetching,
     isQuoteStale,
   });


### PR DESCRIPTION
Fixes APP-1671

## What changed (plus any additional context for devs)
- updated the swap warning to be a derived value instead of an animated reaction
- removed the unused `SwapTimeEstimate` from the `useSwapWarning` hook
- simplified the logic for calculating the swap warning states

## What to test
- update the output amount to 0 and then to "0.1" - there should be no flashing of a swap warning
- updating the inputs from the slider / input amount / output amount should behave as expected without any weird flashes
- updating an input amount to some crazy high amount should show a swap warning as expected

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbow/assets/1285228/845d7389-4794-4918-b439-b1d3c47efa94





