### PR TITLE
refactor: migrate RevokeDelegationPanel to meteorology gas + parallel multi-chain revoke

### DIFF
--- a/src/hooks/useShouldRevokeDelegation.ts
+++ b/src/hooks/useShouldRevokeDelegation.ts
@@ -3,7 +3,7 @@ import { shouldRevokeDelegation } from '@rainbow-me/delegation';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { Navigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
-import { RevokeReason } from '@/screens/delegation/RevokeDelegationPanel';
+import { RevokeReason } from '@/screens/delegation/types';
 import { DELEGATION, getExperimentalFlag } from '@/config';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { EthereumWalletType } from '@/helpers/walletTypes';

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3066,7 +3066,11 @@
           "done": "Done",
           "next": "Next",
           "try_again": "Try Again",
-          "gas_fee": "to revoke on %{chainName}"
+          "gas_fee": "to revoke on %{chainName}",
+          "gas_fee_multi": "to revoke on %{count} networks",
+          "insufficient_gas": "Insufficient Gas",
+          "estimating_gas_fee": "Estimating gas fee...",
+          "simulated": "This is a simulated revoke"
         }
       },
       "balance_title": "Balance",

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -43,7 +43,7 @@ import { type ScrollView } from 'react-native';
 import { type HlTrade, type PerpMarket, type PerpsPosition, type TriggerOrderSource, type TriggerOrderType } from '@/features/perps/types';
 import { type PolymarketPosition } from '@/features/polymarket/types';
 import { type PolymarketEvent, type PolymarketMarket, type PolymarketMarketEvent } from '@/features/polymarket/types/polymarket-event';
