### PR TITLE
Fix RN keychain crash on android api <= 29

### DIFF
--- a/patches/react-native-keychain+10.0.0.patch
+++ b/patches/react-native-keychain+10.0.0.patch
@@ -36,7 +36,7 @@ index 70912a9..006f7d8 100644
      val keyForUsername = stringPreferencesKey(getKeyForUsername(service))
      val keyForPassword = stringPreferencesKey(getKeyForPassword(service))
 diff --git a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt
-index 722a5ed..311a2f4 100644
+index 722a5ed..473c51d 100644
 --- a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt
 +++ b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt
 @@ -281,6 +281,49 @@ class KeychainModule(reactContext: ReactApplicationContext) :
@@ -89,27 +89,27 @@ index 722a5ed..311a2f4 100644
    @ReactMethod
    fun getAllGenericPasswordServices(options: ReadableMap?, promise: Promise) {
      try {
-@@ -767,19 +810,13 @@ class KeychainModule(reactContext: ReactApplicationContext) :
+@@ -766,15 +809,14 @@ class KeychainModule(reactContext: ReactApplicationContext) :
+         usePasscode ->
            BiometricManager.Authenticators.DEVICE_CREDENTIAL
  
-         else ->
+-        else ->
 -          null
+-      }
++        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ->
 +          BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
-       }
  
++        else -> null
++      }
        if (allowedAuthenticators != null) {
          promptInfoBuilder.setAllowedAuthenticators(allowedAuthenticators)
-       }
- 
--      if (!usePasscode) {
--        promptInfoOptionsMap?.getString(AuthPromptOptions.CANCEL)?.let {
--          promptInfoBuilder.setNegativeButtonText(it)
--        }
 -      }
 -
-       /* Bypass confirmation to avoid KeyStore unlock timeout being exceeded when using passive biometrics */
-       promptInfoBuilder.setConfirmationRequired(false)
-       return promptInfoBuilder.build()
+-      if (!usePasscode) {
++      } else {
+         promptInfoOptionsMap?.getString(AuthPromptOptions.CANCEL)?.let {
+           promptInfoBuilder.setNegativeButtonText(it)
+         }
 diff --git a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/PrefsStorageBase.kt b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/PrefsStorageBase.kt
 index d165f3e..91fd8b1 100644
 --- a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/PrefsStorageBase.kt


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

https://rainbow-me.sentry.io/issues/6582602973/?query=is%3Aunresolved%20createWallet&referrer=issue-stream&stream_index=1

We're getting this exception when trying to read a value in keychain on old android versions `java.lang.IllegalArgumentException: Authenticator combination is unsupported on API 28: BIOMETRIC_STRONG | DEVICE_CREDENTIAL`. This is because of our RN keychain patch. This adjusts it so we only pass `BIOMETRIC_STRONG | DEVICE_CREDENTIAL` on versions where it is supported.

## Screen recordings / screenshots


## What to test

Tested creating a wallet on moto8 on Android 9.