### PR TITLE
Update WalletConnectApprovalSheet to use new Network Switcher

### DIFF
--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -118,10 +118,13 @@ export type RootStackParamList = {
     selected: SharedValue<ChainId | undefined> | ChainId | undefined;
     setSelected: (chainId: ChainId | undefined) => void;
     onClose?: VoidFunction;
+    fillPinnedSection?: boolean;
+    canSelect?: boolean;
     canEdit?: boolean;
     canSelectAllNetworks?: boolean;
     allowedNetworks?: ChainId[];
     goBackOnSelect?: boolean;
+    title?: string;
   };
   [Routes.LOG_SHEET]: {
     data: {


### PR DESCRIPTION
Fixes APP-2344

## What changed (plus any additional context for devs)
Adds a variant of NetworkSwitcher to the WalletConnectApprovalSheet. We needed to add the following functionality (or rather remove?)
- the ability to select a network
- we don't want to show which network was selected because technically it's all the networks
- We also want to fill the amount of space in the pinnedNetworks section as possible
- Due to the adjustment of the pinned networks, we needed to also not persist those pinned networks on sheet close

## Screen recordings / screenshots
https://github.com/user-attachments/assets/dda32ab7-f4f0-4bba-a2f4-80337232de89

## What to test
Test walletconnect v1 and v2