### PR TITLE
fix: use correct chainId for send

### DIFF
--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -475,7 +475,6 @@ export const gasPricesStartPolling =
                 defaultGasLimit,
                 gasLimit,
                 selectedGasFee,
-                chainId,
                 selectedGasFee: lastSelectedGasFee,
                 gasFeesBySpeed: lastGasFeesBySpeed,
                 currentBlockParams,


### PR DESCRIPTION
Fixes APP-1846

## What changed (plus any additional context for devs)

incorrect chainId was used to estimate gas, it was using the chainId from state which was mainnet, and then trying to set mainnet chainId to state even tho the tx was in a different chain

![image](https://github.com/user-attachments/assets/95c8feda-3821-40a2-ba61-18e9107e7bf6)


## Screen recordings / screenshots


## What to test

