### PR TITLE
feat: cross-platform install source detection

### DIFF
--- a/android/app/src/main/java/me/rainbow/MainApplication.kt
+++ b/android/app/src/main/java/me/rainbow/MainApplication.kt
@@ -21,6 +21,7 @@ import me.rainbow.NativeModules.RNBip39.RNBip39Package
 import me.rainbow.NativeModules.RNTextAnimatorPackage.RNTextAnimatorPackage
 import me.rainbow.NativeModules.RNZoomableButton.RNZoomableButtonPackage
 import me.rainbow.NativeModules.NavbarHeight.NavbarHeightPackage
+import me.rainbow.NativeModules.AppInstallInfo.AppInstallInfoPackage
 import com.shopify.reactnativeperformance.ReactNativePerformance;
 
 class MainApplication : Application(), ReactApplication {
@@ -39,6 +40,7 @@ class MainApplication : Application(), ReactApplication {
             packages.add(InternalPackage())
             packages.add(RNHapticsPackage())
             packages.add(NavbarHeightPackage())
+            packages.add(AppInstallInfoPackage())
             return packages
         }
 

--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
@@ -1,0 +1,71 @@
+package me.rainbow.NativeModules.AppInstallInfo
+
+import android.content.pm.PackageManager
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
+import java.security.MessageDigest
+
+/**
+ * Determines whether the app was installed from a public store (Google Play, APKMirror, etc.)
+ * or from an internal source (QA APK, local release build).
+ *
+ * Google Play uses Play App Signing with two keys:
+ * - Upload key: held by Rainbow, used to sign APKs built locally (QA, engineer builds).
+ * - App signing key: held by Google, used to re-sign APKs distributed through Play Store.
+ *
+ * We compare the app's signing certificate against Rainbow's upload key fingerprint:
+ * - Match -> locally-built APK (QA/engineer) -> isStoreInstall = false
+ * - No match -> went through Google's signing pipeline (or unknown) -> isStoreInstall = true
+ *
+ * This is intentionally the reverse of checking for Google's app signing key. The failure
+ * modes are safer: if Google rotates the app signing key, nothing breaks. If Rainbow rotates
+ * the upload key, QA builds temporarily lose internal features until the fingerprint is
+ * updated (immediately visible, trivially fixed). Unknown/unexpected keys default to store
+ * install (safe: no dev tools exposed).
+ *
+ * Sideloads from APKMirror/Aurora Store carry Google's app signing key (not Rainbow's upload
+ * key), so they're correctly classified as store installs.
+ */
+@ReactModule(name = AppInstallInfoModule.NAME)
+class AppInstallInfoModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    companion object {
+        const val NAME = "AppInstallInfo"
+
+        // SHA-256 fingerprint of Rainbow's upload key certificate.
+        // Extract with: keytool -list -v -keystore rainbow-key.keystore -alias rainbow-alias
+        // Then convert the hex fingerprint to a byte array.
+        // TODO: paste actual SHA-256 fingerprint bytes here
+        private val UPLOAD_KEY_FINGERPRINT = byteArrayOf(
+            // e.g. 0x2A, 0x3B, 0x4C, ...
+        )
+    }
+
+    override fun getName(): String = NAME
+
+    // GET_SIGNATURES is deprecated in favor of GET_SIGNING_CERTIFICATES (API 28+), but our
+    // minSdkVersion is 26. The deprecation reason (signature spoofing by other apps) doesn't
+    // apply here since we only read our own app's certificate.
+    // TODO: migrate to GET_SIGNING_CERTIFICATES + signingInfo once minSdkVersion >= 28.
+    @Suppress("DEPRECATION")
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun isStoreInstall(): Boolean {
+        return try {
+            val packageInfo = reactApplicationContext
+                .packageManager
+                .getPackageInfo(
+                    reactApplicationContext.packageName,
+                    PackageManager.GET_SIGNATURES
+                )
+            val cert = packageInfo.signatures[0].toByteArray()
+            val fingerprint = MessageDigest.getInstance("SHA-256").digest(cert)
+            !fingerprint.contentEquals(UPLOAD_KEY_FINGERPRINT)
+        } catch (_: Exception) {
+            // Unknown signing state - default to store install (safe: no dev tools exposed)
+            true
+        }
+    }
+}

