### PR TITLE
feat: make splashscreen self-contained on iOS

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -62,7 +62,7 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate {
     if isE2E { return success }
 
     if success, let rootView = window?.rootViewController?.view {
-      RNSplashScreen.showSplash("LaunchScreen", inRootView: rootView)
+      RainbowSplashScreen.showSplash("LaunchScreen", inRootView: rootView)
     }
 
     return success

--- a/ios/RainbowSplashScreen.swift
+++ b/ios/RainbowSplashScreen.swift
@@ -9,29 +9,69 @@ private enum SplashScreenViewTags: Int {
 
 @objc(RainbowSplashScreen)
 class RainbowSplashScreen: NSObject {
+  
+  private static var addedJsLoadErrorObserver = false;
+  private static var loadingView: UIView? = nil;
 
+  // needed since RN does not see the static method
   @objc func hideAnimated() {
+    RainbowSplashScreen.staticHideAnimated()
+  }
+  
+  static func staticHideAnimated() {
     DispatchQueue.main.async {
-      guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let window = windowScene.windows.first(where: { $0.isKeyWindow }),
-            let rootVC = window.rootViewController else {
-        RNSplashScreen.hide()
-        return
-      }
+      
+      if let loadingView = loadingView {
+        guard let subview = loadingView.viewWithTag(SplashScreenViewTags.container.rawValue),
+              let rainbowIcon = loadingView.viewWithTag(SplashScreenViewTags.icon.rawValue) as? UIImageView else {
+          self.hide()
+          return
+        }
 
-      guard let subview = rootVC.view.viewWithTag(SplashScreenViewTags.container.rawValue),
-            let rainbowIcon = subview.viewWithTag(SplashScreenViewTags.icon.rawValue) as? UIImageView else {
-        RNSplashScreen.hide()
-        return
+        UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveEaseIn, animations: {
+          rainbowIcon.transform = CGAffineTransform(scaleX: 0.0000000001, y: 0.0000000001)
+          subview.alpha = 0.0
+        }) { _ in
+          subview.isHidden = true
+          self.hide()
+        }
+      } else {
+        print("WARNING: calling hideAnimated on SplashScreen but loadingView is nil")
       }
+    }
+  }
+  
+  static func showSplash(_ splashScreen: String, inRootView rootView: UIView) {
+    
+    if !addedJsLoadErrorObserver {
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("RCTJavaScriptDidFailToLoadNotification"),
+            object: nil,
+            queue: .main
+        ) { _ in
+          // If there was an error loading JavaScript, hide the splash screen so it can be shown. Otherwise, the splash screen will remain forever, which is a hassle to debug.
+          self.hide()
+        }
+        addedJsLoadErrorObserver = true
+    }
 
-      UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveEaseIn, animations: {
-        rainbowIcon.transform = CGAffineTransform(scaleX: 0.0000000001, y: 0.0000000001)
-        subview.alpha = 0.0
-      }) { _ in
-        subview.isHidden = true
-        RNSplashScreen.hide()
-      }
+    if loadingView == nil {
+        guard let view = Bundle.main.loadNibNamed(splashScreen, owner: self, options: nil)?.first as? UIView else {
+          print("WARNING: SplashScreen nib not found")
+          return
+        }
+        loadingView = view
+        loadingView?.frame = rootView.frame
+        loadingView?.frame.origin = .zero
+    }
+    if let loadingView = loadingView {
+        rootView.addSubview(loadingView)
+    }
+  }
+  
+  static func hide() {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        loadingView?.removeFromSuperview()
     }
   }
 


### PR DESCRIPTION
Fixes APP-2914

## What changed (plus any additional context for devs)

SplashScreen code is now contained solely in `RainbowSplashScreen.swift`. We don't need the hacky way of going through windows of app and looking for a specific view when we can just save the one that holds the nib itself (`loadingView`).

## Screen recordings / screenshots


## What to test

That the SplashScreen correctly disappears after the app loads.