### PR TITLE
Fix P3 colors

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -39,8 +39,6 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate {
     NotificationCenter.default.addObserver(self, selector: #selector(handleRapComplete), name: NSNotification.Name("rapCompleted"), object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handleRsEscape), name: NSNotification.Name("rsEscape"), object: nil)
 
-    RCTSetDefaultColorSpace(RCTColorSpace.displayP3)
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
@@ -156,5 +154,9 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 #else
     Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 #endif
+  }
+
+  override func defaultColorSpace() -> RCTColorSpace {
+    RCTColorSpace.displayP3
   }
 }


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

I wasn't using the API properly to set the default color space, we need to override `defaultColorSpace`, otherwise the value was getting overriden later.

## Screen recordings / screenshots

Before:
![Untitled 2](https://github.com/user-attachments/assets/6c6a62f3-3997-4a98-803d-14755cc9e81c)

After:
![Untitled](https://github.com/user-attachments/assets/d750e33f-0911-46ae-85e4-16d79bd67feb)

## What to test

Compare colors before and after change