### PR TITLE
Use locale-independent uppercasing for referral code normalization

### DIFF
--- a/src/screens/points/content/ReferralContent.tsx
+++ b/src/screens/points/content/ReferralContent.tsx
@@ -48,7 +48,7 @@ const parseReferralCodeFromLink = (code: string) => {
     const [, refCode] = code.split('=');
     if (!refCode) return;
 
-    const trimmed = refCode.replace(/-/g, '').slice(0, 6).toLocaleUpperCase();
+    const trimmed = refCode.replace(/-/g, '').slice(0, 6).toUpperCase();
 
     return trimmed;
   }
@@ -135,7 +135,7 @@ export function ReferralContent() {
     if (externalReferralCode) {
       setDeeplinked(true);
       setReferralCodeDisplay(externalReferralCode);
-      validateReferralCode(externalReferralCode.replace(/-/g, '').slice(0, 6).toLocaleUpperCase());
+      validateReferralCode(externalReferralCode.replace(/-/g, '').slice(0, 6).toUpperCase());
     }
   }, [externalReferralCode, validateReferralCode]);
 
@@ -194,7 +194,7 @@ export function ReferralContent() {
         return;
       }
 
-      const rawCode = code.replace(/-/g, '').slice(0, 6).toLocaleUpperCase();
+      const rawCode = code.replace(/-/g, '').slice(0, 6).toUpperCase();
       let formattedCode = rawCode;
 
       // If the user backspaces over the hyphen, remove the character before the hyphen


### PR DESCRIPTION
## Problem
Referral codes were normalized using `toLocaleUpperCase()` in [ReferralContent](cci:1://file:///d:/0000A/000000-AAA-BOTS/github/rainbow/src/screens/points/content/ReferralContent.tsx:58:0-350:1). Locale-dependent casing can produce unexpected characters in certain locales (e.g., Turkish), leading to corrupted referral codes and failed validation.

## Solution
Replace `toLocaleUpperCase()` with locale-independent `toUpperCase()` for all referral code normalization paths (deeplink, pasted link parsing, and manual input).

## Impact
Ensures referral codes are formatted consistently across all device locales, reducing invalid-code errors and improving reliability of the referral flow.