### PR TITLE
Fix broken unpinning for some tokens auto-pinned from token launcher

### DIFF
--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -46,15 +46,6 @@ export const buildCoinsList = (
     smallAssets: any = [],
     hiddenAssets: any = [];
 
-  // Assets uniqueIds here are always lowercased, but not all pinned uniqueIds are
-  const pinnedCoinsLowercase = Object.keys(pinnedCoins || {}).reduce(
-    (acc, key) => {
-      acc[key.toLowerCase()] = pinnedCoins[key];
-      return acc;
-    },
-    {} as Record<string, boolean>
-  );
-
   // separate into standard, pinned, small balances, hidden assets
   sortedAssets?.forEach((asset: any) => {
     if (hiddenCoins.has(asset.uniqueId)) {
@@ -64,7 +55,7 @@ export const buildCoinsList = (
         isSmall: true,
         ...asset,
       });
-    } else if (pinnedCoinsLowercase[asset.uniqueId.toLowerCase()]) {
+    } else if (pinnedCoins[asset.uniqueId]) {
       pinnedAssets.push({
         isCoin: true,
         isPinned: true,

--- a/src/hooks/useCoinListEditOptions.ts
+++ b/src/hooks/useCoinListEditOptions.ts
@@ -29,8 +29,19 @@ export default function useCoinListEditOptions() {
       setPinnedCoinsObject((prev: BooleanMap | undefined) => {
         return {
           ...(prev ?? {}),
-          [uniqueId]: true,
+          [uniqueId.toLowerCase()]: true,
         };
+      });
+    },
+    [setPinnedCoinsObject]
+  );
+
+  const removePinnedCoin = useCallback(
+    (uniqueId: string) => {
+      setPinnedCoinsObject((prev: BooleanMap | undefined) => {
+        const newPinnedCoins = { ...(prev ?? {}) };
+        delete newPinnedCoins[uniqueId.toLowerCase()];
+        return newPinnedCoins;
       });
     },
     [setPinnedCoinsObject]
@@ -62,6 +73,7 @@ export default function useCoinListEditOptions() {
 
   return {
     addPinnedCoin,
+    removePinnedCoin,
     clearSelectedCoins,
     pinnedCoinsObj: pinnedCoins,
     pushSelectedCoin,

--- a/src/screens/expandedAssetSheet/components/AssetContextMenu.tsx
+++ b/src/screens/expandedAssetSheet/components/AssetContextMenu.tsx
@@ -32,10 +32,10 @@ type ContextMenuAction = (typeof ContextMenuActions)[keyof typeof ContextMenuAct
 export function AssetContextMenu() {
   const { accentColors, basicAsset: asset, assetMetadata } = useExpandedAssetSheetContext();
 
-  const { clearSelectedCoins, pushSelectedCoin } = useCoinListEditOptions();
+  const { clearSelectedCoins, pushSelectedCoin, removePinnedCoin, addPinnedCoin } = useCoinListEditOptions();
   const setHiddenAssets = useUserAssetsStore(state => state.setHiddenAssets);
 
-  const { currentAction, setPinnedCoins } = useCoinListFinishEditingOptions();
+  const { currentAction } = useCoinListFinishEditingOptions();
   const chainLabels = useBackendNetworksStore(state => state.getChainsLabel());
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export function AssetContextMenu() {
     if (asset.address && !asset.isNativeAsset) {
       menuItems.push({
         actionKey: ContextMenuActions.BlockExplorer,
-        actionTitle: i18n.t('expanded_state.asset.menu.view_on', {
+        actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.view_on, {
           blockExplorerName: ethereumUtils.getBlockExplorer({ chainId: asset.chainId }),
         }),
         icon: {
@@ -66,7 +66,7 @@ export function AssetContextMenu() {
     if (asset.address && !asset.isNativeAsset) {
       menuItems.push({
         actionKey: ContextMenuActions.Copy,
-        actionTitle: i18n.t('expanded_state.asset.menu.copy_contract_address'),
+        actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.copy_contract_address),
         actionSubtitle: asset.address.slice(0, 6) + '...' + asset.address.slice(-4),
         icon: {
           iconType: 'SYSTEM',
@@ -77,7 +77,7 @@ export function AssetContextMenu() {
 
     menuItems.push({
       actionKey: ContextMenuActions.Share,
-      actionTitle: i18n.t('expanded_state.asset.menu.share'),
+      actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.share),
       icon: {
         iconType: 'SYSTEM',
         iconValue: 'square.and.arrow.up',
@@ -87,7 +87,7 @@ export function AssetContextMenu() {
     if (currentAction === EditAction.unhide) {
       menuItems.push({
         actionKey: ContextMenuActions.Unhide,
-        actionTitle: i18n.t('expanded_state.asset.menu.unhide'),
+        actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.unhide),
         icon: {
           iconType: 'SYSTEM',
           iconValue: 'eye.slash',
@@ -96,7 +96,7 @@ export function AssetContextMenu() {
     } else {
       menuItems.push({
         actionKey: ContextMenuActions.Hide,
-        actionTitle: i18n.t('expanded_state.asset.menu.hide'),
+        actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.hide),
         icon: {
           iconType: 'SYSTEM',
           iconValue: 'eye.slash',
@@ -107,7 +107,7 @@ export function AssetContextMenu() {
     if (currentAction === EditAction.unpin) {
       menuItems.push({
         actionKey: ContextMenuActions.Unpin,
-        actionTitle: i18n.t('expanded_state.asset.menu.unpin'),
+        actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.unpin),
         icon: {
           iconType: 'SYSTEM',
           iconValue: 'pin',
@@ -116,7 +116,7 @@ export function AssetContextMenu() {
     } else {
       menuItems.push({
         actionKey: ContextMenuActions.Pin,
-        actionTitle: i18n.t('expanded_state.asset.menu.pin'),
+        actionTitle: i18n.t(i18n.l.expanded_state.asset.menu.pin),
         icon: {
           iconType: 'SYSTEM',
           iconValue: 'pin',
@@ -156,10 +156,10 @@ export function AssetContextMenu() {
         ethereumUtils.openTokenEtherscanURL({ address: asset.address, chainId: asset.chainId });
         break;
       case ContextMenuActions.Pin:
-        setPinnedCoins();
+        addPinnedCoin(asset.uniqueId);
         break;
       case ContextMenuActions.Unpin:
-        setPinnedCoins();
+        removePinnedCoin(asset.uniqueId);
         break;
       case ContextMenuActions.Hide:
         setHiddenAssets([asset.uniqueId]);

--- a/src/screens/token-launcher/context/TokenLauncherContext.tsx
+++ b/src/screens/token-launcher/context/TokenLauncherContext.tsx
@@ -67,7 +67,7 @@ export function TokenLauncherContextProvider({ children }: { children: React.Rea
     // As soon as token is created, pin it
     if (launchedTokenAddress) {
       const launchedTokenUniqueId = getUniqueId(launchedTokenAddress, chainId);
-      addPinnedCoin(launchedTokenUniqueId.toLowerCase());
+      addPinnedCoin(launchedTokenUniqueId);
     }
   }, [launchedTokenAddress, chainId, addPinnedCoin]);
 


### PR DESCRIPTION
Fixes APP-2545

## What changed (plus any additional context for devs)
In the initial release of token launcher, the tokens were getting auto-pinned with cased uniqueIds which prevented them from appearing in the pinned section of the wallet list. To fix this for previously created tokens, I made the pinned tokens section explicitly lowercase the uniqueIds. The issue is that this prevents those tokens from being unpinned, as their real uniqueId in the pinned coins object was still cased for the tokens created before the fix. 

This fix has the consequence of losing the auto pin for those tokens created before the fix and those cased uniqueIds will be "stuck" in the pinned coins object unless we run a migration to remove them / fix their casing. Given the small number of users effected and the small number of tokens per user I don't think a migration is necessary. 

Changes 
- Add explicit `removePinnedToken` function
- Lowercase uniqueIds passed to `addPinnedToken` and `removePinnedToken` so this is not possible again
- Do not force lowercase when checking pinned token uniqueIds in building wallet list so old incorrectly cased tokens do not appear 
- Use typed translations in `AssetContextMenu`

## What to test
- Pin and unpin a token
- If you had one of these previously created tokens that couldn't be unpinned, it should no longer be showing in the pinned section unless you explicitly pinned it, and you should not be able to unpin it. 
