### PR TITLE
Fix: Invariant Violation: Invalid URL: should be a string. Was: undefined

### DIFF
--- a/src/utils/openInBrowser.ts
+++ b/src/utils/openInBrowser.ts
@@ -4,6 +4,11 @@ import Routes from '@/navigation/routesNames';
 import { Linking } from 'react-native';
 
 export const openInBrowser = (url: string, internal = true) => {
+  if (!url) {
+    logger.warn(`[openInBrowser] No url provided, returning early...`);
+    return;
+  }
+
   const isDeeplink = !url.startsWith('http');
 
   if (isDeeplink) {


### PR DESCRIPTION
Fixes APP-2276

## What changed (plus any additional context for devs)
Prevents calls to `Linking.openURL` if the url parameter is undefined

## Screen recordings / screenshots
n/a

## What to test
n/a
