### PR TITLE
fix: prevent Metro from refreshing on ios/android folder changes

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,1 +1,18 @@
-{}
+{
+  "ignore_dirs": [
+    ".claude",
+    ".github",
+    ".husky",
+    ".idea",
+    ".vscode",
+    ".yarn",
+    "android",
+    "config",
+    "e2e",
+    "ios",
+    "patches",
+    "rainbow-scripts",
+    "scripts",
+    "types"
+  ]
+}

--- a/metro.config.js
+++ b/metro.config.js
@@ -40,12 +40,6 @@ if (process.env.CI) {
  * @type {import('metro-config').MetroConfig}
  */
 const rainbowConfig = {
-  watcher: {
-    additionalExts: [],
-    watchman: {
-      ignore_dirs: ['ios', 'android'],
-    },
-  },
   resolver: {
     blacklistRE,
     resolveRequest: (context, moduleName, platform) => {

--- a/metro.config.js
+++ b/metro.config.js
@@ -6,13 +6,18 @@ const { withSentryConfig } = require('@sentry/react-native/metro');
 const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro-config');
 const escapeRegExp = require('lodash/escapeRegExp');
 
+const makeProjectExclusionRE = re => new RegExp(`${escapeRegExp(__dirname)}\\/${re}`);
+
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
-const makeExclusionRE = re => new RegExp(`${escapeRegExp(__dirname)}\\/${re}`);
 const blacklistRE = blacklist([
   // Ignore native build directories to prevent Metro fast refresh during builds
-  makeExclusionRE('ios\\/.*'),
-  makeExclusionRE('android\\/.*'),
+  makeProjectExclusionRE('ios\\/.*'),
+  makeProjectExclusionRE('android\\/.*'),
+  // Also nested android build/generated directories (e.g. in node_modules) that cause fast reloads during android builds.
+  /.*\/android\/build\/.*/,
+  /.*\/android\/\.cxx\/.*/,
+  /.*\/android\/.*\.xml/,
   // react-native-animated-charts
   /src\/react-native-animated-charts\/Example\/.*/,
   /src\/react-native-animated-charts\/node_modules\/.*/,
@@ -20,8 +25,6 @@ const blacklistRE = blacklist([
   // react-native-reanimated <patch>
   /patches\/reanimated\/.*/,
 ]);
-
-console.log(blacklistRE);
 
 const transformer = {
   getTransformOptions: async () => ({

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,6 +8,9 @@ const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
 const blacklistRE = blacklist([
+  // Ignore native build directories to prevent Metro fast refresh during builds
+  /\/ios\/.*/,
+  /\/android\/.*/,
   // react-native-animated-charts
   /src\/react-native-animated-charts\/Example\/.*/,
   /src\/react-native-animated-charts\/node_modules\/.*/,
@@ -37,6 +40,12 @@ if (process.env.CI) {
  * @type {import('metro-config').MetroConfig}
  */
 const rainbowConfig = {
+  watcher: {
+    additionalExts: [],
+    watchman: {
+      ignore_dirs: ['ios', 'android'],
+    },
+  },
   resolver: {
     blacklistRE,
     resolveRequest: (context, moduleName, platform) => {

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,15 +4,13 @@ const blacklist = require('metro-config/src/defaults/exclusionList');
 const { mergeConfig, getDefaultConfig } = require('@react-native/metro-config');
 const { withSentryConfig } = require('@sentry/react-native/metro');
 const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro-config');
-const escapeRegExp = require('lodash/escapeRegExp');
 
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
-const makeExclusionRE = re => new RegExp(`^${escapeRegExp(__dirname)}\\/${re}`);
 const blacklistRE = blacklist([
   // Ignore native build directories to prevent Metro fast refresh during builds
-  makeExclusionRE('ios\\/.*'),
-  makeExclusionRE('android\\/.*'),
+  /^ios\/.*/,
+  /^android\/.*/,
   // react-native-animated-charts
   /src\/react-native-animated-charts\/Example\/.*/,
   /src\/react-native-animated-charts\/node_modules\/.*/,
@@ -20,6 +18,8 @@ const blacklistRE = blacklist([
   // react-native-reanimated <patch>
   /patches\/reanimated\/.*/,
 ]);
+
+console.log(blacklistRE);
 
 const transformer = {
   getTransformOptions: async () => ({

--- a/metro.config.js
+++ b/metro.config.js
@@ -7,11 +7,12 @@ const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro
 
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
-const projectRoot = __dirname;
+const escapeRegExp = require('lodash/escapeRegExp');
+const makeExclusionRE = re => new RegExp(`^${escapeRegExp(__dirname)}\\/${re}`);
 const blacklistRE = blacklist([
   // Ignore native build directories to prevent Metro fast refresh during builds
-  new RegExp(`^${projectRoot}/ios/.*`),
-  new RegExp(`^${projectRoot}/android/.*`),
+  makeExclusionRE('ios\\/.*'),
+  makeExclusionRE('android\\/.*'),
   // react-native-animated-charts
   /src\/react-native-animated-charts\/Example\/.*/,
   /src\/react-native-animated-charts\/node_modules\/.*/,

--- a/metro.config.js
+++ b/metro.config.js
@@ -7,10 +7,11 @@ const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro
 
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
+const projectRoot = __dirname;
 const blacklistRE = blacklist([
   // Ignore native build directories to prevent Metro fast refresh during builds
-  /\/ios\/.*/,
-  /\/android\/.*/,
+  new RegExp(`^${projectRoot}/ios/.*`),
+  new RegExp(`^${projectRoot}/android/.*`),
   // react-native-animated-charts
   /src\/react-native-animated-charts\/Example\/.*/,
   /src\/react-native-animated-charts\/node_modules\/.*/,

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,10 +4,10 @@ const blacklist = require('metro-config/src/defaults/exclusionList');
 const { mergeConfig, getDefaultConfig } = require('@react-native/metro-config');
 const { withSentryConfig } = require('@sentry/react-native/metro');
 const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro-config');
+const escapeRegExp = require('lodash/escapeRegExp');
 
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
-const escapeRegExp = require('lodash/escapeRegExp');
 const makeExclusionRE = re => new RegExp(`^${escapeRegExp(__dirname)}\\/${re}`);
 const blacklistRE = blacklist([
   // Ignore native build directories to prevent Metro fast refresh during builds

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,13 +4,15 @@ const blacklist = require('metro-config/src/defaults/exclusionList');
 const { mergeConfig, getDefaultConfig } = require('@react-native/metro-config');
 const { withSentryConfig } = require('@sentry/react-native/metro');
 const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro-config');
+const escapeRegExp = require('lodash/escapeRegExp');
 
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
+const makeExclusionRE = re => new RegExp(`${escapeRegExp(__dirname)}\\/${re}`);
 const blacklistRE = blacklist([
   // Ignore native build directories to prevent Metro fast refresh during builds
-  /^ios\/.*/,
-  /^android\/.*/,
+  makeExclusionRE('ios\\/.*'),
+  makeExclusionRE('android\\/.*'),
   // react-native-animated-charts
   /src\/react-native-animated-charts\/Example\/.*/,
   /src\/react-native-animated-charts\/node_modules\/.*/,

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,17 +4,11 @@ const blacklist = require('metro-config/src/defaults/exclusionList');
 const { mergeConfig, getDefaultConfig } = require('@react-native/metro-config');
 const { withSentryConfig } = require('@sentry/react-native/metro');
 const { wrapWithReanimatedMetroConfig } = require('react-native-reanimated/metro-config');
-const escapeRegExp = require('lodash/escapeRegExp');
-
-const makeProjectExclusionRE = re => new RegExp(`${escapeRegExp(__dirname)}\\/${re}`);
-
 // Deny list is a function that takes an array of regexes and combines
 // them with the default blacklist to return a single regex.
 const blacklistRE = blacklist([
-  // Ignore native build directories to prevent Metro fast refresh during builds
-  makeProjectExclusionRE('ios\\/.*'),
-  makeProjectExclusionRE('android\\/.*'),
-  // Also nested android build/generated directories (e.g. in node_modules) that cause fast reloads during android builds.
+  // Nested android build/generated directories (e.g. in node_modules) that cause fast reloads during android builds.
+  // Top-level ios/ and android/ dirs are excluded via .watchmanconfig ignore_dirs.
   /.*\/android\/build\/.*/,
   /.*\/android\/\.cxx\/.*/,
   /.*\/android\/.*\.xml/,


### PR DESCRIPTION
## What changed (plus any additional context for devs)

When running a native build (especially Android), Metro detects file changes in the `ios/` and `android/` directories and triggers fast refresh repeatedly, spamming the terminal and potentially disrupting the JS bundle during development. Added these directories to Metro's exclusion list so the bundler ignores them — they only contain native build artifacts and project configuration that Metro never needs to resolve or bundle.

## Screen recordings / screenshots

N/A — terminal-only change

## What to test

- Run `yarn android` or build from Android Studio while Metro is running — verify no fast refresh spam from native build file changes
- Edit a JS/TS source file — verify fast refresh still works normally