### PR TITLE
Add wrap test and go through settings flows

### DIFF
--- a/e2e/transactions/SwapTransaction.yaml
+++ b/e2e/transactions/SwapTransaction.yaml
@@ -41,7 +41,6 @@ tags:
       - tapOn:
           id: token-to-buy-dai-1
       - assertVisible: 'DAI.*'
-      - assertVisible: 'No Balance'
 
       # Navigate to swap settings
       - tapOn:

--- a/e2e/transactions/SwapTransaction.yaml
+++ b/e2e/transactions/SwapTransaction.yaml
@@ -1,3 +1,10 @@
+# This flow covers:
+# [x] Swap ETH to ERC20 (DAI)
+# [x] Degen Mode toggle
+# [x] Review panel
+# [x] Gas speed settings
+# [x] Activity Screen updates
+
 appId: ${APP_ID}
 tags:
   - wallet
@@ -34,8 +41,38 @@ tags:
           id: token-to-buy-dai-1
       - assertVisible: 'DAI.*'
       - assertVisible: 'No Balance'
-      - hideKeyboard
 
+      # Navigate to swap settings
+      - tapOn:
+          id: swap-settings-button
+      - assertVisible: 'Degen Mode Skip the review step to swap faster'
+
+      # Toggle Degen Mode off and on and back off
+      - tapOn: 'Degen Mode.*'
+      - assertNotVisible: 'Max Slippage'
+      - tapOn: 'Degen Mode.*'
+      - assertVisible: 'Max Slippage'
+      - tapOn: 'Degen Mode.*'
+      - assertNotVisible: 'Max Slippage'
+      # Close settings
+      - tapOn:
+          id: swap-bottom-action-button
+      # Go to review
+      - tapOn:
+          id: swap-bottom-action-button
+      - assertVisible:
+          id: review-panel
+      - assertVisible: 'Minimum Received'
+      - assertVisible: 'Included Rainbow Fee'
+      - assertVisible: '.*Est. Network Fee.*'
+      - tapOn:
+          id: gas-speed-pager
+      - assertVisible: '.*Custom.*'
+      - assertVisible: '.*Normal.*'
+      - assertVisible: '.*Fast.*'
+      - tapOn: '.*Urgent.*'
+
+      # Execute Swap
       - longPressOn:
           id: swap-bottom-action-button
       - runFlow: ../utils/MaybeSetupPin.yaml

--- a/e2e/transactions/SwapTransaction.yaml
+++ b/e2e/transactions/SwapTransaction.yaml
@@ -37,6 +37,7 @@ tags:
       # Select DAI as output token
       - tapOn: 'Find a token to buy'
       - inputText: 'DAI'
+      - hideKeyboard
       - tapOn:
           id: token-to-buy-dai-1
       - assertVisible: 'DAI.*'
@@ -45,14 +46,16 @@ tags:
       # Navigate to swap settings
       - tapOn:
           id: swap-settings-button
-      - assertVisible: 'Degen Mode Skip the review step to swap faster'
 
       # Toggle Degen Mode off and on and back off
-      - tapOn: 'Degen Mode.*'
+      - tapOn:
+          id: swap-settings-panel-degen-mode-button
       - assertNotVisible: 'Max Slippage'
-      - tapOn: 'Degen Mode.*'
+      - tapOn:
+          id: swap-settings-panel-degen-mode-button
       - assertVisible: 'Max Slippage'
-      - tapOn: 'Degen Mode.*'
+      - tapOn:
+          id: swap-settings-panel-degen-mode-button
       - assertNotVisible: 'Max Slippage'
       # Close settings
       - tapOn:
@@ -62,9 +65,16 @@ tags:
           id: swap-bottom-action-button
       - assertVisible:
           id: review-panel
-      - assertVisible: 'Minimum Received'
-      - assertVisible: 'Included Rainbow Fee'
-      - assertVisible: '.*Est. Network Fee.*'
+      - runFlow:
+          when:
+            platform: ios
+          commands:
+            - assertVisible:
+                id: review-panel-min-received-or-max-sold-label
+            - assertVisible:
+                id: review-panel-network-label
+            - assertVisible:
+                id: review-panel-rainbow-fee-label
       - tapOn:
           id: gas-speed-pager
       - assertVisible: '.*Custom.*'

