### PR TITLE
replace custom native review module with expo-store-review

### DIFF
--- a/ios/Extensions.swift
+++ b/ios/Extensions.swift
@@ -53,10 +53,6 @@ extension UIScreen {
 
 extension UIView {
   
-  open override var canBecomeFirstResponder: Bool {
-      return true
-  }
-  
   static func fromNib<T: UIView>() -> T {
     return Bundle(for: T.self).loadNibNamed(String(describing: T.self), owner: nil, options: nil)![0] as! T
   }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -43,6 +43,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - ExpoStoreReview (7.0.2):
+    - ExpoModulesCore
   - FasterImage (1.6.2):
     - FasterImage/Nuke (= 1.6.2)
     - FasterImage/NukeUI (= 1.6.2)
@@ -1895,6 +1897,7 @@ DEPENDENCIES:
   - ExpoFont (from `../node_modules/expo-font/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
+  - ExpoStoreReview (from `../node_modules/expo-store-review/ios`)
   - "FasterImage (from `../node_modules/@candlefinance/faster-image`)"
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - Firebase
@@ -2097,6 +2100,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-keep-awake/ios"
   ExpoModulesCore:
     :path: "../node_modules/expo-modules-core"
+  ExpoStoreReview:
+    :path: "../node_modules/expo-store-review/ios"
   FasterImage:
     :path: "../node_modules/@candlefinance/faster-image"
   FBLazyVector:
@@ -2369,6 +2374,7 @@ SPEC CHECKSUMS:
   ExpoFont: 00756e6c796d8f7ee8d211e29c8b619e75cbf238
   ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
   ExpoModulesCore: f30a203ff1863bab3dd9f4421e7fc1564797f18a
+  ExpoStoreReview: 15f9a636b62ff00bb21cbe9a9fe22f0239da4481
   FasterImage: af05a76f042ca3654c962b658fdb01cb4d31caee
   FBLazyVector: 7e977dd099937dc5458851233141583abba49ff2
   Firebase: 26b040b20866a55f55eb3611b9fcf3ae64816b86

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "ethereumjs-wallet": "1.0.1",
     "events": "3.3.0",
     "expo": "51.0.33",
+    "expo-store-review": "7.0.2",
     "fast-text-encoding": "1.0.4",
     "global": "4.4.0",
     "grapheme-splitter": "1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9300,6 +9300,7 @@ __metadata:
     ethereumjs-wallet: "npm:1.0.1"
     events: "npm:3.3.0"
     expo: "npm:51.0.33"
+    expo-store-review: "npm:7.0.2"
     fast-text-encoding: "npm:1.0.4"
     global: "npm:4.4.0"
     grapheme-splitter: "npm:1.0.4"
@@ -15024,6 +15025,15 @@ __metadata:
   dependencies:
     invariant: "npm:^2.2.4"
   checksum: 10c0/910ab3819920c36c715c546ec954ceea253ddd466534f839537986fecafc82ed74555f8bc0a852a6b5a5b473ce984a2217416830c835ed940fae5e3a8768da72
+  languageName: node
+  linkType: hard
+
+"expo-store-review@npm:7.0.2":
+  version: 7.0.2
+  resolution: "expo-store-review@npm:7.0.2"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/8a2e0622a0876bcdfdedcfda8a518cfa04c568007ff02d89e2409de00df00c8783fdf668aafada67bb1788b88e87113885355c2a0d5d07499d39bec357ca71f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes APP-2038

## What changed (plus any additional context for devs)

Fixes the app not being able to receive touches after the SKStoreReviewController was shown on iOS.

The app would not be able to receive any touches until force closed regardless of if the user selected "Not Now" or rated the app once the SKStoreReviewController was shown. 

expo-store-review was added to replace custom native module implementation, but that did not fix the issue.

The issue was related to this extension in the Extensions.swift file

```swift
extension UIView { 
  open override var canBecomeFirstResponder: Bool {
      return true
  }
}
```

This code was added in a 5 year old PR (#509) for improving performance of a native list component that is no longer used, so it should be safe to remove.

This issue CocoaDebug/CocoaDebug/issues/143 has more information on why this happens

## Screen recordings / screenshots

https://github.com/user-attachments/assets/cae0e7a1-48c8-49cb-8586-a73753a57a7b



## What to test

- Go to settings
- Click "Review Rainbow"
- Click "Yes"
- Click "Not Now", and the app should not freeze. 