### PR TITLE
APP-3212: Fix issue where password manager won't save the password after backup

### DIFF
--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -371,7 +371,7 @@ export async function getSharedWebCredentials(): Promise<Result<SharedWebCredent
  */
 export async function setSharedWebCredentials(username: string, password: string) {
   logger.debug(`[keychain]: setSharedWebCredentials`, {}, logger.DebugContext.keychain);
-  await originalSetSharedWebCredentials('rainbow.me', username, password);
+  await originalSetSharedWebCredentials('https://rainbow.me', username, password);
 }
 
 /**


### PR DESCRIPTION
Fixes APP-3212

## What changed (plus any additional context for devs)
Looks like the missing part was to provide the full server protocol. Here the example from the keychain docs

<img width="1438" height="848" alt="image" src="https://github.com/user-attachments/assets/85d97b48-7543-4adf-ae46-950d1b318fc7" />


## Screen recordings / screenshots

https://github.com/user-attachments/assets/ac421195-a7ec-4b31-9f6a-89d61658cf3d


## What to test

- Go to Settings -> Developer Settings -> Reset Keychain
- Uninstall and reinstall the app
- Get a new wallet
- Create a new iCould backup
- See that it asks to save password in password manager



