### PR TITLE
Add tracking for wallet screen pull to refresh 

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -302,6 +302,9 @@ export const event = {
 
   // app store review
   appStoreReviewPrompted: 'app_store_review.prompted',
+
+  // refresh account data
+  refreshAccountData: 'refresh_account_data',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -1084,5 +1087,8 @@ export type EventProperties = {
   [event.appStoreReviewPrompted]: {
     action: string;
     promptCount: number;
+  };
+  [event.refreshAccountData]: {
+    duration: number;
   };
 };


### PR DESCRIPTION
Fixes APP-2589

## What changed (plus any additional context for devs)
- Adds analytic for pull to refresh 
- Moves some of the fetches to the awaited `Promise.all` so that the pull to refresh activity indicator exiting more accurately reflects the refresh completion. 

## Screen recordings / screenshots

## What to test
