### PR TITLE
Fix inconsistencies between swaps store slippage and shared value

### DIFF
--- a/src/__swaps__/screens/Swap/navigateToSwaps.ts
+++ b/src/__swaps__/screens/Swap/navigateToSwaps.ts
@@ -1,7 +1,7 @@
 import { GasSpeed } from '@/__swaps__/types/gas';
 import { Navigation } from '@/navigation';
 import store from '@/redux/store';
-import { SwapsState, useSwapsStore } from '@/state/swaps/swapsStore';
+import { SwapsState, swapsStore, useSwapsStore } from '@/state/swaps/swapsStore';
 import { setSelectedGasSpeed } from './hooks/useSelectedGas';
 import { enableActionsOnReadOnlyWallet } from '@/config';
 import walletTypes from '@/helpers/walletTypes';
@@ -51,6 +51,9 @@ export function getSwapsNavigationParams() {
   const lastTypedInput = inputMethod === 'slider' ? 'inputAmount' : inputMethod;
   const slippage =
     params.slippage && !isNaN(+params.slippage) ? slippageInBipsToString(+params.slippage) : getDefaultSlippage(chainId, getRemoteConfig());
+
+  // Set the slippage in the swaps store to keep it in sync with the initial value
+  swapsStore.getState().setSlippage(slippage);
 
   return {
     inputMethod,

--- a/src/__swaps__/screens/Swap/navigateToSwaps.ts
+++ b/src/__swaps__/screens/Swap/navigateToSwaps.ts
@@ -7,6 +7,9 @@ import { enableActionsOnReadOnlyWallet } from '@/config';
 import walletTypes from '@/helpers/walletTypes';
 import { watchingAlert } from '@/utils';
 import Routes from '@/navigation/routesNames';
+import { getDefaultSlippage, slippageInBipsToString } from '@/__swaps__/utils/swaps';
+import { ChainId } from '@/state/backendNetworks/types';
+import { getRemoteConfig } from '@/model/remoteConfig';
 
 export type SwapsParams = Partial<
   Pick<SwapsState, 'inputAsset' | 'outputAsset' | 'percentageToSell' | 'slippage'> & {
@@ -38,18 +41,24 @@ const getInputMethod = (params: SwapsParams) => {
   return 'inputAmount';
 };
 export function getSwapsNavigationParams() {
+  const state = useSwapsStore.getState();
   const params = (Navigation.getActiveRoute().params || {}) as SwapsParams;
 
   const inputMethod = getInputMethod(params);
+  const inputAsset = params.inputAsset || state.inputAsset;
+  const outputAsset = params.outputAsset || state.outputAsset;
+  const chainId = inputAsset?.chainId || ChainId.mainnet;
   const lastTypedInput = inputMethod === 'slider' ? 'inputAmount' : inputMethod;
+  const slippage =
+    params.slippage && !isNaN(+params.slippage) ? slippageInBipsToString(+params.slippage) : getDefaultSlippage(chainId, getRemoteConfig());
 
-  const state = useSwapsStore.getState();
   return {
     inputMethod,
     lastTypedInput,
     focusedInput: lastTypedInput,
-    inputAsset: params.inputAsset || state.inputAsset,
-    outputAsset: params.outputAsset || state.outputAsset,
+    inputAsset,
+    outputAsset,
+    slippage,
     ...params,
   } as const;
 }

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -26,7 +26,7 @@ import { userAssetsQueryKey } from '@/__swaps__/screens/Swap/resources/assets/us
 import { AddressOrEth, ExtendedAnimatedAssetWithColors, ParsedSearchAsset } from '@/__swaps__/types/assets';
 import { ChainId } from '@/state/backendNetworks/types';
 import { SwapAssetType, inputKeys } from '@/__swaps__/types/swap';
-import { clamp, getDefaultSlippageWorklet, parseAssetAndExtend } from '@/__swaps__/utils/swaps';
+import { clamp, parseAssetAndExtend } from '@/__swaps__/utils/swaps';
 import { analyticsV2 } from '@/analytics';
 import { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/entities';
 import { getProvider } from '@/handlers/web3';
@@ -49,13 +49,11 @@ import { haptics } from '@/utils';
 import { CrosschainQuote, Quote, QuoteError, SwapType } from '@rainbow-me/swaps';
 
 import { IS_IOS } from '@/env';
-import { Address } from 'viem';
 import { clearCustomGasSettings } from '../hooks/useCustomGas';
 import { getGasSettingsBySpeed, getSelectedGas } from '../hooks/useSelectedGas';
 import { useSwapOutputQuotesDisabled } from '../hooks/useSwapOutputQuotesDisabled';
 import { SyncGasStateToSharedValues, SyncQuoteSharedValuesToState } from './SyncSwapStateAndSharedValues';
 import { performanceTracking, Screens, TimeToSignOperation } from '@/state/performance/performance';
-import { getRemoteConfig } from '@/model/remoteConfig';
 import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 import { useBackendNetworksStore, getChainsNativeAssetWorklet } from '@/state/backendNetworks/backendNetworks';
 import { getSwapsNavigationParams } from '../navigateToSwaps';
@@ -190,7 +188,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
   );
   const configProgress = useSharedValue<NavigationSteps>(NavigationSteps.INPUT_ELEMENT_FOCUSED);
 
-  const slippage = useSharedValue(getDefaultSlippageWorklet(initialSelectedInputAsset?.chainId || ChainId.mainnet, getRemoteConfig()));
+  const slippage = useSharedValue(initialValues.slippage);
 
   const hasEnoughFundsForGas = useSharedValue<boolean | undefined>(undefined);
 


### PR DESCRIPTION
Fixes APP-2255

## What changed (plus any additional context for devs)

## 1. Swap Navigation Parameters Enhancement

### State Management
- Added slippage parameter handling in `getSwapsNavigationParams`
- Improved default value handling for input/output assets
- Added chainId fallback to mainnet

### Parameter Processing
- Added validation for slippage parameter
- Implemented conversion from basis points to string format
- Added integration with remote config for default slippage values

### Code Organization
- Moved state retrieval to top of function
- Consolidated asset parameter handling
- Added proper type safety for parameters

## 2. Swap Provider Updates

### State Management
- Removed direct worklet call for default slippage
- Now uses navigation parameters for initial slippage value
- Maintained existing haptics and analytics integration

### Code Cleanup
- Removed unused imports
- Simplified parameter initialization
- Improved type definitions

This PR improves the swap navigation parameter handling by adding proper slippage management and better state organization while maintaining existing functionality. 

## Screen recordings / screenshots

https://github.com/user-attachments/assets/4f1d8c61-6a8c-45d3-bf34-dd96dd51d5f5



## What to test
test swaps on different chains and see the `minimum value received` changes with the slippage change
