### PR TITLE
Fix redacted icon on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -260,7 +260,7 @@
           </intent-filter>
       </activity-alias>
       <activity-alias
-          android:name="me.rainbow.MainActivityRedacted"
+          android:name="me.rainbow.MainActivityredacted"
           android:enabled="false"
           android:icon="@mipmap/redacted"
           android:roundIcon="@mipmap/redacted_round"


### PR DESCRIPTION
Fixes APP-2204

## What changed (plus any additional context for devs)
There was a typo on the activity name, which was preventing the icon to be selected on Android.


## Screen recordings / screenshots


https://github.com/user-attachments/assets/e440f092-8a5e-471f-b11d-638f01f1e57c



## What to test
Select the redacted icon on android
