### PR TITLE
Enable CI-7

### DIFF
--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -3,7 +3,7 @@ name: iOS e2e tests
 on: [pull_request, workflow_dispatch]
 jobs:
   ios-e2e:
-    runs-on: ["self-hosted", "CI-7"]
+    runs-on: ["self-hosted"]
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/macstadium-e2e.yml
+++ b/.github/workflows/macstadium-e2e.yml
@@ -3,7 +3,7 @@ name: iOS e2e tests
 on: [pull_request, workflow_dispatch]
 jobs:
   ios-e2e:
-    runs-on: ["self-hosted", "CI-8", "CI-9"]
+    runs-on: ["self-hosted", "CI-7"]
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Fixes APP-1651

## What changed (plus any additional context for devs)
Removing the targeting since now all machines support RN 0.74.3

## Screen recordings / screenshots
Here's a run where the build passed on CI-7

https://github.com/rainbow-me/rainbow/actions/runs/10047236016/job/27769406454


## What to test

CI green

