### PR TITLE
Add Scrolling to NetworkSwitcher

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -530,9 +530,8 @@ function NetworkFilter() {
 
   const setSelected = useCallback(
     (chainId: ChainId | undefined) => {
-      'worklet';
       selected.value = chainId;
-      runOnJS(setChainId)(chainId);
+      setChainId(chainId);
     },
     [selected, setChainId]
   );

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -835,8 +835,10 @@ function Sheet({
     const distanceFromBottom = containerHeight.value - (scrollY.value + scrollViewHeight.value);
     const fadeStartDistance = FOOTER_HEIGHT; // Start fading when FOOTER_HEIGHT px from bottom
 
-    let fadeOpacity = 1;
-    if (distanceFromBottom < fadeStartDistance) {
+    const isLessThanMaxHeight = containerHeight.value < MAX_HEIGHT;
+
+    let fadeOpacity = isLessThanMaxHeight ? 0 : 1;
+    if (distanceFromBottom < fadeStartDistance && !isLessThanMaxHeight) {
       fadeOpacity = Math.max(0, distanceFromBottom / fadeStartDistance);
     }
 

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -121,6 +121,7 @@ export type RootStackParamList = {
     canEdit?: boolean;
     canSelectAllNetworks?: boolean;
     allowedNetworks?: ChainId[];
+    goBackOnSelect?: boolean;
   };
   [Routes.LOG_SHEET]: {
     data: {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -115,9 +115,12 @@ export type RootStackParamList = {
     position: RainbowPosition;
   };
   [Routes.NETWORK_SELECTOR]: {
-    onClose?: VoidFunction;
-    selected: SharedValue<ChainId | undefined>;
+    selected: SharedValue<ChainId | undefined> | ChainId | undefined;
     setSelected: (chainId: ChainId | undefined) => void;
+    onClose?: VoidFunction;
+    canEdit?: boolean;
+    canSelectAllNetworks?: boolean;
+    allowedNetworks?: ChainId[];
   };
   [Routes.LOG_SHEET]: {
     data: {


### PR DESCRIPTION
Fixes APP-2341

## What changed (plus any additional context for devs)
With our growing list of networks, we need to enable scrolling on the network switcher to prevent the sheet from overflowing off the top of the screen.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/5d802955-9c1d-4fdb-a4ee-6e39daf3c759


## What to test
scrolling and drag n drop shouldn't collide
