### PR TITLE
Fix Android prompt

### DIFF
--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -36,10 +36,6 @@ const promptForBackupOnceReadyOrNotAvailable = async (): Promise<boolean> => {
     status = backupsStore.getState().status;
   }
 
-  if (status !== CloudBackupState.Ready) {
-    return false;
-  }
-
   const { backupProvider, timesPromptedForBackup, lastBackupPromptAt } = backupsStore.getState();
 
   // prompt for backup every week if first time prompting, otherwise prompt every 2 weeks


### PR DESCRIPTION
## What changed (plus any additional context for devs)
If the user isn't signed into a google account yet the status will be NotAvailable, so we need to remove this clause and just fall through to the prompt always.

## Screen recordings / screenshots


## What to test

