### PR TITLE
update README and fix various text issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 🤖 [Android available on the Google Play Store](https://play.google.com/store/apps/details?id=me.rainbow&utm_campaign=gh&utm_source=referral&utm_medium=gh)
 
-💻 [Browser extension available on](https://rainbow.me/download?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Chrome](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Brave](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Edge](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh), [FireFox](https://addons.mozilla.org/en-US/firefox/addon/rainbow-extension/?utm_campaign=gh&utm_source=referral&utm_medium=gh), and [Arc](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh).
+💻 [Browser extension available for](https://rainbow.me/download?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Chrome](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Brave](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Edge](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/rainbow-extension/?utm_campaign=gh&utm_source=referral&utm_medium=gh), and [Arc](https://chrome.google.com/webstore/detail/rainbow/opfgelmcmbiajamepnmloijbpoleiama?utm_campaign=gh&utm_source=referral&utm_medium=gh).
 
 🐦️ [Follow us on Twitter](https://twitter.com/rainbowdotme)
 
@@ -21,7 +21,7 @@
 
 ### MacOS
 
-1. Install the [latest version of XCode](https://developer.apple.com/xcode/).
+1. Install the [latest version of Xcode](https://developer.apple.com/xcode/).
 
 2. Install Watchman:
 
@@ -74,10 +74,10 @@ https://reactnative.dev/docs/getting-started
 
    - Etherscan: https://etherscan.io/apis
    - Infura: https://infura.io/
-   - ETH Gas Station: https://docs.ethgasstation.info/
+   - Etherscan Gas Tracker: https://etherscan.io/gastracker
    - Imgix: https://www.imgix.com/
 
-3. Ensure a `google-services.json` has been added to the relevant project
+3. Ensure a Google Services JSON file has been added to the relevant project
    directory/directories so the compile will not fail.
 
    This can either be the live Google Services config (for internal development)
@@ -87,7 +87,7 @@ https://reactnative.dev/docs/getting-started
 ### MacOS
 
 _Note: Darwin versions of the application can only be developed/built on Darwin
-platforms with XCode._
+platforms with Xcode._
 
 1. Start a React Native webserver with:
 
@@ -95,7 +95,7 @@ platforms with XCode._
    yarn start
    ```
 
-2. Open `rainbow-wallet/ios/Rainbow.xcworkspace` in XCode.
+2. Open `rainbow-wallet/ios/Rainbow.xcworkspace` in Xcode.
 
 3. Run the project by clicking the play button.
 

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -19,7 +19,6 @@
     "GHSA-78xj-cgh5-2h22", // https://github.com/advisories/GHSA-78xj-cgh5-2h22
     "GHSA-2p57-rm9w-gvfp", // https://github.com/advisories/GHSA-2p57-rm9w-gvfp
     "GHSA-3h5v-q93c-6h6q", // https://github.com/advisories/GHSA-3h5v-q93c-6h6q
-    "GHSA-2p57-rm9w-gvfp", // https://github.com/advisories/GHSA-2p57-rm9w-gvfp
-    "GHSA-x3m3-4wpv-5vgc", // https://github.com/advisories/GHSA-x3m3-4wpv-5vgc
-  ],
+    "GHSA-x3m3-4wpv-5vgc" // https://github.com/advisories/GHSA-x3m3-4wpv-5vgc
+  ]
 }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -2196,7 +2196,7 @@
         },
         "repay": {
           "pending": "Repaying",
-          "confirmed": "Repayed",
+          "confirmed": "Repaid",
           "failed": "Repay Failed"
         },
         "stake": {


### PR DESCRIPTION
README.md:
-In the line with browser extensions, "available on" was changed to "available for"
- The spelling of "Firefox" was corrected (it was "FireFox") 
-In the API keys section, "ETH Gas Station" was replaced with "Etherscan Gas Tracker" 
-Updated link to "Etherscan Gas Tracker" as "ETH Gas Station" no longer works "As of July 1st, 2023 we have officially retired Eth Gas Station."

audit-ci.jsonc:
-Remove duplicate entries and fix trailing commas in allowlist

src/languages/en_US.json:
-correct spelling of 'Repayed' to 'Repaid'