### PR TITLE
Migrate from addys positions -> summary endpoint for total wallet balance

### DIFF
--- a/src/resources/summary/summary.ts
+++ b/src/resources/summary/summary.ts
@@ -51,6 +51,8 @@ interface AddysSummary {
           num_erc20s: number;
           last_activity: number;
           asset_value: number | null;
+          claimables_value: number | null;
+          positions_value: number | null;
         };
       };
       summary_by_chain: {
@@ -63,6 +65,8 @@ interface AddysSummary {
           num_erc20s: number;
           last_activity: number;
           asset_value: number | null;
+          claimables_value: number | null;
+          positions_value: number | null;
         };
       };
     };


### PR DESCRIPTION
Fixes APP-1808

## What changed (plus any additional context for devs)
- Change total balance calculation to use positions value returned from summary endpoint rather than fetching each accounts positions individually and calculating the total from that.


## What to test
- That your total account balance is correct
