### PR TITLE
fix: present hw pairing sheet during swap

### DIFF
--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -73,11 +73,8 @@ export function SwapBottomPanel() {
   const handleHwConnectionAndSwap = useCallback(() => {
     try {
       if (isHardwareWallet && configProgress.value === NavigationSteps.SHOW_REVIEW) {
-        SwapNavigation.handleSwapAction();
         navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, {
-          submit: () => {
-            navigate(-1); // close hw sheet after receiving device input
-          },
+          submit: SwapNavigation.handleSwapAction,
         });
       } else {
         SwapNavigation.handleSwapAction();

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -73,10 +73,10 @@ export function SwapBottomPanel() {
   const handleHwConnectionAndSwap = useCallback(() => {
     try {
       if (isHardwareWallet && configProgress.value === NavigationSteps.SHOW_REVIEW) {
+        SwapNavigation.handleSwapAction();
         navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, {
           submit: () => {
             navigate(-1); // close hw sheet after receiving device input
-            SwapNavigation.handleSwapAction();
           },
         });
       } else {

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -14,6 +14,7 @@ import { ReviewPanel } from './ReviewPanel';
 import { SwapActionButton } from './SwapActionButton';
 import { SettingsPanel } from './SettingsPanel';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
+import { useWallets } from '@/hooks';
 
 const HOLD_TO_SWAP_DURATION_MS = 400;
 
@@ -28,6 +29,7 @@ export function SwapBottomPanel() {
     internalSelectedOutputAsset,
     quoteFetchingInterval,
   } = useSwapContext();
+  const { isHardwareWallet } = useWallets();
 
   const { swipeToDismissGestureHandler, gestureY } = useBottomPanelGestureHandler();
 
@@ -102,7 +104,7 @@ export function SwapBottomPanel() {
               onPressWorklet={() => {
                 'worklet';
                 if (type.value !== 'hold') {
-                  SwapNavigation.handleSwapAction();
+                  SwapNavigation.handleSwapAction(isHardwareWallet);
                 }
               }}
               onLongPressEndWorklet={success => {
@@ -116,7 +118,7 @@ export function SwapBottomPanel() {
                 'worklet';
                 if (type.value === 'hold') {
                   triggerHaptics('notificationSuccess');
-                  SwapNavigation.handleSwapAction();
+                  SwapNavigation.handleSwapAction(isHardwareWallet);
                 }
               }}
               onPressStartWorklet={() => {

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -73,7 +73,12 @@ export function SwapBottomPanel() {
   const handleHwConnectionAndSwap = useCallback(() => {
     try {
       if (isHardwareWallet && configProgress.value === NavigationSteps.SHOW_REVIEW) {
-        navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: SwapNavigation.handleSwapAction });
+        navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, {
+          submit: () => {
+            navigate(-1); // close hw sheet after receiving device input
+            SwapNavigation.handleSwapAction();
+          },
+        });
       } else {
         SwapNavigation.handleSwapAction();
       }

--- a/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import { DerivedValue, SharedValue, useSharedValue } from 'react-native-reanimated';
 import { useAnimatedInterval } from '@/hooks/reanimated/useAnimatedInterval';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import Routes from '@/navigation/Routes';
+import { navigate } from '@/navigation/Navigation';
 
 export const enum NavigationSteps {
   INPUT_ELEMENT_FOCUSED = 0,
@@ -213,33 +215,40 @@ export function useSwapNavigation({
     }
   }, [handleDismissReview, handleDismissGas, handleDismissSettings, inputProgress, outputProgress, quoteFetchingInterval]);
 
-  const handleSwapAction = useCallback(() => {
-    'worklet';
+  const handleSwapAction = useCallback(
+    (isHardwareWallet: boolean) => {
+      'worklet';
 
-    if (configProgress.value === NavigationSteps.SHOW_GAS) {
-      if (navigateBackToReview.value) {
-        navigateBackToReview.value = false;
-        return handleShowReview();
+      if (configProgress.value === NavigationSteps.SHOW_GAS) {
+        if (navigateBackToReview.value) {
+          navigateBackToReview.value = false;
+          return handleShowReview();
+        }
+
+        return handleDismissGas();
       }
 
-      return handleDismissGas();
-    }
+      if (configProgress.value === NavigationSteps.SHOW_SETTINGS) {
+        if (navigateBackToReview.value && !isDegenMode.value) {
+          navigateBackToReview.value = false;
+          return handleShowReview();
+        }
 
-    if (configProgress.value === NavigationSteps.SHOW_SETTINGS) {
-      if (navigateBackToReview.value && !isDegenMode.value) {
-        navigateBackToReview.value = false;
-        return handleShowReview();
+        return handleDismissSettings();
       }
 
-      return handleDismissSettings();
-    }
+      if (isDegenMode.value || configProgress.value === NavigationSteps.SHOW_REVIEW) {
+        if (isHardwareWallet) {
+          navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: executeSwap });
+        } else {
+          return executeSwap();
+        }
+      }
 
-    if (isDegenMode.value || configProgress.value === NavigationSteps.SHOW_REVIEW) {
-      return executeSwap();
-    }
-
-    return handleShowReview();
-  }, [configProgress, executeSwap, handleDismissGas, handleDismissSettings, handleShowReview, isDegenMode, navigateBackToReview]);
+      return handleShowReview();
+    },
+    [configProgress, executeSwap, handleDismissGas, handleDismissSettings, handleShowReview, isDegenMode, navigateBackToReview]
+  );
 
   return {
     navigateBackToReview,

--- a/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
@@ -239,7 +239,7 @@ export function useSwapNavigation({
 
       if (isDegenMode.value || configProgress.value === NavigationSteps.SHOW_REVIEW) {
         if (isHardwareWallet) {
-          navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: executeSwap });
+          return () => navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: executeSwap });
         } else {
           return executeSwap();
         }

--- a/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 import { DerivedValue, SharedValue, useSharedValue } from 'react-native-reanimated';
 import { useAnimatedInterval } from '@/hooks/reanimated/useAnimatedInterval';
 import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
-import Routes from '@/navigation/Routes';
-import { navigate } from '@/navigation/Navigation';
 
 export const enum NavigationSteps {
   INPUT_ELEMENT_FOCUSED = 0,
@@ -215,41 +213,33 @@ export function useSwapNavigation({
     }
   }, [handleDismissReview, handleDismissGas, handleDismissSettings, inputProgress, outputProgress, quoteFetchingInterval]);
 
-  const handleSwapAction = useCallback(
-    (isHardwareWallet: boolean) => {
-      'worklet';
+  const handleSwapAction = useCallback(() => {
+    'worklet';
 
-      if (configProgress.value === NavigationSteps.SHOW_GAS) {
-        if (navigateBackToReview.value) {
-          navigateBackToReview.value = false;
-          return handleShowReview();
-        }
-
-        return handleDismissGas();
+    if (configProgress.value === NavigationSteps.SHOW_GAS) {
+      if (navigateBackToReview.value) {
+        navigateBackToReview.value = false;
+        return handleShowReview();
       }
 
-      if (configProgress.value === NavigationSteps.SHOW_SETTINGS) {
-        if (navigateBackToReview.value && !isDegenMode.value) {
-          navigateBackToReview.value = false;
-          return handleShowReview();
-        }
+      return handleDismissGas();
+    }
 
-        return handleDismissSettings();
+    if (configProgress.value === NavigationSteps.SHOW_SETTINGS) {
+      if (navigateBackToReview.value && !isDegenMode.value) {
+        navigateBackToReview.value = false;
+        return handleShowReview();
       }
 
-      if (isDegenMode.value || configProgress.value === NavigationSteps.SHOW_REVIEW) {
-        if (isHardwareWallet) {
-          navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: executeSwap });
-          return;
-        } else {
-          return executeSwap();
-        }
-      }
+      return handleDismissSettings();
+    }
 
-      return handleShowReview();
-    },
-    [configProgress, executeSwap, handleDismissGas, handleDismissSettings, handleShowReview, isDegenMode, navigateBackToReview]
-  );
+    if (isDegenMode.value || configProgress.value === NavigationSteps.SHOW_REVIEW) {
+      return executeSwap();
+    }
+
+    return handleShowReview();
+  }, [configProgress, executeSwap, handleDismissGas, handleDismissSettings, handleShowReview, isDegenMode, navigateBackToReview]);
 
   return {
     navigateBackToReview,

--- a/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapNavigation.ts
@@ -239,7 +239,8 @@ export function useSwapNavigation({
 
       if (isDegenMode.value || configProgress.value === NavigationSteps.SHOW_REVIEW) {
         if (isHardwareWallet) {
-          return () => navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: executeSwap });
+          navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: executeSwap });
+          return;
         } else {
           return executeSwap();
         }

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -339,9 +339,13 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       performanceTracking.getState().executeFn({
         fn: () => {
           const { routes, index } = Navigation.getState();
-          if (index === 0 || routes[index - 1].name === Routes.EXPANDED_ASSET_SHEET) {
+          const currentRoute = routes[index - 1];
+          if (index === 0 || currentRoute.name === Routes.EXPANDED_ASSET_SHEET) {
             Navigation.handleAction(Routes.WALLET_SCREEN, {});
           } else {
+            if (currentRoute.name === Routes.HARDWARE_WALLET_TX_NAVIGATOR) {
+              Navigation.goBack();
+            }
             Navigation.goBack();
           }
         },

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -342,7 +342,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
           const activeRoute = Navigation.getActiveRoute();
           if (
             index === 0 ||
-            routes[index - 1] === Routes.EXPANDED_ASSET_SHEET ||
+            routes[index - 1].name === Routes.EXPANDED_ASSET_SHEET ||
             activeRoute.name === Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET
           ) {
             Navigation.handleAction(Routes.WALLET_SCREEN, {});

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -238,6 +238,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
           },
         },
       });
+      const isHardwareWallet = wallet instanceof LedgerSigner;
 
       if (!wallet) {
         isSwapping.value = false;
@@ -306,7 +307,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
           degenMode: isDegenModeEnabled,
           isSwappingToPopularAsset,
           errorMessage,
-          isHardwareWallet: wallet instanceof LedgerSigner,
+          isHardwareWallet,
         });
 
         if (errorMessage !== 'handled') {
@@ -372,7 +373,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
         tradeAmountUSD: parameters.quote.tradeAmountUSD,
         degenMode: isDegenModeEnabled,
         isSwappingToPopularAsset,
-        isHardwareWallet: wallet instanceof LedgerSigner,
+        isHardwareWallet,
       });
     } catch (error) {
       isSwapping.value = false;

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -339,13 +339,14 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       performanceTracking.getState().executeFn({
         fn: () => {
           const { routes, index } = Navigation.getState();
-          const currentRoute = routes[index - 1];
-          if (index === 0 || currentRoute.name === Routes.EXPANDED_ASSET_SHEET) {
+          const activeRoute = Navigation.getActiveRoute();
+          if (
+            index === 0 ||
+            routes[index - 1] === Routes.EXPANDED_ASSET_SHEET ||
+            activeRoute.name === Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET
+          ) {
             Navigation.handleAction(Routes.WALLET_SCREEN, {});
           } else {
-            if (currentRoute.name === Routes.HARDWARE_WALLET_TX_NAVIGATOR) {
-              Navigation.goBack();
-            }
             Navigation.goBack();
           }
         },


### PR DESCRIPTION
Fixes APP-1928

## What changed (plus any additional context for devs)
We have added the ledger bluetooth sheet back to the swap flow. Ledger transactions were working, however we were not displaying the various bluetooth connection states.

## Screen recordings / screenshots
https://github.com/user-attachments/assets/c5441890-464f-4208-ae69-b16cd3832cb6



## What to test
Attempt a swap with a ledger device. Make sure you see the bluetooth connection sheet.
