### PR TITLE
Add rc-push script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "clean:packager": "watchman watch-del-all",
     "clean:node": "rm -rf node_modules",
     "nuke": "./scripts/nuke.sh",
+    "rc-push": "./scripts/rc-push.sh",
     "detox:android:release": "detox build -c android.emu.release && detox test -c android.emu.release",
     "detox:android:tests": "detox test -c android.emu.debug --maxWorkers 2 -- --bail 1",
     "detox:android": "detox build -c android.emu.debug && yarn detox:android:tests",

--- a/scripts/rc-push.sh
+++ b/scripts/rc-push.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Get the current branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# Define the regular expression for the RC branch
+BRANCH_REGEX="^rc-v([0-9]+)\.([0-9]+)\.([0-9]+)$"
+
+# Exit early if the branch name doesn't match the pattern
+if [[ ! $BRANCH_NAME =~ $BRANCH_REGEX ]]; then
+    echo "Error: you are not on the RC branch" >&2
+    exit 1
+fi
+
+# Extract version numbers from the branch name
+MAJOR=${BASH_REMATCH[1]}
+MINOR=${BASH_REMATCH[2]}
+PATCH=${BASH_REMATCH[3]}
+
+# Create a tag from the version numbers (without the rc- prefix)
+TAG="v$MAJOR.$MINOR.$PATCH"
+echo "Creating tag $TAG"
+
+# Create the git tag
+git tag "$TAG"
+
+# Push the tag to the remote repository
+git push --tags
+
+# Force push the current branch to master
+echo "Force pushing branch $BRANCH_NAME to master"
+git push origin "$BRANCH_NAME:master" --force
+
+# Get the latest commit SHA on the master branch
+COMMIT_SHA=$(git rev-parse master)
+
+# Get the current UTC time in ISO 8601 format
+DEPLOYED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# App name, repository, and environment (fill in the correct values)
+APP_NAME="rainbow"
+REPO_NAME="rainbow-me/rainbow"
+ENVIRONMENT="production"
+
+echo "Notifying Swarmia about the new release"
+
+# Make the HTTP request to Swarmia
+curl -X POST \
+  https://hook.swarmia.com/deployments \
+  -H "Authorization: $SWARMIA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": "'"$TAG"'",
+    "appName": "'"$APP_NAME"'",
+    "environment": "'"$ENVIRONMENT"'",
+    "deployedAt": "'"$DEPLOYED_AT"'",
+    "commitSha": "'"$COMMIT_SHA"'",
+    "repositoryFullName": "'"$REPO_NAME"'"
+  }'
+
+echo "";
+echo "Release created succesfully"

--- a/scripts/rc-push.sh
+++ b/scripts/rc-push.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source .env
 
 # Get the current branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
@@ -47,7 +48,7 @@ echo "Notifying Swarmia about the new release"
 # Make the HTTP request to Swarmia
 curl -X POST \
   https://hook.swarmia.com/deployments \
-  -H "Authorization: $SWARMIA_TOKEN" \
+  -H "Authorization: " \
   -H "Content-Type: application/json" \
   -d '{
     "version": "'"$TAG"'",


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Added a script that automates the following tasks:
- Creating a github tag for the active rc branch
- Pushing the tag to github
- Force pushing the RC branch into master
- Notifying swarmia about the release.

Requires https://github.com/rainbow-me/rainbow-env/pull/71

## Screen recordings / screenshots
<img width="1074" alt="Screenshot 2024-09-07 at 12 28 04 AM" src="https://github.com/user-attachments/assets/96dc5455-7bee-43a5-9266-c8147538e641">

<img width="690" alt="Screenshot 2024-09-07 at 12 34 17 AM" src="https://github.com/user-attachments/assets/e47831dd-e2a1-44a7-ad0a-e6a4e4bd72ef">



## What to test
No need to test it. Confirmed locally working on the last release.
