### PR TITLE
Add wallet error alert to swaps flow

### DIFF
--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -60,6 +60,7 @@ import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 import { useBackendNetworksStore, getChainsNativeAssetWorklet } from '@/state/backendNetworks/backendNetworks';
 import { getSwapsNavigationParams } from '../navigateToSwaps';
 import { LedgerSigner } from '@/handlers/LedgerSigner';
+import showWalletErrorAlert from '@/helpers/support';
 
 const swapping = i18n.t(i18n.l.swap.actions.swapping);
 const holdToSwap = i18n.t(i18n.l.swap.actions.hold_to_swap);
@@ -266,6 +267,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
       if (!wallet) {
         isSwapping.value = false;
         haptics.notificationError();
+        showWalletErrorAlert();
         return;
       }
 


### PR DESCRIPTION
Fixes APP-2254

## What changed (plus any additional context for devs)
## 1. Swap Provider Enhancement

### Error Handling
- Added `showWalletErrorAlert` helper function import
- Implemented wallet error alert when wallet is not available during swap
- Maintained existing error feedback (haptic notification)

### Code Organization
- Added error handling in swap provider's wallet check
- Integrated with existing haptics feedback system
- Improved user feedback for wallet-related errors

## 2. Support Helper Integration

### Alert Implementation
- Utilized centralized `showWalletErrorAlert` from support helpers
- Standardized wallet error messaging across the app
- Improved error handling consistency

### User Experience
- Added clear error messaging for wallet-related issues
- Maintained haptic feedback for error states
- Improved user guidance during error scenarios

## 3. Code Structure Improvements

### Dependencies
- Added new import for support helper
- Maintained existing haptics implementation
- Integrated with existing swap provider logic

This PR improves error handling in the swap flow by adding standardized wallet error alerts, providing better user feedback while maintaining existing error handling patterns. 

## Screen recordings / screenshots
n/a

## What to test
damaged wallet state trying to swap
