### PR TITLE
Remove empty object fallback when txn not found from addys endpoint

### DIFF
--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -45,7 +45,7 @@ export const fetchTransaction = async ({
       },
     });
 
-    const tx = response?.data?.payload?.transaction || {};
+    const tx = response?.data?.payload?.transaction;
     if (!tx) {
       return null;
     }


### PR DESCRIPTION
Fixes APP-1947

## What changed (plus any additional context for devs)
seems this has been there for a while. when a user taps on a notification, we grab the txn hash and fetch via the addys txn endpoint. if a txn is not found by this endpoint, then the `transaction` param in the response is `null`. Unfortunately we have a check here from a long time ago that would default `tx` to `{}` but then immediately after, check `if(!tx)`: https://github.com/rainbow-me/rainbow/blob/develop/src/resources/transactions/transaction.ts#L48 which means the transaction would continue and get parsed and have a default `type` of `contract_interaction` and have a missing `status` and therefore result in lang trying to access: `{i18n.t(i18n.l.transactions.type[transaction?.title])}` - where `transaction?.title` is `contract_interaction.`

## Screen recordings / screenshots
TODO

## What to test
Do a transaction, immediately tap on the notification to maximize chances of addys endpoint not being caught up with the latest transaction, and it should no longer direct you to that transaction.
