### PR TITLE
Fix: Address and ens names cut off in send flow on Android

### DIFF
--- a/src/components/coin-row/CollectiblesSendRow.tsx
+++ b/src/components/coin-row/CollectiblesSendRow.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useMemo } from 'react';
-import { PressableProps, TouchableWithoutFeedback } from 'react-native';
+import { PressableProps, TouchableWithoutFeedback, StyleSheet } from 'react-native';
 import { buildAssetUniqueIdentifier } from '../../helpers/assets';
 import { useTheme } from '../../theme/ThemeContext';
 import { deviceUtils, getUniqueTokenType, magicMemo } from '../../utils';
@@ -33,6 +33,7 @@ const BottomRow = ({ selected, subtitle }: { selected: boolean; subtitle: string
       letterSpacing="roundedMedium"
       size="smedium"
       weight={selected ? 'bold' : 'regular'}
+      style={sx.bottomRow}
     >
       {subtitle}
     </TruncatedText>
@@ -136,6 +137,12 @@ const CollectiblesSendRow = React.memo(
   },
   (props, nextProps) => buildAssetUniqueIdentifier(props.item) !== buildAssetUniqueIdentifier(nextProps.item)
 );
+
+const sx = StyleSheet.create({
+  bottomRow: {
+    marginTop: ios ? 0 : -6,
+  },
+});
 
 CollectiblesSendRow.displayName = 'CollectiblesSendRow';
 // @ts-expect-error

--- a/src/components/coin-row/SendCoinRow.js
+++ b/src/components/coin-row/SendCoinRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableWithoutFeedback } from 'react-native';
+import { StyleSheet, TouchableWithoutFeedback } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useTheme } from '../../theme/ThemeContext';
 import { deviceUtils } from '../../utils';
@@ -49,6 +49,7 @@ const BottomRow = ({ balance, native, nativeCurrencySymbol, selected, showNative
       numberOfLines={1}
       size="smedium"
       weight={selected ? 'bold' : 'regular'}
+      style={sx.bottomRow}
     >
       {showNativeValue
         ? `${fiatValue} available`
@@ -133,13 +134,22 @@ const SendCoinRow = ({
           children
         ) : (
           <NativeAmountBubble>
-            <NativeAmountBubbleText>{fiatValueFormatted}</NativeAmountBubbleText>
+            <NativeAmountBubbleText style={sx.nativeAmountBubbleText}>{fiatValueFormatted}</NativeAmountBubbleText>
           </NativeAmountBubble>
         )}
       </CoinRow>
     </Wrapper>
   );
 };
+
+const sx = StyleSheet.create({
+  nativeAmountBubbleText: {
+    marginTop: android ? -2.5 : 0,
+  },
+  bottomRow: {
+    marginTop: android ? -6 : 0,
+  },
+});
 
 SendCoinRow.displayName = 'SendCoinRow';
 SendCoinRow.selectedHeight = selectedHeight;

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -16,6 +16,7 @@ import styled from '@/styled-thing';
 import { margin } from '@/styles';
 import { addressHashedColorIndex, addressHashedEmoji } from '@/utils/profileUtils';
 import * as i18n from '@/languages';
+import { StyleSheet } from 'react-native';
 
 const ContactAddress = styled(TruncatedAddress).attrs(({ theme: { colors }, lite }) => ({
   align: 'left',
@@ -44,7 +45,7 @@ const ContactName = styled(TruncatedText).attrs(({ lite }) => ({
   size: 'lmedium',
   weight: lite ? 'regular' : 'medium',
 }))({
-  height: 22,
+  height: ios ? 22 : 26,
   width: ({ deviceWidth }) => deviceWidth - 90,
 });
 
@@ -52,6 +53,12 @@ const css = {
   default: margin.object(6, 19, 13),
   symmetrical: margin.object(9.5, 19),
 };
+
+const sx = StyleSheet.create({
+  bottomRowText: {
+    marginTop: ios ? 0 : -4.5,
+  },
+});
 
 const ContactRow = ({ address, color, nickname, symmetricalMargins, ...props }, ref) => {
   const profilesEnabled = useExperimentalFlag(PROFILES);
@@ -132,7 +139,12 @@ const ContactRow = ({ address, color, nickname, symmetricalMargins, ...props }, 
                   {isValidDomainFormat(address) ? address : abbreviations.address(address, 4, 6)}
                 </ContactName>
               )}
-              <BottomRowText color={colors.alpha(colors.blueGreyDark, 0.5)} letterSpacing="roundedMedium" weight="medium">
+              <BottomRowText
+                style={sx.bottomRowText}
+                color={colors.alpha(colors.blueGreyDark, 0.5)}
+                letterSpacing="roundedMedium"
+                weight="medium"
+              >
                 {balanceText}
               </BottomRowText>
             </Fragment>


### PR DESCRIPTION
Fixes APP-2323

## What changed (plus any additional context for devs)
Fixes a few row height issues and spacing issues I noticed on Android. Nothing major

## Screen recordings / screenshots
![Screenshot_20250219-134651](https://github.com/user-attachments/assets/007ab708-00bc-48b7-b2e9-fdb954778575)
![Screenshot_20250219-134659](https://github.com/user-attachments/assets/f79f6ab3-1b41-4ebd-a72a-2a766b51d722)


## What to test
n/a
