### PR TITLE
Move allowed rainbow rewards claimable chains to remote config

### DIFF
--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -14,10 +14,13 @@ import { shallowEqual } from '@/worklets/comparisons';
 
 const REMOTE_CONFIG_VERSION = digitsOnly(CURRENT_APP_VERSION);
 
-export interface RainbowConfig extends Record<string, string | boolean | number | Record<string, number>> {
+export interface RainbowConfig extends Record<string, string | boolean | number | Record<string, number> | number[]> {
   /* Objects */
   default_slippage_bips: Record<string, number>;
   default_slippage_bips_chainId: Record<string, number>;
+
+  /* Arrays */
+  rewards_claim_networks: number[];
 
   /* Strings */
   op_nft_network: string;
@@ -138,6 +141,9 @@ export const DEFAULT_CONFIG = {
   default_slippage_bips: DEFAULT_SLIPPAGE_BIPS,
   default_slippage_bips_chainId: DEFAULT_SLIPPAGE_BIPS_CHAINID,
 
+  /* Arrays */
+  rewards_claim_networks: [ChainId.optimism],
+
   /* Strings */
   op_nft_network: 'op-mainnet',
 
@@ -212,11 +218,13 @@ type RemoteConfigKey = keyof typeof DEFAULT_CONFIG;
 type StringifiedFirebaseDefaults = Readonly<{
   default_slippage_bips: string;
   default_slippage_bips_chainId: string;
+  rewards_claim_networks: string;
 }>;
 
 const STRINGIFIED_FIREBASE_DEFAULTS: StringifiedFirebaseDefaults = {
   default_slippage_bips: JSON.stringify(DEFAULT_CONFIG.default_slippage_bips),
   default_slippage_bips_chainId: JSON.stringify(DEFAULT_CONFIG.default_slippage_bips_chainId),
+  rewards_claim_networks: JSON.stringify(DEFAULT_CONFIG.rewards_claim_networks),
 };
 
 type FirebaseConfigDefaults = Omit<RainbowConfig, keyof StringifiedFirebaseDefaults> &


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Move Rainbow rewards claimable chains to remote config, limit to Optimism only. 
- Fix claim button layout, which was cutoff below bottom of panel

## Screen recordings / screenshots


## What to test
- Rainbow ETH rewards claimable - should only see OP Mainnet 
