### PR TITLE
fix: duplicate foreground notification on iOS

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -87,9 +87,10 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate {
 
   func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification,
                               withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-    // Suppress system banner and sound when foregrounded; in-app toast handles user-visible feedback.
-    // .list + .badge keep the notification in Notification Center and update the app icon badge.
-    completionHandler([.list, .badge])
+    // Suppress all iOS-side presentation for the FCM remote when foregrounded.
+    // Rainbow's foreground notification UI is handled by notifee (see foregroundHandler.ts);
+    // letting iOS also present from the FCM payload would duplicate Notification Center entries.
+    completionHandler([])
   }
 
   override func application(_ app: UIApplication, open url: URL,

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -87,7 +87,9 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate {
 
   func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification,
                               withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-    completionHandler([.sound, .badge, .list, .banner])
+    // Suppress system banner and sound when foregrounded; in-app toast handles user-visible feedback.
+    // .list + .badge keep the notification in Notification Center and update the app icon badge.
+    completionHandler([.list, .badge])
   }
 
   override func application(_ app: UIApplication, open url: URL,


### PR DESCRIPTION
After bumping `@react-native-firebase/*` from 20.1.0 to 23.8.8 in #7319 (Apr 2026), iOS users see both a system banner AND a notifee-displayed local notification when a push arrives while the app is foregrounded. Pre-bump behavior was the notifee notification only.

The cause is upstream: invertase/react-native-firebase#8786 (merged Feb 2026, shipped in v23.8.5) reordered RNFB's iOS `willPresent` delegate so the original AppDelegate handler is called first. Previously, RNFB consumed the one-shot `completionHandler` with its own default options (empty, since we don't have a `firebase.json`) before forwarding to AppDelegate, making AppDelegate's `completionHandler([.sound, .badge, .list, .banner])` a no-op. With the new order, AppDelegate wins and iOS now honors the full `[.sound, .badge, .list, .banner]` set the handler has been quietly asking for since #6607 (Aug 2025).

This change updates AppDelegate's `willPresent` to call `completionHandler([])`, which suppresses all iOS-side presentation for the FCM remote when foregrounded. Rainbow's user-visible foreground notification UI is rendered by notifee from the separate `onMessage` JS handler (`src/notifications/foregroundHandler.ts` → `notifee.displayNotification`). Letting iOS also present the FCM payload would duplicate Notification Center entries and add badge increments that pre-bump prod never had. Returning `[]` matches the pre-RNFB-23.8.5 default of `UNNotificationPresentationOptionNone`. Background and killed-app notifications are unaffected since this delegate only runs in the foreground case.