### PR TITLE
feature: exit penalty recovery progress meter and screen polish

### DIFF
--- a/src/features/rnbw-membership/components/ProgressMeter.tsx
+++ b/src/features/rnbw-membership/components/ProgressMeter.tsx
@@ -1,0 +1,162 @@
+import { memo, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Box, useBackgroundColor, useColorMode } from '@/design-system';
+import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { LinearGradient } from 'expo-linear-gradient';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+
+const GRADIENT_FILL_COLORS = ['#27D857', '#1DB847'] as const;
+const GRADIENT_FILL_START = { x: 0, y: 0.5 };
+const GRADIENT_FILL_END = { x: 1, y: 0.5 };
+const GRADIENT_BORDER_START = { x: 0.5, y: 0 };
+const GRADIENT_BORDER_END = { x: 0.5, y: 0.5 };
+const MIN_PROGRESS = 0.05;
+const NOTCH_INNER_SHADOW_COLOR = opacity('#7A7A7A', 0.13);
+
+type ProgressMeterProps = {
+  progress: number;
+  height: number;
+  width: number;
+  notchWidth: number;
+  notchHeight: number;
+  notchCount?: number;
+};
+
+export const ProgressMeter = memo(function ProgressMeter({
+  progress,
+  height,
+  width,
+  notchWidth,
+  notchHeight,
+  notchCount = 4,
+}: ProgressMeterProps) {
+  const { isDarkMode } = useColorMode();
+  const surfaceSecondary = useBackgroundColor('surfaceSecondary');
+  const backgroundColor = isDarkMode ? '#242529' : surfaceSecondary;
+  const clampedProgress = Math.max(MIN_PROGRESS, Math.min(1, progress));
+  const fillHeight = height * clampedProgress;
+  const borderRadius = height / 2;
+
+  const sx = useMemo(
+    () => ({
+      container: {
+        height,
+        width,
+        borderRadius,
+        overflow: 'hidden' as const,
+      },
+      fill: {
+        height: fillHeight,
+        width,
+        shadowColor: opacity('#39D6B2', 0.3),
+        shadowRadius: 2.5,
+      },
+      fillBorderTop: {
+        backgroundColor: isDarkMode ? opacity('#FFFFFF', 0.2) : opacity('#000000', 0.06),
+      },
+    }),
+    [fillHeight, height, width, borderRadius, isDarkMode]
+  );
+
+  return (
+    <GradientBorderView
+      borderGradientColors={
+        isDarkMode
+          ? [opacity('#9AA2A7', 0.016), opacity('#9AA2A7', 0.08)]
+          : // no border in light mode
+            ['rgba(0,0,0,0)', 'rgba(0,0,0,0)']
+      }
+      start={GRADIENT_BORDER_START}
+      end={GRADIENT_BORDER_END}
+      backgroundColor={backgroundColor}
+      style={sx.container}
+    >
+      <InnerShadow
+        width={width}
+        height={height}
+        borderRadius={borderRadius}
+        color={isDarkMode ? opacity('#000000', 0.43) : opacity('#7A7A7A', 0.13)}
+        blur={2}
+        dx={0}
+        dy={1}
+      />
+      <Box style={[styles.fill, sx.fill]}>
+        <LinearGradient colors={GRADIENT_FILL_COLORS} start={GRADIENT_FILL_START} end={GRADIENT_FILL_END} style={StyleSheet.absoluteFill} />
+        <View style={[styles.fillBorderTop, sx.fillBorderTop]} />
+      </Box>
+      <Notches count={notchCount} progress={progress} notchWidth={notchWidth} notchHeight={notchHeight} />
+    </GradientBorderView>
+  );
+});
+
+const Notches = memo(function Notches({
+  count,
+  progress,
+  notchWidth,
+  notchHeight,
+}: {
+  count: number;
+  progress: number;
+  notchWidth: number;
+  notchHeight: number;
+}) {
+  const { isDarkMode } = useColorMode();
+
+  const sx = useMemo(
+    () => ({
+      notch: {
+        width: notchWidth,
+        height: notchHeight,
+        borderRadius: notchHeight / 2,
+        backgroundColor: isDarkMode ? '#2F3034' : '#E3E3E3',
+      },
+      notchOnFill: {
+        backgroundColor: isDarkMode ? opacity('#090909', 0.3) : opacity('#FFFFFF', 0.3),
+      },
+    }),
+    [notchHeight, notchWidth, isDarkMode]
+  );
+
+  return (
+    <View style={styles.notches}>
+      {Array.from({ length: count }).map((_, index) => {
+        const isOnFill = progress >= (count - index) / (count + 1);
+        return (
+          <View key={index} style={[sx.notch, isOnFill && sx.notchOnFill]}>
+            {!isOnFill && (
+              <InnerShadow
+                width={notchWidth}
+                height={notchHeight}
+                borderRadius={notchHeight / 2}
+                color={NOTCH_INNER_SHADOW_COLOR}
+                blur={2}
+                dx={0}
+                dy={1}
+              />
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  fill: {
+    position: 'absolute',
+    bottom: 0,
+    borderBottomWidth: 0,
+  },
+  fillBorderTop: {
+    position: 'absolute',
+    top: 0,
+    height: 1,
+    width: '100%',
+  },
+  notches: {
+    justifyContent: 'space-evenly',
+    alignItems: 'center',
+    flex: 1,
+  },
+});

--- a/src/features/rnbw-membership/components/TierBadge.tsx
+++ b/src/features/rnbw-membership/components/TierBadge.tsx
@@ -9,6 +9,7 @@ import { getValueForColorMode, globalColors } from '@/design-system/color/palett
 import { StyleSheet, View } from 'react-native';
 import type { Tier as TierType } from '@/features/rnbw-membership/types';
 import GradientText from '@/components/text/GradientText';
+import type { TextSize, TextWeight } from '@/design-system/components/Text/Text';
 
 const BORDER_GRADIENT_START = { x: 0, y: 1 };
 const BORDER_GRADIENT_END = { x: 0, y: 0 };
@@ -17,7 +18,17 @@ const BADGE_GRADIENT_END = { x: 0, y: 1 };
 const BADGE_TEXT_GRADIENT_START = { x: 0, y: 0 };
 const BADGE_TEXT_GRADIENT_END = { x: 0, y: 1 };
 
-export const TierBadge = memo(function TierBadge({ tier }: { tier: TierType }) {
+export const TierBadge = memo(function TierBadge({
+  tier,
+  height = 42,
+  fontSize = '22pt',
+  weight = 'heavy',
+}: {
+  tier: TierType;
+  height?: number;
+  fontSize?: TextSize;
+  weight?: TextWeight;
+}) {
   const { colorMode } = useColorMode();
   const { badgeGradient, badgeTextGradient, badgeTextShadow, badgeShadow, badgeBorderGradient } = TIER_VISUALS[tier.level];
   const {
@@ -49,7 +60,7 @@ export const TierBadge = memo(function TierBadge({ tier }: { tier: TierType }) {
         start={borderStart}
         end={borderEnd}
         borderWidth={2}
-        style={styles.tierBadge}
+        style={[styles.tierBadge, { height, borderRadius: height / 2 }]}
       >
         <InnerShadow color={opacity(globalColors.white100, 0.1)} blur={1} dx={0} dy={3} />
         <LinearGradient
@@ -66,7 +77,7 @@ export const TierBadge = memo(function TierBadge({ tier }: { tier: TierType }) {
           end={badgeTextEnd}
           shadow={textShadowStyle}
         >
-          <Text size="22pt" weight="heavy" color="label">
+          <Text size={fontSize} weight={weight} color="label">
             {tier.name.toLocaleUpperCase()}
           </Text>
         </GradientText>

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useCallback } from 'react';
 import { RefreshControl, ScrollView, StyleSheet } from 'react-native';
-import { Box } from '@/design-system';
+import { Box, useColorMode } from '@/design-system';
 import { AccountImage } from '@/components/AccountImage';
 import { Navbar } from '@/components/navbar/Navbar';
 import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
@@ -15,13 +15,16 @@ import { delay } from '@/utils/delay';
 import { time } from '@/utils/time';
 import { RnbwStakingEarningsCard } from './components/RnbwStakingEarningsCard';
 import { TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
+import { TierBadge } from '@/features/rnbw-membership/components/TierBadge';
+import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
   const hasPosition = useStakingPositionStore(s => s.hasPosition());
+  const { isDarkMode } = useColorMode();
 
   return (
-    <Box background="surfaceSecondary" style={styles.flex}>
-      <Navbar hasStatusBarInset title="Membership" leftComponent={<AccountImage />} />
+    <Box backgroundColor={isDarkMode ? '#090909' : '#F5F5F7'} style={styles.flex}>
+      <Navbar hasStatusBarInset titleComponent={<CurrentTierBadge />} leftComponent={<AccountImage />} />
       <ScrollView
         refreshControl={<RefreshControlWrapper />}
         contentContainerStyle={styles.scrollViewContentContainer}
@@ -60,6 +63,11 @@ function RefreshControlWrapper() {
   }, []);
 
   return <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />;
+}
+
+function CurrentTierBadge() {
+  const { currentTier } = useMembershipTierInfo();
+  return <TierBadge tier={currentTier} height={32} fontSize="17pt" />;
 }
 
 const styles = StyleSheet.create({

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwUnstakePenaltyRecoveryCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwUnstakePenaltyRecoveryCard.tsx
@@ -1,21 +1,49 @@
 import { memo } from 'react';
-import { Box, Text } from '@/design-system';
+import { Box, Separator, Text, useColorMode } from '@/design-system';
 import { useRnbwStakingPositionPnl } from '@/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
+import { ProgressMeter } from '@/features/rnbw-membership/components/ProgressMeter';
+import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
+import { formatNumber } from '@/helpers/strings';
 
 export const RnbwUnstakePenaltyRecoveryCard = memo(function RnbwUnstakePenaltyRecoveryCard() {
-  const { exitFeeOffsetRatio, earnedFromExitFees, earningsRequiredToBreakEven } = useRnbwStakingPositionPnl();
+  const { isDarkMode } = useColorMode();
+  const { exitFeeOffsetRatio, exitFeeOffsetRatioDisplay, earnedFromExitFees, earningsRequiredToBreakEven, isPositivePnl } =
+    useRnbwStakingPositionPnl();
+
   return (
-    <Box background="surfacePrimary" borderRadius={24} padding="20px" gap={20} shadow={'18px'}>
-      <Text size="17pt" weight="bold" color="label">
-        {'Loyalty Progress'}
-      </Text>
-      <Text size="17pt" weight="bold" color="label">
-        {exitFeeOffsetRatio}
-      </Text>
-      <Text size="15pt" weight="bold" color="labelSecondary">
-        {`You've earned ${earnedFromExitFees} ${RNBW_SYMBOL} from the pool. Just ${earningsRequiredToBreakEven} ${RNBW_SYMBOL} more to reach pure profit.`}
-      </Text>
-    </Box>
+    <MembershipCard padding="24px">
+      <Box gap={16}>
+        <Box flexDirection="row" alignItems="center" gap={16}>
+          <ProgressMeter progress={Number(exitFeeOffsetRatio)} height={63} width={24} notchWidth={6} notchHeight={2} />
+          <Box gap={16}>
+            <Text size="17pt" weight="bold" color="labelTertiary">
+              {'Loyalty Progress'}
+            </Text>
+            <Text size="34pt" weight="heavy" color="green">
+              {exitFeeOffsetRatioDisplay}
+            </Text>
+          </Box>
+        </Box>
+        <Separator color="separatorTertiary" thickness={1} />
+        {isPositivePnl ? (
+          <Text size="15pt" weight="medium" color="labelTertiary">
+            {'Break even reached!'}
+          </Text>
+        ) : (
+          <Text size="15pt" weight="medium" color="labelTertiary">
+            {"You've earned "}
+            <Text size="15pt" weight="bold" color={isDarkMode ? 'labelSecondary' : 'label'}>
+              {`${formatNumber(earnedFromExitFees, { decimals: 2 })} ${RNBW_SYMBOL}`}
+            </Text>
+            {' from the pool. Just '}
+            <Text size="15pt" weight="bold" color={isDarkMode ? 'labelSecondary' : 'label'}>
+              {`${formatNumber(earningsRequiredToBreakEven, { decimals: 2 })} ${RNBW_SYMBOL}`}
+            </Text>
+            {' more to reach pure profit.'}
+          </Text>
+        )}
+      </Box>
+    </MembershipCard>
   );
 });

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
@@ -1,13 +1,5 @@
-import {
-  divWorklet,
-  greaterThanWorklet,
-  isPositive,
-  mulWorklet,
-  subWorklet,
-  toFixedWorklet,
-  toPercentageWorklet,
-} from '@/framework/core/safeMath';
-import { convertRawAmountToDecimalFormatWorklet, formatNumber } from '@/helpers/utilities';
+import { divWorklet, isPositive, mulWorklet, subWorklet, toFixedWorklet, toPercentageWorklet } from '@/framework/core/safeMath';
+import { convertRawAmountToDecimalFormatWorklet, formatNumber, isZero } from '@/helpers/utilities';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { shallowEqual } from '@/worklets/comparisons';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
@@ -15,6 +7,7 @@ import { UNSTAKE_PENALTY_PERCENTAGE } from '@/features/rnbw-staking/constants';
 
 type StakingPositionPnl = {
   exitFeeOffsetRatio: string;
+  exitFeeOffsetRatioDisplay: string;
   netPnl: string;
   isPositivePnl: boolean;
   earnedFromExitFees: string;
@@ -22,7 +15,8 @@ type StakingPositionPnl = {
 };
 
 const EMPTY_VALUE: StakingPositionPnl = {
-  exitFeeOffsetRatio: '0%',
+  exitFeeOffsetRatio: '0',
+  exitFeeOffsetRatioDisplay: '0%',
   netPnl: '0',
   isPositivePnl: false,
   earnedFromExitFees: '0',
@@ -40,16 +34,14 @@ export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
     const exchangeRateGain = sessionPnl?.exchangeRateGain ?? '0';
     const exitFee = mulWorklet(stakedRnbw, UNSTAKE_PENALTY_PERCENTAGE / 100);
     const exitFeeOffsetRatio = toFixedWorklet(divWorklet(exchangeRateGain, exitFee), 4);
-    const exitFeeOffsetRatioFormatted = !greaterThanWorklet(exitFeeOffsetRatio, '0')
-      ? '0%'
-      : `${toPercentageWorklet(exitFeeOffsetRatio, 0.001)}%`;
 
     const netPnl = subWorklet(exchangeRateGain, exitFee);
     const isPositivePnl = isPositive(netPnl);
     const netPnlFormatted = toFixedWorklet(convertRawAmountToDecimalFormatWorklet(netPnl, decimals), 4);
 
     return {
-      exitFeeOffsetRatio: exitFeeOffsetRatioFormatted,
+      exitFeeOffsetRatio,
+      exitFeeOffsetRatioDisplay: isZero(exitFeeOffsetRatio) ? '0%' : `${toPercentageWorklet(exitFeeOffsetRatio, 0.001)}%`,
       netPnl: isPositivePnl ? `+${netPnlFormatted}` : netPnlFormatted,
       earnedFromExitFees: formatNumber(convertRawAmountToDecimalFormatWorklet(exchangeRateGain, decimals)),
       earningsRequiredToBreakEven: formatNumber(convertRawAmountToDecimalFormatWorklet(subWorklet(exitFee, exchangeRateGain), decimals)),


### PR DESCRIPTION
## What changed
Adds a progress meter component to the unstake penalty card and polishes the membership screen with a custom background and tier badge in the navbar.

#### Main changes
- `ProgressMeter`: vertical progress meter with notch marks. Configurable because it will also be used on the `RnbwStakingLearnScreen` in a future PR. 
- `RnbwUnstakePenaltyRecoveryCard`: redesigned with `ProgressMeter` and contextual break-even text

#### Other changes
- `RnbwMembershipScreen`: custom background color, `TierBadge` replaces text title in navbar
- `TierBadge`: added configurable `height`, `fontSize`, `weight` props
- `useRnbwStakingPositionPnl`: exposes raw `exitFeeOffsetRatio` alongside display string, added `isPositivePnl`

#### To Note
- The tier badge placement in the navbar is temporary. The final design has the badge slightly masking the staking card, which will be done in a future PR. 

## Screenshots / Screen recordings

https://github.com/user-attachments/assets/e635402c-2020-4ebf-bcdb-cd062f7ea9ea
