### PR TITLE
Toasts - improved dismiss gestures

### DIFF
--- a/src/components/rainbow-toast/RainbowToast.tsx
+++ b/src/components/rainbow-toast/RainbowToast.tsx
@@ -414,7 +414,7 @@ const RainbowToastItem = memo(function RainbowToast({ toast, testID, minWidth: m
 
   return (
     <GestureDetector gesture={combinedGesture}>
-      <Animated.View style={[dragStyle, { zIndex: 3 - index }]}>
+      <Animated.View style={[dragStyle, { alignSelf: 'center', zIndex: 3 - index }]}>
         <Animated.View
           testID={testID}
           style={[
@@ -498,9 +498,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 100,
-    alignSelf: 'center',
-    position: 'absolute',
-    flex: 1,
     minHeight: TOAST_HEIGHT,
   },
   background: {

--- a/src/components/rainbow-toast/RainbowToast.tsx
+++ b/src/components/rainbow-toast/RainbowToast.tsx
@@ -160,7 +160,7 @@ function RainbowToastDisplayContent() {
       <RainbowToastExpandedDisplay />
 
       <GestureDetector gesture={panGesture}>
-        <Animated.View pointerEvents="box-none" style={[StyleSheet.absoluteFillObject, hiddenAnimatedStyle]}>
+        <Animated.View style={[StyleSheet.absoluteFillObject, hiddenAnimatedStyle]}>
           {visibleToasts.map(toast => {
             return <RainbowToastItem minWidth={minWidth} onWidth={setToastWidth} key={toast.id} toast={toast} />;
           })}

--- a/src/components/rainbow-toast/RainbowToastExpandedDisplay.tsx
+++ b/src/components/rainbow-toast/RainbowToastExpandedDisplay.tsx
@@ -47,7 +47,6 @@ export const RainbowToastExpandedDisplay = memo(function RainbowToastExpandedDis
     height,
     upwardSensitivityMultiplier: TOAST_EXPANDED_UPWARD_SENSITIVITY_MULTIPLIER,
     dismissSensitivity: TOAST_EXPANDED_DISMISS_SENSITIVITY,
-    initialY: 0,
     dismissTargetY: -100,
   });
 

--- a/src/components/rainbow-toast/constants.ts
+++ b/src/components/rainbow-toast/constants.ts
@@ -1,5 +1,3 @@
-import { TransactionStatus, TransactionType } from '@/entities';
-import * as i18n from '@/languages';
 import { time } from '@/utils';
 
 export const TOAST_ICON_SIZE = 28;
@@ -19,6 +17,6 @@ export const TOAST_DONE_HIDE_TIMEOUT_MS = time.seconds(4);
 export const TOAST_HIDE_TIMEOUT_MS = time.seconds(120); // max time to show a toast
 
 // make dismissing easier (lower) or harder (higher)
-export const TOAST_EXPANDED_DISMISS_SENSITIVITY = 0.5;
+export const TOAST_EXPANDED_DISMISS_SENSITIVITY = 1;
 // upward dragging more sensitive
-export const TOAST_EXPANDED_UPWARD_SENSITIVITY_MULTIPLIER = 2;
+export const TOAST_EXPANDED_UPWARD_SENSITIVITY_MULTIPLIER = 1.5;

--- a/src/components/rainbow-toast/useRainbowToasts.ts
+++ b/src/components/rainbow-toast/useRainbowToasts.ts
@@ -5,7 +5,7 @@ import { Mints } from '@/resources/mints';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 
 // dev tool for seeing helpful formatted logs, only really useful for dev as they are large
-const DEBUG_INCOMING = true || process.env.DEBUG_RAINBOW_TOASTS === '1';
+const DEBUG_INCOMING = process.env.DEBUG_RAINBOW_TOASTS === '1';
 
 export type ToastState = {
   isShowingTransactionDetails: boolean;
@@ -14,6 +14,7 @@ export type ToastState = {
   handleTransactions: (props: { transactions: RainbowTransaction[]; mints?: Mints }) => void;
   startRemoveToast: (id: string, via: 'swipe' | 'finish') => void;
   finishRemoveToast: (id: string) => void;
+  removeAllToasts: () => void;
   dismissedToasts: Record<string, boolean>;
   showExpanded: boolean;
   setShowExpandedToasts: (show: boolean) => void;
@@ -134,6 +135,19 @@ export const useToastStore = createRainbowStore<ToastState>(
         toasts: state.toasts.filter(t => t.id !== id).map((t, index) => ({ ...t, index })),
       }));
     },
+
+    removeAllToasts: () => {
+      set(state => {
+        const dismissedToasts = Object.fromEntries(state.toasts.map(t => [t.id, true]));
+        return {
+          toasts: [],
+          dismissedToasts: {
+            ...state.dismissedToasts,
+            ...dismissedToasts,
+          },
+        };
+      });
+    },
   }),
   {
     storageKey: `rainbow-toasts`,
@@ -162,5 +176,11 @@ function getToastsStateForStartRemove(state: ToastState, id: string, via: 'swipe
   } satisfies Partial<ToastState>;
 }
 
-export const { handleTransactions, startRemoveToast, finishRemoveToast, setShowExpandedToasts, setIsShowingTransactionDetails } =
-  useToastStore.getState();
+export const {
+  handleTransactions,
+  startRemoveToast,
+  finishRemoveToast,
+  removeAllToasts,
+  setShowExpandedToasts,
+  setIsShowingTransactionDetails,
+} = useToastStore.getState();

--- a/src/components/rainbow-toast/useVerticalDismissPanGesture.ts
+++ b/src/components/rainbow-toast/useVerticalDismissPanGesture.ts
@@ -1,0 +1,94 @@
+import { useCallback, useMemo } from 'react';
+import { Gesture } from 'react-native-gesture-handler';
+import { runOnJS, useSharedValue, withSpring } from 'react-native-reanimated';
+
+export const springConfigEnter = { damping: 14, mass: 1, stiffness: 121.6 };
+
+export const springConfigDismiss = {
+  restDisplacementThreshold: 0.5,
+  restSpeedThreshold: 5,
+  damping: 20,
+  mass: 0.8,
+  stiffness: 250,
+};
+
+interface UseVerticalDismissPanGestureProps {
+  onDismiss: () => void | Promise<void>;
+  onStartDismiss?: () => void;
+  height?: number;
+  upwardSensitivityMultiplier?: number;
+  dismissSensitivity?: number;
+  initialY?: number;
+  dismissTargetY?: number;
+}
+
+export function useVerticalDismissPanGesture({
+  onDismiss,
+  onStartDismiss,
+  height = 200,
+  upwardSensitivityMultiplier = 2,
+  dismissSensitivity = 0.3,
+  initialY = 0,
+  dismissTargetY = -100,
+}: UseVerticalDismissPanGestureProps) {
+  const dragY = useSharedValue(initialY);
+  const isDismissed = useSharedValue(false);
+
+  const animateTo = useCallback(
+    (toY: number, config = springConfigEnter) => {
+      'worklet';
+      dragY.value = withSpring(toY, config);
+    },
+    [dragY]
+  );
+
+  const panGesture = useMemo(() => {
+    return Gesture.Pan()
+      .simultaneousWithExternalGesture(Gesture.Pan())
+      .shouldCancelWhenOutside(false)
+      .activeOffsetY([-10, 10])
+      .failOffsetX([-30, 30])
+      .onUpdate(e => {
+        'worklet';
+        const rawTranslation = e.translationY;
+        // friction as you drag down
+        if (rawTranslation > 0) {
+          // reduce movement as distance increases
+          const friction = 0.05; // lower = more friction
+          dragY.value = initialY + (rawTranslation * friction + (rawTranslation * (1 - friction)) / (1 + rawTranslation * 0.01));
+        } else {
+          dragY.value = initialY + rawTranslation;
+        }
+      })
+      .onEnd(e => {
+        'worklet';
+        const dragDistance = dragY.value - initialY;
+        const adjustedDistance = dragDistance < 0 ? dragDistance * upwardSensitivityMultiplier : dragDistance;
+        const distanceRatio = Math.abs(adjustedDistance) / height;
+        const velocityFactor = Math.abs(e.velocityY) / 1000;
+        const dismissScore = distanceRatio + velocityFactor;
+        const shouldDismiss = dismissScore > dismissSensitivity;
+
+        if (shouldDismiss) {
+          onStartDismiss?.();
+          isDismissed.value = true;
+          dragY.value = withSpring(dismissTargetY, springConfigDismiss, () => {
+            runOnJS(onDismiss)();
+
+            // reset state now since its fully dismissed
+            dragY.value = withSpring(initialY, springConfigEnter);
+            isDismissed.value = false;
+          });
+        } else {
+          dragY.value = withSpring(initialY, springConfigEnter);
+        }
+      });
+  }, [dragY, initialY, upwardSensitivityMultiplier, height, dismissSensitivity, onStartDismiss, isDismissed, dismissTargetY, onDismiss]);
+
+  return {
+    dragY,
+    isDismissed,
+    panGesture,
+    animateTo,
+  };
+}

--- a/src/components/rainbow-toast/useVerticalDismissPanGesture.ts
+++ b/src/components/rainbow-toast/useVerticalDismissPanGesture.ts
@@ -18,7 +18,6 @@ interface UseVerticalDismissPanGestureProps {
   height?: number;
   upwardSensitivityMultiplier?: number;
   dismissSensitivity?: number;
-  initialY?: number;
   dismissTargetY?: number;
 }
 
@@ -28,10 +27,9 @@ export function useVerticalDismissPanGesture({
   height = 200,
   upwardSensitivityMultiplier = 2,
   dismissSensitivity = 0.3,
-  initialY = 0,
   dismissTargetY = -100,
 }: UseVerticalDismissPanGestureProps) {
-  const dragY = useSharedValue(initialY);
+  const dragY = useSharedValue(0);
   const isDismissed = useSharedValue(false);
 
   const animateTo = useCallback(
@@ -55,14 +53,14 @@ export function useVerticalDismissPanGesture({
         if (rawTranslation > 0) {
           // reduce movement as distance increases
           const friction = 0.05; // lower = more friction
-          dragY.value = initialY + (rawTranslation * friction + (rawTranslation * (1 - friction)) / (1 + rawTranslation * 0.01));
+          dragY.value = rawTranslation * friction + (rawTranslation * (1 - friction)) / (1 + rawTranslation * 0.01);
         } else {
-          dragY.value = initialY + rawTranslation;
+          dragY.value = rawTranslation;
         }
       })
       .onEnd(e => {
         'worklet';
-        const dragDistance = dragY.value - initialY;
+        const dragDistance = dragY.value;
         const adjustedDistance = dragDistance < 0 ? dragDistance * upwardSensitivityMultiplier : dragDistance;
         const distanceRatio = Math.abs(adjustedDistance) / height;
         const velocityFactor = Math.abs(e.velocityY) / 1000;
@@ -76,14 +74,14 @@ export function useVerticalDismissPanGesture({
             runOnJS(onDismiss)();
 
             // reset state now since its fully dismissed
-            dragY.value = withSpring(initialY, springConfigEnter);
+            dragY.value = withSpring(0, springConfigEnter);
             isDismissed.value = false;
           });
         } else {
-          dragY.value = withSpring(initialY, springConfigEnter);
+          dragY.value = withSpring(0, springConfigEnter);
         }
       });
-  }, [dragY, initialY, upwardSensitivityMultiplier, height, dismissSensitivity, onStartDismiss, isDismissed, dismissTargetY, onDismiss]);
+  }, [dragY, upwardSensitivityMultiplier, height, dismissSensitivity, onStartDismiss, isDismissed, dismissTargetY, onDismiss]);
 
   return {
     dragY,


### PR DESCRIPTION
Fixes APP-2873

## What changed (plus any additional context for devs)

Added useVerticalDismissPanGesture so you can swipe up/down the mini toasts.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/9a4b2af4-e353-4302-b21c-8f3815d3328b

## What to test

All interactions on toasts both mini and expanded, especially:

- pull down to dismiss
- push up to dismiss