### PR TITLE
chore: pin @ledgerhq/logs to a single version

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     ]
   },
   "resolutions": {
+    "@ledgerhq/logs": "6.16.0",
     "@rainbow-me/delegation/viem": "2.38.0",
     "@rainbow-me/provider/viem": "2.38.0",
     "@tanstack/query-core": "4.36.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4904,7 +4904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/logs@npm:^6.12.0, @ledgerhq/logs@npm:^6.16.0":
+"@ledgerhq/logs@npm:6.16.0":
   version: 6.16.0
   resolution: "@ledgerhq/logs@npm:6.16.0"
   checksum: 10c0/f2af7231c578bda193348c2aa23c396967812d542d331628780eebc354363862e99415a9f83a50d3de68668305bd699772c2db469befc7f6931873b94832c0fe


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Adds an explicit yarn resolution for `@ledgerhq/logs` pinned to `6.16.0` — the version already resolved on develop today. This is strictly a pin, not a bump: no package version changes, just making the existing resolution explicit so future dep updates can't split it.

Without this pin, yarn can end up with multiple versions of `@ledgerhq/logs` hoisted into `node_modules` when dependencies are updated, because different ledgerhq packages specify different semver ranges. When that happens, TypeScript sees two separate declarations of the `LocalTracer` class with incompatible private fields, and `src/utils/ledger.ts` fails to type-check with:

```
Argument of type 'BleTransport' is not assignable to parameter of type 'Transport'.
  Types of property 'tracer' are incompatible.
    Type 'import(".../react-native-hw-transport-ble/node_modules/@ledgerhq/hw-transport/node_modules/@ledgerhq/logs/lib/index").LocalTracer' is not assignable to type 'import(".../node_modules/@ledgerhq/logs/lib/index").LocalTracer'.
      Types have separate declarations of a private property 'type'.
```

This should have been added alongside the ble-plx / hw-transport-ble bump in #7323 — the next dep bump that touches anything ledgerhq-adjacent will re-introduce the duplicate otherwise. Surfacing it as a standalone PR so it's easy to review and doesn't get lost inside an unrelated bump.

## Screen recordings / screenshots
N/A — resolutions-only change.

## What to test
- `yarn install` completes without warnings about the ledger stack
- `yarn lint:ts` passes (in particular, no `BleTransport`/`LocalTracer` errors in `src/utils/ledger.ts`)
- Ledger hardware wallet flows still work on iOS and Android (pairing, signing)
