### PR TITLE
ci: support running CI on external fork PRs

### DIFF
--- a/.github/actions/run-script/action.yml
+++ b/.github/actions/run-script/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         sparse-checkout: .github/scripts
         fetch-depth: 1

--- a/.github/actions/run-script/action.yml
+++ b/.github/actions/run-script/action.yml
@@ -1,0 +1,23 @@
+name: Run Script
+description: Checks out .github/scripts and runs a named export from a JS module via actions/github-script.
+
+inputs:
+  module:
+    description: JS module filename in .github/scripts/ (e.g. external-ci.js)
+    required: true
+  function:
+    description: Named export to call (e.g. postGuide)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      with:
+        sparse-checkout: .github/scripts
+        fetch-depth: 1
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      with:
+        script: |
+          const { ${{ inputs.function }} } = require('./.github/scripts/${{ inputs.module }}');
+          await ${{ inputs.function }}({ github, context, core });

--- a/.github/scripts/external-ci.js
+++ b/.github/scripts/external-ci.js
@@ -31,8 +31,18 @@ async function resetOnPush({ github, context, core }) {
   const utils = createGitHubUtils({ github, context, core });
   const prNumber = context.payload.pull_request.number;
   const newSha = context.payload.pull_request.head.sha;
+  const priorSha = context.payload.before;
 
   await utils.deleteBranch(externalBranch.for(prNumber));
+
+  // Only notify if there were approvals to invalidate, otherwise every push
+  // on an unauthorized PR generates a noisy "previous authorizations no
+  // longer apply" comment claiming a reset that never happened.
+  const priorApprovers = await getApproversForSha({ utils, prNumber, headSha: priorSha });
+  if (priorApprovers.size === 0) {
+    return;
+  }
+
   await utils.createComment(
     prNumber,
     `New commits pushed. Previous CI authorizations no longer apply. To re-authorize, review the changes and comment \`${authorizeCommand.format(newSha)}\`.`
@@ -67,12 +77,13 @@ async function handleAuthorization({ github, context, core }) {
     return;
   }
 
-  const approvalCount = await countApprovalsForSha({
-    utils,
-    prNumber,
-    headSha: pr.head.sha,
-    triggeringCommenter: commenter,
-  });
+  const approvers = await getApproversForSha({ utils, prNumber, headSha: pr.head.sha });
+  // listComments may not yet show the just-posted /authorize-ci comment due
+  // to eventual consistency. Add the triggering commenter explicitly since
+  // we already validated their command above.
+  approvers.add(commenter);
+
+  const approvalCount = approvers.size;
   const shortSha = approvedSha.substring(0, 7);
   if (approvalCount < REQUIRED_APPROVALS) {
     await utils.createComment(
@@ -123,22 +134,41 @@ async function relayStatus({ github, context, core }) {
     run_id: run.id,
   });
 
-  for (const job of jobs) {
-    const knownStatuses = ['completed', 'in_progress'];
-    const status = knownStatuses.includes(job.status) ? job.status : 'queued';
-    const conclusion = status === 'completed' ? job.conclusion || 'neutral' : undefined;
-    const title = status === 'completed' ? capitalize(conclusion) : status === 'in_progress' ? 'Running' : 'Queued';
-    const detailsUrl = job.html_url || run.html_url;
+  // workflow_run fires three times per run (requested, in_progress, completed),
+  // so each job would get up to 3 check runs without dedup. Use external_id
+  // keyed on (run.id, job.id) to upsert: a workflow re-run gets fresh check
+  // runs (new run.id), while progress updates within one run replace in place.
+  const existingChecks = await utils.listChecksForRef(headSha);
 
-    await utils.createCheckRun({
-      name: job.name,
-      headSha,
-      status,
-      conclusion,
-      detailsUrl,
-      title,
-      summary: `[View job](${detailsUrl})`,
-    });
+  // Per-job try/catch so one transient API failure (rate-limit, 5xx) doesn't
+  // skip the rest of the jobs in the run. Subsequent workflow_run events
+  // heal partial coverage via the external_id upsert above.
+  let failures = 0;
+  for (const job of jobs) {
+    try {
+      const externalId = relayCheckRun.externalIdFor(run.id, job.id);
+      const existing = existingChecks.find(c => c.external_id === externalId);
+
+      const knownStatuses = ['completed', 'in_progress'];
+      const status = knownStatuses.includes(job.status) ? job.status : 'queued';
+      const conclusion = status === 'completed' ? job.conclusion || 'neutral' : undefined;
+      const title = status === 'completed' ? capitalize(conclusion) : status === 'in_progress' ? 'Running' : 'Queued';
+      const detailsUrl = job.html_url || run.html_url;
+      const payload = { status, conclusion, detailsUrl, title, summary: `[View job](${detailsUrl})` };
+
+      if (existing) {
+        await utils.updateCheckRun({ checkRunId: existing.id, ...payload });
+      } else {
+        await utils.createCheckRun({ name: job.name, headSha, externalId, ...payload });
+      }
+    } catch (err) {
+      failures += 1;
+      utils.warn(`Failed to relay job "${job.name}" (id=${job.id}): ${err.message}`);
+    }
+  }
+
+  if (failures > 0) {
+    utils.fail(`Failed to relay ${failures} of ${jobs.length} jobs for workflow run ${run.id}`);
   }
 }
 
@@ -172,33 +202,32 @@ const externalBranch = {
   },
 };
 
+const relayCheckRun = {
+  externalIdFor(runId, jobId) {
+    return `external-ci-relay:${runId}:${jobId}`;
+  },
+};
+
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-async function countApprovalsForSha({ utils, prNumber, headSha, triggeringCommenter }) {
+async function getApproversForSha({ utils, prNumber, headSha }) {
   const comments = await utils.listComments(prNumber);
 
-  // Count unique authorized users who approved the current HEAD SHA.
+  // Collect unique authorized users who approved the given SHA.
   // Each approval pins to a specific commit via `/authorize-ci <sha>`, so
   // new commits (new SHA) automatically invalidate all previous approvals.
   const approvers = new Set();
   for (const c of comments) {
-    const sha = authorizeCommand.parseSha(c.body);
-    if (sha !== headSha) {
+    if (authorizeCommand.parseSha(c.body) !== headSha) {
       continue;
     }
     if (AUTHORIZED_LOGINS.has(c.user.login)) {
       approvers.add(c.user.login);
     }
   }
-
-  // The triggering comment may not yet be visible in the list API due to
-  // eventual consistency. Include it explicitly since we already validated it.
-  approvers.add(triggeringCommenter);
-
-  utils.info(`Found ${approvers.size}/${REQUIRED_APPROVALS} approvals for ${headSha.substring(0, 7)}`);
-  return approvers.size;
+  return approvers;
 }
 
 module.exports = { postGuide, resetOnPush, handleAuthorization, cleanup, relayStatus };

--- a/.github/scripts/external-ci.js
+++ b/.github/scripts/external-ci.js
@@ -1,0 +1,204 @@
+const { createGitHubUtils } = require('./github-utils');
+
+const REQUIRED_APPROVALS = 2;
+const AUTHORIZED_LOGINS = new Set(['olerass', 'jinchung', 'christianbaroni']);
+const AUTHORIZED_MENTIONS = [...AUTHORIZED_LOGINS].map(login => `@${login}`).join(', ');
+const BRANCH_PREFIX = 'ci/external-pr';
+
+async function postGuide({ github, context, core }) {
+  const utils = createGitHubUtils({ github, context, core });
+  const headSha = context.payload.pull_request.head.sha;
+
+  await utils.createComment(
+    context.payload.pull_request.number,
+    [
+      '**External PR: CI Authorization Required**',
+      '',
+      "CI checks don't run automatically on pull requests from forks (secrets are unavailable for security reasons).",
+      '',
+      `To trigger CI, ${REQUIRED_APPROVALS} of the authorized maintainers (${AUTHORIZED_MENTIONS}) must each comment \`${authorizeCommand.format('<sha>')}\` after reviewing the code, where \`<sha>\` is the latest commit on this PR at the time of review, e.g.:`,
+      '',
+      '```',
+      authorizeCommand.format(headSha),
+      '```',
+      '',
+      'If new commits are pushed, previous approvals no longer apply (the SHA changes).',
+    ].join('\n')
+  );
+}
+
+async function resetOnPush({ github, context, core }) {
+  const utils = createGitHubUtils({ github, context, core });
+  const prNumber = context.payload.pull_request.number;
+  const newSha = context.payload.pull_request.head.sha;
+
+  await utils.deleteBranch(externalBranch.for(prNumber));
+  await utils.createComment(
+    prNumber,
+    `New commits pushed. Previous CI authorizations no longer apply. To re-authorize, review the changes and comment \`${authorizeCommand.format(newSha)}\`.`
+  );
+}
+
+async function handleAuthorization({ github, context, core }) {
+  const utils = createGitHubUtils({ github, context, core });
+  const prNumber = context.payload.issue.number;
+  const commenter = context.payload.comment.user.login;
+
+  const pr = await utils.getPullRequest(prNumber);
+  if (!utils.isForkPR(pr)) {
+    return;
+  }
+
+  if (!AUTHORIZED_LOGINS.has(commenter)) {
+    await utils.createComment(prNumber, `@${commenter} is not authorized to approve external CI. Only authorized maintainers can do this.`);
+    return;
+  }
+
+  const approvedSha = authorizeCommand.parseSha(context.payload.comment.body);
+  if (!approvedSha) {
+    await utils.createComment(prNumber, `Invalid command. Usage: \`${authorizeCommand.format(pr.head.sha)}\``);
+    return;
+  }
+  if (pr.head.sha !== approvedSha) {
+    await utils.createComment(
+      prNumber,
+      `SHA \`${approvedSha}\` doesn't match the current PR head \`${pr.head.sha}\`. Please review the latest changes and use the current SHA.`
+    );
+    return;
+  }
+
+  const approvalCount = await countApprovalsForSha({
+    utils,
+    prNumber,
+    headSha: pr.head.sha,
+    triggeringCommenter: commenter,
+  });
+  const shortSha = approvedSha.substring(0, 7);
+  if (approvalCount < REQUIRED_APPROVALS) {
+    await utils.createComment(
+      prNumber,
+      `\`${authorizeCommand.name}\` recorded from @${commenter} for \`${shortSha}\` (${approvalCount}/${REQUIRED_APPROVALS}). One more authorized approval required.`
+    );
+    return;
+  }
+
+  const branch = externalBranch.for(prNumber);
+  await utils.createOrUpdateBranch(branch, pr.head.sha);
+  await utils.createComment(
+    prNumber,
+    `\`${authorizeCommand.name}\` recorded from @${commenter} for \`${shortSha}\` (${approvalCount}/${REQUIRED_APPROVALS}). CI triggered on internal branch \`${branch}\`.`
+  );
+}
+
+async function cleanup({ github, context, core }) {
+  const utils = createGitHubUtils({ github, context, core });
+  await utils.deleteBranch(externalBranch.for(context.payload.pull_request.number));
+}
+
+async function relayStatus({ github, context, core }) {
+  const utils = createGitHubUtils({ github, context, core });
+  const run = context.payload.workflow_run;
+  let prNumber;
+  try {
+    prNumber = externalBranch.parsePRNumber(run.head_branch);
+  } catch (e) {
+    utils.fail(e.message);
+    return;
+  }
+
+  // Use the SHA the workflow actually ran on, NOT the current PR head.
+  // If new commits were pushed while CI was running, pr.head.sha would
+  // point to untested code. workflow_run.head_sha is the tested commit.
+  const headSha = run.head_sha;
+  const event = context.payload.action;
+
+  utils.info(`Relaying ${event} for "${run.name}" to PR #${prNumber} (${headSha})`);
+
+  // Relay per-job results so check names match the required status checks
+  // on the target branch (e.g. "lint-and-unit-test", "Simulator", "Device").
+  const {
+    data: { jobs },
+  } = await github.rest.actions.listJobsForWorkflowRun({
+    ...context.repo,
+    run_id: run.id,
+  });
+
+  for (const job of jobs) {
+    const knownStatuses = ['completed', 'in_progress'];
+    const status = knownStatuses.includes(job.status) ? job.status : 'queued';
+    const conclusion = status === 'completed' ? job.conclusion || 'neutral' : undefined;
+    const title = status === 'completed' ? capitalize(conclusion) : status === 'in_progress' ? 'Running' : 'Queued';
+    const detailsUrl = job.html_url || run.html_url;
+
+    await utils.createCheckRun({
+      name: job.name,
+      headSha,
+      status,
+      conclusion,
+      detailsUrl,
+      title,
+      summary: `[View job](${detailsUrl})`,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const authorizeCommand = {
+  name: '/authorize-ci',
+  pattern: /^\/authorize-ci\s+([0-9a-f]{40})$/i,
+
+  parseSha(text) {
+    const match = text.trim().match(this.pattern);
+    return match ? match[1] : null;
+  },
+  format(sha) {
+    return `${this.name} ${sha}`;
+  },
+};
+
+const externalBranch = {
+  for(prNumber) {
+    return `${BRANCH_PREFIX}/${prNumber}`;
+  },
+  parsePRNumber(branchName) {
+    const num = parseInt(branchName.split('/').pop(), 10);
+    if (isNaN(num)) {
+      throw new Error(`Could not extract PR number from branch: ${branchName}`);
+    }
+    return num;
+  },
+};
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+async function countApprovalsForSha({ utils, prNumber, headSha, triggeringCommenter }) {
+  const comments = await utils.listComments(prNumber);
+
+  // Count unique authorized users who approved the current HEAD SHA.
+  // Each approval pins to a specific commit via `/authorize-ci <sha>`, so
+  // new commits (new SHA) automatically invalidate all previous approvals.
+  const approvers = new Set();
+  for (const c of comments) {
+    const sha = authorizeCommand.parseSha(c.body);
+    if (sha !== headSha) {
+      continue;
+    }
+    if (AUTHORIZED_LOGINS.has(c.user.login)) {
+      approvers.add(c.user.login);
+    }
+  }
+
+  // The triggering comment may not yet be visible in the list API due to
+  // eventual consistency. Include it explicitly since we already validated it.
+  approvers.add(triggeringCommenter);
+
+  utils.info(`Found ${approvers.size}/${REQUIRED_APPROVALS} approvals for ${headSha.substring(0, 7)}`);
+  return approvers.size;
+}
+
+module.exports = { postGuide, resetOnPush, handleAuthorization, cleanup, relayStatus };

--- a/.github/scripts/external-ci.test.js
+++ b/.github/scripts/external-ci.test.js
@@ -1,0 +1,297 @@
+const mockUtils = {
+  createComment: jest.fn(),
+  getPullRequest: jest.fn(),
+  listComments: jest.fn(),
+  deleteBranch: jest.fn(),
+  createOrUpdateBranch: jest.fn(),
+  createCheckRun: jest.fn(),
+  isForkPR: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  fail: jest.fn(),
+};
+
+jest.mock('./github-utils', () => ({
+  createGitHubUtils: () => mockUtils,
+}));
+
+const { handleAuthorization, relayStatus } = require('./external-ci');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('handleAuthorization', () => {
+  const github = {};
+  const core = {};
+  const HEAD_SHA = 'abc1234def5678abc1234def5678abc1234def56';
+  const OTHER_SHA = '0000000000000000000000000000000000000000';
+  const AUTHORIZE = `/authorize-ci ${HEAD_SHA}`;
+
+  const setupAuthorizationComment = ({ commentBody, commenter = 'olerass', prNumber = 1, isFork, headSha = HEAD_SHA } = {}) => {
+    mockUtils.getPullRequest.mockResolvedValue({ head: { sha: headSha } });
+    mockUtils.isForkPR.mockReturnValue(isFork);
+    mockUtils.listComments.mockResolvedValue([]);
+    return {
+      context: {
+        payload: {
+          issue: { number: prNumber },
+          comment: { body: commentBody, user: { login: commenter } },
+          repository: { full_name: 'rainbow-me/rainbow' },
+        },
+        repo: { owner: 'rainbow-me', repo: 'rainbow' },
+      },
+    };
+  };
+
+  it('posts comments to the correct PR', async () => {
+    const prNumber = 99;
+    const { context } = setupAuthorizationComment({
+      commentBody: AUTHORIZE,
+      commenter: 'olerass',
+      prNumber,
+      isFork: true,
+    });
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(prNumber, expect.any(String));
+  });
+
+  it('ignores non-fork PRs', async () => {
+    const { context } = setupAuthorizationComment({ commentBody: AUTHORIZE, isFork: false });
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthorized users', async () => {
+    const { context } = setupAuthorizationComment({
+      commentBody: AUTHORIZE,
+      commenter: 'random-user',
+      isFork: true,
+    });
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining('not authorized'));
+  });
+
+  it('rejects invalid command format', async () => {
+    const { context } = setupAuthorizationComment({ commentBody: '/authorize-ci', isFork: true });
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining('Invalid command'));
+  });
+
+  it('rejects SHA that does not match PR head', async () => {
+    const { context } = setupAuthorizationComment({
+      commentBody: `/authorize-ci ${OTHER_SHA}`,
+      isFork: true,
+      headSha: 'abc1234def5678abc1234def5678abc1234def567',
+    });
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining("doesn't match"));
+  });
+
+  it('posts waiting status when only 1 of 2 approvals', async () => {
+    const { context } = setupAuthorizationComment({ commentBody: AUTHORIZE, isFork: true });
+    mockUtils.listComments.mockResolvedValue([]);
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining('1/2'));
+    expect(mockUtils.createOrUpdateBranch).not.toHaveBeenCalled();
+  });
+
+  it('pushes internal branch when 2 of 2 approvals met', async () => {
+    const prNumber = 77;
+    const { context } = setupAuthorizationComment({ commentBody: AUTHORIZE, isFork: true, prNumber });
+    mockUtils.listComments.mockResolvedValue([{ user: { login: 'jinchung' }, body: AUTHORIZE, created_at: '2026-01-01T00:00:00Z' }]);
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createOrUpdateBranch).toHaveBeenCalledWith(`ci/external-pr/${prNumber}`, expect.any(String));
+    expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining('CI triggered'));
+  });
+
+  it('counts same user approving twice as a single approval', async () => {
+    const { context } = setupAuthorizationComment({ commentBody: AUTHORIZE, commenter: 'olerass', isFork: true });
+    mockUtils.listComments.mockResolvedValue([
+      { user: { login: 'olerass' }, body: AUTHORIZE },
+      { user: { login: 'olerass' }, body: AUTHORIZE },
+    ]);
+
+    await handleAuthorization({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining('1/2'));
+    expect(mockUtils.createOrUpdateBranch).not.toHaveBeenCalled();
+  });
+});
+
+describe('relayStatus', () => {
+  const core = {};
+
+  const setupWorkflowRun = ({
+    headBranch = 'ci/external-pr/42',
+    headSha = 'abc1234',
+    runName = 'Unit tests',
+    runId = 100,
+    runUrl = 'https://github.com/run/100',
+    action = 'completed',
+    jobs = [],
+  } = {}) => {
+    const github = {
+      rest: {
+        actions: {
+          listJobsForWorkflowRun: jest.fn().mockResolvedValue({ data: { jobs } }),
+        },
+      },
+    };
+    const context = {
+      payload: {
+        action,
+        workflow_run: { head_branch: headBranch, head_sha: headSha, name: runName, id: runId, html_url: runUrl },
+      },
+      repo: { owner: 'rainbow-me', repo: 'rainbow' },
+    };
+    return { github, context };
+  };
+
+  it('fails if branch name is not a valid external PR branch', async () => {
+    const { github, context } = setupWorkflowRun({ headBranch: 'main' });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.fail).toHaveBeenCalledWith(expect.stringContaining('Could not extract PR number'));
+    expect(mockUtils.createCheckRun).not.toHaveBeenCalled();
+  });
+
+  it('creates no check runs when there are no jobs', async () => {
+    const { github, context } = setupWorkflowRun({ jobs: [] });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).not.toHaveBeenCalled();
+  });
+
+  it('maps unknown job status to queued', async () => {
+    const { github, context } = setupWorkflowRun({
+      jobs: [{ name: 'build', status: 'waiting', conclusion: null, html_url: 'https://github.com/job/5' }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'queued',
+        conclusion: undefined,
+        title: 'Queued',
+      })
+    );
+  });
+
+  it('creates a check run for job using the workflow_run head_sha', async () => {
+    const { github, context } = setupWorkflowRun({
+      headSha: 'deadbeef123',
+      jobs: [{ name: 'lint-and-unit-test', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'lint-and-unit-test',
+        headSha: 'deadbeef123',
+        status: 'completed',
+        conclusion: 'success',
+        title: 'Success',
+      })
+    );
+  });
+
+  it('maps in_progress jobs correctly', async () => {
+    const { github, context } = setupWorkflowRun({
+      jobs: [{ name: 'Simulator', status: 'in_progress', conclusion: null, html_url: 'https://github.com/job/2' }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'in_progress',
+        conclusion: undefined,
+        title: 'Running',
+      })
+    );
+  });
+
+  it('maps queued jobs correctly', async () => {
+    const { github, context } = setupWorkflowRun({
+      jobs: [{ name: 'Device', status: 'queued', conclusion: null, html_url: 'https://github.com/job/3' }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'queued',
+        conclusion: undefined,
+        title: 'Queued',
+      })
+    );
+  });
+
+  it('defaults conclusion to neutral when missing on completed jobs', async () => {
+    const { github, context } = setupWorkflowRun({
+      jobs: [{ name: 'lint', status: 'completed', conclusion: null, html_url: 'https://github.com/job/4' }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conclusion: 'neutral',
+        title: 'Neutral',
+      })
+    );
+  });
+
+  it('falls back to run URL when job has no html_url', async () => {
+    const runUrl = 'https://github.com/run/100';
+    const { github, context } = setupWorkflowRun({
+      runUrl,
+      jobs: [{ name: 'build', status: 'completed', conclusion: 'success', html_url: null }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detailsUrl: runUrl,
+        summary: `[View job](${runUrl})`,
+      })
+    );
+  });
+
+  it('creates check runs for multiple jobs', async () => {
+    const { github, context } = setupWorkflowRun({
+      jobs: [
+        { name: 'lint', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' },
+        { name: 'test', status: 'completed', conclusion: 'failure', html_url: 'https://github.com/job/2' },
+        { name: 'build', status: 'in_progress', conclusion: null, html_url: 'https://github.com/job/3' },
+      ],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledTimes(3);
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(expect.objectContaining({ name: 'lint', conclusion: 'success' }));
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'test', conclusion: 'failure', title: 'Failure' })
+    );
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(expect.objectContaining({ name: 'build', title: 'Running' }));
+  });
+});

--- a/.github/scripts/external-ci.test.js
+++ b/.github/scripts/external-ci.test.js
@@ -5,6 +5,8 @@ const mockUtils = {
   deleteBranch: jest.fn(),
   createOrUpdateBranch: jest.fn(),
   createCheckRun: jest.fn(),
+  updateCheckRun: jest.fn(),
+  listChecksForRef: jest.fn(),
   isForkPR: jest.fn(),
   info: jest.fn(),
   warn: jest.fn(),
@@ -15,9 +17,12 @@ jest.mock('./github-utils', () => ({
   createGitHubUtils: () => mockUtils,
 }));
 
-const { handleAuthorization, relayStatus } = require('./external-ci');
+const { handleAuthorization, relayStatus, resetOnPush } = require('./external-ci');
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockUtils.listChecksForRef.mockResolvedValue([]);
+});
 
 describe('handleAuthorization', () => {
   const github = {};
@@ -128,6 +133,88 @@ describe('handleAuthorization', () => {
 
     expect(mockUtils.createComment).toHaveBeenCalledWith(expect.any(Number), expect.stringContaining('1/2'));
     expect(mockUtils.createOrUpdateBranch).not.toHaveBeenCalled();
+  });
+});
+
+describe('resetOnPush', () => {
+  const github = {};
+  const core = {};
+  const PRIOR_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const NEW_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const PRIOR_AUTHORIZE = `/authorize-ci ${PRIOR_SHA}`;
+
+  const setupSync = ({ prNumber = 1, before = PRIOR_SHA, after = NEW_SHA } = {}) => ({
+    context: {
+      payload: {
+        pull_request: { number: prNumber, head: { sha: after } },
+        before,
+      },
+      repo: { owner: 'rainbow-me', repo: 'rainbow' },
+    },
+  });
+
+  it('always deletes the internal branch', async () => {
+    const prNumber = 42;
+    const { context } = setupSync({ prNumber });
+    mockUtils.listComments.mockResolvedValue([]);
+
+    await resetOnPush({ github, context, core });
+
+    expect(mockUtils.deleteBranch).toHaveBeenCalledWith(`ci/external-pr/${prNumber}`);
+  });
+
+  it('does NOT post the reset comment when prior SHA had 0 approvals', async () => {
+    const { context } = setupSync();
+    mockUtils.listComments.mockResolvedValue([]);
+
+    await resetOnPush({ github, context, core });
+
+    expect(mockUtils.createComment).not.toHaveBeenCalled();
+  });
+
+  it('posts the reset comment when prior SHA had a single authorized approval', async () => {
+    const prNumber = 7;
+    const { context } = setupSync({ prNumber });
+    mockUtils.listComments.mockResolvedValue([{ user: { login: 'olerass' }, body: PRIOR_AUTHORIZE }]);
+
+    await resetOnPush({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(prNumber, expect.stringContaining('Previous CI authorizations no longer apply'));
+    expect(mockUtils.createComment).toHaveBeenCalledWith(prNumber, expect.stringContaining(NEW_SHA));
+  });
+
+  it('posts the reset comment when prior SHA had multiple authorized approvals', async () => {
+    const { context } = setupSync();
+    mockUtils.listComments.mockResolvedValue([
+      { user: { login: 'olerass' }, body: PRIOR_AUTHORIZE },
+      { user: { login: 'jinchung' }, body: PRIOR_AUTHORIZE },
+    ]);
+
+    await resetOnPush({ github, context, core });
+
+    expect(mockUtils.createComment).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.stringContaining('Previous CI authorizations no longer apply')
+    );
+  });
+
+  it('does NOT count approvals from non-authorized logins', async () => {
+    const { context } = setupSync();
+    mockUtils.listComments.mockResolvedValue([{ user: { login: 'random-user' }, body: PRIOR_AUTHORIZE }]);
+
+    await resetOnPush({ github, context, core });
+
+    expect(mockUtils.createComment).not.toHaveBeenCalled();
+  });
+
+  it('does NOT count approvals for a different SHA', async () => {
+    const { context } = setupSync();
+    const OTHER_SHA = 'cccccccccccccccccccccccccccccccccccccccc';
+    mockUtils.listComments.mockResolvedValue([{ user: { login: 'olerass' }, body: `/authorize-ci ${OTHER_SHA}` }]);
+
+    await resetOnPush({ github, context, core });
+
+    expect(mockUtils.createComment).not.toHaveBeenCalled();
   });
 });
 
@@ -293,5 +380,127 @@ describe('relayStatus', () => {
       expect.objectContaining({ name: 'test', conclusion: 'failure', title: 'Failure' })
     );
     expect(mockUtils.createCheckRun).toHaveBeenCalledWith(expect.objectContaining({ name: 'build', title: 'Running' }));
+  });
+
+  it('creates a check run with a stable external_id keyed on (run.id, job.id)', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 555,
+      jobs: [{ id: 777, name: 'Simulator', status: 'in_progress', conclusion: null, html_url: 'https://github.com/job/1' }],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Simulator', externalId: 'external-ci-relay:555:777' })
+    );
+  });
+
+  it('updates an existing check run when external_id matches', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 555,
+      jobs: [{ id: 777, name: 'Simulator', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' }],
+    });
+    mockUtils.listChecksForRef.mockResolvedValue([{ id: 9001, external_id: 'external-ci-relay:555:777' }]);
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.updateCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({ checkRunId: 9001, status: 'completed', conclusion: 'success', title: 'Success' })
+    );
+    expect(mockUtils.createCheckRun).not.toHaveBeenCalled();
+  });
+
+  it('creates a fresh check run when run.id changes (workflow re-run)', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 999, // new run.id, different from the existing check run
+      jobs: [{ id: 777, name: 'Simulator', status: 'in_progress', conclusion: null, html_url: 'https://github.com/job/1' }],
+    });
+    mockUtils.listChecksForRef.mockResolvedValue([
+      { id: 9001, external_id: 'external-ci-relay:555:777' }, // from a prior run
+    ]);
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledWith(expect.objectContaining({ externalId: 'external-ci-relay:999:777' }));
+    expect(mockUtils.updateCheckRun).not.toHaveBeenCalled();
+  });
+
+  it('ignores existing check runs without a matching external_id', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 100,
+      jobs: [{ id: 200, name: 'lint', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' }],
+    });
+    mockUtils.listChecksForRef.mockResolvedValue([
+      { id: 9001, external_id: 'unrelated-tool:42' },
+      { id: 9002, external_id: null },
+      { id: 9003 },
+    ]);
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledTimes(1);
+    expect(mockUtils.updateCheckRun).not.toHaveBeenCalled();
+  });
+
+  it('continues relaying remaining jobs when one create rejects', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 100,
+      jobs: [
+        { id: 1, name: 'lint', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' },
+        { id: 2, name: 'Simulator', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/2' },
+        { id: 3, name: 'Device', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/3' },
+      ],
+    });
+    mockUtils.createCheckRun.mockImplementation(({ name }) => {
+      if (name === 'Simulator') return Promise.reject(new Error('rate limit exceeded'));
+      return Promise.resolve();
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.createCheckRun).toHaveBeenCalledTimes(3);
+    expect(mockUtils.warn).toHaveBeenCalledWith(expect.stringContaining('Simulator'));
+    expect(mockUtils.warn).toHaveBeenCalledWith(expect.stringContaining('id=2'));
+    expect(mockUtils.warn).toHaveBeenCalledWith(expect.stringContaining('rate limit exceeded'));
+    expect(mockUtils.fail).toHaveBeenCalledWith(expect.stringContaining('Failed to relay 1 of 3 jobs'));
+  });
+
+  it('continues relaying remaining jobs when one update rejects', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 100,
+      jobs: [
+        { id: 1, name: 'lint', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' },
+        { id: 2, name: 'Simulator', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/2' },
+      ],
+    });
+    mockUtils.listChecksForRef.mockResolvedValue([
+      { id: 9001, external_id: 'external-ci-relay:100:1' },
+      { id: 9002, external_id: 'external-ci-relay:100:2' },
+    ]);
+    mockUtils.updateCheckRun.mockImplementation(({ checkRunId }) => {
+      if (checkRunId === 9001) return Promise.reject(new Error('forbidden'));
+      return Promise.resolve();
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.updateCheckRun).toHaveBeenCalledTimes(2);
+    expect(mockUtils.warn).toHaveBeenCalledTimes(1);
+    expect(mockUtils.fail).toHaveBeenCalledWith(expect.stringContaining('Failed to relay 1 of 2 jobs'));
+  });
+
+  it('does not fail the workflow when every job relays successfully', async () => {
+    const { github, context } = setupWorkflowRun({
+      runId: 100,
+      jobs: [
+        { id: 1, name: 'lint', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/1' },
+        { id: 2, name: 'Simulator', status: 'completed', conclusion: 'success', html_url: 'https://github.com/job/2' },
+      ],
+    });
+
+    await relayStatus({ github, context, core });
+
+    expect(mockUtils.fail).not.toHaveBeenCalled();
+    expect(mockUtils.warn).not.toHaveBeenCalled();
   });
 });

