### PR TITLE
Fix swap submit button getting stuck on 'Fetching'

### DIFF
--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -163,6 +163,7 @@ function deserializeUserAssetsState(serializedState: string) {
   }
 
   const { state, version } = parsedState;
+  let userAssetsDataExists = false;
 
   let chainBalances = new Map<ChainId, number>();
   try {
@@ -186,6 +187,7 @@ function deserializeUserAssetsState(serializedState: string) {
   try {
     if (state.userAssets.length) {
       userAssetsData = new Map(state.userAssets);
+      userAssetsDataExists = true;
     }
   } catch (error) {
     logger.error(new RainbowError(`[userAssetsStore]: Failed to convert userAssets from user assets storage`), { error });
@@ -205,6 +207,7 @@ function deserializeUserAssetsState(serializedState: string) {
       ...state,
       chainBalances,
       idsByChain,
+      isLoadingUserAssets: !userAssetsDataExists,
       userAssets: userAssetsData,
       hiddenAssets,
     },


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- `isLoadingUserAssets` was being reset to `true` during app launch, and not set to `false` until user assets data was next fetched and set via RQ, resulting in the swap submit button often getting stuck in a 'Fetching' state after a fresh app launch (until the next user assets fetch)
- This is where it's causing the swap submit button issue: https://github.com/rainbow-me/rainbow/blob/3bb8e9af8c124215641750f0e4e12dffc5da2a39/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx#L192

## Screen recordings / screenshots


## What to test

