### PR TITLE
feat(discover): dynamic prediction and sports placements

### DIFF
--- a/src/features/discover/components/DiscoverSection.tsx
+++ b/src/features/discover/components/DiscoverSection.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { isMarketSurface, MarketSection } from '@/features/discover/components/MarketSection';
+import { isPredictionsSurface, PredictionsSection } from '@/features/discover/components/PredictionsSection';
 import { type SurfaceLeafNode } from '@/features/placements/surfaces/types';
 
 type DiscoverSectionsProps = {
@@ -21,6 +22,7 @@ export function DiscoverSections({ items, surfaceId }: DiscoverSectionsProps) {
 
 export const DiscoverSection = memo(function DiscoverSection({ surface, surfaceId }: { surface: SurfaceLeafNode; surfaceId: string }) {
   if (isMarketSurface(surface)) return <MarketSection surface={surface} surfaceId={surfaceId} />;
+  if (isPredictionsSurface(surface)) return <PredictionsSection surface={surface} surfaceId={surfaceId} />;
   return null;
 });
 

--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -1,0 +1,400 @@
+import { useCallback, useEffect, useMemo, type ReactNode } from 'react';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+
+import { Skeleton } from '@/components/Skeleton';
+import {
+  PREDICTION_MARKET_EVENT_CARD_BORDER_RADIUS,
+  PREDICTION_MARKET_EVENT_CARD_CAROUSEL_WIDTH,
+  PREDICTION_MARKET_EVENT_CARD_HEIGHT,
+  PREDICTION_MARKET_EVENT_CARD_WIDTH,
+  PredictionMarketEventCard,
+} from '@/features/discover/components/markets/cards/PredictionMarketEventCard';
+import {
+  getTileWidgetTokenIds,
+  PREDICTION_MARKET_TILE_CARD_BORDER_RADIUS,
+  PREDICTION_MARKET_TILE_CARD_HEIGHT,
+  PREDICTION_MARKET_TILE_CARD_WIDTH,
+  PredictionMarketTileCard,
+} from '@/features/discover/components/markets/cards/PredictionMarketTileCard';
+import { getRenderedHeaderCount, renderSectionLayout } from '@/features/discover/components/SectionLayout';
+import {
+  type PlacementBackedSurfaceLeafWithDisplay,
+  type SectionDescriptor,
+  type SurfaceLeafWithDisplay,
+} from '@/features/discover/types/sectionLayout';
+import {
+  getSportsSurfaceIntent,
+  selectSportsEventsForIntent,
+  type SportsSurfaceIntent,
+} from '@/features/discover/utils/sportsSurfaceIntent';
+import { usePredictionsPlacement, type PredictionPlacementItem } from '@/features/placements/stores/derived/predictionsPlacementStore';
+import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
+import { isEventCardDisplay, PREDICTION_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
+import { useIsDiscoverSurfacePlacementPending } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
+import { type Display, type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { LeagueIcon } from '@/features/polymarket/components/league-icon/LeagueIcon';
+import { LiveSectionIndicator } from '@/features/polymarket/components/LiveSectionIndicator';
+import {
+  getPolymarketEventsListTokenIds,
+  HEIGHT as POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
+  PolymarketEventsListItem,
+  PREDICTION_CARD_BORDER_RADIUS,
+} from '@/features/polymarket/components/polymarket-events-list/PolymarketEventsListItem';
+import { getSportsEventRowTokenIds } from '@/features/polymarket/hooks/useSportsEventContent';
+import { usePolymarketSportsEventsStore } from '@/features/polymarket/stores/polymarketSportsEventsStore';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { navigateToPolymarketEvent } from '@/features/polymarket/utils/navigateToPolymarket';
+import { logger } from '@/logger';
+import Routes from '@/navigation/routesNames';
+import { addSubscribedTokens, removeSubscribedTokens, useLiveTokensStore } from '@/state/liveTokens/liveTokensStore';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+
+type PredictionsDisplay = (typeof PREDICTION_DISPLAY_VALUES)[number];
+
+const PREDICTION_TILE_WIDTH = Math.round((DEVICE_WIDTH - 20 * 2 - 8) / 2);
+const PREDICTION_TILE_SKELETON = {
+  borderRadius: PREDICTION_CARD_BORDER_RADIUS,
+  height: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
+  width: PREDICTION_TILE_WIDTH,
+};
+const PREDICTION_WIDGET_SKELETON = {
+  borderRadius: PREDICTION_MARKET_TILE_CARD_BORDER_RADIUS,
+  height: PREDICTION_MARKET_TILE_CARD_HEIGHT,
+  width: PREDICTION_MARKET_TILE_CARD_WIDTH,
+};
+const PREDICTION_EVENT_CARD_SKELETON = {
+  borderRadius: PREDICTION_MARKET_EVENT_CARD_BORDER_RADIUS,
+  height: PREDICTION_MARKET_EVENT_CARD_HEIGHT,
+  width: PREDICTION_MARKET_EVENT_CARD_WIDTH,
+};
+const PREDICTION_EVENT_CAROUSEL_CARD_SKELETON = {
+  borderRadius: PREDICTION_MARKET_EVENT_CARD_BORDER_RADIUS,
+  height: PREDICTION_MARKET_EVENT_CARD_HEIGHT,
+  width: PREDICTION_MARKET_EVENT_CARD_CAROUSEL_WIDTH,
+};
+const renderPredictionEventCardList = renderEventCardList(false);
+const renderPredictionEventCardListWithoutLeagueHeader = renderEventCardList(true);
+const renderPredictionEventCardSized = renderEventCardSized(false);
+const renderPredictionEventCardSizedWithoutLeagueHeader = renderEventCardSized(true);
+
+const LIVE_INDICATOR_HEADER_GAP = 10;
+const HEADER_ACCESSORY_GAP = 4;
+
+type PredictionSkeletonConfig = {
+  borderRadius: number;
+  height: number;
+  width: number;
+};
+
+const PREDICTIONS_SECTION_DESCRIPTORS = {
+  'prediction_tile.carousel': {
+    layout: 'carousel',
+    itemHeight: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
+    itemWidth: PREDICTION_TILE_WIDTH,
+    renderItem: renderPredictionTile,
+    renderSkeleton: () => renderPredictionSkeleton(PREDICTION_TILE_SKELETON),
+  },
+  'prediction_tile.grid': {
+    layout: 'grid',
+    itemHeight: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
+    renderItem: renderPredictionGridTile,
+    renderSkeleton: () => renderPredictionSkeleton(PREDICTION_TILE_SKELETON),
+  },
+  'prediction_tile_widget.carousel': {
+    layout: 'carousel',
+    itemHeight: PREDICTION_MARKET_TILE_CARD_HEIGHT,
+    itemVerticalBleed: 28,
+    itemWidth: PREDICTION_MARKET_TILE_CARD_WIDTH,
+    renderItem: renderPredictionWidget,
+    renderSkeleton: () => renderPredictionSkeleton(PREDICTION_WIDGET_SKELETON),
+  },
+  'prediction_event_card.carousel': {
+    layout: 'carousel',
+    itemHeight: PREDICTION_MARKET_EVENT_CARD_HEIGHT,
+    itemWidth: PREDICTION_MARKET_EVENT_CARD_CAROUSEL_WIDTH,
+    renderItem: renderPredictionEventCardSized,
+    renderSkeleton: () => renderPredictionSkeleton(PREDICTION_EVENT_CAROUSEL_CARD_SKELETON),
+    singleItemWidth: PREDICTION_MARKET_EVENT_CARD_WIDTH,
+  },
+  'prediction_event_card.list': {
+    layout: 'list',
+    renderItem: renderPredictionEventCardList,
+    renderSkeleton: () => renderPredictionSkeleton(PREDICTION_EVENT_CARD_SKELETON),
+  },
+} satisfies Record<PredictionsDisplay, SectionDescriptor<PredictionPlacementItem>>;
+
+export function isPredictionsSurface(surface: SurfaceLeaf): surface is SurfaceLeafWithDisplay<PredictionsDisplay> {
+  return (PREDICTION_DISPLAY_VALUES as readonly string[]).includes(surface.display);
+}
+
+export function PredictionsSection({ surface, surfaceId }: { surface: SurfaceLeafWithDisplay<PredictionsDisplay>; surfaceId: string }) {
+  const sportsIntent = useMemo(() => getSportsSurfaceIntent(surface), [surface]);
+
+  if (!hasPlacement(surface)) {
+    if (sportsIntent) return <SportsQuerySection sportsIntent={sportsIntent} surface={surface} />;
+    return unsupportedUnplacedPredictionSurface(surface, surfaceId);
+  }
+
+  // Only route to the sports section when there's a real sports intent — otherwise it would
+  // mount, run its placement hooks/subscriptions, then immediately delegate, double-mounting.
+  if (isEventCardDisplay(surface.display) && sportsIntent) {
+    return <SportsEventPlacementSection sportsIntent={sportsIntent} surface={surface} />;
+  }
+
+  return <PredictionsPlacementSection surface={surface} />;
+}
+
+function useIsPredictionPlacementPending(surface: PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay>): boolean {
+  const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
+  const isLoadingPlacementSource = usePlacementsV2Store(state => {
+    if (state.getPlacement(surface.placement) !== undefined) return false;
+    return state.getStatus('isInitialLoad') || state.getStatus('isIdle') || state.getStatus('isLoading');
+  });
+  return isPendingSurfacePlacement || isLoadingPlacementSource;
+}
+
+/**
+ * Returns the token-id extractor that matches what the given display actually renders,
+ * so the section subscribes the SAME ids the cards show. Each branch points at the selector
+ * the renderer exports, never a re-derived copy.
+ */
+function getDisplayTokenIdExtractor(display: PredictionsDisplay): (event: PolymarketEvent) => string[] {
+  switch (display) {
+    case 'prediction_event_card.carousel':
+    case 'prediction_event_card.list':
+      // Event card renders the away/home line + moneyline cells from getSportsEventRows.
+      return getSportsEventRowTokenIds;
+    case 'prediction_tile_widget.carousel':
+      // Tile widget renders outcome pills from getOutcomeRows.
+      return getTileWidgetTokenIds;
+    case 'prediction_tile.carousel':
+    case 'prediction_tile.grid':
+      // Tile renders via PolymarketEventsListItem's outcome selection.
+      return getPolymarketEventsListTokenIds;
+  }
+}
+
+function usePredictionTokenSubscription({
+  display,
+  items,
+  limit,
+}: {
+  display: PredictionsDisplay;
+  items: PredictionPlacementItem[];
+  limit: number | undefined;
+}) {
+  // List displays render the full unsliced data (expandable via ShowMore), so subscribe all
+  // items. Carousel/grid slice to surface.limit, so subscribe only the capped slice.
+  const isListDisplay = PREDICTIONS_SECTION_DESCRIPTORS[display].layout === 'list';
+  const renderedItems = useMemo(
+    () => (isListDisplay || typeof limit !== 'number' ? items : items.slice(0, limit)),
+    [isListDisplay, items, limit]
+  );
+
+  useEffect(() => {
+    const extractTokenIds = getDisplayTokenIdExtractor(display);
+    const tokenIds = renderedItems.flatMap(item => extractTokenIds(item.event));
+    const uniqueTokenIds = Array.from(new Set(tokenIds));
+    if (uniqueTokenIds.length === 0) return;
+
+    addSubscribedTokens({ route: Routes.DISCOVER_SCREEN, tokenIds: uniqueTokenIds });
+    useLiveTokensStore.getState().fetch(undefined, { force: true });
+
+    return () => {
+      removeSubscribedTokens({ route: Routes.DISCOVER_SCREEN, tokenIds: uniqueTokenIds });
+    };
+  }, [display, renderedItems]);
+}
+
+function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay> }) {
+  const result = usePredictionsPlacement(surface.placement);
+  const isPlacementPending = useIsPredictionPlacementPending(surface);
+  const descriptor = PREDICTIONS_SECTION_DESCRIPTORS[surface.display];
+
+  usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
+
+  return renderSectionLayout({
+    data: result.items,
+    descriptor,
+    loading: result.isLoading || isPlacementPending,
+    onPressSeeAll: undefined,
+    surface,
+  });
+}
+
+function SportsEventPlacementSection({
+  sportsIntent,
+  surface,
+}: {
+  sportsIntent: SportsSurfaceIntent;
+  surface: PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay>;
+}) {
+  const isPlacementPending = useIsPredictionPlacementPending(surface);
+  const result = usePredictionsPlacement(surface.placement);
+  const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
+
+  usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
+
+  // Header count comes from the curated placement items the layout actually renders (list shows
+  // the expandable full count; carousel/grid cap at surface.limit), not the live sports store.
+  const headerCount = getRenderedHeaderCount({ descriptor, itemCount: result.items.length, limit: surface.limit });
+  const { headerCaret, leadingAccessory } = getSportsHeaderProps(sportsIntent, surface);
+
+  return renderSectionLayout({
+    data: result.items,
+    descriptor,
+    headerCaret,
+    headerCount,
+    leadingAccessory,
+    loading: result.isLoading || isPlacementPending,
+    onPressSeeAll: undefined,
+    surface,
+  });
+}
+
+function SportsQuerySection({
+  sportsIntent,
+  surface,
+}: {
+  sportsIntent: SportsSurfaceIntent;
+  surface: SurfaceLeafWithDisplay<PredictionsDisplay>;
+}) {
+  const events = usePolymarketSportsEventsStore(state => state.getData());
+  const isLoading = usePolymarketSportsEventsStore(state => state.enabled && (state.getStatus('isLoading') || state.getStatus('isIdle')));
+  const items = useMemo<PredictionPlacementItem[]>(() => {
+    if (!events) return [];
+    const selectedEvents = selectSportsEventsForIntent(events, sportsIntent);
+    if (!selectedEvents.length) return [];
+    return selectedEvents.map(event => ({ id: event.id, event }));
+  }, [events, sportsIntent]);
+  const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
+  const headerCount = getRenderedHeaderCount({ descriptor, itemCount: items.length, limit: surface.limit });
+
+  usePredictionTokenSubscription({ display: surface.display, items, limit: surface.limit });
+
+  const { headerCaret, leadingAccessory } = getSportsHeaderProps(sportsIntent, surface);
+
+  return renderSectionLayout({
+    data: items,
+    descriptor,
+    headerCaret,
+    headerCount,
+    leadingAccessory,
+    loading: isLoading,
+    onPressSeeAll: undefined,
+    surface,
+  });
+}
+
+function getSportsHeaderProps(
+  sportsIntent: SportsSurfaceIntent,
+  surface: SurfaceLeaf
+): { headerCaret: boolean | undefined; leadingAccessory: ReactNode } {
+  if ('status' in sportsIntent) {
+    // Live section: always shows live indicator, never shows caret
+    return {
+      headerCaret: false,
+      leadingAccessory: <LiveSectionIndicator style={styles.liveHeaderIndicator} />,
+    };
+  }
+  if ('leagueId' in sportsIntent) {
+    // League section: shows league icon, caret based on destination
+    return {
+      headerCaret: surface.destination !== null,
+      leadingAccessory: <LeagueIcon leagueId={sportsIntent.leagueId} size={28} />,
+    };
+  }
+  // Today/other bucket section: no leading accessory, caret based on destination
+  return {
+    headerCaret: surface.destination !== null,
+    leadingAccessory: undefined,
+  };
+}
+
+function unsupportedUnplacedPredictionSurface(surface: SurfaceLeafWithDisplay<PredictionsDisplay>, surfaceId: string) {
+  logger.warn('[PredictionsSection]: unsupported unplaced prediction surface', {
+    display: surface.display,
+    sectionId: surface.id,
+    surfaceId,
+  });
+  return null;
+}
+
+function hasPlacement<TDisplay extends Display>(
+  surface: SurfaceLeafWithDisplay<TDisplay>
+): surface is PlacementBackedSurfaceLeafWithDisplay<TDisplay> {
+  return typeof surface.placement === 'string' && surface.placement.length > 0;
+}
+
+function renderPredictionTile(item: PredictionPlacementItem) {
+  return <PredictionListItem item={item} style={styles.predictionTile} />;
+}
+
+function renderPredictionGridTile(item: PredictionPlacementItem, width: number) {
+  return <PredictionListItem item={item} style={{ height: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT, width }} />;
+}
+
+function PredictionListItem({ item, style }: { item: PredictionPlacementItem; style: StyleProp<ViewStyle> }) {
+  const onPress = useCallback(() => {
+    navigateToPolymarketEvent({ event: item.event, eventId: item.event.id });
+  }, [item.event]);
+
+  return <PolymarketEventsListItem event={item.event} onPress={onPress} shouldActivateOnStart={false} style={style} />;
+}
+
+function renderPredictionSkeleton({ borderRadius, height, width }: PredictionSkeletonConfig) {
+  return <Skeleton borderRadius={borderRadius} height={height} width={width} />;
+}
+
+function renderPredictionWidget(item: PredictionPlacementItem) {
+  return <PredictionMarketTileCard event={item.event} />;
+}
+
+function getSportsEventSectionDescriptor(
+  surface: SurfaceLeafWithDisplay<PredictionsDisplay>,
+  intent: SportsSurfaceIntent | null
+): SectionDescriptor<PredictionPlacementItem> {
+  const display = surface.display;
+  const shouldHideLeagueHeader = intent !== null && 'leagueId' in intent;
+
+  if (!shouldHideLeagueHeader) return PREDICTIONS_SECTION_DESCRIPTORS[display];
+
+  switch (display) {
+    case 'prediction_event_card.carousel':
+      return {
+        ...PREDICTIONS_SECTION_DESCRIPTORS[display],
+        renderItem: renderPredictionEventCardSizedWithoutLeagueHeader,
+      };
+    case 'prediction_event_card.list':
+      return {
+        ...PREDICTIONS_SECTION_DESCRIPTORS[display],
+        renderItem: renderPredictionEventCardListWithoutLeagueHeader,
+      };
+    case 'prediction_tile.carousel':
+    case 'prediction_tile.grid':
+    case 'prediction_tile_widget.carousel':
+      return PREDICTIONS_SECTION_DESCRIPTORS[display];
+  }
+}
+
+function renderEventCardList(hideLeagueHeader: boolean) {
+  return function render(item: PredictionPlacementItem): ReactNode {
+    return <PredictionMarketEventCard event={item.event} hideLeagueHeader={hideLeagueHeader} />;
+  };
+}
+
+function renderEventCardSized(hideLeagueHeader: boolean) {
+  return function render(item: PredictionPlacementItem, width: number): ReactNode {
+    return <PredictionMarketEventCard event={item.event} hideLeagueHeader={hideLeagueHeader} width={width} />;
+  };
+}
+
+const styles = StyleSheet.create({
+  predictionTile: {
+    height: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
+    width: PREDICTION_TILE_WIDTH,
+  },
+  liveHeaderIndicator: {
+    marginRight: LIVE_INDICATOR_HEADER_GAP - HEADER_ACCESSORY_GAP,
+  },
+});

--- a/src/features/discover/components/SectionLayout.tsx
+++ b/src/features/discover/components/SectionLayout.tsx
@@ -1,7 +1,7 @@
 import { MarketCarousel } from '@/features/discover/components/markets/layouts/MarketCarousel';
 import { MarketGrid } from '@/features/discover/components/markets/layouts/MarketGrid';
 import { MarketList } from '@/features/discover/components/markets/layouts/MarketList';
-import { type SectionLayoutProps } from '@/features/discover/types/sectionLayout';
+import { type SectionDescriptor, type SectionLayoutProps } from '@/features/discover/types/sectionLayout';
 import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
 import { type PlacementItemV2 as PlacementItem } from '@/features/placements/types';
 import * as i18n from '@/languages';
@@ -14,10 +14,30 @@ export function resolveSectionTitle(surface: Pick<SurfaceLeaf, 'id' | 'label'>):
   return i18n.t(`discover.sections.${surface.id}`, { defaultValue: surface.label || surface.id });
 }
 
+/**
+ * Header count that matches what the layout actually renders: list layouts show the full
+ * (expandable) item count; carousel/grid cap at `limit` exactly as renderSectionLayout slices.
+ * Returns undefined for an empty count so the header omits the badge.
+ */
+export function getRenderedHeaderCount<T extends PlacementItem>({
+  descriptor,
+  itemCount,
+  limit,
+}: {
+  descriptor: SectionDescriptor<T>;
+  itemCount: number;
+  limit: number | undefined;
+}): number | undefined {
+  const count = descriptor.layout === 'list' ? itemCount : limit !== undefined ? Math.min(itemCount, limit) : itemCount;
+  return count > 0 ? count : undefined;
+}
+
 export function renderSectionLayout<T extends PlacementItem>({
   data,
   descriptor,
+  headerCaret,
   headerCount,
+  leadingAccessory,
   loading,
   onPressSeeAll,
   surface,
@@ -25,12 +45,12 @@ export function renderSectionLayout<T extends PlacementItem>({
   const hasLimit = surface.limit !== undefined;
   const renderedData = hasLimit ? data.slice(0, surface.limit) : data;
   const skeletonCount = hasLimit ? surface.limit : undefined;
-  const showHeaderCaret = 'showHeaderCaret' in descriptor ? descriptor.showHeaderCaret?.(surface) : undefined;
+  const descriptorHeaderCaret = 'showHeaderCaret' in descriptor ? descriptor.showHeaderCaret?.(surface) : undefined;
+  const showHeaderCaret = headerCaret ?? descriptorHeaderCaret;
   const title = resolveSectionTitle(surface);
-
   const sectionProps = {
     headerCount,
-    leadingAccessory: undefined,
+    leadingAccessory,
     loading,
     onPress: onPressSeeAll,
     title,

--- a/src/features/discover/components/markets/cards/PredictionMarketEventCard.tsx
+++ b/src/features/discover/components/markets/cards/PredictionMarketEventCard.tsx
@@ -1,0 +1,523 @@
+import { memo, useCallback, useMemo } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
+import { globalColors, Text, TextShadow, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
+import { LeagueIcon } from '@/features/polymarket/components/league-icon/LeagueIcon';
+import { TeamLogo } from '@/features/polymarket/components/TeamLogo';
+import { usePolymarketSportsBetCellPress } from '@/features/polymarket/hooks/usePolymarketSportsBetCellPress';
+import { useSportsEventBets, useSportsEventStatus, type SportsEventRows } from '@/features/polymarket/hooks/useSportsEventContent';
+import { getLeagueId, SPORT_LEAGUES, type LeagueId } from '@/features/polymarket/leagues';
+import { type PolymarketTeamInfo } from '@/features/polymarket/types';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { formatOdds, type BetCellData } from '@/features/polymarket/utils/sportsEventBetData';
+import { getSportsEventOutcomeCellColor } from '@/features/polymarket/utils/sportsEventOutcome';
+import { getDiscoverSportsEventTeamLabels } from '@/features/polymarket/utils/sportsEventTeamLabels';
+import { getTeamDisplayInfo } from '@/features/polymarket/utils/sportsEventTeams';
+import { opacity } from '@/framework/ui/utils/opacity';
+import * as i18n from '@/languages';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { getPolymarketTokenId } from '@/state/liveTokens/polymarketAdapter';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+
+export const PREDICTION_MARKET_EVENT_CARD_WIDTH = Math.min(384, DEVICE_WIDTH - 32);
+export const PREDICTION_MARKET_EVENT_CARD_CAROUSEL_WIDTH = Math.min(356, DEVICE_WIDTH - 64);
+export const PREDICTION_MARKET_EVENT_CARD_HEIGHT = 162;
+export const PREDICTION_MARKET_EVENT_CARD_BORDER_RADIUS = 24;
+
+const CARD_BORDER_GRADIENT_CONFIG = {
+  start: { x: 0, y: 0 },
+  end: { x: 1, y: 1 },
+  locations: [0.02, 0.82, 1] as const,
+};
+const CARD_FILL_GRADIENT_CONFIG = {
+  start: { x: 0, y: 0 },
+  end: { x: 1, y: 1 },
+  locations: [0.17824, 0.58889] as const,
+};
+const LINE_CELL_HEIGHT = 42;
+const LINE_CELL_WIDTH = 76;
+const MONEYLINE_CELL_WIDTH = 62;
+const BET_CELL_BORDER_RADIUS = 15;
+const TEAM_LOGO_SIZE = 36;
+const BET_CELLS_OVERLAY_TOP = 51;
+const BET_CELLS_OVERLAY_TOP_NO_LEAGUE_HEADER = 47;
+
+type PredictionMarketEventCardProps = {
+  event: PolymarketEvent;
+  hideLeagueHeader?: boolean;
+  width?: number;
+};
+
+export const PredictionMarketEventCard = memo(function PredictionMarketEventCard({
+  event,
+  hideLeagueHeader = false,
+  width = PREDICTION_MARKET_EVENT_CARD_WIDTH,
+}: PredictionMarketEventCardProps) {
+  const { isDarkMode } = useColorMode();
+  const { rows } = useSportsEventBets(event);
+  const { gameStatusTitle, isLive, scores } = useSportsEventStatus(event);
+  const { labels: upstreamTeamLabels } = useMemo(() => getTeamDisplayInfo(event), [event]);
+  const teamLabels = useMemo(() => getDiscoverSportsEventTeamLabels(event, upstreamTeamLabels), [event, upstreamTeamLabels]);
+  const leagueId = useMemo(() => getLeagueId(event.slug) ?? getLeagueId(event.ticker ?? '') ?? getLeagueIdFromTags(event.tags), [event]);
+  const eventAccentColor = useMemo(() => getEventAccentColor({ event, isDarkMode, leagueId }), [event, isDarkMode, leagueId]);
+  const liveIndicatorColor = useForegroundColor('red');
+  const cardBorderGradientColors = getPredictionEventCardBorderGradientColors(eventAccentColor, isDarkMode);
+  const cardGradientColors = getPredictionEventCardGradientColors(eventAccentColor, isDarkMode);
+  const handlePress = useCallback(() => {
+    Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, { event, eventId: event.id });
+  }, [event]);
+
+  return (
+    <View style={[styles.container, { width }]}>
+      {Platform.OS === 'android' ? <WidgetBetCellsOverlay event={event} hideLeagueHeader={hideLeagueHeader} rows={rows} /> : null}
+      <ButtonPressAnimation onPress={handlePress} scaleTo={0.96} style={styles.flex} wrapperStyle={styles.flex}>
+        <GradientBorderView
+          backgroundColor={isDarkMode ? globalColors.grey100 : globalColors.white100}
+          borderGradientColors={cardBorderGradientColors}
+          borderRadius={PREDICTION_MARKET_EVENT_CARD_BORDER_RADIUS}
+          borderWidth={2}
+          end={CARD_BORDER_GRADIENT_CONFIG.end}
+          locations={CARD_BORDER_GRADIENT_CONFIG.locations}
+          start={CARD_BORDER_GRADIENT_CONFIG.start}
+          style={styles.card}
+        >
+          <LinearGradient
+            colors={cardGradientColors}
+            end={CARD_FILL_GRADIENT_CONFIG.end}
+            locations={CARD_FILL_GRADIENT_CONFIG.locations}
+            pointerEvents="none"
+            start={CARD_FILL_GRADIENT_CONFIG.start}
+            style={StyleSheet.absoluteFill}
+          />
+          <View style={styles.header}>
+            {hideLeagueHeader ? (
+              <View />
+            ) : (
+              <View style={styles.league}>
+                <LeagueIcon eventSlug={event.slug} size={20} />
+                <Text align="left" color="label" size="17pt" style={styles.compactText} weight="heavy">
+                  {getLeagueLabel(leagueId)}
+                </Text>
+              </View>
+            )}
+            <View style={styles.status}>
+              {gameStatusTitle ? (
+                <Text align="right" color="labelTertiary" size="15pt" style={styles.statusText} weight="bold">
+                  {gameStatusTitle.toUpperCase()}
+                </Text>
+              ) : null}
+              {isLive ? (
+                <TextShadow blur={14} shadowOpacity={0.25}>
+                  <Text align="right" color={{ custom: liveIndicatorColor }} size="15pt" style={styles.liveText} weight="heavy">
+                    {i18n.t(i18n.l.predictions.sports.live).toUpperCase()}
+                  </Text>
+                </TextShadow>
+              ) : null}
+            </View>
+          </View>
+          <Separator />
+          <TeamRow
+            event={event}
+            label={rows.away.label ?? teamLabels[0]}
+            score={scores?.teamAScore}
+            team={event.teams?.[0]}
+            lineBet={rows.away.line}
+            moneylineBet={rows.away.moneyline}
+            compact={rows.away.isFallback}
+            interactiveBetCells={Platform.OS === 'ios'}
+          />
+          <InsetSeparator />
+          <TeamRow
+            event={event}
+            label={rows.home.label ?? teamLabels[1]}
+            score={scores?.teamBScore}
+            team={event.teams?.[1]}
+            lineBet={rows.home.line}
+            moneylineBet={rows.home.moneyline}
+            compact={rows.home.isFallback}
+            interactiveBetCells={Platform.OS === 'ios'}
+          />
+        </GradientBorderView>
+      </ButtonPressAnimation>
+    </View>
+  );
+});
+
+function getPredictionEventCardBorderGradientColors(eventAccentColor: string, isDarkMode: boolean) {
+  return isDarkMode
+    ? ([opacity(eventAccentColor, 0.54), opacity(eventAccentColor, 0.12), opacity(eventAccentColor, 0)] as const)
+    : ([opacity(eventAccentColor, 0.28), opacity(eventAccentColor, 0.1), opacity(eventAccentColor, 0.04)] as const);
+}
+
+function getPredictionEventCardGradientColors(eventAccentColor: string, isDarkMode: boolean) {
+  return isDarkMode
+    ? ([opacity(eventAccentColor, 0.18), opacity(eventAccentColor, 0)] as const)
+    : ([opacity(eventAccentColor, 0.12), opacity(eventAccentColor, 0.02)] as const);
+}
+
+const TeamRow = memo(function TeamRow({
+  event,
+  label,
+  lineBet,
+  moneylineBet,
+  compact,
+  score,
+  team,
+  interactiveBetCells = true,
+}: {
+  event: PolymarketEvent;
+  compact?: boolean;
+  interactiveBetCells?: boolean;
+  label: string;
+  lineBet?: BetCellData;
+  moneylineBet?: BetCellData;
+  score?: string;
+  team?: PolymarketTeamInfo;
+}) {
+  return (
+    <View style={styles.teamRow}>
+      <View style={styles.teamInfo}>
+        {team ? <TeamLogo team={team} size={TEAM_LOGO_SIZE} borderRadius={2} /> : null}
+        <Text align="left" color="label" numberOfLines={1} size="17pt" style={styles.teamName} weight="bold">
+          {label}
+        </Text>
+      </View>
+      <View style={styles.betInfo}>
+        {score || !compact ? (
+          <Text align="right" color="label" size="17pt" style={styles.score} weight="heavy">
+            {score ?? ''}
+          </Text>
+        ) : null}
+        <TeamBetCells event={event} compact={compact} interactive={interactiveBetCells} lineBet={lineBet} moneylineBet={moneylineBet} />
+      </View>
+    </View>
+  );
+});
+
+const WidgetBetCellsOverlay = memo(function WidgetBetCellsOverlay({
+  event,
+  hideLeagueHeader,
+  rows,
+}: {
+  event: PolymarketEvent;
+  hideLeagueHeader: boolean;
+  rows: SportsEventRows;
+}) {
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[styles.betCellsOverlay, { top: hideLeagueHeader ? BET_CELLS_OVERLAY_TOP_NO_LEAGUE_HEADER : BET_CELLS_OVERLAY_TOP }]}
+    >
+      <TeamBetCells event={event} compact={rows.away.isFallback} lineBet={rows.away.line} moneylineBet={rows.away.moneyline} />
+      <TeamBetCells event={event} compact={rows.home.isFallback} lineBet={rows.home.line} moneylineBet={rows.home.moneyline} />
+    </View>
+  );
+});
+
+const TeamBetCells = memo(function TeamBetCells({
+  event,
+  compact,
+  interactive = true,
+  lineBet,
+  moneylineBet,
+}: {
+  event: PolymarketEvent;
+  compact?: boolean;
+  interactive?: boolean;
+  lineBet?: BetCellData;
+  moneylineBet?: BetCellData;
+}) {
+  const { isDarkMode } = useColorMode();
+  const lineColor = getSportsEventOutcomeCellColor(event.markets, lineBet?.outcomeTokenId, isDarkMode, event.teams);
+  const moneylineColor = getSportsEventOutcomeCellColor(event.markets, moneylineBet?.outcomeTokenId, isDarkMode, event.teams);
+
+  if (!interactive) {
+    return (
+      <View style={styles.betCells}>
+        {lineBet ? <View style={styles.lineCellButton} /> : compact ? null : <View style={styles.lineCellSpacer} />}
+        {moneylineBet ? <View style={styles.moneylineCellButton} /> : compact ? null : <View style={styles.moneylineCellSpacer} />}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.betCells}>
+      {lineBet ? (
+        <WidgetBetCell event={event} data={lineBet} backgroundColor={lineColor} variant="line" />
+      ) : compact ? null : (
+        <View style={styles.lineCellSpacer} />
+      )}
+      {moneylineBet ? (
+        <WidgetBetCell event={event} data={moneylineBet} backgroundColor={moneylineColor} variant="moneyline" />
+      ) : compact ? null : (
+        <View style={styles.moneylineCellSpacer} />
+      )}
+    </View>
+  );
+});
+
+const WidgetBetCell = memo(function WidgetBetCell({
+  backgroundColor,
+  data,
+  event,
+  variant,
+}: {
+  backgroundColor?: string;
+  data: BetCellData;
+  event: PolymarketEvent;
+  variant: 'line' | 'moneyline';
+}) {
+  const tokenId = getPolymarketTokenId(data.outcomeTokenId, 'sell');
+  const color = backgroundColor ?? '#717784';
+  const onPress = usePolymarketSportsBetCellPress({ event, outcomeTokenId: data.outcomeTokenId });
+  const isLine = variant === 'line';
+  const buttonStyle = isLine ? styles.lineCellButton : styles.moneylineCellButton;
+  const cellStyle = isLine
+    ? [styles.betCell, styles.lineCell, { backgroundColor: opacity(color, 0.22), borderColor: opacity(color, 0.12), shadowColor: color }]
+    : [styles.betCell, styles.moneylineCell, { backgroundColor: color }];
+  const oddsSize = isLine ? '15pt' : '17pt';
+
+  const content = (
+    <View style={cellStyle}>
+      {isLine ? null : <View style={styles.betCellOverlay} pointerEvents="none" />}
+      {data.label ? (
+        <Text
+          align="center"
+          color={{ custom: opacity(globalColors.white100, isLine ? 0.6 : 0.72) }}
+          numberOfLines={1}
+          size={isLine ? '13pt' : '12pt'}
+          style={styles.lineLabel}
+          weight="heavy"
+        >
+          {data.label}
+        </Text>
+      ) : null}
+      <LiveTokenText
+        align="center"
+        autoSubscriptionEnabled={false}
+        color={{ custom: globalColors.white100 }}
+        initialValue={data.odds}
+        numberOfLines={1}
+        selector={token => formatOdds(token.price)}
+        size={oddsSize}
+        style={isLine ? styles.lineOdds : styles.moneylineOdds}
+        tokenId={tokenId}
+        weight="heavy"
+      />
+    </View>
+  );
+
+  return (
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.92} style={buttonStyle}>
+      {content}
+    </ButtonPressAnimation>
+  );
+});
+
+function Separator() {
+  const separatorColor = useBackgroundColor('separatorSecondary');
+  return <View style={[styles.separator, { backgroundColor: separatorColor }]} />;
+}
+
+function InsetSeparator() {
+  const separatorColor = useBackgroundColor('separatorSecondary');
+  return (
+    <View style={styles.insetSeparator}>
+      <View style={[styles.insetSeparatorLine, { backgroundColor: separatorColor }]} />
+    </View>
+  );
+}
+
+function getLeagueLabel(leagueId: LeagueId | undefined) {
+  if (!leagueId) return '';
+  return SPORT_LEAGUES[leagueId].name;
+}
+
+function getLeagueIdFromTags(tags: PolymarketEvent['tags']): LeagueId | undefined {
+  for (const tag of tags) {
+    const leagueId = getLeagueId(tag.slug);
+    if (leagueId) return leagueId;
+  }
+}
+
+function getEventAccentColor({ event, isDarkMode, leagueId }: { event: PolymarketEvent; isDarkMode: boolean; leagueId?: LeagueId }) {
+  const leagueColor = leagueId ? SPORT_LEAGUES[leagueId].color : undefined;
+  if (leagueColor) return getColorValueForThemeWorklet(leagueColor, isDarkMode);
+  return getColorValueForThemeWorklet(event.color, isDarkMode);
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: PREDICTION_MARKET_EVENT_CARD_HEIGHT,
+    position: 'relative',
+    width: PREDICTION_MARKET_EVENT_CARD_WIDTH,
+  },
+  flex: {
+    flex: 1,
+  },
+  card: {
+    flex: 1,
+    paddingBottom: 6,
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingBottom: 12,
+    paddingHorizontal: 16,
+    paddingTop: 14,
+  },
+  league: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 6,
+  },
+  status: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 10,
+    justifyContent: 'flex-end',
+  },
+  compactText: {
+    letterSpacing: 0.37,
+    lineHeight: 18,
+  },
+  statusText: {
+    letterSpacing: 0.44,
+    lineHeight: 16,
+  },
+  liveText: {
+    letterSpacing: 0.44,
+    lineHeight: 16,
+  },
+  separator: {
+    height: 1,
+    width: '100%',
+  },
+  insetSeparator: {
+    flexDirection: 'row',
+    paddingRight: 12,
+  },
+  insetSeparatorLine: {
+    flex: 1,
+    height: 1,
+    marginLeft: 64,
+  },
+  teamRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    height: 54,
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  teamInfo: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 10,
+    minWidth: 0,
+  },
+  teamName: {
+    flexShrink: 1,
+    letterSpacing: 0.37,
+    lineHeight: 18,
+  },
+  betInfo: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 10,
+  },
+  score: {
+    letterSpacing: 0.37,
+    lineHeight: 18,
+    minWidth: 16,
+  },
+  betCells: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 6,
+  },
+  betCellsOverlay: {
+    gap: 13,
+    position: 'absolute',
+    right: 12,
+    zIndex: 1,
+  },
+  betCell: {
+    alignItems: 'center',
+    borderRadius: BET_CELL_BORDER_RADIUS,
+    borderWidth: 2,
+    height: LINE_CELL_HEIGHT,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    position: 'relative',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.28,
+    shadowRadius: 16,
+  },
+  lineCell: {
+    width: LINE_CELL_WIDTH,
+  },
+  lineCellButton: {
+    borderRadius: BET_CELL_BORDER_RADIUS,
+    height: LINE_CELL_HEIGHT,
+    width: LINE_CELL_WIDTH,
+  },
+  moneylineCell: {
+    borderColor: opacity(globalColors.white100, 0.1),
+    shadowColor: globalColors.grey100,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    width: MONEYLINE_CELL_WIDTH,
+  },
+  moneylineCellButton: {
+    borderRadius: BET_CELL_BORDER_RADIUS,
+    height: LINE_CELL_HEIGHT,
+    width: MONEYLINE_CELL_WIDTH,
+  },
+  betCellOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: opacity(globalColors.grey100, 0.3),
+    borderRadius: BET_CELL_BORDER_RADIUS,
+  },
+  lineCellSpacer: {
+    height: LINE_CELL_HEIGHT,
+    width: LINE_CELL_WIDTH,
+  },
+  moneylineCellSpacer: {
+    height: LINE_CELL_HEIGHT,
+    width: MONEYLINE_CELL_WIDTH,
+  },
+  lineLabel: {
+    left: 0,
+    letterSpacing: 0.72,
+    lineHeight: 13,
+    position: 'absolute',
+    right: 0,
+    top: 6,
+  },
+  lineOdds: {
+    bottom: 6,
+    left: 0,
+    letterSpacing: 0.36,
+    lineHeight: 16,
+    position: 'absolute',
+    right: 0,
+  },
+  moneylineOdds: {
+    letterSpacing: 0.36,
+    lineHeight: 20,
+    textShadowColor: opacity(globalColors.grey100, 0.15),
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 8,
+  },
+});

