### PR TITLE
Fix keyboard height on import wallet screen

### DIFF
--- a/src/navigation/AddWalletNavigator.tsx
+++ b/src/navigation/AddWalletNavigator.tsx
@@ -8,6 +8,7 @@ import { ImportOrWatchWalletSheet } from '@/screens/ImportOrWatchWalletSheet';
 import { BackgroundProvider } from '@/design-system';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
+import { setActiveRoute } from '@/state/navigation/navigationStore';
 import { RootStackParamList } from './types';
 
 const Swipe = createMaterialTopTabNavigator();
@@ -35,6 +36,7 @@ export const AddWalletNavigator = () => {
               name={Routes.ADD_WALLET_SHEET}
               listeners={{
                 focus: () => {
+                  setActiveRoute(Routes.ADD_WALLET_SHEET);
                   setScrollEnabled(true);
                 },
               }}
@@ -45,6 +47,7 @@ export const AddWalletNavigator = () => {
               name={Routes.CHOOSE_WALLET_GROUP}
               listeners={{
                 focus: () => {
+                  setActiveRoute(Routes.CHOOSE_WALLET_GROUP);
                   setScrollEnabled(true);
                 },
               }}
@@ -55,6 +58,7 @@ export const AddWalletNavigator = () => {
               name={Routes.IMPORT_OR_WATCH_WALLET_SHEET}
               listeners={{
                 focus: () => {
+                  setActiveRoute(Routes.IMPORT_OR_WATCH_WALLET_SHEET);
                   setScrollEnabled(false);
                 },
               }}


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

`useKeyboardHeight` relies on `activeRoute` being set properly, otherwise it skips updates. The problem is that when using nested swipe navigators the `activeRoute` is not updated. This updates it manually when screens are focused.

## Screen recordings / screenshots

Before:

<img width="391" height="864" alt="image" src="https://github.com/user-attachments/assets/49b12db2-5293-41aa-999c-e98e1e145d10" />

After:

<img width="391" height="863" alt="image" src="https://github.com/user-attachments/assets/383e24c3-a3f7-4c35-b4cd-d470d50a9ce9" />

## What to test

Fresh app install on android and import wallet.