### PR TITLE
refactor(polymarket): derive card colors from event image

### DIFF
--- a/src/features/polymarket/utils/getPolymarketCardColor.ts
+++ b/src/features/polymarket/utils/getPolymarketCardColor.ts
@@ -1,0 +1,50 @@
+import chroma from 'chroma-js';
+
+import { type ResponseByTheme } from '@/__swaps__/utils/swaps';
+import { type PolymarketEvent, type RawPolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { getColorBySeed } from '@/features/polymarket/utils/getColorBySeed';
+import { getImagePrimaryColor } from '@/features/polymarket/utils/getImageColors';
+import { getHighContrastColor } from '@/hooks/useAccountAccentColor';
+import { withTimeout } from '@/utils/promise';
+
+const IMAGE_COLOR_TIMEOUT_MS = 600;
+
+const MIN_CARD_COLOR_SATURATION = 0.16;
+const MIN_CARD_COLOR_LIGHTNESS = 0.12;
+const MAX_CARD_COLOR_LIGHTNESS = 0.92;
+const MIN_CARD_COLOR_ALPHA = 0.05;
+
+function isCardAccentColor(color: string): boolean {
+  if (!chroma.valid(color)) return false;
+  const c = chroma(color);
+  const [, s, l] = c.hsl();
+  const a = c.alpha();
+  if (Number.isNaN(s) || Number.isNaN(l)) return false;
+  return s >= MIN_CARD_COLOR_SATURATION && l >= MIN_CARD_COLOR_LIGHTNESS && l <= MAX_CARD_COLOR_LIGHTNESS && a > MIN_CARD_COLOR_ALPHA;
+}
+
+function getHighContrastColorTheme(color: string): ResponseByTheme<string> {
+  return {
+    light: getHighContrastColor(color, false),
+    dark: getHighContrastColor(color, true),
+  };
+}
+
+export async function resolvePolymarketCardColor({
+  event,
+}: {
+  event: PolymarketEvent | RawPolymarketEvent;
+}): Promise<ResponseByTheme<string>> {
+  const eventImageUrl = event.image || event.icon;
+  if (eventImageUrl) {
+    const eventImageColor = await withTimeout(
+      getImagePrimaryColor(eventImageUrl),
+      IMAGE_COLOR_TIMEOUT_MS,
+      '[resolvePolymarketCardColor]: getImagePrimaryColor timed out'
+    ).catch(() => undefined);
+    if (eventImageColor && isCardAccentColor(eventImageColor)) {
+      return getHighContrastColorTheme(eventImageColor);
+    }
+  }
+  return getColorBySeed(event.id);
+}

--- a/src/features/polymarket/utils/transforms.ts
+++ b/src/features/polymarket/utils/transforms.ts
@@ -14,6 +14,7 @@ import {
 } from '@/features/polymarket/types/polymarket-event';
 import { getImagePrimaryColor } from '@/features/polymarket/utils/getImageColors';
 import { getMarketColors } from '@/features/polymarket/utils/getMarketColor';
+import { resolvePolymarketCardColor } from '@/features/polymarket/utils/getPolymarketCardColor';
 import { getHighContrastColor } from '@/hooks/useAccountAccentColor';
 
 export function processRawPolymarketMarket(market: RawPolymarketMarket, eventColor: ResponseByTheme<string>): PolymarketMarket {
@@ -35,8 +36,7 @@ export function processRawPolymarketMarket(market: RawPolymarketMarket, eventCol
 }
 
 export async function processRawPolymarketEvent(event: RawPolymarketEvent, teams?: PolymarketTeamInfo[]): Promise<PolymarketEvent> {
-  const rawColor = await getImagePrimaryColor(event.icon);
-  const color = { dark: getHighContrastColor(rawColor, true), light: getHighContrastColor(rawColor, false) };
+  const color = await resolvePolymarketCardColor({ event });
   const sortedMarkets = sortMarkets(event.markets, event.sortBy);
   const processedMarkets = sortedMarkets.map(market => processRawPolymarketMarket(market, color));
   const league = getLeague(event.slug);

--- a/src/handlers/LedgerSigner.ts
+++ b/src/handlers/LedgerSigner.ts
@@ -16,6 +16,7 @@ import { ensureError, logger, RainbowError } from '@/logger';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { getEthApp } from '@/utils/ledger';
+import { withTimeout } from '@/utils/promise';
 import { time } from '@/utils/time';
 
 type LedgerTransactionResolution = Awaited<ReturnType<typeof ledgerService.resolveTransaction>>;
@@ -30,17 +31,6 @@ const LEDGER_TRANSACTION_RESOLUTION_CONFIG = {
 function waiter(duration: number): Promise<void> {
   return new Promise(resolve => {
     setTimeout(resolve, duration);
-  });
-}
-
-function withTimeout<T>(promise: Promise<T>, duration: number, message: string): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => reject(new RainbowError(message)), duration);
-  });
-
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) clearTimeout(timeoutId);
   });
 }
 

--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -1,5 +1,18 @@
+import { RainbowError } from '@/logger';
+
 const PromiseAllWithFails = async (promises: Promise<any>[]) =>
   Promise.all(promises.map((promise: any) => (promise?.catch ? promise.catch((error: any) => error) : promise)));
+
+export function withTimeout<T>(promise: Promise<T>, duration: number, message: string): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new RainbowError(message)), duration);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}
 
 export default {
   PromiseAllWithFails,


### PR DESCRIPTION
APP-3670

## What changed

- Adds `resolvePolymarketCardColor` to derive prediction card accent colors from the event image/icon, with high-contrast light/dark variants
- Bounds image color extraction to 600ms and rejects neutral or transparent colors before falling back to seeded event colors
- Filters closed Polymarket events before transforming event payloads for regular and sports event stores
- Extracts `withTimeout` into `src/utils/promise.ts` and reuses it from `LedgerSigner`

## What to test

- Discover prediction cards continue to load when image color extraction is slow or fails
- Prediction cards use image-derived accents when available and seeded fallback colors for neutral or grayscale images
- Closed or ended Polymarket events do not appear in event or sports event lists
