### PR TITLE
chore(design-system): decouple playground from production bundle

### DIFF
--- a/index.playground.js
+++ b/index.playground.js
@@ -1,0 +1,22 @@
+import './shim';
+import { AppRegistry, StyleSheet } from 'react-native';
+import React from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { Playground } from './src/design-system/playground/Playground';
+import { MainThemeProvider } from './src/theme/ThemeContext';
+
+const sx = StyleSheet.create({
+  container: { flex: 1, overflow: 'hidden' },
+});
+
+function PlaygroundApp() {
+  return (
+    <MainThemeProvider>
+      <GestureHandlerRootView style={sx.container}>
+        <Playground />
+      </GestureHandlerRootView>
+    </MainThemeProvider>
+  );
+}
+
+AppRegistry.registerComponent('Rainbow', () => PlaygroundApp);

--- a/metro.config.js
+++ b/metro.config.js
@@ -41,6 +41,14 @@ if (process.env.CI) {
  * @type {import('metro-config').MetroConfig}
  */
 const rainbowConfig = {
+  server: {
+    rewriteRequestUrl: url => {
+      if (process.env.DS_PLAYGROUND && url.includes('index.bundle')) {
+        return url.replace('index.bundle', 'index.playground.bundle');
+      }
+      return url;
+    },
+  },
   resolver: {
     blacklistRE,
     resolveRequest: (context, moduleName, platform) => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "rc-push": "./scripts/rc-push.sh",
     "ds:install": "cd src/design-system/docs && yarn install",
     "ds": "cd src/design-system/docs && yarn dev",
+    "ds:playground": "DS_PLAYGROUND=1 react-native start",
     "fast": "yarn install && yarn setup && yarn install-pods-fast",
     "gradle": "cd android && ./gradlew",
     "anvil": "sh ./scripts/anvil.sh",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,8 @@ import { enableScreens } from 'react-native-screens';
 import { RecoilRoot } from 'recoil';
 import ErrorBoundary from '@/components/error-boundary/ErrorBoundary';
 import { OfflineToast } from '@/components/toasts';
-import { designSystemPlaygroundEnabled, reactNativeDisableYellowBox, showNetworkRequests, showNetworkResponses } from '@/config/debug';
+import { reactNativeDisableYellowBox, showNetworkRequests, showNetworkResponses } from '@/config/debug';
 import monitorNetwork from '@/debugging/network';
-import { Playground } from '@/design-system/playground/Playground';
 import RainbowContextWrapper from '@/helpers/RainbowContext';
 import { setNavigationRef } from '@/navigation/Navigation';
 import { PersistQueryClientProvider, persistOptions, queryClient } from '@/react-query';
@@ -147,18 +146,7 @@ function Root() {
 /** Wrapping Root allows Sentry to accurately track startup times */
 const RootWithSentry = Sentry.wrap(Root);
 
-const PlaygroundWithReduxStore = () => (
-  // @ts-expect-error - Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Provider<AppStateUpdateAction | ChartsUpdateAction | ContactsAction | ... 13 more ... | WalletsAction>> & Readonly<...>'
-  <ReduxProvider store={store}>
-    <MainThemeProvider>
-      <GestureHandlerRootView style={sx.container}>
-        <Playground />
-      </GestureHandlerRootView>
-    </MainThemeProvider>
-  </ReduxProvider>
-);
-
-AppRegistry.registerComponent('Rainbow', () => (designSystemPlaygroundEnabled ? PlaygroundWithReduxStore : RootWithSentry));
+AppRegistry.registerComponent('Rainbow', () => RootWithSentry);
 
 // The report param is not currently used as we have our own time tracking, but it is available at the time we want to finish the app startup report
 function onReportPrepared() {

--- a/src/config/defaultDebug.ts
+++ b/src/config/defaultDebug.ts
@@ -17,4 +17,3 @@ export const showNetworkResponses = false;
 export const arbitrumEnabled = false;
 export const optimismEnabled = false;
 export const polygonEnabled = false;
-export const designSystemPlaygroundEnabled = false;

--- a/src/design-system/README.md
+++ b/src/design-system/README.md
@@ -2,18 +2,12 @@
 
 The Rainbow Design System documentation is currently available at [https://rds-jxom.vercel.app](https://rds-jxom.vercel.app).
 
-To view the documentation locally while working on the app, run `yarn ds` and open http://localhost:3000.
+To view the documentation locally, run `yarn ds:install && yarn ds` and open http://localhost:3000.
 
-## Contribution
+## Playground
 
-To view the design system components in isolation, ensure the following line is in `src/config/debug.js`.
+To view the design system components in isolation on a device/simulator, run `yarn ds:playground`. This starts Metro with a separate entry point that renders the playground instead of the wallet app.
 
-```
-export const designSystemPlaygroundEnabled = true;
-```
+The playground shell lives in `src/design-system/playground/` and imports `*.playground.tsx` files colocated with each component.
 
-This causes the app to render the design system playground instead of the regular app. The playground code is sourced from `src/design-system/playground/Playground.tsx`. This screen imports files named `*.docs.tsx` from each component folder.
-
-When adding a new component, please ensure that it has a matching docs file and that it's imported in the main `Playground` component.
-
-When adding a new text/heading size, please ensure that you've added an example to the respective `*.docs.tsx` file and validate that the space is being trimmed correctly above capital letters and below the baseline on both iOS and Android.
+When adding a new text/heading size, please ensure that you've added an example to the respective `*.playground.tsx` file and validate that the space is being trimmed correctly above capital letters and below the baseline on both iOS and Android.

--- a/src/design-system/README.md
+++ b/src/design-system/README.md
@@ -10,4 +10,6 @@ To view the design system components in isolation on a device/simulator, run `ya
 
 The playground shell lives in `src/design-system/playground/` and imports `*.playground.tsx` files colocated with each component.
 
+When adding a new component, please ensure that it has a matching `*.playground.tsx` file and that it's imported in the main `Playground` component.
+
 When adding a new text/heading size, please ensure that you've added an example to the respective `*.playground.tsx` file and validate that the space is being trimmed correctly above capital letters and below the baseline on both iOS and Android.

--- a/src/design-system/typography/typeHierarchy.ts
+++ b/src/design-system/typography/typeHierarchy.ts
@@ -13,11 +13,10 @@
  * that these corrections are made at the lowest level possible and updated
  * whenever `fontSize` and/or `lineHeight` values are added or updated.
  *
- * While adding/updating margin corrections, edit `src/config/debug.ts` and set
- * `designSystemPlaygroundEnabled` to `true`. This will cause the design system
- * playground to be rendered instead of the app itself. You can then expand the
- * text examples and check that the vertical alignment is correct while
- * updating the values. This will require some trial and error. Note that React
+ * While adding/updating margin corrections, run `yarn ds:playground` to launch
+ * the design system playground. You can then expand the text examples and
+ * check that the vertical alignment is correct while updating the values.
+ * This will require some trial and error. Note that React
  * Native automatically rounds these to the nearest device pixel so you might
  * not see any difference until a large enough change has been made.
  *


### PR DESCRIPTION
The design system playground is statically imported in `App.tsx` and gated by a runtime boolean (`designSystemPlaygroundEnabled`). Metro can't tree-shake runtime conditionals, so the entire playground component tree (`33` files including all `*.playground.tsx` and `*.examples.tsx` stories) ships in every production build. Bundle analysis confirmed `~83 KB` of dead code across `49` source files that no user ever executes.

This change introduces a separate Metro entry point (`index.playground.js`) that replaces the in-app flag. Metro's `rewriteRequestUrl` swaps the bundle when the `DS_PLAYGROUND` env var is set, so `yarn ds:playground` launches the playground without any coupling to the main app. `App.tsx` no longer imports or references the playground at all. The playground files stay in `src/design-system/` where they were, colocated with the components they document. Only the entry path changed, not the file structure.

The playground previously relied on `ReduxProvider` from the main app wrapper, but testing confirmed the DS components only need `MainThemeProvider`. The leaner provider tree in the new entry point means the playground no longer pulls in the Redux store and its transitive dependency graph (gas reducers, swap logic, etc.) that it never used.

To use: run `yarn ds:playground` in one terminal, then launch the app on a device/simulator as normal.