### PR TITLE
feature: encode position leverage in cloid

### DIFF
--- a/src/features/perps/screens/ClosePositionBottomSheet.tsx
+++ b/src/features/perps/screens/ClosePositionBottomSheet.tsx
@@ -127,7 +127,7 @@ function PanelContent({ symbol }: PanelContentProps) {
 
     try {
       const closeStatus = await hyperliquidAccountActions.closePosition({
-        symbol,
+        position,
         price: liveTokenPrice,
         size: mulWorklet(position.size, closePercentage),
       });

--- a/src/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet.tsx
+++ b/src/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet.tsx
@@ -39,7 +39,7 @@ function PerpsTradeDetailsSheetContent({ trade }: { trade: HlTrade }) {
   const pnlShareImageRef = useRef<PnlShareImageHandle>(null);
   const [isSharing, setIsSharing] = useState(false);
   const market = useHyperliquidMarketsStore(state => state.getMarket(trade.symbol));
-  const assumedLeverage = market?.maxLeverage ?? 1;
+  const leverage = trade.leverage ?? market?.maxLeverage ?? 1;
   const entryPrice = trade.entryPrice ?? trade.price;
   const pnlPercentage = useMemo(
     () =>
@@ -47,9 +47,9 @@ function PerpsTradeDetailsSheetContent({ trade }: { trade: HlTrade }) {
         entryPrice,
         markPrice: trade.price,
         isLong: trade.isLong,
-        leverage: assumedLeverage,
+        leverage,
       }),
-    [assumedLeverage, entryPrice, trade.isLong, trade.price]
+    [entryPrice, leverage, trade.isLong, trade.price]
   );
 
   const handleShare = useCallback(async () => {

--- a/src/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic.tsx
+++ b/src/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic.tsx
@@ -365,7 +365,7 @@ export const PnlShareGraphic = memo(function PnlShareGraphic({
   pnlShareImageRef: React.RefObject<PnlShareImageHandle | null>;
 }) {
   const market = useHyperliquidMarketsStore(state => state.getMarket(trade.symbol));
-  const assumedLeverage = market?.maxLeverage ?? 1;
+  const leverage = trade.leverage ?? market?.maxLeverage ?? 1;
   const entryPrice = trade.entryPrice ?? trade.price;
   const assetImageUrl = market?.metadata?.iconUrl;
 
@@ -374,9 +374,9 @@ export const PnlShareGraphic = memo(function PnlShareGraphic({
       entryPrice,
       markPrice: trade.price,
       isLong: trade.isLong,
-      leverage: assumedLeverage,
+      leverage,
     });
-  }, [assumedLeverage, entryPrice, trade.isLong, trade.price]);
+  }, [entryPrice, leverage, trade.isLong, trade.price]);
 
   return (
     <PnlShareImage
@@ -385,7 +385,7 @@ export const PnlShareGraphic = memo(function PnlShareGraphic({
       pnlPercentage={pnlPercentage}
       assetSymbol={extractBaseSymbol(trade.symbol)}
       assetImageUrl={assetImageUrl}
-      leverage={assumedLeverage}
+      leverage={leverage}
       entryPrice={formatPerpAssetPrice(entryPrice)}
       markPrice={formatPerpAssetPrice(trade.price)}
       isLong={trade.isLong}

--- a/src/features/perps/stores/hlTradesStore.ts
+++ b/src/features/perps/stores/hlTradesStore.ts
@@ -8,6 +8,7 @@ import { TriggerOrderType, type HlTrade, type UserFill, type HistoricalOrder, Tr
 import { convertSide } from '../utils';
 import * as i18n from '@/languages';
 import { subWorklet } from '@/framework/core/safeMath';
+import { decodeLeverageFromCloid } from '@/features/perps/utils/hyperliquidCloid';
 
 type HlTradesParams = {
   address: Address | string | null;
@@ -90,6 +91,7 @@ function convertFillAndOrderToTrade({ fill, order }: { fill: UserFill; order: Hi
   const triggerOrderType = isTakeProfit ? TriggerOrderType.TAKE_PROFIT : isStopLoss ? TriggerOrderType.STOP_LOSS : undefined;
   const isLong = fill.dir.includes('Long');
   const entryPrice = getEntryPriceFromFill(fill);
+  const leverage = decodeLeverageFromCloid(fill.cloid || order.cloid);
 
   const trade: Omit<HlTrade, 'description' | 'executionType'> = {
     id: fill.tid,
@@ -114,6 +116,7 @@ function convertFillAndOrderToTrade({ fill, order }: { fill: UserFill; order: Hi
     triggerOrderPrice: order.triggerPx,
     netPnl: subWorklet(fill.closedPnl, fill.fee),
     isLong,
+    leverage,
   };
 
   const executionType = getTradeExecutionType(trade);

--- a/src/features/perps/stores/hyperliquidAccountStore.ts
+++ b/src/features/perps/stores/hyperliquidAccountStore.ts
@@ -91,20 +91,21 @@ async function cancelOrder({ symbol, orderId }: { symbol: string; orderId: numbe
 }
 
 async function closePosition({
-  symbol,
+  position,
   price,
   size,
 }: {
-  symbol: string;
+  position: PerpsPosition;
   price: string;
   size: string;
 }): Promise<OrderStatusResponse | undefined> {
-  const market = getMarket(symbol);
+  const market = getMarket(position.symbol);
   const result = await getHyperliquidExchangeClient().closePosition({
     assetId: market.id,
     price,
     sizeDecimals: market.decimals,
     size,
+    position,
   });
   await refetchHyperliquidStores();
   return result;

--- a/src/features/perps/types.ts
+++ b/src/features/perps/types.ts
@@ -129,6 +129,7 @@ export type HlTrade = {
   triggerOrderType?: TriggerOrderType;
   triggerOrderPrice?: string;
   isLong: boolean;
+  leverage: number | null;
 };
 
 export type TriggerOrder = {

--- a/src/features/perps/utils/hyperliquidCloid.test.ts
+++ b/src/features/perps/utils/hyperliquidCloid.test.ts
@@ -1,0 +1,29 @@
+import { isHex } from 'viem';
+import { decodeLeverageFromCloid, generateCloid } from '@/features/perps/utils/hyperliquidCloid';
+
+describe('generateCloid', () => {
+  it('returns a valid 34-char hex string with rb marker', () => {
+    const cloid = generateCloid(10);
+    expect(cloid).toHaveLength(34);
+    expect(isHex(cloid)).toBe(true);
+    expect(cloid.slice(2, 6)).toBe('7262');
+  });
+});
+
+describe('decodeLeverageFromCloid', () => {
+  it('round-trips with generateCloid', () => {
+    for (const lev of [1, 1.5, 10, 50]) {
+      expect(decodeLeverageFromCloid(generateCloid(lev))).toBe(lev);
+    }
+  });
+
+  it('decodes a known hardcoded cloid', () => {
+    expect(decodeLeverageFromCloid('0x726203e8aabbccddeeff001122334455')).toBe(10);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(decodeLeverageFromCloid(null)).toBeNull();
+    expect(decodeLeverageFromCloid('0x7262')).toBeNull();
+    expect(decodeLeverageFromCloid('0xdead03e8aabbccddeeff001122334455')).toBeNull();
+  });
+});

--- a/src/features/perps/utils/hyperliquidCloid.ts
+++ b/src/features/perps/utils/hyperliquidCloid.ts
@@ -1,0 +1,48 @@
+import { type Hex, isHex } from 'viem';
+
+const CLOID_HEX_LENGTH = 34;
+const MARKER_HEX = '7262'; // "rb" (rainbow) marker
+const MARKER_HEX_LENGTH = MARKER_HEX.length;
+const LEVERAGE_HEX_LENGTH = 4;
+const RANDOM_HEX_LENGTH = 24;
+const MIN_LEVERAGE_BPS = 100;
+const MAX_LEVERAGE_BPS = 0xffff;
+
+export function generateCloid(leverage: number): Hex {
+  const leverageBps = toLeverageBps(leverage);
+  const leverageHex = leverageBps.toString(16).padStart(LEVERAGE_HEX_LENGTH, '0');
+  const randomHex = createRandomHex(RANDOM_HEX_LENGTH);
+
+  return `0x${MARKER_HEX}${leverageHex}${randomHex}` as Hex;
+}
+
+export function decodeLeverageFromCloid(cloid?: string | null): number | null {
+  if (!cloid || !isValidCloidHex(cloid)) return null;
+  if (cloid.slice(2, 2 + MARKER_HEX_LENGTH).toLowerCase() !== MARKER_HEX) return null;
+
+  const leverageHexStart = 2 + MARKER_HEX_LENGTH;
+  const leverageHexEnd = leverageHexStart + LEVERAGE_HEX_LENGTH;
+  const leverageBps = Number.parseInt(cloid.slice(leverageHexStart, leverageHexEnd), 16);
+  if (!Number.isFinite(leverageBps) || leverageBps < MIN_LEVERAGE_BPS || leverageBps > MAX_LEVERAGE_BPS) return null;
+
+  return leverageBps / 100;
+}
+
+function toLeverageBps(leverage: number): number {
+  if (!Number.isFinite(leverage)) return MIN_LEVERAGE_BPS;
+  const leverageBps = Math.round(leverage * 100);
+  return Math.max(MIN_LEVERAGE_BPS, Math.min(MAX_LEVERAGE_BPS, leverageBps));
+}
+
+function createRandomHex(hexLength: number): string {
+  const bytes = new Uint8Array(hexLength / 2);
+  crypto.getRandomValues(bytes);
+
+  return Array.from(bytes)
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function isValidCloidHex(cloid: string): boolean {
+  return cloid.length === CLOID_HEX_LENGTH && isHex(cloid);
+}

--- a/src/features/perps/utils/orders.ts
+++ b/src/features/perps/utils/orders.ts
@@ -73,6 +73,7 @@ export function buildMarketOrder({
   slippageBips = DEFAULT_SLIPPAGE_BIPS,
   reduceOnly = false,
   tif = 'FrontendMarket',
+  clientOrderId,
 }: {
   assetId: number;
   side: PerpPositionSide;
@@ -82,6 +83,7 @@ export function buildMarketOrder({
   slippageBips?: number;
   reduceOnly?: boolean;
   tif?: TIF;
+  clientOrderId?: OrderParams['c'];
 }): OrderParams {
   const marketType = getMarketType(assetId);
   const priceWithSlippage = calculatePriceWithSlippage({ price, side, slippageBips });
@@ -95,6 +97,7 @@ export function buildMarketOrder({
     s: formattedSize,
     r: reduceOnly,
     t: { limit: { tif } },
+    ...(clientOrderId ? { c: clientOrderId } : {}),
   };
 }
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Hyperliquid does not provide the leverage of a given position for an order / fill object. They do allow for setting a custom `cloid` when submitting orders. Previously we did not pass in our own `cloid`.

This change uses the `cloid` to encode the leverage of the position related to the order being submitted. This allows us to display the correct leverage on the `PerpsTradeDetailsSheet` for all future orders. Previously we just displayed the maximum leverage for the asset, which we still fallback to when there is no `cloid`.

This solution is a bit hackish, but is much more robust than the only alternative, which is persisting the leverage related to orders locally.

This will also allow us to display the leverage in the `TradeListItem` in the future, which the original designs had.

## Screen recordings / screenshots

Only visual change is the leverage number displayed on the `PerpsTradeDetailsSheet`