### PR TITLE
fix(sentry): use ignoreErrors instead of ignoreTransactions for error filtering

### DIFF
--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -11,13 +11,15 @@ import { logger, RainbowError } from '@/logger';
 //   3. "lastException.type: lastException.value" (e.g. "AbortError: Aborted")
 // A match on ANY candidate drops the event.
 const IGNORED_ERRORS: Array<string | RegExp> = [
-  // "AbortError: Aborted" -- thrown by whatwg-fetch when a request is intentionally cancelled via
-  // AbortController. This is expected behavior (e.g. createQueryStore aborting stale fetches on param change).
+  // "AbortError: Aborted"
+  // Thrown by whatwg-fetch when a request is intentionally cancelled via AbortController. This is expected behavior
+  // (e.g. createQueryStore aborting stale fetches on param change).
   // Matches candidate 3 ("AbortError: Aborted"). Anchored to the type prefix to avoid false positives.
   /^AbortError:/,
 
-  // "TypeError: Network request failed" -- thrown by whatwg-fetch when the device has no network
-  // connectivity (offline, tunnel, flaky wifi). Not actionable client-side.
+  // "TypeError: Network request failed"
+  // Thrown by whatwg-fetch when the device has no network connectivity (offline, tunnel, flaky wifi). Not actionable
+  // client-side.
   // Matches candidate 2 ("Network request failed"). Exact match to avoid catching other TypeErrors.
   /^Network request failed$/,
 ];

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -5,7 +5,22 @@ import VersionNumber from 'react-native-version-number';
 import { IS_TEST, IS_TEST_FLIGHT } from '@/env';
 import { logger, RainbowError } from '@/logger';
 
-const ERROR_MESSAGE_BLACKLIST = ['AbortError', 'Network request failed', 'There was an error with the request.'];
+// Sentry tests each regex against these candidate strings:
+//   1. event.message
+//   2. lastException.value (e.g. "Aborted")
+//   3. "lastException.type: lastException.value" (e.g. "AbortError: Aborted")
+// A match on ANY candidate drops the event.
+const IGNORED_ERRORS: Array<string | RegExp> = [
+  // "AbortError: Aborted" -- thrown by whatwg-fetch when a request is intentionally cancelled via
+  // AbortController. This is expected behavior (e.g. createQueryStore aborting stale fetches on param change).
+  // Matches candidate 3 ("AbortError: Aborted"). Anchored to the type prefix to avoid false positives.
+  /^AbortError:/,
+
+  // "TypeError: Network request failed" -- thrown by whatwg-fetch when the device has no network
+  // connectivity (offline, tunnel, flaky wifi). Not actionable client-side.
+  // Matches candidate 2 ("Network request failed"). Exact match to avoid catching other TypeErrors.
+  /^Network request failed$/,
+];
 
 export const defaultOptions: Sentry.ReactNativeOptions = {
   attachStacktrace: true,
@@ -15,7 +30,7 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
   enableAutoSessionTracking: false,
   enableTracing: false,
   environment: IS_TEST_FLIGHT ? 'Testflight' : SENTRY_ENVIRONMENT,
-  ignoreTransactions: ERROR_MESSAGE_BLACKLIST,
+  ignoreErrors: IGNORED_ERRORS,
   integrations: [Sentry.httpClientIntegration()], // http client integration will help us see payload / response from errored out requests to better understand the issue
   maxBreadcrumbs: 10,
   tracesSampleRate: 0,


### PR DESCRIPTION
Our Sentry config has been using `ignoreTransactions` to filter non-actionable errors like `AbortError` and `Network request failed` since #6504 (Mar 2025). `ignoreTransactions` only filters performance transaction events, not errors, so the filter list has been silently doing nothing for about a year.

This change switches to `ignoreErrors` (the correct option) and replaces the plain substring strings with anchored regexes to avoid false positives. 

The two errors kept in the list (`AbortError`, `Network request failed`) account for roughly 500K accepted events per 14-day billing period, which should save an estimated ~$400/month in on-demand spend. 

The `"There was an error with the request."` entry has been removed since it needs more nuanced filtering by HTTP status code, which will be handled via a `beforeSend` hook in FEPLAT-37.