### PR TITLE
Implement perceived finality

### DIFF
--- a/src/state/staleBalances/index.test.ts
+++ b/src/state/staleBalances/index.test.ts
@@ -1,0 +1,165 @@
+import { Address } from 'viem';
+
+import { staleBalancesStore } from '.';
+import { ChainId } from '@/__swaps__/types/chains';
+import { DAI_ADDRESS, OP_ADDRESS } from '@/references';
+import { ETH_ADDRESS } from '@rainbow-me/swaps';
+
+const TEST_ADDRESS_1 = '0xFOO';
+const TEST_ADDRESS_2 = '0xBAR';
+const THEN = Date.now() - 700000;
+const WHEN = Date.now() + 60000;
+
+test('should be able to add asset information to the staleBalances object', async () => {
+  const { addStaleBalance, staleBalances } = staleBalancesStore.getState();
+  expect(staleBalances).toStrictEqual({});
+  addStaleBalance({
+    address: TEST_ADDRESS_1,
+    chainId: ChainId.mainnet,
+    info: {
+      address: DAI_ADDRESS,
+      transactionHash: '0xFOOBAR',
+      expirationTime: THEN,
+    },
+  });
+  addStaleBalance({
+    address: TEST_ADDRESS_1,
+    chainId: ChainId.mainnet,
+    info: {
+      address: ETH_ADDRESS,
+      transactionHash: '0xFOOBAR',
+      expirationTime: WHEN,
+    },
+  });
+  const newStaleBalances = staleBalancesStore.getState().staleBalances;
+  expect(newStaleBalances).toStrictEqual({
+    [TEST_ADDRESS_1]: {
+      [ChainId.mainnet]: {
+        [DAI_ADDRESS]: {
+          address: DAI_ADDRESS,
+          transactionHash: '0xFOOBAR',
+          expirationTime: THEN,
+        },
+        [ETH_ADDRESS]: {
+          address: ETH_ADDRESS,
+          transactionHash: '0xFOOBAR',
+          expirationTime: WHEN,
+        },
+      },
+    },
+  });
+});
+
+test('should generate accurate stale balance query params and clear expired data - case #1', async () => {
+  const { getStaleBalancesQueryParam, clearExpiredData } = staleBalancesStore.getState();
+  clearExpiredData(TEST_ADDRESS_1);
+  const queryParam = getStaleBalancesQueryParam(TEST_ADDRESS_1);
+  expect(queryParam).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}`);
+});
+
+test('should be able to remove expired stale balance and preserve unexpired data', async () => {
+  const { addStaleBalance, clearExpiredData } = staleBalancesStore.getState();
+  addStaleBalance({
+    address: TEST_ADDRESS_1,
+    chainId: ChainId.mainnet,
+    info: {
+      address: DAI_ADDRESS,
+      transactionHash: '0xFOOBAR',
+      expirationTime: THEN,
+    },
+  });
+  addStaleBalance({
+    address: TEST_ADDRESS_1,
+    chainId: ChainId.mainnet,
+    info: {
+      address: ETH_ADDRESS as Address,
+      transactionHash: '0xFOOBAR',
+      expirationTime: WHEN,
+    },
+  });
+  clearExpiredData(TEST_ADDRESS_1);
+  const newStaleBalances = staleBalancesStore.getState().staleBalances;
+  expect(newStaleBalances).toStrictEqual({
+    [TEST_ADDRESS_1]: {
+      [ChainId.mainnet]: {
+        [ETH_ADDRESS]: {
+          address: ETH_ADDRESS,
+          transactionHash: '0xFOOBAR',
+          expirationTime: WHEN,
+        },
+      },
+    },
+  });
+});
+
+test('should preserve data from other addresses when clearing expired data', async () => {
+  const { addStaleBalance, clearExpiredData } = staleBalancesStore.getState();
+  addStaleBalance({
+    address: TEST_ADDRESS_1,
+    chainId: ChainId.mainnet,
+    info: {
+      address: DAI_ADDRESS,
+      transactionHash: '0xFOOBAR',
+      expirationTime: THEN,
+    },
+  });
+  addStaleBalance({
+    address: TEST_ADDRESS_2,
+    chainId: ChainId.mainnet,
+    info: {
+      address: ETH_ADDRESS as Address,
+      transactionHash: '0xFOOBAR',
+      expirationTime: WHEN,
+    },
+  });
+  clearExpiredData(TEST_ADDRESS_1);
+  const newStaleBalances = staleBalancesStore.getState().staleBalances;
+  expect(newStaleBalances).toStrictEqual({
+    [TEST_ADDRESS_1]: {
+      [ChainId.mainnet]: {
+        [ETH_ADDRESS]: {
+          address: ETH_ADDRESS,
+          transactionHash: '0xFOOBAR',
+          expirationTime: WHEN,
+        },
+      },
+    },
+    [TEST_ADDRESS_2]: {
+      [ChainId.mainnet]: {
+        [ETH_ADDRESS]: {
+          address: ETH_ADDRESS,
+          transactionHash: '0xFOOBAR',
+          expirationTime: WHEN,
+        },
+      },
+    },
+  });
+});
+
+test('should generate accurate stale balance query params and clear expired data - case #2', async () => {
+  const { getStaleBalancesQueryParam, clearExpiredData } = staleBalancesStore.getState();
+  clearExpiredData(TEST_ADDRESS_2);
+  const queryParam = getStaleBalancesQueryParam(TEST_ADDRESS_2);
+  expect(queryParam).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}`);
+});
+
+test('should generate accurate stale balance query params and clear expired data - case #3', async () => {
+  const { addStaleBalance, getStaleBalancesQueryParam, clearExpiredData } = staleBalancesStore.getState();
+  addStaleBalance({
+    address: TEST_ADDRESS_1,
+    chainId: ChainId.optimism,
+    info: {
+      address: OP_ADDRESS,
+      transactionHash: '0xFOOBAR',
+      expirationTime: WHEN,
+    },
+  });
+
+  clearExpiredData(TEST_ADDRESS_1);
+  const queryParam = getStaleBalancesQueryParam(TEST_ADDRESS_1);
+  expect(queryParam).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}&token=${ChainId.optimism}.${OP_ADDRESS}`);
+
+  clearExpiredData(TEST_ADDRESS_2);
+  const queryParam2 = getStaleBalancesQueryParam(TEST_ADDRESS_2);
+  expect(queryParam2).toStrictEqual(`&token=${ChainId.mainnet}.${ETH_ADDRESS}`);
+});

--- a/src/state/staleBalances/index.test.ts
+++ b/src/state/staleBalances/index.test.ts
@@ -1,9 +1,9 @@
 import { Address } from 'viem';
 
 import { staleBalancesStore } from '.';
-import { ChainId } from '@/__swaps__/types/chains';
 import { DAI_ADDRESS, OP_ADDRESS } from '@/references';
 import { ETH_ADDRESS } from '@rainbow-me/swaps';
+import { ChainId } from '@/networks/types';
 
 const TEST_ADDRESS_1 = '0xFOO';
 const TEST_ADDRESS_2 = '0xBAR';

--- a/src/state/staleBalances/index.ts
+++ b/src/state/staleBalances/index.ts
@@ -1,0 +1,99 @@
+import { createRainbowStore } from '../internal/createRainbowStore';
+
+const TIME_TO_WATCH = 600000;
+
+interface StaleBalanceInfo {
+  address: string;
+  expirationTime?: number;
+  transactionHash: string;
+}
+
+interface StaleBalances {
+  [key: string]: StaleBalanceInfo;
+}
+interface StaleBalancesByChainId {
+  [key: number]: StaleBalances;
+}
+
+export interface StaleBalancesState {
+  addStaleBalance: ({ address, chainId, info }: { address: string; chainId: number; info: StaleBalanceInfo }) => void;
+  clearExpiredData: (address: string) => void;
+  getStaleBalancesQueryParam: (address: string) => string;
+  staleBalances: Record<string, StaleBalancesByChainId>;
+}
+
+export const staleBalancesStore = createRainbowStore<StaleBalancesState>(
+  (set, get) => ({
+    addStaleBalance: ({ address, chainId, info }: { address: string; chainId: number; info: StaleBalanceInfo }) => {
+      set(state => {
+        const { staleBalances } = state;
+        const staleBalancesForUser = staleBalances[address] || {};
+        const staleBalancesForChain = staleBalancesForUser[chainId] || {};
+        const newStaleBalancesForChain = {
+          ...staleBalancesForChain,
+          [info.address]: {
+            ...info,
+            expirationTime: info.expirationTime || Date.now() + TIME_TO_WATCH,
+          },
+        };
+        const newStaleBalancesForUser = {
+          ...staleBalancesForUser,
+          [chainId]: newStaleBalancesForChain,
+        };
+        return {
+          staleBalances: {
+            ...staleBalances,
+            [address]: newStaleBalancesForUser,
+          },
+        };
+      });
+    },
+    clearExpiredData: (address: string) => {
+      set(state => {
+        const { staleBalances } = state;
+        const staleBalancesForUser = staleBalances[address] || {};
+        const newStaleBalancesForUser: StaleBalancesByChainId = {
+          ...staleBalancesForUser,
+        };
+        for (const c of Object.keys(staleBalancesForUser)) {
+          const chainId = parseInt(c, 10);
+          const newStaleBalancesForChain = {
+            ...(staleBalancesForUser[chainId] || {}),
+          };
+          for (const staleBalance of Object.values(newStaleBalancesForChain)) {
+            if (typeof staleBalance.expirationTime === 'number' && staleBalance.expirationTime <= Date.now()) {
+              delete newStaleBalancesForChain[staleBalance.address];
+            }
+          }
+          newStaleBalancesForUser[chainId] = newStaleBalancesForChain;
+        }
+        return {
+          staleBalances: {
+            ...staleBalances,
+            [address]: newStaleBalancesForUser,
+          },
+        };
+      });
+    },
+    getStaleBalancesQueryParam: (address: string) => {
+      let queryStringFragment = '';
+      const { staleBalances } = get();
+      const staleBalancesForUser = staleBalances[address];
+      for (const c of Object.keys(staleBalancesForUser)) {
+        const chainId = parseInt(c, 10);
+        const staleBalancesForChain = staleBalancesForUser[chainId];
+        for (const staleBalance of Object.values(staleBalancesForChain)) {
+          if (typeof staleBalance.expirationTime === 'number') {
+            queryStringFragment += `&token=${chainId}.${staleBalance.address}`;
+          }
+        }
+      }
+      return queryStringFragment;
+    },
+    staleBalances: {},
+  }),
+  {
+    storageKey: 'staleBalances',
+    version: 0,
+  }
+);


### PR DESCRIPTION
Fixes APP-1703

## What changed (plus any additional context for devs)
When a pending transaction is detected as confirmed, we are flagging the affected assets' addresses and refetching updated user assets balances from BE.

## What to test
Ensure the token params sent to BE reflect the correct addresses when the app attempts to update user asset balances.

Suggestions from Jin:

multiple transactions, different assets
multiple transactions, impacting same assets
Swap 1: ETH → USDC
Swap 2: SHITCOIN → ETH
