### PR TITLE
[APP-1909] Await Claimable TX Before Resolving Rap

### DIFF
--- a/src/rapsV2/actions/claimTransactionClaimableAction.ts
+++ b/src/rapsV2/actions/claimTransactionClaimableAction.ts
@@ -16,6 +16,12 @@ export async function claimTransactionClaimable({ parameters, wallet }: ActionPr
     throw new RainbowError('[CLAIM-TRANSACTION-CLAIMABLE]: failed to execute claim transaction');
   }
 
+  const tx = await wallet?.provider?.getTransaction(result.result.hash);
+  const receipt = await tx?.wait();
+  if (!receipt) {
+    throw new RainbowError('[CLAIM-TRANSACTION-CLAIMABLE]: tx not mined');
+  }
+
   const transaction = {
     amount: '0x0',
     gasLimit: result.result.gasLimit,

--- a/src/rapsV2/actions/claimTransactionClaimableAction.ts
+++ b/src/rapsV2/actions/claimTransactionClaimableAction.ts
@@ -16,12 +16,6 @@ export async function claimTransactionClaimable({ parameters, wallet }: ActionPr
     throw new RainbowError('[CLAIM-TRANSACTION-CLAIMABLE]: failed to execute claim transaction');
   }
 
-  const tx = await wallet?.provider?.getTransaction(result.result.hash);
-  const receipt = await tx?.wait();
-  if (!receipt) {
-    throw new RainbowError('[CLAIM-TRANSACTION-CLAIMABLE]: tx not mined');
-  }
-
   const transaction = {
     amount: '0x0',
     gasLimit: result.result.gasLimit,
@@ -41,6 +35,12 @@ export async function claimTransactionClaimable({ parameters, wallet }: ActionPr
     chainId: claimTx.chainId,
     transaction,
   });
+
+  const tx = await wallet?.provider?.getTransaction(result.result.hash);
+  const receipt = await tx?.wait();
+  if (!receipt) {
+    throw new RainbowError('[CLAIM-TRANSACTION-CLAIMABLE]: tx not mined');
+  }
 
   return {
     nonce: result.result.nonce,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
The claimable modal, when doing tx claims, will now wait to display success until after the tx has been mined.

## Screen recordings / screenshots
Proof of Work: https://www.loom.com/share/7ffbf88141274341974d0d5685f6a32c

## What to test
I wouldn't worry about logging tx confirmation since the code is so simple. Just check out the diff and maybe do a test claim to further ensure that I did not break anything.
