### PR TITLE
Use locale-independent uppercasing for points referral codes

### DIFF
--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -212,7 +212,7 @@ export default async function handleDeeplink({ url, initialRoute, handleRequestU
           analytics.track(analytics.event.pointsReferralCodeDeeplinkOpened);
           queryClient.setQueryData(
             pointsReferralCodeQueryKey,
-            (referralCode.slice(0, 3) + '-' + referralCode.slice(3, 7)).toLocaleUpperCase()
+            (referralCode.slice(0, 3) + '-' + referralCode.slice(3, 7)).toUpperCase()
           );
         }
         break;


### PR DESCRIPTION
## Problem
The points deeplink handler formats referral codes using `toLocaleUpperCase()`. This operation is locale-dependent and can produce unexpected characters in certain locales (e.g., Turkish), resulting in incorrectly formatted referral codes.

## Solution
Replace `toLocaleUpperCase()` with locale-independent `toUpperCase()` to ensure consistent referral code formatting across all device locales.

## Impact
Prevents referral codes from being corrupted by locale-specific casing rules, improving reliability of referrals and reducing the risk of invalid or unrecognized codes.