### PR TITLE
chore (positions): move partial error logging from sentry to analytics

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -146,6 +146,7 @@ export const event = {
   positionsOpenedSheet: 'Opened position Sheet',
   positionsOpenedExternalDapp: 'Viewed external dapp',
   positionsOpenedAsset: 'Opened asset from position',
+  positionsError: 'positions.error',
 
   mintsPressedFeaturedMintCard: 'Pressed featured mint card',
   mintsPressedCollectionCell: 'Pressed collection cell in mints card',
@@ -678,6 +679,10 @@ export type EventProperties = {
     positionsValue: string;
     positionsCurrency: string;
   };
+  [event.positionsError]:
+    | { kind: 'price_not_found'; tokenAddress: string; chainId: number }
+    | { kind: 'skipped_portfolio_item'; itemName: string; protocol: string }
+    | { kind: 'unknown'; errorMessage: string };
   [event.mintsPressedFeaturedMintCard]: {
     contractAddress: string;
     chainId: number;

--- a/src/features/positions/stores/fetcher.ts
+++ b/src/features/positions/stores/fetcher.ts
@@ -6,6 +6,7 @@ import { getPlatformClient } from '@/resources/platform/client';
 import { time } from '@/utils/time';
 
 import type { ListPositionsResponse } from '../types/generated/positions/positions';
+import { trackPositionsResponseErrors } from './trackPositionsResponseErrors';
 
 // ============ Constants ====================================================== //
 
@@ -51,10 +52,7 @@ export async function fetchPositions(params: PositionsParams, abortController: A
     }
 
     if (response.data.errors && response.data.errors.length > 0) {
-      logger.warn('[Positions] Partial errors in response', {
-        request: response.data.metadata,
-        errors: response.data.errors,
-      });
+      trackPositionsResponseErrors(response.data.errors);
     }
 
     return response.data;

--- a/src/features/positions/stores/trackPositionsResponseErrors.ts
+++ b/src/features/positions/stores/trackPositionsResponseErrors.ts
@@ -1,0 +1,45 @@
+import { analytics } from '@/analytics';
+import { type EventProperties } from '@/analytics/event';
+
+type ParsedPositionsError = EventProperties[typeof analytics.event.positionsError];
+
+const PRICE_NOT_FOUND_REGEX = /^price not found for key: (.+):(\d+)/;
+const SKIPPED_PORTFOLIO_ITEM_REGEX = /^skipped portfolio item '([^']+)' for protocol (\S+)/;
+
+function paraseErrorMessage(errorMessage: string): ParsedPositionsError {
+  const priceMatch = errorMessage.match(PRICE_NOT_FOUND_REGEX);
+  if (priceMatch) {
+    const [, tokenAddress, chainId] = priceMatch;
+    return { kind: 'price_not_found', tokenAddress: tokenAddress.toLowerCase(), chainId: Number(chainId) };
+  }
+
+  const skippedMatch = errorMessage.match(SKIPPED_PORTFOLIO_ITEM_REGEX);
+  if (skippedMatch) {
+    const [, itemName, protocol] = skippedMatch;
+    return { kind: 'skipped_portfolio_item', itemName, protocol };
+  }
+
+  return { kind: 'unknown', errorMessage };
+}
+
+function getParsedErrorKey(error: ParsedPositionsError): string {
+  switch (error.kind) {
+    case 'price_not_found':
+      return `price:${error.tokenAddress}:${error.chainId}`;
+    case 'skipped_portfolio_item':
+      return `skipped:${error.protocol}:${error.itemName}`;
+    case 'unknown':
+      return `unknown:${error.errorMessage}`;
+  }
+}
+
+export function trackPositionsResponseErrors(errorMessages: string[]): void {
+  const seenErrors = new Set<string>();
+  for (const errorMessage of errorMessages) {
+    const parsedError = paraseErrorMessage(errorMessage);
+    const errorMessageKey = getParsedErrorKey(parsedError);
+    if (seenErrors.has(errorMessageKey)) continue;
+    seenErrors.add(errorMessageKey);
+    analytics.track(analytics.event.positionsError, parsedError);
+  }
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)

The errors response from the positions endpoint is expected for cases where we do not have data for a particular defi protocol or pricing data for a particular token. Because of this we receive lots of warning logs in sentry for this fetch. 

This PR removes the Sentry logging entirely when we receive a valid response that also has partial errors since they are expected. However, we'd still like to know which protocols and tokens we're most often missing for users. 

This is better suited for an analytic event, which is added here as `positions.error`. Currently the error messages are returned from backend as an array of raw strings, so in order to get the chain ID, token address, and protocol, we have to use a regex of the expected response to parse them out into structured data. 