### PR TITLE
ci: move iOS e2s to develop only with slack notifications

### DIFF
--- a/.github/actions/slack-notify-failure/action.yml
+++ b/.github/actions/slack-notify-failure/action.yml
@@ -29,41 +29,59 @@ runs:
           const runUrl = process.env.RUN_URL;
           const channelId = process.env.CHANNEL_ID;
 
-          const match = runUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)/);
-          if (!match) {
+          const parsed = parseRunUrl(runUrl);
+          if (!parsed) {
             core.setFailed(`Invalid run-url format: ${runUrl}`);
             return;
           }
-          const [, owner, repo, runId] = match;
+          const { owner, repo, runId } = parsed;
 
           const { data: run } = await github.rest.actions.getWorkflowRun({
-            owner, repo, run_id: Number(runId),
+            owner, repo, run_id: runId,
           });
           const { data: commit } = await github.rest.repos.getCommit({
             owner, repo, ref: run.head_sha,
           });
+          const associatedPr = await fetchAssociatedPr(owner, repo, run.head_sha);
 
-          let associatedPr = null;
-          try {
-            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner, repo, commit_sha: run.head_sha,
-            });
-            associatedPr = pulls[0] ?? null;
-          } catch (e) {
-            core.warning(`Could not fetch associated PRs: ${e.message}`);
+          const commitLine = formatCommitLine({ owner, repo, sha: run.head_sha, commit, associatedPr });
+          const assignment = formatAssignmentLine(commit.author?.login ?? '');
+          const payload = buildPayload({ channelId, run, commitLine, assignment, runUrl });
+
+          const payloadPath = path.join(process.env.RUNNER_TEMP, 'slack-payload.json');
+          fs.writeFileSync(payloadPath, JSON.stringify(payload));
+          core.setOutput('payload-path', payloadPath);
+
+          function parseRunUrl(url) {
+            const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)/);
+            if (!match) return null;
+            const [, owner, repo, runId] = match;
+            return { owner, repo, runId: Number(runId) };
           }
 
-          const authorUsername = commit.author?.login ?? '';
-          const shortSha = run.head_sha.slice(0, 7);
-          const commitUrl = `https://github.com/${owner}/${repo}/commit/${run.head_sha}`;
-          const commitTitle = commit.commit.message.split('\n')[0].replace(/\s*\(#\d+\)\s*$/, '');
-          const prSuffix = associatedPr ? ` (<${associatedPr.html_url}|#${associatedPr.number}>)` : '';
-          const commitLine = `[<${commitUrl}|${shortSha}>] ${commitTitle}${prSuffix}`;
+          async function fetchAssociatedPr(owner, repo, sha) {
+            try {
+              const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: sha,
+              });
+              return pulls[0];
+            } catch (e) {
+              core.warning(`Could not fetch associated PRs: ${e.message}`);
+            }
+          }
 
