### PR TITLE
fix: Branch listener Sentry noise

### DIFF
--- a/src/utils/branch.ts
+++ b/src/utils/branch.ts
@@ -18,13 +18,11 @@ export const branchListener = async (handleOpenLinkingURL: (url: string) => void
    */
   const unsubscribe = branch.subscribe(({ error, params, uri }) => {
     if (error) {
-      switch (error) {
-        case 'Trouble reaching the Branch servers, please try again shortly.':
-          break;
-        default:
-          logger.error(new RainbowError(`[branchListener]: error when handling event`), {
-            error,
-          });
+      const isNetworkNoise = error.includes('poor network connectivity') || error.includes('Trouble reaching the Branch servers');
+      if (isNetworkNoise) {
+        logger.debug(`[branchListener]: network noise`, { error }, logger.DebugContext.deeplinks);
+      } else {
+        logger.warn(`[branchListener]: error when handling event`, { error });
       }
     }
 


### PR DESCRIPTION
Sentry issue ([RAINBOW-WALLET-3XAM)](https://rainbow-me.sentry.io/issues/?environment=Release&environment=ReleaseAndroid&environment=production&project=1855565&query=is%3Aunresolved%20branchListener&referrer=issue-list&statsPeriod=7d) has accumulated since mid-December, all surfacing the same underlying failure: the Branch SDK fails to reach its init endpoint on a flaky network and reports it via the subscribe callback. In this case we can't do anything on our end, so we already filtered one wording of that failure, but the iOS and Android Branch SDKs emit different strings for the same condition and our switch only matched the iOS one. That's why we're still seeing so many events in Sentry and ~97% of it are Android.

This change replaces the exact-string check with a substring match on the two stable phrases the SDKs use (`"poor network connectivity"` on Android, `"Trouble reaching the Branch servers"` on iOS), so the same condition is dropped on both platforms. The match should also survive wording drift in future SDK bumps; the newer Android SDK already inserts the request name into the message, but keeps these substrings. Note: I investigated if there's better ways to detect this state than string matching, but it doesn't seem like it, not even in the latest Branch SDKs.

The change also degragdes the real error branch from `logger.error` to `logger.warn` since Branch init failing is not a critical issue; deep links conitnue to work, we just loose attribution in a few cases.

Result should be much less unactionable Sentry noise for this specific issue.