### PR TITLE
Fix yarn android launching the activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,8 +53,8 @@
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustPan">
         <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
-            <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
         </intent-filter>
         <!-- Branch URI Scheme -->
         <intent-filter android:autoVerify="true">


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

This was changed because of [rn-fetch-blob](https://github.com/joltup/rn-fetch-blob?tab=readme-ov-file#installation), but it is actually only needed if using Android Download Manager, which we don't (`useDownloadManager` config).

<img width="858" alt="image" src="https://github.com/user-attachments/assets/ac676ab4-d9ba-4d23-b171-19761d444054" />

## Screen recordings / screenshots

Before:

<img width="649" alt="image" src="https://github.com/user-attachments/assets/796f80c5-8bb7-42f9-83e4-47621937e893" />

After:

<img width="652" alt="image" src="https://github.com/user-attachments/assets/64550cc3-517f-49df-8783-1c30988b3c63" />

## What to test

- yarn android -> Check that app is now launched
- Test that saving NFTs still works