### PR TITLE
Set ENS airdrop address as invalid if ENS address resolution fails

### DIFF
--- a/src/screens/token-launcher/components/AirdropSection.tsx
+++ b/src/screens/token-launcher/components/AirdropSection.tsx
@@ -266,18 +266,18 @@ const AddressInput = memo(function AddressInput({ id }: { id: string }) {
             const imageUrl = avatar?.imageUrl ?? null;
 
             if (!ensAddress) {
-              setIsValidAddress(false);
               throw new Error('No address found for ENS name');
             }
 
             setAddressImage(imageUrl);
-
             addOrEditAirdropAddress({ id, address: ensAddress, label: text, isValid, imageUrl });
-          } catch (e: unknown) {
+          } catch (e) {
             const error = e as Error;
             logger.error(new RainbowError('[TokenLauncher]: Error fetching ENS data'), {
               message: error.message,
             });
+            setIsValidAddress(false);
+            addOrEditAirdropAddress({ id, address: text, isValid: false });
           } finally {
             setIsFetchingEnsData(false);
           }


### PR DESCRIPTION
Fixes APP-2543

## What changed (plus any additional context for devs)
- Logic did not account for setting the airdrop address as invalid in the store, only did so for the local component UI. Adds setting in the store as well.

## Screen recordings / screenshots


## What to test
- Should not be able to continue with invalid ens or if you somehow do they will not show up in the airdrop summary section
