### PR TITLE
[APP-2520] Rainbow Creator LP Fee Claimables V1

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/Claimable.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/Claimable.tsx
@@ -75,7 +75,7 @@ export const Claimable = React.memo(function Claimable({ uniqueId, extendedState
       onPress={() => {
         if (!isETHRewards) {
           analyticsV2.track(analyticsV2.event.claimablePanelOpened, {
-            claimableType: claimable?.type,
+            claimableType: claimable?.actionType,
             claimableId: claimable?.analyticsId,
             chainId: claimable?.chainId,
             asset: { symbol: claimable?.asset.symbol, address: claimable?.asset.address },

--- a/src/resources/addys/claimables/query.ts
+++ b/src/resources/addys/claimables/query.ts
@@ -10,7 +10,6 @@ import { IS_TEST } from '@/env';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { getAddysHttpClient } from '../client';
 import { Address } from 'viem';
-import { abort } from 'process';
 
 // ///////////////////////////////////////////////
 // Query Types

--- a/src/resources/addys/claimables/types.ts
+++ b/src/resources/addys/claimables/types.ts
@@ -29,10 +29,31 @@ interface DApp {
   colors: Colors;
 }
 
+export enum ClaimableType {
+  MoxieDaily = 'moxie-daily',
+  MoxieVested = 'moxie-vested',
+  ZoraRewards = 'zora-rewards',
+  DegenAirdrop = 'degen-airdrop',
+  merklClaimable = 'merkl-claimable',
+  MorphoClaimable = 'morpho-claimable',
+  Blur = 'blur',
+  Aerodrome = 'aerodrome-finance',
+  Velodrome = 'velodrome-finance',
+  HypersubV1 = 'hypersub-v1',
+  HypersubV2 = 'hypersub-v2',
+  Clanker = 'clanker',
+  Rainbow = 'rainbow',
+  RainbowSuperTokenCreatorFees = 'rainbow-super-token-creator-fees',
+
+  // test claims
+  Testing = 'frontend-testing',
+  TestingSponsored = 'frontend-testing-sponsored',
+}
+
 interface AddysBaseClaimable {
   name: string;
   unique_id: string;
-  type: string;
+  type: ClaimableType;
   network: ChainId;
   asset: AddysAsset;
   amount: string;
@@ -87,6 +108,7 @@ export interface BaseClaimable {
   uniqueId: string;
   analyticsId: string;
   iconUrl: string;
+  type: ClaimableType;
   value: {
     claimAsset: { amount: string; display: string };
     nativeAsset: { amount: string; display: string };
@@ -95,7 +117,7 @@ export interface BaseClaimable {
 }
 
 export interface TransactionClaimable extends BaseClaimable {
-  type: 'transaction';
+  actionType: 'transaction';
   action: { to: Address; data: string };
 }
 
@@ -104,7 +126,7 @@ export interface RainbowClaimable extends TransactionClaimable {
 }
 
 export interface SponsoredClaimable extends BaseClaimable {
-  type: 'sponsored';
+  actionType: 'sponsored';
   action: { url: string; method: string };
 }
 

--- a/src/resources/addys/claimables/utils.ts
+++ b/src/resources/addys/claimables/utils.ts
@@ -34,6 +34,7 @@ export const parseClaimables = <C extends Claimable>(
         uniqueId: claimable.unique_id,
         analyticsId: claimable.type,
         iconUrl: claimable.dapp.icon_url,
+        type: claimable.type,
         value: {
           claimAsset: convertRawAmountToBalance(claimable.amount, claimable.asset),
           nativeAsset: convertRawAmountToNativeDisplay(claimable.amount, claimable.asset.decimals, claimable.asset.price.value, currency),
@@ -47,7 +48,7 @@ export const parseClaimables = <C extends Claimable>(
         }
         return {
           ...baseClaimable,
-          type: 'transaction',
+          actionType: 'transaction',
           action: {
             to: claimable.claim_action[0].address_to,
             data: claimable.claim_action[0].calldata,
@@ -56,7 +57,7 @@ export const parseClaimables = <C extends Claimable>(
       } else if (claimable.claim_action_type === 'sponsored') {
         return {
           ...baseClaimable,
-          type: 'sponsored',
+          actionType: 'sponsored',
           action: { method: claimable.claim_action[0].method, url: claimable.claim_action[0].url },
         };
       }

--- a/src/screens/claimables/ClaimPanel.tsx
+++ b/src/screens/claimables/ClaimPanel.tsx
@@ -11,7 +11,7 @@ export const ClaimClaimablePanel = () => {
     params: { claimable },
   } = useRoute<RouteProp<RootStackParamList, 'ClaimClaimablePanel'>>();
 
-  switch (claimable.type) {
+  switch (claimable.actionType) {
     case 'transaction':
       return (
         <TransactionClaimableContextProvider claimable={claimable}>

--- a/src/screens/claimables/transaction/components/ClaimCustomization.tsx
+++ b/src/screens/claimables/transaction/components/ClaimCustomization.tsx
@@ -228,7 +228,7 @@ export function ClaimCustomization() {
       setQuoteState({ quote: undefined, nativeValueDisplay: undefined, tokenAmountDisplay: undefined, status: 'none' });
       setIsInitialState(false);
     },
-    [resetState, setOutputConfig, setQuoteState, setGasState]
+    [setOutputConfig, setQuoteState, setGasState]
   );
 
   const isDisabled =

--- a/src/screens/claimables/transaction/components/TransactionClaimableFlow.tsx
+++ b/src/screens/claimables/transaction/components/TransactionClaimableFlow.tsx
@@ -10,6 +10,7 @@ import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation';
 import { useWallets } from '@/hooks';
 import { watchingAlert } from '@/utils';
+import { ClaimableType } from '@/resources/addys/claimables/types';
 
 export function TransactionClaimableFlow() {
   const {
@@ -102,7 +103,7 @@ export function TransactionClaimableFlow() {
           tokenSymbol={outputToken?.symbol}
           chainId={outputChainId}
         />
-        <ClaimCustomization />
+        {claimable.type !== ClaimableType.RainbowSuperTokenCreatorFees && <ClaimCustomization />}
       </Box>
       <Box alignItems="center" width="full">
         <ClaimButton onPress={onPress} disabled={disabled} shimmer={shimmer} biometricIcon={shouldShowClaimText} label={buttonLabel} />


### PR DESCRIPTION
## What changed (plus any additional context for devs)
I added an enum to keep track of our current `AddysClaimable` types. We were treating `type` and `action_type` similarly in the past because our conditionals depended chiefly upon 1 of 2 action types. We want to have more flexibility to make changes based on `type` as well, so I made sure to better separate these values in the logic. `Claimable.type` is now `Claimable.actionType` and `Claimable.type` now accurately reflects the type provided by backend (e.g. "clanker", "rainbow_super_token_creator_fees" etc).

## Screen recordings / screenshots
Here is a small sanity check to confirm that the display of our typical claimables has not changed:
https://www.loom.com/share/25100eb9731e4e4d96dc939b899f6818

## What to test
This change is made in anticipation of BE's release of rainbow creator lp fee claims. There should be no discernible difference in functionality. We just need to ensure we are not introducing any regressions in the meantime.
