### PR TITLE
refactor(env): introduce IS_INTERNAL and IS_STORE_INSTALL flags

### DIFF
--- a/src/components/rainbow-toast/ToastContent.tsx
+++ b/src/components/rainbow-toast/ToastContent.tsx
@@ -7,7 +7,7 @@ import { useToastColors } from '@/components/rainbow-toast/useToastColors';
 import { Text } from '@/design-system';
 import { AssetType } from '@/entities/assetTypes';
 import { TransactionStatus } from '@/entities/transactions';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL } from '@/env';
 import { useTransactionLaunchToken } from '@/helpers/transactions';
 import * as i18n from '@/languages';
 import React, { memo } from 'react';
@@ -115,7 +115,7 @@ function SwapToastContent({ toast }: { toast: RainbowToast }) {
   const subtitle = getSwapToastNetworkLabel(toast);
   const { batch, delegation } = toast.transaction;
   // Type 4 = new delegation + batch, Type 2 = already delegated + batch
-  const bottomLabel = (IS_DEV || IS_TEST_FLIGHT) && batch ? (delegation ? 'Type 4' : 'Type 2') : undefined;
+  const bottomLabel = IS_INTERNAL && batch ? (delegation ? 'Type 4' : 'Type 2') : undefined;
 
   return (
     <ToastContentDisplay

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -1,5 +1,5 @@
 import { createMMKV } from 'react-native-mmkv';
-import { IS_DEV, IS_TEST, IS_TEST_FLIGHT } from '@/env';
+import { IS_DEV, IS_INTERNAL, IS_TEST } from '@/env';
 import { STORAGE_IDS } from '@/model/mmkv';
 
 /**
@@ -77,7 +77,7 @@ const config = {
   [RAINBOW_TRENDING_TOKENS_LIST]: { settings: true, value: false },
   [PRINCE_OF_THE_HILL]: { settings: true, value: false },
   [LAZY_TABS]: { needsRestart: true, settings: true, value: false },
-  [CANDLESTICK_CHARTS]: { settings: true, value: IS_DEV || IS_TEST_FLIGHT || false },
+  [CANDLESTICK_CHARTS]: { settings: true, value: IS_INTERNAL || false },
   [CANDLESTICK_DATA_MONITOR]: { settings: true, value: false },
   [KING_OF_THE_HILL_TAB]: { settings: true, value: false },
   [RAINBOW_TOASTS]: { settings: true, value: false },

--- a/src/config/experimentalHooks.ts
+++ b/src/config/experimentalHooks.ts
@@ -1,10 +1,10 @@
 import { useContext } from 'react';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL } from '@/env';
 import { RainbowContext } from '@/helpers/RainbowContext';
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from './experimental';
 
 const useExperimentalFlag = (name: ExperimentalConfigKey) => {
-  if (IS_DEV || IS_TEST_FLIGHT) {
+  if (IS_INTERNAL) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useContext(RainbowContext).config[name];
   } else {
@@ -13,7 +13,7 @@ const useExperimentalFlag = (name: ExperimentalConfigKey) => {
 };
 
 export const useExperimentalConfig = () => {
-  if (IS_DEV || IS_TEST_FLIGHT) {
+  if (IS_INTERNAL) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useContext(RainbowContext).config;
   } else {

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,3 +26,6 @@ export const RPC_PROXY_BASE_URL = RPC_PROXY_BASE_URL_PROD;
 export const RPC_PROXY_API_KEY = RPC_PROXY_API_KEY_PROD;
 
 export const IS_TEST_FLIGHT = IS_IOS && getInstallerPackageNameSync() === 'TestFlight';
+
+export const IS_STORE_INSTALL = !IS_DEV && !IS_TEST_FLIGHT;
+export const IS_INTERNAL = IS_DEV || !IS_STORE_INSTALL;

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -1,7 +1,7 @@
 import remoteConfig, { type FirebaseRemoteConfigTypes } from '@react-native-firebase/remote-config';
 import { useEffect } from 'react';
 import { dequal } from 'dequal';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_DEV, IS_INTERNAL } from '@/env';
 import { CURRENT_APP_VERSION } from '@/hooks/useAppVersion';
 import { RainbowError, logger } from '@/logger';
 import { ChainId, Network } from '@/state/backendNetworks/types';
@@ -214,8 +214,8 @@ export const DEFAULT_CONFIG = {
   king_of_the_hill2_enabled: false,
   king_of_the_hill_enabled: false,
   prince_of_the_hill_enabled: false,
-  candlestick_charts_enabled: IS_DEV || IS_TEST_FLIGHT,
-  rainbow_toasts_enabled: IS_DEV || IS_TEST_FLIGHT,
+  candlestick_charts_enabled: IS_INTERNAL,
+  rainbow_toasts_enabled: IS_INTERNAL,
   perps_enabled: false,
   polymarket_enabled: false,
   dev_section_enabled: IS_DEV,

--- a/src/react-query/reactQueryUtils.ts
+++ b/src/react-query/reactQueryUtils.ts
@@ -1,7 +1,7 @@
 import { hydrate } from '@tanstack/react-query';
 import { createMMKV } from 'react-native-mmkv';
 import { type LogEntry, showLogSheet } from '@/components/debugging/LogSheet';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_DEV, IS_INTERNAL } from '@/env';
 import { RainbowError, logger } from '@/logger';
 import { persistOptions, queryClient } from '@/react-query';
 import { favoritesQueryKey } from '@/resources/favorites';
@@ -41,7 +41,7 @@ interface CachedQuery {
  * @returns A promise that resolves after the cache is cleared.
  */
 export async function clearReactQueryCache({
-  analyzeAfterClearing = IS_DEV || IS_TEST_FLIGHT,
+  analyzeAfterClearing = IS_INTERNAL,
   onComplete,
   preserveFavorites = true,
 }: {
@@ -178,7 +178,7 @@ interface QueryInfo {
  * @returns A formatted report array or undefined if not displayed.
  */
 export function analyzeReactQueryStore({
-  displayReport = IS_DEV || IS_TEST_FLIGHT,
+  displayReport = IS_INTERNAL,
   logExtendedBreakdown = true,
   logQueryDataShape: logQueryDataShapeParam = false,
   transformReport = report => report,
@@ -188,7 +188,7 @@ export function analyzeReactQueryStore({
   logQueryDataShape?: boolean;
   transformReport?: (report: LogEntry[]) => LogEntry[];
 } = {}): ReturnType<typeof formatReport> | undefined {
-  if (!IS_DEV && !IS_TEST_FLIGHT) return;
+  if (!IS_INTERNAL) return;
 
   devLog('\n[React Query Store Analysis]');
   const report: Report | null = displayReport ? { title: { title: '🔦  React Query Analysis', message: '' } } : null;

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -1,6 +1,6 @@
 import { ImgixImage } from '@/components/images';
 import { defaultConfig, getExperimentalFlag, LOG_PUSH } from '@/config/experimentalHooks';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL } from '@/env';
 import { deleteAllBackups } from '@/handlers/cloudBackup';
 import { RainbowContext } from '@/helpers/RainbowContext';
 import { WrappedAlert as Alert } from '@/helpers/alert';
@@ -263,7 +263,7 @@ const DevSection = () => {
 
   return (
     <MenuContainer testID="developer-settings-sheet">
-      <Menu header={IS_DEV || IS_TEST_FLIGHT ? i18n.t(i18n.l.developer_settings.headers.normie_settings) : ''}>
+      <Menu header={IS_INTERNAL ? i18n.t(i18n.l.developer_settings.headers.normie_settings) : ''}>
         {/* <MenuItem
           disabled
           leftComponent={<MenuItem.TextIcon icon="🕹️" isEmoji />}
@@ -311,7 +311,7 @@ const DevSection = () => {
           titleComponent={<MenuItem.Title text="Wipe App + Restart" />}
         />
       </Menu>
-      {(IS_DEV || IS_TEST_FLIGHT) && (
+      {IS_INTERNAL && (
         <>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.rainbow_developer_settings)}>
             <MenuItem

--- a/src/screens/change-wallet/components/AddressRow.tsx
+++ b/src/screens/change-wallet/components/AddressRow.tsx
@@ -16,7 +16,7 @@ import { DropdownMenu, type MenuItem } from '@/components/DropdownMenu';
 import { Icon } from '@/components/icons';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
 import { address as abbreviateAddress } from '@/utils/abbreviations';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL } from '@/env';
 import { DELEGATION, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { DelegationStatus, useDelegations, useDelegationDisabled } from '@rainbow-me/delegation';
@@ -207,7 +207,7 @@ export function AddressRow({ data, editMode, onPress, menuItems, onPressMenuItem
                 )}
               </>
             )}
-            {(IS_DEV || IS_TEST_FLIGHT) && delegationEnabled && !isReadOnly && !editMode && (
+            {IS_INTERNAL && delegationEnabled && !isReadOnly && !editMode && (
               <Box
                 paddingHorizontal="8px"
                 paddingVertical="6px"

--- a/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
+++ b/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
@@ -13,7 +13,7 @@ import ConditionalWrap from 'conditional-wrap';
 import { address } from '@/utils/abbreviations';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
 import { PANEL_WIDTH } from '@/components/SmoothPager/ListPanel';
-import { IS_DEV, IS_IOS, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL, IS_IOS } from '@/env';
 import { DELEGATION, getExperimentalFlag } from '@/config/experimentalHooks';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { useTheme } from '@/theme/ThemeContext';
@@ -223,9 +223,7 @@ export function PinnedWalletsGrid({ walletItems, onPress, editMode, menuItems, o
                       </Text>
                     ) : null}
 
-                    {(IS_DEV || IS_TEST_FLIGHT) && delegationEnabled && !account.isReadOnly ? (
-                      <DelegationBadge accountAddress={account.address} />
-                    ) : null}
+                    {IS_INTERNAL && delegationEnabled && !account.isReadOnly ? <DelegationBadge accountAddress={account.address} /> : null}
 
                     <Text numberOfLines={1} ellipsizeMode="middle" color="label" size="13pt" weight="bold">
                       {walletName}

--- a/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
@@ -12,7 +12,7 @@ import { transformRainbowTokenToParsedSearchAsset } from '@/__swaps__/utils/asse
 import { convertAmountToNativeDisplay, convertStringToNumber, roundToSignificant1or5 } from '@/helpers/utilities';
 import useAccountAsset from '@/hooks/useAccountAsset';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL } from '@/env';
 import { isL2Chain } from '@/handlers/web3';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { CollapsibleSection, LAYOUT_ANIMATION } from '../shared/CollapsibleSection';
@@ -24,7 +24,7 @@ import { THICK_BORDER_WIDTH } from '@/styles/constants';
 const GRADIENT_FADE_WIDTH = 24;
 const DEFAULT_PERCENTAGES_OF_BALANCE = [0.05, 0.1, 0.25, 0.5, 0.75];
 // Ideally this would be different for different currencies, but that would need to be set in the remote config
-const DEFAULT_MAINNET_MINIMUM_NATIVE_CURRENCY_AMOUNT = IS_DEV || IS_TEST_FLIGHT ? 1 : 10;
+const DEFAULT_MAINNET_MINIMUM_NATIVE_CURRENCY_AMOUNT = IS_INTERNAL ? 1 : 10;
 const DEFAULT_L2_MINIMUM_NATIVE_CURRENCY_AMOUNT = 1;
 
 const BUTTON_INSET_HORIZONTAL = 24;

--- a/src/screens/token-launcher/state/tokenLauncherStore.ts
+++ b/src/screens/token-launcher/state/tokenLauncherStore.ts
@@ -26,7 +26,7 @@ import { type LaunchTokenResponse, TokenLauncherSDKError } from '@rainbow-me/tok
 import { Alert } from 'react-native';
 import { logger, RainbowError } from '@/logger';
 import { analytics } from '@/analytics';
-import { IS_DEV, IS_TEST_FLIGHT } from '@/env';
+import { IS_INTERNAL } from '@/env';
 import { type Link, type LinkType } from '../types';
 import { useSuperTokenStore } from './rainbowSuperTokenStore';
 import { calculateAndCacheDominantColor } from '@/hooks/usePersistentDominantColorFromImage';
@@ -38,7 +38,7 @@ import { type ParsedAsset } from '@/resources/assets/types';
 import { tokenLaunchErrorToErrorMessage } from '../helpers/tokenLaunchErrorToErrorMessage';
 
 // TODO: Remove this — temporary option for testing
-const REQUIRE_TOKEN_LOGO = !(IS_TEST_FLIGHT || IS_DEV);
+const REQUIRE_TOKEN_LOGO = !IS_INTERNAL;
 
 export const enum NavigationSteps {
   INFO = 0,


### PR DESCRIPTION
The codebase currently uses `IS_DEV || IS_TEST_FLIGHT` in ~13 callsites to gate internal-only behavior like developer settings, experimental flag toggles, reduced buy minimums, and debug diagnostics. Because `IS_TEST_FLIGHT` is hardcoded to iOS (`IS_IOS && getInstallerPackageNameSync() === 'TestFlight'`), Android QA get none of these features, every new callsite has to remember the `IS_DEV || IS_TEST_FLIGHT` pattern, and it's easy to forget the `IS_TEST_FLIGHT` half.

To simplify, this change introduces two new flags in `src/env.ts`:
* `IS_STORE_INSTALL` answers "was this installed from a public app store?
* `IS_INTERNAL` answers "should this build have internal features?". 

All existing `IS_DEV || IS_TEST_FLIGHT` callsites are replaced with `IS_INTERNAL`, which is algebraically identical (`IS_DEV || !(!IS_DEV && !IS_TEST_FLIGHT)` reduces to `IS_DEV || IS_TEST_FLIGHT`), so there is zero behavioral change for any build type.

`IS_STORE_INSTALL` is currently backed by a JS-only approximation (`!IS_DEV && !IS_TEST_FLIGHT`) that follows the logic we have today. A follow-up PR will swap this for a proper `AppInstallInfo` native module that detects the install source at runtime via signing certificate (Android) and provisioning profile (iOS), which will give Android QA builds feature parity with iOS TestFlight. 

Another follow-up will use these flags to rewrite Sentry environment detection, replacing the current split `Release`/`ReleaseAndroid`/`Testflight`/`LocalRelease` environments with a unified `production`/`internal`/`development` model as outlined in https://www.notion.so/rainbowdotme/Sentry-Environment-Redesign-for-Mobile-321b001b85b480439e26c4b762a94096.

Ref FEPLAT-62.