### PR TITLE
misc: update @nktkas/hyperliquid lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "@ledgerhq/react-native-hw-transport-ble": "6.34.1",
     "@legendapp/list": "2.0.16",
     "@metamask/eth-sig-util": "7.0.2",
-    "@nktkas/hyperliquid": "0.25.5",
+    "@nktkas/hyperliquid": "0.32.2",
     "@notifee/react-native": "7.8.2",
     "@polymarket/builder-relayer-client": "0.0.7",
     "@polymarket/clob-client": "4.22.8",

--- a/src/features/perps/screens/ClosePositionBottomSheet.tsx
+++ b/src/features/perps/screens/ClosePositionBottomSheet.tsx
@@ -53,7 +53,7 @@ type PanelContentProps = {
 };
 
 function getOrderIdFromCloseStatus(status: OrderStatusResponse | undefined): number | undefined {
-  if (!status) return;
+  if (!status || typeof status !== 'object') return;
   if ('filled' in status) return status.filled.oid;
   if ('resting' in status) return status.resting.oid;
 }

--- a/src/features/perps/services/hyperliquid-exchange-client.ts
+++ b/src/features/perps/services/hyperliquid-exchange-client.ts
@@ -1,6 +1,5 @@
 import { type Wallet } from '@ethersproject/wallet';
 import * as hl from '@nktkas/hyperliquid';
-import { type CancelSuccessResponse } from '@nktkas/hyperliquid';
 import { type Address, type Hex } from 'viem';
 
 import { getOppositePositionSide } from '@/features/perps/utils';
@@ -244,7 +243,7 @@ export class HyperliquidExchangeClient {
     return result.response.data.statuses[0];
   }
 
-  async cancelOrder({ assetId, orderId }: { assetId: number; orderId: number }): Promise<CancelSuccessResponse | undefined> {
+  async cancelOrder({ assetId, orderId }: { assetId: number; orderId: number }): Promise<hl.CancelSuccessResponse | undefined> {
     if (checkIfReadOnlyWallet(this.userAddress)) return undefined;
 
     const exchangeClient = await this.getExchangeClient();
@@ -255,7 +254,7 @@ export class HyperliquidExchangeClient {
     });
   }
 
-  async ensureReferralCodeSet(): Promise<hl.SuccessResponse | undefined> {
+  async ensureReferralCodeSet(): Promise<hl.SetReferrerSuccessResponse | undefined> {
     if (checkIfReadOnlyWallet(this.userAddress)) return;
 
     const isSet = await this.accountClient.isReferralCodeSet();
@@ -269,7 +268,7 @@ export class HyperliquidExchangeClient {
     });
   }
 
-  async ensureApprovedBuilderFee(): Promise<hl.SuccessResponse | void> {
+  async ensureApprovedBuilderFee(): Promise<hl.ApproveBuilderFeeSuccessResponse | void> {
     if (checkIfReadOnlyWallet(this.userAddress)) return undefined;
 
     const isApproved = await this.accountClient.isBuilderFeeApproved();
@@ -284,7 +283,7 @@ export class HyperliquidExchangeClient {
     });
   }
 
