### PR TITLE
[e2e fix] calculate bottom inset w/ screen height vs window height

### DIFF
--- a/e2e/utils/GoogleSignIn.yaml
+++ b/e2e/utils/GoogleSignIn.yaml
@@ -35,14 +35,12 @@ appId: ${APP_ID}
       - tapOn:
           id: 'identifierId'
       - inputText: ${CLOUD_BACKUP_EMAIL}
-      - tapOn:
-          id: 'identifierNext'
+      - tapOn: 'NEXT'
       - tapOn:
           text: 'Enter your password'
           optional: true
       - inputText: ${CLOUD_BACKUP_PASSWORD}
-      - tapOn:
-          id: 'passwordNext'
+      - tapOn: 'NEXT'
 
       # Handle Google Password Manager prompt
       - runFlow:


### PR DESCRIPTION
Fixes RNBW-4880

## What changed (plus any additional context for devs)
Android navigation bar was overlaying the settings sheet and sub-sheets on Pixel 6+. The behavior now matches older phones + other screens in our app.

Tested on an older phone as well to make sure theres no unintended introduced behaviors.

tl;dr: android nav bar was intercepting the tap on step before the failing step bc on Pixel 6+ the android nav bar overlays it (I didnt see this when writing the test bc i accidentally wrote it using Pixel 5)

| Before | After |
| ----- | ----- |
| <img width="352" height="199" alt="Screenshot 2025-07-14 at 12 08 49 PM" src="https://github.com/user-attachments/assets/3b074168-0ba2-4517-b8c4-f407e2814506" /> | <img width="338" height="236" alt="Screenshot 2025-07-14 at 12 35 40 PM" src="https://github.com/user-attachments/assets/6cd840fc-6445-4f2d-9663-86e7e98c33dc" /> |

## What to test
- Does the AndroidCloudBackup test pass now?
- No weird safe areas on older phones / newer phones?
