### PR TITLE
Fix: Sync backendNetworks sync issue

### DIFF
--- a/src/state/backendNetworks/backendNetworks.ts
+++ b/src/state/backendNetworks/backendNetworks.ts
@@ -59,12 +59,11 @@ export interface BackendNetworksState {
   getChainDefaultRpc: (chainId: ChainId) => string;
 }
 
-let lastNetworks: BackendNetworksResponse | null = null;
-
 function createSelector<T>(selectorFn: (networks: BackendNetworksResponse, transformed: Chain[]) => T): () => T {
   const uninitialized = Symbol();
   let cachedResult: T | typeof uninitialized = uninitialized;
   let memoizedFn: ((networks: BackendNetworksResponse, transformed: Chain[]) => T) | null = null;
+  let lastNetworks: BackendNetworksResponse | null = null;
 
   return () => {
     const { backendChains, backendNetworks } = useBackendNetworksStore.getState();
@@ -88,6 +87,7 @@ function createParameterizedSelector<T, Args extends unknown[]>(
   let cachedResult: T | typeof uninitialized = uninitialized;
   let lastArgs: Args | null = null;
   let memoizedFn: ((...args: Args) => T) | null = null;
+  let lastNetworks: BackendNetworksResponse | null = null;
 
   return (...args: Args) => {
     const { backendChains, backendNetworks } = useBackendNetworksStore.getState();


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I noticed this issue on the browser extension when implementing runtime networks. There exists an edge case where `createSelector` would update the reference to `lastNetworks` **before** `createParameterizedSelector` which would lead to out of date backendNetworks / backendChains referenced wherever we use `createParameterizedSelector`.

Simply moving the cached reference into each selector will guarantee that both selectors update when there's a network change. This guarantees non-stale data whenever we detect a change.

## Screen recordings / screenshots
n/a

## What to test
n/a
