### PR TITLE
refactor: extract funding deposit execution

### DIFF
--- a/src/systems/funding/execution/depositRapExecution.ts
+++ b/src/systems/funding/execution/depositRapExecution.ts
@@ -1,0 +1,211 @@
+import { type Signer } from '@ethersproject/abstract-signer';
+import { ethers } from 'ethers';
+
+import { type ParsedAsset } from '@/__swaps__/types/assets';
+import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
+import { logger, RainbowError } from '@/logger';
+import { walletExecuteRap } from '@/raps/execute';
+import { rapTypes, type RapSwapActionParameters } from '@/raps/references';
+import erc20ABI from '@/references/erc20-abi.json';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { executeFn, Screens, TimeToSignOperation } from '@/state/performance/performance';
+import { getUniqueId } from '@/utils/ethereumUtils';
+import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
+
+import {
+  type DepositConfig,
+  type DepositGasParams,
+  type DepositMeteorologyActions,
+  type DepositSuccessMetadata,
+  type DepositToken,
+} from '../types';
+import { determineStrategy, type ExecutionStrategy } from './strategy';
+
+// ============ Types ========================================================= //
+
+type GasFeeParamsBySpeed = NonNullable<ReturnType<DepositMeteorologyActions['getGasSuggestions']>>;
+
+type ExecutionParams = {
+  assetChainId: ChainId;
+  gasFeeParamsBySpeed: GasFeeParamsBySpeed;
+  gasParams: DepositGasParams;
+  nonce: number;
+  parameters: Omit<
+    RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
+    'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
+  >;
+  wallet: Signer;
+};
+
+export type ExecuteDepositRapParams = {
+  asset: RapSwapActionParameters<rapTypes.swap>['assetToSell'];
+  assetChainId: ChainId;
+  config: Pick<DepositConfig, 'directTransferEnabled' | 'to'>;
+  gasFeeParamsBySpeed: GasFeeParamsBySpeed;
+  gasParams: DepositGasParams;
+  nonce: number;
+  quote: Quote | CrosschainQuote;
+  wallet: Signer;
+};
+
+export type ExecuteDepositRapResult =
+  | { error: string; success: false }
+  | {
+      executionStrategy: Exclude<DepositSuccessMetadata['executionStrategy'], 'custom'>;
+      hash: string;
+      isConfirmed: boolean;
+      success: true;
+    };
+
+// ============ Public ======================================================== //
+
+export async function executeDepositRap({
+  asset,
+  assetChainId,
+  config,
+  gasFeeParamsBySpeed,
+  gasParams,
+  nonce,
+  quote,
+  wallet,
+}: ExecuteDepositRapParams): Promise<ExecuteDepositRapResult> {
+  const strategy = determineStrategy(config, quote, quote.from);
+
+  const parameters: Omit<
+    RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
+    'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
+  > = {
+    assetToBuy: buildTargetParsedAsset(config.to.token, config.to.chainId),
+    assetToSell: asset,
+    buyAmount: quote.buyAmount?.toString(),
+    chainId: assetChainId,
+    quote,
+    sellAmount: quote.sellAmount?.toString(),
+  };
+
+  const result = await executeTransaction(strategy, {
+    assetChainId,
+    gasFeeParamsBySpeed,
+    gasParams,
+    nonce,
+    parameters,
+    wallet,
+  });
+
+  if (!result.success) return result;
+
+  return {
+    executionStrategy: strategy.type === 'directTransfer' ? 'directTransfer' : strategy.rapType,
+    hash: result.hash,
+    isConfirmed: result.isConfirmed,
+    success: true,
+  };
+}
+
+// ============ Transaction Execution ========================================= //
+
+type ExecutionResult =
+  | { error: string; hash?: undefined; isConfirmed?: undefined; success: false }
+  | { error?: undefined; hash: string; isConfirmed: boolean; success: true };
+
+async function executeTransaction(strategy: ExecutionStrategy, params: ExecutionParams): Promise<ExecutionResult> {
+  switch (strategy.type) {
+    case 'directTransfer':
+      return executeDirectTransfer(params, strategy.recipient);
+    case 'swap':
+      return executeSwap(params, strategy.rapType);
+  }
+}
+
+async function executeSwap(params: ExecutionParams, rapType: 'crosschainSwap' | 'swap'): Promise<ExecutionResult> {
+  const { errorMessage, hash } = await executeFn(walletExecuteRap, {
+    operation: TimeToSignOperation.SignTransaction,
+    screen: Screens.FUNDING_DEPOSIT,
+  })(params.wallet, rapType === 'crosschainSwap' ? rapTypes.crosschainSwap : rapTypes.swap, {
+    ...params.parameters,
+    chainId: params.assetChainId,
+    gasFeeParamsBySpeed: params.gasFeeParamsBySpeed,
+    gasParams: params.gasParams,
+    nonce: params.nonce,
+  });
+
+  if (errorMessage || !hash) {
+    if (errorMessage && errorMessage !== 'handled') {
+      const extractedError = errorMessage.split('[')[0];
+      return { error: extractedError, success: false };
+    }
+    return { error: errorMessage ?? 'No transaction hash returned', success: false };
+  }
+
+  return { hash, isConfirmed: false, success: true };
+}
+
+async function executeDirectTransfer(params: ExecutionParams, recipient: string): Promise<ExecutionResult> {
+  try {
+    const provider = getProvider({ chainId: params.assetChainId });
+    const tokenAddress = params.parameters.assetToSell.address;
+    const amount = params.parameters.sellAmount ?? '0';
+    const token = new ethers.Contract(tokenAddress, erc20ABI, params.wallet.connect(provider));
+
+    const gasLimit = await estimateGasWithPadding(
+      {
+        data: token.interface.encodeFunctionData('transfer', [recipient, amount]),
+        from: await params.wallet.getAddress(),
+        to: tokenAddress,
+      },
+      undefined,
+      null,
+      provider,
+      1.2
+    );
+
+    const tx = await token.transfer(recipient, amount, {
+      ...params.gasParams,
+      gasLimit: gasLimit ? toHex(gasLimit) : undefined,
+      nonce: params.nonce,
+    });
+
+    return { hash: tx.hash, isConfirmed: false, success: true };
+  } catch (error) {
+    logger.error(new RainbowError('[depositRapExecution]: directTransfer failed', error));
+    return { error: 'Transfer failed. Please try again.', success: false };
+  }
+}
+
+// ============ Asset Building ================================================ //
+
+function buildTargetParsedAsset(token: DepositToken, chainId: ChainId): ParsedAsset {
+  const chainNames = useBackendNetworksStore.getState().getChainsName();
+  return {
+    address: token.address,
+    chainId,
+    chainName: chainNames[chainId],
+    colors: {
+      fallback: '#FFFFFF',
+      primary: '#2775CA',
+    },
+    decimals: token.decimals,
+    icon_url: token.iconUrl,
+    isNativeAsset: false,
+    name: token.symbol,
+    native: {
+      price: {
+        amount: 1,
+        change: '0',
+        display: '$1',
+      },
+    },
+    networks: {
+      [chainId]: {
+        address: token.address,
+        decimals: token.decimals,
+      },
+    },
+    price: {
+      value: 1,
+    },
+    symbol: token.symbol,
+    uniqueId: getUniqueId(token.address, chainId),
+  };
+}

