### PR TITLE
Fix: Clean up old react-query keys for legacy nft store

### DIFF
--- a/src/model/migrations.ts
+++ b/src/model/migrations.ts
@@ -844,16 +844,6 @@ export default async function runMigrations() {
 
   migrations.push(v29);
 
-  /**
-   *************** Migration v30 ******************
-   * Delete all queries except favorites
-   */
-  const v30 = async () => {
-    await clearReactQueryCache({ analyzeAfterClearing: false });
-  };
-
-  migrations.push(v30);
-
   logger.debug(`[runMigrations]: ready to run migrations starting on number ${currentVersion}`);
   // await setMigrationVersion(17);
   if (migrations.length === currentVersion) {

--- a/src/model/migrations.ts
+++ b/src/model/migrations.ts
@@ -844,6 +844,16 @@ export default async function runMigrations() {
 
   migrations.push(v29);
 
+  /**
+   *************** Migration v30 ******************
+   * Delete all queries except favorites
+   */
+  const v30 = async () => {
+    await clearReactQueryCache({ analyzeAfterClearing: false });
+  };
+
+  migrations.push(v30);
+
   logger.debug(`[runMigrations]: ready to run migrations starting on number ${currentVersion}`);
   // await setMigrationVersion(17);
   if (migrations.length === currentVersion) {

--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -42,6 +42,6 @@ export const persistOptions: Omit<PersistQueryClientOptions, 'queryClient'> = {
     shouldDehydrateQuery: query => Boolean(query.cacheTime !== 0 && (query.queryKey[2] as { persisterVersion?: number })?.persisterVersion),
   },
   maxAge: time.weeks(4),
-  buster: '1',
+  buster: '2',
   persister: new MMKVPersister(),
 };


### PR DESCRIPTION
Fixes APP-854

## What changed (plus any additional context for devs)
just another migration that should wipe out any unused nfts storage.

## Screen recordings / screenshots
n/a

## What to test
nothing really to test here, just unused keys being wiped
