### PR TITLE
fix: remove p-queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "moti": "0.28",
     "multiformats": "9.6.2",
     "nanoid": "3.2.0",
-    "p-queue": "7.2.0",
     "p-wait-for": "4.1.0",
     "pako": "2.0.4",
     "parse-ms": "2.1.0",

--- a/src/resources/transactions/firstTransactionTimestampQuery.ts
+++ b/src/resources/transactions/firstTransactionTimestampQuery.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import PQueue from 'p-queue/dist';
 
 import { createQueryKey, queryClient, QueryConfig, QueryFunctionArgs, QueryFunctionResult } from '@/react-query';
 import { getFirstTransactionTimestamp } from '@/utils/ethereumUtils';
@@ -23,8 +22,6 @@ export type FirstTransactionTimestampQueryKey = ReturnType<typeof firstTransacti
 // ///////////////////////////////////////////////
 // Query Function
 
-const queue = new PQueue({ interval: 1000, intervalCap: 5 });
-
 export async function firstTransactionTimestampQueryFunction({
   queryKey: [{ addressOrName }],
 }: QueryFunctionArgs<typeof firstTransactionTimestampQueryKey>) {
@@ -35,7 +32,10 @@ export async function firstTransactionTimestampQueryFunction({
     address = (await fetchENSAddress({ name: addressOrName })) ?? '';
   }
 
-  const timestamp = address ? await queue.add(async () => getFirstTransactionTimestamp(address)) : null;
+  let timestamp;
+  if (address) {
+    timestamp = await getFirstTransactionTimestamp(address);
+  }
   return timestamp ?? null;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7976,7 +7976,6 @@ __metadata:
     multiformats: "npm:9.6.2"
     nanoid: "npm:3.2.0"
     node-vibrant: "npm:3.2.1-alpha.1"
-    p-queue: "npm:7.2.0"
     p-wait-for: "npm:4.1.0"
     pako: "npm:2.0.4"
     parse-ms: "npm:2.1.0"
@@ -13160,13 +13159,6 @@ __metadata:
   version: 5.0.1
   resolution: "eventemitter3@npm:5.0.1"
   checksum: 10c0/4ba5c00c506e6c786b4d6262cfbce90ddc14c10d4667e5c83ae993c9de88aa856033994dd2b35b83e8dc1170e224e66a319fa80adc4c32adcd2379bbc75da814
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
   languageName: node
   linkType: hard
 
@@ -19590,17 +19582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-queue@npm:7.2.0":
-  version: 7.2.0
-  resolution: "p-queue@npm:7.2.0"
-  dependencies:
-    eventemitter3: "npm:^4.0.7"
-    p-timeout: "npm:^5.0.2"
-  checksum: 10c0/0dad31488d6afe5c27a84ed00a703eef1ed4387338e0debe8155d36172808c6ae0451be5d88a12aa41f1deb4d3583ecd19e5f6ded5f06c937b01ff828d18c6cb
-  languageName: node
-  linkType: hard
-
-"p-timeout@npm:^5.0.0, p-timeout@npm:^5.0.2":
+"p-timeout@npm:^5.0.0":
   version: 5.1.0
   resolution: "p-timeout@npm:5.1.0"
   checksum: 10c0/1b026cf9d5878c64bec4341ca9cda8ec6b8b3aea8a57885ca0fe2b35753a20d767fb6f9d3aa41e1252f42bc95432c05ea33b6b18f271fb10bfb0789591850a41


### PR DESCRIPTION
fixes APP-1829

## What changed (plus any additional context for devs)
See ticket description for slack thread detailing the 3 crashes found during regression

## What to test
Should be able to press pfp on home. Should be able to advance through the send flow from expanded state and via send button w/o issues
