### PR TITLE
feat: add sponsorship to Unstake

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1436,7 +1436,9 @@ export type EventProperties = {
   };
   [event.rnbwStakingUnstake]: {
     chainId: number;
-    txHash: string;
+    executionMode: 'sponsored' | 'manual';
+    txHash?: string;
+    executionId?: string;
     stakedAmount: string;
     expectedExitFee: string;
     expectedReceiveAmount: string;
@@ -1444,6 +1446,7 @@ export type EventProperties = {
   };
   [event.rnbwStakingUnstakeFailed]: {
     chainId: number;
+    executionMode?: 'sponsored' | 'manual';
     stakedAmount?: string;
     errorMessage: string;
   };

--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useRef, useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 
+import { destroyStore } from '@storesjs/stores';
 import { LinearGradient } from 'expo-linear-gradient';
 import { LinearTransition } from 'react-native-reanimated';
 
@@ -9,6 +10,9 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { RnbwCoinIcon } from '@/components/RnbwCoinIcon';
 import { Box, globalColors, Separator, Stack, Text, useForegroundColor } from '@/design-system';
+import { SmartWalletActivationCallout } from '@/features/delegation/components/SmartWalletActivationCallout';
+import { createPreparedCallsStore, type PreparedCallsStore } from '@/features/delegation/preparedCallsStore';
+import { predictSponsoredCallsExecution } from '@/features/delegation/sponsoredCalls';
 import { useGasSettings } from '@/features/gas/hooks/useSelectedGas';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
 import { buildGasParams } from '@/features/gas/utils/parseGas';
@@ -17,8 +21,11 @@ import { RNBW_SYMBOL } from '@/features/rnbw-rewards/constants';
 import { UnstakePenaltySign } from '@/features/rnbw-staking/components/UnstakePenaltySign';
 import { LoadingSpinner } from '@/framework/ui/components/LoadingSpinner';
 import { opacity } from '@/framework/ui/utils/opacity';
+import { useCleanup } from '@/hooks/useCleanup';
+import { useStableValue } from '@/hooks/useStableValue';
 import * as i18n from '@/languages';
 import { ensureError, logger, RainbowError } from '@/logger';
+import { useRemoteConfig } from '@/model/remoteConfig';
 import { useNavigation } from '@/navigation/Navigation';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 
@@ -26,7 +33,10 @@ import { STAKING_CHAIN_ID } from '../../constants';
 import { useRnbwStakingBalance } from '../../stores/derived/useRnbwStakingBalance';
 import { useRnbwStakingPositionPnl } from '../../stores/derived/useRnbwStakingPositionPnl';
 import { useStakingPositionStore } from '../../stores/rnbwStakingPositionStore';
+import { prepareUnstakeRnbw, type PreparedUnstakeRnbw, type UnstakeRnbwPreparationParams } from '../../utils/prepareUnstakeRnbw';
 import { unstakeRnbw } from '../../utils/unstakeRnbw';
+
+type UnstakePreparationStore = PreparedCallsStore<PreparedUnstakeRnbw, UnstakeRnbwPreparationParams>;
 
 const LAYOUT_ANIMATION_CONFIG = SPRING_CONFIGS.snappierSpringConfig;
 const LAYOUT_ANIMATION = LinearTransition.springify()
@@ -39,6 +49,11 @@ export const RnbwUnstakeSheet = memo(function RnbwUnstakeSheet() {
   const [step, setStep] = useState<'warning' | 'unstake'>('warning');
   const exitFeePercentage = useStakingPositionStore(s => s.getExitFeePercentage());
   const showSkeleton = exitFeePercentage === undefined;
+  const unstakePreparationStore = useStableValue(() => createPreparedCallsStore(prepareUnstakeRnbw));
+
+  useCleanup(() => {
+    destroyStore(unstakePreparationStore, { clearQueryCache: true });
+  }, [unstakePreparationStore]);
 
   const handleProceedToUnstake = useCallback(() => {
     setStep('unstake');
@@ -53,7 +68,7 @@ export const RnbwUnstakeSheet = memo(function RnbwUnstakeSheet() {
       ) : (
         <>
           {step === 'warning' && <WarningContent exitFeePercentage={exitFeePercentage} onProceed={handleProceedToUnstake} />}
-          {step === 'unstake' && <UnstakeContent exitFeePercentage={exitFeePercentage} />}
+          {step === 'unstake' && <UnstakeContent exitFeePercentage={exitFeePercentage} unstakePreparationStore={unstakePreparationStore} />}
         </>
       )}
     </PanelSheet>
@@ -119,13 +134,24 @@ const WarningContent = memo(function WarningContent({
   );
 });
 
-const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exitFeePercentage: number }) {
+const UnstakeContent = memo(function UnstakeContent({
+  exitFeePercentage,
+  unstakePreparationStore,
+}: {
+  exitFeePercentage: number;
+  unstakePreparationStore: UnstakePreparationStore;
+}) {
   const { tokenAmount, nativeCurrencyAmount } = useRnbwStakingBalance();
   const { netPnl, isPositivePnl, rnbwAfterUnstake } = useRnbwStakingPositionPnl();
   const { goBack } = useNavigation();
   const accountAddress = useAccountAddress();
   const gasSettings = useGasSettings(STAKING_CHAIN_ID, GasSpeed.FAST);
+  const { sponsored_rnbw_unstaking_enabled: sponsoredRnbwUnstakingEnabled } = useRemoteConfig('sponsored_rnbw_unstaking_enabled');
   const [isProcessing, setIsProcessing] = useState(false);
+  const canUseSponsoredUnstake =
+    Boolean(accountAddress) &&
+    sponsoredRnbwUnstakingEnabled &&
+    predictSponsoredCallsExecution({ address: accountAddress, chainId: STAKING_CHAIN_ID });
   const liveDisplay = {
     tokenAmount,
     nativeCurrencyAmount,
@@ -152,7 +178,13 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
     frozenDisplayRef.current = liveDisplay;
     setIsProcessing(true);
     try {
-      const { waitForConfirmation } = await unstakeRnbw({ address: accountAddress, gasParams: buildGasParams(gasSettings) });
+      const preparedCalls = canUseSponsoredUnstake
+        ? unstakePreparationStore
+            .getState()
+            .getPreparedCalls({ accountAddress })
+            .catch(() => null)
+        : Promise.resolve(null);
+      const { waitForConfirmation } = await unstakeRnbw({ address: accountAddress, gasParams: buildGasParams(gasSettings), preparedCalls });
       goBack();
       void waitForConfirmation().catch(error => {
         logger.warn('[RnbwUnstakeSheet]: Unstake confirmation failed', { error });
@@ -167,10 +199,6 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
       const error = ensureError(e);
       logger.error(new RainbowError('[RnbwUnstakeSheet]: Unstake failed', error));
     }
-  };
-
-  const handleUnstake = async () => {
-    await startUnstake();
   };
 
   return (
@@ -224,12 +252,15 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
         <RnbwHoldToActivateButton
           label={i18n.t(i18n.l.rnbw_staking.unstake_sheet.hold_to_unstake)}
           processingLabel={i18n.t(i18n.l.rnbw_staking.unstake_sheet.unstaking)}
-          onActivate={handleUnstake}
+          onActivate={startUnstake}
           isProcessing={isProcessing}
           disabled={!gasSettings}
           showBiometryIcon
           style={styles.fullWidthButton}
         />
+        {canUseSponsoredUnstake && (
+          <SmartWalletActivationCallout address={accountAddress} chainId={STAKING_CHAIN_ID} style={styles.smartWalletActivationCallout} />
+        )}
       </Box>
     </View>
   );
@@ -247,6 +278,10 @@ const styles = StyleSheet.create({
     paddingTop: 33,
   },
   fullWidthButton: {
+    width: '100%',
+  },
+  smartWalletActivationCallout: {
+    marginTop: 8,
     width: '100%',
   },
 });

--- a/src/features/rnbw-staking/utils/executeUnstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/executeUnstakeRnbw.test.ts
@@ -8,8 +8,8 @@ import { Wallet } from '@ethersproject/wallet';
 import { encodeFunctionData, type Address } from 'viem';
 
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
-import { TransactionDirection, TransactionStatus } from '@/entities/transactions';
 import { time } from '@/framework/core/utils/time';
+import { execute, type Call, type CallsRequirements, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 import {
   RNBW_DECIMALS,
@@ -22,8 +22,42 @@ import {
 } from '../constants';
 import { executeUnstakeRnbw } from './executeUnstakeRnbw';
 
+const mockExecuteCalls = jest.fn<Promise<unknown>, [unknown, unknown?]>();
+const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
+const mockBuildUnstakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
+const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unknown]>();
+const mockTrackCallsExecution = jest.fn<void, [unknown]>();
+const mockWaitForManagedExecutionConfirmation = jest.fn<Promise<void>, [string]>();
 const mockBuildSyntheticRnbwSourceAsset = jest.fn<ExtendedAnimatedAssetWithColors | null, []>();
 const mockAddNewTransaction = jest.fn<void, [unknown]>();
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    calls: (params: unknown, clients?: unknown) => mockExecuteCalls(params, clients),
+    prepare: {
+      calls: (params: unknown) => mockPrepareCalls(params),
+    },
+  },
+  RelayExecutionStatus: {
+    Confirmed: 'CONFIRMED',
+    Failed: 'FAILED',
+    Pending: 'PENDING',
+    Reverted: 'REVERTED',
+  },
+}));
+
+jest.mock('@/features/delegation/managedExecutionFailure', () => ({
+  resolveManagedExecutionFailure: (params: unknown) => mockResolveManagedExecutionFailure(params),
+}));
+
+jest.mock('@/features/delegation/callsExecutionTracking', () => ({
+  trackCallsExecution: (params: unknown) => mockTrackCallsExecution(params),
+}));
+
+jest.mock('@/features/delegation/waitForManagedExecution', () => ({
+  waitForManagedExecutionConfirmation: (executionId: string) => mockWaitForManagedExecutionConfirmation(executionId),
+}));
 
 jest.mock('@/state/pendingTransactions', () => ({
   addNewTransaction: (params: unknown) => mockAddNewTransaction(params),
@@ -39,6 +73,14 @@ jest.mock('@/utils/ethereumUtils', () => ({
   getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
 }));
 
+jest.mock('./unstakeRnbwCalls', () => ({
+  buildUnstakeRnbwExecutionPlan: (params: unknown) => mockBuildUnstakeRnbwExecutionPlan(params),
+}));
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
+}));
+
 jest.mock('./syntheticRnbwSourceAsset', () => ({
   buildSyntheticRnbwSourceAsset: () => mockBuildSyntheticRnbwSourceAsset(),
 }));
@@ -51,6 +93,7 @@ const UNSTAKE_ALL_DATA = encodeFunctionData({ abi: STAKING_ABI, functionName: 'u
 const GAS_PARAMS = { maxFeePerGas: '10', maxPriorityFeePerGas: '1' };
 const ESTIMATED_GAS_LIMIT = '123456';
 
+const UNSTAKE_CALL: Call = { data: UNSTAKE_ALL_DATA, to: STAKING_CONTRACT_ADDRESS, value: 0n };
 const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', STAKING_CHAIN_ID);
 const signer = new Wallet(PRIVATE_KEY, provider);
 
@@ -155,15 +198,236 @@ function buildTransactionResponse({
   }));
 }
 
+async function prepareCalls(plan: unknown): Promise<PreparedCallsExecution> {
+  mockPrepareCalls.mockResolvedValueOnce(plan);
+  return execute.prepare.calls({
+    calls: [UNSTAKE_CALL],
+    chainId: STAKING_CHAIN_ID,
+    provider,
+    signer,
+  });
+}
+
 describe('executeUnstakeRnbw', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
+    mockBuildUnstakeRnbwExecutionPlan.mockResolvedValue({ calls: [UNSTAKE_CALL] });
+    mockCanUseDelegatedExecution.mockReturnValue(true);
+    mockResolveManagedExecutionFailure.mockResolvedValue(null);
+    mockWaitForManagedExecutionConfirmation.mockResolvedValue();
     mockBuildSyntheticRnbwSourceAsset.mockReturnValue(rnbwAsset);
     jest.spyOn(provider, 'estimateGas').mockResolvedValue(BigNumber.from(ESTIMATED_GAS_LIMIT));
   });
 
-  it('submits the unstakeAll transaction directly and registers the pending transaction', async () => {
+  it('tracks wallet exact-call execution when prepared calls resolve to a wallet-paid transaction', async () => {
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt());
+    const preparedCalls = await prepareCalls({
+      kind: 'calls.wallet',
+      review: {
+        requiresDelegationAuthorization: false,
+        transactions: [],
+      },
+    });
+
+    mockExecuteCalls.mockResolvedValue({
+      kind: 'calls.wallet',
+      transactions: [
+        {
+          hash: TX_HASH,
+          transaction: {
+            data: UNSTAKE_ALL_DATA,
+            gas: 21000n,
+            maxFeePerGas: 1n,
+            maxPriorityFeePerGas: 1n,
+            nonce: 1,
+            to: STAKING_CONTRACT_ADDRESS,
+            value: 0n,
+          },
+          type: 'eip1559',
+        },
+      ],
+    });
+
+    const result = await executeUnstakeRnbw({
+      address: ACCOUNT,
+      expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+      gasParams: GAS_PARAMS,
+      preparedCalls,
+      provider,
+      signer,
+    });
+
+    expect(result.executionMode).toBe('manual');
+    expect(result.txHash).toBe(TX_HASH);
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId: STAKING_CHAIN_ID,
+      execution: expect.objectContaining({ hash: TX_HASH }),
+      transaction: expect.objectContaining({
+        from: ACCOUNT,
+        to: STAKING_CONTRACT_ADDRESS,
+        type: 'unstake',
+      }),
+    });
+    expect(mockExecuteCalls).toHaveBeenCalledWith(preparedCalls, {
+      chainId: STAKING_CHAIN_ID,
+      provider,
+      signer,
+    });
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('executes sponsored unstaking through the managed relay and waits through relay status', async () => {
+    const preparedCalls = await prepareCalls({
+      executionId: 'prepared-unstake',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+
+    mockExecuteCalls.mockResolvedValue({
+      executionId: 'submitted-unstake',
+      kind: 'calls.managed',
+      status: 'PENDING',
+    });
+
+    const result = await executeUnstakeRnbw({
+      address: ACCOUNT,
+      expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+      gasParams: GAS_PARAMS,
+      preparedCalls,
+      provider,
+      signer,
+    });
+
+    expect(result.executionMode).toBe('sponsored');
+    expect(result.executionId).toBe('submitted-unstake');
+    expect(result.txHash).toBeUndefined();
+    expect(mockExecuteCalls).toHaveBeenCalledWith(preparedCalls, {
+      chainId: STAKING_CHAIN_ID,
+      provider,
+      signer,
+    });
+    expect(mockResolveManagedExecutionFailure).toHaveBeenCalledWith({
+      executionId: 'submitted-unstake',
+      status: 'PENDING',
+    });
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId: STAKING_CHAIN_ID,
+      execution: {
+        executionId: 'submitted-unstake',
+        kind: 'calls.managed',
+        status: 'PENDING',
+      },
+      transaction: expect.objectContaining({
+        from: ACCOUNT,
+        to: STAKING_CONTRACT_ADDRESS,
+        type: 'unstake',
+      }),
+    });
+
+    await result.waitForConfirmation();
+
+    expect(mockWaitForManagedExecutionConfirmation).toHaveBeenCalledWith('submitted-unstake');
+  });
+
+  it('tracks the managed relay failure and throws when sponsored execution reports failure', async () => {
+    const preparedCalls = await prepareCalls({
+      executionId: 'prepared-unstake',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+
+    mockExecuteCalls.mockResolvedValue({
+      executionId: 'submitted-unstake',
+      kind: 'calls.managed',
+      status: 'FAILED',
+    });
+    mockResolveManagedExecutionFailure.mockResolvedValue('relay reported failure');
+
+    await expect(
+      executeUnstakeRnbw({
+        address: ACCOUNT,
+        expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+        gasParams: GAS_PARAMS,
+        preparedCalls,
+        provider,
+        signer,
+      })
+    ).rejects.toThrow('[executeUnstakeRnbw]: relay reported failure');
+    expect(mockTrackCallsExecution).not.toHaveBeenCalled();
+  });
+
+  it('executes unstaking through wallet exact calls when prepared calls are unavailable', async () => {
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt(TX_HASH));
+    mockExecuteCalls.mockResolvedValue({
+      kind: 'calls.wallet',
+      transactions: [
+        {
+          hash: TX_HASH,
+          transaction: {
+            data: UNSTAKE_ALL_DATA,
+            gas: 21000n,
+            maxFeePerGas: 1n,
+            maxPriorityFeePerGas: 1n,
+            nonce: 1,
+            to: STAKING_CONTRACT_ADDRESS,
+            value: 0n,
+          },
+          type: 'eip1559',
+        },
+      ],
+    });
+
+    const result = await executeUnstakeRnbw({
+      address: ACCOUNT,
+      expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+      gasParams: GAS_PARAMS,
+      preparedCalls: null,
+      provider,
+      signer,
+    });
+
+    expect(result.executionMode).toBe('manual');
+    expect(result.txHash).toBe(TX_HASH);
+    expect(mockBuildUnstakeRnbwExecutionPlan).toHaveBeenCalledWith({ address: ACCOUNT });
+    expect(mockExecuteCalls).toHaveBeenCalledWith(
+      {
+        calls: [UNSTAKE_CALL],
+        chainId: STAKING_CHAIN_ID,
+        provider,
+        signer,
+      },
+      undefined
+    );
+    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      chainId: STAKING_CHAIN_ID,
+      execution: expect.objectContaining({ hash: TX_HASH }),
+      transaction: expect.objectContaining({
+        from: ACCOUNT,
+        to: STAKING_CONTRACT_ADDRESS,
+        type: 'unstake',
+      }),
+    });
+    expect(provider.estimateGas).not.toHaveBeenCalled();
+    expect(mockAddNewTransaction).not.toHaveBeenCalled();
+    expect(waitForTransaction).not.toHaveBeenCalled();
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('submits the unstakeAll transaction directly when delegation is unavailable', async () => {
+    mockCanUseDelegatedExecution.mockReturnValue(false);
     const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt(TX_HASH));
     const sendTransaction = jest
       .spyOn(signer, 'sendTransaction')
@@ -173,55 +437,21 @@ describe('executeUnstakeRnbw', () => {
       address: ACCOUNT,
       expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
       gasParams: GAS_PARAMS,
+      preparedCalls: null,
       provider,
       signer,
     });
 
     expect(result.executionMode).toBe('manual');
     expect(result.txHash).toBe(TX_HASH);
-    expect(provider.estimateGas).toHaveBeenCalledWith({
-      data: UNSTAKE_ALL_DATA,
-      from: ACCOUNT,
-      to: STAKING_CONTRACT_ADDRESS,
-    });
+    expect(mockExecuteCalls).not.toHaveBeenCalled();
+    expect(mockTrackCallsExecution).not.toHaveBeenCalled();
     await expect(resolveProperties(sendTransaction.mock.calls[0][0])).resolves.toMatchObject({
       ...GAS_PARAMS,
       to: STAKING_CONTRACT_ADDRESS,
       data: UNSTAKE_ALL_DATA,
       gasLimit: ESTIMATED_GAS_LIMIT,
     });
-    expect(mockAddNewTransaction).toHaveBeenCalledWith({
-      address: ACCOUNT,
-      chainId: STAKING_CHAIN_ID,
-      transaction: expect.objectContaining({
-        asset: expect.objectContaining({
-          address: RNBW_TOKEN_ADDRESS,
-          chainId: STAKING_CHAIN_ID,
-          decimals: RNBW_DECIMALS,
-          isNativeAsset: false,
-          name: 'Rainbow',
-          symbol: 'RNBW',
-          uniqueId: RNBW_TOKEN_UNIQUE_ID,
-        }),
-        changes: [
-          expect.objectContaining({
-            address_from: STAKING_CONTRACT_ADDRESS,
-            address_to: ACCOUNT,
-            direction: TransactionDirection.IN,
-            value: EXPECTED_RECEIVE_AMOUNT_RAW,
-          }),
-        ],
-        data: UNSTAKE_ALL_DATA,
-        from: ACCOUNT,
-        gasLimit: BigNumber.from(ESTIMATED_GAS_LIMIT),
-        hash: TX_HASH,
-        nonce: 1,
-        status: TransactionStatus.pending,
-        to: STAKING_CONTRACT_ADDRESS,
-        type: 'unstake',
-      }),
-    });
-    expect(waitForTransaction).not.toHaveBeenCalled();
 
     await result.waitForConfirmation();
 
@@ -237,13 +467,16 @@ describe('executeUnstakeRnbw', () => {
       address: ACCOUNT,
       expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
       gasParams: GAS_PARAMS,
+      preparedCalls: null,
       provider,
       signer: hardwareSigner,
     });
 
     expect(result.executionMode).toBe('manual');
     expect(result.txHash).toBe(TX_HASH);
+    expect(mockExecuteCalls).not.toHaveBeenCalled();
     expect(hardwareSigner.sendTransactionMock).toHaveBeenCalledTimes(1);
+    expect(mockTrackCallsExecution).not.toHaveBeenCalled();
     await expect(resolveProperties(hardwareSigner.sendTransactionMock.mock.calls[0][0])).resolves.toMatchObject({
       ...GAS_PARAMS,
       to: STAKING_CONTRACT_ADDRESS,
@@ -256,7 +489,8 @@ describe('executeUnstakeRnbw', () => {
     expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
   });
 
-  it('uses the fallback gas limit when unstake gas estimation fails', async () => {
+  it('uses the fallback gas limit when manual unstake gas estimation fails', async () => {
+    mockCanUseDelegatedExecution.mockReturnValue(false);
     jest.spyOn(provider, 'estimateGas').mockRejectedValueOnce(new Error('estimate failed'));
     const sendTransaction = jest
       .spyOn(signer, 'sendTransaction')
@@ -266,6 +500,7 @@ describe('executeUnstakeRnbw', () => {
       address: ACCOUNT,
       expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
       gasParams: GAS_PARAMS,
+      preparedCalls: null,
       provider,
       signer,
     });

--- a/src/features/rnbw-staking/utils/executeUnstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/executeUnstakeRnbw.ts
@@ -1,29 +1,31 @@
 import type { Signer } from '@ethersproject/abstract-signer';
 import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
 import { encodeFunctionData, type Address, type Hex } from 'viem';
 
+import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
 import { RainbowError } from '@/logger';
 import { extractReplayableExecution } from '@/raps/replay';
 import { addNewTransaction } from '@/state/pendingTransactions';
+import { type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
 import { buildUnstakeTransaction } from './buildUnstakeTransaction';
+import { executeRnbwStakingCalls, type RnbwStakingExecution } from './executeRnbwStakingCalls';
+import { buildUnstakeRnbwExecutionPlan } from './unstakeRnbwCalls';
 import { waitForWalletTransactions } from './waitForWalletTransactions';
 
 // ============ Types ========================================================= //
 
 /** Submitted unstaking execution plus the confirmation waiter for its lane. */
-export type UnstakeRnbwExecution = {
-  executionMode: 'manual';
-  txHash: string;
-  waitForConfirmation: () => Promise<void>;
-};
+export type UnstakeRnbwExecution = RnbwStakingExecution;
 
 type ExecuteUnstakeRnbwParams = {
   address: Address;
   expectedReceiveAmountRaw: string;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
+  preparedCalls: PreparedCallsExecution | null;
   provider: StaticJsonRpcProvider;
   signer: Signer;
 };
@@ -37,10 +39,23 @@ export async function executeUnstakeRnbw({
   address,
   expectedReceiveAmountRaw,
   gasParams,
+  preparedCalls,
   provider,
   signer,
 }: ExecuteUnstakeRnbwParams): Promise<UnstakeRnbwExecution> {
-  return executeManualUnstakeRnbw({ address, expectedReceiveAmountRaw, gasParams, provider, signer });
+  if (!(signer instanceof Wallet) || !canUseDelegatedExecution(address)) {
+    return executeManualUnstakeRnbw({ address, expectedReceiveAmountRaw, gasParams, provider, signer });
+  }
+
+  return executeRnbwStakingCalls({
+    address,
+    buildPlan: () => buildUnstakeRnbwExecutionPlan({ address }),
+    errorPrefix: '[executeUnstakeRnbw]',
+    preparedCalls,
+    provider,
+    signer,
+    transaction: buildUnstakeTransaction({ address, unstakeAmountRaw: expectedReceiveAmountRaw }),
+  });
 }
 
 // ============ Local Helpers ================================================= //

--- a/src/features/rnbw-staking/utils/prepareUnstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/prepareUnstakeRnbw.test.ts
@@ -1,0 +1,112 @@
+import { type Address } from 'viem';
+
+import { type Call, type CallsRequirements } from '@rainbow-me/delegation';
+
+import { STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { prepareUnstakeRnbw } from './prepareUnstakeRnbw';
+
+const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
+const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
+const mockBuildUnstakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    prepare: {
+      calls: (params: unknown) => mockPrepareCalls(params),
+    },
+  },
+}));
+
+jest.mock('@/features/delegation/willDelegate', () => ({
+  canUseDelegatedExecution: (address: Address) => mockCanUseDelegatedExecution(address),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    getChainDefaultRpc: () => 'http://127.0.0.1:8545',
+    getDefaultChains: () => ({
+      8453: {
+        id: 8453,
+        name: 'Base',
+        nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+        rpcUrls: { default: { http: ['http://127.0.0.1:8545'] } },
+      },
+    }),
+  },
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+jest.mock('./unstakeRnbwCalls', () => ({
+  buildUnstakeRnbwExecutionPlan: (params: unknown) => mockBuildUnstakeRnbwExecutionPlan(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const UNSTAKE_CALL = { data: '0x1234', to: STAKING_CONTRACT_ADDRESS, value: 0n } satisfies Call;
+const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } } satisfies CallsRequirements;
+
+describe('prepareUnstakeRnbw', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanUseDelegatedExecution.mockReturnValue(true);
+    mockBuildUnstakeRnbwExecutionPlan.mockResolvedValue({ calls: [UNSTAKE_CALL], requirements: SPONSORED_REQUIREMENTS });
+    mockPrepareCalls.mockResolvedValue({
+      executionId: 'prepared-unstake',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+  });
+
+  it('prepares sponsor-paid exact calls ahead of unstaking submission', async () => {
+    await expect(prepareUnstakeRnbw({ accountAddress: ACCOUNT })).resolves.toEqual({
+      preparedCalls: {
+        executionId: 'prepared-unstake',
+        kind: 'calls.managed',
+        review: { fees: { payer: 'sponsor' } },
+      },
+    });
+
+    expect(mockBuildUnstakeRnbwExecutionPlan).toHaveBeenCalledWith({ address: ACCOUNT });
+    expect(mockPrepareCalls).toHaveBeenCalledWith({
+      account: ACCOUNT,
+      calls: [UNSTAKE_CALL],
+      chainId: STAKING_CHAIN_ID,
+      publicClient: expect.objectContaining({
+        chain: expect.objectContaining({ id: STAKING_CHAIN_ID }),
+      }),
+      requirements: SPONSORED_REQUIREMENTS,
+    });
+  });
+
+  it('skips preparation when delegated execution is unavailable', async () => {
+    mockCanUseDelegatedExecution.mockReturnValue(false);
+
+    await expect(prepareUnstakeRnbw({ accountAddress: ACCOUNT })).resolves.toBeNull();
+
+    expect(mockBuildUnstakeRnbwExecutionPlan).not.toHaveBeenCalled();
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+
+  it('skips preparation when unstake sponsorship is unavailable', async () => {
+    mockBuildUnstakeRnbwExecutionPlan.mockResolvedValue({ calls: [UNSTAKE_CALL] });
+
+    await expect(prepareUnstakeRnbw({ accountAddress: ACCOUNT })).resolves.toBeNull();
+
+    expect(mockBuildUnstakeRnbwExecutionPlan).toHaveBeenCalledWith({ address: ACCOUNT });
+    expect(mockPrepareCalls).not.toHaveBeenCalled();
+  });
+
+  it('skips preparation when the SDK does not return sponsor-paid calls', async () => {
+    mockPrepareCalls.mockResolvedValue({
+      kind: 'calls.wallet',
+      review: {
+        requiresDelegationAuthorization: false,
+        transactions: [],
+      },
+    });
+
+    await expect(prepareUnstakeRnbw({ accountAddress: ACCOUNT })).resolves.toBeNull();
+  });
+});

--- a/src/features/rnbw-staking/utils/prepareUnstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/prepareUnstakeRnbw.ts
@@ -1,0 +1,43 @@
+import { type Address } from 'viem';
+
+import { createDelegationPublicClient, isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
+import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
+import { execute, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import { STAKING_CHAIN_ID } from '../constants';
+import { buildUnstakeRnbwExecutionPlan } from './unstakeRnbwCalls';
+
+// ============ Types ========================================================= //
+
+/** Query identity for unstaking exact-call preparation. */
+export type UnstakeRnbwPreparationParams = {
+  accountAddress: Address;
+};
+
+/** Prepared unstaking execution for the wallet-funded portion of an unstake. */
+export type PreparedUnstakeRnbw = {
+  preparedCalls: PreparedCallsExecution;
+};
+
+// ============ Preparation =================================================== //
+
+/**
+ * Prepares unstaking calls ahead of submission.
+ */
+export async function prepareUnstakeRnbw({ accountAddress }: UnstakeRnbwPreparationParams): Promise<PreparedUnstakeRnbw | null> {
+  if (!canUseDelegatedExecution(accountAddress)) return null;
+
+  const plan = await buildUnstakeRnbwExecutionPlan({ address: accountAddress });
+  if (!plan.requirements) return null;
+
+  const preparedCalls = await execute.prepare.calls({
+    ...plan,
+    account: accountAddress,
+    chainId: STAKING_CHAIN_ID,
+    publicClient: createDelegationPublicClient(STAKING_CHAIN_ID),
+  });
+
+  if (!isPreparedCallsExecutionSponsored(preparedCalls)) return null;
+
+  return { preparedCalls };
+}

--- a/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
@@ -1,15 +1,17 @@
+import { Wallet } from '@ethersproject/wallet';
 import { type Address } from 'viem';
 
 import { STAKING_CHAIN_ID } from '../constants';
 import { type StakingPositionData } from '../stores/rnbwStakingPositionStore';
-import { type UnstakeRnbwExecution } from './executeUnstakeRnbw';
+import { type RnbwStakingExecution } from './executeRnbwStakingCalls';
+import { type PreparedUnstakeRnbw } from './prepareUnstakeRnbw';
 import { unstakeRnbw } from './unstakeRnbw';
 
 const mockGetProvider = jest.fn();
 const mockLoadWallet = jest.fn<Promise<unknown>, [unknown]>();
 const mockFetch = jest.fn<Promise<void>, [undefined, { force: boolean } | undefined]>();
 const mockGetData = jest.fn<StakingPositionData | undefined, []>();
-const mockExecuteUnstakeRnbw = jest.fn<Promise<UnstakeRnbwExecution>, [unknown]>();
+const mockExecuteUnstakeRnbw = jest.fn<Promise<RnbwStakingExecution>, [unknown]>();
 const mockPollForStakingUpdate = jest.fn<Promise<boolean>, [string]>();
 const mockTrack = jest.fn();
 
@@ -53,9 +55,17 @@ jest.mock('@/utils/ethereumUtils', () => ({
 }));
 
 const ACCOUNT: Address = '0x3333333333333333333333333333333333333333';
+const PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
 const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const GAS_PARAMS = { maxFeePerGas: '10', maxPriorityFeePerGas: '1' };
 const PROVIDER = { name: 'provider' };
+const PREPARED_CALLS = {
+  preparedCalls: {
+    executionId: 'prepared-unstake',
+    kind: 'calls.managed',
+    review: { fees: { payer: 'sponsor' } },
+  },
+} as unknown as PreparedUnstakeRnbw;
 
 const POSITION: StakingPositionData = {
   allTiers: [],
@@ -86,10 +96,18 @@ const POSITION: StakingPositionData = {
   tier: { level: 1 } as unknown as StakingPositionData['tier'],
 };
 
-function manualExecution(): UnstakeRnbwExecution {
+function manualExecution(): RnbwStakingExecution {
   return {
     executionMode: 'manual',
     txHash: TX_HASH,
+    waitForConfirmation: () => Promise.resolve(),
+  };
+}
+
+function sponsoredExecution(): RnbwStakingExecution {
+  return {
+    executionMode: 'sponsored',
+    executionId: 'submitted-unstake',
     waitForConfirmation: () => Promise.resolve(),
   };
 }
@@ -108,7 +126,7 @@ describe('unstakeRnbw', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetProvider.mockReturnValue(PROVIDER);
-    mockLoadWallet.mockResolvedValue({ sendTransaction: jest.fn() });
+    mockLoadWallet.mockResolvedValue(new Wallet(PRIVATE_KEY));
     mockGetData.mockReturnValue(POSITION);
     mockFetch.mockResolvedValue(undefined);
     mockExecuteUnstakeRnbw.mockResolvedValue(manualExecution());
@@ -125,7 +143,7 @@ describe('unstakeRnbw', () => {
       return manualExecution();
     });
 
-    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) });
 
     expect(mockFetch).toHaveBeenCalledWith(undefined, { force: true });
     expect(mockGetProvider).toHaveBeenCalled();
@@ -135,6 +153,7 @@ describe('unstakeRnbw', () => {
         address: ACCOUNT,
         expectedReceiveAmountRaw: '950000000000000000000',
         gasParams: GAS_PARAMS,
+        preparedCalls: null,
         provider: PROVIDER,
       })
     );
@@ -152,7 +171,7 @@ describe('unstakeRnbw', () => {
       waitForConfirmation: () => confirmationPromise,
     });
 
-    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) });
 
     expect(result.txHash).toBe(TX_HASH);
     expect(mockExecuteUnstakeRnbw).toHaveBeenCalled();
@@ -169,14 +188,18 @@ describe('unstakeRnbw', () => {
   it('throws when refreshed position data is missing', async () => {
     mockGetData.mockReturnValueOnce(POSITION).mockReturnValueOnce(undefined);
 
-    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toThrow('[unstakeRnbw]: Position data missing');
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) })).rejects.toThrow(
+      '[unstakeRnbw]: Position data missing'
+    );
     expect(mockExecuteUnstakeRnbw).not.toHaveBeenCalled();
   });
 
   it('throws when the exit fee percentage changes between snapshot and refresh', async () => {
     mockGetData.mockReturnValueOnce({ ...POSITION, exitFeePercentage: 5 }).mockReturnValueOnce({ ...POSITION, exitFeePercentage: 7 });
 
-    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toThrow('[unstakeRnbw]: Exit fee percentage changed');
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) })).rejects.toThrow(
+      '[unstakeRnbw]: Exit fee percentage changed'
+    );
     expect(mockExecuteUnstakeRnbw).not.toHaveBeenCalled();
   });
 
@@ -194,20 +217,63 @@ describe('unstakeRnbw', () => {
       return true;
     });
 
-    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) });
     await result.waitForConfirmation();
 
     expect(mockPollForStakingUpdate).toHaveBeenCalledWith(POSITION.poolShares);
     expect(order).toEqual(['waitForConfirmation', 'pollForStakingUpdate']);
   });
 
-  it('tracks the success analytics payload with the existing field set', async () => {
-    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+  it('tracks the success analytics payload with executionMode and txHash for manual execution', async () => {
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) });
     await result.waitForConfirmation();
 
     expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake', {
       chainId: STAKING_CHAIN_ID,
+      executionMode: 'manual',
       txHash: TX_HASH,
+      executionId: undefined,
+      stakedAmount: '1000',
+      expectedExitFee: '50',
+      expectedReceiveAmount: '950',
+      pnl: '0',
+    });
+  });
+
+  it('passes prepared calls through to executeUnstakeRnbw when the resolved signer is a software wallet', async () => {
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(PREPARED_CALLS) });
+
+    expect(mockExecuteUnstakeRnbw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preparedCalls: PREPARED_CALLS.preparedCalls,
+      })
+    );
+  });
+
+  it('skips prepared calls when the signer is not a software wallet', async () => {
+    const hardwareSigner = { sendTransaction: jest.fn() };
+    mockLoadWallet.mockResolvedValue(hardwareSigner);
+
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(PREPARED_CALLS) });
+
+    expect(mockExecuteUnstakeRnbw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preparedCalls: null,
+      })
+    );
+  });
+
+  it('tracks executionId and sponsored execution mode in the success analytics payload', async () => {
+    mockExecuteUnstakeRnbw.mockResolvedValue(sponsoredExecution());
+
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(PREPARED_CALLS) });
+    await result.waitForConfirmation();
+
+    expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake', {
+      chainId: STAKING_CHAIN_ID,
+      executionMode: 'sponsored',
+      txHash: undefined,
+      executionId: 'submitted-unstake',
       stakedAmount: '1000',
       expectedExitFee: '50',
       expectedReceiveAmount: '950',
