### PR TITLE
feature: tier progress bar and membership tier card redesign

### DIFF
--- a/src/components/gradient-border/GradientBorderView.tsx
+++ b/src/components/gradient-border/GradientBorderView.tsx
@@ -17,6 +17,10 @@ type GradientBorderViewProps = {
   start?: { x: number; y: number };
   end?: { x: number; y: number };
   borderRadius?: number;
+  borderTopLeftRadius?: number;
+  borderTopRightRadius?: number;
+  borderBottomLeftRadius?: number;
+  borderBottomRightRadius?: number;
   backgroundColor?: string;
   style?: StyleProp<ViewStyle>;
 };
@@ -29,13 +33,24 @@ export const GradientBorderView = memo(function GradientBorderView({
   end = DEFAULT_END,
   borderWidth = THICK_BORDER_WIDTH,
   borderRadius = DEFAULT_BORDER_RADIUS,
+  borderTopLeftRadius,
+  borderTopRightRadius,
+  borderBottomLeftRadius,
+  borderBottomRightRadius,
   style,
   backgroundColor = DEFAULT_BACKGROUND_COLOR,
 }: GradientBorderViewProps) {
+  const radiusStyle = {
+    borderTopLeftRadius: borderTopLeftRadius ?? borderRadius,
+    borderTopRightRadius: borderTopRightRadius ?? borderRadius,
+    borderBottomLeftRadius: borderBottomLeftRadius ?? borderRadius,
+    borderBottomRightRadius: borderBottomRightRadius ?? borderRadius,
+  };
+
   return (
-    <View style={[styles.baseStyle, style, { backgroundColor, borderRadius }]}>
+    <View style={[styles.baseStyle, style, { backgroundColor }, radiusStyle]}>
       <MaskedView
-        maskElement={<View style={[styles.maskElement, { borderWidth, borderRadius }]} />}
+        maskElement={<View style={[styles.maskElement, { borderWidth }, radiusStyle]} />}
         style={styles.maskView}
         pointerEvents="none"
       >

--- a/src/features/rnbw-membership/components/TierProgressBar.tsx
+++ b/src/features/rnbw-membership/components/TierProgressBar.tsx
@@ -1,0 +1,207 @@
+import { memo, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
+import { useBackgroundColor, useColorMode } from '@/design-system';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { TIER_VISUALS } from '@/features/rnbw-membership/constants';
+import { getValueForColorMode } from '@/design-system/color/palettes';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Blur, Canvas, LinearGradient as SkiaLinearGradient, RoundedRect, vec } from '@shopify/react-native-skia';
+import type { Tier } from '@/features/rnbw-membership/types';
+
+const PROGRESS_BAR_HORIZONTAL_PADDING = 12;
+const PROGRESS_HIGHLIGHT_INSET = 5;
+const PROGRESS_HIGHLIGHT_HEIGHT = 5;
+const PROGRESS_HIGHLIGHT_RADIUS = 2.5;
+const PROGRESS_HIGHLIGHT_BLUR = 2;
+const PROGRESS_HIGHLIGHT_BLUR_PADDING = PROGRESS_HIGHLIGHT_BLUR * 2;
+
+type TierProgressBarProps = {
+  width: number;
+  height: number;
+  tier: Tier;
+  tierIndex: number;
+  tierProgress: number;
+  tierCount: number;
+};
+
+export const TierProgressBar = memo(function TierProgressBar({
+  width,
+  height,
+  tier,
+  tierIndex,
+  tierProgress,
+  tierCount,
+}: TierProgressBarProps) {
+  const { isDarkMode, colorMode } = useColorMode();
+  const surfaceSecondary = useBackgroundColor('surfaceSecondary');
+  const backgroundColor = isDarkMode ? '#242529' : surfaceSecondary;
+  const isMaxTier = tierIndex === tierCount - 1;
+
+  const { gradient, borderGradient, shadow, highlightGradient } = useMemo(() => {
+    const visuals = TIER_VISUALS[tier.level];
+    return {
+      gradient: getValueForColorMode(visuals.progressBarGradient, colorMode),
+      borderGradient: getValueForColorMode(visuals.progressBarBorderGradient, colorMode),
+      shadow: getValueForColorMode(visuals.progressBarShadow, colorMode),
+      highlightGradient: getValueForColorMode(visuals.progressHighlightGradient, colorMode),
+    };
+  }, [tier.level, colorMode]);
+
+  const tierMarkerPositions = useMemo(() => {
+    const usableWidth = width - PROGRESS_BAR_HORIZONTAL_PADDING * 2;
+    return Array.from({ length: tierCount }, (_, i) => PROGRESS_BAR_HORIZONTAL_PADDING * 2 + (i * usableWidth) / (tierCount - 1));
+  }, [tierCount, width]);
+
+  const fillWidth = useMemo(() => {
+    const base = tierMarkerPositions[tierIndex];
+    const next = tierMarkerPositions[tierIndex + 1] ?? base;
+    return base + tierProgress * (next - base);
+  }, [tierMarkerPositions, tierIndex, tierProgress]);
+
+  const { leftRadius, rightRadius } = useMemo(() => {
+    const full = height / 2;
+    return { leftRadius: full, rightRadius: isMaxTier ? full : 8 };
+  }, [height, isMaxTier]);
+
+  const progressHighlight = useMemo(() => {
+    const rectWidth = fillWidth - PROGRESS_HIGHLIGHT_INSET * 2;
+
+    // Blur needs extra canvas area, otherwise Skia clips the softened edges.
+    return {
+      canvasLeft: PROGRESS_HIGHLIGHT_INSET - PROGRESS_HIGHLIGHT_BLUR_PADDING,
+      canvasTop: PROGRESS_HIGHLIGHT_INSET - PROGRESS_HIGHLIGHT_BLUR_PADDING,
+      canvasWidth: rectWidth + PROGRESS_HIGHLIGHT_BLUR_PADDING * 2,
+      canvasHeight: PROGRESS_HIGHLIGHT_HEIGHT + PROGRESS_HIGHLIGHT_BLUR_PADDING * 2,
+      rectX: PROGRESS_HIGHLIGHT_BLUR_PADDING,
+      rectY: PROGRESS_HIGHLIGHT_BLUR_PADDING,
+      rectWidth,
+    };
+  }, [fillWidth]);
+
+  return (
+    <GradientBorderView
+      borderGradientColors={isDarkMode ? [opacity('#9AA2A7', 0.016), opacity('#9AA2A7', 0.08)] : ['rgba(0,0,0,0)', 'rgba(0,0,0,0)']}
+      borderWidth={1}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0, y: 1 }}
+      backgroundColor={backgroundColor}
+      style={{ height, width, overflow: 'visible' }}
+    >
+      <TierDots tierCount={tierCount} />
+      <GradientBorderView
+        borderGradientColors={borderGradient.colors}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        borderWidth={1}
+        borderTopRightRadius={rightRadius}
+        borderBottomRightRadius={rightRadius}
+        borderTopLeftRadius={leftRadius}
+        borderBottomLeftRadius={leftRadius}
+        style={{
+          height,
+          width: fillWidth,
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          overflow: 'visible',
+          ...shadow,
+        }}
+      >
+        <LinearGradient
+          colors={gradient.colors}
+          start={gradient.start}
+          end={gradient.end}
+          style={[
+            StyleSheet.absoluteFill,
+            {
+              borderTopRightRadius: rightRadius,
+              borderBottomRightRadius: rightRadius,
+              borderTopLeftRadius: leftRadius,
+              borderBottomLeftRadius: leftRadius,
+              borderCurve: 'continuous',
+            },
+          ]}
+        />
+        <Canvas
+          style={{
+            position: 'absolute',
+            top: progressHighlight.canvasTop,
+            left: progressHighlight.canvasLeft,
+            height: progressHighlight.canvasHeight,
+            width: progressHighlight.canvasWidth,
+          }}
+        >
+          <RoundedRect
+            x={progressHighlight.rectX}
+            y={progressHighlight.rectY}
+            width={progressHighlight.rectWidth}
+            height={PROGRESS_HIGHLIGHT_HEIGHT}
+            r={PROGRESS_HIGHLIGHT_RADIUS}
+            opacity={0.5}
+          >
+            <SkiaLinearGradient
+              start={vec(progressHighlight.rectX, progressHighlight.rectY)}
+              end={vec(progressHighlight.rectX + progressHighlight.rectWidth, progressHighlight.rectY)}
+              // Cast expo LinearGradientProps for Skia compatibility
+              positions={highlightGradient.locations as unknown as number[] | undefined}
+              colors={highlightGradient.colors as unknown as string[]}
+            />
+            <Blur blur={PROGRESS_HIGHLIGHT_BLUR} />
+          </RoundedRect>
+        </Canvas>
+      </GradientBorderView>
+      <InnerShadow
+        width={width}
+        height={height}
+        borderRadius={height / 2}
+        color={isDarkMode ? opacity('#000000', 0.43) : opacity('#7A7A7A', 0.13)}
+        blur={2}
+        dx={0}
+        dy={1}
+      />
+    </GradientBorderView>
+  );
+});
+
+const DOT_SIZE = 8;
+const DOT_RADIUS = DOT_SIZE / 2;
+
+const TierDots = memo(function TierDots({ tierCount }: { tierCount: number }) {
+  return (
+    <View style={styles.dotsContainer}>
+      {Array.from({ length: tierCount }).map((_, index) => (
+        <TierDot key={index} />
+      ))}
+    </View>
+  );
+});
+
+function TierDot() {
+  const { isDarkMode } = useColorMode();
+  return (
+    <View style={[styles.dot, { backgroundColor: isDarkMode ? opacity('#FFFFFF', 0.05) : '#E3E3E3' }]}>
+      {!isDarkMode && (
+        <InnerShadow width={DOT_SIZE} height={DOT_SIZE} borderRadius={DOT_RADIUS} color={opacity('#7A7A7A', 0.13)} blur={2} dx={0} dy={1} />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dotsContainer: {
+    flexDirection: 'row',
+    height: '100%',
+    width: '100%',
+    paddingHorizontal: PROGRESS_BAR_HORIZONTAL_PADDING,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_RADIUS,
+    overflow: 'hidden',
+  },
+});

--- a/src/features/rnbw-membership/constants.ts
+++ b/src/features/rnbw-membership/constants.ts
@@ -33,6 +33,10 @@ type TierVisuals = {
   badgeBorderGradient: Themed<GradientConfig>;
   badgeShadow: Themed<ShadowConfig>;
   badgeTextShadow: Themed<TextShadowConfig>;
+  progressBarGradient: Themed<GradientConfig>;
+  progressBarBorderGradient: Themed<GradientConfig>;
+  progressBarShadow: Themed<ShadowConfig>;
+  progressHighlightGradient: Themed<GradientConfig>;
 };
 
 const BADGE_BORDER_GRADIENT_LIGHT = [opacity(globalColors.grey100, 0.02), opacity(globalColors.grey100, 0.05)] as const;
@@ -62,6 +66,18 @@ export const TIER_VISUALS: Record<TierId, TierVisuals> = {
       textShadowOffset: { width: 0, height: 1 },
       textShadowRadius: 1,
     }),
+    progressBarGradient: sameForModes({ colors: ['#2B80F4', '#1F6FDC'] }),
+    progressBarBorderGradient: {
+      light: { colors: ['rgba(0,0,0,0.06)', 'rgba(0,0,0,0.06)'] },
+      dark: { colors: ['rgba(255,255,255,0.12)', 'rgba(255,255,255,0.12)'] },
+    },
+    progressBarShadow: sameForModes({
+      shadowColor: '#2A99FA',
+      shadowOffset: { width: 0, height: 0 },
+      shadowOpacity: 0.5,
+      shadowRadius: 2.5,
+    }),
+    progressHighlightGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
   },
   STAKING_TIER_LEVEL_SILVER: {
     backgroundGradient: {
@@ -84,6 +100,16 @@ export const TIER_VISUALS: Record<TierId, TierVisuals> = {
       textShadowOffset: { width: 1, height: 1 },
       textShadowRadius: 0,
     }),
+    progressBarGradient: sameForModes({ colors: ['#EFEFEF', '#A2A2A2'] }),
+    progressBarBorderGradient: {
+      light: { colors: [opacity('#959595', 0.15), opacity('#3B3B3B', 0.09)] },
+      dark: { colors: ['rgba(255,255,255,0.3)', 'rgba(255,255,255,0.3)'] },
+    },
+    progressBarShadow: {
+      light: { shadowColor: '#000000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.06, shadowRadius: 6 },
+      dark: { shadowColor: '#B2B2B2', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.3, shadowRadius: 15 },
+    },
+    progressHighlightGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
   },
   STAKING_TIER_LEVEL_GOLD: {
     backgroundGradient: {
@@ -106,6 +132,16 @@ export const TIER_VISUALS: Record<TierId, TierVisuals> = {
       textShadowOffset: { width: 1, height: 1 },
       textShadowRadius: 0,
     }),
+    progressBarGradient: sameForModes({ colors: ['#FAD96A', '#E7B114'] }),
+    progressBarBorderGradient: {
+      light: { colors: ['rgba(0,0,0,0.06)', 'rgba(0,0,0,0.06)'] },
+      dark: { colors: ['rgba(255,255,255,0.3)', 'rgba(255,255,255,0.3)'] },
+    },
+    progressBarShadow: {
+      light: { shadowColor: '#E5B92C', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.5, shadowRadius: 2.5 },
+      dark: { shadowColor: '#FFDD20', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.3, shadowRadius: 15 },
+    },
+    progressHighlightGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
   },
   STAKING_TIER_LEVEL_DIAMOND: {
     backgroundGradient: {
@@ -128,9 +164,19 @@ export const TIER_VISUALS: Record<TierId, TierVisuals> = {
       textShadowOffset: { width: 1, height: 1 },
       textShadowRadius: 0,
     }),
+    progressBarGradient: { light: { colors: ['#ECF2F8', '#C8D1D7'] }, dark: { colors: ['#D5DCE3', '#9AA7B0'] } },
+    progressBarBorderGradient: {
+      light: { colors: [opacity('#6C8CA8', 0.15), opacity('#404647', 0.09)] },
+      dark: { colors: [opacity('#959595', 0.15), opacity('#3B3B3B', 0.06)] },
+    },
+    progressBarShadow: {
+      light: { shadowColor: '#000000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.06, shadowRadius: 6 },
+      dark: { shadowColor: '#42D2EB', shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.3, shadowRadius: 15 },
+    },
+    progressHighlightGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
   },
   STAKING_TIER_LEVEL_BLACK: {
-    backgroundGradient: sameForModes({ colors: [opacity('#FFFFFF', 0), opacity('#FFFFFF', 0)] }),
+    backgroundGradient: sameForModes({ colors: ['rgba(255,255,255,0)', 'rgba(255,255,255,0)'] }),
     textGradient: { light: { colors: ['#000000', '#000000'] }, dark: { colors: ['#FFFFFF', '#FFFFFF'] } },
     badgeTextGradient: sameForModes({ colors: ['#FFFFFF', '#FFFFFF'] }),
     badgeGradient: sameForModes({ colors: ['#444444', '#000000'] }),
@@ -140,6 +186,18 @@ export const TIER_VISUALS: Record<TierId, TierVisuals> = {
       dark: { shadowColor: '#1A1C22', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.3, shadowRadius: 8 },
     },
     badgeTextShadow: sameForModes({ textShadowColor: 'rgba(0, 0, 0, 0)', textShadowOffset: { width: 0, height: 0 }, textShadowRadius: 0 }),
+    progressBarGradient: sameForModes({ colors: ['#444444', '#000000'] }),
+    progressBarBorderGradient: sameForModes({ colors: ['rgba(0,0,0,0)', 'rgba(0,0,0,0)'] }),
+    progressBarShadow: sameForModes({
+      shadowColor: '#000000',
+      shadowOffset: { width: 0, height: 4 },
+      shadowOpacity: 0.06,
+      shadowRadius: 6,
+    }),
+    progressHighlightGradient: sameForModes({
+      colors: ['#7D53FF', '#3FBDFF', '#4BFF9D', '#FFD73A', '#FF5E4D', '#FF3C91'],
+      locations: [0, 0.15, 0.36, 0.57, 0.79, 1],
+    }),
   },
 };
 

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
@@ -1,29 +1,57 @@
 import { memo } from 'react';
-import { Box, Text } from '@/design-system';
+import { Box, Separator, Text } from '@/design-system';
 import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
+import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
+import { TierThemedLabel } from '@/features/rnbw-membership/components/TierThemedLabel';
+import { TierProgressBar } from '@/features/rnbw-membership/components/TierProgressBar';
+import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 export const MembershipTierCard = memo(function MembershipTierCard() {
-  const { currentTier, stakeRequiredForNextTier, cashbackPercentage, currentTierProgress } = useMembershipTierInfo();
+  const { currentTier, currentTierIndex, currentTierProgress, stakeRequiredForNextTier, cashbackPercentage, allTiers } =
+    useMembershipTierInfo();
 
   return (
     <ButtonPressAnimation onPress={navigateToMembershipTiersSheet} scaleTo={0.96}>
-      <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
-        <Text size="22pt" weight="heavy" color="label">
-          {`${currentTier.name} Tier`}
-        </Text>
-        <Text size="17pt" weight="heavy" color="label">
-          {`current tier progress: ${currentTierProgress * 100}/100`}
-        </Text>
-        <Text size="17pt" weight="heavy" color="label">
-          {`Cashback: ${cashbackPercentage}%`}
-        </Text>
-        <Text size="17pt" weight="heavy" color="label">
-          {`Stake to unlock: ${stakeRequiredForNextTier}`}
-        </Text>
-      </Box>
+      <MembershipCard paddingHorizontal="20px" paddingVertical="24px">
+        <Box gap={16}>
+          <TierThemedLabel tier={currentTier}>
+            <Text size="22pt" weight="heavy" color="label">
+              {`${currentTier.name} Tier`}
+            </Text>
+          </TierThemedLabel>
+          <TierProgressBar
+            width={DEVICE_WIDTH - 80}
+            height={24}
+            tier={currentTier}
+            tierIndex={currentTierIndex}
+            tierProgress={currentTierProgress}
+            tierCount={allTiers.length}
+          />
+          <Box gap={16} paddingHorizontal={'4px'}>
+            <Box flexDirection="row" justifyContent="space-between">
+              <Text size="17pt" weight="semibold" color="labelTertiary">
+                {'Rewards'}
+              </Text>
+              <Text size="17pt" weight="bold" color="label">
+                {`${cashbackPercentage}%`}
+              </Text>
+            </Box>
+            <Separator color="separatorTertiary" thickness={1} />
+            <Box flexDirection="row" justifyContent="space-between">
+              <Text size="17pt" weight="semibold" color="labelTertiary">
+                {'Stake to next tier'}
+              </Text>
+              <Text size="17pt" weight="bold" color="label">
+                {`${stakeRequiredForNextTier} ${RNBW_SYMBOL}`}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      </MembershipCard>
     </ButtonPressAnimation>
   );
 });

--- a/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
@@ -10,13 +10,13 @@ import Animated, { Extrapolation, interpolate, useAnimatedStyle, useDerivedValue
 import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
 import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 import { formatNumber } from '@/helpers/strings';
-import { opacity } from '@/framework/ui/utils/opacity';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { TierThemedLabel } from '../../components/TierThemedLabel';
 import { TierBadge } from '../../components/TierBadge';
 import { TIER_VISUALS } from '../../constants';
 import { LinearGradient, type LinearGradientProps } from 'expo-linear-gradient';
 import { getValueForColorMode } from '@/design-system/color/palettes';
+import { TierProgressBar } from '@/features/rnbw-membership/components/TierProgressBar';
 
 const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
 
@@ -40,8 +40,12 @@ export const RnbwMembershipTiersSheet = memo(function RnbwMembershipTiersSheet()
           />
         ))}
         <SmoothPager enableSwipeToGoBack={true} enableSwipeToGoForward={'always'} initialPage={currentTier.level} ref={ref}>
-          {allTiers.map(tier => (
-            <SmoothPager.Page key={tier.level} component={<Tier tier={tier} />} id={tier.level} />
+          {allTiers.map((tier, index) => (
+            <SmoothPager.Page
+              key={tier.level}
+              component={<Tier tier={tier} tierIndex={index} tierCount={allTiers.length} />}
+              id={tier.level}
+            />
           ))}
         </SmoothPager>
         <StepIndicators
@@ -54,7 +58,7 @@ export const RnbwMembershipTiersSheet = memo(function RnbwMembershipTiersSheet()
   );
 });
 
-function Tier({ tier }: { tier: TierType }) {
+function Tier({ tier, tierIndex, tierCount }: { tier: TierType; tierIndex: number; tierCount: number }) {
   const stakeRequiredForTierDisplay = formatNumber(convertRawAmountToDecimalFormat(tier.minStakeAmount, RNBW_DECIMALS));
   const tierCashbackDisplay = `${tier.cashbackBps / 100}%`;
 
@@ -79,6 +83,7 @@ function Tier({ tier }: { tier: TierType }) {
             </Text>
           </Box>
         </Box>
+        <TierProgressBar width={PANEL_WIDTH - 64} height={24} tier={tier} tierIndex={tierIndex} tierProgress={0} tierCount={tierCount} />
         <Box gap={16} paddingHorizontal={'8px'}>
           <Box flexDirection="row" justifyContent="space-between">
             <Text size="17pt" weight="semibold" color="labelTertiary">
@@ -88,7 +93,7 @@ function Tier({ tier }: { tier: TierType }) {
               {tierCashbackDisplay}
             </Text>
           </Box>
-          <Separator thickness={1} color={{ custom: opacity(globalColors.grey100, 0.04) }} />
+          <Separator thickness={1} color={'separatorTertiary'} />
           <Box flexDirection="row" justifyContent="space-between">
             <Text size="17pt" weight="semibold" color="labelTertiary">
               {'Stake to unlock'}

--- a/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
+++ b/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
@@ -11,19 +11,21 @@ import { FALLBACK_TIERS } from '@/features/rnbw-membership/constants';
 type MembershipTierInfo = {
   currentTier: Tier;
   stakeRequiredForNextTier: string;
-  cashbackPercentage: string;
+  cashbackPercentage: number;
   currentTierProgress: number;
   allTiers: Tier[];
   currentTierIndex: number;
+  maxTierProgress: number;
 };
 
 const EMPTY_TIER: MembershipTierInfo = {
   currentTier: FALLBACK_TIERS[0],
   stakeRequiredForNextTier: '0',
-  cashbackPercentage: '10%',
+  cashbackPercentage: 10,
   currentTierProgress: 0,
   allTiers: FALLBACK_TIERS,
   currentTierIndex: 0,
+  maxTierProgress: 0,
 };
 
 export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
@@ -39,13 +41,15 @@ export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
     const currentTierIndex = allTiers.findIndex(t => t.level === currentTier.level);
     const nextTierIndex = currentTierIndex + 1;
     const nextTier = nextTierIndex < allTiers.length ? allTiers[nextTierIndex] : null;
+    const maxTier = allTiers[allTiers.length - 1];
 
     const stakeRequiredForNextTierRaw = nextTier ? subWorklet(nextTier.minStakeAmount, stakedRnbw) : '0';
     const stakeRequiredForNextTier = formatNumber(convertRawAmountToDecimalFormat(stakeRequiredForNextTierRaw, RNBW_DECIMALS));
-    const cashbackPercentage = convertBipsToPercentage(currentTier.cashbackBps, 0);
+    const cashbackPercentage = Number(convertBipsToPercentage(currentTier.cashbackBps, 0));
     const stakedAboveCurrentTier = subWorklet(stakedRnbw, currentTier.minStakeAmount);
     const currentTierRange = subWorklet(nextTier?.minStakeAmount ?? currentTier.minStakeAmount, currentTier.minStakeAmount);
     const currentTierProgress = nextTier ? Number(toFixedWorklet(divWorklet(stakedAboveCurrentTier, currentTierRange), 3)) : 1;
+    const maxTierProgress = Math.min(1, Number(divWorklet(stakedRnbw, maxTier.minStakeAmount)));
 
     return {
       currentTier,
@@ -54,6 +58,7 @@ export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
       currentTierProgress,
       allTiers,
       currentTierIndex,
+      maxTierProgress,
     };
   },
   { equalityFn: shallowEqual, fastMode: true }


### PR DESCRIPTION
## What changed
Adds the tier progress bar and redesigns the membership tier card to use it. Also adds the progress bar to each page in the tiers sheet.

#### Main changes
- `TierProgressBar`: horizontal progress bar with dot markers for each tier and per-tier gradient fill.
- `MembershipTierCard`: adds the `TierProgressBar` and `MembershipCard` wrapper
- `RnbwMembershipTiersSheet`: added `TierProgressBar` to each tier page
- - `rnbw-membership/constants.ts`: added `progressBarGradient`, `progressBarBorderGradient`, `progressBarShadow` to all tier visual configs

#### Other changes
- `GradientBorderView`: added per-corner radius props
- `useMembershipTierInfo`: added `maxTierProgress`, changed `cashbackPercentage` to a number

## Screenshots / Screen recordings

https://github.com/user-attachments/assets/d82f7a77-4790-4267-a45b-10c0cd158508


