### PR TITLE
Fix broken `scrollEnabled` check in ChangeWalletSheet

### DIFF
--- a/src/components/change-wallet/WalletList.tsx
+++ b/src/components/change-wallet/WalletList.tsx
@@ -1,24 +1,30 @@
 import lang from 'i18n-js';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import WalletTypes from '../../helpers/walletTypes';
 import { address } from '../../utils/abbreviations';
+import { Text } from '@/components/text';
 import Divider from '@/components/Divider';
 import { EmptyAssetList } from '../asset-list';
-import { Column } from '../layout';
+import { Centered, Column, Row } from '../layout';
 import AddressRow from './AddressRow';
 import WalletOption from './WalletOption';
 import { EthereumAddress } from '@rainbow-me/entities';
-import { useAccountSettings } from '@/hooks';
+import { useAccountSettings, useWalletsWithBalancesAndNames } from '@/hooks';
 import styled from '@/styled-thing';
 import { position } from '@/styles';
 import { EditWalletContextMenuActions } from '@/screens/ChangeWalletSheet';
-import { HARDWARE_WALLETS, useExperimentalFlag } from '@/config';
+import { getExperimetalFlag, HARDWARE_WALLETS, useExperimentalFlag } from '@/config';
 import { Inset, Stack } from '@/design-system';
 import { Network } from '@/chains/types';
+import { SheetTitle } from '../sheet';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { IS_ANDROID, IS_IOS } from '@/env';
+import { useTheme } from '@/theme';
+import { DEVICE_HEIGHT } from '@/utils/deviceUtils';
 
 const listTopPadding = 7.5;
 const rowHeight = 59;