--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
@@ -35,13 +35,15 @@ class AppInstallInfoModule(reactContext: ReactApplicationContext) :
     companion object {
         const val NAME = "AppInstallInfo"
 
-        // SHA-256 fingerprint of Rainbow's upload key certificate.
+        // SHA-256 fingerprint of Rainbow's upload key certificate (rainbow-key.keystore, alias rainbow-alias).
         // Extract with: keytool -list -v -keystore rainbow-key.keystore -alias rainbow-alias
-        // Then convert the hex fingerprint to a byte array.
-        // TODO: paste actual SHA-256 fingerprint bytes here
-        private val UPLOAD_KEY_FINGERPRINT = byteArrayOf(
-            // e.g. 0x2A, 0x3B, 0x4C, ...
-        )
+        // CD:34:1C:31:91:0F:63:D7:1A:3C:FA:6D:A4:95:81:11:E8:3A:BA:CA:64:14:79:3D:DB:86:A0:F9:0D:26:42:41
+        private val UPLOAD_KEY_FINGERPRINT = intArrayOf(
+            0xCD, 0x34, 0x1C, 0x31, 0x91, 0x0F, 0x63, 0xD7,
+            0x1A, 0x3C, 0xFA, 0x6D, 0xA4, 0x95, 0x81, 0x11,
+            0xE8, 0x3A, 0xBA, 0xCA, 0x64, 0x14, 0x79, 0x3D,
+            0xDB, 0x86, 0xA0, 0xF9, 0x0D, 0x26, 0x42, 0x41,
+        ).map { it.toByte() }.toByteArray()
     }
 
     override fun getName(): String = NAME

--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
@@ -36,7 +36,7 @@ class AppInstallInfoModule(reactContext: ReactApplicationContext) :
         const val NAME = "AppInstallInfo"
 
         // SHA-256 fingerprint of Rainbow's upload key certificate (rainbow-key.keystore, alias rainbow-alias).
-        // Extract with: keytool -list -v -keystore rainbow-key.keystore -alias rainbow-alias
+        // Extracted with: keytool -list -v -keystore rainbow-key.keystore -alias rainbow-alias
         // CD:34:1C:31:91:0F:63:D7:1A:3C:FA:6D:A4:95:81:11:E8:3A:BA:CA:64:14:79:3D:DB:86:A0:F9:0D:26:42:41
         private val UPLOAD_KEY_FINGERPRINT = intArrayOf(
             0xCD, 0x34, 0x1C, 0x31, 0x91, 0x0F, 0x63, 0xD7,

--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
@@ -60,7 +60,7 @@ class AppInstallInfoModule(reactContext: ReactApplicationContext) :
                     reactApplicationContext.packageName,
                     PackageManager.GET_SIGNATURES
                 )
-            val cert = packageInfo.signatures[0].toByteArray()
+            val cert = packageInfo.signatures!![0].toByteArray()
             val fingerprint = MessageDigest.getInstance("SHA-256").digest(cert)
             !fingerprint.contentEquals(UPLOAD_KEY_FINGERPRINT)
         } catch (_: Exception) {

--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoPackage.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoPackage.kt
@@ -1,0 +1,16 @@
+package me.rainbow.NativeModules.AppInstallInfo
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class AppInstallInfoPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(AppInstallInfoModule(reactContext))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}

--- a/ios/AppInstallInfo.m
+++ b/ios/AppInstallInfo.m
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(AppInstallInfo, NSObject)
+
+RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(isStoreInstall)
+
+@end

