### PR TITLE
feature: account for tier in rewards estimate

### DIFF
--- a/src/__swaps__/screens/Swap/providers/SyncSwapRewardsEstimate.tsx
+++ b/src/__swaps__/screens/Swap/providers/SyncSwapRewardsEstimate.tsx
@@ -8,6 +8,7 @@ import { swapsStore, useSwapsStore } from '@/state/swaps/swapsStore';
 export function SyncSwapRewardsEstimate() {
   const quote = useSwapsStore(state => state.quote);
   const currency = userAssetsStoreManager(state => state.currency);
+  const walletAddress = userAssetsStoreManager(state => state.address);
 
   const requestKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -31,7 +32,7 @@ export function SyncSwapRewardsEstimate() {
       return;
     }
 
-    const payload = buildEstimateRewardPayload({ quote, currency });
+    const payload = buildEstimateRewardPayload({ quote, currency, walletAddress });
     if (!payload) {
       resetEstimate();
       return;
@@ -70,7 +71,7 @@ export function SyncSwapRewardsEstimate() {
     return () => {
       abortController.abort();
     };
-  }, [currency, quote, resetEstimate]);
+  }, [currency, quote, resetEstimate, walletAddress]);
 
   return null;
 }

--- a/src/__swaps__/screens/Swap/providers/SyncSwapRewardsEstimate.tsx
+++ b/src/__swaps__/screens/Swap/providers/SyncSwapRewardsEstimate.tsx
@@ -4,11 +4,12 @@ import { buildEstimateRewardPayload, fetchEstimateReward } from '@/features/rnbw
 import { logger, RainbowError } from '@/logger';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { swapsStore, useSwapsStore } from '@/state/swaps/swapsStore';
+import { useAccountAddress } from '@/state/wallets/walletsStore';
 
 export function SyncSwapRewardsEstimate() {
   const quote = useSwapsStore(state => state.quote);
   const currency = userAssetsStoreManager(state => state.currency);
-  const walletAddress = userAssetsStoreManager(state => state.address);
+  const walletAddress = useAccountAddress();
 
   const requestKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -21,9 +22,7 @@ export function SyncSwapRewardsEstimate() {
     if (requestKeyRef.current) {
       requestKeyRef.current = null;
     }
-    swapsStore.setState({
-      rewardsEstimate: null,
-    });
+    swapsStore.setState({ rewardsEstimate: null });
   }, []);
 
   useEffect(() => {
@@ -53,16 +52,12 @@ export function SyncSwapRewardsEstimate() {
 
         if (abortController.signal.aborted || requestKeyRef.current !== nextKey) return;
 
-        swapsStore.setState({
-          rewardsEstimate: result,
-        });
+        swapsStore.setState({ rewardsEstimate: result });
       } catch (error) {
         if (abortController.signal.aborted || requestKeyRef.current !== nextKey) return;
 
         logger.error(new RainbowError('[SyncSwapRewardsEstimate]: Failed to fetch rewards estimate', error));
-        swapsStore.setState({
-          rewardsEstimate: null,
-        });
+        swapsStore.setState({ rewardsEstimate: null });
       }
     };
 

--- a/src/features/rnbw-rewards/utils/estimateReward.ts
+++ b/src/features/rnbw-rewards/utils/estimateReward.ts
@@ -8,6 +8,7 @@ type EstimateRewardToken = {
 
 type EstimateRewardPayload = {
   currency: string;
+  walletAddress: string;
   swap: {
     feeRaw: string;
     feeToken: EstimateRewardToken;
@@ -35,9 +36,11 @@ type EstimateRewardResponse = {
 export function buildEstimateRewardPayload({
   quote,
   currency,
+  walletAddress,
 }: {
   quote: Quote | CrosschainQuote;
   currency: string;
+  walletAddress?: string | null;
 }): EstimateRewardPayload | null {
   const targetRouter = getTargetAddress(quote);
 
@@ -48,7 +51,7 @@ export function buildEstimateRewardPayload({
   const sellToken = quote.sellTokenAsset;
   const buyToken = quote.buyTokenAsset;
 
-  if (!feeTokenAddress || !feeTokenChainId || !targetRouter || !sellToken || !buyToken) return null;
+  if (!walletAddress || !feeTokenAddress || !feeTokenChainId || !targetRouter || !sellToken || !buyToken) return null;
 
   const inputToken = {
     address: quote.sellTokenAddress,
@@ -64,6 +67,7 @@ export function buildEstimateRewardPayload({
   };
   return {
     currency,
+    walletAddress,
     swap: {
       feeRaw: String(quote.fee),
       feeToken,


### PR DESCRIPTION
Fixes APP-3657

## What changed

Adds the `walletAddress` param to the `/rewards/EstimateReward` request so that the backend can account for the addresses membership tier. 

## Screen recordings / screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-16 at 14 13 41" src="https://github.com/user-attachments/assets/ca2cf551-edc8-4e42-9571-a8f6824a93d5" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-16 at 14 13 59" src="https://github.com/user-attachments/assets/42a827fd-f221-4302-ba9c-0e33a7f96da2" />

## What to test
Swapping ETH -> USDC of $10 should produce a higher estimate for black tier wallet than a basic tier wallet.  
