### PR TITLE
Update swaps search endpoint from v2 to v3

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -417,7 +417,7 @@ export function useSearchCurrencyLists() {
     {
       enabled: memoizedData.enableUnverifiedSearch,
       select: (data: TokenSearchResult) => {
-        return getExactMatches(data, query).slice(0, MAX_UNVERIFIED_RESULTS);
+        return isAddress(query) ? getExactMatches(data, query).slice(0, MAX_UNVERIFIED_RESULTS) : data.slice(0, MAX_UNVERIFIED_RESULTS);
       },
     }
   );

--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -321,7 +321,7 @@ export function useSearchCurrencyLists() {
   const { data: verifiedAssets, isLoading: isLoadingVerifiedAssets } = useTokenSearch(
     {
       list: 'verifiedAssets',
-      chainId: isAddress(query) ? state.toChainId : undefined,
+      chainId: state.toChainId,
       keys: isAddress(query) ? ['address'] : ['name', 'symbol'],
       threshold: isAddress(query) ? 'CASE_SENSITIVE_EQUAL' : 'CONTAINS',
       query: query.length > 0 ? query : undefined,

--- a/src/__swaps__/screens/Swap/resources/search/discovery.ts
+++ b/src/__swaps__/screens/Swap/resources/search/discovery.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { parseTokenSearch } from './utils';
 
 const tokenSearchHttp = new RainbowFetchClient({
-  baseURL: 'https://token-search.rainbow.me/v3/discovery',
+  baseURL: 'https://token-search.rainbow.me/v3/trending/swaps',
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json',

--- a/src/__swaps__/screens/Swap/resources/search/search.ts
+++ b/src/__swaps__/screens/Swap/resources/search/search.ts
@@ -12,7 +12,7 @@ import { parseTokenSearch } from './utils';
 const ALL_VERIFIED_TOKENS_PARAM = '/?list=verifiedAssets';
 
 const tokenSearchHttp = new RainbowFetchClient({
-  baseURL: 'https://token-search.rainbow.me/v2',
+  baseURL: 'https://token-search.rainbow.me/v3/tokens',
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
@@ -83,6 +83,7 @@ async function tokenSearchQueryFunction({
         return parseTokenSearch(tokenSearch.data.data, chainId);
       }
 
+      // search for address on other chains
       const allVerifiedTokens = await tokenSearchHttp.get<{ data: SearchAsset[] }>(ALL_VERIFIED_TOKENS_PARAM);
 
       const addressQuery = query.trim().toLowerCase();


### PR DESCRIPTION
Fixes APP-2142

## What changed (plus any additional context for devs)
* Update the swap search endpoint from v2 to v3 which is more efficient and update corresponding handling of data to make it match prod / BX (we can later consolidate our separate calls to the v3 endpoint for verified vs not, but will be part of a follow up PR)
* Update the popular in Rainbow search endpoint (it's the same data, just backend renamed it to a more accurate name)

## Screen recordings / screenshots

https://github.com/user-attachments/assets/f421ee6b-35a0-4807-9c08-81a9da98ba58



## What to test
Testflight: v1.9.49 (30)
* Searching behaves similar to prod / BX across networks
