### PR TITLE
chore: bump @shopify/flash-list 1.8.2 → 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "@reservoir0x/reservoir-sdk": "2.3.0",
     "@rudderstack/rudder-sdk-react-native": "2.0.0",
     "@sentry/react-native": "7.13.0",
-    "@shopify/flash-list": "1.8.2",
+    "@shopify/flash-list": "1.8.3",
     "@shopify/react-native-performance": "4.1.2",
     "@shopify/react-native-skia": "2.4.7",
     "@storesjs/stores": "0.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7353,9 +7353,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shopify/flash-list@npm:1.8.2":
-  version: 1.8.2
-  resolution: "@shopify/flash-list@npm:1.8.2"
+"@shopify/flash-list@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@shopify/flash-list@npm:1.8.3"
   dependencies:
     recyclerlistview: "npm:4.2.3"
     tslib: "npm:2.8.1"
@@ -7363,7 +7363,7 @@ __metadata:
     "@babel/runtime": "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/0d0cf5164b18899fddf0d56ca55a40bdce1ee1484a180e1d57ec3405a227a04201e47389aebd5a0cd89aaaab95e72c6b8c02a9f6e6182781d7f0770341f5aee5
+  checksum: 10c0/0900250ce45157d144e3fef4d1cd8c5dfb03495ecb66da1f512697a6834f4eee7bf0755a3772b3c131135784757e5b36566ed365ea0890d9c10ad872885ef650
   languageName: node
   linkType: hard
 
@@ -9574,7 +9574,7 @@ __metadata:
     "@rock-js/plugin-metro": "npm:0.9.2"
     "@rudderstack/rudder-sdk-react-native": "npm:2.0.0"
     "@sentry/react-native": "npm:7.13.0"
-    "@shopify/flash-list": "npm:1.8.2"
+    "@shopify/flash-list": "npm:1.8.3"
     "@shopify/react-native-performance": "npm:4.1.2"
     "@shopify/react-native-skia": "npm:2.4.7"
     "@storesjs/stores": "npm:0.8.7"


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Bumps `@shopify/flash-list` from **1.8.2 → 1.8.3** (single-PR patch release on the 1.x line).

Extracted from the RN 0.81 upgrade work so it can land independently — the fix in 1.8.3 is exactly what the RN 0.81 branch needed a local patch for. Picking it up now means that branch can drop the patch instead of carrying it.

### Upstream change in 1.8.3

[Shopify/flash-list#1724](https://github.com/Shopify/flash-list/pull/1724) — `Fix Build on RN 0.80`. One-line change in `android/.../BlankAreaEvent.kt`:

```diff
- rctEventEmitter.receiveEvent(viewTag, eventName, eventData)
+ rctEventEmitter.receiveEvent(viewTag, eventName, getEventData())
```

Required because RN's `Event<T>` base class made `eventData` a protected field; subclasses must use the `getEventData()` accessor. With `eventData` access, Android Kotlin compile fails (`Unresolved reference 'eventData'`) on RN 0.80+. On RN 0.79.5 (current `develop`) the old code still compiles — we get zero behavioral change here, just future-proofing.

[Release notes](https://github.com/Shopify/flash-list/releases/tag/v1.8.3) confirm it's the only commit between 1.8.2 and 1.8.3. No JS / TS API changes, no native iOS changes.

### Where flash-list is used in Rainbow

Four spots, all standalone `<FlashList />` consumers (no v1.8.3-specific behavior touched):

- `src/screens/MintsSheet/MintsSheet.tsx`
- `src/screens/NFTOffersSheet/index.tsx`
- `src/components/cards/CarouselCard.tsx`
- `src/components/cards/NFTOffersCard/index.tsx`

## Screen recordings / screenshots

_N/A — no visual changes expected._

## What to test

- [x] App builds
