### PR TITLE
fix(patches): restore reanimated ProMotion patch lost during 3.19.5 bump

### DIFF
--- a/patches/react-native-reanimated+3.19.5.patch
+++ b/patches/react-native-reanimated+3.19.5.patch
@@ -1,0 +1,33 @@
+# PATCH CONTEXT
+# Why: Opt into ProMotion's variable refresh rate on iOS 15+ via
+#   `preferredFrameRateRange = CAFrameRateRangeMake(80, 120, 120)`
+#   instead of `preferredFramesPerSecond = 120`. Without this the
+#   system clamps to 60 fps on devices without ProMotion and never
+#   targets 120 fps on devices that have it.
+# Upstream Issue: none filed yet.
+# Linear Issue: FEPLAT-99
+# Remove when: reanimated adopts a ProMotion-aware default
+#   upstream.
+#
+# Note: this patch was in `react-native-reanimated+3.19.4.patch` on
+# develop alongside the Synchronizable backport. When that file was
+# deleted for the 3.19.5 bump (since the backport is upstream in
+# 3.19.5), the ProMotion hunk was accidentally lost. This restores
+# only the ProMotion hunk.
+
+diff --git a/node_modules/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm b/node_modules/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+--- a/node_modules/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
++++ b/node_modules/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+@@ -175,7 +175,11 @@
+   if (!_displayLink) {
+     _displayLink = [READisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
+ #if !TARGET_OS_OSX
+-    _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
++    if (@available(iOS 15.0, *)) {
++      _displayLink.preferredFrameRateRange = CAFrameRateRangeMake(80, 120, 120);
++    } else {
++      _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
++    }
+ #endif // TARGET_OS_OSX
+     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+   }


### PR DESCRIPTION
Stacked on #7366. Targets `@janic/rn-0.81-bump`.

## Description

The 3.19.4 → 3.19.5 reanimated bump in #7366 deleted `patches/react-native-reanimated+3.19.4.patch` because the `makeSynchronizable` / `Synchronizable` backport that file carried is upstream in 3.19.5 — that part is correct.

The same patch file also carried a second, unrelated hunk for `REANodesManager.mm` that opts into ProMotion's variable refresh rate (`preferredFrameRateRange = CAFrameRateRangeMake(80, 120, 120)` on iOS 15+, falling back to `preferredFramesPerSecond = 120` below 15). Without it, reanimated-driven animations cap at 60 fps on non-ProMotion devices and never target 120 fps on devices that have ProMotion. The hunk has been part of the project's reanimated patch since [#5683 (Reanimated v3.11.0)](https://github.com/rainbow-me/rainbow/pull/5683) and was carried through every reanimated bump until 3.19.5.

That hunk wasn't in the 3.19.5 release notes — it was a genuine accidental drop, not something that became obsolete.

## Solution

Restore the ProMotion hunk as a fresh `patches/react-native-reanimated+3.19.5.patch`. Same hunk content as on develop's `react-native-reanimated+3.19.4.patch`, just rewritten against 3.19.5's source (the surrounding context is unchanged between the two versions, so the line numbers shift but the diff is identical). PATCH CONTEXT header documents what it does and notes the removal regression so the next person doesn't repeat it.

## Test plan

- `yarn install` succeeds with "patches applied" output for `react-native-reanimated@3.19.5` — verified.
- After install, `node_modules/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm` contains the `preferredFrameRateRange = CAFrameRateRangeMake(80, 120, 120)` branch on iOS 15+ — verified.
- iOS build still compiles (TODO once local builds are running).
- Visual: scroll-heavy screens (homepage, swap sheet) feel smoother on a ProMotion device (e.g. iPhone 13 Pro+).
