### PR TITLE
fix analytics missing conversions

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import { PerformanceMetrics } from './src/performance/tracking/types/Performance
 
 initSentry();
 
-analytics.track('Started executing JavaScript bundle');
+analytics.track(analytics.event.startedExecutingJavaScriptBundle);
 PerformanceTracking.logDirectly(PerformanceMetrics.loadJSBundle, performance.now() - StartTime.START_TIME);
 PerformanceTracking.startMeasuring(PerformanceMetrics.loadRootAppComponent);
 PerformanceTracking.startMeasuring(PerformanceMetrics.timeToInteractive);

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1,22 +1,63 @@
 import { AddressOrEth, ExtendedAnimatedAssetWithColors, ParsedSearchAsset, UniqueId } from '@/__swaps__/types/assets';
-import { ChainId, Network } from '@/state/backendNetworks/types';
 import { SwapAssetType } from '@/__swaps__/types/swap';
 import { UnlockableAppIconKey } from '@/appIcons/appIcons';
 import { CardType } from '@/components/cards/GenericCard';
 import { LearnCategory } from '@/components/cards/utils/types';
 import { FiatProviderName } from '@/entities/f2c';
+import { TrendingToken } from '@/resources/trendingTokens/trendingTokens';
+import { TokenLauncherAnalyticsParams } from '@/screens/token-launcher/state/tokenLauncherStore';
+import { ChainId, Network } from '@/state/backendNetworks/types';
+import { FavoritedSite } from '@/state/browser/favoriteDappsStore';
 import { RequestSource } from '@/utils/requestNavigationHandlers';
 import { CrosschainQuote, Quote, QuoteError } from '@rainbow-me/swaps';
 import { AnyPerformanceLog, Screen } from '../state/performance/operations';
