### PR TITLE
chore: use webview fork directly instead of patch-package

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1977,7 +1977,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-webview (13.13.5):
+  - react-native-webview (13.16.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3447,7 +3447,7 @@ SPEC CHECKSUMS:
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
   react-native-video: 9c4c3eae02d1582907c5262f90bf8194ec1b6683
   react-native-view-shot: 44e13d0424a6b0375eae31d89e161fc1153512e5
-  react-native-webview: 1b5778b306d4ed09d13829a6e7a6550e3c1a644a
+  react-native-webview: 7c27252c8f027e2720f69eb194811c587f9a846e
   react-native-widgetkit: 9138fc58146c4f39771516ea9ef0e2d6fb20a9cd
   React-NativeModulesApple: 1ecb83880dd11baf2228f8dd89d8419c387e03ad
   React-oscompat: 0592889a9fcf0eacb205532028e4a364e22907dd

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "react-native-video": "6.19.1",
     "react-native-view-shot": "4.0.3",
     "react-native-vision-camera": "4.7.3",
-    "react-native-webview": "rainbow-me/rainbow-react-native-webview#29ed809813b8dbe03bb88a982783d2f6af09c4a8",
+    "react-native-webview": "rainbow-me/rainbow-react-native-webview#ffa216cb4542f19f42c3e5cb56743f041867c65a",
     "react-native-widgetkit": "1.0.9",
     "react-navigation-backhandler": "2.0.3",
     "react-primitives": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "react-native-video": "6.19.1",
     "react-native-view-shot": "4.0.3",
     "react-native-vision-camera": "4.7.3",
-    "react-native-webview": "rainbow-me/rainbow-react-native-webview#ff26fc0b053b07415a1e579abe7a4add1ddc8b81",
+    "react-native-webview": "rainbow-me/rainbow-react-native-webview#29ed809813b8dbe03bb88a982783d2f6af09c4a8",
     "react-native-widgetkit": "1.0.9",
     "react-navigation-backhandler": "2.0.3",
     "react-primitives": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "react-native-video": "6.19.1",
     "react-native-view-shot": "4.0.3",
     "react-native-vision-camera": "4.7.3",
-    "react-native-webview": "rainbow-me/rainbow-react-native-webview#rainbow-customizations",
+    "react-native-webview": "rainbow-me/rainbow-react-native-webview#ff26fc0b053b07415a1e579abe7a4add1ddc8b81",
     "react-native-widgetkit": "1.0.9",
     "react-navigation-backhandler": "2.0.3",
     "react-primitives": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "react-native-video": "6.19.1",
     "react-native-view-shot": "4.0.3",
     "react-native-vision-camera": "4.7.3",
-    "react-native-webview": "13.13.5",
+    "react-native-webview": "rainbow-me/rainbow-react-native-webview#rainbow-customizations",
     "react-native-widgetkit": "1.0.9",
     "react-navigation-backhandler": "2.0.3",
     "react-primitives": "0.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9784,7 +9784,7 @@ __metadata:
     react-native-video: "npm:6.19.1"
     react-native-view-shot: "npm:4.0.3"
     react-native-vision-camera: "npm:4.7.3"
-    react-native-webview: "npm:13.13.5"
+    react-native-webview: "rainbow-me/rainbow-react-native-webview#ffa216cb4542f19f42c3e5cb56743f041867c65a"
     react-native-widgetkit: "npm:1.0.9"
     react-navigation-backhandler: "npm:2.0.3"
     react-primitives: "npm:0.8.1"
@@ -23496,16 +23496,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:13.13.5":
-  version: 13.13.5
-  resolution: "react-native-webview@npm:13.13.5"
+"react-native-webview@rainbow-me/rainbow-react-native-webview#ffa216cb4542f19f42c3e5cb56743f041867c65a":
+  version: 13.16.1
+  resolution: "react-native-webview@https://github.com/rainbow-me/rainbow-react-native-webview.git#commit=ffa216cb4542f19f42c3e5cb56743f041867c65a"
   dependencies:
     escape-string-regexp: "npm:^4.0.0"
     invariant: "npm:2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/187441eac5a747acb58ae388b07611fcb13c6c8c801b7e3fc5175ea46e20cbc28db38ce777459fa4f405a3b4703e3011cd04c9218ac4a088a8a06031a8a2629c
+  checksum: 10c0/c74ec0b60f026db1c148c4fdec4734e3143e522e9393b792a1038836b3f0810aa2879d8381404616e56f303a2891d6abc8e826669836e2bdc65396002aafa105
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Switch `react-native-webview` from `13.13.5` (npm) + a 2,259-line patch applied by rainbow-scripts to our fork ([rainbow-me/rainbow-react-native-webview@ff26fc0b](https://github.com/rainbow-me/rainbow-react-native-webview/commit/ff26fc0b053b07415a1e579abe7a4add1ddc8b81)) pinned by commit SHA. This also upgrades the base from 13.13.5 to 13.16.1.

All fork customizations (sandbox mode, active state management, Web3 provider injection, permission dialogs, keyboard privacy, iOS UX improvements) are now maintained directly in the fork repo rather than as a patch-package patch in rainbow-scripts.

See [WebView Fork Analysis (Notion)](https://www.notion.so/rainbowdotme/WebView-Fork-Analysis-333b001b85b4800ca577ca8bfb562a6c) for full documentation of the fork changes.

Companion PR: https://github.com/rainbow-me/rainbow-scripts/pull/216

## What to test
- [x] Dapp browser can navigate to any website and works fine
- [x] New sandbox e2e tests pass (https://github.com/rainbow-me/rainbow/pull/7236)