### PR TITLE
fix: crash with new f2c provider

### DIFF
--- a/src/screens/AddCash/index.tsx
+++ b/src/screens/AddCash/index.tsx
@@ -18,6 +18,7 @@ import { logger, RainbowError } from '@/logger';
 import * as i18n from '@/languages';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 import { ProviderListItem } from './ProviderListItem';
+import { FiatProviderName } from '@/entities/f2c';
 
 const deviceHeight = deviceUtils.dimensions.height;
 
@@ -47,7 +48,7 @@ export function AddCashSheet() {
         throw new Error(e.message);
       }
 
-      return data.providers;
+      return data.providers?.filter(p => Object.values(FiatProviderName).includes(p.id));
     },
     {
       staleTime: 1000 * 60, // one min


### PR DESCRIPTION
# Filter out unsupported fiat providers in Add Cash screen

Fixes [APP-3403](https://linear.app/rainbow/issue/APP-3403/adding-new-f2c-provider-causes-a-crash-in-previous-builds)

## What changed (plus any additional context for devs)

Added filtering to the Add Cash providers list to only include providers that are defined in the `FiatProviderName` enum. This prevents crashes that could occur when new fiat-to-crypto providers were added to the API but not yet supported in older app builds.

## What to test

- Open the Add Cash sheet and verify that only supported providers are displayed
- Verify no crashes occur when the API returns providers that aren't defined in the `FiatProviderName` enum
- Check that the providers list still displays correctly with the filtering in place