### PR TITLE
version bump to 1.9.52 / versionCode 246 + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
+## [1.9.51] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.51)
+
+### Added
+
+- Retrieve FID for wallet addresses (#6330)
+- Network Expansion (#6334)
+- Track token lists (#6303)
+- Add default option to dropdown menu for sort (#6359)
+
+### Changed
+
+- User assets migration (#6038)
+- Trending tokens polishes (#6331)
+- Convert `networkColors` to backendNetworks (#6353)
+- Trending tokens / network switcher cleanup (#6372)
+- Backups V2 Follow-up Fixes / Improvements (#6213)
+- Change logic around when to parse into our native formatter (#6360)
+- Support only persisting when search query is undefined (#6358)
+- Use positions value from summary for wallet balance (#6358)
+- Remove zustand selectors that return objects (#6355)
+- Add trending tokens flag to remote config.ts (#6373)
+- Fix and others i18n (#6367)
+
+### Removed
+
+- Trending tokens + network selector + explain sheet remove local networks (#6367)
+
+### Fixed
+
+- Icons hotfixes (#6342, #6345)
+- Selected state for network, timeframe, sort (#6352)
+- Time filters and default to D3 (#6362)
+- Network colors for network switcher (#6361)
+- Prevent backup prompt from firing on import (#6364)
+
 ## [1.9.50] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.50)
 
 ### Fixed

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,8 +135,8 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 244
-        versionName "1.9.51"
+        versionCode 246
+        versionName "1.9.52"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
         renderscriptSupportModeEnabled true

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1883,7 +1883,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.51;
+				MARKETING_VERSION = 1.9.52;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1951,7 +1951,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.51;
+				MARKETING_VERSION = 1.9.52;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2072,7 +2072,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.51;
+				MARKETING_VERSION = 1.9.52;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2192,7 +2192,7 @@
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.9.51;
+				MARKETING_VERSION = 1.9.52;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "1.9.51-1",
+  "version": "1.9.52-1",
   "private": true,
   "scripts": {
     "setup": "yarn graphql-codegen:install && yarn ds:install && yarn allow-scripts && yarn graphql-codegen && yarn fetch:networks",


### PR DESCRIPTION
# Version bumps:
1.9.51 >> 1.9.52
244 >> 246 (had to resubmit so skipping a version)

# Change log:

## [1.9.51] (https://github.com/rainbow-me/rainbow/releases/tag/v1.9.51)

### Added

- Retrieve FID for wallet addresses (#6330)
- Network Expansion (#6334)
- Track token lists (#6303)
- Add default option to dropdown menu for sort (#6359)

### Changed

- User assets migration (#6038)
- Trending tokens polishes (#6331)
- Convert `networkColors` to backendNetworks (#6353)
- Trending tokens / network switcher cleanup (#6372)
- Backups V2 Follow-up Fixes / Improvements (#6213)
- Change logic around when to parse into our native formatter (#6360)
- Support only persisting when search query is undefined (#6358)
- Use positions value from summary for wallet balance (#6358)
- Remove zustand selectors that return objects (#6355)
- Add trending tokens flag to remote config.ts (#6373)
- Fix and others i18n (#6367)

### Removed

- Trending tokens + network selector + explain sheet remove local networks (#6367)

### Fixed

- Icons hotfixes (#6342, #6345)
- Selected state for network, timeframe, sort (#6352)
- Time filters and default to D3 (#6362)
- Network colors for network switcher (#6361)
- Prevent backup prompt from firing on import (#6364)