### PR TITLE
feat: redesigned Sentry environments

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -29,7 +29,6 @@ declare module 'react-native-dotenv' {
   export const IS_APK_BUILD: 'true' | 'false';
   export const ENABLE_DEV_MODE: '0' | '1';
   export const SENTRY_ENDPOINT: string;
-  export const SENTRY_ENVIRONMENT: string;
   export const ADDYS_API_KEY: string;
   export const ETHEREUM_MAINNET_RPC_DEV: string;
   export const IMGIX_DOMAIN: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { RainbowToastDisplay } from '@/components/rainbow-toast/RainbowToast';
 import { OfflineToast } from '@/components/toasts';
 import { reactNativeDisableYellowBox, showNetworkRequests, showNetworkResponses } from '@/config/debug';
 import monitorNetwork from '@/debugging/network';
-import { DANGER_INSTALL_SOURCE, IS_DEV, IS_PROD, IS_TEST } from '@/env';
+import { IS_DEV, IS_PROD, IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { configureDelegationSdk } from '@/features/delegation/configureClient';
 import RainbowContextWrapper from '@/helpers/RainbowContext';
 import { useApplicationSetup } from '@/hooks/useApplicationSetup';
@@ -167,11 +167,12 @@ async function initializeApplication() {
 
   Sentry.setUser({ id: deviceId });
   analytics.init({ deviceId });
-  analytics.identify({ installSource: DANGER_INSTALL_SOURCE });
+  const installSource = IS_DEV ? 'dev' : IS_STORE_INSTALL ? 'store' : 'internal';
+  analytics.identify({ installSource });
   // Paired probe event. Lets us distinguish "identify trait dropped by pipeline"
   // from "whole session too short to flush" by comparing track delivery to
   // user-property delivery in Amplitude. Remove after FEPLAT-67 wraps up.
-  analytics.track(analytics.event.debugIdentifyProbe, { probe: 'installSource', value: String(DANGER_INSTALL_SOURCE) });
+  analytics.track(analytics.event.debugIdentifyProbe, { probe: 'installSource', value: installSource });
 
   await Promise.all([initializeRemoteConfig(), migrate(), loadSettingsData(), configureDelegationSdk()]);
 

--- a/src/analytics/userProperties.ts
+++ b/src/analytics/userProperties.ts
@@ -1,8 +1,9 @@
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import type { InstallSource } from '@/env';
 import { type CandleResolution, type ChartType } from '@/features/charts/types';
 import { type Language } from '@/languages';
 import { type ChainId } from '@/state/backendNetworks/types';
+
+type InstallSource = 'store' | 'internal' | 'dev';
 
 // have to put this here or redux gets important and tests break
 type PushNotificationPermissionStatus = 'enabled' | 'disabled' | 'never asked';

--- a/src/components/AppVersionStamp.tsx
+++ b/src/components/AppVersionStamp.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { Pressable } from 'react-native';
 
 import { Text } from '@/design-system';
-import { DANGER_INSTALL_SOURCE, IS_ANDROID, IS_IOS } from '@/env';
+import { IS_ANDROID, IS_DEV, IS_IOS, IS_STORE_INSTALL } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useAppVersion from '@/hooks/useAppVersion';
 import useTimeout from '@/hooks/useTimeout';
@@ -40,7 +40,7 @@ export function AppVersionStamp() {
   return (
     <StyledButton testID="app-version-stamp" hitSlop={10} onPress={handleVersionPress}>
       <Text color="secondary30 (Deprecated)" size="14px / 19px (Deprecated)" weight="bold">
-        {`${appVersion} · ${DANGER_INSTALL_SOURCE}`}
+        {`${appVersion} · ${IS_DEV ? 'dev' : IS_STORE_INSTALL ? 'store' : 'internal'}`}
       </Text>
     </StyledButton>
   );

--- a/src/components/rainbow-toast/ToastContent.tsx
+++ b/src/components/rainbow-toast/ToastContent.tsx
@@ -11,7 +11,7 @@ import { Text } from '@/design-system';
 import { textSizes, textWeights } from '@/design-system/typography/typography';
 import { AssetType } from '@/entities/assetTypes';
 import { TransactionStatus } from '@/entities/transactions';
-import { IS_INTERNAL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { getTransactionLaunchToken } from '@/helpers/transactions';
 import * as i18n from '@/languages';
 import { measureTextSync, type MeasureTextStyle } from '@/utils/measureText';
@@ -240,7 +240,7 @@ export function areToastContentLayoutsEqual(a: ToastContentLayout | null, b: Toa
 
 function getSwapToastBottomLabel(toast: RainbowToast): string | undefined {
   const { batch, delegation } = toast.transaction;
-  return IS_INTERNAL && batch ? (delegation ? 'Type 4' : 'Type 2') : undefined;
+  return !IS_STORE_INSTALL && batch ? (delegation ? 'Type 4' : 'Type 2') : undefined;
 }
 
 function getSwapToastNetworkLabelText(toast: RainbowToast): string {

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -1,6 +1,6 @@
 import { createMMKV } from 'react-native-mmkv';
 
-import { IS_INTERNAL, IS_TEST } from '@/env';
+import { IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { STORAGE_IDS } from '@/model/mmkv';
 
 /**
@@ -78,7 +78,7 @@ const config = {
   [RAINBOW_TRENDING_TOKENS_LIST]: { settings: true, value: false },
   [PRINCE_OF_THE_HILL]: { settings: true, value: false },
   [LAZY_TABS]: { needsRestart: true, settings: true, value: false },
-  [CANDLESTICK_CHARTS]: { settings: true, value: IS_INTERNAL || false },
+  [CANDLESTICK_CHARTS]: { settings: true, value: !IS_STORE_INSTALL },
   [CANDLESTICK_DATA_MONITOR]: { settings: true, value: false },
   [KING_OF_THE_HILL_TAB]: { settings: true, value: false },
   [RAINBOW_TOASTS]: { settings: true, value: false },

--- a/src/config/experimentalHooks.ts
+++ b/src/config/experimentalHooks.ts
@@ -1,12 +1,12 @@
 import { useContext } from 'react';
 
-import { IS_INTERNAL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { RainbowContext } from '@/helpers/RainbowContext';
 
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from './experimental';
 
 const useExperimentalFlag = (name: ExperimentalConfigKey) => {
-  if (IS_INTERNAL) {
+  if (!IS_STORE_INSTALL) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useContext(RainbowContext).config[name];
   } else {
@@ -15,7 +15,7 @@ const useExperimentalFlag = (name: ExperimentalConfigKey) => {
 };
 
 export const useExperimentalConfig = () => {
-  if (IS_INTERNAL) {
+  if (!IS_STORE_INSTALL) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useContext(RainbowContext).config;
   } else {

--- a/src/env.ts
+++ b/src/env.ts
@@ -29,6 +29,9 @@ export const RPC_PROXY_API_KEY = RPC_PROXY_API_KEY_PROD;
  * Whether the app was installed from App Store / Play Store (real prod app) or not (TestFlight, internal, local builds etc.).
  */
 export const IS_STORE_INSTALL = (() => {
+  if (IS_DEV) {
+    return false;
+  }
   try {
     const result = NativeModules.AppInstallInfo.isStoreInstall();
     if (typeof result === 'boolean') {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,5 @@
 import ReactNative, { NativeModules } from 'react-native';
 
-import { getInstallerPackageNameSync } from 'react-native-device-info';
 import { ENABLE_DEV_MODE, IS_TESTING, RPC_PROXY_API_KEY_PROD, RPC_PROXY_BASE_URL_PROD } from 'react-native-dotenv';
 
 /**
@@ -26,14 +25,17 @@ export const IS_PROD = !IS_DEV && !IS_TEST;
 export const RPC_PROXY_BASE_URL = RPC_PROXY_BASE_URL_PROD;
 export const RPC_PROXY_API_KEY = RPC_PROXY_API_KEY_PROD;
 
-export const IS_TEST_FLIGHT = IS_IOS && getInstallerPackageNameSync() === 'TestFlight';
-
-// TODO: Replace IS_STORE_INSTALL with DANGER_INSTALL_SOURCE (renamed to INSTALL_SOURCE) once verified in production.
-// The AppInstallInfo native module is shipped but not wired in yet. DANGER_INSTALL_SOURCE
-// reads from the new native module for observation/verification only. Do NOT use it for
-// gating features or behavior until the values have been confirmed across all build types.
-export const IS_STORE_INSTALL = !IS_DEV && !IS_TEST_FLIGHT;
-export const IS_INTERNAL = IS_DEV || !IS_STORE_INSTALL;
-
-export type InstallSource = 'store' | 'internal' | 'dev';
-export const DANGER_INSTALL_SOURCE: InstallSource = IS_DEV ? 'dev' : NativeModules.AppInstallInfo.isStoreInstall() ? 'store' : 'internal';
+/**
+ * Whether the app was installed from App Store / Play Store (real prod app) or not (TestFlight, internal, local builds etc.).
+ */
+export const IS_STORE_INSTALL = (() => {
+  try {
+    const result = NativeModules.AppInstallInfo.isStoreInstall();
+    if (typeof result === 'boolean') {
+      return result;
+    }
+  } catch {
+    // Module missing or threw, fallback to safe default below
+  }
+  return true;
+})();

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -1,10 +1,17 @@
 import * as Sentry from '@sentry/react-native';
-import { SENTRY_ENDPOINT, SENTRY_ENVIRONMENT } from 'react-native-dotenv';
+import { SENTRY_ENDPOINT } from 'react-native-dotenv';
 import VersionNumber from 'react-native-version-number';
 
-import { IS_TEST, IS_TEST_FLIGHT } from '@/env';
+import { IS_DEV, IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { logger, RainbowError } from '@/logger';
+
+// Sentry init bails out in dev/test today (see initSentry below), so the
+// 'development' branch is dormant — but the derivation matches the build state
+// honestly so a future SENTRY_DEV opt-in can flip the init guard without
+// touching this mapping.
+type Environment = 'production' | 'internal' | 'development';
+const ENVIRONMENT: Environment = IS_DEV ? 'development' : IS_STORE_INSTALL ? 'production' : 'internal';
 
 // Sentry tests each regex against these candidate strings:
 //   1. event.message
@@ -63,7 +70,7 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
   enableAppHangTracking: false,
   enableAutoPerformanceTracing: false,
   enableAutoSessionTracking: false,
-  environment: IS_TEST_FLIGHT ? 'Testflight' : SENTRY_ENVIRONMENT,
+  environment: ENVIRONMENT,
   ignoreErrors: IGNORED_ERRORS,
   integrations: [Sentry.httpClientIntegration()], // http client integration will help us see payload / response from errored out requests to better understand the issue
   maxBreadcrumbs: 10,
@@ -71,8 +78,8 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
 };
 
 export function initSentry() {
-  if (IS_TEST) {
-    logger.debug(`[sentry]: disabled for test environment`);
+  if (IS_TEST || IS_DEV) {
+    logger.debug(`[sentry]: disabled for ${IS_TEST ? 'test' : 'dev'} build`);
     return;
   }
   try {

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -74,6 +74,7 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
 };
 
 export function initSentry() {
+  // Use __DEV__ over IS_DEV as we only want to disable this on actual Metro dev builds, not when ENABLE_DEV_MODE is set
   if (IS_TEST || __DEV__) {
     logger.debug(`[sentry]: disabled for ${IS_TEST ? 'test' : 'dev'} session`);
     return;

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -6,10 +6,6 @@ import { IS_DEV, IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { logger, RainbowError } from '@/logger';
 
-// Sentry init bails out in dev/test today (see initSentry below), so the
-// 'development' branch is dormant — but the derivation matches the build state
-// honestly so a future SENTRY_DEV opt-in can flip the init guard without
-// touching this mapping.
 type Environment = 'production' | 'internal' | 'development';
 const ENVIRONMENT: Environment = IS_DEV ? 'development' : IS_STORE_INSTALL ? 'production' : 'internal';
 
@@ -78,8 +74,8 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
 };
 
 export function initSentry() {
-  if (IS_TEST || IS_DEV) {
-    logger.debug(`[sentry]: disabled for ${IS_TEST ? 'test' : 'dev'} build`);
+  if (IS_TEST || __DEV__) {
+    logger.debug(`[sentry]: disabled for ${IS_TEST ? 'test' : 'metro dev'} session`);
     return;
   }
   try {

--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -75,7 +75,7 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
 
 export function initSentry() {
   if (IS_TEST || __DEV__) {
-    logger.debug(`[sentry]: disabled for ${IS_TEST ? 'test' : 'metro dev'} session`);
+    logger.debug(`[sentry]: disabled for ${IS_TEST ? 'test' : 'dev'} session`);
     return;
   }
   try {

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import remoteConfig, { type FirebaseRemoteConfigTypes } from '@react-native-firebase/remote-config';
 import { dequal } from 'dequal';
 
-import { IS_DEV, IS_INTERNAL } from '@/env';
+import { IS_DEV, IS_STORE_INSTALL } from '@/env';
 import { CURRENT_APP_VERSION } from '@/hooks/useAppVersion';
 import * as i18n from '@/languages';
 import { logger, RainbowError } from '@/logger';
@@ -219,8 +219,8 @@ export const DEFAULT_CONFIG = {
   king_of_the_hill2_enabled: false,
   king_of_the_hill_enabled: false,
   prince_of_the_hill_enabled: false,
-  candlestick_charts_enabled: IS_INTERNAL,
-  rainbow_toasts_enabled: IS_INTERNAL,
+  candlestick_charts_enabled: !IS_STORE_INSTALL,
+  rainbow_toasts_enabled: !IS_STORE_INSTALL,
   perps_enabled: false,
   polymarket_enabled: false,
   dev_section_enabled: IS_DEV,

--- a/src/performance/tracking/index.ts
+++ b/src/performance/tracking/index.ts
@@ -1,8 +1,6 @@
-import { SENTRY_ENVIRONMENT } from 'react-native-dotenv';
-
 import { analytics } from '@/analytics';
 import { event, type EventProperties } from '@/analytics/event';
-import { IS_DEV, IS_TEST } from '@/env';
+import { IS_PROD, IS_TEST } from '@/env';
 import { logger } from '@/logger';
 import { Timer } from '@/performance/timer';
 
@@ -47,7 +45,7 @@ interface Report {
 type Params = Record<string, unknown>;
 
 class PerformanceTracker {
-  analyticsTrackingEnabled = !IS_TEST && !IS_DEV && SENTRY_ENVIRONMENT !== 'LocalRelease';
+  analyticsTrackingEnabled = IS_PROD;
   // Toggle if you want console logs
   debug = false;
   timer = new Timer();

--- a/src/react-query/reactQueryUtils.ts
+++ b/src/react-query/reactQueryUtils.ts
@@ -2,7 +2,7 @@ import { hydrate } from '@tanstack/react-query';
 import { createMMKV } from 'react-native-mmkv';
 
 import { showLogSheet, type LogEntry } from '@/components/debugging/LogSheet';
-import { IS_DEV, IS_INTERNAL } from '@/env';
+import { IS_DEV, IS_STORE_INSTALL } from '@/env';
 import { getDateFormatter } from '@/helpers/intl';
 import { logger, RainbowError } from '@/logger';
 import { persistOptions, queryClient } from '@/react-query';
@@ -42,7 +42,7 @@ interface CachedQuery {
  * @returns A promise that resolves after the cache is cleared.
  */
 export async function clearReactQueryCache({
-  analyzeAfterClearing = IS_INTERNAL,
+  analyzeAfterClearing = !IS_STORE_INSTALL,
   onComplete,
   preserveFavorites = true,
 }: {
@@ -179,7 +179,7 @@ interface QueryInfo {
  * @returns A formatted report array or undefined if not displayed.
  */
 export function analyzeReactQueryStore({
-  displayReport = IS_INTERNAL,
+  displayReport = !IS_STORE_INSTALL,
   logExtendedBreakdown = true,
   logQueryDataShape: logQueryDataShapeParam = false,
   transformReport = report => report,
@@ -189,7 +189,7 @@ export function analyzeReactQueryStore({
   logQueryDataShape?: boolean;
   transformReport?: (report: LogEntry[]) => LogEntry[];
 } = {}): ReturnType<typeof formatReport> | undefined {
-  if (!IS_INTERNAL) return;
+  if (IS_STORE_INSTALL) return;
 
   devLog('\n[React Query Store Analysis]');
   const report: Report | null = displayReport ? { title: { title: '🔦  React Query Analysis', message: '' } } : null;

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -9,7 +9,7 @@ import Restart from 'react-native-restart';
 
 import { ImgixImage } from '@/components/images';
 import { defaultConfig, getExperimentalFlag, LOG_PUSH } from '@/config/experimentalHooks';
-import { IS_ANDROID, IS_INTERNAL } from '@/env';
+import { IS_ANDROID, IS_STORE_INSTALL } from '@/env';
 import { getDelegationContractAddress, isRainbowDelegated, isThirdPartyDelegated } from '@/features/delegation/status';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { RainbowContext } from '@/helpers/RainbowContext';
@@ -236,7 +236,7 @@ const DevSection = () => {
 
   return (
     <MenuContainer testID="developer-settings-sheet">
-      <Menu header={IS_INTERNAL ? i18n.t(i18n.l.developer_settings.headers.normie_settings) : ''}>
+      <Menu header={!IS_STORE_INSTALL ? i18n.t(i18n.l.developer_settings.headers.normie_settings) : ''}>
         {/* <MenuItem
           disabled
           leftComponent={<MenuItem.TextIcon icon="🕹️" isEmoji />}
@@ -284,7 +284,7 @@ const DevSection = () => {
           titleComponent={<MenuItem.Title text="Wipe App + Restart" />}
         />
       </Menu>
-      {IS_INTERNAL && (
+      {!IS_STORE_INSTALL && (
         <>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.rainbow_developer_settings)}>
             <MenuItem

--- a/src/screens/change-wallet/components/AddressRow.tsx
+++ b/src/screens/change-wallet/components/AddressRow.tsx
@@ -10,7 +10,7 @@ import { Icon } from '@/components/icons';
 import { Box, globalColors, Inline, Stack, Text, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
 import { type TextWeight } from '@/design-system/components/Text/Text';
 import { type TextSize } from '@/design-system/typography/typeHierarchy';
-import { IS_INTERNAL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { useIsDelegationEnabled } from '@/features/delegation/featureFlags';
 import { isRainbowDelegated as hasRainbowDelegation, isThirdPartyDelegated as hasThirdPartyDelegation } from '@/features/delegation/status';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -208,7 +208,7 @@ export function AddressRow({ data, editMode, onPress, menuItems, onPressMenuItem
                 )}
               </>
             )}
-            {IS_INTERNAL && delegationEnabled && !isReadOnly && !editMode && (
+            {!IS_STORE_INSTALL && delegationEnabled && !isReadOnly && !editMode && (
               <Box
                 paddingHorizontal="8px"
                 paddingVertical="6px"

--- a/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
+++ b/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
@@ -12,7 +12,7 @@ import { Draggable, DraggableGrid, type DraggableGridProps, type UniqueIdentifie
 import { DropdownMenu, type MenuItem } from '@/components/DropdownMenu';
 import { PANEL_WIDTH } from '@/components/SmoothPager/ListPanel';
 import { Box, HitSlop, Inline, Stack, Text, TextIcon } from '@/design-system';
-import { IS_INTERNAL, IS_IOS } from '@/env';
+import { IS_IOS, IS_STORE_INSTALL } from '@/env';
 import { useIsDelegationEnabled } from '@/features/delegation/featureFlags';
 import { isRainbowDelegated as hasRainbowDelegation, isThirdPartyDelegated as hasThirdPartyDelegation } from '@/features/delegation/status';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
@@ -226,7 +226,9 @@ export function PinnedWalletsGrid({ walletItems, onPress, editMode, menuItems, o
                       </Text>
                     ) : null}
 
-                    {IS_INTERNAL && delegationEnabled && !account.isReadOnly ? <DelegationBadge accountAddress={account.address} /> : null}
+                    {!IS_STORE_INSTALL && delegationEnabled && !account.isReadOnly ? (
+                      <DelegationBadge accountAddress={account.address} />
+                    ) : null}
 
                     <Text numberOfLines={1} ellipsizeMode="middle" color="label" size="13pt" weight="bold">
                       {walletName}

--- a/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/BuySection.tsx
@@ -9,7 +9,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { Bleed, Box, IconContainer, Stack, Text, TextShadow } from '@/design-system';
-import { IS_INTERNAL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { isL2Chain } from '@/handlers/web3';
 import { convertAmountToNativeDisplay, convertStringToNumber, roundToSignificant1or5 } from '@/helpers/utilities';
 import useAccountAsset from '@/hooks/useAccountAsset';
@@ -27,7 +27,7 @@ import { SheetSeparator } from '../shared/Separator';
 const GRADIENT_FADE_WIDTH = 24;
 const DEFAULT_PERCENTAGES_OF_BALANCE = [0.05, 0.1, 0.25, 0.5, 0.75];
 // Ideally this would be different for different currencies, but that would need to be set in the remote config
-const DEFAULT_MAINNET_MINIMUM_NATIVE_CURRENCY_AMOUNT = IS_INTERNAL ? 1 : 10;
+const DEFAULT_MAINNET_MINIMUM_NATIVE_CURRENCY_AMOUNT = IS_STORE_INSTALL ? 10 : 1;
 const DEFAULT_L2_MINIMUM_NATIVE_CURRENCY_AMOUNT = 1;
 
 const BUTTON_INSET_HORIZONTAL = 24;

--- a/src/screens/token-launcher/state/tokenLauncherStore.ts
+++ b/src/screens/token-launcher/state/tokenLauncherStore.ts
@@ -6,7 +6,7 @@ import { parseEther, type Account, type Chain, type PublicClient, type Transport
 import { analytics } from '@/analytics';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions/transaction';
-import { IS_INTERNAL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { trimTrailingZeros, truncateToDecimals } from '@/framework/core/safeMath';
 import { formatCurrency } from '@/helpers/strings';
 import { abbreviateNumber, convertAmountToNativeDisplay, convertNumberToString } from '@/helpers/utilities';
@@ -37,7 +37,7 @@ import { type Link, type LinkType } from '../types';
 import { useSuperTokenStore } from './rainbowSuperTokenStore';
 
 // TODO: Remove this — temporary option for testing
-const REQUIRE_TOKEN_LOGO = !IS_INTERNAL;
+const REQUIRE_TOKEN_LOGO = IS_STORE_INSTALL;
 
 export const enum NavigationSteps {
   INFO = 0,


### PR DESCRIPTION
The current Sentry environment setup splits iOS and Android production into separate environments (`Release` and `ReleaseAndroid`). JS-level bugs affecting both platforms surface as two separate issues, alert rules have to be duplicated per environment, and there's no way to view "all production errors" in a single filter. Dev builds also report to a `LocalRelease` env that nobody triages, polluting the project with unactionable noise.

With our recent work to incrementally add intelligent detection of how app is installed (install info native module) it's now possible to do the proper sentry environment setup with dynamic detection from the app itself.

This change collapses the model into three environments aligned to deployment/release stage: 
* `production` (App Store and Google Play ONLY, i.e.real users/releases)
* `internal` (TestFlight, QA APKs), and 
* `development` (tophat builds and in the future local Sentry testing)

With this change Android QA APKs also now classify as `internal` and receive the same gated features as iOS TestFlight, giving Android QA feature parity.

The `IS_INTERNAL` export is also removed and replaced with `!IS_STORE_INSTALL` which is logically the same but reveals intent better. It's non clear what "internal" means otherwise and is confusing with the new `internal` sentry env which is something different - by removing it we sidestep this issue entirely.

Closes FEPLAT-62.