### PR TITLE
Make transaction request parameters less rigid

### DIFF
--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -113,7 +113,6 @@ export function createTransport<TPayload, TResponse>({ messenger, topic }: { mes
  * @returns {boolean}
  */
 const messengerProviderRequestFn = async (messenger: Messenger, request: ProviderRequestPayload) => {
-  console.log(JSON.stringify(request, null, 2));
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host: getDappHost(request.meta?.sender.url) || '' });
   const appSession =
     hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]

--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -113,6 +113,7 @@ export function createTransport<TPayload, TResponse>({ messenger, topic }: { mes
  * @returns {boolean}
  */
 const messengerProviderRequestFn = async (messenger: Messenger, request: ProviderRequestPayload) => {
+  console.log(JSON.stringify(request, null, 2));
   const hostSessions = useAppSessionsStore.getState().getActiveSession({ host: getDappHost(request.meta?.sender.url) || '' });
   const appSession =
     hostSessions && hostSessions.sessions?.[hostSessions.activeSessionAddress]

--- a/src/components/Transactions/TransactionMessageCard.tsx
+++ b/src/components/Transactions/TransactionMessageCard.tsx
@@ -10,7 +10,6 @@ import { useClipboard } from '@/hooks';
 import { logger } from '@/logger';
 import { isSignTypedData } from '@/utils/signingMethods';
 
-import { RPCMethod } from '@/walletConnect/types';
 import { sanitizeTypedData } from '@/utils/signingUtils';
 import {
   estimateMessageHeight,
@@ -25,7 +24,7 @@ import { AnimatedCheckmark, IconContainer } from '@/components/Transactions/Tran
 type TransactionMessageCardProps = {
   expandedCardBottomInset: number;
   message: string;
-  method: RPCMethod;
+  method: string;
 };
 
 export const TransactionMessageCard = ({ expandedCardBottomInset, message, method }: TransactionMessageCardProps) => {

--- a/src/helpers/buildTransaction.ts
+++ b/src/helpers/buildTransaction.ts
@@ -1,0 +1,81 @@
+import { RainbowError, logger } from '@/logger';
+import { greaterThan, convertHexToString } from './utilities';
+import { isNil } from 'lodash';
+import { estimateGasWithPadding, toHex } from '@/handlers/web3';
+import { StaticJsonRpcProvider, TransactionRequest } from '@ethersproject/providers';
+import { SelectedGasFee } from '@/entities';
+import { parseGasParamsForTransaction } from '@/parsers';
+import { getNextNonce } from '@/state/nonces';
+import { ChainId } from '@/state/backendNetworks/types';
+import { hexToNumber } from 'viem';
+
+export const getGasLimitForSuggestedGas = async (params: any, provider: StaticJsonRpcProvider) => {
+  const gasLimitFromPayload = params.gasLimit;
+  let gas = params.gas;
+  try {
+    logger.debug(
+      '[SignTransactionSheet]: gas suggested by dapp',
+      {
+        gas: convertHexToString(gas),
+        gasLimitFromPayload: convertHexToString(gasLimitFromPayload),
+      },
+      logger.DebugContext.walletconnect
+    );
+
+    // Estimate the tx with gas limit padding before sending
+    const rawGasLimit = await estimateGasWithPadding(params, null, null, provider);
+    if (!rawGasLimit) {
+      logger.error(new RainbowError('[SignTransactionSheet]: error estimating gas'), {
+        rawGasLimit,
+      });
+      return;
+    }
+
+    // If the estimation with padding is higher or gas limit was missing,
+    // let's use the higher value
+    if (
+      (isNil(gas) && isNil(gasLimitFromPayload)) ||
+      (!isNil(gas) && greaterThan(rawGasLimit, convertHexToString(gas))) ||
+      (!isNil(gasLimitFromPayload) && greaterThan(rawGasLimit, convertHexToString(gasLimitFromPayload)))
+    ) {
+      logger.debug('[SignTransactionSheet]: using padded estimation!', { gas: rawGasLimit.toString() }, logger.DebugContext.walletconnect);
+      gas = toHex(rawGasLimit);
+    }
+  } catch (error) {
+    logger.error(new RainbowError('[SignTransactionSheet]: error estimating gas'), { error });
+  }
+  return gas || gasLimitFromPayload;
+};
+
+export const buildTransaction = async <T extends Partial<TransactionRequest>>({
+  address,
+  chainId,
+  params,
+  selectedGasFee,
+  provider,
+}: {
+  address: string;
+  chainId: ChainId;
+  params: T;
+  selectedGasFee: SelectedGasFee;
+  provider: StaticJsonRpcProvider;
+}) => {
+  const gasLimit = await getGasLimitForSuggestedGas(params, provider);
+  const gasParams = parseGasParamsForTransaction(selectedGasFee);
+  const nonce = await getNextNonce({ address, chainId });
+
+  const { type, to, from, data, value } = params;
+
+  const baseTxn: TransactionRequest = {
+    ...gasParams,
+    ...(gasLimit && { gasLimit }),
+    type: type && typeof type === 'string' ? hexToNumber(type) : undefined,
+    to,
+    from,
+    data: data || '0x',
+    value,
+    nonce,
+  };
+
+  return baseTxn;
+};

--- a/src/walletConnect/types.ts
+++ b/src/walletConnect/types.ts
@@ -24,7 +24,10 @@ export interface RequestData {
   address: string;
   chainId: ChainId;
   dappUrl: string;
-  payload: any;
+  payload: {
+    method: string;
+    params?: any[];
+  };
   displayDetails: RequestDisplayDetails | null | Record<string, never>;
 }
 


### PR DESCRIPTION
Fixes APP-2248

## What changed (plus any additional context for devs)

## 1. Transaction Message Card Component Update

### Type Definition Changes
- Removed dependency on `RPCMethod` from walletConnect types
- Changed `method` prop type from `RPCMethod` to `string` for better flexibility

## 2. New Build Transaction Helper

### New File Creation
- Added new file `src/helpers/buildTransaction.ts`
- Implements two main functions:
  - `getGasLimitForSuggestedGas`
  - `buildTransaction`

### Gas Estimation Logic
- Moved gas estimation logic from `SignTransactionSheet` to dedicated helper
- Implements padding and validation for gas estimates
- Handles fallback scenarios for gas limit calculations

### Transaction Building
- Centralizes transaction building logic in one location
- Handles gas parameters, nonce management, and transaction type conversion
- Provides a cleaner interface for creating transaction objects

## 3. Sign Transaction Sheet Refactor

### Code Cleanup
- Removed duplicated gas estimation logic
- Simplified transaction payload handling
- Improved error handling and logging

### Integration Changes
- Now uses the new `buildTransaction` helper
- Streamlined transaction submission flow
- Better separation of concerns between transaction building and signing

This PR represents a significant improvement in the transaction handling architecture, moving complex transaction building logic into a dedicated helper while simplifying the transaction message card component. The changes promote better code organization and maintainability. 

## Screen recordings / screenshots

https://github.com/user-attachments/assets/57349cc8-955f-425a-955a-4e2ca28965ae



## What to test
sends, sign, txns from MWP, Dapp Browser, WC
