### PR TITLE
feat: add sponsored sends

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1138,8 +1138,11 @@ export type EventProperties = {
   [event.sentTransaction]: {
     assetName: string;
     network: string;
+    chainId: ChainId;
+    isSponsored: boolean;
     isRecepientENS: boolean;
     isHardwareWallet: boolean;
+    submitSuccessful: boolean;
   };
   [event.tappedDoneEditingWallet]: {
     wallet_label: string;

--- a/src/features/delegation/calls.ts
+++ b/src/features/delegation/calls.ts
@@ -16,7 +16,7 @@ export const SPONSORED_CALLS_REQUIREMENTS = {
 /**
  * Creates a viem public client for a Rainbow-supported chain.
  */
-export function createDelegationPublicClient(chainId: ChainId): PublicClient {
+export function createDelegationPublicClient(chainId: ChainId, options?: { signal?: AbortSignal }): PublicClient {
   const chain = backendNetworksActions.getDefaultChains()[chainId];
   if (!chain) {
     throw new RainbowError(`[createDelegationPublicClient]: Unsupported chain ${chainId}`);
@@ -26,7 +26,7 @@ export function createDelegationPublicClient(chainId: ChainId): PublicClient {
 
   return createPublicClient({
     chain,
-    transport: http(rpcUrl),
+    transport: http(rpcUrl, options?.signal ? { fetchOptions: { signal: options.signal } } : undefined),
   });
 }
 

--- a/src/features/delegation/sponsoredSend.test.ts
+++ b/src/features/delegation/sponsoredSend.test.ts
@@ -1,0 +1,336 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { type Address } from 'viem';
+
+import { TransactionStatus, type NewTransaction } from '@/entities/transactions/transaction';
+import { ChainId } from '@/state/backendNetworks/types';
+import { type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import {
+  buildPendingSendTransaction,
+  buildSendCall,
+  executeSponsoredSend,
+  predictSponsoredSend,
+  prepareSponsoredSend,
+} from './sponsoredSend';
+
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
+const mockCreateDelegationPublicClient = jest.fn<unknown, [ChainId, { signal?: AbortSignal }?]>();
+const mockExecuteCalls = jest.fn<Promise<unknown>, [unknown, unknown?]>();
+const mockIsSponsorshipEligible = jest.fn<boolean, [ChainId]>();
+const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
+const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unknown]>();
+const mockSupportsDelegatedExecution = jest.fn<Promise<boolean>, [unknown]>();
+const mockTrackCallsExecution = jest.fn<void, [unknown]>();
+
+const mockRemoteConfig = {
+  sponsored_sends_enabled: true,
+};
+
+const mockSponsoredCallsRequirements = {
+  atomic: 'required',
+  fees: { payer: 'sponsor' },
+};
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    calls: (params: unknown, clients?: unknown) => mockExecuteCalls(params, clients),
+    prepare: {
+      calls: (params: unknown) => mockPrepareCalls(params),
+    },
+  },
+}));
+
+jest.mock('@/model/remoteConfig', () => ({
+  getRemoteConfig: () => mockRemoteConfig,
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    isSponsorshipEligible: (chainId: ChainId) => mockIsSponsorshipEligible(chainId),
+  },
+}));
+
+jest.mock('./calls', () => ({
+  createDelegationPublicClient: (chainId: ChainId, options?: { signal?: AbortSignal }) =>
+    options ? mockCreateDelegationPublicClient(chainId, options) : mockCreateDelegationPublicClient(chainId),
+  SPONSORED_CALLS_REQUIREMENTS: {
+    atomic: 'required',
+    fees: { payer: 'sponsor' },
+  },
+}));
+
+jest.mock('./callsExecutionTracking', () => ({
+  trackCallsExecution: (params: unknown) => mockTrackCallsExecution(params),
+}));
+
+jest.mock('./managedExecutionFailure', () => ({
+  resolveManagedExecutionFailure: (params: unknown) => mockResolveManagedExecutionFailure(params),
+}));
+
+jest.mock('./willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
+  supportsDelegatedExecution: (params: unknown) => mockSupportsDelegatedExecution(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const RECIPIENT = '0x4444444444444444444444444444444444444444' satisfies Address;
+const PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
+const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const chainId = ChainId.base;
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', chainId);
+const signer = new Wallet(PRIVATE_KEY, provider);
+const publicClient = { name: 'public-client' };
+
+const sendCall: Call = {
+  data: '0x1234',
+  to: RECIPIENT,
+  value: 123n,
+};
+
+const baseTransaction = {
+  chainId,
+  from: ACCOUNT,
+  network: 'Base',
+  nonce: -1,
+  to: RECIPIENT,
+} satisfies Omit<NewTransaction, 'hash' | 'status' | 'txTo' | 'type'>;
+
+const pendingTransaction = {
+  ...baseTransaction,
+  data: sendCall.data,
+  status: TransactionStatus.pending,
+  txTo: sendCall.to,
+  type: 'send',
+  value: sendCall.value,
+} satisfies Omit<NewTransaction, 'hash'>;
+
+function executeWith(params?: Partial<Parameters<typeof executeSponsoredSend>[0]>) {
+  return executeSponsoredSend({
+    accountAddress: ACCOUNT,
+    call: sendCall,
+    chainId,
+    preparedCalls: {
+      executionId: 'prepared-send',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    } as PreparedCallsExecution,
+    provider,
+    signer,
+    transaction: pendingTransaction,
+    ...params,
+  });
+}
+
+describe('sponsoredSend', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRemoteConfig.sponsored_sends_enabled = true;
+    mockCanUseDelegatedExecution.mockReturnValue(true);
+    mockCreateDelegationPublicClient.mockReturnValue(publicClient);
+    mockIsSponsorshipEligible.mockReturnValue(true);
+    mockPrepareCalls.mockResolvedValue({
+      executionId: 'prepared-send',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+    mockResolveManagedExecutionFailure.mockResolvedValue(null);
+    mockSupportsDelegatedExecution.mockResolvedValue(true);
+  });
+
+  it('requires remote config and a valid address before predicting sponsored sends', () => {
+    mockRemoteConfig.sponsored_sends_enabled = false;
+
+    expect(predictSponsoredSend({ address: ACCOUNT, chainId })).toBe(false);
+    expect(mockCanUseDelegatedExecution).not.toHaveBeenCalled();
+
+    mockRemoteConfig.sponsored_sends_enabled = true;
+
+    expect(predictSponsoredSend({ address: 'not-an-address', chainId })).toBe(false);
+    expect(mockCanUseDelegatedExecution).not.toHaveBeenCalled();
+    expect(predictSponsoredSend({ address: ACCOUNT, chainId })).toBe(true);
+  });
+
+  it('builds send calls and pending send transactions from wallet transaction data', () => {
+    const call = buildSendCall({
+      data: Uint8Array.from([0x12, 0x34]),
+      to: RECIPIENT,
+      value: BigNumber.from(123),
+    });
+
+    expect(call).toEqual(sendCall);
+    expect(
+      buildPendingSendTransaction({
+        call,
+        transaction: baseTransaction,
+      })
+    ).toEqual(pendingTransaction);
+  });
+
+  it('prepares sponsored exact calls when feature, network, and wallet support allow it', async () => {
+    await expect(prepareSponsoredSend({ accountAddress: ACCOUNT, call: sendCall, chainId })).resolves.toEqual({
+      executionId: 'prepared-send',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+
+    expect(mockSupportsDelegatedExecution).toHaveBeenCalledWith({ address: ACCOUNT, chainId });
+    expect(mockCreateDelegationPublicClient).toHaveBeenCalledWith(chainId);
+    expect(mockPrepareCalls).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      calls: [sendCall],
+      chainId,
+      publicClient,
+      requirements: mockSponsoredCallsRequirements,
+    });
+  });
+
+  it('uses cached delegation support when provided', async () => {
+    await expect(prepareSponsoredSend({ accountAddress: ACCOUNT, call: sendCall, chainId, delegationSupported: true })).resolves.toEqual({
+      executionId: 'prepared-send',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      calls: [sendCall],
+      chainId,
+      publicClient,
+      requirements: mockSponsoredCallsRequirements,
+    });
+  });
+
+  it('skips sponsored preparation when cached delegation support is false', async () => {
+    await expect(
+      prepareSponsoredSend({ accountAddress: ACCOUNT, call: sendCall, chainId, delegationSupported: false })
+    ).resolves.toBeNull();
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+    expect(mockCreateDelegationPublicClient).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+
+  it('passes the abort signal to preparation RPCs', async () => {
+    const abortController = new AbortController();
+
+    await expect(
+      prepareSponsoredSend({ accountAddress: ACCOUNT, call: sendCall, chainId, signal: abortController.signal })
+    ).resolves.toEqual({
+      executionId: 'prepared-send',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+
+    expect(mockCreateDelegationPublicClient).toHaveBeenCalledWith(chainId, { signal: abortController.signal });
+  });
+
+  it('does not prepare if the signal is already aborted', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      prepareSponsoredSend({ accountAddress: ACCOUNT, call: sendCall, chainId, signal: abortController.signal })
+    ).resolves.toBeNull();
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+    expect(mockCreateDelegationPublicClient).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+
+  it('skips sponsored preparation when the chain is not eligible', async () => {
+    mockIsSponsorshipEligible.mockReturnValue(false);
+
+    await expect(prepareSponsoredSend({ accountAddress: ACCOUNT, call: sendCall, chainId })).resolves.toBeNull();
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+
+  it('executes prepared sponsored sends through managed calls and tracks the relay execution', async () => {
+    const managedExecution = {
+      executionId: 'submitted-send',
+      kind: 'calls.managed',
+      status: 'PENDING',
+    };
+    mockExecuteCalls.mockResolvedValue(managedExecution);
+
+    await expect(executeWith()).resolves.toBe(managedExecution);
+
+    expect(mockExecuteCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionId: 'prepared-send',
+        kind: 'calls.managed',
+      }),
+      {
+        chainId,
+        provider,
+        signer,
+      }
+    );
+    expect(mockResolveManagedExecutionFailure).toHaveBeenCalledWith({
+      executionId: 'submitted-send',
+      status: 'PENDING',
+    });
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId,
+      execution: managedExecution,
+      transaction: pendingTransaction,
+    });
+  });
+
+  it('executes an unprepared send by building a sponsored exact-call request', async () => {
+    const walletTransaction = {
+      hash: TX_HASH,
+      transaction: {
+        data: sendCall.data,
+        to: sendCall.to,
+        value: sendCall.value,
+      },
+      type: 'eip1559',
+    };
+    const walletExecution = {
+      kind: 'calls.wallet',
+      transactions: [walletTransaction],
+    };
+    mockExecuteCalls.mockResolvedValue(walletExecution);
+
+    await expect(executeWith({ preparedCalls: null })).resolves.toBe(walletExecution);
+
+    expect(mockExecuteCalls).toHaveBeenCalledWith(
+      {
+        calls: [sendCall],
+        chainId,
+        provider,
+        requirements: mockSponsoredCallsRequirements,
+        signer,
+      },
+      undefined
+    );
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId,
+      execution: walletTransaction,
+      transaction: pendingTransaction,
+    });
+  });
+
+  it('raises managed execution failures before tracking the send', async () => {
+    mockExecuteCalls.mockResolvedValue({
+      executionId: 'failed-send',
+      kind: 'calls.managed',
+      status: 'FAILED',
+    });
+    mockResolveManagedExecutionFailure.mockResolvedValue('relay reverted');
+
+    await expect(executeWith()).rejects.toThrow('[executeSponsoredSend]: relay reverted');
+
+    expect(mockTrackCallsExecution).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/delegation/sponsoredSend.ts
+++ b/src/features/delegation/sponsoredSend.ts
@@ -1,0 +1,217 @@
+import { type Signer } from '@ethersproject/abstract-signer';
+import { hexlify } from '@ethersproject/bytes';
+import { type StaticJsonRpcProvider, type TransactionRequest } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { isAddress, isHex, type Address, type Hex } from 'viem';
+
+import { TransactionStatus, type NewTransaction } from '@/entities/transactions/transaction';
+import { RainbowError } from '@/logger';
+import { getRemoteConfig } from '@/model/remoteConfig';
+import { backendNetworksActions } from '@/state/backendNetworks/backendNetworks';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { execute, type Call, type ExecuteCallsResult, type ExecutionResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import { createDelegationPublicClient, SPONSORED_CALLS_REQUIREMENTS } from './calls';
+import { trackCallsExecution } from './callsExecutionTracking';
+import { resolveManagedExecutionFailure } from './managedExecutionFailure';
+import { predictSponsoredCallsExecution } from './sponsoredCalls';
+import { canUseDelegatedExecution, supportsDelegatedExecution } from './willDelegate';
+
+// ============ Types ========================================================= //
+
+type PredictSponsoredSendParams = {
+  address: string | null | undefined;
+  chainId: ChainId | null;
+  sponsorshipEligibleChainIds?: ChainId[];
+};
+
+type PrepareSponsoredSendParams = {
+  accountAddress: Address;
+  call: Call;
+  chainId: ChainId;
+  delegationSupported?: boolean;
+  signal?: AbortSignal;
+};
+
+type ExecuteSponsoredSendParams = PrepareSponsoredSendParams & {
+  preparedCalls: PreparedCallsExecution | null;
+  provider: StaticJsonRpcProvider;
+  signer: Signer;
+  transaction: Omit<NewTransaction, 'hash'>;
+};
+
+type SendCallTransaction = Pick<TransactionRequest, 'data' | 'to' | 'value'>;
+
+// ============ Sponsorship =================================================== //
+
+export function predictSponsoredSend({ address, chainId, sponsorshipEligibleChainIds }: PredictSponsoredSendParams): boolean {
+  if (!address || !isAddress(address) || !getRemoteConfig().sponsored_sends_enabled) return false;
+
+  return predictSponsoredCallsExecution({
+    address,
+    chainId,
+    sponsorshipEligibleChainIds,
+  });
+}
+
+export async function prepareSponsoredSend({
+  accountAddress,
+  call,
+  chainId,
+  delegationSupported,
+  signal,
+}: PrepareSponsoredSendParams): Promise<PreparedCallsExecution | null> {
+  if (signal?.aborted) return null;
+  if (!canRequestSponsoredSend(chainId)) return null;
+
+  const canExecute = delegationSupported ?? (await supportsDelegatedExecution({ address: accountAddress, chainId }));
+  if (signal?.aborted) return null;
+  if (!canExecute) return null;
+
+  const preparedCalls = await execute.prepare.calls({
+    account: accountAddress,
+    calls: [call],
+    chainId,
+    publicClient: createDelegationPublicClient(chainId, signal ? { signal } : undefined),
+    requirements: SPONSORED_CALLS_REQUIREMENTS,
+  });
+
+  if (signal?.aborted) return null;
+  return preparedCalls;
+}
+
+export async function executeSponsoredSend({
+  accountAddress,
+  call,
+  chainId,
+  preparedCalls,
+  provider,
+  signer,
+  transaction,
+}: ExecuteSponsoredSendParams): Promise<ExecuteCallsResult | null> {
+  if (!(signer instanceof Wallet) || !canUseDelegatedExecution(accountAddress)) return null;
+
+  const execution = await executeSendCall({ call, chainId, preparedCalls, provider, signer });
+
+  if (execution.kind === 'calls.managed') {
+    const failureMessage = await resolveManagedExecutionFailure({
+      executionId: execution.executionId,
+      status: execution.status,
+    });
+
+    if (failureMessage) {
+      throw new RainbowError(`[executeSponsoredSend]: ${failureMessage}`);
+    }
+
+    trackCallsExecution({
+      address: accountAddress,
+      batch: false,
+      chainId,
+      execution,
+      transaction,
+    });
+    return execution;
+  }
+
+  const submittedTransaction = requireSingleWalletSendExecution(execution);
+  trackCallsExecution({
+    address: accountAddress,
+    batch: false,
+    chainId,
+    execution: submittedTransaction,
+    transaction,
+  });
+
+  return execution;
+}
+
+export function buildSendCall(transaction: SendCallTransaction): Call {
+  const to = transaction.to?.toString();
+  if (!to || !isAddress(to)) {
+    throw new RainbowError(`[buildSendCall]: invalid transaction recipient`);
+  }
+
+  return {
+    to,
+    value: parseCallValue(transaction.value),
+    data: normalizeCallData(transaction.data),
+  };
+}
+
+export function buildPendingSendTransaction({
+  call,
+  transaction,
+}: {
+  call: Call;
+  transaction: Omit<NewTransaction, 'hash' | 'status' | 'txTo' | 'type'>;
+}): Omit<NewTransaction, 'hash'> {
+  return {
+    ...transaction,
+    data: call.data,
+    status: TransactionStatus.pending,
+    txTo: call.to,
+    type: 'send',
+    value: call.value,
+  };
+}
+
+// ============ Local Helpers ================================================= //
+
+function canRequestSponsoredSend(chainId: ChainId): boolean {
+  return getRemoteConfig().sponsored_sends_enabled === true && backendNetworksActions.isSponsorshipEligible(chainId);
+}
+
+function executeSendCall({
+  call,
+  chainId,
+  preparedCalls,
+  provider,
+  signer,
+}: {
+  call: Call;
+  chainId: ChainId;
+  preparedCalls: PreparedCallsExecution | null;
+  provider: StaticJsonRpcProvider;
+  signer: Wallet;
+}): Promise<ExecuteCallsResult> {
+  if (preparedCalls) {
+    return execute.calls(preparedCalls, {
+      chainId,
+      provider,
+      signer,
+    });
+  }
+
+  if (!canRequestSponsoredSend(chainId)) {
+    throw new RainbowError(`[executeSponsoredSend]: sponsored sends are unavailable on chain ${chainId}`);
+  }
+
+  return execute.calls({
+    calls: [call],
+    chainId,
+    provider,
+    requirements: SPONSORED_CALLS_REQUIREMENTS,
+    signer,
+  });
+}
+
+function requireSingleWalletSendExecution(result: ExecuteCallsResult): ExecutionResult {
+  if (result.kind !== 'calls.wallet' || result.transactions.length !== 1) {
+    throw new RainbowError(`[executeSponsoredSend]: exact send execution must resolve to one wallet transaction`);
+  }
+
+  return result.transactions[0];
+}
+
+function parseCallValue(value: TransactionRequest['value']): bigint {
+  if (value === undefined || value === null) return 0n;
+  return BigInt(value.toString());
+}
+
+function normalizeCallData(data: TransactionRequest['data']): Hex {
+  const value = data === undefined || data === null ? '0x' : typeof data === 'string' ? data : hexlify(data);
+  if (!isHex(value)) {
+    throw new RainbowError(`[buildSendCall]: invalid transaction data`);
+  }
+  return value;
+}

--- a/src/features/delegation/sponsoredSendExecution.ts
+++ b/src/features/delegation/sponsoredSendExecution.ts
@@ -1,0 +1,108 @@
+import { type Signer } from '@ethersproject/abstract-signer';
+import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { isAddress, type Address } from 'viem';
+
+import { type ParsedAddressAsset } from '@/entities/tokens';
+import { type NewTransaction } from '@/entities/transactions';
+import { buildTransaction } from '@/handlers/web3';
+import { ensureError, logger } from '@/logger';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { type Call, type ExecuteCallsResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import { isPreparedCallsExecutionSponsored } from './calls';
+import { buildPendingSendTransaction, buildSendCall, prepareSponsoredSend } from './sponsoredSend';
+
+type ExecuteSponsoredSendWithTracking = (params: {
+  accountAddress: Address;
+  call: Call;
+  chainId: ChainId;
+  preparedCalls: PreparedCallsExecution | null;
+  provider: StaticJsonRpcProvider;
+  signer: Signer;
+  transaction: Omit<NewTransaction, 'hash'>;
+}) => Promise<ExecuteCallsResult | null>;
+
+type BuildSendCallFromSendDetailsParams = {
+  accountAddress: string;
+  amount: string;
+  asset: ParsedAddressAsset;
+  chainId: ChainId;
+  provider: StaticJsonRpcProvider;
+  toAddress: string;
+};
+
+type ExecuteSponsoredSendIfAvailableParams = {
+  accountAddress: string;
+  call: Call;
+  chainId: ChainId;
+  executeSponsoredSendWithTracking: ExecuteSponsoredSendWithTracking;
+  preparedCalls: PreparedCallsExecution | null;
+  provider: StaticJsonRpcProvider;
+  signer: Signer;
+  transaction: Omit<NewTransaction, 'hash' | 'status' | 'txTo' | 'type'>;
+};
+
+export async function buildSendCallFromSendDetails({
+  accountAddress,
+  amount,
+  asset,
+  chainId,
+  provider,
+  toAddress,
+}: BuildSendCallFromSendDetailsParams): Promise<Call> {
+  const transaction = await buildTransaction(
+    {
+      address: accountAddress,
+      amount: Number(amount),
+      asset,
+      recipient: toAddress,
+    },
+    provider,
+    chainId
+  );
+
+  return buildSendCall(transaction);
+}
+
+export async function executeSponsoredSendIfAvailable({
+  accountAddress,
+  call,
+  chainId,
+  executeSponsoredSendWithTracking,
+  preparedCalls,
+  provider,
+  signer,
+  transaction,
+}: ExecuteSponsoredSendIfAvailableParams): Promise<boolean> {
+  if (!isAddress(accountAddress)) return false;
+
+  let preparedSponsoredSendCalls = preparedCalls;
+
+  if (!preparedCalls && !isPreparedCallsExecutionSponsored(preparedSponsoredSendCalls)) {
+    try {
+      preparedSponsoredSendCalls = await prepareSponsoredSend({
+        accountAddress,
+        call,
+        chainId,
+      });
+    } catch (error) {
+      logger.warn('[executeSponsoredSendIfAvailable]: sponsored send preparation failed during submit', {
+        message: ensureError(error).message,
+      });
+    }
+  }
+
+  if (!isPreparedCallsExecutionSponsored(preparedSponsoredSendCalls)) return false;
+
+  const sponsoredExecution = await executeSponsoredSendWithTracking({
+    accountAddress,
+    call,
+    chainId,
+    preparedCalls: preparedSponsoredSendCalls,
+    provider,
+    signer,
+    transaction: buildPendingSendTransaction({ call, transaction }),
+  });
+
+  return Boolean(sponsoredExecution);
+}

--- a/src/features/send/hooks/useSendSubmit.ts
+++ b/src/features/send/hooks/useSendSubmit.ts
@@ -12,22 +12,31 @@ import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
 import { type UniqueAsset } from '@/entities/uniqueAssets';
+import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
+import { executeSponsoredSend } from '@/features/delegation/sponsoredSend';
+import { buildSendCallFromSendDetails, executeSponsoredSendIfAvailable } from '@/features/delegation/sponsoredSendExecution';
 import type useENSProfile from '@/features/ens/hooks/useENSProfile';
 import { type ActionTypes } from '@/features/ens/hooks/useENSRegistrationActionHandler';
 import { type REGISTRATION_STEPS } from '@/features/ens/utils/helpers';
 import { parseGasParamsForTransaction } from '@/features/gas/utils/parseGas';
 import { isNativeAsset } from '@/handlers/assets';
-import { createSignableTransaction, estimateGasLimit, type NewTransactionNonNullable } from '@/handlers/web3';
+import {
+  assetIsParsedAddressAsset,
+  assetIsUniqueAsset,
+  createSignableTransaction,
+  estimateGasLimit,
+  type NewTransactionNonNullable,
+} from '@/handlers/web3';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { lessThan } from '@/helpers/utilities';
 import * as i18n from '@/languages';
-import { logger, RainbowError } from '@/logger';
+import { ensureError, logger, RainbowError } from '@/logger';
 import { loadWallet, sendTransaction } from '@/model/wallet';
 import { setHardwareTXError } from '@/navigation/HardwareWalletTxNavigator';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { interactionsCountQueryKey } from '@/resources/addys/interactions';
-import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { backendNetworksActions, useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { ChainId } from '@/state/backendNetworks/types';
 import { PAGE_SIZE } from '@/state/nfts/createNftsStore';
 import { useNftsStore } from '@/state/nfts/nfts';
@@ -35,8 +44,15 @@ import { getNextNonce } from '@/state/nonces';
 import { addNewTransaction } from '@/state/pendingTransactions';
 import { executeFn, Screens, TimeToSignOperation } from '@/state/performance/performance';
 import { time } from '@/utils/time';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 type SelectedGasFeeForTx = Parameters<typeof parseGasParamsForTransaction>[0];
+type LoadedWallet = NonNullable<Awaited<ReturnType<typeof loadWallet>>>;
+type SendSubmitScreen = Screens.SEND | Screens.SEND_ENS;
+type SendSubmitTransaction = Partial<Omit<NewTransaction, 'asset'>> & {
+  asset: ParsedAddressAsset | UniqueAsset;
+};
+type SponsoredSendTransaction = Omit<NewTransaction, 'hash' | 'status' | 'txTo' | 'type'>;
 
 type AmountDetails = {
   assetAmount: string;
@@ -80,15 +96,17 @@ type EnsProps = {
 type UseSendSubmitParams = {
   accountAddress: string;
   amountDetails: AmountDetails;
+  canUseSponsoredSend: boolean;
   currentChainId: ChainId;
   currentProvider: StaticJsonRpcProvider | undefined;
   ens: EnsProps;
   gas: GasProps;
   isHardwareWallet: boolean;
-  isUniqueAsset: boolean;
+  isSponsoredSend: boolean;
   nativeCurrency: NativeCurrencyKey;
   recipient: RecipientProps;
   selected: ParsedAddressAsset | UniqueAsset | undefined;
+  sponsoredSendPreparedCalls: PreparedCallsExecution | null;
 };
 
 type UseSendSubmitResult = {
@@ -98,15 +116,17 @@ type UseSendSubmitResult = {
 export function useSendSubmit({
   accountAddress,
   amountDetails,
+  canUseSponsoredSend,
   currentChainId,
   currentProvider,
   ens: { ensName, ensProfile, isENS, transferENS },
   gas: { gasLimit, isSufficientGas, isValidGas, selectedGasFee, updateTxFee, updateTxFeeForOptimism },
   isHardwareWallet,
-  isUniqueAsset,
+  isSponsoredSend,
   nativeCurrency,
   recipient: { isValidAddress, recipient, toAddress },
   selected,
+  sponsoredSendPreparedCalls,
 }: UseSendSubmitParams): UseSendSubmitResult {
   const queryClient = useQueryClient();
   const { goBack, navigate } = useNavigation();
@@ -117,6 +137,7 @@ export function useSendSubmit({
       if (!selected || !currentProvider) return;
 
       const screen = isENS ? Screens.SEND_ENS : Screens.SEND;
+      const selectedAddressAsset = assetIsParsedAddressAsset(selected) ? selected : null;
 
       const wallet = await executeFn(loadWallet, {
         operation: TimeToSignOperation.KeychainRead,
@@ -132,45 +153,23 @@ export function useSendSubmit({
 
       const currentChainIdNetwork = useBackendNetworksStore.getState().getChainsName()[currentChainId ?? ChainId.mainnet];
 
-      const validTransaction = isValidAddress && amountDetails.isSufficientBalance && isSufficientGas && isValidGas;
-      if (!selectedGasFee?.gasFee?.estimatedFee || !validTransaction) {
+      const hasSelectedGasEstimate = Boolean(selectedGasFee?.gasFee?.estimatedFee);
+      const hasSufficientGasForSend = isSponsoredSend || isSufficientGas;
+      const hasValidGasForSend = isSponsoredSend || isValidGas;
+      const validTransaction = isValidAddress && amountDetails.isSufficientBalance && hasSufficientGasForSend && hasValidGasForSend;
+      const hasRequiredGasEstimate = isSponsoredSend || hasSelectedGasEstimate;
+
+      if (!hasRequiredGasEstimate || !validTransaction) {
         logger.error(
           new RainbowError(`[useSendSubmit]: preventing tx submit because selectedGasFee is missing or validTransaction is false`),
           {
             selectedGasFee,
             validTransaction,
-            isValidGas,
+            isSponsoredSend,
+            isValidGas: hasValidGasForSend,
           }
         );
         return false;
-      }
-
-      let submitSuccess = false;
-      let updatedGasLimit: string | null = null;
-
-      if (!isUniqueAsset && selected && !isNativeAsset((selected as ParsedAddressAsset).address, currentChainId)) {
-        try {
-          updatedGasLimit = await estimateGasLimit(
-            {
-              address: accountAddress,
-              amount: Number(amountDetails.assetAmount),
-              asset: selected,
-              recipient: toAddress,
-            },
-            true,
-            currentProvider,
-            currentChainId
-          );
-
-          if (updatedGasLimit && !lessThan(updatedGasLimit, gasLimit)) {
-            if (useBackendNetworksStore.getState().getNeedsL1SecurityFeeChains().includes(currentChainId)) {
-              updateTxFeeForOptimism(updatedGasLimit);
-            } else {
-              updateTxFee(updatedGasLimit, null);
-            }
-          }
-          // eslint-disable-next-line no-empty
-        } catch (e) {}
       }
 
       let nextNonce: number | undefined;
@@ -202,18 +201,15 @@ export function useSendSubmit({
         }
       }
 
-      const gasLimitToUse = updatedGasLimit && !lessThan(updatedGasLimit, gasLimit) ? updatedGasLimit : gasLimit;
-      const gasParams = parseGasParamsForTransaction(selectedGasFee);
-      const txDetails: Partial<NewTransaction> = {
+      const nonce = nextNonce ?? (await getNextNonce({ address: accountAddress, chainId: currentChainId }));
+      const txDetails: SendSubmitTransaction = {
         amount: amountDetails.assetAmount,
-        asset: selected as ParsedAddressAsset,
-        from: accountAddress,
-        gasLimit: gasLimitToUse,
+        asset: selected,
         network: currentChainIdNetwork,
         chainId: currentChainId,
-        nonce: nextNonce ?? (await getNextNonce({ address: accountAddress, chainId: currentChainId })),
+        from: accountAddress,
+        nonce,
         to: toAddress,
-        ...gasParams,
       };
 
       // The interactions count query has a 15-minute cache TTL; without invalidation
@@ -231,77 +227,65 @@ export function useSendSubmit({
       };
 
       try {
-        const signableTransaction = await executeFn(createSignableTransaction, {
-          operation: TimeToSignOperation.CreateSignableTransaction,
+        const didSubmitSponsoredSend = await submitSponsoredSend({
+          accountAddress,
+          amount: amountDetails.assetAmount,
+          canUseSponsoredSend,
+          chainId: currentChainId,
+          chainName: currentChainIdNetwork,
+          preparedCalls: sponsoredSendPreparedCalls,
+          provider: currentProvider,
           screen,
-        })(txDetails as NewTransactionNonNullable);
-        if (!signableTransaction.to) {
-          logger.error(new RainbowError(`[useSendSubmit]: txDetails is missing the "to" field`), {
-            txDetails,
-            signableTransaction,
+          selectedAddressAsset,
+          signer: wallet,
+          toAddress,
+        });
+
+        if (didSubmitSponsoredSend) {
+          invalidateInteractionsCount();
+          return true;
+        }
+
+        if (isSponsoredSend) {
+          setSponsoredSendUnavailable({
+            chainId: currentChainId,
+            error: new RainbowError('[useSendSubmit]: submitSponsoredSend returned false even though sponsored send was selected'),
           });
-          Alert.alert(i18n.t(i18n.l.wallet.transaction.alert.invalid_transaction));
-          submitSuccess = false;
           return false;
         }
 
-        const sendTransactionResult = await executeFn(sendTransaction, {
-          screen,
-          operation: TimeToSignOperation.BroadcastTransaction,
-        })({
-          existingWallet: wallet,
+        const didSubmitPaidSend = await submitPaidSend({
+          accountAddress,
+          amount: amountDetails.assetAmount,
+          chainId: currentChainId,
+          chainName: currentChainIdNetwork,
+          gasLimit,
           provider: currentProvider,
-          transaction: {
-            ...signableTransaction,
-            to: signableTransaction.to,
-            data: signableTransaction.data,
-            from: signableTransaction.from,
-            gasLimit: signableTransaction.gasLimit,
-            chainId: signableTransaction.chainId as ChainId,
-            value: signableTransaction.value,
-            nonce: signableTransaction.nonce,
-          },
+          screen,
+          selectedAddressAsset,
+          selectedGasFee,
+          toAddress,
+          txDetails,
+          updateTxFee,
+          updateTxFeeForOptimism,
+          wallet,
         });
 
-        if (!sendTransactionResult || !sendTransactionResult.result) {
-          logger.error(new RainbowError(`[useSendSubmit]: No result from sendTransaction`), {
-            sendTransactionResult,
-            signableTransaction,
-          });
-          return;
-        }
-
-        if (sendTransactionResult?.error) {
-          logger.error(new RainbowError(`[useSendSubmit]: Error from sendTransaction`), {
-            sendTransactionResult,
-            signableTransaction,
-          });
-          return;
-        }
-
-        const { hash, nonce: txNonce } = sendTransactionResult.result;
-        const { data, value } = signableTransaction;
-        if (!isEmpty(hash)) {
-          submitSuccess = true;
-          if (hash) txDetails.hash = hash;
-          if (data) txDetails.data = data;
-          if (value) txDetails.value = value;
-          txDetails.nonce = txNonce;
-          txDetails.network = currentChainIdNetwork;
-          txDetails.chainId = currentChainId;
-          txDetails.txTo = signableTransaction.to;
-          txDetails.type = 'send';
-          txDetails.status = TransactionStatus.pending;
-          addNewTransaction({
-            address: accountAddress,
-            chainId: currentChainId,
-            transaction: txDetails as NewTransaction,
-          });
-
+        if (didSubmitPaidSend) {
           invalidateInteractionsCount();
         }
+
+        return didSubmitPaidSend;
       } catch (error) {
-        submitSuccess = false;
+        const message = ensureError(error).message;
+        if (isInsufficientSponsorBalanceError(message) || isSponsoredRelayExecutionFailure(message)) {
+          setSponsoredSendUnavailable({
+            chainId: currentChainId,
+            error,
+          });
+          return false;
+        }
+
         logger.error(new RainbowError(`[useSendSubmit]: onSubmit error`), {
           txDetails,
           error,
@@ -310,13 +294,14 @@ export function useSendSubmit({
         if (!(wallet instanceof Wallet)) {
           setHardwareTXError(true);
         }
+        return false;
       }
-      return submitSuccess;
     },
     [
       accountAddress,
       amountDetails.assetAmount,
       amountDetails.isSufficientBalance,
+      canUseSponsoredSend,
       currentChainId,
       currentProvider,
       ensName,
@@ -325,14 +310,15 @@ export function useSendSubmit({
       ensProfile?.data?.records,
       gasLimit,
       isENS,
+      isSponsoredSend,
       isSufficientGas,
-      isUniqueAsset,
       isValidAddress,
       isValidGas,
       nativeCurrency,
       queryClient,
       selected,
       selectedGasFee,
+      sponsoredSendPreparedCalls,
       toAddress,
       transferENS,
       updateTxFee,
@@ -352,8 +338,11 @@ export function useSendSubmit({
       analytics.track(analytics.event.sentTransaction, {
         assetName: selected?.name || '',
         network: selected?.network || '',
+        chainId: currentChainId,
+        isSponsored: isSponsoredSend,
         isRecepientENS: recipient.slice(-4).toLowerCase() === '.eth',
         isHardwareWallet,
+        submitSuccessful: submitSuccessful === true,
       });
 
       const goBackAndNavigate = () => {
@@ -368,9 +357,8 @@ export function useSendSubmit({
       };
 
       if (submitSuccessful) {
-        if (isUniqueAsset && selected) {
-          const uniqueAsset = selected as UniqueAsset;
-          const collectionId = `${uniqueAsset.network}_${uniqueAsset.contractAddress}`;
+        if (assetIsUniqueAsset(selected)) {
+          const collectionId = `${selected.network}_${selected.contractAddress}`;
           useNftsStore.getState(accountAddress).fetchNftCollection(collectionId, true);
           useNftsStore.getState(accountAddress).fetch({ limit: PAGE_SIZE }, { staleTime: time.seconds(5) });
         }
@@ -384,10 +372,11 @@ export function useSendSubmit({
     [
       accountAddress,
       amountDetails,
+      currentChainId,
       goBack,
       isENS,
       isHardwareWallet,
-      isUniqueAsset,
+      isSponsoredSend,
       navigate,
       onSubmit,
       rainbowToastsEnabled,
@@ -397,4 +386,223 @@ export function useSendSubmit({
   );
 
   return { submitTransaction };
+}
+
+function getTransactionAsset(asset: ParsedAddressAsset, network: string): NonNullable<NewTransaction['asset']> {
+  return {
+    ...asset,
+    network: asset.network ?? network,
+  };
+}
+
+async function submitSponsoredSend({
+  accountAddress,
+  amount,
+  canUseSponsoredSend,
+  chainId,
+  chainName,
+  preparedCalls,
+  provider,
+  screen,
+  selectedAddressAsset,
+  signer,
+  toAddress,
+}: {
+  accountAddress: string;
+  amount: string;
+  canUseSponsoredSend: boolean;
+  chainId: ChainId;
+  chainName: string;
+  preparedCalls: PreparedCallsExecution | null;
+  provider: StaticJsonRpcProvider;
+  screen: SendSubmitScreen;
+  selectedAddressAsset: ParsedAddressAsset | null;
+  signer: LoadedWallet;
+  toAddress: string;
+}): Promise<boolean> {
+  if (!canUseSponsoredSend || !selectedAddressAsset) return false;
+
+  const sendCall = await buildSendCallFromSendDetails({
+    accountAddress,
+    amount,
+    asset: selectedAddressAsset,
+    chainId,
+    provider,
+    toAddress,
+  });
+  const sponsoredSendTransaction: SponsoredSendTransaction = {
+    amount,
+    asset: getTransactionAsset(selectedAddressAsset, chainName),
+    network: chainName,
+    chainId,
+    from: accountAddress,
+    nonce: -1,
+    to: toAddress,
+  };
+
+  return executeSponsoredSendIfAvailable({
+    accountAddress,
+    call: sendCall,
+    chainId,
+    executeSponsoredSendWithTracking: executeFn(executeSponsoredSend, {
+      screen,
+      operation: TimeToSignOperation.BroadcastTransaction,
+    }),
+    preparedCalls,
+    provider,
+    signer,
+    transaction: sponsoredSendTransaction,
+  });
+}
+
+function setSponsoredSendUnavailable({ chainId, error }: { chainId: ChainId; error: unknown }) {
+  backendNetworksActions.disableSponsorshipUntilNextFetch(chainId);
+  logger.error(new RainbowError(`[useSendSubmit]: sponsored send was selected but execution was unavailable`), {
+    currentChainId: chainId,
+    error,
+  });
+  Alert.alert(i18n.t(i18n.l.wallet.transaction.alert.failed_transaction), i18n.t(i18n.l.send.sponsorship_unavailable));
+}
+
+function isSponsoredRelayExecutionFailure(message: string): boolean {
+  return message.includes('Managed relay execution failed') || message.includes('Managed relay execution reverted');
+}
+
+async function submitPaidSend({
+  accountAddress,
+  amount,
+  chainId,
+  chainName,
+  gasLimit,
+  provider,
+  screen,
+  selectedAddressAsset,
+  selectedGasFee,
+  toAddress,
+  txDetails,
+  updateTxFee,
+  updateTxFeeForOptimism,
+  wallet,
+}: {
+  accountAddress: string;
+  amount: string;
+  chainId: ChainId;
+  chainName: string;
+  gasLimit: string;
+  provider: StaticJsonRpcProvider;
+  screen: SendSubmitScreen;
+  selectedAddressAsset: ParsedAddressAsset | null;
+  selectedGasFee: SelectedGasFeeForTx;
+  toAddress: string;
+  txDetails: SendSubmitTransaction;
+  updateTxFee: GasProps['updateTxFee'];
+  updateTxFeeForOptimism: GasProps['updateTxFeeForOptimism'];
+  wallet: LoadedWallet;
+}): Promise<boolean | undefined> {
+  let updatedGasLimit: string | null = null;
+  if (selectedAddressAsset && !isNativeAsset(selectedAddressAsset.address, chainId)) {
+    try {
+      updatedGasLimit = await estimateGasLimit(
+        {
+          address: accountAddress,
+          amount: Number(amount),
+          asset: selectedAddressAsset,
+          recipient: toAddress,
+        },
+        true,
+        provider,
+        chainId
+      );
+
+      if (updatedGasLimit && !lessThan(updatedGasLimit, gasLimit)) {
+        if (useBackendNetworksStore.getState().getNeedsL1SecurityFeeChains().includes(chainId)) {
+          updateTxFeeForOptimism(updatedGasLimit);
+        } else {
+          updateTxFee(updatedGasLimit, null);
+        }
+      }
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+  }
+
+  const gasLimitToUse = updatedGasLimit && !lessThan(updatedGasLimit, gasLimit) ? updatedGasLimit : gasLimit;
+  const gasParams = parseGasParamsForTransaction(selectedGasFee);
+  Object.assign(txDetails, {
+    gasLimit: gasLimitToUse,
+    ...gasParams,
+  });
+
+  const signableTransaction = await executeFn(createSignableTransaction, {
+    operation: TimeToSignOperation.CreateSignableTransaction,
+    screen,
+  })(txDetails as NewTransactionNonNullable);
+  if (!signableTransaction.to) {
+    logger.error(new RainbowError(`[useSendSubmit]: txDetails is missing the "to" field`), {
+      txDetails,
+      signableTransaction,
+    });
+    Alert.alert(i18n.t(i18n.l.wallet.transaction.alert.invalid_transaction));
+    return false;
+  }
+
+  const sendTransactionResult = await executeFn(sendTransaction, {
+    screen,
+    operation: TimeToSignOperation.BroadcastTransaction,
+  })({
+    existingWallet: wallet,
+    provider,
+    transaction: {
+      ...signableTransaction,
+      to: signableTransaction.to,
+      data: signableTransaction.data,
+      from: signableTransaction.from,
+      gasLimit: signableTransaction.gasLimit,
+      chainId: signableTransaction.chainId as ChainId,
+      value: signableTransaction.value,
+      nonce: signableTransaction.nonce,
+    },
+  });
+
+  if (!sendTransactionResult || !sendTransactionResult.result) {
+    logger.error(new RainbowError(`[useSendSubmit]: No result from sendTransaction`), {
+      sendTransactionResult,
+      signableTransaction,
+    });
+    return;
+  }
+
+  if (sendTransactionResult?.error) {
+    logger.error(new RainbowError(`[useSendSubmit]: Error from sendTransaction`), {
+      sendTransactionResult,
+      signableTransaction,
+    });
+    return;
+  }
+
+  const { hash, nonce: txNonce } = sendTransactionResult.result;
+  const { data, value } = signableTransaction;
+  if (!isEmpty(hash)) {
+    const pendingTransaction = {
+      ...txDetails,
+      ...(hash ? { hash } : undefined),
+      ...(data ? { data } : undefined),
+      ...(value ? { value } : undefined),
+      nonce: txNonce,
+      network: chainName,
+      chainId,
+      txTo: signableTransaction.to,
+      type: 'send',
+      status: TransactionStatus.pending,
+    };
+
+    addNewTransaction({
+      address: accountAddress,
+      chainId,
+      transaction: pendingTransaction as NewTransaction,
+    });
+
+    return true;
+  }
+
+  return false;
 }

--- a/src/features/send/hooks/useSponsoredSendPreparation.test.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.test.ts
@@ -1,0 +1,162 @@
+import { type Address } from 'viem';
+
+import { ChainId } from '@/state/backendNetworks/types';
+
+import { getCachedDelegationSupport, getDelegationSupportRequestKey, getSponsoredSendRequestKey } from './useSponsoredSendPreparation';
+
+jest.mock('@/handlers/web3', () => ({
+  buildTransaction: jest.fn(),
+}));
+
+jest.mock('@/model/remoteConfig', () => ({
+  getRemoteConfig: () => ({ sponsored_sends_enabled: true }),
+  useRemoteConfig: () => ({ sponsored_sends_enabled: true }),
+}));
+
+jest.mock('@/features/delegation/sponsoredSend', () => ({
+  buildSendCall: jest.fn(),
+  predictSponsoredSend: jest.fn(),
+  prepareSponsoredSend: jest.fn(),
+}));
+
+jest.mock('@/features/delegation/sponsoredSendExecution', () => ({
+  buildSendCallFromSendDetails: jest.fn(),
+}));
+
+const mockSupportsDelegatedExecution = jest.fn<Promise<boolean>, [unknown]>();
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  supportsDelegatedExecution: (params: unknown) => mockSupportsDelegatedExecution(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+
+const SELECTED_ASSET = {
+  address: '0x5555555555555555555555555555555555555555',
+  decimals: 18,
+  uniqueId: 'base-eth',
+};
+
+describe('getSponsoredSendRequestKey', () => {
+  it('returns null until there is a positive amount', () => {
+    expect(
+      getSponsoredSendRequestKey({
+        accountAddress: '0x3333333333333333333333333333333333333333',
+        amount: '0',
+        chainId: ChainId.base,
+        selected: SELECTED_ASSET,
+        toAddress: '0x4444444444444444444444444444444444444444',
+      })
+    ).toBeNull();
+  });
+
+  it('returns null for NaN amount', () => {
+    expect(
+      getSponsoredSendRequestKey({
+        accountAddress: '0x3333333333333333333333333333333333333333',
+        amount: '.',
+        chainId: ChainId.base,
+        selected: SELECTED_ASSET,
+        toAddress: '0x4444444444444444444444444444444444444444',
+      })
+    ).toBeNull();
+  });
+
+  it('normalizes addresses and includes asset, chain, and amount identity', () => {
+    expect(
+      getSponsoredSendRequestKey({
+        accountAddress: '0x3333333333333333333333333333333333333333'.toUpperCase(),
+        amount: '1.5',
+        chainId: ChainId.base,
+        selected: SELECTED_ASSET,
+        toAddress: '0x4444444444444444444444444444444444444444'.toUpperCase(),
+      })
+    ).toBe(
+      '0x3333333333333333333333333333333333333333:8453:base-eth:0x5555555555555555555555555555555555555555:18:0x4444444444444444444444444444444444444444:1.5'
+    );
+  });
+
+  it('separates assets with the same unique id but different token shape', () => {
+    const sharedRequest = {
+      accountAddress: '0x3333333333333333333333333333333333333333',
+      amount: '1.5',
+      chainId: ChainId.base,
+      toAddress: '0x4444444444444444444444444444444444444444',
+    };
+
+    expect(
+      getSponsoredSendRequestKey({
+        ...sharedRequest,
+        selected: {
+          ...SELECTED_ASSET,
+          address: '0x5555555555555555555555555555555555555555'.toUpperCase(),
+        },
+      })
+    ).not.toBe(
+      getSponsoredSendRequestKey({
+        ...sharedRequest,
+        selected: {
+          ...SELECTED_ASSET,
+          address: '0x6666666666666666666666666666666666666666',
+        },
+      })
+    );
+
+    expect(
+      getSponsoredSendRequestKey({
+        ...sharedRequest,
+        selected: SELECTED_ASSET,
+      })
+    ).not.toBe(
+      getSponsoredSendRequestKey({
+        ...sharedRequest,
+        selected: {
+          ...SELECTED_ASSET,
+          decimals: 6,
+        },
+      })
+    );
+  });
+});
+
+describe('getCachedDelegationSupport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('normalizes cache keys by account and chain', () => {
+    expect(
+      getDelegationSupportRequestKey({
+        accountAddress: ACCOUNT.toUpperCase() as Address,
+        chainId: ChainId.base,
+      })
+    ).toBe('0x3333333333333333333333333333333333333333:8453');
+  });
+
+  it('reuses the same delegation support request for matching account and chain', async () => {
+    const cache = new Map<string, Promise<boolean>>();
+    mockSupportsDelegatedExecution.mockResolvedValue(true);
+
+    await expect(getCachedDelegationSupport({ accountAddress: ACCOUNT, cache, chainId: ChainId.base })).resolves.toBe(true);
+    await expect(
+      getCachedDelegationSupport({
+        accountAddress: ACCOUNT.toUpperCase() as Address,
+        cache,
+        chainId: ChainId.base,
+      })
+    ).resolves.toBe(true);
+
+    expect(mockSupportsDelegatedExecution).toHaveBeenCalledTimes(1);
+    expect(mockSupportsDelegatedExecution).toHaveBeenCalledWith({ address: ACCOUNT, chainId: ChainId.base });
+  });
+
+  it('drops failed delegation support requests so the next preparation can retry', async () => {
+    const cache = new Map<string, Promise<boolean>>();
+    mockSupportsDelegatedExecution.mockRejectedValueOnce(new Error('support failed')).mockResolvedValueOnce(true);
+
+    await expect(getCachedDelegationSupport({ accountAddress: ACCOUNT, cache, chainId: ChainId.base })).rejects.toThrow('support failed');
+    await expect(getCachedDelegationSupport({ accountAddress: ACCOUNT, cache, chainId: ChainId.base })).resolves.toBe(true);
+
+    expect(mockSupportsDelegatedExecution).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/send/hooks/useSponsoredSendPreparation.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.ts
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { isAddress, type Address } from 'viem';
+
+import { type ParsedAddressAsset } from '@/entities/tokens';
+import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
+import { predictSponsoredSend, prepareSponsoredSend } from '@/features/delegation/sponsoredSend';
+import { buildSendCallFromSendDetails } from '@/features/delegation/sponsoredSendExecution';
+import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
+import { ensureError, logger } from '@/logger';
+import { useRemoteConfig } from '@/model/remoteConfig';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+type PreparedSponsoredSendState = {
+  key: string;
+  preparedCalls: PreparedCallsExecution | null;
+};
+
+type DelegationSupportCache = Map<string, Promise<boolean>>;
+type DelegationSupportLoader = (params: { address: Address; chainId: ChainId }) => Promise<boolean>;
+
+type UseSponsoredSendPreparationParams = {
+  accountAddress: string | undefined;
+  amount: string;
+  chainId: ChainId;
+  debouncedAmount: string;
+  isENS: boolean;
+  isValidAddress: boolean;
+  provider: StaticJsonRpcProvider | undefined;
+  selected: ParsedAddressAsset | undefined;
+  toAddress: string;
+};
+
+export function getDelegationSupportRequestKey({ accountAddress, chainId }: { accountAddress: Address; chainId: ChainId }): string {
+  return [accountAddress.toLowerCase(), chainId].join(':');
+}
+
+export function getCachedDelegationSupport({
+  accountAddress,
+  cache,
+  chainId,
+  loadSupport = supportsDelegatedExecution,
+}: {
+  accountAddress: Address;
+  cache: DelegationSupportCache;
+  chainId: ChainId;
+  loadSupport?: DelegationSupportLoader;
+}): Promise<boolean> {
+  const cacheKey = getDelegationSupportRequestKey({ accountAddress, chainId });
+  const cachedSupport = cache.get(cacheKey);
+  if (cachedSupport) return cachedSupport;
+
+  const supportRequest = loadSupport({ address: accountAddress, chainId }).catch(error => {
+    cache.delete(cacheKey);
+    throw error;
+  });
+  cache.set(cacheKey, supportRequest);
+  return supportRequest;
+}
+
+export function getSponsoredSendRequestKey({
+  accountAddress,
+  amount,
+  chainId,
+  selected,
+  toAddress,
+}: {
+  accountAddress: string;
+  amount: string;
+  chainId: ChainId;
+  selected: Pick<ParsedAddressAsset, 'address' | 'decimals' | 'uniqueId'>;
+  toAddress: string;
+}): string | null {
+  const parsedAmount = Number(amount);
+  if (isNaN(parsedAmount) || parsedAmount <= 0) return null;
+
+  return [
+    accountAddress.toLowerCase(),
+    chainId,
+    selected.uniqueId,
+    selected.address.toLowerCase(),
+    selected.decimals,
+    toAddress.toLowerCase(),
+    parsedAmount,
+  ].join(':');
+}
+
+export function useSponsoredSendPreparation({
+  accountAddress,
+  amount,
+  chainId,
+  debouncedAmount,
+  isENS,
+  isValidAddress,
+  provider,
+  selected,
+  toAddress,
+}: UseSponsoredSendPreparationParams) {
+  const sponsorshipEligibleChainIds = useBackendNetworksStore(state => state.getSponsorshipEligibleChainIds());
+  const { sponsored_sends_enabled: sponsoredSendsEnabled } = useRemoteConfig('sponsored_sends_enabled');
+  const delegationSupportCacheRef = useRef<DelegationSupportCache>(new Map());
+
+  const canUseSponsoredSend = useMemo(() => {
+    if (!sponsoredSendsEnabled || !accountAddress || !provider || !selected || isENS || !isValidAddress || !toAddress) return false;
+
+    return predictSponsoredSend({
+      address: accountAddress,
+      chainId,
+      sponsorshipEligibleChainIds,
+    });
+  }, [accountAddress, chainId, isENS, isValidAddress, provider, selected, sponsoredSendsEnabled, sponsorshipEligibleChainIds, toAddress]);
+
+  const sponsoredSendRequestKey =
+    accountAddress && selected && toAddress
+      ? getSponsoredSendRequestKey({
+          accountAddress,
+          amount,
+          chainId,
+          selected,
+          toAddress,
+        })
+      : null;
+
+  const debouncedSponsoredSendRequestKey =
+    accountAddress && selected && toAddress
+      ? getSponsoredSendRequestKey({
+          accountAddress,
+          amount: debouncedAmount,
+          chainId,
+          selected,
+          toAddress,
+        })
+      : null;
+
+  const [preparedSponsoredSend, setPreparedSponsoredSend] = useState<PreparedSponsoredSendState | null>(null);
+  const [isPreparingSponsoredSend, setIsPreparingSponsoredSend] = useState(false);
+  const hasResolvedSponsoredSend = preparedSponsoredSend?.key === sponsoredSendRequestKey;
+  const preparedCalls = hasResolvedSponsoredSend ? preparedSponsoredSend.preparedCalls : null;
+  const isSponsoredSend = isPreparedCallsExecutionSponsored(preparedCalls);
+  const shouldShowSponsoredSendGas =
+    canUseSponsoredSend &&
+    (!sponsoredSendRequestKey || isPreparingSponsoredSend || debouncedAmount !== amount || !hasResolvedSponsoredSend || isSponsoredSend);
+
+  useEffect(() => {
+    let isStale = false;
+    const abortController = new AbortController();
+
+    const prepareSend = async () => {
+      if (
+        !canUseSponsoredSend ||
+        !accountAddress ||
+        !isAddress(accountAddress) ||
+        !selected ||
+        !provider ||
+        !debouncedSponsoredSendRequestKey
+      ) {
+        setPreparedSponsoredSend(null);
+        setIsPreparingSponsoredSend(false);
+        return;
+      }
+
+      setPreparedSponsoredSend(null);
+      setIsPreparingSponsoredSend(true);
+
+      try {
+        const call = await buildSendCallFromSendDetails({
+          accountAddress,
+          amount: debouncedAmount,
+          asset: selected,
+          chainId,
+          provider,
+          toAddress,
+        });
+        if (abortController.signal.aborted) return;
+
+        const delegationSupported = await getCachedDelegationSupport({
+          accountAddress,
+          cache: delegationSupportCacheRef.current,
+          chainId,
+        });
+        if (abortController.signal.aborted) return;
+
+        const nextPreparedCalls = await prepareSponsoredSend({
+          accountAddress,
+          call,
+          chainId,
+          delegationSupported,
+          signal: abortController.signal,
+        });
+
+        if (!isStale) {
+          setPreparedSponsoredSend({ key: debouncedSponsoredSendRequestKey, preparedCalls: nextPreparedCalls });
+        }
+      } catch (error) {
+        if (abortController.signal.aborted) return;
+        const message = ensureError(error).message;
+        logger.warn('[useSponsoredSendPreparation]: sponsored send preparation failed', { message });
+        if (!isStale) {
+          setPreparedSponsoredSend({ key: debouncedSponsoredSendRequestKey, preparedCalls: null });
+        }
+      } finally {
+        if (!isStale) {
+          setIsPreparingSponsoredSend(false);
+        }
+      }
+    };
+
+    prepareSend();
+
+    return () => {
+      isStale = true;
+      abortController.abort();
+    };
+  }, [accountAddress, canUseSponsoredSend, chainId, debouncedAmount, debouncedSponsoredSendRequestKey, provider, selected, toAddress]);
+
+  return {
+    canUseSponsoredSend,
+    hasResolvedSponsoredSend,
+    isPreparingSponsoredSend,
+    isSponsoredSend,
+    preparedCalls,
+    shouldShowSponsoredSendGas,
+  };
+}

--- a/src/features/send/screens/SendSheet.tsx
+++ b/src/features/send/screens/SendSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Keyboard, Platform, View, type TextInput } from 'react-native';
+import { InteractionManager, Keyboard, Platform, StyleSheet, View, type TextInput } from 'react-native';
 
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { isEmpty, isEqual, isString } from 'lodash';
@@ -16,6 +16,7 @@ import useExperimentalFlag from '@/config/experimentalHooks';
 import { AssetType } from '@/entities/assetTypes';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { type UniqueAsset } from '@/entities/uniqueAssets';
+import { SmartWalletActivationCallout } from '@/features/delegation/components/SmartWalletActivationCallout';
 import { prefetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { prefetchENSCover } from '@/features/ens/hooks/useENSCover';
 import useENSProfile from '@/features/ens/hooks/useENSProfile';
@@ -25,7 +26,7 @@ import { REGISTRATION_STEPS } from '@/features/ens/utils/helpers';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
 import useGas from '@/features/gas/hooks/useGas';
 import styled from '@/framework/ui/styled-thing';
-import { assetIsUniqueAsset, buildTransaction, estimateGasLimit, resolveNameOrAddress } from '@/handlers/web3';
+import { assetIsParsedAddressAsset, assetIsUniqueAsset, buildTransaction, estimateGasLimit, resolveNameOrAddress } from '@/handlers/web3';
 import { convertAmountAndPriceToNativeDisplay, convertAmountFromNativeValue, formatInputDecimals } from '@/helpers/utilities';
 import { checkIsValidAddressOrDomain, checkIsValidAddressOrDomainFormat, isENSAddressFormat } from '@/helpers/validators';
 import useAccountSettings from '@/hooks/useAccountSettings';
@@ -58,6 +59,7 @@ import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
 import { useSendChainState } from '../hooks/useSendChainState';
 import { useSendSubmit } from '../hooks/useSendSubmit';
+import { useSponsoredSendPreparation } from '../hooks/useSponsoredSendPreparation';
 import { getSendSubmitButtonState } from '../utils/sendSheetUtils';
 
 const sheetHeight = deviceUtils.dimensions.height - (Platform.OS === 'android' ? 30 : 10);
@@ -81,6 +83,17 @@ const SheetContainer = styled(Column).attrs({
   backgroundColor: ({ theme: { colors } }: ComponentPropsWithTheme) => colors.white,
   height: sheetHeight,
   width: '100%',
+});
+
+const SubmitButtonContainer = styled(View)({
+  width: '100%',
+});
+
+const styles = StyleSheet.create({
+  smartWalletActivationCallout: {
+    marginTop: 16,
+    width: '100%',
+  },
 });
 
 const validateRecipient = (toAddress?: string, tokenAddress?: string) => {
@@ -161,6 +174,7 @@ export default function SendSheet() {
 
   const [debouncedInput] = useDebounce(currentInput, 500);
   const [debouncedRecipient] = useDebounce(recipient, 500);
+  const [debouncedAssetAmount] = useDebounce(amountDetails.assetAmount, 500);
 
   const [isValidAddress, setIsValidAddress] = useState(!!recipientOverride);
   const theme = useTheme();
@@ -173,6 +187,8 @@ export default function SendSheet() {
   const showAssetForm = isValidAddress && !isEmpty(selected);
 
   const isUniqueAsset = assetIsUniqueAsset(selected);
+  const selectedAddressAsset = selected && assetIsParsedAddressAsset(selected) ? selected : undefined;
+  const isENS = selected?.type === AssetType.ens;
 
   const { currentChainId, currentProvider, isL2 } = useSendChainState({
     accountChainId: chainId,
@@ -181,7 +197,25 @@ export default function SendSheet() {
     stopPollingGasFees,
   });
 
-  const { maxInputBalance, updateMaxInputBalance } = useMaxInputBalance();
+  const {
+    canUseSponsoredSend,
+    hasResolvedSponsoredSend,
+    isPreparingSponsoredSend,
+    isSponsoredSend,
+    preparedCalls: sponsoredSendPreparedCalls,
+    shouldShowSponsoredSendGas,
+  } = useSponsoredSendPreparation({
+    accountAddress,
+    amount: amountDetails.assetAmount,
+    chainId: currentChainId,
+    debouncedAmount: debouncedAssetAmount,
+    isENS,
+    isValidAddress,
+    provider: currentProvider,
+    selected: selectedAddressAsset,
+    toAddress,
+  });
+  const { maxInputBalance, updateMaxInputBalance } = useMaxInputBalance({ ignoreGasFee: shouldShowSponsoredSendGas });
 
   let colorForAsset = useColorForAsset(selected, undefined, false, true);
   const uniqueAssetColor = usePersistentDominantColorFromImage(isUniqueAsset ? selected?.images.lowResUrl : null) ?? colors.appleBlue;
@@ -189,7 +223,6 @@ export default function SendSheet() {
     colorForAsset = uniqueAssetColor;
   }
 
-  const isENS = selected?.type === AssetType.ens;
   const ensName = isENS ? selected?.name : '';
   const ensProfile = useENSProfile(ensName, {
     enabled: isENS,
@@ -243,6 +276,21 @@ export default function SendSheet() {
   );
 
   // Update all fields passed via params if needed
+  useEffect(() => {
+    if (!selected || isUniqueAsset) return;
+
+    const newMaxInputBalance = updateMaxInputBalance(selected);
+    setAmountDetails(currentAmountDetails => {
+      const isSufficientBalance = Number(currentAmountDetails.assetAmount) <= Number(newMaxInputBalance);
+      if (currentAmountDetails.isSufficientBalance === isSufficientBalance) return currentAmountDetails;
+
+      return {
+        ...currentAmountDetails,
+        isSufficientBalance,
+      };
+    });
+  }, [isUniqueAsset, selected, shouldShowSponsoredSendGas, updateMaxInputBalance]);
+
   useEffect(() => {
     if (recipientOverride && !recipient) {
       setIsValidAddress(true);
@@ -359,15 +407,17 @@ export default function SendSheet() {
   const { submitTransaction } = useSendSubmit({
     accountAddress,
     amountDetails,
+    canUseSponsoredSend,
     currentChainId,
     currentProvider,
     ens: { ensName, ensProfile, isENS, transferENS },
     gas: { gasLimit, isSufficientGas, isValidGas, selectedGasFee, updateTxFee, updateTxFeeForOptimism },
     isHardwareWallet,
-    isUniqueAsset,
+    isSponsoredSend,
     nativeCurrency,
     recipient: { isValidAddress, recipient, toAddress },
     selected,
+    sponsoredSendPreparedCalls,
   });
 
   const { buttonDisabled, buttonLabel } = useMemo(() => {
@@ -380,17 +430,24 @@ export default function SendSheet() {
 
     return getSendSubmitButtonState({
       assetAmount: amountDetails.assetAmount,
+      canUseSponsoredSend,
+      hasResolvedSponsoredSend,
       isENS,
       isENSProfileLoaded: ensProfile.isSuccess,
       isGasFeeReady,
+      isPreparingSponsoredSend,
+      isSponsoredSend,
       isSufficientBalance: amountDetails.isSufficientBalance,
       isSufficientGas,
       isValidGas,
       nativeAssetSymbol: useBackendNetworksStore.getState().getChainsNativeAsset()[currentChainId || ChainId.mainnet]?.symbol,
+      sponsoredAmountIsStale: debouncedAssetAmount !== amountDetails.assetAmount,
     });
   }, [
     amountDetails.assetAmount,
     amountDetails.isSufficientBalance,
+    canUseSponsoredSend,
+    debouncedAssetAmount,
     isENS,
     ensProfile.isSuccess,
     gasFeeParamsBySpeed,
@@ -398,6 +455,9 @@ export default function SendSheet() {
     toAddress,
     currentChainId,
     l1GasFeeOptimism,
+    hasResolvedSponsoredSend,
+    isPreparingSponsoredSend,
+    isSponsoredSend,
     isSufficientGas,
     isValidGas,
   ]);
@@ -449,6 +509,7 @@ export default function SendSheet() {
       ensProfile,
       isENS,
       isL2,
+      isSponsored: isSponsoredSend,
       isUniqueAsset,
       chainId: currentChainId,
       profilesEnabled,
@@ -469,6 +530,7 @@ export default function SendSheet() {
     amountDetails,
     submitTransaction,
     isL2,
+    isSponsoredSend,
     currentChainId,
     profilesEnabled,
   ]);
@@ -536,6 +598,8 @@ export default function SendSheet() {
     if (
       selected &&
       !!accountAddress &&
+      !shouldShowSponsoredSendGas &&
+      Number(amountDetails.assetAmount) > 0 &&
       assetChainId === currentChainId &&
       currentProviderChainId === currentChainId &&
       toAddress &&
@@ -572,6 +636,7 @@ export default function SendSheet() {
     isValidAddress,
     recipient,
     selected,
+    shouldShowSponsoredSendGas,
     toAddress,
     updateTxFee,
     updateTxFeeForOptimism,
@@ -669,17 +734,26 @@ export default function SendSheet() {
             assetAmount={amountDetails.assetAmount}
             assetInputRef={assetInputRef}
             buttonRenderer={
-              <SheetActionButton
-                color={colorForAsset}
-                disabled={buttonDisabled}
-                forceShadows
-                label={buttonLabel}
-                onPress={showConfirmationSheet}
-                scaleTo={buttonDisabled ? 1.025 : 0.9}
-                size="big"
-                testID="send-sheet-confirm"
-                weight="heavy"
-              />
+              <SubmitButtonContainer>
+                <SheetActionButton
+                  color={colorForAsset}
+                  disabled={buttonDisabled}
+                  forceShadows
+                  label={buttonLabel}
+                  onPress={showConfirmationSheet}
+                  scaleTo={buttonDisabled ? 1.025 : 0.9}
+                  size="big"
+                  testID="send-sheet-confirm"
+                  weight="heavy"
+                />
+                {canUseSponsoredSend && (
+                  <SmartWalletActivationCallout
+                    address={accountAddress}
+                    chainId={currentChainId}
+                    style={styles.smartWalletActivationCallout}
+                  />
+                )}
+              </SubmitButtonContainer>
             }
             colorForAsset={colorForAsset}
             nativeAmount={amountDetails.nativeAmount}
@@ -692,14 +766,18 @@ export default function SendSheet() {
             sendMaxBalance={() => setMaxEnabled(true)}
             setLastFocusedInputHandle={setLastFocusedInputHandle}
             txSpeedRenderer={
-              <GasSpeedButton
-                asset={selected}
-                fallbackColor={colorForAsset}
-                chainId={currentChainId}
-                horizontalPadding={0}
-                marginBottom={17}
-                theme={isDarkMode ? 'dark' : 'light'}
-              />
+              shouldShowSponsoredSendGas ? (
+                <View style={{ height: 18 }} />
+              ) : (
+                <GasSpeedButton
+                  asset={selected}
+                  fallbackColor={colorForAsset}
+                  chainId={currentChainId}
+                  horizontalPadding={0}
+                  marginBottom={17}
+                  theme={isDarkMode ? 'dark' : 'light'}
+                />
+              )
             }
           />
         )}

--- a/src/features/send/utils/sendSheetUtils.ts
+++ b/src/features/send/utils/sendSheetUtils.ts
@@ -2,26 +2,48 @@ import * as i18n from '@/languages';
 
 type GetSendSubmitButtonStateParams = {
   assetAmount: string;
+  canUseSponsoredSend: boolean;
+  hasResolvedSponsoredSend: boolean;
   isENSProfileLoaded: boolean;
   isENS: boolean;
   isGasFeeReady: boolean;
+  isPreparingSponsoredSend: boolean;
+  isSponsoredSend: boolean;
   isSufficientBalance: boolean;
   isSufficientGas: boolean;
   isValidGas: boolean;
   nativeAssetSymbol: string | undefined;
+  sponsoredAmountIsStale: boolean;
 };
 
 export function getSendSubmitButtonState({
   assetAmount,
+  canUseSponsoredSend,
+  hasResolvedSponsoredSend,
   isENS,
   isENSProfileLoaded,
   isGasFeeReady,
+  isPreparingSponsoredSend,
+  isSponsoredSend,
   isSufficientBalance,
   isSufficientGas,
   isValidGas,
   nativeAssetSymbol,
+  sponsoredAmountIsStale,
 }: GetSendSubmitButtonStateParams) {
   const isZeroAssetAmount = Number(assetAmount) <= 0;
+  const hasSufficientGasForSend = isSponsoredSend || isSufficientGas;
+  const hasValidGasForSend = isSponsoredSend || isValidGas;
+  const isWaitingForGas = !isSponsoredSend && !isGasFeeReady;
+  const isWaitingForSponsoredSend =
+    canUseSponsoredSend && !isZeroAssetAmount && (isPreparingSponsoredSend || sponsoredAmountIsStale || !hasResolvedSponsoredSend);
+
+  if (isZeroAssetAmount) {
+    return {
+      buttonDisabled: true,
+      buttonLabel: i18n.t(i18n.l.button.confirm_exchange.enter_amount),
+    };
+  }
 
   if (isENS && !isENSProfileLoaded) {
     return {
@@ -30,14 +52,14 @@ export function getSendSubmitButtonState({
     };
   }
 
-  if (!isGasFeeReady) {
+  if (isWaitingForGas || isWaitingForSponsoredSend) {
     return {
       buttonDisabled: true,
       buttonLabel: i18n.t(i18n.l.button.confirm_exchange.loading),
     };
   }
 
-  if (!isZeroAssetAmount && !isSufficientGas) {
+  if (!hasSufficientGasForSend) {
     return {
       buttonDisabled: true,
       buttonLabel: i18n.t(i18n.l.button.confirm_exchange.insufficient_token, {
@@ -46,29 +68,22 @@ export function getSendSubmitButtonState({
     };
   }
 
-  if (!isValidGas) {
+  if (!hasValidGasForSend) {
     return {
       buttonDisabled: true,
       buttonLabel: i18n.t(i18n.l.button.confirm_exchange.invalid_fee),
     };
   }
 
-  if (!isZeroAssetAmount && !isSufficientBalance) {
+  if (!isSufficientBalance) {
     return {
       buttonDisabled: true,
       buttonLabel: i18n.t(i18n.l.button.confirm_exchange.insufficient_funds),
     };
   }
 
-  if (!isZeroAssetAmount) {
-    return {
-      buttonDisabled: false,
-      buttonLabel: `􀕹 ${i18n.t(i18n.l.button.confirm_exchange.review)}`,
-    };
-  }
-
   return {
-    buttonDisabled: true,
-    buttonLabel: i18n.t(i18n.l.button.confirm_exchange.enter_amount),
+    buttonDisabled: false,
+    buttonLabel: `􀕹 ${i18n.t(i18n.l.button.confirm_exchange.review)}`,
   };
 }

--- a/src/hooks/useMaxInputBalance.ts
+++ b/src/hooks/useMaxInputBalance.ts
@@ -6,7 +6,7 @@ import useGas from '@/features/gas/hooks/useGas';
 import { assetIsUniqueAsset } from '@/handlers/web3';
 import ethereumUtils from '@/utils/ethereumUtils';
 
-export default function useMaxInputBalance() {
+export default function useMaxInputBalance({ ignoreGasFee = false }: { ignoreGasFee?: boolean } = {}) {
   const [maxInputBalance, setMaxInputBalance] = useState<string>('0');
 
   const { selectedGasFee, l1GasFeeOptimism } = useGas();
@@ -17,12 +17,15 @@ export default function useMaxInputBalance() {
         return '0';
       }
 
-      const newInputBalance = ethereumUtils.getBalanceAmount(selectedGasFee, inputCurrency, l1GasFeeOptimism);
+      const accountAsset = ethereumUtils.getAccountAsset(inputCurrency.uniqueId);
+      const newInputBalance = ignoreGasFee
+        ? (inputCurrency.balance?.amount ?? accountAsset?.balance?.amount ?? '0')
+        : ethereumUtils.getBalanceAmount(selectedGasFee, inputCurrency, l1GasFeeOptimism);
 
       setMaxInputBalance(newInputBalance);
       return newInputBalance;
     },
-    [l1GasFeeOptimism, selectedGasFee]
+    [ignoreGasFee, l1GasFeeOptimism, selectedGasFee]
   );
 
   return {

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -2109,6 +2109,9 @@
         }
       }
     },
+    "send": {
+      "sponsorship_unavailable": "Free sends are temporarily unavailable on this network. Please try again with network fees."
+    },
     "swap": {
       "actions": {
         "hold_to_swap": "Hold to Swap",

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -96,6 +96,7 @@ export interface RainbowConfig extends Record<
   rnbw_rewards_enabled: boolean;
   rnbw_membership_enabled: boolean;
   delegation_enabled: boolean;
+  sponsored_sends_enabled: boolean;
   sponsored_swaps_enabled: boolean;
   discover_placements_enabled: boolean;
 }
@@ -228,6 +229,7 @@ export const DEFAULT_CONFIG = {
   rnbw_rewards_enabled: false,
   rnbw_membership_enabled: false,
   delegation_enabled: false,
+  sponsored_sends_enabled: true,
   sponsored_swaps_enabled: true,
   discover_placements_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -383,6 +383,7 @@ type RouteParams = {
     ensProfile: ENSProfile;
     isENS: boolean;
     isL2: boolean;
+    isSponsored?: boolean;
     isUniqueAsset: boolean;
     chainId: ChainId;
     profilesEnabled: boolean;

--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -203,7 +203,7 @@ export const SendConfirmationSheet = () => {
   }, []);
 
   const {
-    params: { amountDetails, asset, callback, ensProfile, isL2, isUniqueAsset, chainId, to, toAddress },
+    params: { amountDetails, asset, callback, ensProfile, isL2, isSponsored = false, isUniqueAsset, chainId, to, toAddress },
   } = useRoute<RouteProp<RootStackParamList, typeof Routes.SEND_CONFIRMATION_SHEET>>();
 
   const { userAccounts, watchedAccounts } = useUserAccounts();
@@ -358,9 +358,10 @@ export const SendConfirmationSheet = () => {
   }, [setParams, shouldShowChecks]);
 
   const canSubmit =
-    isSufficientGas && isValidGas && (!shouldShowChecks || checkboxes.filter(check => check.checked === false).length === 0);
+    (isSponsored || (isSufficientGas && isValidGas)) &&
+    (!shouldShowChecks || checkboxes.filter(check => check.checked === false).length === 0);
 
-  const insufficientEth = isSufficientGas === false && isValidGas;
+  const insufficientEth = !isSponsored && isSufficientGas === false && isValidGas;
 
   const handleSubmit = useCallback(async () => {
     if (!canSubmit) return;


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3634/sponsor-sends

## What changed (plus any additional context for devs)

Adds sponsored sends to the Send flow when remote config and chain eligibility allow it, so eligible users can send without needing native gas for the transaction.

Sponsored send availability is prepared from the current sender, recipient, asset, chain, and debounced amount. When sponsorship is available, the Send UI treats gas as covered, hides the gas speed selector, allows max balance without subtracting gas, and records the
resulting pending transaction through the delegated execution path.

If sponsorship is unavailable or preparation fails, the flow falls back to the existing regular send path. If the sponsor balance is insufficient during submission, sponsorship is temporarily disabled for that chain until backend networks are refreshed.

## Screen recordings / screenshots

[Simulator Screen Recording - iPhone 17 Pro - 2026-05-13 at 22.32.56.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3f32f21f-7938-4686-9fcb-e09cf8d065d4.mov" />](https://app.graphite.com/user-attachments/video/3f32f21f-7938-4686-9fcb-e09cf8d065d4.mov)

## What to test

- On a sponsorship-eligible chain, send a supported token to a valid address and verify the gas UI shows the sponsored-send state instead of gas speed controls.
- Submit an eligible sponsored send and verify the transaction appears as pending in activity.
- Verify changing the amount, asset, recipient, or chain refreshes sponsored-send preparation before submission is enabled.
- Verify unavailable sponsorship falls back to the regular gas-based send flow.