### PR TITLE
fix: broad internal network filtering

### DIFF
--- a/src/state/backendNetworks/utils.ts
+++ b/src/state/backendNetworks/utils.ts
@@ -44,5 +44,9 @@ export function transformBackendNetworksToChains(networks?: BackendNetwork[]): C
   if (!networks) {
     return [];
   }
-  return networks.filter(network => IS_DEV || !network.internal).map(network => transformBackendNetworkToChain(network));
+  return networks.map(network => transformBackendNetworkToChain(network));
+}
+
+export function filterSupportedNetworks(networks: BackendNetwork[]): BackendNetwork[] {
+  return networks.filter(network => IS_DEV || !network.internal);
 }


### PR DESCRIPTION
Fixes APP-3141

## What changed (plus any additional context for devs)
- fixed `network.enabledServices` filters in getters like `getSupportedPositionsChainIds` to avoid under-filtering in prod (we were passing through ALL networks that had enabled services, not just services enabled for our list of supported networks)
- mirrored `backendNetworks` and `backendChains` as array type, rather than passing `BackendNetworksResponse` type to state and requiring `networks.networks` accessors
- upgraded state version to `1` from `0` to migrate state data
- added `filterSupportedNetworks` helper to consolidate network filtering

## Screen recordings / screenshots


## What to test

