### PR TITLE
Fix transaction not found Sentry noise during pending tx polling

### DIFF
--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { type consolidatedTransactionsQueryFunction, consolidatedTransactionsQueryKey } from './consolidatedTransactions';
 import { parseTransaction } from '@/parsers/transactions';
 import { RainbowError, logger } from '@/logger';
+import { type RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { createPublicClient, http, type Hash, type PublicClient, type TransactionReceipt } from 'viem';
@@ -148,6 +149,11 @@ export const fetchRawTransaction = async ({
 
     return parsed;
   } catch (e) {
+    // 404 means the backend hasn't indexed this transaction yet, which is expected
+    // for recently submitted transactions. Silently return null so callers can retry.
+    if ((e as RainbowFetchError).response?.status === 404) {
+      return null;
+    }
     logger.error(new RainbowError('[transaction]: Failed to fetch transaction', e));
     return null;
   }


### PR DESCRIPTION
Fixes FEPLAT-41

## What changed

Added a 404 check in `fetchRawTransaction`'s existing catch-all. The backend returns 404 when a transaction hasn't been indexed yet, which is expected for recently submitted transactions. Previously these 404s were logged as `RainbowError`s, generating ~3.2M Sentry events.

Now 404s silently return `null` (same as other error paths) so callers can retry, while unexpected errors continue to be reported to Sentry.

## What to test

1. Send a transaction (any asset, any network)
2. Verify the pending transaction appears and eventually resolves to confirmed
3. Check Sentry — no `[fetchTransaction]: Failed to fetch transaction` errors should appear for 404 responses