### PR TITLE
feature: basic manual staking flow

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -4,6 +4,8 @@ import { useRnbwStakingBalance } from '@/features/rnbw-staking/stores/derived/us
 import { useStakableRnbwBalance } from '@/state/rnbw/useStakableRnbwBalance';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
 
 export const RnbwStakingCard = memo(function RnbwStakingCard() {
   const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
@@ -63,11 +65,11 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
 });
 
 function navigateToStakingLearnSheet() {
-  // TODO:
+  Navigation.handleAction(Routes.RNBW_STAKING_LEARN_SCREEN);
 }
 
 function navigateToStakingScreen() {
-  // TODO:
+  Navigation.handleAction(Routes.RNBW_STAKING_SCREEN);
 }
 
 function navigateToUnstakeSheet() {

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -1,4 +1,4 @@
-import { type Address } from 'viem';
+import { parseAbi, type Address } from 'viem';
 import { ChainId } from '@/state/backendNetworks/types';
 import { getUniqueId } from '@/utils/ethereumUtils';
 
@@ -7,3 +7,12 @@ export const RNBW_TOKEN_ADDRESS: Address = '0xb61832AD7859e64d8525E51d13De94d693
 export const RNBW_CHAIN_ID = ChainId.base;
 export const RNBW_TOKEN_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 export const RNBW_DECIMALS = 18;
+
+export const STAKING_CHAIN_ID = ChainId.base;
+export const STAKING_CONTRACT_ADDRESS: Address = '0x616EB863bd79145c20B44A9A070A3651662D1EBD';
+export const STAKING_ABI = parseAbi([
+  'function stake(uint256 amount)',
+  'function unstakeAll()',
+  'function minStakeAmount() view returns (uint256)',
+]);
+export const STAKING_GAS_LIMIT = 200_000;

--- a/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
@@ -1,0 +1,64 @@
+import { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Text } from '@/design-system';
+import Routes from '@/navigation/routesNames';
+import Navigation from '@/navigation/Navigation';
+
+export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
+  const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
+
+  return (
+    <Box background="surfacePrimary" style={styles.container}>
+      <SheetHandleFixedToTop top={safeAreaTop + 6} />
+      <View style={[styles.content, { marginTop: safeAreaTop + 40, paddingBottom: safeAreaBottom + 8 }]}>
+        <Box alignItems="center" gap={16}>
+          <Text align="center" color="label" size="30pt" weight="heavy">
+            {'Earn More Rewards With Staking'}
+          </Text>
+          <Text align="center" color="labelTertiary" size="17pt" weight="medium">
+            {'Staking allows you to earn cashback rewards on your swaps.'}
+          </Text>
+        </Box>
+        <Box gap={20} paddingVertical={'20px'}>
+          <Text color="label" size="17pt" weight="bold">
+            {'Reason 1'}
+          </Text>
+          <Text color="label" size="17pt" weight="bold">
+            {'Reason 2'}
+          </Text>
+          <Text color="label" size="17pt" weight="bold">
+            {'Reason 3'}
+          </Text>
+        </Box>
+        <ButtonPressAnimation onPress={navigateToStakingScreen} style={styles.button}>
+          <Box backgroundColor="yellow" borderRadius={24} width={'full'} height={48} justifyContent="center" alignItems="center">
+            <Text color="label" size="22pt" weight="heavy">
+              {'Enable Staking'}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+      </View>
+    </Box>
+  );
+});
+
+function navigateToStakingScreen() {
+  Navigation.replace(Routes.RNBW_STAKING_SCREEN);
+}
+
+const styles = StyleSheet.create({
+  button: {
+    marginTop: 'auto',
+    width: '100%',
+  },
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+});

