### PR TITLE
Fix pending transactions when multiple are added at once

### DIFF
--- a/src/components/rainbow-toast/constants.ts
+++ b/src/components/rainbow-toast/constants.ts
@@ -13,8 +13,7 @@ export const TOAST_GAP_FAR = 3.5; // gap for third item
 export const TOAST_TOP_OFFSET = 10;
 export const TOAST_INITIAL_OFFSET_ABOVE = -80;
 export const TOAST_INITIAL_OFFSET_BELOW = 10;
-export const TOAST_CONFIRMED_HIDE_TIMEOUT_MS = time.seconds(4);
-export const TOAST_PENDING_HIDE_TIMEOUT_MS = time.seconds(120); // max time to show a toast
+export const TOAST_HIDE_TIMEOUT_MS = time.seconds(4);
 
 // make dismissing easier (lower) or harder (higher)
 export const TOAST_EXPANDED_DISMISS_SENSITIVITY = 1;

--- a/src/components/rainbow-toast/useRainbowToastsStore.ts
+++ b/src/components/rainbow-toast/useRainbowToastsStore.ts
@@ -1,6 +1,6 @@
-import { TOAST_CONFIRMED_HIDE_TIMEOUT_MS, TOAST_PENDING_HIDE_TIMEOUT_MS } from '@/components/rainbow-toast/constants';
+import { TOAST_HIDE_TIMEOUT_MS } from '@/components/rainbow-toast/constants';
 import type { RainbowToast } from '@/components/rainbow-toast/types';
-import { TransactionStatus, type RainbowTransaction } from '@/entities';
+import { type RainbowTransaction } from '@/entities';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 import { useMemo } from 'react';
 
