### PR TITLE
Fix wrong messages during MWP Flow

### DIFF
--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -176,10 +176,6 @@ export async function get(key: string, options: KeychainOptions = {}): Promise<R
               logger.error(new RainbowError(`[keychain]: _get() handled unknown error`), {
                 message: e.toString(),
               });
-              return {
-                value: undefined,
-                error: ErrorType.NotAuthenticated,
-              };
             }
 
             return {

--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -172,16 +172,20 @@ export async function get(key: string, options: KeychainOptions = {}): Promise<R
           }
           default: {
             // Avoid logging user cancelled operations
-            if (!(e.toString().includes('code: 10') || e.toString().includes('code: 13'))) {
+            if (e.toString().includes('code: 10') || e.toString().includes('code: 13')) {
+              return {
+                value: undefined,
+                error: ErrorType.UserCanceled,
+              };
+            } else {
               logger.error(new RainbowError(`[keychain]: _get() handled unknown error`), {
                 message: e.toString(),
               });
+              return {
+                value: undefined,
+                error: ErrorType.Unknown,
+              };
             }
-
-            return {
-              value: undefined,
-              error: ErrorType.Unknown,
-            };
           }
         }
       }

--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -172,7 +172,7 @@ export async function get(key: string, options: KeychainOptions = {}): Promise<R
           }
           default: {
             // Avoid logging user cancelled operations
-            if (!(e.toString().includes('code: 10') || e.toString().includes('code: 11'))) {
+            if (!(e.toString().includes('code: 10') || e.toString().includes('code: 13'))) {
               logger.error(new RainbowError(`[keychain]: _get() handled unknown error`), {
                 message: e.toString(),
               });

--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -115,6 +115,7 @@ export async function get(key: string, options: KeychainOptions = {}): Promise<R
             error: e.toString(),
           },
         });
