### PR TITLE
feature: prevent hardware wallets from using staking

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -9,6 +9,7 @@ import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { MembershipCard } from './MembershipCard';
 import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
 import { navigateToBuyRnbw } from '@/features/rnbw-membership/utils/navigateToBuyRnbw';
+import { blockRnbwStakingAccessIfNeeded } from '@/features/rnbw-staking/utils/blockStakingAccessIfNeeded';
 import * as i18n from '@/languages';
 import { MIN_STAKE_AMOUNT } from '@/features/rnbw-staking/constants';
 
@@ -81,13 +82,22 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
 });
 
 function navigateToStakingLearnSheet() {
+  if (blockRnbwStakingAccessIfNeeded()) {
+    return;
+  }
   Navigation.handleAction(Routes.RNBW_STAKING_LEARN_SCREEN);
 }
 
 function navigateToStakingScreen() {
+  if (blockRnbwStakingAccessIfNeeded()) {
+    return;
+  }
   Navigation.handleAction(Routes.RNBW_STAKING_SCREEN);
 }
 
 function navigateToUnstakeSheet() {
+  if (blockRnbwStakingAccessIfNeeded()) {
+    return;
+  }
   Navigation.handleAction(Routes.RNBW_UNSTAKE_SHEET);
 }

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -7,9 +7,7 @@ import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { Box, globalColors, Separator, Stack, Text, useForegroundColor } from '@/design-system';
 import { ensureError, logger, RainbowError } from '@/logger';
 import { useNavigation } from '@/navigation/Navigation';
-import Routes from '@/navigation/routesNames';
-import { useAccountAddress, useIsHardwareWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
+import { useAccountAddress } from '@/state/wallets/walletsStore';
 import { unstakeRnbw } from '../../utils/unstakeRnbw';
 import { UnstakePenaltySign } from '@/features/rnbw-staking/components/UnstakePenaltySign';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -101,10 +99,8 @@ const UnstakeContent = memo(function UnstakeContent() {
   const { tokenAmount, nativeCurrencyAmount } = useRnbwStakingBalance();
   const { netPnl, isPositivePnl, rnbwAfterUnstake } = useRnbwStakingPositionPnl();
   const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
-  const { goBack, navigate } = useNavigation();
+  const { goBack } = useNavigation();
   const accountAddress = useAccountAddress();
-  const isReadOnlyWallet = useIsReadOnlyWallet();
-  const isHardwareWallet = useIsHardwareWallet();
   const [isProcessing, setIsProcessing] = useState(false);
   const liveDisplay = {
     tokenAmount,
@@ -138,16 +134,7 @@ const UnstakeContent = memo(function UnstakeContent() {
   };
 
   const handleUnstake = async () => {
-    if (isReadOnlyWallet) {
-      watchingAlert();
-      return;
-    }
-
-    if (isHardwareWallet) {
-      navigate(Routes.HARDWARE_WALLET_TX_NAVIGATOR, { submit: startUnstake });
-    } else {
-      await startUnstake();
-    }
+    await startUnstake();
   };
 
   return (

--- a/src/features/rnbw-staking/utils/blockStakingAccessIfNeeded.ts
+++ b/src/features/rnbw-staking/utils/blockStakingAccessIfNeeded.ts
@@ -1,0 +1,29 @@
+import { Alert } from 'react-native';
+import * as i18n from '@/languages';
+import { getIsHardwareWallet, getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
+import watchingAlert from '@/utils/watchingAlert';
+
+export function blockRnbwStakingAccessIfNeeded(): boolean {
+  const isReadOnlyWallet = getIsReadOnlyWallet();
+
+  if (isReadOnlyWallet) {
+    watchingAlert();
+    return true;
+  }
+
+  const isHardwareWallet = getIsHardwareWallet();
+
+  if (isHardwareWallet) {
+    showHardwareWalletNotSupportedAlert();
+    return true;
+  }
+
+  return false;
+}
+
+function showHardwareWalletNotSupportedAlert() {
+  Alert.alert(
+    i18n.t(i18n.l.rnbw_staking.wallet_access.hardware_wallet_not_supported_title),
+    i18n.t(i18n.l.rnbw_staking.wallet_access.hardware_wallet_not_supported_message)
+  );
+}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3885,6 +3885,10 @@
       }
     },
     "rnbw_staking": {
+      "wallet_access": {
+        "hardware_wallet_not_supported_title": "Hardware Wallet Not Supported",
+        "hardware_wallet_not_supported_message": "RNBW staking is not available for hardware wallets right now."
+      },
       "deposit": {
         "confirm_button": "Hold to Stake",
         "confirm_button_error": "Unable to stake",


### PR DESCRIPTION
## What changed

Blocks hardware wallets wallets from accessing staking flows, showing an alert at button entry points.

## Main changes

- `blockStakingAccessIfNeeded`: Checks wallet type and shows the appropriate alert for watch only wallets or hardware wallets. Added to all staking / unstaking entry points. 