### PR TITLE
Fix remaining send imprecision, ensure prepared call consistency

### DIFF
--- a/src/features/delegation/sponsoredSendExecution.test.ts
+++ b/src/features/delegation/sponsoredSendExecution.test.ts
@@ -7,91 +7,85 @@ import { ChainId } from '@/state/backendNetworks/types';
 
 import { buildSendCallFromSendDetails } from './sponsoredSendExecution';
 
-jest.mock('@/handlers/web3', () => ({
-  resolveNameOrAddress: jest.fn(),
-}));
-
 jest.mock('@/handlers/assets', () => ({
   isNativeAsset: jest.fn(),
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  resolveNameOrAddress: jest.fn(),
 }));
 
 jest.mock('./sponsoredSend', () => ({
   buildPendingSendTransaction: jest.fn(),
 }));
 
-jest.mock('./calls', () => ({
-  isPreparedCallsExecutionSponsored: jest.fn(),
-}));
+const RECIPIENT = '0x4444444444444444444444444444444444444444' satisfies Address;
+const TOKEN_ADDRESS = '0x5555555555555555555555555555555555555555' satisfies Address;
 
-jest.mock('@/logger', () => ({
-  RainbowError: class RainbowError extends Error {},
-}));
+const nativeAsset = {
+  address: '0x0000000000000000000000000000000000000000',
+  chainId: ChainId.base,
+  decimals: 18,
+  name: 'Ether',
+  network: 'base',
+  symbol: 'ETH',
+  uniqueId: 'base-eth',
+} satisfies ParsedAddressAsset;
+
+const tokenAsset = {
+  address: TOKEN_ADDRESS,
+  chainId: ChainId.base,
+  decimals: 18,
+  name: 'Token',
+  network: 'base',
+  symbol: 'TKN',
+  uniqueId: 'base-token',
+} satisfies ParsedAddressAsset;
 
 const mockIsNativeAsset = jest.mocked(isNativeAsset);
 const mockResolveNameOrAddress = jest.mocked(resolveNameOrAddress);
 
-const RECIPIENT = '0x4444444444444444444444444444444444444444' satisfies Address;
-
-const ASSET = {
-  address: '0x5555555555555555555555555555555555555555',
-  decimals: 18,
-  uniqueId: 'base-token',
-} as ParsedAddressAsset;
-
-describe('buildSendCallFromSendDetails', () => {
+describe('sponsoredSendExecution', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsNativeAsset.mockReturnValue(false);
-    mockResolveNameOrAddress.mockResolvedValue(RECIPIENT);
+    mockResolveNameOrAddress.mockImplementation(async address => address);
   });
 
-  it('builds ERC20 transfer calls from the exact decimal amount', async () => {
-    const fullPrecisionAmount = '98765.432109876543210987';
-
-    const call = await buildSendCallFromSendDetails({
-      amount: fullPrecisionAmount,
-      asset: ASSET,
-      chainId: ChainId.base,
-      toAddress: RECIPIENT,
-    });
-
-    expect(call).toEqual({
-      data: encodeFunctionData({
-        abi: erc20Abi,
-        functionName: 'transfer',
-        args: [RECIPIENT, 98765432109876543210987n],
-      }),
-      to: ASSET.address,
-      value: 0n,
-    });
-    expect(Number(fullPrecisionAmount).toString()).not.toBe(fullPrecisionAmount);
-  });
-
-  it('builds native transfer calls from the exact decimal amount', async () => {
+  it('builds native calls from exact raw units', async () => {
     mockIsNativeAsset.mockReturnValue(true);
 
     await expect(
       buildSendCallFromSendDetails({
-        amount: '1.5',
-        asset: ASSET,
+        amount: '0.999999999999999999',
+        asset: nativeAsset,
         chainId: ChainId.base,
         toAddress: RECIPIENT,
       })
     ).resolves.toEqual({
       data: '0x',
       to: RECIPIENT,
-      value: 1500000000000000000n,
+      value: 999999999999999999n,
     });
   });
 
-  it('rejects amounts that exceed the asset precision', async () => {
+  it('builds token calls from exact raw units', async () => {
+    mockIsNativeAsset.mockReturnValue(false);
+
     await expect(
       buildSendCallFromSendDetails({
-        amount: '0.9999999999999999999',
-        asset: ASSET,
+        amount: '1.234567891234567891',
+        asset: tokenAsset,
         chainId: ChainId.base,
         toAddress: RECIPIENT,
       })
-    ).rejects.toThrow('[buildSendCallFromSendDetails]: invalid send amount');
+    ).resolves.toEqual({
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [RECIPIENT, 1234567891234567891n],
+      }),
+      to: TOKEN_ADDRESS,
+      value: 0n,
+    });
   });
 });

--- a/src/features/delegation/sponsoredSendExecution.test.ts
+++ b/src/features/delegation/sponsoredSendExecution.test.ts
@@ -1,21 +1,22 @@
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import { type Address } from 'viem';
+import { encodeFunctionData, erc20Abi, type Address } from 'viem';
 
 import { type ParsedAddressAsset } from '@/entities/tokens';
-import { buildTransferTransaction } from '@/handlers/web3';
+import { isNativeAsset } from '@/handlers/assets';
+import { resolveNameOrAddress } from '@/handlers/web3';
 import { ChainId } from '@/state/backendNetworks/types';
 
