### PR TITLE
Fix improper `to` address for ERC-20 sends

### DIFF
--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -113,10 +113,16 @@ export const parseTransaction = async (
     iconUrl: meta.contract_icon_url,
   };
 
+  // NOTE: For send transactions, the to address should be pulled from the outgoing change directly, not the txn.address_to
+  let to = txn.address_to;
+  if (meta.type === 'send') {
+    to = txn.changes.find(change => change?.direction === 'out')?.address_to ?? txn.address_to;
+  }
+
   return {
     chainId,
     from: txn.address_from,
-    to: txn.address_to,
+    to,
     title: `${type}.${status}`,
     description,
     hash,


### PR DESCRIPTION
Fixes APP-1823
Fixes #5678

## What changed (plus any additional context for devs)
- pulls ERC-20 to address from change direction === 'out' for `meta.type === 'send'`

## Screen recordings / screenshots


## What to test

