### PR TITLE
fix keyboard issue on android

### DIFF
--- a/src/screens/ImportOrWatchWalletSheet.tsx
+++ b/src/screens/ImportOrWatchWalletSheet.tsx
@@ -12,6 +12,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { LoadingOverlay } from '@/components/modal';
 import { RootStackParamList } from '@/navigation/types';
 import Routes from '@/navigation/routesNames';
+import { Keyboard } from 'react-native';
 
 const TRANSLATIONS = i18n.l.wallet.new.import_or_watch_wallet_sheet;
 
@@ -32,10 +33,15 @@ export const ImportOrWatchWalletSheet = () => {
 
   useFocusEffect(
     useCallback(() => {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         inputRef.current?.focus();
         // lower value than this seems to cause a bug where it de-focuses immediately
       }, 500);
+
+      return () => {
+        clearTimeout(timer);
+        Keyboard.dismiss();
+      };
     }, [inputRef])
   );
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- keyboard wasn't dismissing when going to create / input pin after watching a wallet

## Screen recordings / screenshots
Of course. Here is the markdown table for your GitHub PR:

| Before | After |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/739ae3c2-a96c-4e9f-841a-9b845a516032"></video> | <video src="https://github.com/user-attachments/assets/4c4eb0db-8f43-4d54-830d-be2c0f17a4ee"></video> |



## What to test
- watch a wallet on android, does keyboard dismiss?
