### PR TITLE
ci: move Android E2E to develop only with Slack notifications

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -1,29 +1,25 @@
 name: Android
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [develop]
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 env:
-  PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   build:
     name: Test Build
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       github.event_name == 'push' ||
-      (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null &&
-      (
-        startsWith(github.event.comment.body, '/e2e') ||
-        startsWith(github.event.comment.body, '/perf')
-      ) &&
-      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      (github.event_name == 'pull_request' &&
+       github.event.action != 'labeled' &&
+       github.event.pull_request.draft == false) ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'e2e')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     concurrency:
@@ -131,8 +127,10 @@ jobs:
   e2e-tests:
     name: E2E Tests (Shard ${{ matrix.shard-index }})
     if: |
-      github.event_name != 'issue_comment' ||
-      startsWith(github.event.comment.body, '/e2e')
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'e2e') &&
+       (github.event.action != 'labeled' || github.event.label.name == 'e2e'))
     strategy:
       fail-fast: false
       matrix:
@@ -224,8 +222,8 @@ jobs:
   perf-tests:
     name: Perf Tests
     if: |
-      github.event_name != 'issue_comment' ||
-      startsWith(github.event.comment.body, '/perf')
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.action != 'labeled')
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     timeout-minutes: 30
@@ -285,3 +283,23 @@ jobs:
         with:
           name: perf-results-${{ env.PR_NUMBER || github.ref_name }}
           path: ${{ env.ARTIFACTS_FOLDER }}/perf
+
+  notify-failure:
+    name: Notify Slack on failure
+    needs: [build, e2e-tests, perf-tests]
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/develop' &&
+      (needs.build.result == 'failure' || needs.e2e-tests.result == 'failure' || needs.perf-tests.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Notify Slack
+        uses: ./.github/actions/slack-notify-failure
+        with:
+          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ vars.SLACK_CHANNEL_ID_FRONTEND_ALERTS }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -286,12 +286,12 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    needs: [build, e2e-tests, perf-tests]
+    needs: [build, e2e-tests]
     if: |
       always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/develop' &&
-      (needs.build.result == 'failure' || needs.e2e-tests.result == 'failure' || needs.perf-tests.result == 'failure')
+      (needs.build.result == 'failure' || needs.e2e-tests.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Follows up #7489 which did the same for iOS, applying the [RFC: Optimize CI and Delivery](https://www.notion.so/rainbowdotme/RFC-Optimize-CI-and-Delivery-348b001b85b481999ab9d5a5de33960b) to Android. The workflow contains both `e2e-tests` and `perf-tests` jobs and they're treated differently here:

- **`e2e-tests`** moves off the PR-blocking path. It runs on push to `develop` and as opt-in via the `e2e` label on PRs, matching iOS.
- **`perf-tests`** is unchanged: it keeps running automatically on every non-draft PR push. This will be moved off PRs in a separate step later.

The shared `build` job gates on the union of what either downstream needs: push events, automatic non-draft PR events (for perf), or `labeled` events with `e2e` (for e2e). A `notify-failure` job alerts `#frontend-alerts` on any post-merge failure across the 2 jobs (NOT perf), reusing the composite action and `slack-handles.json` introduced in #7489.