### PR TITLE
feature: prompt imported wallets for backup

### DIFF
--- a/src/helpers/backupPrompt.ts
+++ b/src/helpers/backupPrompt.ts
@@ -1,0 +1,31 @@
+import walletBackupTypes from '@/helpers/walletBackupTypes';
+import WalletBackupStepTypes from '@/helpers/walletBackupStepTypes';
+import WalletTypes from '@/helpers/walletTypes';
+import { type RainbowWallet } from '@/model/wallet';
+import { Navigation } from '@/navigation';
+import Routes from '@/navigation/routesNames';
+
+export function canShowBackupPrompt(wallet: RainbowWallet | null): boolean {
+  if (!wallet || wallet.backedUp || wallet.damaged) return false;
+  if (wallet.type === WalletTypes.readOnly || wallet.type === WalletTypes.bluetooth) return false;
+
+  return true;
+}
+
+export function getBackupPromptStep(backupProvider: string | undefined): string {
+  if (backupProvider === walletBackupTypes.cloud) {
+    return WalletBackupStepTypes.backup_prompt_cloud;
+  }
+
+  if (backupProvider === walletBackupTypes.manual) {
+    return WalletBackupStepTypes.backup_prompt_manual;
+  }
+
+  return WalletBackupStepTypes.backup_prompt;
+}
+
+export function showBackupPrompt(backupProvider: string | undefined): void {
+  Navigation.handleAction(Routes.BACKUP_SHEET, {
+    step: getBackupPromptStep(backupProvider),
+  });
+}

--- a/src/screens/SettingsSheet/utils.ts
+++ b/src/screens/SettingsSheet/utils.ts
@@ -58,7 +58,7 @@ export const checkLocalWalletsForBackupStatus = (backups: CloudBackups): WalletB
 
       return {
         allBackedUp: acc.allBackedUp && (wallet.backedUp || !isBackupEligible),
-        areBackedUp: acc.areBackedUp && (wallet.backedUp || !isBackupEligible || wallet.imported),
+        areBackedUp: acc.areBackedUp && (wallet.backedUp || !isBackupEligible),
         canBeBackedUp: acc.canBeBackedUp && isBackupEligible,
       };
     },

--- a/src/state/sync/SessionEntryPromptSync.tsx
+++ b/src/state/sync/SessionEntryPromptSync.tsx
@@ -4,8 +4,6 @@ import { type UnlockableAppIconKey, unlockableAppIcons } from '@/features/app-ic
 import { unlockableAppIconCheck } from '@/features/app-icon/utils/unlockableAppIconCheck';
 import { type EthereumAddress } from '@/entities/wallet';
 import { IS_TEST } from '@/env';
-import WalletBackupStepTypes from '@/helpers/walletBackupStepTypes';
-import walletBackupTypes from '@/helpers/walletBackupTypes';
 import WalletTypes from '@/helpers/walletTypes';
 import { useActiveRoute } from '@/hooks/useActiveRoute';
 import { type RainbowAccount } from '@/model/wallet';
@@ -13,6 +11,7 @@ import { Navigation } from '@/navigation';
 import { type Route } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { backupsStore, LoadingStates, oneWeekInMs } from '@/state/backups/backups';
+import { canShowBackupPrompt, getBackupPromptStep } from '@/helpers/backupPrompt';
 import { isSwipeRoute } from '@/state/navigation/navigationStore';
 import { getSelectedWallet, getWallets, useWalletsStore } from '@/state/wallets/walletsStore';
 import { ReviewPromptAction } from '@/storage/schema';
@@ -57,8 +56,7 @@ async function maybeShowBackupPrompt(): Promise<boolean> {
   const selected = getSelectedWallet();
   if (!selected) return false;
 
-  if (selected.backedUp || selected.damaged || selected.imported) return false;
-  if (selected.type === WalletTypes.readOnly || selected.type === WalletTypes.bluetooth) return false;
+  if (!canShowBackupPrompt(selected)) return false;
 
   await waitForBackupStatusToSettle();
 
@@ -71,14 +69,7 @@ async function maybeShowBackupPrompt(): Promise<boolean> {
     return false;
   }
 
-  const step =
-    backupProvider === walletBackupTypes.cloud
-      ? WalletBackupStepTypes.backup_prompt_cloud
-      : backupProvider === walletBackupTypes.manual
-        ? WalletBackupStepTypes.backup_prompt_manual
-        : WalletBackupStepTypes.backup_prompt;
-
-  Navigation.handleAction(Routes.BACKUP_SHEET, { step });
+  Navigation.handleAction(Routes.BACKUP_SHEET, { step: getBackupPromptStep(backupProvider) });
   return true;
 }
 


### PR DESCRIPTION
## What changed

- Extract backup prompt logic into reusable helpers (`canShowBackupPrompt`, `getBackupPromptStep`,
`showBackupPrompt`) in src/helpers/backupPrompt.ts
- Remove the `wallet.imported` exclusion from `maybeShowBackupPrompt`, so imported wallets are now
prompted for backup
- Change `areBackedUp` check in `checkLocalWalletsForBackupStatus` to no longer skip imported wallets,
keeping it consistent with `allBackedUp`

## Screen recordings / screenshots

## What to test

- Import a wallet and verify the backup prompt appears when 