### PR TITLE
Default idfa check to false when network fails

### DIFF
--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -142,7 +142,7 @@ export const DEFAULT_CONFIG: RainbowConfig = {
   remote_promo_enabled: false,
   points_notifications_toggle: true,
   dapp_browser: true,
-  idfa_check_enabled: true,
+  idfa_check_enabled: false,
   rewards_enabled: true,
 
   degen_mode: true,


### PR DESCRIPTION
Fixes APP-2369

## What changed (plus any additional context for devs)
Changes default config local value to false when network status is offline.

## Screen recordings / screenshots


## What to test
idfa prompt checks
