### PR TITLE
fix: use TAB_BAR_HEIGHT for Android browser search bottom bar position

### DIFF
--- a/src/components/DappBrowser/search/Search.tsx
+++ b/src/components/DappBrowser/search/Search.tsx
@@ -59,8 +59,7 @@ export const Search = () => {
   }));
 
   const bottomBarStyle = useAnimatedStyle(() => {
-    const translateY =
-      _WORKLET && isFocused.value ? -(keyboardHeight.value - (IS_IOS ? TAB_BAR_HEIGHT : 46) + extraWebViewHeight.value) : 0;
+    const translateY = _WORKLET && isFocused.value ? -(keyboardHeight.value - TAB_BAR_HEIGHT + extraWebViewHeight.value) : 0;
     return {
       transform: [
         {


### PR DESCRIPTION
Fixes APP-3631

## What changed (plus any additional context for devs)

Split out from #7337 per review feedback — this is an independent visual fix unrelated to the `dispatchCommand` new arch migration.

The browser search bottom bar `translateY` calculation hardcodes `46` for Android instead of using `TAB_BAR_HEIGHT`. This doesn't match `BASE_TAB_BAR_HEIGHT` (52) and causes the bottom bar to be slightly mispositioned when the keyboard is open on Android.

## Screen recordings / screenshots

Before/after screenshots from reviewer:

Gesture nav:

<img width="1331" height="1148" alt="image" src="https://github.com/user-attachments/assets/d1c97b66-dc90-4ff3-8d8d-81dc2a4d3fb3" />


Button nav:

<img width="392" height="866" alt="image" src="https://github.com/user-attachments/assets/d4105c9b-eccf-4180-a681-55056fb07355" />


## What to test

- Android (gesture nav): Open browser, tap address bar, verify bottom bar position with keyboard open
- Android (3-button nav): Same test — verify bottom bar position is correct
- iOS: No change expected