### PR TITLE
fix: locale re-render upon language switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import '@/languages';
 import * as Sentry from '@sentry/react-native';
 import React, { memo, useCallback, useEffect, useState } from 'react';
-import { Provider as ReduxProvider, useSelector } from 'react-redux';
-import lang from 'i18n-js';
+import { Provider as ReduxProvider } from 'react-redux';
 import { AppRegistry, Dimensions, LogBox, StyleSheet, View } from 'react-native';
 import { Toaster } from 'sonner-native';
 import { MobileWalletProtocolProvider } from '@coinbase/mobile-wallet-protocol-host';
@@ -20,7 +19,7 @@ import { Playground } from '@/design-system/playground/Playground';
 import RainbowContextWrapper from '@/helpers/RainbowContext';
 import { Navigation } from '@/navigation';
 import { PersistQueryClientProvider, persistOptions, queryClient } from '@/react-query';
-import store, { AppState } from '@/redux/store';
+import store from '@/redux/store';
 import { MainThemeProvider } from '@/theme/ThemeContext';
 import { InitialRouteContext } from '@/navigation/initialRoute';
 import { NotificationsHandler } from '@/notifications/NotificationsHandler';
@@ -59,12 +58,6 @@ const sx = StyleSheet.create({
 
 function AppComponent() {
   const { initialRoute } = useApplicationSetup();
-  const language = useSelector((state: AppState) => state.settings.language);
-
-  // Update i18n locale when language changes
-  useEffect(() => {
-    lang.locale = language;
-  }, [language]);
 
   const handleNavigatorRef = useCallback((ref: NavigationContainerRef<RootStackParamList>) => {
     Navigation.setTopLevelNavigator(ref);

--- a/src/components/rainbow-toast/RainbowToast.tsx
+++ b/src/components/rainbow-toast/RainbowToast.tsx
@@ -18,7 +18,7 @@ import { useRainbowToasts, useRainbowToastsStore } from '@/components/rainbow-to
 import { Box, useColorMode, useForegroundColor } from '@/design-system';
 import { TransactionStatus } from '@/entities';
 import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
-import { useDimensions } from '@/hooks';
+import { useAccountSettings, useDimensions } from '@/hooks';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 import React, { memo, PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
@@ -40,12 +40,13 @@ import { useVerticalDismissPanGesture } from './useVerticalDismissPanGesture';
 
 export const RainbowToastDisplay = memo(function RainbowToastDisplay() {
   const rainbowToastsEnabled = useRainbowToastEnabled();
+  const { language } = useAccountSettings();
 
   if (!rainbowToastsEnabled) {
     return null;
   }
 
-  return <RainbowToastDisplayContent />;
+  return <RainbowToastDisplayContent key={language} />;
 });
 
 /**

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -611,6 +611,8 @@ function SwipeNavigatorScreens() {
   const showPointsTab = useExperimentalFlag(POINTS) || points_enabled || IS_TEST;
   const showKingOfTheHillTab = useShowKingOfTheHill();
 
+  const { language } = useAccountSettings();
+
   const getScreenOptions = useCallback(
     (props: { route: RouteProp<ParamListBase, string> }): MaterialTopTabNavigationOptions => {
       const isOnBrowserTab = props.route.name === Routes.DAPP_BROWSER_SCREEN;
@@ -627,8 +629,8 @@ function SwipeNavigatorScreens() {
 
   return (
     <Swipe.Navigator
-      // required to force re-render when showKingOfTheHillTab changes
-      key={`swipe-navigator-${showKingOfTheHillTab ? 'koth' : 'profile'}`}
+      // required to force re-render when showKingOfTheHillTab or language changes
+      key={`swipe-navigator-${showKingOfTheHillTab ? 'koth' : 'profile'}-${language}`}
       initialLayout={deviceUtils.dimensions}
       initialRouteName={Routes.WALLET_SCREEN}
       screenOptions={getScreenOptions}

--- a/src/screens/SettingsSheet/SettingsSheet.tsx
+++ b/src/screens/SettingsSheet/SettingsSheet.tsx
@@ -1,8 +1,6 @@
 import { createStackNavigator } from '@react-navigation/stack';
 import lang from 'i18n-js';
 import React, { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { AppState } from '@/redux/store';
 import ModalHeaderButton from '../../components/modal/ModalHeaderButton';
 import { useTheme } from '@/theme';
 import { BackgroundProvider } from '@/design-system';
@@ -18,13 +16,14 @@ import { settingsOptions } from '@/navigation/config';
 import ViewCloudBackups from './components/Backups/ViewCloudBackups';
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
 import Routes from '@/navigation/routesNames';
+import { useAccountSettings } from '@/hooks';
 
 const Stack = createStackNavigator();
 
 export function SettingsSheet() {
   const { goBack, navigate } = useNavigation();
   const { colors } = useTheme();
-  const language = useSelector((state: AppState) => state.settings.language);
+  const { language } = useAccountSettings();
 
   const sectionOnPressFactory = (section: (typeof SettingsPages)[keyof typeof SettingsPages]['key']) => () => {
     navigate(section);

--- a/src/screens/SettingsSheet/components/LanguageSection.tsx
+++ b/src/screens/SettingsSheet/components/LanguageSection.tsx
@@ -4,7 +4,6 @@ import Menu from './Menu';
 import MenuContainer from './MenuContainer';
 import MenuItem from './MenuItem';
 import { analytics } from '@/analytics';
-import { pickBy } from '@/helpers/utilities';
 import { useAccountSettings } from '@/hooks';
 
 const languageListItems = Object.keys(supportedLanguages)

--- a/src/screens/WalletScreen/WalletScreen.tsx
+++ b/src/screens/WalletScreen/WalletScreen.tsx
@@ -1,6 +1,4 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { AppState } from '@/redux/store';
 import { AssetList } from '../../components/asset-list';
 import { Page } from '../../components/layout';
 import { MobileWalletProtocolListener } from '@/components/MobileWalletProtocolListener';
@@ -69,7 +67,6 @@ function WalletScreen() {
   const accountAddress = useAccountAddress();
   const insets = useSafeAreaInsets();
   const route = useRoute();
-  const language = useSelector((state: AppState) => state.settings.language);
 
   const {
     isWalletEthZero,
@@ -130,7 +127,7 @@ function WalletScreen() {
 
   return (
     <PerformanceMeasureView interactive={!isLoadingUserAssets} screenName="WalletScreen">
-      <Box key={language} as={Page} flex={1} testID="wallet-screen" onLayout={handleWalletScreenMount} style={listContainerStyle}>
+      <Box as={Page} flex={1} testID="wallet-screen" onLayout={handleWalletScreenMount} style={listContainerStyle}>
         <AssetList
           accentColor={highContrastAccentColor}
           disableRefreshControl={disableRefreshControl}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Fixed language reactivity in components by adding language as a key prop on core screens (wallet, settings) to ensure re-rendering upon locale change
- Triggering `loadSettingsData` in `initializeApplication` to ensure the persisted language setting is available on first-render
- Adjusted locale ordering to match BX
- Removed the `SharedValuesProvider` and its context as it's no longer needed
- Added language key to components that need to re-render when language changes:
  - Added language key to `RainbowToastDisplay` component
  - Added language key to `SwipeNavigator` to force re-render on language change
  - Added language key to `SettingsSection` component

## Screen recording
https://github.com/user-attachments/assets/4dea515f-0cbf-40dc-84ff-3a78c73e633e



## What to test

- Change language in settings and verify that all translated strings re-render correctly
- Restart app and ensure that the language is persisted on first-render