### PR TITLE
fix: WelcomeScreen CTA shadow/text layering on Android 9

### DIFF
--- a/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
@@ -1,5 +1,5 @@
 import { type ButtonPressAnimationProps } from '@/components/animations/ButtonPressAnimation/types';
-import { type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import React from 'react';
 import styled from '@/framework/ui/styled-thing';
@@ -8,6 +8,9 @@ import { Emoji, Text } from '@/components/text';
 import { type ThemeContextProps } from '@/theme';
 import { RowWithMargins } from '@/components/layout';
 import { shadow } from '@/styles';
+import { IS_ANDROID } from '@/env';
+
+const IS_ANDROID_9_OR_OLDER = IS_ANDROID && Number(Platform.Version) <= 28;
 
 const ButtonContainer = styled(Reanimated.View)({
   borderRadius: ({ height }: { height: number }) => height / 2,
@@ -44,7 +47,7 @@ const DarkShadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: {
   width: 236,
 }));
 const Shadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: { theme: ThemeContextProps }) => ({
-  ...shadow.buildAsObject(0, 5, 15, colors.shadow, isDarkMode ? 0 : 0.4),
+  ...shadow.buildAsObject(0, IS_ANDROID_9_OR_OLDER ? 3 : 5, IS_ANDROID_9_OR_OLDER ? 10 : 15, colors.shadow, isDarkMode ? 0 : 0.4),
   borderRadius: 30,
   height: 60,
   position: 'absolute',
@@ -55,7 +58,8 @@ const Shadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: { the
         top: -3,
       }
     : {
-        elevation: 30,
+        elevation: IS_ANDROID_9_OR_OLDER ? 18 : 30,
+        zIndex: 0,
       }),
 }));
 
