### PR TITLE
fix chain image in tt

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -519,7 +519,7 @@ function NetworkFilter() {
     return {
       icon: (
         <View style={{ marginRight: 2 }}>
-          <ChainImage chainId={chainId} size={16} />
+          <ChainImage chainId={chainId} size={16} position="relative" />
         </View>
       ),
       label: useBackendNetworksStore.getState().getChainsLabel()[chainId],


### PR DESCRIPTION
## What changed (plus any additional context for devs)
fixes misaligned tt chain badge

## Screen recordings / screenshots
<img width="375" alt="Screenshot 2025-01-17 at 7 45 45 PM" src="https://github.com/user-attachments/assets/3c852bb5-ca8a-4464-bee6-5872eda05526" />


## What to test
make sure chain image looks fine on tt
