### PR TITLE
fix wallets loading on switch

### DIFF
--- a/src/state/wallets/initializeWallet.ts
+++ b/src/state/wallets/initializeWallet.ts
@@ -122,7 +122,6 @@ export const initializeWallet = async (props: InitializeWalletParams = {}) => {
 
     if (seedPhrase || isNew) {
       logger.debug('[initializeWallet]: walletsLoadState call #2');
-      await loadWallets();
       if (shouldCancel()) return null;
     }
 


### PR DESCRIPTION
Quick fix that avoids the wallet balance going into a loading state after every switch wallet.