### PR TITLE
Fix deeplink from-wallet selection to be case-insensitive

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -385,8 +385,9 @@ function isValidGasSpeed(s: string | undefined): s is GasSpeed {
 async function setFromWallet(address: string | undefined) {
   if (!address || !isAddress(address)) return;
 
-  const userWallets = getWallets()!;
-  const wallet = Object.values(userWallets).find(w => w.addresses.some(a => a.address === address));
+  const userWallets = getWallets() as Record<string, { addresses: { address: string }[] }>;
+  const normalizedAddress = address.toLowerCase();
+  const wallet = Object.values(userWallets).find(w => w.addresses.some(a => a.address.toLowerCase() === normalizedAddress));
 
   if (!wallet) return;
 


### PR DESCRIPTION
## Problem
_setFromWallet_ in the deeplink handler compared Ethereum addresses using strict string equality. Because addresses may be provided in different casing (checksum vs lowercase), deeplink parameters such as `from` could fail to match an existing wallet account, preventing the correct wallet from being selected.

## Solution
Normalize the deeplink address and stored account addresses to lowercase before comparing them, making the wallet lookup case-insensitive.

## Impact
Ensures swap deeplinks reliably select the intended “from” wallet regardless of address casing, preventing incorrect wallet selection and improving deeplink correctness.