### PR TITLE
feature: membership card wrapper and card redesigns

### DIFF
--- a/src/components/RnbwCoinIcon.tsx
+++ b/src/components/RnbwCoinIcon.tsx
@@ -1,0 +1,17 @@
+import { memo, useMemo } from 'react';
+import { Image } from 'react-native';
+import rnbwCoinImage from '@/assets/rnbw.png';
+
+export const RnbwCoinIcon = memo(function RnbwCoinIcon({ size }: { size: number }) {
+  const styles = useMemo(
+    () => ({
+      image: {
+        width: size,
+        height: size,
+      },
+    }),
+    [size]
+  );
+
+  return <Image source={rnbwCoinImage} style={styles.image} />;
+});

--- a/src/design-system/components/Border/Border.tsx
+++ b/src/design-system/components/Border/Border.tsx
@@ -11,6 +11,10 @@ export type BorderProps = {
   borderTopLeftRadius?: number;
   borderTopRightRadius?: number;
   borderRadius?: number;
+  borderBottomWidth?: number;
+  borderLeftWidth?: number;
+  borderRightWidth?: number;
+  borderTopWidth?: number;
   borderWidth?: number;
   enableInLightMode?: boolean;
   enableOnAndroid?: boolean;
@@ -40,6 +44,10 @@ export const Border = memo(function Border({
   borderTopLeftRadius,
   borderTopRadius,
   borderTopRightRadius,
+  borderBottomWidth,
+  borderLeftWidth,
+  borderRightWidth,
+  borderTopWidth,
   borderWidth = 1,
   enableInLightMode,
   enableOnAndroid = true,
@@ -57,7 +65,10 @@ export const Border = memo(function Border({
         borderCurve: 'continuous',
         borderTopLeftRadius: borderTopLeftRadius ?? borderTopRadius ?? borderLeftRadius ?? borderRadius,
         borderTopRightRadius: borderTopRightRadius ?? borderTopRadius ?? borderRightRadius ?? borderRadius,
-        borderWidth,
+        borderBottomWidth: borderBottomWidth ?? borderWidth,
+        borderLeftWidth: borderLeftWidth ?? borderWidth,
+        borderRightWidth: borderRightWidth ?? borderWidth,
+        borderTopWidth: borderTopWidth ?? borderWidth,
         overflow: 'hidden',
         pointerEvents: 'none',
         zIndex: 100,

--- a/src/features/rnbw-membership/components/RnbwThemedButton.tsx
+++ b/src/features/rnbw-membership/components/RnbwThemedButton.tsx
@@ -1,0 +1,187 @@
+import React, { memo, useMemo } from 'react';
+import { LinearGradient } from 'expo-linear-gradient';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Text, useColorMode, type TextProps } from '@/design-system';
+import { GradientText } from '@/components/text';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+import { THICK_BORDER_WIDTH } from '@/styles/constants';
+import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { getValueForColorMode } from '@/design-system/color/palettes';
+
+type ShadowStyle = Pick<ViewStyle, 'shadowColor' | 'shadowOffset' | 'shadowOpacity' | 'shadowRadius'>;
+
+const CONFIG = {
+  gradient: {
+    start: { x: 0, y: 0 },
+    end: { x: 0, y: 1 },
+  },
+  primary: {
+    colors: ['#FFE380', '#E3A700'],
+    border: {
+      light: [opacity('#B5910D', 0.1125), opacity('#B5910D', 0.15)],
+      dark: [opacity('#B5910D', 0.1125), opacity('#B5910D', 0.15)],
+    },
+    text: {
+      colors: ['#4F3605', '#90630E'],
+      start: { x: 0, y: 0 },
+      end: { x: 0, y: 1 },
+      shadow: {
+        textShadowOffset: { width: 1, height: 1 },
+        textShadowRadius: 0,
+        textShadowColor: 'rgba(255, 255, 255, 0.26)',
+      },
+    },
+    shadows: {
+      light: [
+        {
+          shadowColor: '#8A6216',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.04,
+          shadowRadius: 10,
+        },
+        {
+          shadowColor: '#000000',
+          shadowOffset: { width: 0, height: 3 },
+          shadowOpacity: 0.08,
+          shadowRadius: 2.5,
+        },
+      ] satisfies ShadowStyle[],
+      dark: [
+        {
+          shadowColor: '#FFDD20',
+          shadowOffset: { width: 0, height: 0 },
+          shadowOpacity: 0.3,
+          shadowRadius: 15,
+        },
+      ] satisfies ShadowStyle[],
+    },
+  },
+  secondary: {
+    colors: {
+      light: [opacity('#F8DE7D', 0.4), opacity('#D9B550', 0.4)],
+      dark: [opacity('#FFE380', 0.1), opacity('#E3A700', 0.1)],
+    },
+    border: {
+      light: [opacity('#B5910D', 0.08), opacity('#B5910D', 0.08)],
+      dark: [opacity('#B5910D', 0.049), opacity('#B5910D', 0.07)],
+    },
+    text: {
+      color: { light: '#6F4D0A', dark: '#FAD96B' },
+    },
+    shadows: {
+      light: [
+        {
+          shadowColor: '#8A6216',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.04,
+          shadowRadius: 10,
+        },
+        {
+          shadowColor: '#000000',
+          shadowOffset: { width: 0, height: 3 },
+          shadowOpacity: 0.08,
+          shadowRadius: 2.5,
+        },
+      ] satisfies ShadowStyle[],
+      dark: [
+        {
+          shadowColor: '#F8DE7D',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.04,
+          shadowRadius: 10,
+        },
+      ] satisfies ShadowStyle[],
+    },
+  },
+} as const;
+
+export const RnbwThemedButton = memo(function RnbwThemedButton({
+  variant = 'primary',
+  label,
+  height = 42,
+  size = '22pt',
+  weight = 'heavy',
+  onPress,
+  style,
+  containerStyle,
+}: {
+  variant?: 'primary' | 'secondary';
+  label: string;
+  height?: number;
+  size?: TextProps['size'];
+  weight?: TextProps['weight'];
+  onPress: () => void;
+  style?: StyleProp<ViewStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+}) {
+  const { isDarkMode, colorMode } = useColorMode();
+  const borderRadius = height / 2;
+
+  const { borderGradientColors, gradientColors, shadows } = useMemo(() => {
+    return {
+      borderGradientColors: getValueForColorMode(CONFIG[variant].border, colorMode),
+      gradientColors: getValueForColorMode(CONFIG[variant].colors, colorMode),
+      shadows: getValueForColorMode(CONFIG[variant].shadows, colorMode),
+    };
+  }, [variant, colorMode]);
+
+  const resolvedContainerStyle = useMemo(() => {
+    return [
+      {
+        height,
+        borderRadius,
+        justifyContent: 'center',
+        alignItems: 'center',
+        overflow: 'visible',
+      },
+      shadows,
+      containerStyle,
+    ] satisfies StyleProp<ViewStyle>[];
+  }, [height, borderRadius, containerStyle, shadows]);
+
+  return (
+    <ButtonPressAnimation onPress={onPress} style={style} scaleTo={0.96}>
+      <GradientBorderView
+        borderWidth={isDarkMode ? THICK_BORDER_WIDTH : 1}
+        borderGradientColors={borderGradientColors}
+        start={CONFIG.gradient.start}
+        end={CONFIG.gradient.end}
+        style={resolvedContainerStyle}
+      >
+        <LinearGradient
+          colors={gradientColors}
+          start={CONFIG.gradient.start}
+          end={CONFIG.gradient.end}
+          style={[StyleSheet.absoluteFill, { borderRadius }]}
+        />
+        {variant === 'primary' && (
+          <LinearGradient
+            colors={[opacity('#FFE67E', 0), opacity('#FFE67E', 0.5), opacity('#FFE67E', 0)]}
+            start={{ x: 0.25, y: 0.5 }}
+            end={{ x: 0.75, y: 0.5 }}
+            style={StyleSheet.absoluteFill}
+          />
+        )}
+        {variant === 'primary' ? (
+          <GradientText
+            colors={CONFIG.primary.text.colors}
+            start={CONFIG.primary.text.start}
+            end={CONFIG.primary.text.end}
+            shadow={CONFIG.primary.text.shadow}
+          >
+            <Text size={size} weight={weight} color="label">
+              {label}
+            </Text>
+          </GradientText>
+        ) : (
+          <Text size={size} weight={weight} color={{ custom: getValueForColorMode(CONFIG.secondary.text.color, colorMode) }}>
+            {label}
+          </Text>
+        )}
+        <InnerShadow color={'rgba(255, 255, 255, 0.1)'} blur={1} dx={0} dy={3} borderRadius={borderRadius} />
+      </GradientBorderView>
+    </ButtonPressAnimation>
+  );
+});

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -17,6 +17,8 @@ import { RnbwStakingEarningsCard } from './components/RnbwStakingEarningsCard';
 import { TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
+  const hasPosition = useStakingPositionStore(s => s.hasPosition());
+
   return (
     <Box background="surfaceSecondary" style={styles.flex}>
       <Navbar hasStatusBarInset title="Membership" leftComponent={<AccountImage />} />
@@ -30,8 +32,8 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
       >
         <Box gap={16} style={{ flex: 1 }}>
           <RnbwStakingCard />
-          <RnbwStakingEarningsCard />
-          <RnbwUnstakePenaltyRecoveryCard />
+          {hasPosition && <RnbwStakingEarningsCard />}
+          {hasPosition && <RnbwUnstakePenaltyRecoveryCard />}
           <MembershipTierCard />
           <RnbwRewardsClaimCard />
           <RnbwAirdropClaimCard />

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react';
+import { StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import type { Space } from '@/design-system';
+import { Border, Box, useColorMode } from '@/design-system';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+
+type MembershipCardProps = {
+  children: ReactNode;
+  borderRadius?: number;
+  padding?: Space;
+  paddingHorizontal?: Space;
+  paddingVertical?: Space;
+  paddingTop?: Space;
+  paddingBottom?: Space;
+};
+
+export function MembershipCard({
+  children,
+  borderRadius = 32,
+  padding,
+  paddingHorizontal,
+  paddingVertical,
+  paddingTop,
+  paddingBottom,
+}: MembershipCardProps) {
+  const { isDarkMode } = useColorMode();
+
+  if (isDarkMode) {
+    return (
+      <Box
+        backgroundColor={opacity('#202429', 0.4)}
+        borderRadius={borderRadius}
+        padding={padding}
+        paddingHorizontal={paddingHorizontal}
+        paddingVertical={paddingVertical}
+        paddingTop={paddingTop}
+        paddingBottom={paddingBottom}
+      >
+        <Border borderTopWidth={2} borderRadius={borderRadius} borderColor={{ custom: opacity('#D6D6D6', 0.02) }} />
+        <InnerShadow borderRadius={borderRadius} color={opacity('#FFFFFF', 0.06)} blur={2.5} dx={0} dy={1} />
+        {children}
+      </Box>
+    );
+  }
+
+  return (
+    <GradientBorderView
+      borderRadius={borderRadius}
+      borderGradientColors={['#FFFFFF', opacity('#FFFFFF', 0.3)]}
+      start={{ x: 0.5, y: 0 }}
+      end={{ x: 0.5, y: 0.57 }}
+      style={styles.shadow}
+    >
+      <Box
+        borderRadius={borderRadius}
+        background={'surfaceSecondary'}
+        padding={padding}
+        paddingHorizontal={paddingHorizontal}
+        paddingVertical={paddingVertical}
+        paddingTop={paddingTop}
+        paddingBottom={paddingBottom}
+      >
+        <LinearGradient
+          colors={['#FFFFFF', '#FFFFFF']}
+          start={{ x: 0.5, y: 0 }}
+          end={{ x: 0.5, y: 0.57 }}
+          style={StyleSheet.absoluteFill}
+        />
+        {children}
+      </Box>
+    </GradientBorderView>
+  );
+}
+
+const styles = StyleSheet.create({
+  shadow: {
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.05,
+    shadowRadius: 9,
+    shadowColor: '#000000',
+  },
+});

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwClaimCard.tsx
@@ -1,10 +1,11 @@
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Text } from '@/design-system';
 import { Image, StyleSheet } from 'react-native';
 import { memo } from 'react';
 import rnbwCoinImage from '@/assets/rnbw.png';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import * as i18n from '@/languages';
+import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
+import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
 
 type RnbwClaimCardProps = {
   tokenAmount: string;
@@ -15,29 +16,25 @@ type RnbwClaimCardProps = {
 
 export const RnbwClaimCard = memo(function RnbwClaimCard({ tokenAmount, nativeCurrencyAmount, title, onPressClaim }: RnbwClaimCardProps) {
   return (
-    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
-      <Text size="22pt" weight="heavy" color="label">
-        {title}
-      </Text>
-      <Box flexDirection="row" alignItems="center" gap={10}>
-        <Image source={rnbwCoinImage} style={styles.coinImage} />
-        <Box gap={10} style={styles.flex}>
-          <Text size="22pt" weight="heavy" color="label">
-            {nativeCurrencyAmount}
-          </Text>
-          <Text size="17pt" weight="bold" color="labelTertiary">
-            {`${tokenAmount} ${RNBW_SYMBOL}`}
-          </Text>
-        </Box>
-        <ButtonPressAnimation onPress={onPressClaim} scaleTo={0.96}>
-          <Box backgroundColor="yellow" borderRadius={21} gap={20} width={94} height={42} justifyContent="center" alignItems="center">
+    <MembershipCard padding="20px">
+      <Box gap={20}>
+        <Text size="22pt" weight="heavy" color="label">
+          {title}
+        </Text>
+        <Box flexDirection="row" alignItems="center" gap={10}>
+          <Image source={rnbwCoinImage} style={styles.coinImage} />
+          <Box gap={10} style={styles.flex}>
             <Text size="22pt" weight="heavy" color="label">
-              {i18n.t(i18n.l.button.claim)}
+              {nativeCurrencyAmount}
+            </Text>
+            <Text size="17pt" weight="bold" color="labelTertiary">
+              {`${tokenAmount} ${RNBW_SYMBOL}`}
             </Text>
           </Box>
-        </ButtonPressAnimation>
+          <RnbwThemedButton onPress={onPressClaim} label={i18n.t(i18n.l.button.claim)} containerStyle={{ paddingHorizontal: 16 }} />
+        </Box>
       </Box>
-    </Box>
+    </MembershipCard>
   );
 });
 

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -3,64 +3,56 @@ import { Text, Box } from '@/design-system';
 import { useRnbwStakingBalance } from '@/features/rnbw-staking/stores/derived/useRnbwStakingBalance';
 import { useStakableRnbwBalance } from '@/state/rnbw/useStakableRnbwBalance';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
+import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
+import { MembershipCard } from './MembershipCard';
+import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
 
 export const RnbwStakingCard = memo(function RnbwStakingCard() {
   const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
   const { tokenAmountFormatted: availableAmount } = useStakableRnbwBalance();
 
   return (
-    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
-      <Text size="17pt" weight="bold" color="label">
-        {'Stake'}
-      </Text>
-      <Text size="44pt" weight="bold" color="label">
-        {nativeCurrencyAmount}
-      </Text>
-      <Text size="17pt" weight="bold" color="labelTertiary">
-        {`${tokenAmount} ${RNBW_SYMBOL}`}
-      </Text>
-      {!hasStakedPosition && (
-        <ButtonPressAnimation onPress={navigateToStakingLearnSheet}>
-          <Box backgroundColor="yellow" borderRadius={21} width={'full'} height={42} justifyContent="center" alignItems="center">
-            <Text size="17pt" weight="bold" color="label">
-              {'Enable Staking'}
-            </Text>
-          </Box>
-        </ButtonPressAnimation>
-      )}
-      {hasStakedPosition && (
-        <Box flexDirection="row" gap={10}>
-          <ButtonPressAnimation onPress={navigateToUnstakeSheet} style={{ flex: 1 }}>
-            <Box
-              flexGrow={1}
-              backgroundColor="yellow"
-              borderRadius={21}
-              width={'full'}
-              height={42}
-              justifyContent="center"
-              alignItems="center"
-            >
-              <Text size="17pt" weight="bold" color="label">
-                {'Unstake'}
-              </Text>
-            </Box>
-          </ButtonPressAnimation>
-          <ButtonPressAnimation onPress={navigateToStakingScreen} style={{ flex: 1 }}>
-            <Box backgroundColor="yellow" borderRadius={21} width={'full'} height={42} justifyContent="center" alignItems="center">
-              <Text size="17pt" weight="bold" color="label">
-                {'Add'}
-              </Text>
-            </Box>
-          </ButtonPressAnimation>
+    <MembershipCard paddingHorizontal="20px" paddingTop="24px" paddingBottom="16px">
+      <Box gap={16}>
+        <Text size="22pt" weight="heavy" color="label">
+          {'Stake'}
+        </Text>
+        <Box alignItems="center" gap={20}>
+          <RnbwCoinIcon size={80} />
+          <Text size="44pt" weight="heavy" color="label">
+            {nativeCurrencyAmount}
+          </Text>
+          <Text size="17pt" weight="bold" color="labelTertiary">
+            {`${tokenAmount} ${RNBW_SYMBOL}`}
+          </Text>
         </Box>
-      )}
-      <Text size="13pt" weight="semibold" color="labelTertiary" align="center">
-        {`${availableAmount} available to stake`}
-      </Text>
-    </Box>
+        {!hasStakedPosition && <RnbwThemedButton onPress={navigateToStakingLearnSheet} label="Enable Staking" />}
+        {hasStakedPosition && (
+          <Box flexDirection="row" gap={10}>
+            <RnbwThemedButton
+              onPress={navigateToUnstakeSheet}
+              style={{ flex: 1 }}
+              label="Unstake"
+              size="22pt"
+              weight="heavy"
+              variant="secondary"
+            />
+            <RnbwThemedButton onPress={navigateToStakingScreen} style={{ flex: 1 }} label="Add" />
+          </Box>
+        )}
+        <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4}>
+          <RnbwCoinIcon size={18} />
+          <Text size="15pt" weight="bold" color="labelSecondary" align="center">
+            {`${availableAmount}`}
+          </Text>
+          <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
+            {'available to stake'}
+          </Text>
+        </Box>
+      </Box>
+    </MembershipCard>
   );
 });
 

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingEarningsCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingEarningsCard.tsx
@@ -4,12 +4,13 @@ import { useRnbwStakingEarnings } from '@/features/rnbw-staking/stores/derived/u
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import rnbwCoinImage from '@/assets/rnbw.png';
 import { Image } from 'react-native';
+import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
 
 export const RnbwStakingEarningsCard = memo(function RnbwStakingEarningsCard() {
   const { totalEarnings, cashbackEarnings, cashbackShare, exitRewardsEarnings, exitRewardsShare } = useRnbwStakingEarnings();
 
   return (
-    <Box background="surfacePrimary" borderRadius={32} padding="24px" shadow="18px">
+    <MembershipCard padding="24px">
       <Box gap={16}>
         <Text size="17pt" weight="bold" color="labelTertiary" align="left">
           {'Total Earnings'}
@@ -21,16 +22,14 @@ export const RnbwStakingEarningsCard = memo(function RnbwStakingEarningsCard() {
             {totalEarnings}
           </Text>
         </Box>
-
         <Separator color="separatorTertiary" thickness={1} />
-
         <Box gap={14}>
           <EarningsRow label="Cashback" percentage={cashbackShare} amount={cashbackEarnings} />
           <Separator color="separatorTertiary" thickness={1} />
           <EarningsRow label="Exit Rewards" percentage={exitRewardsShare} amount={exitRewardsEarnings} />
         </Box>
       </Box>
-    </Box>
+    </MembershipCard>
   );
 });
 


### PR DESCRIPTION
Fixes APP-3555

## What changed (plus any additional context for devs)
Introduces the MembershipCard wrapper and RnbwThemedButton, then redesigns the staking, claim, and earnings cards to use them.

#### Main changes
  - MembershipCard: themed card container for all the cards on the membership screen
  - RnbwThemedButton: gold-themed button with primary and secondary variants. Will be used in other areas of this feature in future PRs. 
  - RnbwStakingCard: Updated layout + use themed buttons

#### Other changes
  - RnbwCoinIcon: simple reusable RNBW coin image component
  - Border: added per edge border width props (needed for the MembershipCard)

## Screen recordings / screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-02 at 18 58 50" src="https://github.com/user-attachments/assets/b5d2d1ff-b995-44c7-b070-75cb6f5e00ae" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-02 at 18 58 10" src="https://github.com/user-attachments/assets/b7cdafb3-f398-4282-84d5-1e0429ba2994" />

