### PR TITLE
fix: misc small fixes

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -5,7 +5,6 @@ import { AccountImage } from '@/components/AccountImage';
 import { Navbar, navbarHeight } from '@/components/navbar/Navbar';
 import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
 import { RnbwAirdropClaimCard } from './components/RnbwAirdropClaimCard';
-import { RnbwUnstakePenaltyRecoveryCard } from './components/RnbwUnstakePenaltyRecoveryCard';
 import { RnbwStakingCard } from './components/RnbwStakingCard';
 import { MembershipTierCard } from './components/MembershipTierCard';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
@@ -24,9 +23,11 @@ import Animated, { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getValueForColorMode } from '@/design-system/color/palettes';
 import { MEMBERSHIP_SCREEN_BACKGROUND_COLOR } from '@/features/rnbw-membership/constants';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
 
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
-  const hasStakingPosition = useStakingPositionStore(s => s.hasPosition());
   const { colorMode } = useColorMode();
   const safeAreaInsets = useSafeAreaInsets();
   const backgroundColor = getValueForColorMode(MEMBERSHIP_SCREEN_BACKGROUND_COLOR, colorMode);
@@ -49,8 +50,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
       >
         <Box gap={16}>
           <RnbwStakingCard />
-          {hasStakingPosition && <RnbwStakingEarningsCard />}
-          {hasStakingPosition && <RnbwUnstakePenaltyRecoveryCard />}
+          <RnbwStakingEarningsCard />
           <MembershipTierCard />
           <RnbwRewardsClaimCard />
           <RnbwAirdropClaimCard />
