### PR TITLE
Different display for markets you have an open position for

### DIFF
--- a/src/features/perps/components/PerpMarketDisabledRow.tsx
+++ b/src/features/perps/components/PerpMarketDisabledRow.tsx
@@ -1,0 +1,25 @@
+import { Box, Text } from '@/design-system';
+import { HyperliquidTokenIcon } from '@/features/perps/components/HyperliquidTokenIcon';
+import { PerpMarket } from '@/features/perps/types';
+import * as i18n from '@/languages';
+import React from 'react';
+
+type PerpMarketDisabledRowProps = {
+  market: PerpMarket;
+};
+
+export const PerpMarketDisabledRow = function PerpMarketDisabledRow({ market }: PerpMarketDisabledRowProps) {
+  return (
+    <Box width="full" flexDirection="row" alignItems="center" gap={12} style={{ opacity: 0.3 }}>
+      <HyperliquidTokenIcon symbol={market.symbol} size={40} />
+      <Box style={{ flex: 1 }} gap={8}>
+        <Text size="17pt" weight="bold" color="label">
+          {market.symbol}
+        </Text>
+        <Text size="11pt" weight="heavy" color="label" uppercase>
+          {i18n.t(i18n.l.perps.markets.already_open)}
+        </Text>
+      </Box>
+    </Box>
+  );
+};

--- a/src/features/perps/components/PerpMarketsList.tsx
+++ b/src/features/perps/components/PerpMarketsList.tsx
@@ -1,10 +1,12 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { Box } from '@/design-system';
 import { LegendList } from '@legendapp/list';
 import { PerpMarketRow } from '@/features/perps/components/PerpMarketRow';
+import { PerpMarketDisabledRow } from '@/features/perps/components/PerpMarketDisabledRow';
 import { PerpMarket } from '@/features/perps/types';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { FOOTER_HEIGHT_WITH_SAFE_AREA } from '@/features/perps/constants';
+import { useHyperliquidAccountStore } from '@/features/perps/stores/hyperliquidAccountStore';
 
 type PerpMarketsListProps = {
   onPressMarket?: (market: PerpMarket) => void;
@@ -12,16 +14,22 @@ type PerpMarketsListProps = {
 
 export const PerpMarketsList = memo(function PerpMarketsList({ onPressMarket }: PerpMarketsListProps) {
   const markets = useHyperliquidMarketsStore(state => state.getSearchResults());
+  const positions = useHyperliquidAccountStore(state => state.positions);
 
-  const renderItem = useCallback(({ item }: { item: PerpMarket }) => {
-    return (
-      <Box paddingBottom={'24px'}>
-        <PerpMarketRow market={item} onPress={onPressMarket} />
-      </Box>
-    );
-  }, []);
+  const renderItem = useCallback(
+    ({ item }: { item: PerpMarket }) => {
+      return (
+        <Box paddingBottom={'24px'}>
+          {positions[item.symbol] ? <PerpMarketDisabledRow market={item} /> : <PerpMarketRow market={item} onPress={onPressMarket} />}
+        </Box>
+      );
+    },
+    [onPressMarket, positions]
+  );
 
   const keyExtractor = useCallback((item: PerpMarket) => item.symbol, []);
+
+  const extraData = useMemo(() => positions, [positions]);
 
   return (
     <LegendList
@@ -30,6 +38,7 @@ export const PerpMarketsList = memo(function PerpMarketsList({ onPressMarket }: 
       keyExtractor={keyExtractor}
       contentContainerStyle={{ paddingTop: 24, paddingHorizontal: 24, paddingBottom: FOOTER_HEIGHT_WITH_SAFE_AREA }}
       style={{ flex: 1 }}
+      extraData={extraData}
     />
   );
 });

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -277,7 +277,6 @@ export const PerpsNavigatorFooter = memo(function PerpsNavigatorFooter() {
         left="0px"
         right="0px"
         width="full"
-        height={110}
         shadow={'24px'}
         style={{
           shadowOffset: {
@@ -286,17 +285,12 @@ export const PerpsNavigatorFooter = memo(function PerpsNavigatorFooter() {
           },
           borderTopWidth: 2,
           borderTopColor: accentColors.opacity6,
-          paddingBottom: safeAreaInsets.bottom,
+          paddingBottom: Math.max(safeAreaInsets.bottom, 20),
+          paddingTop: 20,
           backgroundColor: isDarkMode ? accentColors.surfacePrimary : 'white',
         }}
       >
-        <Box
-          as={Animated.View}
-          entering={FadeIn.duration(150)}
-          exiting={FadeOut.duration(100)}
-          paddingHorizontal={'20px'}
-          paddingVertical={'20px'}
-        >
+        <Box as={Animated.View} entering={FadeIn.duration(150)} exiting={FadeOut.duration(100)} paddingHorizontal={'20px'}>
           {(effectiveRoute === Routes.PERPS_SEARCH_SCREEN || effectiveRoute === Routes.PERPS_NEW_POSITION_SEARCH_SCREEN) && (
             <PerpsSearchScreenFooter />
           )}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1570,6 +1570,9 @@
       }
     },
     "perps": {
+      "markets": {
+        "already_open": "Already Open"
+      },
       "deposit": {
         "title": "Deposit",
         "no_balance": "No Balance",


### PR DESCRIPTION
Fixes APP-3071

## What changed (plus any additional context for devs)

Add a new PerpMarketDisabledRow component to display markets where you already have an open position. Went with separate components instead of a bunch of conditionals in PerpMarketRow.

Also fixes the footer padding on Android with button nav. Since we were settings a height to the view that has the bottom safe area padding, it would result in incorrect layout when the inset is large, like when using button nav on android.

## Screen recordings / screenshots

Before:

<img width="392" height="891" alt="image" src="https://github.com/user-attachments/assets/7cf1fc13-5f02-4248-b66a-d2e8212b54d0" />

After:

<img width="390" height="868" alt="image" src="https://github.com/user-attachments/assets/35e561a5-5ce4-47c0-b959-61b3e17d63b0" />

<img width="390" height="890" alt="image" src="https://github.com/user-attachments/assets/f9acb23f-e71a-4180-8b1d-a05bde10e145" />


## What to test

