### PR TITLE
New tab bar

### DIFF
--- a/src/components/tab-bar/BrowserTabIcon.tsx
+++ b/src/components/tab-bar/BrowserTabIcon.tsx
@@ -8,26 +8,27 @@ import { Box, useColorMode, TextIcon } from '@/design-system';
 import { useBrowserStore } from '@/state/browser/browserStore';
 import { THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { opacityWorklet } from '@/__swaps__/utils/swaps';
+import { shallowEqual } from '@/worklets/comparisons';
 import { TIMING_CONFIGS } from '../animations/animationConfigs';
-import { TAB_BAR_PILL_HEIGHT, TAB_BAR_PILL_WIDTH } from './dimensions';
+import { TAB_BAR_PILL_HEIGHT } from './dimensions';
 
 export const BrowserTabIcon = memo(function BrowserTabIcon({
   accentColor,
   index,
   reanimatedPosition,
+  showNavButtons,
   tabBarIcon,
 }: {
   accentColor: string;
   index: number;
   reanimatedPosition: SharedValue<number>;
+  showNavButtons: SharedValue<boolean>;
   tabBarIcon: string;
 }) {
   const { isDarkMode } = useColorMode();
   const { goBack, goForward } = useBrowserTabBarContext();
 
-  const navState = useBrowserStore(state => state.getActiveTabNavState());
-
-  const showNavButtons = useDerivedValue(() => reanimatedPosition.value === 2 && (navState.canGoBack || navState.canGoForward));
+  const navState = useBrowserStore(state => state.getActiveTabNavState(), shallowEqual);
 
   const navButtonsBackgroundOpacity = useDerivedValue(() => {
     const navButtonsVisible = reanimatedPosition.value === 2 && (navState.canGoBack || navState.canGoForward);
@@ -79,16 +80,10 @@ export const BrowserTabIcon = memo(function BrowserTabIcon({
   });
 
   return (
-    <Box
-      testID="dapp-browser-tab-icon"
-      width={{ custom: TAB_BAR_PILL_WIDTH }}
-      height={{ custom: TAB_BAR_PILL_HEIGHT }}
-      alignItems="center"
-      justifyContent="center"
-    >
-      <Animated.View style={[navButtonsStyle, styles.navButtonsPill]}>
+    <Box alignItems="center" height={{ custom: TAB_BAR_PILL_HEIGHT }} justifyContent="center" testID="dapp-browser-tab-icon" width="full">
+      <Animated.View style={[styles.navButtonsPill, navButtonsStyle]}>
         <ButtonPressAnimation
-          onPress={() => goBack()}
+          onPress={goBack}
           scaleTo={0.75}
           style={[styles.navButton, styles.backButton, { pointerEvents: navState.canGoBack ? 'auto' : 'none' }]}
         >
@@ -99,7 +94,7 @@ export const BrowserTabIcon = memo(function BrowserTabIcon({
           </Animated.View>
         </ButtonPressAnimation>
         <ButtonPressAnimation
-          onPress={() => goForward()}
+          onPress={goForward}
           scaleTo={0.75}
           style={[styles.navButton, styles.forwardButton, { pointerEvents: navState.canGoForward ? 'auto' : 'none' }]}
         >
@@ -153,6 +148,5 @@ const styles = StyleSheet.create({
     borderRadius: TAB_BAR_PILL_HEIGHT / 2,
     flexDirection: 'row',
     height: TAB_BAR_PILL_HEIGHT,
-    width: TAB_BAR_PILL_WIDTH,
   },
 });

--- a/src/components/tab-bar/TabBarIcon.tsx
+++ b/src/components/tab-bar/TabBarIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import MaskedView from '@react-native-masked-view/masked-view';
 import React from 'react';
 import Animated, { interpolate, interpolateColor, useAnimatedStyle, SharedValue, AnimatedStyle } from 'react-native-reanimated';
@@ -25,7 +24,7 @@ export function TabBarIcon({ accentColor, hideShadow, icon, index, reanimatedPos
 
   const hasTransparentInnerFill = icon === 'tabDiscover' || icon === 'tabPoints' || icon === 'tabDappBrowser';
 
-  const outlineColor = isDarkMode ? globalColors.blueGrey60 : globalColors.blueGrey70;
+  const outlineColor = isDarkMode ? globalColors.white70 : globalColors.grey70;
 
   const iconColor = useAnimatedStyle(() => {
     const backgroundColor = interpolateColor(
@@ -75,9 +74,9 @@ export function TabBarIcon({ accentColor, hideShadow, icon, index, reanimatedPos
       [index - 0.7, index - 0.3, index, index + 0.3, index + 0.7],
       [
         isDarkMode ? outlineColor : '#FEFEFE',
-        tintBackdrop || (hasTransparentInnerFill ? (isDarkMode ? '#171819' : '#FEFEFE') : accentColor),
-        tintBackdrop || (hasTransparentInnerFill ? (isDarkMode ? '#171819' : '#FEFEFE') : accentColor),
-        tintBackdrop || (hasTransparentInnerFill ? (isDarkMode ? '#171819' : '#FEFEFE') : accentColor),
+        tintBackdrop || (hasTransparentInnerFill ? (isDarkMode ? '#1F2020' : '#FEFEFE') : accentColor),
+        tintBackdrop || (hasTransparentInnerFill ? (isDarkMode ? '#1F2020' : '#FEFEFE') : accentColor),
+        tintBackdrop || (hasTransparentInnerFill ? (isDarkMode ? '#1F2020' : '#FEFEFE') : accentColor),
         isDarkMode ? outlineColor : '#FEFEFE',
       ]
     );

--- a/src/components/tab-bar/dimensions.ts
+++ b/src/components/tab-bar/dimensions.ts
@@ -1,4 +1,12 @@
+import { initialWindowMetrics } from 'react-native-safe-area-context';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+
+export const TAB_BAR_HORIZONTAL_INSET = (initialWindowMetrics?.insets.bottom ?? 0) + 6;
+export const TAB_BAR_WIDTH = DEVICE_WIDTH - TAB_BAR_HORIZONTAL_INSET * 2;
 export const TAB_BAR_ICON_SIZE = 28;
 
-export const TAB_BAR_PILL_HEIGHT = 36;
-export const TAB_BAR_PILL_WIDTH = 72;
+export const TAB_BAR_INNER_PADDING = 4;
+
+export const BROWSER_BUTTONS_PILL_WIDTH = 72;
+export const TAB_BAR_PILL_HEIGHT = 44;
+export const TAB_BAR_PILL_WIDTH = (DEVICE_WIDTH - TAB_BAR_HORIZONTAL_INSET * 2 - TAB_BAR_INNER_PADDING * 2) / 5;

--- a/src/navigation/RecyclerListViewScrollToTopContext.tsx
+++ b/src/navigation/RecyclerListViewScrollToTopContext.tsx
@@ -1,26 +1,33 @@
-import { RecyclerListViewRef } from '@/components/asset-list/RecyclerAssetList2/core/ViewTypes';
-import React, { createContext, useState } from 'react';
+import React, { createContext, useContext, useRef } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { RecyclerListViewRef } from '@/components/asset-list/RecyclerAssetList2/core/ViewTypes';
 
 export const RecyclerListViewScrollToTopContext = createContext<{
   scrollToTop: () => void;
   setScrollToTopRef: (ref: RecyclerListViewRef | null) => void;
 }>({
-  scrollToTop: () => {},
-  setScrollToTopRef: () => {},
+  scrollToTop: () => {
+    return;
+  },
+  setScrollToTopRef: () => {
+    return;
+  },
 });
 
 type ScrollToTopProviderProps = {
   children: React.ReactNode;
 };
 
-const RecyclerListViewScrollToTopProvider: React.FC<ScrollToTopProviderProps> = ({ children }) => {
+export function RecyclerListViewScrollToTopProvider({ children }: ScrollToTopProviderProps) {
   const insets = useSafeAreaInsets();
-
-  const [scrollToTopRef, setScrollToTopRef] = useState<RecyclerListViewRef | null>(null);
+  const scrollToTopRef = useRef<RecyclerListViewRef | null>(null);
 
   const scrollToTop = () => {
-    scrollToTopRef?.scrollToOffset(0, -insets.top, true);
+    scrollToTopRef?.current?.scrollToOffset(0, -insets.top, true);
+  };
+
+  const setScrollToTopRef = (ref: RecyclerListViewRef | null) => {
+    scrollToTopRef.current = ref;
   };
 
   return (
@@ -28,8 +35,6 @@ const RecyclerListViewScrollToTopProvider: React.FC<ScrollToTopProviderProps> = 
       {children}
     </RecyclerListViewScrollToTopContext.Provider>
   );
-};
+}
 
-export const useRecyclerListViewScrollToTopContext = () => React.useContext(RecyclerListViewScrollToTopContext);
-
-export default RecyclerListViewScrollToTopProvider;
+export const useRecyclerListViewScrollToTopContext = () => useContext(RecyclerListViewScrollToTopContext);

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -1,18 +1,24 @@
 import ConditionalWrap from 'conditional-wrap';
-import { BlurView } from 'react-native-blur-view';
-import { LIGHT_SEPARATOR_COLOR } from '@/__swaps__/screens/Swap/constants';
+import { THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { BrowserTabBarContextProvider, useBrowserTabBarContext } from '@/components/DappBrowser/BrowserContext';
 import { ButtonPressAnimation } from '@/components/animations';
 import { FlexItem } from '@/components/layout';
 import { TabBarIcon } from '@/components/tab-bar/TabBarIcon';
-import { TAB_BAR_PILL_HEIGHT, TAB_BAR_PILL_WIDTH } from '@/components/tab-bar/dimensions';
+import {
+  TAB_BAR_PILL_HEIGHT,
+  TAB_BAR_HORIZONTAL_INSET,
+  TAB_BAR_PILL_WIDTH,
+  TAB_BAR_INNER_PADDING,
+  TAB_BAR_WIDTH,
+} from '@/components/tab-bar/dimensions';
 import { TestnetToast } from '@/components/toasts';
 import { DAPP_BROWSER, KING_OF_THE_HILL_TAB, LAZY_TABS, POINTS, useExperimentalFlag } from '@/config';
-import { Box, Columns, globalColors, Stack, useForegroundColor, useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
+import { Box, Column, Columns, globalColors, useColorMode } from '@/design-system';
+import { IS_IOS, IS_TEST } from '@/env';
 import { useAccountAccentColor, useAccountSettings, useCoinListEdited, useDimensions } from '@/hooks';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import RecyclerListViewScrollToTopProvider, {
+import {
+  RecyclerListViewScrollToTopProvider,
   useRecyclerListViewScrollToTopContext,
 } from '@/navigation/RecyclerListViewScrollToTopContext';
 import { DappBrowser } from '@/components/DappBrowser/DappBrowser';
@@ -21,86 +27,101 @@ import WalletScreen from '@/screens/WalletScreen/WalletScreen';
 import { useTheme } from '@/theme';
 import { deviceUtils } from '@/utils';
 import { createMaterialTopTabNavigator, MaterialTopTabNavigationEventMap } from '@react-navigation/material-top-tabs';
-import { MaterialTopTabBarProps, MaterialTopTabDescriptorMap } from '@react-navigation/material-top-tabs/lib/typescript/src/types';
+import {
+  MaterialTopTabBarProps,
+  MaterialTopTabDescriptorMap,
+  MaterialTopTabNavigationOptions,
+} from '@react-navigation/material-top-tabs/lib/typescript/src/types';
 import { NavigationHelpers, ParamListBase, RouteProp } from '@react-navigation/native';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { MutableRefObject, memo, useCallback, useMemo, useRef, useState } from 'react';
 import { InteractionManager, StyleSheet, View } from 'react-native';
 import Animated, {
+  DerivedValue,
+  Easing,
   interpolate,
+  runOnJS,
+  SharedValue,
   useAnimatedReaction,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
+  withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import {
-  BROWSER_BACKGROUND_COLOR_DARK,
-  BROWSER_BACKGROUND_COLOR_LIGHT,
-  HOMEPAGE_BACKGROUND_COLOR_DARK,
-  HOMEPAGE_BACKGROUND_COLOR_LIGHT,
-} from '@/components/DappBrowser/constants';
-import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
+import { BROWSER_BACKGROUND_COLOR_DARK, BROWSER_BACKGROUND_COLOR_LIGHT } from '@/components/DappBrowser/constants';
+import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useBrowserStore } from '@/state/browser/browserStore';
 import { opacityWorklet } from '@/__swaps__/utils/swaps';
 import ProfileScreen from '../screens/ProfileScreen';
 import DiscoverScreen from '@/screens/DiscoverScreen';
 import { discoverScrollToTopFnRef, discoverOpenSearchFnRef } from '@/components/Discover/DiscoverScreenContext';
-import { ScrollPositionContext } from './ScrollPositionContext';
 import { MainListProvider, useMainList } from './MainListContext';
-import Routes from './routesNames';
+import Routes, { Route } from './routesNames';
 import { ActivityTabIcon } from '@/components/tab-bar/ActivityTabIcon';
 import { BrowserTabIcon } from '@/components/tab-bar/BrowserTabIcon';
 import { initialWindowMetrics } from 'react-native-safe-area-context';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
-import { useNavigationStore } from '@/state/navigation/navigationStore';
 import { KingOfTheHillScreen } from '@/screens/KingOfTheHill';
+import { setActiveRoute, useNavigationStore } from '@/state/navigation/navigationStore';
+import { darkModeThemeColors, lightModeThemeColors } from '@/styles/colors';
+import { BlurGradient } from '@/components/blur/BlurGradient';
+import LinearGradient from 'react-native-linear-gradient';
+import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
+import MaskedView from '@react-native-masked-view/masked-view';
+import { PANEL_COLOR_DARK } from '@/components/SmoothPager/ListPanel';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 
-export const BASE_TAB_BAR_HEIGHT = 48;
+export const BASE_TAB_BAR_HEIGHT = 52;
 export const TAB_BAR_HEIGHT = getTabBarHeight();
 
 function getTabBarHeight() {
-  return BASE_TAB_BAR_HEIGHT + (initialWindowMetrics?.insets.bottom ?? 0);
+  return BASE_TAB_BAR_HEIGHT + (initialWindowMetrics?.insets.bottom ?? 0) + 6;
 }
 
-const HORIZONTAL_TAB_BAR_INSET = 6;
-const HORIZONTAL_TAB_BAR_INSET_5_TABS = 10;
+const TAB_BAR_BORDER_RADIUS = BASE_TAB_BAR_HEIGHT / 2;
 
-const Swipe = createMaterialTopTabNavigator();
+const TAB_BAR_ICONS = {
+  [Routes.WALLET_SCREEN]: 'tabHome',
+  [Routes.DISCOVER_SCREEN]: 'tabDiscover',
+  [Routes.DAPP_BROWSER_SCREEN]: 'tabDappBrowser',
+  [Routes.PROFILE_SCREEN]: 'tabActivity',
+  [Routes.KING_OF_THE_HILL]: 'tabKingOfTheHill',
+  [Routes.POINTS_SCREEN]: 'tabPoints',
+} as const;
 
-interface TabBarProps {
-  descriptors: MaterialTopTabDescriptorMap;
+type TabIconKey = (typeof TAB_BAR_ICONS)[keyof typeof TAB_BAR_ICONS];
+
+type TabBarProps = {
+  activeIndex: DerivedValue<number>;
+  descriptorsRef: MutableRefObject<MaterialTopTabDescriptorMap>;
+  getIsFocused: (index: number) => boolean;
   jumpTo: (key: string) => void;
   navigation: NavigationHelpers<ParamListBase, MaterialTopTabNavigationEventMap>;
-  state: { index: number; routes: RouteProp<ParamListBase, string>[] };
-}
+  stateRef: MutableRefObject<{ index: number; routes: RouteProp<ParamListBase, string>[] }>;
+};
 
-const TabBar = ({ descriptors, jumpTo, navigation, state }: TabBarProps) => {
+const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused, jumpTo, navigation, stateRef }: TabBarProps) {
   const { highContrastAccentColor: accentColor } = useAccountAccentColor();
   const { extraWebViewHeight, tabViewProgress } = useBrowserTabBarContext();
   const { isDarkMode } = useColorMode();
   const { width: deviceWidth } = useDimensions();
-  const { colors } = useTheme();
+  // const { colors } = useTheme();
   const recyclerList = useRecyclerListViewScrollToTopContext();
   const mainList = useMainList();
 
-  const separatorSecondary = useForegroundColor('separatorSecondary');
+  // const separatorSecondary = useForegroundColor('separatorSecondary');
 
   const { dapp_browser, points_enabled } = useRemoteConfig('dapp_browser', 'points_enabled');
   const showDappBrowserTab = useExperimentalFlag(DAPP_BROWSER) || dapp_browser;
   const showPointsTab = useExperimentalFlag(POINTS) || points_enabled || IS_TEST;
 
-  const showBrowserNavButtons = useBrowserStore(state => {
-    if (!showDappBrowserTab) return false;
-    const activeTabNavState = state.getActiveTabNavState();
-    return activeTabNavState.canGoBack || activeTabNavState.canGoForward;
-  });
-
   const numberOfTabs = 3 + (showPointsTab ? 1 : 0) + (showDappBrowserTab ? 1 : 0);
-  const horizontalInset = numberOfTabs > 4 ? HORIZONTAL_TAB_BAR_INSET_5_TABS : HORIZONTAL_TAB_BAR_INSET;
-  const tabWidth = (deviceWidth - horizontalInset * 2) / numberOfTabs;
+  const horizontalInset = TAB_BAR_INNER_PADDING; // numberOfTabs > 4 ? HORIZONTAL_TAB_BAR_INSET_5_TABS : HORIZONTAL_TAB_BAR_INSET;
+  const tabWidth = (deviceWidth - TAB_BAR_HORIZONTAL_INSET * 2 - horizontalInset * 2) / numberOfTabs;
   const tabPillStartPosition = (tabWidth - TAB_BAR_PILL_WIDTH) / 2 + horizontalInset;
 
   const reanimatedPosition = useSharedValue(0);
+  const showBrowserNavButtons = useSharedValue(false);
 
   const tabPositions = useDerivedValue(() => {
     const inputRange = Array.from({ length: numberOfTabs }, (_, index) => index);
@@ -109,30 +130,21 @@ const TabBar = ({ descriptors, jumpTo, navigation, state }: TabBarProps) => {
   });
 
   const backgroundPillStyle = useAnimatedStyle(() => {
-    const isDappBrowserTab = showDappBrowserTab && reanimatedPosition.value === 2 && showBrowserNavButtons;
+    const isDappBrowserTab = showDappBrowserTab && reanimatedPosition.value === 2 && showBrowserNavButtons.value;
     const backgroundOpacity = isDappBrowserTab ? 0 : 1;
     const translateX = interpolate(reanimatedPosition.value, tabPositions.value.inputRange, tabPositions.value.outputRange, 'clamp');
 
     return {
-      backgroundColor: opacityWorklet(accentColor, (isDarkMode ? 0.25 : 0.1) * backgroundOpacity),
-      transform: [{ translateX }],
+      backgroundColor: opacityWorklet(accentColor, (isDarkMode ? 0.2 : 0.1) * backgroundOpacity),
+      // transform: [{ translateX }],
+      transform: [{ translateX: withSpring(translateX, SPRING_CONFIGS.snappyMediumSpringConfig) }],
     };
   });
 
   const dappBrowserTabBarStyle = useAnimatedStyle(() => {
     const shouldUseBrowserStyle = showDappBrowserTab && reanimatedPosition.value === 2;
     return {
-      borderTopColor: isDarkMode ? separatorSecondary : LIGHT_SEPARATOR_COLOR,
-      borderTopWidth: withTiming(shouldUseBrowserStyle ? 1 : 0, TIMING_CONFIGS.slowFadeConfig),
       opacity: withTiming(shouldUseBrowserStyle ? 1 : 0, TIMING_CONFIGS.slowFadeConfig),
-    };
-  });
-
-  const dappBrowserTabBarShadowStyle = useAnimatedStyle(() => {
-    const defaultShadowOpacity = isDarkMode ? 0.2 : 0.04;
-    const shadowOpacity = showDappBrowserTab && reanimatedPosition.value === 2 ? 0 : defaultShadowOpacity;
-    return {
-      shadowOpacity: withTiming(shadowOpacity, TIMING_CONFIGS.slowFadeConfig),
     };
   });
 
@@ -140,6 +152,7 @@ const TabBar = ({ descriptors, jumpTo, navigation, state }: TabBarProps) => {
     const progress = tabViewProgress.value || 0;
     const opacity = 1 - progress / 75;
     const pointerEvents = extraWebViewHeight.value > 0 || opacity < 1 ? 'none' : 'auto';
+    const baseWidth = DEVICE_WIDTH - TAB_BAR_HORIZONTAL_INSET * 2;
 
     return {
       opacity: opacity * (1 - extraWebViewHeight.value / 48),
@@ -152,91 +165,80 @@ const TabBar = ({ descriptors, jumpTo, navigation, state }: TabBarProps) => {
           translateY: extraWebViewHeight.value,
         },
       ],
+      width: withSpring(
+        showBrowserNavButtons.value ? baseWidth + (TAB_BAR_PILL_HEIGHT * 2 - TAB_BAR_PILL_WIDTH) : baseWidth,
+        SPRING_CONFIGS.snappyMediumSpringConfig
+      ),
     };
   });
 
-  // For when QRScannerScreen is re-added
-  // const offScreenTabBar = useAnimatedStyle(() => {
-  //   const translateX = interpolate(
-  //     reanimatedPosition.value,
-  //     [0, 1, 2],
-  //     [deviceWidth, 0, 0]
-  //   );
-  //   return {
-  //     transform: [
-  //       {
-  //         translateX,
-  //       },
-  //     ],
-  //   };
-  // });
-
-  const canSwitchRef = useRef(true);
-  const canSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastPressRef = useRef<number | undefined>(undefined);
 
   useAnimatedReaction(
-    () => state.index,
+    () => activeIndex.value,
     (current, previous) => {
       if (current !== previous) {
         reanimatedPosition.value = current;
       }
-    }
+    },
+    []
   );
 
   const onPress = useCallback(
-    (route: { key: string }, index: number, isFocused: boolean, tabBarIcon: string) => {
-      if (!canSwitchRef.current) return;
-
+    ({ route, index, tabBarIcon }: { route: { key: string; name: string }; index: number; tabBarIcon: string }) => {
+      const isFocused = getIsFocused(index);
       const time = new Date().getTime();
       const delta = time - (lastPressRef.current || 0);
 
       const DOUBLE_PRESS_DELAY = 400;
 
       if (!isFocused) {
-        canSwitchRef.current = false;
-        jumpTo(route.key);
         reanimatedPosition.value = index;
-        if (canSwitchTimeoutRef.current) clearTimeout(canSwitchTimeoutRef.current);
-        canSwitchTimeoutRef.current = setTimeout(() => {
-          canSwitchRef.current = true;
-        }, 5);
-      } else if (isFocused && tabBarIcon === 'tabDiscover') {
-        if (delta < DOUBLE_PRESS_DELAY) {
-          discoverOpenSearchFnRef?.();
-          return;
+        jumpTo(route.key);
+        setActiveRoute(route.name as Route);
+      } else {
+        switch (tabBarIcon) {
+          case TAB_BAR_ICONS[Routes.WALLET_SCREEN]:
+            recyclerList.scrollToTop?.();
+            break;
+          case TAB_BAR_ICONS[Routes.DISCOVER_SCREEN]:
+            if (delta < DOUBLE_PRESS_DELAY) {
+              discoverOpenSearchFnRef?.();
+              return;
+            }
+            if (discoverScrollToTopFnRef?.() === 0) {
+              discoverOpenSearchFnRef?.();
+              return;
+            }
+            break;
+          case TAB_BAR_ICONS[Routes.PROFILE_SCREEN]:
+            mainList?.scrollToTop();
+            break;
         }
-
-        if (discoverScrollToTopFnRef?.() === 0) {
-          discoverOpenSearchFnRef?.();
-          return;
-        }
-      } else if (isFocused && tabBarIcon === 'tabHome') {
-        recyclerList.scrollToTop?.();
-      } else if (isFocused && tabBarIcon === 'tabActivity') {
-        mainList?.scrollToTop();
       }
 
       lastPressRef.current = time;
     },
-    [canSwitchRef, jumpTo, reanimatedPosition, recyclerList, mainList]
+    [getIsFocused, jumpTo, mainList, reanimatedPosition, recyclerList]
   );
 
   const onLongPress = useCallback(
-    (route: { key: string }, tabBarIcon: string) => {
+    ({ route, tabBarIcon }: { route: { key: string }; tabBarIcon: string }) => {
       navigation.emit({
         type: 'tabLongPress',
         target: route.key,
       });
 
-      if (tabBarIcon === 'tabHome') {
-        navigation.navigate(Routes.CHANGE_WALLET_SHEET);
-      }
-      if (tabBarIcon === 'tabDiscover') {
-        navigation.navigate(Routes.DISCOVER_SCREEN);
-        InteractionManager.runAfterInteractions(() => {
-          discoverOpenSearchFnRef?.();
-        });
+      switch (tabBarIcon) {
+        case TAB_BAR_ICONS[Routes.WALLET_SCREEN]:
+          navigation.navigate(Routes.CHANGE_WALLET_SHEET);
+          break;
+        case TAB_BAR_ICONS[Routes.DISCOVER_SCREEN]:
+          navigation.navigate(Routes.DISCOVER_SCREEN);
+          InteractionManager.runAfterInteractions(() => {
+            discoverOpenSearchFnRef?.();
+          });
+          break;
       }
     },
     [navigation]
@@ -244,116 +246,156 @@ const TabBar = ({ descriptors, jumpTo, navigation, state }: TabBarProps) => {
 
   const renderedTabs = useMemo(
     () =>
-      state.routes.map((route: { key: string; name: string }, index: number) => {
-        const { options } = descriptors[route.key];
-        const isFocused = state.index === index;
+      stateRef.current.routes.map((route: RouteProp<ParamListBase, string>, index: number) => {
+        if ((!showDappBrowserTab && route.name === Routes.DAPP_BROWSER_SCREEN) || (!showPointsTab && route.name === Routes.POINTS_SCREEN)) {
+          return null;
+        }
+        const { options } = descriptorsRef.current[route.key];
 
         // This is a hack to avoid the built-in title type of string | undefined
         // options.title should never be undefined as long as a title is specified for each Swipe.Screen
-        const tabBarIcon = options.title as string;
+        const tabBarIcon = options.title as TabIconKey;
 
-        const showBrowserButtons = showBrowserNavButtons && route.name === Routes.DAPP_BROWSER_SCREEN && isFocused;
-
-        return (
-          <Box height="full" key={route.key} justifyContent="flex-start" paddingTop="6px" width="full">
-            <ConditionalWrap
-              condition={IS_IOS || !showBrowserButtons}
-              wrap={children => (
-                <ButtonPressAnimation
-                  testID={`tab-bar-icon-${route.name}`}
-                  disallowInterruption
-                  enableHapticFeedback={!showBrowserButtons}
-                  minLongPressDuration={300}
-                  onLongPress={() => onLongPress(route, tabBarIcon)}
-                  onPress={() => onPress(route, index, isFocused, tabBarIcon)}
-                  scaleTo={showBrowserButtons ? 1 : 0.75}
-                  style={{ pointerEvents: showBrowserButtons ? 'box-none' : 'auto' }}
-                >
-                  {children}
-                </ButtonPressAnimation>
-              )}
-            >
-              <Stack alignHorizontal="center">
-                <Box alignItems="center" height={{ custom: TAB_BAR_PILL_HEIGHT }} justifyContent="center">
-                  {tabBarIcon === 'tabActivity' ? (
-                    <ActivityTabIcon
-                      accentColor={accentColor}
-                      tabBarIcon={tabBarIcon}
-                      index={index}
-                      reanimatedPosition={reanimatedPosition}
-                    />
-                  ) : tabBarIcon === 'tabDappBrowser' ? (
-                    <BrowserTabIcon
-                      accentColor={accentColor}
-                      tabBarIcon={tabBarIcon}
-                      index={index}
-                      reanimatedPosition={reanimatedPosition}
-                    />
-                  ) : (
-                    <TabBarIcon accentColor={accentColor} icon={tabBarIcon} index={index} reanimatedPosition={reanimatedPosition} />
-                  )}
-                </Box>
-              </Stack>
-            </ConditionalWrap>
-          </Box>
+        return tabBarIcon === TAB_BAR_ICONS[Routes.DAPP_BROWSER_SCREEN] ? (
+          <Column width="content">
+            <BrowserTabIconWrapper
+              accentColor={accentColor}
+              activeIndex={reanimatedPosition}
+              index={index}
+              onLongPress={onLongPress}
+              onPress={onPress}
+              route={route}
+              showBrowserNavButtons={showBrowserNavButtons}
+              tabBarIcon={tabBarIcon}
+            />
+          </Column>
+        ) : (
+          <BaseTabIcon
+            accentColor={accentColor}
+            activeIndex={reanimatedPosition}
+            index={index}
+            onLongPress={onLongPress}
+            onPress={onPress}
+            route={route}
+            tabBarIcon={tabBarIcon}
+          />
         );
       }),
-    [accentColor, descriptors, onLongPress, onPress, reanimatedPosition, showBrowserNavButtons, state.index, state.routes]
+    [
+      accentColor,
+      descriptorsRef,
+      onLongPress,
+      onPress,
+      reanimatedPosition,
+      showBrowserNavButtons,
+      showDappBrowserTab,
+      showPointsTab,
+      stateRef,
+    ]
   );
 
-  const shadowStyles = useMemo(() => {
-    if (IS_ANDROID) {
-      return { outer: {}, inner: {} };
-    }
+  const shadowStyle = useAnimatedStyle(() => {
+    const isDappBrowserTab = showDappBrowserTab && reanimatedPosition.value === 2;
     return {
-      outer: {
-        shadowColor: globalColors.grey100,
-        shadowOffset: { width: 0, height: -4 },
-        shadowOpacity: isDarkMode ? 0.2 : 0.04,
-        shadowRadius: 20,
-      },
-      inner: {
-        shadowColor: globalColors.grey100,
-        shadowOffset: { width: 0, height: -1 },
-        shadowOpacity: isDarkMode ? 0.2 : 0.04,
-        shadowRadius: 3,
-      },
+      shadowColor: globalColors.grey100,
+      shadowOffset: { width: 0, height: 12 },
+      shadowOpacity: withSpring(isDarkMode ? 0.6 : isDappBrowserTab ? 0 : 0.2, SPRING_CONFIGS.snappyMediumSpringConfig),
+      shadowRadius: 18,
     };
-  }, [isDarkMode]);
+  });
+
+  const gradientBackgroundStyle = useAnimatedStyle(() => {
+    const route = getRouteFromTabIndex(reanimatedPosition.value);
+    return {
+      backgroundColor: route === Routes.DAPP_BROWSER_SCREEN ? 'transparent' : getTabBackgroundColor(route, isDarkMode),
+    };
+  });
 
   return (
-    <Box bottom={{ custom: 0 }} height={{ custom: TAB_BAR_HEIGHT }} pointerEvents="box-none" position="absolute" width="full">
-      <Box as={Animated.View} style={[shadowStyles.outer, IS_IOS ? dappBrowserTabBarShadowStyle : {}, hideForBrowserTabViewStyle]}>
-        <Box as={Animated.View} style={[shadowStyles.inner, IS_IOS ? dappBrowserTabBarShadowStyle : {}]}>
-          <Box height={{ custom: TAB_BAR_HEIGHT }} width="full">
-            {IS_IOS && <BlurView blurStyle={isDarkMode ? 'chromeMaterialDark' : 'chromeMaterialLight'} style={StyleSheet.absoluteFill} />}
-            <Box
-              height="full"
-              position="absolute"
-              style={{
-                backgroundColor: isDarkMode ? colors.alpha('#191A1C', IS_IOS ? 0.7 : 1) : colors.alpha(colors.white, IS_IOS ? 0.7 : 1),
-              }}
-              width="full"
-            />
+    <>
+      <MaskedView
+        maskElement={
+          <EasingGradient
+            easing={Easing.inOut(Easing.quad)}
+            endColor={globalColors.grey100}
+            endOpacity={0.92}
+            startColor={globalColors.grey100}
+            startOpacity={0}
+            style={styles.tabBarBackgroundFade}
+          />
+        }
+        style={styles.tabBarBackgroundFade}
+      >
+        <Animated.View style={[styles.tabBarBackgroundFade, gradientBackgroundStyle]} />
+      </MaskedView>
+
+      <Animated.View style={shadowStyle}>
+        <Box
+          as={Animated.View}
+          borderColor={isDarkMode ? 'separatorSecondary' : { custom: 'rgba(255, 255, 255, 0.72)' }}
+          borderWidth={THICK_BORDER_WIDTH}
+          borderRadius={TAB_BAR_BORDER_RADIUS}
+          bottom={{ custom: TAB_BAR_HEIGHT - BASE_TAB_BAR_HEIGHT }}
+          height={{ custom: BASE_TAB_BAR_HEIGHT }}
+          pointerEvents="box-none"
+          position="absolute"
+          style={[hideForBrowserTabViewStyle, { alignSelf: 'center' }]}
+        >
+          <Box height={{ custom: BASE_TAB_BAR_HEIGHT }} width="full">
+            {IS_IOS ? (
+              <>
+                <BlurGradient
+                  gradientPoints={[
+                    { x: 0.5, y: 1.2 },
+                    { x: 0.5, y: 0 },
+                  ]}
+                  height={BASE_TAB_BAR_HEIGHT}
+                  intensity={16}
+                  saturation={1.5}
+                  style={StyleSheet.absoluteFill}
+                  width={TAB_BAR_WIDTH}
+                />
+                <LinearGradient
+                  start={{ x: 0.5, y: 0 }}
+                  end={{ x: 0.5, y: 1 }}
+                  colors={
+                    isDarkMode
+                      ? ['rgba(57, 58, 64, 0.36)', 'rgba(57, 58, 64, 0.32)']
+                      : ['rgba(255, 255, 255, 0.36)', 'rgba(255, 255, 255, 0.32)']
+                  }
+                  style={StyleSheet.absoluteFill}
+                />
+              </>
+            ) : (
+              <View style={[StyleSheet.absoluteFill, { backgroundColor: isDarkMode ? PANEL_COLOR_DARK : globalColors.white100 }]} />
+            )}
+            {isDarkMode && (
+              <LinearGradient
+                end={{ x: 0.5, y: 1 }}
+                colors={['rgba(255, 255, 255, 0.02)', 'rgba(255, 255, 255, 0)']}
+                start={{ x: 0.5, y: 0 }}
+                style={StyleSheet.absoluteFill}
+              />
+            )}
             <Box
               as={Animated.View}
               height="full"
               position="absolute"
               style={[
                 dappBrowserTabBarStyle,
-                { backgroundColor: isDarkMode ? HOMEPAGE_BACKGROUND_COLOR_DARK : HOMEPAGE_BACKGROUND_COLOR_LIGHT },
+                { backgroundColor: isDarkMode ? BROWSER_BACKGROUND_COLOR_DARK : BROWSER_BACKGROUND_COLOR_LIGHT },
               ]}
               width="full"
             />
             <Box
               alignItems="center"
               as={Animated.View}
-              borderRadius={TAB_BAR_PILL_HEIGHT / 2}
+              borderRadius={TAB_BAR_BORDER_RADIUS - TAB_BAR_INNER_PADDING}
               height={{ custom: TAB_BAR_PILL_HEIGHT }}
               justifyContent="center"
               position="absolute"
               style={backgroundPillStyle}
-              top={{ custom: 6 }}
+              top={{ custom: TAB_BAR_INNER_PADDING }}
               width={{ custom: TAB_BAR_PILL_WIDTH }}
             />
             <Box paddingHorizontal={{ custom: horizontalInset }}>
@@ -361,32 +403,210 @@ const TabBar = ({ descriptors, jumpTo, navigation, state }: TabBarProps) => {
             </Box>
           </Box>
         </Box>
-      </Box>
+      </Animated.View>
+    </>
+  );
+});
+
+interface BaseTabIconProps {
+  accentColor: string;
+  activeIndex: SharedValue<number>;
+  index: number;
+  onLongPress: ({ route, tabBarIcon }: { route: { key: string; name: string }; tabBarIcon: TabIconKey }) => void;
+  onPress: ({ route, index, tabBarIcon }: { route: { key: string; name: string }; index: number; tabBarIcon: TabIconKey }) => void;
+  route: { key: string; name: string };
+  tabBarIcon: TabIconKey;
+}
+
+export const BaseTabIcon = memo(function BaseTabIcon({
+  accentColor,
+  activeIndex,
+  index,
+  onLongPress,
+  onPress,
+  route,
+  tabBarIcon,
+}: BaseTabIconProps) {
+  return (
+    <Box
+      height="full"
+      key={route.key}
+      justifyContent="flex-start"
+      paddingTop={{ custom: TAB_BAR_INNER_PADDING }}
+      testID={`tab-bar-icon-${route.name}`}
+      width="full"
+    >
+      <ButtonPressAnimation
+        disallowInterruption
+        enableHapticFeedback
+        scaleTo={0.75}
+        onLongPress={() => onLongPress({ route, tabBarIcon })}
+        onPress={() => onPress({ route, index, tabBarIcon })}
+      >
+        <Box alignItems="center" height={{ custom: TAB_BAR_PILL_HEIGHT }} justifyContent="center">
+          {tabBarIcon === TAB_BAR_ICONS[Routes.PROFILE_SCREEN] ? (
+            <ActivityTabIcon accentColor={accentColor} tabBarIcon={tabBarIcon} index={index} reanimatedPosition={activeIndex} />
+          ) : (
+            <TabBarIcon accentColor={accentColor} icon={tabBarIcon} index={index} reanimatedPosition={activeIndex} />
+          )}
+        </Box>
+      </ButtonPressAnimation>
     </Box>
   );
-};
+});
 
-function LazyPlaceholder({ route }: { route: RouteProp<ParamListBase, string>['name'] }) {
+export const BrowserTabIconWrapper = memo(function BrowserTabIconWrapper({
+  accentColor,
+  activeIndex,
+  index,
+  onPress,
+  route,
+  showBrowserNavButtons,
+  tabBarIcon,
+}: BaseTabIconProps & { showBrowserNavButtons: SharedValue<boolean> }) {
+  const [showBrowserButtons, setShowBrowserButtons] = useState(false);
+
+  const canGoBackOrForward = useStoreSharedValue(useBrowserStore, state => {
+    const navState = state.getActiveTabNavState();
+    return navState.canGoBack || navState.canGoForward;
+  });
+
+  useAnimatedReaction(
+    () => activeIndex.value === 2 && canGoBackOrForward.value,
+    (current, previous) => {
+      if (current !== previous) {
+        showBrowserNavButtons.value = current;
+        runOnJS(setShowBrowserButtons)(current);
+      }
+    },
+    []
+  );
+
+  const browserPillWidthStyle = useAnimatedStyle(() => {
+    return {
+      width: withTiming(showBrowserNavButtons.value ? TAB_BAR_PILL_HEIGHT * 2 : TAB_BAR_PILL_WIDTH, TIMING_CONFIGS.slowFadeConfig),
+    };
+  });
+
+  return (
+    <Box
+      as={Animated.View}
+      height="full"
+      key={route.key}
+      justifyContent="flex-start"
+      paddingTop={{ custom: TAB_BAR_INNER_PADDING }}
+      style={browserPillWidthStyle}
+      testID={`tab-bar-icon-${route.name}`}
+    >
+      <ConditionalWrap
+        condition={IS_IOS || !showBrowserButtons}
+        wrap={children => (
+          <ButtonPressAnimation
+            disallowInterruption
+            enableHapticFeedback={!showBrowserButtons}
+            onPress={() => onPress({ route, index, tabBarIcon })}
+            scaleTo={showBrowserButtons ? 1 : 0.75}
+            style={{ pointerEvents: showBrowserButtons ? 'box-none' : 'auto' }}
+          >
+            {children}
+          </ButtonPressAnimation>
+        )}
+      >
+        <Box alignItems="center" height={{ custom: TAB_BAR_PILL_HEIGHT }} justifyContent="center">
+          <BrowserTabIcon
+            accentColor={accentColor}
+            index={index}
+            reanimatedPosition={activeIndex}
+            showNavButtons={showBrowserNavButtons}
+            tabBarIcon={tabBarIcon}
+          />
+        </Box>
+      </ConditionalWrap>
+    </Box>
+  );
+});
+
+function getRouteFromTabIndex(index: number): RouteProp<ParamListBase, string>['name'] {
+  'worklet';
+  switch (index) {
+    case 0:
+      return Routes.WALLET_SCREEN;
+    case 1:
+      return Routes.DISCOVER_SCREEN;
+    case 2:
+      return Routes.DAPP_BROWSER_SCREEN;
+    case 3:
+      return Routes.PROFILE_SCREEN;
+    case 4:
+      return Routes.POINTS_SCREEN;
+    default:
+      return Routes.WALLET_SCREEN;
+  }
+}
+
+function getTabBackgroundColor(route: RouteProp<ParamListBase, string>['name'], isDarkMode: boolean): string {
+  'worklet';
+  switch (route) {
+    case Routes.DISCOVER_SCREEN:
+    case Routes.DAPP_BROWSER_SCREEN:
+    case Routes.POINTS_SCREEN:
+      return isDarkMode ? BROWSER_BACKGROUND_COLOR_DARK : BROWSER_BACKGROUND_COLOR_LIGHT;
+    default:
+      return (isDarkMode ? darkModeThemeColors : lightModeThemeColors).white;
+  }
+}
+
+const LazyPlaceholder = memo(function LazyPlaceholder({ route }: { route: RouteProp<ParamListBase, string>['name'] }) {
   const { isDarkMode } = useColorMode();
-  const { colors } = useTheme();
-
-  const backgroundColor =
-    route === Routes.DAPP_BROWSER_SCREEN || route === Routes.POINTS_SCREEN
-      ? isDarkMode
-        ? BROWSER_BACKGROUND_COLOR_DARK
-        : BROWSER_BACKGROUND_COLOR_LIGHT
-      : colors.white;
+  const backgroundColor = getTabBackgroundColor(route, isDarkMode);
 
   return (
     <View
       style={{ backgroundColor, bottom: 0, height: DEVICE_HEIGHT, left: 0, position: 'absolute', right: 0, top: 0, width: DEVICE_WIDTH }}
     />
   );
-}
+});
 
-function getTabBar({ descriptors, jumpTo, navigation, state }: MaterialTopTabBarProps) {
-  return <TabBar descriptors={descriptors} jumpTo={jumpTo} navigation={navigation} state={state} />;
-}
+const Swipe = createMaterialTopTabNavigator();
+
+const TabBarContainer = ({ descriptors, jumpTo, navigation, state }: MaterialTopTabBarProps) => {
+  const descriptorsRef = useRef(descriptors);
+  const stateRef = useRef(state);
+
+  const focusedIndexRef = useRef<number | undefined>(state.index);
+  const lastNumberOfTabsRef = useRef<number | undefined>(state.routes.length);
+
+  const currentIndex = state.index;
+  const activeIndex = useDerivedValue(() => currentIndex, [currentIndex]);
+
+  if (lastNumberOfTabsRef.current !== state.routes.length) {
+    lastNumberOfTabsRef.current = state.routes.length;
+    descriptorsRef.current = descriptors;
+    stateRef.current = state;
+  }
+
+  if (focusedIndexRef.current !== state.index) {
+    focusedIndexRef.current = state.index;
+  }
+
+  const getIsFocused = useCallback(
+    (index: number) => {
+      return focusedIndexRef.current === index;
+    },
+    [focusedIndexRef]
+  );
+
+  return (
+    <TabBar
+      activeIndex={activeIndex}
+      descriptorsRef={descriptorsRef}
+      getIsFocused={getIsFocused}
+      jumpTo={jumpTo}
+      navigation={navigation}
+      stateRef={stateRef}
+    />
+  );
+};
 
 function SwipeNavigatorScreens() {
   const { isCoinListEdited } = useCoinListEdited();
@@ -403,7 +623,7 @@ function SwipeNavigatorScreens() {
   const showKingOfTheHillTab = (useExperimentalFlag(KING_OF_THE_HILL_TAB) || king_of_the_hill_tab_enabled) && !IS_TEST;
 
   const getScreenOptions = useCallback(
-    (props: { route: RouteProp<ParamListBase, string> }) => {
+    (props: { route: RouteProp<ParamListBase, string> }): MaterialTopTabNavigationOptions => {
       const isOnBrowserTab = props.route.name === Routes.DAPP_BROWSER_SCREEN;
       return {
         animationEnabled: false,
@@ -421,28 +641,26 @@ function SwipeNavigatorScreens() {
       initialLayout={deviceUtils.dimensions}
       initialRouteName={Routes.WALLET_SCREEN}
       screenOptions={getScreenOptions}
-      tabBar={getTabBar}
+      tabBar={TabBarContainer}
       tabBarPosition="bottom"
     >
-      {/* For when QRScannerScreen is re-added */}
-      {/* <Swipe.Screen
-        component={QRScannerScreen}
-        name={Routes.QR_SCANNER_SCREEN}
-        options={{
-          title: 'none',
-        }}
-      /> */}
-      <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} options={{ title: 'tabHome' }} />
-      <Swipe.Screen component={DiscoverScreen} name={Routes.DISCOVER_SCREEN} options={{ title: 'tabDiscover' }} />
+      <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.WALLET_SCREEN] }} />
+      <Swipe.Screen component={DiscoverScreen} name={Routes.DISCOVER_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.DISCOVER_SCREEN] }} />
       {showDappBrowserTab && (
         <Swipe.Screen component={DappBrowser} name={Routes.DAPP_BROWSER_SCREEN} options={{ title: 'tabDappBrowser' }} />
       )}
       {showKingOfTheHillTab ? (
-        <Swipe.Screen component={KingOfTheHillScreen} name={Routes.KING_OF_THE_HILL} options={{ title: 'tabKingOfTheHill' }} />
+        <Swipe.Screen
+          component={KingOfTheHillScreen}
+          name={Routes.KING_OF_THE_HILL}
+          options={{ title: TAB_BAR_ICONS[Routes.KING_OF_THE_HILL] }}
+        />
       ) : (
-        <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} options={{ title: 'tabActivity' }} />
+        <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.PROFILE_SCREEN] }} />
       )}
-      {showPointsTab && <Swipe.Screen component={PointsScreen} name={Routes.POINTS_SCREEN} options={{ title: 'tabPoints' }} />}
+      {showPointsTab && (
+        <Swipe.Screen component={PointsScreen} name={Routes.POINTS_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.POINTS_SCREEN] }} />
+      )}
     </Swipe.Navigator>
   );
 }
@@ -456,10 +674,7 @@ export function SwipeNavigator() {
       <BrowserTabBarContextProvider>
         <MainListProvider>
           <RecyclerListViewScrollToTopProvider>
-            {/* @ts-expect-error JS component */}
-            <ScrollPositionContext.Provider>
-              <SwipeNavigatorScreens />
-            </ScrollPositionContext.Provider>
+            <SwipeNavigatorScreens />
           </RecyclerListViewScrollToTopProvider>
         </MainListProvider>
       </BrowserTabBarContextProvider>
@@ -469,35 +684,12 @@ export function SwipeNavigator() {
   );
 }
 
-// For when QRScannerScreen is re-added
-// const ShadowWrapper = ({ children }: { children: React.ReactNode }) => {
-//   const { isDarkMode } = useTheme();
-
-//   return IS_ANDROID ? (
-//     children
-//   ) : (
-//     <Box
-//       as={Animated.View}
-//       style={[
-//         offScreenTabBar,
-//         {
-//           shadowColor: globalColors.grey100,
-//           shadowOffset: { width: 0, height: -4 },
-//           shadowOpacity: isDarkMode ? 0.2 : 0.04,
-//           shadowRadius: 20,
-//         },
-//       ]}
-//     >
-//       <Box
-//         style={{
-//           shadowColor: globalColors.grey100,
-//           shadowOffset: { width: 0, height: -1 },
-//           shadowOpacity: isDarkMode ? 0.2 : 0.04,
-//           shadowRadius: 3,
-//         }}
-//       >
-//         {children}
-//       </Box>
-//     </Box>
-//   );
-// };
+const styles = StyleSheet.create({
+  tabBarBackgroundFade: {
+    bottom: 0,
+    height: TAB_BAR_HEIGHT,
+    pointerEvents: 'none',
+    position: 'absolute',
+    width: DEVICE_WIDTH,
+  },
+});

--- a/src/state/navigation/navigationStore.ts
+++ b/src/state/navigation/navigationStore.ts
@@ -49,7 +49,6 @@ export const useNavigationStore = createRainbowStore<NavigationState>((set, get)
       if (onSwipeRoute) state.animatedActiveSwipeRoute.value = route;
 
       return {
-        ...state,
         activeRoute: route,
         activeSwipeRoute: onSwipeRoute ? route : state.activeSwipeRoute,
       };


### PR DESCRIPTION
Fixes APP-2871

## What changed (plus any additional context for devs)
- Restyles the tab bar to be a floating pill
- Previously the tab bar re-rendered for every route change due to receiving the navigation state. As a temporary fix, now wrapping the state in a ref and passing that instead, as it doesn't need to react to the state. Will address this properly later, to avoid needing the memo shield, but this lightens the tab bar quite a bit as it now doesn't re-render.
- Minor code cleanup in `RecyclerListViewScrollToTopContext`

## Screen recordings / screenshots

https://github.com/user-attachments/assets/b087153d-310f-4291-b252-0523c292b4a4

Light mode:

<img width="300" height="auto" alt="IMG_1047" src="https://github.com/user-attachments/assets/eda53508-afb6-4fff-9229-28e1634964ab" />

## What to test

