### PR TITLE
Minimize e2e brittleness

### DIFF
--- a/.github/ci-rerun.txt
+++ b/.github/ci-rerun.txt
@@ -1,0 +1,1 @@
+Temporary CI rerun marker for PR 7406.

--- a/.github/ci-rerun.txt
+++ b/.github/ci-rerun.txt
@@ -1,1 +1,0 @@
-Temporary CI rerun marker for PR 7406.

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -176,13 +176,26 @@ jobs:
         run: export MAESTRO_VERSION=2.0.10; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
       - name: Install Anvil
+        id: install_anvil
+        continue-on-error: true
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
         with:
           version: stable
 
+      - name: Retry Install Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
+        with:
+          version: stable
+
+      - name: Verify Anvil
+        run: anvil --version
+
       - name: Download and Unpack APK artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl -L -H "Authorization: token ${{ github.token }}" -o artifact.zip "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build.outputs.artifact-id }}/zip"
+          ./scripts/download-github-artifact.sh "${{ needs.build.outputs.artifact-id }}" artifact.zip
           unzip artifact.zip -d downloaded-artifacts
           ls -l downloaded-artifacts
           APK_PATH=$(find downloaded-artifacts -name "*.apk" -print -quit)
@@ -239,8 +252,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Download and Unpack APK artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl -L -H "Authorization: token ${{ github.token }}" -o artifact.zip "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build.outputs.artifact-id }}/zip"
+          ./scripts/download-github-artifact.sh "${{ needs.build.outputs.artifact-id }}" artifact.zip
           unzip artifact.zip -d downloaded-artifacts
           ls -l downloaded-artifacts
           APK_PATH=$(find downloaded-artifacts -name "*.apk" -print -quit)

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
+      # `/perf` issue comments share the build job but do not run local Anvil tests.
       - name: Cache Foundry binaries
         if: github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/e2e')
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+  FOUNDRY_VERSION: v1.5.1
+  FOUNDRY_BIN_DIR: .foundry-bin
 
 jobs:
   build:
@@ -31,10 +33,35 @@ jobs:
       cancel-in-progress: true
     outputs:
       artifact-id: ${{ steps.rock-remote-build-android.outputs.artifact-id }}
+      foundry-artifact-id: ${{ steps.upload-foundry.outputs.artifact-id }}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Cache Foundry binaries
+        if: github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/e2e')
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.FOUNDRY_BIN_DIR }}
+          key: foundry-${{ runner.os }}-${{ runner.arch }}-${{ env.FOUNDRY_VERSION }}
+
+      - name: Install Foundry
+        if: github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/e2e')
+        run: ./scripts/install-foundry.sh
+
+      - name: Pack Foundry binaries
+        if: github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/e2e')
+        run: tar -czf foundry-bin.tar.gz -C "${FOUNDRY_BIN_DIR}" .
+
+      - name: Upload Foundry binaries
+        if: github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/e2e')
+        id: upload-foundry
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: foundry-${{ runner.os }}-${{ runner.arch }}-${{ env.FOUNDRY_VERSION }}-${{ github.run_id }}
+          path: foundry-bin.tar.gz
+          if-no-files-found: error
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -175,21 +202,10 @@ jobs:
       - name: Install Maestro
         run: export MAESTRO_VERSION=2.0.10; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
-      - name: Install Anvil
-        id: install_anvil
-        continue-on-error: true
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
-        with:
-          version: stable
-
-      - name: Retry Install Anvil
-        if: steps.install_anvil.outcome == 'failure'
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
-        with:
-          version: stable
-
-      - name: Verify Anvil
-        run: anvil --version
+      - name: Install Foundry from build artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/install-foundry-from-artifact.sh "${{ needs.build.outputs.foundry-artifact-id }}"
 
       - name: Download and Unpack APK artifact
         env:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -150,13 +150,26 @@ jobs:
         run: export MAESTRO_VERSION=2.0.10; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
       - name: Install Anvil
+        id: install_anvil
+        continue-on-error: true
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
         with:
           version: stable
 
+      - name: Retry Install Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
+        with:
+          version: stable
+
+      - name: Verify Anvil
+        run: anvil --version
+
       - name: Download and Unpack IPA artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          curl -L -H "Authorization: token ${{ github.token }}" -o artifact.zip "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build.outputs.artifact-id }}/zip"
+          ./scripts/download-github-artifact.sh "${{ needs.build.outputs.artifact-id }}" artifact.zip
           unzip artifact.zip -d downloaded-artifacts
           ls -l downloaded-artifacts
           APP_ARCHIVE_PATH=$(find downloaded-artifacts -name "*.tar.gz" -print -quit)

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -8,6 +8,8 @@ on:
     types: [created]
 env:
   NODE_OPTIONS: '--max-old-space-size=6144'
+  FOUNDRY_VERSION: v1.5.1
+  FOUNDRY_BIN_DIR: .foundry-bin
 
 jobs:
   # iOS build job
@@ -27,9 +29,30 @@ jobs:
     timeout-minutes: 45
     outputs:
       artifact-id: ${{ steps.rock-remote-build-ios.outputs.artifact-id }}
+      foundry-artifact-id: ${{ steps.upload-foundry.outputs.artifact-id }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Cache Foundry binaries
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.FOUNDRY_BIN_DIR }}
+          key: foundry-${{ runner.os }}-${{ runner.arch }}-${{ env.FOUNDRY_VERSION }}
+
+      - name: Install Foundry
+        run: ./scripts/install-foundry.sh
+
+      - name: Pack Foundry binaries
+        run: tar -czf foundry-bin.tar.gz -C "${FOUNDRY_BIN_DIR}" .
+
+      - name: Upload Foundry binaries
+        id: upload-foundry
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: foundry-${{ runner.os }}-${{ runner.arch }}-${{ env.FOUNDRY_VERSION }}-${{ github.run_id }}
+          path: foundry-bin.tar.gz
+          if-no-files-found: error
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -149,21 +172,10 @@ jobs:
       - name: Install Maestro
         run: export MAESTRO_VERSION=2.0.10; curl -fsSL "https://get.maestro.mobile.dev" | bash
 
-      - name: Install Anvil
-        id: install_anvil
-        continue-on-error: true
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
-        with:
-          version: stable
-
-      - name: Retry Install Anvil
-        if: steps.install_anvil.outcome == 'failure'
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
-        with:
-          version: stable
-
-      - name: Verify Anvil
-        run: anvil --version
+      - name: Install Foundry from build artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: ./scripts/install-foundry-from-artifact.sh "${{ needs.build.outputs.foundry-artifact-id }}"
 
       - name: Download and Unpack IPA artifact
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ android/app/src/main/java/me/rainbow/MainActivity.java-e
 node_modules/
 npm-debug.log
 yarn-error.log
+.foundry-bin/
 
 # Keystore
 *.keystore

--- a/e2e/flows/onboarding/CreateWallet.yaml
+++ b/e2e/flows/onboarding/CreateWallet.yaml
@@ -9,8 +9,10 @@ tags:
     arguments:
       isE2ETest: true
 - runFlow: ../../utils/Prepare.yaml
-- assertVisible:
-    id: welcome-screen
+- extendedWaitUntil:
+    visible:
+      id: welcome-screen
+    timeout: 60000
 - tapOn: '.*Get a new wallet'
 - runFlow: ../../utils/MaybeSetupPin.yaml
 - runFlow: ../../utils/HandleOptionalNotificationPermission.yaml
@@ -22,5 +24,5 @@ tags:
     id: copy-address-button
 - extendedWaitUntil:
     visible:
-      text: .*\$[\d,]+\.\d{2}.*
+      id: receive-card
     timeout: 30000

--- a/e2e/flows/onboarding/WatchedWallet.yaml
+++ b/e2e/flows/onboarding/WatchedWallet.yaml
@@ -9,6 +9,10 @@ tags:
     arguments:
       isE2ETest: true
 - runFlow: ../../utils/Prepare.yaml
