### PR TITLE
fix: only retry e2e tests on CI

### DIFF
--- a/scripts/e2e-android-ci.sh
+++ b/scripts/e2e-android-ci.sh
@@ -15,5 +15,5 @@ echo "Install app"
 adb install -r $ARTIFACT_PATH_FOR_E2E
 
 # Run the tests
-./scripts/e2e-run.sh --platform android --record-on-failure --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}
+./scripts/e2e-run.sh --platform android --record-on-failure --retries 3 --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}
 

--- a/scripts/e2e-ios-ci.sh
+++ b/scripts/e2e-ios-ci.sh
@@ -14,4 +14,4 @@ ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
 xcrun simctl install "$DEVICE_UDID" "$ARTIFACT_PATH_FOR_E2E"
 
 # Run the tests
-./scripts/e2e-run.sh --platform ios --record-on-failure --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}
+./scripts/e2e-run.sh --platform ios --record-on-failure --retries 3 --shard-total ${SHARD_TOTAL:-1} --shard-index ${SHARD_INDEX:-1}

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -12,6 +12,7 @@ TEST_FILES=()
 ANVIL_PID=""
 PLATFORM=""
 RECORD_ON_FAILURE=false
+MAX_ATTEMPTS=1
 RECORDING_PID=""
 
 # Stop recording function
@@ -106,6 +107,10 @@ while [[ $# -gt 0 ]]; do
     --record-on-failure)
       RECORD_ON_FAILURE=true
       ;;
+    --retries)
+      MAX_ATTEMPTS="$2"
+      shift
+      ;;
     *)
       ARGS+=("$1")
       ;;
@@ -168,7 +173,7 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
 
   SUCCESS=false
   SHOULD_RECORD=false
-  for ATTEMPT in {1..3}; do
+  for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
     echo "🔁 Attempt $ATTEMPT for $TEST_NAME"
 
     START_TIME=$(date +%s)
@@ -228,7 +233,7 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
 
 
   if ! $SUCCESS; then
-    echo "❌ Failed after 3 attempts: $TEST_NAME"
+    echo "❌ Failed after $MAX_ATTEMPTS attempt(s): $TEST_NAME"
     echo
     EXIT_CODE=1
   fi


### PR DESCRIPTION
## What changed (plus any additional context for devs)

The e2e-run.sh script was always retrying failed tests 3 times, even when running locally. This slows down the local development feedback loop — when a test fails locally you usually want to know immediately rather than waiting for 2 more attempts.

Added a `--retries <n>` flag to e2e-run.sh (defaults to 1). CI scripts now pass `--retries 3` explicitly.

## Screen recordings / screenshots

N/A — script change only.

## What to test

- Run `./scripts/e2e-run.sh --platform ios --flow e2e/flows/<some_test>.yaml` locally and confirm the test only runs once
- Run with `--retries 3` and confirm it retries on failure
- Verify CI scripts pass `--retries 3` (check `scripts/e2e-ios-ci.sh` and `scripts/e2e-android-ci.sh`)