### PR TITLE
fix: swap max amount on non 7702 chains

### DIFF
--- a/src/features/delegation/sponsoredSwapStore.ts
+++ b/src/features/delegation/sponsoredSwapStore.ts
@@ -52,6 +52,7 @@ export const useSponsoredSwapStore = createPreparedCallsStore<PreparedCallsExecu
     quoteKey: $ => $(useSponsoredSwapQuoteKey),
   },
   cacheTime: time.minutes(1),
+  keepPreviousData: true,
   staleTime: time.seconds(12),
 });
 


### PR DESCRIPTION
Fixed: APP-3720

## Why?

Selecting 100% as the swap input glitched in two ways on chains where the native
token is also the gas token and sponsorship is eligible (e.g. MON on Monad):

- **Input amount jitter.** The max swappable amount reserves a native gas buffer
only when the swap isn't sponsored. That decision was driven by the prepared-swap
state, which depends on the quote, which depends on the amount — so picking 100%
kicked off a feedback loop: reserve buffer → refetch quote → resolve sponsored
state → drop/restore the buffer → input changes → refetch… and the amount visibly
oscillated.
- **Sponsored indicator flicker.** On every amount change the quote key changes,
leaving the prepared-swap store with no entry for the new key. The sponsored badge
fell back to an optimistic prediction (true on any eligible chain) and then settled
on the real verdict once preparation resolved — flipping "Sponsored → Not sponsored"
each time the amount changed.

## Approach

Both glitches came from deriving gas/UI decisions off the in-flight prepared-swap
state, which is inherently amount-coupled. The fix decouples them:

- The native gas buffer now keys off `useIsSwapSponsorshipSupported` — a stable,
amount-independent check of whether the account + input chain actually support
sponsored execution — rather than whether a specific quote's swap came back sponsored.
- `useIsSponsoredSwap` now reflects the actual prepared-swap verdict instead of the
optimistic prediction, and `useSponsoredSwapStore` keeps previous data so the verdict
holds steady across refetches.

On chains that don't actually sponsor the buffer is consistently reserved and the badge
consistently reads "Not sponsored"; on chains that do, neither value churns as the amount changes.

## Visuals

| Before | After |
| --- | --- |
| [before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5344afc5-68ae-471b-b004-4d3f1746114e.mov" />](https://app.graphite.com/user-attachments/video/5344afc5-68ae-471b-b004-4d3f1746114e.mov)<br> | [after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/edfe6c99-d973-4e5c-b6e1-82e1e0df7dbf.mov" />](https://app.graphite.com/user-attachments/video/edfe6c99-d973-4e5c-b6e1-82e1e0df7dbf.mov)<br> |

## Testing

1. Open a token whose native asset is the gas token on a sponsorship-eligible chain (e.g. MON on Monad).
2. Start a swap and tap 100% / drag the slider to max → the input amount settles without jittering.
3. Adjust the amount up and down → the gas row's sponsored state stays stable (no "Sponsored ↔ Not sponsored" flicker).
4. On a chain that genuinely sponsors swaps, confirm the gas row still shows "Sponsored" and selecting max uses the full balance.