### PR TITLE
Don't run sentry gradle plugin for debug builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,6 +40,7 @@ if (!isE2E) {
     apply plugin: "io.sentry.android.gradle"
 
     sentry {
+        ignoredBuildTypes = ["debug"]
         // Enables or disables the automatic configuration of Native Symbols
         // for Sentry. This executes sentry-cli automatically so
         // you don't need to do it manually.


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

This causes dev builds to fail since I do not have access to the sentry org. We don't need to run it for debug builds.

## Screen recordings / screenshots

N/A

## What to test

N/A