### PR TITLE
Support only persisting when search query is undefined (the default lists)

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -321,7 +321,7 @@ export function useSearchCurrencyLists() {
   const { data: verifiedAssets, isLoading: isLoadingVerifiedAssets } = useTokenSearch(
     {
       list: 'verifiedAssets',
-      chainId: isAddress(query) ? state.toChainId : undefined,
+      chainId: state.toChainId,
       keys: isAddress(query) ? ['address'] : ['name', 'symbol'],
       threshold: isAddress(query) ? 'CASE_SENSITIVE_EQUAL' : 'CONTAINS',
       query: query.length > 0 ? query : undefined,
@@ -417,7 +417,7 @@ export function useSearchCurrencyLists() {
     {
       enabled: memoizedData.enableUnverifiedSearch,
       select: (data: TokenSearchResult) => {
-        return getExactMatches(data, query).slice(0, MAX_UNVERIFIED_RESULTS);
+        return isAddress(query) ? getExactMatches(data, query).slice(0, MAX_UNVERIFIED_RESULTS) : data.slice(0, MAX_UNVERIFIED_RESULTS);
       },
     }
   );

--- a/src/__swaps__/screens/Swap/resources/search/discovery.ts
+++ b/src/__swaps__/screens/Swap/resources/search/discovery.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { parseTokenSearch } from './utils';
 
 const tokenSearchHttp = new RainbowFetchClient({
-  baseURL: 'https://token-search.rainbow.me/v3/discovery',
+  baseURL: 'https://token-search.rainbow.me/v3/trending/swaps',
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json',

--- a/src/__swaps__/screens/Swap/resources/search/search.ts
+++ b/src/__swaps__/screens/Swap/resources/search/search.ts
@@ -30,13 +30,19 @@ export type TokenSearchArgs = {
   list: TokenSearchListId;
   threshold?: TokenSearchThreshold;
   query?: string;
+  shouldPersist?: boolean;
 };
 
 // ///////////////////////////////////////////////
 // Query Key
 
-const tokenSearchQueryKey = ({ chainId, fromChainId, keys, list, threshold, query }: TokenSearchArgs) =>
-  createQueryKey('TokenSearch', { chainId, fromChainId, keys, list, threshold, query }, { persisterVersion: 2 });
+const tokenSearchQueryKey = ({ chainId, fromChainId, keys, list, threshold, query, shouldPersist }: TokenSearchArgs) => {
+  return createQueryKey(
+    'TokenSearch',
+    { chainId, fromChainId, keys, list, threshold, query },
+    { persisterVersion: shouldPersist ? 3 : undefined }
+  );
+};
 
 type TokenSearchQueryKey = ReturnType<typeof tokenSearchQueryKey>;
 
@@ -104,8 +110,9 @@ export async function fetchTokenSearch(
   { chainId, fromChainId, keys, list, threshold, query }: TokenSearchArgs,
   config: QueryConfigWithSelect<TokenSearchResult, Error, TokenSearchResult, TokenSearchQueryKey> = {}
 ) {
+  const shouldPersist = query === undefined;
   return await queryClient.fetchQuery(
-    tokenSearchQueryKey({ chainId, fromChainId, keys, list, threshold, query }),
+    tokenSearchQueryKey({ chainId, fromChainId, keys, list, threshold, query, shouldPersist }),
     tokenSearchQueryFunction,
     config
   );
@@ -130,7 +137,8 @@ export function useTokenSearch(
   { chainId, fromChainId, keys, list, threshold, query }: TokenSearchArgs,
   config: QueryConfigWithSelect<TokenSearchResult, Error, TokenSearchResult, TokenSearchQueryKey> = {}
 ) {
-  return useQuery(tokenSearchQueryKey({ chainId, fromChainId, keys, list, threshold, query }), tokenSearchQueryFunction, {
+  const shouldPersist = query === undefined;
+  return useQuery(tokenSearchQueryKey({ chainId, fromChainId, keys, list, threshold, query, shouldPersist }), tokenSearchQueryFunction, {
     ...config,
     keepPreviousData: true,
   });

--- a/src/__swaps__/screens/Swap/resources/search/search.ts
+++ b/src/__swaps__/screens/Swap/resources/search/search.ts
@@ -12,7 +12,7 @@ import { parseTokenSearch } from './utils';
 const ALL_VERIFIED_TOKENS_PARAM = '/?list=verifiedAssets';
 
 const tokenSearchHttp = new RainbowFetchClient({
-  baseURL: 'https://token-search.rainbow.me/v2',
+  baseURL: 'https://token-search.rainbow.me/v3/tokens',
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
@@ -83,6 +83,7 @@ async function tokenSearchQueryFunction({
         return parseTokenSearch(tokenSearch.data.data, chainId);
       }
 
+      // search for address on other chains
       const allVerifiedTokens = await tokenSearchHttp.get<{ data: SearchAsset[] }>(ALL_VERIFIED_TOKENS_PARAM);
 
       const addressQuery = query.trim().toLowerCase();


### PR DESCRIPTION
Fixes APP-2163

## What changed (plus any additional context for devs)
* We DO want to persist the initial result list (per network)
* We don't want to persist the results of search when you type something

## Screen recordings / screenshots
* After loading the default lists for a network, killing the app and coming back to search should still show default lists

https://github.com/user-attachments/assets/8bdb5dc2-095a-4d5f-bab2-edc9bb1aed37

* After typing in a search query, closing swap (not killing the app) and searching for the same query should be quick

https://github.com/user-attachments/assets/b308505f-5486-4639-8faf-0d55ea6d4c8c



## What to test
* Testing situations below can happen after installing the TF after having prod version installed (no need to delete the app in between)
* After loading the default lists for a network, killing the app and coming back to search should still show default lists
* After typing in a search query, closing swap (not killing the app) and searching for the same query should be quick
* After typing in a search query, killing the app, it should still load and search the results (but not preloaded from local cache; this might be difficult to see; you may see a little spot where it goes empty and then fills with data)
