### PR TITLE
Normalize decimal separators in perps trigger order input formatting

### DIFF
--- a/src/features/perps/utils/formatTriggerOrderInput.ts
+++ b/src/features/perps/utils/formatTriggerOrderInput.ts
@@ -7,7 +7,9 @@ import { MAX_SIG_FIGS, MAX_DECIMALS_PERP, MAX_DECIMALS_SPOT } from '@/features/p
 export function formatTriggerOrderInput(text: string, sizeDecimals: number, marketType: 'perp' | 'spot' = 'perp'): string {
   'worklet';
 
-  const cleanedText = text.replace(/[^0-9.]/g, '');
+  // Normalize locale decimal separators (e.g., "0,001" -> "0.001")
+  const normalized = text.replace(/,/g, '.');
+  const cleanedText = normalized.replace(/[^0-9.]/g, '');
 
   if (!cleanedText) return '';
 


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)
As shown in the screen recording, when entering a stop loss or take profit price with a keyboard that uses commas as decimal separators, the formatter strips commas and only allows dots, blocking valid decimal input unless the keyboard provides a dot

## Screen recordings / screenshots
https://github.com/user-attachments/assets/91d34bdb-c0f8-4d9c-ae22-6abf9e192562

## What to test

