### PR TITLE
chore: bump react-native-video 6.15.0 → 6.19.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1880,7 +1880,7 @@ PODS:
     - React
   - react-native-version-number (0.3.6):
     - React
-  - react-native-video (6.15.0):
+  - react-native-video (6.19.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1895,7 +1895,7 @@ PODS:
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - react-native-video/Video (= 6.15.0)
+    - react-native-video/Video (= 6.19.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1905,7 +1905,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-video/Video (6.15.0):
+  - react-native-video/Video (6.19.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3358,7 +3358,7 @@ SPEC CHECKSUMS:
   react-native-text-input-mask: b83b8b571cba4bf18fb9b7a0bb8319a14201db9e
   react-native-udp: afd81d997ff141501da6ac680667fd8319545da1
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
-  react-native-video: 6fa10431df5753a4f40ff054898a3634f7123c5e
+  react-native-video: 9c4c3eae02d1582907c5262f90bf8194ec1b6683
   react-native-view-shot: 44e13d0424a6b0375eae31d89e161fc1153512e5
   react-native-webview: 1b5778b306d4ed09d13829a6e7a6550e3c1a644a
   react-native-widgetkit: 9138fc58146c4f39771516ea9ef0e2d6fb20a9cd

--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
     "react-native-udp": "2.7.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-version-number": "0.3.6",
-    "react-native-video": "6.15.0",
+    "react-native-video": "6.19.1",
     "react-native-view-shot": "4.0.3",
     "react-native-vision-camera": "4.7.3",
     "react-native-webview": "13.13.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9627,7 +9627,7 @@ __metadata:
     react-native-udp: "npm:2.7.0"
     react-native-url-polyfill: "npm:2.0.0"
     react-native-version-number: "npm:0.3.6"
-    react-native-video: "npm:6.15.0"
+    react-native-video: "npm:6.19.1"
     react-native-view-shot: "npm:4.0.3"
     react-native-vision-camera: "npm:4.7.3"
     react-native-webview: "npm:13.13.5"
@@ -23941,13 +23941,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-video@npm:6.15.0":
-  version: 6.15.0
-  resolution: "react-native-video@npm:6.15.0"
+"react-native-video@npm:6.19.1":
+  version: 6.19.1
+  resolution: "react-native-video@npm:6.19.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/4615358dbff75745a613c1b316ce2155574d49f3d21da2c792dd4ffc8f9d6aaeeb08d07b77a031ae00293bee7095e7ccf9e5e5ee5299e167a9fce13fffb330e8
+  checksum: 10c0/0a57c490f15d0388db083c678e4feb3f9c67914ac812ec6ce3d03ca498631039d445b7113cc812a304752a9895a9b021c3148cab5573b9d03646aee0be871896
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes APP-3609

## What changed (plus any additional context for devs)
Bumps `react-native-video` from 6.15.0 to 6.19.1. This is a minor version bump that includes bug fixes and improvements. Extracted from the RN 0.81 upgrade PR #6924.

## Screen recordings / screenshots
N/A

## What to test

Manually tested by mocking a video nft since I didn't know where to find a real one.