### PR TITLE
fix: send max amount on non 7702 chains

### DIFF
--- a/src/features/send/hooks/useSponsoredSendPreparation.ts
+++ b/src/features/send/hooks/useSponsoredSendPreparation.ts
@@ -137,6 +137,7 @@ export function useSponsoredSendPreparation({
 
   const [preparedSponsoredSend, setPreparedSponsoredSend] = useState<PreparedSponsoredSendState | null>(null);
   const [isPreparingSponsoredSend, setIsPreparingSponsoredSend] = useState(false);
+  const [isSponsorshipSupported, setIsSponsorshipSupported] = useState(false);
   const hasResolvedSponsoredSend = preparedSponsoredSend?.key === sponsoredSendRequestKey;
   const preparedCalls = hasResolvedSponsoredSend ? preparedSponsoredSend.preparedCalls : null;
   const isSponsoredSend = isPreparedCallsExecutionSponsored(preparedCalls);
@@ -216,12 +217,44 @@ export function useSponsoredSendPreparation({
     };
   }, [accountAddress, canUseSponsoredSend, chainId, debouncedAmount, debouncedSponsoredSendRequestKey, provider, selected, toAddress]);
 
+  useEffect(() => {
+    if (!canUseSponsoredSend || !accountAddress || !isAddress(accountAddress)) {
+      setIsSponsorshipSupported(false);
+      return;
+    }
+
+    let isStale = false;
+    getCachedDelegationSupport({
+      accountAddress,
+      cache: delegationSupportCacheRef.current,
+      chainId,
+    })
+      .then(supported => {
+        if (!isStale) setIsSponsorshipSupported(supported);
+      })
+      .catch(() => {
+        if (!isStale) setIsSponsorshipSupported(false);
+      });
+
+    return () => {
+      isStale = true;
+    };
+  }, [accountAddress, canUseSponsoredSend, chainId]);
+
   return {
+    // [sync gate] form valid + remote config on + chain/account predicted eligible; no network call. Top-level gate for everything below.
     canUseSponsoredSend,
+    // [prep lifecycle] prepared calls match the current (live) amount's request key — i.e. preparation finished for what's on screen now.
     hasResolvedSponsoredSend,
+    // [prep lifecycle] async build → prepare is in flight (debounced amount).
     isPreparingSponsoredSend,
+    // [prep result] the resolved prepared calls are actually sponsor-paid (fees.payer === 'sponsor').
     isSponsoredSend,
+    // [async capability] network-confirmed 7702 delegation support. Drives balance math (ignoreGasFee), NOT the prep flow.
+    isSponsorshipSupported,
+    // [prep result] prepared calls for the current request, or null until hasResolvedSponsoredSend is true.
     preparedCalls,
+    // [derived UI] hide the gas selector / skip gas estimation while sponsored gas applies. Pure derivation of the gate + prep lifecycle.
     shouldShowSponsoredSendGas,
   };
 }

--- a/src/features/send/screens/SendSheet.tsx
+++ b/src/features/send/screens/SendSheet.tsx
@@ -202,6 +202,7 @@ export default function SendSheet() {
     hasResolvedSponsoredSend,
     isPreparingSponsoredSend,
     isSponsoredSend,
+    isSponsorshipSupported,
     preparedCalls: sponsoredSendPreparedCalls,
     shouldShowSponsoredSendGas,
   } = useSponsoredSendPreparation({
@@ -215,7 +216,7 @@ export default function SendSheet() {
     selected: selectedAddressAsset,
     toAddress,
   });
-  const { maxInputBalance, updateMaxInputBalance } = useMaxInputBalance({ ignoreGasFee: shouldShowSponsoredSendGas });
+  const { maxInputBalance, updateMaxInputBalance } = useMaxInputBalance({ ignoreGasFee: isSponsorshipSupported });
 
   let colorForAsset = useColorForAsset(selected, undefined, false, true);
   const uniqueAssetColor = usePersistentDominantColorFromImage(isUniqueAsset ? selected?.images.lowResUrl : null) ?? colors.appleBlue;
@@ -289,7 +290,7 @@ export default function SendSheet() {
         isSufficientBalance,
       };
     });
-  }, [isUniqueAsset, selected, shouldShowSponsoredSendGas, updateMaxInputBalance]);
+  }, [isUniqueAsset, isSponsorshipSupported, selected, updateMaxInputBalance]);
 
   useEffect(() => {
     if (recipientOverride && !recipient) {


### PR DESCRIPTION
Fixed: APP-3766

## Why?

On chains that are sponsorship-eligible but don't support EIP-7702 (e.g. Avalanche), tapping **Max** on a native-asset send left the estimated network fee stuck on "Loading…" indefinitely.

The send screen optimistically treats a transfer as gas-sponsored while it evaluates sponsorship, so **Max** fills in the full balance with no gas deducted. On a chain where sponsorship can never actually succeed, the fee estimate could never settle — the Max amount and the "is this sponsored?" flag each depended on the other, so there was no stable value to converge on.

## Approach

I consider this rather a hot-fix/band-aid. I think we should collapse all those flags on the different steps of creating sponsoring transaction into a simple state machine or something similliar. Created a stub for this here https://linear.app/rainbow/issue/APP-3772 with the initial Claude take on this, but the actual implementation could be ofcourse different.

`Max`'s `ignoreGasFee` keyed off `shouldShowSponsoredSendGas`, which is amount-dependent (it folds in the per-amount sponsored-send preparation). Recomputing the Max amount changed the request key, which flipped the flag back, which reset the amount — a loop with no fixed point on a never-sponsored chain.

`useSponsoredSendPreparation` now exposes `isSponsorshipSupported`, an amount-independent signal derived from the per-(address, chain) delegation-support check, and `Max` keys off that instead. It's stably `false` on non-7702 chains (Max = balance − fee, fee resolves) and stably `true` on genuinely sponsorable chains (Max = full balance). `shouldShowSponsoredSendGas` is unchanged and still drives the gas display.

## Visuals

| Before | After |
| --- | --- |
| [before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/84586260-c313-4f55-aee0-d6315cca89a7.mov" />](https://app.graphite.com/user-attachments/video/84586260-c313-4f55-aee0-d6315cca89a7.mov)<br> | [after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5072d5e3-79dc-4c5a-8cc6-d1e03005fcdb.mov" />](https://app.graphite.com/user-attachments/video/5072d5e3-79dc-4c5a-8cc6-d1e03005fcdb.mov)<br> |

## Testing

1. On a sponsorship-eligible but non-7702 chain (e.g. Avalanche), open Send and select the native asset (AVAX).
2. Enter a valid recipient and tap **Max**.
3. The estimated network fee resolves instead of hanging on "Loading…", and the Max amount is balance minus the gas fee.
4. On a genuinely sponsored chain, confirm the sponsored gas UI and a full-balance Max still behave as before.