### PR TITLE
fix(ci): align E2E builds with production by disabling dev mode

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -71,6 +71,7 @@ jobs:
           mv rainbow-env/android/app/google-services.json android/app/google-services.json
           rm -rf rainbow-env
           sed -i "s/IS_TESTING=false/IS_TESTING=true/" .env
+          sed -i "s/ENABLE_DEV_MODE=1/ENABLE_DEV_MODE=0/" .env
           echo "1" > is_testing
       - name: Setup scripts
         env:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -65,6 +65,7 @@ jobs:
           mv rainbow-env/dotenv .env
           rm -rf rainbow-env
           sed -i'' -e "s/IS_TESTING=false/IS_TESTING=true/" .env && rm -f .env-e
+          sed -i'' -e "s/ENABLE_DEV_MODE=1/ENABLE_DEV_MODE=0/" .env && rm -f .env-e
           echo "1" > is_testing
       - name: Setup scripts
         env:


### PR DESCRIPTION
Our E2E workflows clone `rainbow-env/dotenv` as the `.env` file, which has `ENABLE_DEV_MODE=1`. In a release build (where `__DEV__` is false), this makes `IS_DEV=true` due to the or guard on `ENABLE_DEV_MODE`, causing E2E builds to diverge from production on every `IS_DEV`-gated code path. This is how the `AppInstallInfo` startup crash (#7258) shipped undetected: the native module call in `env.ts` is guarded by `IS_DEV`, so it was never exercised in CI.

This change sets `ENABLE_DEV_MODE=0` in both the Android and iOS E2E workflows, matching production behavior. The test-critical features (Anvil connect button, deeplink import handler) are gated by `IS_TEST`, not `IS_DEV`, so they're unaffected. Traced all `IS_DEV` usages in the codebase and confirmed none would break E2E: analytics and Sentry are independently disabled by `IS_TEST`, the PIN auth path is handled by `MaybeInputPin.yaml`, and everything else is logging or dev UI gated by hardcoded `false` flags in `debug.ts`.