### PR TITLE
Fix MarketStatsCard hooks error

### DIFF
--- a/src/screens/expandedAssetSheet/components/sections/marketSection/MarketStatsCard.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/marketSection/MarketStatsCard.tsx
@@ -14,7 +14,7 @@ import { GestureHandlerButton } from '@/__swaps__/screens/Swap/components/Gestur
 import { colors } from '@/styles';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { abbreviateNumberWorklet } from '@/helpers/utilities';
-import { TimeFrames, useTokenMarketStats } from '@/resources/metadata/tokenStats';
+import { MarketStats, TimeFrames, useTokenMarketStats } from '@/resources/metadata/tokenStats';
 
 const TIMEFRAME_SWITCH_CONFIG = TIMING_CONFIGS.buttonPressConfig;
 
@@ -166,12 +166,8 @@ const TimeframeItem = memo(function TimeframeItem({
   );
 });
 
-export const MarketStatsCard = memo(function MarketStatsCard() {
-  const { accentColors, basicAsset: asset } = useExpandedAssetSheetContext();
-
-  const { data: marketData } = useTokenMarketStats({ chainID: asset.chainId, address: asset.address });
-
-  if (!marketData || Object.keys(marketData).length === 0) return null;
+const MarketStatsCardContent = memo(function MarketStatsCardContent({ marketData }: { marketData: Record<string, MarketStats> }) {
+  const { accentColors } = useExpandedAssetSheetContext();
 
   const defaultTimeframe = Object.keys(marketData)[Object.keys(marketData).length - 1];
   const selectedTimeframe = useSharedValue(defaultTimeframe);
@@ -337,4 +333,13 @@ export const MarketStatsCard = memo(function MarketStatsCard() {
       </Box>
     </Box>
   );
+});
+
+export const MarketStatsCard = memo(function MarketStatsCard() {
+  const { basicAsset: asset } = useExpandedAssetSheetContext();
+  const { data: marketData } = useTokenMarketStats({ chainID: asset.chainId, address: asset.address });
+
+  if (!marketData || Object.keys(marketData).length === 0) return null;
+
+  return <MarketStatsCardContent marketData={marketData} />;
 });

--- a/src/screens/expandedAssetSheet/components/sections/marketSection/MarketStatsCard.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/marketSection/MarketStatsCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import React, { memo } from 'react';
 import { Box, Inline, Stack, Text, AnimatedText, useForegroundColor } from '@/design-system';
 import { useExpandedAssetSheetContext } from '@/screens/expandedAssetSheet/context/ExpandedAssetSheetContext';


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I found a bug that caused e2e tests to fail, it happens when opening an asset page. The MarketStats component had an early return that caused number of hooks to change so react errors. This splits the component into 2 so we can early return properly.

## Screen recordings / screenshots

N/A

## What to test

Open asset screen