--- a/src/systems/funding/execution/strategy.ts
+++ b/src/systems/funding/execution/strategy.ts
@@ -16,9 +16,11 @@ export type DirectTransferStrategy = {
 
 export type ExecutionStrategy = DirectTransferStrategy | SwapStrategy;
 
+type StrategyConfig = Pick<DepositConfig, 'directTransferEnabled' | 'to'>;
+
 // ============ Strategy Determination ======================================== //
 
-export function determineStrategy(config: DepositConfig, quote: Quote, walletAddress: string): ExecutionStrategy {
+export function determineStrategy(config: StrategyConfig, quote: Quote, walletAddress: string): ExecutionStrategy {
   const isSameChain = Number(quote.chainId) === config.to.chainId;
   const isSameToken = quote.sellTokenAddress.toLowerCase() === config.to.token.address.toLowerCase();
   const isSameAsset = isSameChain && isSameToken;

--- a/src/systems/funding/hooks/useDepositHandler.ts
+++ b/src/systems/funding/hooks/useDepositHandler.ts
@@ -2,45 +2,37 @@ import { useCallback } from 'react';
 import { Alert, InteractionManager } from 'react-native';
 
 import { Logger } from '@ethersproject/logger';
-import { ethers } from 'ethers';
 import { type SharedValue } from 'react-native-reanimated';
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
-import { type ParsedAsset } from '@/__swaps__/types/assets';
 import { crosschainQuoteTargetsRecipient, isCrosschainQuote } from '@/__swaps__/utils/quotes';
-import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
+import { getProvider } from '@/handlers/web3';
 import { logger, RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
 import Navigation, { useRoute, type Route } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
-import { walletExecuteRap } from '@/raps/execute';
-import { rapTypes, type RapSwapActionParameters } from '@/raps/references';
-import erc20ABI from '@/references/erc20-abi.json';
-import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { rapTypes } from '@/raps/references';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { type StoreActions } from '@/state/internal/utils/createStoreActions';
 import { getNextNonce } from '@/state/nonces';
 import { executeFn, Screens, startTimeToSignTracking, TimeToSignOperation } from '@/state/performance/performance';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
+import { executeDepositRap } from '@/systems/funding/execution/depositRapExecution';
 import { isValidQuote } from '@/systems/funding/utils/quotes';
 import { isRecordLike } from '@/types/guards';
-import { getUniqueId } from '@/utils/ethereumUtils';
 import { time } from '@/utils/time';
 import watchingAlert from '@/utils/watchingAlert';
 import { sanitizeAmount } from '@/worklets/strings';
 
-import { determineStrategy, type ExecutionStrategy } from '../execution/strategy';
 import {
   type AmountStoreType,
   type DepositConfig,
   type DepositFailureMetadata,
   type DepositGasParams,
   type DepositGasStoresType,
-  type DepositMeteorologyActions,
   type DepositQuoteStoreType,
   type DepositStoreType,
   type DepositSuccessMetadata,
-  type DepositToken,
 } from '../types';
 import { executeRefreshSchedule, type RefreshConfig } from '../utils/scheduleRefreshes';
 
@@ -322,8 +314,6 @@ export function useDepositHandler({
       return;
     }
 
-    const targetAsset = buildTargetParsedAsset(config.to.token, config.to.chainId);
-
     if (isCrosschainQuote(validQuote) && recipient && !crosschainQuoteTargetsRecipient(validQuote, recipient)) {
       logger.error(new RainbowError('[useDepositHandler]: crosschain quote is not targeting recipient'), {
         recipient,
@@ -373,26 +363,14 @@ export function useDepositHandler({
         }
 
         const nonce = await getNextNonce({ address: validQuote.from, chainId: assetChainId });
-        const strategy = determineStrategy(config, validQuote, validQuote.from);
-
-        const parameters: Omit<
-          RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
-          'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
-        > = {
-          assetToBuy: targetAsset,
-          assetToSell: asset,
-          buyAmount: validQuote.buyAmount?.toString(),
-          chainId: assetChainId,
-          quote: validQuote,
-          sellAmount: validQuote.sellAmount?.toString(),
-        };
-
-        const result = await executeTransaction(strategy, {
+        const result = await executeDepositRap({
+          asset,
           assetChainId,
+          config,
           gasFeeParamsBySpeed,
           gasParams,
           nonce,
-          parameters,
+          quote: validQuote,
           wallet,
         });
 
@@ -418,7 +396,7 @@ export function useDepositHandler({
 
         return {
           confirmationChainId: assetChainId,
-          executionStrategy: strategy.type === 'directTransfer' ? 'directTransfer' : strategy.rapType,
+          executionStrategy: result.executionStrategy,
           hash: result.hash,
           isConfirmed: result.isConfirmed,
           success: true,
@@ -426,90 +404,6 @@ export function useDepositHandler({
       },
     });
   }, [config, depositActions, depositRoute, gasStores, isSubmitting, quoteActions, useAmountStore]);
-}
-
-// ============ Execution Types =============================================== //
-
-type ExecutionParams = {
-  assetChainId: ChainId;
-  gasFeeParamsBySpeed: NonNullable<ReturnType<DepositMeteorologyActions['getGasSuggestions']>>;
-  gasParams: DepositGasParams;
-  nonce: number;
-  parameters: Omit<
-    RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
-    'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
-  >;
-  wallet: ethers.Signer;
-};
-
-type ExecutionResult =
-  | { error: string; hash?: undefined; isConfirmed?: undefined; success: false }
-  | { error?: undefined; hash: string; isConfirmed: boolean; success: true };
-
-// ============ Transaction Execution ========================================= //
-
-async function executeTransaction(strategy: ExecutionStrategy, params: ExecutionParams): Promise<ExecutionResult> {
-  switch (strategy.type) {
-    case 'directTransfer':
-      return executeDirectTransfer(params, strategy.recipient);
-    case 'swap':
-      return executeSwap(params, strategy.rapType);
-  }
-}
-
-async function executeSwap(params: ExecutionParams, rapType: 'crosschainSwap' | 'swap'): Promise<ExecutionResult> {
-  const { errorMessage, hash } = await executeFn(walletExecuteRap, {
-    operation: TimeToSignOperation.SignTransaction,
-    screen: Screens.FUNDING_DEPOSIT,
-  })(params.wallet, rapType === 'crosschainSwap' ? rapTypes.crosschainSwap : rapTypes.swap, {
-    ...params.parameters,
-    chainId: params.assetChainId,
-    gasFeeParamsBySpeed: params.gasFeeParamsBySpeed,
-    gasParams: params.gasParams,
-    nonce: params.nonce,
-  });
-
-  if (errorMessage || !hash) {
-    if (errorMessage && errorMessage !== 'handled') {
-      const extractedError = errorMessage.split('[')[0];
-      return { error: extractedError, success: false };
-    }
-    return { error: errorMessage ?? 'No transaction hash returned', success: false };
-  }
-
-  return { hash, isConfirmed: false, success: true };
-}
-
-async function executeDirectTransfer(params: ExecutionParams, recipient: string): Promise<ExecutionResult> {
-  try {
-    const provider = getProvider({ chainId: params.assetChainId });
-    const tokenAddress = params.parameters.assetToSell.address;
-    const amount = params.parameters.sellAmount ?? '0';
-    const token = new ethers.Contract(tokenAddress, erc20ABI, params.wallet.connect(provider));
-
-    const gasLimit = await estimateGasWithPadding(
-      {
-        data: token.interface.encodeFunctionData('transfer', [recipient, amount]),
-        from: await params.wallet.getAddress(),
-        to: tokenAddress,
-      },
-      undefined,
-      null,
-      provider,
-      1.2
-    );
-
-    const tx = await token.transfer(recipient, amount, {
-      ...params.gasParams,
-      gasLimit: gasLimit ? toHex(gasLimit) : undefined,
-      nonce: params.nonce,
-    });
-
-    return { hash: tx.hash, isConfirmed: false, success: true };
-  } catch (error) {
-    logger.error(new RainbowError('[useDepositHandler]: directTransfer failed', error));
-    return { error: 'Transfer failed. Please try again.', success: false };
-  }
 }
 
 // ============ Post-Confirmation Refresh ===================================== //
@@ -574,41 +468,4 @@ function dispatchRefreshesAfterConfirmation({ chainId, hash, isConfirmed, refres
     () => executeRefreshSchedule(refresh, tag),
     error => logger.warn(`[${tag}]: waitForTransaction failed`, { error, hash })
   );
-}
-
-// ============ Asset Building ================================================ //
-
-function buildTargetParsedAsset(token: DepositToken, chainId: ChainId): ParsedAsset {
-  const chainNames = useBackendNetworksStore.getState().getChainsName();
-  return {
-    address: token.address,
-    chainId,
-    chainName: chainNames[chainId],
-    colors: {
-      fallback: '#FFFFFF',
-      primary: '#2775CA',
-    },
-    decimals: token.decimals,
-    icon_url: token.iconUrl,
-    isNativeAsset: false,
-    name: token.symbol,
-    native: {
-      price: {
-        amount: 1,
-        change: '0',
-        display: '$1',
-      },
-    },
-    networks: {
-      [chainId]: {
-        address: token.address,
-        decimals: token.decimals,
-      },
-    },
-    price: {
-      value: 1,
-    },
-    symbol: token.symbol,
-    uniqueId: getUniqueId(token.address, chainId),
-  };
 }


### PR DESCRIPTION
## Description

Separates the funding deposit transaction execution path from `useDepositHandler` so the handler owns flow orchestration while the execution module owns RAP/direct-transfer strategy, gas setup, and transaction submission.

This keeps current deposit behavior unchanged and gives sponsored perps deposits a smaller integration point in the next PR.