### PR TITLE
fix: lossy conversion of amount in Send flow

### DIFF
--- a/src/features/delegation/sponsoredSendExecution.test.ts
+++ b/src/features/delegation/sponsoredSendExecution.test.ts
@@ -1,0 +1,77 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { type Address } from 'viem';
+
+import { type ParsedAddressAsset } from '@/entities/tokens';
+import { buildTransferTransaction } from '@/handlers/web3';
+import { ChainId } from '@/state/backendNetworks/types';
+
+import { buildSendCall } from './sponsoredSend';
+import { buildSendCallFromSendDetails } from './sponsoredSendExecution';
+
+jest.mock('@/handlers/web3', () => ({
+  buildTransferTransaction: jest.fn(),
+}));
+
+jest.mock('./sponsoredSend', () => ({
+  buildPendingSendTransaction: jest.fn(),
+  buildSendCall: jest.fn(),
+  prepareSponsoredSend: jest.fn(),
+}));
+
+jest.mock('./calls', () => ({
+  isPreparedCallsExecutionSponsored: jest.fn(),
+}));
+
+jest.mock('@/logger', () => ({
+  ensureError: (error: unknown) => error,
+  logger: { warn: jest.fn() },
+}));
+
+const mockBuildTransferTransaction = jest.mocked(buildTransferTransaction);
+const mockBuildSendCall = jest.mocked(buildSendCall);
+
+const ACCOUNT = '0x3333333333333333333333333333333333333333' satisfies Address;
+const RECIPIENT = '0x4444444444444444444444444444444444444444' satisfies Address;
+
+const ASSET = {
+  address: '0x5555555555555555555555555555555555555555',
+  decimals: 18,
+  uniqueId: 'base-token',
+} as ParsedAddressAsset;
+
+const provider = new StaticJsonRpcProvider('http://127.0.0.1:8545', ChainId.base);
+
+describe('buildSendCallFromSendDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuildTransferTransaction.mockResolvedValue({ data: '0x', to: RECIPIENT, value: '0' });
+    mockBuildSendCall.mockReturnValue({ data: '0x', to: RECIPIENT, value: 0n });
+  });
+
+  // Regression for APP-3768: a full-balance max send must reach buildTransferTransaction as the exact
+  // decimal string. Coercing through Number() drops precision on 18-decimal balances and can push
+  // the raw amount above the onchain balance ("ERC20: transfer amount exceeds balance").
+  it('forwards the full-precision amount string to buildTransferTransaction without Number() coercion', async () => {
+    const fullPrecisionAmount = '98765.432109876543210987';
+
+    await buildSendCallFromSendDetails({
+      accountAddress: ACCOUNT,
+      amount: fullPrecisionAmount,
+      asset: ASSET,
+      chainId: ChainId.base,
+      provider,
+      toAddress: RECIPIENT,
+    });
+
+    expect(mockBuildTransferTransaction).toHaveBeenCalledWith(
+      { address: ACCOUNT, amount: fullPrecisionAmount, asset: ASSET, recipient: RECIPIENT },
+      provider,
+      ChainId.base
+    );
+
+    const passedAmount = mockBuildTransferTransaction.mock.calls[0][0].amount;
+    expect(typeof passedAmount).toBe('string');
+    expect(passedAmount).toBe(fullPrecisionAmount);
+    expect(Number(passedAmount).toString()).not.toBe(passedAmount);
+  });
+});

--- a/src/features/delegation/sponsoredSendExecution.ts
+++ b/src/features/delegation/sponsoredSendExecution.ts
@@ -4,7 +4,7 @@ import { isAddress, type Address } from 'viem';
 
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { type NewTransaction } from '@/entities/transactions';
-import { buildTransaction } from '@/handlers/web3';
+import { buildTransferTransaction } from '@/handlers/web3';
 import { ensureError, logger } from '@/logger';
 import { type ChainId } from '@/state/backendNetworks/types';
 import { type Call, type ExecuteCallsResult, type PreparedCallsExecution } from '@rainbow-me/delegation';
