### PR TITLE
fix(APP-3447): handle swaps with multiple inputs/outputs in history

### DIFF
--- a/src/utils/__tests__/safeSum.ts
+++ b/src/utils/__tests__/safeSum.ts
@@ -1,0 +1,18 @@
+import { safeSum } from '../safeSum';
+
+it('safeSum sums selected raw values', () => {
+  const values = [{ value: '10' }, { value: 5 }, undefined, { value: null }, { value: ' 7 ' }, { value: '3.14' }] as const;
+
+  const result = safeSum(values, value => value?.value);
+
+  expect(result).toBeCloseTo(25.14);
+});
+
+it('safeSum returns zero for undefined values', () => {
+  const mapper = jest.fn();
+
+  const result = safeSum(undefined, mapper);
+
+  expect(result).toBe(0);
+  expect(mapper).not.toHaveBeenCalled();
+});

--- a/src/utils/safeSum.ts
+++ b/src/utils/safeSum.ts
@@ -1,0 +1,14 @@
+import { type BigNumberish, convertStringToNumber } from '@/helpers/utilities';
+
+type MappableValue = BigNumberish | null | undefined;
+
+export const safeSum = <T>(values: readonly T[] | undefined, mapValue: (value: T) => MappableValue) => {
+  return (
+    values?.reduce((sum, value) => {
+      const mappedValue = mapValue(value);
+      if (mappedValue == null) return sum;
+      const parsedValue = convertStringToNumber(mappedValue);
+      return Number.isFinite(parsedValue) ? sum + parsedValue : sum;
+    }, 0) ?? 0
+  );
+};


### PR DESCRIPTION
# Add support for summing multiple transaction changes

Fixes APP-3447

## What changed

- Added a new utility function `sumTransactionChangeValues` to handle summing values from transaction changes
- Updated swap transaction display to sum values from multiple input or output changes
- Updated transaction masthead to handle multiple input or output changes
- Added comprehensive tests for the new utility function

## What to test





- Verify that transactions with multiple input or output changes display the correct total values
- Check that the transaction masthead correctly shows summed values for both pending and completed transactions
- Confirm that different value formats (strings, numbers, null values) are handled properly

## Screenshots

| Before | After |
| -------|-----|
| ![before.png](https://app.graphite.com/user-attachments/assets/41c6168b-a89c-4173-9acb-9f12565a05d3.png) | ![after.png](https://app.graphite.com/user-attachments/assets/789789a1-05ef-4b33-9251-093fccc5c010.png) | ![before.png](https://app.graphite.com/user-attachments/assets/17664a48-763e-4c6b-8fc4-95717afa2170.png)