--- a/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen.tsx
@@ -1,0 +1,91 @@
+import { memo, useCallback, useState } from 'react';
+import { Alert, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
+import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
+import { Box, Stack, Text } from '@/design-system';
+import { useIsReadOnlyWallet, useIsHardwareWallet, useAccountAddress } from '@/state/wallets/walletsStore';
+import { useNavigation } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import watchingAlert from '@/utils/watchingAlert';
+import { logger, RainbowError } from '@/logger';
+import { stakeRnbw } from '@/features/rnbw-staking/utils/stakeRnbw';
+
+export const RnbwStakingScreen = memo(function RnbwStakingScreen() {
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const { goBack, navigate } = useNavigation();
+  const accountAddress = useAccountAddress();
+  const isReadOnlyWallet = useIsReadOnlyWallet();
+  const isHardwareWallet = useIsHardwareWallet();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const startStake = useCallback(async () => {
+    setIsProcessing(true);
+    try {
+      await stakeRnbw({ address: accountAddress, amount: '1' });
+      goBack();
+    } catch (e) {
+      setIsProcessing(false);
+      Alert.alert('Staking Failed', 'Something went wrong while staking. Please try again.');
+      logger.error(new RainbowError('[RnbwStakingScreen]: Staking failed', e));
+    }
+  }, [accountAddress, goBack]);
+
+  const handleStake = useCallback(async () => {
+    if (isReadOnlyWallet) {
+      watchingAlert();
+      return;
+    }
+    if (isHardwareWallet) {
+      navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: startStake });
+    } else {
+      await startStake();
+    }
+  }, [isReadOnlyWallet, isHardwareWallet, navigate, startStake]);
+
+  return (
+    <Box background="surfacePrimary" style={styles.container}>
+      <SheetHandleFixedToTop top={safeAreaTop + 6} />
+      <View style={[styles.content, { marginTop: safeAreaTop + 40 }]}>
+        <Stack space="24px">
+          <Text color="label" size="30pt" weight="heavy">
+            {'Stake RNBW'}
+          </Text>
+          <Text color="labelSecondary" size="17pt" weight="medium">
+            {'Stake 1 RNBW to enable membership rewards.'}
+          </Text>
+        </Stack>
+        <View style={styles.buttonContainer}>
+          <HoldToActivateButton
+            label="Hold to Stake"
+            processingLabel="Staking..."
+            onLongPress={handleStake}
+            isProcessing={isProcessing}
+            backgroundColor="white"
+            disabledBackgroundColor="white"
+            progressColor="black"
+            showBiometryIcon
+            style={styles.button}
+          />
+        </View>
+      </View>
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+  },
+  buttonContainer: {
+    marginTop: 'auto',
+    paddingBottom: 36,
+  },
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+});

--- a/src/features/rnbw-staking/utils/checkIfStakingNeedsApproval.ts
+++ b/src/features/rnbw-staking/utils/checkIfStakingNeedsApproval.ts
@@ -1,0 +1,19 @@
+import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { decodeFunctionResult, erc20Abi, encodeFunctionData, type Address, type Hex } from 'viem';
+import { STAKING_CONTRACT_ADDRESS, RNBW_TOKEN_ADDRESS } from '../constants';
+import { lessThanWorklet } from '@/framework/core/safeMath';
+
+export async function checkIfStakingNeedsApproval({
+  address,
+  provider,
+  stakeAmountRaw,
+}: {
+  address: Address;
+  provider: StaticJsonRpcProvider;
+  stakeAmountRaw: string;
+}): Promise<boolean> {
+  const data = encodeFunctionData({ abi: erc20Abi, functionName: 'allowance', args: [address, STAKING_CONTRACT_ADDRESS] });
+  const result = await provider.call({ to: RNBW_TOKEN_ADDRESS, data });
+  const currentAllowance = decodeFunctionResult({ abi: erc20Abi, functionName: 'allowance', data: result as Hex });
+  return lessThanWorklet(currentAllowance.toString(), stakeAmountRaw);
+}

--- a/src/features/rnbw-staking/utils/pollForStakingUpdate.ts
+++ b/src/features/rnbw-staking/utils/pollForStakingUpdate.ts
@@ -1,0 +1,24 @@
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { useUserAssetsStore } from '@/state/assets/userAssets';
+import { delay } from '@/utils/delay';
+import { time } from '@/utils/time';
+
+const POLL_INTERVAL_MS = time.seconds(1);
+const MAX_POLL_ATTEMPTS = 5;
+
+export async function pollForStakingUpdate(originalStakedRnbwShares: string): Promise<boolean> {
+  for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt++) {
+    await useStakingPositionStore.getState().fetch(undefined, { force: true });
+
+    const currentStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares;
+
+    if (currentStakedRnbwShares !== originalStakedRnbwShares) {
+      await useUserAssetsStore.getState().fetch(undefined, { force: true });
+      return true;
+    }
+
+    await delay(POLL_INTERVAL_MS);
+  }
+
+  return false;
+}

