### PR TITLE
feat(predictions): sports league deep links

### DIFF
--- a/src/features/polymarket/constants.ts
+++ b/src/features/polymarket/constants.ts
@@ -215,4 +215,5 @@ export const CATEGORIES = {
   },
 } as const;
 
-export type Category = (typeof CATEGORIES)[keyof typeof CATEGORIES];
+export type CategoryKey = keyof typeof CATEGORIES;
+export type Category = (typeof CATEGORIES)[CategoryKey];

--- a/src/features/polymarket/hooks/useCategorySelector.ts
+++ b/src/features/polymarket/hooks/useCategorySelector.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+import { type LayoutChangeEvent, type ScrollView } from 'react-native';
+
+import { useSharedValue, type SharedValue } from 'react-native-reanimated';
+
+import { useListen } from '@/state/internal/hooks/useListen';
+import { type BaseRainbowStore } from '@/state/internal/types';
+
+type ItemLayout = { x: number; width: number };
+
+type UseCategorySelectorParams<StoreState, Item, Key extends string> = {
+  containerWidth: number;
+  getItemKey: (item: Item) => Key;
+  horizontalPadding: number;
+  isNonDefaultInitialSelection?: (initialKey: Key) => boolean;
+  items: readonly Item[];
+  scrollViewRef: RefObject<ScrollView | null>;
+  selectStoreKey: (state: StoreState) => Key;
+  setStoreKey: (key: Key) => void;
+  store: BaseRainbowStore<StoreState>;
+};
+
+type UseCategorySelectorResult<Item, Key extends string> = {
+  onItemLayout: (event: LayoutChangeEvent, index: number) => void;
+  onPress: (item: Item) => void;
+  selectedKey: SharedValue<Key>;
+  skipInitialAnimation: SharedValue<boolean>;
+};
+
+export function useCategorySelector<StoreState, Item, Key extends string>({
+  containerWidth,
+  getItemKey,
+  horizontalPadding,
+  isNonDefaultInitialSelection,
+  items,
+  scrollViewRef,
+  selectStoreKey,
+  setStoreKey,
+  store,
+}: UseCategorySelectorParams<StoreState, Item, Key>): UseCategorySelectorResult<Item, Key> {
+  const itemLayouts = useRef<ItemLayout[]>([]);
+  const didInitialScroll = useRef(false);
+  const initialKey = selectStoreKey(store.getState());
+  const selectedKey = useSharedValue<Key>(initialKey);
+  const skipInitialAnimation = useSharedValue(isNonDefaultInitialSelection?.(initialKey) ?? false);
+
+  useEffect(() => {
+    // Clear after first paint so taps + external syncs animate normally.
+    skipInitialAnimation.value = false;
+  }, [skipInitialAnimation]);
+
+  const scrollToKey = useCallback(
+    (key: Key, animated = false) => {
+      const index = items.findIndex(item => getItemKey(item) === key);
+      const scrollX = calculateCenteredScrollX(itemLayouts.current, index, containerWidth, horizontalPadding);
+      scrollViewRef.current?.scrollTo({ x: scrollX, y: 0, animated });
+    },
+    [containerWidth, getItemKey, horizontalPadding, items, scrollViewRef]
+  );
+
+  const scrollToSelectedKey = useCallback(() => {
+    scrollToKey(selectedKey.value);
+  }, [scrollToKey, selectedKey]);
+
+  const syncExternalSelection = useCallback(
+    (nextKey: Key) => {
+      if (selectedKey.value === nextKey) return;
+
+      selectedKey.value = nextKey;
+      if (allItemsMeasured(itemLayouts.current, items.length)) scrollToKey(nextKey, true);
+    },
+    [items.length, scrollToKey, selectedKey]
+  );
+
+  useListen(store, selectStoreKey, syncExternalSelection);
+
+  const onItemLayout = useCallback(
+    (event: LayoutChangeEvent, index: number) => {
+      itemLayouts.current[index] = { x: event.nativeEvent.layout.x, width: event.nativeEvent.layout.width };
+      if (!didInitialScroll.current && allItemsMeasured(itemLayouts.current, items.length)) {
+        didInitialScroll.current = true;
+        scrollToSelectedKey();
+      }
+    },
+    [items.length, scrollToSelectedKey]
+  );
+
+  const onPress = useCallback(
+    (item: Item) => {
+      const key = getItemKey(item);
+      selectedKey.value = key;
+      if (allItemsMeasured(itemLayouts.current, items.length)) scrollToKey(key, true);
+      setStoreKey(key);
+    },
+    [getItemKey, items.length, scrollToKey, selectedKey, setStoreKey]
+  );
+
+  return { onItemLayout, onPress, selectedKey, skipInitialAnimation };
+}
+
+function allItemsMeasured(layouts: ItemLayout[], itemCount: number): boolean {
+  return layouts.filter(Boolean).length === itemCount;
+}
+
+function calculateCenteredScrollX(layouts: ItemLayout[], index: number, containerWidth: number, horizontalPadding: number): number {
+  const layout = layouts[index];
+  const lastLayout = layouts[layouts.length - 1];
+  if (!layout || !lastLayout) return 0;
+
+  const itemCenter = layout.x + layout.width / 2;
+  const contentWidth = lastLayout.x + lastLayout.width + horizontalPadding;
+  const maxScroll = Math.max(0, contentWidth - containerWidth);
+
+  return Math.min(Math.max(0, itemCenter - containerWidth / 2), maxScroll);
+}

