### PR TITLE
SafeMath fixes

### DIFF
--- a/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.tsx
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPriceLabel.tsx
@@ -3,22 +3,21 @@ import { Text } from '@/design-system';
 import { useAccountSettings } from '@/hooks';
 import { ChartYLabel } from '@/react-native-animated-charts/src';
 import { SupportedCurrency, supportedNativeCurrencies } from '@/references';
-import { DEVICE_WIDTH } from '@/utils/deviceUtils';
-import { orderOfMagnitudeWorklet, significantDecimalsWorklet } from '@/safe-math/SafeMath';
+import { orderOfMagnitudeWorklet, significantDecimalsWorklet, toFixedWorklet } from '@/safe-math/SafeMath';
 
 function calculateDecimalPlaces({
   amount,
-  minimumDecimals = 0,
   maximumDecimals = 6,
+  minimumDecimals = 0,
   precisionAdjustment,
 }: {
   amount: number | string;
-  minimumDecimals?: number;
   maximumDecimals?: number;
+  minimumDecimals?: number;
   precisionAdjustment?: number;
 }): {
-  minimumDecimalPlaces: number;
   maximumDecimalPlaces: number;
+  minimumDecimalPlaces: number;
 } {
   'worklet';
   const orderOfMagnitude = orderOfMagnitudeWorklet(amount);
@@ -42,7 +41,17 @@ function calculateDecimalPlaces({
   };
 }
 
-export function formatNative(value: string, defaultPriceValue: string | null, nativeSelected: SupportedCurrency[keyof SupportedCurrency]) {
+export function formatNative({
+  defaultPriceValue,
+  nativeSelected,
+  trimTrailingZeros = false,
+  value,
+}: {
+  defaultPriceValue: string | null;
+  nativeSelected: SupportedCurrency[keyof SupportedCurrency];
+  trimTrailingZeros?: boolean;
+  value: string;
+}) {
   'worklet';
   if (!value) {
     return defaultPriceValue || '';
@@ -58,9 +67,12 @@ export function formatNative(value: string, defaultPriceValue: string | null, na
     precisionAdjustment: 1,
   });
 
-  let res = `${Number(value).toFixed(numDecimals).toLocaleString()}`;
+  let res = toFixedWorklet(value, numDecimals);
+  if (trimTrailingZeros) res = res.replace(/\.?0+$/, '');
+
   res = nativeSelected?.alignment === 'left' ? `${nativeSelected?.symbol}${res}` : `${res} ${nativeSelected?.symbol}`;
   const vals = res.split('.');
+
   if (vals.length === 2) {
     return vals[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',') + '.' + vals[1];
   }
@@ -82,7 +94,11 @@ export default function ChartPriceLabel({
   const formatWorklet = useCallback(
     (value: string) => {
       'worklet';
-      return formatNative(value, priceValue, nativeSelected);
+      return formatNative({
+        defaultPriceValue: priceValue,
+        nativeSelected,
+        value,
+      });
     },
     [nativeSelected, priceValue]
   );
@@ -92,6 +108,6 @@ export default function ChartPriceLabel({
       {defaultValue}
     </Text>
   ) : (
-    <ChartYLabel formatWorklet={formatWorklet} size="34pt" style={{ maxWidth: DEVICE_WIDTH * (2 / 3) }} weight="heavy" />
+    <ChartYLabel formatWorklet={formatWorklet} size="34pt" weight="heavy" />
   );
 }

--- a/src/components/value-chart/ExtremeLabels.tsx
+++ b/src/components/value-chart/ExtremeLabels.tsx
@@ -83,7 +83,11 @@ const Labels = ({ color, width, isCard }: { color: string; width: number; isCard
           style={{ bottom: isCard ? -24 : -40 }}
           width={width}
         >
-          {formatNative(smallestY.y.toString(), null, nativeSelected)}
+          {formatNative({
+            defaultPriceValue: null,
+            nativeSelected,
+            value: smallestY.y.toString(),
+          })}
         </CenteredLabel>
       ) : null}
       {positionMax ? (
@@ -94,7 +98,11 @@ const Labels = ({ color, width, isCard }: { color: string; width: number; isCard
           style={{ top: -20, left: isCard ? 0 : 40 }}
           width={width}
         >
-          {formatNative(greatestY.y.toString(), null, nativeSelected)}
+          {formatNative({
+            defaultPriceValue: null,
+            nativeSelected,
+            value: greatestY.y.toString(),
+          })}
         </CenteredLabel>
       ) : null}
     </>

--- a/src/safe-math/SafeMath.ts
+++ b/src/safe-math/SafeMath.ts
@@ -1,31 +1,36 @@
 // Utility function to remove the decimal point and keep track of the number of decimal places
-const removeDecimalWorklet = (num: string): [bigint, number] => {
+function removeDecimalWorklet(num: string): [bigint, number] {
   'worklet';
   let decimalPlaces = 0;
   let bigIntNum: bigint;
 
+  // Check if there's an exponent
   if (/[eE]/.test(num)) {
     const [base, exponent] = num.split(/[eE]/);
     const exp = Number(exponent);
+
     const parts = base.split('.');
     const baseDecimalPlaces = parts.length === 2 ? parts[1].length : 0;
-    const bigIntBase = BigInt(parts.join(''));
+    const bigIntBase = BigInt(parts.join('')); // "1.23" => BigInt("123")
 
     if (exp >= 0) {
-      decimalPlaces = baseDecimalPlaces - exp;
+      // Shift integer for e+ exponent, keep baseDecimalPlaces as is
+      decimalPlaces = baseDecimalPlaces;
       bigIntNum = bigIntBase * BigInt(10) ** BigInt(exp);
     } else {
-      decimalPlaces = baseDecimalPlaces - exp;
+      // e- => increase decimalPlaces by abs(exp)
+      decimalPlaces = baseDecimalPlaces - exp; // subtracting negative => plus
       bigIntNum = bigIntBase;
     }
   } else {
+    // No exponent => fallback
     const parts = num.split('.');
     decimalPlaces = parts.length === 2 ? parts[1].length : 0;
     bigIntNum = BigInt(parts.join(''));
   }
 
   return [bigIntNum, decimalPlaces];
-};
+}
 
 export const isNumberStringWorklet = (value: string): boolean => {
   'worklet';
@@ -61,20 +66,14 @@ const formatResultWorklet = (result: bigint): string => {
 };
 
 // Helper function to handle string and number input types
-const toStringWorklet = (value: string | number): string => {
+export const toStringWorklet = (value: string | number): string => {
   'worklet';
-  const ret = typeof value === 'number' ? value.toString() : value;
+  const string = typeof value === 'number' ? value.toString() : value;
 
-  if (ret.includes('e') && !ret.includes('e-')) {
-    const [base, exponent] = ret.split('e');
-    const exp = Number(exponent);
-    return base.replace('.', '') + '0'.repeat(exp);
-  }
+  // Slice trailing decimal point if not followed by a number
+  if (/^\d+\.$/.test(string)) return string.slice(0, -1);
 
-  if (/^\d+\.$/.test(ret)) {
-    return ret.slice(0, -1);
-  }
-  return ret;
+  return string;
 };
 
 // Converts a numeric string to a scaled integer string, preserving the specified decimal places
@@ -202,61 +201,69 @@ export function modWorklet(num1: string | number, num2: string | number): string
   return formatResultWorklet(result);
 }
 
-// return significant decimals in fractional portion of number
+// Returns significant decimals in the fractional portion of a number
 export function significantDecimalsWorklet(num: string | number): number {
   'worklet';
-  if (num === 0) {
-    return 0;
-  }
+  const [rawBigInt, decimalPlaces] = removeDecimalWorklet(typeof num === 'number' ? num.toString() : num);
 
-  // Convert the number to a string to handle large numbers and fractional parts
-  const numStr = num.toString();
+  if (rawBigInt === 0n || decimalPlaces <= 0) return 0;
 
-  // Split the number into integer and fractional parts
-  const [_, fractionalPart] = numStr.split('.');
+  // Work with absolute value for simplicity
+  const bigIntNum = rawBigInt < 0n ? -rawBigInt : rawBigInt;
 
-  // Handle fractional parts
-  if (fractionalPart) {
-    // Find the first non-zero digit in the fractional part
-    for (let i = 0; i < fractionalPart.length; i++) {
-      if (fractionalPart[i] !== '0') {
-        return i + 1;
+  const digitsStr = bigIntNum.toString(); // e.g. '238'
+  // If we have decimalPlaces=10, that means the real fractional portion has length=10,
+  // of which the last digitsStr.length characters are digits, and the rest are leading zeros.
+
+  if (digitsStr.length < decimalPlaces) {
+    // That means we have leading zeros in the fractional portion
+    // e.g. bigIntNum="238", decimalPlaces=10 => fractional part is "0000000238"
+    // leadingZeros = 10 - 3 = 7
+    const leadingZerosCount = decimalPlaces - digitsStr.length;
+
+    // The first 7 digits of fractional are '0'. Then we have '2','3','8'.
+    // We find the first non-zero among the last part:
+    for (let i = 0; i < digitsStr.length; i++) {
+      if (digitsStr[i] !== '0') {
+        // fractional index = leadingZerosCount + i
+        // +1 because the original code returns the 1-based offset
+        return leadingZerosCount + i + 1;
       }
     }
-  }
+    // If no non-zero, it's effectively 0, but we handle that above
+    return 0;
+  } else {
+    // digitsStr.length >= decimalPlaces: the fractional portion is the last
+    // `decimalPlaces` digits of digitsStr
+    // example: bigIntNum = 12345, decimalPlaces=2 => fractional part is "45"
+    const fractionalPart = digitsStr.slice(digitsStr.length - decimalPlaces);
 
-  return 0;
+    for (let i = 0; i < fractionalPart.length; i++) {
+      if (fractionalPart[i] !== '0') {
+        return i + 1; // 1-based index
+      }
+    }
+
+    return 0; // No non-zero found => fractional is all zeros
+  }
 }
 
 export function orderOfMagnitudeWorklet(num: string | number): number {
   'worklet';
-  if (num === 0) {
-    return -Infinity; // log10(0) is -Infinity
-  }
+  // If the numeric value itself is 0, the log10 is -∞
+  if (num === 0 || num === '0') return -Infinity;
 
-  // Convert the number to a string to handle large numbers and fractional parts
-  const numStr = num.toString();
+  const [rawBigInt, rawDecimalPlaces] = removeDecimalWorklet(typeof num === 'number' ? num.toString() : num);
 
-  // Split the number into integer and fractional parts
-  const [integerPart, fractionalPart] = numStr.split('.');
+  if (rawBigInt === 0n) return -Infinity;
 
-  // Handle integer parts
-  if (BigInt(integerPart) !== 0n) {
-    return integerPart.length - 1;
-  }
+  // Simplify to absolute value, since the sign doesn't affect the log10 magnitude
+  const bigIntNum = rawBigInt < 0n ? -rawBigInt : rawBigInt;
+  const digitsCount = bigIntNum.toString().length; // number of digits in the absolute value
+  const decimalPlaces = rawDecimalPlaces; // positive => more fractional digits, negative => large integer
 
-  // Handle fractional parts
-  if (fractionalPart) {
-    // Find the first non-zero digit in the fractional part
-    for (let i = 0; i < fractionalPart.length; i++) {
-      if (fractionalPart[i] !== '0') {
-        return -(i + 1);
-      }
-    }
-  }
-
-  // If the fractional part is all zeros, return a very negative number
-  return -Infinity;
+  // floor(log10(value)) = (digitsCount - 1) - decimalPlaces
+  return digitsCount - 1 - decimalPlaces;
 }
 
 // Equality function
@@ -358,18 +365,32 @@ export function powWorklet(base: string | number, exponent: string | number): st
     return baseStr;
   }
 
-  if (lessThanWorklet(exponentStr, 0)) {
-    return divWorklet(1, powWorklet(base, Math.abs(Number(exponent))));
+  // If exponent is negative => 1 / base^|exponent|
+  if (lessThanWorklet(exponentStr, '0')) {
+    return divWorklet('1', powWorklet(base, Math.abs(Number(exponentStr))));
   }
 
+  // Now handle exponent≥1
   const [bigIntBase, decimalPlaces] = removeDecimalWorklet(baseStr);
-  let result;
+  const exp = Number(exponentStr); // Assume integer exponent
+
+  let result: bigint;
   if (decimalPlaces > 0) {
-    const scaledBigIntBase = scaleUpWorklet(bigIntBase, decimalPlaces);
-    result = scaledBigIntBase ** BigInt(exponentStr) / BigInt(10) ** BigInt(20);
+    const scaledBase = scaleUpWorklet(bigIntBase, decimalPlaces);
+    const raw = scaledBase ** BigInt(exp);
+
+    // We have exp*20 decimals in raw => we only want 20 decimals in final
+    if (exp === 1) {
+      result = raw;
+    } else {
+      const divisor = BigInt(10) ** BigInt(20 * (exp - 1));
+      result = raw / divisor;
+    }
+
     return formatResultWorklet(result);
   } else {
-    result = bigIntBase ** BigInt(exponentStr);
+    // Integer base => bigInt^exponent
+    result = bigIntBase ** BigInt(exp);
     return result.toString();
   }
 }
@@ -377,8 +398,12 @@ export function powWorklet(base: string | number, exponent: string | number): st
 // toFixed function
 export function toFixedWorklet(num: string | number, decimalPlaces: number): string {
   'worklet';
-  const numStr = toStringWorklet(num);
+  // Clamp to internal precision
+  let safeDecimalPlaces = decimalPlaces;
+  if (safeDecimalPlaces > 20) safeDecimalPlaces = 20;
+  if (safeDecimalPlaces < 0) safeDecimalPlaces = 0;
 
+  const numStr = toStringWorklet(num);
   if (!isNumberStringWorklet(numStr)) {
     throw new Error('Argument must be a numeric string or number');
   }
@@ -386,25 +411,31 @@ export function toFixedWorklet(num: string | number, decimalPlaces: number): str
   const [bigIntNum, numDecimalPlaces] = removeDecimalWorklet(numStr);
   const scaledBigIntNum = scaleUpWorklet(bigIntNum, numDecimalPlaces);
 
-  const scaleFactor = BigInt(10) ** BigInt(20 - decimalPlaces);
+  const scaleFactor = BigInt(10) ** BigInt(20 - safeDecimalPlaces);
   const half = scaleFactor / BigInt(2);
 
-  // Handle sign separately so we correctly round negative numbers
   const sign = scaledBigIntNum < 0n ? -1n : 1n;
-  let absScaled = scaledBigIntNum * sign;
-  absScaled = absScaled + half;
+  let absScaled = sign < 0 ? -scaledBigIntNum : scaledBigIntNum;
+
+  // If the number is positive, add half of scaleFactor; if negative, subtract half
+  // This ensures we always round away from zero (e.g., 1.5 → 2, -1.5 → -2)
+  if (sign > 0) {
+    absScaled += half;
+  } else {
+    absScaled -= half;
+  }
+
   absScaled = absScaled / scaleFactor;
-  absScaled = absScaled * scaleFactor;
+  absScaled *= scaleFactor;
   const finalBigInt = absScaled * sign;
 
-  // Convert to string and pad without the sign
   const isNegative = finalBigInt < 0n;
   const finalAbsStr = (isNegative ? -finalBigInt : finalBigInt).toString().padStart(20 + 1, '0');
 
   const integerPart = finalAbsStr.slice(0, -20) || '0';
-  const fractionalPart = finalAbsStr.slice(-20, -20 + decimalPlaces).padEnd(decimalPlaces, '0');
+  const fractionalPart = finalAbsStr.slice(-20, -20 + safeDecimalPlaces).padEnd(safeDecimalPlaces, '0');
 
-  return (isNegative ? '-' : '') + `${integerPart}.${fractionalPart}`;
+  return (isNegative ? '-' : '') + integerPart + (safeDecimalPlaces ? '.' + fractionalPart : '');
 }
 
 // Ceil function
@@ -452,11 +483,17 @@ export function roundWorklet(num: string | number): string {
   }
 
   const [bigIntNum, decimalPlaces] = removeDecimalWorklet(numStr);
-  const scaledBigIntNum = scaleUpWorklet(bigIntNum, decimalPlaces);
+  let scaled = scaleUpWorklet(bigIntNum, decimalPlaces);
 
   const scaleFactor = BigInt(10) ** BigInt(20);
-  const roundBigInt = ((scaledBigIntNum + scaleFactor / BigInt(2)) / scaleFactor) * scaleFactor;
 
+  if (scaled >= 0n) {
+    scaled += scaleFactor / 2n;
+  } else {
+    scaled -= scaleFactor / 2n; // negative => subtract half
+  }
+
+  const roundBigInt = (scaled / scaleFactor) * scaleFactor;
   return formatResultWorklet(roundBigInt);
 }
 

--- a/src/safe-math/__tests__/SafeMath.test.ts
+++ b/src/safe-math/__tests__/SafeMath.test.ts
@@ -243,6 +243,16 @@ describe('SafeMath', () => {
     const bigP = new BigNumber(VALUE_P);
     const fixedP6 = bigP.toFixed(6);
     expect(toFixedWorklet(VALUE_P, 6)).toBe(fixedP6);
+
+    // Test negative numbers
+    const values = [
+      { num: '-0.121235', expected: '-0.12', decimalPlaces: 2 },
+      { num: '-1.345678', expected: '-1.346', decimalPlaces: 3 },
+    ];
+    values.forEach(({ num, expected, decimalPlaces }) => {
+      expect(toFixedWorklet(num, decimalPlaces)).toBe(expected);
+      expect(toFixedWorklet(Number(num), decimalPlaces)).toBe(expected);
+    });
   });
 
   test('ceilWorklet', () => {
@@ -266,7 +276,8 @@ describe('SafeMath', () => {
     expect(roundWorklet(Number(VALUE_D))).toBe(RESULTS.ceil);
     expect(roundWorklet(VALUE_L)).toBe('0');
     expect(roundWorklet('-2500.4')).toBe('-2500');
-    const roundedNegative = new BigNumber('-2500.5').toFixed(0, BigNumber.ROUND_HALF_UP);
+
+    const roundedNegative = new BigNumber('-2500.5').toFixed(0);
     expect(roundWorklet('-2500.5')).toBe(roundedNegative);
   });
 

--- a/src/safe-math/__tests__/SafeMath.test.ts
+++ b/src/safe-math/__tests__/SafeMath.test.ts
@@ -269,41 +269,49 @@ describe('SafeMath', () => {
     const roundedNegative = new BigNumber('-2500.5').toFixed(0, BigNumber.ROUND_HALF_UP);
     expect(roundWorklet('-2500.5')).toBe(roundedNegative);
   });
-});
 
-test('toScaledIntegerWorklet', () => {
-  expect(toScaledIntegerWorklet(VALUE_E, 18)).toBe(RESULTS.toScaledInteger);
+  test('toScaledIntegerWorklet', () => {
+    expect(toScaledIntegerWorklet(VALUE_E, 18)).toBe(RESULTS.toScaledInteger);
 
-  const scaledL8 = new BigNumber(VALUE_L).shiftedBy(8).toFixed(0);
-  expect(toScaledIntegerWorklet(VALUE_L, 8)).toBe(scaledL8);
+    const scaledL8 = new BigNumber(VALUE_L).shiftedBy(8).toFixed(0);
+    expect(toScaledIntegerWorklet(VALUE_L, 8)).toBe(scaledL8);
 
-  const scaledN2 = new BigNumber(VALUE_N).shiftedBy(2).toFixed(0);
-  expect(toScaledIntegerWorklet(VALUE_N, 2)).toBe(scaledN2);
-});
-
-test('orderOfMagnitude', () => {
-  [
-    VALUE_H,
-    VALUE_L,
-    VALUE_M,
-    VALUE_N,
-    VALUE_O,
-    VALUE_P,
-    '12500',
-    '5000',
-    '500',
-    '50',
-    '97.29560620602980607032',
-    '0.6',
-    '0.04219495',
-    '0.00133253382018097672',
-    '0.00064470276596066749',
-  ].forEach(value => {
-    const bigNumberResult = new BigNumber(value).e;
-    expect(orderOfMagnitudeWorklet(value)).toBe(bigNumberResult);
+    const scaledN2 = new BigNumber(VALUE_N).shiftedBy(2).toFixed(0);
+    expect(toScaledIntegerWorklet(VALUE_N, 2)).toBe(scaledN2);
   });
 
-  expect(orderOfMagnitudeWorklet(VALUE_H)).toBe(Number(RESULTS.orderOfMagnitude));
+  test('orderOfMagnitude', () => {
+    [
+      VALUE_H,
+      VALUE_L,
+      VALUE_M,
+      VALUE_N,
+      VALUE_O,
+      VALUE_P,
+      '12500',
+      '5000',
+      '500',
+      '50',
+      '97.29560620602980607032',
+      '0.6',
+      '0.04219495',
+      '0.00133253382018097672',
+      '0.00064470276596066749',
+    ].forEach(value => {
+      const bigNumberResult = new BigNumber(value).e;
+      expect(orderOfMagnitudeWorklet(value)).toBe(bigNumberResult);
+    });
+
+    expect(orderOfMagnitudeWorklet(VALUE_H)).toBe(Number(RESULTS.orderOfMagnitude));
+  });
+
+  test('exponents', () => {
+    expect(new BigNumber(VALUE_L).plus(VALUE_M).toFixed()).toBe(sumWorklet(VALUE_L, VALUE_M));
+    expect(new BigNumber(VALUE_N).minus(ONE_HUNDRED).toFixed()).toBe(subWorklet(VALUE_N, ONE_HUNDRED));
+    expect(new BigNumber(VALUE_L).times(VALUE_M).toFixed()).toBe(mulWorklet(VALUE_L, VALUE_M));
+    expect(new BigNumber(VALUE_M).div(VALUE_L).toFixed()).toBe(divWorklet(VALUE_M, VALUE_L));
+    expect(new BigNumber(VALUE_M).mod(VALUE_L).toFixed()).toBe(modWorklet(VALUE_M, VALUE_L));
+  });
 });
 
 describe('BigNumber', () => {
@@ -360,13 +368,5 @@ describe('BigNumber', () => {
 
   test('toScaledInteger', () => {
     expect(new BigNumber(VALUE_E).shiftedBy(18).toFixed(0)).toBe(RESULTS.toScaledInteger);
-  });
-
-  test('exponents', () => {
-    expect(new BigNumber(VALUE_L).plus(VALUE_M).toFixed()).toBe(sumWorklet(VALUE_L, VALUE_M));
-    expect(new BigNumber(VALUE_N).minus(ONE_HUNDRED).toFixed()).toBe(subWorklet(VALUE_N, ONE_HUNDRED));
-    expect(new BigNumber(VALUE_L).times(VALUE_M).toFixed()).toBe(mulWorklet(VALUE_L, VALUE_M));
-    expect(new BigNumber(VALUE_M).div(VALUE_L).toFixed()).toBe(divWorklet(VALUE_M, VALUE_L));
-    expect(new BigNumber(VALUE_M).mod(VALUE_L).toFixed()).toBe(modWorklet(VALUE_M, VALUE_L));
   });
 });

--- a/src/safe-math/__tests__/SafeMath.test.ts
+++ b/src/safe-math/__tests__/SafeMath.test.ts
@@ -33,7 +33,7 @@ const RESULTS = {
   negativePow: '0.001',
   negativeExp: '6.0895415516156',
   orderOfMagnitude: '29',
-  divWithExp: '100000000000000000000000',
+  divWithExp: '1000000000000000000000',
 };
 
 const VALUE_A = '1243425.345';
@@ -53,6 +53,12 @@ const TEN = '10';
 const MINUS_3 = '-3';
 const NON_NUMERIC_STRING = 'abc';
 
+const VALUE_L = '1.23e-5';
+const VALUE_M = '9.99999e-5';
+const VALUE_N = '-2.5e3';
+const VALUE_O = '5.00000000000000000001e-18';
+const VALUE_P = '99999999999999999999.9999999999';
+
 describe('SafeMath', () => {
   test('sumWorklet', () => {
     expect(() => sumWorklet(NON_NUMERIC_STRING, VALUE_B)).toThrow('Arguments must be a numeric string or number');
@@ -63,6 +69,12 @@ describe('SafeMath', () => {
     expect(sumWorklet(VALUE_A, VALUE_B)).toBe(RESULTS.sum);
     expect(sumWorklet(Number(VALUE_A), VALUE_B)).toBe(RESULTS.sum);
     expect(sumWorklet(VALUE_A, Number(VALUE_B))).toBe(RESULTS.sum);
+
+    const sumLM = new BigNumber(VALUE_L).plus(VALUE_M).toFixed();
+    expect(sumWorklet(VALUE_L, VALUE_M)).toBe(sumLM);
+
+    const sumN_100 = new BigNumber(VALUE_N).plus(100).toFixed();
+    expect(sumWorklet(VALUE_N, '100')).toBe(sumN_100);
   });
 
   test('subWorklet', () => {
@@ -75,6 +87,12 @@ describe('SafeMath', () => {
     expect(subWorklet(VALUE_A, VALUE_B)).toBe(RESULTS.sub);
     expect(subWorklet(Number(VALUE_A), VALUE_B)).toBe(RESULTS.sub);
     expect(subWorklet(VALUE_A, Number(VALUE_B))).toBe(RESULTS.sub);
+
+    const subML = new BigNumber(VALUE_M).minus(VALUE_L).toFixed();
+    expect(subWorklet(VALUE_M, VALUE_L)).toBe(subML);
+
+    const subNN = new BigNumber(VALUE_N).minus(VALUE_N).toFixed();
+    expect(subWorklet(VALUE_N, VALUE_N)).toBe(subNN);
   });
 
   test('mulWorklet', () => {
@@ -87,6 +105,12 @@ describe('SafeMath', () => {
     expect(mulWorklet(Number(VALUE_A), VALUE_B)).toBe(RESULTS.mul);
     expect(mulWorklet(VALUE_A, Number(VALUE_B))).toBe(RESULTS.mul);
     expect(mulWorklet(VALUE_F, VALUE_G)).toBe(RESULTS.negativeExp);
+
+    const mulLM = new BigNumber(VALUE_L).times(VALUE_M).toFixed();
+    expect(mulWorklet(VALUE_L, VALUE_M)).toBe(mulLM);
+
+    const mulN_001 = new BigNumber(VALUE_N).times('0.001').toFixed();
+    expect(mulWorklet(VALUE_N, '0.001')).toBe(mulN_001);
   });
 
   test('divWorklet', () => {
@@ -99,6 +123,12 @@ describe('SafeMath', () => {
     expect(divWorklet(Number(VALUE_A), VALUE_B)).toBe(RESULTS.div);
     expect(divWorklet(VALUE_A, Number(VALUE_B))).toBe(RESULTS.div);
     expect(divWorklet(VALUE_I, VALUE_K)).toBe(RESULTS.divWithExp);
+
+    const divML = new BigNumber(VALUE_M).div(VALUE_L).toFixed();
+    expect(divWorklet(VALUE_M, VALUE_L)).toBe(divML);
+
+    const divN_125 = new BigNumber(VALUE_N).div('-1.25').toFixed();
+    expect(divWorklet(VALUE_N, '-1.25')).toBe(divN_125);
   });
 
   test('modWorklet', () => {
@@ -110,6 +140,12 @@ describe('SafeMath', () => {
     expect(modWorklet(VALUE_A, VALUE_B)).toBe(RESULTS.mod);
     expect(modWorklet(Number(VALUE_A), VALUE_B)).toBe(RESULTS.mod);
     expect(modWorklet(VALUE_A, Number(VALUE_B))).toBe(RESULTS.mod);
+
+    const modML = new BigNumber(VALUE_M).mod(VALUE_L).toFixed();
+    expect(modWorklet(VALUE_M, VALUE_L)).toBe(modML);
+
+    const modN_500 = new BigNumber(VALUE_N).mod('500').toFixed();
+    expect(modWorklet(VALUE_N, '500')).toBe(modN_500);
   });
 
   test('powWorklet', () => {
@@ -121,6 +157,12 @@ describe('SafeMath', () => {
     expect(powWorklet(Number(VALUE_A), VALUE_C)).toBe(RESULTS.pow);
     expect(powWorklet(VALUE_A, Number(VALUE_C))).toBe(RESULTS.pow);
     expect(powWorklet(TEN, Number(MINUS_3))).toBe(RESULTS.negativePow);
+
+    const powL_2 = new BigNumber(VALUE_L).pow(2).toFixed();
+    expect(powWorklet(VALUE_L, 2)).toBe(powL_2);
+
+    const powNegative = new BigNumber('-2.5').pow(3).toFixed();
+    expect(powWorklet('-2.5', 3)).toBe(powNegative);
   });
 
   test('equalWorklet', () => {
@@ -132,6 +174,8 @@ describe('SafeMath', () => {
     expect(equalWorklet(NEGATIVE_VALUE, NEGATIVE_VALUE)).toBe(true);
     expect(equalWorklet(Number(VALUE_A), VALUE_A)).toBe(true);
     expect(equalWorklet(VALUE_A, Number(VALUE_A))).toBe(true);
+    expect(equalWorklet('1.23e-5', '0.0000123')).toBe(true);
+    expect(equalWorklet(VALUE_N, '-2500')).toBe(true);
   });
 
   test('greaterThanWorklet', () => {
@@ -143,6 +187,8 @@ describe('SafeMath', () => {
     expect(greaterThanWorklet(NEGATIVE_VALUE, VALUE_A)).toBe(false);
     expect(greaterThanWorklet(Number(VALUE_A), VALUE_B)).toBe(true);
     expect(greaterThanWorklet(VALUE_A, Number(VALUE_B))).toBe(true);
+    expect(greaterThanWorklet(VALUE_M, VALUE_L)).toBe(true);
+    expect(greaterThanWorklet(VALUE_N, '0')).toBe(false);
   });
 
   test('greaterThanOrEqualToWorklet', () => {
@@ -154,6 +200,8 @@ describe('SafeMath', () => {
     expect(greaterThanOrEqualToWorklet(NEGATIVE_VALUE, VALUE_A)).toBe(false);
     expect(greaterThanOrEqualToWorklet(Number(VALUE_A), VALUE_B)).toBe(true);
     expect(greaterThanOrEqualToWorklet(VALUE_A, Number(VALUE_B))).toBe(true);
+    expect(greaterThanOrEqualToWorklet(VALUE_L, VALUE_L)).toBe(true);
+    expect(greaterThanOrEqualToWorklet(VALUE_N, '-3000')).toBe(true);
   });
 
   test('lessThanWorklet', () => {
@@ -165,6 +213,8 @@ describe('SafeMath', () => {
     expect(lessThanWorklet(NEGATIVE_VALUE, VALUE_A)).toBe(true);
     expect(lessThanWorklet(Number(VALUE_A), VALUE_B)).toBe(false);
     expect(lessThanWorklet(VALUE_A, Number(VALUE_B))).toBe(false);
+    expect(lessThanWorklet(VALUE_L, VALUE_M)).toBe(true);
+    expect(lessThanWorklet(VALUE_N, '-2400')).toBe(true);
   });
 
   test('lessThanOrEqualToWorklet', () => {
@@ -176,31 +226,35 @@ describe('SafeMath', () => {
     expect(lessThanOrEqualToWorklet(NEGATIVE_VALUE, VALUE_A)).toBe(true);
     expect(lessThanOrEqualToWorklet(Number(VALUE_A), VALUE_B)).toBe(false);
     expect(lessThanOrEqualToWorklet(VALUE_A, Number(VALUE_B))).toBe(false);
+    expect(lessThanOrEqualToWorklet(VALUE_L, VALUE_L)).toBe(true);
+    expect(lessThanOrEqualToWorklet(VALUE_N, '-2500')).toBe(true);
   });
 
   test('toFixedWorklet', () => {
     expect(toFixedWorklet(VALUE_A, 2)).toBe(RESULTS.toFixed);
     expect(toFixedWorklet(Number(VALUE_A), 2)).toBe(RESULTS.toFixed);
 
-    // Test negative numbers
-    const values = [
-      { num: '-0.121235', expected: '-0.12', decimalPlaces: 2 },
-      { num: '-1.345678', expected: '-1.346', decimalPlaces: 3 },
-    ];
-    values.forEach(({ num, expected, decimalPlaces }) => {
-      expect(toFixedWorklet(num, decimalPlaces)).toBe(expected);
-      expect(toFixedWorklet(Number(num), decimalPlaces)).toBe(expected);
-    });
+    const bigO = new BigNumber(VALUE_O);
+    const fixedO = bigO.toFixed(18);
+    expect(toFixedWorklet(VALUE_O, 18)).toBe(fixedO);
+
+    const bigP = new BigNumber(VALUE_P);
+    const fixedP6 = bigP.toFixed(6);
+    expect(toFixedWorklet(VALUE_P, 6)).toBe(fixedP6);
   });
 
   test('ceilWorklet', () => {
     expect(ceilWorklet(VALUE_A)).toBe(RESULTS.ceil);
     expect(ceilWorklet(Number(VALUE_A))).toBe(RESULTS.ceil);
+    expect(ceilWorklet(VALUE_L)).toBe('1');
+    expect(ceilWorklet(VALUE_N)).toBe('-2499');
   });
 
   test('floorWorklet', () => {
     expect(floorWorklet(VALUE_A)).toBe(RESULTS.floor);
     expect(floorWorklet(Number(VALUE_A))).toBe(RESULTS.floor);
+    expect(floorWorklet(VALUE_M)).toBe('0');
+    expect(floorWorklet(VALUE_N)).toBe('-2500');
   });
 
   test('roundWorklet', () => {
@@ -208,24 +262,46 @@ describe('SafeMath', () => {
     expect(roundWorklet(VALUE_D)).toBe(RESULTS.ceil);
     expect(roundWorklet(Number(VALUE_A))).toBe(RESULTS.floor);
     expect(roundWorklet(Number(VALUE_D))).toBe(RESULTS.ceil);
+    expect(roundWorklet(VALUE_L)).toBe('0');
+    expect(roundWorklet('-2500.4')).toBe('-2500');
+    const roundedNegative = new BigNumber('-2500.5').toFixed(0, BigNumber.ROUND_HALF_UP);
+    expect(roundWorklet('-2500.5')).toBe(roundedNegative);
+  });
+});
+
+test('toScaledIntegerWorklet', () => {
+  expect(toScaledIntegerWorklet(VALUE_E, 18)).toBe(RESULTS.toScaledInteger);
+
+  const scaledL8 = new BigNumber(VALUE_L).shiftedBy(8).toFixed(0);
+  expect(toScaledIntegerWorklet(VALUE_L, 8)).toBe(scaledL8);
+
+  const scaledN2 = new BigNumber(VALUE_N).shiftedBy(2).toFixed(0);
+  expect(toScaledIntegerWorklet(VALUE_N, 2)).toBe(scaledN2);
+});
+
+test('orderOfMagnitude', () => {
+  [
+    VALUE_H,
+    VALUE_L,
+    VALUE_M,
+    VALUE_N,
+    VALUE_O,
+    VALUE_P,
+    '12500',
+    '5000',
+    '500',
+    '50',
+    '97.29560620602980607032',
+    '0.6',
+    '0.04219495',
+    '0.00133253382018097672',
+    '0.00064470276596066749',
+  ].forEach(value => {
+    const bigNumberResult = new BigNumber(value).e;
+    expect(orderOfMagnitudeWorklet(value)).toBe(bigNumberResult);
   });
 
-  test('toScaledIntegerWorklet', () => {
-    expect(toScaledIntegerWorklet(VALUE_E, 18)).toBe(RESULTS.toScaledInteger);
-  });
-
-  test('orderOfMagnitude', () => {
-    expect(orderOfMagnitudeWorklet(VALUE_H)).toBe(Number(RESULTS.orderOfMagnitude));
-    expect(orderOfMagnitudeWorklet('12500')).toBe(4);
-    expect(orderOfMagnitudeWorklet('5000')).toBe(3);
-    expect(orderOfMagnitudeWorklet('500')).toBe(2);
-    expect(orderOfMagnitudeWorklet('50')).toBe(1);
-    expect(orderOfMagnitudeWorklet('97.29560620602980607032')).toBe(1);
-    expect(orderOfMagnitudeWorklet('0.6')).toBe(-1);
-    expect(orderOfMagnitudeWorklet('0.04219495')).toBe(-2);
-    expect(orderOfMagnitudeWorklet('0.00133253382018097672')).toBe(-3);
-    expect(orderOfMagnitudeWorklet('0.00064470276596066749')).toBe(-4);
-  });
+  expect(orderOfMagnitudeWorklet(VALUE_H)).toBe(Number(RESULTS.orderOfMagnitude));
 });
 
 describe('BigNumber', () => {
@@ -282,5 +358,13 @@ describe('BigNumber', () => {
 
   test('toScaledInteger', () => {
     expect(new BigNumber(VALUE_E).shiftedBy(18).toFixed(0)).toBe(RESULTS.toScaledInteger);
+  });
+
+  test('exponents', () => {
+    expect(new BigNumber(VALUE_L).plus(VALUE_M).toFixed()).toBe(sumWorklet(VALUE_L, VALUE_M));
+    expect(new BigNumber(VALUE_N).minus('100').toFixed()).toBe(subWorklet(VALUE_N, '100'));
+    expect(new BigNumber(VALUE_L).times(VALUE_M).toFixed()).toBe(mulWorklet(VALUE_L, VALUE_M));
+    expect(new BigNumber(VALUE_M).div(VALUE_L).toFixed()).toBe(divWorklet(VALUE_M, VALUE_L));
+    expect(new BigNumber(VALUE_M).mod(VALUE_L).toFixed()).toBe(modWorklet(VALUE_M, VALUE_L));
   });
 });

--- a/src/safe-math/__tests__/SafeMath.test.ts
+++ b/src/safe-math/__tests__/SafeMath.test.ts
@@ -50,6 +50,7 @@ const NEGATIVE_VALUE = '-2412.12';
 const ZERO = '0';
 const ONE = '1';
 const TEN = '10';
+const ONE_HUNDRED = '100';
 const MINUS_3 = '-3';
 const NON_NUMERIC_STRING = 'abc';
 
@@ -73,8 +74,8 @@ describe('SafeMath', () => {
     const sumLM = new BigNumber(VALUE_L).plus(VALUE_M).toFixed();
     expect(sumWorklet(VALUE_L, VALUE_M)).toBe(sumLM);
 
-    const sumN_100 = new BigNumber(VALUE_N).plus(100).toFixed();
-    expect(sumWorklet(VALUE_N, '100')).toBe(sumN_100);
+    const sumN_100 = new BigNumber(VALUE_N).plus(ONE_HUNDRED).toFixed();
+    expect(sumWorklet(VALUE_N, ONE_HUNDRED)).toBe(sumN_100);
   });
 
   test('subWorklet', () => {
@@ -123,6 +124,7 @@ describe('SafeMath', () => {
     expect(divWorklet(Number(VALUE_A), VALUE_B)).toBe(RESULTS.div);
     expect(divWorklet(VALUE_A, Number(VALUE_B))).toBe(RESULTS.div);
     expect(divWorklet(VALUE_I, VALUE_K)).toBe(RESULTS.divWithExp);
+    expect(new BigNumber(VALUE_I).div(VALUE_K).toFixed()).toBe(RESULTS.divWithExp);
 
     const divML = new BigNumber(VALUE_M).div(VALUE_L).toFixed();
     expect(divWorklet(VALUE_M, VALUE_L)).toBe(divML);
@@ -362,7 +364,7 @@ describe('BigNumber', () => {
 
   test('exponents', () => {
     expect(new BigNumber(VALUE_L).plus(VALUE_M).toFixed()).toBe(sumWorklet(VALUE_L, VALUE_M));
-    expect(new BigNumber(VALUE_N).minus('100').toFixed()).toBe(subWorklet(VALUE_N, '100'));
+    expect(new BigNumber(VALUE_N).minus(ONE_HUNDRED).toFixed()).toBe(subWorklet(VALUE_N, ONE_HUNDRED));
     expect(new BigNumber(VALUE_L).times(VALUE_M).toFixed()).toBe(mulWorklet(VALUE_L, VALUE_M));
     expect(new BigNumber(VALUE_M).div(VALUE_L).toFixed()).toBe(divWorklet(VALUE_M, VALUE_L));
     expect(new BigNumber(VALUE_M).mod(VALUE_L).toFixed()).toBe(modWorklet(VALUE_M, VALUE_L));


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Fixes handling of scientific notation in the `SafeMath` functions
- Fixes rounding of negative numbers (up = away from zero)
- Adds new test cases that failed previously, primarily due to the two issues above
- Fixes the `divWithExp` result which was previously incorrect
- Fixes the chart price formatting bug where numbers would be chopped at e.g., `0.000`, as a result of these bugs

## With the updated tests, but without the SafeMath fixes:
<img width="499" alt="Screenshot 2025-01-30 at 12 33 33 AM" src="https://github.com/user-attachments/assets/25fa8d2a-f416-4df9-88b7-b6bf268624a4" />
<img width="486" alt="Screenshot 2025-01-30 at 12 34 34 AM" src="https://github.com/user-attachments/assets/9edcdbe5-80b2-4e96-9490-8f6a81286619" />

## With the SafeMath fixes:
<img width="490" alt="Screenshot 2025-01-30 at 12 23 14 AM" src="https://github.com/user-attachments/assets/958f052b-a8e3-4c65-a675-057ea1a55015" />

---

_(Have since fixed the grouping of tests in the logs — the test results are unchanged.)_

## Screen recordings / screenshots


## What to test

