### PR TITLE
fix and others i18n

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -280,7 +280,7 @@ function FriendHolders({ friends }: { friends: FarcasterUser[] }) {
         {friends.length > 2 && (
           <Text color="labelTertiary" size="11pt" weight="bold">
             {' '}
-            {i18n.t('trending_tokens.and_others', { count: howManyOthers })}
+            {i18n.t(t.and_others[howManyOthers === 1 ? 'one' : 'other'], { count: howManyOthers })}
           </Text>
         )}
       </View>


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Fixes missing `and other(s)` copy from showing

## Screen recordings / screenshots
<img width="568" alt="Screenshot 2024-12-20 at 4 43 06 PM" src="https://github.com/user-attachments/assets/b895ef23-f811-4eed-a00e-072cb75ca21e" />


## What to test

