### PR TITLE
Add max swappable amount on balance badge tap

### DIFF
--- a/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
@@ -102,12 +102,7 @@ function InputAssetBalanceBadge() {
   });
 
   return (
-    <GestureHandlerV1Button
-      onPressWorklet={() => {
-        'worklet';
-        SwapInputController.setValueToMaxSwappableAmount('inputAmount');
-      }}
-    >
+    <GestureHandlerV1Button onPressWorklet={SwapInputController.setValueToMaxSwappableAmount}>
       <BalanceBadge label={label} />
     </GestureHandlerV1Button>
   );

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -131,7 +131,7 @@ function SwapOutputIcon() {
 }
 
 function OutputAssetBalanceBadge() {
-  const { internalSelectedOutputAsset, SwapInputController } = useSwapContext();
+  const { internalSelectedOutputAsset } = useSwapContext();
 
   const label = useDerivedValue(() => {
     const asset = internalSelectedOutputAsset.value;
@@ -141,16 +141,7 @@ function OutputAssetBalanceBadge() {
     return asset ? balance : TOKEN_TO_GET_LABEL;
   });
 
-  return (
-    <GestureHandlerV1Button
-      onPressWorklet={() => {
-        'worklet';
-        SwapInputController.setValueToMaxSwappableAmount('outputAmount');
-      }}
-    >
-      <BalanceBadge label={label} />
-    </GestureHandlerV1Button>
-  );
+  return <BalanceBadge label={label} />;
 }
 
 export function SwapOutputAsset() {

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -2,7 +2,7 @@ import { AnimatedText, Box, Column, Columns, Stack, useColorMode } from '@/desig
 import MaskedView from '@react-native-masked-view/masked-view';
 import React, { useCallback } from 'react';
 import { StatusBar, StyleSheet } from 'react-native';
-import Animated, { runOnJS, useDerivedValue } from 'react-native-reanimated';
+import Animated, { runOnJS, useDerivedValue, withSpring } from 'react-native-reanimated';
 import { ScreenCornerRadius } from 'react-native-screen-corner-radius';
 
 import { AnimatedSwapCoinIcon } from '@/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon';
@@ -12,7 +12,7 @@ import { GestureHandlerV1Button } from '@/__swaps__/screens/Swap/components/Gest
 import { SwapActionButton } from '@/__swaps__/screens/Swap/components/SwapActionButton';
 import { SwapInput } from '@/__swaps__/screens/Swap/components/SwapInput';
 import { TokenList } from '@/__swaps__/screens/Swap/components/TokenList/TokenList';
-import { BASE_INPUT_WIDTH, INPUT_INNER_WIDTH, INPUT_PADDING, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
+import { BASE_INPUT_WIDTH, INPUT_INNER_WIDTH, INPUT_PADDING, SLIDER_WIDTH, THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { IS_ANDROID, IS_IOS } from '@/env';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { ChainId } from '@/__swaps__/types/chains';
@@ -21,6 +21,9 @@ import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { ethereumUtils } from '@/utils';
+import { triggerHapticFeedback } from '@/screens/points/constants';
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
+import { equalWorklet } from '@/__swaps__/safe-math/SafeMath';
 
 const SELECT_LABEL = i18n.t(i18n.l.swap.select);
 const NO_BALANCE_LABEL = i18n.t(i18n.l.swap.no_balance);
@@ -105,7 +108,7 @@ function SwapOutputIcon() {
 }
 
 function OutputAssetBalanceBadge() {
-  const { internalSelectedOutputAsset } = useSwapContext();
+  const { internalSelectedOutputAsset, SwapInputController, sliderXPosition } = useSwapContext();
 
   const label = useDerivedValue(() => {
     const asset = internalSelectedOutputAsset.value;
@@ -115,7 +118,29 @@ function OutputAssetBalanceBadge() {
     return asset ? balance : TOKEN_TO_GET_LABEL;
   });
 
-  return <BalanceBadge label={label} />;
+  const onSetMaxBalance = () => {
+    'worklet';
+
+    const asset = internalSelectedOutputAsset.value;
+    if (!asset?.maxSwappableAmount || equalWorklet(asset.maxSwappableAmount, 0)) return;
+
+    const currentOutputValue = SwapInputController.inputValues.value.outputAmount;
+    const isAlreadyMax = equalWorklet(currentOutputValue, asset.maxSwappableAmount);
+    if (isAlreadyMax) {
+      runOnJS(triggerHapticFeedback)('impactMedium');
+      return;
+    }
+
+    SwapInputController.inputMethod.value = 'outputAmount';
+    SwapInputController.quoteFetchingInterval.stop();
+    SwapInputController.inputValues.modify(prev => ({ ...prev, outputAmount: asset.maxSwappableAmount }));
+  };
+
+  return (
+    <GestureHandlerV1Button onPressWorklet={onSetMaxBalance}>
+      <BalanceBadge label={label} />
+    </GestureHandlerV1Button>
+  );
 }
 
 export function SwapOutputAsset() {

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -418,10 +418,7 @@ export const SwapSlider = ({
                 </Inline>
                 <Column width="content">
                   <GestureHandlerV1Button
-                    onPressWorklet={() => {
-                      'worklet';
-                      SwapInputController.setValueToMaxSwappableAmount('inputAmount');
-                    }}
+                    onPressWorklet={SwapInputController.setValueToMaxSwappableAmount}
                     style={{ margin: -12, padding: 12 }}
                     ref={maxButtonRef}
                   >

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -22,7 +22,7 @@ import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animatio
 import { AnimatedText, Bleed, Box, Column, Columns, Inline, globalColors, useColorMode, useForegroundColor } from '@/design-system';
 import { IS_IOS } from '@/env';
 import { triggerHapticFeedback } from '@/screens/points/constants';
-import { equalWorklet, greaterThanWorklet } from '@/__swaps__/safe-math/SafeMath';
+import { greaterThanWorklet } from '@/__swaps__/safe-math/SafeMath';
 import {
   SCRUBBER_WIDTH,
   SLIDER_COLLAPSED_HEIGHT,
@@ -420,26 +420,7 @@ export const SwapSlider = ({
                   <GestureHandlerV1Button
                     onPressWorklet={() => {
                       'worklet';
-                      SwapInputController.inputMethod.value = 'slider';
-
-                      const currentInputValue = SwapInputController.inputValues.value.inputAmount;
-                      const maxSwappableAmount = internalSelectedInputAsset.value?.maxSwappableAmount;
-
-                      const isAlreadyMax = maxSwappableAmount ? equalWorklet(currentInputValue, maxSwappableAmount) : false;
-                      const exceedsMax = maxSwappableAmount ? greaterThanWorklet(currentInputValue, maxSwappableAmount) : false;
-
-                      if (isAlreadyMax) {
-                        runOnJS(triggerHapticFeedback)('impactMedium');
-                      } else {
-                        SwapInputController.quoteFetchingInterval.stop();
-                        if (exceedsMax) sliderXPosition.value = width * 0.999;
-
-                        sliderXPosition.value = withSpring(width, SPRING_CONFIGS.snappySpringConfig, isFinished => {
-                          if (isFinished) {
-                            runOnJS(onChangeWrapper)(1);
-                          }
-                        });
-                      }
+                      SwapInputController.setValueToMaxSwappableAmount('inputAmount');
                     }}
                     style={{ margin: -12, padding: 12 }}
                     ref={maxButtonRef}

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -574,60 +574,34 @@ export function useSwapInputsController({
     { leading: false, trailing: true }
   );
 
-  const setValueToMaxSwappableAmount = (inputkey: 'inputAmount' | 'outputAmount') => {
+  const setValueToMaxSwappableAmount = () => {
     'worklet';
 
-    switch (inputkey) {
-      case 'inputAmount': {
-        const currentInputValue = inputValues.value.inputAmount;
-        const maxSwappableAmount = internalSelectedInputAsset.value?.maxSwappableAmount;
-        if (!maxSwappableAmount || equalWorklet(maxSwappableAmount, 0)) {
-          runOnJS(triggerHapticFeedback)('impactMedium');
-          return;
-        }
-
-        const isAlreadyMax = maxSwappableAmount ? equalWorklet(currentInputValue, maxSwappableAmount) : false;
-        const exceedsMax = maxSwappableAmount ? greaterThanWorklet(currentInputValue, maxSwappableAmount) : false;
-        if (isAlreadyMax) {
-          runOnJS(triggerHapticFeedback)('impactMedium');
-          return;
-        }
-
-        quoteFetchingInterval.stop();
-        isQuoteStale.value = 1;
-        inputMethod.value = 'slider';
-
-        if (exceedsMax) sliderXPosition.value = SLIDER_WIDTH * 0.999;
-
-        sliderXPosition.value = withSpring(SLIDER_WIDTH, SPRING_CONFIGS.snappySpringConfig, isFinished => {
-          if (isFinished) {
-            runOnJS(onChangedPercentage)(1);
-          }
-        });
-        break;
-      }
-
-      case 'outputAmount': {
-        const currentOutputValue = inputValues.value.outputAmount;
-        const maxSwappableAmount = internalSelectedOutputAsset.value?.maxSwappableAmount;
-
-        if (outputQuotesAreDisabled.value || !maxSwappableAmount || equalWorklet(maxSwappableAmount, 0)) {
-          runOnJS(triggerHapticFeedback)('impactMedium');
-          return;
-        }
-
-        const isAlreadyMax = equalWorklet(currentOutputValue, maxSwappableAmount);
-        if (isAlreadyMax) {
-          runOnJS(triggerHapticFeedback)('impactMedium');
-          return;
-        }
-
-        quoteFetchingInterval.stop();
-        inputMethod.value = 'outputAmount';
-        inputValues.modify(values => ({ ...values, outputAmount: maxSwappableAmount }));
-        break;
-      }
+    const currentInputValue = inputValues.value.inputAmount;
+    const maxSwappableAmount = internalSelectedInputAsset.value?.maxSwappableAmount;
+    if (!maxSwappableAmount || equalWorklet(maxSwappableAmount, 0)) {
+      runOnJS(triggerHapticFeedback)('impactMedium');
+      return;
     }
+
+    const isAlreadyMax = maxSwappableAmount ? equalWorklet(currentInputValue, maxSwappableAmount) : false;
+    const exceedsMax = maxSwappableAmount ? greaterThanWorklet(currentInputValue, maxSwappableAmount) : false;
+    if (isAlreadyMax) {
+      runOnJS(triggerHapticFeedback)('impactMedium');
+      return;
+    }
+
+    quoteFetchingInterval.stop();
+    isQuoteStale.value = 1;
+    inputMethod.value = 'slider';
+
+    if (exceedsMax) sliderXPosition.value = SLIDER_WIDTH * 0.999;
+
+    sliderXPosition.value = withSpring(SLIDER_WIDTH, SPRING_CONFIGS.snappySpringConfig, isFinished => {
+      if (isFinished) {
+        runOnJS(onChangedPercentage)(1);
+      }
+    });
   };
 
   const resetValuesToZeroWorklet = (inputKey?: inputKeys) => {

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -1,14 +1,5 @@
 import { useCallback } from 'react';
-import {
-  DerivedValue,
-  SharedValue,
-  runOnJS,
-  runOnUI,
-  useAnimatedReaction,
-  useDerivedValue,
-  useSharedValue,
-  withSpring,
-} from 'react-native-reanimated';
+import { SharedValue, runOnJS, runOnUI, useAnimatedReaction, useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useDebouncedCallback } from 'use-debounce';
 import { SCRUBBER_WIDTH, SLIDER_WIDTH, snappySpringConfig } from '@/__swaps__/screens/Swap/constants';
 import { RequestNewQuoteParams, inputKeys, inputMethods, inputValuesType } from '@/__swaps__/types/swap';
@@ -83,7 +74,6 @@ export function useSwapInputsController({
   quote,
   sliderXPosition,
   slippage,
-  outputQuotesAreDisabled,
 }: {
   focusedInput: SharedValue<inputKeys>;
   inputProgress: SharedValue<number>;
@@ -97,7 +87,6 @@ export function useSwapInputsController({
   quote: SharedValue<Quote | CrosschainQuote | QuoteError | null>;
   sliderXPosition: SharedValue<number>;
   slippage: SharedValue<string>;
-  outputQuotesAreDisabled: DerivedValue<boolean>;
 }) {
   const percentageToSwap = useDerivedValue(() => {
     return Math.round(clamp((sliderXPosition.value - SCRUBBER_WIDTH / SLIDER_WIDTH) / SLIDER_WIDTH, 0, 1) * 100) / 100;

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -181,7 +181,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     sliderXPosition,
     slippage: SwapSettings.slippage,
     quote,
-    outputQuotesAreDisabled,
   });
 
   const getNonceAndPerformSwap = async ({
@@ -397,6 +396,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     quoteFetchingInterval: SwapInputController.quoteFetchingInterval,
     selectedInputAsset: internalSelectedInputAsset,
     selectedOutputAsset: internalSelectedOutputAsset,
+    isDegenMode: SwapSettings.degenMode,
   });
 
   const SwapWarning = useSwapWarning({

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -159,11 +159,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
   );
   const configProgress = useSharedValue<NavigationSteps>(NavigationSteps.INPUT_ELEMENT_FOCUSED);
 
-  const outputQuotesAreDisabled = useSwapOutputQuotesDisabled({
-    inputAsset: internalSelectedInputAsset,
-    outputAsset: internalSelectedOutputAsset,
-  });
-
   const SwapSettings = useSwapSettings({
     inputAsset: internalSelectedInputAsset,
   });
@@ -416,6 +411,11 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     outputProgress,
     configProgress,
     isFetching,
+  });
+
+  const outputQuotesAreDisabled = useSwapOutputQuotesDisabled({
+    inputAsset: internalSelectedInputAsset,
+    outputAsset: internalSelectedOutputAsset,
   });
 
   const swapInfo = useDerivedValue(() => {

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -159,6 +159,11 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
   );
   const configProgress = useSharedValue<NavigationSteps>(NavigationSteps.INPUT_ELEMENT_FOCUSED);
 
+  const outputQuotesAreDisabled = useSwapOutputQuotesDisabled({
+    inputAsset: internalSelectedInputAsset,
+    outputAsset: internalSelectedOutputAsset,
+  });
+
   const SwapSettings = useSwapSettings({
     inputAsset: internalSelectedInputAsset,
   });
@@ -176,6 +181,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     sliderXPosition,
     slippage: SwapSettings.slippage,
     quote,
+    outputQuotesAreDisabled,
   });
 
   const getNonceAndPerformSwap = async ({
@@ -410,11 +416,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     outputProgress,
     configProgress,
     isFetching,
-  });
-
-  const outputQuotesAreDisabled = useSwapOutputQuotesDisabled({
-    inputAsset: internalSelectedInputAsset,
-    outputAsset: internalSelectedOutputAsset,
   });
 
   const swapInfo = useDerivedValue(() => {


### PR DESCRIPTION
Fixes APP-1557

## What changed (plus any additional context for devs)
Adds balance badge press setting max swappable amount for asset if user has balance.

Note I also added the functionality to output balance badge.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/d123c20e-914d-496d-87ab-3729aa14e1e5



## What to test

