### PR TITLE
Fix wallet notification settings lookup to be case-insensitive

### DIFF
--- a/src/notifications/settings/storage.ts
+++ b/src/notifications/settings/storage.ts
@@ -46,7 +46,8 @@ export const getAllWalletNotificationSettingsFromStorage = () => {
  */
 export const getNotificationSettingsForWalletWithAddress = (address: string) => {
   const allSettings = getAllWalletNotificationSettingsFromStorage();
-  return allSettings.find((wallet: WalletNotificationSettings) => wallet.address === address);
+  const normalizedAddress = address.toLowerCase();
+  return allSettings.find((wallet: WalletNotificationSettings) => wallet.address?.toLowerCase() === normalizedAddress);
 };
 
 /**


### PR DESCRIPTION
## Problem
_getNotificationSettingsForWalletWithAddress_ performed a strict string comparison for Ethereum addresses. Because addresses can be represented with different casing (checksum vs lowercase), existing wallet notification settings could fail to be found.

## Solution
Normalize both the input address and stored wallet addresses to lowercase before comparing, making the lookup case-insensitive.

## Impact
Ensures wallet notification settings are reliably retrieved regardless of address casing, preventing incorrect defaults or missing settings in the notifications flow.