### PR TITLE
feature: staking amount selection screen

### DIFF
--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -2,14 +2,14 @@ import { parseAbi, type Address } from 'viem';
 import { ChainId } from '@/state/backendNetworks/types';
 import { getUniqueId } from '@/utils/ethereumUtils';
 
-// TODO: test token address, use prod address later '0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0'
-export const RNBW_TOKEN_ADDRESS: Address = '0xb61832AD7859e64d8525E51d13De94d693475e6b';
+export const RNBW_TOKEN_ADDRESS: Address = '0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0';
 export const RNBW_CHAIN_ID = ChainId.base;
+export const RNBW_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 export const RNBW_DECIMALS = 18;
 export const RNBW_TOKEN_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 
 export const STAKING_CHAIN_ID = ChainId.base;
-export const STAKING_CONTRACT_ADDRESS: Address = '0x616EB863bd79145c20B44A9A070A3651662D1EBD';
+export const STAKING_CONTRACT_ADDRESS: Address = '0x288ea8Bcb51d53aD361D786EFa904C401904aF70';
 export const STAKING_ABI = parseAbi([
   'function stake(uint256 amount)',
   'function unstakeAll()',
@@ -17,3 +17,5 @@ export const STAKING_ABI = parseAbi([
 ]);
 export const STAKING_GAS_LIMIT = 200_000;
 export const UNSTAKE_PENALTY_PERCENTAGE = 10;
+
+export const MIN_CLAIM_TO_STAKING_RAW = '1000000000000000000'; // 1 RNBW (10^18)

--- a/src/features/rnbw-staking/depositConfig.ts
+++ b/src/features/rnbw-staking/depositConfig.ts
@@ -1,0 +1,77 @@
+import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
+import { createDepositConfig } from '@/systems/funding/config';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { time } from '@/utils/time';
+import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, RNBW_TOKEN_UNIQUE_ID, STAKING_CHAIN_ID } from './constants';
+import { estimateStakeGasLimit } from './utils/estimateStakeGasLimit';
+import { refreshStakingData } from './utils/refreshStakingData';
+import { stakeRnbw } from './utils/stakeRnbw';
+import { canUseSponsoredRnbwStaking } from './utils/canUseSponsoredRnbwStaking';
+import { buildSyntheticRnbwSourceAsset, getInitialSyntheticRnbwSourceUnitPrice } from './utils/syntheticRnbwSourceAsset';
+
+export const RNBW_STAKING_DEPOSIT_CONFIG = createDepositConfig({
+  id: 'rnbwStakingDeposit',
+  directTransferEnabled: true,
+  initialSliderProgress: 100,
+  hideReceiveAmount: true,
+
+  source: {
+    mode: 'fixed',
+    resolveAsset: () => {
+      const rewardsData = useRewardsBalanceStore.getState().getData();
+
+      return buildSyntheticRnbwSourceAsset({
+        claimableRnbwRaw: rewardsData?.claimableRnbw ?? '0',
+        hasPendingClaim: rewardsData?.hasPendingClaim ?? false,
+        unitPrice: getInitialSyntheticRnbwSourceUnitPrice(),
+        walletAsset: useUserAssetsStore.getState().getUserAsset(RNBW_TOKEN_UNIQUE_ID),
+      });
+    },
+  },
+
+  to: {
+    chainId: STAKING_CHAIN_ID,
+    token: {
+      address: RNBW_TOKEN_ADDRESS,
+      decimals: RNBW_DECIMALS,
+      symbol: 'RNBW',
+    },
+  },
+
+  execute: async ({ accountAddress, amount }) => {
+    await stakeRnbw({ address: accountAddress, amount });
+    return {
+      confirmationChainId: STAKING_CHAIN_ID,
+      executionStrategy: 'custom',
+      isConfirmed: true,
+      success: true,
+    };
+  },
+
+  gas: {
+    estimateGasLimit: estimateStakeGasLimit,
+    isSponsored: ({ accountAddress }) => canUseSponsoredRnbwStaking(accountAddress, STAKING_CHAIN_ID),
+  },
+
+  labels: {
+    confirmButton: 'Hold to Stake',
+    confirmButtonError: 'Unable to stake',
+    confirmButtonLoading: 'Staking...',
+    confirmButtonOverBalance: 'Insufficient RNBW',
+    confirmButtonZeroAmount: 'Enter amount',
+    executionErrorTitle: 'Error Staking',
+    insufficientGas: 'Insufficient gas',
+    quoteError: 'Unable to prepare stake',
+    receive: 'Rewards will be automatically claimed',
+    title: 'Stake $RNBW',
+  },
+
+  validation: {
+    minAmount: { label: 'Minimum 1 RNBW', value: '1' },
+  },
+
+  refresh: {
+    delays: [0, time.seconds(3), time.seconds(8)],
+    handler: refreshStakingData,
+  },
+});

--- a/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
@@ -1,97 +1,16 @@
-import { memo, useCallback, useState } from 'react';
-import { Alert, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
-import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
-import { Box, Stack, Text } from '@/design-system';
-import { useIsReadOnlyWallet, useIsHardwareWallet, useAccountAddress } from '@/state/wallets/walletsStore';
-import { useNavigation } from '@/navigation/Navigation';
-import Routes from '@/navigation/routesNames';
-import watchingAlert from '@/utils/watchingAlert';
-import { logger, RainbowError } from '@/logger';
-import { sumWorklet } from '@/framework/core/safeMath';
-import { stakeRnbw } from '@/features/rnbw-staking/utils/stakeRnbw';
-import { useStakableRnbwBalance } from '@/state/rnbw/useStakableRnbwBalance';
+import React, { memo } from 'react';
+import { RNBW_STAKING_DEPOSIT_CONFIG } from '@/features/rnbw-staking/depositConfig';
+import { DepositScreen } from '@/systems/funding/components/DepositScreen';
 
 export const RnbwStakingScreen = memo(function RnbwStakingScreen() {
-  const { top: safeAreaTop } = useSafeAreaInsets();
-  const { goBack, navigate } = useNavigation();
-  const accountAddress = useAccountAddress();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
-  const isHardwareWallet = useIsHardwareWallet();
-  const [isProcessing, setIsProcessing] = useState(false);
-
-  const startStake = useCallback(async () => {
-    setIsProcessing(true);
-    try {
-      const claimableBalance = useStakableRnbwBalance.getState().claimableBalance;
-      // TODO: Fixed amount of RNBW to stake
-      const stakeAmount = sumWorklet('1', claimableBalance);
-      await stakeRnbw({ address: accountAddress, amount: stakeAmount });
-      goBack();
-    } catch (e) {
-      setIsProcessing(false);
-      Alert.alert('Staking Failed', 'Something went wrong while staking. Please try again.');
-      console.log('e', e);
-      logger.error(new RainbowError('[RnbwStakingScreen]: Staking failed', e));
-    }
-  }, [accountAddress, goBack]);
-
-  const handleStake = useCallback(async () => {
-    if (isReadOnlyWallet) {
-      watchingAlert();
-      return;
-    }
-    if (isHardwareWallet) {
-      navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: startStake });
-    } else {
-      await startStake();
-    }
-  }, [isReadOnlyWallet, isHardwareWallet, navigate, startStake]);
-
   return (
-    <Box background="surfacePrimary" style={styles.container}>
-      <SheetHandleFixedToTop top={safeAreaTop + 6} />
-      <View style={[styles.content, { marginTop: safeAreaTop + 40 }]}>
-        <Stack space="24px">
-          <Text color="label" size="30pt" weight="heavy">
-            {'Stake RNBW'}
-          </Text>
-          <Text color="labelSecondary" size="17pt" weight="medium">
-            {'Stake 1 RNBW to enable membership rewards.'}
-          </Text>
-        </Stack>
-        <View style={styles.buttonContainer}>
-          <HoldToActivateButton
-            label="Hold to Stake"
-            processingLabel="Staking..."
-            onLongPress={handleStake}
-            isProcessing={isProcessing}
-            backgroundColor="white"
-            disabledBackgroundColor="white"
-            progressColor="black"
-            showBiometryIcon
-            style={styles.button}
-          />
-        </View>
-      </View>
-    </Box>
+    <DepositScreen
+      config={RNBW_STAKING_DEPOSIT_CONFIG}
+      theme={{
+        accent: '#E3A700',
+        backgroundDark: '#090909',
+        backgroundLight: '#FFFFFF',
+      }}
+    />
   );
-});
-
-const styles = StyleSheet.create({
-  button: {
-    width: '100%',
-  },
-  buttonContainer: {
-    marginTop: 'auto',
-    paddingBottom: 36,
-  },
-  container: {
-    flex: 1,
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
 });

--- a/src/features/rnbw-staking/utils/canUseSponsoredRnbwStaking.ts
+++ b/src/features/rnbw-staking/utils/canUseSponsoredRnbwStaking.ts
@@ -1,0 +1,15 @@
+import { isRainbowDelegatedForChain } from '@/features/delegation/utils/isRainbowDelegatedForChain';
+import { EthereumWalletType } from '@/helpers/walletTypes';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { getWalletWithAccount } from '@/state/wallets/walletsStore';
+import { type Address } from 'viem';
+
+export async function canUseSponsoredRnbwStaking(address: Address, chainId: ChainId): Promise<boolean> {
+  const wallet = getWalletWithAccount(address);
+
+  if (wallet?.type === EthereumWalletType.bluetooth) {
+    return false;
+  }
+
+  return isRainbowDelegatedForChain(address, chainId);
+}

--- a/src/features/rnbw-staking/utils/estimateStakeGasLimit.ts
+++ b/src/features/rnbw-staking/utils/estimateStakeGasLimit.ts
@@ -1,0 +1,46 @@
+import { erc20Abi, encodeFunctionData, parseUnits, type Address } from 'viem';
+import { getProvider } from '@/handlers/web3';
+import { gasUnits } from '@/references/gasUnits';
+import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { checkIfStakingNeedsApproval } from './checkIfStakingNeedsApproval';
+
+const FALLBACK_STAKE_GAS_LIMIT = 200_000n;
+const FALLBACK_APPROVAL_GAS_LIMIT = BigInt(gasUnits.basic_approval);
+
+export async function estimateStakeGasLimit({ accountAddress, amount }: { accountAddress: Address; amount: string }): Promise<string> {
+  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+  const stakeAmount = parseUnits(amount, RNBW_DECIMALS);
+  const needsApproval = await checkIfStakingNeedsApproval({
+    address: accountAddress,
+    provider,
+    stakeAmountRaw: stakeAmount.toString(),
+  });
+
+  let totalGasLimit = FALLBACK_STAKE_GAS_LIMIT;
+  const stakeData = encodeFunctionData({ abi: STAKING_ABI, functionName: 'stake', args: [stakeAmount] });
+  try {
+    const estimatedStakeGasLimit = await provider.estimateGas({ data: stakeData, from: accountAddress, to: STAKING_CONTRACT_ADDRESS });
+    totalGasLimit = estimatedStakeGasLimit.toBigInt();
+  } catch {
+    totalGasLimit = FALLBACK_STAKE_GAS_LIMIT;
+  }
+
+  if (!needsApproval) return totalGasLimit.toString();
+
+  const approveData = encodeFunctionData({
+    abi: erc20Abi,
+    args: [STAKING_CONTRACT_ADDRESS, stakeAmount],
+    functionName: 'approve',
+  });
+
+  try {
+    const estimatedApproveGasLimit = await provider.estimateGas({
+      data: approveData,
+      from: accountAddress,
+      to: RNBW_TOKEN_ADDRESS,
+    });
+    return (totalGasLimit + estimatedApproveGasLimit.toBigInt()).toString();
+  } catch {
+    return (totalGasLimit + FALLBACK_APPROVAL_GAS_LIMIT).toString();
+  }
+}

--- a/src/features/rnbw-staking/utils/refreshStakingData.ts
+++ b/src/features/rnbw-staking/utils/refreshStakingData.ts
@@ -1,0 +1,9 @@
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+
+export async function refreshStakingData() {
+  await Promise.allSettled([
+    useStakingPositionStore.getState().fetch(undefined, { force: true }),
+    useUserAssetsStore.getState().fetch(undefined, { force: true }),
+  ]);
+}

--- a/src/features/rnbw-staking/utils/stakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbw.ts
@@ -3,7 +3,7 @@ import { stakeRnbwManual } from './stakeRnbwManual';
 import { stakeRnbwSponsored } from './stakeRnbwSponsored';
 import { getProvider } from '@/handlers/web3';
 import { loadWallet } from '@/model/wallet';
-import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, STAKING_CHAIN_ID } from '../constants';
+import { MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, STAKING_CHAIN_ID } from '../constants';
 import { useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
 import { RainbowError } from '@/logger';
@@ -11,10 +11,10 @@ import type { Signer } from '@ethersproject/abstract-signer';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { prepareRewardsClaim, submitRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
-import { isRainbowDelegatedForChain } from '@/features/delegation/utils/isRainbowDelegatedForChain';
 import { Alert } from 'react-native';
 import { equalWorklet, greaterThanOrEqualToWorklet, isPositive, subWorklet } from '@/framework/core/safeMath';
 import type { ClaimToDestination } from '@/features/rnbw-rewards/utils/claimRewards';
+import { canUseSponsoredRnbwStaking } from './canUseSponsoredRnbwStaking';
 
 export async function stakeRnbw({ address, amount }: { address: Address; amount: string }) {
   const provider = getProvider({ chainId: STAKING_CHAIN_ID });
@@ -44,7 +44,7 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
     }
   }
 
-  const isRainbowDelegated = await isRainbowDelegatedForChain(address, STAKING_CHAIN_ID);
+  const canUseSponsoredStaking = await canUseSponsoredRnbwStaking(address, STAKING_CHAIN_ID);
   const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
 
   await claimRnbwRewards({ address, signer, claimToDestination });
@@ -61,12 +61,12 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
   await useStakingPositionStore.getState().fetch(undefined, { force: true });
   const postClaimShares = useStakingPositionStore.getState().getData()?.poolShares ?? originalStakedRnbwShares;
 
-  isRainbowDelegated
+  canUseSponsoredStaking
     ? await stakeRnbwSponsored({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer })
     : await stakeRnbwManual({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer });
 
   await pollForStakingUpdate(postClaimShares);
-  Alert.alert(`Staked: ${amount} RNBW (${isRainbowDelegated ? 'Sponsored' : 'Manual'})`);
+  Alert.alert(`Staked: ${amount} RNBW (${canUseSponsoredStaking ? 'Sponsored' : 'Manual'})`);
 }
 
 async function claimRnbwRewards({
@@ -96,7 +96,10 @@ async function resolveClaimStrategy(stakeAmountRaw: string): Promise<{
   await useRewardsBalanceStore.getState().fetch(undefined, { force: true });
   const claimableRnbw = useRewardsBalanceStore.getState().getData()?.claimableRnbw ?? '0';
   const hasClaimable = useRewardsBalanceStore.getState().hasClaimableRewards();
-  const claimToStaking = hasClaimable && greaterThanOrEqualToWorklet(stakeAmountRaw, claimableRnbw);
+  const claimToStaking =
+    hasClaimable &&
+    greaterThanOrEqualToWorklet(stakeAmountRaw, claimableRnbw) &&
+    greaterThanOrEqualToWorklet(claimableRnbw, MIN_CLAIM_TO_STAKING_RAW);
   const requiredWalletBalanceRaw = claimToStaking ? subWorklet(stakeAmountRaw, claimableRnbw) : stakeAmountRaw;
 
   return {

--- a/src/features/rnbw-staking/utils/syntheticRnbwSourceAsset.ts
+++ b/src/features/rnbw-staking/utils/syntheticRnbwSourceAsset.ts
@@ -1,0 +1,169 @@
+import { formatUnits, parseUnits } from 'viem';
+import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
+import { RNBW_CHAIN_ID, RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
+import { convertAmountToBalanceDisplay, convertAmountToNativeDisplayWorklet } from '@/helpers/utilities';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { type ExtendedAnimatedAssetWithColors, type ParsedSearchAsset } from '@/__swaps__/types/assets';
+import { parseAssetAndExtend } from '@/__swaps__/utils/swaps';
+
+type SyntheticRnbwSourceStaticConfig = Pick<
+  ParsedSearchAsset,
+  | 'address'
+  | 'chainId'
+  | 'decimals'
+  | 'highLiquidity'
+  | 'isNativeAsset'
+  | 'isRainbowCurated'
+  | 'isVerified'
+  | 'mainnetAddress'
+  | 'name'
+  | 'symbol'
+  | 'uniqueId'
+> & {
+  bridging: NonNullable<ParsedSearchAsset['bridging']>;
+  networks: ParsedSearchAsset['networks'];
+};
+
+const RNBW_SYNTHETIC_SOURCE_BRIDGING: NonNullable<ParsedSearchAsset['bridging']> = {
+  isBridgeable: false,
+  networks: {},
+};
+
+const RNBW_SYNTHETIC_SOURCE_NETWORKS: ParsedSearchAsset['networks'] = {
+  [RNBW_CHAIN_ID]: {
+    address: RNBW_TOKEN_ADDRESS,
+    decimals: RNBW_DECIMALS,
+  },
+};
+
+const RNBW_SYNTHETIC_SOURCE_COLORS: NonNullable<ParsedSearchAsset['colors']> = {
+  fallback: '#F2C745',
+  primary: '#F2C745',
+};
+
+export const RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG: SyntheticRnbwSourceStaticConfig = {
+  address: RNBW_TOKEN_ADDRESS,
+  bridging: RNBW_SYNTHETIC_SOURCE_BRIDGING,
+  chainId: RNBW_CHAIN_ID,
+  decimals: RNBW_DECIMALS,
+  highLiquidity: false,
+  isNativeAsset: false,
+  isRainbowCurated: true,
+  isVerified: true,
+  mainnetAddress: RNBW_TOKEN_ADDRESS,
+  name: 'Rainbow',
+  networks: RNBW_SYNTHETIC_SOURCE_NETWORKS,
+  symbol: 'RNBW',
+  uniqueId: RNBW_TOKEN_UNIQUE_ID,
+};
+
+type BuildSyntheticRnbwSourceAssetParams = {
+  claimableRnbwRaw: string;
+  hasPendingClaim: boolean;
+  unitPrice: number;
+  walletAsset: ParsedSearchAsset | null;
+};
+
+export function buildSyntheticRnbwSourceAsset({
+  claimableRnbwRaw,
+  hasPendingClaim,
+  unitPrice,
+  walletAsset,
+}: BuildSyntheticRnbwSourceAssetParams): ExtendedAnimatedAssetWithColors | null {
+  const currency = userAssetsStoreManager.getState().currency;
+  const chainName = walletAsset?.chainName ?? useBackendNetworksStore.getState().getChainsName()[RNBW_CHAIN_ID] ?? String(RNBW_CHAIN_ID);
+  const symbol = walletAsset?.symbol ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.symbol;
+  const name = walletAsset?.name ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.name;
+
+  const availableBalanceAmount = getAvailableBalanceAmount({
+    claimableRnbwRaw,
+    hasPendingClaim,
+    walletBalanceAmount: walletAsset?.balance.amount ?? '0',
+  });
+  const nativeBalanceAmount = String(Number(availableBalanceAmount) * unitPrice);
+
+  const syntheticAsset: ParsedSearchAsset = {
+    ...RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG,
+    balance: {
+      amount: availableBalanceAmount,
+      display: convertAmountToBalanceDisplay(availableBalanceAmount, { decimals: RNBW_DECIMALS, symbol }),
+    },
+    chainName,
+    colors: walletAsset?.colors ?? RNBW_SYNTHETIC_SOURCE_COLORS,
+    highLiquidity: walletAsset?.highLiquidity ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.highLiquidity,
+    icon_url: walletAsset?.icon_url,
+    isRainbowCurated: walletAsset?.isRainbowCurated ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.isRainbowCurated,
+    isVerified: walletAsset?.isVerified ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.isVerified,
+    mainnetAddress: walletAsset?.mainnetAddress ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.mainnetAddress,
+    name,
+    native: {
+      balance: {
+        amount: nativeBalanceAmount,
+        display: convertAmountToNativeDisplayWorklet(nativeBalanceAmount, currency, true),
+      },
+      price: {
+        amount: unitPrice,
+        change: '0',
+        display: convertAmountToNativeDisplayWorklet(unitPrice, currency),
+      },
+    },
+    networks: walletAsset?.networks ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.networks,
+    price: { value: unitPrice },
+    symbol,
+    type: walletAsset?.type,
+    bridging: walletAsset?.bridging ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.bridging,
+  };
+
+  return parseAssetAndExtend({ asset: syntheticAsset });
+}
+
+export function getInitialSyntheticRnbwSourceUnitPrice(): number {
+  const rewardsData = useRewardsBalanceStore.getState().getData();
+  const claimableUnitPrice = getClaimableRnbwUnitPrice(rewardsData);
+  if (claimableUnitPrice > 0) return claimableUnitPrice;
+
+  const walletAsset = useUserAssetsStore.getState().getUserAsset(RNBW_TOKEN_UNIQUE_ID);
+  return walletAsset?.price?.value ?? walletAsset?.native.price?.amount ?? 0;
+}
+
+function getClaimableRnbwUnitPrice(
+  rewardsData: {
+    claimableRnbw: string;
+    claimableValueInCurrency: string;
+    hasPendingClaim: boolean;
+  } | null
+): number {
+  if (!rewardsData || rewardsData.hasPendingClaim) return 0;
+
+  const claimableAmount = Number(formatUnits(toRawAmount(rewardsData.claimableRnbw, true), RNBW_DECIMALS));
+  const claimableValue = Number(rewardsData.claimableValueInCurrency);
+  if (claimableAmount > 0 && claimableValue > 0) {
+    return claimableValue / claimableAmount;
+  }
+
+  return 0;
+}
+
+function getAvailableBalanceAmount({
+  claimableRnbwRaw,
+  hasPendingClaim,
+  walletBalanceAmount,
+}: {
+  claimableRnbwRaw: string;
+  hasPendingClaim: boolean;
+  walletBalanceAmount: string;
+}): string {
+  const walletBalanceRaw = toRawAmount(walletBalanceAmount);
+  const claimableRnbw = hasPendingClaim ? 0n : toRawAmount(claimableRnbwRaw, true);
+  return formatUnits(walletBalanceRaw + claimableRnbw, RNBW_DECIMALS);
+}
+
+function toRawAmount(value: string, isRaw = false): bigint {
+  try {
+    return isRaw ? BigInt(value) : parseUnits(value, RNBW_DECIMALS);
+  } catch {
+    return 0n;
+  }
+}

--- a/src/systems/funding/components/DepositScreen.tsx
+++ b/src/systems/funding/components/DepositScreen.tsx
@@ -23,17 +23,18 @@ import { SLIDER_MAX, type SliderColors } from '@/features/perps/components/Slide
 import { PerpsAccentColorContextProvider } from '@/features/perps/context/PerpsAccentColorContext';
 import { useStableValue } from '@/hooks/useStableValue';
 import * as i18n from '@/languages';
-import { divWorklet, equalWorklet, greaterThanWorklet, mulWorklet } from '@/framework/core/safeMath';
-import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { divWorklet, equalWorklet, greaterThanWorklet, lessThanWorklet, mulWorklet } from '@/framework/core/safeMath';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { type ParsedSearchAsset } from '@/__swaps__/types/assets';
 import { GasSpeed } from '@/__swaps__/types/gas';
 import { clamp, getColorValueForThemeWorklet, parseAssetAndExtend } from '@/__swaps__/utils/swaps';
 import { sanitizeAmount } from '@/worklets/strings';
-import { FOOTER_HEIGHT, INITIAL_SLIDER_PROGRESS, NavigationSteps, SLIDER_WIDTH, SLIDER_WITH_LABELS_HEIGHT } from '../constants';
+import { createDepositConfig } from '../config';
+import { FOOTER_HEIGHT, NavigationSteps, SLIDER_WIDTH, SLIDER_WITH_LABELS_HEIGHT } from '../constants';
 import { DepositProvider, useDepositContext } from '../contexts/DepositContext';
 import { computeMaxSwappableAmount } from '../stores/createDepositStore';
-import { type DepositConfig, DepositQuoteStatus, type FundingScreenTheme, getAccentColor } from '../types';
+import { type DepositConfigInput, DepositQuoteStatus, type FundingScreenTheme, getAccentColor } from '../types';
+import { resolveInitialDepositAsset } from '../utils/sourceAsset';
 import { amountFromSliderProgress } from '../utils/sliderWorklets';
 import { DepositAmountInput } from './deposit/DepositAmountInput';
 import { DepositFooter } from './deposit/DepositFooter';
@@ -43,20 +44,18 @@ import { DepositTokenList } from './deposit/DepositTokenList';
 // ============ Types ========================================================== //
 
 type DepositScreenProps = {
-  config: DepositConfig;
+  config: DepositConfigInput;
   theme: FundingScreenTheme;
 };
 
 // ============ Main Screen ==================================================== //
 
 export const DepositScreen = memo(function DepositScreen({ config, theme }: DepositScreenProps) {
-  const initialAsset = useStableValue(() => {
-    const highestValueNativeAsset = useUserAssetsStore.getState().getHighestValueNativeAsset();
-    return highestValueNativeAsset ? parseAssetAndExtend({ asset: highestValueNativeAsset }) : null;
-  });
+  const resolvedConfig = useMemo(() => createDepositConfig(config), [config]);
+  const resolvedInitialAsset = useStableValue(() => resolveInitialDepositAsset(resolvedConfig));
 
   return (
-    <DepositProvider config={config} initialAsset={initialAsset} initialGasSpeed={GasSpeed.FAST} theme={theme}>
+    <DepositProvider config={resolvedConfig} initialAsset={resolvedInitialAsset} initialGasSpeed={GasSpeed.FAST} theme={theme}>
       <DepositScreenContent />
     </DepositProvider>
   );
@@ -66,10 +65,12 @@ export const DepositScreen = memo(function DepositScreen({ config, theme }: Depo
 
 function getInputAmountError(
   amount: string,
-  balance: string
-): DepositQuoteStatus.InsufficientBalance | DepositQuoteStatus.ZeroAmountError | null {
+  balance: string,
+  minAmount: string | undefined
+): DepositQuoteStatus.BelowMinimum | DepositQuoteStatus.InsufficientBalance | DepositQuoteStatus.ZeroAmountError | null {
   'worklet';
   if (equalWorklet(amount, '0')) return DepositQuoteStatus.ZeroAmountError;
+  if (minAmount && lessThanWorklet(amount, minAmount)) return DepositQuoteStatus.BelowMinimum;
   if (greaterThanWorklet(amount, balance)) return DepositQuoteStatus.InsufficientBalance;
   return null;
 }
@@ -77,8 +78,18 @@ function getInputAmountError(
 // ============ Screen Content ================================================= //
 
 const DepositScreenContent = memo(function DepositScreenContent() {
-  const { displayedAmount, fields, gasStores, handleDeposit, handleNumberPadChange, inputMethod, isSubmitting, minifiedAsset, theme } =
-    useDepositContext();
+  const {
+    config,
+    displayedAmount,
+    fields,
+    gasStores,
+    handleDeposit,
+    handleNumberPadChange,
+    inputMethod,
+    isSubmitting,
+    minifiedAsset,
+    theme,
+  } = useDepositContext();
 
   const { isDarkMode } = useColorMode();
   const separatorSecondary = useForegroundColor('separatorSecondary');
@@ -113,9 +124,11 @@ const DepositScreenContent = memo(function DepositScreenContent() {
     [separatorSecondary]
   );
 
+  const minAmountValue = config.validation?.minAmount?.value;
+
   const inputAmountErrorShared = useDerivedValue(() => {
     const balance = maxSwappableAmount.value || '0';
-    return getInputAmountError(displayedAmount.value, balance);
+    return getInputAmountError(displayedAmount.value, balance, minAmountValue);
   });
 
   const focusedSearchNavbarStyle = useAnimatedStyle(() => {
@@ -142,7 +155,7 @@ const DepositScreenContent = memo(function DepositScreenContent() {
           <SheetHandle backgroundColor={isDarkMode ? theme.backgroundDark : theme.backgroundLight} withoutGradient />
         </Animated.View>
         <Box as={Animated.View} paddingVertical="8px" style={focusedSearchNavbarStyle}>
-          <Navbar hasStatusBarInset leftComponent={<AccountImage />} title={i18n.t(i18n.l.perps.deposit.title)} />
+          <Navbar hasStatusBarInset leftComponent={<AccountImage />} title={config.labels.title} />
         </Box>
 
         <Box alignItems="center">
@@ -204,6 +217,7 @@ const DepositSlider = ({ assetColor, sliderColors }: { assetColor: SharedValue<s
 
 const DepositInput = ({ inputProgress }: { inputProgress: SharedValue<number> }) => {
   const {
+    config,
     depositActions,
     displayedAmount,
     displayedNativeValue,
@@ -213,6 +227,7 @@ const DepositInput = ({ inputProgress }: { inputProgress: SharedValue<number> })
     setInputAmounts,
     useAmountStore,
   } = useDepositContext();
+  const isSourceSelectable = config.source.mode === 'selectable';
 
   const handleSelectAsset = useCallback(
     (assetParam: ParsedSearchAsset | null) => {
@@ -223,7 +238,7 @@ const DepositInput = ({ inputProgress }: { inputProgress: SharedValue<number> })
       const isBalanceZero = equalWorklet(currentMaxSwappable, '0');
       const previousAmount = useAmountStore.getState().amount;
       const estimatedSliderProgress =
-        Number(mulWorklet(divWorklet(previousAmount, currentMaxSwappable, '0'), SLIDER_MAX)) || INITIAL_SLIDER_PROGRESS;
+        Number(mulWorklet(divWorklet(previousAmount, currentMaxSwappable, '0'), SLIDER_MAX)) || config.initialSliderProgress;
       const newSliderProgress = isBalanceZero ? 0 : clamp(estimatedSliderProgress, 0, SLIDER_MAX);
 
       const assetDecimals = extendedAsset?.decimals ?? 18;
@@ -253,8 +268,26 @@ const DepositInput = ({ inputProgress }: { inputProgress: SharedValue<number> })
 
   const handleOpenTokenList = useCallback(() => {
     'worklet';
+    if (!isSourceSelectable) return;
     inputProgress.value = NavigationSteps.TOKEN_LIST_FOCUSED;
-  }, [inputProgress]);
+  }, [inputProgress, isSourceSelectable]);
+
+  const tokenListOverlay = useMemo(() => {
+    if (!isSourceSelectable) return null;
+
+    return (
+      <TokenListOverlay inputProgress={inputProgress}>
+        <DepositTokenList
+          inputProgress={inputProgress}
+          onSelectToken={token => {
+            inputProgress.value = NavigationSteps.INPUT_ELEMENT_FOCUSED;
+            handleSelectAsset(token);
+          }}
+        />
+        <DecoyScrollView />
+      </TokenListOverlay>
+    );
+  }, [handleSelectAsset, inputProgress, isSourceSelectable]);
 
   return (
     <DepositInputContainer progress={inputProgress}>
@@ -264,27 +297,14 @@ const DepositInput = ({ inputProgress }: { inputProgress: SharedValue<number> })
             displayedAmount={displayedAmount}
             displayedNativeValue={displayedNativeValue}
             inputMethod={inputMethod}
+            isSourceSelectable={isSourceSelectable}
             onChangeInputMethodWorklet={handleInputMethodChangeWorklet}
             onSelectAssetWorklet={handleOpenTokenList}
           />
         </Box>
       </DepositInputWrapper>
 
-      {useMemo(
-        () => (
-          <TokenListOverlay inputProgress={inputProgress}>
-            <DepositTokenList
-              inputProgress={inputProgress}
-              onSelectToken={token => {
-                inputProgress.value = NavigationSteps.INPUT_ELEMENT_FOCUSED;
-                handleSelectAsset(token);
-              }}
-            />
-            <DecoyScrollView />
-          </TokenListOverlay>
-        ),
-        [handleSelectAsset, inputProgress]
-      )}
+      {tokenListOverlay}
     </DepositInputContainer>
   );
 };

--- a/src/systems/funding/components/WithdrawalScreen.tsx
+++ b/src/systems/funding/components/WithdrawalScreen.tsx
@@ -95,6 +95,7 @@ const WithdrawalScreenContent = memo(function WithdrawalScreenContent() {
     amountActions,
     balanceStore: config.balanceStore,
     decimals: config.amountDecimals,
+    initialSliderProgress: config.initialSliderProgress,
   });
 
   const handleWithdrawal = useWithdrawalHandler({

--- a/src/systems/funding/components/deposit/DepositAmountInput.tsx
+++ b/src/systems/funding/components/deposit/DepositAmountInput.tsx
@@ -21,6 +21,7 @@ type DepositAmountInputProps = {
   displayedAmount: SharedValue<string>;
   displayedNativeValue: SharedValue<string>;
   inputMethod: SharedValue<'inputAmount' | 'inputNativeValue'>;
+  isSourceSelectable: boolean;
   onChangeInputMethodWorklet: () => void;
   onSelectAssetWorklet: () => void;
 };
@@ -29,6 +30,7 @@ type DepositAmountInputProps = {
 
 export const DepositAmountInput = memo(function DepositAmountInput({
   inputMethod,
+  isSourceSelectable,
   onChangeInputMethodWorklet,
   onSelectAssetWorklet,
 }: DepositAmountInputProps) {
@@ -80,7 +82,7 @@ export const DepositAmountInput = memo(function DepositAmountInput({
             <BalanceBadge label={balanceLabel} />
           </Stack>
         </Column>
-        {isAssetSelected && (
+        {isAssetSelected && isSourceSelectable && (
           <Column width="content">
             <SwapActionButton
               asset={minifiedAsset}
@@ -147,14 +149,31 @@ export const DepositAmountInput = memo(function DepositAmountInput({
         </GestureHandlerButton>
       </Box>
 
-      {isAssetSelected && <QuoteOutput targetTokenIconUrl={config.to.token.iconUrl} />}
+      {isAssetSelected && (
+        <QuoteOutput
+          hideAmount={config.hideReceiveAmount}
+          quoteErrorLabel={config.labels.quoteError}
+          receiveLabel={config.labels.receive}
+          targetTokenIconUrl={config.to.token.iconUrl}
+        />
+      )}
     </Box>
   );
 });
 
 // ============ Quote Output =================================================== //
 
-const QuoteOutput = memo(function QuoteOutput({ targetTokenIconUrl }: { targetTokenIconUrl?: string }) {
+const QuoteOutput = memo(function QuoteOutput({
+  hideAmount,
+  quoteErrorLabel,
+  receiveLabel,
+  targetTokenIconUrl,
+}: {
+  hideAmount: boolean;
+  quoteErrorLabel: string;
+  receiveLabel: string;
+  targetTokenIconUrl?: string;
+}) {
   const { useAmountToReceive } = useDepositContext();
   const { formattedAmount, status } = useAmountToReceive();
 
@@ -163,9 +182,9 @@ const QuoteOutput = memo(function QuoteOutput({ targetTokenIconUrl }: { targetTo
       <Separator color="separatorTertiary" thickness={1} />
 
       <Box alignItems="center" flexDirection="row" height={10} justifyContent="center">
-        {quoteHasError(status) ? (
+        {!hideAmount && quoteHasError(status) ? (
           <Text align="center" color={getErrorTextColor(status)} size="15pt" weight="bold">
-            {getErrorLabel(status)}
+            {getErrorLabel(status, quoteErrorLabel)}
           </Text>
         ) : (
           <>
@@ -180,16 +199,18 @@ const QuoteOutput = memo(function QuoteOutput({ targetTokenIconUrl }: { targetTo
               </Bleed>
             )}
             <Text color="labelQuaternary" size="15pt" weight="bold">
-              {i18n.t(i18n.l.perps.deposit.receive)}{' '}
+              {receiveLabel}
+              {hideAmount ? '' : ' '}
             </Text>
 
-            {status === DepositQuoteStatus.Pending ? (
-              <PerpsTextSkeleton height={15} width={90} />
-            ) : (
-              <Text color="labelTertiary" size="15pt" weight="bold">
-                {formattedAmount}
-              </Text>
-            )}
+            {!hideAmount &&
+              (status === DepositQuoteStatus.Pending ? (
+                <PerpsTextSkeleton height={15} width={90} />
+              ) : (
+                <Text color="labelTertiary" size="15pt" weight="bold">
+                  {formattedAmount}
+                </Text>
+              ))}
           </>
         )}
       </Box>
@@ -200,11 +221,12 @@ const QuoteOutput = memo(function QuoteOutput({ targetTokenIconUrl }: { targetTo
 // ============ Helpers ======================================================== //
 
 function getErrorLabel(
-  status: DepositQuoteStatus.Error | DepositQuoteStatus.InsufficientBalance | DepositQuoteStatus.ZeroAmountError
+  status: DepositQuoteStatus.Error | DepositQuoteStatus.InsufficientBalance | DepositQuoteStatus.ZeroAmountError,
+  quoteErrorLabel: string
 ): string {
   switch (status) {
     case DepositQuoteStatus.Error:
-      return i18n.t(i18n.l.perps.deposit.quote_error);
+      return quoteErrorLabel;
     case DepositQuoteStatus.InsufficientBalance:
       return i18n.t(i18n.l.perps.deposit.insufficient_balance);
     case DepositQuoteStatus.ZeroAmountError:

--- a/src/systems/funding/components/deposit/DepositFooter.tsx
+++ b/src/systems/funding/components/deposit/DepositFooter.tsx
@@ -3,7 +3,6 @@ import { type SharedValue, useDerivedValue } from 'react-native-reanimated';
 import { Box, Separator, useColorMode } from '@/design-system';
 import { PerpsSwapButton } from '@/features/perps/components/PerpsSwapButton';
 import { useStableValue } from '@/hooks/useStableValue';
-import * as i18n from '@/languages';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { type InferStoreState } from '@/state/internal/types';
@@ -14,7 +13,11 @@ import { GasButton } from './gas/GasButton';
 
 // ============ Types ========================================================== //
 
-type InputAmountError = DepositQuoteStatus.InsufficientBalance | DepositQuoteStatus.ZeroAmountError | null;
+type InputAmountError =
+  | DepositQuoteStatus.BelowMinimum
+  | DepositQuoteStatus.InsufficientBalance
+  | DepositQuoteStatus.ZeroAmountError
+  | null;
 
 type QuoteStatus =
   | DepositQuoteStatus.Error
@@ -22,17 +25,6 @@ type QuoteStatus =
   | DepositQuoteStatus.InsufficientGas
   | DepositQuoteStatus.Success
   | null;
-
-// ============ Translations =================================================== //
-
-const translations = {
-  confirm: i18n.t(i18n.l.perps.deposit.confirm_button_text),
-  error: i18n.t(i18n.l.perps.deposit.confirm_button_error_text),
-  insufficientGas: i18n.t(i18n.l.perps.deposit.insufficient_gas),
-  loading: i18n.t(i18n.l.perps.deposit.confirm_button_loading_text),
-  overBalance: i18n.t(i18n.l.perps.deposit.confirm_button_over_balance_text),
-  zeroAmount: i18n.t(i18n.l.perps.deposit.confirm_button_zero_text),
-};
 
 // ============ Footer ========================================================= //
 
@@ -57,14 +49,15 @@ export const DepositFooter = memo(function DepositFooter({ inputAmountError, isS
 // ============ Gas Button Wrapper ============================================= //
 
 const GasButtonWrapper = memo(function GasButtonWrapper() {
-  const { depositActions, gasStores, useQuoteStore } = useDepositContext();
+  const { config, depositActions, gasStores, useQuoteStore } = useDepositContext();
+  const useCustomExecute = Boolean(config.execute);
 
   const isLoading = useStoreSharedValue(
     useStableValue(() =>
       createDerivedStore(
         $ => {
           const isGasLimitLoading = $(gasStores.useGasLimitStore, state => !state.getData() && state.status === 'loading');
-          const isQuoteLoading = $(useQuoteStore, state => state.status === 'loading');
+          const isQuoteLoading = useCustomExecute ? false : $(useQuoteStore, state => state.status === 'loading');
           return isQuoteLoading || isGasLimitLoading;
         },
         { debounce: time.ms(100), fastMode: true }
@@ -90,26 +83,35 @@ type SubmitButtonProps = {
 
 const SubmitButton = memo(function SubmitButton({ inputAmountError, isSubmitting, onSubmit }: SubmitButtonProps) {
   const { isDarkMode } = useColorMode();
-  const { theme, useQuoteStore } = useDepositContext();
+  const { config, theme, useQuoteStore } = useDepositContext();
+  const useCustomExecute = Boolean(config.execute);
   const accentColor = getAccentColor(theme, isDarkMode);
 
   const quoteStatus = useStoreSharedValue(useQuoteStore, selectQuoteStatus);
 
+  const configLabels = config.labels;
+  const minAmountLabel = config.validation?.minAmount?.label;
+
   const label = useDerivedValue(() => {
     const inputError = inputAmountError.value;
     const status = quoteStatus.value;
+    const labels = configLabels;
 
-    if (inputError === DepositQuoteStatus.ZeroAmountError) return translations.zeroAmount;
-    if (inputError === DepositQuoteStatus.InsufficientBalance) return translations.overBalance;
-    if (status === DepositQuoteStatus.InsufficientGas) return translations.insufficientGas;
-    if (status === DepositQuoteStatus.Error || status === DepositQuoteStatus.InsufficientBalance) return translations.error;
-    if (isSubmitting.value) return translations.loading;
-    return translations.confirm;
+    if (inputError === DepositQuoteStatus.ZeroAmountError) return labels.confirmButtonZeroAmount;
+    if (inputError === DepositQuoteStatus.BelowMinimum) return minAmountLabel ?? labels.confirmButtonZeroAmount;
+    if (inputError === DepositQuoteStatus.InsufficientBalance) return labels.confirmButtonOverBalance;
+    if (status === DepositQuoteStatus.InsufficientGas) return labels.insufficientGas;
+    if (!useCustomExecute && (status === DepositQuoteStatus.Error || status === DepositQuoteStatus.InsufficientBalance)) {
+      return labels.confirmButtonError;
+    }
+    if (isSubmitting.value) return labels.confirmButtonLoading;
+    return labels.confirmButton;
   });
 
   const disabled = useDerivedValue(() => {
     if (isSubmitting.value) return true;
     if (inputAmountError.value !== null) return true;
+    if (useCustomExecute) return false;
 
     const status = quoteStatus.value;
     return status === null || status === DepositQuoteStatus.Error || status === DepositQuoteStatus.InsufficientGas;

--- a/src/systems/funding/components/deposit/gas/GasFeeText.tsx
+++ b/src/systems/funding/components/deposit/gas/GasFeeText.tsx
@@ -9,7 +9,7 @@ import {
   withTiming,
 } from 'react-native-reanimated';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
-import { AnimatedText, type TextProps, useForegroundColor } from '@/design-system';
+import { AnimatedText, Box, type TextProps, useForegroundColor } from '@/design-system';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { pulsingConfig, sliderConfig } from '@/__swaps__/screens/Swap/constants';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -23,13 +23,15 @@ export const GasFeeText = memo(function GasFeeText({
   tabularNumbers,
   weight,
 }: { isFetching: SharedValue<boolean> } & Pick<TextProps, 'align' | 'color' | 'size' | 'tabularNumbers' | 'weight'>) {
-  const { gasStores } = useDepositContext();
+  const { config, gasStores } = useDepositContext();
 
   const textColor = useForegroundColor(color);
   const labelTertiary = useForegroundColor('labelTertiary');
   const zeroAmountColor = opacity(labelTertiary, 0.3);
 
   const estimatedGasFee = useStoreSharedValue(gasStores.useEstimatedGasFee, estimate => estimate ?? '--');
+  const isGasSponsored = useStoreSharedValue(gasStores.useIsGasSponsored, state => state);
+  const shouldShowSponsored = useDerivedValue(() => isGasSponsored.value && estimatedGasFee.value !== '--');
 
   const animatedOpacity = useDerivedValue(() => {
     return isFetching.value
@@ -44,21 +46,32 @@ export const GasFeeText = memo(function GasFeeText({
     );
   });
 
-  const animatedTextOpacity = useAnimatedStyle(() => ({
+  const animatedTextStyle = useAnimatedStyle(() => ({
     color: animatedColor.value,
     opacity: animatedOpacity.value,
+    textDecorationLine: shouldShowSponsored.value ? 'line-through' : 'none',
+  }));
+
+  const sponsoredTextStyle = useAnimatedStyle(() => ({
+    display: shouldShowSponsored.value ? 'flex' : 'none',
+    opacity: withTiming(shouldShowSponsored.value ? 1 : 0, TIMING_CONFIGS.fadeConfig),
   }));
 
   return (
-    <AnimatedText
-      align={align}
-      color={color}
-      size={size}
-      style={[animatedTextOpacity, { letterSpacing: 0.3 }]}
-      tabularNumbers={tabularNumbers}
-      weight={weight}
-    >
-      {estimatedGasFee}
-    </AnimatedText>
+    <Box alignItems="center" flexDirection="row" gap={4}>
+      <AnimatedText
+        align={align}
+        color={color}
+        size={size}
+        style={[animatedTextStyle, { letterSpacing: 0.3 }]}
+        tabularNumbers={tabularNumbers}
+        weight={weight}
+      >
+        {estimatedGasFee}
+      </AnimatedText>
+      <AnimatedText align={align} color={'green'} size={size} style={sponsoredTextStyle} tabularNumbers={tabularNumbers} weight={weight}>
+        {config.labels.gasSponsored}
+      </AnimatedText>
+    </Box>
   );
 });

--- a/src/systems/funding/components/deposit/gas/GasMenu.tsx
+++ b/src/systems/funding/components/deposit/gas/GasMenu.tsx
@@ -18,6 +18,7 @@ const SWAP_GAS_ICONS = gasUtils.SWAP_GAS_ICONS;
 
 export function GasMenu({ children, onSelectGasSpeed }: { children: ReactNode; onSelectGasSpeed: (speed: GasSpeed) => void }) {
   const { gasStores } = useDepositContext();
+  const isGasSponsored = gasStores.useIsGasSponsored(state => state);
   const metereologySuggestions = gasStores.useMeteorologyStore(state => state.getGasSuggestions());
   const menuOptions = useMemo(() => keys(metereologySuggestions), [metereologySuggestions]);
 
@@ -58,11 +59,16 @@ export function GasMenu({ children, onSelectGasSpeed }: { children: ReactNode; o
   }, [menuOptions, metereologySuggestions]);
 
   return (
-    <Box alignItems="center" justifyContent="center" style={{ margin: IS_ANDROID ? 0 : -GAS_BUTTON_HIT_SLOP }} testID="gas-speed-pager">
+    <Box
+      alignItems="center"
+      justifyContent="center"
+      style={{ margin: IS_ANDROID ? 0 : -GAS_BUTTON_HIT_SLOP }}
+      testID="gas-speed-pager"
+      pointerEvents={isGasSponsored ? 'none' : 'auto'}
+    >
       {IS_ANDROID ? (
         <ContextMenu
           activeOpacity={0}
-          enableContextMenu
           isAnchoredToRight
           isMenuPrimaryAction
           onPressActionSheet={handlePressActionSheet}
@@ -75,13 +81,7 @@ export function GasMenu({ children, onSelectGasSpeed }: { children: ReactNode; o
           </Centered>
         </ContextMenu>
       ) : (
-        <ContextMenuButton
-          enableContextMenu
-          isMenuPrimaryAction
-          menuConfig={menuConfig}
-          onPressMenuItem={handlePressMenuItem}
-          useActionSheetFallback={false}
-        >
+        <ContextMenuButton isMenuPrimaryAction menuConfig={menuConfig} onPressMenuItem={handlePressMenuItem} useActionSheetFallback={false}>
           <ButtonPressAnimation scaleTo={0.825} style={{ padding: GAS_BUTTON_HIT_SLOP }}>
             {children}
           </ButtonPressAnimation>

--- a/src/systems/funding/config.ts
+++ b/src/systems/funding/config.ts
@@ -1,21 +1,57 @@
-import { type BalanceQueryStore, type DepositConfig, type WithdrawalConfig } from './types';
+import * as i18n from '@/languages';
+import { INITIAL_SLIDER_PROGRESS } from './constants';
+import { type BalanceQueryStore, type DepositConfig, type DepositConfigInput, type DepositLabels, type WithdrawalConfig } from './types';
 
 // ============ Config Helpers ================================================= //
 
+function getDefaultDepositLabels(): DepositLabels {
+  return {
+    confirmButton: i18n.t(i18n.l.perps.deposit.confirm_button_text),
+    confirmButtonError: i18n.t(i18n.l.perps.deposit.confirm_button_error_text),
+    confirmButtonLoading: i18n.t(i18n.l.perps.deposit.confirm_button_loading_text),
+    confirmButtonOverBalance: i18n.t(i18n.l.perps.deposit.confirm_button_over_balance_text),
+    confirmButtonZeroAmount: i18n.t(i18n.l.perps.deposit.confirm_button_zero_text),
+    executionErrorTitle: i18n.t(i18n.l.swap.error_executing_swap),
+    gasSponsored: 'Free',
+    insufficientGas: i18n.t(i18n.l.perps.deposit.insufficient_gas),
+    invalidRouteRecipientError: 'Bridge route is not targeting your account. Please retry.',
+    missingRecipientError: 'Missing recipient address',
+    quoteError: i18n.t(i18n.l.perps.deposit.quote_error),
+    receive: i18n.t(i18n.l.perps.deposit.receive),
+    title: i18n.t(i18n.l.perps.deposit.title),
+  };
+}
+
 /**
- * Identity function enabling type inference for deposit configs.
+ * Creates a fully resolved deposit config from partial input.
+ * Fills in default labels, normalizes source and gas config.
  *
  * @example
  * ```ts
  * export const MY_DEPOSIT_CONFIG = createDepositConfig({
  *   id: 'my-feature',
  *   to: { chainId: ChainId.polygon, token: { ... } },
- *   // Full type checking without explicit type annotation
  * });
  * ```
  */
-export function createDepositConfig(config: DepositConfig): DepositConfig {
-  return config;
+export function createDepositConfig(config: DepositConfigInput): DepositConfig {
+  return {
+    ...config,
+    gas: config.gas,
+    hideReceiveAmount: config.hideReceiveAmount ?? false,
+    initialSliderProgress: config.initialSliderProgress ?? INITIAL_SLIDER_PROGRESS,
+    labels: {
+      ...getDefaultDepositLabels(),
+      ...config.labels,
+    },
+    source:
+      config.source?.mode === 'fixed'
+        ? {
+            mode: 'fixed',
+            resolveAsset: config.source.resolveAsset,
+          }
+        : { mode: 'selectable' },
+  };
 }
 
 /**

--- a/src/systems/funding/contexts/DepositContext.tsx
+++ b/src/systems/funding/contexts/DepositContext.tsx
@@ -29,10 +29,10 @@ type DepositProviderProps = {
 
 export function DepositProvider({ children, config, initialAsset, initialGasSpeed, theme }: DepositProviderProps): React.ReactElement {
   const stores = useStableValue(() => {
-    const useAmountStore = createDepositAmountStore(initialAsset);
+    const useAmountStore = createDepositAmountStore(initialAsset, config.initialSliderProgress);
     const useDepositStore = createDepositStore(config, initialAsset, initialGasSpeed);
     const useQuoteStore = createDepositQuoteStore(config, useAmountStore, useDepositStore);
-    const gasStores = createDepositGasStores(config, useDepositStore, useQuoteStore);
+    const gasStores = createDepositGasStores(config, useAmountStore, useDepositStore, useQuoteStore);
     const useAmountToReceive = createAmountToReceiveStore(useAmountStore, useQuoteStore, config.to.token.displaySymbol);
 
     const depositActions = createStoreActions(useAmountStore, createStoreActions(useDepositStore));
@@ -49,7 +49,13 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
     };
   });
 
-  const controller = useDepositController(computeMaxSwappableAmount, stores.gasStores, stores.useAmountStore, stores.useDepositStore);
+  const controller = useDepositController(
+    config,
+    computeMaxSwappableAmount,
+    stores.gasStores,
+    stores.useAmountStore,
+    stores.useDepositStore
+  );
 
   const handleDeposit = useDepositHandler({
     config,
@@ -57,6 +63,7 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
     gasStores: stores.gasStores,
     isSubmitting: controller.isSubmitting,
     quoteActions: stores.quoteActions,
+    useAmountStore: stores.useAmountStore,
   });
 
   const contextValue: DepositContextType = {
@@ -70,6 +77,7 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
   useCleanup(() => {
     stores.gasStores.useMeteorologyStore.getState().reset(true);
     stores.gasStores.useGasLimitStore.getState().reset(true);
+    stores.gasStores.useGasSponsorshipStore.getState().reset(true);
     stores.useQuoteStore.getState().reset(true);
   });
 

--- a/src/systems/funding/hooks/useDepositController.ts
+++ b/src/systems/funding/hooks/useDepositController.ts
@@ -14,15 +14,13 @@ import {
   toFixedWorklet,
   trimTrailingZeros,
 } from '@/framework/core/safeMath';
-import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { useListen } from '@/state/internal/hooks/useListen';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
-import { addCommasToNumber, parseAssetAndExtend } from '@/__swaps__/utils/swaps';
+import { addCommasToNumber } from '@/__swaps__/utils/swaps';
 import { time } from '@/utils/time';
 import { sanitizeAmount } from '@/worklets/strings';
-import { INITIAL_SLIDER_PROGRESS } from '../constants';
 import {
   type AmountStoreType,
   type DepositGasStoresType,
@@ -30,7 +28,9 @@ import {
   type InputMethod,
   type InteractionSource,
   type MinifiedAsset,
+  type DepositConfig,
 } from '../types';
+import { resolveInitialDepositAsset } from '../utils/sourceAsset';
 import { amountFromSliderProgress, sliderProgressFromAmount } from '../utils/sliderWorklets';
 
 // ============ Controller Hook =============================================== //
@@ -42,6 +42,7 @@ type ComputeMaxSwappableFn = (
 ) => string | undefined;
 
 export function useDepositController(
+  config: DepositConfig,
   computeMaxSwappableAmount: ComputeMaxSwappableFn,
   gasStores: DepositGasStoresType,
   useAmountStore: AmountStoreType,
@@ -52,7 +53,10 @@ export function useDepositController(
   const assetDecimals = useStoreSharedValue(useDepositStore, state => state.asset?.decimals ?? 18);
   const assetPrice = useStoreSharedValue(useDepositStore, state => state.asset?.price?.value ?? 0);
 
-  const initialState = useStableValue(() => buildInitialState(useDepositStore, useAmountStore, gasStores.useMaxSwappableAmount.getState()));
+  const { initialSliderProgress } = config;
+  const initialState = useStableValue(() =>
+    buildInitialState(initialSliderProgress, useDepositStore, useAmountStore, gasStores.useMaxSwappableAmount.getState())
+  );
 
   const displayedAmount = useSharedValue(initialState.amount);
   const displayedNativeValue = useSharedValue(initialState.nativeValue);
@@ -60,7 +64,7 @@ export function useDepositController(
   const inputMethod = useSharedValue<InputMethod>('inputNativeValue');
   const interactionSource = useSharedValue<InteractionSource>('slider');
   const isSubmitting = useSharedValue(false);
-  const sliderProgress = useSharedValue(INITIAL_SLIDER_PROGRESS);
+  const sliderProgress = useSharedValue(initialSliderProgress);
 
   const primaryFormattedInput = useDerivedValue(() => {
     const isNativeInput = inputMethod.value === 'inputNativeValue';
@@ -171,7 +175,7 @@ export function useDepositController(
           assetDecimals: decimals,
           assetPrice: price,
           maxSwappableAmount: maxSwappable,
-          progress: sliderProgress.value || INITIAL_SLIDER_PROGRESS,
+          progress: sliderProgress.value || initialSliderProgress,
         });
       })();
     }
@@ -206,13 +210,7 @@ export function useDepositController(
     (current, previous) => {
       if (previous === null || current === previous) return;
       queueMicrotask(() => {
-        useDepositStore.getState().setAsset(
-          current
-            ? parseAssetAndExtend({
-                asset: useUserAssetsStore.getState().getHighestValueNativeAsset(),
-              })
-            : null
-        );
+        useDepositStore.getState().setAsset(current ? resolveInitialDepositAsset(config) : null);
       });
     }
   );
@@ -349,6 +347,7 @@ export type DepositControllerReturn = {
 // ============ Helper Functions ============================================== //
 
 function buildInitialState(
+  initialSliderProgress: number,
   useDepositStore: DepositStoreType,
   useAmountStore: AmountStoreType,
   initialMaxSwappableAmount: string | undefined
@@ -363,7 +362,7 @@ function buildInitialState(
   const nativePrice = asset?.price?.value || 0;
   const decimals = asset?.decimals || 18;
 
-  const { amount, nativeValue } = amountFromSliderProgress(INITIAL_SLIDER_PROGRESS, balance, nativePrice, decimals);
+  const { amount, nativeValue } = amountFromSliderProgress(initialSliderProgress, balance, nativePrice, decimals);
 
   return {
     amount,

--- a/src/systems/funding/hooks/useDepositHandler.ts
+++ b/src/systems/funding/hooks/useDepositHandler.ts
@@ -3,38 +3,43 @@ import { useCallback } from 'react';
 import { Alert } from 'react-native';
 import { type SharedValue } from 'react-native-reanimated';
 import { triggerHaptics } from 'react-native-turbo-haptics';
+import { crosschainQuoteTargetsRecipient, isCrosschainQuote } from '@/__swaps__/utils/quotes';
+import { type GasSettings } from '@/__swaps__/screens/Swap/hooks/useCustomGas';
 import { type ParsedAsset } from '@/__swaps__/types/assets';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/entities/gas';
-import { LedgerSigner } from '@/handlers/LedgerSigner';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
-import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
 import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
 import { walletExecuteRap } from '@/raps/execute';
 import { type RapSwapActionParameters, rapTypes } from '@/raps/references';
 import erc20ABI from '@/references/erc20-abi.json';
 import { sumWorklet } from '@/framework/core/safeMath';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { type ChainId } from '@/state/backendNetworks/types';
+import { type StoreActions } from '@/state/internal/utils/createStoreActions';
 import { getNextNonce } from '@/state/nonces';
 import { executeFn, Screens, startTimeToSignTracking, TimeToSignOperation } from '@/state/performance/performance';
-import { type StoreActions } from '@/state/internal/utils/createStoreActions';
+import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { isValidQuote } from '@/systems/funding/utils/quotes';
-import { determineStrategy, type ExecutionStrategy } from '../execution/strategy';
-import { crosschainQuoteTargetsRecipient, isCrosschainQuote } from '@/__swaps__/utils/quotes';
-import { executeRefreshSchedule, type RefreshConfig } from '../utils/scheduleRefreshes';
 import { time } from '@/utils/time';
 import { getUniqueId } from '@/utils/ethereumUtils';
+import watchingAlert from '@/utils/watchingAlert';
+import { sanitizeAmount } from '@/worklets/strings';
+import { determineStrategy, type ExecutionStrategy } from '../execution/strategy';
 import {
   type AmountStoreType,
-  type DepositConfig,
+  type DepositFailureMetadata,
   type DepositGasStoresType,
   type DepositMeteorologyActions,
   type DepositQuoteStoreType,
+  type DepositSuccessMetadata,
   type DepositStoreType,
   type DepositToken,
+  type DepositConfig,
 } from '../types';
+import { executeRefreshSchedule, type RefreshConfig } from '../utils/scheduleRefreshes';
 
 // ============ Handler Hook ================================================== //
 
@@ -44,7 +49,109 @@ type DepositHandlerParams = {
   gasStores: DepositGasStoresType;
   isSubmitting: SharedValue<boolean>;
   quoteActions: StoreActions<DepositQuoteStoreType>;
+  useAmountStore: AmountStoreType;
 };
+
+type DepositExecutionContext = {
+  amount: string;
+  assetChainId: ChainId;
+  assetSymbol: string;
+};
+
+type DepositExecutionFailure = {
+  error: string;
+  showAlert?: boolean;
+  stage?: DepositFailureMetadata['stage'];
+  success: false;
+};
+
+type DepositExecutionSuccess = {
+  confirmationChainId?: ChainId;
+  executionStrategy: DepositSuccessMetadata['executionStrategy'];
+  hash?: string;
+  isConfirmed?: boolean;
+  success: true;
+  waitForConfirmation?: () => Promise<void>;
+};
+
+type DepositExecutionFlowResult = DepositExecutionFailure | DepositExecutionSuccess;
+
+type RunDepositExecutionFlowParams = DepositExecutionContext & {
+  config: DepositConfig;
+  isSubmitting: SharedValue<boolean>;
+  run: () => Promise<DepositExecutionFlowResult>;
+  showAlertOnThrownError?: boolean;
+};
+
+async function runDepositExecutionFlow({
+  amount,
+  assetChainId,
+  assetSymbol,
+  config,
+  isSubmitting,
+  run,
+  showAlertOnThrownError = false,
+}: RunDepositExecutionFlowParams): Promise<void> {
+  isSubmitting.value = true;
+  startTimeToSignTracking();
+
+  try {
+    const result = await run();
+
+    if (!result.success) {
+      config.trackFailure?.({
+        amount,
+        assetChainId,
+        assetSymbol,
+        error: result.error,
+        stage: result.stage ?? 'execution',
+      });
+
+      if (result.error !== 'handled' && result.showAlert !== false) {
+        Alert.alert(config.labels.executionErrorTitle, result.error);
+      }
+      return;
+    }
+
+    scheduleRefreshAfterExecution({
+      chainId: result.confirmationChainId ?? assetChainId,
+      config,
+      hash: result.hash,
+      isConfirmed: result.isConfirmed,
+      waitForConfirmation: result.waitForConfirmation,
+    });
+
+    executeFn(Navigation.goBack, {
+      isEndOfFlow: true,
+      operation: TimeToSignOperation.SheetDismissal,
+      screen: Screens.PERPS_DEPOSIT,
+    })();
+
+    config.trackSuccess?.({
+      amount,
+      assetChainId,
+      assetSymbol,
+      executionStrategy: result.executionStrategy,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error while processing deposit';
+    logger.error(new RainbowError(`[useDepositHandler]: ${message}`, error), {
+      data: { type: rapTypes.crosschainSwap },
+    });
+    config.trackFailure?.({
+      amount,
+      assetChainId,
+      assetSymbol,
+      error: message,
+      stage: 'execution',
+    });
+    if (showAlertOnThrownError) {
+      Alert.alert(config.labels.executionErrorTitle, message);
+    }
+  } finally {
+    isSubmitting.value = false;
+  }
+}
 
 export function useDepositHandler({
   config,
@@ -52,17 +159,22 @@ export function useDepositHandler({
   gasStores,
   isSubmitting,
   quoteActions,
+  useAmountStore,
 }: DepositHandlerParams): () => Promise<void> {
   return useCallback(async () => {
     const asset = depositActions.getAsset();
-    const gasFeeParamsBySpeed = gasStores.useMeteorologyStore.getState().getGasSuggestions();
-    const gasSettings = gasStores.useGasSettings.getState();
     const quote = quoteActions.getData();
     const recipient = config.to.recipient?.getState() ?? null;
     const assetChainId = asset ? Number(asset.chainId) : null;
-    const isSubmittingSharedValue = isSubmitting;
+    const amount = sanitizeAmount(useAmountStore.getState().amount);
+    const executeCallback = config.execute;
+    const accountAddress = useWalletsStore.getState().accountAddress;
 
-    if (!isValidQuote(quote) || !asset || !gasFeeParamsBySpeed || !gasSettings || isSubmittingSharedValue.value) {
+    if (!asset || isSubmitting.value) {
+      return;
+    }
+
+    if (!amount || amount === '0') {
       return;
     }
 
@@ -71,163 +183,189 @@ export function useDepositHandler({
       return;
     }
 
+    const assetSymbol = asset.symbol ?? '';
+
     if (config.to.recipient && !recipient) {
       logger.error(new RainbowError('[useDepositHandler]: missing recipient'));
       config.trackFailure?.({
-        amount: quote.sellAmount?.toString(),
+        amount,
         assetChainId,
-        assetSymbol: asset.symbol,
+        assetSymbol,
         error: 'Missing recipient',
         stage: 'validation',
       });
-      Alert.alert(i18n.t(i18n.l.perps.deposit.quote_error), 'Missing recipient address');
+      Alert.alert(config.labels.quoteError, config.labels.missingRecipientError);
       return;
     }
 
-    isSubmittingSharedValue.value = true;
-    startTimeToSignTracking();
+    if (executeCallback) {
+      if (!accountAddress) {
+        logger.error(new RainbowError('[useDepositHandler]: missing account address'));
+        config.trackFailure?.({
+          amount,
+          assetChainId,
+          assetSymbol,
+          error: 'No wallet connected',
+          stage: 'validation',
+        });
+        Alert.alert(config.labels.executionErrorTitle, 'No wallet connected');
+        return;
+      }
+
+      const executeCustomDeposit = async () => {
+        await runDepositExecutionFlow({
+          amount,
+          assetChainId,
+          assetSymbol,
+          config,
+          isSubmitting,
+          run: async () => {
+            const result = await executeCallback({
+              accountAddress,
+              amount,
+              asset,
+              assetChainId,
+              quote,
+              recipient,
+            });
+
+            if (!result.success) return result;
+
+            return {
+              confirmationChainId: result.confirmationChainId,
+              executionStrategy: result.executionStrategy ?? 'custom',
+              hash: result.hash,
+              isConfirmed: result.isConfirmed,
+              success: true,
+              waitForConfirmation: result.waitForConfirmation,
+            };
+          },
+          showAlertOnThrownError: true,
+        });
+      };
+
+      const isReadOnlyWallet = useWalletsStore.getState().getIsReadOnlyWallet();
+      if (isReadOnlyWallet) {
+        watchingAlert();
+        return;
+      }
+
+      const isHardwareWallet = useWalletsStore.getState().getIsHardwareWallet();
+      if (isHardwareWallet) {
+        Navigation.handleAction(Routes.HARDWARE_WALLET_TX_NAVIGATOR, {
+          submit: executeCustomDeposit,
+        });
+        return;
+      }
+
+      await executeCustomDeposit();
+      return;
+    }
+
+    const gasFeeParamsBySpeed = gasStores.useMeteorologyStore.getState().getGasSuggestions();
+    const gasSettings = gasStores.useGasSettings.getState();
+    if (!isValidQuote(quote) || !gasFeeParamsBySpeed || !gasSettings) {
+      return;
+    }
+    const validQuote = quote;
 
     const targetAsset = buildTargetParsedAsset(config.to.token, config.to.chainId);
 
-    try {
-      const provider = getProvider({ chainId: assetChainId });
-
-      const wallet = await executeFn(loadWallet, {
-        operation: TimeToSignOperation.KeychainRead,
-        screen: Screens.PERPS_DEPOSIT,
-      })({
-        address: quote.from,
-        provider,
-        timeTracking: {
-          operation: TimeToSignOperation.Authentication,
-          screen: Screens.PERPS_DEPOSIT,
-        },
-      });
-
-      const isHardwareWallet = wallet instanceof LedgerSigner;
-
-      if (!wallet) {
-        triggerHaptics('notificationError');
-        config.trackFailure?.({
-          amount: quote.sellAmount?.toString(),
-          assetChainId,
-          assetSymbol: asset.symbol,
-          error: 'Wallet load failed',
-          stage: 'wallet',
-        });
-        return;
-      }
-
-      let gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
-      if (gasSettings.isEIP1559) {
-        gasParams = {
-          maxFeePerGas: sumWorklet(gasSettings.maxBaseFee, gasSettings.maxPriorityFee),
-          maxPriorityFeePerGas: gasSettings.maxPriorityFee,
-        };
-      } else {
-        gasParams = { gasPrice: gasSettings.gasPrice };
-      }
-
-      const nonce = await getNextNonce({ address: quote.from, chainId: assetChainId });
-      const strategy = determineStrategy(config, quote, quote.from);
-      const isCrosschain = isCrosschainQuote(quote);
-
-      if (isCrosschain && recipient && !crosschainQuoteTargetsRecipient(quote, recipient)) {
-        logger.error(new RainbowError('[useDepositHandler]: crosschain quote is not targeting recipient'), {
-          recipient,
-          routes: quote.routes,
-        });
-        config.trackFailure?.({
-          amount: quote.sellAmount?.toString(),
-          assetChainId,
-          assetSymbol: asset.symbol,
-          error: 'Crosschain quote not targeting recipient',
-          stage: 'validation',
-        });
-        Alert.alert(i18n.t(i18n.l.perps.deposit.quote_error), 'Bridge route is not targeting your account. Please retry.');
-        return;
-      }
-
-      const parameters: Omit<
-        RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
-        'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
-      > = {
-        assetToBuy: targetAsset,
-        assetToSell: asset,
-        buyAmount: quote.buyAmount?.toString(),
-        chainId: assetChainId,
-        quote,
-        sellAmount: quote.sellAmount?.toString(),
-      };
-
-      const result = await executeTransaction(strategy, {
-        assetChainId,
-        gasFeeParamsBySpeed,
-        gasParams,
-        isHardwareWallet,
-        nonce,
-        parameters,
-        wallet,
-      });
-
-      if (!result.success) {
-        config.trackFailure?.({
-          amount: quote.sellAmount?.toString(),
-          assetChainId,
-          assetSymbol: asset.symbol,
-          error: result.error ?? 'Transaction failed',
-          stage: 'execution',
-        });
-        if (result.error && result.error !== 'handled') {
-          Alert.alert(i18n.t(i18n.l.swap.error_executing_swap), result.error);
-        }
-        return;
-      }
-
-      if (config.onSubmit) {
-        config.onSubmit(wallet).catch(error => {
-          logger.error(new RainbowError('[useDepositHandler]: onSubmit error', error));
-        });
-      }
-
-      if (config.refresh) {
-        dispatchRefreshesAfterConfirmation({
-          chainId: assetChainId,
-          hash: result.hash,
-          isConfirmed: result.isConfirmed,
-          refresh: config.refresh,
-          tag: config.id,
-        });
-      }
-
-      executeFn(Navigation.goBack, {
-        isEndOfFlow: true,
-        operation: TimeToSignOperation.SheetDismissal,
-        screen: Screens.PERPS_DEPOSIT,
-      })();
-
-      config.trackSuccess?.({
-        amount: quote.sellAmount?.toString() ?? '',
-        assetChainId,
-        assetSymbol: asset.symbol ?? '',
-        executionStrategy: strategy.type === 'directTransfer' ? 'directTransfer' : strategy.rapType,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error while processing deposit';
-      logger.error(new RainbowError(`[useDepositHandler]: ${message}`, error), {
-        data: { type: rapTypes.crosschainSwap },
+    if (isCrosschainQuote(validQuote) && recipient && !crosschainQuoteTargetsRecipient(validQuote, recipient)) {
+      logger.error(new RainbowError('[useDepositHandler]: crosschain quote is not targeting recipient'), {
+        recipient,
+        routes: validQuote.routes,
       });
       config.trackFailure?.({
-        amount: quote.sellAmount?.toString(),
+        amount: validQuote.sellAmount?.toString(),
         assetChainId,
-        assetSymbol: asset.symbol,
-        error: message,
-        stage: 'execution',
+        assetSymbol,
+        error: 'Crosschain quote not targeting recipient',
+        stage: 'validation',
       });
-    } finally {
-      isSubmittingSharedValue.value = false;
+      Alert.alert(config.labels.quoteError, config.labels.invalidRouteRecipientError);
+      return;
     }
-  }, [config, depositActions, gasStores, isSubmitting, quoteActions]);
+
+    await runDepositExecutionFlow({
+      amount: validQuote.sellAmount?.toString() ?? '',
+      assetChainId,
+      assetSymbol,
+      config,
+      isSubmitting,
+      run: async () => {
+        const provider = getProvider({ chainId: assetChainId });
+
+        const wallet = await executeFn(loadWallet, {
+          operation: TimeToSignOperation.KeychainRead,
+          screen: Screens.PERPS_DEPOSIT,
+        })({
+          address: validQuote.from,
+          provider,
+          timeTracking: {
+            operation: TimeToSignOperation.Authentication,
+            screen: Screens.PERPS_DEPOSIT,
+          },
+        });
+
+        if (!wallet) {
+          triggerHaptics('notificationError');
+          return {
+            error: 'Wallet load failed',
+            showAlert: false,
+            stage: 'wallet',
+            success: false,
+          };
+        }
+
+        const gasParams = buildGasParams(gasSettings);
+        const nonce = await getNextNonce({ address: validQuote.from, chainId: assetChainId });
+        const strategy = determineStrategy(config, validQuote, validQuote.from);
+
+        const parameters: Omit<
+          RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
+          'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
+        > = {
+          assetToBuy: targetAsset,
+          assetToSell: asset,
+          buyAmount: validQuote.buyAmount?.toString(),
+          chainId: assetChainId,
+          quote: validQuote,
+          sellAmount: validQuote.sellAmount?.toString(),
+        };
+
+        const result = await executeTransaction(strategy, {
+          assetChainId,
+          gasFeeParamsBySpeed,
+          gasParams,
+          nonce,
+          parameters,
+          wallet,
+        });
+
+        if (!result.success) {
+          return {
+            error: result.error,
+            success: false,
+          };
+        }
+
+        if (config.onSubmit) {
+          config.onSubmit(wallet).catch(error => {
+            logger.error(new RainbowError('[useDepositHandler]: onSubmit error', error));
+          });
+        }
+
+        return {
+          confirmationChainId: assetChainId,
+          executionStrategy: strategy.type === 'directTransfer' ? 'directTransfer' : strategy.rapType,
+          hash: result.hash,
+          isConfirmed: result.isConfirmed,
+          success: true,
+        };
+      },
+    });
+  }, [config, depositActions, gasStores, isSubmitting, quoteActions, useAmountStore]);
 }
 
 // ============ Execution Types =============================================== //
@@ -236,7 +374,6 @@ type ExecutionParams = {
   assetChainId: ChainId;
   gasFeeParamsBySpeed: NonNullable<ReturnType<DepositMeteorologyActions['getGasSuggestions']>>;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
-  isHardwareWallet: boolean;
   nonce: number;
   parameters: Omit<
     RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
@@ -250,6 +387,17 @@ type ExecutionResult =
   | { error?: undefined; hash: string; isConfirmed: boolean; success: true };
 
 // ============ Transaction Execution ========================================= //
+
+function buildGasParams(gasSettings: GasSettings): LegacyTransactionGasParamAmounts | TransactionGasParamAmounts {
+  if (gasSettings.isEIP1559) {
+    return {
+      maxFeePerGas: sumWorklet(gasSettings.maxBaseFee, gasSettings.maxPriorityFee),
+      maxPriorityFeePerGas: gasSettings.maxPriorityFee,
+    };
+  }
+
+  return { gasPrice: gasSettings.gasPrice };
+}
 
 async function executeTransaction(strategy: ExecutionStrategy, params: ExecutionParams): Promise<ExecutionResult> {
   switch (strategy.type) {
@@ -324,6 +472,47 @@ type DispatchRefreshesParams = {
   refresh: RefreshConfig;
   tag: string;
 };
+
+type ScheduleRefreshAfterExecutionParams = {
+  chainId: ChainId;
+  config: Pick<DepositConfig, 'id' | 'refresh'>;
+  hash?: string;
+  isConfirmed?: boolean;
+  waitForConfirmation?: () => Promise<void>;
+};
+
+function scheduleRefreshAfterExecution({
+  chainId,
+  config,
+  hash,
+  isConfirmed,
+  waitForConfirmation,
+}: ScheduleRefreshAfterExecutionParams): void {
+  const refresh = config.refresh;
+  if (!refresh) return;
+
+  if (waitForConfirmation) {
+    waitForConfirmation()
+      .then(() => executeRefreshSchedule(refresh, config.id))
+      .catch(error => {
+        logger.warn(`[useDepositHandler]: confirmation failed for ${config.id}`, { error });
+      });
+    return;
+  }
+
+  if (hash) {
+    dispatchRefreshesAfterConfirmation({
+      chainId,
+      hash,
+      isConfirmed: Boolean(isConfirmed),
+      refresh,
+      tag: config.id,
+    });
+    return;
+  }
+
+  executeRefreshSchedule(refresh, config.id);
+}
 
 function dispatchRefreshesAfterConfirmation({ chainId, hash, isConfirmed, refresh, tag }: DispatchRefreshesParams): void {
   if (isConfirmed) {

--- a/src/systems/funding/hooks/useWithdrawalController.ts
+++ b/src/systems/funding/hooks/useWithdrawalController.ts
@@ -23,6 +23,7 @@ type WithdrawalControllerOptions = {
   amountActions?: StoreActions<AmountStoreType>;
   balanceStore: BalanceStore;
   decimals: number;
+  initialSliderProgress?: number;
 };
 
 type WithdrawalControllerReturn = {
@@ -44,11 +45,12 @@ export function useWithdrawalController({
   amountActions,
   balanceStore,
   decimals,
+  initialSliderProgress = INITIAL_SLIDER_PROGRESS,
 }: WithdrawalControllerOptions): WithdrawalControllerReturn {
   const balance = useStoreSharedValue(balanceStore, state => state.getBalance());
-  const initial = getInitialValues(balanceStore, decimals);
+  const initial = getInitialValues(balanceStore, decimals, initialSliderProgress);
 
-  const sliderProgress = useSharedValue(INITIAL_SLIDER_PROGRESS);
+  const sliderProgress = useSharedValue(initialSliderProgress);
   const interactionSource = useSharedValue<InteractionSource>('slider');
   const inputMethod = useSharedValue('inputAmount');
   const displayedAmount = useSharedValue(initial.initialAmount);
@@ -180,12 +182,13 @@ export function useWithdrawalController({
 
 function getInitialValues(
   balanceStore: BalanceStore,
-  decimals: number
+  decimals: number,
+  initialSliderProgress: number
 ): {
   fields: Record<InputMethod, NumberPadField>;
   initialAmount: string;
 } {
-  const result = valueFromSliderProgress(INITIAL_SLIDER_PROGRESS, balanceStore.getState().getBalance(), decimals);
+  const result = valueFromSliderProgress(initialSliderProgress, balanceStore.getState().getBalance(), decimals);
   const initialAmount = sanitizeAmount(result.amount);
   return {
     fields: {

--- a/src/systems/funding/stores/createAmountStore.ts
+++ b/src/systems/funding/stores/createAmountStore.ts
@@ -27,8 +27,11 @@ export function createAmountStore(initialAmount = '0'): AmountStoreType {
 
 // ============ Deposit-Specific Amount Store ================================= //
 
-export function createDepositAmountStore(initialAsset: ExtendedAnimatedAssetWithColors | null): AmountStoreType {
-  const initialAmount = computeInitialDepositAmount(initialAsset, undefined, undefined);
+export function createDepositAmountStore(
+  initialAsset: ExtendedAnimatedAssetWithColors | null,
+  initialSliderProgress: number
+): AmountStoreType {
+  const initialAmount = computeInitialDepositAmount(initialAsset, undefined, undefined, initialSliderProgress);
   return createAmountStore(initialAmount);
 }
 

--- a/src/systems/funding/stores/createDepositGasStores.ts
+++ b/src/systems/funding/stores/createDepositGasStores.ts
@@ -3,35 +3,42 @@ import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import { type MeteorologyLegacyResponse, type MeteorologyResponse } from '@/entities/gas';
 import { rainbowMeteorologyGetData } from '@/handlers/gasFees';
 import { convertAmountToNativeDisplayWorklet, formatNumber, multiply } from '@/helpers/utilities';
+import { logger } from '@/logger';
 import { gweiToWei, weiToGwei } from '@/parsers/gas';
 import { estimateUnlockAndCrosschainSwap } from '@/raps/actions/crosschainSwap';
 import { estimateUnlockAndSwap } from '@/raps/actions/swap';
 import { gasUnits } from '@/references/gasUnits';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { ChainId } from '@/state/backendNetworks/types';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { createQueryStore } from '@/state/internal/createQueryStore';
 import { type InferStoreState } from '@/state/internal/types';
+import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { type GasSettings } from '@/__swaps__/screens/Swap/hooks/useCustomGas';
 import { safeBigInt } from '@/__swaps__/screens/Swap/hooks/useEstimatedGasFee';
 import { calculateGasFeeWorklet } from '@/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues';
 import { GasSpeed } from '@/__swaps__/types/gas';
 import { isCrosschainQuote } from '@/__swaps__/utils/quotes';
+import { stripNonDecimalNumbers } from '@/__swaps__/utils/swaps';
 import { isLegacyMeteorologyFeeData } from '@/resources/meteorology/classification';
 import { time } from '@/utils/time';
 import { shallowEqual } from '@/worklets/comparisons';
 import { createExternalTokenStore, type FormattedExternalAsset } from './createExternalTokenStore';
 import { computeMaxSwappableAmount } from './createDepositStore';
-import { isValidQuote } from '../utils/quotes';
 import {
-  type DepositConfig,
+  type AmountStoreType,
+  type DepositGasHookParams,
   type DepositGasLimitParams,
+  type DepositGasSponsorshipParams,
   type DepositGasSuggestions,
   type DepositGasStoresType,
   type DepositMeteorologyActions,
   type DepositMeteorologyParams,
   type DepositQuoteStoreType,
   type DepositStoreType,
+  type DepositConfig,
 } from '../types';
+import { isValidQuote } from '../utils/quotes';
 
 // ============ Types ========================================================= //
 
@@ -41,10 +48,13 @@ type MeteorologyData = MeteorologyLegacyResponse | MeteorologyResponse;
 // ============ Gas Stores Factory ============================================ //
 
 export function createDepositGasStores(
-  _config: DepositConfig,
+  config: DepositConfig,
+  useAmountStore: AmountStoreType,
   useDepositStore: DepositStoreType,
   useQuoteStore: DepositQuoteStoreType
 ): DepositGasStoresType {
+  const hasCustomGasLimitEstimator = Boolean(config.gas?.estimateGasLimit);
+
   /**
    * Produces a numeric key each time the `quote` object identity
    * changes to avoid serializing large quote objects as query keys.
@@ -80,16 +90,61 @@ export function createDepositGasStores(
     })
   );
 
+  const useNormalizedAmount = createDerivedStore($ => $(useAmountStore, state => normalizeAmount(state.amount)), { fastMode: true });
+
+  const useCanEstimateGasLimit = createDerivedStore(
+    $ => {
+      const normalizedAmount = $(useNormalizedAmount);
+      const hasAmount = hasNonZeroAmount(normalizedAmount);
+      const hasAsset = $(useDepositStore, selectAssetUniqueId) !== null;
+
+      if (!hasAsset || !hasAmount) return false;
+      if (hasCustomGasLimitEstimator) return true;
+      return isValidQuoteKey($(useQuoteKey));
+    },
+    { fastMode: true }
+  );
+
+  const useCanCheckGasSponsorship = createDerivedStore(
+    $ => {
+      const hasSponsorshipHook = Boolean(config.gas?.isSponsored);
+      if (!hasSponsorshipHook) return false;
+
+      const normalizedAmount = $(useNormalizedAmount);
+      const hasAmount = hasNonZeroAmount(normalizedAmount);
+      const hasAsset = $(useDepositStore, selectAssetUniqueId) !== null;
+      const hasAccountAddress = $(useWalletsStore, state => Boolean(state.accountAddress));
+
+      return hasAccountAddress && hasAsset && hasAmount;
+    },
+    { fastMode: true }
+  );
+
   const useGasLimitStore = createQueryStore<GasLimit, DepositGasLimitParams>({
-    fetcher: createGasLimitFetcher(useDepositStore, useQuoteStore),
-    enabled: $ => $(useQuoteKey, isValidQuoteKey),
+    fetcher: createGasLimitFetcher(config, useAmountStore, useDepositStore, useQuoteStore),
+    enabled: $ => $(useCanEstimateGasLimit),
     params: {
+      amount: $ => $(useNormalizedAmount),
       assetToSellUniqueId: $ => $(useDepositStore, selectAssetUniqueId),
       quoteKey: $ => $(useQuoteKey),
     },
     cacheTime: time.minutes(1),
     keepPreviousData: true,
     staleTime: time.seconds(30),
+  });
+
+  const useGasSponsorshipStore = createQueryStore<boolean, DepositGasSponsorshipParams>({
+    fetcher: createGasSponsorshipFetcher(config, useAmountStore, useDepositStore, useQuoteStore),
+    enabled: $ => $(useCanCheckGasSponsorship),
+    params: {
+      accountAddress: $ => $(useWalletsStore).accountAddress,
+      amount: $ => $(useNormalizedAmount),
+      assetToSellUniqueId: $ => $(useDepositStore, selectAssetUniqueId),
+      quoteKey: $ => $(useQuoteKey),
+    },
+    cacheTime: time.seconds(20),
+    keepPreviousData: true,
+    staleTime: time.seconds(8),
   });
 
   const useNativeAssetStore = createExternalTokenStore(useDepositStore);
@@ -117,6 +172,13 @@ export function createDepositGasStores(
     { fastMode: true }
   );
 
+  const useIsGasSponsored = createDerivedStore(
+    $ => {
+      return $(useGasSponsorshipStore, state => state.getData()) ?? false;
+    },
+    { fastMode: true }
+  );
+
   const useMaxSwappableAmount = createDerivedStore(
     $ => {
       const asset = $(useDepositStore, state => state.getAsset());
@@ -131,6 +193,8 @@ export function createDepositGasStores(
     useEstimatedGasFee,
     useGasLimitStore,
     useGasSettings,
+    useGasSponsorshipStore,
+    useIsGasSponsored,
     useMaxSwappableAmount,
     useMeteorologyStore,
   };
@@ -149,6 +213,8 @@ async function fetchMeteorologyData(
 // ============ Gas Limit Fetching ============================================ //
 
 function createGasLimitFetcher(
+  config: DepositConfig,
+  useAmountStore: AmountStoreType,
   useDepositStore: DepositStoreType,
   useQuoteStore: DepositQuoteStoreType
 ): (params: DepositGasLimitParams) => Promise<GasLimit> {
@@ -157,8 +223,29 @@ function createGasLimitFetcher(
     const quote = useQuoteStore.getState().getData();
     const chainId = useDepositStore.getState().getAssetChainId();
 
-    if (!asset || !isValidQuote(quote)) {
-      return gasUnits.basic_swap[chainId];
+    if (!asset) {
+      return getDefaultGasLimit(chainId);
+    }
+
+    if (config.gas?.estimateGasLimit) {
+      const params = getGasHookParams(config, useAmountStore, useDepositStore, useQuoteStore);
+      if (!params) {
+        return getDefaultGasLimit(chainId);
+      }
+
+      try {
+        return await config.gas.estimateGasLimit(params);
+      } catch (error) {
+        logger.warn('[createDepositGasStores]: custom gas-limit estimation failed', {
+          error,
+          id: config.id,
+        });
+        return getDefaultGasLimit(chainId);
+      }
+    }
+
+    if (!isValidQuote(quote)) {
+      return getDefaultGasLimit(chainId);
     }
 
     if (isCrosschainQuote(quote)) {
@@ -175,10 +262,68 @@ function createGasLimitFetcher(
   };
 }
 
+function createGasSponsorshipFetcher(
+  config: DepositConfig,
+  useAmountStore: AmountStoreType,
+  useDepositStore: DepositStoreType,
+  useQuoteStore: DepositQuoteStoreType
+): (params: DepositGasSponsorshipParams) => Promise<boolean> {
+  return async function fetchIsGasSponsored(): Promise<boolean> {
+    const sponsorshipHook = config.gas?.isSponsored;
+    if (!sponsorshipHook) return false;
+
+    const params = getGasHookParams(config, useAmountStore, useDepositStore, useQuoteStore);
+    if (!params) return false;
+
+    try {
+      return Boolean(await sponsorshipHook(params));
+    } catch (error) {
+      logger.warn('[createDepositGasStores]: sponsorship check failed', {
+        error,
+        id: config.id,
+      });
+      return false;
+    }
+  };
+}
+
+function getGasHookParams(
+  config: DepositConfig,
+  useAmountStore: AmountStoreType,
+  useDepositStore: DepositStoreType,
+  useQuoteStore: DepositQuoteStoreType
+): DepositGasHookParams | null {
+  const accountAddress = useWalletsStore.getState().accountAddress;
+  const amount = normalizeAmount(useAmountStore.getState().amount);
+  const asset = useDepositStore.getState().asset;
+
+  if (!accountAddress || !asset || !hasNonZeroAmount(amount)) return null;
+
+  return {
+    accountAddress,
+    amount,
+    asset,
+    recipient: config.to.recipient?.getState() ?? null,
+    quote: useQuoteStore.getState().getData(),
+  };
+}
+
+function getDefaultGasLimit(chainId: ChainId): string {
+  return gasUnits.basic_swap[chainId] ?? gasUnits.basic_swap[ChainId.mainnet];
+}
+
 // ============ Selectors ===================================================== //
 
 function isValidQuoteKey(key: number | null): boolean {
   return key !== null;
+}
+
+function normalizeAmount(amount: string): string {
+  return stripNonDecimalNumbers(amount) || '0';
+}
+
+function hasNonZeroAmount(amount: string): boolean {
+  return Number(amount) > 0;
 }
 
 function selectAssetUniqueId(state: InferStoreState<DepositStoreType>): string | null {

--- a/src/systems/funding/types.ts
+++ b/src/systems/funding/types.ts
@@ -53,7 +53,7 @@ export type DepositSuccessMetadata = {
   /** Symbol of the source asset */
   assetSymbol: string;
   /** Execution path taken */
-  executionStrategy: 'crosschainSwap' | 'directTransfer' | 'swap';
+  executionStrategy: 'crosschainSwap' | 'directTransfer' | 'custom' | 'swap';
 };
 
 export type DepositFailureMetadata = {
@@ -89,6 +89,120 @@ export type DepositToken = {
 };
 
 /**
+ * Source asset selection configuration for the deposit flow.
+ *
+ * - `selectable` (default): user can pick any owned source token.
+ * - `fixed`: source token is locked to one specific asset.
+ */
+export type DepositSourceConfigInput =
+  | {
+      mode?: 'selectable';
+    }
+  | {
+      mode: 'fixed';
+      /**
+       * Resolves the fixed source asset used by the flow.
+       * Called when the screen initializes and when account changes.
+       */
+      resolveAsset: () => ExtendedAnimatedAssetWithColors | null;
+    };
+
+export type DepositExecutionBaseParams = {
+  /** Connected wallet address submitting the deposit */
+  accountAddress: Address;
+  /** Sanitized human-readable amount */
+  amount: string;
+  /** Selected source asset */
+  asset: ExtendedAnimatedAssetWithColors;
+  /** Current recipient from config (if any) */
+  recipient: Address | null;
+  /** Current quote data (may be null/unavailable) */
+  quote: DepositQuoteResult;
+};
+
+export type DepositExecuteParams = DepositExecutionBaseParams & {
+  /** Chain of the selected source asset */
+  assetChainId: ChainId;
+};
+
+export type DepositExecuteSuccess = {
+  /**
+   * Chain used for confirmation polling when `hash` is provided.
+   * Falls back to source asset chain when omitted.
+   */
+  confirmationChainId?: ChainId;
+  /** Execution path label for analytics */
+  executionStrategy?: DepositSuccessMetadata['executionStrategy'];
+  /**
+   * Optional transaction hash for confirmation-aware refresh scheduling.
+   * If omitted, refresh scheduling executes immediately on success.
+   */
+  hash?: string;
+  /**
+   * Whether the transaction is already confirmed.
+   * Only relevant when `hash` is provided.
+   * @default false
+   */
+  isConfirmed?: boolean;
+  success: true;
+  /**
+   * Optional explicit confirmation waiter.
+   * When present, this takes precedence over `hash` polling.
+   */
+  waitForConfirmation?: () => Promise<void>;
+};
+
+export type DepositExecuteFailure = {
+  /**
+   * Error message for user display.
+   * Use `'handled'` when UI was already surfaced by the executor.
+   */
+  error: string;
+  success: false;
+};
+
+export type DepositExecuteResult = DepositExecuteFailure | DepositExecuteSuccess;
+
+/**
+ * Optional custom execution callback for deposit submission.
+ *
+ * Use when the flow should keep deposit UX/state coordination but submit
+ * custom transaction logic (e.g. staking).
+ */
+export type DepositExecutor = (params: DepositExecuteParams) => Promise<DepositExecuteResult>;
+
+export type DepositGasHookParams = DepositExecutionBaseParams;
+
+export type DepositGasConfig = {
+  /**
+   * Optional custom gas-limit estimator.
+   * When omitted, the framework uses quote/swap estimation.
+   */
+  estimateGasLimit?: (params: DepositGasHookParams) => Promise<string>;
+  /**
+   * Optional sponsorship signal for UI display.
+   * When true, gas is shown as "estimated (struck-through) + Free".
+   */
+  isSponsored?: (params: DepositGasHookParams) => Promise<boolean> | boolean;
+};
+
+export type DepositLabels = {
+  confirmButton: string;
+  confirmButtonError: string;
+  confirmButtonLoading: string;
+  confirmButtonOverBalance: string;
+  confirmButtonZeroAmount: string;
+  executionErrorTitle: string;
+  gasSponsored: string;
+  insufficientGas: string;
+  invalidRouteRecipientError: string;
+  missingRecipientError: string;
+  quoteError: string;
+  receive: string;
+  title: string;
+};
+
+/**
  * ### `DepositConfig`
  *
  * Configuration for the deposit flow. Defines where funds go, quote behavior,
@@ -114,7 +228,7 @@ export type DepositToken = {
  * });
  * ```
  */
-export type DepositConfig = {
+type DepositConfigBaseInput = {
   /** Unique identifier for logging and analytics */
   id: string;
 
@@ -149,8 +263,33 @@ export type DepositConfig = {
    */
   directTransferEnabled?: boolean;
 
-  /** Callback invoked immediately after transaction submission */
-  onSubmit?: OnDepositSubmit;
+  /**
+   * Source asset behavior.
+   * @default { mode: 'selectable' }
+   */
+  source?: DepositSourceConfigInput;
+
+  /** Optional gas extension hooks */
+  gas?: DepositGasConfig;
+
+  /** Initial slider position (0–100). @default 25 */
+  initialSliderProgress?: number;
+
+  /**
+   * When true, the receive row shows only the `labels.receive` text
+   * without appending the quoted amount.
+   * @default false
+   */
+  hideReceiveAmount?: boolean;
+
+  /** Optional copy overrides for non-perps flows */
+  labels?: Partial<DepositLabels>;
+
+  /** Optional input validation rules */
+  validation?: {
+    /** Minimum deposit amount (human-readable, e.g. '1' for 1 token) */
+    minAmount?: { label: string; value: string };
+  };
 
   /** Store refresh behavior after confirmation */
   refresh?: RefreshConfig;
@@ -162,9 +301,51 @@ export type DepositConfig = {
   trackSuccess?: (metadata: DepositSuccessMetadata) => void;
 };
 
+type DepositExecutionCallbacks =
+  | {
+      /**
+       * Custom execution mode.
+       * Use this when the flow handles transaction submission itself.
+       * In this mode, post-submit side effects must also be handled by the executor.
+       */
+      execute: DepositExecutor;
+      /**
+       * Disallowed in custom execution mode.
+       * The framework will not invoke `onSubmit` when `execute` is present.
+       */
+      onSubmit?: never;
+    }
+  | {
+      /**
+       * Framework execution mode (quote/swap/direct-transfer).
+       * Keep `execute` unset to use the built-in execution pipeline.
+       */
+      execute?: never;
+      /**
+       * Optional post-submit hook for framework execution mode.
+       * Invoked immediately after transaction submission with the active signer.
+       */
+      onSubmit?: OnDepositSubmit;
+    };
+
+export type DepositConfigInput = DepositConfigBaseInput & DepositExecutionCallbacks;
+
+export type DepositSourceConfig = { mode: 'selectable' } | Extract<DepositSourceConfigInput, { mode: 'fixed' }>;
+
+type DepositConfigBase = Omit<DepositConfigBaseInput, 'gas' | 'hideReceiveAmount' | 'initialSliderProgress' | 'labels' | 'source'> & {
+  hideReceiveAmount: boolean;
+  gas: DepositGasConfig | undefined;
+  initialSliderProgress: number;
+  labels: DepositLabels;
+  source: DepositSourceConfig;
+};
+
+export type DepositConfig = DepositConfigBase & DepositExecutionCallbacks;
+
 // ============ Quote Status =================================================== //
 
 export enum DepositQuoteStatus {
+  BelowMinimum = 'belowMinimum',
   Error = 'error',
   InsufficientBalance = 'insufficientBalance',
   InsufficientGas = 'insufficientGas',
@@ -235,6 +416,14 @@ export type DepositQuoteStoreType = QueryStore<DepositQuoteResult, DepositQuoteS
 // ============ Gas Store Types ================================================ //
 
 export type DepositGasLimitParams = {
+  amount: string;
+  assetToSellUniqueId: string | null;
+  quoteKey: number | null;
+};
+
+export type DepositGasSponsorshipParams = {
+  accountAddress: Address;
+  amount: string;
   assetToSellUniqueId: string | null;
   quoteKey: number | null;
 };
@@ -254,6 +443,8 @@ export type DepositMeteorologyActions = {
 export type DepositGasStoresType = {
   useEstimatedGasFee: DerivedStore<string | undefined>;
   useGasLimitStore: QueryStore<string, DepositGasLimitParams>;
+  useGasSponsorshipStore: QueryStore<boolean, DepositGasSponsorshipParams>;
+  useIsGasSponsored: DerivedStore<boolean>;
   useGasSettings: DerivedStore<GasSettings | undefined>;
   useMaxSwappableAmount: DerivedStore<string | undefined>;
   useMeteorologyStore: QueryStore<DepositGasSuggestions, DepositMeteorologyParams, DepositMeteorologyActions>;
@@ -603,6 +794,9 @@ export type WithdrawalConfig<TBalanceStore extends BalanceQueryStore> = {
 
   /** Decimal precision for amount display */
   amountDecimals: number;
+
+  /** Initial slider position (0–100). @default 25 */
+  initialSliderProgress?: number;
 
   /**
    * Routing configuration for multi-chain withdrawals.

--- a/src/systems/funding/utils/sourceAsset.ts
+++ b/src/systems/funding/utils/sourceAsset.ts
@@ -1,0 +1,11 @@
+import { parseAssetAndExtend } from '@/__swaps__/utils/swaps';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { type DepositConfig } from '../types';
+
+export function resolveInitialDepositAsset(config: DepositConfig) {
+  if (config.source.mode === 'fixed') {
+    return config.source.resolveAsset();
+  }
+  const sourceAsset = useUserAssetsStore.getState().getHighestValueNativeAsset();
+  return sourceAsset ? parseAssetAndExtend({ asset: sourceAsset }) : null;
+}


### PR DESCRIPTION
## What changed

Replaces the hard-coded staking screen with a full amount-selection UI powered by the funding system's `DepositScreen`, and generalizes the deposit system to support arbitrary action execution. 

## Main changes

- `RnbwStakingScreen`: replaced with `DepositScreen` using a staking-specific `RNBW_STAKING_DEPOSIT_CONFIG`
- `depositConfig.ts`: new RNBW staking deposit config with fixed source token, custom `execute`, gas estimation, sponsorship check, and staking-specific labels
- `syntheticRnbwSourceAsset`: builds a source asset combining wallet RNBW balance + claimable rewards into one amount for the deposit input. This is also required for cases where the user has no RNBW in their wallet but does have a claimable balance, in which case we do not have the full RNBW asset object the deposit system requires
- `DepositConfigInput` / `DepositConfig`: split config into a partial input type and a resolved type. `createDepositConfig` fills in defaults for labels, source mode, gas, slider progress, etc.
- `useDepositHandler`: supports a custom `execute` callback path alongside the existing quote/swap path
- `createDepositGasStores`: supports custom `estimateGasLimit` and `isSponsored` hooks driven by the config
- `GasFeeText` / `GasMenu`: shows sponsored gas as strikethrough + "Free" label and disables the gas speed menu when sponsored
- `DepositScreen` / `DepositAmountInput`: supports `source.mode = 'fixed'` which hides the token selector and swap button
- `DepositFooter`: adds `BelowMinimum` validation status and uses config labels instead of hardcoded perps translations

## Other changes

- `constants.ts`: switched to prod RNBW token and staking contract addresses, added `MIN_CLAIM_TO_STAKING_RAW`
- `canUseSponsoredRnbwStaking`: extracted sponsorship eligibility check (excludes hardware wallets)
- `estimateStakeGasLimit`: estimates gas for stake + optional approval
- `refreshStakingData`: refreshes staking position and user assets after staking
- `stakeRnbw`: uses new min-claim threshold, references extracted sponsorship check
- `sourceAsset.ts`: resolves initial deposit asset for fixed-source configs
- `WithdrawalScreen` / `useWithdrawalController`: wired through `initialSliderProgress` for consistency

## Notes

- `hideReceiveAmount` suppresses the quoted output row since staking doesn't produce a different receive token