### PR TITLE
feat: integrate ENS Referral Program into registration and renewal flow

### DIFF
--- a/src/features/ens/references/ens-referral-abis.ts
+++ b/src/features/ens/references/ens-referral-abis.ts
@@ -1,0 +1,52 @@
+export const UNWRAPPED_REGISTRAR_ABI = [
+  {
+    name: 'register',
+    type: 'function',
+    inputs: [
+      { name: 'name', type: 'string' },
+      { name: 'owner', type: 'address' },
+      { name: 'duration', type: 'uint256' },
+      { name: 'secret', type: 'bytes32' },
+      { name: 'resolver', type: 'address' },
+      { name: 'data', type: 'bytes[]' },
+      { name: 'reverseRecord', type: 'bool' },
+      { name: 'ownerControlledFuses', type: 'uint16' },
+      { name: 'referrer', type: 'bytes32' },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    name: 'rentPrice',
+    type: 'function',
+    inputs: [
+      { name: 'name', type: 'string' },
+      { name: 'duration', type: 'uint256' },
+    ],
+    outputs: [
+      {
+        name: 'price',
+        type: 'tuple',
+        components: [
+          { name: 'base', type: 'uint256' },
+          { name: 'premium', type: 'uint256' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+] as const;
+
+export const UNIVERSAL_RENEWAL_ABI = [
+  {
+    name: 'renew',
+    type: 'function',
+    inputs: [
+      { name: 'label', type: 'string' },
+      { name: 'duration', type: 'uint256' },
+      { name: 'referrer', type: 'bytes32' },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+] as const;

--- a/src/features/ens/references/ens-referral.ts
+++ b/src/features/ens/references/ens-referral.ts
@@ -1,0 +1,23 @@
+export const ENS_REFERRAL_CONTRACTS = {
+  mainnet: {
+    unwrappedRegistrarController:
+      '0x59e16fccd424cc24e280be16e11bcd56fb0ce547',
+    universalRenewalWithReferrer:
+      '0xf55575Bde5953ee4272d5CE7cdD924c74d8fA81A',
+  },
+  sepolia: {
+    unwrappedRegistrarController:
+      '0xfb3ce5d01e0f33f41dbb39035db9745962f1f968',
+    universalRenewalWithReferrer:
+      '0x7AB2947592C280542e680Ba8f08A589009da8644',
+  },
+} as const;
+
+const RAINBOW_REFERRER_ADDRESS = '0xYourRainbowAddressHere'; // TODO: set before merging
+
+export function encodeReferrer(address: string = RAINBOW_REFERRER_ADDRESS): `0x${string}` {
+  const stripped = address.replace(/^0x/, '').toLowerCase().padStart(40, '0');
+  return `0x${'00'.repeat(12)}${stripped}` as `0x${string}`;
+}
+
+export const RAINBOW_REFERRER = encodeReferrer();

--- a/src/features/ens/utils/helpers.ts
+++ b/src/features/ens/utils/helpers.ts
@@ -37,6 +37,8 @@ import {
   ensReverseRegistrarAddress,
 } from '../references';
 import type { ENSRegistrationRecords } from '../types/registration';
+import { ENS_REFERRAL_CONTRACTS, RAINBOW_REFERRER } from '../references/ens-referral';
+import { UNWRAPPED_REGISTRAR_ABI, UNIVERSAL_RENEWAL_ABI } from '../references/ens-referral-abis';
 
 export const ENS_SECONDS_WAIT = 60;
 export const ENS_SECONDS_PADDING = 5;
@@ -538,15 +540,20 @@ const getENSExecutionDetails = async ({
     case ENSRegistrationTransactionType.REGISTER_WITH_CONFIG: {
       if (!name || !ownerAddress || !duration || !rentPrice) throw new Error('Bad arguments for registerWithConfig');
       value = toHex(addBuffer(rentPrice, 1.1));
-      args = [name.replace(ENS_DOMAIN, ''), ownerAddress, duration, salt, ensPublicResolverAddress, ownerAddress];
+      args = [name.replace(ENS_DOMAIN, ''), ownerAddress, duration, salt, ensPublicResolverAddress, ownerAddress, RAINBOW_REFERRER];
       contract = await getENSRegistrarControllerContract(wallet);
       break;
     }
-    case ENSRegistrationTransactionType.RENEW: {
+   case ENSRegistrationTransactionType.RENEW: {
       if (!name || !duration || !rentPrice) throw new Error('Bad arguments for renew');
+      const signerOrProvider = wallet || (await getProvider({ chainId: ChainId.mainnet }));
       value = toHex(addBuffer(rentPrice, 1.1));
-      args = [name.replace(ENS_DOMAIN, ''), duration];
-      contract = await getENSRegistrarControllerContract(wallet);
+      args = [name.replace(ENS_DOMAIN, ''), duration, RAINBOW_REFERRER];
+      contract = new Contract(
+      ENS_REFERRAL_CONTRACTS.mainnet.universalRenewalWithReferrer,
+      UNIVERSAL_RENEWAL_ABI,
+      signerOrProvider
+      );
       break;
     }
     case ENSRegistrationTransactionType.SET_NAME:


### PR DESCRIPTION

## Summary

This PR adds support for the [ENS Referral Program](https://ensawards.org/ens-referral-program) into Rainbow's existing native `.eth` name registration and renewal flow.

Rainbow already has one of the best native ENS registration experiences of any wallet, so the changes required here are deliberately minimal — primarily routing registration and renewal transactions through the program's referral-aware contracts instead of calling the standard ENS controllers directly, and appending a `referrer` parameter encoded with Rainbow's wallet address.

The ENS Referral Program distributes up to 50% revenue share to referrers whose referred registrations and renewals are tracked onchain. The upcoming edition beginning May 2026 is the program's largest yet. This PR will essentially transform an existing capability in Rainbow Wallet into a revenue-generating feature.

---

## Background: How the ENS Referral Program works

The program tracks onchain referrals at the smart contract level. Instead of calling the standard `ETHRegistrarController` or `WrappedEthRegistrarController` directly, integrators route calls through two referral-aware contracts deployed and maintained by NameHash Labs:

| Purpose | Contract | Mainnet |
|---|---|---|
| New registrations + renewals (unwrapped names) | `UnwrappedEthRegistrarController` | [`0x59e16f...`](https://etherscan.io/address/0x59e16fccd424cc24e280be16e11bcd56fb0ce547) |
| Renewals (wrapped and unwrapped names, recommended) | `UniversalRegistrarRenewalWithReferrer` | [`0xf55575...`](https://etherscan.io/address/0xf55575Bde5953ee4272d5CE7cdD924c74d8fA81A) |

The `renew()` ABI on both contracts is identical to the standard ENS controller, with one additional parameter:

```solidity
function renew(string calldata label, uint256 duration, bytes32 referrer) external payable
```

The `referrer` value is a `bytes32` where the first 12 bytes are zero-padded and the last 20 bytes are Rainbow's Ethereum address (the address where award distributions will be sent). A utility for encoding this is available in the [ENSNode SDK](https://github.com/namehash/ensnode/blob/main/packages/ensnode-sdk/src/registrars/encoded-referrer.ts).

> **Note on the `UniversalRegistrarRenewalWithReferrer` contract for renewals:** The standard `ETHRegistrarController.renew()` has a known bug where renewing a wrapped name causes the expiration date to go out of sync between `BaseRegistrar` and `NameWrapper`. The `UniversalRegistrarRenewalWithReferrer` contract was built in coordination with ENS Labs specifically to handle this correctly regardless of whether a name is wrapped or unwrapped. This PR uses it for all renewals.

---

## Changes

### 1. New constants file: `src/features/ens/references/ens-referral.ts`

Adds contract addresses and the encoded referrer value for Rainbow.

```ts
export const ENS_REFERRAL_CONTRACTS = {
  mainnet: {
    unwrappedRegistrarController:
      '0x59e16fccd424cc24e280be16e11bcd56fb0ce547',
    universalRenewalWithReferrer:
      '0xf55575Bde5953ee4272d5CE7cdD924c74d8fA81A',
  },
  sepolia: {
    unwrappedRegistrarController:
      '0xfb3ce5d01e0f33f41dbb39035db9745962f1f968',
    universalRenewalWithReferrer:
      '0x7AB2947592C280542e680Ba8f08A589009da8644',
  },
} as const;

const RAINBOW_REFERRER_ADDRESS = '0xYourRainbowAddressHere'; // TODO: set before merging

export function encodeReferrer(address: string = RAINBOW_REFERRER_ADDRESS): `0x${string}` {
  const stripped = address.replace(/^0x/, '').toLowerCase().padStart(40, '0');
  return `0x${'00'.repeat(12)}${stripped}` as `0x${string}`;
}

export const RAINBOW_REFERRER = encodeReferrer();
```

### 2. New ABI file: `src/features/ens/references/ens-referral-abis.ts`

Adds minimal ABI fragments for the two referral contracts.

```ts
export const UNWRAPPED_REGISTRAR_ABI = [
  {
    name: 'register',
    type: 'function',
    inputs: [
      { name: 'name', type: 'string' },
      { name: 'owner', type: 'address' },
      { name: 'duration', type: 'uint256' },
      { name: 'secret', type: 'bytes32' },
      { name: 'resolver', type: 'address' },
      { name: 'data', type: 'bytes[]' },
      { name: 'reverseRecord', type: 'bool' },
      { name: 'ownerControlledFuses', type: 'uint16' },
      { name: 'referrer', type: 'bytes32' },
    ],
    outputs: [],
    stateMutability: 'payable',
  },
  {
    name: 'rentPrice',
    type: 'function',
    inputs: [
      { name: 'name', type: 'string' },
      { name: 'duration', type: 'uint256' },
    ],
    outputs: [
      {
        name: 'price',
        type: 'tuple',
        components: [
          { name: 'base', type: 'uint256' },
          { name: 'premium', type: 'uint256' },
        ],
      },
    ],
    stateMutability: 'view',
  },
] as const;

export const UNIVERSAL_RENEWAL_ABI = [
  {
    name: 'renew',
    type: 'function',
    inputs: [
      { name: 'label', type: 'string' },
      { name: 'duration', type: 'uint256' },
      { name: 'referrer', type: 'bytes32' },
    ],
    outputs: [],
    stateMutability: 'payable',
  },
] as const;
```

### 3. Updated `src/features/ens/utils/helpers.ts`

Two new imports added at the top of the file:

```ts
import { ENS_REFERRAL_CONTRACTS, RAINBOW_REFERRER } from '../references/ens-referral';
import { UNWRAPPED_REGISTRAR_ABI, UNIVERSAL_RENEWAL_ABI } from '../references/ens-referral-abis';
```

Two changes inside `getENSExecutionDetails`:

**Registration** — `RAINBOW_REFERRER` appended to args in the `REGISTER_WITH_CONFIG` case:

```ts
args = [name.replace(ENS_DOMAIN, ''), ownerAddress, duration, salt, ensPublicResolverAddress, ownerAddress, RAINBOW_REFERRER];
```

**Renewal** — `RAINBOW_REFERRER` appended to args and contract swapped to `UniversalRegistrarRenewalWithReferrer` in the `RENEW` case:

```ts
case ENSRegistrationTransactionType.RENEW: {
  if (!name || !duration || !rentPrice) throw new Error('Bad arguments for renew');
  const signerOrProvider = wallet || (await getProvider({ chainId: ChainId.mainnet }));
  value = toHex(addBuffer(rentPrice, 1.1));
  args = [name.replace(ENS_DOMAIN, ''), duration, RAINBOW_REFERRER];
  contract = new Contract(
    ENS_REFERRAL_CONTRACTS.mainnet.universalRenewalWithReferrer,
    UNIVERSAL_RENEWAL_ABI,
    signerOrProvider
  );
  break;
}
```

---

## Testing

- [ ] Confirm registration flow on Sepolia using `ENS_REFERRAL_CONTRACTS.sepolia.unwrappedRegistrarController` — verify `NameRegistered` event is emitted and referral is tracked
- [ ] Confirm renewal flow on Sepolia using `ENS_REFERRAL_CONTRACTS.sepolia.universalRenewalWithReferrer` — verify `RenewalReferred` event is emitted with correct `referrer` value
- [ ] Confirm wrapped name renewal does not produce expiry sync issues
- [ ] Verify ENS Referral Program leaderboard at `https://ensawards.org/ens-referral-program/editions/2026-05/leaderboard` reflects referred transactions

> Note: Award distributions are only made on Ethereum Mainnet, not Sepolia. Sepolia testing is purely for functional verification.

---

## No user-facing changes

The registration and renewal UX in the app is unchanged. The only difference is that transactions are routed through the referral-aware contracts onchain — invisible to the end user, but earning Rainbow award distributions for every `.eth` name registered or renewed through the app.

---

## References

- [ENS Referral Program](https://ensawards.org/ens-referral-program)
- [Developer Resources repo (namehash/ens-referrals)](https://github.com/namehash/ens-referrals)
- [UnwrappedEthRegistrarController on Etherscan](https://etherscan.io/address/0x59e16fccd424cc24e280be16e11bcd56fb0ce547)
- [UniversalRegistrarRenewalWithReferrer on Etherscan](https://etherscan.io/address/0xf55575Bde5953ee4272d5CE7cdD924c74d8fA81A)
- [ENSNode SDK — encoded-referrer utility](https://github.com/namehash/ensnode/blob/main/packages/ensnode-sdk/src/registrars/encoded-referrer.ts)
- [April 2026 edition leaderboard](https://ensawards.org/ens-referral-program/editions/2026-04/leaderboard)