### PR TITLE
Hyperliquid charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@ledgerhq/react-native-hw-transport-ble": "6.33.4",
     "@legendapp/list": "1.1.4",
     "@metamask/eth-sig-util": "7.0.2",
-    "@nktkas/hyperliquid": "0.24.0",
+    "@nktkas/hyperliquid": "0.24.3",
     "@notifee/react-native": "7.8.2",
     "@rainbow-me/provider": "0.1.2",
     "@rainbow-me/react-native-animated-number": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@ledgerhq/react-native-hw-transport-ble": "6.33.4",
     "@legendapp/list": "1.1.4",
     "@metamask/eth-sig-util": "7.0.2",
+    "@nktkas/hyperliquid": "0.24.0",
     "@notifee/react-native": "7.8.2",
     "@rainbow-me/provider": "0.1.2",
     "@rainbow-me/react-native-animated-number": "0.0.2",

--- a/shim.js
+++ b/shim.js
@@ -157,7 +157,7 @@ if (!description.writable) {
   });
 }
 
-// Polyfills for nktkas/hyperliquid
+// Polyfills for @nktkas/hyperliquid
 if (!globalThis.EventTarget || !globalThis.Event) {
   globalThis.EventTarget = EventTarget;
   globalThis.Event = Event;

--- a/shim.js
+++ b/shim.js
@@ -9,6 +9,7 @@ import { mmkvStorageBackend } from '@/handlers/localstorage/mmkvStorageBackend';
 import { logger } from '@/logger';
 import 'fast-text-encoding';
 import globalVariables from './globalVariables';
+import { Event, EventTarget } from 'event-target-shim';
 
 if (typeof BigInt === 'undefined') global.BigInt = require('big-integer');
 
@@ -154,4 +155,62 @@ if (!description.writable) {
     })(),
     writable: true,
   });
