### PR TITLE
feature: basic membership tier card

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -7,6 +7,7 @@ import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
 import { RnbwAirdropClaimCard } from './components/RnbwAirdropClaimCard';
 import { RnbwUnstakePenaltyRecoveryCard } from './components/RnbwUnstakePenaltyRecoveryCard';
 import { RnbwStakingCard } from './components/RnbwStakingCard';
+import { MembershipTierCard } from './components/MembershipTierCard';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
 import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
@@ -21,6 +22,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
         <Box gap={16}>
           <RnbwStakingCard />
           <RnbwUnstakePenaltyRecoveryCard />
+          <MembershipTierCard />
           <RnbwRewardsClaimCard />
           <RnbwAirdropClaimCard />
         </Box>

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
@@ -1,0 +1,24 @@
+import { memo } from 'react';
+import { Box, Text } from '@/design-system';
+import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
+
+export const MembershipTierCard = memo(function MembershipTierCard() {
+  const { currentTier, stakeRequiredForNextTier, cashbackPercentage, currentTierProgress } = useMembershipTierInfo();
+
+  return (
+    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+      <Text size="22pt" weight="heavy" color="label">
+        {`${currentTier.name} Tier`}
+      </Text>
+      <Text size="17pt" weight="heavy" color="label">
+        {`current tier progress: ${currentTierProgress * 100}/100`}
+      </Text>
+      <Text size="17pt" weight="heavy" color="label">
+        {`Cashback: ${cashbackPercentage}%`}
+      </Text>
+      <Text size="17pt" weight="heavy" color="label">
+        {`Stake to unlock: ${stakeRequiredForNextTier}`}
+      </Text>
+    </Box>
+  );
+});

--- a/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
+++ b/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
@@ -1,0 +1,58 @@
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { divWorklet, subWorklet, toFixedWorklet } from '@/framework/core/safeMath';
+import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
+import { convertBipsToPercentage, convertRawAmountToDecimalFormat } from '@/helpers/utilities';
+import { formatNumber } from '@/helpers/strings';
+import type { Tier } from '@/features/rnbw-membership/types';
+
+type MembershipTierInfo = {
+  currentTier: Tier;
+  stakeRequiredForNextTier: string;
+  cashbackPercentage: string;
+  currentTierProgress: number;
+};
+
+const EMPTY_TIER: MembershipTierInfo = {
+  currentTier: {
+    level: 'STAKING_TIER_LEVEL_BASIC',
+    name: 'Basic',
+    cashbackBps: 1_000,
+    minStakeAmount: '0',
+  },
+  stakeRequiredForNextTier: '0',
+  cashbackPercentage: '10%',
+  currentTierProgress: 0,
+};
+
+export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
+  $ => {
+    const data = $(useStakingPositionStore, state => state.getData());
+
+    if (!data) {
+      return EMPTY_TIER;
+    }
+
+    const { tier: currentTier, allTiers, stakedRnbw } = data;
+
+    const currentTierIndex = allTiers.findIndex(t => t.level === currentTier.level);
+    const nextTierIndex = currentTierIndex + 1;
+    const nextTier = nextTierIndex < allTiers.length ? allTiers[nextTierIndex] : null;
+
+    const stakeRequiredForNextTierRaw = nextTier ? subWorklet(nextTier.minStakeAmount, stakedRnbw) : '0';
+    const stakeRequiredForNextTier = formatNumber(convertRawAmountToDecimalFormat(stakeRequiredForNextTierRaw, RNBW_DECIMALS));
+    const cashbackPercentage = convertBipsToPercentage(currentTier.cashbackBps, 0);
+    const stakedAboveCurrentTier = subWorklet(stakedRnbw, currentTier.minStakeAmount);
+    const currentTierRange = subWorklet(nextTier?.minStakeAmount ?? currentTier.minStakeAmount, currentTier.minStakeAmount);
+    const currentTierProgress = nextTier ? Number(toFixedWorklet(divWorklet(stakedAboveCurrentTier, currentTierRange), 3)) : 1;
+
+    return {
+      currentTier,
+      stakeRequiredForNextTier,
+      cashbackPercentage,
+      currentTierProgress,
+    };
+  },
+  { equalityFn: shallowEqual, fastMode: true }
+);

--- a/src/features/rnbw-membership/types.ts
+++ b/src/features/rnbw-membership/types.ts
@@ -1,0 +1,13 @@
+export type TierId =
+  | 'STAKING_TIER_LEVEL_BASIC'
+  | 'STAKING_TIER_LEVEL_SILVER'
+  | 'STAKING_TIER_LEVEL_GOLD'
+  | 'STAKING_TIER_LEVEL_DIAMOND'
+  | 'STAKING_TIER_LEVEL_BLACK';
+
+export type Tier = {
+  level: TierId;
+  name: string;
+  cashbackBps: number;
+  minStakeAmount: string;
+};

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -6,15 +6,7 @@ import { createQueryStore } from '@/state/internal/createQueryStore';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { ChainId } from '@/state/backendNetworks/types';
 import { type Address } from 'viem';
-
-type StakingTierLevel = 'STAKING_TIER_LEVEL_UNSPECIFIED' | string;
-
-type StakingTier = {
-  cashbackBps: number;
-  level: StakingTierLevel;
-  minStakeAmount: string;
-  name: string;
-};
+import type { Tier } from '@/features/rnbw-membership/types';
 
 type StakingPnl = {
   exchangeRateGain: string;
@@ -26,7 +18,7 @@ type StakingPnl = {
 };
 
 type StakingPositionData = {
-  allTiers: StakingTier[];
+  allTiers: Tier[];
   decimals: number;
   hasPosition: boolean;
   lastUpdateTime: string;
@@ -36,7 +28,7 @@ type StakingPositionData = {
   stakedRnbw: string;
   stakedValueInCurrency: string;
   stakingStartTime: string;
-  tier: StakingTier;
+  tier: Tier;
 };
 
 type StakingPositionParams = {


### PR DESCRIPTION
Fixes APP-3553

## What changed (plus any additional context for devs)
Adds a membership tier card to the RNBW membership screen showing the user's current tier, cashback
percentage, percentage progress toward the next tier, and stake required to unlock it.

  - New `MembershipTierCard` component and `useMembershipTierInfo` derived store
  - Extracts shared tier types into rnbw-membership/types.ts (replaces inline types in staking
  position store). Today the tier unlocks are limited to staking but that will not always be the case, so keeping their definition separated from the staking store they're currently pulled from is ideal.  

## Screen recordings / screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-30 at 21 29 43" src="https://github.com/user-attachments/assets/fed80690-8089-4099-b777-3d30178f997e" />