--- a/src/features/discover/components/markets/cards/PredictionMarketTileCard.tsx
+++ b/src/features/discover/components/markets/cards/PredictionMarketTileCard.tsx
@@ -1,0 +1,531 @@
+import { memo, useCallback, useMemo } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
+import ImgixImage from '@/components/images/ImgixImage';
+import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
+import { globalColors, Text, useColorMode } from '@/design-system';
+import { DOWN_ARROW, UP_ARROW } from '@/features/perps/constants';
+import { type PolymarketEvent, type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+import { getOutcomeColor } from '@/features/polymarket/utils/getMarketColor';
+import { formatOdds } from '@/features/polymarket/utils/sportsEventBetData';
+import { toPercentageWorklet } from '@/framework/core/safeMath';
+import { getPriceChangeColor, usePriceChangeColors } from '@/framework/ui/price/usePriceChangeColors';
+import { opacity } from '@/framework/ui/utils/opacity';
+import { formatNumber } from '@/helpers/strings';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { getPolymarketTokenId } from '@/state/liveTokens/polymarketAdapter';
+import { DEVICE_WIDTH } from '@/utils/deviceUtils';
+import { createOpacityPalette } from '@/worklets/colors';
+
+export const PREDICTION_MARKET_TILE_CARD_WIDTH = Math.min(300, DEVICE_WIDTH - 40);
+export const PREDICTION_MARKET_TILE_CARD_HEIGHT = Math.round(PREDICTION_MARKET_TILE_CARD_WIDTH * (16 / 15));
+export const PREDICTION_MARKET_TILE_CARD_BORDER_RADIUS = 24;
+
+const OUTCOME_ROW_COUNT = 2;
+const LAST_TRADE_PRICE_THRESHOLDS = [0.05, 0.01];
+const CARD_FILL_GRADIENT_CONFIG = {
+  end: { x: 1, y: 1 },
+  locations: [0.17824, 0.58889] as const,
+  start: { x: 0, y: 0 },
+};
+const CARD_FILL_LIGHT_GRADIENT_CONFIG = {
+  end: { x: 1, y: 0.72 },
+  start: { x: 0, y: 0 },
+};
+const CARD_BORDER_GRADIENT_CONFIG = {
+  end: { x: 1, y: 1 },
+  locations: [0, 0.94] as const,
+  start: { x: 0, y: 0 },
+};
+const OUTCOME_ROW_GRADIENT_CONFIG = {
+  end: { x: 0.89062, y: 0.5 },
+  locations: [0, 1] as const,
+  start: { x: 0, y: 0.5 },
+};
+const OUTCOME_ROW_WIDTH = PREDICTION_MARKET_TILE_CARD_WIDTH - 24;
+const ODDS_PILL_BORDER_RADIUS = 15;
+const ASSET_ACCENT_COLORS = [
+  { color: '#F8931A', pattern: /\b(bitcoin|btc)\b/i },
+  { color: '#9CA4AD', pattern: /\b(ethereum|eth)\b/i },
+  { color: '#C0C1CC', pattern: /\b(silver|xagusd|xag)\b/i },
+  { color: '#D6A438', pattern: /\b(gold|xauusd|xau)\b/i },
+  { color: '#7A70FF', pattern: /\b(solana|sol)\b/i },
+] as const;
+
+// ============ Android Odds-Pill Overlay Geometry ============================= //
+
+const ODDS_PILL_WIDTH = 62;
+const ODDS_PILL_HEIGHT = 42;
+const BORDER_WIDTH = 2;
+const CONTENT_PADDING_BOTTOM = 12;
+const OUTCOME_ROW_HEIGHT = 58;
+const OUTCOME_ROW_GAP = 4;
+const OUTCOME_ROW_CONTENT_LEFT_PADDING = 8;
+const OUTCOME_ROW_PITCH = OUTCOME_ROW_HEIGHT + OUTCOME_ROW_GAP;
+const ODDS_PILL_OVERLAY_LEFT =
+  (PREDICTION_MARKET_TILE_CARD_WIDTH - OUTCOME_ROW_WIDTH) / 2 + BORDER_WIDTH + OUTCOME_ROW_CONTENT_LEFT_PADDING;
+const ODDS_PILL_OVERLAY_BOTTOM = 2 * BORDER_WIDTH + CONTENT_PADDING_BOTTOM + (OUTCOME_ROW_HEIGHT - 2 * BORDER_WIDTH - ODDS_PILL_HEIGHT) / 2;
+
+type PredictionMarketTileCardProps = {
+  event: PolymarketEvent;
+};
+
+type OutcomeRowData = {
+  market: PolymarketMarket;
+  outcomeIndex: number;
+  title: string;
+  initialPrice: string | number;
+  tokenId: string;
+};
+
+export const PredictionMarketTileCard = memo(function PredictionMarketTileCard({ event }: PredictionMarketTileCardProps) {
+  const { isDarkMode } = useColorMode();
+  const eventColor = useMemo(() => getTileAccentColor(event, isDarkMode), [event, isDarkMode]);
+  const rows = useMemo(() => getOutcomeRows(event), [event]);
+  const iconSource = useMemo(() => ({ uri: event.icon ?? event.image }), [event.icon, event.image]);
+  const volumeText = useMemo(() => formatNumber(String(event.volume), { useOrderSuffix: true, decimals: 1, style: '$' }), [event.volume]);
+  const priceChange = rows[0]?.market.oneDayPriceChange;
+  const priceChangeText = useMemo(() => formatPriceChange(priceChange), [priceChange]);
+  const priceChangeIsPositive = priceChange !== undefined && priceChange > 0;
+  const priceChangeColors = usePriceChangeColors();
+  const priceChangeColor =
+    priceChange === undefined ? priceChangeColors.neutral : getPriceChangeColor(String(priceChange), priceChangeColors);
+  const colorPalette = useMemo(() => createOpacityPalette(eventColor, [0, 8, 10, 16, 24]), [eventColor]);
+  const cardBorderGradientColors = useMemo(
+    () =>
+      isDarkMode
+        ? ([opacity(eventColor, 0.08), opacity(eventColor, 0)] as const)
+        : ([opacity(globalColors.white100, 0.8), opacity(globalColors.white100, 0.8)] as const),
+    [eventColor, isDarkMode]
+  );
+  const cardGradientColors = useMemo(
+    () =>
+      isDarkMode
+        ? ([colorPalette.opacity24, colorPalette.opacity0] as const)
+        : ([opacity(eventColor, 0.06), opacity(eventColor, 0)] as const),
+    [colorPalette.opacity0, colorPalette.opacity24, eventColor, isDarkMode]
+  );
+
+  const handlePress = useCallback(() => {
+    Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, { event, eventId: event.id });
+  }, [event]);
+
+  return (
+    <View style={styles.container}>
+      {Platform.OS === 'android' ? (
+        <AndroidOddsPillsOverlay event={event} eventColor={eventColor} isDarkMode={isDarkMode} rows={rows} />
+      ) : null}
+      <ButtonPressAnimation onPress={handlePress} scaleTo={0.96} style={styles.flex} wrapperStyle={styles.flex}>
+        <View style={[styles.cardShadow, !isDarkMode && styles.cardShadowLight]}>
+          <GradientBorderView
+            backgroundColor={isDarkMode ? globalColors.grey100 : opacity(globalColors.white100, 0.92)}
+            borderGradientColors={cardBorderGradientColors}
+            borderRadius={PREDICTION_MARKET_TILE_CARD_BORDER_RADIUS}
+            borderWidth={2}
+            end={CARD_BORDER_GRADIENT_CONFIG.end}
+            locations={isDarkMode ? CARD_BORDER_GRADIENT_CONFIG.locations : undefined}
+            start={CARD_BORDER_GRADIENT_CONFIG.start}
+            style={styles.card}
+          >
+            <LinearGradient
+              colors={cardGradientColors}
+              pointerEvents="none"
+              start={isDarkMode ? CARD_FILL_GRADIENT_CONFIG.start : CARD_FILL_LIGHT_GRADIENT_CONFIG.start}
+              end={isDarkMode ? CARD_FILL_GRADIENT_CONFIG.end : CARD_FILL_LIGHT_GRADIENT_CONFIG.end}
+              locations={isDarkMode ? CARD_FILL_GRADIENT_CONFIG.locations : undefined}
+              style={StyleSheet.absoluteFill}
+            />
+            <View style={styles.content}>
+              <ImgixImage enableFasterImage source={iconSource} size={42} style={styles.icon} />
+              <View style={styles.headerText}>
+                <Text align="left" color="label" numberOfLines={2} size="20pt / 135%" style={styles.title} weight="heavy">
+                  {event.title}
+                </Text>
+                <View style={styles.statsRow}>
+                  <Text align="left" color="labelTertiary" size="15pt" weight="bold">
+                    {`VOL ${volumeText}`}
+                  </Text>
+                  {priceChangeText ? (
+                    <View style={styles.priceChangeRow}>
+                      <Text align="left" color={{ custom: priceChangeColor }} size="icon 11px" weight="heavy">
+                        {priceChangeIsPositive ? UP_ARROW : DOWN_ARROW}
+                      </Text>
+                      <Text align="left" color={{ custom: priceChangeColor }} size="15pt" weight="bold">
+                        {priceChangeText}
+                      </Text>
+                    </View>
+                  ) : null}
+                </View>
+              </View>
+              <View style={styles.outcomes}>
+                {rows.map(row => (
+                  <OutcomeRow
+                    event={event}
+                    eventColor={eventColor}
+                    isDarkMode={isDarkMode}
+                    key={`${row.market.id}:${row.outcomeIndex}`}
+                    row={row}
+                  />
+                ))}
+              </View>
+            </View>
+          </GradientBorderView>
+        </View>
+      </ButtonPressAnimation>
+    </View>
+  );
+});
+
+const OutcomeRow = memo(function OutcomeRow({
+  event,
+  eventColor,
+  isDarkMode,
+  row,
+}: {
+  event: PolymarketEvent;
+  eventColor: string;
+  isDarkMode: boolean;
+  row: OutcomeRowData;
+}) {
+  return (
+    <GradientBorderView
+      borderGradientColors={
+        isDarkMode ? ([opacity(eventColor, 0.08), opacity(eventColor, 0)] as const) : ([eventColor, eventColor] as const)
+      }
+      borderBottomLeftRadius={22}
+      borderBottomRightRadius={20}
+      borderTopLeftRadius={22}
+      borderTopRightRadius={20}
+      borderWidth={2}
+      end={OUTCOME_ROW_GRADIENT_CONFIG.end}
+      locations={isDarkMode ? OUTCOME_ROW_GRADIENT_CONFIG.locations : undefined}
+      start={OUTCOME_ROW_GRADIENT_CONFIG.start}
+      style={styles.outcomeRowFrame}
+    >
+      <LinearGradient
+        colors={[opacity(eventColor, 0.1), opacity(eventColor, 0)]}
+        pointerEvents="none"
+        start={OUTCOME_ROW_GRADIENT_CONFIG.start}
+        end={OUTCOME_ROW_GRADIENT_CONFIG.end}
+        locations={isDarkMode ? OUTCOME_ROW_GRADIENT_CONFIG.locations : undefined}
+        style={StyleSheet.absoluteFill}
+      />
+      <View style={styles.outcomeRowContent}>
+        {Platform.OS === 'android' ? (
+          <View style={styles.oddsButton} />
+        ) : (
+          <OutcomeOddsPill event={event} eventColor={eventColor} isDarkMode={isDarkMode} row={row} />
+        )}
+        <Text align="left" color="label" numberOfLines={1} size="17pt" style={styles.outcomeTitle} weight="bold">
+          {row.title}
+        </Text>
+      </View>
+    </GradientBorderView>
+  );
+});
+
+const OutcomeOddsPill = memo(function OutcomeOddsPill({
+  event,
+  eventColor,
+  isDarkMode,
+  row,
+}: {
+  event: PolymarketEvent;
+  eventColor: string;
+  isDarkMode: boolean;
+  row: OutcomeRowData;
+}) {
+  const outcomeColor = getOutcomeColor({
+    market: row.market,
+    outcome: row.market.outcomes[row.outcomeIndex] ?? row.title,
+    outcomeIndex: row.outcomeIndex,
+    isDarkMode,
+    teams: event.teams,
+  });
+
+  const onPress = useCallback(() => {
+    Navigation.handleAction(Routes.POLYMARKET_NEW_POSITION_SHEET, {
+      market: row.market,
+      event,
+      outcomeIndex: row.outcomeIndex,
+      outcomeColor,
+      fromRoute: Routes.POLYMARKET_BROWSE_EVENTS_SCREEN,
+    });
+  }, [event, outcomeColor, row.market, row.outcomeIndex]);
+
+  return (
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.92} style={styles.oddsButton}>
+      <View
+        style={[
+          styles.oddsPill,
+          {
+            backgroundColor: eventColor,
+            borderColor: opacity(isDarkMode ? globalColors.white100 : globalColors.grey100, 0.1),
+            shadowColor: isDarkMode ? eventColor : globalColors.grey100,
+            shadowOpacity: isDarkMode ? 0.3 : 0.06,
+          },
+        ]}
+      >
+        <View
+          style={[styles.oddsPillOverlay, { backgroundColor: opacity(globalColors.grey100, isDarkMode ? 0.3 : 0.1) }]}
+          pointerEvents="none"
+        />
+        <LiveTokenText
+          align="center"
+          autoSubscriptionEnabled={false}
+          color={{ custom: globalColors.white100 }}
+          initialValue={formatOdds(row.initialPrice)}
+          numberOfLines={1}
+          selector={token => formatOdds(token.price)}
+          size="17pt"
+          tokenId={row.tokenId}
+          weight="heavy"
+        />
+      </View>
+    </ButtonPressAnimation>
+  );
+});
+
+const AndroidOddsPillsOverlay = memo(function AndroidOddsPillsOverlay({
+  event,
+  eventColor,
+  isDarkMode,
+  rows,
+}: {
+  event: PolymarketEvent;
+  eventColor: string;
+  isDarkMode: boolean;
+  rows: OutcomeRowData[];
+}) {
+  return (
+    <View pointerEvents="box-none" style={styles.oddsPillsOverlay}>
+      {rows.map((row, index) => (
+        <View
+          key={`${row.market.id}:${row.outcomeIndex}`}
+          pointerEvents="box-none"
+          style={[styles.oddsPillSlot, { bottom: ODDS_PILL_OVERLAY_BOTTOM + (rows.length - 1 - index) * OUTCOME_ROW_PITCH }]}
+        >
+          <OutcomeOddsPill event={event} eventColor={eventColor} isDarkMode={isDarkMode} row={row} />
+        </View>
+      ))}
+    </View>
+  );
+});
+
+/**
+ * Token ids for the outcome pills this tile-widget renders. Derived from the SAME
+ * getOutcomeRows resolution the card uses, so subscribed == rendered by construction.
+ */
+export function getTileWidgetTokenIds(event: PolymarketEvent): string[] {
+  const tokenIds = getOutcomeRows(event).map(row => row.tokenId);
+  return Array.from(new Set(tokenIds));
+}
+
+function getOutcomeRows(event: PolymarketEvent): OutcomeRowData[] {
+  const activeMarkets = event.markets.filter(market => market.active && !market.closed);
+  const firstMarket = activeMarkets[0];
+  if (!firstMarket) return [];
+
+  if (activeMarkets.length === 1) {
+    return firstMarket.outcomes
+      .slice(0, OUTCOME_ROW_COUNT)
+      .map((outcome, outcomeIndex) =>
+        buildOutcomeRow({
+          market: firstMarket,
+          outcomeIndex,
+          title: outcome,
+        })
+      )
+      .filter(isOutcomeRowData);
+  }
+
+  const marketsAboveThreshold = LAST_TRADE_PRICE_THRESHOLDS.map(threshold =>
+    activeMarkets.filter(market => calculateOddsPrice(market) >= threshold)
+  ).find(markets => markets.length >= OUTCOME_ROW_COUNT);
+  const visibleMarkets = (marketsAboveThreshold ?? activeMarkets).slice(0, OUTCOME_ROW_COUNT);
+
+  return visibleMarkets
+    .map(market =>
+      buildOutcomeRow({
+        market,
+        outcomeIndex: 0,
+        title: formatOutcomeTitle(market.groupItemTitle || market.outcomes[0] || market.question),
+      })
+    )
+    .filter(isOutcomeRowData);
+}
+
+function buildOutcomeRow({
+  market,
+  outcomeIndex,
+  title,
+}: {
+  market: PolymarketMarket;
+  outcomeIndex: number;
+  title: string;
+}): OutcomeRowData | null {
+  const tokenId = market.clobTokenIds[outcomeIndex];
+  if (!tokenId) return null;
+
+  return {
+    market,
+    outcomeIndex,
+    title,
+    initialPrice: getInitialOutcomePrice(market, outcomeIndex),
+    tokenId: getPolymarketTokenId(tokenId, 'sell'),
+  };
+}
+
+function isOutcomeRowData(row: OutcomeRowData | null): row is OutcomeRowData {
+  return row !== null;
+}
+
+function getInitialOutcomePrice(market: PolymarketMarket, outcomeIndex: number): string | number {
+  const outcomePrice = market.outcomePrices[outcomeIndex];
+  return outcomePrice === undefined || outcomePrice === '' ? calculateOddsPrice(market) : outcomePrice;
+}
+
+function calculateOddsPrice(market: PolymarketMarket): number {
+  let price = market.lastTradePrice;
+  if (price === undefined) {
+    if (market.bestAsk !== undefined && market.bestBid !== undefined) {
+      price = (market.bestAsk + market.bestBid) / 2;
+    } else {
+      price = Number(market.outcomePrices[0] ?? 0);
+    }
+  }
+  return price;
+}
+
+function formatOutcomeTitle(title: string): string {
+  const match = title.match(/^([↑↓])\s*(\$)?\s*(.+)$/);
+  if (!match) return title;
+
+  return `${match[1]} $${match[3]}`;
+}
+
+function formatPriceChange(priceChange: number | undefined): string {
+  if (priceChange === undefined || Math.abs(priceChange) < 0.01) return '';
+  const roundedPriceChange = Math.round(priceChange * 100) / 100;
+  return `${toPercentageWorklet(Math.abs(roundedPriceChange))}%`;
+}
+
+function getTileAccentColor(event: PolymarketEvent, isDarkMode: boolean): string {
+  const semanticMatchTarget = `${event.title} ${event.ticker} ${event.slug} ${event.subtitle}`;
+  const semanticAccentColor = ASSET_ACCENT_COLORS.find(({ pattern }) => pattern.test(semanticMatchTarget))?.color;
+  return semanticAccentColor ?? getColorValueForThemeWorklet(event.color, isDarkMode);
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: PREDICTION_MARKET_TILE_CARD_HEIGHT,
+    width: PREDICTION_MARKET_TILE_CARD_WIDTH,
+  },
+  card: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+  cardShadow: {
+    borderCurve: 'continuous',
+    borderRadius: PREDICTION_MARKET_TILE_CARD_BORDER_RADIUS,
+    flex: 1,
+  },
+  cardShadowLight: {
+    backgroundColor: opacity(globalColors.white100, 0.92),
+    elevation: 4,
+    shadowColor: globalColors.grey100,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.06,
+    shadowRadius: 24,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingBottom: 12,
+    paddingHorizontal: 12,
+    paddingTop: 22,
+  },
+  flex: {
+    flex: 1,
+  },
+  headerText: {
+    gap: 12,
+    paddingHorizontal: 10,
+  },
+  icon: {
+    borderRadius: 14,
+    height: 42,
+    marginBottom: 14,
+    width: 42,
+  },
+  oddsPill: {
+    alignItems: 'center',
+    borderRadius: ODDS_PILL_BORDER_RADIUS,
+    borderWidth: 2,
+    height: ODDS_PILL_HEIGHT,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    paddingHorizontal: 8,
+    shadowOffset: { height: 0, width: 0 },
+    shadowRadius: 24,
+    width: ODDS_PILL_WIDTH,
+  },
+  oddsButton: {
+    borderRadius: ODDS_PILL_BORDER_RADIUS,
+    height: ODDS_PILL_HEIGHT,
+    width: ODDS_PILL_WIDTH,
+  },
+  oddsPillOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: ODDS_PILL_BORDER_RADIUS,
+  },
+  oddsPillsOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1,
+  },
+  oddsPillSlot: {
+    height: ODDS_PILL_HEIGHT,
+    left: ODDS_PILL_OVERLAY_LEFT,
+    position: 'absolute',
+    width: ODDS_PILL_WIDTH,
+  },
+  outcomeTitle: {
+    flex: 1,
+  },
+  outcomes: {
+    alignItems: 'center',
+    gap: 4,
+  },
+  outcomeRowContent: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 12,
+    paddingLeft: 8,
+    paddingRight: 12,
+  },
+  outcomeRowFrame: {
+    height: 58,
+    overflow: 'hidden',
+    width: OUTCOME_ROW_WIDTH,
+  },
+  priceChangeRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 2,
+  },
+  statsRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+  },
+  title: {
+    height: 54,
+  },
+});

