### PR TITLE
Make browser tab preview cleanup more robust

### DIFF
--- a/src/components/DappBrowser/DappBrowser.tsx
+++ b/src/components/DappBrowser/DappBrowser.tsx
@@ -13,7 +13,6 @@ import { RootStackParamList } from '@/navigation/types';
 import { useBrowserStore } from '@/state/browser/browserStore';
 import { useBrowserHistoryStore } from '@/state/browserHistory';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
-import { time } from '@/utils';
 import { generateUniqueId } from '@/worklets/strings';
 import { BrowserContextProvider, useBrowserContext } from './BrowserContext';
 import { BrowserTab } from './BrowserTab';
@@ -29,7 +28,7 @@ import {
 } from './constants';
 import { useBrowserScrollView } from './hooks/useBrowserScrollView';
 import { useScreenshotAndScrollTriggers } from './hooks/useScreenshotAndScrollTriggers';
-import { pruneScreenshots } from './screenshots';
+import { schedulePruneScreenshots } from './screenshots';
 import { Search } from './search/Search';
 import { SearchContextProvider } from './search/SearchContext';
 import { AnimatedTabUrls, TabViewGestureStates } from './types';
@@ -100,19 +99,9 @@ function setNewTabUrl(updatedTabUrls: AnimatedTabUrls, newActiveIndex: number | 
   setParams<typeof Routes.DAPP_BROWSER_SCREEN>({ url: undefined });
 }
 
-function useScreenshotPruner() {
+function useScreenshotPruner(): void {
   useEffect(() => {
-    let idleCallbackId: number;
-    const timeoutId = setTimeout(() => {
-      idleCallbackId = requestIdleCallback(() => {
-        pruneScreenshots(useBrowserStore.getState().tabsData);
-      });
-    }, time.seconds(10));
-
-    return () => {
-      clearTimeout(timeoutId);
-      if (typeof idleCallbackId === 'number') cancelIdleCallback(idleCallbackId);
-    };
+    return schedulePruneScreenshots(useBrowserStore.getState().tabsData);
   }, []);
 }
 


### PR DESCRIPTION
Fixes APP-3142

## What changed (plus any additional context for devs)
- Ensures proper cleanup of cached browser tab previews from local device storage. There were a few ways for the registry to lose track of cached images to delete.
- Now using a queue to prevent conflicts between save and prune operations.
- Also added a periodic deep prune to be safe, though the queue likely addresses the original root problem.

## Screen recordings / screenshots


## What to test

