### PR TITLE
Update Claimables to use new Network Switcher

### DIFF
--- a/src/components/buttons/NetworkSelectorButton.tsx
+++ b/src/components/buttons/NetworkSelectorButton.tsx
@@ -22,12 +22,16 @@ interface DefaultButtonOptions {
 type NetworkSelectorProps = Omit<RouteProp<RootStackParamList, 'NetworkSelector'>['params'], 'selected' | 'setSelected'>;
 
 type NetworkSelectorButtonProps = {
+  bleed?: boolean;
+  disabled?: boolean;
   defaultButtonOptions?: DefaultButtonOptions;
   onSelectChain: (chainId: ChainId | undefined) => void;
   selectedChainId: ChainId | undefined;
 } & NetworkSelectorProps;
 
 export const NetworkSelectorButton = ({
+  bleed = true,
+  disabled,
   defaultButtonOptions = {},
   onSelectChain,
   selectedChainId,
@@ -70,8 +74,8 @@ export const NetworkSelectorButton = ({
   }, [actionButton.label, selectedChainId]);
 
   return (
-    <Bleed horizontal="12px">
-      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="network-selector-button">
+    <Bleed horizontal={bleed ? '12px' : undefined}>
+      <ButtonPressAnimation disabled={disabled} onPress={navigateToNetworkSelector} padding="12px" testID="network-selector-button">
         <Inline alignVertical="center" space="6px" wrap={false}>
           {actionButton.icon && !selectedChainId && (
             <Text align="center" color={actionButton.color || iconColor} size={iconSize} weight={actionButton.weight || iconWeight}>

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -483,7 +483,8 @@
         "a_network": "a network",
         "swap_failed": "Swap Failed",
         "receive": "Receive",
-        "on": "on"
+        "on": "on",
+        "reset": "Reset"
       }
     },
     "cloud": {

--- a/src/screens/NetworkSelector.tsx
+++ b/src/screens/NetworkSelector.tsx
@@ -597,6 +597,7 @@ function NetworksGrid({
   scrollY,
   scrollViewHeight,
   goBackOnSelect,
+  canEdit,
 }: NetworksGridProps) {
   const { goBack } = useNavigation();
 
@@ -621,6 +622,8 @@ function NetworksGrid({
     // persists pinned networks when closing the sheet
     // should be the only time this component is unmounted
     return () => {
+      if (!canEdit) return;
+
       if (networks.value[Section.pinned].length > 0) {
         networkSwitcherStore.setState({ pinnedNetworks: networks.value[Section.pinned] });
       } else {
@@ -919,6 +922,7 @@ export function NetworkSelector() {
         scrollY={scrollY}
         scrollViewHeight={scrollViewHeight}
         goBackOnSelect={goBackOnSelect}
+        canEdit={canEdit}
       />
     </Sheet>
   );

--- a/src/screens/claimables/transaction/components/ClaimCustomization.tsx
+++ b/src/screens/claimables/transaction/components/ClaimCustomization.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@/design-system';
+import { Box, Text, useColorMode } from '@/design-system';
 import { haptics } from '@/utils';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
@@ -18,6 +18,8 @@ import { ChainId } from '@/state/backendNetworks/types';
 type TokenMap = Record<TokenToReceive['symbol'], TokenToReceive>;
 
 export function ClaimCustomization() {
+  const { isDarkMode } = useColorMode();
+
   const balanceSortedChainList = useUserAssetsStore(state => state.getBalanceSortedChainList());
   const {
     claimStatus,
@@ -29,8 +31,6 @@ export function ClaimCustomization() {
   } = useTransactionClaimableContext();
 
   const [isInitialState, setIsInitialState] = useState(true);
-
-  const chainsLabel = useBackendNetworksStore.getState().getChainsLabel();
 
   const { data: usdcSearchData } = useTokenSearch(
     {
@@ -249,23 +249,37 @@ export function ClaimCustomization() {
       <Text align="center" weight="bold" color="labelTertiary" size="17pt">
         {i18n.t(i18n.l.claimables.panel.on)}
       </Text>
-      <NetworkSelectorButton
-        bleed={false}
-        disabled={isDisabled}
-        onSelectChain={handleNetworkSelection}
-        selectedChainId={outputChainId}
-        goBackOnSelect
-        canEdit={false}
-        allowedNetworks={balanceSortedChainList.filter(
-          chainId => isInitialState || (chainId !== outputChainId && (!outputToken || chainId in outputToken.networks))
-        )}
-        actionButton={{
-          icon: '􀅉',
-          label: i18n.t(i18n.l.claimables.panel.reset),
-          color: 'labelTertiary',
-          onPress: resetState,
-        }}
-      />
+
+      <Box
+        paddingHorizontal={{ custom: 7 }}
+        height={{ custom: 28 }}
+        flexDirection="row"
+        borderColor={{ custom: isDarkMode ? 'rgba(245, 248, 255, 0.04)' : 'rgba(9, 17, 31, 0.02)' }}
+        borderWidth={1.33}
+        borderRadius={12}
+        gap={4}
+        style={{ backgroundColor: isDarkMode ? 'rgba(245, 248, 255, 0.04)' : 'rgba(9, 17, 31, 0.02)' }}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <NetworkSelectorButton
+          bleed={false}
+          disabled={isDisabled}
+          onSelectChain={handleNetworkSelection}
+          selectedChainId={outputChainId}
+          goBackOnSelect
+          canEdit={false}
+          allowedNetworks={balanceSortedChainList.filter(
+            chainId => isInitialState || (chainId !== outputChainId && (!outputToken || chainId in outputToken.networks))
+          )}
+          actionButton={{
+            icon: '􀅉',
+            label: i18n.t(i18n.l.claimables.panel.reset),
+            color: 'labelTertiary',
+            onPress: resetState,
+          }}
+        />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
Fixes APP-2345

## What changed (plus any additional context for devs)
Claimables customization network selector now uses the new network selector.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/d20caad6-a06c-43d2-8d30-5a95f3347657

## What to test
claimables functionality
