### PR TITLE
Fix network selector edit button

### DIFF
--- a/src/screens/network-selector/NetworkSelector.tsx
+++ b/src/screens/network-selector/NetworkSelector.tsx
@@ -1189,6 +1189,7 @@ const sx = StyleSheet.create({
     height: HEADER_HEIGHT,
     paddingTop: 20,
     width: '100%',
+    zIndex: 1,
   },
   headerContent: {
     alignItems: 'center',


### PR DESCRIPTION
Fixes APP-3171

## What changed (plus any additional context for devs)
- Fixes the network selector view hierarchy so the header isn't placed beneath other layers — was preventing touch events from reaching the button
- Likely introduced here: https://github.com/rainbow-me/rainbow/commit/6ae89a4b3052a8e186cf1679aab055c1b7591c8c#diff-1bc774c8c2f5e3fe74b4818fbef6d46140e5bd28b964b7b08c539f4c3f43bdd2

## Screen recordings / screenshots


## What to test

