### PR TITLE
Fix reanimated crash

### DIFF
--- a/src/components/AnimatedComponents/extendedPropsAllowlists.ts
+++ b/src/components/AnimatedComponents/extendedPropsAllowlists.ts
@@ -12,7 +12,6 @@ import Animated from 'react-native-reanimated';
  */
 Animated.addWhitelistedNativeProps({
   defaultValue: true, // AnimatedTextInput
-  text: true, // AnimatedTextInput
 });
 
 /**

--- a/src/react-native-animated-charts/src/index.ts
+++ b/src/react-native-animated-charts/src/index.ts
@@ -1,6 +1,3 @@
-import Animated from 'react-native-reanimated';
-Animated.addWhitelistedNativeProps({ text: true });
-
 export { ChartPathProvider } from './charts/linear/ChartPathProvider';
 export { default as ChartDot } from './charts/linear/ChartDot';
 export { ChartYLabel, ChartXLabel } from './charts/linear/ChartLabels';


### PR DESCRIPTION
Fixes APP-1916

## What changed (plus any additional context for devs)
whitelisting text as native prop was causing a few runtime crashes that are hard to reproduce but there's a bunch of reports on sentry.  After chatting with @christianbaroni  he suggested we disable it.

https://sentry.io/organizations/rainbow-me/issues/5961374042/events/b5e18c03728340b9aa2e32b8887e4421/

## Screen recordings / screenshots
No

## What to test
make sure it doesn't break the animated inputs that use it, eg dapp browser input / expanded state chart % change label when pressing the chart
