### PR TITLE
chore(claude): expand allowed bash commands

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,6 +7,7 @@
       "Bash(gh pr view:*)",
       "Bash(gh release list:*)",
       "Bash(gh release view:*)",
+      "Bash(gh repo view:*)",
       "Bash(gh search:*)",
       "Bash(git show:*)",
       "Bash(grep:*)",


### PR DESCRIPTION
Adds more read-only bash commands to the Claude Code allow list and sorts entries alphabetically for easier maintenance.