### PR TITLE
Prevent backup prompt from firing on import

### DIFF
--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -28,10 +28,10 @@ const delay = (ms: number) =>
   });
 
 const promptForBackupOnceReadyOrNotAvailable = async (): Promise<boolean> => {
-  const { status } = backupsStore.getState();
-  if (LoadingStates.includes(status)) {
+  let { status } = backupsStore.getState();
+  while (LoadingStates.includes(status)) {
     await delay(1000);
-    return promptForBackupOnceReadyOrNotAvailable();
+    status = backupsStore.getState().status;
   }
 
   logger.debug(`[walletReadyEvents]: BackupSheet: showing backup now sheet for selected wallet`);
@@ -47,9 +47,7 @@ export const runWalletBackupStatusChecks = async (): Promise<boolean> => {
   const { selected } = store.getState().wallets;
   if (!selected || IS_TEST) return false;
 
-  const selectedWalletNeedsBackedUp =
-    !selected.backedUp && !selected.damaged && selected.type !== WalletTypes.readOnly && selected.type !== WalletTypes.bluetooth;
-  if (selectedWalletNeedsBackedUp) {
+  if (!selected.backedUp && !selected.damaged && selected.type !== WalletTypes.readOnly && selected.type !== WalletTypes.bluetooth) {
     logger.debug('[walletReadyEvents]: Selected wallet is not backed up, prompting backup sheet');
     return promptForBackupOnceReadyOrNotAvailable();
   }

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -339,24 +339,6 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
                     });
                   }, 1_000);
 
-                  setTimeout(() => {
-                    // If it's not read only or hardware, show the backup sheet
-                    if (
-                      !(
-                        isENSAddressFormat(input) ||
-                        isUnstoppableAddressFormat(input) ||
-                        isValidAddress(input) ||
-                        isValidBluetoothDeviceId(input)
-                      )
-                    ) {
-                      if (!IS_TEST) {
-                        Navigation.handleAction(Routes.BACKUP_SHEET, {
-                          step: WalletBackupStepTypes.backup_prompt,
-                        });
-                      }
-                    }
-                  }, 1000);
-
                   analytics.track('Imported seed phrase', {
                     isWalletEthZero,
                   });


### PR DESCRIPTION
Fixes APP-2223

## What changed (plus any additional context for devs)
Just removed an entry point into the backup prompt since it runs on wallet ready now, this one is redundant and unnecessary

## Screen recordings / screenshots
// wip

## What to test
you should no longer be asked for backup on import/creation if backed up
