### PR TITLE
Fix wallet screen layout shift

### DIFF
--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -200,25 +200,25 @@ const withBriefBalanceSection = (
 
   const hasTokens = briefAssets?.length;
   const hasNFTs = collectibles?.length;
-
-  const isEmpty = !hasTokens && !hasNFTs;
   const hasNFTsOnly = !hasTokens && hasNFTs;
 
-  let balanceSection: CellTypes[] = [];
-  if (hasTokens && !isLoadingBalance) {
-    balanceSection = [
-      {
-        type: CellType.PROFILE_BALANCE_ROW,
-        uid: 'profile-balance',
-        value: accountBalanceDisplay,
-        isLoadingBalance,
-      },
-      {
-        type: CellType.PROFILE_BALANCE_ROW_SPACE_AFTER,
-        uid: 'profile-balance-space-after',
-      },
-    ];
-  }
+  const isEmpty = !hasTokens && !hasNFTs;
+  const shouldHideBalanceRow = !isLoadingUserAssets && !isLoadingBalance && !hasTokens;
+
+  const balanceSection: CellTypes[] = shouldHideBalanceRow
+    ? []
+    : [
+        {
+          type: CellType.PROFILE_BALANCE_ROW,
+          uid: 'profile-balance',
+          value: accountBalanceDisplay,
+          isLoadingBalance,
+        },
+        {
+          type: CellType.PROFILE_BALANCE_ROW_SPACE_AFTER,
+          uid: 'profile-balance-space-after',
+        },
+      ];
 
   let spacer: CellTypes[] = [];
   if (!hasTokens) {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Fixes an issue from #6521 where switching wallets caused the total balance row to be removed while loading, instead of displaying a loading state

## Screen recordings / screenshots


## What to test