-          let assignment;
-          if (!authorUsername) {
-            assignment = 'Author could not be identified. Frontend platform — please triage.';
-          } else {
+          function formatCommitLine({ owner, repo, sha, commit, associatedPr }) {
+            const shortSha = sha.slice(0, 7);
+            const commitUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
+            const title = commit.commit.message.split('\n')[0].replace(/\s*\(#\d+\)\s*$/, '');
+            const prSuffix = associatedPr ? ` (<${associatedPr.html_url}|#${associatedPr.number}>)` : '';
+            return `[<${commitUrl}|${shortSha}>] ${title}${prSuffix}`;
+          }
+
+          function formatAssignmentLine(authorUsername) {
+            if (!authorUsername) {
+              return 'Author could not be identified. Frontend platform — please triage.';
+            }
             const handlesPath = path.join(process.env.GITHUB_WORKSPACE, '.github', 'slack-handles.json');
             let slackId = '';
             if (fs.existsSync(handlesPath)) {
@@ -71,25 +89,23 @@ runs:
               slackId = handles[authorUsername] ?? '';
             }
             const mention = slackId ? `<@${slackId}>` : `@${authorUsername}`;
-            assignment = `${mention} — you are assigned to triage this failure.`;
+            return `${mention} — you are assigned to triage this failure.`;
           }
 
-          const payload = {
-            channel: channelId,
-            text: `:rotating_light: ${run.name} failed on ${run.head_branch}`,
-            blocks: [
-              { type: 'section', text: { type: 'mrkdwn', text: `:rotating_light: *${run.name}* failed on \`${run.head_branch}\`` } },
-              { type: 'section', text: { type: 'mrkdwn', text: commitLine } },
-              { type: 'section', text: { type: 'mrkdwn', text: assignment } },
-              { type: 'actions', elements: [
-                { type: 'button', text: { type: 'plain_text', text: 'View run' }, url: runUrl },
-              ] },
-            ],
-          };
-
-          const payloadPath = path.join(process.env.RUNNER_TEMP, 'slack-payload.json');
-          fs.writeFileSync(payloadPath, JSON.stringify(payload));
-          core.setOutput('payload-path', payloadPath);
+          function buildPayload({ channelId, run, commitLine, assignment, runUrl }) {
+            return {
+              channel: channelId,
+              text: `:rotating_light: ${run.name} failed on ${run.head_branch}`,
+              blocks: [
+                { type: 'section', text: { type: 'mrkdwn', text: `:rotating_light: *${run.name}* failed on \`${run.head_branch}\`` } },
+                { type: 'section', text: { type: 'mrkdwn', text: commitLine } },
+                { type: 'section', text: { type: 'mrkdwn', text: assignment } },
+                { type: 'actions', elements: [
+                  { type: 'button', text: { type: 'plain_text', text: 'View run' }, url: runUrl },
+                ] },
+              ],
+            };
+          }
 
     - name: Post to Slack
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/actions/slack-notify-failure/action.yml
+++ b/.github/actions/slack-notify-failure/action.yml
@@ -1,0 +1,99 @@
+name: 'Slack notify on CI failure'
+description: 'Posts a Slack notification about a failing workflow run'
+
+inputs:
+  slack-token:
+    description: 'Slack bot token (xoxb-...). Needs chat:write and chat:write.public scopes.'
+    required: true
+  channel-id:
+    description: 'Slack channel ID (e.g. C01ABC2DEF3) to post to.'
+    required: true
+  run-url:
+    description: 'URL of the workflow run to notify about, e.g. https://github.com/owner/repo/actions/runs/12345'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build Slack payload
+      id: build
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        RUN_URL: ${{ inputs.run-url }}
+        CHANNEL_ID: ${{ inputs.channel-id }}
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const runUrl = process.env.RUN_URL;
+          const channelId = process.env.CHANNEL_ID;
+
+          const match = runUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)/);
+          if (!match) {
+            core.setFailed(`Invalid run-url format: ${runUrl}`);
+            return;
+          }
+          const [, owner, repo, runId] = match;
+
+          const { data: run } = await github.rest.actions.getWorkflowRun({
+            owner, repo, run_id: Number(runId),
+          });
+          const { data: commit } = await github.rest.repos.getCommit({
+            owner, repo, ref: run.head_sha,
+          });
+
+          let associatedPr = null;
+          try {
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: run.head_sha,
+            });
+            associatedPr = pulls[0] ?? null;
+          } catch (e) {
+            core.warning(`Could not fetch associated PRs: ${e.message}`);
+          }
+
+          const authorUsername = commit.author?.login ?? '';
+          const shortSha = run.head_sha.slice(0, 7);
+          const commitUrl = `https://github.com/${owner}/${repo}/commit/${run.head_sha}`;
+          const commitTitle = commit.commit.message.split('\n')[0].replace(/\s*\(#\d+\)\s*$/, '');
+          const prSuffix = associatedPr ? ` (<${associatedPr.html_url}|#${associatedPr.number}>)` : '';
+          const commitLine = `[<${commitUrl}|${shortSha}>] ${commitTitle}${prSuffix}`;
+
+          let assignment;
+          if (!authorUsername) {
+            assignment = 'Author could not be identified. Frontend platform — please triage.';
+          } else {
+            const handlesPath = path.join(process.env.GITHUB_WORKSPACE, '.github', 'slack-handles.json');
+            let slackId = '';
+            if (fs.existsSync(handlesPath)) {
+              const handles = JSON.parse(fs.readFileSync(handlesPath, 'utf8'));
+              slackId = handles[authorUsername] ?? '';
+            }
+            const mention = slackId ? `<@${slackId}>` : `@${authorUsername}`;
+            assignment = `${mention} — you are assigned to triage this failure.`;
+          }
+
+          const payload = {
+            channel: channelId,
+            text: `:rotating_light: ${run.name} failed on ${run.head_branch}`,
+            blocks: [
+              { type: 'section', text: { type: 'mrkdwn', text: `:rotating_light: *${run.name}* failed on \`${run.head_branch}\`` } },
+              { type: 'section', text: { type: 'mrkdwn', text: commitLine } },
+              { type: 'section', text: { type: 'mrkdwn', text: assignment } },
+              { type: 'actions', elements: [
+                { type: 'button', text: { type: 'plain_text', text: 'View run' }, url: runUrl },
+              ] },
+            ],
+          };
+
+          const payloadPath = path.join(process.env.RUNNER_TEMP, 'slack-payload.json');
+          fs.writeFileSync(payloadPath, JSON.stringify(payload));
+          core.setOutput('payload-path', payloadPath);
+
+    - name: Post to Slack
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.slack-token }}
+        payload-file-path: ${{ steps.build.outputs.payload-path }}

