### PR TITLE
Fixes `$NaN` wallet balance

### DIFF
--- a/src/hooks/useWalletsWithBalancesAndNames.ts
+++ b/src/hooks/useWalletsWithBalancesAndNames.ts
@@ -21,11 +21,13 @@ export default function useWalletsWithBalancesAndNames() {
           return {
             ...account,
             balances: balances[lowerCaseAddress],
-            hiddenBalances: hiddenBalances[lowerCaseAddress] ?? '0',
-            balancesMinusHiddenBalances: convertAmountToNativeDisplay(
-              subtract(balances[lowerCaseAddress]?.totalBalanceAmount, hiddenBalances[lowerCaseAddress] ?? '0'),
-              nativeCurrency
-            ),
+            hiddenBalances: hiddenBalances[lowerCaseAddress],
+            balancesMinusHiddenBalances: balances[lowerCaseAddress]?.totalBalanceDisplay
+              ? convertAmountToNativeDisplay(
+                  subtract(balances[lowerCaseAddress].totalBalanceAmount, hiddenBalances[lowerCaseAddress] ?? '0'),
+                  nativeCurrency
+                )
+              : undefined,
             ens: walletNames[account.address],
           };
         });


### PR DESCRIPTION
Fixes APP-1971

## What changed (plus any additional context for devs)
Guards the currency conversion until totalBalance is calculated

## Screen recordings / screenshots

https://github.com/user-attachments/assets/54570654-d7e6-4d9e-bbd3-88792ba697b7



## What to test
one way to trigger this is by adding a new wallet
should show the loading skeleton until the balance is loaded
