### PR TITLE
fix: prevent backup sheet from showing over notification permissions

### DIFF
--- a/src/components/wallet-error/WalletErrorSheet.tsx
+++ b/src/components/wallet-error/WalletErrorSheet.tsx
@@ -63,6 +63,7 @@ export default function WalletErrorSheet() {
                   navigation.goBack();
                   InteractionManager.runAfterInteractions(() => {
                     navigation.navigate(Routes.ADD_WALLET_NAVIGATOR, {
+                      flowContext: 'in_app',
                       isFirstWallet: true,
                     });
                   });

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -298,7 +298,7 @@ export default function useImportingWallet({
         // Dismiss the ADD_WALLET_NAVIGATOR modal stack
         dangerouslyGetParent?.()?.goBack();
 
-        if (flowContext !== 'in_app') {
+        if (flowContext === 'onboarding') {
           await navigateAfterOnboarding();
         }
       } catch (error) {

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -27,9 +27,16 @@ import { IS_ANDROID, IS_TEST } from '@/env';
 import walletBackupTypes from '@/helpers/walletBackupTypes';
 import WalletBackupStepTypes from '@/helpers/walletBackupStepTypes';
 import { useWallets, useAccountAddress } from '@/state/wallets/walletsStore';
+import { type ImportFlowContext } from '@/navigation/types';
 import { navigateAfterOnboarding } from '@/navigation/onboardingNavigation';
 
-export default function useImportingWallet({ showImportModal = true } = {}) {
+export default function useImportingWallet({
+  flowContext,
+  showImportModal = true,
+}: {
+  flowContext?: ImportFlowContext;
+  showImportModal?: boolean;
+} = {}) {
   const accountAddress = useAccountAddress();
   const wallets = useWallets();
 
@@ -290,7 +297,10 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
       try {
         // Dismiss the ADD_WALLET_NAVIGATOR modal stack
         dangerouslyGetParent?.()?.goBack();
-        await navigateAfterOnboarding();
+
+        if (flowContext !== 'in_app') {
+          await navigateAfterOnboarding();
+        }
       } catch (error) {
         logger.error(new RainbowError('[useImportingWallet]: Error navigating to wallet screen'), { error });
         try {
@@ -300,9 +310,9 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
         }
       }
 
-      // Show backup prompt after navigation completes
       InteractionManager.runAfterInteractions(() => {
         if (
+          flowContext === 'in_app' &&
           backupProvider === walletBackupTypes.cloud &&
           !(
             IS_TEST ||
@@ -380,6 +390,7 @@ export default function useImportingWallet({ showImportModal = true } = {}) {
     showImportModal,
     profilesEnabled,
     backupProvider,
+    flowContext,
     resetOnFailure,
     dangerouslyGetParent,
     goBack,

--- a/src/navigation/AddWalletNavigator.tsx
+++ b/src/navigation/AddWalletNavigator.tsx
@@ -15,7 +15,7 @@ const Swipe = createMaterialTopTabNavigator();
 
 export const AddWalletNavigator = () => {
   const {
-    params: { isFirstWallet, type },
+    params: { flowContext = 'in_app', isFirstWallet, type },
   } = useRoute<RouteProp<RootStackParamList, typeof Routes.ADD_WALLET_SHEET>>();
 
   const [scrollEnabled, setScrollEnabled] = useState(false);
@@ -32,7 +32,7 @@ export const AddWalletNavigator = () => {
           >
             <Swipe.Screen
               component={AddWalletSheet}
-              initialParams={{ isFirstWallet }}
+              initialParams={{ flowContext, isFirstWallet }}
               name={Routes.ADD_WALLET_SHEET}
               listeners={{
                 focus: () => {
@@ -54,7 +54,7 @@ export const AddWalletNavigator = () => {
             />
             <Swipe.Screen
               component={ImportOrWatchWalletSheet}
-              initialParams={{ type }}
+              initialParams={{ flowContext, type }}
               name={Routes.IMPORT_OR_WATCH_WALLET_SHEET}
               listeners={{
                 focus: () => {

--- a/src/navigation/PairHardwareWalletNavigator.tsx
+++ b/src/navigation/PairHardwareWalletNavigator.tsx
@@ -23,6 +23,7 @@ export const LedgerImportDeviceIdAtom = atom({
 
 export function PairHardwareWalletNavigator() {
   const { params } = useRoute<RouteProp<RootStackParamList, typeof Routes.PAIR_HARDWARE_WALLET_INTRO_SHEET>>();
+  const flowContext = params?.flowContext;
   const { height, width } = useDimensions();
 
   const [currentRouteName, setCurrentRouteName] = useState<string>(Routes.PAIR_HARDWARE_WALLET_INTRO_SHEET);
@@ -83,6 +84,7 @@ export function PairHardwareWalletNavigator() {
             />
             <Swipe.Screen
               component={PairHardwareWalletSigningSheet}
+              initialParams={{ flowContext }}
               name={Routes.PAIR_HARDWARE_WALLET_SIGNING_SHEET}
               listeners={{
                 focus: () => {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -239,6 +239,7 @@ export type HardwareWalletTxParams = {
 
 export type PairHardwareWalletNavigatorParams = {
   entryPoint?: typeof Routes.ADD_WALLET_SHEET | typeof Routes.IMPORT_OR_WATCH_WALLET_SHEET;
+  flowContext?: ImportFlowContext;
   isFirstWallet?: boolean;
 };
 
@@ -543,6 +544,7 @@ type RouteParams = {
         };
       }>;
   [Routes.PAIR_HARDWARE_WALLET_SIGNING_SHEET]: {
+    flowContext?: ImportFlowContext;
     shouldGoBack?: boolean;
   };
   [Routes.DIAGNOSTICS_SHEET]: {
@@ -616,7 +618,7 @@ type RouteParams = {
   };
   [Routes.PAIR_HARDWARE_WALLET_NAVIGATOR]:
     | NavigatorScreenParams<{
-        [Routes.PAIR_HARDWARE_WALLET_SIGNING_SHEET]: { shouldGoBack?: boolean };
+        [Routes.PAIR_HARDWARE_WALLET_SIGNING_SHEET]: { flowContext?: ImportFlowContext; shouldGoBack?: boolean };
         [Routes.PAIR_HARDWARE_WALLET_INTRO_SHEET]: undefined;
       }>
     | PairHardwareWalletNavigatorParams

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -225,9 +225,12 @@ export type ExplainSheetRouteParams = {
   [K in ExplainSheetType]: ExplainSheetParams<K>;
 }[ExplainSheetType];
 
+export type ImportFlowContext = 'onboarding' | 'in_app';
+
 type AddWalletNavigatorParams = {
   type?: 'import' | 'watch';
   isFirstWallet: boolean;
+  flowContext?: ImportFlowContext;
 };
 
 export type HardwareWalletTxParams = {

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -18,18 +18,19 @@ import WatchWalletIcon from '@/assets/watchWallet.png';
 import { cloudPlatform } from '@/utils/platform';
 import { type RouteProp, useRoute } from '@react-navigation/native';
 import { executeFnIfCloudBackupAvailable } from '@/model/backup';
-import { type RootStackParamList } from '@/navigation/types';
+import { type ImportFlowContext, type RootStackParamList } from '@/navigation/types';
 import { IS_DEV } from '@/env';
 
 const TRANSLATIONS = i18n.l.wallet.new.add_wallet_sheet;
 
 export type AddWalletSheetParams = {
+  flowContext?: ImportFlowContext;
   isFirstWallet: boolean;
 };
 
 export const AddWalletSheet = () => {
   const {
-    params: { isFirstWallet },
+    params: { flowContext = 'in_app', isFirstWallet },
   } = useRoute<RouteProp<RootStackParamList, typeof Routes.ADD_WALLET_SHEET>>();
 
   const { goBack, navigate } = useNavigation();
@@ -58,7 +59,7 @@ export const AddWalletSheet = () => {
     });
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
       screen: Routes.IMPORT_OR_WATCH_WALLET_SHEET,
-      params: { type: 'import', isFirstWallet },
+      params: { flowContext, type: 'import', isFirstWallet },
     });
   };
 
@@ -70,7 +71,7 @@ export const AddWalletSheet = () => {
     });
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
       screen: Routes.IMPORT_OR_WATCH_WALLET_SHEET,
-      params: { type: 'watch', isFirstWallet },
+      params: { flowContext, type: 'watch', isFirstWallet },
     });
   };
 

--- a/src/screens/AddWalletSheet.tsx
+++ b/src/screens/AddWalletSheet.tsx
@@ -100,6 +100,7 @@ export const AddWalletSheet = () => {
     InteractionManager.runAfterInteractions(() => {
       navigate(Routes.PAIR_HARDWARE_WALLET_NAVIGATOR, {
         entryPoint: Routes.ADD_WALLET_SHEET,
+        flowContext,
         isFirstWallet,
       });
     });

--- a/src/screens/ImportOrWatchWalletSheet.tsx
+++ b/src/screens/ImportOrWatchWalletSheet.tsx
@@ -18,9 +18,12 @@ import { opacity } from '@/framework/ui/utils/opacity';
 const TRANSLATIONS = i18n.l.wallet.new.import_or_watch_wallet_sheet;
 
 export const ImportOrWatchWalletSheet = () => {
-  const { params: { type = 'watch' } = {} } = useRoute<RouteProp<RootStackParamList, typeof Routes.IMPORT_OR_WATCH_WALLET_SHEET>>();
+  const { params: { flowContext, type = 'watch' } = {} } =
+    useRoute<RouteProp<RootStackParamList, typeof Routes.IMPORT_OR_WATCH_WALLET_SHEET>>();
 
-  const { busy, handlePressImportButton, handleSetSeedPhrase, inputRef, isSecretValid, seedPhrase } = useImportingWallet();
+  const { busy, handlePressImportButton, handleSetSeedPhrase, inputRef, isSecretValid, seedPhrase } = useImportingWallet({
+    flowContext,
+  });
   const keyboardHeight = useKeyboardHeight();
 
   const textStyle = useTextStyle({

--- a/src/screens/WelcomeScreen/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreen.tsx
@@ -197,6 +197,7 @@ export function WelcomeScreen() {
   const showRestoreSheet = useCallback(() => {
     analytics.track(analytics.event.welcomeAlreadyHave);
     navigate(Routes.ADD_WALLET_NAVIGATOR, {
+      flowContext: 'onboarding',
       isFirstWallet: true,
     });
   }, [navigate]);

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -428,6 +428,7 @@ export default function ChangeWalletSheet() {
     goBack();
     InteractionManager.runAfterInteractions(() => {
       navigate(Routes.ADD_WALLET_NAVIGATOR, {
+        flowContext: 'in_app',
         isFirstWallet: false,
       });
     });

--- a/src/screens/hardware-wallets/PairHardwareWalletSigningSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletSigningSheet.tsx
@@ -83,7 +83,10 @@ export function PairHardwareWalletSigningSheet() {
   const { navigate, goBack } = useNavigation();
   const { isSmallPhone } = useDimensions();
   const deviceId = useRecoilValue(LedgerImportDeviceIdAtom);
-  const { busy, handleSetSeedPhrase, handlePressImportButton } = useImportingWallet({ showImportModal: true });
+  const { busy, handleSetSeedPhrase, handlePressImportButton } = useImportingWallet({
+    flowContext: params?.flowContext,
+    showImportModal: true,
+  });
 
   const items: ItemDetails[] = [
     {

--- a/src/utils/watchingAlert.ts
+++ b/src/utils/watchingAlert.ts
@@ -9,7 +9,7 @@ export default function watchingAlert() {
       onPress: () => {
         Navigation.handleAction(Routes.ADD_WALLET_NAVIGATOR, {
           screen: Routes.IMPORT_OR_WATCH_WALLET_SHEET,
-          params: { type: 'import', isFirstWallet: false },
+          params: { flowContext: 'in_app', type: 'import', isFirstWallet: false },
         });
       },
       text: i18n.t(i18n.l.wallet.alert.finish_importing),


### PR DESCRIPTION
## What changed

This adds an `ImportFlowContext` ('onboarding' | 'in_app') param that is passed through the add-wallet
navigation stack. `useImportingWallet` uses it to branch logic after importing:
- 'onboarding': runs `navigateAfterOnboarding()`, skips the inline backup prompt
- 'in_app': skips `navigateAfterOnboarding()`, shows the backup prompt as before if specific conditions are met. 

## Why

During onboarding, importing a wallet would show the backup prompt sheet on top of the notification
permissions screen. This happened because `useImportingWallet` always called `navigateAfterOnboarding()` regardless of the context.

## Screen recordings / screenshots
Not included because it would include seed phrase / private key.

## What to test
From fresh app install, import a wallet via seed phrase / private key. Notification permissions screen should appear without the backup sheet on top