### PR TITLE
[Gelato Migration]: Add staking tests

### DIFF
--- a/src/features/delegation/willDelegate.test.ts
+++ b/src/features/delegation/willDelegate.test.ts
@@ -1,0 +1,60 @@
+import { EthereumWalletType } from '@/helpers/walletTypes';
+import { delegation } from '@rainbow-me/delegation';
+
+import { canUseDelegatedExecution, supportsDelegatedExecution } from './willDelegate';
+
+const mockGetWalletWithAccount = jest.fn();
+const mockIsDelegationEnabled = jest.fn();
+
+jest.mock('@/state/wallets/walletsStore', () => ({
+  getWalletWithAccount: (accountAddress: string) => mockGetWalletWithAccount(accountAddress),
+  useWalletsStore: jest.fn(),
+}));
+
+jest.mock('./featureFlags', () => ({
+  isDelegationEnabled: () => mockIsDelegationEnabled(),
+  useIsDelegationEnabled: jest.fn(),
+}));
+
+jest.mock('@rainbow-me/delegation', () => ({
+  delegation: {
+    isEnabled: jest.fn(),
+    isSupported: jest.fn(),
+    willDelegate: jest.fn(),
+  },
+  useWillDelegate: jest.fn(),
+}));
+
+const ADDRESS = '0x1111111111111111111111111111111111111111';
+const CHAIN_ID = 8453;
+
+function setWallet(type: EthereumWalletType) {
+  mockGetWalletWithAccount.mockReturnValue({
+    addresses: [],
+    type,
+  });
+}
+
+describe('delegation wallet gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDelegationEnabled.mockReturnValue(true);
+    jest.mocked(delegation.isEnabled).mockReturnValue(true);
+    jest.mocked(delegation.isSupported).mockResolvedValue({ supported: true, reason: null });
+  });
+
+  it('rejects hardware wallets even when their optional deviceId is missing', async () => {
+    setWallet(EthereumWalletType.bluetooth);
+
+    expect(canUseDelegatedExecution(ADDRESS)).toBe(false);
+    await expect(supportsDelegatedExecution({ address: ADDRESS, chainId: CHAIN_ID })).resolves.toBe(false);
+    expect(delegation.isSupported).not.toHaveBeenCalled();
+  });
+
+  it('delegates software wallets through SDK support', async () => {
+    setWallet(EthereumWalletType.privateKey);
+
+    await expect(supportsDelegatedExecution({ address: ADDRESS, chainId: CHAIN_ID })).resolves.toBe(true);
+    expect(delegation.isSupported).toHaveBeenCalledWith({ address: ADDRESS, chainId: CHAIN_ID });
+  });
+});

