### PR TITLE
feat: add flag-gated sponsored perps deposit execution

### DIFF
--- a/src/features/perps/depositConfig.ts
+++ b/src/features/perps/depositConfig.ts
@@ -1,3 +1,5 @@
+import { predictSponsoredCallsExecution } from '@/features/delegation/sponsoredCalls';
+import { getRemoteConfig } from '@/model/remoteConfig';
 import { createDepositConfig } from '@/systems/funding/config';
 import { time } from '@/utils/time';
 
@@ -24,6 +26,15 @@ export const PERPS_DEPOSIT_CONFIG = createDepositConfig({
       displaySymbol: 'USDC',
       iconUrl: USDC_ICON_URL,
     },
+  },
+
+  gas: {
+    predictIsSponsored: ({ accountAddress, asset }) =>
+      getRemoteConfig().sponsored_perps_deposits_enabled &&
+      predictSponsoredCallsExecution({
+        address: accountAddress,
+        chainId: asset.chainId,
+      }),
   },
 
   refresh: {

--- a/src/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen.tsx
+++ b/src/features/perps/screens/perps-deposit-withdraw-screen/PerpsDepositScreen.tsx
@@ -2,14 +2,19 @@ import React, { memo } from 'react';
 
 import { HYPERLIQUID_COLORS, PERPS_BACKGROUND_DARK, PERPS_BACKGROUND_LIGHT } from '@/features/perps/constants';
 import { PERPS_DEPOSIT_CONFIG } from '@/features/perps/depositConfig';
+import { createPerpsDepositRuntimeExtensions } from '@/features/perps/stores/perpsDepositRuntimeExtensions';
+import { useStableValue } from '@/hooks/useStableValue';
 import { DepositScreen } from '@/systems/funding/components/DepositScreen';
 
 // ============ Screen ========================================================= //
 
 export const PerpsDepositScreen = memo(function PerpsDepositScreen() {
+  const runtimeExtensions = useStableValue(createPerpsDepositRuntimeExtensions);
+
   return (
     <DepositScreen
       config={PERPS_DEPOSIT_CONFIG}
+      runtimeExtensions={runtimeExtensions}
       theme={{
         accent: HYPERLIQUID_COLORS.green,
         backgroundDark: PERPS_BACKGROUND_DARK,

--- a/src/features/perps/stores/perpsDepositRuntimeExtensions.ts
+++ b/src/features/perps/stores/perpsDepositRuntimeExtensions.ts
@@ -1,0 +1,40 @@
+import { destroyStore } from '@storesjs/stores';
+
+import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
+import { getRemoteConfig } from '@/model/remoteConfig';
+import { createDepositPreparedCallsStore, getDepositPreparedCalls } from '@/systems/funding/execution/depositPreparedCallsStore';
+import { type DepositRuntimeExtensions } from '@/systems/funding/types';
+
+import { PERPS_DEPOSIT_CONFIG } from '../depositConfig';
+
+// ============ Runtime Extensions =========================================== //
+
+export function createPerpsDepositRuntimeExtensions(): DepositRuntimeExtensions {
+  return {
+    createSponsoredExecution: ({ useQuoteStore }) => {
+      const preparedDepositStore = createDepositPreparedCallsStore({
+        config: PERPS_DEPOSIT_CONFIG,
+        readCurrentQuote: () => useQuoteStore.getState().getData(),
+      });
+
+      return {
+        cleanup: () => {
+          destroyStore(preparedDepositStore, { clearQueryCache: true });
+        },
+        gas: {
+          isSponsored: async params => {
+            if (!getRemoteConfig().sponsored_perps_deposits_enabled) return false;
+            const preparedCalls = await getDepositPreparedCalls(preparedDepositStore, params);
+            return isPreparedCallsExecutionSponsored(preparedCalls);
+          },
+        },
+        sponsoredExecution: {
+          getPreparedCalls: params => {
+            if (!getRemoteConfig().sponsored_perps_deposits_enabled) return Promise.resolve(null);
+            return getDepositPreparedCalls(preparedDepositStore, params);
+          },
+        },
+      };
+    },
+  };
+}

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -98,6 +98,7 @@ export interface RainbowConfig extends Record<
   delegation_enabled: boolean;
   sponsored_sends_enabled: boolean;
   sponsored_swaps_enabled: boolean;
+  sponsored_perps_deposits_enabled: boolean;
   discover_placements_enabled: boolean;
 }
 
@@ -231,6 +232,7 @@ export const DEFAULT_CONFIG = {
   delegation_enabled: false,
   sponsored_sends_enabled: true,
   sponsored_swaps_enabled: true,
+  sponsored_perps_deposits_enabled: true,
   discover_placements_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 

--- a/src/systems/funding/components/DepositScreen.tsx
+++ b/src/systems/funding/components/DepositScreen.tsx
@@ -36,7 +36,13 @@ import { createDepositConfig } from '../config';
 import { FOOTER_HEIGHT, NavigationSteps, SLIDER_WIDTH, SLIDER_WITH_LABELS_HEIGHT } from '../constants';
 import { DepositProvider, useDepositContext } from '../contexts/DepositContext';
 import { computeMaxSwappableAmount } from '../stores/createDepositStore';
-import { DepositQuoteStatus, getAccentColor, type DepositConfigInput, type FundingScreenTheme } from '../types';
+import {
+  DepositQuoteStatus,
+  getAccentColor,
+  type DepositConfigInput,
+  type DepositRuntimeExtensions,
+  type FundingScreenTheme,
+} from '../types';
 import { amountFromSliderProgress } from '../utils/sliderWorklets';
 import { resolveInitialDepositAsset } from '../utils/sourceAsset';
 import { DepositAmountInput } from './deposit/DepositAmountInput';
@@ -48,17 +54,24 @@ import { DepositTokenList } from './deposit/DepositTokenList';
 
 type DepositScreenProps = {
   config: DepositConfigInput;
+  runtimeExtensions?: DepositRuntimeExtensions;
   theme: FundingScreenTheme;
 };
 
 // ============ Main Screen ==================================================== //
 
-export const DepositScreen = memo(function DepositScreen({ config, theme }: DepositScreenProps) {
+export const DepositScreen = memo(function DepositScreen({ config, runtimeExtensions, theme }: DepositScreenProps) {
   const resolvedConfig = useMemo(() => createDepositConfig(config), [config]);
   const resolvedInitialAsset = useStableValue(() => resolveInitialDepositAsset(resolvedConfig));
 
   return (
-    <DepositProvider config={resolvedConfig} initialAsset={resolvedInitialAsset} initialGasSpeed={GasSpeed.FAST} theme={theme}>
+    <DepositProvider
+      config={resolvedConfig}
+      initialAsset={resolvedInitialAsset}
+      initialGasSpeed={GasSpeed.FAST}
+      runtimeExtensions={runtimeExtensions}
+      theme={theme}
+    >
       <DepositScreenContent />
     </DepositProvider>
   );

--- a/src/systems/funding/config.ts
+++ b/src/systems/funding/config.ts
@@ -54,6 +54,7 @@ export function createDepositConfig(config: DepositConfigInput): DepositConfig {
             resolveAsset: config.source.resolveAsset,
           }
         : { mode: 'selectable' },
+    sponsoredExecution: config.sponsoredExecution,
   };
 }
 

--- a/src/systems/funding/contexts/DepositContext.tsx
+++ b/src/systems/funding/contexts/DepositContext.tsx
@@ -13,7 +13,13 @@ import { createDepositGasStores } from '../stores/createDepositGasStores';
 import { createDepositQuoteStore } from '../stores/createDepositQuoteStore';
 import { computeMaxSwappableAmount, createDepositStore } from '../stores/createDepositStore';
 import { createAmountToReceiveStore } from '../stores/derived/createAmountToReceiveStore';
-import { type DepositConfig, type DepositContextType, type FundingScreenTheme } from '../types';
+import {
+  type DepositConfig,
+  type DepositContextType,
+  type DepositRuntimeExtensions,
+  type DepositRuntimeStores,
+  type FundingScreenTheme,
+} from '../types';
 
 // ============ Context ======================================================= //
 
@@ -26,21 +32,34 @@ type DepositProviderProps = {
   config: DepositConfig;
   initialAsset: ExtendedAnimatedAssetWithColors | null;
   initialGasSpeed: GasSpeed;
+  runtimeExtensions?: DepositRuntimeExtensions;
   theme: FundingScreenTheme;
 };
 
-export function DepositProvider({ children, config, initialAsset, initialGasSpeed, theme }: DepositProviderProps): React.ReactElement {
+export function DepositProvider({
+  children,
+  config,
+  initialAsset,
+  initialGasSpeed,
+  runtimeExtensions,
+  theme,
+}: DepositProviderProps): React.ReactElement {
   const stores = useStableValue(() => {
     const useAmountStore = createDepositAmountStore(initialAsset, config.initialSliderProgress);
     const useDepositStore = createDepositStore(config, initialAsset, initialGasSpeed);
     const useQuoteStore = createDepositQuoteStore(config, useAmountStore, useDepositStore);
-    const gasStores = createDepositGasStores(config, useAmountStore, useDepositStore, useQuoteStore);
-    const useAmountToReceive = createAmountToReceiveStore(useAmountStore, useQuoteStore, config.to.token.displaySymbol);
+    const { cleanup: cleanupSponsoredExecution, config: runtimeConfig } = createRuntimeSponsoredExecutionConfig(config, runtimeExtensions, {
+      useQuoteStore,
+    });
+    const gasStores = createDepositGasStores(runtimeConfig, useAmountStore, useDepositStore, useQuoteStore);
+    const useAmountToReceive = createAmountToReceiveStore(useAmountStore, useQuoteStore, runtimeConfig.to.token.displaySymbol);
 
     const depositActions = createStoreActions(useAmountStore, createStoreActions(useDepositStore));
     const quoteActions = createStoreActions(useQuoteStore);
 
     return {
+      cleanupSponsoredExecution,
+      config: runtimeConfig,
       depositActions,
       gasStores,
       quoteActions,
@@ -52,7 +71,7 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
   });
 
   const controller = useDepositController(
-    config,
+    stores.config,
     computeMaxSwappableAmount,
     stores.gasStores,
     stores.useAmountStore,
@@ -60,7 +79,7 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
   );
 
   const handleDeposit = useDepositHandler({
-    config,
+    config: stores.config,
     depositActions: stores.depositActions,
     gasStores: stores.gasStores,
     isSubmitting: controller.isSubmitting,
@@ -69,9 +88,15 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
   });
 
   const contextValue: DepositContextType = {
-    ...stores,
+    depositActions: stores.depositActions,
+    gasStores: stores.gasStores,
+    quoteActions: stores.quoteActions,
+    useAmountStore: stores.useAmountStore,
+    useAmountToReceive: stores.useAmountToReceive,
+    useDepositStore: stores.useDepositStore,
+    useQuoteStore: stores.useQuoteStore,
     ...controller,
-    config,
+    config: stores.config,
     handleDeposit,
     theme,
   };
@@ -79,9 +104,28 @@ export function DepositProvider({ children, config, initialAsset, initialGasSpee
   useCleanup(() => {
     stores.gasStores.reset();
     stores.useQuoteStore.getState().reset(true);
+    stores.cleanupSponsoredExecution?.();
   });
 
   return <DepositContext.Provider value={contextValue}>{children}</DepositContext.Provider>;
+}
+
+function createRuntimeSponsoredExecutionConfig(
+  config: DepositConfig,
+  runtimeExtensions: DepositRuntimeExtensions | undefined,
+  stores: DepositRuntimeStores
+): { cleanup?: () => void; config: DepositConfig } {
+  const sponsoredExecution = runtimeExtensions?.createSponsoredExecution?.(stores);
+  if (!sponsoredExecution) return { config };
+
+  return {
+    cleanup: sponsoredExecution.cleanup,
+    config: {
+      ...config,
+      gas: sponsoredExecution.gas ? { ...config.gas, ...sponsoredExecution.gas } : config.gas,
+      sponsoredExecution: sponsoredExecution.sponsoredExecution,
+    },
+  };
 }
 
 // ============ Hook ========================================================== //

--- a/src/systems/funding/execution/depositPreparedCallsStore.ts
+++ b/src/systems/funding/execution/depositPreparedCallsStore.ts
@@ -1,0 +1,81 @@
+import { type Address } from 'viem';
+
+import { createPreparedCallsStore, type PreparedCallsStore } from '@/features/delegation/preparedCallsStore';
+import { getProvider } from '@/handlers/web3';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { time } from '@/utils/time';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import { type DepositConfig, type DepositGasHookParams, type DepositQuoteResult } from '../types';
+import { buildDepositQuoteKey } from '../utils/depositQuoteKey';
+import { isValidQuote } from '../utils/quotes';
+import { prepareSponsoredDepositExecution } from './prepareSponsoredDepositExecution';
+import { determineStrategy } from './strategy';
+
+// ============ Types ========================================================= //
+
+type SponsoredDepositQueryParams = {
+  accountAddress: Address;
+  sourceChainId: ChainId;
+  quoteKey: string;
+};
+
+type CreateDepositPreparedCallsStoreParams = {
+  config: Pick<DepositConfig, 'directTransferEnabled' | 'to'>;
+  readCurrentQuote: () => DepositQuoteResult;
+};
+
+export type DepositPreparedCallsStore = PreparedCallsStore<PreparedCallsExecution, SponsoredDepositQueryParams>;
+
+// ============ Store Factory ================================================= //
+
+export function createDepositPreparedCallsStore({
+  config,
+  readCurrentQuote,
+}: CreateDepositPreparedCallsStoreParams): DepositPreparedCallsStore {
+  return createPreparedCallsStore<PreparedCallsExecution, SponsoredDepositQueryParams>(
+    async ({ accountAddress, sourceChainId, quoteKey }) => {
+      const quote = readCurrentQuote();
+      if (!isValidQuote(quote)) return null;
+      if (buildDepositQuoteKey(quote) !== quoteKey) return null;
+      if (quote.chainId !== sourceChainId) return null;
+      if (quote.from.toLowerCase() !== accountAddress.toLowerCase()) return null;
+
+      return prepareSponsoredDepositExecution({
+        accountAddress,
+        chainId: sourceChainId,
+        provider: getProvider({ chainId: sourceChainId }),
+        quote,
+        strategy: determineStrategy(config, quote, accountAddress),
+      });
+    },
+    {
+      cacheTime: time.minutes(1),
+      staleTime: time.seconds(12),
+    }
+  );
+}
+
+// ============ Param Adapters ================================================ //
+
+export function getDepositPreparedCalls(
+  store: DepositPreparedCallsStore,
+  params: DepositGasHookParams
+): Promise<PreparedCallsExecution | null> {
+  const queryParams = toSponsoredDepositQueryParams(params);
+  if (!queryParams) return Promise.resolve(null);
+  return store.getState().getPreparedCalls(queryParams);
+}
+
+function toSponsoredDepositQueryParams(params: DepositGasHookParams): SponsoredDepositQueryParams | null {
+  if (!isValidQuote(params.quote)) return null;
+
+  if (params.quote.chainId !== params.asset.chainId) return null;
+  if (params.quote.from.toLowerCase() !== params.accountAddress.toLowerCase()) return null;
+
+  return {
+    accountAddress: params.accountAddress,
+    quoteKey: buildDepositQuoteKey(params.quote),
+    sourceChainId: params.asset.chainId,
+  };
+}

--- a/src/systems/funding/execution/depositRapExecution.test.ts
+++ b/src/systems/funding/execution/depositRapExecution.test.ts
@@ -1,0 +1,341 @@
+import { Wallet } from '@ethersproject/wallet';
+
+import { SwapType, type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
+
+import { executeDepositRap } from './depositRapExecution';
+
+const mockWalletExecuteRap = jest.fn();
+
+jest.mock('@/raps/execute', () => ({
+  walletExecuteRap: (...args: unknown[]) => mockWalletExecuteRap(...args),
+}));
+
+jest.mock('@/features/delegation/sponsoredCalls', () => ({
+  isInsufficientSponsorBalanceError: (message: string) => message.includes('INSUFFICIENT_SPONSOR_BALANCE'),
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  estimateGasWithPadding: jest.fn(),
+  getProvider: jest.fn(() => ({})),
+  toHex: jest.fn(),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  useBackendNetworksStore: {
+    getState: () => ({
+      getChainsName: () => ({
+        1: 'Ethereum',
+        8453: 'Base',
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/state/performance/performance', () => ({
+  Screens: {
+    FUNDING_DEPOSIT: 'FUNDING_DEPOSIT',
+  },
+  TimeToSignOperation: {
+    SignTransaction: 'SignTransaction',
+  },
+  executeFn: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+function buildQuote(chainId = 8453): Quote {
+  return {
+    allowanceNeeded: false,
+    allowanceTarget: '0x1111111111111111111111111111111111111111',
+    buyAmount: '2',
+    buyAmountDisplay: '2',
+    buyAmountDisplayMinimum: '2',
+    buyAmountInEth: '0',
+    buyAmountMinusFees: '2',
+    buyTokenAddress: '0x2222222222222222222222222222222222222222',
+    chainId,
+    data: '0x1234',
+    fallback: false,
+    fee: '0',
+    feeInEth: '0',
+    feePercentageBasisPoints: 0,
+    from: '0x3333333333333333333333333333333333333333',
+    inputTokenDecimals: 6,
+    outputTokenDecimals: 6,
+    protocols: [],
+    sellAmount: '1',
+    sellAmountDisplay: '1',
+    sellAmountInEth: '0',
+    sellAmountMinusFees: '1',
+    sellTokenAddress: '0x4444444444444444444444444444444444444444',
+    swapType: SwapType.normal,
+    to: '0x5555555555555555555555555555555555555555',
+    tradeAmountUSD: 1,
+    tradeFeeAmountUSD: 0,
+    value: '0',
+  };
+}
+
+function buildCrosschainQuote(chainId = 8453): CrosschainQuote {
+  return {
+    ...buildQuote(chainId),
+    refuel: null,
+    routes: [],
+    swapType: SwapType.crossChain,
+  };
+}
+
+const MOCK_ASSET = {
+  address: '0x4444444444444444444444444444444444444444',
+  chainId: 8453,
+  decimals: 6,
+  symbol: 'USDC',
+  uniqueId: '0x4444444444444444444444444444444444444444_8453',
+} as const;
+
+const MOCK_CONFIG = {
+  directTransferEnabled: false,
+  to: {
+    chainId: 8453,
+    token: {
+      address: '0x7777777777777777777777777777777777777777',
+      decimals: 6,
+      symbol: 'USDC',
+    },
+  },
+} as const;
+
+describe('executeDepositRap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('executes same-chain quotes as swap RAP actions', async () => {
+    mockWalletExecuteRap.mockResolvedValue({ errorMessage: null, hash: '0xabc', nonce: 12 });
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: MOCK_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 12,
+      preparedCalls: null,
+      quote: buildQuote(8453),
+      wallet: {} as never,
+    });
+
+    expect(result).toEqual({
+      executionStrategy: 'swap',
+      hash: '0xabc',
+      isConfirmed: false,
+      sponsorship: 'walletPaid',
+      success: true,
+    });
+
+    expect(mockWalletExecuteRap).toHaveBeenCalledWith(
+      expect.anything(),
+      'swap',
+      expect.objectContaining({
+        atomic: false,
+        chainId: 8453,
+        nonce: 12,
+        quote: expect.objectContaining({ chainId: 8453 }),
+      }),
+      { preparedCalls: null }
+    );
+  });
+
+  it('executes cross-chain quotes as crosschainSwap RAP actions', async () => {
+    mockWalletExecuteRap.mockResolvedValue({ errorMessage: null, hash: '0xdef', nonce: 15 });
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: {
+        ...MOCK_CONFIG,
+        to: {
+          ...MOCK_CONFIG.to,
+          chainId: 1,
+        },
+      } as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 15,
+      preparedCalls: null,
+      quote: buildCrosschainQuote(8453),
+      wallet: {} as never,
+    });
+
+    expect(result).toEqual({
+      executionStrategy: 'crosschainSwap',
+      hash: '0xdef',
+      isConfirmed: false,
+      sponsorship: 'walletPaid',
+      success: true,
+    });
+
+    expect(mockWalletExecuteRap).toHaveBeenCalledWith(
+      expect.anything(),
+      'crosschainSwap',
+      expect.objectContaining({
+        atomic: false,
+        chainId: 8453,
+        nonce: 15,
+        quote: expect.objectContaining({ swapType: SwapType.crossChain }),
+      }),
+      { preparedCalls: null }
+    );
+  });
+
+  it('treats managed atomic execution without hash as success when sponsored calls are supplied', async () => {
+    mockWalletExecuteRap.mockResolvedValue({ errorMessage: null, hash: null, nonce: undefined });
+    const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945382d4a8a7e3f89f8f51236aa0f5f7f6e8b8');
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: MOCK_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 2,
+      preparedCalls: {
+        executionId: 'managed-123',
+        kind: 'calls.managed',
+        review: { fees: { payer: 'sponsor' } },
+      } as never,
+      quote: buildQuote(8453),
+      wallet,
+    });
+
+    expect(result).toEqual({
+      executionStrategy: 'swap',
+      isConfirmed: false,
+      sponsorship: 'sponsored',
+      success: true,
+    });
+
+    expect(mockWalletExecuteRap).toHaveBeenCalledWith(
+      wallet,
+      'swap',
+      expect.objectContaining({
+        atomic: true,
+      }),
+      {
+        preparedCalls: expect.objectContaining({
+          kind: 'calls.managed',
+        }),
+      }
+    );
+  });
+
+  it('keeps missing hash as a failure for non-sponsored execution', async () => {
+    mockWalletExecuteRap.mockResolvedValue({ errorMessage: null, hash: null, nonce: undefined });
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: MOCK_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 3,
+      preparedCalls: null,
+      quote: buildQuote(8453),
+      wallet: {} as never,
+    });
+
+    expect(result).toEqual({
+      error: 'No transaction hash returned',
+      sponsorshipAttempted: false,
+      success: false,
+    });
+  });
+
+  it('normalizes RAP execution errors before returning a funding failure', async () => {
+    mockWalletExecuteRap.mockResolvedValue({ errorMessage: 'Swap failed[details]', hash: null, nonce: undefined });
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: MOCK_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 4,
+      preparedCalls: null,
+      quote: buildQuote(8453),
+      wallet: {} as never,
+    });
+
+    expect(result).toEqual({
+      error: 'Swap failed',
+      sponsorshipAttempted: false,
+      success: false,
+    });
+  });
+
+  it('classifies depleted sponsor wallet failures', async () => {
+    mockWalletExecuteRap.mockResolvedValue({
+      errorMessage: 'Managed relay execution failed [INSUFFICIENT_SPONSOR_BALANCE]',
+      hash: null,
+      nonce: undefined,
+    });
+    const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945382d4a8a7e3f89f8f51236aa0f5f7f6e8b8');
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: MOCK_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 5,
+      preparedCalls: {
+        executionId: 'managed-456',
+        kind: 'calls.managed',
+        review: { fees: { payer: 'sponsor' } },
+      } as never,
+      quote: buildQuote(8453),
+      wallet,
+    });
+
+    expect(result).toEqual({
+      error: 'Managed relay execution failed ',
+      sponsorshipAttempted: true,
+      sponsorshipFailureReason: 'insufficientSponsorBalance',
+      success: false,
+    });
+  });
+
+  it('classifies managed relay execution failures separately from sponsor balance failures', async () => {
+    mockWalletExecuteRap.mockResolvedValue({
+      errorMessage: 'Managed relay execution reverted',
+      hash: null,
+      nonce: undefined,
+    });
+    const wallet = new Wallet('0x59c6995e998f97a5a0044966f0945382d4a8a7e3f89f8f51236aa0f5f7f6e8b8');
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: MOCK_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: {} as never,
+      nonce: 6,
+      preparedCalls: {
+        executionId: 'managed-789',
+        kind: 'calls.managed',
+        review: { fees: { payer: 'sponsor' } },
+      } as never,
+      quote: buildQuote(8453),
+      wallet,
+    });
+
+    expect(result).toEqual({
+      error: 'Managed relay execution reverted',
+      sponsorshipAttempted: true,
+      sponsorshipFailureReason: 'sponsoredRelayExecutionFailed',
+      success: false,
+    });
+  });
+});

--- a/src/systems/funding/execution/depositRapExecution.ts
+++ b/src/systems/funding/execution/depositRapExecution.ts
@@ -2,6 +2,7 @@ import { type Signer } from '@ethersproject/abstract-signer';
 import { ethers } from 'ethers';
 
 import { type ParsedAsset } from '@/__swaps__/types/assets';
+import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
 import { logger, RainbowError } from '@/logger';
 import { walletExecuteRap } from '@/raps/execute';
@@ -11,12 +12,15 @@ import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks
 import { type ChainId } from '@/state/backendNetworks/types';
 import { executeFn, Screens, TimeToSignOperation } from '@/state/performance/performance';
 import { getUniqueId } from '@/utils/ethereumUtils';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
 import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
 
 import {
   type DepositConfig,
   type DepositGasParams,
   type DepositMeteorologyActions,
+  type DepositSponsorshipFailureReason,
+  type DepositSponsorshipOutcome,
   type DepositSuccessMetadata,
   type DepositToken,
 } from '../types';
@@ -35,6 +39,7 @@ type ExecutionParams = {
     RapSwapActionParameters<rapTypes.crosschainSwap | rapTypes.swap>,
     'gasFeeParamsBySpeed' | 'gasParams' | 'selectedGasFee'
   >;
+  preparedCalls: PreparedCallsExecution | null;
   wallet: Signer;
 };
 
@@ -45,16 +50,23 @@ export type ExecuteDepositRapParams = {
   gasFeeParamsBySpeed: GasFeeParamsBySpeed;
   gasParams: DepositGasParams;
   nonce: number;
+  preparedCalls: PreparedCallsExecution | null;
   quote: Quote | CrosschainQuote;
   wallet: Signer;
 };
 
 export type ExecuteDepositRapResult =
-  | { error: string; success: false }
+  | {
+      error: string;
+      sponsorshipAttempted: boolean;
+      sponsorshipFailureReason?: DepositSponsorshipFailureReason;
+      success: false;
+    }
   | {
       executionStrategy: Exclude<DepositSuccessMetadata['executionStrategy'], 'custom'>;
-      hash: string;
+      hash?: string;
       isConfirmed: boolean;
+      sponsorship: DepositSponsorshipOutcome;
       success: true;
     };
 
@@ -67,6 +79,7 @@ export async function executeDepositRap({
   gasFeeParamsBySpeed,
   gasParams,
   nonce,
+  preparedCalls,
   quote,
   wallet,
 }: ExecuteDepositRapParams): Promise<ExecuteDepositRapResult> {
@@ -90,6 +103,7 @@ export async function executeDepositRap({
     gasParams,
     nonce,
     parameters,
+    preparedCalls,
     wallet,
   });
 
@@ -99,6 +113,7 @@ export async function executeDepositRap({
     executionStrategy: strategy.type === 'directTransfer' ? 'directTransfer' : strategy.rapType,
     hash: result.hash,
     isConfirmed: result.isConfirmed,
+    sponsorship: result.sponsorship,
     success: true,
   };
 }
@@ -106,8 +121,21 @@ export async function executeDepositRap({
 // ============ Transaction Execution ========================================= //
 
 type ExecutionResult =
-  | { error: string; hash?: undefined; isConfirmed?: undefined; success: false }
-  | { error?: undefined; hash: string; isConfirmed: boolean; success: true };
+  | {
+      error: string;
+      hash?: undefined;
+      isConfirmed?: undefined;
+      sponsorshipAttempted: boolean;
+      sponsorshipFailureReason?: DepositSponsorshipFailureReason;
+      success: false;
+    }
+  | {
+      error?: undefined;
+      hash?: string;
+      isConfirmed: boolean;
+      sponsorship: DepositSponsorshipOutcome;
+      success: true;
+    };
 
 async function executeTransaction(strategy: ExecutionStrategy, params: ExecutionParams): Promise<ExecutionResult> {
   switch (strategy.type) {
@@ -119,26 +147,57 @@ async function executeTransaction(strategy: ExecutionStrategy, params: Execution
 }
 
 async function executeSwap(params: ExecutionParams, rapType: 'crosschainSwap' | 'swap'): Promise<ExecutionResult> {
+  const shouldTryAtomic = !!params.preparedCalls;
   const { errorMessage, hash } = await executeFn(walletExecuteRap, {
     operation: TimeToSignOperation.SignTransaction,
     screen: Screens.FUNDING_DEPOSIT,
-  })(params.wallet, rapType === 'crosschainSwap' ? rapTypes.crosschainSwap : rapTypes.swap, {
-    ...params.parameters,
-    chainId: params.assetChainId,
-    gasFeeParamsBySpeed: params.gasFeeParamsBySpeed,
-    gasParams: params.gasParams,
-    nonce: params.nonce,
-  });
-
-  if (errorMessage || !hash) {
-    if (errorMessage && errorMessage !== 'handled') {
-      const extractedError = errorMessage.split('[')[0];
-      return { error: extractedError, success: false };
+  })(
+    params.wallet,
+    rapType === 'crosschainSwap' ? rapTypes.crosschainSwap : rapTypes.swap,
+    {
+      ...params.parameters,
+      atomic: shouldTryAtomic,
+      chainId: params.assetChainId,
+      gasFeeParamsBySpeed: params.gasFeeParamsBySpeed,
+      gasParams: params.gasParams,
+      nonce: params.nonce,
+    },
+    {
+      preparedCalls: params.preparedCalls,
     }
-    return { error: errorMessage ?? 'No transaction hash returned', success: false };
+  );
+
+  if (errorMessage) {
+    const sponsorshipFailureReason = shouldTryAtomic ? classifySponsorshipFailure(errorMessage) : undefined;
+    if (errorMessage !== 'handled') {
+      const extractedError = errorMessage.split('[')[0];
+      return {
+        error: extractedError,
+        sponsorshipAttempted: shouldTryAtomic,
+        sponsorshipFailureReason,
+        success: false,
+      };
+    }
+    return {
+      error: errorMessage,
+      sponsorshipAttempted: shouldTryAtomic,
+      sponsorshipFailureReason,
+      success: false,
+    };
   }
 
-  return { hash, isConfirmed: false, success: true };
+  // Managed relay execution succeeds without an onchain hash; treat that as the
+  // sponsor-paid outcome. Any wallet-broadcast hash (sequential or single-wallet
+  // atomic) is wallet-paid.
+  if (shouldTryAtomic && !hash) return { isConfirmed: false, sponsorship: 'sponsored', success: true };
+
+  if (hash) return { hash, isConfirmed: false, sponsorship: 'walletPaid', success: true };
+
+  return {
+    error: 'No transaction hash returned',
+    sponsorshipAttempted: false,
+    success: false,
+  };
 }
 
 async function executeDirectTransfer(params: ExecutionParams, recipient: string): Promise<ExecutionResult> {
@@ -166,11 +225,23 @@ async function executeDirectTransfer(params: ExecutionParams, recipient: string)
       nonce: params.nonce,
     });
 
-    return { hash: tx.hash, isConfirmed: false, success: true };
+    return { hash: tx.hash, isConfirmed: false, sponsorship: 'walletPaid', success: true };
   } catch (error) {
     logger.error(new RainbowError('[depositRapExecution]: directTransfer failed', error));
-    return { error: 'Transfer failed. Please try again.', success: false };
+    return {
+      error: 'Transfer failed. Please try again.',
+      sponsorshipAttempted: false,
+      success: false,
+    };
   }
+}
+
+function classifySponsorshipFailure(errorMessage: string): DepositSponsorshipFailureReason {
+  if (isInsufficientSponsorBalanceError(errorMessage)) return 'insufficientSponsorBalance';
+  if (errorMessage.includes('Managed relay execution failed') || errorMessage.includes('Managed relay execution reverted')) {
+    return 'sponsoredRelayExecutionFailed';
+  }
+  return 'unknownSponsorshipFailure';
 }
 
 // ============ Asset Building ================================================ //

--- a/src/systems/funding/execution/prepareSponsoredDepositExecution.test.ts
+++ b/src/systems/funding/execution/prepareSponsoredDepositExecution.test.ts
@@ -1,0 +1,194 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { encodeFunctionData, erc20Abi, type Address } from 'viem';
+
+import { ChainId } from '@/state/backendNetworks/types';
+import { type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { SwapType, type Quote } from '@rainbow-me/swaps';
+
+import { prepareSponsoredDepositExecution } from './prepareSponsoredDepositExecution';
+
+const mockCreateDelegationPublicClient = jest.fn<unknown, [ChainId]>();
+const mockPredictSponsoredCallsExecution = jest.fn<boolean, [unknown]>();
+const mockPrepareAtomicSwapCalls = jest.fn<Promise<Call[]>, [unknown]>();
+const mockPrepareCalls = jest.fn<Promise<PreparedCallsExecution>, [unknown]>();
+const mockSupportsDelegatedExecution = jest.fn<Promise<boolean>, [unknown]>();
+
+const mockSponsoredCallsRequirements = {
+  atomic: 'required',
+  fees: { payer: 'sponsor' },
+};
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    prepare: {
+      calls: (params: unknown) => mockPrepareCalls(params),
+    },
+  },
+}));
+
+jest.mock('@/features/delegation/calls', () => ({
+  createDelegationPublicClient: (chainId: ChainId) => mockCreateDelegationPublicClient(chainId),
+  SPONSORED_CALLS_REQUIREMENTS: {
+    atomic: 'required',
+    fees: { payer: 'sponsor' },
+  },
+}));
+
+jest.mock('@/features/delegation/sponsoredCalls', () => ({
+  predictSponsoredCallsExecution: (params: unknown) => mockPredictSponsoredCallsExecution(params),
+}));
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  supportsDelegatedExecution: (params: unknown) => mockSupportsDelegatedExecution(params),
+}));
+
+jest.mock('@/raps/atomicSwapPreparation', () => ({
+  prepareAtomicSwapCalls: (params: unknown) => mockPrepareAtomicSwapCalls(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const RECIPIENT = '0x4444444444444444444444444444444444444444' satisfies Address;
+const SELL_TOKEN = '0x5555555555555555555555555555555555555555' satisfies Address;
+const BUY_TOKEN = '0x6666666666666666666666666666666666666666' satisfies Address;
+const PREPARED_CALLS = {
+  executionId: 'prepared-deposit',
+  kind: 'calls.managed',
+  review: { fees: { payer: 'sponsor' } },
+} as PreparedCallsExecution;
+
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', ChainId.polygon);
+
+function buildQuote(overrides: Partial<Quote> = {}): Quote {
+  return {
+    allowanceNeeded: false,
+    allowanceTarget: '0x1111111111111111111111111111111111111111',
+    buyAmount: '1000000',
+    buyAmountDisplay: '1000000',
+    buyAmountDisplayMinimum: '1000000',
+    buyAmountInEth: '0',
+    buyAmountMinusFees: '1000000',
+    buyTokenAddress: BUY_TOKEN,
+    chainId: ChainId.polygon,
+    data: '0x1234',
+    fallback: false,
+    fee: '0',
+    feeInEth: '0',
+    feePercentageBasisPoints: 0,
+    from: ACCOUNT,
+    sellAmount: '1000000',
+    sellAmountDisplay: '1000000',
+    sellAmountInEth: '0',
+    sellAmountMinusFees: '1000000',
+    sellTokenAddress: SELL_TOKEN,
+    swapType: SwapType.normal,
+    to: '0x7777777777777777777777777777777777777777',
+    tradeAmountUSD: 1,
+    tradeFeeAmountUSD: 0,
+    value: '0',
+    ...overrides,
+  };
+}
+
+describe('prepareSponsoredDepositExecution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateDelegationPublicClient.mockReturnValue({ name: 'public-client' });
+    mockPredictSponsoredCallsExecution.mockReturnValue(true);
+    mockPrepareCalls.mockResolvedValue(PREPARED_CALLS);
+    mockSupportsDelegatedExecution.mockResolvedValue(true);
+  });
+
+  it('prepares a sponsor-paid ERC20 transfer for direct-transfer deposits', async () => {
+    const quote = buildQuote();
+
+    await expect(
+      prepareSponsoredDepositExecution({
+        accountAddress: ACCOUNT,
+        chainId: ChainId.polygon,
+        provider,
+        quote,
+        strategy: { recipient: RECIPIENT, type: 'directTransfer' },
+      })
+    ).resolves.toBe(PREPARED_CALLS);
+
+    expect(mockPrepareAtomicSwapCalls).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      calls: [
+        {
+          to: SELL_TOKEN,
+          value: 0n,
+          data: encodeFunctionData({
+            abi: erc20Abi,
+            functionName: 'transfer',
+            args: [RECIPIENT, 1_000_000n],
+          }),
+        },
+      ],
+      chainId: ChainId.polygon,
+      publicClient: { name: 'public-client' },
+      requirements: mockSponsoredCallsRequirements,
+    });
+  });
+
+  it('reuses atomic swap preparation for RAP-backed deposit strategies', async () => {
+    const quote = buildQuote();
+    const swapCall: Call = { data: '0xaaaa', to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', value: 0n };
+    mockPrepareAtomicSwapCalls.mockResolvedValue([swapCall]);
+
+    await expect(
+      prepareSponsoredDepositExecution({
+        accountAddress: ACCOUNT,
+        chainId: ChainId.polygon,
+        provider,
+        quote,
+        strategy: { rapType: 'swap', type: 'swap' },
+      })
+    ).resolves.toBe(PREPARED_CALLS);
+
+    expect(mockPrepareAtomicSwapCalls).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      chainId: ChainId.polygon,
+      provider,
+      quote,
+    });
+    expect(mockPrepareCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calls: [swapCall],
+        requirements: mockSponsoredCallsRequirements,
+      })
+    );
+  });
+
+  it('skips preparation when sponsorship or delegated execution is unavailable', async () => {
+    mockPredictSponsoredCallsExecution.mockReturnValue(false);
+
+    await expect(
+      prepareSponsoredDepositExecution({
+        accountAddress: ACCOUNT,
+        chainId: ChainId.polygon,
+        provider,
+        quote: buildQuote(),
+        strategy: { recipient: RECIPIENT, type: 'directTransfer' },
+      })
+    ).resolves.toBeNull();
+
+    expect(mockSupportsDelegatedExecution).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+
+    mockPredictSponsoredCallsExecution.mockReturnValue(true);
+    mockSupportsDelegatedExecution.mockResolvedValue(false);
+
+    await expect(
+      prepareSponsoredDepositExecution({
+        accountAddress: ACCOUNT,
+        chainId: ChainId.polygon,
+        provider,
+        quote: buildQuote(),
+        strategy: { recipient: RECIPIENT, type: 'directTransfer' },
+      })
+    ).resolves.toBeNull();
+
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+});

