### PR TITLE
[APP-2194] Navigation to swaps isn't working after opening expanded state

### DIFF
--- a/src/components/sheet/sheet-action-buttons/SwapActionButton.tsx
+++ b/src/components/sheet/sheet-action-buttons/SwapActionButton.tsx
@@ -29,7 +29,7 @@ function SwapActionButton({ asset, color: givenColor, inputType, label, weight =
   const color = givenColor || colors.swapPurple;
 
   const goToSwap = useCallback(async () => {
-    const chainId = chainsIdByName[asset.network];
+    const chainId = asset.chainId || chainsIdByName[asset.network];
     const uniqueId = `${asset.address}_${chainId}`;
     const userAsset = userAssetsStore.getState().userAssets.get(uniqueId);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
We were relying on build time networks in a spot where I'm fairly certain we will always have a chain id value. I left the original value as a fallback to hopefully ensure this causes no widespread change other than that we aren't using an `undefined` chain id value for networks we are unfamiliar with at build time.

## Screen recordings / screenshots
https://www.loom.com/share/e89efd56894245388718959facf44b1f

## What to test
Try to navigate to swaps from asset expanded state after clicking on a trending token row.
