### PR TITLE
fix: wallet telemetry identify

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,18 +18,16 @@ import { designSystemPlaygroundEnabled, reactNativeDisableYellowBox, showNetwork
 import monitorNetwork from '@/debugging/network';
 import { Playground } from '@/design-system/playground/Playground';
 import RainbowContextWrapper from '@/helpers/RainbowContext';
-import * as keychain from '@/model/keychain';
 import { Navigation } from '@/navigation';
 import { PersistQueryClientProvider, persistOptions, queryClient } from '@/react-query';
 import store, { AppDispatch, type AppState } from '@/redux/store';
 import { MainThemeProvider } from '@/theme/ThemeContext';
-import { addressKey } from '@/utils/keychainConstants';
 import { SharedValuesProvider } from '@/helpers/SharedValuesContext';
 import { InitialRouteContext } from '@/navigation/initialRoute';
 import { Portal } from '@/react-native-cool-modals/Portal';
 import { NotificationsHandler } from '@/notifications/NotificationsHandler';
 import { analyticsV2 } from '@/analytics';
-import { getOrCreateDeviceId, securelyHashWalletAddress } from '@/analytics/utils';
+import { getOrCreateDeviceId } from '@/analytics/utils';
 import { logger, RainbowError } from '@/logger';
 import * as ls from '@/storage';
 import { migrate } from '@/migrations';
@@ -38,7 +36,6 @@ import { ReviewPromptAction } from '@/storage/schema';
 import { initializeRemoteConfig } from '@/model/remoteConfig';
 import { NavigationContainerRef } from '@react-navigation/native';
 import { RootStackParamList } from '@/navigation/types';
-import { Address } from 'viem';
 import { IS_ANDROID, IS_DEV } from '@/env';
 import { prefetchDefaultFavorites } from '@/resources/favorites';
 import Routes from '@/navigation/Routes';
@@ -102,27 +99,11 @@ function Root() {
 
       const isReturningUser = ls.device.get(['isReturningUser']);
       const [deviceId, deviceIdWasJustCreated] = await getOrCreateDeviceId();
-      const currentWalletAddress = await keychain.loadString(addressKey);
-      const walletAddressHash =
-        typeof currentWalletAddress === 'string' ? securelyHashWalletAddress(currentWalletAddress as Address) : undefined;
 
-      Sentry.setUser({
-        id: deviceId,
-        walletAddressHash,
-      });
-
-      /**
-       * Add helpful values to `analyticsV2` instance
-       */
+      // Initial telemetry; amended with wallet context later in `useInitializeWallet`
+      Sentry.setUser({ id: deviceId });
       analyticsV2.setDeviceId(deviceId);
-      if (walletAddressHash) {
-        analyticsV2.setWalletAddressHash(walletAddressHash);
-      }
-
-      /**
-       * `analyticsv2` has all it needs to function.
-       */
-      analyticsV2.identify({});
+      analyticsV2.identify();
 
       const isReviewInitialized = ls.review.get(['initialized']);
       if (!isReviewInitialized) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import * as keychain from '@/model/keychain';
 import { Navigation } from '@/navigation';
 import { PersistQueryClientProvider, persistOptions, queryClient } from '@/react-query';
 import store, { AppDispatch, type AppState } from '@/redux/store';
-import { MainThemeProvider, useTheme } from '@/theme/ThemeContext';
+import { MainThemeProvider } from '@/theme/ThemeContext';
 import { addressKey } from '@/utils/keychainConstants';
 import { SharedValuesProvider } from '@/helpers/SharedValuesContext';
 import { InitialRouteContext } from '@/navigation/initialRoute';
@@ -103,20 +103,20 @@ function Root() {
       const isReturningUser = ls.device.get(['isReturningUser']);
       const [deviceId, deviceIdWasJustCreated] = await getOrCreateDeviceId();
       const currentWalletAddress = await keychain.loadString(addressKey);
-      const currentWalletAddressHash =
+      const walletAddressHash =
         typeof currentWalletAddress === 'string' ? securelyHashWalletAddress(currentWalletAddress as Address) : undefined;
 
       Sentry.setUser({
         id: deviceId,
-        currentWalletAddress: currentWalletAddressHash,
+        walletAddressHash,
       });
 
       /**
        * Add helpful values to `analyticsV2` instance
        */
       analyticsV2.setDeviceId(deviceId);
-      if (currentWalletAddressHash) {
-        analyticsV2.setCurrentWalletAddressHash(currentWalletAddressHash);
+      if (walletAddressHash) {
+        analyticsV2.setWalletAddressHash(walletAddressHash);
       }
 
       /**

--- a/src/analytics/__mocks__/index.ts
+++ b/src/analytics/__mocks__/index.ts
@@ -9,7 +9,7 @@ export const analyticsV2 = {
   screen: jest.fn(),
   track: jest.fn(),
   setDeviceId: jest.fn(),
-  setCurrentWalletAddressHash: jest.fn(),
+  setWalletAddressHash: jest.fn(),
   enable: jest.fn(),
   disable: jest.fn(),
   event,

--- a/src/analytics/__mocks__/index.ts
+++ b/src/analytics/__mocks__/index.ts
@@ -9,7 +9,7 @@ export const analyticsV2 = {
   screen: jest.fn(),
   track: jest.fn(),
   setDeviceId: jest.fn(),
-  setWalletAddressHash: jest.fn(),
+  setWalletContext: jest.fn(),
   enable: jest.fn(),
   disable: jest.fn(),
   event,

--- a/src/analytics/__tests__/index.test.ts
+++ b/src/analytics/__tests__/index.test.ts
@@ -18,7 +18,7 @@ describe.skip('@/analytics', () => {
   test('track', () => {
     const analytics = new Analytics();
 
-    analytics.setCurrentWalletAddressHash('hash');
+    analytics.setWalletAddressHash('hash');
     analytics.track(analytics.event.pressedButton);
 
     expect(analytics.client.track).toHaveBeenCalledWith(analytics.event.pressedButton, {
@@ -29,7 +29,7 @@ describe.skip('@/analytics', () => {
   test('identify', () => {
     const analytics = new Analytics();
 
-    analytics.setCurrentWalletAddressHash('hash');
+    analytics.setWalletAddressHash('hash');
     analytics.setDeviceId('id');
     analytics.identify({ currency: 'USD' });
 
@@ -42,7 +42,7 @@ describe.skip('@/analytics', () => {
   test('screen', () => {
     const analytics = new Analytics();
 
-    analytics.setCurrentWalletAddressHash('hash');
+    analytics.setWalletAddressHash('hash');
     analytics.screen(Routes.BACKUP_SHEET);
 
     expect(analytics.client.screen).toHaveBeenCalledWith(Routes.BACKUP_SHEET, {

--- a/src/analytics/__tests__/index.test.ts
+++ b/src/analytics/__tests__/index.test.ts
@@ -18,7 +18,7 @@ describe.skip('@/analytics', () => {
   test('track', () => {
     const analytics = new Analytics();
 
-    analytics.setWalletAddressHash('hash');
+    analytics.setWalletContext({ walletAddressHash: 'hash', walletType: 'owned' });
     analytics.track(analytics.event.pressedButton);
 
     expect(analytics.client.track).toHaveBeenCalledWith(analytics.event.pressedButton, {
@@ -29,7 +29,7 @@ describe.skip('@/analytics', () => {
   test('identify', () => {
     const analytics = new Analytics();
 
-    analytics.setWalletAddressHash('hash');
+    analytics.setWalletContext({ walletAddressHash: 'hash', walletType: 'owned' });
     analytics.setDeviceId('id');
     analytics.identify({ currency: 'USD' });
 
@@ -42,7 +42,7 @@ describe.skip('@/analytics', () => {
   test('screen', () => {
     const analytics = new Analytics();
 
-    analytics.setWalletAddressHash('hash');
+    analytics.setWalletContext({ walletAddressHash: 'hash', walletType: 'owned' });
     analytics.screen(Routes.BACKUP_SHEET);
 
     expect(analytics.client.screen).toHaveBeenCalledWith(Routes.BACKUP_SHEET, {

--- a/src/analytics/__tests__/utils.test.ts
+++ b/src/analytics/__tests__/utils.test.ts
@@ -8,6 +8,8 @@ jest.mock('@/model/keychain', () => ({
   loadString: jest.fn(),
 }));
 
+jest.mock('@/redux/store');
+
 jest.mock('@sentry/react-native', () => ({
   setUser: jest.fn(),
 }));

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -9,9 +9,9 @@ import { device } from '@/storage';
 const isTesting = IS_TESTING === 'true';
 
 export class Analytics {
-  client: any;
-  currentWalletAddressHash?: string;
+  client: typeof rudderClient;
   deviceId?: string;
+  walletAddressHash?: string;
   event = event;
   disabled: boolean;
 
@@ -42,6 +42,7 @@ export class Analytics {
   /**
    * Sends a `screen` event.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   screen(routeName: string, params: Record<string, any> = {}): void {
     if (this.disabled) return;
     const metadata = this.getDefaultMetadata();
@@ -61,7 +62,7 @@ export class Analytics {
 
   private getDefaultMetadata() {
     return {
-      walletAddressHash: this.currentWalletAddressHash,
+      walletAddressHash: this.walletAddressHash,
     };
   }
 
@@ -85,12 +86,12 @@ export class Analytics {
   }
 
   /**
-   * Set `currentWalletAddressHash` for use in events. This DOES NOT call
+   * Set `walletAddressHash` for use in events. This DOES NOT call
    * `identify()`, you must do that on your own.
    */
-  setCurrentWalletAddressHash(currentWalletAddressHash: string) {
-    logger.debug(`[Analytics]: Set currentWalletAddressHash on analytics instance`);
-    this.currentWalletAddressHash = currentWalletAddressHash;
+  setWalletAddressHash(walletAddressHash: string) {
+    logger.debug(`[Analytics]: Set walletAddressHash on analytics instance`);
+    this.walletAddressHash = walletAddressHash;
   }
 
   /**

--- a/src/analytics/utils.ts
+++ b/src/analytics/utils.ts
@@ -1,11 +1,15 @@
 import { nanoid } from 'nanoid/non-secure';
 import { SECURE_WALLET_HASH_KEY } from 'react-native-dotenv';
+import type { Address } from 'viem';
 
 import * as ls from '@/storage';
 import * as keychain from '@/model/keychain';
 import { analyticsUserIdentifier } from '@/utils/keychainConstants';
 import { logger, RainbowError } from '@/logger';
 import { computeHmac, SupportedAlgorithm } from '@ethersproject/sha2';
+import { findWalletWithAccount } from '@/helpers/findWalletWithAccount';
+import store from '@/redux/store';
+import { EthereumWalletType } from '@/helpers/walletTypes';
 
 /**
  * Returns the device id in a type-safe manner. It will throw if no device ID
@@ -58,7 +62,7 @@ export async function getOrCreateDeviceId(): Promise<[string, boolean]> {
   }
 }
 
-export function securelyHashWalletAddress(walletAddress: `0x${string}`): string | undefined {
+function securelyHashWalletAddress(walletAddress: Address): string | undefined {
   if (!SECURE_WALLET_HASH_KEY) {
     logger.error(new RainbowError(`[securelyHashWalletAddress]: Required .env variable SECURE_WALLET_HASH_KEY does not exist`));
   }
@@ -79,4 +83,33 @@ export function securelyHashWalletAddress(walletAddress: `0x${string}`): string 
     // could be an invalid hashing key, or trying to hash an ENS
     logger.error(new RainbowError(`[securelyHashWalletAddress]: Wallet address hashing failed`));
   }
+}
+
+export type WalletContext = {
+  walletType?: 'owned' | 'hardware' | 'watched';
+  walletAddressHash?: string;
+};
+
+export async function getWalletContext(address: Address): Promise<WalletContext> {
+  // currentAddressStore address is initialized to ''
+  if (!address || address === ('' as Address)) return {};
+
+  const { wallets } = store.getState();
+  const wallet = findWalletWithAccount(wallets.wallets || {}, address);
+
+  const walletType = (
+    {
+      [EthereumWalletType.mnemonic]: 'owned',
+      [EthereumWalletType.privateKey]: 'owned',
+      [EthereumWalletType.seed]: 'owned',
+      [EthereumWalletType.readOnly]: 'watched',
+      [EthereumWalletType.bluetooth]: 'hardware',
+    } as const
+  )[wallet?.type!];
+  const walletAddressHash = securelyHashWalletAddress(address);
+
+  return {
+    walletType,
+    walletAddressHash,
+  };
 }

--- a/src/analytics/utils.ts
+++ b/src/analytics/utils.ts
@@ -94,6 +94,7 @@ export async function getWalletContext(address: Address): Promise<WalletContext>
   // currentAddressStore address is initialized to ''
   if (!address || address === ('' as Address)) return {};
 
+  // walletType maybe undefined after initial wallet creation
   const { wallets } = store.getState();
   const wallet = findWalletWithAccount(wallets.wallets || {}, address);
 

--- a/src/hooks/useInitializeWallet.ts
+++ b/src/hooks/useInitializeWallet.ts
@@ -87,6 +87,7 @@ export default function useInitializeWallet() {
         });
 
         // Capture wallet context in telemetry
+        // walletType maybe undefied after initial wallet creation
         const { walletType, walletAddressHash } = await getWalletContext(walletAddress as Address);
         const [deviceId] = await getOrCreateDeviceId();
 
@@ -97,7 +98,7 @@ export default function useInitializeWallet() {
         });
 
         // Allows calling telemetry before currentAddress is available (i.e. onboarding)
-        if (walletType && walletAddressHash) analyticsV2.setWalletContext({ walletAddressHash, walletType });
+        if (walletType || walletAddressHash) analyticsV2.setWalletContext({ walletAddressHash, walletType });
         analyticsV2.setDeviceId(deviceId);
         analyticsV2.identify();
 

--- a/src/hooks/useInitializeWallet.ts
+++ b/src/hooks/useInitializeWallet.ts
@@ -19,6 +19,10 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 import { PROFILES, useExperimentalFlag } from '@/config';
 import { runKeychainIntegrityChecks } from '@/handlers/walletReadyEvents';
 import { RainbowError, logger } from '@/logger';
+import { getOrCreateDeviceId, getWalletContext } from '@/analytics/utils';
+import * as Sentry from '@sentry/react-native';
+import { analyticsV2 } from '@/analytics';
+import { Address } from 'viem';
 
 export default function useInitializeWallet() {
   const dispatch = useDispatch();
@@ -81,6 +85,21 @@ export default function useInitializeWallet() {
           isNew,
           walletAddress,
         });
+
+        // Capture wallet context in telemetry
+        const { walletType, walletAddressHash } = await getWalletContext(walletAddress as Address);
+        const [deviceId] = await getOrCreateDeviceId();
+
+        Sentry.setUser({
+          id: deviceId,
+          walletAddressHash,
+          walletType,
+        });
+
+        // Allows calling telemetry before currentAddress is available (i.e. onboarding)
+        if (walletType && walletAddressHash) analyticsV2.setWalletContext({ walletAddressHash, walletType });
+        analyticsV2.setDeviceId(deviceId);
+        analyticsV2.identify();
 
         if (!switching) {
           // Run keychain integrity checks right after walletInit

--- a/src/redux/__mocks__/store.ts
+++ b/src/redux/__mocks__/store.ts
@@ -1,4 +1,4 @@
-export default {
-  getState: jest.fn(),
-  dispatch: jest.fn(),
-};
+import { jest } from '@jest/globals';
+
+export const getState = jest.fn();
+export const dispatch = jest.fn();


### PR DESCRIPTION
Fixes APP-1956

## What changed (plus any additional context for devs)
- added `walletType` param to `identify` and Sentry user
- setting up Sentry and Rudderstack identify in `useInitializeWallet` to absorb wallet switches
- added `getWalletContext` util to prepare hashes and wallet types consistently throughout the codebase
- added `walletContext` overrides in `track` and `screen` to support scenarios where the actioned wallet is different than the global selected wallet

## Screen recordings / screenshots


## What to test
- confirmed proper hash switching on Rudderstack's side ✅ 
- `walletType` appears to be undefined directly after import because of the following snippet; alternative approach may be necessary 
```
const { wallets } = store.getState();
const wallet = findWalletWithAccount(wallets.wallets || {}, address);
```
