### PR TITLE
refactor: move marquee list and speed animation into framework/ui

### DIFF
--- a/src/components/list/index.js
+++ b/src/components/list/index.js
@@ -3,5 +3,4 @@ export { default as ListFooter } from './ListFooter';
 export { default as ListHeader, ListHeaderHeight } from './ListHeader';
 export { default as ListItem } from './ListItem';
 export { default as ListItemDivider } from './ListItemDivider';
-export { default as MarqueeList } from './MarqueeList';
 export { default as NoResults } from './NoResults';

--- a/src/features/ens/components/registration/IntroMarquee.tsx
+++ b/src/features/ens/components/registration/IntroMarquee.tsx
@@ -4,8 +4,8 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ImgixImage } from '@/components/images';
-import { MarqueeList } from '@/components/list';
 import { Box, Stack, Text } from '@/design-system';
+import { MarqueeList } from '@/framework/ui/components/MarqueeList';
 import { type EnsMarqueeAccount } from '@/graphql/__generated__/metadata';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';

--- a/src/framework/ui/animations/withSpeed.ts
+++ b/src/framework/ui/animations/withSpeed.ts
@@ -1,6 +1,6 @@
 import { defineAnimation } from 'react-native-reanimated';
 
-export default function withSpeed(userConfig: any) {
+export function withSpeed(userConfig: any) {
   'worklet';
 
   return defineAnimation(0, () => {

--- a/src/framework/ui/components/MarqueeList.js
+++ b/src/framework/ui/components/MarqueeList.js
@@ -5,7 +5,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { cancelAnimation, runOnJS, useAnimatedStyle, useDerivedValue, useSharedValue, withDecay } from 'react-native-reanimated';
 
-import withSpeed from '@/utils/withSpeed';
+import { withSpeed } from '@/framework/ui/animations/withSpeed';
 
 const DECCELERATION = 0.998;
 
@@ -168,7 +168,7 @@ const SwipeableList = ({ components, height, speed, testID }) => {
   );
 };
 
-const MarqueeList = ({ height, items = /** @type {any[]} */ ([]), renderItem, speed, testID }) => {
+export const MarqueeList = ({ height, items = /** @type {any[]} */ ([]), renderItem, speed, testID }) => {
   return (
     <>
       <SwipeableList
@@ -192,5 +192,3 @@ const MarqueeList = ({ height, items = /** @type {any[]} */ ([]), renderItem, sp
     </>
   );
 };
-
-export default MarqueeList;


### PR DESCRIPTION
`MarqueeList` (a generic, gesture-driven auto-scrolling list) and `withSpeed` (the constant-speed reanimated animation it relies on) are both app-agnostic UI primitives with no domain knowledge, yet they currently live in legacy `src/utils/` and `src/components/list/`. Under our domain-organized architecture they belong in `framework/ui/`.

This change relocates both into `framework/ui/` (the animation under `animations/`, the component under `components/`), converts them to named exports, and points their only consumer, the ENS registration intro marquee, directly at the component instead of through the barrel. Behavior is unchanged; this is purely a move to the right architectural home.

The component stays as JS for now. Converting it to TSX surfaces a separate reanimated typing wrinkle (`defineAnimation` is typed to return the animation object rather than the animated value), so we're leaving that for a follow-up.