### PR TITLE
Bump iOS and Android to v2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Testing
 
+## [2.0.9] (https://github.com/rainbow-me/rainbow/releases/tag/v2.0.9)
+
+### Added
+
+- Expanded Positions support for Defi protocols (#6885)
+
+### Fixed
+
+- Fixed webview provider injection on old Android versions
+- Fixed keyboard issue with iOS 26 in send form (#6903)
+- Fixed incorrect navigation when new perp creation is dismissed (#6902)
+- Fixed Android keyboard height on import wallet screen (#6890)
+
+### Internal
+
+- Defi positions migration to ListPositions endpoint (#6885)
+
 ## [2.0.8] (https://github.com/rainbow-me/rainbow/releases/tag/v2.0.8)
 
 ### Added
@@ -36,9 +53,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Fixed
 
-- Fixed keyboard issue with ios 26 in send form (#6903)
-- Fixed incorrect navigation when no new position is created (#6902)
-- Fixed keyboard height on import wallet screen (#6890)
 - Fixed network selector edit button (#6901)
 - Various perps fixes (#6888)
 - Fixed broad internal network filtering (#6877)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -157,8 +157,8 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 281
-        versionName "2.0.9"
+        versionCode 282
+        versionName "2.0.10"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
         renderscriptSupportModeEnabled true

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1923,7 +1923,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1990,7 +1990,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2109,7 +2109,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2227,7 +2227,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "2.0.9-1",
+  "version": "2.0.10-1",
   "private": true,
   "scripts": {
     "setup": "yarn graphql-codegen:install && yarn ds:install && yarn allow-scripts && yarn graphql-codegen && yarn fetch:networks",


### PR DESCRIPTION
## Summary
- Updated CHANGELOG.md with 2.0.9 release notes
- Bumped version to 2.0.10 across iOS, Android, and package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)