### PR TITLE
Additional query store improvements / fixes

### DIFF
--- a/src/state/internal/queryStore/classes/SubscriptionManager.ts
+++ b/src/state/internal/queryStore/classes/SubscriptionManager.ts
@@ -8,10 +8,6 @@ interface SubscriptionManagerConfig {
    * The store's `disableAutoRefetching` option, passed through from the query config.
    */
   disableAutoRefetching: boolean;
-  /**
-   * The store's initial `enabled` state, as determined in `initialData`.
-   */
-  initialEnabled: boolean;
 }
 
 /**
@@ -34,7 +30,7 @@ interface SubscriptionHandlerConfig {
  */
 export class SubscriptionManager {
   private count = 0;
-  private enabled: boolean;
+  private enabled = false;
   private lastSubscriptionTime: number | null = null;
   private readonly fetchThrottleMs: number | null = null;
 
@@ -44,8 +40,7 @@ export class SubscriptionManager {
   /**
    * Creates a new SubscriptionManager instance.
    */
-  constructor({ disableAutoRefetching, initialEnabled }: SubscriptionManagerConfig) {
-    this.enabled = initialEnabled;
+  constructor({ disableAutoRefetching }: SubscriptionManagerConfig) {
     if (disableAutoRefetching) {
       this.fetchThrottleMs = time.seconds(5);
     }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Follow-up to #6435
  - `hasAllRequiredParams` was iterating over indices instead of values — **`key in`** should have been **`key of`**
    - This was causing false negatives (params complete, but deemed not) that unnecessarily duplicated the param resolving work
- Fixes an `enabled` edge case where if a store was persisted with an `enabled` value different from its `enabled` config value, the `subscriptionManager` could possibly start out with a different `enabled` value than the store. Also fixes a similar issue affecting dynamic enabled params.
  - (Neither of these issues affect the query stores currently in use as they're always enabled)
- Removes `cancel` from the args passed to `fetcher`, as it was simply calling `abort()` on the `abortController` already provided to `fetcher`. And for "hard" aborts to work (to abort the network call itself, not just the work that follows it), you need to pass the `abortController` along to your actual `fetch` request, so it was a bit of a misdirection.

## Screen recordings / screenshots


## What to test

