### PR TITLE
target ci-8

### DIFF
--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -64,7 +64,11 @@ jobs:
 
       - name: Rebuild detox cache
         run: ./node_modules/.bin/detox clean-framework-cache && ./node_modules/.bin/detox build-framework-cache
-
+      
+      - name: Version debug
+        run: |
+          npx react-native info
+      
       - name: Install pods
         run: yarn install-bundle && yarn install-pods
 
@@ -72,10 +76,6 @@ jobs:
         run: |
           chmod -R +x node_modules/react-native/scripts
           chmod -R +x node_modules/@sentry/react-native/scripts
-     
-      - name: Version debug
-        run: |
-          npx react-native info
 
       - name: Build the app in release mode
         run: yarn detox build --configuration ios.sim.release

--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -3,7 +3,7 @@ name: iOS e2e tests
 on: [pull_request, workflow_dispatch]
 jobs:
   ios-e2e:
-    runs-on: ["self-hosted", "CI-8"]
+    runs-on: ["self-hosted", "CI-8", "CI-9"]
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -3,7 +3,7 @@ name: iOS e2e tests
 on: [pull_request, workflow_dispatch]
 jobs:
   ios-e2e:
-    runs-on: ["self-hosted", "CI-9"]
+    runs-on: ["self-hosted", "CI-8"]
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Temporarily targets CI-8 and CI-9 which are ready to build with the latest stack required for RN 0.74.3



## Screen recordings / screenshots
Here's a run on CI-8 where it got as far as running the tests which is everything we need
https://github.com/rainbow-me/rainbow/actions/runs/10046640311/job/27766537609

## What to test

