### PR TITLE
Fix nft icon sheet present & prioritize backup sheet 

### DIFF
--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -88,13 +88,13 @@ export const runFeatureUnlockChecks = async (): Promise<boolean> => {
 };
 
 export const runFeaturesLocalCampaignAndBackupChecks = async () => {
-  if (await runWalletBackupStatusChecks()) {
-    return true;
-  }
   if (await runFeatureUnlockChecks()) {
     return true;
   }
   if (await runLocalCampaignChecks()) {
+    return true;
+  }
+  if (await runWalletBackupStatusChecks()) {
     return true;
   }
 

--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -88,13 +88,13 @@ export const runFeatureUnlockChecks = async (): Promise<boolean> => {
 };
 
 export const runFeaturesLocalCampaignAndBackupChecks = async () => {
+  if (await runWalletBackupStatusChecks()) {
+    return true;
+  }
   if (await runFeatureUnlockChecks()) {
     return true;
   }
   if (await runLocalCampaignChecks()) {
-    return true;
-  }
-  if (await runWalletBackupStatusChecks()) {
     return true;
   }
 


### PR DESCRIPTION
Fixes APP-2241

## What changed (plus any additional context for devs)
- Prioritizes showing backup sheet on app startup over nft icon unlocks
- Wraps nft icon unlock sheet navigation in `triggerOnSwipeLayout`, removing previous setTimeout hack. 