### PR TITLE
Fix chart Y overflow caused by isFlatDetection

### DIFF
--- a/src/react-native-animated-charts/src/helpers/ChartContext.ts
+++ b/src/react-native-animated-charts/src/helpers/ChartContext.ts
@@ -44,8 +44,6 @@ export interface PathData {
 export interface PathScales {
   scaleX: (value: number) => number;
   scaleY: (value: number) => number;
-  isFlat: boolean;
-  isNearlyFlat: boolean;
 }
 
 type WithPathData = Pick<PathData, 'smallestX' | 'smallestY' | 'greatestX' | 'greatestY'>;


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Removes flat detection and just relies on padding in the fall through case. Because we were using a reduce to sum / average it was causing weird behavior.

## Screen recordings / screenshots

[Check here for before screenshots](https://rainbowhaus.slack.com/archives/C0468CDBE75/p1744045819806949?thread_ts=1744044398.701409&cid=C0468CDBE75)
<img width="568" alt="Screenshot 2025-04-07 at 1 55 15 PM" src="https://github.com/user-attachments/assets/81980078-88f4-406c-9484-533f731edc42" />
<img width="568" alt="Screenshot 2025-04-07 at 1 55 11 PM" src="https://github.com/user-attachments/assets/6aa1962f-5fe8-4e25-96b0-ce31a2070723" />


## What to test

