### PR TITLE
Record e2e test failures

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -124,11 +124,6 @@ jobs:
       cancel-in-progress: false
 
     env:
-      # Can be used to help debug test failures. This will cause the apk to be
-      # built for all architectures so it can be downloaded from the artifacts
-      # and installed locally. It will also record logcat logs and a video of
-      # the test run. Note that the video is limited to 3 minutes.
-      DEBUG: false
       SHARD_TOTAL: 4
       SHARD_INDEX: ${{ matrix.shard-index }}
       ANDROID_EMULATOR_API_LEVEL: 31

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -22,12 +22,6 @@
 
 Logs of the test run are saved in Github Actions artifacts. To access them go to the summary of the run (`https://github.com/rainbow-me/rainbow/actions/runs/<run_id>`) and scroll to the Artifacts section. There you can download the logs in the artifacts archive.
 
-#### Android
-
-The APK used to run the tests is also saved in the Artifacts section.
-
-To get more debug output in CI, set `DEBUG=true` in `.github/workflows/android-e2e.yml`. This will also record logcat logs and a video of the test runs. Unfortunately the video is limited to 3 minutes, so it might not always be useful. Note that we've seen logcat cause adb to crash when running on CI so if this happens try disabling it (`scripts/e2e-android-ci.sh`).
-
 ### E2E test commands
 
 To speedup getting the app into a specific state, we implement some commands. This is a deep link that we send to the app so it performs certain actions. The actions are implemented in `src/components/TestDeeplinkHandler.tsx`, and can be launched by using the following yaml.

--- a/scripts/e2e-android-ci.sh
+++ b/scripts/e2e-android-ci.sh
@@ -6,35 +6,12 @@ export PATH="$PATH":"$HOME/.maestro/bin"
 export MAESTRO_CLI_NO_ANALYTICS=true
 export MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true
 
-DEBUG="${DEBUG:-false}"
 ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
-
-cleanup() {
-  echo "Cleaning up..."
-
-  if [ "${DEBUG:-false}" = "true" ]; then
-    echo "Stopping recording and pulling logs"
-    adb shell "kill -2 \$(cat /data/local/tmp/recording_pid.txt)" || true
-    sleep 1
-    adb pull /data/local/tmp/recording.mp4 "$ARTIFACTS_FOLDER/recording.mp4" || true
-  fi
-}
-
-trap cleanup EXIT INT TERM
 
 # Install the app
 echo "Install app"
 adb install -r $ARTIFACT_PATH_FOR_E2E
 
-# Setup logs and recordings
-if [ $DEBUG = "true" ]; then
-  echo "Debug mode enabled"
-  ADB_LOG_FILE=$ARTIFACTS_FOLDER/adb/adb-log.log
-  mkdir -p "$(dirname $ADB_LOG_FILE)"
-  adb logcat -v time > $ADB_LOG_FILE &
-  adb shell "screenrecord --bugreport /data/local/tmp/recording.mp4 & echo \$! > /data/local/tmp/recording_pid.txt" &
-fi
-
 # Run the tests
-./scripts/e2e-run.sh --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}
+./scripts/e2e-run.sh --platform android --record-on-failure --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}
 

--- a/scripts/e2e-ios-ci.sh
+++ b/scripts/e2e-ios-ci.sh
@@ -12,4 +12,4 @@ ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
 xcrun simctl install "$DEVICE_UDID" "$ARTIFACT_PATH_FOR_E2E"
 
 # Run the tests
-./scripts/e2e-run.sh --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}
+./scripts/e2e-run.sh --platform ios --record-on-failure --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -39,22 +39,20 @@ stop_recording() {
 start_recording() {
   local recording_dir=$1
 
-  if [ "$RECORD_ON_FAILURE" = "true" ] && [ -n "$PLATFORM" ]; then
-    echo "🎥 Starting screen recording..."
-    mkdir -p "$recording_dir"
+  echo "🎥 Starting screen recording..."
+  mkdir -p "$recording_dir"
 
-    if [ "$PLATFORM" = "android" ]; then
-      adb shell "screenrecord --bugreport /data/local/tmp/recording.mp4 & echo \$! > /data/local/tmp/recording_pid.txt" &
-      # Placeholder recording PID for android, since it is saved on the device.
-      RECORDING_PID="android"
-    elif [ "$PLATFORM" = "ios" ]; then
-      if [ -n "${DEVICE_UDID:-}" ]; then
-        xcrun simctl io "$DEVICE_UDID" recordVideo --codec=h264 "$recording_dir/recording.mp4" &
-        RECORDING_PID=$!
-      else
-        xcrun simctl io booted recordVideo --codec=h264 "$recording_dir/recording.mp4" &
-        RECORDING_PID=$!
-      fi
+  if [ "$PLATFORM" = "android" ]; then
+    adb shell "screenrecord --bugreport /data/local/tmp/recording.mp4 & echo \$! > /data/local/tmp/recording_pid.txt" &
+    # Placeholder recording PID for android, since it is saved on the device.
+    RECORDING_PID="android"
+  elif [ "$PLATFORM" = "ios" ]; then
+    if [ -n "${DEVICE_UDID:-}" ]; then
+      xcrun simctl io "$DEVICE_UDID" recordVideo --codec=h264 "$recording_dir/recording.mp4" &
+      RECORDING_PID=$!
+    else
+      xcrun simctl io booted recordVideo --codec=h264 "$recording_dir/recording.mp4" &
+      RECORDING_PID=$!
     fi
   fi
 }
@@ -201,12 +199,12 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
       SUCCESS=true
       echo "✅ Passed: $TEST_NAME (${DURATION}s, $ATTEMPT attempt(s))"
       echo
-      
+
       # Stop recording (if recording was active)
       if [ "$SHOULD_RECORD" = "true" ]; then
         stop_recording "$DEBUG_OUTPUT"
       fi
-      
+
       mv "$DEBUG_OUTPUT" "$ARTIFACTS_FOLDER/maestro/✅-$TEST_NAME-$ATTEMPT"
       break
     else
@@ -214,16 +212,16 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
       DURATION=$((END_TIME - START_TIME))
       echo "⚠️ Attempt $ATTEMPT failed for $TEST_NAME (${DURATION}s)"
       echo
-      
+
       # Stop recording (if recording was active)
       if [ "$SHOULD_RECORD" = "true" ]; then
         stop_recording "$DEBUG_OUTPUT"
       fi
-      
+
       mv "$DEBUG_OUTPUT" "$ARTIFACTS_FOLDER/maestro/❌-$TEST_NAME-$ATTEMPT"
 
-      # Enable recording for subsequent attempts after first failure
-      if [ "$ATTEMPT" -eq 1 ]; then
+      # Enable recording for subsequent attempts after failure
+      if [ "$RECORD_ON_FAILURE" = "true" ]; then
         SHOULD_RECORD=true
       fi
     fi


### PR DESCRIPTION
Fixes APP-2923

## What changed (plus any additional context for devs)

Automatically start recording retries when the test fails the first time. This will help debugging a lot. I think recording only retries for now will be good, and avoid overhead of always recording.

## Screen recordings / screenshots


## What to test

Check that a video recording is available when a test fails in the run artifacts on both iOS and Android.