### PR TITLE
fix native assets outside of eth not working with preferred network

### DIFF
--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -108,7 +108,7 @@ const useMountSignal = () => {
 const useCleanupOnUnmount = () => {
   useEffect(() => {
     return () => {
-      const highestValueEth = userAssetsStore.getState().getHighestValueEth();
+      const highestValueEth = userAssetsStore.getState().getHighestValueNativeAsset();
       const preferredNetwork = swapsStore.getState().preferredNetwork;
       const parsedAsset = highestValueEth
         ? parseSearchAsset({
@@ -139,7 +139,7 @@ const WalletAddressObserver = () => {
   const { setAsset } = useSwapContext();
 
   const setNewInputAsset = useCallback(() => {
-    const newHighestValueEth = userAssetsStore.getState().getHighestValueEth();
+    const newHighestValueEth = userAssetsStore.getState().getHighestValueNativeAsset();
 
     if (userAssetsStore.getState().filter !== 'all') {
       userAssetsStore.setState({ filter: 'all' });

--- a/src/components/DappBrowser/control-panel/ControlPanel.tsx
+++ b/src/components/DappBrowser/control-panel/ControlPanel.tsx
@@ -440,7 +440,7 @@ const HomePanel = ({
     if (!valid) return;
 
     swapsStore.setState({
-      inputAsset: userAssetsStore.getState().getHighestValueEth(),
+      inputAsset: userAssetsStore.getState().getHighestValueNativeAsset(),
     });
     InteractionManager.runAfterInteractions(() => {
       navigate(Routes.SWAP);
@@ -452,7 +452,7 @@ const HomePanel = ({
     if (!valid) return;
 
     swapsStore.setState({
-      inputAsset: userAssetsStore.getState().getHighestValueEth(),
+      inputAsset: userAssetsStore.getState().getHighestValueNativeAsset(),
     });
     InteractionManager.runAfterInteractions(() => {
       navigate(Routes.SWAP);

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -175,7 +175,7 @@ function SwapButton() {
         category: 'home screen',
       });
       swapsStore.setState({
-        inputAsset: userAssetsStore.getState().getHighestValueEth(),
+        inputAsset: userAssetsStore.getState().getHighestValueNativeAsset(),
       });
       InteractionManager.runAfterInteractions(() => {
         navigate(Routes.SWAP);

--- a/src/components/context-menu-buttons/ChainContextMenu.tsx
+++ b/src/components/context-menu-buttons/ChainContextMenu.tsx
@@ -61,7 +61,7 @@ export const ChainContextMenu = ({
         actionTitle: chainsLabel[chainId],
         icon: {
           iconType: 'ASSET',
-          iconValue: `${chainsName[chainId]}Badge${chainId === ChainId.mainnet ? '' : 'NoShadow'}`,
+          iconValue: chainId === ChainId.mainnet ? 'ethereumBadge' : `${chainsName[chainId]}BadgeNoShadow`,
         },
       };
     });

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -2,7 +2,7 @@ import { ParsedSearchAsset, UniqueId, UserAssetFilter } from '@/__swaps__/types/
 import { Address } from 'viem';
 import { RainbowError, logger } from '@/logger';
 import reduxStore, { AppState } from '@/redux/store';
-import { ETH_ADDRESS, supportedNativeCurrencies } from '@/references';
+import { supportedNativeCurrencies } from '@/references';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 import { useStore } from 'zustand';
 import { useCallback } from 'react';
@@ -39,7 +39,7 @@ export interface UserAssetsState {
   getBalanceSortedChainList: () => ChainId[];
   getChainsWithBalance: () => ChainId[];
   getFilteredUserAssetIds: () => UniqueId[];
-  getHighestValueEth: () => ParsedSearchAsset | null;
+  getHighestValueNativeAsset: () => ParsedSearchAsset | null;
   getUserAsset: (uniqueId: UniqueId) => ParsedSearchAsset | null;
   getUserAssets: () => ParsedSearchAsset[];
   selectUserAssetIds: (selector: (asset: ParsedSearchAsset) => boolean, filter?: UserAssetFilter) => Generator<UniqueId, void, unknown>;
@@ -57,7 +57,7 @@ type UserAssetsStateToPersist = Omit<
   | 'getBalanceSortedChainList'
   | 'getChainsWithBalance'
   | 'getFilteredUserAssetIds'
-  | 'getHighestValueEth'
+  | 'getHighestValueNativeAsset'
   | 'getUserAsset'
   | 'getUserAssets'
   | 'selectUserAssetIds'
@@ -201,14 +201,14 @@ export const createUserAssetsStore = (address: Address | string) =>
           return filteredIds;
         }
       },
-      getHighestValueEth: () => {
+      getHighestValueNativeAsset: () => {
         const preferredNetwork = swapsStore.getState().preferredNetwork;
         const assets = get().userAssets;
 
         let highestValueEth = null;
 
         for (const [, asset] of assets) {
-          if (asset.mainnetAddress !== ETH_ADDRESS) continue;
+          if (!asset.isNativeAsset) continue;
 
           if (preferredNetwork && asset.chainId === preferredNetwork) {
             return asset;

--- a/src/state/sync/UserAssetsSync.tsx
+++ b/src/state/sync/UserAssetsSync.tsx
@@ -28,7 +28,7 @@ export const UserAssetsSync = function UserAssetsSync() {
         if (!isSwapsOpen || isUserAssetsStoreMissingData) {
           userAssetsStore.getState().setUserAssets(data as ParsedSearchAsset[]);
 
-          const inputAsset = userAssetsStore.getState().getHighestValueEth();
+          const inputAsset = userAssetsStore.getState().getHighestValueNativeAsset();
           useSwapsStore.setState({
             inputAsset,
             selectedOutputChainId: inputAsset?.chainId ?? ChainId.mainnet,


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Noticed that Apecoin wasn't being set as the inputAsset when the preferred network was set to apechain. This should fix it. Also renamed the function to be more specific, not just ETH but native token on that chain.

## Screen recordings / screenshots
https://github.com/user-attachments/assets/2024a70a-be61-4a51-9109-f28a6a14a9c3



## What to test
nothing really needs testing tbh
