### PR TITLE
Fix userAssets query enabled config

### DIFF
--- a/src/__swaps__/screens/Swap/resources/assets/index.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/index.ts
@@ -1,4 +1,3 @@
 export { useUserAssets } from './userAssets';
 export type { UserAssetsArgs } from './userAssets';
-export { useUserAssetsByChain } from './userAssetsByChain';
 export type { UserAssetsByChainArgs } from './userAssetsByChain';

--- a/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
@@ -188,9 +188,11 @@ async function userAssetsQueryFunctionRetryByChain({
     }
     const parsedRetries = await Promise.all(retries);
     for (const parsedAssets of parsedRetries) {
-      const values = Object.values(parsedAssets);
-      if (values[0]) {
-        cachedUserAssets[values[0].chainId] = parsedAssets;
+      if (parsedAssets) {
+        const values = Object.values(parsedAssets);
+        if (values[0]) {
+          cachedUserAssets[values[0].chainId] = parsedAssets;
+        }
       }
     }
     queryClient.setQueryData(userAssetsQueryKey({ address, currency, testnetMode }), cachedUserAssets);

--- a/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
@@ -86,6 +86,9 @@ export const userAssetsSetQueryData = ({ address, currency, userAssets, testnetM
 async function userAssetsQueryFunction({
   queryKey: [{ address, currency, testnetMode }],
 }: QueryFunctionArgs<typeof userAssetsQueryKey>): Promise<ParsedAssetsDictByChain> {
+  if (!address) {
+    return {};
+  }
   if (testnetMode) {
     const { assets, chainIdsInResponse } = await fetchHardhatBalancesByChainId(address);
     const parsedAssets: Array<{

--- a/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
@@ -124,12 +124,14 @@ async function userAssetsQueryFunction({
     const chainIdsWithErrorsInResponse = res?.data?.meta?.chain_ids_with_errors || [];
     const assets = res?.data?.payload?.assets || [];
     if (address) {
-      userAssetsQueryFunctionRetryByChain({
-        address,
-        chainIds: chainIdsWithErrorsInResponse,
-        currency,
-        testnetMode,
-      });
+      if (chainIdsWithErrorsInResponse.length) {
+        userAssetsQueryFunctionRetryByChain({
+          address,
+          chainIds: chainIdsWithErrorsInResponse,
+          currency,
+          testnetMode,
+        });
+      }
       if (assets.length && chainIdsInResponse.length) {
         const parsedAssetsDict = await parseUserAssets({
           assets,

--- a/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssets.ts
@@ -86,9 +86,6 @@ export const userAssetsSetQueryData = ({ address, currency, userAssets, testnetM
 async function userAssetsQueryFunction({
   queryKey: [{ address, currency, testnetMode }],
 }: QueryFunctionArgs<typeof userAssetsQueryKey>): Promise<ParsedAssetsDictByChain> {
-  if (!address) {
-    return {};
-  }
   if (testnetMode) {
     const { assets, chainIdsInResponse } = await fetchHardhatBalancesByChainId(address);
     const parsedAssets: Array<{
@@ -240,9 +237,9 @@ export function useUserAssets<TSelectResult = UserAssetsResult>(
   config: QueryConfigWithSelect<UserAssetsResult, Error, TSelectResult, UserAssetsQueryKey> = {}
 ) {
   const { connectedToHardhat } = useConnectedToHardhatStore();
-
   return useQuery(userAssetsQueryKey({ address, currency, testnetMode: connectedToHardhat }), userAssetsQueryFunction, {
     ...config,
+    enabled: !!address && !!currency,
     refetchInterval: USER_ASSETS_REFETCH_INTERVAL,
     staleTime: process.env.IS_TESTING === 'true' ? 0 : 1000,
   });

--- a/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
@@ -63,8 +63,12 @@ async function userAssetsByChainQueryFunction({
   const cachedUserAssets = (cache.find(userAssetsQueryKey({ address, currency }))?.state?.data || {}) as ParsedAssetsDictByChain;
   const cachedDataForChain = cachedUserAssets?.[chainId] || {};
   try {
-    const url = `/${chainId}/${address}/assets/?currency=${currency.toLowerCase()}`;
-    const res = await addysHttp.get<AddressAssetsReceivedMessage>(url);
+    const url = `/${chainId}/${address}/assets`;
+    const res = await addysHttp.get<AddressAssetsReceivedMessage>(url, {
+      params: {
+        currency: currency.toLowerCase(),
+      },
+    });
     const chainIdsInResponse = res?.data?.meta?.chain_ids || [];
     const assets = res?.data?.payload?.assets || [];
     if (assets.length && chainIdsInResponse.length) {

--- a/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import { Address } from 'viem';
 
 import { QueryConfigWithSelect, QueryFunctionArgs, QueryFunctionResult, createQueryKey, queryClient } from '@/react-query';
@@ -11,8 +10,6 @@ import { RainbowError, logger } from '@/logger';
 import { parseUserAssets, userAssetsQueryKey } from './userAssets';
 import { RainbowFetchClient } from '@/rainbow-fetch';
 import { ADDYS_API_KEY } from 'react-native-dotenv';
-
-const USER_ASSETS_REFETCH_INTERVAL = 60000;
 
 const addysHttp = new RainbowFetchClient({
   baseURL: 'https://addys.p.rainbow.me/v3',
@@ -90,24 +87,3 @@ export async function userAssetsByChainQueryFunction({
 }
 
 type UserAssetsByChainResult = QueryFunctionResult<typeof userAssetsByChainQueryFunction>;
-
-// ///////////////////////////////////////////////
-// Query Hook
-
-export function useUserAssetsByChain<TSelectResult = UserAssetsByChainResult>(
-  { address, chainId, currency }: UserAssetsByChainArgs,
-  config: QueryConfigWithSelect<UserAssetsByChainResult, Error, TSelectResult, UserAssetsByChainQueryKey> = {}
-) {
-  return useQuery(
-    userAssetsByChainQueryKey({
-      address,
-      chainId,
-      currency,
-    }),
-    userAssetsByChainQueryFunction,
-    {
-      ...config,
-      refetchInterval: USER_ASSETS_REFETCH_INTERVAL,
-    }
-  );
-}

--- a/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
@@ -61,7 +61,7 @@ async function userAssetsByChainQueryFunction({
 }: QueryFunctionArgs<typeof userAssetsByChainQueryKey>): Promise<Record<string, ParsedUserAsset>> {
   const cache = queryClient.getQueryCache();
   const cachedUserAssets = (cache.find(userAssetsQueryKey({ address, currency }))?.state?.data || {}) as ParsedAssetsDictByChain;
-  const cachedDataForChain = cachedUserAssets?.[chainId];
+  const cachedDataForChain = cachedUserAssets?.[chainId] || {};
   try {
     const url = `/${chainId}/${address}/assets/?currency=${currency.toLowerCase()}`;
     const res = await addysHttp.get<AddressAssetsReceivedMessage>(url);

--- a/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
+++ b/src/__swaps__/screens/Swap/resources/assets/userAssetsByChain.ts
@@ -56,7 +56,7 @@ export async function fetchUserAssetsByChain<TSelectData = UserAssetsByChainResu
 // ///////////////////////////////////////////////
 // Query Function
 
-export async function userAssetsByChainQueryFunction({
+async function userAssetsByChainQueryFunction({
   queryKey: [{ address, chainId, currency }],
 }: QueryFunctionArgs<typeof userAssetsByChainQueryKey>): Promise<Record<string, ParsedUserAsset>> {
   const cache = queryClient.getQueryCache();

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -1,5 +1,6 @@
 import { ParsedSearchAsset, UniqueId, UserAssetFilter } from '@/__swaps__/types/assets';
 import { Address } from 'viem';
+import { isEmpty } from 'lodash';
 import { RainbowError, logger } from '@/logger';
 import reduxStore, { AppState } from '@/redux/store';
 import { ETH_ADDRESS, supportedNativeCurrencies } from '@/references';
@@ -156,7 +157,8 @@ export const createUserAssetsStore = (address: Address | string) =>
         const queryKey = getSearchQueryKey({ filter, searchQuery: inputSearchQuery });
 
         // Use an external function to get the cache to prevent updates in response to changes in the cache
-        const cachedData = getCurrentSearchCache()?.get(queryKey);
+        const currentSearchCache = getCurrentSearchCache();
+        const cachedData = !isEmpty(currentSearchCache) ? getCurrentSearchCache()?.get(queryKey) : [];
 
         // Check if the search results are already cached
         if (cachedData) {
@@ -375,6 +377,6 @@ export function useUserAssetsStore<T>(selector: (state: UserAssetsState) => T) {
   return useStore(store, useCallback(selector, []));
 }
 
-function getCurrentSearchCache(): Map<string, UniqueId[]> | undefined {
+function getCurrentSearchCache(): Map<string, UniqueId[]> {
   return getOrCreateStore().getState().searchCache;
 }

--- a/src/state/sync/UserAssetsSync.tsx
+++ b/src/state/sync/UserAssetsSync.tsx
@@ -9,6 +9,8 @@ import { ChainId } from '@/chains/types';
 export const UserAssetsSync = function UserAssetsSync() {
   const { accountAddress, nativeCurrency: currentCurrency } = useAccountSettings();
   const isSwapsOpen = useSwapsStore(state => state.isSwapsOpen);
+  const isUserAssetsStoreMissingData = userAssetsStore.getState().getUserAssets()?.length === 0;
+  const enabled = (!isSwapsOpen || isUserAssetsStoreMissingData) && !!accountAddress && !!currentCurrency;
 
   useUserAssets(
     {
@@ -16,13 +18,13 @@ export const UserAssetsSync = function UserAssetsSync() {
       currency: currentCurrency,
     },
     {
+      enabled,
       select: data =>
         selectorFilterByUserChains({
           data,
           selector: selectUserAssetsList,
         }),
       onSuccess: data => {
-        const isUserAssetsStoreMissingData = userAssetsStore.getState().getUserAssets()?.length === 0;
         if (!isSwapsOpen || isUserAssetsStoreMissingData) {
           userAssetsStore.getState().setUserAssets(data as ParsedSearchAsset[]);
 

--- a/src/state/sync/UserAssetsSync.tsx
+++ b/src/state/sync/UserAssetsSync.tsx
@@ -9,30 +9,25 @@ import { ChainId } from '@/chains/types';
 export const UserAssetsSync = function UserAssetsSync() {
   const { accountAddress, nativeCurrency: currentCurrency } = useAccountSettings();
 
-  const isSwapsOpen = useSwapsStore(state => state.isSwapsOpen);
-
   useUserAssets(
     {
       address: accountAddress,
       currency: currentCurrency,
     },
     {
-      enabled: !isSwapsOpen,
       select: data =>
         selectorFilterByUserChains({
           data,
           selector: selectUserAssetsList,
         }),
       onSuccess: data => {
-        if (!isSwapsOpen) {
-          userAssetsStore.getState().setUserAssets(data as ParsedSearchAsset[]);
+        userAssetsStore.getState().setUserAssets(data as ParsedSearchAsset[]);
 
-          const inputAsset = userAssetsStore.getState().getHighestValueEth();
-          useSwapsStore.setState({
-            inputAsset,
-            selectedOutputChainId: inputAsset?.chainId ?? ChainId.mainnet,
-          });
-        }
+        const inputAsset = userAssetsStore.getState().getHighestValueEth();
+        useSwapsStore.setState({
+          inputAsset,
+          selectedOutputChainId: inputAsset?.chainId ?? ChainId.mainnet,
+        });
       },
     }
   );

--- a/src/state/sync/UserAssetsSync.tsx
+++ b/src/state/sync/UserAssetsSync.tsx
@@ -8,6 +8,7 @@ import { ChainId } from '@/chains/types';
 
 export const UserAssetsSync = function UserAssetsSync() {
   const { accountAddress, nativeCurrency: currentCurrency } = useAccountSettings();
+  const isSwapsOpen = useSwapsStore(state => state.isSwapsOpen);
 
   useUserAssets(
     {
@@ -21,13 +22,16 @@ export const UserAssetsSync = function UserAssetsSync() {
           selector: selectUserAssetsList,
         }),
       onSuccess: data => {
-        userAssetsStore.getState().setUserAssets(data as ParsedSearchAsset[]);
+        const isUserAssetsStoreMissingData = userAssetsStore.getState().getUserAssets()?.length === 0;
+        if (!isSwapsOpen || isUserAssetsStoreMissingData) {
+          userAssetsStore.getState().setUserAssets(data as ParsedSearchAsset[]);
 
-        const inputAsset = userAssetsStore.getState().getHighestValueEth();
-        useSwapsStore.setState({
-          inputAsset,
-          selectedOutputChainId: inputAsset?.chainId ?? ChainId.mainnet,
-        });
+          const inputAsset = userAssetsStore.getState().getHighestValueEth();
+          useSwapsStore.setState({
+            inputAsset,
+            selectedOutputChainId: inputAsset?.chainId ?? ChainId.mainnet,
+          });
+        }
       },
     }
   );


### PR DESCRIPTION
Fixes APP-1977

## What changed (plus any additional context for devs)
There is a race condition that can happen when we first start the app and do a user assets query function call without the address. We weren't disabling the query function call, resulting in us to just return an empty state and therefore empty objects. There could be a race condition from when we set the incorrect data but before we get the latest data with the account address, when a user could open the swap state, preventing further updates from the user assets store from getting synced.

There were a few different issues happening at the same time, but the retry errors we were getting were not causing this - they were other issues.

This will also be improved once we have Ben's user assets consolidation work in place - we should just make sure to keep some of the changes we introduced here, some of which is more aligned with the original user assets query logic.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/07c0a595-4023-4744-842b-ae244176529e


## What to test
Try to open swaps right after starting the app - the input asset may not be selected by default automatically if it hasn't loaded in time, but the input asset list should refresh with updated assets when they arrive.
