### PR TITLE
Cleanup walletStore damaged + readOnly checks

### DIFF
--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -6,7 +6,7 @@ import { useDimensions } from '@/hooks';
 import Routes from '@/navigation/routesNames';
 import ShadowStack from '@/react-native-shadow-stack';
 import { Network } from '@/state/backendNetworks/types';
-import { useAccountAddress, useIsDamagedWallet } from '@/state/wallets/walletsStore';
+import { getIsDamagedWallet, useAccountAddress } from '@/state/wallets/walletsStore';
 import styled from '@/styled-thing';
 import { padding, position } from '@/styles';
 import { openInBrowser } from '@/utils/openInBrowser';
@@ -175,14 +175,13 @@ const AddFundsInterstitial = ({ network }) => {
   const onAddFromFaucet = accountAddress => openInBrowser(`https://faucet.paradigm.xyz/?addr=${accountAddress}`);
   const { isSmallPhone } = useDimensions();
   const { navigate } = useNavigation();
-  const isDamaged = useIsDamagedWallet();
   const accountAddress = useAccountAddress();
   const { colors } = useTheme();
   const { name: routeName } = useRoute();
 
   const handlePressAmount = useCallback(
     amount => {
-      if (isDamaged) {
+      if (getIsDamagedWallet()) {
         showWalletErrorAlert();
         captureMessage('Damaged wallet preventing add cash');
         return;
@@ -199,7 +198,7 @@ const AddFundsInterstitial = ({ network }) => {
         routeName,
       });
     },
-    [isDamaged, navigate, routeName]
+    [navigate, routeName]
   );
 
   const addFundsToAccountAddress = useCallback(() => onAddFromFaucet(accountAddress), [accountAddress]);

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -6,7 +6,7 @@ import { useDimensions } from '@/hooks';
 import Routes from '@/navigation/routesNames';
 import ShadowStack from '@/react-native-shadow-stack';
 import { Network } from '@/state/backendNetworks/types';
-import { useAccountAddress, useWalletsStore } from '@/state/wallets/walletsStore';
+import { useAccountAddress, useIsDamagedWallet } from '@/state/wallets/walletsStore';
 import styled from '@/styled-thing';
 import { padding, position } from '@/styles';
 import { openInBrowser } from '@/utils/openInBrowser';
@@ -175,7 +175,7 @@ const AddFundsInterstitial = ({ network }) => {
   const onAddFromFaucet = accountAddress => openInBrowser(`https://faucet.paradigm.xyz/?addr=${accountAddress}`);
   const { isSmallPhone } = useDimensions();
   const { navigate } = useNavigation();
-  const isDamaged = useWalletsStore(state => state.getIsDamaged());
+  const isDamaged = useIsDamagedWallet();
   const accountAddress = useAccountAddress();
   const { colors } = useTheme();
   const { name: routeName } = useRoute();

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -5,7 +5,7 @@ import * as lang from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
-import { useAccountAddress, useIsDamagedWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet, useAccountAddress, useIsDamagedWallet } from '@/state/wallets/walletsStore';
 import { watchingAlert } from '@/utils';
 import { navigateToSwaps } from '@/__swaps__/screens/Swap/navigateToSwaps';
 import { analytics } from '@/analytics';
@@ -162,16 +162,14 @@ function BuyButton() {
 }
 
 function SwapButton() {
-  const isReadOnlyWallet = useIsReadOnlyWallet();
-
   const handlePress = React.useCallback(async () => {
-    if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+    if (!getIsReadOnlyWallet() || enableActionsOnReadOnlyWallet) {
       analytics.track(analytics.event.navigationSwap, { category: 'home screen' });
       navigateToSwaps();
     } else {
       watchingAlert();
     }
-  }, [isReadOnlyWallet]);
+  }, []);
 
   return (
     <ActionButton icon="􀖅" onPress={handlePress} testID="swap-button">
@@ -181,17 +179,15 @@ function SwapButton() {
 }
 
 function SendButton() {
-  const isReadOnlyWallet = useIsReadOnlyWallet();
-
   const handlePress = React.useCallback(() => {
-    if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+    if (!getIsReadOnlyWallet() || enableActionsOnReadOnlyWallet) {
       analytics.track(analytics.event.navigationSend, { category: 'home screen' });
 
       Navigation.handleAction(Routes.SEND_FLOW);
     } else {
       watchingAlert();
     }
-  }, [isReadOnlyWallet]);
+  }, []);
 
   return (
     <ActionButton icon="􀈟" onPress={handlePress} testID="send-button">

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -5,7 +5,7 @@ import * as lang from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
-import { getIsReadOnlyWallet, useAccountAddress, useIsDamagedWallet } from '@/state/wallets/walletsStore';
+import { getIsDamagedWallet, getIsReadOnlyWallet, useAccountAddress } from '@/state/wallets/walletsStore';
 import { watchingAlert } from '@/utils';
 import { navigateToSwaps } from '@/__swaps__/screens/Swap/navigateToSwaps';
 import { analytics } from '@/analytics';
@@ -139,10 +139,8 @@ function ActionButton({
 }
 
 function BuyButton() {
-  const isDamaged = useIsDamagedWallet();
-
   const handlePress = React.useCallback(() => {
-    if (isDamaged) {
+    if (getIsDamagedWallet()) {
       showWalletErrorAlert();
       return;
     }
@@ -150,7 +148,7 @@ function BuyButton() {
     analytics.track(analytics.event.navigationAddCash, { category: 'home screen' });
 
     Navigation.handleAction(Routes.ADD_CASH_SHEET);
-  }, [isDamaged]);
+  }, []);
 
   return (
     <Box>
@@ -199,10 +197,9 @@ function SendButton() {
 export function CopyButton() {
   const [isToastActive, setToastActive] = useRecoilState(addressCopiedToastAtom);
   const accountAddress = useAccountAddress();
-  const isDamaged = useIsDamagedWallet();
 
   const handlePressCopy = React.useCallback(() => {
-    if (isDamaged) {
+    if (getIsDamagedWallet()) {
       showWalletErrorAlert();
       return;
     }
@@ -214,7 +211,7 @@ export function CopyButton() {
       }, 2000);
     }
     Clipboard.setString(accountAddress);
-  }, [accountAddress, isDamaged, isToastActive, setToastActive]);
+  }, [accountAddress, isToastActive, setToastActive]);
 
   return (
     <>

--- a/src/components/cards/ENSCreateProfileCard.tsx
+++ b/src/components/cards/ENSCreateProfileCard.tsx
@@ -10,7 +10,7 @@ import React, { useCallback } from 'react';
 import ENSAvatarGrid from '../../assets/ensAvatarGrid.png';
 import ENSIcon from '../../assets/ensIcon.png';
 import { useNavigation } from '../../navigation/Navigation';
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import ImgixImage from '../images/ImgixImage';
 import { GenericCard, Gradient } from './GenericCard';
 import { ORB_SIZE } from './reusables/IconOrb';
@@ -26,7 +26,6 @@ const GRADIENT: Gradient = {
 
 export const ENSCreateProfileCard = () => {
   const { navigate } = useNavigation();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
   const { width: deviceWidth } = useDimensions();
   const { name: routeName } = useRoute();
   const cardType = 'stretch';
@@ -37,7 +36,7 @@ export const ENSCreateProfileCard = () => {
   const { uniqueDomain } = useAccountENSDomains();
 
   const handlePress = useCallback(() => {
-    if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+    if (!getIsReadOnlyWallet() || enableActionsOnReadOnlyWallet) {
       if (uniqueDomain?.name) {
         prefetchENSAvatar(uniqueDomain.name);
         prefetchENSRecords(uniqueDomain.name);
@@ -52,7 +51,7 @@ export const ENSCreateProfileCard = () => {
     } else {
       watchingAlert();
     }
-  }, [isReadOnlyWallet, navigate, routeName, uniqueDomain?.name]);
+  }, [navigate, routeName, uniqueDomain?.name]);
 
   return (
     <ColorModeProvider value="lightTinted">

--- a/src/components/cards/ENSSearchCard.tsx
+++ b/src/components/cards/ENSSearchCard.tsx
@@ -10,7 +10,7 @@ import { useRoute } from '@react-navigation/native';
 import React, { useEffect } from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useNavigation } from '../../navigation/Navigation';
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { GenericCard, Gradient } from './GenericCard';
 import { IconOrb } from './reusables/IconOrb';
 
@@ -30,7 +30,6 @@ const springConfig = {
 export const ENSSearchCard = () => {
   const { pendingRegistrations } = useENSPendingRegistrations();
   const { navigate } = useNavigation();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
   const { name: routeName } = useRoute();
   const cardType = 'square';
 
@@ -48,7 +47,7 @@ export const ENSSearchCard = () => {
   }, [pendingBadgeProgress, pendingRegistrations?.length]);
 
   const handlePress = () => {
-    if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+    if (!getIsReadOnlyWallet() || enableActionsOnReadOnlyWallet) {
       analytics.track(analytics.event.cardPressed, {
         cardName: 'ENSSearchCard',
         routeName,

--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -15,7 +15,7 @@ import { ChartDot, ChartPath, ChartPathProvider } from '@/react-native-animated-
 import { ETH_ADDRESS } from '@/references';
 import { FormattedExternalAsset, useExternalToken } from '@/resources/assets/externalAssetsQuery';
 import { ChainId, Network } from '@/state/backendNetworks/types';
-import { useIsDamagedWallet } from '@/state/wallets/walletsStore';
+import { getIsDamagedWallet } from '@/state/wallets/walletsStore';
 import { useTheme } from '@/theme';
 import { deviceUtils } from '@/utils';
 import { getUniqueId } from '@/utils/ethereumUtils';
@@ -33,7 +33,6 @@ export const EthCard = () => {
   const { nativeCurrency } = useAccountSettings();
   const { colors, isDarkMode } = useTheme();
   const { navigate } = useNavigation();
-  const isDamaged = useIsDamagedWallet();
   const { data: externalEthAsset } = useExternalToken({
     address: ETH_ADDRESS,
     chainId: ChainId.mainnet,
@@ -60,7 +59,7 @@ export const EthCard = () => {
         e.stopPropagation();
       }
 
-      if (isDamaged) {
+      if (getIsDamagedWallet()) {
         showWalletErrorAlert();
         return;
       }
@@ -72,7 +71,7 @@ export const EthCard = () => {
         routeName,
       });
     },
-    [isDamaged, navigate, routeName]
+    [navigate, routeName]
   );
 
   const handleAssetPress = useCallback(() => {

--- a/src/components/cards/remote-cards/RemoteCardCarousel.tsx
+++ b/src/components/cards/remote-cards/RemoteCardCarousel.tsx
@@ -10,7 +10,7 @@ import { useDimensions } from '@/hooks';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import Routes from '@/navigation/routesNames';
 import { remoteCardsStore } from '@/state/remoteCards/remoteCards';
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { FlashList } from '@shopify/flash-list';
 
 type RenderItemProps = {
@@ -31,7 +31,6 @@ export const RemoteCardCarousel = () => {
   const carouselRef = useRef<FlashList<string>>(null);
   const { name } = useRoute();
   const config = useRemoteConfig();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
   const { width } = useDimensions();
 
   const remoteCardsEnabled = getExperimetalFlag(REMOTE_CARDS) || config.remote_cards_enabled;
@@ -43,7 +42,7 @@ export const RemoteCardCarousel = () => {
     return <RemoteCard id={item} gutterSize={gutterSize} carouselRef={carouselRef} />;
   };
 
-  if (isReadOnlyWallet || IS_TEST || !remoteCardsEnabled || !cardIds.length) {
+  if (getIsReadOnlyWallet() || IS_TEST || !remoteCardsEnabled || !cardIds.length) {
     return null;
   }
 

--- a/src/components/expanded-state/AvailableNetworksv2.tsx
+++ b/src/components/expanded-state/AvailableNetworksv2.tsx
@@ -11,7 +11,7 @@ import { useNavigation } from '@/navigation';
 import { userAssetsStore } from '@/state/assets/userAssets';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { ChainId } from '@/state/backendNetworks/types';
-import { useWalletsStore, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { position } from '@/styles';
 import { useTheme } from '@/theme';
 import { watchingAlert } from '@/utils';
@@ -47,11 +47,10 @@ const AvailableNetworksv2 = ({
   };
 
   const { goBack } = useNavigation();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
 
   const convertAssetAndNavigate = useCallback(
     (chainId: ChainId) => {
-      if (isReadOnlyWallet && !enableActionsOnReadOnlyWallet) {
+      if (getIsReadOnlyWallet() && !enableActionsOnReadOnlyWallet) {
         watchingAlert();
         return;
       }
@@ -110,7 +109,7 @@ const AvailableNetworksv2 = ({
         navigateToSwaps({ inputAsset: null, outputAsset: parsedAsset });
       }
     },
-    [asset, goBack, isReadOnlyWallet, networks]
+    [asset, goBack, networks]
   );
 
   const handlePressContextMenu = useCallback((chainId: string) => convertAssetAndNavigate(+chainId), [convertAssetAndNavigate]);

--- a/src/components/list/ListHeader.js
+++ b/src/components/list/ListHeader.js
@@ -75,7 +75,7 @@ export default function ListHeader({ children, contextMenuOptions, isCoinListEdi
       <SavingsListHeader
         emoji="whale"
         isOpen={false}
-        onPress={() => { }}
+        onPress={() => {}}
         savingsSumValue={totalValue}
         showSumValue
         title={lang.t('pools.pools_title')}

--- a/src/components/list/ListHeader.js
+++ b/src/components/list/ListHeader.js
@@ -2,7 +2,7 @@ import Divider from '@/components/Divider';
 import { useDimensions, useWebData } from '@/hooks';
 import * as i18n from '@/languages';
 import { RAINBOW_PROFILES_BASE_URL } from '@/references';
-import { useAccountAddress, useAccountProfileInfo, useWalletsStore } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet, useAccountAddress, useAccountProfileInfo } from '@/state/wallets/walletsStore';
 import styled from '@/styled-thing';
 import { padding } from '@/styles';
 import lang from 'i18n-js';
@@ -53,30 +53,29 @@ const StickyBackgroundBlocker = styled.View({
 export default function ListHeader({ children, contextMenuOptions, isCoinListEdited, showDivider = true, title, totalValue }) {
   const deviceDimensions = useDimensions();
   const { colors, isDarkMode } = useTheme();
-  const isReadOnlyWallet = useWalletsStore(state => state.getIsReadOnlyWallet());
   const accountAddress = useAccountAddress();
   const { accountENS } = useAccountProfileInfo();
   const { initializeShowcaseIfNeeded } = useWebData();
 
   const handleShare = useCallback(() => {
-    if (!isReadOnlyWallet) {
+    if (!getIsReadOnlyWallet()) {
       initializeShowcaseIfNeeded();
     }
     const showcaseUrl = `${RAINBOW_PROFILES_BASE_URL}/${accountENS || accountAddress}`;
     const shareOptions = {
-      message: isReadOnlyWallet
+      message: getIsReadOnlyWallet()
         ? lang.t('list.share.check_out_this_wallet', { showcaseUrl })
         : lang.t('list.share.check_out_my_wallet', { showcaseUrl }),
     };
     Share.share(shareOptions);
-  }, [accountAddress, accountENS, initializeShowcaseIfNeeded, isReadOnlyWallet]);
+  }, [accountAddress, accountENS, initializeShowcaseIfNeeded]);
 
   if (title === lang.t('pools.pools_title')) {
     return (
       <SavingsListHeader
         emoji="whale"
         isOpen={false}
-        onPress={() => {}}
+        onPress={() => { }}
         savingsSumValue={totalValue}
         showSumValue
         title={lang.t('pools.pools_title')}

--- a/src/components/sheet/sheet-action-buttons/BuyActionButton.tsx
+++ b/src/components/sheet/sheet-action-buttons/BuyActionButton.tsx
@@ -4,7 +4,7 @@ import SheetActionButton, { SheetActionButtonProps } from './SheetActionButton';
 import { analytics } from '@/analytics';
 import { Text } from '@/design-system';
 import showWalletErrorAlert from '@/helpers/support';
-import { useIsDamagedWallet } from '@/state/wallets/walletsStore';
+import { getIsDamagedWallet } from '@/state/wallets/walletsStore';
 
 import Routes from '@/navigation/routesNames';
 import { colors } from '@/styles';
@@ -16,11 +16,10 @@ type BuyActionButtonProps = SheetActionButtonProps;
 function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) {
   const color = givenColor || colors.paleBlue;
   const navigate = useNavigationForNonReadOnlyWallets();
-  const isDamaged = useIsDamagedWallet();
   const { name: routeName } = useRoute();
 
   const handlePress = useCallback(() => {
-    if (isDamaged) {
+    if (getIsDamagedWallet()) {
       showWalletErrorAlert();
       return;
     }
@@ -31,7 +30,7 @@ function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) 
       componentName: 'BuyActionButton',
       routeName,
     });
-  }, [isDamaged, navigate, routeName]);
+  }, [navigate, routeName]);
 
   return (
     <SheetActionButton

--- a/src/hooks/useHiddenTokens.ts
+++ b/src/hooks/useHiddenTokens.ts
@@ -4,13 +4,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { analytics } from '@/analytics';
 import { UniqueAsset } from '@/entities';
 import { addHiddenToken as rawAddHiddenToken, removeHiddenToken as rawRemoveHiddenToken } from '../redux/hiddenTokens';
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import useWebData from './useWebData';
 
 export default function useHiddenTokens() {
   const dispatch = useDispatch();
   const { updateWebHidden } = useWebData();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
 
   const hiddenTokens: string[] = useSelector(
     // @ts-expect-error
@@ -20,6 +19,7 @@ export default function useHiddenTokens() {
   const addHiddenToken = useCallback(
     async (asset: UniqueAsset) => {
       dispatch(rawAddHiddenToken(asset.fullUniqueId));
+      const isReadOnlyWallet = getIsReadOnlyWallet();
       !isReadOnlyWallet && updateWebHidden([...hiddenTokens, asset.fullUniqueId]);
 
       analytics.track(analytics.event.toggledAnNFTAsHidden, {
@@ -28,12 +28,13 @@ export default function useHiddenTokens() {
         isHidden: true,
       });
     },
-    [dispatch, isReadOnlyWallet, hiddenTokens, updateWebHidden]
+    [dispatch, hiddenTokens, updateWebHidden]
   );
 
   const removeHiddenToken = useCallback(
     async (asset: UniqueAsset) => {
       dispatch(rawRemoveHiddenToken(asset.fullUniqueId));
+      const isReadOnlyWallet = getIsReadOnlyWallet();
       !isReadOnlyWallet && updateWebHidden(hiddenTokens.filter(id => id !== asset.fullUniqueId));
 
       analytics.track(analytics.event.toggledAnNFTAsHidden, {
@@ -42,7 +43,7 @@ export default function useHiddenTokens() {
         isHidden: false,
       });
     },
-    [dispatch, isReadOnlyWallet, hiddenTokens, updateWebHidden]
+    [dispatch, hiddenTokens, updateWebHidden]
   );
 
   return {

--- a/src/hooks/useLoadAccountLateData.ts
+++ b/src/hooks/useLoadAccountLateData.ts
@@ -4,14 +4,12 @@ import { hiddenTokensUpdateStateFromWeb } from '@/redux/hiddenTokens';
 import { showcaseTokensUpdateStateFromWeb } from '@/redux/showcaseTokens';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { useWalletsStore, useAccountAddress, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { useAccountAddress, getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { promiseUtils } from '../utils';
 import { prefetchAccountENSDomains } from './useAccountENSDomains';
-import useAccountSettings from './useAccountSettings';
 
 export default function useLoadAccountLateData() {
   const accountAddress = useAccountAddress();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
   const dispatch = useDispatch();
 
   const loadAccountLateData = useCallback(async () => {
@@ -25,7 +23,7 @@ export default function useLoadAccountLateData() {
 
     promises.push(p1, p2);
 
-    if (!isReadOnlyWallet) {
+    if (!getIsReadOnlyWallet()) {
       // ENS registration info
       const p3 = dispatch(ensRegistrationsLoadState());
       const p4 = prefetchAccountENSDomains({ accountAddress });
@@ -35,7 +33,7 @@ export default function useLoadAccountLateData() {
 
     // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '((dispatch: ThunkDispatch<{ read... Remove this comment to see the full error message
     return promiseUtils.PromiseAllWithFails(promises);
-  }, [accountAddress, dispatch, isReadOnlyWallet]);
+  }, [accountAddress, dispatch]);
 
   return loadAccountLateData;
 }

--- a/src/hooks/useNavigationForNonReadOnlyWallets.ts
+++ b/src/hooks/useNavigationForNonReadOnlyWallets.ts
@@ -1,18 +1,17 @@
 import { useCallback } from 'react';
 import { InteractionManager } from 'react-native';
 
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { enableActionsOnReadOnlyWallet } from '@/config';
 import { useNavigation } from '@/navigation';
 import { watchingAlert } from '@/utils';
 
 export default function useNavigationForNonReadOnlyWallets() {
   const { goBack, navigate } = useNavigation();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
 
   return useCallback(
     (routeName: string, params?: any) => {
-      if (isReadOnlyWallet && !enableActionsOnReadOnlyWallet) {
+      if (getIsReadOnlyWallet() && !enableActionsOnReadOnlyWallet) {
         watchingAlert();
         return;
       }

--- a/src/hooks/useNavigationForNonReadOnlyWallets.ts
+++ b/src/hooks/useNavigationForNonReadOnlyWallets.ts
@@ -21,6 +21,6 @@ export default function useNavigationForNonReadOnlyWallets() {
         setTimeout(() => navigate(routeName, params), 50);
       });
     },
-    [goBack, isReadOnlyWallet, navigate]
+    [goBack, navigate]
   );
 }

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -13,7 +13,7 @@ import {
   useWallets,
   useWalletsStore,
   useSelectedWallet,
-  useIsReadOnlyWallet,
+  getIsReadOnlyWallet,
 } from '@/state/wallets/walletsStore';
 import { isLowerCaseMatch, showActionSheetWithOptions } from '@/utils';
 import { buildRainbowUrl } from '@/utils/buildRainbowUrl';
@@ -40,7 +40,6 @@ type UseOnAvatarPressProps = {
 export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
   const wallets = useWallets();
   const selectedWallet = useSelectedWallet();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
   const { navigate } = useNavigation();
   const { accountAddress, accountColor, accountName, accountImage, accountENS } = useAccountProfileInfo();
   const profilesEnabled = useExperimentalFlag(PROFILES);
@@ -155,7 +154,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
     });
   }, [accountENS, navigate, startRegistration]);
 
-  const isReadOnly = isReadOnlyWallet && !enableActionsOnReadOnlyWallet;
+  const isReadOnly = getIsReadOnlyWallet() && !enableActionsOnReadOnlyWallet;
 
   const isENSProfile = profilesEnabled && profileEnabled && isOwner;
   const isZeroETH = isZero(accountAsset?.balance?.amount || 0);

--- a/src/hooks/useShowcaseTokens.ts
+++ b/src/hooks/useShowcaseTokens.ts
@@ -2,14 +2,13 @@ import { AppState } from '@/redux/store';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { addShowcaseToken as rawAddShowcaseToken, removeShowcaseToken as rawRemoveShowcaseToken } from '../redux/showcaseTokens';
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import useOpenFamilies from './useOpenFamilies';
 import useWebData from './useWebData';
 
 export default function useShowcaseTokens() {
   const dispatch = useDispatch();
   const { updateWebShowcase } = useWebData();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
   const { updateOpenFamilies } = useOpenFamilies();
 
   const showcaseTokens = useSelector((state: AppState) => state.showcaseTokens.showcaseTokens);
@@ -18,17 +17,17 @@ export default function useShowcaseTokens() {
     async (asset: string) => {
       dispatch(rawAddShowcaseToken(asset));
       updateOpenFamilies({ Showcase: true });
-      !isReadOnlyWallet && updateWebShowcase([...showcaseTokens, asset]);
+      !getIsReadOnlyWallet() && updateWebShowcase([...showcaseTokens, asset]);
     },
-    [dispatch, isReadOnlyWallet, showcaseTokens, updateOpenFamilies, updateWebShowcase]
+    [dispatch, showcaseTokens, updateOpenFamilies, updateWebShowcase]
   );
 
   const removeShowcaseToken = useCallback(
     async (asset: string) => {
       dispatch(rawRemoveShowcaseToken(asset));
-      !isReadOnlyWallet && updateWebShowcase(showcaseTokens.filter((id: string) => id !== asset));
+      !getIsReadOnlyWallet() && updateWebShowcase(showcaseTokens.filter((id: string) => id !== asset));
     },
-    [dispatch, isReadOnlyWallet, showcaseTokens, updateWebShowcase]
+    [dispatch, showcaseTokens, updateWebShowcase]
   );
 
   return {

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
@@ -31,7 +31,7 @@ import Routes from '@/navigation/routesNames';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
 import { backupsStore } from '@/state/backups/backups';
 import { walletLoadingStore } from '@/state/walletLoading/walletLoading';
-import { useWallets, useIsDamagedWallet, createAccount } from '@/state/wallets/walletsStore';
+import { useWallets, createAccount, getIsDamagedWallet } from '@/state/wallets/walletsStore';
 import { abbreviations } from '@/utils';
 import { addressHashedEmoji } from '@/utils/profileUtils';
 import { format } from 'date-fns';
@@ -124,7 +124,6 @@ const ViewWalletBackup = () => {
 
   const { walletId, title: incomingTitle } = params;
   const creatingWallet = useRef<boolean>();
-  const isDamaged = useIsDamagedWallet();
   const wallets = useWallets();
   const wallet = wallets?.[walletId];
 
@@ -202,7 +201,7 @@ const ViewWalletBackup = () => {
                 logger.error(new RainbowError(`[ViewWalletBackup]: Error while trying to add account`), {
                   error: e,
                 });
-                if (isDamaged) {
+                if (getIsDamagedWallet()) {
                   setTimeout(() => {
                     showWalletErrorAlert();
                   }, 1000);

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
@@ -226,7 +226,7 @@ const ViewWalletBackup = () => {
         error: e,
       });
     }
-  }, [creatingWallet, isDamaged, navigate, wallet]);
+  }, [creatingWallet, navigate, wallet]);
 
   const handleCopyAddress = React.useCallback(
     (address: string) => {

--- a/src/screens/claimables/shared/components/ClaimButton.tsx
+++ b/src/screens/claimables/shared/components/ClaimButton.tsx
@@ -2,7 +2,7 @@ import { ButtonPressAnimation, ShimmerAnimation } from '@/components/animations'
 import { enableActionsOnReadOnlyWallet } from '@/config';
 import { AccentColorProvider, Box, Inline, Text, TextShadow } from '@/design-system';
 import { HoldToActivateButton } from '@/screens/token-launcher/components/HoldToActivateButton';
-import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { deviceUtils, watchingAlert } from '@/utils';
 import { debounce } from 'lodash';
 import React from 'react';
@@ -26,8 +26,6 @@ export function ClaimButton({
   biometricIcon: boolean;
   label: string;
 }) {
-  const isReadOnlyWallet = useIsReadOnlyWallet();
-
   if (enableHoldToPress) {
     return (
       <HoldToActivateButton
@@ -52,7 +50,7 @@ export function ClaimButton({
       style={{ width: '100%', paddingHorizontal: 18 }}
       scaleTo={0.96}
       onPress={debounce(() => {
-        if (!isReadOnlyWallet || enableActionsOnReadOnlyWallet) {
+        if (!getIsReadOnlyWallet() || enableActionsOnReadOnlyWallet) {
           onPress();
         } else {
           watchingAlert();

--- a/src/state/wallets/walletsStore.ts
+++ b/src/state/wallets/walletsStore.ts
@@ -83,7 +83,7 @@ interface WalletsState {
   refreshWalletNames: () => Promise<void>;
   checkKeychainIntegrity: () => Promise<void>;
 
-  getIsDamaged: () => boolean;
+  getIsDamagedWallet: () => boolean;
   getIsReadOnlyWallet: () => boolean;
   getIsHardwareWallet: () => boolean;
   getWalletWithAccount: (accountAddress: string) => RainbowWallet | undefined;
@@ -92,7 +92,7 @@ interface WalletsState {
 
 export const useWalletsStore = createRainbowStore<WalletsState>(
   (set, get) => ({
-    getIsDamaged: () => !!get().selected?.damaged,
+    getIsDamagedWallet: () => !!get().selected?.damaged,
     getIsReadOnlyWallet: () => get().selected?.type === WalletTypes.readOnly,
     getIsHardwareWallet: () => !!get().selected?.deviceId,
 
@@ -647,7 +647,6 @@ export const useAccountAddress = () => useWalletsStore(state => state.accountAdd
 export const useSelectedWallet = () => useWalletsStore(state => state.selected);
 export const useIsReadOnlyWallet = () => useWalletsStore(state => state.getIsReadOnlyWallet());
 export const useIsHardwareWallet = () => useWalletsStore(state => state.getIsHardwareWallet());
-export const useIsDamagedWallet = () => useWalletsStore(state => state.getIsDamaged());
 
 export function getWalletAddresses(wallets: { [key: string]: RainbowWallet }) {
   return Object.values(wallets).flatMap(wallet => (wallet.addresses || []).map(account => ensureValidHex(account.address)));
@@ -689,7 +688,7 @@ export const {
   clearAllWalletsBackupStatus,
   createAccount,
   getAccountProfileInfo,
-  getIsDamaged,
+  getIsDamagedWallet,
   getIsHardwareWallet,
   getIsReadOnlyWallet,
   getWalletWithAccount,


### PR DESCRIPTION
Fixes [APP-2655
](https://linear.app/rainbow/issue/APP-2655/ensure-function-for-non-damaged-non-read-only-wallets)
## What changed (plus any additional context for devs)

Just cleans up a bit of fallout from wallet store refactor PR, no change in functionality just code cleanup.

## What to test

Just testing the usage of damaged + readonly in one place each should verify the rest work.

