### PR TITLE
fixes object selectors that don't use shallowEqual

### DIFF
--- a/src/components/backup/BackupWalletPrompt.tsx
+++ b/src/components/backup/BackupWalletPrompt.tsx
@@ -28,9 +28,7 @@ export default function BackupSheetSectionNoProvider() {
   const { navigate, goBack } = useNavigation();
   const { selectedWallet } = useWallets();
   const createBackup = useCreateBackup();
-  const { status } = backupsStore(state => ({
-    status: state.status,
-  }));
+  const status = backupsStore(state => state.status);
 
   const onCloudBackup = useCallback(() => {
     // pop the bottom sheet, and navigate to the backup section inside settings sheet

--- a/src/components/backup/ChooseBackupStep.tsx
+++ b/src/components/backup/ChooseBackupStep.tsx
@@ -52,11 +52,9 @@ const Masthead = styled(Box).attrs({
 export function ChooseBackupStep() {
   const { colors } = useTheme();
 
-  const { status, backups, mostRecentBackup } = backupsStore(state => ({
-    status: state.status,
-    backups: state.backups,
-    mostRecentBackup: state.mostRecentBackup,
-  }));
+  const status = backupsStore(state => state.status);
+  const backups = backupsStore(state => state.backups);
+  const mostRecentBackup = backupsStore(state => state.mostRecentBackup);
 
   const isLoading = LoadingStates.includes(status);
 

--- a/src/components/backup/CloudBackupPrompt.tsx
+++ b/src/components/backup/CloudBackupPrompt.tsx
@@ -18,9 +18,7 @@ const imageSize = 72;
 
 export default function CloudBackupPrompt() {
   const { navigate, goBack } = useNavigation();
-  const { mostRecentBackup } = backupsStore(state => ({
-    mostRecentBackup: state.mostRecentBackup,
-  }));
+  const mostRecentBackup = backupsStore(state => state.mostRecentBackup);
   const { selectedWallet } = useWallets();
   const createBackup = useCreateBackup();
 

--- a/src/components/backup/RestoreCloudStep.tsx
+++ b/src/components/backup/RestoreCloudStep.tsx
@@ -89,9 +89,7 @@ type RestoreCloudStepParams = {
 
 export default function RestoreCloudStep() {
   const { params } = useRoute<RouteProp<RestoreCloudStepParams & RestoreSheetParams, 'RestoreSheet'>>();
-  const { password } = backupsStore(state => ({
-    password: state.password,
-  }));
+  const password = backupsStore(state => state.password);
 
   const loadingState = walletLoadingStore(state => state.loadingState);
 

--- a/src/components/secret-display/SecretDisplaySection.tsx
+++ b/src/components/secret-display/SecretDisplaySection.tsx
@@ -63,9 +63,7 @@ export function SecretDisplaySection({ onSecretLoaded, onWalletTypeIdentified }:
   const { colors } = useTheme();
   const { params } = useRoute<RouteProp<SecretDisplaySectionParams, 'SecretDisplaySection'>>();
   const { selectedWallet, wallets } = useWallets();
-  const { backupProvider } = backupsStore(state => ({
-    backupProvider: state.backupProvider,
-  }));
+  const backupProvider = backupsStore(state => state.backupProvider);
   const { onManuallyBackupWalletId } = useWalletManualBackup();
   const { navigate } = useNavigation();
 

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -52,9 +52,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
   const { updateWalletENSAvatars } = useWalletENSAvatar();
   const profilesEnabled = useExperimentalFlag(PROFILES);
 
-  const { backupProvider } = backupsStore(state => ({
-    backupProvider: state.backupProvider,
-  }));
+  const backupProvider = backupsStore(state => state.backupProvider);
 
   const inputRef = useRef<TextInput>(null);
 

--- a/src/react-native-cool-modals/Portal.tsx
+++ b/src/react-native-cool-modals/Portal.tsx
@@ -10,11 +10,8 @@ const Wrapper = IS_IOS ? ({ children }: { children: React.ReactNode }) => childr
 
 export function Portal() {
   const activeRoute = useActiveRoute();
-
-  const { blockTouches, Component } = walletLoadingStore(state => ({
-    blockTouches: state.blockTouches,
-    Component: state.Component,
-  }));
+  const blockTouches = walletLoadingStore(state => state.blockTouches);
+  const Component = walletLoadingStore(state => state.Component);
 
   if (!Component || (activeRoute === Routes.PIN_AUTHENTICATION_SCREEN && !IS_IOS)) {
     return null;

--- a/src/screens/SettingsSheet/components/Backups/ViewCloudBackups.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewCloudBackups.tsx
@@ -34,11 +34,9 @@ const ViewCloudBackups = () => {
   const { navigate } = useNavigation();
 
   const { colors } = useTheme();
-  const { status, backups, mostRecentBackup } = backupsStore(state => ({
-    status: state.status,
-    backups: state.backups,
-    mostRecentBackup: state.mostRecentBackup,
-  }));
+  const status = backupsStore(state => state.status);
+  const backups = backupsStore(state => state.backups);
+  const mostRecentBackup = backupsStore(state => state.mostRecentBackup);
 
   const onSelectCloudBackup = useCallback(
     async (selectedBackup: BackupFile) => {

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
@@ -119,11 +119,10 @@ const ViewWalletBackup = () => {
   const { params } = useRoute<RouteProp<ViewWalletBackupParams, 'ViewWalletBackup'>>();
 
   const createBackup = useCreateBackup();
-  const { status, backupProvider, mostRecentBackup } = backupsStore(state => ({
-    status: state.status,
-    backupProvider: state.backupProvider,
-    mostRecentBackup: state.mostRecentBackup,
-  }));
+  const status = backupsStore(state => state.status);
+  const backupProvider = backupsStore(state => state.backupProvider);
+  const mostRecentBackup = backupsStore(state => state.mostRecentBackup);
+
   const { walletId, title: incomingTitle } = params;
   const creatingWallet = useRef<boolean>();
   const { isDamaged, wallets } = useWallets();

--- a/src/screens/SettingsSheet/components/Backups/WalletsAndBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/WalletsAndBackup.tsx
@@ -105,12 +105,10 @@ export const WalletsAndBackup = () => {
   const scrollviewRef = useRef<ScrollView>(null);
 
   const createBackup = useCreateBackup();
-  const { status, backupProvider, backups, mostRecentBackup } = backupsStore(state => ({
-    status: state.status,
-    backupProvider: state.backupProvider,
-    backups: state.backups,
-    mostRecentBackup: state.mostRecentBackup,
-  }));
+  const status = backupsStore(state => state.status);
+  const backupProvider = backupsStore(state => state.backupProvider);
+  const backups = backupsStore(state => state.backups);
+  const mostRecentBackup = backupsStore(state => state.mostRecentBackup);
 
   const initializeWallet = useInitializeWallet();
 

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -68,10 +68,8 @@ const SettingsSection = ({
   const isLanguageSelectionEnabled = useExperimentalFlag(LANGUAGE_SETTINGS);
   const isNotificationsEnabled = useExperimentalFlag(NOTIFICATIONS);
 
-  const { backupProvider, backups } = backupsStore(state => ({
-    backupProvider: state.backupProvider,
-    backups: state.backups,
-  }));
+  const backupProvider = backupsStore(state => state.backupProvider);
+  const backups = backupsStore(state => state.backups);
 
   const { isDarkMode, setTheme, colorScheme } = useTheme();
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Small changes to a few Zustand store selectors that were constructing objects but not using shallowEqual.

## Screen recordings / screenshots
n/a

## What to test
n/a really?
