### PR TITLE
redesign: change gas estimates visuals on Send like on Swap

### DIFF
--- a/src/__swaps__/screens/Swap/components/GasButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GasButton.tsx
@@ -26,7 +26,7 @@ import { NavigationSteps, useSwapContext } from '../providers/swap-provider';
 import { EstimatedSwapGasFee, EstimatedSwapGasFeeSlot } from './EstimatedSwapGasFee';
 import { UnmountOnAnimatedReaction } from './UnmountOnAnimatedReaction';
 
-const { SWAP_GAS_ICONS } = gasUtils;
+const { GAS_ICONS } = gasUtils;
 const GAS_BUTTON_HIT_SLOP = 16;
 
 function UnmountWhenGasButtonIsNotInScreen({ placeholder, children }: PropsWithChildren<{ placeholder: ReactNode }>) {
@@ -72,17 +72,17 @@ function SelectedGas({ isPill, sponsored }: { isPill?: boolean; sponsored?: bool
     <Inline alignVertical="center" space={{ custom: 5 }}>
       <Inline alignVertical="center" space="4px">
         <TextIcon
-          color={sponsored && buyTokenColor ? { custom: buyTokenColor } : SWAP_GAS_ICONS[selectedGasSpeed].color}
+          color={sponsored && buyTokenColor ? { custom: buyTokenColor } : GAS_ICONS[selectedGasSpeed].color}
           height={10}
           size="icon 13px"
           textStyle={{ top: IS_ANDROID ? 1 : 0 + (selectedGasSpeed === 'fast' ? 0.5 : 0) }}
           width={isPill ? 14 : 18}
           weight={sponsored ? 'heavy' : 'bold'}
         >
-          {sponsored ? '􀁢' : SWAP_GAS_ICONS[selectedGasSpeed].icon}
+          {sponsored ? '􀁢' : GAS_ICONS[selectedGasSpeed].icon}
         </TextIcon>
         <Text align={isPill ? 'center' : 'left'} color={sponsored ? 'labelTertiary' : 'label'} size="15pt" weight="heavy">
-          {sponsored ? i18n.t(i18n.l.swap.gas.gas_sponsored) : i18n.t(i18n.l.gas.speeds[selectedGasSpeed])}
+          {sponsored ? i18n.t(i18n.l.gas.gas_sponsored) : i18n.t(i18n.l.gas.speeds[selectedGasSpeed])}
         </Text>
       </Inline>
       <TextIcon
@@ -178,7 +178,7 @@ const GasMenu = ({
         actionKey: gasOption,
         actionTitle: i18n.t(i18n.l.gas.speeds[gasOption]),
         discoverabilityTitle: subtitle,
-        icon: { iconType: 'SYSTEM', iconValue: SWAP_GAS_ICONS[gasOption].symbolName },
+        icon: { iconType: 'SYSTEM', iconValue: GAS_ICONS[gasOption].symbolName },
       };
     });
     return { menuItems, menuTitle: '' };

--- a/src/components/send/SendAssetFormCollectible.js
+++ b/src/components/send/SendAssetFormCollectible.js
@@ -10,7 +10,7 @@ import { padding, position } from '@/styles';
 
 import OpacityToggler from '../animations/OpacityToggler';
 import { UniqueTokenExpandedStateContent } from '../expanded-state/unique-token';
-import { Column } from '../layout';
+import { Column, Row } from '../layout';
 
 const defaultImageDimensions = { height: 512, width: 512 };
 
@@ -21,6 +21,17 @@ const ButtonWrapper = styled(Column).attrs({
   marginBottom: 21,
   width: '100%',
   ...(ios ? { zIndex: 3 } : { elevation: 3 }),
+});
+
+const FooterRow = styled(Row).attrs({
+  align: 'center',
+})({
+  columnGap: 14,
+  width: '100%',
+});
+
+const ButtonSlot = styled.View({
+  flex: 1,
 });
 
 const Footer = styled(Column).attrs({ justify: 'end' })({
@@ -107,8 +118,10 @@ export default function SendAssetFormCollectible({ asset, buttonRenderer, txSpee
       </NFTWrapper>
       <Footer>
         <ButtonWrapper isTallPhone={isTallPhone}>
-          {buttonRenderer}
-          {txSpeedRenderer}
+          <FooterRow>
+            {txSpeedRenderer}
+            <ButtonSlot>{buttonRenderer}</ButtonSlot>
+          </FooterRow>
         </ButtonWrapper>
         {!IS_ANDROID && (
           <GradientToggler isVisible={!isGradientVisible}>

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -9,15 +9,26 @@ import { useTheme } from '@/theme/ThemeContext';
 import { NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 import { removeLeadingZeros } from '@/utils/formatters';
 
-import { Column } from '../layout';
+import { Column, Row } from '../layout';
 import SendAssetFormField from './SendAssetFormField';
 
 const FooterContainer = styled(Column).attrs({
   justify: 'end',
-  marginBottom: NAVIGATION_BAR_HEIGHT,
+  marginBottom: IS_ANDROID ? NAVIGATION_BAR_HEIGHT + 16 : 0,
 })({
   width: '100%',
   zIndex: 3,
+});
+
+const FooterRow = styled(Row).attrs({
+  align: 'center',
+})({
+  columnGap: 14,
+  width: '100%',
+});
+
+const ButtonSlot = styled.View({
+  flex: 1,
 });
 
 const FormContainer = styled(Column).attrs({
@@ -88,8 +99,10 @@ export default function SendAssetFormToken({
         />
       </FormContainer>
       <FooterContainer>
-        {buttonRenderer}
-        {txSpeedRenderer}
+        <FooterRow>
+          {txSpeedRenderer}
+          <ButtonSlot>{buttonRenderer}</ButtonSlot>
+        </FooterRow>
       </FooterContainer>
     </Fragment>
   );

--- a/src/features/gas/components/GasSpeedButton.tsx
+++ b/src/features/gas/components/GasSpeedButton.tsx
@@ -10,12 +10,10 @@ import { Easing } from 'react-native-reanimated';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
-import { ContextMenu } from '@/components/context-menu';
 import { Centered, Column, Row } from '@/components/layout';
-import ContextMenuButton from '@/components/native-context-menu/contextMenu';
+import { type MenuConfig } from '@/components/native-context-menu/contextMenu';
 import { Text } from '@/components/text';
 import type { ParsedAddressAsset } from '@/entities/tokens';
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isL2Chain } from '@/handlers/web3';
@@ -36,8 +34,9 @@ import useGas from '../hooks/useGas';
 import { type GasSpeed } from '../types/gasSpeed';
 import gasUtils from '../utils/gas';
 import GasSpeedLabelPager from './GasSpeedLabelPager';
+import { GasSpeedMenu } from './GasSpeedMenu';
 
-const { GAS_EMOJIS, GAS_ICONS, GasSpeedOrder, CUSTOM, URGENT, NORMAL, FAST, getGasLabel } = gasUtils;
+const { GasSpeedOrder, GAS_ICONS, CUSTOM, NORMAL, getGasLabel } = gasUtils;
 
 type WithThemeProps = {
   borderColor: string;
@@ -46,6 +45,7 @@ type WithThemeProps = {
   marginBottom: number;
   marginTop: number;
   horizontalPadding: number;
+  inlineFeeDisplay?: boolean;
 };
 
 const CustomGasButton = styled(ButtonPressAnimation).attrs({
@@ -102,13 +102,14 @@ const NativeCoinIconWrapper = styled(Column).attrs({})({
 });
 
 const Container = styled(Column).attrs({
-  alignItems: 'center',
   hapticType: 'impactHeavy',
   justifyContent: 'center',
-})(({ marginBottom, marginTop, horizontalPadding }: WithThemeProps) => ({
+})(({ marginBottom, marginTop, horizontalPadding, inlineFeeDisplay }: WithThemeProps) => ({
+  alignItems: inlineFeeDisplay ? 'flex-start' : 'center',
   ...margin.object(marginTop, 0, marginBottom),
   ...padding.object(0, horizontalPadding),
-  width: '100%',
+  minWidth: inlineFeeDisplay ? 78 : undefined,
+  width: inlineFeeDisplay ? undefined : '100%',
 }));
 
 const Label = styled(Text).attrs(({ size }: { size: string }) => ({
@@ -143,6 +144,100 @@ const shouldRoundGasDisplay = (chainId: ChainId) => {
   }
 };
 
+type InlineGasControlProps = {
+  formatGasPrice: (animatedValue: string) => number | string;
+  gasIsNotReady: boolean;
+  gasOptionsAvailable: boolean;
+  menuConfig: MenuConfig;
+  onPressActionSheet: (buttonIndex: number) => void;
+  onPressMenuItem: (event: { nativeEvent: { actionKey: GasSpeed } }) => void;
+  price: string | null;
+  rawColorForAsset: string;
+  renderGasPriceText: (animatedNumber: number) => React.ReactNode;
+  selectedGasFeeOption: string;
+  showGasOptions: boolean;
+  speedOptions: string[];
+  theme: string;
+};
+
+const InlineGasControl = ({
+  formatGasPrice,
+  gasIsNotReady,
+  gasOptionsAvailable,
+  menuConfig,
+  onPressActionSheet,
+  onPressMenuItem,
+  price,
+  rawColorForAsset,
+  renderGasPriceText,
+  selectedGasFeeOption,
+  showGasOptions,
+  speedOptions,
+  theme,
+}: InlineGasControlProps) => {
+  const { colors } = useTheme();
+  const label = getGasLabel(selectedGasFeeOption);
+  const iconConfig = GAS_ICONS[selectedGasFeeOption];
+  const speedIcon = iconConfig?.icon;
+  const mutedColor = theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.6) : opacity(colors.blueGreyDark, 0.6);
+  const colorByTextColor: Record<string, string> = {
+    red: colors.red,
+    blue: colors.appleBlue,
+    yellow: colors.yellowFavorite,
+    labelSecondary: mutedColor,
+  };
+  const iconColorMap: Record<string, string> = Object.fromEntries(
+    Object.entries(GAS_ICONS).map(([speed, { color }]) => [speed, colorByTextColor[color] ?? mutedColor])
+  );
+  const speedIconColor = iconColorMap[selectedGasFeeOption] || mutedColor;
+  const content = (
+    <Column align="start">
+      <Row align="center">
+        {speedIcon && (
+          <Text color={speedIconColor} lineHeight="normal" size="lmedium" style={{ marginRight: 4 }} weight="heavy">
+            {speedIcon}
+          </Text>
+        )}
+        <Text
+          color={theme === 'dark' ? colors.whiteLabel : opacity(colors.blueGreyDark, 0.8)}
+          lineHeight="normal"
+          size="lmedium"
+          weight="heavy"
+        >
+          {label}
+        </Text>
+        {gasOptionsAvailable && !gasIsNotReady && (
+          <Text
+            align="center"
+            color={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.6) : opacity(colors.blueGreyDark, 0.45)}
+            lineHeight="normal"
+            size="smedium"
+            weight="bold"
+          >
+            {' 􀆏'}
+          </Text>
+        )}
+      </Row>
+      <Row align="center" style={{ marginTop: 6 }}>
+        <Text color={mutedColor} lineHeight="normal" size="smedium" style={{ marginRight: 4 }} weight="heavy">
+          􀵟
+        </Text>
+        <AnimateNumber formatter={formatGasPrice} interval={6} renderContent={renderGasPriceText} steps={6} timing="linear" value={price} />
+      </Row>
+    </Column>
+  );
+
+  if (showGasOptions || !gasOptionsAvailable || gasIsNotReady) return content;
+
+  return (
+    <GasSpeedMenu menuConfig={menuConfig} onPressActionSheet={onPressActionSheet} onPressMenuItem={onPressMenuItem} options={speedOptions}>
+      <ButtonPressAnimation scaleTo={0.9} testID="gas-speed-pager">
+        {content}
+      </ButtonPressAnimation>
+    </GasSpeedMenu>
+  );
+};
+
 type GasSpeedButtonProps = {
   asset?: Partial<ParsedAddressAsset>;
   chainId: ChainId;
@@ -157,6 +252,7 @@ type GasSpeedButtonProps = {
   showGasOptions?: boolean;
   validateGasParams?: React.RefObject<(callback?: () => void) => void>;
   loading?: boolean;
+  inlineFeeDisplay?: boolean;
 };
 
 const GasSpeedButton = ({
@@ -173,6 +269,7 @@ const GasSpeedButton = ({
   showGasOptions = false,
   validateGasParams = undefined,
   loading = false,
+  inlineFeeDisplay = false,
 }: GasSpeedButtonProps) => {
   const { colors } = useTheme();
   const { navigate, goBack } = useNavigation();
@@ -254,16 +351,22 @@ const GasSpeedButton = ({
       const priceText = animatedNumber === 0 || loading ? i18n.t(i18n.l.swap.loading) : animatedNumber;
       return (
         <Text
-          color={theme === 'dark' ? colors.whiteLabel : opacity(colors.blueGreyDark, 0.8)}
+          color={
+            inlineFeeDisplay
+              ? opacity(theme === 'dark' ? colors.whiteLabel : colors.blueGreyDark, 0.6)
+              : theme === 'dark'
+                ? colors.whiteLabel
+                : opacity(colors.blueGreyDark, 0.8)
+          }
           lineHeight="normal"
-          size="lmedium"
-          weight="heavy"
+          size={inlineFeeDisplay ? 'smedium' : 'lmedium'}
+          weight={inlineFeeDisplay ? 'bold' : 'heavy'}
         >
           {priceText}
         </Text>
       );
     },
-    [loading, theme, colors]
+    [colors, price, theme]
   );
 
   // I'M SHITTY CODE BUT GOT THINGS DONE REFACTOR ME ASAP
@@ -321,29 +424,18 @@ const GasSpeedButton = ({
     [handlePressSpeedOption]
   );
 
-  const handlePressActionSheet = useCallback(
-    (buttonIndex: number) => {
-      switch (buttonIndex) {
-        case 0:
-          handlePressSpeedOption(NORMAL);
-          break;
-        case 1:
-          handlePressSpeedOption(FAST);
-          break;
-        case 2:
-          handlePressSpeedOption(URGENT);
-          break;
-        case 3:
-          handlePressSpeedOption(CUSTOM);
-      }
-    },
-    [handlePressSpeedOption]
-  );
-
   const speedOptions = useMemo(() => {
     if (speeds) return speeds;
     return useBackendNetworksStore.getState().getChainsGasSpeeds()[chainId];
   }, [chainId, speeds]);
+
+  const handlePressActionSheet = useCallback(
+    (buttonIndex: number) => {
+      if (buttonIndex < 0) return;
+      handlePressSpeedOption(speedOptions[buttonIndex]);
+    },
+    [handlePressSpeedOption, speedOptions]
+  );
 
   const menuConfig = useMemo(() => {
     const menuOptions = speedOptions?.map(gasOption => {
@@ -361,11 +453,11 @@ const GasSpeedButton = ({
             : `${toFixedDecimals(estimatedGwei, isL2 ? 4 : 0)}–${toFixedDecimals(totalGwei, isL2 ? 4 : 0)} Gwei`;
       return {
         actionKey: gasOption,
-        actionTitle: (android ? `${GAS_EMOJIS[gasOption]}  ` : '') + getGasLabel(gasOption),
+        actionTitle: getGasLabel(gasOption),
         discoverabilityTitle: gweiDisplay,
         icon: {
-          iconType: 'ASSET',
-          iconValue: GAS_ICONS[gasOption],
+          iconType: 'SYSTEM',
+          iconValue: GAS_ICONS[gasOption]?.symbolName,
         },
       };
     });
@@ -402,35 +494,15 @@ const GasSpeedButton = ({
       />
     );
     if (!gasOptionsAvailable || gasIsNotReady) return pager;
-
-    if (IS_ANDROID) {
-      return (
-        <ContextMenu
-          activeOpacity={0}
-          enableContextMenu
-          isAnchoredToRight
-          isMenuPrimaryAction
-          onPressActionSheet={handlePressActionSheet}
-          options={speedOptions}
-          useActionSheetFallback={false}
-          wrapNativeComponent={false}
-        >
-          <Centered>{pager}</Centered>
-        </ContextMenu>
-      );
-    }
-
     return (
-      <ContextMenuButton
-        enableContextMenu
-        isAnchoredToRight
-        isMenuPrimaryAction
+      <GasSpeedMenu
         menuConfig={menuConfig}
+        onPressActionSheet={handlePressActionSheet}
         onPressMenuItem={handlePressMenuItem}
-        useActionSheetFallback={false}
+        options={speedOptions}
       >
         {pager}
-      </ContextMenuButton>
+      </GasSpeedMenu>
     );
   }, [
     colors,
@@ -439,10 +511,10 @@ const GasSpeedButton = ({
     handlePressActionSheet,
     handlePressMenuItem,
     menuConfig,
-    speedOptions,
     rawColorForAsset,
     selectedGasFeeOption,
     showGasOptions,
+    speedOptions,
     theme,
   ]);
 
@@ -467,96 +539,120 @@ const GasSpeedButton = ({
   }, [openCustomGasSheet, prevShouldOpenCustomGasSheet, shouldOpenCustomGasSheet.shouldOpen]);
 
   return (
-    <Container horizontalPadding={horizontalPadding} marginBottom={marginBottom} marginTop={marginTop} testID={testID}>
-      <Row justify="space-between">
-        <ButtonPressAnimation onPress={openGasHelper} scaleTo={0.9} testID="estimated-fee-label" disallowInterruption={false}>
-          <Row>
-            <NativeCoinIconWrapper>
-              <AnimatePresence>
-                {!!chainId && (
-                  <MotiView
-                    animate={{ opacity: 1 }}
-                    from={{ opacity: 0 }}
-                    // @ts-expect-error - MotiTransitionProp is not assignable to TransitionConfig
-                    transition={{
-                      duration: 300,
-                      easing: Easing.bezier(0.2, 0, 0, 1),
-                      type: 'timing',
-                    }}
-                  >
-                    <ChainImage chainId={chainId} position="relative" size={16} />
-                  </MotiView>
-                )}
-              </AnimatePresence>
-            </NativeCoinIconWrapper>
-            <TextContainer>
-              <Text>
-                <AnimateNumber
-                  formatter={formatGasPrice}
-                  interval={6}
-                  renderContent={renderGasPriceText}
-                  steps={6}
-                  timing="linear"
-                  value={price}
-                />
-                <Text letterSpacing="one" size="lmedium" weight="heavy">
-                  {' '}
+    <Container
+      horizontalPadding={horizontalPadding}
+      inlineFeeDisplay={inlineFeeDisplay}
+      marginBottom={marginBottom}
+      marginTop={marginTop}
+      testID={testID}
+    >
+      {inlineFeeDisplay ? (
+        <InlineGasControl
+          formatGasPrice={formatGasPrice}
+          gasIsNotReady={gasIsNotReady}
+          gasOptionsAvailable={gasOptionsAvailable}
+          menuConfig={menuConfig}
+          onPressActionSheet={handlePressActionSheet}
+          onPressMenuItem={handlePressMenuItem}
+          price={price}
+          rawColorForAsset={rawColorForAsset}
+          renderGasPriceText={renderGasPriceText}
+          selectedGasFeeOption={selectedGasFeeOption}
+          showGasOptions={showGasOptions}
+          speedOptions={speedOptions}
+          theme={theme}
+        />
+      ) : (
+        <Row justify="space-between">
+          <ButtonPressAnimation onPress={openGasHelper} scaleTo={0.9} testID="estimated-fee-label" disallowInterruption={false}>
+            <Row>
+              <NativeCoinIconWrapper>
+                <AnimatePresence>
+                  {!!chainId && (
+                    <MotiView
+                      animate={{ opacity: 1 }}
+                      from={{ opacity: 0 }}
+                      // @ts-expect-error - MotiTransitionProp is not assignable to TransitionConfig
+                      transition={{
+                        duration: 300,
+                        easing: Easing.bezier(0.2, 0, 0, 1),
+                        type: 'timing',
+                      }}
+                    >
+                      <ChainImage chainId={chainId} position="relative" size={16} />
+                    </MotiView>
+                  )}
+                </AnimatePresence>
+              </NativeCoinIconWrapper>
+              <TextContainer>
+                <Text>
+                  <AnimateNumber
+                    formatter={formatGasPrice}
+                    interval={6}
+                    renderContent={renderGasPriceText}
+                    steps={6}
+                    timing="linear"
+                    value={price}
+                  />
+                  <Text letterSpacing="one" size="lmedium" weight="heavy">
+                    {' '}
+                  </Text>
+                  <TransactionTimeLabel formatter={formatTransactionTime} theme={theme} />
                 </Text>
-                <TransactionTimeLabel formatter={formatTransactionTime} theme={theme} />
-              </Text>
-            </TextContainer>
-          </Row>
-          <Row justify="space-between">
-            <Label
-              color={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.6) : opacity(colors.blueGreyDark, 0.6)}
-              size="smedium"
-              weight="bold"
-            >
-              {i18n.t(i18n.l.swap.gas.estimated_fee)}{' '}
+              </TextContainer>
+            </Row>
+            <Row justify="space-between">
               <Label
-                color={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.25) : opacity(colors.blueGreyDark, 0.25)}
+                color={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.6) : opacity(colors.blueGreyDark, 0.6)}
                 size="smedium"
                 weight="bold"
               >
-                􀅵
-              </Label>
-            </Label>
-          </Row>
-        </ButtonPressAnimation>
-        <Centered>
-          <GasSpeedPagerCentered testID="gas-speed-pager">{renderGasSpeedPager}</GasSpeedPagerCentered>
-
-          <Centered>
-            {isLegacyGasNetwork ? (
-              <ChainBadgeContainer>
-                <ChainImage chainId={chainId} position="relative" size={16} />
-              </ChainBadgeContainer>
-            ) : showGasOptions ? (
-              <CustomGasButton
-                borderColor={makeColorMoreChill(rawColorForAsset || colors.appleBlue, colors.shadowBlack)}
-                onPress={onDonePress}
-                testID="gas-speed-done-button"
-              >
-                <DoneCustomGas
-                  color={
-                    theme !== 'light' ? colors.whiteLabel : makeColorMoreChill(rawColorForAsset || colors.appleBlue, colors.shadowBlack)
-                  }
+                {i18n.t(i18n.l.gas.estimated_fee)}{' '}
+                <Label
+                  color={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.25) : opacity(colors.blueGreyDark, 0.25)}
+                  size="smedium"
+                  weight="bold"
                 >
-                  {i18n.t(i18n.l.button.done)}
-                </DoneCustomGas>
-              </CustomGasButton>
-            ) : (
-              <CustomGasButton
-                borderColor={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.12) : opacity(colors.blueGreyDark, 0.06)}
-                onPress={openCustomOptions}
-                testID="gas-speed-custom"
-              >
-                <Symbol color={theme === 'dark' ? colors.whiteLabel : opacity(colors.blueGreyDark, 0.8)}>􀌆</Symbol>
-              </CustomGasButton>
-            )}
+                  􀅵
+                </Label>
+              </Label>
+            </Row>
+          </ButtonPressAnimation>
+          <Centered>
+            <GasSpeedPagerCentered testID="gas-speed-pager">{renderGasSpeedPager}</GasSpeedPagerCentered>
+
+            <Centered>
+              {isLegacyGasNetwork ? (
+                <ChainBadgeContainer>
+                  <ChainImage chainId={chainId} position="relative" size={16} />
+                </ChainBadgeContainer>
+              ) : showGasOptions ? (
+                <CustomGasButton
+                  borderColor={makeColorMoreChill(rawColorForAsset || colors.appleBlue, colors.shadowBlack)}
+                  onPress={onDonePress}
+                  testID="gas-speed-done-button"
+                >
+                  <DoneCustomGas
+                    color={
+                      theme !== 'light' ? colors.whiteLabel : makeColorMoreChill(rawColorForAsset || colors.appleBlue, colors.shadowBlack)
+                    }
+                  >
+                    {i18n.t(i18n.l.button.done)}
+                  </DoneCustomGas>
+                </CustomGasButton>
+              ) : (
+                <CustomGasButton
+                  borderColor={theme === 'dark' ? opacity(darkModeThemeColors.blueGreyDark, 0.12) : opacity(colors.blueGreyDark, 0.06)}
+                  onPress={openCustomOptions}
+                  testID="gas-speed-custom"
+                >
+                  <Symbol color={theme === 'dark' ? colors.whiteLabel : opacity(colors.blueGreyDark, 0.8)}>􀌆</Symbol>
+                </CustomGasButton>
+              )}
+            </Centered>
           </Centered>
-        </Centered>
-      </Row>
+        </Row>
+      )}
     </Container>
   );
 };

--- a/src/features/gas/utils/gas.ts
+++ b/src/features/gas/utils/gas.ts
@@ -1,6 +1,5 @@
 import { type TextColor } from '@/design-system/color/palettes';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_IOS } from '@/env';
 import { convertAmountToNativeDisplay } from '@/helpers/utilities';
 import * as i18n from '@/languages';
 import { colors } from '@/styles';
@@ -20,20 +19,11 @@ const NO_TREND = 'notrend';
 const GasSpeedOrder = [NORMAL, FAST, URGENT, CUSTOM];
 const GasTrends = { FALLING, NO_TREND, RISING, STABLE, SURGING };
 
-const GAS_ICONS: {
-  [key in (typeof GasSpeedOrder)[number]]: string;
-} = {
-  [CUSTOM]: 'gear',
-  [FAST]: 'rocket',
-  [NORMAL]: 'stopwatch',
-  [URGENT]: 'policeCarLight',
-};
-
-interface SwapGasIcons {
+interface GasIcons {
   [key: string]: { color: TextColor; icon: string; symbolName: string };
 }
 
-const SWAP_GAS_ICONS: SwapGasIcons = {
+const GAS_ICONS: GasIcons = {
   [CUSTOM]: {
     color: 'labelSecondary',
     icon: '􀣌',
@@ -54,15 +44,6 @@ const SWAP_GAS_ICONS: SwapGasIcons = {
     icon: '􀋦',
     symbolName: 'bolt',
   },
-};
-
-const GAS_EMOJIS: {
-  [key in (typeof GasSpeedOrder)[number]]: string;
-} = {
-  [CUSTOM]: '⚙️',
-  [FAST]: '🚀',
-  [NORMAL]: IS_IOS ? '⏱' : '🕘',
-  [URGENT]: '🚨',
 };
 
 // i18n
@@ -111,13 +92,11 @@ export default {
   FAST,
   getGasLabel,
   getGasFallback,
-  GAS_EMOJIS,
   GAS_ICONS,
   GAS_TRENDS,
   GasSpeedOrder,
   GasTrends,
   NORMAL,
   SLOW,
-  SWAP_GAS_ICONS,
   URGENT,
 };

--- a/src/languages/ar_AR.json
+++ b/src/languages/ar_AR.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "التلميح المعدني مرتفع!",
       "proceed_anyway": "المتابعة على أي حال",
       "edit_max_bass_fee": "تعديل الرسوم الأساسية القصوى",
-      "edit_miner_tip": "تعديل تلميح المعدن"
+      "edit_miner_tip": "تعديل تلميح المعدن",
+      "gas_sponsored": "مجانا",
+      "estimated_fee": "الرسوم المقدرة"
     },
     "homepage": {
       "back": "العودة إلى rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "مخصص",
         "edit_price": "تعديل سعر الغاز",
         "enter_price": "أدخل سعر الغاز",
-        "estimated_fee": "الرسوم المقدرة",
         "fast": "سريع",
         "network_fee": "رسوم الشبكة",
         "normal": "عادي",
-        "slow": "بطيء",
-        "gas_sponsored": "مجانا"
+        "slow": "بطيء"
       },
       "loading": "جار التحميل...",
       "modal_types": {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1229,7 +1229,9 @@
       "alert_title_lower_miner_tip_needed": "High miner tip!",
       "proceed_anyway": "Proceed Anyway",
       "edit_max_bass_fee": "Edit Max Base Fee",
-      "edit_miner_tip": "Edit Miner Tip"
+      "edit_miner_tip": "Edit Miner Tip",
+      "gas_sponsored": "Free",
+      "estimated_fee": "Estimated fee"
     },
     "homepage": {
       "discover_web3": "Discover Web3"
@@ -2142,12 +2144,10 @@
       "gas": {
         "edit_price": "Edit Gas Price",
         "enter_price": "Enter Gas Price",
-        "estimated_fee": "Estimated fee",
         "fast": "Fast",
         "network_fee": "Network Fee",
         "normal": "Normal",
         "slow": "Slow",
-        "gas_sponsored": "Free",
         "loading": "Loading…"
       },
       "loading": "Loading...",

--- a/src/languages/es_419.json
+++ b/src/languages/es_419.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "¡Propina de minero alta!",
       "proceed_anyway": "Continuar de todas formas",
       "edit_max_bass_fee": "Editar límite base máximo",
-      "edit_miner_tip": "Editar propina de minero"
+      "edit_miner_tip": "Editar propina de minero",
+      "gas_sponsored": "Gratis",
+      "estimated_fee": "Tarifa Estimada"
     },
     "homepage": {
       "back": "Volver a rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "Personalizado",
         "edit_price": "Editar Precio del Gas",
         "enter_price": "Ingresar Precio del Gas",
-        "estimated_fee": "Tarifa Estimada",
         "fast": "Rápido",
         "network_fee": "Tarifa de Red",
         "normal": "Normal",
-        "slow": "Lento",
-        "gas_sponsored": "Gratis"
+        "slow": "Lento"
       },
       "loading": "Cargando...",
       "modal_types": {

--- a/src/languages/fr_FR.json
+++ b/src/languages/fr_FR.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "Élevé pourboire aux mineurs !",
       "proceed_anyway": "Continuer quand même",
       "edit_max_bass_fee": "Modifier Max Base Fee",
-      "edit_miner_tip": "Modifier le pourboire aux mineurs"
+      "edit_miner_tip": "Modifier le pourboire aux mineurs",
+      "gas_sponsored": "Gratuit",
+      "estimated_fee": "Frais estimé"
     },
     "homepage": {
       "back": "Retour à rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "Personnalisé",
         "edit_price": "Modifier le Prix de l'Essence",
         "enter_price": "Entrez le Prix de l'Essence",
-        "estimated_fee": "Frais estimé",
         "fast": "Rapide",
         "network_fee": "Frais de réseau",
         "normal": "Normal",
-        "slow": "Lent",
-        "gas_sponsored": "Gratuit"
+        "slow": "Lent"
       },
       "loading": "Chargement...",
       "modal_types": {

--- a/src/languages/hi_IN.json
+++ b/src/languages/hi_IN.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "उच्च खननकर्ता टिप!",
       "proceed_anyway": "फिर भी आगे बढ़ें",
       "edit_max_bass_fee": "अधिकतम आधार शुल्क संपादित करें",
-      "edit_miner_tip": "खननकर्ता टिप संपादित करें"
+      "edit_miner_tip": "खननकर्ता टिप संपादित करें",
+      "gas_sponsored": "मुफ्त",
+      "estimated_fee": "अनुमानित शुल्क"
     },
     "homepage": {
       "back": "rainbow.me की ओर वापस जाएं",
@@ -2410,12 +2412,10 @@
         "custom": "कस्टम",
         "edit_price": "गैस मूल्य संपादित करें",
         "enter_price": "गैस मूल्य दर्ज करें",
-        "estimated_fee": "अनुमानित शुल्क",
         "fast": "तेज",
         "network_fee": "नेटवर्क शुल्क",
         "normal": "साधारण",
-        "slow": "धीमा",
-        "gas_sponsored": "मुफ्त"
+        "slow": "धीमा"
       },
       "loading": "लोड हो रहा है...",
       "modal_types": {

--- a/src/languages/id_ID.json
+++ b/src/languages/id_ID.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "Miner tip tinggi!",
       "proceed_anyway": "Lanjutkan Saja",
       "edit_max_bass_fee": "Edit Max Base Fee",
-      "edit_miner_tip": "Edit Miner Tip"
+      "edit_miner_tip": "Edit Miner Tip",
+      "gas_sponsored": "Gratis",
+      "estimated_fee": "Perkiraan biaya"
     },
     "homepage": {
       "back": "Kembali ke rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "Kustom",
         "edit_price": "Edit Harga Gas",
         "enter_price": "Masukkan Harga Gas",
-        "estimated_fee": "Perkiraan biaya",
         "fast": "Cepat",
         "network_fee": "Biaya Jaringan",
         "normal": "Normal",
-        "slow": "Lambat",
-        "gas_sponsored": "Gratis"
+        "slow": "Lambat"
       },
       "loading": "Memuat...",
       "modal_types": {

--- a/src/languages/ja_JP.json
+++ b/src/languages/ja_JP.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "大きなマイナーチップです!",
       "proceed_anyway": "続ける",
       "edit_max_bass_fee": "最大基本料金を編集",
-      "edit_miner_tip": "マイナーチップを編集"
+      "edit_miner_tip": "マイナーチップを編集",
+      "gas_sponsored": "無料",
+      "estimated_fee": "推定手数料"
     },
     "homepage": {
       "back": "rainbow.meに戻る",
@@ -2410,12 +2412,10 @@
         "custom": "カスタム",
         "edit_price": "ガス価格を編集",
         "enter_price": "ガス価格を入力してください",
-        "estimated_fee": "推定手数料",
         "fast": "高速",
         "network_fee": "ネットワーク手数料",
         "normal": "通常",
-        "slow": "低速",
-        "gas_sponsored": "無料"
+        "slow": "低速"
       },
       "loading": "読み込み中...",
       "modal_types": {

--- a/src/languages/ko_KR.json
+++ b/src/languages/ko_KR.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "마이너 팁이 높습니다!",
       "proceed_anyway": "그래도 진행",
       "edit_max_bass_fee": "최대 기본 수수료 편집",
-      "edit_miner_tip": "마이너 팁 편집"
+      "edit_miner_tip": "마이너 팁 편집",
+      "gas_sponsored": "무료",
+      "estimated_fee": "예상 수수료"
     },
     "homepage": {
       "back": "rainbow.me로 돌아가기",
@@ -2410,12 +2412,10 @@
         "custom": "사용자 정의",
         "edit_price": "가스 가격 수정",
         "enter_price": "가스 가격 입력",
-        "estimated_fee": "예상 수수료",
         "fast": "빠름",
         "network_fee": "네트워크 수수료",
         "normal": "보통",
-        "slow": "느림",
-        "gas_sponsored": "무료"
+        "slow": "느림"
       },
       "loading": "로딩 중...",
       "modal_types": {

--- a/src/languages/pt_BR.json
+++ b/src/languages/pt_BR.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "Gorjeta do minerador alta!",
       "proceed_anyway": "Continuar mesmo assim",
       "edit_max_bass_fee": "Editar Taxa Máxima de Base",
-      "edit_miner_tip": "Editar Gorjeta do Minerador"
+      "edit_miner_tip": "Editar Gorjeta do Minerador",
+      "gas_sponsored": "Grátis",
+      "estimated_fee": "Taxa Estimada"
     },
     "homepage": {
       "back": "Voltar para rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "Personalizado",
         "edit_price": "Editar Preço do Gás",
         "enter_price": "Digite o Preço do Gás",
-        "estimated_fee": "Taxa Estimada",
         "fast": "Rápido",
         "network_fee": "Taxa da Rede",
         "normal": "Normal",
-        "slow": "Lento",
-        "gas_sponsored": "Grátis"
+        "slow": "Lento"
       },
       "loading": "Carregando...",
       "modal_types": {

--- a/src/languages/ru_RU.json
+++ b/src/languages/ru_RU.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "Высокие вознаграждения майнерам!",
       "proceed_anyway": "Продолжить",
       "edit_max_bass_fee": "Изменить максимальное основное вознаграждение",
-      "edit_miner_tip": "Изменить вознаграждение майнерам"
+      "edit_miner_tip": "Изменить вознаграждение майнерам",
+      "gas_sponsored": "Бесплатно",
+      "estimated_fee": "Примерная комиссия"
     },
     "homepage": {
       "back": "Вернуться на rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "Пользовательский",
         "edit_price": "Изменить цену газа",
         "enter_price": "Введите цену газа",
-        "estimated_fee": "Примерная комиссия",
         "fast": "Быстро",
         "network_fee": "Сетевая комиссия",
         "normal": "Обычный",
-        "slow": "Медленно",
-        "gas_sponsored": "Бесплатно"
+        "slow": "Медленно"
       },
       "loading": "Загрузка...",
       "modal_types": {

--- a/src/languages/th_TH.json
+++ b/src/languages/th_TH.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "เคล็ดคุณภาพขุดเหมืองสูง!",
       "proceed_anyway": "ดำเนินการต่อ",
       "edit_max_bass_fee": "แก้ไขฐานค่าธรรมเนียมสูงสุด",
-      "edit_miner_tip": "แก้ไขเคล็ดคุณภาพขุดเหมือง"
+      "edit_miner_tip": "แก้ไขเคล็ดคุณภาพขุดเหมือง",
+      "gas_sponsored": "ฟรี",
+      "estimated_fee": "ค่าธรรมเนียมที่คาดว่าจะได้"
     },
     "homepage": {
       "back": "กลับไปที่ rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "กำหนดเอง",
         "edit_price": "แก้ไขราคาแก๊ส",
         "enter_price": "กรอกราคาแก๊ส",
-        "estimated_fee": "ค่าธรรมเนียมที่คาดว่าจะได้",
         "fast": "รวดเร็ว",
         "network_fee": "ค่าธรรมเนียมเครือข่าย",
         "normal": "ปกติ",
-        "slow": "ช้า",
-        "gas_sponsored": "ฟรี"
+        "slow": "ช้า"
       },
       "loading": "กำลังโหลด...",
       "modal_types": {

--- a/src/languages/tr_TR.json
+++ b/src/languages/tr_TR.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "Yüksek madenci bahşişi!",
       "proceed_anyway": "Yine de Devam Et",
       "edit_max_bass_fee": "Max Taban Ücretini Düzenle",
-      "edit_miner_tip": "Madenci Bahşişini Düzenle"
+      "edit_miner_tip": "Madenci Bahşişini Düzenle",
+      "gas_sponsored": "Ücretsiz",
+      "estimated_fee": "Tahmini ücret"
     },
     "homepage": {
       "back": "Rainbow.me'ye geri dön",
@@ -2410,12 +2412,10 @@
         "custom": "Özel",
         "edit_price": "Gaz Fiyatını Düzenle",
         "enter_price": "Gaz Fiyatını Girin",
-        "estimated_fee": "Tahmini ücret",
         "fast": "Hızlı",
         "network_fee": "Ağ Ücreti",
         "normal": "Normal",
-        "slow": "Yavaş",
-        "gas_sponsored": "Ücretsiz"
+        "slow": "Yavaş"
       },
       "loading": "Yükleniyor...",
       "modal_types": {

--- a/src/languages/zh_CN.json
+++ b/src/languages/zh_CN.json
@@ -1296,7 +1296,9 @@
       "alert_title_lower_miner_tip_needed": "矿工小费高！",
       "proceed_anyway": "无论如何进行",
       "edit_max_bass_fee": "编辑最大基础费用",
-      "edit_miner_tip": "编辑矿工小费"
+      "edit_miner_tip": "编辑矿工小费",
+      "gas_sponsored": "免费",
+      "estimated_fee": "预计费用"
     },
     "homepage": {
       "back": "返回rainbow.me",
@@ -2410,12 +2412,10 @@
         "custom": "自定义",
         "edit_price": "编辑气价",
         "enter_price": "输入气价",
-        "estimated_fee": "预计费用",
         "fast": "快速",
         "network_fee": "网络费用",
         "normal": "正常",
-        "slow": "慢速",
-        "gas_sponsored": "免费"
+        "slow": "慢速"
       },
       "loading": "载入中...",
       "modal_types": {

--- a/src/screens/SendSheet.tsx
+++ b/src/screens/SendSheet.tsx
@@ -1042,6 +1042,7 @@ export default function SendSheet() {
                 onPress={showConfirmationSheet}
                 scaleTo={buttonDisabled ? 1.025 : 0.9}
                 size="big"
+                style={{ width: '100%' }}
                 testID="send-sheet-confirm"
                 weight="heavy"
               />
@@ -1062,7 +1063,9 @@ export default function SendSheet() {
                 fallbackColor={colorForAsset}
                 chainId={currentChainId}
                 horizontalPadding={0}
-                marginBottom={17}
+                inlineFeeDisplay
+                marginBottom={0}
+                marginTop={0}
                 theme={isDarkMode ? 'dark' : 'light'}
               />
             }

--- a/src/systems/funding/components/deposit/gas/GasMenu.tsx
+++ b/src/systems/funding/components/deposit/gas/GasMenu.tsx
@@ -15,7 +15,7 @@ import * as i18n from '@/languages';
 import { useDepositContext } from '@/systems/funding/contexts/DepositContext';
 
 const GAS_BUTTON_HIT_SLOP = 16;
-const SWAP_GAS_ICONS = gasUtils.SWAP_GAS_ICONS;
+const GAS_ICONS = gasUtils.GAS_ICONS;
 
 export function GasMenu({ children, onSelectGasSpeed }: { children: ReactNode; onSelectGasSpeed: (speed: GasSpeed) => void }) {
   const { gasStores } = useDepositContext();
@@ -53,7 +53,7 @@ export function GasMenu({ children, onSelectGasSpeed }: { children: ReactNode; o
         actionKey: gasOption,
         actionTitle: i18n.t(i18n.l.gas.speeds[gasOption]),
         discoverabilityTitle: subtitle,
-        icon: { iconType: 'SYSTEM', iconValue: SWAP_GAS_ICONS[gasOption].symbolName },
+        icon: { iconType: 'SYSTEM', iconValue: GAS_ICONS[gasOption].symbolName },
       };
     });
     return { menuItems, menuTitle: '' };

--- a/src/systems/funding/components/deposit/gas/SelectedGasSpeed.tsx
+++ b/src/systems/funding/components/deposit/gas/SelectedGasSpeed.tsx
@@ -6,7 +6,7 @@ import gasUtils from '@/features/gas/utils/gas';
 import * as i18n from '@/languages';
 import { useDepositContext } from '@/systems/funding/contexts/DepositContext';
 
-const SWAP_GAS_ICONS = gasUtils.SWAP_GAS_ICONS;
+const GAS_ICONS = gasUtils.GAS_ICONS;
 
 export const SelectedGasSpeed = memo(function SelectedGasSpeed({ isPill }: { isPill?: boolean }) {
   const { gasStores, useDepositStore } = useDepositContext();
@@ -17,14 +17,14 @@ export const SelectedGasSpeed = memo(function SelectedGasSpeed({ isPill }: { isP
     <Inline alignVertical="center" space={{ custom: 5 }}>
       <Inline alignVertical="center" space="4px">
         <TextIcon
-          color={SWAP_GAS_ICONS[selectedGasSpeed].color}
+          color={GAS_ICONS[selectedGasSpeed].color}
           height={10}
           size="icon 13px"
           textStyle={{ top: IS_ANDROID ? 1 : 0 + (selectedGasSpeed === 'fast' ? 0.5 : 0) }}
           width={isPill ? 14 : 18}
           weight="bold"
         >
-          {SWAP_GAS_ICONS[selectedGasSpeed].icon}
+          {GAS_ICONS[selectedGasSpeed].icon}
         </TextIcon>
         <Text align={isPill ? 'center' : 'left'} color="label" size="15pt" weight="heavy">
           {i18n.t(i18n.l.gas.speeds[selectedGasSpeed])}


### PR DESCRIPTION
## Why?

First step toward sponsorless sends. To prepare for showing a "Free" gas state on the send screen analogous to swaps, the send screen's gas estimate UI is realigned with the swap design — same speed icons, same gasoline icon next to the price, same inline placement next to the action button. No sponsored behaviour is wired up here; this PR is visual only so the design lands cleanly before sponsored logic stacks on top.

Slack context: https://rainbowhaus.slack.com/archives/C0AA8FSGK4L/p1777989239972549

## What changed

- **`GasSpeedButton`** gains an `inlineFeeDisplay` prop. When set, it renders the new compact two-row layout (speed icon + label on top, gasoline icon + estimated fee underneath) used by `SendSheet`. The legacy centered layout is unchanged for all other callers.
- **`SendSheet`** **footer** is restructured: the gas control now sits to the left of the confirm button in a single row (`SendAssetFormToken` / `SendAssetFormCollectible`), matching the swap screen.
- **Gas icon set is consolidated.** The old emoji-based `GAS_ICONS` and the swap-only `SWAP_GAS_ICONS` are merged into a single `GAS_ICONS` map (color + SF symbol + system symbolName). `GAS_EMOJIS` is removed — nothing referenced it after this. Swap's `GasButton` and the funding deposit gas components are updated to the unified map.
- **i18n keys moved.** `gas_sponsored` and `estimated_fee` move from `swap.gas.*` to the top-level `gas.*` namespace since they're now shared between Send and Swap. 

## Visuals

| Before | After |
| --- | --- |
| iOS<br>[before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d76e0f68-5630-424f-9592-7e4c40a05a73.mov" />](https://app.graphite.com/user-attachments/video/d76e0f68-5630-424f-9592-7e4c40a05a73.mov) | iOS<br>[after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f6b43431-7e25-450a-92d5-528d12c81b11.mov" />](https://app.graphite.com/user-attachments/video/f6b43431-7e25-450a-92d5-528d12c81b11.mov) |
| Android<br>[before.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e3cd427d-c66e-4d4c-9734-4e7e962207cc.webm" />](https://app.graphite.com/user-attachments/video/e3cd427d-c66e-4d4c-9734-4e7e962207cc.webm) | Android<br>[after.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/37453e14-bf81-41c6-aaff-b357cdecb24b.webm" />](https://app.graphite.com/user-attachments/video/37453e14-bf81-41c6-aaff-b357cdecb24b.webm) |

