### PR TITLE
Fixes related to Discover Search and e2e

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -281,18 +281,24 @@ export async function swipeUntilVisible(
   elementId: string | RegExp,
   scrollViewId: string,
   direction: Direction,
-  percentageVisible?: number
+  percentageVisible?: number,
+  maxAttempts?: number
 ) {
   let stop = false;
+  let attempt = 0;
 
   while (!stop) {
     try {
+      attempt++;
       await waitFor(element(by.id(elementId)))
         .toBeVisible(percentageVisible)
         .withTimeout(500);
 
       stop = true;
     } catch (e) {
+      if (maxAttempts && attempt >= maxAttempts) {
+        throw e;
+      }
       await swipe(scrollViewId, direction, 'slow', 0.2);
     }
   }

--- a/e2e/parallel/4_discoverSheetFlow.spec.ts
+++ b/e2e/parallel/4_discoverSheetFlow.spec.ts
@@ -85,8 +85,8 @@ describe('Discover Screen Flow', () => {
     await delayTime('long');
     await checkIfVisible('favorites-0');
     await checkIfVisible('verified-1');
-    await swipeUntilVisible('profiles-2', 'discover-search-list', 'up');
-    await swipeUntilVisible('highLiquidity-3', 'discover-search-list', 'up');
+    await swipeUntilVisible('profiles-2', 'discover-search-list', 'up', 100, 10);
+    await swipeUntilVisible('highLiquidity-3', 'discover-search-list', 'up', 100, 5);
   });
 
   it.skip('Should search and open Profile Sheet for rainbowwallet.eth', async () => {

--- a/e2e/parallel/4_discoverSheetFlow.spec.ts
+++ b/e2e/parallel/4_discoverSheetFlow.spec.ts
@@ -3,6 +3,7 @@ import {
   tap,
   beforeAllcleanApp,
   checkIfVisible,
+  swipeUntilVisible,
   waitAndTap,
   checkIfExists,
   typeText,
@@ -84,8 +85,8 @@ describe('Discover Screen Flow', () => {
     await delayTime('long');
     await checkIfVisible('favorites-0');
     await checkIfVisible('verified-1');
-    // await checkIfExists('profiles-2');
-    // await checkIfExists('highLiquidity-3');
+    await swipeUntilVisible('profiles-2', 'discover-search-list', 'up');
+    await swipeUntilVisible('highLiquidity-3', 'discover-search-list', 'up');
   });
 
   it.skip('Should search and open Profile Sheet for rainbowwallet.eth', async () => {

--- a/src/components/Discover/DiscoverSearch.tsx
+++ b/src/components/Discover/DiscoverSearch.tsx
@@ -100,20 +100,8 @@ export default function DiscoverSearch() {
       list = [...ensResults, ...swapCurrencyList];
     }
 
-    // ONLY FOR e2e!!! Fake tokens with same symbols break detox e2e tests
+    // ONLY FOR e2e!!! Include index along with section key to confirm order while testing for visibility
     if (IS_TEST) {
-      let symbols: string[] = [];
-      list = list?.map(section => {
-        // Remove dupes
-        section.data = uniqBy(section?.data, 'symbol');
-        // Remove dupes across sections
-        section.data = section?.data?.filter(token => !symbols.includes(token?.symbol));
-        const sectionSymbols = section?.data?.map(token => token?.symbol);
-        symbols = symbols.concat(sectionSymbols);
-
-        return section;
-      });
-
       list = list.map((section, index) => ({
         ...section,
         key: `${section.key}-${index}`,

--- a/src/components/Discover/DiscoverSearch.tsx
+++ b/src/components/Discover/DiscoverSearch.tsx
@@ -85,7 +85,7 @@ export default function DiscoverSearch() {
     // 3. profiles
     // 4. unverified high liquidity
     // 5. low liquidity
-    let list = swapCurrencyList;
+    let list = [...swapCurrencyList];
     const listKeys = swapCurrencyList.map(item => item.key);
 
     const profilesSecond = (listKeys[0] === 'favorites' && listKeys[1] !== 'verified') || listKeys[0] === 'verified';

--- a/src/components/Discover/DiscoverSearch.tsx
+++ b/src/components/Discover/DiscoverSearch.tsx
@@ -296,7 +296,11 @@ export default function DiscoverSearch() {
   );
 
   return (
-    <View key={currencyListDataKey} style={{ height: deviceUtils.dimensions.height - TOP_OFFSET - marginBottom }}>
+    <View
+      key={currencyListDataKey}
+      style={{ height: deviceUtils.dimensions.height - TOP_OFFSET - marginBottom }}
+      testID="discover-search-list"
+    >
       <SearchContainer>
         <CurrencySelectionList
           footerSpacer


### PR DESCRIPTION
## What changed (plus any additional context for devs)
There are a few fixes that come along in this PR.
1. In e2e Discover flow: include a `scrollUntilVisible` check for the profiles section and the high liquidity unverified section, as these are below the fold given that there are more verified results when searching for keyword "bitcoin" in e2e now.

2. The `scrollUntilVisible` e2e util has a while loop that would keep going until it found what it wanted - so if in the future some functionality broke and the element could not be found, it would keep trying to scroll forever until the whole test times out. I added an optional param of `maxAttempts` of scrolls for erroring out early if the item hadn't been found within those `maxAttempts` scrolls. I did not update all the places already using `scrollUntilVisible` outside of the Discover search e2e tests, as I kept it backwards compatible. Tested the "fail" case of this by making up an element ID and watching e2e fail as expected.

3. We had super old logic specifically for Discover Search that would remove tokens with the same symbol. This was causing some "high liquidity unverified" results to get filtered out.  I removed this deduping logic as it is no longer needed and now our e2e search results behavior falls more in line with prod.

4. We splice in Profiles into the final results as it comes from a separate source than the search results. Instead of using a shallow copy of the search results, we were splicing into the original search results, sometimes leading to a situation where you have profiles showing up twice after you search for 2 separate terms (once for the new term that is being spliced in, and another time for the old profile results that were spliced into the original search results)

## What to test
When searching for "unisocks" and then "bitcoin" in Discover search - you should only see Profiles section show up once in the search results (once for unisocks, then once for bitcoin).

## Screen recordings / screenshots
Ran e2e tests successfully locally.

![Simulator Screenshot - iPhone 16 Pro - 2025-01-28 at 16 46 42](https://github.com/user-attachments/assets/e2ff6bb0-5579-4ed2-a958-b5d4f3e2e5f2)



