### PR TITLE
chore: bump react-native-screens 4.10.0 → 4.16.0

### DIFF
--- a/android/app/src/main/java/me/rainbow/MainActivity.kt
+++ b/android/app/src/main/java/me/rainbow/MainActivity.kt
@@ -7,6 +7,7 @@ import android.webkit.WebView
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.modules.network.OkHttpClientProvider
+import com.swmansion.rnscreens.fragment.restoration.RNScreensFragmentFactory
 import com.zoontek.rnbootsplash.RNBootSplash
 import io.branch.rnbranch.RNBranchModule
 import me.rainbow.NativeModules.Internals.CustomNetworkModule
@@ -18,13 +19,8 @@ class MainActivity : ReactActivity() {
         if (!isE2ETest) {
             RNBootSplash.init(this, R.style.BootTheme) // Initialize the splash screen
         }
-        // Pass null instead of savedInstanceState to skip Android's fragment restoration
-        // after config change or process death — react-native-screens recreates fragments
-        // from JS and Android restoring them in parallel causes duplicates
-        // (software-mansion/react-native-screens#17). react-native-screens 4.16+ offers a
-        // scoped alternative via RNScreensFragmentFactory, but we have no other native
-        // fragment consumers, so the blunt `null` still does the right thing.
-        super.onCreate(null)
+        supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
+        super.onCreate(savedInstanceState)
         OkHttpClientProvider.setOkHttpClientFactory(CustomNetworkModule())
         WebView.setWebContentsDebuggingEnabled(false)
     }

--- a/android/app/src/main/java/me/rainbow/MainActivity.kt
+++ b/android/app/src/main/java/me/rainbow/MainActivity.kt
@@ -18,7 +18,13 @@ class MainActivity : ReactActivity() {
         if (!isE2ETest) {
             RNBootSplash.init(this, R.style.BootTheme) // Initialize the splash screen
         }
-        super.onCreate(null) // Pass null here as required by react-native-screens
+        // Pass null instead of savedInstanceState to skip Android's fragment restoration
+        // after config change or process death — react-native-screens recreates fragments
+        // from JS and Android restoring them in parallel causes duplicates
+        // (software-mansion/react-native-screens#17). react-native-screens 4.16+ offers a
+        // scoped alternative via RNScreensFragmentFactory, but we have no other native
+        // fragment consumers, so the blunt `null` still does the right thing.
+        super.onCreate(null)
         OkHttpClientProvider.setOkHttpClientFactory(CustomNetworkModule())
         WebView.setWebContentsDebuggingEnabled(false)
     }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2658,7 +2658,7 @@ PODS:
   - RNRudderSdk (2.0.0):
     - React
     - Rudder (< 2.0.0, >= 1.31.0)
