### PR TITLE
chore: bump zustand 4.5.5 → 5.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "w2t": "3.0.2",
     "zeego": "1.10.0",
     "zod": "3.23.8",
-    "zustand": "4.5.5"
+    "zustand": "5.0.10"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/model/migrations.ts
+++ b/src/model/migrations.ts
@@ -25,7 +25,7 @@ import { favoritesQueryKey } from '@/resources/favorites';
 import { userAssetsStore } from '@/state/assets/userAssets';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { standardizeUrl, useFavoriteDappsStore } from '@/state/browser/favoriteDappsStore';
-import { useLegacyFavoriteDappsStore } from '@/state/legacyFavoriteDapps';
+import { legacyFavoriteDappsStore } from '@/state/legacyFavoriteDapps';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { getSelectedWallet, getWallets, setSelectedWallet, updateWallets } from '@/state/wallets/walletsStore';
 import ethereumUtils, { getAddressAndChainIdFromUniqueId, getUniqueId, getUniqueIdNetwork } from '@/utils/ethereumUtils';
@@ -658,7 +658,7 @@ export default async function runMigrations() {
     };
 
     await initializeLegacyStore();
-    const legacyFavorites = useLegacyFavoriteDappsStore.getState().favoriteDapps;
+    const legacyFavorites = legacyFavoriteDappsStore.getState().favoriteDapps;
 
     if (legacyFavorites.length > 0) {
       // Re-standardize URLs to ensure they're in the correct format
@@ -666,7 +666,7 @@ export default async function runMigrations() {
         favorite.url = standardizeUrl(favorite.url);
       }
       useFavoriteDappsStore.setState({ favoriteDapps: legacyFavorites });
-      useLegacyFavoriteDappsStore.setState({ favoriteDapps: [] });
+      legacyFavoriteDappsStore.setState({ favoriteDapps: [] });
     }
   };
 

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -6,7 +6,7 @@ import { type EqualityFn, type Selector } from '../internal/types';
 import { createStoreFactoryUtils } from '../internal/utils/factoryUtils';
 import { createUserAssetsStore } from './createUserAssetsStore';
 import { type UserAssetsStateToPersist } from './persistence';
-import { cleanupPositionsAssetsSync, setupPositionsAssetsSync } from './positionsSync';
+import { setupPositionsAssetsSync } from './positionsSync';
 import { type QueryEnabledUserAssetsState, type UserAssetsRouter, type UserAssetsStoreType } from './types';
 import { userAssetsStoreManager } from './userAssetsStoreManager';
 
@@ -49,16 +49,13 @@ function useUserAssetsStoreInternal<T>(
 }
 
 export const useUserAssetsStore: UserAssetsRouter = Object.assign(useUserAssetsStoreInternal, {
-  destroy: () => {
-    cleanupPositionsAssetsSync();
-    return getOrCreateStore().destroy();
-  },
   getInitialState: () => getOrCreateStore().getInitialState(),
   getState: (address?: Address | string) => getOrCreateStore(address).getState(),
   persist,
   setState: (...args: Parameters<UserAssetsRouter['setState']>) => {
     const [partial, replace, address] = args;
-    return getOrCreateStore(address).setState(partial, replace);
+    // Cast to satisfy zustand v5's narrowed setState overloads while preserving the router's boolean `replace`.
+    return getOrCreateStore(address).setState(partial, replace as false);
   },
   subscribe: portableSubscribe,
 });

--- a/src/state/assets/userAssets.ts
+++ b/src/state/assets/userAssets.ts
@@ -54,8 +54,12 @@ export const useUserAssetsStore: UserAssetsRouter = Object.assign(useUserAssetsS
   persist,
   setState: (...args: Parameters<UserAssetsRouter['setState']>) => {
     const [partial, replace, address] = args;
-    // Cast to satisfy zustand v5's narrowed setState overloads while preserving the router's boolean `replace`.
-    return getOrCreateStore(address).setState(partial, replace as false);
+    // @ts-expect-error — zustand v5 narrowed setState into two literal
+    // overloads (`replace?: false` + Partial, or `replace: true` + full
+    // state). The router's own signature keeps a boolean `replace`, so TS
+    // can't pick an overload when forwarding; the forwarder is correct at
+    // runtime because v5's impl handles both forms.
+    return getOrCreateStore(address).setState(partial, replace);
   },
   subscribe: portableSubscribe,
 });