@@ -40,8 +46,7 @@ const getItemLayout = (data: any, index: number) => {
 
 const keyExtractor = (item: any) => `${item.walletId}-${item?.id}`;
 
-// @ts-ignore
-const Container = styled.View({
+const Container = styled(View)({
   height: ({ height }: { height: number }) => height,
   marginTop: -2,
 });
@@ -59,7 +64,7 @@ const EmptyWalletList = styled(EmptyAssetList).attrs({
   paddingTop: listTopPadding,
 });
 
-const WalletFlatList = styled(FlatList).attrs(({ showDividers }: { showDividers: boolean }) => ({
+const WalletFlatList: FlatList = styled(FlatList).attrs(({ showDividers }: { showDividers: boolean }) => ({
   contentContainerStyle: {
     paddingBottom: showDividers ? 9.5 : 0,
     paddingTop: listTopPadding,
@@ -80,18 +85,71 @@ const WalletListDivider = styled(Divider).attrs(({ theme: { colors } }: any) => 
   marginTop: -1,
 });
 
+const EditButton = styled(ButtonPressAnimation).attrs(({ editMode }: { editMode: boolean }) => ({
+  scaleTo: 0.96,
+  wrapperStyle: {
+    width: editMode ? 70 : 58,
+  },
+  width: editMode ? 100 : 100,
+}))(
+  IS_IOS
+    ? {
+        position: 'absolute',
+        right: 20,
+        top: -11,
+      }
+    : {
+        elevation: 10,
+        position: 'relative',
+        right: 20,
+        top: 6,
+      }
+);
+
+const EditButtonLabel = styled(Text).attrs(({ theme: { colors }, editMode }: { theme: any; editMode: boolean }) => ({
+  align: 'right',
+  color: colors.appleBlue,
+  letterSpacing: 'roundedMedium',
+  size: 'large',
+  weight: editMode ? 'bold' : 'semibold',
+  numberOfLines: 1,
+  ellipsizeMode: 'tail',
+}))({
+  height: 40,
+});
+
+const FOOTER_HEIGHT = getExperimetalFlag(HARDWARE_WALLETS) ? 100 : 60;
+const LIST_PADDING_BOTTOM = 6;
+export const MAX_LIST_HEIGHT = DEVICE_HEIGHT - 220;
+const WALLET_ROW_HEIGHT = 59;
+const WATCH_ONLY_BOTTOM_PADDING = IS_ANDROID ? 20 : 0;
+
+const getWalletListHeight = (numWallets: number, watchOnly: boolean) => {
+  let listHeight = !watchOnly ? FOOTER_HEIGHT + LIST_PADDING_BOTTOM : WATCH_ONLY_BOTTOM_PADDING;
+
+  if (numWallets) {
+    for (let i = 0; i < numWallets; i++) {
+      listHeight += WALLET_ROW_HEIGHT + 6;
+
+      if (listHeight > MAX_LIST_HEIGHT) {
+        return MAX_LIST_HEIGHT;
+      }
+    }
+  }
+
+  return listHeight;
+};
+
 interface Props {
   accountAddress: EthereumAddress;
-  allWallets: any;
+  allWallets: ReturnType<typeof useWalletsWithBalancesAndNames>;
   contextMenuActions: EditWalletContextMenuActions;
   currentWallet: any;
   editMode: boolean;
-  height: number;
+  onPressEditMode: () => void;
   onChangeAccount: (walletId: string, address: EthereumAddress) => void;
   onPressAddAnotherWallet: () => void;
   onPressPairHardwareWallet: () => void;
-  scrollEnabled: boolean;
-  showDividers: boolean;
   watchOnly: boolean;
 }
 
@@ -101,12 +159,10 @@ export default function WalletList({
   contextMenuActions,
   currentWallet,
   editMode,
-  height,
+  onPressEditMode,
   onChangeAccount,
   onPressAddAnotherWallet,
   onPressPairHardwareWallet,
-  scrollEnabled,
-  showDividers,
   watchOnly,
 }: Props) {
   const [rows, setRows] = useState<any[]>([]);
@@ -116,6 +172,7 @@ export default function WalletList({
   const opacityAnimation = useSharedValue(0);
   const emptyOpacityAnimation = useSharedValue(1);
   const hardwareWalletsEnabled = useExperimentalFlag(HARDWARE_WALLETS);
+  const { colors } = useTheme();
 
   // Update the rows when allWallets changes
   useEffect(() => {
@@ -213,43 +270,60 @@ export default function WalletList({
     [contextMenuActions, editMode]
   );
 
+  const height = getWalletListHeight(rows.length, watchOnly);
+
   return (
     <Container height={height}>
-      <Animated.View style={[StyleSheet.absoluteFill, emptyOpacityStyle]}>
-        <EmptyWalletList />
-      </Animated.View>
+      <Column height={40} justify="space-between">
+        <Centered>
+          <SheetTitle testID="change-wallet-sheet-title">{lang.t('wallet.label')}</SheetTitle>
+
+          {!watchOnly && (
+            <Row style={{ position: 'absolute', right: 0 }}>
+              <EditButton editMode={editMode} onPress={onPressEditMode}>
+                <EditButtonLabel editMode={editMode}>{editMode ? lang.t('button.done') : lang.t('button.edit')}</EditButtonLabel>
+              </EditButton>
+            </Row>
+          )}
+        </Centered>
+        <Divider color={colors.rowDividerExtraLight} inset={[0, 15]} />
+      </Column>
       <WalletsContainer style={opacityStyle}>
         <WalletFlatList
           data={rows}
-          initialNumToRender={rows.length}
+          initialNumToRender={10}
           ref={scrollView}
+          scrollEnabled={height >= MAX_LIST_HEIGHT}
           renderItem={renderItem}
-          scrollEnabled={scrollEnabled}
-          showDividers={showDividers}
+          ListEmptyComponent={() => (
+            <Animated.View style={[StyleSheet.absoluteFill, emptyOpacityStyle]}>
+              <EmptyWalletList />
+            </Animated.View>
+          )}
         />
-        {showDividers && <WalletListDivider />}
-        {!watchOnly && (
-          <Inset space="20px">
-            <Stack space="24px">
+      </WalletsContainer>
+      <WalletListDivider />
+      {!watchOnly && (
+        <Inset space="20px">
+          <Stack space="24px">
+            <WalletOption
+              editMode={editMode}
+              label={`􀁍 ${lang.t('wallet.action.add_another')}`}
+              onPress={onPressAddAnotherWallet}
+              testID="add-another-wallet-button"
+            />
+
+            {hardwareWalletsEnabled && (
               <WalletOption
                 editMode={editMode}
-                label={`􀁍 ${lang.t('wallet.action.add_another')}`}
-                onPress={onPressAddAnotherWallet}
-                testID="add-another-wallet-button"
+                label={`􀱝 ${lang.t('wallet.action.pair_hardware_wallet')}`}
+                onPress={onPressPairHardwareWallet}
+                testID="pair-hardware-wallet-button"
               />
-
-              {hardwareWalletsEnabled && (
-                <WalletOption
-                  editMode={editMode}
-                  label={`􀱝 ${lang.t('wallet.action.pair_hardware_wallet')}`}
-                  onPress={onPressPairHardwareWallet}
-                  testID="pair-hardware-wallet-button"
-                />
-              )}
-            </Stack>
-          </Inset>
-        )}
-      </WalletsContainer>
+            )}
+          </Stack>
+        </Inset>
+      )}
     </Container>
   );
 }

--- a/src/design-system/components/DebugLayout/DebugLayout.tsx
+++ b/src/design-system/components/DebugLayout/DebugLayout.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { ReactNode, useState } from 'react';
+import { StyleSheet, View, Text } from 'react-native';
 
 const styles = StyleSheet.create({
   debug: {
@@ -10,10 +10,25 @@ const styles = StyleSheet.create({
   },
 });
 
-export function DebugLayout({ children }: { children: ReactNode }) {
+export function DebugLayout({ children, showDimensions = false }: { children: ReactNode; showDimensions?: boolean }) {
+  const [layout, setLayout] = useState<{ width: number; height: number } | null>(null);
+
   return (
     <View>
-      <View pointerEvents="none" style={styles.debug} />
+      {showDimensions && (
+        <View pointerEvents="none">
+          <Text>Height: {layout?.height}</Text>
+          <Text>Width: {layout?.width}</Text>
+        </View>
+      )}
+      <View
+        pointerEvents="none"
+        style={styles.debug}
+        onLayout={event => {
+          const { width, height } = event.nativeEvent.layout;
+          setLayout({ width, height });
+        }}
+      />
       {children}
     </View>
   );

--- a/src/screens/ChangeWalletSheet.tsx
+++ b/src/screens/ChangeWalletSheet.tsx
@@ -1,95 +1,25 @@
 import { useRoute } from '@react-navigation/native';
 import lang from 'i18n-js';
-import React, { useCallback, useMemo, useState } from 'react';
-import { Alert, InteractionManager, View } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { Alert, InteractionManager } from 'react-native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { useDispatch } from 'react-redux';
-import Divider from '@/components/Divider';
-import { ButtonPressAnimation } from '@/components/animations';
 import WalletList from '@/components/change-wallet/WalletList';
-import { Centered, Column, Row } from '../components/layout';
-import { Sheet, SheetTitle } from '../components/sheet';
-import { Text } from '../components/text';
+import { Sheet } from '../components/sheet';
 import { removeWalletData } from '../handlers/localstorage/removeWallet';
 import { cleanUpWalletKeys } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
 import { addressSetSelected, walletsSetSelected, walletsUpdate } from '../redux/wallets';
 import { analytics, analyticsV2 } from '@/analytics';
-import { getExperimetalFlag, HARDWARE_WALLETS } from '@/config';
 import { useAccountSettings, useInitializeWallet, useWallets, useWalletsWithBalancesAndNames, useWebData } from '@/hooks';
 import Routes from '@/navigation/routesNames';
-import styled from '@/styled-thing';
 import { doesWalletsContainAddress, showActionSheetWithOptions } from '@/utils';
 import { logger, RainbowError } from '@/logger';
 import { useTheme } from '@/theme';
 import { EthereumAddress } from '@/entities';
 import { getNotificationSettingsForWalletWithAddress } from '@/notifications/settings/storage';
-import { DEVICE_HEIGHT } from '@/utils/deviceUtils';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { remotePromoSheetsStore } from '@/state/remotePromoSheets/remotePromoSheets';
-
-const FOOTER_HEIGHT = getExperimetalFlag(HARDWARE_WALLETS) ? 100 : 60;
-const LIST_PADDING_BOTTOM = 6;
-const MAX_LIST_HEIGHT = DEVICE_HEIGHT - 220;
-const WALLET_ROW_HEIGHT = 59;
-const WATCH_ONLY_BOTTOM_PADDING = IS_ANDROID ? 20 : 0;
-
-const EditButton = styled(ButtonPressAnimation).attrs(({ editMode }: { editMode: boolean }) => ({
-  scaleTo: 0.96,
-  wrapperStyle: {
-    width: editMode ? 70 : 58,
-  },
-  width: editMode ? 100 : 100,
-}))(
-  IS_IOS
-    ? {
-        position: 'absolute',
-        right: 20,
-        top: -11,
-      }
-    : {
-        elevation: 10,
-        position: 'relative',
-        right: 20,
-        top: 6,
-      }
-);
-
-const EditButtonLabel = styled(Text).attrs(({ theme: { colors }, editMode }: { theme: any; editMode: boolean }) => ({
-  align: 'right',
-  color: colors.appleBlue,
-  letterSpacing: 'roundedMedium',
-  size: 'large',
-  weight: editMode ? 'bold' : 'semibold',
-  numberOfLines: 1,
-  ellipsizeMode: 'tail',
-}))({
-  height: 40,
-});
-
-const Whitespace = styled(View)({
-  backgroundColor: ({ theme: { colors } }: any) => colors.white,
-  bottom: -398,
-  height: 400,
-  position: 'absolute',
-  width: '100%',
-});
-
-const getWalletListHeight = (wallets: any, watchOnly: boolean) => {
-  let listHeight = !watchOnly ? FOOTER_HEIGHT + LIST_PADDING_BOTTOM : WATCH_ONLY_BOTTOM_PADDING;
-
-  if (wallets) {
-    for (const key of Object.keys(wallets)) {
-      const visibleAccounts = wallets[key].addresses.filter((account: any) => account.visible);
-      listHeight += visibleAccounts.length * WALLET_ROW_HEIGHT;
-
-      if (listHeight > MAX_LIST_HEIGHT) {
-        return { listHeight: MAX_LIST_HEIGHT, scrollEnabled: true };
-      }
-    }
-  }
-  return { listHeight, scrollEnabled: false };
-};
+import { DebugLayout } from '@/design-system';
 
 export type EditWalletContextMenuActions = {
   edit: (walletId: string, address: EthereumAddress) => void;
@@ -113,15 +43,6 @@ export default function ChangeWalletSheet() {
   const [editMode, setEditMode] = useState(false);
   const [currentAddress, setCurrentAddress] = useState(currentAccountAddress || accountAddress);
   const [currentSelectedWallet, setCurrentSelectedWallet] = useState(selectedWallet);
-
-  const [headerHeight, listHeight, scrollEnabled, showDividers] = useMemo(() => {
-    const { listHeight, scrollEnabled } = getWalletListHeight(wallets, watchOnly);
-
-    const headerHeight = scrollEnabled ? 40 : 30;
-    const showDividers = scrollEnabled;
-
-    return [headerHeight, listHeight, scrollEnabled, showDividers];
-  }, [wallets, watchOnly]);
 
   const onChangeAccount = useCallback(
     async (walletId: string, address: string, fromDeletion = false) => {
@@ -373,21 +294,6 @@ export default function ChangeWalletSheet() {
 
   return (
     <Sheet borderRadius={30}>
-      {IS_ANDROID && <Whitespace />}
-      <Column height={headerHeight} justify="space-between">
-        <Centered>
-          <SheetTitle testID="change-wallet-sheet-title">{lang.t('wallet.label')}</SheetTitle>
-
-          {!watchOnly && (
-            <Row style={{ position: 'absolute', right: 0 }}>
-              <EditButton editMode={editMode} onPress={onPressEditMode}>
-                <EditButtonLabel editMode={editMode}>{editMode ? lang.t('button.done') : lang.t('button.edit')}</EditButtonLabel>
-              </EditButton>
-            </Row>
-          )}
-        </Centered>
-        {showDividers && <Divider color={colors.rowDividerExtraLight} inset={[0, 15]} />}
-      </Column>
       <WalletList
         accountAddress={currentAddress}
         allWallets={walletsWithBalancesAndNames}
@@ -400,12 +306,10 @@ export default function ChangeWalletSheet() {
         }
         currentWallet={currentSelectedWallet}
         editMode={editMode}
-        height={listHeight}
+        onPressEditMode={onPressEditMode}
         onChangeAccount={onChangeAccount}
         onPressAddAnotherWallet={onPressAddAnotherWallet}
         onPressPairHardwareWallet={onPressPairHardwareWallet}
-        scrollEnabled={scrollEnabled}
-        showDividers={showDividers}
         watchOnly={watchOnly}
       />
     </Sheet>


### PR DESCRIPTION
Fixes APP-2039

## What changed (plus any additional context for devs)
There was a race condition happening in the flatlist that would calculate the list height before the entire list was rendered, this was preventing the user from scrolling on the wallet list.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/42cde1ef-74ae-4aad-a669-fd5f88c29af2

## What to test
Android – I loaded but didn't thoroughly test it.
OG thread: https://rainbowhaus.slack.com/archives/C02C2FVC6N6/p1732045158373479
