### PR TITLE
fix(postinstall): surface prebuild hook errors in CI logs

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -86,7 +86,7 @@ fi
 
 if [ -n "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK" ]; then
   if [ -n "$CI" ]; then
-    bash -c "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK" > /dev/null 2>&1;
+    bash -c "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK" > /dev/null;
   else
     if bash -c "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK"; then
       echo "✅ executed ios prebuild hook"
@@ -98,7 +98,7 @@ fi
 
 if [ -n "$RAINBOW_SCRIPTS_APP_ANDROID_PREBUILD_HOOK" ]; then
   if [ -n "$CI" ]; then
-    bash -c "$RAINBOW_SCRIPTS_APP_ANDROID_PREBUILD_HOOK" > /dev/null 2>&1;
+    bash -c "$RAINBOW_SCRIPTS_APP_ANDROID_PREBUILD_HOOK" > /dev/null;
   else
     if bash -c "$RAINBOW_SCRIPTS_APP_ANDROID_PREBUILD_HOOK"; then
       echo "✅ executed android prebuild hook"


### PR DESCRIPTION
The CI branch of `scripts/postinstall.sh` currently redirects both stdout and stderr of the iOS and Android prebuild hooks to `/dev/null`. `set -eo pipefail` still fails `yarn install` if a hook exits non-zero, but the only signal in the log is the exit code. Whatever error message the hook printed is lost. That's fine while hooks only do file writes and git pulls, but rainbow-me/rainbow-scripts/pull/219 adds a `.xcode-version` drift check that prints a `FATAL:` message on mismatch, and without this change we would see "yarn install failed" in CI with no hint that the real cause is an Xcode version mismatch.

This change keeps stdout silenced (it's chatty on green runs) but lets stderr flow through. Hook error messages should now surface in CI logs without drowning out successful output.