### PR TITLE
Fix send nft test

### DIFF
--- a/e2e/transactions/SendNft.yaml
+++ b/e2e/transactions/SendNft.yaml
@@ -38,6 +38,10 @@ tags:
 
       - tapOn: '.*Rainbow Pooly.*'
 
+      # Need to scroll a bit more after expanding the section.
+      - swipe:
+          direction: UP
+
       - tapOn:
           id: 'wrapped-nft-Rainbow Pooly 104'
 
@@ -45,11 +49,6 @@ tags:
       - waitForAnimationToEnd:
           timeout: 2000
 
-      - retry:
-          maxRetries: 3
-          commands:
-            - assertVisible:
-                id: 'send-action-button'
       - tapOn:
           id: 'send-action-button'
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I was able to reproduce the issue by running the tests in release mode. For some reason the issue doesn't happen in debug.

I added a swipe down to bring the NFT into view after expanding the section. Seems like before the tap right after tapping the section didn't work and the sheet would not open. Not sure if it has to do with the tap happening too fast or just that the element is not properly into view, but adding this scroll fixes it.

## Screen recordings / screenshots

N/A

## What to test

Tests pass!