### PR TITLE
[Sponsored Swaps]: Final fixes

### DIFF
--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -31,6 +31,7 @@ import {
   useColorMode,
   useForegroundColor,
 } from '@/design-system';
+import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { useWillExecuteDelegation, willExecuteDelegation } from '@/features/delegation/willDelegate';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { convertRawAmountToBalance, convertRawAmountToBalanceWorklet, handleSignificantDecimals, multiply } from '@/helpers/utilities';
@@ -250,11 +251,10 @@ export const SlippageRow = () => {
 };
 
 export function ReviewPanel() {
-  const { navigate } = useNavigation();
   const { isDarkMode } = useColorMode();
   const { configProgress, lastTypedInput, internalSelectedInputAsset, internalSelectedOutputAsset, quote } = useSwapContext();
+  const shouldShowGasRow = !useIsSponsoredSwap();
 
-  const labelTertiary = useForegroundColor('labelTertiary');
   const separator = useForegroundColor('separator');
 
   const chainLabels = backendNetworksActions.getChainsLabel();
@@ -287,19 +287,6 @@ export function ReviewPanel() {
 
     return unknown;
   });
-
-  const openGasExplainer = useCallback(async () => {
-    const chainsNativeAsset = backendNetworksActions.getChainsNativeAsset();
-    const chainId = swapsStore.getState().inputAsset?.chainId ?? ChainId.mainnet;
-    const nativeAsset = chainsNativeAsset[chainId];
-    const decision = await willExecuteDelegation({ address: getAccountAddress(), chainId });
-
-    navigate(Routes.EXPLAIN_SHEET, {
-      chainId,
-      type: decision.willDelegate ? 'smart_wallet_activation' : 'gas',
-      nativeAsset,
-    });
-  }, [navigate]);
 
   const styles = useAnimatedStyle(() => {
     return {
@@ -386,51 +373,77 @@ export function ReviewPanel() {
 
           <SlippageRow />
 
-          <Separator color={{ custom: opacity(separator, 0.03) }} thickness={THICK_BORDER_WIDTH} />
-
-          <Inline horizontalSpace="10px" alignVertical="center" alignHorizontal="justify" wrap={false}>
-            <ButtonPressAnimation onPress={openGasExplainer} scaleTo={0.925}>
-              <Stack space="10px">
-                <Inline alignVertical="center" horizontalSpace="6px" wrap={false}>
-                  <View style={sx.chainBadgeContainer}>
-                    <AnimatedChainImage showMainnetBadge assetType="input" size={16} />
-                  </View>
-                  <UnmountOnAnimatedReaction
-                    isMountedWorklet={() => {
-                      'worklet';
-                      // only mounted when review panel is visible
-                      return configProgress.value === NavigationSteps.SHOW_REVIEW;
-                    }}
-                    placeholder={
-                      <Inline horizontalSpace="4px">
-                        <EstimatedSwapGasFeeSlot text="Loading…" align="left" color="label" size="15pt" weight="heavy" />
-                        {null}
-                      </Inline>
-                    }
-                  >
-                    <Inline horizontalSpace="4px">
-                      <EstimatedGasFee />
-                      <EstimatedArrivalTime />
-                    </Inline>
-                  </UnmountOnAnimatedReaction>
-                </Inline>
-
-                <Inline wrap={false} alignHorizontal="left" alignVertical="center" horizontalSpace="4px">
-                  <GasLabel />
-                  <Text align="center" color={{ custom: opacity(labelTertiary, 0.24) }} size="icon 13px" weight="semibold">
-                    􀅴
-                  </Text>
-                </Inline>
-              </Stack>
-            </ButtonPressAnimation>
-
-            <Inline alignVertical="center" horizontalSpace="8px">
-              <ReviewGasButton />
-            </Inline>
-          </Inline>
+          {shouldShowGasRow && (
+            <>
+              <Separator color={{ custom: opacity(separator, 0.03) }} thickness={THICK_BORDER_WIDTH} />
+              <ReviewGasRow />
+            </>
+          )}
         </Box>
       </Stack>
     </Box>
+  );
+}
+
+function ReviewGasRow() {
+  const { navigate } = useNavigation();
+  const { configProgress } = useSwapContext();
+  const labelTertiary = useForegroundColor('labelTertiary');
+
+  const openGasExplainer = useCallback(async () => {
+    const chainsNativeAsset = backendNetworksActions.getChainsNativeAsset();
+    const chainId = swapsStore.getState().inputAsset?.chainId ?? ChainId.mainnet;
+    const nativeAsset = chainsNativeAsset[chainId];
+    const decision = await willExecuteDelegation({ address: getAccountAddress(), chainId });
+
+    navigate(Routes.EXPLAIN_SHEET, {
+      chainId,
+      type: decision.willDelegate ? 'smart_wallet_activation' : 'gas',
+      nativeAsset,
+    });
+  }, [navigate]);
+
+  return (
+    <Inline horizontalSpace="10px" alignVertical="center" alignHorizontal="justify" wrap={false}>
+      <ButtonPressAnimation onPress={openGasExplainer} scaleTo={0.925}>
+        <Stack space="10px">
+          <Inline alignVertical="center" horizontalSpace="6px" wrap={false}>
+            <View style={sx.chainBadgeContainer}>
+              <AnimatedChainImage showMainnetBadge assetType="input" size={16} />
+            </View>
+            <UnmountOnAnimatedReaction
+              isMountedWorklet={() => {
+                'worklet';
+                // only mounted when review panel is visible
+                return configProgress.value === NavigationSteps.SHOW_REVIEW;
+              }}
+              placeholder={
+                <Inline horizontalSpace="4px">
+                  <EstimatedSwapGasFeeSlot text="Loading…" align="left" color="label" size="15pt" weight="heavy" />
+                  {null}
+                </Inline>
+              }
+            >
+              <Inline horizontalSpace="4px">
+                <EstimatedGasFee />
+                <EstimatedArrivalTime />
+              </Inline>
+            </UnmountOnAnimatedReaction>
+          </Inline>
+
+          <Inline wrap={false} alignHorizontal="left" alignVertical="center" horizontalSpace="4px">
+            <GasLabel />
+            <Text align="center" color={{ custom: opacity(labelTertiary, 0.24) }} size="icon 13px" weight="semibold">
+              􀅴
+            </Text>
+          </Inline>
+        </Stack>
+      </ButtonPressAnimation>
+
+      <Inline alignVertical="center" horizontalSpace="8px">
+        <ReviewGasButton />
+      </Inline>
+    </Inline>
   );
 }
 

--- a/src/__swaps__/screens/Swap/constants.ts
+++ b/src/__swaps__/screens/Swap/constants.ts
@@ -20,6 +20,7 @@ const TOP_INSET = Math.max(safeAreaInsetValues.top, 20);
 
 export const REVIEW_SHEET_ROW_HEIGHT = 10;
 export const REVIEW_SHEET_ROW_GAP = 24;
+export const REVIEW_SHEET_SPONSORED_GAS_OFFSET = 68;
 export const REVIEW_SHEET_HEIGHT = 412;
 export const SETTINGS_SHEET_HEIGHT = 299;
 export const SETTINGS_SHEET_ROW_GAP = 28;

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -15,6 +15,7 @@ import {
   REVIEW_SHEET_HEIGHT,
   REVIEW_SHEET_ROW_GAP,
   REVIEW_SHEET_ROW_HEIGHT,
+  REVIEW_SHEET_SPONSORED_GAS_OFFSET,
   SETTINGS_SHEET_HEIGHT,
   SETTINGS_SHEET_ROW_GAP,
 } from '@/__swaps__/screens/Swap/constants';
@@ -28,7 +29,9 @@ import { getTokenSearchButtonWrapperStyle } from '@/components/token-search/styl
 import { useColorMode } from '@/design-system';
 import { foregroundColors } from '@/design-system/color/palettes';
 import { IS_ANDROID } from '@/env';
+import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { opacity } from '@/framework/ui/utils/opacity';
+import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
@@ -60,6 +63,7 @@ export function useAnimatedSwapStyles({
   swapInfo: DerivedValue<{ areAllInputsZero: boolean; areBothAssetsSet: boolean; isBridging: boolean }>;
 }) {
   const { isDarkMode } = useColorMode();
+  const isSponsoredSwap = useStoreSharedValue(useIsSponsoredSwap, s => s);
 
   const flipButtonStyle = useAnimatedStyle(() => {
     return {
@@ -201,6 +205,7 @@ export function useAnimatedSwapStyles({
 
     if (isReviewing) {
       heightForCurrentSheet -= REVIEW_SHEET_ROW_HEIGHT + REVIEW_SHEET_ROW_GAP;
+      if (isSponsoredSwap.value) heightForCurrentSheet -= REVIEW_SHEET_SPONSORED_GAS_OFFSET;
     } else if (degenMode.value && isSettingsOpen && swapInfo.value.areBothAssetsSet) {
       heightForCurrentSheet += REVIEW_SHEET_ROW_HEIGHT + SETTINGS_SHEET_ROW_GAP * 2 + THICK_BORDER_WIDTH;
     }

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -37,6 +37,7 @@ import { clamp, getDefaultSlippageWorklet, parseAssetAndExtend, trimTrailingZero
 import { trackSwapEvent } from '@/__swaps__/utils/trackSwapEvent';
 import { analytics } from '@/analytics';
 import { IS_IOS } from '@/env';
+import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
 import { getPreparedSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
 import { divWorklet, equalWorklet, lessThanOrEqualToWorklet, mulWorklet } from '@/framework/core/safeMath';
@@ -55,7 +56,7 @@ import { walletExecuteRap } from '@/raps/execute';
 import { type RapSwapActionParameters } from '@/raps/references';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
-import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { backendNetworksActions, useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { ChainId } from '@/state/backendNetworks/types';
 import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 import { getNextNonce } from '@/state/nonces';
@@ -81,6 +82,7 @@ const selectToken = i18n.t(i18n.l.swap.actions.select_token);
 const insufficientFunds = i18n.t(i18n.l.swap.actions.insufficient_funds);
 const insufficient = i18n.t(i18n.l.swap.actions.insufficient);
 const quoteError = i18n.t(i18n.l.swap.actions.quote_error);
+const sponsorshipUnavailable = i18n.t(i18n.l.swap.sponsorship_unavailable);
 
 type ConfirmButtonProps = {
   label: string;
@@ -351,6 +353,13 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
 
         if (errorMessage !== 'handled') {
           logger.error(new RainbowError(`[getNonceAndPerformSwap]: Error executing swap: ${errorMessage}`));
+
+          if (isInsufficientSponsorBalanceError(errorMessage)) {
+            backendNetworksActions.disableSponsorshipUntilNextFetch(parameters.chainId);
+            Alert.alert(i18n.t(i18n.l.swap.error_executing_swap), sponsorshipUnavailable);
+            return;
+          }
+
           const extractedError = errorMessage.split('[')[0];
           Alert.alert(i18n.t(i18n.l.swap.error_executing_swap), extractedError);
           return;

--- a/src/features/delegation/sponsoredCalls.test.ts
+++ b/src/features/delegation/sponsoredCalls.test.ts
@@ -1,0 +1,49 @@
+import { type Address } from 'viem';
+
+import { ChainId } from '@/state/backendNetworks/types';
+
+import { isInsufficientSponsorBalanceError, predictSponsoredCallsExecution } from './sponsoredCalls';
+
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
+const mockIsSponsorshipEligible = jest.fn<boolean, [ChainId]>();
+
+jest.mock('./willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    isSponsorshipEligible: (chainId: ChainId) => mockIsSponsorshipEligible(chainId),
+  },
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+
+describe('sponsoredCalls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanUseDelegatedExecution.mockReturnValue(true);
+    mockIsSponsorshipEligible.mockReturnValue(true);
+  });
+
+  it('uses the provided sponsorship eligibility list when one is supplied', () => {
+    expect(
+      predictSponsoredCallsExecution({
+        address: ACCOUNT,
+        chainId: ChainId.base,
+        sponsorshipEligibleChainIds: [],
+      })
+    ).toBe(false);
+
+    expect(mockIsSponsorshipEligible).not.toHaveBeenCalled();
+  });
+
+  it('recognizes relay sponsor-capacity failures', () => {
+    expect(
+      isInsufficientSponsorBalanceError(
+        'Managed relay execution failed: relay.link POST /execute rejected request: HTTP 400: {"error":"INSUFFICIENT_SPONSOR_BALANCE"}'
+      )
+    ).toBe(true);
+    expect(isInsufficientSponsorBalanceError('Managed relay execution reverted')).toBe(false);
+  });
+});

--- a/src/features/delegation/sponsoredCalls.ts
+++ b/src/features/delegation/sponsoredCalls.ts
@@ -5,10 +5,29 @@ import { type ChainId } from '@/state/backendNetworks/types';
 
 import { canUseDelegatedExecution } from './willDelegate';
 
+const INSUFFICIENT_SPONSOR_BALANCE = 'INSUFFICIENT_SPONSOR_BALANCE';
+
 /**
- * Predicts sponsor-paid exact-call eligibility from synchronous wallet and chain facts.
+ * Synchronously predicts sponsor-paid exact-call eligibility.
  */
-export function predictSponsoredCallsExecution({ address, chainId }: { address: Address; chainId: ChainId | null }): boolean {
+export function predictSponsoredCallsExecution({
+  address,
+  chainId,
+  sponsorshipEligibleChainIds,
+}: {
+  address: Address;
+  chainId: ChainId | null;
+  sponsorshipEligibleChainIds?: ChainId[];
+}): boolean {
   if (!canUseDelegatedExecution(address)) return false;
-  return chainId === null || backendNetworksActions.isSponsorshipEligible(chainId);
+  if (chainId === null) return true;
+
+  return sponsorshipEligibleChainIds?.includes(chainId) ?? backendNetworksActions.isSponsorshipEligible(chainId);
+}
+
+/**
+ * Returns true when a relay error indicates the sponsor wallet is depleted.
+ */
+export function isInsufficientSponsorBalanceError(message: string): boolean {
+  return message.includes(INSUFFICIENT_SPONSOR_BALANCE);
 }

--- a/src/features/delegation/sponsoredSwapStore.ts
+++ b/src/features/delegation/sponsoredSwapStore.ts
@@ -60,15 +60,16 @@ export function getPreparedSponsoredSwap(): Promise<PreparedCallsExecution | nul
 
 export const useIsSponsoredSwap = createDerivedStore<boolean>(
   $ => {
-    const accountAddress = $(useWalletsStore, s => s.accountAddress);
-    const inputChainId = $(useSwapsStore, s => s.inputAsset?.chainId);
+    const address = $(useWalletsStore, s => s.accountAddress);
+    const chainId = $(useSwapsStore, s => s.inputAsset?.chainId ?? null);
+    const isPreparingSwap = $(useSponsoredSwapStore, s => s.getStatus('isInitialLoad'));
     const preparedSwap = $(useSponsoredSwapStore, s => s.getData());
     const sponsoredSwapsEnabled = $(useRemoteConfigStore, s => s.config.sponsored_swaps_enabled);
 
     if (!sponsoredSwapsEnabled) return false;
 
-    const canSponsor = predictSponsoredCallsExecution({ address: accountAddress, chainId: inputChainId ?? null });
-    if (!canSponsor || !preparedSwap) return canSponsor;
+    const canSponsor = predictSponsoredCallsExecution({ address, chainId });
+    if (!canSponsor || isPreparingSwap) return canSponsor;
 
     return isPreparedCallsExecutionSponsored(preparedSwap);
   },

--- a/src/features/delegation/sponsoredSwapStore.ts
+++ b/src/features/delegation/sponsoredSwapStore.ts
@@ -7,6 +7,7 @@ import { predictSponsoredCallsExecution } from '@/features/delegation/sponsoredC
 import { getProvider } from '@/handlers/web3';
 import { useRemoteConfigStore } from '@/model/remoteConfig';
 import { buildAtomicExecutionRequirements, prepareAtomicSwapCalls } from '@/raps/atomicSwapPreparation';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { getAccountAddress, useWalletsStore } from '@/state/wallets/walletsStore';
 import { time } from '@/utils/time';
@@ -15,7 +16,7 @@ import { type CrosschainQuote, type Quote, type QuoteError } from '@rainbow-me/s
 
 import { supportsDelegatedExecution } from './willDelegate';
 
-// ============ Types ========================================================= //
+// ============ Types ========================================================== //
 
 type SponsoredSwapParams = {
   quoteKey: number | null;
@@ -26,21 +27,24 @@ type CurrentSponsoredSwap = {
   quote: Quote | CrosschainQuote;
 };
 
-// ============ Quote Key ===================================================== //
+// ============ Quote Key ====================================================== //
 
 const useSponsoredSwapQuoteKey = createDerivedStore(
   $ => {
     const accountAddress = $(useWalletsStore, s => s.accountAddress);
     const quote = $(useSwapsStore, s => s.quote);
+    const sponsorshipEligibleChainIds = $(useBackendNetworksStore, s => s.getSponsorshipEligibleChainIds());
+    const sponsoredSwapsEnabled = $(useRemoteConfigStore, s => s.config.sponsored_swaps_enabled);
 
     if (!isValidSponsoredSwapQuote(quote, accountAddress)) return null;
+    if (!sponsoredSwapsEnabled || !sponsorshipEligibleChainIds.includes(quote.chainId)) return null;
 
     return performance.now();
   },
   { lockDependencies: true }
 );
 
-// ============ Store ========================================================= //
+// ============ Stores ========================================================= //
 
 export const useSponsoredSwapStore = createPreparedCallsStore<PreparedCallsExecution, SponsoredSwapParams>(fetchPreparedSponsoredSwap, {
   enabled: $ => $(useSponsoredSwapQuoteKey, quoteKey => quoteKey !== null),
@@ -51,30 +55,33 @@ export const useSponsoredSwapStore = createPreparedCallsStore<PreparedCallsExecu
   staleTime: time.seconds(12),
 });
 
-export function getPreparedSponsoredSwap(): Promise<PreparedCallsExecution | null> {
-  const quoteKey = useSponsoredSwapQuoteKey.getState();
-  if (quoteKey === null) return Promise.resolve(null);
-
-  return useSponsoredSwapStore.getState().getPreparedCalls({ quoteKey });
-}
-
 export const useIsSponsoredSwap = createDerivedStore<boolean>(
   $ => {
     const address = $(useWalletsStore, s => s.accountAddress);
     const chainId = $(useSwapsStore, s => s.inputAsset?.chainId ?? null);
+    const sponsorshipEligibleChainIds = $(useBackendNetworksStore, s => s.getSponsorshipEligibleChainIds());
     const isPreparingSwap = $(useSponsoredSwapStore, s => s.getStatus('isInitialLoad'));
     const preparedSwap = $(useSponsoredSwapStore, s => s.getData());
     const sponsoredSwapsEnabled = $(useRemoteConfigStore, s => s.config.sponsored_swaps_enabled);
 
     if (!sponsoredSwapsEnabled) return false;
 
-    const canSponsor = predictSponsoredCallsExecution({ address, chainId });
+    const canSponsor = predictSponsoredCallsExecution({ address, chainId, sponsorshipEligibleChainIds });
     if (!canSponsor || isPreparingSwap) return canSponsor;
 
     return isPreparedCallsExecutionSponsored(preparedSwap);
   },
   { lockDependencies: true }
 );
+
+// ============ Public Helpers ================================================= //
+
+export function getPreparedSponsoredSwap(): Promise<PreparedCallsExecution | null> {
+  const quoteKey = useSponsoredSwapQuoteKey.getState();
+  if (quoteKey === null) return Promise.resolve(null);
+
+  return useSponsoredSwapStore.getState().getPreparedCalls({ quoteKey });
+}
 
 // ============ Fetcher ======================================================== //
 
@@ -106,7 +113,7 @@ async function fetchPreparedSponsoredSwap(): Promise<PreparedCallsExecution | nu
   });
 }
 
-// ============ Local Helpers ================================================= //
+// ============ Local Helpers ================================================== //
 
 function readCurrentSwapQuote(): CurrentSponsoredSwap | null {
   const address = getAccountAddress();

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
@@ -26,6 +26,7 @@ const mockExecuteCalls = jest.fn<Promise<unknown>, [unknown, unknown?]>();
 const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
 const mockBuildStakeRnbwCalls = jest.fn<Promise<Call[]>, [unknown]>();
 const mockBuildStakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
 const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unknown]>();
 const mockTrackCallsExecution = jest.fn<void, [unknown]>();
 const mockWaitForManagedExecutionConfirmation = jest.fn<Promise<void>, [string]>();
@@ -75,6 +76,10 @@ jest.mock('@/utils/ethereumUtils', () => ({
 jest.mock('./stakeRnbwCalls', () => ({
   buildStakeRnbwCalls: (params: unknown) => mockBuildStakeRnbwCalls(params),
   buildStakeRnbwExecutionPlan: (params: unknown) => mockBuildStakeRnbwExecutionPlan(params),
+}));
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
 }));
 
 const ACCOUNT: Address = '0x3333333333333333333333333333333333333333';
@@ -242,6 +247,7 @@ describe('executeStakeRnbw', () => {
     jest.clearAllMocks();
     mockBuildStakeRnbwCalls.mockResolvedValue([STAKE_CALL]);
     mockBuildStakeRnbwExecutionPlan.mockResolvedValue({ calls: [STAKE_CALL] });
+    mockCanUseDelegatedExecution.mockReturnValue(true);
     mockResolveManagedExecutionFailure.mockResolvedValue(null);
     mockWaitForManagedExecutionConfirmation.mockResolvedValue();
   });
@@ -464,6 +470,74 @@ describe('executeStakeRnbw', () => {
       }),
     });
     await expect(submittedRequest(hardwareSigner, 2)).resolves.toMatchObject({
+      to: STAKING_CONTRACT_ADDRESS,
+      value: 0n,
+      gasLimit: ESTIMATED_STAKE_GAS_LIMIT,
+      ...GAS_PARAMS,
+    });
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledTimes(2);
+    expect(waitForTransaction).toHaveBeenLastCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('uses confirmed sequential approval before staking when software-wallet delegation is unavailable', async () => {
+    const approvalConfirmation = defer<TransactionReceipt>();
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockImplementation(hash => {
+      if (hash === APPROVAL_TX_HASH) return approvalConfirmation.promise;
+      return Promise.resolve(buildReceipt(hash));
+    });
+    const sendTransaction = jest
+      .spyOn(signer, 'sendTransaction')
+      .mockImplementationOnce(transaction => buildTransactionResponse({ hash: APPROVAL_TX_HASH, nonce: 1, transaction }))
+      .mockImplementationOnce(transaction => buildTransactionResponse({ hash: TX_HASH, nonce: 2, transaction }));
+
+    mockCanUseDelegatedExecution.mockReturnValue(false);
+    mockBuildStakeRnbwCalls.mockResolvedValue([APPROVAL_CALL, STAKE_CALL]);
+    jest
+      .spyOn(provider, 'estimateGas')
+      .mockRejectedValueOnce(new Error('approval estimate failed'))
+      .mockResolvedValueOnce(ESTIMATED_STAKE_GAS_LIMIT);
+
+    const execution = executeStakeRnbw({
+      address: ACCOUNT,
+      asset: rnbwAsset,
+      gasParams: GAS_PARAMS,
+      preparedCalls: null,
+      provider,
+      signer,
+      stakeAmountRaw: STAKE_AMOUNT_RAW,
+    });
+
+    await waitForMockCalls(waitForTransaction, 1);
+
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+    await expect(resolveProperties(sendTransaction.mock.calls[0][0])).resolves.toMatchObject({
+      to: RNBW_TOKEN_ADDRESS,
+      value: 0n,
+      gasLimit: STAKING_APPROVAL_GAS_LIMIT,
+      ...GAS_PARAMS,
+    });
+    expect(waitForTransaction).toHaveBeenCalledWith(APPROVAL_TX_HASH, 1, time.minutes(2));
+
+    approvalConfirmation.resolve(buildReceipt(APPROVAL_TX_HASH));
+    const result = await execution;
+
+    expect(mockExecuteCalls).not.toHaveBeenCalled();
+    expect(sendTransaction).toHaveBeenCalledTimes(2);
+    expect(result.executionMode).toBe('manual');
+    expect(mockAddNewTransaction).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      chainId: STAKING_CHAIN_ID,
+      transaction: expect.objectContaining({
+        hash: TX_HASH,
+        gasLimit: ESTIMATED_STAKE_GAS_LIMIT,
+        nonce: 2,
+        type: 'stake',
+      }),
+    });
+    await expect(resolveProperties(sendTransaction.mock.calls[1][0])).resolves.toMatchObject({
       to: STAKING_CONTRACT_ADDRESS,
       value: 0n,
       gasLimit: ESTIMATED_STAKE_GAS_LIMIT,

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.ts
@@ -9,6 +9,7 @@ import { TransactionDirection, TransactionStatus, type NewTransaction } from '@/
 import { trackCallsExecution } from '@/features/delegation/callsExecutionTracking';
 import { resolveManagedExecutionFailure } from '@/features/delegation/managedExecutionFailure';
 import { waitForManagedExecutionConfirmation } from '@/features/delegation/waitForManagedExecution';
+import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
 import { RainbowError } from '@/logger';
 import { extractReplayableExecution } from '@/raps/replay';
 import { toTransactionAsset, type TransactionAssetSource } from '@/raps/transactionAsset';
@@ -63,7 +64,7 @@ export async function executeStakeRnbw({
   signer,
   stakeAmountRaw,
 }: ExecuteStakeRnbwParams): Promise<StakeRnbwExecution> {
-  if (!(signer instanceof Wallet)) {
+  if (!(signer instanceof Wallet) || !canUseDelegatedExecution(address)) {
     return executeSequentialStakeRnbw({ address, asset, gasParams, provider, signer, stakeAmountRaw });
   }
 

--- a/src/features/rnbw-staking/utils/prepareStakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/prepareStakeRnbw.test.ts
@@ -5,6 +5,7 @@ import { type Call, type CallsRequirements } from '@rainbow-me/delegation';
 import { STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
 import { prepareStakeRnbw, type StakeRnbwPreparationParams } from './prepareStakeRnbw';
 
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
 const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
 const mockBuildStakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
 const mockGetProvider = jest.fn();
@@ -20,6 +21,10 @@ jest.mock('@rainbow-me/delegation', () => ({
 
 jest.mock('@/handlers/web3', () => ({
   getProvider: () => mockGetProvider(),
+}));
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
 }));
 
 jest.mock('@/state/backendNetworks/backendNetworks', () => ({
@@ -57,6 +62,7 @@ const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } 
 describe('prepareStakeRnbw', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanUseDelegatedExecution.mockReturnValue(true);
     mockGetProvider.mockReturnValue(provider);
     mockBuildStakeRnbwExecutionPlan.mockResolvedValue({ calls: [STAKE_CALL], requirements: SPONSORED_REQUIREMENTS });
     mockResolveStakeClaimStrategy.mockResolvedValue({
@@ -119,6 +125,21 @@ describe('prepareStakeRnbw', () => {
       })
     ).resolves.toBeNull();
 
+    expect(mockBuildStakeRnbwExecutionPlan).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+
+  it('skips preparation when delegated execution is unavailable', async () => {
+    mockCanUseDelegatedExecution.mockReturnValue(false);
+
+    await expect(
+      prepareStakeRnbw({
+        accountAddress: ACCOUNT,
+        amount: '1',
+      })
+    ).resolves.toBeNull();
+
+    expect(mockResolveStakeClaimStrategy).not.toHaveBeenCalled();
     expect(mockBuildStakeRnbwExecutionPlan).not.toHaveBeenCalled();
     expect(mockPrepareCalls).not.toHaveBeenCalled();
   });

--- a/src/features/rnbw-staking/utils/prepareStakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/prepareStakeRnbw.ts
@@ -1,6 +1,7 @@
 import { parseUnits, type Address } from 'viem';
 
 import { createDelegationPublicClient } from '@/features/delegation/calls';
+import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
 import { isPositive } from '@/framework/core/safeMath';
 import { getProvider } from '@/handlers/web3';
 import { execute, type PreparedCallsExecution } from '@rainbow-me/delegation';
@@ -30,6 +31,8 @@ export type PreparedStakeRnbw = {
  */
 export async function prepareStakeRnbw({ accountAddress, amount }: StakeRnbwPreparationParams): Promise<PreparedStakeRnbw | null> {
   const stakeAmountRaw = parseUnits(amount, RNBW_DECIMALS).toString();
+  if (!canUseDelegatedExecution(accountAddress)) return null;
+
   const { claimFulfillsStake, walletStakeAmountRaw } = await resolveStakeClaimStrategy(stakeAmountRaw);
 
   if (claimFulfillsStake || !isPositive(walletStakeAmountRaw)) return null;

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -2383,6 +2383,7 @@
       "find_a_token_to_buy": "Find a token to buy",
       "search_your_tokens": "Search your tokens",
       "error_executing_swap": "Error executing swap",
+      "sponsorship_unavailable": "Free swaps are temporarily unavailable on this network. Please try again with network fees.",
       "tokens_input": {
         "tokens": "Tokens",
         "sort": "Sort",

--- a/src/resources/metadata/sharedQueries.js
+++ b/src/resources/metadata/sharedQueries.js
@@ -88,6 +88,9 @@ const BACKEND_NETWORKS_QUERY = `
         nftProxy {
           enabled
         }
+        sponsorship {
+          enabled
+        }
         launcher {
           v1 {
             enabled

--- a/src/state/backendNetworks/backendNetworks.ts
+++ b/src/state/backendNetworks/backendNetworks.ts
@@ -62,6 +62,7 @@ export interface BackendNetworksState {
 
   getChainGasUnits: (chainId?: ChainId) => BackendNetwork['gasUnits'];
   getChainDefaultRpc: (chainId: ChainId) => string;
+  disableSponsorshipUntilNextFetch: (chainId: ChainId) => void;
   isSponsorshipEligible: (chainId: ChainId) => boolean;
 }
 
@@ -130,7 +131,7 @@ export const useBackendNetworksStore = createQueryStore<BackendNetworksResponse,
     staleTime: time.minutes(30),
   },
 
-  (_, get) => ({
+  (set, get) => ({
     backendChains: transformBackendNetworksToChains(filterSupportedNetworks(INITIAL_BACKEND_NETWORKS)),
     backendNetworks: filterSupportedNetworks(INITIAL_BACKEND_NETWORKS),
 
@@ -343,6 +344,21 @@ export const useBackendNetworksStore = createQueryStore<BackendNetworksResponse,
 
     isSponsorshipEligible: (chainId: ChainId) => {
       return get().getSponsorshipEligibleChainIds().includes(chainId);
+    },
+
+    disableSponsorshipUntilNextFetch: (chainId: ChainId) => {
+      set(state => {
+        const network = state.backendNetworks.find(network => toChainId(network.id) === chainId);
+        if (!network || !isSponsorshipEligibleNetwork(network)) return state;
+
+        return {
+          backendNetworks: state.backendNetworks.map(existingNetwork =>
+            existingNetwork === network
+              ? { ...network, enabledServices: { ...network.enabledServices, sponsorship: { enabled: false } } }
+              : existingNetwork
+          ),
+        };
+      });
     },
 
     getChainGasUnits: createParameterizedSelector(networks => (chainId?: ChainId) => {

--- a/src/systems/funding/stores/createDepositGasStores.ts
+++ b/src/systems/funding/stores/createDepositGasStores.ts
@@ -110,11 +110,9 @@ export function createDepositGasStores(
   const useHasGasHookParams = needsGasHookParams
     ? createDerivedStore(
         $ => {
-          const accountAddress = $(useWalletsStore, s => s.accountAddress);
-          const amount = $(useAmountStore, selectNormalizedAmount);
           const assetUniqueId = $(useDepositStore, selectAssetUniqueId);
-
-          return Boolean(accountAddress && assetUniqueId && hasNonZeroAmount(amount));
+          const hasAmount = $(useAmountStore, s => hasNonZeroAmount(selectNormalizedAmount(s)));
+          return Boolean(assetUniqueId && hasAmount);
         },
         { lockDependencies: true }
       )
@@ -131,6 +129,7 @@ export function createDepositGasStores(
     },
     cacheTime: time.minutes(1),
     keepPreviousData: true,
+    paramChangeThrottle: time.ms(100),
     staleTime: time.seconds(30),
   });
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Hides the swap review sheet gas row for sponsored swaps
- Makes the sponsorship prediction logic in the sponsored swaps store more precise in its determination of when to use the prepared response to determine sponsorship, vs. the `canSponsor` prediction

## Screen recordings / screenshots

## What to test
