### PR TITLE
fix: fix rnbw rewards claim sheet design + nav

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwRewardsClaimCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwRewardsClaimCard.tsx
@@ -24,5 +24,5 @@ export const RnbwRewardsClaimCard = memo(function RnbwRewardsClaimCard() {
 });
 
 function navigateToRewardsScreen() {
-  Navigation.handleAction(Routes.RNBW_REWARDS_SCREEN);
+  Navigation.handleAction(Routes.RNBW_REWARDS_CLAIM_SHEET);
 }

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet.tsx
@@ -2,7 +2,6 @@ import { memo, useCallback, useState } from 'react';
 import { Alert, Image, StyleSheet, View } from 'react-native';
 import { Box, Stack, Text } from '@/design-system';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
-import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { prepareRewardsClaim, submitRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
@@ -14,6 +13,7 @@ import watchingAlert from '@/utils/watchingAlert';
 import * as i18n from '@/languages';
 import rnbwCoinImage from '@/assets/rnbw.png';
 import { useStableValue } from '@/hooks/useStableValue';
+import { RnbwHoldToActivateButton } from '@/features/rnbw-membership/components/RnbwHoldToActivateButton';
 
 export const RnbwRewardsClaimSheet = memo(function RnbwRewardsClaimSheet() {
   const { goBack, navigate } = useNavigation();
@@ -66,17 +66,12 @@ export const RnbwRewardsClaimSheet = memo(function RnbwRewardsClaimSheet() {
               </Text>
             </Stack>
           </Stack>
-          <Box width="full" paddingHorizontal="20px">
-            <HoldToActivateButton
-              label={i18n.t(i18n.l.button.hold_to_authorize.hold_to_claim)}
-              processingLabel={i18n.t(i18n.l.button.hold_to_authorize.claiming)}
-              onLongPress={handleClaim}
+          <Box width="full">
+            <RnbwHoldToActivateButton
               isProcessing={isProcessing}
-              backgroundColor="white"
-              disabledBackgroundColor="white"
-              progressColor="black"
-              showBiometryIcon
-              style={styles.button}
+              label={i18n.t(i18n.l.button.hold_to_authorize.hold_to_claim)}
+              onActivate={handleClaim}
+              processingLabel={i18n.t(i18n.l.button.hold_to_authorize.claiming)}
             />
           </Box>
         </Stack>
@@ -88,7 +83,7 @@ export const RnbwRewardsClaimSheet = memo(function RnbwRewardsClaimSheet() {
 const styles = StyleSheet.create({
   content: {
     paddingTop: 36,
-    paddingBottom: 36,
+    paddingBottom: 20,
     paddingHorizontal: 24,
   },
   coinImage: {


### PR DESCRIPTION
## What changed

Fixes the rewards claim sheet navigation route and updates the button to match the shared RNBW design.

## Main changes

- `RnbwRewardsClaimCard`: fixed navigation to use `RNBW_REWARDS_CLAIM_SHEET`
- `RnbwRewardsClaimSheet`: replaced `HoldToActivateButton` with `RnbwHoldToActivateButton`