### PR TITLE
feature: decoupled claim aidrop flow

### DIFF
--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen.tsx
@@ -1,0 +1,57 @@
+import { memo, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
+import { RnbwHeroCoin } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+import { AmbientCoins } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/AmbientCoins';
+import { BottomGradientGlow } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/BottomGradientGlow';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { ColorModeProvider } from '@/design-system';
+import { useAirdropFlowStore, airdropFlowActions } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { AirdropClaimPromptScene } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimPromptScene';
+import { AirdropClaimingScene } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimingScene';
+import { AirdropClaimedScene } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimedScene';
+
+export const RnbwAirdropScreen = memo(function RnbwAirdropScreen() {
+  const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
+
+  useEffect(() => {
+    airdropFlowActions.reset();
+  }, []);
+
+  return (
+    <ColorModeProvider value="dark">
+      <View style={styles.container} testID="rnbw-airdrop-screen">
+        <SheetHandleFixedToTop color="rgba(245, 248, 255, 0.3)" top={safeAreaTop + 6} />
+        <View style={[styles.flex, { marginTop: safeAreaTop, paddingBottom: safeAreaBottom }]}>
+          <BottomGradientGlow />
+          <AmbientCoins />
+          <RnbwHeroCoin />
+          <RnbwAirdropSceneRouter />
+        </View>
+      </View>
+    </ColorModeProvider>
+  );
+});
+
+function RnbwAirdropSceneRouter() {
+  const activeScene = useAirdropFlowStore(state => state.activeScene);
+
+  return (
+    <View style={styles.flex}>
+      {activeScene === RnbwAirdropScenes.AirdropClaimPrompt && <AirdropClaimPromptScene />}
+      {activeScene === RnbwAirdropScenes.AirdropClaiming && <AirdropClaimingScene />}
+      {activeScene === RnbwAirdropScenes.AirdropClaimed && <AirdropClaimedScene />}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0D0D0D',
+  },
+  flex: {
+    flex: 1,
+  },
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/AmbientCoins.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/AmbientCoins.tsx
@@ -1,0 +1,369 @@
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { StyleSheet, useWindowDimensions, View, Image } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  Easing,
+  interpolate,
+  runOnJS,
+  type SharedValue,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import { BlurView } from 'react-native-blur-view';
+import rnbwCoin from '@/assets/rnbw.png';
+import useTimeout from '@/hooks/useTimeout';
+import { time } from '@/utils/time';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { useAirdropFlowStore } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { getCoinCenterPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+
+// Original design dimensions
+const DESIGN_WIDTH = 393;
+const DESIGN_HEIGHT = 852;
+
+const FLOAT_EASING = Easing.inOut(Easing.ease);
+const EXIT_EASING = Easing.bezier(0.2, 0.9, 0.2, 1);
+const EXIT_DURATION = time.seconds(1);
+// Buffer past exit duration to ensure coins finish animating off-screen before unmount.
+const HIDDEN_UNMOUNT_DELAY = EXIT_DURATION + time.ms(200);
+
+const FLOAT_PATTERNS = {
+  a: { x: 16, y: -18 },
+  b: { x: -18, y: 15 },
+  c: { x: 14, y: 18 },
+  d: { x: -16, y: -16 },
+};
+
+type CoinConfig = {
+  left: number;
+  top: number;
+  size: number;
+  opacity: number;
+  blur: number;
+  pattern: keyof typeof FLOAT_PATTERNS;
+  duration: number;
+  // The x and y translations that the coin animates off screen to
+  exitX: number;
+  exitY: number;
+  // Flips the sign of the x and y values of the pattern
+  reverse?: boolean;
+};
+
+const COINS: CoinConfig[] = [
+  {
+    left: -67,
+    top: 388,
+    size: 108,
+    opacity: 0.8,
+    blur: 2,
+    pattern: 'a',
+    duration: time.seconds(22),
+    reverse: true,
+    exitX: -48,
+    exitY: 24,
+  },
+  {
+    left: -30,
+    top: 236,
+    size: 66,
+    opacity: 0.8,
+    blur: 1,
+    pattern: 'c',
+    duration: time.seconds(16),
+    exitX: -72,
+    exitY: 24,
+  },
+  {
+    left: 63,
+    top: -30,
+    size: 86,
+    opacity: 0.8,
+    blur: 2,
+    pattern: 'a',
+    duration: time.seconds(14),
+    exitX: -48,
+    exitY: -100,
+  },
+  {
+    left: 348,
+    top: 126,
+    size: 74,
+    opacity: 0.9,
+    blur: 1.5,
+    pattern: 'b',
+    duration: time.seconds(18),
+    exitX: 96,
+    exitY: -24,
+  },
+  {
+    left: 300,
+    top: 271,
+    size: 42,
+    opacity: 1,
+    blur: 1,
+    pattern: 'd',
+    duration: time.seconds(20),
+    exitX: 96,
+    exitY: 60,
+  },
+  {
+    left: 333,
+    top: 408,
+    size: 90,
+    opacity: 0.7,
+    blur: 2,
+    pattern: 'b',
+    duration: time.seconds(15),
+    reverse: true,
+    exitX: 78,
+    exitY: 36,
+  },
+];
+
+type AmbientCoinsState = 'visible' | 'hidden' | 'claimed';
+
+const AmbientCoin = memo(function AmbientCoin({
+  config,
+  state,
+  initialExitProgress,
+}: {
+  config: CoinConfig;
+  state: SharedValue<AmbientCoinsState>;
+  initialExitProgress: number;
+}) {
+  const floatProgress = useSharedValue(0);
+  const exitProgress = useSharedValue(initialExitProgress);
+
+  const { left, top, size } = config;
+
+  const claimedCenter = getCoinCenterPosition(RnbwAirdropScenes.AirdropClaimed);
+  const claimedLeft = claimedCenter.x - size / 2;
+  const claimedTop = claimedCenter.y - size / 2;
+
+  const startFloatingAnimation = useCallback(() => {
+    'worklet';
+    const timingConfig = { duration: config.duration / 2, easing: FLOAT_EASING };
+    floatProgress.value = withRepeat(withTiming(1, timingConfig), -1, true);
+  }, [config.duration, floatProgress]);
+
+  const stopFloatingAnimation = useCallback(() => {
+    'worklet';
+    cancelAnimation(floatProgress);
+  }, [floatProgress]);
+
+  const floatX = useDerivedValue(() => {
+    const pattern = FLOAT_PATTERNS[config.pattern];
+    const x = config.reverse ? -pattern.x : pattern.x;
+    return interpolate(floatProgress.value, [0, 1], [0, x]);
+  }, [config.pattern, config.reverse]);
+
+  const floatY = useDerivedValue(() => {
+    const pattern = FLOAT_PATTERNS[config.pattern];
+    const y = config.reverse ? -pattern.y : pattern.y;
+    return interpolate(floatProgress.value, [0, 1], [0, y]);
+  }, [config.pattern, config.reverse]);
+
+  useAnimatedReaction(
+    () => state.value,
+    (current, previous) => {
+      if (current === previous) return;
+      if (current === 'visible') {
+        startFloatingAnimation();
+      } else {
+        stopFloatingAnimation();
+      }
+    },
+    [startFloatingAnimation, stopFloatingAnimation]
+  );
+
+  useEffect(() => {
+    return () => {
+      stopFloatingAnimation();
+      cancelAnimation(exitProgress);
+    };
+  }, [exitProgress, stopFloatingAnimation]);
+
+  // Animate off screen for 'hidden' and behind primary coin icon for 'claimed' state
+  useAnimatedReaction(
+    () => state.value,
+    current => {
+      let delay = 0;
+      if (current === 'claimed') {
+        const distanceFromClaimPosition = Math.sqrt(Math.pow(claimedLeft - left, 2) + Math.pow(claimedTop - top, 2));
+        // Normalize distance to 0-1 from 200-300
+        const normalizedDistance = Math.max(0, Math.min(1, (distanceFromClaimPosition - 200) / 100));
+        delay = normalizedDistance * time.ms(100);
+        // Reset to offscreen starting position so coins fly in from edges
+        exitProgress.value = 0;
+      }
+
+      exitProgress.value = withDelay(
+        delay,
+        withTiming(current === 'visible' ? 0 : 1, {
+          duration: EXIT_DURATION,
+          easing: EXIT_EASING,
+        })
+      );
+    },
+    [exitProgress, claimedLeft, claimedTop, left, top]
+  );
+
+  const containerStyle = useAnimatedStyle(() => {
+    if (state.value === 'claimed') {
+      return {
+        left: interpolate(exitProgress.value, [0, 1], [left + config.exitX, claimedLeft]),
+        top: interpolate(exitProgress.value, [0, 1], [top + config.exitY, claimedTop]),
+        transform: [{ translateX: floatX.value }, { translateY: floatY.value }],
+      };
+    }
+
+    return {
+      left,
+      top,
+      transform: [{ translateX: floatX.value }, { translateY: floatY.value }],
+    };
+  });
+
+  const innerStyle = useAnimatedStyle(() => {
+    if (state.value === 'claimed') {
+      return {
+        opacity: interpolate(exitProgress.value, [0, 1], [config.opacity, 0]),
+        transform: [{ scale: interpolate(exitProgress.value, [0, 1], [1, 0.6]) }],
+      };
+    }
+
+    return {
+      opacity: interpolate(exitProgress.value, [0, 1], [config.opacity, 0]),
+      transform: [
+        { translateX: interpolate(exitProgress.value, [0, 1], [0, config.exitX]) },
+        { translateY: interpolate(exitProgress.value, [0, 1], [0, config.exitY]) },
+        { scale: interpolate(exitProgress.value, [0, 1], [1, 0.55]) },
+      ],
+    };
+  });
+
+  return (
+    <Animated.View
+      style={[
+        styles.coinContainer,
+        {
+          width: size,
+          height: size,
+        },
+        containerStyle,
+      ]}
+    >
+      <Animated.View style={[styles.coinInner, innerStyle]}>
+        <View style={styles.blurWrapper}>
+          <Image source={rnbwCoin} style={{ width: size, height: size }} />
+          <BlurView style={StyleSheet.absoluteFill} blurStyle="plain" blurIntensity={config.blur} />
+        </View>
+      </Animated.View>
+    </Animated.View>
+  );
+});
+
+const _AmbientCoins = memo(function _AmbientCoins({ state, entering }: { state: SharedValue<AmbientCoinsState>; entering: boolean }) {
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
+
+  const scaledCoins: CoinConfig[] = useMemo(() => {
+    const scaleX = screenWidth / DESIGN_WIDTH;
+    const scaleY = screenHeight / DESIGN_HEIGHT;
+
+    return COINS.map(({ left, top, size, ...config }) => ({
+      ...config,
+      left: left * scaleX,
+      top: top * scaleY,
+      exitX: config.exitX * scaleX,
+      exitY: config.exitY * scaleY,
+      size: size * scaleX,
+    }));
+  }, [screenHeight, screenWidth]);
+
+  return (
+    <View style={styles.container} pointerEvents="none">
+      {scaledCoins.map((config, index) => (
+        <AmbientCoin key={index} config={config} state={state} initialExitProgress={entering ? 1 : 0} />
+      ))}
+    </View>
+  );
+});
+
+export const AmbientCoins = memo(function AmbientCoins() {
+  const activeScene = useStoreSharedValue(useAirdropFlowStore, state => state.activeScene, { fireImmediately: true });
+  const [mountState, setMountState] = useState({ shouldRender: true, entering: false });
+  const [startHideTimeout, stopHideTimeout] = useTimeout();
+
+  const state = useDerivedValue(() => {
+    switch (activeScene.value) {
+      case RnbwAirdropScenes.AirdropClaimPrompt:
+        return 'visible';
+      case RnbwAirdropScenes.AirdropClaimed:
+        return 'claimed';
+      default:
+        return 'hidden';
+    }
+  }, [activeScene]);
+
+  const show = useCallback(
+    (nextState: AmbientCoinsState) => {
+      stopHideTimeout();
+      setMountState(prev => {
+        if (prev.shouldRender) return prev;
+        return {
+          shouldRender: true,
+          entering: nextState === 'visible',
+        };
+      });
+    },
+    [stopHideTimeout]
+  );
+
+  const scheduleHide = useCallback(() => {
+    stopHideTimeout();
+    startHideTimeout(() => {
+      setMountState({ shouldRender: false, entering: false });
+    }, HIDDEN_UNMOUNT_DELAY);
+  }, [startHideTimeout, stopHideTimeout]);
+
+  useAnimatedReaction(
+    () => state.value,
+    (current, previous) => {
+      if (current === previous) return;
+      if (current === 'hidden') {
+        runOnJS(scheduleHide)();
+      } else {
+        runOnJS(show)(current);
+      }
+    },
+    [scheduleHide, show]
+  );
+
+  if (!mountState.shouldRender) return null;
+
+  return <_AmbientCoins state={state} entering={mountState.entering} />;
+});
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    overflow: 'visible',
+  },
+  coinContainer: {
+    position: 'absolute',
+  },
+  coinInner: {
+    flex: 1,
+  },
+  blurWrapper: {
+    flex: 1,
+    borderRadius: 9999,
+    overflow: 'hidden',
+  },
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/BottomGradientGlow.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/BottomGradientGlow.tsx
@@ -1,0 +1,172 @@
+import { type RnbwAirdropScene, RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { useAirdropFlowStore } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { Blur, Canvas, LinearGradient, RoundedRect, vec } from '@shopify/react-native-skia';
+import { interpolate, interpolateColor, useAnimatedReaction, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
+import { memo, useMemo } from 'react';
+import useDimensions from '@/hooks/useDimensions';
+import { time } from '@/utils/time';
+
+type GradientConfig = {
+  colors: readonly string[];
+  positions: readonly number[];
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+};
+
+type SceneGradient = {
+  scene: RnbwAirdropScene;
+  gradient: GradientConfig;
+  opacity: number;
+};
+
+const GLOW = {
+  width: 448,
+  height: 695,
+  borderRadius: 180,
+  blurRadius: 60,
+} as const;
+
+const CANVAS_OFFSET_FROM_BOTTOM = 271;
+const BLUR_PADDING = GLOW.blurRadius * 2;
+const ANIMATION_DURATION_MS = time.ms(300);
+
+const BLUE_ORANGE_GRADIENT: GradientConfig = {
+  colors: ['#3887F2', '#40F5CC', '#FF9129', '#FFE636'],
+  positions: [0.11, 0.4, 0.64, 0.9],
+  start: { x: 0.02, y: 0.69 },
+  end: { x: 0.98, y: 0.69 },
+};
+
+export const BottomGradientGlow = memo(function BottomGradientGlow() {
+  const { width: screenWidth, height: screenHeight } = useDimensions();
+  const activeScene = useStoreSharedValue(useAirdropFlowStore, state => state.activeScene, { fireImmediately: true });
+
+  const config = useMemo(() => {
+    const sceneGradients: SceneGradient[] = [
+      { scene: RnbwAirdropScenes.AirdropClaimPrompt, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.2 },
+      { scene: RnbwAirdropScenes.AirdropClaimed, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.12 },
+    ];
+
+    const inputRange = sceneGradients.map((_, index) => index);
+    const sceneIndex = sceneGradients.reduce<Partial<Record<RnbwAirdropScene, number>>>(
+      (acc, item, index) => {
+        acc[item.scene] = index;
+        return acc;
+      },
+      {} as Partial<Record<RnbwAirdropScene, number>>
+    );
+    const sceneOpacity = sceneGradients.reduce<Partial<Record<RnbwAirdropScene, number>>>(
+      (acc, item) => {
+        acc[item.scene] = item.opacity;
+        return acc;
+      },
+      {} as Partial<Record<RnbwAirdropScene, number>>
+    );
+
+    const gradientSequence = sceneGradients.map(item => item.gradient);
+
+    const buildStopOutputRanges = <T,>(configs: GradientConfig[], selector: (config: GradientConfig) => readonly T[]) => {
+      const stopCount = selector(configs[0]).length;
+      const outputRanges: T[][] = Array.from({ length: stopCount }, () => []);
+      for (const config of configs) {
+        const stops = selector(config);
+        for (let i = 0; i < stopCount; i += 1) {
+          outputRanges[i].push(stops[i]);
+        }
+      }
+      return outputRanges;
+    };
+
+    const colorStops = buildStopOutputRanges(gradientSequence, config => config.colors);
+    const positionStops = buildStopOutputRanges(gradientSequence, config => config.positions);
+    const startX = gradientSequence.map(config => config.start.x);
+    const startY = gradientSequence.map(config => config.start.y);
+    const endX = gradientSequence.map(config => config.end.x);
+    const endY = gradientSequence.map(config => config.end.y);
+
+    return {
+      sceneIndex,
+      sceneOpacity,
+      inputRange,
+      colorStops,
+      positionStops,
+      startX,
+      startY,
+      endX,
+      endY,
+    };
+  }, []);
+
+  const sceneProgress = useSharedValue(0);
+  const opacity = useSharedValue(0);
+
+  useAnimatedReaction(
+    () => activeScene.value,
+    scene => {
+      const targetIndex = config.sceneIndex[scene];
+      const targetOpacity = config.sceneOpacity[scene];
+      if (targetIndex !== undefined && targetOpacity !== undefined) {
+        sceneProgress.value = withTiming(targetIndex, { duration: ANIMATION_DURATION_MS });
+        opacity.value = withTiming(targetOpacity, { duration: ANIMATION_DURATION_MS });
+        return;
+      }
+      opacity.value = withTiming(0, { duration: ANIMATION_DURATION_MS });
+    },
+    [activeScene, config]
+  );
+
+  const colors = useDerivedValue(() => {
+    const value = sceneProgress.value;
+    const result = new Array(config.colorStops.length);
+    for (let i = 0; i < config.colorStops.length; i += 1) {
+      result[i] = interpolateColor(value, config.inputRange, config.colorStops[i]);
+    }
+    return result;
+  }, [sceneProgress, config]);
+
+  const positions = useDerivedValue(() => {
+    const value = sceneProgress.value;
+    const result = new Array(config.positionStops.length);
+    for (let i = 0; i < config.positionStops.length; i += 1) {
+      result[i] = interpolate(value, config.inputRange, config.positionStops[i]);
+    }
+    return result;
+  }, [sceneProgress, config]);
+
+  const start = useDerivedValue(() => {
+    const value = sceneProgress.value;
+    return vec(
+      BLUR_PADDING + GLOW.width * interpolate(value, config.inputRange, config.startX),
+      BLUR_PADDING + GLOW.height * interpolate(value, config.inputRange, config.startY)
+    );
+  }, [sceneProgress, config]);
+
+  const end = useDerivedValue(() => {
+    const value = sceneProgress.value;
+    return vec(
+      BLUR_PADDING + GLOW.width * interpolate(value, config.inputRange, config.endX),
+      BLUR_PADDING + GLOW.height * interpolate(value, config.inputRange, config.endY)
+    );
+  }, [sceneProgress, config]);
+
+  const canvasWidth = GLOW.width + BLUR_PADDING * 2;
+  const canvasHeight = GLOW.height + BLUR_PADDING * 2;
+
+  return (
+    <Canvas
+      style={{
+        position: 'absolute',
+        width: canvasWidth,
+        height: canvasHeight,
+        top: screenHeight - CANVAS_OFFSET_FROM_BOTTOM - BLUR_PADDING,
+        left: screenWidth / 2 - GLOW.width / 2 - BLUR_PADDING,
+      }}
+    >
+      <RoundedRect x={BLUR_PADDING} y={BLUR_PADDING} width={GLOW.width} height={GLOW.height} r={GLOW.borderRadius} opacity={opacity}>
+        <LinearGradient start={start} end={end} colors={colors} positions={positions} />
+        <Blur blur={GLOW.blurRadius} />
+      </RoundedRect>
+    </Canvas>
+  );
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin.tsx
@@ -1,0 +1,274 @@
+import { memo, useRef } from 'react';
+import { View, StyleSheet, Image } from 'react-native';
+import { Box, globalColors, Text } from '@/design-system';
+import rnbwCoinImage from '@/assets/rnbw.png';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  withDelay,
+  withTiming,
+  ZoomIn,
+  ZoomOut,
+} from 'react-native-reanimated';
+import { type RnbwAirdropScene, RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+import { time } from '@/utils/time';
+import { transitionEasing } from '@/features/rnbw-rewards/animations/sceneTransitions';
+import { LoadingSpinner } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/components/LoadingSpinner';
+import concentricCircleImage from '@/features/rnbw-rewards/assets/radial-circle.png';
+import { SpinnableCoin, type SpinnableCoinHandle } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/components/SpinnableCoin';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
+import { useAirdropFlowStore } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { Blur, Canvas, RoundedRect } from '@shopify/react-native-skia';
+import { THICK_BORDER_WIDTH } from '@/styles/constants';
+
+const COIN_SIZE = 160;
+const SMALL_COIN_SIZE = 90;
+const MEDIUM_COIN_SIZE = 108;
+const LOADING_SPINNER_SIZE = 112;
+const SMALL_COIN_SCALE = SMALL_COIN_SIZE / COIN_SIZE;
+const MEDIUM_COIN_SCALE = MEDIUM_COIN_SIZE / COIN_SIZE;
+
+const CONCENTRIC_CIRCLE_SIZE = 633;
+const INNERMOST_CIRCLE_SIZE = 182;
+const BLUR_INTENSITY = 47;
+const BLUR_EXTENT = BLUR_INTENSITY * 3;
+const BLUR_CIRCLE_SIZE = 224;
+
+const STEP_TRANSITION_DELAY = time.ms(100);
+
+const scenesConfig: Record<RnbwAirdropScene, { scale: number; translateY: number }> = {
+  [RnbwAirdropScenes.AirdropClaimPrompt]: {
+    scale: 1,
+    translateY: 75,
+  },
+  [RnbwAirdropScenes.AirdropClaiming]: {
+    scale: SMALL_COIN_SCALE,
+    translateY: 262,
+  },
+  [RnbwAirdropScenes.AirdropClaimed]: {
+    scale: MEDIUM_COIN_SCALE,
+    translateY: 246,
+  },
+};
+
+const LOADING_SPINNER_TOP =
+  scenesConfig[RnbwAirdropScenes.AirdropClaiming].translateY -
+  (LOADING_SPINNER_SIZE - COIN_SIZE * scenesConfig[RnbwAirdropScenes.AirdropClaiming].scale) / 2;
+
+const timingConfig = { duration: time.seconds(1), easing: transitionEasing };
+const loadingSpinnerEnteringAnimation = FadeIn.delay(timingConfig.duration * 0.5).easing(transitionEasing);
+const loadingSpinnerExitingAnimation = FadeOut.easing(transitionEasing);
+
+const successIconEnterAnimation = ZoomIn.duration(timingConfig.duration * 0.25)
+  .delay(timingConfig.duration * 0.25)
+  .easing(transitionEasing);
+const successIconExitAnimation = ZoomOut.easing(transitionEasing);
+
+export const RnbwHeroCoin = memo(function RnbwHeroCoin() {
+  const activeScene = useStoreSharedValue(useAirdropFlowStore, state => state.activeScene, { fireImmediately: true });
+  const activeSceneState = useAirdropFlowStore(state => state.activeScene);
+  const coinRef = useRef<SpinnableCoinHandle>(null);
+
+  useAnimatedReaction(
+    () => activeScene.value,
+    (current, previous) => {
+      if (current === RnbwAirdropScenes.AirdropClaiming && previous === RnbwAirdropScenes.AirdropClaimPrompt) {
+        coinRef.current?.spin({ turns: 0.5, durationMs: time.seconds(1.8) });
+      }
+    },
+    []
+  );
+
+  const coinAnimatedStyle = useAnimatedStyle(() => {
+    const config = scenesConfig[activeScene.value];
+    return {
+      transform: [
+        { translateY: withDelay(STEP_TRANSITION_DELAY, withTiming(config.translateY, timingConfig)) },
+        { scale: withDelay(STEP_TRANSITION_DELAY, withTiming(config.scale, timingConfig)) },
+      ],
+    };
+  }, [activeScene]);
+
+  const concentricCircleAnimatedStyle = useAnimatedStyle(() => {
+    const config = scenesConfig[activeScene.value];
+    const coinSize = COIN_SIZE * config.scale;
+    const coinRadius = coinSize / 2;
+
+    const circleSize = CONCENTRIC_CIRCLE_SIZE * config.scale;
+    const circleCenter = getCircleRelativeCenterPoint(circleSize);
+    const top = config.translateY - circleCenter.y + coinRadius;
+
+    return {
+      transform: [
+        { translateY: withDelay(STEP_TRANSITION_DELAY, withTiming(top, timingConfig)) },
+        { scale: withDelay(STEP_TRANSITION_DELAY, withTiming(config.scale, timingConfig)) },
+      ],
+    };
+  }, [activeScene]);
+
+  const blurAnimatedStyle = useAnimatedStyle(() => {
+    const config = scenesConfig[activeScene.value];
+    const coinSize = COIN_SIZE * config.scale;
+    const top = config.translateY + coinSize / 2 - BLUR_CIRCLE_SIZE / 2;
+
+    return {
+      transform: [
+        { translateY: withDelay(STEP_TRANSITION_DELAY, withTiming(top, timingConfig)) },
+        { scale: withDelay(STEP_TRANSITION_DELAY, withTiming(config.scale, timingConfig)) },
+      ],
+    };
+  }, [activeScene]);
+
+  return (
+    <View style={styles.container}>
+      <Animated.View style={[styles.blurContainer, blurAnimatedStyle]}>
+        <Canvas
+          style={{
+            width: BLUR_CIRCLE_SIZE + BLUR_EXTENT * 2,
+            height: BLUR_CIRCLE_SIZE + BLUR_EXTENT * 2,
+          }}
+        >
+          <RoundedRect
+            x={BLUR_EXTENT}
+            y={BLUR_EXTENT}
+            width={BLUR_CIRCLE_SIZE}
+            height={BLUR_CIRCLE_SIZE}
+            r={BLUR_CIRCLE_SIZE / 2}
+            color={opacity('#F6D56B', 0.2)}
+          >
+            <Blur blur={BLUR_INTENSITY} />
+          </RoundedRect>
+        </Canvas>
+      </Animated.View>
+
+      <Animated.View style={[styles.concentricCircleContainer, concentricCircleAnimatedStyle]}>
+        <Image source={concentricCircleImage} style={styles.concentricCircle} />
+      </Animated.View>
+
+      <Animated.View style={[styles.coinContainer, coinAnimatedStyle]}>
+        <SpinnableCoin ref={coinRef} source={rnbwCoinImage} size={COIN_SIZE} />
+        {activeSceneState === RnbwAirdropScenes.AirdropClaimed && (
+          <Animated.View style={styles.successIcon} entering={successIconEnterAnimation} exiting={successIconExitAnimation}>
+            <Box
+              backgroundColor="#1F9E39"
+              width={52}
+              height={52}
+              borderRadius={26}
+              justifyContent="center"
+              alignItems="center"
+              borderWidth={THICK_BORDER_WIDTH}
+              borderColor={{ custom: opacity(globalColors.white100, 0.12) }}
+              shadow={'24px'}
+            >
+              <InnerShadow color={opacity(globalColors.white100, 0.28)} width={52} height={52} blur={3.5} dx={0} dy={6} />
+              <Text color="label" size="26pt" weight="heavy" align="center">
+                {'􀆅'}
+              </Text>
+            </Box>
+          </Animated.View>
+        )}
+      </Animated.View>
+
+      <CoinLoadingSpinner />
+    </View>
+  );
+});
+
+function CoinLoadingSpinner() {
+  const activeSceneState = useAirdropFlowStore(state => state.activeScene);
+  const isLoading = activeSceneState === RnbwAirdropScenes.AirdropClaiming;
+  if (!isLoading) return null;
+  return (
+    <Animated.View
+      style={[styles.loadingSpinner, { top: LOADING_SPINNER_TOP }]}
+      entering={loadingSpinnerEnteringAnimation}
+      exiting={loadingSpinnerExitingAnimation}
+    >
+      <LoadingSpinner color={'#F6D66C'} size={LOADING_SPINNER_SIZE} strokeWidth={2} />
+    </Animated.View>
+  );
+}
+
+function getCircleRelativeCenterPoint(size: number) {
+  'worklet';
+  const circleSizeScale = size / CONCENTRIC_CIRCLE_SIZE;
+  const outerHeight = size;
+  const innerHeight = INNERMOST_CIRCLE_SIZE * circleSizeScale;
+
+  const offsetPercent = 0.095;
+
+  const centeredGap = (outerHeight - innerHeight) / 2;
+  const offsetDistance = offsetPercent * centeredGap;
+  const actualTop = centeredGap + offsetDistance;
+
+  const innerCircleCenterY = actualTop + innerHeight / 2;
+
+  return {
+    x: size / 2,
+    y: innerCircleCenterY,
+  };
+}
+
+export function getCoinBottomPosition(scene: RnbwAirdropScene) {
+  const config = scenesConfig[scene];
+  return config.translateY + COIN_SIZE * config.scale;
+}
+
+export function getCoinCenterPosition(scene: RnbwAirdropScene) {
+  const config = scenesConfig[scene];
+  const coinSize = COIN_SIZE * config.scale;
+  return {
+    x: DEVICE_WIDTH / 2,
+    y: config.translateY + coinSize / 2,
+  };
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+  },
+  coinContainer: {
+    position: 'absolute',
+    left: DEVICE_WIDTH / 2 - COIN_SIZE / 2,
+    transformOrigin: 'center top',
+    shadowColor: opacity(globalColors.grey100, 0.27),
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 17,
+  },
+  loadingSpinner: {
+    position: 'absolute',
+    left: DEVICE_WIDTH / 2 - LOADING_SPINNER_SIZE / 2,
+    width: LOADING_SPINNER_SIZE,
+    height: LOADING_SPINNER_SIZE,
+    transformOrigin: 'center top',
+  },
+  concentricCircleContainer: {
+    position: 'absolute',
+    left: DEVICE_WIDTH / 2 - CONCENTRIC_CIRCLE_SIZE / 2,
+    transformOrigin: 'center top',
+  },
+  concentricCircle: {
+    width: CONCENTRIC_CIRCLE_SIZE,
+    height: CONCENTRIC_CIRCLE_SIZE,
+  },
+  blurContainer: {
+    position: 'absolute',
+    top: 0,
+    left: DEVICE_WIDTH / 2 - BLUR_CIRCLE_SIZE / 2,
+    width: BLUR_CIRCLE_SIZE,
+    height: BLUR_CIRCLE_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'visible',
+  },
+  successIcon: {
+    position: 'absolute',
+    bottom: 0,
+    right: -4,
+  },
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes.ts
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes.ts
@@ -1,0 +1,7 @@
+export const RnbwAirdropScenes = {
+  AirdropClaimPrompt: 'airdrop-claim-prompt',
+  AirdropClaiming: 'airdrop-claiming',
+  AirdropClaimed: 'airdrop-claimed',
+} as const;
+
+export type RnbwAirdropScene = (typeof RnbwAirdropScenes)[keyof typeof RnbwAirdropScenes];

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimPromptScene.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimPromptScene.tsx
@@ -1,0 +1,110 @@
+import { memo, useCallback, useState } from 'react';
+import { Alert, View, StyleSheet } from 'react-native';
+import { Box, globalColors, Text } from '@/design-system';
+import * as i18n from '@/languages';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import Animated from 'react-native-reanimated';
+import { time } from '@/utils/time';
+import { defaultExitAnimation, createScaleInFadeInSlideEnterAnimation } from '@/features/rnbw-rewards/animations/sceneTransitions';
+import { getCoinBottomPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
+import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import { airdropFlowActions } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useAccountAddress, useIsHardwareWallet } from '@/state/wallets/walletsStore';
+import { useNavigation } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { prepareAirdropClaim } from '@/features/rnbw-rewards/utils/claimAirdrop';
+
+const enteringAnimation = createScaleInFadeInSlideEnterAnimation({ translateY: 24, delay: time.ms(200) });
+
+export const AirdropClaimPromptScene = memo(function AirdropClaimPromptScene() {
+  const { tokenAmount, nativeCurrencyAmount } = useAirdropBalanceStore(state => state.getFormattedBalance());
+  const hasClaimableAirdrop = useAirdropBalanceStore(state => state.hasClaimableAirdrop());
+  const getMessageToSign = useAirdropBalanceStore(state => state.getMessageToSign);
+  const { navigate } = useNavigation();
+
+  const accountAddress = useAccountAddress();
+  const isHardwareWallet = useIsHardwareWallet();
+  const [isPreparingClaim, setIsPreparingClaim] = useState(false);
+
+  const showClaimError = useCallback(() => {
+    Alert.alert(i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_title), i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_message));
+  }, []);
+
+  const startClaimAirdrop = useCallback(async () => {
+    setIsPreparingClaim(true);
+    try {
+      const message = getMessageToSign() ?? '';
+      const preparedClaim = await prepareAirdropClaim({ message, address: accountAddress });
+      airdropFlowActions.startAirdropClaimSubmission(preparedClaim);
+      airdropFlowActions.setActiveScene(RnbwAirdropScenes.AirdropClaiming);
+    } catch (error) {
+      showClaimError();
+      setIsPreparingClaim(false);
+    }
+  }, [accountAddress, getMessageToSign, showClaimError]);
+
+  const handleClaimAirdrop = () => {
+    if (isHardwareWallet) {
+      navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: startClaimAirdrop });
+    } else {
+      startClaimAirdrop();
+    }
+  };
+
+  return (
+    <Animated.View style={styles.container} entering={enteringAnimation} exiting={defaultExitAnimation}>
+      <View style={[styles.amountContainer, { top: getCoinBottomPosition(RnbwAirdropScenes.AirdropClaimPrompt) + 32 }]}>
+        <Box gap={16} alignItems="center" width="full">
+          <Text size="22pt" weight="heavy" color="labelQuaternary" align="center">
+            {i18n.t(i18n.l.rnbw_rewards.claim.your_airdrop).toUpperCase()}
+          </Text>
+          <Text size="64pt" weight="heavy" color="label" align="center">
+            {nativeCurrencyAmount}
+          </Text>
+          <Text size="20pt" weight="bold" color={hasClaimableAirdrop ? 'label' : 'labelQuaternary'} align="center">
+            {`${tokenAmount} ${RNBW_SYMBOL}`}
+          </Text>
+        </Box>
+      </View>
+      <Box gap={24} alignItems="center" paddingHorizontal={{ custom: 40 }}>
+        <Text color={{ custom: '#989A9E' }} size="17pt / 150%" weight="semibold" align="center">
+          {i18n.t(i18n.l.rnbw_rewards.claim.your_airdrop_description)}
+        </Text>
+        <HoldToActivateButton
+          label={i18n.t(i18n.l.button.hold_to_authorize.hold_to_claim)}
+          onLongPress={handleClaimAirdrop}
+          backgroundColor={globalColors.white100}
+          disabledBackgroundColor={globalColors.white30}
+          disabled={false}
+          isProcessing={isPreparingClaim}
+          processingLabel={i18n.t(i18n.l.button.hold_to_authorize.claiming)}
+          showBiometryIcon={false}
+          progressColor="black"
+          style={styles.button}
+          weight="black"
+          color="black"
+          size="22pt"
+        />
+      </Box>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingBottom: 32,
+  },
+  button: {
+    height: 51,
+    width: 260,
+    borderRadius: 26,
+  },
+  amountContainer: {
+    position: 'absolute',
+    width: '100%',
+  },
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimedScene.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimedScene.tsx
@@ -1,0 +1,74 @@
+import { memo } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { Box, Text } from '@/design-system';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { createScaleInFadeInSlideEnterAnimation, defaultExitAnimation } from '@/features/rnbw-rewards/animations/sceneTransitions';
+import { getCoinBottomPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
+import * as i18n from '@/languages';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import { useNavigation } from '@/navigation/Navigation';
+
+const enteringAnimation = createScaleInFadeInSlideEnterAnimation({ translateY: -24 });
+const exitingAnimation = defaultExitAnimation;
+
+export const AirdropClaimedScene = memo(function AirdropClaimedScene() {
+  const { tokenAmount } = useAirdropBalanceStore(state => state.getFormattedAirdroppedBalance());
+  const { goBack } = useNavigation();
+
+  return (
+    <Animated.View style={styles.container} entering={enteringAnimation} exiting={exitingAnimation}>
+      <Box
+        gap={24}
+        alignItems="center"
+        style={[styles.claimInfoContainer, { top: getCoinBottomPosition(RnbwAirdropScenes.AirdropClaimed) + 20 }]}
+      >
+        <Text color="label" size="30pt" weight="heavy" align="center">
+          {i18n.t(i18n.l.rnbw_rewards.airdrop_claim_finished.airdrop_claimed)}
+        </Text>
+        <Text color="labelTertiary" size="17pt / 135%" weight="semibold" align="center">
+          {i18n.t(i18n.l.rnbw_rewards.airdrop_claim_finished.you_claimed)}
+          <Text color="label" size="17pt" weight="bold" align="center">
+            {` ${tokenAmount} ${RNBW_SYMBOL}`}
+          </Text>
+        </Text>
+      </Box>
+      <ButtonPressAnimation onPress={goBack} scaleTo={0.96} style={styles.button}>
+        <Box
+          backgroundColor={opacity('#F5F8FF', 0.06)}
+          width="full"
+          height={52}
+          borderRadius={26}
+          justifyContent="center"
+          alignItems="center"
+          borderColor={'separatorTertiary'}
+          borderWidth={1}
+        >
+          <Text color="label" size="22pt" weight="heavy" align="center">
+            {i18n.t(i18n.l.button.done)}
+          </Text>
+        </Box>
+      </ButtonPressAnimation>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingBottom: 24,
+  },
+  claimInfoContainer: {
+    position: 'absolute',
+    width: '100%',
+    alignItems: 'center',
+  },
+  button: {
+    width: '100%',
+    paddingHorizontal: 42,
+  },
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimingScene.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimingScene.tsx
@@ -1,0 +1,100 @@
+import { memo, useCallback, useEffect, useState } from 'react';
+import { Alert, StyleSheet, View } from 'react-native';
+import { Box, Text, TextIcon } from '@/design-system';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { ActionStatusScene } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/ActionStatusScene';
+import { useAirdropFlowStore, airdropFlowActions } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import * as i18n from '@/languages';
+import { getCoinBottomPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+import { ETH_COLOR_DARK } from '@/__swaps__/screens/Swap/constants';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { time } from '@/utils/time';
+import Animated from 'react-native-reanimated';
+import { defaultEnterAnimation, defaultExitAnimation } from '@/features/rnbw-rewards/animations/sceneTransitions';
+
+const LONGER_THAN_USUAL_TIME = time.seconds(10);
+
+export const AirdropClaimingScene = memo(function AirdropClaimingScene() {
+  const airdropClaimRequest = useAirdropFlowStore(state => state.airdropClaimRequest);
+  const labels = [
+    i18n.t(i18n.l.rnbw_rewards.loading_labels.claiming_airdrop),
+    i18n.t(i18n.l.rnbw_rewards.loading_labels.submitting_transaction),
+  ];
+
+  const showClaimError = useCallback(() => {
+    Alert.alert(i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_title), i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_message));
+  }, []);
+
+  const handleClaimAirdropComplete = useCallback(
+    (taskStatus: 'success' | 'error') => {
+      if (taskStatus === 'error') {
+        showClaimError();
+        airdropFlowActions.setActiveScene(RnbwAirdropScenes.AirdropClaimPrompt);
+        return;
+      }
+      airdropFlowActions.setActiveScene(RnbwAirdropScenes.AirdropClaimed);
+    },
+    [showClaimError]
+  );
+
+  const shouldShowLongerThanUsualInfoCard = useLongerThanUsualInfoCard();
+
+  return (
+    <View style={[styles.contentContainer, { paddingTop: getCoinBottomPosition(RnbwAirdropScenes.AirdropClaiming) + 32 }]}>
+      <ActionStatusScene labels={labels} task={airdropClaimRequest} onComplete={handleClaimAirdropComplete} />
+      {shouldShowLongerThanUsualInfoCard && <LongerThanUsualInfoCard />}
+    </View>
+  );
+});
+
+function useLongerThanUsualInfoCard() {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setShouldShow(true);
+    }, LONGER_THAN_USUAL_TIME);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return shouldShow;
+}
+
+const LongerThanUsualInfoCard = memo(function LongerThanUsualInfoCard() {
+  const backgroundColor = opacity(ETH_COLOR_DARK, 0.06);
+  return (
+    <Animated.View entering={defaultEnterAnimation} exiting={defaultExitAnimation}>
+      <Box
+        backgroundColor={backgroundColor}
+        width={'full'}
+        height={100}
+        borderColor={{ custom: backgroundColor }}
+        borderWidth={1}
+        justifyContent="center"
+        alignItems="center"
+        borderRadius={32}
+        padding={'24px'}
+      >
+        <Box flexDirection="row" alignItems="center" gap={12}>
+          <TextIcon size="icon 21px" color="labelQuaternary" weight="bold">
+            {'􀐫'}
+          </TextIcon>
+          <Text color="labelQuaternary" size="15pt / 135%" weight="bold">
+            {i18n.t(i18n.l.rnbw_rewards.longer_than_usual)}
+          </Text>
+        </Box>
+      </Box>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 24,
+    paddingBottom: 32,
+  },
+});

--- a/src/features/rnbw-airdrop/stores/airdropFlowStore.ts
+++ b/src/features/rnbw-airdrop/stores/airdropFlowStore.ts
@@ -1,0 +1,55 @@
+import { type RnbwAirdropScene, RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { submitAirdropClaim, type PreparedAirdropClaim } from '@/features/rnbw-rewards/utils/claimAirdrop';
+import { ensureError } from '@/logger';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
+import { createStoreActions } from '@/state/internal/utils/createStoreActions';
+
+type TaskIdle = { status: 'idle'; runId: number };
+type TaskRunning = { status: 'running'; runId: number };
+type TaskSuccess<T> = { status: 'success'; runId: number; data: T };
+type TaskError = { status: 'error'; runId: number; error: string };
+
+export type AirdropAsyncActionState<T> = TaskIdle | TaskRunning | TaskSuccess<T> | TaskError;
+
+type AirdropFlowStore = {
+  activeScene: RnbwAirdropScene;
+  airdropClaimRequest: AirdropAsyncActionState<Awaited<ReturnType<typeof submitAirdropClaim>>>;
+  reset: () => void;
+  setActiveScene: (scene: RnbwAirdropScene) => void;
+  startAirdropClaimSubmission: (preparedClaim: PreparedAirdropClaim) => Promise<void>;
+};
+
+export const useAirdropFlowStore = createRainbowStore<AirdropFlowStore>((set, get) => ({
+  activeScene: RnbwAirdropScenes.AirdropClaimPrompt,
+  airdropClaimRequest: { status: 'idle', runId: 0 },
+
+  reset: () =>
+    set(state => ({
+      activeScene: RnbwAirdropScenes.AirdropClaimPrompt,
+      airdropClaimRequest: { status: 'idle', runId: state.airdropClaimRequest.runId + 1 },
+    })),
+
+  setActiveScene: scene => set(() => ({ activeScene: scene })),
+
+  startAirdropClaimSubmission: async preparedClaim => {
+    set(state => ({ airdropClaimRequest: { status: 'running', runId: state.airdropClaimRequest.runId + 1 } }));
+    const runId = get().airdropClaimRequest.runId;
+    try {
+      const currency = userAssetsStoreManager.getState().currency;
+      const data = await submitAirdropClaim({ preparedClaim, currency });
+      set(state => {
+        if (state.airdropClaimRequest.runId !== runId) return state;
+        return { airdropClaimRequest: { status: 'success', runId, data } };
+      });
+    } catch (error) {
+      const errorMessage = ensureError(error).message;
+      set(state => {
+        if (state.airdropClaimRequest.runId !== runId) return state;
+        return { airdropClaimRequest: { status: 'error', runId, error: errorMessage } };
+      });
+    }
+  },
+}));
+
+export const airdropFlowActions = createStoreActions(useAirdropFlowStore);

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -1,21 +1,28 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AccountImage } from '@/components/AccountImage';
 import { Navbar } from '@/components/navbar/Navbar';
-import { useTabBarOffset } from '@/hooks/useTabBarOffset';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { RnbwClaimCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard';
+import * as i18n from '@/languages';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
-  const tabBarOffset = useTabBarOffset();
-  const { top } = useSafeAreaInsets();
+  const handlePressClaimAirdrop = useCallback(() => {
+    Navigation.handleAction(Routes.RNBW_AIRDROP_SCREEN);
+  }, []);
 
   return (
     <View style={styles.flex}>
-      <Navbar floating title="Membership" leftComponent={<AccountImage />} />
-      <ScrollView
-        contentContainerStyle={{ paddingTop: top + 48, paddingBottom: tabBarOffset, paddingHorizontal: 20 }}
-        style={styles.flex}
-      />
+      <Navbar hasStatusBarInset title="Membership" leftComponent={<AccountImage />} />
+      <ScrollView contentContainerStyle={styles.scrollViewContentContainer} style={styles.flex}>
+        <RnbwClaimCard
+          tokenAmount="100"
+          nativeCurrencyAmount="$42.58"
+          title={i18n.t(i18n.l.rnbw_membership.claim_card.airdrop)}
+          onPressClaim={handlePressClaimAirdrop}
+        />
+      </ScrollView>
     </View>
   );
 });
@@ -23,5 +30,8 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
+  },
+  scrollViewContentContainer: {
+    paddingHorizontal: 20,
   },
 });

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard.tsx
@@ -1,0 +1,52 @@
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Text } from '@/design-system';
+import { Image, StyleSheet } from 'react-native';
+import { memo } from 'react';
+import rnbwCoinImage from '@/assets/rnbw.png';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import * as i18n from '@/languages';
+
+type RnbwClaimCardProps = {
+  tokenAmount: string;
+  nativeCurrencyAmount: string;
+  title: string;
+  onPressClaim: () => void;
+};
+
+export const RnbwClaimCard = memo(function RnbwClaimCard({ tokenAmount, nativeCurrencyAmount, title, onPressClaim }: RnbwClaimCardProps) {
+  return (
+    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+      <Text size="22pt" weight="heavy" color="label">
+        {title}
+      </Text>
+      <Box flexDirection="row" alignItems="center" gap={10}>
+        <Image source={rnbwCoinImage} style={styles.coinImage} />
+        <Box gap={10} style={styles.flex}>
+          <Text size="22pt" weight="heavy" color="label">
+            {nativeCurrencyAmount}
+          </Text>
+          <Text size="17pt" weight="bold" color="labelTertiary">
+            {`${tokenAmount} ${RNBW_SYMBOL}`}
+          </Text>
+        </Box>
+        <ButtonPressAnimation onPress={onPressClaim} scaleTo={0.96}>
+          <Box backgroundColor="yellow" borderRadius={21} gap={20} width={94} height={42} justifyContent="center" alignItems="center">
+            <Text size="22pt" weight="heavy" color="label">
+              {i18n.t(i18n.l.button.claim)}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+      </Box>
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  coinImage: {
+    width: 48,
+    height: 48,
+  },
+  flex: {
+    flex: 1,
+  },
+});

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -358,7 +358,8 @@
       "unhide": "Unhide",
       "unpin": "Unpin",
       "view": "View",
-      "hidden": "Hidden"
+      "hidden": "Hidden",
+      "claim": "Claim"
     },
     "cards": {
       "ens_create_profile": {
@@ -3844,6 +3845,12 @@
         "oh_i_see": "Oh I see..."
       },
       "longer_than_usual": "Claiming is taking longer than usual. It may take up to one minute."
+    },
+    "rnbw_membership": {
+      "claim_card": {
+        "airdrop": "Airdrop",
+        "rewards": "Rewards"
+      }
     },
     "wallet_error_sheet": {
       "title": "Restore your wallet",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -116,6 +116,7 @@ import { PolymarketNavigator } from '@/features/polymarket/screens/polymarket-na
 import { PolymarketMarketDescriptionSheet } from '@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet';
 import { PolymarketExplainSheet } from '@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet';
 import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet';
+import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
@@ -304,6 +305,7 @@ function BSNavigator() {
       <BSStack.Screen component={PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} />
       <BSStack.Screen component={PolymarketBrowseEventsScreen} name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN} />
       <BSStack.Screen component={PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} />
+      <BSStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
       <BSStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
       <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
     </BSStack.Navigator>

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -140,6 +140,7 @@ import { PolymarketWithdrawalScreen } from '@/features/polymarket/funding/screen
 import { PolymarketMarketDescriptionSheet } from '@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet';
 import { PolymarketExplainSheet } from '@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet';
 import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet';
+import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 
@@ -344,6 +345,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} {...perpsAccountStackConfig} />
       <NativeStack.Screen component={PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} {...learnSheetConfig} />
       <NativeStack.Screen component={PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
 
       <NativeStack.Screen

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -140,6 +140,7 @@ const Routes = {
   POLYMARKET_MARKET_DESCRIPTION_SHEET: 'PolymarketMarketDescriptionSheet',
   POLYMARKET_EXPLAIN_SHEET: 'PolymarketExplainSheet',
   POLYMARKET_SELL_POSITION_SHEET: 'PolymarketSellPositionSheet',
+  RNBW_AIRDROP_SCREEN: 'RnbwAirdropScreen',
   RNBW_MEMBERSHIP_SCREEN: 'RnbwMembershipScreen',
   RNBW_REWARDS_SCREEN: 'RnbwRewardsScreen',
   RNBW_REWARDS_ESTIMATE_SHEET: 'RnbwRewardsEstimateSheet',


### PR DESCRIPTION
This change was largely creating copies of files and making minor spacing adjustments, functionally it should be equivalent. The summary of changes below was mostly written by AI.

## Why

The airdrop claim flow was coupled to the rewards screen, which manages ~9 scenes (intro, eligibility, claim, rewards overview, etc.). To ship the membership screen independently, airdrop claiming needed its own standalone screen — navigable from the membership tab, no rewards scene management involved. Both flows coexist behind a feature flag, so the duplication is intentional.

## Changes

**Direct copies / trimmed only** 

- `airdropScenes.ts`

**Copies with modifications**

- `AmbientCoins.tsx` — swapped context for zustand store, simplified to 2 visibility states, tweaked animation params
- `BottomGradientGlow.tsx` — dropped airdrop balance check, reduced gradient config from 4 scenes to 2
- `RnbwHeroCoin.tsx` — 3-scene config instead of 8, new Y positions, stripped spin/blur animations for removed scenes
- `AirdropClaimPromptScene.tsx` — removed "Claim Later" button (no rewards overview to fall back to), wired to airdrop store
- `AirdropClaimedScene.tsx` — "Done" calls `goBack()` instead of navigating to rewards overview
- `airdropFlowStore.ts` — stripped eligibility check, rewards claim, and configurable `resetFlow()` from `rewardsFlowStore.ts`

**New files**

- `RnbwAirdropScreen.tsx` — full-screen modal composing the above with a 3-scene router
- `AirdropClaimingScene.tsx` — loading/status scene using existing `ActionStatusScene`
- `RnbwClaimCard.tsx` — card component for the membership screen

**Common pattern across copied files:** replace rewards flow context/store with `useAirdropFlowStore`, strip inapplicable scenes, simplify animations accordingly.

**Screen Recording**

https://github.com/user-attachments/assets/af1eceea-00d9-4287-b789-c1f64d56e96d


## What to test
I'm not aware of wallets we control that have airdrops left to claim, so this is difficult to actually test. For the demo above I locally changed it so that it mocked a successful response. Given nothing about the API call itself changed, I think that is sufficient. 