+- extendedWaitUntil:
+    visible:
+      id: welcome-screen
+    timeout: 60000
 - tapOn: '.*I already have one'
 - tapOn:
     id: watch-address-button

--- a/e2e/flows/settings/AndroidCloudBackup.yaml
+++ b/e2e/flows/settings/AndroidCloudBackup.yaml
@@ -64,7 +64,7 @@ tags:
       - tapOn: 'Delete All Google Drive Backups'
       - tapOn: 'Confirm and Delete Backups'
       - tapOn:
-          text: '1'
+          id: numpad-button-1
           repeat: 4
           delay: 1000
       # Skip the "Sign in with ease" phone-lookup interstitial if Google

--- a/e2e/flows/transactions/EditContact.yaml
+++ b/e2e/flows/transactions/EditContact.yaml
@@ -11,13 +11,9 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
-# Connect to Anvil (test network)
-- tapOn:
-    id: dev-button-anvil
+# Send ETH to test wallet and connect to Anvil.
+- runFlow: ../../utils/FundTestWallet.yaml
+- runFlow: ../../utils/ConnectToAnvil.yaml
 
 # Open send sheet
 - retry:

--- a/e2e/flows/transactions/SendNft.yaml
+++ b/e2e/flows/transactions/SendNft.yaml
@@ -11,13 +11,9 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
-# Connect to Anvil (test network)
-- tapOn:
-    id: dev-button-anvil
+# Send ETH to test wallet and connect to Anvil.
+- runFlow: ../../utils/FundTestWallet.yaml
+- runFlow: ../../utils/ConnectToAnvil.yaml
 
 # Open send sheet
 - retry:
@@ -51,6 +47,10 @@ tags:
           from:
             id: wallet-screen
           direction: UP
+      - extendedWaitUntil:
+          visible:
+            id: 'wrapped-nft-Rainbow Pooly 16'
+          timeout: 15000
       - tapOn:
           id: 'wrapped-nft-Rainbow Pooly 16'
 
@@ -86,14 +86,18 @@ tags:
       - runFlow: ../../utils/MaybeInputPin.yaml
 
       # Check toast data
-      - assertVisible:
-          text: 'Sending'
-          childOf:
-            id: toast-.*
-      - assertVisible:
-          text: 'Rainbow Pooly 16'
-          childOf:
-            id: toast-.*
+      - extendedWaitUntil:
+          visible:
+            text: 'Sending'
+            childOf:
+              id: toast-.*
+          timeout: 15000
+      - extendedWaitUntil:
+          visible:
+            text: 'Rainbow Pooly 16'
+            childOf:
+              id: toast-.*
+          timeout: 15000
       # Open toast
       - tapOn:
           id: toast-.*

--- a/e2e/flows/transactions/SendTransaction.yaml
+++ b/e2e/flows/transactions/SendTransaction.yaml
@@ -11,13 +11,9 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
-# Connect to Anvil (test network)
-- tapOn:
-    id: dev-button-anvil
+# Send ETH to test wallet and connect to Anvil.
+- runFlow: ../../utils/FundTestWallet.yaml
+- runFlow: ../../utils/ConnectToAnvil.yaml
 
 # Open send sheet
 - retry:
@@ -76,14 +72,18 @@ tags:
       - runFlow: ../../utils/MaybeInputPin.yaml
 
       # Check toast data
-      - assertVisible:
-          text: 'Sending'
-          childOf:
-            id: toast-.*
-      - assertVisible:
-          text: '0.01 ETH'
-          childOf:
-            id: toast-.*
+      - extendedWaitUntil:
+          visible:
+            text: 'Sending'
+            childOf:
+              id: toast-.*
+          timeout: 15000
+      - extendedWaitUntil:
+          visible:
+            text: '0.01 ETH'
+            childOf:
+              id: toast-.*
+          timeout: 15000
       # Open toast
       - tapOn:
           id: toast-.*

--- a/e2e/flows/transactions/SwapTransaction.yaml
+++ b/e2e/flows/transactions/SwapTransaction.yaml
@@ -18,13 +18,9 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
-# Connect to Anvil (test network)
-- tapOn:
-    id: dev-button-anvil
+# Send ETH to test wallet and connect to Anvil.
+- runFlow: ../../utils/FundTestWallet.yaml
+- runFlow: ../../utils/ConnectToAnvil.yaml
 
 # Open swap screen
 - tapOn:
@@ -63,7 +59,7 @@ tags:
     id: review-panel
 - runFlow:
     when:
-      platform: ios
+      platform: iOS
     commands:
       - assertVisible:
           id: review-panel-min-received-or-max-sold-label

--- a/e2e/flows/transactions/WrapTransaction.yaml
+++ b/e2e/flows/transactions/WrapTransaction.yaml
@@ -103,10 +103,10 @@ tags:
     id: balance-coin-row-Wrapped Ether
 - extendedWaitUntil:
     visible:
-      id: swap
+      id: swap-action-button
     timeout: 30000
 - tapOn:
-    id: swap
+    id: swap-action-button
 - extendedWaitUntil:
     visible:
       id: swap-bottom-action-button

--- a/e2e/flows/transactions/WrapTransaction.yaml
+++ b/e2e/flows/transactions/WrapTransaction.yaml
@@ -18,13 +18,9 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Send ETH to test wallet
-- tapOn:
-    id: fund-test-wallet-button
-
-# Connect to Anvil (test network)
-- tapOn:
-    id: dev-button-anvil
+# Send ETH to test wallet and connect to Anvil.
+- runFlow: ../../utils/FundTestWallet.yaml
+- runFlow: ../../utils/ConnectToAnvil.yaml
 
 # Open swap screen
 - tapOn:
@@ -41,7 +37,7 @@ tags:
 
 - runFlow:
     when:
-      platform: ios
+      platform: iOS
     commands:
       # Test flip button
       - assertVisible: '1 ETH 􀄭 1 WETH'
@@ -103,13 +99,18 @@ tags:
             id: balance-coin-row-Wrapped Ether
           timeout: 30000
 # Unwrap Weth
-- tapOn: '.*Ethereum.*'
 - tapOn:
-    id: swap-action-button
+    id: balance-coin-row-Wrapped Ether
+- extendedWaitUntil:
+    visible:
+      id: swap
+    timeout: 30000
 - tapOn:
-    id: token-to-buy-wrapped-ether-1
-- tapOn:
-    id: flip-button
+    id: swap
+- extendedWaitUntil:
+    visible:
+      id: swap-bottom-action-button
+    timeout: 30000
 - longPressOn:
     id: swap-bottom-action-button
 - runFlow: ../../utils/MaybeInputPin.yaml

--- a/e2e/utils/ConnectToAnvil.yaml
+++ b/e2e/utils/ConnectToAnvil.yaml
@@ -1,0 +1,8 @@
+appId: ${APP_ID}
+---
+- tapOn:
+    id: dev-button-anvil
+- extendedWaitUntil:
+    visible:
+      id: e2e-anvil-connected
+    timeout: 10000

--- a/e2e/utils/FundTestWallet.yaml
+++ b/e2e/utils/FundTestWallet.yaml
@@ -1,0 +1,8 @@
+appId: ${APP_ID}
+---
+- tapOn:
+    id: fund-test-wallet-button
+- extendedWaitUntil:
+    visible:
+      id: e2e-anvil-funded
+    timeout: 30000

--- a/e2e/utils/ImportSecretPhrase.yaml
+++ b/e2e/utils/ImportSecretPhrase.yaml
@@ -18,15 +18,10 @@ env:
       platform: iOS
     commands:
       - tapOn: 'Open'
-# Secret phrase wallets can take longer to load
-- extendedWaitUntil:
-    visible:
-      id: e2e-wallet-ready
-    timeout: 60000
 - extendedWaitUntil:
     visible:
       id: wallet-screen
