### PR TITLE
[e2e] Dont check initial theme state

### DIFF
--- a/e2e/settings/Settings.yaml
+++ b/e2e/settings/Settings.yaml
@@ -35,8 +35,6 @@ tags:
                 id: settings-menu
             - tapOn: 'Settings'
       # Change theme to dark and validate
-      - assertVisible:
-          id: choose-theme-section-light
       - tapOn:
           id: choose-theme-section.*
       - tapOn: 'Dark'


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Where running locally sometimes my emulator will already be in dark mode so the test will fail, we don't need to assert that it is in light mode.

## Screen recordings / screenshots


## What to test

Settings test passes