### PR TITLE
chore: handle network related error on WC echo server subscription

### DIFF
--- a/src/features/wallet-connect/handlers/listeners.test.ts
+++ b/src/features/wallet-connect/handlers/listeners.test.ts
@@ -1,0 +1,131 @@
+import messaging from '@react-native-firebase/messaging';
+import { gretch } from 'gretchen';
+
+import { logger } from '@/logger';
+import { getFCMToken } from '@/notifications/tokens';
+import { delay } from '@/utils/delay';
+
+import { getWalletKitClient } from '../services/client';
+import { initWalletConnectPushNotifications } from './listeners';
+
+jest.mock('@react-native-firebase/messaging', () => jest.fn());
+jest.mock('gretchen', () => ({
+  gretch: jest.fn(),
+}));
+jest.mock('@/logger', () => ({
+  RainbowError: class RainbowError extends Error {},
+  logger: {
+    DebugContext: { walletconnect: 'walletconnect' },
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+jest.mock('@/notifications/tokens', () => ({
+  getFCMToken: jest.fn(),
+}));
+jest.mock('@/utils/delay', () => ({
+  delay: jest.fn(),
+}));
+jest.mock('../services/client', () => ({
+  getWalletKitClient: jest.fn(),
+}));
+jest.mock('@/env', () => ({
+  IS_DEV: false,
+}));
+jest.mock('@/handlers/appEvents', () => ({
+  events: { emit: jest.fn() },
+}));
+jest.mock('@/performance/tracking', () => ({
+  PerformanceReportSegments: { appStartup: { initWalletConnect: 'initWalletConnect' } },
+  PerformanceReports: { appStartup: 'appStartup' },
+  PerformanceTracking: {
+    finishReportSegment: jest.fn(),
+    startReportSegment: jest.fn(),
+  },
+}));
+jest.mock('../services/syncClient', () => ({
+  setSyncWalletKitClient: jest.fn(),
+}));
+jest.mock('./onSessionProposal', () => ({
+  onSessionProposal: jest.fn(),
+}));
+jest.mock('./onSessionRequest', () => ({
+  onSessionRequest: jest.fn(),
+}));
+
+const mockDelay = delay as jest.Mock;
+const mockGetClientId = jest.fn();
+const mockGetFCMToken = getFCMToken as jest.Mock;
+const mockGetWalletKitClient = getWalletKitClient as jest.Mock;
+const mockGretch = gretch as jest.Mock;
+const mockLogger = logger as unknown as {
+  error: jest.Mock;
+  warn: jest.Mock;
+};
+const mockMessaging = messaging as unknown as jest.Mock;
+const mockOnTokenRefresh = jest.fn();
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  mockMessaging.mockReturnValue({ onTokenRefresh: mockOnTokenRefresh });
+  mockGetFCMToken.mockResolvedValue('fcm-token');
+  mockGetClientId.mockResolvedValue('client-id');
+  mockGetWalletKitClient.mockResolvedValue({
+    core: {
+      crypto: {
+        getClientId: mockGetClientId,
+      },
+    },
+  });
+  mockDelay.mockResolvedValue(undefined);
+});
+
+describe('initWalletConnectPushNotifications', () => {
+  test('retries HTTPTimeout errors and does not warn when retries are exhausted', async () => {
+    // gretchen does produce this error on Timeout
+    const timeoutError = new Error('Request timed out');
+    timeoutError.name = 'HTTPTimeout';
+    mockEchoServerResponse({ error: timeoutError });
+    mockEchoServerResponse({ error: timeoutError });
+    mockEchoServerResponse({ error: timeoutError });
+
+    await initWalletConnectPushNotifications();
+
+    expect(mockGretch).toHaveBeenCalledTimes(3);
+    expect(mockDelay).toHaveBeenCalledTimes(2);
+    expect(mockDelay).toHaveBeenNthCalledWith(1, 1_000);
+    expect(mockDelay).toHaveBeenNthCalledWith(2, 2_000);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  test('retries network errors and does not warn if retry succeeds', async () => {
+    mockEchoServerResponse({ error: new TypeError('Network request failed') });
+    mockEchoServerResponse();
+
+    await initWalletConnectPushNotifications();
+
+    expect(mockGretch).toHaveBeenCalledTimes(2);
+    expect(mockDelay).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  test('warns without retrying for non-transient errors', async () => {
+    const parseError = new SyntaxError('JSON Parse error: Unexpected character: <');
+    mockEchoServerResponse({ error: parseError });
+
+    await initWalletConnectPushNotifications();
+
+    expect(mockGretch).toHaveBeenCalledTimes(1);
+    expect(mockDelay).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(`[walletConnect]: echo server subscription failed`, {
+      error: parseError,
+    });
+  });
+});
+
+function mockEchoServerResponse({ error }: { error?: unknown } = {}) {
+  mockGretch.mockReturnValueOnce({
+    json: jest.fn().mockResolvedValue(error ? { error } : { data: {} }),
+  });
+}

--- a/src/features/wallet-connect/handlers/listeners.ts
+++ b/src/features/wallet-connect/handlers/listeners.ts
@@ -5,11 +5,15 @@ import { events } from '@/handlers/appEvents';
 import { logger, RainbowError } from '@/logger';
 import { getFCMToken } from '@/notifications/tokens';
 import { PerformanceReports, PerformanceReportSegments, PerformanceTracking } from '@/performance/tracking';
+import { delay } from '@/utils/delay';
 
 import { getWalletKitClient } from '../services/client';
 import { setSyncWalletKitClient } from '../services/syncClient';
 import { onSessionProposal } from './onSessionProposal';
 import { onSessionRequest } from './onSessionRequest';
+
+const ECHO_SERVER_SUBSCRIPTION_MAX_ATTEMPTS = 3;
+const ECHO_SERVER_SUBSCRIPTION_RETRY_DELAY_MS = 1_000;
 
 export async function initListeners() {
   PerformanceTracking.startReportSegment(PerformanceReports.appStartup, PerformanceReportSegments.appStartup.initWalletConnect);
@@ -55,23 +59,44 @@ export async function initWalletConnectPushNotifications() {
 }
 
 async function subscribeToEchoServer({ client_id, token }: { client_id: string; token: string }) {
-  const res = await gretch(`https://wcpush.p.rainbow.me/clients`, {
-    method: 'POST',
-    json: {
-      type: 'FCM',
-      client_id,
-      token,
-    },
-  }).json();
+  let error: unknown;
 
-  if (res.error) {
+  for (let attempt = 0; attempt < ECHO_SERVER_SUBSCRIPTION_MAX_ATTEMPTS; attempt++) {
+    if (attempt) {
+      await delay(ECHO_SERVER_SUBSCRIPTION_RETRY_DELAY_MS * attempt);
+    }
+
+    const res = await gretch(`https://wcpush.p.rainbow.me/clients`, {
+      method: 'POST',
+      json: {
+        type: 'FCM',
+        client_id,
+        token,
+      },
+    }).json();
+
+    if (!res.error) return;
+
+    if (!isRetryableEchoServerSubscriptionError(res.error)) {
+      error = res.error;
+      break;
+    }
+  }
+
+  if (error) {
     /*
-     * Most of these appear to be network errors and timeouts. So our backend
-     * should report these to Datadog, and we can leave this as a warn to
-     * continue to monitor.
+     * Network errors and timeouts are expected to be transient and are retried
+     * above. Keep this warning for unexpected response/parsing failures.
      */
     logger.warn(`[walletConnect]: echo server subscription failed`, {
-      error: res.error,
+      error,
     });
   }
+}
+
+function isRetryableEchoServerSubscriptionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name.includes('HTTPTimeout') || error.message.includes('Request timed out') || error.message.includes('Network request failed'))
+  );
 }


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3749/sentry-spam-walletconnect-echo-server-subscription-failed

## What changed (plus any additional context for devs)

The echo server subscription logic now retries on transient errors (HTTP timeouts and network failures) up to 3 times with linear backoff (1s, 2s), rather than immediately logging a warning on any failure. Non-transient errors (e.g. JSON parse failures) still log a warning immediately without retrying.

Previously, every timeout or network blip would produce a warning log. Now those are silently retried, and a warning is only emitted for unexpected failures that are unlikely to resolve on retry.