### PR TITLE
add 60 min timeout for e2e jobs

### DIFF
--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -82,6 +82,7 @@ jobs:
   # iOS build and e2e tests
   e2e-ios:
     runs-on: ["self-hosted"]
+    timeout-minutes: 60
     needs: install-deps
     steps:
       - name: Download Yarn cache


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
My theory is that detox is leaving some process hanging whenever the tests fail so the runner is stuck trying to wait for that process to finish before completing the job as you can see [here](https://github.com/rainbow-me/rainbow/actions/runs/10745539430/job/29804928441?pr=6088)

<img width="1126" alt="Screenshot 2024-09-07 at 2 14 57 AM" src="https://github.com/user-attachments/assets/6f405156-289b-4eca-b10e-b8474cf27ff0">


## Screen recordings / screenshots
None


## What to test
Unfortunately we can test this again until there's a failure on e2e but the timeout should just kill the job whenever this happens

