### PR TITLE
Prevent analytics from logging in CI

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -141,7 +141,28 @@ export class Analytics {
  */
 export const analyticsV2 = new Analytics();
 
+// Wrapper around the rudderClient to prevent CI from logging analytics
+class AnalyticsDeprecated {
+  client: typeof rudderClient;
+  disabled: boolean;
+
+  constructor() {
+    this.client = rudderClient;
+    this.disabled = IS_TEST || !!device.get(['doNotTrack']);
+  }
+
+  track(event: string, properties?: Record<string, unknown> | null, options?: Record<string, unknown> | null) {
+    if (this.disabled) return;
+    this.client.track(event, properties, options);
+  }
+
+  screen(name: string, properties?: Record<string, unknown> | null, options?: Record<string, unknown> | null): void {
+    if (this.disabled) return;
+    this.client.screen(name, properties, options);
+  }
+}
+
 /**
  * @deprecated Use the `analyticsV2` export from this same file
  */
-export const analytics = rudderClient;
+export const analytics = new AnalyticsDeprecated();


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Wrap the deprecated analytics usage in class that respects disabling collection. CI was accounting for non insignificant amount of "new users" on iOS. 

## What to test
old analytics should work as normal