### PR TITLE
Default the Swap input currency to ETH 

### DIFF
--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -105,12 +105,12 @@ const useMountSignal = () => {
 const useCleanupOnUnmount = () => {
   useEffect(() => {
     return () => {
-      const highestValueAsset = userAssetsStore.getState().getHighestValueAsset();
-      const parsedAsset = highestValueAsset
+      const highestValueEth = userAssetsStore.getState().getHighestValueEth();
+      const parsedAsset = highestValueEth
         ? parseSearchAsset({
             assetWithPrice: undefined,
-            searchAsset: highestValueAsset,
-            userAsset: highestValueAsset,
+            searchAsset: highestValueEth,
+            userAsset: highestValueEth,
           })
         : null;
 
@@ -135,7 +135,7 @@ const WalletAddressObserver = () => {
   const { setAsset } = useSwapContext();
 
   const setNewInputAsset = useCallback(() => {
-    const newHighestValueAsset = userAssetsStore.getState().getHighestValueAsset();
+    const newHighestValueEth = userAssetsStore.getState().getHighestValueEth();
 
     if (userAssetsStore.getState().filter !== 'all') {
       userAssetsStore.setState({ filter: 'all' });
@@ -143,7 +143,7 @@ const WalletAddressObserver = () => {
 
     setAsset({
       type: SwapAssetType.inputAsset,
-      asset: newHighestValueAsset,
+      asset: newHighestValueEth,
     });
 
     if (userAssetsStore.getState().userAssets.size === 0) {

--- a/src/components/DappBrowser/control-panel/ControlPanel.tsx
+++ b/src/components/DappBrowser/control-panel/ControlPanel.tsx
@@ -456,7 +456,7 @@ const HomePanel = ({
 
     if (swaps_v2 || swapsV2Enabled) {
       swapsStore.setState({
-        inputAsset: userAssetsStore.getState().getHighestValueAsset(),
+        inputAsset: userAssetsStore.getState().getHighestValueEth(),
       });
       InteractionManager.runAfterInteractions(() => {
         navigate(Routes.SWAP);
@@ -484,7 +484,7 @@ const HomePanel = ({
       // TODO: We need to set something in swapsStore that deliniates between a swap and bridge
       // for now let's just treat it like a normal swap
       swapsStore.setState({
-        inputAsset: userAssetsStore.getState().getHighestValueAsset(),
+        inputAsset: userAssetsStore.getState().getHighestValueEth(),
       });
       InteractionManager.runAfterInteractions(() => {
         navigate(Routes.SWAP);

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -181,7 +181,7 @@ function SwapButton() {
       });
       if (swapsV2Enabled) {
         swapsStore.setState({
-          inputAsset: userAssetsStore.getState().getHighestValueAsset(),
+          inputAsset: userAssetsStore.getState().getHighestValueEth(),
         });
         InteractionManager.runAfterInteractions(() => {
           navigate(Routes.SWAP);

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -1,7 +1,7 @@
 import { Address } from 'viem';
 import { RainbowError, logger } from '@/logger';
 import store from '@/redux/store';
-import { SUPPORTED_CHAIN_IDS, supportedNativeCurrencies } from '@/references';
+import { ETH_ADDRESS, SUPPORTED_CHAIN_IDS, supportedNativeCurrencies } from '@/references';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 import { ParsedSearchAsset, UniqueId, UserAssetFilter } from '@/__swaps__/types/assets';
 import { ChainId } from '@/__swaps__/types/chains';
@@ -36,6 +36,7 @@ export interface UserAssetsState {
   getChainsWithBalance: () => ChainId[];
   getFilteredUserAssetIds: () => UniqueId[];
   getHighestValueAsset: (usePreferredNetwork?: boolean) => ParsedSearchAsset | null;
+  getHighestValueEth: () => ParsedSearchAsset | null;
   getUserAsset: (uniqueId: UniqueId) => ParsedSearchAsset | null;
   getUserAssets: () => ParsedSearchAsset[];
   selectUserAssetIds: (selector: (asset: ParsedSearchAsset) => boolean, filter?: UserAssetFilter) => Generator<UniqueId, void, unknown>;
@@ -195,6 +196,25 @@ export const userAssetsStore = createRainbowStore<UserAssetsState>(
 
       // If no preferred network asset, return the highest-value asset
       return assets.values().next().value || null;
+    },
+
+    getHighestValueEth: () => {
+      // const preferredNetwork = usePreferredNetwork ? swapsStore.getState().preferredNetwork : undefined;
+      const assets = get().userAssets;
+
+      // if (preferredNetwork && get().getChainsWithBalance().includes(preferredNetwork)) {
+      //   // Find the highest-value asset on the preferred network
+      //   for (const [, asset] of assets) {
+      //     if (asset.chainId === preferredNetwork) {
+      //       return asset;
+      //     }
+      //   }
+      // }
+      const x = Array.from(assets.values()).filter(asset => asset.name === 'Ethereum');
+      console.log(x);
+      return x?.[0] || null;
+      // // If no preferred network asset, return the highest-value asset
+      // return assets.values().next().value || null;
     },
 
     getUserAsset: (uniqueId: UniqueId) => get().userAssets.get(uniqueId) || null,

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -182,22 +182,23 @@ export const userAssetsStore = createRainbowStore<UserAssetsState>(
 
     getHighestValueEth: () => {
       const preferredNetwork = swapsStore.getState().preferredNetwork;
-      const assets = Array.from(get().userAssets.values());
+      const assets = get().userAssets;
 
-      const ethAssets = assets.filter(asset => asset.mainnetAddress === ETH_ADDRESS);
+      let highestValueEth = null;
 
-      if (!ethAssets.length) {
-        return null;
-      }
+      for (const [, asset] of assets) {
+        if (asset.mainnetAddress !== ETH_ADDRESS) continue;
 
-      if (preferredNetwork) {
-        const preferredEthAsset = ethAssets.find(asset => asset.chainId === preferredNetwork);
-        if (preferredEthAsset) {
-          return preferredEthAsset;
+        if (preferredNetwork && asset.chainId === preferredNetwork) {
+          return asset;
+        }
+
+        if (!highestValueEth || asset.balance > highestValueEth.balance) {
+          highestValueEth = asset;
         }
       }
 
-      return ethAssets.reduce((highest, current) => (current.balance > highest.balance ? current : highest));
+      return highestValueEth;
     },
 
     getUserAsset: (uniqueId: UniqueId) => get().userAssets.get(uniqueId) || null,

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -182,24 +182,22 @@ export const userAssetsStore = createRainbowStore<UserAssetsState>(
 
     getHighestValueEth: () => {
       const preferredNetwork = swapsStore.getState().preferredNetwork;
-      const assets = get().userAssets;
+      const assets = Array.from(get().userAssets.values());
 
-      let highestValueEth: ParsedSearchAsset | null = null;
+      const ethAssets = assets.filter(asset => asset.mainnetAddress === ETH_ADDRESS);
 
-      for (const [, asset] of assets) {
-        if (asset.mainnetAddress === ETH_ADDRESS) {
-          // if there is a preferredNetwork & this eth asset is on that network, return it
-          if (preferredNetwork && asset.chainId === preferredNetwork) {
-            return asset;
-            // if this eth asset is not on the preferredNetwork, update highestValueEth if applicable
-          } else if (!highestValueEth || asset.balance > highestValueEth.balance) {
-            highestValueEth = asset;
-          }
+      if (!ethAssets.length) {
+        return null;
+      }
+
+      if (preferredNetwork) {
+        const preferredEthAsset = ethAssets.find(asset => asset.chainId === preferredNetwork);
+        if (preferredEthAsset) {
+          return preferredEthAsset;
         }
       }
 
-      // If no eth on the preferred network, return the highest value eth asset
-      return highestValueEth;
+      return ethAssets.reduce((highest, current) => (current.balance > highest.balance ? current : highest));
     },
 
     getUserAsset: (uniqueId: UniqueId) => get().userAssets.get(uniqueId) || null,

--- a/src/state/sync/UserAssetsSync.tsx
+++ b/src/state/sync/UserAssetsSync.tsx
@@ -30,7 +30,7 @@ export const UserAssetsSync = memo(function UserAssetsSync() {
         if (!isSwapsOpen || userAssetsWalletAddress !== currentAddress) {
           userAssetsStore.getState().setUserAssets(currentAddress as Address, data as ParsedSearchAsset[]);
 
-          const inputAsset = userAssetsStore.getState().getHighestValueAsset();
+          const inputAsset = userAssetsStore.getState().getHighestValueEth();
           useSwapsStore.setState({
             inputAsset,
             selectedOutputChainId: inputAsset?.chainId ?? ChainId.mainnet,


### PR DESCRIPTION
Fixes APP-1765

## What changed (plus any additional context for devs)
According to swaps spec, the default input asset should be ETH on the network that the user has the most ETH. See this discussion: https://rainbowhaus.slack.com/archives/C0468CDBE75/p1723050551013059

## Screen recordings / screenshots

https://github.com/user-attachments/assets/b153a76b-15ba-4cb4-ab00-75aef9af3648

## What to test

