### PR TITLE
feature: basic staking flow

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -5,6 +5,7 @@ import { AccountImage } from '@/components/AccountImage';
 import { Navbar } from '@/components/navbar/Navbar';
 import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
 import { RnbwAirdropClaimCard } from './components/RnbwAirdropClaimCard';
+import { RnbwStakingCard } from './components/RnbwStakingCard';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
   return (
@@ -12,6 +13,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
       <Navbar hasStatusBarInset title="Membership" leftComponent={<AccountImage />} />
       <ScrollView contentContainerStyle={styles.scrollViewContentContainer} style={styles.flex}>
         <Box gap={16}>
+          <RnbwStakingCard />
           <RnbwRewardsClaimCard />
           <RnbwAirdropClaimCard />
         </Box>

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -1,0 +1,78 @@
+import { memo, useCallback } from 'react';
+import { Text, Box } from '@/design-system';
+import { useStakingBalance } from '@/features/rnbw-staking/stores/derived/useStakingBalance';
+import { useRnbwBalance } from '@/state/rnbw/useRnbwBalance';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { useNavigation } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+
+export const RnbwStakingCard = memo(function RnbwStakingCard() {
+  const { navigate } = useNavigation();
+  const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useStakingBalance();
+  const { tokenAmountFormatted: availableAmount } = useRnbwBalance();
+
+  const handlePressEnableStaking = useCallback(() => {
+    navigate(Routes.RNBW_STAKING_LEARN_SHEET);
+  }, [navigate]);
+
+  const handlePressAddToStake = useCallback(() => {
+    navigate(Routes.RNBW_STAKING_SCREEN);
+  }, [navigate]);
+
+  const handlePressUnstake = useCallback(() => {
+    //
+  }, []);
+
+  return (
+    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+      <Text size="17pt" weight="bold" color="label">
+        {'Stake'}
+      </Text>
+      <Text size="44pt" weight="bold" color="label">
+        {nativeCurrencyAmount}
+      </Text>
+      <Text size="17pt" weight="bold" color="labelTertiary">
+        {`${tokenAmount} ${RNBW_SYMBOL}`}
+      </Text>
+      {!hasStakedPosition && (
+        <ButtonPressAnimation onPress={handlePressEnableStaking}>
+          <Box backgroundColor="yellow" borderRadius={21} width={'full'} height={42} justifyContent="center" alignItems="center">
+            <Text size="17pt" weight="bold" color="label">
+              {'Enable Staking'}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+      )}
+      {hasStakedPosition && (
+        <Box flexDirection="row" gap={10}>
+          <ButtonPressAnimation onPress={handlePressUnstake} style={{ flex: 1 }}>
+            <Box
+              flexGrow={1}
+              backgroundColor="yellow"
+              borderRadius={21}
+              width={'full'}
+              height={42}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Text size="17pt" weight="bold" color="label">
+                {'Unstake'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+          <ButtonPressAnimation onPress={handlePressAddToStake} style={{ flex: 1 }}>
+            <Box backgroundColor="yellow" borderRadius={21} width={'full'} height={42} justifyContent="center" alignItems="center">
+              <Text size="17pt" weight="bold" color="label">
+                {'Add'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+        </Box>
+      )}
+      <Text size="13pt" weight="semibold" color="labelTertiary" align="center">
+        {`${availableAmount} available to stake`}
+      </Text>
+    </Box>
+  );
+});

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -1,0 +1,20 @@
+import { type Address, parseAbi } from 'viem';
+import { ChainId } from '@/state/backendNetworks/types';
+import { IS_DEV } from '@/env';
+
+// TODO: Flip to `false` when switching to the production token
+const USE_TEST_STAKING_TOKEN = true && IS_DEV;
+
+export const STAKING_CHAIN_ID = ChainId.base;
+export const STAKING_CONTRACT_ADDRESS: Address = '0x616EB863bd79145c20B44A9A070A3651662D1EBD';
+export const RNBW_TOKEN_ADDRESS: Address = USE_TEST_STAKING_TOKEN
+  ? '0xb61832AD7859e64d8525E51d13De94d693475e6b'
+  : '0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0';
+export const RNBW_CHAIN_ID = ChainId.base;
+export const RNBW_DECIMALS = 18;
+export const STAKING_ABI = parseAbi([
+  'function stake(uint256 amount)',
+  'function unstakeAll()',
+  'function minStakeAmount() view returns (uint256)',
+]);
+export const STAKING_GAS_LIMIT = 200_000;

--- a/src/features/rnbw-staking/screens/rnbw-staking-learn-sheet/RnbwStakingLearnSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-learn-sheet/RnbwStakingLearnSheet.tsx
@@ -1,0 +1,65 @@
+import { memo, useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Text } from '@/design-system';
+import Routes from '@/navigation/routesNames';
+import { useNavigation } from '@/navigation/Navigation';
+
+export const RnbwStakingLearnSheet = memo(function RnbwStakingLearnSheet() {
+  const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
+  const { replace } = useNavigation();
+
+  const handlePressEnableStaking = useCallback(() => {
+    replace(Routes.RNBW_STAKING_SCREEN);
+  }, [replace]);
+
+  return (
+    <Box background="surfacePrimary" style={styles.container}>
+      <SheetHandleFixedToTop top={safeAreaTop + 6} />
+      <View style={[styles.content, { marginTop: safeAreaTop + 40, paddingBottom: safeAreaBottom + 8 }]}>
+        <Box alignItems="center" gap={16}>
+          <Text align="center" color="label" size="30pt" weight="heavy">
+            {'Earn More Rewards With Staking'}
+          </Text>
+          <Text align="center" color="labelTertiary" size="17pt" weight="medium">
+            {'Staking allows you to earn cashback rewards on your swaps.'}
+          </Text>
+        </Box>
+        <Box gap={20} paddingVertical={'20px'}>
+          <Text color="label" size="17pt" weight="bold">
+            {'Reason 1'}
+          </Text>
+          <Text color="label" size="17pt" weight="bold">
+            {'Reason 2'}
+          </Text>
+          <Text color="label" size="17pt" weight="bold">
+            {'Reason 3'}
+          </Text>
+        </Box>
+        <ButtonPressAnimation onPress={handlePressEnableStaking} style={styles.button}>
+          <Box backgroundColor="yellow" borderRadius={24} width={'full'} height={48} justifyContent="center" alignItems="center">
+            <Text color="label" size="22pt" weight="heavy">
+              {'Enable Staking'}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+      </View>
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  button: {
+    marginTop: 'auto',
+    width: '100%',
+  },
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+});

--- a/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
@@ -1,0 +1,89 @@
+import { memo, useCallback, useState } from 'react';
+import { Alert, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
+import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
+import { Box, Stack, Text } from '@/design-system';
+import { useIsReadOnlyWallet, useIsHardwareWallet } from '@/state/wallets/walletsStore';
+import { useNavigation } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import watchingAlert from '@/utils/watchingAlert';
+import { logger, RainbowError } from '@/logger';
+
+export const RnbwStakingScreen = memo(function RnbwStakingScreen() {
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const { goBack, navigate } = useNavigation();
+  const isReadOnlyWallet = useIsReadOnlyWallet();
+  const isHardwareWallet = useIsHardwareWallet();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const startStake = useCallback(async () => {
+    setIsProcessing(true);
+    try {
+      // TODO: Implement staking logic
+      goBack();
+    } catch (e) {
+      setIsProcessing(false);
+      Alert.alert('Staking Failed', 'Something went wrong while staking. Please try again.');
+      logger.error(new RainbowError('[RnbwStakingScreen]: Staking failed', e));
+    }
+  }, [goBack]);
+
+  const handleStake = useCallback(async () => {
+    if (isReadOnlyWallet) {
+      watchingAlert();
+      return;
+    }
+    if (isHardwareWallet) {
+      navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: startStake });
+    } else {
+      await startStake();
+    }
+  }, [isReadOnlyWallet, isHardwareWallet, navigate, startStake]);
+
+  return (
+    <Box background="surfacePrimary" style={styles.container}>
+      <SheetHandleFixedToTop top={safeAreaTop + 6} />
+      <View style={[styles.content, { marginTop: safeAreaTop + 40 }]}>
+        <Stack space="24px">
+          <Text color="label" size="30pt" weight="heavy">
+            Stake RNBW
+          </Text>
+          <Text color="labelSecondary" size="17pt" weight="medium">
+            {'Stake 1 RNBW to enable membership rewards.'}
+          </Text>
+        </Stack>
+        <View style={styles.buttonContainer}>
+          <HoldToActivateButton
+            label="Hold to Stake"
+            processingLabel="Staking..."
+            onLongPress={handleStake}
+            isProcessing={isProcessing}
+            backgroundColor="white"
+            disabledBackgroundColor="white"
+            progressColor="black"
+            showBiometryIcon
+            style={styles.button}
+          />
+        </View>
+      </View>
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+  },
+  buttonContainer: {
+    marginTop: 'auto',
+    paddingBottom: 36,
+  },
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+});

--- a/src/features/rnbw-staking/stores/derived/useStakingBalance.ts
+++ b/src/features/rnbw-staking/stores/derived/useStakingBalance.ts
@@ -1,0 +1,33 @@
+import { convertAmountToNativeDisplayWorklet, convertRawAmountToDecimalFormat, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+import { useStakingPositionStore } from '../rnbwStakingPositionStore';
+
+type StakingBalance = {
+  tokenAmount: string;
+  nativeCurrencyAmount: string;
+  hasStakedPosition: boolean;
+};
+
+export const useStakingBalance = createDerivedStore<StakingBalance>(
+  $ => {
+    const data = $(useStakingPositionStore, state => state.getData());
+    const currency = $(userAssetsStoreManager, state => state.currency);
+
+    const rawStakedRnbw = data?.stakedRnbw ?? '0';
+    const stakedValueInCurrency = data?.stakedValueInCurrency ?? '0';
+    const decimals = data?.decimals ?? 18;
+    const isZero = rawStakedRnbw === '0';
+
+    const decimalAmount = convertRawAmountToDecimalFormat(rawStakedRnbw, decimals);
+    const formattedTokenAmount = truncateToDecimalsWithThreshold({ value: decimalAmount, decimals: 1, threshold: '0.01' });
+
+    return {
+      tokenAmount: isZero ? '0' : formattedTokenAmount,
+      nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(stakedValueInCurrency, currency, !isZero),
+      hasStakedPosition: !isZero,
+    };
+  },
+  { equalityFn: shallowEqual, fastMode: true }
+);

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -1,0 +1,80 @@
+import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
+import { getPlatformClient } from '@/resources/platform/client';
+import { type PlatformResponse } from '@/resources/platform/types';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { useWalletsStore } from '@/state/wallets/walletsStore';
+import { ChainId } from '@/state/backendNetworks/types';
+import { type Address } from 'viem';
+
+type StakingTierLevel = 'STAKING_TIER_LEVEL_UNSPECIFIED' | string;
+
+type StakingTier = {
+  cashbackBps: number;
+  level: StakingTierLevel;
+  minStakeAmount: string;
+  name: string;
+};
+
+type StakingPnl = {
+  netProfit: string;
+  totalCashbackReceived: string;
+  totalExitFeePaid: string;
+  totalRnbwStaked: string;
+  totalRnbwUnstaked: string;
+};
+
+type StakingPositionData = {
+  allTiers: StakingTier[];
+  decimals: number;
+  hasPosition: boolean;
+  lastUpdateTime: string;
+  pnl: StakingPnl;
+  sessionPnl: StakingPnl;
+  poolShares: string;
+  stakedRnbw: string;
+  stakedValueInCurrency: string;
+  stakingStartTime: string;
+  tier: StakingTier;
+};
+
+type StakingPositionParams = {
+  currency: NativeCurrencyKey;
+  address: Address;
+};
+
+type StakingPositionStore = {
+  hasPosition: () => boolean;
+};
+
+export const useStakingPositionStore = createQueryStore<StakingPositionData, StakingPositionParams, StakingPositionStore>(
+  {
+    fetcher: fetchStakingPosition,
+    params: {
+      currency: $ => $(userAssetsStoreManager).currency,
+      address: $ => $(useWalletsStore).accountAddress,
+    },
+  },
+  (_, get) => ({
+    hasPosition: () => {
+      const data = get().getData();
+      return data?.hasPosition ?? false;
+    },
+  }),
+  { storageKey: 'rnbwStakingPosition' }
+);
+
+type StakingPositionResponse = PlatformResponse<StakingPositionData>;
+
+async function fetchStakingPosition({ currency, address }: StakingPositionParams): Promise<StakingPositionData> {
+  const response = await getPlatformClient().get<StakingPositionResponse>('/staking/GetStakingPosition', {
+    params: {
+      walletAddress: address,
+      chainId: String(ChainId.base),
+      currency,
+      includeTiers: String(true),
+    },
+  });
+
+  return response.data.result;
+}

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -119,6 +119,8 @@ import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polym
 import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
+import { RnbwStakingLearnSheet } from '@/features/rnbw-staking/screens/rnbw-staking-learn-sheet/RnbwStakingLearnSheet';
+import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
 
@@ -309,6 +311,8 @@ function BSNavigator() {
       <BSStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
       <BSStack.Screen component={RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} />
       <BSStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
+      <BSStack.Screen component={RnbwStakingLearnSheet} name={Routes.RNBW_STAKING_LEARN_SHEET} />
+      <BSStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
       <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
     </BSStack.Navigator>
   );

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -143,6 +143,8 @@ import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polym
 import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
+import { RnbwStakingLearnSheet } from '@/features/rnbw-staking/screens/rnbw-staking-learn-sheet/RnbwStakingLearnSheet';
+import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 
 const Stack = createStackNavigator();
@@ -349,6 +351,8 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} {...panelConfig} />
       <NativeStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={RnbwStakingLearnSheet} name={Routes.RNBW_STAKING_LEARN_SHEET} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
 
       <NativeStack.Screen
         component={PolymarketBrowseEventsScreen}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -145,6 +145,8 @@ const Routes = {
   RNBW_REWARDS_SCREEN: 'RnbwRewardsScreen',
   RNBW_REWARDS_CLAIM_SHEET: 'RnbwRewardsClaimSheet',
   RNBW_REWARDS_ESTIMATE_SHEET: 'RnbwRewardsEstimateSheet',
+  RNBW_STAKING_LEARN_SHEET: 'RnbwStakingLearnSheet',
+  RNBW_STAKING_SCREEN: 'RnbwStakingScreen',
   WALLET_ERROR_SHEET: 'WalletErrorSheet',
 } as const;
 

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -719,6 +719,8 @@ type RouteParams = {
   [Routes.RNBW_REWARDS_ESTIMATE_SHEET]: {
     estimatedAmount: string;
   };
+  [Routes.RNBW_STAKING_LEARN_SHEET]: undefined;
+  [Routes.RNBW_STAKING_SCREEN]: undefined;
   [Routes.REVOKE_DELEGATION_PANEL]: {
     address: Address;
     delegationsToRevoke: Array<{

--- a/src/state/rnbw/useRnbwBalance.ts
+++ b/src/state/rnbw/useRnbwBalance.ts
@@ -1,0 +1,31 @@
+import { convertAmountToNativeDisplayWorklet, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+import { RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID } from '@/features/rnbw-staking/constants';
+
+type RnbwBalance = {
+  tokenAmountFormatted: string;
+  nativeCurrencyAmount: string;
+  hasBalance: boolean;
+};
+
+export const useRnbwBalance = createDerivedStore<RnbwBalance>(
+  $ => {
+    const uniqueId = `${RNBW_TOKEN_ADDRESS}_${RNBW_CHAIN_ID}`.toLowerCase();
+    const asset = $(useUserAssetsStore, state => state.getUserAsset(uniqueId));
+    const currency = $(userAssetsStoreManager, state => state.currency);
+
+    const amount = asset?.balance?.amount ?? '0';
+    const nativeValue = asset?.native?.balance?.amount ?? '0';
+    const hasBalance = amount !== '0';
+
+    return {
+      tokenAmountFormatted: truncateToDecimalsWithThreshold({ value: amount, decimals: 2, threshold: '0.01' }),
+      nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(nativeValue, currency, hasBalance),
+      hasBalance,
+    };
+  },
+  { equalityFn: shallowEqual, fastMode: true }
+);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
Adds the basic RNBW staking flow scaffolding for Membership.

  - Adds `RnbwStakingCard` to the Membership screen with entry points for enabling staking and adding to stake.
  - Adds staking screens: `RnbwStakingLearnSheet` and `RnbwStakingScreen` (including read-only + hardware wallet handling).
  - Adds state hooks for staking position and formatted balances.

## Screen recordings

https://github.com/user-attachments/assets/d0d9d81a-6704-4066-893a-7e6b1fb67102
