### PR TITLE
Prevent Google OAuth prompt on app launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "react-native-branch": "5.3.1",
     "react-native-change-icon": "4.0.0",
     "react-native-circular-progress": "1.3.8",
-    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#d890deeaa0bb21c1679addbcfb5db9b98c36024d",
+    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#247c245ff4da8de5bde47b627831798b49087868",
     "react-native-crypto": "2.2.0",
     "react-native-dark-mode": "0.2.2",
     "react-native-device-info": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "react-native-branch": "5.3.1",
     "react-native-change-icon": "4.0.0",
     "react-native-circular-progress": "1.3.8",
-    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#247c245ff4da8de5bde47b627831798b49087868",
+    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#d73f055c441566e5a57eebd621da8df3cf2499bb",
     "react-native-crypto": "2.2.0",
     "react-native-dark-mode": "0.2.2",
     "react-native-device-info": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "react-native-branch": "5.3.1",
     "react-native-change-icon": "4.0.0",
     "react-native-circular-progress": "1.3.8",
-    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#9b204615b76cf3d29bd86a9094dbd95d717b6a7a",
+    "react-native-cloud-fs": "rainbow-me/react-native-cloud-fs#d890deeaa0bb21c1679addbcfb5db9b98c36024d",
     "react-native-crypto": "2.2.0",
     "react-native-dark-mode": "0.2.2",
     "react-native-device-info": "5.3.1",

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -43,7 +43,8 @@ export async function getGoogleAccountUserData(checkPermissions = false): Promis
   if (!IS_ANDROID) {
     return;
   }
-  return RNCloudFs.getCurrentlySignedInUserData({ checkPermissions });
+  const options = { checkPermissions };
+  return RNCloudFs.getCurrentlySignedInUserData(options);
 }
 
 // This is used for dev purposes only!

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -43,7 +43,7 @@ export async function getGoogleAccountUserData(): Promise<GoogleDriveUserData | 
   if (!IS_ANDROID) {
     return;
   }
-  return RNCloudFs.getCurrentlySignedInUserData();
+  return RNCloudFs.getCurrentlySignedInUserData({ checkPermissions: true });
 }
 
 // This is used for dev purposes only!

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -39,11 +39,11 @@ export type GoogleDriveUserData = {
   avatarUrl?: string;
 };
 
