### PR TITLE
fix(scanner): navigate away before processing EIP-681 URIs

### DIFF
--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -47,9 +47,15 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
     enabledVar.current = enabled;
   }, [enabled, disableScanning, enableScanning]);
 
-  const handleScanEthereumUrl = useCallback((data: string) => {
-    ethereumUtils.parseEthereumUrl(data);
-  }, []);
+  const handleScanEthereumUrl = useCallback(
+    (data: string) => {
+      // Navigate away first — prevents the QRScannerScreen beforeRemove listener from
+      // intercepting the SEND_FLOW navigation and looping forever.
+      navigate(Routes.WALLET_SCREEN);
+      ethereumUtils.parseEthereumUrl(data);
+    },
+    [navigate]
+  );
 
   const handleScanAddress = useCallback(
     async (address: string) => {
@@ -140,8 +146,6 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
 
       // EIP 681 / 831
       if (data.startsWith('ethereum:')) {
-        onSuccess();
-
         return handleScanEthereumUrl(data);
       }
       const address = await addressUtils.getEthereumAddressFromQRCodeData(data);


### PR DESCRIPTION
Fixes APP-3526

## What changed (plus any additional context for devs)

Scanning an EIP-681 QR code (`ethereum:` URI) locked the app completely — no crash, just frozen with no recovery path.

`QRScannerScreen` has a `beforeRemove` listener (added in #5178) that intercepts every navigation away from the scanner to deactivate the camera first. Every other QR handler (`handleScanAddress`, `handleScanWalletConnect`) calls `navigate(Routes.WALLET_SCREEN)` before opening the destination, so the scanner is already out of the stack and `beforeRemove` never fires for the deep-navigation step.

`handleScanEthereumUrl` was the exception — it left the scanner mounted and let `parseEthereumUrl` push `SEND_FLOW` directly. That triggered `beforeRemove`, which blocked the navigation, re-dispatched it, which triggered `beforeRemove` again — infinite loop.

Fix: add `navigate(Routes.WALLET_SCREEN)` at the top of `handleScanEthereumUrl`, matching every other handler. Remove the `onSuccess()` call from the EIP-681 branch in `onScan` (navigating away loses focus, deactivating the camera via `isActive`).

## Screen recordings / screenshots


## What to test

**EIP-681 (the fix) — all should open the send sheet, not freeze**

- Base USDC transfer (exact ticket scenario, wallet holding USDC on Base required):
  `ethereum:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913@8453/transfer?address=0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18&uint256=5000000`
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=ethereum%3A0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913%408453%2Ftransfer%3Faddress%3D0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18%26uint256%3D5000000)
- ERC-20 transfer, token not in wallet → should show "you don't have this asset" alert, not freeze
- Native ETH send on mainnet:
  `ethereum:0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18?value=1e18`
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=ethereum%3A0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18%3Fvalue%3D1e18)
- Native ETH send on an L2 (e.g. Base):
  `ethereum:0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18@8453?value=1e18`
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=ethereum%3A0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18%408453%3Fvalue%3D1e18)
- `pay-` prefixed URI (ERC-831):
  `ethereum:pay-0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18?value=5e17`
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=ethereum%3Apay-0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18%3Fvalue%3D5e17)

**Regression — unmodified flows that share the scanner**

- Plain `0x` address → profile sheet opens
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18)
- WalletConnect v2 QR → pairing sheet opens (requires live dapp session)
- POAP QR (poap.xyz link) → mint sheet opens
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=https%3A%2F%2Fpoap.xyz%2Fclaim%2Fabc123)
- Rainbow profile QR → profile sheet opens
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=https%3A%2F%2Frainbow.me%2Fprofile%2Fvitalik.eth)
- Unrecognised QR → "could not be recognized" alert with OK to re-enable scanner
  → [Generate QR](https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=not-a-valid-qr)