### PR TITLE
chore: bump react-native-svg 15.11.2 → 15.15.4

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2649,7 +2649,7 @@ PODS:
     - RNSound/Core (= 0.11.2)
   - RNSound/Core (0.11.2):
     - React-Core
-  - RNSVG (15.11.2):
+  - RNSVG (15.15.4):
     - React-Core
   - RNTextSize (4.0.0-rc.1):
     - React
@@ -3421,7 +3421,7 @@ SPEC CHECKSUMS:
   RNSentry: 4ebc4a48794b704751504d654f5e1ac98f08a819
   RNShare: e374836177ff2675dbc659f2e52a59bf6060d200
   RNSound: 314cc5226453ef4a3314a196c65e8a65e5106a7b
-  RNSVG: ab84f2de7dd4f2c86d01825b8a65e0ef712fc36b
+  RNSVG: c8ba193e7bea6983ebdf544a6ee7b0f706c64559
   RNTextSize: c5e0593c898ad57ef5061464c154ab855da06047
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "react-native-share": "12.2.5",
     "react-native-sound": "0.11.2",
     "react-native-storage": "1.0.1",
-    "react-native-svg": "15.11.2",
+    "react-native-svg": "15.15.4",
     "react-native-tab-view": "3.5.2",
     "react-native-tcp": "3.3.2",
     "react-native-text-input-mask": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9616,7 +9616,7 @@ __metadata:
     react-native-share: "npm:12.2.5"
     react-native-sound: "npm:0.11.2"
     react-native-storage: "npm:1.0.1"
-    react-native-svg: "npm:15.11.2"
+    react-native-svg: "npm:15.15.4"
     react-native-tab-view: "npm:3.5.2"
     react-native-tcp: "npm:3.3.2"
     react-native-text-input-mask: "npm:2.0.0"
@@ -23809,9 +23809,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:15.11.2":
-  version: 15.11.2
-  resolution: "react-native-svg@npm:15.11.2"
+"react-native-svg@npm:15.15.4":
+  version: 15.15.4
+  resolution: "react-native-svg@npm:15.15.4"
   dependencies:
     css-select: "npm:^5.1.0"
     css-tree: "npm:^1.1.3"
@@ -23819,7 +23819,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/040f3a298db80f4a282f9616c9550d7978beebc518de523eb417106afd7f5cb1d021424ea287cedba705f0c48aa15631056c42a79c4b46edcafa34cba71aed63
+  checksum: 10c0/1fb8e3ac9d45a4db74731a006cd32f883051844f361974dff49e1a4142aa7c1a0d87e0b04fff06a1932ca53940bcfb94e45e01a845eb451d4659fbf07092629e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes APP-3611

## What changed (plus any additional context for devs)
Bumps `react-native-svg` from 15.11.2 to 15.15.4. This is a patch/minor bump with rendering fixes. Extracted from the RN 0.81 upgrade PR #6924.

## Screen recordings / screenshots
N/A

## What to test
- SVG icons render correctly throughout the app
- Token logos and network icons display properly
- Charts and graphs render without visual regressions