### PR TITLE
Bump iOS and Android to v2.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Testing
 
+## [2.0.10] (https://github.com/rainbow-me/rainbow/releases/tag/v2.0.10)
+
+### Fixed
+
+- Fixed positions balance/value calculations, LST filtering (#6919)
+
+### Internal
+
+- Version bump swaps sdk to v0.39.0 (#6917)
+- Bump swaps sdk version to v0.38.0 (#6915)
+
 ## [2.0.9] (https://github.com/rainbow-me/rainbow/releases/tag/v2.0.9)
 
 ### Added

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -157,8 +157,8 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 282
-        versionName "2.0.10"
+        versionCode 283
+        versionName "2.0.11"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
         renderscriptSupportModeEnabled true

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1923,7 +1923,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.10;
+				MARKETING_VERSION = 2.0.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1990,7 +1990,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.10;
+				MARKETING_VERSION = 2.0.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2109,7 +2109,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.10;
+				MARKETING_VERSION = 2.0.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2227,7 +2227,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.10;
+				MARKETING_VERSION = 2.0.11;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "2.0.10-1",
+  "version": "2.0.11-1",
   "private": true,
   "scripts": {
     "setup": "yarn graphql-codegen:install && yarn ds:install && yarn allow-scripts && yarn graphql-codegen && yarn fetch:networks",


### PR DESCRIPTION
## Summary

- Updates iOS and Android versions to v2.0.11
- Increments Android versionCode to 283
- Updates CHANGELOG.md with v2.0.10 release notes

## Test plan

- [ ] Verify version numbers are correct in all files
- [ ] Confirm CHANGELOG.md includes v2.0.10 changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)