--- a/src/systems/funding/execution/prepareSponsoredDepositExecution.ts
+++ b/src/systems/funding/execution/prepareSponsoredDepositExecution.ts
@@ -1,0 +1,103 @@
+import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { encodeFunctionData, erc20Abi, type Address } from 'viem';
+
+import { isCrosschainQuote } from '@/__swaps__/utils/quotes';
+import { createDelegationPublicClient, SPONSORED_CALLS_REQUIREMENTS } from '@/features/delegation/calls';
+import { predictSponsoredCallsExecution } from '@/features/delegation/sponsoredCalls';
+import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
+import { RainbowError } from '@/logger';
+import { prepareAtomicSwapCalls } from '@/raps/atomicSwapPreparation';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { execute, type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
+
+import { type ExecutionStrategy } from './strategy';
+
+// ============ Types ========================================================= //
+
+type PrepareSponsoredDepositExecutionParams = {
+  accountAddress: Address;
+  chainId: ChainId;
+  provider: StaticJsonRpcProvider;
+  quote: Quote | CrosschainQuote;
+  strategy: ExecutionStrategy;
+};
+
+// ============ Preparation =================================================== //
+
+/**
+ * Prepares sponsor-paid exact calls for a funding deposit execution.
+ */
+export async function prepareSponsoredDepositExecution({
+  accountAddress,
+  chainId,
+  provider,
+  quote,
+  strategy,
+}: PrepareSponsoredDepositExecutionParams): Promise<PreparedCallsExecution | null> {
+  if (!predictSponsoredCallsExecution({ address: accountAddress, chainId })) return null;
+
+  const canExecuteAtomically = await supportsDelegatedExecution({ address: accountAddress, chainId });
+  if (!canExecuteAtomically) return null;
+
+  const calls = await buildSponsoredDepositCalls({
+    accountAddress,
+    chainId,
+    provider,
+    quote,
+    strategy,
+  });
+
+  return execute.prepare.calls({
+    account: accountAddress,
+    chainId,
+    calls,
+    publicClient: createDelegationPublicClient(chainId),
+    requirements: SPONSORED_CALLS_REQUIREMENTS,
+  });
+}
+
+// ============ Calls ========================================================= //
+
+async function buildSponsoredDepositCalls({
+  accountAddress,
+  chainId,
+  provider,
+  quote,
+  strategy,
+}: PrepareSponsoredDepositExecutionParams): Promise<Call[]> {
+  if (strategy.type === 'directTransfer') {
+    return [buildDirectTransferCall({ quote, recipient: strategy.recipient })];
+  }
+
+  if (strategy.rapType === 'crosschainSwap') {
+    if (!isCrosschainQuote(quote)) throw new RainbowError('[prepareSponsoredDepositExecution]: Expected crosschain quote');
+    return prepareAtomicSwapCalls({
+      account: accountAddress,
+      chainId,
+      provider,
+      quote,
+    });
+  }
+
+  if (isCrosschainQuote(quote)) throw new RainbowError('[prepareSponsoredDepositExecution]: Expected same-chain quote');
+
+  return prepareAtomicSwapCalls({
+    account: accountAddress,
+    chainId,
+    provider,
+    quote,
+  });
+}
+
+function buildDirectTransferCall({ quote, recipient }: { quote: Quote | CrosschainQuote; recipient: string }): Call {
+  return {
+    to: quote.sellTokenAddress,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'transfer',
+      args: [recipient as Address, BigInt(quote.sellAmount.toString())],
+    }),
+  };
+}

