### PR TITLE
Fix swaps search crash 

### DIFF
--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -228,7 +228,7 @@ export const createUserAssetsStore = (address: Address | string) =>
         const { currentAbortController, userAssets } = get();
 
         for (const [id, asset] of userAssets) {
-          if (currentAbortController?.signal.aborted) {
+          if (currentAbortController?.signal?.aborted) {
             return;
           }
           if (selector(asset)) {
@@ -242,7 +242,7 @@ export const createUserAssetsStore = (address: Address | string) =>
           const { currentAbortController } = state;
 
           // Abort any ongoing search work
-          currentAbortController.abort();
+          currentAbortController?.abort?.();
 
           // Create a new AbortController for the new query
           const abortController = new AbortController();

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -214,7 +214,7 @@ export const createUserAssetsStore = (address: Address | string) =>
         const assetIds = filter ? idsByChain.get(filter) || [] : idsByChain.get('all') || [];
 
         for (const id of assetIds) {
-          if (currentAbortController?.signal.aborted) {
+          if (currentAbortController?.signal?.aborted) {
             return;
           }
           const asset = userAssets.get(id);


### PR DESCRIPTION
Fixes APP-1866

## What changed (plus any additional context for devs)
After adding try & catch to all the `runOnJS` calls the error that was happening in release mode only surfaced
<img width="477" alt="Screenshot 2024-09-12 at 5 50 04 PM" src="https://github.com/user-attachments/assets/55567981-598c-4ae1-8af6-11300623b655">


These two values can be undefined and cause a crash that happens only in release mode (due to being a side effect triggered by runOnJS



## Screen recordings / screenshots


https://github.com/user-attachments/assets/f1031578-aba0-44a8-963b-468fb9d66cab



## What to test
Swap search by selecting the input and typing anything
