### PR TITLE
Fix flash/scroll issue on market screen

### DIFF
--- a/src/features/perps/screens/perps-account-screen/PerpsAccountScreen.tsx
+++ b/src/features/perps/screens/perps-account-screen/PerpsAccountScreen.tsx
@@ -12,14 +12,11 @@ export const PerpsAccountScreen = function PerpsAccountScreen() {
 
   return (
     <ScrollView
-      style={{
-        backgroundColor: screenBackgroundColor,
-      }}
-      scrollIndicatorInsets={{
-        bottom: bottomInset,
-      }}
+      style={{ backgroundColor: screenBackgroundColor }}
+      contentContainerStyle={{ paddingTop: 8, paddingBottom: bottomInset, paddingHorizontal: 20 }}
+      scrollIndicatorInsets={{ bottom: bottomInset }}
     >
-      <Box paddingTop={{ custom: 8 }} paddingBottom={{ custom: bottomInset }} width="full" paddingHorizontal="20px" style={{ flex: 1 }}>
+      <Box width="full">
         <Stack space={'20px'}>
           <PerpsAccountBalanceCard />
           <Separator color={'separatorTertiary'} direction="horizontal" />

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -133,7 +133,11 @@ function PerpsAccountNavigator() {
           </Box>
           <PerpsNavbar />
 
-          <PerpsStack.Navigator screenOptions={{ lazy: true }} tabBar={() => null} initialRouteName={Routes.PERPS_ACCOUNT_SCREEN}>
+          <PerpsStack.Navigator
+            screenOptions={{ lazy: true, lazyPreloadDistance: 1 }}
+            tabBar={() => null}
+            initialRouteName={Routes.PERPS_ACCOUNT_SCREEN}
+          >
             <PerpsStack.Screen component={PerpsSearchScreen} name={Routes.PERPS_SEARCH_SCREEN} />
             <PerpsStack.Screen component={PerpsAccountScreen} name={Routes.PERPS_ACCOUNT_SCREEN} />
             <PerpsStack.Screen component={PerpsNewPositionSearchScreen} name={Routes.PERPS_NEW_POSITION_SEARCH_SCREEN} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -164,7 +164,7 @@ function PerpsAccountNavigator() {
           <PerpsNavbar />
 
           <PerpsStack.Navigator
-            screenOptions={{ lazy: true, swipeEnabled: false }}
+            screenOptions={{ lazy: true, lazyPreloadDistance: 1, swipeEnabled: false }}
             tabBar={() => null}
             initialRouteName={Routes.PERPS_ACCOUNT_SCREEN}
           >


### PR DESCRIPTION
Fixes APP-3089

## What changed (plus any additional context for devs)

- Added lazyPreloadDistance which causes the immediate neighbor screens next tab to mount in the background. In our Perps stack, that means the full markets list screen mounts while you’re on the account tab. It doesn’t render offscreen list items or prefetch data by itself. It simply mounts the screen component(s). Any fetching happens if the mounted screen subscribes to data (which in our case it does via the store).
- For the Scroll freeze on first load: Removed the inner flex constraint from the Perps account screen and moved padding to the ScrollView’s content container. This lets the content grow naturally so it scrolls the first time markets render.

## Screen recordings / screenshots


## What to test

