### PR TITLE
Replace node ack retries with a small delay

### DIFF
--- a/src/raps/execute.ts
+++ b/src/raps/execute.ts
@@ -111,30 +111,7 @@ function getRapFullName<T extends RapActionTypes>(actions: RapAction<T>[]) {
 
 const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
 
-const NODE_ACK_MAX_TRIES = 10;
-
-const waitForNodeAck = async (hash: string, provider: Signer['provider'], tries = 0): Promise<void> => {
-  try {
-    const tx = await provider?.getTransaction(hash);
-
-    // This means the node is aware of the tx, we're good to go
-    if ((tx && tx.blockNumber === null) || (tx && tx?.blockNumber && tx?.blockNumber > 0)) {
-      return;
-    }
-
-    // Wait for 1 second and try again
-    if (tries < NODE_ACK_MAX_TRIES) {
-      await delay(1000);
-      return waitForNodeAck(hash, provider, tries + 1);
-    }
-  } catch (e) {
-    // Wait for 1 second and try again
-    if (tries < NODE_ACK_MAX_TRIES) {
-      await delay(1000);
-      return waitForNodeAck(hash, provider, tries + 1);
-    }
-  }
-};
+const NODE_ACK_DELAY = 500;
 
 export const walletExecuteRap = async (
   wallet: Signer,
@@ -173,12 +150,13 @@ export const walletExecuteRap = async (
     };
 
     const { baseNonce, errorMessage: error, hash: firstHash } = await executeAction(actionParams);
-    const shouldWaitForNodeAck = parameters.chainId !== ChainId.mainnet;
+    const shouldDelayForNodeAck = parameters.chainId !== ChainId.mainnet;
 
     if (typeof baseNonce === 'number') {
       let latestHash = firstHash;
       for (let index = 1; index < actions.length; index++) {
-        latestHash && shouldWaitForNodeAck && (await waitForNodeAck(latestHash, wallet.provider));
+        latestHash && shouldDelayForNodeAck && (await delay(NODE_ACK_DELAY));
+
         const action = actions[index];
         const actionParams = {
           action,


### PR DESCRIPTION
Fixes APP-2110

## What changed (plus any additional context for devs)
Replace the recurring retry logic with a small delay for node ack for L2s.

## Screen recordings / screenshots
Ibrahim has tested and confirmed no issues on L2s.
