### PR TITLE
feat: add stripe f2c

### DIFF
--- a/src/resources/f2c/index.ts
+++ b/src/resources/f2c/index.ts
@@ -35,5 +35,5 @@ export const getWidgetURL: GetWidgetURL = (id, query) => {
 };
 
 export function getProviders() {
-  return f2cClient.get<{ providers: ProviderConfig[] }>('/v1/providers/list');
+  return f2cClient.get<{ providers: ProviderConfig[] }>('/v2/providers/list');
 }


### PR DESCRIPTION
# Update F2C API endpoint to v2

Fixes APP-2861

## What changed

- Updated the F2C providers endpoint from `/v1/providers/list` to `/v2/providers/list`
- This change enables the application to use the newer version of the providers API (which supports adding/removing providers on `arc`)

## What to test

- Verify that the F2C functionality continues to work correctly with the updated endpoint
- Confirm that all provider data is properly retrieved and displayed
- Check that users can buy crypto funds with Stripe

**Note for QA**: `iOS 2.0.18 (build 14)` has been built from this PR's branch for testing