+
         switch (e.toString()) {
           /*
            * Can happen if the user initially had biometrics enabled, installed
@@ -170,9 +171,16 @@ export async function get(key: string, options: KeychainOptions = {}): Promise<R
             return _get(attempts + 1);
           }
           default: {
-            logger.error(new RainbowError(`[keychain]: _get() handled unknown error`), {
-              message: e.toString(),
-            });
+            // Avoid logging user cancelled operations
+            if (!(e.toString().includes('code: 10') || e.toString().includes('code: 11'))) {
+              logger.error(new RainbowError(`[keychain]: _get() handled unknown error`), {
+                message: e.toString(),
+              });
+              return {
+                value: undefined,
+                error: ErrorType.NotAuthenticated,
+              };
+            }
 
             return {
               value: undefined,

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -984,12 +984,20 @@ export const getPrivateKey = async (address: EthereumAddress): Promise<null | Pr
       androidEncryptionPin,
     });
 
-    if (error === -2) {
-      Alert.alert(lang.t('wallet.authenticate.alert.error'), lang.t('wallet.authenticate.alert.current_authentication_not_secure_enough'));
-      return null;
+    switch(error){
+      case -1:
+        logger.error(new RainbowError('KC unknown error for PKEY lookup'), { error });
+        break;
+      case -2:
+        Alert.alert(lang.t('wallet.authenticate.alert.error'), lang.t('wallet.authenticate.alert.current_authentication_not_secure_enough'));
+        return null;
+      case -3:
+        logger.error(new RainbowError('KC unavailable for PKEY lookup'), { error });
+        break;
     }
-
+ 
     return pkey || null;
+
   } catch (error) {
     logger.error(new RainbowError('[wallet]: Error in getPrivateKey'), { error });
     return null;

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -291,7 +291,7 @@ export const loadWallet = async <S extends Screen>({
 
   // -1 means the user cancelled, so we don't wanna do anything
   // -2 Means the user is not authenticated (maybe removed biometrics).
-  //    In this case we show an alet inside loadPrivateKey
+  //    In this case we show an alert inside loadPrivateKey
   if (privateKey === -1 || privateKey === -2) {
     return null;
   }
@@ -539,7 +539,7 @@ export const oldLoadSeedPhrase = async (): Promise<null | EthereumWalletSeed> =>
 
 export const loadAddress = (): Promise<null | EthereumAddress> => keychain.loadString(addressKey) as Promise<string | null>;
 
-export const loadPrivateKey = async (address: EthereumAddress, hardware: boolean): Promise<null | EthereumPrivateKey | -1 | -2 | -3> => {
+export const loadPrivateKey = async (address: EthereumAddress, hardware: boolean): Promise<null | EthereumPrivateKey | -1 | -2> => {
   try {
     const isSeedPhraseMigrated = await keychain.loadString(oldSeedPhraseMigratedKey);
 
@@ -553,7 +553,7 @@ export const loadPrivateKey = async (address: EthereumAddress, hardware: boolean
 
     if (!privateKey) {
       const privateKeyData = await getKeyForWallet(address, hardware);
-      if (privateKeyData === -1 || privateKeyData === -2 || privateKeyData === -3) {
+      if (privateKeyData === -1 || privateKeyData === -2) {
         return privateKeyData;
       }
       privateKey = privateKeyData?.privateKey ?? null;
@@ -916,7 +916,7 @@ export const saveKeyForWallet = async (
  * @param hardware If the wallet is a hardware wallet.
  * @return null | PrivateKeyData | -1
  */
-export const getKeyForWallet = async (address: EthereumAddress, hardware: boolean): Promise<null | PrivateKeyData | -1 | -2 | -3> => {
+export const getKeyForWallet = async (address: EthereumAddress, hardware: boolean): Promise<null | PrivateKeyData | -1 | -2> => {
   if (hardware) {
     return await getHardwareKey(address);
   } else {
@@ -976,7 +976,7 @@ export const saveHardwareKey = async (
  * @param address The wallet address.
  * @return null | PrivateKeyData | -1
  */
-export const getPrivateKey = async (address: EthereumAddress): Promise<null | PrivateKeyData | -1 | -2 | -3> => {
+export const getPrivateKey = async (address: EthereumAddress): Promise<null | PrivateKeyData | -1 | -2> => {
   try {
     const key = `${address}_${privateKeyKey}`;
     const options = { authenticationPrompt };

--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -72,6 +72,7 @@ import { useNonceForDisplay } from '@/hooks/useNonceForDisplay';
 import { useProviderSetup } from '@/hooks/useProviderSetup';
 import { useTransactionSubmission } from '@/hooks/useSubmitTransaction';
 import { useConfirmTransaction } from '@/hooks/useConfirmTransaction';
+import { toChecksumAddress } from 'ethereumjs-util';
 
 type SignTransactionSheetParams = {
   transactionDetails: RequestData;
@@ -103,8 +104,6 @@ export const SignTransactionSheet = () => {
     // for request type specific handling
     source,
   } = routeParams;
-
-  console.log({ specifiedAddress });
 
   const addressToUse = specifiedAddress ?? accountAddress;
 
@@ -334,7 +333,7 @@ export const SignTransactionSheet = () => {
         screen: SCREEN_FOR_REQUEST_SOURCE[source],
         operation: TimeToSignOperation.KeychainRead,
       })({
-        address: accountInfo.address,
+        address: toChecksumAddress(accountInfo.address),
         provider: providerToUse,
         timeTracking: {
           screen: SCREEN_FOR_REQUEST_SOURCE[source],

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -503,6 +503,8 @@ const calculateL1FeeOptimism = async (tx: RainbowTransaction, provider: Provider
     }
 
     // @ts-expect-error operand should be optional
+    delete newTx?.chainId;
+    // @ts-expect-error operand should be optional
     delete newTx?.from;
     // @ts-expect-error gas is not in type RainbowTransaction
     delete newTx?.gas;


### PR DESCRIPTION
Fixes APP-1857
Fixes APP-1854

## What changed (plus any additional context for devs)
A few things were happening with MWP causing this issue:

- We were incorrectly handling the keychain errors so any cancellation would trigger the alert about phones swapping.

- Sometimes (?) we were looking up the pkey using a lowercase version while the original is stored checksummed resulting in "unavailable" error.  I am not sure why but I believe this was on Warpcast side sending different versions of the address, which is why reconnecting fixed the issue (they sent the right one there) but somewhere else they were breaking it.  We're now checksumming it so we don't care anymore.

- We were passing through a `chainId` parameter that was making the L1 fee estimation fail


## Screen recordings / screenshots


https://github.com/user-attachments/assets/eab2408d-4304-4268-8850-4b9dd37fd1e6





## What to test

- MWP normal tx signing flow
- MPW cancelling authentication during face id and later pin.
- Normal sends with and without faceID cancellation 


