### PR TITLE
Support configurable icon/label for the masthead button within Network Switcher component

### DIFF
--- a/src/components/buttons/NetworkSelectorButton.tsx
+++ b/src/components/buttons/NetworkSelectorButton.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useMemo } from 'react';
+import { ChainImage } from '@/components/coin-icon/ChainImage';
+import { Bleed, Inline, Text, TextProps } from '@/design-system';
+import * as i18n from '@/languages';
+import { ChainId } from '@/state/backendNetworks/types';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { ButtonPressAnimation } from '@/components/animations';
+import { useNavigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
+import { RootStackParamList } from '@/navigation/types';
+import { RouteProp } from '@react-navigation/native';
+
+interface DefaultButtonOptions {
+  iconColor?: TextProps['color'];
+  iconSize?: TextProps['size'];
+  iconWeight?: TextProps['weight'];
+  textColor?: TextProps['color'];
+  textSize?: TextProps['size'];
+  textWeight?: TextProps['weight'];
+}
+
+type NetworkSelectorProps = Omit<RouteProp<RootStackParamList, 'NetworkSelector'>['params'], 'selected' | 'setSelected'>;
+
+type ChainContextMenuProps = {
+  defaultButtonOptions?: DefaultButtonOptions;
+  onSelectChain: (chainId: ChainId | undefined) => void;
+  selectedChainId: ChainId | undefined;
+} & NetworkSelectorProps;
+
+export const NetworkSwitcherButton = ({
+  defaultButtonOptions = {},
+  onSelectChain,
+  selectedChainId,
+  actionButton = {
+    label: i18n.t(i18n.l.exchange.all_networks),
+    color: 'labelSecondary',
+    weight: 'bold',
+  },
+  ...networkSelectorProps
+}: ChainContextMenuProps) => {
+  const { navigate } = useNavigation();
+  const {
+    iconColor = 'labelSecondary',
+    iconSize = 'icon 13px',
+    iconWeight = 'bold',
+    textColor = 'label',
+    textSize = '15pt',
+    textWeight = 'heavy',
+  } = defaultButtonOptions;
+
+  const handleSelectChain = useCallback(
+    (chainId: ChainId | undefined) => {
+      onSelectChain(chainId);
+    },
+    [onSelectChain]
+  );
+
+  const navigateToNetworkSelector = useCallback(() => {
+    navigate(Routes.NETWORK_SELECTOR, {
+      ...networkSelectorProps,
+      actionButton,
+      selected: selectedChainId,
+      setSelected: handleSelectChain,
+    });
+  }, [handleSelectChain, navigate, networkSelectorProps, selectedChainId]);
+
+  const displayName = useMemo(() => {
+    if (!selectedChainId) return actionButton.label;
+    return useBackendNetworksStore.getState().getChainsLabel()[selectedChainId];
+  }, [actionButton.label, selectedChainId]);
+
+  return (
+    <Bleed horizontal="12px">
+      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="chain-context-menu">
+        <Inline alignVertical="center" space="6px" wrap={false}>
+          {actionButton.icon && !selectedChainId && (
+            <Text align="center" color={actionButton.color || iconColor} size={iconSize} weight={actionButton.weight || iconWeight}>
+              {actionButton.icon}
+            </Text>
+          )}
+          {selectedChainId && (
+            <Bleed vertical="4px">
+              <ChainImage chainId={selectedChainId} position="relative" size={16} />
+            </Bleed>
+          )}
+          <Text color={textColor} numberOfLines={1} size={textSize} weight={textWeight}>
+            {displayName}
+          </Text>
+          <Text align="center" color={iconColor} size={iconSize} weight={iconWeight}>
+            􀆏
+          </Text>
+        </Inline>
+      </ButtonPressAnimation>
+    </Bleed>
+  );
+};

--- a/src/components/buttons/NetworkSelectorButton.tsx
+++ b/src/components/buttons/NetworkSelectorButton.tsx
@@ -21,13 +21,13 @@ interface DefaultButtonOptions {
 
 type NetworkSelectorProps = Omit<RouteProp<RootStackParamList, 'NetworkSelector'>['params'], 'selected' | 'setSelected'>;
 
-type ChainContextMenuProps = {
+type NetworkSelectorButtonProps = {
   defaultButtonOptions?: DefaultButtonOptions;
   onSelectChain: (chainId: ChainId | undefined) => void;
   selectedChainId: ChainId | undefined;
 } & NetworkSelectorProps;
 
-export const NetworkSwitcherButton = ({
+export const NetworkSelectorButton = ({
   defaultButtonOptions = {},
   onSelectChain,
   selectedChainId,
@@ -37,7 +37,7 @@ export const NetworkSwitcherButton = ({
     weight: 'bold',
   },
   ...networkSelectorProps
-}: ChainContextMenuProps) => {
+}: NetworkSelectorButtonProps) => {
   const { navigate } = useNavigation();
   const {
     iconColor = 'labelSecondary',
@@ -71,7 +71,7 @@ export const NetworkSwitcherButton = ({
 
   return (
     <Bleed horizontal="12px">
-      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="chain-context-menu">
+      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="network-selector-button">
         <Inline alignVertical="center" space="6px" wrap={false}>
           {actionButton.icon && !selectedChainId && (
             <Text align="center" color={actionButton.color || iconColor} size={iconSize} weight={actionButton.weight || iconWeight}>

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3140,7 +3140,7 @@
         }
       }
     },
-    "network_switcher": {
+    "network_selector": {
       "customize_networks_banner": {
         "title": "Customize Networks",
         "tap_the": "Tap the",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -94,7 +94,7 @@ import { RootStackParamList } from './types';
 import WalletLoadingListener from '@/components/WalletLoadingListener';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';
 import { LogSheet } from '@/components/debugging/LogSheet';
-import { NetworkSelector } from '@/components/NetworkSwitcher';
+import { NetworkSelector } from '@/screens/NetworkSelector';
 
 const Stack = createStackNavigator();
 const OuterStack = createStackNavigator();

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -108,7 +108,7 @@ import { RootStackParamList } from './types';
 import WalletLoadingListener from '@/components/WalletLoadingListener';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';
 import { LogSheet } from '@/components/debugging/LogSheet';
-import { NetworkSelector } from '@/components/NetworkSwitcher';
+import { NetworkSelector } from '@/screens/NetworkSelector';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -15,6 +15,7 @@ import { Address } from 'viem';
 import { SharedValue } from 'react-native-reanimated';
 import { ChainId } from '@/state/backendNetworks/types';
 import { ExpandedSheetParamAsset } from '@/screens/expandedAssetSheet/context/ExpandedAssetSheetContext';
+import { TextProps } from '@/design-system';
 
 export type PartialNavigatorConfigOptions = Pick<Partial<Parameters<ReturnType<typeof createStackNavigator>['Screen']>[0]>, 'options'>;
 
@@ -122,6 +123,13 @@ export type RootStackParamList = {
     canSelectAllNetworks?: boolean;
     allowedNetworks?: ChainId[];
     goBackOnSelect?: boolean;
+    actionButton?: {
+      color?: TextProps['color'];
+      icon?: string;
+      weight?: TextProps['weight'];
+      label: string;
+      onPress?: () => void;
+    };
   };
   [Routes.LOG_SHEET]: {
     data: {


### PR DESCRIPTION
Fixes APP-2342

## What changed (plus any additional context for devs)
Added `NetworkSelectorButton` component to provide a reusable way to launch into a NetworkSelector route. I also cleaned up a little bit of the file system by moving the NetworkSelector to the screens folder since it's a route.

Biggest most notable change which is what the ticket is for, is introducing `actionButton` prop into the NetworkSelector route. It provides overrides to turn the `All Networks` masthead button into a configurable action button as shown in the below screen recording.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/57706481-c43c-42c2-9401-06de745db5d7

## What to test
nothing to test in this PR as it's not hooked up anywhere yet. Will be a follow-up PR implementing it in the locations it's needed
