### PR TITLE
chore: migrate from react-native-fs to expo-file-system

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,6 @@
     "react-native-device-info": "15.0.1",
     "react-native-edge-to-edge": "1.6.2",
     "react-native-fast-image": "8.5.11",
-    "react-native-fs": "2.16.6",
     "react-native-gesture-handler": "2.31.1",
     "react-native-get-random-values": "1.5.0",
     "react-native-image-colors": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "ethereumjs-wallet": "1.0.1",
     "events": "3.3.0",
     "expo": "53.0.20",
+    "expo-file-system": "18.1.11",
     "expo-image-manipulator": "13.1.7",
     "expo-image-picker": "17.0.0-canary-20250713-8f814f8",
     "expo-linear-gradient": "14.1.5",

--- a/src/components/DappBrowser/hooks/useScreenshotAndScrollTriggers.ts
+++ b/src/components/DappBrowser/hooks/useScreenshotAndScrollTriggers.ts
@@ -38,9 +38,9 @@ export function useScreenshotAndScrollTriggers() {
 
   const saveScreenshotToFileSystem = useCallback(
     async (tempUri: string, tabId: string, timestamp: number, url: string) => {
-      const screenshotWithRNFSPath = await saveScreenshot(tempUri, tabId, timestamp, url);
-      if (!screenshotWithRNFSPath) return;
-      runOnUI(setScreenshotDataWorklet)(screenshotWithRNFSPath);
+      const screenshotWithFullPath = await saveScreenshot(tempUri, tabId, timestamp, url);
+      if (!screenshotWithFullPath) return;
+      runOnUI(setScreenshotDataWorklet)(screenshotWithFullPath);
     },
     [setScreenshotDataWorklet]
   );

--- a/src/components/DappBrowser/screenshots.ts
+++ b/src/components/DappBrowser/screenshots.ts
@@ -1,4 +1,4 @@
-import RNFS from 'react-native-fs';
+import { copyAsync, deleteAsync, documentDirectory, readDirectoryAsync } from 'expo-file-system';
 import { createMMKV } from 'react-native-mmkv';
 
 import { logger, RainbowError } from '@/logger';
@@ -38,7 +38,7 @@ export function findTabScreenshot(id: string, url?: string): ScreenshotType | nu
     const mostRecentScreenshot = matchingScreenshots.reduce((a, b) => (a.timestamp > b.timestamp ? a : b));
     return {
       ...mostRecentScreenshot,
-      uri: `${RNFS.DocumentDirectoryPath}/${mostRecentScreenshot.uri}`,
+      uri: `${documentDirectory}${mostRecentScreenshot.uri}`,
     };
   }
 
