### PR TITLE
fix(backup): confusing "Not Enabled" cloud row label

### DIFF
--- a/src/features/backup/components/backup-wallet-prompt/CloudBackupOptionRow.tsx
+++ b/src/features/backup/components/backup-wallet-prompt/CloudBackupOptionRow.tsx
@@ -43,14 +43,7 @@ export function CloudBackupOptionRow() {
   const disabled = status !== CloudBackupState.Ready && status !== CloudBackupState.NotAvailable;
 
   const { color, text } = useMemo<{ text: string; color: TextColor | CustomColor }>(() => {
-    if (status === CloudBackupState.FailedToInitialize || status === CloudBackupState.NotAvailable) {
-      return {
-        text: i18n.t(i18n.l.back_up.cloud.statuses.not_enabled),
-        color: 'primary (Deprecated)',
-      };
-    }
-
-    if (status === CloudBackupState.Ready) {
+    if (status === CloudBackupState.FailedToInitialize || status === CloudBackupState.NotAvailable || status === CloudBackupState.Ready) {
       return {
         text: i18n.t(i18n.l.back_up.cloud.cloud_backup),
         color: 'primary (Deprecated)',


### PR DESCRIPTION
The wallet backup prompt sheet currently labels its cloud row with the row's status ("Not Enabled") instead of the row name when cloud backup isn't enabled on the device. The row is still tappable in that state, so users see two options titled "Not Enabled" and "Manual backup"; tapping "Not Enabled" actually enables cloud backup, which is confusing.

This change always uses "Cloud Backup" as the row name except during the genuine loading states, where the yellow "Syncing" label is preserved.

Closes APP-3398.

Before | After
--|--
<img width="200" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 23 37 56" src="https://github.com/user-attachments/assets/b296a5f7-76cb-4855-b250-9b0f060702ab" /> | <img width="200"  alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 23 37 12" src="https://github.com/user-attachments/assets/b8300ed0-89ca-4e2c-bf2a-2e762f7e3d5f" />
