### PR TITLE
fix(dev-settings): hide Wipe App + Restart from store builds

### DIFF
--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -273,13 +273,6 @@ const DevSection = () => {
           testID="reset-keychain-section"
           titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.keychain.menu_title)} />}
         />
-        <MenuItem
-          leftComponent={<MenuItem.TextIcon icon="🧨" isEmoji />}
-          onPress={wipeAppAndRestart}
-          size={52}
-          testID="wipe-app-and-restart-section"
-          titleComponent={<MenuItem.Title text="Wipe App + Restart" />}
-        />
       </Menu>
       {!IS_STORE_INSTALL && (
         <>
@@ -289,6 +282,13 @@ const DevSection = () => {
               onPress={() => Restart.Restart()}
               size={52}
               titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.restart_app)} />}
+            />
+            <MenuItem
+              leftComponent={<MenuItem.TextIcon icon="🧨" isEmoji />}
+              onPress={wipeAppAndRestart}
+              size={52}
+              testID="wipe-app-and-restart-section"
+              titleComponent={<MenuItem.Title text="Wipe App + Restart" />}
             />
             {/* TEMP: Removal for public TF */}
             {/* <MenuItem


### PR DESCRIPTION
The "Wipe App + Restart" button currently ships to App Store and Play Store users. It was added in #7108 (Mar 2026) as a drive-by addition inside the always-visible developer menu rather than the `IS_STORE_INSTALL`-gated one. Compared to `Reset Keychain` (which is intentionally exposed for support flows), this option is materially more destructive: it wipes the keychain, clears `AsyncStorage` and MMKV, unsubscribes notifications, then force-restarts the app. It shares the same confirmation alert as `Reset Keychain` but has a friendlier-sounding label, which makes it especially easy for a curious user to trigger and lose unbacked-up wallets.

This change moves the button into the existing dev-only menu next to `Restart App`, so it remains available in TestFlight and internal builds for engineering use but is no longer reachable from store installs. The other entries Support relies on (`Clear Local Storage`, `Clear Pending Transactions`, `Reset Keychain`) stay where they are.

Before | After
--|--
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 11 57 58" src="https://github.com/user-attachments/assets/8e6de848-bd1c-4e24-8fc9-d8e43e93d5bf" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 11 59 10" src="https://github.com/user-attachments/assets/4d8ec36d-81f6-477c-aded-77b83363dd83" />