--- a/.github/slack-handles.json
+++ b/.github/slack-handles.json
@@ -1,0 +1,9 @@
+{
+  "DanielSinclair": "U03FN9BA1M1",
+  "christianbaroni": "UGTL3THQQ",
+  "i1skn": "U0A5DS0EV6Y",
+  "ibrahimtaveras00": "U02HJ9M6KQT",
+  "janicduplessis": "U098WAS6GAH",
+  "maxbbb": "U08057CKBPD",
+  "olerass": "U0A589TR5C6"
+}

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -1,11 +1,9 @@
-name: iOS
+name: iOS E2E
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [develop]
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [labeled, synchronize, reopened]
 env:
   NODE_OPTIONS: '--max-old-space-size=6144'
 
@@ -14,12 +12,10 @@ jobs:
   build:
     name: Test Build
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       github.event_name == 'push' ||
-      (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/e2e') &&
-      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e') &&
+       (github.event.action != 'labeled' || github.event.label.name == 'e2e'))
     runs-on: macos-26-xlarge
     concurrency:
       group: e2e-ios-${{ github.workflow }}-${{ github.ref }}
@@ -183,3 +179,23 @@ jobs:
         with:
           name: artifacts-${{ matrix.shard-index }}
           path: ${{ env.ARTIFACTS_FOLDER }}
+
+  notify-failure:
+    name: Notify Slack on failure
+    needs: [build, e2e-tests]
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/develop' &&
+      (needs.build.result == 'failure' || needs.e2e-tests.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Notify Slack
+        uses: ./.github/actions/slack-notify-failure
+        with:
+          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID_FRONTEND_ALERTS }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
iOS E2E currently runs on every PR push with four shards on `macos-26-xlarge`. It's slow, expensive, and blocks merges; with stacked PRs it multiplies further because every restack reruns the suite. Flaky tests force manual re-triggers. The cost shows up both in development speed (approved work waits on heavy CI) and delivery (approved stacks blocked on duplicated checks).

This change moves iOS E2E off the PR-blocking path. The suite now runs on push to `develop` and as opt-in on labeled PRs:

- **Post-merge on `develop`**: a notify job posts to `#frontend-alerts` on failure, mentioning the commit author and assigning them to triage
- **Opt-in via `e2e` label**: replaces the `/e2e` comment trigger. Adding the label runs the suite; pushes to a labeled PR re-run via `synchronize`. Label write-access takes over the previous `author_association` check.

The alert path uses a new composite action that takes the Slack token, channel ID, and run URL; everything else (workflow name, branch, commit, PR link, author) is derived from the GitHub API. Commit authors resolve to real `@mentions` via `.github/slack-handles.json`, seeded with the active contributors from the last 6 months.

**What the alert will look like** (using a recent commit as an example):

> 🚨 **iOS E2E** failed on `develop`
>
> [`5c83a9f`](https://github.com/rainbow-me/rainbow/commit/5c83a9f84e1eeb31f81d71aeddc0e4d6cf71c765) chore: remove dead Cloudinary icon-signing fast-path ([#7443](https://github.com/rainbow-me/rainbow/pull/7443))
>
> @olerass - you are assigned to triage this failure.
>
> 🔘 [View run](https://github.com/rainbow-me/rainbow/actions/runs/12345678)

This is the iOS portion of [RFC: Optimize CI and Delivery](https://www.notion.so/rainbowdotme/RFC-Optimize-CI-and-Delivery-348b001b85b481999ab9d5a5de33960b), with the scope adjustment that iOS lands on post-merge `develop` rather than nightly. Android gets the same treatment in a follow-up PR.