--- a/ios/AppInstallInfo.swift
+++ b/ios/AppInstallInfo.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Determines whether the app was installed from the App Store or from an internal source
+/// (TestFlight, ad-hoc, local Xcode build).
+///
+/// Uses two signals:
+/// 1. Provisioning profile: Apple strips `embedded.mobileprovision` from App Store and
+///    TestFlight builds. Local/ad-hoc builds always have it. If present -> not a store install.
+/// 2. Receipt URL: Both App Store and TestFlight lack a provisioning profile, but TestFlight
+///    receipts live at `.../sandboxReceipt` while App Store receipts use a production path.
+///    sandboxReceipt -> TestFlight (not store). Production receipt -> App Store (store).
+@objc(AppInstallInfo)
+class AppInstallInfo: NSObject {
+
+  @objc
+  func isStoreInstall() -> Bool {
+    // Local/ad-hoc builds have a provisioning profile.
+    // App Store and TestFlight do not; Apple strips it.
+    let hasProfile = Bundle.main.path(
+      forResource: "embedded", ofType: "mobileprovision"
+    ) != nil
+    if hasProfile { return false }
+
+    // No profile = went through Apple's pipeline.
+    // TestFlight has sandboxReceipt, App Store has production receipt.
+    guard let receiptURL = Bundle.main.appStoreReceiptURL else { return true }
+    return receiptURL.lastPathComponent != "sandboxReceipt"
+  }
+
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+}

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		C9B378BB2C515A860085E5D0 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B378BA2C515A860085E5D0 /* ShareViewController.swift */; };
 		C9B378BE2C515A860085E5D0 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = C9B378BD2C515A860085E5D0 /* Base */; };
 		C9B378C22C515A860085E5D0 /* ShareWithRainbow.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C9B378B82C515A860085E5D0 /* ShareWithRainbow.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		CC31DFBA21E40E08FA23AEC8 /* AppInstallInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 25EC47FA7D8485D6DE97385B /* AppInstallInfo.m */; };
+		D57DF8DE7334657F937E570C /* AppInstallInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E32D5C136AD5C8520C49E22 /* AppInstallInfo.swift */; };
 		E8D2945956C9619768A8D361 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C92E589571C27FFE89AB10 /* ExpoModulesProvider.swift */; };
 		ED2971652150620600B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2971642150620600B7C4FE /* JavaScriptCore.framework */; };
 		FE44FC55302C54B7999CA03C /* libPods-Rainbow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AB1118D6FC6EBBDADC0F01B /* libPods-Rainbow.a */; };
@@ -250,6 +252,7 @@
 		24979E7C20F84004007EB0DA /* FirebaseCoreDiagnostics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCoreDiagnostics.framework; path = Frameworks/FirebaseCoreDiagnostics.framework; sourceTree = "<group>"; };
 		24979E7D20F84005007EB0DA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = Frameworks/module.modulemap; sourceTree = "<group>"; };
 		24979E7E20F84005007EB0DA /* nanopb.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = nanopb.framework; path = Frameworks/nanopb.framework; sourceTree = "<group>"; };
+		25EC47FA7D8485D6DE97385B /* AppInstallInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AppInstallInfo.m; sourceTree = "<group>"; };
 		3950E3F7A7C4CF855DF19F25 /* Pods-Rainbow.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rainbow.debug.xcconfig"; path = "Target Support Files/Pods-Rainbow/Pods-Rainbow.debug.xcconfig"; sourceTree = "<group>"; };
 		3A71142BEB6837762DF54DBE /* Pods-SelectTokenIntent.localrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelectTokenIntent.localrelease.xcconfig"; path = "Target Support Files/Pods-SelectTokenIntent/Pods-SelectTokenIntent.localrelease.xcconfig"; sourceTree = "<group>"; };
 		3C379D5D20FD1F92009AF81F /* Rainbow.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Rainbow.entitlements; path = Rainbow/Rainbow.entitlements; sourceTree = "<group>"; };
@@ -276,6 +279,7 @@
 		98AED33BAB4247CEBEF8464D /* libz.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		9D411F67996894258977077F /* Pods-ImageNotification.localrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ImageNotification.localrelease.xcconfig"; path = "Target Support Files/Pods-ImageNotification/Pods-ImageNotification.localrelease.xcconfig"; sourceTree = "<group>"; };
 		9DEADFA4826D4D0BAA950D21 /* libRNFIRMessaging.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNFIRMessaging.a; sourceTree = "<group>"; };
+		9E32D5C136AD5C8520C49E22 /* AppInstallInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppInstallInfo.swift; sourceTree = "<group>"; };
 		A1DCD9F6831578F1F6ACDBA0 /* libPods-SelectTokenIntent.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SelectTokenIntent.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4277D9E23CBD1910042BAF4 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		A4277DA223CFE85F0042BAF4 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -475,6 +479,8 @@
 				C04D10EF25AFC8C1003BEF7A /* Extras.json */,
 				AAE999CC2E41DD390072AFD5 /* RainbowSplashScreen.swift */,
 				AAE999D02E41E4670072AFD5 /* RainbowSplashScreen.m */,
