### PR TITLE
ci: pause Android perf testing pending measurement rethink

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [develop]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [labeled, synchronize, reopened]
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -15,11 +15,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
-       github.event.action != 'labeled' &&
-       github.event.pull_request.draft == false) ||
-      (github.event_name == 'pull_request' &&
-       github.event.action == 'labeled' &&
-       github.event.label.name == 'e2e')
+       contains(github.event.pull_request.labels.*.name, 'e2e') &&
+       (github.event.action != 'labeled' || github.event.label.name == 'e2e'))
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     concurrency:
@@ -221,9 +218,11 @@ jobs:
 
   perf-tests:
     name: Perf Tests
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.action != 'labeled')
+    # Disabled pending a measurement strategy rethink. Single-run variance on
+    # Device Farm exceeds typical PR-scoped signal, and no consumer currently
+    # reads the develop perf JSON either. To be replaced by a scheduled
+    # sampling approach with baseline storage and distribution comparison.
+    if: false
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     timeout-minutes: 30


### PR DESCRIPTION
Follows #7490 which moved Android E2E off the PR-blocking path. With e2e gone, perf is the only "e2e thing" left auto-running on PRs, and that no longer makes sense:

- Single-run variance on Device Farm (typically ±100-500ms for startup) exceeds the signal a PR-scoped change usually produces (often <50ms), so per-PR perf is mostly measuring noise.
- Develop runs only existed to produce baselines for PR comparisons. Without PR comparisons, the develop pipeline has no consumer either.

This change pauses perf testing entirely. The perf-tests job stays in the workflow as reference, gated by `if: false` with an inline comment, so the implementation isn't lost when the measurement strategy is rebuilt. The build and trigger conditions tighten to match the iOS pattern (#7489) since e2e is now the only PR-driven need.