### PR TITLE
chore(assets): remove dead code from pre-userAssetsStore era

### DIFF
--- a/src/resources/assets/anvilAssets.ts
+++ b/src/resources/assets/anvilAssets.ts
@@ -1,17 +1,14 @@
 import { Contract } from '@ethersproject/contracts';
-import { keyBy, mapValues } from 'lodash';
 import { getProvider } from '@/handlers/web3';
 import balanceCheckerContractAbi from '@/references/balances-checker-abi.json';
-import chainAssets from '@/references/chain-assets.json';
+import type chainAssets from '@/references/chain-assets.json';
 import erc20ABI from '@/references/erc20-abi.json';
 import { ETH_ADDRESS } from '@/references/constants';
-import { parseAddressAsset } from './assets';
-import { type RainbowAddressAssets } from './types';
 import { logger, RainbowError } from '@/logger';
 import { type AddressOrEth, type UniqueId, type ZerionAsset } from '@/__swaps__/types/assets';
 import { AddressZero } from '@ethersproject/constants';
 import chainAssetsByChainId from '@/references/testnet-assets-by-chain';
-import { ChainId, ChainName, type Network } from '@/state/backendNetworks/types';
+import { ChainId, ChainName } from '@/state/backendNetworks/types';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 
@@ -67,39 +64,6 @@ const fetchAnvilBalancesWithBalanceChecker = async (
     logger.error(new RainbowError(`[anvilAssets]: Error fetching balances from Anvil node: ${e}`));
     return null;
   }
-};
-
-/**
- * @deprecated - to be removed once rest of the app is converted to new userAssetsStore
- * Fetches the balances of the anvil assets for the given account address and network.
- * @param accountAddress - The address of the account to fetch the balances for.
- * @param network - The network to fetch the balances for.
- * @returns The balances of the anvil assets for the given account address and network.
- */
-export const fetchAnvilBalances = async (accountAddress: string, chainId: ChainId = ChainId.mainnet): Promise<RainbowAddressAssets> => {
-  const chainAssetsMap = keyBy(
-    chainAssets[`${chainId}` as keyof typeof chainAssets],
-    ({ asset }) => `${asset.asset_code}_${asset.chainId}`
-  );
-
-  const tokenAddresses = Object.values(chainAssetsMap).map(({ asset: { asset_code } }) =>
-    asset_code === ETH_ADDRESS ? AddressZero : asset_code.toLowerCase()
-  );
-  const balances = await fetchAnvilBalancesWithBalanceChecker(tokenAddresses, accountAddress, chainId);
-  if (!balances) return {};
-
-  const updatedAssets = mapValues(chainAssetsMap, chainAsset => {
-    const assetCode = chainAsset.asset.asset_code.toLowerCase();
-    const updatedAsset = {
-      asset: {
-        ...chainAsset.asset,
-        network: chainAsset.asset.network as Network,
-      },
-      quantity: balances[assetCode],
-    };
-    return parseAddressAsset({ assetData: updatedAsset });
-  });
-  return updatedAssets;
 };
 
 export const fetchAnvilBalancesByChainId = async (

--- a/src/resources/assets/assets.ts
+++ b/src/resources/assets/assets.ts
@@ -2,7 +2,7 @@ import * as i18n from '@/languages';
 import { isNativeAsset } from '@/handlers/assets';
 import { convertRawAmountToBalance } from '@/helpers/utilities';
 import type { ParsedAddressAsset } from '@/entities/tokens';
-import { type AddysAddressAsset, type AddysAsset, type ParsedAsset } from './types';
+import { type AddysAsset, type ParsedAsset } from './types';
 import { getUniqueId } from '@/utils/ethereumUtils';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { ChainId } from '@/state/backendNetworks/types';
@@ -85,22 +85,6 @@ export function parseGoldskyAsset({ address, asset }: { address: string; asset: 
   };
 
   return parsedAsset;
-}
-
-// We are still using the Addys version for claimable
-export function parseAddressAsset({ assetData }: { assetData: AddysAddressAsset }): ParsedAddressAsset {
-  const asset = assetData?.asset;
-  const quantity = assetData?.quantity;
-  const address = assetData?.asset?.asset_code;
-
-  const parsedAsset = parseAsset({
-    address,
-    asset,
-  });
-  return {
-    ...parsedAsset,
-    balance: convertRawAmountToBalance(quantity, asset),
-  };
 }
 
 export function parseGoldskyAddressAsset({ assetData }: { assetData: { asset: Asset; quantity: string } }): ParsedAddressAsset {

--- a/src/resources/assets/types.ts
+++ b/src/resources/assets/types.ts
@@ -1,5 +1,4 @@
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import type { ParsedAddressAsset } from '@/entities/tokens';
 import { type TokenColors } from '@/graphql/__generated__/metadata';
 import { type Network } from '@/state/backendNetworks/types';
 
@@ -81,5 +80,3 @@ export interface ParsedAsset {
     animatedMimeType?: string | null | undefined;
   };
 }
-
-export type RainbowAddressAssets = Record<string, ParsedAddressAsset>;


### PR DESCRIPTION
Several symbols in our asset parsing layer have been dead since the `userAssetsStore` migration in #6450 (Feb 2025). `fetchAnvilBalances` was marked `@deprecated` from the moment it was created during the Hardhat-to-Anvil rename (Dec 2023), inheriting the annotation from its predecessor `fetchHardhatBalances`. Neither variant ever had a caller after the old Redux dispatch flow was replaced. `parseAddressAsset` and the `RainbowAddressAssets` type alias were only consumed by that function, so they went dead at the same time.

This change removes all three along with their transitively orphaned imports. The live sibling `fetchAnvilBalancesByChainId` and the rest of the parsing layer are unaffected.

Ref FEPLAT-34.