### PR TITLE
add debug helper for createRainbowStore

### DIFF
--- a/src/state/internal/createRainbowStore.ts
+++ b/src/state/internal/createRainbowStore.ts
@@ -7,6 +7,7 @@ import { time } from '@/utils';
 import { rainbowStorage } from './rainbowStorage';
 import { LazyPersistParams, RainbowPersistConfig, RainbowStateCreator, RainbowStore } from './types';
 import { defaultDeserializeState, defaultSerializeState, omitStoreMethods } from './utils/persistUtils';
+import { debugStore } from '@/state/internal/utils/debugStoreUtils';
 
 /**
  * Creates a Rainbow store without persistence.
@@ -42,7 +43,7 @@ export function createRainbowStore<S, PersistedState extends Partial<S> = Partia
 
   return createWithEqualityFn<S>()(
     subscribeWithSelector(
-      persist(createState, {
+      persist(persistConfig?.debug ? debugStore(createState) : createState, {
         migrate: persistConfig.migrate,
         name: persistConfig.storageKey,
         onRehydrateStorage: persistConfig.onRehydrateStorage,

--- a/src/state/internal/types.ts
+++ b/src/state/internal/types.ts
@@ -192,6 +192,11 @@ export type RainbowPersistConfig<S, PersistedState = Partial<S>> = {
    * @default 0
    */
   version?: number;
+
+  /**
+   * A simple helper for logging out every set() in a store.
+   */
+  debug?: boolean;
 };
 
 export type LazyPersistParams<S, PersistedState extends Partial<S>> = {

--- a/src/state/internal/utils/debugStoreUtils.ts
+++ b/src/state/internal/utils/debugStoreUtils.ts
@@ -1,0 +1,63 @@
+import { RainbowStateCreator } from '@/state/internal/types';
+
+export function debugStore<CreateState extends RainbowStateCreator<any>>(createState: CreateState): CreateState {
+  if (process.env.NODE_ENV === 'development') {
+    return ((set, ...rest) => {
+      // note: this is a bit off anyway because
+      let insideFn = '';
+
+      const wrappedSet = (obj: Record<string, unknown>) => {
+        const trace = new Error().stack;
+
+        const cleanTrace = trace
+          ?.trim()
+          .split('\n')
+          .map(line => {
+            const [name] = line.trim().match(/at ([^\s]+)/) || [];
+            return name?.trim();
+          })
+          .filter(Boolean)
+          .map(x => x.replace('at ', ''))
+          .filter(
+            x =>
+              x &&
+              !/^(\?anon_0|_?next|asyncGeneratorStep|tryCallOne|anonymous|apply|_|callReactNative|tryCallTwo|doResolve|Promise|flushedQueue|invokeCallbackAndReturnFlushedQueue|invokeGuardedCallback|executeDispatch)/.test(
+                x
+              )
+          )
+          .slice(1, 10)
+          .join(' > ');
+
+        console.info(`walletStore.${insideFn} set()`);
+        if (cleanTrace !== insideFn) {
+          console.info(`    via: ${cleanTrace}`);
+        }
+        const strobj = JSON.stringify(obj);
+        console.info(`    value: ${strobj.slice(0, 90) + (strobj.length > 90 ? '...' : '')}`);
+        return set(obj);
+      };
+
+      const storeObj = createState(wrappedSet, ...rest);
+
+      if (storeObj && typeof storeObj === 'object') {
+        return Object.fromEntries(
+          Object.entries(storeObj).map(([key, value]) => {
+            return [
+              key,
+              typeof value === 'function'
+                ? (...args: any[]) => {
+                    insideFn = key;
+                    return value(...args);
+                  }
+                : value,
+            ];
+          })
+        );
+      }
+
+      return storeObj;
+    }) as CreateState;
+  }
+
+  return createState;
+}


### PR DESCRIPTION
Fixes APP-2789

adding a simple option to log the contents of a RainbowStore

Note - it doesn't track through async stuff properly which is a pretty hard limitation, but I wonder if we can't figure it out by doing `new Error().stack` and having a function to manually parse out the names, not sure if error.stack gives us clean names we need.