### PR TITLE
Swaps: fix disabled paste button on Android

### DIFF
--- a/src/__swaps__/screens/Swap/components/SearchInputButton.tsx
+++ b/src/__swaps__/screens/Swap/components/SearchInputButton.tsx
@@ -10,6 +10,7 @@ import { THICK_BORDER_WIDTH } from '../constants';
 import { useClipboard } from '@/hooks';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { triggerHapticFeedback } from '@/screens/points/constants';
+import { IS_ANDROID } from '@/env';
 
 const CANCEL_LABEL = i18n.t(i18n.l.button.cancel);
 const CLOSE_LABEL = i18n.t(i18n.l.button.close);
@@ -73,10 +74,11 @@ export const SearchInputButton = ({
     const isInputSearchFocused = inputProgress.value === NavigationSteps.SEARCH_FOCUSED;
     const isOutputSearchFocused = outputProgress.value === NavigationSteps.SEARCH_FOCUSED;
     const isOutputTokenListFocused = outputProgress.value === NavigationSteps.TOKEN_LIST_FOCUSED;
+    
+    const clipboardDataAvailable = hasClipboardData || IS_ANDROID;
 
+    const isPasteDisabled = output && !internalSelectedOutputAsset.value && isOutputTokenListFocused && !clipboardDataAvailable;
     const isVisible = isInputSearchFocused || isOutputSearchFocused || output || (!output && !!internalSelectedInputAsset.value);
-
-    const isPasteDisabled = output && !internalSelectedOutputAsset.value && isOutputTokenListFocused && !hasClipboardData;
     const visibleOpacity = isPasteDisabled ? 0.4 : 1;
 
     return {


### PR DESCRIPTION
Fixes APP-1883

## What changed (plus any additional context for devs)
- Seems `hasClipboardData` isn't reliable or fully reactive to clipboard changes on Android — this doesn't solve that core issue, but should resolve the immediate problem as the button is now always pressable on Android

## Screen recordings / screenshots


## What to test

