### PR TITLE
Bump persist version on backend networks support for notifs

### DIFF
--- a/src/resources/metadata/backendNetworks.ts
+++ b/src/resources/metadata/backendNetworks.ts
@@ -19,7 +19,7 @@ export interface BackendNetworksResponse {
  */
 export const GRAPHQL_QUERY = BACKEND_NETWORKS_QUERY;
 
-export const backendNetworksQueryKey = () => createQueryKey('backendNetworks', {}, { persisterVersion: 1 });
+export const backendNetworksQueryKey = () => createQueryKey('backendNetworks', {}, { persisterVersion: 2 });
 
 export type BackendNetworksQueryKey = ReturnType<typeof backendNetworksQueryKey>;
 


### PR DESCRIPTION
Fixes APP-1986

## What changed (plus any additional context for devs)
As part of the inclusion of `notifications` enabled flags from the backend networks, I had missed the persist config version bump. Unclear how this got passed initial testing when we were going back and forth from prod builds to TF builds repeatedly - may have been that we didn't delete the app but just reinstalled.

## Screen recordings / screenshots
Screenshot after deleting app, installing prod version, then without deleting, downloading TF 1.9.45 (38)
![IMG_8564](https://github.com/user-attachments/assets/c2baa509-7885-41bd-bc91-97381d2804cf)


## What to test
Delete app, install latest prod, then without deleting the app, install the latest TF with this commit. Should not have any issues.
