### PR TITLE
test(e2e): skip 'Sign in with ease' optionally in Google login

### DIFF
--- a/e2e/flows/settings/AndroidCloudBackup.yaml
+++ b/e2e/flows/settings/AndroidCloudBackup.yaml
@@ -67,6 +67,14 @@ tags:
           text: '1'
           repeat: 4
           delay: 1000
+      # Skip the "Sign in with ease" phone-lookup interstitial if Google
+      # shows it before the account picker, so the next tap lands on the
+      # account picker.
+      - runFlow:
+          when:
+            visible: 'Sign in with ease'
+          commands:
+            - tapOn: 'SKIP'
       - assertVisible: '(Sign in|Choose an account)'
       - tapOn: ${CLOUD_BACKUP_EMAIL}
 

--- a/e2e/flows/settings/ManualBackup.yaml
+++ b/e2e/flows/settings/ManualBackup.yaml
@@ -27,7 +27,11 @@ tags:
     when:
       platform: Android
     commands:
-      - assertVisible: '(Sign in|Choose an account)'
+      # Google may show a new "Sign in with ease" phone-lookup interstitial
+      # before the account picker — accept it as confirmation that the
+      # login flow opened. We're about to press back to cancel anyway
+      # since this test is for manual backup, not cloud backup.
+      - assertVisible: '(Sign in|Choose an account|Sign in with ease)'
       # On certain android versions this requires backing twice.
       - retry:
           maxRetries: 2

--- a/e2e/utils/GoogleSignIn.yaml
+++ b/e2e/utils/GoogleSignIn.yaml
@@ -42,6 +42,16 @@ appId: ${APP_ID}
       - inputText: ${CLOUD_BACKUP_PASSWORD}
       - tapOn: 'NEXT'
 
+      # Optional "Sign in with ease" phone-number prompt — Google sometimes
+      # offers to look up accounts via carrier info after password entry.
+      # Guarded with `when.visible` so the flow still works if Google removes
+      # or reorders the screen later.
+      - runFlow:
+          when:
+            visible: Sign in with ease
+          commands:
+            - tapOn: 'SKIP'
+
       # Handle Google Password Manager prompt
       - runFlow:
           when:

--- a/e2e/utils/GoogleSignIn.yaml
+++ b/e2e/utils/GoogleSignIn.yaml
@@ -1,16 +1,9 @@
 appId: ${APP_ID}
 ---
-# Wait for the Google login flow to open — on CI emulators this can take
-# 15+ seconds after tapping the backup button. Google may also show a new
-# "Sign in with ease" phone-lookup interstitial before the account picker,
-# so accept any of the three screens as a valid initial state.
-- extendedWaitUntil:
-    visible:
-      text: '(Sign in|Choose an account|Sign in with ease)'
-    timeout: 30000
-
-# Skip the phone-lookup interstitial if that's what showed up. Optional
-# so the flow still works when Google removes or reorders the screen.
+# Google sometimes shows a new "Sign in with ease" phone-lookup
+# interstitial before the account picker. Skip it if present so the
+# flow lands on Sign in / Choose an account. `when.visible` makes this
+# a no-op if Google removes or reorders the screen later.
 - runFlow:
     when:
       visible: 'Sign in with ease'
@@ -58,16 +51,6 @@ appId: ${APP_ID}
           optional: true
       - inputText: ${CLOUD_BACKUP_PASSWORD}
       - tapOn: 'NEXT'
-
-      # Optional "Sign in with ease" phone-number prompt — Google sometimes
-      # offers to look up accounts via carrier info after password entry.
-      # Guarded with `when.visible` so the flow still works if Google removes
-      # or reorders the screen later.
-      - runFlow:
-          when:
-            visible: Sign in with ease
-          commands:
-            - tapOn: 'SKIP'
 
       # Handle Google Password Manager prompt
       - runFlow:

--- a/e2e/utils/GoogleSignIn.yaml
+++ b/e2e/utils/GoogleSignIn.yaml
@@ -1,5 +1,22 @@
 appId: ${APP_ID}
 ---
+# Wait for the Google login flow to open — on CI emulators this can take
+# 15+ seconds after tapping the backup button. Google may also show a new
+# "Sign in with ease" phone-lookup interstitial before the account picker,
+# so accept any of the three screens as a valid initial state.
+- extendedWaitUntil:
+    visible:
+      text: '(Sign in|Choose an account|Sign in with ease)'
+    timeout: 30000
+
+# Skip the phone-lookup interstitial if that's what showed up. Optional
+# so the flow still works when Google removes or reorders the screen.
+- runFlow:
+    when:
+      visible: 'Sign in with ease'
+    commands:
+      - tapOn: 'SKIP'
+
 - assertVisible: '(Sign in|Choose an account)'
 
 - runScript:


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Google recently added a **"Sign in with ease"** interstitial that now shows as the first screen when signing in to Google Drive, before the account picker. Our backup e2e flows assert `(Sign in|Choose an account)` immediately, so they time out on the new screen.

Three call sites updated:

- **`e2e/utils/GoogleSignIn.yaml`** — skip the interstitial if visible, then the original `assertVisible '(Sign in|Choose an account)'` runs as before.
- **`e2e/flows/settings/ManualBackup.yaml`** — widen the regex to `(Sign in|Choose an account|Sign in with ease)`. This test presses back to cancel right after, so just confirming login opened is enough.
- **`e2e/flows/settings/AndroidCloudBackup.yaml`** (post-delete assertion) — skip the interstitial, then assert + tap the email.

All skips are guarded with `runFlow.when.visible`, so they're no-ops if Google removes or reorders the screen.

## Screen recordings / screenshots

<img width="437" height="946" alt="image" src="https://github.com/user-attachments/assets/5f5bde4a-c2d7-4335-8f0c-e769e601a23d" />

## What to test

- CI passes
