### PR TITLE
fixed missing padding under the wallet address in receive modal

### DIFF
--- a/src/screens/ReceiveModal.js
+++ b/src/screens/ReceiveModal.js
@@ -26,6 +26,7 @@ const AddressText = styled(TruncatedAddress).attrs(({ theme: { colors } }) => ({
   opacity: 0.6,
   size: 'large',
   weight: 'semibold',
+  paddingBottom: 24,
 }))({
   width: '100%',
 });


### PR DESCRIPTION
added missing padding under the wallet address in receive modal

<img width="485" height="961" alt="Screenshot 2025-09-03 at 16 29 59" src="https://github.com/user-attachments/assets/df9dfc90-6432-456b-b40e-514da2ab5b20" />
