### PR TITLE
Bump Android dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -209,7 +209,8 @@ dependencies {
     implementation("com.facebook.react:react-android")
     
     implementation 'io.github.novacrypto:BIP39:2019.01.27'
-    implementation 'com.google.android.play:core:1.8.2'
+    implementation 'com.google.android.play:review:2.0.1'
+    implementation 'com.google.android.play:app-update:2.1.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     implementation "androidx.core:core-splashscreen:1.0.1"
 

--- a/android/app/src/main/java/me/rainbow/NativeModules/RNReview/RNReviewModule.java
+++ b/android/app/src/main/java/me/rainbow/NativeModules/RNReview/RNReviewModule.java
@@ -8,7 +8,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.Task;
 
 public class RNReviewModule extends ReactContextBaseJavaModule {
     private final ReactApplicationContext reactContext;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1659,10 +1659,10 @@ PODS:
     - React
   - RNKeychain (8.0.0):
     - React-Core
-  - RNNotifee (5.6.0):
+  - RNNotifee (7.8.2):
     - React-Core
-    - RNNotifee/NotifeeCore (= 5.6.0)
-  - RNNotifee/NotifeeCore (5.6.0):
+    - RNNotifee/NotifeeCore (= 7.8.2)
+  - RNNotifee/NotifeeCore (7.8.2):
     - React-Core
   - RNOS (1.2.8):
     - React
@@ -2343,7 +2343,7 @@ SPEC CHECKSUMS:
   RNInputMask: 815461ebdf396beb62cf58916c35cf6930adb991
   RNKeyboard: 14793d75953d99c6d950090b8e9698b234c5d08c
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
-  RNNotifee: 8ee6ddabfc44b16600b978983162e0d4db20ce19
+  RNNotifee: 8e2d3df3f0e9ce8f5d1fe4c967431138190b6175
   RNOS: 31db6fa4a197d179afbba9e6b4d28d450a7f250b
   RNPermissions: 4e3714e18afe7141d000beae3755e5b5fb2f5e05
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@ledgerhq/hw-app-eth": "6.29.9",
     "@ledgerhq/react-native-hw-transport-ble": "6.27.7",
     "@metamask/eth-sig-util": "7.0.2",
-    "@notifee/react-native": "5.6.0",
+    "@notifee/react-native": "7.8.2",
     "@rainbow-me/provider": "0.0.12",
     "@rainbow-me/react-native-animated-number": "0.0.2",
     "@rainbow-me/swaps": "0.22.0",

--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -114,7 +114,15 @@ export const NotificationsHandler = ({ walletReady }: Props) => {
 
   const handleNotificationPressed = (event: NotifeeEvent) => {
     if (event.type === EventType.PRESS) {
-      handleOpenedNotification(event.detail.notification);
+      const notification = event.detail.notification;
+      if (notification) {
+        const minimalNotification: MinimalNotification = {
+          title: notification.title,
+          body: notification.body,
+          data: notification.data as { [key: string]: string | object },
+        };
+        handleOpenedNotification(minimalNotification);
+      }
     }
   };
 

--- a/src/notifications/constants.ts
+++ b/src/notifications/constants.ts
@@ -1,2 +1,3 @@
 export const ANDROID_DEFAULT_CHANNEL_ID = 'default';
+export const ANDROID_GROUP_ID = 'rainbow-group';
 export const WALLETCONNECT_SYNC_DELAY = 500;

--- a/src/notifications/foregroundHandler.ts
+++ b/src/notifications/foregroundHandler.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { ANDROID_DEFAULT_CHANNEL_ID } from '@/notifications/constants';
+import { ANDROID_DEFAULT_CHANNEL_ID, ANDROID_GROUP_ID } from '@/notifications/constants';
 import notifee, { AndroidStyle, Notification } from '@notifee/react-native';
 import { FixedRemoteMessage } from '@/notifications/types';
 import { logger, RainbowError } from '@/logger';
@@ -14,6 +14,7 @@ export function handleShowingForegroundNotification(remoteMessage: FixedRemoteMe
       smallIcon: 'ic_state_ic_notification',
       channelId: ANDROID_DEFAULT_CHANNEL_ID,
       pressAction: { id: 'default' },
+      groupId: ANDROID_GROUP_ID,
     },
     data,
     ios: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4027,12 +4027,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@notifee/react-native@npm:5.6.0":
-  version: 5.6.0
-  resolution: "@notifee/react-native@npm:5.6.0"
+"@notifee/react-native@npm:7.8.2":
+  version: 7.8.2
+  resolution: "@notifee/react-native@npm:7.8.2"
   peerDependencies:
     react-native: "*"
-  checksum: 10c0/f0d3c93e1752c068a7b249386f9675951d4250ee6860d27bde8726bbcab612eb0a26126942c558585467c727bc5b961f9a3150dc9d36ac72e8f88d4739fa7230
+  checksum: 10c0/1559caa74ccc057aa4a4a6fe15bcaf0fe0371ece045a0923c051fcef312e4c2b3e2f38e5032a15d2be327fd707492d014f2f074405123ed561ba368906413f29
   languageName: node
   linkType: hard
 
@@ -7808,7 +7808,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:7.0.2"
     "@nomiclabs/hardhat-ethers": "npm:2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:2.0.6"
-    "@notifee/react-native": "npm:5.6.0"
+    "@notifee/react-native": "npm:7.8.2"
     "@rainbow-me/provider": "npm:0.0.12"
     "@rainbow-me/react-native-animated-number": "npm:0.0.2"
     "@rainbow-me/swaps": "npm:0.22.0"


### PR DESCRIPTION
Fixes APP-1711

## What changed (plus any additional context for devs)
- bumped play:core dependencies to their separate respective packages.
- bumped notifee from `5.6.0` -> `7.8.2`
- added notification grouping on Android as requested by https://github.com/rainbow-me/rainbow/issues/5301

## Screen recordings / screenshots


## What to test

