### PR TITLE
Fix missing KOTH header when top token has no coin icon

### DIFF
--- a/src/components/coin-icon/ShinyCoinIcon.tsx
+++ b/src/components/coin-icon/ShinyCoinIcon.tsx
@@ -19,7 +19,7 @@ import { opacity } from '@/__swaps__/utils/swaps';
 type ShinyCoinIconProps = {
   chainId: ChainId;
   color: string | undefined;
-  imageUrl: string;
+  imageUrl: string | undefined;
   symbol: string;
   size?: number;
   disableShadow?: boolean;

--- a/src/components/king-of-the-hill/KingOfTheHillHeader.tsx
+++ b/src/components/king-of-the-hill/KingOfTheHillHeader.tsx
@@ -89,9 +89,7 @@ export const KingOfTheHillHeader = memo(function KingOfTheHillHeader({ kingOfThe
     return () => clearInterval(interval);
   }, []);
 
-  if (!current || !sizedIconUrl || !currentWinningToken) {
-    return null;
-  }
+  if (!current || !currentWinningToken) return null;
 
   const hours = Math.floor(secondsRemaining / SECONDS_PER_HOUR);
   const minutes = Math.floor((secondsRemaining % SECONDS_PER_HOUR) / 60);


### PR DESCRIPTION
Fixes DES-33

## What changed (plus any additional context for devs)
- The KOTH header was being hidden when the top token had no coin icon — this ensures the header always shows and uses the placeholder coin icon if there's no image.

## Screen recordings / screenshots


## What to test

