### PR TITLE
Adjust default queryClient cacheTime

### DIFF
--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -31,7 +31,7 @@ class MMKVPersister implements Persister {
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      cacheTime: time.days(7),
+      cacheTime: time.minutes(5),
       staleTime: time.minutes(2),
     },
   },


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Turns out `cacheTime` is the time after which inactive query data is garbage collected, not the time that data is stored for
- This sets the default `cacheTime` back to 5 minutes, which is RQ's default

## Screen recordings / screenshots


## What to test

