### PR TITLE
feature: staking card design tweaks

### DIFF
--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -64,60 +64,67 @@ export const RnbwStakingCard = memo(function RnbwStakingCard({ width }: RnbwStak
         <Text size="22pt" weight="heavy" color="label">
           {i18n.t(i18n.l.rnbw_membership.staking_card.stake)}
         </Text>
-        <Box alignItems="center" gap={20}>
-          <RnbwCoinIcon size={80} />
-          <Text size="44pt" weight="heavy" color="label">
-            {nativeCurrencyAmount}
-          </Text>
-          <Text size="17pt" weight="bold" color="labelTertiary">
-            {`${tokenAmount} ${RNBW_SYMBOL}`}
-          </Text>
-        </Box>
-        {hasStakedPosition ? (
-          <Box flexDirection="row" gap={10}>
-            <MembershipTierButton
-              tier={currentTier}
-              onPress={navigateToUnstakeSheet}
-              style={styles.flexButton}
-              label={i18n.t(i18n.l.rnbw_membership.staking_card.unstake)}
-              variant="secondary"
-            />
-            <MembershipTierButton
-              tier={currentTier}
-              onPress={hasMinimumStakeAmount ? navigateToStakingScreen : navigateToBuyRnbw}
-              style={styles.flexButton}
-              label={hasMinimumStakeAmount ? i18n.t(i18n.l.button.add) : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)}
-            />
+        <Box gap={24}>
+          <Box alignItems="center" gap={20}>
+            <RnbwCoinIcon size={80} />
+            <Box alignItems="center" gap={16}>
+              <Text size="44pt" weight="heavy" color="label">
+                {nativeCurrencyAmount}
+              </Text>
+              <Text size="17pt" weight="bold" color="labelTertiary">
+                {`${tokenAmount} ${RNBW_SYMBOL}`}
+              </Text>
+            </Box>
           </Box>
-        ) : (
-          <MembershipTierButton
-            tier={currentTier}
-            onPress={hasMinimumStakeAmount ? navigateToStakingLearnSheet : navigateToBuyRnbw}
-            label={
-              hasMinimumStakeAmount
-                ? i18n.t(i18n.l.rnbw_membership.staking_card.enable_staking)
-                : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)
-            }
-          />
-        )}
-        <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4}>
-          <RnbwCoinIcon size={18} />
-          <Text size="15pt" weight="bold" color="labelSecondary" align="center">
-            {availableAmount}
-          </Text>
-          <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
-            {i18n.t(
-              hasStakedPosition
-                ? i18n.l.rnbw_membership.staking_card.available_to_add
-                : i18n.l.rnbw_membership.staking_card.available_to_stake
+          <Box gap={12}>
+            {hasStakedPosition ? (
+              <Box flexDirection="row" gap={10}>
+                <MembershipTierButton
+                  tier={currentTier}
+                  onPress={navigateToUnstakeSheet}
+                  style={styles.flexButton}
+                  label={i18n.t(i18n.l.rnbw_membership.staking_card.unstake)}
+                  variant="secondary"
+                />
+                <MembershipTierButton
+                  tier={currentTier}
+                  onPress={hasMinimumStakeAmount ? navigateToStakingScreen : navigateToBuyRnbw}
+                  style={styles.flexButton}
+                  label={hasMinimumStakeAmount ? i18n.t(i18n.l.button.add) : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)}
+                />
+              </Box>
+            ) : (
+              <MembershipTierButton
+                tier={currentTier}
+                onPress={hasMinimumStakeAmount ? navigateToStakingLearnSheet : navigateToBuyRnbw}
+                label={
+                  hasMinimumStakeAmount
+                    ? i18n.t(i18n.l.rnbw_membership.staking_card.enable_staking)
+                    : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)
+                }
+              />
             )}
-          </Text>
+            {hasMinimumStakeAmount ? (
+              <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4}>
+                <RnbwCoinIcon size={18} />
+                <Text size="15pt" weight="bold" color="labelSecondary" align="center">
+                  {availableAmount}
+                </Text>
+                <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
+                  {i18n.t(
+                    hasStakedPosition
+                      ? i18n.l.rnbw_membership.staking_card.available_to_add
+                      : i18n.l.rnbw_membership.staking_card.available_to_stake
+                  )}
+                </Text>
+              </Box>
+            ) : (
+              <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
+                {i18n.t(i18n.l.rnbw_membership.staking_card.minimum_stake_amount_required, { minStakeAmount: MIN_STAKE_AMOUNT })}
+              </Text>
+            )}
+          </Box>
         </Box>
-        {!hasMinimumStakeAmount && (
-          <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
-            {i18n.t(i18n.l.rnbw_membership.staking_card.minimum_stake_amount_required, { minStakeAmount: MIN_STAKE_AMOUNT })}
-          </Text>
-        )}
       </Box>
     </NotchedMembershipCard>
   );


### PR DESCRIPTION
Fixes APP-3639

### What changed
Tweaked the staking card layout spacing to match the designs and made the "available to stake" footer conditional on having a minimum stake amount.

### Main changes
- `RnbwStakingCard`: added intermediate gap groupings to separate the balance display from the action buttons, tightened the gap between amount and token label, and only shows the "available to stake/add" footer when the user has the minimum stake amount

### Screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-16 at 09 08 29" src="https://github.com/user-attachments/assets/716a4378-ad8e-421d-8a97-239c88511ec1" />
