### PR TITLE
fix: rename SlackSheet internal borderRadius prop to avoid ViewStyle collision

### DIFF
--- a/src/components/sheet/SlackSheet.tsx
+++ b/src/components/sheet/SlackSheet.tsx
@@ -44,12 +44,12 @@ interface ContainerProps {
   contentHeight?: number;
   deferredHeight?: boolean;
   deviceHeight: number;
-  borderRadius?: number;
+  topBorderRadius?: number;
 }
 
 const Container = styled(Centered).attrs({
   direction: 'column',
-})(({ backgroundColor, additionalTopPadding, contentHeight, deferredHeight, deviceHeight, borderRadius }: ContainerProps) => ({
+})(({ backgroundColor, additionalTopPadding, contentHeight, deferredHeight, deviceHeight, topBorderRadius }: ContainerProps) => ({
   ...(deferredHeight || IS_IOS
     ? {}
     : {
@@ -60,7 +60,7 @@ const Container = styled(Centered).attrs({
               ? deviceHeight - contentHeight
               : 0,
       }),
-  ...(IS_ANDROID ? { borderTopLeftRadius: borderRadius ?? 30, borderTopRightRadius: borderRadius ?? 30 } : {}),
+  ...(IS_ANDROID ? { borderTopLeftRadius: topBorderRadius ?? 30, borderTopRightRadius: topBorderRadius ?? 30 } : {}),
   backgroundColor: backgroundColor,
   bottom: 0,
   left: 0,
@@ -119,7 +119,7 @@ interface SlackSheetProps extends ViewStyle {
   hideHandle?: boolean;
   limitScrollViewContent?: boolean;
   onContentSizeChange?: () => void;
-  renderHeader?: (yPosition: Animated.SharedValue<number>) => React.ReactNode;
+  renderHeader?: (yPosition: SharedValue<number>) => React.ReactNode;
   scrollEnabled?: boolean;
   scrollIndicatorInsets?: Insets;
   showsHorizontalScrollIndicator?: boolean;
@@ -221,7 +221,7 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
         deferredHeight={deferredHeight}
         deviceHeight={deviceHeight}
         testID={testID}
-        borderRadius={borderRadius}
+        topBorderRadius={borderRadius}
         {...props}
       >
         {IS_ANDROID && (


### PR DESCRIPTION
Fixes APP-3619

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

The `Container` styled-component in `SlackSheet` uses a prop named `borderRadius`, which collides with React Native's built-in `ViewStyle.borderRadius` property. On new arch (Fabric), this collision causes RN to apply the prop as a native style rather than passing it through to the styled-component function.

Renames the internal styled-component prop from `borderRadius` to `topBorderRadius`. The external `SlackSheet` API still accepts `borderRadius` — it's mapped to `topBorderRadius` when passed to `Container`. Also switches `Animated.SharedValue` namespace type access to the direct `SharedValue` import.

## What to test

Tested previously in the RN upgrade branch, where before the border radius would apply to bottom corners of the sheets and only to the top ones after.

- [ ] Android: Sheets render with correct top border radius