### PR TITLE
fix(perps): skip account-store fetches without a valid wallet

### DIFF
--- a/src/features/perps/stores/hlOpenOrdersStore.ts
+++ b/src/features/perps/stores/hlOpenOrdersStore.ts
@@ -1,6 +1,7 @@
 import { type FrontendOpenOrdersResponse } from '@nktkas/hyperliquid/api/info';
 import { type Address } from 'viem';
 
+import { isValidAddress } from '@/features/address/core/address';
 import { infoClient } from '@/features/perps/services/hyperliquid-info-client';
 import { hyperliquidDexActions } from '@/features/perps/stores/hyperliquidDexStore';
 import { type OrderSide } from '@/features/perps/types';
@@ -88,6 +89,7 @@ export const useHlOpenOrdersStore = createQueryStore<FetchHlOpenOrdersResponse, 
   {
     fetcher: fetchHlOpenOrders,
     cacheTime: time.days(1),
+    enabled: $ => $(useWalletsStore, state => isValidAddress(state.accountAddress)),
     params: {
       address: $ => $(useWalletsStore).accountAddress,
     },

--- a/src/features/perps/stores/hlTradesStore.ts
+++ b/src/features/perps/stores/hlTradesStore.ts
@@ -1,5 +1,6 @@
 import { type Address } from 'viem';
 
+import { isValidAddress } from '@/features/address/core/address';
 import { getHyperliquidAccountClient, useHyperliquidClients } from '@/features/perps/services';
 import { decodeLeverageFromCloid } from '@/features/perps/utils/hyperliquidCloid';
 import { subWorklet } from '@/framework/core/safeMath';
@@ -43,6 +44,7 @@ export const useHlTradesStore = createQueryStore<FetchHlTradesResponse, HlTrades
   {
     fetcher: fetchHlTrades,
     cacheTime: time.days(1),
+    enabled: $ => $(useHyperliquidClients, state => isValidAddress(state.address)),
     params: { address: $ => $(useHyperliquidClients).address },
     staleTime: time.minutes(1),
   },

--- a/src/features/perps/stores/hyperliquidAccountStore.ts
+++ b/src/features/perps/stores/hyperliquidAccountStore.ts
@@ -1,6 +1,7 @@
 import { type OrderSuccessResponse } from '@nktkas/hyperliquid/api/exchange';
 import { type Address } from 'viem';
 
+import { isValidAddress } from '@/features/address/core/address';
 import { USD_DECIMALS } from '@/features/perps/constants';
 import type { OrderStatusResponse } from '@/features/perps/services/hyperliquid-exchange-client';
 import { hlOpenOrdersStoreActions } from '@/features/perps/stores/hlOpenOrdersStore';
@@ -47,6 +48,7 @@ export const useHyperliquidAccountStore = createQueryStore<
   {
     fetcher: fetchHyperliquidAccount,
     cacheTime: time.days(1),
+    enabled: $ => $(useHyperliquidClients, state => isValidAddress(state.address)),
     params: { address: $ => $(useHyperliquidClients).address },
     staleTime: time.seconds(10),
   },


### PR DESCRIPTION
Cold launch without a connected wallet threw a spurious Sentry error: the three Hyperliquid account stores fetched against the empty-string init address, tripping each fetcher's `RainbowError` guard. This gates the fetchers on a valid wallet.

## What changed

- Each store gates with an `enabled` selector running `isValidAddress` before params evaluate; `createQueryStore` short-circuits so no request fires, also covering failed rehydration.
- Each `enabled` reads from the same store its params read, keeping the gate and params on one dependency.

## What to test

- Launch with no wallet: no Hyperliquid requests fire, no errors logged.
- Connect a wallet, open perps: balance, open orders, trade history load.
- Switch wallets: all three re-fetch for the new address; suppress again if invalid.
