### PR TITLE
feat(rnbw-staking): share wallet confirmation helper between stake and unstake

### DIFF
--- a/src/features/rnbw-staking/utils/executeStakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.ts
@@ -10,7 +10,6 @@ import { resolveManagedExecutionFailure } from '@/features/delegation/managedExe
 import { waitForManagedExecutionConfirmation } from '@/features/delegation/waitForManagedExecution';
 import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
-import { time } from '@/framework/core/utils/time';
 import { RainbowError } from '@/logger';
 import { extractReplayableExecution } from '@/raps/replay';
 import { toTransactionAsset, type TransactionAssetSource } from '@/raps/transactionAsset';
@@ -26,6 +25,7 @@ import {
   STAKING_GAS_LIMIT,
 } from '../constants';
 import { buildStakeRnbwCalls, buildStakeRnbwExecutionPlan } from './stakeRnbwCalls';
+import { waitForWalletTransactions } from './waitForWalletTransactions';
 
 // ============ Types ========================================================= //
 
@@ -260,20 +260,6 @@ function buildStakeTransaction({
     type: 'stake',
     value: 0,
   };
-}
-
-async function waitForWalletTransactions({ provider, txHashes }: { provider: StaticJsonRpcProvider; txHashes: string[] }): Promise<void> {
-  for (const hash of txHashes) {
-    const receipt = await provider.waitForTransaction(hash, 1, time.minutes(2));
-
-    if (!receipt) {
-      throw new RainbowError(`[executeStakeRnbw]: wallet staking transaction was not confirmed (${hash})`);
-    }
-
-    if (receipt.status === 0) {
-      throw new RainbowError(`[executeStakeRnbw]: wallet staking transaction failed (${hash})`);
-    }
-  }
 }
 
 async function resolveStakeRnbwCallGasLimit({

--- a/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
@@ -1,0 +1,221 @@
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { encodeFunctionData, type Address } from 'viem';
+
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
+import { type StakingPositionData } from '../stores/rnbwStakingPositionStore';
+import { unstakeRnbw } from './unstakeRnbw';
+
+const mockGetProvider = jest.fn();
+const mockLoadWallet = jest.fn<Promise<unknown>, [unknown]>();
+const mockFetch = jest.fn<Promise<void>, [undefined, { force: boolean } | undefined]>();
+const mockGetData = jest.fn<StakingPositionData | undefined, []>();
+const mockSendTransaction = jest.fn<Promise<TransactionResponse>, [unknown]>();
+const mockEstimateGas = jest.fn<Promise<{ toString: () => string }>, [unknown]>();
+const mockPollForStakingUpdate = jest.fn<Promise<boolean>, [string]>();
+const mockWaitForWalletTransactions = jest.fn<Promise<void>, [unknown]>();
+const mockTrack = jest.fn();
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    event: {
+      rnbwStakingUnstake: 'rnbw_staking.unstake',
+      rnbwStakingUnstakeFailed: 'rnbw_staking.unstake.failed',
+    },
+    track: (...args: unknown[]) => mockTrack(...args),
+  },
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  getProvider: () => mockGetProvider(),
+}));
+
+jest.mock('@/model/wallet', () => ({
+  loadWallet: (params: unknown) => mockLoadWallet(params),
+}));
+
+jest.mock('../stores/rnbwStakingPositionStore', () => ({
+  useStakingPositionStore: {
+    getState: () => ({
+      fetch: (params: undefined, options?: { force: boolean }) => mockFetch(params, options),
+      getData: () => mockGetData(),
+    }),
+  },
+}));
+
+jest.mock('./pollForStakingUpdate', () => ({
+  pollForStakingUpdate: (originalStakedRnbwShares: string) => mockPollForStakingUpdate(originalStakedRnbwShares),
+}));
+
+jest.mock('./waitForWalletTransactions', () => ({
+  waitForWalletTransactions: (params: unknown) => mockWaitForWalletTransactions(params),
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+const ACCOUNT: Address = '0x3333333333333333333333333333333333333333';
+const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const UNSTAKE_ALL_DATA = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+const GAS_PARAMS = { maxFeePerGas: '10', maxPriorityFeePerGas: '1' };
+const ESTIMATED_GAS_LIMIT = '123456';
+const PROVIDER = {
+  estimateGas: (params: unknown) => mockEstimateGas(params),
+  name: 'provider',
+} as unknown as StaticJsonRpcProvider;
+
+const POSITION: StakingPositionData = {
+  allTiers: [],
+  decimals: 18,
+  exitFeePercentage: 5,
+  hasPosition: true,
+  lastUpdateTime: '0',
+  pnl: {
+    netProfit: '0',
+    totalCashbackReceived: '0',
+    totalExitFeePaid: '0',
+    totalRnbwStaked: '0',
+    totalRnbwUnstaked: '0',
+    exchangeRateGain: '0',
+  },
+  sessionPnl: {
+    netProfit: '0',
+    totalCashbackReceived: '0',
+    totalExitFeePaid: '0',
+    totalRnbwStaked: '0',
+    totalRnbwUnstaked: '0',
+    exchangeRateGain: '50000000000000000000',
+  },
+  poolShares: '900000000000000000000',
+  stakedRnbw: '1000000000000000000000',
+  stakedValueInCurrency: '1000',
+  stakingStartTime: '0',
+  tier: { level: 1 } as unknown as StakingPositionData['tier'],
+};
+
+function recordCallOrder(): { order: string[]; record: (name: string) => void } {
+  const order: string[] = [];
+  return {
+    order,
+    record: (name: string) => {
+      order.push(name);
+    },
+  };
+}
+
+describe('unstakeRnbw', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetProvider.mockReturnValue(PROVIDER);
+    mockLoadWallet.mockResolvedValue({
+      sendTransaction: (params: unknown) => mockSendTransaction(params),
+    });
+    mockGetData.mockReturnValue(POSITION);
+    mockFetch.mockResolvedValue(undefined);
+    mockEstimateGas.mockResolvedValue({ toString: () => ESTIMATED_GAS_LIMIT });
+    mockSendTransaction.mockResolvedValue({ hash: TX_HASH } as TransactionResponse);
+    mockPollForStakingUpdate.mockResolvedValue(true);
+    mockWaitForWalletTransactions.mockResolvedValue(undefined);
+  });
+
+  it('refreshes the staking position before submission and sends unstakeAll() to the staking contract', async () => {
+    const { order, record } = recordCallOrder();
+    mockFetch.mockImplementation(async () => {
+      record('fetch');
+    });
+    mockSendTransaction.mockImplementation(async () => {
+      record('sendTransaction');
+      return { hash: TX_HASH } as TransactionResponse;
+    });
+
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+
+    expect(mockFetch).toHaveBeenCalledWith(undefined, { force: true });
+    expect(mockGetProvider).toHaveBeenCalled();
+    expect(mockLoadWallet).toHaveBeenCalledWith({ address: ACCOUNT, provider: PROVIDER });
+    expect(mockEstimateGas).toHaveBeenCalledWith({
+      data: UNSTAKE_ALL_DATA,
+      from: ACCOUNT,
+      to: STAKING_CONTRACT_ADDRESS,
+    });
+    expect(mockSendTransaction).toHaveBeenCalledWith({
+      ...GAS_PARAMS,
+      to: STAKING_CONTRACT_ADDRESS,
+      data: UNSTAKE_ALL_DATA,
+      gasLimit: ESTIMATED_GAS_LIMIT,
+    });
+    expect(order).toEqual(['fetch', 'sendTransaction']);
+  });
+
+  it('throws when refreshed position data is missing', async () => {
+    mockGetData.mockReturnValueOnce(POSITION).mockReturnValueOnce(undefined);
+
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toThrow('[unstakeRnbw]: Position data missing');
+    expect(mockSendTransaction).not.toHaveBeenCalled();
+  });
+
+  it('throws when the exit fee percentage changes between snapshot and refresh', async () => {
+    mockGetData.mockReturnValueOnce({ ...POSITION, exitFeePercentage: 5 }).mockReturnValueOnce({ ...POSITION, exitFeePercentage: 7 });
+
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toThrow('[unstakeRnbw]: Exit fee percentage changed');
+    expect(mockSendTransaction).not.toHaveBeenCalled();
+  });
+
+  it('uses the fallback gas limit when unstake gas estimation fails', async () => {
+    mockEstimateGas.mockRejectedValueOnce(new Error('estimate failed'));
+
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+
+    expect(mockSendTransaction).toHaveBeenCalledWith({
+      ...GAS_PARAMS,
+      to: STAKING_CONTRACT_ADDRESS,
+      data: UNSTAKE_ALL_DATA,
+      gasLimit: STAKING_UNSTAKE_GAS_LIMIT.toString(),
+    });
+  });
+
+  it('waits for the wallet transaction to confirm before polling staking data', async () => {
+    const { order, record } = recordCallOrder();
+    mockWaitForWalletTransactions.mockImplementation(async () => {
+      record('waitForWalletTransactions');
+    });
+    mockPollForStakingUpdate.mockImplementation(async () => {
+      record('pollForStakingUpdate');
+      return true;
+    });
+
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+
+    expect(mockWaitForWalletTransactions).toHaveBeenCalledWith({ provider: PROVIDER, txHashes: [TX_HASH] });
+    expect(mockPollForStakingUpdate).toHaveBeenCalledWith(POSITION.poolShares);
+    expect(order).toEqual(['waitForWalletTransactions', 'pollForStakingUpdate']);
+  });
+
+  it('tracks the success analytics payload with the existing field set', async () => {
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+
+    expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake', {
+      chainId: STAKING_CHAIN_ID,
+      txHash: TX_HASH,
+      stakedAmount: '1000',
+      expectedExitFee: '50',
+      expectedReceiveAmount: '950',
+      pnl: '0',
+    });
+  });
+
+  it('tracks the failure analytics payload when submission fails', async () => {
+    const error = new Error('boom');
+    mockSendTransaction.mockRejectedValueOnce(error);
+
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toBe(error);
+
+    expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake.failed', {
+      chainId: STAKING_CHAIN_ID,
+      stakedAmount: '1000',
+      errorMessage: 'boom',
+    });
+    expect(mockTrack).not.toHaveBeenCalledWith('rnbw_staking.unstake', expect.anything());
+  });
+});

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -12,6 +12,14 @@ import { loadWallet } from '@/model/wallet';
 import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
 import { useStakingPositionStore, type StakingPositionData } from '../stores/rnbwStakingPositionStore';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
