### PR TITLE
move rest of deprecated analytics to v2

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -11,6 +11,7 @@ import { AnyPerformanceLog, Screen } from '../state/performance/operations';
 import { FavoritedSite } from '@/state/browser/favoriteDappsStore';
 import { TrendingToken } from '@/resources/trendingTokens/trendingTokens';
 import { TokenLauncherAnalyticsParams } from '@/screens/token-launcher/state/tokenLauncherStore';
+import { ENSRegistrationTransactionType } from '../helpers/ens';
 
 /**
  * All events, used by `analytics.track()`
@@ -25,6 +26,14 @@ export const event = {
   promoSheetShown: 'promo_sheet.shown',
   promoSheetDismissed: 'promo_sheet.dismissed',
   swapSubmitted: 'Submitted Swap',
+  cardPressed: 'card.pressed',
+  learnArticleOpened: 'learn_article.opened',
+  learnArticleShared: 'learn_article.shared',
+  qrCodeViewed: 'qr_code.viewed',
+  buyButtonPressed: 'buy_button.pressed',
+  addWalletFlowStarted: 'add_wallet_flow.started',
+  sendMaxPressed: 'send.max_pressed',
+
   // notification promo sheet was shown
   notificationsPromoShown: 'notifications_promo.shown',
   // only for iOS — initial prompt is not allowed — Android is enabled by default
@@ -37,12 +46,9 @@ export const event = {
   notificationsPromoNotificationSettingsOpened: 'notifications_promo.notification_settings_opened',
   // user either swiped the sheet away, or clicked "Not Now"
   notificationsPromoDismissed: 'notifications_promo.dismissed',
-  cardPressed: 'card.pressed',
-  learnArticleOpened: 'learn_article.opened',
-  learnArticleShared: 'learn_article.shared',
-  qrCodeViewed: 'qr_code.viewed',
-  buyButtonPressed: 'buy_button.pressed',
-  addWalletFlowStarted: 'add_wallet_flow.started',
+  notificationsPromoNotificationSettingsChanged: 'notifications_promo.notification_settings_changed',
+  notificationsPromoTapped: 'notifications_promot.tapped',
+
   /**
    * Called either on click or during an open event callback. We want this as
    * early in the flow as possible.
@@ -146,6 +152,7 @@ export const event = {
   swapsFailed: 'swaps.failed',
   swapsSucceeded: 'swaps.succeeded',
   swapsQuoteFailed: 'swaps.quote_failed',
+  swapsGasUpdatedPrice: 'swaps.gas_updated_price',
 
   // app browser events
   browserTrendingDappClicked: 'browser.trending_dapp_pressed',
@@ -195,6 +202,38 @@ export const event = {
   // network status
   networkStatusOffline: 'network_status.offline',
   networkStatusReconnected: 'network_status.reconnected',
+
+  // ens
+  ensInitiatedRegistration: 'ens.initiated_registration',
+  ensEditedRecords: 'ens.edited_records',
+  ensCompletedRegistration: 'ens.completed_registration',
+  ensExtended: 'ens.extended',
+  ensTransferredControl: 'ens.transferred_control',
+  ensSetPrimary: 'ens.set_primary',
+  ensRapFailed: 'ens.rap_failed',
+  ensRapStarted: 'ens.rap_started',
+  ensRapCompleted: 'ens.rap_completed',
+
+  // backup
+  backupError: 'backup.error',
+  backupSavedPassword: 'backup.saved_password',
+  backupSkippedPassword: 'backup.skipped_password',
+  backupComplete: 'backup.complete',
+  backupConfirmed: 'backup.confirmed',
+  backupSheetShown: 'backup.sheet_shown',
+  backupChoosePassword: 'backup.choose_password',
+
+  // QR code 
+  qrCodeScannedAddress: 'qr_code.scanned_address',
+  qrCodeScannedProfile: 'qr_code.scanned_profile',
+  qrCodeScannedWalletConnect: 'qr_code.scanned_wallet_connect',
+  qrCodeScannedInvalid: 'qr_code.scanned_invalid',
+
+  // navigation events
+  navigationAddCash: 'navigation.add_cash',
+  navigationSwap: 'navigation.swap',
+  navigationSend: 'navigation.send',
+  navigationMyQrCode: 'navigation.my_qr_code',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -263,6 +302,13 @@ export type EventProperties = {
   [event.notificationsPromoSystemSettingsOpened]: undefined;
   [event.notificationsPromoNotificationSettingsOpened]: undefined;
   [event.notificationsPromoDismissed]: undefined;
+  [event.notificationsPromoNotificationSettingsChanged]: {
+    topic: string;
+    action: string;
+  };
+  [event.notificationsPromoTapped]: {
+    campaign: string;
+  };
   [event.cardPressed]: {
     cardName: string;
     routeName: string;
@@ -580,7 +626,7 @@ export type EventProperties = {
     name: string;
   };
 
-  // swaps related events
+  // swaps 
   [event.swapsSelectedAsset]: {
     asset: ParsedSearchAsset | ExtendedAnimatedAssetWithColors | null;
     otherAsset: ParsedSearchAsset | ExtendedAnimatedAssetWithColors | null;
@@ -613,6 +659,8 @@ export type EventProperties = {
     outputAsset: ParsedSearchAsset | ExtendedAnimatedAssetWithColors | null;
     quote: Quote | CrosschainQuote | QuoteError | null;
   };
+
+  [event.swapsGasUpdatedPrice]: { gasPriceOption: string };
 
   [event.swapsSubmitted]: SwapEventParameters<'swap' | 'crosschainSwap'>;
   [event.swapsFailed]: SwapsEventFailedParameters<'swap' | 'crosschainSwap'>;
@@ -809,7 +857,38 @@ export type EventProperties = {
     url: string;
   };
 
-  // network status
   [event.networkStatusOffline]: undefined;
   [event.networkStatusReconnected]: undefined;
+
+  [event.sendMaxPressed]: undefined;
+
+  [event.ensInitiatedRegistration]: { category: string };
+  [event.ensEditedRecords]: { category: string };
+  [event.ensCompletedRegistration]: { category: string };
+  [event.ensExtended]: { category: string };
+  [event.ensTransferredControl]: { category: string };
+  [event.ensSetPrimary]: { category: string };
+  [event.ensRapFailed]: { category: string; failed_action: ENSRegistrationTransactionType; label: string };
+  [event.ensRapStarted]: { category: string; label: string };
+  [event.ensRapCompleted]: { category: string; label: string };
+
+  [event.backupError]: { category: string; error: string; label: string };
+  [event.backupSavedPassword]: undefined;
+  [event.backupSkippedPassword]: undefined;
+  [event.backupComplete]: { category: string; label: string };
+  [event.backupConfirmed]: undefined;
+  [event.backupSheetShown]: { category: string; label: string };
+  [event.backupChoosePassword]: { category: string; label: string };
+
+  [event.qrCodeScannedAddress]: undefined;
+  [event.qrCodeScannedProfile]: undefined;
+  [event.qrCodeScannedWalletConnect]: undefined;
+  [event.qrCodeScannedInvalid]: { qrCodeData: string };
+
+  [event.navigationAddCash]: { category: string };
+  [event.navigationSwap]: { category: string };
+  [event.navigationSend]: { category: string };
+  [event.navigationMyQrCode]: { category: string };
+} & {
+  // ... existing properties ...
 };

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -140,29 +140,3 @@ export class Analytics {
  * review this directory's files for more information.
  */
 export const analyticsV2 = new Analytics();
