### PR TITLE
Fix keychain biometric prompts on Android

### DIFF
--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -324,8 +324,9 @@ export async function clear() {
  * Wrapper around the underlying library's method by the same name.
  */
 export async function getSupportedBiometryType(): Promise<BIOMETRY_TYPE | undefined> {
-  logger.debug(`[keychain]: getSupportedBiometryType`, {}, logger.DebugContext.keychain);
-  return (await originalGetSupportedBiometryType()) || undefined;
+  const result = (await originalGetSupportedBiometryType()) || undefined;
+  logger.debug(`[keychain]: getSupportedBiometryType result: ${result}`, {}, logger.DebugContext.keychain);
+  return result;
 }
 
 /**

--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -15,6 +15,7 @@ import {
   SharedWebCredentials,
   SetOptions,
   GetOptions,
+  STORAGE_TYPE,
 } from 'react-native-keychain';
 import { MMKV } from 'react-native-mmkv';
 
@@ -379,5 +380,6 @@ export async function getPrivateAccessControlOptions(): Promise<SetOptions> {
   return {
     accessControl: ios ? ACCESS_CONTROL.USER_PRESENCE : ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE,
     accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    storage: STORAGE_TYPE.RSA,
   };
 }


### PR DESCRIPTION
Fixes APP-2622

## What changed (plus any additional context for devs)

When upgrading `react-native-keychain` to v9 it now uses instead `BLOCK_MODE_GCM` of `BLOCK_MODE_ECB` which supports biometrics authentication. This means that it will prompt for biometrics when trying to encrypt or decrypt values. 

The issue is that when restoring multiple wallets from a backup it executes many operations requiring encryption in a row and it seems like pixel device rate limit how often the prompt can be shown and the encryption key generated is only valid for 5 seconds because of the config in react-native-keychain. This means that sometimes the generated key is expired, but the system will not allow showing a biometrics prompt yet.

To fix this we can increase the validity of the key to 5 minutes to reduce the number of prompts, and I think this still keeps good safety, while avoiding to spam the user.

Another alternative would be to force using an encryption method without biometrics prompt, but this is better in my opinion.

## Screen recordings / screenshots

Tested by @ibrahimtaveras00 on Pixel device where the issue happened.

https://github.com/user-attachments/assets/85a45582-e30d-4277-b1ae-06d3441f75af


## What to test

Restore a wallet from backup as described in the notion document.