--- a/src/features/discover/types/sectionLayout.ts
+++ b/src/features/discover/types/sectionLayout.ts
@@ -39,7 +39,9 @@ export type PlacementBackedSurfaceLeafWithDisplay<TDisplay extends Display> = Su
 export type SectionLayoutProps<T extends PlacementItem> = {
   data: T[];
   descriptor: SectionDescriptor<T>;
+  headerCaret?: boolean;
   headerCount?: number;
+  leadingAccessory?: ReactNode;
   loading: boolean;
   onPressSeeAll?: () => void;
   surface: SurfaceLeaf;

--- a/src/features/discover/utils/refreshDiscoverSurface.ts
+++ b/src/features/discover/utils/refreshDiscoverSurface.ts
@@ -1,9 +1,15 @@
+import { POLYMARKET } from '@/config/experimental';
+import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
 import { IS_TEST } from '@/env';
+import { getSportsSurfaceIntent } from '@/features/discover/utils/sportsSurfaceIntent';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
+import { usePredictionEventsStore } from '@/features/placements/stores/derived/predictionsPlacementStore';
 import { clearTokenRefCache, useTokenRefsStore } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
-import { useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { useDiscoverSurface, useDiscoverSurfacePlacementRefs } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { type DiscoverSurface } from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
 import { getSurfaceStore } from '@/features/placements/surfaces/stores/surfaceStore';
+import { usePolymarketSportsEventsStore } from '@/features/polymarket/stores/polymarketSportsEventsStore';
 import { useRemoteConfigStore } from '@/model/remoteConfig';
 
 export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
@@ -12,8 +18,13 @@ export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
     usePlacementsV2Store.getState().fetch(undefined, { force: true }),
   ]);
 
