### PR TITLE
fix: round zIndex value in useAnimatedTab for Fabric compatibility

### DIFF
--- a/src/components/DappBrowser/hooks/useAnimatedTab.ts
+++ b/src/components/DappBrowser/hooks/useAnimatedTab.ts
@@ -272,7 +272,9 @@ export function useAnimatedTab({ tabId }: { tabId: string }) {
       );
 
     const wasCloseButtonPressed = gestureScale.value === 1 && gestureX.value < 0;
-    const zIndex = scaleWeighting * (isPendingActiveTab || gestureScale.value > 1 ? 9999 : 1) + (wasCloseButtonPressed ? 9999 : 0);
+    const zIndex = Math.round(
+      scaleWeighting * (isPendingActiveTab || gestureScale.value > 1 ? 9999 : 1) + (wasCloseButtonPressed ? 9999 : 0)
+    );
 
     return { zIndex };
   });


### PR DESCRIPTION
Fixes APP-3617

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

The browser tab view computes a `zIndex` value by multiplying `scaleWeighting` with constants, which can produce floating-point values. Fabric (new arch) requires `zIndex` to be an integer or it will crash.

## What to test

Tested previously in the RN upgrade branch

- [ ] Browser tab view renders correctly