### PR TITLE
fix(transactions): stop logging all 4xx errors when fetching transaction

### DIFF
--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -148,9 +148,10 @@ export const fetchRawTransaction = async ({
 
     return parsed;
   } catch (e) {
-    // 404 means the backend hasn't indexed this transaction yet, which is expected
-    // for recently submitted transactions. Silently return null so callers can retry.
-    if (e instanceof RainbowFetchError && e.response?.status === 404) {
+    // 4xx responses are not actionable client-side: 404 means the backend hasn't indexed
+    // the transaction yet, and other 4xx (e.g. 403 WAF blocks) repeat once per second
+    // because the pending-tx watcher polls forever. Return null silently to avoid flooding Sentry.
+    if (e instanceof RainbowFetchError && e.response && e.response.status >= 400 && e.response.status < 500) {
       return null;
     }
     logger.error(new RainbowError('[transaction]: Failed to fetch transaction', e));

--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -61,6 +61,12 @@ export type BackendTransactionArgs = {
   enabled: boolean;
 };
 
+// 4xx responses where the client cannot meaningfully react. Silenced so the pending-tx
+// watcher's 1Hz polling doesn't flood Sentry while a persistent server-side condition
+// (auth, WAF, rate limit, not-yet-indexed) clears. 400 / 422 and other client-bug codes
+// are deliberately omitted: those signal malformed requests we want to see.
+const SILENCED_FETCH_STATUSES = new Set([401, 403, 404, 408, 429]);
+
 export const fetchRawTransaction = async ({
   abortController,
   address,
@@ -148,10 +154,7 @@ export const fetchRawTransaction = async ({
 
     return parsed;
   } catch (e) {
-    // 4xx responses are not actionable client-side: 404 means the backend hasn't indexed
-    // the transaction yet, and other 4xx (e.g. 403 WAF blocks) repeat once per second
-    // because the pending-tx watcher polls forever. Return null silently to avoid flooding Sentry.
-    if (e instanceof RainbowFetchError && e.response && e.response.status >= 400 && e.response.status < 500) {
+    if (e instanceof RainbowFetchError && e.response && SILENCED_FETCH_STATUSES.has(e.response.status)) {
       return null;
     }
     logger.error(new RainbowError('[transaction]: Failed to fetch transaction', e));


### PR DESCRIPTION
Fixes APP-3677

## What changed (plus any additional context for devs)

`fetchRawTransaction` previously only swallowed 404 silently; every other 4xx (notably 403 from CloudFront's WAF) went through `logger.error` and into Sentry. Combined with [`useTransactionWatcher`](https://github.com/rainbow-me/rainbow/blob/develop/src/hooks/useTransactionWatcher.ts) polling every 1 second per pending tx with no backoff, a single user hitting a persistent WAF block can generate thousands of Sentry events per hour. This is the dominant amplifier behind [RAINBOW-WALLET-3YN9](https://rainbow-me.sentry.io/issues/RAINBOW-WALLET-3YN9) (~551k events / ~92 users in a month).

This PR introduces an explicit allowlist of 4xx codes where the client cannot meaningfully react — `401, 403, 404, 408, 429` — and silently returns null for those, letting the watcher keep polling without firing a Sentry error. Everything else (including `400`, `422`, and other client-bug signals) continues to log so a future regression that sends malformed params is still visible.

Rationale per silenced code:
- **401** — static `PLATFORM_API_KEY` Bearer rejected; retrying within the watcher won't help.
- **403** — server policy / WAF (the observed Sentry case).
- **404** — backend hasn't indexed the freshly-submitted tx yet; the watcher is *designed* to poll through this.
- **408** — request timeout; transient.
- **429** — rate limit; logging while continuing to hammer makes the problem worse.

5xx, network failures, abort errors, and the explicitly-not-listed 4xx codes (`400`, `422`, etc.) continue to log as before.

## Screen recordings / screenshots

n/a — error-reporting change only.

## What to test

- Submit a transaction; confirm pending → confirmed flow still works (the 200 path is unchanged).
- Force a 403 from the transactions endpoint (e.g. point the platform base URL at something returning 403). Confirm:
  - The pending tx still polls and eventually gives up when the user dismisses / restarts.
  - **No** `[transaction]: Failed to fetch transaction` errors appear in Sentry / dev console.
- Force a 422 (or 400). Confirm `[transaction]: Failed to fetch transaction` *does* fire to Sentry.
- Force a 5xx (or kill connectivity mid-poll). Confirm errors are still logged.