### PR TITLE
improve RainbowError toString to show cause toString

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -184,6 +184,13 @@ export class RainbowError extends Error {
     super(message, options);
     this.name = this.constructor.name;
   }
+
+  toString() {
+    if (this.cause) {
+      return `${super.toString()} ↠ ${this.cause.toString()}`;
+    }
+    return super.toString();
+  }
 }
 
 export function ensureError(error: unknown): Error {


### PR DESCRIPTION
Fixes APP-2695

## What changed

In dev mode errors that were created like `new RainbowError('this err message', parentErr)`  the parentErr wouldn't log at all. This was causing bad error messages in initializeWallet / walletStore stuff.

After this change it will log the original error message and then ↠ and the cause error message:

![CleanShot 2025-05-30 at 22 21 56@2x](https://github.com/user-attachments/assets/b63afb65-72ba-4c94-a1f9-6dbc4362f22a)

## What to test

Make sure Sentry/dev errors are properly formatted.

