### PR TITLE
fix(sentry): suppress non-actionable rainbowFetch errors

### DIFF
--- a/src/framework/data/http/rainbowFetch.test.ts
+++ b/src/framework/data/http/rainbowFetch.test.ts
@@ -45,7 +45,8 @@ describe('rainbowFetch', () => {
   });
 
   test('re-throws AbortError without wrapping', async () => {
-    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    const abortError = new Error('The operation was aborted.');
+    abortError.name = 'AbortError';
     mockFetch.mockRejectedValueOnce(abortError);
 
     const promise = rainbowFetch('https://example.com', {});

--- a/src/framework/data/http/rainbowFetch.test.ts
+++ b/src/framework/data/http/rainbowFetch.test.ts
@@ -1,0 +1,55 @@
+import { rainbowFetch, RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('rainbowFetch', () => {
+  test('throws RainbowFetchError with reportToSentry false for 5xx responses', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const promise = rainbowFetch('https://example.com', {});
+    await expect(promise).rejects.toThrow(RainbowFetchError);
+    await expect(promise).rejects.toMatchObject({ reportToSentry: false });
+  });
+
+  test('throws RainbowFetchError with reportToSentry true for 4xx responses', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Not Found' }), {
+        status: 404,
+        statusText: 'Not Found',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const promise = rainbowFetch('https://example.com', {});
+    await expect(promise).rejects.toThrow(RainbowFetchError);
+    await expect(promise).rejects.toMatchObject({ reportToSentry: true });
+  });
+
+  test('throws RainbowFetchError with reportToSentry false for network errors', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+
+    const promise = rainbowFetch('https://example.com', {});
+    await expect(promise).rejects.toThrow(RainbowFetchError);
+    await expect(promise).rejects.toMatchObject({ reportToSentry: false });
+  });
+
+  test('re-throws AbortError without wrapping', async () => {
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    const promise = rainbowFetch('https://example.com', {});
+    await expect(promise).rejects.toThrow(abortError);
+    await expect(promise).rejects.not.toBeInstanceOf(RainbowFetchError);
+  });
+});

--- a/src/framework/data/http/rainbowFetch.test.ts
+++ b/src/framework/data/http/rainbowFetch.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
 });
 
 describe('rainbowFetch', () => {
-  test('throws RainbowFetchError with reportToSentry false for 5xx responses', async () => {
+  test('throws RainbowFetchError with response for 5xx responses', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ error: 'Internal Server Error' }), {
         status: 500,
@@ -17,12 +17,12 @@ describe('rainbowFetch', () => {
       })
     );
 
-    const promise = rainbowFetch('https://example.com', {});
-    await expect(promise).rejects.toThrow(RainbowFetchError);
-    await expect(promise).rejects.toMatchObject({ reportToSentry: false });
+    const error = await rainbowFetch('https://example.com', {}).catch(e => e);
+    expect(error).toBeInstanceOf(RainbowFetchError);
+    expect(error.response?.status).toBe(500);
   });
 
-  test('throws RainbowFetchError with reportToSentry true for 4xx responses', async () => {
+  test('throws RainbowFetchError with response for 4xx responses', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ error: 'Not Found' }), {
         status: 404,
@@ -31,17 +31,17 @@ describe('rainbowFetch', () => {
       })
     );
 
-    const promise = rainbowFetch('https://example.com', {});
-    await expect(promise).rejects.toThrow(RainbowFetchError);
-    await expect(promise).rejects.toMatchObject({ reportToSentry: true });
+    const error = await rainbowFetch('https://example.com', {}).catch(e => e);
+    expect(error).toBeInstanceOf(RainbowFetchError);
+    expect(error.response?.status).toBe(404);
   });
 
