### PR TITLE
fix (staking): add gas params to unstake

### DIFF
--- a/src/features/rnbw-staking/constants.ts
+++ b/src/features/rnbw-staking/constants.ts
@@ -22,6 +22,7 @@ export const STAKING_ABI = parseAbi([
 ]);
 export const STAKING_GAS_LIMIT = 200_000;
 export const STAKING_APPROVAL_GAS_LIMIT = Number(gasUnits.basic_approval);
+export const STAKING_UNSTAKE_GAS_LIMIT = 200_000;
 
 export const MIN_CLAIM_TO_STAKING_RAW = '1000000000000000000'; // 1 RNBW (10^18)
 export const MIN_STAKE_AMOUNT = convertRawAmountToDecimalFormat(MIN_CLAIM_TO_STAKING_RAW, RNBW_DECIMALS);

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -9,6 +9,9 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { Box, globalColors, Separator, Stack, Text, useForegroundColor } from '@/design-system';
+import { useGasSettings } from '@/features/gas/hooks/useSelectedGas';
+import { GasSpeed } from '@/features/gas/types/gasSpeed';
+import { buildGasParams } from '@/features/gas/utils/parseGas';
 import { RnbwHoldToActivateButton } from '@/features/rnbw-membership/components/RnbwButton/RnbwHoldToActivateButton';
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { UnstakePenaltySign } from '@/features/rnbw-staking/components/UnstakePenaltySign';
@@ -19,6 +22,7 @@ import { ensureError, logger, RainbowError } from '@/logger';
 import { useNavigation } from '@/navigation/Navigation';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 
+import { STAKING_CHAIN_ID } from '../../constants';
 import { useRnbwStakingBalance } from '../../stores/derived/useRnbwStakingBalance';
 import { useRnbwStakingPositionPnl } from '../../stores/derived/useRnbwStakingPositionPnl';
 import { useStakingPositionStore } from '../../stores/rnbwStakingPositionStore';
@@ -120,6 +124,7 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
   const { netPnl, isPositivePnl, rnbwAfterUnstake } = useRnbwStakingPositionPnl();
   const { goBack } = useNavigation();
   const accountAddress = useAccountAddress();
+  const gasSettings = useGasSettings(STAKING_CHAIN_ID, GasSpeed.FAST);
   const [isProcessing, setIsProcessing] = useState(false);
   const liveDisplay = {
     tokenAmount,
@@ -135,10 +140,19 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
   const displayValues = isProcessing && frozenDisplayRef.current ? frozenDisplayRef.current : liveDisplay;
 
   const startUnstake = async () => {
+    if (!gasSettings) {
+      Alert.alert(
+        i18n.t(i18n.l.rnbw_staking.unstake_sheet.unstake_failed_title),
+        i18n.t(i18n.l.rnbw_staking.unstake_sheet.unstake_failed_message)
+      );
+      logger.error(new RainbowError('[RnbwUnstakeSheet]: Unstake failed, gas data unavailable'));
+      return;
+    }
+
     frozenDisplayRef.current = liveDisplay;
     setIsProcessing(true);
     try {
-      await unstakeRnbw({ address: accountAddress });
+      await unstakeRnbw({ address: accountAddress, gasParams: buildGasParams(gasSettings) });
       goBack();
     } catch (e) {
       setIsProcessing(false);
@@ -209,6 +223,7 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
           processingLabel={i18n.t(i18n.l.rnbw_staking.unstake_sheet.unstaking)}
           onActivate={handleUnstake}
           isProcessing={isProcessing}
+          disabled={!gasSettings}
           showBiometryIcon
           style={styles.fullWidthButton}
         />

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -1,17 +1,25 @@
-import { encodeFunctionData, type Address, type Hash } from 'viem';
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { encodeFunctionData, type Address, type Hash, type Hex } from 'viem';
 
 import { analytics } from '@/analytics';
+import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
 import { mulWorklet, subWorklet } from '@/framework/core/safeMath';
 import { getProvider } from '@/handlers/web3';
 import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 import { RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
 
-import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
 import { useStakingPositionStore, type StakingPositionData } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
 
-export async function unstakeRnbw({ address }: { address: Address }): Promise<Hash> {
+export async function unstakeRnbw({
+  address,
+  gasParams,
+}: {
+  address: Address;
+  gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
+}): Promise<Hash> {
   const initialExitFeePercentage = useStakingPositionStore.getState().getData()?.exitFeePercentage;
   await useStakingPositionStore.getState().fetch(undefined, { force: true });
   const positionData = useStakingPositionStore.getState().getData();
@@ -35,10 +43,13 @@ export async function unstakeRnbw({ address }: { address: Address }): Promise<Ha
 
     const originalStakedRnbwShares = positionData.poolShares;
     const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+    const gasLimit = await estimateUnstakeGasLimit({ address, data, provider });
 
     const tx = await signer.sendTransaction({
+      ...gasParams,
       to: STAKING_CONTRACT_ADDRESS,
       data,
+      gasLimit,
     });
 
     await tx.wait();
@@ -58,6 +69,23 @@ export async function unstakeRnbw({ address }: { address: Address }): Promise<Ha
       errorMessage: error instanceof Error ? error.message : 'Unknown error',
     });
     throw error;
+  }
+}
+
+async function estimateUnstakeGasLimit({
+  address,
+  data,
+  provider,
+}: {
+  address: Address;
+  data: Hex;
+  provider: StaticJsonRpcProvider;
+}): Promise<string> {
+  try {
+    const estimatedGasLimit = await provider.estimateGas({ data, from: address, to: STAKING_CONTRACT_ADDRESS });
+    return estimatedGasLimit.toString();
+  } catch {
+    return STAKING_UNSTAKE_GAS_LIMIT.toString();
   }
 }
 


### PR DESCRIPTION
Fixes APP-3700

## What changed

Unstaking was defaulting to gas priority fee of 1.5 gwei, causing the transaction to cost much more than it needed to (~$0.5 vs. $0.001). This PR adds gas params to the unstake action derived from the `useGasSettings` hook to fix this.  

## Screen recordings / screenshots

Test transaction: https://basescan.org/tx/0xf19b5273ce2d3656ef70ac147f4e425698d00ece8a2c255392696819bc7362db

## What to test

Unstaking should be possible with only $0.01 of Base ETH. 
