### PR TITLE
fix(AppInstallInfo): debug key builds incorrectly classified as store installs

### DIFF
--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
@@ -15,8 +15,8 @@ import java.security.MessageDigest
  * - Upload key: held by Rainbow, used to sign APKs built locally (QA, engineer builds).
  * - App signing key: held by Google, used to re-sign APKs distributed through Play Store.
  *
- * We compare the app's signing certificate against Rainbow's upload key fingerprint:
- * - Match -> locally-built APK (QA/engineer) -> isStoreInstall = false
+ * We compare the app's signing certificate against known Rainbow key fingerprints:
+ * - Match (upload key or debug key) -> locally-built APK (QA/engineer) -> isStoreInstall = false
  * - No match -> went through Google's signing pipeline (or unknown) -> isStoreInstall = true
  *
  * This is intentionally the reverse of checking for Google's app signing key. The failure
@@ -35,15 +35,27 @@ class AppInstallInfoModule(reactContext: ReactApplicationContext) :
     companion object {
         const val NAME = "AppInstallInfo"
 
-        // SHA-256 fingerprint of Rainbow's upload key certificate (rainbow-key.keystore, alias rainbow-alias).
-        // Extracted with: keytool -list -v -keystore rainbow-key.keystore -alias rainbow-alias
-        // CD:34:1C:31:91:0F:63:D7:1A:3C:FA:6D:A4:95:81:11:E8:3A:BA:CA:64:14:79:3D:DB:86:A0:F9:0D:26:42:41
-        private val UPLOAD_KEY_FINGERPRINT = intArrayOf(
-            0xCD, 0x34, 0x1C, 0x31, 0x91, 0x0F, 0x63, 0xD7,
-            0x1A, 0x3C, 0xFA, 0x6D, 0xA4, 0x95, 0x81, 0x11,
-            0xE8, 0x3A, 0xBA, 0xCA, 0x64, 0x14, 0x79, 0x3D,
-            0xDB, 0x86, 0xA0, 0xF9, 0x0D, 0x26, 0x42, 0x41,
-        ).map { it.toByte() }.toByteArray()
+        // SHA-256 fingerprints of Rainbow's known signing certificates.
+        // Extracted with: keytool -list -v -keystore <keystore> -alias <alias>
+        // Any match = internal build. No match = store install (safe default).
+        private val KNOWN_INTERNAL_FINGERPRINTS = listOf(
+            // Upload key (rainbow-key.keystore, alias rainbow-alias)
+            // CD:34:1C:31:91:0F:63:D7:1A:3C:FA:6D:A4:95:81:11:E8:3A:BA:CA:64:14:79:3D:DB:86:A0:F9:0D:26:42:41
+            intArrayOf(
+                0xCD, 0x34, 0x1C, 0x31, 0x91, 0x0F, 0x63, 0xD7,
+                0x1A, 0x3C, 0xFA, 0x6D, 0xA4, 0x95, 0x81, 0x11,
+                0xE8, 0x3A, 0xBA, 0xCA, 0x64, 0x14, 0x79, 0x3D,
+                0xDB, 0x86, 0xA0, 0xF9, 0x0D, 0x26, 0x42, 0x41,
+            ).map { it.toByte() }.toByteArray(),
+            // Debug key (debug.keystore, alias androiddebugkey) — shared across all engineers.
+            // FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C
+            intArrayOf(
+                0xFA, 0xC6, 0x17, 0x45, 0xDC, 0x09, 0x03, 0x78,
+                0x6F, 0xB9, 0xED, 0xE6, 0x2A, 0x96, 0x2B, 0x39,
+                0x9F, 0x73, 0x48, 0xF0, 0xBB, 0x6F, 0x89, 0x9B,
+                0x83, 0x32, 0x66, 0x75, 0x91, 0x03, 0x3B, 0x9C,
+            ).map { it.toByte() }.toByteArray(),
+        )
     }
 
     override fun getName(): String = NAME
@@ -64,7 +76,7 @@ class AppInstallInfoModule(reactContext: ReactApplicationContext) :
                 )
             val cert = packageInfo.signatures!![0].toByteArray()
             val fingerprint = MessageDigest.getInstance("SHA-256").digest(cert)
-            !fingerprint.contentEquals(UPLOAD_KEY_FINGERPRINT)
+            KNOWN_INTERNAL_FINGERPRINTS.none { fingerprint.contentEquals(it) }
         } catch (_: Exception) {
             // Unknown signing state - default to store install (safe: no dev tools exposed)
             true


### PR DESCRIPTION
The install source detection on Android (#7258) only recognizes the upload key (`rainbow-key.keystore`) as an internal build. QA builds are typically signed with the debug keystore (needed for Google Drive backup testing), so they get classified as store installs. This means QA telemetry (soon) would route to the production Sentry environment instead of internal.

This change recognizes both the upload key and the shared debug keystore (`android/keystores/debug.keystore`) as known internal signing certificates. Any unrecognized key (Google's app signing key, APKMirror sideloads) still defaults to store install as expected. The debug keystore fingerprint was verified against the one checked into the repo and used by QA/Ibrahim.

Ref FEPLAT-62.