### PR TITLE
fix: remove dependency cycle in polymarket to avoid crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint:js": "eslint --cache . --quiet",
     "lint:js:ci": "eslint --quiet",
     "lint:ts": "yarn tsc --skipLibCheck --noEmit",
-    "check:cycles": "./scripts/check-cycles.sh 2087",
+    "check:cycles": "./scripts/check-cycles.sh 2086",
     "postinstall": "./scripts/postinstall.sh",
     "start": "react-native start --client-logs",
     "start:clean": "yarn clean:packager && yarn start --reset-cache",

--- a/src/features/polymarket/types.ts
+++ b/src/features/polymarket/types.ts
@@ -1,5 +1,5 @@
-import { ResponseByTheme } from '@/__swaps__/utils/swaps';
 import { PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+import { PolymarketTeamInfo } from '@/features/polymarket/types/team-info';
 
 export type RawPolymarketPosition = {
   proxyWallet: string;
@@ -58,29 +58,4 @@ export type PolymarketWalletListData = {
   enabled: boolean;
 };
 
-export type PolymarketGameMetadata = {
-  teams: string[];
-  sport: string;
-  ordering: TeamSide;
-  type: string[];
-};
-
-export type RawPolymarketTeamInfo = {
-  id: number;
-  name: string;
-  league: string;
-  record: string;
-  logo: string;
-  abbreviation: string;
-  alias: string | null;
-  createdAt: string;
-  updatedAt: string;
-  providerId: number;
-  color?: string;
-};
-
-export type PolymarketTeamInfo = Omit<RawPolymarketTeamInfo, 'color'> & {
-  color: ResponseByTheme<string>;
-};
-
-export type TeamSide = 'away' | 'home';
+export type { PolymarketGameMetadata, PolymarketTeamInfo, RawPolymarketTeamInfo, TeamSide } from '@/features/polymarket/types/team-info';

--- a/src/features/polymarket/types/polymarket-event.ts
+++ b/src/features/polymarket/types/polymarket-event.ts
@@ -1,7 +1,7 @@
 import { ResponseByTheme } from '@/__swaps__/utils/swaps';
 import { POLYMARKET_SPORTS_MARKET_TYPE } from '@/features/polymarket/constants';
 import { League } from '@/features/polymarket/leagues';
-import { PolymarketTeamInfo } from '@/features/polymarket/types';
+import { PolymarketTeamInfo } from '@/features/polymarket/types/team-info';
 
 export type SportsMarketType = (typeof POLYMARKET_SPORTS_MARKET_TYPE)[keyof typeof POLYMARKET_SPORTS_MARKET_TYPE];
 

--- a/src/features/polymarket/types/team-info.ts
+++ b/src/features/polymarket/types/team-info.ts
@@ -1,0 +1,28 @@
+import { ResponseByTheme } from '@/__swaps__/utils/swaps';
+
+export type PolymarketGameMetadata = {
+  teams: string[];
+  sport: string;
+  ordering: TeamSide;
+  type: string[];
+};
+
+export type RawPolymarketTeamInfo = {
+  id: number;
+  name: string;
+  league: string;
+  record: string;
+  logo: string;
+  abbreviation: string;
+  alias: string | null;
+  createdAt: string;
+  updatedAt: string;
+  providerId: number;
+  color?: string;
+};
+
+export type PolymarketTeamInfo = Omit<RawPolymarketTeamInfo, 'color'> & {
+  color: ResponseByTheme<string>;
+};
+
+export type TeamSide = 'away' | 'home';


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3394 
Fixes https://linear.app/rainbow/issue/APP-3360

## What changed (plus any additional context for devs)

I assume that the root cause for the both issues is circular import between `types.ts` and `polymarket-event.ts` inside `src/features/polymarket/`, which results into `React ErrorBoundary TypeError: Cannot read property 'usePolymarketPositionsStore' of undefined` 

  `types.ts -> polymarket-event.ts -> types.ts` (CYCLE)

  When JavaScript resolves this cycle during module initialization, it returns an incomplete module object, causing `usePolymarketPositionsStore` to be undefined when accessed by derived stores.

  To fix I've extracted team-related types to a new leaf module types/team-info.ts that has no polymarket dependencies to break this cycle.

  ## Screen recordings / screenshots

  N/A - Runtime crash fix, no UI changes

  ## What to test
 I was not able to reproduce the crash as by nature it only happens sometimes, so just checking that the app and polymarket screen works normally should be enough.
