### PR TITLE
Add timeout to android e2e tests

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -7,6 +7,7 @@ jobs:
   android-e2e:
     if: github.event.pull_request.draft == false
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I've had a case recently where tests hang on android, so let's add this just as extra safety, if it keeps happening we can investigate the actual cause of the hang. For android 1h is plenty of time as it usually takes 30 min.

## Screen recordings / screenshots

n/a

## What to test

n/a