--- a/src/features/rnbw-staking/utils/canUseSponsoredRnbwStaking.test.ts
+++ b/src/features/rnbw-staking/utils/canUseSponsoredRnbwStaking.test.ts
@@ -1,0 +1,64 @@
+import { type Address } from 'viem';
+
+import { ChainId } from '@/state/backendNetworks/types';
+
+import { canUseSponsoredRnbwStaking } from './canUseSponsoredRnbwStaking';
+
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
+const mockSupportsDelegatedExecution = jest.fn<Promise<boolean>, [unknown]>();
+const mockIsSponsorshipEligible = jest.fn<boolean, [ChainId]>();
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
+  supportsDelegatedExecution: (params: unknown) => mockSupportsDelegatedExecution(params),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    isSponsorshipEligible: (chainId: ChainId) => mockIsSponsorshipEligible(chainId),
+  },
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+
+describe('canUseSponsoredRnbwStaking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanUseDelegatedExecution.mockReturnValue(true);
+  });
+
+  it('requires both sponsorship eligibility and delegated execution support', async () => {
+    mockIsSponsorshipEligible.mockReturnValue(true);
+    mockSupportsDelegatedExecution.mockResolvedValue(true);
+
+    await expect(canUseSponsoredRnbwStaking(ACCOUNT, ChainId.base)).resolves.toBe(true);
+
+    expect(mockSupportsDelegatedExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      chainId: ChainId.base,
+    });
+  });
+
+  it('does not query delegation support when the chain cannot sponsor transactions', async () => {
+    mockIsSponsorshipEligible.mockReturnValue(false);
+
+    await expect(canUseSponsoredRnbwStaking(ACCOUNT, ChainId.mainnet)).resolves.toBe(false);
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+  });
+
+  it('rejects sponsorship when delegation-backed execution is unsupported', async () => {
+    mockIsSponsorshipEligible.mockReturnValue(true);
+    mockSupportsDelegatedExecution.mockResolvedValue(false);
+
+    await expect(canUseSponsoredRnbwStaking(ACCOUNT, ChainId.base)).resolves.toBe(false);
+  });
+
+  it('does not query chain support when local wallet facts rule out delegation', async () => {
+    mockCanUseDelegatedExecution.mockReturnValue(false);
+
+    await expect(canUseSponsoredRnbwStaking(ACCOUNT, ChainId.base)).resolves.toBe(false);
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/rnbw-staking/utils/estimateStakeGasLimit.test.ts
+++ b/src/features/rnbw-staking/utils/estimateStakeGasLimit.test.ts
@@ -1,0 +1,39 @@
+import { BigNumber } from '@ethersproject/bignumber';
+
+import { STAKING_APPROVAL_GAS_LIMIT, STAKING_GAS_LIMIT } from '../constants';
+import { checkIfStakingNeedsApproval } from './checkIfStakingNeedsApproval';
+import { estimateStakeGasLimit } from './estimateStakeGasLimit';
+
+const mockEstimateGas = jest.fn();
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${chainId}:${address}`,
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  getProvider: () => ({
+    estimateGas: mockEstimateGas,
+  }),
+}));
+
+jest.mock('./checkIfStakingNeedsApproval', () => ({
+  checkIfStakingNeedsApproval: jest.fn(),
+}));
+
+const ADDRESS = '0xe5ab64c46313d229d33f7dab3490c9c34806ffb3';
+
+describe('estimateStakeGasLimit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the shared approval fallback when approval gas estimation fails', async () => {
+    jest.mocked(checkIfStakingNeedsApproval).mockResolvedValue(true);
+    mockEstimateGas.mockResolvedValueOnce(BigNumber.from(STAKING_GAS_LIMIT)).mockRejectedValueOnce(new Error('estimateGas failed'));
+
+    await expect(estimateStakeGasLimit({ accountAddress: ADDRESS, amount: '100' })).resolves.toBe(
+      `${STAKING_GAS_LIMIT + STAKING_APPROVAL_GAS_LIMIT}`
+    );
+    expect(mockEstimateGas).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
@@ -1,0 +1,435 @@
+import type { Provider, TransactionReceipt, TransactionRequest, TransactionResponse } from '@ethersproject/abstract-provider';
+import { Signer } from '@ethersproject/abstract-signer';
+import { BigNumber } from '@ethersproject/bignumber';
+import type { Deferrable } from '@ethersproject/properties';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { type Address } from 'viem';
+
+import { TransactionDirection, TransactionStatus } from '@/entities/transactions';
+import { type TransactionAssetSource } from '@/raps/transactionAsset';
+import { time } from '@/utils/time';
+import { execute, type Call, type CallsRequirements, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import {
+  RNBW_DECIMALS,
+  RNBW_TOKEN_ADDRESS,
+  RNBW_TOKEN_UNIQUE_ID,
+  STAKING_CHAIN_ID,
+  STAKING_CONTRACT_ADDRESS,
+  STAKING_GAS_LIMIT,
+} from '../constants';
+import { executeStakeRnbw } from './executeStakeRnbw';
+
+const mockExecuteCalls = jest.fn<Promise<unknown>, [unknown, unknown?]>();
+const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
+const mockBuildStakeRnbwCalls = jest.fn<Promise<Call[]>, [unknown]>();
+const mockBuildStakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
+const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unknown]>();
+const mockTrackCallsExecution = jest.fn<void, [unknown]>();
+const mockWaitForManagedExecutionConfirmation = jest.fn<Promise<void>, [string]>();
+const mockAddNewTransaction = jest.fn<void, [unknown]>();
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    calls: (params: unknown, clients?: unknown) => mockExecuteCalls(params, clients),
+    prepare: {
+      calls: (params: unknown) => mockPrepareCalls(params),
+    },
+  },
+  RelayExecutionStatus: {
+    Confirmed: 'CONFIRMED',
+    Failed: 'FAILED',
+    Pending: 'PENDING',
+    Reverted: 'REVERTED',
+  },
+}));
+
+jest.mock('@/features/delegation/managedExecutionFailure', () => ({
+  resolveManagedExecutionFailure: (params: unknown) => mockResolveManagedExecutionFailure(params),
+}));
+
+jest.mock('@/features/delegation/callsExecutionTracking', () => ({
+  trackCallsExecution: (params: unknown) => mockTrackCallsExecution(params),
+}));
+
+jest.mock('@/features/delegation/waitForManagedExecution', () => ({
+  waitForManagedExecutionConfirmation: (executionId: string) => mockWaitForManagedExecutionConfirmation(executionId),
+}));
+
+jest.mock('@/state/pendingTransactions', () => ({
+  addNewTransaction: (params: unknown) => mockAddNewTransaction(params),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    getChainsName: () => ({ 8453: 'Base' }),
+  },
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+jest.mock('./stakeRnbwCalls', () => ({
+  buildStakeRnbwCalls: (params: unknown) => mockBuildStakeRnbwCalls(params),
+  buildStakeRnbwExecutionPlan: (params: unknown) => mockBuildStakeRnbwExecutionPlan(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
+const STAKE_AMOUNT_RAW = '1000000000000000000';
+const APPROVAL_TX_HASH = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', STAKING_CHAIN_ID);
+const signer = new Wallet(PRIVATE_KEY, provider);
+const APPROVAL_CALL = { data: '0x095ea7b3', to: RNBW_TOKEN_ADDRESS, value: 0n } satisfies Call;
+const STAKE_CALL = { data: '0xa694fc3a', to: STAKING_CONTRACT_ADDRESS, value: 0n } satisfies Call;
+const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } } satisfies CallsRequirements;
+const SPONSORED_PLAN = { calls: [APPROVAL_CALL, STAKE_CALL], requirements: SPONSORED_REQUIREMENTS };
+
+class TestHardwareSigner extends Signer {
+  readonly provider: Provider;
+  readonly sendTransactionMock = jest.fn<Promise<TransactionResponse>, [Deferrable<TransactionRequest>]>();
+
+  constructor(provider: Provider) {
+    super();
+    this.provider = provider;
+  }
+
+  connect(provider: Provider): Signer {
+    return new TestHardwareSigner(provider);
+  }
+
+  getAddress(): Promise<string> {
+    return Promise.resolve(ACCOUNT);
+  }
+
+  signMessage(): Promise<string> {
+    return Promise.resolve('0x');
+  }
+
+  signTransaction(): Promise<string> {
+    return Promise.resolve('0x');
+  }
+
+  sendTransaction(transaction: Deferrable<TransactionRequest>): Promise<TransactionResponse> {
+    return this.sendTransactionMock(transaction);
+  }
+}
+
+const rnbwAsset = {
+  address: RNBW_TOKEN_ADDRESS,
+  chainId: STAKING_CHAIN_ID,
+  chainName: 'Base',
+  colors: { fallback: '#f2c745', primary: '#f2c745' },
+  decimals: RNBW_DECIMALS,
+  isNativeAsset: false,
+  mainnetAddress: RNBW_TOKEN_ADDRESS,
+  name: 'Rainbow',
+  native: {
+    price: { amount: 1, change: '0', display: '$1.00' },
+  },
+  nativePrice: 1,
+  networks: {
+    [STAKING_CHAIN_ID]: {
+      address: RNBW_TOKEN_ADDRESS,
+      decimals: RNBW_DECIMALS,
+    },
+  },
+  price: { value: 1 },
+  symbol: 'RNBW',
+  uniqueId: RNBW_TOKEN_UNIQUE_ID,
+} satisfies TransactionAssetSource;
+
+function buildReceipt(transactionHash = TX_HASH): TransactionReceipt {
+  return {
+    blockHash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    blockNumber: 1,
+    byzantium: true,
+    confirmations: 1,
+    contractAddress: '',
+    cumulativeGasUsed: BigNumber.from(21_000),
+    effectiveGasPrice: BigNumber.from(1),
+    from: ACCOUNT,
+    gasUsed: BigNumber.from(21_000),
+    logs: [],
+    logsBloom: '0x',
+    status: 1,
+    to: STAKING_CONTRACT_ADDRESS,
+    transactionHash,
+    transactionIndex: 0,
+    type: 2,
+  };
+}
+
+function buildTransactionResponse({
+  call = STAKE_CALL,
+  hash = TX_HASH,
+}: {
+  call?: Call;
+  hash?: string;
+} = {}): TransactionResponse {
+  return {
+    chainId: STAKING_CHAIN_ID,
+    confirmations: 0,
+    data: call.data,
+    from: ACCOUNT,
+    gasLimit: BigNumber.from(21_000),
+    hash,
+    nonce: 1,
+    to: call.to,
+    value: BigNumber.from(0),
+    wait: () => Promise.resolve(buildReceipt(hash)),
+  };
+}
+
+async function prepareCalls(plan: unknown): Promise<PreparedCallsExecution> {
+  mockPrepareCalls.mockResolvedValueOnce(plan);
+  return execute.prepare.calls({
+    calls: [STAKE_CALL],
+    chainId: STAKING_CHAIN_ID,
+    provider,
+    signer,
+  });
+}
+
+function defer<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolveDeferred: (value: T) => void = () => undefined;
+  const promise = new Promise<T>(resolve => {
+    resolveDeferred = resolve;
+  });
+  return { promise, resolve: resolveDeferred };
+}
+
+async function waitForMockCalls(mock: { mock: { calls: unknown[][] } }, count: number): Promise<void> {
+  for (let attempt = 0; attempt < 10 && mock.mock.calls.length < count; attempt++) {
+    await Promise.resolve();
+  }
+  if (mock.mock.calls.length < count) throw new Error(`Expected mock to be called ${count} times`);
+}
+
+describe('executeStakeRnbw', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuildStakeRnbwCalls.mockResolvedValue([STAKE_CALL]);
+    mockBuildStakeRnbwExecutionPlan.mockResolvedValue({ calls: [STAKE_CALL] });
+    mockResolveManagedExecutionFailure.mockResolvedValue(null);
+    mockWaitForManagedExecutionConfirmation.mockResolvedValue();
+  });
+
+  it('executes manual staking through wallet exact calls and waits for submitted hashes', async () => {
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt());
+    const preparedCalls = await prepareCalls({
+      kind: 'calls.wallet',
+      review: {
+        requiresDelegationAuthorization: false,
+        transactions: [],
+      },
+    });
+
+    mockExecuteCalls.mockResolvedValue({
+      kind: 'calls.wallet',
+      transactions: [
+        {
+          hash: TX_HASH,
+          transaction: {
+            data: STAKE_CALL.data,
+            gas: 21000n,
+            maxFeePerGas: 1n,
+            maxPriorityFeePerGas: 1n,
+            nonce: 1,
+            to: STAKING_CONTRACT_ADDRESS,
+            value: 0n,
+          },
+          type: 'eip1559',
+        },
+      ],
+    });
+
+    const result = await executeStakeRnbw({
+      address: ACCOUNT,
+      asset: rnbwAsset,
+      preparedCalls,
+      provider,
+      signer,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    expect(result.executionMode).toBe('manual');
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId: STAKING_CHAIN_ID,
+      execution: expect.objectContaining({ hash: TX_HASH }),
+      transaction: expect.objectContaining({ type: 'stake' }),
+    });
+    expect(mockExecuteCalls).toHaveBeenCalledWith(preparedCalls, {
+      chainId: STAKING_CHAIN_ID,
+      provider,
+      signer,
+    });
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('executes sponsored staking through the managed relay and waits through relay status', async () => {
+    const preparedCalls = await prepareCalls({
+      executionId: 'prepared-stake',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+
+    mockExecuteCalls.mockResolvedValue({
+      executionId: 'submitted-stake',
+      kind: 'calls.managed',
+      status: 'PENDING',
+    });
+
+    const result = await executeStakeRnbw({
+      address: ACCOUNT,
+      asset: rnbwAsset,
+      preparedCalls,
+      provider,
+      signer,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    expect(result.executionMode).toBe('sponsored');
+    expect(mockExecuteCalls).toHaveBeenCalledWith(preparedCalls, {
+      chainId: STAKING_CHAIN_ID,
+      provider,
+      signer,
+    });
+    expect(mockResolveManagedExecutionFailure).toHaveBeenCalledWith({
+      executionId: 'submitted-stake',
+      status: 'PENDING',
+    });
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId: STAKING_CHAIN_ID,
+      execution: {
+        executionId: 'submitted-stake',
+        kind: 'calls.managed',
+        status: 'PENDING',
+      },
+      transaction: expect.objectContaining({
+        asset: expect.objectContaining({
+          address: RNBW_TOKEN_ADDRESS,
+          network: 'Base',
+          symbol: 'RNBW',
+          uniqueId: RNBW_TOKEN_UNIQUE_ID,
+        }),
+        chainId: STAKING_CHAIN_ID,
+        changes: [
+          expect.objectContaining({
+            address_from: ACCOUNT,
+            address_to: STAKING_CONTRACT_ADDRESS,
+            direction: TransactionDirection.OUT,
+            price: 1,
+            value: STAKE_AMOUNT_RAW,
+          }),
+        ],
+        from: ACCOUNT,
+        network: 'Base',
+        nonce: -1,
+        status: TransactionStatus.pending,
+        to: STAKING_CONTRACT_ADDRESS,
+        type: 'stake',
+        value: 0,
+      }),
+    });
+
+    await result.waitForConfirmation();
+
+    expect(mockWaitForManagedExecutionConfirmation).toHaveBeenCalledWith('submitted-stake');
+  });
+
+  it('builds one raw exact-call plan when software-wallet submission has no prepared calls', async () => {
+    mockBuildStakeRnbwExecutionPlan.mockResolvedValue(SPONSORED_PLAN);
+    mockExecuteCalls.mockResolvedValue({
+      executionId: 'raw-stake',
+      kind: 'calls.managed',
+      status: 'PENDING',
+    });
+
+    const result = await executeStakeRnbw({
+      address: ACCOUNT,
+      asset: rnbwAsset,
+      preparedCalls: null,
+      provider,
+      signer,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    expect(result.executionMode).toBe('sponsored');
+    expect(mockExecuteCalls).toHaveBeenCalledWith(
+      {
+        calls: [APPROVAL_CALL, STAKE_CALL],
+        chainId: STAKING_CHAIN_ID,
+        provider,
+        requirements: SPONSORED_REQUIREMENTS,
+        signer,
+      },
+      undefined
+    );
+  });
+
+  it('waits for hardware-wallet approval before submitting the stake transaction', async () => {
+    const hardwareSigner = new TestHardwareSigner(provider);
+    const approvalConfirmation = defer<TransactionReceipt>();
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockImplementation(hash => {
+      if (hash === APPROVAL_TX_HASH) return approvalConfirmation.promise;
+      return Promise.resolve(buildReceipt(hash));
+    });
+
+    mockBuildStakeRnbwCalls.mockResolvedValue([APPROVAL_CALL, STAKE_CALL]);
+    hardwareSigner.sendTransactionMock
+      .mockResolvedValueOnce(buildTransactionResponse({ call: APPROVAL_CALL, hash: APPROVAL_TX_HASH }))
+      .mockResolvedValueOnce(buildTransactionResponse({ call: STAKE_CALL, hash: TX_HASH }));
+
+    const execution = executeStakeRnbw({
+      address: ACCOUNT,
+      asset: rnbwAsset,
+      preparedCalls: null,
+      provider,
+      signer: hardwareSigner,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    await waitForMockCalls(waitForTransaction, 1);
+
+    expect(hardwareSigner.sendTransactionMock).toHaveBeenCalledTimes(1);
+    expect(hardwareSigner.sendTransactionMock).toHaveBeenNthCalledWith(1, APPROVAL_CALL);
+    expect(waitForTransaction).toHaveBeenCalledWith(APPROVAL_TX_HASH, 1, time.minutes(2));
+
+    approvalConfirmation.resolve(buildReceipt(APPROVAL_TX_HASH));
+    const result = await execution;
+
+    expect(mockExecuteCalls).not.toHaveBeenCalled();
+    expect(result.executionMode).toBe('manual');
+    expect(mockAddNewTransaction).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      chainId: STAKING_CHAIN_ID,
+      transaction: expect.objectContaining({
+        hash: TX_HASH,
+        gasLimit: BigNumber.from(21_000),
+        nonce: 1,
+        type: 'stake',
+      }),
+    });
+    expect(hardwareSigner.sendTransactionMock).toHaveBeenNthCalledWith(2, {
+      ...STAKE_CALL,
+      gasLimit: STAKING_GAS_LIMIT,
+    });
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledTimes(2);
+    expect(waitForTransaction).toHaveBeenLastCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+});

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
@@ -1,7 +1,8 @@
 import type { Provider, TransactionReceipt, TransactionRequest, TransactionResponse } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
 import { BigNumber } from '@ethersproject/bignumber';
-import type { Deferrable } from '@ethersproject/properties';
+import { hexlify } from '@ethersproject/bytes';
+import { resolveProperties, type Deferrable } from '@ethersproject/properties';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import { type Address } from 'viem';
@@ -15,9 +16,9 @@ import {
   RNBW_DECIMALS,
   RNBW_TOKEN_ADDRESS,
   RNBW_TOKEN_UNIQUE_ID,
+  STAKING_APPROVAL_GAS_LIMIT,
   STAKING_CHAIN_ID,
   STAKING_CONTRACT_ADDRESS,
-  STAKING_GAS_LIMIT,
 } from '../constants';
 import { executeStakeRnbw } from './executeStakeRnbw';
 
@@ -76,18 +77,22 @@ jest.mock('./stakeRnbwCalls', () => ({
   buildStakeRnbwExecutionPlan: (params: unknown) => mockBuildStakeRnbwExecutionPlan(params),
 }));
 
-const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const ACCOUNT: Address = '0x3333333333333333333333333333333333333333';
 const PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
 const STAKE_AMOUNT_RAW = '1000000000000000000';
 const APPROVAL_TX_HASH = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
+const APPROVAL_CALL: Call = { data: '0x095ea7b3', to: RNBW_TOKEN_ADDRESS, value: 0n };
+const STAKE_CALL: Call = { data: '0xa694fc3a', to: STAKING_CONTRACT_ADDRESS, value: 0n };
+const SPONSORED_REQUIREMENTS: CallsRequirements = { atomic: 'required', fees: { payer: 'sponsor' } };
+const SPONSORED_PLAN = { calls: [APPROVAL_CALL, STAKE_CALL], requirements: SPONSORED_REQUIREMENTS };
+
+const GAS_PARAMS = { maxFeePerGas: '6000000', maxPriorityFeePerGas: '1000000' };
+const ESTIMATED_STAKE_GAS_LIMIT = BigNumber.from(103_406);
+
 const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', STAKING_CHAIN_ID);
 const signer = new Wallet(PRIVATE_KEY, provider);
-const APPROVAL_CALL = { data: '0x095ea7b3', to: RNBW_TOKEN_ADDRESS, value: 0n } satisfies Call;
-const STAKE_CALL = { data: '0xa694fc3a', to: STAKING_CONTRACT_ADDRESS, value: 0n } satisfies Call;
-const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } } satisfies CallsRequirements;
-const SPONSORED_PLAN = { calls: [APPROVAL_CALL, STAKE_CALL], requirements: SPONSORED_REQUIREMENTS };
 
 class TestHardwareSigner extends Signer {
   readonly provider: Provider;
@@ -165,24 +170,39 @@ function buildReceipt(transactionHash = TX_HASH): TransactionReceipt {
 }
 
 function buildTransactionResponse({
-  call = STAKE_CALL,
   hash = TX_HASH,
+  nonce = 1,
+  transaction,
 }: {
-  call?: Call;
   hash?: string;
-} = {}): TransactionResponse {
-  return {
+  nonce?: number;
+  transaction: Deferrable<TransactionRequest>;
+}): Promise<TransactionResponse> {
+  return resolveProperties(transaction).then(request => ({
     chainId: STAKING_CHAIN_ID,
     confirmations: 0,
-    data: call.data,
+    data: request.data ? hexlify(request.data) : '0x',
     from: ACCOUNT,
-    gasLimit: BigNumber.from(21_000),
+    gasLimit: BigNumber.from(request.gasLimit ?? 21_000),
+    gasPrice: BigNumber.from(1),
     hash,
-    nonce: 1,
-    to: call.to,
-    value: BigNumber.from(0),
+    maxFeePerGas: request.maxFeePerGas == null ? undefined : BigNumber.from(request.maxFeePerGas),
+    maxPriorityFeePerGas: request.maxPriorityFeePerGas == null ? undefined : BigNumber.from(request.maxPriorityFeePerGas),
+    nonce,
+    to: request.to,
+    value: BigNumber.from(request.value ?? 0),
     wait: () => Promise.resolve(buildReceipt(hash)),
-  };
+  }));
+}
+
+function mockSubmittedTransactions(signer: TestHardwareSigner, submissions: { hash: string; nonce: number }[]): void {
+  let index = 0;
+  signer.sendTransactionMock.mockImplementation(transaction => {
+    const submission = submissions[index];
+    if (!submission) throw new Error(`Unexpected staking transaction ${index + 1}`);
+    index += 1;
+    return buildTransactionResponse({ ...submission, transaction });
+  });
 }
 
 async function prepareCalls(plan: unknown): Promise<PreparedCallsExecution> {
@@ -210,8 +230,15 @@ async function waitForMockCalls(mock: { mock: { calls: unknown[][] } }, count: n
   if (mock.mock.calls.length < count) throw new Error(`Expected mock to be called ${count} times`);
 }
 
+async function submittedRequest(signer: TestHardwareSigner, transactionNumber: number): Promise<TransactionRequest> {
+  const call = signer.sendTransactionMock.mock.calls[transactionNumber - 1];
+  if (!call) throw new Error(`Missing staking transaction ${transactionNumber}`);
+  return resolveProperties(call[0]);
+}
+
 describe('executeStakeRnbw', () => {
   beforeEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
     mockBuildStakeRnbwCalls.mockResolvedValue([STAKE_CALL]);
     mockBuildStakeRnbwExecutionPlan.mockResolvedValue({ calls: [STAKE_CALL] });
@@ -251,6 +278,7 @@ describe('executeStakeRnbw', () => {
     const result = await executeStakeRnbw({
       address: ACCOUNT,
       asset: rnbwAsset,
+      gasParams: GAS_PARAMS,
       preparedCalls,
       provider,
       signer,
@@ -292,6 +320,7 @@ describe('executeStakeRnbw', () => {
     const result = await executeStakeRnbw({
       address: ACCOUNT,
       asset: rnbwAsset,
+      gasParams: GAS_PARAMS,
       preparedCalls,
       provider,
       signer,
@@ -360,6 +389,7 @@ describe('executeStakeRnbw', () => {
     const result = await executeStakeRnbw({
       address: ACCOUNT,
       asset: rnbwAsset,
+      gasParams: GAS_PARAMS,
       preparedCalls: null,
       provider,
       signer,
@@ -379,22 +409,28 @@ describe('executeStakeRnbw', () => {
     );
   });
 
-  it('waits for hardware-wallet approval before submitting the stake transaction', async () => {
+  it('uses selected gas params, estimates call gas, and waits for hardware-wallet approval before staking', async () => {
     const hardwareSigner = new TestHardwareSigner(provider);
     const approvalConfirmation = defer<TransactionReceipt>();
     const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockImplementation(hash => {
       if (hash === APPROVAL_TX_HASH) return approvalConfirmation.promise;
       return Promise.resolve(buildReceipt(hash));
     });
+    jest
+      .spyOn(provider, 'estimateGas')
+      .mockRejectedValueOnce(new Error('approval estimate failed'))
+      .mockResolvedValueOnce(ESTIMATED_STAKE_GAS_LIMIT);
 
     mockBuildStakeRnbwCalls.mockResolvedValue([APPROVAL_CALL, STAKE_CALL]);
-    hardwareSigner.sendTransactionMock
-      .mockResolvedValueOnce(buildTransactionResponse({ call: APPROVAL_CALL, hash: APPROVAL_TX_HASH }))
-      .mockResolvedValueOnce(buildTransactionResponse({ call: STAKE_CALL, hash: TX_HASH }));
+    mockSubmittedTransactions(hardwareSigner, [
+      { hash: APPROVAL_TX_HASH, nonce: 1 },
+      { hash: TX_HASH, nonce: 2 },
+    ]);
 
     const execution = executeStakeRnbw({
       address: ACCOUNT,
       asset: rnbwAsset,
+      gasParams: GAS_PARAMS,
       preparedCalls: null,
       provider,
       signer: hardwareSigner,
@@ -404,7 +440,12 @@ describe('executeStakeRnbw', () => {
     await waitForMockCalls(waitForTransaction, 1);
 
     expect(hardwareSigner.sendTransactionMock).toHaveBeenCalledTimes(1);
-    expect(hardwareSigner.sendTransactionMock).toHaveBeenNthCalledWith(1, APPROVAL_CALL);
+    await expect(submittedRequest(hardwareSigner, 1)).resolves.toMatchObject({
+      to: RNBW_TOKEN_ADDRESS,
+      value: 0n,
+      gasLimit: STAKING_APPROVAL_GAS_LIMIT,
+      ...GAS_PARAMS,
+    });
     expect(waitForTransaction).toHaveBeenCalledWith(APPROVAL_TX_HASH, 1, time.minutes(2));
 
     approvalConfirmation.resolve(buildReceipt(APPROVAL_TX_HASH));
@@ -417,19 +458,53 @@ describe('executeStakeRnbw', () => {
       chainId: STAKING_CHAIN_ID,
       transaction: expect.objectContaining({
         hash: TX_HASH,
-        gasLimit: BigNumber.from(21_000),
-        nonce: 1,
+        gasLimit: ESTIMATED_STAKE_GAS_LIMIT,
+        nonce: 2,
         type: 'stake',
       }),
     });
-    expect(hardwareSigner.sendTransactionMock).toHaveBeenNthCalledWith(2, {
-      ...STAKE_CALL,
-      gasLimit: STAKING_GAS_LIMIT,
+    await expect(submittedRequest(hardwareSigner, 2)).resolves.toMatchObject({
+      to: STAKING_CONTRACT_ADDRESS,
+      value: 0n,
+      gasLimit: ESTIMATED_STAKE_GAS_LIMIT,
+      ...GAS_PARAMS,
     });
 
     await result.waitForConfirmation();
 
     expect(waitForTransaction).toHaveBeenCalledTimes(2);
     expect(waitForTransaction).toHaveBeenLastCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('submits one hardware-wallet stake transaction when approval is not required', async () => {
+    const hardwareSigner = new TestHardwareSigner(provider);
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt(TX_HASH));
+    jest.spyOn(provider, 'estimateGas').mockResolvedValue(ESTIMATED_STAKE_GAS_LIMIT);
+
+    mockBuildStakeRnbwCalls.mockResolvedValue([STAKE_CALL]);
+    mockSubmittedTransactions(hardwareSigner, [{ hash: TX_HASH, nonce: 2 }]);
+
+    const execution = await executeStakeRnbw({
+      address: ACCOUNT,
+      asset: rnbwAsset,
+      gasParams: GAS_PARAMS,
+      preparedCalls: null,
+      provider,
+      signer: hardwareSigner,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    expect(hardwareSigner.sendTransactionMock).toHaveBeenCalledTimes(1);
+    await expect(submittedRequest(hardwareSigner, 1)).resolves.toMatchObject({
+      to: STAKING_CONTRACT_ADDRESS,
+      value: 0n,
+      gasLimit: ESTIMATED_STAKE_GAS_LIMIT,
+      ...GAS_PARAMS,
+    });
+    expect(waitForTransaction).not.toHaveBeenCalled();
+
+    await execution.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
   });
 });

--- a/src/features/rnbw-staking/utils/prepareStakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/prepareStakeRnbw.test.ts
@@ -1,0 +1,125 @@
+import { type Address } from 'viem';
+
+import { type Call, type CallsRequirements } from '@rainbow-me/delegation';
+
+import { STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { prepareStakeRnbw, type StakeRnbwPreparationParams } from './prepareStakeRnbw';
+
+const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
+const mockBuildStakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
+const mockGetProvider = jest.fn();
+const mockResolveStakeClaimStrategy = jest.fn<Promise<unknown>, [string]>();
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    prepare: {
+      calls: (params: unknown) => mockPrepareCalls(params),
+    },
+  },
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  getProvider: () => mockGetProvider(),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    getChainDefaultRpc: () => 'http://127.0.0.1:8545',
+    getDefaultChains: () => ({
+      8453: {
+        id: 8453,
+        name: 'Base',
+        nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+        rpcUrls: { default: { http: ['http://127.0.0.1:8545'] } },
+      },
+    }),
+  },
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+jest.mock('./resolveStakeClaimStrategy', () => ({
+  resolveStakeClaimStrategy: (stakeAmountRaw: string) => mockResolveStakeClaimStrategy(stakeAmountRaw),
+}));
+
+jest.mock('./stakeRnbwCalls', () => ({
+  buildStakeRnbwExecutionPlan: (params: unknown) => mockBuildStakeRnbwExecutionPlan(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const STAKE_AMOUNT_RAW = '1000000000000000000';
+const provider = { name: 'provider' };
+const STAKE_CALL = { data: '0x1234', to: STAKING_CONTRACT_ADDRESS, value: 0n } satisfies Call;
+const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } } satisfies CallsRequirements;
+
+describe('prepareStakeRnbw', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetProvider.mockReturnValue(provider);
+    mockBuildStakeRnbwExecutionPlan.mockResolvedValue({ calls: [STAKE_CALL], requirements: SPONSORED_REQUIREMENTS });
+    mockResolveStakeClaimStrategy.mockResolvedValue({
+      claimFulfillsStake: false,
+      claimToDestination: 'wallet',
+      requiredWalletBalanceRaw: STAKE_AMOUNT_RAW,
+      walletStakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+    mockPrepareCalls.mockResolvedValue({
+      executionId: 'prepared-stake',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+  });
+
+  it('prepares sponsor-paid exact calls ahead of staking submission', async () => {
+    const params: StakeRnbwPreparationParams = {
+      accountAddress: ACCOUNT,
+      amount: '1',
+    };
+
+    await expect(prepareStakeRnbw(params)).resolves.toEqual({
+      preparedCalls: {
+        executionId: 'prepared-stake',
+        kind: 'calls.managed',
+        review: { fees: { payer: 'sponsor' } },
+      },
+      walletStakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    expect(mockResolveStakeClaimStrategy).toHaveBeenCalledWith(STAKE_AMOUNT_RAW);
+    expect(mockBuildStakeRnbwExecutionPlan).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      provider,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+    expect(mockPrepareCalls).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      calls: [STAKE_CALL],
+      chainId: STAKING_CHAIN_ID,
+      publicClient: expect.objectContaining({
+        chain: expect.objectContaining({ id: STAKING_CHAIN_ID }),
+      }),
+      requirements: SPONSORED_REQUIREMENTS,
+    });
+  });
+
+  it('skips preparation when claimable rewards fulfill the stake', async () => {
+    mockResolveStakeClaimStrategy.mockResolvedValue({
+      claimFulfillsStake: true,
+      claimToDestination: 'staking',
+      requiredWalletBalanceRaw: '0',
+      walletStakeAmountRaw: '0',
+    });
+
+    await expect(
+      prepareStakeRnbw({
+        accountAddress: ACCOUNT,
+        amount: '1',
+      })
+    ).resolves.toBeNull();
+
+    expect(mockBuildStakeRnbwExecutionPlan).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/rnbw-staking/utils/resolveStakeClaimStrategy.test.ts
+++ b/src/features/rnbw-staking/utils/resolveStakeClaimStrategy.test.ts
@@ -1,0 +1,71 @@
+import { parseUnits } from 'viem';
+
+import { RNBW_DECIMALS } from '../constants';
+import { resolveStakeClaimStrategy } from './resolveStakeClaimStrategy';
+
+const mockFetch = jest.fn();
+const mockGetData = jest.fn();
+const mockHasClaimableRewards = jest.fn();
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${chainId}:${address}`,
+}));
+
+jest.mock('@/features/rnbw-rewards/stores/rewardsBalanceStore', () => ({
+  useRewardsBalanceStore: {
+    getState: () => ({
+      fetch: mockFetch,
+      getData: mockGetData,
+      hasClaimableRewards: mockHasClaimableRewards,
+    }),
+  },
+}));
+
+function raw(amount: string): string {
+  return parseUnits(amount, RNBW_DECIMALS).toString();
+}
+
+function setClaimableRnbw(claimableRnbw: string): void {
+  mockGetData.mockReturnValue({ claimableRnbw });
+  mockHasClaimableRewards.mockReturnValue(claimableRnbw !== '0');
+}
+
+describe('resolveStakeClaimStrategy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('claims sub-threshold rewards to wallet and stakes the full requested amount from wallet balance', async () => {
+    setClaimableRnbw(raw('0.4'));
+
+    await expect(resolveStakeClaimStrategy(raw('100'))).resolves.toEqual({
+      claimToDestination: 'wallet',
+      requiredWalletBalanceRaw: raw('99.6'),
+      walletStakeAmountRaw: raw('100'),
+      claimFulfillsStake: false,
+    });
+    expect(mockFetch).toHaveBeenCalledWith(undefined, { force: true });
+  });
+
+  it('claims threshold-sized partial rewards directly to staking and stakes only the wallet remainder', async () => {
+    setClaimableRnbw(raw('20'));
+
+    await expect(resolveStakeClaimStrategy(raw('100'))).resolves.toEqual({
+      claimToDestination: 'staking',
+      requiredWalletBalanceRaw: raw('80'),
+      walletStakeAmountRaw: raw('80'),
+      claimFulfillsStake: false,
+    });
+  });
+
+  it('uses a threshold-sized exact claim as the complete stake', async () => {
+    setClaimableRnbw(raw('20'));
+
+    await expect(resolveStakeClaimStrategy(raw('20'))).resolves.toEqual({
+      claimToDestination: 'staking',
+      requiredWalletBalanceRaw: '0',
+      walletStakeAmountRaw: '0',
+      claimFulfillsStake: true,
+    });
+  });
+});

