### PR TITLE
feat(discover): dynamic token market placements

### DIFF
--- a/src/features/charts/stores/factories/createLineChartDataStore.ts
+++ b/src/features/charts/stores/factories/createLineChartDataStore.ts
@@ -25,6 +25,47 @@ type ChartId = string;
  */
 export type FetchedLineChartData = Partial<Record<ChartId, CompactLineChartData | null>>;
 
+// ============ Shared Aggregation Helper ====================================== //
+
+/**
+ * Aggregates per-id fetch promises into a {@link FetchedLineChartData} result.
+ *
+ * - Keeps partial successes: a fulfilled fetch is recorded regardless of other failures.
+ * - Records the first rejection but does not throw immediately.
+ * - Throws only when EVERY fetch failed, re-throwing the first error encountered.
+ *
+ * Use this in any `LineChartDataFetcher` implementation that fans out to one
+ * backend request per id so both token and perp stores behave identically.
+ *
+ * @param ids - The chart ids that were fetched, in the same order as `promises`.
+ * @param promises - Per-id fetch promises (may resolve to `null` for missing data).
+ */
+export async function aggregateLineChartFetches<TId extends string>(
+  ids: readonly TId[],
+  promises: readonly Promise<CompactLineChartData | null>[]
+): Promise<FetchedLineChartData> {
+  const results = await Promise.allSettled(promises);
+
+  const chartsById: FetchedLineChartData = {};
+  let didResolve = false;
+  let firstError: unknown;
+
+  for (let i = 0; i < ids.length; i++) {
+    const result = results[i];
+
+    if (result.status === 'fulfilled') {
+      didResolve = true;
+      chartsById[ids[i]] = result.value;
+    } else if (firstError === undefined) {
+      firstError = result.reason;
+    }
+  }
+
+  if (!didResolve && firstError !== undefined) throw firstError;
+
+  return chartsById;
+}
+
 /**
  * Loads line chart data for ids that need fresh data.
  */

