### PR TITLE
fix: getClaimables sentry noise

### DIFF
--- a/src/resources/addys/claimables/query.ts
+++ b/src/resources/addys/claimables/query.ts
@@ -66,7 +66,7 @@ export async function getClaimables({ address, currency, abortController }: Clai
       totalValueAmount,
     };
   } catch (e) {
-    logger.error(new RainbowError('[getClaimables]: Failed to fetch claimables (client error)'), {
+    logger.error(new RainbowError('[getClaimables]: Failed to fetch claimables (client error)', e), {
       message: (e as Error)?.message,
     });
     return STABLE_CLAIMABLES;


### PR DESCRIPTION
Fixes APP-3686

## What changed (plus any additional context for devs)

Sentry issue `RAINBOW-WALLET-3XAF` is noisy because `getClaimables` logged fetch failures as a fresh `RainbowError`, discarding the original cause. This preserves the underlying error as the `RainbowError` cause so the existing Sentry filters can drop
expected network failures and aborts instead of grouping them under claimables.