--- a/.github/scripts/github-utils.js
+++ b/.github/scripts/github-utils.js
@@ -1,0 +1,61 @@
+function createGitHubUtils({ github, context, core }) {
+  const repo = context.repo;
+
+  return {
+    info: core.info.bind(core),
+    warn: core.warning.bind(core),
+    fail: core.setFailed.bind(core),
+
+    async createComment(prNumber, body) {
+      await github.rest.issues.createComment({ ...repo, issue_number: prNumber, body });
+    },
+
+    async getPullRequest(prNumber) {
+      const { data: pr } = await github.rest.pulls.get({ ...repo, pull_number: prNumber });
+      return pr;
+    },
+
+    async createOrUpdateBranch(branch, sha) {
+      try {
+        await github.rest.git.updateRef({ ...repo, ref: `heads/${branch}`, sha, force: true });
+      } catch {
+        await github.rest.git.createRef({ ...repo, ref: `refs/heads/${branch}`, sha });
+      }
+    },
+
+    async deleteBranch(branch) {
+      try {
+        await github.rest.git.deleteRef({ ...repo, ref: `heads/${branch}` });
+        core.info(`Deleted branch ${branch}`);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async createCheckRun({ name, headSha, status, conclusion, detailsUrl, title, summary }) {
+      await github.rest.checks.create({
+        ...repo,
+        name,
+        head_sha: headSha,
+        status,
+        ...(conclusion && { conclusion }),
+        ...(detailsUrl && { details_url: detailsUrl }),
+        output: { title, summary },
+      });
+    },
+
+    async listComments(prNumber) {
+      return github.paginate(github.rest.issues.listComments, {
+        ...repo,
+        issue_number: prNumber,
+      });
+    },
+
+    isForkPR(pr) {
+      return pr.head.repo?.full_name !== context.payload.repository.full_name;
+    },
+  };
+}
+
+module.exports = { createGitHubUtils };

--- a/.github/scripts/github-utils.js
+++ b/.github/scripts/github-utils.js
@@ -18,7 +18,10 @@ function createGitHubUtils({ github, context, core }) {
     async createOrUpdateBranch(branch, sha) {
       try {
         await github.rest.git.updateRef({ ...repo, ref: `heads/${branch}`, sha, force: true });
-      } catch {
+      } catch (err) {
+        if (err.status !== 422) {
+          throw err;
+        }
         await github.rest.git.createRef({ ...repo, ref: `refs/heads/${branch}`, sha });
       }
     },
@@ -28,20 +31,45 @@ function createGitHubUtils({ github, context, core }) {
         await github.rest.git.deleteRef({ ...repo, ref: `heads/${branch}` });
         core.info(`Deleted branch ${branch}`);
         return true;
-      } catch {
-        return false;
+      } catch (err) {
+        if (err.status === 422) {
+          return false;
+        }
+        core.warning(`Failed to delete branch ${branch}: ${err.message}`);
+        throw err;
       }
     },
 
-    async createCheckRun({ name, headSha, status, conclusion, detailsUrl, title, summary }) {
+    async createCheckRun({ name, headSha, externalId, status, conclusion, detailsUrl, title, summary }) {
       await github.rest.checks.create({
         ...repo,
         name,
         head_sha: headSha,
+        ...(externalId && { external_id: externalId }),
         status,
         ...(conclusion && { conclusion }),
         ...(detailsUrl && { details_url: detailsUrl }),
         output: { title, summary },
+      });
+    },
+
+    async updateCheckRun({ checkRunId, status, conclusion, detailsUrl, title, summary }) {
+      await github.rest.checks.update({
+        ...repo,
+        check_run_id: checkRunId,
+        status,
+        ...(conclusion && { conclusion }),
+        ...(detailsUrl && { details_url: detailsUrl }),
+        output: { title, summary },
+      });
+    },
+
+    async listChecksForRef(headSha) {
+      return github.paginate(github.rest.checks.listForRef, {
+        ...repo,
+        ref: headSha,
+        filter: 'all',
+        per_page: 100,
       });
     },
 

--- a/.github/scripts/github-utils.test.js
+++ b/.github/scripts/github-utils.test.js
@@ -1,0 +1,133 @@
+const { createGitHubUtils } = require('./github-utils');
+
+const REPO = { owner: 'rainbow-me', repo: 'rainbow' };
+
+const makeContext = () => ({
+  repo: REPO,
+  payload: { repository: { full_name: 'rainbow-me/rainbow' } },
+});
+
+const makeCore = () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  setFailed: jest.fn(),
+});
+
+const makeGithub = () => ({
+  rest: {
+    git: {
+      updateRef: jest.fn(),
+      createRef: jest.fn(),
+      deleteRef: jest.fn(),
+    },
+  },
+});
+
+class HttpError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+
+describe('createOrUpdateBranch', () => {
+  it('updates the ref when it exists', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.updateRef.mockResolvedValue();
+
+    await utils.createOrUpdateBranch('ci/external-pr/42', 'abc');
+
+    expect(github.rest.git.updateRef).toHaveBeenCalledWith({
+      ...REPO,
+      ref: 'heads/ci/external-pr/42',
+      sha: 'abc',
+      force: true,
+    });
+    expect(github.rest.git.createRef).not.toHaveBeenCalled();
+  });
+
+  it('falls back to createRef when updateRef returns 422 (ref does not exist)', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.updateRef.mockRejectedValue(new HttpError(422, 'Reference does not exist'));
+    github.rest.git.createRef.mockResolvedValue();
+
+    await utils.createOrUpdateBranch('ci/external-pr/42', 'abc');
+
+    expect(github.rest.git.createRef).toHaveBeenCalledWith({
+      ...REPO,
+      ref: 'refs/heads/ci/external-pr/42',
+      sha: 'abc',
+    });
+  });
+
+  it('re-throws on 403 (branch protection / permissions)', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.updateRef.mockRejectedValue(new HttpError(403, 'Resource not accessible by integration'));
+
+    await expect(utils.createOrUpdateBranch('ci/external-pr/42', 'abc')).rejects.toThrow('Resource not accessible by integration');
+    expect(github.rest.git.createRef).not.toHaveBeenCalled();
+  });
+
+  it('re-throws on 5xx transient failures', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.updateRef.mockRejectedValue(new HttpError(500, 'Server Error'));
+
+    await expect(utils.createOrUpdateBranch('ci/external-pr/42', 'abc')).rejects.toThrow('Server Error');
+    expect(github.rest.git.createRef).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteBranch', () => {
+  it('returns true and logs when delete succeeds', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.deleteRef.mockResolvedValue();
+
+    const result = await utils.deleteBranch('ci/external-pr/42');
+
+    expect(result).toBe(true);
+    expect(core.info).toHaveBeenCalledWith('Deleted branch ci/external-pr/42');
+  });
+
+  it('returns false on 422 (already absent — idempotent)', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.deleteRef.mockRejectedValue(new HttpError(422, 'Reference does not exist'));
+
+    const result = await utils.deleteBranch('ci/external-pr/42');
+
+    expect(result).toBe(false);
+    expect(core.warning).not.toHaveBeenCalled();
+  });
+
+  it('warns and rethrows on 403', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.deleteRef.mockRejectedValue(new HttpError(403, 'forbidden'));
+
+    await expect(utils.deleteBranch('ci/external-pr/42')).rejects.toThrow('forbidden');
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('Failed to delete branch ci/external-pr/42'));
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('forbidden'));
+  });
+
+  it('warns and rethrows on 5xx', async () => {
+    const github = makeGithub();
+    const core = makeCore();
+    const utils = createGitHubUtils({ github, context: makeContext(), core });
+    github.rest.git.deleteRef.mockRejectedValue(new HttpError(500, 'Server Error'));
+
+    await expect(utils.deleteBranch('ci/external-pr/42')).rejects.toThrow('Server Error');
+    expect(core.warning).toHaveBeenCalled();
+  });
+});

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [develop]
+    branches: [develop, ci/external-pr/**]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/authorize-ci.yml
+++ b/.github/workflows/authorize-ci.yml
@@ -1,0 +1,98 @@
+# Authorize External CI
+#
+# Allows running CI on pull requests from forks, which can't access repo
+# secrets by default. Maintainers approve by commenting `/authorize-ci <sha>`
+# on the fork PR, where <sha> is the HEAD commit they reviewed.
+#
+# How it works:
+#   1. Fork PR opened         -> bot posts a guide comment explaining the process
+#   2. Maintainers review     -> each comments `/authorize-ci <sha>`
+#   3. Required approvals met -> fork code is pushed to an internal branch
+#                                (ci/external-pr/<number>), triggering normal CI
+#   4. CI results are relayed -> relay-external-ci.yml mirrors check run status
+#                                back to the fork PR via the Checks API
+#   5. New commits pushed     -> internal branch deleted, approvals invalidated
+#   6. Maintainers re-review  -> repeat from step 2 with the new SHA
+#   7. PR closed              -> internal branch cleaned up
+#
+# Security:
+#   - Approvals are pinned to a specific SHA, so new commits can't reuse old approvals
+#   - Existing (and future) CI workflows only need a push branch trigger (no pull_request_target footgun)
+#   - Fork code runs through the exact same CI pipeline as internal code
+#
+# See .github/scripts/external-ci.js for configuration and implementation details.
+
+name: Authorize External CI
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, closed]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  post-guide:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'opened' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: ./.github/actions/run-script
+        with:
+          module: external-ci.js
+          function: postGuide
+
+  reset-on-push:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: ./.github/actions/run-script
+        with:
+          module: external-ci.js
+          function: resetOnPush
+
+  handle-authorization:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/authorize-ci')
+    concurrency:
+      group: authorize-ci-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      checks: write
+    steps:
+      - uses: ./.github/actions/run-script
+        with:
+          module: external-ci.js
+          function: handleAuthorization
+
+  cleanup:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: ./.github/actions/run-script
+        with:
+          module: external-ci.js
+          function: cleanup

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -2,6 +2,8 @@ name: iOS Builds
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [ci/external-pr/**]
   workflow_dispatch:
 
 jobs:
@@ -12,7 +14,10 @@ jobs:
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
-    if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false && github.event.pull_request.merged == false)
     concurrency:
       group: ${{ github.workflow }}-simulator-${{ github.ref }}
       cancel-in-progress: true
@@ -107,7 +112,10 @@ jobs:
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
-    if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false && github.event.pull_request.merged == false)
     concurrency:
       group: ${{ github.workflow }}-device-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [develop]
+    branches: [develop, ci/external-pr/**]
   issue_comment:
     types: [created]
 env:

--- a/.github/workflows/relay-external-ci.yml
+++ b/.github/workflows/relay-external-ci.yml
@@ -1,0 +1,22 @@
+name: Relay External CI Status
+
+on:
+  workflow_run:
+    # These must match the `name:` field of each CI workflow exactly.
+    workflows: ['Unit tests', 'iOS Builds', 'Android', 'iOS']
+    types: [requested, in_progress, completed]
+    branches: ['ci/external-pr/**']
+
+permissions: {}
+
+jobs:
+  relay:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - uses: ./.github/actions/run-script
+        with:
+          module: external-ci.js
+          function: relayStatus

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,9 @@
 name: Unit tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ci/external-pr/**]
 jobs:
   lint-and-unit-test:
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -89,4 +92,4 @@ jobs:
         run: yarn lint:ci
 
       - name: Unit tests
-        run: yarn test
+        run: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "start:clean": "yarn clean:packager && yarn start --reset-cache",
     "start:client-logs": "react-native start --client-logs",
     "test": "jest --detectOpenHandles --forceExit",
+    "test:ci": "yarn test && yarn test:ci-scripts",
+    "test:ci-scripts": "jest --watchman=false --detectOpenHandles --forceExit --roots '.github/scripts'",
     "ts-coverage": "typescript-coverage-report",
     "ts-migrate-folder": "./scripts/ts-migrate-folder.sh",
     "uninstall:android": "adb uninstall me.rainbow; true",


### PR DESCRIPTION
Fork PRs currently can't pass CI because GitHub blocks repo secrets from fork workflows. Since our CI needs SSH deploy keys to clone private deps like `rainbow-env` in the very first step, everything fails before any code runs. This has been blocking real contributions like #7185 (an Android 9 bug fix) which  has been reviewed and iterated on with the contributor for weeks.

This change adds a `/authorize-ci` flow that lets maintainers approve CI on fork PRs after code review:

1. Fork PR is opened, bot posts a guide comment explaining the process
2. Maintainers review the code
3. Two authorized maintainers (hardcoded to @olerass, @jinchung, and @christianbaroni currently) each comment `/authorize-ci <sha>`, pinning approval to the specific commit they reviewed
4. The fork's HEAD is pushed to an internal branch (`ci/external-pr/<number>`), triggering all CI workflows via their existing `push` triggers
5. A relay workflow mirrors per-job check status back to the fork PR via the Checks API, so the PR shows native checks and the merge button works
6. If new commits are pushed, approvals are automatically invalidated (the SHA changes) and maintainers must re-review

Security properties explicitely thought through in this design:
- SHA-pinned approvals prevent race conditions and ensure maintainers approved the exact code that runs
- Existing CI workflows only need a push branch pattern (no `pull_request_target`, no ref handling easy to get wrong etc)
- Future workflows fail safe: forgetting the push trigger means CI just doesn't run on fork PRs

Changes to existing CI workflows are minimal: 
* Adding `ci/external-pr/**` to push triggers (one line each)
* The `ios-builds` job conditions are updated because they previously only checked `github.event.pull_request.draft == false`, which happens to pass on push events through implicit null coercion. The new conditions explicitly handle `push` and `workflow_dispatch` events instead of relying on that "accident".

This change also establishes the pattern for how we can write more complex workflow scripts going forward. Logic lives in `.github/scripts/` as plain JS modules (full IDE support, linting, testable) rather than inline YAML `run:` blocks or shell + `gh` CLI. The `.github/actions/run-script` composite action provides a thin wrapper that handles checkout and invocation via `actions/github-script`, so workflow YAML stays declarative. Shared GitHub API helpers live in `github-utils.js` as a reusable facade. The scripts are tested via `yarn test:ci-scripts` (using `--watchman=false` since `.github` is in watchman's ignore list), and `yarn test:ci` runs both the app tests and CI script tests together. The unit-test workflow now runs `yarn test:ci` instead of `yarn test`.
  
Note:  PR-specific workflow features like install links (`ios-builds` post-builds) and perf reports (`android-e2e`) won't fire for fork PRs since CI runs as a `push` event where `github.event.pull_request` doesn't exist. Fork PRs still get full build + test results and native check status on the PR. This is an intentional tradeoff for the fail-safe property of the mirror branch approach, and can be addressed later if needed.

Closes FEPLAT-68.