-
-// Wrapper around the rudderClient to prevent CI from logging analytics
-class AnalyticsDeprecated {
-  client: typeof rudderClient;
-  disabled: boolean;
-
-  constructor() {
-    this.client = rudderClient;
-    this.disabled = IS_TEST || !!device.get(['doNotTrack']);
-  }
-
-  track(event: string, properties?: Record<string, unknown> | null, options?: Record<string, unknown> | null) {
-    if (this.disabled) return;
-    this.client.track(event, properties, options);
-  }
-
-  screen(name: string, properties?: Record<string, unknown> | null, options?: Record<string, unknown> | null): void {
-    if (this.disabled) return;
-    this.client.screen(name, properties, options);
-  }
-}
-
-/**
- * @deprecated Use the `analyticsV2` export from this same file
- */
-export const analytics = new AnalyticsDeprecated();

--- a/src/components/asset-list/RecyclerAssetList2/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/index.tsx
@@ -15,9 +15,10 @@ import { useTheme } from '@/theme';
 import { ProfileNameRow } from './profile-header/ProfileNameRow';
 import AndroidContextMenu from '@/components/context-menu/ContextMenu.android';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
 import lang from 'i18n-js';
 import { IS_ANDROID } from '@/env';
+import { event } from '@/analytics/event';
 
 export type AssetListType = 'wallet' | 'ens-profile' | 'select-nft';
 
