### PR TITLE
fix: remove rainbow-scripts from watchman ignore

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -11,7 +11,6 @@
     "e2e",
     "ios",
     "patches",
-    "rainbow-scripts",
     "scripts",
     "types"
   ]


### PR DESCRIPTION
## What changed

Removes `rainbow-scripts` from `.watchmanconfig` `ignore_dirs` added in #7235.

`rainbow-scripts` contains js that Metro needs to resolve. Ignoring it causes module resolution failures.