### PR TITLE
[Discover v2]: Add line chart store factory tests

### DIFF
--- a/src/features/charts/stores/factories/createLineChartDataStore.test.ts
+++ b/src/features/charts/stores/factories/createLineChartDataStore.test.ts
@@ -1,0 +1,188 @@
+import Routes, { type Route } from '@/navigation/routesNames';
+import { useNavigationStore, type SwipeRoute } from '@/state/navigation/navigationStore';
+
+import { type CompactLineChartData } from '../../line/compact/types';
+import { createLineChartDataStore, type FetchedLineChartData } from './createLineChartDataStore';
+
+jest.mock('@/navigation/virtualNavigators', () => ({
+  VIRTUAL_NAVIGATORS: {},
+}));
+
+describe('createLineChartDataStore', () => {
+  it('wrapped chart reads are correctly tracked', () => {
+    const store = createLineChartDataStore(async () => ({}));
+
+    const unsubscribe = store.subscribe(
+      state => {
+        const selectChart = () => state.getChartData('BTC');
+        return selectChart();
+      },
+      () => undefined
+    );
+
+    expect(store.getState().subscribedChartIds).toEqual(['BTC']);
+
+    unsubscribe();
+
+    expect(store.getState().subscribedChartIds).toEqual([]);
+
+    store.getState().reset(true);
+  });
+
+  it('counts subscription only once when a selector reads the same chart twice', () => {
+    const store = createLineChartDataStore(async () => ({}));
+
+    const unsubscribe = store.subscribe(
+      state => {
+        state.getChartData('BTC');
+        return state.getChartData('BTC');
+      },
+      () => undefined
+    );
+    expect(store.getState().subscribedChartIds).toEqual(['BTC']);
+
+    unsubscribe();
+    expect(store.getState().subscribedChartIds).toEqual([]);
+
+    store.getState().reset(true);
+  });
+
+  it('moves a live selector subscription when its chart id changes', () => {
+    const store = createLineChartDataStore(async () => ({}));
+    let chartId = 'BTC';
+
+    const unsubscribe = store.subscribe(
+      state => state.getChartData(chartId),
+      () => undefined
+    );
+    expect(store.getState().subscribedChartIds).toEqual(['BTC']);
+
+    chartId = 'ETH';
+    store.setState(state => ({ queryCache: state.queryCache }));
+    expect(store.getState().subscribedChartIds).toEqual(['ETH']);
+
+    unsubscribe();
+    expect(store.getState().subscribedChartIds).toEqual([]);
+
+    store.getState().reset(true);
+  });
+
+  it('notifies chart listeners from query cache updates', async () => {
+    const store = createLineChartDataStore(fetchChartData);
+    const listener = jest.fn();
+
+    const unsubscribe = store.subscribe(state => state.getChartData('BTC'), listener);
+
+    await store.getState().fetch({ chartIds: ['BTC'] }, { force: true });
+    expect(listener.mock.calls[0]?.[0]).toEqual(buildChartData(3));
+
+    unsubscribe();
+    store.getState().reset(true);
+  });
+
+  it('does not refetch fresh charts when active batches change', async () => {
+    const now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const fetchLineChartData = jest.fn(fetchChartData);
+    const store = createLineChartDataStore(fetchLineChartData);
+
+    try {
+      await store.getState().fetch({ chartIds: ['BTC'] }, { force: true });
+      expect(fetchLineChartData.mock.calls[0]?.[0]).toEqual(['BTC']);
+      expect(store.getState().getChartData('BTC')).toEqual(buildChartData(3));
+
+      await store.getState().fetch({ chartIds: ['BTC', 'ETH'] }, { force: true });
+      expect(fetchLineChartData.mock.calls[1]?.[0]).toEqual(['ETH']);
+      expect(store.getState().isStale()).toBe(false);
+    } finally {
+      store.getState().reset(true);
+      jest.restoreAllMocks();
+    }
+  });
+
+  it('seeds active batch freshness from chart cache when demand changes', async () => {
+    const now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const store = createLineChartDataStore(fetchChartData);
+
+    await store.getState().fetch({ chartIds: ['BTC'] }, { force: true });
+    await store.getState().fetch({ chartIds: ['ETH'] }, { force: true });
+
+    const unsubscribeBtc = store.subscribe(
+      state => state.getChartData('BTC'),
+      () => undefined
+    );
+    const unsubscribeEth = store.subscribe(
+      state => state.getChartData('ETH'),
+      () => undefined
+    );
+
+    expect(store.getState().getCacheEntry({ chartIds: ['BTC', 'ETH'] })?.lastFetchedAt).toBe(now);
+    expect(store.getState().isStale()).toBe(false);
+
+    unsubscribeBtc();
+    unsubscribeEth();
+    store.getState().reset(true);
+    jest.restoreAllMocks();
+  });
+
+  it('gates fetching to the configured navigation scope', async () => {
+    const previousRoute = useNavigationStore.getState().activeRoute;
+    const previousSwipeRoute = useNavigationStore.getState().activeSwipeRoute;
+
+    const routeFetcher = jest.fn(fetchChartData);
+    const swipeFetcher = jest.fn(fetchChartData);
+    const resetStores: (() => void)[] = [];
+
+    try {
+      setNavigationState(Routes.WALLET_SCREEN, Routes.WALLET_SCREEN);
+
+      const routeStore = createLineChartDataStore(routeFetcher, { activeOnRoute: Routes.DISCOVER_SCREEN });
+      resetStores.push(() => routeStore.getState().reset(true));
+
+      await routeStore.getState().fetch({ chartIds: ['BTC'] });
+      expect(routeFetcher).not.toHaveBeenCalled();
+
+      setNavigationState(Routes.DISCOVER_SCREEN, Routes.DISCOVER_SCREEN);
+      await routeStore.getState().fetch({ chartIds: ['BTC'] });
+      expect(routeFetcher.mock.calls[0]?.[0]).toEqual(['BTC']);
+
+      const swipeStore = createLineChartDataStore(swipeFetcher, { activeOnSwipeRoute: Routes.DISCOVER_SCREEN });
+      resetStores.push(() => swipeStore.getState().reset(true));
+
+      setNavigationState(Routes.PERPS_DETAIL_SCREEN, Routes.DISCOVER_SCREEN);
+      await swipeStore.getState().fetch({ chartIds: ['ETH'] });
+      expect(swipeFetcher.mock.calls[0]?.[0]).toEqual(['ETH']);
+
+      setNavigationState(Routes.WALLET_SCREEN, Routes.WALLET_SCREEN);
+      await swipeStore.getState().fetch({ chartIds: ['SOL'] });
+      expect(swipeFetcher).toHaveBeenCalledTimes(1);
+    } finally {
+      resetStores.forEach(resetStore => resetStore());
+      setNavigationState(previousRoute, previousSwipeRoute);
+    }
+  });
+});
+
+function setNavigationState(activeRoute: Route, activeSwipeRoute: SwipeRoute): void {
+  useNavigationStore.setState({ activeRoute, activeSwipeRoute });
+}
+
+async function fetchChartData(chartIds: readonly string[]): Promise<FetchedLineChartData> {
+  const charts: FetchedLineChartData = {};
+
+  for (const id of chartIds) {
+    charts[id] = buildChartData(id.length);
+  }
+
+  return charts;
+}
+
+function buildChartData(value: number): CompactLineChartData {
+  return {
+    prices: new Float32Array([value]),
+    timestamps: new Uint32Array([value]),
+  };
+}

