### PR TITLE
Default to Go relay backend

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -71,6 +71,5 @@ declare module 'react-native-dotenv' {
   export const RAINBOW_RELAY_URL: string;
   export const RAINBOW_RELAY_API_KEY: string;
   export const RAINBOW_RELAY_QUOTE_SIGNER: string;
-  export const RAINBOW_RELAY_GO_BACKEND_API_KEY: string;
   export const RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER: string;
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -71,4 +71,7 @@ declare module 'react-native-dotenv' {
   export const RAINBOW_RELAY_URL: string;
   export const RAINBOW_RELAY_API_KEY: string;
   export const RAINBOW_RELAY_QUOTE_SIGNER: string;
+  export const RAINBOW_RELAY_GO_BACKEND_URL: string;
+  export const RAINBOW_RELAY_GO_BACKEND_API_KEY: string;
+  export const RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER: string;
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -71,7 +71,6 @@ declare module 'react-native-dotenv' {
   export const RAINBOW_RELAY_URL: string;
   export const RAINBOW_RELAY_API_KEY: string;
   export const RAINBOW_RELAY_QUOTE_SIGNER: string;
-  export const RAINBOW_RELAY_GO_BACKEND_URL: string;
   export const RAINBOW_RELAY_GO_BACKEND_API_KEY: string;
   export const RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER: string;
 }

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -37,6 +37,7 @@ export const DEFI_POSITIONS_THRESHOLD_FILTER = 'DeFi Minimum Value Filter';
 export const RNBW_REWARDS = 'RNBW Rewards';
 export const RNBW_MEMBERSHIP = 'RNBW Membership';
 export const DELEGATION = '7702 Delegation';
+export const GO_RELAY_BACKEND = 'Go Relay Backend';
 
 export type ExperimentalValue = {
   settings: boolean;
@@ -78,6 +79,7 @@ const config = {
   [RNBW_REWARDS]: { settings: true, value: false },
   [RNBW_MEMBERSHIP]: { settings: true, value: false },
   [DELEGATION]: { settings: true, value: false },
+  [GO_RELAY_BACKEND]: { needsRestart: true, settings: true, value: false },
 } as const;
 
 /** This flag is not reactive. We use this in a static context. */

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -79,7 +79,7 @@ const config = {
   [RNBW_REWARDS]: { settings: true, value: false },
   [RNBW_MEMBERSHIP]: { settings: true, value: false },
   [DELEGATION]: { settings: true, value: false },
-  [GO_RELAY_BACKEND]: { needsRestart: true, settings: true, value: false },
+  [GO_RELAY_BACKEND]: { needsRestart: true, settings: true, value: true },
 } as const;
 
 /** This flag is not reactive. We use this in a static context. */

--- a/src/config/experimentalConfigStore.ts
+++ b/src/config/experimentalConfigStore.ts
@@ -18,7 +18,7 @@ export const useExperimentalConfigStore = createRainbowStore<ExperimentalConfigS
     },
 
     toggleFlag: key => {
-      set(state => ({ config: { ...state.config, [key]: !state.config[key] } }));
+      set(state => ({ config: { ...state.config, [key]: !(state.config[key] ?? defaultConfig[key].value) } }));
     },
   }),
 

--- a/src/config/experimentalConfigStore.ts
+++ b/src/config/experimentalConfigStore.ts
@@ -1,6 +1,7 @@
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from '@/config/experimental';
 import { IS_STORE_INSTALL } from '@/env';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
+import { time } from '@/utils/time';
 
 export type ExperimentalConfigState = {
   config: Record<ExperimentalConfigKey, boolean>;
@@ -22,7 +23,7 @@ export const useExperimentalConfigStore = createRainbowStore<ExperimentalConfigS
     },
   }),
 
