### PR TITLE
Fix backup when using rainbow PIN

### DIFF
--- a/src/components/backup/RestoreCloudStep.tsx
+++ b/src/components/backup/RestoreCloudStep.tsx
@@ -27,13 +27,13 @@ import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { InteractionManager, TextInput } from 'react-native';
 import { Source } from 'react-native-fast-image';
-import { useDispatch } from 'react-redux';
 import { RainbowButton } from '../buttons';
 import RainbowButtonTypes from '../buttons/rainbow-button/RainbowButtonTypes';
 import { PasswordField } from '../fields';
 import { ImgixImage } from '../images';
 import { Text } from '../text';
 import { initializeWallet } from '@/state/wallets/initializeWallet';
+import { maybeAuthenticateWithPIN } from '@/handlers/authentication';
 
 type ComponentProps = {
   theme: ThemeContextProps;
@@ -91,7 +91,6 @@ export default function RestoreCloudStep() {
     }
   }, [canGoBack, goBack]);
 
-  const dispatch = useDispatch();
   const { width: deviceWidth, height: deviceHeight } = useDimensions();
   const [validPassword, setValidPassword] = useState(false);
   const [incorrectPassword, setIncorrectPassword] = useState(false);
@@ -99,7 +98,7 @@ export default function RestoreCloudStep() {
 
   useEffect(() => {
     const fetchPasswordIfPossible = async () => {
-      const pwd = await getLocalBackupPassword();
+      const pwd = await getLocalBackupPassword(await maybeAuthenticateWithPIN());
       if (pwd) {
         backupsStore.getState().setStoredPassword(pwd);
         backupsStore.getState().setPassword(pwd);

--- a/src/components/backup/useCreateBackup.ts
+++ b/src/components/backup/useCreateBackup.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-promise-executor-return */
 import { analytics } from '@/analytics';
 import { DelayedAlert } from '@/components/alerts';
+import { maybeAuthenticateWithPIN } from '@/handlers/authentication';
 import showWalletErrorAlert from '@/helpers/support';
 import walletBackupStepTypes from '@/helpers/walletBackupStepTypes';
 import { useWalletCloudBackup } from '@/hooks';
@@ -13,7 +14,6 @@ import { useWallets } from '@/state/wallets/walletsStore';
 import { cloudPlatform } from '@/utils/platform';
 import { useCallback } from 'react';
 import { InteractionManager } from 'react-native';
-import { useDispatch } from 'react-redux';
 
 type UseCreateBackupProps = {
   walletId?: string;
@@ -22,11 +22,10 @@ type UseCreateBackupProps = {
 
 type ConfirmBackupProps = {
   password: string;
+  userPIN: string | undefined;
 } & UseCreateBackupProps;
 
 export const useCreateBackup = () => {
-  const dispatch = useDispatch();
-
   const walletCloudBackup = useWalletCloudBackup();
   const wallets = useWallets();
 
@@ -88,7 +87,7 @@ export const useCreateBackup = () => {
   );
 
   const onConfirmBackup = useCallback(
-    async ({ password, walletId, addToCurrentBackup = false }: ConfirmBackupProps) => {
+    async ({ password, walletId, userPIN, addToCurrentBackup = false }: ConfirmBackupProps) => {
       analytics.track(analytics.event.backupConfirmed);
       backupsStore.getState().setStatus(CloudBackupState.InProgress);
 
@@ -111,6 +110,7 @@ export const useCreateBackup = () => {
           password,
           onError,
           onSuccess,
+          userPIN,
         });
         return;
       }
@@ -123,18 +123,18 @@ export const useCreateBackup = () => {
         addToCurrentBackup,
       });
     },
-    [walletCloudBackup, onError, wallets, onSuccess, dispatch]
+    [walletCloudBackup, onError, wallets, onSuccess]
   );
 
-  const getPassword = useCallback(async (props: UseCreateBackupProps): Promise<string | null> => {
-    const password = await getLocalBackupPassword();
+  const getPassword = useCallback(async (props: UseCreateBackupProps, userPIN: string | undefined): Promise<string | null> => {
+    const password = await getLocalBackupPassword(userPIN);
     if (password) {
       backupsStore.getState().setStoredPassword(password);
       return password;
     }
 
     return new Promise(resolve => {
-      return Navigation.handleAction(Routes.BACKUP_SHEET, {
+      Navigation.handleAction(Routes.BACKUP_SHEET, {
         nativeScreen: true,
         step: walletBackupStepTypes.create_cloud_backup,
         onSuccess: async (password: string) => {
@@ -153,7 +153,16 @@ export const useCreateBackup = () => {
       if (backupsStore.getState().status !== CloudBackupState.Ready) {
         return false;
       }
-      const password = await getPassword(props);
+
+      let userPIN: string | undefined;
+      try {
+        userPIN = await maybeAuthenticateWithPIN();
+      } catch (e) {
+        onError?.(i18n.t(i18n.l.back_up.wrong_pin));
+        return;
+      }
+
+      const password = await getPassword(props, userPIN);
       if (!password) {
         setLoadingStateWithTimeout({
           state: CloudBackupState.Ready,
@@ -162,11 +171,12 @@ export const useCreateBackup = () => {
       }
       onConfirmBackup({
         password,
+        userPIN,
         ...props,
       });
       return true;
     },
-    [getPassword, onConfirmBackup, setLoadingStateWithTimeout]
+    [getPassword, onConfirmBackup, setLoadingStateWithTimeout, onError]
   );
 
   return createBackup;

--- a/src/handlers/authentication.ts
+++ b/src/handlers/authentication.ts
@@ -10,6 +10,14 @@ import { IS_ANDROID } from '@/env';
 
 const encryptor = new AesEncryptor();
 
+// Add a short delay to give time for the screen to close.
+// this prevents an issue where the PIN screen won't show if
+// shown twice in a row. Ideally we should never prompt twice
+// in a row, but this is better than never resolving the promise.
+function waitForNavigation(callback: () => void) {
+  setTimeout(callback, 500);
+}
+
 export async function getExistingPIN(): Promise<string | undefined> {
   try {
     const encryptedPin = await keychain.loadString(pinKey);
@@ -56,18 +64,22 @@ export async function authenticateWithPINAndCreateIfNeeded(): Promise<string | u
     // eslint-disable-next-line no-empty
   } catch (e) {}
   return new Promise((resolve, reject) => {
-    return Navigation.handleAction(Routes.PIN_AUTHENTICATION_SCREEN, {
-      onCancel: () => reject(),
-      onSuccess: async (pin: string | undefined) => {
-        // If we didn't have a PIN, we need to encrypt it and store it
-        if (!validPin) {
-          try {
-            await savePIN(pin);
-          } catch (e) {
-            reject();
+    Navigation.handleAction(Routes.PIN_AUTHENTICATION_SCREEN, {
+      onCancel: () => {
+        waitForNavigation(reject);
+      },
+      onSuccess: (pin: string | undefined) => {
+        waitForNavigation(async () => {
+          // If we didn't have a PIN, we need to encrypt it and store it
+          if (!validPin) {
+            try {
+              await savePIN(pin);
+            } catch (e) {
+              reject();
+            }
           }
-        }
-        resolve(pin);
+          resolve(pin);
+        });
       },
       validPin,
     });
@@ -81,10 +93,14 @@ export async function authenticateWithPIN(): Promise<string | undefined> {
     // eslint-disable-next-line no-empty
   } catch (e) {}
   return new Promise((resolve, reject) => {
-    return Navigation.handleAction(Routes.PIN_AUTHENTICATION_SCREEN, {
-      onCancel: () => reject(),
+    Navigation.handleAction(Routes.PIN_AUTHENTICATION_SCREEN, {
+      onCancel: () => {
+        waitForNavigation(reject);
+      },
       onSuccess: async (pin: string | undefined) => {
-        resolve(pin);
+        waitForNavigation(() => {
+          resolve(pin);
+        });
       },
       validPin,
     });

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -1,12 +1,7 @@
 import { analytics } from '@/analytics';
 import { Alert as NativeAlert } from '@/components/alerts';
 import { IS_ANDROID, IS_DEV } from '@/env';
-import {
-  authenticateWithPIN,
-  decryptPIN,
-  maybeAuthenticateWithPIN,
-  maybeAuthenticateWithPINAndCreateIfNeeded,
-} from '@/handlers/authentication';
+import { authenticateWithPIN, decryptPIN, maybeAuthenticateWithPINAndCreateIfNeeded } from '@/handlers/authentication';
 import {
   CLOUD_BACKUP_ERRORS,
   encryptAndSaveDataToCloud,
@@ -26,10 +21,9 @@ import { logger, RainbowError } from '@/logger';
 import * as keychain from '@/model/keychain';
 import { Navigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
-import { AppDispatch } from '@/redux/store';
 import { backupsStore, CloudBackupState } from '@/state/backups/backups';
 import { setAllWalletsWithIdsAsBackedUp } from '@/state/wallets/walletsStore';
-import { allWalletsKey, identifierForVendorKey, pinKey, privateKeyKey, seedPhraseKey, selectedWalletKey } from '@/utils/keychainConstants';
+import { identifierForVendorKey, pinKey, privateKeyKey, seedPhraseKey } from '@/utils/keychainConstants';
 import { openInBrowser } from '@/utils/openInBrowser';
 import { cloudPlatform } from '@/utils/platform';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -197,6 +191,7 @@ async function extractSecretsForWallet(wallet: RainbowWallet) {
 type CreateBackupProps = {
   now?: number;
   onError?: (message: string) => void;
+  userPIN?: string;
 };
 
 export async function backupAllWalletsToCloud({
@@ -204,6 +199,7 @@ export async function backupAllWalletsToCloud({
   password,
   onError,
   onSuccess,
+  userPIN,
 }: CreateBackupProps & {
   onSuccess?: (password: BackupPassword) => void;
   wallets: AllRainbowWallets;
@@ -211,7 +207,7 @@ export async function backupAllWalletsToCloud({
 }) {
   try {
     const now = Date.now();
-    const data = await createBackup({ onError, now });
+    const data = await createBackup({ onError, now, userPIN });
     if (!data) {
       return;
     }
@@ -241,15 +237,7 @@ export async function backupAllWalletsToCloud({
   }
 }
 
-export async function createBackup({ onError, now = Date.now() }: CreateBackupProps) {
-  let userPIN: string | undefined;
-  try {
-    userPIN = await maybeAuthenticateWithPIN();
-  } catch (e) {
-    onError?.(i18n.t(i18n.l.back_up.wrong_pin));
-    return;
-  }
-
+export async function createBackup({ onError, now = Date.now(), userPIN }: CreateBackupProps) {
   /**
    * Loop over all keys and decrypt if necessary for android
    */
@@ -585,8 +573,8 @@ export async function saveBackupPassword(password: BackupPassword): Promise<void
   }
 }
 
-export async function getLocalBackupPassword(): Promise<string | null> {
-  const { value } = await kc.get('RainbowBackupPassword');
+export async function getLocalBackupPassword(androidEncryptionPin: string | undefined): Promise<string | null> {
+  const { value } = await kc.get('RainbowBackupPassword', { androidEncryptionPin });
   if (value) {
     return value;
   }


### PR DESCRIPTION
Fixes APP-2682

## What changed (plus any additional context for devs)

This fixes the issue in 2 steps:

- If the rainbow PIN screen is shown twice in a row, the second time it will not work, and any promise that depends on it will hang forever. This is because 2 navigation actions too close to each other for the same screen will cause one of them to be ignored. This adds a short delay to resolving or rejecting the promise so it never happens.

- We should actually not prompt for PIN twice, this happens because we try to get the backup password from keychain, and also fetch all secrets. To fix this we can explicitly ask for PIN and pass it down to the functions that will need it so it won't prompt.

## Screen recordings / screenshots

After first fix:

https://github.com/user-attachments/assets/de1cbddd-98f1-4560-9637-ef6ef4aabb8a

After second fix:

https://github.com/user-attachments/assets/f79d1dd6-bcab-4c19-8a0f-89b65fbc1207

## What to test

- Try creating a backup with no device passcode so it uses rainbow PIN.

