### PR TITLE
fix: fix Android font rendering and share functionality

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2620,8 +2620,30 @@ PODS:
     - ReactCommon/turbomodule/core
     - Sentry/HybridSDK (= 8.52.1)
     - Yoga
-  - RNShare (8.2.1):
+  - RNShare (12.2.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNSound (0.11.2):
     - React-Core
     - RNSound/Core (= 0.11.2)
@@ -3397,7 +3419,7 @@ SPEC CHECKSUMS:
   RNRudderSdk: cea1f6a95ceab29ceaf75bdadccba5f78121a4ce
   RNScreens: 586139d98cad59cc4c56443b9bd5c8b9b0b6da0e
   RNSentry: 4ebc4a48794b704751504d654f5e1ac98f08a819
-  RNShare: c6c861ad593bdd4856342724c00d5da64c4ff22f
+  RNShare: e374836177ff2675dbc659f2e52a59bf6060d200
   RNSound: 314cc5226453ef4a3314a196c65e8a65e5106a7b
   RNSVG: ab84f2de7dd4f2c86d01825b8a65e0ef712fc36b
   RNTextSize: c5e0593c898ad57ef5061464c154ab855da06047

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screen-corner-radius": "0.2.3",
     "react-native-screens": "4.10.0",
-    "react-native-share": "8.2.1",
+    "react-native-share": "12.2.5",
     "react-native-sound": "0.11.2",
     "react-native-storage": "1.0.1",
     "react-native-svg": "15.11.2",

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1245,6 +1245,9 @@ export type EventProperties = {
     pnlPercentage: number;
     pnl: string;
     netPnl: string;
+    shared: boolean;
+    success: boolean;
+    message: string;
   };
 
   // predictions

--- a/src/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet.tsx
+++ b/src/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet.tsx
@@ -11,7 +11,8 @@ import { opacity } from '@/framework/ui/utils/opacity';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
 import { PnlShareGraphic, type PnlShareImageHandle } from '@/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic';
 import { TradeDetailsSection } from '@/features/perps/screens/perps-trade-details-sheet/TradeDetailsSection';
-import { ActivityIndicator, Share } from 'react-native';
+import { ActivityIndicator } from 'react-native';
+import RNShare from 'react-native-share';
 import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
 import { analytics } from '@/analytics';
@@ -53,23 +54,29 @@ function PerpsTradeDetailsSheetContent({ trade }: { trade: HlTrade }) {
   );
 
   const handleShare = useCallback(async () => {
-    analytics.track(analytics.event.perpsTradeDetailsSharePressed, {
-      market: trade.symbol,
-      direction: trade.isLong ? 'long' : 'short',
-      pnlPercentage,
-      pnl: trade.pnl,
-      netPnl: trade.netPnl,
-    });
-
     setIsSharing(true);
     try {
       const image = await pnlShareImageRef.current?.capture();
       if (!image) {
         return;
       }
-      await Share.share({
-        title: 'pnl',
-        url: image,
+      const imageUrl = image.startsWith('file://') ? image : `file://${image}`;
+
+      const result = await RNShare.open({
+        failOnCancel: false,
+        type: 'image/png',
+        url: imageUrl,
+      });
+
+      analytics.track(analytics.event.perpsTradeDetailsSharePressed, {
+        market: trade.symbol,
+        direction: trade.isLong ? 'long' : 'short',
+        pnlPercentage,
+        pnl: trade.pnl,
+        netPnl: trade.netPnl,
+        shared: !result.dismissedAction,
+        success: result.success,
+        message: result.message,
       });
     } catch (e) {
       logger.error(new RainbowError('[PerpsTradeDetailsSheet]: Error sharing trade', e));
@@ -97,7 +104,7 @@ function PerpsTradeDetailsSheetContent({ trade }: { trade: HlTrade }) {
               </Text>
             </Box>
           ) : (
-            <ActivityIndicator color={'black'} />
+            <ActivityIndicator color={isDarkMode ? 'black' : 'white'} />
           )}
         </HyperliquidButton>
         <TradeDetailsSection trade={trade} />

--- a/src/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic.tsx
+++ b/src/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic.tsx
@@ -12,6 +12,8 @@ import {
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Box, globalColors } from '@/design-system';
+import { IS_ANDROID } from '@/env';
+import { fonts } from '@/design-system/typography/typography';
 import { captureRef } from 'react-native-view-shot';
 import greenArrowsBackground from '../../assets/pnl-share/green-arrows-background.png';
 import redArrowsBackground from '../../assets/pnl-share/red-arrows-background.png';
@@ -50,14 +52,15 @@ const CAPTURE_TEMPLATE_HEIGHT = CAPTURE_TEMPLATE_WIDTH / ASPECT_RATIO;
 const CAPTURE_SCALE = 1 / PixelRatio.get();
 const CAPTURE_WIDTH = CAPTURE_TEMPLATE_WIDTH * CAPTURE_SCALE;
 const CAPTURE_HEIGHT = CAPTURE_TEMPLATE_HEIGHT * CAPTURE_SCALE;
-const SF_FONT_FAMILY = 'SF Pro Rounded';
 const PROFIT_COLOR = PERPS_COLORS.longGreen;
 const SHARE_CARD_SIDE_PEEK = 24;
 const SHARE_CARD_WIDTH = PANEL_WIDTH - SHARE_CARD_SIDE_PEEK * 2;
 const SHARE_CARD_GAP = 8;
 const SHARE_CARD_SNAP_INTERVAL = SHARE_CARD_WIDTH + SHARE_CARD_GAP;
 const SHARE_CAROUSEL_WIDTH = SHARE_CARD_WIDTH + SHARE_CARD_SIDE_PEEK * 2;
-const INITIAL_CHARACTER_INDEX = 0;
+const ANDROID_TEXT_FIX = IS_ANDROID ? ({ includeFontPadding: false, textAlignVertical: 'center' } as const) : {};
+const SF_BOLD = { ...fonts.SFProRounded.bold, ...ANDROID_TEXT_FIX };
+const SF_BLACK = { ...fonts.SFProRounded.black, ...ANDROID_TEXT_FIX };
 
 const PROFIT_CHARACTER_IMAGES = [
   profitCharacter1,
@@ -85,6 +88,7 @@ type PnlShareImageProps = {
   characterImage: ImageSourcePropType;
   includeDisplay?: boolean;
   includeCapture?: boolean;
+  fileName?: string;
 };
 
 type PnlShareContentProps = Omit<PnlShareImageProps, 'width' | 'includeDisplay' | 'includeCapture'> & {
@@ -165,21 +169,18 @@ function PnlShareContent({
         },
         assetFallbackText: {
           fontSize: s(15),
-          fontWeight: '700',
           color: 'white',
-          fontFamily: SF_FONT_FAMILY,
+          ...SF_BOLD,
         },
         assetSymbolText: {
           fontSize: s(15),
-          fontWeight: '900',
           color: 'white',
-          fontFamily: SF_FONT_FAMILY,
+          ...SF_BLACK,
         },
         pnlText: {
           fontSize: s(34),
-          fontWeight: '900',
           letterSpacing: s(0.38),
-          fontFamily: SF_FONT_FAMILY,
+          ...SF_BLACK,
         },
         pricesContainer: {
           flexDirection: 'row',
@@ -191,21 +192,18 @@ function PnlShareContent({
         },
         priceLabelText: {
           fontSize: s(13),
-          fontWeight: '700',
           color: opacity('#F5F8FF', 0.56),
-          fontFamily: SF_FONT_FAMILY,
+          ...SF_BOLD,
         },
         priceValueText: {
           fontSize: s(15),
-          fontWeight: '900',
+          ...SF_BLACK,
           color: 'white',
-          fontFamily: SF_FONT_FAMILY,
         },
         leverageText: {
           fontSize: s(15),
-          fontWeight: '900',
+          ...SF_BLACK,
           color: 'white',
-          fontFamily: SF_FONT_FAMILY,
         },
       }),
     [characterAspectRatio, s]
@@ -297,7 +295,7 @@ function PnlShareContent({
 const PnlShareImage = memo(
   forwardRef<PnlShareImageHandle, PnlShareImageProps>(function PnlShareImage(props, ref) {
     const viewRef = useRef<View>(null);
-    const { width, includeDisplay = true, includeCapture = true, ...contentProps } = props;
+    const { width, includeDisplay = true, includeCapture = true, fileName, ...contentProps } = props;
     const height = width / ASPECT_RATIO;
     const displayScale = width / DESIGN_REFERENCE_WIDTH;
     const captureScale = CAPTURE_WIDTH / DESIGN_REFERENCE_WIDTH;
@@ -336,10 +334,11 @@ const PnlShareImage = memo(
             useRenderInContext: true,
             format: 'png',
             quality: 1,
+            ...(fileName ? { fileName } : {}),
           });
         },
       }),
-      [includeCapture]
+      [fileName, includeCapture]
     );
 
     return (
@@ -392,7 +391,7 @@ export const PnlShareGraphic = memo(function PnlShareGraphic({
   }, [entryPrice, leverage, trade.isLong, trade.price]);
   const isPositivePnl = pnlPercentage >= 0;
   const characterImages = getCharacterImages(isPositivePnl);
-  const [activeCharacterIndex, setActiveCharacterIndex] = useState(INITIAL_CHARACTER_INDEX);
+  const [activeCharacterIndex, setActiveCharacterIndex] = useState(0);
   const activeCharacterImage = characterImages[activeCharacterIndex];
   const formattedEntryPrice = useMemo(() => formatPerpAssetPrice(entryPrice), [entryPrice]);
   const formattedMarkPrice = useMemo(() => formatPerpAssetPrice(trade.price), [trade.price]);
@@ -469,6 +468,7 @@ export const PnlShareGraphic = memo(function PnlShareGraphic({
         isLong={trade.isLong}
         characterImage={activeCharacterImage}
         includeDisplay={false}
+        fileName={`rainbow-pnl-${assetSymbol}-${pnlPercentage}-${trade.tradeId}`}
       />
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9636,7 +9636,7 @@ __metadata:
     react-native-safe-area-context: "npm:5.4.0"
     react-native-screen-corner-radius: "npm:0.2.3"
     react-native-screens: "npm:4.10.0"
-    react-native-share: "npm:8.2.1"
+    react-native-share: "npm:12.2.5"
     react-native-sound: "npm:0.11.2"
     react-native-storage: "npm:1.0.1"
     react-native-svg: "npm:15.11.2"
@@ -23753,10 +23753,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-share@npm:8.2.1":
-  version: 8.2.1
-  resolution: "react-native-share@npm:8.2.1"
-  checksum: 10c0/7727e8eae8fa05fe96f2edfe226fca02a7a4d8005fee0e4e53003ef191210cc8982db1e5a0e4997329c2fb098f17d4877876992320e52bad83d188af70785b28
+"react-native-share@npm:12.2.5":
+  version: 12.2.5
+  resolution: "react-native-share@npm:12.2.5"
+  checksum: 10c0/d0e7f2fa405346b2eab37b3776c9d6c79f673930f0854ac45dfdf3aed0923b8a512fbe8653960399f5d9bf965aa98fe374c27c36e9fd1f93825e572ea3bf83df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
APP-3166

## What changed (plus any additional context for devs)

  - Upgraded react-native-share from 8.2.1 to 12.2.5 and switched from the native Share API to
  RNShare.open() for more reliable sharing behavior and share results on both platforms. Behavior is same on iOS. On Android this change was required to make the image export properly. 
  - Fixed Android font rendering in PnL share graphics by using font patterns from the design
  system instead of raw fontFamily: 'SF Pro Rounded' strings.
  - Enhanced share analytics, moved the analytics event to fire after sharing completes, now tracking
  shared, success, and message fields from the share result. 
  - Fixed ActivityIndicator color in share button to respect dark mode.
  - Added `fileName` to captured pnl images for clean.

Apologies for a few unrelated changes packaged together here, just a bit of final cleanup.

## Screen recordings / screenshots

![Screenshot_20260226_145822_Rainbow](https://github.com/user-attachments/assets/060c0ae9-d8ab-490d-ac96-d4f23c79b2f1)

