### PR TITLE
chore: include .xcode-version in rock build fingerprint

### DIFF
--- a/rock.config.mjs
+++ b/rock.config.mjs
@@ -16,6 +16,6 @@ export default {
   },
   remoteCacheProvider: 'github-actions',
   fingerprint: {
-    extraSources: ['is_testing'],
+    extraSources: ['is_testing', '.xcode-version'],
   },
 };


### PR DESCRIPTION
Rock's remote cache keys iOS artifacts by a native-fingerprint hash of iOS state (Podfile, pbxproj, patches, etc.). `.xcode-version` which we added recently isn't part of that hash, so changing the pinned Xcode without touching any native file produces the same fingerprint as the previous pin. Rock sees a cache hit, downloads the pre-existing artifact (which was compiled against the old Xcode), and re-signs it with the current JS bundle. The resulting IPA looks like a fresh build but was compiled with the wrong toolchain. We hit this during iOS 26 SDK migration work: PR builds meant to exercise Xcode 26.3 were being served as re-signed Xcode 16.4 artifacts from a 3-day-old sibling branch.

This change adds `.xcode-version` to Rock's `fingerprint.extraSources` so any change to the pinned Xcode immediately invalidates matching cached artifacts and forces a fresh compile. 

This is also a sequencing prerequisite for the iOS 26 SDK migration. The upcoming Xcode 26.3 bump can't land on develop without this first. If it did, develop PRs would cache-hit on stale 16.4 artifacts and appear to "work" while running the wrong toolchain.

Ref FEPLAT-81.