### PR TITLE
fix: use direct reanimated type imports instead of namespace access

### DIFF
--- a/src/components/FadeGradient.tsx
+++ b/src/components/FadeGradient.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { type StyleProp, type ViewStyle } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
-import Animated from 'react-native-reanimated';
+import Animated, { type AnimatedStyle } from 'react-native-reanimated';
 
 import { Box, globalColors } from '@/design-system';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useTheme } from '@/theme/ThemeContext';
 
-type FadeGradientProps = { side: 'top' | 'bottom'; style?: StyleProp<Animated.AnimateStyle<StyleProp<ViewStyle>>> };
+type FadeGradientProps = { side: 'top' | 'bottom'; style?: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>> };
 
 export const FadeGradient = ({ side, style }: FadeGradientProps) => {
   const { colors, isDarkMode } = useTheme();

--- a/src/components/animations/HourglassAnimation.tsx
+++ b/src/components/animations/HourglassAnimation.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
-import Animated, { Easing, useAnimatedStyle, useDerivedValue, withRepeat, withSequence, withTiming } from 'react-native-reanimated';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useDerivedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+  type EasingFunction,
+} from 'react-native-reanimated';
 import { Path, Svg } from 'react-native-svg';
 
 import { BackgroundProvider, Box, useForegroundColor } from '@/design-system';
 
 type AnimationConfigOptions = {
   duration: number;
-  easing: Animated.EasingFunction;
+  easing: EasingFunction;
 };
 
 const rotationConfig: AnimationConfigOptions = {

--- a/src/components/cards/GasCard.tsx
+++ b/src/components/cards/GasCard.tsx
@@ -3,7 +3,15 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import AnimateNumber from '@bankify/react-native-animate-number';
 import { useIsFocused } from '@react-navigation/native';
 import { isNaN } from 'lodash';
-import Animated, { Easing, useAnimatedStyle, useSharedValue, withSequence, withSpring, withTiming } from 'react-native-reanimated';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming,
+  type EasingFunction,
+} from 'react-native-reanimated';
 
 import { AccentColorProvider, Box, globalColors, Stack, Text } from '@/design-system';
 import { add } from '@/helpers/utilities';
@@ -15,7 +23,7 @@ import { GenericCard, SQUARE_CARD_SIZE } from './GenericCard';
 
 type AnimationConfigOptions = {
   duration: number;
-  easing: Animated.EasingFunction;
+  easing: EasingFunction;
 };
 
 const TRANSLATIONS = i18n.l.cards.gas;


### PR DESCRIPTION
Fixes APP-3616

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

These namespace exports are deprecated in newer Reanimated versions and will cause TypeScript errors after the upgrade. The direct imports (`EasingFunction`, `AnimatedStyle`) are already available in Reanimated 3.19.4 so this can be landed ahead of the full upgrade.

Type-only change, no runtime impact.

## What to test

- TypeScript compiles without errors (`yarn lint:ts`)