### PR TITLE
Improve google sign in in e2e tests

### DIFF
--- a/e2e/settings/AndroidCloudBackup.yaml
+++ b/e2e/settings/AndroidCloudBackup.yaml
@@ -34,24 +34,7 @@ tags:
             # Begin backup flow by tapping backup now button
             - tapOn:
                 id: backup-now-button
-            - assertVisible: '(Sign in|Choose an account)'
-
-            # Sign in to Google Drive
-            - tapOn: 'Email or phone'
-            - tapOn:
-                id: 'identifierId'
-            - inputText: ${CLOUD_BACKUP_EMAIL}
-            - tapOn:
-                id: 'identifierNext'
-            - tapOn:
-                text: 'Enter your password'
-            - inputText: ${CLOUD_BACKUP_PASSWORD}
-            - tapOn:
-                id: 'passwordNext'
-
-            # Accept TOS
-            - tapOn: 'I agree'
-            - tapOn: 'ACCEPT'
+            - runFlow: ../utils/GoogleSignIn.yaml
             - runFlow: ../utils/MaybeSetupPin.yaml
 
             # Set up Rainbow Cloud password
@@ -86,8 +69,7 @@ tags:
                 repeat: 4
                 delay: 1000
             - assertVisible: '(Sign in|Choose an account)'
-            - tapOn:
-                id: 'com.google.android.gms:id/account_display_name'
+            - tapOn: ${CLOUD_BACKUP_EMAIL}
 
             # Verify backsups are wiped
             - assertVisible: 'Not Enabled'

--- a/e2e/utils/GoogleSignIn.yaml
+++ b/e2e/utils/GoogleSignIn.yaml
@@ -1,0 +1,60 @@
+appId: ${APP_ID}
+---
+- assertVisible: '(Sign in|Choose an account)'
+
+- runScript:
+    when:
+      visible: ${CLOUD_BACKUP_EMAIL}
+    file: ./isLoggedIn.js
+
+# Already logged in
+- runFlow:
+    when:
+      true: ${output.isLoggedIn == true}
+    commands:
+      - tapOn: ${CLOUD_BACKUP_EMAIL}
+
+- runFlow:
+    when:
+      true: ${output.isLoggedIn != true}
+    commands:
+      # Sign in to Google Drive, no existing account
+      - runFlow:
+          when:
+            visible: Sign in
+          commands:
+            - tapOn: 'Email or phone'
+
+      # Sign in to Google Drive, has existing account
+      - runFlow:
+          when:
+            visible: Choose an account
+          commands:
+            - tapOn: 'Add another account'
+
+      - tapOn:
+          id: 'identifierId'
+      - inputText: ${CLOUD_BACKUP_EMAIL}
+      - tapOn: 'NEXT'
+      - tapOn:
+          text: 'Enter your password'
+          optional: true
+      - inputText: ${CLOUD_BACKUP_PASSWORD}
+      - tapOn: 'NEXT'
+
+      # Handle Google Password Manager prompt
+      - runFlow:
+          when:
+            visible: Google Password Manager
+          commands:
+            - tapOn: '(Not now|Never)'
+
+      # Accept TOS
+      - tapOn: 'I agree'
+      # Disable device backup
+      - tapOn:
+          id: 'com.google.android.gms:id/sud_items_switch'
+          optional: true
+      - tapOn:
+          text: 'ACCEPT'
+          optional: true

--- a/e2e/utils/isLoggedIn.js
+++ b/e2e/utils/isLoggedIn.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-undef */
+
+output.isLoggedIn = true;

--- a/scripts/e2e-android-ci.sh
+++ b/scripts/e2e-android-ci.sh
@@ -16,7 +16,7 @@ echo "Running on devices: $DEVICES_LIST"
 # Install the app
 for DEVICE in $DEVICES; do
   echo "Install app on $DEVICE"
-  $ANDROID_HOME/platform-tools/adb -s "$DEVICE" install -r ./android/app/build/outputs/apk/release/app-release.apk &
+  adb -s "$DEVICE" install -r ./android/app/build/outputs/apk/release/app-release.apk &
 done
 wait
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

The android cloud backup test did not handle the case where the app is already logged in. This can happen if the test fails after it has logged in, and also when testing locally without having to wipe the emulator every timee.

## Screen recordings / screenshots

N/A

## What to test

Android backup test passes