### PR TITLE
chore: remove src/config/index.ts barrel file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,6 @@ const allowedBarrelFiles = [
   'src/components/sheet/sheet-action-buttons/index.ts',
   'src/components/unique-token/index.ts',
   'src/components/video/index.ts',
-  'src/config/index.ts',
   'src/design-system/docs/components/CodePreview/index.tsx',
   'src/design-system/docs/components/DocsAccordion/index.tsx',
   'src/design-system/docs/components/index.tsx',

--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -40,7 +40,7 @@ import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import { REVIEW_SHEET_ROW_HEIGHT } from '../constants';
 import { useSelectedGasSpeed } from '../hooks/useSelectedGas';
 import { useWillExecuteDelegation } from '@/hooks/useWillExecuteDelegation';
-import { ATOMIC_SWAPS, getExperimentalFlag } from '@/config';
+import { ATOMIC_SWAPS, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 import { NavigationSteps, useSwapContext } from '../providers/swap-provider';

--- a/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBottomPanel.tsx
@@ -1,7 +1,7 @@
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { Box, Separator, Text, globalColors, useColorMode } from '@/design-system';
-import { ATOMIC_SWAPS, RNBW_REWARDS, getExperimentalFlag, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { ATOMIC_SWAPS, RNBW_REWARDS, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig, useRemoteConfig } from '@/model/remoteConfig';
 import React, { memo, useCallback } from 'react';
 import { StyleSheet } from 'react-native';

--- a/src/__swaps__/screens/Swap/components/SwapNavbar.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapNavbar.tsx
@@ -8,7 +8,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ContactAvatar } from '@/components/contacts';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { Navbar } from '@/components/navbar/Navbar';
-import { DEGEN_MODE, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { DEGEN_MODE } from '@/config/experimentalHooks';
 import {
   AnimatedText,
   Bleed,

--- a/src/__swaps__/screens/Swap/navigateToSwaps.ts
+++ b/src/__swaps__/screens/Swap/navigateToSwaps.ts
@@ -9,7 +9,7 @@ import {
   trimCurrencyZeros,
   trimTrailingZeros,
 } from '@/__swaps__/utils/swaps';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -50,7 +50,7 @@ import { swapsStore } from '@/state/swaps/swapsStore';
 import { getNextNonce } from '@/state/nonces';
 import { type CrosschainQuote, type Quote, type QuoteError, SwapType } from '@rainbow-me/swaps';
 import { IS_IOS } from '@/env';
-import { ATOMIC_SWAPS, getExperimentalFlag } from '@/config';
+import { ATOMIC_SWAPS, getExperimentalFlag } from '@/config/experimentalHooks';
 import { clearCustomGasSettings } from '../hooks/useCustomGas';
 import { getGasSettingsBySpeed, getSelectedGas } from '../hooks/useSelectedGas';
 import { useSwapOutputQuotesDisabled } from '../hooks/useSwapOutputQuotesDisabled';

--- a/src/components/DappBrowser/Homepage.tsx
+++ b/src/components/DappBrowser/Homepage.tsx
@@ -40,7 +40,7 @@ import { useTrendingDApps } from '@/resources/metadata/trendingDapps';
 import { type DApp } from '@/graphql/__generated__/metadata';
 import { HOMEPAGE_BACKGROUND_COLOR_DARK, HOMEPAGE_BACKGROUND_COLOR_LIGHT, HTTP, HTTPS } from './constants';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import { FEATURED_RESULTS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { FEATURED_RESULTS } from '@/config/experimentalHooks';
 import { FeaturedResultStack, type FeaturedResultStackProps } from '@/components/FeaturedResult/FeaturedResultStack';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 

--- a/src/components/asset-list/RecyclerAssetList2/LegacyWrappedNFT.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/LegacyWrappedNFT.tsx
@@ -6,7 +6,7 @@ import useCollectible from '@/hooks/useCollectible';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import { NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 
 export default React.memo(function LegacyWrappedNFT({
   onPress,

--- a/src/components/asset-list/RecyclerAssetList2/LegacyWrappedTokenFamilyHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/LegacyWrappedTokenFamilyHeader.tsx
@@ -1,6 +1,6 @@
 import useLatestCallback from '@/hooks/useLatestCallback';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import { NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 import * as i18n from '@/languages';
 import React, { useMemo, useRef } from 'react';
 import { Animated, Easing, StyleSheet, View } from 'react-native';

--- a/src/components/asset-list/RecyclerAssetList2/NFTEmptyState.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/NFTEmptyState.tsx
@@ -3,7 +3,7 @@ import Animated from 'react-native-reanimated';
 import { Box, Stack, Text, useColorMode } from '@/design-system';
 import * as i18n from '@/languages';
 import { TokenFamilyHeaderHeight } from './NFTLoadingSkeleton';
-import { MINTS, NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { MINTS, NFTS_ENABLED } from '@/config/experimentalHooks';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import { useMints } from '@/resources/mints';
 import { useAccountAddress } from '@/state/wallets/walletsStore';

--- a/src/components/asset-list/RecyclerAssetList2/NFTLoadingSkeleton.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/NFTLoadingSkeleton.tsx
@@ -4,7 +4,7 @@ import { useForegroundColor } from '@/design-system';
 import { useTheme } from '@/theme/ThemeContext';
 import { opacity } from '@/framework/ui/utils/opacity';
 import deviceUtils from '@/utils/deviceUtils';
-import { NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 import { useRemoteConfig } from '@/model/remoteConfig';
 
 export const TokenFamilyHeaderHeight = 50;

--- a/src/components/asset-list/RecyclerAssetList2/WrappedCollectiblesHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedCollectiblesHeader.tsx
@@ -5,7 +5,7 @@ import * as i18n from '@/languages';
 // import { NftCollectionSortCriterion, SortDirection } from '@/graphql/__generated__/arc';
 // import { colors } from '@/styles';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import { NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 // import { IS_IOS } from '@/env';
 // import { nftsStoreManager } from '@/state/nfts/nftsStoreManager';
 

--- a/src/components/asset-list/RecyclerAssetList2/WrappedNFT.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedNFT.tsx
@@ -5,7 +5,7 @@ import type { UniqueAsset } from '@/entities/uniqueAssets';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import { NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 import { useNftsStore } from '@/state/nfts/nfts';
 
 export const WrappedNFT = React.memo(function WrappedNFT({

--- a/src/components/asset-list/RecyclerAssetList2/WrappedTokenFamilyHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedTokenFamilyHeader.tsx
@@ -3,7 +3,7 @@ import { TokenFamilyHeader } from '../../token-family';
 import useLatestCallback from '@/hooks/useLatestCallback';
 import { type ThemeContextProps } from '@/theme/ThemeContext';
 import { useRemoteConfig } from '@/model/remoteConfig';
-import { NFTS_ENABLED, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 import { useNftsStore } from '@/state/nfts/nfts';
 import { useOpenCollectionsStore } from '@/state/nfts/openCollectionsStore';
 

--- a/src/components/asset-list/RecyclerAssetList2/core/getLayoutProvider.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/getLayoutProvider.tsx
@@ -3,7 +3,7 @@ import ViewDimensions from './ViewDimensions';
 import { CellType, type CellTypes } from './ViewTypes';
 import deviceUtils from '@/utils/deviceUtils';
 import { type RainbowConfig } from '@/model/remoteConfig';
-import { NFTS_ENABLED } from '@/config';
+import { NFTS_ENABLED } from '@/config/experimentalHooks';
 import { type useContext } from 'react';
 import { type RainbowContextType } from '@/helpers/RainbowContext';
 

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -9,7 +9,7 @@ import { getIsDamagedWallet, getIsReadOnlyWallet, useAccountAddress, useIsDamage
 import watchingAlert from '@/utils/watchingAlert';
 import { navigateToSwaps } from '@/__swaps__/screens/Swap/navigateToSwaps';
 import { analytics } from '@/analytics';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import * as React from 'react';

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -1,5 +1,5 @@
 import { analytics } from '@/analytics';
-import { PROFILES, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import {
   AccentColorProvider,
   Bleed,

--- a/src/components/king-of-the-hill/useShowKingOfTheHill.ts
+++ b/src/components/king-of-the-hill/useShowKingOfTheHill.ts
@@ -1,4 +1,4 @@
-import { KING_OF_THE_HILL_TAB, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { KING_OF_THE_HILL_TAB } from '@/config/experimentalHooks';
 import { IS_TEST } from '@/env';
 import { useRemoteConfig } from '@/model/remoteConfig';
 

--- a/src/components/rainbow-toast/useRainbowToastEnabled.ts
+++ b/src/components/rainbow-toast/useRainbowToastEnabled.ts
@@ -1,4 +1,4 @@
-import { RAINBOW_TOASTS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { RAINBOW_TOASTS } from '@/config/experimentalHooks';
 import { IS_TEST } from '@/env';
 import { useRemoteConfig } from '@/model/remoteConfig';
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,0 @@
-export * from './debug';
-export * from './experimental';
-export { default as useExperimentalFlag } from './experimentalHooks';

--- a/src/features/charts/candlestick/components/CandlestickChart.tsx
+++ b/src/features/charts/candlestick/components/CandlestickChart.tsx
@@ -37,7 +37,7 @@ import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animatio
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { DelayedMount } from '@/components/utilities/DelayedMount';
 import { MountWhenFocused } from '@/components/utilities/MountWhenFocused';
-import { CANDLESTICK_DATA_MONITOR, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { CANDLESTICK_DATA_MONITOR } from '@/config/experimentalHooks';
 import { Text, TextIcon, globalColors, useColorMode, useForegroundColor } from '@/design-system';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
 import { type TextSegment, useSkiaText } from '@/design-system/components/SkiaText/useSkiaText';

--- a/src/features/charts/stores/chartsStore.ts
+++ b/src/features/charts/stores/chartsStore.ts
@@ -1,4 +1,4 @@
-import { CANDLESTICK_CHARTS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { CANDLESTICK_CHARTS } from '@/config/experimentalHooks';
 import { isHyperliquidToken } from '@/features/charts/utils';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';

--- a/src/features/ens/components/ENSBriefTokenInfoRow.tsx
+++ b/src/features/ens/components/ENSBriefTokenInfoRow.tsx
@@ -6,7 +6,7 @@ import { InteractionManager } from 'react-native';
 import { ENSConfirmRenewSheetHeight } from '../screens/ENSConfirmRegisterSheet';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { TokenInfoItem, TokenInfoValue } from '@/components/token-info';
-import { PROFILES, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { Column, Columns, Inset } from '@/design-system';
 import { REGISTRATION_MODES } from '../utils/helpers';
 import useENSAvatar from '../hooks/useENSAvatar';

--- a/src/features/ens/components/ENSCreateProfileCard.tsx
+++ b/src/features/ens/components/ENSCreateProfileCard.tsx
@@ -1,5 +1,5 @@
 import { analytics } from '@/analytics';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { Bleed, Box, ColorModeProvider, Column, Columns, Stack, Text } from '@/design-system';
 import { prefetchENSAvatar } from '../hooks/useENSAvatar';
 import { prefetchENSRecords } from '../hooks/useENSRecords';

--- a/src/features/ens/components/ENSSearchCard.tsx
+++ b/src/features/ens/components/ENSSearchCard.tsx
@@ -1,5 +1,5 @@
 import { analytics } from '@/analytics';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { Box, ColorModeProvider, globalColors, Stack, Text } from '@/design-system';
 import { REGISTRATION_MODES } from '../utils/helpers';
 import useENSPendingRegistrations from '../hooks/useENSPendingRegistrations';

--- a/src/features/ens/components/profile/ProfileSheetHeader.tsx
+++ b/src/features/ens/components/profile/ProfileSheetHeader.tsx
@@ -9,7 +9,7 @@ import ProfileCover from './ProfileCover';
 import ProfileDescription from './ProfileDescription';
 import RecordTags, { Placeholder as RecordTagsPlaceholder } from './RecordTags';
 import { abbreviateEnsForDisplay } from '@/utils/abbreviations';
-import { PROFILES, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { Bleed, Box, Column, Columns, Heading, Inset, Separator, Stack } from '@/design-system';
 import { ENS_RECORDS } from '../../utils/helpers';
 import useENSAvatar from '../../hooks/useENSAvatar';

--- a/src/features/positions/stores/fetcher.test.ts
+++ b/src/features/positions/stores/fetcher.test.ts
@@ -1,7 +1,7 @@
 import { fetchPositions } from './fetcher';
 import { FIXTURE_LIST_POSITIONS_SUCCESS, FIXTURE_PARAMS } from '../__fixtures__/ListPositions';
 
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defiPositionsThresholdFilter',
 }));

--- a/src/features/positions/stores/transform/aave.test.ts
+++ b/src/features/positions/stores/transform/aave.test.ts
@@ -5,7 +5,7 @@ import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createMockStats, createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));

--- a/src/features/positions/stores/transform/balance.test.ts
+++ b/src/features/positions/stores/transform/balance.test.ts
@@ -6,12 +6,11 @@ import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createMockStats, createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));
 
-jest.mock('@/config/experimentalHooks', () => ({}));
 jest.mock('@/state/backendNetworks/backendNetworks', () => ({
   useBackendNetworksStore: {
     getState: () => ({

--- a/src/features/positions/stores/transform/compound.test.ts
+++ b/src/features/positions/stores/transform/compound.test.ts
@@ -5,7 +5,7 @@ import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createMockStats, createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));

--- a/src/features/positions/stores/transform/curve.test.ts
+++ b/src/features/positions/stores/transform/curve.test.ts
@@ -5,7 +5,7 @@ import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createMockStats, createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));

--- a/src/features/positions/stores/transform/filter.test.ts
+++ b/src/features/positions/stores/transform/filter.test.ts
@@ -2,7 +2,7 @@ import { shouldFilterPosition, shouldFilterPortfolioItem } from './filter';
 import { PositionName, DetailType } from '../../types/generated/positions/positions';
 import { createMockRainbowPosition, createMockDeposit, createMockPortfolioItem } from '../../__fixtures__/mocks/positions';
 
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => true),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));

--- a/src/features/positions/stores/transform/filter.ts
+++ b/src/features/positions/stores/transform/filter.ts
@@ -1,6 +1,6 @@
 import { type RainbowPosition } from '../../types';
 import { PositionName, DetailType, type PortfolioItem, type PositionToken } from '../../types/generated/positions/positions';
-import { getExperimentalFlag, DEFI_POSITIONS_THRESHOLD_FILTER } from '@/config';
+import { getExperimentalFlag, DEFI_POSITIONS_THRESHOLD_FILTER } from '@/config/experimentalHooks';
 
 // ============ Constants ====================================================== //
 

--- a/src/features/positions/stores/transform/filtered.test.ts
+++ b/src/features/positions/stores/transform/filtered.test.ts
@@ -19,12 +19,11 @@ import { createMockStats, createMockPosition, createMockResponse } from '../../_
  */
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));
 
-jest.mock('@/config/experimentalHooks', () => ({}));
 jest.mock('@/state/backendNetworks/backendNetworks', () => ({
   useBackendNetworksStore: {
     getState: () => ({

--- a/src/features/positions/stores/transform/index.test.ts
+++ b/src/features/positions/stores/transform/index.test.ts
@@ -17,7 +17,7 @@ import {
 import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createSimpleDapp } from '../../__fixtures__/mocks/positions';
 
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => true),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));

--- a/src/features/positions/stores/transform/locked.test.ts
+++ b/src/features/positions/stores/transform/locked.test.ts
@@ -6,12 +6,11 @@ import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createMockStats, createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));
 
-jest.mock('@/config/experimentalHooks', () => ({}));
 jest.mock('@/state/backendNetworks/backendNetworks', () => ({
   useBackendNetworksStore: {
     getState: () => ({

--- a/src/features/positions/stores/transform/uniswap.test.ts
+++ b/src/features/positions/stores/transform/uniswap.test.ts
@@ -5,7 +5,7 @@ import { createMockAsset } from '../../__fixtures__/mocks/assets';
 import { createMockStats, createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 
 // Mock config to avoid React Native gesture handler imports
-jest.mock('@/config', () => ({
+jest.mock('@/config/experimentalHooks', () => ({
   getExperimentalFlag: jest.fn(() => false),
   DEFI_POSITIONS_THRESHOLD_FILTER: 'defi_positions_threshold_filter',
 }));

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -10,7 +10,7 @@ import useIsWalletEthZero from './useIsWalletEthZero';
 import usePrevious from './usePrevious';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { analytics } from '@/analytics';
-import { PROFILES, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
 import { getProvider, isValidBluetoothDeviceId, resolveUnstoppableDomain } from '@/handlers/web3';
 import { isENSAddressFormat, isUnstoppableAddressFormat, isValidWallet } from '@/helpers/validators';

--- a/src/hooks/useNavigationForNonReadOnlyWallets.ts
+++ b/src/hooks/useNavigationForNonReadOnlyWallets.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { InteractionManager } from 'react-native';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { useNavigation, type NavigateArgs } from '@/navigation/Navigation';
 import { type Route } from '@/navigation/routesNames';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -1,6 +1,7 @@
 import { analytics } from '@/analytics';
 import { type MenuConfig } from '@/components/native-context-menu/contextMenu';
-import { enableActionsOnReadOnlyWallet, PROFILES, useExperimentalFlag } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
+import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { IS_IOS } from '@/env';
 import { REGISTRATION_MODES } from '@/features/ens/utils/helpers';
 import { isZero } from '@/helpers/utilities';

--- a/src/hooks/useShouldRevokeDelegation.ts
+++ b/src/hooks/useShouldRevokeDelegation.ts
@@ -4,7 +4,7 @@ import { useWalletsStore } from '@/state/wallets/walletsStore';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { RevokeReason } from '@/screens/delegation/RevokeDelegationPanel';
-import { DELEGATION, getExperimentalFlag } from '@/config';
+import { DELEGATION, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { EthereumWalletType } from '@/helpers/walletTypes';
 

--- a/src/hooks/useWillExecuteDelegation.ts
+++ b/src/hooks/useWillExecuteDelegation.ts
@@ -1,6 +1,6 @@
 import { useWillDelegate } from '@rainbow-me/delegation';
 import type { Address } from 'viem';
-import { DELEGATION, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { DELEGATION } from '@/config/experimentalHooks';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import { useIsHardwareWallet } from '@/state/wallets/walletsStore';
 

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -10,7 +10,7 @@ import {
   TAB_BAR_INNER_PADDING,
   TAB_BAR_WIDTH,
 } from '@/components/tab-bar/dimensions';
-import { DAPP_BROWSER, LAZY_TABS, RNBW_REWARDS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { DAPP_BROWSER, LAZY_TABS, RNBW_REWARDS } from '@/config/experimentalHooks';
 import { Box, Columns, globalColors, useColorMode, Column, ColorModeProvider } from '@/design-system';
 import { IS_IOS, IS_TEST } from '@/env';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';

--- a/src/performance/tracking/PerformanceToast.tsx
+++ b/src/performance/tracking/PerformanceToast.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { toast } from 'sonner-native';
-import { getExperimentalFlag, PERFORMANCE_TOAST } from '@/config';
+import { getExperimentalFlag, PERFORMANCE_TOAST } from '@/config/experimentalHooks';
 import { globalColors } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
 import { IS_IOS, IS_TEST } from '@/env';

--- a/src/resources/mints.ts
+++ b/src/resources/mints.ts
@@ -1,6 +1,6 @@
 import { analytics } from '@/analytics';
 import { useCallback, useEffect, useMemo } from 'react';
-import { MINTS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { MINTS } from '@/config/experimentalHooks';
 import { IS_TEST } from '@/env';
 import { arcClient } from '@/graphql';
 import { type GetMintableCollectionsQuery } from '@/graphql/__generated__/arc';

--- a/src/resources/reservoir/nftOffersQuery.ts
+++ b/src/resources/reservoir/nftOffersQuery.ts
@@ -1,6 +1,6 @@
 import { analytics } from '@/analytics';
 import { nftOffersSortAtom } from '@/components/nft-offers/SortMenu';
-import { NFT_OFFERS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NFT_OFFERS } from '@/config/experimentalHooks';
 import { arcClient } from '@/graphql';
 import { type GetNftOffersQuery, type NftOffer, SortCriterion } from '@/graphql/__generated__/arc';
 import { type QueryFunctionArgs, type QueryFunctionResult, createQueryKey, queryClient } from '@/react-query';

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import React from 'react';
 import * as i18n from '@/languages';
-import { HARDWARE_WALLETS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { HARDWARE_WALLETS } from '@/config/experimentalHooks';
 import { analytics } from '@/analytics';
 import { InteractionManager } from 'react-native';
 import { logger, RainbowError } from '@/logger';

--- a/src/screens/SendSheet.tsx
+++ b/src/screens/SendSheet.tsx
@@ -2,7 +2,7 @@ import { analytics } from '@/analytics';
 import { NoResults } from '@/components/list';
 import { NoResultsType } from '@/components/list/NoResults';
 import { useRainbowToastEnabled } from '@/components/rainbow-toast/useRainbowToastEnabled';
-import { PROFILES, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { AssetType } from '@/entities/assetTypes';
 import { type NewTransaction, TransactionStatus } from '@/entities/transactions';
 import { type ParsedAddressAsset } from '@/entities/tokens';

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
@@ -8,7 +8,7 @@ import CloudBackedUpIcon from '@/assets/BackedUpCloud.png';
 import BackupWarningIcon from '@/assets/BackupWarning.png';
 import CloudBackupWarningIcon from '@/assets/CloudBackupWarning.png';
 import ManuallyBackedUpIcon from '@/assets/ManuallyBackedUp.png';
-import { DELEGATION, getExperimentalFlag } from '@/config';
+import { DELEGATION, getExperimentalFlag } from '@/config/experimentalHooks';
 import { useCreateBackup } from '@/components/backup/useCreateBackup';
 import { ContactAvatar } from '@/components/contacts';
 import ImageAvatar from '@/components/contacts/ImageAvatar';

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -1,5 +1,5 @@
 import { ImgixImage } from '@/components/images';
-import { defaultConfig, getExperimentalFlag, LOG_PUSH } from '@/config';
+import { defaultConfig, getExperimentalFlag, LOG_PUSH } from '@/config/experimentalHooks';
 import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
 import { deleteAllBackups } from '@/handlers/cloudBackup';
 import { RainbowContext } from '@/helpers/RainbowContext';

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -5,7 +5,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { SheetHandleFixedToTop } from '@/components/sheet';
 import { FeatureHintTooltip, type TooltipRef } from '@/components/tooltips/FeatureHintTooltip';
-import { NOTIFICATIONS, useExperimentalFlag } from '@/config';
+import useExperimentalFlag, { NOTIFICATIONS } from '@/config/experimentalHooks';
 import { Box, globalColors, HitSlop, Inline, Text } from '@/design-system';
 import type { EthereumAddress } from '@/entities/wallet';
 import { IS_ANDROID, IS_IOS } from '@/env';

--- a/src/screens/change-wallet/components/AddressRow.tsx
+++ b/src/screens/change-wallet/components/AddressRow.tsx
@@ -17,7 +17,7 @@ import { Icon } from '@/components/icons';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
 import { address as abbreviateAddress } from '@/utils/abbreviations';
 import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
-import { DELEGATION, getExperimentalFlag } from '@/config';
+import { DELEGATION, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { DelegationStatus, useDelegations, useDelegationDisabled } from '@rainbow-me/delegation';
 import type { Address } from 'viem';

--- a/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
+++ b/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
@@ -14,7 +14,7 @@ import { address } from '@/utils/abbreviations';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
 import { PANEL_WIDTH } from '@/components/SmoothPager/ListPanel';
 import { IS_DEV, IS_IOS, IS_TEST_FLIGHT } from '@/env';
-import { DELEGATION, getExperimentalFlag } from '@/config';
+import { DELEGATION, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { useTheme } from '@/theme/ThemeContext';
 import { triggerHaptics } from 'react-native-turbo-haptics';

--- a/src/screens/claimables/shared/components/ClaimButton.tsx
+++ b/src/screens/claimables/shared/components/ClaimButton.tsx
@@ -1,6 +1,6 @@
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import ShimmerAnimation from '@/components/animations/ShimmerAnimation';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { AccentColorProvider, Box, Inline, Text, TextShadow } from '@/design-system';
 import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';

--- a/src/screens/expandedAssetSheet/components/sections/NameAndLogoSection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/NameAndLogoSection.tsx
@@ -4,7 +4,7 @@ import { Box, Text, TextShadow } from '@/design-system';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { RainbowCoinEffect } from '@/components/rainbow-coin-effect/RainbowCoinEffect';
 import { RAINBOW_COIN_EFFECT } from '@/config/experimental';
-import { useExperimentalFlag } from '@/config';
+import useExperimentalFlag from '@/config/experimentalHooks';
 
 export const NameAndLogoSection = memo(function NameAndLogoSection() {
   const { basicAsset: asset, isRainbowToken, accentColors } = useExpandedAssetSheetContext();

--- a/src/utils/requestNavigationHandlers.ts
+++ b/src/utils/requestNavigationHandlers.ts
@@ -3,7 +3,7 @@ import Routes from '@/navigation/routesNames';
 
 import { MobileWalletProtocolUserErrors } from '@/components/MobileWalletProtocolListener';
 import { hideWalletConnectToast } from '@/components/toasts/WalletConnectToast';
-import { enableActionsOnReadOnlyWallet } from '@/config';
+import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { maybeSignUri } from '@/handlers/imgix';
 import walletTypes from '@/helpers/walletTypes';
 import { logger, RainbowError } from '@/logger';


### PR DESCRIPTION
# Reduce import cycles by removing config/index.ts

## What changed (plus any additional context for devs)

- Reduced import cycles by removing the barrel file `src/config/index.ts`
- Updated the import path in `NameAndLogoSection.tsx` to directly import from `@/config/experimentalHooks`
- Updated the cycle threshold in `check:cycles` script from 1634 to 1619

## What to test

- Verify that the expanded asset sheet still properly displays the rainbow coin effect when the experimental flag is enabled
- Run `yarn check:cycles` to confirm the reduced cycle count