### PR TITLE
feat: close unstaking sheet once toast is visible

### DIFF
--- a/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
+++ b/src/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet.tsx
@@ -152,8 +152,11 @@ const UnstakeContent = memo(function UnstakeContent({ exitFeePercentage }: { exi
     frozenDisplayRef.current = liveDisplay;
     setIsProcessing(true);
     try {
-      await unstakeRnbw({ address: accountAddress, gasParams: buildGasParams(gasSettings) });
+      const { waitForConfirmation } = await unstakeRnbw({ address: accountAddress, gasParams: buildGasParams(gasSettings) });
       goBack();
+      void waitForConfirmation().catch(error => {
+        logger.warn('[RnbwUnstakeSheet]: Unstake confirmation failed', { error });
+      });
     } catch (e) {
       setIsProcessing(false);
       frozenDisplayRef.current = null;

--- a/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
@@ -213,7 +213,7 @@ describe('unstakeRnbw', () => {
       record('waitForWalletTransactions');
     });
 
-    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
 
     const expectedAsset = expect.objectContaining({
       address: RNBW_TOKEN_ADDRESS,
@@ -257,7 +257,29 @@ describe('unstakeRnbw', () => {
         value: '0',
       }),
     });
+    expect(mockWaitForWalletTransactions).not.toHaveBeenCalled();
+    await result.waitForConfirmation();
     expect(order).toEqual(['addNewTransaction', 'waitForWalletTransactions']);
+  });
+
+  it('returns after registering the pending unstake transaction', async () => {
+    let resolveConfirmation: (() => void) | undefined;
+    const confirmationPromise = new Promise<void>(resolve => {
+      resolveConfirmation = resolve;
+    });
+    mockWaitForWalletTransactions.mockImplementation(() => confirmationPromise);
+
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+
+    expect(result.txHash).toBe(TX_HASH);
+    expect(mockAddNewTransaction).toHaveBeenCalled();
+    expect(mockWaitForWalletTransactions).not.toHaveBeenCalled();
+
+    const waitPromise = result.waitForConfirmation();
+    expect(mockWaitForWalletTransactions).toHaveBeenCalledWith({ provider: PROVIDER, txHashes: [TX_HASH] });
+
+    resolveConfirmation?.();
+    await waitPromise;
   });
 
   it('throws when refreshed position data is missing', async () => {
@@ -277,7 +299,8 @@ describe('unstakeRnbw', () => {
   it('uses the fallback gas limit when unstake gas estimation fails', async () => {
     mockEstimateGas.mockRejectedValueOnce(new Error('estimate failed'));
 
-    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    await result.waitForConfirmation();
 
     expect(mockSendTransaction).toHaveBeenCalledWith({
       ...GAS_PARAMS,
@@ -297,7 +320,8 @@ describe('unstakeRnbw', () => {
       return true;
     });
 
-    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    await result.waitForConfirmation();
 
     expect(mockWaitForWalletTransactions).toHaveBeenCalledWith({ provider: PROVIDER, txHashes: [TX_HASH] });
     expect(mockPollForStakingUpdate).toHaveBeenCalledWith(POSITION.poolShares);
@@ -305,7 +329,8 @@ describe('unstakeRnbw', () => {
   });
 
   it('tracks the success analytics payload with the existing field set', async () => {
-    await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    await result.waitForConfirmation();
 
     expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake', {
       chainId: STAKING_CHAIN_ID,

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -24,30 +24,32 @@ type UnstakeAnalyticsSnapshot = {
   pnl: string;
 };
 
+type UnstakeRnbwResult = {
+  txHash: Hash;
+  waitForConfirmation: () => Promise<void>;
+};
+
 export async function unstakeRnbw({
   address,
   gasParams,
 }: {
   address: Address;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
-}): Promise<Hash> {
+}): Promise<UnstakeRnbwResult> {
   const positionData = await refreshAndValidatePosition();
   const analyticsSnapshot = snapshotUnstakeAnalytics(positionData);
 
   try {
-    const txHash = await submitAndConfirmUnstake({
+    const { provider, txHash } = await submitUnstake({
       address,
       gasParams,
       positionData,
     });
 
-    analytics.track(analytics.event.rnbwStakingUnstake, {
-      chainId: STAKING_CHAIN_ID,
+    return {
       txHash,
-      ...analyticsSnapshot,
-    });
-
-    return txHash;
+      waitForConfirmation: () => finalizeSubmittedUnstake({ analyticsSnapshot, positionData, provider, txHash }),
+    };
   } catch (error) {
     analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
       chainId: STAKING_CHAIN_ID,
@@ -74,7 +76,7 @@ async function refreshAndValidatePosition(): Promise<StakingPositionData> {
   return positionData;
 }
 
-async function submitAndConfirmUnstake({
+async function submitUnstake({
   address,
   gasParams,
   positionData,
@@ -82,7 +84,7 @@ async function submitAndConfirmUnstake({
   address: Address;
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
   positionData: StakingPositionData;
-}): Promise<Hash> {
+}): Promise<{ provider: StaticJsonRpcProvider; txHash: Hash }> {
   const provider = getProvider({ chainId: STAKING_CHAIN_ID });
   const signer = await loadWallet({ address, provider });
   if (!signer) {
@@ -123,10 +125,36 @@ async function submitAndConfirmUnstake({
     },
   });
 
-  await waitForWalletTransactions({ provider, txHashes: [tx.hash] });
-  await pollForStakingUpdate(positionData.poolShares);
+  return { provider, txHash: tx.hash as Hash };
+}
 
-  return tx.hash as Hash;
+async function finalizeSubmittedUnstake({
+  analyticsSnapshot,
+  positionData,
+  provider,
+  txHash,
+}: {
+  analyticsSnapshot: UnstakeAnalyticsSnapshot;
+  positionData: StakingPositionData;
+  provider: StaticJsonRpcProvider;
+  txHash: Hash;
+}): Promise<void> {
+  try {
+    await waitForWalletTransactions({ provider, txHashes: [txHash] });
+    await pollForStakingUpdate(positionData.poolShares);
+    analytics.track(analytics.event.rnbwStakingUnstake, {
+      chainId: STAKING_CHAIN_ID,
+      txHash,
+      ...analyticsSnapshot,
+    });
+  } catch (error) {
+    analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
+      chainId: STAKING_CHAIN_ID,
+      stakedAmount: analyticsSnapshot.stakedAmount,
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+    });
+    throw error;
+  }
 }
 
 async function estimateUnstakeGasLimit({


### PR DESCRIPTION
## Description

The unstake flow was keeping the sheet open until the wallet transaction confirmed and staking data finished polling, even though the pending unstake transaction had already been registered and surfaced through the in-progress toast.

This updates the flow so the sheet dismisses as soon as unstake submission succeeds, while confirmation, staking refresh, and analytics continue in the background.

## Approach

`unstakeRnbw` now separates submission from confirmation by returning a `waitForConfirmation` callback after the pending transaction is registered. The unstake sheet closes after submission and invokes that callback without blocking the UI.

## What to test

- Start unstaking RNBW and sign the transaction.
- Confirm the unstake sheet closes once the pending/in-progress transaction UI is visible.
- Confirm the pending transaction still resolves after confirmation and staking data refreshes.

[Simulator Screen Recording - iPhone 17 Pro - 2026-05-28 at 22.45.08.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d1e02486-f8a5-4399-93ee-75388773c54d.mov" />](https://app.graphite.com/user-attachments/video/d1e02486-f8a5-4399-93ee-75388773c54d.mov)

