### PR TITLE
fix(AppInstallInfo): crash when iOS sync method returns true

### DIFF
--- a/ios/AppInstallInfo.swift
+++ b/ios/AppInstallInfo.swift
@@ -13,7 +13,7 @@ import Foundation
 class AppInstallInfo: NSObject {
 
   @objc
-  func isStoreInstall() -> Bool {
+  func isStoreInstall() -> NSNumber {
     // Local/ad-hoc builds have a provisioning profile.
     // App Store and TestFlight do not; Apple strips it.
     let hasProfile = Bundle.main.path(
@@ -24,7 +24,7 @@ class AppInstallInfo: NSObject {
     // No profile = went through Apple's pipeline.
     // TestFlight has sandboxReceipt, App Store has production receipt.
     guard let receiptURL = Bundle.main.appStoreReceiptURL else { return true }
-    return receiptURL.lastPathComponent != "sandboxReceipt"
+    return NSNumber(value: receiptURL.lastPathComponent != "sandboxReceipt")
   }
 
   @objc


### PR DESCRIPTION
The `AppInstallInfo#isStoreInstall()` Swift method returns `Bool`, but React Native's bridge requires synchronous methods to return an ObjC object type (`id`). The bridge calls `objc_retain` on the raw return value, and a primitive `true` (1) gets misinterpreted as a pointer to address `0x1`, causing a crash on startup. Returning `false` (0) happens to survive because nil is a safe no-op for `objc_retain`. This is why the TestFlight build works (method returns `false` there) but an App Store build (and our E2E fix in #7260 crashes tests right now) would crash (method returns `true`).

This was never caught because the `IS_DEV` guard in `env.ts` short-circuited before reaching the native call in every environment tested so far. We fix this in #7260 so we cover these cases going forward in the E2E suite. Also no compiler or linter catches this mismatch since `Bool` is a valid `@objc` return type and the RN bridge registers method names as strings without validating return types.

This change returns `NSNumber` instead of `Bool`, which is the correct type per the [React Native docs](https://reactnative.dev/docs/legacy/native-modules-ios#synchronous-methods). The JS side still receives a boolean.

Ref FEPLAT-62.