@@ -81,9 +82,7 @@ function NavbarOverlay({ accentColor, position }: { accentColor?: string; positi
   const insets = useSafeAreaInsets();
 
   const handlePressQRCode = React.useCallback(() => {
-    analytics.track('Tapped "My QR Code"', {
-      category: 'home screen',
-    });
+    analyticsV2.track(event.navigationMyQrCode, { category: 'home screen' });
 
     navigate(Routes.RECEIVE_MODAL);
   }, [navigate]);

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -12,13 +12,14 @@ import { useNavigation } from '@/navigation';
 import { watchingAlert } from '@/utils';
 import Routes from '@rainbow-me/routes';
 import showWalletErrorAlert from '@/helpers/support';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
 import { useRecoilState } from 'recoil';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { userAssetsStore } from '@/state/assets/userAssets';
+import { event } from '@/analytics/event';
 
 export const ProfileActionButtonsRowHeight = 80;
 
@@ -149,9 +150,7 @@ function BuyButton() {
       return;
     }
 
-    analytics.track('Tapped "Add Cash"', {
-      category: 'home screen',
-    });
+    analyticsV2.track(event.navigationAddCash, { category: 'home screen' });
 
     navigate(Routes.ADD_CASH_SHEET);
   }, [isDamaged, navigate]);