-    timeout: 30000
+    timeout: 60000
 # Wait for the wallet screen to load.
 - extendedWaitUntil:
     visible:

--- a/e2e/utils/ImportSecretPhrase.yaml
+++ b/e2e/utils/ImportSecretPhrase.yaml
@@ -8,7 +8,8 @@ env:
 - extendedWaitUntil:
     visible:
       id: welcome-screen
-    timeout: 30000
+    # the test fails quite often if the timeout is too low
+    timeout: 60000
 - openLink: rainbow://e2e/import?privateKey=${SECRET_PHRASE}&name=${NAME}
 # The first time a simulator opens a link it shows a dialog.
 - runFlow:
@@ -18,6 +19,10 @@ env:
     commands:
       - tapOn: 'Open'
 # Secret phrase wallets can take longer to load
+- extendedWaitUntil:
+    visible:
+      id: e2e-wallet-ready
+    timeout: 60000
 - extendedWaitUntil:
     visible:
       id: wallet-screen

--- a/e2e/utils/ImportWalletWithKey.yaml
+++ b/e2e/utils/ImportWalletWithKey.yaml
@@ -19,13 +19,9 @@ env:
       - tapOn: 'Open'
 - extendedWaitUntil:
     visible:
-      id: e2e-wallet-ready
+      id: wallet-screen
     timeout: 60000
 - extendedWaitUntil:
     visible:
-      id: wallet-screen
-    timeout: 30000
-- extendedWaitUntil:
-    visible:
-      id: receive-card
-    timeout: 30000
+      id: balance-coin-row-Ethereum
+    timeout: 60000

--- a/e2e/utils/ImportWalletWithKey.yaml
+++ b/e2e/utils/ImportWalletWithKey.yaml
@@ -17,10 +17,15 @@ env:
       platform: iOS
     commands:
       - tapOn: 'Open'
-- assertVisible:
-    id: wallet-screen
-# Wait for wallet to fully load by checking amount
 - extendedWaitUntil:
     visible:
-      text: .*\$[\d,]+\.\d{2}.*
+      id: e2e-wallet-ready
+    timeout: 60000
+- extendedWaitUntil:
+    visible:
+      id: wallet-screen
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      id: receive-card
     timeout: 30000

--- a/e2e/utils/MaybeInputPin.yaml
+++ b/e2e/utils/MaybeInputPin.yaml
@@ -6,6 +6,6 @@ appId: ${APP_ID}
       platform: Android
     commands:
       - tapOn:
-          text: '1'
+          id: numpad-button-1
           repeat: 4
           delay: 1000

--- a/e2e/utils/MaybeSetupPin.yaml
+++ b/e2e/utils/MaybeSetupPin.yaml
@@ -6,10 +6,10 @@ appId: ${APP_ID}
       platform: Android
     commands:
       - tapOn:
-          text: '1'
+          id: numpad-button-1
           repeat: 4
           delay: 1000
       - tapOn:
-          text: '1'
+          id: numpad-button-1
           repeat: 4
           delay: 1000

--- a/scripts/anvil.sh
+++ b/scripts/anvil.sh
@@ -19,4 +19,5 @@ fi
 # Rainbow Router's swapTargets authorization list includes current DEX targets.
 # Stale blocks cause TARGET_NOT_AUTH errors in swap e2e tests.
 # Last updated: 2025-01-28 (block 24333000)
-anvil --fork-url "$ETHEREUM_MAINNET_RPC_DEV" --fork-block-number 24333000 --block-base-fee-per-gas 100000000 --block-gas-limit 30000000 --steps-tracing "$@"
+ANVIL_FORK_BLOCK_NUMBER="${ANVIL_FORK_BLOCK_NUMBER:-24333000}"
+anvil --fork-url "$ETHEREUM_MAINNET_RPC_DEV" --fork-block-number "$ANVIL_FORK_BLOCK_NUMBER" --block-base-fee-per-gas 100000000 --block-gas-limit 30000000 --steps-tracing "$@"

--- a/scripts/download-github-artifact.sh
+++ b/scripts/download-github-artifact.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ARTIFACT_ID="${1:?Usage: $0 <artifact-id> [output-path]}"
+OUTPUT_PATH="${2:-artifact.zip}"
+TMP_PATH="${OUTPUT_PATH}.tmp"
+MAX_ATTEMPTS="${ARTIFACT_DOWNLOAD_ATTEMPTS:-8}"
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+
+ARTIFACT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  rm -f "$TMP_PATH"
+  echo "Downloading artifact $ARTIFACT_ID (attempt $attempt/$MAX_ATTEMPTS)..."
+
+  if curl --fail --location --silent --show-error \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -o "$TMP_PATH" \
+    "$ARTIFACT_URL"; then
+    if unzip -tq "$TMP_PATH" >/dev/null 2>&1; then
+      mv "$TMP_PATH" "$OUTPUT_PATH"
+      echo "Artifact saved to $OUTPUT_PATH"
+      exit 0
+    fi
+
+    echo "Downloaded response is not a valid zip:" >&2
+    head -c 500 "$TMP_PATH" >&2 || true
+    echo >&2
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep $((attempt * 5))
+  fi
+done
+
+echo "Failed to download a valid zip for artifact $ARTIFACT_ID" >&2
+exit 1

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 source .env
 
-ARTIFACTS_FOLDER=e2e-artifacts
+ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
 FLOW="e2e/flows"
 ARGS=()
 SHARD_TOTAL=1
@@ -35,6 +35,28 @@ start_log_capture() {
     adb logcat -v time > "$log_dir/logcat.txt" &
     LOG_CAPTURE_PID=$!
   fi
+}
+
+wait_for_anvil() {
+  local rpc_url="${1:-http://127.0.0.1:8545}"
+  local max_attempts="${ANVIL_READY_ATTEMPTS:-30}"
+
+  for attempt in $(seq 1 "$max_attempts"); do
+    if response=$(curl --silent --show-error --fail --max-time 2 \
+      -H 'Content-Type: application/json' \
+      --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+      "$rpc_url" 2>/dev/null) && [[ "$response" == *'"result"'* ]]; then
+      echo "✅ Anvil ready at $rpc_url"
+      return 0
+    fi
+
+    echo "⏳ Waiting for Anvil ($attempt/$max_attempts)..."
+    sleep 1
+  done
+
+  echo "❌ Anvil did not become ready at $rpc_url" >&2
+  tail -n 100 "$ARTIFACTS_FOLDER/anvil/mainnet.log" >&2 || true
+  exit 1
 }
 
 # Stop recording function
@@ -185,7 +207,7 @@ if $NEEDS_ANVIL; then
   mkdir -p "$ARTIFACTS_FOLDER/anvil"
   ./scripts/anvil.sh --host 0.0.0.0 > "$ARTIFACTS_FOLDER/anvil/mainnet.log" 2>&1 &
   ANVIL_PID=$!
-  sleep 5
+  wait_for_anvil "http://127.0.0.1:8545"
 fi
 
 # Run tests with retries.

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 source .env
 
 ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-e2e-artifacts}"
+ANVIL_FORK_BLOCK_NUMBER="${ANVIL_FORK_BLOCK_NUMBER:-24333000}"
+ANVIL_RPC_URL="http://127.0.0.1:8545"
 FLOW="e2e/flows"
 ARGS=()
 SHARD_TOTAL=1
@@ -15,6 +17,7 @@ RECORD_ON_FAILURE=false
 MAX_ATTEMPTS=1
 RECORDING_PID=""
 LOG_CAPTURE_PID=""
