### PR TITLE
revert third party positions enabled

### DIFF
--- a/src/resources/defi/PositionsQuery.ts
+++ b/src/resources/defi/PositionsQuery.ts
@@ -21,7 +21,7 @@ const getPositions = async (address: string, currency: NativeCurrencyKey): Promi
     method: 'get',
     params: {
       currency,
-      enableThirdParty: 'true',
+      enableThirdParty: 'false',
     },
     headers: {
       Authorization: `Bearer ${ADDYS_API_KEY}`,


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- revert change that enabled third party positions on PositionsQuery
