### PR TITLE
Fix time filters and default to D3

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -564,7 +564,7 @@ function NetworkFilter() {
 
 function TimeFilter() {
   const timeframe = useTrendingTokensStore(state => state.timeframe);
-  const shouldAbbreviate = timeframe === Timeframe.H24;
+  const shouldAbbreviate = timeframe === Timeframe.H24 || timeframe === Timeframe.H12;
 
   return (
     <DropdownMenu

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -578,7 +578,7 @@ function TimeFilter() {
       onPressMenuItem={timeframe => useTrendingTokensStore.getState().setTimeframe(timeframe)}
     >
       <FilterButton
-        selected={timeframe !== Timeframe.H24}
+        selected={timeframe !== Timeframe.D3}
         iconColor={undefined}
         highlightedBackgroundColor={undefined}
         label={shouldAbbreviate ? i18n.t(t.filters.time[`${timeframe}_ABBREVIATED`]) : i18n.t(t.filters.time[timeframe])}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3063,7 +3063,7 @@
           "H24": "24 Hours",
           "H24_ABBREVIATED": "24h",
           "D7": "1 Week",
-          "D3": "1 Month"
+          "D3": "3 Days"
         }
       }
     },

--- a/src/state/trendingTokens/trendingTokens.ts
+++ b/src/state/trendingTokens/trendingTokens.ts
@@ -17,7 +17,7 @@ export const sortFilters = [
   ArcTrendingSort.TopLosers,
 ] as const;
 export type TrendingSort = (typeof sortFilters)[number];
-export const timeFilters = [ArcTimeframe.H24, ArcTimeframe.D7, ArcTimeframe.D3] as const;
+export const timeFilters = [ArcTimeframe.H12, ArcTimeframe.H24, ArcTimeframe.D3, ArcTimeframe.D7] as const;
 export type TrendingTimeframe = (typeof timeFilters)[number];
 
 type TrendingTokensState = {
@@ -36,7 +36,7 @@ export const useTrendingTokensStore = createRainbowStore<TrendingTokensState>(
   set => ({
     category: ArcTrendingCategory.Trending,
     chainId: undefined,
-    timeframe: ArcTimeframe.H24,
+    timeframe: ArcTimeframe.D3,
     sort: ArcTrendingSort.Recommended,
     setCategory: category => set({ category }),
     setChainId: chainId => {


### PR DESCRIPTION
Fixes APP-2222

## What changed (plus any additional context for devs)
Default option to 3 day timeframe. order chronologically in the list.

## Screen recordings / screenshots
<img width="568" alt="Screenshot 2024-12-20 at 10 41 45 AM" src="https://github.com/user-attachments/assets/ca9453b0-25b8-4e48-b62e-f6dd823fd10a" />
<img width="568" alt="Screenshot 2024-12-20 at 10 44 03 AM" src="https://github.com/user-attachments/assets/e288f940-5e3f-495c-8f9c-e137f6e0d22d" />
el

## What to test
n/a
