### PR TITLE
Fix saving SVG NFTs

### DIFF
--- a/src/components/expanded-state/unique-token/saveToCameraRoll.ts
+++ b/src/components/expanded-state/unique-token/saveToCameraRoll.ts
@@ -76,7 +76,7 @@ const saveToCameraRoll = async (url: string): Promise<void> => {
     alertError();
     return;
   }
-  const url2Download = staticImgixClient?.buildURL(url);
+  const url2Download = staticImgixClient?.buildURL(url, { fm: 'png' });
 
   if (Platform.OS === 'android') {
     await downloadImageAndroid(url2Download);


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

While testing another PR I noticed a bug with downloading SVG NFTs. The code assumes the images are PNGs, but it is not always the case. Adding this option will convert the image to PNG if it is not already.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/b49f187d-0568-4280-9d15-5582a4cd6e86

## What to test

- Go to an SVG NFT (rainbowtestwallet.eth -> Arun Cattybinky is one)
- Click ... and Save to Photos
