### PR TITLE
Fixes initialPinned being empty in certain cases

### DIFF
--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -39,6 +39,7 @@ import Animated, {
 import Svg, { Path } from 'react-native-svg';
 import {
   customizeNetworksBannerStore,
+  defaultPinnedNetworks,
   dismissCustomizeNetworksBanner,
   networkSwitcherStore,
   shouldShowCustomizeNetworksBanner,
@@ -562,7 +563,11 @@ function NetworksGrid({
     // persists pinned networks when closing the sheet
     // should be the only time this component is unmounted
     return () => {
-      networkSwitcherStore.setState({ pinnedNetworks: networks.value[Section.pinned] });
+      if (networks.value[Section.pinned].length > 0) {
+        networkSwitcherStore.setState({ pinnedNetworks: networks.value[Section.pinned] });
+      } else {
+        networkSwitcherStore.setState({ pinnedNetworks: defaultPinnedNetworks });
+      }
     };
   }, [networks]);
 


### PR DESCRIPTION
Fixes APP-2207

## What changed (plus any additional context for devs)
Added default initialPinned that gets set if we either:
1. can't parse most used from nonces
2. if the user sets the pinned to no chains (aka, this shouldn't be allowed)

## Screen recordings / screenshots
<img width="568" alt="Screenshot 2024-12-18 at 4 25 25 PM" src="https://github.com/user-attachments/assets/00c04d3e-01f7-46e3-b31d-eb303312a4b7" />


## What to test
see if you can get into a state where the network switcher opens with no initial pinned networks.
