### PR TITLE
Fix native asset symbol always being `ETH` in transaction details

### DIFF
--- a/src/screens/transaction-details/components/TransactionDetailsValueAndFeeSection.tsx
+++ b/src/screens/transaction-details/components/TransactionDetailsValueAndFeeSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DoubleLineTransactionDetailsRow } from '@/screens/transaction-details/components/DoubleLineTransactionDetailsRow';
 import { TransactionDetailsSymbol } from '@/screens/transaction-details/components/TransactionDetailsSymbol';
-import { RainbowTransaction, RainbowTransactionFee } from '@/entities/transactions/transaction';
+import { RainbowTransaction } from '@/entities/transactions/transaction';
 import { Box, Stack, globalColors } from '@/design-system';
 import { TransactionDetailsDivider } from '@/screens/transaction-details/components/TransactionDetailsDivider';
 import * as i18n from '@/languages';
@@ -19,7 +19,6 @@ import { ChainId } from '@/chains/types';
 
 type Props = {
   transaction: RainbowTransaction;
-  fee?: RainbowTransactionFee;
   nativeCurrencyValue?: string;
   value?: string;
 };


### PR DESCRIPTION
Fixes APP-1982

## What changed (plus any additional context for devs)
We now look for native asset on the chain to determine symbol and decimals and fallback to eth mainnet whenever necessary.

## Screen recordings / screenshots
<img width="568" alt="Screenshot 2024-10-30 at 11 19 15 AM" src="https://github.com/user-attachments/assets/33b0175e-635b-4f8c-b5ef-39afa0dc9683">
<img width="568" alt="Screenshot 2024-10-30 at 11 19 09 AM" src="https://github.com/user-attachments/assets/51a79a57-15ce-4f61-aff8-9ed73a37e8a2">


## What to test
test all chains to make sure chain native asset symbol and amount is correct