-  test('throws RainbowFetchError with reportToSentry false for network errors', async () => {
+  test('throws RainbowFetchError without response for network errors', async () => {
     mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
 
-    const promise = rainbowFetch('https://example.com', {});
-    await expect(promise).rejects.toThrow(RainbowFetchError);
-    await expect(promise).rejects.toMatchObject({ reportToSentry: false });
+    const error = await rainbowFetch('https://example.com', {}).catch(e => e);
+    expect(error).toBeInstanceOf(RainbowFetchError);
+    expect(error.response).toBeUndefined();
   });
 
   test('re-throws AbortError without wrapping', async () => {

--- a/src/framework/data/http/rainbowFetch.ts
+++ b/src/framework/data/http/rainbowFetch.ts
@@ -33,16 +33,25 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
   const requestBody = body && typeof body === 'object' ? JSON.stringify(opts.body) : opts.body;
 
   try {
-    const response = await fetch(`${url}${createParams(params)}`, {
-      ...otherOpts,
-      body: requestBody,
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        ...headers,
-      },
-      signal: abortController.signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${url}${createParams(params)}`, {
+        ...otherOpts,
+        body: requestBody,
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        signal: abortController.signal,
+      });
+    } catch (fetchError) {
+      throw new RainbowFetchError({
+        message: fetchError instanceof Error ? fetchError.message : 'Network request failed',
+        requestBody: body,
+        reportToSentry: false,
+      });
+    }
 
     const responseBody = await getBody(response);
 
@@ -51,14 +60,16 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
       return { data: responseBody, headers, status };
     } else {
       const errorResponseBody = typeof responseBody === 'string' ? { error: responseBody } : responseBody;
+      const message =
+        errorResponseBody?.error || errorResponseBody?.message || response?.statusText || 'There was an error with the request.';
 
-      const error = generateError({
-        requestBody: body,
+      throw new RainbowFetchError({
+        message,
         response,
         responseBody: errorResponseBody,
+        requestBody: body,
+        reportToSentry: response.status < 500,
       });
-
-      throw error;
     }
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
@@ -78,30 +89,32 @@ function createParams(params: RainbowFetchRequestOpts['params']) {
   return params ? `?${new URLSearchParams(params)}` : '';
 }
 
-interface RainbowFetchError extends Error {
+export class RainbowFetchError extends Error {
   response?: Response;
   responseBody?: any;
   requestBody?: RequestInit['body'];
-}
+  reportToSentry: boolean;
 
-function generateError({
-  requestBody,
-  response,
-  responseBody,
-}: {
-  requestBody: RequestInit['body'];
-  response: Response;
-  responseBody: any;
-}) {
-  const message = responseBody?.error || responseBody?.message || response?.statusText || 'There was an error with the request.';
-
-  const error: RainbowFetchError = new Error(message);
-
-  error.response = response;
-  error.responseBody = responseBody;
-  error.requestBody = requestBody;
-
-  return error;
+  constructor({
+    message,
+    response,
+    responseBody,
+    requestBody,
+    reportToSentry = true,
+  }: {
+    message: string;
+    response?: Response;
+    responseBody?: any;
+    requestBody?: RequestInit['body'];
+    reportToSentry?: boolean;
+  }) {
+    super(message);
+    this.name = 'RainbowFetchError';
+    this.response = response;
+    this.responseBody = responseBody;
+    this.requestBody = requestBody;
+    this.reportToSentry = reportToSentry;
+  }
 }
 
 interface RainbowFetchClientOpts extends RainbowFetchRequestOpts {

--- a/src/framework/data/http/rainbowFetch.ts
+++ b/src/framework/data/http/rainbowFetch.ts
@@ -54,7 +54,6 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
       throw new RainbowFetchError({
         message: fetchError instanceof Error ? fetchError.message : 'Network request failed',
         requestBody: body,
-        reportToSentry: false,
       });
     }
 
@@ -73,7 +72,6 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
         response,
         responseBody: errorResponseBody,
         requestBody: body,
-        reportToSentry: response.status < 500,
       });
     }
   } finally {
@@ -98,27 +96,23 @@ export class RainbowFetchError extends Error {
   response?: Response;
   responseBody?: any;
   requestBody?: RequestInit['body'];
-  reportToSentry: boolean;
 
   constructor({
     message,
     response,
     responseBody,
     requestBody,
-    reportToSentry = true,
   }: {
     message: string;
     response?: Response;
     responseBody?: any;
     requestBody?: RequestInit['body'];
-    reportToSentry?: boolean;
   }) {
     super(message);
     this.name = 'RainbowFetchError';
     this.response = response;
     this.responseBody = responseBody;
     this.requestBody = requestBody;
-    this.reportToSentry = reportToSentry;
   }
 }
 

--- a/src/framework/data/http/rainbowFetch.ts
+++ b/src/framework/data/http/rainbowFetch.ts
@@ -46,6 +46,8 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
         signal: abortController.signal,
       });
     } catch (fetchError) {
+      // fetch() only throws on network failures (TypeError) and abort signals (AbortError).
+      // Abort errors are re-thrown as-is so callers can detect them via error.name === 'AbortError'.
       if (fetchError instanceof DOMException && fetchError.name === 'AbortError') {
         throw fetchError;
       }

--- a/src/framework/data/http/rainbowFetch.ts
+++ b/src/framework/data/http/rainbowFetch.ts
@@ -48,7 +48,7 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
     } catch (fetchError) {
       // fetch() only throws on network failures (TypeError) and abort signals (AbortError).
       // Abort errors are re-thrown as-is so callers can detect them via error.name === 'AbortError'.
-      if (fetchError instanceof DOMException && fetchError.name === 'AbortError') {
+      if (fetchError instanceof Error && fetchError.name === 'AbortError') {
         throw fetchError;
       }
       throw new RainbowFetchError({

--- a/src/framework/data/http/rainbowFetch.ts
+++ b/src/framework/data/http/rainbowFetch.ts
@@ -46,6 +46,9 @@ export async function rainbowFetch<T>(url: RequestInfo, opts: RainbowFetchReques
         signal: abortController.signal,
       });
     } catch (fetchError) {
+      if (fetchError instanceof DOMException && fetchError.name === 'AbortError') {
+        throw fetchError;
+      }
       throw new RainbowFetchError({
         message: fetchError instanceof Error ? fetchError.message : 'Network request failed',
         requestBody: body,

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -4,7 +4,6 @@ import * as Sentry from '@sentry/react-native';
 import { type SeverityLevel } from '@sentry/types';
 
 import * as env from '@/env';
-import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { DebugContext } from '@/logger/debugContext';
 import { device } from '@/storage';
 import { push } from '@/logger/logDump';
@@ -173,8 +172,6 @@ export const sentryTransport: Transport = (level: LogLevel, message, { type, tag
         extra: metadata,
       });
     }
-  } else if (message instanceof RainbowError && message.cause instanceof RainbowFetchError && !message.cause.reportToSentry) {
-    // Skip Sentry for non-actionable fetch errors (5xx, network errors)
   } else {
     Sentry.captureException(message, {
       tags,

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react-native';
 import { type SeverityLevel } from '@sentry/types';
 
 import * as env from '@/env';
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { DebugContext } from '@/logger/debugContext';
 import { device } from '@/storage';
 import { push } from '@/logger/logDump';
@@ -172,10 +173,9 @@ export const sentryTransport: Transport = (level: LogLevel, message, { type, tag
         extra: metadata,
       });
     }
+  } else if (message instanceof RainbowError && message.cause instanceof RainbowFetchError && !message.cause.reportToSentry) {
+    // Skip Sentry for non-actionable fetch errors (5xx, network errors)
   } else {
-    /**
-     * It's otherwise an Error and should be reported as onReady
-     */
     Sentry.captureException(message, {
       tags,
       extra: metadata,

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -173,6 +173,9 @@ export const sentryTransport: Transport = (level: LogLevel, message, { type, tag
       });
     }
   } else {
+    /**
+     * It's otherwise an Error and should be reported as onReady
+     */
     Sentry.captureException(message, {
       tags,
       extra: metadata,

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -4,17 +4,25 @@ import * as Sentry from '@sentry/react-native';
 
 import { Logger, LogLevel, RainbowError, sentryTransport } from '@/logger';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+import { defaultOptions } from '@/logger/sentry';
 
 jest.mock('@sentry/react-native', () => ({
   addBreadcrumb: jest.fn(),
   captureException: jest.fn(),
   captureMessage: jest.fn(),
+  httpClientIntegration: jest.fn(),
   Severity: {
     Debug: 'debug',
     Info: 'info',
     Warning: 'warning',
     Error: 'error',
   },
+}));
+
+jest.mock('react-native-version-number', () => ({
+  appVersion: '1.0.0',
+  buildVersion: '1',
+  bundleIdentifier: 'com.test',
 }));
 
 describe('general functionality', () => {
@@ -228,41 +236,16 @@ describe('general functionality', () => {
     });
   });
 
-  test('sentryTransport skips captureException when cause is RainbowFetchError with reportToSentry false', () => {
+  test('sentryTransport always calls captureException for RainbowError', () => {
     jest.clearAllMocks();
 
-    const fetchError = new RainbowFetchError({ message: 'Internal Server Error', reportToSentry: false });
-    const error = new RainbowError('fetch failed', fetchError);
-
-    sentryTransport(LogLevel.Error, error, { tags: { route: 'api' } });
-
-    expect(Sentry.captureException).not.toHaveBeenCalled();
-  });
-
-  test('sentryTransport reports captureException when cause is RainbowFetchError with reportToSentry true', () => {
-    jest.clearAllMocks();
-
-    const fetchError = new RainbowFetchError({ message: 'Not Found', reportToSentry: true });
+    const fetchError = new RainbowFetchError({ message: 'Internal Server Error' });
     const error = new RainbowError('fetch failed', fetchError);
 
     sentryTransport(LogLevel.Error, error, { tags: { route: 'api' } });
 
     expect(Sentry.captureException).toHaveBeenCalledWith(error, {
       tags: { route: 'api' },
-      extra: {},
-    });
-  });
-
-  test('sentryTransport reports captureException for non-RainbowFetchError causes', () => {
-    jest.clearAllMocks();
-
-    const cause = new Error('something else');
-    const error = new RainbowError('generic failure', cause);
-
-    sentryTransport(LogLevel.Error, error, {});
-
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-      tags: undefined,
       extra: {},
     });
   });
@@ -411,5 +394,37 @@ describe('supports levels', () => {
     const e = new RainbowError('original message');
     logger.error(e);
     expect(mockTransport).toHaveBeenCalledWith(LogLevel.Error, e, {});
+  });
+});
+
+describe('beforeSend filtering', () => {
+  const beforeSend = defaultOptions.beforeSend!;
+  const dummyEvent = { exception: { values: [{}] } } as Sentry.Event;
+
+  test('drops events caused by 5xx RainbowFetchError', () => {
+    const fetchError = new RainbowFetchError({ message: 'Internal Server Error', response: { status: 500 } as Response });
+    const error = new RainbowError('fetch failed', fetchError);
+    const result = beforeSend(dummyEvent, { originalException: error });
+    expect(result).toBeNull();
+  });
+
+  test('drops events caused by network errors (no response)', () => {
+    const fetchError = new RainbowFetchError({ message: 'Network request failed' });
+    const error = new RainbowError('fetch failed', fetchError);
+    const result = beforeSend(dummyEvent, { originalException: error });
+    expect(result).toBeNull();
+  });
+
+  test('keeps events caused by 4xx RainbowFetchError', () => {
+    const fetchError = new RainbowFetchError({ message: 'Not Found', response: { status: 404 } as Response });
+    const error = new RainbowError('fetch failed', fetchError);
+    const result = beforeSend(dummyEvent, { originalException: error });
+    expect(result).toBe(dummyEvent);
+  });
+
+  test('keeps events for non-fetch RainbowErrors', () => {
+    const error = new RainbowError('something broke');
+    const result = beforeSend(dummyEvent, { originalException: error });
+    expect(result).toBe(dummyEvent);
   });
 });

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -399,7 +399,7 @@ describe('supports levels', () => {
 
 describe('beforeSend filtering', () => {
   const beforeSend = defaultOptions.beforeSend!;
-  const dummyEvent = { exception: { values: [{}] } } as Sentry.Event;
+  const dummyEvent = { exception: { values: [{}] } } as Sentry.ErrorEvent;
 
   test('drops events caused by 5xx RainbowFetchError', () => {
     const fetchError = new RainbowFetchError({ message: 'Internal Server Error', response: { status: 500 } as Response });

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@jest/globals';
 import * as Sentry from '@sentry/react-native';
 
 import { Logger, LogLevel, RainbowError, sentryTransport } from '@/logger';
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 
 jest.mock('@sentry/react-native', () => ({
   addBreadcrumb: jest.fn(),
@@ -224,6 +225,45 @@ describe('general functionality', () => {
       extra: {
         prop: true,
       },
+    });
+  });
+
+  test('sentryTransport skips captureException when cause is RainbowFetchError with reportToSentry false', () => {
+    jest.clearAllMocks();
+
+    const fetchError = new RainbowFetchError({ message: 'Internal Server Error', reportToSentry: false });
+    const error = new RainbowError('fetch failed', fetchError);
+
+    sentryTransport(LogLevel.Error, error, { tags: { route: 'api' } });
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  test('sentryTransport reports captureException when cause is RainbowFetchError with reportToSentry true', () => {
+    jest.clearAllMocks();
+
+    const fetchError = new RainbowFetchError({ message: 'Not Found', reportToSentry: true });
+    const error = new RainbowError('fetch failed', fetchError);
+
+    sentryTransport(LogLevel.Error, error, { tags: { route: 'api' } });
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      tags: { route: 'api' },
+      extra: {},
+    });
+  });
+
+  test('sentryTransport reports captureException for non-RainbowFetchError causes', () => {
+    jest.clearAllMocks();
+
+    const cause = new Error('something else');
+    const error = new RainbowError('generic failure', cause);
+
+    sentryTransport(LogLevel.Error, error, {});
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      tags: undefined,
+      extra: {},
     });
   });
 

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -33,8 +33,9 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
     // The status code on the response is sufficient to decide; no need for a flag on the error.
     const error = hint?.originalException;
     if (error instanceof RainbowError && error.cause instanceof RainbowFetchError) {
-      const status = error.cause.response?.status;
-      if (!status || status >= 500) return null;
+      const { response } = error.cause;
+      if (!response) return null; // Network failure (no connectivity, timeout, etc.)
+      if (response.status >= 500) return null;
     }
 
     // Check if this is a captureMessage call.

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -3,6 +3,7 @@ import { SENTRY_ENDPOINT, SENTRY_ENVIRONMENT } from 'react-native-dotenv';
 import VersionNumber from 'react-native-version-number';
 
 import { IS_TEST, IS_TEST_FLIGHT } from '@/env';
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { logger, RainbowError } from '@/logger';
 
 // Sentry tests each regex against these candidate strings:
@@ -27,7 +28,15 @@ const IGNORED_ERRORS: Array<string | RegExp> = [
 export const defaultOptions: Sentry.ReactNativeOptions = {
   attachStacktrace: true,
 
-  beforeSend(event) {
+  beforeSend(event, hint) {
+    // Drop non-actionable fetch errors (5xx, network failures).
+    // The status code on the response is sufficient to decide; no need for a flag on the error.
+    const error = hint?.originalException;
+    if (error instanceof RainbowError && error.cause instanceof RainbowFetchError) {
+      const status = error.cause.response?.status;
+      if (!status || status >= 500) return null;
+    }
+
     // Check if this is a captureMessage call.
     //
     // captureMessage events (logger.warn, logger.log) have event.message

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -30,7 +30,6 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
 
   beforeSend(event, hint) {
     // Drop non-actionable fetch errors (5xx, network failures).
-    // The status code on the response is sufficient to decide; no need for a flag on the error.
     const error = hint?.originalException;
     if (error instanceof RainbowError && error.cause instanceof RainbowFetchError) {
       const { response } = error.cause;


### PR DESCRIPTION
Fixes FEPLAT-37

## What changed (plus any additional context for devs)

Server 5xx and network errors from `rainbowFetch` are not actionable client-side but flood Sentry with noise. This PR suppresses those errors in Sentry while keeping 4xx and all non-fetch errors reported normally.

`RainbowFetchError` is now a proper Error subclass (replacing the old interface + `generateError()` helper) that carries the `Response` object. The Sentry `beforeSend` hook inspects `hint.originalException` — if the cause is a `RainbowFetchError` with no response (network failure) or a 5xx status, the event is dropped. All filtering logic stays in `sentry.ts` alongside `ignoreErrors`, keeping `RainbowFetchError` and `sentryTransport` generic. `AbortError` is re-thrown unmodified so callers can still detect cancellations.

## Screen recordings / screenshots

N/A

## What to test

Simulate errors using

```ts
  React.useEffect(() => {
    const { rainbowFetch } = require('@/framework/data/http/rainbowFetch');
    const { logger, RainbowError } = require('@/logger');

    // 1) 5xx — should be DROPPED by beforeSend
    rainbowFetch('https://httpbin.org/status/500', {}).catch((e: Error) => {
      console.log('[SentryTest] caught 5xx error:', e.message, e.constructor.name);
      logger.error(new RainbowError('[SentryTest] 5xx error', e));
    });

    // 2) 4xx — should be REPORTED to Sentry
    rainbowFetch('https://httpbin.org/status/404', {}).catch((e: Error) => {
      console.log('[SentryTest] caught 4xx error:', e.message, e.constructor.name);
      logger.error(new RainbowError('[SentryTest] 4xx error', e));
    });

    // 3) Network error — should be DROPPED by beforeSend
    rainbowFetch('https://httpbin.org/delay/999', { timeout: 1000 }).catch((e: Error) => {
      console.log('[SentryTest] caught network/timeout error:', e.message, e.constructor.name, e.name);
      if (e.name === 'AbortError') {
        // Timeout fires AbortController which re-throws as AbortError — test it gets caught
        logger.error(new RainbowError('[SentryTest] abort/timeout error (should be ignored by ignoreErrors)', e));
        return;
      }
      logger.error(new RainbowError('[SentryTest] network error', e));
    });
  }, []);
```

Verify the only error in sentry is the 4xx one

<img width="816" height="423" alt="image" src="https://github.com/user-attachments/assets/7da14b2d-1c04-4239-b9b4-973c26510c4c" />