### PR TITLE
Fix KOTH visible rankings

### DIFF
--- a/src/components/king-of-the-hill/KingOfTheHillContent.tsx
+++ b/src/components/king-of-the-hill/KingOfTheHillContent.tsx
@@ -19,6 +19,7 @@ import { logger, RainbowError } from '@/logger';
 import { useMainListScrollToTop } from '@/navigation/MainListContext';
 import { useKingOfTheHillStore } from '@/state/kingOfTheHill/kingOfTheHillStore';
 
+import { getVisibleKingOfTheHillRankings } from './getVisibleKingOfTheHillRankings';
 import { KingOfTheHillHeader } from './KingOfTheHillHeader';
 import { LaunchButton } from './LaunchButton';
 import { LeaderboardItem } from './LeaderboardItem';
@@ -93,17 +94,14 @@ export const KingOfTheHillContent = memo(function KingOfTheHillContent({
 
     const rankings = kingOfTheHillLeaderBoard?.rankings || [];
 
-    const rankedItems = rankings
-      // start from 2nd place (first is in header)
-      .slice(1)
-      .map(item => {
-        return {
-          type: 'item',
-          ranking: item.rank,
-          token: item.token,
-          windowTradingVolume: item.windowTradingVolume,
-        } satisfies ListItem;
-      });
+    const rankedItems = getVisibleKingOfTheHillRankings(rankings).map(item => {
+      return {
+        type: 'item',
+        ranking: item.rank,
+        token: item.token,
+        windowTradingVolume: item.windowTradingVolume,
+      } satisfies ListItem;
+    });
 
     return [
       {

--- a/src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.test.ts
+++ b/src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.test.ts
@@ -1,0 +1,15 @@
+import { getVisibleKingOfTheHillRankings } from '@/components/king-of-the-hill/getVisibleKingOfTheHillRankings';
+
+describe('getVisibleKingOfTheHillRankings', () => {
+  it('excludes the header rank and ranks beyond the visible top 10', () => {
+    const rankings = Array.from({ length: 12 }, (_, index) => ({ rank: index + 1 }));
+
+    expect(getVisibleKingOfTheHillRankings(rankings).map(({ rank }) => rank)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('preserves rank gaps from backend filtering instead of filling with lower-ranked items', () => {
+    const rankings = [{ rank: 1 }, { rank: 2 }, { rank: 3 }, { rank: 7 }, { rank: 10 }, { rank: 11 }, { rank: 12 }];
+
+    expect(getVisibleKingOfTheHillRankings(rankings).map(({ rank }) => rank)).toEqual([2, 3, 7, 10]);
+  });
+});

--- a/src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.ts
+++ b/src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.ts
@@ -1,0 +1,9 @@
+export const KING_OF_THE_HILL_MAX_VISIBLE_RANK = 10;
+
+type RankingWithRank = {
+  rank: number;
+};
+
+export function getVisibleKingOfTheHillRankings<Ranking extends RankingWithRank>(rankings: readonly Ranking[]): Ranking[] {
+  return rankings.filter(({ rank }) => rank > 1 && rank <= KING_OF_THE_HILL_MAX_VISIBLE_RANK);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes APP-3466

## What changed (plus any additional context for devs)
- Limit KOTH leaderboard rows to ranks 2 through 10; rank 1 remains represented by the header/current token.
- Added a unit-tested helper so backend-filtered rank gaps do not get filled by ranks 11/12.

## Screen recordings / screenshots
- Verification artifact: <a href="/opt/cursor/artifacts/koth_rank_visibility_verification.txt">koth_rank_visibility_verification.txt</a>
- Mobile UI rendering was not available in this Linux cloud VM: `adb devices` returned no connected devices/emulators, and iOS simulator tooling is unavailable.

## What to test
- KOTH list should show the current token plus ranks 2-10 only.
- Ranks 11 and 12 should not appear after scam-filtered backend responses.

## Verification
- `yarn jest src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.test.ts`
- `yarn lint:ts`
- `yarn eslint --quiet src/components/king-of-the-hill/KingOfTheHillContent.tsx src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.ts src/components/king-of-the-hill/getVisibleKingOfTheHillRankings.test.ts`
- Live metadata validation with the actual selector: backend ranks `[1,2,3,4,5,6,7,8,9,10,11,12]` produce visible list ranks `[2,3,4,5,6,7,8,9,10]`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [APP-3466](https://linear.app/rainbow/issue/APP-3466/padding-mismatch-on-koth-list)

<div><a href="https://cursor.com/agents/bc-0731b30b-3fa5-4ca9-a942-ad66514e236c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0731b30b-3fa5-4ca9-a942-ad66514e236c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

