### PR TITLE
feat: set Lighter referrer inside dapp browser

### DIFF
--- a/src/components/DappBrowser/dappReferrals.test.ts
+++ b/src/components/DappBrowser/dappReferrals.test.ts
@@ -21,4 +21,12 @@ describe('dappReferrals', () => {
   it('returns the original URL when a browser referral already exists', () => {
     expect(addReferralToDappBrowserUrl('https://www.polymarket.com/?r=existing')).toBe('https://www.polymarket.com/?r=existing');
   });
+
+  it('returns the Lighter referral URL when a browser referral applies', () => {
+    expect(addReferralToDappBrowserUrl('https://app.lighter.xyz/trade')).toBe('https://app.lighter.xyz/trade?referral=7228476M');
+  });
+
+  it('returns the original URL when a Lighter referral already exists', () => {
+    expect(addReferralToDappBrowserUrl('https://app.lighter.xyz/?referral=existing')).toBe('https://app.lighter.xyz/?referral=existing');
+  });
 });

--- a/src/components/DappBrowser/dappReferrals.ts
+++ b/src/components/DappBrowser/dappReferrals.ts
@@ -1,3 +1,5 @@
+import { LIGHTER_HOSTNAMES } from '@/features/lighter/constants';
+import { getLighterReferralUrl } from '@/features/lighter/utils/lighterReferralUrl';
 import { POLYMARKET_HOSTNAMES } from '@/features/polymarket/constants';
 import { getPolymarketReferralUrl } from '@/features/polymarket/utils/polymarketReferralUrl';
 import { getDappHostname } from '@/utils/connectedApps';
@@ -7,7 +9,10 @@ type DappReferral = {
   hostnames: ReadonlySet<string>;
 };
 
-const DAPP_REFERRALS: DappReferral[] = [{ hostnames: POLYMARKET_HOSTNAMES, getUrl: getPolymarketReferralUrl }];
+const DAPP_REFERRALS: DappReferral[] = [
+  { hostnames: POLYMARKET_HOSTNAMES, getUrl: getPolymarketReferralUrl },
+  { hostnames: LIGHTER_HOSTNAMES, getUrl: getLighterReferralUrl },
+];
 
 export function addReferralToDappBrowserUrl(url: string): string {
   const hostname = getDappHostname(url);

--- a/src/features/lighter/constants.ts
+++ b/src/features/lighter/constants.ts
@@ -1,0 +1,3 @@
+export const LIGHTER_HOSTNAMES: ReadonlySet<string> = new Set(['app.lighter.xyz', 'lighter.xyz', 'www.lighter.xyz']);
+export const LIGHTER_REFERRAL_PARAM = 'referral';
+export const LIGHTER_REFERRAL_CODE = '7228476M';

--- a/src/features/lighter/utils/lighterReferralUrl.test.ts
+++ b/src/features/lighter/utils/lighterReferralUrl.test.ts
@@ -1,0 +1,23 @@
+import { getLighterReferralUrl } from '@/features/lighter/utils/lighterReferralUrl';
+
+describe('getLighterReferralUrl', () => {
+  it('adds the Lighter referral query param', () => {
+    expect(getLighterReferralUrl('https://app.lighter.xyz/trade?foo=bar#positions')).toBe(
+      'https://app.lighter.xyz/trade?foo=bar&referral=7228476M#positions'
+    );
+  });
+
+  it('does not replace an existing Lighter referral query param', () => {
+    expect(getLighterReferralUrl('https://app.lighter.xyz/?referral=existing')).toBe('https://app.lighter.xyz/?referral=existing');
+  });
+
+  it('supports lighter.xyz and www.lighter.xyz hostnames', () => {
+    expect(getLighterReferralUrl('https://lighter.xyz/trade')).toBe('https://lighter.xyz/trade?referral=7228476M');
+    expect(getLighterReferralUrl('https://www.lighter.xyz/trade')).toBe('https://www.lighter.xyz/trade?referral=7228476M');
+  });
+
+  it('returns null for non-Lighter URLs or invalid URLs', () => {
+    expect(getLighterReferralUrl('https://example.com')).toBeNull();
+    expect(getLighterReferralUrl('not a url')).toBeNull();
+  });
+});

--- a/src/features/lighter/utils/lighterReferralUrl.ts
+++ b/src/features/lighter/utils/lighterReferralUrl.ts
@@ -1,0 +1,21 @@
+import { LIGHTER_HOSTNAMES, LIGHTER_REFERRAL_CODE, LIGHTER_REFERRAL_PARAM } from '@/features/lighter/constants';
+
+export function getLighterReferralUrl(url: string): string | null {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (!LIGHTER_HOSTNAMES.has(parsedUrl.hostname)) {
+    return null;
+  }
+
+  if (!parsedUrl.searchParams.has(LIGHTER_REFERRAL_PARAM)) {
+    parsedUrl.searchParams.set(LIGHTER_REFERRAL_PARAM, LIGHTER_REFERRAL_CODE);
+  }
+
+  return parsedUrl.toString();
+}


### PR DESCRIPTION
Fixes APP-3659

## What changed (plus any additional context for devs)

Adds Lighter referral support to the same shared dapp referral pipeline we already use for Polymarket.  
When users open Lighter in dapp browser , we now append Rainbow’s referral code if it is not already present.