### PR TITLE
feature: rnbw staking card and staking position stores

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -1,17 +1,24 @@
-import { memo } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { memo, useState, useCallback } from 'react';
+import { RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
 import { Box } from '@/design-system';
 import { AccountImage } from '@/components/AccountImage';
 import { Navbar } from '@/components/navbar/Navbar';
 import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
 import { RnbwAirdropClaimCard } from './components/RnbwAirdropClaimCard';
+import { RnbwStakingCard } from './components/RnbwStakingCard';
+import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
+import { delay } from '@/utils/delay';
+import { time } from '@/utils/time';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
   return (
     <View style={styles.flex}>
       <Navbar hasStatusBarInset title="Membership" leftComponent={<AccountImage />} />
-      <ScrollView contentContainerStyle={styles.scrollViewContentContainer} style={styles.flex}>
+      <ScrollView refreshControl={<RefreshControlWrapper />} contentContainerStyle={styles.scrollViewContentContainer} style={styles.flex}>
         <Box gap={16}>
+          <RnbwStakingCard />
           <RnbwRewardsClaimCard />
           <RnbwAirdropClaimCard />
         </Box>
@@ -19,6 +26,25 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
     </View>
   );
 });
+
+function RefreshControlWrapper() {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await Promise.allSettled([
+      Promise.allSettled([
+        useRewardsBalanceStore.getState().fetch(undefined, { force: true }),
+        useAirdropBalanceStore.getState().fetch(undefined, { force: true }),
+        useStakingPositionStore.getState().fetch(undefined, { force: true }),
+      ]),
+      delay(time.seconds(1)),
+    ]);
+    setIsRefreshing(false);
+  }, []);
+
+  return <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />;
+}
 
 const styles = StyleSheet.create({
   flex: {

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -1,0 +1,75 @@
+import { memo } from 'react';
+import { Text, Box } from '@/design-system';
+import { useRnbwStakingBalance } from '@/features/rnbw-staking/stores/derived/useRnbwStakingBalance';
+import { useStakableRnbwBalance } from '@/state/rnbw/useStakableRnbwBalance';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+
+export const RnbwStakingCard = memo(function RnbwStakingCard() {
+  const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
+  const { tokenAmountFormatted: availableAmount } = useStakableRnbwBalance();
+
+  return (
+    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+      <Text size="17pt" weight="bold" color="label">
+        {'Stake'}
+      </Text>
+      <Text size="44pt" weight="bold" color="label">
+        {nativeCurrencyAmount}
+      </Text>
+      <Text size="17pt" weight="bold" color="labelTertiary">
+        {`${tokenAmount} ${RNBW_SYMBOL}`}
+      </Text>
+      {!hasStakedPosition && (
+        <ButtonPressAnimation onPress={navigateToStakingLearnSheet}>
+          <Box backgroundColor="yellow" borderRadius={21} width={'full'} height={42} justifyContent="center" alignItems="center">
+            <Text size="17pt" weight="bold" color="label">
+              {'Enable Staking'}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+      )}
+      {hasStakedPosition && (
+        <Box flexDirection="row" gap={10}>
+          <ButtonPressAnimation onPress={navigateToUnstakeSheet} style={{ flex: 1 }}>
+            <Box
+              flexGrow={1}
+              backgroundColor="yellow"
+              borderRadius={21}
+              width={'full'}
+              height={42}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Text size="17pt" weight="bold" color="label">
+                {'Unstake'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+          <ButtonPressAnimation onPress={navigateToStakingScreen} style={{ flex: 1 }}>
+            <Box backgroundColor="yellow" borderRadius={21} width={'full'} height={42} justifyContent="center" alignItems="center">
+              <Text size="17pt" weight="bold" color="label">
+                {'Add'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+        </Box>
+      )}
+      <Text size="13pt" weight="semibold" color="labelTertiary" align="center">
+        {`${availableAmount} available to stake`}
+      </Text>
+    </Box>
+  );
+});
+
+function navigateToStakingLearnSheet() {
+  // TODO:
+}
+
+function navigateToStakingScreen() {
+  // TODO:
+}
+
+function navigateToUnstakeSheet() {
+  // TODO:
+}

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -1,0 +1,9 @@
+import { type Address } from 'viem';
+import { ChainId } from '@/state/backendNetworks/types';
+import { getUniqueId } from '@/utils/ethereumUtils';
+
+// TODO: test token address, use prod address later '0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0'
+export const RNBW_TOKEN_ADDRESS: Address = '0xb61832AD7859e64d8525E51d13De94d693475e6b';
+export const RNBW_CHAIN_ID = ChainId.base;
+export const RNBW_TOKEN_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
+export const RNBW_DECIMALS = 18;

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingBalance.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingBalance.ts
@@ -1,0 +1,34 @@
+import { convertAmountToNativeDisplayWorklet, convertRawAmountToDecimalFormat, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+import { useStakingPositionStore } from '../rnbwStakingPositionStore';
+import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
+
+type StakingBalance = {
+  tokenAmount: string;
+  nativeCurrencyAmount: string;
+  hasStakedPosition: boolean;
+};
+
+export const useRnbwStakingBalance = createDerivedStore<StakingBalance>(
+  $ => {
+    const data = $(useStakingPositionStore, state => state.getData());
+    const currency = $(userAssetsStoreManager, state => state.currency);
+
+    const rawStakedRnbw = data?.stakedRnbw ?? '0';
+    const stakedValueInCurrency = data?.stakedValueInCurrency ?? '0';
+    const decimals = data?.decimals ?? RNBW_DECIMALS;
+    const isZero = rawStakedRnbw === '0';
+
+    const decimalAmount = convertRawAmountToDecimalFormat(rawStakedRnbw, decimals);
+    const formattedTokenAmount = truncateToDecimalsWithThreshold({ value: decimalAmount, decimals: 1, threshold: '0.01' });
+
+    return {
+      tokenAmount: isZero ? '0' : formattedTokenAmount,
+      nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(stakedValueInCurrency, currency, !isZero),
+      hasStakedPosition: !isZero,
+    };
+  },
+  { equalityFn: shallowEqual, fastMode: true }
+);

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -1,0 +1,80 @@
+import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
+import { getPlatformClient } from '@/resources/platform/client';
+import { type PlatformResponse } from '@/resources/platform/types';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { useWalletsStore } from '@/state/wallets/walletsStore';
+import { ChainId } from '@/state/backendNetworks/types';
+import { type Address } from 'viem';
+
+type StakingTierLevel = 'STAKING_TIER_LEVEL_UNSPECIFIED' | string;
+
+type StakingTier = {
+  cashbackBps: number;
+  level: StakingTierLevel;
+  minStakeAmount: string;
+  name: string;
+};
+
+type StakingPnl = {
+  netProfit: string;
+  totalCashbackReceived: string;
+  totalExitFeePaid: string;
+  totalRnbwStaked: string;
+  totalRnbwUnstaked: string;
+};
+
+type StakingPositionData = {
+  allTiers: StakingTier[];
+  decimals: number;
+  hasPosition: boolean;
+  lastUpdateTime: string;
+  pnl: StakingPnl;
+  sessionPnl: StakingPnl;
+  poolShares: string;
+  stakedRnbw: string;
+  stakedValueInCurrency: string;
+  stakingStartTime: string;
+  tier: StakingTier;
+};
+
+type StakingPositionParams = {
+  currency: NativeCurrencyKey;
+  address: Address;
+};
+
+type StakingPositionStore = {
+  hasPosition: () => boolean;
+};
+
+export const useStakingPositionStore = createQueryStore<StakingPositionData, StakingPositionParams, StakingPositionStore>(
+  {
+    fetcher: fetchStakingPosition,
+    params: {
+      currency: $ => $(userAssetsStoreManager).currency,
+      address: $ => $(useWalletsStore).accountAddress,
+    },
+  },
+  (_, get) => ({
+    hasPosition: () => {
+      const data = get().getData();
+      return data?.hasPosition ?? false;
+    },
+  }),
+  { storageKey: 'rnbwStakingPosition' }
+);
+
+type StakingPositionResponse = PlatformResponse<StakingPositionData>;
+
+async function fetchStakingPosition({ currency, address }: StakingPositionParams): Promise<StakingPositionData> {
+  const response = await getPlatformClient().get<StakingPositionResponse>('/staking/GetStakingPosition', {
+    params: {
+      walletAddress: address,
+      chainId: String(ChainId.base),
+      currency,
+      includeTiers: String(true),
+    },
+  });
+
+  return response.data.result;
+}

--- a/src/state/rnbw/useStakableRnbwBalance.ts
+++ b/src/state/rnbw/useStakableRnbwBalance.ts
@@ -1,0 +1,30 @@
+import { convertAmountToNativeDisplayWorklet, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+import { RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
+
+type RnbwBalance = {
+  tokenAmountFormatted: string;
+  nativeCurrencyAmount: string;
+  hasBalance: boolean;
+};
+
+export const useStakableRnbwBalance = createDerivedStore<RnbwBalance>(
+  $ => {
+    const asset = $(useUserAssetsStore, state => state.getUserAsset(RNBW_TOKEN_UNIQUE_ID));
+    const currency = $(userAssetsStoreManager, state => state.currency);
+
+    const amount = asset?.balance?.amount ?? '0';
+    const nativeValue = asset?.native?.balance?.amount ?? '0';
+    const hasBalance = amount !== '0';
+
+    return {
+      tokenAmountFormatted: truncateToDecimalsWithThreshold({ value: amount, decimals: 2, threshold: '0.01' }),
+      nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(nativeValue, currency, hasBalance),
+      hasBalance,
+    };
+  },
+  { equalityFn: shallowEqual, fastMode: true }
+);


### PR DESCRIPTION
## What changed

Introduces basic staking position data to the `RnbwMembershipScreen`. 
  - `rnbwStakingPositionStore`: fetches users current staking position information
  - `useStakingBalance`: derived store that formats staked token and native currency amounts
  - `useStakableRnbwBalance`: derived store that reads the user's available RNBW token balance from user assets. Will later also add in unclaimed rnbw rewards.
  - `RnbwStakingCard`: Card for displaying staked tokens and
  stake/unstake/add actions
  - Add pull-to-refresh on the membership screen that re-fetches rewards, airdrop, and staking data (all the data for the cards currently in the list). 

## Screen recordings / screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-30 at 13 00 19" src="https://github.com/user-attachments/assets/2c442a00-b318-40b8-933a-85dbb75191e6" />

## What to test
If you would like to test if a staked balance shows up correctly, you can switch to a watched wallet that has a staked balance like 0xtester.eth.
