### PR TITLE
Update the mobile app's id'ing of number of wallets to match the BX

### DIFF
--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -6,8 +6,29 @@ type PushNotificationPermissionStatus = 'enabled' | 'disabled' | 'never asked';
 
 // these are all reported seperately so they must be optional
 export interface UserProperties {
+  // number of imported or generated accounts
+  ownedAccounts?: number;
+  // number of accounts tied to paired hardware wallets
+  hardwareAccounts?: number;
+  // number of watched addresses or ens
+  watchedAccounts?: number;
+  // number of imported or generated secret recovery phrases
+  recoveryPhrases?: number;
+  // number of imported secret recovery phrases
+  importedRecoveryPhrases?: number;
+  // number of unique private keys
+  privateKeys?: number;
+  // number of imported unique private keys
+  importedPrivateKeys?: number;
+  // number of paired trezor hardware wallets -- unsupported but leaving BX key here
+  trezorDevices?: number;
+  // number of paired ledger hardware wallets
+  ledgerDevices?: number;
+  // whether a recovery phrase or private key has been imported
+  hasImported?: boolean;
+
   // settings
-  currentAddressHash?: string; // NEW
+  currentAddressHash?: string;
   currency?: NativeCurrencyKey;
   language?: Language;
   enabledTestnets?: boolean;

--- a/src/screens/WalletScreen/index.tsx
+++ b/src/screens/WalletScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AssetList } from '../../components/asset-list';
 import { Page } from '../../components/layout';
@@ -11,6 +11,7 @@ import {
   useInitializeWallet,
   useLoadAccountLateData,
   useLoadGlobalLateData,
+  useWallets,
   useWalletSectionsData,
 } from '@/hooks';
 import { Toast, ToastPositionContainer } from '@/components/toasts';
@@ -29,6 +30,7 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import { RootStackParamList } from '@/navigation/types';
 import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/Routes';
+import walletTypes from '@/helpers/walletTypes';
 
 function WalletScreen() {
   const { params } = useRoute<RouteProp<RootStackParamList, 'WalletScreen'>>();
@@ -41,9 +43,68 @@ function WalletScreen() {
   const loadAccountLateData = useLoadAccountLateData();
   const loadGlobalLateData = useLoadGlobalLateData();
   const insets = useSafeAreaInsets();
+  const { wallets } = useWallets();
 
   const walletReady = useSelector(({ appState: { walletReady } }: AppState) => walletReady);
   const { isWalletEthZero, isLoadingUserAssets, isLoadingBalance, briefSectionsData: walletBriefSectionsData } = useWalletSectionsData();
+
+  const trackWallets = useCallback(() => {
+    const identify = Object.values(wallets || {}).reduce(
+      (result, wallet) => {
+        switch (wallet.type) {
+          case walletTypes.mnemonic:
+            result.ownedAccounts += wallet.addresses.length;
+            result.recoveryPhrases += 1;
+            if (wallet.imported) {
+              result.importedRecoveryPhrases += 1;
+              result.hasImported = true;
+            }
+            break;
+          case walletTypes.privateKey:
+            result.ownedAccounts += wallet.addresses.length;
+            result.privateKeys += 1;
+            if (wallet.imported) {
+              result.importedPrivateKeys += 1;
+              result.hasImported = true;
+            }
+            break;
+          case walletTypes.readOnly:
+            result.watchedAccounts += wallet.addresses.length;
+            break;
+          case walletTypes.bluetooth:
+            result.hardwareAccounts += wallet.addresses.length;
+            result.ledgerDevices += 1;
+            break;
+        }
+        return result;
+      },
+      {
+        ownedAccounts: 0,
+        watchedAccounts: 0,
+        recoveryPhrases: 0,
+        importedRecoveryPhrases: 0,
+        privateKeys: 0,
+        importedPrivateKeys: 0,
+        hasImported: false,
+        hardwareAccounts: 0,
+        ledgerDevices: 0,
+        trezorDevices: 0,
+      }
+    );
+
+    analyticsV2.identify({
+      ownedAccounts: identify.ownedAccounts,
+      hardwareAccounts: identify.hardwareAccounts,
+      watchedAccounts: identify.watchedAccounts,
+      recoveryPhrases: identify.recoveryPhrases,
+      importedRecoveryPhrases: identify.importedRecoveryPhrases,
+      privateKeys: identify.privateKeys,
+      importedPrivateKeys: identify.importedPrivateKeys,
+      ledgerDevices: identify.ledgerDevices,
+      trezorDevices: identify.trezorDevices,
+      hasImported: identify.hasImported,
+    });
+  }, [wallets]);
 
   useEffect(() => {
     // This is the fix for Android wallet creation problem.
@@ -63,13 +124,14 @@ function WalletScreen() {
       await initializeWallet(null, null, null, !params?.emptyWallet);
       setInitialized(true);
       setParams({ emptyWallet: false });
+      trackWallets();
     };
 
     if (!initialized || (params?.emptyWallet && initialized)) {
       // We run the migrations only once on app launch
       initializeAndSetParams();
     }
-  }, [initializeWallet, initialized, params, setParams]);
+  }, [initializeWallet, initialized, params, setParams, trackWallets]);
 
   useEffect(() => {
     if (walletReady) {


### PR DESCRIPTION
Fixes APP-1998

## What changed (plus any additional context for devs)
We now identify wallet types during wallet screen initialization. Similar to the BX: https://github.com/rainbow-me/browser-extension/blob/df46dc44e45f8466c2960eb35b8d19bf9d9edb90/src/analytics/identify/walletTypes.ts#L59

## Screen recordings / screenshots
n/a

## What to test
Verify new data being sent satisfies the ticket's requirements.