### PR TITLE
fix: remove rainbow-scripts from watchman ignore

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -11,7 +11,6 @@
     "e2e",
     "ios",
     "patches",
-    "rainbow-scripts",
     "scripts",
     "types"
   ]


### PR DESCRIPTION
## What changed

Removes `rainbow-scripts` from `.watchmanconfig` `ignore_dirs` added in #7235.

`rainbow-scripts` contains native module code that Metro needs to resolve. Ignoring it causes native module resolution failures after catching up with develop. Deleting the watchman cache alone doesn't fix it — the `.watchmanconfig` file needed to be modified.

The other directories in the ignore list are safe because they don't contain JS/TS source that Metro bundles.