### PR TITLE
[WIP] perf: defer navigation screen requires

### DIFF
--- a/src/features/ens/navigation/RegisterENSNavigator.tsx
+++ b/src/features/ens/navigation/RegisterENSNavigator.tsx
@@ -132,7 +132,7 @@ export default function RegisterENSNavigator() {
             screenOptions={{ swipeEnabled: false }}
           >
             <Swipe.Screen
-              component={ENSIntroSheet}
+              getComponent={() => ENSIntroSheet}
               initialParams={{
                 contentHeight,
                 onSearchForNewName: () => setIsSearchEnabled(true),
@@ -147,7 +147,7 @@ export default function RegisterENSNavigator() {
             />
             {isSearchEnabled && (
               <Swipe.Screen
-                component={ENSSearchSheet}
+                getComponent={() => ENSSearchSheet}
                 listeners={{
                   focus: () => setCurrentRouteName(Routes.ENS_SEARCH_SHEET),
                 }}
@@ -155,7 +155,7 @@ export default function RegisterENSNavigator() {
               />
             )}
             <Swipe.Screen
-              component={ENSAssignRecordsSheet}
+              getComponent={() => ENSAssignRecordsSheet}
               initialParams={{
                 autoFocusKey: params?.autoFocusKey,
                 mode: params?.mode,

--- a/src/features/ens/navigation/RegisterENSNavigator.tsx
+++ b/src/features/ens/navigation/RegisterENSNavigator.tsx
@@ -17,9 +17,7 @@ import deviceUtils from '@/utils/deviceUtils';
 import { avatarMetadataAtom } from '../components/registration/RegistrationAvatar';
 import useENSRegistration from '../hooks/useENSRegistration';
 import useENSRegistrationForm from '../hooks/useENSRegistrationForm';
-import ENSAssignRecordsSheet, { ENSAssignRecordsBottomActions } from '../screens/ENSAssignRecordsSheet';
-import ENSIntroSheet from '../screens/ENSIntroSheet';
-import ENSSearchSheet from '../screens/ENSSearchSheet';
+import { ENSAssignRecordsBottomActions } from '../screens/ENSAssignRecordsSheet';
 import { accentColorAtom, REGISTRATION_MODES } from '../utils/helpers';
 
 const Swipe = createMaterialTopTabNavigator();
@@ -132,7 +130,7 @@ export default function RegisterENSNavigator() {
             screenOptions={{ swipeEnabled: false }}
           >
             <Swipe.Screen
-              getComponent={() => ENSIntroSheet}
+              getComponent={() => require('../screens/ENSIntroSheet').default}
               initialParams={{
                 contentHeight,
                 onSearchForNewName: () => setIsSearchEnabled(true),
@@ -147,7 +145,7 @@ export default function RegisterENSNavigator() {
             />
             {isSearchEnabled && (
               <Swipe.Screen
-                getComponent={() => ENSSearchSheet}
+                getComponent={() => require('../screens/ENSSearchSheet').default}
                 listeners={{
                   focus: () => setCurrentRouteName(Routes.ENS_SEARCH_SHEET),
                 }}
@@ -155,7 +153,7 @@ export default function RegisterENSNavigator() {
               />
             )}
             <Swipe.Screen
-              getComponent={() => ENSAssignRecordsSheet}
+              getComponent={() => require('../screens/ENSAssignRecordsSheet').default}
               initialParams={{
                 autoFocusKey: params?.autoFocusKey,
                 mode: params?.mode,

--- a/src/navigation/AddWalletNavigator.tsx
+++ b/src/navigation/AddWalletNavigator.tsx
@@ -6,9 +6,6 @@ import { useRoute, type RouteProp } from '@react-navigation/native';
 import { SimpleSheet } from '@/components/sheet/SimpleSheet';
 import { BackgroundProvider } from '@/design-system';
 import Routes from '@/navigation/routesNames';
-import { AddWalletSheet } from '@/screens/AddWalletSheet';
-import { ChooseWalletGroup } from '@/screens/ChooseWalletGroup';
-import { ImportOrWatchWalletSheet } from '@/screens/ImportOrWatchWalletSheet';
 import { setActiveRoute } from '@/state/navigation/navigationStore';
 import deviceUtils from '@/utils/deviceUtils';
 
@@ -34,7 +31,7 @@ export const AddWalletNavigator = () => {
             tabBar={() => null}
           >
             <Swipe.Screen
-              getComponent={() => AddWalletSheet}
+              getComponent={() => require('@/screens/AddWalletSheet').AddWalletSheet}
               initialParams={{ flowContext, isFirstWallet }}
               name={Routes.ADD_WALLET_SHEET}
               listeners={{
@@ -45,7 +42,7 @@ export const AddWalletNavigator = () => {
               }}
             />
             <Swipe.Screen
-              getComponent={() => ChooseWalletGroup}
+              getComponent={() => require('@/screens/ChooseWalletGroup').ChooseWalletGroup}
               initialParams={{ isFirstWallet }}
               name={Routes.CHOOSE_WALLET_GROUP}
               listeners={{
@@ -56,7 +53,7 @@ export const AddWalletNavigator = () => {
               }}
             />
             <Swipe.Screen
-              getComponent={() => ImportOrWatchWalletSheet}
+              getComponent={() => require('@/screens/ImportOrWatchWalletSheet').ImportOrWatchWalletSheet}
               initialParams={{ flowContext, type }}
               name={Routes.IMPORT_OR_WATCH_WALLET_SHEET}
               listeners={{

--- a/src/navigation/AddWalletNavigator.tsx
+++ b/src/navigation/AddWalletNavigator.tsx
@@ -34,7 +34,7 @@ export const AddWalletNavigator = () => {
             tabBar={() => null}
           >
             <Swipe.Screen
-              component={AddWalletSheet}
+              getComponent={() => AddWalletSheet}
               initialParams={{ flowContext, isFirstWallet }}
               name={Routes.ADD_WALLET_SHEET}
               listeners={{
@@ -45,7 +45,7 @@ export const AddWalletNavigator = () => {
               }}
             />
             <Swipe.Screen
-              component={ChooseWalletGroup}
+              getComponent={() => ChooseWalletGroup}
               initialParams={{ isFirstWallet }}
               name={Routes.CHOOSE_WALLET_GROUP}
               listeners={{
@@ -56,7 +56,7 @@ export const AddWalletNavigator = () => {
               }}
             />
             <Swipe.Screen
-              component={ImportOrWatchWalletSheet}
+              getComponent={() => ImportOrWatchWalletSheet}
               initialParams={{ flowContext, type }}
               name={Routes.IMPORT_OR_WATCH_WALLET_SHEET}
               listeners={{

--- a/src/navigation/HardwareWalletTxNavigator.tsx
+++ b/src/navigation/HardwareWalletTxNavigator.tsx
@@ -119,8 +119,8 @@ export const HardwareWalletTxNavigator = () => {
             sceneContainerStyle={{ backgroundColor: backgroundColor }}
             tabBar={() => null}
           >
-            <Swipe.Screen component={PairHardwareWalletAgainSheet} name={Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET} />
-            <Swipe.Screen component={PairHardwareWalletErrorSheet} name={Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET} />
+            <Swipe.Screen getComponent={() => PairHardwareWalletAgainSheet} name={Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET} />
+            <Swipe.Screen getComponent={() => PairHardwareWalletErrorSheet} name={Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET} />
           </Swipe.Navigator>
         </SimpleSheet>
       )}

--- a/src/navigation/HardwareWalletTxNavigator.tsx
+++ b/src/navigation/HardwareWalletTxNavigator.tsx
@@ -12,8 +12,6 @@ import { useLedgerConnect } from '@/hooks/useLedgerConnect';
 import { logger } from '@/logger';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
-import { PairHardwareWalletAgainSheet } from '@/screens/hardware-wallets/PairHardwareWalletAgainSheet';
-import { PairHardwareWalletErrorSheet } from '@/screens/hardware-wallets/PairHardwareWalletErrorSheet';
 import { useSelectedWallet } from '@/state/wallets/walletsStore';
 import { LEDGER_ERROR_CODES } from '@/utils/ledger';
 
@@ -119,8 +117,14 @@ export const HardwareWalletTxNavigator = () => {
             sceneContainerStyle={{ backgroundColor: backgroundColor }}
             tabBar={() => null}
           >
-            <Swipe.Screen getComponent={() => PairHardwareWalletAgainSheet} name={Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET} />
-            <Swipe.Screen getComponent={() => PairHardwareWalletErrorSheet} name={Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET} />
+            <Swipe.Screen
+              getComponent={() => require('@/screens/hardware-wallets/PairHardwareWalletAgainSheet').PairHardwareWalletAgainSheet}
+              name={Routes.PAIR_HARDWARE_WALLET_AGAIN_SHEET}
+            />
+            <Swipe.Screen
+              getComponent={() => require('@/screens/hardware-wallets/PairHardwareWalletErrorSheet').PairHardwareWalletErrorSheet}
+              name={Routes.PAIR_HARDWARE_WALLET_ERROR_SHEET}
+            />
           </Swipe.Navigator>
         </SimpleSheet>
       )}

--- a/src/navigation/PairHardwareWalletNavigator.tsx
+++ b/src/navigation/PairHardwareWalletNavigator.tsx
@@ -68,7 +68,7 @@ export function PairHardwareWalletNavigator() {
             tabBar={() => null}
           >
             <Swipe.Screen
-              component={PairHardwareWalletIntroSheet}
+              getComponent={() => PairHardwareWalletIntroSheet}
               name={Routes.PAIR_HARDWARE_WALLET_INTRO_SHEET}
               listeners={{
                 focus: () => {
@@ -77,7 +77,7 @@ export function PairHardwareWalletNavigator() {
               }}
             />
             <Swipe.Screen
-              component={PairHardwareWalletSearchSheet}
+              getComponent={() => PairHardwareWalletSearchSheet}
               name={Routes.PAIR_HARDWARE_WALLET_SEARCH_SHEET}
               listeners={{
                 focus: () => {
@@ -86,7 +86,7 @@ export function PairHardwareWalletNavigator() {
               }}
             />
             <Swipe.Screen
-              component={PairHardwareWalletSigningSheet}
+              getComponent={() => PairHardwareWalletSigningSheet}
               initialParams={{ flowContext }}
               name={Routes.PAIR_HARDWARE_WALLET_SIGNING_SHEET}
               listeners={{

--- a/src/navigation/PairHardwareWalletNavigator.tsx
+++ b/src/navigation/PairHardwareWalletNavigator.tsx
@@ -10,9 +10,6 @@ import { BackgroundProvider } from '@/design-system';
 import useDimensions from '@/hooks/useDimensions';
 import Routes from '@/navigation/routesNames';
 import { NanoXDeviceAnimation } from '@/screens/hardware-wallets/components/NanoXDeviceAnimation';
-import { PairHardwareWalletIntroSheet } from '@/screens/hardware-wallets/PairHardwareWalletIntroSheet';
-import { PairHardwareWalletSearchSheet } from '@/screens/hardware-wallets/PairHardwareWalletSearchSheet';
-import { PairHardwareWalletSigningSheet } from '@/screens/hardware-wallets/PairHardwareWalletSigningSheet';
 
 import { type RootStackParamList } from './types';
 
@@ -68,7 +65,7 @@ export function PairHardwareWalletNavigator() {
             tabBar={() => null}
           >
             <Swipe.Screen
-              getComponent={() => PairHardwareWalletIntroSheet}
+              getComponent={() => require('@/screens/hardware-wallets/PairHardwareWalletIntroSheet').PairHardwareWalletIntroSheet}
               name={Routes.PAIR_HARDWARE_WALLET_INTRO_SHEET}
               listeners={{
                 focus: () => {
@@ -77,7 +74,7 @@ export function PairHardwareWalletNavigator() {
               }}
             />
             <Swipe.Screen
-              getComponent={() => PairHardwareWalletSearchSheet}
+              getComponent={() => require('@/screens/hardware-wallets/PairHardwareWalletSearchSheet').PairHardwareWalletSearchSheet}
               name={Routes.PAIR_HARDWARE_WALLET_SEARCH_SHEET}
               listeners={{
                 focus: () => {
@@ -86,7 +83,7 @@ export function PairHardwareWalletNavigator() {
               }}
             />
             <Swipe.Screen
-              getComponent={() => PairHardwareWalletSigningSheet}
+              getComponent={() => require('@/screens/hardware-wallets/PairHardwareWalletSigningSheet').PairHardwareWalletSigningSheet}
               initialParams={{ flowContext }}
               name={Routes.PAIR_HARDWARE_WALLET_SIGNING_SHEET}
               listeners={{

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -138,27 +138,35 @@ function MainNavigator() {
   const initialRoute = useContext(InitialRouteContext) as unknown as string;
   return (
     <Stack.Navigator initialRouteName={initialRoute} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <Stack.Screen component={SwipeNavigator} name={Routes.SWIPE_LAYOUT} options={expandedPreset} />
-      <Stack.Screen component={AvatarBuilder} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
-      <Stack.Screen component={ConnectedDappsSheet} name={Routes.CONNECTED_DAPPS} options={expandedPreset} />
-      <Stack.Screen component={Portal} name={Routes.PORTAL} options={expandedPreset} />
-      <Stack.Screen component={PositionSheet} name={Routes.POSITION_SHEET} options={expandedPreset} />
+      <Stack.Screen getComponent={() => SwipeNavigator} name={Routes.SWIPE_LAYOUT} options={expandedPreset} />
+      <Stack.Screen getComponent={() => AvatarBuilder} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
+      <Stack.Screen getComponent={() => ConnectedDappsSheet} name={Routes.CONNECTED_DAPPS} options={expandedPreset} />
+      <Stack.Screen getComponent={() => Portal} name={Routes.PORTAL} options={expandedPreset} />
+      <Stack.Screen getComponent={() => PositionSheet} name={Routes.POSITION_SHEET} options={expandedPreset} />
       <Stack.Screen
-        component={SpeedUpAndCancelSheet}
+        getComponent={() => SpeedUpAndCancelSheet}
         name={Routes.SPEED_UP_AND_CANCEL_SHEET}
         options={{
           ...exchangePreset,
           cardStyleInterpolator: speedUpAndCancelStyleInterpolator,
         }}
       />
-      <Stack.Screen component={ReceiveModal} name={Routes.RECEIVE_MODAL} options={androidRecievePreset} />
+      <Stack.Screen getComponent={() => ReceiveModal} name={Routes.RECEIVE_MODAL} options={androidRecievePreset} />
 
-      <Stack.Screen component={WalletConnectRedirectSheet} name={Routes.WALLET_CONNECT_REDIRECT_SHEET} options={wcPromptPreset} />
-      <Stack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
-      <Stack.Screen component={RestoreSheet} name={Routes.RESTORE_SHEET} options={bottomSheetPreset} />
-      <Stack.Screen component={WelcomeScreen} name={Routes.WELCOME_SCREEN} options={{ animationEnabled: false, gestureEnabled: false }} />
-      <Stack.Screen component={ShowSecretView} name="ShowSecretView" options={bottomSheetPreset} />
-      <Stack.Screen component={WalletConnectApprovalSheet} name={Routes.WALLET_CONNECT_APPROVAL_SHEET} options={bottomSheetPreset} />
+      <Stack.Screen getComponent={() => WalletConnectRedirectSheet} name={Routes.WALLET_CONNECT_REDIRECT_SHEET} options={wcPromptPreset} />
+      <Stack.Screen getComponent={() => AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
+      <Stack.Screen getComponent={() => RestoreSheet} name={Routes.RESTORE_SHEET} options={bottomSheetPreset} />
+      <Stack.Screen
+        getComponent={() => WelcomeScreen}
+        name={Routes.WELCOME_SCREEN}
+        options={{ animationEnabled: false, gestureEnabled: false }}
+      />
+      <Stack.Screen getComponent={() => ShowSecretView} name="ShowSecretView" options={bottomSheetPreset} />
+      <Stack.Screen
+        getComponent={() => WalletConnectApprovalSheet}
+        name={Routes.WALLET_CONNECT_APPROVAL_SHEET}
+        options={bottomSheetPreset}
+      />
     </Stack.Navigator>
   );
 }
@@ -167,7 +175,7 @@ function MainNavigator() {
 function MainOuterNavigator() {
   return (
     <OuterStack.Navigator initialRouteName={Routes.MAIN_NAVIGATOR} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <OuterStack.Screen component={MainNavigator} name={Routes.MAIN_NAVIGATOR} />
+      <OuterStack.Screen getComponent={() => MainNavigator} name={Routes.MAIN_NAVIGATOR} />
     </OuterStack.Navigator>
   );
 }
@@ -178,9 +186,9 @@ function BSNavigator() {
 
   return (
     <BSStack.Navigator>
-      <BSStack.Screen component={MainOuterNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
+      <BSStack.Screen getComponent={() => MainOuterNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
       <BSStack.Screen
-        component={NotificationPermissionScreen}
+        getComponent={() => NotificationPermissionScreen}
         name={Routes.NOTIFICATION_PERMISSION_SCREEN}
         options={{
           ...bottomSheetPreset,
@@ -192,27 +200,27 @@ function BSNavigator() {
           height: '100%',
         }}
       />
-      <BSStack.Screen component={LearnWebViewScreen} name={Routes.LEARN_WEB_VIEW_SCREEN} {...learnWebViewScreenConfig} />
-      <BSStack.Screen component={ExpandedAssetSheet} name={Routes.EXPANDED_ASSET_SHEET} />
-      <BSStack.Screen component={PoapSheet} name={Routes.POAP_SHEET} />
-      <BSStack.Screen component={MintSheet} name={Routes.MINT_SHEET} />
-      <BSStack.Screen component={QRScannerScreen} name={Routes.QR_SCANNER_SCREEN} />
-      <BSStack.Screen component={AddWalletNavigator} name={Routes.ADD_WALLET_NAVIGATOR} options={addWalletNavigatorPreset} />
+      <BSStack.Screen getComponent={() => LearnWebViewScreen} name={Routes.LEARN_WEB_VIEW_SCREEN} {...learnWebViewScreenConfig} />
+      <BSStack.Screen getComponent={() => ExpandedAssetSheet} name={Routes.EXPANDED_ASSET_SHEET} />
+      <BSStack.Screen getComponent={() => PoapSheet} name={Routes.POAP_SHEET} />
+      <BSStack.Screen getComponent={() => MintSheet} name={Routes.MINT_SHEET} />
+      <BSStack.Screen getComponent={() => QRScannerScreen} name={Routes.QR_SCANNER_SCREEN} />
+      <BSStack.Screen getComponent={() => AddWalletNavigator} name={Routes.ADD_WALLET_NAVIGATOR} options={addWalletNavigatorPreset} />
       <BSStack.Screen
-        component={PairHardwareWalletNavigator}
+        getComponent={() => PairHardwareWalletNavigator}
         name={Routes.PAIR_HARDWARE_WALLET_NAVIGATOR}
         options={{
           backdropOpacity: 1,
         }}
       />
       <BSStack.Screen
-        component={HardwareWalletTxNavigator}
+        getComponent={() => HardwareWalletTxNavigator}
         name={Routes.HARDWARE_WALLET_TX_NAVIGATOR}
         options={hardwareWalletTxNavigatorPreset}
       />
       {showKingOfTheHillTab && (
         <BSStack.Screen
-          component={ActivitySheetScreen}
+          getComponent={() => ActivitySheetScreen}
           name={Routes.PROFILE_SCREEN}
           options={{
             ...bottomSheetPreset,
@@ -222,33 +230,33 @@ function BSNavigator() {
       )}
       {profilesEnabled && (
         <>
-          <BSStack.Screen component={ENSConfirmRegisterSheet} name={Routes.ENS_CONFIRM_REGISTER_SHEET} />
-          <BSStack.Screen component={RegisterENSNavigator} name={Routes.REGISTER_ENS_NAVIGATOR} />
-          <BSStack.Screen component={ENSAdditionalRecordsSheet} name={Routes.ENS_ADDITIONAL_RECORDS_SHEET} />
-          <BSStack.Screen component={SelectENSSheet} name={Routes.SELECT_ENS_SHEET} />
-          <BSStack.Screen component={ProfileSheet} name={Routes.PROFILE_SHEET} />
-          <BSStack.Screen component={ProfileSheet} name={Routes.PROFILE_PREVIEW_SHEET} />
+          <BSStack.Screen getComponent={() => ENSConfirmRegisterSheet} name={Routes.ENS_CONFIRM_REGISTER_SHEET} />
+          <BSStack.Screen getComponent={() => RegisterENSNavigator} name={Routes.REGISTER_ENS_NAVIGATOR} />
+          <BSStack.Screen getComponent={() => ENSAdditionalRecordsSheet} name={Routes.ENS_ADDITIONAL_RECORDS_SHEET} />
+          <BSStack.Screen getComponent={() => SelectENSSheet} name={Routes.SELECT_ENS_SHEET} />
+          <BSStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_SHEET} />
+          <BSStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_PREVIEW_SHEET} />
           <BSStack.Screen
-            component={SelectUniqueTokenSheet}
+            getComponent={() => SelectUniqueTokenSheet}
             name={Routes.SELECT_UNIQUE_TOKEN_SHEET}
             options={{ ...bottomSheetPreset, height: '95%' }}
           />
-          <BSStack.Screen component={SpeedUpAndCancelSheet} name={Routes.SPEED_UP_AND_CANCEL_BOTTOM_SHEET} />
+          <BSStack.Screen getComponent={() => SpeedUpAndCancelSheet} name={Routes.SPEED_UP_AND_CANCEL_BOTTOM_SHEET} />
         </>
       )}
-      <BSStack.Screen component={ExplainSheet} name={Routes.EXPLAIN_SHEET} options={bottomSheetPreset} />
-      <BSStack.Screen component={ExternalLinkWarningSheet} name={Routes.EXTERNAL_LINK_WARNING_SHEET} options={bottomSheetPreset} />
-      <BSStack.Screen component={ModalScreen} {...closeKeyboardOnClose} name={Routes.MODAL_SCREEN} />
-      <BSStack.Screen component={SendConfirmationSheet} name={Routes.SEND_CONFIRMATION_SHEET} options={sheetPreset} />
+      <BSStack.Screen getComponent={() => ExplainSheet} name={Routes.EXPLAIN_SHEET} options={bottomSheetPreset} />
+      <BSStack.Screen getComponent={() => ExternalLinkWarningSheet} name={Routes.EXTERNAL_LINK_WARNING_SHEET} options={bottomSheetPreset} />
+      <BSStack.Screen getComponent={() => ModalScreen} {...closeKeyboardOnClose} name={Routes.MODAL_SCREEN} />
+      <BSStack.Screen getComponent={() => SendConfirmationSheet} name={Routes.SEND_CONFIRMATION_SHEET} options={sheetPreset} />
       <BSStack.Screen
-        component={ExpandedAssetSheet}
+        getComponent={() => ExpandedAssetSheet}
         name={Routes.CUSTOM_GAS_SHEET}
         options={{
           backdropOpacity: 1,
         }}
       />
       <BSStack.Screen
-        component={BackupSheet}
+        getComponent={() => BackupSheet}
         name={Routes.BACKUP_SHEET}
         options={route => {
           const { params: { step } = {} as any } = route.route;
@@ -263,64 +271,68 @@ function BSNavigator() {
           return { ...bottomSheetPreset, height: heightForStep };
         }}
       />
-      <BSStack.Screen component={WalletDiagnosticsSheet} name={Routes.DIAGNOSTICS_SHEET} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen component={SettingsSheet} name={Routes.SETTINGS_SHEET} options={bottomSheetPreset} />
+      <BSStack.Screen getComponent={() => WalletDiagnosticsSheet} name={Routes.DIAGNOSTICS_SHEET} options={{ ...bottomSheetPreset }} />
+      <BSStack.Screen getComponent={() => SettingsSheet} name={Routes.SETTINGS_SHEET} options={bottomSheetPreset} />
       <BSStack.Screen
         name={Routes.TRANSACTION_DETAILS}
-        component={TransactionDetails}
+        getComponent={() => TransactionDetails}
         // @ts-ignore
         options={{ ...bottomSheetPreset, scrollEnabled: false }}
       />
-      <BSStack.Screen name={Routes.OP_REWARDS_SHEET} component={RewardsSheet} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen name={Routes.NFT_OFFERS_SHEET} component={NFTOffersSheet} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen name={Routes.NFT_SINGLE_OFFER_SHEET} component={NFTSingleOfferSheet} options={nftSingleOfferSheetPreset} />
-      <BSStack.Screen name={Routes.MINTS_SHEET} component={MintsSheet} />
-      <BSStack.Screen component={SignTransactionSheet} name={Routes.CONFIRM_REQUEST} options={walletconnectBottomSheetPreset} />
-      <BSStack.Screen component={AppIconUnlockSheet} name={Routes.APP_ICON_UNLOCK_SHEET} options={appIconUnlockSheetPreset} />
-      <BSStack.Screen component={ControlPanel} name={Routes.DAPP_BROWSER_CONTROL_PANEL} />
-      <BSStack.Screen component={NetworkSelector} name={Routes.NETWORK_SELECTOR} />
-      <BSStack.Screen component={ClaimClaimablePanel} name={Routes.CLAIM_CLAIMABLE_PANEL} />
-      <BSStack.Screen component={RevokeDelegationPanel} name={Routes.REVOKE_DELEGATION_PANEL} />
-      <BSStack.Screen component={ChangeWalletSheet} name={Routes.CHANGE_WALLET_SHEET} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen component={SwapScreen} name={Routes.SWAP} options={swapSheetPreset} />
-      <BSStack.Screen component={PerpsDepositScreen} name={Routes.PERPS_DEPOSIT_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen component={PolymarketDepositScreen} name={Routes.POLYMARKET_DEPOSIT_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen component={PerpsWithdrawalScreen} name={Routes.PERPS_WITHDRAWAL_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen component={PolymarketWithdrawalScreen} name={Routes.POLYMARKET_WITHDRAWAL_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen component={SendSheet} name={Routes.SEND_SHEET_NAVIGATOR} options={expandedPresetWithSmallGestureResponseDistance} />
-      <BSStack.Screen component={ExpandedAssetSheetV2} name={Routes.EXPANDED_ASSET_SHEET_V2} />
-      <BSStack.Screen component={PerpsDetailScreen} name={Routes.PERPS_DETAIL_SCREEN} />
-      <BSStack.Screen component={AirdropsSheet} name={Routes.AIRDROPS_SHEET} />
-      <BSStack.Screen component={ClaimAirdropSheet} name={Routes.CLAIM_AIRDROP_SHEET} />
-      <BSStack.Screen component={LogSheet} name={Routes.LOG_SHEET} />
-      <BSStack.Screen component={TokenLauncherScreen} name={Routes.TOKEN_LAUNCHER_SCREEN} options={tokenLauncherSheetPreset} />
-      <BSStack.Screen component={PerpsNavigator} name={Routes.PERPS_NAVIGATOR} />
-      <BSStack.Screen component={PerpsTradeHistoryScreen} name={Routes.PERPS_TRADE_HISTORY_SCREEN} />
-      <BSStack.Screen component={CreateTriggerOrderBottomSheet} name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET} />
-      <BSStack.Screen component={ClosePositionBottomSheet} name={Routes.CLOSE_POSITION_BOTTOM_SHEET} />
-      <BSStack.Screen component={KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} />
-      <BSStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} />
-      <BSStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
-      <BSStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
-      <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
-      <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
-      <BSStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />
-      <BSStack.Screen component={PolymarketMarketSheet} name={Routes.POLYMARKET_MARKET_SHEET} />
-      <BSStack.Screen component={PolymarketMarketDescriptionSheet} name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET} />
-      <BSStack.Screen component={PolymarketNewPositionSheet} name={Routes.POLYMARKET_NEW_POSITION_SHEET} />
-      <BSStack.Screen component={PolymarketAccountScreen} name={Routes.POLYMARKET_ACCOUNT_SCREEN} />
-      <BSStack.Screen component={PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} />
-      <BSStack.Screen component={PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} />
-      <BSStack.Screen component={PolymarketBrowseEventsScreen} name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN} />
-      <BSStack.Screen component={PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} />
-      <BSStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
-      <BSStack.Screen component={RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} />
-      <BSStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
-      <BSStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} />
-      <BSStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
-      <BSStack.Screen component={RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} />
-      <BSStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
-      <BSStack.Screen component={RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} />
+      <BSStack.Screen name={Routes.OP_REWARDS_SHEET} getComponent={() => RewardsSheet} options={{ ...bottomSheetPreset }} />
+      <BSStack.Screen name={Routes.NFT_OFFERS_SHEET} getComponent={() => NFTOffersSheet} options={{ ...bottomSheetPreset }} />
+      <BSStack.Screen name={Routes.NFT_SINGLE_OFFER_SHEET} getComponent={() => NFTSingleOfferSheet} options={nftSingleOfferSheetPreset} />
+      <BSStack.Screen name={Routes.MINTS_SHEET} getComponent={() => MintsSheet} />
+      <BSStack.Screen getComponent={() => SignTransactionSheet} name={Routes.CONFIRM_REQUEST} options={walletconnectBottomSheetPreset} />
+      <BSStack.Screen getComponent={() => AppIconUnlockSheet} name={Routes.APP_ICON_UNLOCK_SHEET} options={appIconUnlockSheetPreset} />
+      <BSStack.Screen getComponent={() => ControlPanel} name={Routes.DAPP_BROWSER_CONTROL_PANEL} />
+      <BSStack.Screen getComponent={() => NetworkSelector} name={Routes.NETWORK_SELECTOR} />
+      <BSStack.Screen getComponent={() => ClaimClaimablePanel} name={Routes.CLAIM_CLAIMABLE_PANEL} />
+      <BSStack.Screen getComponent={() => RevokeDelegationPanel} name={Routes.REVOKE_DELEGATION_PANEL} />
+      <BSStack.Screen getComponent={() => ChangeWalletSheet} name={Routes.CHANGE_WALLET_SHEET} options={{ ...bottomSheetPreset }} />
+      <BSStack.Screen getComponent={() => SwapScreen} name={Routes.SWAP} options={swapSheetPreset} />
+      <BSStack.Screen getComponent={() => PerpsDepositScreen} name={Routes.PERPS_DEPOSIT_SCREEN} {...swapSheetPreset} />
+      <BSStack.Screen getComponent={() => PolymarketDepositScreen} name={Routes.POLYMARKET_DEPOSIT_SCREEN} {...swapSheetPreset} />
+      <BSStack.Screen getComponent={() => PerpsWithdrawalScreen} name={Routes.PERPS_WITHDRAWAL_SCREEN} {...swapSheetPreset} />
+      <BSStack.Screen getComponent={() => PolymarketWithdrawalScreen} name={Routes.POLYMARKET_WITHDRAWAL_SCREEN} {...swapSheetPreset} />
+      <BSStack.Screen
+        getComponent={() => SendSheet}
+        name={Routes.SEND_SHEET_NAVIGATOR}
+        options={expandedPresetWithSmallGestureResponseDistance}
+      />
+      <BSStack.Screen getComponent={() => ExpandedAssetSheetV2} name={Routes.EXPANDED_ASSET_SHEET_V2} />
+      <BSStack.Screen getComponent={() => PerpsDetailScreen} name={Routes.PERPS_DETAIL_SCREEN} />
+      <BSStack.Screen getComponent={() => AirdropsSheet} name={Routes.AIRDROPS_SHEET} />
+      <BSStack.Screen getComponent={() => ClaimAirdropSheet} name={Routes.CLAIM_AIRDROP_SHEET} />
+      <BSStack.Screen getComponent={() => LogSheet} name={Routes.LOG_SHEET} />
+      <BSStack.Screen getComponent={() => TokenLauncherScreen} name={Routes.TOKEN_LAUNCHER_SCREEN} options={tokenLauncherSheetPreset} />
+      <BSStack.Screen getComponent={() => PerpsNavigator} name={Routes.PERPS_NAVIGATOR} />
+      <BSStack.Screen getComponent={() => PerpsTradeHistoryScreen} name={Routes.PERPS_TRADE_HISTORY_SCREEN} />
+      <BSStack.Screen getComponent={() => CreateTriggerOrderBottomSheet} name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET} />
+      <BSStack.Screen getComponent={() => ClosePositionBottomSheet} name={Routes.CLOSE_POSITION_BOTTOM_SHEET} />
+      <BSStack.Screen getComponent={() => KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} />
+      <BSStack.Screen getComponent={() => PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} />
+      <BSStack.Screen getComponent={() => PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
+      <BSStack.Screen getComponent={() => PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
+      <BSStack.Screen getComponent={() => PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
+      <BSStack.Screen getComponent={() => PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
+      <BSStack.Screen getComponent={() => PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />
+      <BSStack.Screen getComponent={() => PolymarketMarketSheet} name={Routes.POLYMARKET_MARKET_SHEET} />
+      <BSStack.Screen getComponent={() => PolymarketMarketDescriptionSheet} name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET} />
+      <BSStack.Screen getComponent={() => PolymarketNewPositionSheet} name={Routes.POLYMARKET_NEW_POSITION_SHEET} />
+      <BSStack.Screen getComponent={() => PolymarketAccountScreen} name={Routes.POLYMARKET_ACCOUNT_SCREEN} />
+      <BSStack.Screen getComponent={() => PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} />
+      <BSStack.Screen getComponent={() => PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} />
+      <BSStack.Screen getComponent={() => PolymarketBrowseEventsScreen} name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN} />
+      <BSStack.Screen getComponent={() => PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} />
+      <BSStack.Screen getComponent={() => RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
+      <BSStack.Screen getComponent={() => RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} />
+      <BSStack.Screen getComponent={() => RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
+      <BSStack.Screen getComponent={() => RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} />
+      <BSStack.Screen getComponent={() => RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
+      <BSStack.Screen getComponent={() => RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} />
+      <BSStack.Screen getComponent={() => WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
+      <BSStack.Screen getComponent={() => RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} />
     </BSStack.Navigator>
   );
 }
@@ -332,9 +344,9 @@ function AuthNavigator() {
       initialRouteName={Routes.MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR}
       screenOptions={defaultScreenStackOptions}
     >
-      <AuthStack.Screen component={BSNavigator} name={Routes.MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR} />
+      <AuthStack.Screen getComponent={() => BSNavigator} name={Routes.MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR} />
       <AuthStack.Screen
-        component={PinAuthenticationScreen}
+        getComponent={() => PinAuthenticationScreen}
         name={Routes.PIN_AUTHENTICATION_SCREEN}
         options={{ ...sheetPreset, gestureEnabled: false }}
       />

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -4,96 +4,11 @@ import React, { useContext } from 'react';
 import { NavigationContainer, type NavigationContainerRef } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
-import { SwapScreen } from '@/__swaps__/screens/Swap/Swap';
-import { ControlPanel } from '@/components/DappBrowser/control-panel/ControlPanel';
-import { LogSheet } from '@/components/debugging/LogSheet';
-import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
-import BackupSheet from '@/features/backup/components/BackupSheet';
-import RegisterENSNavigator from '@/features/ens/navigation/RegisterENSNavigator';
-import ENSAdditionalRecordsSheet from '@/features/ens/screens/ENSAdditionalRecordsSheet';
-import ENSConfirmRegisterSheet from '@/features/ens/screens/ENSConfirmRegisterSheet';
-import SelectENSSheet from '@/features/ens/screens/SelectENSSheet';
 import { useShowKingOfTheHill } from '@/features/king-of-the-hill/hooks/useShowKingOfTheHill';
-import { KingOfTheHillExplainSheet } from '@/features/king-of-the-hill/screens/KingOfTheHillExplainSheet';
-import { NotificationPermissionScreen } from '@/features/notifications/screens/NotificationPermissionScreen';
-import { ClosePositionBottomSheet } from '@/features/perps/screens/ClosePositionBottomSheet';
-import { CreateTriggerOrderBottomSheet } from '@/features/perps/screens/CreateTriggerOrderBottomSheet';
-import { PerpsDetailScreen } from '@/features/perps/screens/perp-detail-screen/PerpDetailScreen';
-import { PerpsAboutSheet } from '@/features/perps/screens/perps-about-sheet/PerpsAboutSheet';
-import { PerpsAddToPositionSheet } from '@/features/perps/screens/perps-add-to-position-sheet/PerpsAddToPositionSheet';
-import { PerpsDepositScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen';
-import { PerpsWithdrawalScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsWithdrawalScreen';
-import { PerpsExplainSheet } from '@/features/perps/screens/perps-explain-sheet/PerpsExplainSheet';
-import { PerpsTradeDetailsSheet } from '@/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet';
-import { PerpsTradeHistoryScreen } from '@/features/perps/screens/perps-trade-history/PerpsTradeHistoryScreen';
-import { PerpsNavigator } from '@/features/perps/screens/PerpsNavigator';
-import { PolymarketDepositScreen } from '@/features/polymarket/funding/screens/PolymarketDepositScreen';
-import { PolymarketWithdrawalScreen } from '@/features/polymarket/funding/screens/PolymarketWithdrawalScreen';
-import { PolymarketAccountScreen } from '@/features/polymarket/screens/polymarket-account-screen/PolymarketAccountScreen';
-import { PolymarketBrowseEventsScreen } from '@/features/polymarket/screens/polymarket-browse-events-screen/PolymarketBrowseEventsScreen';
-import { PolymarketEventScreen } from '@/features/polymarket/screens/polymarket-event-screen/PolymarketEventScreen';
-import { PolymarketExplainSheet } from '@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet';
-import { PolymarketMarketDescriptionSheet } from '@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet';
-import { PolymarketMarketSheet } from '@/features/polymarket/screens/polymarket-market-sheet/PolymarketMarketSheet';
-import { PolymarketNavigator } from '@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator';
-import { PolymarketNewPositionSheet } from '@/features/polymarket/screens/polymarket-new-position-sheet/PolymarketNewPositionSheet';
-import { PolymarketRedeemPositionSheet } from '@/features/polymarket/screens/polymarket-redeem-position-sheet/PolymarketRedeemPositionSheet';
-import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet';
-import { PositionSheet } from '@/features/positions/screens/PositionSheet';
-import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
-import { RnbwMembershipTiersSheet } from '@/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet';
-import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet';
-import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
-import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen';
-import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
-import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
-import ConnectedDappsSheet from '@/features/wallet-connect/screens/ConnectedDappsSheet';
 import walletBackupStepTypes from '@/helpers/walletBackupStepTypes';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';
-import { ActivitySheetScreen } from '@/screens/ActivitySheetScreen';
-import { AirdropsSheet } from '@/screens/Airdrops/AirdropsSheet';
-import { ClaimAirdropSheet } from '@/screens/Airdrops/ClaimAirdropSheet';
-import { ClaimClaimablePanel } from '@/screens/claimables/ClaimPanel';
-import { RevokeDelegationPanel } from '@/screens/delegation/RevokeDelegationPanel';
-import { ExpandedAssetSheet as ExpandedAssetSheetV2 } from '@/screens/expandedAssetSheet/ExpandedAssetSheet';
-import LearnWebViewScreen from '@/screens/LearnWebViewScreen';
-import MintSheet from '@/screens/mints/MintSheet';
-import PoapSheet from '@/screens/mints/PoapSheet';
-import { MintsSheet } from '@/screens/MintsSheet/MintsSheet';
-import { NetworkSelector } from '@/screens/network-selector/NetworkSelector';
-import { NFTOffersSheet } from '@/screens/NFTOffersSheet';
-import { NFTSingleOfferSheet } from '@/screens/NFTSingleOfferSheet';
-import { Portal } from '@/screens/Portal';
-import QRScannerScreen from '@/screens/QRScannerScreen';
-import { RewardsSheet } from '@/screens/rewards/RewardsSheet';
-import ShowSecretView from '@/screens/SettingsSheet/components/Backups/ShowSecretView';
-import { SettingsSheet } from '@/screens/SettingsSheet/SettingsSheet';
-import { SignTransactionSheet } from '@/screens/SignTransactionSheet';
-import { TokenLauncherScreen } from '@/screens/token-launcher/TokenLauncherScreen';
-import { TransactionDetails } from '@/screens/transaction-details/TransactionDetails';
 
-import { AddCashSheet } from '../screens/AddCash';
-import AvatarBuilder from '../screens/AvatarBuilder';
-import ChangeWalletSheet from '../screens/change-wallet/ChangeWalletSheet';
-import { WalletDiagnosticsSheet } from '../screens/Diagnostics';
-import ExpandedAssetSheet from '../screens/ExpandedAssetSheet';
-import ExplainSheet from '../screens/ExplainSheet';
-import ExternalLinkWarningSheet from '../screens/ExternalLinkWarningSheet';
-import ModalScreen from '../screens/ModalScreen';
-import PinAuthenticationScreen from '../screens/PinAuthenticationScreen';
-import ProfileSheet from '../screens/ProfileSheet';
-import ReceiveModal from '../screens/ReceiveModal';
-import { RestoreSheet } from '../screens/RestoreSheet';
-import SelectUniqueTokenSheet from '../screens/SelectUniqueTokenSheet';
-import { SendConfirmationSheet } from '../screens/SendConfirmationSheet';
-import SendSheet from '../screens/SendSheet';
-import SpeedUpAndCancelSheet from '../screens/SpeedUpAndCancelSheet';
-import WalletConnectApprovalSheet from '../screens/WalletConnectApprovalSheet';
-import WalletConnectRedirectSheet from '../screens/WalletConnectRedirectSheet';
-import { WelcomeScreen } from '../screens/WelcomeScreen/WelcomeScreen';
-import { AddWalletNavigator } from './AddWalletNavigator';
 import { createBottomSheetNavigator } from './bottom-sheet/createBottomSheetNavigator';
 import {
   backupSheetSizes,
@@ -121,12 +36,9 @@ import {
   walletconnectBottomSheetPreset,
   wcPromptPreset,
 } from './effects';
-import { HardwareWalletTxNavigator } from './HardwareWalletTxNavigator';
 import { InitialRouteContext } from './initialRoute';
 import { onNavigationStateChange } from './onNavigationStateChange';
-import { PairHardwareWalletNavigator } from './PairHardwareWalletNavigator';
 import Routes from './routesNames';
-import { SwipeNavigator } from './SwipeNavigator';
 import { type RootStackParamList } from './types';
 
 const Stack = createStackNavigator();
@@ -138,32 +50,56 @@ function MainNavigator() {
   const initialRoute = useContext(InitialRouteContext) as unknown as string;
   return (
     <Stack.Navigator initialRouteName={initialRoute} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <Stack.Screen getComponent={() => SwipeNavigator} name={Routes.SWIPE_LAYOUT} options={expandedPreset} />
-      <Stack.Screen getComponent={() => AvatarBuilder} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
-      <Stack.Screen getComponent={() => ConnectedDappsSheet} name={Routes.CONNECTED_DAPPS} options={expandedPreset} />
-      <Stack.Screen getComponent={() => Portal} name={Routes.PORTAL} options={expandedPreset} />
-      <Stack.Screen getComponent={() => PositionSheet} name={Routes.POSITION_SHEET} options={expandedPreset} />
+      <Stack.Screen getComponent={() => require('./SwipeNavigator').SwipeNavigator} name={Routes.SWIPE_LAYOUT} options={expandedPreset} />
+      <Stack.Screen getComponent={() => require('../screens/AvatarBuilder').default} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
       <Stack.Screen
-        getComponent={() => SpeedUpAndCancelSheet}
+        getComponent={() => require('@/features/wallet-connect/screens/ConnectedDappsSheet').default}
+        name={Routes.CONNECTED_DAPPS}
+        options={expandedPreset}
+      />
+      <Stack.Screen getComponent={() => require('@/screens/Portal').Portal} name={Routes.PORTAL} options={expandedPreset} />
+      <Stack.Screen
+        getComponent={() => require('@/features/positions/screens/PositionSheet').PositionSheet}
+        name={Routes.POSITION_SHEET}
+        options={expandedPreset}
+      />
+      <Stack.Screen
+        getComponent={() => require('../screens/SpeedUpAndCancelSheet').default}
         name={Routes.SPEED_UP_AND_CANCEL_SHEET}
         options={{
           ...exchangePreset,
           cardStyleInterpolator: speedUpAndCancelStyleInterpolator,
         }}
       />
-      <Stack.Screen getComponent={() => ReceiveModal} name={Routes.RECEIVE_MODAL} options={androidRecievePreset} />
-
-      <Stack.Screen getComponent={() => WalletConnectRedirectSheet} name={Routes.WALLET_CONNECT_REDIRECT_SHEET} options={wcPromptPreset} />
-      <Stack.Screen getComponent={() => AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
-      <Stack.Screen getComponent={() => RestoreSheet} name={Routes.RESTORE_SHEET} options={bottomSheetPreset} />
       <Stack.Screen
-        getComponent={() => WelcomeScreen}
+        getComponent={() => require('../screens/ReceiveModal').default}
+        name={Routes.RECEIVE_MODAL}
+        options={androidRecievePreset}
+      />
+
+      <Stack.Screen
+        getComponent={() => require('../screens/WalletConnectRedirectSheet').default}
+        name={Routes.WALLET_CONNECT_REDIRECT_SHEET}
+        options={wcPromptPreset}
+      />
+      <Stack.Screen getComponent={() => require('../screens/AddCash').AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
+      <Stack.Screen
+        getComponent={() => require('../screens/RestoreSheet').RestoreSheet}
+        name={Routes.RESTORE_SHEET}
+        options={bottomSheetPreset}
+      />
+      <Stack.Screen
+        getComponent={() => require('../screens/WelcomeScreen/WelcomeScreen').WelcomeScreen}
         name={Routes.WELCOME_SCREEN}
         options={{ animationEnabled: false, gestureEnabled: false }}
       />
-      <Stack.Screen getComponent={() => ShowSecretView} name="ShowSecretView" options={bottomSheetPreset} />
       <Stack.Screen
-        getComponent={() => WalletConnectApprovalSheet}
+        getComponent={() => require('@/screens/SettingsSheet/components/Backups/ShowSecretView').default}
+        name="ShowSecretView"
+        options={bottomSheetPreset}
+      />
+      <Stack.Screen
+        getComponent={() => require('../screens/WalletConnectApprovalSheet').default}
         name={Routes.WALLET_CONNECT_APPROVAL_SHEET}
         options={bottomSheetPreset}
       />
@@ -188,7 +124,7 @@ function BSNavigator() {
     <BSStack.Navigator>
       <BSStack.Screen getComponent={() => MainOuterNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
       <BSStack.Screen
-        getComponent={() => NotificationPermissionScreen}
+        getComponent={() => require('@/features/notifications/screens/NotificationPermissionScreen').NotificationPermissionScreen}
         name={Routes.NOTIFICATION_PERMISSION_SCREEN}
         options={{
           ...bottomSheetPreset,
@@ -200,27 +136,35 @@ function BSNavigator() {
           height: '100%',
         }}
       />
-      <BSStack.Screen getComponent={() => LearnWebViewScreen} name={Routes.LEARN_WEB_VIEW_SCREEN} {...learnWebViewScreenConfig} />
-      <BSStack.Screen getComponent={() => ExpandedAssetSheet} name={Routes.EXPANDED_ASSET_SHEET} />
-      <BSStack.Screen getComponent={() => PoapSheet} name={Routes.POAP_SHEET} />
-      <BSStack.Screen getComponent={() => MintSheet} name={Routes.MINT_SHEET} />
-      <BSStack.Screen getComponent={() => QRScannerScreen} name={Routes.QR_SCANNER_SCREEN} />
-      <BSStack.Screen getComponent={() => AddWalletNavigator} name={Routes.ADD_WALLET_NAVIGATOR} options={addWalletNavigatorPreset} />
       <BSStack.Screen
-        getComponent={() => PairHardwareWalletNavigator}
+        getComponent={() => require('@/screens/LearnWebViewScreen').default}
+        name={Routes.LEARN_WEB_VIEW_SCREEN}
+        {...learnWebViewScreenConfig}
+      />
+      <BSStack.Screen getComponent={() => require('../screens/ExpandedAssetSheet').default} name={Routes.EXPANDED_ASSET_SHEET} />
+      <BSStack.Screen getComponent={() => require('@/screens/mints/PoapSheet').default} name={Routes.POAP_SHEET} />
+      <BSStack.Screen getComponent={() => require('@/screens/mints/MintSheet').default} name={Routes.MINT_SHEET} />
+      <BSStack.Screen getComponent={() => require('@/screens/QRScannerScreen').default} name={Routes.QR_SCANNER_SCREEN} />
+      <BSStack.Screen
+        getComponent={() => require('./AddWalletNavigator').AddWalletNavigator}
+        name={Routes.ADD_WALLET_NAVIGATOR}
+        options={addWalletNavigatorPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('./PairHardwareWalletNavigator').PairHardwareWalletNavigator}
         name={Routes.PAIR_HARDWARE_WALLET_NAVIGATOR}
         options={{
           backdropOpacity: 1,
         }}
       />
       <BSStack.Screen
-        getComponent={() => HardwareWalletTxNavigator}
+        getComponent={() => require('./HardwareWalletTxNavigator').HardwareWalletTxNavigator}
         name={Routes.HARDWARE_WALLET_TX_NAVIGATOR}
         options={hardwareWalletTxNavigatorPreset}
       />
       {showKingOfTheHillTab && (
         <BSStack.Screen
-          getComponent={() => ActivitySheetScreen}
+          getComponent={() => require('@/screens/ActivitySheetScreen').ActivitySheetScreen}
           name={Routes.PROFILE_SCREEN}
           options={{
             ...bottomSheetPreset,
@@ -230,33 +174,57 @@ function BSNavigator() {
       )}
       {profilesEnabled && (
         <>
-          <BSStack.Screen getComponent={() => ENSConfirmRegisterSheet} name={Routes.ENS_CONFIRM_REGISTER_SHEET} />
-          <BSStack.Screen getComponent={() => RegisterENSNavigator} name={Routes.REGISTER_ENS_NAVIGATOR} />
-          <BSStack.Screen getComponent={() => ENSAdditionalRecordsSheet} name={Routes.ENS_ADDITIONAL_RECORDS_SHEET} />
-          <BSStack.Screen getComponent={() => SelectENSSheet} name={Routes.SELECT_ENS_SHEET} />
-          <BSStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_SHEET} />
-          <BSStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_PREVIEW_SHEET} />
           <BSStack.Screen
-            getComponent={() => SelectUniqueTokenSheet}
+            getComponent={() => require('@/features/ens/screens/ENSConfirmRegisterSheet').default}
+            name={Routes.ENS_CONFIRM_REGISTER_SHEET}
+          />
+          <BSStack.Screen
+            getComponent={() => require('@/features/ens/navigation/RegisterENSNavigator').default}
+            name={Routes.REGISTER_ENS_NAVIGATOR}
+          />
+          <BSStack.Screen
+            getComponent={() => require('@/features/ens/screens/ENSAdditionalRecordsSheet').default}
+            name={Routes.ENS_ADDITIONAL_RECORDS_SHEET}
+          />
+          <BSStack.Screen getComponent={() => require('@/features/ens/screens/SelectENSSheet').default} name={Routes.SELECT_ENS_SHEET} />
+          <BSStack.Screen getComponent={() => require('../screens/ProfileSheet').default} name={Routes.PROFILE_SHEET} />
+          <BSStack.Screen getComponent={() => require('../screens/ProfileSheet').default} name={Routes.PROFILE_PREVIEW_SHEET} />
+          <BSStack.Screen
+            getComponent={() => require('../screens/SelectUniqueTokenSheet').default}
             name={Routes.SELECT_UNIQUE_TOKEN_SHEET}
             options={{ ...bottomSheetPreset, height: '95%' }}
           />
-          <BSStack.Screen getComponent={() => SpeedUpAndCancelSheet} name={Routes.SPEED_UP_AND_CANCEL_BOTTOM_SHEET} />
+          <BSStack.Screen
+            getComponent={() => require('../screens/SpeedUpAndCancelSheet').default}
+            name={Routes.SPEED_UP_AND_CANCEL_BOTTOM_SHEET}
+          />
         </>
       )}
-      <BSStack.Screen getComponent={() => ExplainSheet} name={Routes.EXPLAIN_SHEET} options={bottomSheetPreset} />
-      <BSStack.Screen getComponent={() => ExternalLinkWarningSheet} name={Routes.EXTERNAL_LINK_WARNING_SHEET} options={bottomSheetPreset} />
-      <BSStack.Screen getComponent={() => ModalScreen} {...closeKeyboardOnClose} name={Routes.MODAL_SCREEN} />
-      <BSStack.Screen getComponent={() => SendConfirmationSheet} name={Routes.SEND_CONFIRMATION_SHEET} options={sheetPreset} />
       <BSStack.Screen
-        getComponent={() => ExpandedAssetSheet}
+        getComponent={() => require('../screens/ExplainSheet').default}
+        name={Routes.EXPLAIN_SHEET}
+        options={bottomSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('../screens/ExternalLinkWarningSheet').default}
+        name={Routes.EXTERNAL_LINK_WARNING_SHEET}
+        options={bottomSheetPreset}
+      />
+      <BSStack.Screen getComponent={() => require('../screens/ModalScreen').default} {...closeKeyboardOnClose} name={Routes.MODAL_SCREEN} />
+      <BSStack.Screen
+        getComponent={() => require('../screens/SendConfirmationSheet').SendConfirmationSheet}
+        name={Routes.SEND_CONFIRMATION_SHEET}
+        options={sheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('../screens/ExpandedAssetSheet').default}
         name={Routes.CUSTOM_GAS_SHEET}
         options={{
           backdropOpacity: 1,
         }}
       />
       <BSStack.Screen
-        getComponent={() => BackupSheet}
+        getComponent={() => require('@/features/backup/components/BackupSheet').default}
         name={Routes.BACKUP_SHEET}
         options={route => {
           const { params: { step } = {} as any } = route.route;
@@ -271,68 +239,243 @@ function BSNavigator() {
           return { ...bottomSheetPreset, height: heightForStep };
         }}
       />
-      <BSStack.Screen getComponent={() => WalletDiagnosticsSheet} name={Routes.DIAGNOSTICS_SHEET} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen getComponent={() => SettingsSheet} name={Routes.SETTINGS_SHEET} options={bottomSheetPreset} />
+      <BSStack.Screen
+        getComponent={() => require('../screens/Diagnostics').WalletDiagnosticsSheet}
+        name={Routes.DIAGNOSTICS_SHEET}
+        options={{ ...bottomSheetPreset }}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/SettingsSheet/SettingsSheet').SettingsSheet}
+        name={Routes.SETTINGS_SHEET}
+        options={bottomSheetPreset}
+      />
       <BSStack.Screen
         name={Routes.TRANSACTION_DETAILS}
-        getComponent={() => TransactionDetails}
+        getComponent={() => require('@/screens/transaction-details/TransactionDetails').TransactionDetails}
         // @ts-ignore
         options={{ ...bottomSheetPreset, scrollEnabled: false }}
       />
-      <BSStack.Screen name={Routes.OP_REWARDS_SHEET} getComponent={() => RewardsSheet} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen name={Routes.NFT_OFFERS_SHEET} getComponent={() => NFTOffersSheet} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen name={Routes.NFT_SINGLE_OFFER_SHEET} getComponent={() => NFTSingleOfferSheet} options={nftSingleOfferSheetPreset} />
-      <BSStack.Screen name={Routes.MINTS_SHEET} getComponent={() => MintsSheet} />
-      <BSStack.Screen getComponent={() => SignTransactionSheet} name={Routes.CONFIRM_REQUEST} options={walletconnectBottomSheetPreset} />
-      <BSStack.Screen getComponent={() => AppIconUnlockSheet} name={Routes.APP_ICON_UNLOCK_SHEET} options={appIconUnlockSheetPreset} />
-      <BSStack.Screen getComponent={() => ControlPanel} name={Routes.DAPP_BROWSER_CONTROL_PANEL} />
-      <BSStack.Screen getComponent={() => NetworkSelector} name={Routes.NETWORK_SELECTOR} />
-      <BSStack.Screen getComponent={() => ClaimClaimablePanel} name={Routes.CLAIM_CLAIMABLE_PANEL} />
-      <BSStack.Screen getComponent={() => RevokeDelegationPanel} name={Routes.REVOKE_DELEGATION_PANEL} />
-      <BSStack.Screen getComponent={() => ChangeWalletSheet} name={Routes.CHANGE_WALLET_SHEET} options={{ ...bottomSheetPreset }} />
-      <BSStack.Screen getComponent={() => SwapScreen} name={Routes.SWAP} options={swapSheetPreset} />
-      <BSStack.Screen getComponent={() => PerpsDepositScreen} name={Routes.PERPS_DEPOSIT_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen getComponent={() => PolymarketDepositScreen} name={Routes.POLYMARKET_DEPOSIT_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen getComponent={() => PerpsWithdrawalScreen} name={Routes.PERPS_WITHDRAWAL_SCREEN} {...swapSheetPreset} />
-      <BSStack.Screen getComponent={() => PolymarketWithdrawalScreen} name={Routes.POLYMARKET_WITHDRAWAL_SCREEN} {...swapSheetPreset} />
       <BSStack.Screen
-        getComponent={() => SendSheet}
+        name={Routes.OP_REWARDS_SHEET}
+        getComponent={() => require('@/screens/rewards/RewardsSheet').RewardsSheet}
+        options={{ ...bottomSheetPreset }}
+      />
+      <BSStack.Screen
+        name={Routes.NFT_OFFERS_SHEET}
+        getComponent={() => require('@/screens/NFTOffersSheet').NFTOffersSheet}
+        options={{ ...bottomSheetPreset }}
+      />
+      <BSStack.Screen
+        name={Routes.NFT_SINGLE_OFFER_SHEET}
+        getComponent={() => require('@/screens/NFTSingleOfferSheet').NFTSingleOfferSheet}
+        options={nftSingleOfferSheetPreset}
+      />
+      <BSStack.Screen name={Routes.MINTS_SHEET} getComponent={() => require('@/screens/MintsSheet/MintsSheet').MintsSheet} />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/SignTransactionSheet').SignTransactionSheet}
+        name={Routes.CONFIRM_REQUEST}
+        options={walletconnectBottomSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/app-icon/screens/AppIconUnlockSheet').default}
+        name={Routes.APP_ICON_UNLOCK_SHEET}
+        options={appIconUnlockSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/components/DappBrowser/control-panel/ControlPanel').ControlPanel}
+        name={Routes.DAPP_BROWSER_CONTROL_PANEL}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/network-selector/NetworkSelector').NetworkSelector}
+        name={Routes.NETWORK_SELECTOR}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/claimables/ClaimPanel').ClaimClaimablePanel}
+        name={Routes.CLAIM_CLAIMABLE_PANEL}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/delegation/RevokeDelegationPanel').RevokeDelegationPanel}
+        name={Routes.REVOKE_DELEGATION_PANEL}
+      />
+      <BSStack.Screen
+        getComponent={() => require('../screens/change-wallet/ChangeWalletSheet').default}
+        name={Routes.CHANGE_WALLET_SHEET}
+        options={{ ...bottomSheetPreset }}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/__swaps__/screens/Swap/Swap').SwapScreen}
+        name={Routes.SWAP}
+        options={swapSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen').PerpsDepositScreen}
+        name={Routes.PERPS_DEPOSIT_SCREEN}
+        {...swapSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/polymarket/funding/screens/PolymarketDepositScreen').PolymarketDepositScreen}
+        name={Routes.POLYMARKET_DEPOSIT_SCREEN}
+        {...swapSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-deposit-withdraw-screen/PerpsWithdrawalScreen').PerpsWithdrawalScreen}
+        name={Routes.PERPS_WITHDRAWAL_SCREEN}
+        {...swapSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/polymarket/funding/screens/PolymarketWithdrawalScreen').PolymarketWithdrawalScreen}
+        name={Routes.POLYMARKET_WITHDRAWAL_SCREEN}
+        {...swapSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('../screens/SendSheet').default}
         name={Routes.SEND_SHEET_NAVIGATOR}
         options={expandedPresetWithSmallGestureResponseDistance}
       />
-      <BSStack.Screen getComponent={() => ExpandedAssetSheetV2} name={Routes.EXPANDED_ASSET_SHEET_V2} />
-      <BSStack.Screen getComponent={() => PerpsDetailScreen} name={Routes.PERPS_DETAIL_SCREEN} />
-      <BSStack.Screen getComponent={() => AirdropsSheet} name={Routes.AIRDROPS_SHEET} />
-      <BSStack.Screen getComponent={() => ClaimAirdropSheet} name={Routes.CLAIM_AIRDROP_SHEET} />
-      <BSStack.Screen getComponent={() => LogSheet} name={Routes.LOG_SHEET} />
-      <BSStack.Screen getComponent={() => TokenLauncherScreen} name={Routes.TOKEN_LAUNCHER_SCREEN} options={tokenLauncherSheetPreset} />
-      <BSStack.Screen getComponent={() => PerpsNavigator} name={Routes.PERPS_NAVIGATOR} />
-      <BSStack.Screen getComponent={() => PerpsTradeHistoryScreen} name={Routes.PERPS_TRADE_HISTORY_SCREEN} />
-      <BSStack.Screen getComponent={() => CreateTriggerOrderBottomSheet} name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET} />
-      <BSStack.Screen getComponent={() => ClosePositionBottomSheet} name={Routes.CLOSE_POSITION_BOTTOM_SHEET} />
-      <BSStack.Screen getComponent={() => KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} />
-      <BSStack.Screen getComponent={() => PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} />
-      <BSStack.Screen getComponent={() => PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
-      <BSStack.Screen getComponent={() => PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
-      <BSStack.Screen getComponent={() => PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
-      <BSStack.Screen getComponent={() => PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
-      <BSStack.Screen getComponent={() => PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />
-      <BSStack.Screen getComponent={() => PolymarketMarketSheet} name={Routes.POLYMARKET_MARKET_SHEET} />
-      <BSStack.Screen getComponent={() => PolymarketMarketDescriptionSheet} name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET} />
-      <BSStack.Screen getComponent={() => PolymarketNewPositionSheet} name={Routes.POLYMARKET_NEW_POSITION_SHEET} />
-      <BSStack.Screen getComponent={() => PolymarketAccountScreen} name={Routes.POLYMARKET_ACCOUNT_SCREEN} />
-      <BSStack.Screen getComponent={() => PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} />
-      <BSStack.Screen getComponent={() => PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} />
-      <BSStack.Screen getComponent={() => PolymarketBrowseEventsScreen} name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN} />
-      <BSStack.Screen getComponent={() => PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} />
-      <BSStack.Screen getComponent={() => RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} />
-      <BSStack.Screen getComponent={() => RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} />
-      <BSStack.Screen getComponent={() => RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} />
-      <BSStack.Screen getComponent={() => RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} />
-      <BSStack.Screen getComponent={() => RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} />
-      <BSStack.Screen getComponent={() => RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} />
-      <BSStack.Screen getComponent={() => WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} />
-      <BSStack.Screen getComponent={() => RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/expandedAssetSheet/ExpandedAssetSheet').ExpandedAssetSheet}
+        name={Routes.EXPANDED_ASSET_SHEET_V2}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perp-detail-screen/PerpDetailScreen').PerpsDetailScreen}
+        name={Routes.PERPS_DETAIL_SCREEN}
+      />
+      <BSStack.Screen getComponent={() => require('@/screens/Airdrops/AirdropsSheet').AirdropsSheet} name={Routes.AIRDROPS_SHEET} />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/Airdrops/ClaimAirdropSheet').ClaimAirdropSheet}
+        name={Routes.CLAIM_AIRDROP_SHEET}
+      />
+      <BSStack.Screen getComponent={() => require('@/components/debugging/LogSheet').LogSheet} name={Routes.LOG_SHEET} />
+      <BSStack.Screen
+        getComponent={() => require('@/screens/token-launcher/TokenLauncherScreen').TokenLauncherScreen}
+        name={Routes.TOKEN_LAUNCHER_SCREEN}
+        options={tokenLauncherSheetPreset}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/PerpsNavigator').PerpsNavigator}
+        name={Routes.PERPS_NAVIGATOR}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-trade-history/PerpsTradeHistoryScreen').PerpsTradeHistoryScreen}
+        name={Routes.PERPS_TRADE_HISTORY_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/CreateTriggerOrderBottomSheet').CreateTriggerOrderBottomSheet}
+        name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/ClosePositionBottomSheet').ClosePositionBottomSheet}
+        name={Routes.CLOSE_POSITION_BOTTOM_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/king-of-the-hill/screens/KingOfTheHillExplainSheet').KingOfTheHillExplainSheet}
+        name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-explain-sheet/PerpsExplainSheet').PerpsExplainSheet}
+        name={Routes.PERPS_EXPLAIN_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-add-to-position-sheet/PerpsAddToPositionSheet').PerpsAddToPositionSheet}
+        name={Routes.PERPS_ADD_TO_POSITION_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-about-sheet/PerpsAboutSheet').PerpsAboutSheet}
+        name={Routes.PERPS_ABOUT_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet').PerpsTradeDetailsSheet}
+        name={Routes.PERPS_TRADE_DETAILS_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/polymarket/screens/polymarket-event-screen/PolymarketEventScreen').PolymarketEventScreen}
+        name={Routes.POLYMARKET_EVENT_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-redeem-position-sheet/PolymarketRedeemPositionSheet')
+            .PolymarketRedeemPositionSheet
+        }
+        name={Routes.POLYMARKET_MANAGE_POSITION_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/polymarket/screens/polymarket-market-sheet/PolymarketMarketSheet').PolymarketMarketSheet}
+        name={Routes.POLYMARKET_MARKET_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet')
+            .PolymarketMarketDescriptionSheet
+        }
+        name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-new-position-sheet/PolymarketNewPositionSheet').PolymarketNewPositionSheet
+        }
+        name={Routes.POLYMARKET_NEW_POSITION_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-account-screen/PolymarketAccountScreen').PolymarketAccountScreen
+        }
+        name={Routes.POLYMARKET_ACCOUNT_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator').PolymarketNavigator}
+        name={Routes.POLYMARKET_NAVIGATOR}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet').PolymarketExplainSheet}
+        name={Routes.POLYMARKET_EXPLAIN_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-browse-events-screen/PolymarketBrowseEventsScreen').PolymarketBrowseEventsScreen
+        }
+        name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet').PolymarketSellPositionSheet
+        }
+        name={Routes.POLYMARKET_SELL_POSITION_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen').RnbwAirdropScreen}
+        name={Routes.RNBW_AIRDROP_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet').RnbwRewardsClaimSheet}
+        name={Routes.RNBW_REWARDS_CLAIM_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet').RnbwRewardsEstimateSheet
+        }
+        name={Routes.RNBW_REWARDS_ESTIMATE_SHEET}
+      />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen').RnbwStakingLearnScreen
+        }
+        name={Routes.RNBW_STAKING_LEARN_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen').RnbwStakingScreen}
+        name={Routes.RNBW_STAKING_SCREEN}
+      />
+      <BSStack.Screen
+        getComponent={() => require('@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet').RnbwUnstakeSheet}
+        name={Routes.RNBW_UNSTAKE_SHEET}
+      />
+      <BSStack.Screen getComponent={() => require('@/components/wallet-error/WalletErrorSheet').default} name={Routes.WALLET_ERROR_SHEET} />
+      <BSStack.Screen
+        getComponent={() =>
+          require('@/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet').RnbwMembershipTiersSheet
+        }
+        name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET}
+      />
     </BSStack.Navigator>
   );
 }
@@ -346,7 +489,7 @@ function AuthNavigator() {
     >
       <AuthStack.Screen getComponent={() => BSNavigator} name={Routes.MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR} />
       <AuthStack.Screen
-        getComponent={() => PinAuthenticationScreen}
+        getComponent={() => require('../screens/PinAuthenticationScreen').default}
         name={Routes.PIN_AUTHENTICATION_SCREEN}
         options={{ ...sheetPreset, gestureEnabled: false }}
       />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -4,96 +4,11 @@ import React, { useContext } from 'react';
 import { NavigationContainer, type NavigationContainerRef } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
-import { SwapScreen } from '@/__swaps__/screens/Swap/Swap';
-import { ControlPanel } from '@/components/DappBrowser/control-panel/ControlPanel';
-import { LogSheet } from '@/components/debugging/LogSheet';
-import WalletErrorSheet from '@/components/wallet-error/WalletErrorSheet';
 import useExperimentalFlag, { PROFILES } from '@/config/experimentalHooks';
-import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
-import BackupSheet from '@/features/backup/components/BackupSheet';
-import RegisterENSNavigator from '@/features/ens/navigation/RegisterENSNavigator';
-import ENSAdditionalRecordsSheet from '@/features/ens/screens/ENSAdditionalRecordsSheet';
-import ENSConfirmRegisterSheet from '@/features/ens/screens/ENSConfirmRegisterSheet';
-import SelectENSSheet from '@/features/ens/screens/SelectENSSheet';
 import { useShowKingOfTheHill } from '@/features/king-of-the-hill/hooks/useShowKingOfTheHill';
-import { KingOfTheHillExplainSheet } from '@/features/king-of-the-hill/screens/KingOfTheHillExplainSheet';
-import { NotificationPermissionScreen } from '@/features/notifications/screens/NotificationPermissionScreen';
-import { ClosePositionBottomSheet } from '@/features/perps/screens/ClosePositionBottomSheet';
-import { CreateTriggerOrderBottomSheet } from '@/features/perps/screens/CreateTriggerOrderBottomSheet';
-import { PerpsDetailScreen } from '@/features/perps/screens/perp-detail-screen/PerpDetailScreen';
-import { PerpsAboutSheet } from '@/features/perps/screens/perps-about-sheet/PerpsAboutSheet';
-import { PerpsAddToPositionSheet } from '@/features/perps/screens/perps-add-to-position-sheet/PerpsAddToPositionSheet';
-import { PerpsDepositScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen';
-import { PerpsWithdrawalScreen } from '@/features/perps/screens/perps-deposit-withdraw-screen/PerpsWithdrawalScreen';
-import { PerpsExplainSheet } from '@/features/perps/screens/perps-explain-sheet/PerpsExplainSheet';
-import { PerpsTradeDetailsSheet } from '@/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet';
-import { PerpsTradeHistoryScreen } from '@/features/perps/screens/perps-trade-history/PerpsTradeHistoryScreen';
-import { PerpsNavigator } from '@/features/perps/screens/PerpsNavigator';
-import { PolymarketDepositScreen } from '@/features/polymarket/funding/screens/PolymarketDepositScreen';
-import { PolymarketWithdrawalScreen } from '@/features/polymarket/funding/screens/PolymarketWithdrawalScreen';
-import { PolymarketAccountScreen } from '@/features/polymarket/screens/polymarket-account-screen/PolymarketAccountScreen';
-import { PolymarketBrowseEventsScreen } from '@/features/polymarket/screens/polymarket-browse-events-screen/PolymarketBrowseEventsScreen';
-import { PolymarketEventScreen } from '@/features/polymarket/screens/polymarket-event-screen/PolymarketEventScreen';
-import { PolymarketExplainSheet } from '@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet';
-import { PolymarketMarketDescriptionSheet } from '@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet';
-import { PolymarketMarketSheet } from '@/features/polymarket/screens/polymarket-market-sheet/PolymarketMarketSheet';
-import { PolymarketNavigator } from '@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator';
-import { PolymarketNewPositionSheet } from '@/features/polymarket/screens/polymarket-new-position-sheet/PolymarketNewPositionSheet';
-import { PolymarketRedeemPositionSheet } from '@/features/polymarket/screens/polymarket-redeem-position-sheet/PolymarketRedeemPositionSheet';
-import { PolymarketSellPositionSheet } from '@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet';
-import { PositionSheet } from '@/features/positions/screens/PositionSheet';
-import { RnbwAirdropScreen } from '@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen';
-import { RnbwMembershipTiersSheet } from '@/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet';
-import { RnbwRewardsClaimSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet';
-import { RnbwRewardsEstimateSheet } from '@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet';
-import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen';
-import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
-import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
-import ConnectedDappsSheet from '@/features/wallet-connect/screens/ConnectedDappsSheet';
 import createNativeStackCoolModalNavigator from '@/react-native-cool-modals/createNativeStackNavigator';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';
-import { ActivitySheetScreen } from '@/screens/ActivitySheetScreen';
-import { AirdropsSheet } from '@/screens/Airdrops/AirdropsSheet';
-import { ClaimAirdropSheet } from '@/screens/Airdrops/ClaimAirdropSheet';
-import CheckIdentifierScreen from '@/screens/CheckIdentifierScreen';
-import { ClaimClaimablePanel } from '@/screens/claimables/ClaimPanel';
-import { RevokeDelegationPanel } from '@/screens/delegation/RevokeDelegationPanel';
-import { ExpandedAssetSheet as ExpandedAssetSheetV2 } from '@/screens/expandedAssetSheet/ExpandedAssetSheet';
-import LearnWebViewScreen from '@/screens/LearnWebViewScreen';
-import MintSheet from '@/screens/mints/MintSheet';
-import PoapSheet from '@/screens/mints/PoapSheet';
-import { MintsSheet } from '@/screens/MintsSheet/MintsSheet';
-import { NetworkSelector } from '@/screens/network-selector/NetworkSelector';
-import { NFTOffersSheet } from '@/screens/NFTOffersSheet';
-import { NFTSingleOfferSheet } from '@/screens/NFTSingleOfferSheet';
-import { Portal } from '@/screens/Portal';
-import QRScannerScreen from '@/screens/QRScannerScreen';
-import { RewardsSheet } from '@/screens/rewards/RewardsSheet';
-import { TokenLauncherScreen } from '@/screens/token-launcher/TokenLauncherScreen';
-import { TransactionDetails } from '@/screens/transaction-details/TransactionDetails';
 
-import { AddCashSheet } from '../screens/AddCash';
-import AvatarBuilder from '../screens/AvatarBuilder';
-import ChangeWalletSheet from '../screens/change-wallet/ChangeWalletSheet';
-import { WalletDiagnosticsSheet } from '../screens/Diagnostics';
-import ExpandedAssetSheet from '../screens/ExpandedAssetSheet';
-import ExplainSheet from '../screens/ExplainSheet';
-import ExternalLinkWarningSheet from '../screens/ExternalLinkWarningSheet';
-import ModalScreen from '../screens/ModalScreen';
-import NoNeedWCSheet from '../screens/NoNeedWCSheet';
-import ProfileSheet from '../screens/ProfileSheet';
-import ReceiveModal from '../screens/ReceiveModal';
-import { RestoreSheet } from '../screens/RestoreSheet';
-import SelectUniqueTokenSheet from '../screens/SelectUniqueTokenSheet';
-import { SendConfirmationSheet } from '../screens/SendConfirmationSheet';
-import SendSheet from '../screens/SendSheet';
-import { SettingsSheet } from '../screens/SettingsSheet/SettingsSheet';
-import { SignTransactionSheet } from '../screens/SignTransactionSheet';
-import SpeedUpAndCancelSheet from '../screens/SpeedUpAndCancelSheet';
-import WalletConnectApprovalSheet from '../screens/WalletConnectApprovalSheet';
-import WalletConnectRedirectSheet from '../screens/WalletConnectRedirectSheet';
-import { WelcomeScreen } from '../screens/WelcomeScreen/WelcomeScreen';
-import { AddWalletNavigator } from './AddWalletNavigator';
 import {
   activitySheetConfig,
   addWalletNavigatorConfig,
@@ -143,13 +58,10 @@ import {
   walletErrorSheetConfig,
 } from './config';
 import { addCashSheet, emojiPreset, emojiPresetWallet, overlayExpandedPreset, sheetPreset } from './effects';
-import { HardwareWalletTxNavigator } from './HardwareWalletTxNavigator';
 import { InitialRouteContext } from './initialRoute';
 import { nativeStackConfig } from './nativeStackConfig';
 import { onNavigationStateChange } from './onNavigationStateChange';
-import { PairHardwareWalletNavigator } from './PairHardwareWalletNavigator';
 import Routes from './routesNames';
-import { SwipeNavigator } from './SwipeNavigator';
 import { type RootStackParamList } from './types';
 
 const Stack = createStackNavigator();
@@ -158,8 +70,12 @@ const NativeStack = createNativeStackCoolModalNavigator();
 function SendFlowNavigator() {
   return (
     <Stack.Navigator {...stackNavigationConfig} initialRouteName={Routes.SEND_SHEET}>
-      <Stack.Screen getComponent={() => ModalScreen} name={Routes.MODAL_SCREEN} options={overlayExpandedPreset} />
-      <Stack.Screen getComponent={() => SendSheet} name={Routes.SEND_SHEET} options={sheetPreset} />
+      <Stack.Screen
+        getComponent={() => require('../screens/ModalScreen').default}
+        name={Routes.MODAL_SCREEN}
+        options={overlayExpandedPreset}
+      />
+      <Stack.Screen getComponent={() => require('../screens/SendSheet').default} name={Routes.SEND_SHEET} options={sheetPreset} />
     </Stack.Navigator>
   );
 }
@@ -169,15 +85,19 @@ function MainNavigator() {
 
   return (
     <Stack.Navigator initialRouteName={initialRoute} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <Stack.Screen getComponent={() => SwipeNavigator} name={Routes.SWIPE_LAYOUT} />
+      <Stack.Screen getComponent={() => require('./SwipeNavigator').SwipeNavigator} name={Routes.SWIPE_LAYOUT} />
       <Stack.Screen
-        getComponent={() => WelcomeScreen}
+        getComponent={() => require('../screens/WelcomeScreen/WelcomeScreen').WelcomeScreen}
         name={Routes.WELCOME_SCREEN}
         options={{ animationEnabled: false, gestureEnabled: false }}
       />
-      <Stack.Screen getComponent={() => AvatarBuilder} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
-      <Stack.Screen getComponent={() => AvatarBuilder} name={Routes.AVATAR_BUILDER_WALLET} options={emojiPresetWallet} />
-      <Stack.Screen getComponent={() => AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
+      <Stack.Screen getComponent={() => require('../screens/AvatarBuilder').default} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
+      <Stack.Screen
+        getComponent={() => require('../screens/AvatarBuilder').default}
+        name={Routes.AVATAR_BUILDER_WALLET}
+        options={emojiPresetWallet}
+      />
+      <Stack.Screen getComponent={() => require('../screens/AddCash').AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
     </Stack.Navigator>
   );
 }
@@ -198,28 +118,52 @@ function NativeStackNavigator() {
     <NativeStack.Navigator {...nativeStackConfig}>
       <NativeStack.Screen getComponent={() => MainStack} name={Routes.STACK} />
       <NativeStack.Screen
-        getComponent={() => NotificationPermissionScreen}
+        getComponent={() => require('@/features/notifications/screens/NotificationPermissionScreen').NotificationPermissionScreen}
         name={Routes.NOTIFICATION_PERMISSION_SCREEN}
         {...notificationPermissionSheetConfig}
       />
-      <NativeStack.Screen getComponent={() => LearnWebViewScreen} name={Routes.LEARN_WEB_VIEW_SCREEN} {...learnWebViewScreenConfig} />
-      <NativeStack.Screen getComponent={() => ReceiveModal} name={Routes.RECEIVE_MODAL} {...recieveModalSheetConfig} />
-      <NativeStack.Screen getComponent={() => SettingsSheet} name={Routes.SETTINGS_SHEET} {...settingsSheetConfig} />
       <NativeStack.Screen
-        getComponent={() => ExpandedAssetSheet}
+        getComponent={() => require('@/screens/LearnWebViewScreen').default}
+        name={Routes.LEARN_WEB_VIEW_SCREEN}
+        {...learnWebViewScreenConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/ReceiveModal').default}
+        name={Routes.RECEIVE_MODAL}
+        {...recieveModalSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/SettingsSheet/SettingsSheet').SettingsSheet}
+        name={Routes.SETTINGS_SHEET}
+        {...settingsSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/ExpandedAssetSheet').default}
         name={Routes.EXPANDED_ASSET_SHEET}
         {...expandedAssetSheetConfigWithLimit}
       />
-      <NativeStack.Screen getComponent={() => PoapSheet} name={Routes.POAP_SHEET} {...expandedAssetSheetConfigWithLimit} />
-      <NativeStack.Screen getComponent={() => MintSheet} name={Routes.MINT_SHEET} {...expandedAssetSheetConfigWithLimit} />
-      <NativeStack.Screen getComponent={() => PositionSheet} name={Routes.POSITION_SHEET} {...positionSheetConfig} />
       <NativeStack.Screen
-        getComponent={() => SelectUniqueTokenSheet}
+        getComponent={() => require('@/screens/mints/PoapSheet').default}
+        name={Routes.POAP_SHEET}
+        {...expandedAssetSheetConfigWithLimit}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/mints/MintSheet').default}
+        name={Routes.MINT_SHEET}
+        {...expandedAssetSheetConfigWithLimit}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/positions/screens/PositionSheet').PositionSheet}
+        name={Routes.POSITION_SHEET}
+        {...positionSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/SelectUniqueTokenSheet').default}
         name={Routes.SELECT_UNIQUE_TOKEN_SHEET}
         {...expandedAssetSheetConfigWithLimit}
       />
       <NativeStack.Screen
-        getComponent={() => SpeedUpAndCancelSheet}
+        getComponent={() => require('../screens/SpeedUpAndCancelSheet').default}
         name={Routes.SPEED_UP_AND_CANCEL_SHEET}
         options={{
           allowsDragToDismiss: true,
@@ -230,17 +174,33 @@ function NativeStackNavigator() {
           topOffset: 0,
         }}
       />
-      <Stack.Screen getComponent={() => SendConfirmationSheet} name={Routes.SEND_CONFIRMATION_SHEET} {...sendConfirmationSheetConfig} />
-      <NativeStack.Screen getComponent={() => ExplainSheet} name={Routes.EXPLAIN_SHEET} {...explainSheetConfig} />
+      <Stack.Screen
+        getComponent={() => require('../screens/SendConfirmationSheet').SendConfirmationSheet}
+        name={Routes.SEND_CONFIRMATION_SHEET}
+        {...sendConfirmationSheetConfig}
+      />
       <NativeStack.Screen
-        getComponent={() => ExternalLinkWarningSheet}
+        getComponent={() => require('../screens/ExplainSheet').default}
+        name={Routes.EXPLAIN_SHEET}
+        {...explainSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/ExternalLinkWarningSheet').default}
         name={Routes.EXTERNAL_LINK_WARNING_SHEET}
         {...externalLinkWarningSheetConfig}
       />
-      <NativeStack.Screen getComponent={() => WalletDiagnosticsSheet} name={Routes.DIAGNOSTICS_SHEET} {...walletDiagnosticsSheetConfig} />
-      <NativeStack.Screen getComponent={() => ChangeWalletSheet} name={Routes.CHANGE_WALLET_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => ConnectedDappsSheet}
+        getComponent={() => require('../screens/Diagnostics').WalletDiagnosticsSheet}
+        name={Routes.DIAGNOSTICS_SHEET}
+        {...walletDiagnosticsSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/change-wallet/ChangeWalletSheet').default}
+        name={Routes.CHANGE_WALLET_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/wallet-connect/screens/ConnectedDappsSheet').default}
         name={Routes.CONNECTED_DAPPS}
         options={{
           allowsDragToDismiss: true,
@@ -251,13 +211,17 @@ function NativeStackNavigator() {
         }}
       />
       <NativeStack.Screen
-        getComponent={() => CheckIdentifierScreen}
+        getComponent={() => require('@/screens/CheckIdentifierScreen').default}
         name={Routes.CHECK_IDENTIFIER_SCREEN}
         {...checkIdentifierSheetConfig}
       />
-      <NativeStack.Screen getComponent={() => BackupSheet} name={Routes.BACKUP_SHEET} {...backupSheetConfig} />
       <NativeStack.Screen
-        getComponent={() => ModalScreen}
+        getComponent={() => require('@/features/backup/components/BackupSheet').default}
+        name={Routes.BACKUP_SHEET}
+        {...backupSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/ModalScreen').default}
         name={Routes.MODAL_SCREEN}
         options={{
           customStack: true,
@@ -266,46 +230,78 @@ function NativeStackNavigator() {
           topOffset: 0,
         }}
       />
-      <NativeStack.Screen getComponent={() => RestoreSheet} name={Routes.RESTORE_SHEET} {...restoreSheetConfig} />
-      <NativeStack.Screen getComponent={() => SignTransactionSheet} name={Routes.CONFIRM_REQUEST} {...signTransactionSheetConfig} />
-      <NativeStack.Screen getComponent={() => ExpandedAssetSheet} name={Routes.CUSTOM_GAS_SHEET} {...customGasSheetConfig} />
-      <NativeStack.Screen getComponent={() => QRScannerScreen} name={Routes.QR_SCANNER_SCREEN} {...qrScannerConfig} />
       <NativeStack.Screen
-        getComponent={() => PairHardwareWalletNavigator}
+        getComponent={() => require('../screens/RestoreSheet').RestoreSheet}
+        name={Routes.RESTORE_SHEET}
+        {...restoreSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/SignTransactionSheet').SignTransactionSheet}
+        name={Routes.CONFIRM_REQUEST}
+        {...signTransactionSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/ExpandedAssetSheet').default}
+        name={Routes.CUSTOM_GAS_SHEET}
+        {...customGasSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/QRScannerScreen').default}
+        name={Routes.QR_SCANNER_SCREEN}
+        {...qrScannerConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('./PairHardwareWalletNavigator').PairHardwareWalletNavigator}
         name={Routes.PAIR_HARDWARE_WALLET_NAVIGATOR}
         {...pairHardwareWalletNavigatorConfig}
       />
       <NativeStack.Screen
-        getComponent={() => HardwareWalletTxNavigator}
+        getComponent={() => require('./HardwareWalletTxNavigator').HardwareWalletTxNavigator}
         name={Routes.HARDWARE_WALLET_TX_NAVIGATOR}
         {...hardwareWalletTxNavigatorConfig}
       />
-      <NativeStack.Screen getComponent={() => AddWalletNavigator} name={Routes.ADD_WALLET_NAVIGATOR} {...addWalletNavigatorConfig} />
-      <NativeStack.Screen getComponent={() => Portal} name={Routes.PORTAL} {...portalSheetConfig} />
+      <NativeStack.Screen
+        getComponent={() => require('./AddWalletNavigator').AddWalletNavigator}
+        name={Routes.ADD_WALLET_NAVIGATOR}
+        {...addWalletNavigatorConfig}
+      />
+      <NativeStack.Screen getComponent={() => require('@/screens/Portal').Portal} name={Routes.PORTAL} {...portalSheetConfig} />
       {showKingOfTheHillTab && (
-        <NativeStack.Screen getComponent={() => ActivitySheetScreen} name={Routes.PROFILE_SCREEN} {...activitySheetConfig} />
+        <NativeStack.Screen
+          getComponent={() => require('@/screens/ActivitySheetScreen').ActivitySheetScreen}
+          name={Routes.PROFILE_SCREEN}
+          {...activitySheetConfig}
+        />
       )}
       {profilesEnabled && (
         <>
           <NativeStack.Screen
-            getComponent={() => RegisterENSNavigator}
+            getComponent={() => require('@/features/ens/navigation/RegisterENSNavigator').default}
             name={Routes.REGISTER_ENS_NAVIGATOR}
             {...registerENSNavigatorConfig}
           />
           <NativeStack.Screen
-            getComponent={() => ENSConfirmRegisterSheet}
+            getComponent={() => require('@/features/ens/screens/ENSConfirmRegisterSheet').default}
             name={Routes.ENS_CONFIRM_REGISTER_SHEET}
             {...ensConfirmRegisterSheetConfig}
           />
           <NativeStack.Screen
-            getComponent={() => ENSAdditionalRecordsSheet}
+            getComponent={() => require('@/features/ens/screens/ENSAdditionalRecordsSheet').default}
             name={Routes.ENS_ADDITIONAL_RECORDS_SHEET}
             {...ensAdditionalRecordsSheetConfig}
           />
-          <NativeStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_SHEET} {...profileConfig} />
-          <NativeStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_PREVIEW_SHEET} {...profilePreviewConfig} />
           <NativeStack.Screen
-            getComponent={() => SelectENSSheet}
+            getComponent={() => require('../screens/ProfileSheet').default}
+            name={Routes.PROFILE_SHEET}
+            {...profileConfig}
+          />
+          <NativeStack.Screen
+            getComponent={() => require('../screens/ProfileSheet').default}
+            name={Routes.PROFILE_PREVIEW_SHEET}
+            {...profilePreviewConfig}
+          />
+          <NativeStack.Screen
+            getComponent={() => require('@/features/ens/screens/SelectENSSheet').default}
             name={Routes.SELECT_ENS_SHEET}
             options={{
               allowsDragToDismiss: true,
@@ -318,72 +314,164 @@ function NativeStackNavigator() {
         </>
       )}
       <NativeStack.Screen getComponent={() => SendFlowNavigator} name={Routes.SEND_SHEET_NAVIGATOR} />
-      <NativeStack.Screen getComponent={() => NoNeedWCSheet} name={Routes.NO_NEED_WC_SHEET} {...basicSheetConfig} />
       <NativeStack.Screen
-        getComponent={() => WalletConnectApprovalSheet}
+        getComponent={() => require('../screens/NoNeedWCSheet').default}
+        name={Routes.NO_NEED_WC_SHEET}
+        {...basicSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('../screens/WalletConnectApprovalSheet').default}
         name={Routes.WALLET_CONNECT_APPROVAL_SHEET}
         {...basicSheetConfig}
       />
       <NativeStack.Screen
-        getComponent={() => WalletConnectRedirectSheet}
+        getComponent={() => require('../screens/WalletConnectRedirectSheet').default}
         name={Routes.WALLET_CONNECT_REDIRECT_SHEET}
         {...basicSheetConfig}
       />
-      <NativeStack.Screen name={Routes.TRANSACTION_DETAILS} getComponent={() => TransactionDetails} {...transactionDetailsConfig} />
-      <NativeStack.Screen name={Routes.OP_REWARDS_SHEET} getComponent={() => RewardsSheet} {...opRewardsSheetConfig} />
-      <NativeStack.Screen name={Routes.NFT_OFFERS_SHEET} getComponent={() => NFTOffersSheet} {...nftOffersSheetConfig} />
-      <NativeStack.Screen name={Routes.NFT_SINGLE_OFFER_SHEET} getComponent={() => NFTSingleOfferSheet} {...nftSingleOfferSheetConfig} />
-      <NativeStack.Screen name={Routes.MINTS_SHEET} getComponent={() => MintsSheet} {...mintsSheetConfig} />
-      <NativeStack.Screen getComponent={() => AppIconUnlockSheet} name={Routes.APP_ICON_UNLOCK_SHEET} {...appIconUnlockSheetConfig} />
-      <NativeStack.Screen getComponent={() => NetworkSelector} name={Routes.NETWORK_SELECTOR} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => ControlPanel} name={Routes.DAPP_BROWSER_CONTROL_PANEL} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => ClaimClaimablePanel} name={Routes.CLAIM_CLAIMABLE_PANEL} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => RevokeDelegationPanel} name={Routes.REVOKE_DELEGATION_PANEL} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => SwapScreen} name={Routes.SWAP} {...swapConfig} />
-      <NativeStack.Screen getComponent={() => PerpsDepositScreen} name={Routes.PERPS_DEPOSIT_SCREEN} {...perpsDepositWithdrawalConfig} />
       <NativeStack.Screen
-        getComponent={() => PolymarketDepositScreen}
+        name={Routes.TRANSACTION_DETAILS}
+        getComponent={() => require('@/screens/transaction-details/TransactionDetails').TransactionDetails}
+        {...transactionDetailsConfig}
+      />
+      <NativeStack.Screen
+        name={Routes.OP_REWARDS_SHEET}
+        getComponent={() => require('@/screens/rewards/RewardsSheet').RewardsSheet}
+        {...opRewardsSheetConfig}
+      />
+      <NativeStack.Screen
+        name={Routes.NFT_OFFERS_SHEET}
+        getComponent={() => require('@/screens/NFTOffersSheet').NFTOffersSheet}
+        {...nftOffersSheetConfig}
+      />
+      <NativeStack.Screen
+        name={Routes.NFT_SINGLE_OFFER_SHEET}
+        getComponent={() => require('@/screens/NFTSingleOfferSheet').NFTSingleOfferSheet}
+        {...nftSingleOfferSheetConfig}
+      />
+      <NativeStack.Screen
+        name={Routes.MINTS_SHEET}
+        getComponent={() => require('@/screens/MintsSheet/MintsSheet').MintsSheet}
+        {...mintsSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/app-icon/screens/AppIconUnlockSheet').default}
+        name={Routes.APP_ICON_UNLOCK_SHEET}
+        {...appIconUnlockSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/network-selector/NetworkSelector').NetworkSelector}
+        name={Routes.NETWORK_SELECTOR}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/components/DappBrowser/control-panel/ControlPanel').ControlPanel}
+        name={Routes.DAPP_BROWSER_CONTROL_PANEL}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/claimables/ClaimPanel').ClaimClaimablePanel}
+        name={Routes.CLAIM_CLAIMABLE_PANEL}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/delegation/RevokeDelegationPanel').RevokeDelegationPanel}
+        name={Routes.REVOKE_DELEGATION_PANEL}
+        {...panelConfig}
+      />
+      <NativeStack.Screen getComponent={() => require('@/__swaps__/screens/Swap/Swap').SwapScreen} name={Routes.SWAP} {...swapConfig} />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen').PerpsDepositScreen}
+        name={Routes.PERPS_DEPOSIT_SCREEN}
+        {...perpsDepositWithdrawalConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/polymarket/funding/screens/PolymarketDepositScreen').PolymarketDepositScreen}
         name={Routes.POLYMARKET_DEPOSIT_SCREEN}
         {...perpsDepositWithdrawalConfig}
       />
-      <NativeStack.Screen getComponent={() => PerpsDetailScreen} name={Routes.PERPS_DETAIL_SCREEN} {...expandedAssetSheetV2Config} />
       <NativeStack.Screen
-        getComponent={() => PerpsWithdrawalScreen}
+        getComponent={() => require('@/features/perps/screens/perp-detail-screen/PerpDetailScreen').PerpsDetailScreen}
+        name={Routes.PERPS_DETAIL_SCREEN}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-deposit-withdraw-screen/PerpsWithdrawalScreen').PerpsWithdrawalScreen}
         name={Routes.PERPS_WITHDRAWAL_SCREEN}
         {...perpsDepositWithdrawalConfig}
       />
       <NativeStack.Screen
-        getComponent={() => PolymarketWithdrawalScreen}
+        getComponent={() => require('@/features/polymarket/funding/screens/PolymarketWithdrawalScreen').PolymarketWithdrawalScreen}
         name={Routes.POLYMARKET_WITHDRAWAL_SCREEN}
         {...perpsDepositWithdrawalConfig}
       />
-      <NativeStack.Screen getComponent={() => ExpandedAssetSheetV2} name={Routes.EXPANDED_ASSET_SHEET_V2} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen getComponent={() => AirdropsSheet} name={Routes.AIRDROPS_SHEET} {...airdropsSheetConfig} />
-      <NativeStack.Screen getComponent={() => ClaimAirdropSheet} name={Routes.CLAIM_AIRDROP_SHEET} {...claimAirdropSheetConfig} />
-      <NativeStack.Screen getComponent={() => LogSheet} name={Routes.LOG_SHEET} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => TokenLauncherScreen} name={Routes.TOKEN_LAUNCHER_SCREEN} {...tokenLauncherConfig} />
-      <NativeStack.Screen getComponent={() => PerpsNavigator} name={Routes.PERPS_NAVIGATOR} {...perpsAccountStackConfig} />
       <NativeStack.Screen
-        getComponent={() => PerpsTradeHistoryScreen}
+        getComponent={() => require('@/screens/expandedAssetSheet/ExpandedAssetSheet').ExpandedAssetSheet}
+        name={Routes.EXPANDED_ASSET_SHEET_V2}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/Airdrops/AirdropsSheet').AirdropsSheet}
+        name={Routes.AIRDROPS_SHEET}
+        {...airdropsSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/Airdrops/ClaimAirdropSheet').ClaimAirdropSheet}
+        name={Routes.CLAIM_AIRDROP_SHEET}
+        {...claimAirdropSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/components/debugging/LogSheet').LogSheet}
+        name={Routes.LOG_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/screens/token-launcher/TokenLauncherScreen').TokenLauncherScreen}
+        name={Routes.TOKEN_LAUNCHER_SCREEN}
+        {...tokenLauncherConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/PerpsNavigator').PerpsNavigator}
+        name={Routes.PERPS_NAVIGATOR}
+        {...perpsAccountStackConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-trade-history/PerpsTradeHistoryScreen').PerpsTradeHistoryScreen}
         name={Routes.PERPS_TRADE_HISTORY_SCREEN}
         {...perpsAccountStackConfig}
       />
       <NativeStack.Screen
-        getComponent={() => CreateTriggerOrderBottomSheet}
+        getComponent={() => require('@/features/perps/screens/CreateTriggerOrderBottomSheet').CreateTriggerOrderBottomSheet}
         name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET}
         {...panelConfig}
       />
-      <NativeStack.Screen getComponent={() => ClosePositionBottomSheet} name={Routes.CLOSE_POSITION_BOTTOM_SHEET} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => KingOfTheHillExplainSheet}
+        getComponent={() => require('@/features/perps/screens/ClosePositionBottomSheet').ClosePositionBottomSheet}
+        name={Routes.CLOSE_POSITION_BOTTOM_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-add-to-position-sheet/PerpsAddToPositionSheet').PerpsAddToPositionSheet}
+        name={Routes.PERPS_ADD_TO_POSITION_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/king-of-the-hill/screens/KingOfTheHillExplainSheet').KingOfTheHillExplainSheet}
         name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET}
         {...learnSheetConfig}
       />
-      <NativeStack.Screen getComponent={() => PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
-      <NativeStack.Screen getComponent={() => PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => PerpsTradeDetailsSheet}
+        getComponent={() => require('@/features/perps/screens/perps-explain-sheet/PerpsExplainSheet').PerpsExplainSheet}
+        name={Routes.PERPS_EXPLAIN_SHEET}
+        {...perpsExplainSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-about-sheet/PerpsAboutSheet').PerpsAboutSheet}
+        name={Routes.PERPS_ABOUT_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/perps/screens/perps-trade-details-sheet/PerpsTradeDetailsSheet').PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}
         options={({ route }) => ({
           ...panelConfig.options({ route }),
@@ -391,47 +479,115 @@ function NativeStackNavigator() {
         })}
       />
       <NativeStack.Screen
-        getComponent={() => PolymarketEventScreen}
+        getComponent={() => require('@/features/polymarket/screens/polymarket-event-screen/PolymarketEventScreen').PolymarketEventScreen}
         name={Routes.POLYMARKET_EVENT_SCREEN}
         {...expandedAssetSheetV2Config}
       />
       <NativeStack.Screen
-        getComponent={() => PolymarketRedeemPositionSheet}
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-redeem-position-sheet/PolymarketRedeemPositionSheet')
+            .PolymarketRedeemPositionSheet
+        }
         name={Routes.POLYMARKET_MANAGE_POSITION_SHEET}
         {...panelConfig}
       />
-      <NativeStack.Screen getComponent={() => PolymarketMarketSheet} name={Routes.POLYMARKET_MARKET_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => PolymarketMarketDescriptionSheet}
+        getComponent={() => require('@/features/polymarket/screens/polymarket-market-sheet/PolymarketMarketSheet').PolymarketMarketSheet}
+        name={Routes.POLYMARKET_MARKET_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-market-description-sheet/PolymarketMarketDescriptionSheet')
+            .PolymarketMarketDescriptionSheet
+        }
         name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET}
         {...panelConfig}
       />
-      <NativeStack.Screen getComponent={() => PolymarketNewPositionSheet} name={Routes.POLYMARKET_NEW_POSITION_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => PolymarketAccountScreen}
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-new-position-sheet/PolymarketNewPositionSheet').PolymarketNewPositionSheet
+        }
+        name={Routes.POLYMARKET_NEW_POSITION_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-account-screen/PolymarketAccountScreen').PolymarketAccountScreen
+        }
         name={Routes.POLYMARKET_ACCOUNT_SCREEN}
         {...expandedAssetSheetV2Config}
       />
-      <NativeStack.Screen getComponent={() => PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} {...perpsAccountStackConfig} />
-      <NativeStack.Screen getComponent={() => PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} {...learnSheetConfig} />
-      <NativeStack.Screen getComponent={() => PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen getComponent={() => RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} {...panelConfig} />
-      <NativeStack.Screen getComponent={() => RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => RnbwStakingLearnScreen}
+        getComponent={() => require('@/features/polymarket/screens/polymarket-navigator/PolymarketNavigator').PolymarketNavigator}
+        name={Routes.POLYMARKET_NAVIGATOR}
+        {...perpsAccountStackConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/polymarket/screens/polymarket-learn-sheet/PolymarketExplainSheet').PolymarketExplainSheet}
+        name={Routes.POLYMARKET_EXPLAIN_SHEET}
+        {...learnSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-sell-position-sheet/PolymarketSellPositionSheet').PolymarketSellPositionSheet
+        }
+        name={Routes.POLYMARKET_SELL_POSITION_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/rnbw-airdrop/screens/rnbw-airdrop-screen/RnbwAirdropScreen').RnbwAirdropScreen}
+        name={Routes.RNBW_AIRDROP_SCREEN}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet').RnbwRewardsClaimSheet}
+        name={Routes.RNBW_REWARDS_CLAIM_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/rnbw-rewards/screens/rnbw-rewards-estimate-sheet/RnbwRewardsEstimateSheet').RnbwRewardsEstimateSheet
+        }
+        name={Routes.RNBW_REWARDS_ESTIMATE_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/rnbw-staking/screens/rnbw-staking-learn-screen/RnbwStakingLearnScreen').RnbwStakingLearnScreen
+        }
         name={Routes.RNBW_STAKING_LEARN_SCREEN}
         {...expandedAssetSheetV2Config}
       />
-      <NativeStack.Screen getComponent={() => RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen getComponent={() => RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        getComponent={() => PolymarketBrowseEventsScreen}
+        getComponent={() => require('@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen').RnbwStakingScreen}
+        name={Routes.RNBW_STAKING_SCREEN}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen
+        getComponent={() => require('@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet').RnbwUnstakeSheet}
+        name={Routes.RNBW_UNSTAKE_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/polymarket/screens/polymarket-browse-events-screen/PolymarketBrowseEventsScreen').PolymarketBrowseEventsScreen
+        }
         name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}
         {...expandedAssetSheetV2Config}
       />
-      <NativeStack.Screen getComponent={() => WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} {...walletErrorSheetConfig} />
-      <NativeStack.Screen getComponent={() => RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} {...learnSheetConfig} />
+      <NativeStack.Screen
+        getComponent={() => require('@/components/wallet-error/WalletErrorSheet').default}
+        name={Routes.WALLET_ERROR_SHEET}
+        {...walletErrorSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() =>
+          require('@/features/rnbw-membership/screens/rnbw-membership-tiers-sheet/RnbwMembershipTiersSheet').RnbwMembershipTiersSheet
+        }
+        name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET}
+        {...learnSheetConfig}
+      />
     </NativeStack.Navigator>
   );
 }

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -158,8 +158,8 @@ const NativeStack = createNativeStackCoolModalNavigator();
 function SendFlowNavigator() {
   return (
     <Stack.Navigator {...stackNavigationConfig} initialRouteName={Routes.SEND_SHEET}>
-      <Stack.Screen component={ModalScreen} name={Routes.MODAL_SCREEN} options={overlayExpandedPreset} />
-      <Stack.Screen component={SendSheet} name={Routes.SEND_SHEET} options={sheetPreset} />
+      <Stack.Screen getComponent={() => ModalScreen} name={Routes.MODAL_SCREEN} options={overlayExpandedPreset} />
+      <Stack.Screen getComponent={() => SendSheet} name={Routes.SEND_SHEET} options={sheetPreset} />
     </Stack.Navigator>
   );
 }
@@ -169,11 +169,15 @@ function MainNavigator() {
 
   return (
     <Stack.Navigator initialRouteName={initialRoute} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <Stack.Screen component={SwipeNavigator} name={Routes.SWIPE_LAYOUT} />
-      <Stack.Screen component={WelcomeScreen} name={Routes.WELCOME_SCREEN} options={{ animationEnabled: false, gestureEnabled: false }} />
-      <Stack.Screen component={AvatarBuilder} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
-      <Stack.Screen component={AvatarBuilder} name={Routes.AVATAR_BUILDER_WALLET} options={emojiPresetWallet} />
-      <Stack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
+      <Stack.Screen getComponent={() => SwipeNavigator} name={Routes.SWIPE_LAYOUT} />
+      <Stack.Screen
+        getComponent={() => WelcomeScreen}
+        name={Routes.WELCOME_SCREEN}
+        options={{ animationEnabled: false, gestureEnabled: false }}
+      />
+      <Stack.Screen getComponent={() => AvatarBuilder} name={Routes.AVATAR_BUILDER} options={emojiPreset} />
+      <Stack.Screen getComponent={() => AvatarBuilder} name={Routes.AVATAR_BUILDER_WALLET} options={emojiPresetWallet} />
+      <Stack.Screen getComponent={() => AddCashSheet} name={Routes.ADD_CASH_SHEET} options={addCashSheet} />
     </Stack.Navigator>
   );
 }
@@ -181,7 +185,7 @@ function MainNavigator() {
 function MainStack() {
   return (
     <Stack.Navigator initialRouteName={Routes.MAIN_NAVIGATOR_WRAPPER} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <Stack.Screen component={MainNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
+      <Stack.Screen getComponent={() => MainNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
     </Stack.Navigator>
   );
 }
@@ -192,26 +196,30 @@ function NativeStackNavigator() {
 
   return (
     <NativeStack.Navigator {...nativeStackConfig}>
-      <NativeStack.Screen component={MainStack} name={Routes.STACK} />
+      <NativeStack.Screen getComponent={() => MainStack} name={Routes.STACK} />
       <NativeStack.Screen
-        component={NotificationPermissionScreen}
+        getComponent={() => NotificationPermissionScreen}
         name={Routes.NOTIFICATION_PERMISSION_SCREEN}
         {...notificationPermissionSheetConfig}
       />
-      <NativeStack.Screen component={LearnWebViewScreen} name={Routes.LEARN_WEB_VIEW_SCREEN} {...learnWebViewScreenConfig} />
-      <NativeStack.Screen component={ReceiveModal} name={Routes.RECEIVE_MODAL} {...recieveModalSheetConfig} />
-      <NativeStack.Screen component={SettingsSheet} name={Routes.SETTINGS_SHEET} {...settingsSheetConfig} />
-      <NativeStack.Screen component={ExpandedAssetSheet} name={Routes.EXPANDED_ASSET_SHEET} {...expandedAssetSheetConfigWithLimit} />
-      <NativeStack.Screen component={PoapSheet} name={Routes.POAP_SHEET} {...expandedAssetSheetConfigWithLimit} />
-      <NativeStack.Screen component={MintSheet} name={Routes.MINT_SHEET} {...expandedAssetSheetConfigWithLimit} />
-      <NativeStack.Screen component={PositionSheet} name={Routes.POSITION_SHEET} {...positionSheetConfig} />
+      <NativeStack.Screen getComponent={() => LearnWebViewScreen} name={Routes.LEARN_WEB_VIEW_SCREEN} {...learnWebViewScreenConfig} />
+      <NativeStack.Screen getComponent={() => ReceiveModal} name={Routes.RECEIVE_MODAL} {...recieveModalSheetConfig} />
+      <NativeStack.Screen getComponent={() => SettingsSheet} name={Routes.SETTINGS_SHEET} {...settingsSheetConfig} />
       <NativeStack.Screen
-        component={SelectUniqueTokenSheet}
+        getComponent={() => ExpandedAssetSheet}
+        name={Routes.EXPANDED_ASSET_SHEET}
+        {...expandedAssetSheetConfigWithLimit}
+      />
+      <NativeStack.Screen getComponent={() => PoapSheet} name={Routes.POAP_SHEET} {...expandedAssetSheetConfigWithLimit} />
+      <NativeStack.Screen getComponent={() => MintSheet} name={Routes.MINT_SHEET} {...expandedAssetSheetConfigWithLimit} />
+      <NativeStack.Screen getComponent={() => PositionSheet} name={Routes.POSITION_SHEET} {...positionSheetConfig} />
+      <NativeStack.Screen
+        getComponent={() => SelectUniqueTokenSheet}
         name={Routes.SELECT_UNIQUE_TOKEN_SHEET}
         {...expandedAssetSheetConfigWithLimit}
       />
       <NativeStack.Screen
-        component={SpeedUpAndCancelSheet}
+        getComponent={() => SpeedUpAndCancelSheet}
         name={Routes.SPEED_UP_AND_CANCEL_SHEET}
         options={{
           allowsDragToDismiss: true,
@@ -222,17 +230,17 @@ function NativeStackNavigator() {
           topOffset: 0,
         }}
       />
-      <Stack.Screen component={SendConfirmationSheet} name={Routes.SEND_CONFIRMATION_SHEET} {...sendConfirmationSheetConfig} />
-      <NativeStack.Screen component={ExplainSheet} name={Routes.EXPLAIN_SHEET} {...explainSheetConfig} />
+      <Stack.Screen getComponent={() => SendConfirmationSheet} name={Routes.SEND_CONFIRMATION_SHEET} {...sendConfirmationSheetConfig} />
+      <NativeStack.Screen getComponent={() => ExplainSheet} name={Routes.EXPLAIN_SHEET} {...explainSheetConfig} />
       <NativeStack.Screen
-        component={ExternalLinkWarningSheet}
+        getComponent={() => ExternalLinkWarningSheet}
         name={Routes.EXTERNAL_LINK_WARNING_SHEET}
         {...externalLinkWarningSheetConfig}
       />
-      <NativeStack.Screen component={WalletDiagnosticsSheet} name={Routes.DIAGNOSTICS_SHEET} {...walletDiagnosticsSheetConfig} />
-      <NativeStack.Screen component={ChangeWalletSheet} name={Routes.CHANGE_WALLET_SHEET} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => WalletDiagnosticsSheet} name={Routes.DIAGNOSTICS_SHEET} {...walletDiagnosticsSheetConfig} />
+      <NativeStack.Screen getComponent={() => ChangeWalletSheet} name={Routes.CHANGE_WALLET_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        component={ConnectedDappsSheet}
+        getComponent={() => ConnectedDappsSheet}
         name={Routes.CONNECTED_DAPPS}
         options={{
           allowsDragToDismiss: true,
@@ -242,10 +250,14 @@ function NativeStackNavigator() {
           transitionDuration: 0.25,
         }}
       />
-      <NativeStack.Screen component={CheckIdentifierScreen} name={Routes.CHECK_IDENTIFIER_SCREEN} {...checkIdentifierSheetConfig} />
-      <NativeStack.Screen component={BackupSheet} name={Routes.BACKUP_SHEET} {...backupSheetConfig} />
       <NativeStack.Screen
-        component={ModalScreen}
+        getComponent={() => CheckIdentifierScreen}
+        name={Routes.CHECK_IDENTIFIER_SCREEN}
+        {...checkIdentifierSheetConfig}
+      />
+      <NativeStack.Screen getComponent={() => BackupSheet} name={Routes.BACKUP_SHEET} {...backupSheetConfig} />
+      <NativeStack.Screen
+        getComponent={() => ModalScreen}
         name={Routes.MODAL_SCREEN}
         options={{
           customStack: true,
@@ -254,40 +266,46 @@ function NativeStackNavigator() {
           topOffset: 0,
         }}
       />
-      <NativeStack.Screen component={RestoreSheet} name={Routes.RESTORE_SHEET} {...restoreSheetConfig} />
-      <NativeStack.Screen component={SignTransactionSheet} name={Routes.CONFIRM_REQUEST} {...signTransactionSheetConfig} />
-      <NativeStack.Screen component={ExpandedAssetSheet} name={Routes.CUSTOM_GAS_SHEET} {...customGasSheetConfig} />
-      <NativeStack.Screen component={QRScannerScreen} name={Routes.QR_SCANNER_SCREEN} {...qrScannerConfig} />
+      <NativeStack.Screen getComponent={() => RestoreSheet} name={Routes.RESTORE_SHEET} {...restoreSheetConfig} />
+      <NativeStack.Screen getComponent={() => SignTransactionSheet} name={Routes.CONFIRM_REQUEST} {...signTransactionSheetConfig} />
+      <NativeStack.Screen getComponent={() => ExpandedAssetSheet} name={Routes.CUSTOM_GAS_SHEET} {...customGasSheetConfig} />
+      <NativeStack.Screen getComponent={() => QRScannerScreen} name={Routes.QR_SCANNER_SCREEN} {...qrScannerConfig} />
       <NativeStack.Screen
-        component={PairHardwareWalletNavigator}
+        getComponent={() => PairHardwareWalletNavigator}
         name={Routes.PAIR_HARDWARE_WALLET_NAVIGATOR}
         {...pairHardwareWalletNavigatorConfig}
       />
       <NativeStack.Screen
-        component={HardwareWalletTxNavigator}
+        getComponent={() => HardwareWalletTxNavigator}
         name={Routes.HARDWARE_WALLET_TX_NAVIGATOR}
         {...hardwareWalletTxNavigatorConfig}
       />
-      <NativeStack.Screen component={AddWalletNavigator} name={Routes.ADD_WALLET_NAVIGATOR} {...addWalletNavigatorConfig} />
-      <NativeStack.Screen component={Portal} name={Routes.PORTAL} {...portalSheetConfig} />
-      {showKingOfTheHillTab && <NativeStack.Screen component={ActivitySheetScreen} name={Routes.PROFILE_SCREEN} {...activitySheetConfig} />}
+      <NativeStack.Screen getComponent={() => AddWalletNavigator} name={Routes.ADD_WALLET_NAVIGATOR} {...addWalletNavigatorConfig} />
+      <NativeStack.Screen getComponent={() => Portal} name={Routes.PORTAL} {...portalSheetConfig} />
+      {showKingOfTheHillTab && (
+        <NativeStack.Screen getComponent={() => ActivitySheetScreen} name={Routes.PROFILE_SCREEN} {...activitySheetConfig} />
+      )}
       {profilesEnabled && (
         <>
-          <NativeStack.Screen component={RegisterENSNavigator} name={Routes.REGISTER_ENS_NAVIGATOR} {...registerENSNavigatorConfig} />
           <NativeStack.Screen
-            component={ENSConfirmRegisterSheet}
+            getComponent={() => RegisterENSNavigator}
+            name={Routes.REGISTER_ENS_NAVIGATOR}
+            {...registerENSNavigatorConfig}
+          />
+          <NativeStack.Screen
+            getComponent={() => ENSConfirmRegisterSheet}
             name={Routes.ENS_CONFIRM_REGISTER_SHEET}
             {...ensConfirmRegisterSheetConfig}
           />
           <NativeStack.Screen
-            component={ENSAdditionalRecordsSheet}
+            getComponent={() => ENSAdditionalRecordsSheet}
             name={Routes.ENS_ADDITIONAL_RECORDS_SHEET}
             {...ensAdditionalRecordsSheetConfig}
           />
-          <NativeStack.Screen component={ProfileSheet} name={Routes.PROFILE_SHEET} {...profileConfig} />
-          <NativeStack.Screen component={ProfileSheet} name={Routes.PROFILE_PREVIEW_SHEET} {...profilePreviewConfig} />
+          <NativeStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_SHEET} {...profileConfig} />
+          <NativeStack.Screen getComponent={() => ProfileSheet} name={Routes.PROFILE_PREVIEW_SHEET} {...profilePreviewConfig} />
           <NativeStack.Screen
-            component={SelectENSSheet}
+            getComponent={() => SelectENSSheet}
             name={Routes.SELECT_ENS_SHEET}
             options={{
               allowsDragToDismiss: true,
@@ -299,73 +317,121 @@ function NativeStackNavigator() {
           />
         </>
       )}
-      <NativeStack.Screen component={SendFlowNavigator} name={Routes.SEND_SHEET_NAVIGATOR} />
-      <NativeStack.Screen component={NoNeedWCSheet} name={Routes.NO_NEED_WC_SHEET} {...basicSheetConfig} />
-      <NativeStack.Screen component={WalletConnectApprovalSheet} name={Routes.WALLET_CONNECT_APPROVAL_SHEET} {...basicSheetConfig} />
-      <NativeStack.Screen component={WalletConnectRedirectSheet} name={Routes.WALLET_CONNECT_REDIRECT_SHEET} {...basicSheetConfig} />
-      <NativeStack.Screen name={Routes.TRANSACTION_DETAILS} component={TransactionDetails} {...transactionDetailsConfig} />
-      <NativeStack.Screen name={Routes.OP_REWARDS_SHEET} component={RewardsSheet} {...opRewardsSheetConfig} />
-      <NativeStack.Screen name={Routes.NFT_OFFERS_SHEET} component={NFTOffersSheet} {...nftOffersSheetConfig} />
-      <NativeStack.Screen name={Routes.NFT_SINGLE_OFFER_SHEET} component={NFTSingleOfferSheet} {...nftSingleOfferSheetConfig} />
-      <NativeStack.Screen name={Routes.MINTS_SHEET} component={MintsSheet} {...mintsSheetConfig} />
-      <NativeStack.Screen component={AppIconUnlockSheet} name={Routes.APP_ICON_UNLOCK_SHEET} {...appIconUnlockSheetConfig} />
-      <NativeStack.Screen component={NetworkSelector} name={Routes.NETWORK_SELECTOR} {...panelConfig} />
-      <NativeStack.Screen component={ControlPanel} name={Routes.DAPP_BROWSER_CONTROL_PANEL} {...panelConfig} />
-      <NativeStack.Screen component={ClaimClaimablePanel} name={Routes.CLAIM_CLAIMABLE_PANEL} {...panelConfig} />
-      <NativeStack.Screen component={RevokeDelegationPanel} name={Routes.REVOKE_DELEGATION_PANEL} {...panelConfig} />
-      <NativeStack.Screen component={SwapScreen} name={Routes.SWAP} {...swapConfig} />
-      <NativeStack.Screen component={PerpsDepositScreen} name={Routes.PERPS_DEPOSIT_SCREEN} {...perpsDepositWithdrawalConfig} />
-      <NativeStack.Screen component={PolymarketDepositScreen} name={Routes.POLYMARKET_DEPOSIT_SCREEN} {...perpsDepositWithdrawalConfig} />
-      <NativeStack.Screen component={PerpsDetailScreen} name={Routes.PERPS_DETAIL_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={PerpsWithdrawalScreen} name={Routes.PERPS_WITHDRAWAL_SCREEN} {...perpsDepositWithdrawalConfig} />
+      <NativeStack.Screen getComponent={() => SendFlowNavigator} name={Routes.SEND_SHEET_NAVIGATOR} />
+      <NativeStack.Screen getComponent={() => NoNeedWCSheet} name={Routes.NO_NEED_WC_SHEET} {...basicSheetConfig} />
       <NativeStack.Screen
-        component={PolymarketWithdrawalScreen}
+        getComponent={() => WalletConnectApprovalSheet}
+        name={Routes.WALLET_CONNECT_APPROVAL_SHEET}
+        {...basicSheetConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => WalletConnectRedirectSheet}
+        name={Routes.WALLET_CONNECT_REDIRECT_SHEET}
+        {...basicSheetConfig}
+      />
+      <NativeStack.Screen name={Routes.TRANSACTION_DETAILS} getComponent={() => TransactionDetails} {...transactionDetailsConfig} />
+      <NativeStack.Screen name={Routes.OP_REWARDS_SHEET} getComponent={() => RewardsSheet} {...opRewardsSheetConfig} />
+      <NativeStack.Screen name={Routes.NFT_OFFERS_SHEET} getComponent={() => NFTOffersSheet} {...nftOffersSheetConfig} />
+      <NativeStack.Screen name={Routes.NFT_SINGLE_OFFER_SHEET} getComponent={() => NFTSingleOfferSheet} {...nftSingleOfferSheetConfig} />
+      <NativeStack.Screen name={Routes.MINTS_SHEET} getComponent={() => MintsSheet} {...mintsSheetConfig} />
+      <NativeStack.Screen getComponent={() => AppIconUnlockSheet} name={Routes.APP_ICON_UNLOCK_SHEET} {...appIconUnlockSheetConfig} />
+      <NativeStack.Screen getComponent={() => NetworkSelector} name={Routes.NETWORK_SELECTOR} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => ControlPanel} name={Routes.DAPP_BROWSER_CONTROL_PANEL} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => ClaimClaimablePanel} name={Routes.CLAIM_CLAIMABLE_PANEL} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => RevokeDelegationPanel} name={Routes.REVOKE_DELEGATION_PANEL} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => SwapScreen} name={Routes.SWAP} {...swapConfig} />
+      <NativeStack.Screen getComponent={() => PerpsDepositScreen} name={Routes.PERPS_DEPOSIT_SCREEN} {...perpsDepositWithdrawalConfig} />
+      <NativeStack.Screen
+        getComponent={() => PolymarketDepositScreen}
+        name={Routes.POLYMARKET_DEPOSIT_SCREEN}
+        {...perpsDepositWithdrawalConfig}
+      />
+      <NativeStack.Screen getComponent={() => PerpsDetailScreen} name={Routes.PERPS_DETAIL_SCREEN} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen
+        getComponent={() => PerpsWithdrawalScreen}
+        name={Routes.PERPS_WITHDRAWAL_SCREEN}
+        {...perpsDepositWithdrawalConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => PolymarketWithdrawalScreen}
         name={Routes.POLYMARKET_WITHDRAWAL_SCREEN}
         {...perpsDepositWithdrawalConfig}
       />
-      <NativeStack.Screen component={ExpandedAssetSheetV2} name={Routes.EXPANDED_ASSET_SHEET_V2} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={AirdropsSheet} name={Routes.AIRDROPS_SHEET} {...airdropsSheetConfig} />
-      <NativeStack.Screen component={ClaimAirdropSheet} name={Routes.CLAIM_AIRDROP_SHEET} {...claimAirdropSheetConfig} />
-      <NativeStack.Screen component={LogSheet} name={Routes.LOG_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={TokenLauncherScreen} name={Routes.TOKEN_LAUNCHER_SCREEN} {...tokenLauncherConfig} />
-      <NativeStack.Screen component={PerpsNavigator} name={Routes.PERPS_NAVIGATOR} {...perpsAccountStackConfig} />
-      <NativeStack.Screen component={PerpsTradeHistoryScreen} name={Routes.PERPS_TRADE_HISTORY_SCREEN} {...perpsAccountStackConfig} />
-      <NativeStack.Screen component={CreateTriggerOrderBottomSheet} name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={ClosePositionBottomSheet} name={Routes.CLOSE_POSITION_BOTTOM_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} {...learnSheetConfig} />
-      <NativeStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
-      <NativeStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => ExpandedAssetSheetV2} name={Routes.EXPANDED_ASSET_SHEET_V2} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen getComponent={() => AirdropsSheet} name={Routes.AIRDROPS_SHEET} {...airdropsSheetConfig} />
+      <NativeStack.Screen getComponent={() => ClaimAirdropSheet} name={Routes.CLAIM_AIRDROP_SHEET} {...claimAirdropSheetConfig} />
+      <NativeStack.Screen getComponent={() => LogSheet} name={Routes.LOG_SHEET} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => TokenLauncherScreen} name={Routes.TOKEN_LAUNCHER_SCREEN} {...tokenLauncherConfig} />
+      <NativeStack.Screen getComponent={() => PerpsNavigator} name={Routes.PERPS_NAVIGATOR} {...perpsAccountStackConfig} />
       <NativeStack.Screen
-        component={PerpsTradeDetailsSheet}
+        getComponent={() => PerpsTradeHistoryScreen}
+        name={Routes.PERPS_TRADE_HISTORY_SCREEN}
+        {...perpsAccountStackConfig}
+      />
+      <NativeStack.Screen
+        getComponent={() => CreateTriggerOrderBottomSheet}
+        name={Routes.CREATE_TRIGGER_ORDER_BOTTOM_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen getComponent={() => ClosePositionBottomSheet} name={Routes.CLOSE_POSITION_BOTTOM_SHEET} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        getComponent={() => KingOfTheHillExplainSheet}
+        name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET}
+        {...learnSheetConfig}
+      />
+      <NativeStack.Screen getComponent={() => PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
+      <NativeStack.Screen getComponent={() => PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        getComponent={() => PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}
         options={({ route }) => ({
           ...panelConfig.options({ route }),
           interactWithScrollView: false,
         })}
       />
-      <NativeStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={PolymarketMarketSheet} name={Routes.POLYMARKET_MARKET_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={PolymarketMarketDescriptionSheet} name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={PolymarketNewPositionSheet} name={Routes.POLYMARKET_NEW_POSITION_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={PolymarketAccountScreen} name={Routes.POLYMARKET_ACCOUNT_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} {...perpsAccountStackConfig} />
-      <NativeStack.Screen component={PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} {...learnSheetConfig} />
-      <NativeStack.Screen component={PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
-      <NativeStack.Screen component={RnbwStakingLearnScreen} name={Routes.RNBW_STAKING_LEARN_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
-      <NativeStack.Screen component={RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} {...panelConfig} />
       <NativeStack.Screen
-        component={PolymarketBrowseEventsScreen}
+        getComponent={() => PolymarketEventScreen}
+        name={Routes.POLYMARKET_EVENT_SCREEN}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen
+        getComponent={() => PolymarketRedeemPositionSheet}
+        name={Routes.POLYMARKET_MANAGE_POSITION_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen getComponent={() => PolymarketMarketSheet} name={Routes.POLYMARKET_MARKET_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        getComponent={() => PolymarketMarketDescriptionSheet}
+        name={Routes.POLYMARKET_MARKET_DESCRIPTION_SHEET}
+        {...panelConfig}
+      />
+      <NativeStack.Screen getComponent={() => PolymarketNewPositionSheet} name={Routes.POLYMARKET_NEW_POSITION_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        getComponent={() => PolymarketAccountScreen}
+        name={Routes.POLYMARKET_ACCOUNT_SCREEN}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen getComponent={() => PolymarketNavigator} name={Routes.POLYMARKET_NAVIGATOR} {...perpsAccountStackConfig} />
+      <NativeStack.Screen getComponent={() => PolymarketExplainSheet} name={Routes.POLYMARKET_EXPLAIN_SHEET} {...learnSheetConfig} />
+      <NativeStack.Screen getComponent={() => PolymarketSellPositionSheet} name={Routes.POLYMARKET_SELL_POSITION_SHEET} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => RnbwAirdropScreen} name={Routes.RNBW_AIRDROP_SCREEN} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen getComponent={() => RnbwRewardsClaimSheet} name={Routes.RNBW_REWARDS_CLAIM_SHEET} {...panelConfig} />
+      <NativeStack.Screen getComponent={() => RnbwRewardsEstimateSheet} name={Routes.RNBW_REWARDS_ESTIMATE_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        getComponent={() => RnbwStakingLearnScreen}
+        name={Routes.RNBW_STAKING_LEARN_SCREEN}
+        {...expandedAssetSheetV2Config}
+      />
+      <NativeStack.Screen getComponent={() => RnbwStakingScreen} name={Routes.RNBW_STAKING_SCREEN} {...expandedAssetSheetV2Config} />
+      <NativeStack.Screen getComponent={() => RnbwUnstakeSheet} name={Routes.RNBW_UNSTAKE_SHEET} {...panelConfig} />
+      <NativeStack.Screen
+        getComponent={() => PolymarketBrowseEventsScreen}
         name={Routes.POLYMARKET_BROWSE_EVENTS_SCREEN}
         {...expandedAssetSheetV2Config}
       />
-      <NativeStack.Screen component={WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} {...walletErrorSheetConfig} />
-      <NativeStack.Screen component={RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} {...learnSheetConfig} />
+      <NativeStack.Screen getComponent={() => WalletErrorSheet} name={Routes.WALLET_ERROR_SHEET} {...walletErrorSheetConfig} />
+      <NativeStack.Screen getComponent={() => RnbwMembershipTiersSheet} name={Routes.RNBW_MEMBERSHIP_TIERS_SHEET} {...learnSheetConfig} />
     </NativeStack.Navigator>
   );
 }

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -692,30 +692,42 @@ function SwipeNavigatorScreens() {
       tabBar={TabBarContainer}
       tabBarPosition="bottom"
     >
-      <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.WALLET_SCREEN] }} />
-      <Swipe.Screen component={DiscoverScreen} name={Routes.DISCOVER_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.DISCOVER_SCREEN] }} />
+      <Swipe.Screen
+        getComponent={() => WalletScreen}
+        name={Routes.WALLET_SCREEN}
+        options={{ title: TAB_BAR_ICONS[Routes.WALLET_SCREEN] }}
+      />
+      <Swipe.Screen
+        getComponent={() => DiscoverScreen}
+        name={Routes.DISCOVER_SCREEN}
+        options={{ title: TAB_BAR_ICONS[Routes.DISCOVER_SCREEN] }}
+      />
       {showDappBrowserTab && (
-        <Swipe.Screen component={DappBrowser} name={Routes.DAPP_BROWSER_SCREEN} options={{ title: 'tabDappBrowser' }} />
+        <Swipe.Screen getComponent={() => DappBrowser} name={Routes.DAPP_BROWSER_SCREEN} options={{ title: 'tabDappBrowser' }} />
       )}
       {showKingOfTheHillTab ? (
         <Swipe.Screen
-          component={KingOfTheHillScreen}
+          getComponent={() => KingOfTheHillScreen}
           name={Routes.KING_OF_THE_HILL}
           options={{ title: TAB_BAR_ICONS[Routes.KING_OF_THE_HILL] }}
         />
       ) : (
-        <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.PROFILE_SCREEN] }} />
+        <Swipe.Screen
+          getComponent={() => ProfileScreen}
+          name={Routes.PROFILE_SCREEN}
+          options={{ title: TAB_BAR_ICONS[Routes.PROFILE_SCREEN] }}
+        />
       )}
       {showRnbwRewardsOrMembershipTab &&
         (showRnbwMembership ? (
           <Swipe.Screen
-            component={RnbwMembershipScreen}
+            getComponent={() => RnbwMembershipScreen}
             name={Routes.RNBW_MEMBERSHIP_SCREEN}
             options={{ title: TAB_BAR_ICONS[Routes.RNBW_MEMBERSHIP_SCREEN] }}
           />
         ) : (
           <Swipe.Screen
-            component={RnbwRewardsScreen}
+            getComponent={() => RnbwRewardsScreen}
             name={Routes.RNBW_REWARDS_SCREEN}
             options={{ title: TAB_BAR_ICONS[Routes.RNBW_REWARDS_SCREEN] }}
           />

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -32,7 +32,6 @@ import { AssetUpdateTransactionWatcher } from '@/components/asset-update-transac
 import { BlurGradient } from '@/components/blur/BlurGradient';
 import { BrowserTabBarContextProvider, useBrowserTabBarContext } from '@/components/DappBrowser/BrowserContext';
 import { BROWSER_BACKGROUND_COLOR_DARK, BROWSER_BACKGROUND_COLOR_LIGHT } from '@/components/DappBrowser/constants';
-import { DappBrowser } from '@/components/DappBrowser/DappBrowser';
 import { discoverOpenSearchFnRef, discoverScrollToTopFnRef } from '@/components/Discover/DiscoverScreenContext';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { FlexItem } from '@/components/layout';
@@ -53,9 +52,6 @@ import useExperimentalFlag from '@/config/experimentalHooks';
 import { Box, ColorModeProvider, Column, Columns, globalColors, useColorMode } from '@/design-system';
 import { IS_TEST } from '@/env';
 import { useShowKingOfTheHill } from '@/features/king-of-the-hill/hooks/useShowKingOfTheHill';
-import { KingOfTheHillScreen } from '@/features/king-of-the-hill/screens/KingOfTheHillScreen';
-import { RnbwMembershipScreen } from '@/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen';
-import { RnbwRewardsScreen } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/RnbwRewardsScreen';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import useAccountSettings from '@/hooks/useAccountSettings';
@@ -67,8 +63,6 @@ import {
   RecyclerListViewScrollToTopProvider,
   useRecyclerListViewScrollToTopContext,
 } from '@/navigation/RecyclerListViewScrollToTopContext';
-import DiscoverScreen from '@/screens/DiscoverScreen';
-import WalletScreen from '@/screens/WalletScreen/WalletScreen';
 import { useBrowserStore } from '@/state/browser/browserStore';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
 import { setActiveRoute, useNavigationStore } from '@/state/navigation/navigationStore';
@@ -76,7 +70,6 @@ import { darkModeThemeColors, lightModeThemeColors } from '@/styles/colors';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import deviceUtils, { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
 
-import ProfileScreen from '../screens/ProfileScreen';
 import { MainListProvider, useMainList } from './MainListContext';
 import Routes, { type Route } from './routesNames';
 
@@ -693,27 +686,31 @@ function SwipeNavigatorScreens() {
       tabBarPosition="bottom"
     >
       <Swipe.Screen
-        getComponent={() => WalletScreen}
+        getComponent={() => require('@/screens/WalletScreen/WalletScreen').default}
         name={Routes.WALLET_SCREEN}
         options={{ title: TAB_BAR_ICONS[Routes.WALLET_SCREEN] }}
       />
       <Swipe.Screen
-        getComponent={() => DiscoverScreen}
+        getComponent={() => require('@/screens/DiscoverScreen').default}
         name={Routes.DISCOVER_SCREEN}
         options={{ title: TAB_BAR_ICONS[Routes.DISCOVER_SCREEN] }}
       />
       {showDappBrowserTab && (
-        <Swipe.Screen getComponent={() => DappBrowser} name={Routes.DAPP_BROWSER_SCREEN} options={{ title: 'tabDappBrowser' }} />
+        <Swipe.Screen
+          getComponent={() => require('@/components/DappBrowser/DappBrowser').DappBrowser}
+          name={Routes.DAPP_BROWSER_SCREEN}
+          options={{ title: 'tabDappBrowser' }}
+        />
       )}
       {showKingOfTheHillTab ? (
         <Swipe.Screen
-          getComponent={() => KingOfTheHillScreen}
+          getComponent={() => require('@/features/king-of-the-hill/screens/KingOfTheHillScreen').KingOfTheHillScreen}
           name={Routes.KING_OF_THE_HILL}
           options={{ title: TAB_BAR_ICONS[Routes.KING_OF_THE_HILL] }}
         />
       ) : (
         <Swipe.Screen
-          getComponent={() => ProfileScreen}
+          getComponent={() => require('../screens/ProfileScreen').default}
           name={Routes.PROFILE_SCREEN}
           options={{ title: TAB_BAR_ICONS[Routes.PROFILE_SCREEN] }}
         />
@@ -721,13 +718,15 @@ function SwipeNavigatorScreens() {
       {showRnbwRewardsOrMembershipTab &&
         (showRnbwMembership ? (
           <Swipe.Screen
-            getComponent={() => RnbwMembershipScreen}
+            getComponent={() =>
+              require('@/features/rnbw-membership/screens/rnbw-membership-screen/RnbwMembershipScreen').RnbwMembershipScreen
+            }
             name={Routes.RNBW_MEMBERSHIP_SCREEN}
             options={{ title: TAB_BAR_ICONS[Routes.RNBW_MEMBERSHIP_SCREEN] }}
           />
         ) : (
           <Swipe.Screen
-            getComponent={() => RnbwRewardsScreen}
+            getComponent={() => require('@/features/rnbw-rewards/screens/rnbw-rewards-screen/RnbwRewardsScreen').RnbwRewardsScreen}
             name={Routes.RNBW_REWARDS_SCREEN}
             options={{ title: TAB_BAR_ICONS[Routes.RNBW_REWARDS_SCREEN] }}
           />


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

At launch the app initializes ~3,400 modules, many of them screens that aren't needed until the user navigates to them. This PR defers screen module initialization by registering screens with React Navigation's `getComponent` instead of `component`, so a screen's module graph is only required when the screen is first rendered.

Each `getComponent` callback uses an inline `require(...)` rather than a static import, so the screen module is not pulled in at the navigator file's evaluation time.

Measured on an iPhone 17 Pro simulator using a temporary local Metro require hook, 10s after the app module loads:

| Approach | Modules initialized |
| --- | ---: |
| Baseline (`origin/develop`) | 3425 |
| `getComponent` + static imports (relying on Metro `inlineRequires`) | 3301 |
| `getComponent` + manual inline `require(...)` | 3108 |

317 fewer initialized modules vs. baseline (~9.3%). TTI is not meaningfully changed; memory usage drops by ~10 MB (~2.5%).

## Alternatives considered

`getComponent={() => Screen}` with static imports relying on Metro's `inlineRequires` transform initialized 193 more modules than manual inline `require`, so the manual form was kept.

## Screen recordings / screenshots

N/A — navigation registration refactor only.

## What to test

- Smoke test via e2e tests
- Re-run perf tests a few times to make sure it leads to improvements
