### PR TITLE
Fix iOS 26 touches crash

### DIFF
--- a/ios/Button.swift
+++ b/ios/Button.swift
@@ -158,7 +158,7 @@ class Button : RCTView {
     }
     if let touch = touches.first {
       let location = touch.location(in: self)
-      onCancel(["close":Button.isClose(locationA: location, locationB: tapLocation!), "state": self.longPress?.value(forKey: "_state")])
+      onCancel(["close":Button.isClose(locationA: location, locationB: tapLocation!), "state": self.longPress?.state ?? UIGestureRecognizer.State.cancelled])
     }
     if shouldLongPressHoldPress == false {
       animator = animateTapEnd(duration: pressOutDuration == -1 ? duration : pressOutDuration)


### PR DESCRIPTION
## What changed (plus any additional context for devs)
iOS 26 removed accessing a private `_state` field on the `UILongPressGestureRecognizer`, but it never needed to be accessed this way. Changing it to normal public access fixes the crash. 