@@ -72,17 +72,18 @@ export async function saveScreenshot(tempUri: string, tabId: string, timestamp: 
   const fileName = buildFilePath(timestamp);
 
   screenshotOperationLock.pending = screenshotOperationLock.pending.then(async () => {
+    const destinationUri = `${documentDirectory}${fileName}`;
     try {
-      await RNFS.copyFile(tempUri, `${RNFS.DocumentDirectoryPath}/${fileName}`);
+      await copyAsync({ from: tempUri, to: destinationUri });
       const newScreenshot: ScreenshotType = { id: tabId, timestamp, uri: fileName, url };
 
       const screenshots = getStoredScreenshots();
       screenshots.push(newScreenshot);
       tabScreenshotStorage.set(MMKV_KEY, JSON.stringify(screenshots));
 
-      return { ...newScreenshot, uri: `${RNFS.DocumentDirectoryPath}/${fileName}` };
+      return { ...newScreenshot, uri: destinationUri };
     } catch (error) {
-      await RNFS.unlink(`${RNFS.DocumentDirectoryPath}/${fileName}`).catch(() => {
+      await deleteAsync(destinationUri, { idempotent: true }).catch(() => {
         return;
       });
       logger.error(new RainbowError('[DappBrowser]: Error saving tab screenshot', error), { tabId, url });
@@ -139,7 +140,7 @@ async function pruneScreenshots(tabsData: Map<TabId, TabData>): Promise<void> {
     });
 
     if (screenshotsToDelete.length) {
-      const filesToDelete = screenshotsToDelete.map(s => `${RNFS.DocumentDirectoryPath}/${s.uri}`);
+      const filesToDelete = screenshotsToDelete.map(s => `${documentDirectory}${s.uri}`);
       await deleteFilesInBatches(filesToDelete);
     }
 
@@ -160,17 +161,17 @@ async function pruneOrphanedScreenshots(): Promise<void> {
 
     if (now - lastCleanup < DEEP_PRUNE_INTERVAL) return;
 
-    const screenshotFiles = await getScreenshotFiles();
+    const screenshotFileNames = await getScreenshotFiles();
     const trackedScreenshots = getStoredScreenshots();
     const trackedFileNames = new Set(trackedScreenshots.map(s => s.uri));
-    const orphanedFiles = screenshotFiles.filter(file => !trackedFileNames.has(file.name));
+    const orphanedFileNames = screenshotFileNames.filter(name => !trackedFileNames.has(name));
 
-    if (!orphanedFiles.length) {
+    if (!orphanedFileNames.length) {
       tabScreenshotStorage.set(MMKV_LAST_FULL_CLEANUP_KEY, now);
       return;
     }
 
-    await deleteFilesInBatches(orphanedFiles.map(f => f.path));
+    await deleteFilesInBatches(orphanedFileNames.map(name => `${documentDirectory}${name}`));
     tabScreenshotStorage.set(MMKV_LAST_FULL_CLEANUP_KEY, now);
   } catch (error) {
     logger.error(new RainbowError('[DappBrowser]: Orphaned screenshot cleanup failed', error));
@@ -186,16 +187,16 @@ function buildFilePath(timestamp: number): string {
   return `${FILE_PREFIX}${timestamp}-${random}${FILE_EXTENSION}`;
 }
 
-async function getScreenshotFiles(): Promise<RNFS.ReadDirItem[]> {
-  const files = await RNFS.readDir(RNFS.DocumentDirectoryPath);
-  return files.filter(file => file.name.startsWith(FILE_PREFIX));
+async function getScreenshotFiles(): Promise<string[]> {
+  const fileNames = await readDirectoryAsync(documentDirectory!);
+  return fileNames.filter(name => name.startsWith(FILE_PREFIX));
 }
 
 async function deleteFilesInBatches(filePaths: string[]): Promise<void> {
   for (let i = 0; i < filePaths.length; i += PRUNE_BATCH_SIZE) {
     const batch = filePaths.slice(i, i + PRUNE_BATCH_SIZE);
     const deletePromises = batch.map(filePath =>
-      RNFS.unlink(filePath).catch(error => {
+      deleteAsync(filePath, { idempotent: true }).catch(error => {
         logger.error(new RainbowError('[DappBrowser]: Error deleting screenshot file', error), {
           filePath,
         });

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -1,7 +1,7 @@
+import { deleteAsync, documentDirectory, writeAsStringAsync } from 'expo-file-system';
 import { sortBy } from 'lodash';
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import RNCloudFs from 'react-native-cloud-fs';
-import RNFS from 'react-native-fs';
 
 import { IS_ANDROID, IS_IOS } from '@/env';
 import { logger, RainbowError } from '@/logger';
@@ -94,10 +94,13 @@ export async function encryptAndSaveDataToCloud(data: Record<string, unknown>, p
     const backupFilename = IS_ANDROID ? normalizeAndroidBackupFilename(filename) : filename;
 
     // Store it on the FS first
-    const path = `${RNFS.DocumentDirectoryPath}/${backupFilename}`;
+    const fileUri = `${documentDirectory!}${backupFilename}`;
+    // RNCloudFs's `sourcePath.path` expects a POSIX path, while expo-file-system
+    // wants a `file://` URI. Strip the scheme for the cloud copy.
+    const fsPath = fileUri.replace(/^file:\/\//, '');
     // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
-    await RNFS.writeFile(path, encryptedData, 'utf8');
-    const sourceUri = { path };
+    await writeAsStringAsync(fileUri, encryptedData);
+    const sourceUri = { path: fsPath };
     const destinationPath = `${REMOTE_BACKUP_WALLET_DIR}/${backupFilename}`;
     const mimeType = 'application/json';
     // Only available to our app
@@ -130,7 +133,7 @@ export async function encryptAndSaveDataToCloud(data: Record<string, unknown>, p
       throw error;
     }
 
-    await RNFS.unlink(path);
+    await deleteAsync(fileUri, { idempotent: true });
     return filename;
   } catch (e: any) {
     logger.error(new RainbowError('[cloudBackup]: Error during encryptAndSaveDataToCloud'), {

--- a/src/handlers/pinata.ts
+++ b/src/handlers/pinata.ts
@@ -1,5 +1,5 @@
+import { FileSystemUploadType, uploadAsync } from 'expo-file-system';
 import { PINATA_API_KEY, PINATA_API_SECRET, PINATA_API_URL, PINATA_GATEWAY_URL } from 'react-native-dotenv';
-import RNFS from 'react-native-fs';
 
 type UploadFilesResponse = {
   IpfsHash: string;
@@ -20,22 +20,23 @@ export async function uploadImage({
   path: string;
   mime: string;
 }): Promise<UploadImageReturnData> {
-  const response = await RNFS.uploadFiles({
-    files: [
-      {
-        filename,
-        filepath: path,
-        filetype: mime,
-        name: 'file',
-      },
-    ],
+  // expo-file-system requires a `file://` URI; callers may pass a bare POSIX path.
+  const fileUri = path.startsWith('file://') ? path : `file://${path}`;
+  const response = await uploadAsync(`${PINATA_API_URL}/pinning/pinFileToIPFS`, fileUri, {
+    httpMethod: 'POST',
+    uploadType: FileSystemUploadType.MULTIPART,
+    fieldName: 'file',
+    mimeType: mime,
     headers: {
       pinata_api_key: PINATA_API_KEY,
       pinata_secret_api_key: PINATA_API_SECRET,
     },
-    method: 'POST',
-    toUrl: `${PINATA_API_URL}/pinning/pinFileToIPFS`,
-  }).promise;
+    // Preserve the caller-supplied filename in Pinata's metadata. Without
+    // this, Pinata names the pin from the multipart Content-Disposition,
+    // which expo-file-system derives from the file's basename rather than
+    // any explicit `filename` parameter.
+    parameters: { pinataMetadata: JSON.stringify({ name: filename }) },
+  });
   const parsedBody = JSON.parse(response.body) as UploadFilesResponse;
   return {
     ...parsedBody,

--- a/src/model/migrations.ts
+++ b/src/model/migrations.ts
@@ -1,10 +1,8 @@
-import path from 'path';
-
 import { captureException } from '@sentry/react-native';
+import { cacheDirectory, deleteAsync } from 'expo-file-system';
 import { findKey, isEmpty, isNumber, keys } from 'lodash';
 import uniq from 'lodash/uniq';
 import FastImage from 'react-native-fast-image';
-import RNFS from 'react-native-fs';
 import { createMMKV } from 'react-native-mmkv';
 
 import { type UniqueId } from '@/__swaps__/types/assets';
@@ -565,11 +563,12 @@ export default async function runMigrations() {
    */
   const v16 = async () => {
     try {
-      RNFS.unlink(path.join(RNFS.CachesDirectoryPath, `${RB_TOKEN_LIST_CACHE}.json`)).catch(() => {
+      // `cacheDirectory` ends with a trailing `/`, so concatenation is enough.
+      deleteAsync(`${cacheDirectory!}${RB_TOKEN_LIST_CACHE}.json`, { idempotent: true }).catch(() => {
         // we don't care if it fails
       });
 
-      RNFS.unlink(path.join(RNFS.CachesDirectoryPath, `${RB_TOKEN_LIST_ETAG}.json`)).catch(() => {
+      deleteAsync(`${cacheDirectory!}${RB_TOKEN_LIST_ETAG}.json`, { idempotent: true }).catch(() => {
         // we don't care if it fails
       });
     } catch (error: any) {

--- a/src/screens/Diagnostics/helpers/createAndShareStateDumpFile.ts
+++ b/src/screens/Diagnostics/helpers/createAndShareStateDumpFile.ts
@@ -1,7 +1,6 @@
-import RNFS from 'react-native-fs';
+import { deleteAsync, documentDirectory, writeAsStringAsync } from 'expo-file-system';
 import RNShare from 'react-native-share';
 
-import { IS_ANDROID } from '@/env';
 import { getAllActiveSessions } from '@/features/wallet-connect/services/sessions';
 import { logger, RainbowError } from '@/logger';
 import store from '@/redux/store';
@@ -56,22 +55,21 @@ export async function createAndShareStateDumpFile() {
   };
   const stringifiedState = JSON.stringify(state, cyclicReplacer());
 
-  const documentsFilePath = `${RNFS.DocumentDirectoryPath}/${APP_STATE_DUMP_FILE_NAME}`;
+  // `documentDirectory` is `null` only on web (this code is native-only); the
+  // value is a `file://` URI ending in `/`.
+  const documentsFileUri = `${documentDirectory!}${APP_STATE_DUMP_FILE_NAME}`;
   try {
-    // first remove the old file in case the immediate removal failed
-    const fileExists = await RNFS.exists(documentsFilePath);
-    if (fileExists) {
-      await RNFS.unlink(documentsFilePath);
-    }
-    await RNFS.writeFile(documentsFilePath, stringifiedState, 'utf8');
-    if (IS_ANDROID) {
-      await RNFS.writeFile(`${RNFS.DownloadDirectoryPath}/app_state_dump_${Date.now()}.json`, stringifiedState, 'utf8');
-    }
+    // first remove the old file in case the immediate removal failed; `idempotent`
+    // makes this a no-op when the file is already gone
+    await deleteAsync(documentsFileUri, { idempotent: true });
+    await writeAsStringAsync(documentsFileUri, stringifiedState);
+    // The share sheet (Save to Files / Drive / etc.) is the cross-platform
+    // way to hand the dump off the device.
     await RNShare.open({
-      url: `file://${documentsFilePath}`,
+      url: documentsFileUri,
     });
     // clean up the file since we don't need it anymore
-    await RNFS.unlink(documentsFilePath);
+    await deleteAsync(documentsFileUri, { idempotent: true });
   } catch (error) {
     logger.error(new RainbowError('[createAndShareStateDumpFile]: Saving app state dump data failed'));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9708,7 +9708,6 @@ __metadata:
     react-native-dotenv: "npm:2.4.2"
     react-native-edge-to-edge: "npm:1.6.2"
     react-native-fast-image: "npm:8.5.11"
-    react-native-fs: "npm:2.16.6"
     react-native-gesture-handler: "npm:2.31.1"
     react-native-get-random-values: "npm:1.5.0"
     react-native-image-colors: "npm:2.5.1"
@@ -10930,7 +10929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-64@npm:0.1.0, base-64@npm:^0.1.0":
+"base-64@npm:0.1.0":
   version: 0.1.0
   resolution: "base-64@npm:0.1.0"
   checksum: 10c0/fe0dcf076e823f04db7ee9b02495be08a91c445fbc6db03cb9913be9680e2fcc0af8b74459041fe08ad16800b1f65a549501d8f08696a8a6d32880789b7de69d
@@ -22958,19 +22957,6 @@ __metadata:
   dependencies:
     prop-types: "npm:^15.5.10"
   checksum: 10c0/04d1cb35f2acacda593c80f2d9845f7dc0ed5e0e1fb62043ba5351f914162dcd92f1ae98e80ebf9752f6b4131b1634f6a9ac90e9c649f30b5591f3187d99811f
-  languageName: node
-  linkType: hard
-
-"react-native-fs@npm:2.16.6":
-  version: 2.16.6
-  resolution: "react-native-fs@npm:2.16.6"
-  dependencies:
-    base-64: "npm:^0.1.0"
-    utf8: "npm:^3.0.0"
-  peerDependencies:
-    react-native: ^0.59.5
-    react-native-windows: ^0.57.2
-  checksum: 10c0/223a8810583f2a6316e7533a7f0b85143ebffb3f75b7dbc3a222b35d03175d7c081e61024547bdb91c201af778a5c45b058c34c6770fa007d3afc6ae17f669e1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9642,6 +9642,7 @@ __metadata:
     ethereumjs-wallet: "npm:1.0.1"
     events: "npm:3.3.0"
     expo: "npm:53.0.20"
+    expo-file-system: "npm:18.1.11"
     expo-image-manipulator: "npm:13.1.7"
     expo-image-picker: "npm:17.0.0-canary-20250713-8f814f8"
     expo-linear-gradient: "npm:14.1.5"
@@ -14938,7 +14939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-file-system@npm:~18.1.11":
+"expo-file-system@npm:18.1.11, expo-file-system@npm:~18.1.11":
   version: 18.1.11
   resolution: "expo-file-system@npm:18.1.11"
   peerDependencies:


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

Removes `react-native-fs` from the app and routes every caller through `expo-file-system`, which is already pulled in transitively via the `expo` SDK and is now promoted to a direct dependency. The motivation was twofold: `react-native-fs` is unmaintained and needed a local patch to survive RN 0.81 (`PromiseImpl.reject` now rejects null `code`), and the API surface we use is small and maps cleanly to `expo-file-system`.

Changes by call site:

- `src/components/DappBrowser/screenshots.ts` — `copyFile`/`unlink`/`readDir` → `copyAsync`/`deleteAsync({ idempotent: true })`/`readDirectoryAsync`. The orphan-prune path was reshaped slightly: `readDirectoryAsync` returns plain filename strings, where RNFS returned `ReadDirItem` objects with a `path` field, so the file URIs are now built explicitly from `documentDirectory + name`.
- `src/handlers/cloudBackup.ts` — `writeFile`/`unlink` → `writeAsStringAsync`/`deleteAsync`. RNCloudFs's `sourcePath.path` still expects a POSIX path, so the `file://` URI is stripped before the cloud copy.
- `src/model/migrations.ts` (migration v16) — `unlink(path.join(...))` → `deleteAsync(URI, { idempotent: true })`. `cacheDirectory` already ends with a trailing slash, so `path` is no longer needed.
- `src/handlers/pinata.ts` — `RNFS.uploadFiles({...}).promise` → `FileSystem.uploadAsync(url, fileUri, { uploadType: MULTIPART, ... })`. expo-file-system derives the multipart filename from the URI's basename and has no override; to preserve the caller-supplied filename, it's passed through `pinataMetadata.name` in the form parameters, which Pinata uses for the pin name.
- `src/screens/Diagnostics/helpers/createAndShareStateDumpFile.ts` — same `documentDirectory`/`writeAsStringAsync`/`deleteAsync` swap. The Android-only `RNFS.DownloadDirectoryPath` write was redundant with the share sheet that follows and is dropped — `expo-file-system` has no equivalent for the public Downloads folder, but the cross-platform share sheet ("Save to Files", Drive, AirDrop, etc.) already covers the developer-export use case on both platforms.

`react-native-fs` is removed from `package.json`; `base-64` (its sub-dep) drops out of the lockfile too.

## Screen recordings / screenshots

n/a — equivalent behaviour, no UI surface change.

## What to test

- **DappBrowser screenshots:** open and close several browser tabs over a session; verify tab thumbnails appear correctly when switching between tabs and that orphan cleanup still runs (no leftover screenshot files in the document directory after a tab is closed).
- **Cloud backup:** trigger an iCloud / Google Drive backup of the wallet and verify the file lands in the cloud and the local document copy is deleted afterwards.
- **Migration v16:** install an older build that still writes `rainbow-token-list.json` / `rainbow-token-list-etag.json` into the cache dir, then upgrade to this build; verify those files are gone after first launch (or simply that the migration runs without error in a fresh install).
- **Pinata avatar upload:** through the ENS profile flow, pick an image and upload it as the avatar; verify the upload succeeds, the IPFS URL resolves to the image, and (if you have access to the Pinata dashboard) the pin's name matches the original filename.
- **Diagnostics state dump:** open the Diagnostics screen and trigger "Share state dump"; verify the share sheet opens with the JSON file and that triggering it twice in a row works (no leftover-file errors).