-import { buildSendCall } from './sponsoredSend';
 import { buildSendCallFromSendDetails } from './sponsoredSendExecution';
 
 jest.mock('@/handlers/web3', () => ({
-  buildTransferTransaction: jest.fn(),
+  resolveNameOrAddress: jest.fn(),
+}));
+
+jest.mock('@/handlers/assets', () => ({
+  isNativeAsset: jest.fn(),
 }));
 
 jest.mock('./sponsoredSend', () => ({
   buildPendingSendTransaction: jest.fn(),
-  buildSendCall: jest.fn(),
-  prepareSponsoredSend: jest.fn(),
 }));
 
 jest.mock('./calls', () => ({
@@ -23,14 +24,12 @@ jest.mock('./calls', () => ({
 }));
 
 jest.mock('@/logger', () => ({
-  ensureError: (error: unknown) => error,
-  logger: { warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
 }));
 
-const mockBuildTransferTransaction = jest.mocked(buildTransferTransaction);
-const mockBuildSendCall = jest.mocked(buildSendCall);
+const mockIsNativeAsset = jest.mocked(isNativeAsset);
+const mockResolveNameOrAddress = jest.mocked(resolveNameOrAddress);
 
-const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
 const RECIPIENT = '0x4444444444444444444444444444444444444444' satisfies Address;
 
 const ASSET = {
@@ -39,39 +38,60 @@ const ASSET = {
   uniqueId: 'base-token',
 } as ParsedAddressAsset;
 
-const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', ChainId.base);
-
 describe('buildSendCallFromSendDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockBuildTransferTransaction.mockResolvedValue({ data: '0x', to: RECIPIENT, value: '0' });
-    mockBuildSendCall.mockReturnValue({ data: '0x', to: RECIPIENT, value: 0n });
+    mockIsNativeAsset.mockReturnValue(false);
+    mockResolveNameOrAddress.mockResolvedValue(RECIPIENT);
   });
 
-  // Regression for APP-3768: a full-balance max send must reach buildTransferTransaction as the exact
-  // decimal string. Coercing through Number() drops precision on 18-decimal balances and can push
-  // the raw amount above the onchain balance ("ERC20: transfer amount exceeds balance").
-  it('forwards the full-precision amount string to buildTransferTransaction without Number() coercion', async () => {
+  it('builds ERC20 transfer calls from the exact decimal amount', async () => {
     const fullPrecisionAmount = '98765.432109876543210987';
 
-    await buildSendCallFromSendDetails({
-      accountAddress: ACCOUNT,
+    const call = await buildSendCallFromSendDetails({
       amount: fullPrecisionAmount,
       asset: ASSET,
       chainId: ChainId.base,
-      provider,
       toAddress: RECIPIENT,
     });
 
-    expect(mockBuildTransferTransaction).toHaveBeenCalledWith(
-      { address: ACCOUNT, amount: fullPrecisionAmount, asset: ASSET, recipient: RECIPIENT },
-      provider,
-      ChainId.base
-    );
+    expect(call).toEqual({
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [RECIPIENT, 98765432109876543210987n],
+      }),
+      to: ASSET.address,
+      value: 0n,
+    });
+    expect(Number(fullPrecisionAmount).toString()).not.toBe(fullPrecisionAmount);
+  });
 
-    const passedAmount = mockBuildTransferTransaction.mock.calls[0][0].amount;
-    expect(typeof passedAmount).toBe('string');
-    expect(passedAmount).toBe(fullPrecisionAmount);
-    expect(Number(passedAmount).toString()).not.toBe(passedAmount);
+  it('builds native transfer calls from the exact decimal amount', async () => {
+    mockIsNativeAsset.mockReturnValue(true);
+
+    await expect(
+      buildSendCallFromSendDetails({
+        amount: '1.5',
+        asset: ASSET,
+        chainId: ChainId.base,
+        toAddress: RECIPIENT,
+      })
+    ).resolves.toEqual({
+      data: '0x',
+      to: RECIPIENT,
+      value: 1500000000000000000n,
+    });
+  });
+
+  it('rejects amounts that exceed the asset precision', async () => {
+    await expect(
+      buildSendCallFromSendDetails({
+        amount: '0.9999999999999999999',
+        asset: ASSET,
+        chainId: ChainId.base,
+        toAddress: RECIPIENT,
+      })
+    ).rejects.toThrow('[buildSendCallFromSendDetails]: invalid send amount');
   });
 });

--- a/src/features/delegation/sponsoredSendExecution.ts
+++ b/src/features/delegation/sponsoredSendExecution.ts
@@ -4,13 +4,17 @@ import { isAddress, type Address } from 'viem';
 
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { type NewTransaction } from '@/entities/transactions';
-import { buildTransferTransaction } from '@/handlers/web3';
-import { ensureError, logger } from '@/logger';
+import { requireAddress } from '@/framework/core/evm/address';
+import { encodeErc20Transfer } from '@/framework/core/evm/erc20Calldata';
+import { parsePositiveRawAmount } from '@/framework/core/evm/units';
+import { isNativeAsset } from '@/handlers/assets';
+import { resolveNameOrAddress } from '@/handlers/web3';
+import { RainbowError } from '@/logger';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { type Call, type ExecuteCallsResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 import { isPreparedCallsExecutionSponsored } from './calls';
-import { buildPendingSendTransaction, buildSendCall, prepareSponsoredSend } from './sponsoredSend';
+import { buildPendingSendTransaction } from './sponsoredSend';
 
 type ExecuteSponsoredSendWithTracking = (params: {
   accountAddress: Address;
@@ -23,11 +27,9 @@ type ExecuteSponsoredSendWithTracking = (params: {
 }) => Promise<ExecuteCallsResult | null>;
 
 type BuildSendCallFromSendDetailsParams = {
-  accountAddress: string;
   amount: string;
   asset: ParsedAddressAsset;
   chainId: ChainId;
-  provider: StaticJsonRpcProvider;
   toAddress: string;
 };
 
@@ -43,25 +45,27 @@ type ExecuteSponsoredSendIfAvailableParams = {
 };
 
 export async function buildSendCallFromSendDetails({
-  accountAddress,
   amount,
   asset,
   chainId,
-  provider,
   toAddress,
 }: BuildSendCallFromSendDetailsParams): Promise<Call> {
-  const transaction = await buildTransferTransaction(
-    {
-      address: accountAddress,
-      amount,
-      asset,
-      recipient: toAddress,
-    },
-    provider,
-    chainId
-  );
+  const recipient = await resolveSendAddress(toAddress);
+  const rawAmount = parsePositiveRawAmount(amount, asset.decimals, new RainbowError('[buildSendCallFromSendDetails]: invalid send amount'));
 
-  return buildSendCall(transaction);
+  if (isNativeAsset(asset.address, chainId)) {
+    return {
+      data: '0x',
+      to: recipient,
+      value: rawAmount,
+    };
+  }
+
+  return {
+    data: encodeErc20Transfer({ amount: rawAmount, to: recipient }),
+    to: requireAddress(asset.address, new RainbowError('[buildSendCallFromSendDetails]: invalid token address')),
+    value: 0n,
+  };
 }
 
 export async function executeSponsoredSendIfAvailable({
@@ -74,35 +78,22 @@ export async function executeSponsoredSendIfAvailable({
   signer,
   transaction,
 }: ExecuteSponsoredSendIfAvailableParams): Promise<boolean> {
-  if (!isAddress(accountAddress)) return false;
-
-  let preparedSponsoredSendCalls = preparedCalls;
-
-  if (!preparedCalls && !isPreparedCallsExecutionSponsored(preparedSponsoredSendCalls)) {
-    try {
-      preparedSponsoredSendCalls = await prepareSponsoredSend({
-        accountAddress,
-        call,
-        chainId,
-      });
-    } catch (error) {
-      logger.warn('[executeSponsoredSendIfAvailable]: sponsored send preparation failed during submit', {
-        message: ensureError(error).message,
-      });
-    }
-  }
-
-  if (!isPreparedCallsExecutionSponsored(preparedSponsoredSendCalls)) return false;
+  if (!isAddress(accountAddress) || !isPreparedCallsExecutionSponsored(preparedCalls)) return false;
 
   const sponsoredExecution = await executeSponsoredSendWithTracking({
     accountAddress,
     call,
     chainId,
-    preparedCalls: preparedSponsoredSendCalls,
+    preparedCalls,
     provider,
     signer,
     transaction: buildPendingSendTransaction({ call, transaction }),
   });
 
   return Boolean(sponsoredExecution);
+}
+
+async function resolveSendAddress(address: string): Promise<Address> {
+  const resolved = await resolveNameOrAddress(address);
+  return requireAddress(resolved, new RainbowError('[buildSendCallFromSendDetails]: invalid recipient'));
 }

--- a/src/features/delegation/sponsoredSendExecution.ts
+++ b/src/features/delegation/sponsoredSendExecution.ts
@@ -9,7 +9,6 @@ import { encodeErc20Transfer } from '@/framework/core/evm/erc20Calldata';
 import { parsePositiveRawAmount } from '@/framework/core/evm/units';
 import { isNativeAsset } from '@/handlers/assets';
 import { resolveNameOrAddress } from '@/handlers/web3';
-import { RainbowError } from '@/logger';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { type Call, type ExecuteCallsResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
@@ -51,7 +50,7 @@ export async function buildSendCallFromSendDetails({
   toAddress,
 }: BuildSendCallFromSendDetailsParams): Promise<Call> {
   const recipient = await resolveSendAddress(toAddress);
-  const rawAmount = parsePositiveRawAmount(amount, asset.decimals, new RainbowError('[buildSendCallFromSendDetails]: invalid send amount'));
+  const rawAmount = parsePositiveRawAmount(amount, asset.decimals, '[buildSendCallFromSendDetails]: invalid send amount');
 
   if (isNativeAsset(asset.address, chainId)) {
     return {
@@ -63,7 +62,7 @@ export async function buildSendCallFromSendDetails({
 
   return {
     data: encodeErc20Transfer({ amount: rawAmount, to: recipient }),
-    to: requireAddress(asset.address, new RainbowError('[buildSendCallFromSendDetails]: invalid token address')),
+    to: requireAddress(asset.address, '[buildSendCallFromSendDetails]: invalid token address'),
     value: 0n,
   };
 }
@@ -95,5 +94,5 @@ export async function executeSponsoredSendIfAvailable({
 
 async function resolveSendAddress(address: string): Promise<Address> {
   const resolved = await resolveNameOrAddress(address);
-  return requireAddress(resolved, new RainbowError('[buildSendCallFromSendDetails]: invalid recipient'));
+  return requireAddress(resolved, '[buildSendCallFromSendDetails]: invalid recipient');
 }

--- a/src/features/send/hooks/useSendSubmit.ts
+++ b/src/features/send/hooks/useSendSubmit.ts
@@ -14,7 +14,7 @@ import { TransactionStatus, type NewTransaction } from '@/entities/transactions'
 import { type UniqueAsset } from '@/entities/uniqueAssets';
 import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
 import { executeSponsoredSend } from '@/features/delegation/sponsoredSend';
-import { buildSendCallFromSendDetails, executeSponsoredSendIfAvailable } from '@/features/delegation/sponsoredSendExecution';
+import { executeSponsoredSendIfAvailable } from '@/features/delegation/sponsoredSendExecution';
 import type useENSProfile from '@/features/ens/hooks/useENSProfile';
 import { type ActionTypes } from '@/features/ens/hooks/useENSRegistrationActionHandler';
 import { type REGISTRATION_STEPS } from '@/features/ens/utils/helpers';
@@ -29,7 +29,7 @@ import {
   type NewTransactionNonNullable,
 } from '@/handlers/web3';
 import { WrappedAlert as Alert } from '@/helpers/alert';
-import { lessThan } from '@/helpers/utilities';
+import { greaterThan, lessThan } from '@/helpers/utilities';
 import * as i18n from '@/languages';
 import { ensureError, logger, RainbowError } from '@/logger';
 import { loadWallet, sendTransaction } from '@/model/wallet';
@@ -44,7 +44,7 @@ import { useNftsStore } from '@/state/nfts/nfts';
 import { getNextNonce } from '@/state/nonces';
 import { addNewTransaction } from '@/state/pendingTransactions';
 import { executeFn, Screens, TimeToSignOperation } from '@/state/performance/performance';
-import { type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 type SelectedGasFeeForTx = Parameters<typeof parseGasParamsForTransaction>[0];
 type LoadedWallet = NonNullable<Awaited<ReturnType<typeof loadWallet>>>;
@@ -96,7 +96,6 @@ type EnsProps = {
 type UseSendSubmitParams = {
   accountAddress: string;
   amountDetails: AmountDetails;
-  canUseSponsoredSend: boolean;
   currentChainId: ChainId;
   currentProvider: StaticJsonRpcProvider | undefined;
   ens: EnsProps;
@@ -106,6 +105,7 @@ type UseSendSubmitParams = {
   nativeCurrency: NativeCurrencyKey;
   recipient: RecipientProps;
   selected: ParsedAddressAsset | UniqueAsset | undefined;
+  sponsoredSendPreparedCall: Call | null;
   sponsoredSendPreparedCalls: PreparedCallsExecution | null;
 };
 
@@ -116,7 +116,6 @@ type UseSendSubmitResult = {
 export function useSendSubmit({
   accountAddress,
   amountDetails,
-  canUseSponsoredSend,
   currentChainId,
   currentProvider,
   ens: { ensName, ensProfile, isENS, transferENS },
@@ -126,6 +125,7 @@ export function useSendSubmit({
   nativeCurrency,
   recipient: { isValidAddress, recipient, toAddress },
   selected,
+  sponsoredSendPreparedCall,
   sponsoredSendPreparedCalls,
 }: UseSendSubmitParams): UseSendSubmitResult {
   const queryClient = useQueryClient();
@@ -227,26 +227,26 @@ export function useSendSubmit({
       };
 
       try {
-        const didSubmitSponsoredSend = await submitSponsoredSend({
-          accountAddress,
-          amount: amountDetails.assetAmount,
-          canUseSponsoredSend,
-          chainId: currentChainId,
-          chainName: currentChainIdNetwork,
-          preparedCalls: sponsoredSendPreparedCalls,
-          provider: currentProvider,
-          screen,
-          selectedAddressAsset,
-          signer: wallet,
-          toAddress,
-        });
-
-        if (didSubmitSponsoredSend) {
-          invalidateInteractionsCount();
-          return true;
-        }
-
         if (isSponsoredSend) {
+          const didSubmitSponsoredSend = await submitSponsoredSend({
+            accountAddress,
+            amount: amountDetails.assetAmount,
+            chainId: currentChainId,
+            chainName: currentChainIdNetwork,
+            call: sponsoredSendPreparedCall,
+            preparedCalls: sponsoredSendPreparedCalls,
+            provider: currentProvider,
+            screen,
+            selectedAddressAsset,
+            signer: wallet,
+            toAddress,
+          });
+
+          if (didSubmitSponsoredSend) {
+            invalidateInteractionsCount();
+            return true;
+          }
+
           setSponsoredSendUnavailable({
             chainId: currentChainId,
             error: new RainbowError('[useSendSubmit]: submitSponsoredSend returned false even though sponsored send was selected'),
@@ -301,7 +301,6 @@ export function useSendSubmit({
       accountAddress,
       amountDetails.assetAmount,
       amountDetails.isSufficientBalance,
-      canUseSponsoredSend,
       currentChainId,
       currentProvider,
       ensName,
@@ -317,6 +316,7 @@ export function useSendSubmit({
       nativeCurrency,
       queryClient,
       selected,
+      sponsoredSendPreparedCall,
       selectedGasFee,
       sponsoredSendPreparedCalls,
       toAddress,
@@ -328,7 +328,7 @@ export function useSendSubmit({
 
   const submitTransaction = useCallback(
     async (args?: OnSubmitProps) => {
-      if (Number(amountDetails.assetAmount) <= 0) {
+      if (!greaterThan(amountDetails.assetAmount, 0)) {
         logger.error(new RainbowError(`[useSendSubmit]: preventing tx submit because amountDetails.assetAmount is <= 0`), {
           amountDetails,
         });
@@ -398,7 +398,7 @@ function getTransactionAsset(asset: ParsedAddressAsset, network: string): NonNul
 async function submitSponsoredSend({
   accountAddress,
   amount,
-  canUseSponsoredSend,
+  call,
   chainId,
   chainName,
   preparedCalls,
@@ -410,7 +410,7 @@ async function submitSponsoredSend({
 }: {
   accountAddress: string;
   amount: string;
-  canUseSponsoredSend: boolean;
+  call: Call | null;
   chainId: ChainId;
   chainName: string;
   preparedCalls: PreparedCallsExecution | null;
@@ -420,16 +420,8 @@ async function submitSponsoredSend({
   signer: LoadedWallet;
   toAddress: string;
 }): Promise<boolean> {
-  if (!canUseSponsoredSend || !selectedAddressAsset) return false;
+  if (!selectedAddressAsset || !call) return false;
 
-  const sendCall = await buildSendCallFromSendDetails({
-    accountAddress,
-    amount,
-    asset: selectedAddressAsset,
-    chainId,
-    provider,
-    toAddress,
-  });
   const sponsoredSendTransaction: SponsoredSendTransaction = {
     amount,
     asset: getTransactionAsset(selectedAddressAsset, chainName),
@@ -442,7 +434,7 @@ async function submitSponsoredSend({
 
   return executeSponsoredSendIfAvailable({
     accountAddress,
-    call: sendCall,
+    call,
     chainId,
     executeSponsoredSendWithTracking: executeFn(executeSponsoredSend, {
       screen,

--- a/src/features/send/hooks/useSponsoredSendPreparation.test.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.test.ts
@@ -1,4 +1,4 @@
-import { type Address } from 'viem';
+import { getAddress, type Address } from 'viem';
 
 import { ChainId } from '@/state/backendNetworks/types';
 
@@ -24,7 +24,8 @@ jest.mock('@/features/delegation/willDelegate', () => ({
   supportsDelegatedExecution: (params: unknown) => mockSupportsDelegatedExecution(params),
 }));
 
-const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const ACCOUNT = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' satisfies Address;
+const CHECKSUM_ACCOUNT = getAddress(ACCOUNT);
 
 const SELECTED_ASSET = {
   address: '0x5555555555555555555555555555555555555555',
@@ -79,7 +80,6 @@ describe('getSponsoredSendRequestKey', () => {
       toAddress: '0x4444444444444444444444444444444444444444',
     };
 
-    // Number('0.999999999999999999') === 1, so a Number()-based key would collide these.
     expect(getSponsoredSendRequestKey({ ...request, amount: '0.999999999999999999' })).not.toBe(
       getSponsoredSendRequestKey({ ...request, amount: '1' })
     );
@@ -148,10 +148,10 @@ describe('getCachedDelegationSupport', () => {
   it('normalizes cache keys by account and chain', () => {
     expect(
       getDelegationSupportRequestKey({
-        accountAddress: ACCOUNT.toUpperCase() as Address,
+        accountAddress: CHECKSUM_ACCOUNT,
         chainId: ChainId.base,
       })
-    ).toBe('0x3333333333333333333333333333333333333333:8453');
+    ).toBe('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:8453');
   });
 
   it('reuses the same delegation support request for matching account and chain', async () => {
@@ -161,7 +161,7 @@ describe('getCachedDelegationSupport', () => {
     await expect(getCachedDelegationSupport({ accountAddress: ACCOUNT, cache, chainId: ChainId.base })).resolves.toBe(true);
     await expect(
       getCachedDelegationSupport({
-        accountAddress: ACCOUNT.toUpperCase() as Address,
+        accountAddress: CHECKSUM_ACCOUNT,
         cache,
         chainId: ChainId.base,
       })

--- a/src/features/send/hooks/useSponsoredSendPreparation.test.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.test.ts
@@ -4,17 +4,12 @@ import { ChainId } from '@/state/backendNetworks/types';
 
 import { getCachedDelegationSupport, getDelegationSupportRequestKey, getSponsoredSendRequestKey } from './useSponsoredSendPreparation';
 
-jest.mock('@/handlers/web3', () => ({
-  buildTransferTransaction: jest.fn(),
-}));
-
 jest.mock('@/model/remoteConfig', () => ({
   getRemoteConfig: () => ({ sponsored_sends_enabled: true }),
   useRemoteConfig: () => ({ sponsored_sends_enabled: true }),
 }));
 
 jest.mock('@/features/delegation/sponsoredSend', () => ({
-  buildSendCall: jest.fn(),
   predictSponsoredSend: jest.fn(),
   prepareSponsoredSend: jest.fn(),
 }));

--- a/src/features/send/hooks/useSponsoredSendPreparation.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.ts
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { type StaticJsonRpcProvider } from '@ethersproject/providers';
-import { parseUnits } from '@ethersproject/units';
 import { isAddress, type Address } from 'viem';
 
 import { type ParsedAddressAsset } from '@/entities/tokens';
@@ -9,16 +8,16 @@ import { isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
 import { predictSponsoredSend, prepareSponsoredSend } from '@/features/delegation/sponsoredSend';
 import { buildSendCallFromSendDetails } from '@/features/delegation/sponsoredSendExecution';
 import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
+import { parsePositiveRawAmount } from '@/framework/core/evm/units';
 import { ensureError, logger } from '@/logger';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { type ChainId } from '@/state/backendNetworks/types';
-import { type PreparedCallsExecution } from '@rainbow-me/delegation';
+import { type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
-type PreparedSponsoredSendState = {
-  key: string;
-  preparedCalls: PreparedCallsExecution | null;
-};
+type PreparedSponsoredSendState =
+  | { call: Call; key: string; preparedCalls: PreparedCallsExecution | null }
+  | { call: null; key: string; preparedCalls: null };
 
 type DelegationSupportCache = Map<string, Promise<boolean>>;
 type DelegationSupportLoader = (params: { address: Address; chainId: ChainId }) => Promise<boolean>;
@@ -75,13 +74,8 @@ export function getSponsoredSendRequestKey({
   selected: Pick<ParsedAddressAsset, 'address' | 'decimals' | 'uniqueId'>;
   toAddress: string;
 }): string | null {
-  let rawAmount: bigint;
-  try {
-    rawAmount = BigInt(parseUnits(amount, selected.decimals).toString());
-  } catch {
-    return null;
-  }
-  if (rawAmount <= 0n) return null;
+  const rawAmount = parsePositiveRawAmount(amount, selected.decimals);
+  if (rawAmount === null) return null;
 
   return [
     accountAddress.toLowerCase(),
@@ -147,6 +141,7 @@ export function useSponsoredSendPreparation({
   const hasResolvedSponsoredSend = preparedSponsoredSend?.key === sponsoredSendRequestKey;
   const preparedCalls = hasResolvedSponsoredSend ? preparedSponsoredSend.preparedCalls : null;
   const isSponsoredSend = isPreparedCallsExecutionSponsored(preparedCalls);
+  const preparedCall = hasResolvedSponsoredSend && isSponsoredSend ? preparedSponsoredSend.call : null;
   const shouldShowSponsoredSendGas =
     canUseSponsoredSend &&
     (!sponsoredSendRequestKey || isPreparingSponsoredSend || debouncedAmount !== amount || !hasResolvedSponsoredSend || isSponsoredSend);
@@ -174,11 +169,9 @@ export function useSponsoredSendPreparation({
 
       try {
         const call = await buildSendCallFromSendDetails({
-          accountAddress,
           amount: debouncedAmount,
           asset: selected,
           chainId,
-          provider,
           toAddress,
         });
         if (abortController.signal.aborted) return;
@@ -199,14 +192,14 @@ export function useSponsoredSendPreparation({
         });
 
         if (!isStale) {
-          setPreparedSponsoredSend({ key: debouncedSponsoredSendRequestKey, preparedCalls: nextPreparedCalls });
+          setPreparedSponsoredSend({ call, key: debouncedSponsoredSendRequestKey, preparedCalls: nextPreparedCalls });
         }
       } catch (error) {
         if (abortController.signal.aborted) return;
         const message = ensureError(error).message;
         logger.warn('[useSponsoredSendPreparation]: sponsored send preparation failed', { message });
         if (!isStale) {
-          setPreparedSponsoredSend({ key: debouncedSponsoredSendRequestKey, preparedCalls: null });
+          setPreparedSponsoredSend({ call: null, key: debouncedSponsoredSendRequestKey, preparedCalls: null });
         }
       } finally {
         if (!isStale) {
@@ -248,19 +241,13 @@ export function useSponsoredSendPreparation({
   }, [accountAddress, canUseSponsoredSend, chainId]);
 
   return {
-    // [sync gate] form valid + remote config on + chain/account predicted eligible; no network call. Top-level gate for everything below.
     canUseSponsoredSend,
-    // [prep lifecycle] prepared calls match the current (live) amount's request key — i.e. preparation finished for what's on screen now.
     hasResolvedSponsoredSend,
-    // [prep lifecycle] async build → prepare is in flight (debounced amount).
     isPreparingSponsoredSend,
-    // [prep result] the resolved prepared calls are actually sponsor-paid (fees.payer === 'sponsor').
     isSponsoredSend,
-    // [async capability] network-confirmed 7702 delegation support. Drives balance math (ignoreGasFee), NOT the prep flow.
     isSponsorshipSupported,
-    // [prep result] prepared calls for the current request, or null until hasResolvedSponsoredSend is true.
+    preparedCall,
     preparedCalls,
-    // [derived UI] hide the gas selector / skip gas estimation while sponsored gas applies. Pure derivation of the gate + prep lifecycle.
     shouldShowSponsoredSendGas,
   };
 }

--- a/src/features/send/screens/SendSheet.tsx
+++ b/src/features/send/screens/SendSheet.tsx
@@ -37,6 +37,7 @@ import {
   convertAmountAndPriceToNativeDisplay,
   convertAmountFromNativeValue,
   formatInputDecimals,
+  greaterThan,
   greaterThanOrEqualTo,
 } from '@/helpers/utilities';
 import { checkIsValidAddressOrDomain, checkIsValidAddressOrDomainFormat, isENSAddressFormat } from '@/helpers/validators';
@@ -217,6 +218,7 @@ export default function SendSheet() {
     isPreparingSponsoredSend,
     isSponsoredSend,
     isSponsorshipSupported,
+    preparedCall: sponsoredSendPreparedCall,
     preparedCalls: sponsoredSendPreparedCalls,
     shouldShowSponsoredSendGas,
   } = useSponsoredSendPreparation({
@@ -422,7 +424,6 @@ export default function SendSheet() {
   const { submitTransaction } = useSendSubmit({
     accountAddress,
     amountDetails,
-    canUseSponsoredSend,
     currentChainId,
     currentProvider,
     ens: { ensName, ensProfile, isENS, transferENS },
@@ -432,6 +433,7 @@ export default function SendSheet() {
     nativeCurrency,
     recipient: { isValidAddress, recipient, toAddress },
     selected,
+    sponsoredSendPreparedCall,
     sponsoredSendPreparedCalls,
   });
 
@@ -613,8 +615,8 @@ export default function SendSheet() {
     if (
       selected &&
       !!accountAddress &&
-      !shouldShowSponsoredSendGas &&
-      Number(amountDetails.assetAmount) > 0 &&
+      !isSponsoredSend &&
+      greaterThan(amountDetails.assetAmount, 0) &&
       assetChainId === currentChainId &&
       currentProviderChainId === currentChainId &&
       toAddress &&
@@ -649,9 +651,9 @@ export default function SendSheet() {
     amountDetails.assetAmount,
     currentProvider,
     isValidAddress,
+    isSponsoredSend,
     recipient,
     selected,
-    shouldShowSponsoredSendGas,
     toAddress,
     updateTxFee,
     updateTxFeeForOptimism,

--- a/src/features/send/utils/sendSheetUtils.ts
+++ b/src/features/send/utils/sendSheetUtils.ts
@@ -1,3 +1,4 @@
+import { greaterThan } from '@/helpers/utilities';
 import * as i18n from '@/languages';
 
 type GetSendSubmitButtonStateParams = {
@@ -31,7 +32,7 @@ export function getSendSubmitButtonState({
   nativeAssetSymbol,
   sponsoredAmountIsStale,
 }: GetSendSubmitButtonStateParams) {
-  const isZeroAssetAmount = Number(assetAmount) <= 0;
+  const isZeroAssetAmount = !greaterThan(assetAmount, 0);
   const hasSufficientGasForSend = isSponsoredSend || isSufficientGas;
   const hasValidGasForSend = isSponsoredSend || isValidGas;
   const isWaitingForGas = !isSponsoredSend && !isGasFeeReady;

--- a/src/framework/core/evm/address.ts
+++ b/src/framework/core/evm/address.ts
@@ -1,9 +1,16 @@
-import { isAddress, type Address } from 'viem';
+import { getAddress, type Address } from 'viem';
+
+import { RainbowError } from '@/logger';
 
 /**
- * Returns a validated viem `Address` value or throws the supplied error.
+ * Returns a validated viem `Address` or throws an error with the provided message.
  */
-export function requireAddress(value: string | null | undefined, error: Error): Address {
-  if (value && isAddress(value)) return value;
-  throw error;
+export function requireAddress(value: string | null | undefined, errorMessage: string): Address {
+  if (!value) throw new RainbowError(errorMessage);
+
+  try {
+    return getAddress(value);
+  } catch {
+    throw new RainbowError(errorMessage);
+  }
 }

--- a/src/framework/core/evm/address.ts
+++ b/src/framework/core/evm/address.ts
@@ -1,0 +1,9 @@
+import { isAddress, type Address } from 'viem';
+
+/**
+ * Returns a validated viem `Address` value or throws the supplied error.
+ */
+export function requireAddress(value: string | null | undefined, error: Error): Address {
+  if (value && isAddress(value)) return value;
+  throw error;
+}

--- a/src/framework/core/evm/units.test.ts
+++ b/src/framework/core/evm/units.test.ts
@@ -15,8 +15,6 @@ describe('parsePositiveRawAmount', () => {
   });
 
   it('throws the supplied error when requested', () => {
-    const error = new Error('invalid amount');
-
-    expect(() => parsePositiveRawAmount('0', 18, error)).toThrow(error);
+    expect(() => parsePositiveRawAmount('0', 18, 'invalid amount')).toThrow('invalid amount');
   });
 });

--- a/src/framework/core/evm/units.test.ts
+++ b/src/framework/core/evm/units.test.ts
@@ -1,0 +1,22 @@
+import { parsePositiveRawAmount } from './units';
+
+describe('parsePositiveRawAmount', () => {
+  it('parses exact positive decimal amounts as base units', () => {
+    expect(parsePositiveRawAmount('0.999999999999999999', 18)).toBe(999999999999999999n);
+    expect(parsePositiveRawAmount('1', 18)).toBe(1000000000000000000n);
+    expect(parsePositiveRawAmount('1.0000000000000000000', 18)).toBe(1000000000000000000n);
+    expect(parsePositiveRawAmount('.', 18)).toBeNull();
+    expect(parsePositiveRawAmount('0', 18)).toBeNull();
+  });
+
+  it('rejects decimal amounts that cannot be represented in base units', () => {
+    expect(parsePositiveRawAmount('0.9999999999999999999', 18)).toBeNull();
+    expect(parsePositiveRawAmount('0.0000000000000000005', 18)).toBeNull();
+  });
+
+  it('throws the supplied error when requested', () => {
+    const error = new Error('invalid amount');
+
+    expect(() => parsePositiveRawAmount('0', 18, error)).toThrow(error);
+  });
+});

--- a/src/framework/core/evm/units.ts
+++ b/src/framework/core/evm/units.ts
@@ -1,0 +1,18 @@
+import { parseUnits } from '@ethersproject/units';
+
+/** Parses a positive decimal amount into raw base units without rounding. */
+export function parsePositiveRawAmount(amount: string, decimals: number): bigint | null;
+export function parsePositiveRawAmount(amount: string, decimals: number, error: Error): bigint;
+export function parsePositiveRawAmount(amount: string, decimals: number, error?: Error): bigint | null {
+  try {
+    const value = BigInt(parseUnits(amount, decimals).toString());
+    return value > 0n ? value : invalidRawAmount(error);
+  } catch {
+    return invalidRawAmount(error);
+  }
+}
+
+function invalidRawAmount(error?: Error): null {
+  if (error) throw error;
+  return null;
+}

--- a/src/framework/core/evm/units.ts
+++ b/src/framework/core/evm/units.ts
@@ -1,18 +1,22 @@
 import { parseUnits } from '@ethersproject/units';
 
-/** Parses a positive decimal amount into raw base units without rounding. */
+import { RainbowError } from '@/logger';
+
+/**
+ * Parses a positive decimal amount into raw base units without rounding.
+ */
 export function parsePositiveRawAmount(amount: string, decimals: number): bigint | null;
-export function parsePositiveRawAmount(amount: string, decimals: number, error: Error): bigint;
-export function parsePositiveRawAmount(amount: string, decimals: number, error?: Error): bigint | null {
+export function parsePositiveRawAmount(amount: string, decimals: number, errorMessage: string): bigint;
+export function parsePositiveRawAmount(amount: string, decimals: number, errorMessage?: string): bigint | null {
   try {
     const value = BigInt(parseUnits(amount, decimals).toString());
-    return value > 0n ? value : invalidRawAmount(error);
+    return value > 0n ? value : invalidRawAmount(errorMessage);
   } catch {
-    return invalidRawAmount(error);
+    return invalidRawAmount(errorMessage);
   }
 }
 
-function invalidRawAmount(error?: Error): null {
-  if (error) throw error;
+function invalidRawAmount(errorMessage?: string): null {
+  if (errorMessage) throw new RainbowError(errorMessage);
   return null;
 }

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -6,7 +6,7 @@ import { isHexString as isEthersHexString } from '@ethersproject/bytes';
 import { type Contract } from '@ethersproject/contracts';
 import { isValidMnemonic as ethersIsValidMnemonic } from '@ethersproject/hdnode';
 import { JsonRpcBatchProvider, StaticJsonRpcProvider, type Block, type TransactionRequest } from '@ethersproject/providers';
-import { parseEther } from '@ethersproject/units';
+import { parseEther, parseUnits } from '@ethersproject/units';
 import Resolution from '@unstoppabledomains/resolution';
 import { startsWith } from 'lodash';
 import { type Address, type Hex } from 'viem';
@@ -648,10 +648,19 @@ export const buildTransferTransaction = async (
   provider: StaticJsonRpcProvider | undefined,
   chainId: ChainId
 ): Promise<TransactionRequest> => {
-  const _amount =
-    greaterThan(amount, 0) && assetIsParsedAddressAsset(asset)
-      ? convertAmountToRawAmount(amount, asset.decimals)
-      : estimateAssetBalancePortion(asset);
+  const isParsedAsset = assetIsParsedAddressAsset(asset);
+  const hasPositiveAmount = amount.length > 0 && greaterThan(amount, 0);
+  let rawAmount: string | null = null;
+
+  if (hasPositiveAmount && isParsedAsset) {
+    try {
+      rawAmount = parseUnits(amount, asset.decimals).toString();
+    } catch {
+      throw new RainbowError('[buildTransferTransaction]: invalid send amount');
+    }
+  }
+
+  const _amount = hasPositiveAmount && rawAmount !== null ? rawAmount : estimateAssetBalancePortion(asset);
   const value = _amount.toString();
   const _recipient = (await resolveNameOrAddress(recipient)) as string;
   let txData: TransactionRequest = {


### PR DESCRIPTION
Fixes APP-3680

## What changed (plus any additional context for devs)
- Follow-up to #7549
  - Completes the send precision fixes for max amounts/sponsored sends
  - Adds test coverage for exact amount parsing and sponsored native/token sends
- For consistency, send now submits the same sponsored send the sheet prepared, rather than rebuilding at submit time
- Adds stricter validation for loosely type send flow state

## Screen recordings / screenshots

## What to test