@@ -50,10 +50,10 @@ export async function buildSendCallFromSendDetails({
   provider,
   toAddress,
 }: BuildSendCallFromSendDetailsParams): Promise<Call> {
-  const transaction = await buildTransaction(
+  const transaction = await buildTransferTransaction(
     {
       address: accountAddress,
-      amount: Number(amount),
+      amount,
       asset,
       recipient: toAddress,
     },

--- a/src/features/send/hooks/useSendSubmit.ts
+++ b/src/features/send/hooks/useSendSubmit.ts
@@ -505,7 +505,7 @@ async function submitPaidSend({
       updatedGasLimit = await estimateGasLimit(
         {
           address: accountAddress,
-          amount: Number(amount),
+          amount,
           asset: selectedAddressAsset,
           recipient: toAddress,
         },

--- a/src/features/send/hooks/useSponsoredSendPreparation.test.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.test.ts
@@ -5,7 +5,7 @@ import { ChainId } from '@/state/backendNetworks/types';
 import { getCachedDelegationSupport, getDelegationSupportRequestKey, getSponsoredSendRequestKey } from './useSponsoredSendPreparation';
 
 jest.mock('@/handlers/web3', () => ({
-  buildTransaction: jest.fn(),
+  buildTransferTransaction: jest.fn(),
 }));
 
 jest.mock('@/model/remoteConfig', () => ({
@@ -72,8 +72,34 @@ describe('getSponsoredSendRequestKey', () => {
         toAddress: '0x4444444444444444444444444444444444444444'.toUpperCase(),
       })
     ).toBe(
-      '0x3333333333333333333333333333333333333333:8453:base-eth:0x5555555555555555555555555555555555555555:18:0x4444444444444444444444444444444444444444:1.5'
+      '0x3333333333333333333333333333333333333333:8453:base-eth:0x5555555555555555555555555555555555555555:18:0x4444444444444444444444444444444444444444:1500000000000000000'
     );
+  });
+
+  it('keys by exact raw amount rather than rounded JavaScript number identity', () => {
+    const request = {
+      accountAddress: '0x3333333333333333333333333333333333333333',
+      chainId: ChainId.base,
+      selected: SELECTED_ASSET,
+      toAddress: '0x4444444444444444444444444444444444444444',
+    };
+
+    // Number('0.999999999999999999') === 1, so a Number()-based key would collide these.
+    expect(getSponsoredSendRequestKey({ ...request, amount: '0.999999999999999999' })).not.toBe(
+      getSponsoredSendRequestKey({ ...request, amount: '1' })
+    );
+  });
+
+  it('returns null for amounts that exceed asset precision', () => {
+    expect(
+      getSponsoredSendRequestKey({
+        accountAddress: '0x3333333333333333333333333333333333333333',
+        amount: '0.9999999999999999999',
+        chainId: ChainId.base,
+        selected: SELECTED_ASSET,
+        toAddress: '0x4444444444444444444444444444444444444444',
+      })
+    ).toBeNull();
   });
 
   it('separates assets with the same unique id but different token shape', () => {

--- a/src/features/send/hooks/useSponsoredSendPreparation.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { type StaticJsonRpcProvider } from '@ethersproject/providers';
+import { parseUnits } from '@ethersproject/units';
 import { isAddress, type Address } from 'viem';
 
 import { type ParsedAddressAsset } from '@/entities/tokens';
@@ -74,8 +75,13 @@ export function getSponsoredSendRequestKey({
   selected: Pick<ParsedAddressAsset, 'address' | 'decimals' | 'uniqueId'>;
   toAddress: string;
 }): string | null {
-  const parsedAmount = Number(amount);
-  if (isNaN(parsedAmount) || parsedAmount <= 0) return null;
+  let rawAmount: bigint;
+  try {
+    rawAmount = BigInt(parseUnits(amount, selected.decimals).toString());
+  } catch {
+    return null;
+  }
+  if (rawAmount <= 0n) return null;
 
   return [
     accountAddress.toLowerCase(),
@@ -84,7 +90,7 @@ export function getSponsoredSendRequestKey({
     selected.address.toLowerCase(),
     selected.decimals,
     toAddress.toLowerCase(),
-    parsedAmount,
+    rawAmount.toString(),
   ].join(':');
 }
 

--- a/src/features/send/screens/SendSheet.tsx
+++ b/src/features/send/screens/SendSheet.tsx
@@ -26,8 +26,19 @@ import { REGISTRATION_STEPS } from '@/features/ens/utils/helpers';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
 import useGas from '@/features/gas/hooks/useGas';
 import styled from '@/framework/ui/styled-thing';
-import { assetIsParsedAddressAsset, assetIsUniqueAsset, buildTransaction, estimateGasLimit, resolveNameOrAddress } from '@/handlers/web3';
-import { convertAmountAndPriceToNativeDisplay, convertAmountFromNativeValue, formatInputDecimals } from '@/helpers/utilities';
+import {
+  assetIsParsedAddressAsset,
+  assetIsUniqueAsset,
+  buildTransferTransaction,
+  estimateGasLimit,
+  resolveNameOrAddress,
+} from '@/handlers/web3';
+import {
+  convertAmountAndPriceToNativeDisplay,
+  convertAmountFromNativeValue,
+  formatInputDecimals,
+  greaterThanOrEqualTo,
+} from '@/helpers/utilities';
 import { checkIsValidAddressOrDomain, checkIsValidAddressOrDomainFormat, isENSAddressFormat } from '@/helpers/validators';
 import useAccountSettings from '@/hooks/useAccountSettings';
 import useCoinListEditOptions from '@/hooks/useCoinListEditOptions';
@@ -120,6 +131,9 @@ const validateRecipientDamagedState = (toAddress?: string) => {
   }
   return true;
 };
+
+const hasSufficientAssetBalance = (assetAmount: string, maxInputBalance: string): boolean =>
+  !assetAmount || greaterThanOrEqualTo(maxInputBalance || '0', assetAmount);
 
 export default function SendSheet() {
   const { navigate } = useNavigation();
@@ -239,7 +253,7 @@ export default function SendSheet() {
         _nativeAmount = formatInputDecimals(convertedNativeAmount, _assetAmount);
       }
 
-      const _isSufficientBalance = Number(_assetAmount) <= Number(maxInputBalance);
+      const _isSufficientBalance = hasSufficientAssetBalance(_assetAmount, maxInputBalance);
 
       setAmountDetails({
         assetAmount: _assetAmount,
@@ -281,7 +295,7 @@ export default function SendSheet() {
 
     const newMaxInputBalance = updateMaxInputBalance(selected);
     setAmountDetails(currentAmountDetails => {
-      const isSufficientBalance = Number(currentAmountDetails.assetAmount) <= Number(newMaxInputBalance);
+      const isSufficientBalance = hasSufficientAssetBalance(currentAmountDetails.assetAmount, newMaxInputBalance);
       if (currentAmountDetails.isSufficientBalance === isSufficientBalance) return currentAmountDetails;
 
       return {
@@ -333,7 +347,7 @@ export default function SendSheet() {
         _assetAmount = formatInputDecimals(convertedAssetAmount, _nativeAmount);
       }
 
-      const _isSufficientBalance = Number(_assetAmount) <= Number(maxInputBalance);
+      const _isSufficientBalance = hasSufficientAssetBalance(_assetAmount, maxInputBalance);
       setAmountDetails({
         assetAmount: _assetAmount,
         isSufficientBalance: _isSufficientBalance,
@@ -387,10 +401,10 @@ export default function SendSheet() {
     async (updatedGasLimit: string) => {
       if (!selected || !currentProvider) return;
 
-      const txData = await buildTransaction(
+      const txData = await buildTransferTransaction(
         {
           address: accountAddress,
-          amount: Number(amountDetails.assetAmount),
+          amount: amountDetails.assetAmount,
           asset: selected as ParsedAddressAsset,
           gasLimit: updatedGasLimit,
           recipient: toAddress,
@@ -609,7 +623,7 @@ export default function SendSheet() {
       estimateGasLimit(
         {
           address: accountAddress,
-          amount: Number(amountDetails.assetAmount),
+          amount: amountDetails.assetAmount,
           asset: selected as ParsedAddressAsset,
           recipient: toAddress,
         },

--- a/src/handlers/web3.ts
+++ b/src/handlers/web3.ts
@@ -624,14 +624,14 @@ export const getDataForNftTransfer = (
 };
 
 /**
- * @desc Builds a transaction request object.
+ * @desc Builds a transfer (native, ERC-20, or NFT) transaction request object.
  * @param [{address, amount, asset, gasLimit, recipient}] The transaction
  * initialization details.
  * @param provider The RCP provider to use.
  * @param chainId The chainId for the transaction
  * @return The transaction request.
  */
-export const buildTransaction = async (
+export const buildTransferTransaction = async (
   {
     address,
     amount,
@@ -642,14 +642,14 @@ export const buildTransaction = async (
     asset: ParsedAddressAsset | UniqueAsset;
     address: string;
     recipient: string;
-    amount: number;
+    amount: string;
     gasLimit?: string;
   },
   provider: StaticJsonRpcProvider | undefined,
   chainId: ChainId
 ): Promise<TransactionRequest> => {
   const _amount =
-    amount && Number(amount) && assetIsParsedAddressAsset(asset)
+    greaterThan(amount, 0) && assetIsParsedAddressAsset(asset)
       ? convertAmountToRawAmount(amount, asset.decimals)
       : estimateAssetBalancePortion(asset);
   const value = _amount.toString();
@@ -699,13 +699,13 @@ export const estimateGasLimit = async (
     asset: ParsedAddressAsset | UniqueAsset;
     address: string;
     recipient: string;
-    amount: number;
+    amount: string;
   },
   addPadding = false,
   provider: StaticJsonRpcProvider,
   chainId: ChainId = ChainId.mainnet
 ): Promise<string | null> => {
-  const estimateGasData = await buildTransaction({ address, amount, asset, recipient }, provider, chainId);
+  const estimateGasData = await buildTransferTransaction({ address, amount, asset, recipient }, provider, chainId);
 
   if (addPadding) {
     return estimateGasWithPadding(estimateGasData, null, null, provider);

--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -239,7 +239,7 @@ export const SendConfirmationSheet = () => {
         estimateGasLimit(
           {
             address: accountAddress,
-            amount: 0,
+            amount: '0',
             asset,
             recipient: toAddress,
           },


### PR DESCRIPTION
Fixes APP-3680

## Why?

Send amounts were coerced through a JS `number` before being converted to raw token units. A double can't represent an 18-decimal balance exactly, so `Number("…")` rounds — sometimes up — pushing the raw amount just over the on-chain balance.

This is years-old code that surfaced in two ways:

- **Before sponsored sends** — the lossy amount only fed gas estimation. On large balances it made estimation revert, hanging the Review CTA on "Loading…"; recoverable by entering a smaller amount (APP-3680).
- **With sponsored sends** — the _executed_ amount now runs through the same path, so the rounded-up value becomes the real transfer and reverts on-chain with `ERC20: transfer amount exceeds balance`.

## Approach

Keep the amount as a string end-to-end and never coerce it through `Number()`:

- `buildTransferTransaction` / `estimateGasLimit` now take `amount: string`, so the full-precision decimal flows straight into the BigNumber-based raw conversion.
- All send call sites pass the amount string directly instead of `Number(...)`.
- Renamed `buildTransaction` → `buildTransferTransaction` to disambiguate it from the generic `@/helpers/buildTransaction` (this one only builds native / ERC-20 / NFT transfers).

## Before / After

| Before | After (sponsored) | After (unsponsored) |
| --- | --- | --- |
| [before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d966b87e-23be-4e34-ae12-32e07c73a294.mov" />](https://app.graphite.com/user-attachments/video/d966b87e-23be-4e34-ae12-32e07c73a294.mov)<br> | [after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/51ae1630-acae-467b-8a37-62f0495d6e56.mov" />](https://app.graphite.com/user-attachments/video/51ae1630-acae-467b-8a37-62f0495d6e56.mov)<br> | [Simulator Screen Recording - iPhone 17 Pro - 2026-06-01 at 12.00.35.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/333481fc-ff8c-44dd-980f-e20ceb82af48.mov" />](https://app.graphite.com/user-attachments/video/333481fc-ff8c-44dd-980f-e20ceb82af48.mov) |

