### PR TITLE
Fix Warpcast icon clipping and input validation

### DIFF
--- a/src/components/icons/svg/WarpcastIcon.tsx
+++ b/src/components/icons/svg/WarpcastIcon.tsx
@@ -3,9 +3,9 @@ import { Path } from 'react-native-svg';
 import Svg from '../Svg';
 import { globalColors } from '@/design-system';
 
-export function WarpcastIcon({ color = globalColors.grey100, width = 24, height = 17 }: { color: string; width: number; height: number }) {
+export function WarpcastIcon({ color = globalColors.grey100, width = 25, height = 18 }: { color: string; width: number; height: number }) {
   return (
-    <Svg height={height} viewBox="0 0 24 17" width={width}>
+    <Svg height={height} viewBox="0 0 25 18" width={width}>
       <Path
         d="M19.3208 0.359863L17.2507 8.04873L15.1738 0.359863H10.3943L8.29752 8.10534L6.20759 0.359863H0.763916L5.82233 17.3599H10.5187L12.7644 9.46571L15.0101 17.3599H19.7166L24.7639 0.359863H19.3208Z"
         fill={color}

--- a/src/screens/token-launcher/helpers/inputValidators.ts
+++ b/src/screens/token-launcher/helpers/inputValidators.ts
@@ -79,7 +79,7 @@ const PLATFORM_CONFIGS: Record<LinkType, PlatformConfig> = {
     baseUrls: ['t.me/', 'telegram.me/'],
   },
   farcaster: {
-    usernameRegex: /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,15}$/,
+    usernameRegex: /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,15}(\.eth)?$/,
     baseUrls: ['warpcast.com/'],
   },
   // TODO: if discord is added later


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Right side of Warpcast svg was getting clipped
- Allow '.eth' suffix on warpcast ftl input

## Screen recordings / screenshots

Before:
<img width="187" alt="Screenshot 2025-03-20 at 10 15 14 AM" src="https://github.com/user-attachments/assets/8cf6151d-a1ef-482e-aee4-487f58172d92" />

After:
<img width="552" alt="Screenshot 2025-03-20 at 10 13 42 AM" src="https://github.com/user-attachments/assets/e8cb23b2-efe1-49ed-b0eb-1671d353d6db" />
