### PR TITLE
fix: skip account auto-discovery during backup restore (APP-3446)

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -800,7 +800,7 @@ export const createWallet = async ({
 
     // Initiate auto account discovery for imported wallets via seedphrase
     // or for hardware wallets
-    if ((isHDWallet && root && isImported) || (isHardwareWallet && seed)) {
+    if (!isRestoring && ((isHDWallet && root && isImported) || (isHardwareWallet && seed))) {
       logger.debug('[wallet]: initializing account auto discovery', {}, DebugContext.wallet);
       let index = 1;
       let lookup = 0;


### PR DESCRIPTION
Fixes APP-3446

## What changed (plus any additional context for devs)

User with 122 accounts in Rainbow is unable to restore from iCloud backup. The restore process hangs (20+ seconds in screen recordings) without completing.

Skip account auto-discovery in `createWallet` when restoring from backup. During restore, each seed phrase triggers sequential `hasPreviousTransactions` requests (no timeout) to discover derived accounts. With many accounts (122 in this case), this can hang the restore indefinitely.

The backup already contains all accounts and keys so discovery is unnecessary.

## Screen recordings / screenshots

N/A

## What to test

Was not able to reproduce the infinite loading issue, this is a theoretical fix based on code analysis. However, validated that the code path is correctly hit by adding temporary `logger.info` calls:

1. **Backup restore on `develop` (before fix):** `shouldAutoDiscover: true` and "initializing account auto discovery" log appears → discovery runs during restore
2. **Backup restore on fix branch:** `shouldAutoDiscover: true` but "initializing account auto discovery" does **not** appear → discovery is correctly skipped, restore completes immediately
3. **Seed phrase import on fix branch:** `shouldAutoDiscover: true` and "initializing account auto discovery" log appears → discovery still works for normal imports (no regression)

Tested with Google Drive backup restore (same code path as iCloud).