### PR TITLE
feat: add name + description + about section to Perps Markets

### DIFF
--- a/src/components/collapsible/CollapsibleSectionBase.tsx
+++ b/src/components/collapsible/CollapsibleSectionBase.tsx
@@ -19,6 +19,7 @@ const AnimatedBox = Animated.createAnimatedComponent(Box);
 export interface CollapsibleSectionBaseProps {
   content: React.ReactNode;
   icon: string;
+  iconComponent?: React.ReactNode;
   primaryText: string;
   secondaryText?: string;
   expanded: SharedValue<boolean> | DerivedValue<boolean>;
@@ -30,6 +31,7 @@ export interface CollapsibleSectionBaseProps {
 export function CollapsibleSectionBase({
   content,
   icon,
+  iconComponent,
   primaryText,
   secondaryText,
   expanded,
@@ -48,6 +50,7 @@ export function CollapsibleSectionBase({
     <AnimatedBox layout={LAYOUT_ANIMATION}>
       <SectionHeaderView
         icon={icon}
+        iconComponent={iconComponent}
         primaryText={primaryText}
         secondaryText={secondaryText}
         expanded={expanded}
@@ -63,6 +66,7 @@ export function CollapsibleSectionBase({
 
 const SectionHeaderView = React.memo(function SectionHeaderView({
   icon,
+  iconComponent,
   primaryText,
   secondaryText,
   expanded,
@@ -94,13 +98,15 @@ const SectionHeaderView = React.memo(function SectionHeaderView({
       <Bleed vertical="4px">
         <Box height={'full'} flexDirection="row" justifyContent="space-between" alignItems="center">
           <Box flexDirection="row" gap={10} alignItems="center">
-            <IconContainer height={14} width={24}>
-              <TextShadow blur={12} shadowOpacity={0.24}>
-                <Text align="center" color={resolvedIconColor} size="icon 17px" weight="bold">
-                  {icon}
-                </Text>
-              </TextShadow>
-            </IconContainer>
+            {iconComponent ?? (
+              <IconContainer height={14} width={24}>
+                <TextShadow blur={12} shadowOpacity={0.24}>
+                  <Text align="center" color={resolvedIconColor} size="icon 17px" weight="bold">
+                    {icon}
+                  </Text>
+                </TextShadow>
+              </IconContainer>
+            )}
             <Box flexDirection="row" gap={5}>
               <Text weight="heavy" size="20pt" color="label">
                 {primaryText}

--- a/src/features/perps/components/PerpsNameRow.tsx
+++ b/src/features/perps/components/PerpsNameRow.tsx
@@ -1,0 +1,72 @@
+import React, { memo } from 'react';
+
+import { Bleed, Text, TextShadow } from '@/design-system';
+import { type TextProps, type TextWeight } from '@/design-system/components/Text/Text';
+import { type TextSize } from '@/design-system/typography/typeHierarchy';
+import { PerpsTextSkeleton } from '@/features/perps/components/PerpsTextSkeleton';
+import { extractBaseSymbol } from '@/features/perps/utils/hyperliquidSymbols';
+
+type PerpsNameRowProps = {
+  symbol: string;
+  name?: string;
+  isLoading?: boolean;
+  nameColor: TextProps['color'];
+  nameSize: TextSize;
+  nameWeight?: TextWeight;
+  nameShadow?: boolean;
+  suffixColor?: TextProps['color'];
+  suffixSize?: TextSize;
+  suffixWeight?: TextWeight;
+  skeletonWidth?: number;
+  skeletonHeight?: number;
+};
+
+export const PerpsNameRow = memo(function PerpsNameRow({
+  symbol,
+  name,
+  isLoading,
+  nameColor,
+  nameSize,
+  nameWeight = 'heavy',
+  nameShadow = false,
+  suffixColor = 'labelQuinary',
+  suffixSize = '15pt',
+  suffixWeight = 'bold',
+  skeletonWidth = 120,
+  skeletonHeight = 23,
+}: PerpsNameRowProps) {
+  if (isLoading) {
+    return (
+      <Bleed vertical="4px">
+        <PerpsTextSkeleton height={skeletonHeight} width={skeletonWidth} />
+      </Bleed>
+    );
+  }
+
+  const baseSymbol = extractBaseSymbol(symbol);
+  const displayName = name ?? baseSymbol;
+  const showSuffix = !!name && name !== baseSymbol;
+
+  const nameText = (
+    <Text color={nameColor} size={nameSize} weight={nameWeight}>
+      {displayName}
+    </Text>
+  );
+
+  return (
+    <>
+      {nameShadow ? (
+        <TextShadow blur={12} shadowOpacity={0.16}>
+          {nameText}
+        </TextShadow>
+      ) : (
+        nameText
+      )}
+      {showSuffix && (
+        <Text color={suffixColor} size={suffixSize} weight={suffixWeight}>
+          {baseSymbol}
+        </Text>
+      )}
+    </>
+  );
+});

--- a/src/features/perps/screens/perp-detail-screen/AboutSection.tsx
+++ b/src/features/perps/screens/perp-detail-screen/AboutSection.tsx
@@ -1,0 +1,115 @@
+import React, { memo, useCallback, useMemo } from 'react';
+
+import { Box, Text, TextIcon, useColorMode } from '@/design-system';
+import { HYPERLIQUID_COLORS, PERPS_BACKGROUND_DARK, PERPS_BACKGROUND_LIGHT } from '@/features/perps/constants';
+import { usePerpAnnotationsStore } from '@/features/perps/stores/perpAnnotationsStore';
+import { type PerpMarket } from '@/features/perps/types';
+import { formatCurrency } from '@/features/perps/utils/formatCurrency';
+import { ExpandableDescriptionCard } from '@/framework/ui/components/ExpandableDescriptionCard';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { multiply } from '@/helpers/utilities';
+import * as i18n from '@/languages';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { THICK_BORDER_WIDTH } from '@/styles/constants';
+import { getSolidColorEquivalent } from '@/worklets/colors';
+
+const ROW_BG = opacity(HYPERLIQUID_COLORS.green, 0.03);
+const ROW_BORDER = opacity(HYPERLIQUID_COLORS.green, 0.02);
+
+const BOX_BG_DARK = getSolidColorEquivalent({ background: PERPS_BACKGROUND_DARK, foreground: HYPERLIQUID_COLORS.green, opacity: 0.03 });
+const BOX_BG_LIGHT = getSolidColorEquivalent({ background: PERPS_BACKGROUND_LIGHT, foreground: HYPERLIQUID_COLORS.green, opacity: 0.03 });
+
+type StatRowProps = {
+  icon: string;
+  label: string;
+  highlighted?: boolean;
+  children: React.ReactNode;
+};
+
+const StatRow = memo(function StatRow({ icon, label, highlighted, children }: StatRowProps) {
+  return (
+    <Box
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="space-between"
+      paddingLeft="10px"
+      paddingRight="12px"
+      height={{ custom: 36 }}
+      borderRadius={14}
+      borderWidth={THICK_BORDER_WIDTH}
+      borderColor={{ custom: highlighted ? ROW_BORDER : 'transparent' }}
+      style={highlighted ? { backgroundColor: ROW_BG } : undefined}
+    >
+      <Box flexDirection="row" alignItems="center" gap={12}>
+        <TextIcon color="labelSecondary" height={10} size="icon 15px" width={20} weight="medium">
+          {icon}
+        </TextIcon>
+        <Text color="labelSecondary" size="17pt" weight="semibold">
+          {label}
+        </Text>
+      </Box>
+      {children}
+    </Box>
+  );
+});
+
+type DescriptionBoxProps = {
+  description: string;
+};
+
+const DescriptionBox = memo(function DescriptionBox({ description }: DescriptionBoxProps) {
+  const { isDarkMode } = useColorMode();
+  const boxBg = isDarkMode ? BOX_BG_DARK : BOX_BG_LIGHT;
+
+  const onReadMore = useCallback(() => {
+    Navigation.handleAction(Routes.PERPS_ABOUT_SHEET);
+  }, []);
+
+  return (
+    <ExpandableDescriptionCard
+      backgroundColor={boxBg}
+      borderColor={ROW_BORDER}
+      borderWidth={THICK_BORDER_WIDTH}
+      ctaColor={{ custom: HYPERLIQUID_COLORS.green }}
+      ctaIcon="􀯻"
+      ctaLabel={i18n.t(i18n.l.perps.about.read_more)}
+      description={description}
+      onPress={onReadMore}
+      scaleTo={0.97}
+    />
+  );
+});
+
+export const AboutSection = memo(function AboutSection({ market }: { market: PerpMarket }) {
+  const description = usePerpAnnotationsStore(state => state.getAnnotation()?.description);
+  const volume = useMemo(() => formatCurrency(market.volume['24h'], { useCompactNotation: true, decimals: 2 }), [market.volume]);
+  const openInterest = useMemo(
+    () => formatCurrency(multiply(market.openInterest, market.price), { useCompactNotation: true, decimals: 2 }),
+    [market.openInterest, market.price]
+  );
+  const funding = useMemo(() => `${multiply(market.fundingRate, 100)}%`, [market.fundingRate]);
+
+  return (
+    <Box gap={16}>
+      {description && <DescriptionBox description={description} />}
+      <Box gap={4}>
+        <StatRow icon="􀣉" label={i18n.t(i18n.l.perps.about.volume_24h)} highlighted>
+          <Text color="label" size="17pt" weight="medium">
+            {volume}
+          </Text>
+        </StatRow>
+        <StatRow icon="􀘾" label={i18n.t(i18n.l.perps.about.open_interest)}>
+          <Text color="label" size="17pt" weight="medium">
+            {openInterest}
+          </Text>
+        </StatRow>
+        <StatRow icon="􀓞" label={i18n.t(i18n.l.perps.about.funding)} highlighted>
+          <Text color="label" size="17pt" weight="medium">
+            {funding}
+          </Text>
+        </StatRow>
+      </Box>
+    </Box>
+  );
+});

--- a/src/features/perps/screens/perp-detail-screen/PerpDetailScreen.tsx
+++ b/src/features/perps/screens/perp-detail-screen/PerpDetailScreen.tsx
@@ -9,21 +9,23 @@ import { CollapsibleSectionBase } from '@/components/collapsible/CollapsibleSect
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import SlackSheet from '@/components/sheet/SlackSheet';
 import { Chart } from '@/components/value-chart/Chart';
-import { Bleed, Box, Inline, Separator, Text, TextShadow, useColorMode, useForegroundColor } from '@/design-system';
+import { Bleed, Box, Inline, Separator, Text, useColorMode, useForegroundColor } from '@/design-system';
 import { IS_ANDROID, IS_IOS } from '@/env';
 import { HyperliquidTokenIcon } from '@/features/perps/components/HyperliquidTokenIcon';
+import { PerpsNameRow } from '@/features/perps/components/PerpsNameRow';
 import { PERPS_BACKGROUND_DARK, PERPS_BACKGROUND_LIGHT } from '@/features/perps/constants';
 import { PerpsAccentColorContextProvider, usePerpsAccentColorContext } from '@/features/perps/context/PerpsAccentColorContext';
 import { OpenPositionSection } from '@/features/perps/screens/perp-detail-screen/OpenPositionSection';
 import { TriggerOrdersSection } from '@/features/perps/screens/perp-detail-screen/TriggerOrdersSection';
 import { useHyperliquidAccountStore } from '@/features/perps/stores/hyperliquidAccountStore';
+import { usePerpAnnotationsStore } from '@/features/perps/stores/perpAnnotationsStore';
 import { PerpPositionSide, type PerpMarket } from '@/features/perps/types';
-import { extractBaseSymbol } from '@/features/perps/utils/hyperliquidSymbols';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import type Routes from '@/navigation/routesNames';
 import { type RootStackParamList } from '@/navigation/types';
 
+import { AboutSection } from './AboutSection';
 import { HistorySection } from './HistorySection';
 import { SHEET_FOOTER_HEIGHT, SheetFooter } from './SheetFooter';
 
@@ -36,6 +38,8 @@ export const NameAndPriceSection = memo(function NameAndPriceSection({
   leverage?: number;
   side?: PerpPositionSide;
 }) {
+  const name = usePerpAnnotationsStore(state => state.getAnnotation()?.displayName);
+  const isNameLoading = usePerpAnnotationsStore(state => state.getStatus('isInitialLoad'));
   const { isDarkMode } = useColorMode();
   const green = useForegroundColor('green');
   const red = useForegroundColor('red');
@@ -57,12 +61,16 @@ export const NameAndPriceSection = memo(function NameAndPriceSection({
     <Box gap={20}>
       <HyperliquidTokenIcon size={44} symbol={symbol} />
 
-      <Box flexDirection="row" alignItems="center" gap={8}>
-        <TextShadow blur={12} shadowOpacity={0.16}>
-          <Text color={isDarkMode ? { custom: ETH_COLOR_DARK_ACCENT } : 'labelSecondary'} size="22pt" weight="heavy">
-            {extractBaseSymbol(symbol)}
-          </Text>
-        </TextShadow>
+      <Box flexDirection="row" alignItems="flex-end" gap={8}>
+        <PerpsNameRow
+          symbol={symbol}
+          name={name}
+          isLoading={isNameLoading}
+          nameColor={isDarkMode ? { custom: ETH_COLOR_DARK_ACCENT } : 'labelSecondary'}
+          nameSize="22pt"
+          nameShadow
+          suffixSize="17pt"
+        />
         <Bleed vertical="8px">
           <Inline space="6px">
             {leverage && (
@@ -133,11 +141,18 @@ const LIGHT_HANDLE_COLOR = 'rgba(9, 17, 31, 0.3)';
 
 const PerpsDetailScreenContent = memo(function PerpsDetailScreenContent({ market }: { market: PerpMarket }) {
   const position = useHyperliquidAccountStore(state => state.getPosition(market.symbol));
+
   const { isDarkMode } = useColorMode();
   const backgroundColor = isDarkMode ? PERPS_BACKGROUND_DARK : PERPS_BACKGROUND_LIGHT;
   const colors = usePerpsAccentColorContext();
   const safeAreaInsets = useSafeAreaInsets();
+  const aboutExpanded = useSharedValue(true);
   const historyExpanded = useSharedValue(true);
+
+  const onToggleAbout = () => {
+    'worklet';
+    aboutExpanded.value = !aboutExpanded.value;
+  };
 
   const onToggleHistory = () => {
     'worklet';
@@ -177,6 +192,16 @@ const PerpsDetailScreenContent = memo(function PerpsDetailScreenContent({ market
               <TriggerOrdersSection symbol={market.symbol} />
             </>
           )}
+          <Separator color={'separatorTertiary'} direction="horizontal" thickness={1} />
+          <CollapsibleSectionBase
+            iconColor={colors.accentColors.opacity100}
+            icon="􀠒"
+            iconComponent={<HyperliquidTokenIcon size={24} symbol={market.symbol} />}
+            content={<AboutSection market={market} />}
+            primaryText={i18n.t(i18n.l.perps.about.title)}
+            expanded={aboutExpanded}
+            onToggle={onToggleAbout}
+          />
           <Separator color={'separatorTertiary'} direction="horizontal" thickness={1} />
           <CollapsibleSectionBase
             iconColor={colors.accentColors.opacity100}

--- a/src/features/perps/screens/perps-about-sheet/PerpsAboutSheet.tsx
+++ b/src/features/perps/screens/perps-about-sheet/PerpsAboutSheet.tsx
@@ -1,0 +1,29 @@
+import { memo } from 'react';
+
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Text, useForegroundColor } from '@/design-system';
+import { HyperliquidTokenIcon } from '@/features/perps/components/HyperliquidTokenIcon';
+import { PerpsNameRow } from '@/features/perps/components/PerpsNameRow';
+import { usePerpAnnotationsStore } from '@/features/perps/stores/perpAnnotationsStore';
+
+export const PerpsAboutSheet = memo(function PerpsAboutSheet() {
+  const annotation = usePerpAnnotationsStore(state => state.getAnnotation());
+  const symbol = usePerpAnnotationsStore(state => state.currentSymbol);
+  const separatorSecondaryColor = useForegroundColor('separatorSecondary');
+
+  return (
+    <PanelSheet innerBorderWidth={1} innerBorderColor={separatorSecondaryColor}>
+      <Box paddingHorizontal="24px" paddingTop="36px" paddingBottom="36px" gap={20}>
+        <HyperliquidTokenIcon size={44} symbol={symbol} />
+        <Box flexDirection="row" alignItems="flex-end" gap={6}>
+          <PerpsNameRow symbol={symbol} name={annotation?.displayName} nameColor="label" nameSize="26pt" />
+        </Box>
+        {annotation?.description && (
+          <Text color="labelTertiary" size="17pt" weight="medium">
+            {annotation.description}
+          </Text>
+        )}
+      </Box>
+    </PanelSheet>
+  );
+});

--- a/src/features/perps/stores/perpAnnotationsStore.ts
+++ b/src/features/perps/stores/perpAnnotationsStore.ts
@@ -1,0 +1,33 @@
+import type { PerpAnnotationResponse } from '@nktkas/hyperliquid';
+
+import { infoClient } from '@/features/perps/services/hyperliquid-info-client';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { time } from '@/utils/time';
+
+type PerpAnnotationParams = {
+  symbol: string;
+};
+
+type PerpAnnotationState = {
+  currentSymbol: string;
+  setSymbol: (symbol: string) => void;
+  getAnnotation: () => PerpAnnotationResponse | null;
+};
+
+export const usePerpAnnotationsStore = createQueryStore<PerpAnnotationResponse | null, PerpAnnotationParams, PerpAnnotationState>(
+  {
+    fetcher: async ({ symbol }) => {
+      if (!symbol) return null;
+      return infoClient.perpAnnotation({ coin: symbol });
+    },
+    params: { symbol: ($, store) => $(store).currentSymbol },
+    staleTime: time.minutes(30),
+  },
+  (set, get) => ({
+    currentSymbol: '',
+    setSymbol: (symbol: string) => {
+      if (get().currentSymbol !== symbol) set({ currentSymbol: symbol });
+    },
+    getAnnotation: () => get().getData(),
+  })
+);

--- a/src/features/perps/types.ts
+++ b/src/features/perps/types.ts
@@ -34,6 +34,7 @@ export type PerpMarket = {
   marginTiers?: MarginTier[];
   decimals: number;
   fundingRate: string;
+  openInterest: string;
   dex: string;
 };
 

--- a/src/features/perps/utils/hyperliquid.ts
+++ b/src/features/perps/utils/hyperliquid.ts
@@ -66,6 +66,7 @@ function processMarketsForDex({
         marginTiers: marginTable?.marginTiers,
         decimals: asset.szDecimals,
         fundingRate: assetPricingInfo.funding,
+        openInterest: assetPricingInfo.openInterest,
         dex,
       } satisfies PerpMarket;
     })

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1717,6 +1717,13 @@
         "minimum_amount_is": "Minimum amount is",
         "no_balance": "No Balance"
       },
+      "about": {
+        "title": "About",
+        "read_more": "Read more",
+        "volume_24h": "24h Volume",
+        "open_interest": "Open Interest",
+        "funding": "Funding"
+      },
       "history": {
         "title": "History",
         "no_trades": "No trades",

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -19,6 +19,7 @@ import { NotificationPermissionScreen } from '@/features/notifications/screens/N
 import { ClosePositionBottomSheet } from '@/features/perps/screens/ClosePositionBottomSheet';
 import { CreateTriggerOrderBottomSheet } from '@/features/perps/screens/CreateTriggerOrderBottomSheet';
 import { PerpsDetailScreen } from '@/features/perps/screens/perp-detail-screen/PerpDetailScreen';
+import { PerpsAboutSheet } from '@/features/perps/screens/perps-about-sheet/PerpsAboutSheet';
 import { PerpsAddToPositionSheet } from '@/features/perps/screens/perps-add-to-position-sheet/PerpsAddToPositionSheet';
 import { PerpsDepositScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen';
 import { PerpsWithdrawalScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsWithdrawalScreen';
@@ -302,6 +303,7 @@ function BSNavigator() {
       <BSStack.Screen component={KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} />
       <BSStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} />
       <BSStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
+      <BSStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
       <BSStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -19,6 +19,7 @@ import { NotificationPermissionScreen } from '@/features/notifications/screens/N
 import { ClosePositionBottomSheet } from '@/features/perps/screens/ClosePositionBottomSheet';
 import { CreateTriggerOrderBottomSheet } from '@/features/perps/screens/CreateTriggerOrderBottomSheet';
 import { PerpsDetailScreen } from '@/features/perps/screens/perp-detail-screen/PerpDetailScreen';
+import { PerpsAboutSheet } from '@/features/perps/screens/perps-about-sheet/PerpsAboutSheet';
 import { PerpsAddToPositionSheet } from '@/features/perps/screens/perps-add-to-position-sheet/PerpsAddToPositionSheet';
 import { PerpsDepositScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen';
 import { PerpsWithdrawalScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsWithdrawalScreen';
@@ -336,6 +337,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} {...panelConfig} />
       <NativeStack.Screen component={KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} {...learnSheetConfig} />
       <NativeStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
+      <NativeStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/prefetchRegistry.ts
+++ b/src/navigation/prefetchRegistry.ts
@@ -1,5 +1,6 @@
 import { polymarketChartsActions } from '@/features/charts/polymarket/stores/polymarketStore';
 import { prefetchCandlestickData } from '@/features/charts/stores/candlestickStore';
+import { usePerpAnnotationsStore } from '@/features/perps/stores/perpAnnotationsStore';
 import { prefetchPolymarketEvent } from '@/features/polymarket/stores/polymarketEventStore';
 import { usePolymarketOrderBookStore } from '@/features/polymarket/stores/polymarketOrderBookStore';
 import Routes, { type Route } from '@/navigation/routesNames';
@@ -20,6 +21,7 @@ export const prefetchRegistry = deepFreeze<PrefetchRegistry>({
 
   [Routes.PERPS_DETAIL_SCREEN]: ({ market }) => {
     prefetchCandlestickData(market.symbol);
+    usePerpAnnotationsStore.getState().setSymbol(market.symbol);
   },
 
   [Routes.POLYMARKET_EVENT_SCREEN]: ({ eventId, event }) => {

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -126,6 +126,7 @@ const Routes = {
   PERPS_ADD_TO_POSITION_SHEET: 'PerpsAddToPositionSheet',
   PERPS_EXPLAIN_SHEET: 'PerpsExplainSheet',
   PERPS_TRADE_HISTORY_SCREEN: 'PerpsTradeHistoryScreen',
+  PERPS_ABOUT_SHEET: 'PerpsAboutSheet',
   PERPS_TRADE_DETAILS_SHEET: 'PerpsTradeDetailsSheet',
   POLYMARKET_EVENT_SCREEN: 'PolymarketEventScreen',
   POLYMARKET_MANAGE_POSITION_SHEET: 'PolymarketManagePositionSheet',

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -684,6 +684,7 @@ type RouteParams = {
     market: PerpMarket;
     position: PerpsPosition;
   };
+  [Routes.PERPS_ABOUT_SHEET]: undefined;
   [Routes.PERPS_TRADE_DETAILS_SHEET]: {
     trade: HlTrade;
   };


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3529/add-name-description-to-perps-markets

## What changed (plus any additional context for devs)

This PR introduces names and descriptions for each Hyperliquid market, along with a basic “About” section. We load name and description directly from HL API, as our backend does not expose it.

Because the market name is fetched via a separate network request, we display a loader until that data is available.

Descriptions are shown only for markets where they exist. However, the rest of the “About” section remains visible for all markets, regardless of whether a description is present.

## Screen recordings / screenshots

[Simulator Screen Recording - iPhone 17 Pro - 2026-04-14 at 22.29.00.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/da5c0ed5-ca2b-4f40-ae1e-8022db55c1aa.mov" />](https://app.graphite.com/user-attachments/video/da5c0ed5-ca2b-4f40-ae1e-8022db55c1aa.mov)

## What to test

- Market with where name and symbol are equal shows it only once (BRENTOIL)
- Market with different name and symbol shows both (CL)
- Loader is not visible for a long time
- About section has 3 info rows for all the markets
- About section has description for some markets (commodities mainly)
- Description is truncated after 3rd row
- User can click on description, which open a modal with full text of description