### PR TITLE
chore: upgrade prettier v3.2.5 -> v3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -353,7 +353,7 @@
     "madge": "8.0.0",
     "metro-plugin-anisotropic-transform": "https://github.com/rainbow-me/metro-plugin-anisotropic-transform#593b1299f4fec3ddd3f8ad92d381e3d9ad171b82",
     "patch-package": "8.0.0",
-    "prettier": "3.2.5",
+    "prettier": "3.8.1",
     "react-native-dotenv": "2.4.2",
     "rn-nodeify": "10.2.0",
     "rock": "0.9.2",

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -70,7 +70,7 @@ export function getColorValueForThemeWorklet<T>(
 ): T | string {
   'worklet';
   if (!values) {
-    return isDarkMode ? fallbackColors?.dark ?? ETH_COLOR_DARK : fallbackColors?.light ?? ETH_COLOR;
+    return isDarkMode ? (fallbackColors?.dark ?? ETH_COLOR_DARK) : (fallbackColors?.light ?? ETH_COLOR);
   }
   return isDarkMode ? values.dark : values.light;
 }

--- a/src/components/DappBrowser/control-panel/ControlPanel.tsx
+++ b/src/components/DappBrowser/control-panel/ControlPanel.tsx
@@ -827,7 +827,7 @@ const ListEmojiAvatar = memo(function ListEmojiAvatar({
     typeof color === 'number'
       ? // sometimes the color is gonna be missing so we fallback to white
         // otherwise there will be only shadows without the the placeholder "circle"
-        colors.avatarBackgrounds[color] ?? fillTertiary
+        (colors.avatarBackgrounds[color] ?? fillTertiary)
       : color;
 
   return (

--- a/src/components/DappBrowser/search/results/SearchResult.tsx
+++ b/src/components/DappBrowser/search/results/SearchResult.tsx
@@ -19,7 +19,7 @@ export const SearchResult = ({ index, goToUrl }: { index: number; goToUrl: (url:
   const { width: deviceWidth } = useDimensions();
 
   const dapp = useDerivedValue(() => (_WORKLET ? searchResults?.value[index] : null));
-  const iconUrl = useDerivedValue(() => (_WORKLET ? dapp.value?.iconUrl ?? dapp.value?.name : undefined));
+  const iconUrl = useDerivedValue(() => (_WORKLET ? (dapp.value?.iconUrl ?? dapp.value?.name) : undefined));
   const name = useDerivedValue(() => (_WORKLET ? dapp.value?.name : undefined));
   const urlDisplay = useDerivedValue(() => (_WORKLET ? dapp.value?.urlDisplay : undefined));
 

--- a/src/components/SmoothPager/ListPanel.tsx
+++ b/src/components/SmoothPager/ListPanel.tsx
@@ -282,7 +282,7 @@ export const ListEmojiAvatar = React.memo(function ListEmojiAvatar({
     typeof color === 'number'
       ? // sometimes the color is gonna be missing so we fallback to white
         // otherwise there will be only shadows without the the placeholder "circle"
-        colors.avatarBackgrounds[color] ?? fillTertiary
+        (colors.avatarBackgrounds[color] ?? fillTertiary)
       : color;
 
   return (

--- a/src/components/SmoothPager/SmoothPager.tsx
+++ b/src/components/SmoothPager/SmoothPager.tsx
@@ -291,7 +291,7 @@ const SmoothPagerComponent = (
         const dragPages = dragDistance / (DEVICE_WIDTH + pageGap);
         let newPageIndex = (startPage.value ?? 0) - dragPages;
 
-        const minIndex = enableSwipeToGoBack ? 0 : startPage.value ?? 0;
+        const minIndex = enableSwipeToGoBack ? 0 : (startPage.value ?? 0);
         const maxIndex = maxForwardIndex.value ?? numberOfPages - 1;
 
         newPageIndex = clamp(newPageIndex, minIndex, maxIndex);

--- a/src/components/animations/ButtonPressAnimation/types.ts
+++ b/src/components/animations/ButtonPressAnimation/types.ts
@@ -5,8 +5,7 @@ export type TransformOrigin = [number, number];
 export type Direction = 'bottom' | 'left' | 'right' | 'top';
 
 export interface ButtonPressAnimationProps
-  extends Pick<PressableProps, 'disabled' | 'hitSlop' | 'onLayout' | 'testID'>,
-    Pick<ViewProps, 'style'> {
+  extends Pick<PressableProps, 'disabled' | 'hitSlop' | 'onLayout' | 'testID'>, Pick<ViewProps, 'style'> {
   children?: React.ReactNode;
   onPress?: ((event?: GestureResponderEvent) => void) | null | undefined;
   onLongPress?: ((event?: GestureResponderEvent) => void) | null;

--- a/src/components/avatar-builder/EmojiSelector.tsx
+++ b/src/components/avatar-builder/EmojiSelector.tsx
@@ -119,7 +119,7 @@ export const EmojiSelector = ({ columns = 7, showSectionTitles = true, showTabs 
 
     const nextSection = allEmojiList[(currentIndex.current + 1) * 2] as AllEmojiContentEntry;
 
-    const offsetY = category.index * 2 - 1 > 0 ? (allEmojiList[category.index * 2] as AllEmojiContentEntry).offset ?? 0 : 0;
+    const offsetY = category.index * 2 - 1 > 0 ? ((allEmojiList[category.index * 2] as AllEmojiContentEntry).offset ?? 0) : 0;
 
     scrollToOffset(offsetY, true);
     currentIndex.current = category.index;

--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -139,8 +139,8 @@ function HoldToAuthorizeButtonContent2({
   const isAuthorizing = isAuthorizingProp || isAuthorizingState;
 
   const bgColor = disabled
-    ? disabledBackgroundColor ?? getButtonDisabledBgColor(themeColors)[theme]
-    : backgroundColor ?? themeColors.appleBlue;
+    ? (disabledBackgroundColor ?? getButtonDisabledBgColor(themeColors)[theme])
+    : (backgroundColor ?? themeColors.appleBlue);
 
   const height = tinyButton ? TINY_BUTTON_HEIGHT : smallButton ? SMALL_BUTTON_HEIGHT : BUTTON_HEIGHT;
 

--- a/src/components/contacts/ContactAvatar.js
+++ b/src/components/contacts/ContactAvatar.js
@@ -114,7 +114,7 @@ const ContactAvatar = ({ color, size = 'medium', value, ...props }) => {
     typeof color === 'number'
       ? // sometimes the color is gonna be missing so we fallback to white
         // otherwise there will be only shadows without the the placeholder "circle"
-        colors.avatarBackgrounds[color] ?? colors.white
+        (colors.avatarBackgrounds[color] ?? colors.white)
       : color;
 
   return (

--- a/src/components/floating-emojis/FloatingEmoji.tsx
+++ b/src/components/floating-emojis/FloatingEmoji.tsx
@@ -93,7 +93,7 @@ const FloatingEmoji: React.FC<FloatingEmojiProps> = ({
           left,
           marginTop,
           position: 'absolute',
-          top: centerVertically ? undefined : top ?? size * -0.5,
+          top: centerVertically ? undefined : (top ?? size * -0.5),
         },
         animatedStyle,
       ]}

--- a/src/components/layout/InnerBorder.js
+++ b/src/components/layout/InnerBorder.js
@@ -8,7 +8,7 @@ const InnerBorder = styled.View.withConfig({
   borderColor: color ?? colors.black,
   borderRadius: radius ?? 0,
   borderWidth: width ?? 0.5,
-  opacity: isDarkMode ? 0 : opacity ?? 0.06,
+  opacity: isDarkMode ? 0 : (opacity ?? 0.06),
 }));
 
 export default InnerBorder;

--- a/src/components/toasts/Toast.tsx
+++ b/src/components/toasts/Toast.tsx
@@ -72,7 +72,7 @@ function Toast({ children, color, distance = 90, targetTranslate = 0, icon, isVi
     };
   });
 
-  const currentColor = color ?? isDarkMode ? colors.darkModeDark : colors.dark;
+  const currentColor = (color ?? isDarkMode) ? colors.darkModeDark : colors.dark;
 
   return (
     <Animated.View pointerEvents="none" style={animatedStyle}>

--- a/src/design-system/color/useForegroundColor.ts
+++ b/src/design-system/color/useForegroundColor.ts
@@ -41,7 +41,7 @@ export function useForegroundColors(
       const colorForColorMode = getValueForColorMode(color, colorMode);
 
       return colorForColorMode === 'accent'
-        ? accentColor?.color ?? getDefaultAccentColorForColorMode(colorMode).color
+        ? (accentColor?.color ?? getDefaultAccentColorForColorMode(colorMode).color)
         : foregroundColors[colorForColorMode];
     }
 

--- a/src/design-system/components/Box/Box.tsx
+++ b/src/design-system/components/Box/Box.tsx
@@ -291,7 +291,7 @@ export const Box = forwardRef(function Box(
 
   const styleHasBackgroundColor = !!(styleProp && 'backgroundColor' in styleProp && styleProp.backgroundColor !== 'transparent');
   const backgroundToUse =
-    styleHasBackgroundColor && typeof styleProp.backgroundColor === 'string' ? styleProp.backgroundColor : background ?? backgroundColor;
+    styleHasBackgroundColor && typeof styleProp.backgroundColor === 'string' ? styleProp.backgroundColor : (background ?? backgroundColor);
 
   return backgroundToUse ? (
     <BackgroundProvider color={backgroundToUse} style={style}>

--- a/src/design-system/components/SkiaText/useSkiaText.ts
+++ b/src/design-system/components/SkiaText/useSkiaText.ts
@@ -122,7 +122,7 @@ export function useSkiaText({
           segmentStyle.color = Skia.Color(opacity(segment.color, segment.opacity));
         }
         paragraphBuilder.pushStyle(segmentStyle, segment.foregroundPaint ?? foregroundPaint, segment.backgroundPaint ?? backgroundPaint);
-        paragraphBuilder.addText(typeof segment.text === 'string' ? segment.text : segment.text.value ?? '');
+        paragraphBuilder.addText(typeof segment.text === 'string' ? segment.text : (segment.text.value ?? ''));
         paragraphBuilder.pop();
       };
 
@@ -201,8 +201,8 @@ function getTextStyle({
       ? typeof colorOverride === 'string'
         ? Skia.Color(colorOverride)
         : colorOverride
-      : (defaultColor && 'value' in defaultColor ? defaultColor.value : defaultColor) ??
-        Skia.Color(typeof color === 'string' ? color : color.value),
+      : ((defaultColor && 'value' in defaultColor ? defaultColor.value : defaultColor) ??
+        Skia.Color(typeof color === 'string' ? color : color.value)),
     fontFamilies: IS_IOS ? SF_PRO_ROUNDED_IOS : [`SFProRounded-${weightOverride ?? weight}`],
     fontSize: fontInfo.fontSize,
     fontStyle: IS_IOS ? { weight: getSkiaFontWeight(weightOverride ?? weight) } : EMPTY_FONT_STYLE,

--- a/src/features/charts/polymarket/classes/PolymarketChartManager.ts
+++ b/src/features/charts/polymarket/classes/PolymarketChartManager.ts
@@ -563,8 +563,8 @@ export class PolymarketChartManager {
     const seriesData: SeriesDataInput[] = series.map((s, i) => ({
       // Allow config palette to override incoming series colors when requested
       color: overrideSeriesColors
-        ? colors?.[i] ?? s.color ?? SERIES_COLORS[i % SERIES_COLORS.length]
-        : s.color ?? colors?.[i] ?? SERIES_COLORS[i % SERIES_COLORS.length],
+        ? (colors?.[i] ?? s.color ?? SERIES_COLORS[i % SERIES_COLORS.length])
+        : (s.color ?? colors?.[i] ?? SERIES_COLORS[i % SERIES_COLORS.length]),
       key: s.tokenId,
       label: s.label,
       prices: s.prices,

--- a/src/features/positions/stores/WISHLIST.md
+++ b/src/features/positions/stores/WISHLIST.md
@@ -213,12 +213,10 @@ const changed_at = changedAtStr ? token.asset.price.changedAt.getTime() : undefi
 ### Changes Made
 
 1. **`Position.protocolVersion: string`** → **`protocolVersion?: string`**
-
    - API omits this field for some protocols in the response
    - Example: Many positions in fixture have no `protocolVersion` property
 
 2. **`Detail` token lists** → all made optional
-
    - `supplyTokenList?: PositionToken[]`
    - `rewardTokenList?: PositionToken[]`
    - `borrowTokenList?: PositionToken[]`
@@ -227,34 +225,27 @@ const changed_at = changedAtStr ? token.asset.price.changedAt.getTime() : undefi
    - Example: Liquidity pool positions only have `supplyTokenList`, omit the others
 
 3. **`PortfolioItem.assetDict`** → **`Partial<Record<string, string>>`**
-
    - Was: `{ [key: string]: string }`
    - TypeScript's JSON import creates unions with `undefined` across heterogeneous objects
    - Example: Position A has `{"0xabc": "10"}`, Position B has `{"0xdef": "20"}` → TS infers both keys as optional on both objects
 
 4. **`ListPositionsResponse.errors: string[]`** → **`errors?: string[]`**
-
    - Success responses omit this field entirely instead of returning `[]`
 
 5. **`ListPositionsResponse_Result.uniqueTokens: string[]`** → **`uniqueTokens?: string[]`**
-
    - Empty position responses omit this field
 
 6. **`ListPositionsResponse_Result.stats`** → **`stats?: EnhancedStats`**
-
    - Empty position responses omit this field
 
 7. **`Asset.mainnetAddress: string`** → **`mainnetAddress?: string`**
-
    - Backend doesn't populate this field yet for any assets
    - Likely intended for L2→L1 token mapping
 
 8. **`AssetBridging.bridgeable: boolean`** → **`bridgeable?: boolean`**
-
    - API sends `bridging: {}` for assets without bridging support
 
 9. **`AssetBridging.networks`** → **`networks?: { [key: string]: AssetBridgeNetworkInfo }`**
-
    - API sends `bridging: {}` for assets without bridging support
 
 10. **`DApp_Colors.shadow: string`** → **`shadow?: string`**

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/ActionStatusScene.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/ActionStatusScene.tsx
@@ -45,7 +45,7 @@ export function ActionStatusScene<T>({ labels, task, onComplete }: ActionStatusS
     return () => clearInterval(interval);
   }, [labelIndex, allLabelsDisplayedAndTaskCompleted, onComplete, task.status, labels.length]);
 
-  const currentLabel = isExiting ? EMPTY_LABEL : labels[labelIndex] ?? fallbackLabel;
+  const currentLabel = isExiting ? EMPTY_LABEL : (labels[labelIndex] ?? fallbackLabel);
 
   return (
     <Animated.View key={currentLabel} entering={enteringAnimation} exiting={exitingAnimation}>

--- a/src/hooks/useCollectible.ts
+++ b/src/hooks/useCollectible.ts
@@ -6,7 +6,7 @@ export default function useCollectible(uniqueId: string, externalAddress?: strin
   const accountAddress = useAccountAddress();
 
   const isExternal = Boolean(externalAddress);
-  const address = isExternal ? externalAddress ?? '' : accountAddress;
+  const address = isExternal ? (externalAddress ?? '') : accountAddress;
 
   const { data: asset } = useLegacyNFTs({
     address,

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -225,7 +225,7 @@ export class Logger {
     level?: LogLevel;
     debug?: string;
   } = {}) {
-    this.level = debug ? LogLevel.Debug : level ?? LogLevel.Warn;
+    this.level = debug ? LogLevel.Debug : (level ?? LogLevel.Warn);
     this.debugContextRegexes = (debug || '').split(',').map(context => {
       return new RegExp(context.replace(/[^\w:*]/, '').replace(/\*/g, '.*'));
     });

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -15,8 +15,10 @@ import * as i18n from '@/languages';
 
 const REMOTE_CONFIG_VERSION = digitsOnly(CURRENT_APP_VERSION);
 
-export interface RainbowConfig
-  extends Record<string, string | boolean | number | Record<string, number> | number[] | { title: string; subtitle: string }> {
+export interface RainbowConfig extends Record<
+  string,
+  string | boolean | number | Record<string, number> | number[] | { title: string; subtitle: string }
+> {
   /* Objects */
   default_slippage_bips: Record<string, number>;
   default_slippage_bips_chainId: Record<string, number>;

--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -88,7 +88,7 @@ export const parseTransaction = (transaction: Transaction, nativeCurrency: Nativ
 
   const asset: RainbowTransaction['asset'] = meta?.asset?.assetCode
     ? parseGoldskyAsset({ asset: meta.asset, address: meta.asset.assetCode })
-    : getAssetFromChanges(changes, type) ?? fallbackMetaAsset;
+    : (getAssetFromChanges(changes, type) ?? fallbackMetaAsset);
 
   const direction = txn.direction || getDirection(type);
 

--- a/src/react-native-animated-charts/README.md
+++ b/src/react-native-animated-charts/README.md
@@ -190,7 +190,6 @@ Generator accepts object of parameters as an argument:
 - `includeExtremes`. If it's vital to include extremes in the output, set to true. However, the data might not be fully equidistant.
 - `removePointsSurroundingExtremes`. Makes sense only if `includeExtremes` set to `true`. When disabled, it might be possible that extremes look very "pointy". To get rid of this, you can remove points surrounding extremes.
   E.g.
-
   - `removePointsSurroundingExtremes = false`
 
     `o---------o----Min--o---------o---------o---------o---------o`

--- a/src/resources/nfts/index.ts
+++ b/src/resources/nfts/index.ts
@@ -67,7 +67,7 @@ export const useLegacyNFTs = function useLegacyNFTs<TSelected = NFTData>({
   });
 
   return {
-    data: (config?.select ? data ?? config.select(FALLBACK_DATA) : data ?? FALLBACK_DATA) as TSelected,
+    data: (config?.select ? (data ?? config.select(FALLBACK_DATA)) : (data ?? FALLBACK_DATA)) as TSelected,
     error,
     isLoading,
     isInitialLoading,

--- a/src/screens/Diagnostics/DiagnosticsContent.tsx
+++ b/src/screens/Diagnostics/DiagnosticsContent.tsx
@@ -140,12 +140,20 @@ export function DiagnosticsContent({
       )}
       {pkeys?.length !== undefined && pkeys.length > 0 && (
         <Fragment>
-          <Column>{pkeys?.map(key => <DiagnosticsItemRow data={key} key={`row_${key.username}`} />)}</Column>
+          <Column>
+            {pkeys?.map(key => (
+              <DiagnosticsItemRow data={key} key={`row_${key.username}`} />
+            ))}
+          </Column>
         </Fragment>
       )}
       {keys?.length !== undefined && keys.length > 0 && (
         <Fragment>
-          <Column>{oldSeed?.map(key => <DiagnosticsItemRow data={key} key={`row_${key.username}`} />)}</Column>
+          <Column>
+            {oldSeed?.map(key => (
+              <DiagnosticsItemRow data={key} key={`row_${key.username}`} />
+            ))}
+          </Column>
         </Fragment>
       )}
       {keys && (

--- a/src/screens/SendSheet.tsx
+++ b/src/screens/SendSheet.tsx
@@ -233,7 +233,7 @@ export default function SendSheet() {
       const _assetAmount = newAssetAmount.replace(/[^0-9.]/g, '');
       let _nativeAmount = '';
       if (_assetAmount.length) {
-        const priceUnit = !isUniqueAsset ? selected?.price?.value ?? 0 : selected?.floorPrice ?? 0;
+        const priceUnit = !isUniqueAsset ? (selected?.price?.value ?? 0) : (selected?.floorPrice ?? 0);
         const { amount: convertedNativeAmount } = convertAmountAndPriceToNativeDisplay(_assetAmount, priceUnit, nativeCurrency);
         _nativeAmount = formatInputDecimals(convertedNativeAmount, _assetAmount);
       }
@@ -346,7 +346,7 @@ export default function SendSheet() {
       const _nativeAmount = newNativeAmount.replace(/[^0-9.]/g, '');
       let _assetAmount = '';
       if (_nativeAmount.length) {
-        const priceUnit = !isUniqueAsset ? selected?.price?.value ?? 0 : 0;
+        const priceUnit = !isUniqueAsset ? (selected?.price?.value ?? 0) : 0;
         const decimals = !isUniqueAsset ? (typeof selected?.decimals === 'number' ? selected.decimals : 18) : 0;
         const convertedAssetAmount = convertAmountFromNativeValue(_nativeAmount, priceUnit, decimals);
         _assetAmount = formatInputDecimals(convertedAssetAmount, _nativeAmount);

--- a/src/screens/change-wallet/components/AddressAvatar.tsx
+++ b/src/screens/change-wallet/components/AddressAvatar.tsx
@@ -31,7 +31,7 @@ function AddressEmojiAvatar({
     typeof color === 'number'
       ? // sometimes the color is gonna be missing so we fallback to white
         // otherwise there will be only shadows without the the placeholder "circle"
-        colors.avatarBackgrounds[color] ?? fillTertiary
+        (colors.avatarBackgrounds[color] ?? fillTertiary)
       : color;
 
   const textSize = useMemo(() => {

--- a/src/screens/expandedAssetSheet/components/sections/BalanceSection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/BalanceSection.tsx
@@ -49,7 +49,7 @@ export function BalanceSection() {
 
   const tokenBalanceData = useDerivedValue(() => {
     const priceToUse =
-      chartType === ChartType.Candlestick ? currentCandlestickPrice.value?.price ?? liveTokenPrice.value : liveTokenPrice.value;
+      chartType === ChartType.Candlestick ? (currentCandlestickPrice.value?.price ?? liveTokenPrice.value) : liveTokenPrice.value;
 
     if (!priceToUse) {
       return { displayValue: liveTokenPrice.value, isCapped: false, uncappedValue: liveTokenPrice.value };

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -20,7 +20,7 @@ function getOrCreateStore(address?: Address | string): UserAssetsStoreType {
    * accountAddress. It's needed to ensure there's an address available immediately upon app
    * launch, which currently is not the case — the initial Redux address is an empty string.
    */
-  const accountAddress = rawAddress?.length ? rawAddress : cachedAddress ?? rawAddress;
+  const accountAddress = rawAddress?.length ? rawAddress : (cachedAddress ?? rawAddress);
 
   if (cachedStore && cachedAddress === accountAddress) return cachedStore;
 

--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -208,7 +208,7 @@ export function createQueryStore<
   const persistConfig =
     typeof creatorOrPersistConfig === 'object' && 'storageKey' in creatorOrPersistConfig ? creatorOrPersistConfig : maybePersistConfig;
 
-  let staleTime = typeof config.staleTime === 'function' ? time.minutes(2) : config.staleTime ?? time.minutes(2);
+  let staleTime = typeof config.staleTime === 'function' ? time.minutes(2) : (config.staleTime ?? time.minutes(2));
 
   const {
     fetcher,
@@ -773,7 +773,7 @@ export function createQueryStore<
         const cacheEntry = get().queryCache[currentQueryKey];
         if (keepPreviousData) return cacheEntry?.data ?? null;
         const isExpired = !!cacheEntry?.lastFetchedAt && Date.now() - cacheEntry.lastFetchedAt >= cacheEntry.cacheTime;
-        return isExpired ? null : cacheEntry?.data ?? null;
+        return isExpired ? null : (cacheEntry?.data ?? null);
       },
 
       getStatus,

--- a/src/state/nfts/nfts.ts
+++ b/src/state/nfts/nfts.ts
@@ -15,7 +15,7 @@ function getOrCreateStore(address?: Address | string): NftsStoreType {
    * Fallback to ensure an address is always available on app launch, mirroring
    * the behavior in the user assets store.
    */
-  const accountAddress = rawAddress?.length ? rawAddress : cachedAddress ?? rawAddress;
+  const accountAddress = rawAddress?.length ? rawAddress : (cachedAddress ?? rawAddress);
 
   if (cachedStore && cachedAddress === accountAddress) return cachedStore;
 

--- a/src/state/nfts/openCollectionsStore.ts
+++ b/src/state/nfts/openCollectionsStore.ts
@@ -18,7 +18,7 @@ function getOrCreateStore(address?: Address | string): OpenCollectionsStoreType 
    * Fallback to ensure an address is always available on app launch, mirroring
    * the behavior in the user assets store.
    */
-  const accountAddress = rawAddress?.length ? rawAddress : cachedAddress ?? rawAddress;
+  const accountAddress = rawAddress?.length ? rawAddress : (cachedAddress ?? rawAddress);
 
   if (cachedStore && cachedAddress === accountAddress) return cachedStore;
 

--- a/src/state/nfts/utils.ts
+++ b/src/state/nfts/utils.ts
@@ -99,8 +99,8 @@ export function getShowcaseAndHiddenTokenIds(address: Address | string, category
   if (category) {
     const tokens =
       category === 'showcase'
-        ? queryClient.getQueryData<string[]>(showcaseTokensQueryKey({ address })) ?? []
-        : queryClient.getQueryData<string[]>(hiddenTokensQueryKey({ address })) ?? [];
+        ? (queryClient.getQueryData<string[]>(showcaseTokensQueryKey({ address })) ?? [])
+        : (queryClient.getQueryData<string[]>(hiddenTokensQueryKey({ address })) ?? []);
 
     return new Set(tokens);
   }

--- a/src/styles/buildTextStyles.js
+++ b/src/styles/buildTextStyles.js
@@ -85,7 +85,7 @@ const buildTextStyles = css`
   }}
 
   /* Font Size */
-  font-size:  ${({ size = 'medium' }) => (typeof size === 'number' ? size : fonts?.size?.[size] ?? size)};
+  font-size:  ${({ size = 'medium' }) => (typeof size === 'number' ? size : (fonts?.size?.[size] ?? size))};
 
   /* Font Weight */
   ${({ isEmoji, weight = 'regular' }) => (isEmoji || isNil(weight) || android ? '' : `font-weight: ${fonts?.weight?.[weight] ?? weight};`)}
@@ -130,7 +130,7 @@ buildTextStyles.object = ({
 }) => {
   const styles = {
     color: colors.get(color, theme.colors) || theme.colors.dark,
-    fontSize: typeof size === 'number' ? size : fonts.size[size] ?? size,
+    fontSize: typeof size === 'number' ? size : (fonts.size[size] ?? size),
   };
 
   if (!isEmoji) {

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -343,7 +343,7 @@ const getColorForString = (colorString = '', providedThemeColors = colors) => {
   return isValidColorString
     ? colorString
     : // @ts-expect-error Used in JS code to safely retrieve a color
-      providedThemeColors?.[colorString] ?? null;
+      (providedThemeColors?.[colorString] ?? null);
 };
 
 export const darkModeThemeColors = getColorsByTheme(true);

--- a/src/utils/handleNFTImages.ts
+++ b/src/utils/handleNFTImages.ts
@@ -40,18 +40,18 @@ export function handleNFTImages({
   const isGIF = mimeType === MimeType.GIF;
   const highResUrl = url?.startsWith?.(GOOGLE_USER_CONTENT_URL)
     ? url.replace(/=s\d+$/, `=s${FULL_NFT_IMAGE_SIZE}`)
-    : maybeSignUri(url, {
+    : (maybeSignUri(url, {
         // decrease size for GIFs to avoid hitting imgix's 10MB limit
         w: isGIF ? cardSize : FULL_NFT_IMAGE_SIZE,
-      }) ?? null;
+      }) ?? null);
 
   const lowResUrl =
     previewUrl?.startsWith?.(GOOGLE_USER_CONTENT_URL) && !isGIF
       ? previewUrl
-      : maybeSignUri(url, {
+      : (maybeSignUri(url, {
           w: cardSize,
           // reformat to png in the case that the image may be an SVG or is a GIF
           fm: (!previewUrl && (!mimeType || isSVG)) || isGIF ? 'png' : undefined,
-        }) ?? null;
+        }) ?? null);
   return { highResUrl, lowResUrl };
 }

--- a/src/utils/requestNavigationHandlers.ts
+++ b/src/utils/requestNavigationHandlers.ts
@@ -45,8 +45,10 @@ export enum RequestSource {
 
 // Mobile Wallet Protocol
 
-interface HandleMobileWalletProtocolRequestProps
-  extends Omit<ReturnType<typeof useMobileWalletProtocolHost>, 'message' | 'handleRequestUrl' | 'sendFailureToClient'> {
+interface HandleMobileWalletProtocolRequestProps extends Omit<
+  ReturnType<typeof useMobileWalletProtocolHost>,
+  'message' | 'handleRequestUrl' | 'sendFailureToClient'
+> {
   request: RequestMessage;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9567,7 +9567,7 @@ __metadata:
     parse-ms: "npm:2.1.0"
     patch-package: "npm:8.0.0"
     path-browserify: "npm:0.0.0"
-    prettier: "npm:3.2.5"
+    prettier: "npm:3.8.1"
     prop-types: "npm:15.8.1"
     punycode: "npm:1.4.1"
     qrcode: "npm:1.4.4"
@@ -22659,12 +22659,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.2.5":
-  version: 3.2.5
-  resolution: "prettier@npm:3.2.5"
+"prettier@npm:3.8.1":
+  version: 3.8.1
+  resolution: "prettier@npm:3.8.1"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
+  checksum: 10c0/33169b594009e48f570471271be7eac7cdcf88a209eed39ac3b8d6d78984039bfa9132f82b7e6ba3b06711f3bfe0222a62a1bfb87c43f50c25a83df1b78a2c42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While working on #7306 I noticed Prettier was still on 3.2.5 (over two years old), so this change bumps it to the current stable release.

Nearly all the formatting diffs come from a single Prettier 3.3.3 rule that wraps `??` in parentheses when it appears inside a ternary. Since `??` has lower precedence than `?:`, the parens make the already-evaluated grouping explicit. The remaining changes are minor: interface `extends` clauses with long generics reflow across lines, a couple of JSX `.map()` expressions expand to multi-line, and some markdown list spacing tightens.