### PR TITLE
Fix: Expanded State History spacing off on Android

### DIFF
--- a/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
@@ -122,7 +122,7 @@ export const BuyContent = memo(function BuySection() {
                   </Text>
                 </TextShadow>
               </IconContainer>
-              <TextShadow containerStyle={{ flex: 1 }} blur={12} shadowOpacity={0.24}>
+              <TextShadow blur={12} shadowOpacity={0.24}>
                 <Text weight="semibold" size="17pt" color="accent">
                   {i18n.t(i18n.l.expanded_state.sections.buy.pay_with)}
                 </Text>

--- a/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
@@ -114,7 +114,7 @@ export const BuyContent = memo(function BuySection() {
       <Stack space="4px">
         <Box style={{ opacity: hasBuyOptions ? 1 : 0.5 }}>
           <Row highlighted>
-            <Box alignItems="center" flexDirection="row" gap={12} width={'full'}>
+            <Box alignItems="center" flexDirection="row" gap={12}>
               <IconContainer height={10} width={20}>
                 <TextShadow blur={12} shadowOpacity={0.24}>
                   <Text weight="medium" align="center" size="15pt" color="accent">
@@ -127,20 +127,20 @@ export const BuyContent = memo(function BuySection() {
                   {i18n.t(i18n.l.expanded_state.sections.buy.pay_with)}
                 </Text>
               </TextShadow>
-              <Box alignItems="center" flexDirection="row" gap={8}>
-                <RainbowCoinIcon
-                  size={16}
-                  chainId={buyWithAsset.chainId}
-                  color={buyWithAsset.color}
-                  icon={buyWithAsset.icon_url}
-                  symbol={buyWithAsset.symbol}
-                />
-                <TextShadow blur={12} shadowOpacity={0.24}>
-                  <Text align="right" weight="semibold" size="17pt" color="accent">
-                    {buyWithAsset.symbol}
-                  </Text>
-                </TextShadow>
-              </Box>
+            </Box>
+            <Box alignItems="center" flexDirection="row" gap={8}>
+              <RainbowCoinIcon
+                size={16}
+                chainId={buyWithAsset.chainId}
+                color={buyWithAsset.color}
+                icon={buyWithAsset.icon_url}
+                symbol={buyWithAsset.symbol}
+              />
+              <TextShadow blur={12} shadowOpacity={0.24}>
+                <Text align="right" weight="semibold" size="17pt" color="accent">
+                  {buyWithAsset.symbol}
+                </Text>
+              </TextShadow>
             </Box>
           </Row>
         </Box>

--- a/src/screens/expandedAssetSheet/components/sections/HistorySection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/HistorySection.tsx
@@ -63,6 +63,10 @@ const moreButtonStyles = {
   justifyContent: 'center' as const,
 };
 
+const buttonWrapperStyles = {
+  gap: LIST_ITEM_GAP,
+};
+
 interface MoreButtonProps {
   tokenInteractions: TokenInteraction[];
 }
@@ -229,7 +233,7 @@ export const ListItem = memo(function ListItem({ index, item, nativeCurrency, li
 
   return (
     <Box as={Animated.View} style={isVisibleStyles} height={ROW_HEIGHT}>
-      <Box as={ButtonPressAnimation} scaleTo={0.94} onPress={navigateToTransaction} gap={LIST_ITEM_GAP}>
+      <Box as={ButtonPressAnimation} scaleTo={0.94} onPress={navigateToTransaction} style={buttonWrapperStyles}>
         <Box flexDirection="row" justifyContent="space-between" alignItems="center">
           <Box flexDirection="row" alignItems="center" gap={ICON_TEXT_GAP}>
             <Text size="icon 11px" color={{ custom: iconColor }} weight="bold">


### PR DESCRIPTION
Fixes APP-2567

## What changed (plus any additional context for devs)
Fix spacing on Android history section. It's because ButtonPressAnimation component doesn't accept a gap prop but accepts a style prop. I don't know why this worked on iOS to be honest lol.

## Screen recordings / screenshots
<img width="553" alt="Screenshot 2025-04-16 at 1 15 33 PM" src="https://github.com/user-attachments/assets/0708bb2c-71e6-4ea8-bf03-c5eddb14621c" />


## What to test
no regressions on iOS
