### PR TITLE
refactor(predictions): extract reusable sports event content

### DIFF
--- a/src/features/polymarket/components/polymarket-events-list/PolymarketEventsListBase.tsx
+++ b/src/features/polymarket/components/polymarket-events-list/PolymarketEventsListBase.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/features/polymarket/components/polymarket-events-list/PolymarketEventsListItem';
 import { NAVIGATOR_FOOTER_CLEARANCE, NAVIGATOR_FOOTER_HEIGHT } from '@/features/polymarket/constants';
 import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
-import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
 const ITEM_GAP = 12;
@@ -43,11 +43,17 @@ export const PolymarketEventsListBase = memo(function PolymarketEventsListBase({
 
   const listStyles = useMemo(() => {
     const paddingBottom = safeAreaInsets.bottom + NAVIGATOR_FOOTER_HEIGHT + NAVIGATOR_FOOTER_CLEARANCE;
+    const shouldFillViewport = events.length === 0;
     return {
-      contentContainerStyle: { minHeight: DEVICE_HEIGHT, paddingBottom, paddingHorizontal: ITEM_GAP / 2, paddingTop: ITEM_GAP },
+      contentContainerStyle: {
+        flexGrow: shouldFillViewport ? 1 : undefined,
+        paddingBottom,
+        paddingHorizontal: ITEM_GAP / 2,
+        paddingTop: ITEM_GAP,
+      },
       scrollIndicatorInsets: { bottom: paddingBottom },
     };
-  }, [safeAreaInsets.bottom]);
+  }, [events.length, safeAreaInsets.bottom]);
 
   return (
     <Animated.FlatList

--- a/src/features/polymarket/components/polymarket-sport-event-list-item/PolymarketSportEventListItem.tsx
+++ b/src/features/polymarket/components/polymarket-sport-event-list-item/PolymarketSportEventListItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import ConditionalWrap from 'conditional-wrap';
@@ -8,18 +8,16 @@ import ShimmerAnimation from '@/components/animations/ShimmerAnimation';
 import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
 import { Text, TextShadow, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
 import { TeamLogo } from '@/features/polymarket/components/TeamLogo';
-import { usePolymarketLiveGame } from '@/features/polymarket/hooks/usePolymarketLiveGame';
-import { type PolymarketEvent, type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
-import { getOutcomeColor } from '@/features/polymarket/utils/getMarketColor';
-import { parsePeriod, parseScore, selectGameInfo, type PolymarketEventGameInfo } from '@/features/polymarket/utils/sports';
-import { buildEventBetGrid, formatOdds, type BetCellData } from '@/features/polymarket/utils/sportsEventBetData';
+import { usePolymarketSportsBetCellPress } from '@/features/polymarket/hooks/usePolymarketSportsBetCellPress';
+import { useSportsEventBets, useSportsEventStatus } from '@/features/polymarket/hooks/useSportsEventContent';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { formatOdds, type BetCellData } from '@/features/polymarket/utils/sportsEventBetData';
 import { getTeamDisplayInfo } from '@/features/polymarket/utils/sportsEventTeams';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { getPolymarketTokenId } from '@/state/liveTokens/polymarketAdapter';
-import { formatTimestamp, toUnixTime } from '@/worklets/dates';
 
 const BET_ROW_HEIGHT = 38;
 const BET_ROW_WIDTH = 60;
@@ -38,87 +36,12 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
   const cardBackground = useBackgroundColor('fillQuaternary');
   const fillTertiary = useBackgroundColor('fillTertiary');
   const borderColor = useForegroundColor('separatorSecondary');
-  const { isDarkMode } = useColorMode();
 
-  const liveGame = usePolymarketLiveGame(event.live && !event.ended ? event.gameId : undefined);
-  const gameInfo = useMemo(() => selectGameInfo({ event, liveGame }), [event, liveGame]);
-  const isLive = gameInfo.live && !gameInfo.ended;
+  const { isLive, periodTitle, scores, showScores, subtitle } = useSportsEventStatus(event);
+  const { awayBets, homeBets, totals, awayMoneylineColor, homeMoneylineColor, betCellsPlaceholder } = useSportsEventBets(event);
   const { labels: teamLabels, title } = useMemo(() => getTeamDisplayInfo(event), [event]);
-  const periodTitle = useMemo(
-    () =>
-      isLive
-        ? getPeriodTitle({
-            period: gameInfo.period ?? '',
-            elapsed: gameInfo.elapsed,
-            score: gameInfo.score ?? '',
-          })
-        : undefined,
-    [isLive, gameInfo.period, gameInfo.elapsed, gameInfo.score]
-  );
-  const subtitle = useMemo(() => (isLive ? undefined : getSubtitle({ event, gameInfo })), [event, gameInfo, isLive]);
-  const betGrid = useMemo(() => buildEventBetGrid(event), [event]);
-  const awayBets = betGrid.teamBets.away;
-  const homeBets = betGrid.teamBets.home;
-  const totals = betGrid.totals;
-  const showScores = isLive || gameInfo.ended;
-  const scores = useMemo(() => (showScores ? (gameInfo.score ? parseScore(gameInfo.score) : null) : null), [gameInfo.score, showScores]);
-  const awayMoneylineOutcome = getOutcomeInfoForTokenId(event.markets, awayBets.moneyline?.outcomeTokenId);
-  const homeMoneylineOutcome = getOutcomeInfoForTokenId(event.markets, homeBets.moneyline?.outcomeTokenId);
-  const awayMoneylineColor = awayMoneylineOutcome
-    ? getOutcomeColor({
-        market: awayMoneylineOutcome.market,
-        outcome: awayMoneylineOutcome.outcome,
-        outcomeIndex: awayMoneylineOutcome.outcomeIndex,
-        isDarkMode,
-        teams: event.teams,
-      })
-    : undefined;
-  const homeMoneylineColor = homeMoneylineOutcome
-    ? getOutcomeColor({
-        market: homeMoneylineOutcome.market,
-        outcome: homeMoneylineOutcome.outcome,
-        outcomeIndex: homeMoneylineOutcome.outcomeIndex,
-        isDarkMode,
-        teams: event.teams,
-      })
-    : undefined;
 
   const teamLabelFontSize = useMemo(() => (teamLabels[0].length > 14 || teamLabels[1].length > 14 ? '10pt' : '13pt'), [teamLabels]);
-
-  // Calculate placeholder dimensions for Android to hack around no nested button support.
-  const betCellsPlaceholder = useMemo(() => {
-    const awayRowCellCount = [awayBets.spread, totals.over, awayBets.moneyline].filter(Boolean).length;
-    const homeRowCellCount = [homeBets.spread, totals.under, homeBets.moneyline].filter(Boolean).length;
-    const maxCellCount = Math.max(awayRowCellCount, homeRowCellCount);
-    const width = maxCellCount > 0 ? maxCellCount * BET_ROW_WIDTH + (maxCellCount - 1) * BET_CELL_GAP : 0;
-    const height = 2 * BET_ROW_HEIGHT + 8;
-    return { width, height };
-  }, [awayBets.spread, awayBets.moneyline, homeBets.spread, homeBets.moneyline, totals.over, totals.under]);
-
-  const createBetCellPressHandler = useCallback(
-    (outcomeTokenId: string) => {
-      const outcomeInfo = getOutcomeInfoForTokenId(event.markets, outcomeTokenId);
-      if (!outcomeInfo) return undefined;
-
-      return () => {
-        const outcomeColor = getOutcomeColor({
-          market: outcomeInfo.market,
-          outcome: outcomeInfo.outcome,
-          outcomeIndex: outcomeInfo.outcomeIndex,
-          isDarkMode,
-          teams: event.teams,
-        });
-        Navigation.handleAction(Routes.POLYMARKET_NEW_POSITION_SHEET, {
-          market: outcomeInfo.market,
-          event,
-          outcomeIndex: outcomeInfo.outcomeIndex,
-          outcomeColor,
-          fromRoute: Routes.POLYMARKET_BROWSE_EVENTS_SCREEN,
-        });
-      };
-    },
-    [event, isDarkMode]
-  );
 
   return (
     <ConditionalWrap condition={Platform.OS === 'android'} wrap={children => <View style={[styles.container, style]}>{children}</View>}>
@@ -127,26 +50,14 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
           <View style={styles.betCellsOverlay}>
             <View style={styles.betsColumn}>
               <View style={styles.betRow}>
-                {awayBets.spread && <BetCell data={awayBets.spread} onPress={createBetCellPressHandler(awayBets.spread.outcomeTokenId)} />}
-                {totals.over && <BetCell data={totals.over} onPress={createBetCellPressHandler(totals.over.outcomeTokenId)} />}
-                {awayBets.moneyline && (
-                  <BetCell
-                    data={awayBets.moneyline}
-                    backgroundColor={awayMoneylineColor}
-                    onPress={createBetCellPressHandler(awayBets.moneyline.outcomeTokenId)}
-                  />
-                )}
+                {awayBets.spread && <BetCell data={awayBets.spread} event={event} />}
+                {totals.over && <BetCell data={totals.over} event={event} />}
+                {awayBets.moneyline && <BetCell data={awayBets.moneyline} event={event} backgroundColor={awayMoneylineColor} />}
               </View>
               <View style={styles.betRow}>
-                {homeBets.spread && <BetCell data={homeBets.spread} onPress={createBetCellPressHandler(homeBets.spread.outcomeTokenId)} />}
-                {totals.under && <BetCell data={totals.under} onPress={createBetCellPressHandler(totals.under.outcomeTokenId)} />}
-                {homeBets.moneyline && (
-                  <BetCell
-                    data={homeBets.moneyline}
-                    backgroundColor={homeMoneylineColor}
-                    onPress={createBetCellPressHandler(homeBets.moneyline.outcomeTokenId)}
-                  />
-                )}
+                {homeBets.spread && <BetCell data={homeBets.spread} event={event} />}
+                {totals.under && <BetCell data={totals.under} event={event} />}
+                {homeBets.moneyline && <BetCell data={homeBets.moneyline} event={event} backgroundColor={homeMoneylineColor} />}
               </View>
             </View>
           </View>
@@ -212,30 +123,14 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
                 {Platform.OS === 'ios' ? (
                   <View style={styles.betsColumn}>
                     <View style={styles.betRow}>
-                      {awayBets.spread && (
-                        <BetCell data={awayBets.spread} onPress={createBetCellPressHandler(awayBets.spread.outcomeTokenId)} />
-                      )}
-                      {totals.over && <BetCell data={totals.over} onPress={createBetCellPressHandler(totals.over.outcomeTokenId)} />}
-                      {awayBets.moneyline && (
-                        <BetCell
-                          data={awayBets.moneyline}
-                          backgroundColor={awayMoneylineColor}
-                          onPress={createBetCellPressHandler(awayBets.moneyline.outcomeTokenId)}
-                        />
-                      )}
+                      {awayBets.spread && <BetCell data={awayBets.spread} event={event} />}
+                      {totals.over && <BetCell data={totals.over} event={event} />}
+                      {awayBets.moneyline && <BetCell data={awayBets.moneyline} event={event} backgroundColor={awayMoneylineColor} />}
                     </View>
                     <View style={styles.betRow}>
-                      {homeBets.spread && (
-                        <BetCell data={homeBets.spread} onPress={createBetCellPressHandler(homeBets.spread.outcomeTokenId)} />
-                      )}
-                      {totals.under && <BetCell data={totals.under} onPress={createBetCellPressHandler(totals.under.outcomeTokenId)} />}
-                      {homeBets.moneyline && (
-                        <BetCell
-                          data={homeBets.moneyline}
-                          backgroundColor={homeMoneylineColor}
-                          onPress={createBetCellPressHandler(homeBets.moneyline.outcomeTokenId)}
-                        />
-                      )}
+                      {homeBets.spread && <BetCell data={homeBets.spread} event={event} />}
+                      {totals.under && <BetCell data={totals.under} event={event} />}
+                      {homeBets.moneyline && <BetCell data={homeBets.moneyline} event={event} backgroundColor={homeMoneylineColor} />}
                     </View>
                   </View>
                 ) : (
@@ -252,16 +147,17 @@ export const PolymarketSportEventListItem = memo(function PolymarketSportEventLi
 
 const BetCell = memo(function BetCell({
   data,
+  event,
   backgroundColor,
-  onPress,
 }: {
   data: BetCellData;
+  event: PolymarketEvent;
   backgroundColor?: string;
-  onPress?: () => void;
 }) {
   const fillTertiary = useBackgroundColor('fillTertiary');
   const hasLabel = Boolean(data.label);
   const tokenId = getPolymarketTokenId(data.outcomeTokenId, 'sell');
+  const onPress = usePolymarketSportsBetCellPress({ event, outcomeTokenId: data.outcomeTokenId });
 
   const content = (
     <View style={[styles.betCell, { backgroundColor: backgroundColor ?? fillTertiary }]}>
@@ -311,38 +207,6 @@ export const LoadingSkeleton = memo(function LoadingSkeleton() {
 
 function navigateToEvent(event: PolymarketEvent): void {
   Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, { event, eventId: event.id });
-}
-
-function getSubtitle({ event, gameInfo }: { event: PolymarketEvent; gameInfo: PolymarketEventGameInfo }) {
-  if (gameInfo.ended) {
-    return i18n.t(i18n.l.predictions.sports.final).toUpperCase();
-  }
-
-  const startTime = gameInfo.startTime ?? event.startDate;
-  return startTime ? formatTimestamp(toUnixTime(startTime)) : '';
-}
-
-function getPeriodTitle({ score, period, elapsed }: { score: string; period: string; elapsed?: string }) {
-  const { currentPeriod } = parsePeriod(period);
-  const parsedScore = parseScore(score);
-  if ('bestOf' in parsedScore && parsedScore.bestOf !== undefined && currentPeriod) {
-    return i18n.t(i18n.l.predictions.sports.game_best_of, { currentPeriod, bestOf: String(parsedScore.bestOf) });
-  }
-  if (currentPeriod && elapsed) return `${currentPeriod} - ${elapsed}`;
-  if (currentPeriod) return currentPeriod;
-  return elapsed ?? '';
-}
-
-function getOutcomeInfoForTokenId(markets: PolymarketMarket[], outcomeTokenId?: string) {
-  if (!outcomeTokenId) return null;
-  for (const market of markets) {
-    const index = market.clobTokenIds.indexOf(outcomeTokenId);
-    if (index >= 0) {
-      const outcome = market.groupItemTitle || market.outcomes[index] || '';
-      return { market, outcomeIndex: index, outcome };
-    }
-  }
-  return null;
 }
 
 const styles = StyleSheet.create({

--- a/src/features/polymarket/hooks/usePolymarketSportsBetCellPress.ts
+++ b/src/features/polymarket/hooks/usePolymarketSportsBetCellPress.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo } from 'react';
+
+import { useColorMode } from '@/design-system/color/ColorMode';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { getOutcomeColor } from '@/features/polymarket/utils/getMarketColor';
+import { type SportsEventOutcomeInfo } from '@/features/polymarket/utils/sportsEventOutcome';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+
+type UsePolymarketSportsBetCellPressArgs = {
+  event: PolymarketEvent;
+  outcomeTokenId?: string;
+  onResolvedOutcomePress?: (outcomeInfo: SportsEventOutcomeInfo) => void;
+};
+
+export function usePolymarketSportsBetCellPress({
+  event,
+  outcomeTokenId,
+  onResolvedOutcomePress,
+}: UsePolymarketSportsBetCellPressArgs): (() => void) | undefined {
+  const { isDarkMode } = useColorMode();
+  const outcomeInfo = useMemo(() => {
+    if (!outcomeTokenId) return null;
+
+    for (const market of event.markets) {
+      const outcomeIndex = market.clobTokenIds.indexOf(outcomeTokenId);
+      if (outcomeIndex >= 0) {
+        const outcome = market.groupItemTitle || market.outcomes[outcomeIndex] || '';
+        return { market, outcomeIndex, outcome };
+      }
+    }
+
+    return null;
+  }, [event.markets, outcomeTokenId]);
+
+  const onPress = useCallback(() => {
+    if (!outcomeInfo) return;
+
+    onResolvedOutcomePress?.(outcomeInfo);
+
+    const outcomeColor = getOutcomeColor({
+      market: outcomeInfo.market,
+      outcome: outcomeInfo.outcome,
+      outcomeIndex: outcomeInfo.outcomeIndex,
+      isDarkMode,
+      teams: event.teams,
+    });
+
+    Navigation.handleAction(Routes.POLYMARKET_NEW_POSITION_SHEET, {
+      market: outcomeInfo.market,
+      event,
+      outcomeIndex: outcomeInfo.outcomeIndex,
+      outcomeColor,
+      fromRoute: Routes.POLYMARKET_BROWSE_EVENTS_SCREEN,
+    });
+  }, [event, isDarkMode, onResolvedOutcomePress, outcomeInfo]);
+
+  return outcomeInfo ? onPress : undefined;
+}

--- a/src/features/polymarket/hooks/usePolymarketSportsBetCellPress.ts
+++ b/src/features/polymarket/hooks/usePolymarketSportsBetCellPress.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { useColorMode } from '@/design-system/color/ColorMode';
 import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
 import { getOutcomeColor } from '@/features/polymarket/utils/getMarketColor';
-import { type SportsEventOutcomeInfo } from '@/features/polymarket/utils/sportsEventOutcome';
+import { findSportsEventOutcome, type SportsEventOutcomeInfo } from '@/features/polymarket/utils/sportsEventOutcome';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 
@@ -19,19 +19,7 @@ export function usePolymarketSportsBetCellPress({
   onResolvedOutcomePress,
 }: UsePolymarketSportsBetCellPressArgs): (() => void) | undefined {
   const { isDarkMode } = useColorMode();
-  const outcomeInfo = useMemo(() => {
-    if (!outcomeTokenId) return null;
-
-    for (const market of event.markets) {
-      const outcomeIndex = market.clobTokenIds.indexOf(outcomeTokenId);
-      if (outcomeIndex >= 0) {
-        const outcome = market.groupItemTitle || market.outcomes[outcomeIndex] || '';
-        return { market, outcomeIndex, outcome };
-      }
-    }
-
-    return null;
-  }, [event.markets, outcomeTokenId]);
+  const outcomeInfo = useMemo(() => findSportsEventOutcome(event.markets, outcomeTokenId), [event.markets, outcomeTokenId]);
 
   const onPress = useCallback(() => {
     if (!outcomeInfo) return;

--- a/src/features/polymarket/hooks/useSportsEventContent.ts
+++ b/src/features/polymarket/hooks/useSportsEventContent.ts
@@ -1,0 +1,203 @@
+import { useMemo } from 'react';
+
+import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
+import { useColorMode } from '@/design-system/color/ColorMode';
+import { usePolymarketLiveGame } from '@/features/polymarket/hooks/usePolymarketLiveGame';
+import { getLeagueId, SPORT_LEAGUES, type LeagueId } from '@/features/polymarket/leagues';
+import { type PolymarketEvent, type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+import { parsePeriod, parseScore, selectGameInfo, type PolymarketEventGameInfo } from '@/features/polymarket/utils/sports';
+import { buildEventBetGrid, formatOdds, type BetCellData, type EventBetGrid } from '@/features/polymarket/utils/sportsEventBetData';
+import { getSportsEventOutcomeCellColor } from '@/features/polymarket/utils/sportsEventOutcome';
+import * as i18n from '@/languages';
+import { formatTimestamp, toUnixTime } from '@/worklets/dates';
+
+export type SportsEventTeamRow = {
+  isFallback?: boolean;
+  label?: string;
+  line?: BetCellData;
+  moneyline?: BetCellData;
+};
+
+export type SportsEventRows = {
+  away: SportsEventTeamRow;
+  home: SportsEventTeamRow;
+};
+
+export function useSportsEventBets(event: PolymarketEvent) {
+  const { isDarkMode } = useColorMode();
+  const betGrid = useMemo(() => buildEventBetGrid(event), [event]);
+  const awayBets = betGrid.teamBets.away;
+  const homeBets = betGrid.teamBets.home;
+  const totals = betGrid.totals;
+  const awayMoneylineColor = getSportsEventOutcomeCellColor(event.markets, awayBets.moneyline?.outcomeTokenId, isDarkMode, event.teams);
+  const homeMoneylineColor = getSportsEventOutcomeCellColor(event.markets, homeBets.moneyline?.outcomeTokenId, isDarkMode, event.teams);
+
+  const rows = useMemo(() => getRows(event, betGrid), [betGrid, event]);
+  const betCellsPlaceholder = useMemo(() => {
+    const awayRowCellCount = [awayBets.spread, totals.over, awayBets.moneyline].filter(Boolean).length;
+    const homeRowCellCount = [homeBets.spread, totals.under, homeBets.moneyline].filter(Boolean).length;
+    const maxCellCount = Math.max(awayRowCellCount, homeRowCellCount);
+    const width = maxCellCount > 0 ? maxCellCount * 60 + (maxCellCount - 1) * 6 : 0;
+    const height = 2 * 38 + 8;
+    return { width, height };
+  }, [awayBets.spread, awayBets.moneyline, homeBets.spread, homeBets.moneyline, totals.over, totals.under]);
+
+  return {
+    awayBets,
+    awayMoneylineColor,
+    betCellsPlaceholder,
+    betGrid,
+    homeBets,
+    homeMoneylineColor,
+    rows,
+    totals,
+  };
+}
+
+export function useSportsEventStatus(event: PolymarketEvent) {
+  const liveGame = usePolymarketLiveGame(event.live && !event.ended ? event.gameId : undefined);
+  const gameInfo = useMemo(() => selectGameInfo({ event, liveGame }), [event, liveGame]);
+  const isLive = gameInfo.live && !gameInfo.ended;
+  const showScores = isLive || gameInfo.ended;
+  const scores = useMemo(() => (showScores && gameInfo.score ? parseScore(gameInfo.score) : null), [gameInfo.score, showScores]);
+  const periodTitle = useMemo(
+    () =>
+      isLive
+        ? getPeriodTitle({
+            period: gameInfo.period ?? '',
+            elapsed: gameInfo.elapsed,
+            score: gameInfo.score ?? '',
+          })
+        : undefined,
+    [isLive, gameInfo.period, gameInfo.elapsed, gameInfo.score]
+  );
+  const gameStatusTitle = useMemo(() => getGameStatusTitle({ event, gameInfo, isLive }), [event, gameInfo, isLive]);
+  const subtitle = useMemo(() => (isLive ? undefined : getSubtitle({ event, gameInfo })), [event, gameInfo, isLive]);
+
+  return {
+    gameInfo,
+    gameStatusTitle,
+    isLive,
+    periodTitle,
+    scores,
+    showScores,
+    subtitle,
+  };
+}
+
+export function getSportsEventLeagueId(event: PolymarketEvent): LeagueId | undefined {
+  return getLeagueId(event.slug) ?? getLeagueId(event.ticker ?? '') ?? getLeagueIdFromTags(event.tags);
+}
+
+export function getSportsEventTeamLabelFontSize(teamLabels: readonly [string, string]) {
+  return teamLabels[0].length > 14 || teamLabels[1].length > 14 ? ('10pt' as const) : ('13pt' as const);
+}
+
+export function getSportsEventAccentColor({
+  event,
+  isDarkMode,
+  leagueId,
+}: {
+  event: PolymarketEvent;
+  isDarkMode: boolean;
+  leagueId?: LeagueId;
+}) {
+  const leagueColor = leagueId ? SPORT_LEAGUES[leagueId].color : undefined;
+  if (leagueColor) return getColorValueForThemeWorklet(leagueColor, isDarkMode);
+  return getColorValueForThemeWorklet(event.color, isDarkMode);
+}
+
+function getLeagueIdFromTags(tags: PolymarketEvent['tags']): LeagueId | undefined {
+  for (const tag of tags) {
+    const leagueId = getLeagueId(tag.slug);
+    if (leagueId) return leagueId;
+  }
+}
+
+function getRows(event: PolymarketEvent, betGrid: EventBetGrid): SportsEventRows {
+  const rows: SportsEventRows = {
+    away: {
+      line: betGrid.totals.over ?? betGrid.teamBets.away.spread,
+      moneyline: betGrid.teamBets.away.moneyline,
+    },
+    home: {
+      line: betGrid.totals.under ?? betGrid.teamBets.home.spread,
+      moneyline: betGrid.teamBets.home.moneyline,
+    },
+  };
+
+  if (rows.away.line || rows.away.moneyline || rows.home.line || rows.home.moneyline) return rows;
+
+  return getFallbackMarketRows(event) ?? rows;
+}
+
+function getFallbackMarketRows(event: PolymarketEvent): SportsEventRows | null {
+  const markets = event.markets
+    .filter(
+      market =>
+        market.active !== false &&
+        market.closed !== true &&
+        market.umaResolutionStatus !== 'resolved' &&
+        !!market.groupItemTitle &&
+        market.outcomePrices[0] != null &&
+        market.outcomePrices[0] !== '' &&
+        !!market.clobTokenIds[0]
+    )
+    .sort((a, b) => Number(b.outcomePrices[0] ?? 0) - Number(a.outcomePrices[0] ?? 0))
+    .slice(0, 2);
+
+  if (markets.length < 2) return null;
+
+  return {
+    away: getFallbackMarketRow(markets[0]),
+    home: getFallbackMarketRow(markets[1]),
+  };
+}
+
+function getFallbackMarketRow(market: PolymarketMarket): SportsEventTeamRow {
+  return {
+    isFallback: true,
+    label: market.groupItemTitle,
+    moneyline: {
+      label: '',
+      odds: formatOdds(market.outcomePrices[0]),
+      outcomeTokenId: market.clobTokenIds[0],
+    },
+  };
+}
+
+function getGameStatusTitle({ event, gameInfo, isLive }: { event: PolymarketEvent; gameInfo: PolymarketEventGameInfo; isLive: boolean }) {
+  if (isLive) {
+    const { currentPeriod } = parsePeriod(gameInfo.period ?? '');
+    const parsedScore = parseScore(gameInfo.score ?? '');
+    if ('bestOf' in parsedScore && parsedScore.bestOf !== undefined && currentPeriod) {
+      return i18n.t(i18n.l.predictions.sports.game_best_of, { currentPeriod, bestOf: String(parsedScore.bestOf) });
+    }
+    return currentPeriod || gameInfo.elapsed || undefined;
+  }
+
+  if (gameInfo.ended) return i18n.t(i18n.l.predictions.sports.final);
+
+  const startTime = gameInfo.startTime ?? event.startDate;
+  return startTime ? formatTimestamp(toUnixTime(startTime)) : undefined;
+}
+
+function getSubtitle({ event, gameInfo }: { event: PolymarketEvent; gameInfo: PolymarketEventGameInfo }) {
+  if (gameInfo.ended) {
+    return i18n.t(i18n.l.predictions.sports.final).toUpperCase();
+  }
+
+  const startTime = gameInfo.startTime ?? event.startDate;
+  return startTime ? formatTimestamp(toUnixTime(startTime)) : '';
+}
+
+function getPeriodTitle({ score, period, elapsed }: { score: string; period: string; elapsed?: string }) {
+  const { currentPeriod } = parsePeriod(period);
+  const parsedScore = parseScore(score);
+  if ('bestOf' in parsedScore && parsedScore.bestOf !== undefined && currentPeriod) {
+    return i18n.t(i18n.l.predictions.sports.game_best_of, { currentPeriod, bestOf: String(parsedScore.bestOf) });
+  }
+  if (currentPeriod && elapsed) return `${currentPeriod} - ${elapsed}`;
+  if (currentPeriod) return currentPeriod;
+  return elapsed ?? '';
+}

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsList.tsx
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsList.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useMemo, type RefObject } from 'react';
 import { StyleSheet, View, type NativeScrollEvent, type NativeSyntheticEvent, type ViewToken } from 'react-native';
 
-import { format } from 'date-fns';
 import { debounce } from 'lodash';
 import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -14,10 +13,13 @@ import {
   PolymarketSportEventListItem,
 } from '@/features/polymarket/components/polymarket-sport-event-list-item/PolymarketSportEventListItem';
 import { DEFAULT_SPORTS_LEAGUE_KEY, NAVIGATOR_FOOTER_CLEARANCE, NAVIGATOR_FOOTER_HEIGHT } from '@/features/polymarket/constants';
-import { getLeague, getLeagueId, getLeagueSlugId, LEAGUE_LIST_ORDER } from '@/features/polymarket/leagues';
+import { getLeagueId } from '@/features/polymarket/leagues';
+import {
+  buildPolymarketSportsEventsListData,
+  type SportsListItem,
+} from '@/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData';
 import { usePolymarketSportsEventsStore } from '@/features/polymarket/stores/polymarketSportsEventsStore';
 import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
-import { getSportsEventsDayBoundaries } from '@/features/polymarket/utils/getSportsEventsDateRange';
 import { getSportsEventTokenIds } from '@/features/polymarket/utils/sportsEventBetData';
 import { useStableValue } from '@/hooks/useStableValue';
 import * as i18n from '@/languages';
@@ -34,38 +36,6 @@ type SportsEventsListProps = {
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 };
 
-type EventItem = {
-  type: 'event';
-  key: string;
-  event: PolymarketEvent;
-};
-
-type SectionHeaderItem = {
-  type: 'header';
-  key: string;
-  title: string;
-  isLive?: boolean;
-};
-
-type LeagueHeaderItem = {
-  type: 'league-header';
-  key: string;
-  title: string;
-  eventSlug: string;
-};
-
-type SectionSeparatorItem = {
-  type: 'separator';
-  key: string;
-};
-
-type LeagueSeparatorItem = {
-  type: 'league-separator';
-  key: string;
-};
-
-export type SportsListItem = EventItem | SectionHeaderItem | LeagueHeaderItem | SectionSeparatorItem | LeagueSeparatorItem;
-
 export const PolymarketSportsEventsList = memo(function PolymarketSportsEventsList({ listRef, onScroll }: SportsEventsListProps) {
   const safeAreaInsets = useSafeAreaInsets();
   const events = usePolymarketSportsEventsStore(state => state.getData() ?? EMPTY_EVENTS);
@@ -78,7 +48,10 @@ export const PolymarketSportsEventsList = memo(function PolymarketSportsEventsLi
     return events.filter(event => getLeagueId(event.slug) === selectedLeagueId);
   }, [events, showLeagueHeaders, selectedLeagueId]);
 
-  const listData = useMemo(() => buildListData(filteredEvents, showLeagueHeaders), [filteredEvents, showLeagueHeaders]);
+  const listData = useMemo(
+    () => buildPolymarketSportsEventsListData(filteredEvents, showLeagueHeaders),
+    [filteredEvents, showLeagueHeaders]
+  );
 
   const listStyles = useMemo(() => {
     const paddingBottom = safeAreaInsets.bottom + NAVIGATOR_FOOTER_HEIGHT + NAVIGATOR_FOOTER_CLEARANCE;
@@ -228,162 +201,6 @@ function extractEventTokenIds(viewTokens: Array<ViewToken<SportsListItem>>): str
     }
   }
   return Array.from(tokenIds);
-}
-
-function buildListData(events: PolymarketEvent[], showLeagueHeaders: boolean): SportsListItem[] {
-  if (!events.length) return [];
-
-  const { startOfToday, startOfTomorrow, startOfDayAfterTomorrow } = getSportsEventsDayBoundaries();
-  const startOfTodayMs = startOfToday.getTime();
-  const startOfTomorrowMs = startOfTomorrow.getTime();
-  const startOfDayAfterTomorrowMs = startOfDayAfterTomorrow.getTime();
-
-  const liveEvents: PolymarketEvent[] = [];
-  const todayEvents: PolymarketEvent[] = [];
-  const tomorrowEvents: PolymarketEvent[] = [];
-
-  for (const event of events) {
-    if (event.live && !event.ended) {
-      liveEvents.push(event);
-      continue;
-    }
-
-    const startTime = getTimestamp(event.startTime);
-    const endTime = getTimestamp(event.endDate);
-    const bucket = getTimeBucket({
-      timestamp: startTime ?? endTime ?? startOfTodayMs,
-      startOfTodayMs,
-      startOfTomorrowMs,
-      startOfDayAfterTomorrowMs,
-    });
-
-    if (bucket === 'today') {
-      todayEvents.push(event);
-      continue;
-    }
-    if (bucket === 'tomorrow') {
-      tomorrowEvents.push(event);
-      continue;
-    }
-
-    if (startTime != null && endTime != null && startTime !== endTime) {
-      const fallbackBucket = getTimeBucket({ timestamp: endTime, startOfTodayMs, startOfTomorrowMs, startOfDayAfterTomorrowMs });
-      if (fallbackBucket === 'today') {
-        todayEvents.push(event);
-      } else if (fallbackBucket === 'tomorrow') {
-        tomorrowEvents.push(event);
-      }
-    }
-  }
-
-  const items: SportsListItem[] = [];
-  const tomorrowLabel = format(startOfTomorrow, 'EEE, MMM d', { locale: i18n.getDateFnsLocale() });
-
-  const sections = [
-    { key: 'live', title: i18n.t(i18n.l.predictions.sports.live), events: liveEvents },
-    { key: 'today', title: i18n.t(i18n.l.time.today_caps), events: todayEvents },
-    { key: 'tomorrow', title: tomorrowLabel, events: tomorrowEvents },
-  ];
-
-  for (const section of sections) {
-    if (!section.events.length) continue;
-    if (items.length) {
-      items.push({ type: 'separator', key: `separator-${section.key}` });
-    }
-    pushSection({ items, title: section.title, events: section.events, sectionKey: section.key, showLeagueHeaders });
-  }
-
-  return items;
-}
-
-function pushSection({
-  items,
-  title,
-  events,
-  sectionKey,
-  showLeagueHeaders,
-}: {
-  items: SportsListItem[];
-  title: string;
-  events: PolymarketEvent[];
-  sectionKey: string;
-  showLeagueHeaders: boolean;
-}) {
-  if (!events.length) return;
-  items.push({ type: 'header', key: `header-${sectionKey}`, title, isLive: sectionKey === 'live' });
-  const leagueGroups = groupEventsByLeague(events);
-  for (let i = 0; i < leagueGroups.length; i++) {
-    const group = leagueGroups[i];
-    if (showLeagueHeaders) {
-      if (i > 0) {
-        items.push({ type: 'league-separator', key: `league-separator-${sectionKey}-${group.key}` });
-      }
-      items.push({ type: 'league-header', key: `league-${sectionKey}-${group.key}`, title: group.title, eventSlug: group.events[0].slug });
-    }
-    items.push(...buildEventItems(group.events, `${sectionKey}-${group.key}`));
-  }
-}
-
-function buildEventItems(events: PolymarketEvent[], sectionKey: string): EventItem[] {
-  return events.map((event, index) => ({
-    type: 'event',
-    key: `event-${sectionKey}-${event.id}-${index}`,
-    event,
-  }));
-}
-
-function groupEventsByLeague(events: PolymarketEvent[]) {
-  const groups = new Map<string, { key: string; title: string; events: PolymarketEvent[] }>();
-  for (const event of events) {
-    const leagueId = getLeagueId(event.slug);
-    const league = getLeague(event.slug);
-    const leagueSlugId = getLeagueSlugId(event.slug);
-    const key = leagueId ?? leagueSlugId ?? 'unknown';
-    const title = league?.name ?? (leagueSlugId ? leagueSlugId.toUpperCase() : i18n.t(i18n.l.predictions.bet_types.other));
-    const existing = groups.get(key) ?? { key, title, events: [] };
-    existing.events.push(event);
-    groups.set(key, existing);
-  }
-
-  // Sort events within each group by earliest start time
-  for (const group of groups.values()) {
-    group.events.sort((a, b) => {
-      const aTime = getTimestamp(a.startTime) ?? Infinity;
-      const bTime = getTimestamp(b.startTime) ?? Infinity;
-      return aTime - bTime;
-    });
-  }
-
-  return Array.from(groups.values()).sort((a, b) => {
-    const aIndex = LEAGUE_LIST_ORDER.indexOf(a.key as (typeof LEAGUE_LIST_ORDER)[number]);
-    const bIndex = LEAGUE_LIST_ORDER.indexOf(b.key as (typeof LEAGUE_LIST_ORDER)[number]);
-    if (aIndex === -1 && bIndex === -1) return 0;
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
-}
-
-function getTimestamp(value?: string): number | null {
-  if (!value) return null;
-  const timestamp = new Date(value).getTime();
-  return Number.isNaN(timestamp) ? null : timestamp;
-}
-
-function getTimeBucket({
-  timestamp,
-  startOfTodayMs,
-  startOfTomorrowMs,
-  startOfDayAfterTomorrowMs,
-}: {
-  timestamp: number;
-  startOfTodayMs: number;
-  startOfTomorrowMs: number;
-  startOfDayAfterTomorrowMs: number;
-}) {
-  if (timestamp >= startOfTodayMs && timestamp < startOfTomorrowMs) return 'today';
-  if (timestamp >= startOfTomorrowMs && timestamp < startOfDayAfterTomorrowMs) return 'tomorrow';
-  return null;
 }
 
 const styles = StyleSheet.create({

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsScreen.tsx
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsScreen.tsx
@@ -8,7 +8,7 @@ import { usePolymarketSportsEventsStore } from '@/features/polymarket/stores/pol
 import { useListen } from '@/state/internal/hooks/useListen';
 
 type PolymarketSportsEventsScreenProps = {
-  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 };
 
 export const PolymarketSportsEventsScreen = memo(function PolymarketSportsEventsScreen({ onScroll }: PolymarketSportsEventsScreenProps) {
@@ -19,7 +19,8 @@ export const PolymarketSportsEventsScreen = memo(function PolymarketSportsEvents
     state => state.selectedLeagueId,
     () => {
       listRef?.current?.scrollToOffset({ offset: 0, animated: true });
-    }
+    },
+    { enabled: true }
   );
 
   return (

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData.test.ts
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData.test.ts
@@ -1,0 +1,44 @@
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+
+import { buildPolymarketSportsEventsListData, type SportsListItem } from './buildPolymarketSportsEventsListData';
+
+// Resolve every event to one league so a single selected league yields one group.
+jest.mock('@/features/polymarket/leagues', () => ({
+  getLeague: () => ({ name: 'Test League' }),
+  getLeagueId: () => 'nba',
+  getLeagueSlugId: () => 'nba',
+  LEAGUE_LIST_ORDER: ['nba'],
+}));
+
+jest.mock('@/languages', () => ({
+  t: (key: string) => key,
+  l: {
+    predictions: { sports: { live: 'live' }, bet_types: { other: 'other' } },
+    time: { today_caps: 'today' },
+  },
+  getDateFnsLocale: () => undefined,
+}));
+
+function makeEvent(id: string, startTime: string): PolymarketEvent {
+  return { id, slug: `${id}-slug`, startTime, live: false, ended: false } as unknown as PolymarketEvent;
+}
+
+function eventIds(items: SportsListItem[]): string[] {
+  return items.filter((item): item is Extract<SportsListItem, { type: 'event' }> => item.type === 'event').map(item => item.event.id);
+}
+
+describe('buildPolymarketSportsEventsListData', () => {
+  // Regression guard for the single-league view: with league headers hidden the builder must still
+  // sort by startTime rather than preserve the API's volume order (see Ivan/Codex review on #7536).
+  it('orders single-league events by startTime when league headers are hidden', () => {
+    const referenceDate = new Date(2026, 0, 15, 12, 0, 0);
+    const at = (hour: number) => new Date(2026, 0, 15, hour, 0, 0).toISOString();
+
+    // Intentionally non-chronological input (as the volume-ordered API would return).
+    const events = [makeEvent('late', at(20)), makeEvent('early', at(14)), makeEvent('middle', at(18))];
+
+    const items = buildPolymarketSportsEventsListData(events, false, { referenceDate });
+
+    expect(eventIds(items)).toEqual(['early', 'middle', 'late']);
+  });
+});

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData.ts
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData.ts
@@ -1,0 +1,233 @@
+import { format } from 'date-fns';
+
+import { getLeague, getLeagueId, getLeagueSlugId, LEAGUE_LIST_ORDER, type LeagueId } from '@/features/polymarket/leagues';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { getSportsEventsDayBoundaries } from '@/features/polymarket/utils/getSportsEventsDateRange';
+import * as i18n from '@/languages';
+
+export type SportsEventScheduleBucket = 'live' | 'today' | 'tomorrow';
+
+type EventItem = {
+  type: 'event';
+  key: string;
+  event: PolymarketEvent;
+};
+
+type SectionHeaderItem = {
+  type: 'header';
+  key: string;
+  title: string;
+  isLive?: boolean;
+};
+
+type LeagueHeaderItem = {
+  type: 'league-header';
+  key: string;
+  title: string;
+  eventSlug: string;
+  leagueId?: LeagueId;
+};
+
+type SectionSeparatorItem = {
+  type: 'separator';
+  key: string;
+};
+
+type LeagueSeparatorItem = {
+  type: 'league-separator';
+  key: string;
+};
+
+export type SportsListItem = EventItem | SectionHeaderItem | LeagueHeaderItem | SectionSeparatorItem | LeagueSeparatorItem;
+
+export function buildPolymarketSportsEventsListData(
+  events: PolymarketEvent[],
+  showLeagueHeaders: boolean,
+  options: { referenceDate?: Date } = {}
+): SportsListItem[] {
+  if (!events.length) return [];
+
+  const referenceDate = options.referenceDate ?? new Date();
+  const { startOfTomorrow } = getSportsEventsDayBoundaries(referenceDate);
+
+  const liveEvents: PolymarketEvent[] = [];
+  const todayEvents: PolymarketEvent[] = [];
+  const tomorrowEvents: PolymarketEvent[] = [];
+
+  for (const event of events) {
+    const bucket = getSportsEventScheduleBucket(event, referenceDate);
+
+    if (bucket === 'live') {
+      liveEvents.push(event);
+      continue;
+    }
+    if (bucket === 'today') {
+      todayEvents.push(event);
+      continue;
+    }
+    if (bucket === 'tomorrow') {
+      tomorrowEvents.push(event);
+    }
+  }
+
+  const items: SportsListItem[] = [];
+  const tomorrowLabel = format(startOfTomorrow, 'EEE, MMM d', { locale: i18n.getDateFnsLocale() });
+
+  const sections = [
+    { key: 'live', title: i18n.t(i18n.l.predictions.sports.live), isLive: true, events: liveEvents },
+    { key: 'today', title: i18n.t(i18n.l.time.today_caps), events: todayEvents },
+    { key: 'tomorrow', title: tomorrowLabel, events: tomorrowEvents },
+  ];
+
+  for (const section of sections) {
+    if (!section.events.length) continue;
+    if (items.length) {
+      items.push({ type: 'separator', key: `separator-${section.key}` });
+    }
+    pushSection({
+      events: section.events,
+      header: { title: section.title, isLive: section.isLive },
+      items,
+      sectionKey: section.key,
+      showLeagueHeaders,
+    });
+  }
+
+  return items;
+}
+
+export function isLiveSportsEvent(event: PolymarketEvent): boolean {
+  if (event.ended) return false;
+  return event.live === true;
+}
+
+export function getSportsEventScheduleBucket(event: PolymarketEvent, referenceDate: Date = new Date()): SportsEventScheduleBucket | null {
+  if (isLiveSportsEvent(event)) return 'live';
+
+  const { startOfToday, startOfTomorrow, startOfDayAfterTomorrow } = getSportsEventsDayBoundaries(referenceDate);
+  const startOfTodayMs = startOfToday.getTime();
+  const startOfTomorrowMs = startOfTomorrow.getTime();
+  const startOfDayAfterTomorrowMs = startOfDayAfterTomorrow.getTime();
+  const startTime = getTimestamp(event.startTime);
+  const endTime = getTimestamp(event.endDate);
+  const bucket = getTimeBucket({
+    timestamp: startTime ?? endTime ?? startOfTodayMs,
+    startOfDayAfterTomorrowMs,
+    startOfTodayMs,
+    startOfTomorrowMs,
+  });
+  if (bucket) return bucket;
+
+  if (startTime == null || endTime == null || startTime === endTime) return null;
+  return getTimeBucket({
+    timestamp: endTime,
+    startOfDayAfterTomorrowMs,
+    startOfTodayMs,
+    startOfTomorrowMs,
+  });
+}
+
+function pushSection({
+  items,
+  header,
+  events,
+  sectionKey,
+  showLeagueHeaders,
+}: {
+  items: SportsListItem[];
+  header?: { title: string; isLive?: boolean };
+  events: PolymarketEvent[];
+  sectionKey: string;
+  showLeagueHeaders: boolean;
+}) {
+  if (!events.length) return;
+  if (header) {
+    items.push({ type: 'header', key: `header-${sectionKey}`, title: header.title, isLive: header.isLive });
+  }
+
+  if (!showLeagueHeaders) {
+    items.push(...buildEventItems(events, sectionKey));
+    return;
+  }
+
+  const leagueGroups = groupEventsByLeague(events);
+  for (let i = 0; i < leagueGroups.length; i++) {
+    const group = leagueGroups[i];
+    if (i > 0) {
+      items.push({
+        type: 'league-separator',
+        key: `league-separator-${sectionKey}-${group.key}`,
+      });
+    }
+    items.push({
+      type: 'league-header',
+      key: `league-${sectionKey}-${group.key}`,
+      title: group.title,
+      eventSlug: group.events[0].slug,
+      leagueId: group.leagueId,
+    });
+    const expansionKey = `${sectionKey}-${group.key}`;
+    items.push(...buildEventItems(group.events, expansionKey));
+  }
+}
+
+function buildEventItems(events: PolymarketEvent[], sectionKey: string): EventItem[] {
+  return events.map((event, index) => ({
+    type: 'event',
+    key: `event-${sectionKey}-${event.id}-${index}`,
+    event,
+  }));
+}
+
+function groupEventsByLeague(events: PolymarketEvent[]) {
+  const groups = new Map<string, { key: string; title: string; events: PolymarketEvent[]; leagueId?: LeagueId }>();
+  for (const event of events) {
+    const leagueId = getLeagueId(event.slug);
+    const league = getLeague(event.slug);
+    const leagueSlugId = getLeagueSlugId(event.slug);
+    const key = leagueId ?? leagueSlugId ?? 'unknown';
+    const title = league?.name ?? (leagueSlugId ? leagueSlugId.toUpperCase() : i18n.t(i18n.l.predictions.bet_types.other));
+    const existing = groups.get(key) ?? { key, title, events: [], leagueId };
+    existing.events.push(event);
+    groups.set(key, existing);
+  }
+
+  for (const group of groups.values()) {
+    group.events.sort((a, b) => {
+      const aTime = getTimestamp(a.startTime) ?? Infinity;
+      const bTime = getTimestamp(b.startTime) ?? Infinity;
+      return aTime - bTime;
+    });
+  }
+
+  return Array.from(groups.values()).sort((a, b) => {
+    const aIndex = LEAGUE_LIST_ORDER.indexOf(a.key as (typeof LEAGUE_LIST_ORDER)[number]);
+    const bIndex = LEAGUE_LIST_ORDER.indexOf(b.key as (typeof LEAGUE_LIST_ORDER)[number]);
+    if (aIndex === -1 && bIndex === -1) return 0;
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+}
+
+function getTimestamp(value?: string): number | null {
+  if (!value) return null;
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function getTimeBucket({
+  timestamp,
+  startOfTodayMs,
+  startOfTomorrowMs,
+  startOfDayAfterTomorrowMs,
+}: {
+  timestamp: number;
+  startOfTodayMs: number;
+  startOfTomorrowMs: number;
+  startOfDayAfterTomorrowMs: number;
+}): SportsEventScheduleBucket | null {
+  if (timestamp >= startOfTodayMs && timestamp < startOfTomorrowMs) return 'today';
+  if (timestamp >= startOfTomorrowMs && timestamp < startOfDayAfterTomorrowMs) return 'tomorrow';
+  return null;
+}

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData.ts
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData.ts
@@ -145,27 +145,25 @@ function pushSection({
     items.push({ type: 'header', key: `header-${sectionKey}`, title: header.title, isLive: header.isLive });
   }
 
-  if (!showLeagueHeaders) {
-    items.push(...buildEventItems(events, sectionKey));
-    return;
-  }
-
+  // Always group (sorts each league by startTime); only header/separator rows depend on showLeagueHeaders.
   const leagueGroups = groupEventsByLeague(events);
   for (let i = 0; i < leagueGroups.length; i++) {
     const group = leagueGroups[i];
-    if (i > 0) {
+    if (showLeagueHeaders) {
+      if (i > 0) {
+        items.push({
+          type: 'league-separator',
+          key: `league-separator-${sectionKey}-${group.key}`,
+        });
+      }
       items.push({
-        type: 'league-separator',
-        key: `league-separator-${sectionKey}-${group.key}`,
+        type: 'league-header',
+        key: `league-${sectionKey}-${group.key}`,
+        title: group.title,
+        eventSlug: group.events[0].slug,
+        leagueId: group.leagueId,
       });
     }
-    items.push({
-      type: 'league-header',
-      key: `league-${sectionKey}-${group.key}`,
-      title: group.title,
-      eventSlug: group.events[0].slug,
-      leagueId: group.leagueId,
-    });
     const expansionKey = `${sectionKey}-${group.key}`;
     items.push(...buildEventItems(group.events, expansionKey));
   }

--- a/src/features/polymarket/stores/polymarketEventStore.ts
+++ b/src/features/polymarket/stores/polymarketEventStore.ts
@@ -74,7 +74,7 @@ async function fetchPolymarketEvent({ eventId }: FetchParams, abortController: A
   let teams: PolymarketTeamInfo[] | undefined = undefined;
 
   if (event.gameId) {
-    teams = await fetchTeamsForEvent(event);
+    teams = await fetchTeamsForEvent(event, abortController);
   }
 
   const processedEvent = await processRawPolymarketEvent(event, teams);

--- a/src/features/polymarket/stores/polymarketSportsEventsStore.ts
+++ b/src/features/polymarket/stores/polymarketSportsEventsStore.ts
@@ -1,32 +1,52 @@
+import { POLYMARKET } from '@/config/experimental';
+import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
+import { IS_TEST } from '@/env';
 import { DEFAULT_SPORTS_LEAGUE_KEY, POLYMARKET_GAMMA_API_URL } from '@/features/polymarket/constants';
+import { type LeagueId } from '@/features/polymarket/leagues';
+import { fetchPolymarketTeamMetadataForGameEvents } from '@/features/polymarket/stores/polymarketTeamMetadataStore';
 import { type PolymarketEvent, type RawPolymarketEvent } from '@/features/polymarket/types/polymarket-event';
 import { getSportsEventsStartTimeRange } from '@/features/polymarket/utils/getSportsEventsDateRange';
-import { fetchTeamsForGameEvents } from '@/features/polymarket/utils/sports';
 import { processRawPolymarketEvent } from '@/features/polymarket/utils/transforms';
 import { time } from '@/framework/core/utils/time';
 import { rainbowFetch } from '@/framework/data/http/rainbowFetch';
+import { useRemoteConfigStore } from '@/model/remoteConfig';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
 import { createQueryStore } from '@/state/internal/createQueryStore';
 
 const VOLUME_MIN = '1000';
 
+export type PolymarketSportsLeagueId = LeagueId | typeof DEFAULT_SPORTS_LEAGUE_KEY;
+
 type PolymarketSportsEventsStoreState = {
-  selectedLeagueId: string;
-  setSelectedLeagueId: (leagueId: string) => void;
+  selectedLeagueId: PolymarketSportsLeagueId;
+  setSelectedLeagueId: (leagueId: PolymarketSportsLeagueId) => void;
 };
+
+const usePolymarketSportsEventsEnabled = createDerivedStore<boolean>(
+  $ => {
+    const remoteEnabled = $(useRemoteConfigStore, state => state.getRemoteConfigKey('polymarket_enabled'));
+    const localEnabled = $(useExperimentalConfigStore, state => state.getFlag(POLYMARKET));
+
+    return !IS_TEST && (remoteEnabled || localEnabled);
+  },
+  { fastMode: true }
+);
 
 export const usePolymarketSportsEventsStore = createQueryStore<PolymarketEvent[], never, PolymarketSportsEventsStoreState>(
   {
     fetcher: fetchPolymarketSportsEvents,
+    enabled: $ => $(usePolymarketSportsEventsEnabled),
     staleTime: time.minutes(2),
     cacheTime: time.minutes(20),
   },
   set => ({
     selectedLeagueId: DEFAULT_SPORTS_LEAGUE_KEY,
-    setSelectedLeagueId: (leagueId: string) => set({ selectedLeagueId: leagueId }),
+    setSelectedLeagueId: (leagueId: PolymarketSportsLeagueId) => set({ selectedLeagueId: leagueId }),
   })
 );
 
 export function prefetchPolymarketSportsEvents() {
+  if (!usePolymarketSportsEventsStore.getState().enabled) return;
   usePolymarketSportsEventsStore.getState().fetch();
 }
 
@@ -51,7 +71,7 @@ async function fetchPolymarketSportsEvents(_: never, abortController: AbortContr
 
   const filteredEvents = events.filter(event => event.ended !== true && event.gameId != null);
 
-  const teamsByTicker = await fetchTeamsForGameEvents(filteredEvents);
+  const teamsByTicker = await fetchPolymarketTeamMetadataForGameEvents(filteredEvents, abortController);
 
   return await Promise.all(
     filteredEvents.map(event => {

--- a/src/features/polymarket/stores/polymarketTeamMetadataStore.ts
+++ b/src/features/polymarket/stores/polymarketTeamMetadataStore.ts
@@ -1,0 +1,34 @@
+import {
+  fetchTeamMetadataForGameEvent,
+  fetchTeamsForGameEvents,
+  type GameTeamsMetadata,
+  type GameTeamsSource,
+} from '@/features/polymarket/utils/sports';
+import { time } from '@/framework/core/utils/time';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+
+type TeamMetadataParams = {
+  event: GameTeamsSource;
+};
+
+export const usePolymarketTeamMetadataStore = createQueryStore<GameTeamsMetadata | null, TeamMetadataParams>({
+  enabled: false,
+  fetcher: ({ event }, abortController) => fetchTeamMetadataForGameEvent(event, abortController),
+  params: {
+    event: { slug: '', ticker: '' },
+  },
+  staleTime: time.minutes(15),
+  cacheTime: time.minutes(30),
+});
+
+export function fetchPolymarketTeamMetadataForGameEvents(
+  events: GameTeamsSource[],
+  abortController?: AbortController | null
+): Promise<Map<string, GameTeamsMetadata>> {
+  return fetchTeamsForGameEvents(events, abortController, fetchPolymarketTeamMetadataForGameEvent);
+}
+
+async function fetchPolymarketTeamMetadataForGameEvent(event: GameTeamsSource): Promise<GameTeamsMetadata | null> {
+  if (!event.ticker) return null;
+  return usePolymarketTeamMetadataStore.getState().fetch({ event }, { skipStoreUpdates: 'withCache' });
+}

--- a/src/features/polymarket/stores/polymarketTeamMetadataStore.ts
+++ b/src/features/polymarket/stores/polymarketTeamMetadataStore.ts
@@ -5,30 +5,69 @@ import {
   type GameTeamsSource,
 } from '@/features/polymarket/utils/sports';
 import { time } from '@/framework/core/utils/time';
-import { createQueryStore } from '@/state/internal/createQueryStore';
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
 
-type TeamMetadataParams = {
-  event: GameTeamsSource;
+const TEAM_METADATA_STALE_TIME = time.minutes(15);
+
+type TeamMetadataCacheEntry = {
+  data: GameTeamsMetadata;
+  lastFetchedAt: number;
 };
 
-export const usePolymarketTeamMetadataStore = createQueryStore<GameTeamsMetadata | null, TeamMetadataParams>({
-  enabled: false,
-  fetcher: ({ event }, abortController) => fetchTeamMetadataForGameEvent(event, abortController),
-  params: {
-    event: { slug: '', ticker: '' },
+type PolymarketTeamMetadataState = {
+  metadataByKey: Record<string, TeamMetadataCacheEntry>;
+  fetchForGameEvent: (event: GameTeamsSource, abortController?: AbortController | null) => Promise<GameTeamsMetadata | null>;
+};
+
+function normalizeCacheKeyPart(value?: string): string {
+  return value?.trim().toLowerCase() ?? '';
+}
+
+// Keyed by ticker plus names (normalized) so an event that later arrives with names refetches a richer
+// result, while casing/whitespace differences don't create duplicate entries.
+function getTeamMetadataCacheKey(event: GameTeamsSource): string | null {
+  const ticker = normalizeCacheKeyPart(event.ticker);
+  if (!ticker) return null;
+  return `ticker:${ticker}:${normalizeCacheKeyPart(event.awayTeamName)}:${normalizeCacheKeyPart(event.homeTeamName)}`;
+}
+
+export const usePolymarketTeamMetadataStore = createRainbowStore<PolymarketTeamMetadataState>((set, get) => ({
+  metadataByKey: {},
+
+  // Each call fetches with its own AbortController; the mapWithConcurrency pool already bounds fan-out,
+  // so we don't share in-flight requests (which would couple one caller's abort to another's result).
+  fetchForGameEvent: (event, abortController) => {
+    const key = getTeamMetadataCacheKey(event);
+    if (!key) return Promise.resolve(null);
+
+    const cached = get().metadataByKey[key];
+    if (cached && Date.now() - cached.lastFetchedAt < TEAM_METADATA_STALE_TIME) {
+      return Promise.resolve(cached.data);
+    }
+
+    // Call the fetcher directly so the AbortController reaches rainbowFetch.
+    return fetchTeamMetadataForGameEvent(event, abortController)
+      .then(metadata => {
+        // Skip caching empty lookups so a later, richer event can retry.
+        if (metadata && (metadata.teams?.length || metadata.homeTeamName || metadata.awayTeamName)) {
+          set(state => ({
+            metadataByKey: {
+              ...state.metadataByKey,
+              [key]: { data: metadata, lastFetchedAt: Date.now() },
+            },
+          }));
+        }
+        return metadata;
+      })
+      .catch(() => null);
   },
-  staleTime: time.minutes(15),
-  cacheTime: time.minutes(30),
-});
+}));
 
 export function fetchPolymarketTeamMetadataForGameEvents(
   events: GameTeamsSource[],
   abortController?: AbortController | null
 ): Promise<Map<string, GameTeamsMetadata>> {
-  return fetchTeamsForGameEvents(events, abortController, fetchPolymarketTeamMetadataForGameEvent);
-}
-
-async function fetchPolymarketTeamMetadataForGameEvent(event: GameTeamsSource): Promise<GameTeamsMetadata | null> {
-  if (!event.ticker) return null;
-  return usePolymarketTeamMetadataStore.getState().fetch({ event }, { skipStoreUpdates: 'withCache' });
+  return fetchTeamsForGameEvents(events, abortController, (event, controller) =>
+    usePolymarketTeamMetadataStore.getState().fetchForGameEvent(event, controller)
+  );
 }

--- a/src/features/polymarket/utils/sports.ts
+++ b/src/features/polymarket/utils/sports.ts
@@ -5,16 +5,17 @@ import { getGammaLeagueId } from '@/features/polymarket/leagues';
 import { type PolymarketGameMetadata, type PolymarketTeamInfo, type RawPolymarketTeamInfo } from '@/features/polymarket/types';
 import { type PolymarketMarket, type RawPolymarketMarket } from '@/features/polymarket/types/polymarket-event';
 import { getColorBySeed } from '@/features/polymarket/utils/getColorBySeed';
+import { mapWithConcurrency } from '@/framework/core/utils/mapWithConcurrency';
 import { time } from '@/framework/core/utils/time';
 import { rainbowFetch } from '@/framework/data/http/rainbowFetch';
 import { getHighContrastColor } from '@/hooks/useAccountAccentColor';
 import { logger, RainbowError } from '@/logger';
 
-export async function fetchGameMetadata(eventTicker: string) {
+export async function fetchGameMetadata(eventTicker: string, abortController?: AbortController | null) {
   try {
     const url = new URL(`${POLYMARKET_GAMMA_API_URL}/games`);
     url.searchParams.set('ticker', eventTicker);
-    const { data } = await rainbowFetch<PolymarketGameMetadata>(url.toString(), { timeout: time.seconds(15) });
+    const { data } = await rainbowFetch<PolymarketGameMetadata>(url.toString(), { abortController, timeout: time.seconds(15) });
     return data;
   } catch (e) {
     // For some game types this information is not available and returns an error
@@ -23,7 +24,11 @@ export async function fetchGameMetadata(eventTicker: string) {
   }
 }
 
-async function fetchTeamsByAbbreviations(abbreviations: string[], league: string | undefined): Promise<PolymarketTeamInfo[] | undefined> {
+async function fetchTeamsByAbbreviations(
+  abbreviations: string[],
+  league: string | undefined,
+  abortController?: AbortController | null
+): Promise<PolymarketTeamInfo[] | undefined> {
   try {
     const url = new URL(buildGammaUrl('teams'));
     if (league) {
@@ -32,7 +37,10 @@ async function fetchTeamsByAbbreviations(abbreviations: string[], league: string
     abbreviations.forEach(abbr => {
       url.searchParams.append('abbreviation', abbr);
     });
-    const { data: rawTeams } = await rainbowFetch<RawPolymarketTeamInfo[]>(url.toString(), { timeout: time.seconds(15) });
+    const { data: rawTeams } = await rainbowFetch<RawPolymarketTeamInfo[]>(url.toString(), {
+      abortController,
+      timeout: time.seconds(15),
+    });
     if (!rawTeams) return undefined;
     const teams = enrichTeamsWithColor(rawTeams);
     return sortTeamsByAbbreviations(teams, abbreviations);
@@ -41,7 +49,11 @@ async function fetchTeamsByAbbreviations(abbreviations: string[], league: string
   }
 }
 
-async function fetchTeamsByNames(names: string[], league: string | undefined): Promise<PolymarketTeamInfo[] | undefined> {
+async function fetchTeamsByNames(
+  names: string[],
+  league: string | undefined,
+  abortController?: AbortController | null
+): Promise<PolymarketTeamInfo[] | undefined> {
   try {
     const url = new URL(buildGammaUrl('teams'));
     if (league) {
@@ -50,7 +62,10 @@ async function fetchTeamsByNames(names: string[], league: string | undefined): P
     names.forEach(name => {
       url.searchParams.append('name', name);
     });
-    const { data: rawTeams } = await rainbowFetch<RawPolymarketTeamInfo[]>(url.toString(), { timeout: time.seconds(15) });
+    const { data: rawTeams } = await rainbowFetch<RawPolymarketTeamInfo[]>(url.toString(), {
+      abortController,
+      timeout: time.seconds(15),
+    });
     if (!rawTeams) return undefined;
     const teams = enrichTeamsWithColor(rawTeams);
     if (rawTeams.length > names.length) {
@@ -63,7 +78,10 @@ async function fetchTeamsByNames(names: string[], league: string | undefined): P
   }
 }
 
-export async function fetchTeamsForEvent(event: GameTeamsSource): Promise<PolymarketTeamInfo[] | undefined> {
+export async function fetchTeamsForEvent(
+  event: GameTeamsSource,
+  abortController?: AbortController | null
+): Promise<PolymarketTeamInfo[] | undefined> {
   if (!event.ticker) return undefined;
 
   const tickerAbbreviations = parseTeamAbbreviationsFromTicker(event.ticker);
@@ -72,7 +90,7 @@ export async function fetchTeamsForEvent(event: GameTeamsSource): Promise<Polyma
   // Try abbreviation-based query first (more reliable - some team names fail Polymarket's validation)
   if (tickerAbbreviations) {
     const abbreviations = [tickerAbbreviations.away, tickerAbbreviations.home];
-    const teams = await fetchTeamsByAbbreviations(abbreviations, gammaLeagueId);
+    const teams = await fetchTeamsByAbbreviations(abbreviations, gammaLeagueId, abortController);
     if (teams?.length === abbreviations.length) {
       return teams;
     }
@@ -81,7 +99,7 @@ export async function fetchTeamsForEvent(event: GameTeamsSource): Promise<Polyma
   let homeTeamName = event.homeTeamName;
   let awayTeamName = event.awayTeamName;
   if (!awayTeamName || !homeTeamName) {
-    const gameMetadata = await fetchGameMetadata(event.ticker);
+    const gameMetadata = await fetchGameMetadata(event.ticker, abortController);
     if (gameMetadata) {
       // The `ordering` field represents the order in which the teams are listed in the game metadata.
       // This is not indicative of how the teams should be displayed in the event, which is always away @ home.
@@ -96,14 +114,14 @@ export async function fetchTeamsForEvent(event: GameTeamsSource): Promise<Polyma
   }
 
   if (homeTeamName && awayTeamName) {
-    const teams = await fetchTeamsByNames([awayTeamName, homeTeamName], gammaLeagueId);
+    const teams = await fetchTeamsByNames([awayTeamName, homeTeamName], gammaLeagueId, abortController);
     if (teams?.length === 2) {
       return teams;
     }
   }
 }
 
-type GameTeamsSource = {
+export type GameTeamsSource = {
   gameId?: number;
   ticker?: string;
   slug: string;
@@ -111,13 +129,28 @@ type GameTeamsSource = {
   awayTeamName?: string;
 };
 
-type GameTeamsMetadata = {
+export type GameTeamsMetadata = {
   teams?: PolymarketTeamInfo[];
   homeTeamName?: string;
   awayTeamName?: string;
 };
 
-export async function fetchTeamsForGameEvents(events: GameTeamsSource[]): Promise<Map<string, GameTeamsMetadata>> {
+export async function fetchTeamMetadataForGameEvent(
+  event: GameTeamsSource,
+  abortController?: AbortController | null
+): Promise<GameTeamsMetadata | null> {
+  const teams = await fetchTeamsForEvent(event, abortController);
+  return { teams, homeTeamName: event.homeTeamName, awayTeamName: event.awayTeamName };
+}
+
+export async function fetchTeamsForGameEvents(
+  events: GameTeamsSource[],
+  abortController?: AbortController | null,
+  fetchMetadata: (
+    event: GameTeamsSource,
+    abortController?: AbortController | null
+  ) => Promise<GameTeamsMetadata | null> = fetchTeamMetadataForGameEvent
+): Promise<Map<string, GameTeamsMetadata>> {
   const teamsMap = new Map<string, GameTeamsMetadata>();
   const gameEventsByTicker = new Map<string, GameTeamsSource>();
 
@@ -127,13 +160,15 @@ export async function fetchTeamsForGameEvents(events: GameTeamsSource[]): Promis
     }
   }
 
-  await Promise.all(
-    Array.from(gameEventsByTicker.values()).map(async event => {
-      if (!event.ticker) return;
-      const teams = await fetchTeamsForEvent(event);
-      teamsMap.set(event.ticker, { teams, homeTeamName: event.homeTeamName, awayTeamName: event.awayTeamName });
-    })
-  );
+  const gameEvents = Array.from(gameEventsByTicker.values());
+  const results = await mapWithConcurrency(gameEvents, 4, event => fetchMetadata(event, abortController));
+
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled' && result.value) {
+      const { ticker } = gameEvents[index];
+      if (ticker) teamsMap.set(ticker, result.value);
+    }
+  });
 
   return teamsMap;
 }

--- a/src/features/polymarket/utils/sports.ts
+++ b/src/features/polymarket/utils/sports.ts
@@ -143,6 +143,9 @@ export async function fetchTeamMetadataForGameEvent(
   return { teams, homeTeamName: event.homeTeamName, awayTeamName: event.awayTeamName };
 }
 
+// Bounds Gamma fan-out (each event triggers up to 3 sequential lookups across hundreds of events).
+const TEAM_METADATA_FETCH_CONCURRENCY = 4;
+
 export async function fetchTeamsForGameEvents(
   events: GameTeamsSource[],
   abortController?: AbortController | null,
@@ -161,7 +164,7 @@ export async function fetchTeamsForGameEvents(
   }
 
   const gameEvents = Array.from(gameEventsByTicker.values());
-  const results = await mapWithConcurrency(gameEvents, 4, event => fetchMetadata(event, abortController));
+  const results = await mapWithConcurrency(gameEvents, TEAM_METADATA_FETCH_CONCURRENCY, event => fetchMetadata(event, abortController));
 
   results.forEach((result, index) => {
     if (result.status === 'fulfilled' && result.value) {

--- a/src/features/polymarket/utils/sportsEventOutcome.test.ts
+++ b/src/features/polymarket/utils/sportsEventOutcome.test.ts
@@ -1,0 +1,72 @@
+import { type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+import { findSportsEventOutcome } from '@/features/polymarket/utils/sportsEventOutcome';
+
+jest.mock('@/features/polymarket/utils/getMarketColor', () => ({
+  getOutcomeColor: jest.fn(),
+}));
+
+describe('findSportsEventOutcome', () => {
+  it('finds the market and outcome by clob token id', () => {
+    const spreadMarket = createMarket({
+      id: 'spread',
+      clobTokenIds: ['spread-away-token', 'spread-home-token'],
+      outcomes: ['Away +3.5', 'Home -3.5'],
+    });
+    const moneylineMarket = createMarket({
+      id: 'moneyline',
+      clobTokenIds: ['moneyline-away-token', 'moneyline-home-token'],
+      outcomes: ['Away', 'Home'],
+    });
+
+    expect(findSportsEventOutcome([spreadMarket, moneylineMarket], 'moneyline-home-token')).toEqual({
+      market: moneylineMarket,
+      outcomeIndex: 1,
+      outcome: 'Home',
+    });
+  });
+
+  it('uses the group item title when the market provides one', () => {
+    const market = createMarket({
+      id: 'player-prop',
+      clobTokenIds: ['over-token', 'under-token'],
+      outcomes: ['Over', 'Under'],
+      groupItemTitle: 'LeBron James',
+    });
+
+    expect(findSportsEventOutcome([market], 'under-token')).toEqual({
+      market,
+      outcomeIndex: 1,
+      outcome: 'LeBron James',
+    });
+  });
+
+  it('returns null when the token id is missing or unknown', () => {
+    const market = createMarket({
+      id: 'moneyline',
+      clobTokenIds: ['away-token', 'home-token'],
+      outcomes: ['Away', 'Home'],
+    });
+
+    expect(findSportsEventOutcome([market], undefined)).toBeNull();
+    expect(findSportsEventOutcome([market], 'draw-token')).toBeNull();
+  });
+});
+
+function createMarket({
+  clobTokenIds,
+  groupItemTitle = '',
+  id,
+  outcomes,
+}: {
+  id: string;
+  clobTokenIds: string[];
+  outcomes: string[];
+  groupItemTitle?: string;
+}): PolymarketMarket {
+  return {
+    id,
+    clobTokenIds,
+    groupItemTitle,
+    outcomes,
+  } as PolymarketMarket;
+}

--- a/src/features/polymarket/utils/sportsEventOutcome.ts
+++ b/src/features/polymarket/utils/sportsEventOutcome.ts
@@ -8,24 +8,34 @@ export type SportsEventOutcomeInfo = {
   outcome: string;
 };
 
+export function findSportsEventOutcome(markets: PolymarketMarket[], outcomeTokenId?: string): SportsEventOutcomeInfo | null {
+  if (!outcomeTokenId) return null;
+
+  for (const market of markets) {
+    const outcomeIndex = market.clobTokenIds.indexOf(outcomeTokenId);
+    if (outcomeIndex >= 0) {
+      const outcome = market.groupItemTitle || market.outcomes[outcomeIndex] || '';
+      return { market, outcomeIndex, outcome };
+    }
+  }
+
+  return null;
+}
+
 export function getSportsEventOutcomeCellColor(
   markets: PolymarketMarket[],
   outcomeTokenId: string | undefined,
   isDarkMode: boolean,
   teams?: PolymarketTeamInfo[]
 ): string | undefined {
-  if (!outcomeTokenId) return undefined;
+  const outcomeInfo = findSportsEventOutcome(markets, outcomeTokenId);
+  if (!outcomeInfo) return undefined;
 
-  for (const market of markets) {
-    const outcomeIndex = market.clobTokenIds.indexOf(outcomeTokenId);
-    if (outcomeIndex >= 0) {
-      return getOutcomeColor({
-        market,
-        outcome: market.groupItemTitle || market.outcomes[outcomeIndex] || '',
-        outcomeIndex,
-        isDarkMode,
-        teams,
-      });
-    }
-  }
+  return getOutcomeColor({
+    market: outcomeInfo.market,
+    outcome: outcomeInfo.outcome,
+    outcomeIndex: outcomeInfo.outcomeIndex,
+    isDarkMode,
+    teams,
+  });
 }

--- a/src/features/polymarket/utils/sportsEventOutcome.ts
+++ b/src/features/polymarket/utils/sportsEventOutcome.ts
@@ -1,0 +1,31 @@
+import { type PolymarketTeamInfo } from '@/features/polymarket/types';
+import { type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+import { getOutcomeColor } from '@/features/polymarket/utils/getMarketColor';
+
+export type SportsEventOutcomeInfo = {
+  market: PolymarketMarket;
+  outcomeIndex: number;
+  outcome: string;
+};
+
+export function getSportsEventOutcomeCellColor(
+  markets: PolymarketMarket[],
+  outcomeTokenId: string | undefined,
+  isDarkMode: boolean,
+  teams?: PolymarketTeamInfo[]
+): string | undefined {
+  if (!outcomeTokenId) return undefined;
+
+  for (const market of markets) {
+    const outcomeIndex = market.clobTokenIds.indexOf(outcomeTokenId);
+    if (outcomeIndex >= 0) {
+      return getOutcomeColor({
+        market,
+        outcome: market.groupItemTitle || market.outcomes[outcomeIndex] || '',
+        outcomeIndex,
+        isDarkMode,
+        teams,
+      });
+    }
+  }
+}

--- a/src/framework/core/utils/mapWithConcurrency.test.ts
+++ b/src/framework/core/utils/mapWithConcurrency.test.ts
@@ -1,0 +1,155 @@
+import { mapWithConcurrency } from './mapWithConcurrency';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Drains the microtask queue so parked workers can pick up the next item before we assert.
+const flush = () =>
+  new Promise<void>(resolve => {
+    setImmediate(resolve);
+  });
+
+describe('mapWithConcurrency', () => {
+  it('returns [] for empty input without invoking the mapper', async () => {
+    const mapper = jest.fn(async (n: number) => n);
+    const results = await mapWithConcurrency([], 4, mapper);
+    expect(results).toEqual([]);
+    expect(mapper).not.toHaveBeenCalled();
+  });
+
+  it('preserves input order even when items resolve out of order', async () => {
+    const deferreds = [0, 1, 2, 3].map(() => createDeferred<number>());
+    const promise = mapWithConcurrency([0, 1, 2, 3], 4, (n: number) => deferreds[n].promise);
+
+    deferreds[3].resolve(30);
+    deferreds[2].resolve(20);
+    deferreds[1].resolve(10);
+    deferreds[0].resolve(0);
+
+    const results = await promise;
+    expect(results.map(r => (r.status === 'fulfilled' ? r.value : null))).toEqual([0, 10, 20, 30]);
+  });
+
+  it('captures rejections without aborting the rest of the batch', async () => {
+    const boom = new Error('boom');
+    const results = await mapWithConcurrency([0, 1, 2], 3, async (n: number) => {
+      if (n === 1) throw boom;
+      return n;
+    });
+
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 0 });
+    expect(results[1]).toEqual({ status: 'rejected', reason: boom });
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 2 });
+  });
+
+  it('mirrors the Polymarket team-metadata fetch: a dozen events at concurrency 4', async () => {
+    const items = Array.from({ length: 12 }, (_, i) => i);
+    const deferreds = items.map(() => createDeferred<number>());
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const promise = mapWithConcurrency(items, 4, async (i: number) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await deferreds[i].promise;
+      inFlight -= 1;
+      return i * 2;
+    });
+
+    for (let i = 0; i < items.length; i++) {
+      await flush();
+      expect(inFlight).toBeLessThanOrEqual(4);
+      deferreds[i].resolve(i);
+    }
+
+    const results = await promise;
+    expect(results).toHaveLength(12);
+    expect(maxInFlight).toBe(4);
+    expect(results.map(r => (r.status === 'fulfilled' ? r.value : null))).toEqual(items.map(i => i * 2));
+  });
+
+  it('never exceeds the concurrency cap and actually reaches it', async () => {
+    const total = 6;
+    const concurrency = 2;
+    const deferreds = Array.from({ length: total }, () => createDeferred<number>());
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const promise = mapWithConcurrency(
+      Array.from({ length: total }, (_, i) => i),
+      concurrency,
+      async (i: number) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await deferreds[i].promise;
+        inFlight -= 1;
+        return i;
+      }
+    );
+
+    for (let i = 0; i < total; i++) {
+      await flush();
+      expect(inFlight).toBeLessThanOrEqual(concurrency);
+      deferreds[i].resolve(i);
+    }
+
+    await promise;
+    expect(maxInFlight).toBe(concurrency);
+  });
+
+  it('clamps concurrency greater than items.length to items.length', async () => {
+    const total = 3;
+    const deferreds = Array.from({ length: total }, () => createDeferred<number>());
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const promise = mapWithConcurrency(
+      Array.from({ length: total }, (_, i) => i),
+      10,
+      async (i: number) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await deferreds[i].promise;
+        inFlight -= 1;
+        return i;
+      }
+    );
+
+    await flush();
+    deferreds.forEach((d, i) => d.resolve(i));
+    const results = await promise;
+
+    expect(results).toHaveLength(total);
+    expect(maxInFlight).toBe(total);
+  });
+
+  it.each([0, -3, NaN])('clamps invalid concurrency (%p) to a single serial worker', async concurrency => {
+    const total = 3;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const mapper = jest.fn(async (i: number) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return i;
+    });
+
+    const results = await mapWithConcurrency(
+      Array.from({ length: total }, (_, i) => i),
+      concurrency,
+      mapper
+    );
+
+    expect(mapper).toHaveBeenCalledTimes(total);
+    expect(maxInFlight).toBe(1);
+    expect(results.map(r => (r.status === 'fulfilled' ? r.value : null))).toEqual([0, 1, 2]);
+  });
+});

--- a/src/framework/core/utils/mapWithConcurrency.ts
+++ b/src/framework/core/utils/mapWithConcurrency.ts
@@ -4,6 +4,9 @@
  * Results are returned in input order as `PromiseSettledResult`s, so a single
  * rejection never aborts the rest of the batch — callers inspect each entry's
  * `status` to handle fulfilled vs. rejected work individually.
+ *
+ * `concurrency` is clamped to a finite worker count of at least 1, so `0`,
+ * negative, or `NaN` values degrade to serial execution rather than running nothing.
  */
 export async function mapWithConcurrency<T, R>(
   items: T[],
@@ -14,6 +17,8 @@ export async function mapWithConcurrency<T, R>(
 
   const results: PromiseSettledResult<R>[] = new Array(items.length);
   let nextIndex = 0;
+
+  const workerCount = Math.max(1, Math.min(Math.floor(Number.isFinite(concurrency) ? concurrency : 1), items.length));
 
   async function worker(): Promise<void> {
     while (nextIndex < items.length) {
@@ -34,6 +39,6 @@ export async function mapWithConcurrency<T, R>(
     }
   }
 
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  await Promise.all(Array.from({ length: workerCount }, worker));
   return results;
 }

--- a/src/framework/core/utils/mapWithConcurrency.ts
+++ b/src/framework/core/utils/mapWithConcurrency.ts
@@ -1,0 +1,39 @@
+/**
+ * Maps over `items` with a bounded number of concurrent `mapper` invocations.
+ *
+ * Results are returned in input order as `PromiseSettledResult`s, so a single
+ * rejection never aborts the rest of the batch — callers inspect each entry's
+ * `status` to handle fulfilled vs. rejected work individually.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+  if (!items.length) return [];
+
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      try {
+        results[index] = {
+          status: 'fulfilled',
+          value: await mapper(items[index]),
+        };
+      } catch (reason) {
+        results[index] = {
+          reason,
+          status: 'rejected',
+        };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}


### PR DESCRIPTION
Pulls sports-event presentation and section-classification logic out of the list components into shared hooks, utils, and a React-free classifier the upcoming Discover prediction card can import, with no change to the sports screen's behavior.

## What changed

- Extracted bet-grid, status, and accent-color logic into `useSportsEventBets` and `useSportsEventStatus`, split so a card can take status alone.
- `getSportsEventLeagueId` and `getSportsEventAccentColor` now export the canonical league resolver and shared league/`event.color` accent; gradient tokens defer to the card PR.
- Moved bet-cell press handling into the cell; unresolvable token IDs render disabled and expose an `onResolvedOutcomePress` seam.
- Section classification moved into a React-free `buildPolymarketSportsEventsListData` with an injectable reference date, testable without mocking the clock.
- `getSportsEventScheduleBucket` and `isLiveSportsEvent` are now the single source for placement; ended games no longer jump from Live to Today/Tomorrow on poll.
- Gated the store behind `usePolymarketSportsEventsEnabled`, read as the query store's `enabled` signal, with test suppression.
- Team-metadata prefetch threads an `AbortController` and caps in-flight work at a 4-worker pool; a cache-only store serves repeat lookups under one `GameTeamsMetadata` shape.
- Fixed league-switch scroll-to-top.
- Empty/loading state uses `flexGrow: 1` instead of a fixed height, dropping the spurious scroll indicator.

## What to test

- Events appear under Live, Today, and Tomorrow across the +2-day window.
- Switching leagues scrolls the list to the top.
- A just-ended live game does not flicker into Today/Tomorrow on refresh.
- Bet cells open the order flow; unresolvable outcomes render disabled and don't navigate.
- Team names and logos load on first view, then reappear instantly on back-nav with no network call.
- With Polymarket disabled, no sports requests fire on launch; enabling it runs the prefetch.
