### PR TITLE
feat(placements): v2 placements and surface schema support

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -9,7 +9,14 @@ import { type CandleResolution, type ChartType } from '@/features/charts/types';
 import { type RequestSource } from '@/features/dapp-request/types';
 import { type ENSRapActionType } from '@/features/ens/raps/common';
 import { type PerpPositionSide, type TriggerOrderType } from '@/features/perps/types';
-import { type Placement, type PlacementItem, type PlacementItemAnalyticsMetadata } from '@/features/placements/types';
+import { type Destination, type Display, type SectionId, type SurfaceDocument, type SurfaceId } from '@/features/placements/surfaces/types';
+import {
+  type Placement as LegacyPlacement,
+  type PlacementItem as LegacyPlacementItem,
+  type PlacementItemAnalyticsMetadata,
+  type PlacementItemV2,
+  type PlacementV2,
+} from '@/features/placements/types';
 import { type EthereumWalletType } from '@/helpers/walletTypes';
 import { type WalletLibraryType } from '@/model/wallet';
 import { type PairHardwareWalletNavigatorParams } from '@/navigation/types';
@@ -245,6 +252,7 @@ export const event = {
   discoverPlacementCardPressed: 'discover.placement_card_pressed',
   discoverPlacementSeeAllPressed: 'discover.placement_see_all_pressed',
   placementInteraction: 'placement.interaction',
+  surfaceInteraction: 'surface.interaction',
 
   // ens
   ensInitiatedRegistration: 'Initiated ENS registration',
@@ -996,32 +1004,42 @@ export type EventProperties = {
     durationInMs: number;
   };
   [event.discoverPlacementCardPressed]: {
-    placementId: Placement['id'];
-    placementScreen?: Placement['screen'];
+    placementId: LegacyPlacement['id'];
+    placementScreen?: LegacyPlacement['screen'];
     placementTitle: string;
-    itemOrder: PlacementItem['order'];
+    itemOrder: LegacyPlacementItem['order'];
     marketId: string;
     marketName?: PlacementItemAnalyticsMetadata['marketName'];
     marketSlug?: PlacementItemAnalyticsMetadata['marketSlug'];
     marketSymbol?: PlacementItemAnalyticsMetadata['marketSymbol'];
-    marketType: PlacementItem['ref']['source'];
+    marketType: LegacyPlacementItem['ref']['source'];
   };
   [event.discoverPlacementSeeAllPressed]: {
-    placementId: Placement['id'];
-    placementScreen?: Placement['screen'];
+    placementId: LegacyPlacement['id'];
+    placementScreen?: LegacyPlacement['screen'];
     placementTitle: string;
   };
   [event.placementInteraction]: {
-    id: Placement['id'];
-    interactionType: 'carousel_scroll';
-    screen: Placement['screen'];
-    order: Placement['order'];
-    version: Placement['version'];
-    itemRefSource?: PlacementItem['ref']['source'];
-    itemRefId?: PlacementItem['ref']['id'];
-    itemOrder?: PlacementItem['order'];
+    id: PlacementV2['id'];
+    interactionType: 'card_press' | 'carousel_scroll';
+    source?: PlacementV2['source'];
+    type?: PlacementV2['type'];
+    version?: PlacementV2['version'];
+    display?: Display;
+    sectionId?: SectionId;
+    sectionTitle?: string;
+    surfaceId?: SurfaceId;
+    itemId?: PlacementItemV2['id'];
+    itemOrder?: number;
   };
-
+  [event.surfaceInteraction]: {
+    id: SurfaceId;
+    version: SurfaceDocument['version'];
+    display?: Display;
+    destination?: Destination;
+    sectionId?: SectionId;
+    sectionTitle?: string;
+  };
   [event.ensInitiatedRegistration]: { category: string };
   [event.ensEditedRecords]: { category: string };
   [event.ensCompletedRegistration]: { category: string };

--- a/src/features/discover/components/MarketCarousel.tsx
+++ b/src/features/discover/components/MarketCarousel.tsx
@@ -103,7 +103,7 @@ export function MarketCarousel<T extends PlacementItem>({
   const onScrollSettle = useDebouncedCallback(
     () => {
       if (!placement) return;
-      trackPlacementInteraction({ interactionType: 'carousel_scroll', placement });
+      trackPlacementInteraction({ id: placement.id, interactionType: 'carousel_scroll' });
     },
     SCROLL_DEBOUNCE_MS,
     SCROLL_DEBOUNCE_OPTIONS

--- a/src/features/placements/constants.ts
+++ b/src/features/placements/constants.ts
@@ -1,3 +1,5 @@
+// ============ v1 (legacy DiscoverHome carousels) ============================ //
+
 export const PLACEMENT_SCREENS = {
   DISCOVER: 'discover',
 } as const;
@@ -9,4 +11,18 @@ export const PLACEMENT_IDS = {
 
 export const PLACEMENT_IDS_BY_SCREEN = {
   [PLACEMENT_SCREENS.DISCOVER]: [PLACEMENT_IDS.DISCOVER_PERPS_CAROUSEL, PLACEMENT_IDS.DISCOVER_PREDICTIONS_CAROUSEL],
+} as const;
+
+// ============ v2 (placement document contract) ============================== //
+
+export const PLACEMENT_SOURCES = {
+  HYPERLIQUID: 'hyperliquid',
+  POLYMARKET: 'polymarket',
+  RAINBOW: 'rainbow',
+} as const;
+
+export const PLACEMENT_TYPES = {
+  PERP: 'perp',
+  PREDICTION: 'prediction',
+  TOKEN: 'token',
 } as const;

--- a/src/features/placements/engagement/trackInteraction.ts
+++ b/src/features/placements/engagement/trackInteraction.ts
@@ -1,26 +1,51 @@
 import { analytics } from '@/analytics';
 import { event, type EventProperties } from '@/analytics/event';
-import { type Placement, type PlacementItem } from '@/features/placements/types';
 
-type PlacementInteractionType = EventProperties[typeof event.placementInteraction]['interactionType'];
+type PlacementInteraction = EventProperties[typeof event.placementInteraction];
+type SurfaceInteraction = EventProperties[typeof event.surfaceInteraction];
 
 export function trackPlacementInteraction({
+  display,
+  id,
   interactionType,
-  item,
-  placement,
-}: {
-  interactionType: PlacementInteractionType;
-  item?: PlacementItem;
-  placement: Placement;
-}): void {
+  itemId,
+  itemOrder,
+  sectionId,
+  sectionTitle,
+  source,
+  surfaceId,
+  type,
+  version,
+}: PlacementInteraction): void {
   analytics.track(event.placementInteraction, {
-    id: placement.id,
+    display,
+    id,
     interactionType,
-    screen: placement.screen,
-    order: placement.order,
-    version: placement.version,
-    itemRefSource: item?.ref.source,
-    itemRefId: item?.ref.id,
-    itemOrder: item?.order,
+    itemId,
+    itemOrder,
+    sectionId,
+    sectionTitle,
+    source,
+    surfaceId,
+    type,
+    version,
+  });
+}
+
+export function trackSurfaceInteraction({
+  display,
+  destination,
+  id,
+  sectionId,
+  sectionTitle,
+  version = 1,
+}: Omit<SurfaceInteraction, 'version'> & { version?: SurfaceInteraction['version'] }): void {
+  analytics.track(event.surfaceInteraction, {
+    display,
+    destination,
+    id,
+    sectionId,
+    sectionTitle,
+    version,
   });
 }

--- a/src/features/placements/schema/placements-v2.schema.json
+++ b/src/features/placements/schema/placements-v2.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rainbow.me/schemas/placements-v2.schema.json",
+  "$comment": "Mirrors the placement v2 CMS/write-time schema spec. Keep this client-side defensive parser in sync with the write-time contract.",
+  "title": "Placement v2",
+  "description": "A server-curated, typed list of item ids. Presentation, labels, scheduling, and destination live on surfaces; placements are pure data.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "version", "source", "type", "items"],
+  "properties": {
+    "id": {
+      "description": "Stable slug matching the Firestore document id.",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "version": {
+      "description": "Placement collection schema version. Clients query placements where version == 2 to exclude legacy documents.",
+      "const": 2
+    },
+    "source": {
+      "description": "Hydration provider. Closed enum; adding a provider requires an app release.",
+      "enum": ["hyperliquid", "polymarket", "rainbow"]
+    },
+    "type": {
+      "description": "Asset kind for every item in this placement. The source/type pair is constrained below.",
+      "enum": ["perp", "prediction", "token"]
+    },
+    "updatedAt": {
+      "description": "Optional ISO timestamp from the curator/publisher. The client does not use this for ordering.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "items": {
+      "description": "Ordered list of source-specific ids. Array position is the only order signal; items do not carry labels, display hints, enabled flags, or per-item metadata.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "description": "Provider lookup key, such as BTC, xyz:SP500, a Polymarket event id, or address:chainId for tokens.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "source": { "const": "hyperliquid" } }, "required": ["source"] },
+      "then": { "properties": { "type": { "const": "perp" } } }
+    },
+    {
+      "if": { "properties": { "source": { "const": "polymarket" } }, "required": ["source"] },
+      "then": { "properties": { "type": { "const": "prediction" } } }
+    },
+    {
+      "if": { "properties": { "source": { "const": "rainbow" } }, "required": ["source"] },
+      "then": { "properties": { "type": { "const": "token" } } }
+    }
+  ]
+}

--- a/src/features/placements/schema/surfaces-v1.schema.json
+++ b/src/features/placements/schema/surfaces-v1.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rainbow.me/schemas/surfaces-v1.schema.json",
+  "$comment": "Mirrors the surface v1 CMS/write-time schema spec. Keep this client-side defensive parser in sync with the write-time contract.",
+  "title": "Surface v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "version", "enabled", "items"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "version": {
+      "const": 1
+    },
+    "label": {
+      "type": "string",
+      "minLength": 1
+    },
+    "enabled": {
+      "$ref": "#/definitions/enabled"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/surfaceNode"
+      }
+    }
+  },
+  "definitions": {
+    "enabled": {
+      "oneOf": [
+        { "type": "boolean" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "startsAt": { "type": "string", "format": "date-time" },
+            "endsAt": { "type": "string", "format": "date-time" }
+          },
+          "anyOf": [{ "required": ["startsAt"] }, { "required": ["endsAt"] }]
+        }
+      ]
+    },
+    "destination": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": [{ "enum": ["perps", "predictions", "tokens"] }],
+          "additionalItems": { "type": "string", "minLength": 1 }
+        }
+      ]
+    },
+    "surfaceNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "enabled"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "enabled": {
+          "$ref": "#/definitions/enabled"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/surfaceNode"
+          }
+        },
+        "placement": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*$"
+            },
+            { "type": "null" }
+          ]
+        },
+        "display": {
+          "enum": [
+            "market_pill.carousel",
+            "market_tile.carousel",
+            "market_tile.grid",
+            "market_cell.list",
+            "prediction_tile.carousel",
+            "prediction_tile.grid",
+            "prediction_tile_widget.carousel",
+            "prediction_event_card.carousel",
+            "prediction_event_card.list"
+          ]
+        },
+        "destination": {
+          "$ref": "#/definitions/destination"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["items"],
+          "not": {
+            "anyOf": [
+              { "required": ["placement"] },
+              { "required": ["display"] },
+              { "required": ["destination"] },
+              { "required": ["limit"] }
+            ]
+          }
+        },
+        {
+          "required": ["display", "destination"],
+          "not": { "required": ["items"] }
+        }
+      ]
+    }
+  }
+}

