### PR TITLE
Update Swaps to use new Network Switcher

### DIFF
--- a/src/__swaps__/screens/Swap/components/GestureHandlerButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GestureHandlerButton.tsx
@@ -37,6 +37,7 @@ export type GestureHandlerButtonProps = {
   simultaneousWithExternalGesture?: MutableRefObject<GestureType>;
   style?: StyleProp<ViewStyle> | AnimatedStyle;
   tapRef?: MutableRefObject<TapGesture>;
+  testID?: string;
 };
 
 /**
@@ -78,6 +79,7 @@ export function GestureHandlerButton({
   simultaneousWithExternalGesture,
   style,
   tapRef,
+  testID,
 }: GestureHandlerButtonProps) {
   const isPressed = useSharedValue(false);
 
@@ -162,7 +164,7 @@ export function GestureHandlerButton({
 
   return (
     <GestureDetector gesture={gesture}>
-      <Animated.View accessible accessibilityRole="button" pointerEvents={pointerEvents} style={[style, pressStyle]}>
+      <Animated.View accessible accessibilityRole="button" pointerEvents={pointerEvents} style={[style, pressStyle]} testID={testID}>
         {children}
       </Animated.View>
     </GestureDetector>

--- a/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
@@ -82,6 +82,7 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
       setSelected: handleSelectChain,
       canSelectAllNetworks: !output,
       goBackOnSelect: true,
+      canEdit: false,
       allowedNetworks: balanceSortedChainList,
     });
   }, [balanceSortedChainList, handleSelectChain, output, selectedOutputChainId]);

--- a/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
@@ -16,7 +16,10 @@ import { useSharedValueState } from '@/hooks/reanimated/useSharedValueState';
 import { userAssetsStore, useUserAssetsStore } from '@/state/assets/userAssets';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
-import { DropdownMenu, MenuItem } from '@/components/DropdownMenu';
+import { GestureHandlerButton } from '../GestureHandlerButton';
+import { Navigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
+import { UserAssetFilter } from '@/__swaps__/types/assets';
 
 type ChainSelectionProps = {
   allText?: string;
@@ -29,13 +32,12 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
   const { selectedOutputChainId, setSelectedOutputChainId } = useSwapContext();
 
   const chainLabels = useBackendNetworksStore(state => state.getChainsLabel());
-  const networkBadges = useBackendNetworksStore(state => state.getChainsBadge());
 
   // chains sorted by balance on output, chains without balance hidden on input
   const balanceSortedChainList = useUserAssetsStore(state => (output ? state.getBalanceSortedChainList() : state.getChainsWithBalance()));
   const filter = useUserAssetsStore(state => state.filter);
 
-  const inputListFilter = useSharedValue(filter);
+  const inputListFilter = useSharedValue<UserAssetFilter | undefined>(filter === 'all' ? undefined : filter);
 
   const accentColor = useMemo(() => {
     if (c.contrast(accountColor, isDarkMode ? '#191A1C' : globalColors.white100) < (isDarkMode ? 2.125 : 1.5)) {
@@ -49,61 +51,40 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
   const chainName = useDerivedValue(() => {
     return output
       ? chainLabels[selectedOutputChainId.value]
-      : inputListFilter.value === 'all'
+      : inputListFilter.value === undefined
         ? allText
         : chainLabels[inputListFilter.value as ChainId];
   });
 
   const handleSelectChain = useCallback(
-    (actionKey: string) => {
+    (chainId: ChainId | undefined) => {
       analyticsV2.track(analyticsV2.event.swapsChangedChainId, {
         inputAsset: swapsStore.getState().inputAsset,
         type: output ? 'output' : 'input',
-        chainId: Number(actionKey) as ChainId,
+        chainId,
       });
 
-      if (output) {
-        setSelectedOutputChainId(Number(actionKey) as ChainId);
+      if (output && chainId) {
+        setSelectedOutputChainId(chainId);
       } else {
-        inputListFilter.value = actionKey === 'all' ? 'all' : (Number(actionKey) as ChainId);
+        inputListFilter.value = chainId;
         userAssetsStore.setState({
-          filter: actionKey === 'all' ? 'all' : (Number(actionKey) as ChainId),
+          filter: chainId === undefined ? 'all' : chainId,
         });
       }
     },
     [inputListFilter, output, setSelectedOutputChainId]
   );
 
-  const menuConfig = useMemo(() => {
-    let supportedChains: MenuItem<string>[] = [];
-    supportedChains = balanceSortedChainList.map(chainId => {
-      return {
-        actionKey: `${chainId}`,
-        actionTitle: chainLabels[chainId],
-        icon: {
-          iconType: 'REMOTE',
-          iconValue: {
-            uri: networkBadges[chainId],
-          },
-        },
-      };
+  const navigateToNetworkSelector = useCallback(() => {
+    Navigation.handleAction(Routes.NETWORK_SELECTOR, {
+      selected: output ? selectedOutputChainId : inputListFilter,
+      setSelected: handleSelectChain,
+      canSelectAllNetworks: !output,
+      goBackOnSelect: true,
+      allowedNetworks: balanceSortedChainList,
     });
-
-    if (!output) {
-      supportedChains.unshift({
-        actionKey: 'all',
-        actionTitle: i18n.t(i18n.l.exchange.all_networks),
-        icon: {
-          iconType: 'SYSTEM',
-          iconValue: 'globe',
-        },
-      });
-    }
-
-    return {
-      menuItems: supportedChains,
-    };
-  }, [balanceSortedChainList, chainLabels, networkBadges, output]);
+  }, [balanceSortedChainList, handleSelectChain, output, selectedOutputChainId]);
 
   return (
     <Box as={Animated.View} paddingBottom={output ? '8px' : { custom: 14 }} paddingHorizontal="20px" paddingTop="20px">
@@ -147,7 +128,7 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
           </Inline>
         )}
 
-        <DropdownMenu menuConfig={menuConfig} onPressMenuItem={handleSelectChain} testID={`chain-selection-${output ? 'output' : 'input'}`}>
+        <GestureHandlerButton onPressJS={navigateToNetworkSelector} testID={`chain-selection-${output ? 'output' : 'input'}`}>
           <Box paddingVertical="6px" paddingLeft="16px" flexDirection="row" alignItems="center" justifyContent="center" gap={6}>
             <ChainButtonIcon output={output} />
             <AnimatedText color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="heavy">
@@ -157,7 +138,7 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
               􀆏
             </Text>
           </Box>
-        </DropdownMenu>
+        </GestureHandlerButton>
       </Inline>
     </Box>
   );

--- a/src/__swaps__/types/assets.ts
+++ b/src/__swaps__/types/assets.ts
@@ -7,7 +7,7 @@ import { ResponseByTheme } from '../utils/swaps';
 
 export type AddressOrEth = Address | typeof ETH_ADDRESS;
 
-export type UserAssetFilter = 'all' | ChainId;
+export type UserAssetFilter = ChainId | 'all';
 
 export interface ExtendedAnimatedAssetWithColors extends ParsedSearchAsset {
   // colors

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -579,7 +579,7 @@ export type EventProperties = {
   [event.swapsChangedChainId]: {
     inputAsset: ParsedSearchAsset | ExtendedAnimatedAssetWithColors | null;
     type: 'input' | 'output';
-    chainId: ChainId;
+    chainId: ChainId | undefined;
   };
 
   [event.swapsFlippedAssets]: {


### PR DESCRIPTION
Fixes APP-2343

## What changed (plus any additional context for devs)
Swaps now will utilize the new NetworkSwitcher route to change output / input token lists. The token to sell list is filtered down show networks that the user has tokens on. Output is sorted by balance. This is the same functionality as we had before in the dropdown menus.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/21e184c5-6930-416a-8a3f-d16a066028e4


## What to test
selection of networks etc.
