### PR TITLE
fix android deps errors

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -208,7 +208,15 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
     
-    implementation 'io.github.novacrypto:BIP39:2019.01.27'
+    implementation("com.github.NovaCrypto:BIP39:0e7fa95f80") {
+        exclude group: "io.github.novacrypto", module: "ToRuntime"
+        exclude group: "io.github.novacrypto", module: "SHA256"
+    }
+    implementation("com.github.NovaCrypto:Sha256:57bed72da5") {
+        exclude group: "io.github.novacrypto", module: "ToRuntime"
+    }
+    implementation "com.github.NovaCrypto:ToRuntime:c3ae3080eb"
+
     implementation 'com.google.android.play:review:2.0.1'
     implementation 'com.google.android.play:app-update:2.1.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "react-native-text-input-mask": "2.0.0",
     "react-native-text-size": "rainbow-me/react-native-text-size#15b21c9f88c6df0d1b5e0f2ba792fe59b5dc255a",
     "react-native-tooltip": "rainbow-me/react-native-tooltip#e0e88d212b5b7f350e5eabba87f588a32e0f2590",
-    "react-native-tooltips": "rainbow-me/react-native-tooltips#77338abadbef8225870aea5cfc0dacf94a1448e3",
+    "react-native-tooltips": "rainbow-me/react-native-tooltips#2fc21cef76968d085d953edad18181eafcfcf403",
     "react-native-udp": "2.7.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-version-number": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "react-native-text-input-mask": "2.0.0",
     "react-native-text-size": "rainbow-me/react-native-text-size#15b21c9f88c6df0d1b5e0f2ba792fe59b5dc255a",
     "react-native-tooltip": "rainbow-me/react-native-tooltip#e0e88d212b5b7f350e5eabba87f588a32e0f2590",
-    "react-native-tooltips": "rainbow-me/react-native-tooltips#2fc21cef76968d085d953edad18181eafcfcf403",
+    "react-native-tooltips": "rainbow-me/react-native-tooltips#fdafbc7ba33ee231229f5d3f58b29d0d1c55ddfa",
     "react-native-udp": "2.7.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-version-number": "0.3.6",

--- a/patches/react-native-text-input-mask+2.0.0.patch
+++ b/patches/react-native-text-input-mask+2.0.0.patch
@@ -1,7 +1,310 @@
 diff --git a/node_modules/react-native-text-input-mask/.DS_Store b/node_modules/react-native-text-input-mask/.DS_Store
 new file mode 100644
