### PR TITLE
Fix bottom sheet issue for change wallet for Android

### DIFF
--- a/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
+++ b/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
@@ -5,6 +5,7 @@ import { isKeyboardOpen } from '../../../helpers';
 import { CONTAINER_HEIGHT, DEFAULT_BACKDROP_COLOR, DEFAULT_BACKDROP_OPACITY, DEFAULT_HEIGHT } from '../constants';
 import { BottomSheetNavigatorContext } from '../contexts/internal';
 import type { BottomSheetDescriptor } from '../types';
+import { IS_ANDROID } from '@/env';
 
 interface Props {
   routeKey: string;
@@ -14,7 +15,6 @@ interface Props {
 }
 
 const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation }, onDismiss, removing = false }: Props) => {
-  // #region extract options
   const {
     enableContentPanningGesture,
     enableHandlePanningGesture,
@@ -25,20 +25,14 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
     backdropOpacity = DEFAULT_BACKDROP_OPACITY,
     backdropPressBehavior = 'close',
     height = DEFAULT_HEIGHT,
-    offsetY = android ? 20 : 3,
+    offsetY = IS_ANDROID ? 20 : 3,
   } = options || {};
-  // #endregion
 
-  // #region refs
   const ref = useRef<BottomSheet>(null);
 
   const removingRef = useRef(false);
   removingRef.current = removing;
 
-  // const
-  // #endregion
-
-  // #region styles
   // @ts-ignore type mismatch
   const screenContainerStyle: ViewStyle = useMemo(
     () => ({
@@ -56,9 +50,7 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
     }),
     [backdropColor]
   );
-  // #endregion
 
-  // #region context methods
   const handleSettingSnapPoints = useCallback(
     (_snapPoints: (string | number)[]) => {
       navigation.setOptions({ snapPoints: _snapPoints });
@@ -105,20 +97,16 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
       handleSettingSnapPoints,
     ]
   );
-  // #endregion
 
-  // #region callbacks
   const handleOnClose = useCallback(() => {
     onDismiss(routeKey, removingRef.current);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  // #endregion
 
-  // #region effects
   useEffect(() => {
     if (removing === true && ref.current) {
       // close keyboard before closing the modal
-      if (isKeyboardOpen() && android) {
+      if (isKeyboardOpen() && IS_ANDROID) {
         Keyboard.dismiss();
 
         ref.current.close();
@@ -127,9 +115,7 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
       }
     }
   }, [removing]);
-  // #endregion
 
-  // #region renders
   const renderBackdropComponent = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -550,13 +550,11 @@ export default function ChangeWalletSheet() {
 
       // Wait for snap point to be committed before showing
       if (!isLayoutMeasured) {
-        // Using double requestAnimationFrame to give Reanimated 2 frames to commit the snapPoint change before
+        // Using 32 ms to give Reanimated 2 frames to commit the snapPoint change before
         // making the sheet visible. This should ensure it's already settled at the correct height when it appears.
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            setIsLayoutMeasured(true);
-          });
-        });
+        setTimeout(() => {
+          setIsLayoutMeasured(true);
+        }, 32);
       }
     },
     [navigation, isLayoutMeasured]

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -545,7 +545,7 @@ export default function ChangeWalletSheet() {
       if (!IS_ANDROID) return;
       const { height } = event.nativeEvent.layout;
 
-      // @ts-ignore
+      // @ts-expect-error Bottom sheet options is not typed
       navigation.setOptions({ snapPoints: [height + PANEL_BOTTOM_OFFSET] });
 
       // Wait for snap point to be committed before showing

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -8,7 +8,7 @@ import { FeatureHintTooltip, TooltipRef } from '@/components/tooltips/FeatureHin
 import { NOTIFICATIONS, useExperimentalFlag } from '@/config';
 import { Box, globalColors, HitSlop, Inline, Text } from '@/design-system';
 import { EthereumAddress } from '@/entities';
-import { IS_IOS } from '@/env';
+import { IS_ANDROID, IS_IOS } from '@/env';
 import { removeWalletData } from '@/handlers/localstorage/removeWallet';
 import { isValidHex } from '@/handlers/web3';
 import WalletTypes from '@/helpers/walletTypes';
@@ -43,7 +43,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import ConditionalWrap from 'conditional-wrap';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, InteractionManager } from 'react-native';
+import { Alert, InteractionManager, LayoutChangeEvent } from 'react-native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { Address } from 'viem';
 import { updateWebProfile } from '@/helpers/webData';
@@ -108,6 +108,7 @@ export default function ChangeWalletSheet() {
   const featureHintTooltipRef = useRef<TooltipRef>(null);
 
   const [editMode, setEditMode] = useState(false);
+  const [isLayoutMeasured, setIsLayoutMeasured] = useState(IS_IOS);
 
   const setPinnedAddresses = usePinnedWalletsStore(state => state.setPinnedAddresses);
 
@@ -537,6 +538,30 @@ export default function ChangeWalletSheet() {
     [walletsByAddress, onPressEdit, onPressNotifications, onPressRemove, onPressCopyAddress, onPressWalletSettings]
   );
 
+  const navigation = useNavigation();
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (!IS_ANDROID) return;
+      const { height } = event.nativeEvent.layout;
+
+      // @ts-ignore
+      navigation.setOptions({ snapPoints: [height + PANEL_BOTTOM_OFFSET] });
+
+      // Wait for snap point to be committed before showing
+      if (!isLayoutMeasured) {
+        // Using double requestAnimationFrame to give Reanimated 2 frames to commit the snapPoint change before
+        // making the sheet visible. This should ensure it's already settled at the correct height when it appears.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            setIsLayoutMeasured(true);
+          });
+        });
+      }
+    },
+    [navigation, isLayoutMeasured]
+  );
+
   return (
     <>
       <Box
@@ -548,11 +573,12 @@ export default function ChangeWalletSheet() {
             pointerEvents: 'box-none',
             position: 'absolute',
             zIndex: 30000,
+            opacity: isLayoutMeasured ? 1 : 0,
           },
         ]}
       >
         <Panel>
-          <Box style={{ maxHeight: MAX_PANEL_HEIGHT, paddingHorizontal: PANEL_INSET_HORIZONTAL }}>
+          <Box onLayout={handleLayout} style={{ maxHeight: MAX_PANEL_HEIGHT, paddingHorizontal: PANEL_INSET_HORIZONTAL }}>
             <SheetHandleFixedToTop />
             <Box
               style={{ position: 'relative' }}


### PR DESCRIPTION
Fixes APP-3135

## What changed (plus any additional context for devs)

The issue was caused by the snap points being set to 100%. This made the sheet occupy the full screen, so when dragging a smaller sheet (around 30% of the screen), it wasn’t enough to trigger handleClose from Gorhom.

I also added an isLayoutMeasured check since there was a flicker on the first render.

## Screen recordings / screenshots


## What to test

