### PR TITLE
Consolidate env prod vs dev keys usage

### DIFF
--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -26,6 +26,9 @@ jobs:
         run: |
           source ~/.zshrc
           git clone git@github.com:rainbow-me/rainbow-env.git
+          cd rainbow-env
+          git checkout @jin/prod-dev-env
+          cd ..
           mv rainbow-env/dotenv .env && rm -rf rainbow-env
           eval $CI_SCRIPTS
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -44,7 +44,6 @@ declare module 'react-native-dotenv' {
   export const PINATA_GATEWAY_URL: string;
   export const APP_CENTER_READ_ONLY_TOKEN_ANDROID: string;
   export const APP_CENTER_READ_ONLY_TOKEN_IOS: string;
-  export const CODE_PUSH_DEPLOYMENT_KEY_ANDROID: string;
   export const CODE_PUSH_DEPLOYMENT_KEY_IOS: string;
   export const NFT_API_KEY: string;
   export const NFT_API_URL: string;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -64,10 +64,8 @@ declare module 'react-native-dotenv' {
   export const METADATA_GRAPHQL_API_KEY: string;
   export const GRAPH_ENS_API_KEY: string;
   export const RESERVOIR_API_KEY: string;
-  export const RPC_PROXY_BASE_URL_PROD: string;
-  export const RPC_PROXY_BASE_URL_DEV: string;
-  export const RPC_PROXY_API_KEY_PROD: string;
-  export const RPC_PROXY_API_KEY_DEV: string;
+  export const RPC_PROXY_BASE_URL: string;
+  export const RPC_PROXY_API_KEY: string;
   export const REACT_NATIVE_RUDDERSTACK_WRITE_KEY: string;
   export const RUDDERSTACK_DATA_PLANE_URL: string;
   export const SILENCE_EMOJI_WARNINGS: boolean;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -42,8 +42,6 @@ declare module 'react-native-dotenv' {
   export const PINATA_API_SECRET: string;
   export const PINATA_API_URL: string;
   export const PINATA_GATEWAY_URL: string;
-  export const APP_CENTER_READ_ONLY_TOKEN_ANDROID: string;
-  export const APP_CENTER_READ_ONLY_TOKEN_IOS: string;
   export const CODE_PUSH_DEPLOYMENT_KEY_IOS: string;
   export const NFT_API_KEY: string;
   export const NFT_API_URL: string;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -63,8 +63,7 @@ declare module 'react-native-dotenv' {
   export const ARC_GRAPHQL_API_KEY: string;
   export const METADATA_GRAPHQL_API_KEY: string;
   export const GRAPH_ENS_API_KEY: string;
-  export const RESERVOIR_API_KEY_PROD: string;
-  export const RESERVOIR_API_KEY_DEV: string;
+  export const RESERVOIR_API_KEY: string;
   export const RPC_PROXY_BASE_URL_PROD: string;
   export const RPC_PROXY_BASE_URL_DEV: string;
   export const RPC_PROXY_API_KEY_PROD: string;

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,5 @@
 import ReactNative from 'react-native';
-import { ENABLE_DEV_MODE, IS_TESTING, RPC_PROXY_BASE_URL_PROD, RPC_PROXY_API_KEY_PROD } from 'react-native-dotenv';
+import { ENABLE_DEV_MODE, IS_TESTING, RPC_PROXY_BASE_URL as rpcBaseUrl, RPC_PROXY_API_KEY as rpcProxyKey } from 'react-native-dotenv';
 
 /**
  * @deprecated use IS_ANDROID
@@ -21,5 +21,5 @@ export const IS_DEV = (typeof __DEV__ === 'boolean' && __DEV__) || !!Number(ENAB
 export const IS_TEST = IS_TESTING === 'true';
 export const IS_PROD = !IS_DEV && !IS_TEST;
 
-export const RPC_PROXY_BASE_URL = RPC_PROXY_BASE_URL_PROD;
-export const RPC_PROXY_API_KEY = RPC_PROXY_API_KEY_PROD;
+export const RPC_PROXY_BASE_URL = rpcBaseUrl;
+export const RPC_PROXY_API_KEY = rpcProxyKey;

--- a/src/resources/nfts/utils.ts
+++ b/src/resources/nfts/utils.ts
@@ -3,8 +3,7 @@ import { gretch } from 'gretchen';
 import { paths } from '@reservoir0x/reservoir-sdk';
 import { RainbowError, logger } from '@/logger';
 import { handleSignificantDecimals } from '@/helpers/utilities';
-import { IS_PROD } from '@/env';
-import { RESERVOIR_API_KEY_DEV, RESERVOIR_API_KEY_PROD } from 'react-native-dotenv';
+import { RESERVOIR_API_KEY } from 'react-native-dotenv';
 import { Network } from '@/chains/types';
 
 const SUPPORTED_NETWORKS = [Network.mainnet, Network.polygon, Network.bsc, Network.arbitrum, Network.optimism, Network.base, Network.zora];
@@ -27,7 +26,7 @@ export async function fetchReservoirNFTFloorPrice(nft: UniqueAsset): Promise<str
         {
           method: 'GET',
           headers: {
-            'x-api-key': IS_PROD ? RESERVOIR_API_KEY_PROD : RESERVOIR_API_KEY_DEV,
+            'x-api-key': RESERVOIR_API_KEY,
           },
         }
       ).json();

--- a/src/resources/reservoir/client.ts
+++ b/src/resources/reservoir/client.ts
@@ -1,9 +1,7 @@
 import { createClient } from '@reservoir0x/reservoir-sdk';
 import { IS_PROD } from '@/env';
-import { RESERVOIR_API_KEY_PROD, RESERVOIR_API_KEY_DEV } from 'react-native-dotenv';
+import { RESERVOIR_API_KEY } from 'react-native-dotenv';
 import { ChainId, Network } from '@/chains/types';
-
-const RESERVOIR_API_KEY = IS_PROD ? RESERVOIR_API_KEY_PROD : RESERVOIR_API_KEY_DEV;
 
 export function initializeReservoirClient() {
   createClient({

--- a/src/utils/checkTokenIsScam.ts
+++ b/src/utils/checkTokenIsScam.ts
@@ -1,7 +1,0 @@
-import { rainbowTokenList } from '@/references';
-
-export default function checkTokenIsScam(name: string, symbol: string): boolean {
-  const nameFound = rainbowTokenList.TOKEN_SAFE_LIST[name?.toLowerCase()];
-  const symbolFound = rainbowTokenList.TOKEN_SAFE_LIST[symbol?.toLowerCase()];
-  return !!nameFound || !!symbolFound;
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,6 @@ export { default as abbreviations } from './abbreviations';
 export { default as addressUtils } from './address';
 export { default as AllowancesCache } from './allowancesCache';
 export { default as TokensListenedCache } from './tokensListenedCache';
-export { default as checkTokenIsScam } from './checkTokenIsScam';
 export { default as contenthash } from './contenthash';
 export { default as deviceUtils } from './deviceUtils';
 export { default as profileUtils } from './profileUtils';


### PR DESCRIPTION
Related to APP-2008

## What changed (plus any additional context for devs)
* Cleans up more unused configs
* Consolidates some keys that are prod vs staging (will create a separate followup PR for creating separate staging vs prod configs.)
* Associated with: https://github.com/rainbow-me/rainbow-env/pull/73

## Screen recordings / screenshots

<img width="367" alt="Screenshot 2024-11-07 at 11 36 52 AM" src="https://github.com/user-attachments/assets/4dcef886-fb63-4ffc-94f6-97b0b5103801">
<img width="368" alt="Screenshot 2024-11-07 at 11 37 12 AM" src="https://github.com/user-attachments/assets/7dce7e86-112d-4b8a-bcfe-af8dccc68380">
<img width="372" alt="Screenshot 2024-11-07 at 11 37 24 AM" src="https://github.com/user-attachments/assets/ec1fc7eb-06ee-4ed3-84c6-f911894abca6">
<img width="378" alt="Screenshot 2024-11-07 at 11 37 36 AM" src="https://github.com/user-attachments/assets/7674ec80-e564-474e-8a9e-84dede0a7b3c">

## What to test
* wallet data still behaves as expected
* NFT related data (mints, offers, nft metadata) looks the same

