### PR TITLE
feat(discover-v2): add H1 sparklines to Perps cards

### DIFF
--- a/src/features/discover/components/DiscoverHome.tsx
+++ b/src/features/discover/components/DiscoverHome.tsx
@@ -14,6 +14,7 @@ import { MarketCarousel } from '@/features/discover/components/MarketCarousel';
 import {
   computePerpCardWidth,
   PERP_MARKET_CARD_HEIGHT,
+  PERP_MARKET_CARD_SLOT_WIDTH_WITH_CHART,
   PerpMarketCard,
   type PerpMarketCardProps,
 } from '@/features/discover/components/PerpMarketCard';
@@ -78,7 +79,7 @@ export default function DiscoverHome() {
                   placementId={PLACEMENT_IDS.PERPS}
                   placement={perpsPlacement}
                   itemHeight={PERP_MARKET_CARD_HEIGHT}
-                  itemWidth={computePerpCardWidth({})}
+                  itemWidth={PERP_MARKET_CARD_SLOT_WIDTH_WITH_CHART}
                   getItemWidth={getPerpCardWidth}
                   data={perpsPlacement?.items ?? []}
                   keyExtractor={keyExtractor}

--- a/src/features/discover/components/PerpMarketCard.tsx
+++ b/src/features/discover/components/PerpMarketCard.tsx
@@ -33,15 +33,15 @@ type PerpMarketCardProps = {
 
 export type { PerpMarketCardProps };
 
-const SPARKLINE_WIDTH = 44;
-const SPARKLINE_HEIGHT = 34;
+const SPARKLINE_WIDTH = 46;
+const SPARKLINE_HEIGHT = 52;
 
 const PERP_MARKET_CARD_WIDTH_WITH_CHART = 210;
 export const PERP_MARKET_CARD_SLOT_WIDTH_WITH_CHART = PERP_MARKET_CARD_WIDTH_WITH_CHART;
 export const PERP_MARKET_CARD_HEIGHT = 76;
 
 const PERP_MARKET_CARD_MAX_WIDTH = 280;
-const PERP_MARKET_CHART_FIXED_WIDTH = 138;
+const PERP_MARKET_CHART_FIXED_WIDTH = 150;
 const PERCENT_ARROW_BLOCK_WIDTH = 14;
 
 const SYMBOL_TEXT_STYLE = {
@@ -264,8 +264,7 @@ const styles = StyleSheet.create({
   contentRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
-    justifyContent: 'space-between',
+    gap: 16,
     width: '100%',
   },
   iconBorderShadow: {

--- a/src/features/discover/components/PerpMarketCard.tsx
+++ b/src/features/discover/components/PerpMarketCard.tsx
@@ -9,9 +9,11 @@ import { Text, TextIcon, useColorMode } from '@/design-system';
 import { useCandlestickStore } from '@/features/charts/stores/candlestickStore';
 import { CandleResolution } from '@/features/charts/types';
 import { convertStoredPerpPriceChangeToPercent, formatCompactPerpPercentChange } from '@/features/discover/components/perpMarketFormatting';
+import { PerpMarketSparkline } from '@/features/discover/components/PerpMarketSparkline';
 import { DOWN_ARROW, UP_ARROW } from '@/features/perps/constants';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { navigateToPerpDetailScreen } from '@/features/perps/utils';
+import { useDiscoverPerpsStore } from '@/features/placements/stores/discover/discoverPerpsStore';
 import { type PlacementItem, type PlacementItemAnalyticsMetadata } from '@/features/placements/types';
 import { opacity } from '@/framework/ui/utils/opacity';
 
@@ -23,22 +25,26 @@ type PerpMarketCardProps = {
 
 export type { PerpMarketCardProps };
 
+const SPARKLINE_WIDTH = 44;
+const SPARKLINE_HEIGHT = 34;
+
+const PERP_MARKET_CARD_WIDTH_WITH_CHART = 210;
+export const PERP_MARKET_CARD_SLOT_WIDTH_WITH_CHART = PERP_MARKET_CARD_WIDTH_WITH_CHART;
 export const PERP_MARKET_CARD_HEIGHT = 76;
 
-const PERP_MARKET_CARD_WIDTH_NO_CHART = 154;
 const PERP_MARKET_CARD_MAX_WIDTH = 280;
-const PERP_MARKET_NO_CHART_FIXED_WIDTH = 94;
-const PERP_MARKET_NO_CHART_TEXT_MIN_WIDTH = PERP_MARKET_CARD_WIDTH_NO_CHART - PERP_MARKET_NO_CHART_FIXED_WIDTH;
+const PERP_MARKET_CHART_FIXED_WIDTH = 138;
+const PERP_MARKET_CHART_TEXT_MIN_WIDTH = PERP_MARKET_CARD_WIDTH_WITH_CHART - PERP_MARKET_CHART_FIXED_WIDTH;
 const ESTIMATED_SYMBOL_CHARACTER_WIDTH = 11;
 const SYMBOL_TEXT_BUFFER = 8;
 
 export function computePerpCardWidth({ symbol }: { symbol?: string }): number {
   const estimatedTextWidth = symbol
     ? symbol.length * ESTIMATED_SYMBOL_CHARACTER_WIDTH + SYMBOL_TEXT_BUFFER
-    : PERP_MARKET_NO_CHART_TEXT_MIN_WIDTH;
-  const textWidth = Math.max(PERP_MARKET_NO_CHART_TEXT_MIN_WIDTH, estimatedTextWidth);
+    : PERP_MARKET_CHART_TEXT_MIN_WIDTH;
+  const textWidth = Math.max(PERP_MARKET_CHART_TEXT_MIN_WIDTH, estimatedTextWidth);
 
-  return Math.min(PERP_MARKET_CARD_MAX_WIDTH, Math.ceil(PERP_MARKET_NO_CHART_FIXED_WIDTH + textWidth));
+  return Math.min(PERP_MARKET_CARD_MAX_WIDTH, Math.ceil(PERP_MARKET_CHART_FIXED_WIDTH + textWidth));
 }
 
 const PRICE_CHANGE_COLORS = {
@@ -48,6 +54,7 @@ const PRICE_CHANGE_COLORS = {
 
 export const PerpMarketCard = memo(function PerpMarketCard({ item, onPressTracked, style }: PerpMarketCardProps) {
   const market = useHyperliquidMarketsStore(state => state.getMarket(item.ref.id));
+  const chart = useDiscoverPerpsStore(state => state.getChart(item.ref.id));
   const candlestickPercentChange = useCandlestickStore(state => {
     const price = state.prices[item.ref.id];
     return price?.candleResolution === CandleResolution.H1 ? price.percentChange : undefined;
@@ -71,7 +78,9 @@ export const PerpMarketCard = memo(function PerpMarketCard({ item, onPressTracke
 
   const accentColor = market.metadata?.colors?.color || market.metadata?.colors?.fallbackColor || '#3ECFAD';
   const percentChange =
-    candlestickPercentChange ?? convertStoredPerpPriceChangeToPercent(market.priceChange['1h'] || market.priceChange['24h']);
+    candlestickPercentChange ??
+    chart?.percentChange ??
+    convertStoredPerpPriceChangeToPercent(market.priceChange['1h'] || market.priceChange['24h']);
   const isPositive = percentChange >= 0;
   const changeColor = isPositive
     ? isDarkMode
@@ -129,6 +138,18 @@ export const PerpMarketCard = memo(function PerpMarketCard({ item, onPressTracke
                   </Text>
                 </View>
               </View>
+            </View>
+
+            <View style={styles.chartFrame}>
+              {chart ? (
+                <PerpMarketSparkline
+                  chartColor={changeColor}
+                  data={chart}
+                  height={SPARKLINE_HEIGHT}
+                  percentChange={percentChange}
+                  width={SPARKLINE_WIDTH}
+                />
+              ) : null}
             </View>
           </View>
 
@@ -208,10 +229,17 @@ const styles = StyleSheet.create({
     minHeight: 20,
     minWidth: 0,
   },
+  chartFrame: {
+    alignItems: 'center',
+    height: SPARKLINE_HEIGHT,
+    justifyContent: 'center',
+    width: SPARKLINE_WIDTH,
+  },
   contentRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 10,
+    gap: 8,
+    justifyContent: 'space-between',
     width: '100%',
   },
   iconBorder: {

--- a/src/features/discover/components/PerpMarketCard.tsx
+++ b/src/features/discover/components/PerpMarketCard.tsx
@@ -11,11 +11,13 @@ import { getValueForColorMode } from '@/design-system/color/palettes';
 import { textSizes, textWeights } from '@/design-system/typography/typography';
 import { useCandlestickStore } from '@/features/charts/stores/candlestickStore';
 import { CandleResolution } from '@/features/charts/types';
+import { PerpMarketSparkline } from '@/features/discover/components/PerpMarketSparkline';
 import { HyperliquidTokenIcon } from '@/features/perps/components/HyperliquidTokenIcon';
 import { DOWN_ARROW, HYPERLIQUID_COLORS, UP_ARROW } from '@/features/perps/constants';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { convertStoredPerpPriceChangeToPercent, formatCompactPerpPercentChange, navigateToPerpDetailScreen } from '@/features/perps/utils';
 import { trackPlacementInteraction } from '@/features/placements/engagement/trackInteraction';
+import { useDiscoverPerpsStore } from '@/features/placements/stores/discover/discoverPerpsStore';
 import { type Placement, type PlacementItem } from '@/features/placements/types';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { getHighContrastColor } from '@/hooks/useAccountAccentColor';
@@ -31,10 +33,15 @@ type PerpMarketCardProps = {
 
 export type { PerpMarketCardProps };
 
+const SPARKLINE_WIDTH = 44;
+const SPARKLINE_HEIGHT = 34;
+
+const PERP_MARKET_CARD_WIDTH_WITH_CHART = 210;
+export const PERP_MARKET_CARD_SLOT_WIDTH_WITH_CHART = PERP_MARKET_CARD_WIDTH_WITH_CHART;
 export const PERP_MARKET_CARD_HEIGHT = 76;
 
 const PERP_MARKET_CARD_MAX_WIDTH = 280;
-const PERP_MARKET_NO_CHART_FIXED_WIDTH = 98;
+const PERP_MARKET_CHART_FIXED_WIDTH = 138;
 const PERCENT_ARROW_BLOCK_WIDTH = 14;
 
 const SYMBOL_TEXT_STYLE = {
@@ -52,16 +59,16 @@ const PERCENT_TEXT_STYLE = {
 } as const;
 
 const PERCENT_MIN_WIDTH = Math.ceil(measureTextSync('99.99%', PERCENT_TEXT_STYLE)) + PERCENT_ARROW_BLOCK_WIDTH;
-const PERP_MARKET_NO_CHART_TEXT_MIN_WIDTH = PERCENT_MIN_WIDTH;
+const PERP_MARKET_CHART_TEXT_MIN_WIDTH = PERCENT_MIN_WIDTH;
 
 export function computePerpCardWidth({ percentChangeText, symbol }: { percentChangeText?: string; symbol?: string }): number {
   const symbolWidth = symbol ? Math.ceil(measureTextSync(symbol, SYMBOL_TEXT_STYLE)) : 0;
   const percentWidth = percentChangeText
     ? Math.ceil(measureTextSync(percentChangeText, PERCENT_TEXT_STYLE)) + PERCENT_ARROW_BLOCK_WIDTH
     : 0;
-  const textWidth = Math.max(PERP_MARKET_NO_CHART_TEXT_MIN_WIDTH, percentWidth, symbolWidth);
+  const textWidth = Math.max(PERP_MARKET_CHART_TEXT_MIN_WIDTH, percentWidth, symbolWidth);
 
-  return Math.min(PERP_MARKET_CARD_MAX_WIDTH, PERP_MARKET_NO_CHART_FIXED_WIDTH + textWidth);
+  return Math.min(PERP_MARKET_CARD_MAX_WIDTH, PERP_MARKET_CHART_FIXED_WIDTH + textWidth);
 }
 
 const CARD_BACKGROUND_COLOR = { light: 'rgba(255,255,255,0.92)', dark: '#171B20' } as const;
@@ -70,6 +77,7 @@ const BADGE_BORDER_COLOR = { light: 'rgba(0,0,0,0.07)', dark: 'rgba(255,255,255,
 
 export const PerpMarketCard = memo(function PerpMarketCard({ item, placement, style }: PerpMarketCardProps) {
   const market = useHyperliquidMarketsStore(state => state.getMarket(item.ref.id));
+  const chart = useDiscoverPerpsStore(state => state.getChart(item.ref.id));
   const candlestickPercentChange = useCandlestickStore(state => {
     const price = state.prices[item.ref.id];
     return price?.candleResolution === CandleResolution.H1 ? price.percentChange : undefined;
@@ -98,7 +106,9 @@ export const PerpMarketCard = memo(function PerpMarketCard({ item, placement, st
   const rawAccentColor = market.metadata?.colors?.color || market.metadata?.colors?.fallbackColor || HYPERLIQUID_COLORS.green;
   const accentColor = getHighContrastColor(rawAccentColor, isDarkMode);
   const percentChange =
-    candlestickPercentChange ?? convertStoredPerpPriceChangeToPercent(market.priceChange['1h'] ?? market.priceChange['24h']);
+    candlestickPercentChange ??
+    chart?.percentChange ??
+    convertStoredPerpPriceChangeToPercent(market.priceChange['1h'] ?? market.priceChange['24h']);
   const isPositive = percentChange >= 0;
   const changeColor = isPositive ? positiveChangeColor : negativeChangeColor;
   const cardBackgroundColor = getValueForColorMode(CARD_BACKGROUND_COLOR, colorMode);
@@ -164,6 +174,18 @@ export const PerpMarketCard = memo(function PerpMarketCard({ item, placement, st
                   </Text>
                 </View>
               </View>
+            </View>
+
+            <View style={styles.chartFrame}>
+              {chart ? (
+                <PerpMarketSparkline
+                  chartColor={changeColor}
+                  data={chart}
+                  height={SPARKLINE_HEIGHT}
+                  percentChange={percentChange}
+                  width={SPARKLINE_WIDTH}
+                />
+              ) : null}
             </View>
           </View>
         </Box>
@@ -233,10 +255,17 @@ const styles = StyleSheet.create({
     gap: 2,
     minHeight: 20,
   },
+  chartFrame: {
+    alignItems: 'center',
+    height: SPARKLINE_HEIGHT,
+    justifyContent: 'center',
+    width: SPARKLINE_WIDTH,
+  },
   contentRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 16,
+    gap: 8,
+    justifyContent: 'space-between',
     width: '100%',
   },
   iconBorderShadow: {

--- a/src/features/discover/components/PerpMarketSparkline.tsx
+++ b/src/features/discover/components/PerpMarketSparkline.tsx
@@ -1,0 +1,362 @@
+import React, { memo, useEffect, useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+
+import {
+  Canvas,
+  PaintStyle,
+  Picture,
+  Skia,
+  StrokeCap,
+  StrokeJoin,
+  TileMode,
+  type SkPaint,
+  type SkPath,
+  type SkPicture,
+} from '@shopify/react-native-skia';
+import { convertToRGBA, Easing, runOnUI, useAnimatedReaction, useSharedValue, withTiming, type SharedValue } from 'react-native-reanimated';
+
+import { buildSmoothedPath, LineSmoothing } from '@/features/charts/line/LineSmoothingAlgorithms';
+import { useWorkletClass } from '@/hooks/reanimated/useWorkletClass';
+import { useCleanup } from '@/hooks/useCleanup';
+import { createBlankPicture } from '@/worklets/skia';
+
+type PerpSparklineData = { prices: number[]; timestamps: number[] };
+
+type PerpMarketSparklineProps = {
+  chartColor: string;
+  data?: PerpSparklineData;
+  height?: number;
+  percentChange: number;
+  width?: number;
+};
+
+type PreparedSparklineConfig = {
+  blankPicture: SkPicture;
+  chartPicture: SharedValue<SkPicture>;
+  height: number;
+  progress: SharedValue<number>;
+  width: number;
+};
+
+const LINE_WIDTH = 2.25;
+const FILL_TOP_ALPHA = 0.35;
+const MIN_PADDING_FACTOR = 0.04;
+const MAX_PADDING_FACTOR = 0.25;
+const STROKE_Y_INSET = LINE_WIDTH;
+const ANIMATION_DURATION_MS = 600;
+
+class PerpSparklineRenderer {
+  private readonly __workletClass = true;
+
+  private readonly blankPicture: SkPicture;
+  private readonly chartPicture: SharedValue<SkPicture>;
+  private readonly fillPaint: SkPaint;
+  private readonly fillPath: SkPath;
+  private readonly height: number;
+  private readonly pictureRecorder = Skia.PictureRecorder();
+  private readonly progress: SharedValue<number>;
+  private readonly strokePaint: SkPaint;
+  private readonly strokePath: SkPath;
+  private readonly width: number;
+
+  private currentColor: string | null = null;
+  private currentStartPoints: Float32Array | null = null;
+  private currentTargetPoints: Float32Array | null = null;
+  private currentShader: ReturnType<typeof Skia.Shader.MakeLinearGradient> | null = null;
+
+  constructor({ blankPicture, chartPicture, height, progress, width }: PreparedSparklineConfig) {
+    this.blankPicture = blankPicture;
+    this.chartPicture = chartPicture;
+    this.height = height;
+    this.progress = progress;
+    this.width = width;
+
+    this.strokePath = Skia.Path.Make();
+    this.fillPath = Skia.Path.Make();
+
+    this.strokePaint = Skia.Paint();
+    this.strokePaint.setAntiAlias(true);
+    this.strokePaint.setDither(true);
+    this.strokePaint.setStyle(PaintStyle.Stroke);
+    this.strokePaint.setStrokeWidth(LINE_WIDTH);
+    this.strokePaint.setStrokeCap(StrokeCap.Round);
+    this.strokePaint.setStrokeJoin(StrokeJoin.Round);
+
+    this.fillPaint = Skia.Paint();
+    this.fillPaint.setAntiAlias(true);
+    this.fillPaint.setDither(true);
+    this.fillPaint.setStyle(PaintStyle.Fill);
+  }
+
+  public setData(data: PerpSparklineData | undefined, lineColor: string, percentChange: number): void {
+    if (!data || data.prices.length < 2) {
+      this.currentStartPoints = null;
+      this.currentTargetPoints = null;
+      this.setBlankPicture();
+      return;
+    }
+
+    if (lineColor !== this.currentColor) {
+      this.strokePaint.setColor(Skia.Color(lineColor));
+      this.updateFillShader(lineColor);
+      this.currentColor = lineColor;
+    }
+
+    const targetPoints = this.buildTargetPoints(new Float32Array(data.prices), percentChange);
+    this.currentStartPoints = this.getVisiblePoints() ?? this.buildBaselinePoints(targetPoints.length / 2);
+    this.currentTargetPoints = targetPoints;
+    this.progress.value = 0;
+    this.buildPicture(0);
+    this.progress.value = withTiming(1, {
+      duration: ANIMATION_DURATION_MS,
+      easing: Easing.out(Easing.cubic),
+    });
+  }
+
+  public render(progress: number): void {
+    if (!this.currentTargetPoints) return;
+    this.buildPicture(progress);
+  }
+
+  public dispose(): void {
+    this.currentShader?.dispose();
+    this.currentShader = null;
+    this.currentStartPoints = null;
+    this.currentTargetPoints = null;
+    this.strokePath.dispose();
+    this.fillPath.dispose();
+    this.strokePaint.dispose();
+    this.fillPaint.dispose();
+
+    const currentPicture = this.chartPicture.value;
+    if (currentPicture !== this.blankPicture) {
+      currentPicture.dispose();
+    }
+  }
+
+  private updateFillShader(color: string): void {
+    const [r, g, b] = convertToRGBA(color);
+    const rInt = Math.round(r * 255);
+    const gInt = Math.round(g * 255);
+    const bInt = Math.round(b * 255);
+    const topColor = Skia.Color(`rgba(${rInt}, ${gInt}, ${bInt}, 1)`);
+    const bottomColor = Skia.Color(`rgba(${rInt}, ${gInt}, ${bInt}, 0)`);
+
+    const previous = this.currentShader;
+    const shader = Skia.Shader.MakeLinearGradient(
+      { x: 0, y: 0 },
+      { x: 0, y: this.height },
+      [topColor, bottomColor],
+      [0, 1],
+      TileMode.Clamp
+    );
+    this.fillPaint.setShader(shader);
+    this.currentShader = shader;
+    previous?.dispose();
+  }
+
+  private buildPicture(progress: number): void {
+    const targetPoints = this.currentTargetPoints;
+    if (!targetPoints) return;
+
+    const count = targetPoints.length / 2;
+    const startPoints = this.currentStartPoints ?? this.buildBaselinePoints(count);
+    const points = new Float32Array(count * 2);
+    for (let i = 0; i < count; i++) {
+      const idx = i * 2;
+      const startY = this.getMappedPointY(startPoints, i, count);
+      const targetY = targetPoints[idx + 1];
+      points[idx] = targetPoints[idx];
+      points[idx + 1] = startY + (targetY - startY) * progress;
+    }
+
+    this.strokePath.reset();
+    buildSmoothedPath(this.strokePath, points, count, LineSmoothing.Makima, 1);
+
+    this.fillPath.reset();
+    buildSmoothedPath(this.fillPath, points, count, LineSmoothing.Makima, 1);
+    this.fillPath.lineTo(points[(count - 1) * 2], this.height);
+    this.fillPath.lineTo(points[0], this.height);
+    this.fillPath.close();
+
+    const canvas = this.pictureRecorder.beginRecording({
+      height: this.height,
+      width: this.width,
+      x: 0,
+      y: 0,
+    });
+
+    this.fillPaint.setAlphaf(FILL_TOP_ALPHA);
+    canvas.drawPath(this.fillPath, this.fillPaint);
+    canvas.drawPath(this.strokePath, this.strokePaint);
+
+    const oldPicture = this.chartPicture.value;
+    this.chartPicture.value = this.pictureRecorder.finishRecordingAsPicture();
+    if (oldPicture !== this.blankPicture) {
+      oldPicture.dispose();
+    }
+  }
+
+  private setBlankPicture(): void {
+    const oldPicture = this.chartPicture.value;
+    this.chartPicture.value = this.blankPicture;
+    if (oldPicture !== this.blankPicture) {
+      oldPicture.dispose();
+    }
+  }
+
+  private getVisiblePoints(): Float32Array | null {
+    const targetPoints = this.currentTargetPoints;
+    if (!targetPoints) return null;
+
+    const count = targetPoints.length / 2;
+    const startPoints = this.currentStartPoints ?? this.buildBaselinePoints(count);
+    const progress = this.progress.value;
+    const points = new Float32Array(targetPoints.length);
+
+    for (let i = 0; i < count; i++) {
+      const idx = i * 2;
+      const startY = this.getMappedPointY(startPoints, i, count);
+      const targetY = targetPoints[idx + 1];
+      points[idx] = targetPoints[idx];
+      points[idx + 1] = startY + (targetY - startY) * progress;
+    }
+
+    return points;
+  }
+
+  private buildBaselinePoints(count: number): Float32Array {
+    const baselineY = this.getBaselineY();
+    const stride = count > 1 ? this.width / (count - 1) : 0;
+    const points = new Float32Array(count * 2);
+
+    for (let i = 0; i < count; i++) {
+      const idx = i * 2;
+      points[idx] = i * stride;
+      points[idx + 1] = baselineY;
+    }
+
+    return points;
+  }
+
+  private buildTargetPoints(prices: Float32Array, percentChange: number): Float32Array {
+    const count = prices.length;
+    const { minPrice, maxPrice } = this.computeBounds(prices, percentChange);
+    const range = maxPrice - minPrice || 1;
+    const plotHeight = this.getPlotHeight();
+    const stride = count > 1 ? this.width / (count - 1) : 0;
+    const points = new Float32Array(count * 2);
+
+    for (let i = 0; i < count; i++) {
+      const idx = i * 2;
+      points[idx] = i * stride;
+      points[idx + 1] = STROKE_Y_INSET + plotHeight - ((prices[i] - minPrice) / range) * plotHeight;
+    }
+
+    return points;
+  }
+
+  private getMappedPointY(points: Float32Array, targetIndex: number, targetCount: number): number {
+    const sourceCount = points.length / 2;
+    if (sourceCount === targetCount) return points[targetIndex * 2 + 1];
+
+    const mappedIndex = targetCount > 1 ? Math.round((targetIndex / (targetCount - 1)) * (sourceCount - 1)) : 0;
+    return points[mappedIndex * 2 + 1];
+  }
+
+  private getBaselineY(): number {
+    return STROKE_Y_INSET + this.getPlotHeight() / 2;
+  }
+
+  private getPlotHeight(): number {
+    return this.height - STROKE_Y_INSET * 2;
+  }
+
+  private computeBounds(prices: Float32Array, percentChange: number): { maxPrice: number; minPrice: number } {
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < prices.length; i++) {
+      const value = prices[i];
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      return { maxPrice: 1, minPrice: 0 };
+    }
+
+    const range = max - min;
+    if (range === 0) {
+      const fallback = Math.max(Math.abs(max) * 0.02, 1);
+      return { maxPrice: max + fallback, minPrice: min - fallback };
+    }
+
+    const pct = Math.abs(percentChange);
+    const paddingFactor = Math.min(Math.max(pct / 100, MIN_PADDING_FACTOR), MAX_PADDING_FACTOR);
+    const padding = range * paddingFactor;
+
+    return {
+      maxPrice: max + padding,
+      minPrice: min - padding,
+    };
+  }
+}
+
+export const PerpMarketSparkline = memo(function PerpMarketSparkline({
+  chartColor,
+  data,
+  height = 42,
+  percentChange,
+  width = 44,
+}: PerpMarketSparklineProps) {
+  const initialPicture = useMemo(() => createBlankPicture(width, height), [height, width]);
+  const chartPicture = useSharedValue(initialPicture);
+  const progress = useSharedValue(1);
+  const sparkline = useWorkletClass(
+    () => ({
+      blankPicture: initialPicture,
+      chartPicture,
+      height,
+      progress,
+      width,
+    }),
+    config => {
+      'worklet';
+      return new PerpSparklineRenderer(config);
+    }
+  );
+
+  useEffect(() => {
+    runOnUI((nextData: PerpSparklineData | undefined, nextColor: string, nextPercentChange: number) => {
+      sparkline.value?.setData(nextData, nextColor, nextPercentChange);
+    })(data, chartColor, percentChange);
+  }, [chartColor, data, percentChange, sparkline]);
+
+  useAnimatedReaction(
+    () => progress.value,
+    currentProgress => {
+      sparkline.value?.render(currentProgress);
+    }
+  );
+
+  useCleanup(() => {
+    initialPicture.dispose();
+    runOnUI(() => {
+      sparkline.value?.dispose?.();
+      sparkline.value = undefined;
+    })();
+  }, [initialPicture, sparkline]);
+
+  return (
+    <Canvas style={[styles.canvas, { height, width }]}>
+      <Picture picture={chartPicture} />
+    </Canvas>
+  );
+});
+
+const styles = StyleSheet.create({
+  canvas: {
+    overflow: 'visible',
+  },
+});

--- a/src/features/discover/components/PerpMarketSparkline.tsx
+++ b/src/features/discover/components/PerpMarketSparkline.tsx
@@ -127,6 +127,7 @@ class PerpSparklineRenderer {
     this.fillPath.dispose();
     this.strokePaint.dispose();
     this.fillPaint.dispose();
+    this.pictureRecorder.dispose();
 
     const currentPicture = this.chartPicture.value;
     if (currentPicture !== this.blankPicture) {

--- a/src/features/discover/components/PerpsMarketCarousel.tsx
+++ b/src/features/discover/components/PerpsMarketCarousel.tsx
@@ -7,8 +7,8 @@ import { convertStoredPerpPriceChangeToPercent, formatCompactPerpPercentChange }
 import { navigateToPerpsSearch } from '@/features/perps/utils/navigateToPerps';
 import { PLACEMENT_IDS } from '@/features/placements/constants';
 import { trackPlacementInteraction } from '@/features/placements/engagement/trackInteraction';
-import { useDiscoverPlacementsStore } from '@/features/placements/stores/discover/discoverPlacementsStore';
 import { useDiscoverPerpsStore } from '@/features/placements/stores/discover/discoverPerpsStore';
+import { useDiscoverPlacementsStore } from '@/features/placements/stores/discover/discoverPlacementsStore';
 import { type Placement, type PlacementItem } from '@/features/placements/types';
 import * as i18n from '@/languages';
 

--- a/src/features/discover/components/PerpsMarketCarousel.tsx
+++ b/src/features/discover/components/PerpsMarketCarousel.tsx
@@ -8,6 +8,7 @@ import { navigateToPerpsSearch } from '@/features/perps/utils/navigateToPerps';
 import { PLACEMENT_IDS } from '@/features/placements/constants';
 import { trackPlacementInteraction } from '@/features/placements/engagement/trackInteraction';
 import { useDiscoverPlacementsStore } from '@/features/placements/stores/discover/discoverPlacementsStore';
+import { useDiscoverPerpsStore } from '@/features/placements/stores/discover/discoverPerpsStore';
 import { type Placement, type PlacementItem } from '@/features/placements/types';
 import * as i18n from '@/languages';
 
@@ -23,6 +24,7 @@ export function PerpsMarketCarousel() {
     return items.length === 0 && state.isInitialLoad;
   });
   const markets = useHyperliquidMarketsStore(state => state.markets);
+  const chartsBySymbol = useDiscoverPerpsStore(state => state.chartsBySymbol);
   const marketsLoading = useHyperliquidMarketsStore(state => {
     const hasMarkets = Object.keys(state.markets).length > 0;
     return !hasMarkets && (state.status === 'loading' || state.status === 'idle');
@@ -36,16 +38,16 @@ export function PerpsMarketCarousel() {
   const getPerpCardWidth = useCallback(
     (item: PlacementItem): number => {
       const market = markets[item.ref.id];
-      const percentChange = market
-        ? convertStoredPerpPriceChangeToPercent(market.priceChange['1h'] ?? market.priceChange['24h'])
-        : undefined;
+      const percentChange =
+        chartsBySymbol[item.ref.id]?.percentChange ??
+        (market ? convertStoredPerpPriceChangeToPercent(market.priceChange['1h'] ?? market.priceChange['24h']) : undefined);
 
       return computePerpCardWidth({
         percentChangeText: percentChange === undefined ? undefined : formatCompactPerpPercentChange(percentChange),
         symbol: market?.baseSymbol ?? item.ref.id,
       });
     },
-    [markets]
+    [chartsBySymbol, markets]
   );
   const handlePressSeeAll = useCallback(() => {
     if (placement) trackPlacementInteraction({ placement });

--- a/src/features/perps/stores/hyperliquidSparklineStore.ts
+++ b/src/features/perps/stores/hyperliquidSparklineStore.ts
@@ -1,0 +1,72 @@
+import { fetchHyperliquidChart } from '@/features/charts/candlestick/hyperliquid/hyperliquidCharts';
+import { CandleResolution } from '@/features/charts/types';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { time } from '@/utils/time';
+
+const SPARKLINE_CANDLE_COUNT = 28;
+
+export type PerpSparklineData = { percentChange: number; prices: number[]; timestamps: number[] };
+
+export type HyperliquidSparklineFetchData = { chartsBySymbol: Record<string, PerpSparklineData> };
+
+type Params = { symbolsKey: string };
+type State = {
+  chartsBySymbol: Record<string, PerpSparklineData>;
+  getChart: (symbol: string) => PerpSparklineData | undefined;
+};
+
+export const useHyperliquidSparklineStore = createQueryStore<HyperliquidSparklineFetchData, Params, State>(
+  {
+    fetcher: fetchHyperliquidSparklines,
+    params: { symbolsKey: '' },
+    setData: ({ data, set }) => set({ chartsBySymbol: data.chartsBySymbol }),
+    staleTime: time.minutes(5),
+    cacheTime: time.minutes(10),
+  },
+  (_set, get) => ({
+    chartsBySymbol: {},
+    getChart: (symbol: string) => get().chartsBySymbol[symbol],
+  })
+);
+
+async function fetchHyperliquidSparklines(
+  { symbolsKey }: Params,
+  abortController: AbortController | null
+): Promise<HyperliquidSparklineFetchData> {
+  const symbols = symbolsKey ? symbolsKey.split(',') : [];
+  if (symbols.length === 0) return { chartsBySymbol: {} };
+
+  const charts = await Promise.all(
+    symbols.map(async symbol => {
+      try {
+        const chart = await fetchHyperliquidSparkline(symbol, abortController);
+        return chart ? ([symbol, chart] as const) : null;
+      } catch (error) {
+        if (abortController?.signal.aborted) throw error;
+        return null;
+      }
+    })
+  );
+
+  return { chartsBySymbol: Object.fromEntries(charts.filter(chart => chart !== null)) };
+}
+
+async function fetchHyperliquidSparkline(symbol: string, abortController: AbortController | null): Promise<PerpSparklineData | null> {
+  const response = await fetchHyperliquidChart(
+    { barCount: SPARKLINE_CANDLE_COUNT, candleResolution: CandleResolution.H1, token: symbol },
+    abortController
+  );
+  const candles = [...response.candles].sort((a, b) => a.t - b.t).slice(-SPARKLINE_CANDLE_COUNT);
+  if (candles.length < 2) return null;
+
+  return {
+    percentChange: calculateLatestCandlePercentChange(candles),
+    prices: candles.map(candle => candle.c),
+    timestamps: candles.map(candle => Math.round(candle.t)),
+  };
+}
+
+function calculateLatestCandlePercentChange(candles: { c: number; o: number }[]): number {
+  const currentCandle = candles[candles.length - 1];
+  return currentCandle?.o ? ((currentCandle.c - currentCandle.o) / currentCandle.o) * 100 : 0;
+}

--- a/src/features/perps/stores/hyperliquidSparklineStore.ts
+++ b/src/features/perps/stores/hyperliquidSparklineStore.ts
@@ -60,13 +60,15 @@ async function fetchHyperliquidSparkline(symbol: string, abortController: AbortC
   if (candles.length < 2) return null;
 
   return {
-    percentChange: calculateLatestCandlePercentChange(candles),
+    percentChange: calculateRangePercentChange(candles),
     prices: candles.map(candle => candle.c),
     timestamps: candles.map(candle => Math.round(candle.t)),
   };
 }
 
-function calculateLatestCandlePercentChange(candles: { c: number; o: number }[]): number {
-  const currentCandle = candles[candles.length - 1];
-  return currentCandle?.o ? ((currentCandle.c - currentCandle.o) / currentCandle.o) * 100 : 0;
+function calculateRangePercentChange(candles: { c: number }[]): number {
+  const first = candles[0];
+  const last = candles[candles.length - 1];
+  if (!first?.c) return 0;
+  return ((last.c - first.c) / first.c) * 100;
 }

--- a/src/features/placements/stores/discover/discoverPerpsStore.ts
+++ b/src/features/placements/stores/discover/discoverPerpsStore.ts
@@ -1,0 +1,66 @@
+import {
+  useHyperliquidSparklineStore,
+  type HyperliquidSparklineFetchData,
+  type PerpSparklineData,
+} from '@/features/perps/stores/hyperliquidSparklineStore';
+import { PLACEMENT_IDS } from '@/features/placements/constants';
+import { useDiscoverPlacementAvailability } from '@/features/placements/stores/discover/discoverPlacementAvailabilityStore';
+import { usePlacementsStore } from '@/features/placements/stores/placementsStore';
+import { type Placement } from '@/features/placements/types';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { time } from '@/utils/time';
+import { shallowEqual } from '@/worklets/comparisons';
+
+type DiscoverPerpsRequest = {
+  enabled: boolean;
+  symbolsKey: string;
+};
+
+type DiscoverPerpsState = {
+  chartsBySymbol: Record<string, PerpSparklineData>;
+  getChart: (symbol: string) => PerpSparklineData | undefined;
+};
+
+type Params = { symbolsKey: string };
+
+const useDiscoverPerpsRequestStore = createDerivedStore<DiscoverPerpsRequest>(
+  $ => {
+    const { perps } = $(useDiscoverPlacementAvailability);
+    const symbols = perps ? $(usePlacementsStore, state => readPerpSymbols(state.getPlacement(PLACEMENT_IDS.PERPS))) : [];
+
+    return {
+      enabled: perps && symbols.length > 0,
+      symbolsKey: symbols.join(','),
+    };
+  },
+  { equalityFn: shallowEqual }
+);
+
+export const useDiscoverPerpsStore = createQueryStore<HyperliquidSparklineFetchData, Params, DiscoverPerpsState>(
+  {
+    fetcher: fetchDiscoverPerps,
+    enabled: $ => $(useDiscoverPerpsRequestStore, state => state.enabled),
+    params: {
+      symbolsKey: $ => $(useDiscoverPerpsRequestStore, state => state.symbolsKey),
+    },
+    setData: ({ data, set }) => set({ chartsBySymbol: data.chartsBySymbol }),
+    staleTime: time.minutes(5),
+    cacheTime: time.minutes(10),
+  },
+  (_set, get) => ({
+    chartsBySymbol: {},
+    getChart: (symbol: string) => get().chartsBySymbol[symbol],
+  })
+);
+
+async function fetchDiscoverPerps(params: Params): Promise<HyperliquidSparklineFetchData> {
+  return (await useHyperliquidSparklineStore.getState().fetch(params)) ?? { chartsBySymbol: {} };
+}
+
+function readPerpSymbols(placement: Placement | undefined): string[] {
+  if (!placement) return [];
+  return Array.from(
+    new Set(placement.items.filter(item => item.ref.source === 'hyperliquid' && item.ref.id).map(item => item.ref.id))
+  ).sort();
+}

--- a/src/features/placements/stores/discover/discoverPerpsStore.ts
+++ b/src/features/placements/stores/discover/discoverPerpsStore.ts
@@ -7,6 +7,7 @@ import { PLACEMENT_IDS } from '@/features/placements/constants';
 import { useDiscoverPlacementAvailability } from '@/features/placements/stores/discover/discoverPlacementAvailabilityStore';
 import { usePlacementsStore } from '@/features/placements/stores/placementsStore';
 import { type Placement } from '@/features/placements/types';
+import { logger, RainbowError } from '@/logger';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { createQueryStore } from '@/state/internal/createQueryStore';
 import { time } from '@/utils/time';
@@ -26,8 +27,9 @@ type Params = { symbolsKey: string };
 
 const useDiscoverPerpsRequestStore = createDerivedStore<DiscoverPerpsRequest>(
   $ => {
-    const { perps } = $(useDiscoverPlacementAvailability);
-    const symbols = perps ? $(usePlacementsStore, state => readPerpSymbols(state.getPlacement(PLACEMENT_IDS.PERPS))) : [];
+    const availability = $(useDiscoverPlacementAvailability);
+    const perps = availability[PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL];
+    const symbols = perps ? $(usePlacementsStore, state => readPerpSymbols(state.getPlacement(PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL))) : [];
 
     return {
       enabled: perps && symbols.length > 0,
@@ -55,7 +57,13 @@ export const useDiscoverPerpsStore = createQueryStore<HyperliquidSparklineFetchD
 );
 
 async function fetchDiscoverPerps(params: Params): Promise<HyperliquidSparklineFetchData> {
-  return (await useHyperliquidSparklineStore.getState().fetch(params)) ?? { chartsBySymbol: {} };
+  const data = await useHyperliquidSparklineStore.getState().fetch(params);
+  if (!data) {
+    const error = new RainbowError('[discoverPerpsStore]: sparkline fetch returned null');
+    logger.error(error);
+    throw error;
+  }
+  return data;
 }
 
 function readPerpSymbols(placement: Placement | undefined): string[] {

--- a/src/features/placements/stores/discover/discoverPerpsStore.ts
+++ b/src/features/placements/stores/discover/discoverPerpsStore.ts
@@ -4,8 +4,7 @@ import {
   type PerpSparklineData,
 } from '@/features/perps/stores/hyperliquidSparklineStore';
 import { PLACEMENT_IDS } from '@/features/placements/constants';
-import { useDiscoverPlacementAvailability } from '@/features/placements/stores/discover/discoverPlacementAvailabilityStore';
-import { usePlacementsStore } from '@/features/placements/stores/placementsStore';
+import { useDiscoverPlacementsStore } from '@/features/placements/stores/discover/discoverPlacementsStore';
 import { type Placement } from '@/features/placements/types';
 import { logger, RainbowError } from '@/logger';
 import { createDerivedStore } from '@/state/internal/createDerivedStore';
@@ -27,9 +26,8 @@ type Params = { symbolsKey: string };
 
 const useDiscoverPerpsRequestStore = createDerivedStore<DiscoverPerpsRequest>(
   $ => {
-    const availability = $(useDiscoverPlacementAvailability);
-    const perps = availability[PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL];
-    const symbols = perps ? $(usePlacementsStore, state => readPerpSymbols(state.getPlacement(PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL))) : [];
+    const perps = $(useDiscoverPlacementsStore, state => state.availability[PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL]);
+    const symbols = perps ? $(useDiscoverPlacementsStore, state => readPerpSymbols(state[PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL])) : [];
 
     return {
       enabled: perps && symbols.length > 0,


### PR DESCRIPTION
APP-3674

## What changed

- `useDiscoverPerpsStore` — derived store that computes `symbolsKey` (sorted comma-joined string of all Perps placement symbols) from `useDiscoverPlacements`; used as the fetch cache key
- `useHyperliquidSparklineStore` — query store that batch-fetches the last 28 H1 OHLC candles per symbol keyed by `symbolsKey`; data is shared across any surface requesting the same symbols
- H1 delta: `(candles[last].close - candles[0].close) / candles[0].close` — same `percentChange` value shown on the card label
- `PerpMarketSparkline` — Skia `Canvas` backed by a `PerpSparklineRenderer` worklet class; applies Makima smoothing to the close price series, fills the area below with a gradient matching the delta sign, animates the color via `withTiming` when delta direction changes
- `PerpMarketCard` card width grows dynamically to accommodate the chart frame

## Screen recordings / screenshots

![](https://raw.githubusercontent.com/rainbow-me/rainbow/assets/discover-v2/perps-sparklines.png)

## What to test

- Perps cards on Discover show H1 sparkline charts
- Chart color reflects the sign of the 1h delta
- Card charts animate when delta direction changes; prices update when new data is fetched (open market details, go back)
- Perps flow unaffected: can still tap through to market detail and open a position
- Cards with no chart data yet render without crashing