### PR TITLE
feature: add flow context to wallet import for branching post import behavior

### DIFF
--- a/src/components/wallet-error/WalletErrorSheet.tsx
+++ b/src/components/wallet-error/WalletErrorSheet.tsx
@@ -63,6 +63,7 @@ export default function WalletErrorSheet() {
                   navigation.goBack();
                   InteractionManager.runAfterInteractions(() => {
                     navigation.navigate(Routes.ADD_WALLET_NAVIGATOR, {
+                      flowContext: 'in_app',
                       isFirstWallet: true,
                     });
                   });

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -1,9 +1,7 @@
 import { isValidAddress } from 'ethereumjs-util';
 import * as i18n from '@/languages';
-import { keys } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { InteractionManager, Keyboard, type TextInput } from 'react-native';
-import { useDispatch } from 'react-redux';
 import { fetchENSAvatar } from './useENSAvatar';
 import { initializeWallet } from '../state/wallets/initializeWallet';
 import useIsWalletEthZero from './useIsWalletEthZero';
@@ -12,26 +10,31 @@ import { WrappedAlert as Alert } from '@/helpers/alert';
 import { analytics } from '@/analytics';
 import { PROFILES, useExperimentalFlag } from '@/config';
 import { fetchReverseRecord } from '@/handlers/ens';
-import { getProvider, isValidBluetoothDeviceId, resolveUnstoppableDomain } from '@/handlers/web3';
+import { getProvider, resolveUnstoppableDomain } from '@/handlers/web3';
 import { isENSAddressFormat, isUnstoppableAddressFormat, isValidWallet } from '@/helpers/validators';
-import { Navigation, useNavigation } from '@/navigation';
+import { useNavigation } from '@/navigation';
 import Routes from '@/navigation/routesNames';
+import { type ImportFlowContext } from '@/navigation/types';
 import { sanitizeSeedPhrase } from '@/utils/formatters';
 import { deriveAccountFromWalletInput } from '@/utils/wallet';
 import { logger, RainbowError } from '@/logger';
 import { ChainId } from '@/state/backendNetworks/types';
 import { backupsStore } from '@/state/backups/backups';
+import { canShowBackupPrompt, showBackupPrompt } from '@/helpers/backupPrompt';
 import { walletLoadingStore } from '@/state/walletLoading/walletLoading';
 import { WalletLoadingStates } from '@/helpers/walletLoadingStates';
-import { IS_ANDROID, IS_TEST } from '@/env';
-import walletBackupTypes from '@/helpers/walletBackupTypes';
-import WalletBackupStepTypes from '@/helpers/walletBackupStepTypes';
-import { useWallets, useAccountAddress } from '@/state/wallets/walletsStore';
+import { IS_ANDROID } from '@/env';
+import { getSelectedWallet, useAccountAddress } from '@/state/wallets/walletsStore';
 import { navigateAfterOnboarding } from '@/navigation/onboardingNavigation';
 
-export default function useImportingWallet({ showImportModal = true } = {}) {
+export default function useImportingWallet({
+  flowContext,
+  showImportModal = true,
+}: {
+  flowContext?: ImportFlowContext;
+  showImportModal?: boolean;
+} = {}) {
   const accountAddress = useAccountAddress();
-  const wallets = useWallets();
 
   const { navigate, goBack, getParent: dangerouslyGetParent } = useNavigation<typeof Routes.MODAL_SCREEN>();
   const isWalletEthZero = useIsWalletEthZero();
@@ -275,22 +278,32 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
     [isSecretValid, profilesEnabled, seedPhrase, startImportProfile]
   );
 
-  const dispatch = useDispatch();
-
   useEffect(() => {
     if (wasImporting || !isImporting) {
       return;
     }
 
-    const handleImportSuccess = async (input: string, isWalletEthZero: boolean, backupProvider: string | undefined) => {
+    const handleImportSuccess = async (isWalletEthZero: boolean, backupProvider: string | undefined) => {
       setImporting(false);
       setBusy(false);
       walletLoadingStore.setState({ loadingState: null });
 
+      const selectedWallet = getSelectedWallet();
+      const shouldShowImportBackupPrompt = flowContext === 'in_app' && canShowBackupPrompt(selectedWallet);
+
       try {
         // Dismiss the ADD_WALLET_NAVIGATOR modal stack
         dangerouslyGetParent?.()?.goBack();
-        await navigateAfterOnboarding();
+
+        if (flowContext !== 'in_app') {
+          await navigateAfterOnboarding();
+        }
+
+        if (shouldShowImportBackupPrompt) {
+          InteractionManager.runAfterInteractions(() => {
+            showBackupPrompt(backupProvider);
+          });
+        }
       } catch (error) {
         logger.error(new RainbowError('[useImportingWallet]: Error navigating to wallet screen'), { error });
         try {
@@ -300,23 +313,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
         }
       }
 
-      // Show backup prompt after navigation completes
       InteractionManager.runAfterInteractions(() => {
-        if (
-          backupProvider === walletBackupTypes.cloud &&
-          !(
-            IS_TEST ||
-            isENSAddressFormat(input) ||
-            isUnstoppableAddressFormat(input) ||
-            isValidAddress(input) ||
-            isValidBluetoothDeviceId(input)
-          )
-        ) {
-          Navigation.handleAction(Routes.BACKUP_SHEET, {
-            step: WalletBackupStepTypes.backup_prompt_cloud,
-          });
-        }
-
         analytics.track(analytics.event.importedSeedPhrase, {
           isWalletEthZero,
         });
@@ -341,8 +338,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
         });
 
         if (success) {
-          // Navigate to wallet screen
-          await handleImportSuccess(input, isWalletEthZero, backupProvider);
+          await handleImportSuccess(isWalletEthZero, backupProvider);
         } else {
           // Import failed
           logger.error(new RainbowError('[useImportingWallet]: Import failed'));
@@ -373,13 +369,12 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
     name,
     resolvedAddress,
     seedPhrase,
-    wallets,
     wasImporting,
     image,
-    dispatch,
     showImportModal,
     profilesEnabled,
     backupProvider,
+    flowContext,
     resetOnFailure,
     dangerouslyGetParent,
     goBack,

--- a/src/navigation/AddWalletNavigator.tsx
+++ b/src/navigation/AddWalletNavigator.tsx
@@ -15,7 +15,7 @@ const Swipe = createMaterialTopTabNavigator();
 
 export const AddWalletNavigator = () => {
   const {
-    params: { isFirstWallet, type },
+    params: { flowContext = 'in_app', isFirstWallet, type },
   } = useRoute<RouteProp<RootStackParamList, typeof Routes.ADD_WALLET_SHEET>>();
 
   const [scrollEnabled, setScrollEnabled] = useState(false);
@@ -32,7 +32,7 @@ export const AddWalletNavigator = () => {
           >
             <Swipe.Screen
               component={AddWalletSheet}
-              initialParams={{ isFirstWallet }}
+              initialParams={{ flowContext, isFirstWallet }}
               name={Routes.ADD_WALLET_SHEET}
               listeners={{
                 focus: () => {
@@ -54,7 +54,7 @@ export const AddWalletNavigator = () => {
             />
             <Swipe.Screen
               component={ImportOrWatchWalletSheet}
-              initialParams={{ type }}
+              initialParams={{ flowContext, type }}
               name={Routes.IMPORT_OR_WATCH_WALLET_SHEET}
               listeners={{
                 focus: () => {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -225,9 +225,12 @@ export type ExplainSheetRouteParams = {
   [K in ExplainSheetType]: ExplainSheetParams<K>;
 }[ExplainSheetType];
 
+export type ImportFlowContext = 'onboarding' | 'in_app';
+
 type AddWalletNavigatorParams = {
   type?: 'import' | 'watch';
   isFirstWallet: boolean;
+  flowContext?: ImportFlowContext;
 };
 
 export type HardwareWalletTxParams = {

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -18,18 +18,19 @@ import WatchWalletIcon from '@/assets/watchWallet.png';
 import { cloudPlatform } from '@/utils/platform';
 import { type RouteProp, useRoute } from '@react-navigation/native';
 import { executeFnIfCloudBackupAvailable } from '@/model/backup';
-import { type RootStackParamList } from '@/navigation/types';
+import { type ImportFlowContext, type RootStackParamList } from '@/navigation/types';
 import { IS_DEV } from '@/env';
 
 const TRANSLATIONS = i18n.l.wallet.new.add_wallet_sheet;
 
 export type AddWalletSheetParams = {
+  flowContext?: ImportFlowContext;
   isFirstWallet: boolean;
 };
 
 export const AddWalletSheet = () => {
   const {
-    params: { isFirstWallet },
+    params: { flowContext = 'in_app', isFirstWallet },
   } = useRoute<RouteProp<RootStackParamList, typeof Routes.ADD_WALLET_SHEET>>();
 
   const { goBack, navigate } = useNavigation();
@@ -58,7 +59,7 @@ export const AddWalletSheet = () => {
     });
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
       screen: Routes.IMPORT_OR_WATCH_WALLET_SHEET,
-      params: { type: 'import', isFirstWallet },
+      params: { flowContext, type: 'import', isFirstWallet },
     });
   };
 
@@ -70,7 +71,7 @@ export const AddWalletSheet = () => {
     });
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
       screen: Routes.IMPORT_OR_WATCH_WALLET_SHEET,
-      params: { type: 'watch', isFirstWallet },
+      params: { flowContext, type: 'watch', isFirstWallet },
     });
   };
 

--- a/src/screens/ImportOrWatchWalletSheet.tsx
+++ b/src/screens/ImportOrWatchWalletSheet.tsx
@@ -18,9 +18,12 @@ import { opacity } from '@/framework/ui/utils/opacity';
 const TRANSLATIONS = i18n.l.wallet.new.import_or_watch_wallet_sheet;
 
 export const ImportOrWatchWalletSheet = () => {
-  const { params: { type = 'watch' } = {} } = useRoute<RouteProp<RootStackParamList, typeof Routes.IMPORT_OR_WATCH_WALLET_SHEET>>();
+  const { params: { flowContext, type = 'watch' } = {} } =
+    useRoute<RouteProp<RootStackParamList, typeof Routes.IMPORT_OR_WATCH_WALLET_SHEET>>();
 
-  const { busy, handlePressImportButton, handleSetSeedPhrase, inputRef, isSecretValid, seedPhrase } = useImportingWallet();
+  const { busy, handlePressImportButton, handleSetSeedPhrase, inputRef, isSecretValid, seedPhrase } = useImportingWallet({
+    flowContext,
+  });
   const keyboardHeight = useKeyboardHeight();
 
   const textStyle = useTextStyle({

--- a/src/screens/WelcomeScreen/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreen.tsx
@@ -197,6 +197,7 @@ export function WelcomeScreen() {
   const showRestoreSheet = useCallback(() => {
     analytics.track(analytics.event.welcomeAlreadyHave);
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
+      flowContext: 'onboarding',
       isFirstWallet: true,
     });
   }, [navigate]);

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -428,6 +428,7 @@ export default function ChangeWalletSheet() {
     goBack();
     InteractionManager.runAfterInteractions(() => {
       navigate(Routes.ADD_WALLET_NAVIGATOR, {
+        flowContext: 'in_app',
         isFirstWallet: false,
       });
     });

--- a/src/utils/watchingAlert.ts
+++ b/src/utils/watchingAlert.ts
@@ -9,7 +9,7 @@ export default function watchingAlert() {
       onPress: () => {
         Navigation.handleAction(Routes.ADD_WALLET_NAVIGATOR, {
           screen: Routes.IMPORT_OR_WATCH_WALLET_SHEET,
-          params: { type: 'import', isFirstWallet: false },
+          params: { flowContext: 'in_app', type: 'import', isFirstWallet: false },
         });
       },
       text: i18n.t(i18n.l.wallet.alert.finish_importing),


### PR DESCRIPTION
## What changed

Adds an ImportFlowContext ('onboarding' | 'in_app') param that threads through the add-wallet
navigation stack (AddWalletNavigator → AddWalletSheet → ImportOrWatchWalletSheet →
useImportingWallet). This lets the import flow branch its post-import behavior based on where the user
entered from:

- flowContext: 'onboarding': runs navigateAfterOnboarding() as before
- flowContext: 'in_app': skips the onboarding navigation and instead uses the new
canShowBackupPrompt / showBackupPrompt helpers to conditionally prompt the user to back up the
imported wallet

Replaces the old backup prompt logic in `useImportingWallet` that was deriving the wallet type from the raw input string (seed phrase / private key) with the shared canShowBackupPrompt / showBackupPrompt helpers that use the actual wallet object.

### Screen recordings / screenshots

Not included because it would include testing seed phrase.

## What to test