### PR TITLE
chore(logger): remove unused Sentry Severity from mock

### DIFF
--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -8,12 +8,6 @@ jest.mock('@sentry/react-native', () => ({
   addBreadcrumb: jest.fn(),
   captureException: jest.fn(),
   captureMessage: jest.fn(),
-  Severity: {
-    Debug: 'debug',
-    Info: 'info',
-    Warning: 'warning',
-    Error: 'error',
-  },
 }));
 
 describe('general functionality', () => {


### PR DESCRIPTION
- Remove dead Severity object from @sentry/react-native mock in src/logger/__tests__/logger.test.ts.
- Codebase relies on string SeverityLevel values; no references to Sentry.Severity.
- Aligns tests with current implementation and reduces noise; no functional changes.