### PR TITLE
Fix card carousel horizontal with single item

### DIFF
--- a/src/components/cards/CarouselCard.tsx
+++ b/src/components/cards/CarouselCard.tsx
@@ -90,7 +90,7 @@ export function CarouselCard<T>({
                 paddingHorizontal: HORIZONTAL_PADDING,
               }}
               estimatedItemSize={carouselItem.width}
-              horizontal
+              horizontal={data.length > 1}
               ref={carouselItem.carouselRef}
               estimatedListSize={{
                 height: actualItemHeight,


### PR DESCRIPTION
Fixes APP-1906

## What changed (plus any additional context for devs)
There's a flashlist bug that prevents touch events for horizontal containers with only a single item. https://github.com/Shopify/flash-list/issues/1327

## Screen recordings / screenshots

https://github.com/user-attachments/assets/2b3b119d-ae81-4baa-8dff-c193ae72d28c


## What to test