--- a/src/features/placements/stores/derived/perpsPlacementStore.ts
+++ b/src/features/placements/stores/derived/perpsPlacementStore.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+
+import { IS_TEST } from '@/env';
+import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
+import { type PerpMarketsBySymbol, type PerpMarketWithMetadata } from '@/features/perps/types';
+import {
+  isPlacementHydrating,
+  selectPlacementItemsBySource,
+  usePlacementsV2Store,
+  type PlacementResult,
+} from '@/features/placements/stores/placementsStore';
+import { type PlacementIdV2, type PlacementItemV2 } from '@/features/placements/types';
+import { finalizePlacementResult, pairPlacementItems } from '@/features/placements/utils/finalizePlacementResult';
+import { useRemoteConfigStore } from '@/model/remoteConfig';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { shallowEqual } from '@/worklets/comparisons';
+
+// ============ Types ========================================================== //
+
+/**
+ * Placement item paired with its resolved perp market.
+ */
+export type PerpMarketPlacementItem = PlacementItemV2 & {
+  market: PerpMarketWithMetadata;
+};
+
+// ============ Derived Stores ================================================= //
+
+const usePerpsEnabled = createDerivedStore<boolean>(
+  $ => $(useRemoteConfigStore, state => state.getRemoteConfigKey('perps_enabled')) && !IS_TEST,
+  { fastMode: true }
+);
+
+// ============ Utilities ====================================================== //
+
+export function usePerpsPlacement(placementId: PlacementIdV2): PlacementResult<PerpMarketPlacementItem> {
+  const enabled = usePerpsEnabled();
+  const placement = usePlacementsV2Store(state => state.getPlacement(placementId));
+  const placementItems = usePlacementsV2Store(state => selectPlacementItemsBySource(state, placementId, 'hyperliquid'), shallowEqual);
+  const placementsLoading = usePlacementsV2Store(state => isPlacementHydrating(state, placementId, 'hyperliquid'));
+  const markets = useHyperliquidMarketsStore(state => state.markets);
+  const marketsError = useHyperliquidMarketsStore(state => state.getStatus('isError'));
+  const marketsLoading = useHyperliquidMarketsStore(state => state.getStatus('isIdle') || state.getStatus('isLoading'));
+  const items = useMemo(() => buildPerpMarketPlacementItems(placementItems, markets), [markets, placementItems]);
+  const resolvedLoading = placementItems.length > 0 && items.length === 0 && marketsLoading && !marketsError;
+
+  return useMemo(
+    () =>
+      finalizePlacementResult({
+        enabled,
+        hasRefs: placementItems.length > 0,
+        isInitialLoad: placementsLoading || resolvedLoading,
+        items,
+        placement,
+      }),
+    [enabled, items, placement, placementItems.length, placementsLoading, resolvedLoading]
+  );
+}
+
+function buildPerpMarketPlacementItems(placementItems: PlacementItemV2[], markets: PerpMarketsBySymbol): PerpMarketPlacementItem[] {
+  return pairPlacementItems(
+    placementItems,
+    id => markets[id],
+    (item, market) => ({ ...item, market })
+  );
+}

