### PR TITLE
omit certain defi positions from users wallet balance

### DIFF
--- a/src/resources/defi/types.ts
+++ b/src/resources/defi/types.ts
@@ -40,6 +40,7 @@ export type PositionsTotals = {
 export type Claimable = {
   asset: PositionAsset;
   quantity: string;
+  omit_from_total?: boolean;
 };
 export type Deposit = {
   apr: string;
@@ -47,6 +48,7 @@ export type Deposit = {
   asset: PositionAsset;
   quantity: string;
   total_asset: string; // what does this mean?
+  omit_from_total?: boolean;
   underlying: { asset: PositionAsset; quantity: string }[];
 };
 export type Borrow = {
@@ -55,6 +57,7 @@ export type Borrow = {
   asset: PositionAsset;
   quantity: string;
   total_asset: string; // what does this mean?
+  omit_from_total?: boolean;
   underlying: { asset: PositionAsset; quantity: string }[];
 };
 

--- a/src/resources/defi/utils.ts
+++ b/src/resources/defi/utils.ts
@@ -3,10 +3,7 @@ import {
   AddysPositionsResponse,
   Borrow,
   Claimable,
-  Deposit,
-  NativeDisplay,
   Position,
-  PositionAsset,
   PositionsTotals,
   RainbowBorrow,
   RainbowClaimable,
@@ -20,66 +17,58 @@ import { ethereumUtils } from '@/utils';
 
 export const parsePosition = (position: Position, currency: NativeCurrencyKey): RainbowPosition => {
   let totalDeposits = '0';
-  const parsedDeposits = position.deposits?.map((deposit: Deposit): RainbowDeposit => {
-    deposit.underlying = deposit.underlying?.map(
-      (underlying: {
-        asset: PositionAsset;
-        quantity: string;
-      }): {
-        asset: PositionAsset;
-        quantity: string;
-        native: NativeDisplay;
-      } => {
+  const parsedDeposits = position.deposits?.map((deposit): RainbowDeposit => {
+    return {
+      ...deposit,
+      underlying: deposit.underlying?.map(underlying => {
         const nativeDisplay = convertRawAmountToNativeDisplay(
           underlying.quantity,
           underlying.asset.decimals,
           underlying.asset.price?.value!,
           currency
         );
-        totalDeposits = add(totalDeposits, nativeDisplay.amount);
+        if (!deposit.omit_from_total) {
+          totalDeposits = add(totalDeposits, nativeDisplay.amount);
+        }
 
         return {
           ...underlying,
           native: nativeDisplay,
         };
-      }
-    );
-    return deposit as RainbowDeposit;
+      }),
+    };
   });
 
   let totalBorrows = '0';
 
   const parsedBorrows = position.borrows?.map((borrow: Borrow): RainbowBorrow => {
-    borrow.underlying = borrow.underlying.map(
-      (underlying: {
-        asset: PositionAsset;
-        quantity: string;
-      }): {
-        asset: PositionAsset;
-        quantity: string;
-        native: NativeDisplay;
-      } => {
+    return {
+      ...borrow,
+      underlying: borrow.underlying.map(underlying => {
         const nativeDisplay = convertRawAmountToNativeDisplay(
           underlying.quantity,
           underlying.asset.decimals,
           underlying.asset.price?.value!,
           currency
         );
-        totalBorrows = add(totalBorrows, nativeDisplay.amount);
+        if (!borrow.omit_from_total) {
+          totalBorrows = add(totalBorrows, nativeDisplay.amount);
+        }
 
         return {
           ...underlying,
           native: nativeDisplay,
         };
-      }
-    );
-    return borrow as RainbowBorrow;
+      }),
+    };
   });
 
   let totalClaimables = '0';
   const parsedClaimables = position.claimables?.map((claim: Claimable): RainbowClaimable => {
     const nativeDisplay = convertRawAmountToNativeDisplay(claim.quantity, claim.asset.decimals, claim.asset.price?.value!, currency);
-    totalClaimables = add(totalClaimables, nativeDisplay.amount);
+    if (!claim.omit_from_total) {
+      totalClaimables = add(totalClaimables, nativeDisplay.amount);
+    }
     return {
       asset: claim.asset,
       quantity: claim.quantity,


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

uses BE `omit_from_total` tag to ignore adding certain positions value into the users total wallet balance

## Screen recordings / screenshots

before/after
~note: Im looking into that first token in the list ($125.73) not being accounted~(it was BE wayne fixed it 🎉)

<img width="350" alt="Screenshot 2024-09-13 at 16 40 41" src="https://github.com/user-attachments/assets/09cb92d7-2431-42b8-baaa-7111e3e89a61">
<img width="351" alt="Screenshot 2024-09-13 at 16 41 56" src="https://github.com/user-attachments/assets/207de836-2180-4425-918c-9660f0d13811">
<img width="349" alt="Screenshot 2024-09-13 at 16 42 15" src="https://github.com/user-attachments/assets/7ec299f3-d086-4c87-adb0-391bd8b12e4b">


## What to test

