### PR TITLE
feat(discover): dynamic perp market placements

### DIFF
--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
 import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
@@ -15,6 +15,7 @@ import {
   MarketTileCard,
   MarketTileCardSkeleton,
 } from '@/features/discover/components/markets/cards/MarketTileCard';
+import { perpToMarketPillWidthInput, usePerpMarketDisplay } from '@/features/discover/components/markets/hooks/usePerpMarketDisplay';
 import { tokenToMarketPillWidthInput, useTokenMarketDisplay } from '@/features/discover/components/markets/hooks/useTokenMarketDisplay';
 import { renderSectionLayout } from '@/features/discover/components/SectionLayout';
 import { type MarketDisplayItem } from '@/features/discover/types/marketDisplayItem';
@@ -24,6 +25,7 @@ import {
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
+import { usePerpsEnabled, usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
 import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
 import { MARKET_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
@@ -82,12 +84,18 @@ function MarketPlacementContent({
   surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
   surfaceId: string;
 }) {
+  const perpsEnabled = usePerpsEnabled();
   const placement = usePlacementsV2Store(state => state.getPlacement(surface.placement));
   const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
   const isLoadingPlacementSource = usePlacementsV2Store(state => {
     if (state.getPlacement(surface.placement) !== undefined) return false;
     return state.getStatus('isInitialLoad') || state.getStatus('isIdle') || state.getStatus('isLoading');
   });
+
+  if (placement?.source === 'hyperliquid') {
+    if (!perpsEnabled) return null;
+    return <PerpsMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
+  }
 
   if (placement?.source === 'rainbow') {
     return <TokenMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
@@ -104,6 +112,53 @@ function MarketPlacementContent({
   }
 
   return null;
+}
+
+function PerpsMarketPlacementContent({
+  surface,
+}: {
+  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
+  // surfaceId is threaded from MarketPlacementContent for future use (#7553)
+  surfaceId: string;
+}) {
+  const { onTapSearch } = useDiscoverScreenContext();
+  const perpsResult = usePerpsPlacement(surface.placement);
+  const perpDescriptor = useMemo<SectionDescriptor<PerpMarketPlacementItem>>(() => {
+    switch (surface.display) {
+      case 'market_pill.carousel':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          getItemWidth: (item: PerpMarketPlacementItem) => computeMarketPillWidth(perpToMarketPillWidthInput(item)),
+          renderItem: (item: PerpMarketPlacementItem) => <PerpMarketItem item={item} variant="pill" />,
+        };
+      case 'market_tile.carousel':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          renderItem: (item: PerpMarketPlacementItem) => <PerpMarketItem item={item} variant="tile" />,
+        };
+      case 'market_tile.grid':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          renderItem: (item: PerpMarketPlacementItem, width: number) => <PerpMarketItem item={item} variant="tile" width={width} />,
+        };
+      case 'market_cell.list':
+        return {
+          ...MARKET_SECTION_DESCRIPTORS[surface.display],
+          renderItem: (item: PerpMarketPlacementItem) => <PerpMarketItem item={item} variant="cell" />,
+        };
+    }
+  }, [surface.display]);
+  // Only passed when the destination is perp-owned (`['perps']`); non-perp CMS
+  // destinations are wired in #7553.
+  const onPressSeeAll = useCallback(() => onTapSearch(), [onTapSearch]);
+
+  return renderSectionLayout({
+    data: perpsResult.items,
+    descriptor: perpDescriptor,
+    loading: perpsResult.isLoading,
+    onPressSeeAll: surface.destination?.[0] === 'perps' ? onPressSeeAll : undefined,
+    surface,
+  });
 }
 
 function TokenMarketPlacementContent({
@@ -145,12 +200,13 @@ function TokenMarketPlacementContent({
   }, [nativeCurrency, surface.display]);
   // Only passed when the destination is token-owned (`['tokens']`); non-token CMS
   // destinations are wired in #7553.
+  const onPressSeeAll = useCallback(() => onTapSearch(), [onTapSearch]);
 
   return renderSectionLayout({
     data: tokensResult.items,
     descriptor: tokenDescriptor,
     loading: tokensResult.isLoading,
-    onPressSeeAll: surface.destination?.[0] === 'tokens' ? onTapSearch : undefined,
+    onPressSeeAll: surface.destination?.[0] === 'tokens' ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -191,6 +247,19 @@ function TokenMarketItem({
   width?: number;
 }) {
   const displayItem = useTokenMarketDisplay({ item, nativeCurrency });
+
+  switch (variant) {
+    case 'cell':
+      return <MarketCell item={displayItem} />;
+    case 'pill':
+      return <MarketPill item={displayItem} />;
+    case 'tile':
+      return <MarketTileCard item={displayItem} width={width} />;
+  }
+}
+
+function PerpMarketItem({ item, variant, width }: { item: PerpMarketPlacementItem; variant: 'cell' | 'pill' | 'tile'; width?: number }) {
+  const displayItem = usePerpMarketDisplay(item);
 
   switch (variant) {
     case 'cell':

--- a/src/features/discover/components/markets/hooks/usePerpMarketDisplay.ts
+++ b/src/features/discover/components/markets/hooks/usePerpMarketDisplay.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+
+import { globalColors } from '@/design-system/color/palettes';
+import { type MarketPillWidthInput } from '@/features/discover/components/markets/cards/MarketPill';
+import { type MarketDisplayItem } from '@/features/discover/types/marketDisplayItem';
+import { HYPERLIQUID_COLORS } from '@/features/perps/constants';
+import { useHyperliquidLineChartsStore } from '@/features/perps/stores/hyperliquidLineChartsStore';
+import { type PerpMarketWithMetadata } from '@/features/perps/types';
+import { convertStoredPerpPriceChangeToPercent, getHyperliquidTokenId } from '@/features/perps/utils';
+import { formatPerpAssetPrice } from '@/features/perps/utils/formatPerpsAssetPrice';
+import { type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
+import { getPriceChangeColor, getPriceChangeColors } from '@/framework/ui/price/usePriceChangeColors';
+import { opacity } from '@/framework/ui/utils/opacity';
+
+const MARKET_NEUTRAL_CHART_COLOR = opacity(globalColors.white100, 0.5);
+const MARKET_CHART_PRICE_CHANGE_COLORS = {
+  ...getPriceChangeColors('dark'),
+  neutral: MARKET_NEUTRAL_CHART_COLOR,
+};
+
+/**
+ * Builds the {@link MarketDisplayItem} for a perp market placement item, memoizing
+ * the result. The perp analogue of {@link useTokenMarketDisplay}; charts are fetched
+ * by `market.symbol` with no metadata gating.
+ *
+ * Perps store `market.priceChange['24h']` with an extra /100 baked in by
+ * `calculatePerpPriceChange24h`, so a +5.23% move is stored as `"0.000523"`.
+ * The shared card contract requires percent units (`"5.23"` == 5.23%), so this
+ * source hook converts via `convertStoredPerpPriceChangeToPercent` (× 10_000)
+ * before populating `initialPriceChange` and `priceChangeSelector`.
+ */
+export function usePerpMarketDisplay(item: PerpMarketPlacementItem): MarketDisplayItem {
+  return useMemo<MarketDisplayItem>(() => {
+    const { market } = item;
+    const displayName = market.baseSymbol;
+    // Convert fractional stored value → percent units for the shared card contract.
+    const initialPriceChange = String(convertStoredPerpPriceChangeToPercent(market.priceChange['24h']));
+
+    return {
+      id: item.id,
+      accentColor: getPerpMarketAccentColor(market),
+      chartColor: getPriceChangeColor(initialPriceChange, MARKET_CHART_PRICE_CHANGE_COLORS),
+      chartId: market.symbol,
+      chartStore: useHyperliquidLineChartsStore,
+      displayName,
+      iconUrl: market.metadata?.iconUrl,
+      initialPrice: formatPerpAssetPrice(market.midPrice ?? market.price),
+      initialPriceChange,
+      leverage: market.maxLeverage,
+      liveTokenId: getHyperliquidTokenId(market.symbol),
+      // Live price-change: convert fraction → percent, matching the stored-value contract.
+      priceChangeSelector: token => String(convertStoredPerpPriceChangeToPercent(token.change.change24hPct)),
+      priceSelector: token => formatPerpAssetPrice(token.midPrice ?? token.price),
+    };
+  }, [item]);
+}
+
+export function perpToMarketPillWidthInput(item: PerpMarketPlacementItem): MarketPillWidthInput {
+  const { market } = item;
+  return {
+    displayName: market.baseSymbol,
+    initialPrice: formatPerpAssetPrice(market.midPrice ?? market.price),
+    // Convert to percent so pill-width calculation matches the displayed value.
+    initialPriceChange: String(convertStoredPerpPriceChangeToPercent(market.priceChange['24h'])),
+  };
+}
+
+function getPerpMarketAccentColor(market: PerpMarketWithMetadata): string {
+  return market.metadata?.colors?.color || market.metadata?.colors?.fallbackColor || HYPERLIQUID_COLORS.green;
+}

--- a/src/features/discover/utils/refreshDiscoverSurface.ts
+++ b/src/features/discover/utils/refreshDiscoverSurface.ts
@@ -1,7 +1,10 @@
+import { IS_TEST } from '@/env';
+import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { clearTokenRefCache, useTokenRefsStore } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
 import { useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
 import { getSurfaceStore } from '@/features/placements/surfaces/stores/surfaceStore';
+import { useRemoteConfigStore } from '@/model/remoteConfig';
 
 export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
   await Promise.allSettled([
@@ -10,8 +13,13 @@ export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
   ]);
 
   const refs = useDiscoverSurfacePlacementRefs.getState();
+  const perpsEnabled = useRemoteConfigStore.getState().getRemoteConfigKey('perps_enabled') && !IS_TEST;
 
   const refreshes: Promise<unknown>[] = [];
+
+  if (perpsEnabled && refs.hyperliquid.length) {
+    refreshes.push(useHyperliquidMarketsStore.getState().fetch(undefined, { force: true }));
+  }
 
   if (refs.rainbow.length) {
     // Clear the module-level token-ref cache so a forced refresh always fetches

--- a/src/features/placements/stores/derived/perpsPlacementStore.ts
+++ b/src/features/placements/stores/derived/perpsPlacementStore.ts
@@ -26,7 +26,7 @@ export type PerpMarketPlacementItem = PlacementItemV2 & {
 
 // ============ Derived Stores ================================================= //
 
-const usePerpsEnabled = createDerivedStore<boolean>(
+export const usePerpsEnabled = createDerivedStore<boolean>(
   $ => $(useRemoteConfigStore, state => state.getRemoteConfigKey('perps_enabled')) && !IS_TEST,
   { fastMode: true }
 );

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -226,7 +226,7 @@ export const DEFAULT_CONFIG = {
   prince_of_the_hill_enabled: false,
   candlestick_charts_enabled: !IS_STORE_INSTALL,
   rainbow_toasts_enabled: !IS_STORE_INSTALL,
-  perps_enabled: false,
+  perps_enabled: true,
   polymarket_enabled: false,
   dev_section_enabled: IS_DEV,
   rnbw_rewards_enabled: false,


### PR DESCRIPTION
Discover rendered token sections but had no path for Hyperliquid placements, so perp markets rendered nothing; this adds perp cards by routing `source === 'hyperliquid'` through the section dispatcher and adapting `PerpMarketPlacementItem` to the shared `MarketDisplayItem` shape.

## What changed

- The section dispatcher routes `placement.source === 'hyperliquid'` to a dedicated perp component before the token branch, keeping the two store sets isolated.
- `isLoadingPlacementSource` shows a skeleton until the first fetch resolves, preventing cold-start collapse and layout shift.
- `usePerpMarketDisplay` adapts a `PerpMarketPlacementItem` into `MarketDisplayItem` so all four card variants render perps unchanged; price prefers order-book mid (matching the perp detail screen), falling back to last-trade only when no mid exists.
- Chart cache and live-price use separate keys (`BTC` vs `BTC:hl`) to avoid namespace collision.
- The perp descriptor is memoized and `usePerpMarketDisplay` runs per leaf card, scoping a tick re-render to the single card that changed.
- `refreshDiscoverSurface` gates the Hyperliquid fetch on `perps_enabled` and the surface containing a Hyperliquid ref, staying a no-op otherwise.
- The `perps_enabled` remote config default flips to `true`; production rollout stays remote-controlled.

## What to test

- Open Discover with `perps_enabled` on and a Hyperliquid section; perp cards render in all four variants with price, change, and sparkline.
- On live price updates, only the ticking card animates.
- Turn `perps_enabled` off; no Hyperliquid request fires and no perp section appears.
- Open a surface with no Hyperliquid sections while perps stay on; no Hyperliquid fetch fires.
- Token sections on the same surface keep rendering and live-updating.
