### PR TITLE
fix crash on dapp browser tx

### DIFF
--- a/src/hooks/useColorForAsset.ts
+++ b/src/hooks/useColorForAsset.ts
@@ -13,13 +13,14 @@ export default function useColorForAsset(
 ) {
   const { isDarkMode: isDarkModeTheme, colors } = useTheme();
   const accountAsset = ethereumUtils.getAssetFromAllAssets(asset.uniqueId || asset.mainnet_address || asset.address);
-  const resolvedAddress = asset.mainnet_address || asset.address || accountAsset.address;
+
+  const resolvedAddress = asset.mainnet_address || asset.address || accountAsset?.address;
 
   const derivedColor = usePersistentDominantColorFromImage(accountAsset?.icon_url || asset?.icon_url);
   const isDarkMode = forceLightMode || isDarkModeTheme;
 
   const colorDerivedFromAddress = useMemo(() => {
-    if (!isETH(resolvedAddress)) {
+    if (resolvedAddress && !isETH(resolvedAddress)) {
       return pseudoRandomArrayItemFromString(resolvedAddress, colors.avatarBackgrounds);
     }
 


### PR DESCRIPTION
Fixes APP-1875

## What changed (plus any additional context for devs)
Something change recently causing `accountAsset` to be temporarilly undefined.
Calling accountAsset.address was causing a crash. Now instead when that happens we return the default colors.


## Screen recordings / screenshots


https://github.com/user-attachments/assets/53806616-41a9-417a-a2af-47e2e07d2f49




## What to test
Go to app.hyperliquid.xyz - connect - account - deposit -  and deposit 5 USDC on arb.
See video above

