### PR TITLE
Bump versionCode on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 - Bump iOS and Android to v2.0.31 (https://github.com/rainbow-me/rainbow/pull/7413)
 - Bump @shopify/flash-list from 1.8.2 to 1.8.3 (https://github.com/rainbow-me/rainbow/pull/7396)
+- Remove claimUserRewards mutation (https://github.com/rainbow-me/rainbow/commit/daf838b4927f8ac4b500c1f9138e8cac12491809)
 
 ### Fixed
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -159,7 +159,7 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 308
+        versionCode 309
         versionName "2.0.32"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23


### PR DESCRIPTION
Bump versionCode on Android from latest android release (currently set to 308), and update changelog with latest cherry pick for that release