### PR TITLE
fix: bump positions query cache persist version

### DIFF
--- a/src/resources/defi/PositionsQuery.ts
+++ b/src/resources/defi/PositionsQuery.ts
@@ -42,7 +42,7 @@ const getPositions = async (address: string, currency: NativeCurrencyKey): Promi
 export const POSITIONS_QUERY_KEY = 'positions';
 
 export const positionsQueryKey = ({ address, currency }: PositionsArgs) =>
-  createQueryKey(POSITIONS_QUERY_KEY, { address, currency }, { persisterVersion: 2 });
+  createQueryKey(POSITIONS_QUERY_KEY, { address, currency }, { persisterVersion: 3 });
 
 type PositionsQueryKey = ReturnType<typeof positionsQueryKey>;
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- one line, bumps persist version for positions query. Otherwise, app will crash when serving stale query that does not have new parser that guarantees non-null array fields.