### PR TITLE
tests for import secret and basic settings flows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,12 @@ module.exports = {
     {
       files: ['*.yml', '*.yaml'],
       parser: 'yaml-eslint-parser',
+      rules: {
+        // currently we use single quotes for yaml files
+        'yml/quotes': ['warn', { prefer: 'single', avoidEscape: false }],
+        // we also put scalars in quotes
+        'yml/plain-scalar': 'off',
+      },
     },
   ],
   rules: {

--- a/e2e/dapp-connections/WalletConnect.yaml
+++ b/e2e/dapp-connections/WalletConnect.yaml
@@ -6,73 +6,72 @@ tags:
 - retry:
     maxRetries: 3
     commands:
-        - clearState
-        - launchApp:
-            clearState: true
-            clearKeychain: true
-            arguments:
-            isE2ETest: true
-        - runFlow: ../utils/Prepare.yaml
-        - runFlow: ../utils/ImportWalletWithKey.yaml
+      - launchApp:
+          clearState: true
+          clearKeychain: true
+          arguments:
+          isE2ETest: true
+      - runFlow: ../utils/Prepare.yaml
+      - runFlow: ../utils/ImportWalletWithKey.yaml
 
-        # Navigate to browser
-        - tapOn:
-            id: 'tab-bar-icon-DappBrowserScreen'
+      # Navigate to browser
+      - tapOn:
+          id: 'tab-bar-icon-DappBrowserScreen'
 
-        # connect to bx-test-dapp
-        - tapOn:
-            text: '.*Search or enter website.*'
-        - assertVisible: 'Find apps and more'
-        - inputText: 'https://bx-test-dapp.vercel.app/'
-        - pressKey: 'Enter'
-        # tap on wallet pfp to open the control panel
-        - tapOn:
-            id: account-icon
-        - tapOn:
-            id: connect-button
-        # control panel assertions
-        - assertVisible:
-            text: '.*BX Test Dapp.*'
-        - assertVisible:
-            text: 'Disconnect'
-        # tap somewhere arbitrary to close the control panel sheet
-        - tapOn:
-            point: 550, 1000
+      # connect to bx-test-dapp
+      - tapOn:
+          text: '.*Search or enter website.*'
+      - assertVisible: 'Find apps and more'
+      - inputText: 'https://bx-test-dapp.vercel.app/'
+      - pressKey: 'Enter'
+      # tap on wallet pfp to open the control panel
+      - tapOn:
+          id: account-icon
+      - tapOn:
+          id: connect-button
+      # control panel assertions
+      - assertVisible:
+          text: '.*BX Test Dapp.*'
+      - assertVisible:
+          text: 'Disconnect'
+      # tap somewhere arbitrary to close the control panel sheet
+      - tapOn:
+          point: 550, 1000
 
-        # eth_signMessage
-        # tap on send button to initiate a eth_signTransaction
-        - tapOn:
-            id: signTypedData
-        # sign transaction assertions
-        - assertVisible:
-            text: 'Message Request'
-        - assertVisible:
-            text: '.*Simulated Result.*'
-        - assertVisible:
-            text: '.*Confirm.*'
-        # sign transaction
-        - longPressOn:
-            id: sign-transaction-action-button
-        - runFlow: ../utils/MaybeSetupPin.yaml
-        # assert that the typed message data signature is visible
-        - assertVisible:
-            text: '.*typed message data sig.*'
+      # eth_signMessage
+      # tap on send button to initiate a eth_signTransaction
+      - tapOn:
+          id: signTypedData
+      # sign transaction assertions
+      - assertVisible:
+          text: 'Message Request'
+      - assertVisible:
+          text: '.*Simulated Result.*'
+      - assertVisible:
+          text: '.*Confirm.*'
+      # sign transaction
+      - longPressOn:
+          id: sign-transaction-action-button
+      - runFlow: ../utils/MaybeSetupPin.yaml
+      # assert that the typed message data signature is visible
+      - assertVisible:
+          text: '.*typed message data sig.*'
 
-        # eth_signTransaction
-        # tap on send button to initiate a eth_signTypedData
-        - tapOn:
-            id: signTx
-        # sign transaction assertions
-        - assertVisible:
-            text: 'Message Request'
-        - assertVisible:
-            text: '.*rainbow rocks.*'
-        - assertVisible:
-            text: '.*Confirm.*'
-        # sign transaction
-        - longPressOn:
-            id: sign-transaction-action-button
-        - runFlow: ../utils/MaybeSetupPin.yaml
-        # assert that the signed message data signature is visible
-        - assertVisible:
-            text: '.*sign message data sig.*'
+      # eth_signTransaction
+      # tap on send button to initiate a eth_signTypedData
+      - tapOn:
+          id: signTx
+      # sign transaction assertions
+      - assertVisible:
+          text: 'Message Request'
+      - assertVisible:
+          text: '.*rainbow rocks.*'
+      - assertVisible:
+          text: '.*Confirm.*'
+      # sign transaction
+      - longPressOn:
+          id: sign-transaction-action-button
+      - runFlow: ../utils/MaybeSetupPin.yaml
+      # assert that the signed message data signature is visible
+      - assertVisible:
+          text: '.*sign message data sig.*'

--- a/e2e/dapp-connections/WalletConnect.yaml
+++ b/e2e/dapp-connections/WalletConnect.yaml
@@ -1,0 +1,78 @@
+appId: ${APP_ID}
+tags:
+  - browser
+  - parallel
+---
+- retry:
+    maxRetries: 3
+    commands:
+        - clearState
+        - launchApp:
+            clearState: true
+            clearKeychain: true
+            arguments:
+            isE2ETest: true
+        - runFlow: ../utils/Prepare.yaml
+        - runFlow: ../utils/ImportWalletWithKey.yaml
+
+        # Navigate to browser
+        - tapOn:
+            id: 'tab-bar-icon-DappBrowserScreen'
+
+        # connect to bx-test-dapp
+        - tapOn:
+            text: '.*Search or enter website.*'
+        - assertVisible: 'Find apps and more'
+        - inputText: 'https://bx-test-dapp.vercel.app/'
+        - pressKey: 'Enter'
+        # tap on wallet pfp to open the control panel
+        - tapOn:
+            id: account-icon
+        - tapOn:
+            id: connect-button
+        # control panel assertions
+        - assertVisible:
+            text: '.*BX Test Dapp.*'
+        - assertVisible:
+            text: 'Disconnect'
+        # tap somewhere arbitrary to close the control panel sheet
+        - tapOn:
+            point: 550, 1000
+
+        # eth_signMessage
+        # tap on send button to initiate a eth_signTransaction
+        - tapOn:
+            id: signTypedData
+        # sign transaction assertions
+        - assertVisible:
+            text: 'Message Request'
+        - assertVisible:
+            text: '.*Simulated Result.*'
+        - assertVisible:
+            text: '.*Confirm.*'
+        # sign transaction
+        - longPressOn:
+            id: sign-transaction-action-button
+        - runFlow: ../utils/MaybeSetupPin.yaml
+        # assert that the typed message data signature is visible
+        - assertVisible:
+            text: '.*typed message data sig.*'
+
+        # eth_signTransaction
+        # tap on send button to initiate a eth_signTypedData
+        - tapOn:
+            id: signTx
+        # sign transaction assertions
+        - assertVisible:
+            text: 'Message Request'
+        - assertVisible:
+            text: '.*rainbow rocks.*'
+        - assertVisible:
+            text: '.*Confirm.*'
+        # sign transaction
+        - longPressOn:
+            id: sign-transaction-action-button
+        - runFlow: ../utils/MaybeSetupPin.yaml
+        # assert that the signed message data signature is visible
+        - assertVisible:
+            text: '.*sign message data sig.*'

--- a/e2e/dapp-connections/WalletConnect.yaml
+++ b/e2e/dapp-connections/WalletConnect.yaml
@@ -10,7 +10,7 @@ tags:
           clearState: true
           clearKeychain: true
           arguments:
-          isE2ETest: true
+            isE2ETest: true
       - runFlow: ../utils/Prepare.yaml
       - runFlow: ../utils/ImportWalletWithKey.yaml
 

--- a/e2e/onboarding/SecretPhraseWallet.yaml
+++ b/e2e/onboarding/SecretPhraseWallet.yaml
@@ -1,0 +1,16 @@
+appId: ${APP_ID}
+tags:
+  - auth
+  - parallel
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - clearState
+      - launchApp:
+          clearState: true
+          clearKeychain: true
+          arguments:
+            isE2ETest: true
+      - runFlow: ../utils/Prepare.yaml
+      - runFlow: ../utils/ImportSecretPhrase.yaml

--- a/e2e/onboarding/SecretPhraseWallet.yaml
+++ b/e2e/onboarding/SecretPhraseWallet.yaml
@@ -6,7 +6,6 @@ tags:
 - retry:
     maxRetries: 3
     commands:
-      - clearState
       - launchApp:
           clearState: true
           clearKeychain: true

--- a/e2e/settings/SettingsFlows.yaml
+++ b/e2e/settings/SettingsFlows.yaml
@@ -24,7 +24,7 @@ tags:
       # Change currency to euros and validate
       - tapOn:
           id: currency-section
-      - tapOn: 'Euro'
+      - tapOn: '.*Euro'
       - tapOn: 'Done'
       - assertVisible:
           text: '.*€.*'
@@ -36,12 +36,12 @@ tags:
             - tapOn: 'Settings'
       # Change theme to dark and validate
       - assertVisible:
-          id: theme-section-light
+          id: choose-theme-section-light
       - tapOn:
-          id: choose-theme-section
+          id: choose-theme-section.*
       - tapOn: 'Dark'
       - assertVisible:
-          id: theme-section-dark
+          id: choose-theme-section-dark
       # Open diagnostics
       - scrollUntilVisible:
           element:

--- a/e2e/settings/SettingsFlows.yaml
+++ b/e2e/settings/SettingsFlows.yaml
@@ -45,7 +45,7 @@ tags:
       # Open diagnostics
       - scrollUntilVisible:
           element:
-          id: app-version-stamp
+            id: app-version-stamp
           direction: DOWN
       # TODO: fix. Currently passing on local but failing on CI.
       # - tapOn:

--- a/e2e/settings/SettingsFlows.yaml
+++ b/e2e/settings/SettingsFlows.yaml
@@ -6,50 +6,50 @@ tags:
 - retry:
     maxRetries: 3
     commands:
-        - launchApp:
-            clearState: true
-            clearKeychain: true
-            arguments:
-            isE2ETest: true
-        - runFlow: ../utils/Prepare.yaml
-        - runFlow: ../utils/ImportWalletWithKey.yaml
+      - launchApp:
+          clearState: true
+          clearKeychain: true
+          arguments:
+          isE2ETest: true
+      - runFlow: ../utils/Prepare.yaml
+      - runFlow: ../utils/ImportWalletWithKey.yaml
 
-        # Navigate to settings
-        - retry:
-            maxRetries: 3
-            commands:
+      # Navigate to settings
+      - retry:
+          maxRetries: 3
+          commands:
             - tapOn:
                 id: settings-menu
             - tapOn: 'Settings'
-        # Change currency to euros and validate
-        - tapOn:
-            id: currency-section
-        - tapOn: 'Euro'
-        - tapOn: 'Done'
-        - assertVisible:
-            text: '.*€.*'
-        - retry:
-            maxRetries: 3
-            commands:
+      # Change currency to euros and validate
+      - tapOn:
+          id: currency-section
+      - tapOn: 'Euro'
+      - tapOn: 'Done'
+      - assertVisible:
+          text: '.*€.*'
+      - retry:
+          maxRetries: 3
+          commands:
             - tapOn:
                 id: settings-menu
             - tapOn: 'Settings'
-        # Change theme to dark and validate
-        - assertVisible:
-            id: theme-section-light
-        - tapOn:
-            id: choose-theme-section
-        - tapOn: 'Dark'
-        - assertVisible:
-            id: theme-section-dark
-        # Open diagnostics
-        - scrollUntilVisible:
-            element:
-            id: app-version-stamp
-            direction: DOWN
-        # TODO: fix. Currently passing on local but failing on CI.
-        # - tapOn:
-        #     id: app-version-stamp
-        #     repeat: 15
-        #     delay: 500
-        # - assertVisible: 'Diagnostics'
+      # Change theme to dark and validate
+      - assertVisible:
+          id: theme-section-light
+      - tapOn:
+          id: choose-theme-section
+      - tapOn: 'Dark'
+      - assertVisible:
+          id: theme-section-dark
+      # Open diagnostics
+      - scrollUntilVisible:
+          element:
+          id: app-version-stamp
+          direction: DOWN
+      # TODO: fix. Currently passing on local but failing on CI.
+      # - tapOn:
+      #     id: app-version-stamp
+      #     repeat: 15
+      #     delay: 500
+      # - assertVisible: 'Diagnostics'

--- a/e2e/settings/SettingsFlows.yaml
+++ b/e2e/settings/SettingsFlows.yaml
@@ -1,0 +1,55 @@
+appId: ${APP_ID}
+tags:
+  - backup
+  - parallel
+---
+- retry:
+    maxRetries: 3
+    commands:
+        - launchApp:
+            clearState: true
+            clearKeychain: true
+            arguments:
+            isE2ETest: true
+        - runFlow: ../utils/Prepare.yaml
+        - runFlow: ../utils/ImportWalletWithKey.yaml
+
+        # Navigate to settings
+        - retry:
+            maxRetries: 3
+            commands:
+            - tapOn:
+                id: settings-menu
+            - tapOn: 'Settings'
+        # Change currency to euros and validate
+        - tapOn:
+            id: currency-section
+        - tapOn: 'Euro'
+        - tapOn: 'Done'
+        - assertVisible:
+            text: '.*€.*'
+        - retry:
+            maxRetries: 3
+            commands:
+            - tapOn:
+                id: settings-menu
+            - tapOn: 'Settings'
+        # Change theme to dark and validate
+        - assertVisible:
+            id: theme-section-light
+        - tapOn:
+            id: choose-theme-section
+        - tapOn: 'Dark'
+        - assertVisible:
+            id: theme-section-dark
+        # Open diagnostics
+        - scrollUntilVisible:
+            element:
+            id: app-version-stamp
+            direction: DOWN
+        # TODO: fix. Currently passing on local but failing on CI.
+        # - tapOn:
+        #     id: app-version-stamp
+        #     repeat: 15
+        #     delay: 500
+        # - assertVisible: 'Diagnostics'

--- a/e2e/settings/SettingsFlows.yaml
+++ b/e2e/settings/SettingsFlows.yaml
@@ -10,7 +10,7 @@ tags:
           clearState: true
           clearKeychain: true
           arguments:
-          isE2ETest: true
+            isE2ETest: true
       - runFlow: ../utils/Prepare.yaml
       - runFlow: ../utils/ImportWalletWithKey.yaml
 

--- a/e2e/utils/ImportSecretPhrase.yaml
+++ b/e2e/utils/ImportSecretPhrase.yaml
@@ -1,0 +1,29 @@
+appId: ${APP_ID}
+env:
+  # empty publicly known wallet
+  SECRET_PHRASE: test test test test test test test test test test junk junk
+  NAME: 'Secret Phrase Wallet'
+---
+# This is usually ran as the first command so make sure it has enough time to load the app.
+- extendedWaitUntil:
+    visible:
+      id: welcome-screen
+    timeout: 30000
+- openLink: rainbow://e2e/import?privateKey=${SECRET_PHRASE}&name=${NAME}
+# The first time a simulator opens a link it shows a dialog.
+- runFlow:
+    when:
+      visible: 'Open in .*'
+      platform: iOS
+    commands:
+      - tapOn: 'Open'
+# Secret phrase wallets can take longer to load
+- extendedWaitUntil:
+    visible:
+      id: wallet-screen
+    timeout: 30000
+# Wait for the wallet screen to load.
+- extendedWaitUntil:
+    visible:
+      id: receive-card
+    timeout: 30000

--- a/src/components/AppVersionStamp.tsx
+++ b/src/components/AppVersionStamp.tsx
@@ -36,7 +36,7 @@ export function AppVersionStamp() {
   }, [navigate, numberOfTaps, startTimeout, stopTimeout]);
 
   return (
-    <StyledButton hitSlop={10} onPress={handleVersionPress}>
+    <StyledButton testID="app-version-stamp" hitSlop={10} onPress={handleVersionPress}>
       <Text color="secondary30 (Deprecated)" size="14px / 19px (Deprecated)" weight="bold">
         {appVersion}
       </Text>

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -211,6 +211,7 @@ const SettingsSection = ({
           menuAlignmentOverride="right"
           onPressMenuItem={handleSelectTheme}
           useActionSheetFallback={false}
+          testID="choose-theme-section"
         >
           <MenuItem
             hasChevron

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -211,14 +211,13 @@ const SettingsSection = ({
           menuAlignmentOverride="right"
           onPressMenuItem={handleSelectTheme}
           useActionSheetFallback={false}
-          testID="choose-theme-section"
+          testID={`choose-theme-section-${isDarkMode ? 'dark' : 'light'}`}
         >
           <MenuItem
             hasChevron
             leftComponent={<MenuItem.ImageIcon source={isDarkMode ? DarkModeIconDark : DarkModeIcon} />}
             rightComponent={<MenuItem.Selection>{colorScheme ? capitalize(colorScheme) : ''}</MenuItem.Selection>}
             size={60}
-            testID={`theme-section-${isDarkMode ? 'dark' : 'light'}`}
             titleComponent={<MenuItem.Title text={lang.t(lang.l.settings.theme)} />}
           />
         </ContextMenuButton>

--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -725,6 +725,7 @@ export const SignTransactionSheet = () => {
                     weight="bold"
                   />
                   <SheetActionButton
+                    testID="sign-transaction"
                     label={primaryActionButtonLabel}
                     newShadows
                     onPress={submitFn}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- This is part of expanding maestro to cover more of the critical path 
- This PR covers Secret Phrase importing and Settings flows
- Settings flow covers currency, theme, and diagnostics
- We have a separate settings test that covers Manual Backups

also included a change to our pre-commit for yaml files to match the styles we have been using.

## What to test
- Do they pass?