### PR TITLE
fix: inline time utility worklet calculations

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -44,19 +44,19 @@ export const time: TimeUtils = {
   },
   minutes: minutes => {
     'worklet';
-    return time.seconds(minutes * 60);
+    return minutes * 60 * 1000;
   },
   hours: hours => {
     'worklet';
-    return time.minutes(hours * 60);
+    return hours * 60 * 60 * 1000;
   },
   days: days => {
     'worklet';
-    return time.hours(days * 24);
+    return days * 24 * 60 * 60 * 1000;
   },
   weeks: weeks => {
     'worklet';
-    return time.days(weeks * 7);
+    return weeks * 7 * 24 * 60 * 60 * 1000;
   },
   infinity: Infinity,
   zero: 0,


### PR DESCRIPTION
Fixes APP-3620

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

The `time` utility functions (`minutes`, `hours`, `days`, `weeks`) use recursive worklet-to-worklet calls (e.g., `time.minutes()` calls `time.seconds()`). In newer Reanimated and worklet runtimes required for new arch, calling one worklet function from inside another worklet fails due to how worklet closures are serialized.

Replaces recursive calls with inline arithmetic. Each function now directly computes milliseconds instead of delegating to another worklet. The results are identical.

## What to test

Tested previously in the RN upgrade branch, verified the error happened before and not after this fix.

- [x] `yarn jest src/state/internal/queryStore/queryStore.test.ts` — exercises `time.minutes()` and `time.days()` for cache/stale time configs