### PR TITLE
prevent crash on explainer sheet if no read more link

### DIFF
--- a/src/screens/ExplainSheet.js
+++ b/src/screens/ExplainSheet.js
@@ -1021,8 +1021,8 @@ const ExplainSheet = () => {
   }, [goBack, params]);
 
   const handleReadMore = useCallback(() => {
-    Linking.openURL(explainSheetConfig.readMoreLink);
-  }, [explainSheetConfig.readMoreLink]);
+    explainSheetConfig?.readMoreLink && Linking.openURL(explainSheetConfig.readMoreLink);
+  }, [explainSheetConfig?.readMoreLink]);
 
   const EmojiText = type === 'verified' ? Gradient : Emoji;
   const Title = type === 'verified' ? Gradient : SheetTitle;


### PR DESCRIPTION
Fixes APP-1686

## What changed (plus any additional context for devs)
We had optionals everywhere except  here


## Screen recordings / screenshots
None


## What to test
Explainer sheets

