### PR TITLE
[<< 1297] - Fix non-visible wallets from showing on backups breakdown

### DIFF
--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -220,8 +220,6 @@ export async function backupAllWalletsToCloud({
   try {
     /**
      * Loop over all keys and decrypt if necessary for android
-     * if no latest backup, create first backup with all secrets
-     * if latest backup, update updatedAt and add new secrets to the backup
      */
 
     const allKeys = await kc.getAllKeys();
@@ -251,8 +249,6 @@ export async function backupAllWalletsToCloud({
       label: cloudPlatform,
     });
 
-    let updatedBackupFile: string | null = null;
-
     const data = {
       createdAt: now,
       secrets: {},
@@ -267,7 +263,7 @@ export async function backupAllWalletsToCloud({
     });
 
     await Promise.all(promises);
-    updatedBackupFile = await encryptAndSaveDataToCloud(data, password, `backup_${now}.json`);
+    const updatedBackupFile = await encryptAndSaveDataToCloud(data, password, `backup_${now}.json`);
     const walletIdsToUpdate = Object.keys(wallets);
     await dispatch(setAllWalletsWithIdsAsBackedUp(walletIdsToUpdate, WalletBackupTypes.cloud, updatedBackupFile));
 

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -91,7 +91,7 @@ const SettingsSection = ({
 
   const onPressLearn = useCallback(() => Linking.openURL(SettingsExternalURLs.rainbowLearn), []);
 
-  const { allBackedUp, canBeBackedUp } = useMemo(() => checkLocalWalletsForBackupStatus(wallets, backups), [wallets, backups]);
+  const { allBackedUp } = useMemo(() => checkLocalWalletsForBackupStatus(wallets, backups), [wallets, backups]);
 
   const themeMenuConfig = useMemo(() => {
     return {
@@ -176,21 +176,19 @@ const SettingsSection = ({
   return (
     <MenuContainer testID="settings-menu-container" Footer={<AppVersionStamp />}>
       <Menu>
-        {canBeBackedUp && (
-          <MenuItem
-            hasRightArrow
-            leftComponent={<MenuItem.ImageIcon source={WalletsAndBackupIcon} />}
-            onPress={onPressBackup}
-            rightComponent={
-              <Box paddingBottom="2px" paddingRight="8px">
-                <MenuItem.ImageIcon size={44} source={getWalletsAndBackupAlertIcon()} />
-              </Box>
-            }
-            size={60}
-            testID={'backup-section'}
-            titleComponent={<MenuItem.Title text={lang.t(lang.l.settings.backup)} />}
-          />
-        )}
+        <MenuItem
+          hasRightArrow
+          leftComponent={<MenuItem.ImageIcon source={WalletsAndBackupIcon} />}
+          onPress={onPressBackup}
+          rightComponent={
+            <Box paddingBottom="2px" paddingRight="8px">
+              <MenuItem.ImageIcon size={44} source={getWalletsAndBackupAlertIcon()} />
+            </Box>
+          }
+          size={60}
+          testID={'backup-section'}
+          titleComponent={<MenuItem.Title text={lang.t(lang.l.settings.backup)} />}
+        />
         {isNotificationsEnabled && (
           <MenuItem
             hasRightArrow

--- a/src/screens/SettingsSheet/useVisibleWallets.ts
+++ b/src/screens/SettingsSheet/useVisibleWallets.ts
@@ -51,6 +51,7 @@ export const useVisibleWallets = ({ wallets, walletTypeCount }: UseVisibleWallet
       return {
         ...wallet,
         name: getTitleForWalletType(wallet.type, walletTypeCount),
+        addresses: Object.values(wallet.addresses).filter(address => address.visible),
       };
     });
 };


### PR DESCRIPTION
Fixes APP-2116

## What changed (plus any additional context for devs)
We weren't filtering out the wallets based on the `visible` criteria before sorting them and showing them.

## Screen recordings / screenshots
n/a

## What to test

