### PR TITLE
fix (preferences): fix overfetching of preferences

### DIFF
--- a/src/helpers/webData.ts
+++ b/src/helpers/webData.ts
@@ -28,24 +28,12 @@ export const initWebData = async (
   ]);
 };
 
-export const updateWebHidden = async (address: string, assetIds: string[], forceInit = false) => {
-  const response = await getPreference('hidden', address);
-  if (forceInit || !response || !response.hidden.ids.length) {
-    await setPreference(PreferenceActionType.init, 'hidden', address, assetIds);
-    return;
-  }
-
-  setPreference(PreferenceActionType.update, 'hidden', address, assetIds);
+export const updateWebHidden = async (address: string, assetIds: string[]) => {
+  await setPreference(PreferenceActionType.init, 'hidden', address, assetIds);
 };
 
-export const updateWebShowcase = async (address: string, assetIds: string[], forceInit = false) => {
-  const response = await getPreference('showcase', address);
-  if (forceInit || !response || !response.showcase.ids.length) {
-    await setPreference(PreferenceActionType.init, 'showcase', address, assetIds);
-    return;
-  }
-
-  setPreference(PreferenceActionType.update, 'showcase', address, assetIds);
+export const updateWebShowcase = async (address: string, assetIds: string[]) => {
+  await setPreference(PreferenceActionType.init, 'showcase', address, assetIds);
 };
 
 export const wipeWebData = async (address: string) => {

--- a/src/hooks/useFetchHiddenTokens.ts
+++ b/src/hooks/useFetchHiddenTokens.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { EthereumWalletType } from '@/helpers/walletTypes';
 import { getPreference } from '@/model/preferences';
+import { queryClient } from '@/react-query';
 import { useNftsStore } from '@/state/nfts/nfts';
 import { isDataComplete } from '@/state/nfts/utils';
 import { getWalletWithAccount } from '@/state/wallets/walletsStore';
@@ -53,6 +54,13 @@ export async function getHidden(address: string, isMigration = false) {
   }
 
   return STABLE_ARRAY;
+}
+
+export async function fetchHiddenTokens({ address }: { address: string }) {
+  return queryClient.fetchQuery({
+    queryKey: hiddenTokensQueryKey({ address }),
+    queryFn: () => getHidden(address),
+  });
 }
 
 export default function useFetchHiddenTokens({ address }: { address: string }) {

--- a/src/hooks/useFetchHiddenTokens.ts
+++ b/src/hooks/useFetchHiddenTokens.ts
@@ -11,6 +11,8 @@ import { time } from '@/utils/time';
 export const hiddenTokensQueryKey = ({ address }: { address: string }) => ['hidden-tokens', address];
 
 const STABLE_ARRAY: string[] = [];
+const STALE_TIME = time.minutes(10);
+const CACHE_TIME = time.infinity;
 
 export async function getHidden(address: string, isMigration = false) {
   if (!address) return STABLE_ARRAY;
@@ -60,13 +62,15 @@ export async function fetchHiddenTokens({ address }: { address: string }) {
   return queryClient.fetchQuery({
     queryKey: hiddenTokensQueryKey({ address }),
     queryFn: () => getHidden(address),
+    cacheTime: CACHE_TIME,
+    staleTime: STALE_TIME,
   });
 }
 
 export default function useFetchHiddenTokens({ address }: { address: string }) {
   return useQuery(hiddenTokensQueryKey({ address }), () => getHidden(address), {
     enabled: Boolean(address),
-    cacheTime: time.infinity,
-    staleTime: time.minutes(10),
+    cacheTime: CACHE_TIME,
+    staleTime: STALE_TIME,
   });
 }

--- a/src/state/nfts/createNftsStore.ts
+++ b/src/state/nfts/createNftsStore.ts
@@ -4,8 +4,8 @@ import { type Address } from 'viem';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
 import { arcClient } from '@/graphql';
 import { updateWebHidden, updateWebShowcase } from '@/helpers/webData';
-import { getHidden } from '@/hooks/useFetchHiddenTokens';
-import { getShowcase } from '@/hooks/useFetchShowcaseTokens';
+import { fetchHiddenTokens, getHidden } from '@/hooks/useFetchHiddenTokens';
+import { fetchShowcaseTokens, getShowcase } from '@/hooks/useFetchShowcaseTokens';
 import { logger, RainbowError } from '@/logger';
 import { parseUniqueAsset, parseUniqueId } from '@/resources/nfts/utils';
 import { createQueryStore } from '@/state/internal/createQueryStore';
@@ -53,9 +53,13 @@ const fetchMultipleCollectionNfts = async (collectionId: string, walletAddress: 
   let tokensForCategory: string[] = [];
 
   if (collectionId === 'showcase') {
-    tokensForCategory = (await getShowcase(walletAddress, isMigration)) || [];
+    tokensForCategory = isMigration
+      ? (await getShowcase(walletAddress, true)) || []
+      : (await fetchShowcaseTokens({ address: walletAddress })) || [];
   } else if (collectionId === 'hidden') {
-    tokensForCategory = (await getHidden(walletAddress, isMigration)) || [];
+    tokensForCategory = isMigration
+      ? (await getHidden(walletAddress, true)) || []
+      : (await fetchHiddenTokens({ address: walletAddress })) || [];
   }
 
   if (isMigration) {
@@ -110,10 +114,10 @@ const fetchMultipleCollectionNfts = async (collectionId: string, walletAddress: 
     const isReadOnlyWallet = getIsReadOnlyWallet();
     if (!isReadOnlyWallet) {
       if (collectionId === 'showcase') {
-        await updateWebShowcase(walletAddress, tokensForCategory, true);
+        await updateWebShowcase(walletAddress, tokensForCategory);
         useOpenCollectionsStore.getState(walletAddress).setCollectionOpen('showcase', true);
       } else if (collectionId === 'hidden') {
-        await updateWebHidden(walletAddress, tokensForCategory, true);
+        await updateWebHidden(walletAddress, tokensForCategory);
       }
     }
   }

--- a/src/state/nfts/utils.ts
+++ b/src/state/nfts/utils.ts
@@ -3,8 +3,8 @@ import { type Address } from 'viem';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
 import { ENS_NFT_CONTRACT_ADDRESS } from '@/features/ens/references';
 import { isENSAddressFormat } from '@/helpers/validators';
-import { getHidden, hiddenTokensQueryKey } from '@/hooks/useFetchHiddenTokens';
-import { getShowcase, showcaseTokensQueryKey } from '@/hooks/useFetchShowcaseTokens';
+import { fetchHiddenTokens, hiddenTokensQueryKey } from '@/hooks/useFetchHiddenTokens';
+import { fetchShowcaseTokens, showcaseTokensQueryKey } from '@/hooks/useFetchShowcaseTokens';
 import { queryClient } from '@/react-query';
 import { fetchNFTData, nftsQueryKey, type NFTData } from '@/resources/nfts';
 import { parseUniqueId } from '@/resources/nfts/utils';
@@ -125,7 +125,7 @@ export async function getHiddenAndShowcaseCollectionIds(
   category?: 'showcase' | 'hidden'
 ): Promise<{ collectionIds: Set<string> } | { showcaseCollectionIds: Set<string>; hiddenCollectionIds: Set<string> }> {
   if (category) {
-    const tokens = category === 'showcase' ? await getShowcase(address) : await getHidden(address);
+    const tokens = category === 'showcase' ? await fetchShowcaseTokens({ address }) : await fetchHiddenTokens({ address });
 
     return {
       collectionIds: new Set(
@@ -137,7 +137,7 @@ export async function getHiddenAndShowcaseCollectionIds(
     };
   }
 
-  const [showcaseTokens, hiddenTokens] = await Promise.all([getShowcase(address), getHidden(address)]);
+  const [showcaseTokens, hiddenTokens] = await Promise.all([fetchShowcaseTokens({ address }), fetchHiddenTokens({ address })]);
 
   return {
     showcaseCollectionIds: new Set(


### PR DESCRIPTION
Fixes APP-3699

## What changed

`updateWebHidden` / `updateWebShowcase` did a fetch before write where the response was always discarded. This resulted in either a "failed to fetch" or "aborted" error being logged to Sentry for almost every cold app open. 

The only caller of these functions always passed `forceInit=true` so the update branch was unreachable. This PR removes the wasted fetch and fetches through `queryClient.fetchQuery` instead of raw API calls so that errors are automatically retried and the cache is utilized. 

## What to test
- Adding + removing NFT from showcase
- Hiding + unhiding an NFT