### PR TITLE
chore: read unstake penalty from contract

### DIFF
--- a/src/features/rnbw-staking/components/UnstakePenaltySign.tsx
+++ b/src/features/rnbw-staking/components/UnstakePenaltySign.tsx
@@ -1,11 +1,11 @@
 import { memo } from 'react';
 import { Box, Text, useColorMode, type TextProps } from '@/design-system';
 import { StyleSheet, View } from 'react-native';
-import { UNSTAKE_PENALTY_PERCENTAGE } from '../constants';
 import { LinearGradient } from 'expo-linear-gradient';
 import { opacity } from '@/framework/ui/utils/opacity';
 
 type PenaltySignProps = {
+  percentage: number;
   signFaceConfig?: {
     width: number;
     height: number;
@@ -35,6 +35,7 @@ const SIGN_POST_CONFIG = {
 } as const;
 
 export const UnstakePenaltySign = memo(function UnstakePenaltySign({
+  percentage,
   signFaceConfig: signFaceConfig = SIGN_FACE_CONFIG,
   signPostConfig: signPostConfig = SIGN_POST_CONFIG,
 }: PenaltySignProps) {
@@ -68,7 +69,7 @@ export const UnstakePenaltySign = memo(function UnstakePenaltySign({
         }}
       >
         <Text color="label" size={signFaceConfig.fontSize} weight={signFaceConfig.fontWeight}>
-          {`${UNSTAKE_PENALTY_PERCENTAGE}%`}
+          {`${percentage}%`}
         </Text>
       </Box>
       {/* Sign Post */}

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -16,8 +16,9 @@ export const STAKING_ABI = parseAbi([
   'function stake(uint256 amount)',
   'function unstakeAll()',
   'function minStakeAmount() view returns (uint256)',
+  'function exitFeeBps() view returns (uint256)',
 ]);
 export const STAKING_GAS_LIMIT = 200_000;
-export const UNSTAKE_PENALTY_PERCENTAGE = 10;
+export const DEFAULT_EXIT_FEE_PERCENTAGE = 10;
 
 export const MIN_CLAIM_TO_STAKING_RAW = '1000000000000000000'; // 1 RNBW (10^18)

--- a/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
@@ -6,7 +6,7 @@ import { Box, Text, useColorMode } from '@/design-system';
 import Routes from '@/navigation/routesNames';
 import Navigation from '@/navigation/Navigation';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
-import { UNSTAKE_PENALTY_PERCENTAGE } from '@/features/rnbw-staking/constants';
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
 import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
 import { UnstakePenaltySign } from '@/features/rnbw-staking/components/UnstakePenaltySign';
 import { ProgressMeter } from '@/features/rnbw-membership/components/ProgressMeter';
@@ -21,6 +21,7 @@ const PROGRESS_LABEL_HEIGHT = 24;
 const ARROW_SIZE = 7;
 
 export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
+  const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
   const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
   const { isDarkMode } = useColorMode();
   const screenBackgroundColor = isDarkMode ? '#090909' : '#FEFEFE';
@@ -55,9 +56,9 @@ export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
               icon={<PutYourRnbwToWorkIcon />}
             />
             <ReasonRow
-              title={`${UNSTAKE_PENALTY_PERCENTAGE}% Exit Fee`}
-              subtitle={`Unstaking comes with a ${UNSTAKE_PENALTY_PERCENTAGE}% fee.`}
-              icon={<UnstakePenaltyIcon />}
+              title={`${exitFeePercentage}% Exit Fee`}
+              subtitle={`Unstaking comes with a ${exitFeePercentage}% fee.`}
+              icon={<UnstakePenaltyIcon percentage={exitFeePercentage} />}
             />
             <ReasonRow
               title="Passive Income"
@@ -120,9 +121,10 @@ function PutYourRnbwToWorkIcon() {
   );
 }
 
-function UnstakePenaltyIcon() {
+function UnstakePenaltyIcon({ percentage }: { percentage: number }) {
   return (
     <UnstakePenaltySign
+      percentage={percentage}
       signFaceConfig={{ width: 62, height: 42, borderRadius: 14, borderWidth: 3.33, fontSize: '20pt', fontWeight: 'heavy' }}
       signPostConfig={{ width: 8, height: 16 }}
     />

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -16,7 +16,7 @@ import { opacity } from '@/framework/ui/utils/opacity';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { useRnbwStakingBalance } from '../../stores/derived/useRnbwStakingBalance';
 import { useRnbwStakingPositionPnl } from '../../stores/derived/useRnbwStakingPositionPnl';
-import { UNSTAKE_PENALTY_PERCENTAGE } from '../../constants';
+import { useStakingPositionStore } from '../../stores/rnbwStakingPositionStore';
 import { useStableValue } from '@/hooks/useStableValue';
 import { LinearGradient } from 'expo-linear-gradient';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
@@ -46,18 +46,19 @@ export const RnbwUnstakeSheet = memo(function RnbwUnstakeSheet() {
 const WarningContent = memo(function WarningContent({ onProceed }: { onProceed: () => void }) {
   const { goBack } = useNavigation();
   const redColor = useForegroundColor('red');
+  const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
 
   return (
     <View style={styles.warningContentContainer}>
       <Stack space="32px">
         <Stack space="24px" alignHorizontal="center">
-          <UnstakePenaltySign />
+          <UnstakePenaltySign percentage={exitFeePercentage} />
           <Stack space="20px" alignHorizontal="center">
             <Text color="label" size="34pt" weight="heavy" align="center">
               {'Exit Fee'}
             </Text>
             <Text color="labelTertiary" size="17pt / 135%" weight="semibold" align="center">
-              {'Unstaking will charge a 10% fee to your staked balance.'}
+              {`Unstaking will charge a ${exitFeePercentage}% fee to your staked balance.`}
             </Text>
           </Stack>
         </Stack>
@@ -100,6 +101,7 @@ const UnstakeContent = memo(function UnstakeContent() {
   // We use the initial values only so we do not display 0 prior to the sheet being dismissed after unstaking.
   const { tokenAmount, nativeCurrencyAmount } = useStableValue(() => useRnbwStakingBalance.getState());
   const { exitFeeOffsetRatioDisplay, netPnl, isPositivePnl, rnbwAfterUnstake } = useStableValue(() => useRnbwStakingPositionPnl.getState());
+  const exitFeePercentage = useStableValue(() => useStakingPositionStore.getState().getExitFeePercentage());
   const { goBack, navigate } = useNavigation();
   const accountAddress = useAccountAddress();
   const isReadOnlyWallet = useIsReadOnlyWallet();
@@ -158,7 +160,7 @@ const UnstakeContent = memo(function UnstakeContent() {
               {'Exit Fee'}
             </Text>
             <Text color="label" size="17pt" weight="bold">
-              {`${UNSTAKE_PENALTY_PERCENTAGE}%`}
+              {`${exitFeePercentage}%`}
             </Text>
           </Box>
           <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
@@ -3,7 +3,6 @@ import { convertRawAmountToDecimalFormatWorklet, formatNumber, isZero } from '@/
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { shallowEqual } from '@/worklets/comparisons';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
-import { UNSTAKE_PENALTY_PERCENTAGE } from '@/features/rnbw-staking/constants';
 
 type StakingPositionPnl = {
   exitFeeOffsetRatio: string;
@@ -28,13 +27,14 @@ const EMPTY_VALUE: StakingPositionPnl = {
 export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
   $ => {
     const data = $(useStakingPositionStore, state => state.getData());
+    const exitFeePercentage = $(useStakingPositionStore, state => state.getExitFeePercentage());
 
     if (!data || data?.stakedRnbw === '0') return EMPTY_VALUE;
 
     const { stakedRnbw, sessionPnl, decimals } = data;
 
     const exchangeRateGain = sessionPnl?.exchangeRateGain ?? '0';
-    const exitFee = mulWorklet(stakedRnbw, UNSTAKE_PENALTY_PERCENTAGE / 100);
+    const exitFee = mulWorklet(stakedRnbw, exitFeePercentage / 100);
     const exitFeeOffsetRatio = toFixedWorklet(divWorklet(exchangeRateGain, exitFee), 4);
 
     const netPnl = subWorklet(exchangeRateGain, exitFee);

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -5,8 +5,11 @@ import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { createQueryStore } from '@/state/internal/createQueryStore';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { ChainId } from '@/state/backendNetworks/types';
-import { type Address } from 'viem';
+import { decodeFunctionResult, encodeFunctionData, type Address, type Hex } from 'viem';
 import type { Tier } from '@/features/rnbw-membership/types';
+import { getProvider } from '@/handlers/web3';
+import { DEFAULT_EXIT_FEE_PERCENTAGE, STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { logger, RainbowError } from '@/logger';
 
 type StakingPnl = {
   netProfit: string;
@@ -20,6 +23,7 @@ type StakingPnl = {
 export type StakingPositionData = {
   allTiers: Tier[];
   decimals: number;
+  exitFeePercentage: number | undefined;
   hasPosition: boolean;
   lastUpdateTime: string;
   pnl: StakingPnl;
@@ -37,6 +41,7 @@ type StakingPositionParams = {
 };
 
 type StakingPositionStore = {
+  getExitFeePercentage: () => number;
   hasPosition: () => boolean;
 };
 
@@ -49,6 +54,9 @@ export const useStakingPositionStore = createQueryStore<StakingPositionData, Sta
     },
   },
   (_, get) => ({
+    getExitFeePercentage: () => {
+      return get().getData()?.exitFeePercentage ?? DEFAULT_EXIT_FEE_PERCENTAGE;
+    },
     hasPosition: () => {
       const data = get().getData();
       return data?.hasPosition ?? false;
@@ -57,17 +65,32 @@ export const useStakingPositionStore = createQueryStore<StakingPositionData, Sta
   { storageKey: 'rnbwStakingPosition' }
 );
 
-type StakingPositionResponse = PlatformResponse<StakingPositionData>;
+type StakingPositionResponse = PlatformResponse<Omit<StakingPositionData, 'exitFeePercentage'>>;
 
 async function fetchStakingPosition({ currency, address }: StakingPositionParams): Promise<StakingPositionData> {
-  const response = await getPlatformClient().get<StakingPositionResponse>('/staking/GetStakingPosition', {
-    params: {
-      walletAddress: address,
-      chainId: String(ChainId.base),
-      currency,
-      includeTiers: String(true),
-    },
-  });
+  const [response, exitFeePercentage] = await Promise.all([
+    getPlatformClient().get<StakingPositionResponse>('/staking/GetStakingPosition', {
+      params: {
+        walletAddress: address,
+        chainId: String(ChainId.base),
+        currency,
+        includeTiers: String(true),
+      },
+    }),
+    readExitFeePercentage(),
+  ]);
 
-  return response.data.result;
+  return { ...response.data.result, exitFeePercentage };
+}
+
+async function readExitFeePercentage(): Promise<number | undefined> {
+  try {
+    const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+    const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'exitFeeBps' });
+    const result = await provider.call({ to: STAKING_CONTRACT_ADDRESS, data });
+    const exitFeeBps = decodeFunctionResult({ abi: STAKING_ABI, functionName: 'exitFeeBps', data: result as Hex });
+    return Number(exitFeeBps) / 100;
+  } catch (e) {
+    logger.error(new RainbowError('[readExitFeePercentage]: Failed to read exit fee percentage', e));
+  }
 }

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -1,7 +1,7 @@
 import { encodeFunctionData, type Address, type Hash } from 'viem';
 import { getProvider } from '@/handlers/web3';
 import { loadWallet } from '@/model/wallet';
-import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, UNSTAKE_PENALTY_PERCENTAGE } from '../constants';
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
 import { type StakingPositionData, useStakingPositionStore } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
 import { analytics } from '@/analytics';
@@ -11,7 +11,7 @@ import { RainbowError } from '@/logger';
 
 export async function unstakeRnbw({ address }: { address: Address }): Promise<Hash> {
   const positionData = useStakingPositionStore.getState().getData();
-  if (!positionData) {
+  if (!positionData || !positionData.exitFeePercentage) {
     throw new RainbowError('[unstakeRnbw]: Position data missing');
   }
   const positionSnapshot = snapshotUnstakeAnalytics(positionData);
@@ -53,7 +53,8 @@ export async function unstakeRnbw({ address }: { address: Address }): Promise<Ha
 
 function snapshotUnstakeAnalytics(positionData: StakingPositionData) {
   const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl } = positionData;
-  const exitFeeRaw = mulWorklet(stakedRnbwRaw, UNSTAKE_PENALTY_PERCENTAGE / 100);
+  const exitFeePercentage = useStakingPositionStore.getState().getExitFeePercentage();
+  const exitFeeRaw = mulWorklet(stakedRnbwRaw, exitFeePercentage / 100);
 
   return {
     stakedAmount: convertRawAmountToDecimalFormat(stakedRnbwRaw, decimals),


### PR DESCRIPTION
## What changed

Reads the unstake exit fee percentage from the staking contract instead of using a hardcoded constant.

## Main changes

- `rnbwStakingPositionStore`: reads `exitFeeBps()` from the staking contract alongside the position fetch, converts from basis points to a percentage, and includes it in `StakingPositionData`. Exposes `getExitFeePercentage()` with a fallback default. Ideally this is included as part of the backend response at a later time so that we do not need to do this client side. 
- `RnbwUnstakeSheet`, `RnbwStakingLearnScreen`, `useRnbwStakingPositionPnl`, `UnstakePenaltySign`, `unstakeRnbw`: all now read exit fee from the store instead of the hardcoded constant