### PR TITLE
chore: include .github in prettier formatting

### DIFF
--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Enable KVM
       shell: bash

--- a/.github/actions/clear-cache/action.yml
+++ b/.github/actions/clear-cache/action.yml
@@ -1,10 +1,9 @@
-name: "clear-cache"
+name: 'clear-cache'
 description: 'Clear macstadium cache on a specific instance'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - id: clean
       shell: bash
       run: |
         yarn nuke
-

--- a/.github/actions/ssh/action.yaml
+++ b/.github/actions/ssh/action.yaml
@@ -9,17 +9,17 @@ inputs:
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup key
       shell: bash
       env:
-          PKEY: ${{ inputs.key }}
-          NAME: ${{ inputs.name }}
-          SSH_AUTH_SOCK: /tmp/ssh_agent_${{ inputs.name }}.sock
+        PKEY: ${{ inputs.key }}
+        NAME: ${{ inputs.name }}
+        SSH_AUTH_SOCK: /tmp/ssh_agent_${{ inputs.name }}.sock
       run: |
-          mkdir -p "$HOME/.ssh"
-          echo "$PKEY" > "$HOME/.ssh/$NAME"
-          chmod 600 "$HOME/.ssh/$NAME"
-          ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-          ssh-add "$HOME/.ssh/$NAME"
+        mkdir -p "$HOME/.ssh"
+        echo "$PKEY" > "$HOME/.ssh/$NAME"
+        chmod 600 "$HOME/.ssh/$NAME"
+        ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
+        ssh-add "$HOME/.ssh/$NAME"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,26 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     commit-message:
-      prefix: "fix(actions)"
-    target-branch: "develop"
+      prefix: 'fix(actions)'
+    target-branch: 'develop'
     # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
     open-pull-requests-limit: 0
     reviewers:
-      - "rainbow-me/app-admin"
+      - 'rainbow-me/app-admin'
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     commit-message:
-      prefix: "fix(npm)"
-    target-branch: "develop"
+      prefix: 'fix(npm)'
+    target-branch: 'develop'
     # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
     open-pull-requests-limit: 0
     reviewers:
-      - "rainbow-me/app-admin"
+      - 'rainbow-me/app-admin'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,6 @@ Fixes APP-####
 
 ## What changed (plus any additional context for devs)
 
-
 ## Screen recordings / screenshots
 
-
 ## What to test
-

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -10,7 +10,7 @@ jobs:
     name: Simulator
     runs-on: macos-15-xlarge
     env:
-      NODE_OPTIONS: "--max-old-space-size=6144"
+      NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
     if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
     concurrency:
@@ -102,7 +102,7 @@ jobs:
     name: Device
     runs-on: macos-15-xlarge
     env:
-      NODE_OPTIONS: "--max-old-space-size=6144"
+      NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
     if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
     concurrency:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -7,7 +7,7 @@ on:
   issue_comment:
     types: [created]
 env:
-  NODE_OPTIONS: "--max-old-space-size=6144"
+  NODE_OPTIONS: '--max-old-space-size=6144'
 
 jobs:
   # iOS build job
@@ -164,8 +164,8 @@ jobs:
       - uses: futureware-tech/simulator-action@dab10d813144ef59b48d401cd95da151222ef8cd
         id: simulator
         with:
-          model: "iPhone 16"
-          os_version: "18.5"
+          model: 'iPhone 16'
+          os_version: '18.5'
 
       - name: Ensure Simulator is fully booted
         run: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-    - cron: "30 20 * * 1" # Runs every Monday at 20:30 UTC
+    - cron: '30 20 * * 1' # Runs every Monday at 20:30 UTC
 
 jobs:
   stale:
@@ -15,7 +15,7 @@ jobs:
         uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
-          stale-issue-label: "stale"
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'
+          stale-issue-label: 'stale'
           days-before-stale: 30
           days-before-close: 7

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-.github
 .husky
 android
 coverage-ts


### PR DESCRIPTION
The `.github` directory has been excluded from Prettier since #4100 (Aug 2022), when formatting was first applied across the codebase. It was blanket-ignored alongside `android`, `ios`, and other non-source directories, but unlike those, `.github` contains YAML and Markdown that Prettier handles natively. There's no reason to keep it excluded.

This change removes the exclusion and runs prettier on the .github dir.