### PR TITLE
fix bad merge from network -> chainId work

### DIFF
--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -718,12 +718,10 @@ export async function onSessionRequest(event: SignClientTypes.EventArguments['se
 
     logger.debug(`[walletConnect]: handling request`, {}, logger.DebugContext.walletconnect);
 
-    const dappNetwork = ethereumUtils.getNetworkFromChainId(chainId);
-    const displayDetails = await getRequestDisplayDetails(event.params.request, nativeCurrency, dappNetwork);
+    const displayDetails = await getRequestDisplayDetails(event.params.request, nativeCurrency, chainId);
     const peerMeta = session.peer.metadata;
 
     const metadata = await fetchDappMetadata({ url: peerMeta.url, status: true });
-
     const dappName = metadata?.appName || peerMeta.name || lang.t(lang.l.walletconnect.unknown_url);
     const dappImage = metadata?.appLogo || peerMeta?.icons?.[0];
 


### PR DESCRIPTION
Fixes APP-1843

## What changed (plus any additional context for devs)
- fixes bad merge from network -> chainId rework

Error was being thrown in the `getRequestDisplayDetails` because it was looking for a chainId and receiving a network

## Screen recordings / screenshots


## What to test

