### PR TITLE
Claim improvements, adjust coin icon animation display condition

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -1,5 +1,5 @@
 import { DropdownMenu } from '@/components/DropdownMenu';
-import { globalColors, Text, TextIcon, useBackgroundColor, useColorMode } from '@/design-system';
+import { globalColors, IconContainer, Text, TextIcon, useBackgroundColor, useColorMode } from '@/design-system';
 import { useForegroundColor } from '@/design-system/color/useForegroundColor';
 import RainbowTokenFilter from '@/assets/RainbowTokenFilter.png';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
@@ -226,7 +226,7 @@ function CategoryFilterButton({
         style={{
           flexDirection: 'row',
           alignItems: 'center',
-          gap: 4,
+          gap: typeof icon === 'string' ? 4 : 10,
           height: 36,
           paddingHorizontal: 12,
           borderRadius: 18,
@@ -245,7 +245,9 @@ function CategoryFilterButton({
             {icon}
           </TextIcon>
         ) : (
-          icon
+          <IconContainer height={8} width={12}>
+            {icon}
+          </IconContainer>
         )}
         <View>
           {/* This first Text element sets the width of the container */}

--- a/src/components/expanded-state/chart/ChartExpandedStateHeader.js
+++ b/src/components/expanded-state/chart/ChartExpandedStateHeader.js
@@ -10,6 +10,7 @@ import ChartTypes from '@/helpers/chartTypes';
 import { convertAmountToNativeDisplay } from '@/helpers/utilities';
 import { useAccountSettings } from '@/hooks';
 import { useChartData } from '@/react-native-animated-charts/src';
+import { useExpandedAssetSheetContext } from '@/screens/expandedAssetSheet/context/ExpandedAssetSheetContext';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import { ColumnWithMargins } from '../../layout';
@@ -39,6 +40,7 @@ export default function ChartExpandedStateHeader({
   const { nativeCurrency } = useAccountSettings();
 
   const { data } = useChartData();
+  const { isRainbowToken } = useExpandedAssetSheetContext();
 
   const chartDataExists = useMemo(() => {
     const firstValue = data?.points?.[0]?.y;
@@ -93,7 +95,7 @@ export default function ChartExpandedStateHeader({
   return (
     <Container testID={'expanded-state-header'} showChart={showChart}>
       <Stack space={'20px'}>
-        {shouldUseRainbowCoinEffect && asset?.iconUrl ? (
+        {(isRainbowToken || shouldUseRainbowCoinEffect) && asset?.iconUrl ? (
           <RainbowCoinEffect color={asset?.colors?.primary} imageUrl={asset?.iconUrl} size={44} />
         ) : (
           <RainbowCoinIcon

--- a/src/graphql/queries/metadata.graphql
+++ b/src/graphql/queries/metadata.graphql
@@ -480,6 +480,9 @@ fragment TokenLinksFragment on TokenLinks {
   homepage {
     ...TokenLinkFragment
   }
+  rainbow {
+    ...TokenLinkFragment
+  }
   reddit {
     ...TokenLinkFragment
   }
@@ -555,6 +558,7 @@ query tokenMetadata($address: String!, $chainId: Int!, $currency: String) {
       relativeChange24h
       value
     }
+    rainbow
     totalSupply
     volume1d
   }

--- a/src/hooks/useAdditionalAssetData.ts
+++ b/src/hooks/useAdditionalAssetData.ts
@@ -8,7 +8,7 @@ import { time } from '@/utils';
 // Types
 export type TokenMetadata = Pick<
   Token,
-  'description' | 'volume1d' | 'marketCap' | 'totalSupply' | 'circulatingSupply' | 'fullyDilutedValuation' | 'links'
+  'description' | 'volume1d' | 'marketCap' | 'totalSupply' | 'circulatingSupply' | 'fullyDilutedValuation' | 'links' | 'rainbow'
 >;
 
 // Types for the query arguments

--- a/src/resources/addys/claimables/utils.ts
+++ b/src/resources/addys/claimables/utils.ts
@@ -8,14 +8,14 @@ import { AddysClaimable, BaseClaimable, Claimable, RainbowClaimable } from './ty
 export const parseClaimables = <C extends Claimable>(
   claimables: AddysClaimable[],
   currency: NativeCurrencyKey,
-  prune?: Map<string, number> | null
+  prune?: Record<string, number> | null
 ): C[] => {
   return claimables
     .map(claimable => {
       if (
         !(claimable.claim_action_type === 'transaction' || claimable.claim_action_type === 'sponsored') ||
         !claimable.claim_action?.length ||
-        prune?.has(claimable.unique_id)
+        prune?.[claimable.unique_id]
       ) {
         return undefined;
       }

--- a/src/screens/Airdrops/ClaimAirdropSheet.tsx
+++ b/src/screens/Airdrops/ClaimAirdropSheet.tsx
@@ -142,7 +142,7 @@ export const ClaimAirdropSheet = () => {
 const PanelHeader = memo(function PanelHeader({ symbol, symbolHasEmoji }: { symbol: string; symbolHasEmoji: boolean }) {
   const sheetHandleColor = foregroundColors.labelQuaternary.dark;
   return (
-    <Box alignItems="center" gap={24} justifyContent="center" paddingTop="32px" width="full">
+    <Box alignItems="center" gap={24} justifyContent="center" paddingHorizontal="44px" paddingTop="32px" width="full">
       <SheetHandleFixedToTop color={sheetHandleColor} showBlur={true} top={10} />
       <Text align="center" color="label" containsEmoji={symbolHasEmoji} numberOfLines={1} size="20pt" weight="heavy">
         {i18n.t(i18n.l.token_launcher.claim_airdrop_sheet.title, { symbol })}
@@ -175,7 +175,7 @@ const PanelContent = ({
   );
   return (
     <>
-      <Box alignItems="center" gap={20} paddingBottom="8px">
+      <Box alignItems="center" gap={20} paddingBottom="8px" paddingHorizontal="44px">
         <TextShadow blur={16} shadowOpacity={0.2}>
           <Text align="center" color={{ custom: highContrastColor }} numberOfLines={1} size="44pt" weight="black">
             {airdropValue}

--- a/src/screens/Airdrops/utils.ts
+++ b/src/screens/Airdrops/utils.ts
@@ -39,6 +39,18 @@ interface ClaimableTransactionData {
   usdValue: number;
 }
 
+type ExecuteAirdropClaimResult =
+  | {
+      error?: never;
+      success: true;
+      txHash: string;
+    }
+  | {
+      error: string;
+      success: false;
+      txHash?: never;
+    };
+
 /**
  * Executes an airdrop claim transaction.
  */
@@ -54,7 +66,7 @@ export async function executeAirdropClaim({
   gasLimit: string;
   gasSettings: GasSettings;
   onConfirm?: (receipt: TransactionReceipt) => void;
-}): Promise<{ error?: string; success: boolean; txHash?: string }> {
+}): Promise<ExecuteAirdropClaimResult> {
   const { airdropId, amount, chainId, data, symbol, to, usdValue } = getClaimableTransactionData(claimable);
   const nonce = await getNextNonce({ address: accountAddress, chainId });
 

--- a/src/screens/expandedAssetSheet/components/AssetContextMenu.tsx
+++ b/src/screens/expandedAssetSheet/components/AssetContextMenu.tsx
@@ -135,12 +135,10 @@ export function AssetContextMenu() {
         Clipboard.setString(asset.address);
         break;
       case ContextMenuActions.Share: {
-        const url =
-          assetMetadata?.links?.rainbow?.url ??
-          buildTokenDeeplink({
-            networkLabel: chainLabels[asset.chainId],
-            contractAddress: asset.address,
-          });
+        const url = buildTokenDeeplink({
+          networkLabel: chainLabels[asset.chainId],
+          contractAddress: asset.address,
+        });
         Share.share({
           url,
         });

--- a/src/screens/expandedAssetSheet/components/SheetContent.tsx
+++ b/src/screens/expandedAssetSheet/components/SheetContent.tsx
@@ -70,7 +70,7 @@ export function SheetContent() {
             {isBuySectionVisible && (
               <CollapsibleSection
                 content={<BuySection />}
-                icon="􀋥"
+                icon="􀡓"
                 id={SectionId.BUY}
                 primaryText={i18n.t(i18n.l.expanded_state.sections.buy.title)}
                 secondaryText={asset.symbol}

--- a/src/screens/expandedAssetSheet/components/sections/AboutSection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/AboutSection.tsx
@@ -167,17 +167,18 @@ function Description({ text }: { text: string }) {
 }
 
 export function AboutSection() {
-  const { basicAsset: asset, assetMetadata: metadata } = useExpandedAssetSheetContext();
+  const { basicAsset: asset, assetMetadata: metadata, isRainbowToken } = useExpandedAssetSheetContext();
 
   const rowItems = useMemo(() => {
     const items: RowItem[] = [];
 
-    if (metadata?.links?.homepage?.url) {
+    const rainbowUrl = metadata?.links?.homepage?.url || metadata?.links?.rainbow?.url;
+    if (isRainbowToken && rainbowUrl) {
       items.push({
         icon: '􀎞',
         title: i18n.t(i18n.l.expanded_state.asset.social.website),
-        url: metadata.links.homepage.url,
-        value: formatUrl(metadata.links.homepage.url, false, true, true),
+        url: rainbowUrl,
+        value: formatUrl(rainbowUrl, false, true, true),
       });
     }
 

--- a/src/screens/expandedAssetSheet/context/ExpandedAssetSheetContext.tsx
+++ b/src/screens/expandedAssetSheet/context/ExpandedAssetSheetContext.tsx
@@ -218,6 +218,7 @@ export function ExpandedAssetSheetContextProvider({
     if (rainbowSuperToken) {
       return {
         ...metadata,
+        rainbow: metadata?.rainbow ?? true,
         icon_url: rainbowSuperToken.imageUrl,
         description: rainbowSuperToken.description,
         links: rainbowSuperToken.links || metadata?.links,
@@ -226,10 +227,7 @@ export function ExpandedAssetSheetContextProvider({
     return metadata;
   }, [rainbowSuperToken, metadata]);
 
-  // TODO: Replace with data from the metadata endpoint once available
-  const isRainbowToken = useMemo(() => {
-    return !!(asset.icon_url?.startsWith('https://rainbowme-res.cloudinary.com') && asset.icon_url?.includes('/token-launcher/'));
-  }, [asset.icon_url]);
+  const isRainbowToken = superMetadata?.rainbow ?? false;
 
   const accentColors: AccentColors = useMemo(() => {
     const background = isDarkMode

--- a/src/screens/expandedAssetSheet/context/ExpandedAssetSheetContext.tsx
+++ b/src/screens/expandedAssetSheet/context/ExpandedAssetSheetContext.tsx
@@ -86,6 +86,7 @@ type ExpandedAssetSheetContextType = {
   hideClaimSection: boolean;
   isOwnedAsset: boolean;
   isLoadingMetadata: boolean;
+  isRainbowToken: boolean;
 };
 
 type ExpandedAssetSheetContextProviderProps = {
@@ -225,6 +226,11 @@ export function ExpandedAssetSheetContextProvider({
     return metadata;
   }, [rainbowSuperToken, metadata]);
 
+  // TODO: Replace with data from the metadata endpoint once available
+  const isRainbowToken = useMemo(() => {
+    return !!(asset.icon_url?.startsWith('https://rainbowme-res.cloudinary.com') && asset.icon_url?.includes('/token-launcher/'));
+  }, [asset.icon_url]);
+
   const accentColors: AccentColors = useMemo(() => {
     const background = isDarkMode
       ? chroma(
@@ -273,6 +279,7 @@ export function ExpandedAssetSheetContextProvider({
         hideClaimSection,
         isOwnedAsset,
         isLoadingMetadata,
+        isRainbowToken,
       }}
     >
       {children}


### PR DESCRIPTION
Fixes APP-2476

## What changed (plus any additional context for devs)
- Adds stale balance handling for claims
- Keys optimistic claims by account address, to avoid conflicts if you have two wallets that were airdropped the same token
- Adjusts the expanded state coin icon animation display logic to show it in prod only for Rainbow tokens
  - Not currently seeing this data in the metadata response, so instead using a check based on the asset's `icon_url`, which isn't ideal but works for now, until the data becomes available via the API
- Updates the expanded state Buy section icon
- Fixes the Rainbow list icon alignment
- Improves long symbol handling in `ClaimAirdropSheet`

## Screen recordings / screenshots


## What to test

