### PR TITLE
fix: native asset wallet alignment in dapp browser control panel

### DIFF
--- a/src/components/Transactions/TransactionSimulationCard.tsx
+++ b/src/components/Transactions/TransactionSimulationCard.tsx
@@ -29,7 +29,6 @@ import {
 } from '@/components/Transactions/constants';
 import { ChainId } from '@/state/backendNetworks/types';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
-import { ParsedAddressAsset } from '@/entities/tokens';
 
 interface TransactionSimulationCardProps {
   chainId: ChainId;
@@ -42,7 +41,7 @@ interface TransactionSimulationCardProps {
   simulation: TransactionSimulationResult | undefined;
   simulationError: TransactionErrorType | undefined;
   simulationScanResult: TransactionScanResultType | undefined;
-  nativeAsset: ParsedAddressAsset | ReturnType<ReturnType<typeof useBackendNetworksStore.getState>['getChainsNativeAsset']>[ChainId];
+  nativeAsset: ReturnType<ReturnType<typeof useBackendNetworksStore.getState>['getChainsNativeAsset']>[ChainId];
 }
 
 export const TransactionSimulationCard = ({

--- a/src/hooks/useHasEnoughBalance.ts
+++ b/src/hooks/useHasEnoughBalance.ts
@@ -26,7 +26,7 @@ export const useHasEnoughBalance = ({ isMessageRequest, nativeAssetBalance, chai
     }
 
     const txFeeAmount = fromWei(gasFee?.maxFee?.value?.amount ?? 0);
-    const balanceAmount = nativeAssetBalance?.balance?.amount || 0;
+    const balanceAmount = nativeAssetBalance.balance?.amount || 0;
     const value = req?.value ?? 0;
 
     const totalAmount = new BigNumber(fromWei(value)).plus(txFeeAmount);

--- a/src/hooks/useHasEnoughBalance.ts
+++ b/src/hooks/useHasEnoughBalance.ts
@@ -1,25 +1,18 @@
 import { useEffect, useState } from 'react';
 import { fromWei, greaterThanOrEqualTo } from '@/helpers/utilities';
 import BigNumber from 'bignumber.js';
-import { SelectedGasFee } from '@/entities';
+import { ParsedAddressAsset, SelectedGasFee } from '@/entities';
 import { ChainId } from '@/state/backendNetworks/types';
-
-type WalletBalance = {
-  amount: string | number;
-  display: string;
-  isLoaded: boolean;
-  symbol: string;
-};
 
 type BalanceCheckParams = {
   isMessageRequest: boolean;
-  walletBalance: WalletBalance;
+  nativeAssetBalance: ParsedAddressAsset | undefined;
   chainId: ChainId;
   selectedGasFee: SelectedGasFee;
   req: any;
 };
 
-export const useHasEnoughBalance = ({ isMessageRequest, walletBalance, chainId, selectedGasFee, req }: BalanceCheckParams) => {
+export const useHasEnoughBalance = ({ isMessageRequest, nativeAssetBalance, chainId, selectedGasFee, req }: BalanceCheckParams) => {
   const [isBalanceEnough, setIsBalanceEnough] = useState<boolean>(isMessageRequest);
 
   useEffect(() => {
@@ -28,19 +21,19 @@ export const useHasEnoughBalance = ({ isMessageRequest, walletBalance, chainId, 
     }
 
     const { gasFee } = selectedGasFee;
-    if (!walletBalance.isLoaded || !chainId || !gasFee?.estimatedFee) {
+    if (!nativeAssetBalance || !chainId || !gasFee?.estimatedFee) {
       return;
     }
 
     const txFeeAmount = fromWei(gasFee?.maxFee?.value?.amount ?? 0);
-    const balanceAmount = walletBalance.amount;
+    const balanceAmount = nativeAssetBalance?.balance?.amount || 0;
     const value = req?.value ?? 0;
 
     const totalAmount = new BigNumber(fromWei(value)).plus(txFeeAmount);
     const isEnough = greaterThanOrEqualTo(balanceAmount, totalAmount);
 
     setIsBalanceEnough(isEnough);
-  }, [isMessageRequest, chainId, selectedGasFee, walletBalance, req]);
+  }, [isMessageRequest, chainId, selectedGasFee, nativeAssetBalance, req]);
 
   return { isBalanceEnough };
 };

--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -104,8 +104,14 @@ export const SignTransactionSheet = () => {
   const addressToUse = specifiedAddress ?? accountAddress;
 
   const provider = getProvider({ chainId });
-  const nativeAsset =
-    ethereumUtils.getNetworkNativeAsset({ chainId }) ?? useBackendNetworksStore.getState().getChainsNativeAsset()[chainId];
+
+  // Native asset for dapp browser wallet selection vs global wallet
+  const nativeAsset = useMemo(() => {
+    return (
+      ethereumUtils.getNetworkNativeAsset({ chainId, address: addressToUse }) ??
+      useBackendNetworksStore.getState().getChainsNativeAsset()[chainId]
+    );
+  }, [chainId, addressToUse]);
 
   const isMessageRequest = isMessageDisplayType(transactionDetails.payload.method);
   const isPersonalSignRequest = isPersonalSign(transactionDetails.payload.method);

--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -164,15 +164,6 @@ export const SignTransactionSheet = () => {
         };
   }, [isMessageRequest, transactionDetails?.displayDetails?.request, nativeAsset]);
 
-  const walletBalance = useMemo(() => {
-    return {
-      amount: nativeAssetBalance?.balance?.amount || 0,
-      display: nativeAssetBalance?.balance?.display || `0 ${nativeAsset.symbol}`,
-      isLoaded: nativeAssetBalance?.balance?.display !== undefined || true,
-      symbol: nativeAsset.symbol || 'ETH',
-    };
-  }, [addressToUse, nativeAsset, nativeAssetBalance]);
-
   const { gasLimit, isValidGas, startPollingGasFees, stopPollingGasFees, updateTxFee, selectedGasFee, gasFeeParamsBySpeed } = useGas({
     enableTracking: true,
   });
@@ -188,7 +179,7 @@ export const SignTransactionSheet = () => {
 
   const { isBalanceEnough } = useHasEnoughBalance({
     isMessageRequest,
-    walletBalance,
+    nativeAssetBalance,
     chainId,
     selectedGasFee,
     req,
@@ -726,16 +717,19 @@ export const SignTransactionSheet = () => {
                         ) : (
                           <Box style={{ height: 9 }}>
                             <AnimatePresence>
-                              {!!chainId && walletBalance?.isLoaded && (
+                              {!!chainId && (nativeAssetBalance || nativeAsset) && (
                                 <MotiView animate={{ opacity: 1 }} from={{ opacity: 0 }} transition={{ opacity: motiTimingConfig }}>
                                   <Inline alignVertical="center" space={{ custom: 5 }} wrap={false}>
                                     <Bleed vertical="4px">
                                       <ChainImage chainId={chainId} size={12} position="relative" />
                                     </Bleed>
                                     <Text color="labelQuaternary" size="13pt" weight="semibold">
-                                      {`${walletBalance?.display} ${i18n.t(i18n.l.walletconnect.simulation.profile_section.on_network, {
-                                        network: useBackendNetworksStore.getState().getChainsName()[chainId],
-                                      })}`}
+                                      {`${nativeAssetBalance?.balance?.display || `0 ${nativeAsset.symbol}`} ${i18n.t(
+                                        i18n.l.walletconnect.simulation.profile_section.on_network,
+                                        {
+                                          network: useBackendNetworksStore.getState().getChainsName()[chainId],
+                                        }
+                                      )}`}
                                     </Text>
                                   </Inline>
                                 </MotiView>


### PR DESCRIPTION
Fixes APP-2715

## What changed (plus any additional context for devs)

- Enhanced `getNetworkNativeAsset` to accept an optional wallet address parameter, allowing it to fetch assets for specific wallets rather than just the global wallet
- Modified `getAccountAsset` to support retrieving assets from a specific wallet's cache
- Updated `SignTransactionSheet` to use the improved native asset fetching with the correct wallet address
- Added comments to explain the purpose and behavior of the asset retrieval functions (cached vs not-cached fetching)

## Screen Recording
https://github.com/user-attachments/assets/8fa24f59-c3fe-4604-b57c-23ab001d518c

## What to test

- Verify that the correct native asset is displayed when signing transactions from different wallets
- Confirm that wallet selection in the dapp browser correctly shows the native asset balance for the selected wallet
- Reproduction path: 1) Open the dapp browser and visit any dapp that requires a wallet connection. 2) In the browser’s control panel, switch to a wallet that is not the one currently active on the main WalletScreen. 3) Initiate a transaction from the dapp.