### PR TITLE
Fix useMMKVObject initial value

### DIFF
--- a/src/hooks/useCoinListEditOptions.ts
+++ b/src/hooks/useCoinListEditOptions.ts
@@ -15,12 +15,14 @@ export interface BooleanMap {
   [index: string]: boolean;
 }
 
+const INITIAL_PINNED_COINS: BooleanMap = {};
+
 export default function useCoinListEditOptions() {
   const { accountAddress } = useAccountSettings();
 
   const setSelectedItems = useSetRecoilState(selectedItemsAtom);
 
-  const [pinnedCoins = {}] = useMMKVObject<BooleanMap>('pinned-coins-obj-' + accountAddress);
+  const [pinnedCoins = INITIAL_PINNED_COINS] = useMMKVObject<BooleanMap>('pinned-coins-obj-' + accountAddress);
   const pushSelectedCoin = useCallback(
     (item: string) =>
       setSelectedItems(prev => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- The empty default object was being recreated every time this hook re-rendered, which then triggered additional updates due to `pinnedCoinsObj` changing

## Screen recordings / screenshots


## What to test

