### PR TITLE
Update handling of flashbots flow

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSwapEstimatedGasLimit.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapEstimatedGasLimit.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { ParsedSearchAsset } from '@/__swaps__/types/assets';
 import { ChainId } from '@/chains/types';
-import { estimateUnlockAndCrosschainSwap } from '@/raps/unlockAndCrosschainSwap';
+import { estimateUnlockAndCrosschainSwap } from '@/raps/actions/crosschainSwap';
 import { estimateUnlockAndSwap } from '@/raps/actions/swap';
 import { QueryConfigWithSelect, QueryFunctionArgs, QueryFunctionResult, createQueryKey } from '@/react-query';
 import { gasUnits } from '@/references/gasUnits';

--- a/src/__swaps__/screens/Swap/hooks/useSwapEstimatedGasLimit.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapEstimatedGasLimit.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ParsedSearchAsset } from '@/__swaps__/types/assets';
 import { ChainId } from '@/chains/types';
 import { estimateUnlockAndCrosschainSwap } from '@/raps/unlockAndCrosschainSwap';
-import { estimateUnlockAndSwap } from '@/raps/unlockAndSwap';
+import { estimateUnlockAndSwap } from '@/raps/actions/swap';
 import { QueryConfigWithSelect, QueryFunctionArgs, QueryFunctionResult, createQueryKey } from '@/react-query';
 import { gasUnits } from '@/references/gasUnits';
 

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -204,7 +204,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
 
       const provider =
         parameters.flashbots && supportedFlashbotsChainIds.includes(parameters.chainId)
-          ? await getFlashbotsProvider()
+          ? getFlashbotsProvider()
           : getProvider({ chainId: parameters.chainId });
       const connectedToHardhat = useConnectedToHardhatStore.getState().connectedToHardhat;
 

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -263,7 +263,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       }
 
       const chainId = connectedToHardhat ? ChainId.hardhat : parameters.chainId;
