### PR TITLE
Fix: createQueryStore not setting subscription manager to enabled

### DIFF
--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -1007,6 +1007,7 @@ export function createQueryStore<
           if (enableLogs) console.log('[🌀 Enabled Change 🌀] - [Old]:', `${oldVal},`, '[New]:', newVal);
           oldVal = newVal;
           queryStore.setState(state => ({ ...state, enabled: newVal }));
+          if (newVal) subscriptionManager.setEnabled(newVal);
         }
       });
       paramUnsubscribes.push(unsub);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Noticed there was an edge case where a queryStore would begin disabled and not be triggered to enabled when it should. This fixes it. 

There still exists an edge case if the `enabled` selector and `params` rely on the same piece of state that we don't update the enabled state **before** the params, so we end up triggering a fetch that's guaranteed to fail via abort. Not a huge deal, but should be addressed at some point in the future.

## Screen recordings / screenshots
n/a

## What to test
I'll throw up a mock here in a bit
