### PR TITLE
Fix perf tests baseline

### DIFF
--- a/scripts/e2e-android-perf-ci-report.sh
+++ b/scripts/e2e-android-perf-ci-report.sh
@@ -21,7 +21,7 @@ echo "📥 Looking for baseline artifact..."
 ARTIFACT_ID=$(gh api --paginate \
   -H "Accept: application/vnd.github.v3+json" \
   "/repos/${GITHUB_REPOSITORY}/actions/artifacts" \
-  -q '.artifacts | map(select(.name=="perf-results-e2e-baseline-test")) | sort_by(.updated_at) | reverse | .[0].id' | head -n1 || echo "")
+  -q '.artifacts | map(select(.name=="perf-results-develop")) | sort_by(.updated_at) | reverse | .[0].id' | head -n1 || echo "")
 
 if [[ -n "$ARTIFACT_ID" ]]; then
   echo "✅ Found baseline artifact with ID: $ARTIFACT_ID"


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

The name of the artifact should be `perf-results-develop`, the one that is currently there was the test branch I was using when working on the initial PR.

## Screen recordings / screenshots

N/A

## What to test

See that baseline now appears in the perf report.