--- a/src/features/rnbw-staking/utils/stakeRnbwCalls.test.ts
+++ b/src/features/rnbw-staking/utils/stakeRnbwCalls.test.ts
@@ -1,0 +1,97 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { encodeFunctionData, erc20Abi, type Address } from 'viem';
+
+import { type Call, type CallsRequirements } from '@rainbow-me/delegation';
+
+import { RNBW_TOKEN_ADDRESS, STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { buildStakeRnbwCalls, buildStakeRnbwExecutionPlan } from './stakeRnbwCalls';
+
+const mockCanUseSponsoredRnbwStaking = jest.fn<Promise<boolean>, [Address, number]>();
+const mockCheckIfStakingNeedsApproval = jest.fn<Promise<boolean>, [unknown]>();
+
+jest.mock('./canUseSponsoredRnbwStaking', () => ({
+  canUseSponsoredRnbwStaking: (address: Address, chainId: number) => mockCanUseSponsoredRnbwStaking(address, chainId),
+}));
+
+jest.mock('./checkIfStakingNeedsApproval', () => ({
+  checkIfStakingNeedsApproval: (params: unknown) => mockCheckIfStakingNeedsApproval(params),
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const STAKE_AMOUNT_RAW = '1000000000000000000';
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', STAKING_CHAIN_ID);
+const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } } satisfies CallsRequirements;
+
+function buildApprovalCall(): Call {
+  return {
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      args: [STAKING_CONTRACT_ADDRESS, BigInt(STAKE_AMOUNT_RAW)],
+      functionName: 'approve',
+    }),
+    to: RNBW_TOKEN_ADDRESS,
+    value: 0n,
+  };
+}
+
+function buildStakeCall(): Call {
+  return {
+    data: encodeFunctionData({
+      abi: STAKING_ABI,
+      args: [BigInt(STAKE_AMOUNT_RAW)],
+      functionName: 'stake',
+    }),
+    to: STAKING_CONTRACT_ADDRESS,
+    value: 0n,
+  };
+}
+
+describe('stakeRnbwCalls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanUseSponsoredRnbwStaking.mockResolvedValue(false);
+    mockCheckIfStakingNeedsApproval.mockResolvedValue(false);
+  });
+
+  it('builds approval before stake when allowance is insufficient', async () => {
+    mockCheckIfStakingNeedsApproval.mockResolvedValue(true);
+
+    await expect(buildStakeRnbwCalls({ address: ACCOUNT, provider, stakeAmountRaw: STAKE_AMOUNT_RAW })).resolves.toEqual([
+      buildApprovalCall(),
+      buildStakeCall(),
+    ]);
+
+    expect(mockCheckIfStakingNeedsApproval).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      provider,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+  });
+
+  it('omits approval when allowance covers the stake', async () => {
+    await expect(buildStakeRnbwCalls({ address: ACCOUNT, provider, stakeAmountRaw: STAKE_AMOUNT_RAW })).resolves.toEqual([
+      buildStakeCall(),
+    ]);
+  });
+
+  it('adds sponsor-paid requirements when staking can use sponsored execution', async () => {
+    mockCanUseSponsoredRnbwStaking.mockResolvedValue(true);
+
+    await expect(buildStakeRnbwExecutionPlan({ address: ACCOUNT, provider, stakeAmountRaw: STAKE_AMOUNT_RAW })).resolves.toEqual({
+      calls: [buildStakeCall()],
+      requirements: SPONSORED_REQUIREMENTS,
+    });
+
+    expect(mockCanUseSponsoredRnbwStaking).toHaveBeenCalledWith(ACCOUNT, STAKING_CHAIN_ID);
+  });
+
+  it('omits requirements when sponsorship is unavailable', async () => {
+    await expect(buildStakeRnbwExecutionPlan({ address: ACCOUNT, provider, stakeAmountRaw: STAKE_AMOUNT_RAW })).resolves.toEqual({
+      calls: [buildStakeCall()],
+    });
+  });
+});

