### PR TITLE
refactor: isolate non-sponsored unstaking from general unstaking flow

### DIFF
--- a/src/features/rnbw-staking/utils/executeRnbwStakingCalls.ts
+++ b/src/features/rnbw-staking/utils/executeRnbwStakingCalls.ts
@@ -1,0 +1,125 @@
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import type { Wallet } from '@ethersproject/wallet';
+import { type Address } from 'viem';
+
+import { type NewTransaction } from '@/entities/transactions';
+import { trackCallsExecution } from '@/features/delegation/callsExecutionTracking';
+import { resolveManagedExecutionFailure } from '@/features/delegation/managedExecutionFailure';
+import { waitForManagedExecutionConfirmation } from '@/features/delegation/waitForManagedExecution';
+import { RainbowError } from '@/logger';
+import { execute, type Call, type CallsRequirements, type ExecuteCallsResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import { STAKING_CHAIN_ID } from '../constants';
+import { waitForWalletTransactions } from './waitForWalletTransactions';
+
+// ============ Types ========================================================= //
+
+/** Execution lane used for the wallet-funded or relay-sponsored RNBW staking call. */
+export type RnbwStakingExecutionMode = 'manual' | 'sponsored';
+
+/** SDK exact-call plan accepted as a fallback when no prepared calls are available. */
+export type RnbwStakingExecutionPlan = {
+  calls: Call[];
+  requirements?: CallsRequirements;
+};
+
+/** Submitted RNBW staking SDK execution plus the confirmation waiter for its lane. */
+export type RnbwStakingExecution = {
+  executionMode: RnbwStakingExecutionMode;
+  executionId?: string;
+  txHash?: string;
+  waitForConfirmation: () => Promise<void>;
+};
+
+type WalletCallsExecution = Extract<ExecuteCallsResult, { kind: 'calls.wallet' }>;
+
+// ============ Execution ===================================================== //
+
+/**
+ * Submits an RNBW staking call sequence through the delegation SDK and returns
+ * the execution lane plus its confirmation waiter.
+ *
+ * Shared by stake (approval + stake) and unstake (unstakeAll) execution paths.
+ */
+export async function executeRnbwStakingCalls({
+  address,
+  buildPlan,
+  errorPrefix,
+  preparedCalls,
+  provider,
+  signer,
+  transaction,
+}: {
+  address: Address;
+  buildPlan?: () => Promise<RnbwStakingExecutionPlan>;
+  errorPrefix: string;
+  preparedCalls: PreparedCallsExecution | null;
+  provider: StaticJsonRpcProvider;
+  signer: Wallet;
+  transaction: Omit<NewTransaction, 'hash'>;
+}): Promise<RnbwStakingExecution> {
+  const execution = preparedCalls
+    ? await execute.calls(preparedCalls, { signer, provider, chainId: STAKING_CHAIN_ID })
+    : await execute.calls({ ...(await requireBuildPlan(buildPlan, errorPrefix)()), signer, provider, chainId: STAKING_CHAIN_ID });
+
+  if (execution.kind === 'calls.wallet') {
+    const submittedTransaction = requireSubmittedTransaction(execution, errorPrefix);
+    const txHashes = execution.transactions.map(item => item.hash);
+    trackCallsExecution({
+      address,
+      batch: false,
+      chainId: STAKING_CHAIN_ID,
+      execution: submittedTransaction,
+      transaction,
+    });
+
+    return {
+      executionMode: 'manual',
+      txHash: submittedTransaction.hash,
+      waitForConfirmation: () => waitForWalletTransactions({ provider, txHashes }),
+    };
+  }
+
+  const failureMessage = await resolveManagedExecutionFailure({
+    executionId: execution.executionId,
+    status: execution.status,
+  });
+
+  if (failureMessage) {
+    throw new RainbowError(`${errorPrefix}: ${failureMessage}`);
+  }
+
+  trackCallsExecution({
+    address,
+    batch: false,
+    chainId: STAKING_CHAIN_ID,
+    execution,
+    transaction,
+  });
+
+  return {
+    executionMode: 'sponsored',
+    executionId: execution.executionId,
+    waitForConfirmation: () => waitForManagedExecutionConfirmation(execution.executionId),
+  };
+}
+
+// ============ Local Helpers ================================================= //
+
+function requireSubmittedTransaction(execution: WalletCallsExecution, errorPrefix: string): WalletCallsExecution['transactions'][number] {
+  const submittedTransaction = execution.transactions.at(-1);
+  if (!submittedTransaction) {
+    throw new RainbowError(`${errorPrefix}: wallet execution did not submit a transaction`);
+  }
+  return submittedTransaction;
+}
+
+function requireBuildPlan(
+  buildPlan: (() => Promise<RnbwStakingExecutionPlan>) | undefined,
+  errorPrefix: string
+): () => Promise<RnbwStakingExecutionPlan> {
+  if (!buildPlan) {
+    throw new RainbowError(`${errorPrefix}: missing exact-call execution plan`);
+  }
+  return buildPlan;
+}

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.ts
@@ -5,9 +5,6 @@ import { Wallet } from '@ethersproject/wallet';
 import { type Address } from 'viem';
 
 import { TransactionDirection, TransactionStatus, type NewTransaction } from '@/entities/transactions';
-import { trackCallsExecution } from '@/features/delegation/callsExecutionTracking';
-import { resolveManagedExecutionFailure } from '@/features/delegation/managedExecutionFailure';
-import { waitForManagedExecutionConfirmation } from '@/features/delegation/waitForManagedExecution';
 import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
 import { RainbowError } from '@/logger';
@@ -15,7 +12,7 @@ import { extractReplayableExecution } from '@/raps/replay';
 import { toTransactionAsset, type TransactionAssetSource } from '@/raps/transactionAsset';
 import { backendNetworksActions } from '@/state/backendNetworks/backendNetworks';
 import { addNewTransaction } from '@/state/pendingTransactions';
-import { execute, type Call, type ExecuteCallsResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 import {
   RNBW_TOKEN_ADDRESS,
@@ -24,19 +21,14 @@ import {
   STAKING_CONTRACT_ADDRESS,
   STAKING_GAS_LIMIT,
 } from '../constants';
+import { executeRnbwStakingCalls, type RnbwStakingExecution } from './executeRnbwStakingCalls';
 import { buildStakeRnbwCalls, buildStakeRnbwExecutionPlan } from './stakeRnbwCalls';
 import { waitForWalletTransactions } from './waitForWalletTransactions';
 
 // ============ Types ========================================================= //
 
-/** Execution lane used for the wallet-funded or relay-sponsored stake call. */
-export type StakeRnbwExecutionMode = 'manual' | 'sponsored';
-
 /** Submitted staking execution plus the confirmation waiter for its lane. */
-export type StakeRnbwExecution = {
-  executionMode: StakeRnbwExecutionMode;
-  waitForConfirmation: () => Promise<void>;
-};
+export type StakeRnbwExecution = RnbwStakingExecution;
 
 type ExecuteStakeRnbwParams = {
   address: Address;
@@ -47,8 +39,6 @@ type ExecuteStakeRnbwParams = {
   signer: Signer;
   stakeAmountRaw: string;
 };
-
-type WalletStakeCallsExecution = Extract<ExecuteCallsResult, { kind: 'calls.wallet' }>;
 
 // ============ Execution ===================================================== //
 
@@ -68,87 +58,18 @@ export async function executeStakeRnbw({
     return executeSequentialStakeRnbw({ address, asset, gasParams, provider, signer, stakeAmountRaw });
   }
 
-  const execution = await executeSdkStakeRnbw({
+  return executeRnbwStakingCalls({
     address,
+    buildPlan: () => buildStakeRnbwExecutionPlan({ address, provider, stakeAmountRaw }),
+    errorPrefix: '[executeStakeRnbw]',
     preparedCalls,
     provider,
     signer,
-    stakeAmountRaw,
-  });
-
-  if (execution.kind === 'calls.wallet') {
-    const stakeTransaction = requireSubmittedStakeTransaction(execution);
-    const txHashes = execution.transactions.map(transaction => transaction.hash);
-    trackCallsExecution({
-      address,
-      batch: false,
-      chainId: STAKING_CHAIN_ID,
-      execution: stakeTransaction,
-      transaction: buildStakeTransaction({ address, asset, stakeAmountRaw }),
-    });
-
-    return {
-      executionMode: 'manual',
-      waitForConfirmation: () => waitForWalletTransactions({ provider, txHashes }),
-    };
-  }
-
-  const failureMessage = await resolveManagedExecutionFailure({
-    executionId: execution.executionId,
-    status: execution.status,
-  });
-
-  if (failureMessage) {
-    throw new RainbowError(`[executeStakeRnbw]: ${failureMessage}`);
-  }
-
-  trackCallsExecution({
-    address,
-    batch: false,
-    chainId: STAKING_CHAIN_ID,
-    execution,
     transaction: buildStakeTransaction({ address, asset, stakeAmountRaw }),
   });
-
-  return {
-    executionMode: 'sponsored',
-    waitForConfirmation: () => waitForManagedExecutionConfirmation(execution.executionId),
-  };
 }
 
 // ============ Local Helpers ================================================= //
-
-async function executeSdkStakeRnbw({
-  address,
-  preparedCalls,
-  provider,
-  signer,
-  stakeAmountRaw,
-}: {
-  address: Address;
-  preparedCalls: PreparedCallsExecution | null;
-  provider: StaticJsonRpcProvider;
-  signer: Wallet;
-  stakeAmountRaw: string;
-}): Promise<ExecuteCallsResult> {
-  if (preparedCalls) {
-    return execute.calls(preparedCalls, {
-      signer,
-      provider,
-      chainId: STAKING_CHAIN_ID,
-    });
-  }
-
-  const plan = await buildStakeRnbwExecutionPlan({ address, provider, stakeAmountRaw });
-  const params = {
-    ...plan,
-    signer,
-    provider,
-    chainId: STAKING_CHAIN_ID,
-  };
-
-  return execute.calls(params);
-}
 
 async function executeSequentialStakeRnbw({
   address,
@@ -215,16 +136,9 @@ async function executeSequentialStakeRnbw({
 
   return {
     executionMode: 'manual',
+    txHash: stakeTransaction.hash,
     waitForConfirmation: () => waitForWalletTransactions({ provider, txHashes: confirmationTxHashes }),
   };
-}
-
-function requireSubmittedStakeTransaction(execution: WalletStakeCallsExecution): WalletStakeCallsExecution['transactions'][number] {
-  const stakeTransaction = execution.transactions.at(-1);
-  if (!stakeTransaction) {
-    throw new RainbowError('[executeStakeRnbw]: wallet staking did not submit a transaction');
-  }
-  return stakeTransaction;
 }
 
 function buildStakeTransaction({

--- a/src/features/rnbw-staking/utils/executeUnstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/executeUnstakeRnbw.test.ts
@@ -1,0 +1,280 @@
+import type { Provider, TransactionReceipt, TransactionRequest, TransactionResponse } from '@ethersproject/abstract-provider';
+import { Signer } from '@ethersproject/abstract-signer';
+import { BigNumber } from '@ethersproject/bignumber';
+import { hexlify } from '@ethersproject/bytes';
+import { resolveProperties, type Deferrable } from '@ethersproject/properties';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { encodeFunctionData, type Address } from 'viem';
+
+import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
+import { TransactionDirection, TransactionStatus } from '@/entities/transactions';
+import { time } from '@/framework/core/utils/time';
+
+import {
+  RNBW_DECIMALS,
+  RNBW_TOKEN_ADDRESS,
+  RNBW_TOKEN_UNIQUE_ID,
+  STAKING_ABI,
+  STAKING_CHAIN_ID,
+  STAKING_CONTRACT_ADDRESS,
+  STAKING_UNSTAKE_GAS_LIMIT,
+} from '../constants';
+import { executeUnstakeRnbw } from './executeUnstakeRnbw';
+
+const mockBuildSyntheticRnbwSourceAsset = jest.fn<ExtendedAnimatedAssetWithColors | null, []>();
+const mockAddNewTransaction = jest.fn<void, [unknown]>();
+
+jest.mock('@/state/pendingTransactions', () => ({
+  addNewTransaction: (params: unknown) => mockAddNewTransaction(params),
+}));
+
+jest.mock('@/state/backendNetworks/backendNetworks', () => ({
+  backendNetworksActions: {
+    getChainsName: () => ({ 8453: 'Base' }),
+  },
+}));
+
+jest.mock('@/utils/ethereumUtils', () => ({
+  getUniqueId: (address: string, chainId: number) => `${address}_${chainId}`,
+}));
+
+jest.mock('./syntheticRnbwSourceAsset', () => ({
+  buildSyntheticRnbwSourceAsset: () => mockBuildSyntheticRnbwSourceAsset(),
+}));
+
+const ACCOUNT: Address = '0x3333333333333333333333333333333333333333';
+const PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
+const EXPECTED_RECEIVE_AMOUNT_RAW = '950000000000000000000';
+const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const UNSTAKE_ALL_DATA = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+const GAS_PARAMS = { maxFeePerGas: '10', maxPriorityFeePerGas: '1' };
+const ESTIMATED_GAS_LIMIT = '123456';
+
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', STAKING_CHAIN_ID);
+const signer = new Wallet(PRIVATE_KEY, provider);
+
+class TestHardwareSigner extends Signer {
+  readonly provider: Provider;
+  readonly sendTransactionMock = jest.fn<Promise<TransactionResponse>, [Deferrable<TransactionRequest>]>();
+
+  constructor(provider: Provider) {
+    super();
+    this.provider = provider;
+  }
+
+  connect(): Signer {
+    return new TestHardwareSigner(this.provider);
+  }
+
+  getAddress(): Promise<string> {
+    return Promise.resolve(ACCOUNT);
+  }
+
+  signMessage(): Promise<string> {
+    return Promise.resolve('0x');
+  }
+
+  signTransaction(): Promise<string> {
+    return Promise.resolve('0x');
+  }
+
+  sendTransaction(transaction: Deferrable<TransactionRequest>): Promise<TransactionResponse> {
+    return this.sendTransactionMock(transaction);
+  }
+}
+
+const rnbwAsset = {
+  address: RNBW_TOKEN_ADDRESS,
+  chainId: STAKING_CHAIN_ID,
+  chainName: 'Base',
+  colors: { fallback: '#f2c745', primary: '#f2c745' },
+  decimals: RNBW_DECIMALS,
+  isNativeAsset: false,
+  mainnetAddress: RNBW_TOKEN_ADDRESS,
+  name: 'Rainbow',
+  native: {
+    price: { amount: 1, change: '0', display: '$1.00' },
+  },
+  nativePrice: 1,
+  networks: {
+    [STAKING_CHAIN_ID]: {
+      address: RNBW_TOKEN_ADDRESS,
+      decimals: RNBW_DECIMALS,
+    },
+  },
+  price: { value: 1 },
+  symbol: 'RNBW',
+  uniqueId: RNBW_TOKEN_UNIQUE_ID,
+} as unknown as ExtendedAnimatedAssetWithColors;
+
+function buildReceipt(transactionHash = TX_HASH): TransactionReceipt {
+  return {
+    blockHash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    blockNumber: 1,
+    byzantium: true,
+    confirmations: 1,
+    contractAddress: '',
+    cumulativeGasUsed: BigNumber.from(21_000),
+    effectiveGasPrice: BigNumber.from(1),
+    from: ACCOUNT,
+    gasUsed: BigNumber.from(21_000),
+    logs: [],
+    logsBloom: '0x',
+    status: 1,
+    to: STAKING_CONTRACT_ADDRESS,
+    transactionHash,
+    transactionIndex: 0,
+    type: 2,
+  };
+}
+
+function buildTransactionResponse({
+  hash = TX_HASH,
+  nonce = 1,
+  transaction,
+}: {
+  hash?: string;
+  nonce?: number;
+  transaction: Deferrable<TransactionRequest>;
+}): Promise<TransactionResponse> {
+  return resolveProperties(transaction).then(request => ({
+    chainId: STAKING_CHAIN_ID,
+    confirmations: 0,
+    data: request.data ? hexlify(request.data) : '0x',
+    from: ACCOUNT,
+    gasLimit: BigNumber.from(request.gasLimit ?? 21_000),
+    gasPrice: BigNumber.from(1),
+    hash,
+    maxFeePerGas: request.maxFeePerGas == null ? undefined : BigNumber.from(request.maxFeePerGas),
+    maxPriorityFeePerGas: request.maxPriorityFeePerGas == null ? undefined : BigNumber.from(request.maxPriorityFeePerGas),
+    nonce,
+    to: request.to,
+    value: BigNumber.from(request.value ?? 0),
+    wait: () => Promise.resolve(buildReceipt(hash)),
+  }));
+}
+
+describe('executeUnstakeRnbw', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    mockBuildSyntheticRnbwSourceAsset.mockReturnValue(rnbwAsset);
+    jest.spyOn(provider, 'estimateGas').mockResolvedValue(BigNumber.from(ESTIMATED_GAS_LIMIT));
+  });
+
+  it('submits the unstakeAll transaction directly and registers the pending transaction', async () => {
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt(TX_HASH));
+    const sendTransaction = jest
+      .spyOn(signer, 'sendTransaction')
+      .mockImplementationOnce(transaction => buildTransactionResponse({ hash: TX_HASH, nonce: 1, transaction }));
+
+    const result = await executeUnstakeRnbw({
+      address: ACCOUNT,
+      expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+      gasParams: GAS_PARAMS,
+      provider,
+      signer,
+    });
+
+    expect(result.executionMode).toBe('manual');
+    expect(result.txHash).toBe(TX_HASH);
+    expect(provider.estimateGas).toHaveBeenCalledWith({
+      data: UNSTAKE_ALL_DATA,
+      from: ACCOUNT,
+      to: STAKING_CONTRACT_ADDRESS,
+    });
+    await expect(resolveProperties(sendTransaction.mock.calls[0][0])).resolves.toMatchObject({
+      ...GAS_PARAMS,
+      to: STAKING_CONTRACT_ADDRESS,
+      data: UNSTAKE_ALL_DATA,
+      gasLimit: ESTIMATED_GAS_LIMIT,
+    });
+    expect(mockAddNewTransaction).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      chainId: STAKING_CHAIN_ID,
+      transaction: expect.objectContaining({
+        asset: expect.objectContaining({
+          address: RNBW_TOKEN_ADDRESS,
+          chainId: STAKING_CHAIN_ID,
+          decimals: RNBW_DECIMALS,
+          isNativeAsset: false,
+          name: 'Rainbow',
+          symbol: 'RNBW',
+          uniqueId: RNBW_TOKEN_UNIQUE_ID,
+        }),
+        changes: [
+          expect.objectContaining({
+            address_from: STAKING_CONTRACT_ADDRESS,
+            address_to: ACCOUNT,
+            direction: TransactionDirection.IN,
+            value: EXPECTED_RECEIVE_AMOUNT_RAW,
+          }),
+        ],
+        data: UNSTAKE_ALL_DATA,
+        from: ACCOUNT,
+        gasLimit: BigNumber.from(ESTIMATED_GAS_LIMIT),
+        hash: TX_HASH,
+        nonce: 1,
+        status: TransactionStatus.pending,
+        to: STAKING_CONTRACT_ADDRESS,
+        type: 'unstake',
+      }),
+    });
+    expect(waitForTransaction).not.toHaveBeenCalled();
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('submits the unstakeAll transaction directly for hardware wallets', async () => {
+    const hardwareSigner = new TestHardwareSigner(provider);
+    const waitForTransaction = jest.spyOn(provider, 'waitForTransaction').mockResolvedValue(buildReceipt(TX_HASH));
+    hardwareSigner.sendTransactionMock.mockImplementation(transaction => buildTransactionResponse({ transaction }));
+
+    const result = await executeUnstakeRnbw({
+      address: ACCOUNT,
+      expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+      gasParams: GAS_PARAMS,
+      provider,
+      signer: hardwareSigner,
+    });
+
+    expect(result.executionMode).toBe('manual');
+    expect(result.txHash).toBe(TX_HASH);
+    expect(hardwareSigner.sendTransactionMock).toHaveBeenCalledTimes(1);
+    await expect(resolveProperties(hardwareSigner.sendTransactionMock.mock.calls[0][0])).resolves.toMatchObject({
+      ...GAS_PARAMS,
+      to: STAKING_CONTRACT_ADDRESS,
+      data: UNSTAKE_ALL_DATA,
+      gasLimit: ESTIMATED_GAS_LIMIT,
+    });
+
+    await result.waitForConfirmation();
+
+    expect(waitForTransaction).toHaveBeenCalledWith(TX_HASH, 1, time.minutes(2));
+  });
+
+  it('uses the fallback gas limit when unstake gas estimation fails', async () => {
+    jest.spyOn(provider, 'estimateGas').mockRejectedValueOnce(new Error('estimate failed'));
+    const sendTransaction = jest
+      .spyOn(signer, 'sendTransaction')
+      .mockImplementationOnce(transaction => buildTransactionResponse({ hash: TX_HASH, nonce: 1, transaction }));
+
+    await executeUnstakeRnbw({
+      address: ACCOUNT,
+      expectedReceiveAmountRaw: EXPECTED_RECEIVE_AMOUNT_RAW,
+      gasParams: GAS_PARAMS,
+      provider,
+      signer,
+    });
+
+    await expect(resolveProperties(sendTransaction.mock.calls[0][0])).resolves.toMatchObject({
+      ...GAS_PARAMS,
+      to: STAKING_CONTRACT_ADDRESS,
+      data: UNSTAKE_ALL_DATA,
+      gasLimit: STAKING_UNSTAKE_GAS_LIMIT.toString(),
+    });
+  });
+});

--- a/src/features/rnbw-staking/utils/executeUnstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/executeUnstakeRnbw.ts
@@ -1,0 +1,112 @@
+import type { Signer } from '@ethersproject/abstract-signer';
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { encodeFunctionData, type Address, type Hex } from 'viem';
+
+import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
+import { RainbowError } from '@/logger';
+import { extractReplayableExecution } from '@/raps/replay';
+import { addNewTransaction } from '@/state/pendingTransactions';
+
+import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
+import { buildUnstakeTransaction } from './buildUnstakeTransaction';
+import { waitForWalletTransactions } from './waitForWalletTransactions';
+
+// ============ Types ========================================================= //
+
+/** Submitted unstaking execution plus the confirmation waiter for its lane. */
+export type UnstakeRnbwExecution = {
+  executionMode: 'manual';
+  txHash: string;
+  waitForConfirmation: () => Promise<void>;
+};
+
+type ExecuteUnstakeRnbwParams = {
+  address: Address;
+  expectedReceiveAmountRaw: string;
+  gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
+  provider: StaticJsonRpcProvider;
+  signer: Signer;
+};
+
+// ============ Execution ===================================================== //
+
+/**
+ * Executes the RNBW unstakeAll call.
+ */
+export async function executeUnstakeRnbw({
+  address,
+  expectedReceiveAmountRaw,
+  gasParams,
+  provider,
+  signer,
+}: ExecuteUnstakeRnbwParams): Promise<UnstakeRnbwExecution> {
+  return executeManualUnstakeRnbw({ address, expectedReceiveAmountRaw, gasParams, provider, signer });
+}
+
+// ============ Local Helpers ================================================= //
+
+async function executeManualUnstakeRnbw({
+  address,
+  expectedReceiveAmountRaw,
+  gasParams,
+  provider,
+  signer,
+}: {
+  address: Address;
+  expectedReceiveAmountRaw: string;
+  gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
+  provider: StaticJsonRpcProvider;
+  signer: Signer;
+}): Promise<UnstakeRnbwExecution> {
+  const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
+  const gasLimit = await estimateUnstakeGasLimit({ address, data, provider });
+  const transaction = await signer.sendTransaction({
+    ...gasParams,
+    to: STAKING_CONTRACT_ADDRESS,
+    data,
+    gasLimit,
+  });
+
+  const submittedUnstake = extractReplayableExecution(transaction);
+  if (!submittedUnstake) {
+    throw new RainbowError('[executeUnstakeRnbw]: manual unstaking did not return replayable transaction metadata');
+  }
+
+  addNewTransaction({
+    address,
+    chainId: STAKING_CHAIN_ID,
+    transaction: {
+      ...buildUnstakeTransaction({ address, unstakeAmountRaw: expectedReceiveAmountRaw }),
+      ...submittedUnstake.replayableCall,
+      hash: submittedUnstake.hash,
+      gasLimit: transaction.gasLimit ?? gasLimit,
+      gasPrice: transaction.gasPrice,
+      maxFeePerGas: transaction.maxFeePerGas,
+      maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+      nonce: submittedUnstake.nonce,
+    },
+  });
+
+  return {
+    executionMode: 'manual',
+    txHash: transaction.hash,
+    waitForConfirmation: () => waitForWalletTransactions({ provider, txHashes: [transaction.hash] }),
+  };
+}
+
+async function estimateUnstakeGasLimit({
+  address,
+  data,
+  provider,
+}: {
+  address: Address;
+  data: Hex;
+  provider: StaticJsonRpcProvider;
+}): Promise<string> {
+  try {
+    const estimatedGasLimit = await provider.estimateGas({ data, from: address, to: STAKING_CONTRACT_ADDRESS });
+    return estimatedGasLimit.toString();
+  } catch {
+    return STAKING_UNSTAKE_GAS_LIMIT.toString();
+  }
+}

--- a/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.test.ts
@@ -1,34 +1,17 @@
-import type { TransactionResponse } from '@ethersproject/abstract-provider';
-import type { StaticJsonRpcProvider } from '@ethersproject/providers';
-import { encodeFunctionData, type Address } from 'viem';
+import { type Address } from 'viem';
 
-import { TransactionDirection, TransactionStatus } from '@/entities/transactions';
-
-import {
-  RNBW_DECIMALS,
-  RNBW_TOKEN_ADDRESS,
-  RNBW_TOKEN_ICON_URL,
-  RNBW_TOKEN_UNIQUE_ID,
-  STAKING_ABI,
-  STAKING_CHAIN_ID,
-  STAKING_CONTRACT_ADDRESS,
-  STAKING_UNSTAKE_GAS_LIMIT,
-} from '../constants';
+import { STAKING_CHAIN_ID } from '../constants';
 import { type StakingPositionData } from '../stores/rnbwStakingPositionStore';
+import { type UnstakeRnbwExecution } from './executeUnstakeRnbw';
 import { unstakeRnbw } from './unstakeRnbw';
 
 const mockGetProvider = jest.fn();
 const mockLoadWallet = jest.fn<Promise<unknown>, [unknown]>();
 const mockFetch = jest.fn<Promise<void>, [undefined, { force: boolean } | undefined]>();
 const mockGetData = jest.fn<StakingPositionData | undefined, []>();
-const mockSendTransaction = jest.fn<Promise<TransactionResponse>, [unknown]>();
-const mockEstimateGas = jest.fn<Promise<{ toString: () => string }>, [unknown]>();
+const mockExecuteUnstakeRnbw = jest.fn<Promise<UnstakeRnbwExecution>, [unknown]>();
 const mockPollForStakingUpdate = jest.fn<Promise<boolean>, [string]>();
-const mockWaitForWalletTransactions = jest.fn<Promise<void>, [unknown]>();
 const mockTrack = jest.fn();
-const mockAddNewTransaction = jest.fn();
-const mockBuildSyntheticRnbwSourceAsset = jest.fn();
-const mockGetChainsName = jest.fn();
 
 jest.mock('@/analytics', () => ({
   analytics: {
@@ -48,20 +31,6 @@ jest.mock('@/model/wallet', () => ({
   loadWallet: (params: unknown) => mockLoadWallet(params),
 }));
 
-jest.mock('@/state/backendNetworks/backendNetworks', () => ({
-  backendNetworksActions: {
-    getChainsName: () => mockGetChainsName(),
-  },
-}));
-
-jest.mock('@/state/pendingTransactions', () => ({
-  addNewTransaction: (params: unknown) => mockAddNewTransaction(params),
-}));
-
-jest.mock('./syntheticRnbwSourceAsset', () => ({
-  buildSyntheticRnbwSourceAsset: () => mockBuildSyntheticRnbwSourceAsset(),
-}));
-
 jest.mock('../stores/rnbwStakingPositionStore', () => ({
   useStakingPositionStore: {
     getState: () => ({
@@ -71,12 +40,12 @@ jest.mock('../stores/rnbwStakingPositionStore', () => ({
   },
 }));
 
-jest.mock('./pollForStakingUpdate', () => ({
-  pollForStakingUpdate: (originalStakedRnbwShares: string) => mockPollForStakingUpdate(originalStakedRnbwShares),
+jest.mock('./executeUnstakeRnbw', () => ({
+  executeUnstakeRnbw: (params: unknown) => mockExecuteUnstakeRnbw(params),
 }));
 
-jest.mock('./waitForWalletTransactions', () => ({
-  waitForWalletTransactions: (params: unknown) => mockWaitForWalletTransactions(params),
+jest.mock('./pollForStakingUpdate', () => ({
+  pollForStakingUpdate: (originalStakedRnbwShares: string) => mockPollForStakingUpdate(originalStakedRnbwShares),
 }));
 
 jest.mock('@/utils/ethereumUtils', () => ({
@@ -85,14 +54,8 @@ jest.mock('@/utils/ethereumUtils', () => ({
 
 const ACCOUNT: Address = '0x3333333333333333333333333333333333333333';
 const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-const UNSTAKE_ALL_DATA = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
 const GAS_PARAMS = { maxFeePerGas: '10', maxPriorityFeePerGas: '1' };
-const ESTIMATED_GAS_LIMIT = '123456';
-const TX_NONCE = 7;
-const PROVIDER = {
-  estimateGas: (params: unknown) => mockEstimateGas(params),
-  name: 'provider',
-} as unknown as StaticJsonRpcProvider;
+const PROVIDER = { name: 'provider' };
 
 const POSITION: StakingPositionData = {
   allTiers: [],
@@ -123,6 +86,14 @@ const POSITION: StakingPositionData = {
   tier: { level: 1 } as unknown as StakingPositionData['tier'],
 };
 
+function manualExecution(): UnstakeRnbwExecution {
+  return {
+    executionMode: 'manual',
+    txHash: TX_HASH,
+    waitForConfirmation: () => Promise.resolve(),
+  };
+}
+
 function recordCallOrder(): { order: string[]; record: (name: string) => void } {
   const order: string[] = [];
   return {
@@ -137,52 +108,21 @@ describe('unstakeRnbw', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetProvider.mockReturnValue(PROVIDER);
-    mockGetChainsName.mockReturnValue({ [STAKING_CHAIN_ID]: 'base' });
-    mockBuildSyntheticRnbwSourceAsset.mockReturnValue({
-      address: RNBW_TOKEN_ADDRESS,
-      balance: { amount: '0', display: '0 RNBW' },
-      chainId: STAKING_CHAIN_ID,
-      chainName: 'Base',
-      colors: { fallback: '#f2c745', primary: '#f2c745' },
-      decimals: RNBW_DECIMALS,
-      icon_url: RNBW_TOKEN_ICON_URL,
-      isNativeAsset: false,
-      mainnetAddress: RNBW_TOKEN_ADDRESS,
-      name: 'Rainbow',
-      native: {
-        balance: { amount: '0', display: '$0.00' },
-        price: { amount: 1, change: '0', display: '$1.00' },
-      },
-      nativePrice: 1,
-      networks: {
-        [STAKING_CHAIN_ID]: {
-          address: RNBW_TOKEN_ADDRESS,
-          decimals: RNBW_DECIMALS,
-        },
-      },
-      price: { value: 1 },
-      symbol: 'RNBW',
-      uniqueId: RNBW_TOKEN_UNIQUE_ID,
-    });
-    mockLoadWallet.mockResolvedValue({
-      sendTransaction: (params: unknown) => mockSendTransaction(params),
-    });
+    mockLoadWallet.mockResolvedValue({ sendTransaction: jest.fn() });
     mockGetData.mockReturnValue(POSITION);
     mockFetch.mockResolvedValue(undefined);
-    mockEstimateGas.mockResolvedValue({ toString: () => ESTIMATED_GAS_LIMIT });
-    mockSendTransaction.mockResolvedValue({ hash: TX_HASH, nonce: TX_NONCE } as TransactionResponse);
+    mockExecuteUnstakeRnbw.mockResolvedValue(manualExecution());
     mockPollForStakingUpdate.mockResolvedValue(true);
-    mockWaitForWalletTransactions.mockResolvedValue(undefined);
   });
 
-  it('refreshes the staking position before submission and sends unstakeAll() to the staking contract', async () => {
+  it('refreshes the staking position before submission and delegates to executeUnstakeRnbw', async () => {
     const { order, record } = recordCallOrder();
     mockFetch.mockImplementation(async () => {
       record('fetch');
     });
-    mockSendTransaction.mockImplementation(async () => {
-      record('sendTransaction');
-      return { hash: TX_HASH, nonce: TX_NONCE } as TransactionResponse;
+    mockExecuteUnstakeRnbw.mockImplementation(async () => {
+      record('execute');
+      return manualExecution();
     });
 
     await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
@@ -190,130 +130,64 @@ describe('unstakeRnbw', () => {
     expect(mockFetch).toHaveBeenCalledWith(undefined, { force: true });
     expect(mockGetProvider).toHaveBeenCalled();
     expect(mockLoadWallet).toHaveBeenCalledWith({ address: ACCOUNT, provider: PROVIDER });
-    expect(mockEstimateGas).toHaveBeenCalledWith({
-      data: UNSTAKE_ALL_DATA,
-      from: ACCOUNT,
-      to: STAKING_CONTRACT_ADDRESS,
-    });
-    expect(mockSendTransaction).toHaveBeenCalledWith({
-      ...GAS_PARAMS,
-      to: STAKING_CONTRACT_ADDRESS,
-      data: UNSTAKE_ALL_DATA,
-      gasLimit: ESTIMATED_GAS_LIMIT,
-    });
-    expect(order).toEqual(['fetch', 'sendTransaction']);
+    expect(mockExecuteUnstakeRnbw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: ACCOUNT,
+        expectedReceiveAmountRaw: '950000000000000000000',
+        gasParams: GAS_PARAMS,
+        provider: PROVIDER,
+      })
+    );
+    expect(order).toEqual(['fetch', 'execute']);
   });
 
-  it('adds a pending unstake transaction before waiting for confirmation', async () => {
-    const { order, record } = recordCallOrder();
-    mockAddNewTransaction.mockImplementation(() => {
-      record('addNewTransaction');
-    });
-    mockWaitForWalletTransactions.mockImplementation(async () => {
-      record('waitForWalletTransactions');
-    });
-
-    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
-
-    const expectedAsset = expect.objectContaining({
-      address: RNBW_TOKEN_ADDRESS,
-      chainId: STAKING_CHAIN_ID,
-      decimals: RNBW_DECIMALS,
-      icon_url: RNBW_TOKEN_ICON_URL,
-      isNativeAsset: false,
-      mainnet_address: RNBW_TOKEN_ADDRESS,
-      name: 'Rainbow',
-      network: 'base',
-      symbol: 'RNBW',
-      uniqueId: RNBW_TOKEN_UNIQUE_ID,
-    });
-    expect(mockAddNewTransaction).toHaveBeenCalledWith({
-      address: ACCOUNT,
-      chainId: STAKING_CHAIN_ID,
-      transaction: expect.objectContaining({
-        asset: expectedAsset,
-        chainId: STAKING_CHAIN_ID,
-        changes: [
-          expect.objectContaining({
-            address_from: STAKING_CONTRACT_ADDRESS,
-            address_to: ACCOUNT,
-            asset: expectedAsset,
-            direction: TransactionDirection.IN,
-            value: '950000000000000000000',
-          }),
-        ],
-        data: UNSTAKE_ALL_DATA,
-        from: ACCOUNT,
-        gasLimit: ESTIMATED_GAS_LIMIT,
-        gasPrice: undefined,
-        hash: TX_HASH,
-        maxFeePerGas: undefined,
-        maxPriorityFeePerGas: undefined,
-        network: 'base',
-        nonce: TX_NONCE,
-        status: TransactionStatus.pending,
-        to: STAKING_CONTRACT_ADDRESS,
-        type: 'unstake',
-        value: '0',
-      }),
-    });
-    expect(mockWaitForWalletTransactions).not.toHaveBeenCalled();
-    await result.waitForConfirmation();
-    expect(order).toEqual(['addNewTransaction', 'waitForWalletTransactions']);
-  });
-
-  it('returns after registering the pending unstake transaction', async () => {
+  it('returns after submitting the unstake execution', async () => {
     let resolveConfirmation: (() => void) | undefined;
     const confirmationPromise = new Promise<void>(resolve => {
       resolveConfirmation = resolve;
     });
-    mockWaitForWalletTransactions.mockImplementation(() => confirmationPromise);
+    mockExecuteUnstakeRnbw.mockResolvedValue({
+      executionMode: 'manual',
+      txHash: TX_HASH,
+      waitForConfirmation: () => confirmationPromise,
+    });
 
     const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
 
     expect(result.txHash).toBe(TX_HASH);
-    expect(mockAddNewTransaction).toHaveBeenCalled();
-    expect(mockWaitForWalletTransactions).not.toHaveBeenCalled();
+    expect(mockExecuteUnstakeRnbw).toHaveBeenCalled();
+    expect(mockPollForStakingUpdate).not.toHaveBeenCalled();
 
     const waitPromise = result.waitForConfirmation();
-    expect(mockWaitForWalletTransactions).toHaveBeenCalledWith({ provider: PROVIDER, txHashes: [TX_HASH] });
+    expect(mockPollForStakingUpdate).not.toHaveBeenCalled();
 
     resolveConfirmation?.();
     await waitPromise;
+    expect(mockPollForStakingUpdate).toHaveBeenCalledWith(POSITION.poolShares);
   });
 
   it('throws when refreshed position data is missing', async () => {
     mockGetData.mockReturnValueOnce(POSITION).mockReturnValueOnce(undefined);
 
     await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toThrow('[unstakeRnbw]: Position data missing');
-    expect(mockSendTransaction).not.toHaveBeenCalled();
+    expect(mockExecuteUnstakeRnbw).not.toHaveBeenCalled();
   });
 
   it('throws when the exit fee percentage changes between snapshot and refresh', async () => {
     mockGetData.mockReturnValueOnce({ ...POSITION, exitFeePercentage: 5 }).mockReturnValueOnce({ ...POSITION, exitFeePercentage: 7 });
 
     await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toThrow('[unstakeRnbw]: Exit fee percentage changed');
-    expect(mockSendTransaction).not.toHaveBeenCalled();
+    expect(mockExecuteUnstakeRnbw).not.toHaveBeenCalled();
   });
 
-  it('uses the fallback gas limit when unstake gas estimation fails', async () => {
-    mockEstimateGas.mockRejectedValueOnce(new Error('estimate failed'));
-
-    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
-    await result.waitForConfirmation();
-
-    expect(mockSendTransaction).toHaveBeenCalledWith({
-      ...GAS_PARAMS,
-      to: STAKING_CONTRACT_ADDRESS,
-      data: UNSTAKE_ALL_DATA,
-      gasLimit: STAKING_UNSTAKE_GAS_LIMIT.toString(),
-    });
-  });
-
-  it('waits for the wallet transaction to confirm before polling staking data', async () => {
+  it('waits for the execution to confirm before polling staking data', async () => {
     const { order, record } = recordCallOrder();
-    mockWaitForWalletTransactions.mockImplementation(async () => {
-      record('waitForWalletTransactions');
+    mockExecuteUnstakeRnbw.mockResolvedValue({
+      executionMode: 'manual',
+      txHash: TX_HASH,
+      waitForConfirmation: async () => {
+        record('waitForConfirmation');
+      },
     });
     mockPollForStakingUpdate.mockImplementation(async () => {
       record('pollForStakingUpdate');
@@ -323,9 +197,8 @@ describe('unstakeRnbw', () => {
     const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
     await result.waitForConfirmation();
 
-    expect(mockWaitForWalletTransactions).toHaveBeenCalledWith({ provider: PROVIDER, txHashes: [TX_HASH] });
     expect(mockPollForStakingUpdate).toHaveBeenCalledWith(POSITION.poolShares);
-    expect(order).toEqual(['waitForWalletTransactions', 'pollForStakingUpdate']);
+    expect(order).toEqual(['waitForConfirmation', 'pollForStakingUpdate']);
   });
 
   it('tracks the success analytics payload with the existing field set', async () => {
@@ -344,7 +217,7 @@ describe('unstakeRnbw', () => {
 
   it('tracks the failure analytics payload when submission fails', async () => {
     const error = new Error('boom');
-    mockSendTransaction.mockRejectedValueOnce(error);
+    mockExecuteUnstakeRnbw.mockRejectedValueOnce(error);
 
     await expect(unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS })).rejects.toBe(error);
 
@@ -354,5 +227,26 @@ describe('unstakeRnbw', () => {
       errorMessage: 'boom',
     });
     expect(mockTrack).not.toHaveBeenCalledWith('rnbw_staking.unstake', expect.anything());
+  });
+
+  it('allows a zero exit fee percentage', async () => {
+    mockGetData.mockReturnValue({ ...POSITION, exitFeePercentage: 0 });
+
+    const result = await unstakeRnbw({ address: ACCOUNT, gasParams: GAS_PARAMS });
+    await result.waitForConfirmation();
+
+    expect(mockExecuteUnstakeRnbw).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedReceiveAmountRaw: POSITION.stakedRnbw,
+      })
+    );
+    expect(mockTrack).toHaveBeenCalledWith('rnbw_staking.unstake', {
+      chainId: STAKING_CHAIN_ID,
+      txHash: TX_HASH,
+      stakedAmount: '1000',
+      expectedExitFee: '0',
+      expectedReceiveAmount: '1000',
+      pnl: '50',
+    });
   });
 });

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -93,7 +93,7 @@ async function submitUnstake({
 
   const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
   const gasLimit = await estimateUnstakeGasLimit({ address, data, provider });
-  const tx = await signer.sendTransaction({
+  const transaction = await signer.sendTransaction({
     ...gasParams,
     to: STAKING_CONTRACT_ADDRESS,
     data,

--- a/src/features/rnbw-staking/utils/unstakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/unstakeRnbw.ts
@@ -1,5 +1,4 @@
-import type { StaticJsonRpcProvider } from '@ethersproject/providers';
-import { encodeFunctionData, type Address, type Hash, type Hex } from 'viem';
+import { type Address } from 'viem';
 
 import { analytics } from '@/analytics';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
@@ -8,24 +7,22 @@ import { getProvider } from '@/handlers/web3';
 import { convertRawAmountToDecimalFormat } from '@/helpers/utilities';
 import { RainbowError } from '@/logger';
 import { loadWallet } from '@/model/wallet';
-import { extractReplayableExecution } from '@/raps/replay';
-import { addNewTransaction } from '@/state/pendingTransactions';
 
-import { STAKING_ABI, STAKING_CHAIN_ID, STAKING_CONTRACT_ADDRESS, STAKING_UNSTAKE_GAS_LIMIT } from '../constants';
+import { STAKING_CHAIN_ID } from '../constants';
 import { useStakingPositionStore, type StakingPositionData } from '../stores/rnbwStakingPositionStore';
-import { buildUnstakeTransaction } from './buildUnstakeTransaction';
+import { executeUnstakeRnbw, type UnstakeRnbwExecution } from './executeUnstakeRnbw';
 import { pollForStakingUpdate } from './pollForStakingUpdate';
-import { waitForWalletTransactions } from './waitForWalletTransactions';
 
 type UnstakeAnalyticsSnapshot = {
   stakedAmount: string;
   expectedExitFee: string;
   expectedReceiveAmount: string;
+  receiveRaw: string;
   pnl: string;
 };
 
 type UnstakeRnbwResult = {
-  txHash: Hash;
+  txHash: string;
   waitForConfirmation: () => Promise<void>;
 };
 
@@ -37,18 +34,26 @@ export async function unstakeRnbw({
   gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
 }): Promise<UnstakeRnbwResult> {
   const positionData = await refreshAndValidatePosition();
-  const analyticsSnapshot = snapshotUnstakeAnalytics(positionData);
+  const { receiveRaw, ...analyticsSnapshot } = snapshotUnstakeAnalytics(positionData);
 
   try {
-    const { provider, txHash } = await submitUnstake({
+    const provider = getProvider({ chainId: STAKING_CHAIN_ID });
+    const signer = await loadWallet({ address, provider });
+    if (!signer) {
+      throw new Error('Failed to load wallet');
+    }
+
+    const execution = await executeUnstakeRnbw({
       address,
+      expectedReceiveAmountRaw: receiveRaw,
       gasParams,
-      positionData,
+      provider,
+      signer,
     });
 
     return {
-      txHash,
-      waitForConfirmation: () => finalizeSubmittedUnstake({ analyticsSnapshot, positionData, provider, txHash }),
+      txHash: execution.txHash,
+      waitForConfirmation: () => finalizeSubmittedUnstake({ analyticsSnapshot, execution, positionData }),
     };
   } catch (error) {
     analytics.track(analytics.event.rnbwStakingUnstakeFailed, {
@@ -65,7 +70,7 @@ async function refreshAndValidatePosition(): Promise<StakingPositionData> {
   await useStakingPositionStore.getState().fetch(undefined, { force: true });
   const positionData = useStakingPositionStore.getState().getData();
 
-  if (!positionData || !positionData.exitFeePercentage) {
+  if (!positionData || positionData.exitFeePercentage === undefined) {
     throw new RainbowError('[unstakeRnbw]: Position data missing');
   }
 
@@ -76,75 +81,21 @@ async function refreshAndValidatePosition(): Promise<StakingPositionData> {
   return positionData;
 }
 
-async function submitUnstake({
-  address,
-  gasParams,
-  positionData,
-}: {
-  address: Address;
-  gasParams: LegacyTransactionGasParamAmounts | TransactionGasParamAmounts;
-  positionData: StakingPositionData;
-}): Promise<{ provider: StaticJsonRpcProvider; txHash: Hash }> {
-  const provider = getProvider({ chainId: STAKING_CHAIN_ID });
-  const signer = await loadWallet({ address, provider });
-  if (!signer) {
-    throw new Error('Failed to load wallet');
-  }
-
-  const data = encodeFunctionData({ abi: STAKING_ABI, functionName: 'unstakeAll' });
-  const gasLimit = await estimateUnstakeGasLimit({ address, data, provider });
-  const transaction = await signer.sendTransaction({
-    ...gasParams,
-    to: STAKING_CONTRACT_ADDRESS,
-    data,
-    gasLimit,
-  });
-  const { receiveRaw } = computeUnstakeAmounts(positionData);
-
-  const submittedUnstake = extractReplayableExecution(tx, {
-    to: STAKING_CONTRACT_ADDRESS,
-    data,
-    value: 0,
-  });
-  if (!submittedUnstake) {
-    throw new RainbowError('[executeUnstakeRnbw]: manual unstaking did not return replayable transaction metadata');
-  }
-
-  addNewTransaction({
-    address,
-    chainId: STAKING_CHAIN_ID,
-    transaction: {
-      ...buildUnstakeTransaction({ address, unstakeAmountRaw: receiveRaw }),
-      ...submittedUnstake.replayableCall,
-      gasLimit: tx.gasLimit ?? gasLimit,
-      gasPrice: tx.gasPrice,
-      hash: submittedUnstake.hash,
-      maxFeePerGas: tx.maxFeePerGas,
-      maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-      nonce: submittedUnstake.nonce,
-    },
-  });
-
-  return { provider, txHash: tx.hash as Hash };
-}
-
 async function finalizeSubmittedUnstake({
   analyticsSnapshot,
+  execution,
   positionData,
-  provider,
-  txHash,
 }: {
-  analyticsSnapshot: UnstakeAnalyticsSnapshot;
+  analyticsSnapshot: Omit<UnstakeAnalyticsSnapshot, 'receiveRaw'>;
+  execution: UnstakeRnbwExecution;
   positionData: StakingPositionData;
-  provider: StaticJsonRpcProvider;
-  txHash: Hash;
 }): Promise<void> {
   try {
-    await waitForWalletTransactions({ provider, txHashes: [txHash] });
+    await execution.waitForConfirmation();
     await pollForStakingUpdate(positionData.poolShares);
     analytics.track(analytics.event.rnbwStakingUnstake, {
       chainId: STAKING_CHAIN_ID,
-      txHash,
+      txHash: execution.txHash,
       ...analyticsSnapshot,
     });
   } catch (error) {
@@ -157,23 +108,6 @@ async function finalizeSubmittedUnstake({
   }
 }
 
-async function estimateUnstakeGasLimit({
-  address,
-  data,
-  provider,
-}: {
-  address: Address;
-  data: Hex;
-  provider: StaticJsonRpcProvider;
-}): Promise<string> {
-  try {
-    const estimatedGasLimit = await provider.estimateGas({ data, from: address, to: STAKING_CONTRACT_ADDRESS });
-    return estimatedGasLimit.toString();
-  } catch {
-    return STAKING_UNSTAKE_GAS_LIMIT.toString();
-  }
-}
-
 function snapshotUnstakeAnalytics(positionData: StakingPositionData): UnstakeAnalyticsSnapshot {
   const { stakedRnbw: stakedRnbwRaw, decimals, sessionPnl } = positionData;
   const { receiveRaw, exitFeeRaw } = computeUnstakeAmounts(positionData);
@@ -181,6 +115,7 @@ function snapshotUnstakeAnalytics(positionData: StakingPositionData): UnstakeAna
   return {
     stakedAmount: convertRawAmountToDecimalFormat(stakedRnbwRaw, decimals),
     expectedExitFee: convertRawAmountToDecimalFormat(exitFeeRaw, decimals),
+    receiveRaw,
     expectedReceiveAmount: convertRawAmountToDecimalFormat(receiveRaw, decimals),
     pnl: convertRawAmountToDecimalFormat(subWorklet(sessionPnl.exchangeRateGain, exitFeeRaw), decimals),
   };


### PR DESCRIPTION
## Description

This PR is intended to be behavior-preserving. It does not change the user-facing unstaking flow or how non-sponsored unstake transactions are submitted.

It isolates the existing non-sponsored RNBW unstaking path from the higher-level unstake flow so sponsored unstaking can be added in the next PR without mixing relay-specific behavior into the current manual transaction path.

`unstakeRnbw` now stays focused on position refresh, validation, analytics, and post-confirmation polling. The direct wallet transaction submission and pending transaction registration live behind `executeUnstakeRnbw`, with focused tests around that lower-level behavior.