+}
+
+// Polyfills for nktkas/hyperliquid
+if (!globalThis.EventTarget || !globalThis.Event) {
+  globalThis.EventTarget = EventTarget;
+  globalThis.Event = Event;
+}
+
+if (!globalThis.CustomEvent) {
+  globalThis.CustomEvent = function (type, params) {
+    // eslint-disable-next-line no-param-reassign
+    params = params || {};
+    const event = new Event(type, params);
+    event.detail = params.detail || null;
+    return event;
+  };
+}
+
+if (!AbortSignal.any) {
+  AbortSignal.any = function (signals) {
+    const controller = new AbortController();
+
+    for (const signal of signals) {
+      if (signal.aborted) {
+        controller.abort(signal.reason);
+        return controller.signal;
+      }
+
+      signal.addEventListener(
+        'abort',
+        () => {
+          controller.abort(signal.reason);
+        },
+        { once: true, signal: controller.signal }
+      );
+    }
+
+    return controller.signal;
+  };
+}
+
+if (!AbortSignal.timeout) {
+  AbortSignal.timeout = function (delay) {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), delay);
+    return controller.signal;
+  };
+}
+
+if (!Promise.withResolvers) {
+  Promise.withResolvers = function () {
+    let resolve, reject;
+    const promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
 }

--- a/src/features/charts/candlestick/hyperliquid/hyperliquidCharts.ts
+++ b/src/features/charts/candlestick/hyperliquid/hyperliquidCharts.ts
@@ -1,0 +1,89 @@
+import { Candle, HttpTransport, InfoClient } from '@nktkas/hyperliquid';
+import { INITIAL_BAR_COUNT } from '@/features/charts/constants';
+import { CandleResolution, HyperliquidSymbol } from '@/features/charts/types';
+import { toHyperliquidInterval } from '@/features/charts/utils';
+import { time } from '@/utils';
+import { Bar, CandlestickResponse } from '../types';
+import { getResolutionMinutes } from '../utils';
+
+export type HyperliquidChartParams = {
+  barCount?: number;
+  candleResolution: CandleResolution;
+  startTimestamp?: number;
+  token: HyperliquidSymbol;
+};
+
+/**
+ * Fetches candlestick data from Hyperliquid API and returns it in Bar format.
+ */
+export async function fetchHyperliquidChart(
+  params: HyperliquidChartParams,
+  abortController: AbortController | null
+): Promise<NonNullable<CandlestickResponse>> {
+  const { candleResolution, barCount: requestedCandles = INITIAL_BAR_COUNT, startTimestamp, token: symbol } = params;
+
+  const interval = toHyperliquidInterval(candleResolution);
+  const resolutionMinutes = getResolutionMinutes(candleResolution);
+  const resolutionMs = time.minutes(resolutionMinutes);
+
+  let invertedStartTimeMs: number;
+  let invertedEndTimeMs: number | undefined;
+
+  if (startTimestamp === undefined) {
+    invertedEndTimeMs = Date.now();
+    invertedStartTimeMs = invertedEndTimeMs - resolutionMs * requestedCandles;
+  } else {
+    invertedEndTimeMs = startTimestamp * 1000;
+    invertedStartTimeMs = invertedEndTimeMs - resolutionMs * requestedCandles;
+  }
+
+  const hyperliquidClient = new InfoClient({ transport: new HttpTransport() });
+  const candles = await hyperliquidClient.candleSnapshot(
+    {
+      coin: symbol,
+      endTime: invertedEndTimeMs,
+      interval,
+      startTime: invertedStartTimeMs,
+    },
+    abortController?.signal
+  );
+
+  const bars = convertCandlesToBars(candles, requestedCandles);
+
+  return {
+    candleResolution,
+    candles: bars,
+    hasPreviousCandles: candles.length >= requestedCandles,
+    lastFetchedCurrentPriceAt: Date.now(),
+  };
+}
+
+/**
+ * Converts a Hyperliquid `Candle` array to `Bar` format.
+ */
+function convertCandlesToBars(candles: Candle[], maxBars: number): Bar[] {
+  const length = candles.length;
+  if (!length) return [];
+
+  const offset = length > maxBars ? length - maxBars : 0;
+  const resultLength = Math.min(length, maxBars);
+  const bars = new Array<Bar>(resultLength);
+
+  for (let i = 0; i < resultLength; i++) {
+    const candle = candles[i + offset];
+    bars[i] = {
+      c: Number(candle.c),
+      h: Number(candle.h),
+      l: Number(candle.l),
+      o: Number(candle.o),
+      t: msToSeconds(candle.t),
+      v: Number(candle.v),
+    };
+  }
+
+  return bars;
+}
+
+function msToSeconds(ms: number): number {
+  return ms * 0.001;
+}

--- a/src/features/charts/candlestick/hyperliquid/hyperliquidCharts.ts
+++ b/src/features/charts/candlestick/hyperliquid/hyperliquidCharts.ts
@@ -7,11 +7,16 @@ import { Bar, CandlestickResponse } from '../types';
 import { getResolutionMinutes } from '../utils';
 
 export type HyperliquidChartParams = {
+  /**
+   * The number of candles to fetch. Maximum 500.
+   */
   barCount?: number;
   candleResolution: CandleResolution;
   startTimestamp?: number;
   token: HyperliquidSymbol;
 };
+
+const MAX_HYPERLIQUID_CANDLES = 500;
 
 /**
  * Fetches candlestick data from Hyperliquid API and returns it in Bar format.
@@ -20,8 +25,9 @@ export async function fetchHyperliquidChart(
   params: HyperliquidChartParams,
   abortController: AbortController | null
 ): Promise<NonNullable<CandlestickResponse>> {
-  const { candleResolution, barCount: requestedCandles = INITIAL_BAR_COUNT, startTimestamp, token: symbol } = params;
+  const { candleResolution, barCount: barCountParam = INITIAL_BAR_COUNT, startTimestamp, token: symbol } = params;
 
+  const requestedCandles = Math.min(barCountParam, MAX_HYPERLIQUID_CANDLES);
   const interval = toHyperliquidInterval(candleResolution);
   const resolutionMinutes = getResolutionMinutes(candleResolution);
   const resolutionMs = time.minutes(resolutionMinutes);

--- a/src/features/charts/candlestick/types.ts
+++ b/src/features/charts/candlestick/types.ts
@@ -19,13 +19,20 @@ export type Bar = {
   l: number;
   /** Open price */
   o: number;
-  /** Timestamp */
+  /** Timestamp in seconds */
   t: number;
   /** Volume */
   v: number;
 };
 
