### PR TITLE
fix: replace dispatchCommand with runOnJS for browser search input focus

### DIFF
--- a/src/components/DappBrowser/search/Search.tsx
+++ b/src/components/DappBrowser/search/Search.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { dispatchCommand, runOnJS, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+import Animated, { runOnJS, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useColorMode } from '@/design-system';
@@ -59,8 +59,7 @@ export const Search = () => {
   }));
 
   const bottomBarStyle = useAnimatedStyle(() => {
-    const translateY =
-      _WORKLET && isFocused.value ? -(keyboardHeight.value - (IS_IOS ? TAB_BAR_HEIGHT : 46) + extraWebViewHeight.value) : 0;
+    const translateY = _WORKLET && isFocused.value ? -(keyboardHeight.value - TAB_BAR_HEIGHT + extraWebViewHeight.value) : 0;
     return {
       transform: [
         {
@@ -121,12 +120,16 @@ export const Search = () => {
     [goToUrl, inputRef, searchQuery, searchResults]
   );
 
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus();
+  }, [inputRef]);
+
   const onAddressInputPressWorklet = useCallback(() => {
     'worklet';
     isFocused.value = true;
     searchViewProgress.value = withSpring(100, SPRING_CONFIGS.snappierSpringConfig);
-    dispatchCommand(inputRef, 'focus');
-  }, [inputRef, isFocused, searchViewProgress]);
+    runOnJS(focusInput)();
+  }, [focusInput, isFocused, searchViewProgress]);
 
   const onBlurWorklet = useCallback(() => {
     'worklet';

--- a/src/components/DappBrowser/search/Search.tsx
+++ b/src/components/DappBrowser/search/Search.tsx
@@ -59,7 +59,8 @@ export const Search = () => {
   }));
 
   const bottomBarStyle = useAnimatedStyle(() => {
-    const translateY = _WORKLET && isFocused.value ? -(keyboardHeight.value - TAB_BAR_HEIGHT + extraWebViewHeight.value) : 0;
+    const translateY =
+      _WORKLET && isFocused.value ? -(keyboardHeight.value - (IS_IOS ? TAB_BAR_HEIGHT : 46) + extraWebViewHeight.value) : 0;
     return {
       transform: [
         {


### PR DESCRIPTION
Fixes APP-3622

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

The browser search bar uses Reanimated's `dispatchCommand(inputRef, 'focus')` to focus the text input from a worklet. `dispatchCommand` relies on the legacy Paper command dispatch mechanism which is not available on new arch (Fabric).

Replaces with a `runOnJS` callback that calls `inputRef.current?.focus()` on the JS thread — the standard pattern for triggering imperative methods from worklets.

## What to test

- Browser search: tapping the address bar focuses the input and opens the search view