### PR TITLE
Fix perps trade executed at formatting

### DIFF
--- a/src/features/perps/components/TradeListItem.tsx
+++ b/src/features/perps/components/TradeListItem.tsx
@@ -33,7 +33,7 @@ export const TradeListItem = memo(function TradeListItem({ trade, showMarketIcon
   const pnlColor = isPositivePnl ? 'green' : 'red';
 
   const formattedDate = useMemo(() => {
-    return format(trade.executedAt, 'MMM d, h:mm aaa');
+    return format(new Date(trade.executedAt), 'MMM d, h:mm aaa');
   }, [trade.executedAt]);
 
   const leftHandSide = useMemo(() => {

--- a/src/features/perps/stores/hlTradesStore.ts
+++ b/src/features/perps/stores/hlTradesStore.ts
@@ -55,6 +55,7 @@ export const useHlTradesStore = createQueryStore<FetchHlTradesResponse, HlTrades
   }),
   {
     storageKey: 'hlTradesStore',
+    version: 1,
   }
 );
 
@@ -100,7 +101,7 @@ function convertFillAndOrderToTrade({ fill, order }: { fill: UserFill; order: Hi
     tradeId: fill.tid,
     txHash: fill.hash,
     liquidation: fill.liquidation,
-    executedAt: new Date(fill.time),
+    executedAt: fill.time,
     direction: fill.dir,
     orderType: order.orderType,
     triggerOrderType,

--- a/src/features/perps/types.ts
+++ b/src/features/perps/types.ts
@@ -123,7 +123,7 @@ export type HlTrade = {
   tradeId: number;
   txHash: string;
   liquidation?: UserFill['liquidation'];
-  executedAt: Date;
+  executedAt: number;
   direction: string;
   orderType: string;
   triggerOrderType?: TriggerOrderType;


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Fixes crash when navigating to perps position or perps history screen. 

In this PR (https://github.com/rainbow-me/rainbow/pull/6930) I added persistence to the `hlTradeStore` because I had originally intended for it to be persisted and noticed it was not. I did not realize that the `formattedDate` function in the `TradeListItem` required a date of type `Date` or `number`. The type of `trade.executedAt` was `Date`, but when rehydrated from persistence was a `string`, causing the format function to crash with the error `Invalid time value`. 

This change keeps the `trade.executedAt` as its original type of `number` in the trade object, and casts it to a `Date` in the `formattedDate` function directly. 

## Screen recordings / screenshots


## What to test