--- a/e2e/transactions/WrapTransaction.yaml
+++ b/e2e/transactions/WrapTransaction.yaml
@@ -37,24 +37,29 @@ tags:
       # Select WETH as output token
       - tapOn: 'Find a token to buy'
       - inputText: 'Wrapped'
+      - hideKeyboard
       - tapOn:
           id: token-to-buy-wrapped-ether-1
       - assertVisible: 'WETH.*'
-      - assertVisible: 'No Balance'
 
-      # Test flip button
-      - assertVisible: '1 ETH 􀄭 1 WETH'
-      - tapOn:
-          id: flip-button
-      - assertVisible: '1 WETH 􀄭 1 ETH'
-      - tapOn:
-          id: flip-button
-      - assertVisible: '1 ETH 􀄭 1 WETH'
+      - runFlow:
+          when:
+            platform: ios
+          commands:
+            # Test flip button
+            - assertVisible: '1 ETH 􀄭 1 WETH'
+            - tapOn:
+                id: flip-button
+            - assertVisible: '1 WETH 􀄭 1 ETH'
+            - tapOn:
+                id: flip-button
+            - assertVisible: '1 ETH 􀄭 1 WETH'
 
       # Navigate to swap settings
       - tapOn:
           id: swap-settings-button
-      - assertVisible: 'Degen Mode Skip the review step to swap faster'
+      - assertVisible:
+          id: swap-settings-panel-degen-mode-button
 
       # Interact with slippage settings
       - assertVisible: 'Max Slippage'
@@ -79,7 +84,6 @@ tags:
       - tapOn:
           id: swap-bottom-action-button
 
-      - hideKeyboard
       - longPressOn:
           id: swap-bottom-action-button
       - runFlow: ../utils/MaybeSetupPin.yaml
@@ -88,6 +92,15 @@ tags:
       - retry:
           maxRetries: 3
           commands:
+            # On Android, pull to refresh
+            - runFlow:
+                when:
+                  platform: Android
+                commands:
+                  - swipe:
+                      from:
+                        id: wallet-screen
+                      direction: down
             - extendedWaitUntil:
                 visible:
                   id: balance-coin-row-Wrapped Ether

--- a/e2e/transactions/WrapTransaction.yaml
+++ b/e2e/transactions/WrapTransaction.yaml
@@ -1,0 +1,94 @@
+# This flow covers:
+# [x] ETH wrap to WETH
+# [x] Flip button
+# [x] Slippage settings
+# [x] Preferred network
+# [x] Home screen balance updates
+
+appId: ${APP_ID}
+tags:
+  - wallet
+  - parallel
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          clearKeychain: true
+          arguments:
+            isE2ETest: true
+      - runFlow: ../utils/Prepare.yaml
+      - runFlow: ../utils/ImportWalletWithKey.yaml
+
+      # Send ETH to test wallet
+      - tapOn:
+          id: fund-test-wallet-button
+
+      # Connect to Anvil (test network)
+      - tapOn:
+          id: dev-button-anvil
+
+      # Open swap screen
+      - tapOn:
+          id: swap-button
+      - assertVisible:
+          id: swap-screen
+      # Select WETH as output token
+      - tapOn: 'Find a token to buy'
+      - inputText: 'Wrapped'
+      - tapOn:
+          id: token-to-buy-wrapped-ether-1
+      - assertVisible: 'WETH.*'
+      - assertVisible: 'No Balance'
+
+      # Test flip button
+      - assertVisible: '1 ETH 􀄭 1 WETH'
+      - tapOn:
+          id: flip-button
+      - assertVisible: '1 WETH 􀄭 1 ETH'
+      - tapOn:
+          id: flip-button
+      - assertVisible: '1 ETH 􀄭 1 WETH'
+
+      # Navigate to swap settings
+      - tapOn:
+          id: swap-settings-button
+      - assertVisible: 'Degen Mode Skip the review step to swap faster'
+
+      # Interact with slippage settings
+      - assertVisible: 'Max Slippage'
+      - assertVisible: '1.0'
+      - tapOn:
+          id: slippage-increment-button
+          repeat: 3
+          delay: 500
+      - assertVisible: '2.5'
+      - tapOn:
+          id: slippage-decrement-button
+          repeat: 3
+          delay: 500
+      - assertVisible: '1.0'
+
+      # Check preferred network settings
+      - tapOn:
+          id: network-selector-button
+      - assertVisible: 'Preferred Network'
+      - tapOn: 'Berachain'
+      - assertVisible: 'Berachain.*'
+      - tapOn:
+          id: swap-bottom-action-button
+
+      - hideKeyboard
+      - longPressOn:
+          id: swap-bottom-action-button
+      - runFlow: ../utils/MaybeSetupPin.yaml
+
+      # Update balances
+      - retry:
+          maxRetries: 3
+          commands:
+            - extendedWaitUntil:
+                visible:
+                  id: balance-coin-row-Wrapped Ether
+                timeout: 30000