--- a/src/features/rnbw-staking/utils/stakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbw.ts
@@ -1,0 +1,22 @@
+import { parseUnits, type Address, type Hash } from 'viem';
+import { stakeRnbwManual } from './stakeRnbwManual';
+import { getProvider } from '@/handlers/web3';
+import { RNBW_DECIMALS, STAKING_CHAIN_ID } from '../constants';
+import { useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
+import { pollForStakingUpdate } from './pollForStakingUpdate';
+import { loadWallet } from '@/model/wallet';
+
+export async function stakeRnbw({ address, amount }: { address: Address; amount: string }): Promise<Hash> {
+  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+  const signer = await loadWallet({ address, provider });
+  if (!signer) {
+    throw new Error('Failed to load wallet');
+  }
+
+  const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
+  const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
+  const transactionHash: Hash = await stakeRnbwManual({ signer, address, provider, stakeAmountRaw });
+  await pollForStakingUpdate(originalStakedRnbwShares);
+
+  return transactionHash;
+}

--- a/src/features/rnbw-staking/utils/stakeRnbwManual.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbwManual.ts
@@ -1,0 +1,37 @@
+import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { type Signer } from '@ethersproject/abstract-signer';
+import { erc20Abi, encodeFunctionData, type Address, type Hash } from 'viem';
+import { STAKING_CONTRACT_ADDRESS, STAKING_ABI, RNBW_TOKEN_ADDRESS, STAKING_GAS_LIMIT } from '../constants';
+import { checkIfStakingNeedsApproval } from './checkIfStakingNeedsApproval';
+
+export async function stakeRnbwManual({
+  address,
+  signer,
+  provider,
+  stakeAmountRaw,
+}: {
+  address: Address;
+  signer: Signer;
+  provider: StaticJsonRpcProvider;
+  stakeAmountRaw: string;
+}): Promise<Hash> {
+  const needsApproval = await checkIfStakingNeedsApproval({ address, provider, stakeAmountRaw });
+  const stakeAmountBigInt = BigInt(stakeAmountRaw);
+  if (needsApproval) {
+    const approveTx = await signer.sendTransaction({
+      to: RNBW_TOKEN_ADDRESS,
+      data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [STAKING_CONTRACT_ADDRESS, stakeAmountBigInt] }),
+    });
+    await approveTx.wait();
+  }
+
+  const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'stake', args: [stakeAmountBigInt] });
+  const tx = await signer.sendTransaction({
+    to: STAKING_CONTRACT_ADDRESS,
+    data,
+    gasLimit: STAKING_GAS_LIMIT,
+  });
+  await tx.wait();
+
+  return tx.hash as Hash;
+}

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -119,6 +119,8 @@ import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polym
 import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
+import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen';
+import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
 
@@ -309,6 +311,8 @@ function BSNavigator() {
       <BSStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
       <BSStack.Screen component={RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} />
       <BSStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
+      <BSStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} />
+      <BSStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
       <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
     </BSStack.Navigator>
   );

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -143,6 +143,8 @@ import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polym
 import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
 import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet';
 import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
+import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen';
+import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 
 const Stack = createStackNavigator();
@@ -349,6 +351,8 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} {...panelConfig} />
       <NativeStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
 
       <NativeStack.Screen
         component={PolymarketBrowseEventsScreen}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -145,6 +145,8 @@ const Routes = {
   RNBW_REWARDS_SCREEN: 'RnbwRewardsScreen',
   RNBW_REWARDS_CLAIM_SHEET: 'RnbwRewardsClaimSheet',
   RNBW_REWARDS_ESTIMATE_SHEET: 'RnbwRewardsEstimateSheet',
+  RNBW_STAKING_LEARN_SCREEN: 'RnbwStakingLearnScreen',
+  RNBW_STAKING_SCREEN: 'RnbwStakingScreen',
   WALLET_ERROR_SHEET: 'WalletErrorSheet',
 } as const;
 

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -719,6 +719,8 @@ type RouteParams = {
   [Routes.RNBW_REWARDS_ESTIMATE_SHEET]: {
     estimatedAmount: string;
   };
+  [Routes.RNBW_STAKING_LEARN_SCREEN]: undefined;
+  [Routes.RNBW_STAKING_SCREEN]: undefined;
   [Routes.REVOKE_DELEGATION_PANEL]: {
     address: Address;
     delegationsToRevoke: Array<{


### PR DESCRIPTION
Fixes APP-3559

## What changed (plus any additional context for devs)
- Added staking UI screens: `RnbwStakingScreen` and `RnbwStakingLearnScreen`.
- Added fixed 1 RNBW staking via direct contract interaction. 
- Wired up navigation from the membership staking card to the new staking screens.
- Added staking constants (contract address, ABI, gas limit) and utilities for approval checking,
  manual staking, and polling for staking state updates.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/0576ab03-943c-4e6c-a526-0c337a390e4e

## What to test

Enabling staking -> Hold to stake should result in exactly 1 RNBW being staked.
