### PR TITLE
ens send fix

### DIFF
--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -669,8 +669,16 @@ export const SendConfirmationSheet = () => {
             />
           </SendButtonWrapper>
           {isENS && (
-            /* @ts-expect-error JavaScript component */
-            <GasSpeedButton chainId={ethereumUtils.getChainIdFromNetwork(network)} theme={theme.isDarkMode ? 'dark' : 'light'} />
+            <GasSpeedButton
+              asset={undefined}
+              fallbackColor={undefined}
+              testID={undefined}
+              showGasOptions={undefined}
+              validateGasParams={undefined}
+              crossChainServiceTime={undefined}
+              chainId={chainId}
+              theme={theme.isDarkMode ? 'dark' : 'light'}
+            />
           )}
         </Column>
       </SlackSheet>

--- a/src/screens/SendSheet.js
+++ b/src/screens/SendSheet.js
@@ -762,7 +762,15 @@ export default function SendSheet(props) {
     const assetChainId = selected.chainId;
     const currentProviderChainId = currentProvider._network.chainId;
 
-    if (assetChainId === currentChainId && currentProviderChainId === currentChainId && isValidAddress && !isEmpty(selected)) {
+    if (
+      !!accountAddress &&
+      amountDetails.assetAmount !== '' &&
+      Object.entries(selected).length &&
+      assetChainId === currentChainId &&
+      currentProviderChainId === currentChainId &&
+      isValidAddress &&
+      !isEmpty(selected)
+    ) {
       estimateGasLimit(
         {
           address: accountAddress,


### PR DESCRIPTION
Fixes APP-1844

## What changed (plus any additional context for devs)
`@ts-expect-error` silenced a ts error that `network` was not defined. replaced network w/ chainId, removed the ts-expect-error, and explicitly passed in the missing props as `undefined`

also added the following conditions to be met before attempting gas estimation:
* accountAddress is defined
* `amountDetails.assetAmount` is not an empty string (the default value)
* the `selected` asset to send is not an empty object ( the default value)

## Screen recordings / screenshots

https://github.com/user-attachments/assets/4e09897b-4b85-43a6-a378-104c7d5412a6



## What to test

