### PR TITLE
Fix crash and profile screen empty state

### DIFF
--- a/src/components/activity-list/ActivityList.js
+++ b/src/components/activity-list/ActivityList.js
@@ -79,8 +79,6 @@ function ListFooterComponent({ label, onPress }) {
 const ActivityList = ({
   hasPendingTransaction,
   header,
-  isEmpty,
-  isLoading,
   nativeCurrency,
   network,
   nextPage,
@@ -109,41 +107,38 @@ const ActivityList = ({
     setScrollToTopRef(ref);
   };
 
-  if (network === networkTypes.mainnet || sections.length) {
-    if (isEmpty && !isLoading) {
-      return <ActivityListEmptyState>{header}</ActivityListEmptyState>;
-    } else {
-      return (
-        <SectionList
-          ListFooterComponent={() => remainingItemsLabel && <ListFooterComponent label={remainingItemsLabel} onPress={nextPage} />}
-          ref={handleListRef}
-          ListHeaderComponent={header}
-          alwaysBounceVertical={false}
-          contentContainerStyle={{ paddingBottom: !transactionsCount ? 0 : 90 }}
-          extraData={{
-            hasPendingTransaction,
-            nativeCurrency,
-            pendingTransactionsCount,
-          }}
-          getItemLayout={getItemLayout}
-          initialNumToRender={12}
-          keyExtractor={keyExtractor}
-          removeClippedSubviews
-          renderSectionHeader={renderSectionHeaderWithTheme}
-          scrollIndicatorInsets={{
-            bottom: safeAreaInsetValues.bottom + 14,
-          }}
-          sections={sections}
-        />
-      );
-    }
-  } else {
+  if (network === networkTypes.mainnet) {
     return (
-      <ActivityListEmptyState emoji="👻" label={lang.t(lang.l.empty_state.testnet_label)}>
-        {header}
-      </ActivityListEmptyState>
+      <SectionList
+        ListFooterComponent={() => remainingItemsLabel && <ListFooterComponent label={remainingItemsLabel} onPress={nextPage} />}
+        ref={handleListRef}
+        ListHeaderComponent={header}
+        alwaysBounceVertical={false}
+        contentContainerStyle={{ paddingBottom: !transactionsCount ? 0 : 90 }}
+        extraData={{
+          hasPendingTransaction,
+          nativeCurrency,
+          pendingTransactionsCount,
+        }}
+        ListEmptyComponent={<ActivityListEmptyState />}
+        getItemLayout={getItemLayout}
+        initialNumToRender={12}
+        keyExtractor={keyExtractor}
+        removeClippedSubviews
+        renderSectionHeader={renderSectionHeaderWithTheme}
+        scrollIndicatorInsets={{
+          bottom: safeAreaInsetValues.bottom + 14,
+        }}
+        sections={sections}
+      />
     );
   }
+
+  return (
+    <ActivityListEmptyState emoji="👻" label={lang.t(lang.l.empty_state.testnet_label)}>
+      {header}
+    </ActivityListEmptyState>
+  );
 };
 
 export default ActivityList;

--- a/src/hooks/useAccountTransactions.ts
+++ b/src/hooks/useAccountTransactions.ts
@@ -19,7 +19,7 @@ export default function useAccountTransactions() {
 
   const pendingTransactions = usePendingTransactionsStore(state => state.pendingTransactions[accountAddress] || []);
 
-  const { data, fetchNextPage, hasNextPage } = useConsolidatedTransactions({
+  const { data, isLoading, fetchNextPage, hasNextPage } = useConsolidatedTransactions({
     address: accountAddress,
     currency: nativeCurrency,
   });
@@ -132,7 +132,7 @@ export default function useAccountTransactions() {
   }, [hasNextPage]);
 
   return {
-    isLoadingTransactions: !!allTransactions,
+    isLoadingTransactions: isLoading,
     nextPage: fetchNextPage,
     remainingItemsLabel,
     sections,

--- a/src/navigation/SectionListScrollToTopContext.tsx
+++ b/src/navigation/SectionListScrollToTopContext.tsx
@@ -17,6 +17,7 @@ const SectionListScrollToTopProvider: React.FC<ScrollToTopProviderProps> = ({ ch
   const [scrollToTopRef, setScrollToTopRef] = useState<SectionList | null>(null);
 
   const scrollToTop = () => {
+    if (!scrollToTopRef?.props.sections.length) return;
     scrollToTopRef?.scrollToLocation({
       animated: true,
       itemIndex: 0,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -61,7 +61,7 @@ export default function ProfileScreen() {
         }
       />
 
-      <ActivityList isEmpty={isEmpty} isLoading={isLoading} network={network} sections={sections} {...accountTransactions} />
+      <ActivityList network={network} sections={sections} {...accountTransactions} />
     </ProfileScreenPage>
   );
 }


### PR DESCRIPTION
Fixes APP-1732

## What changed (plus any additional context for devs)
1. `isLoading` flag was never being set to false since it wasn't consuming the react-query `isLoading` flag. 
2. Tapping on the ProfileScreen icon when the sections are empty threw an out of range Invariant Violation

## Screen recordings / screenshots
<img width="578" alt="Screenshot 2024-08-01 at 4 47 13 PM" src="https://github.com/user-attachments/assets/0a35c0a2-07a7-4db5-b844-343a586f9fe0">

## What to test
