### PR TITLE
Add tracking of how often "Insufficient ETH" error message is returned

### DIFF
--- a/src/__swaps__/screens/Swap/components/GasButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GasButton.tsx
@@ -14,7 +14,7 @@ import { swapsStore } from '@/state/swaps/swapsStore';
 import { gasUtils } from '@/utils';
 import React, { PropsWithChildren, ReactNode, useCallback, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
-import Animated, { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
+import Animated, { runOnJS, runOnUI, useAnimatedReaction, useAnimatedStyle } from 'react-native-reanimated';
 import { THICK_BORDER_WIDTH } from '../constants';
 import { GasSettings, useCustomGasSettings } from '../hooks/useCustomGas';
 import { setSelectedGasSpeed, useSelectedGasSpeed } from '../hooks/useSelectedGas';
@@ -23,6 +23,9 @@ import { EstimatedSwapGasFee, EstimatedSwapGasFeeSlot } from './EstimatedSwapGas
 import { GestureHandlerButton } from './GestureHandlerButton';
 import { UnmountOnAnimatedReaction } from './UnmountOnAnimatedReaction';
 import { ChainId } from '@/state/backendNetworks/types';
+import { lessThanOrEqualToWorklet, equalWorklet } from '@/safe-math/SafeMath';
+import { analytics } from '@/analytics';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 
 const { SWAP_GAS_ICONS } = gasUtils;
 const GAS_BUTTON_HIT_SLOP = 16;
@@ -56,10 +59,61 @@ function EstimatedGasFee() {
   );
 }
 
+function useTrackSufficientFunds() {
+  const { hasEnoughFundsForGas, internalSelectedInputAsset, SwapInputController } = useSwapContext();
+
+  const reportInsufficientFunds = useCallback(
+    ({ inputAsset, chainId, inputAmount }: { inputAsset: string; chainId: ChainId; inputAmount: string | number }) => {
+      analytics.track(analytics.event.insufficientNativeAssetForAction, {
+        type: 'swap',
+        inputAsset,
+        inputAmount,
+        nativeAssetSymbol: useBackendNetworksStore.getState().getChainsNativeAsset()[chainId]?.symbol,
+      });
+    },
+    []
+  );
+
+  useAnimatedReaction(
+    () => ({
+      hasEnoughFundsForGas: hasEnoughFundsForGas.value,
+      inputAsset: internalSelectedInputAsset.value,
+      inputAmount: SwapInputController.inputValues.value.inputAmount,
+    }),
+    (prev, curr) => {
+      if (!curr?.inputAsset) return;
+
+      const enoughFundsForSwap =
+        curr?.inputAsset &&
+        !equalWorklet(curr.inputAsset.maxSwappableAmount, '0') &&
+        lessThanOrEqualToWorklet(curr.inputAmount, curr.inputAsset.maxSwappableAmount);
+
+      // Don't report if we're hitting the same insufficient funds case for the same asset
+      if (
+        prev.hasEnoughFundsForGas === false &&
+        curr?.hasEnoughFundsForGas === false &&
+        prev.inputAsset?.uniqueId === curr.inputAsset?.uniqueId
+      ) {
+        return;
+      }
+
+      if ((!enoughFundsForSwap && curr?.hasEnoughFundsForGas !== undefined) || curr?.hasEnoughFundsForGas === false) {
+        runOnJS(reportInsufficientFunds)({
+          inputAsset: curr.inputAsset.uniqueId,
+          chainId: curr.inputAsset.chainId,
+          inputAmount: curr.inputAmount,
+        });
+      }
+    }
+  );
+}
+
 function SelectedGas({ isPill }: { isPill?: boolean }) {
   const preferredNetwork = swapsStore(s => s.preferredNetwork);
   const chainId = swapsStore(s => s.inputAsset?.chainId || preferredNetwork || ChainId.mainnet);
   const selectedGasSpeed = useSelectedGasSpeed(chainId);
+
+  useTrackSufficientFunds();
 
   return (
     <Inline alignVertical="center" space={{ custom: 5 }}>

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -196,6 +196,7 @@ export const event = {
   swapsSucceeded: 'swaps.succeeded',
   swapsQuoteFailed: 'swaps.quote_failed',
   swapsGasUpdatedPrice: 'Updated Gas Price',
+  insufficientNativeAssetForAction: 'insufficient_native_asset_for_action',
 
   // app browser events
   browserTrendingDappClicked: 'browser.trending_dapp_pressed',
@@ -731,6 +732,12 @@ export type EventProperties = {
   [event.swapsSubmitted]: SwapEventParameters<'swap' | 'crosschainSwap'>;
   [event.swapsFailed]: SwapsEventFailedParameters<'swap' | 'crosschainSwap'>;
   [event.swapsSucceeded]: SwapsEventSucceededParameters<'swap' | 'crosschainSwap'>;
+  [event.insufficientNativeAssetForAction]: {
+    type: string;
+    inputAsset: string;
+    inputAmount: string | number;
+    nativeAssetSymbol: string | undefined;
+  };
 
   [event.swapsQuoteFailed]: {
     error_code: number | undefined;


### PR DESCRIPTION
Fixes APP-2580

## What changed (plus any additional context for devs)
Adds in tracking to how often the insufficient funds / insufficient native asset is shown when performing actions.

## Screen recordings / screenshots
soon

## What to test

