### PR TITLE
fix(android): add gap between token list sheet and keyboard (APP-3442)

### DIFF
--- a/src/components/token-search/constants.ts
+++ b/src/components/token-search/constants.ts
@@ -1,8 +1,10 @@
+import { IS_ANDROID } from '@/env';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import { DEVICE_HEIGHT } from '@/utils/deviceUtils';
 import { getDefaultKeyboardHeight } from '@/utils/keyboardHeight';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
 export const TOKEN_SEARCH_CONTROL_ITEM_HEIGHT = 36;
-export const TOKEN_SEARCH_FOCUSED_INPUT_HEIGHT = DEVICE_HEIGHT - safeAreaInsetValues.top - 20 - getDefaultKeyboardHeight();
+export const TOKEN_SEARCH_FOCUSED_INPUT_HEIGHT =
+  DEVICE_HEIGHT - safeAreaInsetValues.top - 20 - getDefaultKeyboardHeight() - (IS_ANDROID ? 12 : 0);
 export const TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING = 20 - THICK_BORDER_WIDTH;


### PR DESCRIPTION
Fixes APP-3442

## What changed (plus any additional context for devs)

- Added an Android-only bottom gap between the token list sheet and keyboard when the token search input is focused.
- Updated `TOKEN_SEARCH_FOCUSED_INPUT_HEIGHT` to subtract an additional `12` px on Android via `IS_ANDROID`.
- iOS behavior is unchanged.

## Screen recordings / screenshots

| Before | After |
| ------ | ----- |
|    ![Screenshot_1770410559.png](https://app.graphite.com/user-attachments/assets/655268e8-b6f1-489f-a554-2d320d28640b.png)    |    ![Screenshot_1770410214.png](https://app.graphite.com/user-attachments/assets/6d09a1ef-c49f-4c7e-891f-c55f271138c6.png)   |





## What to test

- On Android, open token search and focus the input; verify there is a visible gap between the sheet content and keyboard.
- Confirm the focused search layout still fits the screen correctly without clipping.
- On iOS, verify token search layout remains unchanged.
