### PR TITLE
Fix network colors in NetworkSelector

### DIFF
--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { getChainColorWorklet, opacity } from '@/__swaps__/utils/swaps';
+import { opacity } from '@/__swaps__/utils/swaps';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { ChainId } from '@/state/backendNetworks/types';
 import { AnimatedBlurView } from '@/components/AnimatedComponents/AnimatedBlurView';
@@ -48,6 +48,7 @@ import { noop } from 'lodash';
 import { TapToDismiss } from './DappBrowser/control-panel/ControlPanel';
 import { THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { GestureHandlerButton } from '@/__swaps__/screens/Swap/components/GestureHandlerButton';
+import { useTheme } from '@/theme';
 
 const t = i18n.l.network_switcher;
 
@@ -372,8 +373,9 @@ function AllNetworksSection({
 }
 
 function NetworkOption({ chainId, selected }: { chainId: ChainId; selected: SharedValue<ChainId | undefined> }) {
+  const { colors } = useTheme();
   const chainName = useBackendNetworksStore.getState().getChainsLabel()[chainId];
-  const chainColor = getChainColorWorklet(chainId, true);
+  const chainColor = colors.networkColors[chainId] ? colors.networkColors[chainId] : undefined;
   const isSelected = useDerivedValue(() => selected.value === chainId);
   const { animatedStyle } = useNetworkOptionStyle(isSelected, chainColor);
 


### PR DESCRIPTION
Fixes APP-2199

## What changed (plus any additional context for devs)
We were using an old util that requires us to add entries to foregroundColors that is no longer supported. Changed it to pull directly from the theme instead.

@christianbaroni noticed that our Arbitrum color doesn't correspond to what's in the Figma. Didn't want to change the hex without consulting you first.

Here's the FIgma:
<img width="481" alt="Screenshot 2024-12-20 at 10 17 17 AM" src="https://github.com/user-attachments/assets/4540461f-a314-4c93-827e-1d20eb95cb42" />

Here's our current hex: `#2D374B` 
<img width="195" alt="Screenshot 2024-12-20 at 10 18 34 AM" src="https://github.com/user-attachments/assets/372647e7-c368-4f24-b8cb-11c8124d3cba" />

## Screen recordings / screenshots

https://github.com/user-attachments/assets/c330991f-e36d-425d-bacd-6fe0a99cf248


https://github.com/user-attachments/assets/f65e2b0e-30e4-4948-a3dc-e268e6786626



## What to test

