### PR TITLE
enable third party positions to be calculated in address summary

### DIFF
--- a/src/resources/summary/summary.ts
+++ b/src/resources/summary/summary.ts
@@ -101,6 +101,7 @@ async function addysSummaryQueryFunction({ queryKey: [{ addresses, currency }] }
     JSON.stringify({
       currency,
       addresses,
+      enableThirdParty: true,
     })
   );
   return data as AddysSummary;


### PR DESCRIPTION
Fixes APP-2273

## What changed (plus any additional context for devs)

Add field to address summary request that lets endpoint know to add third party positions to address total balance
