### PR TITLE
Fix WalletconnectV2 changeAccount issues

### DIFF
--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -143,8 +143,6 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
     [dappName, dappUrl, handlePressChangeWallet, reload, session]
   );
 
-  console.log(session.namespaces.eip155?.accounts?.[0]);
-
   return (
     <ContextMenuButton
       testID="wallet_connect_v2_list_item"

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -91,7 +91,7 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
 
   const handlePressChangeWallet = useCallback(() => {
     Navigation.handleAction(Routes.CHANGE_WALLET_SHEET, {
-      currentAccountAddress: accountInfo?.accountAddress,
+      currentAccountAddress: address,
       onChangeWallet: async (address: string) => {
         const success = await changeAccount(session, { address });
         if (success) {

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -102,7 +102,7 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
       },
       watchOnly: true,
     });
-  }, [accountInfo, session, reload, goBack]);
+  }, [address, session, goBack, reload]);
 
   const onPressAndroid = useCallback(() => {
     showActionSheetWithOptions(

--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -37,7 +37,7 @@ import { Box } from '@/design-system';
 import { AuthRequestAuthenticateSignature, AuthRequestResponseErrorReason, RPCMethod, RPCPayload } from '@/walletConnect/types';
 import { AuthRequest } from '@/walletConnect/sheets/AuthRequest';
 import { getProvider } from '@/handlers/web3';
-import { isEmpty, uniq } from 'lodash';
+import { uniq } from 'lodash';
 import { fetchDappMetadata } from '@/resources/metadata/dapp';
 import { DAppStatus } from '@/graphql/__generated__/metadata';
 import { handleWalletConnectRequest } from '@/utils/requestNavigationHandlers';


### PR DESCRIPTION
Fixes APP-1712

## What changed (plus any additional context for devs)
Fixes a few issues that were longstanding with walletconnect v2 connections. I noticed that certain dapps send over a `requiredNamespace:{}` so we were never entering the logically loops to handle switching accounts properly. Separate from that, and after I fixed that, the list item never updated the address shown until closing the `ConnectedDappsSheet` and reopening it. I added some react `useState` to fix this. 

Also, I noticed that the `chainIds` were referencing the `requiredNamespace` in `WalletConnectV2ListItem` so we weren't showing those for v2 connections.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/2a4c6c1a-a5ea-4a9f-8338-97b664ac81ed

https://github.com/user-attachments/assets/2b015a9b-be28-43c7-b001-cbc54f482626

## What to test
- walletconnect v2 and v1 pipeline
