### PR TITLE
feature: decoupled claim airdrop flow

### DIFF
--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen.tsx
@@ -1,0 +1,57 @@
+import { memo, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
+import { RnbwHeroCoin } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+import { AmbientCoins } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/AmbientCoins';
+import { BottomGradientGlow } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/BottomGradientGlow';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { ColorModeProvider } from '@/design-system';
+import { useAirdropFlowStore, airdropFlowActions } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { AirdropClaimPromptScene } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimPromptScene';
+import { AirdropClaimingScene } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimingScene';
+import { AirdropClaimedScene } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimedScene';
+
+export const RnbwAirdropScreen = memo(function RnbwAirdropScreen() {
+  const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
+
+  useEffect(() => {
+    airdropFlowActions.reset();
+  }, []);
+
+  return (
+    <ColorModeProvider value="dark">
+      <View style={styles.container} testID="rnbw-airdrop-screen">
+        <SheetHandleFixedToTop color="rgba(245, 248, 255, 0.3)" top={safeAreaTop + 6} />
+        <View style={[styles.flex, { marginTop: safeAreaTop, paddingBottom: safeAreaBottom }]}>
+          <BottomGradientGlow />
+          <AmbientCoins />
+          <RnbwHeroCoin />
+          <RnbwAirdropSceneRouter />
+        </View>
+      </View>
+    </ColorModeProvider>
+  );
+});
+
+function RnbwAirdropSceneRouter() {
+  const activeScene = useAirdropFlowStore(state => state.activeScene);
+
+  return (
+    <View style={styles.flex}>
+      {activeScene === RnbwAirdropScenes.AirdropClaimPrompt && <AirdropClaimPromptScene />}
+      {activeScene === RnbwAirdropScenes.AirdropClaiming && <AirdropClaimingScene />}
+      {activeScene === RnbwAirdropScenes.AirdropClaimed && <AirdropClaimedScene />}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0D0D0D',
+  },
+  flex: {
+    flex: 1,
+  },
+});

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/AmbientCoins.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/AmbientCoins.tsx
@@ -18,9 +18,10 @@ import { BlurView } from 'react-native-blur-view';
 import rnbwCoin from '@/assets/rnbw.png';
 import useTimeout from '@/hooks/useTimeout';
 import { time } from '@/utils/time';
