### PR TITLE
Fix error when creating wallet

### DIFF
--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -40,7 +40,6 @@ export const EthCard = () => {
   });
 
   const ethAsset = useMemo(() => {
-    if (!externalEthAsset) return undefined;
     return {
       ...(externalEthAsset || {}),
       address: ETH_ADDRESS,
@@ -76,7 +75,6 @@ export const EthCard = () => {
   );
 
   const handleAssetPress = useCallback(() => {
-    if (!ethAsset) return;
     navigate(Routes.EXPANDED_ASSET_SHEET_V2, {
       asset: ethAsset,
       address: ETH_ADDRESS,
@@ -110,14 +108,14 @@ export const EthCard = () => {
   const CHART_HEIGHT = 80;
 
   let isNegativePriceChange = false;
-  if (ethAsset?.native?.change[0] === '-') {
+  if (ethAsset.native?.change[0] === '-') {
     isNegativePriceChange = true;
   }
-  const priceChangeDisplay = isNegativePriceChange ? ethAsset?.native?.change.substring(1) : ethAsset?.native?.change;
+  const priceChangeDisplay = isNegativePriceChange ? ethAsset.native?.change.substring(1) : ethAsset.native?.change;
 
   const priceChangeColor = isNegativePriceChange ? colors.red : colors.green;
 
-  const loadedPrice = accentColorLoaded && ethAsset?.native?.change;
+  const loadedPrice = accentColorLoaded && ethAsset.native?.change;
   const loadedChart = throttledData?.points.length && loadedPrice;
 
   const [noChartData, setNoChartData] = useState(false);
@@ -159,7 +157,7 @@ export const EthCard = () => {
                   <>
                     <ChainImage chainId={ChainId.mainnet} position="relative" size={20} />
                     <Text size="17pt" color={{ custom: colorForAsset }} weight="heavy">
-                      {ethAsset?.name}
+                      {ethAsset.name}
                     </Text>
                   </>
                 )}
@@ -195,7 +193,7 @@ export const EthCard = () => {
             </Box>
           ) : (
             <Text size="26pt" color={{ custom: colorForAsset }} weight="heavy">
-              {ethAsset?.native?.price.display}
+              {ethAsset.native?.price.display}
             </Text>
           )}
         </Stack>

--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -21,7 +21,7 @@ import { useRoute } from '@react-navigation/native';
 import * as i18n from '@/languages';
 import { ButtonPressAnimationTouchEvent } from '@/components/animations/ButtonPressAnimation/types';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
-import { useExternalToken } from '@/resources/assets/externalAssetsQuery';
+import { FormattedExternalAsset, useExternalToken } from '@/resources/assets/externalAssetsQuery';
 import assetTypes from '@/entities/assetTypes';
 import { Network, ChainId } from '@/state/backendNetworks/types';
 import { getUniqueId } from '@/utils/ethereumUtils';
@@ -75,8 +75,9 @@ export const EthCard = () => {
   );
 
   const handleAssetPress = useCallback(() => {
+    if (ethAsset.native == null) return;
     navigate(Routes.EXPANDED_ASSET_SHEET_V2, {
-      asset: ethAsset,
+      asset: ethAsset as FormattedExternalAsset,
       address: ETH_ADDRESS,
       chainId: ChainId.mainnet,
     });


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

This fixes an error that happens when transitioning from having no wallet to having a wallet (create or import). It is a regression from https://github.com/rainbow-me/rainbow/commit/a8e41768f8a7fb9eeab95898b25ceea9ae717941#diff-67e8a63e75cf95c7772f41b5c98ea2e4952fd074e00fa7996d4a84d7b48e7cff.  If `ethAsset` is undefined then it will crash in `useChartThrottledPoints`. This bring back the previous behaviour of making it so `ethAsset` can never be undefined.

```
 ERROR  TypeError: Cannot read property 'address' of undefined

This error is located at:
    in EthCard (created by ViewRenderer)
    in RCTView (created by View)
```

## Screen recordings / screenshots

Before

https://github.com/user-attachments/assets/86e852db-cb0c-4d95-84c9-3fc544af4904

After

https://github.com/user-attachments/assets/d7ccffba-8e61-47cc-9539-45cf254c6ddb

## What to test

Reset the app and create a new wallet.

Test that e2e tests now pass.