### PR TITLE
Update testID placement for fast currency selection row

### DIFF
--- a/e2e/parallel/4_discoverSheetFlow.spec.ts
+++ b/e2e/parallel/4_discoverSheetFlow.spec.ts
@@ -64,7 +64,6 @@ describe('Discover Screen Flow', () => {
 
   it('Should search and open expanded state for SOCKS', async () => {
     await typeText('discover-search-input', 'SOCKS\n', true);
-    await delayTime('very-long');
     await checkIfVisible('discover-currency-select-list-exchange-coin-row-SOCKS-1');
     await checkIfNotVisible('discover-currency-select-list-exchange-coin-row-ETH-1');
     await waitAndTap('discover-currency-select-list-exchange-coin-row-SOCKS-1');

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -104,14 +104,8 @@ export default React.memo(function FastCurrencySelectionRow({
   const isInfoButtonVisible = !isNativeAsset(address, chainId) && !showBalance;
 
   return (
-    <View style={sx.row}>
-      <ButtonPressAnimation
-        onPress={onPress}
-        style={[sx.flex, disabled && { opacity: 0.5 }]}
-        testID={rowTestID}
-        wrapperStyle={sx.flex}
-        disabled={disabled}
-      >
+    <View style={sx.row} testID={rowTestID}>
+      <ButtonPressAnimation onPress={onPress} style={[sx.flex, disabled && { opacity: 0.5 }]} wrapperStyle={sx.flex} disabled={disabled}>
         <View style={sx.rootContainer}>
           <View style={sx.iconContainer}>
             <RainbowCoinIcon


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Moved the `testID` to the surrounding `View` of the `ButtonPressAnimation` component inside of the `FastCurrencySelectionRow`

When running locally, found that I didn't need to do the extra delay before waiting for the row to be visible. Confirming the tests pass here first.