+ANVIL_START_COUNT=0
 
 stop_log_capture() {
   if [ -n "${LOG_CAPTURE_PID:-}" ]; then
@@ -38,7 +41,7 @@ start_log_capture() {
 }
 
 wait_for_anvil() {
-  local rpc_url="${1:-http://127.0.0.1:8545}"
+  local rpc_url="${1:-$ANVIL_RPC_URL}"
   local max_attempts="${ANVIL_READY_ATTEMPTS:-30}"
 
   for attempt in $(seq 1 "$max_attempts"); do
@@ -57,6 +60,68 @@ wait_for_anvil() {
   echo "❌ Anvil did not become ready at $rpc_url" >&2
   tail -n 100 "$ARTIFACTS_FOLDER/anvil/mainnet.log" >&2 || true
   exit 1
+}
+
+test_needs_anvil() {
+  [[ "$1" == *"/transactions/"* ]]
+}
+
+stop_anvil() {
+  if [ -n "${ANVIL_PID:-}" ]; then
+    echo "🛑 Killing Anvil (PID: $ANVIL_PID)"
+    kill "$ANVIL_PID" 2>/dev/null || true
+    wait "$ANVIL_PID" 2>/dev/null || true
+    ANVIL_PID=""
+  fi
+}
+
+start_anvil() {
+  echo "🔌 Starting Anvil..."
+
+  local existing_pid
+  existing_pid=$(lsof -t -i:8545 -c anvil 2>/dev/null || true)
+  if [ -n "$existing_pid" ]; then kill "$existing_pid" 2>/dev/null || true; fi
+  sleep 1
+
+  mkdir -p "$ARTIFACTS_FOLDER/anvil"
+  ANVIL_START_COUNT=$((ANVIL_START_COUNT + 1))
+  printf '\n===== Anvil start %s at %s =====\n' "$ANVIL_START_COUNT" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$ARTIFACTS_FOLDER/anvil/mainnet.log"
+  ANVIL_FORK_BLOCK_NUMBER="$ANVIL_FORK_BLOCK_NUMBER" ./scripts/anvil.sh --host 0.0.0.0 >> "$ARTIFACTS_FOLDER/anvil/mainnet.log" 2>&1 &
+  ANVIL_PID=$!
+  wait_for_anvil "$ANVIL_RPC_URL"
+}
+
+reset_anvil() {
+  local payload
+  payload=$(printf '{"jsonrpc":"2.0","id":1,"method":"anvil_reset","params":[{"forking":{"jsonRpcUrl":"%s","blockNumber":%s}}]}' "$ETHEREUM_MAINNET_RPC_DEV" "$ANVIL_FORK_BLOCK_NUMBER")
+
+  for attempt in 1 2 3; do
+    if response=$(curl --silent --show-error --fail --max-time 10 \
+      -H 'Content-Type: application/json' \
+      --data "$payload" \
+      "$ANVIL_RPC_URL" 2>/dev/null) && [[ "$response" == *'"result"'* && "$response" != *'"error"'* ]]; then
+      echo "✅ Anvil reset to fork block $ANVIL_FORK_BLOCK_NUMBER"
+      return 0
+    fi
+
+    echo "⏳ Resetting Anvil ($attempt/3)..."
+    sleep 0.2
+  done
+
+  return 1
+}
+
+prepare_anvil_for_attempt() {
+  if [ -z "${ANVIL_PID:-}" ]; then
+    start_anvil
+    return
+  fi
+
+  if reset_anvil; then return; fi
+
+  echo "⚠️ Anvil reset failed. Restarting Anvil..."
+  stop_anvil
+  start_anvil
 }
 
 # Stop recording function
@@ -115,10 +180,7 @@ cleanup() {
     RECORDING_PID=""
   fi
   stop_log_capture
-  if [ -n "${ANVIL_PID:-}" ]; then
-    echo "🛑 Killing Anvil (PID: $ANVIL_PID)"
-    kill "$ANVIL_PID" 2>/dev/null || true
-  fi
+  stop_anvil
 }
 
 handle_interrupt() {
@@ -188,28 +250,6 @@ else
   fi
 fi
 
-# Start Anvil only if any test path includes "transaction".
-NEEDS_ANVIL=false
-for FILE in "${TEST_FILES[@]}"; do
-  if [[ "$FILE" == *"/transactions/"* ]]; then
-    NEEDS_ANVIL=true
-    break
-  fi
-done
-
-if $NEEDS_ANVIL; then
-  echo "🔌 Transaction test detected. Starting Anvil..."
-
-  ANVIL_PID=$(lsof -t -i:8545 -c anvil 2>/dev/null || true)
-  if [ -n "$ANVIL_PID" ]; then kill "$ANVIL_PID" 2>/dev/null || true; fi
-  sleep 1
-
-  mkdir -p "$ARTIFACTS_FOLDER/anvil"
-  ./scripts/anvil.sh --host 0.0.0.0 > "$ARTIFACTS_FOLDER/anvil/mainnet.log" 2>&1 &
-  ANVIL_PID=$!
-  wait_for_anvil "http://127.0.0.1:8545"
-fi
-
 # Run tests with retries.
 EXIT_CODE=0
 for TEST_FILE in "${TEST_FILES[@]}"; do
@@ -223,6 +263,10 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
 
     START_TIME=$(date +%s)
     DEBUG_OUTPUT="$ARTIFACTS_FOLDER/maestro/⏱️-$TEST_NAME-$ATTEMPT"
+
+    if test_needs_anvil "$TEST_FILE"; then
+      prepare_anvil_for_attempt
+    fi
 
     # Start recording for attempts after first failure
     if [ "$SHOULD_RECORD" = "true" ]; then

--- a/scripts/install-foundry-from-artifact.sh
+++ b/scripts/install-foundry-from-artifact.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ARTIFACT_ID="${1:?Usage: $0 <artifact-id>}"
+FOUNDRY_BIN_DIR="${FOUNDRY_BIN_DIR:-.foundry-bin}"
+TMP_DIR="$(mktemp -d)"
+ARTIFACT_ZIP="${2:-$TMP_DIR/foundry-artifact.zip}"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+./scripts/download-github-artifact.sh "$ARTIFACT_ID" "$ARTIFACT_ZIP"
+
+rm -rf "$FOUNDRY_BIN_DIR"
+mkdir -p "$FOUNDRY_BIN_DIR"
+FOUNDRY_BIN_DIR="$(cd "$FOUNDRY_BIN_DIR" && pwd)"
+
+unzip -q "$ARTIFACT_ZIP" -d "$TMP_DIR"
+tar -xzf "$TMP_DIR/foundry-bin.tar.gz" -C "$FOUNDRY_BIN_DIR"
+chmod +x "$FOUNDRY_BIN_DIR"/*
+
+"$FOUNDRY_BIN_DIR/anvil" --version
+
+if [ -n "${GITHUB_PATH:-}" ]; then
+  echo "$FOUNDRY_BIN_DIR" >> "$GITHUB_PATH"
+fi

--- a/scripts/install-foundry.sh
+++ b/scripts/install-foundry.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+FOUNDRY_VERSION="${FOUNDRY_VERSION:-v1.5.1}"
+FOUNDRY_BIN_DIR="${FOUNDRY_BIN_DIR:-.foundry-bin}"
+FOUNDRY_DOWNLOAD_ATTEMPTS="${FOUNDRY_DOWNLOAD_ATTEMPTS:-8}"
+
+resolve_platform() {
+  case "$(uname -s)" in
+    Darwin) echo darwin ;;
+    Linux) echo linux ;;
+    *)
+      echo "Unsupported Foundry platform: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolve_arch() {
+  case "$(uname -m)" in
+    arm64 | aarch64) echo arm64 ;;
+    x86_64 | amd64) echo amd64 ;;
+    *)
+      echo "Unsupported Foundry architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+anvil_matches_version() {
+  if [ ! -x "$FOUNDRY_BIN_DIR/anvil" ]; then
+    return 1
+  fi
+
+  if [ "$FOUNDRY_VERSION" = "stable" ]; then
+    "$FOUNDRY_BIN_DIR/anvil" --version >/dev/null 2>&1
+    return
+  fi
+
+  "$FOUNDRY_BIN_DIR/anvil" --version | grep -q "${FOUNDRY_VERSION#v}"
+}
+
+add_foundry_to_path() {
+  if [ -n "${GITHUB_PATH:-}" ]; then
+    echo "$FOUNDRY_BIN_DIR" >> "$GITHUB_PATH"
+  fi
+}
+
+mkdir -p "$FOUNDRY_BIN_DIR"
+FOUNDRY_BIN_DIR="$(cd "$FOUNDRY_BIN_DIR" && pwd)"
+
+if anvil_matches_version; then
+  echo "Using Foundry from $FOUNDRY_BIN_DIR"
+  "$FOUNDRY_BIN_DIR/anvil" --version
+  add_foundry_to_path
+  exit 0
+fi
+
+platform="$(resolve_platform)"
+arch="$(resolve_arch)"
+archive_name="foundry_${FOUNDRY_VERSION}_${platform}_${arch}.tar.gz"
+download_url="https://github.com/foundry-rs/foundry/releases/download/${FOUNDRY_VERSION}/${archive_name}"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+for attempt in $(seq 1 "$FOUNDRY_DOWNLOAD_ATTEMPTS"); do
+  echo "Downloading Foundry ${FOUNDRY_VERSION} for ${platform}/${arch} (attempt ${attempt}/${FOUNDRY_DOWNLOAD_ATTEMPTS})..."
+  rm -f "$tmp_dir/$archive_name"
+
+  if curl --fail --location --silent --show-error \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 10 --max-time 120 \
+    -o "$tmp_dir/$archive_name" \
+    "$download_url"; then
+    break
+  fi
+
+  if [ "$attempt" -eq "$FOUNDRY_DOWNLOAD_ATTEMPTS" ]; then
+    echo "Failed to download Foundry from $download_url" >&2
+    exit 1
+  fi
+
+  sleep $((attempt * 5))
+done
+
+mkdir -p "$tmp_dir/extract"
+tar -xzf "$tmp_dir/$archive_name" -C "$tmp_dir/extract"
+
+for binary in anvil cast chisel forge; do
+  if [ -f "$tmp_dir/extract/$binary" ]; then
+    install -m 0755 "$tmp_dir/extract/$binary" "$FOUNDRY_BIN_DIR/$binary"
+  fi
+done
+
+"$FOUNDRY_BIN_DIR/anvil" --version
+add_foundry_to_path

--- a/src/components/E2EStatusMarker.tsx
+++ b/src/components/E2EStatusMarker.tsx
@@ -1,0 +1,27 @@
+import { StyleSheet, View } from 'react-native';
+
+import { IS_TEST } from '@/env';
+
+type E2EStatusMarkerProps = {
+  id: string | null;
+};
+
+/**
+ * Exposes an invisible test-only anchor for asynchronous setup state.
+ */
+export function E2EStatusMarker({ id }: E2EStatusMarkerProps) {
+  if (!IS_TEST || !id) return null;
+
+  return <View collapsable={false} pointerEvents="none" style={styles.marker} testID={id} />;
+}
+
+const styles = StyleSheet.create({
+  marker: {
+    backgroundColor: 'rgba(0, 0, 0, 0.01)',
+    height: 2,
+    position: 'absolute',
+    right: 0,
+    top: 72,
+    width: 2,
+  },
+});

--- a/src/components/TestDeeplinkHandler.tsx
+++ b/src/components/TestDeeplinkHandler.tsx
@@ -84,7 +84,7 @@ export function TestDeeplinkHandler() {
 
   if (commandStatus === 'idle') return null;
 
-  return <View pointerEvents="none" style={styles.marker} testID={`e2e-${commandStatus}`} />;
+  return <View collapsable={false} pointerEvents="none" style={styles.marker} testID={`e2e-${commandStatus}`} />;
 }
 
 function getQueryValue(value: string | string[] | undefined): string | undefined {
@@ -93,11 +93,11 @@ function getQueryValue(value: string | string[] | undefined): string | undefined
 
 const styles = StyleSheet.create({
   marker: {
-    bottom: 0,
-    height: 1,
-    opacity: 0.01,
+    backgroundColor: 'rgba(0, 0, 0, 0.01)',
+    height: 2,
     position: 'absolute',
     right: 0,
-    width: 1,
+    top: 72,
+    width: 2,
   },
 });

--- a/src/components/TestDeeplinkHandler.tsx
+++ b/src/components/TestDeeplinkHandler.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Linking, StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { Linking } from 'react-native';
 
 import URL from 'url-parse';
 
+import { E2EStatusMarker } from '@/components/E2EStatusMarker';
 import { savePIN } from '@/handlers/authentication';
 import { logger, RainbowError } from '@/logger';
 import Navigation from '@/navigation/Navigation';
@@ -15,7 +16,6 @@ type E2ECommandStatus = 'idle' | 'wallet-importing' | 'wallet-ready' | 'wallet-e
  * Handles E2E test commands. See e2e/README.md:31 for usage.
  */
 export function TestDeeplinkHandler() {
-  const handledUrls = useRef(new Set<string>());
   const [commandStatus, setCommandStatus] = useState<E2ECommandStatus>('idle');
 
   const handleUrl = useCallback(async (url: string | null) => {
@@ -26,9 +26,6 @@ export function TestDeeplinkHandler() {
       if (protocol !== 'rainbow:' || host !== 'e2e') {
         return;
       }
-
-      if (handledUrls.current.has(url)) return;
-      handledUrls.current.add(url);
 
       const action = pathname.split('/')[1];
 
@@ -82,22 +79,9 @@ export function TestDeeplinkHandler() {
     return listener.remove;
   }, [handleUrl]);
 
-  if (commandStatus === 'idle') return null;
-
-  return <View collapsable={false} pointerEvents="none" style={styles.marker} testID={`e2e-${commandStatus}`} />;
+  return <E2EStatusMarker id={commandStatus === 'idle' ? null : `e2e-${commandStatus}`} />;
 }
 
 function getQueryValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
-
-const styles = StyleSheet.create({
-  marker: {
-    backgroundColor: 'rgba(0, 0, 0, 0.01)',
-    height: 2,
-    position: 'absolute',
-    right: 0,
-    top: 72,
-    width: 2,
-  },
-});

--- a/src/components/TestDeeplinkHandler.tsx
+++ b/src/components/TestDeeplinkHandler.tsx
@@ -1,47 +1,103 @@
-import { useEffect } from 'react';
-import { Linking } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Linking, StyleSheet, View } from 'react-native';
 
 import URL from 'url-parse';
 
 import { savePIN } from '@/handlers/authentication';
-import { logger } from '@/logger';
+import { logger, RainbowError } from '@/logger';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { initializeWallet } from '@/state/wallets/initializeWallet';
+
+type E2ECommandStatus = 'idle' | 'wallet-importing' | 'wallet-ready' | 'wallet-error';
 
 /**
  * Handles E2E test commands. See e2e/README.md:31 for usage.
  */
 export function TestDeeplinkHandler() {
-  useEffect(() => {
-    const listener = Linking.addListener('url', async ({ url }) => {
+  const handledUrls = useRef(new Set<string>());
+  const [commandStatus, setCommandStatus] = useState<E2ECommandStatus>('idle');
+
+  const handleUrl = useCallback(async (url: string | null) => {
+    if (!url) return;
+
+    try {
       const { protocol, host, pathname, query } = new URL(url, true);
       if (protocol !== 'rainbow:' || host !== 'e2e') {
         return;
       }
 
+      if (handledUrls.current.has(url)) return;
+      handledUrls.current.add(url);
+
       const action = pathname.split('/')[1];
 
       switch (action) {
-        case 'import':
+        case 'import': {
+          const privateKey = getQueryValue(query.privateKey);
+          const name = getQueryValue(query.name);
+          if (!privateKey || !name) {
+            throw new RainbowError('[TestDeeplinkHandler]: missing import params');
+          }
+
+          setCommandStatus('wallet-importing');
           await savePIN('1111');
           await initializeWallet({
-            seedPhrase: query.privateKey,
-            name: query.name,
+            seedPhrase: privateKey,
+            name,
             userPin: '1111',
           });
           Navigation.replace(Routes.SWIPE_LAYOUT, {
             screen: Routes.WALLET_SCREEN,
           });
+          setCommandStatus('wallet-ready');
           break;
+        }
         default:
           logger.debug(`[TestDeeplinkHandler]: unknown path`, { url });
           break;
       }
-    });
-    return listener.remove;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    } catch (e) {
+      setCommandStatus('wallet-error');
+      logger.error(new RainbowError('[TestDeeplinkHandler]: command failed', e), {
+        url,
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
   }, []);
 
-  return null;
+  useEffect(() => {
+    Linking.getInitialURL()
+      .then(handleUrl)
+      .catch(e => {
+        logger.error(new RainbowError('[TestDeeplinkHandler]: failed to read initial URL', e), {
+          message: e instanceof Error ? e.message : String(e),
+        });
+      });
+
+    const listener = Linking.addListener('url', ({ url }) => {
+      void handleUrl(url);
+    });
+
+    return listener.remove;
+  }, [handleUrl]);
+
+  if (commandStatus === 'idle') return null;
+
+  return <View pointerEvents="none" style={styles.marker} testID={`e2e-${commandStatus}`} />;
 }
+
+function getQueryValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+const styles = StyleSheet.create({
+  marker: {
+    bottom: 0,
+    height: 1,
+    opacity: 0.01,
+    position: 'absolute',
+    right: 0,
+    width: 1,
+  },
+});

--- a/src/components/asset-list/RecyclerAssetList2/WrappedTokenFamilyHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/WrappedTokenFamilyHeader.tsx
@@ -30,8 +30,9 @@ export default React.memo(function WrappedTokenFamilyHeader({ name, total, image
 
     // from closed -> open, let's fetch the inner nft metadata
     if (!isOpen) {
-      const force = (useNftsStore.getState().getNftsByCollection(uid.toLowerCase())?.size || 0) !== (total || 0);
-      useNftsStore.getState().fetchNftCollection(uid.toLowerCase(), force);
+      const expectedCount = Number(total || 0);
+      const force = (useNftsStore.getState().getNftsByCollection(uid.toLowerCase())?.size || 0) !== expectedCount;
+      useNftsStore.getState().fetchNftCollection(uid.toLowerCase(), { expectedCount, force });
     }
   });
 

--- a/src/features/ens/screens/ENSConfirmRegisterSheet.tsx
+++ b/src/features/ens/screens/ENSConfirmRegisterSheet.tsx
@@ -156,7 +156,7 @@ export default function ENSConfirmRegisterSheet() {
 
       // revalidate nft data for ens collection
       const ensCollectionId = `${Network.mainnet}_${ENS_NFT_CONTRACT_ADDRESS}`;
-      useNftsStore.getState().fetchNftCollection(ensCollectionId, true);
+      useNftsStore.getState().fetchNftCollection(ensCollectionId, { force: true });
       useNftsStore.getState().fetch({ limit: PAGE_SIZE }, { staleTime: time.seconds(5) });
 
       setTimeout(() => {

--- a/src/helpers/RainbowContext.tsx
+++ b/src/helpers/RainbowContext.tsx
@@ -1,11 +1,12 @@
 import React, { createContext, useCallback, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform } from 'react-native';
 
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { parseEther } from '@ethersproject/units';
 import { Wallet } from '@ethersproject/wallet';
 import { useSharedValue } from 'react-native-reanimated';
 
+import { E2EStatusMarker } from '@/components/E2EStatusMarker';
 import { IS_DEV, IS_TEST } from '@/env';
 import Emoji from '@/framework/ui/components/Emoji';
 import { logger, RainbowError } from '@/logger';
@@ -28,7 +29,7 @@ export const RainbowContext = createContext<RainbowContextType>({
   },
 });
 
-type E2EAnvilStatus = 'idle' | 'connected' | 'connect-error';
+type E2EAnvilStatus = 'idle' | 'connected' | 'disconnected' | 'connect-error';
 type E2EFundingStatus = 'idle' | 'funding' | 'funded' | 'funding-error';
 
 export default function RainbowContextWrapper({ children }: PropsWithChildren) {
@@ -63,9 +64,10 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
 
   const connectToAnvil = useCallback(async () => {
     try {
-      setConnectedToAnvil(true);
-      setE2EAnvilStatus('connected');
-      logger.debug('connected to anvil');
+      const nextConnected = !useConnectedToAnvilStore.getState().connectedToAnvil;
+      setConnectedToAnvil(nextConnected);
+      setE2EAnvilStatus(nextConnected ? 'connected' : 'disconnected');
+      logger.debug(nextConnected ? 'connected to anvil' : 'disconnected from anvil');
     } catch (e) {
       setConnectedToAnvil(false);
       setE2EAnvilStatus('connect-error');
@@ -102,12 +104,8 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
   return (
     <RainbowContext.Provider value={initialValue}>
       {children}
-      {IS_TEST && e2eFundingStatus !== 'idle' && (
-        <View collapsable={false} pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eFundingStatus}`} />
-      )}
-      {IS_TEST && e2eAnvilStatus !== 'idle' && (
-        <View collapsable={false} pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eAnvilStatus}`} />
-      )}
+      <E2EStatusMarker id={e2eFundingStatus === 'idle' ? null : `e2e-anvil-${e2eFundingStatus}`} />
+      <E2EStatusMarker id={e2eAnvilStatus === 'idle' ? null : `e2e-anvil-${e2eAnvilStatus}`} />
       {showReloadButton && IS_DEV && <DevButton color={colors.red} initialDisplacement={200} />}
       {((showConnectToAnvilButton && IS_DEV) || IS_TEST) && (
         <>
@@ -127,14 +125,3 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
     </RainbowContext.Provider>
   );
 }
-
-const styles = StyleSheet.create({
-  e2eMarker: {
-    backgroundColor: 'rgba(0, 0, 0, 0.01)',
-    height: 2,
-    position: 'absolute',
-    right: 0,
-    top: 72,
-    width: 2,
-  },
-});

--- a/src/helpers/RainbowContext.tsx
+++ b/src/helpers/RainbowContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
-import { Platform } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { parseEther } from '@ethersproject/units';
@@ -28,11 +28,16 @@ export const RainbowContext = createContext<RainbowContextType>({
   },
 });
 
+type E2EAnvilStatus = 'idle' | 'connected' | 'connect-error';
+type E2EFundingStatus = 'idle' | 'funding' | 'funded' | 'funding-error';
+
 export default function RainbowContextWrapper({ children }: PropsWithChildren) {
   // This value is hold here to prevent JS VM from shutting down
   // on unmounting all shared values.
   useSharedValue(0);
   const setConnectedToAnvil = useConnectedToAnvilStore(state => state.setConnectedToAnvil);
+  const [e2eAnvilStatus, setE2EAnvilStatus] = useState<E2EAnvilStatus>('idle');
+  const [e2eFundingStatus, setE2EFundingStatus] = useState<E2EFundingStatus>('idle');
   const [globalState, updateGlobalState] = useState({});
 
   useEffect(() => {
@@ -58,11 +63,12 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
 
   const connectToAnvil = useCallback(async () => {
     try {
-      const currentValue = useConnectedToAnvilStore.getState().connectedToAnvil;
-      setConnectedToAnvil(!currentValue);
+      setConnectedToAnvil(true);
+      setE2EAnvilStatus('connected');
       logger.debug('connected to anvil');
     } catch (e) {
       setConnectedToAnvil(false);
+      setE2EAnvilStatus('connect-error');
       logger.error(new RainbowError('error connecting to anvil'), {
         message: e instanceof Error ? e.message : String(e),
       });
@@ -74,14 +80,19 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
     if (!IS_TEST) return;
     const RPC_URL = Platform.OS === 'android' ? 'http://10.0.2.2:8545' : 'http://127.0.0.1:8545';
     try {
+      setE2EFundingStatus('funding');
       const provider = new JsonRpcProvider(RPC_URL);
+      await provider.getNetwork();
       const wallet = new Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', provider);
       const testWalletAddress = '0x4d14289265eb7c166cF111A76B6D742e3b85dF85';
-      await wallet.sendTransaction({
+      const transaction = await wallet.sendTransaction({
         to: testWalletAddress,
         value: parseEther('20'),
       });
+      await transaction.wait(1);
+      setE2EFundingStatus('funded');
     } catch (e) {
+      setE2EFundingStatus('funding-error');
       logger.error(new RainbowError('error funding test wallet'), {
         message: e instanceof Error ? e.message : String(e),
       });
@@ -91,6 +102,12 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
   return (
     <RainbowContext.Provider value={initialValue}>
       {children}
+      {IS_TEST && e2eFundingStatus !== 'idle' && (
+        <View pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eFundingStatus}`} />
+      )}
+      {IS_TEST && e2eAnvilStatus !== 'idle' && (
+        <View pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eAnvilStatus}`} />
+      )}
       {showReloadButton && IS_DEV && <DevButton color={colors.red} initialDisplacement={200} />}
       {((showConnectToAnvilButton && IS_DEV) || IS_TEST) && (
         <>
@@ -110,3 +127,14 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
     </RainbowContext.Provider>
   );
 }
+
+const styles = StyleSheet.create({
+  e2eMarker: {
+    bottom: 0,
+    height: 1,
+    opacity: 0.01,
+    position: 'absolute',
+    right: 0,
+    width: 1,
+  },
+});

--- a/src/helpers/RainbowContext.tsx
+++ b/src/helpers/RainbowContext.tsx
@@ -103,10 +103,10 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
     <RainbowContext.Provider value={initialValue}>
       {children}
       {IS_TEST && e2eFundingStatus !== 'idle' && (
-        <View pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eFundingStatus}`} />
+        <View collapsable={false} pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eFundingStatus}`} />
       )}
       {IS_TEST && e2eAnvilStatus !== 'idle' && (
-        <View pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eAnvilStatus}`} />
+        <View collapsable={false} pointerEvents="none" style={styles.e2eMarker} testID={`e2e-anvil-${e2eAnvilStatus}`} />
       )}
       {showReloadButton && IS_DEV && <DevButton color={colors.red} initialDisplacement={200} />}
       {((showConnectToAnvilButton && IS_DEV) || IS_TEST) && (
@@ -130,11 +130,11 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
 
 const styles = StyleSheet.create({
   e2eMarker: {
-    bottom: 0,
-    height: 1,
-    opacity: 0.01,
+    backgroundColor: 'rgba(0, 0, 0, 0.01)',
+    height: 2,
     position: 'absolute',
     right: 0,
-    width: 1,
+    top: 72,
+    width: 2,
   },
 });

--- a/src/helpers/assets.ts
+++ b/src/helpers/assets.ts
@@ -337,14 +337,15 @@ export const buildBriefUniqueTokenList = (
     }
 
     for (const { id, imageUrl, name, totalCount } of collections.values()) {
-      let adjustedTotalCount = totalCount;
+      const total = Number(totalCount) || 0;
+      let adjustedTotalCount = total;
 
       if (isShowcaseDataMigrated && isHiddenDataMigrated) {
         const specialCount = specialTokensByCollection.get(id.toLowerCase()) || 0;
-        adjustedTotalCount = String(Math.max(0, Number(totalCount) - specialCount));
+        adjustedTotalCount = Math.max(0, total - specialCount);
       }
 
-      if (Number(adjustedTotalCount) === 0) {
+      if (adjustedTotalCount === 0) {
         continue;
       }
 
@@ -356,7 +357,7 @@ export const buildBriefUniqueTokenList = (
         uid: id,
       });
 
-      for (let index = 0; index < Number(adjustedTotalCount); index++) {
+      for (let index = 0; index < adjustedTotalCount; index++) {
         const uniqueId = `${id}_${index}`;
         result.push({ index, type: CellType.NFT, uid: uniqueId, collectionId: id });
       }

--- a/src/hooks/useFetchOpenCollectionsOnMount.ts
+++ b/src/hooks/useFetchOpenCollectionsOnMount.ts
@@ -29,10 +29,11 @@ export default function useFetchOpenCollectionsOnMount() {
 
     const collections = Object.keys(openCollections).filter(collectionId => shouldFetchCollections(collectionId, openCollections));
 
-    const { fetchNftCollection } = useNftsStore.getState(address);
+    const { fetchNftCollection, getNftCollection } = useNftsStore.getState(address);
     const promises = collections.map(collectionId => {
       const normalizedCollectionId = collectionId.toLowerCase();
-      return fetchNftCollection(normalizedCollectionId);
+      const expectedCount = Number(getNftCollection(normalizedCollectionId)?.totalCount || 0) || undefined;
+      return fetchNftCollection(normalizedCollectionId, { expectedCount });
     });
 
     promiseUtils.PromiseAllWithFails(promises);

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import remoteConfig, { type FirebaseRemoteConfigTypes } from '@react-native-firebase/remote-config';
 import { dequal } from 'dequal';
 
-import { IS_DEV, IS_STORE_INSTALL } from '@/env';
+import { IS_DEV, IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { CURRENT_APP_VERSION } from '@/hooks/useAppVersion';
 import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
@@ -303,6 +303,14 @@ export const useRemoteConfigStore = createQueryStore<RainbowConfig, never, Remot
 // ============ Public Methods ================================================= //
 
 export async function initializeRemoteConfig(): Promise<void> {
+  if (IS_TEST) {
+    useRemoteConfigStore.setState({
+      config: { ...DEFAULT_CONFIG },
+      lastFetchedVersion: REMOTE_CONFIG_VERSION,
+    });
+    return;
+  }
+
   const { fetch, lastFetchedVersion } = useRemoteConfigStore.getState();
   if (lastFetchedVersion !== REMOTE_CONFIG_VERSION) {
     await Promise.race([fetch(undefined, { force: true }), delay(time.seconds(3))]);
@@ -326,6 +334,8 @@ export function useRemoteConfig<const K extends readonly RemoteConfigKey[]>(...k
 
 export function useRemoteConfigUpdates(): void {
   useEffect(() => {
+    if (IS_TEST) return;
+
     const rc = remoteConfig();
     const unsubscribe = rc.onConfigUpdated(async (_, error) => {
       if (error) return;
@@ -343,6 +353,8 @@ const PARSERS = buildParsers(DEFAULT_CONFIG);
 let hasInitializedRemoteConfig = false;
 
 async function fetchRemoteConfig(): Promise<RainbowConfig> {
+  if (IS_TEST) return { ...DEFAULT_CONFIG };
+
   const rc = remoteConfig();
   const newConfig: RainbowConfig = { ...DEFAULT_CONFIG };
 

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import remoteConfig, { type FirebaseRemoteConfigTypes } from '@react-native-firebase/remote-config';
 import { dequal } from 'dequal';
 
-import { IS_DEV, IS_STORE_INSTALL, IS_TEST } from '@/env';
+import { IS_DEV, IS_STORE_INSTALL } from '@/env';
 import { CURRENT_APP_VERSION } from '@/hooks/useAppVersion';
 import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
@@ -303,14 +303,6 @@ export const useRemoteConfigStore = createQueryStore<RainbowConfig, never, Remot
 // ============ Public Methods ================================================= //
 
 export async function initializeRemoteConfig(): Promise<void> {
-  if (IS_TEST) {
-    useRemoteConfigStore.setState({
-      config: { ...DEFAULT_CONFIG },
-      lastFetchedVersion: REMOTE_CONFIG_VERSION,
-    });
-    return;
-  }
-
   const { fetch, lastFetchedVersion } = useRemoteConfigStore.getState();
   if (lastFetchedVersion !== REMOTE_CONFIG_VERSION) {
     await Promise.race([fetch(undefined, { force: true }), delay(time.seconds(3))]);
@@ -334,8 +326,6 @@ export function useRemoteConfig<const K extends readonly RemoteConfigKey[]>(...k
 
 export function useRemoteConfigUpdates(): void {
   useEffect(() => {
-    if (IS_TEST) return;
-
     const rc = remoteConfig();
     const unsubscribe = rc.onConfigUpdated(async (_, error) => {
       if (error) return;
@@ -353,8 +343,6 @@ const PARSERS = buildParsers(DEFAULT_CONFIG);
 let hasInitializedRemoteConfig = false;
 
 async function fetchRemoteConfig(): Promise<RainbowConfig> {
-  if (IS_TEST) return { ...DEFAULT_CONFIG };
-
   const rc = remoteConfig();
   const newConfig: RainbowConfig = { ...DEFAULT_CONFIG };
 

--- a/src/screens/SendSheet.tsx
+++ b/src/screens/SendSheet.tsx
@@ -694,7 +694,7 @@ export default function SendSheet() {
         // if the user sent an NFT, we need to revalidate the NFT data
         if (isUniqueAsset) {
           const collectionId = `${selected.network}_${selected.contractAddress}`;
-          useNftsStore.getState(accountAddress).fetchNftCollection(collectionId, true);
+          useNftsStore.getState(accountAddress).fetchNftCollection(collectionId, { force: true });
           useNftsStore.getState(accountAddress).fetch({ limit: PAGE_SIZE }, { staleTime: time.seconds(5) });
         }
         executeFn(goBackAndNavigate, {

--- a/src/state/nfts/createNftsStore.ts
+++ b/src/state/nfts/createNftsStore.ts
@@ -25,6 +25,7 @@ import { useBackendNetworksStore } from '../backendNetworks/backendNetworks';
 import {
   type Collection,
   type CollectionId,
+  type FetchNftCollectionOptions,
   type NftParams,
   type NftsQueryData,
   type NftsState,
@@ -184,6 +185,33 @@ const fetchNftData = async (params: NftParams): Promise<NftsQueryData> => {
     return EMPTY_RETURN_DATA;
   }
 };
+
+function fetchedNftCount(data: NftsQueryData, collectionId: CollectionId): number {
+  if (collectionId === 'showcase' || collectionId === 'hidden') {
+    let count = 0;
+    for (const collection of data.nftsByCollection.values()) {
+      count += collection.size;
+    }
+    return count;
+  }
+
+  return data.nftsByCollection.get(collectionId)?.size ?? 0;
+}
+
+function hasFetchedCollectionResult(data: NftsQueryData | null | undefined, collectionId: CollectionId): data is NftsQueryData {
+  if (!data?.nftsByCollection.size) return false;
+  if (collectionId === 'showcase' || collectionId === 'hidden') {
+    return true;
+  }
+
+  return data.nftsByCollection.has(collectionId);
+}
+
+function hasFetchedExpectedNfts(data: NftsQueryData | null | undefined, collectionId: CollectionId, expectedCount?: number): boolean {
+  if (!hasFetchedCollectionResult(data, collectionId)) return false;
+  if (!expectedCount) return true;
+  return fetchedNftCount(data, collectionId) >= expectedCount;
+}
 
 function createSelector<T>(
   selectorFn: (
@@ -418,8 +446,9 @@ export const createNftsStore = (address: Address | string) =>
         }
       },
 
-      async fetchNftCollection(collectionId, force = false) {
+      async fetchNftCollection(collectionId, options: FetchNftCollectionOptions = {}) {
         const normalizedCollectionId = collectionId.toLowerCase();
+        const { expectedCount, force = false } = options;
 
         let addressPromises = collectionsPromises.get(address);
         if (!addressPromises) {
@@ -469,7 +498,7 @@ export const createNftsStore = (address: Address | string) =>
             }
           } else {
             const collection = getNftsByCollection(normalizedCollectionId);
-            if (collection && !isEmpty(collection)) {
+            if (collection && (expectedCount ? collection.size >= expectedCount : !isEmpty(collection))) {
               return;
             }
           }
@@ -483,8 +512,7 @@ export const createNftsStore = (address: Address | string) =>
                 { force, skipStoreUpdates: true, cacheTime: time.infinity, staleTime: time.infinity }
               );
 
-              // retry clause for if there are no nfts in the collection data
-              if (!data?.nftsByCollection.size) continue;
+              if (!data || !hasFetchedExpectedNfts(data, normalizedCollectionId, expectedCount)) continue;
 
               const now = Date.now();
               set(state => ({

--- a/src/state/nfts/types.ts
+++ b/src/state/nfts/types.ts
@@ -35,6 +35,11 @@ export type Collection = {
   totalCount: string;
 };
 
+export type FetchNftCollectionOptions = {
+  expectedCount?: number;
+  force?: boolean;
+};
+
 export type NftsByCollection = Map<CollectionId, Map<UniqueId, UniqueAsset>>;
 
 export interface NftsState {
@@ -44,7 +49,7 @@ export interface NftsState {
   fetchedCollections: { [collectionId: string]: number };
   pagination: PaginationInfo | null;
   fetchNextNftCollectionPage: () => Promise<void>;
-  fetchNftCollection: (collectionId: CollectionId, force?: boolean) => Promise<void>;
+  fetchNftCollection: (collectionId: CollectionId, options?: FetchNftCollectionOptions) => Promise<void>;
   getNftCollections: () => Map<CollectionId, Collection> | null;
   getNftCollection: (collectionId: CollectionId) => Collection | null;
   getNftsByCollection: (collectionId: CollectionId) => Map<UniqueId, UniqueAsset> | null;


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Fixes several sources of e2e brittleness that were showing up as intermittent Android and iOS shard failures.

## E2E setup

- Runs transaction flows against a pinned Foundry/Anvil setup shared across shards
- Downloads workflow artifacts through a retrying helper that validates the zip before extraction
- Waits for Anvil RPC readiness before Maestro starts a transaction flow
- Resets Anvil to `ANVIL_FORK_BLOCK_NUMBER` before each transaction attempt, with an Anvil restart if reset fails
- Handles test wallet import URLs delivered at launch through `Linking.getInitialURL()`
- Transaction setup waits on app-level state exposed through `E2EStatusMarker`:
  - wallet import exposes `e2e-wallet-importing`, `e2e-wallet-ready`, and `e2e-wallet-error`
  - Anvil connection exposes `e2e-anvil-connected`
  - Anvil funding exposes `e2e-anvil-funded` after the provider is reachable and the funding transaction confirms

## Maestro flows

- Transaction and onboarding flows wait on stable screen/testID anchors instead of rendered balance text
- Android PIN entry uses the numpad testID rather than relying on visible-text matching against `1`
- Swap and wrap iOS command blocks use Maestro's case-sensitive `iOS` platform value
- Send and wrap flows wait for target asset/NFT rows, action buttons, and toast contents before continuing

## NFT collection loading

The SendNft recordings showed the Rainbow Pooly collection with the collection row visible, but `Rainbow Pooly 16` was missing from the expanded collection.

- `fetchNftCollection(...)` accepts `{ expectedCount, force }`
- Non-forced collection fetches retry until the response includes the requested collection and at least the expected number of NFTs
- Collection open/mount paths pass the known collection total as `expectedCount`
- Forced refreshes after NFT sends and ENS registration bypass `expectedCount`, because those refreshes can legitimately remove NFTs from the collection
- `buildBriefUniqueTokenList(...)` normalizes collection totals before building placeholder NFT rows
