### PR TITLE
fix(notifications): silence WC FCM token warning when permission is denied

### DIFF
--- a/src/features/wallet-connect/handlers/listeners.ts
+++ b/src/features/wallet-connect/handlers/listeners.ts
@@ -1,7 +1,6 @@
 import messaging from '@react-native-firebase/messaging';
 import { gretch } from 'gretchen';
 
-import { IS_DEV } from '@/env';
 import { events } from '@/handlers/appEvents';
 import { logger, RainbowError } from '@/logger';
 import { getFCMToken } from '@/notifications/tokens';
@@ -37,31 +36,19 @@ export async function initListeners() {
 export async function initWalletConnectPushNotifications() {
   try {
     const token = await getFCMToken();
-
-    if (token) {
-      const client = await getWalletKitClient();
-      const client_id = await client.core.crypto.getClientId();
-
-      // initial subscription
-      await subscribeToEchoServer({ token, client_id });
-
-      /**
-       * Ensure that if the FCM token changes we update the echo server
-       */
-      messaging().onTokenRefresh(async (token: string) => {
-        await subscribeToEchoServer({ token, client_id });
-      });
-    } else {
-      if (!IS_DEV) {
-        /*
-         * If we failed to fetch an FCM token, this will fail too. You should
-         * see these errors increase proportionally if something goes wrong,
-         * which could be due to network flakiness, SSL server error (has
-         * happened), etc. Things out of our control.
-         */
-        logger.warn(`[walletConnect]: FCM token not found, push notifications will not be received`);
-      }
+    if (!token) {
+      // No token here means push isn't available for this user; nothing to subscribe.
+      return;
     }
+
+    const client = await getWalletKitClient();
+    const client_id = await client.core.crypto.getClientId();
+
+    await subscribeToEchoServer({ token, client_id });
+
+    messaging().onTokenRefresh(async (token: string) => {
+      await subscribeToEchoServer({ token, client_id });
+    });
   } catch (e) {
     logger.error(new RainbowError(`[walletConnect]: initListeners failed`), { error: e });
   }

--- a/src/notifications/tokens.ts
+++ b/src/notifications/tokens.ts
@@ -12,13 +12,13 @@ export const registerTokenRefreshListener = () =>
   });
 
 export const saveFCMToken = async (): Promise<string | null> => {
-  const permissionStatus = await getPermissionStatus();
-  if (!isNotificationPermissionGranted(permissionStatus)) {
-    // Expected state for users who declined permission prompt or have not yet been prompted.
-    return null;
-  }
-
   try {
+    const permissionStatus = await getPermissionStatus();
+    if (!isNotificationPermissionGranted(permissionStatus)) {
+      // Expected state for users who declined permission prompt or have not yet been prompted.
+      return null;
+    }
+
     const fcmToken = await messaging().getToken();
     if (!fcmToken) {
       logger.warn('[notifications]: messaging().getToken() returned empty despite granted permission', {
@@ -29,10 +29,7 @@ export const saveFCMToken = async (): Promise<string | null> => {
     saveLocal(RAINBOW_FCM_TOKEN_KEY, { data: fcmToken });
     return fcmToken;
   } catch (error) {
-    logger.warn('[notifications]: messaging().getToken() threw', {
-      error,
-      permissionStatus,
-    });
+    logger.warn('[notifications]: saveFCMToken failed', { error });
     return null;
   }
 };

--- a/src/notifications/tokens.ts
+++ b/src/notifications/tokens.ts
@@ -12,19 +12,26 @@ export const registerTokenRefreshListener = () =>
   });
 
 export const saveFCMToken = async (): Promise<string | null> => {
-  try {
-    const permissionStatus = await getPermissionStatus();
-    if (isNotificationPermissionGranted(permissionStatus)) {
-      const fcmToken = await messaging().getToken();
-      if (fcmToken) {
-        saveLocal(RAINBOW_FCM_TOKEN_KEY, { data: fcmToken });
-        return fcmToken;
-      }
-    }
+  const permissionStatus = await getPermissionStatus();
+  if (!isNotificationPermissionGranted(permissionStatus)) {
+    // Expected state for users who declined permission prompt or have not yet been prompted.
     return null;
+  }
+
+  try {
+    const fcmToken = await messaging().getToken();
+    if (!fcmToken) {
+      logger.warn('[notifications]: messaging().getToken() returned empty despite granted permission', {
+        permissionStatus,
+      });
+      return null;
+    }
+    saveLocal(RAINBOW_FCM_TOKEN_KEY, { data: fcmToken });
+    return fcmToken;
   } catch (error) {
-    logger.warn('[notifications]: Error while getting and saving FCM token', {
+    logger.warn('[notifications]: messaging().getToken() threw', {
       error,
+      permissionStatus,
     });
     return null;
   }


### PR DESCRIPTION
We have logging for `[walletConnect]: FCM token not found` in WC code that fires for every user without notification permission, not just for users where the FCM mint actually failed. Because we silently return null when permission isn't granted, the WC consumer sees null, and the warn captures it as a Sentry event. The issue has accumulated [~24k events / ~15k users since December](https://rainbow-me.sentry.io/issues/7315295126/?environment=Release&environment=ReleaseAndroid&environment=production&project=1855565&query=is%3Aunresolved%20FCM%20token%20not%20found%2C%20push%20notifications%20will%20not%20be%20received&referrer=issue-stream) and drowns out the genuine signal the warn was meant to monitor (mint failing, not permission denied, which is expected for some users).

This change moves the failure warn into the FCM mint helper itself and distinguishes the two real failure modes (`getToken()` returned empty, `getToken()` threw) from the benign permission-denied case. Each warn carries `permissionStatus` as extra so the platform/condition is filterable in Sentry. The WC subscription site is changed to only no-op (and not log) when there's no token.

The new warns should produce small, actionable Sentry issues at the real FCM failure rate, and remove most of the noise from above issue.