### PR TITLE
feature: claim rewards before staking

### DIFF
--- a/src/features/rnbw-rewards/utils/claimRewards.ts
+++ b/src/features/rnbw-rewards/utils/claimRewards.ts
@@ -10,6 +10,7 @@ import { loadWallet, signTypedDataMessage } from '@/model/wallet';
 import { type RainbowFetchResponse } from '@/framework/data/http/rainbowFetch';
 import { getPlatformClient } from '@/resources/platform/client';
 import { ChainId } from '@rainbow-me/swaps';
+import { type Signer } from '@ethersproject/abstract-signer';
 import { type Address } from 'viem';
 import {
   type ClaimRewardsResult,
@@ -30,7 +31,7 @@ export type PreparedRewardsClaim = {
   signedIntent: string;
 };
 
-export async function prepareRewardsClaim({ address }: { address: Address }): Promise<PreparedRewardsClaim> {
+export async function prepareRewardsClaim({ address, signer }: { address: Address; signer?: Signer }): Promise<PreparedRewardsClaim> {
   // Only base is supported for now
   const chainId = ChainId.base;
   const startedAt = Date.now();
@@ -56,7 +57,7 @@ export async function prepareRewardsClaim({ address }: { address: Address }): Pr
       throw new Error('GetClaimIntent response is missing intent data');
     }
 
-    const signedIntent = await signIntent({ address, intent: intentResult.intent, chainId });
+    const signedIntent = await signIntent({ address, intent: intentResult.intent, chainId, signer });
 
     return {
       address,
@@ -157,10 +158,20 @@ export async function submitRewardsClaim({
   }
 }
 
-async function signIntent({ address, intent, chainId }: { address: Address; intent: GetClaimIntentResult['intent']; chainId: ChainId }) {
+async function signIntent({
+  address,
+  intent,
+  chainId,
+  signer: existingSigner,
+}: {
+  address: Address;
+  intent: GetClaimIntentResult['intent'];
+  chainId: ChainId;
+  signer?: Signer;
+}) {
   const provider = getProvider({ chainId });
-  const signer = await loadWallet({ address, provider });
-  if (!signer) {
+  const resolvedSigner = existingSigner ?? (await loadWallet({ address, provider }));
+  if (!resolvedSigner) {
     throw new Error('Failed to load wallet');
   }
   const messageToSign = {
@@ -174,11 +185,10 @@ async function signIntent({ address, intent, chainId }: { address: Address; inte
     },
     message: intent.message,
   };
-  const signedIntent = await signTypedDataMessage(messageToSign, provider, signer);
+  const signedIntent = await signTypedDataMessage(messageToSign, provider, resolvedSigner);
 
-  // If the wallet is a hardware wallet, the hardware wallet navigator modal will be open
-  const isHardwareWallet = signer instanceof LedgerSigner;
-  if (isHardwareWallet) {
+  const isHardwareWalletNavigatorOpen = !existingSigner && resolvedSigner instanceof LedgerSigner;
+  if (isHardwareWalletNavigatorOpen) {
     Navigation.goBack();
   }
 

--- a/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
@@ -9,7 +9,9 @@ import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import watchingAlert from '@/utils/watchingAlert';
 import { logger, RainbowError } from '@/logger';
+import { sumWorklet } from '@/framework/core/safeMath';
 import { stakeRnbw } from '@/features/rnbw-staking/utils/stakeRnbw';
+import { useStakableRnbwBalance } from '@/state/rnbw/useStakableRnbwBalance';
 
 export const RnbwStakingScreen = memo(function RnbwStakingScreen() {
   const { top: safeAreaTop } = useSafeAreaInsets();
@@ -22,11 +24,15 @@ export const RnbwStakingScreen = memo(function RnbwStakingScreen() {
   const startStake = useCallback(async () => {
     setIsProcessing(true);
     try {
-      await stakeRnbw({ address: accountAddress, amount: '1' });
+      const claimableBalance = useStakableRnbwBalance.getState().claimableBalance;
+      // TODO: Fixed amount of RNBW to stake
+      const stakeAmount = sumWorklet('1', claimableBalance);
+      await stakeRnbw({ address: accountAddress, amount: stakeAmount });
       goBack();
     } catch (e) {
       setIsProcessing(false);
       Alert.alert('Staking Failed', 'Something went wrong while staking. Please try again.');
+      console.log('e', e);
       logger.error(new RainbowError('[RnbwStakingScreen]: Staking failed', e));
     }
   }, [accountAddress, goBack]);

--- a/src/features/rnbw-staking/utils/stakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbw.ts
@@ -1,13 +1,19 @@
-import { parseUnits, type Address, type Hash } from 'viem';
+import { encodeFunctionData, erc20Abi, parseUnits, type Address, type Hash } from 'viem';
 import { stakeRnbwManual } from './stakeRnbwManual';
 import { stakeRnbwSponsored } from './stakeRnbwSponsored';
 import { getProvider } from '@/handlers/web3';
-import { RNBW_DECIMALS, STAKING_CHAIN_ID } from '../constants';
+import { loadWallet } from '@/model/wallet';
+import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, STAKING_CHAIN_ID } from '../constants';
 import { useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
-import { loadWallet } from '@/model/wallet';
+import { RainbowError } from '@/logger';
+import type { Signer } from '@ethersproject/abstract-signer';
+import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
+import { prepareRewardsClaim, submitRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { isRainbowDelegatedForChain } from '@/features/delegation/utils/isRainbowDelegatedForChain';
 import { Alert } from 'react-native';
+import { greaterThanOrEqualToWorklet } from '@/framework/core/safeMath';
 
 export async function stakeRnbw({ address, amount }: { address: Address; amount: string }): Promise<Hash> {
   const provider = getProvider({ chainId: STAKING_CHAIN_ID });
@@ -15,8 +21,27 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
   if (!signer) {
     throw new Error('Failed to load wallet');
   }
+
+  const rnbwBalanceRaw = BigInt(
+    await provider.call({
+      to: RNBW_TOKEN_ADDRESS,
+      data: encodeFunctionData({ abi: erc20Abi, functionName: 'balanceOf', args: [address] }),
+    })
+  ).toString();
+
   const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
+
+  /**
+   * This check is not strictly necessary, as the provider gas estimation will fail if the balance is insufficient.
+   * However, the error returned by the provider in that case is opaque.
+   */
+  const hasSufficientBalance = greaterThanOrEqualToWorklet(rnbwBalanceRaw, stakeAmountRaw);
+  if (!hasSufficientBalance) {
+    throw new RainbowError('[stakeRnbw]: Insufficient balance');
+  }
   const isRainbowDelegated = await isRainbowDelegatedForChain(address, STAKING_CHAIN_ID);
+
+  await claimRnbwRewards({ address, signer });
 
   const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
 
@@ -29,4 +54,16 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
   // TODO: For testing. Remove
   Alert.alert(`Staked: ${amount} RNBW (${isRainbowDelegated ? 'Sponsored' : 'Manual'})`, transactionHash);
   return transactionHash;
+}
+
+async function claimRnbwRewards({ address, signer }: { address: Address; signer: Signer }): Promise<void> {
+  await useRewardsBalanceStore.getState().fetch(undefined, { force: true });
+  const hasClaimable = useRewardsBalanceStore.getState().hasClaimableRewards();
+  const hasPendingClaim = useRewardsBalanceStore.getState().getData()?.hasPendingClaim;
+
+  if (!hasClaimable || hasPendingClaim) return;
+
+  const currency = userAssetsStoreManager.getState().currency;
+  const preparedClaim = await prepareRewardsClaim({ address, signer });
+  await submitRewardsClaim({ preparedClaim, currency });
 }

--- a/src/state/rnbw/useStakableRnbwBalance.ts
+++ b/src/state/rnbw/useStakableRnbwBalance.ts
@@ -1,11 +1,20 @@
-import { convertAmountToNativeDisplayWorklet, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
-import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import {
+  add,
+  convertAmountToNativeDisplayWorklet,
+  convertRawAmountToDecimalFormat,
+  isPositive,
+  truncateToDecimalsWithThreshold,
+} from '@/helpers/utilities';
+import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
+import { RNBW_DECIMALS, RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { shallowEqual } from '@/worklets/comparisons';
-import { RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
 
 type RnbwBalance = {
+  walletBalance: string;
+  claimableBalance: string;
   tokenAmountFormatted: string;
   nativeCurrencyAmount: string;
   hasBalance: boolean;
@@ -14,15 +23,25 @@ type RnbwBalance = {
 export const useStakableRnbwBalance = createDerivedStore<RnbwBalance>(
   $ => {
     const asset = $(useUserAssetsStore, state => state.getUserAsset(RNBW_TOKEN_UNIQUE_ID));
+    const rewardsData = $(useRewardsBalanceStore, state => state.getData());
     const currency = $(userAssetsStoreManager, state => state.currency);
 
-    const amount = asset?.balance?.amount ?? '0';
-    const nativeValue = asset?.native?.balance?.amount ?? '0';
-    const hasBalance = amount !== '0';
+    const walletAmount = asset?.balance?.amount ?? '0';
+    const walletNativeValue = asset?.native?.balance?.amount ?? '0';
+
+    const claimableRaw = rewardsData?.claimableRnbw ?? '0';
+    const claimableAmount = convertRawAmountToDecimalFormat(claimableRaw, RNBW_DECIMALS);
+    const claimableNativeValue = rewardsData?.claimableValueInCurrency ?? '0';
+
+    const totalAmount = add(walletAmount, claimableAmount);
+    const totalNativeValue = add(walletNativeValue, claimableNativeValue);
+    const hasBalance = isPositive(totalAmount);
 
     return {
-      tokenAmountFormatted: truncateToDecimalsWithThreshold({ value: amount, decimals: 2, threshold: '0.01' }),
-      nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(nativeValue, currency, hasBalance),
+      walletBalance: walletAmount,
+      claimableBalance: claimableAmount,
+      tokenAmountFormatted: truncateToDecimalsWithThreshold({ value: totalAmount, decimals: 2, threshold: '0.01' }),
+      nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(totalNativeValue, currency, hasBalance),
       hasBalance,
     };
   },


### PR DESCRIPTION
Fixes APP-3524

## What changed

When the user initiates a stake, any unclaimed RNBW rewards are now automatically claimed first and (for now) included in the staked amount.

- `claimRewards.ts`: adds an optional `signer` to avoid double wallet unlock.
- `stakeRnbw.ts`: reads the on-chain RNBW balance and fails early with a clear error if insufficient. Before executing the stake transaction, calls the new `claimRnbwRewards` helper which checks for claimable rewards and submits the claim if applicable.
- `RnbwStakingScreen.tsx`: reads claimable RNBW from `rewardsBalanceStore` and adds it to the stake amount so the UI reflects the total amount available.
- `useStakableRnbwBalance.ts` — derived store now sums the wallet RNBW balance with unclaimed rewards to show the full stakable amount.

## Screen recording

https://github.com/user-attachments/assets/5cbd41b4-2c56-4742-a796-513dab0e45ca

## What to test

- Stake with unclaimed rewards, rewards should be claimed and the full amount staked.