### PR TITLE
Add shebang to check-lockfile.sh

### DIFF
--- a/scripts/check-lockfile.sh
+++ b/scripts/check-lockfile.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 git diff yarn.lock
 if ! git diff --exit-code yarn.lock; then
     echo "Changes were detected in yarn.lock file after running 'yarn install', which is not expected. Please run 'yarn install' locally and commit the changes.";


### PR DESCRIPTION
Add a #!/bin/bash shebang line at the top of the scripts/check-lockfile.sh script to explicitly specify the Bash interpreter. This ensures the script runs correctly as an executable in Unix-like environments. No other changes were made.