### PR TITLE
fix keychain reset not resetting wallet state

### DIFF
--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -188,6 +188,7 @@ const DevSection = () => {
       if (shouldWipeKeychain) {
         await wipeKeychain();
         await clearMMKVStorage();
+        await clearWalletState({ resetKeychain: true });
 
         // we need to navigate back to the welcome screen
         navigate(Routes.WELCOME_SCREEN);


### PR DESCRIPTION
Fixes bug with duplicated wallets after resetting keychain.

Testing flow:

1. Import wallets using seed or backup
2. Hit "Reset Keychain" and confirm
3. Import same seed or backup again
4. Make sure they look right - no duplicate wallets.