-      const nonce = await getNextNonce({ address: parameters.quote.from, chainId });
+      const nonce = await getNextNonce({ address: parameters.quote.from, chainId, checkFlashbots: true });
 
       const { errorMessage } = await performanceTracking.getState().executeFn({
         fn: walletExecuteRap,

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -44,6 +44,8 @@ import { queryClient } from '@/react-query';
 import { userAssetsQueryKey } from '@/resources/assets/UserAssetsQuery';
 import { userAssetsStore } from '@/state/assets/userAssets';
 import { swapsStore } from '@/state/swaps/swapsStore';
+import { getNextNonce } from '@/state/nonces';
+
 import { haptics } from '@/utils';
 import { CrosschainQuote, Quote, QuoteError, SwapType } from '@rainbow-me/swaps';
 
@@ -261,6 +263,8 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       }
 
       const chainId = connectedToHardhat ? ChainId.hardhat : parameters.chainId;
+      const nonce = await getNextNonce({ address: parameters.quote.from, chainId });
+
       const { errorMessage } = await performanceTracking.getState().executeFn({
         fn: walletExecuteRap,
         screen: Screens.SWAPS,
@@ -270,6 +274,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
         },
       })(wallet, type, {
         ...parameters,
+        nonce,
         chainId,
         gasParams,
         // @ts-expect-error - collision between old gas types and new

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -263,7 +263,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       }
 
       const chainId = connectedToHardhat ? ChainId.hardhat : parameters.chainId;
-      const nonce = await getNextNonce({ address: parameters.quote.from, chainId, checkFlashbots: true });
+      const nonce = await getNextNonce({ address: parameters.quote.from, chainId });
 
       const { errorMessage } = await performanceTracking.getState().executeFn({
         fn: walletExecuteRap,

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -103,8 +103,8 @@ export const isTestnetChain = ({ chainId = ChainId.mainnet }: { chainId?: ChainI
   return !!defaultChains[chainId].testnet;
 };
 
-// shoudl figure out better way to include this in networks
-export const getFlashbotsProvider = async () => {
+// TODO: should figure out better way to include this in networks
+export const getFlashbotsProvider = () => {
   return new StaticJsonRpcProvider(
     proxyCustomRpcEndpoint(
       ChainId.mainnet,

--- a/src/raps/actions/crosschainSwap.ts
+++ b/src/raps/actions/crosschainSwap.ts
@@ -2,6 +2,8 @@ import { Signer } from '@ethersproject/abstract-signer';
 import { CrosschainQuote, fillCrosschainQuote } from '@rainbow-me/swaps';
 import { Address } from 'viem';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
+import { add } from '@/helpers/utilities';
+import { assetNeedsUnlocking, estimateApprove } from './unlock';
 
 import { REFERRER, gasUnits, ReferrerType } from '@/references';
 import { ChainId } from '@/chains/types';
@@ -10,7 +12,8 @@ import { addNewTransaction } from '@/state/pendingTransactions';
 import { RainbowError, logger } from '@/logger';
 
 import { TransactionGasParams, TransactionLegacyGasParams } from '@/__swaps__/types/gas';
-import { ActionProps, RapActionResult } from '../references';
+import { ActionProps, RapActionResult, RapSwapActionParameters } from '../references';
+
 import {
   CHAIN_IDS_WITH_TRACE_SUPPORT,
   SWAP_GAS_PADDING,
@@ -26,6 +29,65 @@ import { swapsStore } from '@/state/swaps/swapsStore';
 import { chainsName } from '@/chains';
 
 const getCrosschainSwapDefaultGasLimit = (quote: CrosschainQuote) => quote?.routes?.[0]?.userTxs?.[0]?.gasFees?.gasLimit;
+
+export const estimateUnlockAndCrosschainSwap = async ({
+  sellAmount,
+  quote,
+  chainId,
+  assetToSell,
+}: Pick<RapSwapActionParameters<'crosschainSwap'>, 'sellAmount' | 'quote' | 'chainId' | 'assetToSell'>) => {
+  const {
+    from: accountAddress,
+    sellTokenAddress,
+    allowanceTarget,
+    allowanceNeeded,
+  } = quote as {
+    from: Address;
+    sellTokenAddress: Address;
+    allowanceTarget: Address;
+    allowanceNeeded: boolean;
+  };
+
+  let gasLimits: (string | number)[] = [];
+  let swapAssetNeedsUnlocking = false;
+
+  if (allowanceNeeded) {
+    swapAssetNeedsUnlocking = await assetNeedsUnlocking({
+      owner: accountAddress,
+      amount: sellAmount,
+      assetToUnlock: assetToSell,
+      spender: allowanceTarget,
+      chainId,
+    });
+  }
+
+  if (swapAssetNeedsUnlocking) {
+    const unlockGasLimit = await estimateApprove({
+      owner: accountAddress,
+      tokenAddress: sellTokenAddress,
+      spender: allowanceTarget,
+      chainId,
+    });
+    gasLimits = gasLimits.concat(unlockGasLimit);
+  }
+
+  const swapGasLimit = await estimateCrosschainSwapGasLimit({
+    chainId,
+    requiresApprove: swapAssetNeedsUnlocking,
+    quote,
+  });
+
+  if (swapGasLimit === null || swapGasLimit === undefined || isNaN(Number(swapGasLimit))) {
+    return null;
+  }
+
+  const gasLimit = gasLimits.concat(swapGasLimit).reduce((acc, limit) => add(acc, limit), '0');
+  if (isNaN(Number(gasLimit))) {
+    return null;
+  }
+
+  return gasLimit.toString();
+};
 
 export const estimateCrosschainSwapGasLimit = async ({
   chainId,

--- a/src/raps/unlockAndCrosschainSwap.ts
+++ b/src/raps/unlockAndCrosschainSwap.ts
@@ -1,70 +1,8 @@
 import { Address } from 'viem';
 
-import { add } from '@/helpers/utilities';
-
-import { assetNeedsUnlocking, estimateApprove } from './actions';
-import { estimateCrosschainSwapGasLimit } from './actions/crosschainSwap';
+import { assetNeedsUnlocking } from './actions';
 import { createNewAction, createNewRap } from './common';
 import { RapAction, RapSwapActionParameters, RapUnlockActionParameters } from './references';
-
-export const estimateUnlockAndCrosschainSwap = async ({
-  sellAmount,
-  quote,
-  chainId,
-  assetToSell,
-}: Pick<RapSwapActionParameters<'crosschainSwap'>, 'sellAmount' | 'quote' | 'chainId' | 'assetToSell'>) => {
-  const {
-    from: accountAddress,
-    sellTokenAddress,
-    allowanceTarget,
-    allowanceNeeded,
-  } = quote as {
-    from: Address;
-    sellTokenAddress: Address;
-    allowanceTarget: Address;
-    allowanceNeeded: boolean;
-  };
-
-  let gasLimits: (string | number)[] = [];
-  let swapAssetNeedsUnlocking = false;
-
-  if (allowanceNeeded) {
-    swapAssetNeedsUnlocking = await assetNeedsUnlocking({
-      owner: accountAddress,
-      amount: sellAmount,
-      assetToUnlock: assetToSell,
-      spender: allowanceTarget,
-      chainId,
-    });
-  }
-
-  if (swapAssetNeedsUnlocking) {
-    const unlockGasLimit = await estimateApprove({
-      owner: accountAddress,
-      tokenAddress: sellTokenAddress,
-      spender: allowanceTarget,
-      chainId,
-    });
-    gasLimits = gasLimits.concat(unlockGasLimit);
-  }
-
-  const swapGasLimit = await estimateCrosschainSwapGasLimit({
-    chainId,
-    requiresApprove: swapAssetNeedsUnlocking,
-    quote,
-  });
-
-  if (swapGasLimit === null || swapGasLimit === undefined || isNaN(Number(swapGasLimit))) {
-    return null;
-  }
-
-  const gasLimit = gasLimits.concat(swapGasLimit).reduce((acc, limit) => add(acc, limit), '0');
-  if (isNaN(Number(gasLimit))) {
-    return null;
-  }
-
-  return gasLimit.toString();
-};
 
 export const createUnlockAndCrosschainSwapRap = async (swapParameters: RapSwapActionParameters<'crosschainSwap'>) => {
   let actions: RapAction<'crosschainSwap' | 'unlock'>[] = [];

--- a/src/raps/unlockAndSwap.ts
+++ b/src/raps/unlockAndSwap.ts
@@ -1,79 +1,8 @@
 import { getRainbowRouterContractAddress } from '@rainbow-me/swaps';
 import { Address } from 'viem';
-
-import { add } from '@/helpers/utilities';
-
-import { assetNeedsUnlocking, estimateApprove, estimateSwapGasLimit } from './actions';
-import { estimateUnlockAndSwapFromMetadata } from './actions/swap';
+import { assetNeedsUnlocking } from './actions';
 import { createNewAction, createNewRap } from './common';
 import { RapAction, RapSwapActionParameters, RapUnlockActionParameters } from './references';
-
-export const estimateUnlockAndSwap = async ({
-  sellAmount,
-  quote,
-  chainId,
-  assetToSell,
-}: Pick<RapSwapActionParameters<'swap'>, 'sellAmount' | 'quote' | 'chainId' | 'assetToSell'>) => {
-  const {
-    from: accountAddress,
-    sellTokenAddress,
-    allowanceNeeded,
-  } = quote as {
-    from: Address;
-    sellTokenAddress: Address;
-    allowanceNeeded: boolean;
-  };
-
-  let gasLimits: (string | number)[] = [];
-  let swapAssetNeedsUnlocking = false;
-
-  if (allowanceNeeded) {
-    swapAssetNeedsUnlocking = await assetNeedsUnlocking({
-      owner: accountAddress,
-      amount: sellAmount,
-      assetToUnlock: assetToSell,
-      spender: getRainbowRouterContractAddress(chainId),
-      chainId,
-    });
-  }
-
-  if (swapAssetNeedsUnlocking) {
-    const gasLimitFromMetadata = await estimateUnlockAndSwapFromMetadata({
-      swapAssetNeedsUnlocking,
-      chainId,
-      accountAddress,
-      sellTokenAddress,
-      quote,
-    });
-    if (gasLimitFromMetadata) {
-      return gasLimitFromMetadata;
-    }
-    const unlockGasLimit = await estimateApprove({
-      owner: accountAddress,
-      tokenAddress: sellTokenAddress,
-      spender: getRainbowRouterContractAddress(chainId),
-      chainId,
-    });
-    gasLimits = gasLimits.concat(unlockGasLimit);
-  }
-
-  const swapGasLimit = await estimateSwapGasLimit({
-    chainId,
-    requiresApprove: swapAssetNeedsUnlocking,
-    quote,
-  });
-
-  if (swapGasLimit === null || swapGasLimit === undefined || isNaN(Number(swapGasLimit))) {
-    return null;
-  }
-
-  const gasLimit = gasLimits.concat(swapGasLimit).reduce((acc, limit) => add(acc, limit), '0');
-  if (isNaN(Number(gasLimit))) {
-    return null;
-  }
-
-  return gasLimit.toString();
-};
 
 export const createUnlockAndSwapRap = async (swapParameters: RapSwapActionParameters<'swap'>) => {
   let actions: RapAction<'swap' | 'unlock'>[] = [];

--- a/src/raps/utils.ts
+++ b/src/raps/utils.ts
@@ -70,7 +70,7 @@ const getStateDiff = async (provider: Provider, quote: Quote | CrosschainQuote):
       value: '0x0',
     },
     ['stateDiff'],
-    blockNumber - TRACE_CALL_BLOCK_NUMBER_OFFSET,
+    toHexNoLeadingZeros(blockNumber - TRACE_CALL_BLOCK_NUMBER_OFFSET),
   ];
 
   const trace = await (provider as StaticJsonRpcProvider).send('trace_call', callParams);

--- a/src/screens/SpeedUpAndCancelSheet.tsx
+++ b/src/screens/SpeedUpAndCancelSheet.tsx
@@ -312,19 +312,15 @@ export default function SpeedUpAndCancelSheet() {
   useEffect(() => {
     if (currentChainId) {
       startPollingGasFees(currentChainId, tx.flashbots);
-      const updateProvider = async () => {
-        let provider;
-        if (supportedFlashbotsChainIds.includes(tx.chainId || ChainId.mainnet) && tx.flashbots) {
-          logger.debug(`[SpeedUpAndCancelSheet]: using flashbots provider for chainId ${tx?.chainId}`);
-          provider = await getFlashbotsProvider();
-        } else {
-          logger.debug(`[SpeedUpAndCancelSheet]: using provider for network ${tx?.chainId}`);
-          provider = getProvider({ chainId: currentChainId });
-        }
-        setCurrentProvider(provider);
-      };
-
-      updateProvider();
+      let provider;
+      if (supportedFlashbotsChainIds.includes(tx.chainId || ChainId.mainnet) && tx.flashbots) {
+        logger.debug(`[SpeedUpAndCancelSheet]: using flashbots provider for chainId ${tx?.chainId}`);
+        provider = getFlashbotsProvider();
+      } else {
+        logger.debug(`[SpeedUpAndCancelSheet]: using provider for network ${tx?.chainId}`);
+        provider = getProvider({ chainId: currentChainId });
+      }
+      setCurrentProvider(provider);
 
       return () => {
         stopPollingGasFees();

--- a/src/state/nonces/index.ts
+++ b/src/state/nonces/index.ts
@@ -28,7 +28,7 @@ export async function getNextNonce({
   const { getNonce } = nonceStore.getState();
   const localNonceData = getNonce({ address, chainId });
   const localNonce = localNonceData?.currentNonce || 0;
-  const provider = checkFlashbots && supportedFlashbotsChainIds.includes(chainId) ? await getFlashbotsProvider() : getProvider({ chainId });
+  const provider = checkFlashbots && supportedFlashbotsChainIds.includes(chainId) ? getFlashbotsProvider() : getProvider({ chainId });
   const txCountIncludingPending = await provider.getTransactionCount(address, 'pending');
   if (!localNonce && !txCountIncludingPending) return 0;
   const ret = Math.max(localNonce + 1, txCountIncludingPending);

--- a/src/state/nonces/index.ts
+++ b/src/state/nonces/index.ts
@@ -1,8 +1,8 @@
 import create from 'zustand';
 import { createStore } from '../internal/createStore';
 import { Network, ChainId } from '@/chains/types';
-import { getFlashbotsProvider, getProvider } from '@/handlers/web3';
-import { chainsIdByName, supportedFlashbotsChainIds } from '@/chains';
+import { getProvider } from '@/handlers/web3';
+import { chainsIdByName } from '@/chains';
 
 type NonceData = {
   currentNonce?: number;
@@ -16,19 +16,11 @@ type GetNonceArgs = {
 
 type UpdateNonceArgs = NonceData & GetNonceArgs;
 
-export async function getNextNonce({
-  address,
-  chainId,
-  checkFlashbots = true,
-}: {
-  address: string;
-  chainId: ChainId;
-  checkFlashbots?: boolean;
-}) {
+export async function getNextNonce({ address, chainId }: { address: string; chainId: ChainId }) {
   const { getNonce } = nonceStore.getState();
   const localNonceData = getNonce({ address, chainId });
   const localNonce = localNonceData?.currentNonce || 0;
-  const provider = checkFlashbots && supportedFlashbotsChainIds.includes(chainId) ? getFlashbotsProvider() : getProvider({ chainId });
+  const provider = getProvider({ chainId });
   const txCountIncludingPending = await provider.getTransactionCount(address, 'pending');
   if (!localNonce && !txCountIncludingPending) return 0;
   const ret = Math.max(localNonce + 1, txCountIncludingPending);

--- a/src/state/nonces/index.ts
+++ b/src/state/nonces/index.ts
@@ -19,7 +19,7 @@ type UpdateNonceArgs = NonceData & GetNonceArgs;
 export async function getNextNonce({
   address,
   chainId,
-  checkFlashbots = false,
+  checkFlashbots = true,
 }: {
   address: string;
   chainId: ChainId;


### PR DESCRIPTION
Fixes APP-2036
Fixes APP-2037

## What changed (plus any additional context for devs)
- The swap and crosschain swap actions do one final gas estimation before submitting the transaction. The function they were using was not taking into account the metadata endpoint which has more accurate gas predictions. Moved them both over to use this function instead.
- The fallback logic of trying different gas limits for estimating gas was failing because trace call complains about formatting of block tag or block number
- The `getNonceAndPerformSwap` function was not actually getting the nonce, causing the provider to default to its own calculated nonce, which was causing issues once we removed the "wait for node ack"
 
## Screen recordings / screenshots


## What to test

