### PR TITLE
chore: update react-native-gesture-handler to 2.31.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2383,7 +2383,7 @@ PODS:
     - Yoga
   - RNFS (2.16.6):
     - React
-  - RNGestureHandler (2.27.2):
+  - RNGestureHandler (2.31.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3356,7 +3356,7 @@ SPEC CHECKSUMS:
   react-native-screen-corner-radius: ebd0d3258fcc894571b41d25ee3db7569d375153
   react-native-skia: 3467bce4be38029a4af437022b88a45e68f4210e
   react-native-text-input-mask: b83b8b571cba4bf18fb9b7a0bb8319a14201db9e
-  react-native-udp: afd81d997ff141501da6ac680667fd8319545da1
+  react-native-udp: 33844c2b4a0430271e46cd069a6152cc4c482095
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
   react-native-video: 6fa10431df5753a4f40ff054898a3634f7123c5e
   react-native-view-shot: 44e13d0424a6b0375eae31d89e161fc1153512e5
@@ -3408,7 +3408,7 @@ SPEC CHECKSUMS:
   RNFBRemoteConfig: d93e54405d06127f58a51c6f96780840f7f47cff
   RNFlashList: bf81b67825dd3fca7c3a0624b9c93dd129f2c903
   RNFS: 3557d4b8e51925b011e787094600d6e05dca414e
-  RNGestureHandler: 43ff77261c9f3cfcfd195aa16860bfdcfe108ef5
+  RNGestureHandler: 8da72f20ac31d42e8672301ccf2127e05c45c959
   RNInputMask: 815461ebdf396beb62cf58916c35cf6930adb991
   RNKeychain: b060a891b105741c67da179f4d88ed87960f22e7
   RNNotifee: 8768d065bf1e2f9f8f347b4bd79147431c7eacd6

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "react-native-edge-to-edge": "1.6.2",
     "react-native-fast-image": "8.5.11",
     "react-native-fs": "2.16.6",
-    "react-native-gesture-handler": "2.27.2",
+    "react-native-gesture-handler": "2.31.1",
     "react-native-get-random-values": "1.5.0",
     "react-native-haptic-feedback": "2.2.0",
     "react-native-image-colors": "2.5.1",

--- a/patches/react-native-gesture-handler+2.31.1.patch
+++ b/patches/react-native-gesture-handler+2.31.1.patch
@@ -2,33 +2,33 @@ diff --git a/node_modules/react-native-gesture-handler/android/src/main/java/com
 index d515011..813c69c 100644
 --- a/node_modules/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
 +++ b/node_modules/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
-@@ -140,7 +140,7 @@ class RNGestureHandlerButtonViewManager :
- 
+@@ -153,7 +153,7 @@ class RNGestureHandlerButtonViewManager :
+
    override fun getDelegate(): ViewManagerDelegate<ButtonViewGroup>? = mDelegate
- 
+
 -  class ButtonViewGroup(context: Context?) :
 +  open class ButtonViewGroup(context: Context?) :
      ViewGroup(context),
-     NativeViewGestureHandler.NativeViewGestureHandlerHook {
-     // Using object because of handling null representing no value set.
+     NativeViewGestureHandler.NativeViewGestureHandlerHook,
+     ReactPointerEventsView {
 diff --git a/node_modules/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm b/node_modules/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
 index 667d600..9054037 100644
 --- a/node_modules/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
 +++ b/node_modules/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
-@@ -161,7 +161,7 @@ - (void)bindToView:(UIView *)view
+@@ -161,7 +161,7 @@
    // because gesture handler system can handle cancellation of scroll recognizer when JS responder
    // is set
    UIScrollView *scrollView = [self retrieveScrollView:view];
 -  scrollView.delaysContentTouches = YES;
 +  scrollView.delaysContentTouches = NO;
  }
- 
+
  - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event
 diff --git a/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm b/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm
 index 708172f..7f1d550 100644
 --- a/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm
 +++ b/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm
-@@ -425,12 +425,28 @@ - (void)setManualActivation:(BOOL)manualActivation
+@@ -452,12 +452,28 @@
      if (_recognizer.view != nil) {
        [_recognizer.view addGestureRecognizer:_manualActivationRecognizer];
      }
@@ -45,7 +45,7 @@ index 708172f..7f1d550 100644
      _manualActivationRecognizer = nil;
    }
  }
- 
+
 +- (void)handleAppWillResignActive:(NSNotification *)notification
 +{
 +  if (_manualActivationRecognizer != nil && _manualActivationRecognizer.enabled) {
@@ -56,4 +56,4 @@ index 708172f..7f1d550 100644
 +
  - (void)bindManualActivationToView:(RNGHUIView *)view
  {
-   if (_manualActivationRecognizer != nil) {      
+   if (_manualActivationRecognizer != nil) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7961,6 +7961,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-test-renderer@npm:^19.1.0":
+  version: 19.1.0
+  resolution: "@types/react-test-renderer@npm:19.1.0"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/799654e430df10aeaf267d71507fb64ec151359ead7e3774111bfd4abce7e0911dba461811195c06c22a6d17496ea92537d3185320ff4112fe29954cad1b9152
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:19.1.3":
   version: 19.1.3
   resolution: "@types/react@npm:19.1.3"
@@ -9587,7 +9596,7 @@ __metadata:
     react-native-edge-to-edge: "npm:1.6.2"
     react-native-fast-image: "npm:8.5.11"
     react-native-fs: "npm:2.16.6"
-    react-native-gesture-handler: "npm:2.27.2"
+    react-native-gesture-handler: "npm:2.31.1"
     react-native-get-random-values: "npm:1.5.0"
     react-native-haptic-feedback: "npm:2.2.0"
     react-native-image-colors: "npm:2.5.1"
@@ -23459,17 +23468,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:2.27.2":
-  version: 2.27.2
-  resolution: "react-native-gesture-handler@npm:2.27.2"
+"react-native-gesture-handler@npm:2.31.1":
+  version: 2.31.1
+  resolution: "react-native-gesture-handler@npm:2.31.1"
   dependencies:
     "@egjs/hammerjs": "npm:^2.0.17"
+    "@types/react-test-renderer": "npm:^19.1.0"
     hoist-non-react-statics: "npm:^3.3.0"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/f671664b29e738b99aa25f4a1acd3c069af506fa1945f03f297158dc655896d441c1be113e9fb5f6cf4eb7eda58fd0471e0dab3e3c498dabd294f2652a0b9575
+  checksum: 10c0/c73621a588ba12cf339c27c5185b3ade250a1bcaf1762d52ecafc09c4883b7ddf2b1956ad427740050af253ee9bb3e201493f391067ef99c084891cbef6dbcc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes APP-3615

## What changed (plus any additional context for devs)

Updates `react-native-gesture-handler` from 2.27.2 to 2.31.1 in preparation for the RN 0.81 upgrade.

All 3 existing patches were migrated to the new version — none have been upstreamed:
- **Android**: `open class ButtonViewGroup` (allows subclassing)
- **iOS**: `delaysContentTouches = NO` (scroll touch handling)
- **iOS**: App resign active handler resets manual activation recognizer

## Screen recordings / screenshots

N/A — native dependency update only.

## What to test

Tested on iOS and Android emulators

- [x] Verify gesture interactions work correctly on both platforms (scrolling, tapping, swiping)