--- a/src/state/internal/utils/createSelectorReadTracker.test.ts
+++ b/src/state/internal/utils/createSelectorReadTracker.test.ts
@@ -1,0 +1,203 @@
+import { createRainbowStore } from '../createRainbowStore';
+import { type RainbowStore } from '../types';
+import { createSelectorReadTracker } from './createSelectorReadTracker';
+
+type TestState = {
+  tick: () => void;
+  read: (key: string) => number;
+  subscribedKeys: string[];
+  version: number;
+};
+
+type NumericTestState = {
+  read: (key: number) => number;
+  subscribedKeys: number[];
+};
+
+describe('createSelectorReadTracker', () => {
+  it('ignores reads outside selector subscriptions', () => {
+    const store = createTestStore();
+
+    store.getState().read('BTC');
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+  });
+
+  it('ignores reads from full-state listeners', () => {
+    const store = createTestStore();
+
+    const unsubscribe = store.subscribe(state => {
+      state.read('BTC');
+    });
+
+    store.getState().tick();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+
+    unsubscribe();
+  });
+
+  it('tracks keys read by selector subscriptions', () => {
+    const store = createTestStore();
+
+    const unsubscribe = store.subscribe(
+      state => state.read('BTC'),
+      () => undefined
+    );
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    unsubscribe();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+  });
+
+  it('counts duplicate reads from one selector once', () => {
+    const store = createTestStore();
+
+    const unsubscribe = store.subscribe(
+      state => {
+        state.read('BTC');
+        return state.read('BTC');
+      },
+      () => undefined
+    );
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    unsubscribe();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+  });
+
+  it('keeps a key active until its last selector subscription is released', () => {
+    const store = createTestStore();
+
+    const unsubscribeA = store.subscribe(
+      state => state.read('BTC'),
+      () => undefined
+    );
+    const unsubscribeB = store.subscribe(
+      state => state.read('BTC'),
+      () => undefined
+    );
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    unsubscribeA();
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    unsubscribeB();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+  });
+
+  it('moves tracked keys when selector reads change', () => {
+    const store = createTestStore();
+    let key = 'BTC';
+
+    const unsubscribe = store.subscribe(
+      state => state.read(key),
+      () => undefined
+    );
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    key = 'ETH';
+    store.getState().tick();
+
+    expect(store.getState().subscribedKeys).toEqual(['ETH']);
+
+    unsubscribe();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+  });
+
+  it('removes keys when a live selector stops reading them', () => {
+    const store = createTestStore();
+    let shouldRead = true;
+
+    const unsubscribe = store.subscribe(
+      state => (shouldRead ? state.read('BTC') : state.version),
+      () => undefined
+    );
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    shouldRead = false;
+    store.getState().tick();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+
+    unsubscribe();
+  });
+
+  it('updates multi-key selector reads without disturbing unchanged keys', () => {
+    const store = createTestStore();
+    let includeEth = true;
+
+    const unsubscribe = store.subscribe(
+      state => {
+        state.read('BTC');
+        if (includeEth) state.read('ETH');
+        return state.version;
+      },
+      () => undefined
+    );
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC', 'ETH']);
+
+    includeEth = false;
+    store.getState().tick();
+
+    expect(store.getState().subscribedKeys).toEqual(['BTC']);
+
+    unsubscribe();
+
+    expect(store.getState().subscribedKeys).toEqual([]);
+  });
+
+  it('tracks zero as a numeric key', () => {
+    const reads = createSelectorReadTracker<number>();
+    const store = createRainbowStore<NumericTestState>(() => ({
+      subscribedKeys: [],
+
+      read: key => {
+        reads.track(key);
+        return key;
+      },
+    }));
+
+    const trackedStore = reads.install(store, subscribedKeys => store.setState({ subscribedKeys }));
+
+    const unsubscribe = trackedStore.subscribe(
+      state => state.read(0),
+      () => undefined
+    );
+
+    expect(trackedStore.getState().subscribedKeys).toEqual([0]);
+
+    unsubscribe();
+
+    expect(trackedStore.getState().subscribedKeys).toEqual([]);
+  });
+});
+
+function createTestStore(): RainbowStore<TestState> {
+  const reads = createSelectorReadTracker<string>();
+
+  const store = createRainbowStore<TestState>((set, get) => ({
+    subscribedKeys: [],
+    version: 0,
+
+    read: key => {
+      reads.track(key);
+      return get().version;
+    },
+
+    tick: () => set(state => ({ version: state.version + 1 })),
+  }));
+
+  return reads.install(store, subscribedKeys => store.setState({ subscribedKeys }));
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Adds two unit tests on top of the implementations in #7456:
  - `createLineChartDataStore.test.ts` covers the line chart store factory
  -  `createSelectorReadTracker.test.ts` covers the selector tracking primitive used by the factory

## Screen recordings / screenshots

## What to test
