### PR TITLE
Cache Intl instances and replace usages to toLocaleString

### DIFF
--- a/src/helpers/intl.ts
+++ b/src/helpers/intl.ts
@@ -1,0 +1,39 @@
+/**
+ * Get a cached instance of Intl.NumberFormat. For best performance keep option keys sorted.
+ */
+export function getNumberFormatter(locale?: string, options: Intl.NumberFormatOptions = {}): Intl.NumberFormat {
+  'worklet';
+
+  // In worklets we cannot use closure variables so use globalThis to store the cache.
+  const g = globalThis as typeof globalThis & { __numberFormatterCache?: Record<string, Intl.NumberFormat> };
+  g.__numberFormatterCache = g.__numberFormatterCache || {};
+
+  const key = `${locale}|${JSON.stringify(options)}`;
+  let formatter = g.__numberFormatterCache[key];
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    g.__numberFormatterCache[key] = formatter;
+  }
+
+  return formatter;
+}
+
+/**
+ * Get a cached instance of Intl.DateTimeFormat. For best performance keep option keys sorted.
+ */
+export function getDateFormatter(locale?: string, options: Intl.DateTimeFormatOptions = {}): Intl.DateTimeFormat {
+  'worklet';
+
+  // In worklets we cannot use closure variables so use globalThis to store the cache.
+  const g = globalThis as typeof globalThis & { __dateFormatterCache?: Record<string, Intl.DateTimeFormat> };
+  g.__dateFormatterCache = g.__dateFormatterCache || {};
+
+  const key = `${locale}|${JSON.stringify(options)}`;
+  let formatter = g.__dateFormatterCache[key];
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, options);
+    g.__dateFormatterCache[key] = formatter;
+  }
+
+  return formatter;
+}

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -3,6 +3,7 @@ import { supportedNativeCurrencies } from '@/references';
 import { NativeCurrencyKey } from '@/entities';
 import { convertAmountToNativeDisplayWorklet } from './utilities';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { getNumberFormatter } from '@/helpers/intl';
 
 /**
  * @desc subtracts two numbers
@@ -62,11 +63,11 @@ export function formatNumber(
 
   return (
     (style === '$' ? '$' : '') +
-    x.toLocaleString('en-US', {
-      style: 'decimal',
-      minimumFractionDigits: decimals,
+    getNumberFormatter('en-US', {
       maximumFractionDigits: decimals,
-    }) +
+      minimumFractionDigits: decimals,
+      style: 'decimal',
+    }).format(x) +
     orderSuffix +
     (style === '%' ? '%' : '')
   );

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -3,6 +3,7 @@ import currency from 'currency.js';
 import { isNil } from 'lodash';
 import { supportedNativeCurrencies } from '@/references';
 import { divWorklet, lessThanWorklet, orderOfMagnitudeWorklet, powWorklet } from '@/safe-math/SafeMath';
+import { getNumberFormatter } from '@/helpers/intl';
 
 type BigNumberish = number | string | BigNumber;
 
@@ -271,11 +272,11 @@ export const handleSignificantDecimalsWorklet = (value: number | string, decimal
     dec = Math.min(decimals, buffer);
   }
 
-  return Number(value).toLocaleString('en-US', {
-    useGrouping: true,
-    minimumFractionDigits: Math.min(2, dec),
+  return getNumberFormatter('en-US', {
     maximumFractionDigits: dec,
-  });
+    minimumFractionDigits: Math.min(2, dec),
+    useGrouping: true,
+  }).format(Number(value));
 };
 
 export const handleSignificantDecimals = (
@@ -460,11 +461,11 @@ export const convertAmountToNativeDisplayWorklet = (
 
   const nativeValue = thresholdReached
     ? threshold
-    : valueNumber.toLocaleString('en-US', {
-        useGrouping: true,
-        minimumFractionDigits: nativeCurrency === 'ETH' ? undefined : decimals,
+    : getNumberFormatter('en-US', {
         maximumFractionDigits: decimals,
-      });
+        minimumFractionDigits: nativeCurrency === 'ETH' ? undefined : decimals,
+        useGrouping: true,
+      }).format(valueNumber);
 
   const nativeDisplay = `${thresholdReached ? '<' : ''}${alignment === 'left' || ignoreAlignment ? symbol : ''}${nativeValue}${!ignoreAlignment && alignment === 'right' ? symbol : ''}`;
 

--- a/src/performance/tracking/PerformanceToast.tsx
+++ b/src/performance/tracking/PerformanceToast.tsx
@@ -12,6 +12,7 @@ import { opacity } from '@/__swaps__/utils/swaps';
 import { isDarkTheme } from '@/theme/ThemeContext';
 import { time } from '@/utils';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+import { getNumberFormatter } from '@/helpers/intl';
 
 let shouldCollectStats = !IS_TEST && getExperimetalFlag(PERFORMANCE_TOAST);
 
@@ -115,7 +116,7 @@ export async function showPerformanceToast(results: Record<string, number>) {
     .map(([metric, data], index) => {
       const duration = Math.round(data.duration);
       const emojiForIndex = index === 0 ? '🦦' : index === 1 ? '🥉' : index === 2 ? '🥈' : '🥇';
-      return `${emojiForIndex}  ${metric.replace('Performance ', '').replace('To', 'to').replace('Root App', 'Root')}: ${duration.toLocaleString()}ms`;
+      return `${emojiForIndex}  ${metric.replace('Performance ', '').replace('To', 'to').replace('Root App', 'Root')}: ${getNumberFormatter().format(duration)}ms`;
     })
     .join('\n')
     .trim();

--- a/src/react-native-animated-charts/Example/src/GenericExample/index.js
+++ b/src/react-native-animated-charts/Example/src/GenericExample/index.js
@@ -17,6 +17,7 @@ import {
   monotoneCubicInterpolation,
   simplifyData,
 } from '@/react-native-animated-charts/src';
+import {getNumberFormatter} from '@/helpers/intl';
 
 export const {width: SIZE} = Dimensions.get('window');
 
@@ -25,9 +26,9 @@ export const formatUSD = (value) => {
   if (value === '') {
     return '';
   }
-  return `$ ${value.toLocaleString('en-US', {
+  return `$ ${getNumberFormatter('en-US', {
     currency: 'USD',
-  })}`;
+  }).format(value)}`;
 };
 
 export const formatDatetime = (value) => {

--- a/src/react-query/reactQueryUtils.ts
+++ b/src/react-query/reactQueryUtils.ts
@@ -7,6 +7,7 @@ import { RainbowError, logger } from '@/logger';
 import { persistOptions, queryClient } from '@/react-query';
 import { favoritesQueryKey } from '@/resources/favorites';
 import { REACT_QUERY_STORAGE_ID } from '@/storage/legacy';
+import { getDateFormatter } from '@/helpers/intl';
 
 // ============ clearReactQueryCache =========================================== //
 
@@ -408,14 +409,14 @@ function logTop10BySize(sizeByType: Record<string, { totalSize: number; queries:
     if (report) logEntry.message += `Example Query Key: ${JSON.stringify(mostRecentQuery.queryKey)}\n`;
 
     if (mostRecentQuery.lastUpdated) {
-      const updatedAt = new Date(mostRecentQuery.lastUpdated).toLocaleString('en-US', {
+      const updatedAt = getDateFormatter('en-US', {
         day: '2-digit',
         hour: '2-digit',
         hour12: true,
         minute: '2-digit',
         month: 'short',
         year: 'numeric',
-      });
+      }).format(new Date(mostRecentQuery.lastUpdated));
       devLog(`Last Updated: ${updatedAt}`);
       if (report) logEntry.message += `Last Updated: ${updatedAt}\n`;
     }

--- a/src/screens/expandedAssetSheet/components/sections/marketSection/MarketStatsCard.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/marketSection/MarketStatsCard.tsx
@@ -14,6 +14,7 @@ import { colors } from '@/styles';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { abbreviateNumberWorklet } from '@/helpers/utilities';
 import { MarketStats, TimeFrames, useTokenMarketStats } from '@/resources/metadata/tokenStats';
+import { getNumberFormatter } from '@/helpers/intl';
 
 const TIMEFRAME_SWITCH_CONFIG = TIMING_CONFIGS.buttonPressConfig;
 
@@ -193,23 +194,23 @@ const MarketStatsCardContent = memo(function MarketStatsCardContent({ marketData
     timeframe => {
       'worklet';
       const timeframeData = marketData[timeframe as TimeFrames];
-      transactions.value = timeframeData.transactions.toLocaleString('en-US', {
+      transactions.value = getNumberFormatter('en-US', {
         maximumFractionDigits: 2,
-      });
+      }).format(timeframeData.transactions);
 
       // TODO
       volume.value = '$' + abbreviateNumberWorklet(timeframeData.volume, 1);
 
-      makers.value = timeframeData.uniques.toLocaleString('en-US', {
+      makers.value = getNumberFormatter('en-US', {
         maximumFractionDigits: 2,
-      });
+      }).format(timeframeData.uniques);
 
-      buys.value = timeframeData.buys.toLocaleString('en-US', {
+      buys.value = getNumberFormatter('en-US', {
         maximumFractionDigits: 2,
-      });
-      sells.value = timeframeData.sells.toLocaleString('en-US', {
+      }).format(timeframeData.buys);
+      sells.value = getNumberFormatter('en-US', {
         maximumFractionDigits: 2,
-      });
+      }).format(timeframeData.sells);
 
       // TODO
       // This is the only section that requires a separate value for the non formatted value so that the ratio bar can be calculated
@@ -218,12 +219,12 @@ const MarketStatsCardContent = memo(function MarketStatsCardContent({ marketData
       buyVolume.value = timeframeData.buyVolume.toString();
       sellVolume.value = timeframeData.sellVolume.toString();
 
-      buyers.value = timeframeData.buyers.toLocaleString('en-US', {
+      buyers.value = getNumberFormatter('en-US', {
         maximumFractionDigits: 2,
-      });
-      sellers.value = timeframeData.sellers.toLocaleString('en-US', {
+      }).format(timeframeData.buyers);
+      sellers.value = getNumberFormatter('en-US', {
         maximumFractionDigits: 2,
-      });
+      }).format(timeframeData.sellers);
     }
   );
 

--- a/src/screens/points/components/LeaderboardRow.tsx
+++ b/src/screens/points/components/LeaderboardRow.tsx
@@ -21,6 +21,7 @@ import { Keyboard, Share } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useSelectedWallet } from '@/state/wallets/walletsStore';
 import { switchWallet } from '@/state/wallets/switchWallet';
+import { getNumberFormatter } from '@/helpers/intl';
 
 const ACTIONS = {
   ADD_CONTACT: 'add-contact',
@@ -181,7 +182,7 @@ export const LeaderboardRow = memo(function LeaderboardRow({
       break;
   }
 
-  const formattedPoints = points.toLocaleString('en-US');
+  const formattedPoints = getNumberFormatter('en-US').format(points);
 
   return (
     <ContextMenuButton

--- a/src/screens/points/constants.ts
+++ b/src/screens/points/constants.ts
@@ -2,6 +2,7 @@ import { safeAreaInsetValues } from '@/utils';
 import { OnboardPointsMutation, PointsOnboardingCategory } from '@/graphql/__generated__/metadata';
 import * as i18n from '@/languages';
 import { IS_IOS } from '@/env';
+import { getNumberFormatter } from '@/helpers/intl';
 
 const ONE_WEEK_MS = 604_800_000;
 const ONE_DAY_MS = ONE_WEEK_MS / 7;
@@ -78,16 +79,16 @@ export const buildTwitterIntentMessage = (
   const ONBOARDING_TOTAL_POINTS = profile.onboardPoints.user.onboarding.earnings.total;
   const referralCode = profile.onboardPoints.user.referralCode;
 
-  let text = `I just had ${ONBOARDING_TOTAL_POINTS.toLocaleString(
-    'en-US'
+  let text = `I just had ${getNumberFormatter('en-US').format(
+    ONBOARDING_TOTAL_POINTS
   )} Rainbow Points dropped into my wallet — everybody has at least 100 points waiting for them, but you might have more!${NEWLINE_OR_SPACE}Claim your drop: https://rainbow.me/points?ref=${referralCode}`;
 
   if (metamaskSwaps && metamaskSwaps?.earnings?.total > 0) {
     const METAMASK_POINTS = metamaskSwaps.earnings.total;
-    text = `I just had ${(ONBOARDING_TOTAL_POINTS - METAMASK_POINTS).toLocaleString(
-      'en-US'
-    )} Rainbow Points dropped into my wallet — plus an extra ${METAMASK_POINTS.toLocaleString(
-      'en-US'
+    text = `I just had ${getNumberFormatter('en-US').format(
+      ONBOARDING_TOTAL_POINTS - METAMASK_POINTS
+    )} Rainbow Points dropped into my wallet — plus an extra ${getNumberFormatter('en-US').format(
+      METAMASK_POINTS
     )} Points as a bonus for migrating my MetaMask wallet into Rainbow 🦊 🔫.${NEWLINE_OR_SPACE}Everybody has at least 100 points waiting for them, but you might have more! Claim your drop: https://rainbow.me/points?ref=${referralCode}`;
   }
 

--- a/src/screens/points/content/PointsContent.tsx
+++ b/src/screens/points/content/PointsContent.tsx
@@ -64,6 +64,7 @@ import { InfoCard } from '../components/InfoCard';
 import { LeaderboardRow } from '../components/LeaderboardRow';
 import { RewardsActionButton } from '../components/RewardsActionButton';
 import { Skeleton } from '../components/Skeleton';
+import { getNumberFormatter } from '@/helpers/intl';
 
 const InfoCards = ({ points }: { points: GetPointsDataForWalletQuery | undefined }) => {
   const labelSecondary = useForegroundColor('labelSecondary');
@@ -123,19 +124,19 @@ const InfoCards = ({ points }: { points: GetPointsDataForWalletQuery | undefined
     if (rankChange === undefined) return '';
     if (rankChange === 0) return i18n.t(i18n.l.points.points.no_change);
 
-    return Math.abs(rankChange).toLocaleString('en-US');
+    return getNumberFormatter('en-US').format(rankChange);
   };
 
   const getRankCardMainText = () => {
     if (!rank) return '';
-    return isUnranked ? i18n.t(i18n.l.points.points.unranked) : `#${rank.toLocaleString('en-US')}`;
+    return isUnranked ? i18n.t(i18n.l.points.points.unranked) : `#${getNumberFormatter('en-US').format(rank)}`;
   };
 
   const getEarnedLastWeekSubtitle = () => {
     if (lastPeriodUnranked || !lastPeriodRank) return i18n.t(i18n.l.points.points.no_weekly_rank);
     if (lastPeriodRank <= 10) return i18n.t(i18n.l.points.points.top_10_earner);
     return i18n.t(i18n.l.points.points.ranking, {
-      rank: lastPeriodRank.toLocaleString('en-US'),
+      rank: getNumberFormatter('en-US').format(lastPeriodRank),
     });
   };
 
@@ -149,7 +150,7 @@ const InfoCards = ({ points }: { points: GetPointsDataForWalletQuery | undefined
               title={i18n.t(i18n.l.points.points.earned_last_week)}
               mainText={
                 lastPeriodEarnings
-                  ? `${lastPeriodEarnings.toLocaleString('en-US')} ${i18n.t(i18n.l.points.points.points_capitalized)}`
+                  ? `${getNumberFormatter('en-US').format(lastPeriodEarnings)} ${i18n.t(i18n.l.points.points.points_capitalized)}`
                   : undefined
               }
               placeholderMainText={i18n.t(i18n.l.points.points.zero_points)}
@@ -160,10 +161,10 @@ const InfoCards = ({ points }: { points: GetPointsDataForWalletQuery | undefined
             <InfoCard
               loading={isLoadingReferralsCard}
               title={i18n.t(i18n.l.points.points.referrals)}
-              mainText={qualifiedReferees ? qualifiedReferees.toLocaleString('en-US') : undefined}
+              mainText={qualifiedReferees ? getNumberFormatter('en-US').format(qualifiedReferees) : undefined}
               placeholderMainText={i18n.t(i18n.l.points.points.none)}
               icon="􀇯"
-              subtitle={`${referralsEarnings?.toLocaleString('en-US') ?? '0'} ${i18n.t(i18n.l.points.points.points_capitalized)}`}
+              subtitle={`${getNumberFormatter('en-US').format(referralsEarnings ?? 0)} ${i18n.t(i18n.l.points.points.points_capitalized)}`}
               accentColor={yellow}
             />
             <InfoCard
@@ -670,7 +671,8 @@ export function PointsContent() {
     setIsRefreshing(false);
   }, [dataUpdatedAt, refetch]);
 
-  const totalPointsString = points?.points?.user?.earnings?.total.toLocaleString('en-US');
+  const totalPointsString =
+    points?.points?.user?.earnings?.total != null ? getNumberFormatter('en-US').format(points.points.user.earnings.total) : undefined;
 
   const rank = points?.points?.user.stats.position.current;
   const isUnranked = !!points?.points?.user?.stats?.position?.unranked;
@@ -913,7 +915,7 @@ export function PointsContent() {
                           </Text>
                         </Box>
                         <Text color={isUnranked ? 'labelQuaternary' : 'label'} size="17pt" weight="heavy">
-                          {isUnranked ? i18n.t(i18n.l.points.points.unranked) : `#${rank.toLocaleString('en-US')}`}
+                          {isUnranked ? i18n.t(i18n.l.points.points.unranked) : `#${getNumberFormatter('en-US').format(rank)}`}
                         </Text>
                       </Box>
                     </Box>

--- a/src/screens/points/content/console/calculate.tsx
+++ b/src/screens/points/content/console/calculate.tsx
@@ -13,6 +13,7 @@ import { NeonButton } from '../../components/NeonButton';
 import { Paragraph } from '../../components/Paragraph';
 import { RainbowPointsFlowSteps, rainbowColors, textColors } from '../../constants';
 import { usePointsProfileContext } from '../../contexts/PointsProfileContext';
+import { getNumberFormatter } from '@/helpers/intl';
 
 export const Calculate = () => {
   const {
@@ -165,7 +166,7 @@ export const Calculate = () => {
                   enableHapticTyping
                   hapticType="impactHeavy"
                   textAlign="right"
-                  textContent={(profile?.onboardPoints?.user.onboarding?.earnings?.total ?? 0).toLocaleString('en-US')}
+                  textContent={getNumberFormatter('en-US').format(profile?.onboardPoints?.user.onboarding?.earnings?.total ?? 0)}
                   onComplete={() => {
                     setShouldShowContinueButton(true);
                   }}

--- a/src/screens/points/content/console/view-weekly-earnings.tsx
+++ b/src/screens/points/content/console/view-weekly-earnings.tsx
@@ -14,6 +14,7 @@ import { LineBreak } from '../../components/LineBreak';
 import { NeonButton } from '../../components/NeonButton';
 import { Paragraph } from '../../components/Paragraph';
 import { rainbowColors, textColors } from '../../constants';
+import { getNumberFormatter } from '@/helpers/intl';
 
 export const ViewWeeklyEarnings = () => {
   const [showCloseButton, setShowCloseButton] = useState(false);
@@ -112,7 +113,7 @@ export const ViewWeeklyEarnings = () => {
                 delayStart={1000}
                 enableHapticTyping
                 textAlign="right"
-                textContent={`+ ${retroactive.toLocaleString('en-US')}`}
+                textContent={`+ ${getNumberFormatter('en-US').format(retroactive)}`}
                 typingSpeed={100}
               />
             </Line>
@@ -129,7 +130,7 @@ export const ViewWeeklyEarnings = () => {
                 delayStart={1000}
                 enableHapticTyping
                 textAlign="right"
-                textContent={`+ ${bonus.toLocaleString('en-US')}`}
+                textContent={`+ ${getNumberFormatter('en-US').format(bonus)}`}
                 typingSpeed={100}
               />
             </Line>
@@ -145,7 +146,7 @@ export const ViewWeeklyEarnings = () => {
               delayStart={1000}
               enableHapticTyping
               textAlign="right"
-              textContent={`+ ${transaction.toLocaleString('en-US')}`}
+              textContent={`+ ${getNumberFormatter('en-US').format(transaction)}`}
               typingSpeed={100}
             />
           </Line>
@@ -161,7 +162,7 @@ export const ViewWeeklyEarnings = () => {
               delayStart={1000}
               enableHapticTyping
               textAlign="right"
-              textContent={`+ ${existingReferrals.toLocaleString('en-US')}`}
+              textContent={`+ ${getNumberFormatter('en-US').format(existingReferrals)}`}
               typingSpeed={100}
             />
           </Line>
@@ -177,7 +178,7 @@ export const ViewWeeklyEarnings = () => {
               delayStart={1000}
               enableHapticTyping
               textAlign="right"
-              textContent={`+ ${newReferrals.toLocaleString('en-US')}`}
+              textContent={`+ ${getNumberFormatter('en-US').format(newReferrals)}`}
               typingSpeed={100}
             />
           </Line>
@@ -216,7 +217,7 @@ export const ViewWeeklyEarnings = () => {
                 }, 500);
                 return () => clearTimeout(complete);
               }}
-              textContent={`+ ${totalWeeklyEarnings.toLocaleString('en-US')} ${i18n.t(i18n.l.points.console.points)}`}
+              textContent={`+ ${getNumberFormatter('en-US').format(totalWeeklyEarnings)} ${i18n.t(i18n.l.points.console.points)}`}
               typingSpeed={100}
             />
           </Line>
@@ -241,7 +242,7 @@ export const ViewWeeklyEarnings = () => {
               enableHapticTyping
               hapticType="impactHeavy"
               textAlign="right"
-              textContent={`${newTotalEarnings.toLocaleString('en-US')} ${i18n.t(i18n.l.points.console.points)}`}
+              textContent={`${getNumberFormatter('en-US').format(newTotalEarnings)} ${i18n.t(i18n.l.points.console.points)}`}
               onComplete={() => {
                 const complete = setTimeout(() => {
                   setShowCloseButton(true);

--- a/src/screens/rewards/components/RewardsClaimed.tsx
+++ b/src/screens/rewards/components/RewardsClaimed.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'react-redux';
 import { AppState } from '@/redux/store';
 import { analytics } from '@/analytics';
 import { formatTokenDisplayValue } from '@/screens/rewards/helpers/formatTokenDisplayValue';
+import { getNumberFormatter } from '@/helpers/intl';
 
 type Props = {
   assetPrice?: number;
@@ -78,7 +79,7 @@ export const RewardsClaimed: React.FC<Props> = ({
   } else {
     const claimed = totalAvailableRewardsInToken - remainingRewards;
     const progress = claimed / totalAvailableRewardsInToken;
-    const claimedTokenFormatted = Math.floor(claimed).toLocaleString('en-US');
+    const claimedTokenFormatted = getNumberFormatter('en-US').format(Math.floor(claimed));
 
     const navigateToAmountsExplainer = () => {
       analytics.track(analytics.event.rewardsPressedAvailableCard);

--- a/src/screens/rewards/helpers/formatTokenDisplayValue.ts
+++ b/src/screens/rewards/helpers/formatTokenDisplayValue.ts
@@ -1,6 +1,6 @@
+import { getNumberFormatter } from '@/helpers/intl';
+
 export function formatTokenDisplayValue(tokenValue: number, tokenSymbol: string): string {
-  const formattedValue = tokenValue.toLocaleString('en-US', {
-    maximumFractionDigits: 2,
-  });
+  const formattedValue = getNumberFormatter('en-US', { maximumFractionDigits: 2 }).format(tokenValue);
   return `${formattedValue} ${tokenSymbol}`;
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,3 +1,4 @@
+import { getDateFormatter } from '@/helpers/intl';
 import * as i18n from '@/languages';
 
 export const formatDate = (dateString: string, precision: 'hours' | 'minutes' | 'days' = 'days') => {
@@ -39,6 +40,6 @@ export const formatDate = (dateString: string, precision: 'hours' | 'minutes' | 
   } else if (diffDays < 365.25) {
     return `${diffMonths} ${i18n.t(i18n.l.walletconnect.simulation.formatted_dates.months_ago)}`;
   } else {
-    return date.toLocaleString('default', { month: 'short', year: 'numeric' });
+    return getDateFormatter(undefined, { month: 'short', year: 'numeric' }).format(date);
   }
 };


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I ran I quick profile of app launch + opening swap screen and found a large number of time spent in `toLocaleString`. This is a wrapper around `Intl` formatters so to improve performance we can use them directly and cache them. For some reason on hermes android creating the formatters is very slow.

## Screen recordings / screenshots

Before:

<img width="704" height="536" alt="image" src="https://github.com/user-attachments/assets/02012665-d5ec-4271-818b-0df0213b6028" />

After:

<img width="741" height="401" alt="image" src="https://github.com/user-attachments/assets/282cc334-def2-4873-86ec-4406c6ec4b73" />

<img width="514" height="91" alt="image" src="https://github.com/user-attachments/assets/17e5e33a-a4f2-4486-998c-ee22f0e1c140" />


## What to test

- Make sure number / date formatting still works
- Hopefully we can feel a small perf improvement generally