### PR TITLE
chore: remove orphaned tokensListenedCache utils

### DIFF
--- a/src/utils/tokensListenedCache.ts
+++ b/src/utils/tokensListenedCache.ts
@@ -1,3 +1,0 @@
-const TokensListenedCache: Record<string, Record<string, boolean>> = {};
-
-export default TokensListenedCache;


### PR DESCRIPTION
The `TokensListenedCache` tracked which token codes had already been subscribed to over the assets websocket so we wouldn't re-subscribe. That whole generic-assets websocket flow was replaced by a GraphQL query in #5357 (Feb 2024), which deleted the cache's only consumer. The file lingered for two more years purely because the `@/utils` barrel kept re-exporting it; once the barrel was removed earlier this year it became fully orphaned, with no importer and no re-export.

Ref FEPLAT-34.