### PR TITLE
Make RainbowError second arg be cause, add error cause to wallet init error capture

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -195,6 +195,9 @@ export const event = {
   // network status
   networkStatusOffline: 'network_status.offline',
   networkStatusReconnected: 'network_status.reconnected',
+
+  // wallet initialization
+  walletInitializationFailed: 'wallet_initialization.failed',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -812,4 +815,10 @@ export type EventProperties = {
   // network status
   [event.networkStatusOffline]: undefined;
   [event.networkStatusReconnected]: undefined;
+
+  // wallet initialization
+  [event.walletInitializationFailed]: {
+    error: string;
+    walletStatus: string;
+  };
 };

--- a/src/hooks/useInitializeWallet.ts
+++ b/src/hooks/useInitializeWallet.ts
@@ -1,5 +1,4 @@
-import { captureException } from '@sentry/react-native';
-import lang from 'i18n-js';
+import * as i18n from '@/languages';
 import { isNil } from 'lodash';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -17,11 +16,12 @@ import useLoadGlobalEarlyData from './useLoadGlobalEarlyData';
 import useOpenSmallBalances from './useOpenSmallBalances';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { runKeychainIntegrityChecks } from '@/handlers/walletReadyEvents';
-import { RainbowError, logger } from '@/logger';
+import { RainbowError, ensureError, logger } from '@/logger';
 import { getOrCreateDeviceId, getWalletContext } from '@/analytics/utils';
 import * as Sentry from '@sentry/react-native';
 import { analyticsV2 } from '@/analytics';
 import { Address } from 'viem';
+import { event } from '@/analytics/event';
 
 export default function useInitializeWallet() {
   const dispatch = useDispatch();
@@ -32,7 +32,9 @@ export default function useInitializeWallet() {
   const hideSplashScreen = useHideSplashScreen();
   const { setIsSmallBalancesOpen } = useOpenSmallBalances();
 
-  const getWalletStatusForPerformanceMetrics = (isNew: boolean, isImporting: boolean): string => {
+  type WalletStatus = 'unknown' | 'new' | 'imported' | 'old';
+
+  function getWalletStatus(isNew: boolean, isImporting: boolean): WalletStatus {
     if (isNew) {
       return 'new';
     } else if (isImporting) {
@@ -40,7 +42,7 @@ export default function useInitializeWallet() {
     } else {
       return 'old';
     }
-  };
+  }
 
   const initializeWallet = useCallback(
     async (
@@ -57,6 +59,7 @@ export default function useInitializeWallet() {
       image,
       silent = false
     ) => {
+      let walletStatus: WalletStatus = 'unknown';
       try {
         PerformanceTracking.startMeasuring(PerformanceMetrics.useInitializeWallet);
         logger.debug('[useInitializeWallet]: Start wallet setup');
@@ -78,6 +81,7 @@ export default function useInitializeWallet() {
         await dispatch(settingsLoadNetwork());
 
         const { isNew, walletAddress } = await walletInit(seedPhrase, color, name, overwrite, checkedWallet, network, image, silent);
+        walletStatus = getWalletStatus(isNew, isImporting);
 
         logger.debug('[useInitializeWallet]: walletInit returned', {
           isNew,
@@ -113,7 +117,7 @@ export default function useInitializeWallet() {
 
         if (isNil(walletAddress)) {
           logger.debug('[useInitializeWallet]: walletAddress is nil');
-          Alert.alert(lang.t('wallet.import_failed_invalid_private_key'));
+          Alert.alert(i18n.t(i18n.l.wallet.import_failed_invalid_private_key));
           if (!isImporting) {
             dispatch(appStateUpdate({ walletReady: true }));
           }
@@ -150,14 +154,19 @@ export default function useInitializeWallet() {
         logger.debug('[useInitializeWallet]: 💰 Wallet initialized');
 
         PerformanceTracking.finishMeasuring(PerformanceMetrics.useInitializeWallet, {
-          walletStatus: getWalletStatusForPerformanceMetrics(isNew, isImporting),
+          walletStatus,
         });
 
         return walletAddress;
-      } catch (error) {
+      } catch (e) {
+        const error = ensureError(e);
         PerformanceTracking.clearMeasure(PerformanceMetrics.useInitializeWallet);
-        logger.error(new RainbowError('[useInitializeWallet]: Error while initializing wallet'), {
-          error,
+        logger.error(new RainbowError('[useInitializeWallet]: Error while initializing wallet', error), {
+          walletStatus,
+        });
+        analyticsV2.track(event.walletInitializationFailed, {
+          error: error.message,
+          walletStatus,
         });
         // TODO specify error states more granular
         if (!switching) {
@@ -172,8 +181,7 @@ export default function useInitializeWallet() {
           });
         }
 
-        captureException(error);
-        Alert.alert(lang.t('wallet.something_went_wrong_importing'));
+        Alert.alert(i18n.t(i18n.l.wallet.something_went_wrong_importing));
         dispatch(appStateUpdate({ walletReady: true }));
         return null;
       }

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -175,8 +175,21 @@ export const sentryTransport: Transport = (level: LogLevel, message, { type, tag
     });
   }
 };
+export class RainbowError extends Error {
+  constructor(message: string, cause?: Error | unknown, options: ErrorOptions = {}) {
+    if (cause !== undefined) {
+      // eslint-disable-next-line no-param-reassign
+      options = { ...options, cause };
+    }
+    super(message, options);
+    this.name = this.constructor.name;
+  }
+}
 
-export class RainbowError extends Error {}
+export function ensureError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
+}
 
 /**
  * Main class. Defaults are provided in the constructor so that subclasses are

--- a/src/react-query/reactQueryUtils.ts
+++ b/src/react-query/reactQueryUtils.ts
@@ -126,22 +126,14 @@ export async function clearReactQueryCache({
     }
   } catch (error) {
     if (preserveFavorites) {
-      logger.error(
-        new RainbowError('First attempt to clear React Query cache failed (preserveFavorites = true):', {
-          cause: error,
-        })
-      );
+      logger.error(new RainbowError('First attempt to clear React Query cache failed (preserveFavorites = true):', error));
       try {
         clearReactQueryCache({ preserveFavorites: false });
       } catch (retryError) {
-        logger.error(
-          new RainbowError('Second attempt to clear React Query cache failed (preserveFavorites = false):', {
-            cause: retryError,
-          })
-        );
+        logger.error(new RainbowError('Second attempt to clear React Query cache failed (preserveFavorites = false):', retryError));
       }
     } else {
-      logger.error(new RainbowError('Failed to clear React Query cache:', { cause: error }));
+      logger.error(new RainbowError('Failed to clear React Query cache:', error));
     }
   }
 }
@@ -162,11 +154,7 @@ export async function forceRehydrateQueryClient(): Promise<void> {
       devLog('❌ [forceRehydrateQueryClient] No persisted state found for rehydration');
     }
   } catch (error) {
-    logger.error(
-      new RainbowError('[forceRehydrateQueryClient] Error during forced React Query rehydration:', {
-        cause: error,
-      })
-    );
+    logger.error(new RainbowError('[forceRehydrateQueryClient] Error during forced React Query rehydration:', error));
   }
 }
 

--- a/src/resources/favorites.ts
+++ b/src/resources/favorites.ts
@@ -132,7 +132,7 @@ async function getFavorites() {
 
     return newFavorites;
   } catch (error) {
-    logger.error(new RainbowError('Failed to refresh favorites:', { cause: error }));
+    logger.error(new RainbowError('Failed to refresh favorites:', error));
     return favorites;
   }
 }

--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -739,9 +739,10 @@ export function createQueryStore<
             try {
               transformedData = transform ? transform(rawResult, effectiveParams) : (rawResult as TData);
             } catch (transformError) {
-              throw new RainbowError(`[createQueryStore: ${persistConfig?.storageKey || currentQueryKey}]: transform failed`, {
-                cause: transformError,
-              });
+              throw new RainbowError(
+                `[createQueryStore: ${persistConfig?.storageKey || currentQueryKey}]: transform failed`,
+                transformError
+              );
             }
 
             if (skipStoreUpdates) {
@@ -825,9 +826,10 @@ export function createQueryStore<
                 onFetched({ data: transformedData, fetch: baseMethods.fetch, params: effectiveParams, set });
               } catch (onFetchedError) {
                 logger.error(
-                  new RainbowError(`[createQueryStore: ${persistConfig?.storageKey || currentQueryKey}]: onFetched callback failed`, {
-                    cause: onFetchedError,
-                  })
+                  new RainbowError(
+                    `[createQueryStore: ${persistConfig?.storageKey || currentQueryKey}]: onFetched callback failed`,
+                    onFetchedError
+                  )
                 );
               }
             }


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Changed the `RainbowError` constructor to be slightly different than the normal Error constructor. This is because in almost all cases where RainbowError is used, there is an original error that should be captured as the cause, and `ErrorOptions` has not other options other than the `cause`. Saves us from having to write `{ cause: error }` every time it's used. 
```js
export class RainbowError extends Error {
  constructor(message: string, cause?: Error | unknown, options: ErrorOptions = {}) {
    if (cause !== undefined) {
      options = { ...options, cause };
    }
    super(message, options);
    this.name = this.constructor.name;
  }
}
```

There were only a couple places the `cause` was actually used when creating a `RainbowError`, and those were changed to match the new constructor. 

There are way too many places where a `RainbowError` is created that should have the `cause` added to do in a PR, so we should just be mindful to use it going forward and to add them to old ones as we see them. 

Other
- Changed wallet init `catch` block to use error cause and log error analytic
- Added `ensureError` helper for converting error type `unknown` to `error`

## Screen recordings / screenshots
We now get the full stack trace in Sentry when an error throws in the wallet initialization

<img width="1259" alt="Screenshot 2025-04-09 at 8 43 32 AM" src="https://github.com/user-attachments/assets/06f5de7a-a665-4795-b731-1d3426aff8de" />

