### PR TITLE
Skip node ack check if txn params are for mainnet

### DIFF
--- a/src/raps/execute.ts
+++ b/src/raps/execute.ts
@@ -111,24 +111,29 @@ function getRapFullName<T extends RapActionTypes>(actions: RapAction<T>[]) {
 
 const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
 
-const waitForNodeAck = async (hash: string, provider: Signer['provider']): Promise<void> => {
-  return new Promise(async resolve => {
-    try {
-      const tx = await provider?.getTransaction(hash);
-      // This means the node is aware of the tx, we're good to go
-      if ((tx && tx.blockNumber === null) || (tx && tx?.blockNumber && tx?.blockNumber > 0)) {
-        resolve();
-      } else {
-        // Wait for 1 second and try again
-        await delay(1000);
-        return waitForNodeAck(hash, provider);
-      }
-    } catch (e) {
-      // Wait for 1 second and try again
-      await delay(1000);
-      return waitForNodeAck(hash, provider);
+const NODE_ACK_MAX_TRIES = 10;
+
+const waitForNodeAck = async (hash: string, provider: Signer['provider'], tries = 0): Promise<void> => {
+  try {
+    const tx = await provider?.getTransaction(hash);
+
+    // This means the node is aware of the tx, we're good to go
+    if ((tx && tx.blockNumber === null) || (tx && tx?.blockNumber && tx?.blockNumber > 0)) {
+      return;
     }
-  });
+
+    // Wait for 1 second and try again
+    if (tries < NODE_ACK_MAX_TRIES) {
+      await delay(1000);
+      return waitForNodeAck(hash, provider, tries + 1);
+    }
+  } catch (e) {
+    // Wait for 1 second and try again
+    if (tries < NODE_ACK_MAX_TRIES) {
+      await delay(1000);
+      return waitForNodeAck(hash, provider, tries + 1);
+    }
+  }
 };
 
 export const walletExecuteRap = async (


### PR DESCRIPTION
* Simplifies node ack check to being before any rap action past the first one needs it (means we no longer need to check if there is more than 1 action after the first action; it also means we don't unnecessarily do this check after the last action)
* Simplifies the node ack check to only be for non-mainnet transactions
* Caps the number of retries for node ack to 10
