### PR TITLE
change height of pkey box

### DIFF
--- a/src/components/secret-display/SecretDisplayCard.tsx
+++ b/src/components/secret-display/SecretDisplayCard.tsx
@@ -15,7 +15,7 @@ interface SecretDisplayCardProps {
 
 const getHeightForType = (type: EthereumWalletType) => {
   if (type === WalletTypes.privateKey) {
-    return 90;
+    return 120;
   }
   return 240;
 };


### PR DESCRIPTION
Fixes APP-2269

## What changed (plus any additional context for devs)
box height from 90 > 120 to accommodate 3 lines of pkey text. previously a large amount of user pkeys were being cut off by the box height.

longest and shortest a pkey can be:
<img width="343" alt="Screenshot 2025-04-18 at 12 13 36 PM" src="https://github.com/user-attachments/assets/1ae8f0fc-933a-4976-8066-161af2728fca" />
<img width="342" alt="Screenshot 2025-04-18 at 12 13 23 PM" src="https://github.com/user-attachments/assets/09fc579c-92fe-425e-8729-195724f3e17d" />


