### PR TITLE
Fix broken link to React Native Reanimated installation docs

### DIFF
--- a/src/react-native-animated-charts/README.md
+++ b/src/react-native-animated-charts/README.md
@@ -17,7 +17,7 @@ It's a part of the [Rainbow.me project](https://rainbow.me/).
 
 ## Installation
 
-1. Install [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/docs/next/installation) in the newest version.
+1. Install [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) in the newest version.
 2.
 
 ```bash


### PR DESCRIPTION
Replaced the outdated and broken link to the React Native Reanimated installation documentation in the README with the current official URL:
https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/
This ensures users can access the latest installation instructions.