### PR TITLE
Enable lazy tab navigation

### DIFF
--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -381,6 +381,7 @@ function SwipeNavigatorScreens() {
         return {
           animationEnabled: false,
           swipeEnabled: (!isOnBrowserTab && !isCoinListEdited) || IS_TEST,
+          lazy: true,
         };
       }}
       tabBar={({ descriptors, jumpTo, navigation, state: { index, routes } }) => (


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Avoid rendering all 5 tabs initially, this will improve performance of initial app loading. I did not measure the exact improvement, but will definitely help. We could also investigate using https://github.com/callstackincubator/react-native-bottom-tabs, but this will be a good improvement for now with a 1 line change.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/10ca903c-7216-43f9-be00-8750f1830fc1

## What to test

Test running the app and switching between tabs.