### PR TITLE
fix: use Animated.View for RainbowToast inner content container

### DIFF
--- a/src/components/rainbow-toast/RainbowToast.tsx
+++ b/src/components/rainbow-toast/RainbowToast.tsx
@@ -391,7 +391,7 @@ const RainbowToastItem = memo(function RainbowToast({ toast, minWidth: minWidthP
           />
 
           {/* separate inner view because overflow hidden + shadow breaks */}
-          <View style={[contentContainerStyle, styles.innerContent]}>
+          <Animated.View style={[contentContainerStyle, styles.innerContent]}>
             {IS_IOS ? (
               <>
                 <BlurGradient
@@ -438,7 +438,7 @@ const RainbowToastItem = memo(function RainbowToast({ toast, minWidth: minWidthP
             <Animated.View style={innerContainerStyle} onLayout={handleLayout}>
               <ToastContent toast={toast} />
             </Animated.View>
-          </View>
+          </Animated.View>
         </Animated.View>
       </GestureDetector>
     </Animated.View>


### PR DESCRIPTION
Fixes APP-3621

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

The `RainbowToast` inner content container receives an animated style (`contentContainerStyle` — a `minWidth` spring animation) but uses a plain `View` as the host component. On new arch, applying Reanimated animated styles to non-animated host components does not work.

Note: on current arch (Paper), the animated style on a plain `View` is silently ignored, meaning the `minWidth` spring animation was never actually running. Switching to `Animated.View` will make it work for the first time — the toast width will now animate smoothly when content changes rather than snapping. This should look better but is worth verifying visually.

## What to test

https://github.com/user-attachments/assets/c3e69e24-4b8b-4624-8dc6-9d931377d222

- [x] Trigger a toast content change (e.g. pending → confirmed) and verify the width transition looks smooth