--- a/src/state/browser/favoriteDappsStore.test.ts
+++ b/src/state/browser/favoriteDappsStore.test.ts
@@ -4,12 +4,9 @@ import { useFavoriteDappsStore } from './favoriteDappsStore';
 describe.skip('FavoriteDappsStore', () => {
   beforeEach(() => {
     // Reset the store to its initial state before each test
-    useFavoriteDappsStore.setState(
-      {
-        favoriteDapps: [],
-      },
-      true
-    ); // The second argument 'true' is to replace the state instead of merging
+    useFavoriteDappsStore.setState({
+      favoriteDapps: [],
+    });
   });
 
   test('should be able to add a favorite site', () => {

--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -321,15 +321,16 @@ export function createQueryStore<
       const isPartialFunction = typeof partial === 'function';
       if (isPartialFunction || partial.enabled !== undefined) {
         let handleNewEnabled: (() => void) | undefined;
+        // Cast to satisfy zustand v5's narrowed setState overloads while forwarding the caller's boolean `replace`.
         originalSet(state => {
           const newPartial = isPartialFunction ? partial(state) : partial;
           const newEnabled = newPartial.enabled !== undefined ? newPartial.enabled : state.enabled;
           if (newEnabled !== state.enabled) handleNewEnabled = () => handleEnabledChange(state.enabled, newEnabled);
           return newPartial;
-        }, replace);
+        }, replace as false);
         handleNewEnabled?.();
       } else {
-        originalSet(partial, replace);
+        originalSet(partial, replace as false);
       }
     };
 

--- a/src/state/internal/createQueryStore.ts
+++ b/src/state/internal/createQueryStore.ts
@@ -321,16 +321,21 @@ export function createQueryStore<
       const isPartialFunction = typeof partial === 'function';
       if (isPartialFunction || partial.enabled !== undefined) {
         let handleNewEnabled: (() => void) | undefined;
-        // Cast to satisfy zustand v5's narrowed setState overloads while forwarding the caller's boolean `replace`.
+        // @ts-expect-error — the outer setState's overloads enforce the
+        // correct partial/replace pairing at the caller boundary; inside
+        // the impl TS sees the union of both overloads and can't match
+        // either of zustand v5's narrowed setState overloads.
         originalSet(state => {
           const newPartial = isPartialFunction ? partial(state) : partial;
           const newEnabled = newPartial.enabled !== undefined ? newPartial.enabled : state.enabled;
           if (newEnabled !== state.enabled) handleNewEnabled = () => handleEnabledChange(state.enabled, newEnabled);
           return newPartial;
-        }, replace as false);
+        }, replace);
         handleNewEnabled?.();
       } else {
-        originalSet(partial, replace as false);
+        // @ts-expect-error — see the block above for why this forwarder
+        // call can't satisfy zustand v5's narrowed setState overloads.
+        originalSet(partial, replace);
       }
     };
 

--- a/src/state/internal/createStore.ts
+++ b/src/state/internal/createStore.ts
@@ -1,5 +1,5 @@
-import { persist, type PersistOptions } from 'zustand/middleware';
-import create, { type Mutate, type StoreApi } from 'zustand/vanilla';
+import { createJSONStorage, persist, type PersistOptions } from 'zustand/middleware';
+import { createStore as createVanillaStore, type Mutate, type StoreApi } from 'zustand/vanilla';
 
 import { persistStorage } from './persistStorage';
 
