### PR TITLE
Retrieve FID for wallet addresses

### DIFF
--- a/src/hooks/useFarcasterAccountForWallets.ts
+++ b/src/hooks/useFarcasterAccountForWallets.ts
@@ -7,8 +7,14 @@ import useAccountSettings from './useAccountSettings';
 import store from '@/redux/store';
 import { isEmpty } from 'lodash';
 import walletTypes from '@/helpers/walletTypes';
+import { isLowerCaseMatch } from '@/utils';
+import { AllRainbowWallets } from '@/model/wallet';
 
 type SummaryData = ReturnType<typeof useAddysSummary>['data'];
+
+const getWalletForAddress = (wallets: AllRainbowWallets, address: string) => {
+  return Object.values(wallets || {}).find(wallet => wallet.addresses.some(addr => isLowerCaseMatch(addr.address, address)));
+};
 
 export const useFarcasterWalletAddress = () => {
   const [farcasterWalletAddress, setFarcasterWalletAddress] = useState<string | null>(null);
@@ -33,22 +39,28 @@ export const useFarcasterWalletAddress = () => {
     }
 
     const selectedAddressFid = summaryData?.data.addresses[accountAddress as Address]?.meta?.farcaster?.fid;
-    if (selectedAddressFid && (wallets || {})[accountAddress]?.type !== walletTypes.readOnly) {
+
+    if (selectedAddressFid && getWalletForAddress(wallets || {}, accountAddress)?.type !== walletTypes.readOnly) {
       setFarcasterWalletAddress(accountAddress);
+      return;
     }
 
     const farcasterWalletAddress = Object.keys(summaryData?.data.addresses || {}).find(addr => {
       const address = addr as Address;
       const faracsterId = summaryData?.data.addresses[address]?.meta?.farcaster?.fid;
-      if (faracsterId && (wallets || {})[address]?.type !== walletTypes.readOnly) {
+      if (faracsterId && getWalletForAddress(wallets || {}, address)?.type !== walletTypes.readOnly) {
         return faracsterId;
       }
     });
 
     if (farcasterWalletAddress) {
       setFarcasterWalletAddress(farcasterWalletAddress);
+      return;
     }
+    setFarcasterWalletAddress(null);
   }, [wallets, allAddresses, accountAddress]);
+
+  console.log('farcasterWalletAddress', farcasterWalletAddress);
 
   return farcasterWalletAddress;
 };

--- a/src/hooks/useFarcasterAccountForWallets.ts
+++ b/src/hooks/useFarcasterAccountForWallets.ts
@@ -60,7 +60,6 @@ export const useFarcasterWalletAddress = () => {
     setFarcasterWalletAddress(null);
   }, [wallets, allAddresses, accountAddress]);
 
-  console.log('farcasterWalletAddress', farcasterWalletAddress);
 
   return farcasterWalletAddress;
 };

--- a/src/hooks/useFarcasterAccountForWallets.ts
+++ b/src/hooks/useFarcasterAccountForWallets.ts
@@ -60,6 +60,5 @@ export const useFarcasterWalletAddress = () => {
     setFarcasterWalletAddress(null);
   }, [wallets, allAddresses, accountAddress]);
 
-
   return farcasterWalletAddress;
 };

--- a/src/hooks/useFarcasterAccountForWallets.ts
+++ b/src/hooks/useFarcasterAccountForWallets.ts
@@ -1,0 +1,54 @@
+import { queryClient } from '@/react-query';
+import useWallets from './useWallets';
+import { useEffect, useMemo, useState } from 'react';
+import { addysSummaryQueryKey, useAddysSummary } from '@/resources/summary/summary';
+import { Address } from 'viem';
+import useAccountSettings from './useAccountSettings';
+import store from '@/redux/store';
+import { isEmpty } from 'lodash';
+import walletTypes from '@/helpers/walletTypes';
+
+type SummaryData = ReturnType<typeof useAddysSummary>['data'];
+
+export const useFarcasterWalletAddress = () => {
+  const [farcasterWalletAddress, setFarcasterWalletAddress] = useState<string | null>(null);
+  const { accountAddress } = useAccountSettings();
+  const { wallets } = useWallets();
+
+  const allAddresses = useMemo(
+    () => Object.values(wallets || {}).flatMap(wallet => (wallet.addresses || []).map(account => account.address as Address)),
+    [wallets]
+  );
+
+  useEffect(() => {
+    const summaryData = queryClient.getQueryData<SummaryData>(
+      addysSummaryQueryKey({
+        addresses: allAddresses,
+        currency: store.getState().settings.nativeCurrency,
+      })
+    );
+    if (isEmpty(summaryData?.data.addresses) || isEmpty(wallets)) {
+      setFarcasterWalletAddress(null);
+      return;
+    }
+
+    const selectedAddressFid = summaryData?.data.addresses[accountAddress as Address]?.meta?.farcaster?.fid;
+    if (selectedAddressFid && (wallets || {})[accountAddress]?.type !== walletTypes.readOnly) {
+      setFarcasterWalletAddress(accountAddress);
+    }
+
+    const farcasterWalletAddress = Object.keys(summaryData?.data.addresses || {}).find(addr => {
+      const address = addr as Address;
+      const faracsterId = summaryData?.data.addresses[address]?.meta?.farcaster?.fid;
+      if (faracsterId && (wallets || {})[address]?.type !== walletTypes.readOnly) {
+        return faracsterId;
+      }
+    });
+
+    if (farcasterWalletAddress) {
+      setFarcasterWalletAddress(farcasterWalletAddress);
+    }
+  }, [wallets, allAddresses, accountAddress]);
+
+  return farcasterWalletAddress;
+};

