### PR TITLE
feature: skeleton loading states and no fallback exit penalty

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCardSkeleton.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCardSkeleton.tsx
@@ -1,0 +1,20 @@
+import { memo } from 'react';
+import { Box } from '@/design-system';
+import { MembershipCard } from './MembershipCard';
+import { Skeleton } from '@/components/Skeleton';
+import type { DimensionValue } from 'react-native';
+
+type MembershipCardSkeletonProps = {
+  width?: DimensionValue;
+  height?: DimensionValue;
+};
+
+export const MembershipCardSkeleton = memo(function MembershipCardSkeleton({ width = '100%', height = 176 }: MembershipCardSkeletonProps) {
+  return (
+    <MembershipCard>
+      <Box style={{ width, height }}>
+        <Skeleton width="100%" height="100%" />
+      </Box>
+    </MembershipCard>
+  );
+});

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipTierCard.tsx
@@ -10,10 +10,17 @@ import { TierProgressBar } from '@/features/rnbw-membership/components/TierProgr
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import * as i18n from '@/languages';
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { MembershipCardSkeleton } from './MembershipCardSkeleton';
 
 export const MembershipTierCard = memo(function MembershipTierCard() {
+  const showPositionSkeleton = useStakingPositionStore(state => state.getStatus('isInitialLoad') && !state.getData());
   const { currentTier, currentTierIndex, currentTierProgress, stakeRequiredForNextTier, cashbackPercentage, allTiers } =
     useMembershipTierInfo();
+
+  if (showPositionSkeleton) {
+    return <MembershipCardSkeleton height={183} />;
+  }
 
   return (
     <ButtonPressAnimation onPress={navigateToMembershipTiersSheet} scaleTo={0.96}>

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -12,10 +12,17 @@ import { navigateToBuyRnbw } from '@/features/rnbw-membership/utils/navigateToBu
 import { blockRnbwStakingAccessIfNeeded } from '@/features/rnbw-staking/utils/blockStakingAccessIfNeeded';
 import * as i18n from '@/languages';
 import { MIN_STAKE_AMOUNT } from '@/features/rnbw-staking/constants';
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { MembershipCardSkeleton } from './MembershipCardSkeleton';
 
 export const RnbwStakingCard = memo(function RnbwStakingCard() {
+  const showPositionSkeleton = useStakingPositionStore(state => state.getStatus('isInitialLoad') && !state.getData());
   const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
   const { tokenAmountFormatted: availableAmount, hasMinimumStakeAmount } = useStakableRnbwBalance();
+
+  if (showPositionSkeleton) {
+    return <MembershipCardSkeleton height={319} />;
+  }
 
   return (
     <MembershipCard paddingHorizontal="20px" paddingTop="24px" paddingBottom="16px">

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingEarningsCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingEarningsCard.tsx
@@ -7,9 +7,16 @@ import { Image } from 'react-native';
 import { MembershipCard } from '@/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard';
 import * as i18n from '@/languages';
 import { isZero } from '@/helpers/utilities';
+import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
+import { MembershipCardSkeleton } from './MembershipCardSkeleton';
 
 export const RnbwStakingEarningsCard = memo(function RnbwStakingEarningsCard() {
+  const showPositionSkeleton = useStakingPositionStore(state => state.getStatus('isInitialLoad') && !state.getData());
   const { totalEarnings, cashbackEarnings, exitRewardsEarnings } = useRnbwStakingEarnings();
+
+  if (showPositionSkeleton) {
+    return <MembershipCardSkeleton height={195} />;
+  }
 
   const isZeroTotalEarnings = isZero(totalEarnings);
 

--- a/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
+++ b/src/features/rnbw-membership/stores/derived/useMembershipTierInfo.ts
@@ -17,27 +17,14 @@ type MembershipTierInfo = {
   maxTierProgress: number;
 };
 
-const EMPTY_TIER: MembershipTierInfo = {
-  currentTier: FALLBACK_TIERS[0],
-  stakeRequiredForNextTier: '0',
-  cashbackPercentage: 10,
-  currentTierProgress: 0,
-  allTiers: FALLBACK_TIERS,
-  currentTierIndex: 0,
-  maxTierProgress: 0,
-};
-
 export const useMembershipTierInfo = createDerivedStore<MembershipTierInfo>(
   $ => {
-    const data = $(useStakingPositionStore, state => state.getData());
+    const currentTierLevel = $(useStakingPositionStore, state => state.getData()?.tier.level ?? FALLBACK_TIERS[0].level);
+    const allTiers = $(useStakingPositionStore, state => state.getData()?.allTiers ?? FALLBACK_TIERS);
+    const stakedRnbw = $(useStakingPositionStore, state => state.getData()?.stakedRnbw ?? '0');
 
-    if (!data) {
-      return EMPTY_TIER;
-    }
-
-    const { tier: currentTier, allTiers, stakedRnbw } = data;
-
-    const currentTierIndex = allTiers.findIndex(t => t.level === currentTier.level);
+    const currentTierIndex = allTiers.findIndex(t => t.level === currentTierLevel);
+    const currentTier = currentTierIndex >= 0 ? allTiers[currentTierIndex] : FALLBACK_TIERS[0];
     const nextTierIndex = currentTierIndex + 1;
     const nextTier = nextTierIndex < allTiers.length ? allTiers[nextTierIndex] : null;
     const maxTier = allTiers[allTiers.length - 1];

--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -19,7 +19,6 @@ export const STAKING_ABI = parseAbi([
   'function exitFeeBps() view returns (uint256)',
 ]);
 export const STAKING_GAS_LIMIT = 200_000;
-export const DEFAULT_EXIT_FEE_PERCENTAGE = 10;
 
 export const MIN_CLAIM_TO_STAKING_RAW = '1000000000000000000'; // 1 RNBW (10^18)
 export const MIN_STAKE_AMOUNT = convertRawAmountToDecimalFormat(MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS);

--- a/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen.tsx
@@ -2,7 +2,7 @@ import { memo, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import SheetHandleFixedToTop from '@/components/sheet/SheetHandleFixedToTop';
-import { Box, Text, useColorMode } from '@/design-system';
+import { Box, Text, useColorMode, useForegroundColor } from '@/design-system';
 import Routes from '@/navigation/routesNames';
 import Navigation from '@/navigation/Navigation';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
@@ -13,6 +13,7 @@ import { ProgressMeter } from '@/features/rnbw-membership/components/ProgressMet
 import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
 import { LinearGradient } from 'expo-linear-gradient';
 import { opacity } from '@/framework/ui/utils/opacity';
+import { LoadingSpinner } from '@/framework/ui/components/LoadingSpinner';
 import * as i18n from '@/languages';
 
 const ICON_CONTAINER_WIDTH = 62;
@@ -24,9 +25,16 @@ const ARROW_SIZE = 7;
 export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
   const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
   const { top: safeAreaTop, bottom: safeAreaBottom } = useSafeAreaInsets();
+  const labelSecondaryColor = useForegroundColor('labelSecondary');
   const { isDarkMode } = useColorMode();
   const screenBackgroundColor = isDarkMode ? '#090909' : '#FEFEFE';
   const backgroundGradientColor = isDarkMode ? '#FADB71' : '#EFC035';
+  const showLoadingState = exitFeePercentage == null;
+
+  const contentContainerStyle = {
+    marginTop: safeAreaTop + 40,
+    paddingBottom: safeAreaBottom + 8,
+  };
 
   return (
     <Box backgroundColor={screenBackgroundColor} style={styles.container}>
@@ -37,44 +45,50 @@ export const RnbwStakingLearnScreen = memo(function RnbwStakingLearnScreen() {
         style={styles.backgroundGradient}
       />
       <SheetHandleFixedToTop top={safeAreaTop + 6} />
-      <View style={[styles.content, { marginTop: safeAreaTop + 40, paddingBottom: safeAreaBottom + 8 }]}>
-        <Box gap={64} flexGrow={1}>
-          <Box alignItems="center" gap={24}>
-            <Text align="center" size="17pt" weight="heavy" color={{ custom: '#D7A921' }}>
-              {i18n.t(i18n.l.rnbw_staking.learn_screen.introducing)}
-            </Text>
-            <Text align="center" color="label" size="44pt" weight="heavy">
-              {i18n.t(i18n.l.rnbw_staking.learn_screen.title)}
-            </Text>
-            <Text align="center" color="labelTertiary" size="20pt / 135%" weight="semibold">
-              {i18n.t(i18n.l.rnbw_staking.learn_screen.description)}
-            </Text>
+      {showLoadingState ? (
+        <View style={[styles.loadingContainer, contentContainerStyle]}>
+          <LoadingSpinner color={labelSecondaryColor} size={40} />
+        </View>
+      ) : (
+        <View style={[styles.content, contentContainerStyle]}>
+          <Box gap={64} flexGrow={1}>
+            <Box alignItems="center" gap={24}>
+              <Text align="center" size="17pt" weight="heavy" color={{ custom: '#D7A921' }}>
+                {i18n.t(i18n.l.rnbw_staking.learn_screen.introducing)}
+              </Text>
+              <Text align="center" color="label" size="44pt" weight="heavy">
+                {i18n.t(i18n.l.rnbw_staking.learn_screen.title)}
+              </Text>
+              <Text align="center" color="labelTertiary" size="20pt / 135%" weight="semibold">
+                {i18n.t(i18n.l.rnbw_staking.learn_screen.description)}
+              </Text>
+            </Box>
+            <Box gap={42} flexGrow={1}>
+              <ReasonRow
+                title={i18n.t(i18n.l.rnbw_staking.learn_screen.fee_cashback)}
+                subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.fee_cashback_subtitle)}
+                icon={<LockedRnbwIcon />}
+              />
+              <ReasonRow
+                title={i18n.t(i18n.l.rnbw_staking.learn_screen.exit_fee_title, { exitFeePercentage })}
+                subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.exit_fee_subtitle, { exitFeePercentage })}
+                icon={<UnstakePenaltyIcon percentage={exitFeePercentage} />}
+              />
+              <ReasonRow
+                title={i18n.t(i18n.l.rnbw_staking.learn_screen.stay_in_to_earn_more)}
+                subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.stay_in_to_earn_more_subtitle)}
+                icon={<ProgressMeterIcon />}
+              />
+            </Box>
           </Box>
-          <Box gap={42} flexGrow={1}>
-            <ReasonRow
-              title={i18n.t(i18n.l.rnbw_staking.learn_screen.fee_cashback)}
-              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.fee_cashback_subtitle)}
-              icon={<LockedRnbwIcon />}
-            />
-            <ReasonRow
-              title={i18n.t(i18n.l.rnbw_staking.learn_screen.exit_fee_title, { exitFeePercentage })}
-              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.exit_fee_subtitle, { exitFeePercentage })}
-              icon={<UnstakePenaltyIcon percentage={exitFeePercentage} />}
-            />
-            <ReasonRow
-              title={i18n.t(i18n.l.rnbw_staking.learn_screen.stay_in_to_earn_more)}
-              subtitle={i18n.t(i18n.l.rnbw_staking.learn_screen.stay_in_to_earn_more_subtitle)}
-              icon={<ProgressMeterIcon />}
-            />
-          </Box>
-        </Box>
-        <RnbwThemedButton
-          onPress={navigateToStakingScreen}
-          label={i18n.t(i18n.l.rnbw_staking.learn_screen.enable_staking)}
-          height={48}
-          style={styles.button}
-        />
-      </View>
+          <RnbwThemedButton
+            onPress={navigateToStakingScreen}
+            label={i18n.t(i18n.l.rnbw_staking.learn_screen.enable_staking)}
+            height={48}
+            style={styles.button}
+          />
+        </View>
+      )}
     </Box>
   );
 });
@@ -187,6 +201,12 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     justifyContent: 'center',
     width: ICON_CONTAINER_WIDTH,
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 32,
   },
   passiveIncomeWrapper: {
     marginLeft: 8,

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -19,6 +19,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { RnbwHoldToActivateButton } from '@/features/rnbw-membership/components/RnbwHoldToActivateButton';
 import * as i18n from '@/languages';
+import { LoadingSpinner } from '@/framework/ui/components/LoadingSpinner';
 
 const LAYOUT_ANIMATION_CONFIG = SPRING_CONFIGS.snappierSpringConfig;
 const LAYOUT_ANIMATION = LinearTransition.springify()
@@ -27,7 +28,10 @@ const LAYOUT_ANIMATION = LinearTransition.springify()
   .stiffness(LAYOUT_ANIMATION_CONFIG.stiffness);
 
 export const RnbwUnstakeSheet = memo(function RnbwUnstakeSheet() {
+  const labelSecondaryColor = useForegroundColor('labelSecondary');
   const [step, setStep] = useState<'warning' | 'unstake'>('warning');
+  const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
+  const showSkeleton = exitFeePercentage === undefined;
 
   const handleProceedToUnstake = useCallback(() => {
     setStep('unstake');
@@ -35,16 +39,29 @@ export const RnbwUnstakeSheet = memo(function RnbwUnstakeSheet() {
 
   return (
     <PanelSheet layoutAnimation={LAYOUT_ANIMATION}>
-      {step === 'warning' && <WarningContent onProceed={handleProceedToUnstake} />}
-      {step === 'unstake' && <UnstakeContent />}
+      {showSkeleton ? (
+        <Box alignItems="center" justifyContent="center" height={400}>
+          <LoadingSpinner color={labelSecondaryColor} size={40} />
+        </Box>
+      ) : (
+        <>
+          {step === 'warning' && <WarningContent exitFeePercentage={exitFeePercentage} onProceed={handleProceedToUnstake} />}
+          {step === 'unstake' && <UnstakeContent exitFeePercentage={exitFeePercentage} />}
+        </>
+      )}
     </PanelSheet>
   );
 });
 
-const WarningContent = memo(function WarningContent({ onProceed }: { onProceed: () => void }) {
+const WarningContent = memo(function WarningContent({
+  exitFeePercentage,
+  onProceed,
+}: {
+  exitFeePercentage: number;
+  onProceed: () => void;
+}) {
   const { goBack } = useNavigation();
   const redColor = useForegroundColor('red');
-  const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
 
   return (
     <View style={styles.warningContentContainer}>
@@ -95,10 +112,9 @@ const WarningContent = memo(function WarningContent({ onProceed }: { onProceed: 
   );
 });
 
-const UnstakeContent = memo(function UnstakeContent() {
+const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exitFeePercentage: number }) {
   const { tokenAmount, nativeCurrencyAmount } = useRnbwStakingBalance();
   const { netPnl, isPositivePnl, rnbwAfterUnstake } = useRnbwStakingPositionPnl();
-  const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
   const { goBack } = useNavigation();
   const accountAddress = useAccountAddress();
   const [isProcessing, setIsProcessing] = useState(false);

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingBalance.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingBalance.ts
@@ -12,12 +12,10 @@ type StakingBalance = {
 
 export const useRnbwStakingBalance = createDerivedStore<StakingBalance>(
   $ => {
-    const data = $(useStakingPositionStore, state => state.getData());
+    const rawStakedRnbw = $(useStakingPositionStore, state => state.getData()?.stakedRnbw ?? '0');
+    const stakedValueInCurrency = $(useStakingPositionStore, state => state.getData()?.stakedValueInCurrency ?? '0');
+    const decimals = $(useStakingPositionStore, state => state.getData()?.decimals ?? RNBW_DECIMALS);
     const currency = $(userAssetsStoreManager, state => state.currency);
-
-    const rawStakedRnbw = data?.stakedRnbw ?? '0';
-    const stakedValueInCurrency = data?.stakedValueInCurrency ?? '0';
-    const decimals = data?.decimals ?? RNBW_DECIMALS;
     const isZero = rawStakedRnbw === '0';
 
     const decimalAmount = convertRawAmountToDecimalFormat(rawStakedRnbw, decimals);

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingEarnings.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingEarnings.ts
@@ -3,6 +3,7 @@ import { createDerivedStore, shallowEqual } from '@storesjs/stores';
 import { useStakingPositionStore } from '../rnbwStakingPositionStore';
 import { sumWorklet } from '@/framework/core/safeMath';
 import { formatNumber } from '@/helpers/strings';
+import { RNBW_DECIMALS } from '@/features/rnbw-staking/constants';
 
 type StakingEarnings = {
   totalEarnings: string;
@@ -10,22 +11,11 @@ type StakingEarnings = {
   exitRewardsEarnings: string;
 };
 
-const EMPTY_EARNINGS: StakingEarnings = {
-  totalEarnings: '0',
-  cashbackEarnings: '0',
-  exitRewardsEarnings: '0',
-};
-
 export const useRnbwStakingEarnings = createDerivedStore<StakingEarnings>(
   $ => {
-    const data = $(useStakingPositionStore, state => state.getData());
-
-    if (!data) return EMPTY_EARNINGS;
-
-    const tokenDecimals = data.decimals;
-    const lifetimePnl = data.pnl;
-    const cashbackRaw = lifetimePnl.totalCashbackReceived;
-    const exitRewardsRaw = lifetimePnl.exchangeRateGain;
+    const tokenDecimals = $(useStakingPositionStore, state => state.getData()?.decimals ?? RNBW_DECIMALS);
+    const cashbackRaw = $(useStakingPositionStore, state => state.getData()?.pnl.totalCashbackReceived ?? '0');
+    const exitRewardsRaw = $(useStakingPositionStore, state => state.getData()?.pnl.exchangeRateGain ?? '0');
     const totalRaw = sumWorklet(cashbackRaw, exitRewardsRaw);
     const totalEarnings = convertRawAmountToDecimalFormat(totalRaw, tokenDecimals);
     const cashbackEarnings = convertRawAmountToDecimalFormat(cashbackRaw, tokenDecimals);

--- a/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
+++ b/src/features/rnbw-staking/stores/derived/useRnbwStakingPositionPnl.ts
@@ -25,11 +25,10 @@ const EMPTY_VALUE: StakingPositionPnl = {
 export const useRnbwStakingPositionPnl = createDerivedStore<StakingPositionPnl>(
   $ => {
     const data = $(useStakingPositionStore, state => state.getData());
-    const exitFeePercentage = $(useStakingPositionStore, state => state.getExitFeePercentage());
 
     if (!data || data?.stakedRnbw === '0') return EMPTY_VALUE;
 
-    const { stakedRnbw, sessionPnl, decimals } = data;
+    const { stakedRnbw, sessionPnl, decimals, exitFeePercentage } = data;
 
     const exchangeRateGain = sessionPnl?.exchangeRateGain ?? '0';
     const exitFee = mulWorklet(stakedRnbw, exitFeePercentage / 100);

--- a/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
+++ b/src/features/rnbw-staking/stores/rnbwStakingPositionStore.ts
@@ -8,7 +8,7 @@ import { ChainId } from '@/state/backendNetworks/types';
 import { decodeFunctionResult, encodeFunctionData, type Address, type Hex } from 'viem';
 import type { Tier } from '@/features/rnbw-membership/types';
 import { getProvider } from '@/handlers/web3';
-import { DEFAULT_EXIT_FEE_PERCENTAGE, STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
 import { logger, RainbowError } from '@/logger';
 
 type StakingPnl = {
@@ -23,7 +23,7 @@ type StakingPnl = {
 export type StakingPositionData = {
   allTiers: Tier[];
   decimals: number;
-  exitFeePercentage: number | undefined;
+  exitFeePercentage: number;
   hasPosition: boolean;
   lastUpdateTime: string;
   pnl: StakingPnl;
@@ -41,7 +41,7 @@ type StakingPositionParams = {
 };
 
 type StakingPositionStore = {
-  getExitFeePercentage: () => number;
+  getExitFeePercentage: () => number | undefined;
   hasPosition: () => boolean;
 };
 
@@ -55,7 +55,7 @@ export const useStakingPositionStore = createQueryStore<StakingPositionData, Sta
   },
   (_, get) => ({
     getExitFeePercentage: () => {
-      return get().getData()?.exitFeePercentage ?? DEFAULT_EXIT_FEE_PERCENTAGE;
+      return get().getData()?.exitFeePercentage;
     },
     hasPosition: () => {
       const data = get().getData();
@@ -83,7 +83,7 @@ async function fetchStakingPosition({ currency, address }: StakingPositionParams
   return { ...response.data.result, exitFeePercentage };
 }
 
-async function readExitFeePercentage(): Promise<number | undefined> {
+async function readExitFeePercentage(): Promise<number> {
   try {
     const provider = getProvider({ chainId: STAKING_CHAIN_ID });
     const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'exitFeeBps' });
@@ -92,5 +92,6 @@ async function readExitFeePercentage(): Promise<number | undefined> {
     return Number(exitFeeBps) / 100;
   } catch (e) {
     logger.error(new RainbowError('[readExitFeePercentage]: Failed to read exit fee percentage', e));
+    throw e;
   }
 }

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -10,10 +10,18 @@ import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 import { RainbowError } from '@/logger';
 
 export async function unstakeRnbw({ address }: { address: Address }): Promise<Hash> {
+  const initialExitFeePercentage = useStakingPositionStore.getState().getData()?.exitFeePercentage;
+  await useStakingPositionStore.getState().fetch(undefined, { force: true });
   const positionData = useStakingPositionStore.getState().getData();
+
   if (!positionData || !positionData.exitFeePercentage) {
     throw new RainbowError('[unstakeRnbw]: Position data missing');
   }
+
+  if (initialExitFeePercentage !== positionData.exitFeePercentage) {
+    throw new RainbowError('[unstakeRnbw]: Exit fee percentage changed');
+  }
+
   const positionSnapshot = snapshotUnstakeAnalytics(positionData);
 
   try {
@@ -52,8 +60,7 @@ export async function unstakeRnbw({ address }: { address: Address }): Promise<Ha
 }
 
 function snapshotUnstakeAnalytics(positionData: StakingPositionData) {
-  const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl } = positionData;
-  const exitFeePercentage = useStakingPositionStore.getState().getExitFeePercentage();
+  const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl, exitFeePercentage } = positionData;
   const exitFeeRaw = mulWorklet(stakedRnbwRaw, exitFeePercentage / 100);
 
   return {


### PR DESCRIPTION
## What changed

Adds skeleton loading states for the membership screen cards while staking position data loads, and removes the hardcoded fallback exit fee percentage. The fee must now come from the contract, and if it fetching it fails, the whole `useStakingPositionStore` throws. 

The reasoning is that we should never show an incorrect exit penalty percentage to the user if it changes on the contract level. 

These loading states will rarely, if ever, be seen.

## Main changes

- `MembershipCardSkeleton`: new reusable skeleton placeholder for membership cards during initial load
- `RnbwStakingCard`, `RnbwStakingEarningsCard`, `MembershipTierCard`: show skeleton placeholders when position store is in its initial load state
- `rnbwStakingPositionStore`: `getExitFeePercentage()` now returns `undefined` instead of a fallback when data hasn't loaded. `readExitFeePercentage` throws on failure instead of returning a default, so the position fetch itself fails if the contract read fails.
- `RnbwStakingLearnScreen`: shows a loading spinner when exit fee percentage is not yet available
- `RnbwUnstakeSheet`: shows a loading spinner until exit fee is available
- `unstakeRnbw`: re-fetches position data before unstaking and aborts if the exit fee percentage changed since the sheet was opened
- `constants.ts`: removed `DEFAULT_EXIT_FEE_PERCENTAGE`

## Other changes

- `useRnbwStakingBalance`, `useRnbwStakingEarnings`, `useRnbwStakingPositionPnl`, `useMembershipTierInfo`: refactored derived store selectors to subscribe to individual fields instead of entire `getData()` objects to prevent formatting drift in the empty state objects. 
