### PR TITLE
ci(setup): skip design system docs install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.22-1",
   "private": true,
   "scripts": {
-    "setup": "yarn graphql-codegen:install && yarn ds:install && yarn graphql-codegen && yarn fetch:networks",
+    "setup": "yarn graphql-codegen:install && yarn graphql-codegen && yarn fetch:networks",
     "setup-ci": "./scripts/setup-ci.sh",
     "adb-all": "adb devices | tail -n +2 | cut -sf 1 | xargs -I {} adb -s {}",
     "android": "react-native run-android --main-activity MainActivityog",


### PR DESCRIPTION
Our `setup` script runs `yarn ds:install` on every invocation, which installs the design system docs site (a Next.js + Playroom app with `498` packages / `~424 MiB` of dependencies). This app is never built, tested, or deployed in any CI workflow. It's also currently broken and doesn't build locally. Across our four main workflows (`~935 job` executions per week), this adds roughly `10` seconds per job and `~2.6` hours of aggregate CI compute per week.

This change removes `ds:install` from the `setup` script. Developers who want to work on the docs site can still run `yarn ds:install` directly, as documented in `src/design-system/README.md`.

Closes FEPLAT-72.