### PR TITLE
Fix mainnet empty badge

### DIFF
--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.android.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.android.tsx
@@ -53,15 +53,11 @@ export function AnimatedChainImage({
   const chainIdState = useSwapsStore(state => state[assetType === 'input' ? 'inputAsset' : 'outputAsset']?.chainId);
 
   const iconSource = useMemo(() => {
-    let source = { uri: '' };
-
-    if (chainIdState !== undefined && !(!showMainnetBadge && chainIdState === ChainId.mainnet)) {
-      source = networkBadges[chainIdState];
-    } else {
-      source = { uri: '' };
+    if (!chainIdState || (!showMainnetBadge && chainIdState === ChainId.mainnet)) {
+      return { uri: '' };
     }
 
-    return source;
+    return networkBadges[chainIdState];
   }, [chainIdState, showMainnetBadge]);
 
   return (

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.android.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.android.tsx
@@ -53,11 +53,15 @@ export function AnimatedChainImage({
   const chainIdState = useSwapsStore(state => state[assetType === 'input' ? 'inputAsset' : 'outputAsset']?.chainId);
 
   const iconSource = useMemo(() => {
-    if (!chainIdState || (!showMainnetBadge && chainIdState === ChainId.mainnet)) {
-      return { uri: '' };
+    let source = { uri: '' };
+
+    if (chainIdState !== undefined && !(!showMainnetBadge && chainIdState === ChainId.mainnet)) {
+      source = networkBadges[chainIdState];
+    } else {
+      source = { uri: '' };
     }
 
-    return networkBadges[chainIdState];
+    return source;
   }, [chainIdState, showMainnetBadge]);
 
   return (

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.ios.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.ios.tsx
@@ -59,18 +59,17 @@ export function AnimatedChainImage({
     const asset = assetType === 'input' ? internalSelectedInputAsset : internalSelectedOutputAsset;
     const chainId = asset?.value?.chainId;
 
-    let url = 'eth';
-
-    if (chainId !== undefined && !(!showMainnetBadge && chainId === ChainId.mainnet)) {
-      url = networkBadges[chainId];
+    if (!chainId || (!showMainnetBadge && chainId === ChainId.mainnet)) {
+      return '';
     }
-    return url;
+
+    return networkBadges[chainId];
   });
 
   const animatedIconSource = useAnimatedProps(() => ({
     source: {
       ...DEFAULT_FASTER_IMAGE_CONFIG,
-      // base64Placeholder: BLANK_BASE64_PIXEL,
+      base64Placeholder: BLANK_BASE64_PIXEL,
       borderRadius: IS_ANDROID ? (size / 2) * PIXEL_RATIO : size / 2,
       url: url.value,
     },

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.ios.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.ios.tsx
@@ -70,7 +70,7 @@ export function AnimatedChainImage({
   const animatedIconSource = useAnimatedProps(() => ({
     source: {
       ...DEFAULT_FASTER_IMAGE_CONFIG,
-      base64Placeholder: BLANK_BASE64_PIXEL,
+      // base64Placeholder: BLANK_BASE64_PIXEL,
       borderRadius: IS_ANDROID ? (size / 2) * PIXEL_RATIO : size / 2,
       url: url.value,
     },

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.ios.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.ios.tsx
@@ -59,17 +59,18 @@ export function AnimatedChainImage({
     const asset = assetType === 'input' ? internalSelectedInputAsset : internalSelectedOutputAsset;
     const chainId = asset?.value?.chainId;
 
-    if (!chainId || (!showMainnetBadge && chainId === ChainId.mainnet)) {
-      return '';
-    }
+    let url = 'eth';
 
-    return networkBadges[chainId];
+    if (chainId !== undefined && !(!showMainnetBadge && chainId === ChainId.mainnet)) {
+      url = networkBadges[chainId];
+    }
+    return url;
   });
 
   const animatedIconSource = useAnimatedProps(() => ({
     source: {
       ...DEFAULT_FASTER_IMAGE_CONFIG,
-      base64Placeholder: BLANK_BASE64_PIXEL,
+      // base64Placeholder: BLANK_BASE64_PIXEL,
       borderRadius: IS_ANDROID ? (size / 2) * PIXEL_RATIO : size / 2,
       url: url.value,
     },


### PR DESCRIPTION
Fixes APP-1853
Fixes APP-1845

**I haven't been able to reproduce this one at all, so please test this thoroughly**

## What changed (plus any additional context for devs)
Removes the base64placeholder prop which I think is causing the animated faster image to show the View around the chain badge.

## Screen recordings / screenshots
n/a

## What to test
lots of asset swaps to and from mainnet
