### PR TITLE
fix missing dapp metadata for eth actions

### DIFF
--- a/src/components/MobileWalletProtocolListener.tsx
+++ b/src/components/MobileWalletProtocolListener.tsx
@@ -5,21 +5,44 @@ import { logger, RainbowError } from '@/logger';
 import { IS_ANDROID, IS_DEV } from '@/env';
 
 export const MobileWalletProtocolListener = () => {
-  const { message, handleRequestUrl, sendFailureToClient, ...mwpProps } = useMobileWalletProtocolHost();
+  const { message, handleRequestUrl, sendFailureToClient, session, ...mwpProps } = useMobileWalletProtocolHost();
   const lastMessageUuidRef = useRef<string | null>(null);
+  const pendingMessageRef = useRef<typeof message | null>(null);
 
   useEffect(() => {
-    if (message && lastMessageUuidRef.current !== message.uuid) {
-      lastMessageUuidRef.current = message.uuid;
-      try {
-        handleMobileWalletProtocolRequest({ request: message, ...mwpProps });
-      } catch (error) {
-        logger.error(new RainbowError('Error handling Mobile Wallet Protocol request'), {
-          error,
-        });
+    const handleMessage = async () => {
+      if (message && lastMessageUuidRef.current !== message.uuid) {
+        console.log('message', message);
+        lastMessageUuidRef.current = message.uuid;
+
+        // Check if it's a handshake request
+        const isHandshake = message.actions.some(action => action.kind === 'handshake');
+
+        if (isHandshake || session) {
+          try {
+            await handleMobileWalletProtocolRequest({ request: message, session, ...mwpProps });
+          } catch (error) {
+            logger.error(new RainbowError('Error handling Mobile Wallet Protocol request'), {
+              error,
+            });
+          }
+        } else {
+          // Store the message to process once we have a valid session
+          pendingMessageRef.current = message;
+        }
       }
+    };
+
+    handleMessage();
+  }, [message, session, mwpProps]);
+
+  useEffect(() => {
+    if (session && pendingMessageRef.current) {
+      const pendingMessage = pendingMessageRef.current;
+      pendingMessageRef.current = null;
+      handleMobileWalletProtocolRequest({ request: pendingMessage, session, ...mwpProps });
     }
-  }, [message, mwpProps]);
+  }, [session, mwpProps]);
 
   useEffect(() => {
     if (IS_DEV) {

--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -104,8 +104,6 @@ export const SignTransactionSheet = () => {
     source,
   } = routeParams;
 
-  console.log({ specifiedAddress });
-
   const addressToUse = specifiedAddress ?? accountAddress;
 
   const { provider, nativeAsset } = useProviderSetup(chainId, addressToUse);


### PR DESCRIPTION
Fixes APP-1856

## What changed (plus any additional context for devs)
Fixes the missing dapp metadata from the connected session. This was due to the useEffect grabbing the incoming messaging and comparing to the previous. Now we always use the latest up to date message and require a session for anything other than a handshake action.

## Screen recordings / screenshots
https://github.com/user-attachments/assets/89c990ed-b990-44b3-b06d-7645f2d569b7

## What to test
test e2e flow for mwp.
- connect
- signing (personal / typed data)
- transactions
- switching chains