+import { waitForWalletTransactions } from './waitForWalletTransactions';
+
+type UnstakeAnalyticsSnapshot = {
+  stakedAmount: string;
+  expectedExitFee: string;
+  expectedReceiveAmount: string;
+  pnl: string;
+};
 
 export async function unstakeRnbw({
   address,
@@ -20,6 +28,34 @@ export async function unstakeRnbw({
   address: Address;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
 }): Promise<Hash> {
+  const positionData = await refreshAndValidatePosition();
+  const analyticsSnapshot = snapshotUnstakeAnalytics(positionData);
+
+  try {
+    const txHash = await submitAndConfirmUnstake({
+      address,
+      gasParams,
+      originalStakedRnbwShares: positionData.poolShares,
+    });
+
+    analytics.track(analytics.event.rnbwStakingUnstake, {
+      chainId: STAKING_CHAIN_ID,
+      txHash,
+      ...analyticsSnapshot,
+    });
+
+    return txHash;
+  } catch (error) {
+    analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
+      chainId: STAKING_CHAIN_ID,
+      stakedAmount: analyticsSnapshot.stakedAmount,
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+    });
+    throw error;
+  }
+}
+
+async function refreshAndValidatePosition(): Promise<StakingPositionData> {
   const initialExitFeePercentage = useStakingPositionStore.getState().getData()?.exitFeePercentage;
   await useStakingPositionStore.getState().fetch(undefined, { force: true });
   const positionData = useStakingPositionStore.getState().getData();
@@ -32,44 +68,37 @@ export async function unstakeRnbw({
     throw new RainbowError('[unstakeRnbw]: Exit fee percentage changed');
   }
 
-  const positionSnapshot = snapshotUnstakeAnalytics(positionData);
+  return positionData;
+}
 
-  try {
-    const provider = getProvider({ chainId: STAKING_CHAIN_ID });
-    const signer = await loadWallet({ address, provider });
-    if (!signer) {
-      throw new Error('Failed to load wallet');
-    }
-
-    const originalStakedRnbwShares = positionData.poolShares;
-    const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
-    const gasLimit = await estimateUnstakeGasLimit({ address, data, provider });
-
-    const tx = await signer.sendTransaction({
-      ...gasParams,
-      to: STAKING_CONTRACT_ADDRESS,
-      data,
-      gasLimit,
-    });
-
-    await tx.wait();
-    await pollForStakingUpdate(originalStakedRnbwShares);
-
-    analytics.track(analytics.event.rnbwStakingUnstake, {
-      chainId: STAKING_CHAIN_ID,
-      txHash: tx.hash as string,
-      ...positionSnapshot,
-    });
-
-    return tx.hash as Hash;
-  } catch (error) {
-    analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
-      chainId: STAKING_CHAIN_ID,
-      stakedAmount: positionSnapshot.stakedAmount,
-      errorMessage: error instanceof Error ? error.message : 'Unknown error',
-    });
-    throw error;
+async function submitAndConfirmUnstake({
+  address,
+  gasParams,
+  originalStakedRnbwShares,
+}: {
+  address: Address;
+  gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
+  originalStakedRnbwShares: string;
+}): Promise<Hash> {
+  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+  const signer = await loadWallet({ address, provider });
+  if (!signer) {
+    throw new Error('Failed to load wallet');
   }
+
+  const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+  const gasLimit = await estimateUnstakeGasLimit({ address, data, provider });
+  const tx = await signer.sendTransaction({
+    ...gasParams,
+    to: STAKING_CONTRACT_ADDRESS,
+    data,
+    gasLimit,
+  });
+
+  await waitForWalletTransactions({ provider, txHashes: [tx.hash] });
+  await pollForStakingUpdate(originalStakedRnbwShares);
+
+  return tx.hash as Hash;
 }
 
 async function estimateUnstakeGasLimit({
@@ -89,7 +118,7 @@ async function estimateUnstakeGasLimit({
   }
 }
 
-function snapshotUnstakeAnalytics(positionData: StakingPositionData) {
+function snapshotUnstakeAnalytics(positionData: StakingPositionData): UnstakeAnalyticsSnapshot {
   const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl, exitFeePercentage } = positionData;
   const exitFeeRaw = mulWorklet(stakedRnbwRaw, exitFeePercentage / 100);
 

--- a/src/features/rnbw-staking/utils/waitForWalletTransactions.ts
+++ b/src/features/rnbw-staking/utils/waitForWalletTransactions.ts
@@ -1,0 +1,29 @@
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+
+import { time } from '@/framework/core/utils/time';
+import { RainbowError } from '@/logger';
+
+const WALLET_CONFIRMATION_TIMEOUT_MS = time.minutes(2);
+
+/**
+ * Waits for each wallet-submitted transaction to confirm with a successful receipt.
+ */
+export async function waitForWalletTransactions({
+  provider,
+  txHashes,
+}: {
+  provider: StaticJsonRpcProvider;
+  txHashes: string[];
+}): Promise<void> {
+  for (const hash of txHashes) {
+    const receipt = await provider.waitForTransaction(hash, 1, WALLET_CONFIRMATION_TIMEOUT_MS);
+
+    if (!receipt) {
+      throw new RainbowError(`[waitForWalletTransactions]: wallet transaction was not confirmed (${hash})`);
+    }
+
+    if (receipt.status === 0) {
+      throw new RainbowError(`[waitForWalletTransactions]: wallet transaction failed (${hash})`);
+    }
+  }
+}


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Extracts the wallet confirmation waiter (`waitForWalletTransactions`) from `executeStakeRnbw` into a small shared helper and routes the manual unstake flow through it. Both stake (sequential fallback path) and unstake now share a single source of truth for receipt-status checking and the 2-minute confirmation timeout.

`unstakeRnbw`'s internals are reorganized into private named helpers (`refreshAndValidatePosition`, `submitAndConfirmUnstake`, `snapshotUnstakeAnalytics`) for readability. The public signature stays `unstakeRnbw({ address })`.

The only observable change is that the unstake wallet wait now uses a 2-minute timeout (via the shared helper) instead of `tx.wait()`'s indefinite wait. Analytics payloads, error messages, position-refresh ordering, and pending-transaction behavior (still none for unstake) are preserved verbatim.

A new `unstakeRnbw.test.ts` characterizes the current behavior: position refresh before submission, missing-position and exit-fee-change error paths, `unstakeAll()` target, confirmation-before-poll ordering, and the success/failure analytics payloads.