### PR TITLE
Fix non fractal price data formatter

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -1,5 +1,5 @@
 import { DropdownMenu } from '@/components/DropdownMenu';
-import { globalColors, Text, useBackgroundColor } from '@/design-system';
+import { DebugLayout, globalColors, Text, useBackgroundColor } from '@/design-system';
 import { useForegroundColor } from '@/design-system/color/useForegroundColor';
 
 import { SwapCoinIcon } from '@/__swaps__/screens/Swap/components/SwapCoinIcon';
@@ -408,10 +408,10 @@ function TrendingTokenRow({ token }: { token: TrendingToken }) {
                 <Text color="label" size="15pt" weight="bold" style={{ maxWidth: 100, flexShrink: 1 }} numberOfLines={1}>
                   {token.name}
                 </Text>
-                <Text color="labelTertiary" size="11pt" weight="bold" style={{ flexGrow: 1 }} numberOfLines={1}>
+                <Text color="labelTertiary" size="11pt" weight="bold" style={{ flexGrow: 0 }} numberOfLines={1}>
                   {token.symbol}
                 </Text>
-                <Text color="label" size="15pt" weight="bold">
+                <Text color="label" size="15pt" weight="bold" align="right">
                   {price}
                 </Text>
               </View>

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -30,6 +30,7 @@ import { ButtonPressAnimation } from '../animations';
 import { useFarcasterAccountForWallets } from '@/hooks/useFarcasterAccountForWallets';
 import { ImgixImage } from '../images';
 import { useRemoteConfig } from '@/model/remoteConfig';
+import { useAccountSettings } from '@/hooks';
 
 const t = i18n.l.trending_tokens;
 
@@ -91,6 +92,7 @@ function FilterButton({ icon, label, onPress }: { onPress?: VoidFunction; label:
 }
 
 function useTrendingTokensData() {
+  const { nativeCurrency } = useAccountSettings();
   const remoteConfig = useRemoteConfig();
   const { chainId, category, timeframe, sort } = useTrendingTokensStore(state => ({
     chainId: state.chainId,
@@ -109,6 +111,7 @@ function useTrendingTokensData() {
     sortDirection: SortDirection.Desc,
     limit: remoteConfig.trending_tokens_limit,
     walletAddress: walletAddress,
+    currency: nativeCurrency,
   });
 }
 
@@ -569,16 +572,21 @@ function SortFilter() {
   );
 }
 
+function TrendingTokensLoader() {
+  const { trending_tokens_limit } = useRemoteConfig();
+
+  return (
+    <View style={{ flex: 1 }}>
+      {Array.from({ length: trending_tokens_limit }).map((_, index) => (
+        <TrendingTokenLoadingRow key={index} />
+      ))}
+    </View>
+  );
+}
+
 function TrendingTokenData() {
   const { data: trendingTokens, isLoading } = useTrendingTokensData();
-  if (isLoading)
-    return (
-      <View style={{ flex: 1 }}>
-        {Array.from({ length: 10 }).map((_, index) => (
-          <TrendingTokenLoadingRow key={index} />
-        ))}
-      </View>
-    );
+  if (isLoading) return <TrendingTokensLoader />;
 
   return (
     <FlatList

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -1,5 +1,5 @@
 import { DropdownMenu } from '@/components/DropdownMenu';
-import { DebugLayout, globalColors, Text, useBackgroundColor } from '@/design-system';
+import { globalColors, Text, useBackgroundColor } from '@/design-system';
 import { useForegroundColor } from '@/design-system/color/useForegroundColor';
 
 import { SwapCoinIcon } from '@/__swaps__/screens/Swap/components/SwapCoinIcon';

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -112,16 +112,19 @@ export function formatCurrency(
   value: string | number,
   { valueIfNaN = '', currency = store.getState().settings.nativeCurrency }: CurrencyFormatterOptions = {}
 ): string {
+  const decimals = supportedNativeCurrencies[currency].decimals;
   const numericString = typeof value === 'number' ? toDecimalString(value) : String(value);
   if (isNaN(+numericString)) return valueIfNaN;
 
   const currencySymbol = supportedNativeCurrencies[currency].symbol;
-
-  const [whole, fraction = '00'] = numericString.split('.');
+  const [whole, fraction = ''] = numericString.split('.');
+  if (fraction === '') {
+    const formattedWhole = formatNumber(numericString, { decimals, useOrderSuffix: true });
+    return `${currencySymbol}${formattedWhole}`;
+  }
 
   const formattedWhole = formatNumber(whole, { decimals: 0, useOrderSuffix: true });
   const formattedFraction = formatFraction(fraction);
-
   // if it ends with a non-numeric character, it's in compact notation like '1.2K'
   if (isNaN(+formattedWhole[formattedWhole.length - 1])) return `${currencySymbol}${formattedWhole}`;
 


### PR DESCRIPTION
Fixes APP-2203

## What changed (plus any additional context for devs)
Reusing the swaps native amount formatter for when we are formatting a non-fractal amount.

## Screen recordings / screenshots
<img width="524" alt="Screenshot 2024-12-18 at 12 12 34 PM" src="https://github.com/user-attachments/assets/fb7dd19a-e834-4cdf-ae5c-2220800612b0" />


## What to test
token formats should either be:
1. decimal fraction with zero subscript
2. decimal fraction without zero subscript (max 3 zeros)
3. Whole number > 1
