### PR TITLE
Enable third party defi positions & fix token list exclusion logic

### DIFF
--- a/src/resources/defi/PositionsQuery.ts
+++ b/src/resources/defi/PositionsQuery.ts
@@ -21,7 +21,7 @@ const getPositions = async (address: string, currency: NativeCurrencyKey): Promi
     method: 'get',
     params: {
       currency,
-      enableThirdParty: 'false',
+      enableThirdParty: 'true',
     },
     headers: {
       Authorization: `Bearer ${ADDYS_API_KEY}`,

--- a/src/resources/defi/utils.ts
+++ b/src/resources/defi/utils.ts
@@ -392,18 +392,15 @@ export function parsePositions(data: AddysPositionsResponse, currency: NativeCur
 
   const positions = Object.values(versionAgnosticPositions);
 
-  const positionTokens: string[] = [];
+  // these are tokens that would be represented twice if shown in the token list, such as a Sushiswap LP token
+  const tokensToExcludeFromTokenList: string[] = [];
 
-  positions.forEach(({ deposits, stakes }) => {
+  positions.forEach(({ deposits }) => {
     deposits.forEach(({ asset }) => {
-      const uniqueId = ethereumUtils.getUniqueId(asset.asset_code.toLowerCase(), chainsIdByName[asset.network]);
-      positionTokens.push(uniqueId);
-    });
-    stakes.forEach(({ underlying }) => {
-      underlying.forEach(({ asset }) => {
+      if (asset.defi_position) {
         const uniqueId = ethereumUtils.getUniqueId(asset.asset_code.toLowerCase(), chainsIdByName[asset.network]);
-        positionTokens.push(uniqueId);
-      });
+        tokensToExcludeFromTokenList.push(uniqueId);
+      }
     });
   });
 
@@ -425,6 +422,6 @@ export function parsePositions(data: AddysPositionsResponse, currency: NativeCur
       ...positionsTotals,
     },
     positions,
-    positionTokens,
+    positionTokens: tokensToExcludeFromTokenList,
   };
 }

--- a/src/screens/positions/LpPositionListItem.tsx
+++ b/src/screens/positions/LpPositionListItem.tsx
@@ -41,6 +41,10 @@ export const LpPositionListItem: React.FC<Props> = ({ assets, totalAssetsValue, 
   const rangeStatus = getRangeStatus(assets, isConcentratedLiquidity);
 
   const assetAllocations = assets.map(asset => {
+    // if both assets value are 0 value, return 1 for asset with non-zero quantity
+    if (totalAssetsValue === '0') {
+      return asset.quantity === '0' ? 0 : 1;
+    }
     return parseFloat(divide(asset.native.amount, totalAssetsValue));
   });
 
@@ -136,10 +140,12 @@ export const LpPositionListItem: React.FC<Props> = ({ assets, totalAssetsValue, 
                     </Text>
                   </Box>
                   <LpRangeBadge
-                    assets={assets.map((underlying, index) => ({
-                      color: underlying.asset.colors?.primary ?? underlying.asset.colors?.fallback ?? colors.black,
-                      allocationPercentage: assetAllocations[index],
-                    }))}
+                    assets={assets
+                      .filter(asset => asset.quantity !== '0')
+                      .map((underlying, index) => ({
+                        color: underlying.asset.colors?.primary ?? underlying.asset.colors?.fallback ?? colors.black,
+                        allocationPercentage: assetAllocations[index],
+                      }))}
                   />
                 </Inline>
               </Column>


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- re-enables third party positions
- removes staked deposits from token list exclusion
- only adds deposit to exclusion list if asset.defi_position is true
- fix NaN% for LP pools where total assets value is 0. 

## Screenshots
Before
<img width="310" alt="Screenshot 2024-12-05 at 2 51 55 PM" src="https://github.com/user-attachments/assets/97b710f6-fe3e-4d1a-90db-ea20d2fa6e3d">

After
![IMG_0416](https://github.com/user-attachments/assets/25b84bb3-9030-4488-a39f-1df74ef4f07b)


## How to Test
- if you have defi positions in your wallet, ensure if you have a token deposited in one of those positions and also have that token in your wallet that it is not missing in the main token list. If you don't a wallet with defi positions, grunt.eth is a good one.
- Check any pool positions such as Uniswap for incorrect asset allocation percentages. grunt.eth has a uniswap position that originally surfaced the bug related to both assets in the pool being worth 0. 
