### PR TITLE
fix: show pending unstake transaction toast

### DIFF
--- a/src/features/rnbw-staking/utils/buildUnstakeTransaction.ts
+++ b/src/features/rnbw-staking/utils/buildUnstakeTransaction.ts
@@ -1,0 +1,47 @@
+import { type Address } from 'viem';
+
+import { TransactionDirection, TransactionStatus, type NewTransaction } from '@/entities/transactions';
+import { RainbowError } from '@/logger';
+import { toTransactionAsset } from '@/raps/transactionAsset';
+import { backendNetworksActions } from '@/state/backendNetworks/backendNetworks';
+
+import { STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS } from '../constants';
+import { buildSyntheticRnbwSourceAsset } from './syntheticRnbwSourceAsset';
+
+export function buildUnstakeTransaction({
+  address,
+  unstakeAmountRaw,
+}: {
+  address: Address;
+  unstakeAmountRaw: string;
+}): Omit<NewTransaction, 'hash'> {
+  const chainName = backendNetworksActions.getChainsName()[STAKING_CHAIN_ID];
+  const asset = buildSyntheticRnbwSourceAsset();
+  if (!asset) {
+    throw new RainbowError('[buildUnstakeTransaction]: RNBW source asset unavailable');
+  }
+
+  const transactionAsset = toTransactionAsset({ asset, chainName });
+
+  return {
+    asset: transactionAsset,
+    chainId: STAKING_CHAIN_ID,
+    changes: [
+      {
+        address_from: STAKING_CONTRACT_ADDRESS,
+        address_to: address,
+        asset: transactionAsset,
+        direction: TransactionDirection.IN,
+        price: asset.price?.value,
+        value: unstakeAmountRaw,
+      },
+    ],
+    from: address,
+    network: chainName,
+    nonce: -1,
+    status: TransactionStatus.pending,
+    to: STAKING_CONTRACT_ADDRESS,
+    type: 'unstake',
+    value: '0',
+  };
+}

