### PR TITLE
fix(android): patch @coinbase/mobile-wallet-protocol-host for forward-compat with RN 0.81

### DIFF
--- a/patches/@coinbase+mobile-wallet-protocol-host+0.1.7.patch
+++ b/patches/@coinbase+mobile-wallet-protocol-host+0.1.7.patch
@@ -1,3 +1,52 @@
+diff --git a/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/MobileWalletProtocolHostModule.kt b/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/MobileWalletProtocolHostModule.kt
+index 79505d4..f17558b 100644
+--- a/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/MobileWalletProtocolHostModule.kt
++++ b/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/MobileWalletProtocolHostModule.kt
+@@ -114,7 +114,7 @@ class MobileWalletProtocolHostModule(reactContext: ReactApplicationContext) : Re
+     @ReactMethod
+     fun getClientAppMetadata(wellKnownCertificates: ReadableArray, promise: Promise) {
+         try {
+-            val activity = requireNotNull(currentActivity)
++            val activity = requireNotNull(reactApplicationContext.currentActivity)
+             val callingPackage = requireNotNull(activity.callingPackage)
+             val certificates = wellKnownCertificates.toArrayList().map { it as String }.toSet()
+
+@@ -140,7 +140,7 @@ class MobileWalletProtocolHostModule(reactContext: ReactApplicationContext) : Re
+     @ReactMethod
+     fun getClientAppMetadataV2(promise: Promise) {
+         try {
+-            val activity = requireNotNull(currentActivity)
++            val activity = requireNotNull(reactApplicationContext.currentActivity)
+             val callingPackage = requireNotNull(activity.callingPackage)
+
+             val appInfo = activity.packageManager.getApplicationInfo(callingPackage, 0)
+@@ -161,7 +161,7 @@ class MobileWalletProtocolHostModule(reactContext: ReactApplicationContext) : Re
+     @ReactMethod
+     fun getClientAppSignatures(promise: Promise) {
+         try {
+-            val activity = requireNotNull(currentActivity)
++            val activity = requireNotNull(reactApplicationContext.currentActivity)
+             val callingPackage = requireNotNull(activity.callingPackage)
+
+             val signatures = Arguments.createArray()
+@@ -178,7 +178,7 @@ class MobileWalletProtocolHostModule(reactContext: ReactApplicationContext) : Re
+     @ReactMethod
+     fun triggerWalletSDKCallback(domain: String, promise: Promise) {
+         try {
+-            val activity = requireNotNull(currentActivity)
++            val activity = requireNotNull(reactApplicationContext.currentActivity)
+
+             val intent = Intent()
+             intent.data = Uri.parse(domain)
+@@ -195,7 +195,7 @@ class MobileWalletProtocolHostModule(reactContext: ReactApplicationContext) : Re
+     @ReactMethod
+     fun getIntentUrl(promise: Promise) {
+         try {
+-            val activity = requireNotNull(currentActivity)
++            val activity = requireNotNull(reactApplicationContext.currentActivity)
+             val data = activity.intent.data
+             promise.resolve(data?.toString())
+         } catch (e: Throwable) {
 diff --git a/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/PackageManagerSignaturesExt.kt b/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/PackageManagerSignaturesExt.kt
 index 6b482fa..89ef7c3 100644
 --- a/node_modules/@coinbase/mobile-wallet-protocol-host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/PackageManagerSignaturesExt.kt


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Extends the existing `@coinbase/mobile-wallet-protocol-host` patch with a forward-compat fix for `MobileWalletProtocolHostModule.kt`, in preparation for the RN 0.81 upgrade.

Five `requireNotNull(currentActivity)` callsites in the module become `requireNotNull(reactApplicationContext.currentActivity)`. The `currentActivity` shorthand on `ReactContextBaseJavaModule` was dropped in RN 0.81; accessing it through `reactApplicationContext` works on every RN version.

### Why land this independently

This change is a no-op on develop's RN 0.79.5 — `reactApplicationContext.currentActivity` and the bare `currentActivity` resolve to the same value. We extract it now so:

1. The integration is testable in isolation (any MWP regression we hit shows up here, not in the much larger RN 0.81 PR).
2. Once merged, the RN 0.81 PR can drop this hunk from its patch.

We carry the patch (rather than waiting for an upstream release) because `@coinbase/mobile-wallet-protocol-host` last shipped a stable in Aug 2024 (`0.1.7`), and the `0.1.8-beta.0` published since still has the bug. The package looks effectively unmaintained for now.

## Screen recordings / screenshots

_N/A — no visual or behavioral changes._

## What to test

- [x] App compiles