### PR TITLE
feature: sponsored staking flow

### DIFF
--- a/src/features/delegation/utils/isRainbowDelegatedForChain.ts
+++ b/src/features/delegation/utils/isRainbowDelegatedForChain.ts
@@ -1,0 +1,9 @@
+import { type ChainId } from '@/state/backendNetworks/types';
+import type { Address } from 'viem';
+import { DelegationStatus, getDelegations } from '@rainbow-me/delegation';
+
+export async function isRainbowDelegatedForChain(address: Address, chainId: ChainId): Promise<boolean> {
+  const delegations = await getDelegations({ address });
+  const chainDelegation = delegations.find(delegation => delegation.chainId === chainId);
+  return chainDelegation?.delegationStatus === DelegationStatus.RAINBOW_DELEGATED;
+}

--- a/src/features/delegation/utils/signBatchedCall.ts
+++ b/src/features/delegation/utils/signBatchedCall.ts
@@ -1,0 +1,260 @@
+import { type Address, type Hex, decodeFunctionResult, encodeAbiParameters, encodeFunctionData, zeroAddress, zeroHash } from 'viem';
+import { signTypedDataMessage } from '@/model/wallet';
+import { getProvider } from '@/handlers/web3';
+import { time } from '@/utils/time';
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import type { Signer } from '@ethersproject/abstract-signer';
+
+type BatchCallForSigning = {
+  to: Address;
+  value: bigint;
+  data: Hex;
+};
+
+type CaliburDomain = {
+  name: string;
+  version: string;
+  chainId: number;
+  verifyingContract: Address;
+  salt: Hex;
+};
+
+type SignedBatchedCall = {
+  batchedCall: {
+    calls: BatchCallForSigning[];
+    revertOnFailure: boolean;
+  };
+  nonce: bigint;
+  keyHash: Hex;
+  executor: Address;
+  deadline: bigint;
+};
+
+/**
+ * Signs a batched call using EIP-712 and encodes the `execute(SignedBatchedCall, bytes)`
+ * calldata for the Calibur delegation contract. This allows any address (e.g. a Gelato
+ * relayer) to submit the transaction on behalf of the user.
+ */
+export async function prepareSignedBatchedCalldata({
+  signer,
+  address,
+  chainId,
+  calls,
+  keyHash = ROOT_KEY_HASH,
+  executor = PERMISSIONLESS_EXECUTOR,
+  deadline = BigInt(Math.floor(Date.now() / 1000) + time.hours(1) / 1000),
+  nonceKey = ROOT_NONCE_KEY,
+  revertOnFailure = true,
+}: {
+  signer: Signer;
+  address: Address;
+  chainId: number;
+  calls: BatchCallForSigning[];
+  keyHash?: Hex;
+  executor?: Address;
+  deadline?: bigint;
+  nonceKey?: bigint;
+  revertOnFailure?: boolean;
+}): Promise<{ to: Address; data: Hex }> {
+  const provider = getProvider({ chainId });
+  const { nonce, domain } = await fetchCaliburNonceAndDomain({ address, provider, nonceKey });
+
+  const signedBatchedCall: SignedBatchedCall = {
+    batchedCall: {
+      calls,
+      revertOnFailure,
+    },
+    nonce,
+    keyHash,
+    executor,
+    deadline,
+  };
+
+  const rawSignature = await signBatchedCallTypedData({
+    signer,
+    provider,
+    domain,
+    signedBatchedCall,
+  });
+  const wrappedSignature = encodeAbiParameters([{ type: 'bytes' }, { type: 'bytes' }], [rawSignature, EMPTY_HOOK_DATA]);
+
+  // Encode the execute(SignedBatchedCall, bytes) calldata
+  const data = encodeFunctionData({
+    abi: caliberAbi,
+    functionName: 'execute',
+    args: [signedBatchedCall, wrappedSignature],
+  });
+
+  return { to: address, data };
+}
+
+async function fetchCaliburNonceAndDomain({
+  address,
+  provider,
+  nonceKey,
+}: {
+  address: Address;
+  provider: StaticJsonRpcProvider;
+  nonceKey: bigint;
+}): Promise<{ nonce: bigint; domain: CaliburDomain }> {
+  const getSeqData = encodeFunctionData({ abi: caliberAbi, functionName: 'getSeq', args: [nonceKey] });
+  const nonceSequenceResult = await provider.call({ to: address, data: getSeqData });
+  const nonceSequence = decodeFunctionResult({
+    abi: caliberAbi,
+    functionName: 'getSeq',
+    data: nonceSequenceResult as Hex,
+  });
+  const nonce = (nonceKey << 64n) | nonceSequence;
+
+  const eip712DomainData = encodeFunctionData({ abi: caliberAbi, functionName: 'eip712Domain' });
+  const eip712DomainResult = await provider.call({ to: address, data: eip712DomainData });
+  const [, name, version, chainId, verifyingContract, salt] = decodeFunctionResult({
+    abi: caliberAbi,
+    functionName: 'eip712Domain',
+    data: eip712DomainResult as Hex,
+  });
+
+  return {
+    nonce,
+    domain: {
+      name,
+      version,
+      chainId: Number(chainId.toString()),
+      verifyingContract,
+      salt,
+    },
+  };
+}
+
+async function signBatchedCallTypedData({
+  signer,
+  provider,
+  domain,
+  signedBatchedCall,
+}: {
+  signer: Signer;
+  provider: StaticJsonRpcProvider;
+  domain: CaliburDomain;
+  signedBatchedCall: SignedBatchedCall;
+}): Promise<Hex> {
+  const typedData = {
+    types: EIP712_TYPES,
+    primaryType: 'SignedBatchedCall',
+    domain,
+    message: {
+      batchedCall: {
+        calls: signedBatchedCall.batchedCall.calls.map(c => ({ to: c.to, value: c.value.toString(), data: c.data })),
+        revertOnFailure: signedBatchedCall.batchedCall.revertOnFailure,
+      },
+      nonce: signedBatchedCall.nonce.toString(),
+      keyHash: signedBatchedCall.keyHash,
+      executor: signedBatchedCall.executor,
+      deadline: signedBatchedCall.deadline.toString(),
+    },
+  };
+
+  const signResult = await signTypedDataMessage(typedData, provider, signer);
+  if (!signResult?.result || signResult?.error) {
+    throw new Error(`Failed to sign batched call: ${signResult?.error?.message ?? 'Unknown error'}`);
+  }
+
+  return signResult.result as Hex;
+}
+
+/**
+ * Subset of the Calibur ABI used for local helpers.
+ * https://github.com/Uniswap/calibur
+ */
+const caliberAbi = [
+  {
+    name: 'execute',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: 'signedBatchedCall',
+        type: 'tuple',
+        components: [
+          {
+            name: 'batchedCall',
+            type: 'tuple',
+            components: [
+              {
+                name: 'calls',
+                type: 'tuple[]',
+                components: [
+                  { name: 'to', type: 'address' },
+                  { name: 'value', type: 'uint256' },
+                  { name: 'data', type: 'bytes' },
+                ],
+              },
+              { name: 'revertOnFailure', type: 'bool' },
+            ],
+          },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'keyHash', type: 'bytes32' },
+          { name: 'executor', type: 'address' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      },
+      { name: 'wrappedSignature', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'getSeq',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'key', type: 'uint256' }],
+    outputs: [{ name: 'seq', type: 'uint256' }],
+  },
+  {
+    name: 'eip712Domain',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [
+      { name: 'fields', type: 'bytes1' },
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+      { name: 'extensions', type: 'uint256[]' },
+    ],
+  },
+] as const;
+
+/** The root EOA owner key in Calibur is always bytes32(0) */
+const ROOT_KEY_HASH = zeroHash;
+
+/** address(0) for executor means any address can relay */
+const PERMISSIONLESS_EXECUTOR = zeroAddress;
+const ROOT_NONCE_KEY = 0n;
+const EMPTY_HOOK_DATA = '0x';
+
+const EIP712_TYPES = {
+  EIP712Domain: [
+    { name: 'name', type: 'string' },
+    { name: 'version', type: 'string' },
+    { name: 'chainId', type: 'uint256' },
+    { name: 'verifyingContract', type: 'address' },
+    { name: 'salt', type: 'bytes32' },
+  ],
+  SignedBatchedCall: [
+    { name: 'batchedCall', type: 'BatchedCall' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'keyHash', type: 'bytes32' },
+    { name: 'executor', type: 'address' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+  BatchedCall: [
+    { name: 'calls', type: 'Call[]' },
+    { name: 'revertOnFailure', type: 'bool' },
+  ],
+  Call: [
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'data', type: 'bytes' },
+  ],
+};

--- a/src/features/rnbw-staking/utils/stakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbw.ts
@@ -1,10 +1,13 @@
 import { parseUnits, type Address, type Hash } from 'viem';
 import { stakeRnbwManual } from './stakeRnbwManual';
+import { stakeRnbwSponsored } from './stakeRnbwSponsored';
 import { getProvider } from '@/handlers/web3';
 import { RNBW_DECIMALS, STAKING_CHAIN_ID } from '../constants';
 import { useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
 import { loadWallet } from '@/model/wallet';
+import { isRainbowDelegatedForChain } from '@/features/delegation/utils/isRainbowDelegatedForChain';
+import { Alert } from 'react-native';
 
 export async function stakeRnbw({ address, amount }: { address: Address; amount: string }): Promise<Hash> {
   const provider = getProvider({ chainId: STAKING_CHAIN_ID });
@@ -12,11 +15,18 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
   if (!signer) {
     throw new Error('Failed to load wallet');
   }
+  const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
+  const isRainbowDelegated = await isRainbowDelegatedForChain(address, STAKING_CHAIN_ID);
 
   const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
-  const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
-  const transactionHash: Hash = await stakeRnbwManual({ signer, address, provider, stakeAmountRaw });
+
+  const transactionHash: Hash = isRainbowDelegated
+    ? await stakeRnbwSponsored({ signer, address, provider, stakeAmountRaw })
+    : await stakeRnbwManual({ signer, address, provider, stakeAmountRaw });
+
   await pollForStakingUpdate(originalStakedRnbwShares);
 
+  // TODO: For testing. Remove
+  Alert.alert(`Staked: ${amount} RNBW (${isRainbowDelegated ? 'Sponsored' : 'Manual'})`, transactionHash);
   return transactionHash;
 }

--- a/src/features/rnbw-staking/utils/stakeRnbwSponsored.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbwSponsored.ts
@@ -1,0 +1,89 @@
+import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { type BatchCall } from '@rainbow-me/delegation';
+import { createGelatoEvmRelayerClient } from '@gelatocloud/gasless/_dist/relayer/evm/index.js';
+import { erc20Abi, encodeFunctionData, type Address, type Hash, type Hex } from 'viem';
+import { GELATO_API_KEY } from 'react-native-dotenv';
+import { getProvider, toHex } from '@/handlers/web3';
+import { RainbowError } from '@/logger';
+import { time } from '@/utils/time';
+import { STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_ABI, RNBW_TOKEN_ADDRESS } from '../constants';
+import { prepareSignedBatchedCalldata } from '../../delegation/utils/signBatchedCall';
+import { checkIfStakingNeedsApproval } from './checkIfStakingNeedsApproval';
+import type { Signer } from '@ethersproject/abstract-signer';
+
+export async function stakeRnbwSponsored({
+  signer,
+  address,
+  provider,
+  stakeAmountRaw,
+}: {
+  signer: Signer;
+  address: Address;
+  provider: StaticJsonRpcProvider;
+  stakeAmountRaw: string;
+}): Promise<Hash> {
+  const calls = await buildStakeCalls({ address, provider, stakeAmountRaw });
+
+  const signedTx = await prepareSignedBatchedCalldata({
+    signer,
+    address,
+    chainId: STAKING_CHAIN_ID,
+    calls: calls.map(c => ({ to: c.to, value: BigInt(c.value), data: c.data })),
+  });
+
+  return relayTransaction({ from: address, chainId: STAKING_CHAIN_ID, to: signedTx.to, data: signedTx.data });
+}
+
+async function relayTransaction({ from, chainId, to, data }: { from: Address; chainId: number; to: Address; data: Hex }): Promise<Hash> {
+  const provider = getProvider({ chainId });
+
+  const gasEstimate = await provider.estimateGas({ from, to, data });
+
+  const gelatoRelayer = createGelatoEvmRelayerClient({
+    apiKey: GELATO_API_KEY,
+    pollingInterval: time.ms(500),
+    timeout: time.seconds(30),
+  });
+
+  const taskId = await gelatoRelayer.sendTransaction({ chainId, to, data, skipSimulation: true, gas: gasEstimate.toBigInt() });
+  const receipt = await gelatoRelayer.waitForReceipt({ id: taskId }, { usePolling: true });
+
+  if (!receipt.transactionHash) {
+    throw new RainbowError('[stakeRnbwSponsored]: gelato relay failed - no transaction hash');
+  }
+
+  if (receipt.status !== 'success') {
+    throw new RainbowError('[stakeRnbwSponsored]: gelato relay failed - transaction failed');
+  }
+
+  return receipt.transactionHash;
+}
+
+async function buildStakeCalls({
+  address,
+  provider,
+  stakeAmountRaw,
+}: {
+  address: Address;
+  provider: StaticJsonRpcProvider;
+  stakeAmountRaw: string;
+}): Promise<BatchCall[]> {
+  const calls: BatchCall[] = [];
+
+  const needsApproval = await checkIfStakingNeedsApproval({ address, provider, stakeAmountRaw });
+  if (needsApproval) {
+    calls.push({
+      to: RNBW_TOKEN_ADDRESS,
+      value: toHex(0),
+      data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [STAKING_CONTRACT_ADDRESS, BigInt(stakeAmountRaw)] }),
+    });
+  }
+
+  calls.push({
+    to: STAKING_CONTRACT_ADDRESS,
+    value: toHex(0),
+    data: encodeFunctionData({ abi: STAKING_ABI, functionName: 'stake', args: [BigInt(stakeAmountRaw)] }),
+  });
+
+  return calls;
+}


### PR DESCRIPTION
Fixes APP-3560

## What changed (plus any additional context for devs)

Adds sponsored RNBW staking for wallets with Rainbow delegation. Note this flow will not attempt to delegate the wallet if it is not already delegated. 

- Sponsored flow batches approve + stake calls into a single signed EIP-712 message (Calibur SignedBatchedCall), then relays via Gelato for execution.
- `signBatchedCall`: Signs batched calls against the Calibur delegation contract so that Gelato can relay them. 
    - This was written as a proof of concept by @christianbaroni, with only minor changes made here. In theory this is code that belongs in the `@rainbow-me/delegation` package, but the decision was made to inline it here given there is a more robust gasless solution coming soon that will replace this implementation.


## Screen recordings / screenshots

https://github.com/user-attachments/assets/f30d70e5-4af1-4b2d-9e64-5f560d533966

## What to test

Staking flow with a 7702 enabled wallet.
