### PR TITLE
chore: add --active-arch-only to android run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "// Fetch backend networks": "",
     "adb-all": "adb devices | tail -n +2 | cut -sf 1 | xargs -I {} adb -s {}",
-    "android": "react-native run-android --main-activity MainActivityog",
+    "android": "react-native run-android --main-activity MainActivityog --active-arch-only",
     "android:apk": "yarn gradle assembleRelease && yarn uninstall:android && yarn android:load-apk",
     "android:bundle": "./scripts/check-env.sh && yarn gradle bundleRelease && open android/app/build/outputs/bundle/release/",
     "android:load-apk": "adb install android/app/build/outputs/apk/release/app-release.apk",


### PR DESCRIPTION
Fixes APP-3624

## What changed (plus any additional context for devs)

Extracted from the new arch migration PR #6924.

Adds `--active-arch-only` to the `yarn android` script so it only builds for the active device architecture during local development. This speeds up Android debug builds by skipping unnecessary architectures.

## What to test

- [x] `yarn android` builds and runs on a connected device/emulator