-index 0000000..5902d8c
-Binary files /dev/null and b/node_modules/react-native-text-input-mask/.DS_Store differ
+index 0000000..e69de29
+diff --git a/node_modules/react-native-text-input-mask/android/build.gradle b/node_modules/react-native-text-input-mask/android/build.gradle
+index ba1e645..18630dc 100644
+--- a/node_modules/react-native-text-input-mask/android/build.gradle
++++ b/node_modules/react-native-text-input-mask/android/build.gradle
+@@ -26,6 +26,6 @@ android {
+ 
+ dependencies {
+     implementation 'com.facebook.react:react-native:+'
+-    implementation 'com.redmadrobot:inputmask:4.1.0'
++    implementation 'com.github.RedMadRobot:input-mask-android:4.1.0'
+     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.21'
+ }
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/3330fd484248ddd211455a7ebeca4def/results.bin b/node_modules/react-native-text-input-mask/android/build/.transforms/3330fd484248ddd211455a7ebeca4def/results.bin
+new file mode 100644
+index 0000000..0d259dd
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/.transforms/3330fd484248ddd211455a7ebeca4def/results.bin
+@@ -0,0 +1 @@
++o/classes
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/3330fd484248ddd211455a7ebeca4def/transformed/classes/classes_dex/classes.dex b/node_modules/react-native-text-input-mask/android/build/.transforms/3330fd484248ddd211455a7ebeca4def/transformed/classes/classes_dex/classes.dex
+new file mode 100644
+index 0000000..b937d77
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/3330fd484248ddd211455a7ebeca4def/transformed/classes/classes_dex/classes.dex differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/results.bin b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/results.bin
+new file mode 100644
+index 0000000..5ff383e
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/results.bin
+@@ -0,0 +1 @@
++o/debug
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/BuildConfig.dex b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/BuildConfig.dex
+new file mode 100644
+index 0000000..530bd9a
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/BuildConfig.dex differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule$1$1.dex b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule$1$1.dex
+new file mode 100644
+index 0000000..b42ab6e
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule$1$1.dex differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule$1.dex b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule$1.dex
+new file mode 100644
+index 0000000..5b4c31c
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule$1.dex differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule.dex b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule.dex
+new file mode 100644
+index 0000000..e4d045f
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskModule.dex differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskPackage.dex b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskPackage.dex
+new file mode 100644
+index 0000000..6f7f156
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/debug_dex/com/RNTextInputMask/RNTextInputMaskPackage.dex differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/desugar_graph.bin b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/desugar_graph.bin
+new file mode 100644
+index 0000000..5cb003f
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/.transforms/558c105ee4e6b972a92b31d57bb15e87/transformed/debug/desugar_graph.bin differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/generated/source/buildConfig/debug/com/RNTextInputMask/BuildConfig.java b/node_modules/react-native-text-input-mask/android/build/generated/source/buildConfig/debug/com/RNTextInputMask/BuildConfig.java
+new file mode 100644
+index 0000000..5187c84
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/generated/source/buildConfig/debug/com/RNTextInputMask/BuildConfig.java
+@@ -0,0 +1,10 @@
++/**
++ * Automatically generated file. DO NOT MODIFY
++ */
++package com.RNTextInputMask;
++
++public final class BuildConfig {
++  public static final boolean DEBUG = Boolean.parseBoolean("true");
++  public static final String LIBRARY_PACKAGE_NAME = "com.RNTextInputMask";
++  public static final String BUILD_TYPE = "debug";
++}
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/AndroidManifest.xml b/node_modules/react-native-text-input-mask/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/AndroidManifest.xml
+new file mode 100644
+index 0000000..32b79dc
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/AndroidManifest.xml
+@@ -0,0 +1,7 @@
++<?xml version="1.0" encoding="utf-8"?>
++<manifest xmlns:android="http://schemas.android.com/apk/res/android"
++    package="com.RNTextInputMask" >
++
++    <uses-sdk android:minSdkVersion="26" />
++
++</manifest>
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/output-metadata.json b/node_modules/react-native-text-input-mask/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/output-metadata.json
+new file mode 100644
+index 0000000..97e5bd9
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/output-metadata.json
+@@ -0,0 +1,18 @@
++{
++  "version": 3,
++  "artifactType": {
++    "type": "AAPT_FRIENDLY_MERGED_MANIFESTS",
++    "kind": "Directory"
++  },
++  "applicationId": "com.RNTextInputMask",
++  "variantName": "debug",
++  "elements": [
++    {
++      "type": "SINGLE",
++      "filters": [],
++      "attributes": [],
++      "outputFile": "AndroidManifest.xml"
++    }
++  ],
++  "elementType": "File"
++}
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/aar_metadata/debug/aar-metadata.properties b/node_modules/react-native-text-input-mask/android/build/intermediates/aar_metadata/debug/aar-metadata.properties
+new file mode 100644
+index 0000000..1211b1e
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/aar_metadata/debug/aar-metadata.properties
+@@ -0,0 +1,6 @@
++aarFormatVersion=1.0
++aarMetadataVersion=1.0
++minCompileSdk=1
++minCompileSdkExtension=0
++minAndroidGradlePluginVersion=1.0.0
++coreLibraryDesugaringEnabled=false
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/annotation_processor_list/debug/annotationProcessors.json b/node_modules/react-native-text-input-mask/android/build/intermediates/annotation_processor_list/debug/annotationProcessors.json
+new file mode 100644
+index 0000000..9e26dfe
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/annotation_processor_list/debug/annotationProcessors.json
+@@ -0,0 +1 @@
++{}
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/compile_library_classes_jar/debug/classes.jar b/node_modules/react-native-text-input-mask/android/build/intermediates/compile_library_classes_jar/debug/classes.jar
+new file mode 100644
+index 0000000..1a5b0f8
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/compile_library_classes_jar/debug/classes.jar differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/compile_r_class_jar/debug/R.jar b/node_modules/react-native-text-input-mask/android/build/intermediates/compile_r_class_jar/debug/R.jar
+new file mode 100644
+index 0000000..82ba69f
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/compile_r_class_jar/debug/R.jar differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/compile_symbol_list/debug/R.txt b/node_modules/react-native-text-input-mask/android/build/intermediates/compile_symbol_list/debug/R.txt
+new file mode 100644
+index 0000000..e69de29
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/debug/packageDebugResources/compile-file-map.properties b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/debug/packageDebugResources/compile-file-map.properties
+new file mode 100644
+index 0000000..e40d27b
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/debug/packageDebugResources/compile-file-map.properties
+@@ -0,0 +1 @@
++#Wed Aug 21 15:12:29 EDT 2024
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/debug/packageDebugResources/merger.xml b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/debug/packageDebugResources/merger.xml
+new file mode 100644
+index 0000000..87dfc96
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/debug/packageDebugResources/merger.xml
+@@ -0,0 +1,2 @@
++<?xml version="1.0" encoding="utf-8"?>
++<merger version="3"><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="main$Generated" generated="true" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="main" generated-set="main$Generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="debug$Generated" generated="true" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/debug/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="debug" generated-set="debug$Generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/debug/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="generated$Generated" generated="true" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/build/generated/res/resValues/debug"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="generated" generated-set="generated$Generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/build/generated/res/resValues/debug"/></dataSet><mergedItems/></merger>
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/mergeDebugJniLibFolders/merger.xml b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/mergeDebugJniLibFolders/merger.xml
+new file mode 100644
+index 0000000..b65d916
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/mergeDebugJniLibFolders/merger.xml
+@@ -0,0 +1,2 @@
++<?xml version="1.0" encoding="utf-8"?>
++<merger version="3"><dataSet config="main" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/jniLibs"/></dataSet><dataSet config="debug" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/debug/jniLibs"/></dataSet></merger>
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/mergeDebugShaders/merger.xml b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/mergeDebugShaders/merger.xml
+new file mode 100644
+index 0000000..85962a0
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/mergeDebugShaders/merger.xml
+@@ -0,0 +1,2 @@
++<?xml version="1.0" encoding="utf-8"?>
++<merger version="3"><dataSet config="main" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/shaders"/></dataSet><dataSet config="debug" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/debug/shaders"/></dataSet></merger>
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/packageDebugAssets/merger.xml b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/packageDebugAssets/merger.xml
+new file mode 100644
+index 0000000..4f8b0d8
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/incremental/packageDebugAssets/merger.xml
+@@ -0,0 +1,2 @@
++<?xml version="1.0" encoding="utf-8"?>
++<merger version="3"><dataSet config="main" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/assets"/></dataSet><dataSet config="debug" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/debug/assets"/></dataSet><dataSet config="generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/build/intermediates/shader_assets/debug/out"/></dataSet></merger>
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/BuildConfig.class b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/BuildConfig.class
+new file mode 100644
+index 0000000..c38e5af
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/BuildConfig.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule$1$1.class b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule$1$1.class
+new file mode 100644
+index 0000000..7aa7e43
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule$1$1.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule$1.class b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule$1.class
+new file mode 100644
+index 0000000..55f4795
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule$1.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule.class b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule.class
+new file mode 100644
+index 0000000..2a9601e
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskModule.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskPackage.class b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskPackage.class
+new file mode 100644
+index 0000000..a7a3f00
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/javac/debug/classes/com/RNTextInputMask/RNTextInputMaskPackage.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/local_only_symbol_list/debug/R-def.txt b/node_modules/react-native-text-input-mask/android/build/intermediates/local_only_symbol_list/debug/R-def.txt
+new file mode 100644
+index 0000000..78ac5b8
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/local_only_symbol_list/debug/R-def.txt
+@@ -0,0 +1,2 @@
++R_DEF: Internal format may change without notice
++local
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/manifest_merge_blame_file/debug/manifest-merger-blame-debug-report.txt b/node_modules/react-native-text-input-mask/android/build/intermediates/manifest_merge_blame_file/debug/manifest-merger-blame-debug-report.txt
+new file mode 100644
+index 0000000..fbfd233
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/manifest_merge_blame_file/debug/manifest-merger-blame-debug-report.txt
+@@ -0,0 +1,7 @@
++1<?xml version="1.0" encoding="utf-8"?>
++2<manifest xmlns:android="http://schemas.android.com/apk/res/android"
++3    package="com.RNTextInputMask" >
++4
++5    <uses-sdk android:minSdkVersion="26" />
++6
++7</manifest>
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/merged_manifest/debug/AndroidManifest.xml b/node_modules/react-native-text-input-mask/android/build/intermediates/merged_manifest/debug/AndroidManifest.xml
+new file mode 100644
+index 0000000..32b79dc
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/merged_manifest/debug/AndroidManifest.xml
+@@ -0,0 +1,7 @@
++<?xml version="1.0" encoding="utf-8"?>
++<manifest xmlns:android="http://schemas.android.com/apk/res/android"
++    package="com.RNTextInputMask" >
++
++    <uses-sdk android:minSdkVersion="26" />
++
++</manifest>
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/navigation_json/debug/navigation.json b/node_modules/react-native-text-input-mask/android/build/intermediates/navigation_json/debug/navigation.json
+new file mode 100644
+index 0000000..0637a08
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/navigation_json/debug/navigation.json
+@@ -0,0 +1 @@
++[]
+\ No newline at end of file
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/BuildConfig.class b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/BuildConfig.class
+new file mode 100644
+index 0000000..c38e5af
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/BuildConfig.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule$1$1.class b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule$1$1.class
+new file mode 100644
+index 0000000..7aa7e43
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule$1$1.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule$1.class b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule$1.class
+new file mode 100644
+index 0000000..55f4795
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule$1.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule.class b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule.class
+new file mode 100644
+index 0000000..2a9601e
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskModule.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskPackage.class b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskPackage.class
+new file mode 100644
+index 0000000..a7a3f00
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_dir/debug/com/RNTextInputMask/RNTextInputMaskPackage.class differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar
+new file mode 100644
+index 0000000..c69e81e
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar differ
+diff --git a/node_modules/react-native-text-input-mask/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt b/node_modules/react-native-text-input-mask/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt
+new file mode 100644
+index 0000000..345473c
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt
+@@ -0,0 +1 @@
++com.RNTextInputMask
+diff --git a/node_modules/react-native-text-input-mask/android/build/outputs/logs/manifest-merger-debug-report.txt b/node_modules/react-native-text-input-mask/android/build/outputs/logs/manifest-merger-debug-report.txt
+new file mode 100644
+index 0000000..3c35afc
+--- /dev/null
++++ b/node_modules/react-native-text-input-mask/android/build/outputs/logs/manifest-merger-debug-report.txt
+@@ -0,0 +1,17 @@
++-- Merging decision tree log ---
++manifest
++ADDED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml:1:1-3:12
++INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml:1:1-3:12
++	package
++		ADDED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml:2:11-40
++		INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml
++	xmlns:android
++		ADDED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml:1:11-69
++uses-sdk
++INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml reason: use-sdk injection requested
++INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml
++INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml
++	android:targetSdkVersion
++		INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml
++	android:minSdkVersion
++		INJECTED from /Users/bruno/repos/rainbow/node_modules/react-native-text-input-mask/android/src/main/AndroidManifest.xml
+diff --git a/node_modules/react-native-text-input-mask/android/build/tmp/compileDebugJavaWithJavac/previous-compilation-data.bin b/node_modules/react-native-text-input-mask/android/build/tmp/compileDebugJavaWithJavac/previous-compilation-data.bin
+new file mode 100644
+index 0000000..dc8c43a
+Binary files /dev/null and b/node_modules/react-native-text-input-mask/android/build/tmp/compileDebugJavaWithJavac/previous-compilation-data.bin differ
 diff --git a/node_modules/react-native-text-input-mask/index.js b/node_modules/react-native-text-input-mask/index.js
 index 408edad..3905a6f 100644
 --- a/node_modules/react-native-text-input-mask/index.js
@@ -61,5 +364,4 @@ index 408edad..3905a6f 100644
 +export default forwardRef(ForwardedTextInputMask);
 diff --git a/node_modules/react-native-text-input-mask/ios/.DS_Store b/node_modules/react-native-text-input-mask/ios/.DS_Store
 new file mode 100644
-index 0000000..66750e8
-Binary files /dev/null and b/node_modules/react-native-text-input-mask/ios/.DS_Store differ
+index 0000000..e69de29

--- a/yarn.lock
+++ b/yarn.lock
@@ -8016,7 +8016,7 @@ __metadata:
     react-native-text-input-mask: "npm:2.0.0"
     react-native-text-size: "rainbow-me/react-native-text-size#15b21c9f88c6df0d1b5e0f2ba792fe59b5dc255a"
     react-native-tooltip: "rainbow-me/react-native-tooltip#e0e88d212b5b7f350e5eabba87f588a32e0f2590"
-    react-native-tooltips: "rainbow-me/react-native-tooltips#77338abadbef8225870aea5cfc0dacf94a1448e3"
+    react-native-tooltips: "rainbow-me/react-native-tooltips#2fc21cef76968d085d953edad18181eafcfcf403"
     react-native-udp: "npm:2.7.0"
     react-native-url-polyfill: "npm:2.0.0"
     react-native-version-number: "npm:0.3.6"
@@ -21347,12 +21347,10 @@ react-native-safe-area-view@rainbow-me/react-native-safe-area-view:
   languageName: node
   linkType: hard
 
-"react-native-tooltips@rainbow-me/react-native-tooltips#77338abadbef8225870aea5cfc0dacf94a1448e3":
-  version: 1.0.3
-  resolution: "react-native-tooltips@https://github.com/rainbow-me/react-native-tooltips.git#commit=77338abadbef8225870aea5cfc0dacf94a1448e3"
-  dependencies:
-    deprecated-react-native-prop-types: "npm:2.2.0"
-  checksum: 10c0/b97f5891e583b15a37362f0b0bb2657a41728347bbf1bb4dc692a620db0ea87b02c11c633594e2c6dddcc3b116f6d186616761352f8f803768af3a9b98f9caab
+"react-native-tooltips@rainbow-me/react-native-tooltips#2fc21cef76968d085d953edad18181eafcfcf403":
+  version: 1.0.2
+  resolution: "react-native-tooltips@https://github.com/rainbow-me/react-native-tooltips.git#commit=2fc21cef76968d085d953edad18181eafcfcf403"
+  checksum: 10c0/f644cda3a7e7ec008d82016893e7dcd4da5273f3402d4f33f917892ef64d1fef284f7629dee0195e461edf30cfd92ac38e2ca39a77ad9e313ccd8132f8dbe82b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8016,7 +8016,7 @@ __metadata:
     react-native-text-input-mask: "npm:2.0.0"
     react-native-text-size: "rainbow-me/react-native-text-size#15b21c9f88c6df0d1b5e0f2ba792fe59b5dc255a"
     react-native-tooltip: "rainbow-me/react-native-tooltip#e0e88d212b5b7f350e5eabba87f588a32e0f2590"
-    react-native-tooltips: "rainbow-me/react-native-tooltips#2fc21cef76968d085d953edad18181eafcfcf403"
+    react-native-tooltips: "rainbow-me/react-native-tooltips#fdafbc7ba33ee231229f5d3f58b29d0d1c55ddfa"
     react-native-udp: "npm:2.7.0"
     react-native-url-polyfill: "npm:2.0.0"
     react-native-version-number: "npm:0.3.6"
@@ -21347,10 +21347,10 @@ react-native-safe-area-view@rainbow-me/react-native-safe-area-view:
   languageName: node
   linkType: hard
 
-"react-native-tooltips@rainbow-me/react-native-tooltips#2fc21cef76968d085d953edad18181eafcfcf403":
-  version: 1.0.2
-  resolution: "react-native-tooltips@https://github.com/rainbow-me/react-native-tooltips.git#commit=2fc21cef76968d085d953edad18181eafcfcf403"
-  checksum: 10c0/f644cda3a7e7ec008d82016893e7dcd4da5273f3402d4f33f917892ef64d1fef284f7629dee0195e461edf30cfd92ac38e2ca39a77ad9e313ccd8132f8dbe82b
+"react-native-tooltips@rainbow-me/react-native-tooltips#fdafbc7ba33ee231229f5d3f58b29d0d1c55ddfa":
+  version: 1.0.4
+  resolution: "react-native-tooltips@https://github.com/rainbow-me/react-native-tooltips.git#commit=fdafbc7ba33ee231229f5d3f58b29d0d1c55ddfa"
+  checksum: 10c0/7a1f79d8d381532b41eff2b6e8dbd818a4cbd05c21c28419cba8bfb63047555d5e10ee93687a56c2e093eff7921503971942f14a9b5584e6be93cd21ab334805
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Without this changes we're no longer able to build android for the following reasons:

- BIP39 is no longer found unless we do this https://github.com/NovaCrypto/BIP39/issues/43#issuecomment-1089757699
- react-native-tooltips and react-native-text-input-mask both have similar issues

## Screen recordings / screenshots
<img width="236" alt="Screenshot 2024-08-21 at 3 26 46 PM" src="https://github.com/user-attachments/assets/fe1d8205-0f76-4c9a-81f1-c32f8936dade">

<img width="453" alt="Screenshot 2024-08-22 at 2 39 35 PM" src="https://github.com/user-attachments/assets/b4a8c615-d38a-42bc-b869-be7657fceca0">




## What to test

Nuke and try to build android from scratch