### PR TITLE
Rework query store enabled handling

### DIFF
--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -1054,8 +1054,8 @@ export function createQueryStore<
       });
       paramUnsubscribes.push(unsub);
     }
-  } else if (subscriptionManager.get().enabled !== initialStoreEnabled) {
-    subscriptionManager.setEnabled(initialStoreEnabled);
+  } else if (initialStoreEnabled !== initialData.enabled) {
+    queryStore.setState(state => ({ ...state, enabled: initialData.enabled }));
   }
 
   for (const k in attachVals?.params) {

--- a/src/state/internal/queryStore/classes/SubscriptionManager.ts
+++ b/src/state/internal/queryStore/classes/SubscriptionManager.ts
@@ -8,6 +8,10 @@ interface SubscriptionManagerConfig {
    * The store's `disableAutoRefetching` option, passed through from the query config.
    */
   disableAutoRefetching: boolean;
+  /**
+   * The initial enabled state for the SubscriptionManager.
+   */
+  initialEnabled: boolean;
 }
 
 /**
@@ -40,7 +44,8 @@ export class SubscriptionManager {
   /**
    * Creates a new SubscriptionManager instance.
    */
-  constructor({ disableAutoRefetching }: SubscriptionManagerConfig) {
+  constructor({ disableAutoRefetching, initialEnabled }: SubscriptionManagerConfig) {
+    this.enabled = initialEnabled;
     if (disableAutoRefetching) {
       this.fetchThrottleMs = time.seconds(5);
     }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Moves the `setState` `enabled` handling up to the store's `setState` function — previously the override existed at the subscription level which was redundant and lacked full coverage
- No longer persisting `enabled` to ensure the config's `enabled` value is always respected when the store is rebuilt
- Now correctly resolving params if either `params` or a dynamic `enabled` value are provided — previously dynamic `enabled` values wouldn't be resolved if no params were provided
- Adjusts the check for non-dynamic `enabled` values to ensure any mismatched persisted `enabled` values get back in sync
- Adds a `skipStoreUpdates: 'withCache'` option for manual `fetch` calls
- Extracts the partial params handling to a pure `getCompleteParams` function

## Screen recordings / screenshots


## What to test

