### PR TITLE
Fix swap smart wallet activation label

### DIFF
--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -394,7 +394,7 @@ function ReviewGasRow() {
     const chainsNativeAsset = backendNetworksActions.getChainsNativeAsset();
     const chainId = swapsStore.getState().inputAsset?.chainId ?? ChainId.mainnet;
     const nativeAsset = chainsNativeAsset[chainId];
-    const decision = await willExecuteDelegation({ address: getAccountAddress(), chainId });
+    const decision = await willExecuteDelegation({ address: getAccountAddress(), chainId, requireFreshStatus: true });
 
     navigate(Routes.EXPLAIN_SHEET, {
       chainId,

--- a/src/features/delegation/configureClient.test.ts
+++ b/src/features/delegation/configureClient.test.ts
@@ -1,0 +1,58 @@
+import { configure as configureDelegationClient } from '@rainbow-me/delegation';
+
+import { createDelegationPublicClient } from './calls';
+import { configureDelegationSdk } from './configureClient';
+
+const mockGetCode = jest.fn();
+
+jest.mock('@rainbow-me/delegation', () => ({
+  configure: jest.fn(),
+}));
+
+jest.mock('@/logger', () => ({
+  logger: {
+    DebugContext: {
+      delegation: 'delegation',
+    },
+    createServiceLogger: jest.fn(() => ({ debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() })),
+  },
+}));
+
+jest.mock('@/resources/platform/client', () => ({
+  getPlatformClient: jest.fn(() => ({ request: jest.fn() })),
+}));
+
+jest.mock('@/state/wallets/walletsStore', () => ({
+  useWalletsStore: jest.fn(),
+}));
+
+jest.mock('./calls', () => ({
+  createDelegationPublicClient: jest.fn(() => ({
+    getCode: mockGetCode,
+  })),
+}));
+
+jest.mock('./relayService', () => ({
+  relayService: { status: jest.fn() },
+}));
+
+const ACCOUNT = '0x1111111111111111111111111111111111111111';
+const CHAIN_ID = 8453;
+
+describe('configureDelegationSdk', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('configures runtime account-code reads for stale delegation-status correction', async () => {
+    mockGetCode.mockResolvedValue('0xef0100');
+
+    configureDelegationSdk();
+
+    const configuration = jest.mocked(configureDelegationClient).mock.calls[0][0];
+    await expect(configuration.readAccountCode?.({ address: ACCOUNT, chainId: CHAIN_ID })).resolves.toBe('0xef0100');
+
+    expect(createDelegationPublicClient).toHaveBeenCalledWith(CHAIN_ID);
+    expect(mockGetCode).toHaveBeenCalledWith({ address: ACCOUNT });
+  });
+});

--- a/src/features/delegation/configureClient.ts
+++ b/src/features/delegation/configureClient.ts
@@ -3,6 +3,7 @@ import { getPlatformClient } from '@/resources/platform/client';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { configure as configureDelegationClient } from '@rainbow-me/delegation';
 
+import { createDelegationPublicClient } from './calls';
 import { relayService } from './relayService';
 
 // ============ Delegation Client ============================================== //
@@ -17,6 +18,7 @@ export function configureDelegationSdk(): void {
     platformClient: getPlatformClient(),
     logger: logger.createServiceLogger(logger.DebugContext.delegation),
     getCurrentAddress: $ => $(useWalletsStore, s => s.accountAddress),
+    readAccountCode: ({ address, chainId }) => createDelegationPublicClient(chainId).getCode({ address }),
     relayService,
   });
 }

--- a/src/features/delegation/willDelegate.test.ts
+++ b/src/features/delegation/willDelegate.test.ts
@@ -1,7 +1,7 @@
 import { EthereumWalletType } from '@/helpers/walletTypes';
 import { delegation } from '@rainbow-me/delegation';
 
-import { canUseDelegatedExecution, supportsDelegatedExecution } from './willDelegate';
+import { canUseDelegatedExecution, supportsDelegatedExecution, willExecuteDelegation } from './willDelegate';
 
 const mockGetWalletWithAccount = jest.fn();
 const mockIsDelegationEnabled = jest.fn();
