### PR TITLE
Fix walletconnect error sheet overflow

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -1,5 +1,5 @@
 import Clipboard from '@react-native-clipboard/clipboard';
-import lang from 'i18n-js';
+import * as lang from '@/languages';
 import * as React from 'react';
 import { InteractionManager, PressableProps } from 'react-native';
 import Animated, { useAnimatedStyle, useDerivedValue, withSpring } from 'react-native-reanimated';

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -609,8 +609,12 @@ export const portalSheetConfig: PartialNavigatorConfigOptions = {
   options: ({ route: { params = {} } }) => ({
     ...buildCoolModalConfig({
       ...params,
-      // @ts-ignore
-      longFormHeight: params.sheetHeight,
+      backgroundOpacity: 0.8,
+      cornerRadius: 0,
+      headerHeight: safeAreaInsetValues.top + 70,
+      springDamping: 1,
+      topOffset: 0,
+      transitionDuration: 0.3,
     }),
   }),
 };

--- a/src/screens/Explain/index.tsx
+++ b/src/screens/Explain/index.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@/theme';
 import { Box, Text, TextProps, AccentColorProvider, Stack } from '@/design-system';
 import { ImgixImage } from '@/components/images';
 import SheetActionButton from '@/components/sheet/sheet-action-buttons/SheetActionButton';
-import { ImageSourcePropType } from 'react-native';
+import { ImageSourcePropType, ScrollView, StyleSheet } from 'react-native';
 
 export { open, close, useOpen } from '@/screens/Portal';
 
@@ -79,15 +79,27 @@ export function Title({ children, color, size, weight, ...props }: Omit<Partial<
 /**
  * Body text for use within the Portal sheet.
  */
-export function Body({ children, size, color, ...props }: Omit<Partial<TextProps>, 'children'> & { children: string }) {
+export function Body({
+  children,
+  size,
+  color,
+  maxHeight,
+  ...props
+}: Omit<Partial<TextProps>, 'children'> & { children: string; maxHeight: number }) {
   return (
-    <Box paddingBottom="20px">
+    <ScrollView showsVerticalScrollIndicator={false} style={[scrollviewStyles.scrollview, { maxHeight }]}>
       <Text color={color || 'labelSecondary'} size={size || '17pt / 135%'} align="center" {...props}>
         {children}
       </Text>
-    </Box>
+    </ScrollView>
   );
 }
+
+const scrollviewStyles = StyleSheet.create({
+  scrollview: {
+    paddingBottom: 20,
+  },
+});
 
 /**
  * A wrapper for any buttons you might want to add to the Portal sheet.

--- a/src/screens/Portal/index.tsx
+++ b/src/screens/Portal/index.tsx
@@ -4,7 +4,9 @@ import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { Box } from '@/design-system';
-import { SimpleSheet } from '@/components/sheet/SimpleSheet';
+import { StyleSheet } from 'react-native';
+import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
+import { Panel, TapToDismiss } from '@/components/SmoothPager/ListPanel';
 
 export type PortalSheetProps = {
   sheetHeight?: number;
@@ -28,13 +30,28 @@ export function Portal() {
   }
 
   return (
-    <SimpleSheet backgroundColor="white" scrollEnabled={false}>
-      <Box paddingVertical="44px" paddingHorizontal="32px" height="full" background="surfaceSecondary">
+    <Box style={styles.container}>
+      <TapToDismiss />
+      <Panel height={params.sheetHeight} innerBorderWidth={0} outerBorderWidth={2.5} style={styles.panel}>
         {params.children({})}
-      </Box>
-    </SimpleSheet>
+      </Panel>
+    </Box>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flex: 1,
+    height: DEVICE_HEIGHT,
+    justifyContent: 'flex-end',
+    pointerEvents: 'box-none',
+  },
+  panel: {
+    justifyContent: 'space-between',
+    width: DEVICE_WIDTH,
+  },
+});
 
 /**
  * Returns a util used to navigate to and render components within the Portal

--- a/src/screens/Portal/index.tsx
+++ b/src/screens/Portal/index.tsx
@@ -32,7 +32,7 @@ export function Portal() {
   return (
     <Box style={styles.container}>
       <TapToDismiss />
-      <Panel height={params.sheetHeight} innerBorderWidth={0} outerBorderWidth={2.5} style={styles.panel}>
+      <Panel height={params.sheetHeight} innerBorderWidth={0} outerBorderWidth={0} style={styles.panel}>
         {params.children({})}
       </Panel>
     </Box>

--- a/src/walletConnect/index.tsx
+++ b/src/walletConnect/index.tsx
@@ -1,6 +1,6 @@
 import { addNewWalletConnectRequest, removeWalletConnectRequest } from '@/state/walletConnectRequests';
 import React from 'react';
-import { InteractionManager } from 'react-native';
+import { InteractionManager, ScrollView } from 'react-native';
 import { SignClientTypes, SessionTypes } from '@walletconnect/types';
 import { getSdkError, parseUri, buildApprovedNamespaces } from '@walletconnect/utils';
 import { WC_PROJECT_ID } from 'react-native-dotenv';
@@ -265,12 +265,17 @@ export function isSupportedMethod(method: RPCMethod) {
   return isSupportedSigningMethod(method) || isSupportedTransactionMethod(method);
 }
 
+const BUTTON_HEIGHT = 52;
+const TITLE_HEIGHT = 55;
+const SPACING_HEIGHT = 18;
+const SHEET_PADDING = 88;
+
 /**
  * Navigates to `ExplainSheet` by way of `WalletConnectApprovalSheet`, and
  * shows the text configured by the `reason` string, which is a key of the
  * `explainers` object in `ExplainSheet`
  */
-function showErrorSheet({
+export function showErrorSheet({
   title,
   body,
   cta,
@@ -281,14 +286,14 @@ function showErrorSheet({
   body: string;
   cta?: string;
   onClose?: () => void;
-  sheetHeight?: number;
+  sheetHeight: number;
 }) {
   explain.open(
     () => (
-      <>
+      <Box paddingVertical="44px" paddingHorizontal="32px">
         <explain.Title>{title}</explain.Title>
-        <explain.Body>{body}</explain.Body>
-        <Box paddingTop="8px">
+        <explain.Body maxHeight={sheetHeight - BUTTON_HEIGHT - TITLE_HEIGHT - SPACING_HEIGHT - SHEET_PADDING}>{body}</explain.Body>
+        <Box paddingTop="20px">
           <explain.Button
             label={cta || lang.t(T.errors.go_back)}
             onPress={() => {
@@ -297,7 +302,7 @@ function showErrorSheet({
             }}
           />
         </Box>
-      </>
+      </Box>
     ),
     { sheetHeight }
   );


### PR DESCRIPTION
Fixes APP-1913

## What changed (plus any additional context for devs)
Fixes up the Portal screen to no longer use SlackSheet and instead opt to use a a fullscreen cool modal with desired sheet height. the body of the portal will overflow a scrollview if needed.

## Screen recordings / screenshots
BEFORE
<img width="568" alt="Screenshot 2025-04-11 at 4 41 11 PM" src="https://github.com/user-attachments/assets/a8e3745c-077f-429b-8b51-a9d006ab01de" />
AFTER
<img width="524" alt="Screenshot 2025-04-15 at 4 24 18 PM" src="https://github.com/user-attachments/assets/0b6d7673-662b-4951-a342-88f434940f13" />
<img width="568" alt="Screenshot 2025-04-15 at 4 44 44 PM" src="https://github.com/user-attachments/assets/5cc1eef8-71f8-444f-94e3-d9fc9b339e24" />


## What to test
no tests really needed for this.
