### PR TITLE
Use commit hash instead of tags for github actions

### DIFF
--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -29,7 +29,7 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     - name: AVD cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       id: avd-cache
       with:
         path: |
@@ -39,7 +39,7 @@ runs:
 
     - name: Create AVD and Generate Snapshot for Caching
       if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed
       with:
         api-level: ${{ inputs.api-level }}
         target: google_apis_playstore

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Install secret tools
         run: sudo apt install libsecret-tools
@@ -64,7 +64,7 @@ jobs:
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Rock Remote Build - Android
         id: rock-remote-build-android
-        uses: callstackincubator/android@v3
+        uses: callstackincubator/android@8c2cb70c209cc7f832130b6e49bcbcaa7ad62613
         env:
           # This is a debug keystore for now.
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
@@ -137,7 +137,7 @@ jobs:
       ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup env key
         uses: ./.github/actions/ssh/
@@ -154,10 +154,10 @@ jobs:
           rm -rf rainbow-env
 
       - name: Install Maestro
-        run: export MAESTRO_VERSION=1.41.0; curl -fsSL "https://get.maestro.mobile.dev" | bash
+        run: export MAESTRO_VERSION=2.0.3; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
       - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
         with:
           version: stable
 
@@ -181,7 +181,7 @@ jobs:
           arch: ${{ env.ARCH }}
 
       - name: Run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed
         id: e2e_test
         with:
           api-level: ${{ env.ANDROID_EMULATOR_API_LEVEL }}
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: artifacts-${{ matrix.shard-index }}
           path: ${{ env.ARTIFACTS_FOLDER }}
@@ -216,7 +216,7 @@ jobs:
       ARTIFACTS_FOLDER: e2e-artifacts
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Download and Unpack APK artifact
         run: |
           curl -L -H "Authorization: token ${{ github.token }}" -o artifact.zip "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build.outputs.artifact-id }}/zip"
@@ -253,7 +253,7 @@ jobs:
           GITHUB_COMMIT: ${{ github.sha }}
 
       - name: Upload Current Perf JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: perf-results-${{ github.event.pull_request.number || github.ref_name }}
           path: ${{ env.ARTIFACTS_FOLDER }}/perf

--- a/.github/workflows/codeqml.yml
+++ b/.github/workflows/codeqml.yml
@@ -2,12 +2,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: ["develop"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "develop" ]
+    branches: ["develop"]
   schedule:
-    - cron: '42 14 * * 6' # Runs every Saturday at 14:42 UTC
+    - cron: "42 14 * * 6" # Runs every Saturday at 14:42 UTC
 
 jobs:
   analyze:
@@ -21,13 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -40,7 +40,6 @@ jobs:
 
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
@@ -59,4 +58,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-        

--- a/.github/workflows/comments-watchdog.yml
+++ b/.github/workflows/comments-watchdog.yml
@@ -24,7 +24,7 @@ jobs:
           # Fetch the list of users in the organization
           ORG_MEMBERS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
           "https://api.github.com/orgs/${{ github.repository_owner }}/members" | jq -r '.[].login')
-          
+
           # Save the allowlisted users in a file
           echo "$ORG_MEMBERS" > allowlisted_users.txt
 
@@ -35,7 +35,7 @@ jobs:
           COMMENT_ID=$(jq -r '.comment.id' < "$GITHUB_EVENT_PATH")
           COMMENT_BODY=$(jq -r '.comment.body' < "$GITHUB_EVENT_PATH")
           COMMENT_USER=$(jq -r '.comment.user.login' < "$GITHUB_EVENT_PATH")
-          
+
           # Check if the comment user is allowlisted
           if grep -q "$COMMENT_USER" allowlisted_users.txt; then
             echo "Comment by $COMMENT_USER is from an allowlisted user. No action taken."
@@ -48,7 +48,7 @@ jobs:
           # Check if the comment contains any spam patterns
           if echo "$COMMENT_BODY" | grep -iE "$SPAM_KEYWORDS"; then
             echo "Spam comment detected: $COMMENT_BODY"
-            
+
             # Delete the comment using the GitHub API
             curl -X DELETE \
               -H "Authorization: token $GITHUB_TOKEN" \
@@ -56,7 +56,7 @@ jobs:
               "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID" || \
               "https://api.github.com/repos/${{ github.repository }}/pulls/comments/$COMMENT_ID" || \
               "https://api.github.com/repos/${{ github.repository }}/discussions/comments/$COMMENT_ID"
-              
+
             echo "Spam comment deleted"
             # Log the deleted comment
             echo "Deleted comment from user $COMMENT_USER: $COMMENT_BODY" >> deleted_comments_log.txt
