### PR TITLE
feature: buy cta if min stake balance not met

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -8,10 +8,11 @@ import Routes from '@/navigation/routesNames';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { MembershipCard } from './MembershipCard';
 import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
+import { navigateToBuyRnbw } from '@/features/rnbw-membership/utils/navigateToBuyRnbw';
 
 export const RnbwStakingCard = memo(function RnbwStakingCard() {
   const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
-  const { tokenAmountFormatted: availableAmount } = useStakableRnbwBalance();
+  const { tokenAmountFormatted: availableAmount, hasMinimumStakeAmount } = useStakableRnbwBalance();
 
   return (
     <MembershipCard paddingHorizontal="20px" paddingTop="24px" paddingBottom="16px">
@@ -28,7 +29,12 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
             {`${tokenAmount} ${RNBW_SYMBOL}`}
           </Text>
         </Box>
-        {!hasStakedPosition && <RnbwThemedButton onPress={navigateToStakingLearnSheet} label="Enable Staking" />}
+        {!hasStakedPosition && (
+          <RnbwThemedButton
+            onPress={hasMinimumStakeAmount ? navigateToStakingLearnSheet : navigateToBuyRnbw}
+            label={hasMinimumStakeAmount ? 'Enable Staking' : 'Buy RNBW'}
+          />
+        )}
         {hasStakedPosition && (
           <Box flexDirection="row" gap={10}>
             <RnbwThemedButton
@@ -39,7 +45,11 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
               weight="heavy"
               variant="secondary"
             />
-            <RnbwThemedButton onPress={navigateToStakingScreen} style={{ flex: 1 }} label="Add" />
+            <RnbwThemedButton
+              onPress={hasMinimumStakeAmount ? navigateToStakingScreen : navigateToBuyRnbw}
+              style={{ flex: 1 }}
+              label={hasMinimumStakeAmount ? 'Add' : 'Buy RNBW'}
+            />
           </Box>
         )}
         <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4}>

--- a/src/features/rnbw-membership/utils/navigateToBuyRnbw.ts
+++ b/src/features/rnbw-membership/utils/navigateToBuyRnbw.ts
@@ -1,0 +1,9 @@
+import { navigateToSwaps } from '@/__swaps__/screens/Swap/navigateToSwaps';
+import { buildSyntheticRnbwSourceAsset } from '@/features/rnbw-staking/utils/syntheticRnbwSourceAsset';
+
+export function navigateToBuyRnbw() {
+  const outputAsset = buildSyntheticRnbwSourceAsset();
+  if (!outputAsset) return;
+
+  navigateToSwaps({ outputAsset });
+}

--- a/src/features/rnbw-staking/depositConfig.ts
+++ b/src/features/rnbw-staking/depositConfig.ts
@@ -1,13 +1,11 @@
-import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { createDepositConfig } from '@/systems/funding/config';
-import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { time } from '@/utils/time';
-import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, RNBW_TOKEN_UNIQUE_ID, STAKING_CHAIN_ID } from './constants';
+import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, STAKING_CHAIN_ID } from './constants';
 import { estimateStakeGasLimit } from './utils/estimateStakeGasLimit';
 import { refreshStakingData } from './utils/refreshStakingData';
 import { stakeRnbw } from './utils/stakeRnbw';
 import { canUseSponsoredRnbwStaking } from './utils/canUseSponsoredRnbwStaking';
