### PR TITLE
chore: retire native module whitelisting

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,3 @@
-const fs = require('fs');
-
-const envLine = fs
-  .readFileSync('./.env', 'utf8')
-  .split('\n')
-  .find(l => l.startsWith('SCRIPT_NM='));
-const data = envLine && envLine.slice(10);
-
 function getAliasesFromTsConfig() {
   const tsConfig = require('./tsconfig.json');
   const paths = tsConfig.compilerOptions.paths;
@@ -23,7 +15,6 @@ module.exports = function (api) {
   api.cache(true);
 
   const plugins = [
-    ...(data ? [data] : []),
     [
       'module-resolver',
       {

--- a/metro.transform.js
+++ b/metro.transform.js
@@ -6,7 +6,6 @@ module.exports.transform = function applyRainbowTransform({ src, filename, optio
   const opts = merge(options, {
     customTransformOptions: {
       'metro-plugin-anisotropic-transform': {
-        cyclicDependents: /.+\/node_modules\/react-native\/Libraries\/BatchedBridge\/NativeModules\.js$/,
         globalScopeFilter: {
           '@react-native-clipboard/clipboard': {},
           'react-native-keychain': {},


### PR DESCRIPTION
Retires the native module whitelisting system per the internal RFC. The mechanism has caused repeated issues and has has never been fully working across all platforms. The ongoing maintenance cost no longer justifies the narrow protection it provides. Removing this also derisks the upcoming RN 0.81 upgrade.

Removes the `SCRIPT_NM` env var reading and conditional plugin loading in `babel.config.js`, and the `cyclicDependents` metro transform config that supported it. Companion cleanup in `rainbow-scripts` and Bitrise will follow separately out of band.

Ref FEPLAT-42.