### PR TITLE
fix: restore decelerationRate="normal" on BrowserTab for iOS

### DIFF
--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -245,6 +245,7 @@ const TabWebViewComponent = (props: WebViewProps, ref: React.Ref<WebView>) => {
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentInset={{ bottom: 0, left: 0, right: 0, top: 0 }}
+      decelerationRate={IS_IOS ? 'normal' : undefined}
       fraudulentWebsiteWarningEnabled
       injectedJavaScript={SCRIPTS_TO_INJECT}
       mediaPlaybackRequiresUserAction


### PR DESCRIPTION
Fixes APP-3618 follow-up

## What changed (plus any additional context for devs)

Follow-up to #7333. The assumption that `"normal"` is the WKWebView default for `decelerationRate` is wrong — iOS actually defaults to `"fast"`, so dropping the explicit `decelerationRate="normal"` from `BrowserTab` changed the scroll friction in the in-app browser.

Restoring the prop, guarded to iOS only (`IS_IOS ? 'normal' : undefined`) to match the other call site in `Homepage.tsx` and avoid the Android new arch crash when a string value is passed.

## What to test

- Decerelation rate for dapp browser is the same as before.