### PR TITLE
chore(eslint): enforce colocated test file placement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,6 +134,19 @@ module.exports = {
       },
     },
     {
+      files: ['**/__tests__/**/*', '**/tests/**/*.test.*'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'Program',
+            message:
+              'Test files must be colocated next to the source file they test (e.g., foo.test.ts next to foo.ts). Do not place tests in __tests__/ or tests/ directories.',
+          },
+        ],
+      },
+    },
+    {
       files: ['**/index.ts', '**/index.tsx'],
       excludedFiles: allowedBarrelFiles,
       rules: {


### PR DESCRIPTION
Our test files have historically landed in a mix of `__tests__/` subdirectories, `tests/` subdirectories, and colocated `.test.ts` files next to their source. A series of recent PRs (#7223, #7224) migrated all existing tests to sit next to the modules they exercise. This change adds an ESLint override that errors on any file inside a `__tests__/` or `tests/` directory, preventing regressions back to the old layout.

Colocated tests are easier to discover, make missing coverage more visible, and keep related code together when files move. The rule targets the `Program` node so it fires once per file with a clear message pointing authors to the expected convention.

Closes FEPLAT-45.