@@ -65,7 +65,7 @@ jobs:
           fi
 
       - name: Upload deleted comments log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: deleted-comments-log
           path: deleted_comments_log.txt

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -18,7 +18,7 @@ jobs:
       artifact-id: ${{ steps.rock-build-simulator.outputs.artifact-id }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Set Xcode version
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
@@ -61,7 +61,7 @@ jobs:
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Rock Build - iOS simulator
         id: rock-build-simulator
-        uses: callstackincubator/ios@v3
+        uses: callstackincubator/ios@0b4a5a6e4d6865d697bd5f277460088501982a5e
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
@@ -103,7 +103,7 @@ jobs:
       artifact-id: ${{ steps.rock-build-device.outputs.artifact-id }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Set Xcode version
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
@@ -152,7 +152,7 @@ jobs:
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -220,7 +220,7 @@ jobs:
 
       - name: Rock Build - iOS device
         id: rock-build-device
-        uses: callstackincubator/ios@v3
+        uses: callstackincubator/ios@0b4a5a6e4d6865d697bd5f277460088501982a5e
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -21,7 +21,7 @@ jobs:
       artifact-id: ${{ steps.rock-remote-build-ios.outputs.artifact-id }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Set Xcode version
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
@@ -65,7 +65,7 @@ jobs:
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Rock Remote Build - iOS simulator
         id: rock-remote-build-ios
-        uses: callstackincubator/ios@v3
+        uses: callstackincubator/ios@0b4a5a6e4d6865d697bd5f277460088501982a5e
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
@@ -114,7 +114,7 @@ jobs:
       ARTIFACTS_FOLDER: e2e-artifacts
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup env key
         uses: ./.github/actions/ssh/
@@ -131,10 +131,10 @@ jobs:
           rm -rf rainbow-env
 
       - name: Install Maestro
-        run: export MAESTRO_VERSION=1.41.0; curl -fsSL "https://get.maestro.mobile.dev" | bash
+        run: export MAESTRO_VERSION=2.0.3; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
       - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
         with:
           version: stable
 
@@ -148,7 +148,7 @@ jobs:
           APP_PATH=$(find downloaded-artifacts -name "*.app" -type d | head -n 1)
           echo "ARTIFACT_PATH_FOR_E2E=$APP_PATH" >> $GITHUB_ENV
 
-      - uses: futureware-tech/simulator-action@v4
+      - uses: futureware-tech/simulator-action@dab10d813144ef59b48d401cd95da151222ef8cd
         id: simulator
         with:
           model: "iPhone 16"
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: artifacts-${{ matrix.shard-index }}
           path: ${{ env.ARTIFACTS_FOLDER }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
@@ -20,4 +20,3 @@ jobs:
         uses: cirrus-actions/rebase@1.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,21 +2,20 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-    - cron: '30 20 * * 1' # Runs every Monday at 20:30 UTC
+    - cron: "30 20 * * 1" # Runs every Monday at 20:30 UTC
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
     permissions:
       issues: write
 
     steps:
       - name: Mark stale issues
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'
-          stale-issue-label: 'stale'
-          days-before-stale: 30  
-          days-before-close: 7  
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          stale-issue-label: "stale"
+          days-before-stale: 30
+          days-before-close: 7

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Install secret tools
         run: sudo apt install libsecret-tools
@@ -35,25 +35,25 @@ jobs:
 
       - name: Setup env
         env:
-            SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
+          SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
         run: |
-            git clone git@github.com:rainbow-me/rainbow-env.git
-            mv rainbow-env/dotenv .env
-            mv rainbow-env/android/app/google-services.json android/app/google-services.json
-            rm -rf rainbow-env
-            sed -i "s/IS_TESTING=false/IS_TESTING=true/" .env
+          git clone git@github.com:rainbow-me/rainbow-env.git
+          mv rainbow-env/dotenv .env
+          mv rainbow-env/android/app/google-services.json android/app/google-services.json
+          rm -rf rainbow-env
+          sed -i "s/IS_TESTING=false/IS_TESTING=true/" .env
       - name: Setup scripts
         env:
-            CI_SCRIPTS: ${{ secrets.CI_SCRIPTS }}
-            SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
+          CI_SCRIPTS: ${{ secrets.CI_SCRIPTS }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
         run: |
-            eval $CI_SCRIPTS
+          eval $CI_SCRIPTS
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Cache Yarn dependencies
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -83,4 +83,3 @@ jobs:
 
       - name: Unit tests
         run: yarn test
-


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

github actions that we use are currently using tags, which is not super secure since every run the latest version will be downloaded. Tags can also be deleted and republished. Using commit hash instead is safer.

## Screen recordings / screenshots

N/A

## What to test

CI passes
