### PR TITLE
chore(discover): hide Farcaster tab from Trending

### DIFF
--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -767,21 +767,12 @@ export function TrendingTokens() {
             selectedChainId={selectedChainId}
           />
           <CategoryFilterButton
-            category={categories[2]}
+            category={categories[1]}
             label={i18n.t(t.filters.categories.NEW)}
             icon="􀋃"
             iconColor={{ default: isDarkMode ? globalColors.yellow60 : '#FFBB00', selected: '#F5A200' }}
             highlightedBackgroundColor={'#FFEAC2'}
             iconWidth={18}
-            selectedChainId={selectedChainId}
-          />
-          <CategoryFilterButton
-            category={categories[3]}
-            label={i18n.t(t.filters.categories.FARCASTER)}
-            icon="􀌥"
-            iconColor={'#5F5AFA'}
-            highlightedBackgroundColor={'#B9B7F7'}
-            iconWidth={20}
             selectedChainId={selectedChainId}
           />
         </Animated.ScrollView>

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -733,9 +733,11 @@ function TrendingTokenData() {
 }
 
 function RainbowFeatureFlagListener() {
-  // If the rainbow list was selected and the flag is disabled, set the category to the "Trending" category
+  // If the persisted category was removed, set the category to "Trending".
   useEffect(() => {
-    if (useTrendingTokensStore.getState().category === 'Rainbow') {
+    const { category } = useTrendingTokensStore.getState();
+    const isStalePersistedCategory = !categories.some(availableCategory => availableCategory === category);
+    if (isStalePersistedCategory) {
       useTrendingTokensStore.getState().setCategory(categories[0]);
     }
   }, []);

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -188,7 +188,6 @@ function CategoryFilterButton({
   iconColor,
   label,
   highlightedBackgroundColor,
-  selectedChainId,
 }: {
   category: TrendingCategory;
   icon: string | JSX.Element;
@@ -196,12 +195,10 @@ function CategoryFilterButton({
   highlightedBackgroundColor: string;
   iconWidth?: number;
   label: string;
-  selectedChainId: SharedValue<ChainId | undefined>;
 }) {
   const { isDarkMode } = useColorMode();
   const fillTertiary = useBackgroundColor('fillTertiary');
   const separatorSecondary = useForegroundColor('separatorSecondary');
-  const tokenLauncherNetworks = useBackendNetworksStore(state => state.getTokenLauncherSupportedChainIds());
 
   const selected = useTrendingTokensStore(state => state.category === category);
 
@@ -214,14 +211,7 @@ function CategoryFilterButton({
 
   const selectCategory = useCallback(() => {
     useTrendingTokensStore.getState().setCategory(category);
-    if (category === 'Rainbow') {
-      const { chainId } = useTrendingTokensStore.getState();
-      if (chainId && !tokenLauncherNetworks.includes(chainId)) {
-        useTrendingTokensStore.getState().setChainId(undefined);
-        selectedChainId.value = undefined;
-      }
-    }
-  }, [category, tokenLauncherNetworks, selectedChainId]);
+  }, [category]);
 
   return (
     <ButtonPressAnimation scaleTo={0.92} onPress={selectCategory}>
@@ -570,17 +560,10 @@ function NoResults() {
 }
 
 function NetworkFilter({ selectedChainId }: { selectedChainId: SharedValue<ChainId | undefined> }) {
-  const { chainId, category } = useTrendingTokensStore(
-    state => ({
-      chainId: state.chainId,
-      category: state.category,
-    }),
-    shallowEqual
-  );
+  const chainId = useTrendingTokensStore(state => state.chainId);
 
   const chainColor = useBackendNetworksStore(state => state.getColorsForChainId(chainId || ChainId.mainnet, false));
   const setChainId = useTrendingTokensStore(state => state.setChainId);
-  const tokenLauncherNetworks = useBackendNetworksStore(state => state.getTokenLauncherSupportedChainIds());
 
   const { icon, label, lightenedNetworkColor } = useMemo(() => {
     if (!chainId) return { icon: '􀤆', label: i18n.t(t.all), lightenedNetworkColor: undefined };
@@ -607,9 +590,8 @@ function NetworkFilter({ selectedChainId }: { selectedChainId: SharedValue<Chain
     Navigation.handleAction(Routes.NETWORK_SELECTOR, {
       selected: selectedChainId.value ?? chainId,
       setSelected,
-      allowedNetworks: category === 'Rainbow' ? tokenLauncherNetworks : undefined,
     });
-  }, [category, chainId, selectedChainId, setSelected, tokenLauncherNetworks]);
+  }, [chainId, selectedChainId, setSelected]);
 
   return (
     <FilterButton
@@ -766,7 +748,6 @@ export function TrendingTokens() {
             icon="􀙭"
             iconColor={'#D0281C'}
             highlightedBackgroundColor={'#E6A39E'}
-            selectedChainId={selectedChainId}
           />
           <CategoryFilterButton
             category={categories[1]}
@@ -775,7 +756,6 @@ export function TrendingTokens() {
             iconColor={{ default: isDarkMode ? globalColors.yellow60 : '#FFBB00', selected: '#F5A200' }}
             highlightedBackgroundColor={'#FFEAC2'}
             iconWidth={18}
-            selectedChainId={selectedChainId}
           />
         </Animated.ScrollView>
 

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3429,9 +3429,7 @@
       "filters": {
         "categories": {
           "TRENDING": "Trending",
-          "RAINBOW": "Rainbow",
-          "NEW": "New",
-          "FARCASTER": "Farcaster"
+          "NEW": "New"
         },
         "sort": {
           "RECOMMENDED": {

--- a/src/resources/trendingTokens/trendingTokens.ts
+++ b/src/resources/trendingTokens/trendingTokens.ts
@@ -1,20 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import qs from 'qs';
-import { TOKEN_SEARCH_URL } from 'react-native-dotenv';
 import { type Address } from 'viem';
 
-import { type AddressOrEth, type UniqueId } from '@/__swaps__/types/assets';
+import { type UniqueId } from '@/__swaps__/types/assets';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { RainbowFetchClient } from '@/framework/data/http/rainbowFetch';
 import { arcClient } from '@/graphql';
-import { Timeframe, type Bridging, type Colors, type Market, type SortDirection, type TrendingData } from '@/graphql/__generated__/arc';
-import { logger, RainbowError } from '@/logger';
+import { type SortDirection } from '@/graphql/__generated__/arc';
 import { createQueryKey, type QueryConfigWithSelect } from '@/react-query';
 import store from '@/redux/store';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { type TrendingCategory, type TrendingSort, type TrendingTimeframe } from '@/state/trendingTokens/trendingTokens';
-import { getUniqueId } from '@/utils/ethereumUtils';
-import { time } from '@/utils/time';
 
 export type FarcasterUser = {
   username: string;
@@ -61,127 +55,10 @@ type FetchTrendingTokensArgs = {
   currency?: NativeCurrencyKey;
 };
 
-let tokenSearchHttp: RainbowFetchClient | undefined;
-
-const getTokenSearchHttp = () => {
-  const clientUrl = tokenSearchHttp?.baseURL;
-  const baseUrl = `${TOKEN_SEARCH_URL}/v3/trending/rainbow`;
-
-  if (!tokenSearchHttp || clientUrl !== baseUrl) {
-    tokenSearchHttp = new RainbowFetchClient({
-      baseURL: baseUrl,
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
-      timeout: time.seconds(30),
-    });
-  }
-  return tokenSearchHttp;
-};
-
-type TrendingRainbowToken = {
-  colors: Colors;
-  icon_url: string;
-  name: string;
-  networks: { [key: string]: { address: AddressOrEth; decimals: number } };
-  symbol: string;
-  decimals: number;
-  highLiquidity: boolean;
-  isRainbowCurated: boolean;
-  isVerified: boolean;
-  uniqueId: AddressOrEth;
-  address: AddressOrEth;
-  market: Market;
-  bridging: Bridging;
-  trending: TrendingData;
-  creationDate: string;
-  chainId: ChainId;
-  type: 'rainbow';
-  transferable: boolean;
-};
-
-const convertTimeframe = (timeframe: Timeframe) => {
-  switch (timeframe) {
-    case Timeframe.H12:
-      return '12h';
-    case Timeframe.H24:
-      return '24h';
-    case Timeframe.D3:
-      return '3d';
-    case Timeframe.D7:
-      return '7d';
-  }
-};
-
-async function fetchRainbowTokens({
-  queryKey: [{ currency = store.getState().settings.nativeCurrency, sortBy, sortDirection, timeframe, walletAddress, chainId, limit }],
-}: {
-  queryKey: TrendingTokensQueryKey;
-}) {
-  try {
-    const params = {
-      currency: currency.toLowerCase(),
-      timeframe: convertTimeframe(timeframe), // FIXME: Once https://linear.app/rainbow/issue/APP-2382/add-rainbow-list-to-trending-tokens#comment-07814b37 is resolved
-      category: 'new', // QQ: Does this ever change?
-      sortBy: sortBy.toLowerCase(),
-      sortDirection: sortDirection?.toLowerCase(),
-      userAddress: walletAddress,
-    };
-
-    const url = `${chainId ? `/${chainId}` : ''}?${qs.stringify(params)}`;
-
-    const response = await getTokenSearchHttp().get<{ data: TrendingRainbowToken[] }>(url);
-
-    const trendingTokens: TrendingToken[] = [];
-
-    for (const token of response.data.data) {
-      const { address, name, symbol, chainId, decimals, trending, market, icon_url, colors } = token;
-      const { bought_stats } = trending.swap_data;
-      const highlightedFriends = (bought_stats.farcaster_users || []).reduce((friends, friend) => {
-        const { username, pfp_url } = friend;
-        if (username && pfp_url) friends.push({ username, pfp_url });
-        return friends;
-      }, [] as FarcasterUser[]);
-      trendingTokens.push({
-        uniqueId: getUniqueId(address, chainId),
-        chainId,
-        address,
-        name,
-        symbol,
-        decimals,
-        price: market.price?.value || 0,
-        priceChange: {
-          hr: trending.pool_data.h1_price_change || 0,
-          day: trending.pool_data.h24_price_change || 0,
-        },
-        marketCap: market.market_cap?.value || 0,
-        volume: market.volume_24h || 0,
-        highlightedFriends,
-        icon_url,
-        colors: {
-          primary: colors.primary,
-        },
-        transferable: token.transferable,
-        creationDate: token.creationDate ?? null,
-      });
-    }
-
-    return trendingTokens;
-  } catch (error) {
-    logger.error(new RainbowError('Error fetching rainbow tokens'), { error });
-    return [];
-  }
-}
-
 async function fetchTrendingTokens({ queryKey }: { queryKey: TrendingTokensQueryKey }) {
   const [
     { currency = store.getState().settings.nativeCurrency, category, sortBy, sortDirection, timeframe, walletAddress, chainId, limit },
   ] = queryKey;
-
-  if (category === 'Rainbow') {
-    return fetchRainbowTokens({ queryKey });
-  }
 
   const response = await arcClient.trendingTokens({
     category,

--- a/src/state/trendingTokens/trendingTokens.ts
+++ b/src/state/trendingTokens/trendingTokens.ts
@@ -9,7 +9,7 @@ import { type ChainId } from '@/state/backendNetworks/types';
 import { createRainbowStore } from '../internal/createRainbowStore';
 
 export const categories = [ArcTrendingCategory.Trending, ArcTrendingCategory.New] as const;
-export type TrendingCategory = (typeof categories)[number] | 'Rainbow' | ArcTrendingCategory.Farcaster;
+export type TrendingCategory = (typeof categories)[number];
 export const sortFilters = [
   ArcTrendingSort.Recommended,
   ArcTrendingSort.Volume,

--- a/src/state/trendingTokens/trendingTokens.ts
+++ b/src/state/trendingTokens/trendingTokens.ts
@@ -8,8 +8,8 @@ import { type ChainId } from '@/state/backendNetworks/types';
 
 import { createRainbowStore } from '../internal/createRainbowStore';
 
-export const categories = [ArcTrendingCategory.Trending, 'Rainbow', ArcTrendingCategory.New, ArcTrendingCategory.Farcaster] as const;
-export type TrendingCategory = (typeof categories)[number];
+export const categories = [ArcTrendingCategory.Trending, ArcTrendingCategory.New] as const;
+export type TrendingCategory = (typeof categories)[number] | 'Rainbow' | ArcTrendingCategory.Farcaster;
 export const sortFilters = [
   ArcTrendingSort.Recommended,
   ArcTrendingSort.Volume,
@@ -22,7 +22,7 @@ export const timeFilters = [ArcTimeframe.H12, ArcTimeframe.H24, ArcTimeframe.D3,
 export type TrendingTimeframe = (typeof timeFilters)[number];
 
 type TrendingTokensState = {
-  category: (typeof categories)[number];
+  category: TrendingCategory;
   chainId: undefined | ChainId;
   timeframe: (typeof timeFilters)[number];
   sort: (typeof sortFilters)[number];


### PR DESCRIPTION
APP-3655

## What changed

- Removes the Farcaster category pill from the Trending filter row; only Trending and New remain
- On first launch, any persisted Farcaster selection is reset to Trending — without this, users who had it selected would see Farcaster content with no pill to escape

## Screen recordings / screenshots

## What to test

- Discover → Trending: only "Trending" and "New" pills visible
- Sim previously set to Farcaster: resets to Trending on launch
- Trending ↔ New switching works as before