### PR TITLE
Network Switcher Implementations

### DIFF
--- a/src/__swaps__/screens/Swap/components/GestureHandlerButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GestureHandlerButton.tsx
@@ -37,6 +37,7 @@ export type GestureHandlerButtonProps = {
   simultaneousWithExternalGesture?: MutableRefObject<GestureType>;
   style?: StyleProp<ViewStyle> | AnimatedStyle;
   tapRef?: MutableRefObject<TapGesture>;
+  testID?: string;
 };
 
 /**
@@ -78,6 +79,7 @@ export function GestureHandlerButton({
   simultaneousWithExternalGesture,
   style,
   tapRef,
+  testID,
 }: GestureHandlerButtonProps) {
   const isPressed = useSharedValue(false);
 
@@ -162,7 +164,7 @@ export function GestureHandlerButton({
 
   return (
     <GestureDetector gesture={gesture}>
-      <Animated.View accessible accessibilityRole="button" pointerEvents={pointerEvents} style={[style, pressStyle]}>
+      <Animated.View accessible accessibilityRole="button" pointerEvents={pointerEvents} style={[style, pressStyle]} testID={testID}>
         {children}
       </Animated.View>
     </GestureDetector>

--- a/src/__swaps__/screens/Swap/components/SettingsPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Animated, { useAnimatedStyle, withDelay, withSpring } from 'react-native-reanimated';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { ChainContextMenu } from '@/components/context-menu-buttons/ChainContextMenu';
+import { NetworkSelectorButton } from '@/components/buttons/NetworkSelectorButton';
 import { Bleed, Border, Box, Column, Columns, Separator, Stack, Text, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
 import * as i18n from '@/languages';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
@@ -11,17 +11,28 @@ import { NavigationSteps, useSwapContext } from '../providers/swap-provider';
 import { AnimatedSwitch } from './AnimatedSwitch';
 import { GestureHandlerButton } from './GestureHandlerButton';
 import { SlippageRow } from './ReviewPanel';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
 
 const PreferredNetworkMenu = () => {
   const preferredNetwork = useSwapsStore(state => state.preferredNetwork);
 
+  const chainsToDisplay = useUserAssetsStore(state => state.getBalanceSortedChainList());
+
   return (
-    <ChainContextMenu
-      allNetworksIcon={{ color: 'labelSecondary', icon: '􀒙', name: 'bolt.horizontal.circle', weight: 'bold' }}
-      allNetworksText={i18n.t(i18n.l.expanded_state.swap_details_v2.automatic)}
+    <NetworkSelectorButton
+      goBackOnSelect
       defaultButtonOptions={{ iconColor: 'labelTertiary' }}
       onSelectChain={chain => useSwapsStore.setState({ preferredNetwork: chain })}
       selectedChainId={preferredNetwork}
+      actionButton={{
+        color: 'labelSecondary',
+        icon: '􀒙',
+        weight: 'bold',
+        label: i18n.t(i18n.l.expanded_state.swap_details_v2.automatic),
+        onPress: () => useSwapsStore.setState({ preferredNetwork: undefined }),
+      }}
+      allowedNetworks={chainsToDisplay}
+      canEdit={false}
     />
   );
 };

--- a/src/__swaps__/screens/Swap/components/SettingsPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SettingsPanel.tsx
@@ -31,7 +31,9 @@ const PreferredNetworkMenu = () => {
         label: i18n.t(i18n.l.expanded_state.swap_details_v2.automatic),
         onPress: () => useSwapsStore.setState({ preferredNetwork: undefined }),
       }}
+      title={i18n.t(i18n.l.expanded_state.swap_details_v2.preferred_network)}
       allowedNetworks={chainsToDisplay}
+      fillPinnedSection
       canEdit={false}
     />
   );

--- a/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
@@ -82,6 +82,7 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
       setSelected: handleSelectChain,
       canSelectAllNetworks: !output,
       goBackOnSelect: true,
+      canEdit: false,
       allowedNetworks: balanceSortedChainList,
     });
   }, [balanceSortedChainList, handleSelectChain, output, selectedOutputChainId]);

--- a/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
+++ b/src/__swaps__/screens/Swap/components/TokenList/ChainSelection.tsx
@@ -16,7 +16,10 @@ import { useSharedValueState } from '@/hooks/reanimated/useSharedValueState';
 import { userAssetsStore, useUserAssetsStore } from '@/state/assets/userAssets';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
-import { DropdownMenu, MenuItem } from '@/components/DropdownMenu';
+import { GestureHandlerButton } from '../GestureHandlerButton';
+import { Navigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
+import { UserAssetFilter } from '@/__swaps__/types/assets';
 
 type ChainSelectionProps = {
   allText?: string;
@@ -29,13 +32,12 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
   const { selectedOutputChainId, setSelectedOutputChainId } = useSwapContext();
 
   const chainLabels = useBackendNetworksStore(state => state.getChainsLabel());
-  const networkBadges = useBackendNetworksStore(state => state.getChainsBadge());
 
   // chains sorted by balance on output, chains without balance hidden on input
   const balanceSortedChainList = useUserAssetsStore(state => (output ? state.getBalanceSortedChainList() : state.getChainsWithBalance()));
   const filter = useUserAssetsStore(state => state.filter);
 
-  const inputListFilter = useSharedValue(filter);
+  const inputListFilter = useSharedValue<UserAssetFilter | undefined>(filter === 'all' ? undefined : filter);
 
   const accentColor = useMemo(() => {
     if (c.contrast(accountColor, isDarkMode ? '#191A1C' : globalColors.white100) < (isDarkMode ? 2.125 : 1.5)) {
@@ -49,61 +51,40 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
   const chainName = useDerivedValue(() => {
     return output
       ? chainLabels[selectedOutputChainId.value]
-      : inputListFilter.value === 'all'
+      : inputListFilter.value === undefined
         ? allText
         : chainLabels[inputListFilter.value as ChainId];
   });
 
   const handleSelectChain = useCallback(
-    (actionKey: string) => {
+    (chainId: ChainId | undefined) => {
       analyticsV2.track(analyticsV2.event.swapsChangedChainId, {
         inputAsset: swapsStore.getState().inputAsset,
         type: output ? 'output' : 'input',
-        chainId: Number(actionKey) as ChainId,
+        chainId,
       });
 
-      if (output) {
-        setSelectedOutputChainId(Number(actionKey) as ChainId);
+      if (output && chainId) {
+        setSelectedOutputChainId(chainId);
       } else {
-        inputListFilter.value = actionKey === 'all' ? 'all' : (Number(actionKey) as ChainId);
+        inputListFilter.value = chainId;
         userAssetsStore.setState({
-          filter: actionKey === 'all' ? 'all' : (Number(actionKey) as ChainId),
+          filter: chainId === undefined ? 'all' : chainId,
         });
       }
     },
     [inputListFilter, output, setSelectedOutputChainId]
   );
 
-  const menuConfig = useMemo(() => {
-    let supportedChains: MenuItem<string>[] = [];
-    supportedChains = balanceSortedChainList.map(chainId => {
-      return {
-        actionKey: `${chainId}`,
-        actionTitle: chainLabels[chainId],
-        icon: {
-          iconType: 'REMOTE',
-          iconValue: {
-            uri: networkBadges[chainId],
-          },
-        },
-      };
+  const navigateToNetworkSelector = useCallback(() => {
+    Navigation.handleAction(Routes.NETWORK_SELECTOR, {
+      selected: output ? selectedOutputChainId : inputListFilter,
+      setSelected: handleSelectChain,
+      canSelectAllNetworks: !output,
+      goBackOnSelect: true,
+      allowedNetworks: balanceSortedChainList,
     });
-
-    if (!output) {
-      supportedChains.unshift({
-        actionKey: 'all',
-        actionTitle: i18n.t(i18n.l.exchange.all_networks),
-        icon: {
-          iconType: 'SYSTEM',
-          iconValue: 'globe',
-        },
-      });
-    }
-
-    return {
-      menuItems: supportedChains,
-    };
-  }, [balanceSortedChainList, chainLabels, networkBadges, output]);
+  }, [balanceSortedChainList, handleSelectChain, output, selectedOutputChainId]);
 
   return (
     <Box as={Animated.View} paddingBottom={output ? '8px' : { custom: 14 }} paddingHorizontal="20px" paddingTop="20px">
@@ -147,7 +128,7 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
           </Inline>
         )}
 
-        <DropdownMenu menuConfig={menuConfig} onPressMenuItem={handleSelectChain} testID={`chain-selection-${output ? 'output' : 'input'}`}>
+        <GestureHandlerButton onPressJS={navigateToNetworkSelector} testID={`chain-selection-${output ? 'output' : 'input'}`}>
           <Box paddingVertical="6px" paddingLeft="16px" flexDirection="row" alignItems="center" justifyContent="center" gap={6}>
             <ChainButtonIcon output={output} />
             <AnimatedText color={isDarkMode ? 'labelSecondary' : 'label'} size="15pt" weight="heavy">
@@ -157,7 +138,7 @@ export const ChainSelection = memo(function ChainSelection({ allText, output }: 
               􀆏
             </Text>
           </Box>
-        </DropdownMenu>
+        </GestureHandlerButton>
       </Inline>
     </Box>
   );

--- a/src/__swaps__/types/assets.ts
+++ b/src/__swaps__/types/assets.ts
@@ -7,7 +7,7 @@ import { ResponseByTheme } from '../utils/swaps';
 
 export type AddressOrEth = Address | typeof ETH_ADDRESS;
 
-export type UserAssetFilter = 'all' | ChainId;
+export type UserAssetFilter = ChainId | 'all';
 
 export interface ExtendedAnimatedAssetWithColors extends ParsedSearchAsset {
   // colors

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -579,7 +579,7 @@ export type EventProperties = {
   [event.swapsChangedChainId]: {
     inputAsset: ParsedSearchAsset | ExtendedAnimatedAssetWithColors | null;
     type: 'input' | 'output';
-    chainId: ChainId;
+    chainId: ChainId | undefined;
   };
 
   [event.swapsFlippedAssets]: {

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -530,9 +530,8 @@ function NetworkFilter() {
 
   const setSelected = useCallback(
     (chainId: ChainId | undefined) => {
-      'worklet';
       selected.value = chainId;
-      runOnJS(setChainId)(chainId);
+      setChainId(chainId);
     },
     [selected, setChainId]
   );

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -835,8 +835,10 @@ function Sheet({
     const distanceFromBottom = containerHeight.value - (scrollY.value + scrollViewHeight.value);
     const fadeStartDistance = FOOTER_HEIGHT; // Start fading when FOOTER_HEIGHT px from bottom
 
-    let fadeOpacity = 1;
-    if (distanceFromBottom < fadeStartDistance) {
+    const isLessThanMaxHeight = containerHeight.value < MAX_HEIGHT;
+
+    let fadeOpacity = isLessThanMaxHeight ? 0 : 1;
+    if (distanceFromBottom < fadeStartDistance && !isLessThanMaxHeight) {
       fadeOpacity = Math.max(0, distanceFromBottom / fadeStartDistance);
     }
 

--- a/src/components/buttons/NetworkSelectorButton.tsx
+++ b/src/components/buttons/NetworkSelectorButton.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useMemo } from 'react';
+import { ChainImage } from '@/components/coin-icon/ChainImage';
+import { Bleed, Inline, Text, TextProps } from '@/design-system';
+import * as i18n from '@/languages';
+import { ChainId } from '@/state/backendNetworks/types';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { ButtonPressAnimation } from '@/components/animations';
+import { useNavigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
+import { RootStackParamList } from '@/navigation/types';
+import { RouteProp } from '@react-navigation/native';
+
+interface DefaultButtonOptions {
+  iconColor?: TextProps['color'];
+  iconSize?: TextProps['size'];
+  iconWeight?: TextProps['weight'];
+  textColor?: TextProps['color'];
+  textSize?: TextProps['size'];
+  textWeight?: TextProps['weight'];
+}
+
+type NetworkSelectorProps = Omit<RouteProp<RootStackParamList, 'NetworkSelector'>['params'], 'selected' | 'setSelected'>;
+
+type ChainContextMenuProps = {
+  defaultButtonOptions?: DefaultButtonOptions;
+  onSelectChain: (chainId: ChainId | undefined) => void;
+  selectedChainId: ChainId | undefined;
+} & NetworkSelectorProps;
+
+export const NetworkSwitcherButton = ({
+  defaultButtonOptions = {},
+  onSelectChain,
+  selectedChainId,
+  actionButton = {
+    label: i18n.t(i18n.l.exchange.all_networks),
+    color: 'labelSecondary',
+    weight: 'bold',
+  },
+  ...networkSelectorProps
+}: ChainContextMenuProps) => {
+  const { navigate } = useNavigation();
+  const {
+    iconColor = 'labelSecondary',
+    iconSize = 'icon 13px',
+    iconWeight = 'bold',
+    textColor = 'label',
+    textSize = '15pt',
+    textWeight = 'heavy',
+  } = defaultButtonOptions;
+
+  const handleSelectChain = useCallback(
+    (chainId: ChainId | undefined) => {
+      onSelectChain(chainId);
+    },
+    [onSelectChain]
+  );
+
+  const navigateToNetworkSelector = useCallback(() => {
+    navigate(Routes.NETWORK_SELECTOR, {
+      ...networkSelectorProps,
+      actionButton,
+      selected: selectedChainId,
+      setSelected: handleSelectChain,
+    });
+  }, [handleSelectChain, navigate, networkSelectorProps, selectedChainId]);
+
+  const displayName = useMemo(() => {
+    if (!selectedChainId) return actionButton.label;
+    return useBackendNetworksStore.getState().getChainsLabel()[selectedChainId];
+  }, [actionButton.label, selectedChainId]);
+
+  return (
+    <Bleed horizontal="12px">
+      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="chain-context-menu">
+        <Inline alignVertical="center" space="6px" wrap={false}>
+          {actionButton.icon && !selectedChainId && (
+            <Text align="center" color={actionButton.color || iconColor} size={iconSize} weight={actionButton.weight || iconWeight}>
+              {actionButton.icon}
+            </Text>
+          )}
+          {selectedChainId && (
+            <Bleed vertical="4px">
+              <ChainImage chainId={selectedChainId} position="relative" size={16} />
+            </Bleed>
+          )}
+          <Text color={textColor} numberOfLines={1} size={textSize} weight={textWeight}>
+            {displayName}
+          </Text>
+          <Text align="center" color={iconColor} size={iconSize} weight={iconWeight}>
+            􀆏
+          </Text>
+        </Inline>
+      </ButtonPressAnimation>
+    </Bleed>
+  );
+};

--- a/src/components/buttons/NetworkSelectorButton.tsx
+++ b/src/components/buttons/NetworkSelectorButton.tsx
@@ -22,12 +22,16 @@ interface DefaultButtonOptions {
 type NetworkSelectorProps = Omit<RouteProp<RootStackParamList, 'NetworkSelector'>['params'], 'selected' | 'setSelected'>;
 
 type NetworkSelectorButtonProps = {
+  bleed?: boolean;
+  disabled?: boolean;
   defaultButtonOptions?: DefaultButtonOptions;
   onSelectChain: (chainId: ChainId | undefined) => void;
   selectedChainId: ChainId | undefined;
 } & NetworkSelectorProps;
 
 export const NetworkSelectorButton = ({
+  bleed = true,
+  disabled,
   defaultButtonOptions = {},
   onSelectChain,
   selectedChainId,
@@ -70,8 +74,8 @@ export const NetworkSelectorButton = ({
   }, [actionButton.label, selectedChainId]);
 
   return (
-    <Bleed horizontal="12px">
-      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="network-selector-button">
+    <Bleed horizontal={bleed ? '12px' : undefined}>
+      <ButtonPressAnimation disabled={disabled} onPress={navigateToNetworkSelector} padding="12px" testID="network-selector-button">
         <Inline alignVertical="center" space="6px" wrap={false}>
           {actionButton.icon && !selectedChainId && (
             <Text align="center" color={actionButton.color || iconColor} size={iconSize} weight={actionButton.weight || iconWeight}>

--- a/src/components/buttons/NetworkSelectorButton.tsx
+++ b/src/components/buttons/NetworkSelectorButton.tsx
@@ -21,13 +21,13 @@ interface DefaultButtonOptions {
 
 type NetworkSelectorProps = Omit<RouteProp<RootStackParamList, 'NetworkSelector'>['params'], 'selected' | 'setSelected'>;
 
-type ChainContextMenuProps = {
+type NetworkSelectorButtonProps = {
   defaultButtonOptions?: DefaultButtonOptions;
   onSelectChain: (chainId: ChainId | undefined) => void;
   selectedChainId: ChainId | undefined;
 } & NetworkSelectorProps;
 
-export const NetworkSwitcherButton = ({
+export const NetworkSelectorButton = ({
   defaultButtonOptions = {},
   onSelectChain,
   selectedChainId,
@@ -37,7 +37,7 @@ export const NetworkSwitcherButton = ({
     weight: 'bold',
   },
   ...networkSelectorProps
-}: ChainContextMenuProps) => {
+}: NetworkSelectorButtonProps) => {
   const { navigate } = useNavigation();
   const {
     iconColor = 'labelSecondary',
@@ -71,7 +71,7 @@ export const NetworkSwitcherButton = ({
 
   return (
     <Bleed horizontal="12px">
-      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="chain-context-menu">
+      <ButtonPressAnimation onPress={navigateToNetworkSelector} padding="12px" testID="network-selector-button">
         <Inline alignVertical="center" space="6px" wrap={false}>
           {actionButton.icon && !selectedChainId && (
             <Text align="center" color={actionButton.color || iconColor} size={iconSize} weight={actionButton.weight || iconWeight}>

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3140,7 +3140,7 @@
         }
       }
     },
-    "network_switcher": {
+    "network_selector": {
       "customize_networks_banner": {
         "title": "Customize Networks",
         "tap_the": "Tap the",

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -483,7 +483,8 @@
         "a_network": "a network",
         "swap_failed": "Swap Failed",
         "receive": "Receive",
-        "on": "on"
+        "on": "on",
+        "reset": "Reset"
       }
     },
     "cloud": {

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -94,7 +94,7 @@ import { RootStackParamList } from './types';
 import WalletLoadingListener from '@/components/WalletLoadingListener';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';
 import { LogSheet } from '@/components/debugging/LogSheet';
-import { NetworkSelector } from '@/components/NetworkSwitcher';
+import { NetworkSelector } from '@/screens/NetworkSelector';
 
 const Stack = createStackNavigator();
 const OuterStack = createStackNavigator();

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -108,7 +108,7 @@ import { RootStackParamList } from './types';
 import WalletLoadingListener from '@/components/WalletLoadingListener';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';
 import { LogSheet } from '@/components/debugging/LogSheet';
-import { NetworkSelector } from '@/components/NetworkSwitcher';
+import { NetworkSelector } from '@/screens/NetworkSelector';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -121,6 +121,7 @@ export type RootStackParamList = {
     canEdit?: boolean;
     canSelectAllNetworks?: boolean;
     allowedNetworks?: ChainId[];
+    goBackOnSelect?: boolean;
   };
   [Routes.LOG_SHEET]: {
     data: {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -15,6 +15,7 @@ import { Address } from 'viem';
 import { SharedValue } from 'react-native-reanimated';
 import { ChainId } from '@/state/backendNetworks/types';
 import { ExpandedSheetParamAsset } from '@/screens/expandedAssetSheet/context/ExpandedAssetSheetContext';
+import { TextProps } from '@/design-system';
 
 export type PartialNavigatorConfigOptions = Pick<Partial<Parameters<ReturnType<typeof createStackNavigator>['Screen']>[0]>, 'options'>;
 
@@ -125,6 +126,13 @@ export type RootStackParamList = {
     allowedNetworks?: ChainId[];
     goBackOnSelect?: boolean;
     title?: string;
+    actionButton?: {
+      color?: TextProps['color'];
+      icon?: string;
+      weight?: TextProps['weight'];
+      label: string;
+      onPress?: () => void;
+    };
   };
   [Routes.LOG_SHEET]: {
     data: {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -118,10 +118,13 @@ export type RootStackParamList = {
     selected: SharedValue<ChainId | undefined> | ChainId | undefined;
     setSelected: (chainId: ChainId | undefined) => void;
     onClose?: VoidFunction;
+    fillPinnedSection?: boolean;
+    canSelect?: boolean;
     canEdit?: boolean;
     canSelectAllNetworks?: boolean;
     allowedNetworks?: ChainId[];
     goBackOnSelect?: boolean;
+    title?: string;
   };
   [Routes.LOG_SHEET]: {
     data: {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -115,9 +115,12 @@ export type RootStackParamList = {
     position: RainbowPosition;
   };
   [Routes.NETWORK_SELECTOR]: {
-    onClose?: VoidFunction;
-    selected: SharedValue<ChainId | undefined>;
+    selected: SharedValue<ChainId | undefined> | ChainId | undefined;
     setSelected: (chainId: ChainId | undefined) => void;
+    onClose?: VoidFunction;
+    canEdit?: boolean;
+    canSelectAllNetworks?: boolean;
+    allowedNetworks?: ChainId[];
   };
   [Routes.LOG_SHEET]: {
     data: {

--- a/src/screens/NetworkSelector.tsx
+++ b/src/screens/NetworkSelector.tsx
@@ -637,6 +637,7 @@ type NetworksGridProps = NetworkSwitcherProps & {
 
 function NetworksGrid({
   canSelect,
+  canEdit,
   editing,
   expanded,
   selected,
@@ -662,8 +663,7 @@ function NetworksGrid({
     // persists pinned networks when closing the sheet
     // should be the only time this component is unmounted
     return () => {
-      // don't persist the pinned networks for sheets where we modify the pinned networks (e.g. - WalletConnectApprovalSheet)
-      if (fillPinnedSection) return;
+      if (!canEdit) return;
 
       if (networks.value[Section.pinned].length > 0) {
         networkSwitcherStore.setState({ pinnedNetworks: networks.value[Section.pinned] });
@@ -983,6 +983,7 @@ export function NetworkSelector() {
         scrollViewHeight={scrollViewHeight}
         goBackOnSelect={goBackOnSelect}
         fillPinnedSection={fillPinnedSection}
+        canEdit={canEdit}
       />
     </Sheet>
   );

--- a/src/screens/claimables/transaction/components/ClaimCustomization.tsx
+++ b/src/screens/claimables/transaction/components/ClaimCustomization.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@/design-system';
+import { Box, Text, useColorMode } from '@/design-system';
 import { haptics } from '@/utils';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
@@ -18,6 +18,8 @@ import { ChainId } from '@/state/backendNetworks/types';
 type TokenMap = Record<TokenToReceive['symbol'], TokenToReceive>;
 
 export function ClaimCustomization() {
+  const { isDarkMode } = useColorMode();
+
   const balanceSortedChainList = useUserAssetsStore(state => state.getBalanceSortedChainList());
   const {
     claimStatus,
@@ -29,8 +31,6 @@ export function ClaimCustomization() {
   } = useTransactionClaimableContext();
 
   const [isInitialState, setIsInitialState] = useState(true);
-
-  const chainsLabel = useBackendNetworksStore.getState().getChainsLabel();
 
   const { data: usdcSearchData } = useTokenSearch(
     {
@@ -249,23 +249,37 @@ export function ClaimCustomization() {
       <Text align="center" weight="bold" color="labelTertiary" size="17pt">
         {i18n.t(i18n.l.claimables.panel.on)}
       </Text>
-      <NetworkSelectorButton
-        bleed={false}
-        disabled={isDisabled}
-        onSelectChain={handleNetworkSelection}
-        selectedChainId={outputChainId}
-        goBackOnSelect
-        canEdit={false}
-        allowedNetworks={balanceSortedChainList.filter(
-          chainId => isInitialState || (chainId !== outputChainId && (!outputToken || chainId in outputToken.networks))
-        )}
-        actionButton={{
-          icon: '􀅉',
-          label: i18n.t(i18n.l.claimables.panel.reset),
-          color: 'labelTertiary',
-          onPress: resetState,
-        }}
-      />
+
+      <Box
+        paddingHorizontal={{ custom: 7 }}
+        height={{ custom: 28 }}
+        flexDirection="row"
+        borderColor={{ custom: isDarkMode ? 'rgba(245, 248, 255, 0.04)' : 'rgba(9, 17, 31, 0.02)' }}
+        borderWidth={1.33}
+        borderRadius={12}
+        gap={4}
+        style={{ backgroundColor: isDarkMode ? 'rgba(245, 248, 255, 0.04)' : 'rgba(9, 17, 31, 0.02)' }}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <NetworkSelectorButton
+          bleed={false}
+          disabled={isDisabled}
+          onSelectChain={handleNetworkSelection}
+          selectedChainId={outputChainId}
+          goBackOnSelect
+          canEdit={false}
+          allowedNetworks={balanceSortedChainList.filter(
+            chainId => isInitialState || (chainId !== outputChainId && (!outputToken || chainId in outputToken.networks))
+          )}
+          actionButton={{
+            icon: '􀅉',
+            label: i18n.t(i18n.l.claimables.panel.reset),
+            color: 'labelTertiary',
+            onPress: resetState,
+          }}
+        />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
Fixes APP-2341, APP-2342, APP-2343, APP-2344, APP-2345, APP-2346

## What changed (plus any additional context for devs)
With our growing list of networks, we need to enable scrolling on the network switcher to prevent the sheet from overflowing off the top of the screen.

Swaps now will utilize the new NetworkSwitcher route to change output / input token lists. The token to sell list is filtered down show networks that the user has tokens on. Output is sorted by balance. This is the same functionality as we had before in the dropdown menus.

Adds a variant of NetworkSwitcher to the WalletConnectApprovalSheet. We needed to add the following functionality (or rather remove?)
- the ability to select a network
- we don't want to show which network was selected because technically it's all the networks
- We also want to fill the amount of space in the pinnedNetworks section as possible
- Due to the adjustment of the pinned networks, we needed to also not persist those pinned networks on sheet close

Added NetworkSelectorButton component to provide a reusable way to launch into a NetworkSelector route. I also cleaned up a little bit of the file system by moving the NetworkSelector to the screens folder since it's a route.

Biggest most notable change which is what the ticket is for, is introducing actionButton prop into the NetworkSelector route. It provides overrides to turn the All Networks masthead button into a configurable action button as shown in the below screen recording.

Adds the Network Selector component to the preferred network selection.

Claimables customization network selector now uses the new network selector.

## Screen recordings / screenshots
See individual PRs: 

https://github.com/rainbow-me/rainbow/pull/6454
https://github.com/rainbow-me/rainbow/pull/6455
https://github.com/rainbow-me/rainbow/pull/6456
https://github.com/rainbow-me/rainbow/pull/6457
https://github.com/rainbow-me/rainbow/pull/6458
https://github.com/rainbow-me/rainbow/pull/6459

## What to test
All locations should behave as expected
