### PR TITLE
feature: show trade details sheet after closing perps position

### DIFF
--- a/src/features/perps/services/hyperliquid-account-client.ts
+++ b/src/features/perps/services/hyperliquid-account-client.ts
@@ -127,6 +127,15 @@ export class HyperliquidAccountClient {
     );
   }
 
+  async isOrderFilled(orderId: number): Promise<boolean> {
+    const orderStatus = await infoClient.orderStatus({
+      user: this.userAddress,
+      oid: orderId,
+    });
+
+    return orderStatus.status === 'order' && orderStatus.order.status === 'filled';
+  }
+
   async isBuilderFeeApproved(): Promise<boolean> {
     const approvedBuilderFee = await infoClient.maxBuilderFee({
       builder: RAINBOW_BUILDER_SETTINGS.b,

--- a/src/features/perps/services/hyperliquid-exchange-client.ts
+++ b/src/features/perps/services/hyperliquid-exchange-client.ts
@@ -22,7 +22,7 @@ import { checkIfReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { logger, RainbowError } from '@/logger';
 import { isBuilderDexAssetId } from '@/features/perps/utils/hyperliquidSymbols';
 
-type OrderStatusResponse = hl.OrderSuccessResponse['response']['data']['statuses'][number];
+export type OrderStatusResponse = hl.OrderSuccessResponse['response']['data']['statuses'][number];
 
 export class HyperliquidExchangeClient {
   private accountClient: HyperliquidAccountClient;

--- a/src/features/perps/stores/hlTradesStore.ts
+++ b/src/features/perps/stores/hlTradesStore.ts
@@ -31,6 +31,7 @@ export const tradeExecutionDescriptions: Readonly<Record<TradeExecutionType, str
 
 type HlTradesStoreActions = {
   getTrade: (tradeId: number) => HlTrade | undefined;
+  getTradeByOrderId: ({ symbol, orderId }: { symbol: string; orderId: number }) => HlTrade | null;
   getTrades: () => HlTrade[] | undefined;
   getTradesBySymbol: () => Record<string, HlTrade[]> | undefined;
 };
@@ -48,6 +49,11 @@ export const useHlTradesStore = createQueryStore<FetchHlTradesResponse, HlTrades
       get()
         .getData()
         ?.trades.find(trade => trade.id === tradeId),
+
+    getTradeByOrderId: ({ symbol, orderId }: { symbol: string; orderId: number }) => {
+      const trades = get().getData()?.tradesBySymbol[symbol] ?? [];
+      return trades.find(trade => trade.orderId === orderId) ?? null;
+    },
 
     getTrades: () => get().getData()?.trades,
 

--- a/src/features/perps/stores/hyperliquidAccountStore.ts
+++ b/src/features/perps/stores/hyperliquidAccountStore.ts
@@ -11,6 +11,7 @@ import { hlOpenOrdersStoreActions } from '@/features/perps/stores/hlOpenOrdersSt
 import { refetchHyperliquidStores } from '@/features/perps/utils';
 import { truncateToDecimals } from '@/framework/core/safeMath';
 import { USD_DECIMALS } from '@/features/perps/constants';
+import type { OrderStatusResponse } from '@/features/perps/services/hyperliquid-exchange-client';
 
 type HyperliquidAccountActions = {
   getBalance: () => string;
@@ -89,15 +90,24 @@ async function cancelOrder({ symbol, orderId }: { symbol: string; orderId: numbe
   await hlOpenOrdersStoreActions.fetch(undefined, { force: true });
 }
 
-async function closePosition({ symbol, price, size }: { symbol: string; price: string; size: string }): Promise<void> {
+async function closePosition({
+  symbol,
+  price,
+  size,
+}: {
+  symbol: string;
+  price: string;
+  size: string;
+}): Promise<OrderStatusResponse | undefined> {
   const market = getMarket(symbol);
-  await getHyperliquidExchangeClient().closePosition({
+  const result = await getHyperliquidExchangeClient().closePosition({
     assetId: market.id,
     price,
     sizeDecimals: market.decimals,
     size,
   });
   await refetchHyperliquidStores();
+  return result;
 }
 
 async function createIsolatedMarginPosition({

--- a/src/features/perps/utils/waitForTradeByOrderId.ts
+++ b/src/features/perps/utils/waitForTradeByOrderId.ts
@@ -1,0 +1,57 @@
+import { type HlTrade } from '../types';
+import { hlTradesStoreActions } from '../stores/hlTradesStore';
+import { getHyperliquidAccountClient } from '../services';
+import { delay } from '@/utils/delay';
+import { time } from '@/utils/time';
+
+const DEFAULT_TIMEOUT_MS = time.seconds(5);
+const POLL_INTERVAL_MS = time.ms(500);
+
+export async function waitForTradeByOrderId({
+  symbol,
+  orderId,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: {
+  symbol: string;
+  orderId?: number;
+  timeoutMs?: number;
+}): Promise<HlTrade | null> {
+  if (orderId === undefined) return null;
+
+  const initialTrade = hlTradesStoreActions.getTradeByOrderId({ symbol, orderId });
+  if (initialTrade) return initialTrade;
+
+  const deadline = Date.now() + timeoutMs;
+  const orderFilled = await pollOrderFilled({ orderId, deadline });
+  if (orderFilled) return await pollTradeByOrderId({ symbol, orderId, deadline });
+  return null;
+}
+
+async function pollOrderFilled({ orderId, deadline }: { orderId: number; deadline: number }): Promise<boolean> {
+  while (Date.now() < deadline) {
+    const orderFilled = await getHyperliquidAccountClient().isOrderFilled(orderId);
+    if (orderFilled) return true;
+    if (Date.now() + POLL_INTERVAL_MS >= deadline) break;
+    await delay(POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+async function pollTradeByOrderId({
+  symbol,
+  orderId,
+  deadline,
+}: {
+  symbol: string;
+  orderId: number;
+  deadline: number;
+}): Promise<HlTrade | null> {
+  while (Date.now() < deadline) {
+    await hlTradesStoreActions.fetch(undefined, { force: true });
+    const trade = hlTradesStoreActions.getTradeByOrderId({ symbol, orderId });
+    if (trade) return trade;
+    if (Date.now() + POLL_INTERVAL_MS >= deadline) break;
+    await delay(POLL_INTERVAL_MS);
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes APP-3166, APP-3198

## What changed (plus any additional context for devs)

 - After a successful perps close, we now wait for the resulting trade to be available and automatically
  open the trade details sheet.
  - `closePosition` now returns the Hyperliquid order status so we can extract the close `orderId`.
  - Added `waitForTradeByOrderId` utility to poll order fill status + refetch trades, then resolve the
  matching trade.
  - Added `getTradeByOrderId` in `hlTradesStore` and `isOrderFilled` in `HyperliquidAccountClient` to
  support this flow.
## Screen recordings / screenshots

https://github.com/user-attachments/assets/5f67ef19-27d4-4c7e-88e0-5ae35e08d6ad



## What to test

Closing perps trades
