### PR TITLE
Update rockjs ios action to fix simulator tophat builds

### DIFF
--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Rock Build - iOS simulator
         id: rock-build-simulator
-        uses: callstackincubator/ios@0b4a5a6e4d6865d697bd5f277460088501982a5e
+        uses: callstackincubator/ios@0bfe6ed5c14bdf3fb88a638d5a19b440e59e845f
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
@@ -224,7 +224,7 @@ jobs:
 
       - name: Rock Build - iOS device
         id: rock-build-device
-        uses: callstackincubator/ios@0b4a5a6e4d6865d697bd5f277460088501982a5e
+        uses: callstackincubator/ios@0bfe6ed5c14bdf3fb88a638d5a19b440e59e845f
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Rock Remote Build - iOS simulator
         id: rock-remote-build-ios
-        uses: callstackincubator/ios@0b4a5a6e4d6865d697bd5f277460088501982a5e
+        uses: callstackincubator/ios@0bfe6ed5c14bdf3fb88a638d5a19b440e59e845f
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

There was a cache issue with the rockjs ios github action that I fixed https://github.com/callstackincubator/ios/pull/22, this updates it to the new version.

## Screen recordings / screenshots

N/A

## What to test

Tophat simulator build uses the actual code in the PR, and doesn't cache an old version.