### PR TITLE
Fix incorrect navigation when no new position is created

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -319,6 +319,7 @@ export const event = {
 
   // perps
   perpsOpenedPosition: 'perps.opened_position',
+  perpsOpenPositionCanceled: 'perps.open_position.canceled',
   perpsOpenPositionFailed: 'perps.open_position.failed',
   perpsClosedPosition: 'perps.closed_position',
   perpsClosePositionFailed: 'perps.close_position.failed',
@@ -1163,6 +1164,12 @@ export type EventProperties = {
       type: TriggerOrderType;
       price: number;
     }>;
+  };
+  [event.perpsOpenPositionCanceled]: {
+    market: string;
+    side: PerpPositionSide;
+    leverage?: number;
+    perpsBalance: number;
   };
   [event.perpsOpenPositionFailed]: {
     market: string;

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -227,7 +227,15 @@ const PerpsNewPositionScreenFooter = memo(function PerpsNewPositionScreenFooter(
         triggerOrders,
       });
 
-      if (!newPosition) return;
+      if (!newPosition) {
+        analytics.track(analytics.event.perpsOpenPositionCanceled, {
+          market: market.symbol,
+          side: positionSide,
+          leverage,
+          perpsBalance: Number(useHyperliquidAccountStore.getState().getValue()),
+        });
+        return;
+      }
 
       const positionValue = Number(amount) * leverage;
       const positionSize = positionValue / Number(entryPrice);


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

If wallet fails to load because user cancels faceid then we still proceed with navigation back as if the position was created. This adds a check to make sure a position was actually created, if it is cancelled newPosition will be undefined.

## Screen recordings / screenshots

Before:

https://github.com/user-attachments/assets/b381afc8-2de3-4b6f-8c9e-b97058afc5d9

After:

https://github.com/user-attachments/assets/b434037b-0278-4021-a558-0aa80c05458b

## What to test

Open a new position and cancel face id.
