### PR TITLE
feat(ios): per-host Sentry grouping for RS escapes

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -70,11 +70,19 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate {
 
   @objc func handleRsEscape(notification: Notification) {
     guard let url = notification.userInfo?["url"] as? String else { return }
-    let msg = "Escape via \(url)"
-    let breadcrumb = Breadcrumb()
-    breadcrumb.message = msg
-    SentrySDK.addBreadcrumb(breadcrumb)
-    SentrySDK.capture(message: msg)
+    let host = URL(string: url)?.host ?? url
+
+    // Per-host fingerprint so each blocked host becomes its own Sentry issue.
+    // Without this, every capture call here shares the same stack and Sentry
+    // collapses all hosts into one mega-issue, making per-host trends and
+    // alerts impossible.
+    let event = Event()
+    event.message = SentryMessage(formatted: "Escape via \(host)")
+    event.level = .warning
+    event.fingerprint = ["rnsandbox-escape", host]
+    event.tags = ["sandbox.host": host]
+    event.extra = ["sandbox.url": url]
+    SentrySDK.capture(event: event)
   }
 
   @objc func handleRapInProgress(notification: Notification) {

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -70,17 +70,25 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate {
 
   @objc func handleRsEscape(notification: Notification) {
     guard let url = notification.userInfo?["url"] as? String else { return }
-    let host = URL(string: url)?.host ?? url
+    let parsed = URL(string: url)
+    let host = parsed?.host
+    // Group by host. Hostless URLs (data:, blob:, malformed) have no host, so
+    // fall back to the scheme, then "unknown" — keeps the fingerprint bounded
+    // instead of spawning a Sentry issue per unique data: payload. The tag
+    // below stays a real host only; the full URL is preserved in the extra.
+    let groupingKey = host ?? parsed?.scheme ?? "unknown"
 
     // Per-host fingerprint so each blocked host becomes its own Sentry issue.
     // Without this, every capture call here shares the same stack and Sentry
     // collapses all hosts into one mega-issue, making per-host trends and
     // alerts impossible.
     let event = Event()
-    event.message = SentryMessage(formatted: "Escape via \(host)")
+    event.message = SentryMessage(formatted: "Escape via \(groupingKey)")
     event.level = .warning
-    event.fingerprint = ["rnsandbox-escape", host]
-    event.tags = ["sandbox.host": host]
+    event.fingerprint = ["rnsandbox-escape", groupingKey]
+    if let host {
+      event.tags = ["sandbox.host": host]
+    }
     event.extra = ["sandbox.url": url]
     SentrySDK.capture(event: event)
   }


### PR DESCRIPTION
iOS RS events are reported to Sentry today with the default fingerprint, which is stack-trace based. Since every report originates from the same line in `handleRsEscape`, all events across all hosts collapse into a single mega-issue, making it impossible to see per-host trends or set up "new host in RS traffic" alerting.

This change gives each event a per-host fingerprint and host tag, so every host becomes its own Sentry issue with discoverable, queryable values. The issue title switches from the full URL to just the host to keep titles clean, with the full URL preserved as event data for drill-down. Hostless URLs (e.g. `data:`) fall back to their scheme so grouping stays bounded instead of spawning an issue per payload.

Smaller changes included here:
* The per-event breadcrumb is dropped. It duplicated the captured event's own message, and at the volume we see it would fill our `maxBreadcrumbs: 10` buffer in busy dapp sessions, pushing out genuinely useful trail context.
* The level is changed from `info` to `warning`.

iOS counterpart to the Android PR on the other repo. Together the two bring per-host Sentry grouping to both platforms.