--- a/src/handlers/LedgerSigner.test.ts
+++ b/src/handlers/LedgerSigner.test.ts
@@ -1,0 +1,109 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { ledgerService } from '@ledgerhq/hw-app-eth';
+
+import { time } from '@/utils/time';
+
+import { LedgerSigner } from './LedgerSigner';
+
+type LedgerSignature = {
+  r: string;
+  s: string;
+  v: string;
+};
+
+const mockSignTransaction = jest.fn<Promise<LedgerSignature>, [string, string, unknown]>();
+const mockGetEthApp = jest.fn();
+
+jest.mock('@ledgerhq/hw-app-eth', () => ({
+  ledgerService: {
+    resolveTransaction: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/ledger', () => ({
+  getEthApp: (deviceId: string) => mockGetEthApp(deviceId),
+}));
+
+jest.mock('@/logger', () => ({
+  ensureError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+  logger: {
+    DebugContext: { ledger: 'ledger' },
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('@/navigation/Navigation', () => ({
+  __esModule: true,
+  default: { handleAction: jest.fn() },
+}));
+
+jest.mock('@/navigation/routesNames', () => ({
+  __esModule: true,
+  default: {
+    PAIR_HARDWARE_WALLET_NAVIGATOR: 'PairHardwareWalletNavigator',
+    PAIR_HARDWARE_WALLET_SIGNING_SHEET: 'PairHardwareWalletSigningSheet',
+  },
+}));
+
+const LEDGER_PATH = "44'/60'/0'/0/0";
+const RESOLUTION_TIMEOUT_MS = time.seconds(10);
+const approvalTransaction = {
+  chainId: 8453,
+  data: '0x095ea7b300000000000000000000000022222222222222222222222222222222222222220000000000000000000000000000000000000000000000000000000000000001',
+  gasLimit: 100_000,
+  gasPrice: 1,
+  nonce: 0,
+  to: '0x1111111111111111111111111111111111111111',
+  value: 0,
+};
+
+function buildSigner() {
+  return new LedgerSigner(new StaticJsonRpcProvider('http://127.0.0.1:8545', 8453), LEDGER_PATH, 'ledger-device-id');
+}
+
+describe('LedgerSigner', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    mockGetEthApp.mockResolvedValue({
+      loadConfig: {},
+      signTransaction: mockSignTransaction,
+    });
+    mockSignTransaction.mockResolvedValue({
+      r: `0x${'11'.repeat(32)}`,
+      s: `0x${'22'.repeat(32)}`,
+      v: '0x1b',
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('falls back to blind signing when Ledger transaction resolution fails', async () => {
+    jest.mocked(ledgerService.resolveTransaction).mockRejectedValue(new Error('resolution unavailable'));
+
+    await expect(buildSigner().signTransaction(approvalTransaction)).resolves.toEqual(expect.stringMatching(/^0x/));
+
+    expect(mockSignTransaction).toHaveBeenCalledWith(LEDGER_PATH, expect.any(String), null);
+  });
+
+  it('falls back to blind signing when Ledger transaction resolution stalls', async () => {
+    jest.useFakeTimers();
+    jest.mocked(ledgerService.resolveTransaction).mockReturnValue(
+      new Promise(() => {
+        return;
+      })
+    );
+
+    const signedTransaction = buildSigner().signTransaction(approvalTransaction);
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(RESOLUTION_TIMEOUT_MS);
+
+    await expect(signedTransaction).resolves.toEqual(expect.stringMatching(/^0x/));
+    expect(mockSignTransaction).toHaveBeenCalledWith(LEDGER_PATH, expect.any(String), null);
+  });
+});

--- a/src/parsers/gas.test.ts
+++ b/src/parsers/gas.test.ts
@@ -1,0 +1,29 @@
+import { buildGasParams } from './gas';
+
+jest.mock('@/handlers/web3', () => ({
+  toHex: (value: string) => `0x${BigInt(value).toString(16)}`,
+}));
+
+describe('buildGasParams', () => {
+  it('builds EIP-1559 transaction gas params from base and priority fees', () => {
+    expect(
+      buildGasParams({
+        isEIP1559: true,
+        maxBaseFee: '100',
+        maxPriorityFee: '10',
+      })
+    ).toEqual({
+      maxFeePerGas: '110',
+      maxPriorityFeePerGas: '10',
+    });
+  });
+
+  it('builds legacy transaction gas params from gas price', () => {
+    expect(
+      buildGasParams({
+        gasPrice: '42',
+        isEIP1559: false,
+      })
+    ).toEqual({ gasPrice: '42' });
+  });
+});


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Adds unit test coverage for RNBW staking flows:

- Sponsored staking eligibility requires chain sponsorship capability and delegated execution support
- Approval + stake call construction includes approval only when allowance is insufficient
- Sponsor-paid requirements are added only for sponsored staking
- Preparation covers wallet-funded staking and claim-only staking
- Software-wallet staking covers both wallet-submitted exact calls and relay-managed sponsored execution
- Hardware-wallet staking waits for approval confirmation before submitting the stake transaction

## Screen recordings / screenshots

## What to test
