### PR TITLE
fix(sentry): prevent platform splitting of captureMessage issues

### DIFF
--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -26,6 +26,30 @@ const IGNORED_ERRORS: Array<string | RegExp> = [
 
 export const defaultOptions: Sentry.ReactNativeOptions = {
   attachStacktrace: true,
+
+  beforeSend(event) {
+    // Check if this is a captureMessage call.
+    //
+    // captureMessage events (logger.warn, logger.log) have event.message
+    // but no event.exception. captureException events (logger.error) always
+    // have event.exception, so this guard skips them.
+    if (event.message && !event.exception) {
+      // Without this, attachStacktrace adds a synthetic stack that Sentry
+      // groups on instead of the message. Since all messages route through
+      // sentryTransport, the stacks are nearly identical, and minor platform
+      // differences (Hermes function names, bundle filenames) split iOS and
+      // Android into separate issues.
+      //
+      // Grouping by message is the correct semantic for warnings/logs since
+      // the message describes what happened. In practice messages are
+      // naturally unique per call site (most use context prefixes like
+      // "[Positions] ..."). The stack trace is still preserved on each
+      // event for debugging, it just no longer drives the grouping.
+      event.fingerprint = [event.message];
+    }
+    return event;
+  },
+
   dsn: SENTRY_ENDPOINT,
   enableAppHangTracking: false,
   enableAutoPerformanceTracing: false,


### PR DESCRIPTION
Sentry is currently splitting identical warnings into separate iOS and Android issues. This happens because the `attachStacktrace` option adds a synthetic stack trace to every `captureMessage` event, and Sentry's grouping algorithm prefers stack traces over message content. Since all our warnings route through `sentryTransport`, the stacks are nearly identical, but minor platform differences cause different grouping hashes. Hermes generates different function name annotations per platform (e.g. `warn` on iOS vs `Logger#warn` on Android), and the compiled bundle filenames differ (`main.jsbundle` vs `index.android.bundle`). Together these produce two distinct issues in Sentry UI for every warning we emit, with their only difference being the platform.

This change adds a `beforeSend` hook that overrides the fingerprint to the message string for `captureMessage` events, so Sentry groups by what happened rather than the synthetic call stack. `captureException` events (real errors with their own stack traces) are unaffected. The stack trace is still attached to each event for debugging, it just no longer drives the grouping.

This is one half of the fix. The other half is a set of server-side Stack Trace Rules in Sentry's project settings that I added recently (see SS below) that exclude our logger transport frames and non-source-mapped bundle frames from the grouping algorithm. Those rules fix the culprit display (showing the actual call site instead of "sentryTransport") and prevent the bundle filename split for error events too.

Sentry ST rule config:
<img width="500" height="1005" alt="image" src="https://github.com/user-attachments/assets/d01ecd52-61bc-4b63-8789-2dabe004dd93" />

Fixes FEPLAT-46