### PR TITLE
add imported check on backup prompt

### DIFF
--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -47,7 +47,13 @@ export const runWalletBackupStatusChecks = async (): Promise<boolean> => {
   const { selected } = store.getState().wallets;
   if (!selected || IS_TEST) return false;
 
-  if (!selected.backedUp && !selected.damaged && selected.type !== WalletTypes.readOnly && selected.type !== WalletTypes.bluetooth) {
+  if (
+    !selected.backedUp &&
+    !selected.damaged &&
+    !selected.imported &&
+    selected.type !== WalletTypes.readOnly &&
+    selected.type !== WalletTypes.bluetooth
+  ) {
     logger.debug('[walletReadyEvents]: Selected wallet is not backed up, prompting backup sheet');
     return promptForBackupOnceReadyOrNotAvailable();
   }

--- a/src/screens/SettingsSheet/components/Backups/WalletsAndBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/WalletsAndBackup.tsx
@@ -10,7 +10,7 @@ import WalletBackupTypes from '@/helpers/walletBackupTypes';
 import WalletTypes, { EthereumWalletType } from '@/helpers/walletTypes';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { useENSAvatar, useInitializeWallet, useManageCloudBackups, useWallets } from '@/hooks';
-import { useNavigation } from '@/navigation';
+import { Navigation, useNavigation } from '@/navigation';
 import { abbreviations, deviceUtils } from '@/utils';
 import { addressHashedEmoji } from '@/utils/profileUtils';
 import * as i18n from '@/languages';
@@ -38,6 +38,7 @@ import { executeFnIfCloudBackupAvailable } from '@/model/backup';
 import { walletLoadingStore } from '@/state/walletLoading/walletLoading';
 import { AbsolutePortalRoot } from '@/components/AbsolutePortal';
 import { FlatList, ScrollView } from 'react-native';
+import walletBackupStepTypes from '@/helpers/walletBackupStepTypes';
 
 type WalletPillProps = {
   account: RainbowAccount;
@@ -198,6 +199,9 @@ export const WalletsAndBackup = () => {
             loadingState: null,
           });
           scrollviewRef.current?.scrollTo({ y: 0, animated: true });
+          Navigation.handleAction(Routes.BACKUP_SHEET, {
+            step: walletBackupStepTypes.backup_prompt,
+          });
         }
       },
     });


### PR DESCRIPTION
Fixes APP-2240

## What changed (plus any additional context for devs)
Prevents the backup prompt from firing for imported wallets

## Screen recordings / screenshots


## What to test
backup prompt annoyances
