### PR TITLE
Update flipping logic in SwapInputsController

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -853,8 +853,15 @@ export function useSwapInputsController({
         sliderXPosition: sliderXPosition.value,
       });
       newInputAmount = inputAmountBasedOnSlider;
-      newOutputAmount = 0;
       inputMethod.value = 'slider';
+      inputValues.modify(values => {
+        return {
+          ...values,
+          inputAmount: newInputAmount,
+          inputNativeValue: mulWorklet(newInputAmount, inputNativePrice),
+        };
+      });
+      return;
     } else {
       inputMethod.value = 'inputAmount';
       const prevOutputAmount = inputValues.value.outputAmount;

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -593,7 +593,7 @@ export function useSwapInputsController({
     });
   };
 
-  const resetValuesToZeroWorklet = (inputKey?: inputKeys) => {
+  const resetValuesToZeroWorklet = ({ updateSlider, inputKey }: { updateSlider: boolean; inputKey?: inputKeys }) => {
     'worklet';
     quoteFetchingInterval.stop();
     if (isFetching.value) isFetching.value = false;
@@ -620,7 +620,7 @@ export function useSwapInputsController({
       [inputKey]: hasDecimal ? inputKeyValue : 0,
     }));
 
-    sliderXPosition.value = withSpring(0, snappySpringConfig);
+    if (updateSlider) sliderXPosition.value = withSpring(0, snappySpringConfig);
   };
 
   const debouncedFetchQuote = useDebouncedCallback(
@@ -712,7 +712,7 @@ export function useSwapInputsController({
         if (inputMethod.value === 'slider' && internalSelectedInputAsset.value && current.sliderXPosition !== previous.sliderXPosition) {
           // If the slider position changes
           if (percentageToSwap.value === 0) {
-            resetValuesToZeroWorklet();
+            resetValuesToZeroWorklet({ updateSlider: false });
           } else {
             // If the change set the slider position to > 0
             if (!internalSelectedInputAsset.value) return;
@@ -752,7 +752,7 @@ export function useSwapInputsController({
           lastTypedInput.value = 'inputAmount';
           if (equalWorklet(current.values.inputAmount, 0)) {
             // If the input amount was set to 0
-            resetValuesToZeroWorklet('inputAmount');
+            resetValuesToZeroWorklet({ updateSlider: true, inputKey: 'inputAmount' });
           } else {
             // If the input amount was set to a non-zero value
             if (!internalSelectedInputAsset.value) return;
@@ -788,7 +788,7 @@ export function useSwapInputsController({
           lastTypedInput.value = 'outputAmount';
           if (equalWorklet(current.values.outputAmount, 0)) {
             // If the output amount was set to 0
-            resetValuesToZeroWorklet('outputAmount');
+            resetValuesToZeroWorklet({ updateSlider: true, inputKey: 'outputAmount' });
           } else if (greaterThanWorklet(current.values.outputAmount, 0)) {
             // If the output amount was set to a non-zero value
             if (isQuoteStale.value !== 1) isQuoteStale.value = 1;
@@ -836,17 +836,7 @@ export function useSwapInputsController({
 
         // Handle when there is no balance for the input
         if (!balance || equalWorklet(balance, 0)) {
-          isQuoteStale.value = 0;
-          isFetching.value = false;
-          inputValues.modify(values => {
-            return {
-              ...values,
-              inputAmount: 0,
-              inputNativeValue: 0,
-              outputAmount: 0,
-              outputNativeValue: 0,
-            };
-          });
+          resetValuesToZeroWorklet({ updateSlider: true });
           return;
         }
 

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -668,6 +668,8 @@ export function useSwapInputsController({
           percentageToSwap,
           sliderXPosition,
           inputMethod,
+          lastTypedInput,
+          focusedInput,
         });
       }
 

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -821,8 +821,8 @@ export function useSwapInputsController({
 
     const prevInputNativeValue = inputValues.value.inputNativeValue;
 
-    const outputBalance = internalSelectedOutputAsset.value?.maxSwappableAmount;
-    const hasOutputBalance = outputBalance && greaterThanWorklet(outputBalance, 0);
+    const outputBalance = internalSelectedOutputAsset.value?.maxSwappableAmount || 0;
+    const hasOutputBalance = greaterThanWorklet(outputBalance, 0);
 
     let newInputAmount: string | number = greaterThanWorklet(inputNativePrice, 0) ? divWorklet(prevInputNativeValue, inputNativePrice) : 0;
     let newOutputAmount: string | number = 0;
@@ -830,7 +830,17 @@ export function useSwapInputsController({
     const exceedsMaxBalance = greaterThanWorklet(newInputAmount, inputBalance);
     const validBalanceIfAny = (hasInputBalance && !exceedsMaxBalance) || !hasInputBalance;
 
-    if (hasNonZeroInputPrice && hasNonZeroOutputPrice && validBalanceIfAny) {
+    // determine if we previously had max selected and can still set max on the new input
+    let setToMax = hasInputBalance && equalWorklet(percentageToSwap.value, 1);
+
+    /*
+    const prevInputAmount = inputValues.value.inputAmount;
+    if (hasInputBalance && hasOutputBalance && equalWorklet(prevInputAmount, outputBalance)) {
+      isNotMax = false;
+    }
+   */
+
+    if (hasNonZeroInputPrice && hasNonZeroOutputPrice && validBalanceIfAny && !setToMax) {
       // use previous native input amount if available
       const formattedInputAmount = Number(
         valueBasedDecimalFormatter({

--- a/src/__swaps__/utils/flipAssets.ts
+++ b/src/__swaps__/utils/flipAssets.ts
@@ -1,0 +1,133 @@
+import { SharedValue } from 'react-native-reanimated';
+import { inputMethods, inputValuesType } from '@/__swaps__/types/swap';
+import { valueBasedDecimalFormatter } from '@/__swaps__/utils/decimalFormatter';
+import { niceIncrementFormatter } from '@/__swaps__/utils/swaps';
+import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import { divWorklet, equalWorklet, greaterThanWorklet, mulWorklet } from '@/__swaps__/safe-math/SafeMath';
+
+export function getInputValuesForSliderPositionWorklet({
+  selectedInputAsset,
+  percentageToSwap,
+  sliderXPosition,
+}: {
+  selectedInputAsset: ExtendedAnimatedAssetWithColors | null;
+  percentageToSwap: number;
+  sliderXPosition: number;
+}) {
+  'worklet';
+  const inputAssetMaxSwappableBalance = selectedInputAsset?.maxSwappableAmount || 0;
+  const isStablecoin = selectedInputAsset?.type === 'stablecoin';
+
+  const inputAmount = niceIncrementFormatter({
+    inputAssetBalance: inputAssetMaxSwappableBalance,
+    inputAssetNativePrice: selectedInputAsset?.price?.value ?? 0,
+    percentageToSwap,
+    sliderXPosition,
+    stripSeparators: true,
+    isStablecoin,
+  });
+
+  const inputNativeValue = mulWorklet(inputAmount, selectedInputAsset?.price?.value ?? 0);
+
+  return {
+    inputAmount,
+    inputNativeValue,
+  };
+}
+
+export const updateInputValuesAfterFlip = ({
+  internalSelectedInputAsset,
+  internalSelectedOutputAsset,
+  inputValues,
+  percentageToSwap,
+  sliderXPosition,
+  inputMethod,
+}: {
+  internalSelectedInputAsset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
+  internalSelectedOutputAsset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
+  inputValues: SharedValue<inputValuesType>;
+  percentageToSwap: SharedValue<number>;
+  sliderXPosition: SharedValue<number>;
+  inputMethod: SharedValue<inputMethods>;
+}) => {
+  'worklet';
+  const inputNativePrice = internalSelectedInputAsset.value?.nativePrice || internalSelectedInputAsset.value?.price?.value || 0;
+  const outputNativePrice = internalSelectedOutputAsset.value?.nativePrice || internalSelectedOutputAsset.value?.price?.value || 0;
+  const hasNonZeroInputPrice = greaterThanWorklet(inputNativePrice, 0);
+  const hasNonZeroOutputPrice = greaterThanWorklet(outputNativePrice, 0);
+
+  const inputBalance = internalSelectedInputAsset.value?.maxSwappableAmount || 0;
+  const hasInputBalance = greaterThanWorklet(inputBalance, 0);
+
+  const prevInputNativeValue = inputValues.value.inputNativeValue;
+
+  const outputBalance = internalSelectedOutputAsset.value?.maxSwappableAmount || 0;
+  const hasOutputBalance = greaterThanWorklet(outputBalance, 0);
+
+  let newInputAmount: string | number = greaterThanWorklet(inputNativePrice, 0) ? divWorklet(prevInputNativeValue, inputNativePrice) : 0;
+  let newOutputAmount: string | number = 0;
+
+  const exceedsMaxBalance = greaterThanWorklet(newInputAmount, inputBalance);
+  const validBalanceIfAny = (hasInputBalance && !exceedsMaxBalance) || !hasInputBalance;
+
+  // determine if we previously had max selected and can still set max on the new input
+  const prevInputAmount = inputValues.value.inputAmount;
+  const setToMax = hasInputBalance && hasOutputBalance && equalWorklet(prevInputAmount, outputBalance);
+
+  if (hasNonZeroInputPrice && hasNonZeroOutputPrice && validBalanceIfAny && !setToMax) {
+    // use previous native input amount if available
+    const formattedInputAmount = Number(
+      valueBasedDecimalFormatter({
+        amount: newInputAmount,
+        nativePrice: inputNativePrice,
+        roundingMode: 'up',
+        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin',
+        stripSeparators: true,
+      })
+    );
+    newInputAmount = formattedInputAmount;
+    const prevOutputNativeValue = inputValues.value.outputNativeValue;
+    newOutputAmount = divWorklet(prevOutputNativeValue, outputNativePrice);
+    inputMethod.value = 'inputAmount';
+  } else if (hasInputBalance && hasOutputBalance) {
+    // use slider position if available
+    const { inputAmount: inputAmountBasedOnSlider } = getInputValuesForSliderPositionWorklet({
+      selectedInputAsset: internalSelectedInputAsset.value,
+      percentageToSwap: percentageToSwap.value,
+      sliderXPosition: sliderXPosition.value,
+    });
+    newInputAmount = inputAmountBasedOnSlider;
+    inputMethod.value = 'slider';
+    inputValues.modify(values => {
+      return {
+        ...values,
+        inputAmount: newInputAmount,
+        inputNativeValue: mulWorklet(newInputAmount, inputNativePrice),
+      };
+    });
+    return;
+  } else {
+    inputMethod.value = 'inputAmount';
+    const prevOutputAmount = inputValues.value.outputAmount;
+
+    if (prevOutputAmount) {
+      // use previous output amount if available
+      newInputAmount = prevOutputAmount;
+      newOutputAmount = prevInputAmount;
+    } else {
+      // otherwise, reset to 0
+      newInputAmount = 0;
+      newOutputAmount = 0;
+    }
+  }
+
+  inputValues.modify(values => {
+    return {
+      ...values,
+      inputAmount: newInputAmount,
+      inputNativeValue: mulWorklet(newInputAmount, inputNativePrice),
+      outputAmount: newOutputAmount,
+      outputNativeValue: mulWorklet(newOutputAmount, outputNativePrice),
+    };
+  });
+};

--- a/src/__swaps__/utils/flipAssets.ts
+++ b/src/__swaps__/utils/flipAssets.ts
@@ -1,5 +1,5 @@
 import { SharedValue } from 'react-native-reanimated';
-import { inputMethods, inputValuesType } from '@/__swaps__/types/swap';
+import { inputKeys, inputMethods, inputValuesType } from '@/__swaps__/types/swap';
 import { valueBasedDecimalFormatter } from '@/__swaps__/utils/decimalFormatter';
 import { niceIncrementFormatter } from '@/__swaps__/utils/swaps';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
@@ -42,6 +42,8 @@ export const updateInputValuesAfterFlip = ({
   percentageToSwap,
   sliderXPosition,
   inputMethod,
+  lastTypedInput,
+  focusedInput,
 }: {
   internalSelectedInputAsset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
   internalSelectedOutputAsset: SharedValue<ExtendedAnimatedAssetWithColors | null>;
@@ -49,6 +51,8 @@ export const updateInputValuesAfterFlip = ({
   percentageToSwap: SharedValue<number>;
   sliderXPosition: SharedValue<number>;
   inputMethod: SharedValue<inputMethods>;
+  lastTypedInput: SharedValue<inputKeys>;
+  focusedInput: SharedValue<inputKeys>;
 }) => {
   'worklet';
   const inputNativePrice = internalSelectedInputAsset.value?.nativePrice || internalSelectedInputAsset.value?.price?.value || 0;
@@ -98,6 +102,8 @@ export const updateInputValuesAfterFlip = ({
     });
     newInputAmount = inputAmountBasedOnSlider;
     inputMethod.value = 'slider';
+    lastTypedInput.value = 'inputAmount';
+    focusedInput.value = 'inputAmount';
     inputValues.modify(values => {
       return {
         ...values,

--- a/src/__swaps__/utils/flipAssets.ts
+++ b/src/__swaps__/utils/flipAssets.ts
@@ -68,7 +68,18 @@ export const updateInputValuesAfterFlip = ({
   const outputBalance = internalSelectedOutputAsset.value?.maxSwappableAmount || 0;
   const hasOutputBalance = greaterThanWorklet(outputBalance, 0);
 
-  let newInputAmount: string | number = greaterThanWorklet(inputNativePrice, 0) ? divWorklet(prevInputNativeValue, inputNativePrice) : 0;
+  const calculatedInputAmount: string | number = greaterThanWorklet(inputNativePrice, 0)
+    ? divWorklet(prevInputNativeValue, inputNativePrice)
+    : 0;
+  const newFormattedInputAmount = valueBasedDecimalFormatter({
+    amount: calculatedInputAmount,
+    nativePrice: inputNativePrice,
+    roundingMode: 'up',
+    isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin',
+    stripSeparators: true,
+  });
+
+  let newInputAmount: string | number = newFormattedInputAmount;
   let newOutputAmount: string | number = 0;
 
   const exceedsMaxBalance = greaterThanWorklet(newInputAmount, inputBalance);
@@ -80,14 +91,6 @@ export const updateInputValuesAfterFlip = ({
 
   if (hasNonZeroInputPrice && hasNonZeroOutputPrice && validBalanceIfAny && !setToMax) {
     // use previous native input amount if available
-    const formattedInputAmount = valueBasedDecimalFormatter({
-      amount: newInputAmount,
-      nativePrice: inputNativePrice,
-      roundingMode: 'up',
-      isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin',
-      stripSeparators: true,
-    });
-    newInputAmount = formattedInputAmount;
     const prevOutputNativeValue = inputValues.value.outputNativeValue;
     newOutputAmount = divWorklet(prevOutputNativeValue, outputNativePrice);
     inputMethod.value = 'inputAmount';

--- a/src/__swaps__/utils/flipAssets.ts
+++ b/src/__swaps__/utils/flipAssets.ts
@@ -80,15 +80,13 @@ export const updateInputValuesAfterFlip = ({
 
   if (hasNonZeroInputPrice && hasNonZeroOutputPrice && validBalanceIfAny && !setToMax) {
     // use previous native input amount if available
-    const formattedInputAmount = Number(
-      valueBasedDecimalFormatter({
-        amount: newInputAmount,
-        nativePrice: inputNativePrice,
-        roundingMode: 'up',
-        isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin',
-        stripSeparators: true,
-      })
-    );
+    const formattedInputAmount = valueBasedDecimalFormatter({
+      amount: newInputAmount,
+      nativePrice: inputNativePrice,
+      roundingMode: 'up',
+      isStablecoin: internalSelectedInputAsset.value?.type === 'stablecoin',
+      stripSeparators: true,
+    });
     newInputAmount = formattedInputAmount;
     const prevOutputNativeValue = inputValues.value.outputNativeValue;
     newOutputAmount = divWorklet(prevOutputNativeValue, outputNativePrice);


### PR DESCRIPTION
Fixes APP-1675
Fixes APP-1699

More comments are inline in the code files changed below.

## What changed (plus any additional context for devs)
- Moved a couple functions to a separate file to make setting up testing easier later
- Moved the animatedReaction for reacting to asset changes / flips to be done before the animatedReaction that changes the `maxSwappableAmount` value as this was causing the reliance of "did the user intend to use max" check unreliable
- Fixes an issue where from wallet list for testmar27.eth: select BOOMER and swap → the output amount is just 0.0 and when you flip, the input amount goes to "7.5e-8" bc of an unnecessary Number conversion

Overall, the flipping logic will try to figure out which values to used in this priority order:
- base the updated values on the native input amount (requires that there is a valid price for both input and output assets, and that the balance won't exceed the max balance, and that it isn't the user's intent to select the max balance)
- base the updated values on the current slider position: if we can't do the above, or if the calculated amount would result in an automatic "Insufficient Balance" for the input, or if the user intended to select max, then we use the slider (requires the previous output has a balance)
- otherwise, we use the previous output amount as the new input amount and vice versa
- worst case scenario, we just zero out the values

## Screen recordings / screenshots
- Max scenario:

https://github.com/user-attachments/assets/3783b626-f5f1-40ba-bc40-951f81463d81

- Example of when you have enough balance after the flip to keep using the native input or what happens when you don't (and it falls back to using the current slider position):

https://github.com/user-attachments/assets/a8823084-2137-46b5-8445-e96f318c2f66




- BEFORE: "7.5e-8" bug
https://github.com/user-attachments/assets/ce2fc0c9-64c0-41f8-8f08-e4ff81689190


- AFTER fixing "7.5e-8" bug

https://github.com/user-attachments/assets/8aeb24f5-c60c-421a-9551-76922b395dd9




## What to test
- I've added a full breakdown of combinations in the Linear ticket, but generally flipping should "behave as expected" for max as well as non-max
- when flipping assets, it should avoid getting into a state of "Insufficient Funds" when possible
