### PR TITLE
chore(ci): use --immutable installs over custom lockfile check

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -98,10 +98,7 @@ jobs:
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
         run: |
-          yarn install && yarn setup
-
-      - name: Check for frozen lockfile
-        run: ./scripts/check-lockfile.sh
+          yarn install --immutable && yarn setup
 
       - name: Audit CI
         run: yarn audit-ci --config audit-ci.jsonc

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install dependencies
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-        run: yarn install && yarn setup
+        run: yarn install --immutable && yarn setup
 
       - name: Rock Build - iOS simulator
         id: rock-build-simulator
@@ -186,7 +186,7 @@ jobs:
       - name: Install dependencies
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-        run: yarn install && yarn setup
+        run: yarn install --immutable && yarn setup
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install dependencies
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-        run: yarn install && yarn setup
+        run: yarn install --immutable && yarn setup
 
       - name: Rock Remote Build - iOS simulator
         id: rock-remote-build-ios

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -74,10 +74,7 @@ jobs:
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
         run: |
-          yarn install && yarn setup
-
-      - name: Check for frozen lockfile
-        run: ./scripts/check-lockfile.sh
+          yarn install --immutable && yarn setup
 
       - name: Audit CI
         run: yarn audit-ci --config audit-ci.jsonc

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "anvil": "sh ./scripts/anvil.sh",
     "bundle-inpage": "yarn webpack --config src/browser/webpack.config.js && cp InjectedJSBundle.js android/app/src/main/res/raw/injected_js_bundle.js",
     "check:cycles": "./scripts/check-cycles.sh 0",
-    "check-lockfile": "./scripts/check-lockfile.sh",
     "check-translations": "./scripts/check-translations.sh ./src './src/languages/*.json' lang.t",
     "clean:android": "yarn uninstall:android && rm -rf android/build && yarn gradle clean && rm -rf ~/.gradle/caches",
     "clean:ios": "rm -rf ios/build && cd ios && bundle exec pod deintegrate",

--- a/scripts/check-lockfile.sh
+++ b/scripts/check-lockfile.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-git diff yarn.lock
-if ! git diff --exit-code yarn.lock; then
-    echo "Changes were detected in yarn.lock file after running 'yarn install', which is not expected. Please run 'yarn install' locally and commit the changes.";
-    exit 1;
-fi


### PR DESCRIPTION
CI workflows currently use a custom postinstall script to check lockfile drift. However, yarn v4 has built in support for this with the `--immutable` flag.

This change adds `--immutable` to every `yarn install` across all CI workflows. With this, lockfile drift now fails fast at install time with a clear Yarn error instead of via a separate post-install diff step.