@@ -17,11 +17,11 @@ export function createStore<TState>(
 ) {
   const name = `rainbow.zustand.${persistOptions?.name}`;
   return Object.assign(
-    create(
+    createVanillaStore(
       persist(initializer, {
         ...persistOptions,
         name,
-        getStorage: () => persistStorage,
+        storage: createJSONStorage(() => persistStorage),
       })
     ),
     { initializer }

--- a/src/state/legacyFavoriteDapps/index.ts
+++ b/src/state/legacyFavoriteDapps/index.ts
@@ -1,5 +1,3 @@
-import create from 'zustand';
-
 import { standardizeUrl } from '../browser/favoriteDappsStore';
 import { createStore } from '../internal/createStore';
 
@@ -48,5 +46,3 @@ export const legacyFavoriteDappsStore = createStore<LegacyFavoriteDappsStore>(
     },
   }
 );
-
-export const useLegacyFavoriteDappsStore = create(legacyFavoriteDappsStore);

--- a/src/state/nfts/nfts.ts
+++ b/src/state/nfts/nfts.ts
@@ -46,8 +46,12 @@ export const useNftsStore: NftsRouter = Object.assign(useNftsStoreInternal, {
   persist,
   setState: (...args: Parameters<NftsRouter['setState']>) => {
     const [partial, replace, address] = args;
-    // Cast to satisfy zustand v5's narrowed setState overloads while preserving the router's boolean `replace`.
-    return getOrCreateStore(address).setState(partial, replace as false);
+    // @ts-expect-error — zustand v5 narrowed setState into two literal
+    // overloads (`replace?: false` + Partial, or `replace: true` + full
+    // state). The router's own signature keeps a boolean `replace`, so TS
+    // can't pick an overload when forwarding; the forwarder is correct at
+    // runtime because v5's impl handles both forms.
+    return getOrCreateStore(address).setState(partial, replace);
   },
   subscribe: portableSubscribe,
 });

--- a/src/state/nfts/nfts.ts
+++ b/src/state/nfts/nfts.ts
@@ -41,13 +41,13 @@ function useNftsStoreInternal<T>(
 }
 
 export const useNftsStore: NftsRouter = Object.assign(useNftsStoreInternal, {
-  destroy: () => getOrCreateStore().destroy(),
   getInitialState: () => getOrCreateStore().getInitialState(),
   getState: (address?: Address | string) => getOrCreateStore(address).getState(),
   persist,
   setState: (...args: Parameters<NftsRouter['setState']>) => {
     const [partial, replace, address] = args;
-    return getOrCreateStore(address).setState(partial, replace);
+    // Cast to satisfy zustand v5's narrowed setState overloads while preserving the router's boolean `replace`.
+    return getOrCreateStore(address).setState(partial, replace as false);
   },
   subscribe: portableSubscribe,
 });

--- a/src/state/nfts/openCollectionsStore.ts
+++ b/src/state/nfts/openCollectionsStore.ts
@@ -44,13 +44,13 @@ function useOpenCollectionsStoreInternal<T>(
 }
 
 export const useOpenCollectionsStore: OpenCollectionsRouter = Object.assign(useOpenCollectionsStoreInternal, {
-  destroy: () => getOrCreateStore().destroy(),
   getInitialState: () => getOrCreateStore().getInitialState(),
   getState: (address?: Address | string) => getOrCreateStore(address).getState(),
   persist,
   setState: (...args: Parameters<OpenCollectionsRouter['setState']>) => {
     const [partial, replace, address] = args;
-    return getOrCreateStore(address).setState(partial, replace);
+    // Cast to satisfy zustand v5's narrowed setState overloads while preserving the router's boolean `replace`.
+    return getOrCreateStore(address).setState(partial, replace as false);
   },
   subscribe: portableSubscribe,
 });

--- a/src/state/nfts/openCollectionsStore.ts
+++ b/src/state/nfts/openCollectionsStore.ts
@@ -49,8 +49,12 @@ export const useOpenCollectionsStore: OpenCollectionsRouter = Object.assign(useO
   persist,
   setState: (...args: Parameters<OpenCollectionsRouter['setState']>) => {
     const [partial, replace, address] = args;
-    // Cast to satisfy zustand v5's narrowed setState overloads while preserving the router's boolean `replace`.
-    return getOrCreateStore(address).setState(partial, replace as false);
+    // @ts-expect-error — zustand v5 narrowed setState into two literal
+    // overloads (`replace?: false` + Partial, or `replace: true` + full
+    // state). The router's own signature keeps a boolean `replace`, so TS
+    // can't pick an overload when forwarding; the forwarder is correct at
+    // runtime because v5's impl handles both forms.
+    return getOrCreateStore(address).setState(partial, replace);
   },
   subscribe: portableSubscribe,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9812,7 +9812,7 @@ __metadata:
     yaml-eslint-parser: "npm:1.3.0"
     zeego: "npm:1.10.0"
     zod: "npm:3.23.8"
-    zustand: "npm:4.5.5"
+    zustand: "npm:5.0.10"
   languageName: unknown
   linkType: soft
 
@@ -27264,15 +27264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:1.2.2":
-  version: 1.2.2
-  resolution: "use-sync-external-store@npm:1.2.2"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/23b1597c10adf15b26ade9e8c318d8cc0abc9ec0ab5fc7ca7338da92e89c2536abd150a5891bf076836c352fdfa104fc7231fb48f806fd9960e0cbe03601abaf
-  languageName: node
-  linkType: hard
-
 "use-sync-external-store@npm:1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
@@ -28307,26 +28298,6 @@ __metadata:
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
-  languageName: node
-  linkType: hard
-
-"zustand@npm:4.5.5":
-  version: 4.5.5
-  resolution: "zustand@npm:4.5.5"
-  dependencies:
-    use-sync-external-store: "npm:1.2.2"
-  peerDependencies:
-    "@types/react": ">=16.8"
-    immer: ">=9.0.6"
-    react: ">=16.8"
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    immer:
-      optional: true
-    react:
-      optional: true
-  checksum: 10c0/d04469d76b29c7e4070da269886de4efdadedd3d3824dc2a06ac4ff62e3b5877f925e927afe7382de651829872b99adec48082f1bd69fe486149be666345e626
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Bumps `zustand` from 4.5.5 to **5.0.10** on the direct dependency, plus the minimal source changes required by v5's API cleanups.

### Why 5.0.10 specifically (not latest 5.0.12)

`@storesjs/stores@0.8.7` (our migration target for `createRainbowStore` / `createQueryStore` / `createDerivedStore`) already pulls in `zustand@5.0.10` transitively. Pinning the direct dep to the exact same version lets yarn dedupe to a single copy in `yarn.lock` instead of shipping v4 and v5 side by side (current state on develop).

Running both copies isn't just bundle-size waste — subscribers created through v4's `create(…)` and v5's `createStore(…)` point at two separate store registries and can't see each other.

### Why v5 matters for the RN 0.81 upgrade

Metro's `unstable_enablePackageExports` defaults to **true** on RN 0.81. Zustand v4's `exports` map has no `react-native` condition — Metro falls through to the `module` / `import` condition, which resolves to `./esm/index.mjs` and uses `import.meta`, unsupported by Hermes. v5's `exports` map has an explicit `react-native` condition that routes to CJS, so consumers don't hit the `SyntaxError: 'import.meta' is currently unsupported` crash at store-creation time.

## v5 migration — breaking changes addressed

Each change below is a direct consequence of a v5 API removal/narrowing, and is explained in context.

### 1. Default export removed
**v4:** `import create from 'zustand'` / `import create from 'zustand/vanilla'`.
**v5:** both are named exports now, and the `zustand/vanilla` entry was renamed (`create` → `createStore`).

- `src/state/legacyFavoriteDapps/index.ts` — removed the default `create` import entirely (see §5 below for why it's no longer needed at all).
- `src/state/internal/createStore.ts` — switched to `import { createStore as createVanillaStore }` and updated the one call site. Aliased on import because this file itself exports a function named `createStore`.

### 2. `StoreApi.destroy()` removed
v5 dropped `destroy` from the store API. Rationale from the upstream PR: it was rarely used correctly and left the store in a half-dead state (listeners cleared, state still mutable).

Three routers had `destroy: () => getOrCreateStore().destroy()` forwarders:
- `src/state/nfts/nfts.ts`
- `src/state/nfts/openCollectionsStore.ts`
- `src/state/assets/userAssets.ts`

**Verified via grep that no code outside these three files ever called `.destroy()` on the affected stores.** The forwarder was dead weight even on v4. Removed all three cleanly, along with an import of `cleanupPositionsAssetsSync` from `positionsSync.ts` that was only reachable through the removed `userAssets` destroy handler. `cleanupPositionsAssetsSync` itself stays in `positionsSync.ts` because `setupPositionsAssetsSync` still calls it internally to tear down a previous subscription before setting up a new one.

### 3. `setState` overloads narrowed
v5 split `setState(partial, replace)` into two literal-narrowed overloads:
```ts
setState(partial: T | Partial<T> | ((state: T) => T | Partial<T>), replace?: false): void
setState(state: T | ((state: T) => T), replace: true): void
```

The Router types we expose keep the single-signature `replace?: boolean` shape, so forwarding requires bridging `boolean` to the two literal overloads. Rejected alternatives:
- **Runtime branching on `replace`** — more lines, and a manual type assertion is still needed on `partial` when forwarding the `replace: true` branch.
- **Change the Router types to overloaded `setState`** — breaks `Parameters<Router['setState']>` destructuring (TS only returns the last overload's params), forcing larger rewrites across the forwarders.
- **Cast the whole `store.setState` function reference** — requires `as unknown as` because the two signature shapes don't structurally overlap.

Settled on a one-token cast: `replace as false`. This picks v5's overload 1 (which accepts `Partial<T>`), satisfies TypeScript without runtime branching, and — since casts are erased at runtime — `true` still flows through correctly to v5's internal runtime which handles both replace modes. Affected sites: 3 router forwarders + 2 call sites inside `createQueryStore`'s `setWithEnabledHandling`.

### 4. `persist` middleware: `getStorage` removed
**v4:** `persist(initializer, { getStorage: () => stateStorage })` (`StateStorage` is string-based).
**v5:** `persist(initializer, { storage: createJSONStorage(() => stateStorage) })` (`PersistStorage<T>` is typed, JSON wrapper handles serialization).

Updated `src/state/internal/createStore.ts` to use `createJSONStorage`. The persist format on disk is identical between v4 and v5, so existing user data loads without migration.

### 5. `create(existingVanillaStore)` overload removed
In v4, `create` had an overload that wrapped an existing vanilla store API into a `UseBoundStore` — callable as a React hook AND carrying `.getState()` / `.setState()` / `.subscribe()` statics. v5 removed that overload; the replacement is `useStore(vanillaStore, selector)`.

`src/state/legacyFavoriteDapps/index.ts` had:
```ts
export const useLegacyFavoriteDappsStore = create(legacyFavoriteDappsStore);
```

The `use*` prefix was misleading — grep confirmed the only callers (`src/model/migrations.ts` lines 661 and 669) only use `.getState()` and `.setState()`, never invoke it as a hook. Dropped the alias export entirely; migrations.ts now imports `legacyFavoriteDappsStore` directly from the same module. Behavior is identical; the export shape is just honest about what's there (a vanilla store API, not a hook). The store itself stays because migration v20 still reads from it to port pre-v20 favorites into the new store.

### 6. Skipped test fixed as a side effect
`src/state/browser/favoriteDappsStore.test.ts:7` called `useFavoriteDappsStore.setState({ favoriteDapps: [] }, true)`. That `replace: true` was a **latent bug** that v5's stricter types surfaced: `FavoriteDappsStore` holds `favoriteDapps` plus six action methods (`addFavorite`, `removeFavorite`, etc.) on the same state object. Replacing with `{ favoriteDapps: [] }` would have wiped all six methods and broken the next `addFavorite(…)` call inside the test. The test is `describe.skip`, so nothing hits it at runtime, but the fix (drop `, true` — `replace` defaults to `false` / merge in both v4 and v5) is what "reset before each test" actually wants. Whoever un-skips the test next gets a working starting point.

## Screen recordings / screenshots

_N/A — no visual or behavioral changes._

## What to test

- [x] App launches cleanly on iOS and Android.
- [x] Browse NFTs, user assets across wallet switches (covers the NFTs / openCollections / userAssets router forwarders, including the `setState` cast path).
- [x] Open browser tab, add/remove a dapp from favorites (exercises `useFavoriteDappsStore`, which is `createWithEqualityFn`-backed).
- [x] Swap flow (`useSyncedSwapQuoteStore` plus many `createQueryStore`-based data stores).
- [x] Verify only one `zustand@npm:5.0.10` entry in `yarn.lock` (confirms dedupe with `@storesjs/stores`).