+  const surface = useDiscoverSurface.getState();
   const refs = useDiscoverSurfacePlacementRefs.getState();
   const perpsEnabled = useRemoteConfigStore.getState().getRemoteConfigKey('perps_enabled') && !IS_TEST;
+  const polymarketEnabled =
+    (useRemoteConfigStore.getState().getRemoteConfigKey('polymarket_enabled') ||
+      useExperimentalConfigStore.getState().getFlag(POLYMARKET)) &&
+    !IS_TEST;
 
   const refreshes: Promise<unknown>[] = [];
 
@@ -28,5 +39,17 @@ export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
     refreshes.push(useTokenRefsStore.getState().fetch(undefined, { force: true }));
   }
 
+  if (polymarketEnabled && refs.polymarket.length) {
+    refreshes.push(usePredictionEventsStore.getState().fetch(undefined, { force: true }));
+  }
+
+  if (polymarketEnabled && surface && surfaceUsesSportsEvents(surface)) {
+    refreshes.push(usePolymarketSportsEventsStore.getState().fetch(undefined, { force: true }));
+  }
+
   await Promise.allSettled(refreshes);
+}
+
+function surfaceUsesSportsEvents(surface: DiscoverSurface): boolean {
+  return surface.tabs.some(tab => tab.sections.some(section => getSportsSurfaceIntent(section) !== null));
 }

