### PR TITLE
Fix logic for "First time send" that we show in Send flow

### DIFF
--- a/src/entities/transactions/transaction.ts
+++ b/src/entities/transactions/transaction.ts
@@ -56,11 +56,19 @@ export enum TransactionStatus {
 export interface RainbowTransaction {
   address?: string;
   asset?:
-    | (ParsedAsset & {
-        asset_contract?: {
-          address?: string;
-        };
-      })
+    | (ParsedAsset &
+        (
+          | {
+              id: string;
+              asset_contract: never;
+            }
+          | {
+              id: never;
+              asset_contract: {
+                address?: string;
+              };
+            }
+        ))
     | null;
   balance?: {
     amount: string;

--- a/src/entities/transactions/transaction.ts
+++ b/src/entities/transactions/transaction.ts
@@ -59,14 +59,12 @@ export interface RainbowTransaction {
     | (ParsedAsset &
         (
           | {
-              id: string;
+              id?: string;
               asset_contract: never;
             }
           | {
-              id: never;
-              asset_contract: {
-                address?: string;
-              };
+              id?: string;
+              asset_contract?: UniqueAsset['asset_contract'];
             }
         ))
     | null;

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -551,7 +551,7 @@ export const getDataForTokenTransfer = (value: string, to: string): string => {
 export const getDataForNftTransfer = (
   from: string,
   to: string,
-  asset: Pick<UniqueAsset, 'id' | 'asset_contract' | 'chainId'>
+  asset: Partial<Pick<UniqueAsset, 'id' | 'asset_contract' | 'chainId'>>
 ): string | undefined => {
   if (!asset.id || !asset.asset_contract?.address) return;
   const lowercasedContractAddress = asset.asset_contract.address.toLowerCase();

--- a/src/hooks/useWatchPendingTxs.ts
+++ b/src/hooks/useWatchPendingTxs.ts
@@ -93,7 +93,7 @@ export const useWatchPendingTransactions = ({ address }: { address: string }) =>
       minedTransactions.forEach(tx => {
         if (tx.changes?.length) {
           tx.changes?.forEach(change => {
-            processStaleAsset({ asset: change?.asset, address, transactionHash: tx?.hash });
+            change?.asset && processStaleAsset({ asset: change.asset, address, transactionHash: tx?.hash });
           });
         } else if (tx.asset) {
           processStaleAsset({ address, asset: tx.asset, transactionHash: tx?.hash });

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -2894,6 +2894,7 @@
         "sending_title": "Sending",
         "you_own_this_wallet": "You own this wallet",
         "first_time_send": "First time send",
+        "previous_send": "%{number} previous send",
         "previous_sends": "%{number} previous sends"
       },
       "wallet_connect": {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -14,6 +14,8 @@ import { SharedValue } from 'react-native-reanimated';
 import { ChainId } from '@/state/backendNetworks/types';
 import { ExpandedSheetParamAsset } from '@/screens/expandedAssetSheet/context/ExpandedAssetSheetContext';
 import { TextProps } from '@/design-system';
+import { Checkbox } from '@/screens/SendConfirmationSheet';
+import { ENSProfile } from '@/entities/ens';
 
 export type PartialNavigatorConfigOptions = Pick<Partial<Parameters<ReturnType<typeof createStackNavigator>['Screen']>[0]>, 'options'>;
 
@@ -62,7 +64,22 @@ export type RootStackParamList = {
   };
   [Routes.SETTINGS_BACKUP_VIEW]: any;
   [Routes.SEND_CONFIRMATION_SHEET]: {
-    shouldShowChecks: boolean;
+    amountDetails: {
+      assetAmount: string;
+      isSufficientBalance: boolean;
+      nativeAmount: string;
+    };
+    asset: ParsedAddressAsset | UniqueAsset;
+    callback: (...args: unknown[]) => Promise<boolean>;
+    checkboxes: Checkbox[];
+    ensProfile: ENSProfile;
+    isENS: boolean;
+    isL2: boolean;
+    isNft: boolean;
+    chainId: ChainId;
+    profilesEnabled: boolean;
+    to: string;
+    toAddress: string;
   };
   [Routes.EXPLAIN_SHEET]: {
     type: string;

--- a/src/resources/addys/interactions.ts
+++ b/src/resources/addys/interactions.ts
@@ -1,0 +1,184 @@
+import { NativeCurrencyKey } from '@/entities';
+import { QueryConfigWithSelect, createQueryKey } from '@/react-query';
+import { useQuery, type QueryFunctionContext } from '@tanstack/react-query';
+import { logger, RainbowError } from '@/logger';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { getAddysHttpClient } from './client';
+import useAccountSettings from '@/hooks/useAccountSettings';
+import { Address } from 'viem';
+
+// ///////////////////////////////////////////////
+// Types
+
+interface InteractionTransaction {
+  id: string;
+  type: string;
+  chain_id: number;
+  network: string;
+  block_number: number;
+  mined_at: number;
+  status: string;
+  hash: string;
+  direction: string;
+  address_from: string;
+  address_to: string;
+  nonce: number;
+  changes: unknown[]; // Define more specific type if needed
+  fee: {
+    value: number;
+    price: number;
+  };
+  meta: {
+    action?: string;
+    contract_name?: string;
+    fourbyte?: string;
+    explorer_label?: string;
+    explorer_url?: string;
+    type?: string;
+  };
+}
+
+interface InteractionsResponseMetadataErrorDetail {
+  chain_id: number;
+  error: string;
+}
+
+interface InteractionsResponseMetadataError {
+  address: string;
+  errors: InteractionsResponseMetadataErrorDetail[];
+}
+
+interface InteractionsResponseMetadata {
+  addresses: string[];
+  currency: string;
+  chain_ids: number[];
+  current_page_cursor: string;
+  errors?: InteractionsResponseMetadataError[];
+  addresses_with_errors?: string[];
+  chain_ids_with_errors?: number[];
+  status: 'ok' | 'error';
+  interactions_with: string;
+}
+
+interface InteractionsResponsePayload {
+  transactions: InteractionTransaction[];
+}
+
+interface InteractionsResponse {
+  meta: InteractionsResponseMetadata;
+  payload: InteractionsResponsePayload;
+}
+
+export interface InteractionsCountArgs {
+  fromAddress?: string;
+  toAddress: string;
+  currency?: NativeCurrencyKey;
+  chainId?: number; // Optional chainId for specific count
+}
+
+// ///////////////////////////////////////////////
+// Query Key
+
+// Query key remains the same, fetching all transactions for the given addresses
+export function interactionsCountQueryKey({
+  fromAddress,
+  toAddress,
+  currency,
+}: Required<Omit<InteractionsCountArgs, 'chainId'> & { currency: NativeCurrencyKey }>) {
+  return createQueryKey(
+    'interactionsCount',
+    { fromAddress: fromAddress.toLowerCase(), toAddress: toAddress.toLowerCase(), currency },
+    { persisterVersion: 1 }
+  );
+}
+
+type InteractionsCountQueryKey = ReturnType<typeof interactionsCountQueryKey>;
+
+// ///////////////////////////////////////////////
+// Query Function
+
+// Function now returns the list of transactions
+export async function interactionsCountQueryFunction({
+  queryKey,
+}: QueryFunctionContext<InteractionsCountQueryKey>): Promise<InteractionTransaction[]> {
+  const [{ fromAddress, toAddress, currency }] = queryKey;
+  const supportedChainIds = useBackendNetworksStore.getState().getInteractionsWithSupportedChainIds();
+
+  if (!fromAddress || !toAddress || supportedChainIds.length === 0) {
+    logger.warn('[interactionsCountQueryFunction]: Missing address or supported chains, returning empty array.');
+    return []; // Return empty array if params missing
+  }
+
+  const url = `/${supportedChainIds.join(',')}/${fromAddress}/transactions`;
+
+  try {
+    const { data } = await getAddysHttpClient().get<InteractionsResponse>(url, {
+      params: {
+        currency: currency.toLowerCase(),
+        interactions_with: toAddress,
+      },
+      timeout: 20000,
+    });
+
+    if (data.meta.status !== 'ok' && data.meta.errors) {
+      logger.warn('[interactionsCountQueryFunction]: API returned errors for interactions count', {
+        apiErrors: data.meta.errors,
+        fromAddress,
+        toAddress,
+        chainIds: supportedChainIds,
+      });
+    }
+
+    // Return the full transaction list, or empty array if none
+    return data.payload?.transactions ?? [];
+  } catch (error) {
+    logger.error(new RainbowError('[interactionsCountQueryFunction]: Failed to fetch interactions count'), {
+      message: (error as Error)?.message,
+      fromAddress,
+      toAddress,
+      currency,
+      chainIds: supportedChainIds,
+    });
+    return []; // Return empty array on error
+  }
+}
+
+// Result type is now the array of transactions
+export type InteractionsCountResult = InteractionTransaction[];
+
+// Define the structure returned by the hook's select function
+export interface SelectedInteractionsCount {
+  totalCount: number;
+  specificChainCount: number | undefined;
+}
+
+// ///////////////////////////////////////////////
+// Query Hook
+
+export function useInteractionsCount(
+  { fromAddress: inputFromAddress, toAddress, currency: inputCurrency, chainId }: InteractionsCountArgs,
+  config: QueryConfigWithSelect<InteractionsCountResult, Error, SelectedInteractionsCount, InteractionsCountQueryKey> = {}
+) {
+  const { accountAddress, nativeCurrency } = useAccountSettings();
+  const resolvedFromAddress = (inputFromAddress || accountAddress)?.toLowerCase();
+  const resolvedCurrency = inputCurrency || nativeCurrency;
+
+  const queryKey = interactionsCountQueryKey({
+    fromAddress: resolvedFromAddress as Address,
+    toAddress,
+    currency: resolvedCurrency,
+  });
+
+  return useQuery(queryKey, interactionsCountQueryFunction, {
+    ...config,
+    enabled: !!toAddress && !!resolvedFromAddress && (config.enabled ?? true),
+    staleTime: 1000 * 60 * 5,
+    cacheTime: 1000 * 60 * 60,
+    // Select function processes the raw transaction list
+    select: (transactions: InteractionsCountResult): SelectedInteractionsCount => {
+      const totalCount = transactions.length;
+      const specificChainCount = chainId !== undefined ? transactions.filter(tx => tx.chain_id === chainId).length : undefined;
+      return { totalCount, specificChainCount };
+    },
+  });
+}

--- a/src/resources/addys/interactions.ts
+++ b/src/resources/addys/interactions.ts
@@ -82,12 +82,7 @@ export type InteractionsCountArgs = {
 // ///////////////////////////////////////////////
 // Query Key
 
-// Query key remains the same, fetching all transactions for the given addresses
-export function interactionsCountQueryKey({
-  fromAddress,
-  toAddress,
-  currency,
-}: Required<Omit<InteractionsCountArgs, 'chainId'> & { currency: NativeCurrencyKey }>) {
+export function interactionsCountQueryKey({ fromAddress, toAddress, currency }: Required<Omit<InteractionsCountArgs, 'chainId'>>) {
   return createQueryKey(
     'interactionsCount',
     { fromAddress: fromAddress.toLowerCase(), toAddress: toAddress.toLowerCase(), currency },
@@ -156,23 +151,22 @@ export interface SelectedInteractionsCount {
 // Query Hook
 
 export function useInteractionsCount(
-  { fromAddress: inputFromAddress, toAddress, currency: inputCurrency, chainId }: InteractionsCountArgs,
+  { fromAddress: inputFromAddress, toAddress, chainId }: Omit<InteractionsCountArgs, 'currency'>,
   config: QueryConfigWithSelect<InteractionsCountResult, Error, SelectedInteractionsCount, InteractionsCountQueryKey> = {}
 ) {
-  const { accountAddress, nativeCurrency } = useAccountSettings();
-  const resolvedFromAddress = (inputFromAddress || accountAddress)?.toLowerCase();
-  const resolvedCurrency = inputCurrency || nativeCurrency;
+  const { accountAddress, nativeCurrency: currency } = useAccountSettings();
+  const fromAddress = (inputFromAddress || accountAddress)?.toLowerCase() as Address;
 
   return useQuery(
     interactionsCountQueryKey({
-      fromAddress: resolvedFromAddress as Address,
+      fromAddress,
       toAddress,
-      currency: resolvedCurrency,
+      currency,
     }),
     interactionsCountQueryFunction,
     {
       ...config,
-      enabled: !!toAddress && !!resolvedFromAddress && (config.enabled ?? true),
+      enabled: !!toAddress && !!fromAddress && (config.enabled ?? true),
       staleTime: time.minutes(15),
       cacheTime: time.hours(1),
       select: data => ({

--- a/src/resources/metadata/sharedQueries.js
+++ b/src/resources/metadata/sharedQueries.js
@@ -80,6 +80,7 @@ const BACKEND_NETWORKS_QUERY = `
           transactions
           assets
           positions
+          interactionsWith
         }
         tokenSearch {
           enabled

--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -351,8 +351,8 @@ export const SendConfirmationSheet = () => {
     color = theme.colors.appleBlue;
   }
 
-  const shouldShowChecks =
-    isL2 && !isSendingToUserAccount && (typeof interactions?.specificChainCount === 'undefined' || interactions.specificChainCount < 3);
+  const lessThanThreeInteractions = typeof interactions?.specificChainCount === 'undefined' || interactions.specificChainCount < 3;
+  const shouldShowChecks = isL2 && !isSendingToUserAccount && lessThanThreeInteractions;
 
   useEffect(() => {
     setParams({ shouldShowChecks });

--- a/src/state/backendNetworks/backendNetworks.ts
+++ b/src/state/backendNetworks/backendNetworks.ts
@@ -55,6 +55,7 @@ export interface BackendNetworksState {
   getFlashbotsSupportedChainIds: () => ChainId[];
   getTokenLauncherSupportedChainIds: () => ChainId[];
   getTokenLauncherSupportedChainInfo: () => { chainId: ChainId; contractAddress: string }[];
+  getInteractionsWithSupportedChainIds: () => ChainId[];
   getShouldDefaultToFastGasChainIds: () => ChainId[];
 
   getChainGasUnits: (chainId?: ChainId) => BackendNetwork['gasUnits'];
@@ -333,6 +334,10 @@ export const useBackendNetworksStore = createQueryStore<BackendNetworksResponse,
             contractAddress: network.enabledServices.launcher?.v1?.contractAddress || '',
           };
         })
+    ),
+
+    getInteractionsWithSupportedChainIds: createSelector(networks =>
+      networks.networks.filter(network => network.enabledServices.addys.interactionsWith).map(network => toChainId(network.id))
     ),
 
     getFlashbotsSupportedChainIds: createSelector(() => [ChainId.mainnet]),

--- a/src/state/backendNetworks/types.ts
+++ b/src/state/backendNetworks/types.ts
@@ -155,6 +155,7 @@ export interface BackendNetworkServices {
     transactions: boolean;
     assets: boolean;
     positions: boolean;
+    interactionsWith: boolean;
   };
   tokenSearch: {
     enabled: boolean;


### PR DESCRIPTION
Fixes APP-1299

## What changed (plus any additional context for devs)
Implements the addys endpoint to receive interactions between two wallets. This can be used in other places, but right now is only used in our send confirmation sheet to let the user know if they've sent to that address before or not. It also is used to show the checks for layer 2 networks if necessary.

## Screen recordings / screenshots
https://github.com/user-attachments/assets/e9d30adb-4d57-42be-b007-75d03d4b1532

## What to test
sends on different networks with different account types
should probably test nft sends / ens sends since I strengthened some types there and might've tweaked something wrong
