### PR TITLE
feature (staking): staking card ui cleanup

### DIFF
--- a/src/features/rnbw-membership/components/TierBadge.tsx
+++ b/src/features/rnbw-membership/components/TierBadge.tsx
@@ -27,12 +27,14 @@ export const TierBadge = memo(function TierBadge({
   tier,
   height = 42,
   borderWidth = 2,
+  paddingHorizontal = 16,
   fontSize = '22pt',
   weight = 'heavy',
 }: {
   tier: TierType;
   height?: number;
   borderWidth?: number;
+  paddingHorizontal?: number;
   fontSize?: TextSize;
   weight?: TextWeight;
 }) {
@@ -87,7 +89,7 @@ export const TierBadge = memo(function TierBadge({
         start={borderStart}
         end={borderEnd}
         borderWidth={borderWidth}
-        style={[styles.tierBadge, { height, borderRadius }]}
+        style={[styles.tierBadge, { height, borderRadius, paddingHorizontal }]}
       >
         <InnerShadow color={opacity(globalColors.white100, 0.1)} blur={1} dx={0} dy={3} borderRadius={borderRadius} />
         {resolvedOverlay ? (
@@ -129,11 +131,8 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
   tierBadge: {
-    height: 42,
-    paddingHorizontal: 16,
     justifyContent: 'center',
     alignItems: 'center',
-    borderRadius: 21,
     overflow: 'hidden',
   },
 });

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useState } from 'react';
-import { RefreshControl, StyleSheet } from 'react-native';
+import { RefreshControl, View } from 'react-native';
 
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AccountImage } from '@/components/AccountImage';
@@ -38,15 +38,20 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
   const bottomInset = TAB_BAR_HEIGHT + 16;
   const stakingCardWidth = screenWidth - MEMBERSHIP_SCREEN_HORIZONTAL_PADDING * 2;
 
+  const scrollViewAnimatedStyle = useAnimatedStyle(() => ({
+    flex: 1,
+    overflow: scrollOffset.value > 0 ? 'hidden' : 'visible',
+  }));
+
   return (
-    <Box backgroundColor={backgroundColor} style={styles.flex} testID="rnbw-membership-screen" paddingTop={{ custom: safeAreaInsets.top }}>
+    <View style={{ flex: 1, backgroundColor, paddingTop: safeAreaInsets.top }} testID="rnbw-membership-screen">
       <ScrollHeaderFade color={backgroundColor} height={32} scrollOffset={scrollOffset} topInset={safeAreaInsets.top} />
       <Animated.ScrollView
         refreshControl={<RefreshControlWrapper />}
         contentContainerStyle={{
           paddingBottom: IS_ANDROID ? bottomInset : 0,
         }}
-        style={styles.scrollView}
+        style={scrollViewAnimatedStyle}
         onScroll={onScroll}
         contentInset={{
           bottom: bottomInset,
@@ -61,7 +66,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
           <RnbwAirdropClaimCard />
         </Box>
       </Animated.ScrollView>
-    </Box>
+    </View>
   );
 });
 
@@ -90,13 +95,3 @@ function RefreshControlWrapper(props: Omit<React.ComponentProps<typeof RefreshCo
     />
   );
 }
-
-const styles = StyleSheet.create({
-  flex: {
-    flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-    overflow: 'hidden',
-  },
-});

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/components/RnbwStakingCard.tsx
@@ -9,7 +9,6 @@ import { TierBadge } from '@/features/rnbw-membership/components/TierBadge';
 import { useMembershipTierInfo } from '@/features/rnbw-membership/stores/derived/useMembershipTierInfo';
 import { navigateToBuyRnbw } from '@/features/rnbw-membership/utils/navigateToBuyRnbw';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
-import { MIN_STAKE_AMOUNT } from '@/features/rnbw-staking/constants';
 import { useRnbwStakingBalance } from '@/features/rnbw-staking/stores/derived/useRnbwStakingBalance';
 import { useStakingPositionStore } from '@/features/rnbw-staking/stores/rnbwStakingPositionStore';
 import { blockRnbwStakingAccessIfNeeded } from '@/features/rnbw-staking/utils/blockStakingAccessIfNeeded';
@@ -52,7 +51,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard({ width }: RnbwStak
       notchOverlay={
         <ButtonPressAnimation onPress={navigateToMembershipTiersSheet}>
           <View onLayout={handleTierBadgeLayout}>
-            <TierBadge tier={currentTier} height={36} fontSize="17pt" borderWidth={THICK_BORDER_WIDTH} />
+            <TierBadge tier={currentTier} height={36} fontSize="17pt" borderWidth={THICK_BORDER_WIDTH} paddingHorizontal={14} />
           </View>
         </ButtonPressAnimation>
       }
@@ -90,7 +89,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard({ width }: RnbwStak
                   tier={currentTier}
                   onPress={hasMinimumStakeAmount ? navigateToStakingScreen : navigateToBuyRnbw}
                   style={styles.flexButton}
-                  label={hasMinimumStakeAmount ? i18n.t(i18n.l.button.add) : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)}
+                  label={hasMinimumStakeAmount ? i18n.t(i18n.l.button.add) : i18n.t(i18n.l.rnbw_membership.staking_card.buy)}
                 />
               </Box>
             ) : (
@@ -100,7 +99,7 @@ export const RnbwStakingCard = memo(function RnbwStakingCard({ width }: RnbwStak
                 label={
                   hasMinimumStakeAmount
                     ? i18n.t(i18n.l.rnbw_membership.staking_card.enable_staking)
-                    : i18n.t(i18n.l.rnbw_membership.staking_card.buy_rnbw)
+                    : i18n.t(i18n.l.rnbw_membership.staking_card.buy)
                 }
               />
             )}
@@ -119,9 +118,20 @@ export const RnbwStakingCard = memo(function RnbwStakingCard({ width }: RnbwStak
                 </Text>
               </Box>
             ) : (
-              <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
-                {i18n.t(i18n.l.rnbw_membership.staking_card.minimum_stake_amount_required, { minStakeAmount: MIN_STAKE_AMOUNT })}
-              </Text>
+              <Box flexDirection="row" alignItems="center" justifyContent="center" gap={4}>
+                <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
+                  {i18n.t(i18n.l.rnbw_membership.staking_card.buy_more)}
+                </Text>
+                <RnbwCoinIcon size={18} />
+                <Text size="15pt" weight="bold" color="labelSecondary" align="center">
+                  {RNBW_SYMBOL}
+                </Text>
+                <Text size="15pt" weight="semibold" color="labelQuaternary" align="center">
+                  {i18n.t(
+                    hasStakedPosition ? i18n.l.rnbw_membership.staking_card.to_add_to_stake : i18n.l.rnbw_membership.staking_card.to_stake
+                  )}
+                </Text>
+              </Box>
             )}
           </Box>
         </Box>

--- a/src/features/rnbw-membership/tierVisuals.ts
+++ b/src/features/rnbw-membership/tierVisuals.ts
@@ -337,7 +337,9 @@ const TIER_THEMES: Record<TierId, TierTheme> = {
     background: background('#E6E6E6', '#CFCFCF'),
     labelGradient: themed(gradient(['#313131', '#888888'])),
     badge: SILVER_BADGE,
-    primaryButton: badgePrimaryButton(SILVER_BADGE),
+    primaryButton: badgePrimaryButton(SILVER_BADGE, {
+      shadows: themedShadows([DEFAULT_BADGE_SHADOW], shadow('#B2B2B2', { width: 0, height: 0 }, 0.3, 15)),
+    }),
     secondaryButton: secondaryButton(SILVER_BADGE, {
       fill: themed(
         gradient([opacity('#EFEFEF', 0.5), opacity('#CDCDCD', 0.5)]),
@@ -345,6 +347,7 @@ const TIER_THEMES: Record<TierId, TierTheme> = {
       ),
       border: themed(gradient([opacity('#959595', 0.15), opacity('#3B3B3B', 0.045)])),
       textColor: themed('#6A6A6A', '#CBCBCB'),
+      shadows: themedShadows(DEFAULT_BADGE_SHADOW),
     }),
     progress: {
       fill: themed(gradient(['#EFEFEF', '#A2A2A2'])),
@@ -374,7 +377,7 @@ const TIER_THEMES: Record<TierId, TierTheme> = {
     labelGradient: themed(gradient(['#424749', '#7CADB4'])),
     badge: DIAMOND_BADGE,
     primaryButton: badgePrimaryButton(DIAMOND_BADGE, {
-      shadows: themedShadows(DEFAULT_BADGE_SHADOW, shadow('#42D2EB', { width: 0, height: 0 }, 0.3, 30)),
+      shadows: themedShadows(DEFAULT_BADGE_SHADOW, shadow('#42D2EB', { width: 0, height: 0 }, 0.3, 15)),
     }),
     secondaryButton: secondaryButton(DIAMOND_BADGE, {
       fill: themed(

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3892,7 +3892,6 @@
         "available_to_add": "available to add",
         "to_add_to_stake": "to add to stake",
         "to_stake": "to stake",
-        "minimum_stake_amount_required": "You need at least %{minStakeAmount} RNBW to stake",
         "buy_more": "Buy more"
       },
       "staking_earnings_card": {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -3886,11 +3886,14 @@
       "staking_card": {
         "stake": "Stake",
         "enable_staking": "Enable Staking",
-        "buy_rnbw": "Buy RNBW",
+        "buy": "Buy",
         "unstake": "Unstake",
         "available_to_stake": "available to stake",
         "available_to_add": "available to add",
-        "minimum_stake_amount_required": "You need at least %{minStakeAmount} RNBW to stake"
+        "to_add_to_stake": "to add to stake",
+        "to_stake": "to stake",
+        "minimum_stake_amount_required": "You need at least %{minStakeAmount} RNBW to stake",
+        "buy_more": "Buy more"
       },
       "staking_earnings_card": {
         "lifetime_earnings": "Lifetime Earnings",


### PR DESCRIPTION
## What changed

Minor UI polish on the membership staking card and tier visuals

#### Main changes
- `RnbwStakingCard`: replaced the plain "minimum stake required" line with "buy more rnbw to stake"
    - Renamed the buy CTA from "Buy RNBW" to "Buy".
- `TierBadge`: Smaller horizontal padding for staking card tier badge
- `tierVisuals`: Fixed silver and diamond shadow button configs.
- `RnbwMembershipScreen`:  `overflow: 'hidden'` conditional on `scrollOffset > 0` via `useAnimatedStyle`, so `TierBadge` shadow can overflow towards top of screen.
