### PR TITLE
ci: improve Graphite stack CI behavior

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -10,6 +10,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
 env:
   PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -3,6 +3,8 @@ name: Android
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - '**/graphite-base/**'
   push:
     branches: [develop]
   issue_comment:

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: e2e-android-${{ github.workflow }}-${{ github.ref }}-shard-${{ matrix.shard-index }}
-      cancel-in-progress: false
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     env:
       SHARD_TOTAL: 4

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -14,9 +14,24 @@ env:
   PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
 jobs:
+  optimize_ci:
+    name: Graphite CI Optimizer
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        if: github.event_name == 'pull_request'
+        uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   build:
     name: Test Build
+    needs: optimize_ci
     if: |
+      needs.optimize_ci.outputs.skip != 'true' && (
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       github.event_name == 'push' ||
       (github.event_name == 'issue_comment' &&
@@ -26,6 +41,7 @@ jobs:
         startsWith(github.event.comment.body, '/perf')
       ) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      )
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -7,14 +7,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  optimize_ci:
+    name: Graphite CI Optimizer
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        if: github.event_name == 'pull_request'
+        uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   # Build iOS simulator app
   build-simulator:
     name: Simulator
+    needs: optimize_ci
     runs-on: macos-26-xlarge
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
-    if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
+    if: needs.optimize_ci.outputs.skip != 'true' && github.event.pull_request.draft == false && github.event.pull_request.merged == false
     concurrency:
       group: ${{ github.workflow }}-simulator-${{ github.ref }}
       cancel-in-progress: true
@@ -105,11 +119,12 @@ jobs:
   # Build iOS device app
   build-device:
     name: Device
+    needs: optimize_ci
     runs-on: macos-26-xlarge
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
-    if: github.event.pull_request.draft == false && github.event.pull_request.merged == false
+    if: needs.optimize_ci.outputs.skip != 'true' && github.event.pull_request.draft == false && github.event.pull_request.merged == false
     concurrency:
       group: ${{ github.workflow }}-device-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -6,6 +6,11 @@ on:
       - '**/graphite-base/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
 jobs:
   optimize_ci:
     name: Graphite CI Optimizer

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -2,6 +2,8 @@ name: iOS Builds
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - '**/graphite-base/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -140,7 +140,7 @@ jobs:
         shard-index: [1, 2, 3, 4]
     concurrency:
       group: e2e-ios-${{ github.workflow }}-${{ github.ref }}-shard-${{ matrix.shard-index }}
-      cancel-in-progress: false
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     timeout-minutes: 30
     env:
       SHARD_TOTAL: 4

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -12,16 +12,32 @@ env:
   NODE_OPTIONS: '--max-old-space-size=6144'
 
 jobs:
+  optimize_ci:
+    name: Graphite CI Optimizer
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        if: github.event_name == 'pull_request'
+        uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   # iOS build job
   build:
     name: Test Build
+    needs: optimize_ci
     if: |
+      needs.optimize_ci.outputs.skip != 'true' && (
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       github.event_name == 'push' ||
       (github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/e2e') &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      )
     runs-on: macos-26-xlarge
     concurrency:
       group: e2e-ios-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -2,6 +2,8 @@ name: iOS
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - '**/graphite-base/**'
   push:
     branches: [develop]
   issue_comment:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -8,6 +8,11 @@ on:
     branches: [develop]
   issue_comment:
     types: [created]
+
+permissions:
+  contents: read
+  actions: read
+
 env:
   NODE_OPTIONS: '--max-old-space-size=6144'
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,9 @@
 name: Unit tests
 
-on: [pull_request]
+on:
+  pull_request:
+    branches-ignore:
+      - '**/graphite-base/**'
 jobs:
   lint-and-unit-test:
     runs-on: blacksmith-2vcpu-ubuntu-2204


### PR DESCRIPTION
# Graphite CI Optimizations

This PR addresses CI over-runs and duplicative runs that are a side effect of Graphite's push mechanism. Duplicative CI runs is most visible during Graphite PR-by-PR merges and restacking today: we amend, restack, and resubmit, then CI continues to process and queue stale jobs. Temporary branches that Graphite creates during the auto-merge and PR protection mechanism will also unexpectedly run.

## Ignore Graphite Temporary Bases

Graphite creates temporary `graphite-base/*` branches while maintaining stacks. Their docs recommend ignoring those branches in CI because jobs can fail after Graphite deletes the temporary ref: [Graphite recommended CI settings](https://graphite.com/docs/setup-recommended-ci-settings).

What changes:

- PR workflows ignore `**/graphite-base/**`.
- Upstack PRs still run CI.
- We do not restrict PR checks to `develop`, which Graphite calls out as a bad fit for stacked PRs.

Example:

- Before: restack creates temporary Graphite base -> mobile CI can start on that temporary ref.
- After: restack creates temporary Graphite base -> workflow is ignored.

## Graphite CI Optimizer

Graphite’s CI optimizer exists for the exact stacking cost pattern we saw: more PRs and behind-the-scenes rebases mean more CI unless expensive checks are stack-aware. Their optimizer lets CI ask Graphite whether a job should run for this PR’s stack position: [Graphite CI optimizations](https://graphite.com/docs/stacking-and-ci).

What changes:

- Android E2E asks Graphite before running.
- iOS E2E asks Graphite before running.
- iOS build artifacts ask Graphite before running.
- Unit tests stay always-on.

This should help most after a commit amend or restack. Without the optimizer, every updated PR in a stack can request the full mobile surface again. With it, Graphite can keep required signal at configured stack positions and skip expensive checks elsewhere. Graphite also documents that it fails open and does not skip CI for merge queue / stack merge cases.

Example:

- Before: restack 5 PRs -> each PR can request Android E2E + iOS E2E + iOS Builds.
- After: restack 5 PRs -> Graphite policy decides which stack positions need expensive mobile CI.

Requires `GRAPHITE_CI_OPTIMIZER_TOKEN`.

## Cancel Stale PR E2E Shards

This fixes the case where we push a newer commit to the same PR but old E2E shard jobs keep running or stay queued. That is pure waste: the old commit cannot merge anymore.

What changes:

- PR E2E shards cancel older shard jobs for the same PR/ref/shard.
- `/e2e` comment-triggered runs keep existing behavior.
- `develop` push runs keep existing behavior.
- This uses GitHub Actions concurrency cancellation: [GitHub concurrency docs](https://docs.github.com/en/actions/using-jobs/using-concurrency).

Example:

- Before: commit A shard queued -> push commit B -> commit A shard still consumes capacity.
- After: commit A shard queued -> push commit B -> commit A shard is cancelled.

This is intentionally narrower than `cancel-in-progress: true`; it only changes `pull_request` behavior.

## Scope Workflow Token Permissions

CodeQL flagged these changed workflows with `actions/missing-workflow-permissions`. The workflows used `GITHUB_TOKEN` but did not declare explicit token scopes.

What changes:

- `contents: read` for checkout.
- `actions: read` for artifact downloads.
- `issues: write` only where the workflow posts or updates PR comments.
- iOS E2E does not get comment write access.

Why `issues: write` is needed:

- Android E2E posts/updates the Flashlight performance comment.
- iOS Builds posts the simulator/device install-link comment.
- iOS E2E only downloads artifacts and runs tests.

Example:

- Before: workflow inherits default GITHUB_TOKEN permissions.
- After: workflow declares the minimum scopes it uses.