-  - RNScreens (4.10.0):
+  - RNScreens (4.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3443,7 +3443,7 @@ SPEC CHECKSUMS:
   react-native-screen-corner-radius: ebd0d3258fcc894571b41d25ee3db7569d375153
   react-native-skia: 3467bce4be38029a4af437022b88a45e68f4210e
   react-native-text-input-mask: b83b8b571cba4bf18fb9b7a0bb8319a14201db9e
-  react-native-udp: 33844c2b4a0430271e46cd069a6152cc4c482095
+  react-native-udp: afd81d997ff141501da6ac680667fd8319545da1
   react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
   react-native-video: 9c4c3eae02d1582907c5262f90bf8194ec1b6683
   react-native-view-shot: 44e13d0424a6b0375eae31d89e161fc1153512e5
@@ -3503,7 +3503,7 @@ SPEC CHECKSUMS:
   RNPermissions: bd0d9ca7969ff7b999aa605ee2e5919c12522bfe
   RNReanimated: 3e727b205ad6d3d48f9f5b07887ebefb4b20e9a4
   RNRudderSdk: cea1f6a95ceab29ceaf75bdadccba5f78121a4ce
-  RNScreens: 586139d98cad59cc4c56443b9bd5c8b9b0b6da0e
+  RNScreens: 0cba9551497bcf6ceaa75878c08f5cb9a2fac6a4
   RNSentry: 5903eefdcd6446708f27c2a7035f019b59d54a9a
   RNShare: e374836177ff2675dbc659f2e52a59bf6060d200
   RNSound: 314cc5226453ef4a3314a196c65e8a65e5106a7b

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "react-native-restart": "0.0.22",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screen-corner-radius": "0.2.3",
-    "react-native-screens": "4.10.0",
+    "react-native-screens": "4.16.0",
     "react-native-share": "12.2.5",
     "react-native-sound": "0.11.2",
     "react-native-storage": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9755,7 +9755,7 @@ __metadata:
     react-native-restart: "npm:0.0.22"
     react-native-safe-area-context: "npm:5.4.0"
     react-native-screen-corner-radius: "npm:0.2.3"
-    react-native-screens: "npm:4.10.0"
+    react-native-screens: "npm:4.16.0"
     react-native-share: "npm:12.2.5"
     react-native-sound: "npm:0.11.2"
     react-native-storage: "npm:1.0.1"
@@ -23272,16 +23272,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:4.10.0":
-  version: 4.10.0
-  resolution: "react-native-screens@npm:4.10.0"
+"react-native-screens@npm:4.16.0":
+  version: 4.16.0
+  resolution: "react-native-screens@npm:4.16.0"
   dependencies:
     react-freeze: "npm:^1.0.0"
+    react-native-is-edge-to-edge: "npm:^1.2.1"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/09d1f55431b85e556ef7b5efd776ac5e85303e47d9138f910cb8c25ff3804effc43185f84e8842bcae2219e8fee12366b3725f955f638c109387efb82e0260f3
+  checksum: 10c0/8ec459ff52cbd317bfca598843a0010b4ca9070d05664f28d792594d8ceabb398b9d68abb578f40295e41f906308efe7ac7359046fba7aaf318a0d9d65446102
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Bumps `react-native-screens` from 4.10.0 to 4.16.0 (Expo 54's pinned range). No patch needed.

We only directly import `enableScreens` and `FullWindowOverlay`, neither of which changed. React-navigation depends on this library heavily under the hood, so it is foundational for the whole navigation stack. Between 4.10 and 4.16 the library added `formSheet` / `pageSheet` presentations, experimental native bottom tabs (gated behind flags we don't enable), iOS 26 compatibility, and edge-to-edge integration. Everything RN-version-specific is gated to new arch via CMake guards, so on our old-arch build there is no coupling to RN 0.79 vs 0.81. 4.14.0 drops RN < 0.79 support — still fine for us.

### Why not 4.24.0 (latest)
Initially tried 4.24.0 but the Android CI build failed for two reasons that both trace back to newer-RN assumptions:

1. **compileSdk mismatch** — 4.24 pulls in `androidx.core:core-ktx:1.17.0` transitively, which requires `compileSdk=36`. We're still on 35 until the RN 0.81 bump PR lands.
2. **Codegen failure** — `ScreenStackHeaderConfigNativeComponent.ts` has an `onAttached` prop whose type resolves to `undefined` under our current codegen.

4.16.0 avoids both issues and matches Expo 54's `~4.16.0` pin.

### `MainActivity.kt`: migrate to `RNScreensFragmentFactory`

4.16 introduced a scoped alternative ([software-mansion/react-native-screens#3089](https://github.com/software-mansion/react-native-screens/pull/3089)) to the long-standing `super.onCreate(null)` workaround ([software-mansion/react-native-screens#17](https://github.com/software-mansion/react-native-screens/issues/17)): install an `RNScreensFragmentFactory` on the fragment manager and it removes only RNS fragments when Android tries to restore them, so other fragment restoration still works.

Swapped the old `super.onCreate(null)` for `supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()` followed by `super.onCreate(savedInstanceState)`. We don't have other native fragment consumers today, but adopting the upstream-recommended pattern means we're not stuck on a workaround any reviewer has to re-derive next time they touch this file.

Verified against our [Mobile React Native 0.81 Upgrade Plan](https://www.notion.so/rainbowdotme/Mobile-React-Native-0-81-Upgrade-Plan-30bb001b85b48050b8c8db580ffb4346). Extracted from [#7366](https://github.com/rainbow-me/rainbow/pull/7366) (RN 0.81 bump) so it can land independently.

## Screen recordings / screenshots

_N/A — no visual changes expected._

## What to test

- [x] Quick smoke test of app navigation
- [ ] Rotate device or trigger process death (enable "Don't keep activities" in developer options) and reopen the app — navigation should restore without duplicate screens