--- a/e2e/utils/ImportWalletWithKey.yaml
+++ b/e2e/utils/ImportWalletWithKey.yaml
@@ -8,7 +8,7 @@ env:
     visible:
       id: welcome-screen
     # the test fail quite often if the timeout is too low
-    timeout: 30000
+    timeout: 60000
 - openLink: rainbow://e2e/import?privateKey=${PKEY}&name=${NAME}
 # The first time a simulator opens a link it shows a dialog.
 - runFlow:

--- a/scripts/e2e-android.sh
+++ b/scripts/e2e-android.sh
@@ -56,7 +56,7 @@ if [ -n "$ANVIL_PID" ]; then
   kill "$ANVIL_PID" 2>/dev/null || true
 fi
 # kill any other processes using port 8545
-ANVIL_PID=$(lsof -t -i:8545 -a -c anvil 2>/dev/null)
+lsof -t -i:8545 -a -c anvil | xargs kill
 
 # Remove the Anvil log file
 rm -rf anvil.log

--- a/scripts/e2e-android.sh
+++ b/scripts/e2e-android.sh
@@ -29,7 +29,7 @@ if [[ $FLOW == *"transaction"* || $FLOW == "e2e" ]]; then
 
   # Kill any existing Anvil process
   echo "Cleaning up any existing Anvil processes..."
-  ANVIL_PID=$(lsof -t -i:8545 -c anvil 2>/dev/null)
+  ANVIL_PID=$(lsof -t -i:8545 -a -c anvil 2>/dev/null)
   if [ -n "$ANVIL_PID" ]; then
     kill $ANVIL_PID
   fi
@@ -56,7 +56,7 @@ if [ -n "$ANVIL_PID" ]; then
   kill "$ANVIL_PID" 2>/dev/null || true
 fi
 # kill any other processes using port 8545
-kill $(lsof -t -i:8545) 2>/dev/null || true
+ANVIL_PID=$(lsof -t -i:8545 -a -c anvil 2>/dev/null)
 
 # Remove the Anvil log file
 rm -rf anvil.log

--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -172,7 +172,6 @@ const SliderAndKeyboardAndBottomControls = () => {
       position="absolute"
       bottom="0px"
       style={AnimatedSwapStyles.hideWhenInputsExpanded && IS_TEST && { bottom: 50, height: 200 }}
-      testID="outer-text-please"
     >
       <SliderAndKeyboard />
       <SwapBottomPanel />

--- a/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
+++ b/src/__swaps__/screens/Swap/components/ExchangeRateBubble.tsx
@@ -176,6 +176,7 @@ export const ExchangeRateBubble = () => {
             bubbleVisibilityWrapper,
             { borderColor: isDarkMode ? SEPARATOR_COLOR : LIGHT_SEPARATOR_COLOR, borderWidth: THICK_BORDER_WIDTH },
           ]}
+          testID="swap-exchange-rate-bubble"
         >
           <Inline alignHorizontal="center" alignVertical="center" space="6px" wrap={false}>
             <AnimatedText align="center" color="labelQuaternary" size="13pt" style={{ opacity: isDarkMode ? 0.6 : 0.75 }} weight="heavy">

