### PR TITLE
refactor(wallet): move watchingAlert into wallet domain

### DIFF
--- a/src/__swaps__/screens/Swap/navigateToSwaps.ts
+++ b/src/__swaps__/screens/Swap/navigateToSwaps.ts
@@ -11,6 +11,7 @@ import {
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { setSelectedGasSpeed } from '@/features/gas/hooks/useSelectedGas';
 import { type GasSpeed } from '@/features/gas/types/gasSpeed';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { divWorklet, mulWorklet, toFixedWorklet } from '@/framework/core/safeMath';
 import { getRemoteConfig } from '@/model/remoteConfig';
 import Navigation from '@/navigation/Navigation';
@@ -21,7 +22,6 @@ import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { ChainId } from '@/state/backendNetworks/types';
 import { useSwapsStore, type SwapsState } from '@/state/swaps/swapsStore';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 import { INITIAL_SLIDER_POSITION, SLIDER_WIDTH } from './constants';
 

--- a/src/components/DappBrowser/control-panel/ControlPanel.tsx
+++ b/src/components/DappBrowser/control-panel/ControlPanel.tsx
@@ -36,6 +36,7 @@ import {
   useForegroundColor,
 } from '@/design-system';
 import { type TextColor } from '@/design-system/color/palettes';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { removeFirstEmojiFromString, returnStringFirstEmoji } from '@/helpers/emojiHandler';
 import { greaterThan } from '@/helpers/utilities';
@@ -62,7 +63,6 @@ import { address } from '@/utils/abbreviations';
 import deviceUtils from '@/utils/deviceUtils';
 import { addressHashedEmoji } from '@/utils/profileUtils';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
-import watchingAlert from '@/utils/watchingAlert';
 import { getHighContrastTextColorWorklet } from '@/worklets/colors';
 
 import { RAINBOW_HOME } from '../constants';

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -9,6 +9,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { CopyFloatingEmojis } from '@/components/floating-emojis';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { AccentColorProvider, Box, Column, Columns, Inset, Stack, Text, useColorMode } from '@/design-system';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import * as i18n from '@/languages';
 import { useRemoteConfig } from '@/model/remoteConfig';
@@ -16,7 +17,6 @@ import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { addressCopiedToastAtom } from '@/recoil/addressCopiedToastAtom';
 import { getIsDamagedWallet, getIsReadOnlyWallet, useAccountAddress, useIsDamagedWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 export const ProfileActionButtonsRowHeight = 80;
 

--- a/src/features/ens/components/ENSCreateProfileCard.tsx
+++ b/src/features/ens/components/ENSCreateProfileCard.tsx
@@ -8,12 +8,12 @@ import { ORB_SIZE } from '@/components/cards/reusables/IconOrb';
 import ImgixImage from '@/components/images/ImgixImage';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { Bleed, Box, ColorModeProvider, Column, Columns, Stack, Text } from '@/design-system';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 import ENSAvatarGrid from '../assets/ensAvatarGrid.png';
 import ENSIcon from '../assets/ensIcon.png';

--- a/src/features/ens/components/ENSSearchCard.tsx
+++ b/src/features/ens/components/ENSSearchCard.tsx
@@ -8,11 +8,11 @@ import { GenericCard, type Gradient } from '@/components/cards/GenericCard';
 import { IconOrb } from '@/components/cards/reusables/IconOrb';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { Box, ColorModeProvider, globalColors, Stack, Text } from '@/design-system';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 import useENSPendingRegistrations from '../hooks/useENSPendingRegistrations';
 import { REGISTRATION_MODES } from '../utils/helpers';

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-claim-sheet/RnbwRewardsClaimSheet.tsx
@@ -8,13 +8,13 @@ import { RnbwHoldToActivateButton } from '@/features/rnbw-membership/components/
 import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { prepareRewardsClaim, submitRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { useStableValue } from '@/hooks/useStableValue';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { useAccountAddress, useIsHardwareWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 export const RnbwRewardsClaimSheet = memo(function RnbwRewardsClaimSheet() {
   const { goBack, navigate } = useNavigation();

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-screen/components/AirdropSummaryCard.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-screen/components/AirdropSummaryCard.tsx
@@ -13,11 +13,11 @@ import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
 import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBalanceStore';
 import { rewardsFlowActions } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStableValue } from '@/hooks/useStableValue';
 import * as i18n from '@/languages';
 import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 const BORDER_RADIUS = 32;
 

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/AirdropIntroScene.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/AirdropIntroScene.tsx
@@ -11,10 +11,10 @@ import {
 } from '@/features/rnbw-rewards/animations/sceneTransitions';
 import { RnbwRewardsScenes } from '@/features/rnbw-rewards/screens/rnbw-rewards-screen/constants/rewardsScenes';
 import { rewardsFlowActions } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import * as i18n from '@/languages';
 import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { time } from '@/utils/time';
-import watchingAlert from '@/utils/watchingAlert';
 
 const enteringAnimation = createScaleInFadeInSlideEnterAnimation({ delay: time.ms(200) });
 

--- a/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/RewardsOverviewScene.tsx
+++ b/src/features/rnbw-rewards/screens/rnbw-rewards-screen/scenes/RewardsOverviewScene.tsx
@@ -16,6 +16,7 @@ import { useAirdropBalanceStore } from '@/features/rnbw-rewards/stores/airdropBa
 import { useRewardsBalanceStore } from '@/features/rnbw-rewards/stores/rewardsBalanceStore';
 import { rewardsFlowActions } from '@/features/rnbw-rewards/stores/rewardsFlowStore';
 import { prepareRewardsClaim } from '@/features/rnbw-rewards/utils/claimRewards';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useTabBarOffset } from '@/hooks/useTabBarOffset';
 import * as i18n from '@/languages';
@@ -24,7 +25,6 @@ import Routes from '@/navigation/routesNames';
 import { useAccountAddress, useIsHardwareWallet, useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import { delay } from '@/utils/delay';
 import { time } from '@/utils/time';
-import watchingAlert from '@/utils/watchingAlert';
 
 const enterAnimation = createScaleInFadeInSlideEnterAnimation({ delay: time.ms(200) });
 

--- a/src/features/rnbw-staking/utils/blockStakingAccessIfNeeded.ts
+++ b/src/features/rnbw-staking/utils/blockStakingAccessIfNeeded.ts
@@ -1,5 +1,5 @@
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 /**
  * Blocks staking entry for wallets that cannot submit staking transactions.

--- a/src/features/wallet/utils/watchingAlert.ts
+++ b/src/features/wallet/utils/watchingAlert.ts
@@ -3,7 +3,7 @@ import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 
-export default function watchingAlert() {
+export function watchingAlert() {
   Alert.alert(i18n.t(i18n.l.wallet.alert.this_wallet_in_watching_mode), i18n.t(i18n.l.wallet.alert.looks_like_imported_public_address), [
     {
       onPress: () => {

--- a/src/hooks/useNavigationForNonReadOnlyWallets.ts
+++ b/src/hooks/useNavigationForNonReadOnlyWallets.ts
@@ -2,10 +2,10 @@ import { useCallback } from 'react';
 import { InteractionManager } from 'react-native';
 
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { useNavigation, type NavigateArgs } from '@/navigation/Navigation';
 import { type Route } from '@/navigation/routesNames';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 export default function useNavigationForNonReadOnlyWallets() {
   const { goBack, navigate } = useNavigation();

--- a/src/screens/Airdrops/ClaimAirdropSheet.tsx
+++ b/src/screens/Airdrops/ClaimAirdropSheet.tsx
@@ -39,6 +39,7 @@ import { foregroundColors } from '@/design-system/color/palettes';
 import { getColorForTheme } from '@/design-system/color/useForegroundColor';
 import { fetchENSAvatar } from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { getSizedImageUrl } from '@/handlers/imgix';
 import { containsEmoji } from '@/helpers/strings';
@@ -59,7 +60,6 @@ import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { addressHashedColorIndex, addressHashedEmoji } from '@/utils/profileUtils';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 import { time } from '@/utils/time';
-import watchingAlert from '@/utils/watchingAlert';
 import { getHighContrastTextColorWorklet } from '@/worklets/colors';
 import { getCirclePath } from '@/worklets/skia';
 

--- a/src/screens/claimables/shared/components/ClaimButton.tsx
+++ b/src/screens/claimables/shared/components/ClaimButton.tsx
@@ -7,9 +7,9 @@ import ShimmerAnimation from '@/components/animations/ShimmerAnimation';
 import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { AccentColorProvider, Box, Inline, Text, TextShadow } from '@/design-system';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { getIsReadOnlyWallet } from '@/state/wallets/walletsStore';
 import deviceUtils from '@/utils/deviceUtils';
-import watchingAlert from '@/utils/watchingAlert';
 
 const BUTTON_WIDTH = deviceUtils.dimensions.width - 52;
 

--- a/src/screens/claimables/sponsored/components/SponsoredClaimableFlow.tsx
+++ b/src/screens/claimables/sponsored/components/SponsoredClaimableFlow.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useMemo } from 'react';
 
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 import { ClaimButton } from '../../shared/components/ClaimButton';
 import { ClaimPanel } from '../../shared/components/ClaimPanel';

--- a/src/screens/claimables/transaction/components/TransactionClaimableFlow.tsx
+++ b/src/screens/claimables/transaction/components/TransactionClaimableFlow.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo } from 'react';
 
 import { Box } from '@/design-system';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import { ClaimableType } from '@/resources/addys/claimables/types';
 import { useIsReadOnlyWallet } from '@/state/wallets/walletsStore';
-import watchingAlert from '@/utils/watchingAlert';
 
 import { ClaimButton } from '../../shared/components/ClaimButton';
 import { ClaimPanel } from '../../shared/components/ClaimPanel';

--- a/src/screens/mints/MintSheet.tsx
+++ b/src/screens/mints/MintSheet.tsx
@@ -21,6 +21,7 @@ import useENSAvatar from '@/features/ens/hooks/useENSAvatar';
 import { fetchReverseRecord } from '@/features/ens/utils/handlers';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
 import useGas from '@/features/gas/hooks/useGas';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import styled from '@/framework/ui/styled-thing';
 import { metadataPOSTClient } from '@/graphql';
 import { type ReservoirCollection } from '@/graphql/__generated__/arcDev';
@@ -59,7 +60,6 @@ import abbreviations from '@/utils/abbreviations';
 import ethereumUtils, { getUniqueId } from '@/utils/ethereumUtils';
 import { openInBrowser } from '@/utils/openInBrowser';
 import { addressHashedColorIndex } from '@/utils/profileUtils';
-import watchingAlert from '@/utils/watchingAlert';
 
 import ImgixImage from '../../components/images/ImgixImage';
 import { SlackSheet } from '../../components/sheet';

--- a/src/screens/mints/PoapSheet.tsx
+++ b/src/screens/mints/PoapSheet.tsx
@@ -11,6 +11,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import Spinner from '@/components/Spinner';
 import { Box, ColorModeProvider, Row, Rows, Stack, Text } from '@/design-system';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import styled from '@/framework/ui/styled-thing';
 import { arcClient } from '@/graphql';
 import { maybeSignUri } from '@/handlers/imgix';
@@ -27,7 +28,6 @@ import { useTheme } from '@/theme/ThemeContext';
 import { delay } from '@/utils/delay';
 import { openInBrowser } from '@/utils/openInBrowser';
 import { type PoapMintError } from '@/utils/poaps';
-import watchingAlert from '@/utils/watchingAlert';
 
 import ImgixImage from '../../components/images/ImgixImage';
 import { SheetActionButton, SheetActionButtonRow, SlackSheet } from '../../components/sheet';

--- a/src/state/wallets/walletsStore.ts
+++ b/src/state/wallets/walletsStore.ts
@@ -6,6 +6,7 @@ import { type Address } from 'viem';
 import { normalizeAddress } from '@/features/address/core/address';
 import { parseTimestampFromBackupFile } from '@/features/backup/backup';
 import { fetchENSAvatarWithRetry } from '@/features/ens/hooks/useENSAvatar';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { ensureValidHex, isValidHex } from '@/handlers/web3';
 import { removeFirstEmojiFromString, returnStringFirstEmoji } from '@/helpers/emojiHandler';
 import { getConsistentArray } from '@/helpers/getConsistentArray';
@@ -36,7 +37,6 @@ import isLowerCaseMatch from '@/utils/isLowerCaseMatch';
 import { didShowWalletErrorSheetKey } from '@/utils/keychainConstants';
 import { addressHashedColorIndex, addressHashedEmoji, fetchReverseRecordWithRetry, isValidImagePath } from '@/utils/profileUtils';
 import { time } from '@/utils/time';
-import watchingAlert from '@/utils/watchingAlert';
 import { shallowEqual } from '@/worklets/comparisons';
 
 import { createRainbowStore } from '../internal/createRainbowStore';

--- a/src/systems/funding/hooks/useDepositHandler.ts
+++ b/src/systems/funding/hooks/useDepositHandler.ts
@@ -8,6 +8,7 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { crosschainQuoteTargetsRecipient, isCrosschainQuote } from '@/__swaps__/utils/quotes';
 import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { getProvider } from '@/handlers/web3';
 import { logger, RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
@@ -24,7 +25,6 @@ import { executeDepositRap } from '@/systems/funding/execution/depositRapExecuti
 import { isValidQuote } from '@/systems/funding/utils/quotes';
 import { isRecordLike } from '@/types/guards';
 import { time } from '@/utils/time';
-import watchingAlert from '@/utils/watchingAlert';
 import { sanitizeAmount } from '@/worklets/strings';
 import { type PreparedCallsExecution } from '@rainbow-me/delegation';
 import { type CrosschainQuote, type Quote } from '@rainbow-me/swaps';

--- a/src/utils/requestNavigationHandlers.ts
+++ b/src/utils/requestNavigationHandlers.ts
@@ -25,6 +25,7 @@ import {
   type WalletconnectRequestData,
   type WalletconnectResultType,
 } from '@/features/wallet-connect/types';
+import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { maybeSignUri } from '@/handlers/imgix';
 import walletTypes from '@/helpers/walletTypes';
 import { logger, RainbowError } from '@/logger';
@@ -37,7 +38,6 @@ import { ChainId } from '@/state/backendNetworks/types';
 import { getAccountAddress, getIsReadOnlyWallet, getWalletWithAccount } from '@/state/wallets/walletsStore';
 
 import { SEND_TRANSACTION } from './signingMethods';
-import watchingAlert from './watchingAlert';
 
 export enum RequestSource {
   WALLETCONNECT = 'walletconnect',


### PR DESCRIPTION
`watchingAlert` currently lives in the catch-all `src/utils/`, but it's wallet-domain code: it prompts a read-only ("watching") wallet to finish importing and routes into the add-wallet flow. As we migrate toward domain-organized `features/`, this is a natural first slice to pull out.

This change establishes a `features/wallet/` module and moves `watchingAlert` into it, switching it to a named export and updating its consumers. It's purely a relocation, with no behavior change.