### PR TITLE
feature: unstaking flow

### DIFF
--- a/src/components/PanelSheet/PanelSheet.tsx
+++ b/src/components/PanelSheet/PanelSheet.tsx
@@ -34,6 +34,7 @@ type PanelProps = {
   height?: number;
   innerBorderColor?: string;
   innerBorderWidth?: number;
+  layoutAnimation?: ComponentProps<typeof Animated.View>['layout'];
   outerBorderColor?: string;
   outerBorderWidth?: number;
   panelStyle?: StyleProp<ViewStyle> | AnimatedStyle;
@@ -44,6 +45,7 @@ const Panel = ({
   height,
   innerBorderColor,
   innerBorderWidth,
+  layoutAnimation,
   outerBorderColor,
   outerBorderWidth,
   panelStyle,
@@ -80,7 +82,7 @@ const Panel = ({
   }, [height, innerBorderColor, innerBorderWidth, isDarkMode, outerBorderColor, outerBorderWidth, separatorSecondary]);
 
   return (
-    <Animated.View style={[panelContainerStyle, panelStyle]}>
+    <Animated.View layout={layoutAnimation} style={[panelContainerStyle, panelStyle]}>
       {children}
       {borders}
     </Animated.View>
@@ -91,6 +93,7 @@ type PanelSheetProps = PanelProps & {
   bottomOffset?: number;
   containerStyle?: StyleProp<ViewStyle>;
   handleProps?: Partial<ComponentProps<typeof SheetHandleFixedToTop>>;
+  layoutAnimation?: ComponentProps<typeof Animated.View>['layout'];
   showHandle?: boolean;
   showTapToDismiss?: boolean;
   panelStyle?: StyleProp<ViewStyle> | AnimatedStyle;
@@ -111,6 +114,7 @@ export const PanelSheet = ({
   height,
   innerBorderColor,
   innerBorderWidth,
+  layoutAnimation,
   outerBorderColor,
   outerBorderWidth,
   showHandle = true,
@@ -122,7 +126,7 @@ export const PanelSheet = ({
   const { isDarkMode } = useColorMode();
   return (
     <>
-      <Box style={[panelSheetStyles.panelContainer, { bottom: bottomOffset }, containerStyle]}>
+      <Animated.View layout={layoutAnimation} style={[panelSheetStyles.panelContainer, { bottom: bottomOffset }, containerStyle]}>
         <ConditionalWrap
           wrap={children => <KeyboardStickyView offset={keyboardAvoidanceOffset}>{children}</KeyboardStickyView>}
           condition={enableKeyboardAvoidance}
@@ -139,6 +143,7 @@ export const PanelSheet = ({
               height={height}
               innerBorderColor={innerBorderColor}
               innerBorderWidth={innerBorderWidth}
+              layoutAnimation={layoutAnimation}
               outerBorderColor={outerBorderColor}
               outerBorderWidth={outerBorderWidth}
               panelStyle={panelStyle}
@@ -147,7 +152,7 @@ export const PanelSheet = ({
             </Panel>
           </>
         </ConditionalWrap>
-      </Box>
+      </Animated.View>
       {showTapToDismiss && <TapToDismiss />}
     </>
   );

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -73,5 +73,5 @@ function navigateToStakingScreen() {
 }
 
 function navigateToUnstakeSheet() {
-  // TODO:
+  Navigation.handleAction(Routes.RNBW_UNSTAKE_SHEET);
 }

--- a/src/features/rnbw-staking/components/UnstakePenaltySign.tsx
+++ b/src/features/rnbw-staking/components/UnstakePenaltySign.tsx
@@ -1,0 +1,11 @@
+import { memo } from 'react';
+import { Text } from '@/design-system';
+
+export const UnstakePenaltySign = memo(function UnstakePenaltySign() {
+  return (
+    <Text color="label" size="26pt" weight="heavy">
+      {/* TODO: Replace with actual penalty sign design */}
+      🚧
+    </Text>
+  );
+});

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -16,3 +16,4 @@ export const STAKING_ABI = parseAbi([
   'function minStakeAmount() view returns (uint256)',
 ]);
 export const STAKING_GAS_LIMIT = 200_000;
+export const UNSTAKE_PENALTY_PERCENTAGE = 10;

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -5,8 +5,8 @@ import { getUniqueId } from '@/utils/ethereumUtils';
 // TODO: test token address, use prod address later '0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0'
 export const RNBW_TOKEN_ADDRESS: Address = '0xb61832AD7859e64d8525E51d13De94d693475e6b';
 export const RNBW_CHAIN_ID = ChainId.base;
-export const RNBW_TOKEN_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 export const RNBW_DECIMALS = 18;
+export const RNBW_TOKEN_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 
 export const STAKING_CHAIN_ID = ChainId.base;
 export const STAKING_CONTRACT_ADDRESS: Address = '0x616EB863bd79145c20B44A9A070A3651662D1EBD';

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -1,0 +1,205 @@
+import { memo, useCallback, useState } from 'react';
+import { Alert, Image, StyleSheet, View } from 'react-native';
+import { LinearTransition } from 'react-native-reanimated';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
+import { Box, Separator, Stack, Text, useForegroundColor } from '@/design-system';
+import { ensureError, logger, RainbowError } from '@/logger';
+import { useNavigation } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { useAccountAddress, useIsHardwareWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import watchingAlert from '@/utils/watchingAlert';
+import { unstakeRnbw } from '../../utils/unstakeRnbw';
+import { UnstakePenaltySign } from '@/features/rnbw-staking/components/UnstakePenaltySign';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import { useRnbwStakingBalance } from '../../stores/derived/useRnbwStakingBalance';
+import { useRnbwStakingPositionPnl } from '../../stores/derived/useRnbwStakingPositionPnl';
+import { UNSTAKE_PENALTY_PERCENTAGE } from '../../constants';
+import { useStableValue } from '@/hooks/useStableValue';
+import rnbwCoinImage from '@/assets/rnbw.png';
+
+const LAYOUT_ANIMATION_CONFIG = SPRING_CONFIGS.snappierSpringConfig;
+const LAYOUT_ANIMATION = LinearTransition.springify()
+  .mass(LAYOUT_ANIMATION_CONFIG.mass)
+  .damping(LAYOUT_ANIMATION_CONFIG.damping)
+  .stiffness(LAYOUT_ANIMATION_CONFIG.stiffness);
+
+export const RnbwUnstakeSheet = memo(function RnbwUnstakeSheet() {
+  const [step, setStep] = useState<'warning' | 'unstake'>('warning');
+
+  const handleProceedToUnstake = useCallback(() => {
+    setStep('unstake');
+  }, []);
+
+  return (
+    <PanelSheet layoutAnimation={LAYOUT_ANIMATION}>
+      {step === 'warning' && <WarningContent onProceed={handleProceedToUnstake} />}
+      {step === 'unstake' && <UnstakeContent />}
+    </PanelSheet>
+  );
+});
+
+const WarningContent = memo(function WarningContent({ onProceed }: { onProceed: () => void }) {
+  const { goBack } = useNavigation();
+  const redColor = useForegroundColor('red');
+
+  return (
+    <View style={styles.content}>
+      <Stack space="24px">
+        <Stack space="24px" alignHorizontal="center">
+          <UnstakePenaltySign />
+          <Stack space="20px" alignHorizontal="center">
+            <Text color="label" size="34pt" weight="heavy" align="center">
+              {'Exit Fee'}
+            </Text>
+            <Text color="labelTertiary" size="17pt" weight="semibold" align="center">
+              {'Be aware of unstaking penalty. Earn yield, unlock swap discounts, and more.'}
+            </Text>
+          </Stack>
+        </Stack>
+        <Stack space="32px" alignHorizontal="center">
+          <ButtonPressAnimation onPress={onProceed} style={{ width: '100%' }}>
+            <Box
+              backgroundColor={opacity(redColor, 0.2)}
+              borderRadius={24}
+              height={48}
+              justifyContent="center"
+              alignItems="center"
+              width="full"
+              borderColor={{ custom: opacity(redColor, 0.1) }}
+              borderWidth={2}
+            >
+              <Text color={{ custom: redColor }} size="22pt" weight="heavy">
+                {'I understand'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+          <ButtonPressAnimation onPress={goBack}>
+            <Text color="label" size="22pt" weight="heavy">
+              {'Cancel'}
+            </Text>
+          </ButtonPressAnimation>
+        </Stack>
+      </Stack>
+    </View>
+  );
+});
+
+const UnstakeContent = memo(function UnstakeContent() {
+  // We use the initial values only so we do not display 0 prior to the sheet being dismissed after unstaking.
+  const { tokenAmount, nativeCurrencyAmount } = useStableValue(() => useRnbwStakingBalance.getState());
+  const { exitFeeOffsetRatio, netPnl, isPositivePnl } = useStableValue(() => useRnbwStakingPositionPnl.getState());
+  const { goBack, navigate } = useNavigation();
+  const accountAddress = useAccountAddress();
+  const isReadOnlyWallet = useIsReadOnlyWallet();
+  const isHardwareWallet = useIsHardwareWallet();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const startUnstake = useCallback(async () => {
+    setIsProcessing(true);
+    try {
+      await unstakeRnbw({ address: accountAddress });
+      goBack();
+    } catch (e) {
+      const error = ensureError(e);
+      setIsProcessing(false);
+      // TODO: For internal testing. Remove before production
+      Alert.alert('Unstake Failed', error.message);
+      logger.error(new RainbowError('[RnbwUnstakeSheet]: Unstake failed', error));
+    }
+  }, [accountAddress, goBack]);
+
+  const handleUnstake = useCallback(async () => {
+    if (isReadOnlyWallet) {
+      watchingAlert();
+      return;
+    }
+
+    if (isHardwareWallet) {
+      navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: startUnstake });
+    } else {
+      await startUnstake();
+    }
+  }, [isHardwareWallet, isReadOnlyWallet, navigate, startUnstake]);
+
+  return (
+    <View style={styles.content}>
+      <Stack space="44px">
+        <Text color="label" size="20pt" weight="heavy" align="center">
+          {`Unstake $${RNBW_SYMBOL}`}
+        </Text>
+        <Stack space="24px" alignHorizontal="center">
+          <Image source={rnbwCoinImage} style={styles.coinImage} />
+          <Stack space="12px" alignHorizontal="center">
+            <Text color="label" size="44pt" weight="heavy" align="center">
+              {nativeCurrencyAmount}
+            </Text>
+            <Text color="labelTertiary" size="17pt" weight="bold" align="center">
+              {`${tokenAmount} ${RNBW_SYMBOL}`}
+            </Text>
+          </Stack>
+        </Stack>
+      </Stack>
+      <Box paddingHorizontal="16px" marginTop={{ custom: 48 }}>
+        <Separator color="separator" thickness={1} />
+        <Stack separator={<Separator color="separator" thickness={1} />}>
+          <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">
+            <Text color="labelTertiary" size="17pt" weight="semibold">
+              {'Exit Penalty'}
+            </Text>
+            <Text color="label" size="17pt" weight="bold">
+              {`${UNSTAKE_PENALTY_PERCENTAGE}%`}
+            </Text>
+          </Box>
+          <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">
+            <Text color="labelTertiary" size="17pt" weight="semibold">
+              {'Exit Fee Recovered'}
+            </Text>
+            <Text color="label" size="17pt" weight="bold">
+              {exitFeeOffsetRatio}
+            </Text>
+          </Box>
+          <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">
+            <Text color="labelTertiary" size="17pt" weight="semibold">
+              {'PnL'}
+            </Text>
+            <Text color={isPositivePnl ? 'green' : 'red'} size="17pt" weight="bold">
+              {`${netPnl} ${RNBW_SYMBOL}`}
+            </Text>
+          </Box>
+        </Stack>
+      </Box>
+      <Box marginTop={{ custom: 24 }}>
+        <HoldToActivateButton
+          label="Hold to Unstake"
+          processingLabel="Unstaking..."
+          onLongPress={handleUnstake}
+          isProcessing={isProcessing}
+          backgroundColor="white"
+          disabledBackgroundColor="white"
+          progressColor="black"
+          showBiometryIcon
+          style={styles.holdButton}
+        />
+      </Box>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  content: {
+    paddingBottom: 24,
+    paddingHorizontal: 20,
+    paddingTop: 44,
+  },
+  holdButton: {
+    width: '100%',
+  },
+  coinImage: {
+    width: 80,
+    height: 80,
+  },
+});

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
@@ -1,0 +1,54 @@
+import {
+  divWorklet,
+  greaterThanWorklet,
+  isPositive,
+  mulWorklet,
+  subWorklet,
+  toFixedWorklet,
+  toPercentageWorklet,
+} from '@/framework/core/safeMath';
+import { convertRawAmountToDecimalFormatWorklet } from '@/helpers/utilities';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+import { useStakingPositionStore } from '../rnbwStakingPositionStore';
+import { UNSTAKE_PENALTY_PERCENTAGE } from '@/features/rnbw-staking/constants';
+
+type StakingPositionPnl = {
+  exitFeeOffsetRatio: string;
+  netPnl: string;
+  isPositivePnl: boolean;
+};
+
+const EMPTY_VALUE: StakingPositionPnl = {
+  exitFeeOffsetRatio: '0%',
+  netPnl: '0',
+  isPositivePnl: false,
+};
+
+export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
+  $ => {
+    const data = $(useStakingPositionStore, state => state.getData());
+
+    if (!data || data?.stakedRnbw === '0') return EMPTY_VALUE;
+
+    const { stakedRnbw, sessionPnl, decimals } = data;
+
+    const exchangeRateGain = sessionPnl?.exchangeRateGain ?? '0';
+    const exitFee = mulWorklet(stakedRnbw, UNSTAKE_PENALTY_PERCENTAGE / 100);
+    const exitFeeOffsetRatio = toFixedWorklet(divWorklet(exchangeRateGain, exitFee), 4);
+    const exitFeeOffsetRatioFormatted = !greaterThanWorklet(exitFeeOffsetRatio, '0')
+      ? '0%'
+      : `${toPercentageWorklet(exitFeeOffsetRatio, 0.001)}%`;
+
+    const netPnl = subWorklet(exchangeRateGain, exitFee);
+    const isPositivePnl = isPositive(netPnl);
+    const netPnlFormatted = toFixedWorklet(convertRawAmountToDecimalFormatWorklet(netPnl, decimals), 4);
+
+    return {
+      exitFeeOffsetRatio: exitFeeOffsetRatioFormatted,
+      netPnl: isPositivePnl ? `+${netPnlFormatted}` : netPnlFormatted,
+      isPositivePnl,
+    };
+  },
+  { equalityFn: shallowEqual, fastMode: true }
+);

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -17,6 +17,7 @@ type StakingTier = {
 };
 
 type StakingPnl = {
+  exchangeRateGain: string;
   netProfit: string;
   totalCashbackReceived: string;
   totalExitFeePaid: string;

--- a/src/features/rnbw-staking/utils/refreshStakingData.ts
+++ b/src/features/rnbw-staking/utils/refreshStakingData.ts
@@ -1,9 +1,0 @@
-import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
-import { useUserAssetsStore } from '@/state/assets/userAssets';
-
-export async function refreshStakingData() {
-  await Promise.allSettled([
-    useStakingPositionStore.getState().fetch(undefined, { force: true }),
-    useUserAssetsStore.getState().fetch(undefined, { force: true }),
-  ]);
-}

--- a/src/features/rnbw-staking/utils/refreshStakingData.ts
+++ b/src/features/rnbw-staking/utils/refreshStakingData.ts
@@ -1,0 +1,9 @@
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+
+export async function refreshStakingData() {
+  await Promise.allSettled([
+    useStakingPositionStore.getState().fetch(undefined, { force: true }),
+    useUserAssetsStore.getState().fetch(undefined, { force: true }),
+  ]);
+}

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -1,0 +1,27 @@
+import { encodeFunctionData, type Address, type Hash } from 'viem';
+import { getProvider } from '@/handlers/web3';
+import { loadWallet } from '@/model/wallet';
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_GAS_LIMIT } from '../constants';
+import { useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
+import { pollForStakingUpdate } from './pollForStakingUpdate';
+
+export async function unstakeRnbw({ address }: { address: Address }): Promise<Hash> {
+  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+  const signer = await loadWallet({ address, provider });
+  if (!signer) {
+    throw new Error('Failed to load wallet');
+  }
+
+  const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
+  const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+
+  const tx = await signer.sendTransaction({
+    to: STAKING_CONTRACT_ADDRESS,
+    data,
+    gasLimit: STAKING_GAS_LIMIT,
+  });
+  await tx.wait();
+  await pollForStakingUpdate(originalStakedRnbwShares);
+
+  return tx.hash as Hash;
+}

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -121,6 +121,7 @@ import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewa
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
 import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen';
 import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
+import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
 
@@ -313,6 +314,7 @@ function BSNavigator() {
       <BSStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
       <BSStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} />
       <BSStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
+      <BSStack.Screen component={RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} />
       <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
     </BSStack.Navigator>
   );

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -145,6 +145,7 @@ import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewa
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
 import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen';
 import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
+import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 
 const Stack = createStackNavigator();
@@ -353,6 +354,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
       <NativeStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen component={RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} {...panelConfig} />
 
       <NativeStack.Screen
         component={PolymarketBrowseEventsScreen}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -147,6 +147,7 @@ const Routes = {
   RNBW_REWARDS_ESTIMATE_SHEET: 'RnbwRewardsEstimateSheet',
   RNBW_STAKING_LEARN_SCREEN: 'RnbwStakingLearnScreen',
   RNBW_STAKING_SCREEN: 'RnbwStakingScreen',
+  RNBW_UNSTAKE_SHEET: 'RnbwUnstakeSheet',
   WALLET_ERROR_SHEET: 'WalletErrorSheet',
 } as const;
 

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -721,6 +721,7 @@ type RouteParams = {
   };
   [Routes.RNBW_STAKING_LEARN_SCREEN]: undefined;
   [Routes.RNBW_STAKING_SCREEN]: undefined;
+  [Routes.RNBW_UNSTAKE_SHEET]: undefined;
   [Routes.REVOKE_DELEGATION_PANEL]: {
     address: Address;
     delegationsToRevoke: Array<{


### PR DESCRIPTION
Fixes APP-3562

## What changed (plus any additional context for devs)
Adds core unstaking flow

- `RnbwUnstakeSheet`: This sheet has two states, first a warning and then the core unstake action. The unstake action content includes information about the pnl of the staking session. 
- `useRnbwStakingPositionPnl`: Derived store for calculating the pnl of the current staking session, accounting for the unstaking penalty. 
- `PanelSheet`: Minor change to the existing `PanelSheet` component to support the transition between the two states of the panel sheet. Adds a layout animation prop that allows the sheet to animate between two content drive heights. Yes this could have been a separate PR.  
- `unstakeRnbw`: Simple contract call to the `unstakeAll` function with polling for backend updates. 

## Screen recordings / screenshots

https://github.com/user-attachments/assets/0d4942b8-49b0-4c0a-a895-10bd587f2940

## What to test

Unstaking flow should unstake full staked balance. 
