### PR TITLE
Fixes opacity on mwp sign txn sheet

### DIFF
--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -277,7 +277,8 @@ export const signTransactionSheetConfig = {
   options: ({ route }: { route: SignTransactionSheetRouteProp }) => ({
     ...buildCoolModalConfig({
       ...route.params,
-      backgroundOpacity: route?.params?.source === RequestSource.WALLETCONNECT ? 1 : 0.7,
+      backgroundOpacity:
+        route?.params?.source === RequestSource.WALLETCONNECT || route?.params?.source === RequestSource.MOBILE_WALLET_PROTOCOL ? 1 : 0.7,
       cornerRadius: 0,
       springDamping: 1,
       topOffset: 0,

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -277,8 +277,7 @@ export const signTransactionSheetConfig = {
   options: ({ route }: { route: SignTransactionSheetRouteProp }) => ({
     ...buildCoolModalConfig({
       ...route.params,
-      backgroundOpacity:
-        route?.params?.source === RequestSource.WALLETCONNECT || route?.params?.source === RequestSource.MOBILE_WALLET_PROTOCOL ? 1 : 0.7,
+      backgroundOpacity: [RequestSource.WALLETCONNECT, RequestSource.MOBILE_WALLET_PROTOCOL].includes(route?.params?.source) ? 1 : 0.7,
       cornerRadius: 0,
       springDamping: 1,
       topOffset: 0,


### PR DESCRIPTION
Fixes APP-1852

## What changed (plus any additional context for devs)
fixes opacity on route source for mwp

## Screen 
<img width="559" alt="Screenshot 2024-09-06 at 10 35 23 AM" src="https://github.com/user-attachments/assets/e916d8bb-4a62-419c-8290-cd0634040abc">
recordings / screenshots


## What to test
test that both mobile wallet protocol & wallet connect have a solid background on the SignTransaction sheet.
