### PR TITLE
Add Tea Mainnet support

### DIFF
--- a/src/state/appSessions/index.ts
+++ b/src/state/appSessions/index.ts
@@ -24,6 +24,7 @@ const chainsIdByNetwork: Record<Network, ChainId> = {
   [Network.gnosis]: ChainId.gnosis,
   [Network.blast]: ChainId.blast,
   [Network.goerli]: ChainId.goerli,
+  [Network.tea]: ChainId.tea,
 };
 
 export interface AppSessionV0 {

--- a/src/state/backendNetworks/backendNetworks.test.ts
+++ b/src/state/backendNetworks/backendNetworks.test.ts
@@ -1,0 +1,154 @@
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { ChainId, type BackendNetwork } from '@/state/backendNetworks/types';
+
+const mockFetchBackendNetworks = jest.fn();
+
+jest.mock('@/resources/metadata/backendNetworks', () => ({
+  fetchBackendNetworks: () => mockFetchBackendNetworks(),
+}));
+
+jest.mock('@/references/networks.json', () => ({ networks: [] }), { virtual: true });
+
+function buildTeaNetwork(): BackendNetwork {
+  return {
+    id: '6122',
+    name: 'tea',
+    label: 'Tea',
+    colors: {
+      light: '#00A86B',
+      dark: '#00C781',
+    },
+    icons: {
+      badgeURL: 'https://example.com/tea-badge.png',
+    },
+    testnet: false,
+    internal: false,
+    opStack: true,
+    defaultExplorer: {
+      url: 'https://explorer.tea.xyz',
+      label: 'Tea Explorer',
+      transactionURL: 'https://explorer.tea.xyz/tx/{hash}',
+      tokenURL: 'https://explorer.tea.xyz/token/{address}',
+    },
+    defaultRPC: {
+      enabledDevices: ['APP'],
+      url: 'https://rpc.tea.xyz',
+    },
+    gasUnits: {
+      basic: {
+        approval: '60000',
+        eoaTransfer: '21000',
+        swap: '200000',
+        swapPermit: '200000',
+        tokenTransfer: '65000',
+      },
+      wrapped: {
+        wrap: '50000',
+        unwrap: '50000',
+      },
+    },
+    nativeAsset: {
+      address: 'eth',
+      name: 'Tea',
+      symbol: 'TEA',
+      decimals: 18,
+      iconURL: 'https://example.com/tea.png',
+      colors: {
+        primary: '#00A86B',
+        fallback: '#E4FFF3',
+        shadow: '#00A86B',
+      },
+    },
+    nativeWrappedAsset: {
+      address: '0x0000000000000000000000000000000000000000',
+      name: 'Wrapped Tea',
+      symbol: 'WTEA',
+      decimals: 18,
+      iconURL: 'https://example.com/wtea.png',
+      colors: {
+        primary: '#00A86B',
+        fallback: '#E4FFF3',
+        shadow: '#00A86B',
+      },
+    },
+    enabledServices: {
+      addys: {
+        approvals: true,
+        assets: true,
+        interactionsWith: true,
+        positions: false,
+        transactions: true,
+      },
+      launcher: {
+        v1: {
+          enabled: false,
+          contractAddress: '0x0000000000000000000000000000000000000000',
+        },
+      },
+      meteorology: {
+        enabled: true,
+      },
+      nftProxy: {
+        enabled: false,
+      },
+      notifications: {
+        enabled: true,
+      },
+      sponsorship: {
+        enabled: true,
+      },
+      swap: {
+        bridge: false,
+        bridgeExactOutput: false,
+        enabled: false,
+        swap: false,
+        swapExactOutput: false,
+      },
+      tokenSearch: {
+        enabled: true,
+      },
+    },
+  };
+}
+
+describe('backendNetworks', () => {
+  beforeEach(() => {
+    mockFetchBackendNetworks.mockReset();
+    useBackendNetworksStore.setState({
+      backendChains: [],
+      backendNetworks: [],
+      enabled: true,
+    });
+  });
+
+  afterEach(() => {
+    useBackendNetworksStore.getState().reset();
+  });
+
+  it('supports Tea mainnet metadata from backend networks', async () => {
+    mockFetchBackendNetworks.mockResolvedValue({
+      networks: [buildTeaNetwork()],
+    });
+
+    await useBackendNetworksStore.getState().fetch(undefined, { force: true });
+
+    expect(useBackendNetworksStore.getState().getSupportedMainnetChainIds()).toContain(ChainId.tea);
+    expect(useBackendNetworksStore.getState().getNeedsL1SecurityFeeChains()).toContain(ChainId.tea);
+    expect(useBackendNetworksStore.getState().getChainsName()[ChainId.tea]).toBe('tea');
+    expect(useBackendNetworksStore.getState().getDefaultChains()[ChainId.tea]).toMatchObject({
+      id: 6122,
+      name: 'Tea',
+      nativeCurrency: {
+        decimals: 18,
+        name: 'Tea',
+        symbol: 'TEA',
+      },
+      blockExplorers: {
+        default: {
+          name: 'Tea Explorer',
+          url: 'https://explorer.tea.xyz',
+        },
+      },
+    });
+  });
+});

--- a/src/state/backendNetworks/types.ts
+++ b/src/state/backendNetworks/types.ts
@@ -29,6 +29,7 @@ export enum Network {
   scroll = 'scroll',
   zksync = 'zksync',
   zora = 'zora',
+  tea = 'tea',
 }
 
 export enum ChainId {
@@ -66,6 +67,7 @@ export enum ChainId {
   sanko = chain.sanko.id,
   scroll = chain.scroll.id,
   sepolia = chain.sepolia.id,
+  tea = 6122,
   zksync = chain.zksync.id,
   zora = chain.zora.id,
   zoraSepolia = chain.zoraSepolia.id,
@@ -106,6 +108,7 @@ export enum ChainName {
   sanko = 'sanko',
   scroll = 'scroll',
   sepolia = 'sepolia',
+  tea = 'tea',
   zksync = 'zksync',
   zora = 'zora',
   zoraSepolia = 'zora-sepolia',


### PR DESCRIPTION
Fixes #7461

## What changed (plus any additional context for devs)

- Added local Tea network identifiers for backend-provided Tea Mainnet metadata.
- Mapped the legacy `Network.tea` app session value to `ChainId.tea` so session migrations can resolve the chain.
- Added a backend network regression test proving Tea metadata becomes a supported mainnet chain and is included in OP Stack L1 security fee handling.

## Screen recordings / screenshots

N/A - metadata/type support only.

## What to test

- `yarn jest src/state/backendNetworks/backendNetworks.test.ts`
- `yarn jest src/state/backendNetworks/backendNetworks.test.ts --runInBand`
- `yarn prettier --check src/state/backendNetworks/backendNetworks.test.ts src/state/backendNetworks/types.ts src/state/appSessions/index.ts`
- `yarn eslint --cache src/state/backendNetworks/backendNetworks.test.ts src/state/backendNetworks/types.ts src/state/appSessions/index.ts --quiet`

Not fully verified locally:

- `yarn lint:ts` and `yarn lint:js --quiet` are currently blocked by missing generated `src/graphql/__generated__/ens.ts`. Running `yarn graphql-codegen` also fails without `GRAPH_ENS_API_KEY` because The Graph rejects ENS schema introspection with a missing API key error.