### PR TITLE
feat: add flag-gated sponsored predictions deposit execution

### DIFF
--- a/src/features/polymarket/depositConfig.ts
+++ b/src/features/polymarket/depositConfig.ts
@@ -1,5 +1,7 @@
 import { analytics } from '@/analytics';
+import { predictSponsoredCallsExecution } from '@/features/delegation/sponsoredCalls';
 import { USDC_ICON_URL } from '@/features/perps/constants';
+import { getRemoteConfig } from '@/model/remoteConfig';
 import { ChainId } from '@/state/backendNetworks/types';
 import { createDepositConfig } from '@/systems/funding/config';
 import { time } from '@/utils/time';
@@ -31,6 +33,18 @@ export const POLYMARKET_DEPOSIT_CONFIG = createDepositConfig({
       iconUrl: USDC_ICON_URL,
     },
     recipient: usePolymarketProxyAddress,
+  },
+
+  gas: {
+    predictIsSponsored: ({ accountAddress, asset }) => {
+      return (
+        getRemoteConfig().sponsored_polymarket_deposits_enabled &&
+        predictSponsoredCallsExecution({
+          address: accountAddress,
+          chainId: asset.chainId,
+        })
+      );
+    },
   },
 
   refresh: {

--- a/src/features/polymarket/funding/screens/PolymarketDepositScreen.tsx
+++ b/src/features/polymarket/funding/screens/PolymarketDepositScreen.tsx
@@ -2,12 +2,17 @@ import React, { memo } from 'react';
 
 import { POLYMARKET_ACCENT_COLOR, POLYMARKET_BACKGROUND_DARK, POLYMARKET_BACKGROUND_LIGHT } from '@/features/polymarket/constants';
 import { POLYMARKET_DEPOSIT_CONFIG } from '@/features/polymarket/depositConfig';
+import { createPolymarketDepositRuntimeExtensions } from '@/features/polymarket/stores/polymarketDepositRuntimeExtensions';
+import { useStableValue } from '@/hooks/useStableValue';
 import { DepositScreen } from '@/systems/funding/components/DepositScreen';
 
 export const PolymarketDepositScreen = memo(function PolymarketDepositScreen() {
+  const runtimeExtensions = useStableValue(createPolymarketDepositRuntimeExtensions);
+
   return (
     <DepositScreen
       config={POLYMARKET_DEPOSIT_CONFIG}
+      runtimeExtensions={runtimeExtensions}
       theme={{
         accent: POLYMARKET_ACCENT_COLOR,
         backgroundDark: POLYMARKET_BACKGROUND_DARK,

--- a/src/features/polymarket/stores/polymarketDepositRuntimeExtensions.ts
+++ b/src/features/polymarket/stores/polymarketDepositRuntimeExtensions.ts
@@ -1,0 +1,40 @@
+import { destroyStore } from '@storesjs/stores';
+
+import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
+import { getRemoteConfig } from '@/model/remoteConfig';
+import { createDepositPreparedCallsStore, getDepositPreparedCalls } from '@/systems/funding/execution/depositPreparedCallsStore';
+import { type DepositRuntimeExtensions } from '@/systems/funding/types';
+
+import { POLYMARKET_DEPOSIT_CONFIG } from '../depositConfig';
+
+// ============ Runtime Extensions =========================================== //
+
+export function createPolymarketDepositRuntimeExtensions(): DepositRuntimeExtensions {
+  return {
+    createSponsoredExecution: ({ useQuoteStore }) => {
+      const preparedDepositStore = createDepositPreparedCallsStore({
+        config: POLYMARKET_DEPOSIT_CONFIG,
+        readCurrentQuote: () => useQuoteStore.getState().getData(),
+      });
+
+      return {
+        cleanup: () => {
+          destroyStore(preparedDepositStore, { clearQueryCache: true });
+        },
+        gas: {
+          isSponsored: async params => {
+            if (!getRemoteConfig().sponsored_polymarket_deposits_enabled) return false;
+            const preparedCalls = await getDepositPreparedCalls(preparedDepositStore, params);
+            return isPreparedCallsExecutionSponsored(preparedCalls);
+          },
+        },
+        sponsoredExecution: {
+          getPreparedCalls: params => {
+            if (!getRemoteConfig().sponsored_polymarket_deposits_enabled) return Promise.resolve(null);
+            return getDepositPreparedCalls(preparedDepositStore, params);
+          },
+        },
+      };
+    },
+  };
+}

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -99,6 +99,7 @@ export interface RainbowConfig extends Record<
   sponsored_sends_enabled: boolean;
   sponsored_swaps_enabled: boolean;
   sponsored_perps_deposits_enabled: boolean;
+  sponsored_polymarket_deposits_enabled: boolean;
   discover_placements_enabled: boolean;
 }
 
@@ -233,6 +234,7 @@ export const DEFAULT_CONFIG = {
   sponsored_sends_enabled: true,
   sponsored_swaps_enabled: true,
   sponsored_perps_deposits_enabled: true,
+  sponsored_polymarket_deposits_enabled: true,
   discover_placements_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 

--- a/src/systems/funding/execution/depositRapExecution.test.ts
+++ b/src/systems/funding/execution/depositRapExecution.test.ts
@@ -1,13 +1,43 @@
 import { Wallet } from '@ethersproject/wallet';
+import { Wallet as EthersWallet } from 'ethers';
 
 import { SwapType, type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
 
 import { executeDepositRap } from './depositRapExecution';
 
+const mockContractTransfer = jest.fn();
+const mockEncodeFunctionData = jest.fn();
+const mockEstimateGasWithPadding = jest.fn();
+const mockExecuteCalls = jest.fn();
+const mockGetProvider = jest.fn();
+const mockResolveManagedExecutionFailure = jest.fn();
+const mockToHex = jest.fn();
 const mockWalletExecuteRap = jest.fn();
+
+jest.mock('ethers', () => ({
+  ethers: {
+    Contract: jest.fn(() => ({
+      interface: {
+        encodeFunctionData: (...args: unknown[]) => mockEncodeFunctionData(...args),
+      },
+      transfer: (...args: unknown[]) => mockContractTransfer(...args),
+    })),
+  },
+  Wallet: class MockWallet {},
+}));
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    calls: (...args: unknown[]) => mockExecuteCalls(...args),
+  },
+}));
 
 jest.mock('@/raps/execute', () => ({
   walletExecuteRap: (...args: unknown[]) => mockWalletExecuteRap(...args),
+}));
+
+jest.mock('@/features/delegation/managedExecutionFailure', () => ({
+  resolveManagedExecutionFailure: (...args: unknown[]) => mockResolveManagedExecutionFailure(...args),
 }));
 
 jest.mock('@/features/delegation/sponsoredCalls', () => ({
@@ -15,9 +45,9 @@ jest.mock('@/features/delegation/sponsoredCalls', () => ({
 }));
 
 jest.mock('@/handlers/web3', () => ({
-  estimateGasWithPadding: jest.fn(),
-  getProvider: jest.fn(() => ({})),
-  toHex: jest.fn(),
+  estimateGasWithPadding: (...args: unknown[]) => mockEstimateGasWithPadding(...args),
+  getProvider: (...args: unknown[]) => mockGetProvider(...args),
+  toHex: (...args: unknown[]) => mockToHex(...args),
 }));
 
 jest.mock('@/state/backendNetworks/backendNetworks', () => ({
@@ -107,9 +137,32 @@ const MOCK_CONFIG = {
   },
 } as const;
 
+const DIRECT_TRANSFER_CONFIG = {
+  directTransferEnabled: true,
+  to: {
+    chainId: 8453,
+    recipient: {
+      getState: () => '0x9999999999999999999999999999999999999999',
+    },
+    token: {
+      address: MOCK_ASSET.address,
+      decimals: 6,
+      symbol: 'USDC',
+    },
+  },
+} as const;
+
+const MOCK_PROVIDER = { provider: 'base' };
+const MOCK_CONNECTED_WALLET = { signer: 'connected' };
+
 describe('executeDepositRap', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockContractTransfer.mockResolvedValue({ hash: '0xtransfer' });
+    mockEncodeFunctionData.mockReturnValue('0xtransferdata');
+    mockEstimateGasWithPadding.mockResolvedValue('21000');
+    mockGetProvider.mockReturnValue(MOCK_PROVIDER);
+    mockToHex.mockImplementation(value => `hex:${value}`);
   });
 
   it('executes same-chain quotes as swap RAP actions', async () => {
@@ -188,6 +241,100 @@ describe('executeDepositRap', () => {
       }),
       { preparedCalls: null }
     );
+  });
+
+  it('executes wallet-paid direct transfers without RAP when prepared calls are unavailable', async () => {
+    const wallet = {
+      connect: jest.fn(() => MOCK_CONNECTED_WALLET),
+      getAddress: jest.fn(() => Promise.resolve(buildQuote().from)),
+    };
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: DIRECT_TRANSFER_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: { gasPrice: '1' } as never,
+      nonce: 7,
+      preparedCalls: null,
+      quote: buildQuote(8453),
+      wallet: wallet as never,
+    });
+
+    expect(result).toEqual({
+      executionStrategy: 'directTransfer',
+      hash: '0xtransfer',
+      isConfirmed: false,
+      sponsorship: 'walletPaid',
+      success: true,
+    });
+
+    expect(mockWalletExecuteRap).not.toHaveBeenCalled();
+    expect(mockGetProvider).toHaveBeenCalledWith({ chainId: 8453 });
+    expect(wallet.connect).toHaveBeenCalledWith(MOCK_PROVIDER);
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith('transfer', [DIRECT_TRANSFER_CONFIG.to.recipient.getState(), '1']);
+    expect(mockEstimateGasWithPadding).toHaveBeenCalledWith(
+      {
+        data: '0xtransferdata',
+        from: buildQuote().from,
+        to: MOCK_ASSET.address,
+      },
+      undefined,
+      null,
+      MOCK_PROVIDER,
+      1.2
+    );
+    expect(mockContractTransfer).toHaveBeenCalledWith(DIRECT_TRANSFER_CONFIG.to.recipient.getState(), '1', {
+      gasLimit: 'hex:21000',
+      gasPrice: '1',
+      nonce: 7,
+    });
+  });
+
+  it('executes prepared direct transfers through exact calls when source asset matches target token', async () => {
+    const wallet = new EthersWallet('0x59c6995e998f97a5a0044966f0945382d4a8a7e3f89f8f51236aa0f5f7f6e8b8');
+    const preparedCalls = {
+      executionId: 'managed-direct-123',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    } as never;
+    mockExecuteCalls.mockResolvedValue({
+      executionId: 'managed-direct-123',
+      kind: 'calls.managed',
+      status: 'PENDING',
+    });
+    mockResolveManagedExecutionFailure.mockResolvedValue(null);
+
+    const result = await executeDepositRap({
+      asset: MOCK_ASSET as never,
+      assetChainId: 8453 as never,
+      config: DIRECT_TRANSFER_CONFIG as never,
+      gasFeeParamsBySpeed: {} as never,
+      gasParams: { gasPrice: '1' } as never,
+      nonce: 7,
+      preparedCalls,
+      quote: buildQuote(8453),
+      wallet,
+    });
+
+    expect(result).toEqual({
+      executionStrategy: 'directTransfer',
+      isConfirmed: false,
+      sponsorship: 'sponsored',
+      success: true,
+    });
+
+    expect(mockWalletExecuteRap).not.toHaveBeenCalled();
+    expect(mockContractTransfer).not.toHaveBeenCalled();
+    expect(mockExecuteCalls).toHaveBeenCalledWith(preparedCalls, {
+      chainId: 8453,
+      provider: MOCK_PROVIDER,
+      signer: wallet,
+    });
+    expect(mockResolveManagedExecutionFailure).toHaveBeenCalledWith({
+      executionId: 'managed-direct-123',
+      status: 'PENDING',
+    });
   });
 
   it('treats managed atomic execution without hash as success when sponsored calls are supplied', async () => {

--- a/src/systems/funding/execution/depositRapExecution.ts
+++ b/src/systems/funding/execution/depositRapExecution.ts
@@ -1,7 +1,8 @@
 import { type Signer } from '@ethersproject/abstract-signer';
-import { ethers } from 'ethers';
+import { ethers, Wallet } from 'ethers';
 
 import { type ParsedAsset } from '@/__swaps__/types/assets';
+import { resolveManagedExecutionFailure } from '@/features/delegation/managedExecutionFailure';
 import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
 import { estimateGasWithPadding, getProvider, toHex } from '@/handlers/web3';
 import { logger, RainbowError } from '@/logger';
@@ -12,7 +13,7 @@ import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks
 import { type ChainId } from '@/state/backendNetworks/types';
 import { executeFn, Screens, TimeToSignOperation } from '@/state/performance/performance';
 import { getUniqueId } from '@/utils/ethereumUtils';
-import { type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { execute, type PreparedCallsExecution } from '@rainbow-me/delegation';
 import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';
 
 import {
@@ -140,6 +141,13 @@ type ExecutionResult =
 async function executeTransaction(strategy: ExecutionStrategy, params: ExecutionParams): Promise<ExecutionResult> {
   switch (strategy.type) {
     case 'directTransfer':
+      if (params.wallet instanceof Wallet && params.preparedCalls) {
+        return executePreparedDirectTransfer({
+          wallet: params.wallet,
+          assetChainId: params.assetChainId,
+          preparedCalls: params.preparedCalls,
+        });
+      }
       return executeDirectTransfer(params, strategy.recipient);
     case 'swap':
       return executeSwap(params, strategy.rapType);
@@ -242,6 +250,44 @@ function classifySponsorshipFailure(errorMessage: string): DepositSponsorshipFai
     return 'sponsoredRelayExecutionFailed';
   }
   return 'unknownSponsorshipFailure';
+}
+
+async function executePreparedDirectTransfer(params: {
+  assetChainId: ChainId;
+  preparedCalls: PreparedCallsExecution;
+  wallet: Wallet;
+}): Promise<ExecutionResult> {
+  const provider = getProvider({ chainId: params.assetChainId });
+  const execution = await execute.calls(params.preparedCalls, {
+    chainId: params.assetChainId,
+    provider,
+    signer: params.wallet,
+  });
+
+  if (execution.kind === 'calls.managed') {
+    const failureMessage = await resolveManagedExecutionFailure({
+      executionId: execution.executionId,
+      status: execution.status,
+    });
+
+    if (failureMessage) {
+      return {
+        error: failureMessage,
+        sponsorshipAttempted: true,
+        sponsorshipFailureReason: classifySponsorshipFailure(failureMessage),
+        success: false,
+      };
+    }
+
+    return { isConfirmed: false, sponsorship: 'sponsored', success: true };
+  }
+
+  if (execution.kind !== 'calls.wallet' || execution.transactions.length !== 1) {
+    throw new RainbowError('[depositRapExecution]: direct transfer exact calls must resolve to one wallet transaction');
+  }
+
+  const transaction = execution.transactions[0];
+  return { hash: transaction.hash, isConfirmed: false, sponsorship: 'walletPaid', success: true };
 }
 
 // ============ Asset Building ================================================ //


### PR DESCRIPTION
## What changed (plus any additional context for devs)

fixes https://linear.app/rainbow/issue/APP-3603/sponsor-deposits-into-predictions

This completes the sponsored Polymarket deposit path on top of the shared funding execution work. Polymarket deposits now use a dedicated remote flag to predict and resolve sponsorship, prepare exact deposit calls from the current quote, and pass those calls into the funding runtime at submit time.

Direct same-token deposits can execute prepared calls without going through RAP, including managed relay executions that may complete without a transaction hash.

## Showcase

[Simulator Screen Recording - iPhone 17 Pro - 2026-05-26 at 19.34.27.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/fc9bdd2a-f1db-453e-ad84-c9aa4db4277a.mov" />](https://app.graphite.com/user-attachments/video/fc9bdd2a-f1db-453e-ad84-c9aa4db4277a.mov)[Simulator Screen Recording - iPhone 17 Pro - 2026-05-26 at 19.07.28.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/b9ca6814-d060-42cb-9ad1-903396bff2f6.mov" />](https://app.graphite.com/user-attachments/video/b9ca6814-d060-42cb-9ad1-903396bff2f6.mov)

## What to test

- With `sponsored_polymarket_deposits_enabled` enabled and an eligible delegated wallet, start a Polymarket USDC deposit and verify the deposit shows sponsored gas and submits successfully.
- Disable the flag or use an ineligible wallet and verify the flow falls back to normal wallet-paid gas behavior.
- For same-token USDC deposits, verify the transfer path succeeds without routing through swap RAP execution (deposit USDC on Polygon)