--- a/src/__swaps__/screens/Swap/components/FlipButton.tsx
+++ b/src/__swaps__/screens/Swap/components/FlipButton.tsx
@@ -143,6 +143,7 @@ export const FlipButton = () => {
       as={Animated.View}
       justifyContent="center"
       style={[AnimatedSwapStyles.flipButtonStyle, AnimatedSwapStyles.focusedSearchStyle, { height: 12, width: 28, zIndex: 10 }]}
+      testID="flip-button"
     >
       <Box
         as={Animated.View}

--- a/src/__swaps__/screens/Swap/components/GasButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GasButton.tsx
@@ -189,7 +189,7 @@ const GasMenu = ({ backToReview = false, children }: { backToReview?: boolean; c
           onPressMenuItem={handlePressMenuItem}
           useActionSheetFallback={false}
         >
-          <ButtonPressAnimation scaleTo={0.825} style={{ padding: GAS_BUTTON_HIT_SLOP }}>
+          <ButtonPressAnimation scaleTo={0.825} style={{ padding: GAS_BUTTON_HIT_SLOP }} testID="gas-speed-pager-button">
             {children}
           </ButtonPressAnimation>
         </ContextMenuButton>

--- a/src/__swaps__/screens/Swap/components/GasPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/GasPanel.tsx
@@ -58,14 +58,7 @@ function UnmountWhenGasPanelIsClosed({ placeholder, children }: PropsWithChildre
 
 function PressableLabel({ onPress, children }: PropsWithChildren<{ onPress: VoidFunction }>) {
   return (
-    <Box
-      as={ButtonPressAnimation}
-      paddingVertical="8px"
-      marginVertical="-8px"
-      onPress={onPress}
-      backgroundColor="accent"
-      style={{ maxWidth: 175 }}
-    >
+    <Box as={ButtonPressAnimation} paddingVertical="8px" marginVertical="-8px" onPress={onPress} style={{ maxWidth: 175 }}>
       <Inline horizontalSpace="4px" alignVertical="center">
         <Text color="labelTertiary" size="15pt" weight="semibold" numberOfLines={2}>
           {`${children} `}

--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -310,7 +310,7 @@ export function ReviewPanel() {
         </Text>
 
         <Box gap={24} justifyContent="space-between" width="full">
-          <Inline horizontalSpace="10px" alignVertical="center" alignHorizontal="justify">
+          <Inline horizontalSpace="10px" alignVertical="center" alignHorizontal="justify" testID="review-panel-network-label">
             <Inline horizontalSpace="12px" alignVertical="center">
               <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
                 􀤆
@@ -338,7 +338,7 @@ export function ReviewPanel() {
 
           <Columns space="10px" alignVertical="center" alignHorizontal="justify">
             <Column width="content">
-              <Box alignItems="center" flexDirection="row" gap={12}>
+              <Box alignItems="center" flexDirection="row" gap={12} testID="review-panel-min-received-or-max-sold-label">
                 <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
                   􀄩
                 </TextIcon>
@@ -357,7 +357,7 @@ export function ReviewPanel() {
 
           <Columns space="10px" alignVertical="center" alignHorizontal="justify">
             <Column width="content">
-              <Box alignItems="center" flexDirection="row" gap={12}>
+              <Box alignItems="center" flexDirection="row" gap={12} testID="review-panel-rainbow-fee-label">
                 <TextIcon color="labelTertiary" height={9} size="icon 13px" weight="bold" width={16}>
                   􀘾
                 </TextIcon>

--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -176,7 +176,7 @@ export const SlippageRow = () => {
 
         <Box alignItems="center" flexDirection="row">
           <Bleed horizontal="12px" vertical="8px">
-            <GestureHandlerButton onPressWorklet={handleDecrementSlippage}>
+            <GestureHandlerButton onPressWorklet={handleDecrementSlippage} testID="slippage-decrement-button">
               <Box paddingHorizontal="12px" paddingVertical="8px">
                 <Box
                   style={{
@@ -215,7 +215,7 @@ export const SlippageRow = () => {
           </Box>
 
           <Bleed horizontal="12px" vertical="8px">
-            <GestureHandlerButton onPressWorklet={handleIncrementSlippage}>
+            <GestureHandlerButton onPressWorklet={handleIncrementSlippage} testID="slippage-increment-button">
               <Box paddingHorizontal="12px" paddingVertical="8px">
                 <Box
                   style={{

--- a/src/__swaps__/screens/Swap/components/SettingsPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SettingsPanel.tsx
@@ -76,7 +76,7 @@ export function SettingsPanel() {
         {i18n.t(i18n.l.expanded_state.swap_details_v2.settings)}
       </Text>
 
-      <GestureHandlerButton onPressWorklet={SwapSettings.onToggleDegenMode} scaleTo={0.97}>
+      <GestureHandlerButton onPressWorklet={SwapSettings.onToggleDegenMode} scaleTo={0.97} testID="swap-settings-panel-degen-mode-button">
         <Box
           background={isDarkMode ? 'fillQuaternary' : 'fillTertiary'}
           borderRadius={20}

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -107,7 +107,6 @@ export function SwapBottomPanel() {
           AnimatedSwapStyles.keyboardStyle,
           AnimatedSwapStyles.swapActionWrapperStyle,
           IS_TEST && {
-            width: '100%',
             height: 200,
             opacity: 1,
             pointerEvents: 'auto',
@@ -127,12 +126,9 @@ export function SwapBottomPanel() {
           style={[
             { alignSelf: 'center' },
             IS_TEST && {
-              width: '100%',
-              height: 200,
               opacity: 1,
               pointerEvents: 'auto',
               overflow: 'visible',
-              bottom: 50,
             },
           ]}
           width="full"

--- a/src/__swaps__/screens/Swap/components/SwapNavbar.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapNavbar.tsx
@@ -71,6 +71,7 @@ function SwapSettings() {
               borderColor: isDarkMode ? separatorTertiary : opacity(separatorTertiary, 0.01),
             },
           ]}
+          testID="swap-settings-button"
         >
           <IconContainer opacity={0.8} size={34}>
             <Bleed space={isDarkMode ? '12px' : undefined}>

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -16,7 +16,7 @@ import { getColorValueForThemeWorklet, opacityWorklet } from '@/__swaps__/utils/
 import { spinnerExitConfig } from '@/components/animations/AnimatedSpinner';
 import { useColorMode } from '@/design-system';
 import { foregroundColors } from '@/design-system/color/palettes';
-import { IS_ANDROID } from '@/env';
+import { IS_ANDROID, IS_TEST } from '@/env';
 import { safeAreaInsetValues } from '@/utils';
 import { DerivedValue, SharedValue, interpolate, useAnimatedStyle, useDerivedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { NavigationSteps } from '../providers/swap-provider';
@@ -203,12 +203,18 @@ export function useAnimatedSwapStyles({
         SPRING_CONFIGS.springConfig
       ),
       borderRadius: withSpring(isBottomSheetOpen ? 40 : 0, SPRING_CONFIGS.springConfig),
-      bottom: withSpring(isBottomSheetOpen ? Math.max(safeAreaInsetValues.bottom, 28) : -2, SPRING_CONFIGS.springConfig),
+      bottom: IS_TEST
+        ? isBottomSheetOpen
+          ? 125
+          : -2
+        : withSpring(isBottomSheetOpen ? Math.max(safeAreaInsetValues.bottom, 28) : -2, SPRING_CONFIGS.springConfig),
       height: withSpring(heightForCurrentSheet, SPRING_CONFIGS.springConfig),
       left: withSpring(isBottomSheetOpen ? 12 : -2, SPRING_CONFIGS.springConfig),
       right: withSpring(isBottomSheetOpen ? 12 : -2, SPRING_CONFIGS.springConfig),
       paddingHorizontal: withSpring((isBottomSheetOpen ? 16 : 18) - THICK_BORDER_WIDTH, SPRING_CONFIGS.springConfig),
       paddingTop: withSpring((isBottomSheetOpen ? 28 : 16) - THICK_BORDER_WIDTH, SPRING_CONFIGS.springConfig),
+      overflow: IS_TEST ? 'visible' : 'hidden',
+      position: IS_TEST ? 'relative' : 'absolute',
     };
   });
 

--- a/src/design-system/components/Inline/Inline.tsx
+++ b/src/design-system/components/Inline/Inline.tsx
@@ -10,6 +10,7 @@ export type InlineProps = {
   space?: Space;
   horizontalSpace?: Space;
   verticalSpace?: Space;
+  testID?: string;
 } & (
   | {
       separator?: undefined;
@@ -34,6 +35,7 @@ export function Inline({
   verticalSpace: verticalSpaceProp,
   separator,
   wrap = true,
+  testID,
 }: InlineProps) {
   const verticalSpace = verticalSpaceProp ?? space;
   const horizontalSpace = horizontalSpaceProp ?? space;
@@ -48,6 +50,7 @@ export function Inline({
         columnGap: horizontalSpace ? resolveToken(spaceTokens, horizontalSpace) : undefined,
         rowGap: verticalSpace ? resolveToken(spaceTokens, verticalSpace) : undefined,
       }}
+      testID={testID}
     >
       {wrap || !separator
         ? children

--- a/src/helpers/RainbowContext.tsx
+++ b/src/helpers/RainbowContext.tsx
@@ -13,6 +13,7 @@ import Routes from '@rainbow-me/routes';
 import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 import { IS_ANDROID, IS_DEV, IS_TEST } from '@/env';
 import { ethers } from 'ethers';
+import { getFavorites } from '@/resources/favorites';
 
 export type RainbowContextType = {
   config: Record<keyof typeof defaultConfig, boolean> | Record<string, never>;
@@ -45,6 +46,9 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
   const [globalState, updateGlobalState] = useState({});
 
   useEffect(() => {
+    if (IS_TEST) {
+      getFavorites();
+    }
     const configFromStorage = storage.getString(storageKey);
     if (configFromStorage) {
       setConfig(config => ({ ...config, ...JSON.parse(configFromStorage) }));
@@ -113,8 +117,7 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
   return (
     <RainbowContext.Provider value={initialValue}>
       {children}
-      {/* @ts-expect-error ts-migrate(2741) FIXME: Property 'color' is missing in type... Remove this comment to see the full error message */}
-      {showReloadButton && IS_DEV && <DevButton initialDisplacement={200} />}
+      {showReloadButton && IS_DEV && <DevButton color={colors.red} initialDisplacement={200} />}
       {((showConnectToAnvilButton && IS_DEV) || IS_TEST) && (
         <>
           <DevButton color={colors.purple} onPress={connectToAnvil} initialDisplacement={150} testID={'dev-button-anvil'} size={20}>

--- a/src/references/testnet-assets-by-chain.ts
+++ b/src/references/testnet-assets-by-chain.ts
@@ -37,8 +37,10 @@ export const chainAssets: Partial<Record<ChainId, ChainAssets>> = {
       quantity: '0',
     },
   },
+  // Mainnet Assets
   [ChainId.mainnet]: {
-    eth_1: {
+    // Mainnet ETH
+    'eth_1': {
       asset: {
         asset_code: 'eth',
         mainnet_address: 'eth',
@@ -60,6 +62,58 @@ export const chainAssets: Partial<Record<ChainId, ChainAssets>> = {
           value: 2590.2,
         },
         symbol: 'ETH',
+      },
+      quantity: '0',
+    },
+    // Mainnet DAI
+    '0x6b175474e89094c44da98b954eedeac495271d0f_1': {
+      asset: {
+        asset_code: '0x6b175474e89094c44da98b954eedeac495271d0f',
+        mainnet_address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+        colors: {
+          fallback: '#FCE57F',
+          primary: '#F5AC37',
+        },
+        decimals: 18,
+        icon_url: 'https://s3.amazonaws.com/icons.assets/DAI.png',
+        name: 'Dai',
+        network: ChainName.mainnet,
+        implementations: {},
+        bridging: {
+          bridgeable: true,
+          networks: {},
+        },
+        price: {
+          relative_change_24h: 0,
+          value: 1,
+        },
+        symbol: 'DAI',
+      },
+      quantity: '0',
+    },
+    // Mainnet WETH
+    '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2_1': {
+      asset: {
+        asset_code: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        mainnet_address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        colors: {
+          fallback: '#E8EAF5',
+          primary: '#808088',
+        },
+        decimals: 18,
+        icon_url: 'https://s3.amazonaws.com/icons.assets/ETH.png',
+        name: 'Wrapped Ether',
+        network: ChainName.mainnet,
+        implementations: {},
+        bridging: {
+          bridgeable: true,
+          networks: {},
+        },
+        price: {
+          relative_change_24h: -4.586615622469276,
+          value: 2590.2,
+        },
+        symbol: 'WETH',
       },
       quantity: '0',
     },

--- a/src/state/assets/utils.ts
+++ b/src/state/assets/utils.ts
@@ -34,7 +34,7 @@ export async function fetchUserAssets(
   const { address, currency, testnetMode } = params;
 
   if (testnetMode) {
-    const { assets, chainIdsInResponse } = await fetchAnvilBalancesByChainId(address);
+    const { assets, chainIdsInResponse } = await fetchAnvilBalancesByChainId(address, ChainId.mainnet);
     const parsedAssets: Array<{
       asset: ZerionAsset;
       quantity: string;


### PR DESCRIPTION
This PR adds one flow and several test case assertions.
Added:
- Eth > Weth wrapping
- flipping assets
- review sheet
- changing gas
- degen mode
- slippage
- activity screen
- preferred network
- home screen balance updates

I decided to split these tests through the two swaps flows we currently have so that no one is super long and maybe to also reduce flakiness if possible.