### PR TITLE
Fix hyperliquid token symbol metadata lookup

### DIFF
--- a/src/features/perps/stores/hyperliquidMarketsStore.ts
+++ b/src/features/perps/stores/hyperliquidMarketsStore.ts
@@ -8,7 +8,6 @@ import { formatPerpAssetPrice } from '@/features/perps/utils/formatPerpsAssetPri
 import { getAllMarketsInfo } from '@/features/perps/utils/hyperliquid';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
-import { extractBaseSymbol } from '@/features/perps/utils/hyperliquidSymbols';
 
 type PerpMarketsBySymbol = Partial<Record<string, PerpMarketWithMetadata>>;
 
@@ -158,5 +157,5 @@ async function fetchHyperliquidMarkets(): Promise<HyperliquidMarketsFetchData> {
 }
 
 function buildHypercoreTokenId(symbol: string): string {
-  return `${extractBaseSymbol(symbol).toLowerCase()}:${HYPERCORE_PSEUDO_CHAIN_ID}`;
+  return `${symbol.toLowerCase()}:${HYPERCORE_PSEUDO_CHAIN_ID}`;
 }


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Use full symbol when looking for markets metadata. Fixes missing HIP-3 markets icons. 

## Screen recordings / screenshots
<img width="587" height="1045" alt="Screenshot 2025-11-12 at 6 01 06 PM" src="https://github.com/user-attachments/assets/de6757e8-bee3-4a17-9305-17e49c521aa6" />


