### PR TITLE
fix initial asset missing on expanded state navigation

### DIFF
--- a/src/components/sheet/sheet-action-buttons/SendActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.js
@@ -13,7 +13,7 @@ function SendActionButton({ asset, color: givenColor, ...props }) {
     () =>
       navigate(Routes.SEND_FLOW, {
         asset,
-        ...(IS_IOS ? { screen: Routes.SEND_SHEET } : {}),
+        ...(IS_IOS ? { screen: Routes.SEND_SHEET, params: { asset } } : {}),
       }),
     [navigate, asset]
   );

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -59,7 +59,6 @@ import {
   settingsSheetConfig,
   signTransactionSheetConfig,
   stackNavigationConfig,
-  swapDetailsSheetConfig,
   learnWebViewScreenConfig,
   transactionDetailsConfig,
   addWalletNavigatorConfig,
@@ -98,7 +97,6 @@ import { ConsoleSheet } from '@/screens/points/ConsoleSheet';
 import { PointsProfileProvider } from '@/screens/points/contexts/PointsProfileContext';
 import AppIconUnlockSheet from '@/screens/AppIconUnlockSheet';
 import { SwapScreen } from '@/__swaps__/screens/Swap/Swap';
-import { useRemoteConfig } from '@/model/remoteConfig';
 import CheckIdentifierScreen from '@/screens/CheckIdentifierScreen';
 import { ControlPanel } from '@/components/DappBrowser/control-panel/ControlPanel';
 import { ClaimRewardsPanel } from '@/screens/points/claim-flow/ClaimRewardsPanel';


### PR DESCRIPTION
Fixes APP-1974

## What changed (plus any additional context for devs)
Fixes the missing asset param in send sheet flow from expanded state

## Screen recordings / screenshots


## What to test

