### PR TITLE
fix (perps): market price fallback

### DIFF
--- a/src/components/live-token-text/LiveTokenText.tsx
+++ b/src/components/live-token-text/LiveTokenText.tsx
@@ -42,7 +42,7 @@ export function useLiveTokenSharedValue({
   }, [initialValue, liveValue, prevTokenId, tokenId, routeName]);
 
   const updateToken = useCallback(
-    (token: TokenData) => {
+    (token: TokenData | undefined) => {
       if (!token) return;
 
       const newValue = selector(token);
@@ -97,7 +97,7 @@ export function useLiveTokenValue({
   }, [initialValue, prevTokenId, tokenId, routeName]);
 
   const updateToken = useCallback(
-    (token: TokenData) => {
+    (token: TokenData | undefined) => {
       if (!token) return;
 
       const newValue = selector(token);

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -216,14 +216,13 @@ const PerpsNewPositionScreenFooter = memo(function PerpsNewPositionScreenFooter(
     const perpsBalance = Number(useHyperliquidAccountStore.getState().getValue());
 
     try {
-      const livePrice = useLiveTokensStore.getState().tokens[getHyperliquidTokenId(market.symbol)].midPrice;
+      const livePrice = useLiveTokensStore.getState().tokens[getHyperliquidTokenId(market.symbol)]?.midPrice;
       const entryPrice = livePrice ?? market.price;
       const newPosition = await hyperliquidAccountActions.createIsolatedMarginPosition({
         symbol: market.symbol,
         side: positionSide,
         leverage,
         marginAmount: amount,
-        // There is not case in which the live price should actually be null at this point
         price: entryPrice,
         triggerOrders,
       });

--- a/src/hooks/useLiveWalletBalance.ts
+++ b/src/hooks/useLiveWalletBalance.ts
@@ -25,6 +25,7 @@ export const useLiveWalletBalance = createDerivedStore(
     let valueDifference = '0';
     if (liveTokens) {
       for (const [tokenId, token] of Object.entries(liveTokens)) {
+        if (!token) continue;
         const userAsset = userAssets.get(tokenId);
         const canUseLivePrice = token.reliability.status === 'PRICE_RELIABILITY_STATUS_TRUSTED';
 

--- a/src/state/assets/createUserAssetsStore.ts
+++ b/src/state/assets/createUserAssetsStore.ts
@@ -181,7 +181,7 @@ export const createUserAssetsStore = (address: Address | string) =>
       updateTokens: (tokens: LiveTokensData) => {
         set(state => {
           for (const [tokenId, token] of Object.entries(tokens)) {
-            if (token.reliability.status !== 'PRICE_RELIABILITY_STATUS_TRUSTED') continue;
+            if (!token || token.reliability.status !== 'PRICE_RELIABILITY_STATUS_TRUSTED') continue;
 
             const asset = state.userAssets.get(tokenId);
             const currency = userAssetsStoreManager.getState().currency;

--- a/src/state/liveTokens/liveTokensStore.ts
+++ b/src/state/liveTokens/liveTokensStore.ts
@@ -67,7 +67,7 @@ export interface TokenData {
 }
 
 export interface LiveTokensData {
-  [tokenId: string]: TokenData;
+  [tokenId: string]: TokenData | undefined;
 }
 
 type LiveTokensResponse = {


### PR DESCRIPTION
## What changed
Fixes a error in the new position flow where reading `midPrice` off a live token entry that doesn't exist yet threw `Cannot read property 'midPrice' of undefined`. Also tightens the `LiveTokensData` type so this type of bug is not possible. 