### PR TITLE
Disable react native performance in dev

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ import { initializeReservoirClient } from '@/resources/reservoir/client';
 import { initializeRemoteConfig } from '@/model/remoteConfig';
 import { NavigationContainerRef } from '@react-navigation/native';
 import { RootStackParamList } from '@/navigation/types';
-import { IS_DEV, IS_TEST } from '@/env';
+import { IS_DEV, IS_PROD, IS_TEST } from '@/env';
 import Routes from '@/navigation/Routes';
 import { BackupsSync } from '@/state/sync/BackupsSync';
 import { AbsolutePortalRoot } from './components/AbsolutePortal';
@@ -115,7 +115,7 @@ function Root() {
   }, [setInitializing]);
 
   return initializing ? null : (
-    <PerformanceProfiler useRenderTimeouts={false} onReportPrepared={onReportPrepared}>
+    <PerformanceProfiler useRenderTimeouts={false} enabled={IS_PROD} onReportPrepared={onReportPrepared}>
       {/* @ts-expect-error - Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Provider<AppStateUpdateAction | ChartsUpdateAction | ContactsAction | ... 13 more ... | WalletsAction>> & Readonly<...>' */}
       <ReduxProvider store={store}>
         <RecoilRoot>


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Set enabled flag for `PerformanceProfiler` to true in prod only. Fast refresh can cause errors and we don't need to be measuring the performance in dev anyway. 

## Screen recordings / screenshots


## What to test

