### PR TITLE
disable one click auth on WC

### DIFF
--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -363,7 +363,7 @@ export async function initListeners() {
 
   client.on('session_proposal', onSessionProposal);
   client.on('session_request', onSessionRequest);
-  // Temporarilly disabling this since there's a bug on the WC side
+  // Temporarily disabling this since there's a bug on the WC side
   // client.on('session_authenticate', onSessionAuthenticate);
   client.on('session_delete', () => {
     logger.debug(`[walletConnect]: session_delete`, {}, logger.DebugContext.walletconnect);

--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -363,7 +363,8 @@ export async function initListeners() {
 
   client.on('session_proposal', onSessionProposal);
   client.on('session_request', onSessionRequest);
-  client.on('session_authenticate', onSessionAuthenticate);
+  // Temporarilly disabling this since there's a bug on the WC side
+  // client.on('session_authenticate', onSessionAuthenticate);
   client.on('session_delete', () => {
     logger.debug(`[walletConnect]: session_delete`, {}, logger.DebugContext.walletconnect);
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Temporarily disabling one click auth flow for WC 

For context: https://rainbowhaus.slack.com/archives/C02SU6XKFD0/p1728689410030729

## Screen recordings / screenshots
None

## What to test
Nothing.

