### PR TITLE
pin hardhat

### DIFF
--- a/scripts/hardhat.sh
+++ b/scripts/hardhat.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 source .env
-npx hardhat node --fork $ETHEREUM_MAINNET_RPC_DEV
+npx hardhat node --fork "$ETHEREUM_MAINNET_RPC_DEV" --fork-block-number 18700000


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Previously, Hardhat tests forked from the latest mainnet block, causing intermittent failures as new blocks were added with varying post-merge parameters (was having errors with `totalDifficulty`). Pin to block #18700000 to ensure consistent test behavior. They seem to work now.

the block number was chosen arbitrarily. happy to change it.

