### PR TITLE
fix(notifications): drop redundant FCM token MMKV storage

### DIFF
--- a/src/hooks/useApplicationSetup.ts
+++ b/src/hooks/useApplicationSetup.ts
@@ -9,7 +9,6 @@ import {
 import { loadAddress } from '@/model/wallet';
 import { type InitialRoute } from '@/navigation/initialRoute';
 import Routes from '@/navigation/routesNames';
-import { saveFCMToken } from '@/notifications/tokens';
 import { PerformanceReports, PerformanceTracking } from '@/performance/tracking';
 import { initializeWallet } from '@/state/wallets/initializeWallet';
 
@@ -26,9 +25,7 @@ export function useApplicationSetup() {
 async function runSetup(setInitialRoute: Dispatch<SetStateAction<InitialRoute>>): Promise<void> {
   const address = await loadAddress();
 
-  Promise.all([initWalletConnectListeners(), saveFCMToken()]).then(() => {
-    initWalletConnectPushNotifications();
-  });
+  initWalletConnectListeners().then(initWalletConnectPushNotifications);
 
   if (address) {
     void initializeWallet({ shouldRunMigrations: true });

--- a/src/notifications/NotificationsHandler.tsx
+++ b/src/notifications/NotificationsHandler.tsx
@@ -25,7 +25,6 @@ import { WalletNotificationRelationship } from '@/notifications/settings/constan
 import { initializeNotificationSettingsForAllAddresses } from '@/notifications/settings/initialization';
 import type { AddressWithRelationship } from '@/notifications/settings/types';
 import { setupAndroidChannels } from '@/notifications/setupAndroidChannels';
-import { registerTokenRefreshListener, saveFCMToken } from '@/notifications/tokens';
 import {
   NotificationTypes,
   type FixedRemoteMessage,
@@ -47,7 +46,6 @@ export const NotificationsHandler = () => {
   const wallets = useWallets();
   const dispatch: ThunkDispatch<AppState, unknown, AnyAction> = useDispatch();
   const subscriptionChangesListener = useRef<NotificationSubscriptionChangesListener>(undefined);
-  const onTokenRefreshListener = useRef<Callback>(undefined);
   const foregroundNotificationListener = useRef<Callback>(undefined);
   const notificationOpenedListener = useRef<Callback>(undefined);
   const appStateListener = useRef<NativeEventSubscription>(undefined);
@@ -182,10 +180,8 @@ export const NotificationsHandler = () => {
     };
 
     setupAndroidChannels();
-    saveFCMToken();
     trackWalletsSubscribedForNotifications();
     subscriptionChangesListener.current = registerNotificationSubscriptionChangesListener();
-    onTokenRefreshListener.current = registerTokenRefreshListener();
     foregroundNotificationListener.current = messaging().onMessage(onForegroundRemoteNotification);
     messaging().getInitialNotification().then(handleAppOpenedWithNotification);
     notificationOpenedListener.current = messaging().onNotificationOpenedApp(handleAppOpenedWithNotification);
@@ -200,7 +196,6 @@ export const NotificationsHandler = () => {
 
     return () => {
       subscriptionChangesListener.current?.remove();
-      onTokenRefreshListener.current?.();
       foregroundNotificationListener.current?.();
       notificationOpenedListener.current?.();
       appStateListener.current?.remove();

--- a/src/notifications/permissions.ts
+++ b/src/notifications/permissions.ts
@@ -6,7 +6,6 @@ import { logger, RainbowError } from '@/logger';
 import { trackPushNotificationPermissionStatus } from '@/notifications/analytics';
 import { subscribeExistingNotificationsSettings } from '@/notifications/settings/initialization';
 import { notificationSettingsStorage } from '@/notifications/settings/storage';
-import { saveFCMToken } from '@/notifications/tokens';
 
 const HAS_SHOWN_PERMISSION_SCREEN_KEY = 'hasShownNotificationPermissionScreen';
 
@@ -49,7 +48,6 @@ export const checkPushNotificationPermissions = async () => {
                 const status = await requestNotificationPermission();
                 const enabled = isNotificationPermissionGranted(status);
                 trackPushNotificationPermissionStatus(enabled ? 'enabled' : 'disabled');
-                await saveFCMToken();
               } catch (error) {
                 logger.error(new RainbowError('[notifications]: Error while getting permissions'), { error });
               } finally {

--- a/src/notifications/settings/firebase.ts
+++ b/src/notifications/settings/firebase.ts
@@ -7,7 +7,7 @@ import {
   type NotificationSubscriptionWalletsType,
   type WalletNotificationSettings,
 } from '@/notifications/settings/types';
-import { getFCMToken, saveFCMToken } from '@/notifications/tokens';
+import { getFCMToken } from '@/notifications/tokens';
 
 const NOTIFICATION_SUBSCRIPTIONS_URL = 'https://notifications.p.rainbow.me/api/v1/subscriptions';
 
@@ -82,7 +82,7 @@ const updateNotificationSubscriptionWithRetry = async ({
     return true;
   } else if (subscriptionResponse.shouldRetry) {
     // retry with an updated FCM token
-    const refreshedFirebaseToken = await saveFCMToken();
+    const refreshedFirebaseToken = await getFCMToken();
     if (!refreshedFirebaseToken) return false;
 
     const subscriptionRetryResponse = await updateNotificationSubscription({
@@ -107,13 +107,8 @@ export const publishWalletSettings = async ({
   try {
     const wallets = parseWalletSettings(walletSettings);
     const marketingTopics = Object.keys(globalSettings).filter(topic => globalSettings[topic]);
-    let firebaseToken = await getFCMToken();
-
-    // refresh the FCM token if not found
-    if (!firebaseToken) {
-      firebaseToken = await saveFCMToken();
-      if (!firebaseToken) return;
-    }
+    const firebaseToken = await getFCMToken();
+    if (!firebaseToken) return;
 
     const success = await updateNotificationSubscriptionWithRetry({ firebaseToken, marketingTopics, wallets });
     if (success) {

--- a/src/notifications/tokens.ts
+++ b/src/notifications/tokens.ts
@@ -1,46 +1,32 @@
 import messaging from '@react-native-firebase/messaging';
 
-import { getLocal, saveLocal } from '@/handlers/localstorage/common';
 import { logger } from '@/logger';
 import { getPermissionStatus, isNotificationPermissionGranted } from '@/notifications/permissions';
 
-const RAINBOW_FCM_TOKEN_KEY = 'rainbowFcmToken';
-
-export const registerTokenRefreshListener = () =>
-  messaging().onTokenRefresh(fcmToken => {
-    saveLocal(RAINBOW_FCM_TOKEN_KEY, { data: fcmToken });
-  });
-
-export const saveFCMToken = async (): Promise<string | null> => {
+/**
+ * Reads the current FCM token from Firebase's native cache. The SDK refreshes
+ * the cache on rotation including while the app is killed or backgrounded,
+ * so callers should read fresh on every use rather than holding the value.
+ */
+export async function getFCMToken(): Promise<string | null> {
   try {
-    const permissionStatus = await getPermissionStatus();
-    if (!isNotificationPermissionGranted(permissionStatus)) {
-      // Expected state for users who declined permission prompt or have not yet been prompted.
-      return null;
-    }
-
     const fcmToken = await messaging().getToken();
     if (!fcmToken) {
-      logger.warn('[notifications]: messaging().getToken() returned empty despite granted permission', {
-        permissionStatus,
-      });
+      logger.warn('[notifications]: messaging().getToken() returned empty');
       return null;
     }
-    saveLocal(RAINBOW_FCM_TOKEN_KEY, { data: fcmToken });
     return fcmToken;
   } catch (error) {
-    logger.warn('[notifications]: saveFCMToken failed', { error });
+    // On iOS, messaging().getToken() throws for users without an APNs token,
+    // which is the expected state when permission was never granted. Only warn
+    // when permission is granted, so this surfaces genuine mint failures and
+    // stays quiet on the expected path.
+    const granted = await getPermissionStatus()
+      .then(isNotificationPermissionGranted)
+      .catch(() => false);
+    if (granted) {
+      logger.warn('[notifications]: getFCMToken failed', { error });
+    }
     return null;
   }
-};
-
-export async function getFCMToken(): Promise<string | null> {
-  const fcmTokenLocal = await getLocal(RAINBOW_FCM_TOKEN_KEY);
-  const token = fcmTokenLocal?.data || null;
-
-  if (!token) {
-    logger.debug('[notifications]: getFCMToken No FCM token found');
-  }
-
-  return token;
 }


### PR DESCRIPTION
We currently cache the FCM token in MMKV alongside Firebase's own native cache, so two copies of the same token can drift apart. Firebase's `onTokenRefresh` only fires while the app is active; when the SDK rotates the token while we're killed or backgrounded, our mirror goes stale while Firebase's cache stays correct. We then send the stale value to the WC echo server and notifications backend, which keep routing pushes to a dead address until the next app launch repopulates the mirror. Users silently miss WC approval requests and transaction alerts in the meantime. The noisy Sentry warning fixed in #7508 was another downstream symptom.

This change makes Firebase the single source of truth. `getFCMToken` reads from `messaging().getToken()` directly; the startup priming, refresh listener, and post-grant prime become redundant and are removed. The read no longer gates on OS permission so subscription removals can still publish for users who revoke after granting. Token-read failures are only reported when permission is granted, which keeps the #7508 noise suppressed for users who never granted.