### PR TITLE
Fix sheet dismiss gesture on iOS

### DIFF
--- a/src/components/sheet/SlackSheet.tsx
+++ b/src/components/sheet/SlackSheet.tsx
@@ -15,7 +15,7 @@ import { position } from '@/styles';
 import { IS_ANDROID, IS_IOS } from '@/env';
 import { ScrollView } from 'react-native-gesture-handler';
 
-const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
+const AnimatedRNGHScrollView = Animated.createAnimatedComponent(ScrollView);
 
 interface AndroidBackgroundProps {
   backgroundColor: string;
@@ -221,7 +221,14 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
         <ContentWrapper backgroundColor={bg}>
           {renderHeader?.(yPosition)}
           <Content
-            as={isInsideBottomSheet ? BottomSheetScrollView : AnimatedScrollView}
+            as={
+              isInsideBottomSheet
+                ? BottomSheetScrollView
+                : // Android requires RNGH ScrollView while iOS requires the RN one for the dismiss gesture to work.
+                  IS_ANDROID
+                  ? AnimatedRNGHScrollView
+                  : Animated.ScrollView
+            }
             backgroundColor={bg}
             contentContainerStyle={scrollEnabled && contentContainerStyle}
             contentHeight={contentHeight}


### PR DESCRIPTION
Fix for https://rainbowhaus.slack.com/team/UGV52LYN8

## What changed (plus any additional context for devs)

The recent change to fix positions sheet on Android broke iOS. This applies the change only to Android.

## Screen recordings / screenshots


## What to test

Dismiss sheets with gesture works on both iOS and Android. Also test positions sheet.