@@ -56,5 +56,19 @@ describe('delegation wallet gating', () => {
 
     await expect(supportsDelegatedExecution({ address: ADDRESS, chainId: CHAIN_ID })).resolves.toBe(true);
     expect(delegation.isSupported).toHaveBeenCalledWith({ address: ADDRESS, chainId: CHAIN_ID });
+  });
+
+  it('checks fresh delegation intent before showing activation UI', async () => {
+    setWallet(EthereumWalletType.privateKey);
+    jest.mocked(delegation.willDelegate).mockResolvedValue({
+      delegation: null,
+      willDelegate: false,
+    });
+
+    await expect(willExecuteDelegation({ address: ADDRESS, chainId: CHAIN_ID, requireFreshStatus: true })).resolves.toEqual({
+      delegation: null,
+      willDelegate: false,
+    });
+    expect(delegation.willDelegate).toHaveBeenCalledWith({ address: ADDRESS, chainId: CHAIN_ID, requireFreshStatus: true });
   });
 });

--- a/src/features/delegation/willDelegate.ts
+++ b/src/features/delegation/willDelegate.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { type Address } from 'viem';
 
 import WalletTypes from '@/helpers/walletTypes';
@@ -65,11 +67,36 @@ export function useWillExecuteDelegation(address: Address, chainId: number): boo
   const delegationEnabled = useIsDelegationEnabled();
   const wallet = useWalletsStore(s => s.getWalletWithAccount(address));
   const sdkWillDelegate = useWillDelegate(address, chainId);
+  const [freshWillDelegate, setFreshWillDelegate] = useState(false);
 
   const canUseDelegation = delegationEnabled && canUseDelegatedWallet(wallet);
+
+  useEffect(() => {
+    let isCurrent = true;
+    setFreshWillDelegate(false);
+
+    if (!canUseDelegation || !sdkWillDelegate) {
+      return () => {
+        isCurrent = false;
+      };
+    }
+
+    willExecuteDelegation({ address, chainId, requireFreshStatus: true })
+      .then(decision => {
+        if (isCurrent) setFreshWillDelegate(decision.willDelegate);
+      })
+      .catch(() => {
+        if (isCurrent) setFreshWillDelegate(false);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [address, canUseDelegation, chainId, sdkWillDelegate]);
+
   if (!canUseDelegation) return false;
 
-  return sdkWillDelegate;
+  return sdkWillDelegate && freshWillDelegate;
 }
 
 function canUseDelegatedWallet(wallet: RainbowWallet | undefined): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes BX-2141

## What changed (plus any additional context for devs)
- Configured the delegation SDK with runtime account-code reads so stale backend delegation status can be corrected against onchain 7702 delegation state.
- Updated the swap activation label hook to confirm `willDelegate` with a fresh delegation check before showing Smart Wallet activation copy.
- Updated the swap gas explainer tap path to use the same fresh delegation decision.
- Added focused coverage for the fresh delegation intent check and SDK account-code reader configuration.

## Screen recordings / screenshots
N/A - logic/state fix validated with automated tests.

## What to test
- `yarn jest src/features/delegation/willDelegate.test.ts src/features/delegation/configureClient.test.ts`
- `yarn lint:ts`
- `yarn lint:js --quiet src/features/delegation/willDelegate.ts src/features/delegation/configureClient.ts src/features/delegation/willDelegate.test.ts src/features/delegation/configureClient.test.ts src/__swaps__/screens/Swap/components/ReviewPanel.tsx`
- `yarn prettier --check src/features/delegation/willDelegate.ts src/features/delegation/configureClient.ts src/features/delegation/willDelegate.test.ts src/features/delegation/configureClient.test.ts src/__swaps__/screens/Swap/components/ReviewPanel.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BX-2141](https://linear.app/rainbow/issue/BX-2141/smart-wallet-activation-label-appears-on-every-swap)

<div><a href="https://cursor.com/agents/bc-735a01ca-be2e-4ce4-8109-07da77a7b817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-735a01ca-be2e-4ce4-8109-07da77a7b817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

