### PR TITLE
small cleanup on activity list

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@lavamoat/preinstall-always-fail": "2.0.0",
     "@ledgerhq/hw-app-eth": "6.39.0",
     "@ledgerhq/react-native-hw-transport-ble": "6.33.4",
-    "@legendapp/list": "1.1.0",
+    "@legendapp/list": "1.1.4",
     "@metamask/eth-sig-util": "7.0.2",
     "@notifee/react-native": "7.8.2",
     "@rainbow-me/provider": "0.1.2",

--- a/src/components/activity-list/ActivityList.tsx
+++ b/src/components/activity-list/ActivityList.tsx
@@ -5,7 +5,6 @@ import { lazyMount } from '@/helpers/lazyMount';
 import { useAccountTransactions } from '@/hooks';
 import { useMainList } from '@/navigation/MainListContext';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
-import { usePendingTransactionsStore } from '@/state/pendingTransactions';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 import styled from '@/styled-thing';
 import { useTheme } from '@/theme';
@@ -78,9 +77,7 @@ const ITEM_HEIGHT = 59;
 const ActivityList = lazyMount(() => {
   const accountAddress = useAccountAddress();
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
-
   const { sections, nextPage, transactionsCount, remainingItemsLabel } = useAccountTransactions();
-  const pendingTransactions = usePendingTransactionsStore(state => state.pendingTransactions[accountAddress] || []);
 
   const theme = useTheme();
 
@@ -168,11 +165,6 @@ const ActivityList = lazyMount(() => {
       renderItem={renderItem}
       keyExtractor={keyExtractor}
       contentContainerStyle={{ paddingBottom: !transactionsCount ? 0 : 90 }}
-      extraData={{
-        hasPendingTransaction: pendingTransactions.length > 0,
-        nativeCurrency,
-        pendingTransactionsCount: pendingTransactions.length,
-      }}
       testID={'wallet-activity-list'}
       ListEmptyComponent={<ActivityListEmptyState />}
       ListFooterComponent={() => remainingItemsLabel && <ListFooterComponent label={remainingItemsLabel} onPress={nextPage} />}

--- a/src/hooks/useAccountTransactions.ts
+++ b/src/hooks/useAccountTransactions.ts
@@ -11,12 +11,16 @@ import { ChainId } from '@/state/backendNetworks/types';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import usePendingTransactions from '@/hooks/usePendingTransactions';
 
 export const NOE_PAGE = 30;
 
 export default function useAccountTransactions() {
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
   const accountAddress = useAccountAddress();
+
+  // without this this hook won't react to new pending transactions
+  usePendingTransactions();
 
   const { getPendingTransactionsInReverseOrder } = pendingTransactionsStore.getState();
   const pendingTransactionsMostRecentFirst = getPendingTransactionsInReverseOrder(accountAddress);

--- a/src/hooks/useAccountTransactions.ts
+++ b/src/hooks/useAccountTransactions.ts
@@ -1,17 +1,16 @@
+import { RainbowTransaction } from '@/entities';
+import { useNavigation } from '@/navigation';
+import { useConsolidatedTransactions } from '@/resources/transactions/consolidatedTransactions';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { ChainId } from '@/state/backendNetworks/types';
+import { pendingTransactionsStore, usePendingTransactionsStore } from '@/state/pendingTransactions';
+import { getSortedWalletConnectRequests } from '@/state/walletConnectRequests';
+import { useAccountAddress } from '@/state/wallets/walletsStore';
+import { useTheme } from '@/theme';
 import { useEffect, useMemo } from 'react';
 import { buildTransactionsSections } from '../helpers/buildTransactionsSectionsSelector';
 import useContacts from './useContacts';
-import { useNavigation } from '@/navigation';
-import { useTheme } from '@/theme';
-import { useConsolidatedTransactions } from '@/resources/transactions/consolidatedTransactions';
-import { RainbowTransaction } from '@/entities';
-import { pendingTransactionsStore } from '@/state/pendingTransactions';
-import { getSortedWalletConnectRequests } from '@/state/walletConnectRequests';
-import { ChainId } from '@/state/backendNetworks/types';
-import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
-import { useAccountAddress } from '@/state/wallets/walletsStore';
-import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
-import usePendingTransactions from '@/hooks/usePendingTransactions';
 
 export const NOE_PAGE = 30;
 
@@ -19,11 +18,10 @@ export default function useAccountTransactions() {
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
   const accountAddress = useAccountAddress();
 
-  // without this this hook won't react to new pending transactions
-  usePendingTransactions();
+  const pendingTransactionsMostRecentFirst = usePendingTransactionsStore(state =>
+    state.getPendingTransactionsInReverseOrder(accountAddress)
+  );
 
-  const { getPendingTransactionsInReverseOrder } = pendingTransactionsStore.getState();
-  const pendingTransactionsMostRecentFirst = getPendingTransactionsInReverseOrder(accountAddress);
   const walletConnectRequests = getSortedWalletConnectRequests();
 
   const { data, isLoading, fetchNextPage, hasNextPage } = useConsolidatedTransactions({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4263,15 +4263,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@legendapp/list@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@legendapp/list@npm:1.1.0"
+"@legendapp/list@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@legendapp/list@npm:1.1.4"
   dependencies:
     use-sync-external-store: "npm:^1.5.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/dcb6ae5199b5e65d9674e0a773d5b4f61492da32e4aca749ca4b96392dac3cbc35318c5f43b6ce9efa4a6b0cab94df010aea0bcaab529678718c22e2e448baa6
+  checksum: 10c0/add14842533c2a50de36c9e019620b982e6fb76e1133258c1f959371180cb2d81a5436e2c3228987ef278efe18187282e6357d5b195b75b0add5fe7d0246902e
   languageName: node
   linkType: hard
 
@@ -8635,7 +8635,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:2.0.0"
     "@ledgerhq/hw-app-eth": "npm:6.39.0"
     "@ledgerhq/react-native-hw-transport-ble": "npm:6.33.4"
-    "@legendapp/list": "npm:1.1.0"
+    "@legendapp/list": "npm:1.1.4"
     "@metamask/eth-sig-util": "npm:7.0.2"
     "@notifee/react-native": "npm:7.8.2"
     "@rainbow-me/provider": "npm:0.1.2"


### PR DESCRIPTION
Fixes APP-2855

## What changed (plus any additional context for devs)

I had seen pending transactions showing "empty" yesterday while working on king of the hill, but was unable to reproduce it today on either koth or develop branch.

While I was there I upgraded to the latest legend-list and tested it, and removed some unused code I found.

## Screen recordings / screenshots

No changes visually:

<img width="1136" height="2168" alt="CleanShot 2025-07-23 at 10 40 54@2x" src="https://github.com/user-attachments/assets/5cfbca9d-0c71-4a0a-9534-9490b8e096ab" />

## What to test

LegendList is upgraded so it's useful to test it:

- ActivityList
- AirdropsSheet