-  { storageKey: 'experimentalConfig' }
+  { persistThrottleMs: time.zero, storageKey: 'experimentalConfig' }
 );
 
 export function getExperimentalFlag(key: ExperimentalConfigKey): boolean {

--- a/src/features/delegation/relayService.ts
+++ b/src/features/delegation/relayService.ts
@@ -10,12 +10,13 @@ import { getAddress } from 'viem';
 
 import { GO_RELAY_BACKEND } from '@/config/experimental';
 import { getExperimentalFlag } from '@/config/experimentalConfigStore';
+import { useRemoteConfigStore } from '@/model/remoteConfig';
 import { createRelayService } from '@rainbow-me/delegation';
 
 export type RelayStatusResponse = Awaited<ReturnType<typeof relayService.getStatus>>;
 
 export const relayService = createRelayService(
-  getExperimentalFlag(GO_RELAY_BACKEND)
+  shouldUseGoBackend()
     ? {
         apiKey: PLATFORM_API_KEY,
         baseUrl: PLATFORM_BASE_URL,
@@ -27,3 +28,7 @@ export const relayService = createRelayService(
         quoteSigner: getAddress(RAINBOW_RELAY_QUOTE_SIGNER),
       }
 );
+
+function shouldUseGoBackend(): boolean {
+  return getExperimentalFlag(GO_RELAY_BACKEND) && useRemoteConfigStore.getState().getRemoteConfigKey('go_relay_backend_enabled');
+}

--- a/src/features/delegation/relayService.ts
+++ b/src/features/delegation/relayService.ts
@@ -1,7 +1,7 @@
 import {
+  PLATFORM_API_KEY,
   PLATFORM_BASE_URL,
   RAINBOW_RELAY_API_KEY,
-  RAINBOW_RELAY_GO_BACKEND_API_KEY,
   RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER,
   RAINBOW_RELAY_QUOTE_SIGNER,
   RAINBOW_RELAY_URL,
@@ -17,7 +17,7 @@ export type RelayStatusResponse = Awaited<ReturnType<typeof relayService.getStat
 export const relayService = createRelayService(
   getExperimentalFlag(GO_RELAY_BACKEND)
     ? {
-        apiKey: RAINBOW_RELAY_GO_BACKEND_API_KEY,
+        apiKey: PLATFORM_API_KEY,
         baseUrl: PLATFORM_BASE_URL,
         quoteSigner: getAddress(RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER),
       }

--- a/src/features/delegation/relayService.ts
+++ b/src/features/delegation/relayService.ts
@@ -1,12 +1,29 @@
-import { RAINBOW_RELAY_API_KEY, RAINBOW_RELAY_QUOTE_SIGNER, RAINBOW_RELAY_URL } from 'react-native-dotenv';
+import {
+  RAINBOW_RELAY_API_KEY,
+  RAINBOW_RELAY_GO_BACKEND_API_KEY,
+  RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER,
+  RAINBOW_RELAY_GO_BACKEND_URL,
+  RAINBOW_RELAY_QUOTE_SIGNER,
+  RAINBOW_RELAY_URL,
+} from 'react-native-dotenv';
 import { getAddress } from 'viem';
 
+import { GO_RELAY_BACKEND } from '@/config/experimental';
+import { getExperimentalFlag } from '@/config/experimentalConfigStore';
 import { createRelayService } from '@rainbow-me/delegation';
 
 export type RelayStatusResponse = Awaited<ReturnType<typeof relayService.getStatus>>;
 
-export const relayService = createRelayService({
-  apiKey: RAINBOW_RELAY_API_KEY,
-  baseUrl: RAINBOW_RELAY_URL,
-  quoteSigner: getAddress(RAINBOW_RELAY_QUOTE_SIGNER),
-});
+export const relayService = createRelayService(
+  getExperimentalFlag(GO_RELAY_BACKEND)
+    ? {
+        apiKey: RAINBOW_RELAY_GO_BACKEND_API_KEY,
+        baseUrl: RAINBOW_RELAY_GO_BACKEND_URL,
+        quoteSigner: getAddress(RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER),
+      }
+    : {
+        apiKey: RAINBOW_RELAY_API_KEY,
+        baseUrl: RAINBOW_RELAY_URL,
+        quoteSigner: getAddress(RAINBOW_RELAY_QUOTE_SIGNER),
+      }
+);

--- a/src/features/delegation/relayService.ts
+++ b/src/features/delegation/relayService.ts
@@ -1,8 +1,8 @@
 import {
+  PLATFORM_BASE_URL,
   RAINBOW_RELAY_API_KEY,
   RAINBOW_RELAY_GO_BACKEND_API_KEY,
   RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER,
-  RAINBOW_RELAY_GO_BACKEND_URL,
   RAINBOW_RELAY_QUOTE_SIGNER,
   RAINBOW_RELAY_URL,
 } from 'react-native-dotenv';
@@ -18,7 +18,7 @@ export const relayService = createRelayService(
   getExperimentalFlag(GO_RELAY_BACKEND)
     ? {
         apiKey: RAINBOW_RELAY_GO_BACKEND_API_KEY,
-        baseUrl: RAINBOW_RELAY_GO_BACKEND_URL,
+        baseUrl: PLATFORM_BASE_URL,
         quoteSigner: getAddress(RAINBOW_RELAY_GO_BACKEND_QUOTE_SIGNER),
       }
     : {

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -101,6 +101,7 @@ export interface RainbowConfig extends Record<
   sponsored_perps_deposits_enabled: boolean;
   sponsored_polymarket_deposits_enabled: boolean;
   discover_placements_enabled: boolean;
+  go_relay_backend_enabled: boolean;
 }
 
 const Bips = {
@@ -236,6 +237,7 @@ export const DEFAULT_CONFIG = {
   sponsored_perps_deposits_enabled: true,
   sponsored_polymarket_deposits_enabled: true,
   discover_placements_enabled: true,
+  go_relay_backend_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 
 type RemoteConfigKey = keyof typeof DEFAULT_CONFIG;

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -463,14 +463,14 @@ const DevSection = () => {
             })}
           </Menu>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.feature_flags)}>
-            {(Object.keys(config) as ExperimentalConfigKey[])
+            {(Object.keys(defaultConfig) as ExperimentalConfigKey[])
               .sort()
               .filter(key => defaultConfig[key]?.settings)
               .map(key => (
                 <MenuItem
                   key={key}
                   onPress={() => onExperimentalKeyChange(key)}
-                  rightComponent={!!config[key] && <MenuItem.StatusIcon status="selected" />}
+                  rightComponent={!!(config[key] ?? defaultConfig[key].value) && <MenuItem.StatusIcon status="selected" />}
                   size={52}
                   titleComponent={<MenuItem.Title text={key} />}
                 />

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -470,7 +470,7 @@ const DevSection = () => {
                 <MenuItem
                   key={key}
                   onPress={() => onExperimentalKeyChange(key)}
-                  rightComponent={!!(config[key] ?? defaultConfig[key].value) && <MenuItem.StatusIcon status="selected" />}
+                  rightComponent={!!config[key] && <MenuItem.StatusIcon status="selected" />}
                   size={52}
                   titleComponent={<MenuItem.Title text={key} />}
                 />

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -463,7 +463,7 @@ const DevSection = () => {
             })}
           </Menu>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.feature_flags)}>
-            {(Object.keys(defaultConfig) as ExperimentalConfigKey[])
+            {(Object.keys(config) as ExperimentalConfigKey[])
               .sort()
               .filter(key => defaultConfig[key]?.settings)
               .map(key => (


### PR DESCRIPTION
Fixes APP-3663

## What changed (plus any additional context for devs)
- Adds an experimental flag to allow toggling the Go backend on/off internally
- Adds a remote flag to allow toggling off if needed
  - This is intentionally non-reactive, and at worst applies on next app launch
  - Unlikely to be needed and not worth the complexity to make it immediately reactive
  - Also avoids e.g. the relay backend switching midway through a sponsored execution, in the event it is toggled on/off
- Both flags default to the Go relay backend
- Disables the persist throttle on the experimental config store — the default throttle was preventing flags that use `needsRestart: true` from being applied when toggled due to the immediate JS thread restart (including this new flag)
- Adjusts the experimental store's `toggleFlag()` method to use the default value as a base in case the newly added config item isn't present in existing data

## Screen recordings / screenshots

## What to test
