### PR TITLE
Fix: ERC20 Token Transfer Stuck on "Loading"

### DIFF
--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -101,10 +101,10 @@ const ContactRow = ({ address, color, nickname, symmetricalMargins, ...props }, 
     if (showcaseItem) {
       onPress(showcaseItem, nickname);
     } else {
-      const recipient = accountType === 'suggestions' && isENSAddressFormat(nickname) ? nickname : ensName || address;
+      const recipient = accountType === 'suggestions' && isENSAddressFormat(nickname) ? nickname : address;
       onPress(recipient, nickname ?? recipient);
     }
-  }, [accountType, address, ensName, nickname, onPress, showcaseItem]);
+  }, [accountType, address, nickname, onPress, showcaseItem]);
 
   const imageAvatar = ensAvatar?.imageUrl ?? image;
 

--- a/src/components/send/SendContactList.js
+++ b/src/components/send/SendContactList.js
@@ -17,7 +17,7 @@ import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
 import styled from '@/styled-thing';
 import { useTheme } from '@/theme';
-import { filterList } from '@/utils';
+import { filterList, isLowerCaseMatch } from '@/utils';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 
 const KeyboardArea = styled.View({
@@ -129,13 +129,13 @@ export default function SendContactList({
   const filteredAddresses = useMemo(() => {
     return sortBy(
       filterList(
-        userAccounts.filter(account => account.visible && account.address.toLowerCase() !== accountAddress.toLowerCase()),
+        userAccounts.filter(account => account.visible && !isLowerCaseMatch(account.address, accountAddress)),
         currentInput,
         ['label']
       ),
       ['index']
     );
-  }, [currentInput, userAccounts]);
+  }, [accountAddress, currentInput, userAccounts]);
 
   const filteredWatchedAddresses = useMemo(() => {
     return sortBy(


### PR DESCRIPTION
Fixes APP-2680

## What changed (plus any additional context for devs)
We had an erroneous `ensName` prop that was resolving to the shorthand of the address field (e.g. - `0x1231...123123`) that was throwing an invalid address which put users into an infinite loading button state. This fixes it by always using the address.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/5b70df61-3439-4aed-8d43-41336c658d27

## What to test
ERC 20 sends to addresses, ens names, contacts, etc.