--- a/src/features/discover/utils/sportsSurfaceIntent.ts
+++ b/src/features/discover/utils/sportsSurfaceIntent.ts
@@ -1,0 +1,27 @@
+import { isEventCardDisplay } from '@/features/placements/surfaces/constants';
+import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { getLeagueId, type LeagueId } from '@/features/polymarket/leagues';
+import {
+  getSportsEventScheduleBucket,
+  isLiveSportsEvent,
+  type SportsEventScheduleBucket,
+} from '@/features/polymarket/screens/polymarket-sports-events-screen/buildPolymarketSportsEventsListData';
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+
+export type SportsSurfaceIntent = { status: 'live' } | { timeBucket: Extract<SportsEventScheduleBucket, 'today'> } | { leagueId: LeagueId };
+
+export function getSportsSurfaceIntent(surface: SurfaceLeaf): SportsSurfaceIntent | null {
+  if (!isEventCardDisplay(surface.display)) return null;
+
+  if (surface.id === 'live') return { status: 'live' };
+  if (surface.id === 'today') return { timeBucket: 'today' };
+
+  const leagueId = getLeagueId(surface.id);
+  return leagueId ? { leagueId } : null;
+}
+
+export function selectSportsEventsForIntent(events: PolymarketEvent[], intent: SportsSurfaceIntent): PolymarketEvent[] {
+  if ('status' in intent) return events.filter(isLiveSportsEvent);
+  if ('timeBucket' in intent) return events.filter(event => getSportsEventScheduleBucket(event) === intent.timeBucket);
+  return events.filter(event => getLeagueId(event.slug) === intent.leagueId);
+}

