### PR TITLE
Fixes to pending transaction watching

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -305,6 +305,11 @@ export const event = {
 
   // refresh account data
   refreshAccountData: 'refresh_account_data',
+
+  // pending transactions
+  pendingTransactionResolved: 'pending_transaction.resolved',
+  minedTransactionAssetsResolved: 'mined_transaction.assets_resolved',
+  minedTransactionAssetsTimedOut: 'mined_transaction.assets_timed_out',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -1090,5 +1095,17 @@ export type EventProperties = {
   };
   [event.refreshAccountData]: {
     duration: number;
+  };
+  [event.pendingTransactionResolved]: {
+    chainId: number;
+    type: string;
+    timeToResolve?: number;
+  };
+  [event.minedTransactionAssetsResolved]: {
+    timeToResolve?: number;
+  };
+  [event.minedTransactionAssetsTimedOut]: {
+    chainId: number;
+    type: string;
   };
 };

--- a/src/components/pending-transaction-watcher/PendingTransactionWatcher.tsx
+++ b/src/components/pending-transaction-watcher/PendingTransactionWatcher.tsx
@@ -2,11 +2,27 @@ import { useAccountAddress } from '@/state/wallets/walletsStore';
 import { useWatchPendingTransactions } from '@/hooks/useWatchPendingTxs';
 import { usePoll } from '@/hooks/usePoll';
 import { time } from '@/utils/time';
-import { memo } from 'react';
+import { memo, useRef, useCallback } from 'react';
 
 export const PendingTransactionWatcher = memo(function PendingTransactionWatcher() {
   const address = useAccountAddress();
   const { watchPendingTransactions } = useWatchPendingTransactions({ address });
-  usePoll(watchPendingTransactions, time.seconds(5));
+  const isProcessingRef = useRef(false);
+
+  const safeWatchPendingTransactions = useCallback(async () => {
+    if (isProcessingRef.current) return;
+
+    isProcessingRef.current = true;
+    try {
+      await watchPendingTransactions();
+    } finally {
+      // This is to satisify the linter
+      if (isProcessingRef.current === true) {
+        isProcessingRef.current = false;
+      }
+    }
+  }, [watchPendingTransactions]);
+
+  usePoll(safeWatchPendingTransactions, time.seconds(1));
   return null;
 });

--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -163,7 +163,7 @@ export const transactionFetchQuery = async ({
   chainId: ChainId;
   hash: string;
   originalType?: TransactionType;
-}) => queryClient.fetchQuery(transactionQueryKey({ address, currency, chainId, hash, originalType }), fetchTransaction);
+}) => queryClient.fetchQuery(transactionQueryKey({ address, currency, chainId, hash, originalType }), fetchTransaction, { staleTime: 0 });
 
 export function useBackendTransaction({ hash, chainId }: BackendTransactionArgs) {
   const nativeCurrency = userAssetsStoreManager(state => state.currency);

--- a/src/state/assets/types.ts
+++ b/src/state/assets/types.ts
@@ -149,6 +149,6 @@ export type GetAssetsResponse = {
     success: boolean;
     chainIdsWithErrors?: ChainId[];
   };
-  result: Record<string, UserAsset>;
+  result?: Record<string, UserAsset>;
   errors: { chainId: ChainId; error: string }[];
 };


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
- Adds analytics for watched pending transactions and balance polling updates. 
- Reduce pending transaction polling from 5s -> 1s
- Guard polling function from multiple in flight requests
- Use more reliable method for refreshing transactions when pending transaction is confirmed. 

## Screen recordings / screenshots
No visual changes

## What to test
Swaps on base should result in roughly 5 seconds until pending transaction is confirmed and 4-5 seconds until balance updates. 