@@ -88,7 +88,16 @@ function RefreshControlWrapper(props: Omit<React.ComponentProps<typeof RefreshCo
 
 function CurrentTierBadge() {
   const { currentTier } = useMembershipTierInfo();
-  return <TierBadge tier={currentTier} height={32} fontSize="17pt" />;
+
+  return (
+    <ButtonPressAnimation onPress={navigateToMembershipTiersSheet}>
+      <TierBadge tier={currentTier} height={32} fontSize="17pt" />
+    </ButtonPressAnimation>
+  );
+}
+
+function navigateToMembershipTiersSheet() {
+  Navigation.handleAction(Routes.RNBW_MEMBERSHIP_TIERS_SHEET);
 }
 
 const styles = StyleSheet.create({

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Box, Separator, Text } from '@/design-system';
+import { Box, Separator, Text, TextIcon } from '@/design-system';
 import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Navigation from '@/navigation/Navigation';
@@ -18,6 +18,11 @@ export const MembershipTierCard = memo(function MembershipTierCard() {
   return (
     <ButtonPressAnimation onPress={navigateToMembershipTiersSheet} scaleTo={0.96}>
       <MembershipCard paddingHorizontal="20px" paddingVertical="24px">
+        <Box position="absolute" top={{ custom: 24 }} right={{ custom: 20 }}>
+          <TextIcon size="icon 17px" weight="bold" color="labelQuaternary">
+            {'􀅴'}
+          </TextIcon>
+        </Box>
         <Box gap={16}>
           <TierThemedLabel tier={currentTier}>
             <Text size="22pt" weight="heavy" color="label">
@@ -35,7 +40,7 @@ export const MembershipTierCard = memo(function MembershipTierCard() {
           <Box gap={16} paddingHorizontal={'4px'}>
             <Box flexDirection="row" justifyContent="space-between">
               <Text size="17pt" weight="semibold" color="labelTertiary">
-                {i18n.t(i18n.l.rnbw_membership.shared.rewards)}
+                {i18n.t(i18n.l.rnbw_membership.shared.fee_cashback)}
               </Text>
               <Text size="17pt" weight="bold" color="label">
                 {`${cashbackPercentage}%`}

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -10,6 +10,7 @@ import { MembershipCard } from './MembershipCard';
 import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
 import { navigateToBuyRnbw } from '@/features/rnbw-membership/utils/navigateToBuyRnbw';
 import * as i18n from '@/languages';
+import { MIN_STAKE_AMOUNT } from '@/features/rnbw-staking/constants';
 
 export const RnbwStakingCard = memo(function RnbwStakingCard() {
   const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
@@ -30,17 +31,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
             {`${tokenAmount} ${RNBW_SYMBOL}`}
           </Text>
         </Box>
-        {!hasStakedPosition && (
-          <RnbwThemedButton
-            onPress={hasMinimumStakeAmount ? navigateToStakingLearnSheet : navigateToBuyRnbw}
-            label={
-              hasMinimumStakeAmount
-                ? i18n.t(i18n.l.rnbw_membership.staking_card.enable_staking)
-                : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)
-            }
-          />
-        )}
-        {hasStakedPosition && (
+        {hasStakedPosition ? (
           <Box flexDirection="row" gap={10}>
             <RnbwThemedButton
               onPress={navigateToUnstakeSheet}
@@ -56,16 +47,34 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
               label={hasMinimumStakeAmount ? i18n.t(i18n.l.button.add) : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)}
             />
           </Box>
+        ) : (
+          <RnbwThemedButton
+            onPress={hasMinimumStakeAmount ? navigateToStakingLearnSheet : navigateToBuyRnbw}
+            label={
+              hasMinimumStakeAmount
+                ? i18n.t(i18n.l.rnbw_membership.staking_card.enable_staking)
+                : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)
+            }
+          />
         )}
         <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4}>
           <RnbwCoinIcon size={18} />
           <Text size="15pt" weight="bold" color="labelSecondary" align="center">
-            {`${availableAmount}`}
+            {availableAmount}
           </Text>
           <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
-            {i18n.t(i18n.l.rnbw_membership.staking_card.available_to_stake)}
+            {i18n.t(
+              hasStakedPosition
+                ? i18n.l.rnbw_membership.staking_card.available_to_add
+                : i18n.l.rnbw_membership.staking_card.available_to_stake
+            )}
           </Text>
         </Box>
+        {!hasMinimumStakeAmount && (
+          <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
+            {i18n.t(i18n.l.rnbw_membership.staking_card.minimum_stake_amount_required, { minStakeAmount: MIN_STAKE_AMOUNT })}
+          </Text>
+        )}
       </Box>
     </MembershipCard>
   );

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingEarningsCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingEarningsCard.tsx
@@ -6,58 +6,51 @@ import rnbwCoinImage from '@/assets/rnbw.png';
 import { Image } from 'react-native';
 import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
 import * as i18n from '@/languages';
+import { isZero } from '@/helpers/utilities';
 
 export const RnbwStakingEarningsCard = memo(function RnbwStakingEarningsCard() {
-  const { totalEarnings, cashbackEarnings, cashbackShare, exitRewardsEarnings, exitRewardsShare } = useRnbwStakingEarnings();
+  const { totalEarnings, cashbackEarnings, exitRewardsEarnings } = useRnbwStakingEarnings();
+
+  const isZeroTotalEarnings = isZero(totalEarnings);
 
   return (
     <MembershipCard padding="24px">
       <Box gap={16}>
         <Text size="17pt" weight="bold" color="labelTertiary" align="left">
-          {i18n.t(i18n.l.rnbw_membership.staking_earnings_card.total_earnings)}
+          {i18n.t(i18n.l.rnbw_membership.staking_earnings_card.lifetime_earnings)}
         </Text>
 
         <Box flexDirection="row" alignItems="center" gap={8}>
           <Image source={rnbwCoinImage} style={{ width: 40, height: 40 }} />
-          <Text size="34pt" weight="bold" color="label">
+          <Text size="34pt" weight="bold" color={isZeroTotalEarnings ? 'labelQuaternary' : 'label'}>
             {totalEarnings}
           </Text>
         </Box>
         <Separator color="separatorTertiary" thickness={1} />
         <Box gap={14}>
-          <EarningsRow
-            label={i18n.t(i18n.l.rnbw_membership.staking_earnings_card.cashback)}
-            percentage={cashbackShare}
-            amount={cashbackEarnings}
-          />
+          <EarningsRow label={i18n.t(i18n.l.rnbw_membership.shared.fee_cashback)} amount={cashbackEarnings} />
           <Separator color="separatorTertiary" thickness={1} />
-          <EarningsRow
-            label={i18n.t(i18n.l.rnbw_membership.staking_earnings_card.exit_rewards)}
-            percentage={exitRewardsShare}
-            amount={exitRewardsEarnings}
-          />
+          <EarningsRow label={i18n.t(i18n.l.rnbw_membership.staking_earnings_card.exit_fee_rewards)} amount={exitRewardsEarnings} />
         </Box>
       </Box>
     </MembershipCard>
   );
 });
 
-const EarningsRow = memo(function EarningsRow({ label, percentage, amount }: { label: string; percentage: string; amount: string }) {
+const EarningsRow = memo(function EarningsRow({ label, amount }: { label: string; amount: string }) {
+  const isZeroAmount = isZero(amount);
   return (
     <Box flexDirection="row" alignItems="center" justifyContent="space-between">
       <Box flexDirection="row" alignItems="center" gap={6}>
         <Text size="17pt" weight="bold" color="label">
           {label}
         </Text>
-        <Text size="17pt" weight="bold" color="labelQuaternary">
-          {percentage}
-        </Text>
       </Box>
       <Box flexDirection="row" alignItems="center" gap={2}>
-        <Text size="17pt" weight="bold" color={'green'}>
+        <Text size="17pt" weight="bold" color={isZeroAmount ? 'labelQuaternary' : 'green'}>
           {amount}
         </Text>
-        <Text size="17pt" weight="bold" color={'green'}>
+        <Text size="17pt" weight="bold" color={isZeroAmount ? 'labelQuaternary' : 'green'}>
           {RNBW_SYMBOL}
         </Text>
       </Box>

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwUnstakePenaltyRecoveryCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwUnstakePenaltyRecoveryCard.tsx
@@ -1,16 +1,16 @@
 import { memo } from 'react';
 import { Box, Separator, Text, useColorMode } from '@/design-system';
+import { useRnbwStakingEarnings } from '@/features/rnbw-staking/stores/derived/useRnbwStakingEarnings';
 import { useRnbwStakingPositionPnl } from '@/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { ProgressMeter } from '@/features/rnbw-membership/components/ProgressMeter';
 import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
-import { formatNumber } from '@/helpers/strings';
 import * as i18n from '@/languages';
 
 export const RnbwUnstakePenaltyRecoveryCard = memo(function RnbwUnstakePenaltyRecoveryCard() {
   const { isDarkMode } = useColorMode();
-  const { exitFeeOffsetRatio, exitFeeOffsetRatioDisplay, earnedFromExitFees, earningsRequiredToBreakEven, isPositivePnl } =
-    useRnbwStakingPositionPnl();
+  const { exitRewardsEarnings } = useRnbwStakingEarnings();
+  const { exitFeeOffsetRatio, exitFeeOffsetRatioDisplay, earningsRequiredToBreakEven, isPositivePnl } = useRnbwStakingPositionPnl();
 
   return (
     <MembershipCard padding="24px">
@@ -35,11 +35,11 @@ export const RnbwUnstakePenaltyRecoveryCard = memo(function RnbwUnstakePenaltyRe
           <Text size="15pt" weight="medium" color="labelTertiary">
             {i18n.t(i18n.l.rnbw_membership.unstake_penalty_recovery_card.earned_prefix)}
             <Text size="15pt" weight="bold" color={isDarkMode ? 'labelSecondary' : 'label'}>
-              {`${formatNumber(earnedFromExitFees, { decimals: 2 })} ${RNBW_SYMBOL}`}
+              {`${exitRewardsEarnings} ${RNBW_SYMBOL}`}
             </Text>
             {i18n.t(i18n.l.rnbw_membership.unstake_penalty_recovery_card.earned_middle)}
             <Text size="15pt" weight="bold" color={isDarkMode ? 'labelSecondary' : 'label'}>
-              {`${formatNumber(earningsRequiredToBreakEven, { decimals: 2 })} ${RNBW_SYMBOL}`}
+              {`${earningsRequiredToBreakEven} ${RNBW_SYMBOL}`}
             </Text>
             {i18n.t(i18n.l.rnbw_membership.unstake_penalty_recovery_card.earned_suffix)}
           </Text>

--- a/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
@@ -80,7 +80,7 @@ function Tier({ tier, tierIndex, tierCount }: { tier: TierType; tierIndex: numbe
               </Text>
             </TierThemedLabel>
             <Text size="17pt" weight="semibold" color="labelTertiary">
-              {i18n.t(i18n.l.rnbw_membership.shared.rewards)}
+              {i18n.t(i18n.l.rnbw_membership.shared.fee_cashback)}
             </Text>
           </Box>
         </Box>
@@ -88,7 +88,7 @@ function Tier({ tier, tierIndex, tierCount }: { tier: TierType; tierIndex: numbe
         <Box gap={16} paddingHorizontal={'8px'}>
           <Box flexDirection="row" justifyContent="space-between">
             <Text size="17pt" weight="semibold" color="labelTertiary">
-              {i18n.t(i18n.l.rnbw_membership.shared.rewards)}
+              {i18n.t(i18n.l.rnbw_membership.shared.fee_cashback)}
             </Text>
             <Text size="17pt" weight="bold" color="label">
               {tierCashbackDisplay}

--- a/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
+++ b/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
@@ -1,5 +1,4 @@
-import { createDerivedStore } from '@/state/internal/createDerivedStore';
-import { shallowEqual } from '@/worklets/comparisons';
+import { createDerivedStore, shallowEqual } from '@storesjs/stores';
 import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
 import { divWorklet, subWorklet, toFixedWorklet } from '@/framework/core/safeMath';
 import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
@@ -61,5 +60,5 @@ export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
       maxTierProgress,
     };
   },
-  { equalityFn: shallowEqual, fastMode: true }
+  { equalityFn: shallowEqual, lockDependencies: true }
 );

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -1,10 +1,10 @@
 import { parseAbi, type Address } from 'viem';
 import { ChainId } from '@/state/backendNetworks/types';
 import { getUniqueId } from '@/utils/ethereumUtils';
+import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 
 export const RNBW_TOKEN_ADDRESS: Address = '0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0';
 export const RNBW_CHAIN_ID = ChainId.base;
-export const RNBW_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 export const RNBW_DECIMALS = 18;
 export const RNBW_TOKEN_UNIQUE_ID = getUniqueId(RNBW_TOKEN_ADDRESS, RNBW_CHAIN_ID).toLowerCase();
 export const RNBW_TOKEN_ICON_URL =
@@ -22,3 +22,4 @@ export const STAKING_GAS_LIMIT = 200_000;
 export const DEFAULT_EXIT_FEE_PERCENTAGE = 10;
 
 export const MIN_CLAIM_TO_STAKING_RAW = '1000000000000000000'; // 1 RNBW (10^18)
+export const MIN_STAKE_AMOUNT = convertRawAmountToDecimalFormat(MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS);

--- a/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
@@ -52,9 +52,9 @@ export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
           </Box>
           <Box gap={42} flexGrow={1}>
             <ReasonRow
-              title={i18n.t(i18n.l.rnbw_staking.learn_screen.put_your_rnbw_to_work_title)}
-              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.put_your_rnbw_to_work_subtitle)}
-              icon={<PutYourRnbwToWorkIcon />}
+              title={i18n.t(i18n.l.rnbw_staking.learn_screen.fee_cashback)}
+              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.fee_cashback_subtitle)}
+              icon={<LockedRnbwIcon />}
             />
             <ReasonRow
               title={i18n.t(i18n.l.rnbw_staking.learn_screen.exit_fee_title, { exitFeePercentage })}
@@ -62,9 +62,9 @@ export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
               icon={<UnstakePenaltyIcon percentage={exitFeePercentage} />}
             />
             <ReasonRow
-              title={i18n.t(i18n.l.rnbw_staking.learn_screen.passive_income_title)}
-              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.passive_income_subtitle)}
-              icon={<PassiveIncomeIcon />}
+              title={i18n.t(i18n.l.rnbw_staking.learn_screen.stay_in_to_earn_more)}
+              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.stay_in_to_earn_more_subtitle)}
+              icon={<ProgressMeterIcon />}
             />
           </Box>
         </Box>
@@ -95,7 +95,7 @@ function ReasonRow({ title, subtitle, icon }: { title: string; subtitle: string;
   );
 }
 
-function PutYourRnbwToWorkIcon() {
+function LockedRnbwIcon() {
   const { isDarkMode } = useColorMode();
   return (
     <View style={styles.rnbwIconWrapper}>
@@ -137,7 +137,7 @@ function UnstakePenaltyIcon({ percentage }: { percentage: number }) {
   );
 }
 
-function PassiveIncomeIcon() {
+function ProgressMeterIcon() {
   const { isDarkMode } = useColorMode();
   const backgroundColor = isDarkMode ? '#383A40' : '#FFFFFF';
   return (

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import { LinearTransition } from 'react-native-reanimated';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
@@ -17,7 +17,6 @@ import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { useRnbwStakingBalance } from '../../stores/derived/useRnbwStakingBalance';
 import { useRnbwStakingPositionPnl } from '../../stores/derived/useRnbwStakingPositionPnl';
 import { useStakingPositionStore } from '../../stores/rnbwStakingPositionStore';
-import { useStableValue } from '@/hooks/useStableValue';
 import { LinearGradient } from 'expo-linear-gradient';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { RnbwHoldToActivateButton } from '@/features/rnbw-membership/components/RnbwHoldToActivateButton';
@@ -81,14 +80,14 @@ const WarningContent = memo(function WarningContent({ onProceed }: { onProceed: 
                 style={StyleSheet.absoluteFill}
               />
               <Text color={{ custom: globalColors.red60 }} size="22pt" weight="heavy">
-                {i18n.t(i18n.l.rnbw_staking.unstake_sheet.confirm_unstake)}
+                {i18n.t(i18n.l.button.continue)}
               </Text>
             </Box>
           </ButtonPressAnimation>
           <Box height={48} justifyContent="center" alignItems="center">
             <ButtonPressAnimation onPress={goBack}>
               <Text color="label" size="22pt" weight="heavy">
-                {i18n.t(i18n.l.rnbw_staking.unstake_sheet.keep_staking)}
+                {i18n.t(i18n.l.button.cancel)}
               </Text>
             </ButtonPressAnimation>
           </Box>
@@ -99,23 +98,36 @@ const WarningContent = memo(function WarningContent({ onProceed }: { onProceed: 
 });
 
 const UnstakeContent = memo(function UnstakeContent() {
-  // We use the initial values only so we do not display 0 prior to the sheet being dismissed after unstaking.
-  const { tokenAmount, nativeCurrencyAmount } = useStableValue(() => useRnbwStakingBalance.getState());
-  const { exitFeeOffsetRatioDisplay, netPnl, isPositivePnl, rnbwAfterUnstake } = useStableValue(() => useRnbwStakingPositionPnl.getState());
-  const exitFeePercentage = useStableValue(() => useStakingPositionStore.getState().getExitFeePercentage());
+  const { tokenAmount, nativeCurrencyAmount } = useRnbwStakingBalance();
+  const { netPnl, isPositivePnl, rnbwAfterUnstake } = useRnbwStakingPositionPnl();
+  const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
   const { goBack, navigate } = useNavigation();
   const accountAddress = useAccountAddress();
   const isReadOnlyWallet = useIsReadOnlyWallet();
   const isHardwareWallet = useIsHardwareWallet();
   const [isProcessing, setIsProcessing] = useState(false);
+  const liveDisplay = {
+    tokenAmount,
+    nativeCurrencyAmount,
+    netPnl,
+    isPositivePnl,
+    rnbwAfterUnstake,
+    exitFeePercentage,
+  };
+  const frozenDisplayRef = useRef<typeof liveDisplay | null>(null);
 
-  const startUnstake = useCallback(async () => {
+  // Keep values live until submit, then freeze to prevent a brief zero value flash during sheet dismissal.
+  const displayValues = isProcessing && frozenDisplayRef.current ? frozenDisplayRef.current : liveDisplay;
+
+  const startUnstake = async () => {
+    frozenDisplayRef.current = liveDisplay;
     setIsProcessing(true);
     try {
       await unstakeRnbw({ address: accountAddress });
       goBack();
     } catch (e) {
       setIsProcessing(false);
+      frozenDisplayRef.current = null;
       Alert.alert(
         i18n.t(i18n.l.rnbw_staking.unstake_sheet.unstake_failed_title),
         i18n.t(i18n.l.rnbw_staking.unstake_sheet.unstake_failed_message)
@@ -123,9 +135,9 @@ const UnstakeContent = memo(function UnstakeContent() {
       const error = ensureError(e);
       logger.error(new RainbowError('[RnbwUnstakeSheet]: Unstake failed', error));
     }
-  }, [accountAddress, goBack]);
+  };
 
-  const handleUnstake = useCallback(async () => {
+  const handleUnstake = async () => {
     if (isReadOnlyWallet) {
       watchingAlert();
       return;
@@ -136,7 +148,7 @@ const UnstakeContent = memo(function UnstakeContent() {
     } else {
       await startUnstake();
     }
-  }, [isHardwareWallet, isReadOnlyWallet, navigate, startUnstake]);
+  };
 
   return (
     <View style={styles.unstakeContentContainer}>
@@ -148,10 +160,10 @@ const UnstakeContent = memo(function UnstakeContent() {
           <RnbwCoinIcon size={80} />
           <Stack space="12px" alignHorizontal="center">
             <Text color="label" size="44pt" weight="heavy" align="center">
-              {tokenAmount}
+              {displayValues.tokenAmount}
             </Text>
             <Text color="labelTertiary" size="17pt" weight="bold" align="center">
-              {nativeCurrencyAmount}
+              {displayValues.nativeCurrencyAmount}
             </Text>
           </Stack>
         </Stack>
@@ -164,15 +176,7 @@ const UnstakeContent = memo(function UnstakeContent() {
               {i18n.t(i18n.l.rnbw_staking.unstake_sheet.exit_fee)}
             </Text>
             <Text color="label" size="17pt" weight="bold">
-              {`${exitFeePercentage}%`}
-            </Text>
-          </Box>
-          <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">
-            <Text color="labelTertiary" size="17pt" weight="semibold">
-              {i18n.t(i18n.l.rnbw_staking.unstake_sheet.loyalty_progress)}
-            </Text>
-            <Text color="label" size="17pt" weight="bold">
-              {`${exitFeeOffsetRatioDisplay}`}
+              {`${displayValues.exitFeePercentage}%`}
             </Text>
           </Box>
           <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">
@@ -180,15 +184,15 @@ const UnstakeContent = memo(function UnstakeContent() {
               {i18n.t(i18n.l.rnbw_staking.unstake_sheet.receive)}
             </Text>
             <Text color="label" size="17pt" weight="bold">
-              {`${rnbwAfterUnstake} ${RNBW_SYMBOL}`}
+              {`${displayValues.rnbwAfterUnstake} ${RNBW_SYMBOL}`}
             </Text>
           </Box>
           <Box flexDirection="row" height={44} alignItems="center" justifyContent="space-between" width="full">
             <Text color="labelTertiary" size="17pt" weight="semibold">
               {i18n.t(i18n.l.rnbw_staking.unstake_sheet.total_return)}
             </Text>
-            <Text color={isPositivePnl ? 'green' : 'red'} size="17pt" weight="bold">
-              {`${netPnl} ${RNBW_SYMBOL}`}
+            <Text color={displayValues.isPositivePnl ? 'green' : 'red'} size="17pt" weight="bold">
+              {`${displayValues.netPnl} ${RNBW_SYMBOL}`}
             </Text>
           </Box>
         </Stack>

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingBalance.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingBalance.ts
@@ -1,7 +1,6 @@
 import { convertAmountToNativeDisplayWorklet, convertRawAmountToDecimalFormat, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
-import { createDerivedStore } from '@/state/internal/createDerivedStore';
-import { shallowEqual } from '@/worklets/comparisons';
+import { createDerivedStore, shallowEqual } from '@storesjs/stores';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
 import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
 
@@ -30,5 +29,5 @@ export const useRnbwStakingBalance = createDerivedStore<StakingBalance>(
       hasStakedPosition: !isZero,
     };
   },
-  { equalityFn: shallowEqual, fastMode: true }
+  { equalityFn: shallowEqual, lockDependencies: true }
 );

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingEarnings.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingEarnings.ts
@@ -1,24 +1,19 @@
-import { convertRawAmountToDecimalFormat, isZero } from '@/helpers/utilities';
-import { createDerivedStore } from '@/state/internal/createDerivedStore';
-import { shallowEqual } from '@/worklets/comparisons';
+import { convertRawAmountToDecimalFormat, isZero, truncateToDecimalsWithThreshold } from '@/helpers/utilities';
+import { createDerivedStore, shallowEqual } from '@storesjs/stores';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
-import { divWorklet, sumWorklet, toFixedWorklet, toPercentageWorklet, truncateToDecimals } from '@/framework/core/safeMath';
+import { sumWorklet } from '@/framework/core/safeMath';
 import { formatNumber } from '@/helpers/strings';
 
 type StakingEarnings = {
   totalEarnings: string;
   cashbackEarnings: string;
-  cashbackShare: string;
   exitRewardsEarnings: string;
-  exitRewardsShare: string;
 };
 
 const EMPTY_EARNINGS: StakingEarnings = {
-  totalEarnings: formatNumber('0', { decimals: 4 }),
-  cashbackEarnings: formatNumber('0'),
-  cashbackShare: '0%',
-  exitRewardsEarnings: formatNumber('0'),
-  exitRewardsShare: '0%',
+  totalEarnings: '0',
+  cashbackEarnings: '0',
+  exitRewardsEarnings: '0',
 };
 
 export const useRnbwStakingEarnings = createDerivedStore<StakingEarnings>(
@@ -28,24 +23,23 @@ export const useRnbwStakingEarnings = createDerivedStore<StakingEarnings>(
     if (!data) return EMPTY_EARNINGS;
 
     const tokenDecimals = data.decimals;
-    const sessionPnl = data.sessionPnl;
-    const cashbackRaw = sessionPnl.totalCashbackReceived;
-    const exitRewardsRaw = sessionPnl.exchangeRateGain;
+    const lifetimePnl = data.pnl;
+    const cashbackRaw = lifetimePnl.totalCashbackReceived;
+    const exitRewardsRaw = lifetimePnl.exchangeRateGain;
     const totalRaw = sumWorklet(cashbackRaw, exitRewardsRaw);
-    const totalIsZero = isZero(totalRaw);
     const totalEarnings = convertRawAmountToDecimalFormat(totalRaw, tokenDecimals);
     const cashbackEarnings = convertRawAmountToDecimalFormat(cashbackRaw, tokenDecimals);
     const exitRewardsEarnings = convertRawAmountToDecimalFormat(exitRewardsRaw, tokenDecimals);
-    const cashbackRatio = totalIsZero ? '0' : toFixedWorklet(divWorklet(cashbackRaw, totalRaw), 2);
-    const exitRewardsRatio = totalIsZero ? '0' : toFixedWorklet(divWorklet(exitRewardsRaw, totalRaw), 2);
 
     return {
-      totalEarnings: formatNumber(totalEarnings, { decimals: 4 }),
-      cashbackEarnings: isZero(cashbackEarnings) ? '0' : formatNumber(truncateToDecimals(cashbackEarnings, 2), { decimals: 2 }),
-      cashbackShare: totalIsZero ? '0%' : `${toPercentageWorklet(cashbackRatio)}%`,
-      exitRewardsEarnings: isZero(exitRewardsEarnings) ? '0' : formatNumber(truncateToDecimals(exitRewardsEarnings, 2), { decimals: 2 }),
-      exitRewardsShare: totalIsZero ? '0%' : `${toPercentageWorklet(exitRewardsRatio)}%`,
+      totalEarnings: isZero(totalEarnings) ? '0' : formatNumber(totalEarnings, { decimals: 4 }),
+      cashbackEarnings: isZero(cashbackEarnings)
+        ? '0'
+        : truncateToDecimalsWithThreshold({ value: cashbackEarnings, decimals: 2, threshold: '0.01' }),
+      exitRewardsEarnings: isZero(exitRewardsEarnings)
+        ? '0'
+        : truncateToDecimalsWithThreshold({ value: exitRewardsEarnings, decimals: 2, threshold: '0.01' }),
     };
   },
-  { equalityFn: shallowEqual, fastMode: true }
+  { equalityFn: shallowEqual, lockDependencies: true }
 );

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
@@ -1,7 +1,7 @@
 import { divWorklet, isPositive, mulWorklet, subWorklet, toFixedWorklet, toPercentageWorklet } from '@/framework/core/safeMath';
-import { convertRawAmountToDecimalFormatWorklet, formatNumber, isZero } from '@/helpers/utilities';
-import { createDerivedStore } from '@/state/internal/createDerivedStore';
-import { shallowEqual } from '@/worklets/comparisons';
+import { convertRawAmountToDecimalFormatWorklet, isZero } from '@/helpers/utilities';
+import { formatNumber } from '@/helpers/strings';
+import { createDerivedStore, shallowEqual } from '@storesjs/stores';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
 
 type StakingPositionPnl = {
@@ -9,7 +9,6 @@ type StakingPositionPnl = {
   exitFeeOffsetRatioDisplay: string;
   netPnl: string;
   isPositivePnl: boolean;
-  earnedFromExitFees: string;
   earningsRequiredToBreakEven: string;
   rnbwAfterUnstake: string;
 };
@@ -19,7 +18,6 @@ const EMPTY_VALUE: StakingPositionPnl = {
   exitFeeOffsetRatioDisplay: '0%',
   netPnl: '0',
   isPositivePnl: false,
-  earnedFromExitFees: '0',
   earningsRequiredToBreakEven: '0',
   rnbwAfterUnstake: '0',
 };
@@ -39,17 +37,16 @@ export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
 
     const netPnl = subWorklet(exchangeRateGain, exitFee);
     const isPositivePnl = isPositive(netPnl);
-    const netPnlFormatted = toFixedWorklet(convertRawAmountToDecimalFormatWorklet(netPnl, decimals), 4);
+    const netPnlFormatted = formatNumber(toFixedWorklet(convertRawAmountToDecimalFormatWorklet(netPnl, decimals), 4));
 
     return {
       exitFeeOffsetRatio,
       exitFeeOffsetRatioDisplay: isZero(exitFeeOffsetRatio) ? '0%' : `${toPercentageWorklet(exitFeeOffsetRatio, 0.001)}%`,
       netPnl: isPositivePnl ? `+${netPnlFormatted}` : netPnlFormatted,
-      earnedFromExitFees: formatNumber(convertRawAmountToDecimalFormatWorklet(exchangeRateGain, decimals)),
       earningsRequiredToBreakEven: formatNumber(convertRawAmountToDecimalFormatWorklet(subWorklet(exitFee, exchangeRateGain), decimals)),
       rnbwAfterUnstake: formatNumber(convertRawAmountToDecimalFormatWorklet(subWorklet(stakedRnbw, exitFee), decimals)),
       isPositivePnl,
     };
   },
-  { equalityFn: shallowEqual, fastMode: true }
+  { equalityFn: shallowEqual, lockDependencies: true }
 );

--- a/src/features/rnbw-staking/utils/stakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbw.ts
@@ -32,7 +32,7 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
     const claimStrategy = await resolveClaimStrategy(stakeAmountRaw);
     claimToDestination = claimStrategy.claimToDestination;
     claimFulfillsStake = claimStrategy.claimFulfillsStake;
-    const { requiredWalletBalanceRaw } = claimStrategy;
+    const { requiredWalletBalanceRaw, walletStakeAmountRaw } = claimStrategy;
     const amountFromWallet = formatUnits(BigInt(requiredWalletBalanceRaw), RNBW_DECIMALS);
     const amountFromRewards = subWorklet(amount, amountFromWallet);
 
@@ -83,8 +83,8 @@ export async function stakeRnbw({ address, amount }: { address: Address; amount:
 
     executionMode = canUseSponsoredStaking ? 'sponsored' : 'manual';
     canUseSponsoredStaking
-      ? await stakeRnbwSponsored({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer })
-      : await stakeRnbwManual({ address, provider, stakeAmountRaw: requiredWalletBalanceRaw, signer });
+      ? await stakeRnbwSponsored({ address, provider, stakeAmountRaw: walletStakeAmountRaw, signer })
+      : await stakeRnbwManual({ address, provider, stakeAmountRaw: walletStakeAmountRaw, signer });
 
     await pollForStakingUpdate(postClaimShares);
 
@@ -132,20 +132,33 @@ async function claimRnbwRewards({
 async function resolveClaimStrategy(stakeAmountRaw: string): Promise<{
   claimToDestination: ClaimToDestination;
   requiredWalletBalanceRaw: string;
+  walletStakeAmountRaw: string;
   claimFulfillsStake: boolean;
 }> {
   await useRewardsBalanceStore.getState().fetch(undefined, { force: true });
   const claimableRnbw = useRewardsBalanceStore.getState().getData()?.claimableRnbw ?? '0';
   const hasClaimable = useRewardsBalanceStore.getState().hasClaimableRewards();
-  const claimToStaking =
-    hasClaimable &&
-    greaterThanOrEqualToWorklet(stakeAmountRaw, claimableRnbw) &&
-    greaterThanOrEqualToWorklet(claimableRnbw, MIN_CLAIM_TO_STAKING_RAW);
-  const requiredWalletBalanceRaw = claimToStaking ? subWorklet(stakeAmountRaw, claimableRnbw) : stakeAmountRaw;
+  const canOffsetWithClaim = hasClaimable && greaterThanOrEqualToWorklet(stakeAmountRaw, claimableRnbw);
+  const claimToStaking = canOffsetWithClaim && greaterThanOrEqualToWorklet(claimableRnbw, MIN_CLAIM_TO_STAKING_RAW);
+
+  /**
+   * The claim always executes before the stake tx, so any claimable rewards — whether routed
+   * to staking or to the wallet — reduce the wallet balance the user needs up front.
+   */
+  const requiredWalletBalanceRaw = canOffsetWithClaim ? subWorklet(stakeAmountRaw, claimableRnbw) : stakeAmountRaw;
+
+  /**
+   * When claiming to staking, the claimed tokens go directly to the staking contract,
+   * so only the remainder needs to be staked from the wallet.
+   * When claiming to wallet, the full stake amount is pulled from the wallet (which
+   * now includes the claimed tokens).
+   */
+  const walletStakeAmountRaw = claimToStaking ? subWorklet(stakeAmountRaw, claimableRnbw) : stakeAmountRaw;
 
   return {
     claimToDestination: claimToStaking ? 'staking' : 'wallet',
     requiredWalletBalanceRaw,
+    walletStakeAmountRaw,
     claimFulfillsStake: claimToStaking && equalWorklet(stakeAmountRaw, claimableRnbw),
   };
 }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3855,8 +3855,8 @@
       },
       "shared": {
         "tier_label": "%{tierName} Tier",
-        "rewards": "Rewards",
-        "loyalty_progress": "Loyalty Progress"
+        "loyalty_progress": "Loyalty Progress",
+        "fee_cashback": "Fee Cashback"
       },
       "membership_tier_card": {
         "stake_to_next_tier": "Stake to next tier"
@@ -3869,12 +3869,13 @@
         "enable_staking": "Enable Staking",
         "buy_rnbw": "Buy RNBW",
         "unstake": "Unstake",
-        "available_to_stake": "available to stake"
+        "available_to_stake": "available to stake",
+        "available_to_add": "available to add",
+        "minimum_stake_amount_required": "You need at least %{minStakeAmount} RNBW to stake"
       },
       "staking_earnings_card": {
-        "total_earnings": "Total Earnings",
-        "cashback": "Cashback",
-        "exit_rewards": "Exit Rewards"
+        "lifetime_earnings": "Lifetime Earnings",
+        "exit_fee_rewards": "Exit Fee Rewards"
       },
       "unstake_penalty_recovery_card": {
         "break_even_reached": "Break even reached!",
@@ -3900,24 +3901,21 @@
       "learn_screen": {
         "introducing": "INTRODUCING",
         "title": "Staking",
-        "description": "Lock your $RNBW to join the pool. Stay longer to recover your exit fee and earn from those who leave.",
-        "put_your_rnbw_to_work_title": "Put Your $RNBW to Work",
-        "put_your_rnbw_to_work_subtitle": "Stake your RNBW to lock your position and start earning from the pool.",
+        "description": "Stake RNBW to unlock status tiers and exclusive member benefits.",
+        "fee_cashback": "Fee Cashback",
+        "fee_cashback_subtitle": "Receive up to 100% of fees as staked RNBW.",
         "exit_fee_title": "%{exitFeePercentage}% Exit Fee",
-        "exit_fee_subtitle": "Unstaking comes with a %{exitFeePercentage}% fee.",
-        "passive_income_title": "Passive Income",
-        "passive_income_subtitle": "Benefit from every exit. Exit fees are distributed to the pool. Stay longer to offset your own fees and reach pure profit.",
+        "exit_fee_subtitle": "You can unstake anytime. Just pay a %{exitFeePercentage}% exit fee that's distributed to other stakers.",
+        "stay_in_to_earn_more": "Stay in to earn more",
+        "stay_in_to_earn_more_subtitle": "When someone unstakes their RNBW, exit fees go back to those still in the pool.",
         "enable_staking": "Enable Staking"
       },
       "unstake_sheet": {
         "exit_fee": "Exit Fee",
-        "warning_description": "Unstaking will charge a %{exitFeePercentage}% fee to your staked balance.",
-        "confirm_unstake": "Confirm Unstake",
-        "keep_staking": "Keep Staking",
+        "warning_description": "Unstaking will charge a %{exitFeePercentage}% fee to your currently staked balance.",
         "unstake_failed_title": "Unstake Failed",
         "unstake_failed_message": "An error occurred while unstaking your RNBW. Please try again.",
         "unstake_title": "Unstake $%{symbol}",
-        "loyalty_progress": "Loyalty Progress",
         "receive": "Receive",
         "total_return": "Total Return",
         "hold_to_unstake": "Hold to Unstake",

--- a/src/state/rnbw/useStakableRnbwBalance.ts
+++ b/src/state/rnbw/useStakableRnbwBalance.ts
@@ -4,17 +4,14 @@ import {
   convertRawAmountToDecimalFormat,
   greaterThanOrEqualTo,
   isPositive,
+  truncateToDecimalsWithThreshold,
 } from '@/helpers/utilities';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
-import { MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS, RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
+import { MIN_STAKE_AMOUNT, RNBW_DECIMALS, RNBW_TOKEN_UNIQUE_ID } from '@/features/rnbw-staking/constants';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { shallowEqual } from '@/worklets/comparisons';
-import { toFixedWorklet } from '@/framework/core/safeMath';
-import { formatNumber } from '@/helpers/strings';
-
-const MIN_STAKE_AMOUNT = convertRawAmountToDecimalFormat(MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS);
 
 type RnbwBalance = {
   walletBalance: string;
@@ -45,7 +42,8 @@ export const useStakableRnbwBalance = createDerivedStore<RnbwBalance>(
     return {
       walletBalance: walletAmount,
       claimableBalance: claimableAmount,
-      tokenAmountFormatted: formatNumber(toFixedWorklet(totalAmount, 2)),
+      tokenAmountFormatted:
+        totalAmount === '0' ? '0' : truncateToDecimalsWithThreshold({ value: totalAmount, decimals: 2, threshold: '0.01' }),
       nativeCurrencyAmount: convertAmountToNativeDisplayWorklet(totalNativeValue, currency, hasBalance),
       hasBalance,
       hasMinimumStakeAmount: greaterThanOrEqualTo(totalAmount, MIN_STAKE_AMOUNT),

--- a/src/systems/funding/stores/createAmountStore.ts
+++ b/src/systems/funding/stores/createAmountStore.ts
@@ -44,6 +44,11 @@ export function computeInitialDepositAmount(
   sliderProgress = INITIAL_SLIDER_PROGRESS
 ): string {
   const maxSwappableAmount = computeMaxSwappableAmount(asset, gasSettings, gasLimit ?? undefined) || '0';
-  const { amount } = amountFromSliderProgress(sliderProgress, maxSwappableAmount, asset?.price?.value ?? 0, asset?.decimals ?? 18);
-  return amount;
+  const { amount, trueBalance } = amountFromSliderProgress(
+    sliderProgress,
+    maxSwappableAmount,
+    asset?.price?.value ?? 0,
+    asset?.decimals ?? 18
+  );
+  return trueBalance ?? amount;
 }


### PR DESCRIPTION
## What changed

Assorted polish fixes across the feature that came up in testing / final product decisions. Mostly UI/UX improvements, copy updates, and a staking logic fix.

## Main changes

- `RnbwUnstakeSheet`: replaced `useStableValue` snapshot pattern with a `ref`-based freeze. Display values stay live until submit, then freeze to prevent a zero-flash during sheet dismissal. The `useStableValue` solution allowed for a bug where all of the values would be 0 if the stores data had not yet loaded by the time the component mounted. 
- `RnbwEarningsCard`: Switched to lifetime earnings, removed ratio %, and changed copy.
- `stakeRnbw`: fixed wallet stake amount calculation logic error. Now correctly distinguishes `requiredWalletBalanceRaw` from `walletStakeAmountRaw` (actual amount sent to the stake tx), accounting for claim-to-wallet vs claim-to-staking paths
-  Migrated all derived stores to the published package `@storesjs/stores`. There was a subtle reactivity bug in the app derived store version that caused stores to not react to query store param changes when the return of the derived store was the empty response. 
- `createAmountStore`: uses `trueBalance` from slider progress when available for initial deposit amount. Previously if the slider wasn't manually moved to the max, the submitted amount would be truncated. 
- `RnbwMembershipScreen`: Made tier badge in navbar tappable to open tiers sheet
