### PR TITLE
Add tracking of "Verified Assets" swaps to Amplitude

### DIFF
--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -128,6 +128,7 @@ const useCleanupOnUnmount = () => {
         outputAsset: null,
         quote: null,
         selectedOutputChainId: parsedAsset?.chainId ?? preferredNetwork ?? ChainId.mainnet,
+        lastNavigatedTrendingToken: undefined,
       });
 
       useSwapsSearchStore.setState({ searchQuery: '' });

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -222,6 +222,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
 
     return {
       isBridge: isBridge,
+      sectionId: outputAsset?.sectionId,
       inputAssetSymbol: inputAsset?.symbol || '',
       inputAssetName: inputAsset?.name || '',
       inputAssetAddress: inputAsset?.address as AddressOrEth,
@@ -411,11 +412,6 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
         },
       });
     }
-
-    // reset the last navigated trending token after a swap has taken place
-    swapsStore.setState({
-      lastNavigatedTrendingToken: undefined,
-    });
   };
 
   const executeSwap = performanceTracking.getState().executeFn({


### PR DESCRIPTION
Fixes APP-2360

## What changed (plus any additional context for devs)
Adds tracking to all token to buy asset list sections. Simply filter based on `sectionId === 'verified'`

## Screen recordings / screenshots
n/a

## What to test
n/a
