### PR TITLE
Claim Bridge Slippage Adjustment to Follow Config & Better Error Logging

### DIFF
--- a/src/raps/actions/claimBridge.ts
+++ b/src/raps/actions/claimBridge.ts
@@ -20,6 +20,8 @@ import { ActionProps } from '../references';
 import { executeCrosschainSwap } from './crosschainSwap';
 import { ChainId } from '@/state/backendNetworks/types';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { getDefaultSlippageWorklet } from '@/__swaps__/utils/swaps';
+import { getRemoteConfig } from '@/model/remoteConfig';
 
 // This action is used to bridge the claimed funds to another chain
 export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps<'claimBridge'>) {
@@ -43,7 +45,7 @@ export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps
     sellTokenAddress: AddressZero,
     buyTokenAddress: AddressZero,
     sellAmount: sellAmount,
-    slippage: 5,
+    slippage: +getDefaultSlippageWorklet(chainId, getRemoteConfig()),
     currency,
   });
 
@@ -102,7 +104,7 @@ export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps
       sellTokenAddress: AddressZero,
       buyTokenAddress: AddressZero,
       sellAmount: maxBridgeableAmount,
-      slippage: 2,
+      slippage: +getDefaultSlippageWorklet(chainId, getRemoteConfig()),
       currency,
     });
 

--- a/src/raps/actions/claimBridge.ts
+++ b/src/raps/actions/claimBridge.ts
@@ -43,13 +43,13 @@ export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps
     sellTokenAddress: AddressZero,
     buyTokenAddress: AddressZero,
     sellAmount: sellAmount,
-    slippage: 2,
+    slippage: 5,
     currency,
   });
 
   // if we don't get a quote or there's an error we can't continue
   if (!claimBridgeQuote || (claimBridgeQuote as QuoteError)?.error) {
-    throw new Error('[CLAIM-BRIDGE]: error getting getClaimBridgeQuote');
+    throw new Error(`[CLAIM-BRIDGE]: error getting getClaimBridgeQuote: ${claimBridgeQuote}`);
   }
 
   let bridgeQuote = claimBridgeQuote as CrosschainQuote;
@@ -60,11 +60,10 @@ export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps
   const provider = getProvider({ chainId: ChainId.optimism });
 
   const l1GasFeeOptimism = await ethereumUtils.calculateL1FeeOptimism(
-    // @ts-expect-error - TODO: fix improper arguments here
     {
       data: bridgeQuote.data,
       from: bridgeQuote.from,
-      to: bridgeQuote.to ?? null,
+      to: bridgeQuote.to,
       value: bridgeQuote.value,
     },
     provider
@@ -108,7 +107,7 @@ export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps
     });
 
     if (!newQuote || (newQuote as QuoteError)?.error) {
-      throw new Error('[CLAIM-BRIDGE]: error getClaimBridgeQuote (new)');
+      throw new Error(`[CLAIM-BRIDGE]: error getClaimBridgeQuote (new): ${newQuote}`);
     }
 
     bridgeQuote = newQuote as CrosschainQuote;
@@ -151,7 +150,7 @@ export async function claimBridge({ parameters, wallet, baseNonce }: ActionProps
   try {
     swap = await executeCrosschainSwap(swapParams);
   } catch (e) {
-    throw new Error('[CLAIM-BRIDGE]: crosschainSwap error');
+    throw new Error(`[CLAIM-BRIDGE]: crosschainSwap error: ${e}`);
   }
 
   if (!swap) {


### PR DESCRIPTION
Fixes APP-2253

## What changed (plus any additional context for devs)
Surfacing more information about bridging failures after points claims and using our slippage config within the claim bridge logic.

## PoW
<div>
    <a href="https://www.loom.com/share/3af0bd251fff42c0a8923da3ef76a529">
      <p>Testing Slippage Changes - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/3af0bd251fff42c0a8923da3ef76a529">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/3af0bd251fff42c0a8923da3ef76a529-afb0a2c988bfd09d-full-play.gif">
    </a>
  </div>

## What to test
Bridging after claim is not currently working and there is not a great way to test it at the moment either. So we're blocked from testing the slippage change, but I think that's fairly safe to include. Otherwise this PR is just meant to improve the information in Sentry.
