### PR TITLE
Change logic on when we should use native formatter for trending tokens

### DIFF
--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -119,9 +119,10 @@ export function formatCurrency(
   const currencySymbol = supportedNativeCurrencies[currency].symbol;
   const [whole, fraction = ''] = numericString.split('.');
 
-  if (fraction === '') {
+  const numericalWholeNumber = +whole;
+  if (numericalWholeNumber > 0) {
     // if the fraction is empty and the numeric string is less than 6 characters, we can just run it through our native currency display worklet
-    if (numericString.length <= 6) {
+    if (whole.length <= 6) {
       return convertAmountToNativeDisplayWorklet(numericString, currency, false, true);
     }
 


### PR DESCRIPTION
Fixes APP-2203

## What changed (plus any additional context for devs)
Previously we were only checking for numbers with no fractal value, but we should actually use our native formatter whenever the whole number is > 0. 

## Screen recordings / screenshots
https://github.com/user-attachments/assets/a9fcb08d-aa69-423f-8ba5-9aa7734b838b


## What to test
test each network and see if you can get a funky number