--- a/src/features/charts/stores/tokenLineChartsStore.ts
+++ b/src/features/charts/stores/tokenLineChartsStore.ts
@@ -1,0 +1,99 @@
+import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
+import { type CompactLineChartData } from '@/features/charts/line/compact/types';
+import {
+  aggregateLineChartFetches,
+  createLineChartDataStore,
+  type FetchedLineChartData,
+} from '@/features/charts/stores/factories/createLineChartDataStore';
+import { metadataClient } from '@/graphql';
+import Routes from '@/navigation/routesNames';
+import { type ChainId } from '@/state/backendNetworks/types';
+
+const CHART_ID_SEPARATOR = '|';
+
+type TokenChartParams = {
+  address: string;
+  chainId: ChainId;
+  currency: NativeCurrencyKey;
+};
+
+type TokenPriceChart = {
+  points?: [timestamp: number, price: number][];
+};
+
+export const useTokenLineChartsStore = createLineChartDataStore(fetchTokenLineCharts, {
+  activeOnRoute: Routes.DISCOVER_SCREEN,
+});
+
+export function buildTokenLineChartId({ address, chainId, currency }: TokenChartParams): string {
+  return [address, chainId, currency].join(CHART_ID_SEPARATOR);
+}
+
+async function fetchTokenLineCharts(chartIds: readonly string[]): Promise<FetchedLineChartData> {
+  return aggregateLineChartFetches(
+    chartIds,
+    chartIds.map(chartId => fetchTokenLineChart(chartId))
+  );
+}
+
+async function fetchTokenLineChart(chartId: string): Promise<CompactLineChartData | null> {
+  const params = parseTokenLineChartId(chartId);
+  if (!params) return null;
+
+  const response = await metadataClient.priceChart({
+    address: params.address,
+    chainId: params.chainId,
+    currency: params.currency,
+    day: true,
+    hour: false,
+    month: false,
+    week: false,
+    year: false,
+  });
+
+  return buildLineChartData(response.token?.priceCharts.day as TokenPriceChart | undefined);
+}
+
+function parseTokenLineChartId(chartId: string): TokenChartParams | null {
+  const [address, chainId, currency] = chartId.split(CHART_ID_SEPARATOR);
+  const numericChainId = Number(chainId);
+
+  if (!address || !Number.isInteger(numericChainId) || !currency) return null;
+
+  return {
+    address,
+    chainId: numericChainId as ChainId,
+    currency: currency as NativeCurrencyKey,
+  };
+}
+
+/**
+ * Normalizes a token price chart timestamp to seconds.
+ *
+ * The token metadata API returns timestamps inconsistently — sometimes milliseconds,
+ * sometimes seconds. Values over 1e12 are treated as milliseconds and converted to
+ * seconds so the chart store always holds second-resolution timestamps.
+ */
+function normalizeTokenChartTimestampSeconds(timestamp: number): number {
+  return timestamp > 1_000_000_000_000 ? Math.floor(timestamp / 1000) : timestamp;
+}
+
+function buildLineChartData(priceChart: TokenPriceChart | undefined): CompactLineChartData | null {
+  const points = priceChart?.points?.filter(isPricePoint) ?? [];
+  if (!points.length) return null;
+
+  const prices = new Float32Array(points.length);
+  const timestamps = new Uint32Array(points.length);
+
+  for (let i = 0; i < points.length; i++) {
+    const [timestamp, price] = points[i];
+    prices[i] = price;
+    timestamps[i] = normalizeTokenChartTimestampSeconds(timestamp);
+  }
+
+  return { prices, timestamps };
+}
+
+function isPricePoint(point: unknown): point is [number, number] {
+  return Array.isArray(point) && point.length >= 2 && typeof point[0] === 'number' && typeof point[1] === 'number';
+}

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -1,3 +1,7 @@
+import { useMemo } from 'react';
+
+import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
+import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
 import { MarketCell, MarketCellSkeleton } from '@/features/discover/components/markets/cards/MarketCell';
 import {
   computeMarketPillWidth,
@@ -11,6 +15,7 @@ import {
   MarketTileCard,
   MarketTileCardSkeleton,
 } from '@/features/discover/components/markets/cards/MarketTileCard';
+import { tokenToMarketPillWidthInput, useTokenMarketDisplay } from '@/features/discover/components/markets/hooks/useTokenMarketDisplay';
 import { renderSectionLayout } from '@/features/discover/components/SectionLayout';
 import { type MarketDisplayItem } from '@/features/discover/types/marketDisplayItem';
 import {
@@ -19,10 +24,12 @@ import {
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
+import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
 import { MARKET_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
 import { useIsDiscoverSurfacePlacementPending } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
 import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 
 const hasDestination = (surface: SurfaceLeaf) => surface.destination !== null;
 
@@ -75,13 +82,16 @@ function MarketPlacementContent({
   surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
   surfaceId: string;
 }) {
+  const placement = usePlacementsV2Store(state => state.getPlacement(surface.placement));
   const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
   const isLoadingPlacementSource = usePlacementsV2Store(state => {
     if (state.getPlacement(surface.placement) !== undefined) return false;
     return state.getStatus('isInitialLoad') || state.getStatus('isIdle') || state.getStatus('isLoading');
   });
 
-  // Per-source content (e.g. the `rainbow` token source) is added by feature branches.
+  if (placement?.source === 'rainbow') {
+    return <TokenMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
+  }
 
   if (isLoadingPlacementSource || isPendingSurfacePlacement) {
     return renderSectionLayout({
@@ -94,6 +104,55 @@ function MarketPlacementContent({
   }
 
   return null;
+}
+
+function TokenMarketPlacementContent({
+  surface,
+  surfaceId,
+}: {
+  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
+  surfaceId: string;
+}) {
+  const { onTapSearch } = useDiscoverScreenContext();
+  const nativeCurrency = userAssetsStoreManager(state => state.currency);
+  const tokensResult = useTokensPlacement(surface.placement);
+  const tokenDescriptor = useMemo<SectionDescriptor<TokenPlacementItem>>(() => {
+    switch (surface.display) {
+      case 'market_pill.carousel':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          getItemWidth: (item: TokenPlacementItem) => computeMarketPillWidth(tokenToMarketPillWidthInput({ item, nativeCurrency })),
+          renderItem: (item: TokenPlacementItem) => <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="pill" />,
+        };
+      case 'market_tile.carousel':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          renderItem: (item: TokenPlacementItem) => <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="tile" />,
+        };
+      case 'market_tile.grid':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          renderItem: (item: TokenPlacementItem, width: number) => (
+            <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="tile" width={width} />
+          ),
+        };
+      case 'market_cell.list':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          renderItem: (item: TokenPlacementItem) => <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="cell" />,
+        };
+    }
+  }, [nativeCurrency, surface.display]);
+  // Only passed when the destination is token-owned (`['tokens']`); non-token CMS
+  // destinations are wired in #7553.
+
+  return renderSectionLayout({
+    data: tokensResult.items,
+    descriptor: tokenDescriptor,
+    loading: tokensResult.isLoading,
+    onPressSeeAll: surface.destination?.[0] === 'tokens' ? onTapSearch : undefined,
+    surface,
+  });
 }
 
 function hasPlacement(surface: SurfaceLeafWithDisplay<MarketDisplay>): surface is PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> {
@@ -118,4 +177,27 @@ function renderMarketGridTileSkeleton(width: number) {
 
 function renderMarketCell(item: MarketDisplayItem) {
   return <MarketCell item={item} />;
+}
+
+function TokenMarketItem({
+  item,
+  nativeCurrency,
+  variant,
+  width,
+}: {
+  item: TokenPlacementItem;
+  nativeCurrency: NativeCurrencyKey;
+  variant: 'cell' | 'pill' | 'tile';
+  width?: number;
+}) {
+  const displayItem = useTokenMarketDisplay({ item, nativeCurrency });
+
+  switch (variant) {
+    case 'cell':
+      return <MarketCell item={displayItem} />;
+    case 'pill':
+      return <MarketPill item={displayItem} />;
+    case 'tile':
+      return <MarketTileCard item={displayItem} width={width} />;
+  }
 }

--- a/src/features/discover/components/markets/hooks/useTokenMarketDisplay.ts
+++ b/src/features/discover/components/markets/hooks/useTokenMarketDisplay.ts
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+
+import { globalColors } from '@/design-system/color/palettes';
+import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
+import { buildTokenLineChartId, useTokenLineChartsStore } from '@/features/charts/stores/tokenLineChartsStore';
+import { type MarketPillWidthInput } from '@/features/discover/components/markets/cards/MarketPill';
+import { type MarketDisplayItem } from '@/features/discover/types/marketDisplayItem';
+import { type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
+import { getPriceChangeColor, getPriceChangeColors } from '@/framework/ui/price/usePriceChangeColors';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { formatCurrency } from '@/helpers/strings';
+import useColorForAsset from '@/hooks/useColorForAsset';
+import { getUniqueId } from '@/utils/ethereumUtils';
+
+const MARKET_NEUTRAL_CHART_COLOR = opacity(globalColors.white100, 0.5);
+const MARKET_CHART_PRICE_CHANGE_COLORS = {
+  ...getPriceChangeColors('dark'),
+  neutral: MARKET_NEUTRAL_CHART_COLOR,
+};
+
+/**
+ * Normalizes a token API price-change value to the shared percent-unit string used by
+ * generic market cards. The token metadata API already returns `relativeChange24h` and
+ * `change24hPct` in percent units (`"5.23"` == 5.23%), matching the shared
+ * `formatNormalizedPercentChange` contract, so no scaling is applied — only a nullish
+ * and finite guard.
+ */
+function normalizeTokenPercentChange(priceChange: number | string | null | undefined): string {
+  const value = Number(priceChange ?? 0);
+  return isFinite(value) ? String(value) : '0';
+}
+
+/**
+ * Builds the {@link MarketDisplayItem} for a token placement item, resolving the
+ * dominant accent color via {@link useColorForAsset} and memoizing the result.
+ */
+export function useTokenMarketDisplay({
+  item,
+  nativeCurrency,
+}: {
+  item: TokenPlacementItem;
+  nativeCurrency: NativeCurrencyKey;
+}): MarketDisplayItem {
+  const { asset } = item;
+  const accentColor = useColorForAsset({
+    address: asset.address,
+    name: asset.name,
+    symbol: asset.symbol,
+  });
+
+  return useMemo<MarketDisplayItem>(() => {
+    // `asset.price` may be absent for newly-listed or low-liquidity tokens.
+    const initialPriceChange = normalizeTokenPercentChange(asset.price?.relativeChange24h);
+    const liveTokenId = getUniqueId(asset.address, asset.chainId);
+
+    return {
+      id: item.id,
+      accentColor,
+      chartColor: getTokenPriceChangeChartColor(asset.price?.relativeChange24h),
+      chartId: buildTokenLineChartId({ address: asset.address, chainId: asset.chainId, currency: nativeCurrency }),
+      chartStore: useTokenLineChartsStore,
+      displayName: asset.name,
+      iconUrl: asset.iconUrl ?? undefined,
+      initialPrice: formatCurrency(asset.price?.value ? String(asset.price.value) : '0', { currency: nativeCurrency }),
+      initialPriceLastUpdated: asset.price?.updatedAt,
+      initialPriceChange,
+      leverage: undefined,
+      liveTokenId,
+      priceChangeSelector: token => normalizeTokenPercentChange(token.change.change24hPct),
+      priceSelector: token => formatCurrency(token.price, { currency: nativeCurrency }),
+    };
+  }, [accentColor, asset, item.id, nativeCurrency]);
+}
+
+export function tokenToMarketPillWidthInput({
+  item,
+  nativeCurrency,
+}: {
+  item: TokenPlacementItem;
+  nativeCurrency: NativeCurrencyKey;
+}): MarketPillWidthInput {
+  const { asset } = item;
+  return {
+    displayName: asset.name,
+    initialPrice: formatCurrency(asset.price?.value ? String(asset.price.value) : '0', { currency: nativeCurrency }),
+    initialPriceChange: normalizeTokenPercentChange(asset.price?.relativeChange24h),
+  };
+}
+
+function getTokenPriceChangeChartColor(priceChange: number | string | null | undefined): string {
+  return getPriceChangeColor(String(priceChange ?? 0), MARKET_CHART_PRICE_CHANGE_COLORS);
+}

--- a/src/features/discover/utils/refreshDiscoverSurface.ts
+++ b/src/features/discover/utils/refreshDiscoverSurface.ts
@@ -1,4 +1,6 @@
+import { clearTokenRefCache, useTokenRefsStore } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
+import { useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
 import { getSurfaceStore } from '@/features/placements/surfaces/stores/surfaceStore';
 
 export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
@@ -7,5 +9,16 @@ export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
     usePlacementsV2Store.getState().fetch(undefined, { force: true }),
   ]);
 
-  // per-source refresh added by feature branches
+  const refs = useDiscoverSurfacePlacementRefs.getState();
+
+  const refreshes: Promise<unknown>[] = [];
+
+  if (refs.rainbow.length) {
+    // Clear the module-level token-ref cache so a forced refresh always fetches
+    // fresh token data from the network, even within TOKEN_REFS_STALE_TIME.
+    clearTokenRefCache();
+    refreshes.push(useTokenRefsStore.getState().fetch(undefined, { force: true }));
+  }
+
+  await Promise.allSettled(refreshes);
 }

--- a/src/features/perps/stores/hyperliquidLineChartsStore.ts
+++ b/src/features/perps/stores/hyperliquidLineChartsStore.ts
@@ -1,5 +1,9 @@
 import { type CompactLineChartData } from '@/features/charts/line/compact/types';
-import { createLineChartDataStore, type FetchedLineChartData } from '@/features/charts/stores/factories/createLineChartDataStore';
+import {
+  aggregateLineChartFetches,
+  createLineChartDataStore,
+  type FetchedLineChartData,
+} from '@/features/charts/stores/factories/createLineChartDataStore';
 import { CandleResolution, type HyperliquidCandle } from '@/features/charts/types';
 import { msToSeconds, toHyperliquidInterval } from '@/features/charts/utils';
 import { infoClient } from '@/features/perps/services/hyperliquid-info-client';
@@ -21,28 +25,10 @@ async function fetchHyperliquidLineCharts(
   symbols: readonly string[],
   abortController: AbortController | null
 ): Promise<FetchedLineChartData> {
-  const chartFetches = symbols.map(symbol => fetchHyperliquidChartData(symbol, abortController));
-
-  const results = await Promise.allSettled(chartFetches);
-
-  const chartsById: FetchedLineChartData = {};
-  let didResolve = false;
-  let firstError: unknown;
-
-  for (let i = 0; i < symbols.length; i++) {
-    const result = results[i];
-
-    if (result.status === 'fulfilled') {
-      didResolve = true;
-      chartsById[symbols[i]] = result.value;
-    } else if (firstError === undefined) {
-      firstError = result.reason;
-    }
-  }
-
-  if (!didResolve && firstError !== undefined) throw firstError;
-
-  return chartsById;
+  return aggregateLineChartFetches(
+    symbols,
+    symbols.map(symbol => fetchHyperliquidChartData(symbol, abortController))
+  );
 }
 
 async function fetchHyperliquidChartData(symbol: string, abortController: AbortController | null): Promise<CompactLineChartData | null> {

--- a/src/features/placements/stores/derived/tokensPlacementStore.ts
+++ b/src/features/placements/stores/derived/tokensPlacementStore.ts
@@ -53,6 +53,17 @@ const EMPTY_TOKEN_ASSETS_BY_REF: TokenAssetsByRef = Object.freeze({});
 const hasTokenRefsOrPendingHydration = hasRefsOrPendingHydration('rainbow', 'token');
 const tokenRefCache = new Map<string, TokenRefCacheEntry>();
 
+// ============ Cache Control ================================================== //
+
+/**
+ * Clears the module-level token-ref cache so that the next {@link fetchTokenRefs}
+ * call fetches fresh assets from the network, even if refs are within
+ * {@link TOKEN_REFS_STALE_TIME}. Call this before a forced refresh.
+ */
+export function clearTokenRefCache(): void {
+  tokenRefCache.clear();
+}
+
 // ============ Stores ========================================================= //
 
 const useTokensEnabled = createDerivedStore<boolean>(


### PR DESCRIPTION
Discover rendered perp and prediction sections but `rainbow` token placements had no card pipeline, so those surfaces fell through to nothing; this adapts token placements into the shared card system so a new source is just an adapter.

## What changed

- New `useTokenMarketDisplay` hook adapts a `TokenPlacementItem` into the shared `MarketDisplayItem`, memoizing on the live price tick and resolving accent color outside the memo so async dominant color lands.
- New `tokenLineChartsStore` fetches 24h sparkline data in batches and pauses while Discover is off-stage.
- `MarketSection` materializes the placement before loading guards and routes `source === 'rainbow'` to its own loading state, killing a skeleton flash on refresh.
- A `tokens` destination sentinel routes "See All" through `onTapSearch`, keeping token awareness out of the navigation utility.
- `refreshDiscoverSurface` re-fetches token refs only after stores settle and only when the `rainbow` bucket is non-empty.

## What to test

- Open Discover on a surface with a rainbow token section; confirm cards render across all four layouts with icon, price, 24h change, and sparkline.
- Navigate away and back; confirm sparklines resume and prices are current.
- Pull to refresh; confirm surface, placement data, and token cards update.
- Tap a token card; confirm the asset sheet opens for the right token and chain.
- Tap "See All" on a `tokens` destination; confirm the search sheet opens.
- Open a surface with no token placements; confirm no token-refs request fires on refresh.
- Confirm perp sections still render and live-update alongside token sections.
