### PR TITLE
Fix incorrect ask of rainbow pin when backing up new wallet

### DIFF
--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -174,13 +174,8 @@ async function extractSecretsForWallet(wallet: RainbowWallet) {
   const allowedPkeysKeys = wallet?.addresses?.map(account => `${account.address}_${privateKeyKey}`);
 
   allKeys.forEach(item => {
-    // Ignore allWalletsKey
-    if (item.username === allWalletsKey) {
-      return;
-    }
-
-    // Ignore selected wallet
-    if (item.username === selectedWalletKey) {
+    // Ignore keys that are not seed phrases or private keys.
+    if (item.username.indexOf(seedPhraseKey) === -1 && item.username.indexOf(privateKeyKey) === -1) {
       return;
     }
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

When adding a wallet this function gets all keychain values that must be saved https://github.com/rainbow-me/rainbow/blob/3680f0bb83929127bc95e587a62f180fe17c3038/src/model/backup.ts#L169. The problem is that it filters the values differently from the function that backs up all wallets, and more keys are included. In itself this isn't a big problem, but some of these keys are encrypted using rainbow password (signature_ keys). The code that tries to decrypt values that might be encrypted with rainbow PIN then incorrectly tries to decrypt those and prompts for rainbow PIN, even if the user doesn't have one.

Note that the backup still works, since the keys it tries to decrypt are not used.

This fixes the key filtering to only include private keys and secret phrases, making it the same as the code that backs up all wallets.

## Screen recordings / screenshots

Before:

https://github.com/user-attachments/assets/cc7d45c4-915e-468f-8459-0e7f774bd0df

After:

https://github.com/user-attachments/assets/619d0d11-1bff-4ce7-b988-79a8d4a6845f

## What to test

In an existing wallet, create a new 