+				9E32D5C136AD5C8520C49E22 /* AppInstallInfo.swift */,
+				25EC47FA7D8485D6DE97385B /* AppInstallInfo.m */,
 			);
 			name = Rainbow;
 			sourceTree = "<group>";
@@ -1486,6 +1492,8 @@ Upload Debug Symbols to Sentry */ = {
 				66A1FEBC24ACBBE600C3F539 /* RNCMPortal.m in Sources */,
 				C18FCD43273C64E40079CE28 /* PriceDataProvider.swift in Sources */,
 				E8D2945956C9619768A8D361 /* ExpoModulesProvider.swift in Sources */,
+				D57DF8DE7334657F937E570C /* AppInstallInfo.swift in Sources */,
+				CC31DFBA21E40E08FA23AEC8 /* AppInstallInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import { migrate } from '@/migrations';
 import { initializeReservoirClient } from '@/resources/reservoir/client';
 import { initializeRemoteConfig } from '@/model/remoteConfig';
 import { loadSettingsData } from '@/state/settings/loadSettingsData';
-import { IS_DEV, IS_PROD, IS_TEST } from '@/env';
+import { DANGER_INSTALL_SOURCE, IS_DEV, IS_PROD, IS_TEST } from '@/env';
 import Routes from '@/navigation/Routes';
 import { BackupsSync } from '@/state/sync/BackupsSync';
 import { AbsolutePortalRoot } from './components/AbsolutePortal';
@@ -177,6 +177,7 @@ async function initializeApplication() {
 
   Sentry.setUser({ id: deviceId });
   analytics.init({ deviceId });
+  analytics.identify({ installSource: DANGER_INSTALL_SOURCE });
 
   await Promise.all([
     initializeRemoteConfig(),

--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -96,6 +96,7 @@ export interface UserProperties {
   screenHeight?: number;
   screenWidth?: number;
   screenScale?: number;
+  installSource?: 'store' | 'internal' | 'dev';
 
   // branch
   branchCampaign?: string;

--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -1,4 +1,5 @@
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
+import type { InstallSource } from '@/env';
 import { type CandleResolution, type ChartType } from '@/features/charts/types';
 import { type Language } from '@/languages';
 import { type ChainId } from '@/state/backendNetworks/types';
@@ -96,7 +97,7 @@ export interface UserProperties {
   screenHeight?: number;
   screenWidth?: number;
   screenScale?: number;
-  installSource?: 'store' | 'internal' | 'dev';
+  installSource?: InstallSource;
 
   // branch
   branchCampaign?: string;

--- a/src/components/AppVersionStamp.tsx
+++ b/src/components/AppVersionStamp.tsx
@@ -6,7 +6,7 @@ import useTimeout from '@/hooks/useTimeout';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import styled from '@/framework/ui/styled-thing';
-import { IS_ANDROID, IS_IOS } from '@/env';
+import { DANGER_INSTALL_SOURCE, IS_ANDROID, IS_IOS } from '@/env';
 
 const DEBUG_TAP_COUNT = 15;
 
@@ -39,7 +39,7 @@ export function AppVersionStamp() {
   return (
     <StyledButton testID="app-version-stamp" hitSlop={10} onPress={handleVersionPress}>
       <Text color="secondary30 (Deprecated)" size="14px / 19px (Deprecated)" weight="bold">
-        {appVersion}
+        {`${appVersion} · ${DANGER_INSTALL_SOURCE}`}
       </Text>
     </StyledButton>
   );

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import ReactNative from 'react-native';
+import ReactNative, { NativeModules } from 'react-native';
 import { ENABLE_DEV_MODE, IS_TESTING, RPC_PROXY_BASE_URL_PROD, RPC_PROXY_API_KEY_PROD } from 'react-native-dotenv';
 import { getInstallerPackageNameSync } from 'react-native-device-info';
 
@@ -27,5 +27,12 @@ export const RPC_PROXY_API_KEY = RPC_PROXY_API_KEY_PROD;
 
 export const IS_TEST_FLIGHT = IS_IOS && getInstallerPackageNameSync() === 'TestFlight';
 
+// TODO: Replace IS_STORE_INSTALL with DANGER_INSTALL_SOURCE (renamed to INSTALL_SOURCE) once verified in production.
+// The AppInstallInfo native module is shipped but not wired in yet. DANGER_INSTALL_SOURCE
+// reads from the new native module for observation/verification only. Do NOT use it for
+// gating features or behavior until the values have been confirmed across all build types.
 export const IS_STORE_INSTALL = !IS_DEV && !IS_TEST_FLIGHT;
 export const IS_INTERNAL = IS_DEV || !IS_STORE_INSTALL;
+
+type InstallSource = 'store' | 'internal' | 'dev';
+export const DANGER_INSTALL_SOURCE: InstallSource = IS_DEV ? 'dev' : NativeModules.AppInstallInfo.isStoreInstall() ? 'store' : 'internal';

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,5 +34,5 @@ export const IS_TEST_FLIGHT = IS_IOS && getInstallerPackageNameSync() === 'TestF
 export const IS_STORE_INSTALL = !IS_DEV && !IS_TEST_FLIGHT;
 export const IS_INTERNAL = IS_DEV || !IS_STORE_INSTALL;
 
-type InstallSource = 'store' | 'internal' | 'dev';
+export type InstallSource = 'store' | 'internal' | 'dev';
 export const DANGER_INSTALL_SOURCE: InstallSource = IS_DEV ? 'dev' : NativeModules.AppInstallInfo.isStoreInstall() ? 'store' : 'internal';


### PR DESCRIPTION
`IS_STORE_INSTALL` and `IS_INTERNAL` currently rely on `IS_TEST_FLIGHT`, which uses `getInstallerPackageNameSync()` from react-native-device-info. This is iOS-only, so all non-dev Android builds (including QA APKs built with the upload key) are incorrectly classified as store installs and thus doesn't have dev settings etc.

This change adds an `AppInstallInfo` native module on both platforms that can accurately distinguish store installs from internal builds:
* On iOS it checks for the presence of a provisioning profile (stripped by Apple for App Store/TestFlight) and the receipt URL path (sandbox for TestFlight, production for App Store). 
* On Android it compares the app's signing certificate against Rainbow's upload key fingerprint. Builds signed with the upload key (QA, local release) are internal; everything else (Google Play, APKMirror sideloads, unknown sources) defaults to store install.

The module is shipped but **not yet wired into `IS_STORE_INSTALL`**. Instead, the native module's output is exported as `DANGER_INSTALL_SOURCE` from `env.ts`, a deliberately scary name signaling it should not be used for feature gating until verified. 

The version stamp in Settings now displays the install source label (`dev`, `store`, or `internal`) so we can visually verify the native module returns correct values across all build types, and is generally a nice info to have regardless (see screenshots below). The value is also sent to Amplitude as an `installSource` user property so we can validate at scale.

Once verified across a release cycle, a follow-up PR will replace the `IS_TEST_FLIGHT`-based `IS_STORE_INSTALL` with the native module, giving Android QA feature parity with iOS TestFlight. That also unblocks the Sentry environment rewrite (replacing `Release`/`Testflight`/`ReleaseAndroid`/`LocalRelease` with `production`/`internal`/`development`).

iOS | Android
--|--
<img width="250" alt="Simulator Screenshot - iPhone 17 - 2026-03-24 at 11 07 14" src="https://github.com/user-attachments/assets/027fcc07-5460-453e-bd41-e06846d2b060" /> | <img width="250" alt="Screenshot_20260324_114811" src="https://github.com/user-attachments/assets/3f442ada-1303-40d4-843c-d551bc8aeeb8" />

Ref FEPLAT-62.