### PR TITLE
[FIX] ios e2e Discover test failing

### DIFF
--- a/e2e/screens/Discover.yaml
+++ b/e2e/screens/Discover.yaml
@@ -73,9 +73,5 @@ tags:
       - tapOn:
           id: profile-sheet-watch-button
       - runFlow: ../utils/MaybeSetupPin.yaml
-      #   - swipe:
-      #       direction: DOWN
-      #   - tapOn:
-      #       id: done-button
       - assertVisible:
           id: wallet-screen


### PR DESCRIPTION
Fixes RNBW-4878

## What changed (plus any additional context for devs)
- Previously when watching a wallet our app wouldn't navigate the user back to the wallet screen
- This behavior was fixed with the new wallet state work
- The e2e test now reflects the correct flow
- This should get all ios tests passing consistently


## What to test
- do they pass?