--- a/src/features/polymarket/leagues.ts
+++ b/src/features/polymarket/leagues.ts
@@ -957,7 +957,7 @@ export function getLeagueSlugId(value: string): string | undefined {
 }
 
 export function isLeagueId(value: string): value is LeagueId {
-  return value in SPORT_LEAGUES;
+  return Object.prototype.hasOwnProperty.call(SPORT_LEAGUES, value);
 }
 
 export function getLeagueId(value: string): LeagueId | undefined {

--- a/src/features/polymarket/screens/polymarket-browse-events-screen/PolymarketEventCategorySelector.tsx
+++ b/src/features/polymarket/screens/polymarket-browse-events-screen/PolymarketEventCategorySelector.tsx
@@ -1,14 +1,15 @@
-import { memo, useCallback, useMemo, useRef } from 'react';
-import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+import { memo, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { ScrollView } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, withTiming, type SharedValue } from 'react-native-reanimated';
 
-import { AnimatedTextIcon } from '@/components/AnimatedComponents/AnimatedTextIcon';
+import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
-import { Border, globalColors, Text, useColorMode, useForegroundColor } from '@/design-system';
+import { Border, globalColors, Text, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
-import { CATEGORIES, type Category } from '@/features/polymarket/constants';
+import { CATEGORIES, DEFAULT_CATEGORY_KEY, type CategoryKey } from '@/features/polymarket/constants';
+import { useCategorySelector } from '@/features/polymarket/hooks/useCategorySelector';
 import { usePolymarketContext } from '@/features/polymarket/screens/polymarket-navigator/PolymarketContext';
 import { usePolymarketCategoryStore } from '@/features/polymarket/stores/usePolymarketCategoryStore';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -17,52 +18,36 @@ import { deepFreeze } from '@/utils/deepFreeze';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { createOpacityPalette } from '@/worklets/colors';
 
-type CategoryKey = keyof typeof CATEGORIES;
-type CategoryWithKey = Category & { key: CategoryKey };
-type ItemLayout = { x: number; width: number };
-
 const VERTICAL_PADDING = 0;
 const CONTAINER_HEIGHT = 40 + VERTICAL_PADDING * 2;
 const HORIZONTAL_PADDING = 16;
-const CATEGORY_ITEMS: CategoryWithKey[] = Object.entries(CATEGORIES).map<CategoryWithKey>(([key, category]) => ({
+const CATEGORY_ITEMS = Object.entries(CATEGORIES).map(([key, category]) => ({
   ...category,
   key: key as CategoryKey,
 }));
+type CategoryWithKey = (typeof CATEGORY_ITEMS)[number];
 const PALETTE_OPACITIES = deepFreeze([6, 8, 28]);
 
 // ============ Category Selector ============================================== //
 
 export const PolymarketEventCategorySelector = memo(function PolymarketEventCategorySelector() {
   const { categorySelectorRef } = usePolymarketContext();
-  const itemLayouts = useRef<ItemLayout[]>([]);
-  const didInitialScroll = useRef(false);
-
-  const selectedCategoryKey = useSharedValue<CategoryKey>(usePolymarketCategoryStore.getState().tagId as CategoryKey);
-
-  const scrollToSelectedCategory = useCallback(() => {
-    const index = CATEGORY_ITEMS.findIndex(category => category.key === selectedCategoryKey.value);
-    const scrollX = calculateCenteredScrollX(itemLayouts.current, index);
-    categorySelectorRef.current?.scrollTo({ x: scrollX, y: 0, animated: false });
-  }, [categorySelectorRef, selectedCategoryKey]);
-
-  const onItemLayout = useCallback(
-    (event: LayoutChangeEvent, index: number) => {
-      itemLayouts.current[index] = { x: event.nativeEvent.layout.x, width: event.nativeEvent.layout.width };
-      if (!didInitialScroll.current && allItemsMeasured(itemLayouts.current)) {
-        didInitialScroll.current = true;
-        scrollToSelectedCategory();
-      }
-    },
-    [scrollToSelectedCategory]
-  );
-
-  const onPress = useCallback(
-    (category: CategoryWithKey) => {
-      selectedCategoryKey.value = category.key;
-      usePolymarketCategoryStore.getState().setTagId(category.key);
-    },
-    [selectedCategoryKey]
-  );
+  const {
+    onItemLayout,
+    onPress,
+    selectedKey: selectedCategoryKey,
+    skipInitialAnimation,
+  } = useCategorySelector({
+    containerWidth: DEVICE_WIDTH,
+    getItemKey: getCategoryKey,
+    horizontalPadding: HORIZONTAL_PADDING,
+    isNonDefaultInitialSelection: key => key !== DEFAULT_CATEGORY_KEY,
+    items: CATEGORY_ITEMS,
+    scrollViewRef: categorySelectorRef,
+    selectStoreKey: state => state.tagId,
+    setStoreKey: setCategoryKey,
+    store: usePolymarketCategoryStore,
+  });
 
   return (
     <View style={styles.container}>
@@ -75,7 +60,12 @@ export const PolymarketEventCategorySelector = memo(function PolymarketEventCate
       >
         {CATEGORY_ITEMS.map((category, index) => (
           <View key={category.key} onLayout={event => onItemLayout(event, index)}>
-            <CategoryItem category={category} onPress={onPress} selectedCategoryKey={selectedCategoryKey} />
+            <CategoryItem
+              category={category}
+              onPress={onPress}
+              selectedCategoryKey={selectedCategoryKey}
+              skipInitialAnimation={skipInitialAnimation}
+            />
           </View>
         ))}
       </ScrollView>
@@ -89,9 +79,10 @@ type CategoryItemProps = {
   category: CategoryWithKey;
   onPress: (category: CategoryWithKey) => void;
   selectedCategoryKey: SharedValue<CategoryKey>;
+  skipInitialAnimation: SharedValue<boolean>;
 };
 
-const CategoryItem = memo(function CategoryItem({ category, onPress, selectedCategoryKey }: CategoryItemProps) {
+const CategoryItem = memo(function CategoryItem({ category, onPress, selectedCategoryKey, skipInitialAnimation }: CategoryItemProps) {
   const { isDarkMode } = useColorMode();
   const labelColor = useForegroundColor('label');
   const selectedColor = isDarkMode ? category.color.dark : category.color.light;
@@ -108,13 +99,26 @@ const CategoryItem = memo(function CategoryItem({ category, onPress, selectedCat
     [isDarkMode, accentColors]
   );
 
-  const borderContainerStyle = useAnimatedStyle(() => ({
-    opacity: selectedCategoryKey.value === categoryKey ? 1 : 0,
-  }));
+  const borderContainerStyle = useAnimatedStyle(() => {
+    const target = selectedCategoryKey.value === categoryKey ? 1 : 0;
+    return {
+      opacity: skipInitialAnimation.value ? target : withTiming(target, TIMING_CONFIGS.buttonPressConfig),
+    };
+  });
 
-  const iconStyle = useAnimatedStyle(() => ({
-    color: selectedCategoryKey.value === categoryKey ? selectedColor : unselectedIconColor,
-  }));
+  const selectedIconStyle = useAnimatedStyle(() => {
+    const target = selectedCategoryKey.value === categoryKey ? 1 : 0;
+    return {
+      opacity: skipInitialAnimation.value ? target : withTiming(target, TIMING_CONFIGS.buttonPressConfig),
+    };
+  });
+
+  const unselectedIconStyle = useAnimatedStyle(() => {
+    const target = selectedCategoryKey.value === categoryKey ? 0 : 1;
+    return {
+      opacity: skipInitialAnimation.value ? target : withTiming(target, TIMING_CONFIGS.buttonPressConfig),
+    };
+  });
 
   return (
     <ButtonPressAnimation onPress={() => onPress(category)} scaleTo={0.88}>
@@ -125,9 +129,16 @@ const CategoryItem = memo(function CategoryItem({ category, onPress, selectedCat
           {isDarkMode && <InnerShadow blur={16} borderRadius={CONTAINER_HEIGHT / 2} color={accentColors.opacity28} dx={0} dy={8} />}
         </Animated.View>
         <View style={styles.iconContainer}>
-          <AnimatedTextIcon align="center" color="label" size="icon 16px" textStyle={iconStyle} weight="heavy">
-            {category.icon}
-          </AnimatedTextIcon>
+          <Animated.View style={[styles.iconLayer, unselectedIconStyle]}>
+            <TextIcon align="center" color={{ custom: unselectedIconColor }} size="icon 16px" weight="heavy">
+              {category.icon}
+            </TextIcon>
+          </Animated.View>
+          <Animated.View style={[styles.iconLayer, selectedIconStyle]}>
+            <TextIcon align="center" color={{ custom: selectedColor }} size="icon 16px" weight="heavy">
+              {category.icon}
+            </TextIcon>
+          </Animated.View>
         </View>
         <Text align="center" color="label" size="17pt" weight="heavy">
           {category.label}
@@ -139,20 +150,12 @@ const CategoryItem = memo(function CategoryItem({ category, onPress, selectedCat
 
 // ============ Utilities ====================================================== //
 
-function allItemsMeasured(layouts: ItemLayout[]): boolean {
-  return layouts.filter(Boolean).length === CATEGORY_ITEMS.length;
+function getCategoryKey(category: CategoryWithKey): CategoryKey {
+  return category.key;
 }
 
-function calculateCenteredScrollX(layouts: ItemLayout[], index: number): number {
-  const layout = layouts[index];
-  const lastLayout = layouts[layouts.length - 1];
-  if (!layout || !lastLayout) return 0;
-
-  const itemCenter = layout.x + layout.width / 2;
-  const contentWidth = lastLayout.x + lastLayout.width + HORIZONTAL_PADDING;
-  const maxScroll = Math.max(0, contentWidth - DEVICE_WIDTH);
-
-  return Math.min(Math.max(0, itemCenter - DEVICE_WIDTH / 2), maxScroll);
+function setCategoryKey(key: CategoryKey): void {
+  usePolymarketCategoryStore.getState().setTagId(key);
 }
 
 // ============ Styles ========================================================= //
@@ -168,6 +171,9 @@ const styles = StyleSheet.create({
     height: 20,
     justifyContent: 'center',
     width: 24,
+  },
+  iconLayer: {
+    position: 'absolute',
   },
   itemContainer: {
     alignItems: 'center',

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
@@ -15,6 +15,7 @@ import { PolymarketSearchScreen } from '@/features/polymarket/screens/polymarket
 import { useCleanup } from '@/hooks/useCleanup';
 import { useStableValue } from '@/hooks/useStableValue';
 import { createVirtualNavigator } from '@/navigation/createVirtualNavigator';
+import { useRoute } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { type PolymarketRoute } from '@/navigation/types';
 import { useListen } from '@/state/internal/hooks/useListen';
@@ -49,6 +50,19 @@ const PolymarketNavigatorContent = () => {
   );
 
   useCleanup(PolymarketNavigation.resetNavigationState);
+
+  // Apply a deep-link route intent passed through the outer navigation params: reset stale
+  // virtual history, then switch the virtual navigator to the requested inner tab. Keyed on
+  // routeRequestKey so a repeated request to the same route still re-applies.
+  const { params } = useRoute<typeof Routes.POLYMARKET_NAVIGATOR>();
+  const requestedRoute = params?.initialRoute;
+  const routeRequestKey = params?.routeRequestKey;
+
+  useEffect(() => {
+    if (!requestedRoute) return;
+    PolymarketNavigation.resetNavigationState();
+    PolymarketNavigation.navigate(requestedRoute);
+  }, [requestedRoute, routeRequestKey]);
 
   return (
     <>

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketNavigator.tsx
@@ -39,7 +39,7 @@ export const PolymarketNavigator = memo(function PolymarketNavigator() {
 const PolymarketNavigatorContent = () => {
   const { isDarkMode } = useColorMode();
   const { ref, goToPage } = usePagerNavigation();
-  const { categorySelectorRef } = usePolymarketContext();
+  const { categorySelectorRef, eventsListRef } = usePolymarketContext();
 
   const screenBackgroundColor = isDarkMode ? POLYMARKET_BACKGROUND_DARK : POLYMARKET_BACKGROUND_LIGHT;
 
@@ -62,6 +62,9 @@ const PolymarketNavigatorContent = () => {
     if (!requestedRoute) return;
     PolymarketNavigation.resetNavigationState();
     PolymarketNavigation.navigate(requestedRoute);
+    // Reset list scroll too: a repeated deep link to the same league leaves
+    // selectedLeagueId unchanged, so the value-based useListen won't fire.
+    eventsListRef.current?.scrollToOffset({ offset: 0, animated: false });
   }, [requestedRoute, routeRequestKey]);
 
   return (

--- a/src/features/polymarket/screens/polymarket-navigator/PolymarketTabSelector.tsx
+++ b/src/features/polymarket/screens/polymarket-navigator/PolymarketTabSelector.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
@@ -53,7 +53,14 @@ export const PolymarketTabSelector = memo(function PolymarketTabSelector() {
   const { accountScrollRef, eventsListRef } = usePolymarketContext();
 
   const buttonWidth = useDerivedValue<number>(() => PILL.width);
-  const selectedIndex = useSharedValue(TABS[usePolymarketNavigationStore.getState().activeRoute as Tab]?.index ?? 0);
+  const initialIndex = TABS[usePolymarketNavigationStore.getState().activeRoute as Tab]?.index ?? 0;
+  const selectedIndex = useSharedValue(initialIndex);
+  const skipInitialAnimation = useSharedValue(initialIndex !== 0);
+
+  useEffect(() => {
+    // Clear after first paint so tab changes animate normally.
+    skipInitialAnimation.value = false;
+  }, [skipInitialAnimation]);
 
   useListen(
     usePolymarketNavigationStore,
@@ -121,7 +128,12 @@ export const PolymarketTabSelector = memo(function PolymarketTabSelector() {
         )}
         {isDarkMode && <InnerShadow borderRadius={PILL.borderRadius} color={opacity('#DC91F4', 0.14)} blur={5} dx={0} dy={1} />}
       </View>
-      <SelectedHighlight buttonWidth={buttonWidth} selectedIndex={selectedIndex} paddingHorizontal={PADDING_HORIZONTAL} />
+      <SelectedHighlight
+        buttonWidth={buttonWidth}
+        selectedIndex={selectedIndex}
+        skipInitialAnimation={skipInitialAnimation}
+        paddingHorizontal={PADDING_HORIZONTAL}
+      />
       <TabButtons onPress={onPress} selectedIndex={selectedIndex} />
     </Box>
   );
@@ -130,23 +142,28 @@ export const PolymarketTabSelector = memo(function PolymarketTabSelector() {
 const SelectedHighlight = memo(function SelectedHighlight({
   buttonWidth,
   selectedIndex,
+  skipInitialAnimation,
   paddingHorizontal = 0,
 }: {
   buttonWidth: DerivedValue<number>;
   selectedIndex: SharedValue<number>;
+  skipInitialAnimation: SharedValue<boolean>;
   paddingHorizontal?: number;
 }) {
   const { isDarkMode } = useColorMode();
   const highlightBackgroundColor = isDarkMode ? opacity('#82408F', 0.3) : opacity('#FF76FF', 0.07);
   const borderColor = opacity('#DC91F4', isDarkMode ? 0.06 : 0.03);
 
-  const translateX = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateX: withSpring(selectedIndex.value * buttonWidth.value + paddingHorizontal, SPRING_CONFIGS.snappyMediumSpringConfig),
-      },
-    ],
-  }));
+  const translateX = useAnimatedStyle(() => {
+    const target = selectedIndex.value * buttonWidth.value + paddingHorizontal;
+    return {
+      transform: [
+        {
+          translateX: skipInitialAnimation.value ? target : withSpring(target, SPRING_CONFIGS.snappyMediumSpringConfig),
+        },
+      ],
+    };
+  });
 
   const width = useAnimatedStyle(() => ({
     width: withSpring(buttonWidth.value, SPRING_CONFIGS.snappyMediumSpringConfig),

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketLeagueSelector.tsx
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketLeagueSelector.tsx
@@ -1,30 +1,30 @@
-import { Fragment, memo, useCallback, useMemo, useRef } from 'react';
-import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+import { Fragment, memo, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { ScrollView } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, withTiming, type SharedValue } from 'react-native-reanimated';
 
+import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Border, globalColors, Text, useColorMode } from '@/design-system';
 import { InnerShadow } from '@/features/polymarket/components/InnerShadow';
 import { getIconByLeagueId, LeagueIcon } from '@/features/polymarket/components/league-icon/LeagueIcon';
 import { DEFAULT_SPORTS_LEAGUE_KEY } from '@/features/polymarket/constants';
-import { LEAGUE_SELECTOR_ORDER, SPORT_LEAGUES, type LeagueId } from '@/features/polymarket/leagues';
+import { useCategorySelector } from '@/features/polymarket/hooks/useCategorySelector';
+import { LEAGUE_SELECTOR_ORDER, SPORT_LEAGUES } from '@/features/polymarket/leagues';
 import { usePolymarketContext } from '@/features/polymarket/screens/polymarket-navigator/PolymarketContext';
-import { usePolymarketSportsEventsStore } from '@/features/polymarket/stores/polymarketSportsEventsStore';
+import { usePolymarketSportsEventsStore, type PolymarketSportsLeagueId } from '@/features/polymarket/stores/polymarketSportsEventsStore';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { THICK_BORDER_WIDTH, THICKER_BORDER_WIDTH } from '@/styles/constants';
 import { deepFreeze } from '@/utils/deepFreeze';
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 import { createOpacityPalette } from '@/worklets/colors';
 
-type LeagueItemKey = LeagueId | typeof DEFAULT_SPORTS_LEAGUE_KEY;
 type LeagueItem = {
-  key: LeagueItemKey;
+  key: PolymarketSportsLeagueId;
   label: string;
   color: { dark: string; light: string };
 };
-type ItemLayout = { x: number; width: number };
 
 const VERTICAL_PADDING = 4;
 const CONTAINER_HEIGHT = 40 + VERTICAL_PADDING * 2;
@@ -50,35 +50,22 @@ export const LEAGUE_SELECTOR_HEIGHT = CONTAINER_HEIGHT;
 export const PolymarketLeagueSelector = memo(function PolymarketLeagueSelector() {
   const { isDarkMode } = useColorMode();
   const { leagueSelectorRef } = usePolymarketContext();
-  const itemLayouts = useRef<ItemLayout[]>([]);
-  const didInitialScroll = useRef(false);
-
-  const selectedLeagueKey = useSharedValue<LeagueItemKey>(usePolymarketSportsEventsStore.getState().selectedLeagueId as LeagueItemKey);
-
-  const scrollToSelectedLeague = useCallback(() => {
-    const index = LEAGUE_ITEMS.findIndex(league => league.key === selectedLeagueKey.value);
-    const scrollX = calculateCenteredScrollX(itemLayouts.current, index);
-    leagueSelectorRef.current?.scrollTo({ x: scrollX, y: 0, animated: false });
-  }, [leagueSelectorRef, selectedLeagueKey]);
-
-  const onItemLayout = useCallback(
-    (event: LayoutChangeEvent, index: number) => {
-      itemLayouts.current[index] = { x: event.nativeEvent.layout.x, width: event.nativeEvent.layout.width };
-      if (!didInitialScroll.current && allItemsMeasured(itemLayouts.current)) {
-        didInitialScroll.current = true;
-        scrollToSelectedLeague();
-      }
-    },
-    [scrollToSelectedLeague]
-  );
-
-  const onPress = useCallback(
-    (league: LeagueItem) => {
-      selectedLeagueKey.value = league.key;
-      usePolymarketSportsEventsStore.getState().setSelectedLeagueId(league.key);
-    },
-    [selectedLeagueKey]
-  );
+  const {
+    onItemLayout,
+    onPress,
+    selectedKey: selectedLeagueKey,
+    skipInitialAnimation,
+  } = useCategorySelector({
+    containerWidth: CONTAINER_WIDTH,
+    getItemKey: getLeagueKey,
+    horizontalPadding: HORIZONTAL_PADDING,
+    isNonDefaultInitialSelection: key => key !== DEFAULT_SPORTS_LEAGUE_KEY,
+    items: LEAGUE_ITEMS,
+    scrollViewRef: leagueSelectorRef,
+    selectStoreKey: state => state.selectedLeagueId,
+    setStoreKey: setLeagueKey,
+    store: usePolymarketSportsEventsStore,
+  });
 
   return (
     <View
@@ -109,7 +96,12 @@ export const PolymarketLeagueSelector = memo(function PolymarketLeagueSelector()
         {LEAGUE_ITEMS.map((league, index) => (
           <Fragment key={league.key}>
             <View onLayout={event => onItemLayout(event, index)}>
-              <LeagueItemComponent league={league} onPress={onPress} selectedLeagueKey={selectedLeagueKey} />
+              <LeagueItemComponent
+                league={league}
+                onPress={onPress}
+                selectedLeagueKey={selectedLeagueKey}
+                skipInitialAnimation={skipInitialAnimation}
+              />
             </View>
             {index < LEAGUE_ITEMS.length - 1 && (
               <View style={[styles.separator, { backgroundColor: opacity('#1A1A1A', isDarkMode ? 1 : 0.04) }]} />
@@ -126,12 +118,18 @@ export const PolymarketLeagueSelector = memo(function PolymarketLeagueSelector()
 type LeagueItemProps = {
   league: LeagueItem;
   onPress: (league: LeagueItem) => void;
-  selectedLeagueKey: SharedValue<LeagueItemKey>;
+  selectedLeagueKey: SharedValue<PolymarketSportsLeagueId>;
+  skipInitialAnimation: SharedValue<boolean>;
 };
 
-const LeagueItemComponent = memo(function LeagueItemComponent({ league, onPress, selectedLeagueKey }: LeagueItemProps) {
+const LeagueItemComponent = memo(function LeagueItemComponent({
+  league,
+  onPress,
+  selectedLeagueKey,
+  skipInitialAnimation,
+}: LeagueItemProps) {
   const { isDarkMode } = useColorMode();
-  const selectedColor = isDarkMode ? league.color.dark : opacity(globalColors.white100, 0.5);
+  const selectedColor = opacity(globalColors.white100, 0.5);
 
   const leagueKey = league.key;
   const accentColors = useMemo(() => createOpacityPalette(selectedColor, PALETTE_OPACITIES), [selectedColor]);
@@ -145,11 +143,17 @@ const LeagueItemComponent = memo(function LeagueItemComponent({ league, onPress,
     [backgroundColor]
   );
 
-  const borderContainerStyle = useAnimatedStyle(() => ({
-    opacity: selectedLeagueKey.value === leagueKey ? 1 : 0,
-  }));
+  const borderContainerStyle = useAnimatedStyle(() => {
+    const target = selectedLeagueKey.value === leagueKey ? 1 : 0;
+    return {
+      opacity: skipInitialAnimation.value ? target : withTiming(target, TIMING_CONFIGS.buttonPressConfig),
+    };
+  });
 
-  const hasIcon = useMemo(() => league.key !== DEFAULT_SPORTS_LEAGUE_KEY && getIconByLeagueId(league.key) !== undefined, [league.key]);
+  const iconLeagueId = useMemo(
+    () => (league.key !== DEFAULT_SPORTS_LEAGUE_KEY && getIconByLeagueId(league.key) !== undefined ? league.key : undefined),
+    [league.key]
+  );
 
   return (
     <ButtonPressAnimation onPress={() => onPress(league)} scaleTo={0.88}>
@@ -159,9 +163,11 @@ const LeagueItemComponent = memo(function LeagueItemComponent({ league, onPress,
           <View style={[StyleSheet.absoluteFill, backgroundFillStyle]} />
           {isDarkMode && <InnerShadow blur={16} borderRadius={CONTAINER_HEIGHT / 2} color={accentColors.opacity28} dx={0} dy={8} />}
         </Animated.View>
-        {hasIcon && (
+        {iconLeagueId && (
           <View style={styles.iconContainer}>
-            <LeagueIcon leagueId={league.key as LeagueId} size={24} />
+            <View style={styles.iconLayer}>
+              <LeagueIcon leagueId={iconLeagueId} size={24} />
+            </View>
           </View>
         )}
         <Text align="center" color="label" size="17pt" weight="heavy">
@@ -174,20 +180,12 @@ const LeagueItemComponent = memo(function LeagueItemComponent({ league, onPress,
 
 // ============ Utilities ====================================================== //
 
-function allItemsMeasured(layouts: ItemLayout[]): boolean {
-  return layouts.filter(Boolean).length === LEAGUE_ITEMS.length;
+function getLeagueKey(league: LeagueItem): PolymarketSportsLeagueId {
+  return league.key;
 }
 
-function calculateCenteredScrollX(layouts: ItemLayout[], index: number): number {
-  const layout = layouts[index];
-  const lastLayout = layouts[layouts.length - 1];
-  if (!layout || !lastLayout) return 0;
-
-  const itemCenter = layout.x + layout.width / 2;
-  const contentWidth = lastLayout.x + lastLayout.width + HORIZONTAL_PADDING;
-  const maxScroll = Math.max(0, contentWidth - CONTAINER_WIDTH);
-
-  return Math.min(Math.max(0, itemCenter - CONTAINER_WIDTH / 2), maxScroll);
+function setLeagueKey(key: PolymarketSportsLeagueId): void {
+  usePolymarketSportsEventsStore.getState().setSelectedLeagueId(key);
 }
 
 // ============ Styles ========================================================= //
@@ -205,6 +203,9 @@ const styles = StyleSheet.create({
     height: 16,
     justifyContent: 'center',
     width: 16,
+  },
+  iconLayer: {
+    position: 'absolute',
   },
   itemContainer: {
     alignItems: 'center',

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketLeagueSelector.tsx
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketLeagueSelector.tsx
@@ -165,9 +165,7 @@ const LeagueItemComponent = memo(function LeagueItemComponent({
         </Animated.View>
         {iconLeagueId && (
           <View style={styles.iconContainer}>
-            <View style={styles.iconLayer}>
-              <LeagueIcon leagueId={iconLeagueId} size={24} />
-            </View>
+            <LeagueIcon leagueId={iconLeagueId} size={24} />
           </View>
         )}
         <Text align="center" color="label" size="17pt" weight="heavy">
@@ -203,9 +201,6 @@ const styles = StyleSheet.create({
     height: 16,
     justifyContent: 'center',
     width: 16,
-  },
-  iconLayer: {
-    position: 'absolute',
   },
   itemContainer: {
     alignItems: 'center',

--- a/src/features/polymarket/stores/usePolymarketCategoryStore.ts
+++ b/src/features/polymarket/stores/usePolymarketCategoryStore.ts
@@ -1,15 +1,15 @@
-import { DEFAULT_CATEGORY_KEY } from '@/features/polymarket/constants';
+import { DEFAULT_CATEGORY_KEY, type CategoryKey } from '@/features/polymarket/constants';
 import { createRainbowStore } from '@/state/internal/createRainbowStore';
 
 type PolymarketCategoryStoreState = {
-  tagId: string;
-  setTagId: (tagId: string) => void;
+  tagId: CategoryKey;
+  setTagId: (tagId: CategoryKey) => void;
 };
 
 export const usePolymarketCategoryStore = createRainbowStore<PolymarketCategoryStoreState>(
   set => ({
     tagId: DEFAULT_CATEGORY_KEY,
-    setTagId: (tagId: string) => set({ tagId }),
+    setTagId: (tagId: CategoryKey) => set({ tagId }),
   }),
   { storageKey: 'polymarketCategoryStore' }
 );

--- a/src/features/polymarket/utils/navigateToPolymarket.ts
+++ b/src/features/polymarket/utils/navigateToPolymarket.ts
@@ -29,7 +29,7 @@ export function navigateToPolymarketSportsLeague(leagueId: string): void {
   const selectedLeagueId = parseSportsLeagueKey(leagueId);
   if (!selectedLeagueId) return;
 
-  usePolymarketCategoryStore.getState().setTagId(CATEGORIES.sports.tagId);
+  usePolymarketCategoryStore.getState().setTagId('sports');
   usePolymarketSportsEventsStore.getState().setSelectedLeagueId(selectedLeagueId);
   navigateToPolymarketBrowse();
 }

--- a/src/features/polymarket/utils/navigateToPolymarket.ts
+++ b/src/features/polymarket/utils/navigateToPolymarket.ts
@@ -22,7 +22,7 @@ export function navigateToPolymarketCategory(tagId: string): void {
   usePolymarketCategoryStore.getState().setTagId(categoryKey);
   usePolymarketSportsEventsStore.getState().setSelectedLeagueId(DEFAULT_SPORTS_LEAGUE_KEY);
 
-  navigateToPolymarket();
+  navigateToPolymarketBrowse();
 }
 
 export function navigateToPolymarketSportsLeague(leagueId: string): void {
@@ -31,7 +31,22 @@ export function navigateToPolymarketSportsLeague(leagueId: string): void {
 
   usePolymarketCategoryStore.getState().setTagId(CATEGORIES.sports.tagId);
   usePolymarketSportsEventsStore.getState().setSelectedLeagueId(selectedLeagueId);
-  navigateToPolymarket();
+  navigateToPolymarketBrowse();
+}
+
+// Monotonic key so a repeated deep link to the same inner route still re-triggers the
+// navigator's route effect even when `initialRoute` is unchanged.
+let polymarketRouteRequestKey = 0;
+
+// Opens the Polymarket navigator on the browse tab. The inner-route intent is passed through
+// the outer navigation params and applied by PolymarketNavigator, so this util never imports
+// the navigator's component/store (avoiding a screen-tree dependency).
+function navigateToPolymarketBrowse(): void {
+  polymarketRouteRequestKey += 1;
+  navigateToPolymarket({
+    initialRoute: Routes.POLYMARKET_BROWSE_EVENTS_SCREEN,
+    routeRequestKey: polymarketRouteRequestKey,
+  });
 }
 
 function parseCategoryKey(tagId: string): CategoryKey | undefined {

--- a/src/features/polymarket/utils/navigateToPolymarket.ts
+++ b/src/features/polymarket/utils/navigateToPolymarket.ts
@@ -54,7 +54,7 @@ function parseCategoryKey(tagId: string): CategoryKey | undefined {
 }
 
 function isCategoryKey(tagId: string): tagId is CategoryKey {
-  return tagId in CATEGORIES;
+  return Object.prototype.hasOwnProperty.call(CATEGORIES, tagId);
 }
 
 function parseSportsLeagueKey(leagueId: string): PolymarketSportsLeagueId | undefined {

--- a/src/features/polymarket/utils/navigateToPolymarket.ts
+++ b/src/features/polymarket/utils/navigateToPolymarket.ts
@@ -1,3 +1,7 @@
+import { CATEGORIES, DEFAULT_SPORTS_LEAGUE_KEY, type CategoryKey } from '@/features/polymarket/constants';
+import { getLeagueId } from '@/features/polymarket/leagues';
+import { usePolymarketSportsEventsStore, type PolymarketSportsLeagueId } from '@/features/polymarket/stores/polymarketSportsEventsStore';
+import { usePolymarketCategoryStore } from '@/features/polymarket/stores/usePolymarketCategoryStore';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { type RootStackParamList } from '@/navigation/types';
@@ -9,6 +13,38 @@ export function navigateToPolymarket(params?: RootStackParamList[typeof Routes.P
 
 export function navigateToPolymarketEvent(params: RootStackParamList[typeof Routes.POLYMARKET_EVENT_SCREEN]) {
   Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, params);
+}
+
+export function navigateToPolymarketCategory(tagId: string): void {
+  const categoryKey = parseCategoryKey(tagId);
+  if (!categoryKey) return;
+
+  usePolymarketCategoryStore.getState().setTagId(categoryKey);
+  usePolymarketSportsEventsStore.getState().setSelectedLeagueId(DEFAULT_SPORTS_LEAGUE_KEY);
+
+  navigateToPolymarket();
+}
+
+export function navigateToPolymarketSportsLeague(leagueId: string): void {
+  const selectedLeagueId = parseSportsLeagueKey(leagueId);
+  if (!selectedLeagueId) return;
+
+  usePolymarketCategoryStore.getState().setTagId(CATEGORIES.sports.tagId);
+  usePolymarketSportsEventsStore.getState().setSelectedLeagueId(selectedLeagueId);
+  navigateToPolymarket();
+}
+
+function parseCategoryKey(tagId: string): CategoryKey | undefined {
+  return isCategoryKey(tagId) ? tagId : undefined;
+}
+
+function isCategoryKey(tagId: string): tagId is CategoryKey {
+  return tagId in CATEGORIES;
+}
+
+function parseSportsLeagueKey(leagueId: string): PolymarketSportsLeagueId | undefined {
+  if (leagueId === DEFAULT_SPORTS_LEAGUE_KEY) return DEFAULT_SPORTS_LEAGUE_KEY;
+  return getLeagueId(leagueId);
 }
 
 function navigateToPolymarketSection(params?: RootStackParamList[typeof Routes.POLYMARKET_NAVIGATOR]) {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -715,6 +715,12 @@ type RouteParams = {
   [Routes.POLYMARKET_EXPLAIN_SHEET]: {
     onDismiss?: () => void;
   };
+  [Routes.POLYMARKET_NAVIGATOR]: {
+    // Deep-link intent: which inner tab to open, with a monotonic key so repeated
+    // requests to the same route still re-trigger the navigator's route effect.
+    initialRoute?: PolymarketRoute;
+    routeRequestKey?: number;
+  };
   [Routes.RNBW_REWARDS_CLAIM_SHEET]: undefined;
   [Routes.RNBW_REWARDS_ESTIMATE_SHEET]: {
     estimatedAmount: string;


### PR DESCRIPTION
Deep-linking into Polymarket sports landed on the wrong tab with a flash-then-slide, and the list-item logic couldn't be reused from Discover. This adds category/league deep links that pre-seed the stores, kills the flash, and extracts the sports-event logic for a Discover prediction card.

## What changed

- The category and league nav helpers write the relevant stores synchronously before navigating; the league entry forces the sports tab and clears any prior league filter, and an invalid league payload is a validated no-op.
- Selectors read the deep-link seed synchronously and skip the initial animation, so the highlight lands instantly on arrival and animates on tap.
- The sports-events store and prefetch gate on the feature flags, so nothing fetches when they're off.
- Team lookups run through a bounded concurrent pool so one failure no longer aborts the batch, with per-event metadata caching.
- List-item logic splits into reusable bet/status hooks, a leaf bet cell, and bucketing/color modules with an injectable reference date for deterministic tests.
- The events screen scrolls cleanly when populated and fills the screen only when empty.

## What to test

- Open a category deep link: selector lands on the right tab with no slide.
- Open a league deep link: sports tab active, league scrolled to instantly, no leftover filter from a prior visit.
- Open a bad league payload: nothing crashes, no navigation.
- With the flags off: no network requests on launch; turning them on resumes fetching.
- Team metadata trickles in on a long list; one failing lookup leaves the rest intact.
- Tap a bet cell: position sheet opens with correct market, outcome, and color.
- Events bucket into live / today / tomorrow; empty state fills the screen, populated list scrolls clean.
