### PR TITLE
fix: codified android app link intent filter matching

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,13 +62,51 @@
           <category android:name="android.intent.category.BROWSABLE" />
           <data android:scheme="https" />
           <data android:host="rnbwapp.com" />
-          <data android:host="rainbow-web.vercel.app" />
-          <data android:host="rainbow.me" />
           <data android:host="rnbw.app" />
           <data android:host="rainbowdotme.app.link" />
           <data android:host="rnbwappdotcom.app.link" />
           <data android:host="rainbowdotme-alternate.app.link" />
           <data android:host="rnbwappdotcom-alternate.app.link" />
+        </intent-filter>
+        <!-- Rainbow.me URI Scheme -->
+        <intent-filter android:autoVerify="true">
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="https" android:host="rainbow.me" />
+          <!-- ENS Profiles -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPrefix="/0x" />
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/.*\\.eth" />
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/.*\\.xyz" />
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/.*\\.crypto" />
+          <!-- /token?addr=… -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/token\\?addr=.*" />
+          <!-- /token/<network>/<address> -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/token/.+/.+" />
+          <!-- WalletConnect redirect: /wc?uri=… -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/wc\\?uri=.*" />
+          <!-- Plaid OAuth redirect -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPrefix="/plaid/" />
+          <!-- Fiat-on-ramp redirect -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPrefix="/f2c/" />
+          <!-- POAP sheet -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPrefix="/poap/" />
+          <!-- Points referral link: /points?ref=XXXXXX  (exactly six chars) -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathAdvancedPattern="/points\\?ref=[A-Za-z0-9]{6}" />
+          <!-- Points claim link: /points/claim?code=… -->
+          <data android:scheme="https" android:host="rainbow.me"
+                android:pathPattern="/points/claim\\?code=.*" />
         </intent-filter>
         <intent-filter>
           <data android:scheme="ethereum" />


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- Fixed `rainbow.me/points` app link capture on Android
- This change mirrors the behavior of the iOS AASA file, but sadly cannot be amended remotely. Historically we've treated all rainbow.me links as app links and would capture all new routes as a redirect and inadvertently block web access to rainbow.me paths on Android; now we'll need to be considerate and add routes with releases.

## Screen recordings / screenshots


## What to test

