### PR TITLE
Fix broken 'open in Rainbow' option in Safari share menu

### DIFF
--- a/ios/OpenInRainbow/ActionViewController.swift
+++ b/ios/OpenInRainbow/ActionViewController.swift
@@ -84,17 +84,25 @@ class ActionViewController: UIViewController {
       self.finish()
     }
 
-    private func handleUrl(_ url: NSURL) {
-        // From http://stackoverflow.com/questions/24297273/openurl-not-work-in-action-extension
-        var responder = self as UIResponder?
-        let selectorOpenURL = sel_registerName("openURL:")
+    @objc @discardableResult private func openURL(_ url: URL) -> Bool {
+        var responder: UIResponder? = self
         while responder != nil {
-            if responder!.responds(to: selectorOpenURL) {
-                responder!.callSelector(selector: selectorOpenURL, object: url, delay: 0)
+            if let application = responder as? UIApplication {
+                if #available(iOS 18.0, *) {
+                    application.open(url, options: [:], completionHandler: nil)
+                    return true
+                } else {
+                    return application.perform(#selector(openURL(_:)), with: url) != nil
+                }
             }
-
-            responder = responder!.next
+            responder = responder?.next
         }
+        return false
+    }
+    
+    private func handleUrl(_ url: NSURL) {
+        let swiftUrl = url as URL
+        _ = openURL(swiftUrl)
         finish()
     }
 

--- a/ios/ShareWithRainbow/ShareViewController.swift
+++ b/ios/ShareWithRainbow/ShareViewController.swift
@@ -84,17 +84,25 @@ class ShareViewController: UIViewController {
       self.finish()
     }
 
-    private func handleUrl(_ url: NSURL) {
-        // From http://stackoverflow.com/questions/24297273/openurl-not-work-in-action-extension
-        var responder = self as UIResponder?
-        let selectorOpenURL = sel_registerName("openURL:")
+    @objc @discardableResult private func openURL(_ url: URL) -> Bool {
+        var responder: UIResponder? = self
         while responder != nil {
-            if responder!.responds(to: selectorOpenURL) {
-                responder!.callSelector(selector: selectorOpenURL, object: url, delay: 0)
+            if let application = responder as? UIApplication {
+                if #available(iOS 18.0, *) {
+                    application.open(url, options: [:], completionHandler: nil)
+                    return true
+                } else {
+                    return application.perform(#selector(openURL(_:)), with: url) != nil
+                }
             }
-
-            responder = responder!.next
+            responder = responder?.next
         }
+        return false
+    }
+    
+    private func handleUrl(_ url: NSURL) {
+        let swiftUrl = url as URL
+        _ = openURL(swiftUrl)
         finish()
     }
 


### PR DESCRIPTION
Fixes APP-2353

## What changed (plus any additional context for devs)
> BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(:) needs to migrate to the non-deprecated UIApplication.open(:options:completionHandler:). Force returning false (NO).

Apple released a breaking change in iOS 18 that broke the method I was using to open the UIResponder. This uses the new `application.open` API on iOS 18 and the old logic for older iOS versions for both the Share and Open extensions.

## Screen recordings / screenshots
https://github.com/user-attachments/assets/6effef82-42ea-45db-9cef-afad51a7634d

## What to test
does it work for you?
