### PR TITLE
Fix crash when updating airdrops recentlyClaimed from null state

### DIFF
--- a/src/state/claimables/airdropsStore.ts
+++ b/src/state/claimables/airdropsStore.ts
@@ -228,8 +228,8 @@ export const useAirdropsStore = createQueryStore<AirdropsQueryData, AirdropsPara
           airdrops: newAirdrops,
           queryCache: newCacheEntry ? { ...queryCache, [queryKey]: newCacheEntry } : queryCache,
           recentlyClaimed: {
-            ...recentlyClaimed,
-            [accountAddress]: { ...recentlyClaimed?.[accountAddress], [uniqueId]: Date.now() },
+            ...(recentlyClaimed ?? {}),
+            [accountAddress]: { ...(recentlyClaimed?.[accountAddress] ?? {}), [uniqueId]: Date.now() },
           },
         };
       });


### PR DESCRIPTION
## Problem
**airdropsStore.markClaimed** updates `recentlyClaimed` using object spread. However, `recentlyClaimed` can be `null` on a fresh store state, and spreading `null` causes a runtime crash on the first call to **markClaimed**

## Solution
Default `recentlyClaimed` (and the per-address map) to empty objects when building the next state, avoiding object-spread on `null`.

## Impact
Prevents a runtime crash during the first optimistic claim update (e.g., on fresh installs or cleared storage), making the airdrops claim flow more robust.