### PR TITLE
fix activity list scrolling down after switching wallets

### DIFF
--- a/src/components/activity-list/ActivityList.tsx
+++ b/src/components/activity-list/ActivityList.tsx
@@ -3,7 +3,7 @@ import { FastTransactionCoinRow } from '@/components/coin-row';
 import { lazyMount } from '@/helpers/lazyMount';
 import { DEVICE_HEIGHT } from '@/utils/deviceUtils';
 import { LegendList, LegendListRef } from '@legendapp/list';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import ActivityIndicator from '../ActivityIndicator';
 import Spinner from '../Spinner';
@@ -135,20 +135,36 @@ const ActivityList = lazyMount(() => {
     [nativeCurrency, theme]
   );
 
+  const listRef = useRef<LegendListRef | null>(null);
+
+  const scrollToTopRef = useMemo(() => {
+    return {
+      scrollToTop() {
+        if (!listRef.current) {
+          return;
+        }
+        if (listRef.current.getState().isAtStart) {
+          return;
+        }
+        listRef.current.scrollToIndex({
+          index: 0,
+          animated: true,
+        });
+      },
+    };
+  }, []);
+
+  useEffect(() => {
+    setScrollToTopRef?.(scrollToTopRef);
+  }, [scrollToTopRef, setScrollToTopRef]);
+
   return (
     <LegendList
       data={flatData}
-      ref={list => {
-        if (list) {
-          setScrollToTopRef?.({
-            scrollToTop() {
-              list.scrollToIndex({
-                index: 0,
-                animated: true,
-              });
-            },
-          });
-        }
+      // changing key
+      key={accountAddress}
+      ref={ref => {
+        listRef.current = ref;
       }}
       renderItem={renderItem}
       keyExtractor={keyExtractor}


### PR DESCRIPTION
was caused by legend list not liking getting all new list data where one or two keys could match in different places due to label titles being off.

## What changed (plus any additional context for devs)

Bug:

- Have two wallets where the titles "This month" aren't in the same location on the list, then go home switch to one, go to activity list, go back home, switch to another, back to activity list - bug shows that it scroll downs partially to where the old title was.
