### PR TITLE
fix(logger): dont disabling error reporting with analytics opt-out

### DIFF
--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -2269,7 +2269,7 @@
         "when_public_prefix": "When public, your NFT Showcase will be visible on your Rainbow web profile! You can view your profile at",
         "view_profile": "View your profile",
         "analytics_toggle": "Analytics",
-        "analytics_toggle_description": "Help Rainbow improve its products and services by allowing analytics of usage data. Collected data is not associated with you or your account."
+        "analytics_toggle_description": "Help Rainbow improve its products and services by allowing analytics of usage data. Collected data is not associated with you or your account. When disabled, only essential crash diagnostics are collected."
       },
       "restore": "Restore to original deployment",
       "review": "Review Rainbow",

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -5,7 +5,6 @@ import { type SeverityLevel } from '@sentry/types';
 
 import * as env from '@/env';
 import { DebugContext } from '@/logger/debugContext';
-import { device } from '@/storage';
 import { push } from '@/logger/logDump';
 import { getExperimentalFlag, LOG_PUSH } from '@/config/experimental';
 
@@ -214,22 +213,18 @@ export class Logger {
   LogLevel = LogLevel;
   DebugContext = DebugContext;
 
-  enabled: boolean;
   level: LogLevel;
   transports: Transport[] = [];
 
   protected debugContextRegexes: RegExp[] = [];
 
   constructor({
-    enabled = !device.get(['doNotTrack']),
     level = LOG_LEVEL as LogLevel,
     debug = LOG_DEBUG || '',
   }: {
-    enabled?: boolean;
     level?: LogLevel;
     debug?: string;
   } = {}) {
-    this.enabled = enabled !== false;
     this.level = debug ? LogLevel.Debug : level ?? LogLevel.Warn;
     this.debugContextRegexes = (debug || '').split(',').map(context => {
       return new RegExp(context.replace(/[^\w:*]/, '').replace(/\*/g, '.*'));
@@ -268,14 +263,6 @@ export class Logger {
     };
   }
 
-  disable() {
-    this.enabled = false;
-  }
-
-  enable() {
-    this.enabled = true;
-  }
-
   /**
    * Creates a scoped logger for service/SDK integration boundaries with
    * `[context]:` prefixed messages and debug-context filtering.
@@ -309,7 +296,6 @@ export class Logger {
   }
 
   protected transport(level: LogLevel, message: string | RainbowError, metadata?: Metadata) {
-    if (!this.enabled) return;
     if (!enabledLogLevels[this.level].includes(level)) return;
 
     const resolvedMetadata = metadata || EMPTY_METADATA;
@@ -328,10 +314,7 @@ export class Logger {
  *   `logger.debug(message[, metadata, debugContext])`
  *   `logger.info(message[, metadata])`
  *   `logger.warn(message[, metadata])`
- *   `logger.error(RainbowError[, metadata])`
- *   `logger.disable()`
- *   `logger.enable()`
- */
+ *   `logger.error(RainbowError[, metadata])` */
 export const logger = new Logger();
 
 /**

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -28,47 +28,14 @@ jest.mock('react-native-version-number', () => ({
 describe('general functionality', () => {
   test('default params', () => {
     const logger = new Logger();
-    expect(logger.enabled).toBeTruthy();
     expect(logger.level).toEqual(LogLevel.Warn);
   });
 
   test('can override default params', () => {
     const logger = new Logger({
-      enabled: true,
       level: LogLevel.Info,
     });
-    expect(logger.enabled).toBeTruthy();
     expect(logger.level).toEqual(LogLevel.Info);
-  });
-
-  test('disabled logger does not report', () => {
-    const logger = new Logger({
-      enabled: false,
-      level: LogLevel.Debug,
-    });
-
-    const mockTransport = jest.fn();
-
-    logger.addTransport(mockTransport);
-    logger.debug('message');
-
-    expect(mockTransport).not.toHaveBeenCalled();
-  });
-
-  test('disablement', () => {
-    const logger = new Logger({
-      enabled: true,
-      level: LogLevel.Debug,
-    });
-
-    logger.disable();
-
-    const mockTransport = jest.fn();
-
-    logger.addTransport(mockTransport);
-    logger.debug('message');
-
-    expect(mockTransport).not.toHaveBeenCalled();
   });
 
   test('passing debug contexts automatically enables debug mode', () => {
@@ -77,7 +44,7 @@ describe('general functionality', () => {
   });
 
   test('supports extra metadata', () => {
-    const logger = new Logger({ enabled: true });
+    const logger = new Logger();
 
     const mockTransport = jest.fn();
 
@@ -90,7 +57,7 @@ describe('general functionality', () => {
   });
 
   test('supports nullish/falsy metadata', () => {
-    const logger = new Logger({ enabled: true });
+    const logger = new Logger();
 
     const mockTransport = jest.fn();
 
@@ -119,7 +86,7 @@ describe('general functionality', () => {
   });
 
   test('logger.error expects a RainbowError', () => {
-    const logger = new Logger({ enabled: true });
+    const logger = new Logger();
 
     const mockTransport = jest.fn();
 
@@ -132,7 +99,6 @@ describe('general functionality', () => {
 
   test('createServiceLogger debug honors context filtering and prefixes messages', () => {
     const logger = new Logger({
-      enabled: true,
       debug: 'delegation',
     });
     const mockTransport = jest.fn();
@@ -147,7 +113,7 @@ describe('general functionality', () => {
   });
 
   test('createServiceLogger error wraps external errors into RainbowError', () => {
-    const logger = new Logger({ enabled: true, level: LogLevel.Error });
+    const logger = new Logger({ level: LogLevel.Error });
     const mockTransport = jest.fn();
     logger.addTransport(mockTransport);
 
@@ -251,7 +217,7 @@ describe('general functionality', () => {
   });
 
   test('add/remove transport', () => {
-    const logger = new Logger({ enabled: true });
+    const logger = new Logger();
     const mockTransport = jest.fn();
 
     const remove = logger.addTransport(mockTransport);
@@ -273,7 +239,6 @@ describe('debug contexts', () => {
   test('specific', () => {
     const message = nanoid();
     const logger = new Logger({
-      enabled: true,
       debug: 'specific',
     });
 
@@ -286,7 +251,6 @@ describe('debug contexts', () => {
   test('namespaced', () => {
     const message = nanoid();
     const logger = new Logger({
-      enabled: true,
       debug: 'namespace*',
     });
 
@@ -299,7 +263,6 @@ describe('debug contexts', () => {
   test('ignores inactive', () => {
     const message = nanoid();
     const logger = new Logger({
-      enabled: true,
       debug: 'namespace:foo:*',
     });
 
@@ -313,7 +276,6 @@ describe('debug contexts', () => {
 describe('supports levels', () => {
   test('debug', () => {
     const logger = new Logger({
-      enabled: true,
       level: LogLevel.Debug,
     });
     const message = nanoid();
@@ -337,7 +299,6 @@ describe('supports levels', () => {
 
   test('info', () => {
     const logger = new Logger({
-      enabled: true,
       level: LogLevel.Info,
     });
     const message = nanoid();
@@ -354,7 +315,6 @@ describe('supports levels', () => {
 
   test('warn', () => {
     const logger = new Logger({
-      enabled: true,
       level: LogLevel.Warn,
     });
     const message = nanoid();
@@ -374,7 +334,6 @@ describe('supports levels', () => {
 
   test('error', () => {
     const logger = new Logger({
-      enabled: true,
       level: LogLevel.Error,
     });
     const message = nanoid();

--- a/src/screens/SettingsSheet/components/PrivacySection.tsx
+++ b/src/screens/SettingsSheet/components/PrivacySection.tsx
@@ -29,12 +29,10 @@ const PrivacySection = () => {
         device.set(['doNotTrack'], true);
         logger.debug(`[PrivacySection]: Analytics tracking disabled`);
         analytics.track(analytics.event.analyticsTrackingDisabled);
-        logger.disable();
         analytics.disable();
         return false;
       } else {
         device.set(['doNotTrack'], false);
-        logger.enable();
         analytics.enable();
         logger.debug(`[PrivacySection]: Analytics tracking enabled`);
         analytics.track(analytics.event.analyticsTrackingEnabled);


### PR DESCRIPTION
When a user disables the "Analytics" toggle in privacy settings, the app currently disables both RudderStack analytics and the logger. Because the logger is the sole transport for JS errors and Sentry breadcrumbs in production, opting out of analytics silently kills all JavaScript-level error reporting. Native crashes still reach Sentry but arrive without breadcrumb context, making them much harder to diagnose.

The PII concern that likely motivated coupling these together is already handled server-side (we should also add client side scrubbing in general, but that's an issue for another time), and would apply equally to non-opted out users anyway. Sentry's project-level data scrubbing masks Ethereum addresses and transaction hashes before storage.

This change makes the privacy toggle control only product analytics (RudderStack/Amplitude). The logger and its Sentry transport now run unconditionally in production -- this is also matching how the browser extension works. The `enabled` property and `disable()`/`enable()` methods are removed from the `Logger` class since no callers remain. Wording is also added to tell users we still submit crash metrics when analytics is disabled.