### PR TITLE
prevent e2e flow to run while PRs are on draft

### DIFF
--- a/.github/workflows/macstadium-tests.yml
+++ b/.github/workflows/macstadium-tests.yml
@@ -1,5 +1,8 @@
 name: iOS e2e tests
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   # Job to install dependencies


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
Changing the triggers for the e2e flow so we don't use CI resources for PRs that are still on draft.

## Screen recordings / screenshots
This PR is opened as a draft on purpose and e2e shouldn't run.

## What to test
See above.

