### PR TITLE
Remove invalid dapp browser image URL fallbacks

### DIFF
--- a/src/components/DappBrowser/search/results/SearchResult.tsx
+++ b/src/components/DappBrowser/search/results/SearchResult.tsx
@@ -22,7 +22,7 @@ export const SearchResult = ({ index, goToUrl }: { index: number; goToUrl: (url:
   const { width: deviceWidth } = useDimensions();
 
   const dapp = useDerivedValue(() => (_WORKLET ? searchResults?.value[index] : null));
-  const iconUrl = useDerivedValue(() => (_WORKLET ? (dapp.value?.iconUrl ?? dapp.value?.name) : undefined));
+  const iconUrl = useDerivedValue(() => (_WORKLET ? (dapp.value?.iconUrl ?? '') : ''));
   const name = useDerivedValue(() => (_WORKLET ? dapp.value?.name : undefined));
   const urlDisplay = useDerivedValue(() => (_WORKLET ? dapp.value?.urlDisplay : undefined));
 


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Fallback URL for dapp browser search result icons was the dapp name (not a URL), which was likely triggering excessive Sentry noise
- I believe this was covering for a cache key issue in the underlying image library, which now seems to be resolved as I didn't notice any stuck images

## Screen recordings / screenshots

## What to test