--- a/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
@@ -2,7 +2,18 @@ import type { TransactionResponse } from '@ethersproject/abstract-provider';
 import type { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { encodeFunctionData, type Address } from 'viem';
 
-import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
+import { TransactionDirection, TransactionStatus } from '@/entities/transactions';
+
+import {
+  RNBW_DECIMALS,
+  RNBW_TOKEN_ADDRESS,
+  RNBW_TOKEN_ICON_URL,
+  RNBW_TOKEN_UNIQUE_ID,
+  STAKING_ABI,
+  STAKING_CHAIN_ID,
+  STAKING_CONTRACT_ADDRESS,
+  STAKING_UNSTAKE_GAS_LIMIT,
+} from '../constants';
 import { type StakingPositionData } from '../stores/rnbwStakingPositionStore';
 import { unstakeRnbw } from './unstakeRnbw';
 
@@ -15,6 +26,9 @@ const mockEstimateGas = jest.fn<Promise<{ toString: () => string }>, [unknown]>(
 const mockPollForStakingUpdate = jest.fn<Promise<boolean>, [string]>();
 const mockWaitForWalletTransactions = jest.fn<Promise<void>, [unknown]>();
 const mockTrack = jest.fn();
+const mockAddNewTransaction = jest.fn();
+const mockBuildSyntheticRnbwSourceAsset = jest.fn();
+const mockGetChainsName = jest.fn();
 
 jest.mock('@/analytics', () => ({
   analytics: {
@@ -32,6 +46,20 @@ jest.mock('@/handlers/web3', () => ({
 
 jest.mock('@/model/wallet', () => ({
   loadWallet: (params: unknown) => mockLoadWallet(params),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    getChainsName: () => mockGetChainsName(),
+  },
+}));
+
+jest.mock('@/state/pendingTransactions', () => ({
+  addNewTransaction: (params: unknown) => mockAddNewTransaction(params),
+}));
+
+jest.mock('./syntheticRnbwSourceAsset', () => ({
+  buildSyntheticRnbwSourceAsset: () => mockBuildSyntheticRnbwSourceAsset(),
 }));
 
 jest.mock('../stores/rnbwStakingPositionStore', () => ({
@@ -60,6 +88,7 @@ const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 const UNSTAKE_ALL_DATA = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
 const GAS_PARAMS = { maxFeePerGas: '10', maxPriorityFeePerGas: '1' };
 const ESTIMATED_GAS_LIMIT = '123456';
+const TX_NONCE = 7;
 const PROVIDER = {
   estimateGas: (params: unknown) => mockEstimateGas(params),
   name: 'provider',
@@ -108,13 +137,40 @@ describe('unstakeRnbw', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetProvider.mockReturnValue(PROVIDER);
+    mockGetChainsName.mockReturnValue({ [STAKING_CHAIN_ID]: 'base' });
+    mockBuildSyntheticRnbwSourceAsset.mockReturnValue({
+      address: RNBW_TOKEN_ADDRESS,
+      balance: { amount: '0', display: '0 RNBW' },
+      chainId: STAKING_CHAIN_ID,
+      chainName: 'Base',
+      colors: { fallback: '#f2c745', primary: '#f2c745' },
+      decimals: RNBW_DECIMALS,
+      icon_url: RNBW_TOKEN_ICON_URL,
+      isNativeAsset: false,
+      mainnetAddress: RNBW_TOKEN_ADDRESS,
+      name: 'Rainbow',
+      native: {
+        balance: { amount: '0', display: '$0.00' },
+        price: { amount: 1, change: '0', display: '$1.00' },
+      },
+      nativePrice: 1,
+      networks: {
+        [STAKING_CHAIN_ID]: {
+          address: RNBW_TOKEN_ADDRESS,
+          decimals: RNBW_DECIMALS,
+        },
+      },
+      price: { value: 1 },
+      symbol: 'RNBW',
+      uniqueId: RNBW_TOKEN_UNIQUE_ID,
+    });
     mockLoadWallet.mockResolvedValue({
       sendTransaction: (params: unknown) => mockSendTransaction(params),
     });
     mockGetData.mockReturnValue(POSITION);
     mockFetch.mockResolvedValue(undefined);
     mockEstimateGas.mockResolvedValue({ toString: () => ESTIMATED_GAS_LIMIT });
-    mockSendTransaction.mockResolvedValue({ hash: TX_HASH } as TransactionResponse);
+    mockSendTransaction.mockResolvedValue({ hash: TX_HASH, nonce: TX_NONCE } as TransactionResponse);
     mockPollForStakingUpdate.mockResolvedValue(true);
     mockWaitForWalletTransactions.mockResolvedValue(undefined);
   });
@@ -126,7 +182,7 @@ describe('unstakeRnbw', () => {
     });
     mockSendTransaction.mockImplementation(async () => {
       record('sendTransaction');
-      return { hash: TX_HASH } as TransactionResponse;
+      return { hash: TX_HASH, nonce: TX_NONCE } as TransactionResponse;
     });
 
     await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
@@ -146,6 +202,62 @@ describe('unstakeRnbw', () => {
       gasLimit: ESTIMATED_GAS_LIMIT,
     });
     expect(order).toEqual(['fetch', 'sendTransaction']);
+  });
+
+  it('adds a pending unstake transaction before waiting for confirmation', async () => {
+    const { order, record } = recordCallOrder();
+    mockAddNewTransaction.mockImplementation(() => {
+      record('addNewTransaction');
+    });
+    mockWaitForWalletTransactions.mockImplementation(async () => {
+      record('waitForWalletTransactions');
+    });
+
+    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+
+    const expectedAsset = expect.objectContaining({
+      address: RNBW_TOKEN_ADDRESS,
+      chainId: STAKING_CHAIN_ID,
+      decimals: RNBW_DECIMALS,
+      icon_url: RNBW_TOKEN_ICON_URL,
+      isNativeAsset: false,
+      mainnet_address: RNBW_TOKEN_ADDRESS,
+      name: 'Rainbow',
+      network: 'base',
+      symbol: 'RNBW',
+      uniqueId: RNBW_TOKEN_UNIQUE_ID,
+    });
+    expect(mockAddNewTransaction).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      chainId: STAKING_CHAIN_ID,
+      transaction: expect.objectContaining({
+        asset: expectedAsset,
+        chainId: STAKING_CHAIN_ID,
+        changes: [
+          expect.objectContaining({
+            address_from: STAKING_CONTRACT_ADDRESS,
+            address_to: ACCOUNT,
+            asset: expectedAsset,
+            direction: TransactionDirection.IN,
+            value: '950000000000000000000',
+          }),
+        ],
+        data: UNSTAKE_ALL_DATA,
+        from: ACCOUNT,
+        gasLimit: ESTIMATED_GAS_LIMIT,
+        gasPrice: undefined,
+        hash: TX_HASH,
+        maxFeePerGas: undefined,
+        maxPriorityFeePerGas: undefined,
+        network: 'base',
+        nonce: TX_NONCE,
+        status: TransactionStatus.pending,
+        to: STAKING_CONTRACT_ADDRESS,
+        type: 'unstake',
+        value: '0',
+      }),
+    });
+    expect(order).toEqual(['addNewTransaction', 'waitForWalletTransactions']);
   });
 
   it('throws when refreshed position data is missing', async () => {

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -8,9 +8,12 @@ import { getProvider } from '@/handlers/web3';
 import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 import { RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
+import { extractReplayableExecution } from '@/raps/replay';
+import { addNewTransaction } from '@/state/pendingTransactions';
 
 import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
 import { useStakingPositionStore, type StakingPositionData } from '../stores/rnbwStakingPositionStore';
+import { buildUnstakeTransaction } from './buildUnstakeTransaction';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
 import { waitForWalletTransactions } from './waitForWalletTransactions';
 
@@ -35,7 +38,7 @@ export async function unstakeRnbw({
     const txHash = await submitAndConfirmUnstake({
       address,
       gasParams,
-      originalStakedRnbwShares: positionData.poolShares,
+      positionData,
     });
 
     analytics.track(analytics.event.rnbwStakingUnstake, {
@@ -74,11 +77,11 @@ async function refreshAndValidatePosition(): Promise<StakingPositionData> {
 async function submitAndConfirmUnstake({
   address,
   gasParams,
-  originalStakedRnbwShares,
+  positionData,
 }: {
   address: Address;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
-  originalStakedRnbwShares: string;
+  positionData: StakingPositionData;
 }): Promise<Hash> {
   const provider = getProvider({ chainId: STAKING_CHAIN_ID });
   const signer = await loadWallet({ address, provider });
@@ -94,9 +97,34 @@ async function submitAndConfirmUnstake({
     data,
     gasLimit,
   });
+  const { receiveRaw } = computeUnstakeAmounts(positionData);
+
+  const submittedUnstake = extractReplayableExecution(tx, {
+    to: STAKING_CONTRACT_ADDRESS,
+    data,
+    value: 0,
+  });
+  if (!submittedUnstake) {
+    throw new RainbowError('[executeUnstakeRnbw]: manual unstaking did not return replayable transaction metadata');
+  }
+
+  addNewTransaction({
+    address,
+    chainId: STAKING_CHAIN_ID,
+    transaction: {
+      ...buildUnstakeTransaction({ address, unstakeAmountRaw: receiveRaw }),
+      ...submittedUnstake.replayableCall,
+      gasLimit: tx.gasLimit ?? gasLimit,
+      gasPrice: tx.gasPrice,
+      hash: submittedUnstake.hash,
+      maxFeePerGas: tx.maxFeePerGas,
+      maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+      nonce: submittedUnstake.nonce,
+    },
+  });
 
   await waitForWalletTransactions({ provider, txHashes: [tx.hash] });
-  await pollForStakingUpdate(originalStakedRnbwShares);
+  await pollForStakingUpdate(positionData.poolShares);
 
   return tx.hash as Hash;
 }
@@ -119,13 +147,19 @@ async function estimateUnstakeGasLimit({
 }
 
 function snapshotUnstakeAnalytics(positionData: StakingPositionData): UnstakeAnalyticsSnapshot {
-  const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl, exitFeePercentage } = positionData;
-  const exitFeeRaw = mulWorklet(stakedRnbwRaw, exitFeePercentage / 100);
+  const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl } = positionData;
+  const { receiveRaw, exitFeeRaw } = computeUnstakeAmounts(positionData);
 
   return {
     stakedAmount: convertRawAmountToDecimalFormat(stakedRnbwRaw, decimals),
     expectedExitFee: convertRawAmountToDecimalFormat(exitFeeRaw, decimals),
-    expectedReceiveAmount: convertRawAmountToDecimalFormat(subWorklet(stakedRnbwRaw, exitFeeRaw), decimals),
+    expectedReceiveAmount: convertRawAmountToDecimalFormat(receiveRaw, decimals),
     pnl: convertRawAmountToDecimalFormat(subWorklet(sessionPnl.exchangeRateGain, exitFeeRaw), decimals),
   };
+}
+
+function computeUnstakeAmounts(positionData: StakingPositionData): { exitFeeRaw: string; receiveRaw: string } {
+  const { stakedRnbw, exitFeePercentage } = positionData;
+  const exitFeeRaw = mulWorklet(stakedRnbw, exitFeePercentage / 100);
+  return { exitFeeRaw, receiveRaw: subWorklet(stakedRnbw, exitFeeRaw) };
 }


### PR DESCRIPTION
Fixed: APP-3761

## Why?

APP-3761 reports two unstaking bugs with the same root cause: after submitting unstake, users do not see an “Unstaking” progress toast, and the unstake transaction may not appear in history until another wallet action refreshes transaction state.

Unstake was submitting and confirming correctly, but it skipped the local pending transaction overlay. That overlay powers both RainbowToast and the immediate activity list row.

## Approach

Register unstake as a local pending transaction as soon as the wallet returns a hash, using the same RNBW asset normalization path used by staking. The existing confirmation wait, staking-position polling, and analytics flow remain unchanged.

## Testing

Unstake RNBW from a wallet with an active staking position.

Confirm the “Unstaking” toast appears immediately and the activity list shows the pending unstake without needing another action.

Let the transaction settle and confirm it resolves to “Unstaked” and staking balances refresh.

[Simulator Screen Recording - iPhone 17 Pro - 2026-05-28 at 20.16.00.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/134f042f-c6ec-4019-afd4-0726f0e06a49.mov" />](https://app.graphite.com/user-attachments/video/134f042f-c6ec-4019-afd4-0726f0e06a49.mov)

