### PR TITLE
Use sentry token from secrets

### DIFF
--- a/.github/workflows/macstadium-builds.yml
+++ b/.github/workflows/macstadium-builds.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ["self-hosted"]
     timeout-minutes: 75
     if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     permissions:
@@ -67,11 +67,13 @@ jobs:
         with:
           key: xcode-cache-deriveddata-${{ github.workflow }}-${{ github.sha }}
           restore-keys: xcode-cache-deriveddata-${{ github.workflow }}-
-        
-        # TOPHAT iOS SIM   
+
+        # TOPHAT iOS SIM
       - name: Build the app in release mode for simulator
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          sed -i'' -e "s/IS_TESTING=true/IS_TESTING=false/" .env && rm -f .env-e 
+          sed -i'' -e "s/IS_TESTING=true/IS_TESTING=false/" .env && rm -f .env-e
           sed -i '' 's/match AppStore/match AdHoc/g' "ios/Rainbow.xcodeproj/project.pbxproj"
 
           xcodebuild -workspace ios/Rainbow.xcworkspace -scheme Rainbow -configuration Release -sdk iphonesimulator -derivedDataPath ios/build
@@ -81,12 +83,13 @@ jobs:
         run: |
           cp ~/appstore/AuthKey_63N65C2G2S.p8 ios/fastlane/AuthKey_63N65C2G2S.p8
 
-        # TOPHAT iOS DEVICE  
+        # TOPHAT iOS DEVICE
       - name: Build the app in release mode for iOS devices
-        env: 
+        env:
           FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
             cd ios && gem update fastlane && bundle exec fastlane ios build_device
       - name: Upload builds to AWS S3
@@ -101,7 +104,7 @@ jobs:
             aws s3 cp "${APP_FILE}" "s3://${AWS_BUCKET}/${BRANCH_NAME}/${COMMIT_HASH}.app.zip"
             IPA_FILE=./ios/build/Rainbow.ipa
             aws s3 cp "${IPA_FILE}" "s3://${AWS_BUCKET}/${BRANCH_NAME}/${COMMIT_HASH}.ipa"
-            
+
       - name: Post comment to PR
         if: github.event_name == 'pull_request'
         env:
@@ -113,6 +116,6 @@ jobs:
           curl -s -H "Authorization: token $TOPHAT_GITHUB_TOKEN" -X POST \
           -d "{\"body\":\"$COMMENT\"}" \
           "${{ github.event.pull_request.comments_url }}"
-          
-          
-       
+
+
+

--- a/.github/workflows/macstadium-ios-e2e.yml
+++ b/.github/workflows/macstadium-ios-e2e.yml
@@ -75,6 +75,8 @@ jobs:
         run: export MAESTRO_VERSION=1.39.13; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
       - name: Modify env and build app in release mode
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           sed -i'' -e "s/IS_TESTING=false/IS_TESTING=true/" .env && rm -f .env-e
           ./scripts/e2e-ios-build.sh


### PR DESCRIPTION
Fixes RNBW-4882

## What changed (plus any additional context for devs)

The sentry token on macstadium runners no longer work, instead of relying on it we use the one from repo secrets.

## Screen recordings / screenshots


## What to test

builds pass