### PR TITLE
feat: set Polymarket referrer inside dapp browser

### DIFF
--- a/src/components/DappBrowser/BrowserContext.tsx
+++ b/src/components/DappBrowser/BrowserContext.tsx
@@ -19,6 +19,7 @@ import { useBrowserStore } from '@/state/browser/browserStore';
 import { useNavigationStore } from '@/state/navigation/navigationStore';
 
 import { RAINBOW_HOME } from './constants';
+import { addReferralToDappBrowserUrl } from './dappReferrals';
 import { EXTRA_WEBVIEW_HEIGHT } from './Dimensions';
 import { useGestureManager } from './hooks/useGestureManager';
 import {
@@ -160,9 +161,10 @@ export const BrowserContextProvider = ({ children }: { children: React.ReactNode
   }, [activeTabRef]);
 
   const goToUrl = useCallback(
-    (url: string, tabId?: string) => {
+    (originalUrl: string, tabId?: string) => {
       const { url: activeTabUrl } = activeTabInfo.value;
       const tabIdToUse = tabId || activeTabId.value;
+      const url = addReferralToDappBrowserUrl(originalUrl);
 
       if (normalizeUrlWorklet(url) === normalizeUrlWorklet(activeTabUrl)) {
         refreshPage();

--- a/src/components/DappBrowser/DappBrowser.tsx
+++ b/src/components/DappBrowser/DappBrowser.tsx
@@ -27,6 +27,7 @@ import {
   TAB_VIEW_BACKGROUND_COLOR_DARK,
   TAB_VIEW_BACKGROUND_COLOR_LIGHT,
 } from './constants';
+import { addReferralToDappBrowserUrl } from './dappReferrals';
 import { useBrowserScrollView } from './hooks/useBrowserScrollView';
 import { useScreenshotAndScrollTriggers } from './hooks/useScreenshotAndScrollTriggers';
 import { ProgressBar } from './ProgressBar';
@@ -74,7 +75,7 @@ const NewTabTrigger = () => {
   const { newTabWorklet } = useBrowserWorkletsContext();
 
   const route = useRoute<RouteProp<RootStackParamList, typeof Routes.DAPP_BROWSER_SCREEN>>();
-  const newTabUrl = route.params?.url;
+  const newTabUrl = route.params?.url ? addReferralToDappBrowserUrl(route.params.url) : undefined;
 
   useAnimatedReaction(
     () => newTabUrl,

--- a/src/components/DappBrowser/dappReferrals.test.ts
+++ b/src/components/DappBrowser/dappReferrals.test.ts
@@ -1,0 +1,24 @@
+import { addReferralToDappBrowserUrl } from '@/components/DappBrowser/dappReferrals';
+
+// Unfortunately @/features/polymarket/constants has some imports, so we need to mock it
+jest.mock('@/features/polymarket/constants', () => ({
+  POLYMARKET_HOSTNAMES: new Set(['polymarket.com', 'www.polymarket.com']),
+  POLYMARKET_REFERRAL_CODE: 'referrals',
+  POLYMARKET_REFERRAL_PARAM: 'r',
+}));
+
+describe('dappReferrals', () => {
+  it('returns the referral URL when a browser referral applies', () => {
+    expect(addReferralToDappBrowserUrl('https://polymarket.com/event/some-market')).toBe(
+      'https://polymarket.com/event/some-market?r=referrals'
+    );
+  });
+
+  it('returns the original URL when no browser referral applies', () => {
+    expect(addReferralToDappBrowserUrl('https://example.com/somewhere')).toBe('https://example.com/somewhere');
+  });
+
+  it('returns the original URL when a browser referral already exists', () => {
+    expect(addReferralToDappBrowserUrl('https://www.polymarket.com/?r=existing')).toBe('https://www.polymarket.com/?r=existing');
+  });
+});

--- a/src/components/DappBrowser/dappReferrals.ts
+++ b/src/components/DappBrowser/dappReferrals.ts
@@ -1,0 +1,22 @@
+import { POLYMARKET_HOSTNAMES } from '@/features/polymarket/constants';
+import { getPolymarketReferralUrl } from '@/features/polymarket/utils/polymarketReferralUrl';
+import { getDappHostname } from '@/utils/connectedApps';
+
+type DappReferral = {
+  getUrl: (url: string) => string | null;
+  hostnames: ReadonlySet<string>;
+};
+
+const DAPP_REFERRALS: DappReferral[] = [{ hostnames: POLYMARKET_HOSTNAMES, getUrl: getPolymarketReferralUrl }];
+
+export function addReferralToDappBrowserUrl(url: string): string {
+  const hostname = getDappHostname(url);
+  if (!hostname) return url;
+
+  const referral = DAPP_REFERRALS.find(({ hostnames }) => hostnames.has(hostname));
+  const referralUrl = referral?.getUrl(url);
+
+  if (!referral || !referralUrl) return url;
+
+  return referralUrl;
+}

--- a/src/components/DappBrowser/hooks/useWebViewHandlers.ts
+++ b/src/components/DappBrowser/hooks/useWebViewHandlers.ts
@@ -19,6 +19,7 @@ import { generateUniqueId } from '@/worklets/strings';
 
 import { useBrowserContext } from '../BrowserContext';
 import { useBrowserWorkletsContext } from '../BrowserWorkletsContext';
+import { addReferralToDappBrowserUrl } from '../dappReferrals';
 import { handleProviderRequestApp } from '../handleProviderRequest';
 import { type TabId } from '../types';
 import { isValidAppStoreUrl } from '../utils';
@@ -50,6 +51,7 @@ export function useWebViewHandlers({
   const { updateTabUrlWorklet } = useBrowserWorkletsContext();
 
   const currentMessengerRef = useRef<MessengerWithUrl | null>(null);
+  const dappReferralsAppliedRef = useRef(new Set<string>());
   const logoRef = useRef<string | null>(null);
 
   const getCurrentMessenger = useCallback(
@@ -138,6 +140,26 @@ export function useWebViewHandlers({
     [addRecent, backgroundColor, setLogo, setTitle, tabId, titleRef, getCurrentMessenger]
   );
 
+  const applyDappReferral = useCallback(
+    (url: string) => {
+      const dappHostname = getDappHostname(url);
+      if (!dappHostname || dappReferralsAppliedRef.current.has(dappHostname)) {
+        return false;
+      }
+
+      const referralUrl = addReferralToDappBrowserUrl(url);
+      if (referralUrl === url) {
+        return false;
+      }
+
+      dappReferralsAppliedRef.current.add(dappHostname);
+      useBrowserStore.getState().goToPage(referralUrl, tabId);
+      runOnUI(updateTabUrlWorklet)({ tabId, url: referralUrl });
+      return true;
+    },
+    [tabId, updateTabUrlWorklet]
+  );
+
   const handleShouldStartLoadWithRequest = useCallback(
     (request: ShouldStartLoadRequest) => {
       if (request.url.startsWith('rainbow://wc') || request.url.startsWith('https://rnbwappdotcom.app.link/')) {
@@ -145,9 +167,14 @@ export function useWebViewHandlers({
         activeTabRef.current?.reload();
         return false;
       }
+
+      if (request.isTopFrame && applyDappReferral(request.url)) {
+        return false;
+      }
+
       return true;
     },
-    [activeTabRef]
+    [activeTabRef, applyDappReferral]
   );
 
   const handleOnLoadProgress = useCallback(

--- a/src/features/polymarket/constants.ts
+++ b/src/features/polymarket/constants.ts
@@ -42,6 +42,9 @@ export const POLYMARKET_GAMMA_API_URL = 'https://gamma-api.polymarket.com';
 export const POLYMARKET_DATA_API_URL = 'https://data-api.polymarket.com';
 
 export const POLYMARKET_SPORTS_WS_URL = 'wss://sports-api.polymarket.com/ws';
+export const POLYMARKET_HOSTNAMES: ReadonlySet<string> = new Set(['polymarket.com', 'www.polymarket.com']);
+export const POLYMARKET_REFERRAL_PARAM = 'r';
+export const POLYMARKET_REFERRAL_CODE = 'referrals';
 
 export const POLYMARKET_BUILDER_CODE = '0xabce5abdc189cba6fb85edb9170e3e6e41607e946b06d112b7f87e2f2977020c';
 

--- a/src/features/polymarket/utils/polymarketReferralUrl.test.ts
+++ b/src/features/polymarket/utils/polymarketReferralUrl.test.ts
@@ -1,0 +1,31 @@
+import { getPolymarketReferralUrl } from '@/features/polymarket/utils/polymarketReferralUrl';
+
+// Unfortunately @/features/polymarket/constants has some imports, so we need to mock it
+jest.mock('@/features/polymarket/constants', () => ({
+  POLYMARKET_HOSTNAMES: new Set(['polymarket.com', 'www.polymarket.com']),
+  POLYMARKET_REFERRAL_CODE: 'referrals',
+  POLYMARKET_REFERRAL_PARAM: 'r',
+}));
+
+describe('getPolymarketReferralUrl', () => {
+  it('adds the Polymarket referral query param', () => {
+    expect(getPolymarketReferralUrl('https://polymarket.com/event/some-market?foo=bar#activity')).toBe(
+      'https://polymarket.com/event/some-market?foo=bar&r=referrals#activity'
+    );
+  });
+
+  it('does not replace an existing Polymarket referral query param', () => {
+    expect(getPolymarketReferralUrl('https://polymarket.com/?r=existing')).toBe('https://polymarket.com/?r=existing');
+  });
+
+  it('supports the www Polymarket hostname', () => {
+    expect(getPolymarketReferralUrl('https://www.polymarket.com/event/some-market')).toBe(
+      'https://www.polymarket.com/event/some-market?r=referrals'
+    );
+  });
+
+  it('ignores unrelated URLs and invalid input', () => {
+    expect(getPolymarketReferralUrl('https://example.com')).toBeNull();
+    expect(getPolymarketReferralUrl('not a url')).toBeNull();
+  });
+});

--- a/src/features/polymarket/utils/polymarketReferralUrl.ts
+++ b/src/features/polymarket/utils/polymarketReferralUrl.ts
@@ -1,0 +1,21 @@
+import { POLYMARKET_HOSTNAMES, POLYMARKET_REFERRAL_CODE, POLYMARKET_REFERRAL_PARAM } from '@/features/polymarket/constants';
+
+export function getPolymarketReferralUrl(url: string): string | null {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (!POLYMARKET_HOSTNAMES.has(parsedUrl.hostname)) {
+    return null;
+  }
+
+  if (!parsedUrl.searchParams.has(POLYMARKET_REFERRAL_PARAM)) {
+    parsedUrl.searchParams.set(POLYMARKET_REFERRAL_PARAM, POLYMARKET_REFERRAL_CODE);
+  }
+
+  return parsedUrl.toString();
+}


### PR DESCRIPTION
Partially fixes https://linear.app/rainbow/issue/APP-3658/add-polymarket-referral-code-to-mobile-app-mobile-dapp-browser-and-bx

## Why?

We want to add Polymarket attribution in the mobile dapp browser. The goal here is to make referral attribution reliable whenever the user lands on Polymarket, while avoiding repeated redirects or interference with embedded resource loads.

## Description

We now enforce a single referral-injection strategy across the three real entry cases that matter:

1. Alternate app/new-tab entry path  
When Polymarket is opened via route-driven tab creation (for example from another app surface/deep-link-like entry), the referral is applied before the first load so attribution is present immediately.
2. Direct browser navigation path  
When navigation goes through the browser’s normal URL routing flow, the same referral rule is applied consistently so manual/pasted/redirected navigations do not bypass attribution.
3. Cross-site navigation path (e.g. starting on Google)  
When a user reaches Polymarket from another site, we intercept only top-frame navigations, rewrite once with referral, and stop the original navigation so the referrer is not missed on first arrival.  
This keeps iframe/subresource traffic untouched and avoids referral re-application loops.

## What to test

- Log in on Polymarket from within dapp browser using a new fresh account
- Go to https://polymarket.com/settings?tab=profile and try to set referrer.
- Get error: "referral code already set on this profile"