@@ -83,7 +87,7 @@ export const WelcomeScreenRainbowButton = ({
     <ButtonPressAnimation onPress={onPress} radiusAndroid={height / 2} scaleTo={0.9} {...props}>
       {ios && <DarkShadow style={darkShadowStyle} />}
       <Shadow style={shadowStyle} />
-      <ButtonContainer height={height} style={style}>
+      <ButtonContainer height={height} style={[style, IS_ANDROID_9_OR_OLDER && styles.legacyButtonContainer]}>
         <ButtonContent>
           <ButtonEmoji name={emoji} />
           <ButtonLabel textColor={textColor}>{text}</ButtonLabel>
@@ -92,3 +96,10 @@ export const WelcomeScreenRainbowButton = ({
     </ButtonPressAnimation>
   );
 };
+
+const styles = StyleSheet.create({
+  legacyButtonContainer: {
+    elevation: 19,
+    zIndex: 1,
+  },
+});

--- a/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
@@ -83,7 +83,7 @@ export const WelcomeScreenRainbowButton = ({
     <ButtonPressAnimation onPress={onPress} radiusAndroid={height / 2} scaleTo={0.9} {...props}>
       {ios && <DarkShadow style={darkShadowStyle} />}
       <Shadow style={shadowStyle} />
-      <ButtonContainer height={height} style={[style, { elevation: 30 }]}>
+      <ButtonContainer height={height} style={[style, { elevation: 31, shadowColor: 'transparent' }]}>
         <ButtonContent>
           <ButtonEmoji name={emoji} />
           <ButtonLabel textColor={textColor}>{text}</ButtonLabel>

--- a/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
@@ -1,5 +1,5 @@
 import { type ButtonPressAnimationProps } from '@/components/animations/ButtonPressAnimation/types';
-import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { type StyleProp, type ViewStyle } from 'react-native';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import React from 'react';
 import styled from '@/framework/ui/styled-thing';
@@ -8,9 +8,6 @@ import { Emoji, Text } from '@/components/text';
 import { type ThemeContextProps } from '@/theme';
 import { RowWithMargins } from '@/components/layout';
 import { shadow } from '@/styles';
-import { IS_ANDROID } from '@/env';
-
-const IS_ANDROID_9_OR_OLDER = IS_ANDROID && Number(Platform.Version) <= 28;
 
 const ButtonContainer = styled(Reanimated.View)({
   borderRadius: ({ height }: { height: number }) => height / 2,
@@ -47,7 +44,7 @@ const DarkShadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: {
   width: 236,
 }));
 const Shadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: { theme: ThemeContextProps }) => ({
-  ...shadow.buildAsObject(0, IS_ANDROID_9_OR_OLDER ? 3 : 5, IS_ANDROID_9_OR_OLDER ? 10 : 15, colors.shadow, isDarkMode ? 0 : 0.4),
+  ...shadow.buildAsObject(0, 5, 15, colors.shadow, isDarkMode ? 0 : 0.4),
   borderRadius: 30,
   height: 60,
   position: 'absolute',
@@ -58,8 +55,7 @@ const Shadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: { the
         top: -3,
       }
     : {
-        elevation: IS_ANDROID_9_OR_OLDER ? 18 : 30,
-        zIndex: 0,
+        elevation: 30,
       }),
 }));
 
@@ -87,7 +83,7 @@ export const WelcomeScreenRainbowButton = ({
     <ButtonPressAnimation onPress={onPress} radiusAndroid={height / 2} scaleTo={0.9} {...props}>
       {ios && <DarkShadow style={darkShadowStyle} />}
       <Shadow style={shadowStyle} />
-      <ButtonContainer height={height} style={[style, IS_ANDROID_9_OR_OLDER && styles.legacyButtonContainer]}>
+      <ButtonContainer height={height} style={[style, { elevation: 30 }]}>
         <ButtonContent>
           <ButtonEmoji name={emoji} />
           <ButtonLabel textColor={textColor}>{text}</ButtonLabel>
@@ -96,10 +92,3 @@ export const WelcomeScreenRainbowButton = ({
     </ButtonPressAnimation>
   );
 };
-
-const styles = StyleSheet.create({
-  legacyButtonContainer: {
-    elevation: 19,
-    zIndex: 1,
-  },
-});


### PR DESCRIPTION
## Summary

Fix CTA button elevation rendering issues on Android version 9 where the shadow and button layers were incorrectly composed.

## Background / Problem

On certain devices (e.g. Galaxy S8+ on Android 9), the CTA button animation renders incorrectly due to how Android handles elevation and shadow composition in hwui
When a child view has elevation but its parent does not, the rendering order can break, causing:
* Incorrect shadow positioning
* Visual glitches during animation
* Inconsistent behavior across Android versions/devices

## Solution (High-Level)
Instead of keeping the button and shadow at the same Z level, we explicitly separate them:
* The shadow layer remains below
* The button is elevated above it

## Screen recordings / screenshots

Before:
- Galaxy S8+ dark mode: 

https://github.com/user-attachments/assets/2fb53fc5-a693-4107-98ac-bf0422c0af6b


- Galaxy S8+ light mode: 

https://github.com/user-attachments/assets/caf9fccb-220d-4487-b6f5-3d5e85666a86

After:
- Galaxy S8+ dark mode: 

https://github.com/user-attachments/assets/e8733ee2-f42f-4dca-a7de-a5b0151d0a3e


- Galaxy S8+ light: 
https://github.com/user-attachments/assets/200839c7-91b4-4275-9d70-a160651c9e56


Comparison controls:
- Pixel 5 dark mode: 

https://github.com/user-attachments/assets/9800923d-2039-4fdf-b3ae-06ee385f98d3


- Pixel 5 light mode: 

https://github.com/user-attachments/assets/9a71fb74-fb55-4a06-bc17-4a45be01096f



- Galaxy S20 FE dark mode: 

https://github.com/user-attachments/assets/5eee8c86-1d08-46fd-a114-59754d459b5c

- Galaxy S20 FE light mode: 

https://github.com/user-attachments/assets/8651b800-735d-4844-98bf-db43aaba66a5


## What to test

- Galaxy S8+ (Android 9, Samsung One UI version 1.0):
  - CTA text/icon are visible.
  - Shadow is outside border only (no inner glow/double border).
- Galaxy S20 FE / Pixel 5:
  - Existing modern shadow look remains unchanged.
- iOS sanity:
  - CTA rendering unchanged.
- Dark and light mode on all tested devices.


## Test device details

### Samsung Galaxy S8+ (physical device)

- Model: SM-G955F
- Android version: 9
- One UI version: 1.0
- Build number: PPR1.180610.011.G955FXXUCDUD1
- Kernel version: 4.4.111-21427293
- Security patch level: 1 April 2021

### Samsung Galaxy S20 FE (physical device)

- Model: SM-G780F
- Android version: 13
- One UI version: 5.1
- Build number: TP1A.220624.014.G780FXXSNFYF2
- Kernel version: 4.19.87-27231340
- Security patch level: 1 July 2025

### Google Pixel 5 (Android Emulator)

- Device name/model: sdk_gphone_arm64
- Android version: 11
- Build number: sdk_gphone_arm64-userdebug 11 RSR1.210722.002 7602718 dev-keys