### PR TITLE
ci: drop custom simulator boot-wait loop for iOS e2e

### DIFF
--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -169,21 +169,7 @@ jobs:
         with:
           model: 'iPhone 16'
           os_version: '18.5'
-
-      - name: Ensure Simulator is fully booted
-        run: |
-          echo "Waiting for simulator to be fully booted..."
-          timeout=0
-          while [[ "$(xcrun simctl list | grep "${{ steps.simulator.outputs.udid }}" | grep -o 'Booted')" != "Booted" ]]; do
-            sleep 5
-            timeout=$((timeout+5))
-            echo "Still waiting... ($timeout seconds)"
-            if [ $timeout -ge 120 ]; then
-              echo "Timed out waiting for simulator"
-              exit 1
-            fi
-          done
-          echo "Simulator is ready."
+          wait_for_boot: true
 
       - name: Run Tests
         run: ./scripts/e2e-ios-ci.sh

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -164,7 +164,7 @@ jobs:
           APP_PATH=$(find downloaded-artifacts -name "*.app" -type d | head -n 1)
           echo "ARTIFACT_PATH_FOR_E2E=$APP_PATH" >> $GITHUB_ENV
 
-      - uses: futureware-tech/simulator-action@dab10d813144ef59b48d401cd95da151222ef8cd
+      - uses: futureware-tech/simulator-action@e89aa8f93d3aec35083ff49d2854d07f7186f7f5 # v5
         id: simulator
         with:
           model: 'iPhone 16'

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -170,6 +170,7 @@ jobs:
           model: 'iPhone 16'
           os_version: '18.5'
           wait_for_boot: true
+          boot_timeout_seconds: 180
 
       - name: Run Tests
         run: ./scripts/e2e-ios-ci.sh


### PR DESCRIPTION
The `Ensure Simulator is fully booted` step in `ios-e2e.yml` polls `xcrun simctl list | grep "Booted"` with a 120-second timeout. The `simulator-action` that creates the simulator already supports a `wait_for_boot: true` input that uses Apple's `simctl bootstatus` internally, which is the supported mechanism for detecting simulator readiness. The custom loop was added in #6713 (Aug 2025) during the GH Actions migration with no documented rationale; presumably the action's native wait was simply overlooked at the time.

We noticed the grep-based detection is fragile while working on the iOS 26 SDK migration. An iOS 26.4 simulator booted in ~36 seconds, yet our custom loop timed out at 120s because the `grep 'Booted'` pattern didn't match reliably during the boot transition. Swapping to the action's native wait fixed it cleanly in that context.

This change backports the combined swap to develop's current iPhone 16 / iOS 18.5 setup. Behavior should be equivalent on green runs and more robust on slow boots.

@janicduplessis pointed out on this PR that the built-in wait has historically been flaky: `simctl bootstatus` sometimes returns while the simulator isn't actually ready, or hangs outright. We actually observed that hang pattern on one shard here. To combat this the change also bumps the simulator-action from v4 to v5, which addresses this exact class of flake. v5 ships `boot_timeout_seconds: 360` and `boot_retries: 2` as defaults (see [#563](https://github.com/futureware-tech/simulator-action/pull/563)), so a hung `bootstatus` call now bails after 6 minutes and retries up to twice before failing the step. No explicit config needed on our side.

Ref FEPLAT-81.