### PR TITLE
fix: guard decelerationRate string values to iOS only

### DIFF
--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -245,7 +245,6 @@ const TabWebViewComponent = (props: WebViewProps, ref: React.Ref<WebView>) => {
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentInset={{ bottom: 0, left: 0, right: 0, top: 0 }}
-      decelerationRate={IS_IOS ? 'normal' : undefined}
       fraudulentWebsiteWarningEnabled
       injectedJavaScript={SCRIPTS_TO_INJECT}
       mediaPlaybackRequiresUserAction

--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -245,7 +245,7 @@ const TabWebViewComponent = (props: WebViewProps, ref: React.Ref<WebView>) => {
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentInset={{ bottom: 0, left: 0, right: 0, top: 0 }}
-      decelerationRate="normal"
+      decelerationRate={IS_IOS ? 'normal' : undefined}
       fraudulentWebsiteWarningEnabled
       injectedJavaScript={SCRIPTS_TO_INJECT}
       mediaPlaybackRequiresUserAction

--- a/src/components/DappBrowser/Homepage.tsx
+++ b/src/components/DappBrowser/Homepage.tsx
@@ -130,7 +130,7 @@ const Trending = ({ goToUrl }: { goToUrl: (url: string) => void }) => {
       <Bleed space="24px">
         <ScrollView
           horizontal
-          decelerationRate="fast"
+          decelerationRate={IS_IOS ? 'fast' : undefined}
           disableIntervalMomentum
           showsHorizontalScrollIndicator={false}
           snapToOffsets={data.dApps.map((_, index) => index * (CARD_WIDTH + CARD_PADDING))}


### PR DESCRIPTION
Fixes APP-3618

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

Android does not support string `decelerationRate` values (`"normal"`, `"fast"`) on new arch.

- `BrowserTab`: Removed `decelerationRate="normal"` entirely since `"normal"` is the default value
- `Homepage`: Guarded `decelerationRate="fast"` to iOS only, passing `undefined` on Android to use the platform default

## What to test

Validated previously in RN upgrade PR that it crashed before and not after this fix.