### PR TITLE
Fix: Manual seed phrase entry removes spaces automatically

### DIFF
--- a/src/graphql/queries/arc.graphql
+++ b/src/graphql/queries/arc.graphql
@@ -5,7 +5,7 @@ fragment asset on Asset {
   name
 }
 
-fragment amount on AssetAmount {
+fragment assetAmount on AssetAmount {
   raw
   decimal
   usd
@@ -32,10 +32,10 @@ query getNFTOffers($walletAddress: String!, $sortBy: SortCriterion!) {
       imageUrl
     }
     grossAmount {
-      ...amount
+      ...assetAmount
     }
     netAmount {
-      ...amount
+      ...assetAmount
     }
     paymentToken {
       ...asset
@@ -44,7 +44,7 @@ query getNFTOffers($walletAddress: String!, $sortBy: SortCriterion!) {
     feesPercentage
     floorPrice {
       amount {
-        ...amount
+        ...assetAmount
       }
       paymentToken {
         ...asset

--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -16,7 +16,7 @@ query getEnsMarquee {
   }
 }
 
-fragment amount on RewardsAmount {
+fragment rewardsAmount on RewardsAmount {
   usd
   token
 }
@@ -50,7 +50,7 @@ query getRewardsDataForWallet($address: String!) {
     ...baseQuery
     earnings {
       total {
-        ...amount
+        ...rewardsAmount
       }
       multiplier {
         amount
@@ -60,7 +60,7 @@ query getRewardsDataForWallet($address: String!) {
         }
       }
       pending {
-        ...amount
+        ...rewardsAmount
       }
       daily {
         day
@@ -73,7 +73,7 @@ query getRewardsDataForWallet($address: String!) {
       actions {
         type
         amount {
-          ...amount
+          ...rewardsAmount
         }
         rewardPercent
       }
@@ -131,7 +131,7 @@ query getdApps {
   }
 }
 
-fragment asset on TransactionSimulationAsset {
+fragment transactionSimulationAsset on TransactionSimulationAsset {
   assetCode
   decimals
   iconURL
@@ -144,21 +144,9 @@ fragment asset on TransactionSimulationAsset {
   status
 }
 
-fragment asset on TransactionSimulationAsset {
-  assetCode
-  decimals
-  iconURL
-  name
-  network
-  symbol
-  type
-  interface
-  tokenId
-  status
-}
 fragment change on TransactionSimulationChange {
   asset {
-    ...asset
+    ...transactionSimulationAsset
   }
   price
   quantity
@@ -202,7 +190,7 @@ query simulateTransactions($chainId: Int!, $transactions: [Transaction!], $domai
       }
       approvals {
         asset {
-          ...asset
+          ...transactionSimulationAsset
         }
         spender {
           ...target
@@ -240,7 +228,7 @@ query simulateMessage($address: String!, $chainId: Int!, $message: Message!, $do
       }
       approvals {
         asset {
-          ...asset
+          ...transactionSimulationAsset
         }
         spender {
           ...target

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -77,7 +77,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
   const handleSetSeedPhrase = useCallback(
     (text: string) => {
       if (isImporting) return null;
-      return setSeedPhrase(text.trim());
+      return setSeedPhrase(text);
     },
     [isImporting]
   );

--- a/src/screens/ImportOrWatchWalletSheet.tsx
+++ b/src/screens/ImportOrWatchWalletSheet.tsx
@@ -94,7 +94,9 @@ export const ImportOrWatchWalletSheet = () => {
               <ButtonPressAnimation
                 disabled={buttonDisabled}
                 onPress={
-                  seedPhrase ? handlePressImportButton : () => Clipboard.getString().then((text: string) => handleSetSeedPhrase(text))
+                  seedPhrase
+                    ? handlePressImportButton
+                    : () => Clipboard.getString().then((text: string) => handleSetSeedPhrase(text.trim()))
                 }
                 overflowMargin={50}
                 testID="import-sheet-button"


### PR DESCRIPTION
Fixes APP-2352

## What changed (plus any additional context for devs)
Fixes a misplaced `.trim()` causing manual entry of seedphrases to not allow whitespace.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/8ecf3733-9a85-4cb5-bee4-5f15686c95c4

## What to test
pasting should still trim whitespace
typing it out should not remove whitespace