@@ -219,10 +285,11 @@ describe('unstakeRnbw', () => {
     const error = new Error('boom');
     mockExecuteUnstakeRnbw.mockRejectedValueOnce(error);
 
-    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toBe(error);
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) })).rejects.toBe(error);
 
     expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake.failed', {
       chainId: STAKING_CHAIN_ID,
+      executionMode: 'manual',
       stakedAmount: '1000',
       errorMessage: 'boom',
     });
@@ -232,7 +299,7 @@ describe('unstakeRnbw', () => {
   it('allows a zero exit fee percentage', async () => {
     mockGetData.mockReturnValue({ ...POSITION, exitFeePercentage: 0 });
 
-    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(null) });
     await result.waitForConfirmation();
 
     expect(mockExecuteUnstakeRnbw).toHaveBeenCalledWith(
@@ -242,11 +309,50 @@ describe('unstakeRnbw', () => {
     );
     expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake', {
       chainId: STAKING_CHAIN_ID,
+      executionMode: 'manual',
       txHash: TX_HASH,
+      executionId: undefined,
       stakedAmount: '1000',
       expectedExitFee: '0',
       expectedReceiveAmount: '1000',
       pnl: '50',
+    });
+  });
+
+  it('records sponsored execution mode when sponsored submission fails before returning an execution', async () => {
+    const error = new Error('relay rejected execution');
+    mockExecuteUnstakeRnbw.mockRejectedValueOnce(error);
+
+    await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(PREPARED_CALLS) })).rejects.toBe(
+      error
+    );
+
+    expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake.failed', {
+      chainId: STAKING_CHAIN_ID,
+      executionMode: 'sponsored',
+      stakedAmount: '1000',
+      errorMessage: 'relay rejected execution',
+    });
+  });
+
+  it('records the sponsored execution mode on failure analytics when sponsored execution reports a relay failure', async () => {
+    const error = new Error('relay reported failure');
+    mockExecuteUnstakeRnbw.mockResolvedValueOnce({
+      executionMode: 'sponsored',
+      executionId: 'submitted-unstake',
+      waitForConfirmation: async () => {
+        throw error;
+      },
+    });
+
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS, preparedCalls: Promise.resolve(PREPARED_CALLS) });
+    await expect(result.waitForConfirmation()).rejects.toBe(error);
+
+    expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake.failed', {
+      chainId: STAKING_CHAIN_ID,
+      executionMode: 'sponsored',
+      stakedAmount: '1000',
+      errorMessage: 'relay reported failure',
     });
   });
 });

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -1,6 +1,8 @@
+import { Wallet } from '@ethersproject/wallet';
 import { type Address } from 'viem';
 
 import { analytics } from '@/analytics';