--- a/src/features/polymarket/components/LiveSectionIndicator.tsx
+++ b/src/features/polymarket/components/LiveSectionIndicator.tsx
@@ -1,0 +1,49 @@
+import { memo } from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { useForegroundColor } from '@/design-system/color/useForegroundColor';
+import { useBackgroundColor } from '@/design-system/components/BackgroundProvider/BackgroundProvider';
+import { opacity } from '@/framework/ui/utils/opacity';
+
+const LIVE_INDICATOR_SIZE = 28;
+const LIVE_INDICATOR_CUTOUT_SIZE = 16;
+const LIVE_INDICATOR_DOT_SIZE = 8;
+
+type LiveSectionIndicatorProps = {
+  style?: StyleProp<ViewStyle>;
+};
+
+export const LiveSectionIndicator = memo(function LiveSectionIndicator({ style }: LiveSectionIndicatorProps) {
+  const backgroundColor = useBackgroundColor('surfacePrimary');
+  const liveIndicatorColor = useForegroundColor('red');
+
+  return (
+    <View style={[styles.outer, { backgroundColor: opacity(liveIndicatorColor, 0.34) }, style]}>
+      <View style={[styles.cutout, { backgroundColor }]}>
+        <View style={[styles.dot, { backgroundColor: liveIndicatorColor }]} />
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  cutout: {
+    alignItems: 'center',
+    borderRadius: LIVE_INDICATOR_CUTOUT_SIZE / 2,
+    height: LIVE_INDICATOR_CUTOUT_SIZE,
+    justifyContent: 'center',
+    width: LIVE_INDICATOR_CUTOUT_SIZE,
+  },
+  dot: {
+    borderRadius: LIVE_INDICATOR_DOT_SIZE / 2,
+    height: LIVE_INDICATOR_DOT_SIZE,
+    width: LIVE_INDICATOR_DOT_SIZE,
+  },
+  outer: {
+    alignItems: 'center',
+    borderRadius: LIVE_INDICATOR_SIZE / 2,
+    height: LIVE_INDICATOR_SIZE,
+    justifyContent: 'center',
+    width: LIVE_INDICATOR_SIZE,
+  },
+});

--- a/src/features/polymarket/components/polymarket-events-list/PolymarketEventsListItem.tsx
+++ b/src/features/polymarket/components/polymarket-events-list/PolymarketEventsListItem.tsx
@@ -8,6 +8,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import ShimmerAnimation from '@/components/animations/ShimmerAnimation';
 import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
 import ImgixImage from '@/components/images/ImgixImage';
+import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
 import { globalColors, Separator, Text, useBackgroundColor, useColorMode } from '@/design-system';
 import { POLYMARKET_SPORTS_MARKET_TYPE } from '@/features/polymarket/constants';
 // import {
@@ -15,11 +16,13 @@ import { POLYMARKET_SPORTS_MARKET_TYPE } from '@/features/polymarket/constants';
 //   usePolymarketRecommendationsStore,
 // } from '@/features/polymarket/stores/polymarketRecommendationsStore';
 import { type PolymarketEvent, type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+import { formatOdds } from '@/features/polymarket/utils/sportsEventBetData';
 import { roundWorklet, toPercentageWorklet } from '@/framework/core/safeMath';
 import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
+import { getPolymarketTokenId } from '@/state/liveTokens/polymarketAdapter';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import { deepFreeze } from '@/utils/deepFreeze';
 import { createOpacityPalette } from '@/worklets/colors';
@@ -58,41 +61,7 @@ export const PolymarketEventsListItem = memo(function PolymarketEventsListItem({
 }) {
   const { isDarkMode } = useColorMode();
 
-  const markets = useMemo(() => {
-    const activeMarkets = event.markets.filter(m => m.active && !m.closed);
-    const firstMarket = activeMarkets[0];
-    const isGame =
-      firstMarket &&
-      firstMarket.sportsMarketType === POLYMARKET_SPORTS_MARKET_TYPE.MONEYLINE &&
-      firstMarket.outcomes[0] !== 'Yes' &&
-      firstMarket.outcomes[1] !== 'No';
-    const isSingleMarketEvent = activeMarkets.length === 1;
-    /**
-     * When the first market is a moneyline market the event represents a game
-     * For games, we show the two outcomes of this market as the first and second market (excluding three-way moneyline markets)
-     * We also do this when an even has only one market with Yes / No outcomes
-     */
-    if (isGame || isSingleMarketEvent) {
-      return [
-        { odds: `${roundWorklet(toPercentageWorklet(firstMarket.outcomePrices?.[0] ?? 0))}%`, title: firstMarket.outcomes[0] },
-        { odds: `${roundWorklet(toPercentageWorklet(firstMarket.outcomePrices?.[1] ?? 0))}%`, title: firstMarket.outcomes[1] },
-      ];
-    }
-
-    const marketsAboveThreshold = LAST_TRADE_PRICE_THRESHOLDS.map(threshold =>
-      activeMarkets.filter(m => (m.lastTradePrice ?? 0) >= threshold)
-    ).find(markets => markets.length >= 2);
-    const marketsToShow = (marketsAboveThreshold ?? activeMarkets).slice(0, 2);
-
-    if (marketsToShow.length === 0) {
-      return [{ odds: '', title: i18n.t(i18n.l.predictions.outcomes.yes) }];
-    }
-
-    return marketsToShow.map(market => ({
-      odds: `${roundWorklet(toPercentageWorklet(calculateOddsPrice(market)))}%`,
-      title: market.groupItemTitle || market.outcomes[0],
-    }));
-  }, [event]);
+  const markets = useMemo(() => getPolymarketEventsListOutcomes(event), [event]);
 
   const eventColor = getColorValueForThemeWorklet(event.color, isDarkMode);
   const colors = useMemo(() => {
@@ -164,9 +133,15 @@ export const PolymarketEventsListItem = memo(function PolymarketEventsListItem({
                 pointerEvents="none"
               />
               <View style={styles.row}>
-                <Text color={colors.textColor} size="13pt" weight="heavy">
-                  {markets[0].odds}
-                </Text>
+                <LiveTokenText
+                  autoSubscriptionEnabled={false}
+                  color={colors.textColor}
+                  initialValue={markets[0].odds}
+                  selector={token => formatOdds(token.price)}
+                  size="13pt"
+                  tokenId={markets[0].tokenId ?? ''}
+                  weight="heavy"
+                />
                 <Text color="label" numberOfLines={1} size="13pt" weight="heavy" style={styles.flex}>
                   {markets[0].title}
                 </Text>
@@ -178,9 +153,15 @@ export const PolymarketEventsListItem = memo(function PolymarketEventsListItem({
               ) : null}
               {markets[1] ? (
                 <View style={styles.row}>
-                  <Text color={colors.textColor} size="13pt" weight="heavy">
-                    {markets[1].odds}
-                  </Text>
+                  <LiveTokenText
+                    autoSubscriptionEnabled={false}
+                    color={colors.textColor}
+                    initialValue={markets[1].odds}
+                    selector={token => formatOdds(token.price)}
+                    size="13pt"
+                    tokenId={markets[1].tokenId ?? ''}
+                    weight="heavy"
+                  />
                   <Text color="labelSecondary" numberOfLines={1} size="13pt" weight="bold" style={styles.flex}>
                     {markets[1].title}
                   </Text>
@@ -226,6 +207,72 @@ export const LoadingSkeleton = memo(function LoadingSkeleton() {
     </View>
   );
 });
+
+type PolymarketEventsListOutcome = {
+  odds: string;
+  title: string;
+  tokenId: string | undefined;
+};
+
+/**
+ * The outcome rows this list item renders (odds + title + token id). Single source of
+ * truth shared by the card render and the live-odds subscription so they can't drift.
+ */
+export function getPolymarketEventsListOutcomes(event: PolymarketEvent): PolymarketEventsListOutcome[] {
+  const activeMarkets = event.markets.filter(m => m.active && !m.closed);
+  const firstMarket = activeMarkets[0];
+  const isGame =
+    firstMarket &&
+    firstMarket.sportsMarketType === POLYMARKET_SPORTS_MARKET_TYPE.MONEYLINE &&
+    firstMarket.outcomes[0] !== 'Yes' &&
+    firstMarket.outcomes[1] !== 'No';
+  const isSingleMarketEvent = activeMarkets.length === 1;
+  /**
+   * When the first market is a moneyline market the event represents a game
+   * For games, we show the two outcomes of this market as the first and second market (excluding three-way moneyline markets)
+   * We also do this when an even has only one market with Yes / No outcomes
+   */
+  if (isGame || isSingleMarketEvent) {
+    return [
+      {
+        odds: `${roundWorklet(toPercentageWorklet(firstMarket.outcomePrices?.[0] ?? 0))}%`,
+        title: firstMarket.outcomes[0],
+        tokenId: firstMarket.clobTokenIds[0] ? getPolymarketTokenId(firstMarket.clobTokenIds[0], 'sell') : undefined,
+      },
+      {
+        odds: `${roundWorklet(toPercentageWorklet(firstMarket.outcomePrices?.[1] ?? 0))}%`,
+        title: firstMarket.outcomes[1],
+        tokenId: firstMarket.clobTokenIds[1] ? getPolymarketTokenId(firstMarket.clobTokenIds[1], 'sell') : undefined,
+      },
+    ];
+  }
+
+  const marketsAboveThreshold = LAST_TRADE_PRICE_THRESHOLDS.map(threshold =>
+    activeMarkets.filter(m => (m.lastTradePrice ?? 0) >= threshold)
+  ).find(markets => markets.length >= 2);
+  const marketsToShow = (marketsAboveThreshold ?? activeMarkets).slice(0, 2);
+
+  if (marketsToShow.length === 0) {
+    return [{ odds: '', title: i18n.t(i18n.l.predictions.outcomes.yes), tokenId: undefined }];
+  }
+
+  return marketsToShow.map(market => ({
+    odds: `${roundWorklet(toPercentageWorklet(calculateOddsPrice(market)))}%`,
+    title: market.groupItemTitle || market.outcomes[0],
+    tokenId: market.clobTokenIds[0] ? getPolymarketTokenId(market.clobTokenIds[0], 'sell') : undefined,
+  }));
+}
+
+/**
+ * Token ids for the outcomes this list item renders. Derived from the SAME selection
+ * as the render, so subscribed == rendered by construction.
+ */
+export function getPolymarketEventsListTokenIds(event: PolymarketEvent): string[] {
+  const tokenIds = getPolymarketEventsListOutcomes(event)
+    .map(outcome => outcome.tokenId)
+    .filter((tokenId): tokenId is string => Boolean(tokenId));
+  return Array.from(new Set(tokenIds));
+}
 
 function navigateToEvent(event: PolymarketEvent): void {
   Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, { event, eventId: event.id });

--- a/src/features/polymarket/hooks/useSportsEventContent.ts
+++ b/src/features/polymarket/hooks/useSportsEventContent.ts
@@ -9,6 +9,7 @@ import { parsePeriod, parseScore, selectGameInfo, type PolymarketEventGameInfo }
 import { buildEventBetGrid, formatOdds, type BetCellData, type EventBetGrid } from '@/features/polymarket/utils/sportsEventBetData';
 import { getSportsEventOutcomeCellColor } from '@/features/polymarket/utils/sportsEventOutcome';
 import * as i18n from '@/languages';
+import { getPolymarketTokenId } from '@/state/liveTokens/polymarketAdapter';
 import { formatTimestamp, toUnixTime } from '@/worklets/dates';
 
 export type SportsEventTeamRow = {
@@ -112,6 +113,32 @@ function getLeagueIdFromTags(tags: PolymarketEvent['tags']): LeagueId | undefine
     const leagueId = getLeagueId(tag.slug);
     if (leagueId) return leagueId;
   }
+}
+
+/**
+ * Resolves the exact bet rows a sports event card renders (away/home line + moneyline,
+ * with the fallback-market path). Exported so live-odds subscriptions can derive token ids
+ * from the SAME resolution the card uses, keeping subscribed == rendered by construction.
+ */
+export function getSportsEventRows(event: PolymarketEvent): SportsEventRows {
+  return getRows(event, buildEventBetGrid(event));
+}
+
+/**
+ * Token ids for the cells a sports event card actually renders (line/moneyline per team,
+ * including the fallback-market rows). Mirrors getSportsEventRows so subscribed == rendered.
+ */
+export function getSportsEventRowTokenIds(event: PolymarketEvent): string[] {
+  const rows = getSportsEventRows(event);
+  const outcomeTokenIds = [
+    rows.away.line?.outcomeTokenId,
+    rows.away.moneyline?.outcomeTokenId,
+    rows.home.line?.outcomeTokenId,
+    rows.home.moneyline?.outcomeTokenId,
+  ].filter((tokenId): tokenId is string => Boolean(tokenId));
+
+  const tokenIds = outcomeTokenIds.map(tokenId => getPolymarketTokenId(tokenId, 'sell'));
+  return Array.from(new Set(tokenIds));
 }
 
 function getRows(event: PolymarketEvent, betGrid: EventBetGrid): SportsEventRows {

--- a/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsList.tsx
+++ b/src/features/polymarket/screens/polymarket-sports-events-screen/PolymarketSportsEventsList.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Text, useForegroundColor } from '@/design-system';
 import { LeagueIcon } from '@/features/polymarket/components/league-icon/LeagueIcon';
+import { LiveSectionIndicator } from '@/features/polymarket/components/LiveSectionIndicator';
 import {
   HEIGHT as ITEM_HEIGHT,
   LoadingSkeleton,
@@ -148,7 +149,7 @@ const SectionHeader = memo(function SectionHeader({ title, isLive }: { title: st
   return (
     <View style={styles.sectionHeader}>
       <View style={styles.sectionHeaderContent}>
-        {isLive ? <View style={[styles.liveIndicator, { backgroundColor: '#FF584D' }]} /> : null}
+        {isLive ? <LiveSectionIndicator /> : null}
         <Text align="left" color="label" size="20pt" weight="heavy">
           {title}
         </Text>
@@ -218,11 +219,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
-  },
-  liveIndicator: {
-    height: 8,
-    width: 8,
-    borderRadius: 4,
   },
   leagueHeader: {
     flexDirection: 'row',

--- a/src/features/polymarket/utils/sportsEventBetData.ts
+++ b/src/features/polymarket/utils/sportsEventBetData.ts
@@ -126,7 +126,7 @@ export function buildEventBetGrid(event: PolymarketEvent): EventBetGrid {
   return { teamBets, totals };
 }
 
-export function formatOdds(value?: string) {
+export function formatOdds(value?: string | number | null) {
   if (value == null || value === '') return '--';
   return `${roundWorklet(toPercentageWorklet(value))}%`;
 }

--- a/src/features/polymarket/utils/sportsEventTeamLabels.ts
+++ b/src/features/polymarket/utils/sportsEventTeamLabels.ts
@@ -1,0 +1,39 @@
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+
+const NON_TEAM_OUTCOME_LABELS = new Set(['draw', 'no', 'over', 'under', 'yes']);
+
+export function getDiscoverSportsEventTeamLabels(event: PolymarketEvent, labels: [string, string]): [string, string] {
+  if (labels[0] && labels[1]) return labels;
+  return parseTeamNamesFromTitle(event.title) ?? getTeamNamesFromMarketOutcomes(event) ?? labels;
+}
+
+function parseTeamNamesFromTitle(title: string): [string, string] | undefined {
+  const match = title.match(/(.+?)\s+vs\.?\s+(.+)/i);
+  if (!match) return undefined;
+
+  const awayName = cleanTitleTeamName(match[1]);
+  const homeName = cleanTitleTeamName(match[2]);
+  return awayName && homeName ? [awayName, homeName] : undefined;
+}
+
+function cleanTitleTeamName(value: string): string {
+  const withoutPrefix = value.includes(':') ? value.slice(value.lastIndexOf(':') + 1) : value;
+  return withoutPrefix
+    .replace(/\s+\(.+$/, '')
+    .replace(/\s+-\s+.+$/, '')
+    .trim();
+}
+
+function getTeamNamesFromMarketOutcomes(event: PolymarketEvent): [string, string] | undefined {
+  for (const market of event.markets) {
+    const [awayName, homeName] = market.outcomes;
+    if (isTeamOutcomeLabel(awayName) && isTeamOutcomeLabel(homeName)) {
+      return [awayName, homeName];
+    }
+  }
+}
+
+function isTeamOutcomeLabel(value: string | undefined): value is string {
+  if (!value) return false;
+  return !NON_TEAM_OUTCOME_LABELS.has(value.trim().toLowerCase());
+}

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -227,7 +227,7 @@ export const DEFAULT_CONFIG = {
   candlestick_charts_enabled: !IS_STORE_INSTALL,
   rainbow_toasts_enabled: !IS_STORE_INSTALL,
   perps_enabled: true,
-  polymarket_enabled: false,
+  polymarket_enabled: true,
   dev_section_enabled: IS_DEV,
   rnbw_rewards_enabled: false,
   rnbw_membership_enabled: false,


### PR DESCRIPTION
Prediction markets and live sports events didn't render in Discover — the section dispatcher returned null for every prediction display.

## What changed

- `PredictionsSection` dispatches three ways: no-placement placements drive `SportsQuerySection` from the live events store, placement-backed event cards route to `SportsEventPlacementSection`, all other placements use `PredictionsPlacementSection`; `isPredictionsSurface` adds the branch in `DiscoverSection`.
- `SportsSurfaceIntent` derives live, today, or league intent from `surface.id` alone, gated on `isEventCardDisplay`; `selectSportsEventsForIntent` keeps header count and visible cards in sync across all three paths.
- `SectionLayout` renders `LiveSectionIndicator` for live sections and `LeagueIcon` for league-scoped ones; live sections suppress the header caret.
- `LiveSectionIndicator` extracted as a standalone component — a ring with a `surfacePrimary` cutout composable on any background; replaces the hardcoded dot on the sports screen.
- Android bet-cell taps fixed: `WidgetBetCellsOverlay` positions cells absolutely with `pointerEvents="box-none"` so taps hit cells and transparent regions fall through to the card beneath.
- `getDiscoverSportsEventTeamLabels` resolves labels via upstream metadata, then title 'vs' parsing, then market outcome scan filtered against non-team labels.
- `refreshDiscoverSurface` fans out to the predictions store (via placement refs) and the sports events store (via `surfaceUsesSportsEvents` tree walk), gated on `polymarket_enabled` (now defaulting `true`) or the dev flag.

## What to test

- Prediction tile, tile-widget, carousel, and grid sections render with live odds updating in place.
- Live section headers show the ring indicator and no caret; today/league sections show a caret when a destination exists.
- League sections show the league icon and suppress per-card league labels; live and today sections keep the label.
- Header badge count matches the visible card count per section type.
- Tapping a tile or card navigates to the event screen; tapping a bet cell opens the new-position sheet — including outside-vs-on-cell taps on Android.
- Disabling `polymarket_enabled` and the dev flag leaves prediction sections empty, not stuck loading; token and perp sections unaffected.
- Live indicator renders correctly in light and dark mode on both the sports screen and Discover headers.
