### PR TITLE
Update the Readme to specify the version of Node required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ https://reactnative.dev/docs/getting-started
 
 ### Preflight
 
-1. Run `nvm use` to force Node.js 18.
+1. Run `nvm use` to force Node.js v18.
 
 2. Set up your .env file, use our env.example as a guide.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### General
 
-- Install NVM or Node.js 16: https://github.com/creationix/nvm
+- Install NVM or Node.js 18: https://github.com/creationix/nvm
 - Install all project dependencies with `yarn setup`
 
 ### MacOS
@@ -64,7 +64,7 @@ https://reactnative.dev/docs/getting-started
 
 ### Preflight
 
-1. Run `nvm use` to force Node.js v16.
+1. Run `nvm use` to force Node.js 18.
 
 2. Set up your .env file, use our env.example as a guide.
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
In the `.nvmrc` file, we use version 18, whereas the Readme document still indicates version 16.

## Screen recordings / screenshots
N/A

## What to test
N/A