-import { type RevokeReason } from '@/screens/delegation/RevokeDelegationPanel';
+import { type RevokeReason } from '@/screens/delegation/types';
 
 export type PortalSheetProps = {
   children: React.FC;

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletDelegations.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletDelegations.tsx
@@ -29,7 +29,7 @@ import {
 } from '@rainbow-me/delegation';
 import { backendNetworksActions } from '@/state/backendNetworks/backendNetworks';
 import type { Address } from 'viem';
-import { RevokeReason } from '@/screens/delegation/RevokeDelegationPanel';
+import { RevokeReason } from '@/screens/delegation/types';
 import { navigate } from '@/navigation/Navigation';
 
 type ViewWalletDelegationsParams = {

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -30,7 +30,7 @@ import { unsubscribeAllNotifications } from '@/notifications/settings/settings';
 import { getFCMToken } from '@/notifications/tokens';
 import { analyzeReactQueryStore, clearReactQueryCache } from '@/react-query/reactQueryUtils';
 import { resetCache as resetDelegationCache, getDelegations, DelegationStatus } from '@rainbow-me/delegation';
-import { RevokeReason } from '@/screens/delegation/RevokeDelegationPanel';
+import { RevokeReason } from '@/screens/delegation/types';
 import { ChainId } from '@/state/backendNetworks/types';
 import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 import { nonceActions } from '@/state/nonces';

--- a/src/screens/delegation/RevokeDelegationPanel.tsx
+++ b/src/screens/delegation/RevokeDelegationPanel.tsx
@@ -24,37 +24,6 @@ import { opacity } from '@/framework/ui/utils/opacity';
 import { convertAmountToNativeDisplayWorklet } from '@/helpers/utilities';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 
-/**
- * Reasons for revoking delegation - determines the panel's appearance and messaging
- */
-export enum RevokeReason {
-  // User-triggered
-  /** Toggle off Smart Wallet — revokes all chains */
-  DISABLE_SMART_WALLET = 'disable_smart_wallet',
-  /** Disable a single Rainbow-delegated chain */
-  DISABLE_SINGLE_NETWORK = 'disable_single_network',
-  /** Disable a third-party delegated chain */
-  DISABLE_THIRD_PARTY = 'disable_third_party',
-  // Backend-triggered (from shouldRevokeDelegation())
-  /** Contract has a known exploit */
-  ALERT_VULNERABILITY = 'alert_vulnerability',
-  /** Contract has a known bug */
-  ALERT_BUG = 'alert_bug',
-  /** Unrecognized revoke reason from backend */
-  ALERT_UNRECOGNIZED = 'alert_unrecognized',
-  /** Catch-all for unspecified backend revoke signals */
-  ALERT_UNSPECIFIED = 'alert_unspecified',
-}
-
-export type RevokeStatus =
-  | 'notReady' // preparing the data necessary to revoke
-  | 'ready' // ready to revoke state
-  | 'revoking' // user has pressed the revoke button
-  | 'pending' // revoke has been submitted but we don't have a tx hash
-  | 'success' // revoke has been submitted and we have a tx hash
-  | 'recoverableError' // revoke or auth has failed, can try again
-  | 'unrecoverableError'; // revoke has failed, unrecoverable error
-
 type SheetContent = {
   title: string;
   subtitle: string;

--- a/src/screens/delegation/types.ts
+++ b/src/screens/delegation/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Reasons for revoking delegation - determines the panel's appearance and messaging
+ */
+export enum RevokeReason {
+  // User-triggered
+  /** Toggle off Smart Wallet — revokes all chains */
+  DISABLE_SMART_WALLET = 'disable_smart_wallet',
+  /** Disable a single Rainbow-delegated chain */
+  DISABLE_SINGLE_NETWORK = 'disable_single_network',
+  /** Disable a third-party delegated chain */
+  DISABLE_THIRD_PARTY = 'disable_third_party',
+  // Backend-triggered (from shouldRevokeDelegation())
+  /** Contract has a known exploit */
+  ALERT_VULNERABILITY = 'alert_vulnerability',
+  /** Contract has a known bug */
+  ALERT_BUG = 'alert_bug',
+  /** Unrecognized revoke reason from backend */
+  ALERT_UNRECOGNIZED = 'alert_unrecognized',
+  /** Catch-all for unspecified backend revoke signals */
+  ALERT_UNSPECIFIED = 'alert_unspecified',
+}
+
+export type RevokeStatus =
+  | 'notReady' // no delegations to revoke
+  | 'ready' // ready to revoke
+  | 'revoking' // at least one chain is in-flight
+  | 'success' // all chains succeeded
+  | 'error' // at least one chain failed (retry-able)
+  | 'insufficientGas'; // all remaining chains lack gas (non-retry-able)
+
+export type ChainRevokeStatus =
+  | 'pending' // not yet attempted
+  | 'revoking' // tx in-flight
+  | 'success' // tx confirmed
+  | 'error' // tx failed, can retry
+  | 'insufficientGas'; // skipped, native balance too low

--- a/src/screens/delegation/useRevokeDelegation.test.ts
+++ b/src/screens/delegation/useRevokeDelegation.test.ts
@@ -1,0 +1,77 @@
+jest.mock('@/utils/haptics', () => ({
+  __esModule: true,
+  default: {
+    notificationError: jest.fn(),
+    notificationSuccess: jest.fn(),
+  },
+}));
+jest.mock('@/model/wallet', () => ({ loadWallet: jest.fn() }));
+jest.mock('@/handlers/web3', () => ({ getProvider: jest.fn() }));
+jest.mock('@/state/nonces', () => ({ getNextNonce: jest.fn() }));
+jest.mock('@/__swaps__/utils/meteorology', () => ({ getMeteorologyCachedData: jest.fn() }));
+jest.mock('@/resources/meteorology/classification', () => ({ isLegacyMeteorologyFeeData: jest.fn() }));
+jest.mock('@rainbow-me/delegation', () => ({ executeRevokeDelegation: jest.fn() }));
+jest.mock('@/state/assets/userAssets', () => ({
+  userAssetsStore: {
+    getState: () => ({
+      getNativeAssetForChain: jest.fn(),
+    }),
+  },
+}));
+jest.mock('@/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+import { ChainId } from '@/state/backendNetworks/types';
+import { partitionChainsByGasAvailability } from './useRevokeDelegation';
+
+describe('partitionChainsByGasAvailability', () => {
+  const address = '0x123';
+
+  it('marks cached zero native balance as insufficient without RPC fallback', async () => {
+    const getChainBalance = jest.fn(async () => 100n);
+    const result = await partitionChainsByGasAvailability({
+      chains: [{ chainId: ChainId.gnosis }],
+      address,
+      getNativeAssetBalance: () => '0',
+      getChainBalance,
+    });
+
+    expect(result.insufficientGasChainIds).toEqual([ChainId.gnosis]);
+    expect(result.actionableChains).toEqual([]);
+    expect(getChainBalance).not.toHaveBeenCalled();
+  });
+
+  it('falls back to provider balance when cached native asset is missing', async () => {
+    const getChainBalance = jest.fn(async (chainId: ChainId) => (chainId === ChainId.gnosis ? 0n : 1n));
+    const result = await partitionChainsByGasAvailability({
+      chains: [{ chainId: ChainId.gnosis }, { chainId: ChainId.mainnet }],
+      address,
+      getNativeAssetBalance: () => null,
+      getChainBalance,
+    });
+
+    expect(result.insufficientGasChainIds).toEqual([ChainId.gnosis]);
+    expect(result.actionableChains).toEqual([{ chainId: ChainId.mainnet }]);
+    expect(getChainBalance).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps chain actionable if balance lookup fails', async () => {
+    const getChainBalance = jest.fn(async () => {
+      throw new Error('rpc failed');
+    });
+    const result = await partitionChainsByGasAvailability({
+      chains: [{ chainId: ChainId.gnosis }],
+      address,
+      getNativeAssetBalance: () => undefined,
+      getChainBalance,
+    });
+
+    expect(result.insufficientGasChainIds).toEqual([]);
+    expect(result.actionableChains).toEqual([{ chainId: ChainId.gnosis }]);
+  });
+});

--- a/src/screens/delegation/useRevokeDelegation.ts
+++ b/src/screens/delegation/useRevokeDelegation.ts
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { logger, RainbowError } from '@/logger';
+import haptics from '@/utils/haptics';
+import { executeRevokeDelegation } from '@rainbow-me/delegation';
+import { loadWallet } from '@/model/wallet';
+import { getProvider } from '@/handlers/web3';
+import { getNextNonce } from '@/state/nonces';
+import type { ChainId } from '@/state/backendNetworks/types';
+import { getMeteorologyCachedData } from '@/__swaps__/utils/meteorology';
+import { isLegacyMeteorologyFeeData } from '@/resources/meteorology/classification';
+import { userAssetsStore } from '@/state/assets/userAssets';
+import type { RevokeStatus, ChainRevokeStatus } from './types';
+
+type LoadedWallet = Exclude<Awaited<ReturnType<typeof loadWallet>>, null>;
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Per-chain revocation status tracking. Aggregates individual ChainRevokeStatus values (see ./types) into a single RevokeStatus. */
+function useChainsStatus(delegationsToRevoke: { chainId: number }[]) {
+  const [chainStatuses, setChainStatuses] = useState<Record<number, ChainRevokeStatus>>(() =>
+    Object.fromEntries(delegationsToRevoke.map(d => [d.chainId, 'pending']))
+  );
+  const [success, setSuccess] = useState(false);
+
+  const delegationChainIds = useMemo(
+    () =>
+      delegationsToRevoke
+        .map(d => d.chainId)
+        .sort()
+        .join(','),
+    [delegationsToRevoke]
+  );
+
+  useEffect(() => {
+    setChainStatuses(Object.fromEntries(delegationsToRevoke.map(d => [d.chainId, 'pending'])));
+    setSuccess(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [delegationChainIds]);
+
+  const revokeStatus: RevokeStatus = useMemo(() => {
+    if (success) return 'success';
+    const statuses = Object.values(chainStatuses);
+    if (statuses.length === 0) return 'ready';
+    if (statuses.some(s => s === 'revoking')) return 'revoking';
+    if (statuses.every(s => s === 'success')) return 'success';
+    if (statuses.some(s => s === 'insufficientGas') && statuses.every(s => s === 'insufficientGas' || s === 'success'))
+      return 'insufficientGas';
+    if (statuses.some(s => s === 'error' || s === 'insufficientGas')) return 'error';
+    return 'ready';
+  }, [chainStatuses, success]);
+
+  const setChainStatus = useCallback((status: ChainRevokeStatus | 'success', chainIds?: Iterable<number>) => {
+    if (!chainIds) {
+      if (status === 'success') setSuccess(true);
+      return;
+    }
+    setChainStatuses(prev => {
+      const next = { ...prev };
+      for (const cid of chainIds) {
+        if (status === 'insufficientGas' && next[cid] === 'success') continue;
+        next[cid] = status as ChainRevokeStatus;
+      }
+      return next;
+    });
+  }, []);
+
+  const mergeChainStatuses = useCallback((results: Record<number, ChainRevokeStatus>) => {
+    setChainStatuses(prev => ({ ...prev, ...results }));
+  }, []);
+
+  return {
+    revokeStatus,
+    chainStatuses,
+    setChainStatus,
+    mergeChainStatuses,
+  };
+}
+
+/** Partitions chains by native gas balance via userAssetsStore (src/state/assets/userAssets). */
+function useActionableChains() {
+  return useCallback((chains: { chainId: number }[]) => {
+    const insufficientGasChainIds: number[] = [];
+    const actionableChains: { chainId: number }[] = [];
+    for (const d of chains) {
+      const nativeAsset = userAssetsStore.getState().getNativeAssetForChain(d.chainId as ChainId);
+      if (nativeAsset && Number(nativeAsset.balance?.amount ?? 0) <= 0) {
+        insufficientGasChainIds.push(d.chainId);
+      } else {
+        actionableChains.push(d);
+      }
+    }
+    return { insufficientGasChainIds, actionableChains };
+  }, []);
+}
+
+/** Fires revocations in parallel via executeRevokeDelegation (@rainbow-me/delegation). Uses getMeteorologyCachedData for EIP-1559 fees and getNextNonce (src/state/nonces) per chain. */
+async function executeRevokeAll(
+  chains: { chainId: number }[],
+  address: string,
+  wallet: LoadedWallet
+): Promise<{ chainStatuses: Record<number, ChainRevokeStatus>; anyFailed: boolean }> {
+  const results = await Promise.allSettled(
+    chains.map(async d => {
+      const chainId = d.chainId as ChainId;
+      // Reconnect the wallet to this chain's provider so the signer targets the right RPC
+      const chainProvider = getProvider({ chainId });
+      const chainSigner = wallet.connect(chainProvider);
+
+      const cachedMeteorology = getMeteorologyCachedData(chainId);
+      let maxFeePerGas: bigint | undefined;
+      let maxPriorityFeePerGas: bigint | undefined;
+
+      if (cachedMeteorology && !isLegacyMeteorologyFeeData(cachedMeteorology)) {
+        maxFeePerGas = BigInt(cachedMeteorology.data.baseFeeSuggestion) + BigInt(cachedMeteorology.data.maxPriorityFeeSuggestions.fast);
+        maxPriorityFeePerGas = BigInt(cachedMeteorology.data.maxPriorityFeeSuggestions.fast);
+      }
+
+      const nonce = await getNextNonce({ address, chainId });
+      const result = await executeRevokeDelegation({
+        // @ts-expect-error SDK SignerLike requires privateKey; ethers signer satisfies this at runtime
+        signer: chainSigner,
+        provider: chainProvider,
+        chainId,
+        // Allow undefined fees so SDK/provider can apply fallback values.
+        transactionOptions: { maxFeePerGas, maxPriorityFeePerGas, gasLimit: null } as unknown as {
+          maxFeePerGas: bigint;
+          maxPriorityFeePerGas: bigint;
+          gasLimit: bigint | null;
+        },
+        nonce,
+      });
+
+      logger.info('Delegation removed successfully', { hash: result.hash, chainId });
+      return { chainId };
+    })
+  );
+
+  const chainStatuses: Record<number, ChainRevokeStatus> = {};
+  let anyFailed = false;
+  results.forEach((r, i) => {
+    const cid = chains[i].chainId;
+    if (r.status === 'fulfilled') {
+      chainStatuses[cid] = 'success';
+    } else {
+      chainStatuses[cid] = 'error';
+      anyFailed = true;
+      logger.error(new RainbowError('Failed to revoke delegation'), {
+        error: r.reason,
+        chainId: cid,
+      });
+    }
+  });
+
+  return { chainStatuses, anyFailed };
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────
+
+type UseRevokeDelegationParams = {
+  address: string | undefined;
+  delegationsToRevoke: { chainId: number }[];
+  onSuccess: (() => void) | undefined;
+};
+
+type UseRevokeDelegationResult = {
+  revokeStatus: RevokeStatus;
+  handleRevoke: () => void;
+  revokeCount: number;
+};
+
+export function useRevokeDelegation({ address, delegationsToRevoke, onSuccess }: UseRevokeDelegationParams): UseRevokeDelegationResult {
+  const { revokeStatus, chainStatuses, setChainStatus, mergeChainStatuses } = useChainsStatus(delegationsToRevoke);
+  const getActionableChains = useActionableChains();
+
+  const revokeChains = useCallback(
+    async (chains: { chainId: number }[]) => {
+      if (!address || chains.length === 0) return;
+
+      const { insufficientGasChainIds, actionableChains } = getActionableChains(chains);
+      if (actionableChains.length === 0) {
+        setChainStatus('insufficientGas', insufficientGasChainIds);
+        return;
+      }
+
+      setChainStatus(
+        'revoking',
+        actionableChains.map(d => d.chainId)
+      );
+      setChainStatus('insufficientGas', insufficientGasChainIds);
+
+      // Load wallet once so biometrics only prompts a single time
+      const provider = getProvider({ chainId: actionableChains[0].chainId as ChainId });
+      const wallet = await loadWallet({ address, provider });
+      if (!wallet) {
+        setChainStatus(
+          'error',
+          actionableChains.map(d => d.chainId)
+        );
+        haptics.notificationError();
+        return;
+      }
+
+      const { chainStatuses: newStatuses, anyFailed } = await executeRevokeAll(actionableChains, address, wallet);
+      mergeChainStatuses(newStatuses);
+      haptics[anyFailed ? 'notificationError' : 'notificationSuccess']();
+    },
+    [address, getActionableChains, setChainStatus, mergeChainStatuses]
+  );
+
+  const handleRetry = useCallback(async () => {
+    const failedChains = delegationsToRevoke.filter(d => chainStatuses[d.chainId] === 'error');
+    if (failedChains.length === 0) return;
+    await revokeChains(failedChains);
+  }, [delegationsToRevoke, chainStatuses, revokeChains]);
+
+  const onSuccessRef = useRef(onSuccess);
+  onSuccessRef.current = onSuccess;
+  useEffect(() => {
+    if (revokeStatus === 'success') {
+      onSuccessRef.current?.();
+    }
+  }, [revokeStatus]);
+
+  const handleRevoke = useCallback(() => {
+    if (revokeStatus === 'ready') {
+      if (delegationsToRevoke.length === 0) {
+        setChainStatus('success');
+        return;
+      }
+      revokeChains(delegationsToRevoke);
+    } else if (revokeStatus === 'error') {
+      handleRetry();
+    }
+  }, [revokeStatus, delegationsToRevoke, setChainStatus, revokeChains, handleRetry]);
+
+  return {
+    revokeStatus,
+    handleRevoke,
+    revokeCount: delegationsToRevoke.length,
+  };
+}

--- a/src/screens/delegation/useRevokeDelegationGas.ts
+++ b/src/screens/delegation/useRevokeDelegationGas.ts
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { createQueryKey, type QueryFunctionArgs } from '@/react-query';
+import { getProvider } from '@/handlers/web3';
+import { safeBigInt } from '@/__swaps__/screens/Swap/hooks/useEstimatedGasFee';
+import { useMeteorologySuggestionMultichain } from '@/__swaps__/utils/meteorology';
+import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
+import ethereumUtils from '@/utils/ethereumUtils';
+import { add, convertAmountToNativeDisplayWorklet, multiply } from '@/helpers/utilities';
+import { formatUnits } from 'viem';
+import { userAssetsStore } from '@/state/assets/userAssets';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import type { ChainId } from '@/state/backendNetworks/types';
+import { GasSpeed } from '@/__swaps__/types/gas';
+
+// Keep preview gas estimation aligned with delegation SDK buffering for authorization txs (+50k gas).
+const REVOKE_GAS_BUFFER_MINIMUM = 50_000n;
+
+// ///////////////////////////////////////////////
+// Query Key
+
+const estimateRevokeDelegationGasLimitQueryKey = ({ chainId, address }: { chainId: ChainId; address: string | undefined }) =>
+  createQueryKey('estimateRevokeDelegationGasLimit', { chainId, address });
+
+type EstimateRevokeDelegationGasLimitQueryKey = ReturnType<typeof estimateRevokeDelegationGasLimitQueryKey>;
+type EstimateRevokeDelegationGasLimitQueryFunctionArgs = QueryFunctionArgs<typeof estimateRevokeDelegationGasLimitQueryKey>;
+
+// ///////////////////////////////////////////////
+// Query Function
+
+async function estimateRevokeDelegationGasLimitQueryFunction({
+  queryKey: [{ chainId, address }],
+}: EstimateRevokeDelegationGasLimitQueryFunctionArgs) {
+  if (!address || !chainId) return undefined;
+
+  const provider = getProvider({ chainId });
+  const estimate = await provider.estimateGas({ from: address, to: address });
+  const estimatedGas = estimate.toBigInt();
+  const multiplied = (estimatedGas * 12n) / 10n;
+  const additive = estimatedGas + REVOKE_GAS_BUFFER_MINIMUM;
+  return (multiplied > additive ? multiplied : additive).toString();
+}
+
+/** Multi-chain aggregation: fetches gas limits + meteorology for all chains in parallel, sums fees */
+export function useRevokeDelegationGasFee(delegations: { chainId: number }[], address: string | undefined): string | undefined {
+  const nativeCurrency = userAssetsStoreManager(state => state.currency);
+  const chainIds = useMemo(() => delegations.map(d => d.chainId as ChainId), [delegations]);
+
+  const estimateRevokeDelegationGasLimitQueries = useQueries({
+    queries: chainIds.map(chainId => {
+      const queryKey: EstimateRevokeDelegationGasLimitQueryKey = estimateRevokeDelegationGasLimitQueryKey({ chainId, address });
+
+      return {
+        queryKey,
+        queryFn: estimateRevokeDelegationGasLimitQueryFunction,
+        enabled: !!address && !!chainId,
+      };
+    }),
+  });
+
+  const meteorologyFastQueries = useMeteorologySuggestionMultichain({ chainIds, speed: GasSpeed.FAST, enabled: !!address });
+
+  return useMemo(() => {
+    let total = '0';
+    for (let i = 0; i < chainIds.length; i++) {
+      const estimatedGasLimit = estimateRevokeDelegationGasLimitQueries[i]?.data;
+      const chainId = chainIds[i];
+
+      if (!estimatedGasLimit) continue;
+
+      const gasSettings = meteorologyFastQueries[i]?.data;
+      if (!gasSettings) continue;
+
+      const gasFeeWei = calculateGasFeeWorklet(gasSettings, estimatedGasLimit);
+      if (isNaN(Number(gasFeeWei))) continue;
+
+      const chainNativeAsset = useBackendNetworksStore.getState().getChainsNativeAsset()[chainId];
+      if (chainNativeAsset?.decimals == null) continue;
+      const gasFeeNativeToken = formatUnits(safeBigInt(gasFeeWei), chainNativeAsset.decimals);
+      const userNativeAsset = userAssetsStore.getState().getNativeAssetForChain(chainId);
+      const nativeAssetPrice = (userNativeAsset?.price?.value || ethereumUtils.getPriceOfNativeAssetForNetwork({ chainId }))?.toString();
+
+      if (!nativeAssetPrice) continue;
+
+      total = add(total, multiply(nativeAssetPrice, gasFeeNativeToken));
+    }
+    return convertAmountToNativeDisplayWorklet(total, nativeCurrency, true);
+  }, [chainIds, estimateRevokeDelegationGasLimitQueries, meteorologyFastQueries, nativeCurrency]);
+}


### PR DESCRIPTION
## What changed

Splits `RevokeDelegationPanel` into a presentation layer + two hooks, and migrates gas from the legacy `useGas` polling hook to meteorology.

- **`RevokeDelegationPanel.tsx`** is now a pure presenter. All tx execution, state management, and gas logic moved out.
- **`useRevokeDelegation`** (new) handles the full lifecycle: per-chain status tracking, native-balance preflight (skips chains with no gas instead of failing), parallel `Promise.allSettled` execution across all chains, single wallet load (one biometric prompt), and retry of only failed chains.
- **`useRevokeDelegationGas`** (new) estimates fees across all chains using `useMeteorologySuggestionMultichain` + `estimateGas`, sums them into one display value with the same gas buffer the delegation SDK applies.
- **`meteorology.ts`** adds `useMeteorologyMultichain`, `useMeteorologySuggestionMultichain`, and `getMeteorologyCachedData` for multi-chain and non-React cache reads.
- **`types.ts`** (new) extracts `RevokeReason`, `RevokeStatus`, and `ChainRevokeStatus` so they're importable without pulling in the panel.
- **DevSection** passes real delegations to the simulated revoke panel per reason (vulnerability/bug use Rainbow delegations, third-party uses third-party, etc.) instead of hardcoded `{ chainId: mainnet }` fallbacks.
- New i18n keys for multi-network gas display, insufficient gas, and estimating state.

## Why

The old panel executed chains one at a time via component-level index state, prompted biometrics per chain, used the legacy gas hook, and had no concept of insufficient gas. This was slow for multi-chain revokes and had poor error UX.

## Benefit

- Parallel multi-chain revoke with a single biometric prompt
- `insufficientGas` as a first-class state with clear messaging
- Gas estimates match what the delegation SDK actually builds
- Clean separation makes the panel trivially testable