### PR TITLE
fix: properly append referrer fingerprint during speed up

### DIFF
--- a/src/raps/actions/swap.ts
+++ b/src/raps/actions/swap.ts
@@ -398,7 +398,7 @@ export const swap = async ({
 
   const transaction = {
     chainId: parameters.chainId,
-    data: parameters.quote.data,
+    data: swap.data,
     from: parameters.quote.from,
     to: getTargetAddress(parameters.quote) as Address,
     value: parameters.quote.value?.toString(),
@@ -431,11 +431,9 @@ export const swap = async ({
       type: SwapType.normal,
       fromChainId: parameters.assetToSell.chainId,
       toChainId: parameters.assetToBuy.chainId,
-
-      // TODO: Is this right?
       isBridge:
         parameters.assetToBuy.chainId !== parameters.assetToSell.chainId &&
-        parameters.assetToSell.address === parameters.assetToBuy.address,
+        parameters.assetToSell.mainnetAddress === parameters.assetToBuy.mainnetAddress,
     },
     ...gasParamsToUse,
   } satisfies NewTransaction;


### PR DESCRIPTION
Fixes APP-2549

## What changed (plus any additional context for devs)
We needed to store `swap.data` rather than the quote data to include the referrer fingerprint when attempting to execute the transaction again in the speed up flow.

Also saw a question in our comments and made a small fix.

## Screen recordings / screenshots
https://etherscan.io/tx/0xb050e4b36f8c23f7f831a96f0f24d35528522630775f83c25c0f0ad2a8907e18
![Screenshot 2025-04-10 at 12 02 45 PM](https://github.com/user-attachments/assets/db88d4ec-2372-4613-80fa-50b9019baa02)

## What to test
Attempt a slow transaction, proceed through the speed up flow, check Input Data on the explorer afterwards.

`keccak256(toUtf8Bytes('native-app')).substring(2, 10) === 'd7e44d53'`
