### PR TITLE
docs: add important security note for analytics

### DIFF
--- a/src/analytics/README.md
+++ b/src/analytics/README.md
@@ -60,6 +60,8 @@ export const event = {
 
 You'll also need to define the payload for the event on the `EventProperties` type. If your event doesn't have a payload, use `undefined` as its value. See the file for examples.
 
+**Important:** Never include sensitive user data (private keys, mnemonics, passwords, or wallet addresses) in analytics events. This data will be sent to third-party analytics services and could compromise user security.
+
 ### Updating old events
 
 **Important:** once an event name has been used in production, it should not be


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Added an important warning to the analytics documentation section stating that sensitive user data should never be included in analytics events.

This is an essential security addition for all developers, especially beginners. Directly specifying specific data types (keys, mnemonics, addresses) helps prevent accidental leaks.


## What to test
This is only an update to the documentation and does not affect the code, project structure, or application logic.
