### PR TITLE
Bump swaps sdk version to v0.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@notifee/react-native": "7.8.2",
     "@rainbow-me/provider": "0.1.2",
     "@rainbow-me/react-native-animated-number": "0.0.2",
-    "@rainbow-me/swaps": "0.36.0",
+    "@rainbow-me/swaps": "0.38.0",
     "@rainbow-me/token-launcher": "0.2.0",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-camera-roll/camera-roll": "7.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,9 +5464,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rainbow-me/swaps@npm:0.36.0":
-  version: 0.36.0
-  resolution: "@rainbow-me/swaps@npm:0.36.0"
+"@rainbow-me/swaps@npm:0.38.0":
+  version: 0.38.0
+  resolution: "@rainbow-me/swaps@npm:0.38.0"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@ethersproject/abi": "npm:5.7.0"
@@ -5481,7 +5481,7 @@ __metadata:
     "@ethersproject/transactions": "npm:5.7.0"
     "@ethersproject/wallet": "npm:5.7.0"
     "@metamask/eth-sig-util": "npm:7.0.0"
-  checksum: 10c0/f5cd4ae1d73ec1434a534df5ccaa9e7861c6b8a69460df507157698ab76b3e9c07876e9e9d3be10ad52e8b08f444ae6e06d5dfe32dccd85d2ccb1f9ab0a60e6f
+  checksum: 10c0/d41a5a2ea4e64d47d5c439e22ea07a7b716c470a8702e5705e3a484fa974ed09cfd4dc49823f917847ab2bd8b399490b10ba908bacd11e9134d72ce56ccaeca6
   languageName: node
   linkType: hard
 
@@ -9119,7 +9119,7 @@ __metadata:
     "@notifee/react-native": "npm:7.8.2"
     "@rainbow-me/provider": "npm:0.1.2"
     "@rainbow-me/react-native-animated-number": "npm:0.0.2"
-    "@rainbow-me/swaps": "npm:0.36.0"
+    "@rainbow-me/swaps": "npm:0.38.0"
     "@rainbow-me/token-launcher": "npm:0.2.0"
     "@react-native-async-storage/async-storage": "npm:1.23.1"
     "@react-native-camera-roll/camera-roll": "npm:7.10.0"


### PR DESCRIPTION
Related for deploying on further networks from swap sdk changes here: https://github.com/rainbow-me/swaps/pull/111

Testing database here: https://www.notion.so/rainbowdotme/TD-Swap-Router-Testing-Database-28db001b85b4801ba287d398c56e9e3f

