### PR TITLE
Add clearKeychain for Maestro tests

### DIFF
--- a/e2e/onboarding/CreateWallet.yaml
+++ b/e2e/onboarding/CreateWallet.yaml
@@ -3,8 +3,9 @@ tags:
   - auth
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml

--- a/e2e/onboarding/WatchedWallet.yaml
+++ b/e2e/onboarding/WatchedWallet.yaml
@@ -3,8 +3,9 @@ tags:
   - wallet
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml

--- a/e2e/screens/Discover.yaml
+++ b/e2e/screens/Discover.yaml
@@ -3,8 +3,9 @@ tags:
   - discover
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml

--- a/e2e/screens/Home.yaml
+++ b/e2e/screens/Home.yaml
@@ -3,8 +3,9 @@ tags:
   - home
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml
@@ -36,4 +37,4 @@ tags:
 - tapOn:
     id: paste-address-button
 - assertVisible:
-    text: 'Test Wallet'
+    text: "Test Wallet"

--- a/e2e/screens/MaliciousDappWarning.yaml
+++ b/e2e/screens/MaliciousDappWarning.yaml
@@ -3,8 +3,9 @@ tags:
   - browser
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml
@@ -31,8 +32,8 @@ tags:
       # tap on browser search input
       - tapOn:
           point: 80, 80
-      - assertVisible: 'Find apps and more'
-      - inputText: 'https://test-dap-welps.vercel.app/'
+      - assertVisible: "Find apps and more"
+      - inputText: "https://test-dap-welps.vercel.app/"
 
       # tap on connect button
       - tapOn:
@@ -46,5 +47,5 @@ tags:
       - assertVisible:
           id: malicious-dapp-warning
 
-      - assertVisible: 'Find apps and more'
-      - inputText: 'https://test-dap-welps.vercel.app/'
+      - assertVisible: "Find apps and more"
+      - inputText: "https://test-dap-welps.vercel.app/"

--- a/e2e/transactions/SendTransaction.yaml
+++ b/e2e/transactions/SendTransaction.yaml
@@ -3,8 +3,9 @@ tags:
   - wallet
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml

--- a/e2e/transactions/SwapTransaction.yaml
+++ b/e2e/transactions/SwapTransaction.yaml
@@ -3,8 +3,9 @@ tags:
   - wallet
   - parallel
 ---
-- clearState
 - launchApp:
+    clearState: true
+    clearKeychain: true
     arguments:
       isE2ETest: true
 - runFlow: ../utils/Prepare.yaml


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
On iOS, it is necessary to clear the Keychain for testing purposes to ensure that the state is reset appropriately.

## Screen recordings / screenshots
N/A

## What to test
N/A
