### PR TITLE
bump swaps sdk to 0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@notifee/react-native": "7.8.2",
     "@rainbow-me/provider": "0.0.12",
     "@rainbow-me/react-native-animated-number": "0.0.2",
-    "@rainbow-me/swaps": "0.24.0",
+    "@rainbow-me/swaps": "0.26.0",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-camera-roll/camera-roll": "7.7.0",
     "@react-native-clipboard/clipboard": "1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4403,9 +4403,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rainbow-me/swaps@npm:0.24.0":
-  version: 0.24.0
-  resolution: "@rainbow-me/swaps@npm:0.24.0"
+"@rainbow-me/swaps@npm:0.26.0":
+  version: 0.26.0
+  resolution: "@rainbow-me/swaps@npm:0.26.0"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@ethersproject/abi": "npm:5.7.0"
@@ -4420,7 +4420,7 @@ __metadata:
     "@ethersproject/transactions": "npm:5.7.0"
     "@ethersproject/wallet": "npm:5.7.0"
     "@metamask/eth-sig-util": "npm:7.0.0"
-  checksum: 10c0/c04cdd4f8dca5c2d6f8e371dca88e6359387dea9c9241a98fcacb334cd2016ba985ae70e412bc8983f7074c17a61f80edef1d367222defceb2666c750386f8b9
+  checksum: 10c0/f98672819af669e7dc0c9cc89a439e24e6ac2944ab661ba1c28d691cd2793a0b08550032d4b2f50a67aee0e52907d73efb203798f54264bc40519540eef9ff6a
   languageName: node
   linkType: hard
 
@@ -7862,7 +7862,7 @@ __metadata:
     "@notifee/react-native": "npm:7.8.2"
     "@rainbow-me/provider": "npm:0.0.12"
     "@rainbow-me/react-native-animated-number": "npm:0.0.2"
-    "@rainbow-me/swaps": "npm:0.24.0"
+    "@rainbow-me/swaps": "npm:0.26.0"
     "@react-native-async-storage/async-storage": "npm:1.23.1"
     "@react-native-camera-roll/camera-roll": "npm:7.7.0"
     "@react-native-clipboard/clipboard": "npm:1.13.2"


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Bumping the swaps SDK to v0.26.0 which is required by https://linear.app/rainbow/issue/APP-1849/refactor-swap-submitted-analytic-event

## Screen recordings / screenshots
None because there are no breaking changes, only a  new field has been added.


## What to test
No testing required.