-// ============ API Types ====================================================== //
+export type CandlestickResponse = {
+  candleResolution: CandleResolution;
+  candles: Bar[];
+  hasPreviousCandles: boolean;
+  lastFetchedCurrentPriceAt: number | undefined;
+} | null;
+
+// ============ Enums ========================================================== //
 
 /**
  * The candle resolutions supported by the API but not currently used in the app.
@@ -35,17 +42,11 @@ enum DisabledCandleResolution {
   UNSPECIFIED = 'RESOLUTION_UNSPECIFIED',
 }
 
-export type GetCandlestickChartRequest = {
-  /** Pricing currency code (e.g., `'usd'`) */
-  currency: string;
-  /** Number of candles to request */
-  requested_candles: number;
-  /** Candle resolution */
-  resolution: CandleResolution | DisabledCandleResolution;
-  /** Inclusive start of the time window, as epoch-seconds */
-  start_time?: number;
-  /** Token identifier in the form `'address:chainId'` (e.g., `'0x123…:1'`) */
-  token_id: string;
+// ============ API Types ====================================================== //
+
+export type CandlestickEndpointResponse = {
+  metadata: CandlestickChartMetadata;
+  result: CandlestickChartResult;
 };
 
 export type CandlestickChartMetadata = {
@@ -71,7 +72,20 @@ export type CandlestickChartMetadata = {
   tokenId: string;
 };
 
-export type CandlestickChartPayload = {
+export type GetCandlestickChartRequest = {
+  /** Pricing currency code (e.g., `'usd'`) */
+  currency: string;
+  /** Number of candles to request */
+  requested_candles: number;
+  /** Candle resolution */
+  resolution: CandleResolution | DisabledCandleResolution;
+  /** Inclusive start of the time window, as epoch-seconds */
+  start_time?: number;
+  /** Token identifier in the form `'address:chainId'` (e.g., `'0x123…:1'`) */
+  token_id: string;
+};
+
+type CandlestickChartPayload = {
   /** Close prices as decimal strings */
   c: string[];
   /** High prices as decimal strings */
@@ -86,7 +100,7 @@ export type CandlestickChartPayload = {
   v: string[];
 };
 
-export type CandlestickChartSummary = {
+type CandlestickChartSummary = {
   /** First candle price */
   first: string;
   /** Last candle price */
@@ -97,14 +111,9 @@ export type CandlestickChartSummary = {
   min: string;
 };
 
-export type CandlestickChartResult = {
+type CandlestickChartResult = {
   /** Chart details */
   payload: CandlestickChartPayload;
   /** Chart summary over close prices values */
   summary: CandlestickChartSummary;
-};
-
-export type CandlestickChartResponse = {
-  metadata: CandlestickChartMetadata;
-  result: CandlestickChartResult;
 };

--- a/src/features/charts/candlestick/utils.ts
+++ b/src/features/charts/candlestick/utils.ts
@@ -1,5 +1,5 @@
 import { CandleResolution } from '../types';
-import { Bar, CandlestickChartResponse, Price } from './types';
+import { Bar, CandlestickEndpointResponse, Price } from './types';
 
 /**
  * Compares two candle `Bar` objects for equality.
@@ -17,7 +17,7 @@ export function arePricesEqual(previousPrice: Price | undefined, price: Price | 
   return price?.price === previousPrice?.price && price?.percentChange === previousPrice?.percentChange;
 }
 
-export function transformApiResponseToBars(response: CandlestickChartResponse, filterEmptyVolumes = false): Bar[] {
+export function transformApiResponseToBars(response: CandlestickEndpointResponse, filterEmptyVolumes = false): Bar[] {
   const payload = response.result.payload;
   const length = payload.t.length;
   const bars: Bar[] = [];

--- a/src/features/charts/constants.ts
+++ b/src/features/charts/constants.ts
@@ -1,4 +1,9 @@
-import { CandleResolution, LineChartTimePeriod, LineChartTimespan } from '@/features/charts/types';
+import { CandleResolution, HyperliquidInterval, LineChartTimePeriod, LineChartTimespan } from '@/features/charts/types';
+
+/**
+ * Initial number of candles to fetch for candlestick charts.
+ */
+export const INITIAL_BAR_COUNT = 200;
 
 export const CANDLE_RESOLUTIONS: Record<CandleResolution, { index: number; label: string; resolution: CandleResolution }> = {
   [CandleResolution.M1]: { index: 0, label: '1M', resolution: CandleResolution.M1 },
@@ -26,4 +31,15 @@ export const LINE_CHART_TIME_PERIODS: Record<
     timespan: LineChartTimespan.Month,
   },
   [LineChartTimePeriod.Y1]: { index: 4, label: '1Y', suffix: 'Year', timePeriod: LineChartTimePeriod.Y1, timespan: LineChartTimespan.Year },
+};
+
+export const CANDLE_RESOLUTION_TO_HYPERLIQUID_INTERVAL: Record<CandleResolution, HyperliquidInterval> = {
+  [CandleResolution.M1]: '1m',
+  [CandleResolution.M5]: '5m',
+  [CandleResolution.M15]: '15m',
+  [CandleResolution.H1]: '1h',
+  [CandleResolution.H4]: '4h',
+  [CandleResolution.H12]: '12h',
+  [CandleResolution.D1]: '1d',
+  [CandleResolution.D7]: '1w',
 };

--- a/src/features/charts/stores/candlestickStore.ts
+++ b/src/features/charts/stores/candlestickStore.ts
@@ -1,6 +1,7 @@
 import qs from 'qs';
 import { NativeCurrencyKey } from '@/entities';
 import { IS_DEV } from '@/env';
+import { fetchHyperliquidChart, HyperliquidChartParams } from '@/features/charts/candlestick/hyperliquid/hyperliquidCharts';
 import { ChartsState, useChartsStore } from '@/features/charts/stores/chartsStore';
 import { ensureError } from '@/logger';
 import { getPlatformClient } from '@/resources/platform/client';
@@ -8,9 +9,17 @@ import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { createQueryStore, getQueryKey } from '@/state/internal/createQueryStore';
 import { CacheEntry, SetDataParams } from '@/state/internal/queryStore/types';
 import { time } from '@/utils';
-import { Bar, CandlestickChartMetadata, CandlestickChartResponse, GetCandlestickChartRequest, Price } from '../candlestick/types';
+import {
+  Bar,
+  CandlestickChartMetadata,
+  CandlestickEndpointResponse,
+  CandlestickResponse,
+  GetCandlestickChartRequest,
+  Price,
+} from '../candlestick/types';
 import { areCandlesEqual, getResolutionMinutes, transformApiResponseToBars } from '../candlestick/utils';
-import { CandleResolution, ChartType, Token } from '../types';
+import { INITIAL_BAR_COUNT } from '../constants';
+import { CandleResolution, ChartType, HyperliquidSymbol, Token } from '../types';
 
 // ============ Constants ====================================================== //
 
@@ -19,17 +28,9 @@ const CANDLESTICK_ENDPOINT = '/tokens/charts/GetCandleChart';
 const ERROR_NO_DATA_FOUND = 'token data not found';
 const ERROR_UNSUPPORTED_CHAIN = 'unsupported chain id';
 
-const INITIAL_BAR_COUNT = 200;
 const MAX_CANDLES_PER_REQUEST = 1500;
 
 // ============ Core Types ===================================================== //
-
-export type CandlestickResponse = {
-  candleResolution: CandleResolution;
-  candles: Bar[];
-  hasPreviousCandles: boolean;
-  lastFetchedCurrentPriceAt: number | undefined;
-} | null;
 
 type BaseParams = Pick<CandlestickParams, 'candleResolution' | 'token'> & Partial<Pick<CandlestickParams, 'currency'>>;
 type TokenId = string;
@@ -75,7 +76,7 @@ export const useCandlestickStore = createQueryStore<CandlestickResponse, Candles
 
       const { getData, prices } = get();
       const existingData = getData();
-      const tokenId = typeof token === 'string' ? token : getTokenId(token);
+      const tokenId = getTokenId(token);
       const price = prices[tokenId];
       if (!price || !existingData) return price;
 
@@ -99,7 +100,11 @@ async function fetchCandlestickData(params: CandlestickParams, abortController: 
   if (!requestUrl) return null;
 
   try {
-    const response = await getPlatformClient().get<CandlestickChartResponse>(requestUrl, {
+    if (isHyperliquidChart(params)) {
+      return await fetchHyperliquidChart(buildHyperliquidParams(params), abortController);
+    }
+
+    const response = await getPlatformClient().get<CandlestickEndpointResponse>(requestUrl, {
       abortController,
     });
 
@@ -247,7 +252,7 @@ function parseResponseMetadata(metadata: CandlestickChartMetadata, params: Candl
   const includesCurrentPrice = !params.startTimestamp;
   return {
     candleResolution: params.candleResolution,
-    hasPreviousCandles: requestedCount === returnedCount,
+    hasPreviousCandles: requestedCount >= returnedCount,
     lastFetchedCurrentPriceAt: includesCurrentPrice ? new Date(metadata.responseTime).getTime() : undefined,
   };
 }
@@ -255,18 +260,18 @@ function parseResponseMetadata(metadata: CandlestickChartMetadata, params: Candl
 function buildCandlestickRequest(params: CandlestickParams): string | null {
   if (!params.token) return null;
 
-  const { barCount: barCountParam, candleResolution, currency, startTimestamp, token } = params;
-  const barCount = barCountParam ?? INITIAL_BAR_COUNT;
+  const { barCount, candleResolution, currency, startTimestamp, token } = params;
+  const requestedBarCount = barCount ?? INITIAL_BAR_COUNT;
 
   const existingData = useCandlestickStore.getState().getData(params) ?? null;
   const isPrepending = startTimestamp !== undefined;
   const resolutionMinutes = getResolutionMinutes(candleResolution);
 
   const candlesToRequest = isPrepending
-    ? Math.min(barCount, MAX_CANDLES_PER_REQUEST)
+    ? Math.min(requestedBarCount, MAX_CANDLES_PER_REQUEST)
     : determineCandlesToRequest({
         existingData,
-        requestedBarCount: barCount,
+        requestedBarCount,
         resolutionMinutes,
       });
 
@@ -279,6 +284,30 @@ function buildCandlestickRequest(params: CandlestickParams): string | null {
   };
 
   return `${CANDLESTICK_ENDPOINT}?${qs.stringify(queryParams)}`;
+}
+
+function buildHyperliquidParams(params: HyperliquidChartParams & Pick<CandlestickParams, 'currency'>): HyperliquidChartParams {
+  const { barCount, candleResolution, startTimestamp, token } = params;
+  const requestedBarCount = barCount ?? INITIAL_BAR_COUNT;
+
+  const existingData = useCandlestickStore.getState().getData(params) ?? null;
+  const isPrepending = startTimestamp !== undefined;
+  const resolutionMinutes = getResolutionMinutes(candleResolution);
+
+  const candlesToRequest = isPrepending
+    ? Math.min(requestedBarCount, MAX_CANDLES_PER_REQUEST)
+    : determineCandlesToRequest({
+        existingData,
+        requestedBarCount,
+        resolutionMinutes,
+      });
+
+  return {
+    barCount: candlesToRequest,
+    candleResolution,
+    startTimestamp,
+    token,
+  };
 }
 
 /**
@@ -390,8 +419,9 @@ function mergeOrReturnCached({
 /**
  * Returns a unique identifier for a token in the format `address:chainId`.
  */
-function getTokenId({ address, chainId }: Token): string {
-  return `${address}:${chainId}`;
+function getTokenId(token: Token): string {
+  if (typeof token === 'string') return token;
+  return `${token.address}:${token.chainId}`;
 }
 
 /**
@@ -461,6 +491,13 @@ function firstIndexAtOrAfterTimestamp(candles: readonly Bar[], timestamp: number
     else right = middle;
   }
   return left;
+}
+
+/**
+ * Determines if a chart request is for a Hyperliquid chart.
+ */
+function isHyperliquidChart(params: CandlestickParams): params is CandlestickParams & { token: HyperliquidSymbol } {
+  return typeof params.token === 'string';
 }
 
 /**

--- a/src/features/charts/stores/chartsStore.ts
+++ b/src/features/charts/stores/chartsStore.ts
@@ -98,5 +98,6 @@ export function useChartType(): ChartType {
 function areTokensEqual(previousToken: Token | null, newToken: Token | null): boolean {
   if (!previousToken && !newToken) return true;
   if (!previousToken || !newToken) return false;
+  if (typeof previousToken === 'string' || typeof newToken === 'string') return previousToken === newToken;
   return previousToken.address === newToken.address && previousToken.chainId === newToken.chainId;
 }

--- a/src/features/charts/types.ts
+++ b/src/features/charts/types.ts
@@ -1,8 +1,10 @@
+import { CandleSnapshotRequest } from '@nktkas/hyperliquid/script/src/types/mod';
 import { ChainId } from '@/state/backendNetworks/types';
 
 // ============ Types ========================================================== //
 
-export type Token = { address: string; chainId: ChainId };
+export type HyperliquidSymbol = string;
+export type Token = { address: string; chainId: ChainId } | HyperliquidSymbol;
 
 // ============ Enums ========================================================== //
 
@@ -37,3 +39,7 @@ export enum LineChartTimespan {
   Month = 'month',
   Year = 'year',
 }
+
+// ============ Hyperliquid ==================================================== //
+
+export type HyperliquidInterval = CandleSnapshotRequest['req']['interval'];

--- a/src/features/charts/utils.ts
+++ b/src/features/charts/utils.ts
@@ -1,9 +1,16 @@
-import { LINE_CHART_TIME_PERIODS } from '@/features/charts/constants';
-import { LineChartTimePeriod, LineChartTimespan } from '@/features/charts/types';
+import { CANDLE_RESOLUTION_TO_HYPERLIQUID_INTERVAL, LINE_CHART_TIME_PERIODS } from '@/features/charts/constants';
+import { CandleResolution, HyperliquidInterval, LineChartTimePeriod, LineChartTimespan } from '@/features/charts/types';
 
 /**
  * Converts a `LineChartTimePeriod` to a `LineChartTimespan`.
  */
 export function toLineChartTimespan(lineChartTimePeriod: LineChartTimePeriod): LineChartTimespan {
   return LINE_CHART_TIME_PERIODS[lineChartTimePeriod].timespan;
+}
+
+/**
+ * Converts a `CandleResolution` to a `HyperliquidInterval`.
+ */
+export function toHyperliquidInterval(resolution: CandleResolution): HyperliquidInterval {
+  return CANDLE_RESOLUTION_TO_HYPERLIQUID_INTERVAL[resolution];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4507,10 +4507,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@msgpack/msgpack@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@msgpack/msgpack@npm:3.1.2"
+  checksum: 10c0/4fee6dbea70a485d3a787ac76dd43687f489d662f22919237db1f2abbc3c88070c1d3ad78417ce6e764bcd041051680284654021f52068e0aff82d570cb942d5
+  languageName: node
+  linkType: hard
+
 "@multiformats/base-x@npm:^4.0.1":
   version: 4.0.1
   resolution: "@multiformats/base-x@npm:4.0.1"
   checksum: 10c0/f6d16d2d7793ea371206fc17853a0932a7e697ddc739a6b63421a7ee090ee8ab28224c3c7e4401899d0a343bc95284a5f0aa7502edadfb5ad21967f9cbd6a9d2
+  languageName: node
+  linkType: hard
+
+"@nktkas/hyperliquid@npm:0.24.0":
+  version: 0.24.0
+  resolution: "@nktkas/hyperliquid@npm:0.24.0"
+  dependencies:
+    "@msgpack/msgpack": "npm:^3.1.2"
+    "@noble/hashes": "npm:^1.8.0"
+    "@noble/secp256k1": "npm:^2.3.0"
+  checksum: 10c0/976952d408f54d98edc49fbf74a1f1535575661c66a9a88111c2d795bf63ff79fa73869e4b34f5f750699fbf336bf6ae706fa34120fd85e6b24fa9d58b451eb0
   languageName: node
   linkType: hard
 
@@ -4585,10 +4603,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.2":
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 10c0/23c020b33da4172c988e44100e33cd9f8f6250b68b43c467d3551f82070ebd9716e0d9d2347427aa3774c85934a35fa9ee6f026fca2117e3fa12db7bedae7668
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@noble/secp256k1@npm:2.3.0"
+  checksum: 10c0/8f455b57b10ce069e445324ce88603cf2af1b37d741d33ce1ab669b47b464f864b20ec056bbc0c1b18609d27b2e4503bb915052f3d81d357e587b322c5684dbb
   languageName: node
   linkType: hard
 
@@ -8985,6 +9017,7 @@ __metadata:
     "@ledgerhq/react-native-hw-transport-ble": "npm:6.33.4"
     "@legendapp/list": "npm:1.1.4"
     "@metamask/eth-sig-util": "npm:7.0.2"
+    "@nktkas/hyperliquid": "npm:0.24.0"
     "@notifee/react-native": "npm:7.8.2"
     "@rainbow-me/provider": "npm:0.1.2"
     "@rainbow-me/react-native-animated-number": "npm:0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4521,14 +4521,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nktkas/hyperliquid@npm:0.24.0":
-  version: 0.24.0
-  resolution: "@nktkas/hyperliquid@npm:0.24.0"
+"@nktkas/hyperliquid@npm:0.24.3":
+  version: 0.24.3
+  resolution: "@nktkas/hyperliquid@npm:0.24.3"
   dependencies:
     "@msgpack/msgpack": "npm:^3.1.2"
     "@noble/hashes": "npm:^1.8.0"
     "@noble/secp256k1": "npm:^2.3.0"
-  checksum: 10c0/976952d408f54d98edc49fbf74a1f1535575661c66a9a88111c2d795bf63ff79fa73869e4b34f5f750699fbf336bf6ae706fa34120fd85e6b24fa9d58b451eb0
+  checksum: 10c0/ba77d36e3143c3e538952d063eb71c2837b4e3d41fc2df37ab4af21b0e405401316157707e3e226b08b5449ef77c0eb629da5e31ce3e20b2d9712cfd2cbe1fd6
   languageName: node
   linkType: hard
 
@@ -9017,7 +9017,7 @@ __metadata:
     "@ledgerhq/react-native-hw-transport-ble": "npm:6.33.4"
     "@legendapp/list": "npm:1.1.4"
     "@metamask/eth-sig-util": "npm:7.0.2"
-    "@nktkas/hyperliquid": "npm:0.24.0"
+    "@nktkas/hyperliquid": "npm:0.24.3"
     "@notifee/react-native": "npm:7.8.2"
     "@rainbow-me/provider": "npm:0.1.2"
     "@rainbow-me/react-native-animated-number": "npm:0.0.2"


### PR DESCRIPTION
Fixes APP-2987

## What changed (plus any additional context for devs)
- Integrates Hyperliquid candlestick charts via a forked `fetcher` in the candlestick store
- If the `token` in the charts store is a string (a `HyperliquidSymbol`), it uses adapter functions to build an analogous Hyperliquid API request and maps the response to the existing charts system
  - We can alter the Hyperliquid token IDs as needed
- Adds a polyfill for `AbortSignal.any` which seems to be needed for Hyperliquid charts requests
- Not blocking this PR, but need to verify behavior if a non-USD currency is selected as Hyperliquid only supports USD (USDC). Will likely need to account for this in the charts components, which currently rely exclusively on the global `currency` setting.

## Screen recordings / screenshots

_With charts hardcoded to HYPE for testing:_

https://github.com/user-attachments/assets/335d5a75-affa-4abe-8fdc-a80ac57e55fd

## What to test
- Should be no visible changes, and no changes to existing candlestick charts

**Easiest way to test Hyperliquid charts:**

1) Hardcode the `setToken` method in `chartsStore.ts` to:
```ts
setToken: () => set({ token: 'HYPE' }), // Or any Hyperliquid token symbol
```

2) In the `fetchAdditionalCandles` function in `CandlestickChart.tsx`, hardcode the same `token` symbol:

```ts
fetchPromise.current = fetchHistoricalCandles({
  candleResolution: useChartsStore.getState().candleResolution,
  token: 'HYPE',
})
  .then(data => {
    // ...
```
