### PR TITLE
feature(predictions): paginated fetching for events browse screen

### DIFF
--- a/src/features/polymarket/components/polymarket-events-list/PolymarketEventsListBase.tsx
+++ b/src/features/polymarket/components/polymarket-events-list/PolymarketEventsListBase.tsx
@@ -86,8 +86,8 @@ const ListLoadingSkeleton = memo(function ListLoadingSkeleton() {
 
 function getItemLayout(data: unknown, index: number) {
   return {
-    length: ITEM_HEIGHT,
-    offset: Math.floor(index / 2) * ROW_HEIGHT,
+    length: ROW_HEIGHT,
+    offset: index * ROW_HEIGHT,
     index,
   };
 }

--- a/src/features/polymarket/screens/polymarket-browse-events-screen/PolymarketBrowseEventsScreen.tsx
+++ b/src/features/polymarket/screens/polymarket-browse-events-screen/PolymarketBrowseEventsScreen.tsx
@@ -10,9 +10,8 @@ import { PolymarketEventCategorySelector } from '@/features/polymarket/screens/p
 import { PolymarketSportsEventsScreen } from '@/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsScreen';
 import { usePolymarketContext } from '@/features/polymarket/screens/polymarket-navigator/PolymarketContext';
 import { usePolymarketCategoryStore } from '@/features/polymarket/stores/usePolymarketCategoryStore';
-import { usePolymarketEventsStore } from '@/features/polymarket/stores/polymarketEventsStore';
+import { polymarketEventsActions, usePolymarketEventsStore } from '@/features/polymarket/stores/polymarketEventsStore';
 import { useListen } from '@/state/internal/hooks/useListen';
-import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
 import { LEAGUE_SELECTOR_HEIGHT } from '@/features/polymarket/screens/polymarket-sports-events-screen/PolymarketLeagueSelector';
 
 export const PolymarketBrowseEventsScreen = memo(function PolymarketBrowseEventsScreen() {
@@ -23,8 +22,6 @@ export const PolymarketBrowseEventsScreen = memo(function PolymarketBrowseEvents
     </View>
   );
 });
-
-const EMPTY_EVENTS: PolymarketEvent[] = [];
 
 const PolymarketBrowseEventsList = () => {
   const { isDarkMode } = useColorMode();
@@ -54,8 +51,17 @@ const PolymarketBrowseEventsList = () => {
 
 const EventsList = ({ onScroll }: { onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void }) => {
   const { eventsListRef } = usePolymarketContext();
-  const events = usePolymarketEventsStore(state => state.getData() ?? EMPTY_EVENTS);
-  return <PolymarketEventsListBase events={events} listRef={eventsListRef} onScroll={onScroll} />;
+  const events = usePolymarketEventsStore(state => state.getEvents());
+
+  return (
+    <PolymarketEventsListBase
+      events={events}
+      listRef={eventsListRef}
+      onEndReached={polymarketEventsActions.fetchNextPage}
+      onEndReachedThreshold={1}
+      onScroll={onScroll}
+    />
+  );
 };
 
 const styles = StyleSheet.create({

--- a/src/features/polymarket/stores/polymarketEventsStore.ts
+++ b/src/features/polymarket/stores/polymarketEventsStore.ts
@@ -4,41 +4,206 @@ import { createQueryStore } from '@/state/internal/createQueryStore';
 import { type RawPolymarketEvent, type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
 import { CATEGORIES, DEFAULT_CATEGORY_KEY, POLYMARKET_GAMMA_API_URL } from '@/features/polymarket/constants';
 import { processRawPolymarketEvent } from '@/features/polymarket/utils/transforms';
+import { logger, RainbowError } from '@/logger';
+import { createStoreActions } from '@/state/internal/utils/createStoreActions';
 import { usePolymarketCategoryStore } from './usePolymarketCategoryStore';
 
+const PAGE_SIZE = 26;
+const EMPTY_EVENTS: PolymarketEvent[] = [];
+
 type PolymarketEventsParams = {
-  tagId: string;
+  categoryKey: string;
+  offset: number;
 };
 
-export const usePolymarketEventsStore = createQueryStore<PolymarketEvent[], PolymarketEventsParams>(
+type PolymarketEventsPage = {
+  events: PolymarketEvent[];
+  hasMore: boolean;
+  nextOffset: number;
+};
+
+type CategoryEvents = {
+  events: PolymarketEvent[];
+  hasMore: boolean;
+  isFetchingNextPage: boolean;
+  nextOffset: number;
+};
+
+type PolymarketEventsStoreState = {
+  eventsByCategory: Record<string, CategoryEvents>;
+  fetchNextPage: () => Promise<void>;
+  getEvents: () => PolymarketEvent[];
+  hasNextPage: () => boolean;
+  isFetchingNextPage: () => boolean;
+};
+
+export const usePolymarketEventsStore = createQueryStore<PolymarketEventsPage, PolymarketEventsParams, PolymarketEventsStoreState>(
   {
-    fetcher: fetchPolymarketEvents,
+    fetcher: fetchPolymarketEventsPage,
     staleTime: time.minutes(2),
     cacheTime: time.minutes(20),
     enabled: $ => $(usePolymarketCategoryStore, state => state.tagId !== CATEGORIES.sports.tagId),
-    params: { tagId: $ => $(usePolymarketCategoryStore).tagId },
+    params: {
+      categoryKey: $ => $(usePolymarketCategoryStore).tagId,
+      offset: 0,
+    },
+    onFetched: ({ data, params, set }) => {
+      if (params.offset !== 0) return;
+
+      set(state => ({
+        eventsByCategory: {
+          ...state.eventsByCategory,
+          [params.categoryKey]: {
+            events: data.events,
+            hasMore: data.hasMore,
+            isFetchingNextPage: false,
+            nextOffset: data.nextOffset,
+          },
+        },
+      }));
+    },
   },
-  { storageKey: 'polymarketEventsStore' }
+  (set, get) => {
+    const fetchPromisesByCategory = new Map<string, Promise<void>>();
+
+    function getInitialCategoryEvents(categoryKey: string): CategoryEvents | null {
+      const firstPage = get().getData({ categoryKey, offset: 0 });
+      if (!firstPage) return null;
+
+      return {
+        events: firstPage.events,
+        hasMore: firstPage.hasMore,
+        isFetchingNextPage: false,
+        nextOffset: firstPage.nextOffset,
+      };
+    }
+
+    function setCategoryFetchingState(categoryKey: string, isFetchingNextPage: boolean) {
+      set(state => {
+        const categoryEvents = state.eventsByCategory[categoryKey];
+        if (!categoryEvents || categoryEvents.isFetchingNextPage === isFetchingNextPage) return state;
+
+        return {
+          eventsByCategory: {
+            ...state.eventsByCategory,
+            [categoryKey]: {
+              ...categoryEvents,
+              isFetchingNextPage,
+            },
+          },
+        };
+      });
+    }
+
+    return {
+      eventsByCategory: {},
+
+      async fetchNextPage() {
+        const categoryKey = usePolymarketCategoryStore.getState().tagId;
+        if (categoryKey === CATEGORIES.sports.tagId) return;
+
+        const { fetch, eventsByCategory } = get();
+
+        const currentCategoryEvents = eventsByCategory[categoryKey] ?? getInitialCategoryEvents(categoryKey);
+
+        if (!currentCategoryEvents?.hasMore || currentCategoryEvents.isFetchingNextPage) return;
+        if (!currentCategoryEvents.events.length) return;
+
+        if (!eventsByCategory[categoryKey] && currentCategoryEvents) {
+          set(state => ({
+            eventsByCategory: {
+              ...state.eventsByCategory,
+              [categoryKey]: currentCategoryEvents,
+            },
+          }));
+        }
+
+        const existingFetchPromise = fetchPromisesByCategory.get(categoryKey);
+        if (existingFetchPromise) return existingFetchPromise;
+
+        const nextOffset = currentCategoryEvents.nextOffset;
+        setCategoryFetchingState(categoryKey, true);
+
+        const fetchPromise = fetch(
+          { categoryKey, offset: nextOffset },
+          {
+            force: true,
+            skipStoreUpdates: true,
+          }
+        )
+          .then(data => {
+            if (!data) return;
+
+            const latestState = get();
+            const latestCategoryEvents = latestState.eventsByCategory[categoryKey] ?? getInitialCategoryEvents(categoryKey);
+            if (!latestCategoryEvents) return;
+
+            set({
+              eventsByCategory: {
+                ...latestState.eventsByCategory,
+                [categoryKey]: {
+                  events: mergeEventsById(latestCategoryEvents.events, data.events),
+                  hasMore: data.hasMore,
+                  isFetchingNextPage: false,
+                  nextOffset: data.nextOffset,
+                },
+              },
+            });
+          })
+          .catch(error => {
+            logger.error(new RainbowError('[polymarketEventsStore]: Failed to fetch next page', error));
+          })
+          .finally(() => {
+            setCategoryFetchingState(categoryKey, false);
+            fetchPromisesByCategory.delete(categoryKey);
+          });
+
+        fetchPromisesByCategory.set(categoryKey, fetchPromise);
+        return fetchPromise;
+      },
+
+      getEvents: () => {
+        const categoryKey = usePolymarketCategoryStore.getState().tagId;
+        return get().eventsByCategory[categoryKey]?.events ?? get().getData({ categoryKey, offset: 0 })?.events ?? EMPTY_EVENTS;
+      },
+
+      hasNextPage: () => {
+        const categoryKey = usePolymarketCategoryStore.getState().tagId;
+        return get().eventsByCategory[categoryKey]?.hasMore ?? get().getData({ categoryKey, offset: 0 })?.hasMore ?? false;
+      },
+
+      isFetchingNextPage: () => {
+        const categoryKey = usePolymarketCategoryStore.getState().tagId;
+        return get().eventsByCategory[categoryKey]?.isFetchingNextPage ?? false;
+      },
+    };
+  },
+  { storageKey: 'polymarketEventsStore', version: 1 }
 );
+
+export const polymarketEventsActions = createStoreActions(usePolymarketEventsStore);
 
 export function prefetchPolymarketEvents() {
   usePolymarketEventsStore.getState().fetch();
 }
 
-async function fetchPolymarketEvents(
-  { tagId }: PolymarketEventsParams,
+async function fetchPolymarketEventsPage(
+  { categoryKey, offset }: PolymarketEventsParams,
   abortController: AbortController | null
-): Promise<PolymarketEvent[]> {
+): Promise<PolymarketEventsPage> {
   const url = new URL(`${POLYMARKET_GAMMA_API_URL}/events`);
-  url.searchParams.set('limit', '26');
+  url.searchParams.set('limit', String(PAGE_SIZE));
   url.searchParams.set('active', 'true');
   url.searchParams.set('archived', 'false');
   url.searchParams.set('closed', 'false');
   url.searchParams.set('order', 'volume24hr');
   url.searchParams.set('ascending', 'false');
+  if (offset > 0) {
+    url.searchParams.set('offset', String(offset));
+  }
 
-  if (tagId && tagId !== DEFAULT_CATEGORY_KEY) {
-    url.searchParams.set('tag_slug', tagId);
+  if (categoryKey !== DEFAULT_CATEGORY_KEY) {
+    url.searchParams.set('tag_slug', categoryKey);
   }
 
   const { data: events }: { data: RawPolymarketEvent[] } = await rainbowFetch(url.toString(), {
@@ -47,6 +212,17 @@ async function fetchPolymarketEvents(
   });
 
   const filteredEvents = events.filter(event => event.ended !== true);
+  const processedEvents = await Promise.all(filteredEvents.map(event => processRawPolymarketEvent(event)));
 
-  return await Promise.all(filteredEvents.map(event => processRawPolymarketEvent(event)));
+  return {
+    events: processedEvents,
+    hasMore: events.length === PAGE_SIZE,
+    nextOffset: offset + events.length,
+  };
+}
+
+function mergeEventsById(existingEvents: PolymarketEvent[], nextEvents: PolymarketEvent[]): PolymarketEvent[] {
+  const existingIds = new Set(existingEvents.map(event => event.id));
+  const uniqueNextEvents = nextEvents.filter(event => !existingIds.has(event.id));
+  return existingEvents.concat(uniqueNextEvents);
 }


### PR DESCRIPTION
Fixes APP-3351

## What changed (plus any additional context for devs)
 Adds pagination to the Polymarket browse events screen so events are fetched as the user scrolls.

  - Refactored `polymarketEventsStore` to support paginated fetching and storage.
  - Fixed `getItemLayout`'s `offset`  to use `index` instead of `Math.floor(index / 2)`. The index in this case is the row index, not the actual items index.  
  - Bumped store version to 1 to account for the new data shape.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/7a63c2ec-bb28-4247-b1a0-e4039b16fa8a
