### PR TITLE
Fix ApprovalSheet not using WCV2 `isScam` flag 

### DIFF
--- a/src/screens/WalletConnectApprovalSheet.js
+++ b/src/screens/WalletConnectApprovalSheet.js
@@ -196,7 +196,7 @@ export default function WalletConnectApprovalSheet() {
     url: verifiedData?.origin || dappUrl,
   });
 
-  const isScam = metadata?.status === DAppStatus.Scam;
+  const isScam = metadata?.status === DAppStatus.Scam || verifiedData?.isScam;
 
   // we can only safely mark a dapp as verified if the source is the browser
   const isVerified = metadata?.status === DAppStatus.Verified && source === 'browser';


### PR DESCRIPTION
Fixes APP-1714

## What changed (plus any additional context for devs)
At some point we moved to an external fetch to rely on malicious dapps, but we should respect fallback to wcv2 `isScam`. This should work on walletconnect AND rainbowkit now.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/a27b7c4e-5584-40fa-b6e7-ebc9601cf8b1

## What to test
- Walletconnect and Rainbowkit valid / malicious dapps
