### PR TITLE
Align weekly Hyperliquid candles to calendar weeks

### DIFF
--- a/src/features/charts/candlestick/hyperliquid/hyperliquidCharts.ts
+++ b/src/features/charts/candlestick/hyperliquid/hyperliquidCharts.ts
@@ -67,7 +67,7 @@ export async function fetchHyperliquidChart(
 /**
  * Converts a Hyperliquid `Candle` array to `Bar` format.
  */
-function convertCandlesToBars(candles: Candle[],  candleResolution: CandleResolution, maxBars: number): Bar[] {
+function convertCandlesToBars(candles: Candle[], candleResolution: CandleResolution, maxBars: number): Bar[] {
   const length = candles.length;
   if (!length) return [];
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Hyperliquid's API serves Thursday-based (midnight UTC) weekly candles
- This aligns them to calendar weeks

```
 LOG  [Hyperliquid] Original: Thu, 30 Oct 2025 00:00:00 GMT
 LOG  [Hyperliquid] Shifted:  Mon, 27 Oct 2025 00:00:00 GMT
```

## Screen recordings / screenshots


## What to test

