### PR TITLE
Fix airdrops card number formatting

### DIFF
--- a/src/components/cards/skia-cards/AirdropsCard.tsx
+++ b/src/components/cards/skia-cards/AirdropsCard.tsx
@@ -274,11 +274,9 @@ function getCoinIconPath(): SkPath {
 }
 
 function getBadgeConfig(numberOfAirdrops: number | null): {
-  badgeHeight: number;
   badgeRect: SkRRect;
   badgeWidth: number;
   badgeXOffset: number;
-  badgeYOffset: number;
   formattedAirdropsCount: string;
 } {
   let formattedAirdropsCount = numberOfAirdrops === null ? '?' : numberOfAirdrops.toString();
@@ -291,5 +289,5 @@ function getBadgeConfig(numberOfAirdrops: number | null): {
   const badgeYOffset = CARD_CONFIG.dimensions.badge.y - badgeHeight / 2;
   const badgeRect = rrect(rect(0, badgeYOffset, badgeWidth, badgeHeight), badgeHeight / 2, badgeHeight / 2);
 
-  return { badgeHeight, badgeRect, badgeWidth, badgeXOffset, badgeYOffset, formattedAirdropsCount };
+  return { badgeRect, badgeWidth, badgeXOffset, formattedAirdropsCount };
 }


### PR DESCRIPTION
Fixes APP-2529

## What changed (plus any additional context for devs)
- Adds proper formatting of large airdrop counts in `AirdropsCard`

## Screen recordings / screenshots
<img src="https://github.com/user-attachments/assets/b5197b9b-4877-4b36-a8c0-583c852d8631" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 12 37" width="300" />
<img src="https://github.com/user-attachments/assets/262305e6-ebe1-467f-a274-6e561c1ce47b" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 12 45" width="300" />
<img src="https://github.com/user-attachments/assets/3a42d39d-e8d7-4f23-b367-788cf344185d" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 12 49" width="300" />
<img src="https://github.com/user-attachments/assets/b8e41b02-1ca1-409b-a44f-fbbd61d0d88b" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 13 02" width="300" />
<img src="https://github.com/user-attachments/assets/d4f964d5-9d4d-4ef8-adf4-875131d058c3" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 19 00" width="300" />

## What to test

