### PR TITLE
chore: fix error logging for token launcher airdrop fetching

### DIFF
--- a/src/state/claimables/airdropsStore.ts
+++ b/src/state/claimables/airdropsStore.ts
@@ -266,7 +266,7 @@ async function fetchAirdrops(
 
   if (data.metadata.status !== 'ok') {
     logger.error(new RainbowError('[fetchTokenLauncherAirdrops]: Failed to fetch airdrop claimables (API error)'), {
-      message: data.metadata.errors,
+      errorMessages: data.metadata.errors?.map(error => error.errors.map(e => `${e.chain_id}: ${e.error}`).join(', ')).join(', '),
     });
     abortController?.abort();
     return EMPTY_RETURN_DATA;

--- a/src/state/claimables/airdropsStore.ts
+++ b/src/state/claimables/airdropsStore.ts
@@ -266,7 +266,9 @@ async function fetchAirdrops(
 
   if (data.metadata.status !== 'ok') {
     logger.error(new RainbowError('[fetchTokenLauncherAirdrops]: Failed to fetch airdrop claimables (API error)'), {
-      errorMessages: data.metadata.errors?.map(error => error.errors.map(e => `${e.chain_id}: ${e.error}`).join(', ')).join(', '),
+      errors: data.metadata.errors?.flatMap(({ address, errors }) =>
+        errors.map(({ chain_id, error }) => `${address} ${chain_id}: ${error}`)
+      ),
     });
     abortController?.abort();
     return EMPTY_RETURN_DATA;


### PR DESCRIPTION
Fixes FEPLAT-92

## What changed (plus any additional context for devs)

We're seeing ~100-300/day errors logged related to fetching the airdrops from the token launcher. Upon inspection the errors themselves are a backend issue which is being resolved. However, we were unable to see the error messages returned from backend in Sentry because they were too deeply nested, resulting in the following for the message field in Sentry: 

```json
[
    {
        address: ******************************************,
        errors: [Array]
    }
]
 ```

This PR flattens the errors into a single array of strings so that future error logs are actually readable. 
