### PR TITLE
refactor: drop ios/android globals for direct Platform.OS imports

### DIFF
--- a/globalVariables.js
+++ b/globalVariables.js
@@ -8,8 +8,6 @@ import magicMemo from '@/utils/magicMemo';
 import { useTheme } from './src/theme/ThemeContext';
 
 export default {
-  android: Platform.OS === 'android',
-  ios: Platform.OS === 'ios',
   IS_DEV: (typeof __DEV__ === 'boolean' && __DEV__) || !!Number(ENABLE_DEV_MODE),
   magicMemo,
   useCallback,

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -4,14 +4,6 @@ declare module '*.jpeg';
 declare module '*.jpg';
 
 /**
- * @deprecated use `IS_ANDROID` from `@/env`
- */
-declare let android: boolean;
-/**
- * @deprecated use `IS_IOS` from `@/env`
- */
-declare let ios: boolean;
-/**
  * @deprecated use `IS_WEB` from `@/env`
  */
 declare let web: boolean;

--- a/src/components/AddFundsInterstitial.js
+++ b/src/components/AddFundsInterstitial.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { useRoute } from '@react-navigation/native';
 import { captureMessage } from '@sentry/react-native';
@@ -105,12 +105,12 @@ const Subtitle = styled(Title).attrs(({ theme: { colors } }) => ({
 
 const AmountText = styled(Text).attrs(({ children }) => ({
   align: 'center',
-  children: android ? `  ${children.join('')}  ` : children,
+  children: Platform.OS === 'android' ? `  ${children.join('')}  ` : children,
   letterSpacing: 'roundedTightest',
   size: 'bigger',
   weight: 'heavy',
 }))(({ color }) => ({
-  ...(android ? padding.object(15, 4.5) : padding.object(24, 15, 25)),
+  ...(Platform.OS === 'android' ? padding.object(15, 4.5) : padding.object(24, 15, 25)),
   alignSelf: 'center',
   textShadowColor: color,
   textShadowOffset: { height: 0, width: 0 },
@@ -125,12 +125,12 @@ const AmountButtonWrapper = styled(Row).attrs({
   marginLeft: isVeryNarrowPhone ? 5 : 7.5,
   marginRight: isVeryNarrowPhone ? 5 : 7.5,
 })({
-  ...(android && { width: isVeryNarrowPhone ? 95 : 100 }),
+  ...(Platform.OS === 'android' && { width: isVeryNarrowPhone ? 95 : 100 }),
 });
 
-const InnerBPA = android ? ButtonPressAnimation : ({ children }) => children;
+const InnerBPA = Platform.OS === 'android' ? ButtonPressAnimation : ({ children }) => children;
 
-const Wrapper = android ? ScaleButtonZoomableAndroid : AmountBPA;
+const Wrapper = Platform.OS === 'android' ? ScaleButtonZoomableAndroid : AmountBPA;
 
 const AmountButton = ({ amount, backgroundColor, color, onPress }) => {
   const handlePress = useCallback(() => onPress?.(amount), [amount, onPress]);
@@ -148,13 +148,13 @@ const AmountButton = ({ amount, backgroundColor, color, onPress }) => {
 
   return (
     <AmountButtonWrapper>
-      <Wrapper disabled={android} onPress={handlePress}>
+      <Wrapper disabled={Platform.OS === 'android'} onPress={handlePress}>
         <ShadowStack
           {...position.coverAsObject}
           backgroundColor={backgroundColor}
           borderRadius={25}
           shadows={shadows?.[backgroundColor] || []}
-          {...(android && {
+          {...(Platform.OS === 'android' && {
             height: 80,
             width: isVeryNarrowPhone ? 95 : 100,
           })}
@@ -219,7 +219,9 @@ const AddFundsInterstitial = ({ network }) => {
     <Container isSmallPhone={isSmallPhone}>
       {network === Network.mainnet ? (
         <Fragment>
-          <Title>{ios ? i18n.t(i18n.l.add_funds.to_get_started_ios) : i18n.t(i18n.l.add_funds.to_get_started_android)}</Title>
+          <Title>
+            {Platform.OS === 'ios' ? i18n.t(i18n.l.add_funds.to_get_started_ios) : i18n.t(i18n.l.add_funds.to_get_started_android)}
+          </Title>
           <Row justify="space-between" marginVertical={30}>
             <AmountButton amount={100} backgroundColor={colors.swapPurple} color={colors.neonSkyblue} onPress={handlePressAmount} />
             <AmountButton amount={200} backgroundColor={colors.swapPurple} color={colors.neonSkyblue} onPress={handlePressAmount} />

--- a/src/components/ContactRowInfoButton.js
+++ b/src/components/ContactRowInfoButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { startCase } from 'lodash';
 import { ContextMenuButton } from 'react-native-ios-context-menu';
@@ -150,7 +150,7 @@ const ContactRowInfoButton = ({ children, item, chainId, scaleTo }) => {
       <ContextMenuButton
         activeOpacity={0}
         menuConfig={menuConfig}
-        {...(android ? { onPress: onPressAndroid } : {})}
+        {...(Platform.OS === 'android' ? { onPress: onPressAndroid } : {})}
         isMenuPrimaryAction
         onPressMenuItem={handlePressMenuItem}
         useActionSheetFallback={false}

--- a/src/components/ExchangeInput.js
+++ b/src/components/ExchangeInput.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback, useState } from 'react';
-import { InteractionManager } from 'react-native';
+import { InteractionManager, Platform } from 'react-native';
 
 import TextInputMask from 'react-native-text-input-mask';
 
@@ -24,7 +24,7 @@ const Input = styled(TextInputMask).attrs({
 })(props => ({
   flex: 1,
   ...buildTextStyles.object(props),
-  ...(android ? { fontWeight: 'normal' } : {}),
+  ...(Platform.OS === 'android' ? { fontWeight: 'normal' } : {}),
 }));
 
 const ExchangeInput = (

--- a/src/components/L2Disclaimer.js
+++ b/src/components/L2Disclaimer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import RadialGradient from 'react-native-radial-gradient';
 
@@ -40,7 +41,11 @@ const L2Disclaimer = ({
   return (
     <>
       <ButtonPressAnimation marginBottom={marginBottom} onPress={onPress} scaleTo={0.95}>
-        <Row borderRadius={16} marginHorizontal={marginHorizontal} style={padding.object(android ? 6 : 10, 10, android ? 6 : 10, 10)}>
+        <Row
+          borderRadius={16}
+          marginHorizontal={marginHorizontal}
+          style={padding.object(Platform.OS === 'android' ? 6 : 10, 10, Platform.OS === 'android' ? 6 : 10, 10)}
+        >
           <RadialGradient {...radialGradientProps} borderRadius={16} radius={600} />
           <Column justify="center">
             <ChainImage chainId={chainId} position="relative" size={20} />

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import styled from '@/framework/ui/styled-thing';
 import formatURLForDisplay from '@/utils/formatURLForDisplay';
@@ -15,7 +16,7 @@ const Container = styled(RowWithMargins).attrs({
   align: 'center',
   margin: 5,
 })({
-  ...(android ? { paddingVertical: 10 } : { paddingTop: 14 }),
+  ...(Platform.OS === 'android' ? { paddingVertical: 10 } : { paddingTop: 14 }),
 });
 
 const Link = ({

--- a/src/components/activity-list/ActivityList.tsx
+++ b/src/components/activity-list/ActivityList.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, View, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
+import { Platform, StyleSheet, View, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 
 import { LegendList, type LegendListRef } from '@legendapp/list';
 import { type SharedValue } from 'react-native-reanimated';
@@ -39,7 +39,7 @@ const sx = StyleSheet.create({
 
 const keyExtractor = (data: ListItems) => data.key;
 
-const LoadingSpinner = android ? Spinner : ActivityIndicator;
+const LoadingSpinner = Platform.OS === 'android' ? Spinner : ActivityIndicator;
 
 const FooterWrapper = styled(ButtonPressAnimation)({
   alignItems: 'center',

--- a/src/components/animations/CheckmarkAnimation.tsx
+++ b/src/components/animations/CheckmarkAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import RadialGradient from 'react-native-radial-gradient';
 import Animated, {
@@ -128,7 +129,7 @@ export function CheckmarkAnimation() {
           <RadialGradient
             center={[60, 60]}
             colors={
-              android ? colors.gradients.checkmarkAnimation : ['rgba(31,194,74,0.00)', 'rgba(31,194,74,0.03)']
+              Platform.OS === 'android' ? colors.gradients.checkmarkAnimation : ['rgba(31,194,74,0.00)', 'rgba(31,194,74,0.03)']
               // https://github.com/surajitsarkar19/react-native-radial-gradient/issues/9
             }
             stops={[1, 0.5]}
@@ -153,7 +154,7 @@ export function CheckmarkAnimation() {
           <RadialGradient
             center={[60, 60]}
             colors={
-              android ? colors.gradients.checkmarkAnimation : ['rgba(31,194,74,0.00)', 'rgba(31,194,74,0.06)']
+              Platform.OS === 'android' ? colors.gradients.checkmarkAnimation : ['rgba(31,194,74,0.00)', 'rgba(31,194,74,0.06)']
               // https://github.com/surajitsarkar19/react-native-radial-gradient/issues/9
             }
             stops={[1, 0.5]}

--- a/src/components/asset-list/AssetListHeader.tsx
+++ b/src/components/asset-list/AssetListHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, type ComponentProps } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -41,8 +41,8 @@ const AccountName = styled(TruncatedText).attrs({
   truncationLength: 4,
   weight: 'heavy',
 })({
-  height: android ? 35 : 30,
-  marginBottom: android ? 8 : 0,
+  height: Platform.OS === 'android' ? 35 : 30,
+  marginBottom: Platform.OS === 'android' ? 8 : 0,
   marginTop: 2,
   maxWidth: ({ maxWidth }: { maxWidth: number }) => maxWidth,
   paddingRight: 6,
@@ -51,7 +51,7 @@ const AccountName = styled(TruncatedText).attrs({
 const DropdownArrow = styled(Centered)({
   borderRadius: 15,
   height: dropdownArrowWidth,
-  marginTop: android ? 9 : 2,
+  marginTop: Platform.OS === 'android' ? 9 : 2,
   width: dropdownArrowWidth,
 });
 

--- a/src/components/asset-list/RecyclerAssetList2/core/useLayoutItemAnimator.ts
+++ b/src/components/asset-list/RecyclerAssetList2/core/useLayoutItemAnimator.ts
@@ -1,5 +1,5 @@
 import { useMemo, type MutableRefObject } from 'react';
-import { LayoutAnimation, type LayoutAnimationConfig } from 'react-native';
+import { LayoutAnimation, Platform, type LayoutAnimationConfig } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BaseItemAnimator } from 'recyclerlistview';
@@ -23,7 +23,7 @@ const springAnimation: LayoutAnimationConfig = {
   duration: 200,
   update: {
     initialVelocity: 0,
-    springDamping: ios ? 1 : 3,
+    springDamping: Platform.OS === 'ios' ? 1 : 3,
     type: LayoutAnimation.Types.spring,
   },
 };

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileAvatarRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text as NativeText, Animated as RNAnimated } from 'react-native';
+import { Text as NativeText, Platform, Animated as RNAnimated } from 'react-native';
 
 import Animated, { Easing, useAnimatedStyle, useDerivedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -204,7 +204,7 @@ export const EmojiAvatar = React.memo(function EmojiAvatar({ size }: { size: num
       <Box background="accent" borderRadius={size / 2} height={{ custom: size }} width={{ custom: size }}>
         <Cover alignHorizontal="center" alignVertical="center">
           <Box>
-            <NativeText style={{ fontSize: ios ? 48 : 36, color: 'white' }}>
+            <NativeText style={{ fontSize: Platform.OS === 'ios' ? 48 : 36, color: 'white' }}>
               {typeof accountSymbol === 'string' && getFirstGrapheme(accountSymbol.toUpperCase())}
             </NativeText>
           </Box>

--- a/src/components/audio/AudioPlayer.js
+++ b/src/components/audio/AudioPlayer.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { WebView } from 'react-native-webview';
 
@@ -14,7 +14,7 @@ const Container = styled(FlexItem)({
 
 const StyledWebView = styled(WebView)({
   backgroundColor: ({ theme: { colors } }) => colors.transparent,
-  marginTop: android ? 30 : 50,
+  marginTop: Platform.OS === 'android' ? 30 : 50,
 });
 
 const formatColor = color => (color && typeof color === 'string' ? color.replace('#', '') : null);
@@ -66,7 +66,7 @@ export default function AudioPlayer({ fontColor, imageColor, uri }) {
       () => {
         setReady(true);
       },
-      ios ? 500 : 800
+      Platform.OS === 'ios' ? 500 : 800
     );
   }, []);
 

--- a/src/components/avatar-builder/EmojiContent.tsx
+++ b/src/components/avatar-builder/EmojiContent.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { TouchableOpacity as GHTouchableOpacity } from 'react-native-gesture-handler';
 
@@ -52,7 +52,7 @@ const EmojiContent = ({ data, columns, onEmojiSelect, cellSize, fontSize }: Prop
                 width: cellSize,
               },
             };
-            return ios ? (
+            return Platform.OS === 'ios' ? (
               <TouchableOpacity activeOpacity={0.5} {...touchableProps}>
                 <Text
                   style={{

--- a/src/components/avatar-builder/EmojiSelector.tsx
+++ b/src/components/avatar-builder/EmojiSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
-import { Dimensions, StyleSheet, View, type ViewStyle } from 'react-native';
+import { Dimensions, Platform, StyleSheet, View, type ViewStyle } from 'react-native';
 
 import {
   State as GestureHandlerState,
@@ -49,7 +49,13 @@ type Props = {
   columns: number;
 };
 
-export const EmojiSelector = ({ columns = 7, showSectionTitles = true, showTabs = ios, onEmojiSelected, ...other }: Props) => {
+export const EmojiSelector = ({
+  columns = 7,
+  showSectionTitles = true,
+  showTabs = Platform.OS === 'ios',
+  onEmojiSelected,
+  ...other
+}: Props) => {
   const { colors } = useTheme();
   const [allEmojiList, setAllEmojiList] = useState<AllEmojiEntry[]>([]);
   const [isReady, setIsReady] = useState(false);
@@ -147,7 +153,7 @@ export const EmojiSelector = ({ columns = 7, showSectionTitles = true, showTabs 
   };
 
   const handleScroll = (event: ScrollEvent, offsetX: number, offsetY: number) => {
-    if (ios && !blockCategories.current) {
+    if (Platform.OS === 'ios' && !blockCategories.current) {
       const nextSection = allEmojiList[(currentIndex.current + 1) * 2] as AllEmojiContentEntry;
 
       const currentSection = allEmojiList[currentIndex.current * 2] as AllEmojiContentEntry;
@@ -207,7 +213,7 @@ export const EmojiSelector = ({ columns = 7, showSectionTitles = true, showTabs 
           overlayStyle.bottom = -3000;
         }
 
-        return ios ? (
+        return Platform.OS === 'ios' ? (
           <View
             style={[
               sx.header,

--- a/src/components/avatar-builder/constants.ts
+++ b/src/components/avatar-builder/constants.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 export const EMOJIS_CONTAINER_HORIZONTAL_MARGIN = 10;
 export const EMOJIS_TOP_OFFSET = 35;
-export const EMOJI_FONT_SIZE_OFFSET = ios ? 15 : 22;
+export const EMOJI_FONT_SIZE_OFFSET = Platform.OS === 'ios' ? 15 : 22;

--- a/src/components/buttons/MiniButton.js
+++ b/src/components/buttons/MiniButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import styled from '@/framework/ui/styled-thing';
 import ShadowStack from '@/react-native-shadow-stack';
@@ -56,7 +56,7 @@ export default function MiniButton({
 
   const content = (
     <Content
-      backgroundColor={android ? (disabled ? colors.lightGrey : backgroundColor || colors.appleBlue) : 'none'}
+      backgroundColor={Platform.OS === 'android' ? (disabled ? colors.lightGrey : backgroundColor || colors.appleBlue) : 'none'}
       disablePadding={disablePadding}
       hasLeadingIcon={hasLeadingIcon}
       height={height ? height : small ? 27 : 30}
@@ -66,7 +66,7 @@ export default function MiniButton({
           align="center"
           color={color || colors.whiteLabel}
           letterSpacing={letterSpacing}
-          lineHeight={android ? 19 : null}
+          lineHeight={Platform.OS === 'android' ? 19 : null}
           weight={weight || 'bold'}
         >
           {children}
@@ -89,7 +89,7 @@ export default function MiniButton({
       <View style={{ borderRadius }}>
         <ShadowStack
           {...position.coverAsObject}
-          backgroundColor={android ? 'none' : disabled ? colors.lightGrey : backgroundColor || colors.appleBlue}
+          backgroundColor={Platform.OS === 'android' ? 'none' : disabled ? colors.lightGrey : backgroundColor || colors.appleBlue}
           borderRadius={borderRadius}
           height={height}
           shadows={hideShadow ? shadows.none : disabled ? shadows.disabled : shadows.default}

--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButtonContent.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useState, type PropsWithChildren } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import {
   State as GestureHandlerState,
@@ -238,8 +238,8 @@ function HoldToAuthorizeButtonContent2({
             <Content backgroundColor={bgColor} height={height} smallButton={smallButton} tinyButton={tinyButton}>
               {children ?? (
                 <Fragment>
-                  {!android && !disabled && <HoldToAuthorizeButtonIcon sharedValue={longPressProgress} />}
-                  {(loading || (android && isAuthorizing)) && <LoadingSpinner />}
+                  {Platform.OS !== 'android' && !disabled && <HoldToAuthorizeButtonIcon sharedValue={longPressProgress} />}
+                  {(loading || (Platform.OS === 'android' && isAuthorizing)) && <LoadingSpinner />}
                   <Label
                     label={buttonLabel}
                     showIcon={showBiometryIcon && !isAuthorizing}

--- a/src/components/buttons/rainbow-button/RainbowButton.tsx
+++ b/src/components/buttons/rainbow-button/RainbowButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 
@@ -85,7 +85,7 @@ const Shadow = styled(ShadowView)(({ height, strokeWidth, isDarkMode, disabled, 
   backgroundColor: colors.white,
   borderRadius: height / 2 + strokeWidth,
   height,
-  opacity: isDarkMode && disabled ? 0 : android ? 1 : 0.2,
+  opacity: isDarkMode && disabled ? 0 : Platform.OS === 'android' ? 1 : 0.2,
   position: 'absolute',
   width,
 }));

--- a/src/components/buttons/rainbow-button/RainbowButtonBackground.tsx
+++ b/src/components/buttons/rainbow-button/RainbowButtonBackground.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 import RadialGradient from 'react-native-radial-gradient';
@@ -114,14 +114,15 @@ const OuterGradient = styled(RainbowButtonGradient).attrs(({ disabled, type, gra
   zIndex: -1,
 }));
 
-const WrapperView = android
-  ? styled(View)({
-      height: ({ height }: any) => height,
-      overflow: 'hidden',
-      position: 'absolute',
-      width: ({ width }: any) => width,
-    })
-  : ({ children }: any) => children;
+const WrapperView =
+  Platform.OS === 'android'
+    ? styled(View)({
+        height: ({ height }: any) => height,
+        overflow: 'hidden',
+        position: 'absolute',
+        width: ({ width }: any) => width,
+      })
+    : ({ children }: any) => children;
 
 type RainbowButtonBackgroundProps = {
   disabled: boolean;

--- a/src/components/cards/FeaturedMintCard.tsx
+++ b/src/components/cards/FeaturedMintCard.tsx
@@ -164,7 +164,7 @@ export function FeaturedMintCard() {
                       style={{
                         height: '100%',
                         width: '100%',
-                        backgroundColor: `rgba(22, 22, 22, ${ios ? 0.5 : 0.8})`,
+                        backgroundColor: `rgba(22, 22, 22, ${Platform.OS === 'ios' ? 0.5 : 0.8})`,
                       }}
                     />
                   </Cover>

--- a/src/components/coin-row/CoinName.js
+++ b/src/components/coin-row/CoinName.js
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import styled from '@/framework/ui/styled-thing';
 
 import { TruncatedText } from '../text';
@@ -9,7 +11,7 @@ const CoinName = styled(TruncatedText).attrs(({ color, size, theme: { colors } }
   size: size || 'lmedium',
   weight: 'semibold',
 }))({
-  marginTop: android ? 1.5 : 0,
+  marginTop: Platform.OS === 'android' ? 1.5 : 0,
   paddingRight: ({ paddingRight = 19 }) => paddingRight,
 });
 

--- a/src/components/coin-row/SendCoinRow.js
+++ b/src/components/coin-row/SendCoinRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableWithoutFeedback } from 'react-native';
+import { Platform, TouchableWithoutFeedback } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -22,7 +22,7 @@ const isTinyPhone = deviceUtils.dimensions.height <= 568;
 const selectedHeight = isTinyPhone ? 50 : isSmallPhone ? 64 : 70;
 
 const containerStyles = {
-  paddingTop: android ? 9 : 19,
+  paddingTop: Platform.OS === 'android' ? 9 : 19,
 };
 
 const NativeAmountBubble = styled(LinearGradient).attrs(({ theme: { colors } }) => ({

--- a/src/components/contacts/ContactRow.js
+++ b/src/components/contacts/ContactRow.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import useENSAvatar from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
@@ -50,7 +50,7 @@ const ContactName = styled(TruncatedText).attrs(({ lite }) => ({
   size: 'lmedium',
   weight: lite ? 'regular' : 'medium',
 }))({
-  height: ios ? 22 : 26,
+  height: Platform.OS === 'ios' ? 22 : 26,
   width: ({ deviceWidth }) => deviceWidth - 90,
 });
 
@@ -61,7 +61,7 @@ const css = {
 
 const sx = StyleSheet.create({
   bottomRowText: {
-    marginTop: ios ? 0 : -4.5,
+    marginTop: Platform.OS === 'ios' ? 0 : -4.5,
   },
 });
 
@@ -133,7 +133,7 @@ const ContactRow = ({ address, color, nickname, symmetricalMargins, ...props }, 
         ) : (
           <ContactAvatar color={bgColor} marginRight={10} size="medium" value={emojiAvatar} />
         )}
-        <Column justify={ios ? 'space-between' : 'center'}>
+        <Column justify={Platform.OS === 'ios' ? 'space-between' : 'center'}>
           {accountType === 'accounts' || accountType === 'watching' ? (
             <Fragment>
               {cleanedUpLabel || ens ? (

--- a/src/components/contacts/SwipeableContactRow.js
+++ b/src/components/contacts/SwipeableContactRow.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useImperativeHandle, useRef } from 'react';
-import { Animated } from 'react-native';
+import { Animated, Platform } from 'react-native';
 
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 
@@ -18,7 +18,7 @@ import showDeleteContactActionSheet from './showDeleteContactActionSheet';
 
 const AnimatedCentered = Animated.createAnimatedComponent(Centered);
 
-const styles = [margin.object(0, 10, android ? 0 : 3, 10), position.sizeAsObject(35)];
+const styles = [margin.object(0, 10, Platform.OS === 'android' ? 0 : 3, 10), position.sizeAsObject(35)];
 
 const RightAction = ({ onPress, progress, text, type, x }) => {
   const isEdit = type === 'edit';

--- a/src/components/context-menu/ContextMenuButton.js
+++ b/src/components/context-menu/ContextMenuButton.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { ContextMenuButton as IOSContextMenuButton } from 'react-native-ios-context-menu';
 
@@ -9,7 +10,7 @@ export default function ContextMenuButton({ children, hitSlop = 0, menuItems, me
     <IOSContextMenuButton
       activeOpacity={0}
       isMenuPrimaryAction
-      {...(android ? { onPress: onPressAndroid } : {})}
+      {...(Platform.OS === 'android' ? { onPress: onPressAndroid } : {})}
       menuConfig={{
         menuItems,
         menuTitle,

--- a/src/components/exchangeAssetRowContextMenuProps.ts
+++ b/src/components/exchangeAssetRowContextMenuProps.ts
@@ -1,4 +1,4 @@
-import { type NativeSyntheticEvent } from 'react-native';
+import { Platform, type NativeSyntheticEvent } from 'react-native';
 
 import { startCase } from 'lodash';
 import { triggerHaptics } from 'react-native-turbo-haptics';
@@ -20,7 +20,7 @@ const buildBlockExplorerAction = (chainId: ChainId) => {
     actionTitle: blockExplorerText,
     icon: {
       iconType: 'SYSTEM',
-      iconValue: ios ? 'link' : null,
+      iconValue: Platform.OS === 'ios' ? 'link' : null,
     },
   };
 };
@@ -36,7 +36,7 @@ const CoinRowActions = {
     actionTitle: i18n.t(i18n.l.wallet.action.copy_contract_address),
     icon: {
       iconType: 'SYSTEM',
-      iconValue: ios ? 'doc.on.doc' : null,
+      iconValue: Platform.OS === 'ios' ? 'doc.on.doc' : null,
     },
   },
 };
@@ -96,7 +96,7 @@ export default function contextMenuProps(item: any, onCopySwapDetailsText: (addr
   };
   return {
     menuConfig,
-    ...(android ? { isAnchoredToRight: true, onPress: onPressAndroid } : {}),
+    ...(Platform.OS === 'android' ? { isAnchoredToRight: true, onPress: onPressAndroid } : {}),
     onPressMenuItem: handlePressMenuItem,
   };
 }

--- a/src/components/expanded-state/profile/ProfileModal.tsx
+++ b/src/components/expanded-state/profile/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import Divider from '@/components/Divider';
 import styled from '@/framework/ui/styled-thing';
@@ -25,7 +25,7 @@ const ProfileAddressText = styled(TruncatedAddress).attrs(({ theme: { colors } }
   truncationLength: 4,
   weight: 'bold',
 }))({
-  ...margin.object(android ? 0 : 6, 0, android ? 0 : 5),
+  ...margin.object(Platform.OS === 'android' ? 0 : 6, 0, Platform.OS === 'android' ? 0 : 5),
   width: '100%',
 });
 
@@ -97,7 +97,7 @@ const ProfileModal = ({
 
   return (
     <Container>
-      <Centered direction="column" paddingBottom={android ? 15 : 30} testID="wallet-info-modal" width="100%">
+      <Centered direction="column" paddingBottom={Platform.OS === 'android' ? 15 : 30} testID="wallet-info-modal" width="100%">
         {toggleAvatar &&
           (imageAvatar ? (
             <AvatarCircle
@@ -151,7 +151,7 @@ const ProfileModal = ({
             letterSpacing="roundedMedium"
             testID="wallet-info-cancel-button"
             weight="medium"
-            {...(android && { lineHeight: 21 })}
+            {...(Platform.OS === 'android' && { lineHeight: 21 })}
           >
             {i18n.t(i18n.l.button.cancel)}
           </ProfileButtonText>

--- a/src/components/expanded-state/useSwapDetailsButtonPosition.ts
+++ b/src/components/expanded-state/useSwapDetailsButtonPosition.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { type LayoutChangeEvent } from 'react-native';
+import { Platform, type LayoutChangeEvent } from 'react-native';
 
 import { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 
@@ -28,7 +28,7 @@ export default ({ contentHeight }: { contentHeight: number }) => {
 
   const wrapperStyle = useMemo(
     () =>
-      ios && [
+      Platform.OS === 'ios' && [
         buttonWrapperStyle,
         buttonPosition && {
           position: 'absolute',

--- a/src/components/fab/FloatingActionButton.js
+++ b/src/components/fab/FloatingActionButton.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -28,7 +29,7 @@ const Content = styled(Centered)({
   backgroundColor: ({ backgroundColor }) => backgroundColor,
 });
 
-const Wrapper = android ? ScaleButtonZoomableAndroid : ButtonPressAnimation;
+const Wrapper = Platform.OS === 'android' ? ScaleButtonZoomableAndroid : ButtonPressAnimation;
 
 const FloatingActionButton = ({
   backgroundColor,
@@ -61,7 +62,7 @@ const FloatingActionButton = ({
 
   return (
     <Wrapper
-      disabled={disabled || android}
+      disabled={disabled || Platform.OS === 'android'}
       hapticType="impactLight"
       onPress={handlePress}
       onPressIn={handlePressIn}
@@ -77,7 +78,7 @@ const FloatingActionButton = ({
         shadows={isDarkMode ? DarkModeShadow : shadows}
       >
         <ButtonPressAnimation
-          disabled={disabled || ios}
+          disabled={disabled || Platform.OS === 'ios'}
           onPress={handlePress}
           reanimatedButton
           style={{

--- a/src/components/fields/AddressField.js
+++ b/src/components/fields/AddressField.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
 
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -15,7 +16,7 @@ import { Row } from '../layout';
 const AddressInput = styled(Input).attrs({
   autoCapitalize: 'none',
   autoCorrect: false,
-  keyboardType: android ? 'visible-password' : 'default',
+  keyboardType: Platform.OS === 'android' ? 'visible-password' : 'default',
   maxLength: addressUtils.maxLength,
   selectTextOnFocus: true,
   size: 'large',
@@ -71,7 +72,9 @@ const AddressField = ({ address, autoFocus, editable, name, isValid, onChangeTex
         testID={testID}
         value={formatValue(inputValue)}
         placeholder={
-          android || isTinyPhone ? i18n.t(i18n.l.fields.address.short_placeholder) : i18n.t(i18n.l.fields.address.long_placeholder)
+          Platform.OS === 'android' || isTinyPhone
+            ? i18n.t(i18n.l.fields.address.short_placeholder)
+            : i18n.t(i18n.l.fields.address.long_placeholder)
         }
         placeholderTextColor={opacity(colors.blueGreyDark, 0.3)}
       />

--- a/src/components/fields/BubbleField.js
+++ b/src/components/fields/BubbleField.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 
 import ExchangeInput from '@/components/ExchangeInput';
 import styled from '@/framework/ui/styled-thing';
@@ -16,8 +17,8 @@ const BubbleInput = styled(ExchangeInput).attrs(({ isSmallPhone, isTinyPhone, th
   size: isTinyPhone ? 'big' : isSmallPhone ? 'bigger' : 'h3',
   weight: 'semibold',
 }))(({ isTinyPhone }) => ({
-  ...(android ? (isTinyPhone ? { height: 40 } : { height: 46 }) : {}),
-  ...(android ? { paddingBottom: 0, paddingTop: 0 } : {}),
+  ...(Platform.OS === 'android' ? (isTinyPhone ? { height: 40 } : { height: 46 }) : {}),
+  ...(Platform.OS === 'android' ? { paddingBottom: 0, paddingTop: 0 } : {}),
   marginRight: 10,
 }));
 
@@ -106,7 +107,7 @@ const BubbleField = (
           autoFocus={autoFocus}
           color={colorForAsset}
           isDarkMode={isDarkMode}
-          isSmallPhone={android || isSmallPhone}
+          isSmallPhone={Platform.OS === 'android' || isSmallPhone}
           isTinyPhone={isTinyPhone}
           keyboardType={keyboardType}
           mask={mask}

--- a/src/components/icons/svg/CaretIcon.js
+++ b/src/components/icons/svg/CaretIcon.js
@@ -1,11 +1,18 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { Path } from 'react-native-svg';
 
 import Svg from '../Svg';
 
 const CaretIcon = ({ color, colors, size, ...props }, ref) => (
-  <Svg {...props} height={size ? (size * 21) / 9 : '21'} ref={ref} viewBox={`0 0 ${ios ? 9 : 10} 21`} width={size || ios ? 9 : 10}>
+  <Svg
+    {...props}
+    height={size ? (size * 21) / 9 : '21'}
+    ref={ref}
+    viewBox={`0 0 ${Platform.OS === 'ios' ? 9 : 10} 21`}
+    width={size || Platform.OS === 'ios' ? 9 : 10}
+  >
     <Path
       d="M0.712582 0.51331C0.167648 0.937147 0.0694796 1.72249 0.493317 2.26743L6.18017 9.57909C6.60146 10.1208 6.60146 10.8792 6.18017 11.4209L0.493317 18.7326C0.0694796 19.2775 0.167648 20.0629 0.712582 20.4867C1.25752 20.9105 2.04286 20.8124 2.4667 20.2674L8.15355 12.9558C9.277 11.5113 9.277 9.48868 8.15355 8.04424L2.4667 0.732574C2.04286 0.18764 1.25752 0.089472 0.712582 0.51331Z"
       fill={color || colors.dark}

--- a/src/components/images/ImagePreviewOverlay.tsx
+++ b/src/components/images/ImagePreviewOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Pressable, StyleSheet, View, type LayoutChangeEvent, type PressableProps } from 'react-native';
+import { InteractionManager, Platform, Pressable, StyleSheet, View, type LayoutChangeEvent, type PressableProps } from 'react-native';
 
 import { uniqueId } from 'lodash';
 import { BlurView } from 'react-native-blur-view';
@@ -242,7 +242,7 @@ function ImagePreview({ backgroundOverlay, index, id, opacity: givenOpacity, yPo
             </Box>
           ) : (
             <Box as={Animated.View} style={[overlayStyle, StyleSheet.absoluteFillObject]}>
-              {ios && (
+              {Platform.OS === 'ios' && (
                 <Box
                   as={View}
                   height={{
@@ -268,7 +268,10 @@ function ImagePreview({ backgroundOverlay, index, id, opacity: givenOpacity, yPo
                   custom: hideStatusBar ? deviceHeight : deviceHeight - safeAreaInsetValues.top,
                 }}
                 style={{
-                  backgroundColor: colorMode === 'dark' ? `rgba(22, 22, 22, ${ios ? 0.8 : 1})` : `rgba(26, 26, 26, ${ios ? 0.8 : 1})`,
+                  backgroundColor:
+                    colorMode === 'dark'
+                      ? `rgba(22, 22, 22, ${Platform.OS === 'ios' ? 0.8 : 1})`
+                      : `rgba(26, 26, 26, ${Platform.OS === 'ios' ? 0.8 : 1})`,
                 }}
                 width="full"
               />
@@ -454,7 +457,7 @@ export function ImagePreviewOverlayTarget({
             });
           }
         },
-        android ? 500 : 0
+        Platform.OS === 'android' ? 500 : 0
       );
     },
     [aspectRatio, setWidth, setXOffset, setYOffset, topOffset, yPosition?.value]

--- a/src/components/inputs/InlineField.tsx
+++ b/src/components/inputs/InlineField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { type TextInputProps } from 'react-native';
+import { Platform, type TextInputProps } from 'react-native';
 
 import { Bleed, Column, Columns, Inline, Inset, Text, useTextStyle, type TextProps } from '@/design-system';
 import { WrappedAlert as Alert } from '@/helpers/alert';
@@ -77,15 +77,15 @@ export default function InlineField({
       marginBottom: 0,
       marginTop: 0,
       minHeight: inputHeight + paddingVertical * 2,
-      paddingBottom: inputProps?.multiline ? (ios ? 15 : 10) : 0,
-      paddingTop: inputProps?.multiline ? (ios ? 15 : 10) : 0,
-      width: startsWith ? (ios ? 0.55 * width : 0.56 * width) : ios ? 0.6 * width : 0.61 * width,
+      paddingBottom: inputProps?.multiline ? (Platform.OS === 'ios' ? 15 : 10) : 0,
+      paddingTop: inputProps?.multiline ? (Platform.OS === 'ios' ? 15 : 10) : 0,
+      width: startsWith ? (Platform.OS === 'ios' ? 0.55 * width : 0.56 * width) : Platform.OS === 'ios' ? 0.6 * width : 0.61 * width,
     }),
     [textStyle, inputHeight, inputProps?.multiline, startsWith, width]
   );
 
   let keyboardType = inputProps?.keyboardType;
-  if (android) {
+  if (Platform.OS === 'android') {
     keyboardType = shouldFormatText ? 'default' : 'visible-password';
   }
 
@@ -114,7 +114,7 @@ export default function InlineField({
       <Column>
         <Inline alignVertical="center" space="2px" wrap={false}>
           {startsWith && (
-            <Inset top={ios ? '2px' : '1px (Deprecated)'}>
+            <Inset top={Platform.OS === 'ios' ? '2px' : '1px (Deprecated)'}>
               <Text color="secondary30 (Deprecated)" size="16px / 22px (Deprecated)" weight="heavy">
                 {startsWith}
               </Text>
@@ -126,7 +126,7 @@ export default function InlineField({
             autoFocus={autoFocus}
             defaultValue={defaultValue}
             onChangeText={onChangeText}
-            onContentSizeChange={android && inputProps?.multiline ? handleContentSizeChange : undefined}
+            onContentSizeChange={Platform.OS === 'android' && inputProps?.multiline ? handleContentSizeChange : undefined}
             onEndEditing={onEndEditing}
             onFocus={onFocus}
             placeholder={placeholder}

--- a/src/components/list/ListHeader.js
+++ b/src/components/list/ListHeader.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Share } from 'react-native';
+import { Platform, Share } from 'react-native';
 
 import Divider from '@/components/Divider';
 import styled from '@/framework/ui/styled-thing';
@@ -102,7 +102,7 @@ export default function ListHeader({ children, contextMenuOptions, isCoinListEdi
          The divider shows up as a white line in dark mode (android)
          so we won't render it till we figure it out why
         */
-        showDivider && !(android && isDarkMode) && <Divider color={colors.rowDividerLight} />
+        showDivider && !(Platform.OS === 'android' && isDarkMode) && <Divider color={colors.rowDividerLight} />
       }
       <StickyBackgroundBlocker deviceDimensions={deviceDimensions} isEditMode={isCoinListEdited} />
     </Fragment>

--- a/src/components/list/MarqueeList.js
+++ b/src/components/list/MarqueeList.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef } from 'react';
+import { Platform } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -56,20 +57,20 @@ const SwipeableList = ({ components, height, speed, testID }) => {
   const panGesture = Gesture.Pan()
     .activeOffsetX([-6, 10])
     .onBegin(() => {
-      if (android) {
+      if (Platform.OS === 'android') {
         cancelAnimation(transX);
         cancelAnimation(swiping);
       }
     })
     .onStart(() => {
       panStart.value = transX.value;
-      if (android) runOnJS(startPan)();
+      if (Platform.OS === 'android') runOnJS(startPan)();
     })
     .onUpdate(event => {
       transX.value = panStart.value + event.translationX;
     })
     .onEnd(event => {
-      if (android) runOnJS(endPan)();
+      if (Platform.OS === 'android') runOnJS(endPan)();
       transX.value = withDecay({
         deceleration: DECCELERATION,
         velocity: event.velocityX,
@@ -78,7 +79,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
     })
     .onFinalize((_, success) => {
       if (!success) {
-        if (android) runOnJS(endPan)();
+        if (Platform.OS === 'android') runOnJS(endPan)();
         swiping.value = withSpeed({ targetSpeed: speed });
       }
     });
@@ -99,7 +100,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
   const tapGesture = Gesture.Tap()
     .cancelsTouchesInView(false)
     .onBegin(() => {
-      if (ios) {
+      if (Platform.OS === 'ios') {
         cancelAnimation(transX);
         cancelAnimation(swiping);
       }
@@ -108,7 +109,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
       swiping.value = withSpeed({ targetSpeed: speed });
     })
     .onFinalize((_, success) => {
-      if (!success && ios) {
+      if (!success && Platform.OS === 'ios') {
         swiping.value = withSpeed({ targetSpeed: speed });
       }
     });
@@ -116,7 +117,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
   const longPressGesture = Gesture.LongPress()
     .maxDistance(100000)
     .onEnd(() => {
-      if (android) swiping.value = withSpeed({ targetSpeed: speed });
+      if (Platform.OS === 'android') swiping.value = withSpeed({ targetSpeed: speed });
     });
 
   const translate = useDerivedValue(() => swiping.value + transX.value, []);
@@ -139,7 +140,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
             transX={translate}
           >
             {components.map(({ view }) =>
-              ios
+              Platform.OS === 'ios'
                 ? view({
                     testID: null,
                   })
@@ -151,7 +152,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
           </SingleElement>
           <SingleElement offset={offset} sumWidth={offset} transX={translate}>
             {components.map(({ view }) =>
-              ios
+              Platform.OS === 'ios'
                 ? view({
                     testID: testID,
                   })
@@ -172,16 +173,17 @@ const MarqueeList = ({ height, items = /** @type {any[]} */ ([]), renderItem, sp
     <>
       <SwipeableList
         components={items.map((item, index) => ({
-          view: ios
-            ? () => renderItem({ index, item, testID: item.testID })
-            : ({ onPressCancel, onPressStart }) =>
-                renderItem({
-                  index,
-                  item,
-                  onPressCancel,
-                  onPressStart,
-                  testID: item.testID,
-                }),
+          view:
+            Platform.OS === 'ios'
+              ? () => renderItem({ index, item, testID: item.testID })
+              : ({ onPressCancel, onPressStart }) =>
+                  renderItem({
+                    index,
+                    item,
+                    onPressCancel,
+                    onPressStart,
+                    testID: item.testID,
+                  }),
         }))}
         height={height}
         speed={speed}

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -14,7 +15,7 @@ const Container = styled(Centered).attrs(({ fixedToTop }) => ({
   direction: 'column',
   justify: fixedToTop ? 'start' : 'center',
 }))({
-  marginTop: ({ insetTop }) => (android ? insetTop : 0),
+  marginTop: ({ insetTop }) => (Platform.OS === 'android' ? insetTop : 0),
   padding: ({ containerPadding }) => containerPadding,
   ...position.sizeAsObject('100%'),
   shadowColor: ({ shadowColor }) => shadowColor,
@@ -39,12 +40,12 @@ export default function Modal({ containerPadding = 15, fixedToTop, height, onClo
 
   return (
     <Container containerPadding={containerPadding} fixedToTop={fixedToTop} insetTop={insetTop} shadowColor={colors.shadowBlack}>
-      {ios && <TouchableBackdrop onPress={onCloseModal} />}
+      {Platform.OS === 'ios' && <TouchableBackdrop onPress={onCloseModal} />}
       <Content
         {...props}
         backgroundColor={colors.white}
         fixedToTop={fixedToTop}
-        height={(fullScreenOnAndroid && android ? '100%' : height) || deviceHeight - 220}
+        height={(fullScreenOnAndroid && Platform.OS === 'android' ? '100%' : height) || deviceHeight - 220}
         radius={radius}
       />
     </Container>

--- a/src/components/modal/ModalHeaderButton.js
+++ b/src/components/modal/ModalHeaderButton.js
@@ -16,7 +16,7 @@ const BackArrow = styled(Icon).attrs(({ theme: { colors } }) => ({
   name: 'caret',
 }))({
   height: 16,
-  marginTop: android ? 6 : 0,
+  marginTop: Platform.OS === 'android' ? 6 : 0,
 });
 
 const Container = styled(Row).attrs(({ side }) => ({
@@ -45,7 +45,7 @@ const Text = styled(UnstyledText).attrs(({ theme: { colors } }) => ({
 const ModalHeaderButton = ({ label, onPress, side }) => (
   <Container
     {...(Platform.OS === 'android' ? { borderColor: 'transparent' } : {})}
-    as={ios ? BorderlessButton : Button}
+    as={Platform.OS === 'ios' ? BorderlessButton : Button}
     onPress={onPress}
     side={side}
   >

--- a/src/components/profile/AvatarCircle.js
+++ b/src/components/profile/AvatarCircle.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import ContextMenu from '@/components/native-context-menu/contextMenu';
 import styled from '@/framework/ui/styled-thing';
@@ -19,8 +20,8 @@ const AvatarCircleSize = 60;
 
 const AvatarCircleView = styled(Flex)({
   ...position.sizeAsObject(AvatarCircleSize),
-  alignItems: ios ? 'flex-start' : 'center',
-  justifyContent: ios ? 'flex-start' : 'center',
+  alignItems: Platform.OS === 'ios' ? 'flex-start' : 'center',
+  justifyContent: Platform.OS === 'ios' ? 'flex-start' : 'center',
   marginBottom: 16,
 });
 
@@ -28,12 +29,12 @@ const FirstLetter = styled(Text).attrs(({ theme: { colors } }) => ({
   align: 'center',
   color: colors.whiteLabel,
   letterSpacing: 2,
-  size: ios ? 38 : 30,
+  size: Platform.OS === 'ios' ? 38 : 30,
   weight: 'semibold',
-  ...(ios && { lineHeight: 60 }),
+  ...(Platform.OS === 'ios' && { lineHeight: 60 }),
 }))({
-  ...(android && { left: -1 }),
-  ...(ios && { width: 62 }),
+  ...(Platform.OS === 'android' && { left: -1 }),
+  ...(Platform.OS === 'ios' && { width: 62 }),
 });
 
 export default function AvatarCircle({
@@ -100,7 +101,7 @@ export default function AvatarCircle({
           borderRadius={AvatarCircleSize}
           marginBottom={12}
           shadows={shadows[overlayStyles ? 'overlay' : 'default']}
-          {...(android && {
+          {...(Platform.OS === 'android' && {
             height: 60,
             width: 60,
           })}

--- a/src/components/rainbows-background/RainbowsBackground.tsx
+++ b/src/components/rainbows-background/RainbowsBackground.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions } from 'react-native';
+import { Dimensions, Platform } from 'react-native';
 
 import { type SharedValue } from 'react-native-reanimated';
 
@@ -18,7 +18,7 @@ const rainbows = [
     id: 'grey',
     rotate: 150,
     scale: 0.5066666667,
-    source: ios ? { uri: 'greyneon' } : RainbowGreyNeon,
+    source: Platform.OS === 'ios' ? { uri: 'greyneon' } : RainbowGreyNeon,
     x: -116,
     y: -202,
   },
@@ -27,7 +27,7 @@ const rainbows = [
     id: 'neon',
     rotate: 394.75,
     scale: 0.3333333333,
-    source: ios ? { uri: 'neon' } : RainbowNeon,
+    source: Platform.OS === 'ios' ? { uri: 'neon' } : RainbowNeon,
     x: 149,
     y: deviceHeight < 725 ? 380 * (deviceHeight / 725) : 380,
   },
@@ -36,7 +36,7 @@ const rainbows = [
     id: 'pixel',
     rotate: 360,
     scale: 0.6666666667,
-    source: ios ? { uri: 'pixel' } : RainbowPixel,
+    source: Platform.OS === 'ios' ? { uri: 'pixel' } : RainbowPixel,
     x: 173,
     y: deviceHeight < 800 ? -263 * (deviceHeight / 800) : -263,
   },
@@ -45,7 +45,7 @@ const rainbows = [
     id: 'light',
     rotate: -33,
     scale: 0.2826666667,
-    source: ios ? { uri: 'light' } : RainbowLight,
+    source: Platform.OS === 'ios' ? { uri: 'light' } : RainbowLight,
     x: -172,
     y: 180,
   },
@@ -54,7 +54,7 @@ const rainbows = [
     id: 'liquid',
     rotate: 75,
     scale: deviceHeight < 800 ? 0.42248 * (deviceHeight / 800) : 0.42248,
-    source: ios ? { uri: 'liquid' } : RainbowLiquid,
+    source: Platform.OS === 'ios' ? { uri: 'liquid' } : RainbowLiquid,
     x: 40,
     y: deviceHeight < 800 ? 215 * (deviceHeight / 800) : 215,
   },

--- a/src/components/send/SendAssetFormCollectible.js
+++ b/src/components/send/SendAssetFormCollectible.js
@@ -20,7 +20,7 @@ const ButtonWrapper = styled(Column).attrs({
   ...padding.object(0, 19, 15),
   marginBottom: 21,
   width: '100%',
-  ...(ios ? { zIndex: 3 } : { elevation: 3 }),
+  ...(Platform.OS === 'ios' ? { zIndex: 3 } : { elevation: 3 }),
 });
 
 const Footer = styled(Column).attrs({ justify: 'end' })({

--- a/src/components/send/SendAssetFormField.js
+++ b/src/components/send/SendAssetFormField.js
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import RadialGradient from 'react-native-radial-gradient';
 
@@ -31,7 +32,7 @@ const GradientBackground = styled(RadialGradient).attrs(({ colorForAsset, theme:
   width: ({ width }) => width - 38,
 });
 
-const Wrapper = styled(android ? Row : ButtonPressAnimation).attrs({
+const Wrapper = styled(Platform.OS === 'android' ? Row : ButtonPressAnimation).attrs({
   scaleTo: 1.05,
 })({
   borderRadius: 29.5,
@@ -41,7 +42,7 @@ const Wrapper = styled(android ? Row : ButtonPressAnimation).attrs({
   paddingHorizontal: ({ isSmallPhone, isTinyPhone }) => (isTinyPhone ? 12 : isSmallPhone ? 15 : 19),
   paddingTop: ({ isSmallPhone, isTinyPhone }) => (isTinyPhone ? 6 : isSmallPhone ? 7 : 10),
   position: 'relative',
-  width: ({ width }) => (android ? width - 38 : '100%'),
+  width: ({ width }) => (Platform.OS === 'android' ? width - 38 : '100%'),
 });
 
 const SendAssetFormField = (
@@ -76,15 +77,15 @@ const SendAssetFormField = (
 
   return (
     <Wrapper
-      isSmallPhone={android || isSmallPhone}
+      isSmallPhone={Platform.OS === 'android' || isSmallPhone}
       isTinyPhone={isTinyPhone}
-      onPress={() => !android && ref?.current.focus()}
+      onPress={() => Platform.OS !== 'android' && ref?.current.focus()}
       width={width}
       accessible={false}
     >
       <GradientBackground
         colorForAsset={colorForAsset || colors.dark}
-        isSmallPhone={android || isSmallPhone}
+        isSmallPhone={Platform.OS === 'android' || isSmallPhone}
         isTinyPhone={isTinyPhone}
         width={width}
       />
@@ -109,8 +110,8 @@ const SendAssetFormField = (
           align="right"
           color={colorForAsset || colors.dark}
           letterSpacing="roundedTight"
-          lineHeight={android ? (isTinyPhone ? 27 : android || isSmallPhone ? 31 : 38) : null}
-          size={isTinyPhone ? 'big' : android || isSmallPhone ? 'bigger' : 'h3'}
+          lineHeight={Platform.OS === 'android' ? (isTinyPhone ? 27 : Platform.OS === 'android' || isSmallPhone ? 31 : 38) : null}
+          size={isTinyPhone ? 'big' : Platform.OS === 'android' || isSmallPhone ? 'bigger' : 'h3'}
           weight="medium"
         >
           {label.length > labelMaxLength ? label.substring(0, labelMaxLength) : label}

--- a/src/components/send/SendContactList.js
+++ b/src/components/send/SendContactList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { SectionList } from 'react-native';
+import { Platform, SectionList } from 'react-native';
 
 import { toChecksumAddress } from 'ethereumjs-util';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -44,7 +44,7 @@ const SectionTitle = styled(Text).attrs({
 })({
   color: ({ theme: { colors } }) => opacity(colors.blueGreyDark, 0.6),
   marginLeft: 19,
-  marginTop: android ? 6 : 12,
+  marginTop: Platform.OS === 'android' ? 6 : 12,
 });
 
 const SectionWrapper = styled(LinearGradient).attrs(({ theme: { colors } }) => ({
@@ -218,7 +218,7 @@ export default function SendContactList({
       >
         <InvalidPasteToast />
       </ToastPositionContainer>
-      {ios && <KeyboardArea keyboardHeight={keyboardHeight} />}
+      {Platform.OS === 'ios' && <KeyboardArea keyboardHeight={keyboardHeight} />}
     </FlyInAnimation>
   );
 }

--- a/src/components/send/SendEmptyState.js
+++ b/src/components/send/SendEmptyState.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useTheme } from '@/theme/ThemeContext';
@@ -13,7 +13,7 @@ const SendEmptyState = () => {
 
   const icon = <Icon color={opacity(colors.blueGreyDark, 0.06)} height={88} name="send" style={sx.icon} width={91} />;
 
-  if (android) {
+  if (Platform.OS === 'android') {
     return <View style={sx.androidContainer}>{icon}</View>;
   }
 
@@ -29,7 +29,7 @@ export default SendEmptyState;
 const sx = StyleSheet.create({
   androidContainer: { alignItems: 'center', flex: 1 },
   icon: {
-    marginBottom: ios ? 0 : 150,
-    marginTop: ios ? 0 : 150,
+    marginBottom: Platform.OS === 'ios' ? 0 : 150,
+    marginTop: Platform.OS === 'ios' ? 0 : 150,
   },
 });

--- a/src/components/send/SendHeader.tsx
+++ b/src/components/send/SendHeader.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Keyboard, type TextInput } from 'react-native';
+import { ActivityIndicator, Keyboard, Platform, type TextInput } from 'react-native';
 
 import { isHexString } from '@ethersproject/bytes';
 import isEmpty from 'lodash/isEmpty';
@@ -55,9 +55,11 @@ const AddressFieldLabel = styled(Label).attrs({
   opacity: 1,
 });
 
-const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(({ theme: { colors } }: ComponentPropsWithTheme) => ({
-  color: opacity(colors.blueGreyDark, 0.3),
-}))({
+const LoadingSpinner = styled(Platform.OS === 'android' ? Spinner : ActivityIndicator).attrs(
+  ({ theme: { colors } }: ComponentPropsWithTheme) => ({
+    color: opacity(colors.blueGreyDark, 0.3),
+  })
+)({
   marginRight: 2,
 });
 
@@ -156,7 +158,7 @@ export default function SendHeader({
       }
     }
 
-    android && Keyboard.dismiss();
+    Platform.OS === 'android' && Keyboard.dismiss();
     navigate(Routes.MODAL_SCREEN, {
       additionalPadding: true,
       address: hexAddress,

--- a/src/components/sheet/DynamicHeightSheet.js
+++ b/src/components/sheet/DynamicHeightSheet.js
@@ -119,7 +119,7 @@ export default forwardRef(function SlackSheet(
   // In discover sheet we need to set it additionally
   useEffect(
     () => {
-      discoverSheet && ios && sheet.current.setNativeProps({ scrollIndicatorInsets });
+      discoverSheet && Platform.OS === 'ios' && sheet.current.setNativeProps({ scrollIndicatorInsets });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []

--- a/src/components/sheet/sheet-action-buttons/SheetActionButton.tsx
+++ b/src/components/sheet/sheet-action-buttons/SheetActionButton.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, type PropsWithChildren } from 'react';
-import { type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, type StyleProp, type ViewStyle } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -134,7 +134,7 @@ const SheetActionButton: React.FC<SheetActionButtonProps> = ({
         height: typeof size === 'number' ? size : size === 'big' ? 52 : 46,
         width: isSquare ? (typeof size === 'number' ? size : size === 'big' ? 52 : 46) : undefined,
       }}
-      elevation={android ? elevation : null}
+      elevation={Platform.OS === 'android' ? elevation : null}
       isCharts={isCharts}
       isSquare={isSquare}
       onPress={disabled ? () => undefined : onPress}

--- a/src/components/token-family/TokenFamilyHeaderIcon.tsx
+++ b/src/components/token-family/TokenFamilyHeaderIcon.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { type Source } from 'react-native-fast-image';
 
@@ -21,7 +21,7 @@ type Props = {
   style?: any;
 };
 
-const shadowsFactory = (colors: ThemeContextProps['colors']) => [[0, 3, android ? 5 : 9, colors.shadow, 0.1]];
+const shadowsFactory = (colors: ThemeContextProps['colors']) => [[0, 3, Platform.OS === 'android' ? 5 : 9, colors.shadow, 0.1]];
 
 const sx = StyleSheet.create({
   trophy: {

--- a/src/components/token-info/TokenInfoBalanceValue.js
+++ b/src/components/token-info/TokenInfoBalanceValue.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import styled from '@/framework/ui/styled-thing';
 import useColorForAsset from '@/hooks/useColorForAsset';
@@ -9,7 +9,7 @@ import RainbowCoinIcon from '../coin-icon/RainbowCoinIcon';
 import { RowWithMargins } from '../layout';
 import TokenInfoValue from './TokenInfoValue';
 
-const InfoValue = styled(TokenInfoValue)(android ? { height: 37.7 } : {});
+const InfoValue = styled(TokenInfoValue)(Platform.OS === 'android' ? { height: 37.7 } : {});
 
 const TokenInfoBalanceValue = ({ align, asset, ...props }) => {
   const { balance, value } = asset;

--- a/src/components/token-info/TokenInfoItem.js
+++ b/src/components/token-info/TokenInfoItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 
@@ -71,7 +71,7 @@ export default function TokenInfoItem({
       <ColumnWithMargins
         flex={asset ? 1 : 0}
         justify={align === 'left' ? 'start' : 'end'}
-        margin={android ? (isNft ? -3 : -6) : isNft ? 6 : 3}
+        margin={Platform.OS === 'android' ? (isNft ? -3 : -6) : isNft ? 6 : 3}
         {...props}
       >
         <ButtonPressAnimation disabled={!showInfoButton} onPress={showInfoButton && onInfoPress} scaleTo={0.88}>

--- a/src/components/unique-token/Tag.js
+++ b/src/components/unique-token/Tag.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { upperCase, upperFirst } from 'lodash';
 import PropTypes from 'prop-types';
@@ -175,7 +176,7 @@ const Tag = ({
       <ContextMenuButton
         activeOpacity={0}
         menuConfig={menuConfig}
-        {...(android ? { onPress: onPressAndroid } : {})}
+        {...(Platform.OS === 'android' ? { onPress: onPressAndroid } : {})}
         enableContextMenu
         isMenuPrimaryAction
         onPressMenuItem={handlePressMenuItem}

--- a/src/design-system/components/private/ApplyShadow/ApplyShadow.tsx
+++ b/src/design-system/components/private/ApplyShadow/ApplyShadow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View, type ViewProps, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type ViewProps, type ViewStyle } from 'react-native';
 
 import { AndroidShadow } from './AndroidShadow';
 import { IOSShadow } from './IOSShadow';
@@ -97,13 +97,15 @@ export const ApplyShadow = ({ backgroundColor, children: child, shadows }: Apply
 
   return (
     <View style={parentStyles}>
-      {(ios || web) && <IOSShadow backgroundColor={backgroundColor} shadows={iosShadows} style={[childStyles, { overflow: 'visible' }]} />}
-      {android && (
+      {(Platform.OS === 'ios' || web) && (
+        <IOSShadow backgroundColor={backgroundColor} shadows={iosShadows} style={[childStyles, { overflow: 'visible' }]} />
+      )}
+      {Platform.OS === 'android' && (
         <AndroidShadow backgroundColor={backgroundColor} shadow={shadows.android} style={[childStyles, { overflow: 'visible' }]} />
       )}
 
       {React.cloneElement(child, {
-        style: [{ flex: 1 }, childStyles, android ? androidChildStyles : undefined],
+        style: [{ flex: 1 }, childStyles, Platform.OS === 'android' ? androidChildStyles : undefined],
       })}
     </View>
   );

--- a/src/design-system/typography/createLineHeightFixNode.tsx
+++ b/src/design-system/typography/createLineHeightFixNode.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text as NativeText } from 'react-native';
+import { Text as NativeText, Platform } from 'react-native';
 
 // https://github.com/facebook/react-native/issues/29232#issuecomment-889767516
 // On Android, space between lines of multiline text seems to be irregular
@@ -10,4 +10,4 @@ import { Text as NativeText } from 'react-native';
 // To remove this additional space we've dropped the line height offset to an
 // arbitrarily small number that's close to zero.
 export const createLineHeightFixNode = (lineHeight: number | undefined) =>
-  android && lineHeight !== undefined ? <NativeText style={{ lineHeight: lineHeight - 0.001 }} /> : null;
+  Platform.OS === 'android' && lineHeight !== undefined ? <NativeText style={{ lineHeight: lineHeight - 0.001 }} /> : null;

--- a/src/design-system/typography/typography.ts
+++ b/src/design-system/typography/typography.ts
@@ -24,39 +24,39 @@ const capsize = (options: Parameters<typeof precomputeValues>[0]) => {
 export const fonts = {
   SFProRounded: {
     regular: {
-      fontFamily: ios ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Regular',
-      fontWeight: ios ? fontWeights.regular : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Regular',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.regular : 'normal',
     },
     medium: {
-      fontFamily: ios ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Medium',
-      fontWeight: ios ? fontWeights.medium : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Medium',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.medium : 'normal',
     },
     semibold: {
-      fontFamily: ios ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Semibold',
-      fontWeight: ios ? fontWeights.semibold : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Semibold',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.semibold : 'normal',
     },
     bold: {
-      fontFamily: ios ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Bold',
-      fontWeight: ios ? fontWeights.bold : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Bold',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.bold : 'normal',
     },
     heavy: {
-      fontFamily: ios ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Heavy',
-      fontWeight: ios ? fontWeights.heavy : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Heavy',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.heavy : 'normal',
     },
     black: {
-      fontFamily: ios ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Black',
-      fontWeight: ios ? fontWeights.black : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Pro Rounded' : 'SF-Pro-Rounded-Black',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.black : 'normal',
     },
   },
 
   SFMono: {
     regular: {
-      fontFamily: ios ? 'SF Mono' : 'SF-Mono-Regular',
-      fontWeight: ios ? fontWeights.regular : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Mono' : 'SF-Mono-Regular',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.regular : 'normal',
     },
     medium: {
-      fontFamily: ios ? 'SF Mono' : 'SF-Mono-Medium',
-      fontWeight: ios ? fontWeights.medium : 'normal',
+      fontFamily: Platform.OS === 'ios' ? 'SF Mono' : 'SF-Mono-Medium',
+      fontWeight: Platform.OS === 'ios' ? fontWeights.medium : 'normal',
     },
   },
 } as const;
@@ -97,7 +97,7 @@ const createTextSize = ({
     }),
   } as const;
 
-  const marginCorrectionForPlatform = marginCorrection[ios ? 'ios' : 'android'];
+  const marginCorrectionForPlatform = marginCorrection[Platform.OS === 'ios' ? 'ios' : 'android'];
 
   if (Platform.OS === 'web') {
     return styles;

--- a/src/features/backup/components/ChooseBackupStep.tsx
+++ b/src/features/backup/components/ChooseBackupStep.tsx
@@ -37,7 +37,7 @@ const Title = styled(RNText).attrs({
 
 const LoadingText = styled(RNText).attrs(({ theme: { colors } }: any) => ({
   color: colors.blueGreyDark,
-  lineHeight: ios ? 'none' : 24,
+  lineHeight: Platform.OS === 'ios' ? 'none' : 24,
   size: 'large',
   weight: 'semibold',
 }))({
@@ -218,7 +218,7 @@ export function ChooseBackupStep() {
 
           {isLoading && (
             <Box width="full" height="full" color={colors.transparent} alignItems="center" justifyContent="center" flex={1} as={Page}>
-              {android ? <Spinner color={colors.blueGreyDark} /> : <ActivityIndicator color={colors.blueGreyDark} />}
+              {Platform.OS === 'android' ? <Spinner color={colors.blueGreyDark} /> : <ActivityIndicator color={colors.blueGreyDark} />}
               <LoadingText>{titleForBackupState[status]}</LoadingText>
             </Box>
           )}

--- a/src/features/ens/components/ExternalENSProfileScrollView.tsx
+++ b/src/features/ens/components/ExternalENSProfileScrollView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useImperativeHandle, useState, type RefObject } from 'react';
-import { Animated as RNAnimated, type ScrollViewProps, type ViewStyle } from 'react-native';
+import { Platform, Animated as RNAnimated, type ScrollViewProps, type ViewStyle } from 'react-native';
 
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { BottomSheetContext } from '@gorhom/bottom-sheet/src/contexts/external';
@@ -35,11 +35,11 @@ const ExternalENSProfileScrollViewWithRefFactory = (type: string) =>
 
     const { scrollViewRef } = useContext(StickyHeaderContext)!;
 
-    const [scrollEnabled, setScrollEnabled] = useState(ios);
+    const [scrollEnabled, setScrollEnabled] = useState(Platform.OS === 'ios');
     useEffect(() => {
       // For Android, delay scroll until sheet has been mounted (to avoid
       // ImagePreviewOverlay mounting issues).
-      if (android) {
+      if (Platform.OS === 'android') {
         setTimeout(() => setScrollEnabled(true), 500);
       }
     });
@@ -91,7 +91,7 @@ const ExternalENSProfileScrollViewWithRefFactory = (type: string) =>
               onScroll: event,
             })}
       >
-        <ImagePreviewOverlay enableZoom={ios && enableZoomableImages} yPosition={yPosition}>
+        <ImagePreviewOverlay enableZoom={Platform.OS === 'ios' && enableZoomableImages} yPosition={yPosition}>
           {type === 'ens-profile' && <ProfileSheetHeader />}
           {props.children}
         </ImagePreviewOverlay>

--- a/src/features/ens/components/expanded-state/InfoRow.tsx
+++ b/src/features/ens/components/expanded-state/InfoRow.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useCallback, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { Switch } from 'react-native-gesture-handler';
 
@@ -107,9 +108,9 @@ export default function InfoRow({
           <Inline space="4px">
             <Text color="secondary60 (Deprecated)" size="16px / 22px (Deprecated)" weight="bold">
               {label}
-              {android && <Fragment> {explainer}</Fragment>}
+              {Platform.OS === 'android' && <Fragment> {explainer}</Fragment>}
             </Text>
-            {ios && explainer}
+            {Platform.OS === 'ios' && explainer}
           </Inline>
         </Inset>
       </Box>
@@ -131,7 +132,7 @@ export default function InfoRow({
             padding={isSwitch ? undefined : isMultiline ? ('15px (Deprecated)' as const) : ('10px' as const)}
             style={{
               backgroundColor: isSwitch ? 'transparent' : useAccentColor ? accentColor + '10' : 'rgba(255, 255, 255, 0.08)',
-              maxWidth: android ? 250 : undefined,
+              maxWidth: Platform.OS === 'android' ? 250 : undefined,
               opacity: show ? 1 : 0,
             }}
           >
@@ -158,7 +159,7 @@ export default function InfoRow({
                   onValueChange={onSwitchChange}
                   testID="ens-reverse-record-switch"
                   trackColor={{
-                    false: android ? colors.lightGrey : colors.white,
+                    false: Platform.OS === 'android' ? colors.lightGrey : colors.white,
                     true: accentColor,
                   }}
                   value={switchValue}
@@ -195,7 +196,12 @@ function ImageValue({ ensName, url, value }: { ensName?: string; url?: string; v
 
   if (!url) return null;
   return (
-    <ImagePreviewOverlayTarget aspectRatioType="cover" enableZoomOnPress={ios && enableZoomOnPress} imageUrl={url} onPress={onPress}>
+    <ImagePreviewOverlayTarget
+      aspectRatioType="cover"
+      enableZoomOnPress={Platform.OS === 'ios' && enableZoomOnPress}
+      imageUrl={url}
+      onPress={onPress}
+    >
       <Box as={ImgixImage} height="full" source={{ uri: url }} size={CardSize} />
     </ImagePreviewOverlayTarget>
   );

--- a/src/features/ens/components/profile/ActionButtons/WatchButton.tsx
+++ b/src/features/ens/components/profile/ActionButtons/WatchButton.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { ContextMenuButton, type MenuConfig } from 'react-native-ios-context-menu';
@@ -47,7 +48,7 @@ export default function WatchButton({ address, ensName, avatarUrl }: { address?:
         <ContextMenuButton
           enableContextMenu
           menuConfig={menuConfig}
-          {...(android ? { onPress: handlePressWatch } : {})}
+          {...(Platform.OS === 'android' ? { onPress: handlePressWatch } : {})}
           isMenuPrimaryAction
           onPressMenuItem={handlePressWatch}
           useActionSheetFallback={false}

--- a/src/features/ens/components/profile/ProfileAvatar.tsx
+++ b/src/features/ens/components/profile/ProfileAvatar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text as NativeText } from 'react-native';
+import { Text as NativeText, Platform } from 'react-native';
 
 import Animated from 'react-native-reanimated';
 
@@ -11,7 +11,7 @@ import { BackgroundProvider, Box, Cover } from '@/design-system';
 import useFadeImage from '@/hooks/useFadeImage';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
 
-const imagePreviewOverlayTopOffset = ios ? 68 + sharedCoolModalTopOffset : 107;
+const imagePreviewOverlayTopOffset = Platform.OS === 'ios' ? 68 + sharedCoolModalTopOffset : 107;
 const size = 70;
 
 export default function ProfileAvatar({

--- a/src/features/ens/components/profile/ProfileCover.tsx
+++ b/src/features/ens/components/profile/ProfileCover.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import RadialGradient from 'react-native-radial-gradient';
 import Animated from 'react-native-reanimated';
@@ -11,7 +11,7 @@ import { Box, useForegroundColor } from '@/design-system';
 import useFadeImage from '@/hooks/useFadeImage';
 import { sharedCoolModalTopOffset } from '@/navigation/config';
 
-const imagePreviewOverlayTopOffset = ios ? 68 + sharedCoolModalTopOffset : 107;
+const imagePreviewOverlayTopOffset = Platform.OS === 'ios' ? 68 + sharedCoolModalTopOffset : 107;
 
 export default function ProfileCover({
   coverUrl,
@@ -32,7 +32,7 @@ export default function ProfileCover({
   });
 
   const showSkeleton = isLoading || !isFetched;
-  const showRadialGradient = ios && !coverUrl && isFetched && !isLoading;
+  const showRadialGradient = Platform.OS === 'ios' && !coverUrl && isFetched && !isLoading;
 
   return (
     <>

--- a/src/features/ens/components/profile/ProfileSheetHeader.tsx
+++ b/src/features/ens/components/profile/ProfileSheetHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 
@@ -84,7 +85,7 @@ export default function ProfileSheetHeader({
   const emoji = useMemo(() => (profileAddress ? addressHashedEmoji(profileAddress) : ''), [profileAddress]);
 
   return (
-    <Box background="body (Deprecated)" {...(ios && { onLayout: (e: any) => setTimeout(() => layout(e), 500) })}>
+    <Box background="body (Deprecated)" {...(Platform.OS === 'ios' && { onLayout: (e: any) => setTimeout(() => layout(e), 500) })}>
       <Stack space={{ custom: 18 }}>
         <ProfileCover
           coverUrl={cover?.imageUrl}

--- a/src/features/ens/components/registration/EditContent.tsx
+++ b/src/features/ens/components/registration/EditContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { Switch } from 'react-native-gesture-handler';
 
@@ -55,7 +56,7 @@ const EditContent = ({
               testID="ens-reverse-record-switch"
               thumbColor={colors.white}
               trackColor={{
-                false: android ? colors.lightGrey : colors.white,
+                false: Platform.OS === 'android' ? colors.lightGrey : colors.white,
                 true: accentColor,
               }}
               value={sendReverseRecord}

--- a/src/features/ens/components/registration/RegisterContent.tsx
+++ b/src/features/ens/components/registration/RegisterContent.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import { Switch } from 'react-native-gesture-handler';
 
@@ -62,7 +63,7 @@ const RegisterContent = ({
                 testID="ens-reverse-record-switch"
                 thumbColor={colors.white}
                 trackColor={{
-                  false: android ? colors.lightGrey : colors.white,
+                  false: Platform.OS === 'android' ? colors.lightGrey : colors.white,
                   true: accentColor,
                 }}
                 value={sendReverseRecord}

--- a/src/features/ens/components/registration/RegistrationCover.tsx
+++ b/src/features/ens/components/registration/RegistrationCover.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
 import { type ImagePickerAsset } from 'expo-image-picker';
@@ -140,10 +140,10 @@ const RegistrationCover = ({
       <ButtonPressAnimation onPress={!hasSeenExplainSheet ? onShowExplainSheet : enableNFTs ? undefined : handleSelectImage} scaleTo={1}>
         <Box
           alignItems="center"
-          as={ios ? RadialGradient : View}
+          as={Platform.OS === 'ios' ? RadialGradient : View}
           height="126px"
           justifyContent="center"
-          {...(ios
+          {...(Platform.OS === 'ios'
             ? {
                 colors: [accentColor + '10', accentColor + '33'],
                 stops: [0.6, 0],

--- a/src/features/ens/components/registration/SearchInput.tsx
+++ b/src/features/ens/components/registration/SearchInput.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { type TextInput, type TextInputProps } from 'react-native';
+import { Platform, type TextInput, type TextInputProps } from 'react-native';
 
 import MaskedView from '@react-native-masked-view/masked-view';
 
@@ -94,7 +94,7 @@ const SearchInput = ({ isLoading, onChangeText, value, variant = 'rainbow', sele
             </Column>
             <Input
               autoCorrect={false}
-              keyboardType={android ? 'visible-password' : 'default'}
+              keyboardType={Platform.OS === 'android' ? 'visible-password' : 'default'}
               onChangeText={onChangeText}
               onFocus={handleFocus}
               ref={inputRef}
@@ -104,7 +104,7 @@ const SearchInput = ({ isLoading, onChangeText, value, variant = 'rainbow', sele
                 () => ({
                   ...headingStyle,
                   height,
-                  top: ios ? 1.5 : 0,
+                  top: Platform.OS === 'ios' ? 1.5 : 0,
                 }),
                 [headingStyle]
               )}

--- a/src/features/ens/components/registration/SelectableButton.tsx
+++ b/src/features/ens/components/registration/SelectableButton.tsx
@@ -1,4 +1,5 @@
 import React, { type ReactNode } from 'react';
+import { Platform } from 'react-native';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { AccentColorProvider, Box, Text, useForegroundColor } from '@/design-system';
@@ -36,7 +37,7 @@ export default function SelectableButton({ children, onSelect, isSelected, testI
           style={{
             borderColor: borderColor,
             borderWidth: 2,
-            paddingBottom: android ? 2 : 0,
+            paddingBottom: Platform.OS === 'android' ? 2 : 0,
           }}
         >
           <Text align="center" color="accent" size="16px / 22px (Deprecated)" weight="heavy">

--- a/src/features/ens/hooks/useENSRecordDisplayProperties.tsx
+++ b/src/features/ens/hooks/useENSRecordDisplayProperties.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, type PropsWithChildren } from 'react';
+import { Platform } from 'react-native';
 
 import { upperFirst } from 'lodash';
 import URL from 'url-parse';
@@ -100,7 +101,7 @@ export default function useENSRecordDisplayProperties({
 
   const value = useMemo(() => {
     if (isUrlRecord && displayUrl) {
-      return android ? ` 􀤆 ${displayUrl} ` : `􀤆 ${displayUrl}`;
+      return Platform.OS === 'android' ? ` 􀤆 ${displayUrl} ` : `􀤆 ${displayUrl}`;
     }
     if (isUrlValue && displayUrlUsername) {
       return displayUrlUsername;
@@ -193,7 +194,7 @@ export default function useENSRecordDisplayProperties({
       <ContextMenuButton
         enableContextMenu
         menuConfig={{ menuItems, menuTitle: '' }}
-        {...(android ? { handlePressMenuItem } : {})}
+        {...(Platform.OS === 'android' ? { handlePressMenuItem } : {})}
         isMenuPrimaryAction
         onPressMenuItem={handlePressMenuItem}
         style={{ flexGrow: isImageValue ? 1 : 0, flexShrink: 1 }}

--- a/src/features/ens/screens/ENSAssignRecordsSheet.tsx
+++ b/src/features/ens/screens/ENSAssignRecordsSheet.tsx
@@ -136,7 +136,7 @@ export default function ENSAssignRecordsSheet() {
 
   const handleFocus = useCallback(() => {
     if (!hasSeenExplainSheet) {
-      android && Keyboard.dismiss();
+      Platform.OS === 'android' && Keyboard.dismiss();
       navigate(Routes.EXPLAIN_SHEET, {
         type: 'ensOnChainDataWarning',
       });
@@ -154,7 +154,7 @@ export default function ENSAssignRecordsSheet() {
           paddingBottom: bottomActionHeight + ExtraBottomPadding,
         }}
         flexGrow={1}
-        scrollEnabled={android}
+        scrollEnabled={Platform.OS === 'android'}
         testID={`ens-${REGISTRATION_MODES.EDIT.toLowerCase()}-records-sheet`}
       >
         <Stack space="19px (Deprecated)">
@@ -260,7 +260,7 @@ export function ENSAssignRecordsBottomActions({
   }, [accountENS, mode, name, navigate, submit, values.avatar]);
 
   const navigateToAdditionalRecords = useCallback(() => {
-    android && Keyboard.dismiss();
+    Platform.OS === 'android' && Keyboard.dismiss();
     navigate(Routes.ENS_ADDITIONAL_RECORDS_SHEET);
   }, [navigate]);
 
@@ -304,7 +304,7 @@ export function ENSAssignRecordsBottomActions({
       >
         <AccentColorProvider color={accentColor}>
           <Box paddingBottom={{ custom: insets.bottom }} style={{ height: bottomActionHeight }}>
-            {ios ? <Shadow /> : null}
+            {Platform.OS === 'ios' ? <Shadow /> : null}
             <Rows>
               <Row>
                 <Inset horizontal="19px (Deprecated)" top={isSmallPhone ? '19px (Deprecated)' : '30px (Deprecated)'}>
@@ -371,8 +371,8 @@ function HideKeyboardButton({ color }: { color: string }) {
     const handleShowKeyboard = () => (show.value = true);
     const handleHideKeyboard = () => (show.value = false);
 
-    const showListener = android ? 'keyboardDidShow' : 'keyboardWillShow';
-    const hideListener = android ? 'keyboardDidHide' : 'keyboardWillHide';
+    const showListener = Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow';
+    const hideListener = Platform.OS === 'android' ? 'keyboardDidHide' : 'keyboardWillHide';
 
     keyboardShowListener.current = Keyboard.addListener(showListener, handleShowKeyboard);
     keyboardHideListener.current = Keyboard.addListener(hideListener, handleHideKeyboard);
@@ -394,7 +394,7 @@ function HideKeyboardButton({ color }: { color: string }) {
         <AccentColorProvider color={color}>
           <Box background="accent" borderRadius={15} height={{ custom: 30 }} shadow="15px light (Deprecated)" width={{ custom: 30 }}>
             <Cover alignHorizontal="center" alignVertical="center">
-              <Box paddingTop={android ? '4px' : '2px'}>
+              <Box paddingTop={Platform.OS === 'android' ? '4px' : '2px'}>
                 <Text align="center" color="primary (Deprecated)" size="14px / 19px (Deprecated)" weight="heavy">
                   􀆈
                 </Text>

--- a/src/features/ens/screens/ENSIntroSheet.tsx
+++ b/src/features/ens/screens/ENSIntroSheet.tsx
@@ -32,7 +32,7 @@ enum AnotherENSEnum {
   my_ens = 'my_ens',
 }
 
-const topPadding = android ? 29 : 19;
+const topPadding = Platform.OS === 'android' ? 29 : 19;
 
 const minHeight = 740;
 
@@ -238,7 +238,7 @@ export default function ENSIntroSheet() {
                   {isFetched && (
                     <>
                       {controlledDomains?.length === 0 ? (
-                        <Inset bottom={android ? '10px' : undefined}>
+                        <Inset bottom={Platform.OS === 'android' ? '10px' : undefined}>
                           <SheetActionButton
                             color={colors.appleBlue}
                             label={'􀠎 ' + i18n.t(i18n.l.profiles.intro.find_your_name)}
@@ -319,7 +319,7 @@ function InfoRow({ icon, title, description }: { icon: string; title: string; de
         <MaskedView
           maskElement={
             <Box
-              {...(android && {
+              {...(Platform.OS === 'android' && {
                 paddingTop: '6px',
               })}
             >

--- a/src/features/ens/screens/ENSSearchSheet.tsx
+++ b/src/features/ens/screens/ENSSearchSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
 import { type Source } from 'react-native-fast-image';
@@ -29,7 +29,7 @@ import { normalizeENS } from '../utils/records';
 export default function ENSSearchSheet() {
   const { navigate } = useNavigation();
 
-  const topPadding = android ? 29 : 19;
+  const topPadding = Platform.OS === 'android' ? 29 : 19;
 
   const { startRegistration, name } = useENSRegistration();
   const { finishRegistration } = useENSPendingRegistrations();

--- a/src/features/gas/components/CustomGasState.js
+++ b/src/features/gas/components/CustomGasState.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { useIsFocused, useRoute } from '@react-navigation/native';
 
@@ -28,7 +29,7 @@ function useAndroidDisableGesturesOnFocus() {
   const { params } = useRoute();
   const isFocused = useIsFocused();
   useEffect(() => {
-    android && params?.toggleGestureEnabled?.(!isFocused);
+    Platform.OS === 'android' && params?.toggleGestureEnabled?.(!isFocused);
   }, [isFocused, params]);
 }
 

--- a/src/features/gas/components/GasSpeedButton.tsx
+++ b/src/features/gas/components/GasSpeedButton.tsx
@@ -58,7 +58,7 @@ const CustomGasButton = styled(ButtonPressAnimation).attrs({
   borderColor: ({ borderColor, color, theme: { colors } }: WithThemeProps) => borderColor || color || colors.appleBlue,
   borderRadius: 19,
   borderWidth: 2,
-  ...padding.object(android ? 2 : 3, 0),
+  ...padding.object(Platform.OS === 'android' ? 2 : 3, 0),
 });
 
 const Symbol = styled(Text).attrs({
@@ -68,7 +68,7 @@ const Symbol = styled(Text).attrs({
   size: 'lmedium',
   weight: 'heavy',
 })({
-  ...padding.object(android ? 1 : 0, 6, 0, 7),
+  ...padding.object(Platform.OS === 'android' ? 1 : 0, 6, 0, 7),
 });
 
 const DoneCustomGas = styled(Text).attrs({
@@ -237,7 +237,7 @@ const GasSpeedButton = ({
 
   const openCustomOptions = useCallback(
     (focusTo: string) => {
-      if (ios) {
+      if (Platform.OS === 'ios') {
         setShouldOpenCustomGasSheet({ focusTo, shouldOpen: true });
       } else {
         openCustomGasSheet();
@@ -269,7 +269,7 @@ const GasSpeedButton = ({
   const handlePressSpeedOption = useCallback(
     (selectedSpeed: string) => {
       if (selectedSpeed === CUSTOM) {
-        if (ios) {
+        if (Platform.OS === 'ios') {
           InteractionManager.runAfterInteractions(() => {
             setShouldOpenCustomGasSheet({
               focusTo: null,
@@ -360,7 +360,7 @@ const GasSpeedButton = ({
             : `${toFixedDecimals(estimatedGwei, isL2 ? 4 : 0)}–${toFixedDecimals(totalGwei, isL2 ? 4 : 0)} Gwei`;
       return {
         actionKey: gasOption,
-        actionTitle: (android ? `${GAS_EMOJIS[gasOption]}  ` : '') + getGasLabel(gasOption),
+        actionTitle: (Platform.OS === 'android' ? `${GAS_EMOJIS[gasOption]}  ` : '') + getGasLabel(gasOption),
         discoverabilityTitle: gweiDisplay,
         icon: {
           iconType: 'ASSET',

--- a/src/features/gas/components/GasSpeedEmoji.js
+++ b/src/features/gas/components/GasSpeedEmoji.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { Emoji } from '@/components/text';
 import styled from '@/framework/ui/styled-thing';
@@ -11,27 +12,27 @@ const EmojiForGasSpeedType = {
   [gasUtils.URGENT]: {
     emoji: 'police_car_light',
     // 🚨
-    top: android ? -2 : -0.5,
+    top: Platform.OS === 'android' ? -2 : -0.5,
   },
   [gasUtils.FAST]: {
     emoji: 'rocket',
     // 🚀️
-    top: android ? -1.25 : -1.25,
+    top: Platform.OS === 'android' ? -1.25 : -1.25,
   },
   [gasUtils.NORMAL]: {
-    emoji: ios ? 'stopwatch' : 'nine_o_clock',
+    emoji: Platform.OS === 'ios' ? 'stopwatch' : 'nine_o_clock',
     // ⏱️ 🕘
-    top: android ? 0 : -1.25,
+    top: Platform.OS === 'android' ? 0 : -1.25,
   },
   [gasUtils.SLOW]: {
     emoji: 'snail',
     // 🐌️
-    top: android ? 0 : -1,
+    top: Platform.OS === 'android' ? 0 : -1,
   },
   [gasUtils.CUSTOM]: {
     emoji: 'gear',
     // ⚙️
-    top: android ? -0.5 : -0.5,
+    top: Platform.OS === 'android' ? -0.5 : -0.5,
   },
 };
 

--- a/src/features/gas/components/GasSpeedLabelPager.js
+++ b/src/features/gas/components/GasSpeedLabelPager.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 
 import { upperFirst } from 'lodash';
 
@@ -16,7 +17,7 @@ const SpeedButton = styled(ButtonPressAnimation).attrs({
   hapticType: 'impactHeavy',
   height: 30,
 })({
-  ...padding.object(2.5, 4, android ? 2.5 : 3.5, 5),
+  ...padding.object(2.5, 4, Platform.OS === 'android' ? 2.5 : 3.5, 5),
   borderColor: ({ color, theme: { colors } }) => color ?? colors.appleBlue,
   borderRadius: 19,
   borderWidth: 2,
@@ -25,7 +26,7 @@ const SpeedButton = styled(ButtonPressAnimation).attrs({
 const Symbol = styled(Text).attrs({
   align: 'center',
   lineHeight: 'normal',
-  size: android ? 'bmedium' : 'lmedium',
+  size: Platform.OS === 'android' ? 'bmedium' : 'lmedium',
   weight: 'heavy',
 })(margin.object(0));
 

--- a/src/features/wallet-connect/components/WalletConnectV2ListItem.tsx
+++ b/src/features/wallet-connect/components/WalletConnectV2ListItem.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { type SessionTypes } from '@walletconnect/types';
 import RadialGradient from 'react-native-radial-gradient';
@@ -163,7 +164,7 @@ export function WalletConnectV2ListItem({ session, reload }: { session: SessionT
             showLargeShadow={false}
             size={VENDOR_LOGO_ICON_SIZE}
           />
-          <ColumnWithMargins flex={1} margin={android ? -4 : 5} style={columnStyle}>
+          <ColumnWithMargins flex={1} margin={Platform.OS === 'android' ? -4 : 5} style={columnStyle}>
             <Row width="95%">
               <TruncatedText size="lmedium" weight="heavy">
                 {dappName || i18n.t(i18n.l.walletconnect.unknown_application)}

--- a/src/handlers/aesEncryption.ts
+++ b/src/handlers/aesEncryption.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const AesEncryption = NativeModules.Aes;
 
@@ -13,7 +13,7 @@ export default class AesEncryptor {
   }
 
   generateKey = (password: any, salt: any) =>
-    android ? AesEncryption.pbkdf2(password, salt, 5000, 256) : AesEncryption.pbkdf2(password, salt);
+    Platform.OS === 'android' ? AesEncryption.pbkdf2(password, salt, 5000, 256) : AesEncryption.pbkdf2(password, salt);
 
   keyFromPassword = (password: any, salt: any) => this.generateKey(password, salt);
 

--- a/src/handlers/cloudBackup.ts
+++ b/src/handlers/cloudBackup.ts
@@ -53,7 +53,7 @@ export async function getGoogleAccountUserData(checkPermissions = false): Promis
 
 // This is used for dev purposes only!
 export async function deleteAllBackups() {
-  if (android) {
+  if (Platform.OS === 'android') {
     await RNCloudFs.loginIfNeeded();
   }
   const backups = await RNCloudFs.listFiles({
@@ -68,7 +68,7 @@ export async function deleteAllBackups() {
 }
 
 export async function fetchAllBackups(): Promise<CloudBackups> {
-  if (android) {
+  if (Platform.OS === 'android') {
     await RNCloudFs.loginIfNeeded();
   }
 
@@ -150,7 +150,7 @@ function getGoogleDriveDocument(id: any) {
 }
 
 export function syncCloud() {
-  if (ios) {
+  if (Platform.OS === 'ios') {
     return RNCloudFs.syncCloud();
   }
   return true;
@@ -193,7 +193,7 @@ export async function getDataFromCloud(backupPassword: any, filename: string | n
     const sortedBackups = sortBy(backups.files, 'lastModified').reverse();
     document = sortedBackups[0];
   }
-  const encryptedData = ios ? await getICloudDocument(filename) : await getGoogleDriveDocument(document.id);
+  const encryptedData = Platform.OS === 'ios' ? await getICloudDocument(filename) : await getGoogleDriveDocument(document.id);
 
   if (encryptedData) {
     logger.debug(`[cloudBackup]: Got cloud document ${filename}`);
@@ -220,7 +220,7 @@ export function isCloudBackupPasswordValid(password: any) {
 }
 
 export function isCloudBackupAvailable() {
-  if (ios) {
+  if (Platform.OS === 'ios') {
     return RNCloudFs.isAvailable();
   }
   return true;

--- a/src/helpers/alert.ts
+++ b/src/helpers/alert.ts
@@ -1,11 +1,11 @@
-import { Alert, ToastAndroid, type AlertButton, type AlertOptions } from 'react-native';
+import { Alert, Platform, ToastAndroid, type AlertButton, type AlertOptions } from 'react-native';
 
 import { IS_TEST } from '@/env';
 
 const WrappedAlert = {
   ...Alert,
   alert: (title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions) => {
-    if (android && !buttons && !options && IS_TEST) {
+    if (Platform.OS === 'android' && !buttons && !options && IS_TEST) {
       const text = message ? `${title}\n${message}` : title;
       ToastAndroid.show(text, ToastAndroid.SHORT);
     } else {

--- a/src/hooks/useAndroidScrollViewGestureHandler.ts
+++ b/src/hooks/useAndroidScrollViewGestureHandler.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
+import { Platform, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 
 import { type NavigationProp } from '@react-navigation/native';
 
@@ -20,7 +20,7 @@ export default function useAndroidScrollViewGestureHandler({
   const gestureEnabled = useRef(true);
   const onScroll = useCallback(
     ({ nativeEvent }: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (!android) return;
+      if (Platform.OS !== 'android') return;
       if (nativeEvent.contentOffset.y <= 0 && !gestureEnabled.current) {
         navigation.setOptions({ gestureEnabled: true });
         gestureEnabled.current = true;

--- a/src/hooks/useMagicAutofocus.ts
+++ b/src/hooks/useMagicAutofocus.ts
@@ -89,7 +89,7 @@ export default function useMagicAutofocus(
   // ✨️ Make the magic happen
   useFocusEffect(
     useCallback(() => {
-      if (android && !shouldFocusOnNavigateOnAndroid) {
+      if (Platform.OS === 'android' && !shouldFocusOnNavigateOnAndroid) {
         return;
       }
 

--- a/src/hooks/useOnAvatarPress.ts
+++ b/src/hooks/useOnAvatarPress.ts
@@ -202,27 +202,27 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
         !isZeroETH && {
           actionKey: 'editProfile',
           actionTitle: i18n.t(i18n.l.profiles.profile_avatar.edit_profile),
-          ...(ios && { icon: { iconType: 'SYSTEM', iconValue: 'pencil.circle' } }),
+          ...(Platform.OS === 'ios' && { icon: { iconType: 'SYSTEM', iconValue: 'pencil.circle' } }),
         },
       isENSProfile && {
         actionKey: 'viewProfile',
         actionTitle: i18n.t(i18n.l.profiles.profile_avatar.view_profile),
-        ...(ios && { icon: { iconType: 'SYSTEM', iconValue: 'person.crop.circle' } }),
+        ...(Platform.OS === 'ios' && { icon: { iconType: 'SYSTEM', iconValue: 'person.crop.circle' } }),
       },
       !isENSProfile &&
         !isReadOnly &&
         !isZeroETH && {
           actionKey: 'createProfile',
           actionTitle: i18n.t(i18n.l.profiles.profile_avatar.create_profile),
-          ...(ios && { icon: { iconType: 'SYSTEM', iconValue: 'person.crop.circle' } }),
+          ...(Platform.OS === 'ios' && { icon: { iconType: 'SYSTEM', iconValue: 'person.crop.circle' } }),
         },
       {
         actionKey: 'chooseFromLibrary',
         actionTitle: i18n.t(i18n.l.profiles.profile_avatar.choose_from_library),
-        ...(ios && { icon: { iconType: 'SYSTEM', iconValue: 'photo.on.rectangle.angled' } }),
+        ...(Platform.OS === 'ios' && { icon: { iconType: 'SYSTEM', iconValue: 'photo.on.rectangle.angled' } }),
       },
       !accountImage
-        ? ios
+        ? Platform.OS === 'ios'
           ? {
               actionKey: 'pickEmoji',
               actionTitle: i18n.t(i18n.l.profiles.profile_avatar.pick_emoji),
@@ -244,7 +244,7 @@ export default ({ screenType = 'transaction' }: UseOnAvatarPressProps = {}) => {
 
   const avatarActionSheetOptions = avatarContextMenuConfig.menuItems
     .map(item => item && item.actionTitle)
-    .concat(ios ? ['Cancel'] : [])
+    .concat(Platform.OS === 'ios' ? ['Cancel'] : [])
     .filter(Boolean) as string[];
 
   const onAvatarPressProfile = useCallback(() => {

--- a/src/hooks/useSelectImageMenu.tsx
+++ b/src/hooks/useSelectImageMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
+import { Platform } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
 import { useMutation } from '@tanstack/react-query';
@@ -188,7 +189,7 @@ export default function useSelectImageMenu({
           menuItems: menuItems.map(item => items[item]) as any,
           menuTitle: '',
         }}
-        {...(android ? { onPress: handleAndroidPress } : {})}
+        {...(Platform.OS === 'android' ? { onPress: handleAndroidPress } : {})}
         isMenuPrimaryAction
         onPressMenuItem={handlePressMenuItem}
         testID={`use-select-image-${testID}`}

--- a/src/keychain/index.ts
+++ b/src/keychain/index.ts
@@ -390,7 +390,7 @@ export async function getPrivateAccessControlOptions(): Promise<SetOptions> {
   const usePin = await shouldAuthenticateWithPIN();
 
   return {
-    accessControl: ios ? ACCESS_CONTROL.USER_PRESENCE : ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE,
+    accessControl: Platform.OS === 'ios' ? ACCESS_CONTROL.USER_PRESENCE : ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE,
     accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
     // storage is explicitly set in order to specify RSA instead of the symmetric AES_GCM default.
     storage: usePin ? STORAGE_TYPE.AES_GCM_NO_AUTH : STORAGE_TYPE.RSA,

--- a/src/navigation/config.tsx
+++ b/src/navigation/config.tsx
@@ -89,7 +89,7 @@ const buildCoolModalConfig = (params: CoolModalConfigParams): CoolModalConfigOpt
   blocksBackgroundTouches: true,
   cornerRadius:
     params.cornerRadius === 'device'
-      ? android
+      ? Platform.OS === 'android'
         ? 30
         : 0.666 // 0.666 gets the screen corner radius internally
       : params.cornerRadius === 0
@@ -719,7 +719,7 @@ export const walletErrorSheetConfig: PartialNavigatorConfigOptions = {
 
 export const stackNavigationConfig = {
   headerMode: 'none',
-  keyboardHandlingEnabled: ios,
+  keyboardHandlingEnabled: Platform.OS === 'ios',
   mode: 'modal',
 };
 
@@ -733,7 +733,7 @@ export const closeKeyboardOnClose = {
   listeners: {
     // @ts-ignore
     transitionEnd: ({ data: { closing } }) => {
-      closing && android && Keyboard.dismiss();
+      closing && Platform.OS === 'android' && Keyboard.dismiss();
     },
   },
 };
@@ -764,7 +764,7 @@ const BackArrow = styled(Icon).attrs({
 })({
   marginLeft: 15,
   marginRight: 5,
-  marginTop: android ? 12 : 0.5,
+  marginTop: Platform.OS === 'android' ? 12 : 0.5,
 });
 
 const BackImage = () => <BackArrow />;
@@ -782,7 +782,7 @@ const headerConfigOptions = {
   headerRightContainerStyle: {
     paddingRight: 4,
   },
-  ...(android && {
+  ...(Platform.OS === 'android' && {
     headerRightContainerStyle: {
       paddingTop: 6,
     },

--- a/src/navigation/effects.tsx
+++ b/src/navigation/effects.tsx
@@ -19,7 +19,7 @@ import { type BottomSheetNavigationOptions } from './bottom-sheet/types';
 const statusBarHeight = safeAreaInsetValues.top;
 export const sheetVerticalOffset = statusBarHeight;
 
-export const AVATAR_CIRCLE_TOP_MARGIN = android ? 10 : 4;
+export const AVATAR_CIRCLE_TOP_MARGIN = Platform.OS === 'android' ? 10 : 4;
 
 const backgroundInterpolator = ({ current: { progress: current }, layouts: { screen } }: any) => {
   const cardOpacity = current.interpolate({

--- a/src/navigation/onNavigationStateChange.js
+++ b/src/navigation/onNavigationStateChange.js
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 import { SystemBars } from 'react-native-edge-to-edge';
 
@@ -34,7 +34,7 @@ export function onHandleStatusBar(currentState, prevState) {
       if (isRoutesLengthDecrease && isFromWalletScreen && routeName === Routes.EXPANDED_ASSET_SHEET) {
         SystemBars.setStyle({ statusBar: 'dark' });
         break;
-      } else if (!android && isFromWalletScreen && memRouteName !== Routes.WALLET_SCREEN) {
+      } else if (Platform.OS !== 'android' && isFromWalletScreen && memRouteName !== Routes.WALLET_SCREEN) {
         SystemBars.setStyle({ statusBar: 'light' });
         break;
       }
@@ -105,7 +105,7 @@ export function onNavigationStateChange(currentState) {
   const prevState = memState;
   memState = currentState;
 
-  if (android) {
+  if (Platform.OS === 'android') {
     NativeModules.MenuViewModule.dismiss();
     setTimeout(NativeModules.MenuViewModule.dismiss, 400);
   }

--- a/src/notifications/foregroundHandler.ts
+++ b/src/notifications/foregroundHandler.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Platform } from 'react-native';
+
 import notifee, { AndroidStyle, type Notification } from '@notifee/react-native';
 
 import { logger, RainbowError } from '@/logger';
@@ -6,7 +8,7 @@ import { ANDROID_DEFAULT_CHANNEL_ID, ANDROID_GROUP_ID } from '@/notifications/co
 import { type FixedRemoteMessage } from '@/notifications/types';
 
 export function handleShowingForegroundNotification(remoteMessage: FixedRemoteMessage) {
-  const image = ios ? remoteMessage.data?.fcm_options?.image : remoteMessage.notification?.android?.imageUrl;
+  const image = Platform.OS === 'ios' ? remoteMessage.data?.fcm_options?.image : remoteMessage.notification?.android?.imageUrl;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { fcm_options, ...data } = remoteMessage.data;
   const notification: Notification = {

--- a/src/react-native-shadow-stack/ShadowStack.js
+++ b/src/react-native-shadow-stack/ShadowStack.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import ShadowItem from './ShadowItem';
 
@@ -30,13 +30,13 @@ const ShadowStack = React.forwardRef(
         {...props}
         backgroundColor="transparent"
         borderRadius={borderRadius}
-        height={ios ? height : height || 0}
+        height={Platform.OS === 'ios' ? height : height || 0}
         ref={ref}
         style={style}
         width={width}
         zIndex={1}
       >
-        {ios && shadows?.map(renderItem)}
+        {Platform.OS === 'ios' && shadows?.map(renderItem)}
         <View
           {...props}
           borderRadius={borderRadius}

--- a/src/react-native-shadow-stack/ShadowView.js
+++ b/src/react-native-shadow-stack/ShadowView.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 const ShadowView = props => {
-  if (ios || props.elevation > 0) {
+  if (Platform.OS === 'ios' || props.elevation > 0) {
     return <View {...props} />;
   }
   return <View {...props} elevation={Math.min(StyleSheet.flatten(props.style).shadowRadius, 5)} />;

--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { changeIcon } from 'react-native-change-icon';
 import { type Dispatch } from 'redux';
 import { type ThunkDispatch } from 'redux-thunk';
@@ -181,7 +183,7 @@ export const settingsChangeAppIcon = (appIcon: string) => (dispatch: Dispatch<Se
     }
   };
 
-  if (android) {
+  if (Platform.OS === 'android') {
     Alert.alert(i18n.t(i18n.l.settings.icon_change.title), i18n.t(i18n.l.settings.icon_change.warning), [
       {
         onPress: () => {},

--- a/src/screens/Diagnostics/DiagnosticsSecretInput.tsx
+++ b/src/screens/Diagnostics/DiagnosticsSecretInput.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { TextInput } from 'react-native';
+import { Platform, TextInput } from 'react-native';
 
 import Clipboard from '@react-native-clipboard/clipboard';
 import { triggerHaptics } from 'react-native-turbo-haptics';
@@ -48,7 +48,7 @@ export const DiagnosticsSecretInput = ({ value, color }: { value: string; color:
         <Row
           backgroundColor={colors.appleBlue}
           borderRadius={15}
-          style={{ paddingHorizontal: android ? 10 : 15, paddingVertical: 10 }}
+          style={{ paddingHorizontal: Platform.OS === 'android' ? 10 : 15, paddingVertical: 10 }}
           width="100%"
         >
           <Text align="center" color={colors.whiteLabel} weight="bold">

--- a/src/screens/ExpandedAssetSheet.tsx
+++ b/src/screens/ExpandedAssetSheet.tsx
@@ -1,4 +1,5 @@
 import React, { createElement } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 
@@ -39,7 +40,7 @@ export default function ExpandedAssetSheet(props: any) {
 
   return (
     <Container deviceHeight={deviceHeight} height={params.longFormHeight}>
-      {ios && <TouchableBackdrop onPress={goBack} />}
+      {Platform.OS === 'ios' && <TouchableBackdrop onPress={goBack} />}
 
       {createElement(ScreenTypes[params.type], {
         ...params,

--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Keyboard } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 
 import { useRoute } from '@react-navigation/native';
 import { triggerHaptics } from 'react-native-turbo-haptics';
@@ -128,7 +128,7 @@ const PinAuthenticationScreen = () => {
 
   const handleNumpadPress = useCallback(
     newValue => {
-      android && triggerHaptics('selection');
+      Platform.OS === 'android' && triggerHaptics('selection');
       setValue(prevValue => {
         let nextValue = prevValue;
         if (nextValue === null) {

--- a/src/screens/ProfileSheet.tsx
+++ b/src/screens/ProfileSheet.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useEffect, useMemo } from 'react';
+import { Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -102,7 +103,7 @@ export default function ProfileSheet() {
 function AndroidWrapper({ children }: { children: React.ReactElement }) {
   const safeAreaInsets = useSafeAreaInsets();
 
-  return android ? (
+  return Platform.OS === 'android' ? (
     <Box borderTopRadius={30} style={{ overflow: 'hidden' }} top={{ custom: safeAreaInsets.top }}>
       {children}
     </Box>

--- a/src/screens/SelectUniqueTokenSheet.tsx
+++ b/src/screens/SelectUniqueTokenSheet.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useEffect } from 'react';
+import { Platform } from 'react-native';
 
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 
@@ -37,8 +38,8 @@ export default function SelectUniqueTokenSheet() {
     <Box
       background="body (Deprecated)"
       height="full"
-      paddingTop={android ? undefined : '34px (Deprecated)'}
-      {...(android && { borderTopRadius: 30 })}
+      paddingTop={Platform.OS === 'android' ? undefined : '34px (Deprecated)'}
+      {...(Platform.OS === 'android' && { borderTopRadius: 30 })}
     >
       <Box alignItems="center" justifyContent="center" paddingVertical="10px">
         <SheetHandle />

--- a/src/screens/SettingsSheet/components/Backups/ViewCloudBackups.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewCloudBackups.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Platform } from 'react-native';
 
 import ActivityIndicator from '@/components/ActivityIndicator';
 import { Page } from '@/components/layout';
@@ -25,7 +26,7 @@ type LoadingTextProps = {
 
 const LoadingText = styled(RNText).attrs(({ theme: { colors } }: LoadingTextProps) => ({
   color: colors.blueGreyDark,
-  lineHeight: ios ? 'none' : 24,
+  lineHeight: Platform.OS === 'ios' ? 'none' : 24,
   size: 'large',
   weight: 'semibold',
 }))({
@@ -148,7 +149,7 @@ const ViewCloudBackups = () => {
   if (isLoading) {
     return (
       <Box color={colors.transparent} alignItems="center" justifyContent="center" flex={1} as={Page}>
-        {android ? <Spinner color={colors.blueGreyDark} /> : <ActivityIndicator color={colors.blueGreyDark} />}
+        {Platform.OS === 'android' ? <Spinner color={colors.blueGreyDark} /> : <ActivityIndicator color={colors.blueGreyDark} />}
         <LoadingText>{titleForBackupState[status]}</LoadingText>
       </Box>
     );

--- a/src/screens/SettingsSheet/components/MenuContainer.tsx
+++ b/src/screens/SettingsSheet/components/MenuContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -18,18 +18,18 @@ const MenuContainer = ({ scrollviewRef, children, testID, Footer, space = '36px'
 
   return (
     // ios scroll fix
-    <Inset bottom={{ custom: safeAreaInsets.bottom }} top={ios ? '12px' : undefined}>
+    <Inset bottom={{ custom: safeAreaInsets.bottom }} top={Platform.OS === 'ios' ? '12px' : undefined}>
       <ScrollView
         ref={scrollviewRef}
         scrollEventThrottle={32}
         // ios scroll fix
-        {...(ios && { style: { overflow: 'visible' } })}
+        {...(Platform.OS === 'ios' && { style: { overflow: 'visible' } })}
         testID={testID}
       >
         <Box
           paddingHorizontal="19px (Deprecated)"
           // fix clipped shadows on android
-          {...(android && {
+          {...(Platform.OS === 'android' && {
             paddingBottom: { custom: 22 },
             paddingTop: { custom: 7 },
           })}

--- a/src/screens/SettingsSheet/components/MenuHeader.tsx
+++ b/src/screens/SettingsSheet/components/MenuHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type ImageSourcePropType } from 'react-native';
+import { Platform, type ImageSourcePropType } from 'react-native';
 
 import { type Source } from 'react-native-fast-image';
 
@@ -105,7 +105,7 @@ const StatusIcon = ({ status, text }: StatusIconProps) => {
       borderRadius={23}
       shadowColor={isDarkMode ? colors.shadow : statusColors[status].backgroundColor}
       elevation={12}
-      shadowOpacity={ios ? 0.4 : 1}
+      shadowOpacity={Platform.OS === 'ios' ? 0.4 : 1}
       shadowRadius={6}
       padding={{ custom: 8 }}
       marginTop={{ custom: 8 }}

--- a/src/screens/SettingsSheet/components/MenuItem.tsx
+++ b/src/screens/SettingsSheet/components/MenuItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type ImageSourcePropType } from 'react-native';
+import { Platform, type ImageSourcePropType } from 'react-native';
 
 import { type Source } from 'react-native-fast-image';
 
@@ -101,7 +101,7 @@ const StatusIcon = ({ status }: StatusIconProps) => {
         width: 0,
       }}
       elevation={12}
-      shadowOpacity={ios ? 0.4 : 1}
+      shadowOpacity={Platform.OS === 'ios' ? 0.4 : 1}
       shadowRadius={6}
     />
   );

--- a/src/screens/SettingsSheet/components/SettingsSection.tsx
+++ b/src/screens/SettingsSheet/components/SettingsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { Share } from 'react-native';
+import { Platform, Share } from 'react-native';
 
 import { ContextMenuButton, type MenuActionConfig } from 'react-native-ios-context-menu';
 
@@ -76,7 +76,7 @@ const SettingsSection = ({
   const { isDarkMode, setTheme, colorScheme } = useTheme();
 
   const onPressReview = useCallback(async () => {
-    if (ios) {
+    if (Platform.OS === 'ios') {
       onCloseModal();
     }
     handleReviewPromptAction(ReviewPromptAction.UserPrompt);
@@ -216,7 +216,7 @@ const SettingsSection = ({
         />
         <ContextMenuButton
           menuConfig={themeMenuConfig}
-          {...(android ? { onPress: onPressThemeAndroidActions } : {})}
+          {...(Platform.OS === 'android' ? { onPress: onPressThemeAndroidActions } : {})}
           isMenuPrimaryAction
           // @ts-ignore
           menuAlignmentOverride="right"
@@ -308,7 +308,7 @@ const SettingsSection = ({
         />
         {dev_section_enabled && (
           <MenuItem
-            leftComponent={<MenuItem.TextIcon icon={ios ? '🚧' : '🐞'} isEmoji />}
+            leftComponent={<MenuItem.TextIcon icon={Platform.OS === 'ios' ? '🚧' : '🐞'} isEmoji />}
             onPress={onPressDev}
             size={52}
             testID="developer-section"

--- a/src/screens/SpeedUpAndCancelSheet.tsx
+++ b/src/screens/SpeedUpAndCancelSheet.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, Platform, View } from 'react-native';
 
 import { type BigNumberish } from '@ethersproject/bignumber';
 import { type BytesLike } from '@ethersproject/bytes';
@@ -81,10 +81,12 @@ const ExtendedSheetBackground = styled(View)({
   width: '100%',
 });
 
-const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(({ theme: { colors } }: WithThemeContextProps) => ({
-  color: opacity(colors.blueGreyDark, 0.3),
-  size: 'large',
-}))({});
+const LoadingSpinner = styled(Platform.OS === 'android' ? Spinner : ActivityIndicator).attrs(
+  ({ theme: { colors } }: WithThemeContextProps) => ({
+    color: opacity(colors.blueGreyDark, 0.3),
+    size: 'large',
+  })
+)({});
 
 const AnimatedContainer = Animated.createAnimatedComponent(Container);
 const AnimatedSheet = Animated.createAnimatedComponent<ComponentProps<typeof CenteredSheet>>(CenteredSheet);
@@ -435,9 +437,10 @@ export default function SpeedUpAndCancelSheet() {
     offset.value = withSpring(0, springConfig);
   }, [offset]);
 
-  const sheetHeight = ios ? (type === CANCEL_TX ? 491 : 442) + safeAreaInsetValues.bottom : 850 + safeAreaInsetValues.bottom;
+  const sheetHeight =
+    Platform.OS === 'ios' ? (type === CANCEL_TX ? 491 : 442) + safeAreaInsetValues.bottom : 850 + safeAreaInsetValues.bottom;
 
-  const marginTop = android ? deviceHeight - sheetHeight + (type === CANCEL_TX ? 290 : 340) : null;
+  const marginTop = Platform.OS === 'android' ? deviceHeight - sheetHeight + (type === CANCEL_TX ? 290 : 340) : null;
 
   const { colors, isDarkMode } = useTheme();
 
@@ -465,7 +468,7 @@ export default function SpeedUpAndCancelSheet() {
             borderRadius={39}
             direction="column"
             marginTop={marginTop}
-            paddingBottom={android ? 30 : 0}
+            paddingBottom={Platform.OS === 'android' ? 30 : 0}
           >
             <SheetHandleFixedToTop showBlur={false} />
             <Centered direction="column">
@@ -492,8 +495,8 @@ export default function SpeedUpAndCancelSheet() {
                     <Divider color={colors.rowDividerExtraLight} inset={[0, 143.5]} />
                   </Centered>
                   {type === CANCEL_TX && (
-                    <Column marginBottom={android && 15}>
-                      <SheetActionButtonRow ignorePaddingBottom ignorePaddingTop={ios}>
+                    <Column marginBottom={Platform.OS === 'android' && 15}>
+                      <SheetActionButtonRow ignorePaddingBottom ignorePaddingTop={Platform.OS === 'ios'}>
                         <SheetActionButton
                           color={colors.red}
                           disabled={!hasTransactionNonce}
@@ -516,7 +519,7 @@ export default function SpeedUpAndCancelSheet() {
                     </Column>
                   )}
                   {type === SPEED_UP && (
-                    <SheetActionButtonRow ignorePaddingBottom={ios} ignorePaddingTop={ios}>
+                    <SheetActionButtonRow ignorePaddingBottom={Platform.OS === 'ios'} ignorePaddingTop={Platform.OS === 'ios'}>
                       <SheetActionButton
                         color={colors.white}
                         label={i18n.t(i18n.l.button.cancel)}

--- a/src/screens/WalletConnectApprovalSheet.tsx
+++ b/src/screens/WalletConnectApprovalSheet.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, InteractionManager } from 'react-native';
+import { ActivityIndicator, InteractionManager, Platform } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { noop } from 'lodash';
@@ -41,9 +41,9 @@ type WithThemeProps = {
   theme: ThemeContextProps;
 };
 
-const LoadingSpinner = styled(android ? Spinner : ActivityIndicator).attrs(({ theme: { colors } }: WithThemeProps) => ({
+const LoadingSpinner = styled(Platform.OS === 'android' ? Spinner : ActivityIndicator).attrs(({ theme: { colors } }: WithThemeProps) => ({
   color: opacity(colors.blueGreyDark, 0.3),
-  size: android ? 40 : 'large',
+  size: Platform.OS === 'android' ? 40 : 'large',
 }))({});
 
 const DappLogo = styled(RequestVendorLogoIcon).attrs(({ theme: { colors } }: WithThemeProps) => ({
@@ -431,7 +431,7 @@ export function WalletConnectApprovalSheet() {
               />
             </Box>
           )}
-          <SheetActionButtonRow paddingBottom={android ? 20 : 30}>
+          <SheetActionButtonRow paddingBottom={Platform.OS === 'android' ? 20 : 30}>
             <SheetActionButton
               color={colors.white}
               label={i18n.t(i18n.l.button.cancel)}

--- a/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
+++ b/src/screens/WelcomeScreen/WelcomeScreenRainbowButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, type StyleProp, type ViewStyle } from 'react-native';
 
 import Reanimated from 'react-native-reanimated';
 
@@ -51,7 +51,7 @@ const Shadow = styled(Reanimated.View)(({ theme: { colors, isDarkMode } }: { the
   height: 60,
   position: 'absolute',
   width: 236,
-  ...(ios
+  ...(Platform.OS === 'ios'
     ? {
         left: -3,
         top: -3,
@@ -83,7 +83,7 @@ export const WelcomeScreenRainbowButton = ({
 }: Props) => {
   return (
     <ButtonPressAnimation onPress={onPress} radiusAndroid={height / 2} scaleTo={0.9} {...props}>
-      {ios && <DarkShadow style={darkShadowStyle} />}
+      {Platform.OS === 'ios' && <DarkShadow style={darkShadowStyle} />}
       <Shadow style={shadowStyle} />
       <ButtonContainer height={height} style={style}>
         <ButtonContent>

--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -96,7 +96,7 @@ const BlurWrapper = styled(View).attrs({
   overflow: 'hidden',
   position: 'absolute',
   width: ({ width }: BlurWrapperProps) => width,
-  ...(android ? { borderTopLeftRadius: 30, borderTopRightRadius: 30 } : {}),
+  ...(Platform.OS === 'android' ? { borderTopLeftRadius: 30, borderTopRightRadius: 30 } : {}),
 });
 
 interface MintSheetProps {
@@ -528,7 +528,7 @@ const MintSheet = () => {
 
   return (
     <>
-      {ios && (
+      {Platform.OS === 'ios' && (
         <BlurWrapper height={deviceHeight} width={deviceWidth}>
           <BackgroundImage>
             <ImgixImage
@@ -542,7 +542,9 @@ const MintSheet = () => {
         </BlurWrapper>
       )}
       <SlackSheet
-        backgroundColor={isDarkMode ? `rgba(22, 22, 22, ${ios ? 0.4 : 1})` : `rgba(26, 26, 26, ${ios ? 0.4 : 1})`}
+        backgroundColor={
+          isDarkMode ? `rgba(22, 22, 22, ${Platform.OS === 'ios' ? 0.4 : 1})` : `rgba(26, 26, 26, ${Platform.OS === 'ios' ? 0.4 : 1})`
+        }
         {...(Platform.OS === 'ios' ? { height: '100%' } : {})}
         ref={sheetRef}
         scrollEnabled

--- a/src/screens/mints/components/QuantityButton.tsx
+++ b/src/screens/mints/components/QuantityButton.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
@@ -133,12 +134,12 @@ export function QuantityButton({ value, plusAction, minusAction, buttonColor, di
     if (!prevTrigger && trigger) {
       if (actionType === PLUS_ACTION_TYPE) {
         plusAction();
-        if (!android) {
+        if (Platform.OS !== 'android') {
           triggerHaptics('selection');
         }
       } else if (actionType === MINUS_ACTION_TYPE) {
         minusAction();
-        if (!android) {
+        if (Platform.OS !== 'android') {
           triggerHaptics('selection');
         }
       }

--- a/src/screens/transaction-details/components/TransactionMasthead.tsx
+++ b/src/screens/transaction-details/components/TransactionMasthead.tsx
@@ -48,7 +48,7 @@ import { addressHashedColorIndex, addressHashedEmoji } from '@/utils/profileUtil
 import { safeSum } from '@/utils/safeSum';
 import { useDelegations } from '@rainbow-me/delegation';
 
-const TransactionMastheadHeight = android ? 153 : 135;
+const TransactionMastheadHeight = Platform.OS === 'android' ? 153 : 135;
 
 const Container = styled(Box).attrs({
   direction: 'column',
@@ -59,7 +59,7 @@ const Container = styled(Box).attrs({
   height: TransactionMastheadHeight,
   overflow: 'hidden',
   zIndex: 0,
-  ...(android ? { paddingTop: 4 } : {}),
+  ...(Platform.OS === 'android' ? { paddingTop: 4 } : {}),
   justifyContent: 'center',
   alitnItems: 'center',
 });

--- a/src/styles/buildTextStyles.js
+++ b/src/styles/buildTextStyles.js
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { isNil } from 'lodash';
 
 import { css } from '@/framework/ui/styled-thing';
@@ -49,7 +51,7 @@ function selectBestFontFitWorklet(weight) {
 }
 
 function familyFontWithAndroidWidth(weight, family) {
-  return `${fonts.family[family]}${android ? `-${selectBestFontFit(weight)}` : ''}`;
+  return `${fonts.family[family]}${Platform.OS === 'android' ? `-${selectBestFontFit(weight)}` : ''}`;
 }
 
 export function fontWithWidth(weight, family = 'SFProRounded') {
@@ -57,13 +59,13 @@ export function fontWithWidth(weight, family = 'SFProRounded') {
     fontFamily: familyFontWithAndroidWidth(weight, family),
     // https://github.com/facebook/react-native/issues/18820
     // https://www.youtube.com/watch?v=87rhZTumujw
-    ...(ios ? { fontWeight: weight } : { fontWeight: 'normal' }),
+    ...(Platform.OS === 'ios' ? { fontWeight: weight } : { fontWeight: 'normal' }),
   };
 }
 
 function familyFontWithAndroidWidthWorklet(weight, family) {
   'worklet';
-  return `${fonts.family[family]}${android ? `-${selectBestFontFitWorklet(weight)}` : ''}`;
+  return `${fonts.family[family]}${Platform.OS === 'android' ? `-${selectBestFontFitWorklet(weight)}` : ''}`;
 }
 
 export function fontWithWidthWorklet(weight, family = 'SFProRounded') {
@@ -72,7 +74,7 @@ export function fontWithWidthWorklet(weight, family = 'SFProRounded') {
     fontFamily: familyFontWithAndroidWidthWorklet(weight, family),
     // https://github.com/facebook/react-native/issues/18820
     // https://www.youtube.com/watch?v=87rhZTumujw
-    ...(ios ? { fontWeight: weight } : { fontWeight: 'normal' }),
+    ...(Platform.OS === 'ios' ? { fontWeight: weight } : { fontWeight: 'normal' }),
   };
 }
 
@@ -90,7 +92,8 @@ const buildTextStyles = css`
   font-size:  ${({ size = 'medium' }) => (typeof size === 'number' ? size : (fonts?.size?.[size] ?? size))};
 
   /* Font Weight */
-  ${({ isEmoji, weight = 'regular' }) => (isEmoji || isNil(weight) || android ? '' : `font-weight: ${fonts?.weight?.[weight] ?? weight};`)}
+  ${({ isEmoji, weight = 'regular' }) =>
+    isEmoji || isNil(weight) || Platform.OS === 'android' ? '' : `font-weight: ${fonts?.weight?.[weight] ?? weight};`}
 
   /* Letter Spacing */
   ${({ letterSpacing = 'rounded' }) =>
@@ -98,7 +101,7 @@ const buildTextStyles = css`
 
   /* Line Height */
   ${({ isEmoji, lineHeight }) =>
-    isNil(lineHeight) || (isEmoji && android) ? '' : `line-height: ${fonts?.lineHeight?.[lineHeight] ?? lineHeight};`}
+    isNil(lineHeight) || (isEmoji && Platform.OS === 'android') ? '' : `line-height: ${fonts?.lineHeight?.[lineHeight] ?? lineHeight};`}
 
   /* Opacity */
   ${({ opacity }) => (isNil(opacity) ? '' : `opacity: ${opacity};`)}
@@ -112,7 +115,7 @@ const buildTextStyles = css`
   /* Uppercase */
   ${({ uppercase }) => (uppercase ? 'text-transform: uppercase;' : '')}
 
-  ${android ? 'include-font-padding: false;\ntext-align-vertical: center;' : ''}
+  ${Platform.OS === 'android' ? 'include-font-padding: false;\ntext-align-vertical: center;' : ''}
 `;
 
 buildTextStyles.object = ({
@@ -139,7 +142,7 @@ buildTextStyles.object = ({
     styles.fontFamily = familyFontWithAndroidWidth(weight, family, mono);
   }
 
-  if (!(isEmoji || isNil(weight) || android)) {
+  if (!(isEmoji || isNil(weight) || Platform.OS === 'android')) {
     if (typeof weight === 'undefined') {
       weight = 'regular';
     }
@@ -151,7 +154,7 @@ buildTextStyles.object = ({
     styles.letterSpacing = fonts.letterSpacing[letterSpacing] ?? letterSpacing;
   }
 
-  if (!(isNil(lineHeight) || (isEmoji && android))) {
+  if (!(isNil(lineHeight) || (isEmoji && Platform.OS === 'android'))) {
     styles.lineHeight = fonts.lineHeight[lineHeight] ?? lineHeight;
   }
 
@@ -171,7 +174,7 @@ buildTextStyles.object = ({
     styles.textTransform = 'uppercase';
   }
 
-  if (android) {
+  if (Platform.OS === 'android') {
     styles.includeFontPadding = false;
     styles.textAlignVertical = 'center';
   }

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
-import { Appearance, LayoutAnimation, useColorScheme } from 'react-native';
+import { Appearance, LayoutAnimation, Platform, useColorScheme } from 'react-native';
 
 import { useDarkMode } from 'react-native-dark-mode';
 import { ThemeProvider } from 'styled-components';
@@ -54,7 +54,7 @@ export const MainThemeProvider = (props: PropsWithChildren) => {
   // looks like one works on Android and another one on iOS. good.
   const isSystemDarkModeIOS = useDarkMode();
   const isSystemDarkModeAndroid = useColorScheme() === 'dark';
-  const isSystemDarkMode = ios ? isSystemDarkModeIOS : isSystemDarkModeAndroid;
+  const isSystemDarkMode = Platform.OS === 'ios' ? isSystemDarkModeIOS : isSystemDarkModeAndroid;
 
   const colorSchemeSystemAdjusted = colorScheme === Themes.SYSTEM ? (isSystemDarkMode ? 'dark' : 'light') : colorScheme;
 

--- a/src/utils/getDominantColorFromImage.ts
+++ b/src/utils/getDominantColorFromImage.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import c from 'chroma-js';
 import makeColorMoreChill from 'make-color-more-chill';
 import Palette, { type IPalette } from 'react-native-palette-full';
@@ -12,7 +14,7 @@ export default async function getDominantColorFromImage(imageUrl: string, colorT
   }
 
   // react-native-palette keys for Android are not the same as iOS so we fix here
-  if (android) {
+  if (Platform.OS === 'android') {
     // @ts-expect-error ts-migrate(2740) FIXME: Type '{}' is missing the following properties from... Remove this comment to see the full error message
     colors = Object.keys(colors).reduce((acc, key) => {
       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message


### PR DESCRIPTION
Follows up on #7450 which dropped the `IS_IOS`/`IS_ANDROID` wrapper exports from `@/env` for the platform-shaking reasons documented there. That PR left in place the older lowercase ancestors: bare `ios` / `android` globals defined in `globalVariables.js` and injected onto `global` via `shim.js`. They have the same platform-shaking problem (the `Platform.OS` reference is hidden behind a global indirection, so the constant-folding optimization can't fire), plus they're harder for tools to track than imported symbols.

This change replaces every bare `ios` / `android` usage with `Platform.OS === '...'`, importing `Platform` directly from `react-native` in each file, and drops the corresponding entries from `globalVariables.js` and `globals.d.ts`.