### PR TITLE
Small swap input caret improvement + SafeMath optimizations

### DIFF
--- a/src/__swaps__/screens/Swap/components/SwapInputValuesCaret.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputValuesCaret.tsx
@@ -63,15 +63,18 @@ export function SwapInputValuesCaret({ inputCaretType, disabled }: { inputCaretT
       : withTiming(0, caretConfig);
   });
 
-  const caretStyle = useAnimatedStyle(() => {
-    const isZero =
+  const isZero = useDerivedValue(() => {
+    return (
       (inputMethod.value !== 'slider' && inputValues.value[inputCaretType] === 0) ||
-      (inputMethod.value === 'slider' && equalWorklet(inputValues.value.inputAmount, 0));
+      (inputMethod.value === 'slider' && equalWorklet(inputValues.value.inputAmount, 0))
+    );
+  });
 
+  const caretStyle = useAnimatedStyle(() => {
     return {
       display: shouldShow.value ? 'flex' : 'none',
       opacity: blinkAnimation.value,
-      position: isZero ? 'absolute' : 'relative',
+      position: isZero.value ? 'absolute' : 'relative',
     };
   });
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Moved `SafeMath` regex expression definitions outside of functions. Using regex expressions inline like this causes them to create new `Regex` objects on every call. Normally this doesn't matter but these functions can be called frequently in some cases. Results in ~20% speed up per invocation. 
- While doing this, found that the `equalWorklet` was being called on every frame in swaps due to doing calculations inside the `useAnimatedStyle` hook used for animating the opacity of the input caret. Moved to a `useDerivedValue`. 

## Screen recordings / screenshots


## What to test

