### PR TITLE
Reintroduce support for crosschain search results in swaps search

### DIFF
--- a/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
+++ b/src/__swaps__/screens/Swap/hooks/useSearchCurrencyLists.ts
@@ -12,7 +12,6 @@ import {
   NAME_SYMBOL_SEARCH_KEYS,
   useSwapsSearchStore,
   useTokenSearchStore,
-  useUnverifiedTokenSearchStore,
 } from '@/__swaps__/screens/Swap/resources/search/searchV2';
 import { AssetToBuySectionId, SearchAsset, TokenToBuyListItem } from '@/__swaps__/types/search';
 import { RecentSwap } from '@/__swaps__/types/swap';
@@ -25,8 +24,7 @@ const MAX_POPULAR_RESULTS = 3;
 
 export function useSearchCurrencyLists() {
   const lastTrackedTimeRef = useRef<number | null>(null);
-  const verifiedAssets = useTokenSearchStore(state => state.getData());
-  const unverifiedAssets = useUnverifiedTokenSearchStore(state => state.getData());
+  const searchResults = useTokenSearchStore(state => state.getData());
   const popularAssets = usePopularTokensStore(state => state.getData());
   const { favoritesMetadata: favorites } = useFavorites();
 
@@ -58,28 +56,28 @@ export function useSearchCurrencyLists() {
   }, [favorites, toChainId]);
 
   const filteredBridgeAsset = useDeepCompareMemo(() => {
-    if (!verifiedAssets?.bridgeAsset) return null;
+    if (!searchResults?.bridgeAsset) return null;
 
     const inputAssetBridgedToSelectedChainAddress = useSwapsStore.getState().inputAsset?.networks?.[toChainId]?.address;
 
     const shouldShowBridgeResult =
       isCrosschainSearch &&
       inputAssetBridgedToSelectedChainAddress &&
-      inputAssetBridgedToSelectedChainAddress === verifiedAssets?.bridgeAsset?.networks?.[toChainId]?.address &&
-      filterBridgeAsset({ asset: verifiedAssets?.bridgeAsset, filter: query });
+      inputAssetBridgedToSelectedChainAddress === searchResults?.bridgeAsset?.networks?.[toChainId]?.address &&
+      filterBridgeAsset({ asset: searchResults?.bridgeAsset, filter: query });
 
-    return shouldShowBridgeResult && verifiedAssets.bridgeAsset
+    return shouldShowBridgeResult && searchResults.bridgeAsset
       ? {
-          ...verifiedAssets.bridgeAsset,
+          ...searchResults.bridgeAsset,
           chainId: toChainId,
           favorite: unfilteredFavorites.some(
             fav =>
               fav.networks?.[toChainId]?.address ===
-              (verifiedAssets?.bridgeAsset?.networks?.[toChainId]?.address || inputAssetBridgedToSelectedChainAddress)
+              (searchResults?.bridgeAsset?.networks?.[toChainId]?.address || inputAssetBridgedToSelectedChainAddress)
           ),
         }
       : null;
-  }, [isCrosschainSearch, query, toChainId, unfilteredFavorites, verifiedAssets?.bridgeAsset]);
+  }, [isCrosschainSearch, query, toChainId, unfilteredFavorites, searchResults?.bridgeAsset]);
 
   const favoritesList = useDeepCompareMemo(() => {
     if (query === '') return unfilteredFavorites;
@@ -110,11 +108,11 @@ export function useSearchCurrencyLists() {
       results: buildListSectionsData({
         combinedData: {
           bridgeAsset: filteredBridgeAsset,
-          crosschainExactMatches: verifiedAssets?.crosschainResults,
+          crosschainExactMatches: searchResults?.crosschainResults,
           popularAssets: popularAssetsForChain,
           recentSwaps: recentsForChain,
-          unverifiedAssets: unverifiedAssets,
-          verifiedAssets: verifiedAssets?.results,
+          unverifiedAssets: searchResults?.unverifiedAssets,
+          verifiedAssets: searchResults?.verifiedAssets,
         },
         favoritesList,
         filteredBridgeAssetAddress: filteredBridgeAsset?.address,
@@ -125,9 +123,9 @@ export function useSearchCurrencyLists() {
     filteredBridgeAsset,
     popularAssetsForChain,
     recentsForChain,
-    unverifiedAssets,
-    verifiedAssets?.crosschainResults,
-    verifiedAssets?.results,
+    searchResults?.crosschainResults,
+    searchResults?.verifiedAssets,
+    searchResults?.unverifiedAssets,
   ]);
 
   useEffect(() => {
@@ -255,7 +253,7 @@ const buildListSectionsData = ({
   combinedData: {
     bridgeAsset: SearchAsset | null;
     verifiedAssets: SearchAsset[] | undefined;
-    unverifiedAssets: SearchAsset[] | null;
+    unverifiedAssets: SearchAsset[] | undefined;
     crosschainExactMatches: SearchAsset[] | undefined;
     recentSwaps: RecentSwap[] | undefined;
     popularAssets: SearchAsset[] | undefined;

--- a/src/__swaps__/screens/Swap/resources/search/searchV2.ts
+++ b/src/__swaps__/screens/Swap/resources/search/searchV2.ts
@@ -6,7 +6,7 @@ import { ChainId } from '@/state/backendNetworks/types';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 import { createQueryStore } from '@/state/internal/createQueryStore';
-import { SearchAsset, TokenSearchAssetKey, TokenSearchThreshold } from '@/__swaps__/types/search';
+import { SearchAsset, TokenSearchAssetKey } from '@/__swaps__/types/search';
 import { time } from '@/utils';
 import { parseTokenSearch } from './utils';
 
@@ -24,7 +24,6 @@ type TokenSearchParams<List extends TokenLists = TokenLists> = {
   keys: TokenSearchAssetKey[];
   list: List;
   query: string | undefined;
-  threshold: TokenSearchThreshold;
 };
 
 type TokenSearchState = {
@@ -66,7 +65,6 @@ export const useTokenSearchStore = createQueryStore<VerifiedTokenData, TokenSear
       chainId: $ => $(useSwapsStore).selectedOutputChainId,
       keys: $ => $(useSwapsSearchStore, state => getSearchKeys(state.searchQuery.trim())),
       query: $ => $(useSwapsSearchStore, state => (state.searchQuery.trim().length ? state.searchQuery.trim() : undefined)),
-      threshold: $ => $(useSwapsSearchStore, state => getSearchThreshold(state.searchQuery.trim())),
     },
     staleTime: time.minutes(2),
   },
@@ -91,7 +89,6 @@ export const useUnverifiedTokenSearchStore = createQueryStore<SearchAsset[], Tok
       chainId: $ => $(useSwapsStore).selectedOutputChainId,
       keys: $ => $(useSwapsSearchStore, state => getSearchKeys(state.searchQuery.trim())),
       query: $ => $(useSwapsSearchStore, state => state.searchQuery.trim()),
-      threshold: $ => $(useSwapsSearchStore, state => getSearchThreshold(state.searchQuery.trim())),
     },
     staleTime: time.minutes(2),
   },
@@ -179,36 +176,28 @@ function getSearchKeys(query: string): TokenSearchAssetKey[] {
   return isAddress(query) ? ADDRESS_SEARCH_KEY : NAME_SYMBOL_SEARCH_KEYS;
 }
 
-const CASE_SENSITIVE_EQUAL_THRESHOLD: TokenSearchThreshold = 'CASE_SENSITIVE_EQUAL';
-const CONTAINS_THRESHOLD: TokenSearchThreshold = 'CONTAINS';
-
-function getSearchThreshold(query: string): TokenSearchThreshold {
-  return isAddress(query) ? CASE_SENSITIVE_EQUAL_THRESHOLD : CONTAINS_THRESHOLD;
-}
-
 const ALL_VERIFIED_TOKENS_PARAM = '/?list=verifiedAssets';
 
 /** Unverified token search */
 async function tokenSearchQueryFunction(
-  { chainId, keys, list, query, threshold }: TokenSearchParams<TokenLists.HighLiquidity>,
+  { chainId, keys, list, query }: TokenSearchParams<TokenLists.HighLiquidity>,
   abortController: AbortController | null
 ): Promise<SearchAsset[]>;
 
 /** Verified token search */
 async function tokenSearchQueryFunction(
-  { chainId, keys, list, query, threshold }: TokenSearchParams<TokenLists.Verified>,
+  { chainId, keys, list, query }: TokenSearchParams<TokenLists.Verified>,
   abortController: AbortController | null
 ): Promise<VerifiedTokenData>;
 
 async function tokenSearchQueryFunction(
-  { chainId, keys, list, query, threshold }: TokenSearchParams,
+  { chainId, keys, list, query }: TokenSearchParams,
   abortController: AbortController | null
 ): Promise<SearchAsset[] | VerifiedTokenData> {
   const queryParams: Omit<TokenSearchParams, 'chainId' | 'keys'> & { keys: string } = {
     keys: keys?.join(','),
     list,
     query,
-    threshold,
   };
 
   const isAddressSearch = query && isAddress(query);

--- a/src/__swaps__/screens/Swap/resources/search/searchV2.ts
+++ b/src/__swaps__/screens/Swap/resources/search/searchV2.ts
@@ -21,7 +21,6 @@ const tokenSearchClient = new RainbowFetchClient({
 
 type TokenSearchParams<List extends TokenLists = TokenLists> = {
   chainId: ChainId;
-  fromChainId?: ChainId;
   keys: TokenSearchAssetKey[];
   list: List;
   query: string | undefined;
@@ -191,22 +190,21 @@ const ALL_VERIFIED_TOKENS_PARAM = '/?list=verifiedAssets';
 
 /** Unverified token search */
 async function tokenSearchQueryFunction(
-  { chainId, fromChainId, keys, list, query, threshold }: TokenSearchParams<TokenLists.HighLiquidity>,
+  { chainId, keys, list, query, threshold }: TokenSearchParams<TokenLists.HighLiquidity>,
   abortController: AbortController | null
 ): Promise<SearchAsset[]>;
 
 /** Verified token search */
 async function tokenSearchQueryFunction(
-  { chainId, fromChainId, keys, list, query, threshold }: TokenSearchParams<TokenLists.Verified>,
+  { chainId, keys, list, query, threshold }: TokenSearchParams<TokenLists.Verified>,
   abortController: AbortController | null
 ): Promise<VerifiedTokenData>;
 
 async function tokenSearchQueryFunction(
-  { chainId, fromChainId, keys, list, query, threshold }: TokenSearchParams,
+  { chainId, keys, list, query, threshold }: TokenSearchParams,
   abortController: AbortController | null
 ): Promise<SearchAsset[] | VerifiedTokenData> {
   const queryParams: Omit<TokenSearchParams, 'chainId' | 'keys'> & { keys: string } = {
-    fromChainId,
     keys: keys?.join(','),
     list,
     query,

--- a/src/__swaps__/screens/Swap/resources/search/searchV2.ts
+++ b/src/__swaps__/screens/Swap/resources/search/searchV2.ts
@@ -48,6 +48,8 @@ enum TokenLists {
 
 const MAX_VERIFIED_RESULTS = 24;
 const MAX_UNVERIFIED_RESULTS = 6;
+const MAX_CROSSCHAIN_RESULTS = 3;
+
 const NO_RESULTS: VerifiedTokenData = { bridgeAsset: null, crosschainResults: [], verifiedAssets: [], unverifiedAssets: [] };
 
 export const useSwapsSearchStore = createRainbowStore<SearchQueryState>(() => ({ searchQuery: '' }));
@@ -129,7 +131,7 @@ function selectTopSearchResults({
 
   return {
     bridgeAsset,
-    crosschainResults: crosschainResults,
+    crosschainResults: crosschainResults.slice(0, MAX_CROSSCHAIN_RESULTS),
     verifiedAssets: currentChainVerifiedResults.slice(0, MAX_VERIFIED_RESULTS),
     unverifiedAssets: currentChainUnverifiedResults.slice(0, MAX_UNVERIFIED_RESULTS),
   };

--- a/src/__swaps__/screens/Swap/resources/search/searchV2.ts
+++ b/src/__swaps__/screens/Swap/resources/search/searchV2.ts
@@ -1,4 +1,3 @@
-import { isAddress } from '@ethersproject/address';
 import qs from 'qs';
 import { RainbowError, logger } from '@/logger';
 import { RainbowFetchClient } from '@/rainbow-fetch';
@@ -164,8 +163,6 @@ async function tokenSearchQueryFunction(
     query,
   };
 
-  const isAddressSearch = query && isAddress(query);
-
   const searchDefaultVerifiedList = query === '';
   if (searchDefaultVerifiedList) {
     queryParams.list = 'verifiedAssets';
@@ -174,18 +171,8 @@ async function tokenSearchQueryFunction(
   const url = `${searchDefaultVerifiedList ? `/${chainId}` : ''}/?${qs.stringify(queryParams)}`;
 
   try {
-    if (isAddressSearch) {
-      const tokenSearch = await tokenSearchClient.get<{ data: SearchAsset[] }>(url);
-
-      if (tokenSearch && tokenSearch.data.data.length > 0) {
-        return selectTopSearchResults({ abortController, data: parseTokenSearchResults(tokenSearch.data.data), query, toChainId: chainId });
-      } else {
-        return NO_RESULTS;
-      }
-    } else {
-      const tokenSearch = await tokenSearchClient.get<{ data: SearchAsset[] }>(url);
-      return selectTopSearchResults({ abortController, data: parseTokenSearchResults(tokenSearch.data.data), query, toChainId: chainId });
-    }
+    const tokenSearch = await tokenSearchClient.get<{ data: SearchAsset[] }>(url);
+    return selectTopSearchResults({ abortController, data: parseTokenSearchResults(tokenSearch.data.data), query, toChainId: chainId });
   } catch (e) {
     logger.error(new RainbowError('[tokenSearchQueryFunction]: Token search failed'), { url });
     return NO_RESULTS;

--- a/src/__swaps__/screens/Swap/resources/search/utils.ts
+++ b/src/__swaps__/screens/Swap/resources/search/utils.ts
@@ -4,6 +4,27 @@ import { SearchAsset } from '@/__swaps__/types/search';
 import { Address } from 'viem';
 import { isNativeAsset } from '@/handlers/assets';
 
+export function parseTokenSearchResults(assets: SearchAsset[]): SearchAsset[] {
+  const results: SearchAsset[] = [];
+
+  for (const asset of assets) {
+    const assetNetworks = asset.networks;
+    const mainnetInfo = assetNetworks[ChainId.mainnet];
+    const address = asset.address;
+    const chainId = asset.chainId;
+    const uniqueId = `${address}_${chainId}`;
+
+    results.push({
+      ...asset,
+      isNativeAsset: isNativeAsset(address, chainId),
+      mainnetAddress: mainnetInfo ? mainnetInfo.address : chainId === ChainId.mainnet ? address : ('' as Address),
+      uniqueId,
+    });
+  }
+
+  return results;
+}
+
 export function parseTokenSearch(assets: SearchAsset[], chainId?: ChainId): SearchAsset[] {
   const results: SearchAsset[] = [];
 


### PR DESCRIPTION
Fixes APP-2321

## What changed (plus any additional context for devs)
1. Consolidate calls that were being done separately for verified and unverified results. The new v3 endpoint allows consolidation across chains as well as "lists" (e.g, verified, high liquidity unverified, and low liquidity unverified). We can reduce the number of calls we were doing.
2. Re-introduce crosschain search results when there's an exact match on the query.


## Screen recordings / screenshots
Example showing crosschain results:
<img width="438" alt="Screenshot 2025-02-02 at 6 05 34 PM" src="https://github.com/user-attachments/assets/31e2dd52-734f-439f-8d20-722515ac1c5d" />

Another example showing crosschain results:
<img width="429" alt="Screenshot 2025-02-02 at 6 05 25 PM" src="https://github.com/user-attachments/assets/7b7e6087-047b-4470-beac-9f806d5afb6f" />

Example showing result for address search:
<img width="468" alt="Screenshot 2025-02-02 at 12 06 50 PM" src="https://github.com/user-attachments/assets/16f7ac17-c277-4e27-a4f9-c1942c4bbc45" />


## What to test
* Test that swap search results still behave as expected, with the addition of crosschain search results showing up when there is an exact match (in name or symbol)
* Test that pasting in a full address still works as expected

