### PR TITLE
chore: staking analytics events

### DIFF
--- a/e2e/flows/screens/Discover.yaml
+++ b/e2e/flows/screens/Discover.yaml
@@ -25,7 +25,7 @@ tags:
 - swipe:
     direction: LEFT
 - assertVisible:
-    id: rnbw-rewards-screen
+    id: rnbw-membership-screen
 - tapOn:
     point: ${output.tabCoordinates.discoverTab}
 - assertVisible:

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -333,6 +333,12 @@ export const event = {
   // rnbw airdrop
   rnbwAirdropClaim: 'rnbw_airdrop.claim',
   rnbwAirdropClaimFailed: 'rnbw_airdrop.claim.failed',
+
+  // rnbw staking
+  rnbwStakingStake: 'rnbw_staking.stake',
+  rnbwStakingStakeFailed: 'rnbw_staking.stake.failed',
+  rnbwStakingUnstake: 'rnbw_staking.unstake',
+  rnbwStakingUnstakeFailed: 'rnbw_staking.unstake.failed',
 } as const;
 
 type SwapEventParameters<T extends 'swap' | 'crosschainSwap'> = {
@@ -1386,5 +1392,37 @@ export type EventProperties = {
       claim?: string;
       status?: string;
     };
+  };
+
+  // rnbw staking
+  [event.rnbwStakingStake]: {
+    chainId: number;
+    amount: string;
+    amountFromWallet: string;
+    amountFromRewards: string;
+    executionMode: 'sponsored' | 'manual' | 'claim_only';
+    claimToDestination: 'staking' | 'wallet';
+    claimFulfillsStake: boolean;
+  };
+  [event.rnbwStakingStakeFailed]: {
+    chainId: number;
+    amount: string;
+    executionMode?: 'sponsored' | 'manual' | 'claim_only';
+    claimToDestination?: 'staking' | 'wallet';
+    claimFulfillsStake?: boolean;
+    errorMessage: string;
+  };
+  [event.rnbwStakingUnstake]: {
+    chainId: number;
+    txHash: string;
+    stakedAmount: string;
+    expectedExitFee: string;
+    expectedReceiveAmount: string;
+    pnl: string;
+  };
+  [event.rnbwStakingUnstakeFailed]: {
+    chainId: number;
+    stakedAmount?: string;
+    errorMessage: string;
   };
 };

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -35,7 +35,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
   const bottomInset = TAB_BAR_HEIGHT + 16;
 
   return (
-    <Box backgroundColor={backgroundColor} style={styles.flex}>
+    <Box backgroundColor={backgroundColor} style={styles.flex} testID="rnbw-membership-screen">
       <Navbar hasStatusBarInset titleComponent={<CurrentTierBadge />} leftComponent={<AccountImage />} />
       <ScrollHeaderFade color={backgroundColor} height={32} scrollOffset={scrollOffset} topInset={safeAreaInsets.top + navbarHeight} />
       <Animated.ScrollView

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -17,7 +17,7 @@ type StakingPnl = {
   exchangeRateGain: string;
 };
 
-type StakingPositionData = {
+export type StakingPositionData = {
   allTiers: Tier[];
   decimals: number;
   hasPosition: boolean;

--- a/src/features/rnbw-staking/utils/stakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbw.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, erc20Abi, parseUnits, type Address, type Hash } from 'viem';
+import { encodeFunctionData, erc20Abi, formatUnits, parseUnits, type Address, type Hash } from 'viem';
 import { stakeRnbwManual } from './stakeRnbwManual';
 import { stakeRnbwSponsored } from './stakeRnbwSponsored';
 import { getProvider } from '@/handlers/web3';
@@ -11,62 +11,103 @@ import type { Signer } from '@ethersproject/abstract-signer';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { prepareRewardsClaim, submitRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
-import { Alert } from 'react-native';
 import { equalWorklet, greaterThanOrEqualToWorklet, isPositive, subWorklet } from '@/framework/core/safeMath';
 import type { ClaimToDestination } from '@/features/rnbw-rewards/utils/claimRewards';
 import { canUseSponsoredRnbwStaking } from './canUseSponsoredRnbwStaking';
+import { analytics } from '@/analytics';
 
 export async function stakeRnbw({ address, amount }: { address: Address; amount: string }) {
-  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
-  const signer = await loadWallet({ address, provider });
-  if (!signer) {
-    throw new Error('Failed to load wallet');
-  }
+  let claimToDestination: ClaimToDestination | undefined;
+  let claimFulfillsStake: boolean | undefined;
+  let executionMode: 'sponsored' | 'manual' | 'claim_only' | undefined;
 
-  const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
-  const { claimToDestination, requiredWalletBalanceRaw, claimFulfillsStake } = await resolveClaimStrategy(stakeAmountRaw);
+  try {
+    const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+    const signer = await loadWallet({ address, provider });
+    if (!signer) {
+      throw new Error('Failed to load wallet');
+    }
 
-  if (isPositive(requiredWalletBalanceRaw)) {
-    const rnbwBalanceRaw = BigInt(
-      await provider.call({
-        to: RNBW_TOKEN_ADDRESS,
-        data: encodeFunctionData({ abi: erc20Abi, functionName: 'balanceOf', args: [address] }),
-      })
-    ).toString();
+    const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
+    const claimStrategy = await resolveClaimStrategy(stakeAmountRaw);
+    claimToDestination = claimStrategy.claimToDestination;
+    claimFulfillsStake = claimStrategy.claimFulfillsStake;
+    const { requiredWalletBalanceRaw } = claimStrategy;
+    const amountFromWallet = formatUnits(BigInt(requiredWalletBalanceRaw), RNBW_DECIMALS);
+    const amountFromRewards = subWorklet(amount, amountFromWallet);
+
+    if (isPositive(requiredWalletBalanceRaw)) {
+      const rnbwBalanceRaw = BigInt(
+        await provider.call({
+          to: RNBW_TOKEN_ADDRESS,
+          data: encodeFunctionData({ abi: erc20Abi, functionName: 'balanceOf', args: [address] }),
+        })
+      ).toString();
+
+      /**
+       * This check is not strictly necessary, as the provider gas estimation will fail if the balance is insufficient.
+       * However, the error returned by the provider in that case is opaque.
+       */
+      const hasSufficientBalance = greaterThanOrEqualToWorklet(rnbwBalanceRaw, requiredWalletBalanceRaw);
+      if (!hasSufficientBalance) {
+        throw new RainbowError('[stakeRnbw]: Insufficient balance');
+      }
+    }
+
+    const canUseSponsoredStaking = await canUseSponsoredRnbwStaking(address, STAKING_CHAIN_ID);
+    const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
+
+    await claimRnbwRewards({ address, signer, claimToDestination });
+
+    if (claimFulfillsStake) {
+      await pollForStakingUpdate(originalStakedRnbwShares);
+
+      analytics.track(analytics.event.rnbwStakingStake, {
+        chainId: STAKING_CHAIN_ID,
+        amount,
+        amountFromWallet,
+        amountFromRewards,
+        executionMode: 'claim_only',
+        claimToDestination,
+        claimFulfillsStake,
+      });
+      return;
+    }
 
     /**
-     * This check is not strictly necessary, as the provider gas estimation will fail if the balance is insufficient.
-     * However, the error returned by the provider in that case is opaque.
+     * Re-snapshot shares after the claim so the final poll baseline reflects the claim-to-staking.
+     * Without this, the poll would resolve as soon as the claim is indexed, before the wallet stake is reflected.
      */
-    const hasSufficientBalance = greaterThanOrEqualToWorklet(rnbwBalanceRaw, requiredWalletBalanceRaw);
-    if (!hasSufficientBalance) {
-      throw new RainbowError('[stakeRnbw]: Insufficient balance');
-    }
+    await useStakingPositionStore.getState().fetch(undefined, { force: true });
+    const postClaimShares = useStakingPositionStore.getState().getData()?.poolShares ?? originalStakedRnbwShares;
+
+    executionMode = canUseSponsoredStaking ? 'sponsored' : 'manual';
+    canUseSponsoredStaking
+      ? await stakeRnbwSponsored({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer })
+      : await stakeRnbwManual({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer });
+
+    await pollForStakingUpdate(postClaimShares);
+
+    analytics.track(analytics.event.rnbwStakingStake, {
+      chainId: STAKING_CHAIN_ID,
+      amount,
+      amountFromWallet,
+      amountFromRewards,
+      executionMode,
+      claimToDestination,
+      claimFulfillsStake,
+    });
+  } catch (error) {
+    analytics.track(analytics.event.rnbwStakingStakeFailed, {
+      chainId: STAKING_CHAIN_ID,
+      amount,
+      executionMode,
+      claimToDestination,
+      claimFulfillsStake,
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+    });
+    throw error;
   }
-
-  const canUseSponsoredStaking = await canUseSponsoredRnbwStaking(address, STAKING_CHAIN_ID);
-  const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
-
-  await claimRnbwRewards({ address, signer, claimToDestination });
-
-  if (claimFulfillsStake) {
-    await pollForStakingUpdate(originalStakedRnbwShares);
-    return;
-  }
-
-  /**
-   * Re-snapshot shares after the claim so the final poll baseline reflects the claim-to-staking.
-   * Without this, the poll would resolve as soon as the claim is indexed, before the wallet stake is reflected.
-   */
-  await useStakingPositionStore.getState().fetch(undefined, { force: true });
-  const postClaimShares = useStakingPositionStore.getState().getData()?.poolShares ?? originalStakedRnbwShares;
-
-  canUseSponsoredStaking
-    ? await stakeRnbwSponsored({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer })
-    : await stakeRnbwManual({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer });
-
-  await pollForStakingUpdate(postClaimShares);
-  Alert.alert(`Staked: ${amount} RNBW (${canUseSponsoredStaking ? 'Sponsored' : 'Manual'})`);
 }
 
 async function claimRnbwRewards({

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -1,27 +1,64 @@
 import { encodeFunctionData, type Address, type Hash } from 'viem';
 import { getProvider } from '@/handlers/web3';
 import { loadWallet } from '@/model/wallet';
-import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
-import { useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, UNSTAKE_PENALTY_PERCENTAGE } from '../constants';
+import { type StakingPositionData, useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
+import { analytics } from '@/analytics';
+import { mulWorklet, subWorklet } from '@/framework/core/safeMath';
+import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
+import { RainbowError } from '@/logger';
 
 export async function unstakeRnbw({ address }: { address: Address }): Promise<Hash> {
-  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
-  const signer = await loadWallet({ address, provider });
-  if (!signer) {
-    throw new Error('Failed to load wallet');
+  const positionData = useStakingPositionStore.getState().getData();
+  if (!positionData) {
+    throw new RainbowError('[unstakeRnbw]: Position data missing');
   }
+  const positionSnapshot = snapshotUnstakeAnalytics(positionData);
 
-  const originalStakedRnbwShares = useStakingPositionStore.getState().getData()?.poolShares ?? '0';
-  const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+  try {
+    const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+    const signer = await loadWallet({ address, provider });
+    if (!signer) {
+      throw new Error('Failed to load wallet');
+    }
 
-  const tx = await signer.sendTransaction({
-    to: STAKING_CONTRACT_ADDRESS,
-    data,
-  });
+    const originalStakedRnbwShares = positionData.poolShares;
+    const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
 
-  await tx.wait();
-  await pollForStakingUpdate(originalStakedRnbwShares);
+    const tx = await signer.sendTransaction({
+      to: STAKING_CONTRACT_ADDRESS,
+      data,
+    });
 
-  return tx.hash as Hash;
+    await tx.wait();
+    await pollForStakingUpdate(originalStakedRnbwShares);
+
+    analytics.track(analytics.event.rnbwStakingUnstake, {
+      chainId: STAKING_CHAIN_ID,
+      txHash: tx.hash as string,
+      ...positionSnapshot,
+    });
+
+    return tx.hash as Hash;
+  } catch (error) {
+    analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
+      chainId: STAKING_CHAIN_ID,
+      stakedAmount: positionSnapshot.stakedAmount,
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+    });
+    throw error;
+  }
+}
+
+function snapshotUnstakeAnalytics(positionData: StakingPositionData) {
+  const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl } = positionData;
+  const exitFeeRaw = mulWorklet(stakedRnbwRaw, UNSTAKE_PENALTY_PERCENTAGE / 100);
+
+  return {
+    stakedAmount: convertRawAmountToDecimalFormat(stakedRnbwRaw, decimals),
+    expectedExitFee: convertRawAmountToDecimalFormat(exitFeeRaw, decimals),
+    expectedReceiveAmount: convertRawAmountToDecimalFormat(subWorklet(stakedRnbwRaw, exitFeeRaw), decimals),
+    pnl: convertRawAmountToDecimalFormat(subWorklet(sessionPnl.exchangeRateGain, exitFeeRaw), decimals),
+  };
 }

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -121,8 +121,8 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
     'rnbw_membership_enabled'
   );
   const showDappBrowserTab = useExperimentalFlag(DAPP_BROWSER) || dapp_browser;
-  const showRnbwRewardsTab = useExperimentalFlag(RNBW_REWARDS) || rnbw_rewards_enabled || IS_TEST;
-  const showRnbwMembership = useExperimentalFlag(RNBW_MEMBERSHIP) || rnbw_membership_enabled;
+  const showRnbwRewardsTab = useExperimentalFlag(RNBW_REWARDS) || rnbw_rewards_enabled;
+  const showRnbwMembership = useExperimentalFlag(RNBW_MEMBERSHIP) || rnbw_membership_enabled || IS_TEST;
   const showRnbwRewardsOrMembershipTab = showRnbwRewardsTab || showRnbwMembership;
 
   const numberOfTabs = 3 + (showRnbwRewardsOrMembershipTab ? 1 : 0) + (showDappBrowserTab ? 1 : 0);
@@ -644,7 +644,7 @@ function SwipeNavigatorScreens() {
   const showDappBrowserTab = useExperimentalFlag(DAPP_BROWSER) || dapp_browser;
   const showKingOfTheHillTab = useShowKingOfTheHill();
   const showRnbwRewardsTab = useExperimentalFlag(RNBW_REWARDS) || rnbw_rewards_enabled || IS_TEST;
-  const showRnbwMembership = useExperimentalFlag(RNBW_MEMBERSHIP) || rnbw_membership_enabled;
+  const showRnbwMembership = useExperimentalFlag(RNBW_MEMBERSHIP) || rnbw_membership_enabled || IS_TEST;
   const showRnbwRewardsOrMembershipTab = showRnbwRewardsTab || showRnbwMembership;
 
   const { language } = useAccountSettings();


### PR DESCRIPTION
Fixes APP-3541

## What changed

Adds analytics events for staking and unstaking flows.

## Main changes

- `event.ts`: added `rnbw_staking.stake`, `rnbw_staking.stake.failed`, `rnbw_staking.unstake`, and `rnbw_staking.unstake.failed` events. 
- `stakeRnbw`: tracks execution mode (`sponsored` / `manual` / `claim_only`), claim destination (wallet vs. direct to staking), and whether the claim alone fulfilled the stake
- `unstakeRnbw`: snapshots position data before unstaking and tracks staked amount, expected exit fee, expected receive amount, PnL, and tx hash on success. 

## Other changes

- Removed `Alert.alert` after successful staking