### PR TITLE
refactor(install-info): single-source signing cert fingerprints

### DIFF
--- a/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
+++ b/android/app/src/main/java/me/rainbow/NativeModules/AppInstallInfo/AppInstallInfoModule.kt
@@ -35,27 +35,18 @@ class AppInstallInfoModule(reactContext: ReactApplicationContext) :
     companion object {
         const val NAME = "AppInstallInfo"
 
-        // SHA-256 fingerprints of Rainbow's known signing certificates.
+        // SHA-256 fingerprints (colon-separated hex) of Rainbow's known signing certs.
+        // Any match -> internal build. No match -> store install (safe default).
         // Extracted with: keytool -list -v -keystore <keystore> -alias <alias>
-        // Any match = internal build. No match = store install (safe default).
-        private val KNOWN_INTERNAL_FINGERPRINTS = listOf(
-            // Upload key (rainbow-key.keystore, alias rainbow-alias)
-            // CD:34:1C:31:91:0F:63:D7:1A:3C:FA:6D:A4:95:81:11:E8:3A:BA:CA:64:14:79:3D:DB:86:A0:F9:0D:26:42:41
-            intArrayOf(
-                0xCD, 0x34, 0x1C, 0x31, 0x91, 0x0F, 0x63, 0xD7,
-                0x1A, 0x3C, 0xFA, 0x6D, 0xA4, 0x95, 0x81, 0x11,
-                0xE8, 0x3A, 0xBA, 0xCA, 0x64, 0x14, 0x79, 0x3D,
-                0xDB, 0x86, 0xA0, 0xF9, 0x0D, 0x26, 0x42, 0x41,
-            ).map { it.toByte() }.toByteArray(),
-            // Debug key (debug.keystore, alias androiddebugkey) — shared across all engineers.
-            // FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C
-            intArrayOf(
-                0xFA, 0xC6, 0x17, 0x45, 0xDC, 0x09, 0x03, 0x78,
-                0x6F, 0xB9, 0xED, 0xE6, 0x2A, 0x96, 0x2B, 0x39,
-                0x9F, 0x73, 0x48, 0xF0, 0xBB, 0x6F, 0x89, 0x9B,
-                0x83, 0x32, 0x66, 0x75, 0x91, 0x03, 0x3B, 0x9C,
-            ).map { it.toByte() }.toByteArray(),
-        )
+        // Upload key (rainbow-key.keystore, alias rainbow-alias).
+        private const val UPLOAD_CERT_SHA256 = "CD:34:1C:31:91:0F:63:D7:1A:3C:FA:6D:A4:95:81:11:E8:3A:BA:CA:64:14:79:3D:DB:86:A0:F9:0D:26:42:41"
+        // Debug key (debug.keystore, alias androiddebugkey) — shared across all engineers.
+        private const val DEBUG_CERT_SHA256 = "FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C"
+
+        private val KNOWN_INTERNAL_FINGERPRINTS: List<ByteArray> = listOf(
+            UPLOAD_CERT_SHA256,
+            DEBUG_CERT_SHA256,
+        ).map { sha -> sha.split(":").map { it.toInt(16).toByte() }.toByteArray() }
     }
 
     override fun getName(): String = NAME


### PR DESCRIPTION
Our native module for detecting store installs currently has each known signing cert fingerprint living in two places: a colon-separated hex string in a comment, and a parallel `intArrayOf(0x..)` byte literal. Only the byte literal is read at runtime, so the comment can silently drift if anyone updates one without the other.

This change hoists each fingerprint into a single `const val` string and derives the runtime `ByteArray` list from those at class init. Runtime byte content is unchanged for both the upload and debug keys.

This also gives the upload fingerprint a stable named const that the upcoming Android Play Store build workflow can read directly to verify the CI keystore.

Ref FEPLAT-102.