### PR TITLE
Fix adding to backup when creating a new secret phrase

### DIFF
--- a/src/components/backup/CloudBackupPrompt.tsx
+++ b/src/components/backup/CloudBackupPrompt.tsx
@@ -36,6 +36,7 @@ export default function CloudBackupPrompt() {
       fn: () =>
         createBackup({
           walletId: selectedWallet.id,
+          addToCurrentBackup: true,
         }),
       logout: true,
     });

--- a/src/components/backup/useCreateBackup.ts
+++ b/src/components/backup/useCreateBackup.ts
@@ -17,6 +17,7 @@ import { useDispatch } from 'react-redux';
 
 type UseCreateBackupProps = {
   walletId?: string;
+  addToCurrentBackup?: boolean;
 };
 
 type ConfirmBackupProps = {
@@ -87,7 +88,7 @@ export const useCreateBackup = () => {
   );
 
   const onConfirmBackup = useCallback(
-    async ({ password, walletId }: ConfirmBackupProps) => {
+    async ({ password, walletId, addToCurrentBackup = false }: ConfirmBackupProps) => {
       analytics.track(analytics.event.backupConfirmed);
       backupsStore.getState().setStatus(CloudBackupState.InProgress);
 
@@ -119,6 +120,7 @@ export const useCreateBackup = () => {
         onSuccess,
         password,
         walletId,
+        addToCurrentBackup,
       });
     },
     [walletCloudBackup, onError, wallets, onSuccess, dispatch]


### PR DESCRIPTION
Fixes APP-2684

## What changed (plus any additional context for devs)

This adds a parameter to `createBackup` to add the wallet to the current backup, instead of creating a new backup with only that wallet.

We already had a function `addWalletToCloudBackup` to do that but it wasn't being used anywhere.

## Screen recordings / screenshots

N/A

## What to test

- Create a new wallet.
- Go to Settings -> Wallets & Backups -> Create a New Secret Phrase.
- When prompted to add to current backup, accept.
- Clear app data and restart it.
- Restore wallet from backup and make sure both wallets are there.