### PR TITLE
store artifact per branch

### DIFF
--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload Yarn cache
         uses: actions/upload-artifact@v4
         with:
-          name: yarn-cache-${{ github.ref_name }}
+          name: yarn-cache-${{ github.ref_name | replace('/', '-') }}
           path: |
             .yarn/cache
             .yarn/install-state.gz
@@ -65,7 +65,7 @@ jobs:
       - name: Download Yarn cache
         uses: actions/download-artifact@v4
         with:
-          name: yarn-cache-${{ github.ref_name }}
+          name: yarn-cache-${{ github.ref_name | replace('/', '-') }}
           path: .yarn
 
       - name: Check for frozen lockfile
@@ -92,7 +92,7 @@ jobs:
       - name: Download Yarn cache
         uses: actions/download-artifact@v4
         with:
-          name: yarn-cache-${{ github.ref_name }}
+          name: yarn-cache-${{ github.ref_name | replace('/', '-') }}
           path: .yarn
 
       - name: Rebuild detox cache

--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -49,10 +49,14 @@ jobs:
         run: |
           yarn install && yarn setup
 
+      - name: Set sanitized branch name
+        id: sanitize
+        run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
+
       - name: Upload Yarn cache
         uses: actions/upload-artifact@v4
         with:
-          name: yarn-cache-${{ github.ref_name | replace('/', '-') }}
+          name: yarn-cache-${{ env.SANITIZED_REF_NAME }}
           path: |
             .yarn/cache
             .yarn/install-state.gz
@@ -62,10 +66,13 @@ jobs:
     runs-on: ["self-hosted"]
     needs: install-deps
     steps:
+      - name: Set sanitized branch name
+        id: sanitize
+        run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
       - name: Download Yarn cache
         uses: actions/download-artifact@v4
         with:
-          name: yarn-cache-${{ github.ref_name | replace('/', '-') }}
+          name: yarn-cache-${{ env.SANITIZED_REF_NAME }}
           path: .yarn
 
       - name: Check for frozen lockfile
@@ -89,10 +96,13 @@ jobs:
     timeout-minutes: 60
     needs: install-deps
     steps:
+      - name: Set sanitized branch name
+        id: sanitize
+        run: echo "SANITIZED_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
       - name: Download Yarn cache
         uses: actions/download-artifact@v4
         with:
-          name: yarn-cache-${{ github.ref_name | replace('/', '-') }}
+          name: yarn-cache-${{ env.SANITIZED_REF_NAME }}
           path: .yarn
 
       - name: Rebuild detox cache

--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload Yarn cache
         uses: actions/upload-artifact@v4
         with:
-          name: yarn-cache
+          name: yarn-cache-${{ github.ref_name }}
           path: |
             .yarn/cache
             .yarn/install-state.gz
@@ -65,7 +65,7 @@ jobs:
       - name: Download Yarn cache
         uses: actions/download-artifact@v4
         with:
-          name: yarn-cache
+          name: yarn-cache-${{ github.ref_name }}
           path: .yarn
 
       - name: Check for frozen lockfile
@@ -92,7 +92,7 @@ jobs:
       - name: Download Yarn cache
         uses: actions/download-artifact@v4
         with:
-          name: yarn-cache
+          name: yarn-cache-${{ github.ref_name }}
           path: .yarn
 
       - name: Rebuild detox cache


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I think artifacts were being stored with the same name for all branches so having multiple builds running could cause pulling the wrong cache.

Using the branch name on the artifact name should prevent this while maintaining the benefits of cashing between runs.

## Screen recordings / screenshots
None

## What to test
CI should be green
