### PR TITLE
fix: flicked sponsorship status on stake

### DIFF
--- a/src/features/rnbw-staking/depositConfig.ts
+++ b/src/features/rnbw-staking/depositConfig.ts
@@ -13,9 +13,6 @@ import { refreshStakingData } from './utils/refreshStakingData';
 import { stakeRnbw } from './utils/stakeRnbw';
 import { buildSyntheticRnbwSourceAsset } from './utils/syntheticRnbwSourceAsset';
 
-/**
- * Builds the RNBW staking deposit config.
- */
 export function createRnbwStakingDepositConfig(
   stakePreparationStore: PreparedCallsStore<PreparedStakeRnbw, StakeRnbwPreparationParams>
 ): DepositConfigInput {
@@ -60,8 +57,11 @@ export function createRnbwStakingDepositConfig(
       estimateGasLimit: estimateStakeGasLimit,
       predictIsSponsored: ({ accountAddress }) => predictSponsoredCallsExecution({ address: accountAddress, chainId: STAKING_CHAIN_ID }),
       isSponsored: async params => {
-        const preparedStake = await stakePreparationStore.getState().fetch(params);
-        return isPreparedCallsExecutionSponsored(preparedStake?.preparedCalls ?? null);
+        const preparedStake = await stakePreparationStore
+          .getState()
+          .fetch({ accountAddress: params.accountAddress, amount: params.amount });
+        if (!preparedStake) return null;
+        return isPreparedCallsExecutionSponsored(preparedStake.preparedCalls);
       },
     },
 

--- a/src/systems/funding/stores/createDepositGasStores.ts
+++ b/src/systems/funding/stores/createDepositGasStores.ts
@@ -161,7 +161,7 @@ export function createDepositGasStores(
 
   const useGasSponsorshipStore =
     hasGasSponsorshipResolver && useHasGasHookParams
-      ? createQueryStore<boolean, GasSponsorshipQueryParams>({
+      ? createQueryStore<boolean | null, GasSponsorshipQueryParams>({
           fetcher: createGasSponsorshipFetcher(config, useDepositStore, useQuoteStore),
           enabled: $ => $(useCanCheckGasSponsorship),
           params: {
@@ -314,8 +314,8 @@ function createGasSponsorshipFetcher(
   config: DepositConfig,
   useDepositStore: DepositStoreType,
   useQuoteStore: DepositQuoteStoreType
-): (params: GasSponsorshipQueryParams) => Promise<boolean> {
-  return async function fetchIsGasSponsored(queryParams: GasSponsorshipQueryParams): Promise<boolean> {
+): (params: GasSponsorshipQueryParams) => Promise<boolean | null> {
+  return async function fetchIsGasSponsored(queryParams: GasSponsorshipQueryParams): Promise<boolean | null> {
     const sponsorshipHook = config.gas?.isSponsored;
     if (!sponsorshipHook) return false;
 
@@ -330,13 +330,16 @@ function createGasSponsorshipFetcher(
     if (!params) return false;
 
     try {
-      return Boolean(await sponsorshipHook(params));
+      const resolved = await sponsorshipHook(params);
+      // Preserve `null` (unknown) so it falls back to the prediction in
+      // `useIsGasSponsored` rather than reading as "not sponsored".
+      return resolved == null ? null : Boolean(resolved);
     } catch (error) {
       logger.warn('[createDepositGasStores]: sponsorship check failed', {
         error,
         id: config.id,
       });
-      return false;
+      return null;
     }
   };
 }

--- a/src/systems/funding/types.ts
+++ b/src/systems/funding/types.ts
@@ -243,8 +243,10 @@ export type DepositGasConfig = {
   /**
    * Optional sponsorship resolver for authoritative UI state.
    * Custom flows may also use this hook to prepare sponsor-paid execution in advance.
+   * Returns `null` when the outcome can't be determined yet (e.g. an in-flight
+   * resolution was superseded) so the UI keeps the prediction instead of flipping.
    */
-  isSponsored?: (params: DepositGasHookParams) => Promise<boolean> | boolean;
+  isSponsored?: (params: DepositGasHookParams) => Promise<boolean | null> | boolean | null;
 };
 
 export type DepositRuntimeStores = {


### PR DESCRIPTION
Fixed: APP-3764

## Description

On the staking sheet, gas would occasionally show **Sponsored** and then flip to non-sponsored — often right after holding the confirm CTA — even for plain wallet stakes that genuinely execute sponsor-paid. It's intermittent, not every time.

`useIsGasSponsored` shows an optimistic prediction (`predictIsSponsored`) immediately, then defers to the authoritative async resolution (`isSponsored`) once it lands. The resolution re-runs on every quote tick — its `quoteKey` derives from the synthetic transfer quote, which rebuilds on each price update — and each run calls `stakePreparationStore.fetch(...)`. Preparing the sponsored calls takes a few seconds, so each new run supersedes the still-in-flight one and `fetch` resolves to `null`. `isSponsored` mapped that null prepared result to "not sponsored" (`false`), which overrode the (correct) prediction and flipped the UI. The prepared calls themselves are always sponsored — they just rarely survive long enough to be read.

The fix treats a non-resolvable check as **unknown** rather than **not sponsored**:

- `isSponsored` returns `null` when it gets no prepared calls (in-flight resolution superseded, or a claim-only stake); `useIsGasSponsored` keeps the prediction on `null`.
- The shared sponsorship fetcher preserves `null` (and now also returns `null` on a thrown check) instead of collapsing to `false`.
- `isSponsored` keys the prepared-calls cache on the stable `{ accountAddress, amount }` (same as `execute`) instead of the churning quote.

A genuine relay decline is unaffected: that path returns prepared calls with a non-sponsor payer, which still resolves `false` and correctly shows non-sponsored — in every sponsored deposit flow, not just staking.

## Visuals

| Before | After |
| --- | --- |
| [before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/41fbfed5-a312-4012-8f0e-553f915c2dca.mov" />](https://app.graphite.com/user-attachments/video/41fbfed5-a312-4012-8f0e-553f915c2dca.mov) | [after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0c563f15-5349-467b-bac4-340f757872ea.mov" />](https://app.graphite.com/user-attachments/video/0c563f15-5349-467b-bac4-340f757872ea.mov) |

## Testing

1. On a delegated wallet on a sponsorship-eligible chain, open the RNBW staking sheet and enter an amount.
2. Confirm gas shows **Sponsored**.
3. Hold the confirm CTA to submit.
4. Gas stays **Sponsored** throughout — no intermittent flip to a regular fee.
