### PR TITLE
chore: migrate f2c api from gretchen

### DIFF
--- a/src/resources/f2c/index.ts
+++ b/src/resources/f2c/index.ts
@@ -1,16 +1,8 @@
-import { create, GretchResponse } from 'gretchen';
-import qs from 'query-string';
-
+import { RainbowFetchClient } from '@/rainbow-fetch';
 import { IS_PROD } from '@/env';
 import { ProviderConfig } from '@/screens/AddCash/types';
 import { Address } from 'viem';
 import { FiatProviderName } from '@/entities/f2c';
-
-type ErrorResponse = {
-  errors: {
-    message: string;
-  }[];
-};
 
 export type GetWidgetURL = (
   id: FiatProviderName,
@@ -18,31 +10,30 @@ export type GetWidgetURL = (
     redirectUri?: string;
     destinationAddress: Address;
   }
-) => Promise<GretchResponse<{ url: string }, ErrorResponse>>;
+) => Promise<{ data: { url: string }; headers: Headers; status: number }>;
 
 const DEV_HOST = `http://localhost:8787`;
 const STAGING_HOST = `https://f2c.rainbowdotme.workers.dev`;
 const PROD_HOST = `https://f2c.rainbow.me`;
 
-const gretch = create({
+const f2cClient = new RainbowFetchClient({
   baseURL: IS_PROD ? PROD_HOST : STAGING_HOST,
 });
 
 export function ratioGetClientSession({ signingAddress, depositAddress }: { signingAddress: string; depositAddress: string }) {
-  return gretch<{ id: string }, ErrorResponse>('/v1/providers/ratio/client-session', {
-    method: 'POST',
-    json: {
-      signingAddress,
-      depositAddress,
-      signingNetwork: 'ETHEREUM',
-    },
-  }).json();
+  return f2cClient.post<{ id: string }>('/v1/providers/ratio/client-session', {
+    signingAddress,
+    depositAddress,
+    signingNetwork: 'ETHEREUM',
+  });
 }
 
 export const getWidgetURL: GetWidgetURL = (id, query) => {
-  return gretch<{ url: string }, ErrorResponse>(`/v1/providers/${id}/create-widget-url?${qs.stringify(query)}`).json();
+  return f2cClient.get<{ url: string }>(`/v1/providers/${id}/create-widget-url`, {
+    params: query as Record<string, string>,
+  });
 };
 
 export function getProviders() {
-  return gretch<{ providers: ProviderConfig[] }, ErrorResponse>(`/v1/providers/list`).json();
+  return f2cClient.get<{ providers: ProviderConfig[] }>('/v1/providers/list');
 }

--- a/src/screens/AddCash/ProviderListItem.tsx
+++ b/src/screens/AddCash/ProviderListItem.tsx
@@ -27,12 +27,7 @@ export function ProviderListItem({ accountAddress, config, getWidgetURL }: Provi
       const redirectUri = `https://rnbw.app/f2c?provider=${config.id}&sessionId=${sessionId}`;
       // we're only passing redirect URL to Moonpay for now
       const query = { destinationAddress: accountAddress, ...(config.id === FiatProviderName.Moonpay ? { redirectUri } : {}) };
-      const { data, error } = await getWidgetURL(config.id, query);
-
-      if (!data || error) {
-        const [{ message }] = error?.errors || [];
-        throw new Error(`F2C: URL generation failed: ${message}`);
-      }
+      const { data } = await getWidgetURL(config.id, query);
 
       const { url } = data;
 

--- a/src/screens/AddCash/index.tsx
+++ b/src/screens/AddCash/index.tsx
@@ -36,9 +36,9 @@ export function AddCashSheet() {
   } = useQuery(
     ['f2c', 'providers'],
     async () => {
-      const [{ data, error }] = await wait(1000, [await getProviders()]);
+      const [{ data }] = await wait(1000, [await getProviders()]);
 
-      if (!data || error) {
+      if (!data) {
         const e = new RainbowError('[AddCash]: failed to fetch providers');
 
         logger.error(e);


### PR DESCRIPTION
# Replace Gretchen with RainbowFetchClient in F2C API

## What changed

- Replaced the `gretchen` library with our custom `RainbowFetchClient` for F2C API requests
- Simplified API endpoint calls using the new client's methods
- Updated response types to match the RainbowFetchClient structure
- Removed explicit error handling in the AddCash components as it's now handled by the client

## What to test

- Verify that all F2C API requests work correctly:
  - Getting widget URLs
  - Ratio client session creation
  - Provider listing
- Confirm error handling works as expected when API requests fail