### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -62,7 +62,7 @@ jobs:
     needs: install-deps
     steps:
       - name: Download Yarn cache
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: yarn-cache
           path: .yarn
@@ -86,7 +86,7 @@ jobs:
     needs: install-deps
     steps:
       - name: Download Yarn cache
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: yarn-cache
           path: .yarn


### PR DESCRIPTION
Reverts rainbow-me/rainbow#6072