### PR TITLE
Remove chain ID from notifs payload as it is no longer needed

### DIFF
--- a/src/notifications/settings/firebase.ts
+++ b/src/notifications/settings/firebase.ts
@@ -1,6 +1,5 @@
 import { NOTIFICATIONS_API_KEY } from 'react-native-dotenv';
 import { logger, RainbowError } from '@/logger';
-import { supportedNotificationsChainIds } from '@/chains';
 import {
   GlobalNotificationTopics,
   GlobalNotificationTopicType,
@@ -138,15 +137,12 @@ export const publishWalletSettings = async ({
 
 const parseWalletSettings = (walletSettings: WalletNotificationSettings[]): NotificationSubscriptionWalletsType[] => {
   const enabledWalletSettings = walletSettings.filter(setting => setting.enabled);
-  return enabledWalletSettings.flatMap(setting => {
+  return enabledWalletSettings.map(setting => {
     const topics = Object.keys(setting.topics).filter(topic => !!setting.topics[topic]);
-    return supportedNotificationsChainIds.map(chainId => {
-      return {
-        type: setting.type,
-        chain_id: chainId,
-        address: setting.address.toLowerCase(),
-        transaction_action_types: topics,
-      };
-    });
+    return {
+      type: setting.type,
+      address: setting.address.toLowerCase(),
+      transaction_action_types: topics,
+    };
   });
 };

--- a/src/notifications/settings/types.ts
+++ b/src/notifications/settings/types.ts
@@ -16,7 +16,6 @@ export type GlobalNotificationTopics = {
 
 export type NotificationSubscriptionWalletsType = {
   type: WalletNotificationRelationshipType;
-  chain_id: number;
   address: string;
   transaction_action_types: WalletNotificationTopicType[];
 };


### PR DESCRIPTION
Fixes APP-985

Backend changes have fixed APP-985; this PR itself is a no-op, it only reduces the payload we send to the backend for notifications subscription.

## What changed (plus any additional context for devs)
Previously, we would send a notification subscription for each wallet on each chain. Now, the backend will handle managing the supported chains, so we only need to send a subscription for each wallet.

## Screen recordings / screenshots
TODO: will update once build completes

## What to test
Confirm that subscribing and unsubscribing to notifications still behaves as expected (there should be no change.)
