### PR TITLE
Fix nonce issue for dropped transactions

### DIFF
--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -46,7 +46,7 @@ export const fetchTransaction = async ({
     });
 
     const tx = response?.data?.payload?.transaction;
-    if (!tx) {
+    if (!tx || !tx?.status || (tx?.status as string) === '') {
       return null;
     }
     const parsedTx = await parseTransaction(tx, currency, chainId);

--- a/src/state/nonces/index.ts
+++ b/src/state/nonces/index.ts
@@ -106,7 +106,7 @@ export const nonceStore = createStore<CurrentNonceState<Nonces>>(
   {
     persist: {
       name: 'nonces',
-      version: 1,
+      version: 2,
       migrate: (persistedState: unknown, version: number) => {
         if (version === 0) {
           const chainsIdByName = useBackendNetworksStore.getState().getChainsIdByName();

--- a/src/state/nonces/index.ts
+++ b/src/state/nonces/index.ts
@@ -107,26 +107,6 @@ export const nonceStore = createStore<CurrentNonceState<Nonces>>(
     persist: {
       name: 'nonces',
       version: 2,
-      migrate: (persistedState: unknown, version: number) => {
-        if (version === 0) {
-          const chainsIdByName = useBackendNetworksStore.getState().getChainsIdByName();
-          const oldState = persistedState as CurrentNonceState<NoncesV0>;
-          const newNonces: CurrentNonceState<Nonces>['nonces'] = {};
-          for (const [address, networkNonces] of Object.entries(oldState.nonces)) {
-            for (const [network, nonceData] of Object.entries(networkNonces)) {
-              if (!newNonces[address]) {
-                newNonces[address] = {} as Record<ChainId, NonceData>;
-              }
-              newNonces[address][chainsIdByName[network as Network]] = nonceData;
-            }
-          }
-          return {
-            ...oldState,
-            nonces: newNonces,
-          };
-        }
-        return persistedState as CurrentNonceState<Nonces>;
-      },
     },
   }
 );


### PR DESCRIPTION
Fixes APP-2265

## What changed (plus any additional context for devs)
* Treat an addy's txn API response object that doesn't have a valid status as not existing yet, so that we don't override the pending transaction with incomplete data and remove it prematurely from the pending txns list. We had been treating txn status of `""` as the same as "not pending" and removed the pending transaction before its time. This impacted the getNextNonce logic when it tries to go through pending transactions and check timestamps against the privateMempool time.
* Bumped the nonce persist version for users who may have been negatively impacted by the previous logic
* Removed the nonce migration function as nonce isn't a user preference that needs to be stored; it can always be refreshed

## Screen recordings / screenshots
You can see it healed here: https://dashboard.alchemy.com/mempool?app_id=all&network_id=BASE_MAINNET&search_input=0x2e67869829c734ac13723a138a952f7a8b56e774&status=0&time_min=1736694316000&time_range_preset=last3Days

## What to test
* Without needing to do anything else other than upgrading to the TF version, do a base send transaction - it should pick up the correct nonce.
* Do another base send transaction, but this time update the gas to be super low such that the likelihood of it getting dropped increases. Wait > 2 minutes, then do another base send transaction with a different amount and normal gas and it should pick up the same nonce and go through.
* Test out sending a mix of swaps and sends
