### PR TITLE
Fix sponsored gas UI flicker

### DIFF
--- a/src/features/delegation/sponsoredSwapStore.ts
+++ b/src/features/delegation/sponsoredSwapStore.ts
@@ -60,7 +60,7 @@ export const useIsSponsoredSwap = createDerivedStore<boolean>(
     const address = $(useWalletsStore, s => s.accountAddress);
     const chainId = $(useSwapsStore, s => s.inputAsset?.chainId ?? null);
     const sponsorshipEligibleChainIds = $(useBackendNetworksStore, s => s.getSponsorshipEligibleChainIds());
-    const hasPreparedSwap = $(useSponsoredSwapStore, s => s.getStatus('isSuccess') || s.getStatus('isError'));
+    const hasPreparedSwap = $(useSponsoredSwapStore, s => !s.isDataExpired());
     const preparedSwap = $(useSponsoredSwapStore, s => s.getData());
     const sponsoredSwapsEnabled = $(useRemoteConfigStore, s => s.config.sponsored_swaps_enabled);
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)

- Fixes a small flicker that can occur in the swaps sponsored gas UI between swap quote loads due to an overly specific store status check

## Screen recordings / screenshots

## What to test
