### PR TITLE
Update default currentNonce value to -1 (use case: fresh wallet or freshly imported wallet)

### DIFF
--- a/src/state/nonces/index.ts
+++ b/src/state/nonces/index.ts
@@ -21,7 +21,7 @@ type UpdateNonceArgs = NonceData & GetNonceArgs;
 export async function getNextNonce({ address, chainId }: { address: string; chainId: ChainId }): Promise<number> {
   const { getNonce } = nonceStore.getState();
   const localNonceData = getNonce({ address, chainId });
-  const localNonce = localNonceData?.currentNonce || 0;
+  const localNonce = localNonceData?.currentNonce || -1;
   const provider = getBatchedProvider({ chainId });
   const privateMempoolTimeout = chainsPrivateMempoolTimeout[chainId];
 

--- a/src/state/pendingTransactions/index.ts
+++ b/src/state/pendingTransactions/index.ts
@@ -84,7 +84,7 @@ export const addNewTransaction = ({
   const parsedTransaction = convertNewTransactionToRainbowTransaction(transaction);
   addPendingTransaction({ address, pendingTransaction: parsedTransaction });
   const localNonceData = getNonce({ address, chainId });
-  const localNonce = localNonceData?.currentNonce || 0;
+  const localNonce = localNonceData?.currentNonce || -1;
   if (transaction.nonce > localNonce) {
     setNonce({
       address,


### PR DESCRIPTION
This change sets the default "currentNonce" to -1 to distinguish between an actual current nonce of 0 vs an unknown current nonce (e.g, for a fresh wallet we just created that has no outgoing txns, or a freshly imported wallet that we hadn't previously tracked.) 

This helps us treat nonces vs txn counts accurately.