-import { buildSyntheticRnbwSourceAsset, getInitialSyntheticRnbwSourceUnitPrice } from './utils/syntheticRnbwSourceAsset';
+import { buildSyntheticRnbwSourceAsset } from './utils/syntheticRnbwSourceAsset';
 
 export const RNBW_STAKING_DEPOSIT_CONFIG = createDepositConfig({
   id: 'rnbwStakingDeposit',
@@ -18,13 +16,8 @@ export const RNBW_STAKING_DEPOSIT_CONFIG = createDepositConfig({
   source: {
     mode: 'fixed',
     resolveAsset: () => {
-      const rewardsData = useRewardsBalanceStore.getState().getData();
-
       return buildSyntheticRnbwSourceAsset({
-        claimableRnbwRaw: rewardsData?.claimableRnbw ?? '0',
-        hasPendingClaim: rewardsData?.hasPendingClaim ?? false,
-        unitPrice: getInitialSyntheticRnbwSourceUnitPrice(),
-        walletAsset: useUserAssetsStore.getState().getUserAsset(RNBW_TOKEN_UNIQUE_ID),
+        includeRewardsBalance: true,
       });
     },
   },

--- a/src/features/rnbw-staking/utils/syntheticRnbwSourceAsset.ts
+++ b/src/features/rnbw-staking/utils/syntheticRnbwSourceAsset.ts
@@ -65,19 +65,16 @@ export const RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG: SyntheticRnbwSourceStaticConfi
   uniqueId: RNBW_TOKEN_UNIQUE_ID,
 };
 
-type BuildSyntheticRnbwSourceAssetParams = {
-  claimableRnbwRaw: string;
-  hasPendingClaim: boolean;
-  unitPrice: number;
-  walletAsset: ParsedSearchAsset | null;
-};
-
 export function buildSyntheticRnbwSourceAsset({
-  claimableRnbwRaw,
-  hasPendingClaim,
-  unitPrice,
-  walletAsset,
-}: BuildSyntheticRnbwSourceAssetParams): ExtendedAnimatedAssetWithColors | null {
+  includeRewardsBalance = false,
+}: { includeRewardsBalance?: boolean } = {}): ExtendedAnimatedAssetWithColors | null {
+  const walletAsset = useUserAssetsStore.getState().getUserAsset(RNBW_TOKEN_UNIQUE_ID) ?? null;
+  const rewardsData = includeRewardsBalance ? useRewardsBalanceStore.getState().getData() : null;
+  const unitPrice = snapshotUnitPrice(rewardsData, walletAsset);
+
+  const claimableRnbwRaw = rewardsData?.claimableRnbw ?? '0';
+  const hasPendingClaim = rewardsData?.hasPendingClaim ?? false;
+
   const currency = userAssetsStoreManager.getState().currency;
   const chainName = walletAsset?.chainName ?? useBackendNetworksStore.getState().getChainsName()[RNBW_CHAIN_ID] ?? String(RNBW_CHAIN_ID);
   const symbol = walletAsset?.symbol ?? RNBW_SYNTHETIC_SOURCE_STATIC_CONFIG.symbol;
@@ -125,12 +122,13 @@ export function buildSyntheticRnbwSourceAsset({
   return parseAssetAndExtend({ asset: syntheticAsset });
 }
 
-export function getInitialSyntheticRnbwSourceUnitPrice(): number {
-  const rewardsData = useRewardsBalanceStore.getState().getData();
+function snapshotUnitPrice(
+  rewardsData: { claimableRnbw: string; claimableValueInCurrency: string; hasPendingClaim: boolean } | null,
+  walletAsset: ParsedSearchAsset | null
+): number {
   const claimableUnitPrice = getClaimableRnbwUnitPrice(rewardsData);
   if (claimableUnitPrice > 0) return claimableUnitPrice;
 
-  const walletAsset = useUserAssetsStore.getState().getUserAsset(RNBW_TOKEN_UNIQUE_ID);
   return walletAsset?.price?.value ?? walletAsset?.native.price?.amount ?? 0;
 }
 

--- a/src/state/rnbw/useStakableRnbwBalance.ts
+++ b/src/state/rnbw/useStakableRnbwBalance.ts
@@ -1,6 +1,12 @@
-import { add, convertAmountToNativeDisplayWorklet, convertRawAmountToDecimalFormat, isPositive } from '@/helpers/utilities';
+import {
+  add,
+  convertAmountToNativeDisplayWorklet,
+  convertRawAmountToDecimalFormat,
+  greaterThanOrEqualTo,
+  isPositive,
+} from '@/helpers/utilities';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
-import { RNBW_DECIMALS, RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
+import { MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS, RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
@@ -8,12 +14,15 @@ import { shallowEqual } from '@/worklets/comparisons';
 import { toFixedWorklet } from '@/framework/core/safeMath';
 import { formatNumber } from '@/helpers/strings';
 
+const MIN_STAKE_AMOUNT = convertRawAmountToDecimalFormat(MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS);
+
 type RnbwBalance = {
   walletBalance: string;
   claimableBalance: string;
   tokenAmountFormatted: string;
   nativeCurrencyAmount: string;
   hasBalance: boolean;
+  hasMinimumStakeAmount: boolean;
 };
 
 export const useStakableRnbwBalance = createDerivedStore<RnbwBalance>(
@@ -39,6 +48,7 @@ export const useStakableRnbwBalance = createDerivedStore<RnbwBalance>(
       tokenAmountFormatted: formatNumber(toFixedWorklet(totalAmount, 2)),
       nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(totalNativeValue, currency, hasBalance),
       hasBalance,
+      hasMinimumStakeAmount: greaterThanOrEqualTo(totalAmount, MIN_STAKE_AMOUNT),
     };
   },
   { equalityFn: shallowEqual, fastMode: true }


### PR DESCRIPTION
## What changed

Shows a "Buy RNBW" button instead of "Enable Staking" / "Add" on the staking card when the user doesn't have enough RNBW to meet the minimum stake amount, and navigates them to swaps with RNBW as the output token.

## Main changes

- `RnbwStakingCard`: switches the CTA label and navigation target based on `hasMinimumStakeAmount` — routes to the buy flow when the balance is insufficient
- `navigateToBuyRnbw`: opens the swap screen with a synthetic RNBW asset as the output

## Other changes
- `syntheticRnbwSourceAsset`: simplified `buildSyntheticRnbwSourceAsset` to read wallet/rewards state internally instead of accepting params, making it reusable from both the staking screen and the buy flow

## Screen recording

https://github.com/user-attachments/assets/fe80cafb-39d0-4622-a42b-a9187a615649


