### PR TITLE
Fix backup stuck in syncing state

### DIFF
--- a/src/components/backup/useCreateBackup.ts
+++ b/src/components/backup/useCreateBackup.ts
@@ -30,17 +30,24 @@ export const useCreateBackup = () => {
   const setLoadingStateWithTimeout = useCallback(
     ({ state, outOfSync = false, failInMs = 10_000 }: { state: CloudBackupState; outOfSync?: boolean; failInMs?: number }) => {
       backupsStore.getState().setStatus(state);
+      let outOfSyncTimeout: NodeJS.Timeout | null = null;
       if (outOfSync) {
-        setTimeout(() => {
+        outOfSyncTimeout = setTimeout(() => {
           backupsStore.getState().setStatus(CloudBackupState.Syncing);
         }, 1_000);
       }
-      setTimeout(() => {
+      const endTimeout = setTimeout(() => {
         const currentState = backupsStore.getState().status;
         if (currentState === state) {
           backupsStore.getState().setStatus(CloudBackupState.Ready);
         }
       }, failInMs);
+      return () => {
+        clearTimeout(endTimeout);
+        if (outOfSyncTimeout != null) {
+          clearTimeout(outOfSyncTimeout);
+        }
+      };
     },
     []
   );
@@ -53,11 +60,12 @@ export const useCreateBackup = () => {
       // Reset the storedPassword state for next backup
       backupsStore.getState().setStoredPassword('');
       analytics.track(analytics.event.backupComplete, { category: 'backup', label: cloudPlatform });
-      setLoadingStateWithTimeout({
+      const cancelTimeout = setLoadingStateWithTimeout({
         state: CloudBackupState.Success,
         outOfSync: true,
       });
-      backupsStore.getState().syncAndFetchBackups();
+      await backupsStore.getState().syncAndFetchBackups();
+      cancelTimeout();
     },
     [setLoadingStateWithTimeout]
   );


### PR DESCRIPTION
Fixes APP-2682

## What changed (plus any additional context for devs)

If the sync completes too early then the timeout that sets the syncing state will happen after and the state will never be set back to success. To fix it we can cancel the timeouts once the sync is done.

## Screen recordings / screenshots

Before:

https://github.com/user-attachments/assets/97ccc1ac-1a77-4255-b827-29987df3979c

After:

https://github.com/user-attachments/assets/2acf6a5f-2b7d-44f5-8941-7dbe4dfc881a

## What to test

Create a new backup and check that it doesn't stay stuck in syncing state