### PR TITLE
feature: stake card top cutout + tier badge design

### DIFF
--- a/src/features/rnbw-membership/components/TierBadge.tsx
+++ b/src/features/rnbw-membership/components/TierBadge.tsx
@@ -23,11 +23,13 @@ const BADGE_TEXT_GRADIENT_END = { x: 0, y: 1 };
 export const TierBadge = memo(function TierBadge({
   tier,
   height = 42,
+  borderWidth = 2,
   fontSize = '22pt',
   weight = 'heavy',
 }: {
   tier: TierType;
   height?: number;
+  borderWidth?: number;
   fontSize?: TextSize;
   weight?: TextWeight;
 }) {
@@ -61,7 +63,7 @@ export const TierBadge = memo(function TierBadge({
         locations={borderGradientLocations}
         start={borderStart}
         end={borderEnd}
-        borderWidth={2}
+        borderWidth={borderWidth}
         style={[styles.tierBadge, { height, borderRadius: height / 2 }]}
       >
         <InnerShadow color={opacity(globalColors.white100, 0.1)} blur={1} dx={0} dy={3} />

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -5,21 +5,17 @@ import Animated, { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AccountImage } from '@/components/AccountImage';
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
-import { Navbar, navbarHeight } from '@/components/navbar/Navbar';
+import { Navbar } from '@/components/navbar/Navbar';
 import { ScrollHeaderFade } from '@/components/scroll-header-fade/ScrollHeaderFade';
 import { useScrollFadeHandler } from '@/components/scroll-header-fade/useScrollFadeHandler';
 import { Box, useColorMode } from '@/design-system';
 import { getValueForColorMode } from '@/design-system/color/palettes';
 import { IS_ANDROID } from '@/env';
-import { TierBadge } from '@/features/rnbw-membership/components/TierBadge';
 import { MEMBERSHIP_SCREEN_BACKGROUND_COLOR } from '@/features/rnbw-membership/constants';
-import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
 import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
-import Navigation from '@/navigation/Navigation';
-import Routes from '@/navigation/routesNames';
+import useDimensions from '@/hooks/useDimensions';
 import { TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
 import { delay } from '@/utils/delay';
 import { time } from '@/utils/time';
@@ -30,29 +26,35 @@ import { RnbwRewardsClaimCard } from './components/RnbwRewardsClaimCard';
 import { RnbwStakingCard } from './components/RnbwStakingCard';
 import { RnbwStakingEarningsCard } from './components/RnbwStakingEarningsCard';
 
+const MEMBERSHIP_SCREEN_HORIZONTAL_PADDING = 20;
+
 export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
   const { colorMode } = useColorMode();
   const safeAreaInsets = useSafeAreaInsets();
+  const { width: screenWidth } = useDimensions();
   const backgroundColor = getValueForColorMode(MEMBERSHIP_SCREEN_BACKGROUND_COLOR, colorMode);
   const scrollOffset = useSharedValue(0);
   const onScroll = useScrollFadeHandler(scrollOffset);
   const bottomInset = TAB_BAR_HEIGHT + 16;
+  const stakingCardWidth = screenWidth - MEMBERSHIP_SCREEN_HORIZONTAL_PADDING * 2;
 
   return (
-    <Box backgroundColor={backgroundColor} style={styles.flex} testID="rnbw-membership-screen">
-      <Navbar hasStatusBarInset titleComponent={<CurrentTierBadge />} leftComponent={<AccountImage />} />
-      <ScrollHeaderFade color={backgroundColor} height={32} scrollOffset={scrollOffset} topInset={safeAreaInsets.top + navbarHeight} />
+    <Box backgroundColor={backgroundColor} style={styles.flex} testID="rnbw-membership-screen" paddingTop={{ custom: safeAreaInsets.top }}>
+      <ScrollHeaderFade color={backgroundColor} height={32} scrollOffset={scrollOffset} topInset={safeAreaInsets.top} />
       <Animated.ScrollView
         refreshControl={<RefreshControlWrapper />}
-        contentContainerStyle={[styles.scrollViewContentContainer, { paddingBottom: IS_ANDROID ? bottomInset : 0 }]}
-        style={styles.flex}
+        contentContainerStyle={{
+          paddingBottom: IS_ANDROID ? bottomInset : 0,
+        }}
+        style={styles.scrollView}
         onScroll={onScroll}
         contentInset={{
           bottom: bottomInset,
         }}
       >
-        <Box gap={16}>
-          <RnbwStakingCard />
+        <Navbar leftComponent={<AccountImage />} />
+        <Box gap={16} paddingHorizontal={{ custom: MEMBERSHIP_SCREEN_HORIZONTAL_PADDING }}>
+          <RnbwStakingCard width={stakingCardWidth} />
           <RnbwStakingEarningsCard />
           <MembershipTierCard />
           <RnbwRewardsClaimCard />
@@ -89,25 +91,12 @@ function RefreshControlWrapper(props: Omit<React.ComponentProps<typeof RefreshCo
   );
 }
 
-function CurrentTierBadge() {
-  const { currentTier } = useMembershipTierInfo();
-
-  return (
-    <ButtonPressAnimation onPress={navigateToMembershipTiersSheet}>
-      <TierBadge tier={currentTier} height={32} fontSize="17pt" />
-    </ButtonPressAnimation>
-  );
-}
-
-function navigateToMembershipTiersSheet() {
-  Navigation.handleAction(Routes.RNBW_MEMBERSHIP_TIERS_SHEET);
-}
-
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
-  scrollViewContentContainer: {
-    paddingHorizontal: 20,
+  scrollView: {
+    flex: 1,
+    overflow: 'hidden',
   },
 });

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/MembershipCard.tsx
@@ -6,7 +6,17 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
 import { Border, Box, useColorMode, type Space } from '@/design-system';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
-import { opacity } from '@/framework/ui/utils/opacity';
+
+import {
+  MEMBERSHIP_CARD_BORDER_RADIUS,
+  MEMBERSHIP_CARD_DARK_FILL,
+  MEMBERSHIP_CARD_DARK_INNER_SHADOW,
+  MEMBERSHIP_CARD_DARK_TOP_HIGHLIGHT,
+  MEMBERSHIP_CARD_LIGHT_BORDER_GRADIENT,
+  MEMBERSHIP_CARD_LIGHT_FILL,
+  MEMBERSHIP_CARD_LIGHT_GRADIENT_END,
+  MEMBERSHIP_CARD_LIGHT_GRADIENT_START,
+} from './membershipCardVisuals';
 
 type MembershipCardProps = {
   children: ReactNode;
@@ -20,7 +30,7 @@ type MembershipCardProps = {
 
 export function MembershipCard({
   children,
-  borderRadius = 32,
+  borderRadius = MEMBERSHIP_CARD_BORDER_RADIUS,
   padding,
   paddingHorizontal,
   paddingVertical,
@@ -32,7 +42,7 @@ export function MembershipCard({
   if (isDarkMode) {
     return (
       <Box
-        backgroundColor={opacity('#202429', 0.4)}
+        backgroundColor={MEMBERSHIP_CARD_DARK_FILL}
         borderRadius={borderRadius}
         padding={padding}
         paddingHorizontal={paddingHorizontal}
@@ -40,8 +50,14 @@ export function MembershipCard({
         paddingTop={paddingTop}
         paddingBottom={paddingBottom}
       >
-        <Border borderTopWidth={2} borderRadius={borderRadius} borderColor={{ custom: opacity('#D6D6D6', 0.02) }} />
-        <InnerShadow borderRadius={borderRadius} color={opacity('#FFFFFF', 0.06)} blur={2.5} dx={0} dy={1} />
+        <Border borderTopWidth={2} borderRadius={borderRadius} borderColor={{ custom: MEMBERSHIP_CARD_DARK_TOP_HIGHLIGHT }} />
+        <InnerShadow
+          borderRadius={borderRadius}
+          color={MEMBERSHIP_CARD_DARK_INNER_SHADOW.color}
+          blur={MEMBERSHIP_CARD_DARK_INNER_SHADOW.blur}
+          dx={MEMBERSHIP_CARD_DARK_INNER_SHADOW.dx}
+          dy={MEMBERSHIP_CARD_DARK_INNER_SHADOW.dy}
+        />
         {children}
       </Box>
     );
@@ -50,9 +66,9 @@ export function MembershipCard({
   return (
     <GradientBorderView
       borderRadius={borderRadius}
-      borderGradientColors={['#FFFFFF', opacity('#FFFFFF', 0.3)]}
-      start={{ x: 0.5, y: 0 }}
-      end={{ x: 0.5, y: 0.57 }}
+      borderGradientColors={MEMBERSHIP_CARD_LIGHT_BORDER_GRADIENT}
+      start={MEMBERSHIP_CARD_LIGHT_GRADIENT_START}
+      end={MEMBERSHIP_CARD_LIGHT_GRADIENT_END}
       style={styles.shadow}
     >
       <Box
@@ -65,9 +81,9 @@ export function MembershipCard({
         paddingBottom={paddingBottom}
       >
         <LinearGradient
-          colors={['#FFFFFF', '#FFFFFF']}
-          start={{ x: 0.5, y: 0 }}
-          end={{ x: 0.5, y: 0.57 }}
+          colors={[MEMBERSHIP_CARD_LIGHT_FILL, MEMBERSHIP_CARD_LIGHT_FILL]}
+          start={MEMBERSHIP_CARD_LIGHT_GRADIENT_START}
+          end={MEMBERSHIP_CARD_LIGHT_GRADIENT_END}
           style={StyleSheet.absoluteFill}
         />
         {children}

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/NotchedMembershipCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/NotchedMembershipCard.tsx
@@ -1,0 +1,384 @@
+import { memo, useCallback, useMemo, useState, type ReactNode } from 'react';
+import { PixelRatio, StyleSheet, View, type LayoutChangeEvent, type StyleProp, type ViewStyle } from 'react-native';
+
+import { Canvas, dist, Group, mixVector, Path, PathOp, point, Shadow, Skia, toDegrees } from '@shopify/react-native-skia';
+
+import { Box, useColorMode, type Space } from '@/design-system';
+import { THICK_BORDER_WIDTH } from '@/styles/constants';
+
+import {
+  MEMBERSHIP_CARD_BORDER_RADIUS,
+  MEMBERSHIP_CARD_DARK_CUTOUT_BORDER,
+  MEMBERSHIP_CARD_DARK_FILL,
+  MEMBERSHIP_CARD_DARK_INNER_SHADOW,
+  MEMBERSHIP_CARD_LIGHT_CUTOUT_BORDER,
+  MEMBERSHIP_CARD_LIGHT_DROP_SHADOW,
+  MEMBERSHIP_CARD_LIGHT_FILL,
+} from './membershipCardVisuals';
+
+const DEFAULT_NOTCH_HEIGHT = 56;
+const DEFAULT_NOTCH_DEPTH = 18;
+const DEFAULT_NOTCH_DESIGN_CORNER_RADIUS = 12;
+const DEFAULT_NOTCH_SHOULDER_RADIUS = resolveShoulderRadiusFromDesignRadius({
+  notchHeight: DEFAULT_NOTCH_HEIGHT,
+  notchDepth: DEFAULT_NOTCH_DEPTH,
+  designCornerRadius: DEFAULT_NOTCH_DESIGN_CORNER_RADIUS,
+});
+const NO_SHADOW_OUTSETS = { top: 0, right: 0, bottom: 0, left: 0 } as const;
+const LIGHT_DROP_SHADOW_OUTSETS = createShadowOutsets(MEMBERSHIP_CARD_LIGHT_DROP_SHADOW);
+
+type NotchedMembershipCardProps = {
+  children: ReactNode;
+  notchOverlay?: ReactNode;
+  width: number;
+  padding?: Space;
+  paddingHorizontal?: Space;
+  paddingVertical?: Space;
+  paddingTop?: Space;
+  paddingBottom?: Space;
+  notchWidth: number | null;
+  notchHeight?: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+type NotchedCardPathParams = {
+  cardRadius: number;
+  width: number;
+  height: number;
+  notchWidth: number;
+  notchHeight: number;
+  notchDepth: number;
+  notchShoulderRadius: number;
+};
+
+type NotchGeometry = NotchedCardPathParams & {
+  lowerArcRadius: number;
+  leftLowerArcCenterX: number;
+  rightLowerArcCenterX: number;
+  leftShoulderCenterX: number;
+  rightShoulderCenterX: number;
+  lowerArcCenterY: number;
+};
+
+type ShadowOutsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+export const NotchedMembershipCard = memo(function NotchedMembershipCard({
+  children,
+  notchOverlay,
+  width: cardWidth,
+  padding,
+  paddingHorizontal,
+  paddingVertical,
+  paddingTop,
+  paddingBottom,
+  notchHeight = DEFAULT_NOTCH_HEIGHT,
+  notchWidth,
+  style,
+}: NotchedMembershipCardProps) {
+  const { isDarkMode } = useColorMode();
+  const [cardHeight, setCardHeight] = useState(0);
+  // Skia clips drawing to the canvas bounds, so the light-mode drop shadow needs extra
+  // surface area based on its blur and offset to avoid getting cropped.
+  const shadowOutsets = isDarkMode ? NO_SHADOW_OUTSETS : LIGHT_DROP_SHADOW_OUTSETS;
+
+  const notchedCardPath = useMemo(() => {
+    if (cardHeight <= 0 || notchWidth === null || notchWidth <= 0) return null;
+
+    return createNotchedCardPath({
+      cardRadius: MEMBERSHIP_CARD_BORDER_RADIUS,
+      width: cardWidth,
+      height: cardHeight,
+      notchWidth,
+      notchHeight,
+      notchDepth: DEFAULT_NOTCH_DEPTH,
+      notchShoulderRadius: DEFAULT_NOTCH_SHOULDER_RADIUS,
+    });
+  }, [cardHeight, cardWidth, notchHeight, notchWidth]);
+
+  const handleContentLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = PixelRatio.roundToNearestPixel(event.nativeEvent.layout.height);
+    setCardHeight(height => (height === nextHeight ? height : nextHeight));
+  }, []);
+
+  const isReady = Boolean(notchedCardPath);
+
+  return (
+    <View style={[styles.container, { width: cardWidth }, style, !isReady && styles.hidden]}>
+      {notchedCardPath && (
+        <View
+          pointerEvents="none"
+          style={[
+            styles.canvasContainer,
+            {
+              width: cardWidth + shadowOutsets.left + shadowOutsets.right,
+              height: cardHeight + shadowOutsets.top + shadowOutsets.bottom,
+              top: -shadowOutsets.top,
+              left: -shadowOutsets.left,
+            },
+          ]}
+        >
+          <Canvas style={styles.canvas}>
+            <Group antiAlias dither transform={[{ translateX: shadowOutsets.left }, { translateY: shadowOutsets.top }]}>
+              {isDarkMode ? (
+                <>
+                  <Path path={notchedCardPath} color={MEMBERSHIP_CARD_DARK_FILL} />
+                  <Path path={notchedCardPath} style="stroke" strokeWidth={THICK_BORDER_WIDTH} color={MEMBERSHIP_CARD_DARK_CUTOUT_BORDER} />
+                  <Path path={notchedCardPath}>
+                    <Shadow
+                      dx={MEMBERSHIP_CARD_DARK_INNER_SHADOW.dx}
+                      dy={MEMBERSHIP_CARD_DARK_INNER_SHADOW.dy}
+                      blur={MEMBERSHIP_CARD_DARK_INNER_SHADOW.blur}
+                      color={MEMBERSHIP_CARD_DARK_INNER_SHADOW.color}
+                      inner
+                      shadowOnly
+                    />
+                  </Path>
+                </>
+              ) : (
+                <>
+                  <Path path={notchedCardPath} color="transparent">
+                    <Shadow
+                      dx={MEMBERSHIP_CARD_LIGHT_DROP_SHADOW.dx}
+                      dy={MEMBERSHIP_CARD_LIGHT_DROP_SHADOW.dy}
+                      blur={MEMBERSHIP_CARD_LIGHT_DROP_SHADOW.blur}
+                      color={MEMBERSHIP_CARD_LIGHT_DROP_SHADOW.color}
+                      shadowOnly
+                    />
+                  </Path>
+                  <Path path={notchedCardPath} color={MEMBERSHIP_CARD_LIGHT_FILL} />
+                  <Path
+                    path={notchedCardPath}
+                    style="stroke"
+                    strokeWidth={THICK_BORDER_WIDTH}
+                    color={MEMBERSHIP_CARD_LIGHT_CUTOUT_BORDER}
+                  />
+                </>
+              )}
+            </Group>
+          </Canvas>
+        </View>
+      )}
+      <View onLayout={handleContentLayout} style={styles.contentWrapper}>
+        <Box
+          padding={padding}
+          paddingHorizontal={paddingHorizontal}
+          paddingVertical={paddingVertical}
+          paddingTop={paddingTop}
+          paddingBottom={paddingBottom}
+          style={styles.content}
+        >
+          {children}
+        </Box>
+      </View>
+      {notchOverlay && (
+        <View
+          pointerEvents="box-none"
+          style={[
+            styles.notchOverlaySlot,
+            {
+              height: notchHeight,
+              top: DEFAULT_NOTCH_DEPTH - notchHeight,
+            },
+          ]}
+        >
+          {notchOverlay}
+        </View>
+      )}
+    </View>
+  );
+});
+
+function createNotchedCardPath(params: NotchedCardPathParams) {
+  const notchGeometry = createNotchGeometry(params);
+  const card = Skia.Path.Make();
+  const notch = createNotchPath(notchGeometry);
+
+  card.addRRect(
+    Skia.RRectXY(Skia.XYWHRect(0, 0, notchGeometry.width, notchGeometry.height), notchGeometry.cardRadius, notchGeometry.cardRadius)
+  );
+  return Skia.Path.MakeFromOp(card, notch, PathOp.Difference);
+}
+
+function createNotchGeometry(params: NotchedCardPathParams): NotchGeometry {
+  const { cardRadius, notchShoulderRadius, notchDepth, height, notchHeight, notchWidth, width } = params;
+  const centerX = width / 2;
+  const lowerArcRadius = notchHeight / 2;
+  const lowerArcHalfSpan = notchWidth / 2 - lowerArcRadius;
+  const shoulderCenterOffsetX = resolveShoulderCenterOffsetX({
+    lowerArcRadius,
+    notchDepth,
+    notchShoulderRadius,
+  });
+  const shoulderHalfSpan = lowerArcHalfSpan + shoulderCenterOffsetX;
+
+  return {
+    ...params,
+    cardRadius,
+    height,
+    leftLowerArcCenterX: centerX - lowerArcHalfSpan,
+    leftShoulderCenterX: centerX - shoulderHalfSpan,
+    lowerArcCenterY: notchDepth - lowerArcRadius,
+    lowerArcRadius,
+    rightLowerArcCenterX: centerX + lowerArcHalfSpan,
+    rightShoulderCenterX: centerX + shoulderHalfSpan,
+    width,
+  };
+}
+
+function resolveShoulderCenterOffsetX({
+  lowerArcRadius,
+  notchDepth,
+  notchShoulderRadius,
+}: {
+  lowerArcRadius: number;
+  notchDepth: number;
+  notchShoulderRadius: number;
+}) {
+  const lowerArcCenterY = notchDepth - lowerArcRadius;
+  const distanceSquared =
+    (lowerArcRadius + notchShoulderRadius) * (lowerArcRadius + notchShoulderRadius) -
+    (lowerArcCenterY - notchShoulderRadius) * (lowerArcCenterY - notchShoulderRadius);
+
+  return Math.sqrt(distanceSquared);
+}
+
+function resolveShoulderRadiusFromDesignRadius({
+  notchHeight,
+  notchDepth,
+  designCornerRadius,
+}: {
+  notchHeight: number;
+  notchDepth: number;
+  designCornerRadius: number;
+}) {
+  const topIntersectionOffset = Math.sqrt(notchHeight * notchDepth - notchDepth * notchDepth);
+
+  return (designCornerRadius * (2 * topIntersectionOffset + designCornerRadius)) / (2 * notchDepth);
+}
+
+function createNotchPath(notchGeometry: NotchGeometry) {
+  const cutoutTopY = -Math.max(notchGeometry.notchHeight, notchGeometry.notchShoulderRadius * 2);
+  const path = Skia.Path.Make();
+  const leftTangency = resolveShoulderLowerArcTangency({
+    shoulderCenterX: notchGeometry.leftShoulderCenterX,
+    shoulderRadius: notchGeometry.notchShoulderRadius,
+    lowerArcCenterX: notchGeometry.leftLowerArcCenterX,
+    lowerArcCenterY: notchGeometry.lowerArcCenterY,
+  });
+  const rightTangency = resolveShoulderLowerArcTangency({
+    shoulderCenterX: notchGeometry.rightShoulderCenterX,
+    shoulderRadius: notchGeometry.notchShoulderRadius,
+    lowerArcCenterX: notchGeometry.rightLowerArcCenterX,
+    lowerArcCenterY: notchGeometry.lowerArcCenterY,
+  });
+
+  path.moveTo(notchGeometry.leftShoulderCenterX, cutoutTopY);
+  path.lineTo(notchGeometry.leftShoulderCenterX, 0);
+  path.arcToOval(
+    createCircleBounds(notchGeometry.leftShoulderCenterX, notchGeometry.notchShoulderRadius, notchGeometry.notchShoulderRadius),
+    -90,
+    leftTangency.shoulderSweepAngle,
+    false
+  );
+  path.arcToOval(
+    createCircleBounds(notchGeometry.leftLowerArcCenterX, notchGeometry.lowerArcCenterY, notchGeometry.lowerArcRadius),
+    leftTangency.lowerArcTangencyAngle,
+    90 - leftTangency.lowerArcTangencyAngle,
+    false
+  );
+  path.lineTo(notchGeometry.rightLowerArcCenterX, notchGeometry.notchDepth);
+  path.arcToOval(
+    createCircleBounds(notchGeometry.rightLowerArcCenterX, notchGeometry.lowerArcCenterY, notchGeometry.lowerArcRadius),
+    90,
+    rightTangency.lowerArcTangencyAngle - 90,
+    false
+  );
+  path.arcToOval(
+    createCircleBounds(notchGeometry.rightShoulderCenterX, notchGeometry.notchShoulderRadius, notchGeometry.notchShoulderRadius),
+    rightTangency.shoulderStartAngle,
+    -90 - rightTangency.shoulderStartAngle,
+    false
+  );
+  path.lineTo(notchGeometry.rightShoulderCenterX, cutoutTopY);
+  path.close();
+
+  return path;
+}
+
+function resolveShoulderLowerArcTangency({
+  shoulderCenterX,
+  shoulderRadius,
+  lowerArcCenterX,
+  lowerArcCenterY,
+}: {
+  shoulderCenterX: number;
+  shoulderRadius: number;
+  lowerArcCenterX: number;
+  lowerArcCenterY: number;
+}) {
+  const shoulderCenter = point(shoulderCenterX, shoulderRadius);
+  const lowerArcCenter = point(lowerArcCenterX, lowerArcCenterY);
+  const centerDistance = dist(shoulderCenter, lowerArcCenter);
+  const tangentPoint = mixVector(shoulderRadius / centerDistance, shoulderCenter, lowerArcCenter);
+  const shoulderAngle = angleFromCenter(tangentPoint.x, tangentPoint.y, shoulderCenterX, shoulderRadius);
+
+  return {
+    lowerArcTangencyAngle: angleFromCenter(tangentPoint.x, tangentPoint.y, lowerArcCenterX, lowerArcCenterY),
+    shoulderStartAngle: shoulderAngle,
+    shoulderSweepAngle: shoulderAngle + 90,
+    tangentPoint,
+  };
+}
+
+function createCircleBounds(centerX: number, centerY: number, radius: number) {
+  return Skia.XYWHRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+}
+
+function angleFromCenter(x: number, y: number, centerX: number, centerY: number) {
+  return toDegrees(Math.atan2(y - centerY, x - centerX));
+}
+
+function createShadowOutsets({ dx, dy, blur }: { dx: number; dy: number; blur: number }): ShadowOutsets {
+  const blurPadding = Math.ceil(blur * 2);
+
+  return {
+    left: blurPadding - dx,
+    right: blurPadding + dx,
+    top: blurPadding - dy,
+    bottom: blurPadding + dy,
+  };
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    flex: 1,
+  },
+  canvasContainer: {
+    position: 'absolute',
+  },
+  container: {
+    position: 'relative',
+  },
+  content: {
+    position: 'relative',
+  },
+  contentWrapper: {
+    width: '100%',
+  },
+  notchOverlaySlot: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+  },
+  hidden: {
+    opacity: 0,
+  },
+});

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -1,8 +1,12 @@
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
+import { PixelRatio, StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { Box, Text } from '@/design-system';
 import { RnbwThemedButton } from '@/features/rnbw-membership/components/RnbwThemedButton';
+import { TierBadge } from '@/features/rnbw-membership/components/TierBadge';
+import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
 import { navigateToBuyRnbw } from '@/features/rnbw-membership/utils/navigateToBuyRnbw';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { MIN_STAKE_AMOUNT } from '@/features/rnbw-staking/constants';
@@ -13,21 +17,49 @@ import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { useStakableRnbwBalance } from '@/state/rnbw/useStakableRnbwBalance';
+import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
-import { MembershipCard } from './MembershipCard';
 import { MembershipCardSkeleton } from './MembershipCardSkeleton';
+import { NotchedMembershipCard } from './NotchedMembershipCard';
 
-export const RnbwStakingCard = memo(function RnbwStakingCard() {
+type RnbwStakingCardProps = {
+  width: number;
+};
+
+const TIER_BADGE_NOTCH_HORIZONTAL_PADDING = 12;
+export const TIER_BADGE_HEIGHT = 36;
+
+export const RnbwStakingCard = memo(function RnbwStakingCard({ width }: RnbwStakingCardProps) {
   const showPositionSkeleton = useStakingPositionStore(state => state.getStatus('isInitialLoad') && !state.getData());
+  const { currentTier } = useMembershipTierInfo();
   const { tokenAmount, nativeCurrencyAmount, hasStakedPosition } = useRnbwStakingBalance();
   const { tokenAmountFormatted: availableAmount, hasMinimumStakeAmount } = useStakableRnbwBalance();
+  const [measuredTierBadgeWidth, setMeasuredTierBadgeWidth] = useState<number | null>(null);
+
+  const handleTierBadgeLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextWidth = PixelRatio.roundToNearestPixel(event.nativeEvent.layout.width);
+    setMeasuredTierBadgeWidth(width => (width === nextWidth ? width : nextWidth));
+  }, []);
 
   if (showPositionSkeleton) {
-    return <MembershipCardSkeleton height={319} />;
+    return <MembershipCardSkeleton width={width} height={319} />;
   }
 
   return (
-    <MembershipCard paddingHorizontal="20px" paddingTop="24px" paddingBottom="16px">
+    <NotchedMembershipCard
+      width={width}
+      notchWidth={measuredTierBadgeWidth === null ? null : measuredTierBadgeWidth + TIER_BADGE_NOTCH_HORIZONTAL_PADDING * 2}
+      notchOverlay={
+        <ButtonPressAnimation onPress={navigateToMembershipTiersSheet}>
+          <View onLayout={handleTierBadgeLayout}>
+            <TierBadge tier={currentTier} height={36} fontSize="17pt" borderWidth={THICK_BORDER_WIDTH} />
+          </View>
+        </ButtonPressAnimation>
+      }
+      paddingTop={'24px'}
+      paddingHorizontal="24px"
+      paddingBottom="16px"
+    >
       <Box gap={16}>
         <Text size="22pt" weight="heavy" color="label">
           {i18n.t(i18n.l.rnbw_membership.staking_card.stake)}
@@ -45,7 +77,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
           <Box flexDirection="row" gap={10}>
             <RnbwThemedButton
               onPress={navigateToUnstakeSheet}
-              style={{ flex: 1 }}
+              style={styles.flexButton}
               label={i18n.t(i18n.l.rnbw_membership.staking_card.unstake)}
               size="22pt"
               weight="heavy"
@@ -53,7 +85,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
             />
             <RnbwThemedButton
               onPress={hasMinimumStakeAmount ? navigateToStakingScreen : navigateToBuyRnbw}
-              style={{ flex: 1 }}
+              style={styles.flexButton}
               label={hasMinimumStakeAmount ? i18n.t(i18n.l.button.add) : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)}
             />
           </Box>
@@ -86,7 +118,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard() {
           </Text>
         )}
       </Box>
-    </MembershipCard>
+    </NotchedMembershipCard>
   );
 });
 
@@ -110,3 +142,13 @@ function navigateToUnstakeSheet() {
   }
   Navigation.handleAction(Routes.RNBW_UNSTAKE_SHEET);
 }
+
+function navigateToMembershipTiersSheet() {
+  Navigation.handleAction(Routes.RNBW_MEMBERSHIP_TIERS_SHEET);
+}
+
+const styles = StyleSheet.create({
+  flexButton: {
+    flex: 1,
+  },
+});

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/membershipCardVisuals.ts
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/membershipCardVisuals.ts
@@ -1,0 +1,25 @@
+import { opacity } from '@/framework/ui/utils/opacity';
+
+export const MEMBERSHIP_CARD_BORDER_RADIUS = 32;
+
+export const MEMBERSHIP_CARD_LIGHT_FILL = '#FFFFFF';
+export const MEMBERSHIP_CARD_LIGHT_BORDER_GRADIENT = ['#FFFFFF', opacity('#FFFFFF', 0.3)] as const;
+export const MEMBERSHIP_CARD_LIGHT_CUTOUT_BORDER = opacity('#FFFFFF', 0.65);
+export const MEMBERSHIP_CARD_LIGHT_GRADIENT_START = { x: 0.5, y: 0 };
+export const MEMBERSHIP_CARD_LIGHT_GRADIENT_END = { x: 0.5, y: 0.57 };
+export const MEMBERSHIP_CARD_LIGHT_DROP_SHADOW = {
+  dx: 0,
+  dy: 6,
+  blur: 9,
+  color: 'rgba(0, 0, 0, 0.05)',
+};
+
+export const MEMBERSHIP_CARD_DARK_FILL = opacity('#202429', 0.4);
+export const MEMBERSHIP_CARD_DARK_TOP_HIGHLIGHT = opacity('#D6D6D6', 0.02);
+export const MEMBERSHIP_CARD_DARK_CUTOUT_BORDER = MEMBERSHIP_CARD_DARK_TOP_HIGHLIGHT;
+export const MEMBERSHIP_CARD_DARK_INNER_SHADOW = {
+  color: opacity('#FFFFFF', 0.06),
+  blur: 2.5,
+  dx: 0,
+  dy: 1,
+};


### PR DESCRIPTION
Fixes APP-3575

## What changed

Replaces the membership tier badge in the navbar with a new design where the badge sits in a notch at the top of the staking card.

The bulk of the code for creating this notch effect is in `createNotchedCardPath`, and most of the geometry code was produced by Codex.

#### Main changes
- `NotchedMembershipCard`: uses Skia to draw the card path directly with a pill shaped notch at the top center. Exposes `notchOverlay` for the `TierBadge` to sit inside the notch.
- `RnbwStakingCard`: switched from `MembershipCard` to `NotchedMembershipCard`, measures the tier badge via `onLayout` and passes its width as `notchWidth`.
- `membershipCardVisuals.ts`: new shared visual constants used by both `MembershipCard` and `NotchedMembershipCard`.

#### Other changes
- `MembershipCard`: refactored to consume the shared constants from `membershipCardVisuals.ts`.
- `TierBadge`: added a `borderWidth` prop.

## Screen recordings / screenshots

https://github.com/user-attachments/assets/da76c487-9acd-432d-8295-b5f24fbad4b9