--- a/src/features/placements/stores/derived/predictionsPlacementStore.ts
+++ b/src/features/placements/stores/derived/predictionsPlacementStore.ts
@@ -1,0 +1,152 @@
+import { useMemo } from 'react';
+
+import { POLYMARKET } from '@/config/experimental';
+import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
+import { IS_TEST } from '@/env';
+import {
+  isPlacementHydrating,
+  selectPlacementItemsBySource,
+  usePlacementsV2Store,
+  type PlacementResult,
+} from '@/features/placements/stores/placementsStore';
+import { useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { type PlacementIdV2, type PlacementItemV2 } from '@/features/placements/types';
+import { finalizePlacementResult } from '@/features/placements/utils/finalizePlacementResult';
+import { hasRefsOrPendingHydration } from '@/features/placements/utils/hasRefsOrPendingHydration';
+import { fetchPolymarketEventsByIds } from '@/features/polymarket/stores/polymarketEventsStore';
+import { fetchPolymarketTeamMetadataForGameEvents } from '@/features/polymarket/stores/polymarketTeamMetadataStore';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { processRawPolymarketEvent } from '@/features/polymarket/utils/transforms';
+import { time } from '@/framework/core/utils/time';
+import { useRemoteConfigStore } from '@/model/remoteConfig';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { shallowEqual } from '@/worklets/comparisons';
+
+// ============ Types ========================================================== //
+
+export type PredictionPlacementItem = PlacementItemV2 & {
+  event: PolymarketEvent;
+};
+
+type PredictionEventsParams = {
+  eventIds: string[];
+};
+
+type PredictionEventsData = {
+  activeEventIds: string[];
+  eventsById: EventsById;
+};
+
+type EventsById = Record<string, PolymarketEvent>;
+
+// ============ Constants ====================================================== //
+
+const hasPredictionRefsOrPendingHydration = hasRefsOrPendingHydration('polymarket', 'prediction');
+
+// ============ Stores ========================================================= //
+
+const usePredictionsEnabled = createDerivedStore<boolean>(
+  $ => {
+    const polymarketEnabled = $(useRemoteConfigStore, state => state.getRemoteConfigKey('polymarket_enabled'));
+    const polymarketEnabledLocally = $(useExperimentalConfigStore, state => state.getFlag(POLYMARKET));
+
+    if (!hasPredictionRefsOrPendingHydration($) || IS_TEST) return false;
+
+    return polymarketEnabled || polymarketEnabledLocally;
+  },
+  { fastMode: true }
+);
+
+export const usePredictionEventsStore = createQueryStore<PredictionEventsData, PredictionEventsParams>({
+  fetcher: fetchPredictionEvents,
+  enabled: $ => $(usePredictionsEnabled),
+  params: {
+    eventIds: $ => $(useDiscoverSurfacePlacementRefs, refs => refs.polymarket),
+  },
+  keepPreviousData: true,
+  staleTime: time.minutes(2),
+  cacheTime: time.minutes(15),
+});
+
+// ============ Fetcher ======================================================== //
+
+async function fetchPredictionEvents(
+  { eventIds }: PredictionEventsParams,
+  abortController: AbortController | null
+): Promise<PredictionEventsData> {
+  const rawEvents = await fetchPolymarketEventsByIds(eventIds, abortController);
+  const teamsByTicker = await fetchPolymarketTeamMetadataForGameEvents(rawEvents, abortController);
+
+  const events = await Promise.all(
+    rawEvents.map(event => {
+      const teamMetadata = event.ticker ? teamsByTicker.get(event.ticker) : undefined;
+      return processRawPolymarketEvent(event, teamMetadata?.teams);
+    })
+  );
+
+  return normalizePredictionEvents(events);
+}
+
+// ============ Utilities ====================================================== //
+
+export function usePredictionsPlacement(placementId: PlacementIdV2): PlacementResult<PredictionPlacementItem> {
+  const enabled = usePredictionsEnabled();
+  const placement = usePlacementsV2Store(state => state.getPlacement(placementId));
+  const placementItems = usePlacementsV2Store(state => selectPlacementItemsBySource(state, placementId, 'polymarket'), shallowEqual);
+  const placementsLoading = usePlacementsV2Store(state => isPlacementHydrating(state, placementId, 'polymarket'));
+  const events = usePredictionEventsStore(state => state.getData());
+  const eventsLoading = usePredictionEventsStore(
+    state => placementItems.length > 0 && state.enabled && (state.getStatus('isIdle') || state.getStatus('isLoading'))
+  );
+  const activeEventIds = useMemo(() => (events ? new Set(events.activeEventIds) : undefined), [events]);
+  const items = useMemo(
+    () => (events && activeEventIds ? parsePredictionItems(placementItems, events.eventsById, activeEventIds) : []),
+    [activeEventIds, events, placementItems]
+  );
+
+  return useMemo(
+    () =>
+      finalizePlacementResult({
+        enabled,
+        hasRefs: placementItems.length > 0,
+        isInitialLoad: placementsLoading || eventsLoading,
+        items,
+        placement,
+      }),
+    [enabled, eventsLoading, items, placement, placementItems.length, placementsLoading]
+  );
+}
+
+function parsePredictionItems(
+  placementItems: PlacementItemV2[],
+  eventsById: EventsById,
+  activeEventIds: ReadonlySet<string>
+): PredictionPlacementItem[] {
+  const items: PredictionPlacementItem[] = [];
+
+  for (const item of placementItems) {
+    const event = eventsById[item.id];
+    if (event && activeEventIds.has(item.id)) items.push({ ...item, event });
+  }
+
+  return items.length ? items : [];
+}
+
+function normalizePredictionEvents(events: PolymarketEvent[]): PredictionEventsData {
+  const activeEventIds: string[] = [];
+  const eventsById: EventsById = {};
+
+  for (const event of events) {
+    eventsById[event.id] = event;
+    if (isActivePredictionEvent(event)) activeEventIds.push(event.id);
+  }
+
+  return { activeEventIds, eventsById };
+}
+
+function isActivePredictionEvent(event: PolymarketEvent): boolean {
+  if (event.closed === true || event.ended === true) return false;
+
+  return event.markets.some(market => market.active !== false && market.closed !== true && market.umaResolutionStatus !== 'resolved');
+}

--- a/src/features/placements/stores/derived/tokensPlacementStore.ts
+++ b/src/features/placements/stores/derived/tokensPlacementStore.ts
@@ -1,0 +1,176 @@
+import { useMemo } from 'react';
+
+import { isAddress, type Address } from 'viem';
+
+import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
+import { IS_TEST } from '@/env';
+import {
+  isPlacementHydrating,
+  selectPlacementItemsBySource,
+  usePlacementsV2Store,
+  type PlacementResult,
+} from '@/features/placements/stores/placementsStore';
+import { useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { type PlacementIdV2, type PlacementItemV2 } from '@/features/placements/types';
+import { finalizePlacementResult, pairPlacementItems } from '@/features/placements/utils/finalizePlacementResult';
+import { hasRefsOrPendingHydration } from '@/features/placements/utils/hasRefsOrPendingHydration';
+import { mapWithConcurrency } from '@/framework/core/utils/mapWithConcurrency';
+import { time } from '@/framework/core/utils/time';
+import { fetchExternalToken, type FormattedExternalAsset } from '@/resources/assets/externalAssetsQuery';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { type ChainId } from '@/state/backendNetworks/types';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+import { shallowEqual } from '@/worklets/comparisons';
+
+// ============ Types ========================================================== //
+
+export type TokenPlacementItem = PlacementItemV2 & {
+  asset: FormattedExternalAsset;
+};
+
+type TokenRefsParams = {
+  currency: NativeCurrencyKey;
+  tokenRefs: string[];
+};
+
+type TokenAssetsByRef = Record<string, FormattedExternalAsset>;
+type TokenRefCacheEntry = {
+  asset: FormattedExternalAsset | null;
+  fetchedAt: number;
+};
+type TokenRefFetchResult = {
+  asset: FormattedExternalAsset | null;
+  tokenRef: string;
+};
+
+// ============ Constants ====================================================== //
+
+const TOKEN_REF_FETCH_CONCURRENCY = 4;
+const TOKEN_REFS_STALE_TIME = time.minutes(2);
+// Keep object identity stable for Object.is store selectors; arrays are compared structurally downstream.
+const EMPTY_TOKEN_ASSETS_BY_REF: TokenAssetsByRef = Object.freeze({});
+const hasTokenRefsOrPendingHydration = hasRefsOrPendingHydration('rainbow', 'token');
+const tokenRefCache = new Map<string, TokenRefCacheEntry>();
+
+// ============ Stores ========================================================= //
+
+const useTokensEnabled = createDerivedStore<boolean>(
+  $ => {
+    return hasTokenRefsOrPendingHydration($) && !IS_TEST;
+  },
+  { fastMode: true }
+);
+
+export const useTokenRefsStore = createQueryStore<TokenAssetsByRef, TokenRefsParams>({
+  fetcher: fetchTokenRefs,
+  enabled: $ => $(useTokensEnabled),
+  params: {
+    currency: $ => $(userAssetsStoreManager, state => state.currency),
+    tokenRefs: $ => $(useDiscoverSurfacePlacementRefs, refs => refs.rainbow),
+  },
+  keepPreviousData: true,
+  staleTime: TOKEN_REFS_STALE_TIME,
+  cacheTime: time.minutes(10),
+});
+
+// ============ Fetcher ======================================================== //
+
+async function fetchTokenRefs(
+  { currency, tokenRefs }: TokenRefsParams,
+  abortController: AbortController | null
+): Promise<TokenAssetsByRef> {
+  if (!tokenRefs.length) return EMPTY_TOKEN_ASSETS_BY_REF;
+
+  const now = Date.now();
+  const assetsByRef: TokenAssetsByRef = {};
+  const staleTokenRefs: string[] = [];
+
+  for (const tokenRef of tokenRefs) {
+    const cached = tokenRefCache.get(getTokenRefCacheKey(tokenRef, currency));
+    if (cached && now - cached.fetchedAt < TOKEN_REFS_STALE_TIME) {
+      if (cached.asset) assetsByRef[tokenRef] = cached.asset;
+    } else {
+      staleTokenRefs.push(tokenRef);
+    }
+  }
+
+  const results = await mapWithConcurrency(staleTokenRefs, TOKEN_REF_FETCH_CONCURRENCY, tokenRef =>
+    fetchTokenRef(tokenRef, currency, abortController)
+  );
+  const fetchedAt = Date.now();
+
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value) {
+      const { asset, tokenRef } = result.value;
+      tokenRefCache.set(getTokenRefCacheKey(tokenRef, currency), { asset, fetchedAt });
+      if (asset) assetsByRef[tokenRef] = asset;
+    }
+  }
+
+  return Object.keys(assetsByRef).length ? assetsByRef : EMPTY_TOKEN_ASSETS_BY_REF;
+}
+
+async function fetchTokenRef(
+  tokenRef: string,
+  currency: TokenRefsParams['currency'],
+  abortController: AbortController | null
+): Promise<TokenRefFetchResult> {
+  const params = parseTokenRef(tokenRef);
+  if (!params) return { asset: null, tokenRef };
+
+  const asset = await fetchExternalToken({ ...params, abortController, currency });
+  return { asset, tokenRef };
+}
+
+// ============ Utilities ====================================================== //
+
+export function useTokensPlacement(placementId: PlacementIdV2): PlacementResult<TokenPlacementItem> {
+  const enabled = useTokensEnabled();
+  const placement = usePlacementsV2Store(state => state.getPlacement(placementId));
+  const placementItems = usePlacementsV2Store(state => selectPlacementItemsBySource(state, placementId, 'rainbow'), shallowEqual);
+  const placementsLoading = usePlacementsV2Store(state => isPlacementHydrating(state, placementId, 'rainbow'));
+  const assetsByRef = useTokenRefsStore(state => state.getData());
+  const tokenRefsLoading = useTokenRefsStore(state => {
+    return placementItems.length > 0 && state.enabled && (state.getStatus('isIdle') || state.getStatus('isLoading'));
+  });
+  const items = useMemo(() => (assetsByRef ? parseTokenItems(placementItems, assetsByRef) : []), [assetsByRef, placementItems]);
+
+  return useMemo(
+    () =>
+      finalizePlacementResult({
+        enabled,
+        hasRefs: placementItems.length > 0,
+        isInitialLoad: placementsLoading || tokenRefsLoading,
+        items,
+        placement,
+      }),
+    [enabled, items, placement, placementItems.length, placementsLoading, tokenRefsLoading]
+  );
+}
+
+function parseTokenItems(placementItems: PlacementItemV2[], assetsByRef: TokenAssetsByRef): TokenPlacementItem[] {
+  return pairPlacementItems(
+    placementItems,
+    id => assetsByRef[id],
+    (item, asset) => ({ ...item, asset })
+  );
+}
+
+// CMS authors token refs as colon-delimited `address:chainId`, distinct from the app's
+// underscore-delimited `UniqueId` (`address_chainId`) — they are not interchangeable.
+function parseTokenRef(tokenRef: string): { address: Address; chainId: ChainId } | null {
+  const [address, chainId] = tokenRef.split(':');
+  const numericChainId = Number(chainId);
+
+  if (!address || !isAddress(address) || !Number.isInteger(numericChainId)) return null;
+
+  return {
+    address,
+    chainId: numericChainId as ChainId,
+  };
+}
+
+function getTokenRefCacheKey(tokenRef: string, currency: NativeCurrencyKey): string {
+  return `${currency}:${tokenRef}`;
+}

