### PR TITLE
fix(sentry): missing timestamps on custom breadcrumbs

### DIFF
--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -170,7 +170,7 @@ describe('general functionality', () => {
       data: {},
       type: 'default',
       level: LogLevel.Debug,
-      timestamp: Date.now(),
+      timestamp: Date.now() / 1000,
     });
 
     sentryTransport(LogLevel.Info, message, { type: 'info', prop: true });
@@ -179,7 +179,7 @@ describe('general functionality', () => {
       data: { prop: true },
       type: 'info',
       level: LogLevel.Info,
-      timestamp: Date.now(),
+      timestamp: Date.now() / 1000,
     });
 
     sentryTransport(LogLevel.Log, message, {});
@@ -188,7 +188,7 @@ describe('general functionality', () => {
       data: {},
       type: 'default',
       level: 'debug',
-      timestamp: Date.now(),
+      timestamp: Date.now() / 1000,
     });
     expect(Sentry.captureMessage).toHaveBeenCalledWith(message, {
       tags: undefined,
@@ -201,7 +201,7 @@ describe('general functionality', () => {
       data: {},
       type: 'default',
       level: 'warning',
-      timestamp: Date.now(),
+      timestamp: Date.now() / 1000,
     });
     expect(Sentry.captureMessage).toHaveBeenCalledWith(message, {
       level: 'warning',

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -149,7 +149,7 @@ export const sentryTransport: Transport = (level: LogLevel, message, { type, tag
       data: metadata,
       type: type || 'default',
       level: severity,
-      timestamp: Date.now(),
+      timestamp: Date.now() / 1000,
     });
 
     /**


### PR DESCRIPTION
Our Sentry logger passes `Date.now()` as the timestamp to breadcrumbs, but the Sentry SDK expects **seconds, not milliseconds**. This means Sentry currently interprets the millisecond value as seconds, sees a date in an impossible future year, and discards it with a "timestamp out of range" processing error. The breadcrumb content still comes through, but the timestamp is silently dropped, so logger breadcrumbs have no timing information in the Sentry UI. Below screenshows how this currently manifests itself on e.g an [example Sentry issue ](https://rainbow-me.sentry.io/issues/7315289162/?project=1855565&query=is%3Aunresolved&referrer=issue-stream&sort=date):

<img width="500" height="741" alt="Screenshot 2026-03-06 at 14 38 39" src="https://github.com/user-attachments/assets/02b7fd90-ab76-4f45-95be-25c500168549" />

Fixes FEPLAT-47.