### PR TITLE
feature (perps): migrate users to unified account type

### DIFF
--- a/src/features/perps/services/hyperliquid-account-client.ts
+++ b/src/features/perps/services/hyperliquid-account-client.ts
@@ -1,11 +1,16 @@
-import { type HistoricalOrdersResponse, type UserFillsResponse } from '@nktkas/hyperliquid';
+import {
+  type ClearinghouseStateResponse,
+  type HistoricalOrdersResponse,
+  type UserAbstractionResponse,
+  type UserFillsResponse,
+} from '@nktkas/hyperliquid';
 import { type Address } from 'viem';
 
 import { RAINBOW_BUILDER_SETTINGS } from '@/features/perps/constants';
 import { infoClient } from '@/features/perps/services/hyperliquid-info-client';
 import { hyperliquidDexActions } from '@/features/perps/stores/hyperliquidDexStore';
 import { normalizeDexSymbol } from '@/features/perps/utils/hyperliquidSymbols';
-import { add, greaterThan } from '@/helpers/utilities';
+import { add, greaterThan, subtract } from '@/helpers/utilities';
 
 import { PerpPositionSide, type PerpAccount, type PerpsPosition } from '../types';
 
@@ -38,67 +43,35 @@ export class HyperliquidAccountClient {
   async getPerpAccount(abortSignal: AbortSignal | undefined): Promise<PerpAccount> {
     await hyperliquidDexActions.fetch();
     const dexIds = hyperliquidDexActions.getDexIds();
-    const clearinghouseStates = await Promise.all(
-      dexIds.map(async dex => {
-        const state = await infoClient.clearinghouseState(
-          {
-            user: this.userAddress,
-            dex,
-          },
-          abortSignal
-        );
 
-        return { state, dex };
-      })
-    );
+    const [accountAbstractionMode, spotState, clearinghouseStates] = await Promise.all([
+      this.getAbstractionMode(),
+      infoClient.spotClearinghouseState({ user: this.userAddress }, abortSignal),
+      Promise.all(
+        dexIds.map(dex => infoClient.clearinghouseState({ user: this.userAddress, dex }, abortSignal).then(state => ({ state, dex })))
+      ),
+    ]);
 
-    let totalAccountValue = '0';
-    let totalWithdrawable = '0';
-    const positions: PerpsPosition[] = [];
+    const positions = buildPositions(clearinghouseStates);
 
-    clearinghouseStates.forEach(({ state, dex }) => {
-      const accountValue = state.marginSummary?.accountValue ?? '0';
-      const withdrawable = state.withdrawable ?? '0';
-
-      totalAccountValue = add(totalAccountValue, accountValue);
-      totalWithdrawable = add(totalWithdrawable, withdrawable);
-
-      state.assetPositions.forEach(({ position }) => {
-        const symbol = normalizeDexSymbol(position.coin, dex);
-        const equity = position.leverage.type === 'isolated' ? position.marginUsed : add(position.unrealizedPnl, position.marginUsed);
-
-        positions.push({
-          symbol,
-          side: greaterThan(position.szi, 0) ? PerpPositionSide.LONG : PerpPositionSide.SHORT,
-          leverage: position.leverage.value,
-          liquidationPrice: position.liquidationPx,
-          entryPrice: position.entryPx,
-          value: position.positionValue,
-          unrealizedPnl: position.unrealizedPnl,
-          returnOnEquity: position.returnOnEquity,
-          marginUsed: position.marginUsed,
-          size: position.szi,
-          equity,
-          funding: position.cumFunding.sinceOpen,
-          dex,
-        });
+    if (accountAbstractionMode !== 'unifiedAccount') {
+      let value = '0';
+      let balance = '0';
+      clearinghouseStates.forEach(({ state }) => {
+        value = add(value, state.marginSummary?.accountValue ?? '0');
+        balance = add(balance, state.withdrawable ?? '0');
       });
-    });
+      return { value, balance, positions };
+    }
 
-    positions.sort((a, b) => Number(b.equity) - Number(a.equity));
-
-    const positionsBySymbol = positions.reduce(
-      (acc, position) => {
-        acc[position.symbol] = position;
-        return acc;
-      },
-      {} as Record<string, PerpsPosition>
-    );
+    const usdc = spotState.balances.find(b => b.coin === 'USDC');
+    const usdcTotal = usdc?.total ?? '0';
+    const usdcHold = usdc?.hold ?? '0';
 
     return {
-      value: totalAccountValue,
-      balance: totalWithdrawable,
-      positions: positionsBySymbol,
+      value: usdcTotal,
+      balance: subtract(usdcTotal, usdcHold),
+      positions,
     };
   }
 
@@ -153,7 +126,43 @@ export class HyperliquidAccountClient {
     return referral.referredBy !== null;
   }
 
-  async isDexAbstractionEnabled(): Promise<boolean> {
-    return (await infoClient.userDexAbstraction({ user: this.userAddress })) ?? false;
+  async getAbstractionMode(): Promise<UserAbstractionResponse> {
+    return await infoClient.userAbstraction({ user: this.userAddress });
   }
+}
+
+function buildPositions(clearinghouseStates: { state: ClearinghouseStateResponse; dex: string }[]): Record<string, PerpsPosition> {
+  const positions: PerpsPosition[] = [];
+
+  clearinghouseStates.forEach(({ state, dex }) => {
+    state.assetPositions.forEach(({ position }) => {
+      const symbol = normalizeDexSymbol(position.coin, dex);
+      const equity = position.leverage.type === 'isolated' ? position.marginUsed : add(position.unrealizedPnl, position.marginUsed);
+
+      positions.push({
+        symbol,
+        side: greaterThan(position.szi, 0) ? PerpPositionSide.LONG : PerpPositionSide.SHORT,
+        leverage: position.leverage.value,
+        liquidationPrice: position.liquidationPx,
+        entryPrice: position.entryPx,
+        value: position.positionValue,
+        unrealizedPnl: position.unrealizedPnl,
+        returnOnEquity: position.returnOnEquity,
+        marginUsed: position.marginUsed,
+        size: position.szi,
+        equity,
+        funding: position.cumFunding.sinceOpen,
+        dex,
+      });
+    });
+  });
+
+  positions.sort((a, b) => Number(b.equity) - Number(a.equity));
+
+  const positionsBySymbol = positions.reduce<Record<string, PerpsPosition>>((acc, position) => {
+    acc[position.symbol] = position;
+    return acc;
+  }, {});
+
+  return positionsBySymbol;
 }

--- a/src/features/perps/services/hyperliquid-exchange-client.ts
+++ b/src/features/perps/services/hyperliquid-exchange-client.ts
@@ -5,7 +5,6 @@ import { type Address, type Hex } from 'viem';
 import { getOppositePositionSide } from '@/features/perps/utils';
 import { formatOrderPrice } from '@/features/perps/utils/formatOrderPrice';
 import { generateCloid } from '@/features/perps/utils/hyperliquidCloid';
-import { isBuilderDexAssetId } from '@/features/perps/utils/hyperliquidSymbols';
 import {
   buildMarketOrder,
   buildMarketTriggerOrder,
@@ -104,7 +103,7 @@ export class HyperliquidExchangeClient {
     if (!exchangeClient) return undefined;
 
     // Must be enabled before updating leverage
-    await this.ensureDexAbstractionEnabled(assetId);
+    await this.ensureUnifiedAccountMode();
 
     await Promise.all([
       // TODO: This step could be skipped if we have already traded this asset in the session
@@ -177,7 +176,7 @@ export class HyperliquidExchangeClient {
     const exchangeClient = await this.getExchangeClient();
     if (!exchangeClient) return undefined;
 
-    await Promise.all([this.ensureDexAbstractionEnabled(assetId), this.ensureApprovedBuilderFee(), this.ensureReferralCodeSet()]);
+    await Promise.all([this.ensureUnifiedAccountMode(), this.ensureApprovedBuilderFee(), this.ensureReferralCodeSet()]);
 
     const marketType = getMarketType(assetId);
     const formattedTriggerPrice = formatOrderPrice({ price: triggerPrice, sizeDecimals, marketType });
@@ -232,7 +231,7 @@ export class HyperliquidExchangeClient {
     const exchangeClient = await this.getExchangeClient();
     if (!exchangeClient) return undefined;
 
-    await Promise.all([this.ensureDexAbstractionEnabled(assetId), this.ensureApprovedBuilderFee(), this.ensureReferralCodeSet()]);
+    await Promise.all([this.ensureUnifiedAccountMode(), this.ensureApprovedBuilderFee(), this.ensureReferralCodeSet()]);
 
     const result = await exchangeClient.order({
       orders: [closeOrder],
@@ -283,19 +282,18 @@ export class HyperliquidExchangeClient {
     });
   }
 
-  async ensureDexAbstractionEnabled(assetId: number): Promise<hl.UserDexAbstractionSuccessResponse | undefined> {
-    if (!isBuilderDexAssetId(assetId)) return;
+  async ensureUnifiedAccountMode(): Promise<hl.UserSetAbstractionSuccessResponse | undefined> {
     if (checkIfReadOnlyWallet(this.userAddress)) return;
 
-    const isEnabled = await this.accountClient.isDexAbstractionEnabled();
-    if (isEnabled) return;
+    const mode = await this.accountClient.getAbstractionMode();
+    if (mode === 'unifiedAccount') return;
 
     const exchangeClient = await this.getExchangeClient();
     if (!exchangeClient) return;
 
-    return await exchangeClient.userDexAbstraction({
+    return await exchangeClient.userSetAbstraction({
       user: this.userAddress,
-      enabled: true,
+      abstraction: 'unifiedAccount',
     });
   }
 }

--- a/src/features/perps/stores/derived/usePerpsPositionsInfo.ts
+++ b/src/features/perps/stores/derived/usePerpsPositionsInfo.ts
@@ -71,7 +71,7 @@ export const usePerpsPositionsInfo = createDerivedStore<PerpsPositionsInfo>(
       textColor: textColor satisfies TextColor,
       unrealizedPnl: formatCurrency(abs(totalPositionsPnl)),
       unrealizedPnlPercent: `${toFixedWorklet(abs(unrealizedPnlPercent), 2)}%`,
-      value: add(balance, totalPositionsEquity),
+      value: accountData.value,
     };
   },
 


### PR DESCRIPTION
Fixes APP-3697

## What changed

Hyperliquid will begin defaulting all new users on their website to `unifiedAccount` types beginning 05/13/26. Currently users can opt into this mode manually or can be opted into it through using other wallets. Users on this mode currently cannot properly see their total balance. 

Adds support for the `unifiedAccount` account abstraction type. Silently migrates all users off of the legacy `dexAbstraction` mode, bundled with their next order submission. 

#### Main changes
- `hyperliquid-exchange-client.ts`: `ensureDexAbstractionEnabled(assetId)` → `ensureUnifiedAccountMode()`.
- `hyperliquid-account-client.ts`: `getPerpAccount` also fetches the spot clearinghouse state for unified account values. 

#### Other changes
- `hyperliquid-account-client.ts`: pulled position construction out into a `buildPositions` helper.

## What to test
- Place an order on an account that hasn't been migrated, confirm it transitions to unified account mode and the action succeeds. You can use this site to look at any account's abstraction mode: https://hypurrscan.io/address/0x2e67869829c734ac13723a138a952f7a8b56e774#more
- Account value and withdrawable balance display correctly for both account types. 
