### PR TITLE
Add support in positions for LP positions & staked deposits

### DIFF
--- a/src/components/positions/PositionsCard.tsx
+++ b/src/components/positions/PositionsCard.tsx
@@ -78,10 +78,7 @@ function CoinIconStack({ tokens }: { tokens: CoinStackToken[] }) {
 export const PositionCard = ({ position }: PositionCardProps) => {
   const { colors, isDarkMode } = useTheme();
   const totalPositions =
-    (position.borrows?.length || 0) +
-    (position.deposits?.length || 0) +
-    (position.claimables?.length || 0) +
-    (position.stakes?.length || 0);
+    (position.borrows.length || 0) + (position.deposits.length || 0) + (position.claimables.length || 0) + (position.stakes.length || 0);
 
   const { navigate } = useNavigation();
 
@@ -92,8 +89,8 @@ export const PositionCard = ({ position }: PositionCardProps) => {
 
   const depositTokens: CoinStackToken[] = useMemo(() => {
     const tokens: CoinStackToken[] = [];
-    position.deposits?.forEach((deposit: RainbowDeposit) => {
-      deposit.underlying?.forEach(({ asset }) => {
+    position.deposits.forEach((deposit: RainbowDeposit) => {
+      deposit.underlying.forEach(({ asset }) => {
         tokens.push({
           address: asset.asset_code,
           network: asset.network,
@@ -101,8 +98,8 @@ export const PositionCard = ({ position }: PositionCardProps) => {
         });
       });
     });
-    position.stakes?.forEach((stake: RainbowStake) => {
-      stake.underlying?.forEach(({ asset }) => {
+    position.stakes.forEach((stake: RainbowStake) => {
+      stake.underlying.forEach(({ asset }) => {
         tokens.push({
           address: asset.asset_code,
           network: asset.network,
@@ -110,15 +107,15 @@ export const PositionCard = ({ position }: PositionCardProps) => {
         });
       });
     });
-    position.claimables?.forEach((claimable: RainbowClaimable) => {
+    position.claimables.forEach((claimable: RainbowClaimable) => {
       tokens.push({
         address: claimable.asset.asset_code,
         network: claimable.asset.network,
         symbol: claimable.asset.symbol,
       });
     });
-    position.borrows?.forEach((borrow: RainbowBorrow) => {
-      borrow.underlying?.forEach(({ asset }) => {
+    position.borrows.forEach((borrow: RainbowBorrow) => {
+      borrow.underlying.forEach(({ asset }) => {
         tokens.push({
           address: asset.asset_code,
           network: asset.network,

--- a/src/components/positions/PositionsCard.tsx
+++ b/src/components/positions/PositionsCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Column, Columns, Inline, Stack, Text } from '@/design-system';
+import { Box, Column, Columns, Inline, Stack, Text, globalColors } from '@/design-system';
 import React, { useCallback, useMemo } from 'react';
 import { useTheme } from '@/theme';
 
@@ -92,7 +92,7 @@ export const PositionCard = ({ position }: PositionCardProps) => {
 
   const depositTokens: CoinStackToken[] = useMemo(() => {
     const tokens: CoinStackToken[] = [];
-    position.deposits.forEach((deposit: RainbowDeposit) => {
+    position.deposits?.forEach((deposit: RainbowDeposit) => {
       deposit.underlying?.forEach(({ asset }) => {
         tokens.push({
           address: asset.asset_code,
@@ -101,7 +101,7 @@ export const PositionCard = ({ position }: PositionCardProps) => {
         });
       });
     });
-    position.stakes.forEach((stake: RainbowStake) => {
+    position.stakes?.forEach((stake: RainbowStake) => {
       stake.underlying?.forEach(({ asset }) => {
         tokens.push({
           address: asset.asset_code,
@@ -110,15 +110,15 @@ export const PositionCard = ({ position }: PositionCardProps) => {
         });
       });
     });
-    position.claimables.forEach((claimable: RainbowClaimable) => {
+    position.claimables?.forEach((claimable: RainbowClaimable) => {
       tokens.push({
         address: claimable.asset.asset_code,
         network: claimable.asset.network,
         symbol: claimable.asset.symbol,
       });
     });
-    position.borrows.forEach((borrow: RainbowBorrow) => {
-      borrow.underlying.forEach(({ asset }) => {
+    position.borrows?.forEach((borrow: RainbowBorrow) => {
+      borrow.underlying?.forEach(({ asset }) => {
         tokens.push({
           address: asset.asset_code,
           network: asset.network,
@@ -132,7 +132,8 @@ export const PositionCard = ({ position }: PositionCardProps) => {
     return dedupedTokens?.slice(0, 5);
   }, [position]);
 
-  const positionColor = position.dapp.colors.primary || position.dapp.colors.fallback || '#000000';
+  const positionColor =
+    position.dapp.colors.primary || position.dapp.colors.fallback || (isDarkMode ? globalColors.white100 : globalColors.white10);
 
   return (
     <Box width="full" height={{ custom: 117 }}>

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -6,7 +6,7 @@ import { ClaimableExtraData, PositionExtraData } from '@/components/asset-list/R
 import { DEFI_POSITIONS, CLAIMABLES, ExperimentalValue } from '@/config/experimental';
 import { RainbowPositions } from '@/resources/defi/types';
 import { Claimable } from '@/resources/addys/claimables/types';
-import { add, convertAmountToNativeDisplay } from './utilities';
+import { add, convertAmountToNativeDisplay, lessThan } from './utilities';
 import { RainbowConfig } from '@/model/remoteConfig';
 import { IS_TEST } from '@/env';
 import { UniqueId } from '@/__swaps__/types/assets';
@@ -88,7 +88,10 @@ const buildBriefWalletSections = (
 
 const withPositionsSection = (positionsObj: RainbowPositions | undefined, isLoadingUserAssets: boolean) => {
   const result: PositionExtraData[] = [];
-  const sortedPositions = positionsObj?.positions?.sort((a, b) => (a.totals.totals.amount > b.totals.totals.amount ? -1 : 1));
+  const sortedPositions = positionsObj?.positions?.sort((a, b) => {
+    return lessThan(b.totals.totals.amount, a.totals.totals.amount) ? -1 : 1;
+  });
+
   sortedPositions?.forEach((position, index) => {
     const listData = {
       type: 'POSITION',

--- a/src/hooks/useWalletBalances.ts
+++ b/src/hooks/useWalletBalances.ts
@@ -71,7 +71,7 @@ const useWalletBalances = (wallets: AllRainbowWallets): WalletBalanceResult => {
       const lowerCaseAddress = address.toLowerCase() as Address;
       const assetBalance = summaryData?.data?.addresses?.[lowerCaseAddress]?.summary?.asset_value?.toString() || '0';
       const positionData = queryClient.getQueryData<RainbowPositions | undefined>(positionsQueryKey({ address, currency: nativeCurrency }));
-      const positionsBalance = positionData ? subtract(positionData.totals.total.amount, positionData.totals.totalLocked) : '0';
+      const positionsBalance = positionData ? positionData.totals.total.amount : '0';
       const totalAccountBalance = add(assetBalance, positionsBalance);
 
       result[lowerCaseAddress] = {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1868,10 +1868,17 @@
       }
     },
     "positions": {
+      "lp_range_status": {
+        "full_range": "Full Range",
+        "out_of_range": "Out of Range",
+        "in_range": "In Range"
+      },
       "open_dapp": "Open 􀮶",
       "deposits": "Deposits",
       "borrows": "Borrows",
-      "rewards": "Rewards"
+      "stakes": "Staked",
+      "rewards": "Rewards",
+      "pools": "Pools"
     },
     "savings": {
       "deposit": "Deposit",

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,6 +9,7 @@ import { ParsedAddressAsset, PendingTransaction, UniqueAsset } from '@/entities'
 import { Claimable } from '@/resources/addys/claimables/types';
 import { WalletconnectApprovalSheetRouteParams, WalletconnectResultType } from '@/walletConnect/types';
 import { WalletConnectApprovalSheetType } from '@/helpers/walletConnectApprovalSheetTypes';
+import { RainbowPosition } from '@/resources/defi/types';
 
 export type PartialNavigatorConfigOptions = Pick<Partial<Parameters<ReturnType<typeof createStackNavigator>['Screen']>[0]>, 'options'>;
 
@@ -99,5 +100,8 @@ export type RootStackParamList = {
     longFormHeight: number;
     type: 'token' | 'unique_token';
     asset: ParsedAddressAsset | UniqueAsset;
+  };
+  [Routes.POSITION_SHEET]: {
+    position: RainbowPosition;
   };
 };

--- a/src/resources/defi/PositionsQuery.ts
+++ b/src/resources/defi/PositionsQuery.ts
@@ -21,6 +21,7 @@ const getPositions = async (address: string, currency: NativeCurrencyKey): Promi
     method: 'get',
     params: {
       currency,
+      enableThirdParty: 'true',
     },
     headers: {
       Authorization: `Bearer ${ADDYS_API_KEY}`,

--- a/src/resources/defi/types.ts
+++ b/src/resources/defi/types.ts
@@ -1,6 +1,6 @@
-import { NativeCurrencyKey, ZerionAsset } from '@/entities';
+import { NativeCurrencyKey } from '@/entities';
 import { ChainId, Network } from '@/chains/types';
-import { TokenColors } from '@/graphql/__generated__/metadata';
+import { AddysAsset } from '@/resources/addys/types';
 
 export type AddysPositionsResponse =
   | {
@@ -21,12 +21,9 @@ export type NativeDisplay = {
   display: string;
 };
 
-// TODO: this does not have all the fields returned by the API
-export type PositionAsset = ZerionAsset & {
+export type PositionAsset = AddysAsset & {
   network: Network;
   chain_id: ChainId;
-  networks: Record<ChainId, { address: string; decimals: number }>;
-  colors: TokenColors;
 };
 
 export type PositionDapp = {

--- a/src/resources/defi/types.ts
+++ b/src/resources/defi/types.ts
@@ -100,8 +100,9 @@ export type RainbowDeposit = {
   quantity: string;
   isLp: boolean;
   isConcentratedLiquidity: boolean;
-  omit_from_total?: boolean;
+  totalValue: string;
   underlying: RainbowUnderlyingAsset[];
+  omit_from_total?: boolean;
   apr?: string;
   apy?: string;
   dappVersion?: string;
@@ -110,10 +111,11 @@ export type RainbowDeposit = {
 export type RainbowBorrow = {
   asset: PositionAsset;
   quantity: string;
-  omit_from_total?: boolean;
   apr: string;
   apy: string;
   total_asset: string; // what does this mean?
+  totalValue: string;
+  omit_from_total?: boolean;
   dappVersion?: string;
   underlying: RainbowUnderlyingAsset[];
 };
@@ -122,6 +124,7 @@ export type RainbowStake = {
   quantity: string;
   isLp: boolean;
   isConcentratedLiquidity: boolean;
+  totalValue: string;
   omit_from_total?: boolean;
   underlying: RainbowUnderlyingAsset[];
   dappVersion?: string;

--- a/src/resources/defi/types.ts
+++ b/src/resources/defi/types.ts
@@ -1,10 +1,13 @@
 import { NativeCurrencyKey, ZerionAsset } from '@/entities';
-import { Network } from '@/chains/types';
+import { ChainId, Network } from '@/chains/types';
+import { TokenColors } from '@/graphql/__generated__/metadata';
 
 export type AddysPositionsResponse =
   | {
       meta: Record<string, any>;
-      payload: Record<string, any>;
+      payload: {
+        positions: Position[];
+      };
     }
   | Record<string, never>;
 
@@ -18,7 +21,13 @@ export type NativeDisplay = {
   display: string;
 };
 
-export type PositionAsset = ZerionAsset & { network: Network };
+// TODO: this does not have all the fields returned by the API
+export type PositionAsset = ZerionAsset & {
+  network: Network;
+  chain_id: ChainId;
+  networks: Record<ChainId, { address: string; decimals: number }>;
+  colors: TokenColors;
+};
 
 export type PositionDapp = {
   name: string;
@@ -31,12 +40,18 @@ export type PositionDapp = {
   };
 };
 
+export type UnderlyingAsset = {
+  asset: PositionAsset;
+  quantity: string;
+};
+
 export type PositionsTotals = {
   totals: NativeDisplay;
   totalLocked: string;
   borrows: NativeDisplay;
   claimables: NativeDisplay;
   deposits: NativeDisplay;
+  stakes: NativeDisplay;
 };
 export type Claimable = {
   asset: PositionAsset;
@@ -44,13 +59,13 @@ export type Claimable = {
   omit_from_total?: boolean;
 };
 export type Deposit = {
-  apr: string;
-  apy: string;
   asset: PositionAsset;
   quantity: string;
-  total_asset: string; // what does this mean?
+  apr?: string;
+  apy?: string;
+  total_asset?: string; // what does this mean?
   omit_from_total?: boolean;
-  underlying: { asset: PositionAsset; quantity: string }[];
+  underlying?: UnderlyingAsset[];
 };
 export type Borrow = {
   apr: string;
@@ -59,37 +74,59 @@ export type Borrow = {
   quantity: string;
   total_asset: string; // what does this mean?
   omit_from_total?: boolean;
-  underlying: { asset: PositionAsset; quantity: string }[];
+  underlying: UnderlyingAsset[];
 };
+export type Stake = {
+  asset: PositionAsset;
+  quantity: string;
+  apr?: string;
+  apy?: string;
+  total_asset?: string; // what does this mean?
+  omit_from_total?: boolean;
+  underlying?: UnderlyingAsset[];
+};
+
+export type RainbowUnderlyingAsset = UnderlyingAsset & { native: NativeDisplay };
 
 export type RainbowClaimable = {
   asset: PositionAsset;
   quantity: string;
   native: NativeDisplay;
+  omit_from_total?: boolean;
+  dappVersion?: string;
 };
 export type RainbowDeposit = {
-  apr: string;
-  apy: string;
   asset: PositionAsset;
   quantity: string;
-  total_asset: string; // what does this mean?
-  underlying: {
-    asset: PositionAsset;
-    quantity: string;
-    native: NativeDisplay;
-  }[];
+  isLp: boolean;
+  isConcentratedLiquidity: boolean;
+  omit_from_total?: boolean;
+  underlying: RainbowUnderlyingAsset[];
+  apr?: string;
+  apy?: string;
+  dappVersion?: string;
+  total_asset?: string; // what does this mean?
 };
 export type RainbowBorrow = {
-  apr: string;
-  apy: string;
   asset: PositionAsset;
   quantity: string;
+  omit_from_total?: boolean;
+  apr: string;
+  apy: string;
   total_asset: string; // what does this mean?
-  underlying: {
-    asset: PositionAsset;
-    quantity: string;
-    native: NativeDisplay;
-  }[];
+  dappVersion?: string;
+  underlying: RainbowUnderlyingAsset[];
+};
+export type RainbowStake = {
+  asset: PositionAsset;
+  quantity: string;
+  isLp: boolean;
+  isConcentratedLiquidity: boolean;
+  omit_from_total?: boolean;
+  underlying: RainbowUnderlyingAsset[];
+  dappVersion?: string;
+  apr?: string;
+  apy?: string;
 };
 
 // TODO: need to add dapp metadata once its added via BE
@@ -97,6 +134,7 @@ export type Position = {
   type: string;
   claimables: Claimable[];
   borrows: Borrow[];
+  stakes: Stake[];
   deposits: Deposit[];
   dapp: PositionDapp;
 };
@@ -107,17 +145,12 @@ export type RainbowPosition = {
   claimables: RainbowClaimable[];
   borrows: RainbowBorrow[];
   deposits: RainbowDeposit[];
+  stakes: RainbowStake[];
   dapp: PositionDapp;
 };
 
 export type RainbowPositions = {
-  totals: {
-    total: NativeDisplay;
-    totalLocked: string;
-    borrows: NativeDisplay;
-    claimables: NativeDisplay;
-    deposits: NativeDisplay;
-  };
+  totals: PositionsTotals & { total: NativeDisplay };
   positionTokens: string[];
   positions: RainbowPosition[];
 };

--- a/src/resources/defi/utils.ts
+++ b/src/resources/defi/utils.ts
@@ -31,7 +31,7 @@ function isLpPositionItem(item: Deposit | Stake): boolean {
 
 function calculatePositionItemNativeDisplayValue(item: UnderlyingAsset | Claimable | Stake, currency: NativeCurrencyKey) {
   const decimals = typeof item.asset.decimals === 'number' ? item.asset.decimals : 18;
-  return convertRawAmountToNativeDisplay(item.quantity, decimals, item.asset.price?.value!, currency);
+  return convertRawAmountToNativeDisplay(item.quantity, decimals, item.asset.price?.value ?? 0, currency);
 }
 
 function addPositionTotals(totals1: PositionsTotals, totals2: PositionsTotals, currency: NativeCurrencyKey): PositionsTotals {

--- a/src/resources/defi/utils.ts
+++ b/src/resources/defi/utils.ts
@@ -3,6 +3,7 @@ import {
   AddysPositionsResponse,
   Borrow,
   Claimable,
+  Deposit,
   Position,
   PositionsTotals,
   RainbowBorrow,
@@ -10,80 +11,173 @@ import {
   RainbowDeposit,
   RainbowPosition,
   RainbowPositions,
+  RainbowStake,
+  Stake,
+  UnderlyingAsset,
 } from './types';
 import { add, convertAmountToNativeDisplay, convertRawAmountToNativeDisplay, subtract } from '@/helpers/utilities';
 import { maybeSignUri } from '@/handlers/imgix';
 import { ethereumUtils } from '@/utils';
 import { chainsIdByName } from '@/chains';
 
-export const parsePosition = (position: Position, currency: NativeCurrencyKey): RainbowPosition => {
+const PROTOCOL_VERSION_REGEX = /-[vV]\d+$/;
+const LP_POOL_SYMBOL = 'LP-POOL';
+const CONCENTRATED_LIQUIDITY_ONLY_DAPPS = ['uniswap-v3'];
+
+// Zerion currently has no specific lp position signifier
+function isLpPositionItem(item: Deposit | Stake): boolean {
+  return item.asset.symbol === LP_POOL_SYMBOL;
+}
+
+function calculatePositionItemNativeDisplayValue(item: UnderlyingAsset | Claimable | Stake, currency: NativeCurrencyKey) {
+  const decimals = typeof item.asset.decimals === 'number' ? item.asset.decimals : 18;
+  return convertRawAmountToNativeDisplay(item.quantity, decimals, item.asset.price?.value!, currency);
+}
+
+function addPositionTotals(totals1: PositionsTotals, totals2: PositionsTotals, currency: NativeCurrencyKey): PositionsTotals {
+  return {
+    totals: {
+      amount: add(totals1.totals.amount, totals2.totals.amount),
+      display: convertAmountToNativeDisplay(add(totals1.totals.amount, totals2.totals.amount), currency),
+    },
+    totalLocked: add(totals1.totalLocked, totals2.totalLocked),
+    borrows: {
+      amount: add(totals1.borrows.amount, totals2.borrows.amount),
+      display: convertAmountToNativeDisplay(add(totals1.borrows.amount, totals2.borrows.amount), currency),
+    },
+    claimables: {
+      amount: add(totals1.claimables.amount, totals2.claimables.amount),
+      display: convertAmountToNativeDisplay(add(totals1.claimables.amount, totals2.claimables.amount), currency),
+    },
+    deposits: {
+      amount: add(totals1.deposits.amount, totals2.deposits.amount),
+      display: convertAmountToNativeDisplay(add(totals1.deposits.amount, totals2.deposits.amount), currency),
+    },
+    stakes: {
+      amount: add(totals1.stakes.amount, totals2.stakes.amount),
+      display: convertAmountToNativeDisplay(add(totals1.stakes.amount, totals2.stakes.amount), currency),
+    },
+  };
+}
+
+/**
+ * Parses a pool string to extract token symbols
+ * @param {string} name - String in format "Name TOKEN1/TOKEN2 Pool (#ID)"
+ * @returns {string[]} Array of token symbols
+ */
+function parseTokenSymbolsFromPoolName(name: string): string[] {
+  try {
+    const match = name.match(/\b[A-Z]+(?:\/[A-Z]+)+\b/);
+    if (!match) {
+      return [];
+    }
+    return match[0].split('/');
+  } catch (error) {
+    return [];
+  }
+}
+
+// hack to fix for Zerion api returning only 1 asset for lp position when position is out of range
+function fixOutOfRangeLpPosition(positionItem: Deposit | Stake, claimables: Claimable[]): Deposit | Stake {
+  if (!positionItem.underlying) {
+    return positionItem;
+  }
+
+  const lpTokenSymbols = parseTokenSymbolsFromPoolName(positionItem.asset.name);
+
+  // we already have the correct number of underlying assets
+  if (lpTokenSymbols.length === positionItem.underlying.length) {
+    return positionItem;
+  }
+
+  const missingUnderlyingAssetSymbols = lpTokenSymbols.filter(
+    symbol => !positionItem.underlying?.some(underlying => underlying.asset.symbol === symbol)
+  );
+
+  if (missingUnderlyingAssetSymbols.length === 0) {
+    return positionItem;
+  }
+
+  const missingUnderlyingAssets = missingUnderlyingAssetSymbols.map(symbol => {
+    // since each lp earns from both tokens, we can just take the first claimable that matches the symbol and network
+    const claimable = claimables.find(claim => claim.asset.symbol === symbol && claim.asset.network === positionItem.asset.network);
+    return {
+      asset: claimable?.asset,
+      quantity: '0',
+    };
+  });
+
+  // could not find claimable for at least one of the missing underlying assets
+  if (missingUnderlyingAssets.some(asset => !asset.asset)) {
+    return positionItem;
+  }
+
+  return {
+    ...positionItem,
+    // cast to UnderlyingAsset[] because typescript cannot infer that there will not be any nullish asset values from the check above
+    underlying: [...(positionItem.underlying ?? []), ...missingUnderlyingAssets] as UnderlyingAsset[],
+  };
+}
+
+function parsePositionTotals(position: Position, currency: NativeCurrencyKey): PositionsTotals {
   let totalLocked = '0';
-
   let totalDeposits = '0';
-  const parsedDeposits = position.deposits?.map((deposit): RainbowDeposit => {
-    return {
-      ...deposit,
-      underlying: deposit.underlying?.map(underlying => {
-        const decimals = typeof underlying.asset.decimals === 'number' ? underlying.asset.decimals : 18;
-        const nativeDisplay = convertRawAmountToNativeDisplay(underlying.quantity, decimals, underlying.asset.price?.value!, currency);
-
-        if (deposit.omit_from_total) {
-          totalLocked = add(totalLocked, nativeDisplay.amount);
-        }
-        totalDeposits = add(totalDeposits, nativeDisplay.amount);
-
-        return {
-          ...underlying,
-          native: nativeDisplay,
-        };
-      }),
-    };
-  });
-
   let totalBorrows = '0';
+  let totalClaimables = '0';
+  let totalStakes = '0';
 
-  const parsedBorrows = position.borrows?.map((borrow: Borrow): RainbowBorrow => {
-    return {
-      ...borrow,
-      underlying: borrow.underlying.map(underlying => {
-        const decimals = typeof underlying.asset.decimals === 'number' ? underlying.asset.decimals : 18;
-        const nativeDisplay = convertRawAmountToNativeDisplay(underlying.quantity, decimals, underlying.asset.price?.value!, currency);
+  position.deposits.forEach(deposit => {
+    deposit.underlying?.forEach(underlying => {
+      const native = calculatePositionItemNativeDisplayValue(underlying, currency);
 
-        if (borrow.omit_from_total) {
-          totalLocked = subtract(totalLocked, nativeDisplay.amount);
-        }
+      if (deposit.omit_from_total) {
+        totalLocked = add(totalLocked, native.amount);
+      }
 
-        totalBorrows = add(totalBorrows, nativeDisplay.amount);
-
-        return {
-          ...underlying,
-          native: nativeDisplay,
-        };
-      }),
-    };
+      totalDeposits = add(totalDeposits, native.amount);
+    });
   });
 
-  let totalClaimables = '0';
-  const parsedClaimables = position.claimables?.map((claim: Claimable): RainbowClaimable => {
-    const decimals = typeof claim.asset.decimals === 'number' ? claim.asset.decimals : 18;
-    const nativeDisplay = convertRawAmountToNativeDisplay(claim.quantity, decimals, claim.asset.price?.value!, currency);
+  position.borrows.forEach(borrow => {
+    borrow.underlying?.forEach(underlying => {
+      const native = calculatePositionItemNativeDisplayValue(underlying, currency);
+
+      if (borrow.omit_from_total) {
+        totalLocked = subtract(totalLocked, native.amount);
+      }
+
+      totalBorrows = add(totalBorrows, native.amount);
+    });
+  });
+
+  position.claimables.forEach(claim => {
+    const native = calculatePositionItemNativeDisplayValue(claim, currency);
 
     if (claim.omit_from_total) {
-      totalLocked = add(totalLocked, nativeDisplay.amount);
+      totalLocked = add(totalLocked, native.amount);
     }
-    totalClaimables = add(totalClaimables, nativeDisplay.amount);
 
-    return {
-      asset: claim.asset,
-      quantity: claim.quantity,
-      native: nativeDisplay,
-    };
+    totalClaimables = add(totalClaimables, native.amount);
   });
 
-  const positionTotals: PositionsTotals = {
+  position.stakes.forEach(stake => {
+    stake.underlying?.forEach(underlying => {
+      const native = calculatePositionItemNativeDisplayValue(underlying, currency);
+
+      if (stake.omit_from_total) {
+        totalLocked = add(totalLocked, native.amount);
+      }
+
+      totalStakes = add(totalStakes, native.amount);
+    });
+  });
+
+  const totalAmount = subtract(add(add(totalDeposits, totalClaimables), totalStakes), totalBorrows);
+
+  return {
     totals: {
-      amount: subtract(add(totalDeposits, totalClaimables), totalBorrows),
-      display: convertAmountToNativeDisplay(subtract(add(totalDeposits, totalClaimables), totalBorrows), currency),
+      amount: totalAmount,
+      display: convertAmountToNativeDisplay(totalAmount, currency),
     },
     totalLocked,
     borrows: {
@@ -98,14 +192,125 @@ export const parsePosition = (position: Position, currency: NativeCurrencyKey): 
       amount: totalDeposits,
       display: convertAmountToNativeDisplay(totalDeposits, currency),
     },
+    stakes: {
+      amount: totalStakes,
+      display: convertAmountToNativeDisplay(totalStakes, currency),
+    },
   };
+}
+
+function parsePosition(position: Position, currency: NativeCurrencyKey): RainbowPosition {
+  // check if the string ends with -v{number}
+  const isDappVersioned = PROTOCOL_VERSION_REGEX.test(position.type);
+  const dappVersion = isDappVersioned ? position.type.match(PROTOCOL_VERSION_REGEX)?.[0].slice(1) : undefined;
+
+  const parsedDeposits = position.deposits?.map((deposit): RainbowDeposit => {
+    let parsedDeposit = deposit;
+
+    const isLpDeposit = isLpPositionItem(parsedDeposit);
+
+    if (isLpDeposit) {
+      parsedDeposit = fixOutOfRangeLpPosition(parsedDeposit, position.claimables);
+    }
+
+    // it's okay that this is after the lp fix because an lp deposit will always have at least one underlying asset
+    // not all deposits have underlying assets, normalize to avoid conditional rendering logic
+    if (!parsedDeposit.underlying) {
+      parsedDeposit.underlying = [
+        {
+          asset: parsedDeposit.asset,
+          quantity: parsedDeposit.quantity,
+        },
+      ];
+    }
+
+    return {
+      ...parsedDeposit,
+      dappVersion,
+      isLp: isLpDeposit,
+      isConcentratedLiquidity: CONCENTRATED_LIQUIDITY_ONLY_DAPPS.includes(position.type),
+      underlying: parsedDeposit.underlying?.map(underlying => {
+        return {
+          ...underlying,
+          native: calculatePositionItemNativeDisplayValue(underlying, currency),
+        };
+      }),
+    };
+  });
+
+  const parsedStakes = position.stakes?.map((stake): RainbowStake => {
+    let parsedStake = stake;
+
+    const isLpStake = isLpPositionItem(parsedStake);
+
+    if (isLpStake) {
+      parsedStake = fixOutOfRangeLpPosition(parsedStake, position.claimables);
+    }
+
+    // not all stakes have underlying assets, normalize to avoid conditional rendering logic
+    if (!parsedStake.underlying) {
+      parsedStake.underlying = [
+        {
+          asset: parsedStake.asset,
+          quantity: parsedStake.quantity,
+        },
+      ];
+    }
+
+    return {
+      ...parsedStake,
+      dappVersion,
+      isLp: isLpStake,
+      isConcentratedLiquidity: CONCENTRATED_LIQUIDITY_ONLY_DAPPS.includes(position.type),
+      underlying: parsedStake.underlying?.map(underlying => {
+        return {
+          ...underlying,
+          native: calculatePositionItemNativeDisplayValue(underlying, currency),
+        };
+      }),
+    };
+  });
+
+  const parsedBorrows = position.borrows?.map((borrow: Borrow): RainbowBorrow => {
+    if (!borrow.underlying) {
+      borrow.underlying = [
+        {
+          asset: borrow.asset,
+          quantity: borrow.quantity,
+        },
+      ];
+    }
+
+    return {
+      ...borrow,
+      underlying:
+        borrow.underlying.map(underlying => {
+          return {
+            ...underlying,
+            dappVersion,
+            native: calculatePositionItemNativeDisplayValue(underlying, currency),
+          };
+        }) ?? [],
+    };
+  });
+
+  const parsedClaimables = position.claimables?.map((claim: Claimable): RainbowClaimable => {
+    return {
+      asset: claim.asset,
+      quantity: claim.quantity,
+      omit_from_total: claim.omit_from_total,
+      native: calculatePositionItemNativeDisplayValue(claim, currency),
+      dappVersion,
+    };
+  });
 
   return {
     type: position.type,
-    totals: positionTotals,
+    totals: parsePositionTotals(position, currency),
     deposits: parsedDeposits,
     borrows: parsedBorrows,
     claimables: parsedClaimables,
+    stakes: parsedStakes,
     // revert dapp name bs once versions are handled via backend
     dapp: {
       ...position.dapp,
@@ -113,72 +318,91 @@ export const parsePosition = (position: Position, currency: NativeCurrencyKey): 
       icon_url: maybeSignUri(position.dapp.icon_url) || position.dapp.icon_url,
     },
   };
-};
+}
 
-export const parsePositions = (data: AddysPositionsResponse, currency: NativeCurrencyKey): RainbowPositions => {
-  const networkAgnosticPositions = data.payload?.positions.reduce((acc: Record<string, Position>, position: Position) => {
+export function parsePositions(data: AddysPositionsResponse, currency: NativeCurrencyKey): RainbowPositions {
+  const networkAgnosticPositions: Record<string, Position> = data.payload?.positions.reduce(
+    (acc: Record<string, Position>, position: Position) => {
+      const type = position.type;
+
+      return {
+        ...acc,
+        [type]: {
+          type,
+          claimables: [...(acc?.[type]?.claimables || []), ...(position?.claimables || [])],
+          deposits: [...(acc?.[type]?.deposits || []), ...(position?.deposits || [])],
+          borrows: [...(acc?.[type]?.borrows || []), ...(position?.borrows || [])],
+          stakes: [...(acc?.[type]?.stakes || []), ...(position?.stakes || [])],
+          dapp: position.dapp,
+        },
+      };
+    },
+    {}
+  );
+
+  // parse positions before grouping by non-versioned dapp so version can be attached to position items
+  const parsedPositions = Object.values(networkAgnosticPositions).map(position => parsePosition(position, currency));
+
+  const versionAgnosticPositions = parsedPositions.reduce((acc: Record<string, RainbowPosition>, position: RainbowPosition) => {
+    const isDappVersioned = PROTOCOL_VERSION_REGEX.test(position.type);
+
+    const nonVersionedType = isDappVersioned ? position.type.replace(PROTOCOL_VERSION_REGEX, '') : position.type;
+    const nonVersionedDappName = isDappVersioned ? position.dapp.name.replace(PROTOCOL_VERSION_REGEX, '') : position.dapp.name;
+
     return {
       ...acc,
-      [position.type]: {
-        claimables: [...(acc?.[position.type]?.claimables || []), ...(position?.claimables || [])],
-        deposits: [...(acc?.[position.type]?.deposits || []), ...(position?.deposits || [])],
-        borrows: [...(acc?.[position.type]?.borrows || []), ...(position?.borrows || [])],
-        dapp: position.dapp,
-      },
-    };
+      [nonVersionedType]: {
+        type: nonVersionedType,
+        claimables: [...(acc?.[nonVersionedType]?.claimables || []), ...(position?.claimables || [])],
+        deposits: [...(acc?.[nonVersionedType]?.deposits || []), ...(position?.deposits || [])],
+        borrows: [...(acc?.[nonVersionedType]?.borrows || []), ...(position?.borrows || [])],
+        stakes: [...(acc?.[nonVersionedType]?.stakes || []), ...(position?.stakes || [])],
+        dapp: {
+          ...position.dapp,
+          name: nonVersionedDappName,
+        },
+        totals: acc?.[nonVersionedType]?.totals
+          ? addPositionTotals(acc?.[nonVersionedType]?.totals, position.totals, currency)
+          : position.totals,
+      } satisfies RainbowPosition,
+    } as Record<string, RainbowPosition>;
   }, {});
 
-  const positions = Object.keys(networkAgnosticPositions).map(key => ({
-    type: key,
-    ...networkAgnosticPositions[key],
-  }));
-
-  const parsedPositions = positions.map(position => parsePosition(position, currency));
+  const positions = Object.values(versionAgnosticPositions);
 
   const positionTokens: string[] = [];
 
-  parsedPositions.forEach(({ deposits }) => {
+  positions.forEach(({ deposits, stakes }) => {
     deposits.forEach(({ asset }) => {
       const uniqueId = ethereumUtils.getUniqueId(asset.asset_code.toLowerCase(), chainsIdByName[asset.network]);
       positionTokens.push(uniqueId);
     });
+    stakes.forEach(({ underlying }) => {
+      underlying.forEach(({ asset }) => {
+        const uniqueId = ethereumUtils.getUniqueId(asset.asset_code.toLowerCase(), chainsIdByName[asset.network]);
+        positionTokens.push(uniqueId);
+      });
+    });
   });
 
-  const positionsTotals = parsedPositions.reduce(
-    (acc, position) => ({
-      totalLocked: add(acc.totalLocked, position.totals.totalLocked),
-      borrows: {
-        amount: add(acc.borrows.amount, position.totals.borrows.amount),
-        display: convertAmountToNativeDisplay(add(acc.borrows.amount, position.totals.borrows.amount), currency),
-      },
-      deposits: {
-        amount: add(acc.deposits.amount, position.totals.deposits.amount),
-        display: convertAmountToNativeDisplay(add(acc.deposits.amount, position.totals.deposits.amount), currency),
-      },
-      claimables: {
-        amount: add(acc.claimables.amount, position.totals.claimables.amount),
-        display: convertAmountToNativeDisplay(add(acc.claimables.amount, position.totals.claimables.amount), currency),
-      },
-    }),
-    {
-      totalLocked: '0',
-      borrows: { amount: '0', display: '0' },
-      claimables: { amount: '0', display: '0' },
-      deposits: { amount: '0', display: '0' },
-    }
-  );
-
-  const totalAmount = subtract(add(positionsTotals.deposits.amount, positionsTotals.claimables.amount), positionsTotals.borrows.amount);
+  const positionsTotals = positions.reduce((acc, position) => addPositionTotals(acc, position.totals, currency), {
+    totals: { amount: '0', display: '0' },
+    totalLocked: '0',
+    borrows: { amount: '0', display: '0' },
+    deposits: { amount: '0', display: '0' },
+    claimables: { amount: '0', display: '0' },
+    stakes: { amount: '0', display: '0' },
+  });
 
   return {
     totals: {
       total: {
-        amount: totalAmount,
-        display: convertAmountToNativeDisplay(totalAmount, currency),
+        amount: positionsTotals.totals.amount,
+        display: positionsTotals.totals.display,
       },
       ...positionsTotals,
     },
-    positions: parsedPositions,
+    positions,
     positionTokens,
   };
-};
+}

--- a/src/screens/positions/LpPositionListItem.tsx
+++ b/src/screens/positions/LpPositionListItem.tsx
@@ -79,7 +79,7 @@ export const LpPositionListItem: React.FC<Props> = ({ underlyingAssets, isConcen
             <Columns alignVertical="center">
               <Column>
                 <Inline alignVertical="center" space={'6px'}>
-                  <Text size="17pt" weight="bold" color="label" numberOfLines={1}>
+                  <Text size="17pt" weight="medium" color="label" numberOfLines={1}>
                     {underlyingAssets.map(underlying => underlying.asset.symbol).join(' / ')}
                   </Text>
                   {dappVersion && (

--- a/src/screens/positions/LpPositionListItem.tsx
+++ b/src/screens/positions/LpPositionListItem.tsx
@@ -27,12 +27,8 @@ export const LpPositionListItem: React.FC<Props> = ({ underlyingAssets, isConcen
   const { colors } = useTheme();
   const { nativeCurrency } = useAccountSettings();
   const theme = useTheme();
-  // const chainId = chainsIdByName[asset.network];
-  // const { data: externalAsset } = useExternalToken({ address: asset.asset_code, chainId, currency: nativeCurrency });
 
   const separatorSecondary = useForegroundColor('separatorSecondary');
-
-  // const priceChangeColor = (asset.price?.relative_change_24h || 0) < 0 ? theme.colors.blueGreyDark60 : theme.colors.green;
 
   const totalDepositValue = underlyingAssets.reduce((acc, underlying) => add(acc, underlying.native.amount), '0');
   const assetAllocations = underlyingAssets.map(underlying => {

--- a/src/screens/positions/LpPositionListItem.tsx
+++ b/src/screens/positions/LpPositionListItem.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { Box, Column, Columns, Inline, Stack, Text, useForegroundColor } from '@/design-system';
+import { useTheme } from '@/theme';
+import { add, convertAmountToPercentageDisplay, convertRawAmountToNativeDisplay, divide } from '@/helpers/utilities';
+import { RainbowUnderlyingAsset } from '@/resources/defi/types';
+import { useAccountSettings } from '@/hooks';
+import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
+import { LpRangeBadge } from './LpRangeBadge';
+import { TwoCoinsIcon } from '@/components/coin-icon/TwoCoinsIcon';
+import { IS_IOS } from '@/env';
+import * as i18n from '@/languages';
+
+function getRangeStatus(isConcentratedLiquidity: boolean, isOutOfRange: boolean) {
+  if (!isConcentratedLiquidity) {
+    return 'full_range';
+  }
+  return isOutOfRange ? 'out_of_range' : 'in_range';
+}
+
+type Props = {
+  underlyingAssets: RainbowUnderlyingAsset[];
+  isConcentratedLiquidity: boolean;
+  dappVersion?: string;
+};
+
+export const LpPositionListItem: React.FC<Props> = ({ underlyingAssets, isConcentratedLiquidity, dappVersion }) => {
+  const { colors } = useTheme();
+  const { nativeCurrency } = useAccountSettings();
+  const theme = useTheme();
+  // const chainId = chainsIdByName[asset.network];
+  // const { data: externalAsset } = useExternalToken({ address: asset.asset_code, chainId, currency: nativeCurrency });
+
+  const separatorSecondary = useForegroundColor('separatorSecondary');
+
+  // const priceChangeColor = (asset.price?.relative_change_24h || 0) < 0 ? theme.colors.blueGreyDark60 : theme.colors.green;
+
+  const totalDepositValue = underlyingAssets.reduce((acc, underlying) => add(acc, underlying.native.amount), '0');
+  const assetAllocations = underlyingAssets.map(underlying => {
+    return parseFloat(divide(underlying.native.amount, totalDepositValue));
+  });
+
+  const totalValueNative = convertRawAmountToNativeDisplay(totalDepositValue, 0, 1, nativeCurrency);
+
+  const isOutOfRange =
+    underlyingAssets.some(underlying => {
+      return underlying.quantity === '0';
+    }) || underlyingAssets.length === 1;
+
+  const rangeStatus = getRangeStatus(isConcentratedLiquidity, isOutOfRange);
+
+  return (
+    <Columns space={'10px'}>
+      <Column width={'content'}>
+        {underlyingAssets.length === 2 && (
+          <TwoCoinsIcon
+            badge
+            // @ts-expect-error component uses different Token entity type, but it is compatible
+            under={{
+              ...underlyingAssets[0].asset,
+              chainId: underlyingAssets[0].asset.chain_id,
+            }}
+            // @ts-expect-error component uses different Token entity type, but it is compatible
+            over={{
+              ...underlyingAssets[1].asset,
+              chainId: underlyingAssets[1].asset.chain_id,
+            }}
+          />
+        )}
+        {underlyingAssets.length === 1 && (
+          <RainbowCoinIcon
+            icon={underlyingAssets[0].asset.icon_url ?? undefined}
+            chainId={underlyingAssets[0].asset.chain_id}
+            symbol={underlyingAssets[0].asset.symbol}
+            theme={theme}
+            colors={underlyingAssets[0].asset.colors}
+          />
+        )}
+        {/* TODO: add three+ coins icon */}
+      </Column>
+      <Box justifyContent="center" style={{ height: 40 }}>
+        <Stack space="10px">
+          <Inline alignHorizontal="justify" alignVertical="center" wrap={false}>
+            <Columns alignVertical="center">
+              <Column>
+                <Inline alignVertical="center" space={'6px'}>
+                  <Text size="17pt" weight="bold" color="label" numberOfLines={1}>
+                    {underlyingAssets.map(underlying => underlying.asset.symbol).join(' / ')}
+                  </Text>
+                  {dappVersion && (
+                    <Box
+                      borderRadius={7}
+                      padding={{ custom: 4.5 }}
+                      style={{
+                        borderColor: separatorSecondary,
+                        borderWidth: 1.5,
+                        // offset vertical padding
+                        marginVertical: -11,
+                      }}
+                    >
+                      <Text color="labelQuaternary" size="13pt" weight="bold">
+                        {dappVersion}
+                      </Text>
+                    </Box>
+                  )}
+                </Inline>
+              </Column>
+              <Column width={'content'}>
+                <Text size="17pt" weight="medium" color="label" numberOfLines={1}>
+                  {`${totalValueNative.display}`}
+                </Text>
+              </Column>
+            </Columns>
+          </Inline>
+          <Inline alignHorizontal="justify" alignVertical="center" wrap={false}>
+            <Columns alignVertical="center">
+              <Column>
+                <Inline alignVertical="center" space={'6px'}>
+                  <Box
+                    width={{ custom: 7 }}
+                    height={{ custom: 7 }}
+                    borderRadius={7 / 2}
+                    borderWidth={1}
+                    borderColor={{ custom: 'rgba(0,0,0,0.02)' }}
+                    backgroundColor={rangeStatus === 'in_range' || rangeStatus === 'full_range' ? colors.green : colors.red}
+                    shadowColor={rangeStatus === 'in_range' || rangeStatus === 'full_range' ? colors.green : colors.red}
+                    elevation={12}
+                    shadowOpacity={IS_IOS ? 0.2 : 1}
+                    shadowRadius={6}
+                    style={{
+                      shadowOffset: { width: 0, height: 2 },
+                    }}
+                  />
+                  <Box style={{ maxWidth: 150 }}>
+                    <Text size="13pt" weight="semibold" color="labelTertiary" numberOfLines={1}>
+                      {i18n.t(i18n.l.positions.lp_range_status[rangeStatus])}
+                    </Text>
+                  </Box>
+                  <LpRangeBadge
+                    assets={underlyingAssets.map((underlying, index) => ({
+                      color: underlying.asset.colors.primary ?? underlying.asset.colors.fallback ?? colors.black,
+                      allocationPercentage: assetAllocations[index],
+                    }))}
+                  />
+                </Inline>
+              </Column>
+              <Column width="content">
+                <Text size="13pt" weight="medium" color={'labelSecondary'} align="right">
+                  {assetAllocations
+                    .map(allocation => `${convertAmountToPercentageDisplay(allocation * 100, 0, undefined, true)}`)
+                    .join(' / ')}
+                </Text>
+              </Column>
+            </Columns>
+          </Inline>
+        </Stack>
+      </Box>
+    </Columns>
+  );
+};

--- a/src/screens/positions/LpRangeBadge.tsx
+++ b/src/screens/positions/LpRangeBadge.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import { Box } from '@/design-system';
+import { IS_IOS } from '@/env';
+
+const ASSET_SPACE = 2;
+const WIDTH = 32;
+const OUTTER_BORDER_RADIUS = 4;
+const INNER_BORDER_RADIUS = 2;
+const MIN_ALLOCATION_PERCENTAGE = 0.25;
+const MAX_ALLOCATION_PERCENTAGE = 0.75;
+
+type LpRangeBadgeProps = {
+  assets: {
+    color: string;
+    allocationPercentage: number;
+  }[];
+};
+
+export const LpRangeBadge = ({ assets }: LpRangeBadgeProps) => {
+  return (
+    <Box flexDirection="row" width={{ custom: 32 }} height={{ custom: 10 }} gap={ASSET_SPACE}>
+      {assets.map((asset, index) => {
+        const isFirst = index === 0;
+        const isLast = index === assets.length - 1;
+        const isMiddle = !isFirst && !isLast;
+
+        let borderTopLeftRadius = isFirst ? OUTTER_BORDER_RADIUS : INNER_BORDER_RADIUS;
+        let borderBottomLeftRadius = isFirst ? OUTTER_BORDER_RADIUS : INNER_BORDER_RADIUS;
+        let borderTopRightRadius = isLast ? OUTTER_BORDER_RADIUS : INNER_BORDER_RADIUS;
+        let borderBottomRightRadius = isLast ? OUTTER_BORDER_RADIUS : INNER_BORDER_RADIUS;
+
+        let width = Math.max(
+          Math.min(asset.allocationPercentage * WIDTH, MAX_ALLOCATION_PERCENTAGE * WIDTH),
+          MIN_ALLOCATION_PERCENTAGE * WIDTH
+        );
+
+        if (asset.allocationPercentage === 0) {
+          width = 0;
+          borderTopLeftRadius = OUTTER_BORDER_RADIUS;
+          borderBottomLeftRadius = OUTTER_BORDER_RADIUS;
+          borderTopRightRadius = OUTTER_BORDER_RADIUS;
+          borderBottomRightRadius = OUTTER_BORDER_RADIUS;
+        }
+
+        if (asset.allocationPercentage === 1) {
+          width = WIDTH;
+          borderTopLeftRadius = OUTTER_BORDER_RADIUS;
+          borderBottomLeftRadius = OUTTER_BORDER_RADIUS;
+          borderTopRightRadius = OUTTER_BORDER_RADIUS;
+          borderBottomRightRadius = OUTTER_BORDER_RADIUS;
+        }
+
+        return (
+          <Box
+            key={`${asset.color}-${asset.allocationPercentage}`}
+            borderTopLeftRadius={borderTopLeftRadius}
+            borderBottomLeftRadius={borderBottomLeftRadius}
+            borderTopRightRadius={borderTopRightRadius}
+            borderBottomRightRadius={borderBottomRightRadius}
+            backgroundColor={asset.color}
+            height={'full'}
+            width={{ custom: width }}
+            shadowColor={asset.color}
+            shadowOpacity={IS_IOS ? 0.2 : 1}
+            shadowRadius={9}
+            style={{
+              shadowOffset: { width: 0, height: 3 },
+              borderCurve: 'continuous',
+            }}
+          >
+            <LinearGradient
+              colors={
+                isMiddle
+                  ? ['rgba(255, 255, 255, 0.1)', 'rgba(255, 255, 255, 0.0)', 'rgba(255, 255, 255, 0.1)']
+                  : ['rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 0.3)']
+              }
+              start={{ x: isFirst ? 0 : 1, y: 0.5 }}
+              end={{ x: isFirst ? 1 : 0, y: 0.5 }}
+              style={StyleSheet.absoluteFillObject}
+            />
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};

--- a/src/screens/positions/PositionSheet.tsx
+++ b/src/screens/positions/PositionSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { SlackSheet } from '@/components/sheet';
-import { BackgroundProvider, Box, Inline, Separator, Stack, Text } from '@/design-system';
+import { BackgroundProvider, Box, globalColors, Inline, Separator, Stack, Text, useColorMode } from '@/design-system';
 import { IS_IOS } from '@/env';
 import { Linking } from 'react-native';
 import { useRoute } from '@react-navigation/native';
@@ -43,10 +43,12 @@ export function getPositionSheetHeight({ position }: { position: RainbowPosition
 export const PositionSheet: React.FC = () => {
   const { params } = useRoute();
   const { colors } = useTheme();
+  const { isDarkMode } = useColorMode();
 
   const { position } = params as { position: RainbowPosition };
 
-  const positionColor = position.dapp.colors.primary || position.dapp.colors.fallback || colors.black;
+  const positionColor =
+    position.dapp.colors.primary || position.dapp.colors.fallback || (isDarkMode ? globalColors.white100 : globalColors.white10);
 
   const deposits = position.deposits.filter(deposit => !deposit.isLp);
   const lpDeposits = position.deposits.filter(deposit => deposit.isLp);
@@ -153,7 +155,6 @@ export const PositionSheet: React.FC = () => {
                     <LpPositionListItem
                       key={`stake-${stake.asset.asset_code}-${stake.quantity}`}
                       underlyingAssets={stake.underlying}
-                      // TODO: move to parsing utils
                       isConcentratedLiquidity={stake.isConcentratedLiquidity}
                       dappVersion={stake.dappVersion}
                     />

--- a/src/screens/positions/PositionSheet.tsx
+++ b/src/screens/positions/PositionSheet.tsx
@@ -3,7 +3,7 @@ import { SlackSheet } from '@/components/sheet';
 import { BackgroundProvider, Box, globalColors, Inline, Separator, Stack, Text, useColorMode } from '@/design-system';
 import { IS_IOS } from '@/env';
 import { Linking } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { analyticsV2 } from '@/analytics';
 import { RequestVendorLogoIcon } from '@/components/coin-icon';
 import startCase from 'lodash/startCase';
@@ -15,6 +15,7 @@ import * as i18n from '@/languages';
 import { capitalize } from 'lodash';
 import { RainbowPosition } from '@/resources/defi/types';
 import { LpPositionListItem } from './LpPositionListItem';
+import { RootStackParamList } from '@/navigation/types';
 
 const DEPOSIT_ITEM_HEIGHT = 44;
 const BORROW_ITEM_HEIGHT = 44;
@@ -24,12 +25,12 @@ const ITEM_PADDING = 20;
 const SECTION_TITLE_HEIGHT = 20 + ITEM_PADDING;
 
 export function getPositionSheetHeight({ position }: { position: RainbowPosition }) {
-  let height = android ? 120 : 100;
-  const numberOfDeposits = position?.deposits.filter(deposit => !deposit.isLp).length || 0;
-  const numberOfLpDeposits = position?.deposits.filter(deposit => deposit.isLp).length || 0;
-  const numberOfBorrows = position?.borrows?.length || 0;
-  const numberOfClaimables = position?.claimables?.length || 0;
-  const numberOfStakes = position?.stakes?.length || 0;
+  let height = IS_IOS ? 100 : 120;
+  const numberOfDeposits = position.deposits.filter(deposit => !deposit.isLp).length || 0;
+  const numberOfLpDeposits = position.deposits.filter(deposit => deposit.isLp).length || 0;
+  const numberOfBorrows = position.borrows.length || 0;
+  const numberOfClaimables = position.claimables.length || 0;
+  const numberOfStakes = position.stakes.length || 0;
 
   height += numberOfDeposits > 0 ? SECTION_TITLE_HEIGHT + numberOfDeposits * (DEPOSIT_ITEM_HEIGHT + ITEM_PADDING) : 0;
   height += numberOfLpDeposits > 0 ? SECTION_TITLE_HEIGHT + numberOfLpDeposits * (DEPOSIT_ITEM_HEIGHT + ITEM_PADDING) : 0;
@@ -41,11 +42,11 @@ export function getPositionSheetHeight({ position }: { position: RainbowPosition
 }
 
 export const PositionSheet: React.FC = () => {
-  const { params } = useRoute();
+  const {
+    params: { position },
+  } = useRoute<RouteProp<RootStackParamList, 'PositionSheet'>>();
   const { colors } = useTheme();
   const { isDarkMode } = useColorMode();
-
-  const { position } = params as { position: RainbowPosition };
 
   const positionColor =
     position.dapp.colors.primary || position.dapp.colors.fallback || (isDarkMode ? globalColors.white100 : globalColors.white10);
@@ -96,21 +97,23 @@ export const PositionSheet: React.FC = () => {
                     </Stack>
                   </Inline>
                 </Box>
-                <ButtonPressAnimation onPress={openDapp}>
-                  <Box
-                    style={{
-                      backgroundColor: colors.alpha(positionColor, 0.08),
-                      borderRadius: 20,
-                      height: 40,
-                    }}
-                    justifyContent="center"
-                    padding="12px"
-                  >
-                    <Text size="17pt" weight="heavy" color={{ custom: positionColor }}>
-                      {i18n.t(i18n.l.positions.open_dapp)}
-                    </Text>
-                  </Box>
-                </ButtonPressAnimation>
+                {position.dapp.url && (
+                  <ButtonPressAnimation onPress={openDapp}>
+                    <Box
+                      style={{
+                        backgroundColor: colors.alpha(positionColor, 0.08),
+                        borderRadius: 20,
+                        height: 40,
+                      }}
+                      justifyContent="center"
+                      padding="12px"
+                    >
+                      <Text size="17pt" weight="heavy" color={{ custom: positionColor }}>
+                        {i18n.t(i18n.l.positions.open_dapp)}
+                      </Text>
+                    </Box>
+                  </ButtonPressAnimation>
+                )}
               </Inline>
 
               <Stack space={'20px'}>
@@ -145,12 +148,12 @@ export const PositionSheet: React.FC = () => {
                   />
                 ))}
 
-                {(position?.stakes?.length || false) && (
+                {(position.stakes.length || false) && (
                   <Text size="17pt" weight="heavy" color="label">
                     {i18n.t(i18n.l.positions.stakes)}
                   </Text>
                 )}
-                {position?.stakes?.map(stake =>
+                {position.stakes.map(stake =>
                   stake.isLp ? (
                     <LpPositionListItem
                       key={`stake-${stake.asset.asset_code}-${stake.quantity}`}
@@ -170,12 +173,12 @@ export const PositionSheet: React.FC = () => {
                   )
                 )}
 
-                {(position?.borrows?.length || false) && (
+                {(position.borrows.length || false) && (
                   <Text size="17pt" weight="heavy" color="label">
                     {i18n.t(i18n.l.positions.borrows)}
                   </Text>
                 )}
-                {position?.borrows?.map(borrow => (
+                {position.borrows.map(borrow => (
                   <SubPositionListItem
                     key={`borrow-${borrow.underlying[0].asset.asset_code}-${borrow.quantity}-${borrow.apy}`}
                     asset={borrow.underlying[0].asset}
@@ -186,12 +189,12 @@ export const PositionSheet: React.FC = () => {
                   />
                 ))}
 
-                {(position?.claimables?.length || false) && (
+                {(position.claimables.length || false) && (
                   <Text size="17pt" weight="heavy" color="label">
                     {i18n.t(i18n.l.positions.rewards)}
                   </Text>
                 )}
-                {position?.claimables?.map(claim => (
+                {position.claimables.map(claim => (
                   <SubPositionListItem
                     key={`claimable-${claim.asset.asset_code}-${claim.quantity}`}
                     asset={claim.asset}

--- a/src/screens/positions/PositionSheet.tsx
+++ b/src/screens/positions/PositionSheet.tsx
@@ -142,7 +142,8 @@ export const PositionSheet: React.FC = () => {
                 {lpDeposits.map(deposit => (
                   <LpPositionListItem
                     key={`deposit-${deposit.asset.asset_code}-${deposit.quantity}`}
-                    underlyingAssets={deposit.underlying}
+                    assets={deposit.underlying}
+                    totalAssetsValue={deposit.totalValue}
                     isConcentratedLiquidity={deposit.isConcentratedLiquidity}
                     dappVersion={deposit.dappVersion}
                   />
@@ -157,7 +158,8 @@ export const PositionSheet: React.FC = () => {
                   stake.isLp ? (
                     <LpPositionListItem
                       key={`stake-${stake.asset.asset_code}-${stake.quantity}`}
-                      underlyingAssets={stake.underlying}
+                      assets={stake.underlying}
+                      totalAssetsValue={stake.totalValue}
                       isConcentratedLiquidity={stake.isConcentratedLiquidity}
                       dappVersion={stake.dappVersion}
                     />

--- a/src/screens/positions/SubPositionListItem.tsx
+++ b/src/screens/positions/SubPositionListItem.tsx
@@ -48,7 +48,7 @@ export const SubPositionListItem: React.FC<Props> = ({ asset, apy, quantity, nat
             <Columns alignVertical="center">
               <Column>
                 <Inline alignVertical="center" space={'6px'}>
-                  <Text size="17pt" weight="bold" color="label" numberOfLines={1}>
+                  <Text size="17pt" weight="semibold" color="label" numberOfLines={1}>
                     {asset.name}
                   </Text>
                   {dappVersion && (

--- a/src/screens/positions/SubPositionListItem.tsx
+++ b/src/screens/positions/SubPositionListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bleed, Box, Column, Columns, Inline, Stack, Text } from '@/design-system';
+import { Bleed, Box, Column, Columns, Inline, Stack, Text, useForegroundColor } from '@/design-system';
 import { useTheme } from '@/theme';
 import {
   convertAmountToPercentageDisplay,
@@ -18,13 +18,16 @@ type Props = {
   apy: string | undefined;
   native: NativeDisplay;
   positionColor: string;
+  dappVersion?: string;
 };
 
-export const SubPositionListItem: React.FC<Props> = ({ asset, apy, quantity, native, positionColor }) => {
+export const SubPositionListItem: React.FC<Props> = ({ asset, apy, quantity, native, positionColor, dappVersion }) => {
   const theme = useTheme();
   const { nativeCurrency } = useAccountSettings();
   const chainId = chainsIdByName[asset.network];
   const { data: externalAsset } = useExternalToken({ address: asset.asset_code, chainId, currency: nativeCurrency });
+
+  const separatorSecondary = useForegroundColor('separatorSecondary');
 
   const priceChangeColor = (asset.price?.relative_change_24h || 0) < 0 ? theme.colors.blueGreyDark60 : theme.colors.green;
 
@@ -44,9 +47,27 @@ export const SubPositionListItem: React.FC<Props> = ({ asset, apy, quantity, nat
           <Inline key={`${asset.symbol}-${quantity}`} alignHorizontal="justify" alignVertical="center" wrap={false}>
             <Columns alignVertical="center">
               <Column>
-                <Text size="17pt" weight="bold" color="label" numberOfLines={1}>
-                  {asset.name}
-                </Text>
+                <Inline alignVertical="center" space={'6px'}>
+                  <Text size="17pt" weight="bold" color="label" numberOfLines={1}>
+                    {asset.name}
+                  </Text>
+                  {dappVersion && (
+                    <Box
+                      borderRadius={7}
+                      padding={{ custom: 4.5 }}
+                      style={{
+                        borderColor: separatorSecondary,
+                        borderWidth: 1.5,
+                        // offset vertical padding
+                        marginVertical: -11,
+                      }}
+                    >
+                      <Text color="labelQuaternary" size="13pt" weight="bold">
+                        {dappVersion}
+                      </Text>
+                    </Box>
+                  )}
+                </Inline>
               </Column>
               <Column width={'content'}>
                 <Text size="17pt" weight="medium" color="label" numberOfLines={1}>


### PR DESCRIPTION
Fixes APP-2047

## What changed (plus any additional context for devs)

What changed

- Refactored [defi/utils.ts](https://github.com/rainbow-me/rainbow/blob/65b94cd885c2082e6f5d146d9bc28884bac924e8/src/resources/defi/utils.ts) to support parsing staked tokens and LP positions

- `LpPositionListItem` component for displaying LP positions

- All dapp positions are grouped across versions, with a version badge on the PositionSheet delineating the version

Context

- Currently marking an LP position with `isConcentratedLiquidity: true` is hard coded to check against an array of dapps that *only* support concentrated liquidity, such as uniswap-v3. This array should be updated with other protocols. Ideally some checking is done on the backend based on the pool info to determine if it's a concentrated liquidity pool or not.

- For out of position LP positions, the Zerion API does not return both underlying assets of the LP pool. Instead, the zero asset is removed from the underlying assets array. To hack around this to get asset info for displaying token icon & symbol, the `fixOutOfRangeLpPosition` function looks at the claimables associated with the position and tries to find a matching symbol name from the LP Pool asset name. 

- LP positions can be returned from the backend in either the deposits or stakes array, so staked LP positions are displayed under the "stakes" section list header instead of the "pools" header.

- On the PositionSheet there can be multiple rows of the same token under the Rewards section (claimables) if there are positions in multiple pools that share a token. These could be grouped into one later, but would be slightly misleading as the user would have to go to each related pool to claim each part of the aggregated claimable.

- LP positions with more than two tokens are supported, such as Curve's USDC/USDT/DAI pool, but will need a separate PR to add an icon component for representing more than two tokens. 

## Screen recordings / screenshots

![IMG_0407](https://github.com/user-attachments/assets/602c11d6-65b2-4e58-9ff4-de8488031cdc)

## What to test
Check your own wallet or add a wallet to watch that has lots of defi positions, click through them and make sure they all look correct.
