### PR TITLE
Fix invalid wallet state after system backup restore

### DIFF
--- a/src/hooks/useApplicationSetup.ts
+++ b/src/hooks/useApplicationSetup.ts
@@ -7,6 +7,8 @@ import Routes from '@/navigation/routesNames';
 import { saveFCMToken } from '@/notifications/tokens';
 import { PerformanceReports, PerformanceTracking } from '@/performance/tracking';
 import { initListeners as initWalletConnectListeners, initWalletConnectPushNotifications } from '@/walletConnect';
+import { addressKey } from '@/utils/keychainConstants';
+import * as kc from '@/keychain';
 
 export function useApplicationSetup() {
   const [initialRoute, setInitialRoute] = useState<InitialRoute>(null);
@@ -19,6 +21,7 @@ export function useApplicationSetup() {
 }
 
 async function runSetup(setInitialRoute: Dispatch<SetStateAction<InitialRoute>>): Promise<void> {
+  await kc.validateCacheIntegrity(addressKey);
   const address = await loadAddress();
 
   Promise.all([initWalletConnectListeners(), saveFCMToken()]).then(() => {


### PR DESCRIPTION
Fixes APP-3221

## What changed (plus any additional context for devs)

After restoring from a system icloud backup on a new device the app stays in a logged in state, though it would no longer be able to access wallet secrets due to DEVICE_ONLY restrictions on the keychain. We cache public keychain data in react-native-mmkv, which gets transferred during backups, but the data in the underlying keychain is not, which means we get in a state where we have the wallet public data and start the app in a logged in state, but we don't actually have any of the private data.

This checks on app start if keychain data is in the cache, but not in the keychain, and wipe the cache if this is the case.

## Screen recordings / screenshots


## What to test

- Reset an iOS device
- On another device have rainbow installed and import a wallet
- With the reset device, restore from device with rainbow installed
- Once restore is complete, open the app

Before this change the app will be in a logged in state, but seed cannot be accessed. After this change the app starts on the create / import wallet screen.
