### PR TITLE
Adjust query store's internal set usage to cover all enabled changes

### DIFF
--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -544,7 +544,7 @@ export function createQueryStore<
     }
   };
 
-  const createState: StateCreator<S, [], [['zustand/subscribeWithSelector', never]]> = (set, get, api) => {
+  const createState: StateCreator<S, [], [['zustand/subscribeWithSelector', never]]> = (_set, get, api) => {
     const originalSet = api.setState;
     const handleEnabledChange = (prevEnabled: boolean, newEnabled: boolean) => {
       if (prevEnabled !== newEnabled && lastHandledEnabled !== newEnabled) {
@@ -562,7 +562,7 @@ export function createQueryStore<
       }
     };
 
-    const setStateWithEnabledHandling: typeof originalSet = (partial, replace) => {
+    const setWithEnabledHandling: typeof originalSet = (partial, replace) => {
       const isPartialFunction = typeof partial === 'function';
       if (isPartialFunction || partial.enabled !== undefined) {
         let handleNewEnabled: (() => void) | undefined;
@@ -578,8 +578,9 @@ export function createQueryStore<
       }
     };
 
-    // Override the store's setState method
-    api.setState = setStateWithEnabledHandling;
+    // Replace the store's set method
+    api.setState = setWithEnabledHandling;
+    const set = setWithEnabledHandling;
 
     subscriptionManager.init({
       onSubscribe: (enabled, isFirstSubscription, shouldThrottle) => {


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- There were a few spots internally where `setWithEnabledHandling` should've been used over `set`, which is a reference to the original `api.setState` and lacks the extra handling around changes to `enabled`
- Specifically, `setData`, `onFetched`, and the user's `customStateCreator` now receive `setWithEnabledHandling` instead of the original `set`, so changes to `enabled` that occur within those functions are properly reacted to
- Shoutout @maxbbb for discovering this

## Screen recordings / screenshots


## What to test

