### PR TITLE
feature: staking learn sheet complete designs

### DIFF
--- a/src/features/rnbw-staking/components/UnstakePenaltySign.tsx
+++ b/src/features/rnbw-staking/components/UnstakePenaltySign.tsx
@@ -20,9 +20,23 @@ type PenaltySignProps = {
   };
 };
 
+const SIGN_FACE_CONFIG = {
+  width: 81,
+  height: 58,
+  borderRadius: 18,
+  borderWidth: 4.33,
+  fontSize: '26pt',
+  fontWeight: 'heavy',
+} as const;
+
+const SIGN_POST_CONFIG = {
+  width: 8,
+  height: 24,
+} as const;
+
 export const UnstakePenaltySign = memo(function UnstakePenaltySign({
-  signFaceConfig: signFaceConfig = { width: 81, height: 58, borderRadius: 18, borderWidth: 4.33, fontSize: '26pt', fontWeight: 'heavy' },
-  signPostConfig: signPostConfig = { width: 8, height: 24 },
+  signFaceConfig: signFaceConfig = SIGN_FACE_CONFIG,
+  signPostConfig: signPostConfig = SIGN_POST_CONFIG,
 }: PenaltySignProps) {
   const { isDarkMode } = useColorMode();
   const signColor = isDarkMode ? 'rgba(255,255,255,0.6)' : '#000000';

--- a/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
@@ -1,55 +1,163 @@
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
-import { Box, Text } from '@/design-system';
+import { Box, Text, useColorMode } from '@/design-system';
 import Routes from '@/navigation/routesNames';
 import Navigation from '@/navigation/Navigation';
+import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
+import { UNSTAKE_PENALTY_PERCENTAGE } from '@/features/rnbw-staking/constants';
+import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
+import { UnstakePenaltySign } from '@/features/rnbw-staking/components/UnstakePenaltySign';
+import { ProgressMeter } from '@/features/rnbw-membership/components/ProgressMeter';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+import { LinearGradient } from 'expo-linear-gradient';
+import { opacity } from '@/framework/ui/utils/opacity';
+
+const ICON_CONTAINER_WIDTH = 62;
+const RNBW_ICON_SIZE = 52;
+const PROGRESS_METER_HEIGHT = 63;
+const PROGRESS_LABEL_HEIGHT = 24;
+const ARROW_SIZE = 7;
 
 export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
   const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
+  const { isDarkMode } = useColorMode();
+  const screenBackgroundColor = isDarkMode ? '#090909' : '#FEFEFE';
+  const backgroundGradientColor = isDarkMode ? '#FADB71' : '#EFC035';
 
   return (
-    <Box background="surfacePrimary" style={styles.container}>
+    <Box backgroundColor={screenBackgroundColor} style={styles.container}>
+      <LinearGradient
+        colors={[opacity(backgroundGradientColor, 0.2), opacity(backgroundGradientColor, 0)]}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        style={styles.backgroundGradient}
+      />
       <SheetHandleFixedToTop top={safeAreaTop + 6} />
       <View style={[styles.content, { marginTop: safeAreaTop + 40, paddingBottom: safeAreaBottom + 8 }]}>
-        <Box alignItems="center" gap={16}>
-          <Text align="center" color="label" size="30pt" weight="heavy">
-            {'Earn More Rewards With Staking'}
-          </Text>
-          <Text align="center" color="labelTertiary" size="17pt" weight="medium">
-            {'Staking allows you to earn cashback rewards on your swaps.'}
-          </Text>
-        </Box>
-        <Box gap={20} paddingVertical={'20px'}>
-          <Text color="label" size="17pt" weight="bold">
-            {'Reason 1'}
-          </Text>
-          <Text color="label" size="17pt" weight="bold">
-            {'Reason 2'}
-          </Text>
-          <Text color="label" size="17pt" weight="bold">
-            {'Reason 3'}
-          </Text>
-        </Box>
-        <ButtonPressAnimation onPress={navigateToStakingScreen} style={styles.button}>
-          <Box backgroundColor="yellow" borderRadius={24} width={'full'} height={48} justifyContent="center" alignItems="center">
-            <Text color="label" size="22pt" weight="heavy">
-              {'Enable Staking'}
+        <Box gap={64}>
+          <Box alignItems="center" gap={24}>
+            <Text align="center" size="17pt" weight="heavy" color={{ custom: '#D7A921' }}>
+              {'INTRODUCING'}
+            </Text>
+            <Text align="center" color="label" size="44pt" weight="heavy">
+              {'Staking'}
+            </Text>
+            <Text align="center" color="labelTertiary" size="20pt / 135%" weight="semibold">
+              {'Lock your $RNBW to join the pool. Stay longer to recover your exit fee and earn from those who leave.'}
             </Text>
           </Box>
-        </ButtonPressAnimation>
+          <Box gap={42} flexGrow={1}>
+            <ReasonRow
+              title="Put Your $RNBW to Work"
+              subtitle="Stake your RNBW to lock your position and start earning from the pool."
+              icon={<PutYourRnbwToWorkIcon />}
+            />
+            <ReasonRow
+              title={`${UNSTAKE_PENALTY_PERCENTAGE}% Exit Fee`}
+              subtitle={`Unstaking comes with a ${UNSTAKE_PENALTY_PERCENTAGE}% fee.`}
+              icon={<UnstakePenaltyIcon />}
+            />
+            <ReasonRow
+              title="Passive Income"
+              subtitle="Benefit from every exit. Exit fees are distributed to the pool. Stay longer to offset your own fees and reach pure profit."
+              icon={<PassiveIncomeIcon />}
+            />
+          </Box>
+        </Box>
+        <RnbwThemedButton onPress={navigateToStakingScreen} label="Enable Staking" height={48} style={styles.button} />
       </View>
     </Box>
   );
 });
