### PR TITLE
Fix browser favorites migration

### DIFF
--- a/src/model/migrations.ts
+++ b/src/model/migrations.ts
@@ -641,9 +641,19 @@ export default async function runMigrations() {
 
   /**
    *************** Migration v19 ******************
-   * Migrates dapp browser favorites store from createStore to createRainbowStore
+   * Deleted migration
    */
   const v19 = async () => {
+    return;
+  };
+
+  migrations.push(v19);
+
+  /**
+   *************** Migration v20 ******************
+   * Migrates dapp browser favorites store from createStore to createRainbowStore
+   */
+  const v20 = async () => {
     const initializeLegacyStore = () => {
       return new Promise<void>(resolve => {
         // Give the async legacy store a moment to initialize
@@ -666,7 +676,7 @@ export default async function runMigrations() {
     }
   };
 
-  migrations.push(v19);
+  migrations.push(v20);
 
   logger.sentry(`Migrations: ready to run migrations starting on number ${currentVersion}`);
   // await setMigrationVersion(17);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- There was a previously deleted v19 migration that was preventing the browser favorites migration from running on devices that had already run the old v19 migration

## Screen recordings / screenshots


## What to test

