### PR TITLE
chore(DappBrowser): remove unused ToolbarTextButton component

### DIFF
--- a/src/components/DappBrowser/ToolbarIcon.tsx
+++ b/src/components/DappBrowser/ToolbarIcon.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet } from 'react-native';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
-import { Bleed, Box, Text, TextIcon, useForegroundColor } from '@/design-system';
+import { TextIcon } from '@/design-system';
 import { type TextColor } from '@/design-system/color/palettes';
 import { type TextWeight } from '@/design-system/components/Text/Text';
 import { type TextSize } from '@/design-system/typography/typeHierarchy';
-import { useTheme } from '@/theme/ThemeContext';
-import { opacity } from '@/framework/ui/utils/opacity';
 
 export const ToolbarIcon = ({
   color,
@@ -40,53 +38,6 @@ export const ToolbarIcon = ({
         {icon}
       </TextIcon>
     </ButtonPressAnimation>
-  );
-};
-
-export const ToolbarTextButton = ({
-  color,
-  disabled,
-  label,
-  onPress,
-  showBackground,
-  textAlign,
-}: {
-  color?: TextColor;
-  disabled?: boolean;
-  label: string;
-  onPress: () => void;
-  showBackground?: boolean;
-  textAlign?: 'center' | 'left' | 'right';
-}) => {
-  const { colors } = useTheme();
-  const hexColor = useForegroundColor(color || 'blue');
-
-  return (
-    <TouchableOpacity
-      activeOpacity={0.4}
-      disabled={disabled}
-      hitSlop={{ bottom: 8, left: 0, right: 0, top: 8 }}
-      onPress={onPress}
-      style={{ opacity: disabled ? 0.5 : 1 }}
-    >
-      <Bleed vertical={showBackground ? '4px' : undefined}>
-        <Box
-          alignItems="center"
-          borderRadius={showBackground ? 14 : undefined}
-          height={{ custom: showBackground ? 28 : 20 }}
-          justifyContent="center"
-          paddingHorizontal={showBackground ? '8px' : undefined}
-          style={{
-            backgroundColor: showBackground ? opacity(hexColor, 0.1) : undefined,
-            flex: 1,
-          }}
-        >
-          <Text align={textAlign || 'center'} color={disabled ? 'labelQuaternary' : color || 'blue'} size="17pt" weight="bold">
-            {label}
-          </Text>
-        </Box>
-      </Bleed>
-    </TouchableOpacity>
   );
 };
 


### PR DESCRIPTION
`ToolbarTextButton` has been dead since #5566 (Mar 2024) when the browser toolbar was rewritten. The component was copied from the deleted `BrowserToolbar.tsx` into `ToolbarIcon.tsx` but never imported in the new implementation. This change removes it and cleans up the imports it was the sole consumer of.

Ref FEPLAT-34.