### PR TITLE
remove FULL_SCREEN_INTENT permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,9 +14,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" tools:node="remove" />
     <uses-feature android:name="android.hardware.bluetooth" android:required="true"/>
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
-
   <application
       android:name=".MainApplication"
       android:label="@string/app_name"


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Google Play Store is complaining about this permission which we're not using but some dep is requiring it by default so I've explicitly removed from the manifest

## Screen recordings / screenshots


## What to test

