### PR TITLE
KOT small loading logic fix

### DIFF
--- a/src/components/Discover/KingOfTheHill.tsx
+++ b/src/components/Discover/KingOfTheHill.tsx
@@ -94,16 +94,15 @@ function SyncStoreEnabled() {
 export function KingOfTheHill() {
   const kingOfTheHill = useKingOfTheHillStore(store => store.getData(), isEqual);
 
-  if (!kingOfTheHill) {
-    return <Skeleton width={'100%'} height={84 + 26 + 6} />;
-  }
-
   return (
     <>
-      <Box gap={6}>
-        {kingOfTheHill.lastWinner && <LastWinnerSection lastWinner={kingOfTheHill.lastWinner} />}
-        <KingOfTheHillCard king={kingOfTheHill.current} />
-      </Box>
+      {!kingOfTheHill && <Skeleton width={'100%'} height={84 + 26 + 6} />}
+      {kingOfTheHill && (
+        <Box gap={6}>
+          {kingOfTheHill.lastWinner && <LastWinnerSection lastWinner={kingOfTheHill.lastWinner} />}
+          <KingOfTheHillCard king={kingOfTheHill.current} />
+        </Box>
+      )}
       <SyncStoreEnabled />
     </>
   );

--- a/src/state/kingOfTheHill/kingOfTheHillStore.ts
+++ b/src/state/kingOfTheHill/kingOfTheHillStore.ts
@@ -36,7 +36,7 @@ export const useKingOfTheHillStore = createQueryStore<KingOfTheHill | null, King
       }
     },
     cacheTime: time.hours(1),
-    keepPreviousData: true,
+    keepPreviousData: false,
     params: {
       currency: $ => $(userAssetsStoreManager).currency,
     },


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Was seeing an issue when loading the app after a new round of kot starts where the timer was displaying "waiting for next round" instead of the countdown. 
- I believe this was related to the the `keepPreviousData: true` setting on the store. 
- Also noticed an issue with the loading skeleton logic that would prevent the `SyncStoreEnabled` component from rendering. 

## Screen recordings / screenshots


## What to test