-import { RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
-import { useRnbwRewardsFlowContext } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/context/RnbwRewardsFlowContext';
-import { getCoinBottomPosition, getCoinCenterPosition } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/components/RnbwHeroCoin';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { useAirdropFlowStore } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { getCoinCenterPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
 
 // Original design dimensions
 const DESIGN_WIDTH = 393;
@@ -87,7 +88,7 @@ const COINS: CoinConfig[] = [
     pattern: 'a',
     duration: time.seconds(14),
     exitX: -48,
-    exitY: -54,
+    exitY: -100,
   },
   {
     left: 348,
@@ -108,7 +109,7 @@ const COINS: CoinConfig[] = [
     blur: 1,
     pattern: 'd',
     duration: time.seconds(20),
-    exitX: 72,
+    exitX: 96,
     exitY: 60,
   },
   {
@@ -141,8 +142,9 @@ const AmbientCoin = memo(function AmbientCoin({
 
   const { left, top, size } = config;
 
-  const claimedLeft = getCoinCenterPosition(RnbwRewardsScenes.AirdropClaimed).x - size / 2;
-  const claimedTop = getCoinBottomPosition(RnbwRewardsScenes.AirdropClaimed);
+  const claimedCenter = getCoinCenterPosition(RnbwAirdropScenes.AirdropClaimed);
+  const claimedLeft = claimedCenter.x - size / 2;
+  const claimedTop = claimedCenter.y - size / 2;
 
   const startFloatingAnimation = useCallback(() => {
     'worklet';
@@ -197,6 +199,8 @@ const AmbientCoin = memo(function AmbientCoin({
         // Normalize distance to 0-1 from 200-300
         const normalizedDistance = Math.max(0, Math.min(1, (distanceFromClaimPosition - 200) / 100));
         delay = normalizedDistance * time.ms(100);
+        // Reset to offscreen starting position so coins fly in from edges
+        exitProgress.value = 0;
       }
 
       exitProgress.value = withDelay(
@@ -213,8 +217,8 @@ const AmbientCoin = memo(function AmbientCoin({
   const containerStyle = useAnimatedStyle(() => {
     if (state.value === 'claimed') {
       return {
-        left: interpolate(exitProgress.value, [0, 1], [left, claimedLeft]),
-        top: interpolate(exitProgress.value, [0, 1], [top, claimedTop]),
+        left: interpolate(exitProgress.value, [0, 1], [left + config.exitX, claimedLeft]),
+        top: interpolate(exitProgress.value, [0, 1], [top + config.exitY, claimedTop]),
         transform: [{ translateX: floatX.value }, { translateY: floatY.value }],
       };
     }
@@ -292,18 +296,15 @@ const _AmbientCoins = memo(function _AmbientCoins({ state, entering }: { state: 
 });
 
 export const AmbientCoins = memo(function AmbientCoins() {
-  const { activeScene } = useRnbwRewardsFlowContext();
+  const activeScene = useStoreSharedValue(useAirdropFlowStore, state => state.activeScene, { fireImmediately: true });
   const [mountState, setMountState] = useState({ shouldRender: true, entering: false });
   const [startHideTimeout, stopHideTimeout] = useTimeout();
 
   const state = useDerivedValue(() => {
     switch (activeScene.value) {
-      case RnbwRewardsScenes.AirdropIntro:
-      case RnbwRewardsScenes.AirdropClaimPrompt:
+      case RnbwAirdropScenes.AirdropClaimPrompt:
         return 'visible';
-      case RnbwRewardsScenes.AirdropEligibility:
-        return 'hidden';
-      case RnbwRewardsScenes.AirdropClaimed:
+      case RnbwAirdropScenes.AirdropClaimed:
         return 'claimed';
       default:
         return 'hidden';

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/BottomGradientGlow.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/BottomGradientGlow.tsx
@@ -1,11 +1,11 @@
-import { type RnbwRewardsScene, RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
-import { useRnbwRewardsFlowContext } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/context/RnbwRewardsFlowContext';
+import { type RnbwAirdropScene, RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { useAirdropFlowStore } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { Blur, Canvas, LinearGradient, RoundedRect, vec } from '@shopify/react-native-skia';
 import { interpolate, interpolateColor, useAnimatedReaction, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 import { memo, useMemo } from 'react';
 import useDimensions from '@/hooks/useDimensions';
 import { time } from '@/utils/time';
-import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
 
 type GradientConfig = {
   colors: readonly string[];
@@ -15,7 +15,7 @@ type GradientConfig = {
 };
 
 type SceneGradient = {
-  scene: RnbwRewardsScene;
+  scene: RnbwAirdropScene;
   gradient: GradientConfig;
   opacity: number;
 };
@@ -40,31 +40,28 @@ const BLUE_ORANGE_GRADIENT: GradientConfig = {
 
 export const BottomGradientGlow = memo(function BottomGradientGlow() {
   const { width: screenWidth, height: screenHeight } = useDimensions();
-  const { activeScene } = useRnbwRewardsFlowContext();
-  const hasClaimableAirdrop = useAirdropBalanceStore(state => state.hasClaimableAirdrop());
+  const activeScene = useStoreSharedValue(useAirdropFlowStore, state => state.activeScene, { fireImmediately: true });
 
   const config = useMemo(() => {
     const sceneGradients: SceneGradient[] = [
-      { scene: RnbwRewardsScenes.AirdropClaimPrompt, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.2 },
-      ...(hasClaimableAirdrop ? [{ scene: RnbwRewardsScenes.RewardsOverview, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.12 }] : []),
-      { scene: RnbwRewardsScenes.AirdropClaimed, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.12 },
-      { scene: RnbwRewardsScenes.RewardsClaimed, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.12 },
+      { scene: RnbwAirdropScenes.AirdropClaimPrompt, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.2 },
+      { scene: RnbwAirdropScenes.AirdropClaimed, gradient: BLUE_ORANGE_GRADIENT, opacity: 0.12 },
     ];
 
     const inputRange = sceneGradients.map((_, index) => index);
-    const sceneIndex = sceneGradients.reduce<Partial<Record<RnbwRewardsScene, number>>>(
+    const sceneIndex = sceneGradients.reduce<Partial<Record<RnbwAirdropScene, number>>>(
       (acc, item, index) => {
         acc[item.scene] = index;
         return acc;
       },
-      {} as Partial<Record<RnbwRewardsScene, number>>
+      {} as Partial<Record<RnbwAirdropScene, number>>
     );
-    const sceneOpacity = sceneGradients.reduce<Partial<Record<RnbwRewardsScene, number>>>(
+    const sceneOpacity = sceneGradients.reduce<Partial<Record<RnbwAirdropScene, number>>>(
       (acc, item) => {
         acc[item.scene] = item.opacity;
         return acc;
       },
-      {} as Partial<Record<RnbwRewardsScene, number>>
+      {} as Partial<Record<RnbwAirdropScene, number>>
     );
 
     const gradientSequence = sceneGradients.map(item => item.gradient);
@@ -99,7 +96,7 @@ export const BottomGradientGlow = memo(function BottomGradientGlow() {
       endX,
       endY,
     };
-  }, [hasClaimableAirdrop]);
+  }, []);
 
   const sceneProgress = useSharedValue(0);
   const opacity = useSharedValue(0);

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin.tsx
@@ -12,8 +12,7 @@ import Animated, {
   ZoomIn,
   ZoomOut,
 } from 'react-native-reanimated';
-import { type RnbwRewardsScene, RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
-import { useRnbwRewardsFlowContext } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/context/RnbwRewardsFlowContext';
+import { type RnbwAirdropScene, RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { time } from '@/utils/time';
 import { transitionEasing } from '@/features/rnbw-rewards/animations/sceneTransitions';
@@ -22,7 +21,8 @@ import concentricCircleImage from '@/features/rnbw-rewards/assets/radial-circle.
 import { SpinnableCoin, type SpinnableCoinHandle } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/components/SpinnableCoin';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
-import { useRewardsFlowStore } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
+import { useAirdropFlowStore } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { Blur, Canvas, RoundedRect } from '@shopify/react-native-skia';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
@@ -41,49 +41,24 @@ const BLUR_CIRCLE_SIZE = 224;
 
 const STEP_TRANSITION_DELAY = time.ms(100);
 
-// These translations are relative to the bottom of the navbar on the rewards screen
-const scenesConfig: Record<RnbwRewardsScene, { scale: number; translateY: number }> = {
-  [RnbwRewardsScenes.AirdropIntro]: {
+const scenesConfig: Record<RnbwAirdropScene, { scale: number; translateY: number }> = {
+  [RnbwAirdropScenes.AirdropClaimPrompt]: {
     scale: 1,
-    translateY: 15,
+    translateY: 75,
   },
-  [RnbwRewardsScenes.AirdropEligibility]: {
+  [RnbwAirdropScenes.AirdropClaiming]: {
     scale: SMALL_COIN_SCALE,
-    translateY: 202,
+    translateY: 262,
   },
-  [RnbwRewardsScenes.AirdropClaimPrompt]: {
-    scale: 1,
-    translateY: 15,
-  },
-  [RnbwRewardsScenes.RewardsOverview]: {
+  [RnbwAirdropScenes.AirdropClaimed]: {
     scale: MEDIUM_COIN_SCALE,
-    translateY: 24,
-  },
-  [RnbwRewardsScenes.AirdropClaiming]: {
-    scale: SMALL_COIN_SCALE,
-    translateY: 202,
-  },
-  [RnbwRewardsScenes.RewardsClaiming]: {
-    scale: SMALL_COIN_SCALE,
-    translateY: 202,
-  },
-  [RnbwRewardsScenes.AirdropClaimed]: {
-    scale: MEDIUM_COIN_SCALE,
-    translateY: 186,
-  },
-  [RnbwRewardsScenes.RewardsClaimed]: {
-    scale: MEDIUM_COIN_SCALE,
-    translateY: 186,
-  },
-  [RnbwRewardsScenes.AirdropUnavailable]: {
-    scale: MEDIUM_COIN_SCALE,
-    translateY: 186,
+    translateY: 246,
   },
 };
 
-const loadingSpinnerTop =
-  scenesConfig[RnbwRewardsScenes.AirdropEligibility].translateY -
-  (LOADING_SPINNER_SIZE - COIN_SIZE * scenesConfig[RnbwRewardsScenes.AirdropEligibility].scale) / 2;
+const LOADING_SPINNER_TOP =
+  scenesConfig[RnbwAirdropScenes.AirdropClaiming].translateY -
+  (LOADING_SPINNER_SIZE - COIN_SIZE * scenesConfig[RnbwAirdropScenes.AirdropClaiming].scale) / 2;
 
 const timingConfig = { duration: time.seconds(1), easing: transitionEasing };
 const loadingSpinnerEnteringAnimation = FadeIn.delay(timingConfig.duration * 0.5).easing(transitionEasing);
@@ -95,23 +70,15 @@ const successIconEnterAnimation = ZoomIn.duration(timingConfig.duration * 0.25)
 const successIconExitAnimation = ZoomOut.easing(transitionEasing);
 
 export const RnbwHeroCoin = memo(function RnbwHeroCoin() {
-  const { activeScene } = useRnbwRewardsFlowContext();
-  const activeSceneState = useRewardsFlowStore(state => state.activeScene);
+  const activeScene = useStoreSharedValue(useAirdropFlowStore, state => state.activeScene, { fireImmediately: true });
+  const activeSceneState = useAirdropFlowStore(state => state.activeScene);
   const coinRef = useRef<SpinnableCoinHandle>(null);
 
   useAnimatedReaction(
     () => activeScene.value,
     (current, previous) => {
-      if (current === RnbwRewardsScenes.AirdropClaiming && previous === RnbwRewardsScenes.AirdropClaimPrompt) {
+      if (current === RnbwAirdropScenes.AirdropClaiming && previous === RnbwAirdropScenes.AirdropClaimPrompt) {
         coinRef.current?.spin({ turns: 0.5, durationMs: time.seconds(1.8) });
-      } else if (current === RnbwRewardsScenes.AirdropClaimPrompt && previous === RnbwRewardsScenes.AirdropEligibility) {
-        coinRef.current?.spin({ turns: 2, durationMs: time.seconds(3) });
-      } else if (current === RnbwRewardsScenes.RewardsOverview && previous === RnbwRewardsScenes.AirdropClaimed) {
-        coinRef.current?.spin({ turns: 0.5, durationMs: time.seconds(1.8) });
-      } else if (current === RnbwRewardsScenes.RewardsOverview && previous === RnbwRewardsScenes.RewardsClaimed) {
-        coinRef.current?.spin({ turns: 0.5, durationMs: time.seconds(1.8) });
-      } else if (current === RnbwRewardsScenes.RewardsClaiming && previous === RnbwRewardsScenes.RewardsOverview) {
-        coinRef.current?.spin({ turns: 0.5, durationMs: time.seconds(3) });
       }
     },
     []
@@ -131,11 +98,10 @@ export const RnbwHeroCoin = memo(function RnbwHeroCoin() {
     const config = scenesConfig[activeScene.value];
     const coinSize = COIN_SIZE * config.scale;
     const coinRadius = coinSize / 2;
-    const coinTopY = config.translateY;
 
     const circleSize = CONCENTRIC_CIRCLE_SIZE * config.scale;
     const circleCenter = getCircleRelativeCenterPoint(circleSize);
-    const top = coinTopY - circleCenter.y + coinRadius;
+    const top = config.translateY - circleCenter.y + coinRadius;
 
     return {
       transform: [
@@ -149,10 +115,8 @@ export const RnbwHeroCoin = memo(function RnbwHeroCoin() {
     const config = scenesConfig[activeScene.value];
     const coinSize = COIN_SIZE * config.scale;
     const top = config.translateY + coinSize / 2 - BLUR_CIRCLE_SIZE / 2;
-    const opacity = activeScene.value === RnbwRewardsScenes.AirdropEligibility ? 0 : 1;
 
     return {
-      opacity: withDelay(STEP_TRANSITION_DELAY, withTiming(opacity, timingConfig)),
       transform: [
         { translateY: withDelay(STEP_TRANSITION_DELAY, withTiming(top, timingConfig)) },
         { scale: withDelay(STEP_TRANSITION_DELAY, withTiming(config.scale, timingConfig)) },
@@ -188,7 +152,7 @@ export const RnbwHeroCoin = memo(function RnbwHeroCoin() {
 
       <Animated.View style={[styles.coinContainer, coinAnimatedStyle]}>
         <SpinnableCoin ref={coinRef} source={rnbwCoinImage} size={COIN_SIZE} />
-        {(activeSceneState === RnbwRewardsScenes.AirdropClaimed || activeSceneState === RnbwRewardsScenes.RewardsClaimed) && (
+        {activeSceneState === RnbwAirdropScenes.AirdropClaimed && (
           <Animated.View style={styles.successIcon} entering={successIconEnterAnimation} exiting={successIconExitAnimation}>
             <Box
               backgroundColor="#1F9E39"
@@ -216,14 +180,15 @@ export const RnbwHeroCoin = memo(function RnbwHeroCoin() {
 });
 
 function CoinLoadingSpinner() {
-  const activeSceneState = useRewardsFlowStore(state => state.activeScene);
-  const isLoading =
-    activeSceneState === RnbwRewardsScenes.AirdropEligibility ||
-    activeSceneState === RnbwRewardsScenes.AirdropClaiming ||
-    activeSceneState === RnbwRewardsScenes.RewardsClaiming;
+  const activeSceneState = useAirdropFlowStore(state => state.activeScene);
+  const isLoading = activeSceneState === RnbwAirdropScenes.AirdropClaiming;
   if (!isLoading) return null;
   return (
-    <Animated.View style={styles.loadingSpinner} entering={loadingSpinnerEnteringAnimation} exiting={loadingSpinnerExitingAnimation}>
+    <Animated.View
+      style={[styles.loadingSpinner, { top: LOADING_SPINNER_TOP }]}
+      entering={loadingSpinnerEnteringAnimation}
+      exiting={loadingSpinnerExitingAnimation}
+    >
       <LoadingSpinner color={'#F6D66C'} size={LOADING_SPINNER_SIZE} strokeWidth={2} />
     </Animated.View>
   );
@@ -235,10 +200,8 @@ function getCircleRelativeCenterPoint(size: number) {
   const outerHeight = size;
   const innerHeight = INNERMOST_CIRCLE_SIZE * circleSizeScale;
 
-  // This is the approximate offset relative to the absolute center of the image that the innermost circle is shifted by.
   const offsetPercent = 0.095;
 
-  // Calculate the innermost circle's actual top position
   const centeredGap = (outerHeight - innerHeight) / 2;
   const offsetDistance = offsetPercent * centeredGap;
   const actualTop = centeredGap + offsetDistance;
@@ -251,12 +214,12 @@ function getCircleRelativeCenterPoint(size: number) {
   };
 }
 
-export function getCoinBottomPosition(scene: RnbwRewardsScene) {
+export function getCoinBottomPosition(scene: RnbwAirdropScene) {
   const config = scenesConfig[scene];
   return config.translateY + COIN_SIZE * config.scale;
 }
 
-export function getCoinCenterPosition(scene: RnbwRewardsScene) {
+export function getCoinCenterPosition(scene: RnbwAirdropScene) {
   const config = scenesConfig[scene];
   const coinSize = COIN_SIZE * config.scale;
   return {
@@ -277,13 +240,8 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 8 },
     shadowRadius: 17,
   },
-  coin: {
-    width: COIN_SIZE,
-    height: COIN_SIZE,
-  },
   loadingSpinner: {
     position: 'absolute',
-    top: loadingSpinnerTop,
     left: DEVICE_WIDTH / 2 - LOADING_SPINNER_SIZE / 2,
     width: LOADING_SPINNER_SIZE,
     height: LOADING_SPINNER_SIZE,

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes.ts
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes.ts
@@ -1,13 +1,7 @@
-export const RnbwRewardsScenes = {
-  AirdropIntro: 'airdrop-intro',
-  AirdropEligibility: 'airdrop-eligibility',
-  AirdropClaiming: 'airdrop-claiming',
-  RewardsClaiming: 'rewards-claiming',
+export const RnbwAirdropScenes = {
   AirdropClaimPrompt: 'airdrop-claim-prompt',
+  AirdropClaiming: 'airdrop-claiming',
   AirdropClaimed: 'airdrop-claimed',
-  RewardsClaimed: 'rewards-claimed',
-  AirdropUnavailable: 'airdrop-unavailable',
-  RewardsOverview: 'rewards-overview',
 } as const;
 
-export type RnbwRewardsScene = (typeof RnbwRewardsScenes)[keyof typeof RnbwRewardsScenes];
+export type RnbwAirdropScene = (typeof RnbwAirdropScenes)[keyof typeof RnbwAirdropScenes];

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimPromptScene.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimPromptScene.tsx
@@ -1,17 +1,16 @@
 import { memo, useCallback, useState } from 'react';
 import { Alert, View, StyleSheet } from 'react-native';
-import { Box, globalColors, Text, TextIcon } from '@/design-system';
+import { Box, globalColors, Text } from '@/design-system';
 import * as i18n from '@/languages';
-import { RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
 import Animated from 'react-native-reanimated';
 import { time } from '@/utils/time';
 import { defaultExitAnimation, createScaleInFadeInSlideEnterAnimation } from '@/features/rnbw-rewards/animations/sceneTransitions';
-import { getCoinBottomPosition } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/components/RnbwHeroCoin';
+import { getCoinBottomPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
 import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
-import { rewardsFlowActions } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
+import { airdropFlowActions } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
 import { useAccountAddress, useIsHardwareWallet } from '@/state/wallets/walletsStore';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -29,10 +28,6 @@ export const AirdropClaimPromptScene = memo(function AirdropClaimPromptScene() {
   const isHardwareWallet = useIsHardwareWallet();
   const [isPreparingClaim, setIsPreparingClaim] = useState(false);
 
-  const handleClaimLater = () => {
-    rewardsFlowActions.setActiveScene(RnbwRewardsScenes.RewardsOverview);
-  };
-
   const showClaimError = useCallback(() => {
     Alert.alert(i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_title), i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_message));
   }, []);
@@ -42,8 +37,8 @@ export const AirdropClaimPromptScene = memo(function AirdropClaimPromptScene() {
     try {
       const message = getMessageToSign() ?? '';
       const preparedClaim = await prepareAirdropClaim({ message, address: accountAddress });
-      rewardsFlowActions.startAirdropClaimSubmission(preparedClaim);
-      rewardsFlowActions.setActiveScene(RnbwRewardsScenes.AirdropClaiming);
+      airdropFlowActions.startAirdropClaimSubmission(preparedClaim);
+      airdropFlowActions.setActiveScene(RnbwAirdropScenes.AirdropClaiming);
     } catch (error) {
       showClaimError();
       setIsPreparingClaim(false);
@@ -60,7 +55,7 @@ export const AirdropClaimPromptScene = memo(function AirdropClaimPromptScene() {
 
   return (
     <Animated.View style={styles.container} entering={enteringAnimation} exiting={defaultExitAnimation}>
-      <View style={styles.amountContainer}>
+      <View style={[styles.amountContainer, { top: getCoinBottomPosition(RnbwAirdropScenes.AirdropClaimPrompt) + 32 }]}>
         <Box gap={16} alignItems="center" width="full">
           <Text size="22pt" weight="heavy" color="labelQuaternary" align="center">
             {i18n.t(i18n.l.rnbw_rewards.claim.your_airdrop).toUpperCase()}
@@ -77,33 +72,21 @@ export const AirdropClaimPromptScene = memo(function AirdropClaimPromptScene() {
         <Text color={{ custom: '#989A9E' }} size="17pt / 150%" weight="semibold" align="center">
           {i18n.t(i18n.l.rnbw_rewards.claim.your_airdrop_description)}
         </Text>
-        <Box gap={28}>
-          <HoldToActivateButton
-            label={i18n.t(i18n.l.button.hold_to_authorize.hold_to_claim)}
-            onLongPress={handleClaimAirdrop}
-            backgroundColor={globalColors.white100}
-            disabledBackgroundColor={globalColors.white30}
-            disabled={false}
-            isProcessing={isPreparingClaim}
-            processingLabel={i18n.t(i18n.l.button.hold_to_authorize.claiming)}
-            showBiometryIcon={false}
-            progressColor="black"
-            style={styles.button}
-            weight="black"
-            color="black"
-            size="22pt"
-          />
-          <ButtonPressAnimation onPress={handleClaimLater} scaleTo={0.96}>
-            <Box flexDirection="row" gap={8} alignItems="center" justifyContent="center">
-              <Text color="labelTertiary" size="17pt" weight="bold" align="center">
-                {i18n.t(i18n.l.rnbw_rewards.claim.claim_later)}
-              </Text>
-              <TextIcon color="labelQuaternary" size="icon 13px" weight="bold" align="center">
-                {'􀆊'}
-              </TextIcon>
-            </Box>
-          </ButtonPressAnimation>
-        </Box>
+        <HoldToActivateButton
+          label={i18n.t(i18n.l.button.hold_to_authorize.hold_to_claim)}
+          onLongPress={handleClaimAirdrop}
+          backgroundColor={globalColors.white100}
+          disabledBackgroundColor={globalColors.white30}
+          disabled={false}
+          isProcessing={isPreparingClaim}
+          processingLabel={i18n.t(i18n.l.button.hold_to_authorize.claiming)}
+          showBiometryIcon={false}
+          progressColor="black"
+          style={styles.button}
+          weight="black"
+          color="black"
+          size="22pt"
+        />
       </Box>
     </Animated.View>
   );
@@ -122,7 +105,6 @@ const styles = StyleSheet.create({
   },
   amountContainer: {
     position: 'absolute',
-    top: getCoinBottomPosition(RnbwRewardsScenes.AirdropClaimPrompt) + 32,
     width: '100%',
   },
 });

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimedScene.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimedScene.tsx
@@ -2,25 +2,30 @@ import { memo } from 'react';
 import { StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { Box, Text } from '@/design-system';
-import { RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
 import { createScaleInFadeInSlideEnterAnimation, defaultExitAnimation } from '@/features/rnbw-rewards/animations/sceneTransitions';
-import { getCoinBottomPosition } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/components/RnbwHeroCoin';
+import { getCoinBottomPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
 import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
 import * as i18n from '@/languages';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
-import { rewardsFlowActions } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
+import { useNavigation } from '@/navigation/Navigation';
 
 const enteringAnimation = createScaleInFadeInSlideEnterAnimation({ translateY: -24 });
 const exitingAnimation = defaultExitAnimation;
 
 export const AirdropClaimedScene = memo(function AirdropClaimedScene() {
   const { tokenAmount } = useAirdropBalanceStore(state => state.getFormattedAirdroppedBalance());
+  const { goBack } = useNavigation();
 
   return (
     <Animated.View style={styles.container} entering={enteringAnimation} exiting={exitingAnimation}>
-      <Box gap={24} alignItems="center" style={styles.claimInfoContainer}>
+      <Box
+        gap={24}
+        alignItems="center"
+        style={[styles.claimInfoContainer, { top: getCoinBottomPosition(RnbwAirdropScenes.AirdropClaimed) + 20 }]}
+      >
         <Text color="label" size="30pt" weight="heavy" align="center">
           {i18n.t(i18n.l.rnbw_rewards.airdrop_claim_finished.airdrop_claimed)}
         </Text>
@@ -31,11 +36,7 @@ export const AirdropClaimedScene = memo(function AirdropClaimedScene() {
           </Text>
         </Text>
       </Box>
-      <ButtonPressAnimation
-        onPress={() => rewardsFlowActions.setActiveScene(RnbwRewardsScenes.RewardsOverview)}
-        scaleTo={0.96}
-        style={styles.button}
-      >
+      <ButtonPressAnimation onPress={goBack} scaleTo={0.96} style={styles.button}>
         <Box
           backgroundColor={opacity('#F5F8FF', 0.06)}
           width="full"
@@ -47,7 +48,7 @@ export const AirdropClaimedScene = memo(function AirdropClaimedScene() {
           borderWidth={1}
         >
           <Text color="label" size="22pt" weight="heavy" align="center">
-            {i18n.t(i18n.l.button.continue)}
+            {i18n.t(i18n.l.button.done)}
           </Text>
         </Box>
       </ButtonPressAnimation>
@@ -63,7 +64,6 @@ const styles = StyleSheet.create({
   },
   claimInfoContainer: {
     position: 'absolute',
-    top: getCoinBottomPosition(RnbwRewardsScenes.AirdropEligibility) + 20,
     width: '100%',
     alignItems: 'center',
   },

--- a/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimingScene.tsx
+++ b/src/features/rnbw-airdrop/screens/rnbw-airdrop-screen/scenes/AirdropClaimingScene.tsx
@@ -1,0 +1,100 @@
+import { memo, useCallback, useEffect, useState } from 'react';
+import { Alert, StyleSheet, View } from 'react-native';
+import { Box, Text, TextIcon } from '@/design-system';
+import { RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
+import { ActionStatusScene } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/ActionStatusScene';
+import { useAirdropFlowStore, airdropFlowActions } from '@/features/rnbw-airdrop/stores/airdropFlowStore';
+import * as i18n from '@/languages';
+import { getCoinBottomPosition } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/components/RnbwHeroCoin';
+import { ETH_COLOR_DARK } from '@/__swaps__/screens/Swap/constants';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { time } from '@/utils/time';
+import Animated from 'react-native-reanimated';
+import { defaultEnterAnimation, defaultExitAnimation } from '@/features/rnbw-rewards/animations/sceneTransitions';
+
+const LONGER_THAN_USUAL_TIME = time.seconds(10);
+
+export const AirdropClaimingScene = memo(function AirdropClaimingScene() {
+  const airdropClaimRequest = useAirdropFlowStore(state => state.airdropClaimRequest);
+  const labels = [
+    i18n.t(i18n.l.rnbw_rewards.loading_labels.claiming_airdrop),
+    i18n.t(i18n.l.rnbw_rewards.loading_labels.submitting_transaction),
+  ];
+
+  const showClaimError = useCallback(() => {
+    Alert.alert(i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_title), i18n.t(i18n.l.rnbw_rewards.claim.claim_failed_message));
+  }, []);
+
+  const handleClaimAirdropComplete = useCallback(
+    (taskStatus: 'success' | 'error') => {
+      if (taskStatus === 'error') {
+        showClaimError();
+        airdropFlowActions.setActiveScene(RnbwAirdropScenes.AirdropClaimPrompt);
+        return;
+      }
+      airdropFlowActions.setActiveScene(RnbwAirdropScenes.AirdropClaimed);
+    },
+    [showClaimError]
+  );
+
+  const shouldShowLongerThanUsualInfoCard = useLongerThanUsualInfoCard();
+
+  return (
+    <View style={[styles.contentContainer, { paddingTop: getCoinBottomPosition(RnbwAirdropScenes.AirdropClaiming) + 32 }]}>
+      <ActionStatusScene labels={labels} task={airdropClaimRequest} onComplete={handleClaimAirdropComplete} />
+      {shouldShowLongerThanUsualInfoCard && <LongerThanUsualInfoCard />}
+    </View>
+  );
+});
+
+function useLongerThanUsualInfoCard() {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setShouldShow(true);
+    }, LONGER_THAN_USUAL_TIME);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return shouldShow;
+}
+
+const LongerThanUsualInfoCard = memo(function LongerThanUsualInfoCard() {
+  const backgroundColor = opacity(ETH_COLOR_DARK, 0.06);
+  return (
+    <Animated.View entering={defaultEnterAnimation} exiting={defaultExitAnimation}>
+      <Box
+        backgroundColor={backgroundColor}
+        width={'full'}
+        height={100}
+        borderColor={{ custom: backgroundColor }}
+        borderWidth={1}
+        justifyContent="center"
+        alignItems="center"
+        borderRadius={32}
+        padding={'24px'}
+      >
+        <Box flexDirection="row" alignItems="center" gap={12}>
+          <TextIcon size="icon 21px" color="labelQuaternary" weight="bold">
+            {'􀐫'}
+          </TextIcon>
+          <Text color="labelQuaternary" size="15pt / 135%" weight="bold">
+            {i18n.t(i18n.l.rnbw_rewards.longer_than_usual)}
+          </Text>
+        </Box>
+      </Box>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 24,
+    paddingBottom: 32,
+  },
+});

--- a/src/features/rnbw-airdrop/stores/airdropFlowStore.ts
+++ b/src/features/rnbw-airdrop/stores/airdropFlowStore.ts
@@ -1,69 +1,36 @@
-import { type RnbwRewardsScene, RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
+import { type RnbwAirdropScene, RnbwAirdropScenes } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/constants/airdropScenes';
 import { submitAirdropClaim, type PreparedAirdropClaim } from '@/features/rnbw-rewards/utils/claimAirdrop';
-import { submitRewardsClaim, type PreparedRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
 import { ensureError } from '@/logger';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 import { createStoreActions } from '@/state/internal/utils/createStoreActions';
-import { delay } from '@/utils/delay';
-import { time } from '@/utils/time';
 
 type TaskIdle = { status: 'idle'; runId: number };
 type TaskRunning = { status: 'running'; runId: number };
 type TaskSuccess<T> = { status: 'success'; runId: number; data: T };
 type TaskError = { status: 'error'; runId: number; error: string };
 
-export type AsyncActionState<T> = TaskIdle | TaskRunning | TaskSuccess<T> | TaskError;
+export type AirdropAsyncActionState<T> = TaskIdle | TaskRunning | TaskSuccess<T> | TaskError;
 
-type RewardsFlowStore = {
-  activeScene: RnbwRewardsScene;
-  airdropEligibilityRequest: AsyncActionState<void>;
-  airdropClaimRequest: AsyncActionState<Awaited<ReturnType<typeof submitAirdropClaim>>>;
-  rewardsClaimRequest: AsyncActionState<Awaited<ReturnType<typeof submitRewardsClaim>>>;
-  resetFlow: (initialScene: RnbwRewardsScene) => void;
-  setActiveScene: (scene: RnbwRewardsScene) => void;
-  startAirdropEligibilityCheck: () => Promise<void>;
+type AirdropFlowStore = {
+  activeScene: RnbwAirdropScene;
+  airdropClaimRequest: AirdropAsyncActionState<Awaited<ReturnType<typeof submitAirdropClaim>>>;
+  reset: () => void;
+  setActiveScene: (scene: RnbwAirdropScene) => void;
   startAirdropClaimSubmission: (preparedClaim: PreparedAirdropClaim) => Promise<void>;
-  startRewardsClaimSubmission: (preparedClaim: PreparedRewardsClaim) => Promise<void>;
 };
 
-const createIdleAction = <T>(): AsyncActionState<T> => ({ status: 'idle', runId: 0 });
+export const useAirdropFlowStore = createRainbowStore<AirdropFlowStore>((set, get) => ({
+  activeScene: RnbwAirdropScenes.AirdropClaimPrompt,
+  airdropClaimRequest: { status: 'idle', runId: 0 },
 
-export const useRewardsFlowStore = createRainbowStore<RewardsFlowStore>((set, get) => ({
-  activeScene: RnbwRewardsScenes.AirdropIntro,
-  airdropEligibilityRequest: createIdleAction(),
-  airdropClaimRequest: createIdleAction(),
-  rewardsClaimRequest: createIdleAction(),
-
-  resetFlow: initialScene =>
-    set(state => {
-      return {
-        activeScene: initialScene,
-        airdropEligibilityRequest: { status: 'idle', runId: state.airdropEligibilityRequest.runId + 1 },
-        airdropClaimRequest: { status: 'idle', runId: state.airdropClaimRequest.runId + 1 },
-        rewardsClaimRequest: { status: 'idle', runId: state.rewardsClaimRequest.runId + 1 },
-      };
-    }),
+  reset: () =>
+    set(state => ({
+      activeScene: RnbwAirdropScenes.AirdropClaimPrompt,
+      airdropClaimRequest: { status: 'idle', runId: state.airdropClaimRequest.runId + 1 },
+    })),
 
   setActiveScene: scene => set(() => ({ activeScene: scene })),
-
-  startAirdropEligibilityCheck: async () => {
-    set(state => ({ airdropEligibilityRequest: { status: 'running', runId: state.airdropEligibilityRequest.runId + 1 } }));
-    const runId = get().airdropEligibilityRequest.runId;
-    try {
-      await delay(time.seconds(3));
-      set(state => {
-        if (state.airdropEligibilityRequest.runId !== runId) return state;
-        return { airdropEligibilityRequest: { status: 'success', runId, data: undefined } };
-      });
-    } catch (error) {
-      const errorMessage = ensureError(error).message;
-      set(state => {
-        if (state.airdropEligibilityRequest.runId !== runId) return state;
-        return { airdropEligibilityRequest: { status: 'error', runId, error: errorMessage } };
-      });
-    }
-  },
 
   startAirdropClaimSubmission: async preparedClaim => {
     set(state => ({ airdropClaimRequest: { status: 'running', runId: state.airdropClaimRequest.runId + 1 } }));
@@ -83,25 +50,6 @@ export const useRewardsFlowStore = createRainbowStore<RewardsFlowStore>((set, ge
       });
     }
   },
-
-  startRewardsClaimSubmission: async preparedClaim => {
-    set(state => ({ rewardsClaimRequest: { status: 'running', runId: state.rewardsClaimRequest.runId + 1 } }));
-    const runId = get().rewardsClaimRequest.runId;
-    try {
-      const currency = userAssetsStoreManager.getState().currency;
-      const data = await submitRewardsClaim({ preparedClaim, currency });
-      set(state => {
-        if (state.rewardsClaimRequest.runId !== runId) return state;
-        return { rewardsClaimRequest: { status: 'success', runId, data } };
-      });
-    } catch (error) {
-      const errorMessage = ensureError(error).message;
-      set(state => {
-        if (state.rewardsClaimRequest.runId !== runId) return state;
-        return { rewardsClaimRequest: { status: 'error', runId, error: errorMessage } };
-      });
-    }
-  },
 }));
 
-export const rewardsFlowActions = createStoreActions(useRewardsFlowStore);
+export const airdropFlowActions = createStoreActions(useAirdropFlowStore);

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -1,21 +1,28 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AccountImage } from '@/components/AccountImage';
 import { Navbar } from '@/components/navbar/Navbar';
-import { useTabBarOffset } from '@/hooks/useTabBarOffset';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { RnbwClaimCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard';
+import * as i18n from '@/languages';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
-  const tabBarOffset = useTabBarOffset();
-  const { top } = useSafeAreaInsets();
+  const handlePressClaimAirdrop = useCallback(() => {
+    Navigation.handleAction(Routes.RNBW_AIRDROP_SCREEN);
+  }, []);
 
   return (
     <View style={styles.flex}>
-      <Navbar floating title="Membership" leftComponent={<AccountImage />} />
-      <ScrollView
-        contentContainerStyle={{ paddingTop: top + 48, paddingBottom: tabBarOffset, paddingHorizontal: 20 }}
-        style={styles.flex}
-      />
+      <Navbar hasStatusBarInset title="Membership" leftComponent={<AccountImage />} />
+      <ScrollView contentContainerStyle={styles.scrollViewContentContainer} style={styles.flex}>
+        <RnbwClaimCard
+          tokenAmount="100"
+          nativeCurrencyAmount="$42.58"
+          title={i18n.t(i18n.l.rnbw_membership.claim_card.airdrop)}
+          onPressClaim={handlePressClaimAirdrop}
+        />
+      </ScrollView>
     </View>
   );
 });
@@ -23,5 +30,8 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
+  },
+  scrollViewContentContainer: {
+    paddingHorizontal: 20,
   },
 });

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard.tsx
@@ -1,0 +1,52 @@
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Text } from '@/design-system';
+import { Image, StyleSheet } from 'react-native';
+import { memo } from 'react';
+import rnbwCoinImage from '@/assets/rnbw.png';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import * as i18n from '@/languages';
+
+type RnbwClaimCardProps = {
+  tokenAmount: string;
+  nativeCurrencyAmount: string;
+  title: string;
+  onPressClaim: () => void;
+};
+
+export const RnbwClaimCard = memo(function RnbwClaimCard({ tokenAmount, nativeCurrencyAmount, title, onPressClaim }: RnbwClaimCardProps) {
+  return (
+    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+      <Text size="22pt" weight="heavy" color="label">
+        {title}
+      </Text>
+      <Box flexDirection="row" alignItems="center" gap={10}>
+        <Image source={rnbwCoinImage} style={styles.coinImage} />
+        <Box gap={10} style={styles.flex}>
+          <Text size="22pt" weight="heavy" color="label">
+            {nativeCurrencyAmount}
+          </Text>
+          <Text size="17pt" weight="bold" color="labelTertiary">
+            {`${tokenAmount} ${RNBW_SYMBOL}`}
+          </Text>
+        </Box>
+        <ButtonPressAnimation onPress={onPressClaim} scaleTo={0.96}>
+          <Box backgroundColor="yellow" borderRadius={21} gap={20} width={94} height={42} justifyContent="center" alignItems="center">
+            <Text size="22pt" weight="heavy" color="label">
+              {i18n.t(i18n.l.button.claim)}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+      </Box>
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  coinImage: {
+    width: 48,
+    height: 48,
+  },
+  flex: {
+    flex: 1,
+  },
+});

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -358,7 +358,8 @@
       "unhide": "Unhide",
       "unpin": "Unpin",
       "view": "View",
-      "hidden": "Hidden"
+      "hidden": "Hidden",
+      "claim": "Claim"
     },
     "cards": {
       "ens_create_profile": {
@@ -3844,6 +3845,12 @@
         "oh_i_see": "Oh I see..."
       },
       "longer_than_usual": "Claiming is taking longer than usual. It may take up to one minute."
+    },
+    "rnbw_membership": {
+      "claim_card": {
+        "airdrop": "Airdrop",
+        "rewards": "Rewards"
+      }
     },
     "wallet_error_sheet": {
       "title": "Restore your wallet",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -116,6 +116,7 @@ import { PolymarketNavigator } from '@/features/polymarket/screens/polymarket-na
 import { PolymarketMarketDescriptionSheet } from '@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet';
 import { PolymarketExplainSheet } from '@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet';
 import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet';
+import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
@@ -304,6 +305,7 @@ function BSNavigator() {
       <BSStack.Screen component={PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} />
       <BSStack.Screen component={PolymarketBrowseEventsScreen} name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN} />
       <BSStack.Screen component={PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} />
+      <BSStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
       <BSStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
       <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
     </BSStack.Navigator>

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -140,6 +140,7 @@ import { PolymarketWithdrawalScreen } from '@/features/polymarket/funding/screen
 import { PolymarketMarketDescriptionSheet } from '@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet';
 import { PolymarketExplainSheet } from '@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet';
 import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet';
+import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 
@@ -344,6 +345,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} {...perpsAccountStackConfig} />
       <NativeStack.Screen component={PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} {...learnSheetConfig} />
       <NativeStack.Screen component={PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
 
       <NativeStack.Screen

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -140,6 +140,7 @@ const Routes = {
   POLYMARKET_MARKET_DESCRIPTION_SHEET: 'PolymarketMarketDescriptionSheet',
   POLYMARKET_EXPLAIN_SHEET: 'PolymarketExplainSheet',
   POLYMARKET_SELL_POSITION_SHEET: 'PolymarketSellPositionSheet',
+  RNBW_AIRDROP_SCREEN: 'RnbwAirdropScreen',
   RNBW_MEMBERSHIP_SCREEN: 'RnbwMembershipScreen',
   RNBW_REWARDS_SCREEN: 'RnbwRewardsScreen',
   RNBW_REWARDS_ESTIMATE_SHEET: 'RnbwRewardsEstimateSheet',


### PR DESCRIPTION
Fixes APP-3535

## Why

The airdrop claim flow was coupled to the rewards screen, which manages ~9 scenes (intro, eligibility, claim, rewards overview, etc.). To ship the membership screen independently, airdrop claiming needed its own standalone screen — navigable from the membership tab, no rewards scene management involved. Both flows coexist behind a feature flag, so the duplication is intentional.

## Changes

**Direct copies / trimmed only** 

- `airdropScenes.ts`

**Copies with modifications**

- `AmbientCoins.tsx` — swapped context for zustand store, simplified to 2 visibility states, tweaked animation params
- `BottomGradientGlow.tsx` — dropped airdrop balance check, reduced gradient config from 4 scenes to 2
- `RnbwHeroCoin.tsx` — 3-scene config instead of 8, new Y positions, stripped spin/blur animations for removed scenes
- `AirdropClaimPromptScene.tsx` — removed "Claim Later" button (no rewards overview to fall back to), wired to airdrop store
- `AirdropClaimedScene.tsx` — "Done" calls `goBack()` instead of navigating to rewards overview
- `airdropFlowStore.ts` — stripped eligibility check, rewards claim, and configurable `resetFlow()` from `rewardsFlowStore.ts`

**New files**

- `RnbwAirdropScreen.tsx` — full-screen modal composing the above with a 3-scene router
- `AirdropClaimingScene.tsx` — loading/status scene using existing `ActionStatusScene`
- `RnbwClaimCard.tsx` — card component for the membership screen

**Common pattern across copied files:** replace rewards flow context/store with `useAirdropFlowStore`, strip inapplicable scenes, simplify animations accordingly.

**Screen Recording**

https://github.com/user-attachments/assets/af1eceea-00d9-4287-b789-c1f64d56e96d


## What to test
I'm not aware of wallets we control that have airdrops left to claim, so this is difficult to actually test. For the demo above I locally changed it so that it mocked a successful response. Given nothing about the API call itself changed, I think that is sufficient. 