@@ -171,9 +170,7 @@ function SwapButton() {
 
   const handlePress = React.useCallback(async () => {
     if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
-      analytics.track('Tapped "Swap"', {
-        category: 'home screen',
-      });
+      analyticsV2.track(event.navigationSwap, { category: 'home screen' });
       swapsStore.setState({
         inputAsset: userAssetsStore.getState().getHighestValueNativeAsset(),
       });
@@ -194,14 +191,11 @@ function SwapButton() {
 
 function SendButton() {
   const { isReadOnlyWallet } = useWallets();
-
   const { navigate } = useNavigation();
 
   const handlePress = React.useCallback(() => {
     if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
-      analytics.track('Tapped "Send"', {
-        category: 'home screen',
-      });
+      analyticsV2.track(event.navigationSend, { category: 'home screen' });
 
       navigate(Routes.SEND_FLOW);
     } else {
@@ -218,7 +212,6 @@ function SendButton() {
 
 export function CopyButton() {
   const [isToastActive, setToastActive] = useRecoilState(addressCopiedToastAtom);
-  const { accountAddress } = useAccountProfile();
   const { isDamaged } = useWallets();
 
   const handlePressCopy = React.useCallback(() => {

--- a/src/components/backup/BackupCloudStep.tsx
+++ b/src/components/backup/BackupCloudStep.tsx
@@ -9,7 +9,8 @@ import { cloudPlatform } from '@/utils/platform';
 import { PasswordField } from '@/components/fields';
 import { Text } from '@/components/text';
 import WalletAndBackup from '@/assets/WalletsAndBackup.png';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { cloudBackupPasswordMinLength, isCloudBackupPasswordValid } from '@/handlers/cloudBackup';
 import { useDimensions, useMagicAutofocus } from '@/hooks';
 import styled from '@/styled-thing';
@@ -59,10 +60,7 @@ export function BackupCloudStep() {
     setTimeout(() => {
       passwordRef.current?.focus();
     }, 1);
-    analytics.track('Choose Password Step', {
-      category: 'backup',
-      label: cloudPlatform,
-    });
+    analyticsV2.track(event.backupChoosePassword, { category: 'backup', label: cloudPlatform });
   }, []);
 
   const { handleFocus } = useMagicAutofocus(passwordRef);

--- a/src/components/backup/BackupSheetSection.tsx
+++ b/src/components/backup/BackupSheetSection.tsx
@@ -4,7 +4,8 @@ import { RainbowButton } from '../buttons';
 import { Column, ColumnWithMargins } from '../layout';
 import { SheetActionButton } from '../sheet';
 import { Text } from '../text';
-import { analytics } from '@/analytics';
+import { analytics, analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import { Bleed, Separator } from '@/design-system';
@@ -51,10 +52,7 @@ export default function BackupSheetSection({
 }: BackupSheetSectionProps) {
   const { colors } = useTheme();
   useEffect(() => {
-    analytics.track('BackupSheet shown', {
-      category: 'backup',
-      label: type,
-    });
+    analyticsV2.track(event.backupSheetShown, { category: 'backup', label: type });
   }, [type]);
 
   return (

--- a/src/components/backup/useCreateBackup.ts
+++ b/src/components/backup/useCreateBackup.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { backupAllWalletsToCloud, getLocalBackupPassword, saveLocalBackupPassword } from '@/model/backup';
 import { backupsStore, CloudBackupState } from '@/state/backups/backups';
 import { cloudPlatform } from '@/utils/platform';
-import { analytics } from '@/analytics';
+import { analytics, analyticsV2 } from '@/analytics';
 import { useWalletCloudBackup, useWallets } from '@/hooks';
 import Routes from '@/navigation/routesNames';
 import walletBackupStepTypes from '@/helpers/walletBackupStepTypes';
@@ -13,6 +13,7 @@ import { DelayedAlert } from '@/components/alerts';
 import { useDispatch } from 'react-redux';
 import * as i18n from '@/languages';
 import showWalletErrorAlert from '@/helpers/support';
+import { event } from '@/analytics/event';
 
 type UseCreateBackupProps = {
   walletId?: string;
@@ -58,10 +59,7 @@ export const useCreateBackup = () => {
       }
       // Reset the storedPassword state for next backup
       backupsStore.getState().setStoredPassword('');
-      analytics.track('Backup Complete', {
-        category: 'backup',
-        label: cloudPlatform,
-      });
+      analyticsV2.track(event.backupComplete, { category: 'backup', label: cloudPlatform });
       setLoadingStateWithTimeout({
         state: CloudBackupState.Success,
         outOfSync: true,
@@ -87,7 +85,7 @@ export const useCreateBackup = () => {
 
   const onConfirmBackup = useCallback(
     async ({ password, walletId, navigateToRoute }: ConfirmBackupProps) => {
-      analytics.track('Tapped "Confirm Backup"');
+      analyticsV2.track(event.backupConfirmed);
       backupsStore.getState().setStatus(CloudBackupState.InProgress);
 
       if (typeof walletId === 'undefined') {

--- a/src/components/contacts/ContactRow.tsx
+++ b/src/components/contacts/ContactRow.tsx
@@ -1,0 +1,7 @@
+import { analytics, analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
+
+const handlePress = useCallback(() => {
+  analyticsV2.track(event.contactPressed, { address });
+  onPress?.(address);
+}, [address, onPress]);

--- a/src/components/expanded-state/NewWalletGroupState.tsx
+++ b/src/components/expanded-state/NewWalletGroupState.tsx
@@ -1,7 +1,8 @@
 import * as lang from '@/languages';
 import React, { useCallback, useState } from 'react';
 import ProfileModal from './profile/ProfileModal';
-import { analyticsV2 as analytics } from '@/analytics';
+import { analytics, analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { useNavigation } from '@/navigation';
 
 type NewWalletGroupStateProps = {
@@ -15,7 +16,7 @@ export default function NewWalletGroupState({ onCloseModal, numWalletGroups }: N
   const [value, setValue] = useState('');
 
   const handleSubmit = useCallback(() => {
-    analytics.track(analytics.event.addNewWalletGroupName, {
+    analyticsV2.track(event.addNewWalletGroupName, {
       name: value.trim(),
     });
     onCloseModal({

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -2,7 +2,8 @@ import lang from 'i18n-js';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import useUpdateEmoji from '../../../src/hooks/useUpdateEmoji';
 import ProfileModal from './profile/ProfileModal';
-import { analytics } from '@/analytics';
+import { analytics, analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
 import { getWalletProfileMeta } from '@/helpers/walletProfileHandler';
 import { setCallbackAfterObtainingSeedsFromKeychainOrError } from '@/model/wallet';
@@ -38,14 +39,14 @@ export default function WalletProfileState({
   const handleCancel = useCallback(() => {
     onCancel?.();
     goBack();
-    analytics.track('Tapped "Cancel" on Wallet Profile modal');
+    analyticsV2.track(event.walletProfileCancelled);
     if (actionType === 'Create' && !isFromSettings) {
       navigate(Routes.CHANGE_WALLET_SHEET);
     }
   }, [actionType, goBack, navigate, onCancel, isFromSettings]);
 
   const handleSubmit = useCallback(async () => {
-    analytics.track('Tapped "Submit" on Wallet Profile modal');
+    analyticsV2.track(event.walletProfileSubmitted);
     onCloseModal({
       color: typeof nameColor === 'string' ? profileUtils.colorHexToIndex(nameColor) : nameColor,
       image: profileImage,

--- a/src/components/send/SendAssetFormField.js
+++ b/src/components/send/SendAssetFormField.js
@@ -6,7 +6,8 @@ import { ButtonPressAnimation } from '../animations';
 import { BubbleField } from '../fields';
 import { Row, RowWithMargins } from '../layout';
 import { Text } from '../text';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { useDimensions } from '@/hooks';
 import styled from '@/styled-thing';
 
@@ -62,9 +63,9 @@ const SendAssetFormField = (
   const { isTinyPhone, isSmallPhone, width } = useDimensions();
   const { colors } = useTheme();
   const handlePressMax = useCallback(
-    event => {
-      analytics.track('Clicked "Max" in Send flow input');
-      onPressButton?.(event);
+    e => {
+      analyticsV2.track(event.sendMaxPressed);
+      onPressButton?.(e);
     },
     [onPressButton]
   );

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -9,7 +9,8 @@ import { Alert } from '../components/alerts';
 import useExperimentalFlag, { PROFILES } from '../config/experimentalHooks';
 import { useNavigation } from '../navigation/Navigation';
 import { fetchReverseRecordWithRetry } from '@/utils/profileUtils';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { checkIsValidAddressOrDomain, isENSAddressFormat } from '@/helpers/validators';
 import { Navigation } from '@/navigation';
 import { POAP_BASE_URL, RAINBOW_PROFILES_BASE_URL } from '@/references';
@@ -52,7 +53,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
   const handleScanAddress = useCallback(
     async (address: string) => {
       haptics.notificationSuccess();
-      analytics.track('Scanned address QR code');
+      analyticsV2.track(event.qrCodeScannedAddress);
       const ensName = isENSAddressFormat(address) ? address : await fetchReverseRecordWithRetry(address);
       // First navigate to wallet screen
       navigate(Routes.WALLET_SCREEN);
@@ -73,7 +74,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
   const handleScanRainbowProfile = useCallback(
     async (url: string) => {
       haptics.notificationSuccess();
-      analytics.track('Scanned Rainbow profile url');
+      analyticsV2.track(event.qrCodeScannedProfile);
 
       const urlObj = new URL(url);
       const addressOrENS = urlObj.pathname?.split('/profile/')?.[1] || '';
@@ -100,7 +101,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
   const handleScanWalletConnect = useCallback(
     async (uri: string, connector?: string) => {
       haptics.notificationSuccess();
-      analytics.track('Scanned WalletConnect QR code');
+      analyticsV2.track(event.qrCodeScannedWalletConnect);
       await checkPushNotificationPermissions();
       goBack();
       onSuccess();
@@ -119,7 +120,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
   const handleScanInvalid = useCallback(
     (qrCodeData: string) => {
       haptics.notificationError();
-      analytics.track('Scanned broken or unsupported QR code', { qrCodeData });
+      analyticsV2.track(event.qrCodeScannedInvalid, { qrCodeData });
 
       Alert({
         buttons: [{ onPress: enableScanning, text: lang.t('button.okay') }],

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -18,7 +18,7 @@ import { allWalletsKey, pinKey, privateKeyKey, seedPhraseKey, selectedWalletKey,
 import * as keychain from '@/model/keychain';
 import * as kc from '@/keychain';
 import { AllRainbowWallets, createWallet, RainbowWallet } from './wallet';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
 import { logger, RainbowError } from '@/logger';
 import { IS_ANDROID, IS_DEV } from '@/env';
 import AesEncryptor from '../handlers/aesEncryption';
@@ -36,6 +36,7 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 import { AppDispatch } from '@/redux/store';
 import { backupsStore, CloudBackupState } from '@/state/backups/backups';
 import { openInBrowser } from '@/utils/openInBrowser';
+import { event } from '@/analytics/event';
 
 const { DeviceUUID } = NativeModules;
 const encryptor = new AesEncryptor();
@@ -280,7 +281,7 @@ export async function backupAllWalletsToCloud({
       const userError = getUserError(error);
       onError?.(userError);
       captureException(error);
-      analytics.track(`Error backing up all wallets to ${cloudPlatform}`, {
+      analyticsV2.track(event.backupError, {
         category: 'backup',
         error: userError,
         label: cloudPlatform,
@@ -594,10 +595,10 @@ export async function saveBackupPassword(password: BackupPassword): Promise<void
   try {
     if (!IS_ANDROID) {
       await kc.setSharedWebCredentials('Backup Password', password);
-      analytics.track('Saved backup password on iCloud');
+      analyticsV2.track(event.backupSavedPassword);
     }
   } catch (e) {
-    analytics.track("Didn't save backup password on iCloud");
+    analyticsV2.track(event.backupSkippedPassword);
   }
 }
 

--- a/src/notifications/analytics.ts
+++ b/src/notifications/analytics.ts
@@ -1,4 +1,5 @@
-import { analytics, analyticsV2 } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { MinimalNotification } from '@/notifications/types';
 import { getPermissionStatus } from '@/notifications/permissions';
 import messaging from '@react-native-firebase/messaging';
@@ -7,23 +8,19 @@ import {
   WALLET_GROUPS_STORAGE_KEY,
   WALLET_TOPICS_STORAGE_KEY,
   GroupSettings,
-  WalletNotificationRelationshipType,
   GlobalNotificationTopicType,
   WalletNotificationSettings,
   notificationSettingsStorage,
 } from '@/notifications/settings';
 
 export const trackTappedPushNotification = (notification: MinimalNotification | undefined) => {
-  analytics.track('Tapped Push Notification', {
-    campaign: {
-      name: notification?.data?.type ?? 'default',
-      medium: 'Push',
-    },
+  analyticsV2.track(event.notificationsPromoTapped, {
+    campaign: `${notification?.data?.type ?? 'default'}`,
   });
 };
 
 export const trackChangedGlobalNotificationSettings = (topic: GlobalNotificationTopicType, enableTopic: boolean) => {
-  analytics.track('Changed Global Notification Settings', {
+  analyticsV2.track(event.notificationsPromoNotificationSettingsChanged, {
     topic,
     action: enableTopic ? 'subscribe' : 'unsubscribe',
   });

--- a/src/raps/actions/ens.ts
+++ b/src/raps/actions/ens.ts
@@ -1,6 +1,7 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { ENSActionParameters, ENSRap, ENSRapActionType, RapENSAction, RapENSActionParameters } from '@/raps/common';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
+import { event } from '@/analytics/event';
 import { ENSRegistrationRecords, NewTransaction, TransactionGasParamAmounts, TransactionStatus } from '@/entities';
 import { estimateENSTransactionGasLimit, formatRecordsForTransaction } from '@/handlers/ens';
 import { toHex } from '@/handlers/web3';
@@ -386,13 +387,13 @@ const ensAction = async (
             salt,
           })
         );
-        analytics.track('Initiated ENS registration', {
+        analyticsV2.track(event.ensInitiatedRegistration, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.MULTICALL:
         tx = await executeMulticall(name, ensRegistrationRecords, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Edited ENS records', {
+        analyticsV2.track(event.ensEditedRecords, {
           category: 'profiles',
         });
         break;
@@ -414,43 +415,43 @@ const ensAction = async (
             registerTransactionHash: tx?.hash,
           })
         );
-        analytics.track('Completed ENS registration', {
+        analyticsV2.track(event.ensCompletedRegistration, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.RENEW:
         tx = await executeRenew(name, duration, ownerAddress, rentPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Extended ENS', {
+        analyticsV2.track(event.ensExtended, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.SET_TEXT:
         tx = await executeSetText(name, ensRegistrationRecords, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Edited ENS records', {
+        analyticsV2.track(event.ensEditedRecords, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.SET_CONTENTHASH:
         tx = await executeSetContenthash(name, ensRegistrationRecords, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Edited ENS records', {
+        analyticsV2.track(event.ensEditedRecords, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.SET_ADDR:
         tx = await executeSetAddr(name, ensRegistrationRecords, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Edited ENS records', {
+        analyticsV2.track(event.ensEditedRecords, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.RECLAIM:
         tx = await executeReclaim(name, toAddress, ensRegistrationRecords, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Transferred ENS control', {
+        analyticsV2.track(event.ensTransferredControl, {
           category: 'profiles',
         });
         break;
       case ENSRegistrationTransactionType.SET_NAME:
         tx = await executeSetName(name, ownerAddress, gasLimit, maxFeePerGas, maxPriorityFeePerGas, wallet, nonce);
-        analytics.track('Set ENS to primary ', {
+        analyticsV2.track(event.ensSetPrimary, {
           category: 'profiles',
         });
     }
@@ -682,7 +683,7 @@ const executeAction = async (
     return { baseNonce: nonce, errorMessage: null };
   } catch (error: any) {
     logger.error(new RainbowError(`[raps/ens]: [${rapName}] Error executing action: ${action} ${error}`));
-    analytics.track('Rap failed', {
+    analyticsV2.track(event.ensRapFailed, {
       category: 'raps',
       failed_action: type,
       label: rapName,
@@ -711,7 +712,7 @@ export const executeENSRap = async (
   const { actions } = rap;
   const rapName = getRapFullName(actions);
 
-  analytics.track('Rap started', {
+  analyticsV2.track(event.ensRapStarted, {
     category: 'raps',
     label: rapName,
   });
@@ -736,7 +737,7 @@ export const executeENSRap = async (
     }
   }
 
-  analytics.track('Rap completed', {
+  analyticsV2.track(event.ensRapCompleted, {
     category: 'raps',
     label: rapName,
   });

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -2,7 +2,7 @@ import { Mutex } from 'async-mutex';
 import BigNumber from 'bignumber.js';
 import { isEmpty } from 'lodash';
 import { AppDispatch, AppGetState } from './store';
-import { analytics } from '@/analytics';
+import { analyticsV2 } from '@/analytics';
 import { logger, RainbowError } from '@/logger';
 import {
   BlocksToConfirmation,
@@ -41,6 +41,7 @@ import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks
 import { MeteorologyLegacyResponse, MeteorologyResponse } from '@/entities/gas';
 import { addBuffer } from '@/helpers/utilities';
 import { IS_TEST } from '@/env';
+import { event } from '@/analytics/event';
 
 const { CUSTOM, NORMAL, URGENT } = gasUtils;
 
@@ -492,7 +493,7 @@ export const gasUpdateGasFeeOption = (newGasPriceOption: string) => (dispatch: A
       payload: selectedGasFee,
       type: GAS_UPDATE_GAS_PRICE_OPTION,
     });
-    analytics.track('Updated Gas Price', { gasPriceOption: gasPriceOption });
+    analyticsV2.track(event.swapsGasUpdatedPrice, { gasPriceOption });
   });
 
 export const gasUpdateDefaultGasLimit =


### PR DESCRIPTION
## What changed (plus any additional context for devs)

This should remove the rest of the deprecated `analytics` to v2. I tried to keep things pretty aligned with the existing stuff, but for example the "category: 'profiles'" is somewhat redundant (but harmless).

I only tested a handful of the events, happy to test more thoroughly though if wanted.

## What to test

See the `events` diff.