### PR TITLE
refactor: move gas speed menu as a shared component

### DIFF
--- a/src/__swaps__/screens/Swap/components/GasButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GasButton.tsx
@@ -6,12 +6,10 @@ import Animated, { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
-import { ContextMenu } from '@/components/context-menu';
-import { Centered } from '@/components/layout';
-import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Box, Inline, Text, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
 import { IS_ANDROID } from '@/env';
 import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
+import { GasSpeedMenu } from '@/features/gas/components/GasSpeedMenu';
 import { useCustomGasSettings, type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { setSelectedGasSpeed, useSelectedGasSpeed } from '@/features/gas/hooks/useSelectedGas';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
@@ -195,34 +193,20 @@ const GasMenu = ({
       style={{ margin: IS_ANDROID ? 0 : -GAS_BUTTON_HIT_SLOP, pointerEvents: disabled ? 'none' : 'auto' }}
       testID="gas-speed-pager"
     >
-      {IS_ANDROID ? (
-        <ContextMenu
-          activeOpacity={0}
-          enableContextMenu
-          isAnchoredToRight
-          isMenuPrimaryAction
-          onPressActionSheet={handlePressActionSheet}
-          options={menuOptions}
-          useActionSheetFallback={false}
-          wrapNativeComponent={false}
+      <GasSpeedMenu
+        menuConfig={menuConfig}
+        onPressActionSheet={handlePressActionSheet}
+        onPressMenuItem={handlePressMenuItem}
+        options={menuOptions}
+      >
+        <ButtonPressAnimation
+          scaleTo={0.825}
+          style={IS_ANDROID ? undefined : { padding: GAS_BUTTON_HIT_SLOP }}
+          testID={IS_ANDROID ? undefined : 'gas-speed-pager-button'}
         >
-          <Centered>
-            <ButtonPressAnimation scaleTo={0.825}>{children}</ButtonPressAnimation>
-          </Centered>
-        </ContextMenu>
-      ) : (
-        <ContextMenuButton
-          enableContextMenu
-          isMenuPrimaryAction
-          menuConfig={menuConfig}
-          onPressMenuItem={handlePressMenuItem}
-          useActionSheetFallback={false}
-        >
-          <ButtonPressAnimation scaleTo={0.825} style={{ padding: GAS_BUTTON_HIT_SLOP }} testID="gas-speed-pager-button">
-            {children}
-          </ButtonPressAnimation>
-        </ContextMenuButton>
-      )}
+          {children}
+        </ButtonPressAnimation>
+      </GasSpeedMenu>
     </Box>
   );
 };

--- a/src/features/gas/components/GasSpeedMenu.tsx
+++ b/src/features/gas/components/GasSpeedMenu.tsx
@@ -1,0 +1,44 @@
+import React, { type ReactNode } from 'react';
+
+import { ContextMenu } from '@/components/context-menu';
+import { Centered } from '@/components/layout';
+import ContextMenuButton, { type MenuConfig } from '@/components/native-context-menu/contextMenu';
+import { IS_ANDROID } from '@/env';
+
+type GasSpeedMenuProps = {
+  children: ReactNode;
+  menuConfig: MenuConfig;
+  onPressActionSheet: (buttonIndex: number) => void;
+  onPressMenuItem: (event: { nativeEvent: { actionKey: any } }) => void;
+  options: string[];
+};
+
+export const GasSpeedMenu = ({ children, menuConfig, onPressActionSheet, onPressMenuItem, options }: GasSpeedMenuProps) => {
+  if (IS_ANDROID) {
+    return (
+      <ContextMenu
+        activeOpacity={0}
+        enableContextMenu
+        isAnchoredToRight
+        isMenuPrimaryAction
+        onPressActionSheet={onPressActionSheet}
+        options={options}
+        useActionSheetFallback={false}
+        wrapNativeComponent={false}
+      >
+        <Centered>{children}</Centered>
+      </ContextMenu>
+    );
+  }
+  return (
+    <ContextMenuButton
+      enableContextMenu
+      isMenuPrimaryAction
+      menuConfig={menuConfig}
+      onPressMenuItem={onPressMenuItem}
+      useActionSheetFallback={false}
+    >
+      {children}
+    </ContextMenuButton>
+  );
+};


### PR DESCRIPTION
## Description

The swap-side `GasMenu` and the send-side `GasSpeedButton` both duplicate the same iOS `ContextMenuButton` / Android `ContextMenu` wrapping around the gas-speed picker. Extract it into a shared `GasSpeedMenu` component so future changes only need to be made in one place.

The PR is purely structural — same props pass through to the underlying menu components, no UI or behavior change for the swap path.