-export async function getGoogleAccountUserData(): Promise<GoogleDriveUserData | undefined> {
+export async function getGoogleAccountUserData(checkPermissions = false): Promise<GoogleDriveUserData | undefined> {
   if (!IS_ANDROID) {
     return;
   }
-  return RNCloudFs.getCurrentlySignedInUserData({ checkPermissions: true });
+  return RNCloudFs.getCurrentlySignedInUserData({ checkPermissions });
 }
 
 // This is used for dev purposes only!

--- a/src/state/backups/backups.ts
+++ b/src/state/backups/backups.ts
@@ -145,6 +145,16 @@ export const backupsStore = createRainbowStore<BackupsStore>((set, get) => ({
           error: e,
         });
         set({ status: CloudBackupState.FailedToInitialize });
+
+        // See https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInStatusCodes#public-static-final-int-sign_in_cancelled
+        const stringifiedError = JSON.stringify(e);
+        if (stringifiedError.includes('12501')) {
+          logger.warn('[backupsStore]: Google sign in / oauth cancelled');
+          return {
+            success: false,
+            retry: false,
+          };
+        }
       }
 
       return {

--- a/src/state/backups/backups.ts
+++ b/src/state/backups/backups.ts
@@ -98,7 +98,7 @@ export const backupsStore = createRainbowStore<BackupsStore>((set, get) => ({
         }
 
         if (IS_ANDROID) {
-          const gdata = await getGoogleAccountUserData();
+          const gdata = await getGoogleAccountUserData(true);
           if (!gdata) {
             logger.debug('[backupsStore]: Google account is not available');
             set({ backupProvider: undefined, status: CloudBackupState.NotAvailable, backups: { files: [] }, mostRecentBackup: undefined });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,7 +8882,7 @@ __metadata:
     react-native-branch: "npm:5.3.1"
     react-native-change-icon: "npm:4.0.0"
     react-native-circular-progress: "npm:1.3.8"
-    react-native-cloud-fs: "rainbow-me/react-native-cloud-fs#d890deeaa0bb21c1679addbcfb5db9b98c36024d"
+    react-native-cloud-fs: "rainbow-me/react-native-cloud-fs#247c245ff4da8de5bde47b627831798b49087868"
     react-native-crypto: "npm:2.2.0"
     react-native-dark-mode: "npm:0.2.2"
     react-native-device-info: "npm:5.3.1"
@@ -22280,10 +22280,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-cloud-fs@rainbow-me/react-native-cloud-fs#d890deeaa0bb21c1679addbcfb5db9b98c36024d":
+"react-native-cloud-fs@rainbow-me/react-native-cloud-fs#247c245ff4da8de5bde47b627831798b49087868":
   version: 2.6.2
-  resolution: "react-native-cloud-fs@https://github.com/rainbow-me/react-native-cloud-fs.git#commit=d890deeaa0bb21c1679addbcfb5db9b98c36024d"
-  checksum: 10c0/4ee21476080754953bdd88adb6242339fe13cfe5fd98f64767e301a59a04f035d6072959945d516487080afa5075ca683d035d7501328de13fc069fca08e3d3a
+  resolution: "react-native-cloud-fs@https://github.com/rainbow-me/react-native-cloud-fs.git#commit=247c245ff4da8de5bde47b627831798b49087868"
+  checksum: 10c0/0d78db6a3978bf9a0fe485d2dc0cf80fb1185a63eec1d22d7e3afd6c693417b011779d8318c603a9a81ff6c9c67f194dd469fc16a220ac0cd2b9b1ec374f1e2b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,7 +8882,7 @@ __metadata:
     react-native-branch: "npm:5.3.1"
     react-native-change-icon: "npm:4.0.0"
     react-native-circular-progress: "npm:1.3.8"
-    react-native-cloud-fs: "rainbow-me/react-native-cloud-fs#9b204615b76cf3d29bd86a9094dbd95d717b6a7a"
+    react-native-cloud-fs: "rainbow-me/react-native-cloud-fs#d890deeaa0bb21c1679addbcfb5db9b98c36024d"
     react-native-crypto: "npm:2.2.0"
     react-native-dark-mode: "npm:0.2.2"
     react-native-device-info: "npm:5.3.1"
@@ -22280,10 +22280,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-cloud-fs@rainbow-me/react-native-cloud-fs#9b204615b76cf3d29bd86a9094dbd95d717b6a7a":
+"react-native-cloud-fs@rainbow-me/react-native-cloud-fs#d890deeaa0bb21c1679addbcfb5db9b98c36024d":
   version: 2.6.2
-  resolution: "react-native-cloud-fs@https://github.com/rainbow-me/react-native-cloud-fs.git#commit=9b204615b76cf3d29bd86a9094dbd95d717b6a7a"
-  checksum: 10c0/db1c719b90475201aa1e1177209723598ac38689a827d387dd281ea5190ad09f3e6c8fee77caff70b46a228b6552459d9a9e73e4159c18a29d19d235e17d7907
+  resolution: "react-native-cloud-fs@https://github.com/rainbow-me/react-native-cloud-fs.git#commit=d890deeaa0bb21c1679addbcfb5db9b98c36024d"
+  checksum: 10c0/4ee21476080754953bdd88adb6242339fe13cfe5fd98f64767e301a59a04f035d6072959945d516487080afa5075ca683d035d7501328de13fc069fca08e3d3a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,7 +8882,7 @@ __metadata:
     react-native-branch: "npm:5.3.1"
     react-native-change-icon: "npm:4.0.0"
     react-native-circular-progress: "npm:1.3.8"
-    react-native-cloud-fs: "rainbow-me/react-native-cloud-fs#247c245ff4da8de5bde47b627831798b49087868"
+    react-native-cloud-fs: "rainbow-me/react-native-cloud-fs#d73f055c441566e5a57eebd621da8df3cf2499bb"
     react-native-crypto: "npm:2.2.0"
     react-native-dark-mode: "npm:0.2.2"
     react-native-device-info: "npm:5.3.1"
@@ -22280,9 +22280,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-cloud-fs@rainbow-me/react-native-cloud-fs#247c245ff4da8de5bde47b627831798b49087868":
+"react-native-cloud-fs@rainbow-me/react-native-cloud-fs#d73f055c441566e5a57eebd621da8df3cf2499bb":
   version: 2.6.2
-  resolution: "react-native-cloud-fs@https://github.com/rainbow-me/react-native-cloud-fs.git#commit=247c245ff4da8de5bde47b627831798b49087868"
+  resolution: "react-native-cloud-fs@https://github.com/rainbow-me/react-native-cloud-fs.git#commit=d73f055c441566e5a57eebd621da8df3cf2499bb"
   checksum: 10c0/0d78db6a3978bf9a0fe485d2dc0cf80fb1185a63eec1d22d7e3afd6c693417b011779d8318c603a9a81ff6c9c67f194dd469fc16a220ac0cd2b9b1ec374f1e2b
   languageName: node
   linkType: hard


### PR DESCRIPTION
Fixes APP-2239

## What changed (plus any additional context for devs)
If the user had pending OAuth permissions, our backups sync would spam them due to the nature of how we retry on failures. We now prevent the prompt if they don't have permissions enabled, and if it does prompt we detect the cancellation and only prompt once instead of falling through the `try...catch` block.

## Screen recordings / screenshots
will try to capture one soon

## What to test
https://rainbowhaus.slack.com/archives/C02C2FVC6N6/p1735921689825149?thread_ts=1735501963.465679&cid=C02C2FVC6N6