+import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
 import { mulWorklet, subWorklet } from '@/framework/core/safeMath';
 import { getProvider } from '@/handlers/web3';
@@ -10,8 +12,10 @@ import { loadWallet } from '@/model/wallet';
 
 import { STAKING_CHAIN_ID } from '../constants';
 import { useStakingPositionStore, type StakingPositionData } from '../stores/rnbwStakingPositionStore';
-import { executeUnstakeRnbw, type UnstakeRnbwExecution } from './executeUnstakeRnbw';
+import { type RnbwStakingExecution, type RnbwStakingExecutionMode } from './executeRnbwStakingCalls';
+import { executeUnstakeRnbw } from './executeUnstakeRnbw';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
+import { type PreparedUnstakeRnbw } from './prepareUnstakeRnbw';
 
 type UnstakeAnalyticsSnapshot = {
   stakedAmount: string;
@@ -22,20 +26,24 @@ type UnstakeAnalyticsSnapshot = {
 };
 
 type UnstakeRnbwResult = {
-  txHash: string;
+  executionId?: string;
+  txHash?: string;
   waitForConfirmation: () => Promise<void>;
 };
 
 export async function unstakeRnbw({
   address,
   gasParams,
+  preparedCalls: preparedCallsPromise,
 }: {
   address: Address;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
+  preparedCalls: Promise<PreparedUnstakeRnbw | null>;
 }): Promise<UnstakeRnbwResult> {
   const positionData = await refreshAndValidatePosition();
   const { receiveRaw, ...analyticsSnapshot } = snapshotUnstakeAnalytics(positionData);
 
+  let executionMode: RnbwStakingExecutionMode | undefined;
   try {
     const provider = getProvider({ chainId: STAKING_CHAIN_ID });
     const signer = await loadWallet({ address, provider });
@@ -43,21 +51,28 @@ export async function unstakeRnbw({
       throw new Error('Failed to load wallet');
     }
 
+    const resolvedPrepared = signer instanceof Wallet ? await preparedCallsPromise : null;
+    const preparedCalls = resolvedPrepared?.preparedCalls ?? null;
+    executionMode = signer instanceof Wallet && isPreparedCallsExecutionSponsored(preparedCalls) ? 'sponsored' : 'manual';
+
     const execution = await executeUnstakeRnbw({
       address,
       expectedReceiveAmountRaw: receiveRaw,
       gasParams,
+      preparedCalls,
       provider,
       signer,
     });
 
     return {
+      executionId: execution.executionId,
       txHash: execution.txHash,
       waitForConfirmation: () => finalizeSubmittedUnstake({ analyticsSnapshot, execution, positionData }),
     };
   } catch (error) {
     analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
       chainId: STAKING_CHAIN_ID,
+      executionMode,
       stakedAmount: analyticsSnapshot.stakedAmount,
       errorMessage: error instanceof Error ? error.message : 'Unknown error',
     });
@@ -87,7 +102,7 @@ async function finalizeSubmittedUnstake({
   positionData,
 }: {
   analyticsSnapshot: Omit<UnstakeAnalyticsSnapshot, 'receiveRaw'>;
-  execution: UnstakeRnbwExecution;
+  execution: RnbwStakingExecution;
   positionData: StakingPositionData;
 }): Promise<void> {
   try {
@@ -95,12 +110,15 @@ async function finalizeSubmittedUnstake({
     await pollForStakingUpdate(positionData.poolShares);
     analytics.track(analytics.event.rnbwStakingUnstake, {
       chainId: STAKING_CHAIN_ID,
+      executionMode: execution.executionMode,
       txHash: execution.txHash,
+      executionId: execution.executionId,
       ...analyticsSnapshot,
     });
   } catch (error) {
     analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
       chainId: STAKING_CHAIN_ID,
+      executionMode: execution.executionMode,
       stakedAmount: analyticsSnapshot.stakedAmount,
       errorMessage: error instanceof Error ? error.message : 'Unknown error',
     });

--- a/src/features/rnbw-staking/utils/unstakeRnbwCalls.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbwCalls.test.ts
@@ -1,0 +1,72 @@
+import { encodeFunctionData, type Address } from 'viem';
+
+import { type Call, type CallsRequirements } from '@rainbow-me/delegation';
+
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { buildUnstakeRnbwCalls, buildUnstakeRnbwExecutionPlan } from './unstakeRnbwCalls';
+
+const mockCanUseSponsoredRnbwStaking = jest.fn<Promise<boolean>, [Address, number]>();
+const mockGetRemoteConfig = jest.fn<{ sponsored_rnbw_unstaking_enabled: boolean }, []>();
+
+jest.mock('./canUseSponsoredRnbwStaking', () => ({
+  canUseSponsoredRnbwStaking: (address: Address, chainId: number) => mockCanUseSponsoredRnbwStaking(address, chainId),
+}));
+
+jest.mock('@/model/remoteConfig', () => ({
+  getRemoteConfig: () => mockGetRemoteConfig(),
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const SPONSORED_REQUIREMENTS = { atomic: 'required', fees: { payer: 'sponsor' } } satisfies CallsRequirements;
+
+function buildUnstakeCall(): Call {
+  return {
+    data: encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' }),
+    to: STAKING_CONTRACT_ADDRESS,
+    value: 0n,
+  };
+}
+
+describe('unstakeRnbwCalls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanUseSponsoredRnbwStaking.mockResolvedValue(false);
+    mockGetRemoteConfig.mockReturnValue({ sponsored_rnbw_unstaking_enabled: true });
+  });
+
+  it('builds a single unstakeAll call', () => {
+    expect(buildUnstakeRnbwCalls()).toEqual([buildUnstakeCall()]);
+  });
+
+  it('adds sponsor-paid requirements when unstaking can use sponsored execution and flag is on', async () => {
+    mockCanUseSponsoredRnbwStaking.mockResolvedValue(true);
+
+    await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
+      calls: [buildUnstakeCall()],
+      requirements: SPONSORED_REQUIREMENTS,
+    });
+
+    expect(mockCanUseSponsoredRnbwStaking).toHaveBeenCalledWith(ACCOUNT, STAKING_CHAIN_ID);
+  });
+
+  it('omits requirements when sponsorship is unavailable', async () => {
+    await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
+      calls: [buildUnstakeCall()],
+    });
+  });
+
+  it('omits requirements when the feature flag is off, even if sponsored execution is available', async () => {
+    mockCanUseSponsoredRnbwStaking.mockResolvedValue(true);
+    mockGetRemoteConfig.mockReturnValue({ sponsored_rnbw_unstaking_enabled: false });
+
+    await expect(buildUnstakeRnbwExecutionPlan({ address: ACCOUNT })).resolves.toEqual({
+      calls: [buildUnstakeCall()],
+    });
+
+    expect(mockCanUseSponsoredRnbwStaking).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/rnbw-staking/utils/unstakeRnbwCalls.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbwCalls.ts
@@ -1,0 +1,46 @@
+import { encodeFunctionData, type Address } from 'viem';
+
+import { SPONSORED_CALLS_REQUIREMENTS } from '@/features/delegation/calls';
+import { getRemoteConfig } from '@/model/remoteConfig';
+import { type Call, type CallsRequirements } from '@rainbow-me/delegation';
+
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { canUseSponsoredRnbwStaking } from './canUseSponsoredRnbwStaking';
+
+// ============ Types ========================================================= //
+
+/** Exact-call sequence plus execution requirements for SDK unstaking execution. */
+export type UnstakeRnbwExecutionPlan = {
+  calls: Call[];
+  requirements?: CallsRequirements;
+};
+
+// ============ Calls ========================================================= //
+
+/**
+ * Builds the exact unstake call sequence for a full RNBW unstake.
+ */
+export function buildUnstakeRnbwCalls(): Call[] {
+  return [
+    {
+      to: STAKING_CONTRACT_ADDRESS,
+      value: 0n,
+      data: encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' }),
+    },
+  ];
+}
+
+/**
+ * Builds the SDK exact-call plan shared by preparation and software-wallet fallback execution.
+ */
+export async function buildUnstakeRnbwExecutionPlan({ address }: { address: Address }): Promise<UnstakeRnbwExecutionPlan> {
+  const calls = buildUnstakeRnbwCalls();
+  const requirements = await resolveUnstakeRnbwCallsRequirements(address);
+
+  return requirements ? { calls, requirements } : { calls };
+}
+
+async function resolveUnstakeRnbwCallsRequirements(address: Address): Promise<CallsRequirements | undefined> {
+  if (!getRemoteConfig().sponsored_rnbw_unstaking_enabled) return undefined;
+  return (await canUseSponsoredRnbwStaking(address, STAKING_CHAIN_ID)) ? SPONSORED_CALLS_REQUIREMENTS : undefined;
+}

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -98,6 +98,8 @@ export interface RainbowConfig extends Record<
   sponsored_swaps_enabled: boolean;
   sponsored_perps_deposits_enabled: boolean;
   sponsored_polymarket_deposits_enabled: boolean;
+  sponsored_rnbw_unstaking_enabled: boolean;
+  discover_placements_enabled: boolean;
   go_relay_backend_enabled: boolean;
 }
 
@@ -231,6 +233,8 @@ export const DEFAULT_CONFIG = {
   sponsored_swaps_enabled: true,
   sponsored_perps_deposits_enabled: true,
   sponsored_polymarket_deposits_enabled: true,
+  sponsored_rnbw_unstaking_enabled: true,
+  discover_placements_enabled: true,
   go_relay_backend_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3759/sponsor-unstaking

## What changed (plus any additional context for devs)

Adds sponsored execution support to RNBW unstaking so eligible software-wallet users can unstake through the managed calls lane instead of always paying gas manually.

The unstake flow now prepares the exact unstake call when sponsorship is available, submits it through the delegation SDK when possible, and keeps the existing manual transaction path for hardware wallets, unavailable delegation, or disabled sponsorship. Analytics now record whether unstaking completed through manual or sponsored execution.

## Screen recordings / screenshots

[Simulator Screen Recording - iPhone 17 Pro - 2026-05-29 at 00.53.38.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3cdfe15d-9ce4-49e2-9057-4216af9328df.mov" />](https://app.graphite.com/user-attachments/video/3cdfe15d-9ce4-49e2-9057-4216af9328df.mov)