--- a/src/features/placements/stores/placementsStore.ts
+++ b/src/features/placements/stores/placementsStore.ts
@@ -1,13 +1,24 @@
 import { getApp } from '@react-native-firebase/app';
 import { collection, getDocs, getFirestore, orderBy, query, where, type FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
 
-import { PLACEMENT_IDS } from '@/features/placements/constants';
-import { type Placement, type PlacementId, type PlacementItem, type PlacementSource } from '@/features/placements/types';
+import { PLACEMENT_IDS, PLACEMENT_SOURCES, PLACEMENT_TYPES } from '@/features/placements/constants';
+import {
+  type Placement,
+  type PlacementId,
+  type PlacementIdV2,
+  type PlacementItem,
+  type PlacementItemV2,
+  type PlacementSource,
+  type PlacementSourceV2,
+  type PlacementTypeV2,
+  type PlacementV2,
+} from '@/features/placements/types';
+import { isNonEmptyString, oneOf } from '@/features/placements/utils/decoders';
 import { time } from '@/framework/core/utils/time';
 import { getConsistentArray } from '@/helpers/getConsistentArray';
 import { createQueryStore } from '@/state/internal/createQueryStore';
 
-// ============ Types ========================================================== //
+// ============ v1 Types ======================================================= //
 
 export type PlacementsState = {
   placementsById: PlacementsById;
@@ -116,4 +127,163 @@ function isPlacementId(id: string): id is PlacementId {
 
 function isPlacementItemSource<Source extends PlacementSource>(item: PlacementItem, source: Source): item is PlacementItem<Source> {
   return item.ref.source === source;
+}
+
+// ============================================================================ //
+// ============ v2 (placement document contract) ============================== //
+// ============================================================================ //
+
+export type PlacementsV2State = {
+  placementsById: PlacementsV2ById;
+  getPlacement: (id: PlacementIdV2) => PlacementV2 | undefined;
+  getItemsBySource: <Source extends PlacementSourceV2>(id: PlacementIdV2, source: Source) => PlacementItemV2[];
+};
+
+export type PlacementResult<Hydrated> = {
+  isLoading: boolean;
+  items: Hydrated[];
+  placement: PlacementV2 | undefined;
+};
+
+type PlacementsV2ById = Partial<Record<PlacementIdV2, PlacementV2>>;
+
+type PlacementV2Document = Partial<PlacementV2>;
+type PlacementV2DocumentSnapshot = {
+  data: () => unknown;
+  id: string;
+};
+
+// ============ v2 Constants =================================================== //
+
+const isPlacementSourceV2 = oneOf<PlacementSourceV2>(Object.values(PLACEMENT_SOURCES));
+const isPlacementTypeV2 = oneOf<PlacementTypeV2>(Object.values(PLACEMENT_TYPES));
+
+// ============ v2 Query Store ================================================= //
+
+export const usePlacementsV2Store = createQueryStore<PlacementsV2ById, never, PlacementsV2State>(
+  {
+    fetcher: fetchPlacementsV2,
+    setData: ({ data, set }) => set({ placementsById: data }),
+    keepPreviousData: true,
+    staleTime: time.minutes(15),
+    cacheTime: time.days(2),
+  },
+
+  (_, get) => {
+    return {
+      placementsById: {},
+
+      getPlacement: id => {
+        return get().placementsById[id];
+      },
+
+      getItemsBySource: (id, source) => {
+        const placement = get().placementsById[id];
+        if (placement?.source !== source) return [];
+        return getItemsV2(placement);
+      },
+    };
+  },
+
+  { storageKey: 'placementsStoreV2' }
+);
+
+export function selectPlacementItemsBySource<Source extends PlacementSourceV2>(
+  state: ReturnType<typeof usePlacementsV2Store.getState>,
+  placementId: PlacementIdV2,
+  source: Source
+): PlacementItemV2[] {
+  return state.getItemsBySource(placementId, source);
+}
+
+export function isPlacementHydrating<Source extends PlacementSourceV2>(
+  state: ReturnType<typeof usePlacementsV2Store.getState>,
+  placementId: PlacementIdV2,
+  source: Source
+): boolean {
+  const isInitialLoad = state.getStatus('isInitialLoad');
+  const isIdleWithoutCachedPlacement =
+    state.getStatus('isIdle') && state.getPlacement(placementId) === undefined && !state.getItemsBySource(placementId, source).length;
+
+  return isInitialLoad || isIdleWithoutCachedPlacement;
+}
+
+// ============ v2 Fetcher ===================================================== //
+
+async function fetchPlacementsV2(): Promise<PlacementsV2ById> {
+  const db = getFirestore(getApp());
+  const placementsRef = collection(db, 'placements');
+  const q = query(placementsRef, where('version', '==', 2));
+
+  const snap: FirebaseFirestoreTypes.QuerySnapshot<PlacementV2Document> = await getDocs<
+    PlacementV2Document,
+    FirebaseFirestoreTypes.DocumentData
+  >(q);
+
+  return buildPlacementsV2ById(snap.docs);
+}
+
+// ============ v2 Utilities =================================================== //
+
+function buildPlacementsV2ById(placements: PlacementV2DocumentSnapshot[]): PlacementsV2ById {
+  const placementsById: PlacementsV2ById = {};
+
+  for (const doc of placements) {
+    const placementDocument = doc.data();
+    if (!isPlacementV2Document(doc.id, placementDocument)) continue;
+
+    const placement = buildPlacementV2(doc.id, placementDocument);
+    placementsById[placement.id] = placement;
+  }
+
+  return placementsById;
+}
+
+function buildPlacementV2(id: PlacementIdV2, placement: PlacementV2): PlacementV2 {
+  return {
+    ...placement,
+    id,
+    items: placement.items.filter(isPlacementItemV2),
+  };
+}
+
+function getItemsV2(placement: PlacementV2 | undefined): PlacementItemV2[] {
+  return placement?.items ?? [];
+}
+
+// ============ v2 Type Guards ================================================= //
+
+// Contract: schema/placements-v2.schema.json
+function isPlacementV2Document(id: string, placement: unknown): placement is PlacementV2 {
+  if (typeof placement !== 'object' || placement === null) return false;
+
+  const document = placement as Partial<PlacementV2>;
+
+  return (
+    isNonEmptyString(id) &&
+    document.id === id &&
+    document.version === 2 &&
+    isPlacementRefPairV2(document.source, document.type) &&
+    Array.isArray(document.items)
+  );
+}
+
+function isPlacementItemV2(item: unknown): item is PlacementItemV2 {
+  if (typeof item !== 'object' || item === null) return false;
+
+  const id = (item as Partial<PlacementItemV2>).id;
+  return isNonEmptyString(id);
+}
+
+function isPlacementRefPairV2(source: unknown, type: unknown): source is PlacementSourceV2 {
+  if (!isPlacementSourceV2(source) || !isPlacementTypeV2(type)) return false;
+
+  switch (source) {
+    case 'hyperliquid':
+      return type === 'perp';
+    case 'polymarket':
+      return type === 'prediction';
+    case 'rainbow':
+      return type === 'token';
+  }
 }

--- a/src/features/placements/surfaces/constants.ts
+++ b/src/features/placements/surfaces/constants.ts
@@ -1,0 +1,45 @@
+export const DISPLAYS = {
+  MARKET_PILL_CAROUSEL: 'market_pill.carousel',
+  MARKET_TILE_CAROUSEL: 'market_tile.carousel',
+  MARKET_TILE_GRID: 'market_tile.grid',
+  MARKET_CELL_LIST: 'market_cell.list',
+  PREDICTION_TILE_CAROUSEL: 'prediction_tile.carousel',
+  PREDICTION_TILE_GRID: 'prediction_tile.grid',
+  PREDICTION_TILE_WIDGET_CAROUSEL: 'prediction_tile_widget.carousel',
+  PREDICTION_EVENT_CARD_CAROUSEL: 'prediction_event_card.carousel',
+  PREDICTION_EVENT_CARD_LIST: 'prediction_event_card.list',
+} as const;
+
+export const DESTINATION_ROOTS = {
+  PERPS: 'perps',
+  PREDICTIONS: 'predictions',
+  TOKENS: 'tokens',
+} as const;
+
+export const MARKET_DISPLAY_VALUES = [
+  DISPLAYS.MARKET_PILL_CAROUSEL,
+  DISPLAYS.MARKET_TILE_CAROUSEL,
+  DISPLAYS.MARKET_TILE_GRID,
+  DISPLAYS.MARKET_CELL_LIST,
+] as const;
+
+export const PREDICTION_DISPLAY_VALUES = [
+  DISPLAYS.PREDICTION_TILE_CAROUSEL,
+  DISPLAYS.PREDICTION_TILE_GRID,
+  DISPLAYS.PREDICTION_TILE_WIDGET_CAROUSEL,
+  DISPLAYS.PREDICTION_EVENT_CARD_CAROUSEL,
+  DISPLAYS.PREDICTION_EVENT_CARD_LIST,
+] as const;
+
+export const EVENT_CARD_DISPLAY_VALUES = [DISPLAYS.PREDICTION_EVENT_CARD_CAROUSEL, DISPLAYS.PREDICTION_EVENT_CARD_LIST] as const;
+
+export const DISPLAY_VALUES = [...MARKET_DISPLAY_VALUES, ...PREDICTION_DISPLAY_VALUES] as const;
+export const DESTINATION_ROOT_VALUES = Object.values(DESTINATION_ROOTS);
+
+/**
+ * Whether a surface display renders the event-card layouts (carousel/list).
+ * Generic over any prediction event-card display — not specific to sports.
+ */
+export function isEventCardDisplay(display: string): boolean {
+  return (EVENT_CARD_DISPLAY_VALUES as readonly string[]).includes(display);
+}

--- a/src/features/placements/surfaces/hooks/useDiscoverSurfacePlacements.ts
+++ b/src/features/placements/surfaces/hooks/useDiscoverSurfacePlacements.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
+import { useDiscoverSurfaceStore } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import {
+  getMissingSurfacePlacementIds,
+  isSurfaceNewerThanPlacements,
+  surfaceContainsPlacement,
+} from '@/features/placements/surfaces/stores/discoverSurfaceTransforms';
+
+export function useIsDiscoverSurfacePlacementPending(placementId: string): boolean {
+  const rawSurface = useDiscoverSurfaceStore(state => state.getData());
+  const surfaceLastFetchedAt = useDiscoverSurfaceStore(state => state.lastFetchedAt);
+  const placementsById = usePlacementsV2Store(state => state.placementsById);
+  const placementsLastFetchedAt = usePlacementsV2Store(state => state.lastFetchedAt);
+  const placementsLoading = usePlacementsV2Store(state => state.getStatus('isLoading') || state.getStatus('isInitialLoad'));
+
+  if (!rawSurface || placementsById[placementId]) return false;
+  if (!surfaceContainsPlacement(rawSurface, placementId)) return false;
+  return placementsLoading || isSurfaceNewerThanPlacements(surfaceLastFetchedAt, placementsLastFetchedAt);
+}
+
+export function useSyncDiscoverSurfacePlacements(): void {
+  const rawSurface = useDiscoverSurfaceStore(state => state.getData());
+  const surfaceLastFetchedAt = useDiscoverSurfaceStore(state => state.lastFetchedAt);
+  const placementsById = usePlacementsV2Store(state => state.placementsById);
+  const placementsLastFetchedAt = usePlacementsV2Store(state => state.lastFetchedAt);
+  const placementsLoading = usePlacementsV2Store(state => state.getStatus('isLoading'));
+  const lastRequestedKey = useRef<string | null>(null);
+
+  const missingPlacementIds = useMemo(() => {
+    if (!rawSurface) return [];
+    return getMissingSurfacePlacementIds(rawSurface, placementsById);
+  }, [placementsById, rawSurface]);
+
+  useEffect(() => {
+    if (!surfaceLastFetchedAt || !missingPlacementIds.length || placementsLoading) return;
+
+    const surfaceFetchedAfterPlacements = !placementsLastFetchedAt || surfaceLastFetchedAt > placementsLastFetchedAt;
+    if (!surfaceFetchedAfterPlacements) return;
+
+    const requestKey = `${surfaceLastFetchedAt}:${missingPlacementIds.join(',')}`;
+    if (lastRequestedKey.current === requestKey) return;
+    lastRequestedKey.current = requestKey;
+
+    usePlacementsV2Store.getState().fetch(undefined, { force: true });
+  }, [missingPlacementIds, placementsLastFetchedAt, placementsLoading, surfaceLastFetchedAt]);
+}

--- a/src/features/placements/surfaces/stores/discoverSurfaceStore.ts
+++ b/src/features/placements/surfaces/stores/discoverSurfaceStore.ts
@@ -1,0 +1,55 @@
+import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
+import {
+  buildDiscoverSurface,
+  filterMissingPlacementSurface,
+  getDiscoverSurfacePlacementRefs,
+  isSurfaceWaitingForPlacements,
+} from '@/features/placements/surfaces/stores/discoverSurfaceTransforms';
+import { type DiscoverSurface, type DiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
+import { getSurfaceStore } from '@/features/placements/surfaces/stores/surfaceStore';
+import { filterSurfaceTree, isSurfaceEnabled } from '@/features/placements/surfaces/utils/filterSurface';
+import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { deepEqual } from '@/worklets/comparisons';
+
+export const useDiscoverSurfaceStore = getSurfaceStore('discover');
+
+export const useDiscoverSurface = createDerivedStore<DiscoverSurface | undefined>(
+  $ => {
+    const rawSurface = $(useDiscoverSurfaceStore, state => state.getData());
+    const surfaceLastFetchedAt = $(useDiscoverSurfaceStore, state => state.lastFetchedAt);
+    const placementsById = $(usePlacementsV2Store, state => state.placementsById);
+    const placementsLastFetchedAt = $(usePlacementsV2Store, state => state.lastFetchedAt);
+    const placementsReady = $(usePlacementsV2Store, state => state.getStatus('isSuccess'));
+
+    if (!rawSurface) return undefined;
+
+    const enabledSurface = filterSurfaceTree(rawSurface, surface => isSurfaceEnabled(surface.enabled, Date.now()));
+    if (!enabledSurface) return undefined;
+    if (!placementsReady) return buildDiscoverSurface(enabledSurface);
+    if (isSurfaceWaitingForPlacements(enabledSurface, placementsById, surfaceLastFetchedAt, placementsLastFetchedAt)) {
+      return buildDiscoverSurface(enabledSurface);
+    }
+
+    const surfaceWithPlacements = filterMissingPlacementSurface(enabledSurface, placementsById);
+    return surfaceWithPlacements ? buildDiscoverSurface(surfaceWithPlacements) : undefined;
+  },
+  { equalityFn: deepEqual, fastMode: true }
+);
+
+export const useDiscoverSurfacePlacementRefs = createDerivedStore<DiscoverSurfacePlacementRefs>(
+  $ => {
+    const surface = $(useDiscoverSurface);
+    const placementsById = $(usePlacementsV2Store, state => state.placementsById);
+
+    if (!surface) {
+      return {
+        hyperliquid: [],
+        polymarket: [],
+        rainbow: [],
+      };
+    }
+
+    return getDiscoverSurfacePlacementRefs(surface, placementsById);
+  },
+  { equalityFn: deepEqual, fastMode: true }
+);

--- a/src/features/placements/surfaces/stores/discoverSurfaceTransforms.ts
+++ b/src/features/placements/surfaces/stores/discoverSurfaceTransforms.ts
@@ -1,0 +1,143 @@
+import { type usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
+import { DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
+import {
+  type DiscoverSurface,
+  type DiscoverSurfacePlacementRefs,
+  type DiscoverTab,
+  type SurfaceTree,
+} from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
+import { type SurfaceDocument, type SurfaceLeafNode } from '@/features/placements/surfaces/types';
+import { filterSurfaceTree, walkSurfaceLeaves } from '@/features/placements/surfaces/utils/filterSurface';
+import { getConsistentArray } from '@/helpers/getConsistentArray';
+import { logger } from '@/logger';
+
+type PlacementsById = ReturnType<typeof usePlacementsV2Store.getState>['placementsById'];
+
+export function isSurfaceWaitingForPlacements(
+  surface: SurfaceDocument,
+  placementsById: PlacementsById,
+  surfaceLastFetchedAt: number | null,
+  placementsLastFetchedAt: number | null
+): boolean {
+  if (!isSurfaceNewerThanPlacements(surfaceLastFetchedAt, placementsLastFetchedAt)) return false;
+  return getMissingSurfacePlacementIds(surface, placementsById).length > 0;
+}
+
+export function isSurfaceNewerThanPlacements(surfaceLastFetchedAt: number | null, placementsLastFetchedAt: number | null): boolean {
+  return !!surfaceLastFetchedAt && (!placementsLastFetchedAt || surfaceLastFetchedAt > placementsLastFetchedAt);
+}
+
+export function surfaceContainsPlacement(surface: SurfaceTree, placementId: string): boolean {
+  let containsPlacement = false;
+
+  walkSurfaceLeaves(surface, leaf => {
+    if (leaf.placement === placementId) containsPlacement = true;
+  });
+
+  return containsPlacement;
+}
+
+export function getMissingSurfacePlacementIds(surface: SurfaceTree, placementsById: PlacementsById): string[] {
+  const missingPlacementIds = new Set<string>();
+
+  walkSurfaceLeaves(surface, leaf => {
+    if (leaf.placement && !placementsById[leaf.placement]) missingPlacementIds.add(leaf.placement);
+  });
+
+  return missingPlacementIds.size ? [...missingPlacementIds].sort() : [];
+}
+
+export function filterMissingPlacementSurface(surface: SurfaceDocument, placementsById: PlacementsById): SurfaceDocument | undefined {
+  return filterSurfaceTree(surface, item => 'items' in item || !item.placement || placementsById[item.placement] !== undefined);
+}
+
+export function getDiscoverSurfacePlacementRefs(surface: DiscoverSurface, placementsById: PlacementsById): DiscoverSurfacePlacementRefs {
+  const refIdsBySource: DiscoverSurfacePlacementRefs = {
+    hyperliquid: [],
+    polymarket: [],
+    rainbow: [],
+  };
+
+  for (const tab of surface.tabs) {
+    for (const section of tab.sections) {
+      collectDiscoverSurfacePlacementRefs(section, placementsById, refIdsBySource);
+    }
+  }
+
+  return {
+    hyperliquid: getConsistentArray(refIdsBySource.hyperliquid),
+    polymarket: getConsistentArray(refIdsBySource.polymarket),
+    rainbow: getConsistentArray(refIdsBySource.rainbow),
+  };
+}
+
+function collectDiscoverSurfacePlacementRefs(
+  surface: SurfaceLeafNode,
+  placementsById: PlacementsById,
+  refIdsBySource: DiscoverSurfacePlacementRefs
+): void {
+  if (!surface.placement) return;
+
+  const placement = placementsById[surface.placement];
+  if (!placement) return;
+
+  for (const item of placement.items) {
+    refIdsBySource[placement.source].push(item.id);
+  }
+}
+
+export function buildDiscoverSurface(surface: SurfaceDocument): DiscoverSurface | undefined {
+  const tabs: DiscoverTab[] = [];
+
+  for (const item of surface.items) {
+    if (!('items' in item)) {
+      warnInvalidDiscoverSurface(surface.id, item.id, 'top-level-leaf');
+      continue;
+    }
+
+    const sections: SurfaceLeafNode[] = [];
+
+    for (const section of item.items) {
+      if ('items' in section) {
+        warnInvalidDiscoverSurface(surface.id, section.id, 'nested-container');
+        continue;
+      }
+
+      if (!(DISPLAY_VALUES as readonly string[]).includes(section.display)) {
+        warnInvalidDiscoverSurface(surface.id, section.id, 'unsupported-display');
+        continue;
+      }
+
+      sections.push(section);
+    }
+
+    if (!sections.length) {
+      warnInvalidDiscoverSurface(surface.id, item.id, 'empty-tab');
+      continue;
+    }
+
+    tabs.push({
+      id: item.id,
+      label: item.label,
+      sections,
+    });
+  }
+
+  if (!tabs.length) {
+    warnInvalidDiscoverSurface(surface.id, surface.id, 'empty-surface');
+    return undefined;
+  }
+
+  return {
+    id: surface.id,
+    tabs,
+  };
+}
+
+export function warnInvalidDiscoverSurface(surfaceId: string, nodeId: string, reason: string): void {
+  logger.warn('[useDiscoverSurface]: invalid Discover surface shape', {
+    nodeId,
+    reason,
+    surfaceId,
+  });
+}

--- a/src/features/placements/surfaces/stores/discoverSurfaceTypes.ts
+++ b/src/features/placements/surfaces/stores/discoverSurfaceTypes.ts
@@ -1,0 +1,23 @@
+import {
+  type SectionId,
+  type SurfaceDocument,
+  type SurfaceId,
+  type SurfaceLeafNode,
+  type SurfaceNode,
+} from '@/features/placements/surfaces/types';
+import { type PlacementSourceV2 } from '@/features/placements/types';
+
+export type DiscoverSurfacePlacementRefs = Record<PlacementSourceV2, string[]>;
+
+export type DiscoverSurface = {
+  id: SurfaceId;
+  tabs: DiscoverTab[];
+};
+
+export type DiscoverTab = {
+  id: SectionId;
+  label?: string;
+  sections: SurfaceLeafNode[];
+};
+
+export type SurfaceTree = SurfaceDocument | SurfaceNode;

--- a/src/features/placements/surfaces/stores/surfaceStore.ts
+++ b/src/features/placements/surfaces/stores/surfaceStore.ts
@@ -1,0 +1,119 @@
+import { getApp } from '@react-native-firebase/app';
+import { doc, getDoc, getFirestore } from '@react-native-firebase/firestore';
+
+import { DESTINATION_ROOT_VALUES, DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
+import {
+  type DestinationRoot,
+  type Display,
+  type SurfaceDocument,
+  type SurfaceNode,
+  type SurfaceNodeBase,
+} from '@/features/placements/surfaces/types';
+import { isNonEmptyString, isValidDateString, oneOf } from '@/features/placements/utils/decoders';
+import { time } from '@/framework/core/utils/time';
+import { createQueryStore } from '@/state/internal/createQueryStore';
+
+type SurfaceStore = ReturnType<typeof createSurfaceStore>;
+
+const storesBySurfaceId = new Map<string, SurfaceStore>();
+const SURFACE_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
+const isDestinationRoot = oneOf<DestinationRoot>(DESTINATION_ROOT_VALUES);
+const isSurfaceDisplay = oneOf<Display>(DISPLAY_VALUES);
+
+export function getSurfaceStore(surfaceId: string): SurfaceStore {
+  let store = storesBySurfaceId.get(surfaceId);
+  if (!store) {
+    store = createSurfaceStore(surfaceId);
+    storesBySurfaceId.set(surfaceId, store);
+  }
+  return store;
+}
+
+function createSurfaceStore(surfaceId: string) {
+  return createQueryStore<SurfaceDocument | undefined>(
+    {
+      fetcher: () => fetchSurface(surfaceId),
+      staleTime: time.minutes(10),
+      cacheTime: time.minutes(15),
+    },
+    { storageKey: `surfaceStore:${surfaceId}`, version: 5 }
+  );
+}
+
+async function fetchSurface(surfaceId: string): Promise<SurfaceDocument | undefined> {
+  const db = getFirestore(getApp());
+  const surfaceRef = doc(db, 'surfaces', surfaceId);
+  const snap = await getDoc(surfaceRef);
+  const surface = snap.data();
+
+  return isSurfaceDocument(surfaceId, surface) ? surface : undefined;
+}
+
+function isSurfaceDocument(surfaceId: string, surface: unknown): surface is SurfaceDocument {
+  if (!isSurfaceBase(surface, { labelRequired: false })) return false;
+
+  const document = surface as Partial<SurfaceDocument>;
+  if (!Array.isArray(document.items) || document.id !== surfaceId || document.version !== 1) return false;
+
+  document.items = document.items.filter(isSurfaceNode);
+  return document.items.length > 0;
+}
+
+function isSurfaceNode(surface: unknown): surface is SurfaceNode {
+  if (!isSurfaceBase(surface, { labelRequired: true })) return false;
+
+  const document = surface as Partial<SurfaceNode>;
+
+  if ('items' in document) {
+    // Reject containers carrying a leaf-only key (`filters` was a former leaf field): structural shape guard.
+    if (!Array.isArray(document.items) || 'filters' in document) return false;
+    document.items = document.items.filter(isSurfaceNode);
+    return document.items.length > 0;
+  }
+
+  if (!('display' in document)) return false;
+
+  return (
+    (document.placement === undefined || typeof document.placement === 'string' || document.placement === null) &&
+    isSurfaceDisplay(document.display) &&
+    isSurfaceDestination(document.destination) &&
+    (document.limit === undefined || (Number.isInteger(document.limit) && document.limit > 0))
+  );
+}
+
+function isSurfaceBase(surface: unknown, { labelRequired }: { labelRequired: boolean }): surface is Partial<SurfaceNodeBase> {
+  if (typeof surface !== 'object' || surface === null) return false;
+
+  const document = surface as Partial<SurfaceNodeBase>;
+
+  return (
+    isSurfaceId(document.id) &&
+    isSurfaceEnabled(document.enabled) &&
+    (!labelRequired || document.label !== undefined) &&
+    (document.label === undefined || isNonEmptyString(document.label)) &&
+    (document.updatedAt === undefined || isValidDateString(document.updatedAt))
+  );
+}
+
+function isSurfaceEnabled(enabled: unknown): boolean {
+  if (typeof enabled === 'boolean') return true;
+  if (typeof enabled !== 'object' || enabled === null) return false;
+
+  const schedule = enabled as { endsAt?: unknown; startsAt?: unknown };
+  return (
+    (schedule.startsAt !== undefined || schedule.endsAt !== undefined) &&
+    (schedule.startsAt === undefined || isValidDateString(schedule.startsAt)) &&
+    (schedule.endsAt === undefined || isValidDateString(schedule.endsAt))
+  );
+}
+
+function isSurfaceDestination(destination: unknown): boolean {
+  if (destination === null) return true;
+  if (!Array.isArray(destination) || destination.length === 0) return false;
+
+  return isDestinationRoot(destination[0]) && destination.every(isNonEmptyString);
+}
+
+function isSurfaceId(value: unknown): value is string {
+  return typeof value === 'string' && SURFACE_ID_PATTERN.test(value);
+}

--- a/src/features/placements/surfaces/types.ts
+++ b/src/features/placements/surfaces/types.ts
@@ -1,0 +1,43 @@
+import { type DESTINATION_ROOTS, type DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
+
+export type Enabled = boolean | { startsAt?: string; endsAt?: string };
+
+export type DestinationRoot = (typeof DESTINATION_ROOTS)[keyof typeof DESTINATION_ROOTS];
+
+export type Destination = [DestinationRoot, ...string[]] | null;
+
+export type Display = (typeof DISPLAY_VALUES)[number];
+
+export type SurfaceId = string;
+
+export type SectionId = string;
+
+export type SurfaceNodeBase = {
+  id: string;
+  label?: string;
+  enabled: Enabled;
+  updatedAt?: string;
+};
+
+export type SurfaceDocument = SurfaceNodeBase & {
+  version: 1;
+  items: SurfaceNode[];
+};
+
+export type SurfaceContainerNode = SurfaceNodeBase & {
+  items: SurfaceNode[];
+};
+
+export type SurfaceLeafNode = SurfaceNodeBase & {
+  placement?: string | null;
+  display: Display;
+  destination: Destination;
+  limit?: number;
+};
+
+export type SurfaceNode = SurfaceContainerNode | SurfaceLeafNode;
+
+export type SurfaceBase = SurfaceNodeBase;
+export type SurfaceContainer = SurfaceContainerNode;
+export type SurfaceLeaf = SurfaceLeafNode;
+export type Surface = SurfaceNode;

--- a/src/features/placements/surfaces/utils/filterSurface.ts
+++ b/src/features/placements/surfaces/utils/filterSurface.ts
@@ -1,0 +1,57 @@
+import { type Enabled, type SurfaceDocument, type SurfaceLeafNode, type SurfaceNode } from '@/features/placements/surfaces/types';
+
+type FilterableSurface = SurfaceDocument | SurfaceNode;
+
+export function filterSurfaceTree(
+  surface: SurfaceDocument,
+  predicate: (surface: FilterableSurface) => boolean
+): SurfaceDocument | undefined;
+export function filterSurfaceTree(surface: SurfaceNode, predicate: (surface: FilterableSurface) => boolean): SurfaceNode | undefined;
+export function filterSurfaceTree(
+  surface: FilterableSurface,
+  predicate: (surface: FilterableSurface) => boolean
+): FilterableSurface | undefined {
+  if (!predicate(surface)) return undefined;
+
+  if (!('items' in surface)) return surface;
+
+  const filteredItems: SurfaceNode[] = [];
+  let didChange = false;
+
+  for (const item of surface.items) {
+    const filteredItem = filterSurfaceTree(item, predicate);
+    if (!filteredItem) {
+      didChange = true;
+      continue;
+    }
+    if (filteredItem !== item) didChange = true;
+    filteredItems.push(filteredItem);
+  }
+
+  if (!filteredItems.length) return undefined;
+  return didChange ? { ...surface, items: filteredItems } : surface;
+}
+
+export function walkSurfaceLeaves(surface: FilterableSurface, visit: (surface: SurfaceLeafNode) => void): void {
+  if (!('items' in surface)) {
+    visit(surface);
+    return;
+  }
+
+  for (const item of surface.items) {
+    walkSurfaceLeaves(item, visit);
+  }
+}
+
+export function isSurfaceEnabled(enabled: Enabled | undefined, now: number): boolean {
+  if (enabled === undefined || enabled === true) return true;
+  if (enabled === false) return false;
+
+  const startsAt = enabled.startsAt ? Date.parse(enabled.startsAt) : undefined;
+  const endsAt = enabled.endsAt ? Date.parse(enabled.endsAt) : undefined;
+
+  if (startsAt !== undefined && (!Number.isFinite(startsAt) || now < startsAt)) return false;
+  if (endsAt !== undefined && (!Number.isFinite(endsAt) || now >= endsAt)) return false;
+
+  return true;
+}

--- a/src/features/placements/types.ts
+++ b/src/features/placements/types.ts
@@ -1,4 +1,6 @@
-import { type PLACEMENT_IDS, type PLACEMENT_SCREENS } from '@/features/placements/constants';
+import { type PLACEMENT_IDS, type PLACEMENT_SCREENS, type PLACEMENT_SOURCES, type PLACEMENT_TYPES } from '@/features/placements/constants';
+
+// ============ v1 (legacy DiscoverHome carousels) ============================ //
 
 export type PlacementId = (typeof PLACEMENT_IDS)[keyof typeof PLACEMENT_IDS];
 
@@ -32,4 +34,25 @@ export type Placement = {
   items: PlacementItem[];
   version: number;
   updatedAt: string;
+};
+
+// ============ v2 (placement document contract) ============================== //
+
+export type PlacementIdV2 = string;
+
+export type PlacementSourceV2 = (typeof PLACEMENT_SOURCES)[keyof typeof PLACEMENT_SOURCES];
+
+export type PlacementTypeV2 = (typeof PLACEMENT_TYPES)[keyof typeof PLACEMENT_TYPES];
+
+export type PlacementItemV2 = {
+  id: string;
+};
+
+export type PlacementV2 = {
+  id: PlacementIdV2;
+  version: 2;
+  source: PlacementSourceV2;
+  type: PlacementTypeV2;
+  items: PlacementItemV2[];
+  updatedAt?: string;
 };

--- a/src/features/placements/utils/decoders.ts
+++ b/src/features/placements/utils/decoders.ts
@@ -1,0 +1,11 @@
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function isValidDateString(value: unknown): value is string {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value));
+}
+
+export function oneOf<T extends string>(values: readonly T[]) {
+  return (value: unknown): value is T => typeof value === 'string' && values.includes(value as T);
+}

--- a/src/features/placements/utils/finalizePlacementResult.ts
+++ b/src/features/placements/utils/finalizePlacementResult.ts
@@ -1,0 +1,48 @@
+import { type PlacementResult } from '@/features/placements/stores/placementsStore';
+import { type PlacementItemV2, type PlacementV2 } from '@/features/placements/types';
+
+/**
+ * Pairs configured placement items with their resolved values, preserving the
+ * placement order and dropping any items whose ref did not resolve.
+ */
+export function pairPlacementItems<Resolved, Hydrated>(
+  placementItems: PlacementItemV2[],
+  resolvedById: (id: string) => Resolved | undefined,
+  toItem: (item: PlacementItemV2, resolved: Resolved) => Hydrated
+): Hydrated[] {
+  const items: Hydrated[] = [];
+
+  for (const item of placementItems) {
+    const resolved = resolvedById(item.id);
+    if (resolved !== undefined) items.push(toItem(item, resolved));
+  }
+
+  return items;
+}
+
+/**
+ * Normalizes a per-source hydration result. `isLoading` is true only while the
+ * placement is enabled, has configured refs, and the underlying resolver is in
+ * its initial load. A placement is only surfaced once it has resolved items.
+ */
+export function finalizePlacementResult<Hydrated>({
+  enabled,
+  hasRefs,
+  isInitialLoad,
+  items,
+  placement,
+}: {
+  enabled: boolean;
+  hasRefs: boolean;
+  isInitialLoad: boolean;
+  items: Hydrated[];
+  placement: PlacementV2 | undefined;
+}): PlacementResult<Hydrated> {
+  if (!enabled) return { isLoading: false, items: [], placement: undefined };
+
+  return {
+    isLoading: hasRefs && isInitialLoad && items.length === 0,
+    items,
+    placement: items.length ? placement : undefined,
+  };
+}

--- a/src/features/placements/utils/hasRefsOrPendingHydration.ts
+++ b/src/features/placements/utils/hasRefsOrPendingHydration.ts
@@ -1,0 +1,19 @@
+import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
+import { useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { type PlacementSourceV2, type PlacementTypeV2 } from '@/features/placements/types';
+import { type DeriveGetter } from '@/state/internal/createDerivedStore';
+
+const sourceByType: Record<PlacementTypeV2, PlacementSourceV2> = {
+  perp: 'hyperliquid',
+  prediction: 'polymarket',
+  token: 'rainbow',
+};
+
+export function hasRefsOrPendingHydration(source: PlacementSourceV2, type: PlacementTypeV2): ($: DeriveGetter) => boolean {
+  return $ => {
+    const hasRefs = sourceByType[type] === source && $(useDiscoverSurfacePlacementRefs, refs => refs[source].length > 0);
+    const placementsPending = $(usePlacementsV2Store, state => state.getStatus('isIdle') || state.getStatus('isInitialLoad'));
+
+    return hasRefs || placementsPending;
+  };
+}

--- a/src/graphql/utils/getFetchRequester.ts
+++ b/src/graphql/utils/getFetchRequester.ts
@@ -7,7 +7,7 @@ import { buildGetQueryParams } from '@/graphql/utils/buildGetQueryParams';
 
 const allowedOperations = ['mutation', 'query'];
 
-type Options = Pick<RainbowFetchRequestOpts, 'timeout' | 'headers'>;
+type Options = Pick<RainbowFetchRequestOpts, 'abortController' | 'timeout' | 'headers'>;
 
 type Config = {
   __name: string;

--- a/src/resources/assets/externalAssetsQuery.ts
+++ b/src/resources/assets/externalAssetsQuery.ts
@@ -34,6 +34,9 @@ type ExternalTokenArgs = {
   chainId: ChainId;
   currency: NativeCurrencyKey;
 };
+type FetchExternalTokenArgs = ExternalTokenArgs & {
+  abortController?: AbortController | null;
+};
 
 // Query Key for Token Price
 export const externalTokenQueryKey = ({ address, chainId, currency }: ExternalTokenArgs) =>
@@ -62,12 +65,15 @@ const formatExternalAsset = (
 };
 
 // Query Function for Token Price
-export async function fetchExternalToken({ address, chainId, currency }: ExternalTokenArgs) {
-  const response = await metadataClient.externalToken({
-    address,
-    chainId,
-    currency,
-  });
+export async function fetchExternalToken({ abortController, address, chainId, currency }: FetchExternalTokenArgs) {
+  const response = await metadataClient.externalToken(
+    {
+      address,
+      chainId,
+      currency,
+    },
+    { abortController }
+  );
   if (response.token) {
     return formatExternalAsset(address as AddressOrEth, chainId, response.token, currency);
   } else {


### PR DESCRIPTION
Adds the v2 placements and surfaces data layer so the Discover layout can be driven from Firestore instead of an app release — nothing is wired to a screen yet, and v1 stores and types are preserved.

## What changed

- A v2 placement is now pure data: a typed, ordered list of item ids with a closed source/type pair (hyperliquid→perp, polymarket→prediction, rainbow→token), reusable across surfaces.
- The placements store queries v2 docs with keepPreviousData to avoid empty-flash, re-validates each on read, and silently drops malformed docs.
- A surface is a two-level tree — tabs containing leaf sections with display, destination, and an optional placement ref — with a JSON Schema mirroring the write contract.
- The surface builds tabs and sections from the raw document without filtering missing placements, so tabs appear immediately with per-section skeletons.
- Placements force-refetch when the surface is newer than the cache, gated by a request key so it fires at most once per missing-ids set.
- Placement refs collapse into stable per-source arrays, keeping the ref stores from refetching on no-op re-evaluations.
- The per-source hydrators stay enabled through the placements store's initial load and check source/type, so refs can't leak across sources.
- Hydrators fire skeletons once, withhold the section until an item resolves (zero-item sections never render), and keep items in CMS order with unresolved refs dropped.
- Token fetches are backed by a TTL cache so only new or stale refs hit the network; prediction events are filtered post-fetch so closed or resolved markets never render as live.

## What to test

- With no surface document, v1 carousels render normally and no v2 Firestore requests fire.
- Publish a surface and confirm tabs and sections appear immediately with per-section skeletons.
- A section resolving to zero items never renders; a section with items stops spinning once content arrives.
- Items appear in CMS order, with deleted or unresolved ids absent rather than leaving gaps.
- Point a fresh surface at an uncached placement id and confirm content arrives once, with no repeated calls.
- A null destination renders but does nothing on tap; an enabled schedule shows the section only in its window.
- A closed or resolved Polymarket event never shows as live; a malformed surface or placement document drops silently without crashing Discover.
