### PR TITLE
fix(analytics): sync testnet identify trait

### DIFF
--- a/src/redux/settings.ts
+++ b/src/redux/settings.ts
@@ -165,6 +165,7 @@ export const settingsChangeTestnetsEnabled =
       type: SETTINGS_UPDATE_TESTNET_PREF_SUCCESS,
     });
     saveTestnetsEnabled(testnetsEnabled);
+    analytics.identify({ enabledTestnets: testnetsEnabled });
   };
 
 export const settingsChangeAppIcon = (appIcon: string) => (dispatch: Dispatch<SettingsStateUpdateAppIconSuccessAction>) => {


### PR DESCRIPTION
Fixes APP-####

## What changed (plus any additional context for devs)

`settingsLoadState` identifies the current `enabledTestnets` trait at startup, and the language/currency mutation paths already re-identify their updated traits.

This adds the matching `analytics.identify({ enabledTestnets: testnetsEnabled })` call to `settingsChangeTestnetsEnabled` so the analytics user property updates immediately after the testnets preference is toggled, instead of staying stale until the next app load.

## Screen recordings / screenshots

N/A — analytics trait sync only.

## What to test

- Toggle testnets on/off.
- Confirm the app state and persisted setting still update as before.
- Confirm the analytics identify payload includes the updated `enabledTestnets` value after the toggle.

Local validation:

- `git diff --check HEAD~1..HEAD`

Not run successfully:

- `yarn lint:ts --pretty false --noEmit` — blocked because this fresh worktree has no `node_modules` state file; Yarn reports that an install is needed.
