### PR TITLE
Fix CI: Pods git unlock

### DIFF
--- a/.github/workflows/macstadium-builds.yml
+++ b/.github/workflows/macstadium-builds.yml
@@ -59,7 +59,9 @@ jobs:
           npx react-native info
 
       - name: Install pods
-        run: yarn install-bundle && yarn install-pods
+        run: |
+          rm -rf /Users/administrator/.cocoapods/repos/cocoapods/.git/index.lock
+          yarn install-bundle && yarn install-pods
 
       - uses: irgaly/xcode-cache@v1
         with:

--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -103,8 +103,10 @@ jobs:
           npx react-native info
 
       - name: Install pods
-        run: yarn install-bundle && yarn install-pods
-      
+        run: |
+          rm -rf /Users/administrator/.cocoapods/repos/cocoapods/.git/index.lock
+          yarn install-bundle && yarn install-pods
+
       - uses: irgaly/xcode-cache@v1
         with:
           key: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Whenever pod repo update fails, it nevers remove the lock from git internally so I've added a line to remove that file (in case it still exists from a previously failed run) which should solve the issue


## Screen recordings / screenshots
PoW is CI being all green


## What to test
Nothing really

