### PR TITLE
crash fix

### DIFF
--- a/src/hooks/useWalletBalances.ts
+++ b/src/hooks/useWalletBalances.ts
@@ -62,7 +62,7 @@ const useWalletBalances = (wallets: AllRainbowWallets): WalletBalanceResult => {
 
     for (const address of allAddresses) {
       const lowerCaseAddress = address.toLowerCase() as Address;
-      const assetBalance = summaryData?.data?.addresses?.[lowerCaseAddress]?.summary?.asset_value.toString() || '0';
+      const assetBalance = summaryData?.data?.addresses?.[lowerCaseAddress]?.summary?.asset_value?.toString() || '0';
 
       const positionData = queryClient.getQueryData<RainbowPositions | undefined>(positionsQueryKey({ address, currency: nativeCurrency }));
       const positionsBalance = positionData?.totals?.total?.amount || '0';

--- a/src/resources/summary/summary.ts
+++ b/src/resources/summary/summary.ts
@@ -26,7 +26,7 @@ export interface AddySummary {
           };
           num_erc20s: number;
           last_activity: number;
-          asset_value: number;
+          asset_value: number | null;
         };
       };
       summary_by_chain: {
@@ -38,7 +38,7 @@ export interface AddySummary {
           };
           num_erc20s: number;
           last_activity: number;
-          asset_value: number;
+          asset_value: number | null;
         };
       };
     };

--- a/src/resources/summary/summary.ts
+++ b/src/resources/summary/summary.ts
@@ -12,7 +12,7 @@ const addysHttp = new RainbowFetchClient({
   },
 });
 
-export interface AddySummary {
+interface AddysSummary {
   data: {
     addresses: {
       [key: Address]: {
@@ -72,7 +72,7 @@ async function addysSummaryQueryFunction({ queryKey: [{ addresses, currency }] }
       addresses,
     })
   );
-  return data as AddySummary;
+  return data as AddysSummary;
 }
 
 type AddysSumaryResult = QueryFunctionResult<typeof addysSummaryQueryFunction>;


### PR DESCRIPTION
Fixes APP-1789

## What changed (plus any additional context for devs)
Our response type for https://addys.p.rainbow.me/v3/summary was not aligned with the [actual api schema](https://github.com/rainbow-me/addys/blob/23069b10fc8bdda62c35bc9ba7e7f51f64a326cc/internal/addys/aggregated_service.go#L322). `asset_value` was typed as `number`, but it can also be `null`. In `useWalletBalances` we try to convert `asset_value` to a string, which crashes when `asset_value` is `null`. To fix this, I modified the type of `asset_value` in the `AddysSummary` interface to be `number | null`, and added optional chaining before the `toString()` conversion in `useWalletBalances`.

![Simulator Screenshot - iPhone 15 Pro - 2024-08-20 at 16 25 53](https://github.com/user-attachments/assets/3ae66f7a-203e-464b-b58e-25a05bf27bab)


## Screen recordings / screenshots


## What to test

