### PR TITLE
chore: skip iOS prebuild hook in postinstall on non-Darwin

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -84,7 +84,7 @@ else
   echo "Please make sure the file exists and it's located in the root of the project"
 fi
 
-if [ -n "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK" ]; then
+if [ "$PLATFORM" == "Darwin" ] && [ -n "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK" ]; then
   if [ -n "$CI" ]; then
     bash -c "$RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK" > /dev/null;
   else


### PR DESCRIPTION
CI started failing on develop after the latest rainbow-scripts merge added an `xcodebuild -version` check at the end of the iOS prebuild hook. For the job runs on Linux runners they exits with `FATAL: xcodebuild -version returned nothing`. The underlying issue is that the iOS hook has actually been running on Linux for a while doing iOS-targeted things that mostly failed silently. The xcode check is just the first iOS hook step that exits non-zero loudly enough to fail `yarn install`.

The `RAINBOW_SCRIPTS_APP_IOS_PREBUILD_HOOK` env var was meant to gate the hook, but the `CI_SCRIPTS` GitHub secret that sets it does so unconditionally on every workflow that uses CI scripts, including the Android workflow. Since GH secrets are write-only and reconstructing the secret blind is risky, gating at the call site in `postinstall.sh` is the safer fix.

Ref FEPLAT-81.