--- a/src/systems/funding/hooks/useDepositHandler.ts
+++ b/src/systems/funding/hooks/useDepositHandler.ts
@@ -5,13 +5,16 @@ import { Logger } from '@ethersproject/logger';
 import { type SharedValue } from 'react-native-reanimated';
 import { triggerHaptics } from 'react-native-turbo-haptics';
 
+import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { crosschainQuoteTargetsRecipient, isCrosschainQuote } from '@/__swaps__/utils/quotes';
+import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
 import { getProvider } from '@/handlers/web3';
 import { logger, RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
 import Navigation, { useRoute, type Route } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { rapTypes } from '@/raps/references';
+import { backendNetworksActions } from '@/state/backendNetworks/backendNetworks';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { type StoreActions } from '@/state/internal/utils/createStoreActions';
 import { getNextNonce } from '@/state/nonces';
@@ -23,14 +26,18 @@ import { isRecordLike } from '@/types/guards';
 import { time } from '@/utils/time';
 import watchingAlert from '@/utils/watchingAlert';
 import { sanitizeAmount } from '@/worklets/strings';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
 
 import {
   type AmountStoreType,
   type DepositConfig,
   type DepositFailureMetadata,
+  type DepositGasHookParams,
   type DepositGasParams,
   type DepositGasStoresType,
   type DepositQuoteStoreType,
+  type DepositSponsorshipFailureReason,
   type DepositStoreType,
   type DepositSuccessMetadata,
 } from '../types';
@@ -58,6 +65,8 @@ type DepositExecutionErrorLabels = Pick<DepositConfig['labels'], 'insufficientGa
 type DepositExecutionFailure = {
   error: string;
   showAlert?: boolean;
+  sponsorshipAttempted?: boolean;
+  sponsorshipFailureReason?: DepositSponsorshipFailureReason;
   stage?: DepositFailureMetadata['stage'];
   success: false;
 };
@@ -67,6 +76,7 @@ type DepositExecutionSuccess = {
   executionStrategy: DepositSuccessMetadata['executionStrategy'];
   hash?: string;
   isConfirmed?: boolean;
+  sponsorship: DepositSuccessMetadata['sponsorship'];
   success: true;
   waitForConfirmation?: () => Promise<void>;
 };
@@ -103,6 +113,8 @@ async function runDepositExecutionFlow({
         assetChainId,
         assetSymbol,
         error: result.error,
+        sponsorshipAttempted: result.sponsorshipAttempted ?? false,
+        sponsorshipFailureReason: result.sponsorshipFailureReason,
         stage: result.stage ?? 'execution',
       });
 
@@ -127,6 +139,7 @@ async function runDepositExecutionFlow({
       assetChainId,
       assetSymbol,
       executionStrategy: result.executionStrategy,
+      sponsorship: result.sponsorship,
     });
   } catch (error) {
     const message = formatThrownDepositExecutionError(error, config.labels);
@@ -138,6 +151,7 @@ async function runDepositExecutionFlow({
       assetChainId,
       assetSymbol,
       error: message,
+      sponsorshipAttempted: false,
       stage: 'execution',
     });
     if (showAlertOnThrownError) {
@@ -213,6 +227,7 @@ export function useDepositHandler({
         assetChainId,
         assetSymbol,
         error: 'Missing recipient',
+        sponsorshipAttempted: false,
         stage: 'validation',
       });
       Alert.alert(config.labels.quoteError, config.labels.missingRecipientError);
@@ -227,6 +242,7 @@ export function useDepositHandler({
           assetChainId,
           assetSymbol,
           error: 'No wallet connected',
+          sponsorshipAttempted: false,
           stage: 'validation',
         });
         Alert.alert(config.labels.executionErrorTitle, config.labels.noWalletConnected);
@@ -269,6 +285,7 @@ export function useDepositHandler({
               executionStrategy: result.executionStrategy ?? 'custom',
               hash: result.hash,
               isConfirmed: result.isConfirmed,
+              sponsorship: 'walletPaid',
               success: true,
               waitForConfirmation: result.waitForConfirmation,
             };
@@ -324,6 +341,7 @@ export function useDepositHandler({
         assetChainId,
         assetSymbol,
         error: 'Crosschain quote not targeting recipient',
+        sponsorshipAttempted: false,
         stage: 'validation',
       });
       Alert.alert(config.labels.quoteError, config.labels.invalidRouteRecipientError);
@@ -357,10 +375,19 @@ export function useDepositHandler({
           return {
             error: 'Wallet load failed',
             showAlert: false,
+            sponsorshipAttempted: false,
             stage: 'wallet',
             success: false,
           };
         }
+
+        const preparedCalls = await resolveSponsoredPreparedCalls({
+          accountAddress: validQuote.from,
+          asset,
+          config,
+          quote: validQuote,
+          recipient,
+        });
 
         const nonce = await getNextNonce({ address: validQuote.from, chainId: assetChainId });
         const result = await executeDepositRap({
@@ -370,6 +397,7 @@ export function useDepositHandler({
           gasFeeParamsBySpeed,
           gasParams,
           nonce,
+          preparedCalls,
           quote: validQuote,
           wallet,
         });
@@ -377,6 +405,8 @@ export function useDepositHandler({
         if (!result.success) {
           return {
             error: result.error,
+            sponsorshipAttempted: result.sponsorshipAttempted,
+            sponsorshipFailureReason: result.sponsorshipFailureReason,
             success: false,
           };
         }
@@ -399,11 +429,53 @@ export function useDepositHandler({
           executionStrategy: result.executionStrategy,
           hash: result.hash,
           isConfirmed: result.isConfirmed,
+          sponsorship: result.sponsorship,
           success: true,
         };
       },
     });
   }, [config, depositActions, depositRoute, gasStores, isSubmitting, quoteActions, useAmountStore]);
+}
+
+// ============ Sponsored Calls =============================================== //
+
+async function resolveSponsoredPreparedCalls({
+  accountAddress,
+  asset,
+  config,
+  quote,
+  recipient,
+}: {
+  accountAddress: Quote['from'];
+  asset: ExtendedAnimatedAssetWithColors;
+  config: DepositConfig;
+  quote: Quote | CrosschainQuote;
+  recipient: DepositGasHookParams['recipient'];
+}): Promise<PreparedCallsExecution | null> {
+  if (!config.sponsoredExecution) return null;
+
+  if (!backendNetworksActions.isSponsorshipEligible(asset.chainId)) {
+    return null;
+  }
+
+  const hookParams: DepositGasHookParams = {
+    accountAddress,
+    amount: quote.sellAmount?.toString() ?? '0',
+    asset,
+    quote,
+    recipient,
+  };
+
+  try {
+    const preparedCalls = await config.sponsoredExecution.getPreparedCalls(hookParams);
+    return isPreparedCallsExecutionSponsored(preparedCalls) ? preparedCalls : null;
+  } catch (error) {
+    logger.warn('[useDepositHandler]: sponsored prepared calls unavailable', {
+      error,
+      id: config.id,
+    });
+    return null;
+  }
 }
 
 // ============ Post-Confirmation Refresh ===================================== //

--- a/src/systems/funding/stores/createDepositGasStores.ts
+++ b/src/systems/funding/stores/createDepositGasStores.ts
@@ -27,6 +27,7 @@ import { shallowEqual } from '@/worklets/comparisons';
 import {
   type AmountStoreType,
   type DepositConfig,
+  type DepositGasConfig,
   type DepositGasHookParams,
   type DepositGasLimitParams,
   type DepositGasStoresType,
@@ -54,7 +55,7 @@ type GasSponsorshipQueryParams = {
 
 // ============ Gas Stores Factory ============================================ //
 
-const useNoGasSponsorship = createDerivedStore(() => false, { lockDependencies: true });
+const useAlwaysFalse = createDerivedStore(() => false, { lockDependencies: true });
 
 export function createDepositGasStores(
   config: DepositConfig,
@@ -133,11 +134,36 @@ export function createDepositGasStores(
     staleTime: time.seconds(30),
   });
 
+  const useCanCheckGasSponsorship =
+    hasGasSponsorshipResolver && useHasGasHookParams
+      ? createDerivedStore(
+          $ => {
+            const hasHookParams = $(useHasGasHookParams);
+            const params = buildGasHookParams({
+              accountAddress: $(useWalletsStore, s => s.accountAddress),
+              amount: $(useAmountStore, selectNormalizedAmount),
+              asset: $(useDepositStore, s => s.asset),
+              config,
+              quote: $(useQuoteStore, s => s.getData()),
+            });
+            const quoteKey = $(useQuoteKey);
+            if (!hasHookParams) return false;
+            if (!params) return false;
+
+            const predictedSponsorship = resolveGasSponsorshipPrediction(config.gas?.predictIsSponsored, params, config);
+            if (predictedSponsorship === false) return false;
+
+            return hasHookParams && isValidQuoteKey(quoteKey);
+          },
+          { lockDependencies: true }
+        )
+      : useAlwaysFalse;
+
   const useGasSponsorshipStore =
     hasGasSponsorshipResolver && useHasGasHookParams
       ? createQueryStore<boolean, GasSponsorshipQueryParams>({
           fetcher: createGasSponsorshipFetcher(config, useDepositStore, useQuoteStore),
-          enabled: $ => $(useHasGasHookParams),
+          enabled: $ => $(useCanCheckGasSponsorship),
           params: {
             accountAddress: $ => $(useWalletsStore, s => s.accountAddress),
             amount: $ => $(useAmountStore, selectNormalizedAmount),
@@ -187,24 +213,17 @@ export function createDepositGasStores(
           });
 
           const resolvedSponsorship = useGasSponsorshipStore ? $(useGasSponsorshipStore, s => s.getData()) : null;
+          const predictedSponsorship = resolveGasSponsorshipPrediction(config.gas?.predictIsSponsored, params, config);
+
+          if (!params) return false;
+          if (predictedSponsorship === false) return false;
           if (resolvedSponsorship !== null) return resolvedSponsorship;
 
-          const predictSponsorship = config.gas?.predictIsSponsored;
-          if (!predictSponsorship || !params) return false;
-
-          try {
-            return Boolean(predictSponsorship(params));
-          } catch (error) {
-            logger.warn('[createDepositGasStores]: sponsorship prediction failed', {
-              error,
-              id: config.id,
-            });
-            return false;
-          }
+          return predictedSponsorship ?? false;
         },
         { lockDependencies: true }
       )
-    : useNoGasSponsorship;
+    : useAlwaysFalse;
 
   const useMaxSwappableAmount = createDerivedStore(
     $ => {
@@ -320,6 +339,24 @@ function createGasSponsorshipFetcher(
       return false;
     }
   };
+}
+
+function resolveGasSponsorshipPrediction(
+  predictSponsorship: DepositGasConfig['predictIsSponsored'] | undefined,
+  params: DepositGasHookParams | null,
+  config: DepositConfig
+): boolean | null {
+  if (!predictSponsorship || !params) return null;
+
+  try {
+    return Boolean(predictSponsorship(params));
+  } catch (error) {
+    logger.warn('[createDepositGasStores]: sponsorship prediction failed', {
+      error,
+      id: config.id,
+    });
+    return false;
+  }
 }
 
 function buildGasHookParams({

--- a/src/systems/funding/types.ts
+++ b/src/systems/funding/types.ts
@@ -12,6 +12,7 @@ import { type ChainId } from '@/state/backendNetworks/types';
 import { type QueryStore, type StoreState } from '@/state/internal/queryStore/types';
 import { type BaseRainbowStore, type DerivedStore, type RainbowStore } from '@/state/internal/types';
 import { type StoreActions } from '@/state/internal/utils/createStoreActions';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
 import { type CrosschainQuote, type Quote, type Source } from '@rainbow-me/swaps';
 
 // ============ Shared Types =================================================== //
@@ -64,6 +65,26 @@ export type DepositGasParams = LegacyTransactionGasParamAmounts | TransactionGas
  */
 export type OnDepositSubmit = (signer: Signer, context: DepositSubmitContext) => Promise<void>;
 
+/**
+ * Resolved sponsorship outcome for an executed deposit.
+ *
+ * - `sponsored`: relay sponsor paid for the transaction.
+ * - `walletPaid`: the user's wallet paid for the transaction (either because
+ *   sponsorship was ineligible/unavailable at prepare time, or because the
+ *   prepared sponsored calls were not used at submit time).
+ */
+export type DepositSponsorshipOutcome = 'sponsored' | 'walletPaid';
+
+/**
+ * Classification of a sponsor-paid execution failure.
+ *
+ * - `insufficientSponsorBalance`: the sponsor wallet was depleted.
+ * - `sponsoredRelayExecutionFailed`: the managed relay execution failed onchain
+ *   or otherwise reverted before broadcasting.
+ * - `unknownSponsorshipFailure`: a sponsored attempt failed for any other reason.
+ */
+export type DepositSponsorshipFailureReason = 'insufficientSponsorBalance' | 'sponsoredRelayExecutionFailed' | 'unknownSponsorshipFailure';
+
 export type DepositSuccessMetadata = {
   /** Amount deposited in source asset units */
   amount: string;
@@ -73,6 +94,8 @@ export type DepositSuccessMetadata = {
   assetSymbol: string;
   /** Execution path taken */
   executionStrategy: 'crosschainSwap' | 'directTransfer' | 'custom' | 'swap';
+  /** Whether the executed deposit was sponsor-paid or wallet-paid */
+  sponsorship: DepositSponsorshipOutcome;
 };
 
 export type DepositFailureMetadata = {
@@ -86,6 +109,10 @@ export type DepositFailureMetadata = {
   error: string;
   /** Point in the flow where failure occurred */
   stage: 'execution' | 'validation' | 'wallet';
+  /** Whether a sponsor-paid execution was attempted before failing */
+  sponsorshipAttempted: boolean;
+  /** Classification of the sponsor-paid failure when `sponsorshipAttempted` is true */
+  sponsorshipFailureReason?: DepositSponsorshipFailureReason;
 };
 
 /**
@@ -194,6 +221,14 @@ export type DepositExecutor = (params: DepositExecuteParams) => Promise<DepositE
 
 export type DepositGasHookParams = Omit<DepositExecutionBaseParams, 'gasParams'>;
 
+export type DepositSponsoredExecutionConfig = {
+  /**
+   * Returns prepared exact calls for submit-time execution.
+   * Return null to fall back to normal wallet-paid execution.
+   */
+  getPreparedCalls: (params: DepositGasHookParams) => Promise<PreparedCallsExecution | null>;
+};
+
 export type DepositGasConfig = {
   /**
    * Optional custom gas-limit estimator.
@@ -210,6 +245,20 @@ export type DepositGasConfig = {
    * Custom flows may also use this hook to prepare sponsor-paid execution in advance.
    */
   isSponsored?: (params: DepositGasHookParams) => Promise<boolean> | boolean;
+};
+
+export type DepositRuntimeStores = {
+  useQuoteStore: DepositQuoteStoreType;
+};
+
+export type DepositRuntimeSponsoredExecution = {
+  cleanup?: () => void;
+  gas?: Pick<DepositGasConfig, 'isSponsored'>;
+  sponsoredExecution: DepositSponsoredExecutionConfig;
+};
+
+export type DepositRuntimeExtensions = {
+  createSponsoredExecution?: (stores: DepositRuntimeStores) => DepositRuntimeSponsoredExecution;
 };
 
 export type DepositLabels = {
@@ -309,6 +358,9 @@ type DepositConfigBaseInput = {
   /** Optional gas extension hooks */
   gas?: DepositGasConfig;
 
+  /** Optional sponsored exact-call execution hook used at submit time. */
+  sponsoredExecution?: DepositSponsoredExecutionConfig;
+
   /** Initial slider position (0–100). @default 25 */
   initialSliderProgress?: number;
 
@@ -372,11 +424,15 @@ export type DepositConfigInput = DepositConfigBaseInput & DepositExecutionCallba
 
 export type DepositSourceConfig = { mode: 'selectable' } | Extract<DepositSourceConfigInput, { mode: 'fixed' }>;
 
-type DepositConfigBase = Omit<DepositConfigBaseInput, 'gas' | 'hideReceiveAmount' | 'initialSliderProgress' | 'labels' | 'source'> & {
+type DepositConfigBase = Omit<
+  DepositConfigBaseInput,
+  'gas' | 'hideReceiveAmount' | 'initialSliderProgress' | 'labels' | 'source' | 'sponsoredExecution'
+> & {
   hideReceiveAmount: boolean;
   gas: DepositGasConfig | undefined;
   initialSliderProgress: number;
   labels: DepositLabels;
+  sponsoredExecution: DepositSponsoredExecutionConfig | undefined;
   source: DepositSourceConfig;
 };
 

--- a/src/systems/funding/utils/depositQuoteKey.ts
+++ b/src/systems/funding/utils/depositQuoteKey.ts
@@ -1,0 +1,30 @@
+import { isCrosschainQuote } from '@/__swaps__/utils/quotes';
+import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
+
+/**
+ * Builds a stable identity for the executable parts of a deposit quote.
+ */
+export function buildDepositQuoteKey(quote: Quote | CrosschainQuote): string {
+  const base = {
+    allowanceTarget: quote.allowanceTarget.toLowerCase(),
+    buyAmount: quote.buyAmount?.toString() ?? null,
+    buyTokenAddress: quote.buyTokenAddress.toLowerCase(),
+    chainId: quote.chainId,
+    data: quote.data,
+    fallback: quote.fallback ?? false,
+    from: quote.from.toLowerCase(),
+    sellAmount: quote.sellAmount?.toString() ?? null,
+    sellTokenAddress: quote.sellTokenAddress.toLowerCase(),
+    swapType: quote.swapType,
+    to: quote.to?.toLowerCase() ?? null,
+    value: quote.value?.toString() ?? null,
+  };
+
+  if (!isCrosschainQuote(quote)) return JSON.stringify(base);
+
+  return JSON.stringify({
+    ...base,
+    refuel: quote.refuel,
+    routes: quote.routes,
+  });
+}


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3715/sponsor-deposits-into-perps

## Why?

Perps deposits currently use the normal wallet-paid funding execution path even when the wallet and source chain can support sponsored delegated calls. This adds a flag-gated sponsored execution path so eligible perps deposits can be prepared and submitted as sponsor-paid exact calls, while preserving the existing wallet-paid fallback for disabled, unsupported, or failed preparation cases.

## Approach

The funding deposit flow now accepts runtime extensions that can attach submit-time sponsored execution without hardcoding perps-specific behavior into the shared deposit screen. Perps wires that extension to a prepared-calls store keyed by the active executable quote, uses the prepared call review to resolve sponsored gas UI state, and passes sponsored prepared calls into RAP execution when available.

The execution path remains conservative: preparation is gated by `sponsored_perps_deposits_enabled`, delegation support, chain sponsorship eligibility, quote identity checks, and sponsored-fee validation. If any step does not qualify, deposits fall back to the existing wallet-paid RAP flow.

## Showcase

[Simulator Screen Recording - iPhone 17 Pro - 2026-05-26 at 17.29.13.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/da916061-0f58-4ce1-a1e7-bfa1193c79e1.mov" />](https://app.graphite.com/user-attachments/video/da916061-0f58-4ce1-a1e7-bfa1193c79e1.mov)



## Testing

- With `sponsored_perps_deposits_enabled` enabled, use a delegation-eligible wallet on a sponsorship-eligible source chain and verify a perps deposit shows sponsored gas and submits successfully.
- Disable `sponsored_perps_deposits_enabled` and verify the same deposit continues through the normal wallet-paid flow.
- Use unsupported source chain (mainnet) and verify the deposit falls back to wallet-paid execution without blocking submission.