### PR TITLE
Remove twitter post bonus points

### DIFF
--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1624,7 +1624,7 @@
         "invalid_referral_code_alert": "Invalid referral code. Please double check your code and try again.",
         "no_balance_alert": "To enroll in Points, you must have a non-zero wallet balance.",
         "referral_link_is_ready": "Your referral link is ready",
-        "referral_link_bonus_text": "Tweet your referral link and get an extra 250 points",
+        "referral_link_bonus_text": "Tweet your referral link and you'll earn 10% of the points earned by anyone you refer",
         "referral_link_bonus_text_extended": "Plus you'll earn 10% of the points earned by anyone you refer",
         "complete_onboarding": "Done",
         "share_to_x": "Share to X",

--- a/src/screens/points/content/console/share.tsx
+++ b/src/screens/points/content/console/share.tsx
@@ -12,7 +12,6 @@ import { NeonButton } from '../../components/NeonButton';
 import { LineBreak } from '../../components/LineBreak';
 import { Bleed, Box, Inline, Stack } from '@/design-system';
 import { Linking } from 'react-native';
-import { metadataPOSTClient } from '@/graphql';
 import { analyticsV2 } from '@/analytics';
 
 export const Share = () => {
@@ -42,12 +41,6 @@ export const Share = () => {
         <AnimatedText
           color={textColors.account}
           delayStart={1000}
-          multiline
-          textContent={i18n.t(i18n.l.points.console.referral_link_bonus_text)}
-        />
-        <AnimatedText
-          color={textColors.account}
-          delayStart={1000}
           onComplete={() => {
             const complete = setTimeout(() => {
               setShowShareButtons(true);
@@ -55,7 +48,7 @@ export const Share = () => {
             return () => clearTimeout(complete);
           }}
           multiline
-          textContent={i18n.t(i18n.l.points.console.referral_link_bonus_text_extended)}
+          textContent={i18n.t(i18n.l.points.console.referral_link_bonus_text)}
         />
       </Stack>
       <AnimatePresence condition={showShareButtons && !!intent?.length} duration={300}>
@@ -82,10 +75,6 @@ export const Share = () => {
                 const beginNextPhase = setTimeout(async () => {
                   if (intent) {
                     Linking.openURL(intent);
-                    await metadataPOSTClient.redeemCodeForPoints({
-                      address: accountAddress,
-                      redemptionCode: 'TWITTERSHARED',
-                    });
                   }
                   setAnimationKey(prevKey => prevKey + 1);
                   setStep(RainbowPointsFlowSteps.Review);


### PR DESCRIPTION
Fixes APP-2515

## What changed (plus any additional context for devs)
- Removed api call to monitor for twitter post to award bonus
- Changed copy to reflect no additional posting bonus

## Screen recordings / screenshots

https://github.com/user-attachments/assets/8998df7e-a563-4c4c-b902-aa1ced704d2d

## What to test
This flow is only in the points onboarding flow, which can only be reached on a wallet group that has not onboarded yet and that has at least a $5 balance. 
