### PR TITLE
Fix improper `First time send` message

### DIFF
--- a/src/hooks/useSendTransactionMessage.ts
+++ b/src/hooks/useSendTransactionMessage.ts
@@ -51,7 +51,6 @@ export const useSendTransactionMessage = ({ isL2, toAddress, network }: UseSendT
       const checkBatch = (txs: typeof transactions) => {
         for (const tx of txs) {
           if (tx.to?.toLowerCase() === toAddress?.toLowerCase() && tx.from?.toLowerCase() === accountAddress?.toLowerCase()) {
-            console.log('tx', tx.to.toLowerCase(), toAddress?.toLowerCase(), tx.from?.toLowerCase(), accountAddress?.toLowerCase());
             sends.current += 1;
             if (tx.network === network) {
               sendsCurrentNetwork.current += 1;

--- a/src/hooks/useSendTransactionMessage.ts
+++ b/src/hooks/useSendTransactionMessage.ts
@@ -1,0 +1,96 @@
+import { useConsolidatedTransactions } from '@/resources/transactions/consolidatedTransactions';
+import useAccountSettings from './useAccountSettings';
+import useUserAccounts from './useUserAccounts';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Network } from '@/helpers';
+import { Address } from 'viem';
+import * as i18n from '@/languages';
+
+type UseSendTransactionMessageProps = {
+  isL2: boolean;
+  toAddress: Address;
+  network: Network;
+};
+
+const MAX_BATCHES_TO_CHECK = 10;
+
+export const useSendTransactionMessage = ({ isL2, toAddress, network }: UseSendTransactionMessageProps) => {
+  const { accountAddress, nativeCurrency } = useAccountSettings();
+  const { userAccounts } = useUserAccounts();
+
+  const sends = useRef<number>(0);
+  const sendsCurrentNetwork = useRef<number>(0);
+
+  const shouldShowChecks = useRef<boolean>(false);
+
+  const [message, setMessage] = useState<string>();
+
+  const { data, fetchNextPage, hasNextPage } = useConsolidatedTransactions({
+    address: accountAddress,
+    currency: nativeCurrency,
+  });
+
+  const transactions = useMemo(() => {
+    return data?.pages.flatMap(page => page.transactions) || [];
+  }, [data]);
+
+  const isSendingToUserAccount = useMemo(() => {
+    const found = userAccounts?.find(account => {
+      return account.address.toLowerCase() === toAddress?.toLowerCase();
+    });
+    return !!found;
+  }, [toAddress, userAccounts]);
+
+  useEffect(() => {
+    const checkTransactions = async () => {
+      if (isSendingToUserAccount) {
+        setMessage(i18n.t(i18n.l.wallet.transaction.you_own_this_wallet));
+        return;
+      }
+
+      const checkBatch = (txs: typeof transactions) => {
+        for (const tx of txs) {
+          if (tx.to?.toLowerCase() === toAddress?.toLowerCase() && tx.from?.toLowerCase() === accountAddress?.toLowerCase()) {
+            console.log('tx', tx.to.toLowerCase(), toAddress?.toLowerCase(), tx.from?.toLowerCase(), accountAddress?.toLowerCase());
+            sends.current += 1;
+            if (tx.network === network) {
+              sendsCurrentNetwork.current += 1;
+              shouldShowChecks.current = isL2 && sendsCurrentNetwork.current < 3;
+            }
+          }
+        }
+      };
+
+      checkBatch(transactions);
+
+      const fetchAndCheckBatches = async () => {
+        const batchPromises = [];
+        for (let i = 0; i < MAX_BATCHES_TO_CHECK && hasNextPage; i++) {
+          batchPromises.push(fetchNextPage().then(result => result.data?.pages.slice(-1)[0].transactions || []));
+        }
+
+        const batchResults = await Promise.all(batchPromises);
+        batchResults.forEach(checkBatch);
+      };
+
+      await fetchAndCheckBatches();
+
+      if (sends.current > 0) {
+        setMessage(
+          i18n.t(i18n.l.wallet.transaction.previous_sends, {
+            number: sends.current,
+          })
+        );
+      } else {
+        setMessage(i18n.t(i18n.l.wallet.transaction.first_time_send));
+      }
+    };
+
+    checkTransactions();
+  }, [accountAddress, isSendingToUserAccount, network, toAddress, transactions, hasNextPage, fetchNextPage, data]);
+
+  return {
+    message,
+    shouldShowChecks: shouldShowChecks.current,
+  };
+};


### PR DESCRIPTION
Fixes APP-1299

## What changed (plus any additional context for devs)
The underlying issue with the check here was that the consolidated transactions hook only goes 80 txns back. This PR introduces parallelization of pages in batch so it now checks the most 10 batches of 80 (aka last 800) transactions for records of previous sends.

Functionally, I think we could increase the amount to any number of batches, we just need to be mindful of the amount of requests sent to backend. 

I also added a loading skeleton while the check takes place, but it's dang near instantaneous so you hardly ever see it.

Question for you @brunobar79: Do we want to get rid of the `N previous sends` i18n and replace it with a more generic message? Something like `Recently sent to this address` or something?

## Screen recordings / screenshots

https://github.com/user-attachments/assets/e2c085e0-36db-4dd0-a954-4b33ae788019

## What to test

