### PR TITLE
fix(strings): guard containsEmoji against non-string input

### DIFF
--- a/src/helpers/__tests__/utilities.test.ts
+++ b/src/helpers/__tests__/utilities.test.ts
@@ -5,6 +5,7 @@ import {
   handleSignificantDecimals,
   updatePrecisionToDisplay,
 } from '../utilities';
+import { containsEmoji } from '../strings';
 
 it('convertAmountFromNativeValue', () => {
   const result = convertAmountFromNativeValue('1', '40.00505', 5);
@@ -64,6 +65,10 @@ it('convertBipsToPercentage, returns 0 when given nullish value', () => {
 it('convertBipsToPercentage', () => {
   const result = convertBipsToPercentage('12.34567', 2);
   expect(result).toBe('0.12');
+});
+
+it('containsEmoji handles non-string inputs', () => {
+  expect(containsEmoji(undefined as never)).toBe(false);
 });
 
 it('updatePrecisionToDisplay1', () => {

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -12,8 +12,8 @@ import { getNumberFormatter } from '@/helpers/intl';
  * @return {String}
  */
 export const containsEmoji = memoFn(str => {
+  if (typeof str !== 'string') return false;
   const ranges = ['(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])'];
-  // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.
   return !!str.match(ranges.join('|'));
 });
 


### PR DESCRIPTION
**Motivation**

> `containsEmoji` would throw when passed non-string values, which can bubble up from user-provided data.

**Solution**

> Add a simple type guard to `containsEmoji` so it safely returns `false` for non-strings and document the behavior with a unit test to prevent regressions.

**Safety & Compatibility**

> No APIs or behaviors change aside from avoiding a runtime crash; no dependencies or configs touched.