### PR TITLE
chore(analytics): instrument identify calls to diagnose missing traits

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,7 +173,7 @@ async function initializeApplication() {
   // Paired probe event. Lets us distinguish "identify trait dropped by pipeline"
   // from "whole session too short to flush" by comparing track delivery to
   // user-property delivery in Amplitude. Remove after FEPLAT-67 wraps up.
-  analytics.track(analytics.event.debugIdentifyProbe, { probe: 'installSource', value: DANGER_INSTALL_SOURCE });
+  analytics.track(analytics.event.debugIdentifyProbe, { probe: 'installSource', value: String(DANGER_INSTALL_SOURCE) });
 
   await Promise.all([
     initializeRemoteConfig(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,10 @@ async function initializeApplication() {
   Sentry.setUser({ id: deviceId });
   analytics.init({ deviceId });
   analytics.identify({ installSource: DANGER_INSTALL_SOURCE });
+  // Paired probe event. Lets us distinguish "identify trait dropped by pipeline"
+  // from "whole session too short to flush" by comparing track delivery to
+  // user-property delivery in Amplitude. Remove after FEPLAT-67 wraps up.
+  analytics.track(analytics.event.debugIdentifyProbe, { probe: 'installSource', value: DANGER_INSTALL_SOURCE });
 
   await Promise.all([
     initializeRemoteConfig(),

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -76,6 +76,7 @@ export const event = {
   appStateChange: 'State change',
   analyticsTrackingDisabled: 'analytics_tracking.disabled',
   analyticsTrackingEnabled: 'analytics_tracking.enabled',
+  debugIdentifyProbe: 'debug.identify_probe',
   swapSubmitted: 'Submitted Swap',
   cardPressed: 'card.pressed',
   learnArticleOpened: 'learn_article.opened',
@@ -404,6 +405,10 @@ export type EventProperties = {
   };
   [event.analyticsTrackingDisabled]: undefined;
   [event.analyticsTrackingEnabled]: undefined;
+  [event.debugIdentifyProbe]: {
+    probe: 'installSource' | 'currency';
+    value: string;
+  };
   [event.swapSubmitted]: {
     usdValue: number;
     inputCurrencySymbol: string;

--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -116,7 +116,7 @@ export const settingsLoadState =
       });
       // Paired probe. Companion to the installSource probe in App.tsx; see
       // event.debugIdentifyProbe for rationale. Remove after FEPLAT-67 wraps up.
-      analytics.track(analytics.event.debugIdentifyProbe, { probe: 'currency', value: nativeCurrency });
+      analytics.track(analytics.event.debugIdentifyProbe, { probe: 'currency', value: String(nativeCurrency) });
 
       dispatch({
         payload: { nativeCurrency, testnetsEnabled },

--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -114,6 +114,9 @@ export const settingsLoadState =
         currency: nativeCurrency,
         enabledTestnets: testnetsEnabled,
       });
+      // Paired probe. Companion to the installSource probe in App.tsx; see
+      // event.debugIdentifyProbe for rationale. Remove after FEPLAT-67 wraps up.
+      analytics.track(analytics.event.debugIdentifyProbe, { probe: 'currency', value: nativeCurrency });
 
       dispatch({
         payload: { nativeCurrency, testnetsEnabled },


### PR DESCRIPTION
We're seeing some weird analytics data on the recently added `installSource` property. A meaningful fraction of new users on v2.0.20+ show `(none)` for `gp:installSource` in Amplitude (roughly 54% in April 2026) even though it shouldn't technically be possible to have none set as the value is computed at module load time and sent to Amplitude unconditionally in the app startup. The obvious explanations don't account for it: 
* Sentry shows zero `identify called before deviceId set` warnings on v2.0.20+ (so the #7207 fix is working)
* no `AppInstallInfo` native crashes
* no Rudderstack `client.setup()` rejections
* And it's not pure session-length pressure either. 79% of the `(none)`-installSource cohort have `gp:currency` set from the same sessions, meaning the pipeline works for them on other traits. 397 high-engagement new users with 100+ events each show the same pattern: currency lands, installSource doesn't.

Two candidate explanations remain that the app can't distinguish in its current state:
* Either Rudderstack's Amplitude destination is selectively dropping identify traits (there's an unfixed race in `rudder-sdk-ios` v1.31.1 matching this fingerprint, documented in rudderlabs/rudder-sdk-ios#422 which never merged to the stable v1.x line), or
* an upstream batching pattern silently drops the first identify of a session in a way that happens to hit installSource specifically because it's the first call. 

Picking the right mitigation depends on which.

This change fires a `debug.identify_probe` track event alongside each of the two `identify()` calls we care about. Track events and identify traits transit the same SDK, same native DB, same Rudderstack data plane, but land in different Amplitude datasets via different destination transforms, so comparing delivery rates across the same users isolates the failure layer. If the probe lands but the identify trait doesn't, the drop is identify-specific. If both miss together, it's session-level. One release cycle of data should resolve which.

The probe is intended as temporary diagnostic tooling and should be removed once the investigation concludes.

Ref FEPLAT-67.