### PR TITLE
Fix tophat triggers

### DIFF
--- a/.github/workflows/macstadium-builds.yml
+++ b/.github/workflows/macstadium-builds.yml
@@ -8,7 +8,8 @@ jobs:
   # Job to install dependencies
   build:
     runs-on: ["self-hosted"]
-    if: github.event.pull_request.draft == false
+    timeout-minutes: 75
+    if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- Adds a 75 minute timeout for the entire build job which is more than enough for a normal run.
- Prevents running the job if the PRs were already merged. We don't need test builds if we decided to merge the PR already.


## Screen recordings / screenshots
None

## What to test
I'll let @jinchung  admin merge this PR as soon as I we change it from draft to ready for review,  so we can confirm it works correctly.

