### PR TITLE
Add rainbow hyperliquid referral code 

### DIFF
--- a/src/features/perps/constants.ts
+++ b/src/features/perps/constants.ts
@@ -16,6 +16,7 @@ export const RAINBOW_BUILDER_SETTINGS = {
   b: '0x60dC8E3dAd2e4E0738e813B9cB09b9c00B5e0Fc9',
   f: 50,
 } as const satisfies HlBuilderSettings;
+export const RAINBOW_REFERRAL_CODE = 'RNBW';
 export const HYPERCORE_PSEUDO_CHAIN_ID = 1337;
 export const HYPERLIQUID_TOKEN_ID_SUFFIX = 'hl';
 export const SPOT_ASSET_ID_OFFSET = 10_000;

--- a/src/features/perps/services/hyperliquid-account-client.ts
+++ b/src/features/perps/services/hyperliquid-account-client.ts
@@ -113,4 +113,11 @@ export class HyperliquidAccountClient {
     });
     return approvedBuilderFee >= RAINBOW_BUILDER_SETTINGS.f;
   }
+
+  async isReferralCodeSet(): Promise<boolean> {
+    const referral = await infoClient.referral({
+      user: this.userAddress,
+    });
+    return referral.referredBy !== null;
+  }
 }


### PR DESCRIPTION
Fixes APP-3162

## What changed (plus any additional context for devs)
- Added setting the RNBW referral code for the user if none is already set. Check and set occurs in same places as builder fee approval. 

## Screen recordings / screenshots


## What to test