+
+function ReasonRow({ title, subtitle, icon }: { title: string; subtitle: string; icon: ReactNode }) {
+  return (
+    <Box flexDirection="row" alignItems="flex-start" gap={20}>
+      <View style={styles.iconContainer}>{icon}</View>
+      <Box flexShrink={1} gap={12}>
+        <Text color="label" size="20pt" weight="heavy">
+          {title}
+        </Text>
+        <Text color="labelTertiary" size="17pt / 135%" weight="semibold">
+          {subtitle}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function PutYourRnbwToWorkIcon() {
+  const { isDarkMode } = useColorMode();
+  return (
+    <View style={styles.rnbwIconWrapper}>
+      <GradientBorderView
+        borderGradientColors={isDarkMode ? [opacity('#FFDD20', 0.5), '#FFDD20'] : ['#EFC035', '#FFE69B']}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        borderWidth={3}
+        style={styles.gradientBorderView}
+      >
+        <RnbwCoinIcon size={30} />
+      </GradientBorderView>
+      <Box
+        width={26}
+        height={26}
+        borderRadius={13}
+        backgroundColor={isDarkMode ? '#090909' : '#FEFEFE'}
+        position="absolute"
+        top={{ custom: -8 }}
+        right={{ custom: -8 }}
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Text color={{ custom: isDarkMode ? '#968316' : '#EFC340' }} size="13pt" weight="heavy">
+          {'􀎠'}
+        </Text>
+      </Box>
+    </View>
+  );
+}
+
+function UnstakePenaltyIcon() {
+  return (
+    <UnstakePenaltySign
+      signFaceConfig={{ width: 62, height: 42, borderRadius: 14, borderWidth: 3.33, fontSize: '20pt', fontWeight: 'heavy' }}
+      signPostConfig={{ width: 8, height: 16 }}
+    />
+  );
+}
+
+function PassiveIncomeIcon() {
+  const { isDarkMode } = useColorMode();
+  const backgroundColor = isDarkMode ? '#383A40' : '#FFFFFF';
+  return (
+    <View style={styles.passiveIncomeWrapper}>
+      <ProgressMeter progress={0.5} height={PROGRESS_METER_HEIGHT} width={28} notchWidth={8} notchHeight={2} />
+      <Box style={[styles.progressLabel, { backgroundColor }]}>
+        <View style={[styles.progressLabelArrow, { backgroundColor }]} />
+        <Text color="green" size="13pt" weight="heavy" style={styles.progressLabelText}>
+          {'52%'}
+        </Text>
+      </Box>
+    </View>
+  );
+}
 
 function navigateToStakingScreen() {
   Navigation.replace(Routes.RNBW_STAKING_SCREEN);
 }
 
 const styles = StyleSheet.create({
+  backgroundGradient: {
+    height: 300,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    width: '100%',
+  },
   button: {
     marginTop: 'auto',
     width: '100%',
@@ -59,6 +167,58 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    paddingHorizontal: 20,
+    paddingHorizontal: 32,
+  },
+  gradientBorderView: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    height: RNBW_ICON_SIZE,
+    justifyContent: 'center',
+    width: RNBW_ICON_SIZE,
+  },
+  iconContainer: {
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    width: ICON_CONTAINER_WIDTH,
+  },
+  passiveIncomeWrapper: {
+    marginLeft: 8,
+  },
+  progressLabel: {
+    alignItems: 'center',
+    borderRadius: 10,
+    bottom: 0,
+    height: PROGRESS_LABEL_HEIGHT,
+    justifyContent: 'center',
+    left: 20,
+    position: 'absolute',
+    right: 0,
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    top: (PROGRESS_METER_HEIGHT - PROGRESS_LABEL_HEIGHT) / 2,
+    width: 40,
+  },
+  progressLabelArrow: {
+    borderCurve: 'continuous',
+    borderRadius: 1,
+    bottom: 0,
+    height: ARROW_SIZE,
+    left: -ARROW_SIZE / 3,
+    position: 'absolute',
+    right: 0,
+    top: PROGRESS_LABEL_HEIGHT / 2 - ARROW_SIZE / 2,
+    transform: [{ rotate: '45deg' }],
+    width: ARROW_SIZE,
+  },
+  progressLabelText: {
+    paddingLeft: ARROW_SIZE / 3,
+  },
+  rnbwIconWrapper: {
+    alignItems: 'center',
+    height: RNBW_ICON_SIZE,
+    justifyContent: 'center',
+    width: RNBW_ICON_SIZE,
   },
 });


### PR DESCRIPTION
Fixes APP-3574

**What changed**

Implements the designs for the `RnbwStakingLearnScreen` that is displayed prior to a user staking. Minor change to the `UnstakePenaltySign` to move default configs objects out of prop params. 

**Screenshots**
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-03 at 11 50 59" src="https://github.com/user-attachments/assets/9b26ef95-ec72-483e-858e-c82c90a70563" /> <img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-03 at 11 51 24" src="https://github.com/user-attachments/assets/a8da29f1-ad9d-4948-b20d-66c6e9d31a3c" />


