### PR TITLE
fix(wallet): enforce EIP-55 on import and heal non-canonical persisted state

### DIFF
--- a/src/features/address/core/address.ts
+++ b/src/features/address/core/address.ts
@@ -1,0 +1,42 @@
+import { getAddress, isAddress, type Address } from 'viem';
+
+/**
+ * Strict EIP-55 validator for user-typed/pasted addresses.
+ *
+ * Accepts pure lowercase, pure uppercase, or canonical EIP-55 mixed case. Rejects mixed case with a bad
+ * checksum — that's the typo signal EIP-55 is designed to surface.
+ *
+ * Use at every user-input boundary (e.g. watch wallet, send recipient, scanner, paste, deeplinks). Catching
+ * bad-checksum input here is what protects users from silent typos.
+ */
+export function isValidAddress(input: string): input is Address {
+  return isAddress(input);
+}
+
+/**
+ * Lax shape check: returns true for any `0x` + 40 hex chars regardless of EIP-55 casing. Useful for
+ * branching on "the user pasted something that looks like an address but failed strict checksum" so we
+ * can show a specific error rather than falling through to a generic failure.
+ *
+ * Do NOT use as the gate for trusting an address.
+ */
+export function looksLikeAddress(input: string): boolean {
+  return isAddress(input, { strict: false });
+}
+
+/**
+ * Normalize a trusted-source address to canonical EIP-55 form.
+ *
+ * Use for storage rehydration, RPC responses, ENS resolution results, and any path where the bytes are
+ * trusted but the casing isn't guaranteed canonical. Returns null if the input isn't a valid address shape.
+ *
+ * Do NOT use for user input — lazy-normalizing a user-pasted address defeats EIP-55's typo protection.
+ * Use `isValidAddress` for input.
+ */
+export function normalizeAddress(input: string): Address | null {
+  try {
+    return getAddress(input.toLowerCase());
+  } catch {
+    return null;
+  }
+}

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -242,7 +242,7 @@ export default function useImportingWallet({
         // Not strictly valid EIP-55 address (due to `isValidAddress` falling through above), but could still be just a
         // case mismatch (checksum fail). If so, show guiding message to user.
         setBusy(false);
-        Alert.alert(i18n.t(i18n.l.wallet.invalid_address), i18n.t(i18n.l.wallet.invalid_address_checksum));
+        Alert.alert(i18n.t(i18n.l.wallet.invalid_address_title), i18n.t(i18n.l.wallet.invalid_address_message));
       } else {
         try {
           const walletResult = await deriveAccountFromWalletInput(input);

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -242,7 +242,7 @@ export default function useImportingWallet({
         // Not strictly valid EIP-55 address (due to `isValidAddress` falling through above), but could still be just a
         // case mismatch (checksum fail). If so, show guiding message to user.
         setBusy(false);
-        Alert.alert(i18n.t(i18n.l.wallet.invalid_address_checksum));
+        Alert.alert(i18n.t(i18n.l.wallet.invalid_address), i18n.t(i18n.l.wallet.invalid_address_checksum));
       } else {
         try {
           const walletResult = await deriveAccountFromWalletInput(input);

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { InteractionManager, Keyboard, type TextInput } from 'react-native';
 
-import { isValidAddress } from 'ethereumjs-util';
 import { keys } from 'lodash';
 import { useDispatch } from 'react-redux';
 
 import { analytics } from '@/analytics';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { IS_ANDROID, IS_TEST } from '@/env';
+import { isValidAddress, looksLikeAddress } from '@/features/address/core/address';
 import { fetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
 import { getProvider, isValidBluetoothDeviceId, resolveUnstoppableDomain } from '@/handlers/web3';
@@ -209,7 +209,7 @@ export default function useImportingWallet({
         }
       } else if (isValidAddress(input)) {
         let finalAvatarUrl: string | null | undefined = avatarUrl;
-        let ens = input;
+        let ens: string = input;
         try {
           ens = await fetchReverseRecord(input);
           if (ens && ens !== input) {
@@ -238,6 +238,11 @@ export default function useImportingWallet({
         }
 
         startImportProfile(name || '', forceColor, input, finalAvatarUrl);
+      } else if (looksLikeAddress(input)) {
+        // Not strictly valid EIP-55 address (due to `isValidAddress` falling through above), but could still be just a
+        // case mismatch (checksum fail). If so, show guiding message to user.
+        setBusy(false);
+        Alert.alert(i18n.t(i18n.l.wallet.invalid_address_checksum));
       } else {
         try {
           const walletResult = await deriveAccountFromWalletInput(input);

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3008,6 +3008,7 @@
         "warning": "This is alpha software.",
         "welcome": "Welcome to Rainbow"
       },
+      "invalid_address_checksum": "This address is invalid. Double-check the casing and try again.",
       "invalid_ens_name": "This is not a valid ENS name",
       "invalid_unstoppable_name": "This is not a valid Unstoppable name",
       "label": "Wallets",

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3008,8 +3008,8 @@
         "warning": "This is alpha software.",
         "welcome": "Welcome to Rainbow"
       },
-      "invalid_address": "Invalid address",
-      "invalid_address_checksum": "Double-check the casing and try again.",
+      "invalid_address_title": "Invalid address",
+      "invalid_address_message": "Double-check the casing and try again.",
       "invalid_ens_name": "This is not a valid ENS name",
       "invalid_unstoppable_name": "This is not a valid Unstoppable name",
       "label": "Wallets",

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3008,7 +3008,8 @@
         "warning": "This is alpha software.",
         "welcome": "Welcome to Rainbow"
       },
-      "invalid_address_checksum": "This address is invalid. Double-check the casing and try again.",
+      "invalid_address": "Invalid address",
+      "invalid_address_checksum": "Double-check the casing and try again.",
       "invalid_ens_name": "This is not a valid ENS name",
       "invalid_unstoppable_name": "This is not a valid Unstoppable name",
       "label": "Wallets",

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -3,6 +3,7 @@ import { InteractionManager } from 'react-native';
 import * as env from '@/env';
 import { logger, RainbowError } from '@/logger';
 import { deleteImgixMMKVCache } from '@/migrations/migrations/deleteImgixMMKVCache';
+import { healEip55KeychainAddresses } from '@/migrations/migrations/healEip55KeychainAddresses';
 import { migrateNotificationSettingsToV2 } from '@/migrations/migrations/migrateNotificationSettingsToV2';
 import { migrateNotificationSettingsToV3 } from '@/migrations/migrations/migrateNotificationSettingsToV3';
 import { prepareDefaultNotificationGroupSettingsState } from '@/migrations/migrations/prepareDefaultNotificationGroupSettingsState';
@@ -44,6 +45,7 @@ const migrations: Migration[] = [
   migrateFavoritesV2(),
   migrateFavoritesV3(),
   migrateNotificationSettingsToV3(),
+  healEip55KeychainAddresses(),
 ];
 
 /**

--- a/src/migrations/migrations/healEip55KeychainAddresses.ts
+++ b/src/migrations/migrations/healEip55KeychainAddresses.ts
@@ -1,0 +1,43 @@
+import { normalizeAddress } from '@/features/address/core/address';
+import { MigrationName, type Migration } from '@/migrations/types';
+import { getAllWallets, loadAddress, saveAddress, saveAllWallets } from '@/model/wallet';
+
+/**
+ * One-shot heal: canonicalize EIP-55 addresses persisted in keychain.
+ *
+ * The watched-wallet import flow previously accepted addresses without enforcing EIP-55 checksum,
+ * so non-canonical addresses could end up persisted as if they were valid (APP-3673). This
+ * migration canonicalizes any such entries so downstream consumers receive properly-formed
+ * addresses regardless of how the data originally got written.
+ */
+export function healEip55KeychainAddresses(): Migration {
+  return {
+    name: MigrationName.healEip55KeychainAddresses,
+    async migrate() {
+      const storedAddress = await loadAddress();
+      if (storedAddress) {
+        const normalized = normalizeAddress(storedAddress);
+        if (normalized && normalized !== storedAddress) {
+          await saveAddress(normalized);
+        }
+      }
+
+      const result = await getAllWallets();
+      if (result?.wallets) {
+        let changed = false;
+        for (const wallet of Object.values(result.wallets)) {
+          for (const account of wallet.addresses || []) {
+            const normalized = normalizeAddress(account.address);
+            if (normalized && normalized !== account.address) {
+              account.address = normalized;
+              changed = true;
+            }
+          }
+        }
+        if (changed) {
+          await saveAllWallets(result.wallets);
+        }
+      }
+    },
+  };
+}

--- a/src/migrations/migrations/healEip55KeychainAddresses.ts
+++ b/src/migrations/migrations/healEip55KeychainAddresses.ts
@@ -1,6 +1,6 @@
 import { normalizeAddress } from '@/features/address/core/address';
 import { MigrationName, type Migration } from '@/migrations/types';
-import { getAllWallets, loadAddress, saveAddress, saveAllWallets } from '@/model/wallet';
+import { getAllWallets, getSelectedWallet, loadAddress, saveAddress, saveAllWallets, setSelectedWallet } from '@/model/wallet';
 
 /**
  * One-shot heal: canonicalize EIP-55 addresses persisted in keychain.
@@ -14,6 +14,9 @@ export function healEip55KeychainAddresses(): Migration {
   return {
     name: MigrationName.healEip55KeychainAddresses,
     async migrate() {
+      // `addressKey`: source of truth for the active address. `loadWallets` reads this and writes
+      // it into the Zustand store on every boot. If left non-canonical here, the in-memory state
+      // would be re-polluted on every launch even after the MMKV-side migration ran.
       const storedAddress = await loadAddress();
       if (storedAddress) {
         const normalized = normalizeAddress(storedAddress);
@@ -22,6 +25,9 @@ export function healEip55KeychainAddresses(): Migration {
         }
       }
 
+      // `allWalletsKey`: source of truth for the full wallets map. `loadWallets` reads this and
+      // hydrates `state.wallets`, which powers the wallet switcher and any address-based UI lookup.
+      // Same re-pollution concern as above if left bad-case.
       const result = await getAllWallets();
       if (result?.wallets) {
         let changed = false;
@@ -36,6 +42,25 @@ export function healEip55KeychainAddresses(): Migration {
         }
         if (changed) {
           await saveAllWallets(result.wallets);
+        }
+      }
+
+      // `selectedWalletKey`: separate keychain entry holding a snapshot of the active wallet.
+      // `loadWallets` reads this independently and assigns it to `state.selected`. Without healing
+      // it here, the wallet switcher / account header would still surface bad-case addresses on
+      // next boot, even though the wallets map and active address are clean.
+      const selectedWalletData = await getSelectedWallet();
+      if (selectedWalletData?.wallet) {
+        let changed = false;
+        for (const account of selectedWalletData.wallet.addresses || []) {
+          const normalized = normalizeAddress(account.address);
+          if (normalized && normalized !== account.address) {
+            account.address = normalized;
+            changed = true;
+          }
+        }
+        if (changed) {
+          await setSelectedWallet(selectedWalletData.wallet);
         }
       }
     },

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -21,6 +21,7 @@ export enum MigrationName {
   migrateFavoritesV3 = 'migration_migrateFavoritesV3',
   removeDuplicateRecentSwaps = 'migration_removeDuplicateRecentSwaps',
   migrateNotificationSettingsToVersion3 = 'migration_migrateNotificationSettingsToVersion3',
+  healEip55KeychainAddresses = 'migration_healEip55KeychainAddresses',
 }
 
 export type Migration = {

--- a/src/state/wallets/walletsStore.ts
+++ b/src/state/wallets/walletsStore.ts
@@ -635,12 +635,19 @@ export const useWalletsStore = createRainbowStore<WalletsState>(
     migrate: (persistedState, fromVersion) => {
       const state = persistedState as Partial<WalletsState>;
       if (fromVersion < 1) {
+        // Active address used by every downstream consumer (polymarket derive, displays,
+        // address comparisons). This is the primary field that triggers the boot crash when
+        // non-canonical because it gets fed into viem's strict EIP-55 encoder.
         if (state.accountAddress) {
           const normalized = normalizeAddress(state.accountAddress);
           if (normalized) {
             state.accountAddress = normalized;
           }
         }
+
+        // Wallets map; powers the wallet switcher, account list, and any Copy action sourced
+        // from a wallet card. Without this, switching to or copying from a non-canonical wallet
+        // surfaces the bad-case form even after the active address was healed.
         if (state.wallets) {
           for (const wallet of Object.values(state.wallets)) {
             for (const account of wallet.addresses || []) {
@@ -650,6 +657,30 @@ export const useWalletsStore = createRainbowStore<WalletsState>(
               }
             }
           }
+        }
+
+        // Independent snapshot of the active wallet. Some UI paths read directly from
+        // `state.selected.addresses` instead of looking up via `state.wallets[selected.id]`,
+        // so this needs to be canonicalized separately to avoid stle bad-case display.
+        if (state.selected) {
+          for (const account of state.selected.addresses || []) {
+            const normalized = normalizeAddress(account.address);
+            if (normalized) {
+              account.address = normalized;
+            }
+          }
+        }
+
+        // ENS name cache, keyed by address. Post-canonicalization, lookups happen with
+        // canonical-case addresses; if the keys here remain bad-case, those lookups silently
+        // miss and the user's ENS names disappear. Re-key the map under canonical addresses.
+        if (state.walletNames) {
+          const next: WalletNames = {};
+          for (const [address, ensName] of Object.entries(state.walletNames)) {
+            const normalized = normalizeAddress(address);
+            next[normalized ?? address] = ensName;
+          }
+          state.walletNames = next;
         }
       }
       return state;

--- a/src/state/wallets/walletsStore.ts
+++ b/src/state/wallets/walletsStore.ts
@@ -3,6 +3,7 @@ import { dequal } from 'dequal';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { type Address } from 'viem';
 
+import { normalizeAddress } from '@/features/address/core/address';
 import { fetchENSAvatarWithRetry } from '@/features/ens/hooks/useENSAvatar';
 import { ensureValidHex, isValidHex } from '@/handlers/web3';
 import { removeFirstEmojiFromString, returnStringFirstEmoji } from '@/helpers/emojiHandler';
@@ -627,6 +628,32 @@ export const useWalletsStore = createRainbowStore<WalletsState>(
       wallets: state.wallets,
       walletNames: state.walletNames,
     }),
+    // v1: canonicalize EIP-55 addresses on rehydration. The watched-wallet import flow previously
+    // accepted addresses without enforcing EIP-55 checksum, so non-canonical entries could end up
+    // persisted (APP-3673). Normalize here so consumers always read canonical data.
+    version: 1,
+    migrate: (persistedState, fromVersion) => {
+      const state = persistedState as Partial<WalletsState>;
+      if (fromVersion < 1) {
+        if (state.accountAddress) {
+          const normalized = normalizeAddress(state.accountAddress);
+          if (normalized) {
+            state.accountAddress = normalized;
+          }
+        }
+        if (state.wallets) {
+          for (const wallet of Object.values(state.wallets)) {
+            for (const account of wallet.addresses || []) {
+              const normalized = normalizeAddress(account.address);
+              if (normalized) {
+                account.address = normalized;
+              }
+            }
+          }
+        }
+      }
+      return state;
+    },
     persistThrottleMs: time.seconds(1),
   }
 );


### PR DESCRIPTION
The watched-wallet import flow currently accepts addresses without enforcing EIP-55 checksum (it uses `ethereumjs-util.isValidAddress`, which only validates `0x` + hex shape). Non-canonical addresses pasted by users get persisted as if valid, polluting both keychain and MMKV state. The most visible consequence is a permanent boot-loop crash for affected users, since Polymarket's derived store activates on home-screen render and feeds `accountAddress` into viem's strict EIP-55 encoder. The underlying issue is data integrity though: bad addresses in persisted state could break any consumer that strict-validates them.

This change tightens validation at the input boundary and heals already-corrupted state:
* The import flow now uses viem's strict `isAddress`, mirroring what the browser extension does. Bad-checksum input is rejected with a specific "invalid casing" alert so users can re-enter.
* For users with bad data already persisted we do two things since the data is both in MMKV and the keychain:
  * A Zustand `migrate` (version 1) on `walletsStore` canonicalizes addresses on rehydration
  * And a new `healEip55KeychainAddresses` migration in our custom migration system walks keychain entries and normalizes anything non-canonical.

After both heals run once on a stuck device, every storage layer contains canonical EIP-55 addresses and downstream consumers receive correctly-formed input regardless of how the data was originally written.

The new `src/features/address/core/address.ts` helpers are intentionally generic. We have what looks like other latent address-validation and canonicalization gaps (scanner, deeplinks, send recipient) that should migrate to these helpers in a follow-up audit.

Tested both recovery from stuck boot loop and new input validation works on both iOS and Android. Example from iOS:

<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-04-27 at 12 04 27" src="https://github.com/user-attachments/assets/54218a4a-33c6-48f1-b7e3-37800c879bc1" /> 


Fixes APP-3673 and APP-3557