### PR TITLE
Visual indicators for token balance liquidity capping

### DIFF
--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastBalanceCoinRow.tsx
@@ -14,7 +14,7 @@ import { ChainId } from '@/state/backendNetworks/types';
 import { Navigation } from '@/navigation';
 import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
 import { toSignificantDigits } from '@/helpers/utilities';
-import { getBalance, TokenData } from '@/state/liveTokens/liveTokensStore';
+import { getLiquidityCappedBalance, TokenData } from '@/state/liveTokens/liveTokensStore';
 
 interface CoinCheckButtonProps {
   isHidden: boolean;
@@ -98,9 +98,10 @@ const MemoizedBalanceCoinRow = React.memo(
 
     const tokenBalanceSelector = useCallback(
       (token: TokenData) => {
-        return getBalance({ token, balanceAmount: tokenBalanceAmount, nativeCurrency });
+        const { balance, isCapped } = getLiquidityCappedBalance({ token, balanceAmount: tokenBalanceAmount, nativeCurrency });
+        return `${isCapped ? '~' : ''}${balance}`;
       },
-      [tokenBalanceAmount, nativeCurrency]
+      [nativeCurrency, tokenBalanceAmount]
     );
 
     return (

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -716,6 +716,10 @@
         "uniswap_liquidity": "Uniswap liquidity",
         "value": "Value",
         "volume_24_hours": "24h volume",
+        "liquidity_cap_disclaimer": {
+          "value_lower_than": "Value is lower than",
+          "due_to_low_liquidity": "due to low liquidity"
+        },
         "menu": {
           "view_on": "View on %{blockExplorerName}",
           "share": "Share",

--- a/src/screens/WalletScreen/WalletScreen.tsx
+++ b/src/screens/WalletScreen/WalletScreen.tsx
@@ -16,7 +16,7 @@ import Routes from '@/navigation/Routes';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
 import { useNavigationStore } from '@/state/navigation/navigationStore';
 import { CellTypes } from '@/components/asset-list/RecyclerAssetList2/core/ViewTypes';
-import { addSubscribedTokens, removeSubscribedTokens } from '@/state/liveTokens/liveTokensStore';
+import { addSubscribedTokens, removeSubscribedTokens, useLiveTokensStore } from '@/state/liveTokens/liveTokensStore';
 import { debounce } from 'lodash';
 import { useRoute } from '@react-navigation/native';
 import { RemoteCardsSync } from '@/state/sync/RemoteCardsSync';
@@ -100,6 +100,10 @@ function WalletScreen() {
       const viewableTokenUniqueIds = extractTokenRowIds(viewableItems);
       if (viewableTokenUniqueIds.length > 0) {
         addSubscribedTokens({ route: routeName, tokenIds: viewableTokenUniqueIds });
+        // Immediately force a fetch of the newly added tokens
+        useLiveTokensStore.getState().fetch(undefined, {
+          force: true,
+        });
       }
     }, 250)
   );

--- a/src/screens/expandedAssetSheet/components/sections/BalanceSection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/BalanceSection.tsx
@@ -119,7 +119,7 @@ export function BalanceSection() {
               </Text>
             </TextShadow>
             <AnimatedNumber
-              value={balanceDisplayValue.value}
+              value={balanceDisplayValue}
               easingMaskColor={backgroundColor}
               color="label"
               numberOfLines={1}


### PR DESCRIPTION
Fixes APP-3038

## What changed (plus any additional context for devs)
- Added "~" to any balance value on the wallet screen that is capped due to low liquidity 
- Added disclaimer below balance section on expanded state stating the uncapped value
- Slightly related fixes
    - Fixed issue with live token subscriptions on wallet screen being removed immediately on mount. 
    - Force live token refetch immediately after adding token subscriptions from wallet list

## Screen recordings / screenshots

https://github.com/user-attachments/assets/9a1d5cd2-0149-44ce-b447-19c5a25d0fde



## What to test