-  async ensureDexAbstractionEnabled(assetId: number): Promise<hl.SuccessResponse | undefined> {
+  async ensureDexAbstractionEnabled(assetId: number): Promise<hl.UserDexAbstractionSuccessResponse | undefined> {
     if (!isBuilderDexAssetId(assetId)) return;
     if (checkIfReadOnlyWallet(this.userAddress)) return;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,11 @@
       "react-native-cool-modals": ["src/react-native-cool-modals"],
       "@rainbow-me/animated-charts": ["src/react-native-animated-charts/src"],
       "react-native-shadow-stack": ["src/react-native-shadow-stack"],
-      "@nktkas/hyperliquid/api/info": ["node_modules/@nktkas/hyperliquid/esm/src/api/info/~mod.d.ts"],
-      "@nktkas/hyperliquid/api/exchange": ["node_modules/@nktkas/hyperliquid/esm/src/api/exchange/~mod.d.ts"],
-      "@nktkas/hyperliquid/api/subscription": ["node_modules/@nktkas/hyperliquid/esm/src/api/subscription/~mod.d.ts"],
-      "@nktkas/hyperliquid/utils": ["node_modules/@nktkas/hyperliquid/esm/src/utils/mod.d.ts"],
-      "@nktkas/hyperliquid/signing": ["node_modules/@nktkas/hyperliquid/esm/src/signing/mod.d.ts"]
+      "@nktkas/hyperliquid/api/info": ["node_modules/@nktkas/hyperliquid/esm/api/info/mod"],
+      "@nktkas/hyperliquid/api/exchange": ["node_modules/@nktkas/hyperliquid/esm/api/exchange/mod"],
+      "@nktkas/hyperliquid/api/subscription": ["node_modules/@nktkas/hyperliquid/esm/api/subscription/mod"],
+      "@nktkas/hyperliquid/utils": ["node_modules/@nktkas/hyperliquid/esm/utils/mod"],
+      "@nktkas/hyperliquid/signing": ["node_modules/@nktkas/hyperliquid/esm/signing/mod"]
     },
     "resolveJsonModule": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5121,13 +5121,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@msgpack/msgpack@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "@msgpack/msgpack@npm:3.1.2"
-  checksum: 10c0/4fee6dbea70a485d3a787ac76dd43687f489d662f22919237db1f2abbc3c88070c1d3ad78417ce6e764bcd041051680284654021f52068e0aff82d570cb942d5
-  languageName: node
-  linkType: hard
-
 "@multiformats/base-x@npm:^4.0.1":
   version: 4.0.1
   resolution: "@multiformats/base-x@npm:4.0.1"
@@ -5135,18 +5128,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nktkas/hyperliquid@npm:0.25.5":
-  version: 0.25.5
-  resolution: "@nktkas/hyperliquid@npm:0.25.5"
+"@nktkas/hyperliquid@npm:0.32.2":
+  version: 0.32.2
+  resolution: "@nktkas/hyperliquid@npm:0.32.2"
   dependencies:
-    "@msgpack/msgpack": "npm:^3.1.2"
-    "@noble/hashes": "npm:^2.0.0"
-    "@noble/secp256k1": "npm:^3.0.0"
-    typescript-event-target: "npm:1.1.1"
-    valibot: "npm:1.1.0"
-  bin:
-    hyperliquid: esm/bin/cli.js
-  checksum: 10c0/ae01b071949e67869f2bf6672c86ca2f87f82a5d543a27246306e7811510cb8f03375b8ada3e910cbc869497eb764474b10413211c41f29633760fce03301b9e
+    "@nktkas/rews": "npm:^2"
+    "@noble/hashes": "npm:^2"
+    valibot: "npm:1.3.1"
+  checksum: 10c0/5b337d5c244deb445e3f150676e23a9fa99f3c20190b473888f1fcce66de4b47f4fad8b37b54ffbe59c01b17ded62aa2768a99e64da9bf3f59a8d12f34ffc949
+  languageName: node
+  linkType: hard
+
+"@nktkas/rews@npm:^2":
+  version: 2.1.1
+  resolution: "@nktkas/rews@npm:2.1.1"
+  checksum: 10c0/5ceaf48d0dd456fd98988238fb6b2a317e8b3b47be5c573f4caa72d2b12dee6374da0f68001d1e1430c684648db19a7198482d54e06c97446f3393caacd98985
   languageName: node
   linkType: hard
 
@@ -5214,17 +5210,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@noble/hashes@npm:2.0.1"
-  checksum: 10c0/e81769ce21c3b1c80141a3b99bd001f17edea09879aa936692ae39525477386d696101cd573928a304806efb2b9fa751e1dd83241c67d0c84d30091e85c79bdb
-  languageName: node
-  linkType: hard
-
-"@noble/secp256k1@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@noble/secp256k1@npm:3.0.0"
-  checksum: 10c0/bf844b9c1d4bd69f24d677eec5e0d2eb93506e6b1c32f30fd62690b539618e2d18d98297a66cde224196f4c73d4395f437eade496f241f867907f3db8cc7a2ee
+"@noble/hashes@npm:^2":
+  version: 2.2.0
+  resolution: "@noble/hashes@npm:2.2.0"
+  checksum: 10c0/cad8630c504d6b9271984f685cd0af9101b40988fc2dfbe17ccdf068a9941f95cc5c9957d89e9ca4b7ca94c15cb35f93510c5d53a09fbcc83ee503b93d0a1034
   languageName: node
   linkType: hard
 
@@ -9574,7 +9563,7 @@ __metadata:
     "@ledgerhq/react-native-hw-transport-ble": "npm:6.34.1"
     "@legendapp/list": "npm:2.0.16"
     "@metamask/eth-sig-util": "npm:7.0.2"
-    "@nktkas/hyperliquid": "npm:0.25.5"
+    "@nktkas/hyperliquid": "npm:0.32.2"
     "@notifee/react-native": "npm:7.8.2"
     "@polymarket/builder-relayer-client": "npm:0.0.7"
     "@polymarket/clob-client": "npm:4.22.8"
@@ -26765,13 +26754,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-event-target@npm:1.1.1":
-  version: 1.1.1
-  resolution: "typescript-event-target@npm:1.1.1"
-  checksum: 10c0/022a8b4389056a84c1c33ec35eb18826db20aed826990b3381bf09e3d4c03f5717d0adeb4154dff4fb3340d4a439b05a850271caf538204e18891b1586bb7f4f
-  languageName: node
-  linkType: hard
-
 "typescript@npm:4.1.3":
   version: 4.1.3
   resolution: "typescript@npm:4.1.3"
@@ -27438,15 +27420,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"valibot@npm:1.1.0":
-  version: 1.1.0
-  resolution: "valibot@npm:1.1.0"
+"valibot@npm:1.3.1":
+  version: 1.3.1
+  resolution: "valibot@npm:1.3.1"
   peerDependencies:
     typescript: ">=5"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/39580b4e4683cc44398fb775e88c03639dbaa7e6f587df416125916cb6307292d45df18f656054e8846093ced13a2d2fdc98659da6dd104d1d20180edcbd99d4
+  checksum: 10c0/e20a4097fa726f57530da1e64558af47ddd2303129c77978fe93c522c66cf4c79540ea3af864523589283ea25e347c3d65b8044fa4913376208dde576b9f6382
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We need to use https://nktkas.gitbook.io/hyperliquid/api-reference/info-methods/perpannotation, which is not available in `0.25.5`