### PR TITLE
Update Fastfile match action flag from force to readonly

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -40,7 +40,7 @@ platform :ios do
     )
 
     match(
-      force: true,
+      readonly: true,
       type: "appstore",
       app_identifier: ["me.rainbow", "me.rainbow.PriceWidget", "me.rainbow.SelectTokenIntent", "me.rainbow.ImageNotification", "me.rainbow.OpenInRainbow", "me.rainbow.ShareWithRainbow"],
       git_url: "git@github.com:rainbow-me/rainbow-code-signing.git"


### PR DESCRIPTION
Issue with bitrise that started yesterday; this is a workaround