### PR TITLE
Ensure new `@storesjs/stores` stores use the Rainbow logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import '@walletconnect/react-native-compat';
 import { initSentry } from '@/logger/sentry';
 import { APP_START_TIME } from '@/performance/start-time';
 import { PerformanceReports, PerformanceReportSegments, PerformanceTracking } from '@/performance/tracking';
+import { initStores } from '@/state/internal/initStores';
 
 // TODO: Migrate to modular API and remove this stopgap (FEPLAT-80)
 // Silence RNFB v23 namespaced-API deprecation warnings.
@@ -19,6 +20,8 @@ PerformanceTracking.logReportSegmentRelative(PerformanceReports.appStartup, Perf
 PerformanceTracking.startReportSegment(PerformanceReports.appStartup, PerformanceReportSegments.appStartup.loadMainModule);
 
 initSentry();
+initStores();
+
 /*
 We need to use require calls in order to stop babel from moving imports
 to the top of the file above all other calls. We want Performance tracking

--- a/src/logger/debugContext.ts
+++ b/src/logger/debugContext.ts
@@ -17,4 +17,5 @@ export const DebugContext = {
   keychain: 'keychain',
   deeplinks: 'deeplinks',
   delegation: 'delegation',
+  stores: 'stores',
 } as const;

--- a/src/state/internal/initStores.ts
+++ b/src/state/internal/initStores.ts
@@ -1,0 +1,9 @@
+import { configureStores } from '@storesjs/stores';
+
+import { logger } from '@/logger';
+
+export function initStores(): void {
+  configureStores({
+    logger: logger.createServiceLogger(logger.DebugContext.stores),
+  });
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Ensures any new stores created via `@storesjs/stores` are configured with the Rainbow logger

## Screen recordings / screenshots

## What to test
