### PR TITLE
feature: membership tiers sheet

### DIFF
--- a/src/components/text/GradientText.tsx
+++ b/src/components/text/GradientText.tsx
@@ -1,16 +1,26 @@
+import { type TextProps } from '@/design-system/components/Text/Text';
 import { useTextStyle } from '@/design-system/components/Text/useTextStyle';
 import MaskedView from '@react-native-masked-view/masked-view';
 import React, { memo, useMemo } from 'react';
+import { StyleSheet, type TextStyle, View } from 'react-native';
 import { LinearGradient, type LinearGradientProps } from 'expo-linear-gradient';
+
+interface TextShadowConfig {
+  textShadowColor: string;
+  textShadowOffset?: TextStyle['textShadowOffset'];
+  textShadowRadius?: number;
+}
 
 interface GradientTextProps extends LinearGradientProps {
   bleed?: number;
-  children: React.ReactElement<any>;
+  children: React.ReactElement<TextProps>;
+  shadow?: TextShadowConfig;
 }
 
 const GradientText = memo(function GradientText({
   children,
   bleed = 0,
+  shadow,
   start = { x: 0, y: 0.5 },
   end = { x: 1, y: 0.5 },
   ...linearGradientProps
@@ -24,6 +34,7 @@ const GradientText = memo(function GradientText({
     weight: children.props.weight,
   });
 
+  const { marginTop, marginBottom } = textStyle;
   textStyle = {
     ...textStyle,
     marginTop: 0,
@@ -42,8 +53,16 @@ const GradientText = memo(function GradientText({
     });
   }, [children, textStyle]);
 
-  return (
-    <MaskedView style={{ marginTop: textStyle.marginTop, marginBottom: textStyle.marginBottom }} maskElement={visibleChild}>
+  const shadowChild = useMemo(() => {
+    if (!shadow) return null;
+    return React.cloneElement(children, {
+      color: { custom: 'transparent' },
+      style: [textStyle, children.props.style, shadow],
+    });
+  }, [children, shadow, textStyle]);
+
+  const maskedView = (
+    <MaskedView style={shadow ? undefined : { marginTop, marginBottom }} maskElement={visibleChild}>
       <LinearGradient
         start={start}
         end={end}
@@ -56,6 +75,22 @@ const GradientText = memo(function GradientText({
       </LinearGradient>
     </MaskedView>
   );
+
+  if (!shadow) return maskedView;
+
+  return (
+    <View style={{ marginTop, marginBottom }}>
+      <View style={styles.shadow}>{shadowChild}</View>
+      {maskedView}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  shadow: {
+    position: 'absolute',
+    alignSelf: 'center',
+  },
 });
 
 export default GradientText;

--- a/src/features/rnbw-membership/components/TierBadge.tsx
+++ b/src/features/rnbw-membership/components/TierBadge.tsx
@@ -1,0 +1,91 @@
+import { memo } from 'react';
+import { Text, useColorMode } from '@/design-system';
+import { TIER_VISUALS } from '@/features/rnbw-membership/constants';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
+import { LinearGradient } from 'expo-linear-gradient';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { getValueForColorMode, globalColors } from '@/design-system/color/palettes';
+import { StyleSheet, View } from 'react-native';
+import type { Tier as TierType } from '@/features/rnbw-membership/types';
+import GradientText from '@/components/text/GradientText';
+
+const BORDER_GRADIENT_START = { x: 0, y: 1 };
+const BORDER_GRADIENT_END = { x: 0, y: 0 };
+const BADGE_GRADIENT_START = { x: 0, y: 0 };
+const BADGE_GRADIENT_END = { x: 0, y: 1 };
+const BADGE_TEXT_GRADIENT_START = { x: 0, y: 0 };
+const BADGE_TEXT_GRADIENT_END = { x: 0, y: 1 };
+
+export const TierBadge = memo(function TierBadge({ tier }: { tier: TierType }) {
+  const { colorMode } = useColorMode();
+  const { badgeGradient, badgeTextGradient, badgeTextShadow, badgeShadow, badgeBorderGradient } = TIER_VISUALS[tier.level];
+  const {
+    colors: badgeGradientColors,
+    locations: badgeGradientLocations,
+    start: badgeStart = BADGE_GRADIENT_START,
+    end: badgeEnd = BADGE_GRADIENT_END,
+  } = getValueForColorMode(badgeGradient, colorMode);
+  const {
+    colors: badgeTextGradientColors,
+    locations: badgeTextGradientLocations,
+    start: badgeTextStart = BADGE_TEXT_GRADIENT_START,
+    end: badgeTextEnd = BADGE_TEXT_GRADIENT_END,
+  } = getValueForColorMode(badgeTextGradient, colorMode);
+  const {
+    colors: borderGradientColors,
+    locations: borderGradientLocations,
+    start: borderStart = BORDER_GRADIENT_START,
+    end: borderEnd = BORDER_GRADIENT_END,
+  } = getValueForColorMode(badgeBorderGradient, colorMode);
+  const shadowStyle = getValueForColorMode(badgeShadow, colorMode);
+  const textShadowStyle = getValueForColorMode(badgeTextShadow, colorMode);
+
+  return (
+    <View style={[styles.shadowWrapper, shadowStyle]}>
+      <GradientBorderView
+        borderGradientColors={borderGradientColors}
+        locations={borderGradientLocations}
+        start={borderStart}
+        end={borderEnd}
+        borderWidth={2}
+        style={styles.tierBadge}
+      >
+        <InnerShadow color={opacity(globalColors.white100, 0.1)} blur={1} dx={0} dy={3} />
+        <LinearGradient
+          colors={badgeGradientColors}
+          locations={badgeGradientLocations}
+          start={badgeStart}
+          end={badgeEnd}
+          style={StyleSheet.absoluteFill}
+        />
+        <GradientText
+          colors={badgeTextGradientColors}
+          locations={badgeTextGradientLocations}
+          start={badgeTextStart}
+          end={badgeTextEnd}
+          shadow={textShadowStyle}
+        >
+          <Text size="22pt" weight="heavy" color="label">
+            {tier.name.toLocaleUpperCase()}
+          </Text>
+        </GradientText>
+      </GradientBorderView>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  shadowWrapper: {
+    alignSelf: 'center',
+    borderRadius: 21,
+  },
+  tierBadge: {
+    height: 42,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 21,
+    overflow: 'hidden',
+  },
+});

--- a/src/features/rnbw-membership/components/TierThemedLabel.tsx
+++ b/src/features/rnbw-membership/components/TierThemedLabel.tsx
@@ -1,0 +1,29 @@
+import type { Tier } from '@/features/rnbw-membership/types';
+import { memo } from 'react';
+import { useColorMode, type TextProps } from '@/design-system';
+import { TIER_VISUALS } from '@/features/rnbw-membership/constants';
+import GradientText from '@/components/text/GradientText';
+import { getValueForColorMode } from '@/design-system/color/palettes';
+
+const GRADIENT_START = { x: 0, y: 0 };
+const GRADIENT_END = { x: 0, y: 1 };
+
+export const TierThemedLabel = memo(function TierThemedLabel({ tier, children }: { tier: Tier; children: React.ReactElement<TextProps> }) {
+  const { colorMode, isDarkMode } = useColorMode();
+
+  if (isDarkMode) return children;
+
+  const { textGradient } = TIER_VISUALS[tier.level];
+  const {
+    colors: textGradientColors,
+    locations: textGradientLocations,
+    start: textGradientStart = GRADIENT_START,
+    end: textGradientEnd = GRADIENT_END,
+  } = getValueForColorMode(textGradient, colorMode);
+
+  return (
+    <GradientText colors={textGradientColors} locations={textGradientLocations} start={textGradientStart} end={textGradientEnd}>
+      {children}
+    </GradientText>
+  );
+});

--- a/src/features/rnbw-membership/constants.ts
+++ b/src/features/rnbw-membership/constants.ts
@@ -1,0 +1,177 @@
+import { globalColors } from '@/design-system/color/palettes';
+import type { Tier, TierId } from '@/features/rnbw-membership/types';
+import { opacity } from '@/framework/ui/utils/opacity';
+import type { LinearGradientProps } from 'expo-linear-gradient';
+
+type Themed<T> = { light: T; dark: T };
+
+type ShadowConfig = {
+  shadowColor: string;
+  shadowOffset: { width: number; height: number };
+  shadowOpacity: number;
+  shadowRadius: number;
+};
+
+type GradientConfig = {
+  colors: LinearGradientProps['colors'];
+  locations?: LinearGradientProps['locations'];
+  start?: { x: number; y: number };
+  end?: { x: number; y: number };
+};
+
+type TextShadowConfig = {
+  textShadowColor: string;
+  textShadowOffset: { width: number; height: number };
+  textShadowRadius: number;
+};
+
+type TierVisuals = {
+  backgroundGradient: Themed<GradientConfig>;
+  textGradient: Themed<GradientConfig>;
+  badgeTextGradient: Themed<GradientConfig>;
+  badgeGradient: Themed<GradientConfig>;
+  badgeBorderGradient: Themed<GradientConfig>;
+  badgeShadow: Themed<ShadowConfig>;
+  badgeTextShadow: Themed<TextShadowConfig>;
+};
+
+const BADGE_BORDER_GRADIENT_LIGHT = [opacity(globalColors.grey100, 0.02), opacity(globalColors.grey100, 0.05)] as const;
+const BADGE_SHADOW_LIGHT = { shadowColor: '#000000', shadowOffset: { width: 0, height: 8 }, shadowOpacity: 0.1, shadowRadius: 9 } as const;
+
+const sameForModes = <T>(value: T): Themed<T> => ({ light: value, dark: value });
+
+export const TIER_VISUALS: Record<TierId, TierVisuals> = {
+  STAKING_TIER_LEVEL_BASIC: {
+    backgroundGradient: {
+      light: { colors: [opacity('#0086FF', 0.4), opacity('#0086FF', 0)] },
+      dark: { colors: [opacity('#0086FF', 0.16), opacity('#0086FF', 0)] },
+    },
+    textGradient: { light: { colors: ['#000000', '#000000'] }, dark: { colors: ['#FFFFFF', '#FFFFFF'] } },
+    badgeTextGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
+    badgeGradient: sameForModes({ colors: ['#2B80F4', '#1661C9'] }),
+    badgeBorderGradient: {
+      light: { colors: BADGE_BORDER_GRADIENT_LIGHT },
+      dark: { colors: [opacity('#69A8FF', 0.5), opacity('#69A8FF', 0.3)] },
+    },
+    badgeShadow: {
+      light: BADGE_SHADOW_LIGHT,
+      dark: BADGE_SHADOW_LIGHT,
+    },
+    badgeTextShadow: sameForModes({
+      textShadowColor: 'rgba(0, 0, 0, 0.14)',
+      textShadowOffset: { width: 0, height: 1 },
+      textShadowRadius: 1,
+    }),
+  },
+  STAKING_TIER_LEVEL_SILVER: {
+    backgroundGradient: {
+      light: { colors: [opacity('#E6E6E6', 0.4), opacity('#E6E6E6', 0)] },
+      dark: { colors: [opacity('#CFCFCF', 0.16), opacity('#CFCFCF', 0)] },
+    },
+    textGradient: sameForModes({ colors: ['#313131', '#888888'] }),
+    badgeTextGradient: { light: { colors: ['#313131', '#888888'] }, dark: { colors: ['#111111', '#585858'] } },
+    badgeGradient: { light: { colors: ['#EFEFEF', '#CDCDCD'] }, dark: { colors: ['#D6D6D6', '#828282'] } },
+    badgeBorderGradient: {
+      light: { colors: BADGE_BORDER_GRADIENT_LIGHT },
+      dark: { colors: [opacity('#EBEBEB', 0.5), opacity('#EBEBEB', 0.3)] },
+    },
+    badgeShadow: {
+      light: BADGE_SHADOW_LIGHT,
+      dark: { shadowColor: '#B2B2B2', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.3, shadowRadius: 15 },
+    },
+    badgeTextShadow: sameForModes({
+      textShadowColor: 'rgba(255, 255, 255, 0.46)',
+      textShadowOffset: { width: 1, height: 1 },
+      textShadowRadius: 0,
+    }),
+  },
+  STAKING_TIER_LEVEL_GOLD: {
+    backgroundGradient: {
+      light: { colors: [opacity('#FADB71', 0.4), opacity('#FADB71', 0)] },
+      dark: { colors: [opacity('#FADB71', 0.16), opacity('#FADB71', 0)] },
+    },
+    textGradient: sameForModes({ colors: ['#4F3605', '#90630E'] }),
+    badgeTextGradient: sameForModes({ colors: ['#4F3605', '#90630E'] }),
+    badgeGradient: sameForModes({ colors: ['#FFE380', '#E3A700'] }),
+    badgeBorderGradient: {
+      light: { colors: BADGE_BORDER_GRADIENT_LIGHT },
+      dark: { colors: [opacity('#FFF4CC', 0.5), opacity('#FFF4CC', 0.3)] },
+    },
+    badgeShadow: {
+      light: BADGE_SHADOW_LIGHT,
+      dark: { shadowColor: '#FFDD20', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.3, shadowRadius: 15 },
+    },
+    badgeTextShadow: sameForModes({
+      textShadowColor: 'rgba(255, 255, 255, 0.26)',
+      textShadowOffset: { width: 1, height: 1 },
+      textShadowRadius: 0,
+    }),
+  },
+  STAKING_TIER_LEVEL_DIAMOND: {
+    backgroundGradient: {
+      light: { colors: [opacity('#D1E9F0', 0.4), opacity('#D1E9F0', 0)] },
+      dark: { colors: [opacity('#42D2EB', 0.16), opacity('#42D2EB', 0)] },
+    },
+    textGradient: sameForModes({ colors: ['#424749', '#7CADB4'] }),
+    badgeTextGradient: { light: { colors: ['#424749', '#7CADB4'] }, dark: { colors: ['#314145', '#1D5D67'] } },
+    badgeGradient: { light: { colors: ['#ECF2F8', '#C8D1D7'] }, dark: { colors: ['#D5DCE3', '#9AA7B0'] } },
+    badgeBorderGradient: {
+      light: { colors: BADGE_BORDER_GRADIENT_LIGHT },
+      dark: { colors: [opacity('#D5DCE3', 0.5), opacity('#D5DCE3', 0.3)] },
+    },
+    badgeShadow: {
+      light: BADGE_SHADOW_LIGHT,
+      dark: { shadowColor: '#42D2EB', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.3, shadowRadius: 15 },
+    },
+    badgeTextShadow: sameForModes({
+      textShadowColor: opacity('#CBF6FF', 0.46),
+      textShadowOffset: { width: 1, height: 1 },
+      textShadowRadius: 0,
+    }),
+  },
+  STAKING_TIER_LEVEL_BLACK: {
+    backgroundGradient: sameForModes({ colors: [opacity('#FFFFFF', 0), opacity('#FFFFFF', 0)] }),
+    textGradient: { light: { colors: ['#000000', '#000000'] }, dark: { colors: ['#FFFFFF', '#FFFFFF'] } },
+    badgeTextGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
+    badgeGradient: sameForModes({ colors: ['#444444', '#000000'] }),
+    badgeBorderGradient: sameForModes({ colors: BADGE_BORDER_GRADIENT_LIGHT }),
+    badgeShadow: {
+      light: BADGE_SHADOW_LIGHT,
+      dark: { shadowColor: '#1A1C22', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.3, shadowRadius: 8 },
+    },
+    badgeTextShadow: sameForModes({ textShadowColor: 'rgba(0, 0, 0, 0)', textShadowOffset: { width: 0, height: 0 }, textShadowRadius: 0 }),
+  },
+};
+
+export const FALLBACK_TIERS: Tier[] = [
+  {
+    level: 'STAKING_TIER_LEVEL_BASIC',
+    name: 'Basic',
+    minStakeAmount: '0',
+    cashbackBps: 1000,
+  },
+  {
+    level: 'STAKING_TIER_LEVEL_SILVER',
+    name: 'Silver',
+    minStakeAmount: '5000000000000000000000',
+    cashbackBps: 2500,
+  },
+  {
+    level: 'STAKING_TIER_LEVEL_GOLD',
+    name: 'Gold',
+    minStakeAmount: '10000000000000000000000',
+    cashbackBps: 5000,
+  },
+  {
+    level: 'STAKING_TIER_LEVEL_DIAMOND',
+    name: 'Diamond',
+    minStakeAmount: '15000000000000000000000',
+    cashbackBps: 7500,
+  },
+  {
+    level: 'STAKING_TIER_LEVEL_BLACK',
+    name: 'Black',
+    minStakeAmount: '20000000000000000000000',
+    cashbackBps: 10000,
+  },
+];

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
@@ -1,24 +1,33 @@
 import { memo } from 'react';
 import { Box, Text } from '@/design-system';
 import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
 
 export const MembershipTierCard = memo(function MembershipTierCard() {
   const { currentTier, stakeRequiredForNextTier, cashbackPercentage, currentTierProgress } = useMembershipTierInfo();
 
   return (
-    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
-      <Text size="22pt" weight="heavy" color="label">
-        {`${currentTier.name} Tier`}
-      </Text>
-      <Text size="17pt" weight="heavy" color="label">
-        {`current tier progress: ${currentTierProgress * 100}/100`}
-      </Text>
-      <Text size="17pt" weight="heavy" color="label">
-        {`Cashback: ${cashbackPercentage}%`}
-      </Text>
-      <Text size="17pt" weight="heavy" color="label">
-        {`Stake to unlock: ${stakeRequiredForNextTier}`}
-      </Text>
-    </Box>
+    <ButtonPressAnimation onPress={navigateToMembershipTiersSheet} scaleTo={0.96}>
+      <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
+        <Text size="22pt" weight="heavy" color="label">
+          {`${currentTier.name} Tier`}
+        </Text>
+        <Text size="17pt" weight="heavy" color="label">
+          {`current tier progress: ${currentTierProgress * 100}/100`}
+        </Text>
+        <Text size="17pt" weight="heavy" color="label">
+          {`Cashback: ${cashbackPercentage}%`}
+        </Text>
+        <Text size="17pt" weight="heavy" color="label">
+          {`Stake to unlock: ${stakeRequiredForNextTier}`}
+        </Text>
+      </Box>
+    </ButtonPressAnimation>
   );
 });
+
+function navigateToMembershipTiersSheet() {
+  Navigation.handleAction(Routes.RNBW_MEMBERSHIP_TIERS_SHEET);
+}

--- a/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
@@ -1,0 +1,123 @@
+import { StyleSheet } from 'react-native';
+import { StepIndicators } from '@/components/explainer-sheet/components/StepIndicators';
+import { PanelSheet, PANEL_WIDTH } from '@/components/PanelSheet/PanelSheet';
+import { downscalePagerIndex, SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { Box, globalColors, Separator, Text, useColorMode } from '@/design-system';
+import { useMembershipTierInfo } from '../../stores/derived/useMembershipTierInfo';
+import { memo } from 'react';
+import type { Tier as TierType } from '../../types';
+import Animated, { Extrapolation, interpolate, useAnimatedStyle, useDerivedValue, type SharedValue } from 'react-native-reanimated';
+import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
+import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
+import { formatNumber } from '@/helpers/strings';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import { TierThemedLabel } from '../../components/TierThemedLabel';
+import { TierBadge } from '../../components/TierBadge';
+import { TIER_VISUALS } from '../../constants';
+import { LinearGradient, type LinearGradientProps } from 'expo-linear-gradient';
+import { getValueForColorMode } from '@/design-system/color/palettes';
+
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
+
+export const RnbwMembershipTiersSheet = memo(function RnbwMembershipTiersSheet() {
+  const { isDarkMode, colorMode } = useColorMode();
+  const { currentTier, allTiers } = useMembershipTierInfo();
+  const { ref } = usePagerNavigation();
+  const currentPageIndex = useDerivedValue(() => {
+    return downscalePagerIndex(ref.current?.currentPageIndex.value ?? 0);
+  });
+
+  return (
+    <PanelSheet>
+      <Box paddingBottom={{ custom: 20 }} paddingTop={{ custom: 53 }} alignItems="center">
+        {allTiers.map((tier, index) => (
+          <TierGradientLayer
+            key={tier.level}
+            colors={getValueForColorMode(TIER_VISUALS[tier.level].backgroundGradient, colorMode).colors}
+            index={index}
+            pageIndex={currentPageIndex}
+          />
+        ))}
+        <SmoothPager enableSwipeToGoBack={true} enableSwipeToGoForward={'always'} initialPage={currentTier.level} ref={ref}>
+          {allTiers.map(tier => (
+            <SmoothPager.Page key={tier.level} component={<Tier tier={tier} />} id={tier.level} />
+          ))}
+        </SmoothPager>
+        <StepIndicators
+          stepCount={allTiers.length}
+          currentIndex={currentPageIndex}
+          color={isDarkMode ? globalColors.white100 : globalColors.grey100}
+        />
+      </Box>
+    </PanelSheet>
+  );
+});
+
+function Tier({ tier }: { tier: TierType }) {
+  const stakeRequiredForTierDisplay = formatNumber(convertRawAmountToDecimalFormat(tier.minStakeAmount, RNBW_DECIMALS));
+  const tierCashbackDisplay = `${tier.cashbackBps / 100}%`;
+
+  return (
+    <Box paddingBottom={{ custom: 42 }} paddingHorizontal={'32px'} width={PANEL_WIDTH}>
+      <Box gap={32}>
+        <TierBadge tier={tier} />
+        <Box gap={20}>
+          <TierThemedLabel tier={tier}>
+            <Text size="34pt" weight="heavy" color="label" align="center">
+              {`${tier.name} Tier`}
+            </Text>
+          </TierThemedLabel>
+          <Box flexDirection="row" justifyContent="center" gap={4}>
+            <TierThemedLabel tier={tier}>
+              <Text size="17pt" weight="heavy" color="label">
+                {tierCashbackDisplay}
+              </Text>
+            </TierThemedLabel>
+            <Text size="17pt" weight="semibold" color="labelTertiary">
+              {'Rewards'}
+            </Text>
+          </Box>
+        </Box>
+        <Box gap={16} paddingHorizontal={'8px'}>
+          <Box flexDirection="row" justifyContent="space-between">
+            <Text size="17pt" weight="semibold" color="labelTertiary">
+              {'Rewards'}
+            </Text>
+            <Text size="17pt" weight="bold" color="label">
+              {tierCashbackDisplay}
+            </Text>
+          </Box>
+          <Separator thickness={1} color={{ custom: opacity(globalColors.grey100, 0.04) }} />
+          <Box flexDirection="row" justifyContent="space-between">
+            <Text size="17pt" weight="semibold" color="labelTertiary">
+              {'Stake to unlock'}
+            </Text>
+            <Text size="17pt" weight="bold" color="label">
+              {`${stakeRequiredForTierDisplay} ${RNBW_SYMBOL}`}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+const GRADIENT_START = { x: 0.5, y: 0 };
+const GRADIENT_END = { x: 0.5, y: 0.31 };
+
+function TierGradientLayer({
+  colors,
+  index,
+  pageIndex,
+}: {
+  colors: LinearGradientProps['colors'];
+  index: number;
+  pageIndex: SharedValue<number>;
+}) {
+  const style = useAnimatedStyle(() => ({
+    opacity: interpolate(pageIndex.value, [index - 1, index, index + 1], [0, 1, 0], Extrapolation.CLAMP),
+  }));
+
+  return <AnimatedLinearGradient colors={colors} start={GRADIENT_START} end={GRADIENT_END} style={[StyleSheet.absoluteFill, style]} />;
+}

--- a/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
+++ b/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
@@ -6,24 +6,24 @@ import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
 import { convertBipsToPercentage, convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 import { formatNumber } from '@/helpers/strings';
 import type { Tier } from '@/features/rnbw-membership/types';
+import { FALLBACK_TIERS } from '@/features/rnbw-membership/constants';
 
 type MembershipTierInfo = {
   currentTier: Tier;
   stakeRequiredForNextTier: string;
   cashbackPercentage: string;
   currentTierProgress: number;
+  allTiers: Tier[];
+  currentTierIndex: number;
 };
 
 const EMPTY_TIER: MembershipTierInfo = {
-  currentTier: {
-    level: 'STAKING_TIER_LEVEL_BASIC',
-    name: 'Basic',
-    cashbackBps: 1_000,
-    minStakeAmount: '0',
-  },
+  currentTier: FALLBACK_TIERS[0],
   stakeRequiredForNextTier: '0',
   cashbackPercentage: '10%',
   currentTierProgress: 0,
+  allTiers: FALLBACK_TIERS,
+  currentTierIndex: 0,
 };
 
 export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
@@ -52,6 +52,8 @@ export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
       stakeRequiredForNextTier,
       cashbackPercentage,
       currentTierProgress,
+      allTiers,
+      currentTierIndex,
     };
   },
   { equalityFn: shallowEqual, fastMode: true }

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -124,6 +124,7 @@ import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-
 import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
+import { RnbwMembershipTiersSheet } from '@/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet';
 
 const Stack = createStackNavigator();
 const OuterStack = createStackNavigator();
@@ -316,6 +317,7 @@ function BSNavigator() {
       <BSStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
       <BSStack.Screen component={RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} />
       <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
+      <BSStack.Screen component={RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} />
     </BSStack.Navigator>
   );
 }

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -147,6 +147,7 @@ import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-sta
 import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
 import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
 import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
+import { RnbwMembershipTiersSheet } from '@/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackCoolModalNavigator();
@@ -355,13 +356,13 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen component={RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} {...panelConfig} />
-
       <NativeStack.Screen
         component={PolymarketBrowseEventsScreen}
         name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}
         {...expandedAssetSheetV2Config}
       />
       <NativeStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} {...walletErrorSheetConfig} />
+      <NativeStack.Screen component={RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} {...learnSheetConfig} />
     </NativeStack.Navigator>
   );
 }

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -149,6 +149,7 @@ const Routes = {
   RNBW_STAKING_SCREEN: 'RnbwStakingScreen',
   RNBW_UNSTAKE_SHEET: 'RnbwUnstakeSheet',
   WALLET_ERROR_SHEET: 'WalletErrorSheet',
+  RNBW_MEMBERSHIP_TIERS_SHEET: 'RnbwMembershipTiersSheet',
 } as const;
 
 export const NATIVE_ROUTES = new Set<Route>([


### PR DESCRIPTION
Fixes APP-3544

## What changed
Adds the membership tiers sheet The tier card on the membership screen now navigates to the tiers sheet on press. 

#### Main changes
  - `RnbwMembershipTiersSheet`: paginated sheet showing all tiers with animated background gradients that crossfade on swipe. Each page shows the tier badge, cashback rate, and stake requirement.
  - `TierBadge`: Pill badge for a given tier, with per-tier color configs.
  - `TierThemedLabel`: wraps text in a tier themed gradient.
  -  constants.ts: `TIER_VISUALS` with themed gradient/shadow/border configs for all tiers FALLBACK_TIERS for the default tier list.
  - `useMembershipTierInfo`: now exposes `allTiers` and `currentTierIndex`

#### Other changes
  - `GradientText`: added support for shadow config (iOS only atm).
  -  Swapped `RNBW_TOKEN_ADDRESS` and `STAKING_CONTRACT_ADDRESS` to production values.

#### Notes 
- The real RNBW staking contract and token addresses was meant to be in a separate PR, but it's fine here.
- The black tier badge does not have it's final designs yet, they are much more complex and will be in a follow up PR. 

## Screen recordings / screenshots

https://github.com/user-attachments/assets/45576605-2f5d-4ae6-acd0-17323b9cea3c

