### PR TITLE
refactor: move getSquirclePath util to DS

### DIFF
--- a/src/components/cards/skia-cards/SkiaCard.tsx
+++ b/src/components/cards/skia-cards/SkiaCard.tsx
@@ -1,5 +1,4 @@
 import { Canvas, DrawingNodeProps, Fill, Group, LinearGradient, Path, Rect, Shadow, SkiaProps, vec } from '@shopify/react-native-skia';
-import { getSvgPath } from 'figma-squircle';
 import React, { ReactElement, ReactNode, memo, useMemo } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import { convertToRGBA } from 'react-native-reanimated';
@@ -10,6 +9,7 @@ import { BackgroundColor, globalColors } from '@/design-system/color/palettes';
 import { IS_IOS } from '@/env';
 import { opacity } from '@/__swaps__/utils/swaps';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+import { getSquirclePath } from '@/design-system/layout/shapes';
 
 type ValueByTheme<T extends string | number | boolean | null | undefined> = { dark: T; light: T } | T;
 
@@ -145,25 +145,6 @@ const CardHighlights = memo(function CardHighlights({
     </>
   );
 });
-
-export function getSquirclePath({
-  borderRadius,
-  cornerSmoothing = IS_IOS ? 0.6 : 0,
-  height,
-  width,
-}: {
-  borderRadius: number;
-  cornerSmoothing?: number;
-  height: number;
-  width: number;
-}): string {
-  return getSvgPath({
-    cornerRadius: borderRadius,
-    cornerSmoothing,
-    height,
-    width,
-  });
-}
 
 function getStrokeGradientConfig(strokeOpacity: { start: number; end: number }) {
   return {

--- a/src/design-system/layout/shapes.ts
+++ b/src/design-system/layout/shapes.ts
@@ -1,0 +1,34 @@
+import { getSvgPath } from 'figma-squircle';
+import { IS_IOS } from '@/env';
+
+/**
+ * Creates a squircle (superellipse) path - a smooth blend between a square and circle.
+ * This produces the characteristic iOS-style rounded corners seen in app icons and modern UI.
+ *
+ * On iOS, applies corner smoothing (0.6 by default) for platform-native appearance.
+ * On Android, defaults to regular rounded rectangles (smoothing = 0) to match Material Design.
+ *
+ * @param borderRadius - The radius of the corners
+ * @param cornerSmoothing - How smooth the corners should be (0 = rounded rect, 1 = circle-like). Defaults to 0.6 on iOS, 0 on Android
+ * @param height - The height of the shape
+ * @param width - The width of the shape
+ * @returns An SVG path representing the squircle
+ */
+export function getSquirclePath({
+  borderRadius,
+  cornerSmoothing = IS_IOS ? 0.6 : 0,
+  height,
+  width,
+}: {
+  borderRadius: number;
+  cornerSmoothing?: number;
+  height: number;
+  width: number;
+}): string {
+  return getSvgPath({
+    cornerRadius: borderRadius,
+    cornerSmoothing,
+    height,
+    width,
+  });
+}

--- a/src/screens/token-launcher/components/StepBorderEffects.tsx
+++ b/src/screens/token-launcher/components/StepBorderEffects.tsx
@@ -5,7 +5,7 @@ import { THICK_BORDER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { useTokenLauncherContext } from '../context/TokenLauncherContext';
 import Animated, { interpolate, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
 import { useForegroundColor } from '@/design-system';
-import { getSquirclePath } from '@/components/cards/skia-cards/SkiaCard';
+import { getSquirclePath } from '@/design-system/layout/shapes';
 
 export const StepBorderEffects = memo(function StepBorderEffects({ width, height }: { width: number; height: number }) {
   const separatorSecondaryColor = useForegroundColor('separatorSecondary');


### PR DESCRIPTION
Move `getSquirclePath` from `SkiaCard.tsx` to a new file in DS `design-system/layout/shapes.ts`. Also adds some docs to the fn given it's (now properly) a generic util.

This function is a generic geometric utility with no card-specific logic, and was seemingly only in `SkiaCard.tsx` because that's where it was first written. The new location makes the architecture clearer and removes unnecessary dependencies on the unused skia-cards components, which we can then remove in isolation in an upcoming PR.