### PR TITLE
fix: allow private key import over damaged seed wallet (APP-3443)

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -730,15 +730,12 @@ export const createWallet = async ({
       // Don't allow adding a readOnly wallet that you have already visible
       // or a private key that you already have visible as a seed or mnemonic.
       // Exception: allow overwriting if the existing wallet is damaged (keychain data lost) so users can repair it.
+      // Note: damaged status is read from the walletsStore (not keychain) since it's only persisted in-memory.
       const isPrivateKeyOverwritingSeedMnemonic =
         type === EthereumWalletType.privateKey &&
         (alreadyExistingWallet?.type === EthereumWalletType.seed || alreadyExistingWallet?.type === EthereumWalletType.mnemonic);
-      if (
-        !overwrite &&
-        alreadyExistingWallet &&
-        !alreadyExistingWallet.damaged &&
-        (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)
-      ) {
+      const isExistingWalletDamaged = alreadyExistingWallet ? getIsDamagedWallet(alreadyExistingWallet.id) : false;
+      if (!overwrite && alreadyExistingWallet && !isExistingWalletDamaged && (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)) {
         if (!isRestoring) {
           logger.debug('[wallet]: already imported this wallet', {}, DebugContext.wallet);
           const error = new Error(i18n.t(i18n.l.wallet.new.alert.looks_like_already_imported));

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -730,7 +730,7 @@ export const createWallet = async ({
       // Don't allow adding a readOnly wallet that you have already visible
       // or a private key that you already have visible as a seed or mnemonic.
       // Exception: allow overwriting if the existing wallet is damaged (keychain data lost) so users can repair it.
-      // Note: damaged status is read from the walletsStore (not keychain) since it's only persisted in-memory.
+      // Note: damaged status is read from the walletsStore since getAllWallets() reads from keychain where it's not persisted.
       const isPrivateKeyOverwritingSeedMnemonic =
         type === EthereumWalletType.privateKey &&
         (alreadyExistingWallet?.type === EthereumWalletType.seed || alreadyExistingWallet?.type === EthereumWalletType.mnemonic);

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -728,11 +728,17 @@ export const createWallet = async ({
       existingWalletId = alreadyExistingWallet?.id;
 
       // Don't allow adding a readOnly wallet that you have already visible
-      // or a private key that you already have visible as a seed or mnemonic
+      // or a private key that you already have visible as a seed or mnemonic.
+      // Exception: allow overwriting if the existing wallet is damaged (keychain data lost) so users can repair it.
       const isPrivateKeyOverwritingSeedMnemonic =
         type === EthereumWalletType.privateKey &&
         (alreadyExistingWallet?.type === EthereumWalletType.seed || alreadyExistingWallet?.type === EthereumWalletType.mnemonic);
-      if (!overwrite && alreadyExistingWallet && (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)) {
+      if (
+        !overwrite &&
+        alreadyExistingWallet &&
+        !alreadyExistingWallet.damaged &&
+        (isReadOnlyType || isPrivateKeyOverwritingSeedMnemonic)
+      ) {
         if (!isRestoring) {
           logger.debug('[wallet]: already imported this wallet', {}, DebugContext.wallet);
           const error = new Error(i18n.t(i18n.l.wallet.new.alert.looks_like_already_imported));


### PR DESCRIPTION
Fixes APP-3443

## What changed

When a user's seed wallet is damaged (keychain data lost after device migration on iOS), re-importing via **private key** was blocked by the "already imported" guard.

Also make sure to get wallet damaged store from wallet store and not keychain since it is not persisted there.

## What to test

1. Import a wallet from seed phrase
2. Use "Simulate device transfer" in dev settings to corrupt keychain data
3. Reload the app, wallet restore sheet appears
4. Restore via private key
5. Should proceed with import instead of showing "already imported" error