### PR TITLE
swaps bug fix: missing asset balance for some tokens

### DIFF
--- a/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
@@ -11,7 +11,7 @@ import { SupportedCurrencyKey, SUPPORTED_CHAIN_IDS } from '@/references';
 import { ParsedAssetsDictByChain, ZerionAsset } from '@/__swaps__/types/assets';
 import { ChainId } from '@/__swaps__/types/chains';
 import { AddressAssetsReceivedMessage } from '@/__swaps__/types/refraction';
-import { filterAsset, parseUserAsset } from '@/__swaps__/utils/assets';
+import { parseUserAsset } from '@/__swaps__/utils/assets';
 import { greaterThan } from '@/__swaps__/utils/numbers';
 
 import { fetchUserAssetsByChain } from './userAssetsByChain';
@@ -190,7 +190,7 @@ export async function parseUserAssets({
 }) {
   const parsedAssetsDict = chainIds.reduce((dict, currentChainId) => ({ ...dict, [currentChainId]: {} }), {}) as ParsedAssetsDictByChain;
   for (const { asset, quantity, small_balance } of assets) {
-    if (!filterAsset(asset) && greaterThan(quantity, 0)) {
+    if (greaterThan(quantity, 0)) {
       const parsedAsset = parseUserAsset({
         asset,
         currency,

--- a/src/__swaps__/utils/assets.ts
+++ b/src/__swaps__/utils/assets.ts
@@ -305,15 +305,6 @@ export const parseSearchAsset = ({
   type: userAsset?.type || assetWithPrice?.type || searchAsset?.type,
 });
 
-export function filterAsset(asset: ZerionAsset) {
-  const nameFragments = asset?.name?.split(' ');
-  const nameContainsURL = nameFragments.some(f => isValidDomain(f));
-  const symbolFragments = asset?.symbol?.split(' ');
-  const symbolContainsURL = symbolFragments.some(f => isValidDomain(f));
-  const shouldFilter = nameContainsURL || symbolContainsURL;
-  return shouldFilter;
-}
-
 const assetQueryFragment = (
   address: AddressOrEth,
   chainId: ChainId,


### PR DESCRIPTION
Fixes APP-1774

## What changed (plus any additional context for devs)
* removed asset filter, was causing moxie fan tokens to get filtered out by userAssetsQuery bc ens names were not passing the `isValidDomain` check. see this convo: https://rainbowhaus.slack.com/archives/C02C2FVC6N6/p1723248357542129

## Screen recordings / screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-08-12 at 12 06 04](https://github.com/user-attachments/assets/92ea42da-e7d6-46e6-b37d-21e1bd79fb62)


## What to test

