### PR TITLE
feature: basic exit penalty card

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -5,6 +5,7 @@ import { AccountImage } from '@/components/AccountImage';
 import { Navbar } from '@/components/navbar/Navbar';
 import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
 import { RnbwAirdropClaimCard } from './components/RnbwAirdropClaimCard';
+import { RnbwUnstakePenaltyRecoveryCard } from './components/RnbwUnstakePenaltyRecoveryCard';
 import { RnbwStakingCard } from './components/RnbwStakingCard';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
@@ -19,6 +20,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
       <ScrollView refreshControl={<RefreshControlWrapper />} contentContainerStyle={styles.scrollViewContentContainer} style={styles.flex}>
         <Box gap={16}>
           <RnbwStakingCard />
+          <RnbwUnstakePenaltyRecoveryCard />
           <RnbwRewardsClaimCard />
           <RnbwAirdropClaimCard />
         </Box>

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwUnstakePenaltyRecoveryCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwUnstakePenaltyRecoveryCard.tsx
@@ -1,0 +1,21 @@
+import { memo } from 'react';
+import { Box, Text } from '@/design-system';
+import { useRnbwStakingPositionPnl } from '@/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+
+export const RnbwUnstakePenaltyRecoveryCard = memo(function RnbwUnstakePenaltyRecoveryCard() {
+  const { exitFeeOffsetRatio, earnedFromExitFees, earningsRequiredToBreakEven } = useRnbwStakingPositionPnl();
+  return (
+    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+      <Text size="17pt" weight="bold" color="label">
+        {'Loyalty Progress'}
+      </Text>
+      <Text size="17pt" weight="bold" color="label">
+        {exitFeeOffsetRatio}
+      </Text>
+      <Text size="15pt" weight="bold" color="labelSecondary">
+        {`You've earned ${earnedFromExitFees} ${RNBW_SYMBOL} from the pool. Just ${earningsRequiredToBreakEven} ${RNBW_SYMBOL} more to reach pure profit.`}
+      </Text>
+    </Box>
+  );
+});

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
@@ -7,7 +7,7 @@ import {
   toFixedWorklet,
   toPercentageWorklet,
 } from '@/framework/core/safeMath';
-import { convertRawAmountToDecimalFormatWorklet } from '@/helpers/utilities';
+import { convertRawAmountToDecimalFormatWorklet, formatNumber } from '@/helpers/utilities';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { shallowEqual } from '@/worklets/comparisons';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
@@ -17,12 +17,16 @@ type StakingPositionPnl = {
   exitFeeOffsetRatio: string;
   netPnl: string;
   isPositivePnl: boolean;
+  earnedFromExitFees: string;
+  earningsRequiredToBreakEven: string;
 };
 
 const EMPTY_VALUE: StakingPositionPnl = {
   exitFeeOffsetRatio: '0%',
   netPnl: '0',
   isPositivePnl: false,
+  earnedFromExitFees: '0',
+  earningsRequiredToBreakEven: '0',
 };
 
 export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
@@ -47,6 +51,8 @@ export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
     return {
       exitFeeOffsetRatio: exitFeeOffsetRatioFormatted,
       netPnl: isPositivePnl ? `+${netPnlFormatted}` : netPnlFormatted,
+      earnedFromExitFees: formatNumber(convertRawAmountToDecimalFormatWorklet(exchangeRateGain, decimals)),
+      earningsRequiredToBreakEven: formatNumber(convertRawAmountToDecimalFormatWorklet(subWorklet(exitFee, exchangeRateGain), decimals)),
       isPositivePnl,
     };
   },


### PR DESCRIPTION
Fixes APP-3554

## What changed (plus any additional context for devs)

Adds `RnbwUnstakePenaltyRecoveryCard` to the `RnbwMembershipScreen`. Displays to the user how much they've earned in exit penalties and their progress towards offsetting their own hypothetical exit fee. 

## Screen recordings / screenshots

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-31 at 17 19 48" src="https://github.com/user-attachments/assets/b396feaa-8d57-477a-a134-b8c39442c31c" />

