### PR TITLE
Fix incorrect rainbow pin prompt on backup restore

### DIFF
--- a/src/components/backup/RestoreCloudStep.tsx
+++ b/src/components/backup/RestoreCloudStep.tsx
@@ -98,7 +98,7 @@ export default function RestoreCloudStep() {
 
   useEffect(() => {
     const fetchPasswordIfPossible = async () => {
-      const pwd = await getLocalBackupPassword(await maybeAuthenticateWithPIN());
+      const pwd = await getLocalBackupPassword(undefined);
       if (pwd) {
         backupsStore.getState().setStoredPassword(pwd);
         backupsStore.getState().setPassword(pwd);


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I noticed a regression caused by https://github.com/rainbow-me/rainbow/pull/6679. To repro, on a freshly installed app, restore a wallet from google drive backup. You will then be incorrectly prompted for a rainbow pin before entering the backup password.

The issue is that I added `maybeAuthenticateWithPIN` incorrectly there for backup restore when trying to get the backup password from keychain. At this point the rainbow pin has not yet been set up and the backup password doesn't exist in the keychain.

The keychain code only prompts for rainbow pin if the key we're trying to get actually exists, which means it won't display here, so in that case just let the keychain handle the pin prompt instead of explicitly showing it.

## Screen recordings / screenshots

Before:

https://github.com/user-attachments/assets/7f3be838-25f9-4469-b3b1-5c152e932076

After:

https://github.com/user-attachments/assets/2228435e-ff84-4f82-b885-1cbeadedc73f

## What to test

On a fresh app restore a backup from google drive.