### PR TITLE
refactor: drop IS_IOS/IS_ANDROID for direct Platform.OS imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -175,6 +175,15 @@ module.exports = {
         ],
       },
     ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        // Import `Platform` directly from 'react-native' so platform shaking can constant-fold `Platform.OS`
+        // checks at build time. Re-imports from wrapper modules break the optimization (https://docs.expo.dev/guides/tree-shaking/#platform-shaking).
+        selector: "ImportDeclaration[source.value!='react-native'] > ImportSpecifier[imported.name='Platform'][local.name='Platform']",
+        message: "Import `Platform` directly from 'react-native'. Re-importing from a wrapper breaks platform shaking optimization.",
+      },
+    ],
     'jest/expect-expect': 'off',
     'jest/no-disabled-tests': 'off',
     'no-await-in-loop': 'off',

--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import Animated from 'react-native-reanimated';
 import { ScreenCornerRadius } from 'react-native-screen-corner-radius';
@@ -19,7 +19,6 @@ import { Page } from '@/components/layout';
 import { navbarHeight } from '@/components/navbar/Navbar';
 import { DecoyScrollView } from '@/components/sheet/DecoyScrollView';
 import { Box } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { useSponsoredSwapStore } from '@/features/delegation/sponsoredSwapStore';
 import { clearCustomGasSettings } from '@/features/gas/hooks/useCustomGas';
 import { useDelayedMount } from '@/hooks/useDelayedMount';
@@ -206,10 +205,10 @@ const ExchangeRateBubbleAndWarning = () => {
 
 export const styles = StyleSheet.create({
   rootViewBackground: {
-    borderTopLeftRadius: IS_ANDROID ? 20 : ScreenCornerRadius,
-    borderTopRightRadius: IS_ANDROID ? 20 : ScreenCornerRadius,
-    borderBottomLeftRadius: IS_ANDROID ? 0 : ScreenCornerRadius,
-    borderBottomRightRadius: IS_ANDROID ? 0 : ScreenCornerRadius,
+    borderTopLeftRadius: Platform.OS === 'android' ? 20 : ScreenCornerRadius,
+    borderTopRightRadius: Platform.OS === 'android' ? 20 : ScreenCornerRadius,
+    borderBottomLeftRadius: Platform.OS === 'android' ? 0 : ScreenCornerRadius,
+    borderBottomRightRadius: Platform.OS === 'android' ? 0 : ScreenCornerRadius,
     flex: 1,
     overflow: 'hidden',
   },

--- a/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedChainImage.tsx
@@ -1,8 +1,8 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
 
 import { AnimatedChainImage as AnimatedChainImageAndroid } from './AnimatedChainImage.android';
 import { AnimatedChainImage as AnimatedChainImageIOS } from './AnimatedChainImage.ios';
 
-const componentToExport = IS_IOS ? AnimatedChainImageIOS : AnimatedChainImageAndroid;
+const componentToExport = Platform.OS === 'ios' ? AnimatedChainImageIOS : AnimatedChainImageAndroid;
 
 export { componentToExport as AnimatedChainImage };

--- a/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
+++ b/src/__swaps__/screens/Swap/components/AnimatedSwapCoinIcon.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { StyleSheet, View, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type ViewStyle } from 'react-native';
 
 import Animated, { useAnimatedProps, useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -7,7 +7,6 @@ import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import { AnimatedFasterImage } from '@/components/AnimatedComponents/AnimatedFasterImage';
 import { DEFAULT_FASTER_IMAGE_CONFIG } from '@/components/images/ImgixImage';
 import { Box, globalColors, useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { borders } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
 import { PIXEL_RATIO } from '@/utils/deviceUtils';
@@ -43,7 +42,7 @@ export const AnimatedSwapCoinIcon = memo(function AnimatedSwapCoinIcon({
     return {
       source: {
         ...DEFAULT_FASTER_IMAGE_CONFIG,
-        borderRadius: IS_ANDROID ? (size / 2) * PIXEL_RATIO : undefined,
+        borderRadius: Platform.OS === 'android' ? (size / 2) * PIXEL_RATIO : undefined,
         url: coinIconUrl.value,
       },
     };
@@ -106,7 +105,7 @@ export const AnimatedSwapCoinIcon = memo(function AnimatedSwapCoinIcon({
             style={[
               sx.coinIcon,
               {
-                borderRadius: IS_IOS ? size / 2 : undefined,
+                borderRadius: Platform.OS === 'ios' ? size / 2 : undefined,
                 height: size,
                 width: size,
               },
@@ -124,7 +123,6 @@ export const AnimatedSwapCoinIcon = memo(function AnimatedSwapCoinIcon({
           style={[animatedEmptyStateStyles, coinIconFallbackStyle(size)]}
         />
       </Animated.View>
-
       {showBadge && <AnimatedChainImage assetType={assetType} size={chainSize} />}
     </View>
   );

--- a/src/__swaps__/screens/Swap/components/FlipButton.tsx
+++ b/src/__swaps__/screens/Swap/components/FlipButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { InteractionManager, StyleSheet } from 'react-native';
+import { InteractionManager, Platform, StyleSheet } from 'react-native';
 
 import Animated, { runOnJS, useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated';
 
@@ -13,7 +13,6 @@ import { AnimatedSpinner } from '@/components/animations/AnimatedSpinner';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { Bleed, Box, globalColors, IconContainer, Text, useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { ChainId } from '@/state/backendNetworks/types';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
@@ -172,14 +171,14 @@ export const FlipButton = () => {
                 AnimatedSwapStyles.flipButtonFetchingStyle,
                 styles.flipButton,
                 {
-                  backgroundColor: IS_ANDROID ? (isDarkMode ? globalColors.blueGrey100 : globalColors.white100) : undefined,
+                  backgroundColor: Platform.OS === 'android' ? (isDarkMode ? globalColors.blueGrey100 : globalColors.white100) : undefined,
                   borderColor: isDarkMode ? SEPARATOR_COLOR : opacity(globalColors.white100, 0.5),
                 },
               ]}
             />
             <IconContainer size={24} opacity={isDarkMode ? 0.6 : 0.8}>
               <Box alignItems="center" justifyContent="center">
-                <Bleed bottom={{ custom: IS_IOS ? 0.5 : 4 }}>
+                <Bleed bottom={{ custom: Platform.OS === 'ios' ? 0.5 : 4 }}>
                   <Text align="center" color="labelTertiary" size="icon 13px" weight="heavy">
                     􀆈
                   </Text>

--- a/src/__swaps__/screens/Swap/components/GasButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GasButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, type PropsWithChildren, type ReactNode } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import Animated, { runOnUI, useAnimatedStyle } from 'react-native-reanimated';
 
@@ -7,7 +7,6 @@ import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { Box, Inline, Text, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { GasSpeedMenu } from '@/features/gas/components/GasSpeedMenu';
 import { useCustomGasSettings, type GasSettings } from '@/features/gas/hooks/useCustomGas';
@@ -75,7 +74,7 @@ function SelectedGas({ isPill, sponsored }: { isPill?: boolean; sponsored?: bool
           color={sponsored && buyTokenColor ? { custom: buyTokenColor } : SWAP_GAS_ICONS[selectedGasSpeed].color}
           height={10}
           size="icon 13px"
-          textStyle={{ top: IS_ANDROID ? 1 : 0 + (selectedGasSpeed === 'fast' ? 0.5 : 0) }}
+          textStyle={{ top: Platform.OS === 'android' ? 1 : 0 + (selectedGasSpeed === 'fast' ? 0.5 : 0) }}
           width={isPill ? 14 : 18}
           weight={sponsored ? 'heavy' : 'bold'}
         >
@@ -190,7 +189,7 @@ const GasMenu = ({
     <Box
       alignItems="center"
       justifyContent="center"
-      style={{ margin: IS_ANDROID ? 0 : -GAS_BUTTON_HIT_SLOP, pointerEvents: disabled ? 'none' : 'auto' }}
+      style={{ margin: Platform.OS === 'android' ? 0 : -GAS_BUTTON_HIT_SLOP, pointerEvents: disabled ? 'none' : 'auto' }}
       testID="gas-speed-pager"
     >
       <GasSpeedMenu
@@ -201,8 +200,8 @@ const GasMenu = ({
       >
         <ButtonPressAnimation
           scaleTo={0.825}
-          style={IS_ANDROID ? undefined : { padding: GAS_BUTTON_HIT_SLOP }}
-          testID={IS_ANDROID ? undefined : 'gas-speed-pager-button'}
+          style={Platform.OS === 'android' ? undefined : { padding: GAS_BUTTON_HIT_SLOP }}
+          testID={Platform.OS === 'android' ? undefined : 'gas-speed-pager-button'}
         >
           {children}
         </ButtonPressAnimation>

--- a/src/__swaps__/screens/Swap/components/GasPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/GasPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, type PropsWithChildren, type ReactNode } from 'react';
-import { type LayoutChangeEvent } from 'react-native';
+import { Platform, type LayoutChangeEvent } from 'react-native';
 
 import Animated, { runOnJS, useAnimatedReaction, useAnimatedStyle, withDelay, withSpring } from 'react-native-reanimated';
 
@@ -8,7 +8,6 @@ import { NavigationSteps, useSwapContext } from '@/__swaps__/screens/Swap/provid
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Bleed, Box, globalColors, Inline, Separator, Stack, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { getCustomGasSettings, setCustomGasSettings, useCustomGasStore, type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { getSelectedGas, setSelectedGasSpeed, useSelectedGasSpeed } from '@/features/gas/hooks/useSelectedGas';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
@@ -69,7 +68,7 @@ function PressableLabel({ onPress, children }: PropsWithChildren<{ onPress: Void
             􀅴
           </Text>
         </Text>
-        <Box marginBottom={IS_ANDROID ? '-4px' : undefined}></Box>
+        <Box marginBottom={Platform.OS === 'android' ? '-4px' : undefined}></Box>
       </Inline>
     </Box>
   );

--- a/src/__swaps__/screens/Swap/components/SwapActionButton.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapActionButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 
 import chroma from 'chroma-js';
 import Animated, {
@@ -19,7 +19,6 @@ import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton, type GestureHandlerButtonProps } from '@/components/buttons/GestureHandlerButton';
 import { AnimatedText, Box, Column, Columns, Cover, globalColors, Stack, useColorMode, useForegroundColor } from '@/design-system';
 import { type SharedOrDerivedValueText } from '@/design-system/components/Text/AnimatedText';
-import { IS_IOS } from '@/env';
 import { type DepositContextType } from '@/systems/funding/types';
 
 import { useSwapContext } from '../providers/swap-provider';
@@ -267,7 +266,7 @@ const HoldProgress = ({ holdProgress }: { holdProgress: SharedValue<number> }) =
           {
             backgroundColor: brightenedColor,
             height: '100%',
-            ...(IS_IOS
+            ...(Platform.OS === 'ios'
               ? {
                   shadowColor: brightenedColor,
                   shadowOffset: {

--- a/src/__swaps__/screens/Swap/components/SwapBackground.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapBackground.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { Canvas, LinearGradient, Rect, vec } from '@shopify/react-native-skia';
 import { useDerivedValue, withTiming } from 'react-native-reanimated';
@@ -8,7 +8,7 @@ import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider
 import { getColorValueForThemeWorklet, getTintedBackgroundColor } from '@/__swaps__/utils/swaps';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { useStableValue } from '@/hooks/useStableValue';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -55,7 +55,7 @@ export const SwapBackground = () => {
 
   return (
     <Canvas style={[styles.background, { backgroundColor: initialColors.top }]}>
-      <Rect antiAlias dither height={DEVICE_HEIGHT + (IS_ANDROID ? 24 : 0)} width={DEVICE_WIDTH} x={0} y={0}>
+      <Rect antiAlias dither height={DEVICE_HEIGHT + (Platform.OS === 'android' ? 24 : 0)} width={DEVICE_WIDTH} x={0} y={0}>
         <LinearGradient colors={gradientColors} end={vec(DEVICE_WIDTH / 2, DEVICE_HEIGHT)} start={vec(DEVICE_WIDTH / 2, 0)} />
       </Rect>
     </Canvas>
@@ -64,9 +64,9 @@ export const SwapBackground = () => {
 
 const styles = StyleSheet.create({
   background: {
-    borderRadius: IS_ANDROID ? 20 : 0,
+    borderRadius: Platform.OS === 'android' ? 20 : 0,
     flex: 1,
-    height: DEVICE_HEIGHT + (IS_ANDROID ? 24 : 0),
+    height: DEVICE_HEIGHT + (Platform.OS === 'android' ? 24 : 0),
     position: 'absolute',
     width: DEVICE_WIDTH,
     zIndex: -10,

--- a/src/__swaps__/screens/Swap/components/SwapInput.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInput.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import Animated, { type SharedValue } from 'react-native-reanimated';
 
@@ -8,7 +8,6 @@ import { useSwapInputStyles } from '@/__swaps__/screens/Swap/hooks/useSwapInputS
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING } from '@/components/token-search/constants';
 import { Box } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
 export const SwapInput = ({
@@ -49,7 +48,7 @@ export const styles = StyleSheet.create({
   staticInputStyles: {
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
+    borderWidth: Platform.OS === 'ios' ? THICK_BORDER_WIDTH : 0,
     overflow: 'hidden',
     padding: TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING,
     width: BASE_INPUT_WIDTH,

--- a/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapInputAsset.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import MaskedView from '@react-native-masked-view/masked-view';
@@ -18,7 +18,6 @@ import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING } from '@/components/token-search/constants';
 import { AnimatedText, Box, Column, Columns, Stack, useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
@@ -186,7 +185,7 @@ export const styles = StyleSheet.create({
   inputTextMask: { alignItems: 'center', flexDirection: 'row', height: 36, pointerEvents: 'box-only' },
   rootViewBackground: {
     backgroundColor: 'transparent',
-    borderRadius: IS_ANDROID ? 20 : ScreenCornerRadius,
+    borderRadius: Platform.OS === 'android' ? 20 : ScreenCornerRadius,
     flex: 1,
     overflow: 'hidden',
   },
@@ -198,7 +197,7 @@ export const styles = StyleSheet.create({
   staticInputStyles: {
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
+    borderWidth: Platform.OS === 'ios' ? THICK_BORDER_WIDTH : 0,
     overflow: 'hidden',
     padding: TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING,
     width: BASE_INPUT_WIDTH,

--- a/src/__swaps__/screens/Swap/components/SwapNavbar.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapNavbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, StyleSheet } from 'react-native';
+import { Platform, Pressable, StyleSheet } from 'react-native';
 
 import Animated, { useDerivedValue } from 'react-native-reanimated';
 
@@ -22,7 +22,6 @@ import {
   useColorMode,
   useForegroundColor,
 } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import { useRemoteConfig } from '@/model/remoteConfig';
@@ -113,7 +112,7 @@ export function SwapNavbar() {
       top={{ custom: 0 }}
       width="full"
     >
-      {IS_ANDROID ? <Pressable onPress={goBack} style={[StyleSheet.absoluteFillObject]} /> : null}
+      {Platform.OS === 'android' ? <Pressable onPress={goBack} style={[StyleSheet.absoluteFillObject]} /> : null}
       <Box
         borderRadius={5}
         height={{ custom: 5 }}
@@ -140,7 +139,7 @@ export function SwapNavbar() {
         }
         rightComponent={<SwapSettings />}
         titleComponent={
-          <Inset bottom={{ custom: IS_IOS ? 5.5 : 14 }}>
+          <Inset bottom={{ custom: Platform.OS === 'ios' ? 5.5 : 14 }}>
             <AnimatedText align="center" color="label" size="20pt" weight="heavy">
               {swapOrBridgeLabel}
             </AnimatedText>

--- a/src/__swaps__/screens/Swap/components/SwapNumberPad.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapNumberPad.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import Animated, {
   Easing,
@@ -20,7 +21,6 @@ import { stripNonDecimalNumbers } from '@/__swaps__/utils/swaps';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { Bleed, Box, Columns, HitSlop, Separator, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { equalWorklet } from '@/framework/core/safeMath';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { supportedCurrencies as supportedNativeCurrencies } from '@/references/supportedCurrencies';
@@ -367,7 +367,7 @@ const NumberPadKey = ({
             !transparent && {
               borderColor: isDarkMode ? separatorTertiary : 'transparent',
               borderCurve: 'continuous',
-              borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
+              borderWidth: Platform.OS === 'ios' ? THICK_BORDER_WIDTH : 0,
               shadowColor: isDarkMode ? 'transparent' : colors.dark,
               shadowOffset: {
                 width: 0,

--- a/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapOutputAsset.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import MaskedView from '@react-native-masked-view/masked-view';
@@ -19,7 +19,6 @@ import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING } from '@/components/token-search/constants';
 import { AnimatedText, Box, Column, Columns, Stack, useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -216,7 +215,7 @@ export const styles = StyleSheet.create({
   inputTextMask: { alignItems: 'center', flexDirection: 'row', height: 36, pointerEvents: 'box-only' },
   rootViewBackground: {
     backgroundColor: 'transparent',
-    borderRadius: IS_ANDROID ? 20 : ScreenCornerRadius,
+    borderRadius: Platform.OS === 'android' ? 20 : ScreenCornerRadius,
     flex: 1,
     overflow: 'hidden',
   },
@@ -228,7 +227,7 @@ export const styles = StyleSheet.create({
   staticInputStyles: {
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
+    borderWidth: Platform.OS === 'ios' ? THICK_BORDER_WIDTH : 0,
     overflow: 'hidden',
     padding: TOKEN_SEARCH_INPUT_HORIZONTAL_PADDING,
     width: BASE_INPUT_WIDTH,

--- a/src/__swaps__/screens/Swap/components/SwapSlider.tsx
+++ b/src/__swaps__/screens/Swap/components/SwapSlider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { Gesture, GestureDetector, type TapGesture } from 'react-native-gesture-handler';
 import Animated, {
@@ -24,7 +24,6 @@ import { clamp, getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons';
 import { AnimatedText, Bleed, Box, Column, Columns, globalColors, Inline, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { greaterThanWorklet } from '@/framework/core/safeMath';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
@@ -174,12 +173,12 @@ export const SwapSlider = ({
         // On Android, for some reason waiting until onActive to set SwapInputController.isQuoteStale.value = 1 causes
         // the outputAmount text color to break. It's preferable to set it in onActive, so we're setting it in onStart
         // for Android only. It's possible that migrating this handler to the RNGH v2 API will remove the need for this.
-        if (!IS_IOS) isQuoteStale.value = 1;
+        if (Platform.OS !== 'ios') isQuoteStale.value = 1;
       })
       .onUpdate(event => {
         const hasSwappableBalance = hasBalance.value;
 
-        if (IS_IOS && sliderXPosition.value > 0 && isQuoteStale.value !== 1 && hasSwappableBalance) {
+        if (Platform.OS === 'ios' && sliderXPosition.value > 0 && isQuoteStale.value !== 1 && hasSwappableBalance) {
           isQuoteStale.value = 1;
         }
 
@@ -363,28 +362,30 @@ export const SwapSlider = ({
         ),
         SPRING_CONFIGS.springConfig
       ),
-      borderWidth: IS_IOS
-        ? interpolate(
-            xPercentage.value,
-            [0, (THICK_BORDER_WIDTH * 2) / width, (THICK_BORDER_WIDTH * 4) / width, 1],
-            [0, 0, THICK_BORDER_WIDTH, THICK_BORDER_WIDTH],
-            'clamp'
-          )
-        : 0,
+      borderWidth:
+        Platform.OS === 'ios'
+          ? interpolate(
+              xPercentage.value,
+              [0, (THICK_BORDER_WIDTH * 2) / width, (THICK_BORDER_WIDTH * 4) / width, 1],
+              [0, 0, THICK_BORDER_WIDTH, THICK_BORDER_WIDTH],
+              'clamp'
+            )
+          : 0,
       width: `${uiXPercentage.value * 100}%`,
     };
   });
 
   const rightBarContainerStyle = useAnimatedStyle(() => {
     return {
-      borderWidth: IS_IOS
-        ? interpolate(
-            xPercentage.value,
-            [0, 1 - (THICK_BORDER_WIDTH * 4) / width, 1 - (THICK_BORDER_WIDTH * 2) / width, 1],
-            [THICK_BORDER_WIDTH, THICK_BORDER_WIDTH, 0, 0],
-            'clamp'
-          )
-        : 0,
+      borderWidth:
+        Platform.OS === 'ios'
+          ? interpolate(
+              xPercentage.value,
+              [0, 1 - (THICK_BORDER_WIDTH * 4) / width, 1 - (THICK_BORDER_WIDTH * 2) / width, 1],
+              [THICK_BORDER_WIDTH, THICK_BORDER_WIDTH, 0, 0],
+              'clamp'
+            )
+          : 0,
       backgroundColor: colors.value.inactiveColorRight,
       width: `${(1 - uiXPercentage.value - SCRUBBER_WIDTH / width) * 100}%`,
     };

--- a/src/__swaps__/screens/Swap/constants.ts
+++ b/src/__swaps__/screens/Swap/constants.ts
@@ -1,8 +1,9 @@
+import { Platform } from 'react-native';
+
 import { Easing } from 'react-native-reanimated';
 
 import { buildTestSafeConfig } from '@/components/animations/animationConfigs';
 import { NAVBAR_HEIGHT_WITH_PADDING } from '@/components/navbar/constants';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import deviceUtils, { DEVICE_HEIGHT, NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 import { getDefaultKeyboardHeight } from '@/utils/keyboardHeight';
@@ -26,7 +27,7 @@ export const SETTINGS_SHEET_HEIGHT = 299;
 export const SETTINGS_SHEET_ROW_GAP = 28;
 export const ACTION_BUTTON_HEIGHT = 45;
 export const GAS_SHEET_HEIGHT = 274;
-export const BOTTOM_ACTION_BAR_HEIGHT = IS_ANDROID ? 48 + 32 + safeAreaInsetValues.bottom : 114;
+export const BOTTOM_ACTION_BAR_HEIGHT = Platform.OS === 'android' ? 48 + 32 + safeAreaInsetValues.bottom : 114;
 export const BASE_INPUT_HEIGHT = 104;
 export const BASE_INPUT_WIDTH = deviceUtils.dimensions.width - 24;
 export const EXPANDED_REVIEW_SECTION = 408;
@@ -36,7 +37,7 @@ export const EXPANDED_INPUT_HEIGHT =
   NAVBAR_HEIGHT_WITH_PADDING -
   BASE_INPUT_HEIGHT -
   SPACE_BETWEEN_SWAP_BUBBLES -
-  Math.max(IS_IOS ? safeAreaInsetValues.bottom : NAVIGATION_BAR_HEIGHT, SPACE_BETWEEN_SWAP_BUBBLES);
+  Math.max(Platform.OS === 'ios' ? safeAreaInsetValues.bottom : NAVIGATION_BAR_HEIGHT, SPACE_BETWEEN_SWAP_BUBBLES);
 export const INPUT_INNER_WIDTH = BASE_INPUT_WIDTH - THICK_BORDER_WIDTH * 2;
 
 export const SLIDER_HEIGHT = 16;

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import {
   interpolate,
   useAnimatedStyle,
@@ -28,7 +30,6 @@ import { TOKEN_SEARCH_FOCUSED_INPUT_HEIGHT } from '@/components/token-search/con
 import { getTokenSearchButtonWrapperStyle } from '@/components/token-search/styles';
 import { useColorMode } from '@/design-system';
 import { foregroundColors } from '@/design-system/color/palettes';
-import { IS_ANDROID } from '@/env';
 import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
@@ -243,7 +244,7 @@ export function useAnimatedSwapStyles({
   });
 
   const flipButtonFetchingStyle = useAnimatedStyle(() => {
-    if (IS_ANDROID) return { borderWidth: 0 };
+    if (Platform.OS === 'android') return { borderWidth: 0 };
     return {
       borderWidth: isFetching.value ? withTiming(2, { duration: 300 }) : withTiming(THICK_BORDER_WIDTH, spinnerExitConfig),
     };

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -1,6 +1,6 @@
 // @refresh
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
-import { InteractionManager, NativeModules, type StyleProp, type TextInput, type TextStyle } from 'react-native';
+import { InteractionManager, NativeModules, Platform, type StyleProp, type TextInput, type TextStyle } from 'react-native';
 
 import {
   runOnJS,
@@ -36,7 +36,6 @@ import { getInputValuesForSliderPositionWorklet, updateInputValuesAfterFlip } fr
 import { clamp, getDefaultSlippageWorklet, parseAssetAndExtend, trimTrailingZeros } from '@/__swaps__/utils/swaps';
 import { trackSwapEvent } from '@/__swaps__/utils/trackSwapEvent';
 import { analytics } from '@/analytics';
-import { IS_IOS } from '@/env';
 import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
 import { getPreparedSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
@@ -261,7 +260,7 @@ export const SwapProvider = ({ children }: SwapProviderProps) => {
     parameters: Omit<RapSwapActionParameters<typeof type>, 'gasParams' | 'gasFeeParamsBySpeed' | 'selectedGasFee'>;
   }) => {
     try {
-      const NotificationManager = IS_IOS ? NativeModules.NotificationManager : null;
+      const NotificationManager = Platform.OS === 'ios' ? NativeModules.NotificationManager : null;
       NotificationManager?.postNotification('rapInProgress');
 
       const provider = getProvider({ chainId: parameters.chainId });

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,10 +1,12 @@
+import { Platform } from 'react-native';
+
 import rudderClient from '@rudderstack/rudder-sdk-react-native';
 import * as DeviceInfo from 'react-native-device-info';
 import { REACT_NATIVE_RUDDERSTACK_WRITE_KEY, RUDDERSTACK_DATA_PLANE_URL } from 'react-native-dotenv';
 
 import { event, type EventProperties } from '@/analytics/event';
 import { type UserProperties } from '@/analytics/userProperties';
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { logger, RainbowError } from '@/logger';
 import type Routes from '@/navigation/routesNames';
 import { device } from '@/storage';
@@ -44,7 +46,7 @@ export class Analytics {
       return;
     }
 
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       this.deviceBrand = DeviceInfo.getBrand();
       this.deviceManufacturer = DeviceInfo.getManufacturerSync();
       this.deviceModel = DeviceInfo.getModel();
@@ -130,7 +132,7 @@ export class Analytics {
       walletType: this.walletType,
     };
 
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       metadata.device_brand = this.deviceBrand;
       metadata.device_manufacturer = this.deviceManufacturer;
       metadata.device_model = this.deviceModel;

--- a/src/components/AnimatedComponents/AnimatedBlurView.ts
+++ b/src/components/AnimatedComponents/AnimatedBlurView.ts
@@ -1,6 +1,6 @@
+import { Platform } from 'react-native';
+
 import { BlurView } from 'react-native-blur-view';
 import Animated from 'react-native-reanimated';
 
-import { IS_IOS } from '@/env';
-
-export const AnimatedBlurView = IS_IOS ? Animated.createAnimatedComponent(BlurView) : Animated.View;
+export const AnimatedBlurView = Platform.OS === 'ios' ? Animated.createAnimatedComponent(BlurView) : Animated.View;

--- a/src/components/AnimatedComponents/AnimatedImage.tsx
+++ b/src/components/AnimatedComponents/AnimatedImage.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { type ImageStyle, type StyleProp } from 'react-native';
+import { Platform, type ImageStyle, type StyleProp } from 'react-native';
 
 import { type FasterImageProps } from '@candlefinance/faster-image';
 import { useAnimatedProps, type AnimatedStyle } from 'react-native-reanimated';
 
 import { DEFAULT_FASTER_IMAGE_CONFIG } from '@/components/images/ImgixImage';
 import { type SharedOrDerivedValueText } from '@/design-system/components/Text/AnimatedText';
-import { IS_ANDROID } from '@/env';
 import { PIXEL_RATIO } from '@/utils/deviceUtils';
 
 import { AnimatedFasterImage } from './AnimatedFasterImage';
@@ -31,7 +30,7 @@ export const AnimatedImage = ({
   const animatedIconSource = useAnimatedProps<{ source: FasterImageProps['source'] }>(() => ({
     source: {
       ...DEFAULT_FASTER_IMAGE_CONFIG,
-      borderRadius: borderRadius ? (IS_ANDROID ? borderRadius * PIXEL_RATIO : borderRadius) : undefined,
+      borderRadius: borderRadius ? (Platform.OS === 'android' ? borderRadius * PIXEL_RATIO : borderRadius) : undefined,
       url: url.value || '',
     },
   }));

--- a/src/components/AppVersionStamp.tsx
+++ b/src/components/AppVersionStamp.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useState } from 'react';
-import { Pressable } from 'react-native';
+import { Platform, Pressable } from 'react-native';
 
 import { Text } from '@/design-system';
-import { IS_ANDROID, IS_DEV, IS_IOS, IS_STORE_INSTALL } from '@/env';
+import { IS_DEV, IS_STORE_INSTALL } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useAppVersion from '@/hooks/useAppVersion';
 import useTimeout from '@/hooks/useTimeout';
@@ -12,8 +12,8 @@ import Routes from '@/navigation/routesNames';
 const DEBUG_TAP_COUNT = 15;
 
 const StyledButton = styled(Pressable)({
-  paddingTop: IS_IOS ? 32 : 16,
-  paddingBottom: IS_ANDROID ? 32 : 0,
+  paddingTop: Platform.OS === 'ios' ? 32 : 16,
+  paddingBottom: Platform.OS === 'android' ? 32 : 0,
   paddingHorizontal: 40,
   alignItems: 'center',
 });

--- a/src/components/Border.tsx
+++ b/src/components/Border.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { Cover, useColorMode, useForegroundColor } from '@/design-system';
 import { type ForegroundColor } from '@/design-system/color/palettes';
-import { IS_IOS } from '@/env';
 
 export const Border = ({
   borderColor = 'separatorTertiary',
@@ -23,7 +23,7 @@ export const Border = ({
 
   return (
     (isDarkMode || enableInLightMode) &&
-    (IS_IOS || enableOnAndroid) && (
+    (Platform.OS === 'ios' || enableOnAndroid) && (
       <Cover
         style={{
           borderColor: color,

--- a/src/components/DappBrowser/BrowserTab.tsx
+++ b/src/components/DappBrowser/BrowserTab.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useRef, useState, type MutableRefObject } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { Freeze } from 'react-freeze';
 import Animated, { FadeIn, useAnimatedProps, type AnimatedStyle, type DerivedValue, type SharedValue } from 'react-native-reanimated';
@@ -8,7 +8,7 @@ import { type WebViewProps } from 'react-native-webview';
 import type WebView from 'react-native-webview';
 
 import { globalColors, useColorMode } from '@/design-system';
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 import { useBrowserStore, type BrowserState } from '@/state/browser/browserStore';
 import { type BrowserHistoryStore } from '@/state/browserHistory';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -42,7 +42,7 @@ export const BrowserTab = memo(function BrowserTab({ addRecent, setLogo, setTitl
 
   return (
     <WebViewShadows tabId={tabId} zIndexAnimatedStyle={zIndexAnimatedStyle}>
-      <Animated.View style={[styles.webViewContainer, animatedWebViewStyle, IS_IOS ? {} : zIndexAnimatedStyle]}>
+      <Animated.View style={[styles.webViewContainer, animatedWebViewStyle, Platform.OS === 'ios' ? {} : zIndexAnimatedStyle]}>
         <ViewShot options={TAB_SCREENSHOT_FILE_FORMAT} ref={viewShotRef}>
           <Animated.View
             collapsable={false}
@@ -60,7 +60,7 @@ export const BrowserTab = memo(function BrowserTab({ addRecent, setLogo, setTitl
           </Animated.View>
         </ViewShot>
         <TabScreenshotContainer tabId={tabId} />
-        {IS_IOS && <WebViewBorder tabId={tabId} />}
+        {Platform.OS === 'ios' && <WebViewBorder tabId={tabId} />}
         <CloseTabButton tabId={tabId} />
       </Animated.View>
     </WebViewShadows>
@@ -245,20 +245,20 @@ const TabWebViewComponent = (props: WebViewProps, ref: React.Ref<WebView>) => {
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentInset={{ bottom: 0, left: 0, right: 0, top: 0 }}
-      decelerationRate={IS_IOS ? 'normal' : undefined}
+      decelerationRate={Platform.OS === 'ios' ? 'normal' : undefined}
       fraudulentWebsiteWarningEnabled
       injectedJavaScript={SCRIPTS_TO_INJECT}
       mediaPlaybackRequiresUserAction
-      onScroll={IS_IOS ? onScrollWebView : undefined}
-      onTouchEnd={IS_IOS ? onTouchEnd : undefined}
-      onTouchMove={IS_IOS ? onTouchMove : undefined}
-      onTouchStart={IS_IOS ? onTouchStart : undefined}
+      onScroll={Platform.OS === 'ios' ? onScrollWebView : undefined}
+      onTouchEnd={Platform.OS === 'ios' ? onTouchEnd : undefined}
+      onTouchMove={Platform.OS === 'ios' ? onTouchMove : undefined}
+      onTouchStart={Platform.OS === 'ios' ? onTouchStart : undefined}
       originWhitelist={['*']}
       ref={ref}
       renderError={() => <ErrorPage />}
       renderLoading={() => <></>}
       style={styles.webView}
-      userAgent={USER_AGENT[IS_IOS ? 'IOS' : 'ANDROID']}
+      userAgent={USER_AGENT[Platform.OS === 'ios' ? 'IOS' : 'ANDROID']}
       webviewDebuggingEnabled={IS_DEV}
     />
   );
@@ -268,7 +268,7 @@ const TabWebView = memo(React.forwardRef(TabWebViewComponent));
 
 const styles = StyleSheet.create({
   screenshotContainer: {
-    height: IS_IOS ? WEBVIEW_HEIGHT + EXTRA_WEBVIEW_HEIGHT : WEBVIEW_HEIGHT,
+    height: Platform.OS === 'ios' ? WEBVIEW_HEIGHT + EXTRA_WEBVIEW_HEIGHT : WEBVIEW_HEIGHT,
     left: 0,
     position: 'absolute',
     right: 0,
@@ -277,7 +277,7 @@ const styles = StyleSheet.create({
     zIndex: 20000,
   },
   viewShotContainer: {
-    height: IS_IOS ? WEBVIEW_HEIGHT + EXTRA_WEBVIEW_HEIGHT : WEBVIEW_HEIGHT,
+    height: Platform.OS === 'ios' ? WEBVIEW_HEIGHT + EXTRA_WEBVIEW_HEIGHT : WEBVIEW_HEIGHT,
     width: DEVICE_WIDTH,
   },
   webViewContainer: {

--- a/src/components/DappBrowser/CloseTabButton.tsx
+++ b/src/components/DappBrowser/CloseTabButton.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { BlurView } from 'react-native-blur-view';
 import Animated, { interpolate, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 
 import { Box, TextIcon, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import deviceUtils from '@/utils/deviceUtils';
 
 import { TIMING_CONFIGS } from '../animations/animationConfigs';
@@ -110,7 +109,7 @@ export const CloseTabButton = ({ tabId }: { tabId: TabId }) => {
   return (
     <Animated.View style={[styles.containerStyle, containerStyle]}>
       <Box as={Animated.View} position="absolute" style={singleTabStyle}>
-        {IS_IOS ? (
+        {Platform.OS === 'ios' ? (
           <Animated.View style={[styles.closeButtonStyle, closeButtonStyle, { borderRadius: SCALE_ADJUSTED_X_BUTTON_SIZE_SINGLE_TAB / 2 }]}>
             <BlurView
               blurStyle={isDarkMode ? 'chromeMaterialDark' : 'materialLight'}
@@ -144,7 +143,7 @@ export const CloseTabButton = ({ tabId }: { tabId: TabId }) => {
         )}
       </Box>
       <Box as={Animated.View} position="absolute" style={multipleTabsStyle}>
-        {IS_IOS ? (
+        {Platform.OS === 'ios' ? (
           <Animated.View style={[styles.closeButtonStyle, closeButtonStyle, { borderRadius: SCALE_ADJUSTED_X_BUTTON_SIZE / 2 }]}>
             <BlurView
               blurStyle={isDarkMode ? 'materialDark' : 'materialLight'}

--- a/src/components/DappBrowser/DappBrowser.tsx
+++ b/src/components/DappBrowser/DappBrowser.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { GestureDetector } from 'react-native-gesture-handler';
@@ -7,7 +7,6 @@ import Animated, { interpolateColor, runOnJS, useAnimatedReaction, useAnimatedSt
 
 import { Page } from '@/components/layout';
 import { Box, globalColors, useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { useSyncSharedValue } from '@/hooks/reanimated/useSyncSharedValue';
 import { setParams } from '@/navigation/Navigation';
 import type Routes from '@/navigation/routesNames';
@@ -211,7 +210,7 @@ const styles = StyleSheet.create({
   },
   tabViewBackground: {
     height: '100%',
-    paddingTop: IS_ANDROID ? 30 : 0,
+    paddingTop: Platform.OS === 'android' ? 30 : 0,
     position: 'absolute',
     width: '100%',
   },

--- a/src/components/DappBrowser/DappBrowserShadows.tsx
+++ b/src/components/DappBrowser/DappBrowserShadows.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import Animated, { useAnimatedStyle, type AnimatedStyle } from 'react-native-reanimated';
 
 import { clamp } from '@/__swaps__/utils/swaps';
 import { globalColors, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 import { useBrowserContext } from './BrowserContext';
 import { RAINBOW_HOME } from './constants';
@@ -27,7 +26,7 @@ export const BrowserButtonShadows = ({
 }) => {
   const { isDarkMode } = useColorMode();
 
-  if (!IS_IOS || (isDarkMode && hideDarkModeShadows)) return <>{children}</>;
+  if (Platform.OS !== 'ios' || (isDarkMode && hideDarkModeShadows)) return <>{children}</>;
 
   return (
     <View
@@ -125,7 +124,7 @@ export const WebViewShadows = ({
     };
   });
 
-  if (!IS_IOS) return <>{children}</>;
+  if (Platform.OS !== 'ios') return <>{children}</>;
 
   return (
     <Animated.View style={[styles.boxNone, isDarkMode ? {} : styles.outerWebViewShadow, outerShadowOpacityOverride, zIndexAnimatedStyle]}>

--- a/src/components/DappBrowser/Dimensions.ts
+++ b/src/components/DappBrowser/Dimensions.ts
@@ -1,4 +1,5 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
+
 import { BASE_TAB_BAR_HEIGHT } from '@/navigation/constants';
 import { TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -9,10 +10,11 @@ export const SEARCH_BAR_BORDER_RADIUS = 18;
 export const SEARCH_BAR_HEIGHT = 48;
 export const SEARCH_BAR_WIDTH = DEVICE_WIDTH - 72 * 2;
 
-const ADJUSTED_DEVICE_HEIGHT = IS_IOS ? DEVICE_HEIGHT : DEVICE_HEIGHT - safeAreaInsetValues.bottom;
+const ADJUSTED_DEVICE_HEIGHT = Platform.OS === 'ios' ? DEVICE_HEIGHT : DEVICE_HEIGHT - safeAreaInsetValues.bottom;
 
 export const TOP_INSET = Math.max(safeAreaInsetValues.top, 20);
-export const WEBVIEW_HEIGHT = ADJUSTED_DEVICE_HEIGHT - TOP_INSET - (IS_IOS ? TAB_BAR_HEIGHT : BASE_TAB_BAR_HEIGHT) - BOTTOM_BAR_HEIGHT;
+export const WEBVIEW_HEIGHT =
+  ADJUSTED_DEVICE_HEIGHT - TOP_INSET - (Platform.OS === 'ios' ? TAB_BAR_HEIGHT : BASE_TAB_BAR_HEIGHT) - BOTTOM_BAR_HEIGHT;
 export const EXTRA_WEBVIEW_HEIGHT = 62;
 export const COLLAPSED_WEBVIEW_ASPECT_RATIO = 4 / 3;
 export const COLLAPSED_WEBVIEW_HEIGHT_UNSCALED = Math.min(WEBVIEW_HEIGHT, DEVICE_WIDTH * COLLAPSED_WEBVIEW_ASPECT_RATIO);

--- a/src/components/DappBrowser/Homepage.tsx
+++ b/src/components/DappBrowser/Homepage.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import { uniqBy } from 'lodash';
@@ -27,7 +27,7 @@ import {
   useBackgroundColor,
   useColorMode,
 } from '@/design-system';
-import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { type DApp } from '@/graphql/__generated__/metadata';
 import * as i18n from '@/languages';
@@ -54,8 +54,8 @@ const SCROLL_INDICATOR_INSETS = { bottom: 20, top: 36 };
 const LOGOS_PER_ROW = 4;
 const LOGO_SIZE = 64;
 const RAW_LOGO_PADDING = (DEVICE_WIDTH - LOGOS_PER_ROW * LOGO_SIZE - HORIZONTAL_PAGE_INSET * 2) / (LOGOS_PER_ROW - 1);
-const LOGO_PADDING = IS_IOS ? RAW_LOGO_PADDING : Math.floor(RAW_LOGO_PADDING);
-const LOGO_BORDER_RADIUS = IS_ANDROID ? 32 : 16;
+const LOGO_PADDING = Platform.OS === 'ios' ? RAW_LOGO_PADDING : Math.floor(RAW_LOGO_PADDING);
+const LOGO_BORDER_RADIUS = Platform.OS === 'android' ? 32 : 16;
 const LOGO_LABEL_SPILLOVER = 12;
 
 const NUM_CARDS = 2;
@@ -65,7 +65,7 @@ const CARD_HEIGHT = 137;
 const CARD_LOGO_SIZE = 48;
 const RAW_CARD_WIDTH = (DEVICE_WIDTH - HORIZONTAL_PAGE_INSET * 2 - (NUM_CARDS - 1) * CARD_PADDING) / NUM_CARDS;
 
-export const CARD_WIDTH = IS_IOS ? RAW_CARD_WIDTH : Math.floor(RAW_CARD_WIDTH);
+export const CARD_WIDTH = Platform.OS === 'ios' ? RAW_CARD_WIDTH : Math.floor(RAW_CARD_WIDTH);
 
 export const Homepage = ({ tabId }: { tabId: string }) => {
   const { extraWebViewHeight, goToUrl } = useBrowserContext();
@@ -130,7 +130,7 @@ const Trending = ({ goToUrl }: { goToUrl: (url: string) => void }) => {
       <Bleed space="24px">
         <ScrollView
           horizontal
-          decelerationRate={IS_IOS ? 'fast' : undefined}
+          decelerationRate={Platform.OS === 'ios' ? 'fast' : undefined}
           disableIntervalMomentum
           showsHorizontalScrollIndicator={false}
           snapToOffsets={data.dApps.map((_, index) => index * (CARD_WIDTH + CARD_PADDING))}
@@ -432,7 +432,7 @@ const Card = memo(function Card({
                 color="labelSecondary"
                 containerSize={24}
                 size="icon 13px"
-                textStyle={{ opacity: isDarkMode || IS_ANDROID ? 1 : 0.9 }}
+                textStyle={{ opacity: isDarkMode || Platform.OS === 'android' ? 1 : 0.9 }}
                 weight="heavy"
               >
                 􀍠
@@ -455,7 +455,7 @@ const CardBackground = memo(function CardBackgroundOverlay({
   return imageUrl ? (
     <View shouldRasterizeIOS style={styles.cardBackgroundContainer}>
       <ImgixImage enableFasterImage size={CARD_WIDTH} source={{ uri: imageUrl }} style={styles.cardBackgroundImage} />
-      {IS_IOS ? (
+      {Platform.OS === 'ios' ? (
         <>
           <BlurView
             blurIntensity={isDarkMode ? 36 : 64}
@@ -533,14 +533,13 @@ const Logo = memo(function Logo({ onPress, site }: { onPress: (site: FavoritedSi
             width={{ custom: LOGO_SIZE }}
           />
         )}
-
         <Box
           background={site.image ? undefined : 'fillTertiary'}
           borderRadius={LOGO_BORDER_RADIUS}
           height={{ custom: LOGO_SIZE }}
           position={site.image ? 'absolute' : undefined}
           style={[
-            IS_IOS
+            Platform.OS === 'ios'
               ? {
                   borderColor: isDarkMode ? opacity(globalColors.white100, 0.04) : opacity(globalColors.grey100, 0.02),
                   borderWidth: THICK_BORDER_WIDTH,
@@ -553,7 +552,6 @@ const Logo = memo(function Logo({ onPress, site }: { onPress: (site: FavoritedSi
           ]}
           width={{ custom: LOGO_SIZE }}
         />
-
         {!site.image && (
           <Box alignItems="center" height="full" position="absolute" width="full">
             <TextIcon color="labelQuaternary" containerSize={LOGO_SIZE} opacity={isDarkMode ? 0.4 : 0.6} size="icon 28px" weight="black">
@@ -585,7 +583,7 @@ const Logo = memo(function Logo({ onPress, site }: { onPress: (site: FavoritedSi
 
 export const PlaceholderLogo = memo(function PlaceholderLogo() {
   const { isDarkMode } = useColorMode();
-  const borderRadius = IS_ANDROID ? LOGO_BORDER_RADIUS / 2 : LOGO_BORDER_RADIUS;
+  const borderRadius = Platform.OS === 'android' ? LOGO_BORDER_RADIUS / 2 : LOGO_BORDER_RADIUS;
 
   return (
     <View style={{ opacity: isDarkMode ? 0.6 : 0.5, width: LOGO_SIZE }}>

--- a/src/components/DappBrowser/TabViewToolbar.tsx
+++ b/src/components/DappBrowser/TabViewToolbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { BlurView } from 'react-native-blur-view';
 import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated';
@@ -10,7 +11,6 @@ import { Bleed, Box, globalColors, Text, useColorMode, useForegroundColor, type 
 import { type TextColor } from '@/design-system/color/palettes';
 import { type TextWeight } from '@/design-system/components/Text/Text';
 import { type TextSize } from '@/design-system/typography/typeHierarchy';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import { TAB_BAR_HEIGHT } from '@/navigation/SwipeNavigator';
@@ -116,7 +116,7 @@ const BaseButton = ({
 
   const buttonColorIOS = isDarkMode ? fillSecondary : opacity(globalColors.white100, 0.9);
   const buttonColorAndroid = isDarkMode ? globalColors.blueGrey100 : globalColors.white100;
-  const buttonColor = IS_IOS ? buttonColorIOS : buttonColorAndroid;
+  const buttonColor = Platform.OS === 'ios' ? buttonColorIOS : buttonColorAndroid;
 
   return (
     <BrowserButtonShadows lightShadows={lightShadows}>
@@ -144,7 +144,7 @@ const BaseButton = ({
                 {icon}
               </Text>
             )}
-            {IS_IOS && (
+            {Platform.OS === 'ios' && (
               <BlurView
                 blurIntensity={20}
                 blurStyle={isDarkMode ? 'dark' : 'light'}
@@ -167,7 +167,7 @@ const BaseButton = ({
                   borderColor: separatorSecondary,
                   borderCurve: 'continuous',
                   borderRadius: 22,
-                  borderWidth: IS_IOS && isDarkMode ? THICK_BORDER_WIDTH : 0,
+                  borderWidth: Platform.OS === 'ios' && isDarkMode ? THICK_BORDER_WIDTH : 0,
                   overflow: 'hidden',
                   zIndex: -1,
                 },

--- a/src/components/DappBrowser/constants.ts
+++ b/src/components/DappBrowser/constants.ts
@@ -1,8 +1,9 @@
+import { Platform } from 'react-native';
+
 import { type ImageOptions } from '@candlefinance/faster-image';
 import { type CaptureOptions } from 'react-native-view-shot';
 
 import { globalColors } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 export const GOOGLE_SEARCH_URL = 'https://www.google.com/search?q=';
 export const HTTP = 'http://';
@@ -26,7 +27,7 @@ export const TAB_SCREENSHOT_FASTER_IMAGE_CONFIG: Partial<ImageOptions> = {
   // This placeholder avoids an occasional loading spinner flash
   base64Placeholder: BLANK_BASE64_PIXEL,
   cachePolicy: 'memory',
-  resizeMode: IS_IOS ? 'topContain' : 'cover',
+  resizeMode: Platform.OS === 'ios' ? 'topContain' : 'cover',
   showActivityIndicator: false,
   transitionDuration: 0,
 };
@@ -40,4 +41,4 @@ export const HOMEPAGE_BACKGROUND_COLOR_DARK = globalColors.grey100;
 export const HOMEPAGE_BACKGROUND_COLOR_LIGHT = '#F7F7F9';
 
 export const BROWSER_BACKGROUND_COLOR_DARK = HOMEPAGE_BACKGROUND_COLOR_DARK;
-export const BROWSER_BACKGROUND_COLOR_LIGHT = IS_IOS ? HOMEPAGE_BACKGROUND_COLOR_LIGHT : TAB_VIEW_BACKGROUND_COLOR_LIGHT;
+export const BROWSER_BACKGROUND_COLOR_LIGHT = Platform.OS === 'ios' ? HOMEPAGE_BACKGROUND_COLOR_LIGHT : TAB_VIEW_BACKGROUND_COLOR_LIGHT;

--- a/src/components/DappBrowser/control-panel/ControlPanel.tsx
+++ b/src/components/DappBrowser/control-panel/ControlPanel.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import chroma from 'chroma-js';
@@ -36,7 +36,6 @@ import {
   useForegroundColor,
 } from '@/design-system';
 import { type TextColor } from '@/design-system/color/palettes';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { removeFirstEmojiFromString, returnStringFirstEmoji } from '@/helpers/emojiHandler';
 import { greaterThan } from '@/helpers/utilities';
@@ -517,7 +516,7 @@ const HomePanelLogo = memo(function HomePanelLogo() {
       width={{ custom: 44 }}
       height={{ custom: 44 }}
       background="fillTertiary"
-      style={{ borderRadius: IS_ANDROID ? 30 : 12 }}
+      style={{ borderRadius: Platform.OS === 'android' ? 30 : 12 }}
     />
   );
 });
@@ -680,7 +679,7 @@ const ListHeader = memo(function ListHeader({
       <Box style={controlPanelStyles.listHeaderContent}>
         <ButtonPressAnimation
           // eslint-disable-next-line react/jsx-props-no-spreading
-          {...(IS_ANDROID && { wrapperStyle: controlPanelStyles.listHeaderButtonWrapper })}
+          {...(Platform.OS === 'android' && { wrapperStyle: controlPanelStyles.listHeaderButtonWrapper })}
           onPress={goBack}
           scaleTo={0.8}
           style={controlPanelStyles.listHeaderButtonWrapper}
@@ -751,10 +750,10 @@ const ControlPanelMenuItem = memo(function ControlPanelMenuItem({
       // eslint-disable-next-line no-nested-ternary
       backgroundColor: selected ? (isDarkMode ? globalColors.white10 : '#F7F7F9') : 'transparent',
       borderColor: selected ? borderColor : 'transparent',
-      borderWidth: !selected || IS_ANDROID ? 0 : THICK_BORDER_WIDTH,
-      paddingLeft: !selected || IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
-      paddingRight: !selected || IS_ANDROID ? 14 : 14 - THICK_BORDER_WIDTH,
-      paddingVertical: !selected || IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
+      borderWidth: !selected || Platform.OS === 'android' ? 0 : THICK_BORDER_WIDTH,
+      paddingLeft: !selected || Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
+      paddingRight: !selected || Platform.OS === 'android' ? 14 : 14 - THICK_BORDER_WIDTH,
+      paddingVertical: !selected || Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
     };
   });
 
@@ -976,7 +975,7 @@ const ConnectButton = memo(function ControlPanelButton({
   const buttonBackground = useAnimatedStyle(() => {
     return {
       backgroundColor: opacity(buttonColor.value, isDarkMode ? 0.16 : 0.9),
-      borderColor: IS_IOS ? opacity(buttonColor.value, isDarkMode ? 0.08 : 0.3) : undefined,
+      borderColor: Platform.OS === 'ios' ? opacity(buttonColor.value, isDarkMode ? 0.08 : 0.3) : undefined,
     };
   });
   const buttonIconStyle = useAnimatedStyle(() => {
@@ -1009,7 +1008,7 @@ const ConnectButton = memo(function ControlPanelButton({
         style={[controlPanelStyles.buttonContainer]}
         testID="connect-button"
       >
-        <Box paddingHorizontal={IS_IOS ? '16px' : undefined} paddingVertical={IS_IOS ? '10px' : undefined}>
+        <Box paddingHorizontal={Platform.OS === 'ios' ? '16px' : undefined} paddingVertical={Platform.OS === 'ios' ? '10px' : undefined}>
           <Stack alignHorizontal="center" space="10px">
             <Box as={Animated.View} style={[controlPanelStyles.button, controlPanelStyles.connectButton, buttonBackground]}>
               <Bleed space="16px">
@@ -1048,7 +1047,7 @@ function Panel({ children, height }: { children?: React.ReactNode; height?: numb
       ]}
     >
       {children}
-      {IS_IOS && isDarkMode && (
+      {Platform.OS === 'ios' && isDarkMode && (
         <Box style={controlPanelStyles.panelBorderContainer}>
           <Box style={[controlPanelStyles.panelBorder, { borderColor: separatorSecondary }]} />
         </Box>
@@ -1070,7 +1069,7 @@ const controlPanelStyles = StyleSheet.create({
     justifyContent: 'center',
   },
   connectButton: {
-    borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
+    borderWidth: Platform.OS === 'ios' ? THICK_BORDER_WIDTH : 0,
   },
   connectButtonContainer: {
     alignItems: 'center',
@@ -1163,20 +1162,20 @@ const controlPanelStyles = StyleSheet.create({
     alignItems: 'center',
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: IS_ANDROID ? 0 : THICK_BORDER_WIDTH,
+    borderWidth: Platform.OS === 'android' ? 0 : THICK_BORDER_WIDTH,
     height: 60,
     justifyContent: 'center',
     overflow: 'hidden',
-    paddingLeft: IS_ANDROID ? 12 : 12 - THICK_BORDER_WIDTH,
-    paddingRight: IS_ANDROID ? 16 : 16 - THICK_BORDER_WIDTH,
-    paddingVertical: IS_ANDROID ? 12 : 12 - THICK_BORDER_WIDTH,
+    paddingLeft: Platform.OS === 'android' ? 12 : 12 - THICK_BORDER_WIDTH,
+    paddingRight: Platform.OS === 'android' ? 16 : 16 - THICK_BORDER_WIDTH,
+    paddingVertical: Platform.OS === 'android' ? 12 : 12 - THICK_BORDER_WIDTH,
     width: '100%',
   },
   menuItemSelected: {
-    borderWidth: IS_ANDROID ? 0 : THICK_BORDER_WIDTH,
-    paddingLeft: IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
-    paddingRight: IS_ANDROID ? 14 : 14 - THICK_BORDER_WIDTH,
-    paddingVertical: IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
+    borderWidth: Platform.OS === 'android' ? 0 : THICK_BORDER_WIDTH,
+    paddingLeft: Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
+    paddingRight: Platform.OS === 'android' ? 14 : 14 - THICK_BORDER_WIDTH,
+    paddingVertical: Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
   },
   menuItemSelectedDark: {
     backgroundColor: globalColors.white10,
@@ -1185,7 +1184,7 @@ const controlPanelStyles = StyleSheet.create({
     backgroundColor: '#F7F7F9',
   },
   panelContainer: {
-    bottom: Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30),
+    bottom: Math.max(safeAreaInsetValues.bottom + 5, Platform.OS === 'ios' ? 8 : 30),
     pointerEvents: 'box-none',
     position: 'absolute',
     zIndex: 30000,

--- a/src/components/DappBrowser/hooks/useAnimatedTab.ts
+++ b/src/components/DappBrowser/hooks/useAnimatedTab.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import {
   convertToRGBA,
   interpolate,
@@ -12,7 +14,6 @@ import {
 
 import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { globalColors, useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { useStableValue } from '@/hooks/useStableValue';
 import { useBrowserStore } from '@/state/browser/browserStore';
 
@@ -135,7 +136,7 @@ export function useAnimatedTab({ tabId }: { tabId: string }) {
 
     const backgroundColor = isOnHomepage ? homepageBackgroundColor : safeBackgroundColor.value;
 
-    if (IS_ANDROID) return { backgroundColor };
+    if (Platform.OS === 'android') return { backgroundColor };
 
     const { isFullSizeTab } = getTabInfo({
       animatedActiveTabIndex: animatedActiveTabIndex.value,

--- a/src/components/DappBrowser/hooks/useBrowserScrollView.ts
+++ b/src/components/DappBrowser/hooks/useBrowserScrollView.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { Gesture } from 'react-native-gesture-handler';
 import {
@@ -13,7 +14,6 @@ import {
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { useStableValue } from '@/hooks/useStableValue';
 import { useBrowserStore } from '@/state/browser/browserStore';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -59,7 +59,7 @@ export function useBrowserScrollView() {
   const scrollViewHeight = useDerivedValue(() => {
     const numberOfTabs = _WORKLET ? currentlyOpenTabIds.value.length : initialNumberOfTabs;
     const height = Math.max(
-      Math.ceil(numberOfTabs / 2) * TAB_VIEW_ROW_HEIGHT + safeAreaInsetValues.bottom + 165 + 28 + (IS_ANDROID ? 35 : 0),
+      Math.ceil(numberOfTabs / 2) * TAB_VIEW_ROW_HEIGHT + safeAreaInsetValues.bottom + 165 + 28 + (Platform.OS === 'android' ? 35 : 0),
       DEVICE_HEIGHT
     );
     return withSpring(height, SPRING_CONFIGS.slowSpring);
@@ -187,7 +187,7 @@ export function useBrowserScrollView() {
 
             // Handle iOS scroll bounce
             if (gestureManagerState.value === 'pending') {
-              if (IS_IOS) {
+              if (Platform.OS === 'ios') {
                 if (scrollViewOffset.value < 0) {
                   // Snap back to top
                   dispatchCommand(scrollViewRef, 'scrollTo', [0, 0, true]);

--- a/src/components/DappBrowser/hooks/useScreenshotAndScrollTriggers.ts
+++ b/src/components/DappBrowser/hooks/useScreenshotAndScrollTriggers.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { dispatchCommand, runOnJS, runOnUI, useAnimatedReaction } from 'react-native-reanimated';
 
-import { IS_IOS } from '@/env';
 import { logger, RainbowError } from '@/logger';
 
 import { useBrowserContext } from '../BrowserContext';
@@ -89,7 +89,7 @@ export function useScreenshotAndScrollTriggers() {
 
       const didBeginSwitchingTabs = current.tabSwitchGestureX !== 0 && previous.tabSwitchGestureX === 0;
       const didFinishSwitchingTabs =
-        IS_IOS &&
+        Platform.OS === 'ios' &&
         current.tabSwitchGestureX === 0 &&
         previous.tabSwitchGestureX !== 0 &&
         !tabViewVisible.value &&

--- a/src/components/DappBrowser/hooks/useWebViewHandlers.ts
+++ b/src/components/DappBrowser/hooks/useWebViewHandlers.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, type MutableRefObject } from 'react';
 import type React from 'react';
+import { Platform } from 'react-native';
 
 import { runOnUI, withTiming, type SharedValue } from 'react-native-reanimated';
 import { type WebViewMessageEvent } from 'react-native-webview';
@@ -8,7 +9,6 @@ import { type ShouldStartLoadRequest, type WebViewNavigation } from 'react-nativ
 
 import { appMessenger, type Messenger } from '@/browserMessaging/AppMessenger';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
-import { IS_IOS } from '@/env';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { useBrowserStore, type BrowserState } from '@/state/browser/browserStore';
@@ -75,7 +75,7 @@ export function useWebViewHandlers({
         const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
         if (!parsedData || (!parsedData.topic && !parsedData.payload)) return;
 
-        if (IS_IOS && parsedData.topic === 'injectedUnderPageBackgroundColor') {
+        if (Platform.OS === 'ios' && parsedData.topic === 'injectedUnderPageBackgroundColor') {
           const { underPageBackgroundColor } = parsedData.payload;
 
           if (underPageBackgroundColor && typeof underPageBackgroundColor === 'string') {
@@ -84,7 +84,7 @@ export function useWebViewHandlers({
         } else if (parsedData.topic === 'websiteMetadata') {
           const { bgColor, logoUrl, pageTitle } = parsedData.payload;
 
-          if (!IS_IOS && bgColor && typeof bgColor === 'string') {
+          if (Platform.OS !== 'ios' && bgColor && typeof bgColor === 'string') {
             backgroundColor.value = bgColor;
           }
 

--- a/src/components/DappBrowser/scripts.ts
+++ b/src/components/DappBrowser/scripts.ts
@@ -1,4 +1,4 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
 
 export const freezeWebsite = `(function() {
     // Pause media elements
@@ -57,7 +57,7 @@ export const unfreezeWebsite = `(function() {
 const getWebsiteMetadata = `
   requestAnimationFrame(() => {
     ${
-      IS_IOS
+      Platform.OS === 'ios'
         ? `
     function getActualBackgroundColor() {
       return undefined;

--- a/src/components/DappBrowser/search-input/SearchInput.tsx
+++ b/src/components/DappBrowser/search-input/SearchInput.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, View, type NativeSyntheticEvent, type TextInput, type TextInputChangeEventData } from 'react-native';
+import { Platform, StyleSheet, View, type NativeSyntheticEvent, type TextInput, type TextInputChangeEventData } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import { BlurView } from 'react-native-blur-view';
@@ -24,7 +24,6 @@ import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animatio
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { AnimatedText, globalColors, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { showActionSheetWithOptions } from '@/framework/ui/utils/actionsheet';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStableValue } from '@/hooks/useStableValue';
@@ -202,7 +201,7 @@ const ThreeDotMenu = function ThreeDotMenu({ formattedUrlValue }: { formattedUrl
 
   return (
     <>
-      {IS_IOS ? (
+      {Platform.OS === 'ios' ? (
         <View style={styles.searchBarContextMenuContainer}>
           <ContextMenuButton menuConfig={menuConfig} onPressMenuItem={onPressMenuItem} style={styles.searchBarContextMenu}>
             <ToolbarIcon
@@ -363,7 +362,7 @@ const AddressBar = memo(function AddressBar({
   const separatorSecondary = useForegroundColor('separatorSecondary');
   const buttonColorIOS = isDarkMode ? fillSecondary : opacity(globalColors.white100, 0.9);
   const buttonColorAndroid = isDarkMode ? globalColors.blueGrey100 : globalColors.white100;
-  const buttonColor = IS_IOS ? buttonColorIOS : buttonColorAndroid;
+  const buttonColor = Platform.OS === 'ios' ? buttonColorIOS : buttonColorAndroid;
 
   const animatedButtonWrapperStyle = useAnimatedStyle(() => ({
     pointerEvents: _WORKLET && isFocused.value ? 'none' : 'auto',
@@ -444,13 +443,13 @@ const AddressBar = memo(function AddressBar({
               {formattedUrlValue}
             </AnimatedText>
           </Animated.View>
-          {IS_IOS && <BlurView blurIntensity={20} blurStyle={isDarkMode ? 'dark' : 'light'} style={styles.blurViewStyle} />}
+          {Platform.OS === 'ios' && <BlurView blurIntensity={20} blurStyle={isDarkMode ? 'dark' : 'light'} style={styles.blurViewStyle} />}
           <Animated.View
             style={[
               {
                 backgroundColor: buttonColor,
                 borderColor: separatorSecondary,
-                borderWidth: IS_IOS && isDarkMode ? THICK_BORDER_WIDTH : 0,
+                borderWidth: Platform.OS === 'ios' && isDarkMode ? THICK_BORDER_WIDTH : 0,
               },
               styles.inputBorderStyle,
               pointerEventsStyle,

--- a/src/components/DappBrowser/search-input/TabButton.tsx
+++ b/src/components/DappBrowser/search-input/TabButton.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, type TextInput } from 'react-native';
+import { Platform, StyleSheet, type TextInput } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { BlurView } from 'react-native-blur-view';
@@ -9,7 +9,6 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { AnimatedText, Bleed, Box, globalColors, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { showActionSheetWithOptions } from '@/framework/ui/utils/actionsheet';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useSharedValueState } from '@/hooks/reanimated/useSharedValueState';
@@ -53,7 +52,7 @@ export const TabButton = React.memo(function TabButton({
 
   const buttonColorIOS = isDarkMode ? fillSecondary : opacity(globalColors.white100, 0.9);
   const buttonColorAndroid = isDarkMode ? globalColors.blueGrey100 : globalColors.white100;
-  const buttonColor = IS_IOS ? buttonColorIOS : buttonColorAndroid;
+  const buttonColor = Platform.OS === 'ios' ? buttonColorIOS : buttonColorAndroid;
   const label = useForegroundColor('label');
   const labelSecondary = useForegroundColor('labelSecondary');
 
@@ -183,11 +182,11 @@ export const TabButton = React.memo(function TabButton({
     <BrowserButtonShadows borderRadius={TAB_BUTTON_SIZE / 2} hideDarkModeShadows>
       <Bleed space="8px">
         <ConditionalWrap
-          condition={IS_IOS}
+          condition={Platform.OS === 'ios'}
           wrap={children => (
             <ContextMenuButton
-              enableContextMenu={IS_IOS ? !isFocusedState : undefined}
-              isMenuPrimaryAction={IS_IOS ? isFocusedState : undefined}
+              enableContextMenu={Platform.OS === 'ios' ? !isFocusedState : undefined}
+              isMenuPrimaryAction={Platform.OS === 'ios' ? isFocusedState : undefined}
               menuConfig={longPressMenuConfig}
               onPressMenuItem={onPressMenuItem}
             >
@@ -196,7 +195,7 @@ export const TabButton = React.memo(function TabButton({
           )}
         >
           <GestureHandlerButton
-            onLongPressJS={IS_IOS || isFocusedState ? undefined : onLongPressAndroid}
+            onLongPressJS={Platform.OS === 'ios' || isFocusedState ? undefined : onLongPressAndroid}
             onPressWorklet={onPressWorklet}
             style={{ padding: 8 }}
           >
@@ -224,14 +223,14 @@ const BlurLayer = memo(function BlurLayer({ buttonColor }: { buttonColor: string
 
   return (
     <>
-      {IS_IOS && <BlurView blurIntensity={20} blurStyle={isDarkMode ? 'dark' : 'light'} style={styles.blurLayer} />}
+      {Platform.OS === 'ios' && <BlurView blurIntensity={20} blurStyle={isDarkMode ? 'dark' : 'light'} style={styles.blurLayer} />}
       <Box
         style={[
           styles.blurTint,
           {
             backgroundColor: buttonColor,
             borderColor: separatorSecondary,
-            borderWidth: IS_IOS && isDarkMode ? THICK_BORDER_WIDTH : 0,
+            borderWidth: Platform.OS === 'ios' && isDarkMode ? THICK_BORDER_WIDTH : 0,
           },
         ]}
       />

--- a/src/components/DappBrowser/utils/layoutUtils.ts
+++ b/src/components/DappBrowser/utils/layoutUtils.ts
@@ -1,4 +1,5 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
+
 import { DEVICE_HEIGHT as SCREEN_HEIGHT } from '@/utils/deviceUtils';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
@@ -18,7 +19,7 @@ export function calculateScrollPositionToCenterTab(index: number, numberOfOpenTa
   'worklet';
 
   const scrollViewHeight =
-    Math.ceil(numberOfOpenTabs / 2) * TAB_VIEW_ROW_HEIGHT + safeAreaInsetValues.bottom + 165 + 28 + (IS_IOS ? 0 : 35);
+    Math.ceil(numberOfOpenTabs / 2) * TAB_VIEW_ROW_HEIGHT + safeAreaInsetValues.bottom + 165 + 28 + (Platform.OS === 'ios' ? 0 : 35);
 
   if (scrollViewHeight <= SCREEN_HEIGHT) {
     // No need to scroll if all tabs fit on the screen

--- a/src/components/Discover/TrendingTokens.tsx
+++ b/src/components/Discover/TrendingTokens.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, type JSX, type ReactNode } from 'react';
-import { FlatList, View } from 'react-native';
+import { FlatList, Platform, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { useSharedValue, type SharedValue } from 'react-native-reanimated';
@@ -13,7 +13,6 @@ import Skeleton, { FakeAvatar, FakeText } from '@/components/skeleton/Skeleton';
 import { globalColors, IconContainer, Text, TextIcon, useBackgroundColor, useColorMode } from '@/design-system';
 import { useForegroundColor } from '@/design-system/color/useForegroundColor';
 import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { SortDirection, Timeframe, TrendingSort } from '@/graphql/__generated__/arc';
 import { formatCurrency, formatNumber } from '@/helpers/strings';
@@ -91,7 +90,7 @@ function FilterButton({
           <TextIcon
             color={{ custom: iconColor || defaultIconColor }}
             size="icon 13px"
-            textStyle={IS_IOS ? undefined : { marginTop: -2 }}
+            textStyle={Platform.OS === 'ios' ? undefined : { marginTop: -2 }}
             weight="heavy"
             width={16}
           >
@@ -232,7 +231,7 @@ function CategoryFilterButton({
           <TextIcon
             color={{ custom: typeof iconColor === 'string' ? iconColor : selected ? iconColor.selected : iconColor.default }}
             size="icon 13px"
-            textStyle={{ marginTop: IS_IOS ? -3.5 : -2 }}
+            textStyle={{ marginTop: Platform.OS === 'ios' ? -3.5 : -2 }}
             weight="heavy"
             width={iconWidth}
           >
@@ -422,7 +421,7 @@ function TrendingTokenRow({ token, currency }: { token: TrendingToken; currency:
             <View style={{ gap: 12 }}>
               <View
                 style={{
-                  alignItems: IS_IOS ? 'baseline' : 'flex-end',
+                  alignItems: Platform.OS === 'ios' ? 'baseline' : 'flex-end',
                   flexDirection: 'row',
                   gap: 6,
                   height: 12,
@@ -446,7 +445,7 @@ function TrendingTokenRow({ token, currency }: { token: TrendingToken; currency:
                   ellipsizeMode="middle"
                   size="11pt"
                   style={{
-                    bottom: IS_IOS ? 0 : -0.2,
+                    bottom: Platform.OS === 'ios' ? 0 : -0.2,
                     maxWidth: symbolWidth,
                   }}
                   weight="bold"
@@ -668,7 +667,7 @@ function SortFilter() {
           <TextIcon
             color={{ custom: iconColor }}
             size="icon 13px"
-            textStyle={IS_IOS ? undefined : { marginTop: -2 }}
+            textStyle={Platform.OS === 'ios' ? undefined : { marginTop: -2 }}
             weight="heavy"
             width={20}
           >

--- a/src/components/ExchangeAssetList.tsx
+++ b/src/components/ExchangeAssetList.tsx
@@ -9,7 +9,7 @@ import React, {
   type MutableRefObject,
   type ReactElement,
 } from 'react';
-import { InteractionManager, Keyboard, SectionList, StyleSheet, type SectionListData } from 'react-native';
+import { InteractionManager, Keyboard, Platform, SectionList, StyleSheet, type SectionListData } from 'react-native';
 
 import { useIsFocused } from '@react-navigation/native';
 import ConditionalWrap from 'conditional-wrap';
@@ -23,7 +23,6 @@ import { GradientText } from '@/components/text';
 import { CopyToast, ToastPositionContainer } from '@/components/toasts';
 import { Box, globalColors, Text, useColorMode } from '@/design-system';
 import type { SwappableAsset } from '@/entities/tokens';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import useAccountSettings from '@/hooks/useAccountSettings';
 import useAndroidScrollViewGestureHandler from '@/hooks/useAndroidScrollViewGestureHandler';
 import usePrevious from '@/hooks/usePrevious';
@@ -232,7 +231,7 @@ const ExchangeAssetList: ForwardRefRenderFunction<SectionList, ExchangeAssetList
               const newValue = !prev?.[address];
               toggleFavorite(address);
               if (newValue) {
-                IS_IOS && onNewEmoji();
+                Platform.OS === 'ios' && onNewEmoji();
                 triggerHaptics('notificationSuccess');
               } else {
                 triggerHaptics('selection');
@@ -278,7 +277,7 @@ const ExchangeAssetList: ForwardRefRenderFunction<SectionList, ExchangeAssetList
           keyboardShouldPersistTaps="always"
           keyboardDismissMode={keyboardDismissMode}
           onLayout={onLayout}
-          onScroll={IS_ANDROID ? onScroll : undefined}
+          onScroll={Platform.OS === 'android' ? onScroll : undefined}
           ref={sectionListRef}
           renderItem={isExchangeList ? renderExchangeItem : renderItem}
           renderSectionHeader={renderSectionHeader}
@@ -288,7 +287,6 @@ const ExchangeAssetList: ForwardRefRenderFunction<SectionList, ExchangeAssetList
           scrollIndicatorInsets={scrollIndicatorInsets}
         />
       </Box>
-
       <ToastPositionContainer>
         <CopyToast copiedText={copiedText} copyCount={copyCount} />
       </ToastPositionContainer>

--- a/src/components/ExchangeTokenRow.tsx
+++ b/src/components/ExchangeTokenRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import isEqual from 'react-fast-compare';
 
@@ -9,7 +9,6 @@ import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { FloatingEmojis } from '@/components/floating-emojis';
 import { Box, Column, Columns, Inline, Stack, Text } from '@/design-system';
 import type { ParsedAddressAsset } from '@/entities/tokens';
-import { IS_IOS } from '@/env';
 import { isNativeAsset } from '@/handlers/assets';
 import useAsset from '@/hooks/useAsset';
 import { ChainId } from '@/state/backendNetworks/types';
@@ -100,7 +99,7 @@ export default React.memo(function ExchangeTokenRow({
             <Inline alignVertical="center" space="12px">
               {isInfoButtonVisible && <Info contextMenuProps={contextMenuProps} showFavoriteButton={showFavoriteButton} theme={theme} />}
               {showFavoriteButton &&
-                (IS_IOS ? (
+                (Platform.OS === 'ios' ? (
                   <FloatingEmojis
                     centerVertically
                     disableHorizontalMovement

--- a/src/components/FeesGweiInput.tsx
+++ b/src/components/FeesGweiInput.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { type TextInput } from 'react-native';
+import { Platform, type TextInput } from 'react-native';
 
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import GweiInputPill from '@/components/GweiInputPill';
 import { Box, Text } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { delay } from '@/helpers/utilities';
 import usePrevious from '@/hooks/usePrevious';
 import { colors } from '@/styles';
@@ -53,7 +52,7 @@ const GweiStepButton = ({ buttonColor, onLongPress, onLongPressEnded, onPress, t
       useLateHaptic={false}
       padding="4px"
       margin="-4px"
-      marginTop={IS_ANDROID ? '-2px' : undefined}
+      marginTop={Platform.OS === 'android' ? '-2px' : undefined}
     >
       <Text size="icon 16px" color={{ custom: buttonColor || colors.appleBlue }} weight="heavy">
         {type === 'plus' ? '􀁍' : '􀁏'}

--- a/src/components/GweiInputPill.tsx
+++ b/src/components/GweiInputPill.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { type TextInput } from 'react-native';
+import { Platform, type TextInput } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 // @ts-expect-error - no declaration file
@@ -7,7 +7,7 @@ import TextInputMask from 'react-native-text-input-mask';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Inline, Inset, Text } from '@/design-system';
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { buildTextStyles, padding } from '@/styles';
@@ -33,7 +33,7 @@ const GweiNumberInput = styled(TextInputMask).attrs(
     keyboardType: 'decimal-pad',
     // On android using letterSpacing causes wrong text input width
     // which causes numbers to be cut off a little bit.
-    letterSpacing: IS_ANDROID ? null : 'rounded',
+    letterSpacing: Platform.OS === 'android' ? null : 'rounded',
     size: 'lmedium',
     textAlign: 'left',
     timing: 'linear',
@@ -47,7 +47,7 @@ const GweiNumberInput = styled(TextInputMask).attrs(
   props => ({
     // @ts-expect-error
     ...buildTextStyles.object(props),
-    ...(IS_ANDROID ? padding.object(0, 0, 0, 0) : {}),
+    ...(Platform.OS === 'android' ? padding.object(0, 0, 0, 0) : {}),
   })
 );
 

--- a/src/components/MobileWalletProtocolListener.tsx
+++ b/src/components/MobileWalletProtocolListener.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
 
 import {
   addDiagnosticLogListener,
@@ -7,7 +8,7 @@ import {
   useMobileWalletProtocolHost,
 } from '@coinbase/mobile-wallet-protocol-host';
 
-import { IS_ANDROID, IS_DEV } from '@/env';
+import { IS_DEV } from '@/env';
 import { logger, RainbowError } from '@/logger';
 import { handleMobileWalletProtocolRequest } from '@/utils/requestNavigationHandlers';
 
@@ -78,7 +79,7 @@ export const MobileWalletProtocolListener = () => {
   }, []);
 
   useEffect(() => {
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       (async function handleAndroidIntent() {
         const intentUrl = await getAndroidIntentUrl();
         if (intentUrl) {

--- a/src/components/PanelSheet/PanelSheet.tsx
+++ b/src/components/PanelSheet/PanelSheet.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo, type ComponentProps } from 'react';
-import { StyleSheet, TouchableWithoutFeedback, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, TouchableWithoutFeedback, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
@@ -7,7 +7,6 @@ import Animated, { type AnimatedStyle } from 'react-native-reanimated';
 
 import { SheetHandleFixedToTop } from '@/components/sheet';
 import { Box, globalColors, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useNavigation } from '@/navigation/Navigation';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
@@ -26,7 +25,7 @@ export const TapToDismiss = memo(function TapToDismiss() {
 
 export const PANEL_BACKGROUND_DARK = '#191A1C';
 export const PANEL_BACKGROUND_LIGHT = globalColors.white100;
-export const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30);
+export const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, Platform.OS === 'ios' ? 8 : 30);
 export const PANEL_INSET = 8;
 export const PANEL_WIDTH = DEVICE_WIDTH - PANEL_INSET * 2;
 

--- a/src/components/SmoothPager/ListPanel.tsx
+++ b/src/components/SmoothPager/ListPanel.tsx
@@ -1,5 +1,14 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { ScrollView, StyleSheet, TouchableWithoutFeedback, View, type ScrollViewProps, type StyleProp, type ViewStyle } from 'react-native';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+  type ScrollViewProps,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 
 import Animated, { useAnimatedStyle, type AnimatedStyle, type SharedValue } from 'react-native-reanimated';
 
@@ -18,7 +27,6 @@ import {
   useForegroundColor,
 } from '@/design-system';
 import { type TextColor } from '@/design-system/color/palettes';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { returnStringFirstEmoji } from '@/helpers/emojiHandler';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
@@ -45,7 +53,7 @@ const PANEL_INSET = 8;
 export const PANEL_WIDTH = DEVICE_WIDTH - PANEL_INSET * 2;
 export const PANEL_COLOR_DARK = globalColors.white10;
 export const PANEL_COLOR_LIGHT = '#F7F7F9';
-export const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30);
+export const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, Platform.OS === 'ios' ? 8 : 30);
 
 const PANEL_BORDER_RADIUS = 42;
 const LIST_SCROLL_INDICATOR_BOTTOM_INSET = { bottom: PANEL_BORDER_RADIUS };
@@ -220,10 +228,10 @@ export const ControlPanelMenuItem = memo(function ControlPanelMenuItem({
       // eslint-disable-next-line no-nested-ternary
       backgroundColor: selected ? (isDarkMode ? globalColors.white10 : '#F7F7F9') : 'transparent',
       borderColor: selected ? borderColor : 'transparent',
-      borderWidth: !selected || IS_ANDROID ? 0 : THICK_BORDER_WIDTH,
-      paddingLeft: !selected || IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
-      paddingRight: !selected || IS_ANDROID ? 14 : 14 - THICK_BORDER_WIDTH,
-      paddingVertical: !selected || IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
+      borderWidth: !selected || Platform.OS === 'android' ? 0 : THICK_BORDER_WIDTH,
+      paddingLeft: !selected || Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
+      paddingRight: !selected || Platform.OS === 'android' ? 14 : 14 - THICK_BORDER_WIDTH,
+      paddingVertical: !selected || Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
     };
   });
 
@@ -442,20 +450,20 @@ export const controlPanelStyles = StyleSheet.create({
     alignItems: 'center',
     borderCurve: 'continuous',
     borderRadius: 30,
-    borderWidth: IS_ANDROID ? 0 : THICK_BORDER_WIDTH,
+    borderWidth: Platform.OS === 'android' ? 0 : THICK_BORDER_WIDTH,
     height: 60,
     justifyContent: 'center',
     overflow: 'hidden',
-    paddingLeft: IS_ANDROID ? 12 : 12 - THICK_BORDER_WIDTH,
-    paddingRight: IS_ANDROID ? 16 : 16 - THICK_BORDER_WIDTH,
-    paddingVertical: IS_ANDROID ? 12 : 12 - THICK_BORDER_WIDTH,
+    paddingLeft: Platform.OS === 'android' ? 12 : 12 - THICK_BORDER_WIDTH,
+    paddingRight: Platform.OS === 'android' ? 16 : 16 - THICK_BORDER_WIDTH,
+    paddingVertical: Platform.OS === 'android' ? 12 : 12 - THICK_BORDER_WIDTH,
     width: '100%',
   },
   menuItemSelected: {
-    borderWidth: IS_ANDROID ? 0 : THICK_BORDER_WIDTH,
-    paddingLeft: IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
-    paddingRight: IS_ANDROID ? 14 : 14 - THICK_BORDER_WIDTH,
-    paddingVertical: IS_ANDROID ? 10 : 10 - THICK_BORDER_WIDTH,
+    borderWidth: Platform.OS === 'android' ? 0 : THICK_BORDER_WIDTH,
+    paddingLeft: Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
+    paddingRight: Platform.OS === 'android' ? 14 : 14 - THICK_BORDER_WIDTH,
+    paddingVertical: Platform.OS === 'android' ? 10 : 10 - THICK_BORDER_WIDTH,
   },
   menuItemSelectedDark: {
     backgroundColor: globalColors.white10,

--- a/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/FastComponents/FastCurrencySelectionRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text as RNText, StyleSheet, View } from 'react-native';
+import { Platform, Text as RNText, StyleSheet, View } from 'react-native';
 
 import isEqual from 'react-fast-compare';
 import RadialGradient from 'react-native-radial-gradient';
@@ -7,7 +7,7 @@ import RadialGradient from 'react-native-radial-gradient';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Text, TextIcon } from '@/design-system';
-import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isNativeAsset } from '@/handlers/assets';
 import { ChainId } from '@/state/backendNetworks/types';
@@ -160,7 +160,7 @@ export default React.memo(function FastCurrencySelectionRow({
         <View style={sx.fav}>
           {isInfoButtonVisible && <Info contextMenuProps={contextMenuProps} showFavoriteButton={canShowFavoriteButton} theme={theme} />}
           {canShowFavoriteButton &&
-            (IS_IOS ? (
+            (Platform.OS === 'ios' ? (
               <FloatingEmojis
                 centerVertically
                 disableHorizontalMovement
@@ -235,7 +235,7 @@ const sx = StyleSheet.create({
     overflow: 'hidden',
   },
   infoIcon: {
-    paddingTop: IS_ANDROID ? 2 : 1,
+    paddingTop: Platform.OS === 'android' ? 2 : 1,
     paddingLeft: StyleSheet.hairlineWidth * 2,
   },
   info: {
@@ -251,7 +251,7 @@ const sx = StyleSheet.create({
   name: {
     fontSize: getFontSize(fonts.size.lmedium),
     letterSpacing: 0.5,
-    lineHeight: IS_IOS ? 16 : 17,
+    lineHeight: Platform.OS === 'ios' ? 16 : 17,
     ...fontWithWidth(fonts.weight.semibold),
   },
   nameWithBalances: {
@@ -276,13 +276,13 @@ const sx = StyleSheet.create({
     color: colors.yellowFavorite,
   },
   starIcon: {
-    paddingTop: IS_IOS ? 1 : 3,
+    paddingTop: Platform.OS === 'ios' ? 1 : 3,
     paddingLeft: StyleSheet.hairlineWidth * 2,
   },
   symbol: {
     fontSize: getFontSize(fonts.size.smedium),
     letterSpacing: 0.5,
-    lineHeight: IS_IOS ? 13.5 : 16,
+    lineHeight: Platform.OS === 'ios' ? 13.5 : 16,
     paddingTop: 5.5,
     ...fontWithWidth(fonts.weight.medium),
   },

--- a/src/components/asset-list/RecyclerAssetList2/cards/RnbwFeatureCard.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/cards/RnbwFeatureCard.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { Image, StyleSheet, View, type GestureResponderEvent } from 'react-native';
+import { Image, Platform, StyleSheet, View, type GestureResponderEvent } from 'react-native';
 
 import { Blur, Canvas, LinearGradient, RoundedRect } from '@shopify/react-native-skia';
 import { BlurView } from 'react-native-blur-view';
@@ -10,7 +10,6 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { RNBW_MEMBERSHIP } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import { Box, globalColors, Inline, Text, TextIcon, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { useRnbwFeatureCard } from '@/features/rnbw-rewards/hooks/useRnbwFeatureCard';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
@@ -73,9 +72,9 @@ export const RnbwFeatureCard = memo(function RnbwFeatureCard() {
             </Box>
           </Box>
         </View>
-        {IS_IOS && <DismissButton />}
+        {Platform.OS === 'ios' && <DismissButton />}
       </ButtonPressAnimation>
-      {!IS_IOS && <DismissButton />}
+      {Platform.OS !== 'ios' && <DismissButton />}
     </View>
   );
 });

--- a/src/components/asset-list/RecyclerAssetList2/core/ExternalScrollView.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/ExternalScrollView.tsx
@@ -1,12 +1,11 @@
 import React, { useContext, useImperativeHandle } from 'react';
-import { Animated as RNAnimated, type ScrollViewProps, type ViewStyle } from 'react-native';
+import { Platform, Animated as RNAnimated, type ScrollViewProps, type ViewStyle } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type ScrollViewDefaultProps } from 'recyclerlistview/dist/reactnative/core/scrollcomponent/BaseScrollView';
 import type BaseScrollView from 'recyclerlistview/dist/reactnative/core/scrollcomponent/BaseScrollView';
 import { useMemoOne } from 'use-memo-one';
 
-import { IS_ANDROID } from '@/env';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
 import { useRecyclerAssetListPosition } from './Contexts';
@@ -43,7 +42,11 @@ const ExternalScrollViewWithRef = React.forwardRef<BaseScrollView, ScrollViewDef
     return (
       <RNAnimated.ScrollView
         {...(rest as ScrollViewProps)}
-        contentContainerStyle={[extraPadding, rest.contentContainerStyle, { paddingTop: IS_ANDROID ? insets.top - 24 : insets.top }]}
+        contentContainerStyle={[
+          extraPadding,
+          rest.contentContainerStyle,
+          { paddingTop: Platform.OS === 'android' ? insets.top - 24 : insets.top },
+        ]}
         onScroll={event}
         // @ts-expect-error possibly undefined
         ref={scrollViewRef}

--- a/src/components/asset-list/RecyclerAssetList2/core/ViewDimensions.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/ViewDimensions.tsx
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { AssetListHeaderHeight } from '@/components/asset-list/AssetListHeader';
 import { AssetListItemSkeletonHeight } from '@/components/asset-list/AssetListItemSkeleton';
 import { POLYMARKET_FEATURE_CARD_HEIGHT } from '@/components/asset-list/RecyclerAssetList2/cards/PolymarketFeatureCard';
@@ -19,7 +21,6 @@ import { CoinDividerContainerHeight } from '@/components/coin-divider';
 import { CoinRowHeight } from '@/components/coin-row';
 import { TokenFamilyHeaderHeight } from '@/components/token-family';
 import { CardSize, UniqueTokenCardMargin } from '@/components/unique-token/CardSize';
-import { IS_IOS } from '@/env';
 import deviceUtils from '@/utils/deviceUtils';
 
 type Dim = {
@@ -44,7 +45,7 @@ const ViewDimensions: Record<CellType, Dim> = {
   [CellType.PROFILE_ACTION_BUTTONS_ROW_SPACE_AFTER]: { height: 24 },
   [CellType.PROFILE_AVATAR_ROW]: { height: ProfileAvatarRowHeight },
   [CellType.PROFILE_AVATAR_ROW_SPACE_BEFORE]: {
-    height: IS_IOS ? ProfileAvatarRowTopInset : ProfileAvatarRowTopInset * 2,
+    height: Platform.OS === 'ios' ? ProfileAvatarRowTopInset : ProfileAvatarRowTopInset * 2,
   },
   [CellType.PROFILE_AVATAR_ROW_SPACE_AFTER]: { height: 15 },
   [CellType.PROFILE_NAME_ROW]: { height: ProfileNameRowHeight },

--- a/src/components/asset-list/RecyclerAssetList2/index.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useMemo, useState } from 'react';
-import { Animated as RNAnimated } from 'react-native';
+import { Platform, Animated as RNAnimated } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -12,7 +12,6 @@ import { NAVBAR_ICON_SIZE, NavBarTextIconFrame } from '@/components/navbar/Navba
 import { Box, Cover, Text } from '@/design-system';
 import { type TextSize } from '@/design-system/typography/typeHierarchy';
 import { type UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_ANDROID } from '@/env';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import useAccountSettings from '@/hooks/useAccountSettings';
 import usePendingTransactions from '@/hooks/usePendingTransactions';
@@ -118,7 +117,7 @@ const NavbarOverlay = React.memo(function NavbarOverlay({ accentColor, position 
   const { language } = useAccountSettings();
   const menuItems = buildMenuItems(language);
 
-  const yOffset = IS_ANDROID ? navbarHeight : insets.top;
+  const yOffset = Platform.OS === 'android' ? navbarHeight : insets.top;
 
   useEffect(() => {
     const listener = position.addListener(({ value }) => {
@@ -220,7 +219,6 @@ const NavbarOverlay = React.memo(function NavbarOverlay({ accentColor, position 
           />
         </Box>
       </Box>
-
       <Box
         style={{
           top: navbarHeight + insets.top,
@@ -262,7 +260,7 @@ const NavbarOverlay = React.memo(function NavbarOverlay({ accentColor, position 
               height={{ custom: navbarHeight }}
               justifyContent="center"
               pointerEvents={isHeaderInteractive ? 'auto' : 'none'}
-              style={[walletNameStyle, { alignSelf: 'center', bottom: IS_ANDROID ? 8 : 2 }]}
+              style={[walletNameStyle, { alignSelf: 'center', bottom: Platform.OS === 'android' ? 8 : 2 }]}
             >
               <ProfileNameRow variant="header" />
             </Box>

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileStickyHeader.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileStickyHeader.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 
 import { navbarHeight } from '@/components/navbar/Navbar';
 import { Box } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { useTheme } from '@/theme/ThemeContext';
 
 import { StickyHeader } from '../core/StickyHeaders';
 
 export const ProfileStickyHeaderHeight = 52;
-const visiblePosition = IS_IOS ? navbarHeight : navbarHeight + 80;
+const visiblePosition = Platform.OS === 'ios' ? navbarHeight : navbarHeight + 80;
 
 export const ProfileStickyHeader = React.memo(function ProfileStickyHeader() {
   const { colors } = useTheme();

--- a/src/components/avatar-builder/EmojisStickyListItem.tsx
+++ b/src/components/avatar-builder/EmojisStickyListItem.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 
 import { BlurView } from 'react-native-blur-view';
 import Animated, { useAnimatedStyle, type SharedValue } from 'react-native-reanimated';
 
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { fonts } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
@@ -30,7 +29,7 @@ const EmojisStickyListItem = ({ index, scrollPosition, headerData }: Props) => {
   return (
     <View style={sx.sectionStickyHeaderWrap}>
       <Animated.View style={animatedStyle}>
-        {IS_IOS ? (
+        {Platform.OS === 'ios' ? (
           <View
             style={[
               sx.sectionStickyBlur,

--- a/src/components/blur/BlurGradient.tsx
+++ b/src/components/blur/BlurGradient.tsx
@@ -1,12 +1,11 @@
 import React, { memo, useMemo, type ReactNode } from 'react';
-import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 import { BlurView } from 'react-native-blur-view';
 import Animated, { Easing, type AnimatedStyle } from 'react-native-reanimated';
 
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 type FadeTo = 'top' | 'bottom' | 'left' | 'right';
 type GradientPoints = [from: { x: number; y: number }, to: { x: number; y: number }];
@@ -45,7 +44,7 @@ export const BlurGradient = memo(function BlurGradient({
   fadeTo = 'top',
   feather = 8,
   gradientBuffer = 0,
-  gradientOpacity = IS_IOS ? { dark: 0.96, light: 0.92 } : { dark: 1, light: 1 },
+  gradientOpacity = Platform.OS === 'ios' ? { dark: 0.96, light: 0.92 } : { dark: 1, light: 1 },
   gradientPoints: gradientPointsProp,
   height,
   intensity = 8,
@@ -67,7 +66,7 @@ export const BlurGradient = memo(function BlurGradient({
 
   return (
     <Animated.View style={[styles.blurHeaderWrapper, style, { height, width }]}>
-      {IS_IOS ? (
+      {Platform.OS === 'ios' ? (
         <BlurView
           blurIntensity={intensity}
           blurStyle="variable"
@@ -79,7 +78,6 @@ export const BlurGradient = memo(function BlurGradient({
       ) : (
         androidBlurFallback
       )}
-
       {color === 'transparent' ? null : (
         <EasingGradient
           easing={Easing.inOut(Easing.quad)}

--- a/src/components/buttons/BiometricButtonContent.js
+++ b/src/components/buttons/BiometricButtonContent.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { BiometryTypes } from '@/helpers';
 import useBiometryType from '@/hooks/useBiometryType';
@@ -47,12 +47,12 @@ export function useBiometryIconString({ showIcon, isHardwareWallet }) {
 
 export default function BiometricButtonContent({ label, showIcon = true, testID, ...props }) {
   const isHardwareWallet = useIsHardwareWallet();
-  const biometryIcon = useBiometryIconString({ showIcon: !IS_ANDROID && showIcon, isHardwareWallet });
+  const biometryIcon = useBiometryIconString({ showIcon: Platform.OS !== 'android' && showIcon, isHardwareWallet });
   const { colors } = useTheme();
   return (
     <>
       {isHardwareWallet && showIcon && <LedgerIcon color={props?.color || colors.appleBlue} marginRight={8} />}
-      <Label testID={testID || label} {...props} {...(IS_ANDROID && { lineHeight: 23 })}>
+      <Label testID={testID || label} {...props} {...(Platform.OS === 'android' && { lineHeight: 23 })}>
         {`${biometryIcon}${label}`}
       </Label>
     </>

--- a/src/components/buttons/HoldToActivateProgress.tsx
+++ b/src/components/buttons/HoldToActivateProgress.tsx
@@ -1,10 +1,10 @@
 import { memo } from 'react';
+import { Platform } from 'react-native';
 
 import chroma from 'chroma-js';
 import Animated, { interpolate, useAnimatedStyle, type SharedValue } from 'react-native-reanimated';
 
 import { Cover, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 type HoldToActivateProgressProps = {
   holdProgress: SharedValue<number>;
@@ -32,7 +32,7 @@ export const HoldToActivateProgress = memo(function HoldToActivateProgress({ hol
           {
             backgroundColor: brightenedColor,
             height: '100%',
-            ...(IS_IOS
+            ...(Platform.OS === 'ios'
               ? {
                   shadowColor: brightenedColor,
                   shadowOffset: { width: 12, height: 0 },

--- a/src/components/cards/CarouselCard.tsx
+++ b/src/components/cards/CarouselCard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, { useEffect, useRef, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { Platform, ScrollView, View } from 'react-native';
 
 import { FlashList, type ListRenderItem } from '@shopify/flash-list';
 
@@ -8,12 +8,11 @@ import ActivityIndicator from '@/components/ActivityIndicator';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Spinner from '@/components/Spinner';
 import { Bleed, Box, Column, Columns, Stack, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 
 const HORIZONTAL_PADDING = 20;
 
-const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
+const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
 function EmptyComponent({ emptyMessage }: { emptyMessage?: string }) {
   return (

--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { type GestureResponderEvent } from 'react-native';
+import { Platform, type GestureResponderEvent } from 'react-native';
 
 import { useRoute } from '@react-navigation/native';
 
@@ -7,7 +7,6 @@ import { analytics } from '@/analytics';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
 import { ExtremeLabels } from '@/components/value-chart/ExtremeLabels';
 import { AccentColorProvider, Bleed, Box, Inline, Stack, Text } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useChartThrottledPoints from '@/hooks/charts/useChartThrottledPoints';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
@@ -140,7 +139,7 @@ export const EthCard = () => {
   const { f2c_enabled: addCashEnabled } = useRemoteConfig();
 
   return (
-    <GenericCard onPress={IS_IOS ? handleAssetPress : handlePressBuy} type={cardType} testID="eth-card">
+    <GenericCard onPress={Platform.OS === 'ios' ? handleAssetPress : handlePressBuy} type={cardType} testID="eth-card">
       <Stack space={{ custom: 41 }}>
         <Stack space="12px">
           <Bleed top="4px">

--- a/src/components/cards/FeaturedMintCard.tsx
+++ b/src/components/cards/FeaturedMintCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { BlurView } from 'react-native-blur-view';
 
@@ -18,7 +18,6 @@ import {
   useColorMode,
   useForegroundColor,
 } from '@/design-system';
-import { IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { abbreviateNumber, convertRawAmountToRoundedDecimal } from '@/helpers/utilities';
 import useDimensions from '@/hooks/useDimensions';
@@ -88,7 +87,7 @@ export function FeaturedMintCard() {
       <AccentColorProvider color={accentColor ?? labelSecondary}>
         <View
           style={
-            IS_IOS
+            Platform.OS === 'ios'
               ? {
                   shadowColor: globalColors.grey100,
                   shadowOffset: { width: 0, height: 2 },
@@ -100,7 +99,7 @@ export function FeaturedMintCard() {
         >
           <View
             style={
-              IS_IOS
+              Platform.OS === 'ios'
                 ? {
                     shadowColor: globalColors.grey100,
                     shadowOffset: { width: 0, height: 6 },
@@ -125,7 +124,7 @@ export function FeaturedMintCard() {
             >
               <Cover>
                 <BlurWrapper>
-                  {!!imageUrl && IS_IOS && (
+                  {!!imageUrl && Platform.OS === 'ios' && (
                     <Cover>
                       <ImgixImage
                         resizeMode="cover"
@@ -141,7 +140,7 @@ export function FeaturedMintCard() {
                     </Cover>
                   )}
                   <Cover>
-                    {IS_IOS ? (
+                    {Platform.OS === 'ios' ? (
                       <BlurView
                         blurIntensity={100}
                         blurStyle="light"
@@ -236,7 +235,7 @@ export function FeaturedMintCard() {
                     {!!imageUrl && (
                       <View
                         style={
-                          IS_IOS
+                          Platform.OS === 'ios'
                             ? {
                                 shadowColor: globalColors.grey100,
                                 shadowOffset: { width: 0, height: 2 },
@@ -248,7 +247,7 @@ export function FeaturedMintCard() {
                       >
                         <View
                           style={
-                            IS_IOS
+                            Platform.OS === 'ios'
                               ? {
                                   shadowColor: isDarkMode || !accentColor ? globalColors.grey100 : accentColor,
                                   shadowOffset: { width: 0, height: 4 },

--- a/src/components/cards/GenericCard.tsx
+++ b/src/components/cards/GenericCard.tsx
@@ -1,11 +1,11 @@
 // @ts-nocheck
 import React, { type PropsWithChildren } from 'react';
+import { Platform } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { LinearGradient } from 'expo-linear-gradient';
 
 import { AccentColorProvider, Box, type Space } from '@/design-system';
-import { IS_IOS } from '@/env';
 import deviceUtils from '@/utils/deviceUtils';
 
 import ButtonPressAnimation from '../animations/ButtonPressAnimation';
@@ -86,7 +86,7 @@ export const GenericCard = ({
           shadow: color ? '18px accent' : '18px',
         })}
         style={{
-          flex: IS_IOS ? 0 : undefined,
+          flex: Platform.OS === 'ios' ? 0 : undefined,
           borderColor: borderColor ?? undefined,
           borderWidth: borderColor ? 1 : undefined,
         }}

--- a/src/components/cards/MintsCard/CollectionCell.tsx
+++ b/src/components/cards/MintsCard/CollectionCell.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { analytics } from '@/analytics';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
@@ -7,7 +7,6 @@ import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { ImgixImage } from '@/components/images';
 import { AccentColorProvider, Bleed, Box, Cover, Inline, Inset, Text } from '@/design-system';
 import { globalColors } from '@/design-system/color/palettes';
-import { IS_IOS } from '@/env';
 import { type MintableCollection } from '@/graphql/__generated__/arc';
 import { convertRawAmountToRoundedDecimal } from '@/helpers/utilities';
 import * as i18n from '@/languages';
@@ -89,7 +88,7 @@ export function CollectionCell({ collection }: { collection: MintableCollection 
             >
               <View
                 style={
-                  IS_IOS
+                  Platform.OS === 'ios'
                     ? {
                         shadowColor: globalColors.grey100,
                         shadowOffset: { width: 0, height: 6 },

--- a/src/components/cards/NFTOffersCard/index.tsx
+++ b/src/components/cards/NFTOffersCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView } from 'react-native';
 
 import { FlashList } from '@shopify/flash-list';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
@@ -24,7 +24,6 @@ import {
   useColorMode,
   useForegroundColor,
 } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { type NftOffer } from '@/graphql/__generated__/arc';
 import { convertAmountToNativeDisplay } from '@/helpers/utilities';
 import useDimensions from '@/hooks/useDimensions';
@@ -42,7 +41,7 @@ const CARD_HEIGHT = 250;
 const OFFER_CELL_HEIGHT = NFT_IMAGE_SIZE + 60;
 const OFFER_CELL_WIDTH = NFT_IMAGE_SIZE + CELL_HORIZONTAL_PADDING * 2;
 
-const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
+const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
 export const NFTOffersCard = () => {
   const borderColor = useForegroundColor('separator');

--- a/src/components/contacts/ContactAvatar.js
+++ b/src/components/contacts/ContactAvatar.js
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { toUpper } from 'lodash';
 
 import { useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import ShadowStack from '@/react-native-shadow-stack';
 import { borders } from '@/styles';
 import { getFirstGrapheme } from '@/utils/formatters';
@@ -22,7 +22,7 @@ const buildShadows = (color, size, darkMode, colors) => {
   } else if (size === 'smaller' || size === 'smallest') {
     return [[0, 4, 12, darkMode ? darkModeThemeColors.shadow : darkModeThemeColors.avatarBackgrounds[color] || color, 0.3]];
   } else if (size === 'lmedium' || size === 'medium' || size === 'smedium') {
-    return [[0, 4, IS_ANDROID ? 5 : 12, darkMode ? colors.shadow : colors.avatarBackgrounds[color] || color, 0.4]];
+    return [[0, 4, Platform.OS === 'android' ? 5 : 12, darkMode ? colors.shadow : colors.avatarBackgrounds[color] || color, 0.4]];
   } else if (size === 'signing') {
     return [
       [0, 4, 12, darkMode ? colors.shadow : colors.avatarBackgrounds[color] || color, darkMode ? 0.16 : 0.2],
@@ -89,12 +89,13 @@ const sizeConfigs = colors => ({
   },
   rewards: {
     dimensions: 36,
-    shadow: IS_ANDROID
-      ? [[0, 4, 5, colors.shadow, 0.16]]
-      : [
-          [0, 4, 12, colors.shadow, 0.16],
-          [0, 2, 6, colors.shadow, 0.02],
-        ],
+    shadow:
+      Platform.OS === 'android'
+        ? [[0, 4, 5, colors.shadow, 0.16]]
+        : [
+            [0, 4, 12, colors.shadow, 0.16],
+            [0, 2, 6, colors.shadow, 0.02],
+          ],
     textSize: 'large',
   },
   smallest: {

--- a/src/components/contacts/ImageAvatar.js
+++ b/src/components/contacts/ImageAvatar.js
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { ImgixImage } from '@/components/images';
 import { useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import ShadowStack from '@/react-native-shadow-stack';
@@ -69,17 +69,18 @@ const sizeConfigs = (accentColor, colors, isDarkMode) => ({
   },
   smedium: {
     dimensions: 36,
-    shadow: [[0, 4, IS_ANDROID ? 5 : 12, colors.shadow, 0.4]],
+    shadow: [[0, 4, Platform.OS === 'android' ? 5 : 12, colors.shadow, 0.4]],
     textSize: 'large',
   },
   rewards: {
     dimensions: 36,
-    shadow: IS_ANDROID
-      ? [[0, 4, 5, colors.shadow, 0.16]]
-      : [
-          [0, 4, 12, colors.shadow, 0.16],
-          [0, 2, 6, colors.shadow, 0.02],
-        ],
+    shadow:
+      Platform.OS === 'android'
+        ? [[0, 4, 5, colors.shadow, 0.16]]
+        : [
+            [0, 4, 12, colors.shadow, 0.16],
+            [0, 2, 6, colors.shadow, 0.02],
+          ],
     textSize: 'large',
   },
   smedium_shadowless: {

--- a/src/components/drag-and-drop/components/Draggable.tsx
+++ b/src/components/drag-and-drop/components/Draggable.tsx
@@ -1,10 +1,9 @@
 import React, { type FunctionComponent, type PropsWithChildren } from 'react';
-import { type ViewProps } from 'react-native';
+import { Platform, type ViewProps } from 'react-native';
 
 import Animated, { useAnimatedStyle, withTiming, type AnimatedProps } from 'react-native-reanimated';
 
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
-import { IS_IOS } from '@/env';
 
 import { useDraggable, type DraggableConstraints, type UseDroppableOptions } from '../hooks';
 import type { AnimatedStyleWorklet } from '../types';
@@ -103,7 +102,7 @@ export const Draggable: FunctionComponent<PropsWithChildren<DraggableProps>> = (
     <Animated.View
       onLayout={onLayout}
       // @ts-expect-error onLayoutWorklet prop is arbitrarily named, we just need to pass setNodeLayout via some prop
-      onLayoutWorklet={IS_IOS ? onLayoutWorklet : undefined}
+      onLayoutWorklet={Platform.OS === 'ios' ? onLayoutWorklet : undefined}
       ref={setNodeRef}
       style={[style, animatedStyle]}
       // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/drag-and-drop/components/Droppable.tsx
+++ b/src/components/drag-and-drop/components/Droppable.tsx
@@ -1,10 +1,9 @@
 import React, { type FunctionComponent, type PropsWithChildren } from 'react';
-import { type ViewProps } from 'react-native';
+import { Platform, type ViewProps } from 'react-native';
 
 import Animated, { useAnimatedStyle, withTiming, type AnimatedProps } from 'react-native-reanimated';
 
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
-import { IS_IOS } from '@/env';
 
 import { useDroppable, type UseDraggableOptions } from '../hooks';
 import type { AnimatedStyleWorklet } from '../types';
@@ -68,7 +67,7 @@ export const Droppable: FunctionComponent<PropsWithChildren<DroppableProps>> = (
     <Animated.View
       onLayout={onLayout}
       // @ts-expect-error onLayoutWorklet prop is arbitrarily named, we just need to pass setNodeLayout via some prop
-      onLayoutWorklet={IS_IOS ? onLayoutWorklet : undefined}
+      onLayoutWorklet={Platform.OS === 'ios' ? onLayoutWorklet : undefined}
       ref={setNodeRef}
       style={[style, animatedStyle]}
       // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/drag-and-drop/hooks/useDraggable.ts
+++ b/src/components/drag-and-drop/hooks/useDraggable.ts
@@ -1,9 +1,8 @@
 import { useCallback, useLayoutEffect } from 'react';
-import { type LayoutRectangle, type ViewProps } from 'react-native';
+import { Platform, type LayoutRectangle, type ViewProps } from 'react-native';
 
 import { runOnUI, useSharedValue } from 'react-native-reanimated';
 
-import { IS_IOS } from '@/env';
 import { useLayoutWorklet } from '@/hooks/reanimated/useLayoutWorklet';
 
 import { useDndContext, type DraggableState } from '../DndContext';
@@ -138,7 +137,7 @@ export const useDraggable = ({
 
   // Standard onLayout event for Android — also required to trigger 'topLayout' event on iOS
   const onLayout: ViewProps['onLayout'] = useCallback(() => {
-    if (IS_IOS) return;
+    if (Platform.OS === 'ios') return;
 
     assert(containerRef.current);
     node.current?.measureLayout(containerRef.current, (x, y, width, height) => {

--- a/src/components/drag-and-drop/hooks/useDroppable.ts
+++ b/src/components/drag-and-drop/hooks/useDroppable.ts
@@ -1,9 +1,8 @@
 import { useCallback, useLayoutEffect } from 'react';
-import { type LayoutRectangle, type ViewProps } from 'react-native';
+import { Platform, type LayoutRectangle, type ViewProps } from 'react-native';
 
 import { runOnUI, useAnimatedReaction, useSharedValue } from 'react-native-reanimated';
 
-import { IS_IOS } from '@/env';
 import { useLayoutWorklet } from '@/hooks/reanimated/useLayoutWorklet';
 
 import { useDndContext } from '../DndContext';
@@ -91,7 +90,7 @@ export const useDroppable = ({ id, data = {}, disabled = false }: UseDroppableOp
 
   // Standard onLayout event for Android — also required to trigger 'topLayout' event on iOS
   const onLayout: ViewProps['onLayout'] = useCallback(() => {
-    if (IS_IOS) return;
+    if (Platform.OS === 'ios') return;
 
     assert(containerRef.current);
     node.current?.measureLayout(containerRef.current, (x, y, width, height) => {

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
-import { InteractionManager, Share, View } from 'react-native';
+import { InteractionManager, Platform, Share, View } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
 import c from 'chroma-js';
@@ -30,7 +30,6 @@ import {
 } from '@/design-system';
 import { AssetType } from '@/entities/assetTypes';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import ENSBriefTokenInfoRow from '@/features/ens/components/ENSBriefTokenInfoRow';
 import ConfigurationSection from '@/features/ens/components/expanded-state/ConfigurationSection';
 import ProfileInfoSection from '@/features/ens/components/expanded-state/ProfileInfoSection';
@@ -99,7 +98,7 @@ const BlurWrapper = styled(View).attrs({
   overflow: 'hidden',
   position: 'absolute',
   width: ({ width }: BlurWrapperProps) => width,
-  ...(IS_ANDROID ? { borderTopLeftRadius: 30, borderTopRightRadius: 30 } : {}),
+  ...(Platform.OS === 'android' ? { borderTopLeftRadius: 30, borderTopRightRadius: 30 } : {}),
 });
 
 const Spacer = styled(View)({
@@ -179,7 +178,7 @@ const Section = ({
               <Heading
                 containsEmoji
                 color="primary (Deprecated)"
-                size={IS_IOS ? '23px / 27px (Deprecated)' : '20px / 22px (Deprecated)'}
+                size={Platform.OS === 'ios' ? '23px / 27px (Deprecated)' : '20px / 22px (Deprecated)'}
                 weight="heavy"
               >
                 {titleEmoji}
@@ -359,7 +358,7 @@ const UniqueTokenExpandedState = ({ asset, external }: UniqueTokenExpandedStateP
     }
 
     Share.share({
-      message: IS_ANDROID ? shareUrl : undefined,
+      message: Platform.OS === 'android' ? shareUrl : undefined,
       title: `Share ${buildUniqueTokenName({
         collectionName: asset.collectionName ?? '',
         tokenId: asset.tokenId,
@@ -417,7 +416,7 @@ const UniqueTokenExpandedState = ({ asset, external }: UniqueTokenExpandedStateP
 
   return (
     <>
-      {IS_IOS && (
+      {Platform.OS === 'ios' && (
         <BlurWrapper height={deviceHeight} width={deviceWidth}>
           <BackgroundImage>
             <UniqueTokenImage
@@ -434,10 +433,12 @@ const UniqueTokenExpandedState = ({ asset, external }: UniqueTokenExpandedStateP
         </BlurWrapper>
       )}
       <SlackSheet
-        backgroundColor={isDarkMode ? `rgba(22, 22, 22, ${IS_IOS ? 0.4 : 1})` : `rgba(26, 26, 26, ${IS_IOS ? 0.4 : 1})`}
+        backgroundColor={
+          isDarkMode ? `rgba(22, 22, 22, ${Platform.OS === 'ios' ? 0.4 : 1})` : `rgba(26, 26, 26, ${Platform.OS === 'ios' ? 0.4 : 1})`
+        }
         bottomInset={42}
         hideHandle
-        {...(IS_IOS ? { height: '100%' } : { additionalTopPadding: true, contentHeight: deviceHeight })}
+        {...(Platform.OS === 'ios' ? { height: '100%' } : { additionalTopPadding: true, contentHeight: deviceHeight })}
         ref={sheetRef}
         scrollEnabled
         showsVerticalScrollIndicator={!contentFocused}
@@ -446,7 +447,7 @@ const UniqueTokenExpandedState = ({ asset, external }: UniqueTokenExpandedStateP
       >
         <ColorModeProvider value="darkTinted">
           <AccentColorProvider color={imageColor}>
-            <ImagePreviewOverlay enableZoom={IS_IOS} opacity={ensCoverOpacity} yPosition={yPosition}>
+            <ImagePreviewOverlay enableZoom={Platform.OS === 'ios'} opacity={ensCoverOpacity} yPosition={yPosition}>
               <Inset bottom={sectionSpace} top={{ custom: topInset }}>
                 <Stack alignHorizontal="center">
                   <Animated.View style={sheetHandleStyle}>
@@ -559,8 +560,8 @@ const UniqueTokenExpandedState = ({ asset, external }: UniqueTokenExpandedStateP
                     <Stack separator={<Separator color="divider20 (Deprecated)" />} space={sectionSpace}>
                       {isNFT || isENS ? (
                         <Bleed // Manually crop surrounding space until TokenInfoItem uses design system components
-                          bottom={IS_ANDROID ? '15px (Deprecated)' : '6px'}
-                          top={IS_ANDROID ? '10px' : '4px'}
+                          bottom={Platform.OS === 'android' ? '15px (Deprecated)' : '6px'}
+                          top={Platform.OS === 'android' ? '10px' : '4px'}
                         >
                           {isENS && (
                             <ENSBriefTokenInfoRow
@@ -649,7 +650,7 @@ const UniqueTokenExpandedState = ({ asset, external }: UniqueTokenExpandedStateP
                             <Markdown>{asset.collectionDescription}</Markdown>
                             {asset.collectionUrl ? (
                               <Bleed // Manually crop surrounding space until Link uses design system components
-                                bottom={IS_ANDROID ? '15px (Deprecated)' : undefined}
+                                bottom={Platform.OS === 'android' ? '15px (Deprecated)' : undefined}
                                 top="15px (Deprecated)"
                               >
                                 {/* @ts-expect-error emoji prop is optional but inferred as required from untyped JS */}

--- a/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.tsx
+++ b/src/components/expanded-state/chart/chart-data-labels/ChartPercentChangeLabel.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { Platform } from 'react-native';
 
 import {
   useAnimatedReaction,
@@ -13,12 +14,11 @@ import {
 import { AnimatedNumber } from '@/components/animated-number/AnimatedNumber';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { AnimatedText, Box, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { greaterThanWorklet, lessThanWorklet, toFixedWorklet } from '@/framework/core/safeMath';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useTheme } from '@/theme/ThemeContext';
 
-const UP_ARROW = IS_ANDROID ? '' : '↑';
+const UP_ARROW = Platform.OS === 'android' ? '' : '↑';
 
 type ChartPercentChangeLabelProps = {
   backgroundColor: string;

--- a/src/components/expanded-state/profile/ProfileModalContainer.js
+++ b/src/components/expanded-state/profile/ProfileModalContainer.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute } from '@react-navigation/native';
 
-import { IS_IOS } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 
 import { AssetPanel, FloatingPanels } from '../../floating-panels';
@@ -14,7 +14,7 @@ export default function ProfileModalContainer({ onPressBackdrop, ...props }) {
   const { params } = useRoute();
 
   return (
-    <KeyboardFixedOpenLayout additionalPadding={params?.additionalPadding && IS_IOS ? 80 : 0} position="absolute">
+    <KeyboardFixedOpenLayout additionalPadding={params?.additionalPadding && Platform.OS === 'ios' ? 80 : 0} position="absolute">
       <TouchableBackdrop onPress={onPressBackdrop} />
       <FloatingPanels maxWidth={deviceWidth - 110}>
         <AssetPanel {...props} />

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateContent.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native';
 
 import { type DerivedValue, type SharedValue } from 'react-native-reanimated';
 
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useAnimationType from '@/hooks/useAnimationType';
 import usePersistentAspectRatio from '@/hooks/usePersistentAspectRatio';
@@ -73,7 +72,7 @@ const UniqueTokenExpandedStateContent = ({
       animationProgress={animationProgress}
       aspectRatio={aspectRatioWithFallback}
       borderRadius={borderRadius}
-      disableAnimations={disablePreview || (IS_IOS ? animationType === 'video' : supportsAnythingExceptImageAnd3d)}
+      disableAnimations={disablePreview || (Platform.OS === 'ios' ? animationType === 'video' : supportsAnythingExceptImageAnd3d)}
       horizontalPadding={horizontalPadding}
       onZoomIn={onContentFocus}
       onZoomOut={onContentBlur}

--- a/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
+++ b/src/components/expanded-state/unique-token/UniqueTokenExpandedStateHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { startCase } from 'lodash';
 import URL from 'url-parse';
@@ -9,7 +9,6 @@ import { ImgixImage } from '@/components/images';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Bleed, Column, Columns, Heading, Inline, Inset, Stack, Text, type Space } from '@/design-system';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { showActionSheetWithOptions } from '@/framework/ui/utils/actionsheet';
 import { buildUniqueTokenName } from '@/helpers/assets';
@@ -53,6 +52,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'square.on.square',
       },
     },
+
     [AssetActionsEnum.download]: {
       actionKey: AssetActionsEnum.download,
       actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.save_to_photos),
@@ -61,6 +61,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'photo.on.rectangle.angled',
       },
     },
+
     [AssetActionsEnum.etherscan]: {
       actionKey: AssetActionsEnum.etherscan,
       actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.view_on_block_explorer, {
@@ -71,6 +72,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'link',
       },
     },
+
     [AssetActionsEnum.rainbowWeb]: {
       actionKey: AssetActionsEnum.rainbowWeb,
       actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.view_on_web),
@@ -79,6 +81,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'safari.fill',
       },
     },
+
     [AssetActionsEnum.hide]: {
       actionKey: AssetActionsEnum.hide,
       actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.hide),
@@ -87,6 +90,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'eye',
       },
     },
+
     [AssetActionsEnum.opensea]: {
       actionKey: AssetActionsEnum.opensea,
       actionTitle: 'OpenSea',
@@ -95,6 +99,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'opensea',
       },
     },
+
     [AssetActionsEnum.refresh]: {
       actionKey: AssetActionsEnum.refresh,
       actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.refresh),
@@ -103,6 +108,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'arrow.clockwise',
       },
     },
+
     [AssetActionsEnum.report]: {
       actionKey: AssetActionsEnum.report,
       actionTitle: i18n.t(i18n.l.expanded_state.unique_expanded.report),
@@ -111,6 +117,7 @@ const getAssetActions = ({ chainId }: { chainId: ChainId }) =>
         iconValue: 'exclamationmark.triangle',
       },
     },
+
     [AssetActionsEnum.looksrare]: {
       actionKey: AssetActionsEnum.looksrare,
       actionTitle: 'LooksRare',
@@ -452,7 +459,7 @@ const UniqueTokenExpandedStateHeader = ({
         <Column width="content">
           <Bleed space={overflowMenuHitSlop}>
             {/* NOTE: Necessary since other context menu overflows off screen on android */}
-            {IS_ANDROID && (
+            {Platform.OS === 'android' && (
               <ContextCircleButton
                 testID="unique-token-expanded-state-context-menu-button"
                 options={assetMenuOptions}
@@ -474,7 +481,7 @@ const UniqueTokenExpandedStateHeader = ({
                 </ButtonPressAnimation>
               </ContextCircleButton>
             )}
-            {IS_IOS && (
+            {Platform.OS === 'ios' && (
               <ContextMenuButton
                 menuConfig={assetMenuConfig}
                 isMenuPrimaryAction
@@ -498,7 +505,7 @@ const UniqueTokenExpandedStateHeader = ({
         <Bleed space={familyNameHitSlop}>
           <ContextMenuButton
             menuConfig={familyMenuConfig}
-            {...(IS_ANDROID ? { onPress: onPressAndroidFamily, isAnchoredToRight: true } : {})}
+            {...(Platform.OS === 'android' ? { onPress: onPressAndroidFamily, isAnchoredToRight: true } : {})}
             isMenuPrimaryAction
             onPressMenuItem={handlePressFamilyMenuItem}
             useActionSheetFallback={false}

--- a/src/components/fields/PasswordField.tsx
+++ b/src/components/fields/PasswordField.tsx
@@ -1,8 +1,7 @@
 import React, { forwardRef, useCallback, type Ref } from 'react';
-import { View, type TextInput, type TextInputProps } from 'react-native';
+import { Platform, View, type TextInput, type TextInputProps } from 'react-native';
 
 import { Box } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { cloudBackupPasswordMinLength } from '@/handlers/cloudBackup';
@@ -57,7 +56,7 @@ const PasswordInput = styled(Input).attrs(({ theme: { colors } }: any) => ({
 });
 
 // Use styled-components attrs for dynamic props to ensure they are memoized
-const ShadowContainer = styled(IS_IOS ? ShadowStack : View).attrs(({ theme: { colors, isDarkMode }, deviceWidth }: any) => {
+const ShadowContainer = styled(Platform.OS === 'ios' ? ShadowStack : View).attrs(({ theme: { colors, isDarkMode }, deviceWidth }: any) => {
   return {
     backgroundColor: isDarkMode ? colors.offWhite : colors.white,
     borderRadius: 16,
@@ -66,7 +65,7 @@ const ShadowContainer = styled(IS_IOS ? ShadowStack : View).attrs(({ theme: { co
       [0, 5, 15, colors.shadow, 0.06],
       [0, 10, 30, colors.shadow, 0.12],
     ],
-    width: IS_ANDROID ? deviceWidth - 48 : '100%',
+    width: Platform.OS === 'android' ? deviceWidth - 48 : '100%',
     elevation: 15,
   };
 })({});

--- a/src/components/hold-to-activate-button/HoldToActivateButton.tsx
+++ b/src/components/hold-to-activate-button/HoldToActivateButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { StyleSheet, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
@@ -21,7 +21,6 @@ import HoldToAuthorizeButtonIcon from '@/components/buttons/hold-to-authorize/Ho
 import { LedgerIcon } from '@/components/icons/svg/LedgerIcon';
 import { Box, Text, useColorMode, type BoxProps, type TextProps } from '@/design-system';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
-import { IS_ANDROID } from '@/env';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 import { colors } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
@@ -49,7 +48,7 @@ type LabelProps = Omit<TextProps, 'children'> & {
 
 function LabelWithBiometryIcon({ label, showIcon = true, testID, color, size, weight, ...textProps }: LabelProps) {
   const isHardwareWallet = useWalletsStore(state => state.getIsHardwareWallet());
-  const biometryIcon = useBiometryIconString({ showIcon: !IS_ANDROID && showIcon, isHardwareWallet });
+  const biometryIcon = useBiometryIconString({ showIcon: Platform.OS !== 'android' && showIcon, isHardwareWallet });
   const { colorMode } = useColorMode();
   const { colors } = useTheme();
 

--- a/src/components/images/ImgixImage.tsx
+++ b/src/components/images/ImgixImage.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import { PixelRatio, StyleSheet } from 'react-native';
+import { PixelRatio, Platform, StyleSheet } from 'react-native';
 
 import { FasterImageView, type ImageOptions } from '@candlefinance/faster-image';
 import FastImage, { type FastImageProps, type Source } from 'react-native-fast-image';
-
-import { IS_IOS } from '@/env';
 
 import { maybeSignSource } from '../../handlers/imgix';
 
@@ -47,7 +45,9 @@ const ImgixImage = React.memo(function ImgixImage(props: ImgixImageProps) {
       return {
         ...DEFAULT_FASTER_IMAGE_CONFIG,
         borderRadius:
-          !fasterImageStyle?.borderRadius || IS_IOS ? fasterImageStyle?.borderRadius : fasterImageStyle.borderRadius * PIXEL_RATIO,
+          !fasterImageStyle?.borderRadius || Platform.OS === 'ios'
+            ? fasterImageStyle?.borderRadius
+            : fasterImageStyle.borderRadius * PIXEL_RATIO,
         resizeMode: props.resizeMode && props.resizeMode !== 'stretch' ? props.resizeMode : DEFAULT_FASTER_IMAGE_CONFIG.resizeMode,
         ...props.fasterImageConfig,
         url: signedUrl,

--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -1,8 +1,7 @@
 import React, { type ForwardedRef } from 'react';
-import { TextInput as TextInputPrimitive, type StyleProp, type TextInputProps, type TextStyle } from 'react-native';
+import { Platform, TextInput as TextInputPrimitive, type StyleProp, type TextInputProps, type TextStyle } from 'react-native';
 
 import { useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { buildTextStyles } from '@/styles';
@@ -37,7 +36,7 @@ const Input = (
   const labelQuaternary = useForegroundColor('labelQuaternary');
 
   const blue = isDarkMode ? '#0A84FF' : '#007AFF';
-  const defaultSelectionColor = IS_IOS ? blue : opacity(blue, 0.2);
+  const defaultSelectionColor = Platform.OS === 'ios' ? blue : opacity(blue, 0.2);
 
   return (
     <TextInput
@@ -51,7 +50,7 @@ const Input = (
       ref={ref}
       selectionColor={selectionColor || defaultSelectionColor}
       spellCheck={spellCheck}
-      style={[IS_ANDROID && { padding: 0, includeFontPadding: false }, style]}
+      style={[Platform.OS === 'android' && { padding: 0, includeFontPadding: false }, style]}
       testID={testID}
       textContentType={textContentType}
     />

--- a/src/components/modal/LoadingOverlay.tsx
+++ b/src/components/modal/LoadingOverlay.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 import { BlurView } from 'react-native-blur-view';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { Box, globalColors, Text } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import neverRerender from '@/utils/neverRerender';
 
@@ -22,11 +21,11 @@ type LoadingOverlayProps = {
 
 const LoadingOverlayComponent = ({ title, paddingTop = 0, style }: LoadingOverlayProps) => {
   const { colors, isDarkMode } = useTheme();
-  const overlayBackgroundColor = IS_ANDROID ? colors.white : opacity(colors.blueGreyDark, 0.15);
+  const overlayBackgroundColor = Platform.OS === 'android' ? colors.white : opacity(colors.blueGreyDark, 0.15);
 
   return (
     <Box alignItems="center" justifyContent="center" style={[styles.container, { paddingTop }, style]}>
-      {IS_IOS ? <TouchableBackdrop disabled /> : null}
+      {Platform.OS === 'ios' ? <TouchableBackdrop disabled /> : null}
       <Animated.View
         entering={FadeIn}
         exiting={FadeOut}
@@ -44,14 +43,16 @@ const LoadingOverlayComponent = ({ title, paddingTop = 0, style }: LoadingOverla
         style={{ backgroundColor: overlayBackgroundColor }}
       >
         <Box alignItems="center" flexDirection="row" justifyContent="center" zIndex={2}>
-          {IS_ANDROID ? <Spinner color={colors.blueGreyDark} /> : <ActivityIndicator />}
+          {Platform.OS === 'android' ? <Spinner color={colors.blueGreyDark} /> : <ActivityIndicator />}
           {title ? (
             <Text color={{ custom: colors.blueGreyDark }} size="20pt" style={styles.title} weight="semibold">
               {title}
             </Text>
           ) : null}
         </Box>
-        {IS_IOS ? <BlurView blurIntensity={40} blurStyle={isDarkMode ? 'dark' : 'light'} style={styles.overlayBlur} /> : null}
+        {Platform.OS === 'ios' ? (
+          <BlurView blurIntensity={40} blurStyle={isDarkMode ? 'dark' : 'light'} style={styles.overlayBlur} />
+        ) : null}
       </Box>
     </Box>
   );

--- a/src/components/modal/ModalHeaderButton.js
+++ b/src/components/modal/ModalHeaderButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { BorderlessButton } from 'react-native-gesture-handler';
 
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 
 import { Button } from '../buttons';
@@ -43,7 +43,12 @@ const Text = styled(UnstyledText).attrs(({ theme: { colors } }) => ({
 });
 
 const ModalHeaderButton = ({ label, onPress, side }) => (
-  <Container {...(IS_ANDROID ? { borderColor: 'transparent' } : {})} as={ios ? BorderlessButton : Button} onPress={onPress} side={side}>
+  <Container
+    {...(Platform.OS === 'android' ? { borderColor: 'transparent' } : {})}
+    as={ios ? BorderlessButton : Button}
+    onPress={onPress}
+    side={side}
+  >
     <Row>
       {side === 'left' && <BackArrow />}
       <Text side={side}>{label}</Text>

--- a/src/components/qrcode-scanner/QRCodeScanner.tsx
+++ b/src/components/qrcode-scanner/QRCodeScanner.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
 import Animated from 'react-native-reanimated';
 import { Camera, useCameraDevice, type CodeScanner } from 'react-native-vision-camera';
 
 import { Box, Cover, Row, Rows } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import * as i18n from '@/languages';
 import deviceUtils, { NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 
@@ -63,7 +63,7 @@ export const QRCodeScanner: React.FC<QRCodeScannerProps> = ({ flashEnabled, isAc
             </Row>
             <Row height="content">
               <Box alignItems="center">
-                <CameraMaskSvg width={deviceWidth} height={deviceWidth - (IS_ANDROID ? 19 : 20)} />
+                <CameraMaskSvg width={deviceWidth} height={deviceWidth - (Platform.OS === 'android' ? 19 : 20)} />
               </Box>
               <Cover alignHorizontal="left">
                 <Box height="full" width={{ custom: 10 }} style={{ backgroundColor: 'black', opacity: 0.9 }} />

--- a/src/components/rainbow-toast/RainbowToast.tsx
+++ b/src/components/rainbow-toast/RainbowToast.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { createDerivedStore } from '@storesjs/stores';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -47,7 +47,7 @@ import {
 } from '@/components/rainbow-toast/useRainbowToastsStore';
 import { Box, useColorMode, useForegroundColor } from '@/design-system';
 import { TransactionStatus } from '@/entities/transactions';
-import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import useAccountSettings from '@/hooks/useAccountSettings';
 import useDimensions from '@/hooks/useDimensions';
 import { useListen } from '@/state/internal/hooks/useListen';
@@ -145,7 +145,7 @@ function RainbowToastDisplayContent() {
   );
 
   // FullWindowOverlay blocks all views for maestro.
-  if (IS_IOS && !IS_TEST) {
+  if (Platform.OS === 'ios' && !IS_TEST) {
     return <FullWindowOverlay>{content}</FullWindowOverlay>;
   }
 
@@ -353,14 +353,14 @@ const RainbowToastItem = memo(function RainbowToast({ toast, stackWidth, index }
             style={[
               styles.background,
               {
-                borderColor: isDarkMode ? borderDark : IS_ANDROID ? 'rgba(150,150,150,0.5)' : 'rgba(255, 255, 255, 0.72)',
+                borderColor: isDarkMode ? borderDark : Platform.OS === 'android' ? 'rgba(150,150,150,0.5)' : 'rgba(255, 255, 255, 0.72)',
               },
             ]}
           />
 
           {/* separate inner view because overflow hidden + shadow breaks */}
           <Animated.View style={[contentContainerStyle, styles.innerContent]}>
-            {IS_IOS ? (
+            {Platform.OS === 'ios' ? (
               <>
                 <BlurGradient
                   gradientPoints={[

--- a/src/components/secret-display/SecretDisplayCard.tsx
+++ b/src/components/secret-display/SecretDisplayCard.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { SeedWordGrid } from '@/components/secret-display/SeedWordGrid';
 import { Box, Inset } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import WalletTypes, { EthereumWalletType } from '@/helpers/walletTypes';
 import * as i18n from '@/languages';
 
@@ -38,7 +38,7 @@ export function SecretDisplayCard({ seed, type = EthereumWalletType.seed }: Secr
             <Box alignItems="center" height="full" justifyContent="center">
               {seed && type === WalletTypes.mnemonic && <SeedWordGrid seed={seed} />}
               {seed && type === WalletTypes.privateKey && (
-                <Text align="center" weight="semibold" lineHeight="looser" size={IS_ANDROID ? 'smedium' : 'lmedium'}>
+                <Text align="center" weight="semibold" lineHeight="looser" size={Platform.OS === 'android' ? 'smedium' : 'lmedium'}>
                   {seed}
                 </Text>
               )}

--- a/src/components/secret-display/SecretDisplaySection.tsx
+++ b/src/components/secret-display/SecretDisplaySection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { type Source } from 'react-native-fast-image';
@@ -8,7 +8,6 @@ import ManuallyBackedUpIcon from '@/assets/ManuallyBackedUp.png';
 import { SecretDisplayError } from '@/components/secret-display/SecretDisplayError';
 import { SecretDisplayStates, type SecretDisplayStatesType } from '@/components/secret-display/states';
 import { Bleed, Box, Inline, Inset, Stack, Text } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { backupsStore } from '@/features/backup/stores/backupsStore';
 import WalletBackupTypes from '@/helpers/walletBackupTypes';
 import WalletTypes, { type EthereumWalletType } from '@/helpers/walletTypes';
@@ -33,7 +32,7 @@ import SecretDisplayCard from './SecretDisplayCard';
 
 const MIN_HEIGHT = 740;
 
-const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
+const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
 type WrapperProps = {
   children?: ReactNode;

--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -4,7 +4,6 @@ import { Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
-import { IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { assetIsUniqueAsset } from '@/handlers/web3';
 import useDimensions from '@/hooks/useDimensions';
@@ -30,7 +29,7 @@ const AssetRowShadow = colors => [
 // iOS 26 has keyboard behavior changes that require extra space
 // Footer height calculation: button (~56px) + tx speed selector (~90px) + spacing (~104px) = ~250px
 const IOS_26_FOOTER_HEIGHT = 250;
-const isIOS26OrHigher = IS_IOS && parseFloat(String(Platform.Version)) >= 26;
+const isIOS26OrHigher = Platform.OS === 'ios' && parseFloat(String(Platform.Version)) >= 26;
 
 const AssetRowGradient = styled(LinearGradient).attrs(({ theme: { colors } }) => ({
   colors: colors.gradients.offWhite,
@@ -45,7 +44,7 @@ const Container = styled(Column)({
 });
 
 const FormContainer = styled(Column).attrs(
-  IS_IOS
+  Platform.OS === 'ios'
     ? {
         align: 'end',
         justify: 'space-between',
@@ -99,7 +98,7 @@ export default function SendAssetForm({
     <KeyboardAwareScrollView
       contentContainerStyle={{ flexGrow: 1 }}
       keyboardShouldPersistTaps="always"
-      extraKeyboardSpace={isIOS26OrHigher ? IOS_26_FOOTER_HEIGHT : IS_IOS ? 0 : -NAVIGATION_BAR_HEIGHT}
+      extraKeyboardSpace={isIOS26OrHigher ? IOS_26_FOOTER_HEIGHT : Platform.OS === 'ios' ? 0 : -NAVIGATION_BAR_HEIGHT}
     >
       <Container>
         <ButtonPressAnimation onPress={onResetAssetSelection} overflowMargin={30} scaleTo={0.925}>

--- a/src/components/send/SendAssetFormCollectible.js
+++ b/src/components/send/SendAssetFormCollectible.js
@@ -1,8 +1,8 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useDimensions from '@/hooks/useDimensions';
 import useImageMetadata from '@/hooks/useImageMetadata';
@@ -110,7 +110,7 @@ export default function SendAssetFormCollectible({ asset, buttonRenderer, txSpee
           {buttonRenderer}
           {txSpeedRenderer}
         </ButtonWrapper>
-        {!IS_ANDROID && (
+        {Platform.OS !== 'android' && (
           <GradientToggler isVisible={!isGradientVisible}>
             <Gradient isTallPhone={isTallPhone} />
           </GradientToggler>

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
+import { Platform } from 'react-native';
 
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useDimensions from '@/hooks/useDimensions';
@@ -25,7 +25,7 @@ const FormContainer = styled(Column).attrs({
   justify: 'center',
 })({
   flex: 1,
-  minHeight: ({ isSmallPhone, isTinyPhone }) => (isTinyPhone ? 104 : IS_ANDROID || isSmallPhone ? 134 : 167),
+  minHeight: ({ isSmallPhone, isTinyPhone }) => (isTinyPhone ? 104 : Platform.OS === 'android' || isSmallPhone ? 134 : 167),
   width: '100%',
 });
 

--- a/src/components/sheet/DecoyScrollView.tsx
+++ b/src/components/sheet/DecoyScrollView.tsx
@@ -1,7 +1,5 @@
 import React, { memo } from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
-
-import { IS_IOS } from '@/env';
+import { Platform, ScrollView, StyleSheet } from 'react-native';
 
 /**
  * #### `🪤 DecoyScrollView 🪤`
@@ -11,7 +9,7 @@ import { IS_IOS } from '@/env';
  * the decoy is rendered after the real ScrollView. The decoy is invisible.
  */
 export const DecoyScrollView = memo(function DecoyScrollView() {
-  return IS_IOS ? <ScrollView scrollEnabled style={styles.decoyScrollView} /> : null;
+  return Platform.OS === 'ios' ? <ScrollView scrollEnabled style={styles.decoyScrollView} /> : null;
 });
 
 const styles = StyleSheet.create({

--- a/src/components/sheet/DynamicHeightSheet.js
+++ b/src/components/sheet/DynamicHeightSheet.js
@@ -1,12 +1,11 @@
 import React, { forwardRef, Fragment, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
-import { Pressable, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import { Platform, Pressable, StyleSheet, TouchableWithoutFeedback } from 'react-native';
 
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { BottomSheetContext } from '@gorhom/bottom-sheet/src/contexts/external';
 import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useDimensions from '@/hooks/useDimensions';
 import { useNavigation } from '@/navigation/Navigation';
@@ -142,9 +141,8 @@ export default forwardRef(function SlackSheet(
 
   return (
     <Fragment>
-      {IS_ANDROID ? <Pressable onPress={goBack} style={[StyleSheet.absoluteFillObject]} /> : null}
+      {Platform.OS === 'android' ? <Pressable onPress={goBack} style={[StyleSheet.absoluteFillObject]} /> : null}
       <TouchableBackdrop onPress={goBack} />
-
       <Container
         additionalTopPadding={additionalTopPadding}
         backgroundColor={bg}
@@ -157,7 +155,7 @@ export default forwardRef(function SlackSheet(
         testID={testID}
         {...props}
       >
-        {IS_ANDROID && (
+        {Platform.OS === 'android' && (
           <AndroidBackground as={TouchableWithoutFeedback} backgroundColor={bg}>
             <AndroidBackground backgroundColor={bg} />
           </AndroidBackground>
@@ -181,7 +179,7 @@ export default forwardRef(function SlackSheet(
             scrollIndicatorInsets={scrollIndicatorInsets}
             showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
             showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-            {...(isInsideBottomSheet && IS_ANDROID
+            {...(isInsideBottomSheet && Platform.OS === 'android'
               ? {
                   onScrollWorklet: scrollHandler,
                 }

--- a/src/components/sheet/SheetGestureBlocker.tsx
+++ b/src/components/sheet/SheetGestureBlocker.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { ScrollView, View } from 'react-native';
+import { Platform, ScrollView, View } from 'react-native';
 
 import { PanGestureHandler } from 'react-native-gesture-handler';
 
 import { Box } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 export const SheetGestureBlocker = ({
   children,
@@ -15,7 +14,7 @@ export const SheetGestureBlocker = ({
   disabled?: boolean;
   preventScrollViewDismissal?: boolean;
 }) => {
-  return IS_IOS ? (
+  return Platform.OS === 'ios' ? (
     <PanGestureHandler enabled={!disabled}>
       <View style={{ height: '100%', width: '100%' }}>
         <>

--- a/src/components/sheet/SheetHandle.tsx
+++ b/src/components/sheet/SheetHandle.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { View, type ViewProps } from 'react-native';
+import { Platform, View, type ViewProps } from 'react-native';
 
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { type Colors } from '@/styles';
@@ -10,7 +9,7 @@ import { useTheme } from '@/theme/ThemeContext';
 export const SHEET_HANDLE_HEIGHT = 5;
 
 const defaultColor = (colors: Colors, showBlur: boolean): string =>
-  IS_ANDROID
+  Platform.OS === 'android'
     ? showBlur
       ? opacity(colors.blueGreyDark, 0.3)
       : colors.blueGreyDark30

--- a/src/components/sheet/SlackSheet.tsx
+++ b/src/components/sheet/SlackSheet.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import React, { forwardRef, Fragment, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import {
+  Platform,
   Pressable,
   StyleSheet,
   TouchableWithoutFeedback,
@@ -17,7 +18,6 @@ import { ScrollView } from 'react-native-gesture-handler';
 import Animated, { useAnimatedScrollHandler, useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useDimensions from '@/hooks/useDimensions';
 import { useNavigation } from '@/navigation/Navigation';
@@ -50,7 +50,7 @@ interface ContainerProps {
 const Container = styled(Centered).attrs({
   direction: 'column',
 })(({ backgroundColor, additionalTopPadding, contentHeight, deferredHeight, deviceHeight, topBorderRadius }: ContainerProps) => ({
-  ...(deferredHeight || IS_IOS
+  ...(deferredHeight || Platform.OS === 'ios'
     ? {}
     : {
         top:
@@ -60,7 +60,7 @@ const Container = styled(Centered).attrs({
               ? deviceHeight - contentHeight
               : 0,
       }),
-  ...(IS_ANDROID ? { borderTopLeftRadius: topBorderRadius ?? 30, borderTopRightRadius: topBorderRadius ?? 30 } : {}),
+  ...(Platform.OS === 'android' ? { borderTopLeftRadius: topBorderRadius ?? 30, borderTopRightRadius: topBorderRadius ?? 30 } : {}),
   backgroundColor: backgroundColor,
   bottom: 0,
   left: 0,
@@ -191,7 +191,7 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
   // In discover sheet we need to set it additionally
   useEffect(
     () => {
-      discoverSheet && IS_IOS && sheet.current?.setNativeProps({ scrollIndicatorInsets });
+      discoverSheet && Platform.OS === 'ios' && sheet.current?.setNativeProps({ scrollIndicatorInsets });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -213,7 +213,7 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
 
   return (
     <Fragment>
-      {IS_ANDROID ? <Pressable onPress={goBack} style={[StyleSheet.absoluteFillObject]} /> : null}
+      {Platform.OS === 'android' ? <Pressable onPress={goBack} style={[StyleSheet.absoluteFillObject]} /> : null}
       <Container
         additionalTopPadding={additionalTopPadding}
         backgroundColor={bg}
@@ -224,7 +224,7 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
         topBorderRadius={borderRadius}
         {...props}
       >
-        {IS_ANDROID && (
+        {Platform.OS === 'android' && (
           <AndroidBackground as={TouchableWithoutFeedback} backgroundColor={bg}>
             <AndroidBackground backgroundColor={bg} />
           </AndroidBackground>
@@ -237,7 +237,7 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
               isInsideBottomSheet
                 ? BottomSheetScrollView
                 : // Android requires RNGH ScrollView while iOS requires the RN one for the dismiss gesture to work.
-                  IS_ANDROID
+                  Platform.OS === 'android'
                   ? AnimatedRNGHScrollView
                   : Animated.ScrollView
             }
@@ -254,7 +254,7 @@ export default forwardRef<unknown, SlackSheetProps>(function SlackSheet(
             scrollIndicatorInsets={scrollIndicatorInsets}
             showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
             showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-            {...(isInsideBottomSheet && IS_ANDROID
+            {...(isInsideBottomSheet && Platform.OS === 'android'
               ? {
                   onScrollWorklet: scrollHandler,
                 }

--- a/src/components/sheet/sheet-action-buttons/SendActionButton.tsx
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { Text } from '@/design-system';
 import type { ParsedAddressAsset, RainbowToken } from '@/entities/tokens';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_IOS } from '@/env';
 import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
@@ -20,7 +20,7 @@ function SendActionButton({ asset, color: givenColor, textColor, ...props }: Sen
   const navigate = useNavigationForNonReadOnlyWallets();
 
   const handlePress = useCallback(() => {
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       navigate(Routes.SEND_FLOW, { screen: Routes.SEND_SHEET, params: { asset } });
     } else {
       navigate(Routes.SEND_FLOW, { asset });

--- a/src/components/toasts/WalletConnectToast.tsx
+++ b/src/components/toasts/WalletConnectToast.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { toast } from 'sonner-native';
 
 import { globalColors } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import { fontWithWidth } from '@/styles';
@@ -111,11 +110,11 @@ const conditionalStyles = StyleSheet.create({
 const styles = StyleSheet.create({
   toastContainerDark: {
     ...conditionalStyles.toastContainer,
-    ...(IS_IOS ? conditionalStyles.toastContainerShadowDark : {}),
+    ...(Platform.OS === 'ios' ? conditionalStyles.toastContainerShadowDark : {}),
   },
   toastContainerLight: {
     ...conditionalStyles.toastContainer,
-    ...(IS_IOS ? conditionalStyles.toastContainerShadowLight : {}),
+    ...(Platform.OS === 'ios' ? conditionalStyles.toastContainerShadowLight : {}),
   },
   toastContent: {
     alignItems: 'center',
@@ -125,12 +124,12 @@ const styles = StyleSheet.create({
   },
   toastDark: {
     ...conditionalStyles.toast,
-    ...(IS_IOS ? conditionalStyles.toastBorderDark : {}),
+    ...(Platform.OS === 'ios' ? conditionalStyles.toastBorderDark : {}),
   },
   toastLight: conditionalStyles.toast,
   title: {
     ...conditionalStyles.title,
-    ...(IS_IOS ? conditionalStyles.titleShadow : {}),
+    ...(Platform.OS === 'ios' ? conditionalStyles.titleShadow : {}),
   },
   zeroDimensions: {
     height: 0,

--- a/src/components/token-search/SearchInputButton.tsx
+++ b/src/components/token-search/SearchInputButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { type TextInput } from 'react-native';
+import { Platform, type TextInput } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import Animated, {
@@ -15,7 +15,6 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { AnimatedText, Box } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import useClipboard from '@/hooks/useClipboard';
 import * as i18n from '@/languages';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
@@ -78,7 +77,7 @@ export const SearchInputButton = ({
   }, [pastedSearchInputValue, onPasteSearchQuery]);
 
   const buttonInfo = useDerivedValue(() => {
-    const clipboardDataAvailable = hasClipboardData || IS_ANDROID;
+    const clipboardDataAvailable = hasClipboardData || Platform.OS === 'android';
 
     const isPasteDisabled = enablePaste && !isAssetSelected.value && isTokenListFocused.value && !clipboardDataAvailable;
     const isVisible = isSearchFocused.value || showButtonWhenNoAsset || isAssetSelected.value;

--- a/src/components/wallet-error/WalletErrorSheet.tsx
+++ b/src/components/wallet-error/WalletErrorSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Platform } from 'react-native';
 
 import FastImage from 'react-native-fast-image';
 
@@ -7,7 +7,6 @@ import restoreWalletIcon from '@/assets/restoreWalletIcon.png';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
 import { BackgroundProvider, Box, Separator, Text } from '@/design-system';
-import { IS_IOS } from '@/env';
 import useBiometryType from '@/hooks/useBiometryType';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
@@ -22,7 +21,7 @@ export default function WalletErrorSheet() {
   const navigation = useNavigation();
   const biometryType = useBiometryType();
   const { cause, resolution } = (() => {
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       if (biometryType === 'none') {
         return { cause: 'passcode_disabled', resolution: 'enable_passcode' } as const;
       } else {

--- a/src/design-system/components/Border/Border.tsx
+++ b/src/design-system/components/Border/Border.tsx
@@ -1,9 +1,9 @@
 import React, { memo } from 'react';
+import { Platform } from 'react-native';
 
 import { Cover, useColorMode, useForegroundColor } from '@/design-system';
 import { type ForegroundColor } from '@/design-system/color/palettes';
 import { type CustomColor } from '@/design-system/color/useForegroundColor';
-import { IS_IOS } from '@/env';
 
 export type BorderProps = {
   borderBottomLeftRadius?: number;
@@ -57,7 +57,7 @@ export const Border = memo(function Border({
 
   const color = useForegroundColor(borderColor);
 
-  return (isDarkMode || enableInLightMode) && (IS_IOS || enableOnAndroid) ? (
+  return (isDarkMode || enableInLightMode) && (Platform.OS === 'ios' || enableOnAndroid) ? (
     <Cover
       style={{
         borderBottomLeftRadius: borderBottomLeftRadius ?? borderBottomRadius ?? borderLeftRadius ?? borderRadius,

--- a/src/design-system/components/Heading/Heading.tsx
+++ b/src/design-system/components/Heading/Heading.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useEffect, useMemo, type ElementRef, type ReactNode } from 'react';
-import { Text as NativeText } from 'react-native';
+import { Text as NativeText, Platform } from 'react-native';
 
 import { SILENCE_EMOJI_WARNINGS } from 'react-native-dotenv';
 
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 
 import { type TextColor } from '../../color/palettes';
 import { type CustomColor } from '../../color/useForegroundColor';
@@ -55,7 +55,7 @@ export const Heading = forwardRef<ElementRef<typeof NativeText>, HeadingProps>(f
 
   return (
     <NativeText allowFontScaling={false} numberOfLines={numberOfLines} ref={ref} style={headingStyle} testID={testID}>
-      {IS_IOS && containsEmojiProp && nodeIsString(children) ? renderStringWithEmoji(children) : children}
+      {Platform.OS === 'ios' && containsEmojiProp && nodeIsString(children) ? renderStringWithEmoji(children) : children}
       {lineHeightFixNode}
     </NativeText>
   );

--- a/src/design-system/components/SkiaText/skiaFontManager.ts
+++ b/src/design-system/components/SkiaText/skiaFontManager.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, type Dispatch, type RefObject, type SetStateAction } from 'react';
+import { Platform } from 'react-native';
 
 import {
   FontWeight,
@@ -9,11 +10,11 @@ import {
   type SkParagraphBuilder,
   type SkTypefaceFontProvider,
 } from '@shopify/react-native-skia';
-import { Platform } from '@shopify/react-native-skia/src/Platform';
+import { Platform as SkiaPlatform } from '@shopify/react-native-skia/src/Platform';
 
 import { type TextAlign } from '@/components/text/types';
 import { type TextWeight } from '@/design-system/components/Text/Text';
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 import { useCleanup } from '@/hooks/useCleanup';
 import { useLazyRef } from '@/hooks/useLazyRef';
 
@@ -53,13 +54,13 @@ export function useSkiaFontManager(align: TextAlign, weight: TextWeight, additio
   const [manager, setManager] = useState<FontManager>(() => getInitialFontManager(align));
 
   const fontInfoRef = useLazyRef<FontInfo>(() => ({
-    prevWeights: IS_IOS ? new Set(Array.isArray(additionalWeights) ? [weight, ...additionalWeights] : [weight]) : new Set(),
+    prevWeights: Platform.OS === 'ios' ? new Set(Array.isArray(additionalWeights) ? [weight, ...additionalWeights] : [weight]) : new Set(),
     textAlign: align,
   }));
 
   // ============ [iOS] Handle align prop changes ============================== //
   useEffect(() => {
-    if (!IS_IOS || align === fontInfoRef.current.textAlign) return;
+    if (Platform.OS !== 'ios' || align === fontInfoRef.current.textAlign) return;
     setManager(prev => ({ fontManager: prev.fontManager, paragraphBuilder: getParagraphBuilder(align) }));
     releaseParagraphBuilder(fontInfoRef);
     fontInfoRef.current.textAlign = align;
@@ -68,7 +69,7 @@ export function useSkiaFontManager(align: TextAlign, weight: TextWeight, additio
   // ============ [Android] Handle align and weight prop changes =============== //
   useEffect(
     () => {
-      if (IS_IOS || !isAndroidFontManager(manager)) return;
+      if (Platform.OS === 'ios' || !isAndroidFontManager(manager)) return;
       handleAndroidFontChanges({ additionalWeights, align, fontInfoRef, manager, setManager, weight });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -164,7 +165,7 @@ function getInitialFontManager(textAlign: TextAlign): FontManager {
   if (!getGlobalFontManager()) setGlobalFontManager(Skia.FontMgr.System());
   return {
     fontManager: getGlobalFontManager(),
-    paragraphBuilder: IS_IOS ? getParagraphBuilder(textAlign) : null,
+    paragraphBuilder: Platform.OS === 'ios' ? getParagraphBuilder(textAlign) : null,
   };
 }
 
@@ -172,7 +173,7 @@ function getInitialFontManager(textAlign: TextAlign): FontManager {
  * Returns the current global font manager.
  */
 function getGlobalFontManager(): SkFontMgr | SkTypefaceFontProvider {
-  if (!_fontManager) _fontManager = IS_IOS ? Skia.FontMgr.System() : Skia.TypefaceFontProvider.Make();
+  if (!_fontManager) _fontManager = Platform.OS === 'ios' ? Skia.FontMgr.System() : Skia.TypefaceFontProvider.Make();
   return _fontManager;
 }
 
@@ -237,7 +238,7 @@ function getTypeface(fontManager: SkTypefaceFontProvider, weight: TextWeight): P
   if (existing) return existing.promise;
 
   // Create a new promise for loading the typeface
-  const loadPromise = Skia.Data.fromURI(Platform.resolveAsset(FONT_LOADERS[weight]?.()))
+  const loadPromise = Skia.Data.fromURI(SkiaPlatform.resolveAsset(FONT_LOADERS[weight]?.()))
     .then(data => {
       const typeface = Skia.Typeface.MakeFreeTypeFaceFromData(data);
       if (!typeface) return;
@@ -276,7 +277,7 @@ function getParagraphBuilder(textAlign: TextAlign): SkParagraphBuilder {
  * @param fontInfoRef - The font info ref to release the paragraph builder for
  */
 function releaseParagraphBuilder(fontInfoRef: RefObject<FontInfo>): void {
-  if (!IS_IOS) return;
+  if (Platform.OS !== 'ios') return;
   const existing = getParagraphBuilders().get(fontInfoRef.current.textAlign);
   if (existing) {
     existing.refCount -= 1;

--- a/src/design-system/components/SkiaText/useSkiaText.ts
+++ b/src/design-system/components/SkiaText/useSkiaText.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import {
   Skia,
@@ -19,7 +20,6 @@ import { getColorForTheme } from '@/design-system/color/useForegroundColor';
 import { type SharedOrDerivedValueText } from '@/design-system/components/Text/AnimatedText';
 import { type TextWeight } from '@/design-system/components/Text/Text';
 import { typeHierarchy, type TextSize } from '@/design-system/typography/typeHierarchy';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { type SharedOrDerivedValue } from '@/types/reanimated';
 
@@ -94,7 +94,7 @@ export function useSkiaText({
   // On Android, weight changes trigger the creation of a new paragraphBuilder, and we want to wait
   // until the new paragraphBuilder is created before rebuilding the paragraph. So to avoid a flash
   // of the incorrect weight if the new weight isn't yet loaded, we omit the dependency on weight.
-  const weightDep = IS_IOS ? weight : undefined;
+  const weightDep = Platform.OS === 'ios' ? weight : undefined;
 
   const buildParagraph = useCallback(
     (segments: TextSegment | TextSegment[]) => {
@@ -206,9 +206,9 @@ function getTextStyle({
         : colorOverride
       : ((defaultColor && 'value' in defaultColor ? defaultColor.value : defaultColor) ??
         Skia.Color(typeof color === 'string' ? color : color.value)),
-    fontFamilies: IS_IOS ? SF_PRO_ROUNDED_IOS : [`SFProRounded-${weightOverride ?? weight}`],
+    fontFamilies: Platform.OS === 'ios' ? SF_PRO_ROUNDED_IOS : [`SFProRounded-${weightOverride ?? weight}`],
     fontSize: fontInfo.fontSize,
-    fontStyle: IS_IOS ? { weight: getSkiaFontWeight(weightOverride ?? weight) } : EMPTY_FONT_STYLE,
+    fontStyle: Platform.OS === 'ios' ? { weight: getSkiaFontWeight(weightOverride ?? weight) } : EMPTY_FONT_STYLE,
     fontFeatures: tabularNumbers ? TABULAR_NUMBERS : EMPTY_FONT_FEATURES,
     halfLeading,
     heightMultiplier: (lineHeight ? lineHeight : fontInfo.lineHeight) / fontInfo.fontSize,

--- a/src/design-system/components/Text/Text.tsx
+++ b/src/design-system/components/Text/Text.tsx
@@ -1,9 +1,16 @@
 import React, { useEffect, useMemo, type ReactNode, type Ref } from 'react';
-import { Text as NativeText, type NativeSyntheticEvent, type StyleProp, type TextLayoutEventData, type TextStyle } from 'react-native';
+import {
+  Text as NativeText,
+  Platform,
+  type NativeSyntheticEvent,
+  type StyleProp,
+  type TextLayoutEventData,
+  type TextStyle,
+} from 'react-native';
 
 import { SILENCE_EMOJI_WARNINGS } from 'react-native-dotenv';
 
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 
 import { type TextColor } from '../../color/palettes';
 import { type CustomColor } from '../../color/useForegroundColor';
@@ -99,7 +106,7 @@ export function Text({
       onPress={onPress}
       onTextLayout={onTextLayout}
     >
-      {IS_IOS && containsEmojiProp && nodeIsString(children) ? renderStringWithEmoji(children) : children}
+      {Platform.OS === 'ios' && containsEmojiProp && nodeIsString(children) ? renderStringWithEmoji(children) : children}
       {lineHeightFixNode}
     </NativeText>
   );

--- a/src/design-system/components/TextShadow/TextShadow.tsx
+++ b/src/design-system/components/TextShadow/TextShadow.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, type ReactElement } from 'react';
-import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 
 import { useColorMode } from '../../color/ColorMode';
@@ -60,7 +60,7 @@ export const TextShadow = ({
       }),
     [blur, color, disabled, enableInLightMode, inferredTextColor, isAnimatedText, isDarkMode, shadowOpacity, x, y]
   );
-  if (IS_TEST || (IS_ANDROID && !enableOnAndroid)) {
+  if (IS_TEST || (Platform.OS === 'android' && !enableOnAndroid)) {
     // Make sure to apply containerStyle if we have one.
     return (
       <ConditionalWrap condition={!!containerStyle} wrap={children => <View style={containerStyle}>{children}</View>}>

--- a/src/design-system/layout/shapes.ts
+++ b/src/design-system/layout/shapes.ts
@@ -1,6 +1,6 @@
-import { getSvgPath } from 'figma-squircle';
+import { Platform } from 'react-native';
 
-import { IS_IOS } from '@/env';
+import { getSvgPath } from 'figma-squircle';
 
 /**
  * Creates a squircle (superellipse) path - a smooth blend between a square and circle.
@@ -17,7 +17,7 @@ import { IS_IOS } from '@/env';
  */
 export function getSquirclePath({
   borderRadius,
-  cornerSmoothing = IS_IOS ? 0.6 : 0,
+  cornerSmoothing = Platform.OS === 'ios' ? 0.6 : 0,
   height,
   width,
 }: {

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,16 +3,6 @@ import ReactNative, { NativeModules } from 'react-native';
 import { ENABLE_DEV_MODE, IS_TESTING, RPC_PROXY_API_KEY_PROD, RPC_PROXY_BASE_URL_PROD } from 'react-native-dotenv';
 
 /**
- * @deprecated use IS_ANDROID
- */
-export const android = ReactNative.Platform.OS === 'android';
-export const IS_ANDROID = android;
-/**
- * @deprecated use IS_IOS
- */
-export const ios = ReactNative.Platform.OS === 'ios';
-export const IS_IOS = ios;
-/**
  * @deprecated use IS_WEB
  */
 export const web = ReactNative.Platform.OS === 'web';

--- a/src/features/backup/backup.ts
+++ b/src/features/backup/backup.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { captureException } from '@sentry/react-native';
@@ -6,7 +6,7 @@ import { endsWith } from 'lodash';
 
 import { analytics } from '@/analytics';
 import { Alert as NativeAlert } from '@/components/alerts';
-import { IS_ANDROID, IS_DEV } from '@/env';
+import { IS_DEV } from '@/env';
 import AesEncryptor from '@/handlers/aesEncryption';
 import { authenticateWithPIN, decryptPIN, maybeAuthenticateWithPINAndCreateIfNeeded } from '@/handlers/authentication';
 import {
@@ -104,7 +104,7 @@ type MaybePromise<T> = T | Promise<T>;
 export const executeFnIfCloudBackupAvailable = async <T>({ fn, logout = false }: { fn: () => MaybePromise<T>; logout?: boolean }) => {
   backupsStore.getState().setStatus(CloudBackupState.InProgress);
 
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     try {
       if (logout) {
         await logoutFromGoogleDrive();
@@ -358,7 +358,7 @@ export async function addWalletToCloudBackup({
 export async function decryptAllPinEncryptedSecretsIfNeeded(secrets: Record<string, string>, maybeUserPIN?: string) {
   const processedSecrets = { ...secrets };
   // We need to decrypt PIN code encrypted secrets before backup
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     let userPIN = maybeUserPIN;
     // We only prompt for PIN if it is currently needed, but it is possible
     // that secrets were previously encrypted with PIN, so we also need
@@ -574,7 +574,7 @@ async function decryptSecretFromBackupPin({ secret, backupPIN }: { secret?: stri
 // Attempts to save the password to decrypt the backup from the iCloud keychain
 export async function saveBackupPassword(password: BackupPassword): Promise<void> {
   try {
-    if (!IS_ANDROID) {
+    if (Platform.OS !== 'android') {
       await kc.setSharedWebCredentials('Backup Password', password);
       analytics.track(analytics.event.backupSavedPassword);
     }
@@ -601,7 +601,7 @@ export async function saveLocalBackupPassword(password: string) {
 
 // Attempts to fetch the password to decrypt the backup from the iCloud keychain
 export async function fetchBackupPassword(): Promise<null | BackupPassword> {
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     return null;
   }
 
@@ -618,7 +618,7 @@ export async function fetchBackupPassword(): Promise<null | BackupPassword> {
 }
 
 export async function getDeviceUUID(): Promise<string | null> {
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     return null;
   }
 
@@ -660,7 +660,7 @@ const FailureAlert = () =>
  */
 export async function checkIdentifierOnLaunch() {
   // Unable to really persist things on Android, so let's just exit early...
-  if (IS_ANDROID) return;
+  if (Platform.OS === 'android') return;
 
   const { idfa_check_enabled } = getRemoteConfig();
   if (!idfa_check_enabled || IS_DEV) {

--- a/src/features/backup/components/ChooseBackupStep.tsx
+++ b/src/features/backup/components/ChooseBackupStep.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { type Source } from 'react-native-fast-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -10,7 +11,6 @@ import { Page } from '@/components/layout';
 import Spinner from '@/components/Spinner';
 import { Text as RNText } from '@/components/text';
 import { Box, Stack } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
@@ -74,7 +74,7 @@ export function ChooseBackupStep() {
     [navigate]
   );
 
-  const height = IS_ANDROID ? deviceHeight - top : deviceHeight - sharedCoolModalTopOffset - 48;
+  const height = Platform.OS === 'android' ? deviceHeight - top : deviceHeight - sharedCoolModalTopOffset - 48;
   return (
     <Box height={{ custom: height }}>
       <MenuContainer>

--- a/src/features/backup/components/RestoreCloudStep.tsx
+++ b/src/features/backup/components/RestoreCloudStep.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { InteractionManager, type TextInput } from 'react-native';
+import { InteractionManager, Platform, type TextInput } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { isEmpty } from 'lodash';
@@ -12,7 +12,6 @@ import { PasswordField } from '@/components/fields';
 import { ImgixImage } from '@/components/images';
 import { Text } from '@/components/text';
 import { Box, Inset, Stack } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isCloudBackupPasswordValid, normalizeAndroidBackupFilename } from '@/handlers/cloudBackup';
@@ -149,7 +148,7 @@ export default function RestoreCloudStep() {
         }
 
         InteractionManager.runAfterInteractions(async () => {
-          if (IS_ANDROID && filename) {
+          if (Platform.OS === 'android' && filename) {
             filename = normalizeAndroidBackupFilename(filename);
           }
 

--- a/src/features/backup/stores/backupsStore.ts
+++ b/src/features/backup/stores/backupsStore.ts
@@ -1,6 +1,7 @@
+import { Platform } from 'react-native';
+
 import { Mutex } from 'async-mutex';
 
-import { IS_ANDROID } from '@/env';
 import { fetchAllBackups, getGoogleAccountUserData, isCloudBackupAvailable, syncCloud } from '@/handlers/cloudBackup';
 import walletBackupTypes from '@/helpers/walletBackupTypes';
 import { logger, RainbowError } from '@/logger';
@@ -142,7 +143,7 @@ export const backupsStore = createRainbowStore<BackupsStore>(
             };
           }
 
-          if (IS_ANDROID) {
+          if (Platform.OS === 'android') {
             const gdata = await getGoogleAccountUserData(true);
             if (!gdata) {
               logger.debug('[backupsStore]: Google account is not available');

--- a/src/features/charts/candlestick/components/ActiveCandleCard.tsx
+++ b/src/features/charts/candlestick/components/ActiveCandleCard.tsx
@@ -1,5 +1,5 @@
 import React, { memo, type ComponentType, type ReactElement, type ReactNode } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import Animated, {
   useAnimatedStyle,
@@ -15,7 +15,6 @@ import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animatio
 import { AnimatedText, Box, Text, TextShadow, useColorMode, type AnimatedTextProps, type BoxProps, type TextProps } from '@/design-system';
 import { foregroundColors, globalColors } from '@/design-system/color/palettes';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { formatAssetPrice } from '@/helpers/formatAssetPrice';
 import { abbreviateNumberWorklet } from '@/helpers/utilities';
@@ -583,7 +582,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     gap: 10,
-    marginTop: IS_IOS ? -6 : 0,
+    marginTop: Platform.OS === 'ios' ? -6 : 0,
     paddingHorizontal: 24,
     position: 'relative',
     width: '100%',

--- a/src/features/charts/candlestick/components/CandlestickChart.tsx
+++ b/src/features/charts/candlestick/components/CandlestickChart.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import {
   BlendMode,
@@ -44,7 +44,7 @@ import { globalColors, Text, TextIcon, useColorMode, useForegroundColor } from '
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
 import { useSkiaText, type TextSegment } from '@/design-system/components/SkiaText/useSkiaText';
 import { NativeCurrencyKeys, type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 import { areCandlesEqual, formatCandlestickPrice } from '@/features/charts/candlestick/utils';
 import { candlestickActions, fetchHistoricalCandles, useCandlestickStore } from '@/features/charts/stores/candlestickStore';
 import { useChartsStore } from '@/features/charts/stores/chartsStore';
@@ -1875,7 +1875,7 @@ function useCandlestickChart({
   }, [backgroundColor, chartManager, isDarkMode, providedConfig]);
 
   useOnChange(() => {
-    if (IS_IOS) return;
+    if (Platform.OS === 'ios') return;
     // Android loads Skia fonts asynchronously, so we need to
     // propagate buildParagraph updates to the chart class.
     runOnUI(() => chartManager.value?.setBuildParagraph?.(buildParagraph))();

--- a/src/features/charts/candlestick/components/PerpsIndicatorsToggle.tsx
+++ b/src/features/charts/candlestick/components/PerpsIndicatorsToggle.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, type SharedValue } from 'react-native-reanimated';
 
@@ -7,7 +7,6 @@ import { AnimatedTextIcon } from '@/components/AnimatedComponents/AnimatedTextIc
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { Border, Box, globalColors, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { chartsActions, useChartsStore, useChartType } from '@/features/charts/stores/chartsStore';
 import { ChartType } from '@/features/charts/types';
 import { useHasPositionCheck } from '@/features/perps/stores/derived/useHasPositionCheck';
@@ -101,7 +100,7 @@ const PerpsIndicatorsToggle = memo(function PerpsIndicatorsToggle({
           pointerEvents="none"
           style={[
             styles.switchSelectedHighlight,
-            IS_IOS && !isDarkMode ? styles.switchShadowLight : undefined,
+            Platform.OS === 'ios' && !isDarkMode ? styles.switchShadowLight : undefined,
             {
               backgroundColor: isDarkMode ? mixedBackgroundColor : globalColors.white100,
             },

--- a/src/features/charts/components/TimeframeSelector.tsx
+++ b/src/features/charts/components/TimeframeSelector.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo, useRef, type RefObject } from 'react';
-import { ScrollView, StyleSheet, View, type ScrollViewProps } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View, type ScrollViewProps } from 'react-native';
 
 import Animated, {
   runOnJS,
@@ -16,7 +16,6 @@ import { easing, SPRING_CONFIGS } from '@/components/animations/animationConfigs
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { AnimatedText, globalColors, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStableValue } from '@/hooks/useStableValue';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -108,7 +107,7 @@ export const TimeframeSelector = memo(function TimeframeSelector({
   return (
     <View style={styles.container}>
       <ScrollView
-        centerContent={!IS_IOS || chartType === ChartType.Line || hideChartTypeToggle}
+        centerContent={Platform.OS !== 'ios' || chartType === ChartType.Line || hideChartTypeToggle}
         contentContainerStyle={scrollViewProps.contentContainerStyle}
         contentOffset={initialState.contentOffset}
         horizontal
@@ -126,7 +125,6 @@ export const TimeframeSelector = memo(function TimeframeSelector({
           <LineChartButtons color={color} onPress={onPress} selectedIndex={selectedIndex} />
         )}
       </ScrollView>
-
       <EasingGradient
         easing={easing.in.sin}
         endColor={backgroundColor}
@@ -136,7 +134,6 @@ export const TimeframeSelector = memo(function TimeframeSelector({
         steps={8}
         style={styles.leftFade}
       />
-
       <EasingGradient
         easing={easing.in.sin}
         endColor={backgroundColor}
@@ -147,7 +144,6 @@ export const TimeframeSelector = memo(function TimeframeSelector({
         steps={8}
         style={hideChartTypeToggle ? [styles.rightFade, styles.symmetricalRightFade] : styles.rightFade}
       />
-
       {hideChartTypeToggle ? null : (
         <ChartTypeToggle
           backgroundColor={backgroundColor}
@@ -196,7 +192,7 @@ const TimeframeButton = ({ candleResolution, color, index, label, lineChartTimeP
   const textStyle = useAnimatedStyle(() => {
     const isSelected = selectedIndex.value === index;
     const textColor = isSelected ? color : labelQuaternary;
-    if (!IS_IOS) return { color: textColor };
+    if (Platform.OS !== 'ios') return { color: textColor };
     return {
       color: textColor,
       fontWeight: isSelected ? '800' : '700',
@@ -413,7 +409,7 @@ function getScrollViewProps(
       : hideChartTypeToggle
         ? [styles.contentContainer, styles.hideChartToggleOverride]
         : styles.contentContainer,
-    maintainVisibleContentPosition: IS_IOS ? undefined : { minIndexForVisible: 0 },
+    maintainVisibleContentPosition: Platform.OS === 'ios' ? undefined : { minIndexForVisible: 0 },
     style: styles.scrollView,
   };
 }
@@ -424,7 +420,7 @@ function toggleChartTypeAndScroll(scrollViewRef: RefObject<ScrollView | null>, s
   const isLineChart = newChartType === ChartType.Line;
   selectedIndex.value = newSelectedIndex;
 
-  if (IS_IOS && isLineChart) return;
+  if (Platform.OS === 'ios' && isLineChart) return;
 
   const scrollTo = () =>
     scrollViewRef.current?.setNativeProps({
@@ -434,7 +430,7 @@ function toggleChartTypeAndScroll(scrollViewRef: RefObject<ScrollView | null>, s
       },
     });
 
-  if (IS_IOS || isLineChart) scrollTo();
+  if (Platform.OS === 'ios' || isLineChart) scrollTo();
   else requestAnimationFrame(scrollTo);
 }
 
@@ -451,7 +447,7 @@ const styles = StyleSheet.create({
   candleBody: {
     borderCurve: 'continuous',
     borderRadius: 1.8,
-    borderWidth: IS_IOS ? 1 : 0,
+    borderWidth: Platform.OS === 'ios' ? 1 : 0,
     overflow: 'hidden',
     position: 'relative',
     width: 5,
@@ -506,11 +502,11 @@ const styles = StyleSheet.create({
     paddingRight: RIGHT_INSET,
     paddingVertical: 12,
     position: 'relative',
-    width: IS_IOS ? undefined : CANDLESTICK_CONTENT_WIDTH + BASE_HORIZONTAL_INSET + RIGHT_INSET,
+    width: Platform.OS === 'ios' ? undefined : CANDLESTICK_CONTENT_WIDTH + BASE_HORIZONTAL_INSET + RIGHT_INSET,
   },
   hideChartToggleOverride: {
     paddingRight: BASE_HORIZONTAL_INSET,
-    width: IS_IOS ? undefined : CANDLESTICK_CONTENT_WIDTH + BASE_HORIZONTAL_INSET * 2,
+    width: Platform.OS === 'ios' ? undefined : CANDLESTICK_CONTENT_WIDTH + BASE_HORIZONTAL_INSET * 2,
   },
   leftFade: {
     height: '100%',

--- a/src/features/charts/components/TimeframeSelectorCore.tsx
+++ b/src/features/charts/components/TimeframeSelectorCore.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo, type ReactNode, type RefObject } from 'react';
-import { ScrollView, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import Animated, { useAnimatedStyle, useDerivedValue, withSpring, type DerivedValue, type SharedValue } from 'react-native-reanimated';
 
@@ -7,7 +7,6 @@ import { easing, SPRING_CONFIGS } from '@/components/animations/animationConfigs
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { AnimatedText, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
@@ -78,11 +77,11 @@ export const TimeframeSelectorCore = memo(function TimeframeSelectorCore({
   return (
     <View style={styles.container}>
       <ScrollView
-        centerContent={!IS_IOS || layout === 'fill' || !rightAccessory}
+        centerContent={Platform.OS !== 'ios' || layout === 'fill' || !rightAccessory}
         contentContainerStyle={contentContainerStyle}
         contentOffset={initialContentOffset}
         horizontal
-        maintainVisibleContentPosition={IS_IOS ? undefined : { minIndexForVisible: 0 }}
+        maintainVisibleContentPosition={Platform.OS === 'ios' ? undefined : { minIndexForVisible: 0 }}
         ref={scrollViewRef}
         scrollEnabled={scrollEnabled}
         showsHorizontalScrollIndicator={false}
@@ -102,7 +101,6 @@ export const TimeframeSelectorCore = memo(function TimeframeSelectorCore({
           />
         ))}
       </ScrollView>
-
       {scrollEnabled ? (
         <>
           <EasingGradient
@@ -126,7 +124,6 @@ export const TimeframeSelectorCore = memo(function TimeframeSelectorCore({
           />
         </>
       ) : null}
-
       {rightAccessory}
     </View>
   );
@@ -185,7 +182,7 @@ const TimeframeButton = ({
   const textStyle = useAnimatedStyle(() => {
     const isSelected = selectedIndex.value === index;
     const textColor = isSelected ? color : labelQuaternary;
-    if (!IS_IOS) return { color: textColor };
+    if (Platform.OS !== 'ios') return { color: textColor };
     return {
       color: textColor,
       fontWeight: isSelected ? '800' : '700',
@@ -223,7 +220,7 @@ function getContentContainerStyle(layout: 'fill' | 'scrollable', optionsCount: n
     styles.contentContainer,
     {
       paddingRight: rightInset,
-      width: IS_IOS ? undefined : totalWidth,
+      width: Platform.OS === 'ios' ? undefined : totalWidth,
     },
   ];
 }

--- a/src/features/charts/components/TimeframeSelectorV2.tsx
+++ b/src/features/charts/components/TimeframeSelectorV2.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useRef, type RefObject } from 'react';
-import { StyleSheet, View, type ScrollView } from 'react-native';
+import { Platform, StyleSheet, View, type ScrollView } from 'react-native';
 
 import Animated, {
   runOnJS,
@@ -13,7 +13,6 @@ import Animated, {
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { globalColors, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStableValue } from '@/hooks/useStableValue';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
@@ -235,7 +234,7 @@ function toggleChartTypeAndScroll(scrollViewRef: RefObject<ScrollView | null>, s
   const isLineChart = newChartType === ChartType.Line;
   selectedIndex.value = newSelectedIndex;
 
-  if (IS_IOS && isLineChart) return;
+  if (Platform.OS === 'ios' && isLineChart) return;
 
   const scrollTo = () =>
     scrollViewRef.current?.setNativeProps({
@@ -245,7 +244,7 @@ function toggleChartTypeAndScroll(scrollViewRef: RefObject<ScrollView | null>, s
       },
     });
 
-  if (IS_IOS || isLineChart) scrollTo();
+  if (Platform.OS === 'ios' || isLineChart) scrollTo();
   else requestAnimationFrame(scrollTo);
 }
 
@@ -262,7 +261,7 @@ const styles = StyleSheet.create({
   candleBody: {
     borderCurve: 'continuous',
     borderRadius: 1.8,
-    borderWidth: IS_IOS ? 1 : 0,
+    borderWidth: Platform.OS === 'ios' ? 1 : 0,
     overflow: 'hidden',
     position: 'relative',
     width: 5,

--- a/src/features/charts/polymarket/components/PolymarketChart.tsx
+++ b/src/features/charts/polymarket/components/PolymarketChart.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { Canvas, Picture, type SkPicture } from '@shopify/react-native-skia';
 import { cloneDeep, merge } from 'lodash';
@@ -17,7 +17,6 @@ import { AnimatedSpinner } from '@/components/animations/AnimatedSpinner';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { globalColors, useColorMode, useForegroundColor } from '@/design-system';
 import { useSkiaText } from '@/design-system/components/SkiaText/useSkiaText';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useWorkletClass } from '@/hooks/reanimated/useWorkletClass';
 import { useCleanup } from '@/hooks/useCleanup';
@@ -239,7 +238,7 @@ export const PolymarketChart = memo(function PolymarketChart({
   }, [backgroundColor, chartManager, isDarkMode]);
 
   useOnChange(() => {
-    if (IS_IOS) return;
+    if (Platform.OS === 'ios') return;
     runOnUI(() => chartManager.value?.setBuildParagraph?.(buildParagraph))();
   }, [buildParagraph, chartManager]);
 

--- a/src/features/charts/polymarket/components/PolymarketChartHeader.tsx
+++ b/src/features/charts/polymarket/components/PolymarketChartHeader.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { useAnimatedStyle, useDerivedValue, withTiming, type DerivedValue, type SharedValue } from 'react-native-reanimated';
@@ -8,7 +8,6 @@ import { getColorValueForThemeWorklet, type ResponseByTheme } from '@/__swaps__/
 import { easing, TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { AnimatedText, Text, TextShadow, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { type StoreState } from '@/state/internal/queryStore/types';
 import { type BaseRainbowStore } from '@/state/internal/types';
@@ -179,7 +178,7 @@ const LegendItem = memo(function LegendItem({
     () => [
       styles.legendDot,
       { backgroundColor: getColorValueForThemeWorklet(color, isDarkMode) },
-      IS_IOS && isDarkMode && { shadowColor: getColorValueForThemeWorklet(color, isDarkMode) },
+      Platform.OS === 'ios' && isDarkMode && { shadowColor: getColorValueForThemeWorklet(color, isDarkMode) },
     ],
     [color, isDarkMode]
   );
@@ -293,7 +292,7 @@ const OutcomeBubble = memo(function OutcomeBubble({
         style={[
           styles.bubbleBackground,
           bubbleBackgroundStyle,
-          { borderWidth: IS_IOS ? (isDarkMode ? BUBBLE.borderWidth : THICKER_BORDER_WIDTH) : 0 },
+          { borderWidth: Platform.OS === 'ios' ? (isDarkMode ? BUBBLE.borderWidth : THICKER_BORDER_WIDTH) : 0 },
         ]}
       />
       <LinearGradient

--- a/src/features/ens/components/profile/ActionButtons/MoreButton.tsx
+++ b/src/features/ens/components/profile/ActionButtons/MoreButton.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
-import { Keyboard, Share } from 'react-native';
+import { Keyboard, Platform, Share } from 'react-native';
 
 import { showDeleteContactActionSheet } from '@/components/contacts';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import useClipboard from '@/hooks/useClipboard';
 import useContacts from '@/hooks/useContacts';
 import useWatchWallet from '@/hooks/useWatchWallet';
@@ -135,23 +134,23 @@ export default function MoreButton({ address, ensName }: { address?: string; ens
           nickname: contact!.nickname,
           removeContact: onRemoveContact,
         });
-        IS_ANDROID && Keyboard.dismiss();
+        Platform.OS === 'android' && Keyboard.dismiss();
       }
       if (actionKey === ACTIONS.SHARE) {
         const walletDisplay = ensName || address;
         const shareLink = `${RAINBOW_PROFILES_BASE_URL}/${walletDisplay}`;
-        Share.share(IS_ANDROID ? { message: shareLink } : { url: shareLink });
+        Share.share(Platform.OS === 'android' ? { message: shareLink } : { url: shareLink });
       }
     },
     [address, contact, ensName, isSelectedWallet, navigate, onRemoveContact, setClipboard]
   );
 
-  const menuConfig = useMemo(() => ({ menuItems, ...(IS_IOS && { menuTitle: '' }) }), [menuItems]);
+  const menuConfig = useMemo(() => ({ menuItems, ...(Platform.OS === 'ios' && { menuTitle: '' }) }), [menuItems]);
   return (
     <ContextMenuButton
       enableContextMenu
       menuConfig={menuConfig}
-      {...(IS_ANDROID ? { handlePressMenuItem } : {})}
+      {...(Platform.OS === 'android' ? { handlePressMenuItem } : {})}
       isMenuPrimaryAction
       onPressMenuItem={handlePressMenuItem}
       useActionSheetFallback={false}

--- a/src/features/ens/components/profile/ActionButtons/SendButton.tsx
+++ b/src/features/ens/components/profile/ActionButtons/SendButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
-import { IS_IOS } from '@/env';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 
@@ -9,7 +9,7 @@ import ActionButton from './ActionButton';
 export default function SendButton({ ensName }: { ensName?: string }) {
   const { navigate } = useNavigation();
   const handlePressSend = useCallback(async () => {
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       navigate(Routes.SEND_FLOW, {
         screen: Routes.SEND_SHEET,
         params: {

--- a/src/features/ens/hooks/useENSRegistrationActionHandler.ts
+++ b/src/features/ens/hooks/useENSRegistrationActionHandler.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
 
 import { type StaticJsonRpcProvider } from '@ethersproject/providers';
 import { type ImagePickerAsset } from 'expo-image-picker';
@@ -7,7 +8,6 @@ import { useRecoilValue } from 'recoil';
 import { type Hex } from 'viem';
 
 import { type PendingTransaction } from '@/entities/transactions';
-import { IS_IOS } from '@/env';
 import { uploadImage } from '@/handlers/pinata';
 import { getProvider } from '@/handlers/web3';
 import usePendingTransactions from '@/hooks/usePendingTransactions';
@@ -176,7 +176,7 @@ const useENSRegistrationActionHandler: UseENSRegistrationActionHandler = ({ step
 
       const tx = getPendingTransactionByHash(commitTransactionHash || '');
       if (commitTransactionHash && tx) {
-        if (IS_IOS) {
+        if (Platform.OS === 'ios') {
           navigate(Routes.SPEED_UP_AND_CANCEL_SHEET, {
             accentColor,
             tx: tx as PendingTransaction,

--- a/src/features/ens/screens/ENSAdditionalRecordsSheet.tsx
+++ b/src/features/ens/screens/ENSAdditionalRecordsSheet.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from 'react';
-import { useWindowDimensions } from 'react-native';
+import { Platform, useWindowDimensions } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useRecoilState } from 'recoil';
 
 import { SlackSheet } from '@/components/sheet';
 import { AccentColorProvider, Box, Inline } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import type Routes from '@/navigation/routesNames';
 import { type RootStackParamList } from '@/navigation/types';
 import deviceUtils from '@/utils/deviceUtils';
@@ -41,7 +40,7 @@ export default function ENSAdditionalRecordsSheet() {
   const androidTop = deviceHeight - boxStyle.height - recordLineHeight;
 
   return (
-    <SlackSheet additionalTopPadding height="100%" scrollEnabled={false} style={IS_ANDROID ? { top: androidTop } : {}}>
+    <SlackSheet additionalTopPadding height="100%" scrollEnabled={false} style={Platform.OS === 'android' ? { top: androidTop } : {}}>
       <AccentColorProvider color={accentColor}>
         <Box
           background="body (Deprecated)"

--- a/src/features/ens/screens/ENSAssignRecordsSheet.tsx
+++ b/src/features/ens/screens/ENSAssignRecordsSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { Keyboard, ScrollView, type EmitterSubscription, type LayoutChangeEvent } from 'react-native';
+import { Keyboard, Platform, ScrollView, type EmitterSubscription, type LayoutChangeEvent } from 'react-native';
 
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { BottomSheetContext } from '@gorhom/bottom-sheet/src/contexts/external';
@@ -13,7 +13,6 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import TintButton from '@/components/buttons/TintButton';
 import { SheetActionButton, SheetActionButtonRow } from '@/components/sheet';
 import { AccentColorProvider, Bleed, Box, Cover, Heading, Inline, Inset, Row, Rows, Stack, Text } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 import useKeyboardHeight from '@/hooks/useKeyboardHeight';
 import { delayNext } from '@/hooks/useMagicAutofocus';
@@ -319,7 +318,7 @@ export function ENSAssignRecordsBottomActions({
               </Row>
               <Row height="content">
                 <SheetActionButtonRow
-                  {...(IS_ANDROID
+                  {...(Platform.OS === 'android'
                     ? {
                         ignorePaddingBottom: true,
                         paddingBottom: 8,

--- a/src/features/ens/screens/ENSIntroSheet.tsx
+++ b/src/features/ens/screens/ENSIntroSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { InteractionManager, View } from 'react-native';
+import { InteractionManager, Platform, View } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import { useRoute, type RouteProp } from '@react-navigation/native';
@@ -11,7 +11,7 @@ import { ContextMenu } from '@/components/context-menu';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { SheetActionButton } from '@/components/sheet';
 import { Bleed, Box, Column, Columns, Heading, Inset, Row, Rows, Separator, Stack, Text } from '@/design-system';
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
@@ -93,7 +93,7 @@ const ContextMenuRenderer = ({ children, handleSelectExistingName, handleNavigat
     [handleNavigateToSearch, handleSelectExistingName]
   );
 
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     return (
       <ContextMenu
         activeOpacity={0}

--- a/src/features/gas/components/FeesPanel.tsx
+++ b/src/features/gas/components/FeesPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { InteractionManager, Keyboard, KeyboardAvoidingView } from 'react-native';
+import { InteractionManager, Keyboard, KeyboardAvoidingView, Platform } from 'react-native';
 
 import { useIsFocused, useRoute, type RouteProp } from '@react-navigation/native';
 
@@ -7,7 +7,7 @@ import { Alert } from '@/components/alerts';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import FeesGweiInput from '@/components/FeesGweiInput';
 import { Box, Inline, Inset, Row, Rows, Text } from '@/design-system';
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isL2Chain } from '@/handlers/web3';
 import { add, greaterThan, isZero, lessThan, multiply, toFixedDecimals } from '@/helpers/utilities';
@@ -173,7 +173,7 @@ export default function FeesPanel({ currentGasTrend, colorForAsset, setCanGoBack
                 {text}
               </Text>
             </Text>
-            <Box marginBottom={IS_ANDROID ? '-4px' : undefined}></Box>
+            <Box marginBottom={Platform.OS === 'android' ? '-4px' : undefined}></Box>
           </Inline>
         </Box>
       );

--- a/src/features/gas/components/FeesPanelTabs.tsx
+++ b/src/features/gas/components/FeesPanelTabs.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { isEmpty } from 'lodash';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { AccentColorProvider, Box, Inline, Inset, Text } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { colors } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
@@ -58,7 +58,7 @@ const TabPill = ({ speed, isSelected, handleOnPressTabPill, color, testID }: Tab
             elevation: 5,
           }}
         >
-          <Inset vertical={{ custom: IS_ANDROID ? 8 : 9 }}>
+          <Inset vertical={{ custom: Platform.OS === 'android' ? 8 : 9 }}>
             <Text
               size="16px / 22px (Deprecated)"
               color={{

--- a/src/features/gas/components/GasSpeedButton.tsx
+++ b/src/features/gas/components/GasSpeedButton.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Keyboard, View } from 'react-native';
+import { InteractionManager, Keyboard, Platform, View } from 'react-native';
 
 import AnimateNumber from '@bankify/react-native-animate-number';
 import { isEmpty, isNaN, isNil, noop } from 'lodash';
@@ -15,7 +15,6 @@ import { Centered, Column, Row } from '@/components/layout';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Text } from '@/components/text';
 import type { ParsedAddressAsset } from '@/entities/tokens';
-import { IS_ANDROID } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isL2Chain } from '@/handlers/web3';
@@ -403,7 +402,7 @@ const GasSpeedButton = ({
     );
     if (!gasOptionsAvailable || gasIsNotReady) return pager;
 
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       return (
         <ContextMenu
           activeOpacity={0}

--- a/src/features/gas/components/GasSpeedMenu.tsx
+++ b/src/features/gas/components/GasSpeedMenu.tsx
@@ -1,9 +1,9 @@
 import React, { type ReactNode } from 'react';
+import { Platform } from 'react-native';
 
 import { ContextMenu } from '@/components/context-menu';
 import { Centered } from '@/components/layout';
 import ContextMenuButton, { type MenuConfig } from '@/components/native-context-menu/contextMenu';
-import { IS_ANDROID } from '@/env';
 
 type GasSpeedMenuProps = {
   children: ReactNode;
@@ -14,7 +14,7 @@ type GasSpeedMenuProps = {
 };
 
 export const GasSpeedMenu = ({ children, menuConfig, onPressActionSheet, onPressMenuItem, options }: GasSpeedMenuProps) => {
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     return (
       <ContextMenu
         activeOpacity={0}

--- a/src/features/gas/utils/gas.ts
+++ b/src/features/gas/utils/gas.ts
@@ -1,6 +1,7 @@
+import { Platform } from 'react-native';
+
 import { type TextColor } from '@/design-system/color/palettes';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_IOS } from '@/env';
 import { convertAmountToNativeDisplay } from '@/helpers/utilities';
 import * as i18n from '@/languages';
 import { colors } from '@/styles';
@@ -61,7 +62,7 @@ const GAS_EMOJIS: {
 } = {
   [CUSTOM]: '⚙️',
   [FAST]: '🚀',
-  [NORMAL]: IS_IOS ? '⏱' : '🕘',
+  [NORMAL]: Platform.OS === 'ios' ? '⏱' : '🕘',
   [URGENT]: '🚨',
 };
 

--- a/src/features/notifications/screens/NotificationPermissionScreen.tsx
+++ b/src/features/notifications/screens/NotificationPermissionScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Image, ImageBackground, StyleSheet, View } from 'react-native';
+import { Image, ImageBackground, Platform, StyleSheet, View } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import { useNavigation } from '@react-navigation/native';
@@ -14,7 +14,6 @@ import mockNotificationsIOS from '@/assets/mockNotificationsIOS.png';
 import backgroundImage from '@/assets/notificationsPromoSheetBackground.png';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Bleed, Box, ColorModeProvider, Column, Columns, Stack, Text } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { useHardwareBackOnFocus } from '@/hooks/useHardwareBack';
 import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
@@ -46,7 +45,7 @@ export function NotificationPermissionScreen() {
     },
   ];
 
-  const headerImage = IS_IOS ? mockNotificationsIOS : mockNotificationsAndroid;
+  const headerImage = Platform.OS === 'ios' ? mockNotificationsIOS : mockNotificationsAndroid;
 
   const navigateToWallet = useCallback(() => {
     goBack();
@@ -58,7 +57,7 @@ export function NotificationPermissionScreen() {
     navigateToWallet();
   }, [navigateToWallet]);
 
-  useHardwareBackOnFocus(() => true, !IS_ANDROID);
+  useHardwareBackOnFocus(() => true, Platform.OS !== 'android');
 
   const handleEnable = useCallback(async () => {
     try {
@@ -126,7 +125,7 @@ const ValuePropItem = ({ title, description, icon }: { title: string; descriptio
       <Column width="content">
         <MaskedView
           maskElement={
-            <Box paddingTop={IS_ANDROID ? '6px' : undefined}>
+            <Box paddingTop={Platform.OS === 'android' ? '6px' : undefined}>
               <Text align="center" color="accent" size="30pt" weight="bold">
                 {icon}
               </Text>
@@ -162,7 +161,7 @@ const ValuePropItem = ({ title, description, icon }: { title: string; descriptio
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    ...(IS_ANDROID && {
+    ...(Platform.OS === 'android' && {
       borderTopLeftRadius: 40,
       borderTopRightRadius: 40,
       overflow: 'hidden',

--- a/src/features/perps/components/NumberPad/NumberPadKey.tsx
+++ b/src/features/perps/components/NumberPad/NumberPadKey.tsx
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import Animated, {
   Easing,
   interpolateColor,
@@ -14,7 +16,6 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { HitSlop, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { colors } from '@/styles';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
@@ -145,7 +146,7 @@ export const NumberPadKey = <K extends string>({
             !transparent && {
               borderColor: isDarkMode ? separatorTertiary : 'transparent',
               borderCurve: 'continuous',
-              borderWidth: IS_IOS ? THICK_BORDER_WIDTH : 0,
+              borderWidth: Platform.OS === 'ios' ? THICK_BORDER_WIDTH : 0,
               shadowColor: isDarkMode ? 'transparent' : colors.dark,
               shadowOffset: {
                 width: 0,

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, StyleSheet, type NativeSyntheticEvent, type TextInput, type TextInputChangeEventData } from 'react-native';
+import { Alert, Platform, StyleSheet, type NativeSyntheticEvent, type TextInput, type TextInputChangeEventData } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
@@ -13,7 +13,6 @@ import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldT
 import { DEFAULT_MOUNT_ANIMATIONS } from '@/components/utilities/MountWhenFocused';
 import { Box, Text, TextShadow, useColorMode } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
-import { IS_ANDROID } from '@/env';
 import { HyperliquidButton } from '@/features/perps/components/HyperliquidButton';
 import { usePerpsAccentColorContext } from '@/features/perps/context/PerpsAccentColorContext';
 import { PerpsNavigation, usePerpsNavigationStore } from '@/features/perps/screens/PerpsNavigator';
@@ -339,7 +338,7 @@ export const PerpsNavigatorFooter = memo(function PerpsNavigatorFooter() {
   return (
     <>
       {/* Required to block touches from passing through on Android */}
-      {IS_ANDROID && <Box position="absolute" bottom="0px" left="0px" right="0px" width="full" height={footerHeight} />}
+      {Platform.OS === 'android' && <Box position="absolute" bottom="0px" left="0px" right="0px" width="full" height={footerHeight} />}
       <KeyboardStickyView offset={{ opened: safeAreaInsets.bottom + MAGIC_KEYBOARD_OFFSET_NUDGE - PADDING }} enabled={enableStickyKeyboard}>
         <Box
           position="absolute"

--- a/src/features/perps/components/PerpsSwapButton.tsx
+++ b/src/features/perps/components/PerpsSwapButton.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type ViewStyle } from 'react-native';
 
 import chroma from 'chroma-js';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -17,7 +17,6 @@ import { SPRING_CONFIGS, TIMING_CONFIGS } from '@/components/animations/animatio
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { Box, Cover, useColorMode, useForegroundColor } from '@/design-system';
 import { AnimatedText, type SharedOrDerivedValueText } from '@/design-system/components/Text/AnimatedText';
-import { IS_IOS } from '@/env';
 import { usePerpsAccentColorContext } from '@/features/perps/context/PerpsAccentColorContext';
 import { opacity } from '@/framework/ui/utils/opacity';
 
@@ -46,7 +45,7 @@ const HoldProgress = ({ holdProgress, color }: { holdProgress: SharedValue<numbe
           {
             backgroundColor: brightenedColor,
             height: '100%',
-            ...(IS_IOS
+            ...(Platform.OS === 'ios'
               ? {
                   shadowColor: brightenedColor,
                   shadowOffset: {

--- a/src/features/perps/components/Slider/Slider.tsx
+++ b/src/features/perps/components/Slider/Slider.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type ViewStyle } from 'react-native';
 
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
@@ -19,7 +19,6 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import { SCRUBBER_WIDTH } from '@/__swaps__/screens/Swap/constants';
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { Box, globalColors, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
@@ -365,28 +364,30 @@ export const Slider: React.FC<SliderProps> = ({
         interpolateColor(sliderPressProgress.value, [collapsedPercentage, 1], [colors.value.inactiveLeft, colors.value.activeLeft]),
         SPRING_CONFIGS.springConfig
       ),
-      borderWidth: IS_IOS
-        ? interpolate(
-            percentageValue.value,
-            [0, (THICK_BORDER_WIDTH * 2) / width, (THICK_BORDER_WIDTH * 4) / width, 1],
-            [0, 0, THICK_BORDER_WIDTH, THICK_BORDER_WIDTH],
-            'clamp'
-          )
-        : 0,
+      borderWidth:
+        Platform.OS === 'ios'
+          ? interpolate(
+              percentageValue.value,
+              [0, (THICK_BORDER_WIDTH * 2) / width, (THICK_BORDER_WIDTH * 4) / width, 1],
+              [0, 0, THICK_BORDER_WIDTH, THICK_BORDER_WIDTH],
+              'clamp'
+            )
+          : 0,
       width: `${uiXPercentage.value * 100}%`,
     };
   });
 
   const rightBarContainerStyle = useAnimatedStyle(() => {
     return {
-      borderWidth: IS_IOS
-        ? interpolate(
-            percentageValue.value,
-            [0, 1 - (THICK_BORDER_WIDTH * 4) / width, 1 - (THICK_BORDER_WIDTH * 2) / width, 1],
-            [THICK_BORDER_WIDTH, THICK_BORDER_WIDTH, 0, 0],
-            'clamp'
-          )
-        : 0,
+      borderWidth:
+        Platform.OS === 'ios'
+          ? interpolate(
+              percentageValue.value,
+              [0, 1 - (THICK_BORDER_WIDTH * 4) / width, 1 - (THICK_BORDER_WIDTH * 2) / width, 1],
+              [THICK_BORDER_WIDTH, THICK_BORDER_WIDTH, 0, 0],
+              'clamp'
+            )
+          : 0,
       backgroundColor: colors.value.inactiveRight,
       width: `${(1 - uiXPercentage.value - SCRUBBER_WIDTH / width) * 100}%`,
     };
@@ -427,7 +428,7 @@ export const Slider: React.FC<SliderProps> = ({
             style={[
               styles.sliderBox,
               rightBarContainerStyle,
-              IS_IOS ? { borderColor: isDarkMode ? 'rgba(245, 248, 255, 0.015)' : 'rgba(26, 28, 31, 0.005)' } : undefined,
+              Platform.OS === 'ios' ? { borderColor: isDarkMode ? 'rgba(245, 248, 255, 0.015)' : 'rgba(26, 28, 31, 0.005)' } : undefined,
             ]}
           />
         </Animated.View>

--- a/src/features/perps/screens/perp-detail-screen/PerpDetailScreen.tsx
+++ b/src/features/perps/screens/perp-detail-screen/PerpDetailScreen.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSharedValue } from 'react-native-reanimated';
@@ -10,7 +11,6 @@ import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import SlackSheet from '@/components/sheet/SlackSheet';
 import { Chart } from '@/components/value-chart/Chart';
 import { Bleed, Box, Inline, Separator, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { HyperliquidTokenIcon } from '@/features/perps/components/HyperliquidTokenIcon';
 import { PerpsNameRow } from '@/features/perps/components/PerpsNameRow';
 import { PERPS_BACKGROUND_DARK, PERPS_BACKGROUND_LIGHT } from '@/features/perps/constants';
@@ -164,7 +164,7 @@ const PerpsDetailScreenContent = memo(function PerpsDetailScreenContent({ market
       <SlackSheet
         backgroundColor={backgroundColor}
         // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(IS_IOS ? { height: '100%' } : {})}
+        {...(Platform.OS === 'ios' ? { height: '100%' } : {})}
         scrollEnabled
         removeTopPadding
         hideHandle
@@ -214,7 +214,7 @@ const PerpsDetailScreenContent = memo(function PerpsDetailScreenContent({ market
         </Box>
       </SlackSheet>
       <Box position="absolute" top="0px" left="0px" right="0px" width="full" pointerEvents="none">
-        <Box backgroundColor={backgroundColor} height={safeAreaInsets.top + (IS_ANDROID ? 24 : 12)} width="full">
+        <Box backgroundColor={backgroundColor} height={safeAreaInsets.top + (Platform.OS === 'android' ? 24 : 12)} width="full">
           <Box
             height={{ custom: 5 }}
             width={{ custom: 36 }}

--- a/src/features/perps/screens/perps-new-position-screen/PerpsNewPositionScreen.tsx
+++ b/src/features/perps/screens/perps-new-position-screen/PerpsNewPositionScreen.tsx
@@ -1,11 +1,10 @@
 import React, { memo } from 'react';
-import { Keyboard, ScrollView } from 'react-native';
+import { Keyboard, Platform, ScrollView } from 'react-native';
 
 import Animated, { useSharedValue } from 'react-native-reanimated';
 
 import { AmountInputCard } from '@/components/amount-input-card/AmountInputCard';
 import { Box, Separator, Stack, useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { HeaderFade } from '@/features/perps/components/HeaderFade';
 import { FOOTER_HEIGHT_WITH_SAFE_AREA, LAYOUT_ANIMATION, PERPS_BACKGROUND_DARK, PERPS_BACKGROUND_LIGHT } from '@/features/perps/constants';
 import { usePerpsAccentColorContext } from '@/features/perps/context/PerpsAccentColorContext';
@@ -48,7 +47,7 @@ export const PerpsNewPositionScreen = memo(function PerpsNewPositionScreen() {
             paddingHorizontal: 20,
             overflow: 'visible',
             paddingTop: POSITION_SIDE_SELECTOR_HEIGHT_WITH_PADDING,
-            paddingBottom: IS_ANDROID ? FOOTER_HEIGHT_WITH_SAFE_AREA : 0,
+            paddingBottom: Platform.OS === 'android' ? FOOTER_HEIGHT_WITH_SAFE_AREA : 0,
           }}
         >
           <Box paddingTop={'24px'}>

--- a/src/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic.tsx
+++ b/src/features/perps/screens/perps-trade-details-sheet/PnlShareGraphic.tsx
@@ -3,6 +3,7 @@ import {
   Image,
   ImageBackground,
   PixelRatio,
+  Platform,
   StyleSheet,
   Text,
   View,
@@ -20,7 +21,6 @@ import rainbowTextLogo from '@/assets/rainbowTextLogo.png';
 import { PANEL_WIDTH } from '@/components/PanelSheet/PanelSheet';
 import { Box, globalColors } from '@/design-system';
 import { fonts } from '@/design-system/typography/typography';
-import { IS_ANDROID } from '@/env';
 import { PERPS_COLORS } from '@/features/perps/constants';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { type HlTrade } from '@/features/perps/types';
@@ -62,7 +62,7 @@ const SHARE_CARD_GAP = 8;
 const SHARE_CARD_SNAP_INTERVAL = SHARE_CARD_WIDTH + SHARE_CARD_GAP;
 const SHARE_CAROUSEL_WIDTH = SHARE_CARD_WIDTH + SHARE_CARD_SIDE_PEEK * 2;
 const SHARE_CARD_BORDER_RADIUS = 20;
-const ANDROID_TEXT_FIX = IS_ANDROID ? ({ includeFontPadding: false, textAlignVertical: 'center' } as const) : {};
+const ANDROID_TEXT_FIX = Platform.OS === 'android' ? ({ includeFontPadding: false, textAlignVertical: 'center' } as const) : {};
 const SF_BOLD = { ...fonts.SFProRounded.bold, ...ANDROID_TEXT_FIX };
 const SF_BLACK = { ...fonts.SFProRounded.black, ...ANDROID_TEXT_FIX };
 

--- a/src/features/polymarket/components/PolymarketPositionCard.tsx
+++ b/src/features/polymarket/components/PolymarketPositionCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, type GestureResponderEvent } from 'react-native';
+import { Platform, StyleSheet, type GestureResponderEvent } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -10,7 +10,6 @@ import { GradientBorderView } from '@/components/gradient-border/GradientBorderV
 import ImgixImage from '@/components/images/ImgixImage';
 import { LiveTokenText, useLiveTokenValue } from '@/components/live-token-text/LiveTokenText';
 import { Bleed, Box, Separator, Text, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { formatCurrency } from '@/features/perps/utils/formatCurrency';
 import { CheckOrXBadge } from '@/features/polymarket/components/CheckOrXBadge';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
@@ -119,9 +118,9 @@ export const PolymarketPositionCard = memo(function PolymarketPositionCard({
   }, [livePositionValue, position.initialValue]);
 
   return (
-    <ConditionalWrap condition={!IS_IOS} wrap={children => <Box style={styles.container}>{children}</Box>}>
+    <ConditionalWrap condition={Platform.OS !== 'ios'} wrap={children => <Box style={styles.container}>{children}</Box>}>
       <>
-        {!IS_IOS && showActionButton && (
+        {Platform.OS !== 'ios' && showActionButton && (
           <Box style={styles.actionButtonOverlay}>
             <ButtonPressAnimation onPress={onPressActionButton} scaleTo={0.975} exclusive>
               <Box
@@ -282,7 +281,7 @@ export const PolymarketPositionCard = memo(function PolymarketPositionCard({
                   </Box>
                 </Box>
                 {showActionButton &&
-                  (IS_IOS ? (
+                  (Platform.OS === 'ios' ? (
                     <ButtonPressAnimation onPress={onPressActionButton} scaleTo={0.975} exclusive>
                       <Box
                         width="full"

--- a/src/features/polymarket/components/polymarket-sport-event-list-item/PolymarketSportEventListItem.tsx
+++ b/src/features/polymarket/components/polymarket-sport-event-list-item/PolymarketSportEventListItem.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 
@@ -7,7 +7,6 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import ShimmerAnimation from '@/components/animations/ShimmerAnimation';
 import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
 import { Text, TextShadow, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { TeamLogo } from '@/features/polymarket/components/TeamLogo';
 import { usePolymarketLiveGame } from '@/features/polymarket/hooks/usePolymarketLiveGame';
 import { type PolymarketEvent, type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
@@ -122,9 +121,9 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
   );
 
   return (
-    <ConditionalWrap condition={IS_ANDROID} wrap={children => <View style={[styles.container, style]}>{children}</View>}>
+    <ConditionalWrap condition={Platform.OS === 'android'} wrap={children => <View style={[styles.container, style]}>{children}</View>}>
       <>
-        {IS_ANDROID && (
+        {Platform.OS === 'android' && (
           <View style={styles.betCellsOverlay}>
             <View style={styles.betsColumn}>
               <View style={styles.betRow}>
@@ -152,7 +151,7 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
             </View>
           </View>
         )}
-        <ButtonPressAnimation onPress={() => navigateToEvent(event)} scaleTo={0.98} style={IS_IOS ? style : undefined}>
+        <ButtonPressAnimation onPress={() => navigateToEvent(event)} scaleTo={0.98} style={Platform.OS === 'ios' ? style : undefined}>
           <View style={[styles.card, { backgroundColor: cardBackground, borderColor }]}>
             <View style={styles.header}>
               <Text align="left" color="label" size="13pt" weight="heavy" numberOfLines={2}>
@@ -210,7 +209,7 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
                     </View>
                   </View>
                 ) : null}
-                {IS_IOS ? (
+                {Platform.OS === 'ios' ? (
                   <View style={styles.betsColumn}>
                     <View style={styles.betRow}>
                       {awayBets.spread && (

--- a/src/features/polymarket/screens/polymarket-event-screen/BetTypeSelector.tsx
+++ b/src/features/polymarket/screens/polymarket-event-screen/BetTypeSelector.tsx
@@ -1,10 +1,9 @@
 import React, { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { useAnimatedStyle } from 'react-native-reanimated';
 
 import { AnimatedText, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 
 import { ItemSelector, type Item, type RenderItemProps } from './ItemSelector';
@@ -107,7 +106,7 @@ const BetTypeItemContent = memo(function BetTypeItemContent({
   const textStyle = useAnimatedStyle(() => {
     const isSelected = selectedIndex.value === index;
     const textColor = isSelected ? accentColor : labelQuaternary;
-    if (!IS_IOS) return { color: textColor };
+    if (Platform.OS !== 'ios') return { color: textColor };
     return {
       color: textColor,
       fontWeight: isSelected ? '800' : '700',

--- a/src/features/polymarket/screens/polymarket-event-screen/ItemSelector.tsx
+++ b/src/features/polymarket/screens/polymarket-event-screen/ItemSelector.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
-import { ScrollView, StyleSheet, View, type ScrollViewProps, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View, type ScrollViewProps, type StyleProp, type ViewStyle } from 'react-native';
 
 import Animated, {
   runOnJS,
@@ -15,7 +15,6 @@ import { easing, SPRING_CONFIGS } from '@/components/animations/animationConfigs
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { AnimatedText, Box, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 
 // ============ Constants ====================================================== //
@@ -280,7 +279,7 @@ const DefaultItemContent = memo(function DefaultItemContent({
   const textStyle = useAnimatedStyle(() => {
     const isSelected = selectedIndex.value === index;
     const textColor = isSelected ? accentColor : labelQuaternary;
-    if (!IS_IOS) return { color: textColor };
+    if (Platform.OS !== 'ios') return { color: textColor };
     return {
       color: textColor,
       fontWeight: isSelected ? '800' : '700',
@@ -431,10 +430,10 @@ function getScrollViewProps({
   pillWidth: number;
   paddingHorizontal: number;
 }): Pick<ScrollViewProps, 'contentContainerStyle' | 'maintainVisibleContentPosition' | 'style'> {
-  const contentWidth = IS_IOS ? undefined : valueCount * pillWidth + pillGap * (valueCount - 1) + paddingHorizontal * 2;
+  const contentWidth = Platform.OS === 'ios' ? undefined : valueCount * pillWidth + pillGap * (valueCount - 1) + paddingHorizontal * 2;
   return {
     contentContainerStyle: [styles.contentContainer, { width: contentWidth, gap: pillGap, paddingHorizontal }],
-    maintainVisibleContentPosition: IS_IOS ? undefined : { minIndexForVisible: 0 },
+    maintainVisibleContentPosition: Platform.OS === 'ios' ? undefined : { minIndexForVisible: 0 },
     style: styles.scrollView,
   };
 }

--- a/src/features/polymarket/screens/polymarket-event-screen/PolymarketEventScreen.tsx
+++ b/src/features/polymarket/screens/polymarket-event-screen/PolymarketEventScreen.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSharedValue } from 'react-native-reanimated';
@@ -9,7 +10,6 @@ import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import ImgixImage from '@/components/images/ImgixImage';
 import SlackSheet from '@/components/sheet/SlackSheet';
 import { Bleed, Box, globalColors, Separator, Text, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { type ActiveInteractionData } from '@/features/charts/polymarket/classes/PolymarketChartManager';
 import { PolymarketChart } from '@/features/charts/polymarket/components/PolymarketChart';
 import { PolymarketChartHeader } from '@/features/charts/polymarket/components/PolymarketChartHeader';
@@ -161,7 +161,7 @@ export const PolymarketEventScreen = memo(function PolymarketEventScreen() {
       <SlackSheet
         backgroundColor={screenBackgroundColor}
         // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(IS_IOS ? { height: '100%' } : {})}
+        {...(Platform.OS === 'ios' ? { height: '100%' } : {})}
         scrollEnabled
         removeTopPadding
         hideHandle
@@ -197,7 +197,7 @@ export const PolymarketEventScreen = memo(function PolymarketEventScreen() {
         </Box>
       </SlackSheet>
       <Box position="absolute" top="0px" left="0px" right="0px" width="full" pointerEvents="none">
-        <Box backgroundColor={screenBackgroundColor} height={safeAreaInsets.top + (IS_ANDROID ? 24 : 12)} width="full">
+        <Box backgroundColor={screenBackgroundColor} height={safeAreaInsets.top + (Platform.OS === 'android' ? 24 : 12)} width="full">
           <Box
             height={{ custom: 5 }}
             width={{ custom: 36 }}

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigatorFooter.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigatorFooter.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import Animated from 'react-native-reanimated';
@@ -9,7 +9,6 @@ import { easing } from '@/components/animations/animationConfigs';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { DEFAULT_MOUNT_ANIMATIONS } from '@/components/utilities/MountWhenFocused';
 import { Box, globalColors, useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { NAVIGATOR_FOOTER_HEIGHT } from '@/features/polymarket/constants';
 import { usePolymarketNavigationStore } from '@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator';
 import { PolymarketSearchButton } from '@/features/polymarket/screens/polymarket-navigator/PolymarketSearchButton';
@@ -40,7 +39,7 @@ export const PolymarketNavigatorFooter = function PolymarketNavigatorFooter() {
   return (
     <>
       {/* Required to block touches from passing through on Android */}
-      {IS_ANDROID && (
+      {Platform.OS === 'android' && (
         <Box
           position="absolute"
           bottom="0px"

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketSearchButton.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketSearchButton.tsx
@@ -1,12 +1,11 @@
 import React, { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'react-native-blur-view';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, globalColors, TextIcon, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
 import { POLYMARKET_BACKGROUND_LIGHT } from '@/features/polymarket/constants';
 import { PolymarketNavigation } from '@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator';
@@ -41,7 +40,7 @@ export const PolymarketSearchButton = memo(function PolymarketSearchButton() {
           />
           {isDarkMode && (
             <>
-              {IS_IOS ? (
+              {Platform.OS === 'ios' ? (
                 <BlurView blurIntensity={24} blurStyle={'dark'} style={StyleSheet.absoluteFill} />
               ) : (
                 <View style={[StyleSheet.absoluteFill, { backgroundColor: '#190F1C' }]} />

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketSearchFooter.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketSearchFooter.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
-import { StyleSheet, View, type NativeSyntheticEvent, type TextInput, type TextInputChangeEventData } from 'react-native';
+import { Platform, StyleSheet, View, type NativeSyntheticEvent, type TextInput, type TextInputChangeEventData } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'react-native-blur-view';
@@ -9,7 +9,6 @@ import { AnimatedInput } from '@/components/AnimatedComponents/AnimatedInput';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, globalColors, Text, useColorMode } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
-import { IS_IOS } from '@/env';
 import { POLYMARKET_BACKGROUND_LIGHT } from '@/features/polymarket/constants';
 import { PolymarketNavigation } from '@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator';
 import { polymarketEventSearchActions } from '@/features/polymarket/stores/polymarketEventSearchStore';
@@ -98,7 +97,6 @@ export const PolymarketSearchFooter = memo(function PolymarketSearchFooter() {
           </Text>
         </Box>
       </ButtonPressAnimation>
-
       <View style={styles.flex}>
         <Box
           height={SEARCH_BAR_HEIGHT}
@@ -111,7 +109,7 @@ export const PolymarketSearchFooter = memo(function PolymarketSearchFooter() {
         >
           {isDarkMode && (
             <>
-              {IS_IOS ? (
+              {Platform.OS === 'ios' ? (
                 <>
                   <BlurView blurIntensity={24} blurStyle={'dark'} style={StyleSheet.absoluteFill} />
                   <LinearGradient

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketTabSelector.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketTabSelector.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'react-native-blur-view';
@@ -16,7 +16,6 @@ import Animated, {
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { AnimatedText, Box, useColorMode, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
 import { POLYMARKET_BACKGROUND_LIGHT } from '@/features/polymarket/constants';
 import { usePolymarketContext } from '@/features/polymarket/screens/polymarket-navigator/PolymarketContext';
@@ -115,7 +114,7 @@ export const PolymarketTabSelector = memo(function PolymarketTabSelector() {
             end={{ x: 0, y: 1 }}
           />
         )}
-        {IS_IOS ? (
+        {Platform.OS === 'ios' ? (
           <BlurView blurIntensity={24} blurStyle={isDarkMode ? 'dark' : 'light'} style={StyleSheet.absoluteFill} />
         ) : (
           <View style={[StyleSheet.absoluteFill, { backgroundColor: isDarkMode ? '#190F1C' : POLYMARKET_BACKGROUND_LIGHT }]} />

--- a/src/features/positions/components/LpPositionListItem.tsx
+++ b/src/features/positions/components/LpPositionListItem.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { TwoCoinsIcon } from '@/components/coin-icon/TwoCoinsIcon';
 import { Box, Column, Columns, Inline, Stack, Text, useForegroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { type LpAllocation, type RainbowUnderlyingAsset, type RangeStatus } from '@/features/positions/types';
 import * as i18n from '@/languages';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
@@ -138,7 +138,7 @@ export const LpPositionListItem = React.memo(function LpPositionListItem({
                     backgroundColor={rangeStatus === 'in_range' || rangeStatus === 'full_range' ? colors.green : colors.red}
                     shadowColor={rangeStatus === 'in_range' || rangeStatus === 'full_range' ? colors.green : colors.red}
                     elevation={2}
-                    shadowOpacity={IS_IOS ? 0.2 : 1}
+                    shadowOpacity={Platform.OS === 'ios' ? 0.2 : 1}
                     shadowRadius={6}
                     style={{
                       shadowOffset: { width: 0, height: 2 },

--- a/src/features/positions/components/LpPositionRangeBadge.tsx
+++ b/src/features/positions/components/LpPositionRangeBadge.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
 import { Box } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 const ASSET_SPACE = 2;
 const WIDTH = 32;
@@ -66,7 +65,7 @@ export const LpPositionRangeBadge = ({ assets }: LpPositionRangeBadgeProps) => {
             height={'full'}
             width={{ custom: width }}
             shadowColor={asset.color}
-            shadowOpacity={IS_IOS ? 0.2 : 1}
+            shadowOpacity={Platform.OS === 'ios' ? 0.2 : 1}
             shadowRadius={9}
             elevation={3}
             style={{

--- a/src/features/positions/components/PositionCard.tsx
+++ b/src/features/positions/components/PositionCard.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useCallback, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { capitalize, uniqBy } from 'lodash';
 import startCase from 'lodash/startCase';
@@ -9,7 +10,6 @@ import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import RequestVendorLogoIcon from '@/components/coin-icon/RequestVendorLogoIcon';
 import { Box, Column, Columns, globalColors, Inline, Stack, Text } from '@/design-system';
 import { NativeCurrencyKeys } from '@/entities/nativeCurrencyTypes';
-import { IS_ANDROID } from '@/env';
 import { type PositionAsset, type RainbowPosition } from '@/features/positions/types';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useNavigation } from '@/navigation/Navigation';
@@ -104,7 +104,7 @@ export const PositionCard = memo(function PositionCard({ position }: PositionCar
         onPress={onPressHandler}
         color={opacity(positionColor, 0.04)}
         borderColor={opacity(positionColor, 0.02)}
-        ignoreShadow={IS_ANDROID && isDarkMode}
+        ignoreShadow={Platform.OS === 'android' && isDarkMode}
         padding={'16px'}
       >
         <Stack space="16px">
@@ -119,7 +119,7 @@ export const PositionCard = memo(function PositionCard({ position }: PositionCar
                   size={32}
                   borderRadius={10}
                   imageUrl={position.dapp.icon_url}
-                  noShadow={IS_ANDROID}
+                  noShadow={Platform.OS === 'android'}
                 />
               </Column>
               <Column width="content">

--- a/src/features/positions/screens/PositionSheet.tsx
+++ b/src/features/positions/screens/PositionSheet.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { capitalize } from 'lodash';
@@ -11,7 +12,6 @@ import RequestVendorLogoIcon from '@/components/coin-icon/RequestVendorLogoIcon'
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
 import { BackgroundProvider, Box, globalColors, Inline, Separator, Stack, Text, useColorMode } from '@/design-system';
 import { NativeCurrencyKeys } from '@/entities/nativeCurrencyTypes';
-import { IS_IOS } from '@/env';
 import type { PositionAsset, RainbowPosition } from '@/features/positions/types';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useDimensions from '@/hooks/useDimensions';
@@ -101,7 +101,7 @@ export const PositionSheet: React.FC = () => {
     [nativeCurrency, position.protocol, position.totals.total.amount, position.type]
   );
 
-  const customHeight = IS_IOS ? undefined : Math.min(getPositionSheetHeight({ position }), height - insets.top);
+  const customHeight = Platform.OS === 'ios' ? undefined : Math.min(getPositionSheetHeight({ position }), height - insets.top);
 
   return (
     <BackgroundProvider color="surfaceSecondary">

--- a/src/features/rnbw-membership/components/RnbwButton/RnbwHoldToActivateButton.tsx
+++ b/src/features/rnbw-membership/components/RnbwButton/RnbwHoldToActivateButton.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 import chroma from 'chroma-js';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
@@ -11,7 +11,6 @@ import { HoldToActivateProgress } from '@/components/buttons/HoldToActivateProgr
 import { useHoldToActivate } from '@/components/buttons/useHoldToActivate';
 import { LedgerIcon } from '@/components/icons/svg/LedgerIcon';
 import { type TextProps } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { RNBW_BUTTON_CONFIG } from '@/features/rnbw-membership/rnbwButtonTheme';
 import { LoadingSpinner } from '@/framework/ui/components/LoadingSpinner';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
@@ -61,7 +60,10 @@ export const RnbwHoldToActivateButton = memo(function RnbwHoldToActivateButton({
   testID,
 }: RnbwHoldToActivateButtonProps) {
   const isHardwareWallet = useWalletsStore(state => state.getIsHardwareWallet());
-  const biometryIcon = useBiometryIconString({ showIcon: !IS_ANDROID && showBiometryIcon && !isProcessing, isHardwareWallet });
+  const biometryIcon = useBiometryIconString({
+    showIcon: Platform.OS !== 'android' && showBiometryIcon && !isProcessing,
+    isHardwareWallet,
+  });
 
   const { holdProgress, gestureHandlerProps } = useHoldToActivate({
     onActivate,

--- a/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
+++ b/src/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useState } from 'react';
-import { RefreshControl, View } from 'react-native';
+import { Platform, RefreshControl, View } from 'react-native';
 
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -10,7 +10,6 @@ import { ScrollHeaderFade } from '@/components/scroll-header-fade/ScrollHeaderFa
 import { useScrollFadeHandler } from '@/components/scroll-header-fade/useScrollFadeHandler';
 import { Box, useColorMode } from '@/design-system';
 import { getValueForColorMode } from '@/design-system/color/palettes';
-import { IS_ANDROID } from '@/env';
 import { MEMBERSHIP_SCREEN_BACKGROUND_COLOR } from '@/features/rnbw-membership/constants';
 import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
@@ -49,7 +48,7 @@ export const RnbwMembershipScreen = memo(function RnbwMembershipScreen() {
       <Animated.ScrollView
         refreshControl={<RefreshControlWrapper />}
         contentContainerStyle={{
-          paddingBottom: IS_ANDROID ? bottomInset : 0,
+          paddingBottom: Platform.OS === 'android' ? bottomInset : 0,
         }}
         style={scrollViewAnimatedStyle}
         onScroll={onScroll}

--- a/src/features/wallet-connect/handlers/onSessionAuthenticate.ts
+++ b/src/features/wallet-connect/handlers/onSessionAuthenticate.ts
@@ -1,6 +1,7 @@
+import { Platform } from 'react-native';
+
 import type { WalletKitTypes } from '@reown/walletkit';
 
-import { IS_ANDROID } from '@/env';
 import { DAppStatus } from '@/graphql/__generated__/metadata';
 import { getProvider } from '@/handlers/web3';
 import WalletTypes from '@/helpers/walletTypes';
@@ -134,6 +135,6 @@ export async function onSessionAuthenticate(event: WalletKitTypes.SessionAuthent
         requesterMeta: event.params.requester.metadata,
         verifiedData: event?.verifyContext.verified,
       }),
-    { sheetHeight: IS_ANDROID ? 560 : 520 + (isScam ? 40 : 0) }
+    { sheetHeight: Platform.OS === 'android' ? 560 : 520 + (isScam ? 40 : 0) }
   );
 }

--- a/src/features/wallet-connect/handlers/onSessionProposal.ts
+++ b/src/features/wallet-connect/handlers/onSessionProposal.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import type { WalletKitTypes } from '@reown/walletkit';
 import { getSdkError } from '@walletconnect/utils';
 import { uniq } from 'lodash';
@@ -5,7 +7,6 @@ import { uniq } from 'lodash';
 import { analytics } from '@/analytics';
 import Alert from '@/components/alerts/Alert';
 import { hideWalletConnectToast } from '@/components/toasts/WalletConnectToast';
-import { IS_IOS } from '@/env';
 import { events } from '@/handlers/appEvents';
 import { maybeSignUri } from '@/handlers/imgix';
 import * as i18n from '@/languages';
@@ -160,7 +161,7 @@ export async function onSessionProposal(proposal: WalletKitTypes.SessionProposal
               });
 
               maybeGoBackAndClearHasPendingRedirect();
-              if (IS_IOS) {
+              if (Platform.OS === 'ios') {
                 Navigation.handleAction(Routes.WALLET_CONNECT_REDIRECT_SHEET, {
                   type: 'connect',
                 });

--- a/src/features/wallet-connect/handlers/onSessionRequest.ts
+++ b/src/features/wallet-connect/handlers/onSessionRequest.ts
@@ -1,8 +1,9 @@
+import { Platform } from 'react-native';
+
 import { formatJsonRpcError, formatJsonRpcResult } from '@json-rpc-tools/utils';
 import type { SignClientTypes } from '@walletconnect/types';
 
 import { analytics } from '@/analytics';
-import { IS_IOS } from '@/env';
 import { maybeSignUri } from '@/handlers/imgix';
 import WalletTypes from '@/helpers/walletTypes';
 import * as i18n from '@/languages';
@@ -184,7 +185,7 @@ export async function onSessionRequest(event: SignClientTypes.EventArguments['se
         address,
         chainId,
         onComplete(type: WalletconnectResultType) {
-          if (IS_IOS) {
+          if (Platform.OS === 'ios') {
             Navigation.handleAction(Routes.WALLET_CONNECT_REDIRECT_SHEET, {
               type,
             });

--- a/src/features/wallet-connect/services/pair.ts
+++ b/src/features/wallet-connect/services/pair.ts
@@ -1,9 +1,8 @@
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Platform } from 'react-native';
 
 import { parseUri } from '@walletconnect/utils';
 import Minimizer from 'react-native-minimizer';
 
-import { IS_IOS } from '@/env';
 import { logger } from '@/logger';
 
 import { getWalletKitClient } from './client';
@@ -38,7 +37,7 @@ export function maybeGoBackAndClearHasPendingRedirect({ delay = 0 }: { delay?: n
       setTimeout(() => {
         setHasPendingDeeplinkPendingRedirect(false);
 
-        if (!IS_IOS) {
+        if (Platform.OS !== 'ios') {
           Minimizer.goBack();
         }
       }, delay);

--- a/src/framework/ui/utils/actionsheet.ts
+++ b/src/framework/ui/utils/actionsheet.ts
@@ -1,8 +1,6 @@
-import { ActionSheetIOS, type ActionSheetIOSOptions } from 'react-native';
+import { ActionSheetIOS, Platform, type ActionSheetIOSOptions } from 'react-native';
 
 import ActionSheet from 'react-native-action-sheet';
-
-import { IS_IOS } from '@/env';
 
 /**
  * @desc Safely convert options to strings.
@@ -29,7 +27,7 @@ export async function showActionSheetWithOptions(
 ) {
   const sheetOptions = safeOptions(options);
 
-  if (IS_IOS) {
+  if (Platform.OS === 'ios') {
     ActionSheetIOS.showActionSheetWithOptions(
       {
         options: sheetOptions,

--- a/src/handlers/authentication.ts
+++ b/src/handlers/authentication.ts
@@ -1,6 +1,7 @@
+import { Platform } from 'react-native';
+
 import { RAINBOW_MASTER_KEY } from 'react-native-dotenv';
 
-import { IS_ANDROID } from '@/env';
 import * as kc from '@/keychain';
 import { logger, RainbowError } from '@/logger';
 import Routes from '@/navigation/routesNames';
@@ -113,7 +114,7 @@ export async function authenticateWithPIN(): Promise<string | undefined> {
 }
 
 export async function shouldAuthenticateWithPIN(): Promise<boolean> {
-  if (!IS_ANDROID) {
+  if (Platform.OS !== 'android') {
     return false;
   }
 

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -1,9 +1,10 @@
+import { Platform } from 'react-native';
+
 import { sortBy } from 'lodash';
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import RNCloudFs from 'react-native-cloud-fs';
 import RNFS from 'react-native-fs';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { type BackupFile, type CloudBackups } from '@/features/backup/backup';
 import { logger, RainbowError } from '@/logger';
 
@@ -33,7 +34,7 @@ export function normalizeAndroidBackupFilename(filename: string) {
 }
 
 export async function logoutFromGoogleDrive() {
-  IS_ANDROID && RNCloudFs.logout();
+  Platform.OS === 'android' && RNCloudFs.logout();
 }
 
 export type GoogleDriveUserData = {
@@ -43,7 +44,7 @@ export type GoogleDriveUserData = {
 };
 
 export async function getGoogleAccountUserData(checkPermissions = false): Promise<GoogleDriveUserData | undefined> {
-  if (!IS_ANDROID) {
+  if (Platform.OS !== 'android') {
     return;
   }
   const options = { checkPermissions };
@@ -91,7 +92,7 @@ export async function encryptAndSaveDataToCloud(data: Record<string, unknown>, p
      * the filename is returned with the path used for Google Drive storage.
      * That is with REMOTE_BACKUP_WALLET_DIR included.
      */
-    const backupFilename = IS_ANDROID ? normalizeAndroidBackupFilename(filename) : filename;
+    const backupFilename = Platform.OS === 'android' ? normalizeAndroidBackupFilename(filename) : filename;
 
     // Store it on the FS first
     const path = `${RNFS.DocumentDirectoryPath}/${backupFilename}`;
@@ -102,7 +103,7 @@ export async function encryptAndSaveDataToCloud(data: Record<string, unknown>, p
     const mimeType = 'application/json';
     // Only available to our app
     const scope = 'hidden';
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       await RNCloudFs.loginIfNeeded();
     }
     const result = await RNCloudFs.copyToCloud({
@@ -114,7 +115,7 @@ export async function encryptAndSaveDataToCloud(data: Record<string, unknown>, p
     });
     // Now we need to verify the file has been stored in the cloud
     const exists = await RNCloudFs.fileExists(
-      IS_IOS
+      Platform.OS === 'ios'
         ? {
             scope,
             targetPath: destinationPath,
@@ -156,7 +157,7 @@ export function syncCloud() {
 }
 
 export async function getDataFromCloud(backupPassword: any, filename: string | null = null) {
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     await RNCloudFs.loginIfNeeded();
   }
 
@@ -172,7 +173,7 @@ export async function getDataFromCloud(backupPassword: any, filename: string | n
 
   let document;
   if (filename) {
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       // .icloud are files that were not yet synced
       document = backups.files.find((file: any) => file.name === filename || file.name === `.${filename}.icloud`);
     } else {
@@ -226,7 +227,7 @@ export function isCloudBackupAvailable() {
 }
 
 export async function login() {
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     return RNCloudFs.loginIfNeeded();
   }
 

--- a/src/handlers/localstorage/theme.ts
+++ b/src/handlers/localstorage/theme.ts
@@ -1,6 +1,7 @@
+import { Platform } from 'react-native';
+
 import { SystemBars } from 'react-native-edge-to-edge';
 
-import { IS_ANDROID } from '@/env';
 import { Themes, type ThemesType } from '@/theme/ThemeContext';
 
 import { getGlobal, saveGlobal } from './common';
@@ -17,7 +18,7 @@ export const getTheme = (): Promise<ThemesType> => getGlobal(THEME, 'system');
  * @desc save theme
  */
 export const saveTheme = (theme: ThemesType, isSystemDarkMode: boolean) => {
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     const themeToUse = theme === Themes.SYSTEM ? (isSystemDarkMode ? Themes.DARK : Themes.LIGHT) : theme;
     SystemBars.setStyle(themeToUse === Themes.DARK ? 'light' : 'dark');
   }

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { getAddress } from '@ethersproject/address';
 import { BigNumber, type BigNumberish } from '@ethersproject/bignumber';
 import { isHexString as isEthersHexString } from '@ethersproject/bytes';
@@ -13,7 +15,7 @@ import { AssetType } from '@/entities/assetTypes';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { type NewTransaction } from '@/entities/transactions';
 import { type UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_IOS, RPC_PROXY_API_KEY, RPC_PROXY_BASE_URL } from '@/env';
+import { RPC_PROXY_API_KEY, RPC_PROXY_BASE_URL } from '@/env';
 import { NftTokenType } from '@/graphql/__generated__/arc';
 import { isNativeAsset } from '@/handlers/assets';
 import {
@@ -240,7 +242,7 @@ export const isValidMnemonic = (value: string): boolean => ethersIsValidMnemonic
  * @return Whether or not the string was a valid bluetooth device id
  */
 export const isValidBluetoothDeviceId = (value: string): boolean => {
-  return IS_IOS
+  return Platform.OS === 'ios'
     ? value.length === 36 && isHexStringIgnorePrefix(value.replaceAll('-', ''))
     : value.length === 17 && isHexStringIgnorePrefix(value.replaceAll(':', ''));
 };

--- a/src/helpers/RainbowContext.tsx
+++ b/src/helpers/RainbowContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import { Platform } from 'react-native';
 
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { parseEther } from '@ethersproject/units';
@@ -7,7 +8,7 @@ import { createMMKV } from 'react-native-mmkv';
 import { useSharedValue } from 'react-native-reanimated';
 
 import { defaultConfigValues, type defaultConfig } from '@/config/experimental';
-import { IS_ANDROID, IS_DEV, IS_TEST } from '@/env';
+import { IS_DEV, IS_TEST } from '@/env';
 import Emoji from '@/framework/ui/components/Emoji';
 import { logger, RainbowError } from '@/logger';
 import { STORAGE_IDS } from '@/model/mmkv';
@@ -98,7 +99,7 @@ export default function RainbowContextWrapper({ children }: PropsWithChildren) {
 
   const fundTestWallet = useCallback(async () => {
     if (!IS_TEST) return;
-    const RPC_URL = IS_ANDROID ? 'http://10.0.2.2:8545' : 'http://127.0.0.1:8545';
+    const RPC_URL = Platform.OS === 'android' ? 'http://10.0.2.2:8545' : 'http://127.0.0.1:8545';
     try {
       const provider = new JsonRpcProvider(RPC_URL);
       const wallet = new Wallet('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', provider);

--- a/src/hooks/reanimated/useLayoutWorklet.ts
+++ b/src/hooks/reanimated/useLayoutWorklet.ts
@@ -1,7 +1,7 @@
+import { Platform } from 'react-native';
+
 import { useEvent } from 'react-native-reanimated';
 import { type WorkletFunction } from 'react-native-reanimated/lib/typescript/commonTypes';
-
-import { IS_IOS } from '@/env';
 
 interface Layout {
   x: number;
@@ -10,7 +10,7 @@ interface Layout {
   height: number;
 }
 
-const SHOULD_REBUILD = IS_IOS ? undefined : false;
+const SHOULD_REBUILD = Platform.OS === 'ios' ? undefined : false;
 
 /**
  * ### `📐 useLayoutWorklet 📐`

--- a/src/hooks/useHideSplashScreen.ts
+++ b/src/hooks/useHideSplashScreen.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { InteractionManager, NativeModules } from 'react-native';
+import { InteractionManager, NativeModules, Platform } from 'react-native';
 
 import { SystemBars } from 'react-native-edge-to-edge';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { type AppIconKey } from '@/features/app-icon/models/appIcons';
 import { getAppIcon } from '@/handlers/localstorage/globalSettings';
 import { logger, RainbowError } from '@/logger';
@@ -23,14 +22,14 @@ export const hideSplashScreen = async () => {
   try {
     if (RainbowSplashScreen?.hideAnimated) {
       RainbowSplashScreen.hideAnimated();
-    } else if (IS_ANDROID) {
+    } else if (Platform.OS === 'android') {
       const RNBootSplash = require('react-native-bootsplash');
       await RNBootSplash.hide({ fade: true });
     }
 
     onHandleStatusBar();
 
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       SystemBars.setHidden({ statusBar: false });
     } else {
       InteractionManager.runAfterInteractions(() => {

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Keyboard, type TextInput } from 'react-native';
+import { InteractionManager, Keyboard, Platform, type TextInput } from 'react-native';
 
 import { useDispatch } from 'react-redux';
 
 import { analytics } from '@/analytics';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import { IS_ANDROID, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { isValidAddress, looksLikeAddress } from '@/features/address/core/address';
 import { backupsStore } from '@/features/backup/stores/backupsStore';
 import { fetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
@@ -90,7 +90,7 @@ export default function useImportingWallet({
         });
 
       if (showImportModal) {
-        if (IS_ANDROID) {
+        if (Platform.OS === 'android') {
           Keyboard.dismiss();
         }
 

--- a/src/hooks/useKeyboardHeight.ts
+++ b/src/hooks/useKeyboardHeight.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { Keyboard, type EmitterSubscription, type KeyboardEventListener } from 'react-native';
+import { Keyboard, Platform, type EmitterSubscription, type KeyboardEventListener } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { IS_ANDROID } from '@/env';
 import KeyboardTypes from '@/helpers/keyboardTypes';
 import { type Route } from '@/navigation/routesNames';
 import { type RootStackParamList } from '@/navigation/types';
@@ -27,7 +26,7 @@ export default function useKeyboardHeight(options: UseKeyboardHeightOptions = {}
   const listenerRef = useRef<EmitterSubscription>(undefined);
   const insets = useSafeAreaInsets();
   // Android keyboard height doesn't include the bottom inset.
-  const extraHeight = IS_ANDROID ? insets.bottom : 0;
+  const extraHeight = Platform.OS === 'android' ? insets.bottom : 0;
 
   const dispatch = useDispatch();
 

--- a/src/hooks/useLedgerImport.ts
+++ b/src/hooks/useLedgerImport.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
 
 import { type Subscription } from '@ledgerhq/hw-transport';
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { logger, RainbowError } from '@/logger';
 import { checkAndRequestAndroidBluetooth, showBluetoothPermissionsAlert, showBluetoothPoweredOffAlert } from '@/utils/bluetoothPermissions';
 import { ledgerErrorHandler, type LEDGER_ERROR_CODES } from '@/utils/ledger';
@@ -69,7 +69,7 @@ export function useLedgerImport({
           // App is not authorized to use Bluetooth
           if (e.type === 'Unauthorized') {
             logger.debug('[useLedgerImport]: Bluetooth Unauthorized', {});
-            if (IS_IOS) {
+            if (Platform.OS === 'ios') {
               await showBluetoothPermissionsAlert();
               return;
             } else {
@@ -133,7 +133,7 @@ export function useLedgerImport({
     const asyncFn = async () => {
       logger.debug('[useLedgerImport]: init device polling', {});
 
-      const isBluetoothEnabled = IS_ANDROID ? await checkAndRequestAndroidBluetooth() : true;
+      const isBluetoothEnabled = Platform.OS === 'android' ? await checkAndRequestAndroidBluetooth() : true;
       logger.debug('[useLedgerImport]: bluetooth enabled? ', { isBluetoothEnabled });
 
       if (isBluetoothEnabled) {

--- a/src/hooks/useMagicAutofocus.ts
+++ b/src/hooks/useMagicAutofocus.ts
@@ -1,10 +1,9 @@
 import type React from 'react';
 import { useCallback, useEffect, useRef } from 'react';
-import { InteractionManager, TextInput } from 'react-native';
+import { InteractionManager, Platform, TextInput } from 'react-native';
 
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 
-import { IS_ANDROID } from '@/env';
 import { setListener } from '@/navigation/nativeStackHelpers';
 
 import useInteraction from './useInteraction';
@@ -106,7 +105,7 @@ export default function useMagicAutofocus(
             delay = false;
           }, 400);
         });
-      } else if (IS_ANDROID) {
+      } else if (Platform.OS === 'android') {
         // We need to do this in order to assure that the input gets focused
         // when using fallback stacks.
         InteractionManager.runAfterInteractions(fallbackRefocusLastInput);

--- a/src/hooks/useManageCloudBackups.ts
+++ b/src/hooks/useManageCloudBackups.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { useDispatch } from 'react-redux';
 
-import { IS_ANDROID } from '@/env';
 import { backupsStore, CloudBackupState } from '@/features/backup/stores/backupsStore';
 import { showActionSheetWithOptions } from '@/framework/ui/utils/actionsheet';
 import { maybeAuthenticateWithPIN } from '@/handlers/authentication';
@@ -40,12 +40,12 @@ export default function useManageCloudBackups() {
   const manageCloudBackups = useCallback(() => {
     const buttons = [
       i18n.t(i18n.l.settings.delete_backups, { cloudPlatform }),
-      IS_ANDROID ? i18n.t(i18n.l.settings.backup_switch_google_account) : undefined,
+      Platform.OS === 'android' ? i18n.t(i18n.l.settings.backup_switch_google_account) : undefined,
       i18n.t(i18n.l.button.cancel),
     ].filter(Boolean);
 
     const getTitleForPlatform = () => {
-      if (IS_ANDROID && accountDetails?.email) {
+      if (Platform.OS === 'android' && accountDetails?.email) {
         return i18n.t(i18n.l.settings.manage_backups, {
           cloudPlatformOrEmail: accountDetails.email,
         });
@@ -84,8 +84,8 @@ export default function useManageCloudBackups() {
 
     showActionSheetWithOptions(
       {
-        cancelButtonIndex: IS_ANDROID ? 2 : 1,
-        destructiveButtonIndex: IS_ANDROID ? 0 : 1,
+        cancelButtonIndex: Platform.OS === 'android' ? 2 : 1,
+        destructiveButtonIndex: Platform.OS === 'android' ? 0 : 1,
         options: buttons,
         title: getTitleForPlatform(),
       },
@@ -111,7 +111,7 @@ export default function useManageCloudBackups() {
                   // Prompt for authentication before allowing them to delete backups
                   await keychain.getAllKeys();
 
-                  if (IS_ANDROID) {
+                  if (Platform.OS === 'android') {
                     logoutFromGoogleDrive();
                     setAccountDetails(undefined);
                   }
@@ -131,7 +131,7 @@ export default function useManageCloudBackups() {
           );
         }
 
-        if (buttonIndex === 1 && IS_ANDROID) {
+        if (buttonIndex === 1 && Platform.OS === 'android') {
           logoutFromGoogleDrive();
           setAccountDetails(undefined);
           loginToGoogleDrive();

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { type ImagePickerAsset } from 'expo-image-picker';
 
@@ -6,7 +7,6 @@ import { analytics } from '@/analytics';
 import { type MenuConfig } from '@/components/native-context-menu/contextMenu';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import { IS_IOS } from '@/env';
 import useENSAvatar, { prefetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { prefetchENSCover } from '@/features/ens/hooks/useENSCover';
 import useENSOwner from '@/features/ens/hooks/useENSOwner';
@@ -141,7 +141,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
             if (accountImage) {
               onAvatarRemovePhoto();
             } else {
-              IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
+              Platform.OS === 'ios' ? onAvatarPickEmoji() : setNextEmoji();
             }
           }
         } else {
@@ -152,7 +152,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
             if (accountImage) {
               onAvatarRemovePhoto();
             } else {
-              IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
+              Platform.OS === 'ios' ? onAvatarPickEmoji() : setNextEmoji();
             }
           }
         }
@@ -163,7 +163,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
             if (accountImage) {
               onAvatarRemovePhoto();
             } else {
-              IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
+              Platform.OS === 'ios' ? onAvatarPickEmoji() : setNextEmoji();
             }
           }
         } else {
@@ -173,7 +173,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
             if (accountImage) {
               onAvatarRemovePhoto();
             } else {
-              IS_IOS ? onAvatarPickEmoji() : setNextEmoji();
+              Platform.OS === 'ios' ? onAvatarPickEmoji() : setNextEmoji();
             }
           }
         }

--- a/src/hooks/useRemoveFirstScreen.ts
+++ b/src/hooks/useRemoveFirstScreen.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
+import { Platform } from 'react-native';
 
-import { IS_ANDROID } from '@/env';
 import { useNavigation } from '@/navigation/Navigation';
 import type Routes from '@/navigation/routesNames';
 import { useRemoveFirst } from '@/navigation/useRemoveFirst';
@@ -14,7 +14,7 @@ export const useRemoveScreen = (screenName: RouteName) => {
   useEffect(() => {
     // This is the fix for Android wallet creation problem.
     // We need to remove the welcome screen from the stack.
-    if (!IS_ANDROID) {
+    if (Platform.OS !== 'android') {
       return;
     }
     const isScreen = dangerouslyGetParent()?.getState().routes[0].name === screenName;

--- a/src/hooks/useSendFeedback.ts
+++ b/src/hooks/useSendFeedback.ts
@@ -1,10 +1,9 @@
-import { Linking } from 'react-native';
+import { Linking, Platform } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import { capitalize } from 'lodash';
 import * as DeviceInfo from 'react-native-device-info';
 
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import { getWalletAddresses, getWallets } from '@/state/wallets/walletsStore';
 import { device } from '@/storage';
@@ -13,7 +12,7 @@ import { Alert } from '../components/alerts';
 import useAppVersion from './useAppVersion';
 
 const FeedbackEmailAddress = 'support@rainbow.me';
-const platform = IS_IOS ? 'iOS' : 'Android';
+const platform = Platform.OS === 'ios' ? 'iOS' : 'Android';
 const categorySubjectMap: Record<SupportCategory, string> = {
   getting_started: 'Getting Started',
   backup_recovery: 'Backup & Recovery',
@@ -61,7 +60,7 @@ const FeedbackErrorAlert = () =>
   });
 
 function buildDebugInfo(appVersion: string): string {
-  const deviceModel = IS_IOS ? DeviceInfo.getModel() : `${capitalize(DeviceInfo.getBrand())} ${DeviceInfo.getModel()}`;
+  const deviceModel = Platform.OS === 'ios' ? DeviceInfo.getModel() : `${capitalize(DeviceInfo.getBrand())} ${DeviceInfo.getModel()}`;
   const osVersion = DeviceInfo.getSystemVersion();
   const deviceId = device.get(['id']) ?? 'unknown';
   const walletAddresses = getWalletAddresses(getWallets());

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { values } from 'lodash';
 
 import { analytics } from '@/analytics';
-import { IS_ANDROID } from '@/env';
 import { addWalletToCloudBackup, backupWalletToCloud } from '@/features/backup/backup';
 import { backupsStore } from '@/features/backup/stores/backupsStore';
 import { maybeAuthenticateWithPIN } from '@/handlers/authentication';
@@ -58,7 +58,7 @@ export default function useWalletCloudBackup() {
       walletId: string;
       addToCurrentBackup: boolean;
     }): Promise<boolean> => {
-      if (IS_ANDROID) {
+      if (Platform.OS === 'android') {
         try {
           await login();
           const userData = await getGoogleAccountUserData();

--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import DeviceInfo from 'react-native-device-info';
 import {
   ACCESS_CONTROL,
@@ -20,7 +22,7 @@ import {
 } from 'react-native-keychain';
 import { createMMKV } from 'react-native-mmkv';
 
-import { IS_ANDROID, IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 import AesEncryptor from '@/handlers/aesEncryption';
 import { authenticateWithPIN, authenticateWithPINAndCreateIfNeeded, shouldAuthenticateWithPIN } from '@/handlers/authentication';
 import { logger, RainbowError } from '@/logger';
@@ -95,7 +97,7 @@ export async function get(key: string, options: KeychainOptions<GetOptions> = {}
            * `RAINBOW_MASTER_KEY`, and are saved as "public" values. We don't
            * want to decrypt those here.
            */
-          if (IS_ANDROID && result.password.includes('cipher') && !EXEMPT_ENCRYPTED_KEYS.includes(key)) {
+          if (Platform.OS === 'android' && result.password.includes('cipher') && !EXEMPT_ENCRYPTED_KEYS.includes(key)) {
             logger.debug(`[keychain]: decrypting private data on Android`, {}, logger.DebugContext.keychain);
 
             const pin = options.androidEncryptionPin || (await authenticateWithPIN());
@@ -381,7 +383,7 @@ export async function setSharedWebCredentials(username: string, password: string
 export async function getPrivateAccessControlOptions(): Promise<SetOptions> {
   logger.debug(`[keychain]: getPrivateAccessControlOptions`, {}, logger.DebugContext.keychain);
 
-  const isSimulator = IS_DEV && IS_IOS && (await DeviceInfo.isEmulator());
+  const isSimulator = IS_DEV && Platform.OS === 'ios' && (await DeviceInfo.isEmulator());
 
   if (isSimulator) return {};
 

--- a/src/model/migrations.ts
+++ b/src/model/migrations.ts
@@ -1,5 +1,7 @@
 import path from 'path';
 
+import { Platform } from 'react-native';
+
 import { captureException } from '@sentry/react-native';
 import { findKey, isEmpty, isNumber, keys } from 'lodash';
 import uniq from 'lodash/uniq';
@@ -10,7 +12,6 @@ import { createMMKV } from 'react-native-mmkv';
 import { type UniqueId } from '@/__swaps__/types/assets';
 import type { RainbowToken } from '@/entities/tokens';
 import type { EthereumAddress } from '@/entities/wallet';
-import { IS_IOS } from '@/env';
 import { unlockableAppIcons, type UnlockableAppIconKey } from '@/features/app-icon/models/appIcons';
 import { unlockableAppIconStorage } from '@/features/app-icon/utils/unlockableAppIconCheck';
 import { getAssets, getHiddenCoins, getPinnedCoins, saveHiddenCoins, savePinnedCoins } from '@/handlers/localstorage/accountLocal';
@@ -842,7 +843,7 @@ export default async function runMigrations() {
       return;
     }
 
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       for (const wallet of Object.values(wallets)) {
         if (!wallet.encryptionType) {
           // On iOS only keychain is supported.

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { type TransactionRequest } from '@ethersproject/abstract-provider';
 import { type Signer } from '@ethersproject/abstract-signer';
 import { arrayify } from '@ethersproject/bytes';
@@ -14,7 +16,6 @@ import { type GetOptions, type SetOptions } from 'react-native-keychain';
 
 import { analytics } from '@/analytics';
 import type { EthereumAddress } from '@/entities/wallet';
-import { IS_IOS } from '@/env';
 import { maybeAuthenticateWithPIN, maybeAuthenticateWithPINAndCreateIfNeeded } from '@/handlers/authentication';
 import { LedgerSigner } from '@/handlers/LedgerSigner';
 import { addHexPrefix, isHexString, isHexStringIgnorePrefix, isValidBluetoothDeviceId, isValidMnemonic } from '@/handlers/web3';
@@ -1461,7 +1462,7 @@ export const checkWalletsDamagedState = async (wallets: AllRainbowWallets): Prom
   }
 
   // Try to detect cases where wallets will be unusable and might need to be re-imported
-  if (IS_IOS) {
+  if (Platform.OS === 'ios') {
     // Passcode is disabled - the keychain data will be inaccessible until the user re-enables it.
     const isPasscodeAuthAvailable = await kc.isPasscodeAuthAvailable();
     if (!isPasscodeAuthAvailable) {

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo, useRef, useState, type MutableRefObject } from 'react';
-import { InteractionManager, StyleSheet, View } from 'react-native';
+import { InteractionManager, Platform, StyleSheet, View } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import { createMaterialTopTabNavigator, type MaterialTopTabNavigationEventMap } from '@react-navigation/material-top-tabs';
@@ -52,7 +52,7 @@ import { TabBarIcon } from '@/components/tab-bar/TabBarIcon';
 import { DAPP_BROWSER, LAZY_TABS, RNBW_MEMBERSHIP, RNBW_REWARDS } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import { Box, ColorModeProvider, Column, Columns, globalColors, useColorMode } from '@/design-system';
-import { IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { RnbwMembershipScreen } from '@/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen';
 import { RnbwRewardsScreen } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/RnbwRewardsScreen';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -352,7 +352,6 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
           <Animated.View style={[styles.tabBarBackgroundFade, gradientBackgroundStyle]} />
         </MaskedView>
       </Animated.View>
-
       <Animated.View style={[{ shadowColor: globalColors.grey100, shadowOffset: { width: 0, height: 12 }, shadowRadius: 18 }, shadowStyle]}>
         <Box
           as={Animated.View}
@@ -366,7 +365,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
           style={[hideForBrowserTabViewStyle, { alignSelf: 'center' }]}
         >
           <Box height={{ custom: BASE_TAB_BAR_HEIGHT }} width="full">
-            {IS_IOS ? (
+            {Platform.OS === 'ios' ? (
               <>
                 <BlurGradient
                   gradientPoints={[
@@ -522,7 +521,7 @@ export const BrowserTabIconWrapper = memo(function BrowserTabIconWrapper({
       testID={`tab-bar-icon-${route.name}`}
     >
       <ConditionalWrap
-        condition={IS_IOS || !showBrowserButtons}
+        condition={Platform.OS === 'ios' || !showBrowserButtons}
         wrap={children => (
           <ButtonPressAnimation
             disallowInterruption

--- a/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
+++ b/src/navigation/bottom-sheet/views/BottomSheetRoute.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Keyboard, View, type ViewStyle } from 'react-native';
+import { Keyboard, Platform, View, type ViewStyle } from 'react-native';
 
 import BottomSheet, { BottomSheetBackdrop, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import { useSharedValue } from 'react-native-reanimated';
-
-import { IS_ANDROID } from '@/env';
 
 import { isKeyboardOpen } from '../../../helpers';
 import { CONTAINER_HEIGHT, DEFAULT_BACKDROP_COLOR, DEFAULT_BACKDROP_OPACITY, DEFAULT_HEIGHT } from '../constants';
@@ -29,7 +27,7 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
     backdropOpacity = DEFAULT_BACKDROP_OPACITY,
     backdropPressBehavior = 'close',
     height = DEFAULT_HEIGHT,
-    offsetY = IS_ANDROID ? 20 : 3,
+    offsetY = Platform.OS === 'android' ? 20 : 3,
   } = options || {};
 
   const ref = useRef<BottomSheet>(null);
@@ -114,7 +112,7 @@ const BottomSheetRoute = ({ routeKey, descriptor: { options, render, navigation 
   useEffect(() => {
     if (removing === true && ref.current) {
       // close keyboard before closing the modal
-      if (isKeyboardOpen() && IS_ANDROID) {
+      if (isKeyboardOpen() && Platform.OS === 'android') {
         Keyboard.dismiss();
 
         ref.current.close();

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import { type RouteProp } from '@react-navigation/native';
 import { type StackNavigationOptions } from '@react-navigation/stack';
@@ -9,7 +9,6 @@ import { SheetHandleFixedToTopHeight } from '@/components/sheet';
 import { Text } from '@/components/text';
 import { getWalletErrorSheetHeight } from '@/components/wallet-error/WalletErrorSheet';
 import { Box } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { getENSAdditionalRecordsSheetHeight } from '@/features/ens/screens/ENSAdditionalRecordsSheet';
 import { ENSConfirmRegisterSheetHeight } from '@/features/ens/screens/ENSConfirmRegisterSheet';
 import { getPositionSheetHeight } from '@/features/positions/screens/PositionSheet';
@@ -115,9 +114,10 @@ const buildCoolModalConfig = (params: CoolModalConfigParams): CoolModalConfigOpt
 });
 
 export const backupSheetSizes = {
-  long: IS_ANDROID
-    ? deviceUtils.dimensions.height - safeAreaInsetValues.top
-    : deviceUtils.dimensions.height + safeAreaInsetValues.bottom + sharedCoolModalTopOffset + SheetHandleFixedToTopHeight,
+  long:
+    Platform.OS === 'android'
+      ? deviceUtils.dimensions.height - safeAreaInsetValues.top
+      : deviceUtils.dimensions.height + safeAreaInsetValues.bottom + sharedCoolModalTopOffset + SheetHandleFixedToTopHeight,
   medium: 550,
   short: 424,
   check_identifier: 414,
@@ -801,7 +801,7 @@ const SettingsTitle = ({ children }: React.PropsWithChildren) => {
   const { colors } = useTheme();
 
   return (
-    <Box paddingTop={IS_ANDROID ? '8px' : undefined}>
+    <Box paddingTop={Platform.OS === 'android' ? '8px' : undefined}>
       <Text align="center" color={colors.dark} letterSpacing="roundedMedium" size="large" weight="heavy">
         {children}
       </Text>

--- a/src/navigation/effects.tsx
+++ b/src/navigation/effects.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, View } from 'react-native';
+import { Animated, Platform, View } from 'react-native';
 
 import { type StackNavigationOptions, type TransitionPreset } from '@react-navigation/stack';
 import { initialWindowMetrics } from 'react-native-safe-area-context';
@@ -7,7 +7,6 @@ import { initialWindowMetrics } from 'react-native-safe-area-context';
 import { EmojiAvatar, ProfileAvatarSize } from '@/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow';
 import { HeaderHeightWithStatusBar } from '@/components/header';
 import AvatarCircle from '@/components/profile/AvatarCircle';
-import { IS_ANDROID } from '@/env';
 import { HARDWARE_WALLET_TX_NAVIGATOR_SHEET_HEIGHT } from '@/navigation/HardwareWalletTxNavigator';
 import Routes from '@/navigation/routesNames';
 import { lightModeThemeColors } from '@/styles';
@@ -426,7 +425,7 @@ export const walletconnectBottomSheetPreset: BottomSheetNavigationOptions = {
 export const swapSheetPreset: BottomSheetNavigationOptions = {
   backdropColor: 'black',
   backdropOpacity: 0.9,
-  enableContentPanningGesture: IS_ANDROID,
+  enableContentPanningGesture: Platform.OS === 'android',
   backdropPressBehavior: 'none',
   height: '100%',
 };

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -1,4 +1,4 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
 
 const Routes = {
   ADD_CASH_SCREEN_NAVIGATOR: 'AddCashSheetNavigator',
@@ -179,7 +179,7 @@ export const NATIVE_ROUTES = new Set<Route>([
   Routes.RECEIVE_MODAL,
   Routes.SETTINGS_SHEET,
   Routes.SWAP,
-  ...(IS_IOS ? [Routes.SEND_SHEET_NAVIGATOR, Routes.ADD_CASH_SCREEN_NAVIGATOR] : []),
+  ...(Platform.OS === 'ios' ? [Routes.SEND_SHEET_NAVIGATOR, Routes.ADD_CASH_SCREEN_NAVIGATOR] : []),
 ]);
 
 const RoutesWithPlatformDifferences = {

--- a/src/performance/tracking/PerformanceToast.tsx
+++ b/src/performance/tracking/PerformanceToast.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { toast } from 'sonner-native';
 
 import { getExperimentalFlag, PERFORMANCE_TOAST } from '@/config/experimentalHooks';
 import { globalColors } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
-import { IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { getNumberFormatter } from '@/helpers/intl';
 import { fontWithWidth } from '@/styles';
@@ -86,11 +86,11 @@ export async function showPerformanceToast(results: Record<string, number>) {
   const styles = StyleSheet.create({
     toastContainerDark: {
       ...conditionalStyles.toastContainer,
-      ...(IS_IOS ? conditionalStyles.toastContainerShadowDark : {}),
+      ...(Platform.OS === 'ios' ? conditionalStyles.toastContainerShadowDark : {}),
     },
     toastContainerLight: {
       ...conditionalStyles.toastContainer,
-      ...(IS_IOS ? conditionalStyles.toastContainerShadowLight : {}),
+      ...(Platform.OS === 'ios' ? conditionalStyles.toastContainerShadowLight : {}),
     },
     toastContent: {
       alignItems: 'center',
@@ -100,12 +100,12 @@ export async function showPerformanceToast(results: Record<string, number>) {
     },
     toastDark: {
       ...conditionalStyles.toast,
-      ...(IS_IOS ? conditionalStyles.toastBorderDark : {}),
+      ...(Platform.OS === 'ios' ? conditionalStyles.toastBorderDark : {}),
     },
     toastLight: conditionalStyles.toast,
     title: {
       ...conditionalStyles.title,
-      ...(IS_IOS ? conditionalStyles.titleShadow : {}),
+      ...(Platform.OS === 'ios' ? conditionalStyles.titleShadow : {}),
     },
     zeroDimensions: {
       height: 0,

--- a/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
+++ b/src/react-native-animated-charts/src/charts/linear/ChartPath.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 import { Gesture, GestureDetector, type LongPressGestureHandlerProperties } from 'react-native-gesture-handler';
 import Animated, {
   FadeIn,
@@ -19,8 +19,6 @@ import Animated, {
 import { getYForX } from 'react-native-redash';
 import Svg, { Path, type PathProps } from 'react-native-svg';
 import { triggerHaptics } from 'react-native-turbo-haptics';
-// @ts-ignore this library is no longer maintained independently of the app, so this is fine
-import { IS_IOS } from '@/env';
 import { type ChartData, type PathData } from '../../helpers/ChartContext';
 import { requireOnWorklet, useWorkletValue } from '../../helpers/requireOnWorklet';
 import { useChartData } from '../../helpers/useChartData';
@@ -189,7 +187,7 @@ const ChartPathInner = React.memo(
 
           progress.value = 0;
 
-          progress.value = withDelay(IS_IOS ? 0 : 100, withTiming(1, timingAnimationConfig || timingAnimationDefaultConfig));
+          progress.value = withDelay(Platform.OS === 'ios' ? 0 : 100, withTiming(1, timingAnimationConfig || timingAnimationDefaultConfig));
         } else {
           interpolatorWorklet().value = undefined;
           progress.value = 1;

--- a/src/react-native-cool-modals/Portal.tsx
+++ b/src/react-native-cool-modals/Portal.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
-import { requireNativeComponent, StyleSheet, View } from 'react-native';
+import { Platform, requireNativeComponent, StyleSheet, View } from 'react-native';
 
 import { LoadingOverlay } from '@/components/modal/LoadingOverlay';
-import { IS_IOS } from '@/env';
 import { useActiveRoute } from '@/hooks/useActiveRoute';
 import { sheetVerticalOffset } from '@/navigation/effects';
 import Routes from '@/navigation/routesNames';
 import { walletLoadingStore } from '@/state/walletLoading/walletLoading';
 
-const NativePortal = IS_IOS ? requireNativeComponent('WindowPortal') : View;
-const Wrapper = IS_IOS ? ({ children }: { children: React.ReactNode }) => children : View;
+const NativePortal = Platform.OS === 'ios' ? requireNativeComponent('WindowPortal') : View;
+const Wrapper = Platform.OS === 'ios' ? ({ children }: { children: React.ReactNode }) => children : View;
 
 export function Portal() {
   const activeRoute = useActiveRoute();
   const loadingState = walletLoadingStore(state => state.loadingState);
-  const shouldHide = !loadingState || (activeRoute === Routes.PIN_AUTHENTICATION_SCREEN && !IS_IOS);
+  const shouldHide = !loadingState || (activeRoute === Routes.PIN_AUTHENTICATION_SCREEN && Platform.OS !== 'ios');
 
   if (shouldHide) return null;
 
@@ -26,7 +25,7 @@ export function Portal() {
         pointerEvents: 'none',
       }}
     >
-      <NativePortal {...(IS_IOS ? { blockTouches: true } : {})} pointerEvents="none" style={StyleSheet.absoluteFillObject}>
+      <NativePortal {...(Platform.OS === 'ios' ? { blockTouches: true } : {})} pointerEvents="none" style={StyleSheet.absoluteFillObject}>
         <LoadingOverlay paddingTop={sheetVerticalOffset} title={loadingState} />
       </NativePortal>
     </Wrapper>

--- a/src/screens/ActivitySheetScreen.tsx
+++ b/src/screens/ActivitySheetScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { useSharedValue } from 'react-native-reanimated';
 
@@ -7,7 +7,6 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ContactAvatar } from '@/components/contacts';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { Navbar } from '@/components/navbar/Navbar';
-import { IS_ANDROID } from '@/env';
 import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -27,7 +26,7 @@ export function ActivitySheetScreen() {
         backgroundColor: colors.white,
         flex: 1,
         // android border radius
-        ...(IS_ANDROID && {
+        ...(Platform.OS === 'android' && {
           borderTopRightRadius: 40,
           borderTopLeftRadius: 40,
           overflow: 'hidden',
@@ -50,7 +49,6 @@ export function ActivitySheetScreen() {
           </ButtonPressAnimation>
         }
       />
-
       <View style={{ flex: 1 }}>
         <ActivityList key={accountAddress} scrollY={scrollY} paddingTopForNavBar />
       </View>

--- a/src/screens/AddCash/components/ProviderCard.tsx
+++ b/src/screens/AddCash/components/ProviderCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView } from 'react-native';
 
 import chroma from 'chroma-js';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -11,7 +11,6 @@ import { Ramp as RampLogo } from '@/components/icons/svg/Ramp';
 import { Stripe as StripeLogo } from '@/components/icons/svg/Stripe';
 import { Bleed, Box, Inline, Text, useBackgroundColor } from '@/design-system';
 import { FiatProviderName } from '@/entities/f2c';
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import { CalloutType, PaymentMethod, type ProviderConfig } from '@/screens/AddCash/types';
 import { convertAPINetworkToInternalChainIds } from '@/screens/AddCash/utils';
@@ -116,7 +115,7 @@ export function ProviderCard({ config }: { config: ProviderConfig }) {
       paddingHorizontal="20px"
       borderRadius={20}
       shadow="12px"
-      style={{ flex: IS_IOS ? 0 : undefined }}
+      style={{ flex: Platform.OS === 'ios' ? 0 : undefined }}
     >
       <Inline alignVertical="center">
         <Box
@@ -135,13 +134,11 @@ export function ProviderCard({ config }: { config: ProviderConfig }) {
           </Text>
         </Box>
       </Inline>
-
       <Box paddingTop="8px" paddingBottom="20px">
         <Text size="17pt" weight="semibold" color="labelSecondary">
           {config.content.description}
         </Text>
       </Box>
-
       <Bleed horizontal="20px">
         <LinearGradient
           colors={[backgroundColor, backgroundColorAlpha]}

--- a/src/screens/Airdrops/AirdropsSheet.tsx
+++ b/src/screens/Airdrops/AirdropsSheet.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useState } from 'react';
-import { RefreshControl, ScrollView, StyleSheet, View, type ScrollViewProps } from 'react-native';
+import { Platform, RefreshControl, ScrollView, StyleSheet, View, type ScrollViewProps } from 'react-native';
 
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { LegendList } from '@legendapp/list';
@@ -25,7 +25,6 @@ import {
   type TextProps,
 } from '@/design-system';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
@@ -104,7 +103,12 @@ const CloseButton = () => {
           hitSlop={16}
           width={CLOSE_BUTTON_SIZE}
         >
-          <Text color="labelSecondary" size="icon 14px" style={IS_IOS ? undefined : styles.closeButtonIconOffset} weight="black">
+          <Text
+            color="labelSecondary"
+            size="icon 14px"
+            style={Platform.OS === 'ios' ? undefined : styles.closeButtonIconOffset}
+            weight="black"
+          >
             􀆄
           </Text>
         </IconContainer>
@@ -180,7 +184,7 @@ function keyExtractor(item: RainbowClaimable): string {
 }
 
 const ListScrollView = ({ children, ...props }: ScrollViewProps) => {
-  return IS_IOS ? (
+  return Platform.OS === 'ios' ? (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <ScrollView refreshControl={<PullToRefresh />} {...props}>
       {children}

--- a/src/screens/Airdrops/ClaimAirdropSheet.tsx
+++ b/src/screens/Airdrops/ClaimAirdropSheet.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { Blur, Canvas, Circle, Fill, Group, Image, Paint, point, Shadow, useImage } from '@shopify/react-native-skia';
@@ -37,7 +37,6 @@ import {
 } from '@/design-system';
 import { foregroundColors } from '@/design-system/color/palettes';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
-import { IS_IOS } from '@/env';
 import { fetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -652,7 +651,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     height: 16,
     justifyContent: 'center',
-    marginTop: IS_IOS ? undefined : -3,
+    marginTop: Platform.OS === 'ios' ? undefined : -3,
     overflow: 'hidden',
     position: 'relative',
     width: 16,

--- a/src/screens/Diagnostics/DiagnosticsContent.tsx
+++ b/src/screens/Diagnostics/DiagnosticsContent.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, type PropsWithChildren } from 'react';
+import { Platform } from 'react-native';
 
 import { type UserCredentials } from 'react-native-keychain';
 
@@ -8,13 +9,12 @@ import { Column } from '@/components/layout';
 import { SheetActionButton } from '@/components/sheet';
 import Spinner from '@/components/Spinner';
 import { Box, Stack, Text } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import { DiagnosticsItemRow } from '@/screens/Diagnostics/DiagnosticsItemRow';
 import { useTheme } from '@/theme/ThemeContext';
 
-const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
+const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
 type Props = PropsWithChildren<{
   keys: UserCredentials[] | undefined;
@@ -92,7 +92,7 @@ export function DiagnosticsContent({
         />
       </Box>
       {/* PIN Auth to reveal secrets on Android */}
-      {IS_ANDROID && keys && pinRequired && !userPin && (
+      {Platform.OS === 'android' && keys && pinRequired && !userPin && (
         <>
           <Box paddingBottom="16px">
             <Stack space="10px">
@@ -159,7 +159,7 @@ export function DiagnosticsContent({
         </Fragment>
       )}
       {keys && (
-        <Box paddingBottom={IS_ANDROID ? '44px' : '16px'}>
+        <Box paddingBottom={Platform.OS === 'android' ? '44px' : '16px'}>
           <SheetActionButton
             color={opacity(colors.appleBlue, 0.06)}
             isTransparent

--- a/src/screens/Diagnostics/helpers/createAndShareStateDumpFile.ts
+++ b/src/screens/Diagnostics/helpers/createAndShareStateDumpFile.ts
@@ -1,7 +1,8 @@
+import { Platform } from 'react-native';
+
 import RNFS from 'react-native-fs';
 import RNShare from 'react-native-share';
 
-import { IS_ANDROID } from '@/env';
 import { getAllActiveSessions } from '@/features/wallet-connect/services/sessions';
 import { logger, RainbowError } from '@/logger';
 import store from '@/redux/store';
@@ -64,7 +65,7 @@ export async function createAndShareStateDumpFile() {
       await RNFS.unlink(documentsFilePath);
     }
     await RNFS.writeFile(documentsFilePath, stringifiedState, 'utf8');
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       await RNFS.writeFile(`${RNFS.DownloadDirectoryPath}/app_state_dump_${Date.now()}.json`, stringifiedState, 'utf8');
     }
     await RNShare.open({

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import { useIsFocused } from '@react-navigation/native';
 import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
@@ -14,7 +14,6 @@ import DiscoverScreenProvider, { useDiscoverScreenContext } from '@/components/D
 import { DiscoverSearchBar } from '@/components/Discover/DiscoverSearchBar';
 import { Navbar } from '@/components/navbar/Navbar';
 import { Box, globalColors, TextIcon, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -87,14 +86,13 @@ const Content = () => {
         automaticallyAdjustsScrollIndicatorInsets={false}
         onScroll={scrollHandler}
         scrollEnabled={!isSearching}
-        refreshControl={IS_IOS ? <PullToRefresh /> : undefined}
+        refreshControl={Platform.OS === 'ios' ? <PullToRefresh /> : undefined}
         removeClippedSubviews
         scrollIndicatorInsets={{ bottom: safeAreaInsetValues.bottom + 167 }}
         testID="discover-sheet"
       >
         <DiscoverScreenContent />
       </Box>
-
       <KeyboardDismissHandler />
     </Box>
   );

--- a/src/screens/ExternalLinkWarningSheet.tsx
+++ b/src/screens/ExternalLinkWarningSheet.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 
-import { IS_ANDROID } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
@@ -20,7 +20,7 @@ import { SheetActionButton, SheetTitle, SlackSheet } from '../components/sheet';
 import { Emoji, Text } from '../components/text';
 import { useNavigation } from '../navigation/Navigation';
 
-export const ExternalLinkWarningSheetHeight = 380 + (IS_ANDROID ? 20 : 0);
+export const ExternalLinkWarningSheetHeight = 380 + (Platform.OS === 'android' ? 20 : 0);
 
 const Container = styled(Centered).attrs({ direction: 'column' })(({ deviceHeight, height }) => ({
   ...position.coverAsObject,

--- a/src/screens/ImportOrWatchWalletSheet.tsx
+++ b/src/screens/ImportOrWatchWalletSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import { useFocusEffect, useRoute, type RouteProp } from '@react-navigation/native';
@@ -9,7 +9,6 @@ import { Input } from '@/components/inputs';
 import { LoadingOverlay } from '@/components/modal/LoadingOverlay';
 import { SheetHandleFixedToTopHeight } from '@/components/sheet';
 import { AccentColorProvider, Box, globalColors, Inset, Stack, Text, useForegroundColor, useTextStyle } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useImportingWallet from '@/hooks/useImportingWallet';
 import useKeyboardHeight from '@/hooks/useKeyboardHeight';
@@ -90,7 +89,7 @@ export const ImportOrWatchWalletSheet = () => {
             textContentType="none"
             enablesReturnKeyAutomatically
             onBlur={refocusOnce}
-            keyboardType={IS_ANDROID ? 'visible-password' : 'default'}
+            keyboardType={Platform.OS === 'android' ? 'visible-password' : 'default'}
             onChangeText={handleSetSeedPhrase}
             multiline
             numberOfLines={3}

--- a/src/screens/LearnWebViewScreen.tsx
+++ b/src/screens/LearnWebViewScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Share, View } from 'react-native';
+import { Platform, Share, View } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { WebView } from 'react-native-webview';
@@ -11,7 +11,6 @@ import { SlackSheet } from '@/components/sheet';
 import Spinner from '@/components/Spinner';
 import { Box, Text, useBackgroundColor } from '@/design-system';
 import { globalColors } from '@/design-system/color/palettes';
-import { IS_ANDROID } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
@@ -82,7 +81,7 @@ export default function LearnWebViewScreen() {
 
   const contentHeight = deviceHeight - (!isSmallPhone ? sharedCoolModalTopOffset : 0);
 
-  const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
+  const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
   const surfacePrimaryElevated = useBackgroundColor('surfacePrimaryElevated');
 

--- a/src/screens/MintsSheet/MintsSheet.tsx
+++ b/src/screens/MintsSheet/MintsSheet.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { FlashList } from '@shopify/flash-list';
 
@@ -21,7 +22,6 @@ import {
   Text,
   useColorMode,
 } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
@@ -33,7 +33,7 @@ import { useAccountProfileInfo } from '@/state/wallets/walletsStore';
 import { Card } from './card/Card';
 import { TabBar } from './TabBar';
 
-const LoadingSpinner = IS_ANDROID ? Spinner : ActivityIndicator;
+const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
 export function MintsSheet() {
   const { accountAddress, accountImage, accountColorHex, accountSymbol } = useAccountProfileInfo();
@@ -57,13 +57,13 @@ export function MintsSheet() {
       <BackgroundProvider color="surfaceSecondaryElevated">
         {({ backgroundColor }) => (
           <SimpleSheet backgroundColor={backgroundColor as string}>
-            <Inset top="20px" bottom={{ custom: IS_IOS ? 110 : 150 }}>
+            <Inset top="20px" bottom={{ custom: Platform.OS === 'ios' ? 110 : 150 }}>
               <Inset horizontal="20px">
                 <Stack space="10px">
                   <Columns alignVertical="center">
                     <Column width="content">
                       <AccentColorProvider color={accountColorHex ?? globalColors.grey100}>
-                        <ButtonPressAnimation onPress={() => navigate(Routes.CHANGE_WALLET_SHEET)} disabled={IS_ANDROID}>
+                        <ButtonPressAnimation onPress={() => navigate(Routes.CHANGE_WALLET_SHEET)} disabled={Platform.OS === 'android'}>
                           {accountImage ? (
                             <Box
                               as={ImgixImage}

--- a/src/screens/MintsSheet/TabBar.tsx
+++ b/src/screens/MintsSheet/TabBar.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'react-native-blur-view';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { AccentColorProvider, Box, Cover, globalColors, Inline, Text } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { getMintsFilterLabel, MintsFilter, useMintsFilter } from '@/resources/mints';
 import { useTheme } from '@/theme/ThemeContext';
 
@@ -21,7 +20,7 @@ function FilterButton({ filter }: { filter: MintsFilter }) {
     <AccentColorProvider color={highlightedBackgroundColor}>
       <View
         style={
-          IS_IOS
+          Platform.OS === 'ios'
             ? {
                 shadowColor: globalColors.grey100,
                 shadowOffset: { width: 0, height: 2 },
@@ -33,7 +32,7 @@ function FilterButton({ filter }: { filter: MintsFilter }) {
       >
         <View
           style={{
-            ...(IS_IOS
+            ...(Platform.OS === 'ios'
               ? {
                   shadowOffset: { width: 0, height: 4 },
                   shadowRadius: 6,
@@ -76,7 +75,7 @@ export function TabBar() {
         shadowColor: globalColors.grey100,
         shadowOffset: { width: 0, height: 15 },
         shadowRadius: 22.5,
-        shadowOpacity: IS_IOS ? (isDarkMode ? 0.8 : 0.3) : 1,
+        shadowOpacity: Platform.OS === 'ios' ? (isDarkMode ? 0.8 : 0.3) : 1,
         elevation: 24,
         alignSelf: 'center',
       }}

--- a/src/screens/MintsSheet/card/RecentMintCell.tsx
+++ b/src/screens/MintsSheet/card/RecentMintCell.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { ImgixImage } from '@/components/images';
 import { Box, Cover, Text } from '@/design-system';
 import { globalColors } from '@/design-system/color/palettes';
-import { IS_IOS } from '@/env';
 import { type MintedNft } from '@/graphql/__generated__/arc';
 import { useTheme } from '@/theme/ThemeContext';
 import deviceUtils from '@/utils/deviceUtils';
@@ -46,7 +45,7 @@ export function RecentMintCell({ recentMint }: { recentMint: MintedNft }) {
         <Cover>
           <View
             style={
-              IS_IOS
+              Platform.OS === 'ios'
                 ? {
                     shadowColor: globalColors.grey100,
                     shadowOffset: { width: 0, height: 2 },
@@ -58,7 +57,7 @@ export function RecentMintCell({ recentMint }: { recentMint: MintedNft }) {
           >
             <View
               style={
-                IS_IOS
+                Platform.OS === 'ios'
                   ? {
                       shadowColor: globalColors.grey100,
                       shadowOffset: { width: 0, height: 6 },

--- a/src/screens/NFTSingleOfferSheet/index.tsx
+++ b/src/screens/NFTSingleOfferSheet/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { BigNumber } from '@ethersproject/bignumber';
 import { useRoute, type RouteProp } from '@react-navigation/native';
@@ -29,7 +29,6 @@ import {
   useForegroundColor,
 } from '@/design-system';
 import { TransactionDirection, TransactionStatus, type NewTransaction } from '@/entities/transactions';
-import { IS_ANDROID } from '@/env';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
 import useGas from '@/features/gas/hooks/useGas';
 import { metadataPOSTClient } from '@/graphql';
@@ -600,7 +599,7 @@ export function NFTSingleOfferSheet() {
                         borderRadius={16}
                         size={16}
                         // shadow is way off on android idk why
-                        shadow={IS_ANDROID ? undefined : '30px accent'}
+                        shadow={Platform.OS === 'android' ? undefined : '30px accent'}
                       />
                       <Text color="labelSecondary" align="right" size="17pt" weight="medium">
                         {offer.marketplace.name}

--- a/src/screens/ReceiveModal.js
+++ b/src/screens/ReceiveModal.js
@@ -1,10 +1,10 @@
 import React, { useCallback, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
 import { Box } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { toChecksumAddress } from '@/handlers/web3';
 import useDimensions from '@/hooks/useDimensions';
@@ -21,7 +21,7 @@ import ShareButton from '../components/qr-code/ShareButton';
 import { Text, TruncatedAddress } from '../components/text';
 import { CopyToast, ToastPositionContainer } from '../components/toasts';
 
-const QRCodeSize = IS_IOS ? 250 : Math.min(230, deviceUtils.dimensions.width - 20);
+const QRCodeSize = Platform.OS === 'ios' ? 250 : Math.min(230, deviceUtils.dimensions.width - 20);
 
 const AddressText = styled(TruncatedAddress).attrs(({ theme: { colors } }) => ({
   align: 'center',
@@ -71,7 +71,7 @@ export default function ReceiveModal() {
       testID="receive-modal"
       backgroundColor={'rgba(0,0,0,0.85)'}
       useAdditionalTopPadding
-      customHeight={IS_ANDROID ? deviceHeight - top : deviceHeight - sharedCoolModalTopOffset}
+      customHeight={Platform.OS === 'android' ? deviceHeight - top : deviceHeight - sharedCoolModalTopOffset}
       scrollEnabled={false}
     >
       <Box alignItems="center" justifyContent="center" height="full" width="full">

--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import { AddressZero } from '@ethersproject/constants';
 import { useRoute, type RouteProp } from '@react-navigation/native';
@@ -12,7 +12,6 @@ import Divider from '@/components/Divider';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
 import { Box, Heading, Inset, Stack, Text, useBackgroundColor, useColorMode } from '@/design-system';
 import { AssetType } from '@/entities/assetTypes';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import ENSCircleIcon from '@/features/ens/components/ENSCircleIcon';
 import useENSAvatar from '@/features/ens/hooks/useENSAvatar';
 import { type ENSProfile } from '@/features/ens/types/profile';
@@ -199,7 +198,7 @@ export const SendConfirmationSheet = () => {
   const shimmerColor = opacity(fillSecondary, isDarkMode ? 0.025 : 0.06);
 
   useEffect(() => {
-    IS_ANDROID && Keyboard.dismiss();
+    Platform.OS === 'android' && Keyboard.dismiss();
   }, []);
 
   const {
@@ -469,8 +468,8 @@ export const SendConfirmationSheet = () => {
 
   return (
     <Container deviceHeight={deviceHeight} height={contentHeight}>
-      {IS_IOS && <TouchableBackdrop onPress={goBack} />}
-      <SlackSheet additionalTopPadding={IS_ANDROID} contentHeight={contentHeight} scrollEnabled={false}>
+      {Platform.OS === 'ios' && <TouchableBackdrop onPress={goBack} />}
+      <SlackSheet additionalTopPadding={Platform.OS === 'android'} contentHeight={contentHeight} scrollEnabled={false}>
         <SheetTitle>{i18n.t(i18n.l.wallet.transaction.sending_title)}</SheetTitle>
         <Column>
           <Column padding={24}>

--- a/src/screens/SendSheet.tsx
+++ b/src/screens/SendSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Keyboard, View, type TextInput } from 'react-native';
+import { InteractionManager, Keyboard, Platform, View, type TextInput } from 'react-native';
 
 import { type StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
@@ -18,7 +18,6 @@ import { AssetType } from '@/entities/assetTypes';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
 import { type UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { prefetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { prefetchENSCover } from '@/features/ens/hooks/useENSCover';
 import useENSProfile from '@/features/ens/hooks/useENSProfile';
@@ -85,7 +84,7 @@ import { SendAssetForm, SendAssetList, SendContactList, SendHeader } from '../co
 import { SheetActionButton } from '../components/sheet';
 import { getDefaultCheckboxes } from './SendConfirmationSheet';
 
-const sheetHeight = deviceUtils.dimensions.height - (IS_ANDROID ? 30 : 10);
+const sheetHeight = deviceUtils.dimensions.height - (Platform.OS === 'android' ? 30 : 10);
 
 type ComponentPropsWithTheme = {
   theme: ThemeContextProps;
@@ -94,7 +93,7 @@ type ComponentPropsWithTheme = {
 const Container = styled(View)({
   backgroundColor: ({ theme: { colors } }: ComponentPropsWithTheme) => colors.transparent,
   flex: 1,
-  paddingTop: IS_IOS ? 0 : safeAreaInsetValues.top,
+  paddingTop: Platform.OS === 'ios' ? 0 : safeAreaInsetValues.top,
   width: '100%',
 });
 
@@ -102,7 +101,7 @@ const SheetContainer = styled(Column).attrs({
   align: 'center',
   flex: 1,
 })({
-  ...borders.buildRadiusAsObject('top', IS_IOS ? 0 : 16),
+  ...borders.buildRadiusAsObject('top', Platform.OS === 'ios' ? 0 : 16),
   backgroundColor: ({ theme: { colors } }: ComponentPropsWithTheme) => colors.white,
   height: sheetHeight,
   width: '100%',

--- a/src/screens/SettingsSheet/components/Backups/SecretWarning.tsx
+++ b/src/screens/SettingsSheet/components/Backups/SecretWarning.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 
 import { SheetActionButton } from '@/components/sheet';
 import { Bleed, Box, Column, Columns, Inset, Stack, Text } from '@/design-system';
 import { type TextColor } from '@/design-system/color/palettes';
-import { IS_ANDROID } from '@/env';
 import WalletTypes from '@/helpers/walletTypes';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
@@ -102,7 +102,7 @@ const SecretWarningPage = () => {
             {items.map(item => (
               <Columns key={item.icon} space={{ custom: 13 }}>
                 <Column width={{ custom: 50 }}>
-                  <Box paddingTop={IS_ANDROID ? '6px' : undefined}>
+                  <Box paddingTop={Platform.OS === 'android' ? '6px' : undefined}>
                     <Text align="center" color={item.color} size="20pt" weight="bold">
                       {item.icon}
                     </Text>
@@ -120,11 +120,10 @@ const SecretWarningPage = () => {
           </Stack>
         </Stack>
       </Inset>
-
       <Box
         testID={'show-secret-button'}
         position="absolute"
-        bottom={{ custom: IS_ANDROID ? 40 : 20 }}
+        bottom={{ custom: Platform.OS === 'android' ? 40 : 20 }}
         alignItems="center"
         style={{ paddingHorizontal: 24 }}
       >

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Platform } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import { useRoute, type RouteProp } from '@react-navigation/native';
@@ -17,7 +17,6 @@ import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { ContextCircleButton } from '@/components/context-menu';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Box, Stack } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { executeFnIfCloudBackupAvailable } from '@/features/backup/backup';
 import { useCreateBackup } from '@/features/backup/hooks/useCreateBackup';
 import { backupsStore } from '@/features/backup/stores/backupsStore';
@@ -98,7 +97,7 @@ type ContextMenuWrapperProps = {
 };
 
 const ContextMenuWrapper = ({ children, account, menuConfig, onPressMenuItem }: ContextMenuWrapperProps) => {
-  return IS_IOS ? (
+  return Platform.OS === 'ios' ? (
     <ContextMenuButton menuConfig={menuConfig} onPressMenuItem={e => onPressMenuItem({ ...e, account })}>
       {children}
     </ContextMenuButton>

--- a/src/screens/SettingsSheet/components/Backups/ViewWalletDelegations.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletDelegations.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { Alert, Text as NativeText, StyleSheet } from 'react-native';
+import { Alert, Text as NativeText, Platform, StyleSheet } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -11,7 +11,7 @@ import { GradientBorderView } from '@/components/gradient-border/GradientBorderV
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Box, Separator, Stack, Text, useForegroundColor } from '@/design-system';
 import { fonts } from '@/design-system/typography/typography';
-import { IS_DEV, IS_IOS } from '@/env';
+import { IS_DEV } from '@/env';
 import {
   hasActiveDelegation,
   isRainbowDelegated as hasRainbowDelegation,
@@ -424,7 +424,7 @@ export const ViewWalletDelegations = () => {
                 <Menu>
                   {rainbowDelegations.map((network, index) => {
                     const NetworkContextMenuWrapper = ({ children }: { children: React.ReactNode }) => {
-                      return IS_IOS ? (
+                      return Platform.OS === 'ios' ? (
                         <ContextMenuButton
                           menuConfig={activeNetworkMenuConfig}
                           onPressMenuItem={e => onPressNetworkMenuItem({ ...e, chainId: network.chainId })}
@@ -498,7 +498,7 @@ export const ViewWalletDelegations = () => {
                 <Menu>
                   {thirdPartyDelegations.map((network, index) => {
                     const NetworkContextMenuWrapper = ({ children }: { children: React.ReactNode }) => {
-                      return IS_IOS ? (
+                      return Platform.OS === 'ios' ? (
                         <ContextMenuButton
                           menuConfig={inactiveNetworkMenuConfig}
                           onPressMenuItem={e => onPressNetworkMenuItem({ ...e, chainId: network.chainId })}

--- a/src/screens/SettingsSheet/components/Backups/WalletsAndBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/WalletsAndBackup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { type ScrollView } from 'react-native';
+import { Platform, type ScrollView } from 'react-native';
 
 import { useRoute } from '@react-navigation/native';
 import { format } from 'date-fns';
@@ -12,7 +12,7 @@ import { backupsCard } from '@/components/cards/utils/constants';
 import { ContactAvatar } from '@/components/contacts';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { Box, Inline, Stack, Text } from '@/design-system';
-import { IS_ANDROID, IS_DEV } from '@/env';
+import { IS_DEV } from '@/env';
 import { executeFnIfCloudBackupAvailable } from '@/features/backup/backup';
 import { useCreateBackup } from '@/features/backup/hooks/useCreateBackup';
 import { backupsStore, CloudBackupState } from '@/features/backup/stores/backupsStore';
@@ -136,7 +136,7 @@ export const WalletsAndBackup = () => {
       fn: async () => {
         // NOTE: For Android we could be coming from a not-logged-in state, so we
         // need to check if we have any wallets to back up first.
-        if (IS_ANDROID) {
+        if (Platform.OS === 'android') {
           const currentBackups = backupsStore.getState().backups;
           if (checkLocalWalletsForBackupStatus(currentBackups).allBackedUp) {
             return;

--- a/src/screens/SettingsSheet/components/CurrencySection.tsx
+++ b/src/screens/SettingsSheet/components/CurrencySection.tsx
@@ -6,7 +6,6 @@ import { reloadTimelines } from 'react-native-widgetkit';
 import { analytics } from '@/analytics';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import type { NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_IOS } from '@/env';
 import { resolveCurrencyFlagEmoji } from '@/framework/core/emoji/currencyFlagEmoji';
 import useAccountSettings from '@/hooks/useAccountSettings';
 import * as i18n from '@/languages';
@@ -35,7 +34,7 @@ const CurrencySection = () => {
       userAssetsStoreManager.setState({ currency });
       settingsChangeNativeCurrency(currency);
       // reload widget timelines only if on ios version 14 or above
-      if (IS_IOS && parseInt(Platform.Version as string) >= 14) {
+      if (Platform.OS === 'ios' && parseInt(Platform.Version as string) >= 14) {
         reloadTimelines('PriceWidget');
       }
       analytics.track(analytics.event.changedNativeCurrency, { currency });

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
+import { Platform } from 'react-native';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -9,7 +10,7 @@ import Restart from 'react-native-restart';
 
 import { ImgixImage } from '@/components/images';
 import { defaultConfig, getExperimentalFlag, LOG_PUSH } from '@/config/experimentalHooks';
-import { IS_ANDROID, IS_STORE_INSTALL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { getDelegationContractAddress, isRainbowDelegated, isThirdPartyDelegated } from '@/features/delegation/status';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { RainbowContext } from '@/helpers/RainbowContext';
@@ -79,7 +80,7 @@ const DevSection = () => {
   const checkAlert = useCallback(async () => {
     try {
       const request = await fetch('https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest');
-      if (IS_ANDROID && request.status === 500) throw new Error('failed');
+      if (Platform.OS === 'android' && request.status === 500) throw new Error('failed');
       await request.json();
       Alert.alert(i18n.t(i18n.l.developer_settings.status), i18n.t(i18n.l.developer_settings.not_applied));
     } catch (e) {

--- a/src/screens/SettingsSheet/components/SettingsLoadingIndicator.tsx
+++ b/src/screens/SettingsSheet/components/SettingsLoadingIndicator.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { ActivityIndicator } from 'react-native';
+import { ActivityIndicator, Platform } from 'react-native';
 
 import Spinner from '@/components/Spinner';
-import { IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { useTheme } from '@/theme/ThemeContext';
 
@@ -15,7 +14,7 @@ const ActivityIndicatorIos = styled(ActivityIndicator).attrs({
 
 export const SettingsLoadingIndicator = () => {
   const { colors } = useTheme();
-  if (IS_IOS) {
+  if (Platform.OS === 'ios') {
     return <ActivityIndicatorIos color={colors.black} />;
   } else {
     return <Spinner color={colors.black} />;

--- a/src/screens/SettingsSheet/utils.ts
+++ b/src/screens/SettingsSheet/utils.ts
@@ -1,7 +1,8 @@
+import { Platform } from 'react-native';
+
 import { format } from 'date-fns';
 import { isEmpty } from 'lodash';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { type CloudBackups } from '@/features/backup/backup';
 import { backupsStore, CloudBackupState } from '@/features/backup/stores/backupsStore';
 import { normalizeAndroidBackupFilename } from '@/handlers/cloudBackup';
@@ -29,7 +30,7 @@ export const checkLocalWalletsForBackupStatus = (backups: CloudBackups): WalletB
   }
 
   // FOR ANDROID, we need to check if the current google account also has the backup file
-  if (IS_ANDROID) {
+  if (Platform.OS === 'android') {
     return Object.values(wallets).reduce<WalletBackupStatus>(
       (acc, wallet) => {
         const isBackupEligible = wallet.type !== WalletTypes.readOnly && wallet.type !== WalletTypes.bluetooth;
@@ -74,7 +75,7 @@ export const titleForBackupState: Partial<Record<CloudBackupState, string>> = {
 };
 
 export const isWalletBackedUpForCurrentAccount = ({ backupType, backedUp, backupFile }: Partial<RainbowWallet>) => {
-  if (IS_IOS || backupType === WalletBackupTypes.manual) {
+  if (Platform.OS === 'ios' || backupType === WalletBackupTypes.manual) {
     return backedUp;
   }
 

--- a/src/screens/SignTransactionSheet.tsx
+++ b/src/screens/SignTransactionSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Image, InteractionManager, PixelRatio, ScrollView } from 'react-native';
+import { Image, InteractionManager, PixelRatio, Platform, ScrollView } from 'react-native';
 
 import { isAddress } from '@ethersproject/address';
 import { type Transaction } from '@ethersproject/transactions';
@@ -30,7 +30,6 @@ import { TransactionSimulationCard } from '@/components/Transactions/Transaction
 import { Bleed, Box, Columns, globalColors, Inline, Inset, Stack, Text, useBackgroundColor, useForegroundColor } from '@/design-system';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
-import { IS_IOS } from '@/env';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
 import { useCalculateGasLimit } from '@/features/gas/hooks/useCalculateGasLimit';
 import useGas from '@/features/gas/hooks/useGas';
@@ -600,7 +599,7 @@ export const SignTransactionSheet = () => {
   const expandedCardBottomInset = EXPANDED_CARD_BOTTOM_INSET + (isMessageRequest ? 0 : GAS_BUTTON_SPACE);
 
   return (
-    <PanGestureHandler enabled={IS_IOS}>
+    <PanGestureHandler enabled={Platform.OS === 'ios'}>
       <Animated.View>
         <Inset bottom={{ custom: SCREEN_BOTTOM_INSET }}>
           <Box height="full" justifyContent="flex-end" style={{ gap: 24 }} width="full">
@@ -784,7 +783,7 @@ export const SignTransactionSheet = () => {
               </Box>
 
               {/* Extra ScrollView to prevent the sheet from hijacking the real ScrollViews */}
-              {IS_IOS && (
+              {Platform.OS === 'ios' && (
                 <Box height={{ custom: 0 }} pointerEvents="none" position="absolute" style={{ opacity: 0 }}>
                   <ScrollView scrollEnabled={false} />
                 </Box>

--- a/src/screens/WelcomeScreen/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Alert, StyleSheet, View } from 'react-native';
+import { Alert, Platform, StyleSheet, View } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import { PerformanceMeasureView } from '@shopify/react-native-performance';
@@ -20,7 +20,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { analytics } from '@/analytics';
 import { Box } from '@/design-system';
-import { IS_ANDROID, IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { WalletLoadingStates } from '@/helpers/walletLoadingStates';
 import { useHardwareBackOnFocus } from '@/hooks/useHardwareBack';
@@ -43,9 +43,9 @@ import { Text } from '../../components/text';
 const RAINBOW_TEXT_HEIGHT = 32;
 const RAINBOW_TEXT_WIDTH = 125;
 const ANIMATION_COLORS = ['rgb(255,73,74)', 'rgb(255,170,0)', 'rgb(0,163,217)', 'rgb(0,163,217)', 'rgb(115,92,255)', 'rgb(255,73,74)'];
-const PRIMARY_BUTTON_HEIGHT = IS_IOS ? 54 : 60;
-const PRIMARY_BUTTON_WIDTH = IS_IOS ? 230 : 236;
-const PRIMARY_BUTTON_BORDER_WIDTH = IS_IOS ? 0 : 3;
+const PRIMARY_BUTTON_HEIGHT = Platform.OS === 'ios' ? 54 : 60;
+const PRIMARY_BUTTON_WIDTH = Platform.OS === 'ios' ? 230 : 236;
+const PRIMARY_BUTTON_BORDER_WIDTH = Platform.OS === 'ios' ? 0 : 3;
 
 export function WelcomeScreen() {
   const insets = useSafeAreaInsets();
@@ -205,14 +205,14 @@ export function WelcomeScreen() {
     });
   }, [navigate]);
 
-  useHardwareBackOnFocus(() => true, !IS_ANDROID);
+  useHardwareBackOnFocus(() => true, Platform.OS !== 'android');
 
   return (
     <PerformanceMeasureView interactive={true} screenName="WelcomeScreen">
       <Box style={styles.container} testID="welcome-screen" backgroundColor={colors.white}>
         <RainbowsBackground shouldAnimate={shouldAnimateRainbows} />
         <Animated.View style={[contentStyle, styles.contentContainer]}>
-          {IS_ANDROID && IS_TEST ? (
+          {Platform.OS === 'android' && IS_TEST ? (
             <RainbowText colors={colors} />
           ) : (
             <MaskedView maskElement={<RainbowText colors={colors} />}>

--- a/src/screens/change-wallet/ChangeWalletSheet.tsx
+++ b/src/screens/change-wallet/ChangeWalletSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, InteractionManager, type LayoutChangeEvent } from 'react-native';
+import { Alert, InteractionManager, Platform, type LayoutChangeEvent } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import { useRoute, type RouteProp } from '@react-navigation/native';
@@ -17,7 +17,6 @@ import { FeatureHintTooltip, type TooltipRef } from '@/components/tooltips/Featu
 import useExperimentalFlag, { NOTIFICATIONS } from '@/config/experimentalHooks';
 import { Box, globalColors, HitSlop, Inline, Text } from '@/design-system';
 import type { EthereumAddress } from '@/entities/wallet';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import { showActionSheetWithOptions } from '@/framework/ui/utils/actionsheet';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { removeWalletData } from '@/handlers/localstorage/removeWallet';
@@ -52,7 +51,7 @@ import { DEVICE_HEIGHT } from '@/utils/deviceUtils';
 import doesWalletsContainAddress from '@/utils/doesWalletsContainAddress';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
-const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30);
+const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, Platform.OS === 'ios' ? 8 : 30);
 
 export const PANEL_INSET_HORIZONTAL = 20;
 export const MAX_PANEL_HEIGHT = Math.min(690, DEVICE_HEIGHT - 100);
@@ -112,7 +111,7 @@ export default function ChangeWalletSheet() {
   const featureHintTooltipRef = useRef<TooltipRef>(null);
 
   const [editMode, setEditMode] = useState(false);
-  const [isLayoutMeasured, setIsLayoutMeasured] = useState(IS_IOS);
+  const [isLayoutMeasured, setIsLayoutMeasured] = useState(Platform.OS === 'ios');
 
   const setPinnedAddresses = usePinnedWalletsStore(state => state.setPinnedAddresses);
 
@@ -546,7 +545,7 @@ export default function ChangeWalletSheet() {
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
-      if (!IS_ANDROID) return;
+      if (Platform.OS !== 'android') return;
       const { height } = event.nativeEvent.layout;
 
       // @ts-expect-error Bottom sheet options is not typed

--- a/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
+++ b/src/screens/change-wallet/components/PinnedWalletsGrid.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { BlurView } from 'react-native-blur-view';
@@ -12,7 +12,7 @@ import { Draggable, DraggableGrid, type DraggableGridProps, type UniqueIdentifie
 import { DropdownMenu, type MenuItem } from '@/components/DropdownMenu';
 import { PANEL_WIDTH } from '@/components/SmoothPager/ListPanel';
 import { Box, HitSlop, Inline, Stack, Text, TextIcon } from '@/design-system';
-import { IS_IOS, IS_STORE_INSTALL } from '@/env';
+import { IS_STORE_INSTALL } from '@/env';
 import { useIsDelegationEnabled } from '@/features/delegation/featureFlags';
 import { isRainbowDelegated as hasRainbowDelegation, isThirdPartyDelegated as hasThirdPartyDelegation } from '@/features/delegation/status';
 import { removeFirstEmojiFromString } from '@/helpers/emojiHandler';
@@ -193,11 +193,11 @@ export function PinnedWalletsGrid({ walletItems, onPress, editMode, menuItems, o
                                 height={{ custom: UNPIN_BADGE_SIZE }}
                                 justifyContent="center"
                                 alignItems="center"
-                                backgroundColor={IS_IOS ? 'transparent' : colors.darkGrey}
+                                backgroundColor={Platform.OS === 'ios' ? 'transparent' : colors.darkGrey}
                                 borderRadius={UNPIN_BADGE_SIZE / 2}
                                 style={{ overflow: 'hidden' }}
                               >
-                                {IS_IOS && (
+                                {Platform.OS === 'ios' && (
                                   <BlurView
                                     blurStyle={isDarkMode ? 'materialDark' : 'materialLight'}
                                     style={[StyleSheet.absoluteFill, { borderRadius: UNPIN_BADGE_SIZE / 2, overflow: 'hidden' }]}

--- a/src/screens/claimables/shared/components/ClaimPanel.tsx
+++ b/src/screens/claimables/shared/components/ClaimPanel.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { controlPanelStyles, Panel, TapToDismiss } from '@/components/SmoothPager/ListPanel';
 import { Box } from '@/design-system';
-import { IS_IOS } from '@/env';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
 import { type ClaimStatus } from '../../shared/types';
@@ -26,7 +26,7 @@ export function ClaimPanel({
       <Box
         style={[
           controlPanelStyles.panelContainer,
-          { bottom: Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30), alignItems: 'center', width: '100%' },
+          { bottom: Math.max(safeAreaInsetValues.bottom + 5, Platform.OS === 'ios' ? 8 : 30), alignItems: 'center', width: '100%' },
         ]}
       >
         <Panel>

--- a/src/screens/claimables/shared/components/ClaimValueDisplay.tsx
+++ b/src/screens/claimables/shared/components/ClaimValueDisplay.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import ShimmerAnimation from '@/components/animations/ShimmerAnimation';
 import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { Bleed, Box, globalColors, Text, TextShadow, useColorMode } from '@/design-system';
-import { IS_IOS } from '@/env';
 
 export function ClaimValueDisplay({
   label,
@@ -25,7 +24,7 @@ export function ClaimValueDisplay({
         <Box alignItems="center" flexDirection="row" gap={8} justifyContent="center">
           <View
             style={
-              IS_IOS && isDarkMode
+              Platform.OS === 'ios' && isDarkMode
                 ? {
                     shadowColor: globalColors.grey100,
                     shadowOpacity: 0.2,

--- a/src/screens/claimables/transaction/components/ClaimCustomization.tsx
+++ b/src/screens/claimables/transaction/components/ClaimCustomization.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
@@ -7,7 +8,6 @@ import { type SearchAsset } from '@/__swaps__/types/search';
 import { NetworkSelectorButton } from '@/components/buttons/NetworkSelectorButton';
 import { type MenuItem } from '@/components/DropdownMenu';
 import { Box, Text, useColorMode } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import * as i18n from '@/languages';
 import { ETH_SYMBOL, USDC_ADDRESS } from '@/references/constants';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
@@ -183,7 +183,7 @@ export function ClaimCustomization() {
       ...availableTokens,
     ];
 
-    if (IS_ANDROID) {
+    if (Platform.OS === 'android') {
       availableTokens = availableTokens.reverse();
     }
 

--- a/src/screens/expandedAssetSheet/ExpandedAssetSheet.tsx
+++ b/src/screens/expandedAssetSheet/ExpandedAssetSheet.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -6,7 +7,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { SlackSheet } from '@/components/sheet';
 import { Box, useColorMode } from '@/design-system';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import type Routes from '@/navigation/routesNames';
 import { type RootStackParamList } from '@/navigation/types';
 
@@ -27,7 +27,7 @@ function ExpandedAssetSheetContent() {
       <SlackSheet
         backgroundColor={accentColors.background}
         // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(IS_IOS ? { height: '100%' } : {})}
+        {...(Platform.OS === 'ios' ? { height: '100%' } : {})}
         scrollEnabled
         removeTopPadding
         hideHandle
@@ -41,7 +41,7 @@ function ExpandedAssetSheetContent() {
         <SheetContent accentColor={accentColors.color} />
       </SlackSheet>
       <Box position="absolute" top="0px" left="0px" right="0px" width="full" pointerEvents="none">
-        <Box backgroundColor={accentColors.background} height={safeAreaInsets.top + (IS_ANDROID ? 24 : 12)} width="full">
+        <Box backgroundColor={accentColors.background} height={safeAreaInsets.top + (Platform.OS === 'android' ? 24 : 12)} width="full">
           <Box
             height={{ custom: 5 }}
             width={{ custom: 36 }}

--- a/src/screens/expandedAssetSheet/components/AssetContextMenu.tsx
+++ b/src/screens/expandedAssetSheet/components/AssetContextMenu.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useMemo } from 'react';
-import { Share } from 'react-native';
+import { Platform, Share } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 
 import { DropdownMenu, type MenuConfig, type MenuItem } from '@/components/DropdownMenu';
 import { SheetActionButton } from '@/components/sheet';
 import { Box, TextIcon } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { buildTokenDeeplink } from '@/handlers/deeplinks';
 import EditAction from '@/helpers/EditAction';
 import useCoinListEditOptions, { useCoinListFinishEditingOptions } from '@/hooks/useCoinListEditOptions';
@@ -145,7 +144,7 @@ export function AssetContextMenu() {
             contractAddress: asset.address,
           });
         Share.share(
-          IS_ANDROID
+          Platform.OS === 'android'
             ? {
                 message: url,
               }
@@ -174,9 +173,9 @@ export function AssetContextMenu() {
   };
 
   return (
-    <Box style={{ margin: IS_ANDROID ? 0 : -HIT_SLOP }}>
+    <Box style={{ margin: Platform.OS === 'android' ? 0 : -HIT_SLOP }}>
       <DropdownMenu<ContextMenuAction> menuConfig={menuConfig} onPressMenuItem={handlePressMenuItem}>
-        <Box style={{ margin: IS_ANDROID ? 0 : HIT_SLOP }}>
+        <Box style={{ margin: Platform.OS === 'android' ? 0 : HIT_SLOP }}>
           <SheetActionButton color={accentColors.opacity100} newShadows isSquare size={48}>
             <TextIcon color="label" containerSize={48} size="icon 20px" weight="heavy">
               􀍠

--- a/src/screens/expandedAssetSheet/components/sections/shared/CreatorInfoRow.tsx
+++ b/src/screens/expandedAssetSheet/components/sections/shared/CreatorInfoRow.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import Animated, {
   FadeIn,
@@ -18,7 +18,6 @@ import { pulsingConfig, sliderConfig } from '@/__swaps__/screens/Swap/constants'
 import { AnimatedImage } from '@/components/AnimatedComponents/AnimatedImage';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { AnimatedText, Bleed, Box, Text, TextIcon, TextShadow, useBackgroundColor } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStableValue } from '@/hooks/useStableValue';
 import { fetchAndSetEnsData } from '@/screens/Airdrops/ClaimAirdropSheet';
@@ -116,7 +115,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     height: 16,
     justifyContent: 'center',
-    marginTop: IS_IOS ? undefined : -3,
+    marginTop: Platform.OS === 'ios' ? undefined : -3,
     overflow: 'hidden',
     position: 'relative',
     width: 16,

--- a/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
+++ b/src/screens/hardware-wallets/PairHardwareWalletAgainSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ImageBackground } from 'react-native';
+import { ImageBackground, Platform } from 'react-native';
 
 import { useMMKVBoolean } from 'react-native-mmkv';
 import Animated, { useAnimatedStyle, useDerivedValue, withDelay, withRepeat, withSequence, withTiming } from 'react-native-reanimated';
@@ -9,7 +9,6 @@ import gridDotsDark from '@/assets/dot-grid-dark.png';
 import gridDotsLight from '@/assets/dot-grid-light.png';
 import ledgerNano from '@/assets/ledger-nano.png';
 import { Box, Inline, Inset, Stack, Text } from '@/design-system';
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import {
   HARDWARE_TX_ERROR_KEY,
@@ -143,7 +142,7 @@ export const PairHardwareWalletAgainSheet = () => {
                           width={{ custom: INDICATOR_SIZE }}
                           height={{ custom: INDICATOR_SIZE }}
                           background="yellow"
-                          shadow={IS_IOS ? '30px yellow' : undefined}
+                          shadow={Platform.OS === 'ios' ? '30px yellow' : undefined}
                           position="absolute"
                           borderRadius={INDICATOR_SIZE / 2}
                         />
@@ -154,7 +153,7 @@ export const PairHardwareWalletAgainSheet = () => {
                       height={{ custom: INDICATOR_SIZE }}
                       style={{ zIndex: -1 }}
                       background={hardwareTXError ? 'red' : isReady ? 'green' : 'surfaceSecondary'}
-                      shadow={IS_IOS ? (hardwareTXError ? '30px red' : isReady ? '30px green' : undefined) : undefined}
+                      shadow={Platform.OS === 'ios' ? (hardwareTXError ? '30px red' : isReady ? '30px green' : undefined) : undefined}
                       borderRadius={INDICATOR_SIZE / 2}
                     />
                   </Box>

--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { useFocusEffect, useRoute, type RouteProp } from '@react-navigation/native';
 import { getClient, type Execute } from '@reservoir0x/reservoir-sdk';
@@ -17,7 +17,6 @@ import { ContactAvatar } from '@/components/contacts';
 import { useRainbowToastEnabled } from '@/components/rainbow-toast/useRainbowToastEnabled';
 import { Bleed, Box, ColorModeProvider, Column, Columns, Inline, Inset, Separator, Stack, Text } from '@/design-system';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
-import { IS_IOS } from '@/env';
 import useENSAvatar from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
@@ -544,7 +543,7 @@ const MintSheet = () => {
       )}
       <SlackSheet
         backgroundColor={isDarkMode ? `rgba(22, 22, 22, ${ios ? 0.4 : 1})` : `rgba(26, 26, 26, ${ios ? 0.4 : 1})`}
-        {...(IS_IOS ? { height: '100%' } : {})}
+        {...(Platform.OS === 'ios' ? { height: '100%' } : {})}
         ref={sheetRef}
         scrollEnabled
         additionalTopPadding

--- a/src/screens/mints/PoapSheet.tsx
+++ b/src/screens/mints/PoapSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { useFocusEffect, useRoute, type RouteProp } from '@react-navigation/native';
 import { format } from 'date-fns';
@@ -11,7 +11,6 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Spinner from '@/components/Spinner';
 import { Box, ColorModeProvider, Row, Rows, Stack, Text } from '@/design-system';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
-import { IS_ANDROID, IS_IOS } from '@/env';
 import styled from '@/framework/ui/styled-thing';
 import { arcClient } from '@/graphql';
 import { maybeSignUri } from '@/handlers/imgix';
@@ -60,7 +59,7 @@ const BlurWrapper = styled(View).attrs({
   overflow: 'hidden',
   position: 'absolute',
   width: ({ width }: BlurWrapperProps) => width,
-  ...(IS_ANDROID ? { borderTopLeftRadius: 30, borderTopRightRadius: 30 } : {}),
+  ...(Platform.OS === 'android' ? { borderTopLeftRadius: 30, borderTopRightRadius: 30 } : {}),
 });
 
 type PoapClaimStatus = 'none' | 'claiming' | 'claimed' | 'error';
@@ -213,7 +212,7 @@ const PoapSheet = () => {
 
   return (
     <>
-      {IS_IOS && (
+      {Platform.OS === 'ios' && (
         <BlurWrapper height={deviceHeight} width={deviceWidth}>
           <BackgroundImage>
             <ImgixImage
@@ -227,7 +226,9 @@ const PoapSheet = () => {
         </BlurWrapper>
       )}
       <SlackSheet
-        backgroundColor={isDarkMode ? `rgba(22, 22, 22, ${IS_IOS ? 0.4 : 1})` : `rgba(26, 26, 26, ${IS_IOS ? 0.4 : 1})`}
+        backgroundColor={
+          isDarkMode ? `rgba(22, 22, 22, ${Platform.OS === 'ios' ? 0.4 : 1})` : `rgba(26, 26, 26, ${Platform.OS === 'ios' ? 0.4 : 1})`
+        }
         height={'100%'}
         ref={sheetRef}
         scrollEnabled
@@ -238,7 +239,7 @@ const PoapSheet = () => {
           <Box
             width="full"
             height={{
-              custom: deviceHeight - (IS_IOS ? 100 : 50) - (errorCode ? 24 : 0),
+              custom: deviceHeight - (Platform.OS === 'ios' ? 100 : 50) - (errorCode ? 24 : 0),
             }}
             justifyContent="center"
             alignItems="center"

--- a/src/screens/network-selector/NetworkSelector.tsx
+++ b/src/screens/network-selector/NetworkSelector.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
-import { Pressable, ScrollView, StyleSheet, View, type TextInput } from 'react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, View, type TextInput } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import { useRoute, type RouteProp } from '@react-navigation/native';
@@ -50,7 +50,6 @@ import {
   useColorMode,
 } from '@/design-system';
 import { useForegroundColor } from '@/design-system/color/useForegroundColor';
-import { IS_IOS } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import Navigation, { useNavigation } from '@/navigation/Navigation';
@@ -101,7 +100,7 @@ const SEPARATOR_HEIGHT = 68;
 const SEPARATOR_HEIGHT_NETWORK_CHIP = 18;
 const SHEET_WIDTH = deviceUtils.dimensions.width - 16;
 const ALL_NETWORKS_BADGE_SIZE = 16;
-const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, IS_IOS ? 8 : 30);
+const PANEL_BOTTOM_OFFSET = Math.max(safeAreaInsetValues.bottom + 5, Platform.OS === 'ios' ? 8 : 30);
 const MAX_NETWORK_LIST_HEIGHT = MAX_HEIGHT - HEADER_HEIGHT;
 const SEARCH_BAR_CLEARANCE = SEARCH_BAR_HEIGHT + SHEET_INNER_PADDING + 18;
 
@@ -1170,7 +1169,7 @@ const sx = StyleSheet.create({
     paddingHorizontal: 10 - THICK_BORDER_WIDTH,
     position: 'absolute',
     right: 4,
-    top: IS_IOS ? 0 : -14,
+    top: Platform.OS === 'ios' ? 0 : -14,
   },
   emptyUnpinnedPlaceholder: {
     alignItems: 'center',

--- a/src/screens/rewards/components/RewardsSectionCard.tsx
+++ b/src/screens/rewards/components/RewardsSectionCard.tsx
@@ -1,8 +1,7 @@
 import React, { type PropsWithChildren } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { Box, globalColors, useBackgroundColor, type Space } from '@/design-system';
-import { IS_IOS } from '@/env';
 import { useTheme } from '@/theme/ThemeContext';
 
 type Props = {
@@ -18,7 +17,7 @@ export function RewardsSectionCard({ children, paddingVertical = '20px', padding
   return (
     <View
       style={
-        IS_IOS
+        Platform.OS === 'ios'
           ? {
               shadowColor: globalColors.grey100,
               shadowOffset: { width: 0, height: 2 },
@@ -30,7 +29,7 @@ export function RewardsSectionCard({ children, paddingVertical = '20px', padding
     >
       <View
         style={
-          IS_IOS
+          Platform.OS === 'ios'
             ? {
                 shadowColor: globalColors.grey100,
                 shadowOffset: { width: 0, height: 4 },

--- a/src/screens/token-launcher/TokenLauncherScreen.tsx
+++ b/src/screens/token-launcher/TokenLauncherScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { Dimensions, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { Dimensions, Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 import { KeyboardAvoidingView, KeyboardStickyView } from 'react-native-keyboard-controller';
 import Animated, { Extrapolation, FadeIn, FadeOut, interpolate, useAnimatedStyle, withTiming } from 'react-native-reanimated';
@@ -7,7 +7,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { PANEL_COLOR_DARK } from '@/components/SmoothPager/ListPanel';
 import { Border, Box, ColorModeProvider, globalColors } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 
 import { CreatingStep } from './components/CreatingStep';
@@ -54,7 +53,7 @@ function TokenLauncherScreenContent() {
   const step = useTokenLauncherStore(state => state.step);
 
   const footerHeight = FOOTER_HEIGHT + (step === NavigationSteps.SUCCESS ? 42 : 0);
-  const contentContainerHeight = screenHeight - footerHeight - (IS_ANDROID ? 0 : safeAreaTop + safeAreaBottom);
+  const contentContainerHeight = screenHeight - footerHeight - (Platform.OS === 'android' ? 0 : safeAreaTop + safeAreaBottom);
 
   useEffect(() => {
     return () => {
@@ -64,7 +63,10 @@ function TokenLauncherScreenContent() {
 
   const isReviewStepVisible = useMemo(() => step === NavigationSteps.REVIEW || step === NavigationSteps.INFO, [step]);
 
-  const stickyFooterKeyboardOffset = useMemo(() => ({ closed: 0, opened: IS_ANDROID ? 0 : safeAreaBottom }), [safeAreaBottom]);
+  const stickyFooterKeyboardOffset = useMemo(
+    () => ({ closed: 0, opened: Platform.OS === 'android' ? 0 : safeAreaBottom }),
+    [safeAreaBottom]
+  );
 
   const infoStepAnimatedStyle = useAnimatedStyle(() => ({
     transform: [
@@ -92,7 +94,7 @@ function TokenLauncherScreenContent() {
     ],
   }));
 
-  const keyboardVerticalOffset = IS_ANDROID ? FOOTER_HEIGHT + safeAreaBottom : FOOTER_HEIGHT;
+  const keyboardVerticalOffset = Platform.OS === 'android' ? FOOTER_HEIGHT + safeAreaBottom : FOOTER_HEIGHT;
 
   const animatedBorderStyle = useAnimatedStyle(() => ({
     opacity: interpolate(stepAnimatedSharedValue.value, [NavigationSteps.INFO, NavigationSteps.REVIEW], [1, 0], 'clamp'),
@@ -210,7 +212,7 @@ function getTokenLauncherStyles({
     borderEffectsStyle: [StyleSheet.absoluteFill, { pointerEvents: 'none', zIndex: 3 }],
     borderStyle: [StyleSheet.absoluteFill, { pointerEvents: 'none', zIndex: 100 }, animatedBorderStyle],
     containerStyle: {
-      backgroundColor: IS_ANDROID ? globalColors.grey100 : undefined,
+      backgroundColor: Platform.OS === 'android' ? globalColors.grey100 : undefined,
       flex: 1,
       height: screenHeight,
       paddingBottom: safeAreaBottom,

--- a/src/screens/token-launcher/components/FieldContainer.tsx
+++ b/src/screens/token-launcher/components/FieldContainer.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, type StyleProp, type ViewStyle } from 'react-native';
 
 import Animated from 'react-native-reanimated';
-
-import { IS_ANDROID } from '@/env';
 
 import { FIELD_BACKGROUND_COLOR, FIELD_BORDER_COLOR, FIELD_BORDER_RADIUS, FIELD_BORDER_WIDTH } from '../constants';
 
@@ -22,7 +20,7 @@ export function FieldContainer({ style, children }: FieldContainerProps) {
           borderRadius: FIELD_BORDER_RADIUS,
           borderColor: FIELD_BORDER_COLOR,
           overflow: 'hidden',
-          paddingVertical: IS_ANDROID ? 0 : 8,
+          paddingVertical: Platform.OS === 'android' ? 0 : 8,
           paddingHorizontal: 20,
           backgroundColor: FIELD_BACKGROUND_COLOR,
         },

--- a/src/screens/token-launcher/components/InfoInputStep.tsx
+++ b/src/screens/token-launcher/components/InfoInputStep.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { StyleSheet, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
+import { Platform, StyleSheet, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import Animated from 'react-native-reanimated';
@@ -7,7 +7,6 @@ import Animated from 'react-native-reanimated';
 import { Icon } from '@/components/icons';
 import { Bleed, Box, Separator, Text } from '@/design-system';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
-import { IS_ANDROID } from '@/env';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import { PrebuySection } from '@/screens/token-launcher/components/PrebuySection';
@@ -120,7 +119,7 @@ export function InfoInputStep() {
       ref={infoInputScrollRef}
       onScroll={onScroll}
       scrollEventThrottle={64}
-      bottomOffset={FOOTER_HEIGHT + (IS_ANDROID ? 56 : 36)}
+      bottomOffset={FOOTER_HEIGHT + (Platform.OS === 'android' ? 56 : 36)}
       contentContainerStyle={styles.contentContainerStyle}
       extraKeyboardSpace={FOOTER_HEIGHT}
       keyboardDismissMode="interactive"

--- a/src/screens/token-launcher/components/TokenLauncherFooter.tsx
+++ b/src/screens/token-launcher/components/TokenLauncherFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Alert, Keyboard, Share } from 'react-native';
+import { Alert, Keyboard, Platform, Share } from 'react-native';
 
 import Animated, { Extrapolation, FadeOut, interpolate, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { createPublicClient, createWalletClient, http, isHex } from 'viem';
@@ -12,7 +12,6 @@ import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
 import { Box, Inline, Text } from '@/design-system';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
-import { IS_ANDROID } from '@/env';
 import { buildTokenDeeplink } from '@/handlers/deeplinks';
 import { BiometryTypes } from '@/helpers';
 import useBiometryType from '@/hooks/useBiometryType';
@@ -51,7 +50,7 @@ function HoldToCreateButton() {
 
   const isLongPressAvailableForBiometryType =
     biometryType === BiometryTypes.FaceID || biometryType === BiometryTypes.Face || biometryType === BiometryTypes.none;
-  const showBiometryIcon = !IS_ANDROID && isLongPressAvailableForBiometryType && !isHardwareWallet;
+  const showBiometryIcon = Platform.OS !== 'android' && isLongPressAvailableForBiometryType && !isHardwareWallet;
 
   const handleLongPress = useCallback(async () => {
     setIsProcessing(true);
@@ -202,7 +201,7 @@ function ShareButton() {
           contractAddress: launchedTokenAddress,
         });
         await Share.share(
-          IS_ANDROID
+          Platform.OS === 'android'
             ? {
                 message: url,
               }

--- a/src/screens/token-launcher/components/TokenLogo.tsx
+++ b/src/screens/token-launcher/components/TokenLogo.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { Canvas, Group, Image, rect, rrect, Shadow, Box as SkBox } from '@shopify/react-native-skia';
 import * as ImagePicker from 'expo-image-picker';
@@ -8,7 +8,6 @@ import Svg, { Circle } from 'react-native-svg';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Text, TextIcon, TextShadow } from '@/design-system';
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 
 import { ERROR_RED } from '../constants';
@@ -87,7 +86,7 @@ export function TokenLogo({ size = SIZE, disabled = false }: { size?: number; di
             <Box borderRadius={size / 2} style={StyleSheet.absoluteFill}>
               <Box width={'full'} height={'full'} justifyContent={'center'} alignItems={'center'}>
                 <Box
-                  backgroundColor={IS_IOS ? accentColors.opacity6 : accentColors.opacity10}
+                  backgroundColor={Platform.OS === 'ios' ? accentColors.opacity6 : accentColors.opacity10}
                   borderRadius={size / 2}
                   height={size - 14}
                   position="absolute"
@@ -132,7 +131,6 @@ export function TokenLogo({ size = SIZE, disabled = false }: { size?: number; di
           </Box>
         )}
       </ButtonPressAnimation>
-
       {error && (
         <Box gap={8} paddingTop={'12px'}>
           <Text align="center" size="13pt" color={{ custom: ERROR_RED }} weight="medium">

--- a/src/screens/transaction-details/TransactionDetails.tsx
+++ b/src/screens/transaction-details/TransactionDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { type LayoutChangeEvent } from 'react-native';
+import { Platform, type LayoutChangeEvent } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -8,7 +8,6 @@ import { rainbowToastsActions } from '@/components/rainbow-toast/useRainbowToast
 import { SlackSheet } from '@/components/sheet';
 import { Toast, ToastPositionContainer } from '@/components/toasts';
 import { BackgroundProvider, Box } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
@@ -46,7 +45,7 @@ export const TransactionDetails = () => {
     (event: LayoutChangeEvent) => {
       const contentHeight = event.nativeEvent.layout.height;
       if (contentHeight > deviceHeight) setStatusIconHidden(true);
-      setSheetHeight(contentHeight + (IS_ANDROID ? bottom : 0));
+      setSheetHeight(contentHeight + (Platform.OS === 'android' ? bottom : 0));
     },
     [bottom, deviceHeight]
   );
@@ -65,8 +64,8 @@ export const TransactionDetails = () => {
         <SlackSheet
           contentHeight={sheetHeight}
           backgroundColor={backgroundColor}
-          height={IS_ANDROID ? sheetHeight : '100%'}
-          deferredHeight={IS_ANDROID}
+          height={Platform.OS === 'android' ? sheetHeight : '100%'}
+          deferredHeight={Platform.OS === 'android'}
           showsVerticalScrollIndicator={false}
         >
           <Box paddingHorizontal="20px" paddingBottom="20px" onLayout={onSheetContentLayout}>

--- a/src/screens/transaction-details/components/TransactionMasthead.tsx
+++ b/src/screens/transaction-details/components/TransactionMasthead.tsx
@@ -1,6 +1,7 @@
 // @refresh reset
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 
 import Animated, { Easing, interpolate, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTiming } from 'react-native-redash';
@@ -18,7 +19,6 @@ import RowWithMargins from '@/components/layout/RowWithMargins';
 import { Bleed, Box, Columns, Cover, Row, Rows, Separator, Stack, Text, type TextProps } from '@/design-system';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { type RainbowTransaction } from '@/entities/transactions';
-import { IS_ANDROID } from '@/env';
 import { getDelegationContractAddress, isRainbowDelegated } from '@/features/delegation/status';
 import { fetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
@@ -174,7 +174,6 @@ function CurrencyTile({
   return (
     <Container>
       <Gradient color={colorToUse} />
-
       <Rows alignHorizontal="center" alignVertical="center" space="10px">
         <Row height="content">
           <Box>
@@ -218,7 +217,12 @@ function CurrencyTile({
           <Box width="full">
             <Rows space={'10px'}>
               <Row height="content">
-                <Box alignItems="center" justifyContent="center" marginTop={IS_ANDROID ? '-6px' : { custom: 0 }} width="full">
+                <Box
+                  alignItems="center"
+                  justifyContent="center"
+                  marginTop={Platform.OS === 'android' ? '-6px' : { custom: 0 }}
+                  width="full"
+                >
                   <AnimatedText
                     size="16px / 22px (Deprecated)"
                     color="label"
@@ -230,7 +234,12 @@ function CurrencyTile({
                 </Box>
               </Row>
               <Row height="content">
-                <Box alignItems="center" justifyContent="center" marginTop={IS_ANDROID ? '-6px' : { custom: 0 }} width="full">
+                <Box
+                  alignItems="center"
+                  justifyContent="center"
+                  marginTop={Platform.OS === 'android' ? '-6px' : { custom: 0 }}
+                  width="full"
+                >
                   <AnimatedText
                     size="14px / 19px (Deprecated)"
                     color="labelSecondary"

--- a/src/state/backendNetworks/types.ts
+++ b/src/state/backendNetworks/types.ts
@@ -1,12 +1,13 @@
+import { Platform } from 'react-native';
+
 import type { Address } from 'viem';
 import * as chain from 'viem/chains';
 
 import type { AddressOrEth } from '@/__swaps__/types/assets';
-import { IS_ANDROID } from '@/env';
 
 const ANVIL_CHAIN_ID = 1337;
 const ANVIL_OP_CHAIN_ID = 1338;
-const ANVIL_RPC_URL = IS_ANDROID ? 'http://10.0.2.2:8545' : 'http://127.0.0.1:8545';
+const ANVIL_RPC_URL = Platform.OS === 'android' ? 'http://10.0.2.2:8545' : 'http://127.0.0.1:8545';
 
 export enum Network {
   apechain = 'apechain',

--- a/src/state/internal/createRainbowStore.ts
+++ b/src/state/internal/createRainbowStore.ts
@@ -1,8 +1,10 @@
+import { Platform } from 'react-native';
+
 import { debounce } from 'lodash';
 import { persist, subscribeWithSelector, type PersistOptions, type PersistStorage } from 'zustand/middleware';
 import { createWithEqualityFn } from 'zustand/traditional';
 
-import { IS_IOS, IS_TEST } from '@/env';
+import { IS_TEST } from '@/env';
 import { logger, RainbowError } from '@/logger';
 import { time } from '@/utils/time';
 
@@ -81,7 +83,7 @@ function buildPersistOptions<S, PersistedState extends Partial<S>>(
   return persistConfig;
 }
 
-const DEFAULT_PERSIST_THROTTLE_MS = IS_TEST ? 0 : IS_IOS ? time.seconds(3) : time.seconds(5);
+const DEFAULT_PERSIST_THROTTLE_MS = IS_TEST ? 0 : Platform.OS === 'ios' ? time.seconds(3) : time.seconds(5);
 
 /**
  * Creates a persist storage object for the Rainbow store.

--- a/src/styles/fonts.js
+++ b/src/styles/fonts.js
@@ -1,10 +1,10 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
 
 const font = {};
 
 font.family = {
-  SFProRounded: IS_IOS ? 'SF Pro Rounded' : 'SF-Pro-Rounded',
-  SFMono: IS_IOS ? 'SF Mono' : 'SF-Mono-Bold',
+  SFProRounded: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded',
+  SFMono: Platform.OS === 'ios' ? 'SF Mono' : 'SF-Mono-Bold',
 };
 
 font.letterSpacing = {

--- a/src/systems/funding/components/deposit/gas/GasMenu.tsx
+++ b/src/systems/funding/components/deposit/gas/GasMenu.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo, type ReactNode } from 'react';
+import { Platform } from 'react-native';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ContextMenu } from '@/components/context-menu';
 import { Centered } from '@/components/layout';
 import ContextMenuButton from '@/components/native-context-menu/contextMenu';
 import { Box } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import { type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { type GasSpeed } from '@/features/gas/types/gasSpeed';
 import gasUtils from '@/features/gas/utils/gas';
@@ -63,11 +63,11 @@ export function GasMenu({ children, onSelectGasSpeed }: { children: ReactNode; o
     <Box
       alignItems="center"
       justifyContent="center"
-      style={{ margin: IS_ANDROID ? 0 : -GAS_BUTTON_HIT_SLOP }}
+      style={{ margin: Platform.OS === 'android' ? 0 : -GAS_BUTTON_HIT_SLOP }}
       testID="gas-speed-pager"
       pointerEvents={isGasSponsored ? 'none' : 'auto'}
     >
-      {IS_ANDROID ? (
+      {Platform.OS === 'android' ? (
         <ContextMenu
           activeOpacity={0}
           isAnchoredToRight

--- a/src/systems/funding/components/deposit/gas/SelectedGasSpeed.tsx
+++ b/src/systems/funding/components/deposit/gas/SelectedGasSpeed.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
+import { Platform } from 'react-native';
 
 import { Inline, Text, TextIcon } from '@/design-system';
-import { IS_ANDROID } from '@/env';
 import gasUtils from '@/features/gas/utils/gas';
 import * as i18n from '@/languages';
 import { useDepositContext } from '@/systems/funding/contexts/DepositContext';
@@ -20,7 +20,7 @@ export const SelectedGasSpeed = memo(function SelectedGasSpeed({ isPill }: { isP
           color={SWAP_GAS_ICONS[selectedGasSpeed].color}
           height={10}
           size="icon 13px"
-          textStyle={{ top: IS_ANDROID ? 1 : 0 + (selectedGasSpeed === 'fast' ? 0.5 : 0) }}
+          textStyle={{ top: Platform.OS === 'android' ? 1 : 0 + (selectedGasSpeed === 'fast' ? 0.5 : 0) }}
           width={isPill ? 14 : 18}
           weight="bold"
         >

--- a/src/utils/bluetoothPermissions.ts
+++ b/src/utils/bluetoothPermissions.ts
@@ -1,4 +1,4 @@
-import { Alert, Linking } from 'react-native';
+import { Alert, Linking, Platform } from 'react-native';
 
 import {
   checkMultiple as checkForMultiplePermissions,
@@ -9,7 +9,6 @@ import {
   type AndroidPermission,
 } from 'react-native-permissions';
 
-import { IS_IOS } from '@/env';
 import * as i18n from '@/languages';
 import { logger } from '@/logger';
 
@@ -20,7 +19,7 @@ export const showBluetoothPoweredOffAlert = async () => {
   await Alert.alert(i18n.t(i18n.l.bluetooth.powered_off_alert.title), i18n.t(i18n.l.bluetooth.powered_off_alert.message), [
     {
       onPress: () => {
-        IS_IOS ? Linking.openURL('App-Prefs:Bluetooth') : Linking.sendIntent('android.settings.BLUETOOTH_SETTINGS');
+        Platform.OS === 'ios' ? Linking.openURL('App-Prefs:Bluetooth') : Linking.sendIntent('android.settings.BLUETOOTH_SETTINGS');
       },
       text: i18n.t(i18n.l.bluetooth.powered_off_alert.open_settings),
     },

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -2,12 +2,10 @@ import { Dimensions, NativeModules, PixelRatio, Platform } from 'react-native';
 
 import { initialWindowMetrics } from 'react-native-safe-area-context';
 
-import { IS_ANDROID, IS_IOS } from '@/env';
-
 const scale = Dimensions.get('screen').scale;
 const { height, width } = Dimensions.get('window');
 
-export const NAVIGATION_BAR_HEIGHT = IS_ANDROID ? NativeModules.NavbarHeight.getNavigationBarHeight() / scale : 0;
+export const NAVIGATION_BAR_HEIGHT = Platform.OS === 'android' ? NativeModules.NavbarHeight.getNavigationBarHeight() / scale : 0;
 
 const deviceUtils = (function () {
   const iPhone15ProHeight = 852,
@@ -17,7 +15,7 @@ const deviceUtils = (function () {
     iPhoneXWidth = 375,
     veryNarrowPhoneThreshold = 340;
 
-  const isIOS14 = IS_IOS && parseFloat(Platform.Version as string) >= 14;
+  const isIOS14 = Platform.OS === 'ios' && parseFloat(Platform.Version as string) >= 14;
   const isAndroid12 = Platform.OS === 'android' && parseFloat(Platform.constants.Release as string) >= 12;
 
   return {
@@ -42,7 +40,7 @@ const deviceUtils = (function () {
 })();
 
 export function isUsingButtonNavigation() {
-  if (!IS_ANDROID) return false;
+  if (Platform.OS !== 'android') return false;
   return NAVIGATION_BAR_HEIGHT > 40;
 }
 

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -1,4 +1,4 @@
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Platform } from 'react-native';
 
 import { type BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
@@ -15,7 +15,6 @@ import { type AddressOrEth } from '@/__swaps__/types/assets';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { type NewTransaction, type RainbowTransaction } from '@/entities/transactions';
 import { type EthereumAddress } from '@/entities/wallet';
-import { IS_IOS } from '@/env';
 import { type GasFee, type LegacySelectedGasFee, type SelectedGasFee } from '@/features/gas/types/gas';
 import { getOnchainAssetBalance } from '@/handlers/assets';
 import { getProvider, isTestnetChain, toHex } from '@/handlers/web3';
@@ -453,7 +452,7 @@ async function parseEthereumUrl(data: string) {
 
   InteractionManager.runAfterInteractions(() => {
     const params = { address, asset: assetWithPrice, nativeAmount };
-    if (IS_IOS) {
+    if (Platform.OS === 'ios') {
       Navigation.handleAction(Routes.SEND_FLOW, {
         params,
         screen: Routes.SEND_SHEET,

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,4 +1,4 @@
-import { IS_IOS } from '@/env';
+import { Platform } from 'react-native';
 
-export const cloudPlatform = IS_IOS ? 'iCloud' : 'Google Drive';
-export const cloudPlatformAccountName = IS_IOS ? 'Apple iCloud' : 'Google';
+export const cloudPlatform = Platform.OS === 'ios' ? 'iCloud' : 'Google Drive';
+export const cloudPlatformAccountName = Platform.OS === 'ios' ? 'Apple iCloud' : 'Google';

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -1,10 +1,9 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 import { Wallet } from '@ethersproject/wallet';
 import { mnemonicToSeed } from 'bip39';
 import { hdkey } from 'ethereumjs-wallet';
 
-import { IS_IOS } from '@/env';
 import { addHexPrefix, ensureChecksumAddress } from '@/handlers/web3';
 import WalletTypes from '@/helpers/walletTypes';
 import {
@@ -48,7 +47,7 @@ export const deriveAccountFromBluetoothHardwareWallet = async (deviceId: string,
 
 export const deriveAccountFromMnemonic = async (mnemonic: string, index = 0): Promise<EthereumWalletFromSeed> => {
   let seed;
-  if (IS_IOS) {
+  if (Platform.OS === 'ios') {
     seed = await mnemonicToSeed(mnemonic);
   } else {
     const res = await RNBip39.mnemonicToSeed({ mnemonic, passphrase: null });


### PR DESCRIPTION
`IS_IOS` and `IS_ANDROID` utils from `env.ts` are used across the codebase for platform branching. The wrapper looks innocuous, but per [Expo's platform shaking docs](https://docs.expo.dev/guides/tree-shaking/#platform-shaking), the constant-folding optimization that strips dead platform branches at build time only fires when `Platform.OS` is imported directly from `react-native` in each file. Custom consts re-exported from another module explicitly break the optimization. Today we use `@react-native-community/cli` with `@react-native/metro-config`, not `expo/metro-config`, so platform shaking isn't running yet, but the indirection is a forward-compat blocker the day we swap to Expo's Metro pipeline. The same wrapper also surfaces as a boundary leak in `src/design-system/`, where DS components reach into app aware `@/env` instead of depending only o npm packages.

This change replaces every `IS_IOS`/`IS_ANDROID` callsite with `Platform.OS === '...'`, importing `Platform` directly from `react-native` in each file. A new ESLint rule is also added that should prevent the wrapper pattern from creeping back. It flags patterns like `import { Platform } from '<not-react-native>'`.