-import { FavoritedSite } from '@/state/browser/favoriteDappsStore';
-import { TrendingToken } from '@/resources/trendingTokens/trendingTokens';
-import { TokenLauncherAnalyticsParams } from '@/screens/token-launcher/state/tokenLauncherStore';
-import { ENSRegistrationTransactionType } from '../helpers/ens';
 
 /**
  * All events, used by `analytics.track()`
  */
 export const event = {
+  excludedFromFeaturePromo: 'Excluded from Feature Promo',
+  manuallyDisconnectedFromWalletConnectConnection: 'Manually disconnected from WalletConnect connection',
+  receivedWcConnection: 'Received wc connection',
+  resetAssetSelectionSend: 'Reset Asset Selection Send',
+  searchQuery: 'Search Query',
+  showSecretView: 'Show Secret View',
+  shownWalletconnectSessionRequest: 'Shown Walletconnect session request',
+  tappedAddExistingWallet: 'Tapped Add Existing Wallet',
+  tappedCreateNewWallet: 'Tapped Create New Wallet',
+  tappedDeleteWallet: 'Tapped Delete Wallet',
+  tappedEdit: 'Tapped Edit',
+  tappedWatchAddress: 'Tapped Watch Address',
+  toggledAnNFTAsHidden: 'Toggled an NFT as Hidden',
+  viewedEnsProfile: 'Viewed ENS profile',
+  viewedFeaturePromo: 'Viewed Feature Promo',
+  viewedProfile: 'Viewed profile',
+  applicationBecameInteractive: 'Application became interactive',
+  changedLanguage: 'Changed language',
+  changedNativeCurrency: 'Changed native currency',
+  changedNetwork: 'Changed network',
+  changedNativeCurrencyInputSend: 'Changed native currency input in Send flow',
+  changedTokenInputSend: 'Changed token input in Send flow',
+  sentTransaction: 'Sent transaction',
+  setAppIcon: 'Set App Icon',
+  tappedDoneEditingWallet: 'Tapped "Done" after editing wallet',
+  tappedCancelEditingWallet: 'Tapped "Cancel" after editing wallet',
+  tappedEditWallet: 'Tapped "Edit Wallet"',
+  tappedNotificationSettings: 'Tapped "Notification Settings"',
+  tappedDeleteWalletConfirm: 'Tapped "Delete Wallet" (final confirm)',
+  errorUpdatingBackupStatus: 'Error updating Backup status',
+  errorDuringICloudBackup: `Error during iCloud Backup`,
+  errorDuringGoogleDriveBackup: `Error during Google Drive Backup`,
+  ignoreHowToEnableICloud: 'Ignore how to enable iCloud',
+  viewHowToEnableICloud: 'View how to Enable iCloud',
+  iCloudNotEnabled: 'iCloud not enabled',
+  importedSeedPhrase: 'Imported seed phrase',
+  showWalletProfileModalForImportedWallet: 'Show wallet profile modal for imported wallet',
+  showWalletProfileModalForReadOnlyWallet: 'Show wallet profile modal for read only wallet',
+  showWalletProfileModalForUnstoppableAddress: 'Show wallet profile modal for Unstoppable address',
+  showWalletProfileModalForENSAddress: 'Show wallet profile modal for ENS address',
+  tappedImportButton: 'Tapped "Import" button',
+  startedExecutingJavaScriptBundle: 'Started executing JavaScript bundle',
   firstAppOpen: 'First App Open',
   applicationDidMount: 'React component tree finished initial mounting',
   pressedButton: 'Pressed Button',
@@ -238,6 +279,13 @@ export const event = {
   // Wallet Profile Modal Events
   walletProfileCancelled: 'Tapped "Cancel" on Wallet Profile modal',
   walletProfileSubmitted: 'Tapped "Submit" on Wallet Profile modal',
+
+  // welcome screen
+  welcomeNewWallet: 'Tapped "Get a new wallet"',
+  welcomeAlreadyHave: 'Tapped "I already have one"',
+
+  // discover screen
+  discoverTapSearch: 'Tapped Search',
 } as const;
 
 export type QuickBuyAnalyticalData =
@@ -621,7 +669,6 @@ export type EventProperties = {
     appIcon: UnlockableAppIconKey;
   };
   [event.txRequestShownSheet]: {
-    requestType: 'transaction' | 'signature';
     source: RequestSource;
   };
   [event.txRequestApprove]: {
@@ -880,7 +927,7 @@ export type EventProperties = {
   [event.ensExtended]: { category: string };
   [event.ensTransferredControl]: { category: string };
   [event.ensSetPrimary]: { category: string };
-  [event.ensRapFailed]: { category: string; failed_action: ENSRegistrationTransactionType; label: string };
+  [event.ensRapFailed]: { category: string; failed_action: string; label: string };
   [event.ensRapStarted]: { category: string; label: string };
   [event.ensRapCompleted]: { category: string; label: string };
 
@@ -901,4 +948,111 @@ export type EventProperties = {
   [event.navigationSwap]: { category: string };
   [event.navigationSend]: { category: string };
   [event.navigationMyQrCode]: { category: string };
+
+  [event.walletProfileCancelled]: undefined;
+  [event.walletProfileSubmitted]: undefined;
+
+  [event.welcomeNewWallet]: undefined;
+  [event.welcomeAlreadyHave]: undefined;
+
+  [event.discoverTapSearch]: {
+    category: string;
+  };
+
+  [event.applicationBecameInteractive]: undefined;
+  [event.changedLanguage]: { language: string };
+  [event.changedNativeCurrency]: { currency: string };
+  [event.changedNetwork]: { chainId: number };
+  [event.excludedFromFeaturePromo]: { campaign: string; exclusion: string; type: string };
+  [event.manuallyDisconnectedFromWalletConnectConnection]: { dappName: string; dappUrl: string };
+  [event.receivedWcConnection]: { dappName: string; dappUrl: string; waitingTime?: string | number };
+  [event.resetAssetSelectionSend]: undefined;
+  [event.searchQuery]: { category: string; length: number; query: string };
+  [event.showSecretView]: { category: string };
+  [event.shownWalletconnectSessionRequest]: undefined;
+  [event.tappedAddExistingWallet]: undefined;
+  [event.tappedCreateNewWallet]: undefined;
+  [event.tappedDeleteWallet]: undefined;
+  [event.tappedEdit]: undefined;
+  [event.tappedWatchAddress]: undefined;
+  [event.toggledAnNFTAsHidden]: {
+    isHidden: boolean;
+    collectionContractAddress?: string | null;
+    collectionName?: string;
+  };
+  [event.viewedEnsProfile]: {
+    category: string;
+    ens: string;
+    from: string;
+    address?: string;
+  };
+  [event.viewedFeaturePromo]: { campaign: string };
+  [event.viewedProfile]: {
+    category: string;
+    fromRoute: string;
+    name: string;
+  };
+  [event.showWalletProfileModalForENSAddress]: {
+    address: string;
+    input: string;
+  };
+  [event.showWalletProfileModalForUnstoppableAddress]: {
+    address: string;
+    input: string;
+  };
+  [event.showWalletProfileModalForReadOnlyWallet]: {
+    ens: string;
+    input: string;
+  };
+  [event.showWalletProfileModalForImportedWallet]: {
+    address: string;
+    type: string;
+  };
+  [event.importedSeedPhrase]: {
+    isWalletEthZero: boolean;
+  };
+  [event.iCloudNotEnabled]: {
+    category: string;
+  };
+  [event.viewHowToEnableICloud]: {
+    category: string;
+  };
+  [event.ignoreHowToEnableICloud]: {
+    category: string;
+  };
+  [event.errorDuringICloudBackup]: {
+    category: string;
+    error: string;
+    label: string;
+  };
+  [event.errorDuringGoogleDriveBackup]: {
+    category: string;
+    error: string;
+    label: string;
+  };
+  [event.errorUpdatingBackupStatus]: {
+    category: string;
+    label: string;
+  };
+  [event.changedNativeCurrencyInputSend]: undefined;
+  [event.changedTokenInputSend]: undefined;
+  [event.sentTransaction]: {
+    assetName: string;
+    network: string;
+    isRecepientENS: boolean;
+    isHardwareWallet: boolean;
+  };
+  [event.tappedDoneEditingWallet]: {
+    wallet_label: string;
+  };
+  [event.tappedCancelEditingWallet]: undefined;
+  [event.tappedEditWallet]: undefined;
+  [event.tappedNotificationSettings]: undefined;
+  [event.tappedDeleteWalletConfirm]: undefined;
+  [event.tappedEdit]: undefined;
+  [event.tappedDeleteWallet]: undefined;
+  [event.setAppIcon]: {
+    appIcon: string;
+  };
+  [event.tappedImportButton]: undefined;
 };

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -10,6 +10,7 @@ import { ChainId, Network } from '@/state/backendNetworks/types';
 import { FavoritedSite } from '@/state/browser/favoriteDappsStore';
 import { RequestSource } from '@/utils/requestNavigationHandlers';
 import { CrosschainQuote, Quote, QuoteError } from '@rainbow-me/swaps';
+import { ENSRapActionType } from '../raps/common';
 import { AnyPerformanceLog, Screen } from '../state/performance/operations';
 
 /**
@@ -927,7 +928,7 @@ export type EventProperties = {
   [event.ensExtended]: { category: string };
   [event.ensTransferredControl]: { category: string };
   [event.ensSetPrimary]: { category: string };
-  [event.ensRapFailed]: { category: string; failed_action: string; label: string };
+  [event.ensRapFailed]: { category: string; failed_action: ENSRapActionType; label: string };
   [event.ensRapStarted]: { category: string; label: string };
   [event.ensRapCompleted]: { category: string; label: string };
 

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -8,6 +8,7 @@ import { logger, RainbowError } from '@/logger';
 import { device } from '@/storage';
 import { WalletContext } from './utils';
 import { IS_ANDROID, IS_TEST } from '@/env';
+import { PerformanceMetricsType } from '../performance/tracking/types/PerformanceMetrics';
 
 export class Analytics {
   client: typeof rudderClient;
@@ -62,6 +63,15 @@ export class Analytics {
     if (this.disabled) return;
     const metadata = this.getDefaultMetadata();
     this.client.screen(routeName, { ...metadata, ...walletContext, ...params });
+  }
+
+  /**
+   * Carve out for performance events to support the existing usage.
+   */
+  trackPerformance(event: PerformanceMetricsType, params: Record<string, string | number>) {
+    if (this.disabled) return;
+    const metadata = this.getDefaultMetadata();
+    this.client.track(event, { ...metadata, ...params });
   }
 
   /**

--- a/src/components/Discover/DiscoverScreenContext.tsx
+++ b/src/components/Discover/DiscoverScreenContext.tsx
@@ -47,7 +47,7 @@ const DiscoverScreenProvider = ({ children }: { children: React.ReactNode }) => 
       searchInputRef.current?.focus();
     } else {
       useDiscoverSearchQueryStore.setState({ isSearching: true });
-      analytics.track('Tapped Search', {
+      analytics.track(analytics.event.discoverTapSearch, {
         category: 'discover',
       });
     }

--- a/src/components/Discover/DiscoverSearch.tsx
+++ b/src/components/Discover/DiscoverSearch.tsx
@@ -169,7 +169,7 @@ export default function DiscoverSearch() {
             fromRoute: 'DiscoverSearch',
           });
           if (profilesEnabled) {
-            analytics.track('Viewed ENS profile', {
+            analytics.track(analytics.event.viewedEnsProfile, {
               category: 'profiles',
               ens: item.nickname,
               from: 'Discover search',

--- a/src/components/Discover/DiscoverSearchInput.tsx
+++ b/src/components/Discover/DiscoverSearchInput.tsx
@@ -136,7 +136,7 @@ const DiscoverSearchInput = ({
   const { searchInputRef } = useDiscoverScreenContext();
   const handleClearInput = useCallback(() => {
     if (isDiscover && searchQuery.length > 1) {
-      analytics.track('Search Query', {
+      analytics.track(analytics.event.searchQuery, {
         category: 'discover',
         length: searchQuery.length,
         query: searchQuery,

--- a/src/components/remote-promo-sheet/localCampaignChecks.ts
+++ b/src/components/remote-promo-sheet/localCampaignChecks.ts
@@ -36,13 +36,13 @@ export const runLocalCampaignChecks = async (): Promise<boolean> => {
     InteractionManager.runAfterInteractions(async () => {
       const response = await campaign.check();
       if (response === GenericCampaignCheckResponse.activated) {
-        analytics.track('Viewed Feature Promo', {
+        analytics.track(analytics.event.viewedFeaturePromo, {
           campaign: campaign.campaignKey,
         });
         return true;
       }
       if (response !== GenericCampaignCheckResponse.nonstarter) {
-        analytics.track('Excluded from Feature Promo', {
+        analytics.track(analytics.event.excludedFromFeaturePromo, {
           campaign: campaign.campaignKey,
           exclusion: response,
           type: campaign.checkType,

--- a/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
+++ b/src/components/walletconnect-list/WalletConnectV2ListItem.tsx
@@ -116,7 +116,7 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
         } else if (index === 1) {
           await disconnectSession(session);
           reload();
-          analytics.track('Manually disconnected from WalletConnect connection', {
+          analytics.track(analytics.event.manuallyDisconnectedFromWalletConnectConnection, {
             dappName,
             dappUrl,
           });
@@ -131,7 +131,7 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
       if (actionKey === 'disconnect') {
         await disconnectSession(session);
         reload();
-        analytics.track('Manually disconnected from WalletConnect connection', {
+        analytics.track(analytics.event.manuallyDisconnectedFromWalletConnectConnection, {
           dappName,
           dappUrl,
         });

--- a/src/hooks/useHiddenTokens.ts
+++ b/src/hooks/useHiddenTokens.ts
@@ -22,7 +22,7 @@ export default function useHiddenTokens() {
       dispatch(rawAddHiddenToken(asset.fullUniqueId));
       !isReadOnlyWallet && updateWebHidden([...hiddenTokens, asset.fullUniqueId]);
 
-      analytics.track('Toggled an NFT as Hidden', {
+      analytics.track(analytics.event.toggledAnNFTAsHidden, {
         collectionContractAddress: asset.asset_contract.address || null,
         collectionName: asset.collection.name,
         isHidden: true,
@@ -36,7 +36,7 @@ export default function useHiddenTokens() {
       dispatch(rawRemoveHiddenToken(asset.fullUniqueId));
       !isReadOnlyWallet && updateWebHidden(hiddenTokens.filter(id => id !== asset.fullUniqueId));
 
-      analytics.track('Toggled an NFT as Hidden', {
+      analytics.track(analytics.event.toggledAnNFTAsHidden, {
         collectionContractAddress: asset.asset_contract.address || null,
         collectionName: asset.collection.name,
         isHidden: false,

--- a/src/hooks/useHideSplashScreen.ts
+++ b/src/hooks/useHideSplashScreen.ts
@@ -43,7 +43,7 @@ export default function useHideSplashScreen() {
       const additionalParams = initialRoute !== undefined ? { initialRoute } : undefined;
       PerformanceTracking.finishMeasuring(PerformanceMetrics.timeToInteractive, additionalParams);
       PerformanceTracking.logDirectly(PerformanceMetrics.completeStartupTime, performance.now() - StartTime.START_TIME, additionalParams);
-      analytics.track('Application became interactive');
+      analytics.track(analytics.event.applicationBecameInteractive);
       alreadyLoggedPerformance.current = true;
 
       // need to load setting straight from storage, redux isnt ready yet

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -130,7 +130,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
       type?: 'import' | 'watch';
     } = {}) => {
       setBusy(true);
-      analytics.track('Tapped "Import" button');
+      analytics.track(analytics.event.tappedImportButton);
       // guard against pressEvent coming in as forceColor if
       // handlePressImportButton is used as onClick handler
       const guardedForceColor = typeof forceColor === 'string' || typeof forceColor === 'number' ? forceColor : null;
@@ -164,7 +164,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
           }
 
           startImportProfile(name, guardedForceColor, address, finalAvatarUrl);
-          analytics.track('Show wallet profile modal for ENS address', {
+          analytics.track(analytics.event.showWalletProfileModalForENSAddress, {
             address,
             input,
           });
@@ -195,7 +195,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
 
           // @ts-expect-error ts-migrate(2554) FIXME: Expected 4 arguments, but got 3.
           startImportProfile(name, guardedForceColor, address);
-          analytics.track('Show wallet profile modal for Unstoppable address', {
+          analytics.track(analytics.event.showWalletProfileModalForUnstoppableAddress, {
             address,
             input,
           });
@@ -217,7 +217,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
             }
           }
 
-          analytics.track('Show wallet profile modal for read only wallet', {
+          analytics.track(analytics.event.showWalletProfileModalForReadOnlyWallet, {
             ens,
             input,
           });
@@ -264,7 +264,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
             }
 
             startImportProfile(name, guardedForceColor, walletResult.address, finalAvatarUrl);
-            analytics.track('Show wallet profile modal for imported wallet', {
+            analytics.track(analytics.event.showWalletProfileModalForImportedWallet, {
               address: walletResult.address,
               type: walletResult.type,
             });
@@ -353,7 +353,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
                     });
                   }, 1_000);
 
-                  analytics.track('Imported seed phrase', {
+                  analytics.track(analytics.event.importedSeedPhrase, {
                     isWalletEthZero,
                   });
 

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -118,7 +118,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
   }, [accountAddress, accountENS]);
 
   const onAvatarViewProfile = useCallback(() => {
-    analytics.track('Viewed ENS profile', {
+    analytics.track(analytics.event.viewedEnsProfile, {
       category: 'profiles',
       ens: accountENS,
       from: 'Transaction list',

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -72,7 +72,7 @@ export default function useWalletCloudBackup() {
       } else {
         const isAvailable = await isCloudBackupAvailable();
         if (!isAvailable) {
-          analytics.track('iCloud not enabled', {
+          analytics.track(analytics.event.iCloudNotEnabled, {
             category: 'backup',
           });
           Alert.alert(
@@ -82,7 +82,7 @@ export default function useWalletCloudBackup() {
               {
                 onPress: () => {
                   openInBrowser('https://support.apple.com/en-us/HT204025');
-                  analytics.track('View how to Enable iCloud', {
+                  analytics.track(analytics.event.viewHowToEnableICloud, {
                     category: 'backup',
                   });
                 },
@@ -90,7 +90,7 @@ export default function useWalletCloudBackup() {
               },
               {
                 onPress: () => {
-                  analytics.track('Ignore how to enable iCloud', {
+                  analytics.track(analytics.event.ignoreHowToEnableICloud, {
                     category: 'backup',
                   });
                 },
@@ -137,11 +137,14 @@ export default function useWalletCloudBackup() {
         const userError = getUserError(e);
         !!onError && onError(userError);
         logger.error(new RainbowError(`[useWalletCloudBackup]: error while trying to backup wallet to ${cloudPlatform}: ${e}`));
-        analytics.track(`Error during ${cloudPlatform} Backup`, {
-          category: 'backup',
-          error: userError,
-          label: cloudPlatform,
-        });
+        analytics.track(
+          cloudPlatform === 'Google Drive' ? analytics.event.errorDuringGoogleDriveBackup : analytics.event.errorDuringICloudBackup,
+          {
+            category: 'backup',
+            error: userError,
+            label: cloudPlatform,
+          }
+        );
         return false;
       }
 
@@ -155,13 +158,13 @@ export default function useWalletCloudBackup() {
         logger.error(new RainbowError(`[useWalletCloudBackup]: error while trying to save wallet backup state: ${e}`));
         const userError = getUserError(new Error(CLOUD_BACKUP_ERRORS.WALLET_BACKUP_STATUS_UPDATE_FAILED));
         !!onError && onError(userError);
-        analytics.track('Error updating Backup status', {
+        analytics.track(analytics.event.errorUpdatingBackupStatus, {
           category: 'backup',
           label: cloudPlatform,
         });
-      }
 
-      return false;
+        return false;
+      }
     },
     [dispatch, wallets]
   );

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -162,9 +162,9 @@ export default function useWalletCloudBackup() {
           category: 'backup',
           label: cloudPlatform,
         });
-
-        return false;
       }
+
+      return false;
     },
     [dispatch, wallets]
   );

--- a/src/performance/tracking/index.ts
+++ b/src/performance/tracking/index.ts
@@ -38,7 +38,7 @@ function logDirectly(metric: PerformanceMetricsType, durationInMs: number, addit
   logDurationIfAppropriate(metric, durationInMs);
   collectResultForPerformanceToast(metric, durationInMs);
   if (shouldReportMeasurement) {
-    analytics.track(metric, {
+    analytics.trackPerformance(metric, {
       durationInMs,
       performanceTrackingVersion,
       ...additionalParams, // wondering if we need to protect ourselves here
@@ -89,7 +89,7 @@ function finishMeasuring(metric: PerformanceMetricsType, additionalParams?: Addi
   collectResultForPerformanceToast(metric, durationInMs);
 
   if (shouldReportMeasurement) {
-    analytics.track(metric, {
+    analytics.trackPerformance(metric, {
       durationInMs,
       performanceTrackingVersion,
       ...savedEntry.additionalParams,
@@ -130,7 +130,7 @@ export function withPerformanceTracking<Fn extends (...args: Parameters<Fn>) => 
     const durationInMs = performance.now() - startTime;
     logDurationIfAppropriate(metric, durationInMs);
     if (shouldReportMeasurement) {
-      analytics.track(metric, {
+      analytics.trackPerformance(metric, {
         durationInMs,
         performanceTrackingVersion,
         ...additionalParams,

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -43,7 +43,7 @@ export const AddWalletSheet = () => {
         isFirstWallet,
         type: 'new',
       });
-      analytics.track('Tapped "Create a new wallet"');
+      analytics.track(analytics.event.tappedCreateNewWallet);
 
       navigate(Routes.CHOOSE_WALLET_GROUP, {});
     } catch (e) {
@@ -54,7 +54,7 @@ export const AddWalletSheet = () => {
   };
 
   const onPressRestoreFromSeed = () => {
-    analytics.track('Tapped "Add an existing wallet"');
+    analytics.track(analytics.event.tappedAddExistingWallet);
     analytics.track(analytics.event.addWalletFlowStarted, {
       isFirstWallet,
       type: 'seed',
@@ -66,7 +66,7 @@ export const AddWalletSheet = () => {
   };
 
   const onPressWatch = () => {
-    analytics.track('Tapped "Watch an Ethereum Address"');
+    analytics.track(analytics.event.tappedWatchAddress);
     analytics.track(analytics.event.addWalletFlowStarted, {
       isFirstWallet,
       type: 'watch',

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -62,7 +62,7 @@ export default function ProfileSheet() {
 
   useEffect(() => {
     if (profileAddress && accountAddress) {
-      analytics.track('Viewed profile', {
+      analytics.track(analytics.event.viewedProfile, {
         category: 'profiles',
         fromRoute: params.fromRoute,
         name: profileAddress !== accountAddress ? ensName : '',

--- a/src/screens/SendSheet.tsx
+++ b/src/screens/SendSheet.tsx
@@ -348,7 +348,7 @@ export default function SendSheet() {
         isSufficientBalance: _isSufficientBalance,
         nativeAmount: _nativeAmount,
       });
-      analytics.track('Changed native currency input in Send flow');
+      analytics.track(analytics.event.changedNativeCurrencyInputSend);
     },
     [maxEnabled, maxInputBalance, isUniqueAsset, selected]
   );
@@ -369,7 +369,7 @@ export default function SendSheet() {
           setMaxEnabled(false);
         }
         sendUpdateAssetAmount(newAssetAmount);
-        analytics.track('Changed token input in Send flow');
+        analytics.track(analytics.event.changedTokenInputSend);
       }
     },
     [maxEnabled, sendUpdateAssetAmount]
@@ -644,7 +644,7 @@ export default function SendSheet() {
         return false;
       }
       const submitSuccessful = await onSubmit(args);
-      analytics.track('Sent transaction', {
+      analytics.track(analytics.event.sentTransaction, {
         assetName: selected?.name || '',
         network: selected?.network || '',
         isRecepientENS: recipient.slice(-4).toLowerCase() === '.eth',
@@ -788,7 +788,7 @@ export default function SendSheet() {
   ]);
 
   const onResetAssetSelection = useCallback(() => {
-    analytics.track('Reset asset selection in Send flow');
+    analytics.track(analytics.event.resetAssetSelectionSend);
     sendUpdateSelected(undefined);
     setMaxEnabled(false);
   }, [sendUpdateSelected]);

--- a/src/screens/SettingsSheet/components/AppIconSection.tsx
+++ b/src/screens/SettingsSheet/components/AppIconSection.tsx
@@ -19,7 +19,7 @@ const AppIconSection = () => {
   const onSelectIcon = useCallback(
     (icon: string) => {
       logger.debug(`[AppIconSection]: onSelectIcon: ${icon}`);
-      analytics.track('Set App Icon', { appIcon: icon });
+      analytics.track(analytics.event.setAppIcon, { appIcon: icon });
       settingsChangeAppIcon(icon);
     },
     [settingsChangeAppIcon]

--- a/src/screens/SettingsSheet/components/Backups/ShowSecretView.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ShowSecretView.tsx
@@ -6,7 +6,7 @@ import { SecretDisplaySection } from '@/components/secret-display/SecretDisplayS
 
 export default function ShowSecretView() {
   useEffect(() => {
-    analytics.track('Show Secret View', {
+    analytics.track(analytics.event.showSecretView, {
       category: 'settings backup',
     });
   }, []);

--- a/src/screens/SettingsSheet/components/CurrencySection.tsx
+++ b/src/screens/SettingsSheet/components/CurrencySection.tsx
@@ -36,7 +36,7 @@ const CurrencySection = () => {
       if (IS_IOS && parseInt(Platform.Version as string) >= 14) {
         reloadTimelines('PriceWidget');
       }
-      analytics.track('Changed native currency', { currency });
+      analytics.track(analytics.event.changedNativeCurrency, { currency });
     },
     [settingsChangeNativeCurrency]
   );

--- a/src/screens/SettingsSheet/components/LanguageSection.tsx
+++ b/src/screens/SettingsSheet/components/LanguageSection.tsx
@@ -25,7 +25,7 @@ const LanguageSection = () => {
   const onSelectLanguage = useCallback(
     (language: string) => {
       settingsChangeLanguage(language);
-      analytics.track('Changed language', { language });
+      analytics.track(analytics.event.changedLanguage, { language });
     },
     [settingsChangeLanguage]
   );

--- a/src/screens/SettingsSheet/components/NetworkSection.tsx
+++ b/src/screens/SettingsSheet/components/NetworkSection.tsx
@@ -26,7 +26,7 @@ const NetworkSection = ({ inDevSection }: NetworkSectionProps) => {
       dispatch(settingsUpdateNetwork(chainId));
       InteractionManager.runAfterInteractions(async () => {
         await loadAccountData();
-        analytics.track('Changed network', { chainId });
+        analytics.track(analytics.event.changedNetwork, { chainId });
       });
     },
     [dispatch, loadAccountData]

--- a/src/screens/WalletConnectApprovalSheet.tsx
+++ b/src/screens/WalletConnectApprovalSheet.tsx
@@ -253,7 +253,7 @@ export function WalletConnectApprovalSheet() {
 
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => {
-      analytics.track('Shown Walletconnect session request');
+      analytics.track(analytics.event.shownWalletconnectSessionRequest);
     });
     // Reject if the modal is dismissed
     return () => {
@@ -291,7 +291,7 @@ export function WalletConnectApprovalSheet() {
   useEffect(() => {
     const waitingTime = (Date.now() - receivedTimestamp) / 1000;
     InteractionManager.runAfterInteractions(() => {
-      analytics.track('Received wc connection', {
+      analytics.track(analytics.event.receivedWcConnection, {
         dappName,
         dappUrl,
         waitingTime: isNaN(waitingTime) ? 'Error calculating waiting time.' : waitingTime,

--- a/src/screens/WelcomeScreen/index.tsx
+++ b/src/screens/WelcomeScreen/index.tsx
@@ -178,7 +178,7 @@ export default function WelcomeScreen() {
   }));
 
   const onCreateWallet = useCallback(async () => {
-    analytics.track('Tapped "Get a new wallet"');
+    analytics.track(analytics.event.welcomeNewWallet);
     const operation = dangerouslyGetState()?.index === 1 ? navigate : replace;
     operation(Routes.SWIPE_LAYOUT, {
       params: { emptyWallet: true },
@@ -191,7 +191,7 @@ export default function WelcomeScreen() {
   }, []);
 
   const showRestoreSheet = useCallback(() => {
-    analytics.track('Tapped "I already have one"');
+    analytics.track(analytics.event.welcomeAlreadyHave);
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
       isFirstWallet: true,
     });

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -316,9 +316,7 @@ export default function ChangeWalletSheet() {
             onCloseModal: async (args: any) => {
               if (args) {
                 if ('name' in args) {
-                  analytics.track('Tapped "Done" after editing wallet', {
-                    wallet_label: args.name,
-                  });
+                  analytics.track(analytics.event.tappedDoneEditingWallet, { wallet_label: args.name });
 
                   const walletAddresses = wallets[walletId].addresses;
                   const walletAddressIndex = walletAddresses.findIndex(account => account.address === address);
@@ -350,7 +348,7 @@ export default function ChangeWalletSheet() {
 
                   dispatch(walletsUpdate(updatedWallets));
                 } else {
-                  analytics.track('Tapped "Cancel" after editing wallet');
+                  analytics.track(analytics.event.tappedCancelEditingWallet);
                 }
               }
             },
@@ -369,7 +367,7 @@ export default function ChangeWalletSheet() {
 
   const onPressEdit = useCallback(
     (walletId: string, address: string) => {
-      analytics.track('Tapped "Edit Wallet"');
+      analytics.track(analytics.event.tappedEditWallet);
       renameWallet(walletId, address);
     },
     [renameWallet]
@@ -377,7 +375,7 @@ export default function ChangeWalletSheet() {
 
   const onPressNotifications = useCallback(
     (walletName: string, address: string) => {
-      analytics.track('Tapped "Notification Settings"');
+      analytics.track(analytics.event.tappedNotificationSettings);
       const walletNotificationSettings = getNotificationSettingsForWalletWithAddress(address);
       if (walletNotificationSettings) {
         navigate(Routes.SETTINGS_SHEET, {
@@ -399,7 +397,7 @@ export default function ChangeWalletSheet() {
 
   const onPressRemove = useCallback(
     (walletId: string, address: string) => {
-      analytics.track('Tapped "Delete Wallet"');
+      analytics.track(analytics.event.tappedDeleteWallet);
       // If there's more than 1 account
       // it's deletable
       let isLastAvailableWallet = false;
@@ -423,7 +421,7 @@ export default function ChangeWalletSheet() {
         },
         async buttonIndex => {
           if (buttonIndex === 0) {
-            analytics.track('Tapped "Delete Wallet" (final confirm)');
+            analytics.track(analytics.event.tappedDeleteWalletConfirm);
             await deleteWallet(walletId, address);
             ReactNativeHapticFeedback.trigger('notificationSuccess');
             if (!isLastAvailableWallet) {
@@ -493,7 +491,7 @@ export default function ChangeWalletSheet() {
   }, [goBack, navigate]);
 
   const onPressEditMode = useCallback(() => {
-    analytics.track('Tapped "Edit"');
+    analytics.track(analytics.event.tappedEdit);
     if (featureHintTooltipRef.current) {
       featureHintTooltipRef.current.dismiss();
     }


### PR DESCRIPTION
Fixes my last PR which missed a few conversions and caused some type errors.

## What changed (plus any additional context for devs)

This one is straightforward, I just missed a few areas. This should finish the conversion and fix type issues. I am seeing one type error:

```
src/resources/metadata/tokenInteractions.ts:23:43 - error TS2339: Property 'interactionsWithToken' does not exist on type '{ getContractFunction(variables: Exact<{ chainID: number; hex: string; }>, options?: Options | undefined): Promise<GetContractFunctionQuery>; getEnsMarquee(variables?: Exact<...> | undefined, options?: Options | undefined): Promise<GetEnsMarqueeQuery>; ... 15 more ...; trendingDApps(variables?: Exact<...> | undefine...'.

23     const response = await metadataClient.interactionsWithToken({
                                             ~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/resources/metadata/tokenInteractions.ts:23
```

But this is also in `develop` branch currently.

I added `trackPerformance`, this is mostly because they are using a bit different type structure and I didn't want to do fancy and weird TS stuff, instead just carve out this helper. It's the same as `track` just with types to match the performance usages.
