### PR TITLE
chore(lint): disallow unused imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,7 +105,7 @@ module.exports = {
   parserOptions: {
     project: ['./tsconfig.json'],
   },
-  plugins: ['yml'],
+  plugins: ['yml', 'unused-imports'],
   globals: globalVars,
 
   overrides: [
@@ -149,6 +149,7 @@ module.exports = {
   rules: {
     'no-duplicate-imports': 'off',
     'import/no-duplicates': 'error',
+    'unused-imports/no-unused-imports': 'error',
     '@typescript-eslint/consistent-type-imports': [
       'error',
       {

--- a/package.json
+++ b/package.json
@@ -415,6 +415,7 @@
     "emoji-datasource": "4.1.0",
     "eslint": "8.57.1",
     "eslint-config-rainbow": "4.3.0",
+    "eslint-plugin-unused-imports": "2.0.0",
     "eslint-plugin-yml": "1.18.0",
     "graphql": "15.3.0",
     "husky": "8.0.1",

--- a/src/__swaps__/screens/Swap/components/GasPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/GasPanel.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState, type PropsWithChildren, type ReactNode } from 'react';
+import React, { useCallback, useMemo, type PropsWithChildren, type ReactNode } from 'react';
 import { type LayoutChangeEvent } from 'react-native';
 
-import Animated, { runOnJS, useAnimatedReaction, useAnimatedStyle, useSharedValue, withDelay, withSpring } from 'react-native-reanimated';
+import Animated, { runOnJS, useAnimatedReaction, useAnimatedStyle, withDelay, withSpring } from 'react-native-reanimated';
 
 import { ACTION_BUTTON_HEIGHT } from '@/__swaps__/screens/Swap/constants';
 import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';

--- a/src/__swaps__/screens/Swap/components/SwapWarning.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapWarning.tsx
@@ -5,7 +5,7 @@ import Animated, { useAnimatedStyle, useDerivedValue, withSpring } from 'react-n
 import { SwapWarningType } from '@/__swaps__/screens/Swap/hooks/useSwapWarning';
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { AnimatedText, Box, Inline } from '@/design-system';
+import { AnimatedText, Box } from '@/design-system';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 export const SwapWarning = () => {

--- a/src/__swaps__/screens/Swap/resources/search/searchV2.ts
+++ b/src/__swaps__/screens/Swap/resources/search/searchV2.ts
@@ -4,7 +4,7 @@ import { groupBy } from 'lodash';
 import qs from 'qs';
 import { TOKEN_SEARCH_URL } from 'react-native-dotenv';
 
-import { TokenSearchThreshold, type SearchAsset, type TokenSearchAssetKey } from '@/__swaps__/types/search';
+import { type SearchAsset, type TokenSearchAssetKey } from '@/__swaps__/types/search';
 import { RainbowFetchClient } from '@/framework/data/http/rainbowFetch';
 import { getProvider } from '@/handlers/web3';
 import { logger, RainbowError } from '@/logger';

--- a/src/__swaps__/utils/swaps.ts
+++ b/src/__swaps__/utils/swaps.ts
@@ -2,7 +2,6 @@ import { type BigNumberish } from '@ethersproject/bignumber';
 import c from 'chroma-js';
 // DO NOT REMOVE THESE COMMENTED ENV VARS
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { IS_APK_BUILD } from 'react-native-dotenv';
 import { type SharedValue } from 'react-native-reanimated';
 import { getAddress, type Address } from 'viem';
 

--- a/src/components/DappBrowser/hooks/useWebViewHandlers.ts
+++ b/src/components/DappBrowser/hooks/useWebViewHandlers.ts
@@ -4,7 +4,7 @@ import type React from 'react';
 import { runOnUI, withTiming, type SharedValue } from 'react-native-reanimated';
 import { type WebViewMessageEvent } from 'react-native-webview';
 import type WebView from 'react-native-webview';
-import { WebViewEvent, type ShouldStartLoadRequest, type WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
+import { type ShouldStartLoadRequest, type WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
 
 import { appMessenger, type Messenger } from '@/browserMessaging/AppMessenger';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';

--- a/src/components/DappBrowser/search/Search.tsx
+++ b/src/components/DappBrowser/search/Search.tsx
@@ -6,7 +6,6 @@ import Animated, { runOnJS, useAnimatedStyle, withSpring } from 'react-native-re
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { useSharedValueState } from '@/hooks/reanimated/useSharedValueState';
 import { useSyncSharedValue } from '@/hooks/reanimated/useSyncSharedValue';
 import useKeyboardHeight from '@/hooks/useKeyboardHeight';

--- a/src/components/FeesGweiInput.tsx
+++ b/src/components/FeesGweiInput.tsx
@@ -5,7 +5,7 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import GweiInputPill from '@/components/GweiInputPill';
-import { Box, Inline, Text } from '@/design-system';
+import { Box, Text } from '@/design-system';
 import { IS_ANDROID } from '@/env';
 import { delay } from '@/helpers/utilities';
 import usePrevious from '@/hooks/usePrevious';

--- a/src/components/Pill.js
+++ b/src/components/Pill.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import RadialGradient from 'react-native-radial-gradient';
 
-import { Box, Text } from '@/design-system';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { padding } from '@/styles';

--- a/src/components/asset-list/RecyclerAssetList2/LegacyWrappedNFT.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/LegacyWrappedNFT.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 
 import useExperimentalFlag, { NFTS_ENABLED } from '@/config/experimentalHooks';
 import { Box, type BoxProps } from '@/design-system';

--- a/src/components/cards/MintsCard/Menu.tsx
+++ b/src/components/cards/MintsCard/Menu.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { DropdownMenu, type MenuConfig } from '@/components/DropdownMenu';
 import { Inline, Inset, Text } from '@/design-system';
 import { getMintsFilterLabel, MintsFilter, useMintsFilter } from '@/resources/mints';

--- a/src/components/cards/reusables/TintButton.tsx
+++ b/src/components/cards/reusables/TintButton.tsx
@@ -5,7 +5,6 @@ import ConditionalWrap from 'conditional-wrap';
 import Skeleton, { FakeText } from '@/components/skeleton/Skeleton';
 import { AccentColorProvider, Box, Text, useAccentColor } from '@/design-system';
 import { opacity } from '@/framework/ui/utils/opacity';
-import { colors } from '@/styles';
 
 import ButtonPressAnimation from '../../animations/ButtonPressAnimation';
 

--- a/src/components/coin-row/CollectiblesSendRow.tsx
+++ b/src/components/coin-row/CollectiblesSendRow.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useMemo } from 'react';
-import { StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import { TouchableWithoutFeedback } from 'react-native';
 
 import Divider from '@/components/Divider';
 import type { UniqueAsset } from '@/entities/uniqueAssets';

--- a/src/components/drag-and-drop/features/sort/hooks/useDraggableScroll.ts
+++ b/src/components/drag-and-drop/features/sort/hooks/useDraggableScroll.ts
@@ -4,7 +4,7 @@ import { scrollTo, useAnimatedReaction, type AnimatedRef, type SharedValue } fro
 import type Animated from 'react-native-reanimated';
 
 import { useDndContext } from '@/components/drag-and-drop/DndContext';
-import { applyOffset, doesOverlapOnAxis, getFlexLayoutPosition } from '@/components/drag-and-drop/utils';
+import { applyOffset, doesOverlapOnAxis } from '@/components/drag-and-drop/utils';
 
 import { useDraggableSort, type UseDraggableSortOptions } from './useDraggableSort';
 

--- a/src/components/inputs/InlineField.tsx
+++ b/src/components/inputs/InlineField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { type TextInputProps } from 'react-native';
 
 import { Bleed, Column, Columns, Inline, Inset, Text, useTextStyle, type TextProps } from '@/design-system';

--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -5,7 +5,7 @@ import { useColorMode, useForegroundColor } from '@/design-system';
 import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
-import { buildTextStyles, fonts } from '@/styles';
+import { buildTextStyles } from '@/styles';
 
 interface InputProps extends TextInputProps {
   style?: StyleProp<TextStyle>;

--- a/src/components/qr-code/ShareButton.js
+++ b/src/components/qr-code/ShareButton.js
@@ -7,7 +7,7 @@ import ShadowStack from '@/react-native-shadow-stack';
 
 import { useTheme } from '../../theme/ThemeContext';
 import ButtonPressAnimation from '../animations/ButtonPressAnimation';
-import { Centered, InnerBorder, Row } from '../layout';
+import { Centered, InnerBorder } from '../layout';
 import { Text } from '../text';
 
 const Label = styled(Text).attrs(({ theme: { colors } }) => ({

--- a/src/components/rainbow-coin-effect/RainbowCoinEffect.tsx
+++ b/src/components/rainbow-coin-effect/RainbowCoinEffect.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 
-import { BlendColor, Blur, Canvas, Circle, Fill, Image, Paint, Shadow, SweepGradient, useImage } from '@shopify/react-native-skia';
+import { BlendColor, Blur, Canvas, Circle, Image, Paint, Shadow, SweepGradient, useImage } from '@shopify/react-native-skia';
 import Animated, {
   interpolate,
   runOnUI,

--- a/src/components/send/SendHeader.tsx
+++ b/src/components/send/SendHeader.tsx
@@ -19,7 +19,6 @@ import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { type RainbowAccount } from '@/model/wallet';
 import Routes from '@/navigation/routesNames';
-import { Contact } from '@/redux/contacts';
 import { padding } from '@/styles';
 import profileUtils from '@/utils/profileUtils';
 

--- a/src/components/sheet/DynamicHeightSheet.js
+++ b/src/components/sheet/DynamicHeightSheet.js
@@ -6,7 +6,7 @@ import { BottomSheetContext } from '@gorhom/bottom-sheet/src/contexts/external';
 import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
+import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useDimensions from '@/hooks/useDimensions';
 import { useNavigation } from '@/navigation/Navigation';

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -1,6 +1,6 @@
 import { createMMKV } from 'react-native-mmkv';
 
-import { IS_DEV, IS_INTERNAL, IS_TEST } from '@/env';
+import { IS_INTERNAL, IS_TEST } from '@/env';
 import { STORAGE_IDS } from '@/model/mmkv';
 
 /**

--- a/src/features/ens/components/profile/ProfileCover.tsx
+++ b/src/features/ens/components/profile/ProfileCover.tsx
@@ -7,7 +7,6 @@ import Animated from 'react-native-reanimated';
 import { ImgixImage } from '@/components/images';
 import { ImagePreviewOverlayTarget } from '@/components/images/ImagePreviewOverlay';
 import Skeleton from '@/components/skeleton/Skeleton';
-import { CardSize } from '@/components/unique-token/CardSize';
 import { Box, useForegroundColor } from '@/design-system';
 import useFadeImage from '@/hooks/useFadeImage';
 import { sharedCoolModalTopOffset } from '@/navigation/config';

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -11,7 +11,7 @@ import { AnimatedInput } from '@/components/AnimatedComponents/AnimatedInput';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
 import { DEFAULT_MOUNT_ANIMATIONS } from '@/components/utilities/MountWhenFocused';
-import { Border, Box, Text, TextShadow, useColorMode } from '@/design-system';
+import { Box, Text, TextShadow, useColorMode } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
 import { IS_ANDROID } from '@/env';
 import { HyperliquidButton } from '@/features/perps/components/HyperliquidButton';

--- a/src/features/perps/constants.ts
+++ b/src/features/perps/constants.ts
@@ -5,7 +5,7 @@ import { type ParsedAsset } from '@/__swaps__/types/assets';
 import { type SearchAsset } from '@/__swaps__/types/search';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { NativeCurrencyKeys, type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { MarketSortOrder, type HlBuilderSettings } from '@/features/perps/types';
+import { type HlBuilderSettings } from '@/features/perps/types';
 import { supportedCurrencies as supportedNativeCurrencies } from '@/references/supportedCurrencies';
 import { ChainId } from '@/state/backendNetworks/types';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';

--- a/src/features/perps/stores/derived/useOrderAmountValidation.ts
+++ b/src/features/perps/stores/derived/useOrderAmountValidation.ts
@@ -1,6 +1,6 @@
 import { useHlNewPositionStore } from '@/features/perps/stores/hlNewPositionStore';
 import { useHyperliquidAccountStore } from '@/features/perps/stores/hyperliquidAccountStore';
-import { buildOrderAmountValidation, OrderAmountValidation } from '@/features/perps/utils/buildOrderAmountValidation';
+import { buildOrderAmountValidation } from '@/features/perps/utils/buildOrderAmountValidation';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { shallowEqual } from '@/worklets/comparisons';
 

--- a/src/features/positions/stores/transform/balance.test.ts
+++ b/src/features/positions/stores/transform/balance.test.ts
@@ -1,7 +1,7 @@
 import { transformPositions } from '.';
 import { FIXTURE_PARAMS } from '../../__fixtures__/ListPositions';
 import { createMockAsset } from '../../__fixtures__/mocks/assets';
-import { createMockPosition, createMockResponse, createMockStats } from '../../__fixtures__/mocks/positions';
+import { createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 import { DetailType, PositionName } from '../../types/generated/positions/positions';
 import { usePositionsStore } from '../positionsStore';
 

--- a/src/features/positions/stores/transform/filtered.test.ts
+++ b/src/features/positions/stores/transform/filtered.test.ts
@@ -1,7 +1,7 @@
 import { transformPositions } from '.';
 import { FIXTURE_PARAMS } from '../../__fixtures__/ListPositions';
 import { createMockAsset } from '../../__fixtures__/mocks/assets';
-import { createMockPosition, createMockResponse, createMockStats } from '../../__fixtures__/mocks/positions';
+import { createMockPosition, createMockResponse } from '../../__fixtures__/mocks/positions';
 import { DetailType, PositionName } from '../../types/generated/positions/positions';
 import { usePositionsStore } from '../positionsStore';
 

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/ActionStatusScene.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/ActionStatusScene.tsx
@@ -8,7 +8,6 @@ import {
   createScaleOutFadeOutSlideExitAnimation,
 } from '@/features/rnbw-rewards/animations/sceneTransitions';
 import { type AsyncActionState } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
-import * as i18n from '@/languages';
 import { time } from '@/utils/time';
 
 const EXIT_ANIMATION_DURATION = time.ms(500);

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -3,7 +3,6 @@ import { chunk, compact, groupBy, isEmpty, slice, sortBy } from 'lodash';
 import { type UniqueId } from '@/__swaps__/types/assets';
 import { type AssetListType } from '@/components/asset-list/RecyclerAssetList2';
 import { CellType, type CellTypes } from '@/components/asset-list/RecyclerAssetList2/core/ViewTypes';
-import { AssetType } from '@/entities/assetTypes';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import type { ParsedAddressAsset } from '@/entities/tokens';
 import type { UniqueAsset } from '@/entities/uniqueAssets';

--- a/src/hooks/useFadeImage.ts
+++ b/src/hooks/useFadeImage.ts
@@ -3,8 +3,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { type Source } from 'react-native-fast-image';
 import { Easing, useAnimatedReaction, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
-import { ImgixImage } from '@/components/images';
-
 export default function useFadeImage({ source, enabled = true }: { source?: Source; enabled?: boolean }) {
   const [isLoading, setIsLoading] = useState(false);
 

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { InteractionManager, Keyboard, type TextInput } from 'react-native';
 
-import { keys } from 'lodash';
 import { useDispatch } from 'react-redux';
 
 import { analytics } from '@/analytics';

--- a/src/hooks/useLedgerImport.ts
+++ b/src/hooks/useLedgerImport.ts
@@ -5,7 +5,6 @@ import TransportBLE from '@ledgerhq/react-native-hw-transport-ble';
 
 import { IS_ANDROID, IS_IOS } from '@/env';
 import { logger, RainbowError } from '@/logger';
-import { DebugContext } from '@/logger/debugContext';
 import { checkAndRequestAndroidBluetooth, showBluetoothPermissionsAlert, showBluetoothPoweredOffAlert } from '@/utils/bluetoothPermissions';
 import { ledgerErrorHandler, type LEDGER_ERROR_CODES } from '@/utils/ledger';
 

--- a/src/hooks/useSubmitTransaction.ts
+++ b/src/hooks/useSubmitTransaction.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 
-import { SCREEN_FOR_REQUEST_SOURCE } from '@/components/Transactions/constants';
 import { logger, RainbowError } from '@/logger';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -37,7 +37,7 @@ import AesEncryptor from '../handlers/aesEncryption';
 import WalletBackupTypes from '../helpers/walletBackupTypes';
 import { clearAllStorages } from './mmkv';
 import { getRemoteConfig } from './remoteConfig';
-import { createWallet, loadWallet, type AllRainbowWallets, type RainbowWallet } from './wallet';
+import { createWallet, type AllRainbowWallets, type RainbowWallet } from './wallet';
 
 const { DeviceUUID } = NativeModules;
 const encryptor = new AesEncryptor();

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -32,7 +32,6 @@ import Routes from '@/navigation/routesNames';
 import { WalletNotificationRelationship } from '@/notifications/settings/constants';
 import { initializeNotificationSettingsForAddresses } from '@/notifications/settings/initialization';
 import type { AddressWithRelationship } from '@/notifications/settings/types';
-import { Network } from '@/state/backendNetworks/types';
 import { executeFn, type ExecuteFnParams, type Screen } from '@/state/performance/performance';
 import { getIsDamagedWallet, getWalletWithAccount, setWalletDamaged } from '@/state/wallets/walletsStore';
 import ethereumUtils from '@/utils/ethereumUtils';

--- a/src/parsers/transactions.ts
+++ b/src/parsers/transactions.ts
@@ -1,6 +1,5 @@
 import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import {
-  PaginatedTransactionsApiResponse,
   TransactionDirection,
   TransactionStatus,
   TransactionTypeMap,

--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -20,7 +20,7 @@ import { getYForX } from 'react-native-redash';
 import Svg, { Path, type PathProps } from 'react-native-svg';
 import { triggerHaptics } from 'react-native-turbo-haptics';
 // @ts-ignore this library is no longer maintained independently of the app, so this is fine
-import { IS_ANDROID, IS_IOS } from '@/env';
+import { IS_IOS } from '@/env';
 import { type ChartData, type PathData } from '../../helpers/ChartContext';
 import { requireOnWorklet, useWorkletValue } from '../../helpers/requireOnWorklet';
 import { useChartData } from '../../helpers/useChartData';

--- a/src/redux/gas.ts
+++ b/src/redux/gas.ts
@@ -26,7 +26,6 @@ import { addBuffer } from '@/helpers/utilities';
 import { logger, RainbowError } from '@/logger';
 import {
   defaultGasParamsFormat,
-  gweiToWei,
   parseGasFeeParam,
   parseGasFees,
   parseGasFeesBySpeed,

--- a/src/resources/trendingTokens/trendingTokens.ts
+++ b/src/resources/trendingTokens/trendingTokens.ts
@@ -7,15 +7,7 @@ import { type AddressOrEth, type UniqueId } from '@/__swaps__/types/assets';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import { RainbowFetchClient } from '@/framework/data/http/rainbowFetch';
 import { arcClient } from '@/graphql';
-import {
-  TrendingSort as ArcTrendingSort,
-  Timeframe,
-  type Bridging,
-  type Colors,
-  type Market,
-  type SortDirection,
-  type TrendingData,
-} from '@/graphql/__generated__/arc';
+import { Timeframe, type Bridging, type Colors, type Market, type SortDirection, type TrendingData } from '@/graphql/__generated__/arc';
 import { logger, RainbowError } from '@/logger';
 import { createQueryKey, type QueryConfigWithSelect } from '@/react-query';
 import store from '@/redux/store';

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useEffect, useMemo } from 'react';
-import { Dimensions } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';

--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -43,7 +43,7 @@ import { useInteractionsCount } from '@/resources/addys/interactions';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { type ChainId } from '@/state/backendNetworks/types';
-import { Screens, startTimeToSignTracking } from '@/state/performance/performance';
+import { startTimeToSignTracking } from '@/state/performance/performance';
 import { useAccountAddress, useWalletsStore } from '@/state/wallets/walletsStore';
 import { position } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';

--- a/src/screens/SettingsSheet/components/MenuItem.tsx
+++ b/src/screens/SettingsSheet/components/MenuItem.tsx
@@ -9,7 +9,6 @@ import { ImgixImage } from '@/components/images';
 import { Box, Inline, Stack, Text } from '@/design-system';
 import { type Width } from '@/design-system/layout/size';
 import { opacity } from '@/framework/ui/utils/opacity';
-import { colors } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
 
 import ButtonPressAnimation from '../../../components/animations/ButtonPressAnimation';

--- a/src/screens/claimables/transaction/components/TransactionClaimableFlow.tsx
+++ b/src/screens/claimables/transaction/components/TransactionClaimableFlow.tsx
@@ -4,7 +4,7 @@ import { Box } from '@/design-system';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import { ClaimableType } from '@/resources/addys/claimables/types';
-import { useIsReadOnlyWallet, useWalletsStore } from '@/state/wallets/walletsStore';
+import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import watchingAlert from '@/utils/watchingAlert';
 
 import { ClaimButton } from '../../shared/components/ClaimButton';

--- a/src/screens/claimables/transaction/context/TransactionClaimableContext.tsx
+++ b/src/screens/claimables/transaction/context/TransactionClaimableContext.tsx
@@ -24,7 +24,6 @@ import {
   formatNumber,
   multiply,
 } from '@/helpers/utilities';
-import useAccountSettings from '@/hooks/useAccountSettings';
 import { logger, RainbowError } from '@/logger';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import { loadWallet } from '@/model/wallet';

--- a/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { ImageBackground } from 'react-native';
 
-import { Source } from 'react-native-fast-image';
 import { useMMKVBoolean } from 'react-native-mmkv';
 import Animated, { useAnimatedStyle, useDerivedValue, withDelay, withRepeat, withSequence, withTiming } from 'react-native-reanimated';
 import { useRecoilState, useSetRecoilState } from 'recoil';
@@ -9,7 +8,6 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 import gridDotsDark from '@/assets/dot-grid-dark.png';
 import gridDotsLight from '@/assets/dot-grid-light.png';
 import ledgerNano from '@/assets/ledger-nano.png';
-import { ImgixImage } from '@/components/images';
 import { Box, Inline, Inset, Stack, Text } from '@/design-system';
 import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';

--- a/src/screens/hardware-wallets/components/NanoXDeviceAnimation.tsx
+++ b/src/screens/hardware-wallets/components/NanoXDeviceAnimation.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
-import { BackdropBlur, Canvas, Circle, Group, mix, Paint, Rect } from '@shopify/react-native-skia';
+import { BackdropBlur, Canvas, Circle, Group, mix, Rect } from '@shopify/react-native-skia';
 import { type Source } from 'react-native-fast-image';
 import Animated, {
   Easing,

--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -18,7 +18,7 @@ import { GasSpeedButton } from '@/components/gas';
 import { useRainbowToastEnabled } from '@/components/rainbow-toast/useRainbowToastEnabled';
 import { Bleed, Box, ColorModeProvider, Column, Columns, Inline, Inset, Separator, Stack, Text } from '@/design-system';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
-import { IS_ANDROID, IS_IOS } from '@/env';
+import { IS_IOS } from '@/env';
 import useENSAvatar from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
 import styled from '@/framework/ui/styled-thing';

--- a/src/screens/rewards/components/RewardsEarnings.tsx
+++ b/src/screens/rewards/components/RewardsEarnings.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Image, ImageBackground } from 'react-native';
+import { ImageBackground } from 'react-native';
 
 import { addDays, differenceInDays, differenceInHours, fromUnixTime, isPast } from 'date-fns';
 import { useSelector } from 'react-redux';

--- a/src/screens/rewards/components/RewardsLeaderboardItem.tsx
+++ b/src/screens/rewards/components/RewardsLeaderboardItem.tsx
@@ -8,7 +8,7 @@ import { analytics } from '@/analytics';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ContactAvatar } from '@/components/contacts';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
-import { Bleed, Box, Column, Columns, Inline, Stack, Text } from '@/design-system';
+import { Box, Column, Columns, Inline, Stack, Text } from '@/design-system';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { TOP_RANK_SYMBOLS } from '@/screens/rewards/constants';

--- a/src/screens/rewards/components/RewardsSectionCard.tsx
+++ b/src/screens/rewards/components/RewardsSectionCard.tsx
@@ -2,7 +2,7 @@ import React, { type PropsWithChildren } from 'react';
 import { View } from 'react-native';
 
 import { Box, globalColors, useBackgroundColor, type Space } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
+import { IS_IOS } from '@/env';
 import { useTheme } from '@/theme/ThemeContext';
 
 type Props = {

--- a/src/screens/token-launcher/components/NetworkField.tsx
+++ b/src/screens/token-launcher/components/NetworkField.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
-import { Bleed, Box, Inline, Text, TextIcon } from '@/design-system';
+import { Bleed, Box, Inline, Text } from '@/design-system';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';

--- a/src/screens/transaction-details/components/SingleLineTransactionDetailsRow.tsx
+++ b/src/screens/transaction-details/components/SingleLineTransactionDetailsRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Columns, Inline, Text } from '@/design-system';
+import { Columns, Inline, Text } from '@/design-system';
 import { TransactionDetailsSymbol } from '@/screens/transaction-details/components/TransactionDetailsSymbol';
 
 type Props = {

--- a/src/screens/transaction-details/components/TransactionDetailsSymbol.tsx
+++ b/src/screens/transaction-details/components/TransactionDetailsSymbol.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Bleed, Box, Text } from '@/design-system';
+import { Box, Text } from '@/design-system';
 
 const SIZE = { custom: 40 };
 

--- a/src/state/assets/types.ts
+++ b/src/state/assets/types.ts
@@ -1,6 +1,6 @@
 import { type Address } from 'viem';
 
-import { ParsedAssetsDictByChain, type ParsedSearchAsset, type UniqueId, type UserAssetFilter } from '@/__swaps__/types/assets';
+import { type ParsedSearchAsset, type UniqueId, type UserAssetFilter } from '@/__swaps__/types/assets';
 import type { ParsedAddressAsset } from '@/entities/tokens';
 import type { SupportedCurrencyKey } from '@/references/supportedCurrencies';
 import { type ChainId } from '@/state/backendNetworks/types';

--- a/src/state/nfts/createNftsStore.ts
+++ b/src/state/nfts/createNftsStore.ts
@@ -2,7 +2,6 @@ import { isEmpty } from 'lodash';
 import { type Address } from 'viem';
 
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_DEV } from '@/env';
 import { arcClient } from '@/graphql';
 import { updateWebHidden, updateWebShowcase } from '@/helpers/webData';
 import { getHidden } from '@/hooks/useFetchHiddenTokens';

--- a/src/systems/funding/utils/withdrawalSwap.ts
+++ b/src/systems/funding/utils/withdrawalSwap.ts
@@ -1,5 +1,3 @@
-import type { Address } from 'viem';
-
 import { type AddressOrEth } from '@/__swaps__/types/assets';
 import { type ChainId } from '@/state/backendNetworks/types';
 

--- a/src/utils/uniqueTokens.ts
+++ b/src/utils/uniqueTokens.ts
@@ -1,5 +1,3 @@
-import type { UniqueAsset } from '@/entities/uniqueAssets';
-
 export const uniqueTokenTypes = {
   ENS: 'ENS',
   NFT: 'NFT',

--- a/src/worklets/gradients.ts
+++ b/src/worklets/gradients.ts
@@ -1,4 +1,4 @@
-import { convertToRGBA, processColor } from 'react-native-reanimated';
+import { convertToRGBA } from 'react-native-reanimated';
 
 import { clampColor, interpolateHue, oklabToOklch, oklchToHex, rgbToOklab, standardizeColors } from './colors';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9636,6 +9636,7 @@ __metadata:
     emoji-regex: "npm:10.0.0"
     eslint: "npm:8.57.1"
     eslint-config-rainbow: "npm:4.3.0"
+    eslint-plugin-unused-imports: "npm:2.0.0"
     eslint-plugin-yml: "npm:1.18.0"
     eth-url-parser: "npm:1.0.4"
     ethereumjs-util: "npm:6.2.1"
@@ -14280,6 +14281,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-unused-imports@npm:2.0.0":
+  version: 2.0.0
+  resolution: "eslint-plugin-unused-imports@npm:2.0.0"
+  dependencies:
+    eslint-rule-composer: "npm:^0.3.0"
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": ^5.0.0
+    eslint: ^8.0.0
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+  checksum: 10c0/016241cda51ccf953b1e04a50b8c18543d46bae08670573dca3cf0ea195be38964f66e9d179a1f4c50cfcad5b9b76e21c3142fde171587a42fc6824727b0ca3d
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-yml@npm:1.18.0":
   version: 1.18.0
   resolution: "eslint-plugin-yml@npm:1.18.0"
@@ -14292,6 +14308,13 @@ __metadata:
   peerDependencies:
     eslint: ">=6.0.0"
   checksum: 10c0/ff6619bb488c98f3b6639c58f135f375bba6a4e4763cfeded461c6bbe654164678055981d1a27949568efc5ca9f3904e3abdda593b837cabb96f58948cc2d6be
+  languageName: node
+  linkType: hard
+
+"eslint-rule-composer@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "eslint-rule-composer@npm:0.3.0"
+  checksum: 10c0/1f0c40d209e1503a955101a0dbba37e7fc67c8aaa47a5b9ae0b0fcbae7022c86e52b3df2b1b9ffd658e16cd80f31fff92e7222460a44d8251e61d49e0af79a07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There's no automated check for unused imports today, so they accumulate as code shifts around. Sweeping them up by hand is rarely worth a dedicated PR, but the noise shows up in every diff and obscures real dependencies between modules.

This change adds `eslint-plugin-unused-imports`, enables `unused-imports/no-unused-imports` at error level and runs the auto fix to remove all unused imports from the codebase.