### PR TITLE
shorten popular tokens list from 6 to 3

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -27,6 +27,7 @@ export interface AssetToBuySection {
 
 const MAX_UNVERIFIED_RESULTS = 8;
 const MAX_VERIFIED_RESULTS = 48;
+const MAX_POPULAR_RESULTS = 3;
 
 const mergeAssetsFavoriteStatus = ({
   assets,
@@ -177,7 +178,7 @@ const buildListSectionsData = ({
       assets: combinedData.popularAssets,
       recentSwaps: combinedData.recentSwaps,
       filteredBridgeAssetAddress,
-    }).slice(0, 6);
+    }).slice(0, MAX_POPULAR_RESULTS);
     addSection(
       'popular',
       mergeAssetsFavoriteStatus({

--- a/src/hooks/useWalletBalances.ts
+++ b/src/hooks/useWalletBalances.ts
@@ -79,7 +79,7 @@ const useWalletBalances = (wallets: AllRainbowWallets): WalletBalanceResult => {
     }
 
     return result;
-  }, [allAddresses, summaryData, nativeCurrency]);
+  }, [isLoading, allAddresses, summaryData?.data?.addresses, nativeCurrency]);
 
   return {
     balances,


### PR DESCRIPTION
Fixes APP-1799

## What changed (plus any additional context for devs)
* shortened popular tokens list from 6 to 3
* unrelated: added `isLoading` dependency to memoized wallet balances 

## Screen recordings / screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 14 08 36](https://github.com/user-attachments/assets/89fb4fdf-a1c0-44a6-9e17-e042f3619346)


## What to test

