### PR TITLE
Run e2e tests on develop

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -3,13 +3,17 @@ name: Android e2e tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - develop
 jobs:
   android-e2e:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: app-e2e-runner
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      # For pushes on develop run for every commit, but for PRs cancel in-progress runs.
+      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
 
     env:

--- a/.github/workflows/macstadium-ios-e2e.yml
+++ b/.github/workflows/macstadium-ios-e2e.yml
@@ -4,14 +4,17 @@ on:
     # prevent running on draft PRs
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
-
+  push:
+    branches:
+      - develop
 jobs:
   # iOS build and e2e tests
   e2e-ios:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ["self-hosted"]
     concurrency:
-      group: e2e-ios-${{ github.workflow }}-${{ github.ref }}
+      # For pushes on develop run for every commit, but for PRs cancel in-progress runs.
+      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: read


### PR DESCRIPTION
Fixes RNBW-4879

## What changed (plus any additional context for devs)

Make test run on develop pushes. Also make sure concurrency settings doesn't cancel in progress runs to make sure it runs on every commit when running on develop.

## Screen recordings / screenshots

N/A

## What to test

Check that tests run on develop properly once merged.

