### PR TITLE
feat(sentry): enable auto session tracking for release health

### DIFF
--- a/src/logger/sentry.ts
+++ b/src/logger/sentry.ts
@@ -65,7 +65,7 @@ export const defaultOptions: Sentry.ReactNativeOptions = {
   dsn: SENTRY_ENDPOINT,
   enableAppHangTracking: false,
   enableAutoPerformanceTracing: false,
-  enableAutoSessionTracking: false,
+  enableAutoSessionTracking: true,
   environment: ENVIRONMENT,
   ignoreErrors: IGNORED_ERRORS,
   integrations: [Sentry.httpClientIntegration()], // http client integration will help us see payload / response from errored out requests to better understand the issue


### PR DESCRIPTION
Sentry's session tracking has been off, so we don't get crash-free user/session rates, release adoption metrics, or the release health dashboard. We have errors but no denominator to compare them against.

This was parked until the Sentry environment redesign in #7437 (May 2026); the prior split between `Release` and `ReleaseAndroid` would have fragmented session data and made crash-free rates effectively useless across platforms. With production now consolidated, flipping this on gives us a single coherent view of release stability.

Session tracking only adds lifecycle pings (start/end, duration, status) tagged with the same user scope we already attach to error events (`deviceId` + hashed wallet address + wallet type). No new payload categories.

Closes FEPLAT-60.