### PR TITLE
Trending tokens / network switcher cleanup

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -17,10 +17,8 @@ import { FarcasterUser, TrendingToken, useTrendingTokens } from '@/resources/tre
 import { useNavigationStore } from '@/state/navigation/navigationStore';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { sortFilters, timeFilters, useTrendingTokensStore } from '@/state/trendingTokens/trendingTokens';
-import { colors } from '@/styles';
-import { darkModeThemeColors } from '@/styles/colors';
 import { useCallback, useEffect, useMemo } from 'react';
-import React, { Dimensions, FlatList, View } from 'react-native';
+import React, { FlatList, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import Animated, { runOnJS, useSharedValue } from 'react-native-reanimated';
 import { ButtonPressAnimation } from '../animations';
@@ -31,6 +29,7 @@ import { useAccountSettings } from '@/hooks';
 import { getColorWorklet, getMixedColor, opacity } from '@/__swaps__/utils/swaps';
 import { THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { IS_IOS } from '@/env';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 const t = i18n.l.trending_tokens;
 
@@ -72,18 +71,24 @@ function FilterButton({
         end={{ x: 0.5, y: 1 }}
         start={{ x: 0.5, y: 0 }}
         style={{
-          flexDirection: 'row',
           alignItems: 'center',
+          borderColor,
+          borderRadius: 18,
+          borderWidth: THICK_BORDER_WIDTH,
+          flexDirection: 'row',
           gap: 4,
           height: 36,
           paddingHorizontal: 12 - THICK_BORDER_WIDTH,
-          borderRadius: 18,
-          borderWidth: THICK_BORDER_WIDTH,
-          borderColor,
         }}
       >
         {typeof icon === 'string' ? (
-          <TextIcon color={{ custom: iconColor || defaultIconColor }} size="icon 13px" weight="heavy" width={16}>
+          <TextIcon
+            color={{ custom: iconColor || defaultIconColor }}
+            size="icon 13px"
+            textStyle={IS_IOS ? undefined : { marginTop: -2 }}
+            weight="heavy"
+            width={16}
+          >
             {icon}
           </TextIcon>
         ) : (
@@ -209,7 +214,7 @@ function CategoryFilterButton({
         <TextIcon
           color={{ custom: typeof iconColor === 'string' ? iconColor : selected ? iconColor.selected : iconColor.default }}
           size="icon 13px"
-          textStyle={IS_IOS ? { marginTop: -3.5 } : undefined}
+          textStyle={{ marginTop: IS_IOS ? -3.5 : -2 }}
           weight="heavy"
           width={iconWidth}
         >
@@ -240,15 +245,16 @@ function FriendPfp({ pfp_url }: { pfp_url: string }) {
   const backgroundColor = useBackgroundColor('surfacePrimary');
   return (
     <ImgixImage
+      enableFasterImage
       source={{ uri: pfp_url }}
       style={{
         height: 12 + 2,
         width: 12 + 2,
-        borderRadius: 6,
+        borderRadius: 7,
         borderWidth: 1,
         borderColor: backgroundColor,
         marginVertical: -1,
-        marginLeft: -6,
+        marginLeft: -4,
       }}
     />
   );
@@ -259,18 +265,18 @@ function FriendHolders({ friends }: { friends: FarcasterUser[] }) {
   const separator = howManyOthers === 1 && friends.length === 2 ? ` ${i18n.t(t.and)} ` : ', ';
 
   return (
-    <View style={{ flexDirection: 'row', gap: 5.67, height: 12, alignItems: 'center' }}>
-      <View style={{ flexDirection: 'row-reverse', alignItems: 'center', paddingLeft: 6 }}>
+    <View style={{ alignItems: 'center', flexDirection: 'row', flexWrap: 'nowrap', gap: 5.67, height: 7 }}>
+      <View style={{ flexDirection: 'row-reverse', alignItems: 'center', height: 7, paddingLeft: 4 }}>
         <FriendPfp pfp_url={friends[0].pfp_url} />
         {friends[1] && <FriendPfp pfp_url={friends[1].pfp_url} />}
       </View>
 
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <Text color="labelSecondary" size="11pt" weight="bold" numberOfLines={1}>
+      <View style={{ alignItems: 'center', flexDirection: 'row', marginTop: -0.5 }}>
+        <Text color="labelTertiary" size="11pt" weight="bold" numberOfLines={1}>
           {friends[0].username}
           {friends[1] && (
             <>
-              <Text color="labelTertiary" size="11pt" weight="bold">
+              <Text color="labelQuaternary" size="11pt" weight="bold">
                 {separator}
               </Text>
               {friends[1].username}
@@ -278,7 +284,7 @@ function FriendHolders({ friends }: { friends: FarcasterUser[] }) {
           )}
         </Text>
         {friends.length > 2 && (
-          <Text color="labelTertiary" size="11pt" weight="bold">
+          <Text color="labelQuaternary" size="11pt" weight="bold">
             {' '}
             {i18n.t(t.and_others[howManyOthers === 1 ? 'one' : 'other'], { count: howManyOthers })}
           </Text>
@@ -289,75 +295,21 @@ function FriendHolders({ friends }: { friends: FarcasterUser[] }) {
 }
 
 function TrendingTokenLoadingRow() {
-  const backgroundColor = useBackgroundColor('surfacePrimary');
-  const { isDarkMode } = useColorMode();
   return (
-    <View style={{ flex: 1, height: 78, width: '100%' }}>
-      <Skeleton>
-        <View style={{ paddingVertical: 12, flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+    <View style={{ flex: 1, height: 48, width: '100%' }}>
+      <Skeleton style={{ alignItems: 'center', justifyContent: 'center' }}>
+        <View style={{ alignItems: 'center', flexDirection: 'row', gap: 12, height: 48, justifyContent: 'center' }}>
           <FakeAvatar />
 
-          <View style={{ gap: 12, flex: 1 }}>
-            <View style={{ flexDirection: 'row', gap: 5.67, alignItems: 'center', marginTop: -2 }}>
-              <View style={{ flexDirection: 'row-reverse', alignItems: 'center' }}>
-                <View
-                  style={{
-                    height: 12 + 2,
-                    width: 12 + 2,
-                    borderRadius: 6,
-                    borderWidth: 1,
-                    borderColor: backgroundColor,
-                    backgroundColor: isDarkMode ? darkModeThemeColors.skeleton : colors.skeleton,
-                    marginVertical: -1,
-                    marginLeft: -6,
-                  }}
-                />
-                <View
-                  style={{
-                    height: 12 + 2,
-                    width: 12 + 2,
-                    borderRadius: 6,
-                    borderWidth: 1,
-                    borderColor: backgroundColor,
-                    backgroundColor: isDarkMode ? darkModeThemeColors.skeleton : colors.skeleton,
-                    marginVertical: -1,
-                  }}
-                />
-              </View>
+          <View style={{ flex: 1, flexDirection: 'column', gap: 12 }}>
+            <FakeText height={7} width={100} />
+            <FakeText height={10} width={136} />
+            <FakeText height={7} width={104} />
+          </View>
 
-              <FakeText width={148} />
-            </View>
-
-            <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-              <View style={{ gap: 8 }}>
-                <View style={{ flexDirection: 'row', gap: 6, alignItems: 'baseline' }}>
-                  <FakeText height={16} width={84} />
-                  <FakeText height={14} width={32} />
-                  <FakeText height={16} width={60} />
-                </View>
-
-                <View style={{ flexDirection: 'row', gap: 18, alignItems: 'center' }}>
-                  <View style={{ flexDirection: 'row', gap: 4 }}>
-                    <FakeText height={14} width={32} />
-                    <FakeText height={14} width={44} />
-                  </View>
-
-                  <View style={{ flexDirection: 'row', gap: 4 }}>
-                    <FakeText height={14} width={36} />
-                    <FakeText height={14} width={52} />
-                  </View>
-                </View>
-              </View>
-
-              <View style={{ gap: 8, marginLeft: 'auto' }}>
-                <View style={{ flexDirection: 'row', gap: 2, alignItems: 'center' }}>
-                  <FakeText height={16} width={60} />
-                </View>
-                <View style={{ flexDirection: 'row', gap: 5, justifyContent: 'flex-end' }}>
-                  <FakeText width={40} />
-                </View>
-              </View>
-            </View>
+          <View style={{ alignItems: 'flex-end', flex: 1, flexDirection: 'column', gap: 12, height: '100%', justifyContent: 'flex-end' }}>
+            <FakeText height={10} width={72} />
+            <FakeText height={7} width={60} />
           </View>
         </View>
       </Skeleton>
@@ -371,7 +323,7 @@ function getPriceChangeColor(priceChange: number) {
 }
 
 function TrendingTokenRow({ token }: { token: TrendingToken }) {
-  const separatorColor = useForegroundColor('separator');
+  const separatorSecondary = useForegroundColor('separatorSecondary');
 
   const price = formatCurrency(token.price);
   const marketCap = formatNumber(token.marketCap, { useOrderSuffix: true, decimals: 1, style: '$' });
@@ -400,7 +352,15 @@ function TrendingTokenRow({ token }: { token: TrendingToken }) {
 
   return (
     <ButtonPressAnimation onPress={handleNavigateToToken} scaleTo={0.94}>
-      <View style={{ height: 48, overflow: 'visible', flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+      <View
+        style={{
+          overflow: 'visible',
+          flexDirection: 'row',
+          gap: 12,
+          height: token.highlightedFriends.length > 0 ? 48 : 40,
+          alignItems: 'center',
+        }}
+      >
         <SwapCoinIcon
           iconUrl={token.icon_url}
           color={token.colors.primary}
@@ -418,24 +378,24 @@ function TrendingTokenRow({ token }: { token: TrendingToken }) {
             <View style={{ gap: 12 }}>
               <View
                 style={{
+                  alignItems: IS_IOS ? 'baseline' : 'flex-end',
                   flexDirection: 'row',
                   gap: 6,
                   height: 10,
-                  alignItems: 'baseline',
                   maxWidth:
-                    Dimensions.get('screen').width -
-                    40 - // 40 screen paddings
-                    (40 + 12) - // 40 token icon, 12 gap
-                    70, // 70 width for price change %
+                    DEVICE_WIDTH -
+                    40 - // horizontal list padding
+                    (40 + 12) - // token icon width + 12px gap
+                    70, // approx. % price change width
                 }}
               >
-                <Text color="label" size="15pt" weight="bold" style={{ maxWidth: 100, flexShrink: 1 }} numberOfLines={1}>
+                <Text color="label" numberOfLines={1} size="15pt" style={{ flexShrink: 1, maxWidth: 100 }} weight="bold">
                   {token.name}
                 </Text>
-                <Text color="labelTertiary" size="11pt" weight="bold" style={{ flexGrow: 0 }} numberOfLines={1}>
+                <Text color="labelTertiary" numberOfLines={1} size="11pt" style={{ bottom: IS_IOS ? 0 : -0.2, flexGrow: 0 }} weight="bold">
                   {token.symbol}
                 </Text>
-                <Text color="label" size="15pt" weight="bold">
+                <Text color="label" numberOfLines={1} size="15pt" weight="bold">
                   {price}
                 </Text>
               </View>
@@ -445,20 +405,18 @@ function TrendingTokenRow({ token }: { token: TrendingToken }) {
                   <Text color="labelQuaternary" size="11pt" weight="bold">
                     VOL
                   </Text>
-                  <Text color="labelTertiary" size="11pt" weight="bold">
+                  <Text color="labelTertiary" numberOfLines={1} size="11pt" weight="bold">
                     {volume}
                   </Text>
                 </View>
 
-                <Text color={{ custom: separatorColor }} size="icon 9px" weight="bold">
-                  |
-                </Text>
+                <View style={{ backgroundColor: separatorSecondary, borderRadius: 1, height: 7, marginTop: 1, width: 1 }} />
 
                 <View style={{ flexDirection: 'row', gap: 4 }}>
                   <Text color="labelQuaternary" size="11pt" weight="bold">
                     MCAP
                   </Text>
-                  <Text color="labelTertiary" size="11pt" weight="bold">
+                  <Text color="labelTertiary" numberOfLines={1} size="11pt" weight="bold">
                     {marketCap}
                   </Text>
                 </View>
@@ -512,16 +470,14 @@ function NoResults() {
 }
 
 function NetworkFilter() {
-  const { isDarkMode } = useColorMode();
-
-  const selected = useSharedValue<ChainId | undefined>(undefined);
   const chainId = useTrendingTokensStore(state => state.chainId);
+  const selected = useSharedValue<ChainId | undefined>(chainId);
+
+  const chainColor = useBackendNetworksStore(state => state.getColorsForChainId(chainId || ChainId.mainnet, false));
   const setChainId = useTrendingTokensStore(state => state.setChainId);
 
   const { icon, label, lightenedNetworkColor } = useMemo(() => {
     if (!chainId) return { icon: '􀤆', label: i18n.t(t.all), lightenedNetworkColor: undefined };
-    const lightenedNetworkColor = useBackendNetworksStore.getState().getColorsForChainId(chainId, isDarkMode);
-
     return {
       icon: (
         <View style={{ marginRight: 2 }}>
@@ -529,11 +485,9 @@ function NetworkFilter() {
         </View>
       ),
       label: useBackendNetworksStore.getState().getChainsLabel()[chainId],
-      lightenedNetworkColor: lightenedNetworkColor
-        ? getMixedColor(lightenedNetworkColor, globalColors.white100, isDarkMode ? 0.55 : 0.6)
-        : undefined,
+      lightenedNetworkColor: chainColor ? getMixedColor(chainColor, globalColors.white100, 0.6) : undefined,
     };
-  }, [chainId, isDarkMode]);
+  }, [chainColor, chainId]);
 
   const setSelected = useCallback(
     (chainId: ChainId | undefined) => {
@@ -564,7 +518,7 @@ function NetworkFilter() {
 
 function TimeFilter() {
   const timeframe = useTrendingTokensStore(state => state.timeframe);
-  const shouldAbbreviate = timeframe === Timeframe.H24 || timeframe === Timeframe.H12;
+  const shouldAbbreviate = timeframe === Timeframe.H12 || timeframe === Timeframe.H24;
 
   return (
     <DropdownMenu
@@ -580,7 +534,6 @@ function TimeFilter() {
     >
       <FilterButton
         selected={timeframe !== Timeframe.D3}
-        iconColor={undefined}
         highlightedBackgroundColor={undefined}
         label={shouldAbbreviate ? i18n.t(t.filters.time[`${timeframe}_ABBREVIATED`]) : i18n.t(t.filters.time[timeframe])}
         icon="􀐫"
@@ -590,10 +543,11 @@ function TimeFilter() {
 }
 
 function SortFilter() {
+  const { isDarkMode } = useColorMode();
   const sort = useTrendingTokensStore(state => state.sort);
   const selected = sort !== TrendingSort.Recommended;
 
-  const iconColor = useForegroundColor(selected ? 'labelSecondary' : 'labelTertiary');
+  const iconColor = getColorWorklet(selected ? 'labelSecondary' : 'labelTertiary', selected ? false : isDarkMode);
 
   const sortLabel = useMemo(() => {
     if (sort === TrendingSort.Recommended) return i18n.t(t.filters.sort.RECOMMENDED.label);
@@ -621,9 +575,15 @@ function SortFilter() {
         highlightedBackgroundColor={undefined}
         label={sortLabel}
         icon={
-          <Text color={{ custom: iconColor }} size="icon 13px" weight="heavy" style={{ width: 20 }}>
+          <TextIcon
+            color={{ custom: iconColor }}
+            size="icon 13px"
+            textStyle={IS_IOS ? undefined : { marginTop: -2 }}
+            weight="heavy"
+            width={20}
+          >
             􀄬
-          </Text>
+          </TextIcon>
         }
       />
     </DropdownMenu>
@@ -634,7 +594,7 @@ function TrendingTokensLoader() {
   const { trending_tokens_limit } = useRemoteConfig();
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, gap: 28 }}>
       {Array.from({ length: trending_tokens_limit }).map((_, index) => (
         <TrendingTokenLoadingRow key={index} />
       ))}
@@ -648,8 +608,8 @@ function TrendingTokenData() {
 
   return (
     <FlatList
-      style={{ marginHorizontal: -20, marginVertical: -12, paddingBottom: 20, paddingTop: 12 }}
-      contentContainerStyle={{ gap: 28, paddingHorizontal: 20 }}
+      style={{ marginHorizontal: -20, marginVertical: -12, paddingBottom: 8 }}
+      contentContainerStyle={{ gap: 28, paddingHorizontal: 20, paddingVertical: 12 }}
       ListEmptyComponent={<NoResults />}
       data={trendingTokens}
       renderItem={({ item }) => <TrendingTokenRow token={item} />}

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -1,12 +1,22 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { BlurView } from '@react-native-community/blur';
 import { opacity } from '@/__swaps__/utils/swaps';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { ChainId } from '@/state/backendNetworks/types';
-import { AnimatedBlurView } from '@/components/AnimatedComponents/AnimatedBlurView';
 import { ButtonPressAnimation } from '@/components/animations';
 import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
-import { AnimatedText, Box, DesignSystemProvider, globalColors, Separator, Text, useBackgroundColor, useColorMode } from '@/design-system';
+import {
+  AnimatedText,
+  Box,
+  DesignSystemProvider,
+  globalColors,
+  Inset,
+  Separator,
+  Text,
+  TextShadow,
+  useBackgroundColor,
+  useColorMode,
+} from '@/design-system';
 import { useForegroundColor } from '@/design-system/color/useForegroundColor';
 import * as i18n from '@/languages';
 import deviceUtils, { DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -28,7 +38,7 @@ import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-  withDelay,
+  withClamp,
   withSequence,
   withSpring,
   withTiming,
@@ -48,14 +58,15 @@ import { noop } from 'lodash';
 import { TapToDismiss } from './DappBrowser/control-panel/ControlPanel';
 import { THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { GestureHandlerButton } from '@/__swaps__/screens/Swap/components/GestureHandlerButton';
-import { useTheme } from '@/theme';
+import { triggerHaptics } from 'react-native-turbo-haptics';
+import { AnimatedTextIcon } from './AnimatedComponents/AnimatedTextIcon';
 
 const t = i18n.l.network_switcher;
 
 const translations = {
   edit: i18n.t(t.edit),
   done: i18n.t(i18n.l.done),
-  networks: i18n.t(t.networks),
+  network: i18n.t(t.network),
   more: i18n.t(t.more),
   show_more: i18n.t(t.show_more),
   show_less: i18n.t(t.show_less),
@@ -74,23 +85,13 @@ function EditButton({ editing }: { editing: SharedValue<boolean> }) {
         'worklet';
         editing.value = !editing.value;
       }}
-      scaleTo={0.95}
-      style={{
-        borderColor,
-        borderCurve: 'continuous',
-        borderRadius: 14,
-        borderWidth: THICK_BORDER_WIDTH,
-        height: 28,
-        justifyContent: 'center',
-        overflow: 'hidden',
-        paddingHorizontal: 10,
-        position: 'absolute',
-        right: 0,
-      }}
+      style={[sx.editButton, { borderColor }]}
     >
-      <AnimatedText color="blue" size="17pt" weight="bold" style={{ shadowColor: '#268FFF', shadowOpacity: 0.4, shadowRadius: 12 }}>
-        {text}
-      </AnimatedText>
+      <TextShadow blur={12} shadowOpacity={0.4}>
+        <AnimatedText align="center" color="blue" size="17pt" weight="bold">
+          {text}
+        </AnimatedText>
+      </TextShadow>
     </ButtonPressAnimation>
   );
 }
@@ -100,27 +101,15 @@ function Header({ editing }: { editing: SharedValue<boolean> }) {
   const fill = useForegroundColor('fill');
 
   const title = useDerivedValue(() => {
-    return editing.value ? translations.edit : translations.networks;
+    return editing.value ? translations.edit : translations.network;
   });
 
   return (
-    <View style={{ height: 66, borderBottomWidth: 1, borderBottomColor: separatorTertiary, paddingTop: 20 }}>
-      <View style={{ position: 'absolute', left: 0, right: 0, top: 6 }}>
-        <View
-          style={{
-            height: 5,
-            width: 36,
-            marginHorizontal: 'auto',
-            borderRadius: 3,
-            borderCurve: 'continuous',
-            backgroundColor: fill,
-            overflow: 'hidden',
-          }}
-        />
-      </View>
+    <View style={[sx.headerContainer, { borderBottomColor: separatorTertiary }]}>
+      <View style={[sx.sheetHandle, { backgroundColor: fill }]} />
 
-      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', height: 28 }}>
-        <AnimatedText color="label" size="20pt" weight="heavy">
+      <View style={sx.headerContent}>
+        <AnimatedText align="center" color="label" size="20pt" style={{ width: '100%' }} weight="heavy">
           {title}
         </AnimatedText>
 
@@ -129,6 +118,8 @@ function Header({ editing }: { editing: SharedValue<boolean> }) {
     </View>
   );
 }
+
+const BANNER_HEIGHT = 75;
 
 const CustomizeNetworksBanner = !shouldShowCustomizeNetworksBanner(customizeNetworksBannerStore.getState().dismissedAt)
   ? () => null
@@ -143,19 +134,14 @@ const CustomizeNetworksBanner = !shouldShowCustomizeNetworksBanner(customizeNetw
       const dismissedAt = customizeNetworksBannerStore(s => s.dismissedAt);
       if (!shouldShowCustomizeNetworksBanner(dismissedAt)) return null;
 
-      const height = 75;
       const blue = '#268FFF';
 
       return (
         <DesignSystemProvider colorMode="light">
-          <Animated.View
-            entering={FadeIn.duration(300).delay(600)}
-            exiting={FadeOutUp.duration(200)}
-            style={{ position: 'absolute', top: -(height + 14), left: 0, right: 0 }}
-          >
+          <Animated.View entering={FadeIn.duration(300).delay(600)} exiting={FadeOutUp.duration(200)} style={sx.banner}>
             <MaskedView
               maskElement={
-                <Svg width="100%" height={height} viewBox="0 0 353 75" fill="none">
+                <Svg width="100%" height={BANNER_HEIGHT} viewBox="0 0 353 75" fill="none">
                   <Path
                     d="M1.27368 16.2855C0 20.0376 0 24.6917 0 34C0 43.3083 0 47.9624 1.27368 51.7145C3.67205 58.7799 9.22007 64.3279 16.2855 66.7263C20.0376 68 24.6917 68 34 68H303.795C305.065 68 305.7 68 306.306 68.1265C306.844 68.2388 307.364 68.4243 307.851 68.6781C308.401 68.9641 308.892 69.3661 309.874 70.17L313.454 73.0986L313.454 73.0988C314.717 74.1323 315.349 74.6491 316.052 74.8469C316.672 75.0214 317.328 75.0214 317.948 74.8469C318.651 74.6491 319.283 74.1323 320.546 73.0988L320.546 73.0986L324.269 70.0528C325.203 69.2882 325.671 68.9059 326.166 68.6362C326.634 68.3817 327.044 68.2214 327.56 68.0907C328.107 67.9521 328.787 67.911 330.146 67.8287C332.84 67.6657 334.885 67.3475 336.715 66.7263C343.78 64.3279 349.328 58.7799 351.726 51.7145C353 47.9624 353 43.3083 353 34C353 24.6917 353 20.0376 351.726 16.2855C349.328 9.22007 343.78 3.67205 336.715 1.27368C332.962 0 328.308 0 319 0H34C24.6917 0 20.0376 0 16.2855 1.27368C9.22007 3.67205 3.67205 9.22007 1.27368 16.2855Z"
                     fill="black"
@@ -163,34 +149,10 @@ const CustomizeNetworksBanner = !shouldShowCustomizeNetworksBanner(customizeNetw
                 </Svg>
               }
             >
-              <AnimatedBlurView blurType="xlight" blurAmount={6} style={{ height }}>
-                <View
-                  style={{
-                    flexDirection: 'row',
-                    height: 68,
-                    flex: 1,
-                    padding: 16 + 12,
-                    gap: 12,
-                    alignItems: 'center',
-                    marginTop: 68 - height,
-                  }}
-                >
-                  <LinearGradient
-                    colors={['#268FFF1F', '#268FFF14']}
-                    angle={135}
-                    useAngle
-                    style={{
-                      height: 36,
-                      width: 36,
-                      borderRadius: 10,
-                      borderWidth: 1,
-                      borderColor: '#268FFF0D',
-                      backgroundColor: '#268FFF14',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                  >
-                    <Text weight="heavy" size="17pt" color={{ custom: blue }}>
+              <BlurView blurType="xlight" blurAmount={6} style={sx.bannerBlurView}>
+                <View style={sx.bannerContent}>
+                  <LinearGradient colors={['#268FFF1F', '#268FFF14']} angle={135} useAngle style={sx.bannerGradient}>
+                    <Text color={{ custom: blue }} size="17pt" weight="heavy">
                       􀍱
                     </Text>
                   </LinearGradient>
@@ -212,14 +174,14 @@ const CustomizeNetworksBanner = !shouldShowCustomizeNetworksBanner(customizeNetw
                     </Text>
                   </Pressable>
                 </View>
-              </AnimatedBlurView>
+              </BlurView>
             </MaskedView>
           </Animated.View>
         </DesignSystemProvider>
       );
     };
 
-const BADGE_BORDER_COLORS = {
+const ALL_BADGE_BORDER_COLORS = {
   default: {
     dark: globalColors.white10,
     light: '#F2F3F4',
@@ -230,7 +192,7 @@ const BADGE_BORDER_COLORS = {
   },
 };
 
-const useNetworkOptionStyle = (isSelected: SharedValue<boolean>, color?: string) => {
+const useNetworkOptionStyle = (isSelected: SharedValue<boolean>, color?: string, disableScale = false) => {
   const { isDarkMode } = useColorMode();
   const label = useForegroundColor('labelTertiary');
 
@@ -253,11 +215,11 @@ const useNetworkOptionStyle = (isSelected: SharedValue<boolean>, color?: string)
 
   const scale = useSharedValue(1);
   useAnimatedReaction(
-    () => isSelected.value,
+    () => (disableScale ? false : isSelected.value),
     (current, prev) => {
       if (current === true && prev === false) {
         scale.value = withSequence(
-          withTiming(0.9, { duration: 120, easing: Easing.bezier(0.25, 0.46, 0.45, 0.94) }),
+          withTiming(0.93, { duration: 110, easing: Easing.bezier(0.25, 0.46, 0.45, 0.94) }),
           withTiming(1, TIMING_CONFIGS.fadeConfig)
         );
       }
@@ -291,115 +253,89 @@ function AllNetworksOption({
   const blue = useForegroundColor('blue');
 
   const isSelected = useDerivedValue(() => selected.value === undefined);
-  const { animatedStyle } = useNetworkOptionStyle(isSelected, blue);
+  const { animatedStyle } = useNetworkOptionStyle(isSelected, blue, true);
 
   const overlappingBadge = useAnimatedStyle(() => {
     return {
       borderColor: isSelected.value
-        ? BADGE_BORDER_COLORS.selected[isDarkMode ? 'dark' : 'light']
-        : BADGE_BORDER_COLORS.default[isDarkMode ? 'dark' : 'light'],
+        ? ALL_BADGE_BORDER_COLORS.selected[isDarkMode ? 'dark' : 'light']
+        : ALL_BADGE_BORDER_COLORS.default[isDarkMode ? 'dark' : 'light'],
     };
   });
 
   return (
     <GestureHandlerButton
+      hapticTrigger="tap-end"
       onPressWorklet={() => {
         'worklet';
         setSelected(undefined);
       }}
-      scaleTo={0.95}
+      scaleTo={0.94}
+      style={[sx.allNetworksButton, animatedStyle]}
     >
-      <Animated.View
-        style={[
-          {
-            height: ITEM_HEIGHT,
-            paddingHorizontal: 12,
-            flexDirection: 'row',
-            alignItems: 'center',
-            borderRadius: 24,
-            borderWidth: THICK_BORDER_WIDTH,
-            borderCurve: 'continuous',
-            overflow: 'hidden',
-          },
-          animatedStyle,
-        ]}
-      >
-        <View style={{ flexDirection: 'row', alignItems: 'center', position: 'absolute', marginLeft: 20 }}>
-          <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
-            <ChainImage chainId={ChainId.base} size={16} />
-          </Animated.View>
-          <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
-            <ChainImage chainId={ChainId.mainnet} size={16} />
-          </Animated.View>
-          <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
-            <ChainImage chainId={ChainId.optimism} size={16} />
-          </Animated.View>
-          <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
-            <ChainImage chainId={ChainId.arbitrum} size={16} />
-          </Animated.View>
-        </View>
-        <Text color="label" size="17pt" weight="bold" style={{ textAlign: 'center', flex: 1 }}>
-          {i18n.t(t.all_networks)}
-        </Text>
-      </Animated.View>
+      <View style={sx.allNetworksCoinIcons}>
+        <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
+          <ChainImage chainId={ChainId.base} size={16} />
+        </Animated.View>
+        <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
+          <ChainImage chainId={ChainId.mainnet} size={16} />
+        </Animated.View>
+        <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
+          <ChainImage chainId={ChainId.optimism} size={16} />
+        </Animated.View>
+        <Animated.View style={[sx.overlappingBadge, overlappingBadge]}>
+          <ChainImage chainId={ChainId.arbitrum} size={16} />
+        </Animated.View>
+      </View>
+      <Text align="center" color="label" size="17pt" weight="bold" style={sx.flex}>
+        {i18n.t(t.all_networks)}
+      </Text>
     </GestureHandlerButton>
   );
 }
 
 function AllNetworksSection({
   editing,
-  setSelected,
   selected,
+  setSelected,
 }: {
   editing: SharedValue<boolean>;
-  setSelected: (chainId: ChainId | undefined) => void;
   selected: SharedValue<ChainId | undefined>;
+  setSelected: (chainId: ChainId | undefined) => void;
 }) {
-  const style = useAnimatedStyle(() => ({
-    opacity: editing.value ? withTiming(0, TIMING_CONFIGS.fastFadeConfig) : withTiming(1, TIMING_CONFIGS.fastFadeConfig),
-    height: withTiming(
-      editing.value ? 0 : ITEM_HEIGHT + 14, // 14 is the gap to the separator
-      TIMING_CONFIGS.fastFadeConfig
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: withClamp(
+      { min: 0, max: ITEM_HEIGHT + 14 * 2 },
+      withSpring(
+        editing.value ? 0 : ITEM_HEIGHT + 14 * 2, // 14 is the gap to the separator
+        SPRING_CONFIGS.springConfig
+      )
     ),
-    marginTop: editing.value ? 0 : 14,
+    opacity: editing.value ? withSpring(0, SPRING_CONFIGS.snappierSpringConfig) : withTiming(1, TIMING_CONFIGS.slowerFadeConfig),
     pointerEvents: editing.value ? 'none' : 'auto',
   }));
+
   return (
-    <Animated.View style={[style, { gap: 14 }]}>
+    <Animated.View style={[sx.allNetworksContainer, animatedStyle]}>
       <AllNetworksOption selected={selected} setSelected={setSelected} />
-      <Separator color="separatorTertiary" direction="horizontal" thickness={1} />
+      <Inset horizontal="10px">
+        <Separator color="separatorTertiary" direction="horizontal" thickness={1} />
+      </Inset>
     </Animated.View>
   );
 }
 
 function NetworkOption({ chainId, selected }: { chainId: ChainId; selected: SharedValue<ChainId | undefined> }) {
   const { isDarkMode } = useColorMode();
-  const getColorsForChainId = useBackendNetworksStore(state => state.getColorsForChainId);
+  const chainColor = useBackendNetworksStore.getState().getColorsForChainId(chainId, isDarkMode);
   const chainName = useBackendNetworksStore.getState().getChainsLabel()[chainId];
-  const chainColor = getColorsForChainId(chainId, isDarkMode);
   const isSelected = useDerivedValue(() => selected.value === chainId);
   const { animatedStyle } = useNetworkOptionStyle(isSelected, chainColor);
 
   return (
-    <Animated.View
-      layout={LinearTransition.springify().mass(0.4)}
-      style={[
-        {
-          alignItems: 'center',
-          borderCurve: 'continuous',
-          borderRadius: 24,
-          borderWidth: THICK_BORDER_WIDTH,
-          flexDirection: 'row',
-          height: ITEM_HEIGHT,
-          overflow: 'hidden',
-          paddingHorizontal: 12,
-          width: ITEM_WIDTH,
-        },
-        animatedStyle,
-      ]}
-    >
+    <Animated.View layout={LinearTransition.springify().mass(0.4)} style={[sx.networkOption, animatedStyle]}>
       <ChainImage chainId={chainId} size={24} />
-      <Text color="label" size="17pt" weight="bold" style={{ textAlign: 'center', flex: 1 }}>
+      <Text align="center" color="label" size="17pt" weight="bold" style={sx.flex}>
         {chainName}
       </Text>
     </Animated.View>
@@ -407,11 +343,12 @@ function NetworkOption({ chainId, selected }: { chainId: ChainId; selected: Shar
 }
 
 const SHEET_OUTER_INSET = 8;
-const SHEET_INNER_PADDING = 16;
-const GAP = 12;
-const ITEM_WIDTH = (DEVICE_WIDTH - SHEET_INNER_PADDING * 2 - SHEET_OUTER_INSET * 2 - GAP) / 2;
+const SHEET_INNER_PADDING = 18;
+const ITEM_GAP = 12;
+const ITEM_WIDTH = (DEVICE_WIDTH - SHEET_INNER_PADDING * 2 - SHEET_OUTER_INSET * 2 - ITEM_GAP) / 2;
 const ITEM_HEIGHT = 48;
 const SEPARATOR_HEIGHT = 68;
+const SEPARATOR_HEIGHT_NETWORK_CHIP = 18;
 
 const ALL_NETWORKS_BADGE_SIZE = 16;
 const THICKER_BORDER_WIDTH = 5 / 3;
@@ -451,33 +388,29 @@ function Draggable({
     const itemIndex = networks.value[section].indexOf(chainId);
     const slotPosition = positionFromIndex(itemIndex, sectionsOffsets.value[section]);
 
-    const opacity =
-      section === Section.unpinned && isUnpinnedHidden.value
-        ? withTiming(0, TIMING_CONFIGS.fastFadeConfig)
-        : withDelay(100, withTiming(1, TIMING_CONFIGS.fadeConfig));
-
     const isBeingDragged = dragging.value?.chainId === chainId;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const position = isBeingDragged ? dragging.value!.position : slotPosition;
 
     return {
-      opacity,
-      zIndex: zIndex.value,
+      opacity: withSpring(section === Section.unpinned && isUnpinnedHidden.value ? 0 : 1, SPRING_CONFIGS.snappierSpringConfig),
       transform: [
-        { scale: withSpring(isBeingDragged ? 1.05 : 1, SPRING_CONFIGS.springConfig) },
         { translateX: isBeingDragged ? position.x : withSpring(position.x, SPRING_CONFIGS.springConfig) },
         { translateY: isBeingDragged ? position.y : withSpring(position.y, SPRING_CONFIGS.springConfig) },
+        { scale: withSpring(isBeingDragged ? 1.075 : 1, SPRING_CONFIGS.springConfig) },
       ],
+      zIndex: zIndex.value,
     };
   });
 
-  return <Animated.View style={[{ position: 'absolute' }, draggableStyles]}>{children}</Animated.View>;
+  return <Animated.View style={[sx.positionAbsolute, draggableStyles]}>{children}</Animated.View>;
 }
 
 const indexFromPosition = (x: number, y: number, offset: { y: number }) => {
   'worklet';
   const yoffsets = y > offset.y ? offset.y : 0;
-  const column = x > ITEM_WIDTH + GAP / 2 ? 1 : 0;
-  const row = Math.floor((y - yoffsets) / (ITEM_HEIGHT + GAP));
+  const column = x > ITEM_WIDTH + ITEM_GAP / 2 ? 1 : 0;
+  const row = Math.floor((y - yoffsets) / (ITEM_HEIGHT + ITEM_GAP));
   const index = row * 2 + column;
   return index < 0 ? 0 : index; // row can be negative if the dragged item is above the first row
 };
@@ -486,7 +419,7 @@ const positionFromIndex = (index: number, offset: { y: number }) => {
   'worklet';
   const column = index % 2;
   const row = Math.floor(index / 2);
-  const position = { x: column * (ITEM_WIDTH + GAP), y: row * (ITEM_HEIGHT + GAP) + offset.y };
+  const position = { x: column * (ITEM_WIDTH + ITEM_GAP), y: row * (ITEM_HEIGHT + ITEM_GAP) + offset.y };
   return position;
 };
 
@@ -497,21 +430,20 @@ type DraggingState = {
 };
 
 function SectionSeparator({
-  sectionsOffsets,
   editing,
   expanded,
   networks,
+  sectionsOffsets,
+  showExpandButtonAsNetworkChip,
 }: {
-  sectionsOffsets: SharedValue<Record<Section, { y: number }>>;
   editing: SharedValue<boolean>;
   expanded: SharedValue<boolean>;
   networks: SharedValue<Record<Section.pinned | Section.unpinned, ChainId[]>>;
+  sectionsOffsets: SharedValue<Record<Section, { y: number }>>;
+  showExpandButtonAsNetworkChip: SharedValue<boolean>;
 }) {
+  const { isDarkMode } = useColorMode();
   const pressed = useSharedValue(false);
-
-  const showExpandButtonAsNetworkChip = useDerivedValue(() => {
-    return !expanded.value && !editing.value && networks.value[Section.pinned].length % 2 !== 0;
-  });
 
   const visible = useDerivedValue(() => {
     return networks.value[Section.unpinned].length > 0 || editing.value;
@@ -523,8 +455,12 @@ function SectionSeparator({
       pressed.value = true;
     })
     .onEnd(() => {
-      pressed.value = false;
+      triggerHaptics('selection');
       expanded.value = !expanded.value;
+      pressed.value = false;
+    })
+    .onFinalize(() => {
+      if (pressed.value) pressed.value = false;
     });
 
   const text = useDerivedValue(() => {
@@ -534,13 +470,13 @@ function SectionSeparator({
   });
 
   const unpinnedNetworksLength = useDerivedValue(() => networks.value[Section.unpinned].length.toString());
-  const showMoreAmountStyle = useAnimatedStyle(() => ({
-    opacity: expanded.value || editing.value ? 0 : 1,
-  }));
-  const showMoreOrLessIcon = useDerivedValue(() => (expanded.value ? '􀆇' : '􀆈') as string);
-  const showMoreOrLessIconStyle = useAnimatedStyle(() => ({ opacity: editing.value ? 0 : 1 }));
+  const showMoreOrLessIcon = useDerivedValue<string>(() => (expanded.value ? '􀆇' : '􀆈'));
 
-  const { isDarkMode } = useColorMode();
+  const showMoreOrLessIconStyle = useAnimatedStyle(() => ({ opacity: editing.value ? 0 : 1 }));
+  const showMoreAmountStyle = useAnimatedStyle(() => ({
+    opacity: withSpring(expanded.value || editing.value ? 0 : 1, SPRING_CONFIGS.snappierSpringConfig),
+    width: expanded.value ? 0 : parseFloat(unpinnedNetworksLength.value) >= 10 ? 30 : 24,
+  }));
 
   const separatorContainerStyles = useAnimatedStyle(() => {
     if (showExpandButtonAsNetworkChip.value) {
@@ -549,87 +485,68 @@ function SectionSeparator({
         backgroundColor: isDarkMode ? globalColors.white10 : globalColors.grey20,
         borderColor: '#F5F8FF05',
         height: ITEM_HEIGHT,
-        width: ITEM_WIDTH,
-        flexDirection: 'row',
-        alignItems: 'center',
-        borderRadius: 24,
-        borderWidth: THICK_BORDER_WIDTH,
+        opacity: visible.value ? 1 : 0,
         transform: [{ translateX: position.x }, { translateY: position.y }],
+        width: ITEM_WIDTH,
       };
     }
 
     return {
       backgroundColor: 'transparent',
-      opacity: visible.value ? 1 : 0,
-      transform: [{ translateY: sectionsOffsets.value[Section.separator].y }, { scale: withTiming(pressed.value ? 0.95 : 1) }],
-      position: 'absolute',
-      width: '100%',
+      borderColor: 'transparent',
       height: SEPARATOR_HEIGHT,
+      opacity: visible.value ? 1 : 0,
+      transform: [
+        { translateY: sectionsOffsets.value[Section.separator].y },
+        { scale: withTiming(pressed.value ? 0.925 : 1, TIMING_CONFIGS.buttonPressConfig) },
+      ],
+      width: '100%',
     };
   });
 
   return (
     <GestureDetector gesture={tapExpand}>
-      <Animated.View style={[separatorContainerStyles, { gap: 8, justifyContent: 'center', alignItems: 'center', flexDirection: 'row' }]}>
-        <Animated.View
-          style={[
-            {
-              backgroundColor: isDarkMode ? '#F5F8FF05' : '#1B1D1F0f',
-              height: 24,
-              width: 24,
-              borderRadius: 12,
-              alignItems: 'center',
-              justifyContent: 'center',
-            },
-            showMoreAmountStyle,
-          ]}
-        >
-          <AnimatedText color="labelQuaternary" weight="bold" size="15pt" align="center">
+      <Animated.View style={[sx.sectionSeparatorContainer, separatorContainerStyles]}>
+        <Animated.View style={[sx.networkCountBadge, { backgroundColor: isDarkMode ? '#F5F8FF05' : '#1B1D1F0f' }, showMoreAmountStyle]}>
+          <AnimatedText align="center" color="labelQuaternary" size="15pt" weight="bold">
             {unpinnedNetworksLength}
           </AnimatedText>
         </Animated.View>
-        <AnimatedText color="labelQuaternary" weight="bold" size="17pt">
+        <AnimatedText align="center" color="labelQuaternary" size="17pt" weight="bold">
           {text}
         </AnimatedText>
-        <Animated.View style={[{ width: 24, justifyContent: 'center' }, showMoreOrLessIconStyle]}>
-          <AnimatedText color="labelQuaternary" weight="heavy" size="13pt">
-            {showMoreOrLessIcon}
-          </AnimatedText>
-        </Animated.View>
+        <AnimatedTextIcon color="labelQuaternary" size="13pt" textStyle={showMoreOrLessIconStyle} weight="heavy" width={16}>
+          {showMoreOrLessIcon}
+        </AnimatedTextIcon>
       </Animated.View>
     </GestureDetector>
   );
 }
 
 function EmptyUnpinnedPlaceholder({
-  sectionsOffsets,
-  networks,
   isUnpinnedHidden,
+  networks,
+  sectionsOffsets,
 }: {
-  sectionsOffsets: SharedValue<Record<Section, { y: number }>>;
-  networks: SharedValue<Record<Section.pinned | Section.unpinned, ChainId[]>>;
   isUnpinnedHidden: SharedValue<boolean>;
+  networks: SharedValue<Record<Section.pinned | Section.unpinned, ChainId[]>>;
+  sectionsOffsets: SharedValue<Record<Section, { y: number }>>;
 }) {
-  const styles = useAnimatedStyle(() => {
+  const { isDarkMode } = useColorMode();
+  const animatedStyle = useAnimatedStyle(() => {
     const isVisible = networks.value[Section.unpinned].length === 0 && !isUnpinnedHidden.value;
     return {
-      opacity: isVisible ? withTiming(1, { duration: 800 }) : 0,
+      opacity: withSpring(isVisible ? 0.5 : 0, SPRING_CONFIGS.snappierSpringConfig),
       transform: [{ translateY: sectionsOffsets.value[Section.unpinned].y }],
     };
   });
-  const { isDarkMode } = useColorMode();
+
   return (
     <Animated.View
-      style={[
-        { height: 48, width: '100%' },
-        { paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center' },
-        { borderRadius: 24, borderWidth: THICK_BORDER_WIDTH },
-        { backgroundColor: isDarkMode ? globalColors.white10 : globalColors.grey20, borderColor: '#F5F8FF05' },
-        styles,
-      ]}
+      style={[sx.emptyUnpinnedPlaceholder, { backgroundColor: isDarkMode ? globalColors.white10 : globalColors.grey20 }, animatedStyle]}
     >
-      <Text color="labelQuaternary" size="15pt" weight="semibold" align="center" style={{ flex: 1 }}>
-        {i18n.t(t.drag_here_to_unpin)}
+      <Text align="center" color="labelQuaternary" size="17pt" style={sx.flex} weight="bold">
+        {i18n.t(t.drop_here_to_unpin)}
       </Text>
     </Animated.View>
   );
@@ -637,12 +554,12 @@ function EmptyUnpinnedPlaceholder({
 
 function NetworksGrid({
   editing,
-  setSelected,
   selected,
+  setSelected,
 }: {
   editing: SharedValue<boolean>;
-  setSelected: (chainId: ChainId | undefined) => void;
   selected: SharedValue<ChainId | undefined>;
+  setSelected: (chainId: ChainId | undefined) => void;
 }) {
   const initialPinned = networkSwitcherStore.getState().pinnedNetworks;
   const sortedSupportedChainIds = useBackendNetworksStore.getState().getSortedSupportedChainIds();
@@ -662,33 +579,38 @@ function NetworksGrid({
   }, [networks]);
 
   const expanded = useSharedValue(false);
+  const dragging = useSharedValue<DraggingState | null>(null);
   const isUnpinnedHidden = useDerivedValue(() => !expanded.value && !editing.value);
 
-  const dragging = useSharedValue<DraggingState | null>(null);
+  const showExpandButtonAsNetworkChip = useDerivedValue(() => {
+    return !expanded.value && !editing.value && networks.value[Section.pinned].length % 2 !== 0;
+  });
 
   const sectionsOffsets = useDerivedValue(() => {
-    const pinnedHeight = Math.ceil(networks.value[Section.pinned].length / 2) * (ITEM_HEIGHT + GAP) - GAP;
+    const pinnedHeight = Math.ceil(networks.value[Section.pinned].length / 2) * (ITEM_HEIGHT + ITEM_GAP) - ITEM_GAP;
     return {
       [Section.pinned]: { y: 0 },
       [Section.separator]: { y: pinnedHeight },
-      [Section.unpinned]: { y: pinnedHeight + SEPARATOR_HEIGHT },
+      [Section.unpinned]: { y: pinnedHeight + (showExpandButtonAsNetworkChip.value ? SEPARATOR_HEIGHT_NETWORK_CHIP : SEPARATOR_HEIGHT) },
     };
   });
+
   const containerHeight = useDerivedValue(() => {
     const length = networks.value[Section.unpinned].length;
-    const paddingBottom = 32;
+    const paddingBottom = 18;
     const unpinnedHeight = isUnpinnedHidden.value
       ? length === 0
         ? -SEPARATOR_HEIGHT + paddingBottom
         : 0
       : length === 0
         ? ITEM_HEIGHT + paddingBottom
-        : Math.ceil((length + 1) / 2) * (ITEM_HEIGHT + GAP) - GAP + paddingBottom;
+        : Math.ceil((length + (editing.value ? 1 : 0)) / 2) * (ITEM_HEIGHT + ITEM_GAP) - ITEM_GAP + paddingBottom;
     const height = sectionsOffsets.value[Section.unpinned].y + unpinnedHeight;
     return height;
   });
+
   const containerStyle = useAnimatedStyle(() => ({
-    height: withDelay(expanded.value ? 0 : 25, withTiming(containerHeight.value, TIMING_CONFIGS.slowerFadeConfig)),
+    height: withSpring(containerHeight.value, SPRING_CONFIGS.springConfig),
   }));
 
   const dragNetwork = Gesture.Pan()
@@ -711,6 +633,7 @@ function NetworksGrid({
       }
 
       const position = positionFromIndex(index, sectionOffset);
+      triggerHaptics('soft');
       dragging.value = { chainId, position };
     })
     .onChange(e => {
@@ -732,6 +655,7 @@ function NetworksGrid({
           networks[Section.unpinned] = sortedSupportedChainIds.filter(chainId => !networks[Section.pinned].includes(chainId));
         } else if (section === Section.pinned && newIndex !== currentIndex) {
           // Reorder
+          triggerHaptics('selection');
           networks[Section.pinned].splice(currentIndex, 1);
           networks[Section.pinned].splice(newIndex, 0, chainId);
         }
@@ -758,6 +682,7 @@ function NetworksGrid({
       const chainId = networks.value[section][index];
       if (!chainId) return;
 
+      triggerHaptics('selection');
       setSelected(chainId);
     });
 
@@ -779,7 +704,13 @@ function NetworksGrid({
           </Draggable>
         ))}
 
-        <SectionSeparator sectionsOffsets={sectionsOffsets} expanded={expanded} editing={editing} networks={networks} />
+        <SectionSeparator
+          editing={editing}
+          expanded={expanded}
+          networks={networks}
+          sectionsOffsets={sectionsOffsets}
+          showExpandButtonAsNetworkChip={showExpandButtonAsNetworkChip}
+        />
 
         <EmptyUnpinnedPlaceholder sectionsOffsets={sectionsOffsets} networks={networks} isUnpinnedHidden={isUnpinnedHidden} />
 
@@ -840,33 +771,160 @@ export function NetworkSelector() {
   return (
     <Sheet editing={editing} onClose={onClose}>
       <CustomizeNetworksBanner editing={editing} />
-      <AllNetworksSection editing={editing} setSelected={setSelected} selected={selected} />
-      <NetworksGrid editing={editing} setSelected={setSelected} selected={selected} />
+      <AllNetworksSection editing={editing} selected={selected} setSelected={setSelected} />
+      <NetworksGrid editing={editing} selected={selected} setSelected={setSelected} />
     </Sheet>
   );
 }
 
 const sx = StyleSheet.create({
+  allNetworksButton: {
+    alignItems: 'center',
+    borderCurve: 'continuous',
+    borderRadius: 24,
+    borderWidth: THICK_BORDER_WIDTH,
+    flexDirection: 'row',
+    height: ITEM_HEIGHT,
+    overflow: 'hidden',
+    paddingHorizontal: 12,
+  },
+  allNetworksCoinIcons: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginLeft: 20,
+    position: 'absolute',
+  },
+  allNetworksContainer: {
+    gap: 14,
+    justifyContent: 'flex-end',
+  },
+  banner: {
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: -(BANNER_HEIGHT + 14),
+  },
+  bannerBlurView: {
+    height: BANNER_HEIGHT,
+  },
+  bannerContent: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 12,
+    height: 68,
+    marginTop: 68 - BANNER_HEIGHT,
+    padding: 16 + 12,
+  },
+  bannerGradient: {
+    alignItems: 'center',
+    backgroundColor: '#268FFF14',
+    borderColor: '#268FFF0D',
+    borderRadius: 10,
+    borderWidth: 1,
+    height: 36,
+    justifyContent: 'center',
+    width: 36,
+  },
+  editButton: {
+    borderCurve: 'continuous',
+    borderRadius: 14,
+    borderWidth: THICK_BORDER_WIDTH,
+    height: 28,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    paddingHorizontal: 10 - THICK_BORDER_WIDTH,
+    position: 'absolute',
+    right: 4,
+    top: IS_IOS ? 0 : -14,
+  },
+  emptyUnpinnedPlaceholder: {
+    alignItems: 'center',
+    borderColor: '#F5F8FF05',
+    borderRadius: 24,
+    borderWidth: THICK_BORDER_WIDTH,
+    flexDirection: 'row',
+    height: 48,
+    paddingHorizontal: 12,
+    width: '100%',
+  },
+  flex: {
+    flex: 1,
+  },
+  headerContainer: {
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    height: 66,
+    paddingTop: 20,
+    width: '100%',
+  },
+  headerContent: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    height: 28,
+    justifyContent: 'center',
+  },
+  networkCountBadge: {
+    alignItems: 'center',
+    borderRadius: 12,
+    height: 24,
+    justifyContent: 'center',
+    width: 24,
+  },
+  networkOption: {
+    alignItems: 'center',
+    borderCurve: 'continuous',
+    borderRadius: 24,
+    borderWidth: THICK_BORDER_WIDTH,
+    flexDirection: 'row',
+    height: ITEM_HEIGHT,
+    overflow: 'hidden',
+    paddingHorizontal: 12,
+    width: ITEM_WIDTH,
+  },
   overlappingBadge: {
-    borderWidth: THICKER_BORDER_WIDTH,
     borderRadius: ALL_NETWORKS_BADGE_SIZE,
+    borderWidth: THICKER_BORDER_WIDTH,
+    height: ALL_NETWORKS_BADGE_SIZE + THICKER_BORDER_WIDTH * 2,
     marginLeft: -9,
     width: ALL_NETWORKS_BADGE_SIZE + THICKER_BORDER_WIDTH * 2,
-    height: ALL_NETWORKS_BADGE_SIZE + THICKER_BORDER_WIDTH * 2,
+  },
+  positionAbsolute: {
+    position: 'absolute',
+  },
+  sectionSeparatorContainer: {
+    alignItems: 'center',
+    borderRadius: 24,
+    borderWidth: THICK_BORDER_WIDTH,
+    flexDirection: 'row',
+    gap: 8,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    position: 'absolute',
   },
   sheet: {
-    flex: 1,
-    width: deviceUtils.dimensions.width - 16,
-    bottom: Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30),
-    pointerEvents: 'box-none',
-    position: 'absolute',
-    zIndex: 30000,
-    left: 8,
-    right: 8,
-    paddingHorizontal: 16,
     borderCurve: 'continuous',
     borderRadius: 42,
     borderWidth: THICK_BORDER_WIDTH,
+    bottom: Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30),
+    flex: 1,
+    left: 8,
     overflow: 'hidden',
+    paddingHorizontal: 16,
+    pointerEvents: 'box-none',
+    position: 'absolute',
+    right: 8,
+    width: deviceUtils.dimensions.width - 16,
+    zIndex: 30000,
+  },
+  sheetHandle: {
+    alignSelf: 'center',
+    borderCurve: 'continuous',
+    borderRadius: 3,
+    height: 5,
+    overflow: 'hidden',
+    position: 'absolute',
+    top: 6,
+    width: 36,
   },
 });

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3076,8 +3076,9 @@
         "tap_the": "Tap the",
         "button_to_set_up": "button below to set up"
       },
-      "drag_here_to_unpin": "Drop Here to Unpin",
+      "drop_here_to_unpin": "Drop Here to Unpin",
       "edit": "Edit",
+      "network": "Network",
       "networks": "Networks",
       "drag_to_rearrange": "Drag to Rearrange",
       "show_less": "Show Less",


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Cleans up the trending tokens and network switcher UIs
- Fixes an Android text wrapping bug caused by `alignItems: 'baseline'` in trending tokens coin rows
- Simplifies the trending tokens loading skeleton
- Fixes an issue causing the last selected network to be forgotten in the network switcher
- Fixes x/y positioning of dragged networks in the network switcher
- Improves network switcher animations and corrects sheet sizing
- Adds haptics to the network switcher
- Minor code cleanup

## Screen recordings / screenshots


## What to test

