### PR TITLE
Fix: ClassCastException: java.lang.Double cannot be cast to java.lang.String

### DIFF
--- a/src/__swaps__/screens/Swap/components/CoinRow.tsx
+++ b/src/__swaps__/screens/Swap/components/CoinRow.tsx
@@ -268,13 +268,16 @@ const InfoButton = ({
     }
   };
 
-  const onPressAndroid = () =>
+  const onPressAndroid = () => {
+    const androidOptions = [
+      options.copy.title,
+      ...(isSupportedChain && options.blockExplorer?.title ? [options.blockExplorer?.title] : []),
+    ];
     showActionSheetWithOptions(
       {
-        options: [options.copy.title, ...(isSupportedChain ? [options.blockExplorer?.title] : [])],
-        showSeparators: true,
+        options: androidOptions,
       },
-      (idx: number) => {
+      idx => {
         if (idx === 0) {
           options.copy.action();
         }
@@ -283,6 +286,7 @@ const InfoButton = ({
         }
       }
     );
+  };
 
   return (
     <ContextMenuButton

--- a/src/components/ContactRowInfoButton.js
+++ b/src/components/ContactRowInfoButton.js
@@ -98,7 +98,6 @@ const ContactRowInfoButton = ({ children, item, chainId, scaleTo }) => {
       {
         cancelButtonIndex: 2,
         options: androidContractActions,
-        showSeparators: true,
         title: `${item?.name}`,
       },
       idx => {

--- a/src/components/DappBrowser/search-input/SearchInput.tsx
+++ b/src/components/DappBrowser/search-input/SearchInput.tsx
@@ -187,7 +187,8 @@ const ThreeDotMenu = function ThreeDotMenu({ formattedUrlValue }: { formattedUrl
         ...{ cancelButtonIndex: menuConfig.menuItems.length - 1 },
         options: menuConfig.menuItems.map(item => item?.actionTitle),
       },
-      (buttonIndex: number) => {
+      buttonIndex => {
+        if (buttonIndex === undefined) return;
         onPressMenuItem({ nativeEvent: { actionKey: menuConfig.menuItems[buttonIndex]?.actionKey as MenuActionKey } });
       }
     );

--- a/src/components/DappBrowser/search-input/TabButton.tsx
+++ b/src/components/DappBrowser/search-input/TabButton.tsx
@@ -168,7 +168,8 @@ export const TabButton = React.memo(function TabButton({
         ...{ cancelButtonIndex: longPressMenuConfig.menuItems.length - 1 },
         options: longPressMenuConfig.menuItems.map(item => item?.actionTitle),
       },
-      (buttonIndex: number) => {
+      buttonIndex => {
+        if (buttonIndex === undefined) return;
         onPressMenuItem({ nativeEvent: { actionKey: longPressMenuConfig.menuItems[buttonIndex]?.actionKey as MenuActionKey } });
       }
     );

--- a/src/components/context-menu-buttons/ChainContextMenu.tsx
+++ b/src/components/context-menu-buttons/ChainContextMenu.tsx
@@ -100,7 +100,6 @@ export const ChainContextMenu = ({
     showActionSheetWithOptions(
       {
         options,
-        showSeparators: true,
       },
       (selectedIndex: number | undefined) => {
         if (selectedIndex !== undefined) {

--- a/src/components/exchangeAssetRowContextMenuProps.ts
+++ b/src/components/exchangeAssetRowContextMenuProps.ts
@@ -51,10 +51,9 @@ export default function contextMenuProps(item: any, onCopySwapDetailsText: (addr
       {
         cancelButtonIndex: 2,
         options: androidContractActions,
-        showSeparators: true,
         title: `${item?.name} (${item?.symbol})`,
       },
-      (idx: number) => {
+      idx => {
         if (idx === 0) {
           handleCopyContractAddress(item?.address);
         }

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -426,10 +426,9 @@ const UniqueTokenExpandedStateHeader = ({
     showActionSheetWithOptions(
       {
         options: baseActions,
-        showSeparators: true,
         title: '',
       },
-      (idx: number) => {
+      idx => {
         if (idx === collectionIndex && asset.marketplaceCollectionUrl) {
           openInBrowser(asset.marketplaceCollectionUrl);
         } else if (idx === websiteIndex) {

--- a/src/components/send/SendHeader.tsx
+++ b/src/components/send/SendHeader.tsx
@@ -185,7 +185,7 @@ export default function SendHeader({
           lang.t('contacts.options.cancel'), // <-- cancelButtonIndex
         ],
       },
-      async (buttonIndex: number) => {
+      async buttonIndex => {
         if (buttonIndex === 0) {
           showDeleteContactActionSheet({
             address: hexAddress,

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -133,7 +133,6 @@ const Tag = ({
     showActionSheetWithOptions(
       {
         options: androidContractActions,
-        showSeparators: true,
         title: '',
       },
       idx => {

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -108,10 +108,9 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
     showActionSheetWithOptions(
       {
         options: androidContextMenuActions,
-        showSeparators: true,
         title: dappName,
       },
-      async (index: number) => {
+      async index => {
         if (index === 0) {
           handlePressChangeWallet();
         } else if (index === 1) {

--- a/src/handlers/localstorage/theme.ts
+++ b/src/handlers/localstorage/theme.ts
@@ -18,7 +18,7 @@ export const getColorForThemeAndNavigationStyle = (theme: ThemesType) => {
  * @desc get theme
  * @return {String}
  */
-export const getTheme = () => getGlobal(THEME, 'system');
+export const getTheme = (): Promise<ThemesType> => getGlobal(THEME, 'system');
 
 /**
  * @desc save theme

--- a/src/helpers/walletConnectNetworks.ts
+++ b/src/helpers/walletConnectNetworks.ts
@@ -9,7 +9,7 @@ const androidNetworkActions = () => {
   const { testnetsEnabled } = store.getState().settings;
   return Object.values(useBackendNetworksStore.getState().getDefaultChains())
     .filter(chain => testnetsEnabled || !chain.testnet)
-    .map(chain => chain.id);
+    .map(chain => `${chain.id}`);
 };
 
 export const NETWORK_MENU_ACTION_KEY_FILTER = 'switch-to-network-';
@@ -74,14 +74,14 @@ export const androidShowNetworksActionSheet = (callback: any) => {
   showActionSheetWithOptions(
     {
       options: androidNetworkActions(),
-      showSeparators: true,
       title: i18n.t(i18n.l.walletconnect.menu_options.available_networks),
     },
-    (idx: number) => {
+    idx => {
       if (idx !== undefined) {
         const defaultChains = useBackendNetworksStore.getState().getDefaultChains();
         const networkActions = androidNetworkActions();
-        const chain = defaultChains[networkActions[idx]] || defaultChains[ChainId.mainnet];
+        const chainId = parseInt(networkActions[idx]);
+        const chain = defaultChains[chainId] || defaultChains[ChainId.mainnet];
         callback({ chainId: chain.id });
       }
     }

--- a/src/hooks/useManageCloudBackups.ts
+++ b/src/hooks/useManageCloudBackups.ts
@@ -87,8 +87,8 @@ export default function useManageCloudBackups() {
         options: buttons,
         title: getTitleForPlatform(),
       },
-      async (_buttonIndex: number) => {
-        if (_buttonIndex === 0) {
+      async buttonIndex => {
+        if (buttonIndex === 0) {
           showActionSheetWithOptions(
             {
               cancelButtonIndex: 1,
@@ -96,8 +96,8 @@ export default function useManageCloudBackups() {
               message: i18n.t(i18n.l.settings.confirm_delete_backups_description, { cloudPlatform }),
               options: [i18n.t(i18n.l.settings.confirm_delete_backups), i18n.t(i18n.l.button.cancel)],
             },
-            async (buttonIndex: any) => {
-              if (buttonIndex === 0) {
+            async nextButtonIndex => {
+              if (nextButtonIndex === 0) {
                 try {
                   let userPIN: string | undefined;
                   const hasBiometricsEnabled = await keychain.getSupportedBiometryType();
@@ -133,7 +133,7 @@ export default function useManageCloudBackups() {
           );
         }
 
-        if (_buttonIndex === 1 && IS_ANDROID) {
+        if (buttonIndex === 1 && IS_ANDROID) {
           logoutFromGoogleDrive();
           setAccountDetails(undefined);
           loginToGoogleDrive();

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -227,7 +227,10 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
     ].filter(Boolean),
   };
 
-  const avatarActionSheetOptions = avatarContextMenuConfig.menuItems.map(item => item && item.actionTitle).concat(ios ? ['Cancel'] : []);
+  const avatarActionSheetOptions = avatarContextMenuConfig.menuItems
+    .map(item => item && item.actionTitle)
+    .concat(ios ? ['Cancel'] : [])
+    .filter(Boolean) as string[];
 
   const onAvatarPressProfile = useCallback(() => {
     navigate(Routes.PROFILE_SHEET, {
@@ -252,7 +255,10 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
           destructiveButtonIndex: !hasENSAvatar && accountImage ? avatarActionSheetOptions.length - 2 : undefined,
           options: avatarActionSheetOptions,
         },
-        (buttonIndex: number) => callback(buttonIndex)
+        buttonIndex => {
+          if (buttonIndex === undefined) return;
+          callback(buttonIndex);
+        }
       );
     }
   }, [hasENSAvatar, accountENS, onAvatarPressProfile, avatarActionSheetOptions, accountImage, callback]);

--- a/src/hooks/useSelectImageMenu.tsx
+++ b/src/hooks/useSelectImageMenu.tsx
@@ -166,7 +166,7 @@ export default function useSelectImageMenu({
       {
         options: actionSheetOptions,
       },
-      async (buttonIndex: number) => {
+      async buttonIndex => {
         if (buttonIndex === 0) {
           isRemoved.current = false;
           handleSelectImage();

--- a/src/screens/SettingsSheet/components/GoogleAccountSection.tsx
+++ b/src/screens/SettingsSheet/components/GoogleAccountSection.tsx
@@ -37,7 +37,7 @@ export const GoogleAccountSection: React.FC = () => {
           i18n.t(i18n.l.button.cancel),
         ],
       },
-      (buttonIndex: number) => {
+      buttonIndex => {
         if (buttonIndex === 0) {
           logoutFromGoogleDrive();
           setAccountDetails(undefined);

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -47,6 +47,12 @@ interface SettingsSectionProps {
   onPressNotifications: () => void;
 }
 
+const androidActions = [
+  lang.t('settings.theme_section.system'),
+  lang.t('settings.theme_section.light'),
+  lang.t('settings.theme_section.dark'),
+];
+
 const SettingsSection = ({
   onCloseModal,
   onPressAppIcon,
@@ -128,19 +134,12 @@ const SettingsSection = ({
   }, [colorScheme]);
 
   const onPressThemeAndroidActions = useCallback(() => {
-    const androidActions = [
-      lang.t('settings.theme_section.system'),
-      lang.t('settings.theme_section.light'),
-      lang.t('settings.theme_section.dark'),
-    ] as const;
-
     showActionSheetWithOptions(
       {
         options: androidActions,
-        showSeparators: true,
         title: '',
       },
-      (idx: number) => {
+      idx => {
         if (idx === 0) {
           setTheme(Themes.SYSTEM);
         } else if (idx === 1) {

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -421,7 +421,7 @@ export default function ChangeWalletSheet() {
           message: i18n.t(i18n.l.wallet.action.remove_confirm),
           options: [i18n.t(i18n.l.wallet.action.remove), i18n.t(i18n.l.button.cancel)],
         },
-        async (buttonIndex: number) => {
+        async buttonIndex => {
           if (buttonIndex === 0) {
             analytics.track('Tapped "Delete Wallet" (final confirm)');
             await deleteWallet(walletId, address);

--- a/src/screens/token-launcher/components/TokenLauncherHeader.tsx
+++ b/src/screens/token-launcher/components/TokenLauncherHeader.tsx
@@ -49,7 +49,7 @@ export function TokenLauncherHeader() {
         destructiveButtonIndex: 0,
         options: [i18n.t(i18n.l.token_launcher.discard_and_exit), i18n.t(i18n.l.button.cancel)],
       },
-      (buttonIndex: number) => {
+      buttonIndex => {
         if (buttonIndex === 0) {
           navigation.goBack();
           analyticsV2.track(analyticsV2.event.tokenLauncherAbandoned, {

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -41,8 +41,8 @@ export const isDarkTheme = async () => {
   let currentTheme: ThemesType = await getTheme();
 
   if (currentTheme === Themes.SYSTEM) {
-    const isSystemDarkMode = Appearance.getColorScheme() === 'dark';
-    currentTheme = isSystemDarkMode ? 'dark' : 'light';
+    const isSystemDarkMode = Appearance.getColorScheme() === Themes.DARK;
+    currentTheme = isSystemDarkMode ? Themes.DARK : Themes.LIGHT;
   }
 
   return currentTheme === Themes.DARK;

--- a/src/utils/actionsheet.ts
+++ b/src/utils/actionsheet.ts
@@ -1,19 +1,6 @@
 import { IS_IOS } from '@/env';
-import { getTheme } from '@/handlers/localstorage/theme';
-import { ActionSheetIOS, ActionSheetIOSOptions, Appearance } from 'react-native';
+import { ActionSheetIOS, ActionSheetIOSOptions } from 'react-native';
 import ActionSheet from 'react-native-action-sheet';
-import { Themes } from '@/theme/ThemeContext';
-
-const determineUserInterfaceStyle = async () => {
-  let currentTheme = await getTheme();
-
-  if (currentTheme === Themes.SYSTEM) {
-    const isSystemDarkMode = Appearance.getColorScheme() === Themes.DARK;
-    currentTheme = isSystemDarkMode ? Themes.DARK : Themes.LIGHT;
-  }
-
-  return currentTheme;
-};
 
 /**
  * @desc Safely convert options to strings.
@@ -38,13 +25,11 @@ export default async function showActionSheetWithOptions(
   { options, ...props }: ActionSheetIOSOptions,
   callback: (buttonIndex: number | undefined) => void
 ) {
-  const userInterfaceStyle = await determineUserInterfaceStyle();
   const sheetOptions = safeOptions(options);
 
   if (IS_IOS) {
     ActionSheetIOS.showActionSheetWithOptions(
       {
-        userInterfaceStyle,
         options: sheetOptions,
         ...props,
       },
@@ -53,7 +38,6 @@ export default async function showActionSheetWithOptions(
   } else {
     ActionSheet.showActionSheetWithOptions(
       {
-        userInterfaceStyle,
         options: sheetOptions,
         ...props,
       },

--- a/src/utils/actionsheet.ts
+++ b/src/utils/actionsheet.ts
@@ -15,16 +15,38 @@ const determineUserInterfaceStyle = async () => {
   return currentTheme;
 };
 
+/**
+ * @desc Safely convert options to strings.
+ * This should technically never do anything since we have proper type checking, but
+ * it's a good sanity check for javascript files that are not typed.
+ * @param options - The options to convert (string[])
+ * @returns The options as strings
+ */
+const safeOptions = (options: ActionSheetIOSOptions['options']) => {
+  return options
+    .map(option => {
+      if (typeof option === 'undefined') return null;
+      if (typeof option === 'string') {
+        return option;
+      }
+      return `${option}`;
+    })
+    .filter(Boolean);
+};
+
 export default async function showActionSheetWithOptions(
-  options: ActionSheetIOSOptions,
+  { options, ...props }: ActionSheetIOSOptions,
   callback: (buttonIndex: number | undefined) => void
 ) {
   const userInterfaceStyle = await determineUserInterfaceStyle();
+  const sheetOptions = safeOptions(options);
+
   if (IS_IOS) {
     ActionSheetIOS.showActionSheetWithOptions(
       {
         userInterfaceStyle,
-        ...options,
+        options: sheetOptions,
+        ...props,
       },
       callback
     );
@@ -32,7 +54,8 @@ export default async function showActionSheetWithOptions(
     ActionSheet.showActionSheetWithOptions(
       {
         userInterfaceStyle,
-        ...options,
+        options: sheetOptions,
+        ...props,
       },
       callback
     );

--- a/src/utils/actionsheet.ts
+++ b/src/utils/actionsheet.ts
@@ -1,12 +1,11 @@
-import { ActionSheetIOS } from 'react-native';
+import { IS_IOS } from '@/env';
+import { ActionSheetIOS, ActionSheetIOSOptions } from 'react-native';
 import ActionSheet from 'react-native-action-sheet';
 
-export default function showActionSheetWithOptions(...args: any[]) {
-  if (ios) {
-    // @ts-ignore
-    ActionSheetIOS.showActionSheetWithOptions(...args);
+export default function showActionSheetWithOptions(options: ActionSheetIOSOptions, callback: (buttonIndex: number | undefined) => void) {
+  if (IS_IOS) {
+    ActionSheetIOS.showActionSheetWithOptions(options, callback);
   } else {
-    // @ts-ignore
-    ActionSheet.showActionSheetWithOptions(...args);
+    ActionSheet.showActionSheetWithOptions(options, callback);
   }
 }

--- a/src/utils/actionsheet.ts
+++ b/src/utils/actionsheet.ts
@@ -1,11 +1,40 @@
 import { IS_IOS } from '@/env';
-import { ActionSheetIOS, ActionSheetIOSOptions } from 'react-native';
+import { getTheme } from '@/handlers/localstorage/theme';
+import { ActionSheetIOS, ActionSheetIOSOptions, Appearance } from 'react-native';
 import ActionSheet from 'react-native-action-sheet';
+import { Themes } from '@/theme/ThemeContext';
 
-export default function showActionSheetWithOptions(options: ActionSheetIOSOptions, callback: (buttonIndex: number | undefined) => void) {
+const determineUserInterfaceStyle = async () => {
+  let currentTheme = await getTheme();
+
+  if (currentTheme === Themes.SYSTEM) {
+    const isSystemDarkMode = Appearance.getColorScheme() === Themes.DARK;
+    currentTheme = isSystemDarkMode ? Themes.DARK : Themes.LIGHT;
+  }
+
+  return currentTheme;
+};
+
+export default async function showActionSheetWithOptions(
+  options: ActionSheetIOSOptions,
+  callback: (buttonIndex: number | undefined) => void
+) {
+  const userInterfaceStyle = await determineUserInterfaceStyle();
   if (IS_IOS) {
-    ActionSheetIOS.showActionSheetWithOptions(options, callback);
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        userInterfaceStyle,
+        ...options,
+      },
+      callback
+    );
   } else {
-    ActionSheet.showActionSheetWithOptions(options, callback);
+    ActionSheet.showActionSheetWithOptions(
+      {
+        userInterfaceStyle,
+        ...options,
+      },
+      callback
+    );
   }
 }


### PR DESCRIPTION
Fixes APP-2502

## What changed (plus any additional context for devs)
culprit of the fatal exception was in the walletconnect options where we were mapping chainIds. I just wrapped that in a string template. Also took the opportunity to improve the type safety of the `showActionSheetWithOptions` function. I noticed that the actual callback function could be a number or undefined which isn't what their types declare, so I made sure to check that as well where it applies.

~~Also, been a nitpick of mine, but the action sheets don't follow the current app theme, so I took care of that in this PR as well.~~ This didn't work on Android so I removed it.

## Screen recordings / screenshots
I don't believe these are needed. Nothing functionally changed, just improved type safety and fixed the crash

## What to test
major test should be to test the walletconnect options action sheet on Android
