### PR TITLE
APP-2933: Fix in app browser padding for Android

### DIFF
--- a/src/components/DappBrowser/Dimensions.ts
+++ b/src/components/DappBrowser/Dimensions.ts
@@ -1,14 +1,14 @@
 import { IS_IOS } from '@/env';
 import { BASE_TAB_BAR_HEIGHT, TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
 import { safeAreaInsetValues } from '@/utils';
-import { DEVICE_HEIGHT, DEVICE_WIDTH, isUsingButtonNavigation } from '@/utils/deviceUtils';
+import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 export const BOTTOM_BAR_HEIGHT = 88;
 export const SEARCH_BAR_BORDER_RADIUS = 18;
 export const SEARCH_BAR_HEIGHT = 48;
 export const SEARCH_BAR_WIDTH = DEVICE_WIDTH - 72 * 2;
 
-const ADJUSTED_DEVICE_HEIGHT = IS_IOS ? DEVICE_HEIGHT : DEVICE_HEIGHT - (isUsingButtonNavigation() ? 0 : safeAreaInsetValues.bottom);
+const ADJUSTED_DEVICE_HEIGHT = IS_IOS ? DEVICE_HEIGHT : DEVICE_HEIGHT - safeAreaInsetValues.bottom;
 
 export const TOP_INSET = Math.max(safeAreaInsetValues.top, 20);
 export const WEBVIEW_HEIGHT = ADJUSTED_DEVICE_HEIGHT - TOP_INSET - (IS_IOS ? TAB_BAR_HEIGHT : BASE_TAB_BAR_HEIGHT) - BOTTOM_BAR_HEIGHT;


### PR DESCRIPTION
Fixes APP-2933

## What changed (plus any additional context for devs)

Did fix the padding at the bottom.

## Screen recordings / screenshots

#### Before

<img width="467" height="926" alt="image" src="https://github.com/user-attachments/assets/b930d22f-148e-4963-ba6c-68e2eeb74eca" />


#### After the fix

<img width="494" height="941" alt="image" src="https://github.com/user-attachments/assets/9fb2552c-dd80-4687-ba22-8d1cedad641a" />


## What to test

I tested on Samsung Galaxy S24 and Pixel 5
