### PR TITLE
Fix activity list contract icon style

### DIFF
--- a/src/components/coin-row/FastTransactionCoinRow.tsx
+++ b/src/components/coin-row/FastTransactionCoinRow.tsx
@@ -299,36 +299,13 @@ export const ActivityIcon = ({
 
   if (contractIconUrl) {
     return (
-      <View
-        style={{
-          shadowColor: globalColors.grey100,
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.02,
-          shadowRadius: 3,
-          overflow: 'visible',
-        }}
-      >
-        <View
-          style={{
-            shadowColor: !transaction?.asset?.color ? globalColors.grey100 : transaction.asset.color,
-            shadowOffset: { width: 0, height: 6 },
-            shadowOpacity: 0.24,
-            shadowRadius: 9,
-          }}
-        >
-          <ImgixImage
-            size={CardSize}
-            style={{
-              width: size,
-              height: size,
-              borderRadius: 10,
-            }}
-            source={{
-              uri: contractIconUrl,
-            }}
-          />
-        </View>
-        <ChainImage chainId={transaction.chainId} showBadge={badge && transaction.chainId !== ChainId.mainnet} />
+      <View style={sx.iconContainer}>
+        <RainbowCoinIcon
+          icon={contractIconUrl}
+          chainId={transaction?.asset?.chainId || ChainId.mainnet}
+          symbol={transaction?.asset?.symbol || ''}
+          color={transaction?.asset?.colors?.primary || transaction?.asset?.colors?.fallback || undefined}
+        />
       </View>
     );
   }


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

We have custom code to display activity that have a contract icon url, but that code diverges a bit from the rest of the icons. It doesn't apply border radius in dark mode like the other icons do so that explains the white outline. I also noticed different alignment of the network icon.

I think here we can just use the same component that we use to display other kinds of transactions. If you prefer a smaller change it would also be possible to just add the border radius there too, but this seems like a better fix.

## Screen recordings / screenshots

Before:

<img width="375" height="511" alt="image" src="https://github.com/user-attachments/assets/11ce8dd2-6b91-4f8b-b0d6-54df9f2bd81e" />

<img width="379" height="527" alt="image" src="https://github.com/user-attachments/assets/58394f84-1362-4e44-a800-b2c55f3ce6e4" />


After:

<img width="371" height="523" alt="image" src="https://github.com/user-attachments/assets/0a3aeb84-593a-435d-a589-34f52ceb5bbb" />

<img width="371" height="495" alt="image" src="https://github.com/user-attachments/assets/0b2d896c-2658-43c5-ab2d-0179f1a08c21" />


## What to test

Check activity list with a send of DEGEN coin