@@ -38,10 +38,11 @@ export const useRainbowToastsStore = createRainbowStore<ToastState>((set, get) =
       if (show === false && state.pendingRemoveToastIds.length) {
         const nextState = { ...state };
         for (const pendingId of state.pendingRemoveToastIds) {
-          Object.assign(nextState, getToastsStateForStartRemove(state, state.toasts[pendingId], 'finish'));
+          Object.assign(nextState, getToastsStateForStartRemove(nextState, nextState.toasts[pendingId], 'finish'));
         }
         return {
           ...nextState,
+          pendingRemoveToastIds: [],
           showExpanded: false,
         };
       }
@@ -79,12 +80,9 @@ export const useRainbowToastsStore = createRainbowStore<ToastState>((set, get) =
       if (toast.timeoutId != null) {
         clearTimeout(toast.timeoutId);
       }
-      toast.timeoutId = setTimeout(
-        () => {
-          get().startRemoveToast(id, 'finish');
-        },
-        toast.transaction.status === TransactionStatus.pending ? TOAST_PENDING_HIDE_TIMEOUT_MS : TOAST_CONFIRMED_HIDE_TIMEOUT_MS
-      );
+      toast.timeoutId = setTimeout(() => {
+        get().startRemoveToast(id, 'finish');
+      }, TOAST_HIDE_TIMEOUT_MS);
 
       toasts[toast.id] = toast;
 

--- a/src/components/rainbow-toast/useRainbowToastsStore.ts
+++ b/src/components/rainbow-toast/useRainbowToastsStore.ts
@@ -68,7 +68,7 @@ export const useRainbowToastsStore = createRainbowStore<ToastState>((set, get) =
         };
       } else {
         toast = {
-          id: toToastId(transaction),
+          id,
           updatedAt: Date.now(),
           transaction,
           isRemoving: false,

--- a/src/hooks/useTransactionWatcher.ts
+++ b/src/hooks/useTransactionWatcher.ts
@@ -3,20 +3,23 @@ import { time } from '@/utils/time';
 
 interface UseTransactionWatcherProps<T> {
   transactions: T[];
-  watchFunction: (transactions: T[]) => Promise<void>;
+  watchFunction: (transactions: T[], signal: AbortSignal) => Promise<void>;
   interval?: number;
 }
 
 export function useTransactionWatcher<T>({ transactions, watchFunction, interval = time.seconds(1) }: UseTransactionWatcherProps<T>) {
   const isProcessingRef = useRef(false);
   const intervalRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const processTransactions = useCallback(async () => {
     if (isProcessingRef.current || transactions.length === 0) return;
 
     isProcessingRef.current = true;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = new AbortController();
     try {
-      await watchFunction(transactions);
+      await watchFunction(transactions, abortControllerRef.current.signal);
     } finally {
       // eslint-disable-next-line require-atomic-updates
       isProcessingRef.current = false;
@@ -35,6 +38,8 @@ export function useTransactionWatcher<T>({ transactions, watchFunction, interval
     }
 
     return () => {
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }

--- a/src/hooks/useWatchPendingTxs.ts
+++ b/src/hooks/useWatchPendingTxs.ts
@@ -56,7 +56,7 @@ export const useWatchPendingTransactions = ({ address }: { address: string }) =>
 
       // This abort signal will be called if new transactions are received. In that
       // case we need to cancel this fetch since it will now be stale.
-      let canceled = false;
+      let canceled = signal.aborted;
       signal.addEventListener('abort', () => {
         canceled = true;
       });

--- a/src/state/pendingTransactions/index.ts
+++ b/src/state/pendingTransactions/index.ts
@@ -27,7 +27,6 @@ export const pendingTransactionsStore = createStore<PendingTransactionsState>(
       return orderedPendingTransactions;
     },
     addPendingTransaction: ({ address, pendingTransaction }) => {
-      console.log('addPendingTransaction', { address, hash: pendingTransaction.hash, nonce: pendingTransaction.nonce });
       const { pendingTransactions: currentPendingTransactions } = get();
       const addressPendingTransactions = currentPendingTransactions[address] || [];
       const updatedPendingTransactions = [
@@ -42,10 +41,6 @@ export const pendingTransactionsStore = createStore<PendingTransactionsState>(
       const orderedPendingTransactions = updatedPendingTransactions.sort((a, b) => {
         return (a.nonce || 0) - (b.nonce || 0);
       });
-      console.log(
-        'orderedPendingTransactions',
-        orderedPendingTransactions.map(tx => ({ hash: tx.hash, nonce: tx.nonce }))
-      );
       set({
         pendingTransactions: {
           ...currentPendingTransactions,

--- a/src/state/pendingTransactions/index.ts
+++ b/src/state/pendingTransactions/index.ts
@@ -27,6 +27,7 @@ export const pendingTransactionsStore = createStore<PendingTransactionsState>(
       return orderedPendingTransactions;
     },
     addPendingTransaction: ({ address, pendingTransaction }) => {
+      console.log('addPendingTransaction', { address, hash: pendingTransaction.hash, nonce: pendingTransaction.nonce });
       const { pendingTransactions: currentPendingTransactions } = get();
       const addressPendingTransactions = currentPendingTransactions[address] || [];
       const updatedPendingTransactions = [
@@ -41,6 +42,10 @@ export const pendingTransactionsStore = createStore<PendingTransactionsState>(
       const orderedPendingTransactions = updatedPendingTransactions.sort((a, b) => {
         return (a.nonce || 0) - (b.nonce || 0);
       });
+      console.log(
+        'orderedPendingTransactions',
+        orderedPendingTransactions.map(tx => ({ hash: tx.hash, nonce: tx.nonce }))
+      );
       set({
         pendingTransactions: {
           ...currentPendingTransactions,


### PR DESCRIPTION
Fixes APP-3041

## What changed (plus any additional context for devs)

The problem here was that when multiple pending transactions were added in a row, it would cause the watcher to fetch only the first one, then set the pending transactions state with that, overriding any transactions that came in after.

To avoid this we can pass an abort signal that will be called whenever a new transaction watcher function is called. Any previous execution can then return instead of continuing to process.

## Screen recordings / screenshots


## What to test

Send an ens, should now generate 3 pending transactions in the activity list as well as 3 toasts.