### PR TITLE
fix: allow private key import over damaged seed wallet (APP-3443)

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -728,11 +728,17 @@ export const createWallet = async ({
       existingWalletId = alreadyExistingWallet?.id;
 
       // Don't allow adding a readOnly wallet that you have already visible
-      // or a private key that you already have visible as a seed or mnemonic
+      // or a private key that you already have visible as a seed or mnemonic.
+      // Exception: allow overwriting if the existing wallet is damaged (keychain data lost) so users can repair it.
       const isPrivateKeyOverwritingSeedMnemonic =
         type === EthereumWalletType.privateKey &&
         (alreadyExistingWallet?.type === EthereumWalletType.seed || alreadyExistingWallet?.type === EthereumWalletType.mnemonic);
-      if (!overwrite && alreadyExistingWallet && (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)) {
+      if (
+        !overwrite &&
+        alreadyExistingWallet &&
+        !alreadyExistingWallet.damaged &&
+        (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)
+      ) {
         if (!isRestoring) {
           logger.debug('[wallet]: already imported this wallet', {}, DebugContext.wallet);
           const error = new Error(i18n.t(i18n.l.wallet.new.alert.looks_like_already_imported));


### PR DESCRIPTION
Fixes APP-3443

## What changed

When a user's seed wallet is damaged (keychain data lost after device migration on iOS), re-importing via **private key** was silently blocked by the "already imported" guard:

```ts
// isPrivateKeyOverwritingSeedMnemonic = true when importing pkey over seed wallet
// → throws WalletAlreadyExistsError → "already imported" alert
if (!overwrite && alreadyExistingWallet && (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)) {
```

The fix adds `!alreadyExistingWallet.damaged` exception so damaged wallets can be repaired:

```ts
if (!overwrite && alreadyExistingWallet && !alreadyExistingWallet.damaged && (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)) {
```

Note: seed phrase re-import over a damaged seed wallet already worked (that path falls through this check correctly).

## Why only some users hit this

Only users importing via **private key** over a damaged **seed** wallet hit this. Users who successfully repaired by "deleting and re-adding" were working around it. The users who couldn't repair likely tried private key first.

## What to test

Hard to test on Android (damaged state requires missing keychain data which doesn't happen on Android emulator). To test on iOS:
1. Set up a seed wallet
2. Manually mark wallet as damaged in the store
3. Attempt to restore via private key for one of the wallet's addresses
4. Should now proceed to import rather than showing "already imported" alert