### PR TITLE
Revert Fix yarn android launching the activity (#6678)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,8 +53,8 @@
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustPan">
         <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
+            <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
         </intent-filter>
         <!-- Branch URI Scheme -->
         <intent-filter android:autoVerify="true">


### PR DESCRIPTION
This reverts commit 495900c0fa929deb4319577556983797c0358bb8 from the following PR Fix yarn android launching the activity (#6678)

This produced the issue of seeing two Rainbow icons on Android 

Issue seen here:
![image](https://github.com/user-attachments/assets/0102607e-063a-4870-a9ff-5a6400869f9a)

With this PR we're back to seeing 1 icon as expected: 
<img width="359" alt="Screenshot 2025-06-18 at 6 59 02 AM" src="https://github.com/user-attachments/assets/ff717255-8a5f-46ed-83b2-9200cee3f605" />
