### PR TITLE
force fastlane update

### DIFF
--- a/.github/workflows/macstadium-builds.yml
+++ b/.github/workflows/macstadium-builds.yml
@@ -85,7 +85,7 @@ jobs:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: |
-            cd ios && bundle exec fastlane ios build_device
+            cd ios && bundle update fastlane && bundle exec fastlane ios build_device
       - name: Upload builds to AWS S3
         env:
           AWS_BUCKET: rainbow-app-team-production


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Tophat job is failing because of a bug in fastlane.  See https://github.com/fastlane/fastlane/issues/21460#issuecomment-2428565479

This PR forces fastlane to update to the latest version before running


## Screen recordings / screenshots
None


## What to test
The tophat build job should be green.
