### PR TITLE
bump positions query persister version

### DIFF
--- a/src/resources/defi/PositionsQuery.ts
+++ b/src/resources/defi/PositionsQuery.ts
@@ -41,7 +41,7 @@ const getPositions = async (address: string, currency: NativeCurrencyKey): Promi
 export const POSITIONS_QUERY_KEY = 'positions';
 
 export const positionsQueryKey = ({ address, currency }: PositionsArgs) =>
-  createQueryKey(POSITIONS_QUERY_KEY, { address, currency }, { persisterVersion: 1 });
+  createQueryKey(POSITIONS_QUERY_KEY, { address, currency }, { persisterVersion: 2 });
 
 type PositionsQueryKey = ReturnType<typeof positionsQueryKey>;
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

when removing moxie locked positions from the total wallet balance I introduced a new `positions.totals.totalLocked` that the `useWalletBalances` subtract from the total, when the user has old persisted data this prop does not exist while it's refetching/reparsing the positions, making it try to subtract undefined and returning NaN

instead of bumping the persister version (which may cause the user to have the wrong balance, without any positions value, for a couple seconds while it refetches it for the first time after this change is released)
we could do like `positions.totals.totalLocked || '0'` defensive style but I ~think~ in this case I like to have and keep the type contract, not a strong opinion tho

## Screen recordings / screenshots


## What to test

