### PR TITLE
Bump e2e job timeout

### DIFF
--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -117,7 +117,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: install-deps
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Seems like this is taking longer now and we need more runtime.

## Screen recordings / screenshots


## What to test
e2e should pass just fine
