### PR TITLE
Avoid duplicate local campaign check timers

### DIFF
--- a/src/handlers/walletReadyEvents.ts
+++ b/src/handlers/walletReadyEvents.ts
@@ -15,6 +15,7 @@ import { useNavigationStore } from '@/state/navigation/navigationStore';
 import { triggerOnSwipeLayout } from '../navigation/onNavigationStateChange';
 
 let integrityCheckTimeout: NodeJS.Timeout | null = null;
+let localCampaignCheckTimeout: NodeJS.Timeout | null = null;
 
 export const runKeychainIntegrityChecks = (): void => {
   // Run with a small delay to avoid blocking more important tasks on startup.
@@ -109,10 +110,14 @@ const notificationsCampaignCheckTimeout = 15_000;
 const routesToExitEarlyOn: string[] = [Routes.BACKUP_SHEET, Routes.APP_ICON_UNLOCK_SHEET, Routes.REMOTE_PROMO_SHEET];
 
 const handleLocalCampaignChecks = async () => {
-  setTimeout(() => {
+  if (localCampaignCheckTimeout) {
+    clearTimeout(localCampaignCheckTimeout);
+  }
+  localCampaignCheckTimeout = setTimeout(() => {
     const { activeRoute } = useNavigationStore.getState();
     if (routesToExitEarlyOn.includes(activeRoute)) return;
     runLocalCampaignChecks();
+    localCampaignCheckTimeout = null;
   }, notificationsCampaignCheckTimeout);
 };
 


### PR DESCRIPTION
# Problem

[handleLocalCampaignChecks()](cci:1://file:///d:/0000A/000000-AAA-BOTS/github/rainbow/src/handlers/walletReadyEvents.ts:111:0-121:2) schedules a delayed `runLocalCampaignChecks()` via `setTimeout`, but it does not track or clear any previously scheduled timer.

If this startup/ready path is triggered multiple times, multiple timers can be queued, causing repeated local campaign checks to run in parallel (or back-to-back) unexpectedly.

# Solution

- Introduced a module-level `localCampaignCheckTimeout` handle.
- Before scheduling a new timer:
  - clear any existing pending timeout.
- After the timeout fires:
  - reset `localCampaignCheckTimeout` back to `null`.

This ensures the local campaign check is scheduled at most once per invocation window and prevents duplicated delayed execution.

# Testing

- **Manual**:
  - Triggered the feature/local-campaign flow multiple times and verified only one delayed campaign check is pending at a time (previous one is cancelled when rescheduled).

# Notes

- Change is intentionally minimal and limited to timer lifecycle management.
- No behavior changes when the function is called only once; it only prevents duplicate scheduling on repeated calls.