--- a/src/hooks/useWalletBalances.ts
+++ b/src/hooks/useWalletBalances.ts
@@ -6,7 +6,7 @@ import { useAddysSummary } from '@/resources/summary/summary';
 import { useQueries } from '@tanstack/react-query';
 import { fetchPositions, positionsQueryKey } from '@/resources/defi/PositionsQuery';
 import { RainbowPositions } from '@/resources/defi/types';
-import { add, convertAmountToNativeDisplay, subtract } from '@/helpers/utilities';
+import { add, convertAmountToNativeDisplay } from '@/helpers/utilities';
 import { queryClient } from '@/react-query';
 
 const QUERY_CONFIG = {

--- a/src/hooks/useWalletsHiddenBalances.ts
+++ b/src/hooks/useWalletsHiddenBalances.ts
@@ -7,7 +7,7 @@ import { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import { userAssetsStore } from '@/state/assets/userAssets';
 import { queryClient } from '@/react-query';
 import { userAssetsQueryKey, UserAssetsResult } from '@/resources/assets/UserAssetsQuery';
-import { convertAmountAndPriceToNativeDisplay, add, isEqual, multiply } from '@/helpers/utilities';
+import { add, isEqual, multiply } from '@/helpers/utilities';
 import { isEqual as _isEqual } from 'lodash';
 
 export type WalletBalanceResult = {

--- a/src/resources/summary/summary.ts
+++ b/src/resources/summary/summary.ts
@@ -16,6 +16,30 @@ interface AddysSummary {
   data: {
     addresses: {
       [key: Address]: {
+        meta: {
+          farcaster?: {
+            object: string;
+            fid: number;
+            username: string;
+            display_name: string;
+            pfp_url: string;
+            custody_address: string;
+            profile: {
+              Bio: {
+                text: string;
+              };
+            };
+            follower_count: number;
+            following_count: number;
+            verifications: string[];
+            verified_addresses: {
+              eth_addresses: string[];
+              sol_addresses: string[];
+            };
+            verified_accounts: string[];
+            power_badge: boolean;
+          };
+        };
         summary: {
           native_balance_by_symbol: {
             [key in 'ETH' | 'MATIC' | 'BNB' | 'AVAX']: {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
This hook retrieves the farcaster id for the first found non-watched wallet for personalization

## Screen recordings / screenshots
#### is not watched wallet
<img width="1038" alt="Screenshot 2024-12-12 at 3 35 50 PM" src="https://github.com/user-attachments/assets/7cefa057-01e4-414c-af09-444ebd3400fa" />
<img width="1038" alt="Screenshot 2024-12-12 at 3 35 39 PM" src="https://github.com/user-attachments/assets/e516f44f-31e6-4498-82e7-ad6d7e44262b" />

#### is watched wallet (should be `null`)
<img width="1038" alt="Screenshot 2024-12-12 at 3 34 48 PM" src="https://github.com/user-attachments/assets/04e40acc-6f08-4e8e-ac73-4c0d959eeeca" />
<img width="1038" alt="Screenshot 2024-12-12 at 3 34 36 PM" src="https://github.com/user-attachments/assets/c898ca55-e63f-4c8d-8b9e-db75afc20c51" />


## What to test
will write some unit tests for this momentarily
