### PR TITLE
adds a couple more analytics events

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/analyticsTrackQuoteFailed.ts
+++ b/src/__swaps__/screens/Swap/hooks/analyticsTrackQuoteFailed.ts
@@ -1,0 +1,47 @@
+import { ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import { analyticsV2 } from '@/analytics';
+import { EventProperties } from '@/analytics/event';
+import { QuoteError } from '@rainbow-me/swaps';
+import { runOnJS } from 'react-native-reanimated';
+
+const analyticsTrack: typeof analyticsV2.track = (...args) => analyticsV2.track(...args);
+let lastParams: EventProperties[typeof analyticsV2.event.swapsQuoteFailed];
+export function analyticsTrackQuoteFailed(
+  quote: QuoteError | null,
+  {
+    inputAsset,
+    outputAsset,
+    inputAmount,
+    outputAmount,
+  }: {
+    inputAsset: ExtendedAnimatedAssetWithColors | null;
+    outputAsset: ExtendedAnimatedAssetWithColors | null;
+    inputAmount: number | undefined;
+    outputAmount: number | undefined;
+  }
+) {
+  'worklet';
+  // we are tracking 'Insufficient funds' 'Out of gas' 'No routes found' and 'No quotes found'
+  if (!quote || !inputAsset || !outputAsset || !inputAmount) return;
+
+  if (
+    lastParams &&
+    quote.error_code === lastParams.error_code &&
+    inputAmount === lastParams.inputAmount &&
+    outputAmount === lastParams.outputAmount &&
+    inputAsset.address === lastParams.inputAsset.address &&
+    outputAsset.address === lastParams.outputAsset.address
+  )
+    return;
+
+  const params = {
+    error_code: quote.error_code,
+    reason: quote.message,
+    inputAsset: { address: inputAsset.address, chainId: inputAsset.chainId, symbol: inputAsset.symbol },
+    outputAsset: { address: outputAsset.address, chainId: outputAsset.chainId, symbol: outputAsset.symbol },
+    inputAmount,
+    outputAmount,
+  };
+  lastParams = params;
+  runOnJS(analyticsTrack)(analyticsV2.event.swapsQuoteFailed, params);
+}

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -40,52 +40,9 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import { useDebouncedCallback } from 'use-debounce';
 import { NavigationSteps } from './useSwapNavigation';
 import { deepEqualWorklet } from '@/worklets/comparisons';
-
-import { EventProperties } from '@/analytics/event';
+import { analyticsTrackQuoteFailed } from './analyticsTrackQuoteFailed';
 
 const REMOTE_CONFIG = getRemoteConfig();
-
-const analyticsTrack: typeof analyticsV2.track = (...args) => analyticsV2.track(...args);
-let lastParams: EventProperties[typeof analyticsV2.event.swapsQuoteFailed];
-function analyticsTrackQuoteFailed(
-  quote: QuoteError | null,
-  {
-    inputAsset,
-    outputAsset,
-    inputAmount,
-    outputAmount,
-  }: {
-    inputAsset: ExtendedAnimatedAssetWithColors | null;
-    outputAsset: ExtendedAnimatedAssetWithColors | null;
-    inputAmount: number | undefined;
-    outputAmount: number | undefined;
-  }
-) {
-  'worklet';
-  // we are tracking 'Insufficient funds' 'Out of gas' 'No routes found' and 'No quotes found'
-  if (!quote || !inputAsset || !outputAsset || !inputAmount) return;
-
-  if (
-    lastParams &&
-    quote.error_code === lastParams.error_code &&
-    inputAmount === lastParams.inputAmount &&
-    outputAmount === lastParams.outputAmount &&
-    inputAsset.address === lastParams.inputAsset.address &&
-    outputAsset.address === lastParams.outputAsset.address
-  )
-    return;
-
-  const params = {
-    error_code: quote.error_code,
-    reason: quote.message,
-    inputAsset: { address: inputAsset.address, chainId: inputAsset.chainId, symbol: inputAsset.symbol },
-    outputAsset: { address: outputAsset.address, chainId: outputAsset.chainId, symbol: outputAsset.symbol },
-    inputAmount,
-    outputAmount,
-  };
-  lastParams = params;
-  runOnJS(analyticsTrack)(analyticsV2.event.swapsQuoteFailed, params);
-}
 
 export function useSwapInputsController({
   focusedInput,

--- a/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSwapInputsController.ts
@@ -48,20 +48,23 @@ const REMOTE_CONFIG = getRemoteConfig();
 const analyticsTrack: typeof analyticsV2.track = (...args) => analyticsV2.track(...args);
 let lastParams: EventProperties[typeof analyticsV2.event.swapsQuoteFailed];
 function analyticsTrackQuoteFailed(
-  quote: QuoteError,
+  quote: QuoteError | null,
   {
     inputAsset,
     outputAsset,
     inputAmount,
     outputAmount,
   }: {
-    inputAsset: ExtendedAnimatedAssetWithColors;
-    outputAsset: ExtendedAnimatedAssetWithColors;
+    inputAsset: ExtendedAnimatedAssetWithColors | null;
+    outputAsset: ExtendedAnimatedAssetWithColors | null;
     inputAmount: number | undefined;
     outputAmount: number | undefined;
   }
 ) {
   'worklet';
+  // we are tracking 'Insufficient funds' 'Out of gas' 'No routes found' and 'No quotes found'
+  if (!quote || !inputAsset || !outputAsset || !inputAmount) return;
+
   if (
     lastParams &&
     quote.error_code === lastParams.error_code &&
@@ -83,6 +86,7 @@ function analyticsTrackQuoteFailed(
   lastParams = params;
   runOnJS(analyticsTrack)(analyticsV2.event.swapsQuoteFailed, params);
 }
+
 export function useSwapInputsController({
   focusedInput,
   inputProgress,

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -137,34 +137,6 @@ interface SwapProviderProps {
   children: ReactNode;
 }
 
-let lastQuoteFailedEventParams: EventProperties[typeof analyticsV2.event.swapsQuoteFailed] | object = {};
-function trackQuoteFailed(
-  quote: QuoteError,
-  {
-    inputAsset,
-    outputAsset,
-    inputAmount,
-    outputAmount,
-  }: {
-    inputAsset: ExtendedAnimatedAssetWithColors;
-    outputAsset: ExtendedAnimatedAssetWithColors;
-    inputAmount: string | number;
-    outputAmount: string | number;
-  }
-) {
-  const params = {
-    error_code: quote.error_code,
-    reason: quote.message,
-    inputAsset: { address: inputAsset.address, chainId: inputAsset.chainId, symbol: inputAsset.symbol },
-    outputAsset: { address: outputAsset.address, chainId: outputAsset.chainId, symbol: outputAsset.symbol },
-    inputAmount,
-    outputAmount,
-  };
-  if (isEqual(params, lastQuoteFailedEventParams)) return;
-  analyticsV2.track(analyticsV2.event.swapsQuoteFailed, params);
-  lastQuoteFailedEventParams = params;
-}
-
 export const SwapProvider = ({ children }: SwapProviderProps) => {
   const { nativeCurrency } = useAccountSettings();
 
@@ -512,23 +484,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     isFetching,
     isQuoteStale,
   });
-
-  /** Failed Quote analytics */
-  useAnimatedReaction(
-    () => quote.value,
-    quote => {
-      const inputAsset = internalSelectedInputAsset.value;
-      const outputAsset = internalSelectedOutputAsset.value;
-      if (quote && 'error' in quote && inputAsset && outputAsset) {
-        runOnJS(trackQuoteFailed)(quote, {
-          inputAsset,
-          outputAsset,
-          inputAmount: SwapInputController.inputValues.value.inputAmount,
-          outputAmount: SwapInputController.inputValues.value.outputAmount,
-        });
-      }
-    }
-  );
 
   const AnimatedSwapStyles = useAnimatedSwapStyles({
     SwapWarning,

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -162,6 +162,10 @@ export const event = {
   // error boundary
   errorBoundary: 'error_boundary.viewed',
   errorBoundaryReset: 'error_boundary.reset',
+
+  // token details
+  tokenDetailsErc20: 'token_details.erc20',
+  tokenDetailsNFT: 'token_details.nft',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -650,4 +654,34 @@ export type EventProperties = {
 
   [event.errorBoundary]: { error: Error | null };
   [event.errorBoundaryReset]: { error: Error | null };
+
+  [event.tokenDetailsErc20]: {
+    token: {
+      address: string;
+      chainId: ChainId;
+      symbol: string;
+      name: string;
+      icon_url: string;
+      price: number;
+    };
+    eventSentAfterMs: number;
+    available_data: {
+      chart: boolean;
+      description: boolean;
+      iconUrl: boolean;
+    };
+  };
+  [event.tokenDetailsNFT]: {
+    token: {
+      isPoap: boolean;
+      isParty: boolean;
+      isENS: boolean;
+      address: string;
+      chainId: ChainId;
+      name: string;
+      image_url: string | null | undefined;
+    };
+    eventSentAfterMs: number;
+    available_data: { description: boolean; image_url: boolean; floorPrice: boolean };
+  };
 };

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -141,6 +141,7 @@ export const event = {
   swapsSubmitted: 'swaps.submitted',
   swapsFailed: 'swaps.failed',
   swapsSucceeded: 'swaps.succeeded',
+  swapsQuoteFailed: 'swaps.quote_failed',
 
   // app browser events
   browserTrendingDappClicked: 'browser.trending_dapp_pressed',
@@ -580,6 +581,15 @@ export type EventProperties = {
   [event.swapsSubmitted]: SwapEventParameters<'swap' | 'crosschainSwap'>;
   [event.swapsFailed]: SwapsEventFailedParameters<'swap' | 'crosschainSwap'>;
   [event.swapsSucceeded]: SwapsEventSucceededParameters<'swap' | 'crosschainSwap'>;
+
+  [event.swapsQuoteFailed]: {
+    error_code: number | undefined;
+    reason: string;
+    inputAsset: { symbol: string; address: string; chainId: ChainId };
+    inputAmount: string | number;
+    outputAsset: { symbol: string; address: string; chainId: ChainId };
+    outputAmount: string | number;
+  };
 
   [event.browserTrendingDappClicked]: {
     name: string;

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -158,6 +158,10 @@ export const event = {
   claimClaimableSucceeded: 'claim_claimable.succeeded',
   claimClaimableFailed: 'claim_claimable.failed',
   claimablePanelOpened: 'claimable_panel.opened',
+
+  // error boundary
+  errorBoundary: 'error_boundary.viewed',
+  errorBoundaryReset: 'error_boundary.reset',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -643,4 +647,7 @@ export type EventProperties = {
     amount: string;
     usdValue: number;
   };
+
+  [event.errorBoundary]: { error: Error | null };
+  [event.errorBoundaryReset]: { error: Error | null };
 };

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -586,7 +586,7 @@ export type EventProperties = {
     error_code: number | undefined;
     reason: string;
     inputAsset: { symbol: string; address: string; chainId: ChainId };
-    inputAmount: string | number | undefined;
+    inputAmount: string | number;
     outputAsset: { symbol: string; address: string; chainId: ChainId };
     outputAmount: string | number | undefined;
   };

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -586,9 +586,9 @@ export type EventProperties = {
     error_code: number | undefined;
     reason: string;
     inputAsset: { symbol: string; address: string; chainId: ChainId };
-    inputAmount: string | number;
+    inputAmount: string | number | undefined;
     outputAsset: { symbol: string; address: string; chainId: ChainId };
-    outputAmount: string | number;
+    outputAmount: string | number | undefined;
   };
 
   [event.browserTrendingDappClicked]: {

--- a/src/components/error-boundary/ErrorBoundary.tsx
+++ b/src/components/error-boundary/ErrorBoundary.tsx
@@ -3,14 +3,24 @@ import * as Sentry from '@sentry/react-native';
 import Fallback from './Fallback';
 import { IS_TEST } from '@/env';
 import { useTheme } from '@/theme';
+import { analyticsV2 } from '@/analytics';
 
 const NoErrorBoundary = ({ children }: { children: React.ReactNode }) => children;
+
+function onReset(error: Error | null) {
+  analyticsV2.track(analyticsV2.event.errorBoundaryReset, { error });
+}
+function onError(error: Error | null) {
+  analyticsV2.track(analyticsV2.event.errorBoundary, { error });
+}
 
 const ErrorBoundaryWithSentry = ({ children }: { children: React.ReactNode }) => {
   const { colors } = useTheme();
   return (
     <Sentry.ErrorBoundary
       beforeCapture={scope => scope.setTag('RainbowErrorBoundary', 'true')}
+      onError={onError}
+      onReset={onReset}
       fallback={props => <Fallback {...props} colors={colors} />}
     >
       {children}

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -24,7 +24,7 @@ export function useTimeoutEffect(onTimeout: (cancelled: boolean) => void, delay:
     callback.current = onTimeout;
   }, [onTimeout]);
 
-  const timeoutRef = useRef<Timer>();
+  const timeoutRef = useRef<NodeJS.Timeout>();
   useEffect(() => {
     const startedAt = Date.now();
     timeoutRef.current = setTimeout(() => callback.current(false), delay);

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
+import { MutableRefObject, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
 export default function useTimeout(): [(func: () => void, ms?: number) => void, () => void, MutableRefObject<NodeJS.Timeout | null>] {
   const handle = useRef<NodeJS.Timeout | null>(null);
@@ -16,4 +16,22 @@ export default function useTimeout(): [(func: () => void, ms?: number) => void, 
   useEffect(() => () => stop(), [stop]);
 
   return [start, stop, handle];
+}
+
+export function useTimeoutEffect(onTimeout: (cancelled: boolean) => void, delay: number) {
+  const callback = useRef(onTimeout);
+  useLayoutEffect(() => {
+    callback.current = onTimeout;
+  }, [onTimeout]);
+
+  const timeoutRef = useRef<Timer>();
+  useEffect(() => {
+    const startedAt = Date.now();
+    timeoutRef.current = setTimeout(() => callback.current(false), delay);
+    const timeout = timeoutRef.current;
+    return () => {
+      clearTimeout(timeout);
+      if (Date.now() - startedAt < delay) callback.current(true);
+    };
+  }, [delay]);
 }


### PR DESCRIPTION
Fixes APP-2068, APP-2066, APP-2064

## Adds analytics for

- viewing token details, erc20s and nfts
  - added a timeout to send the event 5s after the component is mounted
  - as a buffer to wait for all different sources to load, like chart, price, description etc
  - if the user closes the sheet before 5s it sends the event with the state it had at the time

- quote failed, sends `error_code`, `reason`, `inputAsset`, `outputAsset`, `inputAmount`, `outputAmount`

- Crash/something went wrong screen sends an event on error and on reset


## Screen recordings / screenshots


## What to test

