### PR TITLE
Update tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "run build",
             "type": "shell",
-            "command": "cd ${workspaceFolder}/android && ./gradlew assembleDebug",
+            "command": "cd \"${workspaceFolder}/android\" && ./gradlew assembleDebug",
             "presentation": {
                 "echo": true,
                 "reveal": "always",
@@ -22,7 +22,7 @@
         {
             "label": "run clean",
             "type": "shell",
-            "command": "cd ${workspaceFolder}/android && ./gradlew clean",
+            "command": "cd \"${workspaceFolder}/android\" && ./gradlew clean",
             "presentation": {
                 "echo": true,
                 "reveal": "always",
@@ -40,7 +40,7 @@
         {
             "label": "run sync",
             "type": "shell",
-            "command": "cd ${workspaceFolder}/android && ./gradlew --refresh-dependencies",
+            "command": "cd \"${workspaceFolder}/android\" && ./gradlew --refresh-dependencies",
             "presentation": {
                 "echo": true,
                 "reveal": "always",
@@ -58,7 +58,7 @@
         {
             "label": "run invalidate",
             "type": "shell",
-            "command": " rm -rf ~/.gradle/caches && rm -rf ~/.gradle && cd ${workspaceFolder}/android && ./gradlew --stop",
+            "command": "rm -rf \"${HOME}/.gradle/caches\" && rm -rf \"${HOME}/.gradle\" && cd \"${workspaceFolder}/android\" && ./gradlew --stop",
             "presentation": {
                 "echo": true,
                 "reveal": "always",


### PR DESCRIPTION
I wrapped the ${workspaceFolder} and ${HOME} variables in quotes. This helps to avoid issues if there are spaces in the paths (e.g., C:/Users/John Doe/).
The presentation and group settings were duplicated in all tasks. You could refactor this into a reusable block for better maintainability, but in this example, I kept them in each task for clarity.
I changed the rm -rf ~/.gradle/caches and rm -rf ~/.gradle commands to use "${HOME}" instead of ~. Using ${HOME} is safer and more portable in shell scripts, and it ensures that the command will work on all systems (even if ~ is not properly expanded).
I added quotes to paths with potential spaces or special characters (e.g., cd "${workspaceFolder}/android"). This ensures that the shell command works even if the folder path contains spaces or other special characters.


