### PR TITLE
fix token address searches on discover screen

### DIFF
--- a/src/handlers/tokenSearch.ts
+++ b/src/handlers/tokenSearch.ts
@@ -1,17 +1,15 @@
 import { isAddress } from '@ethersproject/address';
 import { qs } from 'url-parse';
 import { RainbowFetchClient } from '../rainbow-fetch';
-import { TokenSearchThreshold, TokenSearchTokenListId, TokenSearchUniswapAssetKey } from '@/entities';
+import { TokenSearchThreshold, TokenSearchTokenListId } from '@/entities';
 import { logger, RainbowError } from '@/logger';
-import { EthereumAddress } from '@rainbow-me/swaps';
 import { RainbowToken, TokenSearchToken } from '@/entities/tokens';
 import { chainsName } from '@/chains';
+import { ChainId } from '@/chains/types';
 
-type TokenSearchApiResponse = {
-  data: TokenSearchToken[];
-};
+const ALL_VERIFIED_TOKENS_PARAM = '/?list=verifiedAssets';
 
-const tokenSearchApi = new RainbowFetchClient({
+const tokenSearchHttp = new RainbowFetchClient({
   baseURL: 'https://token-search.rainbow.me/v2',
   headers: {
     'Accept': 'application/json',
@@ -20,50 +18,77 @@ const tokenSearchApi = new RainbowFetchClient({
   timeout: 30000,
 });
 
+function parseTokenSearch(assets: TokenSearchToken[]): RainbowToken[] {
+  return assets.map(token => {
+    const networkKeys = Object.keys(token.networks);
+    const chainId = Number(networkKeys[0]);
+    const network = chainsName[chainId];
+    return {
+      ...token,
+      chainId,
+      address: token.networks['1']?.address || token.networks[chainId]?.address,
+      network,
+      mainnet_address: token.networks['1']?.address,
+    };
+  });
+}
+
 export const tokenSearch = async (searchParams: {
-  chainId: number;
+  chainId: ChainId;
   fromChainId?: number | '';
-  keys: TokenSearchUniswapAssetKey[];
+  keys: (keyof RainbowToken)[];
   list: TokenSearchTokenListId;
   threshold: TokenSearchThreshold;
   query: string;
 }): Promise<RainbowToken[]> => {
   const queryParams: {
-    keys: TokenSearchUniswapAssetKey[];
+    keys: string;
     list: TokenSearchTokenListId;
     threshold: TokenSearchThreshold;
     query?: string;
     fromChainId?: number;
   } = {
-    keys: searchParams.keys,
+    keys: searchParams.keys.join(','),
     list: searchParams.list,
     threshold: searchParams.threshold,
     query: searchParams.query,
   };
 
+  const { chainId, query } = searchParams;
+
+  const isAddressSearch = query && isAddress(query);
+
+  if (isAddressSearch) {
+    queryParams.keys = `networks.${chainId}.address`;
+  }
+
+  const url = `/?${qs.stringify(queryParams)}`;
+  const isSearchingVerifiedAssets = queryParams.list === 'verifiedAssets';
+
   try {
-    if (isAddress(searchParams.query)) {
-      // @ts-ignore
-      params.keys = `networks.${searchParams.chainId}.address`;
+    const tokenSearch = await tokenSearchHttp.get<{ data: TokenSearchToken[] }>(url);
+
+    if (isAddressSearch && isSearchingVerifiedAssets) {
+      if (tokenSearch && tokenSearch.data.data.length > 0) {
+        return parseTokenSearch(tokenSearch.data.data);
+      }
+
+      const allVerifiedTokens = await tokenSearchHttp.get<{ data: TokenSearchToken[] }>(ALL_VERIFIED_TOKENS_PARAM);
+
+      const addressQuery = query.trim().toLowerCase();
+
+      const addressMatchesOnOtherChains = allVerifiedTokens.data.data.filter(a =>
+        Object.values(a.networks).some(n => n?.address === addressQuery)
+      );
+
+      return parseTokenSearch(addressMatchesOnOtherChains);
     }
-    const url = `/?${qs.stringify(queryParams)}`;
-    const tokenSearch = await tokenSearchApi.get<TokenSearchApiResponse>(url);
+
     if (!tokenSearch.data?.data) {
       return [];
     }
 
-    return tokenSearch.data.data.map(token => {
-      const networkKeys = Object.keys(token.networks);
-      const chainId = Number(networkKeys[0]);
-      const network = chainsName[chainId];
-      return {
-        ...token,
-        chainId,
-        address: token.networks['1']?.address || token.networks[chainId]?.address,
-        network,
-        mainnet_address: token.networks['1']?.address,
-      };
-    });
+    return parseTokenSearch(tokenSearch.data.data);
   } catch (e: any) {
     logger.error(new RainbowError(`[tokenSearch]: An error occurred while searching for query`), {
       query: searchParams.query,


### PR DESCRIPTION
Fixes APP-1674

## What changed (plus any additional context for devs)
- Incorrectly named variable "params" was replaced with correctly named variable "queryParams", which fixed mainnet address searches throwing an error.
- tokenSearch function logic was changed to more closely match search logic in `src/__swaps__/screens/Swap/resources/search/search.ts` which fixed cross-chain address search. 

## Screen recordings / screenshots
![IMG_0397 2](https://github.com/user-attachments/assets/e06769bf-8659-484e-8de8-b1c1012c1d84)


## What to test
- Search for an exact address on the discover screen (ex "0x6982508145454Ce325dDbE47a25d4ec3d2311933")
- Search normally
