### PR TITLE
chore: bump react-native-safe-area-context 5.4.0 → 5.7.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1866,7 +1866,7 @@ PODS:
     - React
   - react-native-restart (0.0.22):
     - React-Core
-  - react-native-safe-area-context (5.4.0):
+  - react-native-safe-area-context (5.7.0):
     - React-Core
   - react-native-screen-corner-radius (0.2.3):
     - React
@@ -3439,11 +3439,11 @@ SPEC CHECKSUMS:
   react-native-quick-md5: b648df1c4f23f4cc9df48c97f60c254dda2ae0b9
   react-native-randombytes: 4a00fba06ca0d80a7c02a6b73cfe58ffa4a093a0
   react-native-restart: f6f591aeb40194c41b9b5013901f00e6cf7d0f29
-  react-native-safe-area-context: 9d72abf6d8473da73033b597090a80b709c0b2f1
+  react-native-safe-area-context: e89848fc12d32ccca63d0d7d16dd96918d07c730
   react-native-screen-corner-radius: ebd0d3258fcc894571b41d25ee3db7569d375153
   react-native-skia: 3467bce4be38029a4af437022b88a45e68f4210e
   react-native-text-input-mask: b83b8b571cba4bf18fb9b7a0bb8319a14201db9e
-  react-native-udp: 33844c2b4a0430271e46cd069a6152cc4c482095
+  react-native-udp: afd81d997ff141501da6ac680667fd8319545da1
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
   react-native-video: 9c4c3eae02d1582907c5262f90bf8194ec1b6683
   react-native-view-shot: 44e13d0424a6b0375eae31d89e161fc1153512e5

--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "react-native-reanimated": "3.19.4",
     "react-native-redash": "16.3.0",
     "react-native-restart": "0.0.22",
-    "react-native-safe-area-context": "5.4.0",
+    "react-native-safe-area-context": "5.7.0",
     "react-native-screen-corner-radius": "0.2.3",
     "react-native-screens": "4.10.0",
     "react-native-share": "12.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,7 +9753,7 @@ __metadata:
     react-native-reanimated: "npm:3.19.4"
     react-native-redash: "npm:16.3.0"
     react-native-restart: "npm:0.0.22"
-    react-native-safe-area-context: "npm:5.4.0"
+    react-native-safe-area-context: "npm:5.7.0"
     react-native-screen-corner-radius: "npm:0.2.3"
     react-native-screens: "npm:4.10.0"
     react-native-share: "npm:12.2.5"
@@ -23252,13 +23252,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:5.4.0":
-  version: 5.4.0
-  resolution: "react-native-safe-area-context@npm:5.4.0"
+"react-native-safe-area-context@npm:5.7.0":
+  version: 5.7.0
+  resolution: "react-native-safe-area-context@npm:5.7.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/729fef1f768d57b905f51882374aa93b209d54576b8a0cf328e0a349c8dc9705ae8f9032e572fd7a7c9e94b588105f44760c0bb15ab9911b7977073d6754b54d
+  checksum: 10c0/c3799e17321b41df1e0a10492c98472f8f8225ef0bbaf8146c4a9acb9519aae9ac11429059143c215e4402c2808e8445274850a339f8477522ded2461e18da80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Bumps `react-native-safe-area-context` from 5.4.0 to 5.7.0 (latest). No patches, no API changes on anything we use (`SafeAreaProvider`, `useSafeAreaInsets`, `SafeAreaView`).

Between 5.4 and 5.7 the library added `SafeAreaListener`, a Fabric view pool fix, and new-arch-only Yoga/CMake fixes. The only C/C++ build surface is new-arch — on old arch we build pure Java/Kotlin + ObjC, so the RN version coupling is effectively none. Verified against our [Mobile React Native 0.81 Upgrade Plan](https://www.notion.so/rainbowdotme/Mobile-React-Native-0-81-Upgrade-Plan-30bb001b85b48050b8c8db580ffb4346), which targets this as a safe pre-bump. Expo SDK 54 pins `~5.6.0`, so 5.7.0 is a minor above the pin but still compatible.

Extracted from [#7366](https://github.com/rainbow-me/rainbow/pull/7366) (RN 0.81 bump) so it can land independently.

## Screen recordings / screenshots

_N/A — no visual changes._

## What to test

- [x] Quick smoke test of safe area