### PR TITLE
fix: record failed sponsored sends to the activities

### DIFF
--- a/src/features/delegation/callsExecutionTracking.ts
+++ b/src/features/delegation/callsExecutionTracking.ts
@@ -1,15 +1,16 @@
-import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
+import { buildTransactionTitle, TransactionStatus, type NewTransaction } from '@/entities/transactions';
 import { convertNewTransactionToRainbowTransaction } from '@/parsers/transactions';
 import { extractReplayableCall } from '@/raps/replay';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { addNewTransaction, pendingTransactionsActions } from '@/state/pendingTransactions';
 import { type ExecuteCallsResult, type ExecutionResult } from '@rainbow-me/delegation';
 
+import { resolveManagedExecutionFailure } from './managedExecutionFailure';
+
 type ManagedCallsExecution = Extract<ExecuteCallsResult, { kind: 'calls.managed' }>;
-type SubmittedCallsExecution = ManagedCallsExecution | ExecutionResult;
 
 /**
- * Registers a submitted SDK exact-call execution with the local pending transaction overlay.
+ * Registers a submitted wallet-owned SDK exact-call execution with the local pending transaction overlay.
  */
 export function trackCallsExecution({
   address,
@@ -21,18 +22,17 @@ export function trackCallsExecution({
   address: string;
   batch: boolean;
   chainId: ChainId;
-  execution: SubmittedCallsExecution;
+  execution: ExecutionResult;
   transaction: Omit<NewTransaction, 'hash'>;
 }): void {
-  if ('kind' in execution) {
-    trackManagedCallsExecution({ address, batch, execution, transaction });
-    return;
-  }
-
   trackWalletCallsExecution({ address, batch, chainId, execution, transaction });
 }
 
-function trackManagedCallsExecution({
+/**
+ * Records a managed relay execution in the local overlay and returns the
+ * terminal failure message, when the relay rejected it before onchain indexing.
+ */
+export async function trackManagedCallsExecutionResult({
   address,
   batch,
   execution,
@@ -42,16 +42,50 @@ function trackManagedCallsExecution({
   batch: boolean;
   execution: ManagedCallsExecution;
   transaction: Omit<NewTransaction, 'hash'>;
+}): Promise<string | null> {
+  const failureMessage = await resolveManagedExecutionFailure({
+    executionId: execution.executionId,
+    status: execution.status,
+  });
+
+  addManagedCallsTransaction({
+    address,
+    batch,
+    execution,
+    status: failureMessage ? TransactionStatus.failed : TransactionStatus.pending,
+    transaction,
+  });
+
+  return failureMessage;
+}
+
+function addManagedCallsTransaction({
+  address,
+  batch,
+  execution,
+  status,
+  transaction,
+}: {
+  address: string;
+  batch: boolean;
+  execution: ManagedCallsExecution;
+  status: TransactionStatus.failed | TransactionStatus.pending;
+  transaction: Omit<NewTransaction, 'hash'>;
 }): void {
+  const parsedTransaction = convertNewTransactionToRainbowTransaction({
+    ...transaction,
+    ...(batch ? { batch: true, delegation: false } : undefined),
+    hash: execution.executionId,
+    relayExecutionId: execution.executionId,
+  });
+
   pendingTransactionsActions.addPendingTransaction({
     address,
-    pendingTransaction: convertNewTransactionToRainbowTransaction({
-      ...transaction,
-      ...(batch ? { batch: true, delegation: false } : undefined),
-      hash: execution.executionId,
-      relayExecutionId: execution.executionId,
-      status: TransactionStatus.pending,
-    }),
+    pendingTransaction: {
+      ...parsedTransaction,
+      status,
+      title: buildTransactionTitle(parsedTransaction.type, status),
+    },
   });
 }
 

--- a/src/features/delegation/sponsoredSend.test.ts
+++ b/src/features/delegation/sponsoredSend.test.ts
@@ -20,9 +20,9 @@ const mockCreateDelegationPublicClient = jest.fn<unknown, [ChainId, { signal?: A
 const mockExecuteCalls = jest.fn<Promise<unknown>, [unknown, unknown?]>();
 const mockIsSponsorshipEligible = jest.fn<boolean, [ChainId]>();
 const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
-const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unknown]>();
 const mockSupportsDelegatedExecution = jest.fn<Promise<boolean>, [unknown]>();
 const mockTrackCallsExecution = jest.fn<void, [unknown]>();
+const mockTrackManagedCallsExecutionResult = jest.fn<Promise<string | null>, [unknown]>();
 
 const mockRemoteConfig = {
   sponsored_sends_enabled: true,
@@ -63,10 +63,7 @@ jest.mock('./calls', () => ({
 
 jest.mock('./callsExecutionTracking', () => ({
   trackCallsExecution: (params: unknown) => mockTrackCallsExecution(params),
-}));
-
-jest.mock('./managedExecutionFailure', () => ({
-  resolveManagedExecutionFailure: (params: unknown) => mockResolveManagedExecutionFailure(params),
+  trackManagedCallsExecutionResult: (params: unknown) => mockTrackManagedCallsExecutionResult(params),
 }));
 
 jest.mock('./willDelegate', () => ({
@@ -136,7 +133,7 @@ describe('sponsoredSend', () => {
       kind: 'calls.managed',
       review: { fees: { payer: 'sponsor' } },
     });
-    mockResolveManagedExecutionFailure.mockResolvedValue(null);
+    mockTrackManagedCallsExecutionResult.mockResolvedValue(null);
     mockSupportsDelegatedExecution.mockResolvedValue(true);
   });
 
@@ -271,17 +268,13 @@ describe('sponsoredSend', () => {
         signer,
       }
     );
-    expect(mockResolveManagedExecutionFailure).toHaveBeenCalledWith({
-      executionId: 'submitted-send',
-      status: 'PENDING',
-    });
-    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+    expect(mockTrackManagedCallsExecutionResult).toHaveBeenCalledWith({
       address: ACCOUNT,
       batch: false,
-      chainId,
       execution: managedExecution,
       transaction: pendingTransaction,
     });
+    expect(mockTrackCallsExecution).not.toHaveBeenCalled();
   });
 
   it('executes an unprepared send by building a sponsored exact-call request', async () => {
@@ -321,16 +314,23 @@ describe('sponsoredSend', () => {
     });
   });
 
-  it('raises managed execution failures before tracking the send', async () => {
-    mockExecuteCalls.mockResolvedValue({
+  it('records the failed send before raising managed execution failures', async () => {
+    const failedExecution = {
       executionId: 'failed-send',
       kind: 'calls.managed',
       status: 'FAILED',
-    });
-    mockResolveManagedExecutionFailure.mockResolvedValue('relay reverted');
+    };
+    mockExecuteCalls.mockResolvedValue(failedExecution);
+    mockTrackManagedCallsExecutionResult.mockResolvedValue('relay reverted');
 
     await expect(executeWith()).rejects.toThrow('[executeSponsoredSend]: relay reverted');
 
+    expect(mockTrackManagedCallsExecutionResult).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      execution: failedExecution,
+      transaction: pendingTransaction,
+    });
     expect(mockTrackCallsExecution).not.toHaveBeenCalled();
   });
 });

--- a/src/features/delegation/sponsoredSend.ts
+++ b/src/features/delegation/sponsoredSend.ts
@@ -12,8 +12,7 @@ import { type ChainId } from '@/state/backendNetworks/types';
 import { execute, type Call, type ExecuteCallsResult, type ExecutionResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
 
 import { createDelegationPublicClient, SPONSORED_CALLS_REQUIREMENTS } from './calls';
-import { trackCallsExecution } from './callsExecutionTracking';
-import { resolveManagedExecutionFailure } from './managedExecutionFailure';
+import { trackCallsExecution, trackManagedCallsExecutionResult } from './callsExecutionTracking';
 import { predictSponsoredCallsExecution } from './sponsoredCalls';
 import { canUseDelegatedExecution, supportsDelegatedExecution } from './willDelegate';
 
@@ -94,22 +93,17 @@ export async function executeSponsoredSend({
   const execution = await executeSendCall({ call, chainId, preparedCalls, provider, signer });
 
   if (execution.kind === 'calls.managed') {
-    const failureMessage = await resolveManagedExecutionFailure({
-      executionId: execution.executionId,
-      status: execution.status,
+    const failureMessage = await trackManagedCallsExecutionResult({
+      address: accountAddress,
+      batch: false,
+      execution,
+      transaction,
     });
 
     if (failureMessage) {
       throw new RainbowError(`[executeSponsoredSend]: ${failureMessage}`);
     }
 
-    trackCallsExecution({
-      address: accountAddress,
-      batch: false,
-      chainId,
-      execution,
-      transaction,
-    });
     return execution;
   }
 

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.test.ts
@@ -27,8 +27,8 @@ const mockPrepareCalls = jest.fn<Promise<unknown>, [unknown]>();
 const mockBuildStakeRnbwCalls = jest.fn<Promise<Call[]>, [unknown]>();
 const mockBuildStakeRnbwExecutionPlan = jest.fn<Promise<{ calls: Call[]; requirements?: CallsRequirements }>, [unknown]>();
 const mockCanUseDelegatedExecution = jest.fn<boolean, [Address]>();
-const mockResolveManagedExecutionFailure = jest.fn<Promise<string | null>, [unknown]>();
 const mockTrackCallsExecution = jest.fn<void, [unknown]>();
+const mockTrackManagedCallsExecutionResult = jest.fn<Promise<string | null>, [unknown]>();
 const mockWaitForManagedExecutionConfirmation = jest.fn<Promise<void>, [string]>();
 const mockAddNewTransaction = jest.fn<void, [unknown]>();
 
@@ -47,12 +47,9 @@ jest.mock('@rainbow-me/delegation', () => ({
   },
 }));
 
-jest.mock('@/features/delegation/managedExecutionFailure', () => ({
-  resolveManagedExecutionFailure: (params: unknown) => mockResolveManagedExecutionFailure(params),
-}));
-
 jest.mock('@/features/delegation/callsExecutionTracking', () => ({
   trackCallsExecution: (params: unknown) => mockTrackCallsExecution(params),
+  trackManagedCallsExecutionResult: (params: unknown) => mockTrackManagedCallsExecutionResult(params),
 }));
 
 jest.mock('@/features/delegation/waitForManagedExecution', () => ({
@@ -248,7 +245,7 @@ describe('executeStakeRnbw', () => {
     mockBuildStakeRnbwCalls.mockResolvedValue([STAKE_CALL]);
     mockBuildStakeRnbwExecutionPlan.mockResolvedValue({ calls: [STAKE_CALL] });
     mockCanUseDelegatedExecution.mockReturnValue(true);
-    mockResolveManagedExecutionFailure.mockResolvedValue(null);
+    mockTrackManagedCallsExecutionResult.mockResolvedValue(null);
     mockWaitForManagedExecutionConfirmation.mockResolvedValue();
   });
 
@@ -339,14 +336,9 @@ describe('executeStakeRnbw', () => {
       provider,
       signer,
     });
-    expect(mockResolveManagedExecutionFailure).toHaveBeenCalledWith({
-      executionId: 'submitted-stake',
-      status: 'PENDING',
-    });
-    expect(mockTrackCallsExecution).toHaveBeenCalledWith({
+    expect(mockTrackManagedCallsExecutionResult).toHaveBeenCalledWith({
       address: ACCOUNT,
       batch: false,
-      chainId: STAKING_CHAIN_ID,
       execution: {
         executionId: 'submitted-stake',
         kind: 'calls.managed',
@@ -382,6 +374,41 @@ describe('executeStakeRnbw', () => {
     await result.waitForConfirmation();
 
     expect(mockWaitForManagedExecutionConfirmation).toHaveBeenCalledWith('submitted-stake');
+  });
+
+  it('records sponsored staking failures before raising relay errors', async () => {
+    const preparedCalls = await prepareCalls({
+      executionId: 'prepared-stake',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    });
+    const failedExecution = {
+      executionId: 'failed-stake',
+      kind: 'calls.managed',
+      status: 'FAILED',
+    };
+    mockExecuteCalls.mockResolvedValue(failedExecution);
+    mockTrackManagedCallsExecutionResult.mockResolvedValue('relay reverted');
+
+    await expect(
+      executeStakeRnbw({
+        address: ACCOUNT,
+        asset: rnbwAsset,
+        gasParams: GAS_PARAMS,
+        preparedCalls,
+        provider,
+        signer,
+        stakeAmountRaw: STAKE_AMOUNT_RAW,
+      })
+    ).rejects.toThrow('[executeStakeRnbw]: relay reverted');
+
+    expect(mockTrackManagedCallsExecutionResult).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: false,
+      execution: failedExecution,
+      transaction: expect.objectContaining({ type: 'stake' }),
+    });
+    expect(mockWaitForManagedExecutionConfirmation).not.toHaveBeenCalled();
   });
 
   it('builds one raw exact-call plan when software-wallet submission has no prepared calls', async () => {

--- a/src/features/rnbw-staking/utils/executeStakeRnbw.ts
+++ b/src/features/rnbw-staking/utils/executeStakeRnbw.ts
@@ -5,8 +5,7 @@ import { Wallet } from '@ethersproject/wallet';
 import { type Address } from 'viem';
 
 import { TransactionDirection, TransactionStatus, type NewTransaction } from '@/entities/transactions';
-import { trackCallsExecution } from '@/features/delegation/callsExecutionTracking';
-import { resolveManagedExecutionFailure } from '@/features/delegation/managedExecutionFailure';
+import { trackCallsExecution, trackManagedCallsExecutionResult } from '@/features/delegation/callsExecutionTracking';
 import { waitForManagedExecutionConfirmation } from '@/features/delegation/waitForManagedExecution';
 import { canUseDelegatedExecution } from '@/features/delegation/willDelegate';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
@@ -93,22 +92,16 @@ export async function executeStakeRnbw({
     };
   }
 
-  const failureMessage = await resolveManagedExecutionFailure({
-    executionId: execution.executionId,
-    status: execution.status,
+  const failureMessage = await trackManagedCallsExecutionResult({
+    address,
+    batch: false,
+    execution,
+    transaction: buildStakeTransaction({ address, asset, stakeAmountRaw }),
   });
 
   if (failureMessage) {
     throw new RainbowError(`[executeStakeRnbw]: ${failureMessage}`);
   }
-
-  trackCallsExecution({
-    address,
-    batch: false,
-    chainId: STAKING_CHAIN_ID,
-    execution,
-    transaction: buildStakeTransaction({ address, asset, stakeAmountRaw }),
-  });
 
   return {
     executionMode: 'sponsored',

--- a/src/hooks/useWatchPendingTxs.test.ts
+++ b/src/hooks/useWatchPendingTxs.test.ts
@@ -394,11 +394,42 @@ describe('watchPendingTransactions', () => {
       transactions: [pendingTransaction],
     });
 
-    expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);
+    // The relay reported failure without an onchain hash, so the backend can never
+    // index it — the failed send is retained in the overlay so it stays in history.
+    expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([failedTransaction]);
     expect(Object.values(useRainbowToastsStore.getState().toasts)).toHaveLength(1);
     expect(Object.values(useRainbowToastsStore.getState().toasts)[0]?.transaction).toEqual(failedTransaction);
     expect(useAssetUpdatesStore.getState().watchedTransactions[TEST_ADDRESS]).toBeUndefined();
     expect(refetchQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops a failed managed overlay once it has an onchain hash for the backend to index', async () => {
+    const onchainHash: `0x${string}` = '0x3333333333333333333333333333333333333333333333333333333333333333';
+    const pendingTransaction = buildManagedPendingTransaction({ hash: 'execution-1', relayExecutionId: 'execution-1' });
+    const failedTransaction: SettledTransaction = {
+      ...pendingTransaction,
+      hash: onchainHash,
+      status: TransactionStatus.failed,
+      title: 'swap.failed',
+    };
+
+    pendingTransactionsActions.setPendingTransactions({
+      address: TEST_ADDRESS,
+      pendingTransactions: [pendingTransaction],
+    });
+    mockResolveTrackedTransaction.mockResolvedValue({
+      kind: 'settled',
+      transaction: failedTransaction,
+    });
+
+    await watchPendingTransactions({
+      abortController: new AbortController(),
+      address: TEST_ADDRESS,
+      currency: TEST_CURRENCY,
+      transactions: [pendingTransaction],
+    });
+
+    expect(usePendingTransactionsStore.getState().pendingTransactions[TEST_ADDRESS]).toEqual([]);
   });
 
   it('updates the local overlay before managed history sync finishes', async () => {

--- a/src/hooks/useWatchPendingTxs.ts
+++ b/src/hooks/useWatchPendingTxs.ts
@@ -351,7 +351,10 @@ function shouldRetainLocalTransactionOverlay({
   transaction: RainbowTransaction;
 }): boolean {
   if (transaction.status === TransactionStatus.pending) return true;
-  if (transaction.status === TransactionStatus.failed) return false;
+  // A relay send that failed before producing an onchain hash is never indexed by
+  // the backend, so the local overlay is the only place it can surface — retain it.
+  // Failed sends that did reach chain keep their real hash and are left to the backend.
+  if (transaction.status === TransactionStatus.failed) return isAwaitingRelayTransactionHash(transaction);
   if (isAwaitingRelayTransactionHash(transaction)) return false;
   return !isTransactionInHistory({ historyPages, transaction });
 }

--- a/src/raps/execute.test.ts
+++ b/src/raps/execute.test.ts
@@ -1,0 +1,174 @@
+import { Wallet } from '@ethersproject/wallet';
+import { type Address } from 'viem';
+
+import { TransactionStatus, type NewTransaction } from '@/entities/transactions/transaction';
+import { ChainId } from '@/state/backendNetworks/types';
+import { type Call, type PreparedCallsExecution } from '@rainbow-me/delegation';
+
+import { walletExecuteRap } from './execute';
+import { type RapSwapActionParameters } from './references';
+
+const mockExecuteCalls = jest.fn<Promise<unknown>, [unknown, unknown?]>();
+const mockCreateUnlockAndSwapRap = jest.fn<Promise<unknown>, [unknown]>();
+const mockPrepareSwap = jest.fn<Promise<unknown>, [unknown]>();
+const mockTrackCallsExecution = jest.fn<void, [unknown]>();
+const mockTrackManagedCallsExecutionResult = jest.fn<Promise<string | null>, [unknown]>();
+
+jest.mock('@rainbow-me/delegation', () => ({
+  execute: {
+    calls: (params: unknown, clients?: unknown) => mockExecuteCalls(params, clients),
+    prepare: {
+      calls: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/features/delegation/callsExecutionTracking', () => ({
+  trackCallsExecution: (params: unknown) => mockTrackCallsExecution(params),
+  trackManagedCallsExecutionResult: (params: unknown) => mockTrackManagedCallsExecutionResult(params),
+}));
+
+jest.mock('@/handlers/web3', () => ({
+  getProvider: () => ({ name: 'provider' }),
+}));
+
+jest.mock('@/logger', () => ({
+  ensureError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('@/state/performance/performance', () => ({
+  executeFn: (fn: (...args: unknown[]) => unknown) => fn,
+  Screens: {
+    SWAPS: 'SWAPS',
+  },
+  TimeToSignOperation: {
+    BroadcastTransaction: 'BroadcastTransaction',
+    CreateRap: 'CreateRap',
+  },
+}));
+
+jest.mock('@/state/swaps/swapsStore', () => ({
+  swapsStore: {
+    getState: () => ({ degenMode: false }),
+  },
+}));
+
+jest.mock('./actions', () => ({
+  swap: jest.fn(),
+  unlock: jest.fn(),
+}));
+
+jest.mock('./actions/claimClaimable', () => ({
+  claimClaimable: jest.fn(),
+}));
+
+jest.mock('./actions/crosschainSwap', () => ({
+  crosschainSwap: jest.fn(),
+  prepareCrosschainSwap: jest.fn(),
+}));
+
+jest.mock('./actions/swap', () => ({
+  prepareSwap: (params: unknown) => mockPrepareSwap(params),
+}));
+
+jest.mock('./actions/unlock', () => ({
+  prepareUnlock: jest.fn(),
+}));
+
+jest.mock('./atomicSwapPreparation', () => ({
+  buildAtomicExecutionRequirements: () => ({ atomic: 'required', fees: { payer: 'sponsor' } }),
+}));
+
+jest.mock('./claimClaimable', () => ({
+  createClaimClaimableRap: jest.fn(),
+}));
+
+jest.mock('./unlockAndCrosschainSwap', () => ({
+  createUnlockAndCrosschainSwapRap: jest.fn(),
+}));
+
+jest.mock('./unlockAndSwap', () => ({
+  createUnlockAndSwapRap: (params: unknown) => mockCreateUnlockAndSwapRap(params),
+}));
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
+const chainId = ChainId.base;
+const signer = new Wallet(PRIVATE_KEY);
+
+const swapCall: Call = {
+  data: '0x1234',
+  to: '0x4444444444444444444444444444444444444444',
+  value: 123n,
+};
+
+const pendingSwapTransaction = {
+  chainId,
+  data: swapCall.data,
+  from: ACCOUNT,
+  network: 'Base',
+  nonce: 7,
+  status: TransactionStatus.pending,
+  to: swapCall.to,
+  type: 'swap',
+  value: swapCall.value,
+} satisfies Omit<NewTransaction, 'hash'>;
+
+const swapParameters = {
+  atomic: true,
+  chainId,
+  gasFeeParamsBySpeed: {},
+  gasParams: {},
+  nonce: pendingSwapTransaction.nonce,
+  quote: {
+    from: ACCOUNT,
+  },
+} as unknown as RapSwapActionParameters<'swap'>;
+
+describe('walletExecuteRap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateUnlockAndSwapRap.mockResolvedValue({
+      actions: [{ type: 'swap', parameters: swapParameters }],
+    });
+    mockPrepareSwap.mockResolvedValue({
+      call: swapCall,
+      transaction: pendingSwapTransaction,
+    });
+    mockTrackManagedCallsExecutionResult.mockResolvedValue(null);
+  });
+
+  it('records failed sponsored swaps before returning relay errors', async () => {
+    const preparedCalls = {
+      executionId: 'prepared-swap',
+      kind: 'calls.managed',
+      review: { fees: { payer: 'sponsor' } },
+    } as PreparedCallsExecution;
+    const failedExecution = {
+      executionId: 'failed-swap',
+      kind: 'calls.managed',
+      status: 'FAILED',
+    };
+    mockExecuteCalls.mockResolvedValue(failedExecution);
+    mockTrackManagedCallsExecutionResult.mockResolvedValue('relay reverted');
+
+    await expect(walletExecuteRap(signer, 'swap', swapParameters, { preparedCalls })).resolves.toEqual({
+      errorMessage: 'relay reverted',
+      hash: null,
+      nonce: undefined,
+    });
+
+    expect(mockTrackManagedCallsExecutionResult).toHaveBeenCalledWith({
+      address: ACCOUNT,
+      batch: true,
+      execution: failedExecution,
+      transaction: pendingSwapTransaction,
+    });
+    expect(mockTrackCallsExecution).not.toHaveBeenCalled();
+  });
+});

--- a/src/raps/execute.ts
+++ b/src/raps/execute.ts
@@ -3,8 +3,7 @@ import { Wallet } from '@ethersproject/wallet';
 
 import type { NewTransaction } from '@/entities/transactions';
 import { IS_TEST } from '@/env';
-import { trackCallsExecution } from '@/features/delegation/callsExecutionTracking';
-import { resolveManagedExecutionFailure } from '@/features/delegation/managedExecutionFailure';
+import { trackCallsExecution, trackManagedCallsExecutionResult } from '@/features/delegation/callsExecutionTracking';
 import type { LegacyTransactionGasParamAmounts, TransactionGasParamAmounts } from '@/features/gas/types/gas';
 import { getProvider } from '@/handlers/web3';
 import { ensureError, logger, RainbowError } from '@/logger';
@@ -226,9 +225,23 @@ export async function walletExecuteRap<T extends RapTypes>(
         });
 
         if (execution.kind === 'calls.managed') {
-          const failureMessage = await resolveManagedExecutionFailure({
-            executionId: execution.executionId,
-            status: execution.status,
+          if (!pendingTransaction) {
+            logger.error(new RainbowError(`[raps/execute]: ${rapName} - missing transaction metadata for managed atomic execution`), {
+              executionId: execution.executionId,
+              status: execution.status,
+            });
+            return {
+              nonce: undefined,
+              hash: null,
+              errorMessage: 'Missing transaction metadata for managed atomic execution',
+            };
+          }
+
+          const failureMessage = await trackManagedCallsExecutionResult({
+            address: fromAddress,
+            batch: true,
+            execution,
+            transaction: pendingTransaction,
           });
 
           if (failureMessage) {
@@ -238,16 +251,6 @@ export async function walletExecuteRap<T extends RapTypes>(
               failureMessage,
             });
             return { nonce: undefined, hash: null, errorMessage: failureMessage };
-          }
-
-          if (pendingTransaction) {
-            trackCallsExecution({
-              address: fromAddress,
-              batch: true,
-              chainId,
-              execution,
-              transaction: pendingTransaction,
-            });
           }
 
           logger.debug(`[${rapName}] submitted managed atomic execution`, {


### PR DESCRIPTION
Fixes APP-3768

## Why?

Sponsored transactions that fail at the managed relay before reaching chain never produce an on-chain hash, so the backend has nothing to index. Previously this meant the activity row could disappear entirely: the caller surfaced the relay error, while the local overlay either was never written or was later pruned because failed overlays were assumed to be backend-owned.

This affects sponsored sends and the same managed execution path used by sponsored atomic swaps/bridges and sponsored RNBW staking.

## Approach

- Record managed relay executions through one shared tracking path, so terminal pre-chain failures are saved locally as `failed` transactions keyed by the relay `executionId`.
- Keep the caller behavior unchanged: sends/staking still throw relay errors, and swaps still return the relay error to the swap flow.
- Retain failed relay overlays only while they are still awaiting an on-chain hash. If the relay failure has a real chain hash, indexed history owns the row so we do not duplicate it locally.

## Visuals

| Before | After |
| --- | --- |
| [before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/dbc0e0d9-3a75-43b9-b3e3-a0e66160c6c0.mov" />](https://app.graphite.com/user-attachments/video/dbc0e0d9-3a75-43b9-b3e3-a0e66160c6c0.mov)<br> | [after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/512ffff2-3135-47d5-99d8-1480923f3597.mov" />](https://app.graphite.com/user-attachments/video/512ffff2-3135-47d5-99d8-1480923f3597.mov) |

