### PR TITLE
feature: custom submit button support for deposit funding system

### DIFF
--- a/src/features/rnbw-staking/components/RnbwStakingSubmitButton.tsx
+++ b/src/features/rnbw-staking/components/RnbwStakingSubmitButton.tsx
@@ -1,0 +1,39 @@
+import React, { memo, useCallback } from 'react';
+import { StyleSheet } from 'react-native';
+import { RnbwHoldToActivateButton } from '@/features/rnbw-membership/components/RnbwHoldToActivateButton';
+import { useSharedValueState } from '@/hooks/reanimated/useSharedValueState';
+import { type DepositSubmitButtonProps } from '@/systems/funding/types';
+
+export const RnbwStakingSubmitButton = memo(function RnbwStakingSubmitButton({
+  disabled,
+  isSubmitting,
+  label,
+  onSubmit,
+}: DepositSubmitButtonProps) {
+  const disabledState = useSharedValueState(disabled);
+  const isSubmittingState = useSharedValueState(isSubmitting);
+  const labelState = useSharedValueState(label);
+
+  const handleActivate = useCallback(async () => {
+    await onSubmit();
+  }, [onSubmit]);
+
+  return (
+    <RnbwHoldToActivateButton
+      disabled={disabledState}
+      isProcessing={isSubmittingState}
+      label={labelState}
+      onActivate={handleActivate}
+      processingLabel={labelState}
+      showBiometryIcon={!disabledState}
+      style={styles.submitButton}
+      testID="rnbw-staking-submit-button"
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  submitButton: {
+    width: '100%',
+  },
+});

--- a/src/features/rnbw-staking/depositConfig.ts
+++ b/src/features/rnbw-staking/depositConfig.ts
@@ -1,5 +1,6 @@
 import { createDepositConfig } from '@/systems/funding/config';
 import { time } from '@/utils/time';
+import { RnbwStakingSubmitButton } from './components/RnbwStakingSubmitButton';
 import { RNBW_DECIMALS, RNBW_TOKEN_ADDRESS, STAKING_CHAIN_ID } from './constants';
 import { estimateStakeGasLimit } from './utils/estimateStakeGasLimit';
 import { refreshStakingData } from './utils/refreshStakingData';
@@ -15,11 +16,7 @@ export const RNBW_STAKING_DEPOSIT_CONFIG = createDepositConfig({
 
   source: {
     mode: 'fixed',
-    resolveAsset: () => {
-      return buildSyntheticRnbwSourceAsset({
-        includeRewardsBalance: true,
-      });
-    },
+    resolveAsset: () => buildSyntheticRnbwSourceAsset({ includeRewardsBalance: true }),
   },
 
   to: {
@@ -58,6 +55,8 @@ export const RNBW_STAKING_DEPOSIT_CONFIG = createDepositConfig({
     receive: 'Rewards will be automatically claimed',
     title: 'Stake $RNBW',
   },
+
+  submitButtonComponent: RnbwStakingSubmitButton,
 
   validation: {
     minAmount: { label: 'Minimum 1 RNBW', value: '1' },

--- a/src/systems/funding/components/deposit/DepositFooter.tsx
+++ b/src/systems/funding/components/deposit/DepositFooter.tsx
@@ -85,6 +85,7 @@ const SubmitButton = memo(function SubmitButton({ inputAmountError, isSubmitting
   const { isDarkMode } = useColorMode();
   const { config, theme, useQuoteStore } = useDepositContext();
   const useCustomExecute = Boolean(config.execute);
+  const SubmitButtonComponent = config.submitButtonComponent;
   const accentColor = getAccentColor(theme, isDarkMode);
 
   const quoteStatus = useStoreSharedValue(useQuoteStore, selectQuoteStatus);
@@ -119,7 +120,11 @@ const SubmitButton = memo(function SubmitButton({ inputAmountError, isSubmitting
 
   return (
     <Box flexGrow={1}>
-      <PerpsSwapButton accentColor={accentColor} disabled={disabled} label={label} onLongPress={onSubmit} />
+      {SubmitButtonComponent ? (
+        <SubmitButtonComponent disabled={disabled} isSubmitting={isSubmitting} label={label} onSubmit={onSubmit} />
+      ) : (
+        <PerpsSwapButton accentColor={accentColor} disabled={disabled} label={label} onLongPress={onSubmit} />
+      )}
     </Box>
   );
 });

--- a/src/systems/funding/types.ts
+++ b/src/systems/funding/types.ts
@@ -1,4 +1,5 @@
 import { type Signer } from '@ethersproject/abstract-signer';
+import { type ComponentType } from 'react';
 import { type Address } from 'viem';
 import { type DerivedValue, type SharedValue } from 'react-native-reanimated';
 import { type CrosschainQuote, type Quote, type Source } from '@rainbow-me/swaps';
@@ -202,6 +203,15 @@ export type DepositLabels = {
   title: string;
 };
 
+export type DepositSubmitButtonProps = {
+  disabled: SharedValue<boolean> | DerivedValue<boolean>;
+  isSubmitting: SharedValue<boolean>;
+  label: SharedValue<string> | DerivedValue<string>;
+  onSubmit: () => Promise<void>;
+};
+
+export type DepositSubmitButtonComponent = ComponentType<DepositSubmitButtonProps>;
+
 /**
  * ### `DepositConfig`
  *
@@ -284,6 +294,9 @@ type DepositConfigBaseInput = {
 
   /** Optional copy overrides for non-perps flows */
   labels?: Partial<DepositLabels>;
+
+  /** Optional custom submit button UI for the footer action */
+  submitButtonComponent?: DepositSubmitButtonComponent;
 
   /** Optional input validation rules */
   validation?: {


### PR DESCRIPTION
Fixes APP-3593

## What changed

Adds a `renderSubmitButton` prop to `DepositScreen` so consumers can replace the default hold-to-submit button with a custom component. Used here to render the RNBW themed hold-to-activate button on the staking screen.

## Main changes

- `DepositScreen` / `DepositFooter` / `SubmitButton`: threads a `renderSubmitButton` render prop through to the footer. When provided, shared values for label, disabled, and submitting state are bridged to plain values and passed to the custom renderer

## Screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-06 at 16 11 11" src="https://github.com/user-attachments/assets/2505abe3-61e8-4f1c-94b9-24d0c2ea2cfa" />

