### PR TITLE
fix: add fallback tier visuals

### DIFF
--- a/src/features/rnbw-membership/components/TierBadge.tsx
+++ b/src/features/rnbw-membership/components/TierBadge.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { Text, useColorMode } from '@/design-system';
-import { TIER_VISUALS } from '@/features/rnbw-membership/constants';
+import { getTierVisuals } from '@/features/rnbw-membership/constants';
 import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -30,7 +30,7 @@ export const TierBadge = memo(function TierBadge({
   weight?: TextWeight;
 }) {
   const { colorMode } = useColorMode();
-  const { badgeGradient, badgeTextGradient, badgeTextShadow, badgeShadow, badgeBorderGradient } = TIER_VISUALS[tier.level];
+  const { badgeGradient, badgeTextGradient, badgeTextShadow, badgeShadow, badgeBorderGradient } = getTierVisuals(tier.level);
   const {
     colors: badgeGradientColors,
     locations: badgeGradientLocations,

--- a/src/features/rnbw-membership/components/TierProgressBar.tsx
+++ b/src/features/rnbw-membership/components/TierProgressBar.tsx
@@ -4,7 +4,7 @@ import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
 import { useBackgroundColor, useColorMode } from '@/design-system';
 import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
 import { opacity } from '@/framework/ui/utils/opacity';
-import { TIER_VISUALS } from '@/features/rnbw-membership/constants';
+import { getTierVisuals } from '@/features/rnbw-membership/constants';
 import { getValueForColorMode } from '@/design-system/color/palettes';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Blur, Canvas, LinearGradient as SkiaLinearGradient, RoundedRect, vec } from '@shopify/react-native-skia';
@@ -40,7 +40,7 @@ export const TierProgressBar = memo(function TierProgressBar({
   const isMaxTier = tierIndex === tierCount - 1;
 
   const { gradient, borderGradient, shadow, highlightGradient } = useMemo(() => {
-    const visuals = TIER_VISUALS[tier.level];
+    const visuals = getTierVisuals(tier.level);
     return {
       gradient: getValueForColorMode(visuals.progressBarGradient, colorMode),
       borderGradient: getValueForColorMode(visuals.progressBarBorderGradient, colorMode),

--- a/src/features/rnbw-membership/components/TierThemedLabel.tsx
+++ b/src/features/rnbw-membership/components/TierThemedLabel.tsx
@@ -1,7 +1,7 @@
 import type { Tier } from '@/features/rnbw-membership/types';
 import { memo } from 'react';
 import { useColorMode, type TextProps } from '@/design-system';
-import { TIER_VISUALS } from '@/features/rnbw-membership/constants';
+import { getTierVisuals } from '@/features/rnbw-membership/constants';
 import GradientText from '@/components/text/GradientText';
 import { getValueForColorMode } from '@/design-system/color/palettes';
 
@@ -13,7 +13,7 @@ export const TierThemedLabel = memo(function TierThemedLabel({ tier, children }:
 
   if (isDarkMode) return children;
 
-  const { textGradient } = TIER_VISUALS[tier.level];
+  const { textGradient } = getTierVisuals(tier.level);
   const {
     colors: textGradientColors,
     locations: textGradientLocations,

--- a/src/features/rnbw-membership/constants.ts
+++ b/src/features/rnbw-membership/constants.ts
@@ -201,6 +201,15 @@ export const TIER_VISUALS: Record<TierId, TierVisuals> = {
   },
 };
 
+const UNKNOWN_TIER_VISUALS = TIER_VISUALS.STAKING_TIER_LEVEL_BASIC;
+
+export function getTierVisuals(level: string): TierVisuals {
+  if (level in TIER_VISUALS) {
+    return TIER_VISUALS[level as TierId];
+  }
+  return UNKNOWN_TIER_VISUALS;
+}
+
 export const FALLBACK_TIERS: Tier[] = [
   {
     level: 'STAKING_TIER_LEVEL_BASIC',

--- a/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet.tsx
@@ -13,7 +13,7 @@ import { formatNumber } from '@/helpers/strings';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { TierThemedLabel } from '../../components/TierThemedLabel';
 import { TierBadge } from '../../components/TierBadge';
-import { TIER_VISUALS } from '../../constants';
+import { getTierVisuals } from '../../constants';
 import { LinearGradient, type LinearGradientProps } from 'expo-linear-gradient';
 import { getValueForColorMode } from '@/design-system/color/palettes';
 import { TierProgressBar } from '@/features/rnbw-membership/components/TierProgressBar';
@@ -35,7 +35,7 @@ export const RnbwMembershipTiersSheet = memo(function RnbwMembershipTiersSheet()
         {allTiers.map((tier, index) => (
           <TierGradientLayer
             key={tier.level}
-            colors={getValueForColorMode(TIER_VISUALS[tier.level].backgroundGradient, colorMode).colors}
+            colors={getValueForColorMode(getTierVisuals(tier.level).backgroundGradient, colorMode).colors}
             index={index}
             pageIndex={currentPageIndex}
           />


### PR DESCRIPTION
## Changes

Adds fallback visuals for unknown tier ids. The tier visuals are defined in the app but the tiers themselves are backend driven. Prior to these changes if backend added a new tier, the app would crash when trying to display the `TierBadge` or `RnbwMembershipTiersSheet`

