### PR TITLE
feat(discover): discover v2 swipe nav + cutover

### DIFF
--- a/e2e/flows/screens/Discover.yaml
+++ b/e2e/flows/screens/Discover.yaml
@@ -32,18 +32,21 @@ tags:
 - assertVisible:
     id: discover-sections-pager
 
-# Navigate the Discover v2 tabs by POSITION. Number-based IDs are stable across the
-# server-driven surface, and page assertions verify the active tab content changed.
+# Navigate the Discover v2 tabs by POSITION. Section-tab IDs are server-driven, so match
+# the discover-section-tab- prefix and select by index; page assertions verify the active
+# tab content changed.
 - extendedWaitUntil:
     visible:
-      id: tab-1
+      id: 'discover-section-tab-.*'
     timeout: 30000
 - tapOn:
-    id: tab-2
+    id: 'discover-section-tab-.*'
+    index: 1
 - assertVisible:
     id: discover-section-page-2
 - tapOn:
-    id: tab-1
+    id: 'discover-section-tab-.*'
+    index: 0
 - assertVisible:
     id: discover-section-page-1
 

--- a/e2e/flows/screens/Discover.yaml
+++ b/e2e/flows/screens/Discover.yaml
@@ -32,10 +32,8 @@ tags:
 - assertVisible:
     id: discover-sections-pager
 
-# Navigate the Discover v2 tabs by POSITION. Number-based IDs (tab-1..tab-N) are stable
-# across the server-driven surface, so the flow doesn't depend on dynamic tab labels or
-# section ids. Only the first two pills are asserted: later pills may render off-screen
-# (e.g. Android), where assertVisible would fail.
+# Navigate the Discover v2 tabs by POSITION. Number-based IDs are stable across the
+# server-driven surface, and page assertions verify the active tab content changed.
 - extendedWaitUntil:
     visible:
       id: tab-1
@@ -43,11 +41,11 @@ tags:
 - tapOn:
     id: tab-2
 - assertVisible:
-    id: tab-2
+    id: discover-section-page-2
 - tapOn:
     id: tab-1
 - assertVisible:
-    id: tab-1
+    id: discover-section-page-1
 
 # Discover search (SOCKS + bitcoin) — search is unchanged in v2; carried over verbatim
 - tapOn:

--- a/e2e/flows/screens/Discover.yaml
+++ b/e2e/flows/screens/Discover.yaml
@@ -11,13 +11,14 @@ tags:
 - runFlow: ../../utils/Prepare.yaml
 - runFlow: ../../utils/ImportWalletWithKey.yaml
 
-# Check various screens exist and can be navigated to
+# Open Discover (v2 surface pager) and confirm cross-tab navigation still works.
+# The legacy navbar header (discover-header) was replaced by the v2 surface pager.
 - runScript:
     file: ../../utils/coordinates.js
 - tapOn:
     point: ${output.tabCoordinates.discoverTab}
 - assertVisible:
-    id: discover-header
+    id: discover-sections-pager
 - tapOn:
     point: ${output.tabCoordinates.activityTab}
 - assertVisible:
@@ -29,9 +30,26 @@ tags:
 - tapOn:
     point: ${output.tabCoordinates.discoverTab}
 - assertVisible:
-    id: discover-header
+    id: discover-sections-pager
 
-# Discover screen search for SOCKS and open expanded state
+# Navigate the Discover v2 tabs by POSITION. Number-based IDs (tab-1..tab-N) are stable
+# across the server-driven surface, so the flow doesn't depend on dynamic tab labels or
+# section ids. Only the first two pills are asserted: later pills may render off-screen
+# (e.g. Android), where assertVisible would fail.
+- extendedWaitUntil:
+    visible:
+      id: tab-1
+    timeout: 30000
+- tapOn:
+    id: tab-2
+- assertVisible:
+    id: tab-2
+- tapOn:
+    id: tab-1
+- assertVisible:
+    id: tab-1
+
+# Discover search (SOCKS + bitcoin) — search is unchanged in v2; carried over verbatim
 - tapOn:
     id: discover-search-icon
 - assertVisible:
@@ -49,8 +67,6 @@ tags:
     id: discover-search-clear-input
 - tapOn:
     id: discover-search-input
-
-# Bitcoin search and section verification
 - inputText: 'bitcoin'
 - assertVisible:
     id: favorites-0

--- a/src/components/Discover/DiscoverScreenContent.tsx
+++ b/src/components/Discover/DiscoverScreenContent.tsx
@@ -1,26 +1,48 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { type ReactElement } from 'react';
+import { StyleSheet, View, type RefreshControlProps } from 'react-native';
 
+import { type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useDiscoverSearchQueryStore } from '@/__swaps__/screens/Swap/resources/search/searchV2';
 import DiscoverSearch from '@/components/Discover/DiscoverSearch';
-import { Box, Inset } from '@/design-system';
-import { DiscoverHome } from '@/features/discover/components/DiscoverHome';
+import { Box } from '@/design-system';
+import { DiscoverSectionsPager } from '@/features/discover/components/DiscoverSectionsPager';
 
-export function DiscoverScreenContent() {
+type DiscoverScreenContentProps = {
+  renderRefreshControl?: () => ReactElement<RefreshControlProps>;
+  scrollOffset: SharedValue<number>;
+};
+
+export function DiscoverScreenContent({ renderRefreshControl, scrollOffset }: DiscoverScreenContentProps) {
   const insets = useSafeAreaInsets();
   const isSearching = useDiscoverSearchQueryStore(state => state.isSearching);
 
   return (
-    <Box style={{ flex: 1 }} testID="discover-home">
-      <Inset bottom={{ custom: insets.bottom }}>
-        {/* TODO: without this empty view, the app crashes with no error. Something in the discover search cannot handle display: none */}
+    <Box style={styles.container} testID="discover-home">
+      <View style={[styles.searchContainer, { marginBottom: insets.bottom }, !isSearching && styles.hidden]}>
+        {/* without this empty view, the app crashes with no error. Something in the discover search cannot handle display: none */}
         <View>{isSearching ? <DiscoverSearch /> : <View />}</View>
-        <View style={{ display: isSearching ? 'none' : 'flex' }}>
-          <DiscoverHome />
-        </View>
-      </Inset>
+      </View>
+
+      <View style={[styles.sectionsContainer, isSearching && styles.hidden]}>
+        <DiscoverSectionsPager renderRefreshControl={renderRefreshControl} scrollOffset={scrollOffset} />
+      </View>
     </Box>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  hidden: {
+    display: 'none',
+  },
+  searchContainer: {
+    flex: 1,
+  },
+  sectionsContainer: {
+    flex: 1,
+  },
+});

--- a/src/components/Discover/DiscoverScreenContent.tsx
+++ b/src/components/Discover/DiscoverScreenContent.tsx
@@ -1,5 +1,5 @@
-import React, { type ReactElement } from 'react';
-import { StyleSheet, View, type RefreshControlProps } from 'react-native';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 
 import { type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -10,11 +10,10 @@ import { Box } from '@/design-system';
 import { DiscoverSectionsPager } from '@/features/discover/components/DiscoverSectionsPager';
 
 type DiscoverScreenContentProps = {
-  renderRefreshControl?: () => ReactElement<RefreshControlProps>;
   scrollOffset: SharedValue<number>;
 };
 
-export function DiscoverScreenContent({ renderRefreshControl, scrollOffset }: DiscoverScreenContentProps) {
+export function DiscoverScreenContent({ scrollOffset }: DiscoverScreenContentProps) {
   const insets = useSafeAreaInsets();
   const isSearching = useDiscoverSearchQueryStore(state => state.isSearching);
 
@@ -26,7 +25,7 @@ export function DiscoverScreenContent({ renderRefreshControl, scrollOffset }: Di
       </View>
 
       <View style={[styles.sectionsContainer, isSearching && styles.hidden]}>
-        <DiscoverSectionsPager renderRefreshControl={renderRefreshControl} scrollOffset={scrollOffset} />
+        <DiscoverSectionsPager scrollOffset={scrollOffset} />
       </View>
     </Box>
   );

--- a/src/components/Discover/DiscoverScreenContext.tsx
+++ b/src/components/Discover/DiscoverScreenContext.tsx
@@ -5,6 +5,7 @@ import type Animated from 'react-native-reanimated';
 
 import { useDiscoverSearchQueryStore } from '@/__swaps__/screens/Swap/resources/search/searchV2';
 import { analytics } from '@/analytics';
+import { useDiscoverNavigationStore, type DiscoverSection } from '@/features/discover/stores/discoverNavigationStore';
 
 import { useTrackDiscoverScreenTime } from './useTrackDiscoverScreenTime';
 
@@ -12,10 +13,11 @@ export let discoverScrollToTopFnRef: () => number | null = () => null;
 export let discoverOpenSearchFnRef: () => void = () => null;
 
 type DiscoverScreenContextType = {
-  scrollViewRef: RefObject<Animated.ScrollView | null>;
   sectionListRef: RefObject<SectionList | null>;
   searchInputRef: RefObject<TextInput | null>;
   cancelSearch: () => void;
+  registerSectionScrollView: (section: DiscoverSection, scrollView: Animated.ScrollView | null) => void;
+  scrollToSectionTop: (section: DiscoverSection) => number | null;
   scrollToTop: () => number | null;
   onTapSearch: () => void;
 };
@@ -24,20 +26,33 @@ const DiscoverScreenContext = createContext<DiscoverScreenContextType | null>(nu
 
 export const DiscoverScreenProvider = ({ children }: { children: React.ReactNode }) => {
   const searchInputRef = useRef<TextInput>(null);
-  const scrollViewRef = useRef<Animated.ScrollView>(null);
+  const sectionScrollViewRefs = useRef<Partial<Record<DiscoverSection, Animated.ScrollView | null>>>({});
   const sectionListRef = useRef<SectionList>(null);
+
+  const scrollToSectionTop = useCallback((section: DiscoverSection) => {
+    sectionScrollViewRefs.current[section]?.scrollTo({ animated: true, y: 0 });
+    return null;
+  }, []);
 
   const scrollToTop = useCallback(() => {
     try {
       if (isSearching()) {
         sectionListRef.current?.scrollToLocation({ animated: true, itemIndex: 0, sectionIndex: 0 });
       } else {
-        scrollViewRef.current?.scrollTo({ animated: true, y: 0 });
+        scrollToSectionTop(useDiscoverNavigationStore.getState().activeSection);
       }
     } catch (ex) {
       // Scrolling to top may fail if the list is empty.
     }
     return null;
+  }, [scrollToSectionTop]);
+
+  const registerSectionScrollView = useCallback((section: DiscoverSection, scrollView: Animated.ScrollView | null) => {
+    if (scrollView) {
+      sectionScrollViewRefs.current[section] = scrollView;
+    } else {
+      delete sectionScrollViewRefs.current[section];
+    }
   }, []);
 
   const onTapSearch = useCallback(() => {
@@ -65,10 +80,11 @@ export const DiscoverScreenProvider = ({ children }: { children: React.ReactNode
   return (
     <DiscoverScreenContext.Provider
       value={{
-        scrollViewRef,
         sectionListRef,
         searchInputRef,
         cancelSearch,
+        registerSectionScrollView,
+        scrollToSectionTop,
         scrollToTop,
         onTapSearch,
       }}

--- a/src/components/Discover/DiscoverScreenContext.tsx
+++ b/src/components/Discover/DiscoverScreenContext.tsx
@@ -1,8 +1,6 @@
 import React, { createContext, useCallback, useEffect, useRef, type RefObject } from 'react';
 import { type SectionList, type TextInput } from 'react-native';
 
-import type Animated from 'react-native-reanimated';
-
 import { useDiscoverSearchQueryStore } from '@/__swaps__/screens/Swap/resources/search/searchV2';
 import { analytics } from '@/analytics';
 import { useDiscoverNavigationStore, type DiscoverSection } from '@/features/discover/stores/discoverNavigationStore';
@@ -12,11 +10,15 @@ import { useTrackDiscoverScreenTime } from './useTrackDiscoverScreenTime';
 export let discoverScrollToTopFnRef: () => number | null = () => null;
 export let discoverOpenSearchFnRef: () => void = () => null;
 
+export type DiscoverSectionScrollViewRef = {
+  scrollTo: (options: { animated?: boolean; y?: number }) => void;
+};
+
 type DiscoverScreenContextType = {
   sectionListRef: RefObject<SectionList | null>;
   searchInputRef: RefObject<TextInput | null>;
   cancelSearch: () => void;
-  registerSectionScrollView: (section: DiscoverSection, scrollView: Animated.ScrollView | null) => void;
+  registerSectionScrollView: (section: DiscoverSection, scrollView: DiscoverSectionScrollViewRef | null) => void;
   scrollToSectionTop: (section: DiscoverSection) => number | null;
   scrollToTop: () => number | null;
   onTapSearch: () => void;
@@ -26,7 +28,7 @@ const DiscoverScreenContext = createContext<DiscoverScreenContextType | null>(nu
 
 export const DiscoverScreenProvider = ({ children }: { children: React.ReactNode }) => {
   const searchInputRef = useRef<TextInput>(null);
-  const sectionScrollViewRefs = useRef<Partial<Record<DiscoverSection, Animated.ScrollView | null>>>({});
+  const sectionScrollViewRefs = useRef<Partial<Record<DiscoverSection, DiscoverSectionScrollViewRef | null>>>({});
   const sectionListRef = useRef<SectionList>(null);
 
   const scrollToSectionTop = useCallback((section: DiscoverSection) => {
@@ -47,7 +49,7 @@ export const DiscoverScreenProvider = ({ children }: { children: React.ReactNode
     return null;
   }, [scrollToSectionTop]);
 
-  const registerSectionScrollView = useCallback((section: DiscoverSection, scrollView: Animated.ScrollView | null) => {
+  const registerSectionScrollView = useCallback((section: DiscoverSection, scrollView: DiscoverSectionScrollViewRef | null) => {
     if (scrollView) {
       sectionScrollViewRefs.current[section] = scrollView;
     } else {

--- a/src/components/Discover/DiscoverSearch.tsx
+++ b/src/components/Discover/DiscoverSearch.tsx
@@ -9,8 +9,8 @@ import { analytics } from '@/analytics';
 import CurrencySelectionList from '@/components/CurrencySelectionList';
 import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
 import { type EnrichedExchangeAsset } from '@/components/ExchangeAssetList';
-import { navbarHeight } from '@/components/navbar/Navbar';
 import { IS_TEST } from '@/env';
+import { DISCOVER_HEADER_HEIGHT } from '@/features/discover/components/DiscoverHeader';
 import { useHardwareBackOnFocus } from '@/hooks/useHardwareBack';
 import useSearchCurrencyList from '@/hooks/useSearchCurrencyList';
 import { useTimeoutEffect } from '@/hooks/useTimeout';
@@ -42,7 +42,7 @@ export default function DiscoverSearch() {
 
   const { swapCurrencyList, swapCurrencyListLoading } = useSearchCurrencyList();
 
-  const TOP_OFFSET = safeAreaInsets.top + navbarHeight;
+  const TOP_OFFSET = safeAreaInsets.top + DISCOVER_HEADER_HEIGHT;
 
   const currencyList = useMemo(() => {
     // order:

--- a/src/components/Discover/DiscoverSearchBar.tsx
+++ b/src/components/Discover/DiscoverSearchBar.tsx
@@ -5,12 +5,13 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
 import DiscoverSearchInput from '@/components/Discover/DiscoverSearchInput';
 import { Box, Inline, Text } from '@/design-system';
+import { DISCOVER_HEADER_HEIGHT } from '@/features/discover/components/DiscoverHeader';
 import useDelayedValueWithLayoutAnimation from '@/hooks/useDelayedValueWithLayoutAnimation';
 import * as i18n from '@/languages';
 import { useTheme } from '@/theme/ThemeContext';
 import deviceUtils from '@/utils/deviceUtils';
 
-import { NAVBAR_HORIZONTAL_INSET, navbarHeight } from '../navbar/Navbar';
+import { NAVBAR_HORIZONTAL_INSET } from '../navbar/Navbar';
 
 const placeholderText = deviceUtils.isNarrowPhone
   ? i18n.t(i18n.l.discover.search.search_ethereum_short)
@@ -23,7 +24,12 @@ export function DiscoverSearchBar() {
   const delayedShowSearch = useDelayedValueWithLayoutAnimation(isSearching);
 
   return (
-    <Box height={navbarHeight} width="full" justifyContent="center" paddingHorizontal={{ custom: NAVBAR_HORIZONTAL_INSET }}>
+    <Box
+      height={{ custom: DISCOVER_HEADER_HEIGHT }}
+      width="full"
+      justifyContent="center"
+      paddingHorizontal={{ custom: NAVBAR_HORIZONTAL_INSET }}
+    >
       <Inline alignVertical="center" space={'16px'}>
         <Box justifyContent="center" style={{ flex: 1 }}>
           <DiscoverSearchInput

--- a/src/components/SmoothPager/SmoothPager.tsx
+++ b/src/components/SmoothPager/SmoothPager.tsx
@@ -698,6 +698,7 @@ const styles = StyleSheet.create({
   },
   fillHeight: {
     height: '100%',
+    pointerEvents: 'auto',
   },
   subPageStyle: {
     alignItems: 'center',

--- a/src/components/SmoothPager/SmoothPager.tsx
+++ b/src/components/SmoothPager/SmoothPager.tsx
@@ -97,6 +97,7 @@ type SmoothPagerProps = {
   children: React.ReactElement<PageProps | GroupProps>[];
   enableSwipeToGoBack?: boolean;
   enableSwipeToGoForward?: boolean | 'always';
+  fillHeight?: boolean;
   initialPage: PageId;
   lazy?: boolean;
   onNewIndex?: (index: number) => void;
@@ -114,6 +115,7 @@ const SmoothPagerComponent = (
     children,
     enableSwipeToGoBack = true,
     enableSwipeToGoForward = true,
+    fillHeight = false,
     initialPage,
     lazy = false,
     onNewIndex,
@@ -353,6 +355,7 @@ const SmoothPagerComponent = (
         <Animated.View
           style={[
             styles.pagerWrapper,
+            fillHeight && styles.fillHeight,
             pagerWrapperStyle,
             {
               gap: pageGap,
@@ -692,6 +695,9 @@ const styles = StyleSheet.create({
   pagerWrapper: {
     flexDirection: 'row',
     pointerEvents: 'box-none',
+  },
+  fillHeight: {
+    height: '100%',
   },
   subPageStyle: {
     alignItems: 'center',

--- a/src/components/asset-list/RecyclerAssetList2/core/DiscoverMoreButton.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/core/DiscoverMoreButton.tsx
@@ -5,6 +5,7 @@ import { TintButton } from '@/components/cards/reusables/TintButton';
 import { AccentColorProvider } from '@/design-system';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import * as i18n from '@/languages';
+import { useRemoteConfig } from '@/model/remoteConfig';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 
@@ -13,14 +14,17 @@ export const DISCOVER_MORE_BUTTON_HEIGHT = 40;
 export const DiscoverMoreButton = React.memo(function DiscoverMoreButton() {
   const { navigate } = useNavigation();
   const { accentColor } = useAccountAccentColor();
+  const { discover_enabled: discoverEnabled } = useRemoteConfig('discover_enabled');
 
   const handlePressDiscover = useCallback(() => {
+    if (!discoverEnabled) return;
+
     navigate(Routes.DISCOVER_SCREEN);
     analytics.track(analytics.event.pressedButton, {
       buttonName: 'DiscoverMoreButton',
       action: 'Navigates from WalletScreen to DiscoverHome',
     });
-  }, [navigate]);
+  }, [discoverEnabled, navigate]);
 
   return (
     <AccentColorProvider color={accentColor}>

--- a/src/features/discover/components/DiscoverHeader.tsx
+++ b/src/features/discover/components/DiscoverHeader.tsx
@@ -156,7 +156,6 @@ function DiscoverCategorySelector() {
           return (
             <View
               key={section.id}
-              testID={`tab-${index + 1}`}
               onLayout={event => {
                 tabLayoutsRef.current[section.id] = event.nativeEvent.layout;
                 if (section.id === activeSection) scrollSelectedTabIntoView(section.id, false);

--- a/src/features/discover/components/DiscoverHeader.tsx
+++ b/src/features/discover/components/DiscoverHeader.tsx
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { ScrollView, StyleSheet, View, type LayoutChangeEvent, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
+
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
+import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
+import { Skeleton } from '@/components/Skeleton';
+import { Box, Text, TextIcon, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
+import { type BackgroundColor } from '@/design-system/color/palettes';
+import { resolveSectionTitle } from '@/features/discover/components/SectionLayout';
+import {
+  DiscoverSectionNavigation,
+  useDiscoverNavigationStore,
+  type DiscoverSection,
+} from '@/features/discover/stores/discoverNavigationStore';
+import { useDiscoverSurface } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { type DiscoverTab } from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
+import { THICK_BORDER_WIDTH } from '@/styles/constants';
+
+export const DISCOVER_HEADER_HEIGHT = 80;
+
+const SEARCH_BUTTON_RIGHT_INSET = 19;
+const SEARCH_BUTTON_SIZE = 36;
+const CONTENT_TOP_INSET = 40;
+const RIGHT_FADE_WIDTH = SEARCH_BUTTON_RIGHT_INSET + 100;
+const SELECTED_TAB_RIGHT_INSET = SEARCH_BUTTON_RIGHT_INSET + SEARCH_BUTTON_SIZE + 12;
+const FALLBACK_TAB_WIDTHS = [72, 84, 92, 76];
+
+export function DiscoverHeader() {
+  const separatorColor = useForegroundColor('separator');
+  return (
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
+      alignItems="center"
+      height={DISCOVER_HEADER_HEIGHT}
+      style={{
+        borderBottomWidth: 1,
+        borderBottomColor: separatorColor,
+      }}
+    >
+      <DiscoverCategorySelector />
+      <DiscoverSearchButton />
+    </Box>
+  );
+}
+
+function DiscoverSearchButton() {
+  const { onTapSearch } = useDiscoverScreenContext();
+  return (
+    <View style={styles.searchButtonContainer}>
+      <ButtonPressAnimation onPress={onTapSearch} scaleTo={0.8} testID="discover-search-icon">
+        <Box
+          background="surfaceSecondaryElevated"
+          width={SEARCH_BUTTON_SIZE}
+          height={SEARCH_BUTTON_SIZE}
+          borderRadius={18}
+          alignItems="center"
+          justifyContent="center"
+          borderWidth={THICK_BORDER_WIDTH}
+          borderColor="buttonStroke"
+        >
+          <TextIcon size="icon 16px" color="label" weight="heavy" containerSize={36}>
+            {'􀊫'}
+          </TextIcon>
+        </Box>
+      </ButtonPressAnimation>
+    </View>
+  );
+}
+
+function DiscoverCategorySelector() {
+  const activeSection = useDiscoverNavigationStore(state => state.activeSection);
+  const surface = useDiscoverSurface();
+  const tabs = surface?.tabs ?? [];
+  const { scrollToSectionTop } = useDiscoverScreenContext();
+  const { isDarkMode } = useColorMode();
+  const screenBackgroundToken: BackgroundColor = isDarkMode ? 'black' : 'surfacePrimary';
+  const screenBackgroundColor = useBackgroundColor(screenBackgroundToken);
+  const scrollViewRef = useRef<ScrollView>(null);
+  const scrollOffsetRef = useRef(0);
+  const scrollViewWidthRef = useRef(0);
+  const tabLayoutsRef = useRef<Partial<Record<DiscoverSection, { width: number; x: number }>>>({});
+
+  const scrollSelectedTabIntoView = useCallback((section: DiscoverSection, animated = true) => {
+    const tabLayout = tabLayoutsRef.current[section];
+    const scrollViewWidth = scrollViewWidthRef.current;
+    if (!tabLayout || !scrollViewWidth) return;
+
+    const visibleWidth = scrollViewWidth - SELECTED_TAB_RIGHT_INSET;
+    const leftEdge = scrollOffsetRef.current;
+    const rightEdge = leftEdge + visibleWidth;
+    const tabLeft = tabLayout.x;
+    const tabRight = tabLayout.x + tabLayout.width;
+
+    if (tabLeft < leftEdge) {
+      const nextOffset = Math.max(0, tabLeft - 24);
+      scrollOffsetRef.current = nextOffset;
+      scrollViewRef.current?.scrollTo({ animated, x: nextOffset });
+      return;
+    }
+
+    if (tabRight > rightEdge) {
+      const nextOffset = Math.max(0, tabRight - visibleWidth + 16);
+      scrollOffsetRef.current = nextOffset;
+      scrollViewRef.current?.scrollTo({ animated, x: nextOffset });
+    }
+  }, []);
+
+  useEffect(() => {
+    requestAnimationFrame(() => scrollSelectedTabIntoView(activeSection));
+  }, [activeSection, scrollSelectedTabIntoView]);
+
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffsetRef.current = event.nativeEvent.contentOffset.x;
+  }, []);
+
+  const handleScrollViewLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      scrollViewWidthRef.current = event.nativeEvent.layout.width;
+      scrollSelectedTabIntoView(activeSection, false);
+    },
+    [activeSection, scrollSelectedTabIntoView]
+  );
+
+  const handlePress = useCallback(
+    (section: DiscoverTab) => {
+      const wasActive = DiscoverSectionNavigation.isSectionActive(section.id);
+
+      if (wasActive) {
+        scrollToSectionTop(section.id);
+      } else {
+        DiscoverSectionNavigation.navigate(section.id);
+      }
+    },
+    [scrollToSectionTop]
+  );
+
+  if (!tabs.length) return <DiscoverCategorySelectorFallback />;
+
+  return (
+    <Box width="full" height="full">
+      <ScrollView
+        ref={scrollViewRef}
+        horizontal
+        contentContainerStyle={styles.tabScrollContent}
+        style={styles.fullHeight}
+        onLayout={handleScrollViewLayout}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        showsHorizontalScrollIndicator={false}
+      >
+        {tabs.map((section, index) => {
+          const isSelected = section.id === activeSection;
+          const sectionLabel = resolveSectionTitle(section);
+          return (
+            <View
+              key={section.id}
+              testID={`tab-${index + 1}`}
+              onLayout={event => {
+                tabLayoutsRef.current[section.id] = event.nativeEvent.layout;
+                if (section.id === activeSection) scrollSelectedTabIntoView(section.id, false);
+              }}
+            >
+              <ButtonPressAnimation
+                hitSlop={4}
+                onPress={() => handlePress(section)}
+                scaleTo={0.92}
+                testID={`discover-section-tab-${section.id}`}
+              >
+                <Text color={isSelected ? 'label' : 'labelTertiary'} size="22pt" weight="heavy">
+                  {sectionLabel}
+                </Text>
+              </ButtonPressAnimation>
+            </View>
+          );
+        })}
+      </ScrollView>
+      <View style={styles.fadeContainer} pointerEvents="none">
+        <EasingGradient
+          startColor={screenBackgroundColor}
+          endColor={screenBackgroundColor}
+          startPosition="right"
+          endPosition="left"
+          startOpacity={1}
+          endOpacity={0}
+          style={{ width: RIGHT_FADE_WIDTH }}
+        />
+        <View
+          style={{
+            height: '100%',
+            width: SEARCH_BUTTON_RIGHT_INSET,
+            backgroundColor: screenBackgroundColor,
+          }}
+        />
+      </View>
+    </Box>
+  );
+}
+
+function DiscoverCategorySelectorFallback() {
+  return (
+    <Box width="full" height="full" flexDirection="row" gap={16} paddingLeft={{ custom: 24 }} paddingTop={{ custom: CONTENT_TOP_INSET }}>
+      {FALLBACK_TAB_WIDTHS.map((width, index) => (
+        <Skeleton key={index} borderRadius={12} height={26} width={width} />
+      ))}
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  fadeContainer: {
+    bottom: 0,
+    flexDirection: 'row',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  fullHeight: {
+    height: '100%',
+  },
+  searchButtonContainer: {
+    position: 'absolute',
+    right: SEARCH_BUTTON_RIGHT_INSET,
+    top: 28,
+  },
+  tabScrollContent: {
+    gap: 16,
+    height: '100%',
+    paddingLeft: 24,
+    paddingRight: SELECTED_TAB_RIGHT_INSET + 32,
+    paddingTop: CONTENT_TOP_INSET,
+  },
+});

--- a/src/features/discover/components/DiscoverRefreshControl.tsx
+++ b/src/features/discover/components/DiscoverRefreshControl.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useState } from 'react';
-import { RefreshControl } from 'react-native';
+import { RefreshControl, type RefreshControlProps } from 'react-native';
 
 import { useForegroundColor } from '@/design-system';
 import { refreshDiscoverSurface } from '@/features/discover/utils/refreshDiscoverSurface';
 
-export function DiscoverRefreshControl() {
+type DiscoverRefreshControlProps = Pick<RefreshControlProps, 'children' | 'style'>;
+
+export function DiscoverRefreshControl({ children, style }: DiscoverRefreshControlProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const tintColor = useForegroundColor('label');
 
@@ -17,5 +19,9 @@ export function DiscoverRefreshControl() {
     }
   }, []);
 
-  return <RefreshControl onRefresh={onRefresh} refreshing={isRefreshing} tintColor={tintColor} />;
+  return (
+    <RefreshControl onRefresh={onRefresh} refreshing={isRefreshing} style={style} tintColor={tintColor}>
+      {children}
+    </RefreshControl>
+  );
 }

--- a/src/features/discover/components/DiscoverRefreshControl.tsx
+++ b/src/features/discover/components/DiscoverRefreshControl.tsx
@@ -1,0 +1,21 @@
+import React, { useCallback, useState } from 'react';
+import { RefreshControl } from 'react-native';
+
+import { useForegroundColor } from '@/design-system';
+import { refreshDiscoverSurface } from '@/features/discover/utils/refreshDiscoverSurface';
+
+export function DiscoverRefreshControl() {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const tintColor = useForegroundColor('label');
+
+  const onRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await refreshDiscoverSurface('discover');
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  return <RefreshControl onRefresh={onRefresh} refreshing={isRefreshing} tintColor={tintColor} />;
+}

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -85,13 +85,14 @@ export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrol
         springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
         verticalPageAlignment="top"
       >
-        {tabs.map(section => (
+        {tabs.map((section, index) => (
           <SmoothPager.Page
             component={
               <DiscoverSectionScrollView
                 isActive={section.id === activeSectionId}
                 scrollOffset={scrollOffset}
                 section={section}
+                sectionIndex={index}
                 sectionScrollOffsets={sectionScrollOffsets}
                 surfaceId={surface.id}
               />
@@ -138,12 +139,14 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
   isActive,
   scrollOffset,
   section,
+  sectionIndex,
   sectionScrollOffsets,
   surfaceId,
 }: {
   isActive: boolean;
   scrollOffset: SharedValue<number>;
   section: DiscoverTab;
+  sectionIndex: number;
   sectionScrollOffsets: MutableRefObject<SectionScrollOffsets>;
   surfaceId: string;
 }) {
@@ -210,9 +213,11 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
       showsVerticalScrollIndicator={false}
       contentInset={{ bottom: bottomInset }}
       style={[styles.scrollView, { paddingBottom: Platform.OS === 'android' ? bottomInset : 0 }]}
-      testID={`discover-section-${section.id}`}
+      testID={`discover-section-page-${sectionIndex + 1}`}
     >
-      <DiscoverSections items={section.sections} surfaceId={surfaceId} />
+      <Box testID={`discover-section-${section.id}`}>
+        <DiscoverSections items={section.sections} surfaceId={surfaceId} />
+      </Box>
     </SectionScrollView>
   );
 });

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -1,0 +1,224 @@
+import React, { memo, useCallback, useEffect, useMemo, useRef, type MutableRefObject } from 'react';
+import { Platform, ScrollView, StyleSheet } from 'react-native';
+
+import Animated, { runOnJS, useAnimatedScrollHandler, useSharedValue, type SharedValue } from 'react-native-reanimated';
+
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
+import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
+import { DEFAULT_SCROLL_FADE_DISTANCE } from '@/components/scroll-header-fade/ScrollHeaderFade';
+import { Skeleton } from '@/components/Skeleton';
+import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
+import { Box } from '@/design-system';
+import { DiscoverRefreshControl } from '@/features/discover/components/DiscoverRefreshControl';
+import { DiscoverSections } from '@/features/discover/components/DiscoverSection';
+import {
+  DiscoverSectionNavigation,
+  useDiscoverNavigationStore,
+  type DiscoverSection,
+} from '@/features/discover/stores/discoverNavigationStore';
+import { useDiscoverSurface } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
+import { type DiscoverTab } from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
+import { useTabBarOffset } from '@/hooks/useTabBarOffset';
+import { useListen } from '@/state/internal/hooks/useListen';
+import { clamp } from '@/worklets/numbers';
+
+type DiscoverSectionsPagerProps = {
+  scrollOffset: SharedValue<number>;
+};
+
+type SectionScrollOffsets = Partial<Record<DiscoverSection, number>>;
+
+const FALLBACK_SECTION_COUNT = 3;
+const FALLBACK_TILE_COUNT = 2;
+
+export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrollOffset }: DiscoverSectionsPagerProps) {
+  const surface = useDiscoverSurface();
+  const tabs = useMemo(() => surface?.tabs ?? [], [surface]);
+  const activeSectionId = useDiscoverNavigationStore(state => state.activeSection);
+  const { ref, goToPage } = usePagerNavigation<DiscoverSection>();
+  const initialSection = getInitialSection(tabs, activeSectionId);
+  const sectionScrollOffsets = useRef<SectionScrollOffsets>({});
+  const pagerKey = tabs.map(tab => tab.id).join('|');
+
+  useListen(
+    useDiscoverNavigationStore,
+    state => state.activeSection,
+    section => {
+      scrollOffset.value = sectionScrollOffsets.current[section] ?? 0;
+      goToPage(section);
+    }
+  );
+
+  const handlePagerIndexChange = useCallback(
+    (index: number) => {
+      const section = tabs[index]?.id;
+      if (section) DiscoverSectionNavigation.navigate(section);
+    },
+    [tabs]
+  );
+
+  useEffect(() => {
+    const firstTab = tabs[0];
+    if (surface && firstTab && !tabs.some(tab => tab.id === activeSectionId)) {
+      DiscoverSectionNavigation.navigate(firstTab.id);
+    }
+  }, [activeSectionId, surface, tabs]);
+
+  if (!surface || !tabs.length) {
+    return (
+      <Box style={styles.container} testID="discover-sections-pager">
+        <DiscoverSectionsFallback />
+      </Box>
+    );
+  }
+
+  return (
+    <Box style={styles.container} testID="discover-sections-pager">
+      <SmoothPager
+        enableSwipeToGoBack={false}
+        enableSwipeToGoForward={false}
+        fillHeight
+        initialPage={initialSection}
+        key={pagerKey}
+        onNewIndex={handlePagerIndexChange}
+        ref={ref}
+        scaleTo={1}
+        springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
+        verticalPageAlignment="top"
+      >
+        {tabs.map(section => (
+          <SmoothPager.Page
+            component={
+              <DiscoverSectionScrollView
+                isActive={section.id === activeSectionId}
+                scrollOffset={scrollOffset}
+                section={section}
+                sectionScrollOffsets={sectionScrollOffsets}
+                surfaceId={surface.id}
+              />
+            }
+            id={section.id}
+            key={section.id}
+            lazy
+          />
+        ))}
+      </SmoothPager>
+    </Box>
+  );
+});
+
+const DiscoverSectionsFallback = memo(function DiscoverSectionsFallback() {
+  const tabBarOffset = useTabBarOffset();
+  const bottomInset = tabBarOffset + 12;
+
+  return (
+    <ScrollView
+      automaticallyAdjustsScrollIndicatorInsets={false}
+      contentContainerStyle={styles.fallbackContent}
+      refreshControl={<DiscoverRefreshControl />}
+      showsVerticalScrollIndicator={false}
+      contentInset={{ bottom: bottomInset }}
+      style={[styles.scrollView, { paddingBottom: Platform.OS === 'android' ? bottomInset : 0 }]}
+      testID="discover-section-fallback"
+    >
+      {Array.from({ length: FALLBACK_SECTION_COUNT }, (_, sectionIndex) => (
+        <Box key={sectionIndex} gap={20}>
+          <Skeleton borderRadius={12} height={30} width={sectionIndex === 0 ? 96 : 148} />
+          <Box flexDirection="row" gap={12}>
+            {Array.from({ length: FALLBACK_TILE_COUNT }, (_, tileIndex) => (
+              <Skeleton key={tileIndex} borderRadius={20} height={166} width="48%" />
+            ))}
+          </Box>
+        </Box>
+      ))}
+    </ScrollView>
+  );
+});
+
+const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
+  isActive,
+  scrollOffset,
+  section,
+  sectionScrollOffsets,
+  surfaceId,
+}: {
+  isActive: boolean;
+  scrollOffset: SharedValue<number>;
+  section: DiscoverTab;
+  sectionScrollOffsets: MutableRefObject<SectionScrollOffsets>;
+  surfaceId: string;
+}) {
+  const { registerSectionScrollView } = useDiscoverScreenContext();
+  const tabBarOffset = useTabBarOffset();
+  const bottomInset = tabBarOffset + 12;
+  const storedScrollOffset = useSharedValue(sectionScrollOffsets.current[section.id] ?? 0);
+
+  const setScrollViewRef = useCallback(
+    (scrollView: Animated.ScrollView | null) => {
+      registerSectionScrollView(section.id, scrollView);
+    },
+    [registerSectionScrollView, section]
+  );
+
+  const updateSectionScrollOffset = useCallback(
+    (nextOffset: number) => {
+      sectionScrollOffsets.current[section.id] = nextOffset;
+    },
+    [section.id, sectionScrollOffsets]
+  );
+
+  const onScroll = useAnimatedScrollHandler({
+    onScroll: event => {
+      const clampedPosition = clamp(event.contentOffset.y, 0, DEFAULT_SCROLL_FADE_DISTANCE);
+
+      if (storedScrollOffset.value !== clampedPosition) {
+        storedScrollOffset.value = clampedPosition;
+        runOnJS(updateSectionScrollOffset)(clampedPosition);
+      }
+
+      if (!isActive || scrollOffset.value === clampedPosition) return;
+      scrollOffset.value = clampedPosition;
+    },
+  });
+
+  return (
+    <Animated.ScrollView
+      automaticallyAdjustsScrollIndicatorInsets={false}
+      contentContainerStyle={styles.scrollContent}
+      onScroll={onScroll}
+      pointerEvents={isActive ? 'auto' : 'none'}
+      ref={setScrollViewRef}
+      refreshControl={<DiscoverRefreshControl />}
+      scrollEventThrottle={16}
+      showsVerticalScrollIndicator={false}
+      contentInset={{ bottom: bottomInset }}
+      style={[styles.scrollView, { paddingBottom: Platform.OS === 'android' ? bottomInset : 0 }]}
+      testID={`discover-section-${section.id}`}
+    >
+      <DiscoverSections items={section.sections} surfaceId={surfaceId} />
+    </Animated.ScrollView>
+  );
+});
+
+function getInitialSection(tabs: DiscoverTab[], activeSectionId: string): string {
+  return tabs.some(tab => tab.id === activeSectionId) ? activeSectionId : (tabs[0]?.id ?? activeSectionId);
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  fallbackContent: {
+    flexGrow: 1,
+    gap: 32,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+  scrollView: {
+    flex: 1,
+    width: '100%',
+  },
+});

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -1,10 +1,10 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef, type MutableRefObject } from 'react';
-import { Platform, ScrollView, StyleSheet } from 'react-native';
+import { Platform, ScrollView, StyleSheet, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 
 import Animated, { runOnJS, useAnimatedScrollHandler, useSharedValue, type SharedValue } from 'react-native-reanimated';
 
 import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
-import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
+import { useDiscoverScreenContext, type DiscoverSectionScrollViewRef } from '@/components/Discover/DiscoverScreenContext';
 import { DEFAULT_SCROLL_FADE_DISTANCE } from '@/components/scroll-header-fade/ScrollHeaderFade';
 import { Skeleton } from '@/components/Skeleton';
 import { SmoothPager, usePagerNavigation } from '@/components/SmoothPager/SmoothPager';
@@ -154,7 +154,7 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
   const storedScrollOffset = useSharedValue(sectionScrollOffsets.current[section.id] ?? 0);
 
   const setScrollViewRef = useCallback(
-    (scrollView: Animated.ScrollView | null) => {
+    (scrollView: DiscoverSectionScrollViewRef | null) => {
       registerSectionScrollView(section.id, scrollView);
     },
     [registerSectionScrollView, section]
@@ -165,6 +165,21 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
       sectionScrollOffsets.current[section.id] = nextOffset;
     },
     [section.id, sectionScrollOffsets]
+  );
+
+  const onAndroidScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const clampedPosition = clamp(event.nativeEvent.contentOffset.y, 0, DEFAULT_SCROLL_FADE_DISTANCE);
+
+      if (storedScrollOffset.value !== clampedPosition) {
+        storedScrollOffset.value = clampedPosition;
+        updateSectionScrollOffset(clampedPosition);
+      }
+
+      if (!isActive || scrollOffset.value === clampedPosition) return;
+      scrollOffset.value = clampedPosition;
+    },
+    [isActive, scrollOffset, storedScrollOffset, updateSectionScrollOffset]
   );
 
   const onScroll = useAnimatedScrollHandler({
@@ -181,11 +196,14 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
     },
   });
 
+  const SectionScrollView = Platform.OS === 'android' ? ScrollView : Animated.ScrollView;
+  const sectionScrollHandler = Platform.OS === 'android' ? onAndroidScroll : onScroll;
+
   return (
-    <Animated.ScrollView
+    <SectionScrollView
       automaticallyAdjustsScrollIndicatorInsets={false}
       contentContainerStyle={styles.scrollContent}
-      onScroll={onScroll}
+      onScroll={sectionScrollHandler}
       pointerEvents={isActive ? 'auto' : 'none'}
       ref={setScrollViewRef}
       refreshControl={<DiscoverRefreshControl />}
@@ -196,7 +214,7 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
       testID={`discover-section-${section.id}`}
     >
       <DiscoverSections items={section.sections} surfaceId={surfaceId} />
-    </Animated.ScrollView>
+    </SectionScrollView>
   );
 });
 

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -75,8 +75,7 @@ export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrol
   return (
     <Box style={styles.container} testID="discover-sections-pager">
       <SmoothPager
-        enableSwipeToGoBack={false}
-        enableSwipeToGoForward={false}
+        enableSwipeToGoForward="always"
         fillHeight
         initialPage={initialSection}
         key={pagerKey}

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -27,12 +27,13 @@ import {
 } from '@/features/discover/types/sectionLayout';
 import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
 import { maybeNavigateToPerpsExplainSheet } from '@/features/perps/utils/navigateToPerps';
-import { usePerpsEnabled, usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
+import { usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
 import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
 import { MARKET_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
 import { useIsDiscoverSurfacePlacementPending } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
 import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { useRemoteConfig } from '@/model/remoteConfig';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
@@ -85,7 +86,7 @@ export function MarketSection({ surface }: { surface: SurfaceLeafWithDisplay<Mar
 }
 
 function MarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
-  const perpsEnabled = usePerpsEnabled();
+  const perpsEnabled = useRemoteConfig('perps_enabled').perps_enabled;
   const placement = usePlacementsV2Store(state => state.getPlacement(surface.placement));
   const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
   const isLoadingPlacementSource = usePlacementsV2Store(state => {

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -25,6 +25,7 @@ import {
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
+import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
 import { usePerpsEnabled, usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
 import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
@@ -121,7 +122,6 @@ function PerpsMarketPlacementContent({
   // surfaceId is threaded from MarketPlacementContent for future use (#7553)
   surfaceId: string;
 }) {
-  const { onTapSearch } = useDiscoverScreenContext();
   const perpsResult = usePerpsPlacement(surface.placement);
   const perpDescriptor = useMemo<SectionDescriptor<PerpMarketPlacementItem>>(() => {
     switch (surface.display) {
@@ -148,15 +148,15 @@ function PerpsMarketPlacementContent({
         };
     }
   }, [surface.display]);
-  // Only passed when the destination is perp-owned (`['perps']`); non-perp CMS
-  // destinations are wired in #7553.
-  const onPressSeeAll = useCallback(() => onTapSearch(), [onTapSearch]);
+  // Perp "See All" routes to the CMS destination (perps -> perps screen), gated on
+  // a destination existing.
+  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
 
   return renderSectionLayout({
     data: perpsResult.items,
     descriptor: perpDescriptor,
     loading: perpsResult.isLoading,
-    onPressSeeAll: surface.destination?.[0] === 'perps' ? onPressSeeAll : undefined,
+    onPressSeeAll: hasDestination(surface) ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -198,8 +198,8 @@ function TokenMarketPlacementContent({
         };
     }
   }, [nativeCurrency, surface.display]);
-  // Only passed when the destination is token-owned (`['tokens']`); non-token CMS
-  // destinations are wired in #7553.
+  // Token "See All" opens Discover search rather than routing a CMS destination;
+  // navigateDiscoverDestination('tokens') is intentionally a no-op.
   const onPressSeeAll = useCallback(() => onTapSearch(), [onTapSearch]);
 
   return renderSectionLayout({

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -26,7 +26,7 @@ import {
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
 import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
-import { navigateToPerpDetailScreen } from '@/features/perps/utils';
+import { maybeNavigateToPerpsExplainSheet } from '@/features/perps/utils/navigateToPerps';
 import { usePerpsEnabled, usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
 import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
@@ -253,8 +253,8 @@ function TokenMarketItem({
 function PerpMarketItem({ item, variant, width }: { item: PerpMarketPlacementItem; variant: 'cell' | 'pill' | 'tile'; width?: number }) {
   const displayItem = usePerpMarketDisplay(item);
   const onPress = useCallback(() => {
-    navigateToPerpDetailScreen(item.market.symbol);
-  }, [item.market.symbol]);
+    maybeNavigateToPerpsExplainSheet(() => Navigation.handleAction(Routes.PERPS_DETAIL_SCREEN, { market: item.market }));
+  }, [item.market]);
 
   switch (variant) {
     case 'cell':

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -38,6 +38,7 @@ import Routes from '@/navigation/routesNames';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 
 const hasDestination = (surface: SurfaceLeaf) => surface.destination !== null;
+const MARKET_TILE_SHADOW_BLEED = 28;
 
 const MARKET_SECTION_DESCRIPTORS = {
   'market_pill.carousel': {
@@ -52,7 +53,9 @@ const MARKET_SECTION_DESCRIPTORS = {
   },
   'market_tile.carousel': {
     layout: 'carousel',
+    itemHorizontalBleed: MARKET_TILE_SHADOW_BLEED,
     itemHeight: MARKET_TILE_CARD_HEIGHT,
+    itemVerticalBleed: MARKET_TILE_SHADOW_BLEED,
     itemWidth: MARKET_TILE_CARD_WIDTH,
     renderItem: renderMarketTile,
     renderSkeleton: MarketTileCardSkeleton,

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -25,7 +25,7 @@ import {
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
-import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
+import { hasDestinationRoot, navigateDiscoverDestination } from '@/features/discover/utils/navigation';
 import { maybeNavigateToPerpsExplainSheet } from '@/features/perps/utils/navigateToPerps';
 import { usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
 import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
@@ -144,14 +144,17 @@ function PerpsMarketPlacementContent({ surface }: { surface: PlacementBackedSurf
     }
   }, [surface.display]);
   // Perp "See All" routes to the CMS destination (perps -> perps screen), gated on
-  // a destination existing.
-  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
+  // a perps destination existing.
+  const perpsDestination = hasDestinationRoot(surface.destination, 'perps') ? surface.destination : null;
+  const onPressSeeAll = useCallback(() => {
+    if (perpsDestination) navigateDiscoverDestination(perpsDestination);
+  }, [perpsDestination]);
 
   return renderSectionLayout({
     data: perpsResult.items,
     descriptor: perpDescriptor,
     loading: perpsResult.isLoading,
-    onPressSeeAll: hasDestination(surface) ? onPressSeeAll : undefined,
+    onPressSeeAll: perpsDestination ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -195,7 +198,7 @@ function TokenMarketPlacementContent({ surface }: { surface: PlacementBackedSurf
     data: tokensResult.items,
     descriptor: tokenDescriptor,
     loading: tokensResult.isLoading,
-    onPressSeeAll: surface.destination?.[0] === 'tokens' ? onPressSeeAll : undefined,
+    onPressSeeAll: hasDestinationRoot(surface.destination, 'tokens') ? onPressSeeAll : undefined,
     surface,
   });
 }

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -26,12 +26,15 @@ import {
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
 import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
+import { navigateToPerpDetailScreen } from '@/features/perps/utils';
 import { usePerpsEnabled, usePerpsPlacement, type PerpMarketPlacementItem } from '@/features/placements/stores/derived/perpsPlacementStore';
 import { useTokensPlacement, type TokenPlacementItem } from '@/features/placements/stores/derived/tokensPlacementStore';
 import { usePlacementsV2Store } from '@/features/placements/stores/placementsStore';
 import { MARKET_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
 import { useIsDiscoverSurfacePlacementPending } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
 import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 
 const hasDestination = (surface: SurfaceLeaf) => surface.destination !== null;
@@ -73,18 +76,12 @@ export function isMarketSurface(surface: SurfaceLeaf): surface is SurfaceLeafWit
   return (MARKET_DISPLAY_VALUES as readonly string[]).includes(surface.display);
 }
 
-export function MarketSection({ surface, surfaceId }: { surface: SurfaceLeafWithDisplay<MarketDisplay>; surfaceId: string }) {
+export function MarketSection({ surface }: { surface: SurfaceLeafWithDisplay<MarketDisplay>; surfaceId: string }) {
   if (!hasPlacement(surface)) return null;
-  return <MarketPlacementContent surface={surface} surfaceId={surfaceId} />;
+  return <MarketPlacementContent surface={surface} />;
 }
 
-function MarketPlacementContent({
-  surface,
-  surfaceId,
-}: {
-  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
-  surfaceId: string;
-}) {
+function MarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
   const perpsEnabled = usePerpsEnabled();
   const placement = usePlacementsV2Store(state => state.getPlacement(surface.placement));
   const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
@@ -95,11 +92,11 @@ function MarketPlacementContent({
 
   if (placement?.source === 'hyperliquid') {
     if (!perpsEnabled) return null;
-    return <PerpsMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
+    return <PerpsMarketPlacementContent surface={surface} />;
   }
 
   if (placement?.source === 'rainbow') {
-    return <TokenMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
+    return <TokenMarketPlacementContent surface={surface} />;
   }
 
   if (isLoadingPlacementSource || isPendingSurfacePlacement) {
@@ -115,13 +112,7 @@ function MarketPlacementContent({
   return null;
 }
 
-function PerpsMarketPlacementContent({
-  surface,
-}: {
-  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
-  // surfaceId is threaded from MarketPlacementContent for future use (#7553)
-  surfaceId: string;
-}) {
+function PerpsMarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
   const perpsResult = usePerpsPlacement(surface.placement);
   const perpDescriptor = useMemo<SectionDescriptor<PerpMarketPlacementItem>>(() => {
     switch (surface.display) {
@@ -161,13 +152,7 @@ function PerpsMarketPlacementContent({
   });
 }
 
-function TokenMarketPlacementContent({
-  surface,
-  surfaceId,
-}: {
-  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
-  surfaceId: string;
-}) {
+function TokenMarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
   const { onTapSearch } = useDiscoverScreenContext();
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
   const tokensResult = useTokensPlacement(surface.placement);
@@ -247,26 +232,36 @@ function TokenMarketItem({
   width?: number;
 }) {
   const displayItem = useTokenMarketDisplay({ item, nativeCurrency });
+  const onPress = useCallback(() => {
+    Navigation.handleAction(Routes.EXPANDED_ASSET_SHEET_V2, {
+      asset: item.asset,
+      address: item.asset.address,
+      chainId: item.asset.chainId,
+    });
+  }, [item.asset]);
 
   switch (variant) {
     case 'cell':
-      return <MarketCell item={displayItem} />;
+      return <MarketCell item={displayItem} onPress={onPress} />;
     case 'pill':
-      return <MarketPill item={displayItem} />;
+      return <MarketPill item={displayItem} onPress={onPress} />;
     case 'tile':
-      return <MarketTileCard item={displayItem} width={width} />;
+      return <MarketTileCard item={displayItem} onPress={onPress} width={width} />;
   }
 }
 
 function PerpMarketItem({ item, variant, width }: { item: PerpMarketPlacementItem; variant: 'cell' | 'pill' | 'tile'; width?: number }) {
   const displayItem = usePerpMarketDisplay(item);
+  const onPress = useCallback(() => {
+    navigateToPerpDetailScreen(item.market.symbol);
+  }, [item.market.symbol]);
 
   switch (variant) {
     case 'cell':
-      return <MarketCell item={displayItem} />;
+      return <MarketCell item={displayItem} onPress={onPress} />;
     case 'pill':
-      return <MarketPill item={displayItem} />;
+      return <MarketPill item={displayItem} onPress={onPress} />;
     case 'tile':
-      return <MarketTileCard item={displayItem} width={width} />;
+      return <MarketTileCard item={displayItem} onPress={onPress} width={width} />;
   }
 }

--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -22,6 +22,7 @@ import {
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
+import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
 import {
   getSportsSurfaceIntent,
   selectSportsEventsForIntent,
@@ -217,7 +218,8 @@ function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurf
     data: result.items,
     descriptor,
     loading: result.isLoading || isPlacementPending,
-    onPressSeeAll: undefined,
+    // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
+    onPressSeeAll: () => navigateDiscoverDestination(surface.destination),
     surface,
   });
 }
@@ -247,7 +249,8 @@ function SportsEventPlacementSection({
     headerCount,
     leadingAccessory,
     loading: result.isLoading || isPlacementPending,
-    onPressSeeAll: undefined,
+    // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
+    onPressSeeAll: () => navigateDiscoverDestination(surface.destination),
     surface,
   });
 }
@@ -281,7 +284,8 @@ function SportsQuerySection({
     headerCount,
     leadingAccessory,
     loading: isLoading,
-    onPressSeeAll: undefined,
+    // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
+    onPressSeeAll: () => navigateDiscoverDestination(surface.destination),
     surface,
   });
 }

--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -23,7 +23,7 @@ import {
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
 } from '@/features/discover/types/sectionLayout';
-import { navigateDiscoverDestination } from '@/features/discover/utils/navigation';
+import { hasDestinationRoot, navigateDiscoverDestination } from '@/features/discover/utils/navigation';
 import {
   getSportsSurfaceIntent,
   selectSportsEventsForIntent,
@@ -54,7 +54,6 @@ import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 type PredictionsDisplay = (typeof PREDICTION_DISPLAY_VALUES)[number];
 
-const hasDestination = (surface: SurfaceLeaf) => surface.destination !== null;
 const PREDICTION_TILE_SHADOW_BLEED = 28;
 const PREDICTION_TILE_WIDTH = Math.round((DEVICE_WIDTH - 20 * 2 - 8) / 2);
 const PREDICTION_TILE_SKELETON = {
@@ -217,7 +216,10 @@ function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurf
   const result = usePredictionsPlacement(surface.placement);
   const isPlacementPending = useIsPredictionPlacementPending(surface);
   const descriptor = PREDICTIONS_SECTION_DESCRIPTORS[surface.display];
-  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
+  const predictionsDestination = hasDestinationRoot(surface.destination, 'predictions') ? surface.destination : null;
+  const onPressSeeAll = useCallback(() => {
+    if (predictionsDestination) navigateDiscoverDestination(predictionsDestination);
+  }, [predictionsDestination]);
 
   usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
 
@@ -226,7 +228,7 @@ function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurf
     descriptor,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: hasDestination(surface) && result.placement ? onPressSeeAll : undefined,
+    onPressSeeAll: predictionsDestination && result.placement ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -241,7 +243,10 @@ function SportsEventPlacementSection({
   const isPlacementPending = useIsPredictionPlacementPending(surface);
   const result = usePredictionsPlacement(surface.placement);
   const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
-  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
+  const predictionsDestination = hasDestinationRoot(surface.destination, 'predictions') ? surface.destination : null;
+  const onPressSeeAll = useCallback(() => {
+    if (predictionsDestination) navigateDiscoverDestination(predictionsDestination);
+  }, [predictionsDestination]);
 
   usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
 
@@ -258,7 +263,7 @@ function SportsEventPlacementSection({
     leadingAccessory,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: hasDestination(surface) && result.placement ? onPressSeeAll : undefined,
+    onPressSeeAll: predictionsDestination && result.placement ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -280,7 +285,10 @@ function SportsQuerySection({
   }, [events, sportsIntent]);
   const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
   const headerCount = getRenderedHeaderCount({ descriptor, itemCount: items.length, limit: surface.limit });
-  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
+  const predictionsDestination = hasDestinationRoot(surface.destination, 'predictions') ? surface.destination : null;
+  const onPressSeeAll = useCallback(() => {
+    if (predictionsDestination) navigateDiscoverDestination(predictionsDestination);
+  }, [predictionsDestination]);
 
   usePredictionTokenSubscription({ display: surface.display, items, limit: surface.limit });
 
@@ -294,7 +302,7 @@ function SportsQuerySection({
     leadingAccessory,
     loading: isLoading,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: hasDestination(surface) ? onPressSeeAll : undefined,
+    onPressSeeAll: predictionsDestination ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -313,13 +321,13 @@ function getSportsHeaderProps(
   if ('leagueId' in sportsIntent) {
     // League section: shows league icon, caret based on destination
     return {
-      headerCaret: hasDestination(surface),
+      headerCaret: hasDestinationRoot(surface.destination, 'predictions'),
       leadingAccessory: <LeagueIcon leagueId={sportsIntent.leagueId} size={28} />,
     };
   }
   // Today/other bucket section: no leading accessory, caret based on destination
   return {
-    headerCaret: hasDestination(surface),
+    headerCaret: hasDestinationRoot(surface.destination, 'predictions'),
     leadingAccessory: undefined,
   };
 }

--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -52,6 +52,7 @@ import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 type PredictionsDisplay = (typeof PREDICTION_DISPLAY_VALUES)[number];
 
+const hasDestination = (surface: SurfaceLeaf) => surface.destination !== null;
 const PREDICTION_TILE_WIDTH = Math.round((DEVICE_WIDTH - 20 * 2 - 8) / 2);
 const PREDICTION_TILE_SKELETON = {
   borderRadius: PREDICTION_CARD_BORDER_RADIUS,
@@ -211,6 +212,7 @@ function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurf
   const result = usePredictionsPlacement(surface.placement);
   const isPlacementPending = useIsPredictionPlacementPending(surface);
   const descriptor = PREDICTIONS_SECTION_DESCRIPTORS[surface.display];
+  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
 
   usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
 
@@ -219,7 +221,7 @@ function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurf
     descriptor,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: () => navigateDiscoverDestination(surface.destination),
+    onPressSeeAll: hasDestination(surface) && result.placement ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -234,6 +236,7 @@ function SportsEventPlacementSection({
   const isPlacementPending = useIsPredictionPlacementPending(surface);
   const result = usePredictionsPlacement(surface.placement);
   const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
+  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
 
   usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
 
@@ -250,7 +253,7 @@ function SportsEventPlacementSection({
     leadingAccessory,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: () => navigateDiscoverDestination(surface.destination),
+    onPressSeeAll: hasDestination(surface) && result.placement ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -272,6 +275,7 @@ function SportsQuerySection({
   }, [events, sportsIntent]);
   const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
   const headerCount = getRenderedHeaderCount({ descriptor, itemCount: items.length, limit: surface.limit });
+  const onPressSeeAll = useCallback(() => navigateDiscoverDestination(surface.destination), [surface.destination]);
 
   usePredictionTokenSubscription({ display: surface.display, items, limit: surface.limit });
 
@@ -285,7 +289,7 @@ function SportsQuerySection({
     leadingAccessory,
     loading: isLoading,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: () => navigateDiscoverDestination(surface.destination),
+    onPressSeeAll: hasDestination(surface) ? onPressSeeAll : undefined,
     surface,
   });
 }
@@ -304,13 +308,13 @@ function getSportsHeaderProps(
   if ('leagueId' in sportsIntent) {
     // League section: shows league icon, caret based on destination
     return {
-      headerCaret: surface.destination !== null,
+      headerCaret: hasDestination(surface),
       leadingAccessory: <LeagueIcon leagueId={sportsIntent.leagueId} size={28} />,
     };
   }
   // Today/other bucket section: no leading accessory, caret based on destination
   return {
-    headerCaret: surface.destination !== null,
+    headerCaret: hasDestination(surface),
     leadingAccessory: undefined,
   };
 }

--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, type ReactNode } from 'react';
-import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 import { Skeleton } from '@/components/Skeleton';
+import { globalColors, useColorMode } from '@/design-system';
 import {
   PREDICTION_MARKET_EVENT_CARD_BORDER_RADIUS,
   PREDICTION_MARKET_EVENT_CARD_CAROUSEL_WIDTH,
@@ -45,6 +46,7 @@ import { getSportsEventRowTokenIds } from '@/features/polymarket/hooks/useSports
 import { usePolymarketSportsEventsStore } from '@/features/polymarket/stores/polymarketSportsEventsStore';
 import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
 import { navigateToPolymarketEvent } from '@/features/polymarket/utils/navigateToPolymarket';
+import { opacity } from '@/framework/ui/utils/opacity';
 import { logger } from '@/logger';
 import Routes from '@/navigation/routesNames';
 import { addSubscribedTokens, removeSubscribedTokens, useLiveTokensStore } from '@/state/liveTokens/liveTokensStore';
@@ -53,6 +55,7 @@ import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 type PredictionsDisplay = (typeof PREDICTION_DISPLAY_VALUES)[number];
 
 const hasDestination = (surface: SurfaceLeaf) => surface.destination !== null;
+const PREDICTION_TILE_SHADOW_BLEED = 28;
 const PREDICTION_TILE_WIDTH = Math.round((DEVICE_WIDTH - 20 * 2 - 8) / 2);
 const PREDICTION_TILE_SKELETON = {
   borderRadius: PREDICTION_CARD_BORDER_RADIUS,
@@ -91,7 +94,9 @@ type PredictionSkeletonConfig = {
 const PREDICTIONS_SECTION_DESCRIPTORS = {
   'prediction_tile.carousel': {
     layout: 'carousel',
+    itemHorizontalBleed: PREDICTION_TILE_SHADOW_BLEED,
     itemHeight: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
+    itemVerticalBleed: PREDICTION_TILE_SHADOW_BLEED,
     itemWidth: PREDICTION_TILE_WIDTH,
     renderItem: renderPredictionTile,
     renderSkeleton: () => renderPredictionSkeleton(PREDICTION_TILE_SKELETON),
@@ -343,11 +348,19 @@ function renderPredictionGridTile(item: PredictionPlacementItem, width: number) 
 }
 
 function PredictionListItem({ item, style }: { item: PredictionPlacementItem; style: StyleProp<ViewStyle> }) {
+  const { isDarkMode } = useColorMode();
   const onPress = useCallback(() => {
     navigateToPolymarketEvent({ event: item.event, eventId: item.event.id });
   }, [item.event]);
 
-  return <PolymarketEventsListItem event={item.event} onPress={onPress} shouldActivateOnStart={false} style={style} />;
+  return (
+    <PolymarketEventsListItem
+      event={item.event}
+      onPress={onPress}
+      shouldActivateOnStart={false}
+      style={[style, styles.predictionTileShadow, isDarkMode ? styles.predictionTileShadowDark : styles.predictionTileShadowLight]}
+    />
+  );
 }
 
 function renderPredictionSkeleton({ borderRadius, height, width }: PredictionSkeletonConfig) {
@@ -401,6 +414,24 @@ const styles = StyleSheet.create({
   predictionTile: {
     height: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT,
     width: PREDICTION_TILE_WIDTH,
+  },
+  predictionTileShadow: {
+    borderCurve: 'continuous',
+    borderRadius: PREDICTION_CARD_BORDER_RADIUS,
+  },
+  predictionTileShadowDark: {
+    shadowColor: globalColors.grey100,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.16,
+    shadowRadius: 24,
+  },
+  predictionTileShadowLight: {
+    backgroundColor: Platform.OS === 'android' ? opacity(globalColors.white100, 0.89) : undefined,
+    elevation: 4,
+    shadowColor: globalColors.grey100,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.06,
+    shadowRadius: 24,
   },
   liveHeaderIndicator: {
     marginRight: LIVE_INDICATOR_HEADER_GAP - HEADER_ACCESSORY_GAP,

--- a/src/features/discover/components/SectionLayout.tsx
+++ b/src/features/discover/components/SectionLayout.tsx
@@ -63,6 +63,7 @@ export function renderSectionLayout<T extends PlacementItem>({
           {...sectionProps}
           data={renderedData}
           getItemWidth={descriptor.getItemWidth}
+          itemHorizontalBleed={descriptor.itemHorizontalBleed}
           itemHeight={descriptor.itemHeight}
           itemVerticalBleed={descriptor.itemVerticalBleed}
           itemWidth={descriptor.itemWidth}

--- a/src/features/discover/components/markets/cards/MarketTileCard.tsx
+++ b/src/features/discover/components/markets/cards/MarketTileCard.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -71,7 +71,7 @@ const CARD_COLORS = {
     gradientOpacity: 0.16,
   },
   light: {
-    backgroundColor: 'rgba(255,255,255,0.92)',
+    backgroundColor: opacity(globalColors.white100, 0.92),
     badgeBorderColor: opacity(globalColors.grey100, 0.07),
     badgeShadowOpacity: 0.25,
     borderColor: 'rgba(255,255,255,0.8)',
@@ -226,6 +226,7 @@ const styles = StyleSheet.create({
     shadowRadius: 24,
   },
   cardShadowLight: {
+    backgroundColor: Platform.OS === 'android' ? opacity(globalColors.white100, 0.92) : undefined,
     elevation: 4,
     shadowColor: globalColors.grey100,
     shadowOffset: { width: 0, height: 4 },

--- a/src/features/discover/components/markets/cards/MarketTileCard.tsx
+++ b/src/features/discover/components/markets/cards/MarketTileCard.tsx
@@ -71,7 +71,7 @@ const CARD_COLORS = {
     gradientOpacity: 0.16,
   },
   light: {
-    backgroundColor: 'transparent',
+    backgroundColor: 'rgba(255,255,255,0.92)',
     badgeBorderColor: opacity(globalColors.grey100, 0.07),
     badgeShadowOpacity: 0.25,
     borderColor: 'rgba(255,255,255,0.8)',

--- a/src/features/discover/components/markets/cards/MarketTileCard.tsx
+++ b/src/features/discover/components/markets/cards/MarketTileCard.tsx
@@ -94,7 +94,7 @@ export const MarketTileCard = memo(function MarketTileCard({ item, onPress, widt
   const chartWidth = width - CARD_LAYOUT.paddingHorizontal * 2;
 
   return (
-    <ButtonPressAnimation scaleTo={0.96} style={[styles.pressable, { width }]}>
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.96} style={[styles.pressable, { width }]}>
       <View style={[styles.cardShadow, isDarkMode ? styles.cardShadowDark : styles.cardShadowLight]}>
         <View style={[styles.card, { backgroundColor: cardColors.backgroundColor }]}>
           <LinearGradient

--- a/src/features/discover/components/markets/layouts/MarketCarousel.tsx
+++ b/src/features/discover/components/markets/layouts/MarketCarousel.tsx
@@ -16,6 +16,7 @@ type MarketCarouselProps<T extends PlacementItem> = {
   data: T[];
   getItemWidth?: (item: T) => number;
   headerCount?: number;
+  itemHorizontalBleed?: number;
   itemHeight: number;
   itemVerticalBleed?: number;
   itemWidth: number;
@@ -34,6 +35,7 @@ export function MarketCarousel<T extends PlacementItem>({
   data,
   getItemWidth,
   headerCount,
+  itemHorizontalBleed = 0,
   itemHeight,
   itemVerticalBleed = 0,
   itemWidth,
@@ -90,13 +92,19 @@ export function MarketCarousel<T extends PlacementItem>({
           ))}
         </View>
       ) : (
-        <View style={[styles.carouselViewport, itemVerticalBleed ? { marginVertical: -itemVerticalBleed } : undefined]}>
+        <View
+          style={[
+            styles.carouselViewport,
+            itemHorizontalBleed ? { marginHorizontal: HORIZONTAL_PADDING - itemHorizontalBleed } : undefined,
+            itemVerticalBleed ? { marginVertical: -itemVerticalBleed } : undefined,
+          ]}
+        >
           <FlatList
             data={data}
             horizontal
             disallowInterruption
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.contentContainer}
+            contentContainerStyle={[styles.contentContainer, itemHorizontalBleed ? { paddingHorizontal: itemHorizontalBleed } : undefined]}
             decelerationRate="fast"
             snapToOffsets={snapToOffsets}
             snapToAlignment="start"

--- a/src/features/discover/stores/discoverNavigationStore.ts
+++ b/src/features/discover/stores/discoverNavigationStore.ts
@@ -1,0 +1,26 @@
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
+import { createStoreActions } from '@/state/internal/utils/createStoreActions';
+
+export type DiscoverSection = string;
+
+type DiscoverNavigationStore = {
+  activeSection: DiscoverSection;
+  getActiveSection: () => DiscoverSection;
+  isSectionActive: (section: DiscoverSection) => boolean;
+  navigate: (section: DiscoverSection) => void;
+};
+
+export const useDiscoverNavigationStore = createRainbowStore<DiscoverNavigationStore>((set, get) => ({
+  activeSection: 'for_you',
+
+  getActiveSection: () => get().activeSection,
+
+  isSectionActive: section => get().activeSection === section,
+
+  navigate: section => {
+    if (get().activeSection === section) return;
+    set({ activeSection: section });
+  },
+}));
+
+export const DiscoverSectionNavigation = createStoreActions(useDiscoverNavigationStore);

--- a/src/features/discover/types/sectionLayout.ts
+++ b/src/features/discover/types/sectionLayout.ts
@@ -7,6 +7,7 @@ import { type PlacementItemV2 as PlacementItem } from '@/features/placements/typ
 export type CarouselSectionDescriptor<T extends PlacementItem> = {
   layout: 'carousel';
   getItemWidth?: (item: T) => number;
+  itemHorizontalBleed?: number;
   itemHeight: number;
   itemVerticalBleed?: number;
   itemWidth: number;

--- a/src/features/discover/utils/navigation.ts
+++ b/src/features/discover/utils/navigation.ts
@@ -1,0 +1,30 @@
+import { navigateToPerps, navigateToPerpsSearch } from '@/features/perps/utils/navigateToPerps';
+import { type Destination } from '@/features/placements/surfaces/types';
+import { DEFAULT_SPORTS_LEAGUE_KEY } from '@/features/polymarket/constants';
+import {
+  navigateToPolymarket,
+  navigateToPolymarketCategory,
+  navigateToPolymarketSportsLeague,
+} from '@/features/polymarket/utils/navigateToPolymarket';
+
+export function navigateDiscoverDestination(destination: Destination): void {
+  if (!destination) return;
+
+  const [root, ...segments] = destination;
+
+  switch (root) {
+    case 'predictions': {
+      const [category, league] = segments;
+      if (category === 'sports') navigateToPolymarketSportsLeague(league ?? DEFAULT_SPORTS_LEAGUE_KEY);
+      else if (category) navigateToPolymarketCategory(category);
+      else navigateToPolymarket();
+      return;
+    }
+    case 'perps':
+      if (segments.length) navigateToPerpsSearch();
+      else navigateToPerps();
+      return;
+    case 'tokens':
+      return;
+  }
+}

--- a/src/features/discover/utils/navigation.ts
+++ b/src/features/discover/utils/navigation.ts
@@ -1,5 +1,5 @@
 import { navigateToPerps, navigateToPerpsSearch } from '@/features/perps/utils/navigateToPerps';
-import { type Destination } from '@/features/placements/surfaces/types';
+import { type Destination, type DestinationRoot } from '@/features/placements/surfaces/types';
 import { DEFAULT_SPORTS_LEAGUE_KEY } from '@/features/polymarket/constants';
 import {
   navigateToPolymarket,
@@ -7,9 +7,11 @@ import {
   navigateToPolymarketSportsLeague,
 } from '@/features/polymarket/utils/navigateToPolymarket';
 
-export function navigateDiscoverDestination(destination: Destination): void {
-  if (!destination) return;
+export type DestinationForRoot<Root extends DestinationRoot> = [Root, ...string[]];
 
+export type NavigableDiscoverDestination = DestinationForRoot<'perps'> | DestinationForRoot<'predictions'>;
+
+export function navigateDiscoverDestination(destination: NavigableDiscoverDestination): void {
   const [root, ...segments] = destination;
 
   switch (root) {
@@ -24,7 +26,12 @@ export function navigateDiscoverDestination(destination: Destination): void {
       if (segments.length) navigateToPerpsSearch();
       else navigateToPerps();
       return;
-    case 'tokens':
-      return;
   }
+}
+
+export function hasDestinationRoot<Root extends DestinationRoot>(
+  destination: Destination,
+  root: Root
+): destination is DestinationForRoot<Root> {
+  return destination?.[0] === root;
 }

--- a/src/features/discover/utils/refreshDiscoverSurface.ts
+++ b/src/features/discover/utils/refreshDiscoverSurface.ts
@@ -1,6 +1,5 @@
 import { POLYMARKET } from '@/config/experimental';
 import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
-import { IS_TEST } from '@/env';
 import { getSportsSurfaceIntent } from '@/features/discover/utils/sportsSurfaceIntent';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { usePredictionEventsStore } from '@/features/placements/stores/derived/predictionsPlacementStore';
@@ -20,11 +19,9 @@ export async function refreshDiscoverSurface(surfaceId: string): Promise<void> {
 
   const surface = useDiscoverSurface.getState();
   const refs = useDiscoverSurfacePlacementRefs.getState();
-  const perpsEnabled = useRemoteConfigStore.getState().getRemoteConfigKey('perps_enabled') && !IS_TEST;
+  const perpsEnabled = useRemoteConfigStore.getState().getRemoteConfigKey('perps_enabled');
   const polymarketEnabled =
-    (useRemoteConfigStore.getState().getRemoteConfigKey('polymarket_enabled') ||
-      useExperimentalConfigStore.getState().getFlag(POLYMARKET)) &&
-    !IS_TEST;
+    useRemoteConfigStore.getState().getRemoteConfigKey('polymarket_enabled') || useExperimentalConfigStore.getState().getFlag(POLYMARKET);
 
   const refreshes: Promise<unknown>[] = [];
 

--- a/src/features/placements/stores/derived/perpsPlacementStore.ts
+++ b/src/features/placements/stores/derived/perpsPlacementStore.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import { IS_TEST } from '@/env';
 import { useHyperliquidMarketsStore } from '@/features/perps/stores/hyperliquidMarketsStore';
 import { type PerpMarketsBySymbol, type PerpMarketWithMetadata } from '@/features/perps/types';
 import {
@@ -27,8 +26,10 @@ export type PerpMarketPlacementItem = PlacementItemV2 & {
 // ============ Derived Stores ================================================= //
 
 export const usePerpsEnabled = createDerivedStore<boolean>(
-  $ => $(useRemoteConfigStore, state => state.getRemoteConfigKey('perps_enabled')) && !IS_TEST,
-  { fastMode: true }
+  $ => $(useRemoteConfigStore, state => state.getRemoteConfigKey('perps_enabled')),
+  {
+    fastMode: true,
+  }
 );
 
 // ============ Utilities ====================================================== //

--- a/src/features/placements/stores/derived/perpsPlacementStore.ts
+++ b/src/features/placements/stores/derived/perpsPlacementStore.ts
@@ -10,8 +10,7 @@ import {
 } from '@/features/placements/stores/placementsStore';
 import { type PlacementIdV2, type PlacementItemV2 } from '@/features/placements/types';
 import { finalizePlacementResult, pairPlacementItems } from '@/features/placements/utils/finalizePlacementResult';
-import { useRemoteConfigStore } from '@/model/remoteConfig';
-import { createDerivedStore } from '@/state/internal/createDerivedStore';
+import { useRemoteConfig } from '@/model/remoteConfig';
 import { shallowEqual } from '@/worklets/comparisons';
 
 // ============ Types ========================================================== //
@@ -23,19 +22,10 @@ export type PerpMarketPlacementItem = PlacementItemV2 & {
   market: PerpMarketWithMetadata;
 };
 
-// ============ Derived Stores ================================================= //
-
-export const usePerpsEnabled = createDerivedStore<boolean>(
-  $ => $(useRemoteConfigStore, state => state.getRemoteConfigKey('perps_enabled')),
-  {
-    fastMode: true,
-  }
-);
-
 // ============ Utilities ====================================================== //
 
 export function usePerpsPlacement(placementId: PlacementIdV2): PlacementResult<PerpMarketPlacementItem> {
-  const enabled = usePerpsEnabled();
+  const enabled = useRemoteConfig('perps_enabled').perps_enabled;
   const placement = usePlacementsV2Store(state => state.getPlacement(placementId));
   const placementItems = usePlacementsV2Store(state => selectPlacementItemsBySource(state, placementId, 'hyperliquid'), shallowEqual);
   const placementsLoading = usePlacementsV2Store(state => isPlacementHydrating(state, placementId, 'hyperliquid'));

--- a/src/features/placements/stores/derived/predictionsPlacementStore.ts
+++ b/src/features/placements/stores/derived/predictionsPlacementStore.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 
 import { POLYMARKET } from '@/config/experimental';
 import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
-import { IS_TEST } from '@/env';
 import {
   isPlacementHydrating,
   selectPlacementItemsBySource,
@@ -51,7 +50,7 @@ const usePredictionsEnabled = createDerivedStore<boolean>(
     const polymarketEnabled = $(useRemoteConfigStore, state => state.getRemoteConfigKey('polymarket_enabled'));
     const polymarketEnabledLocally = $(useExperimentalConfigStore, state => state.getFlag(POLYMARKET));
 
-    if (!hasPredictionRefsOrPendingHydration($) || IS_TEST) return false;
+    if (!hasPredictionRefsOrPendingHydration($)) return false;
 
     return polymarketEnabled || polymarketEnabledLocally;
   },

--- a/src/features/placements/stores/derived/tokensPlacementStore.ts
+++ b/src/features/placements/stores/derived/tokensPlacementStore.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { isAddress, type Address } from 'viem';
 
 import { type NativeCurrencyKey } from '@/entities/nativeCurrencyTypes';
-import { IS_TEST } from '@/env';
 import {
   isPlacementHydrating,
   selectPlacementItemsBySource,
@@ -68,7 +67,7 @@ export function clearTokenRefCache(): void {
 
 const useTokensEnabled = createDerivedStore<boolean>(
   $ => {
-    return hasTokenRefsOrPendingHydration($) && !IS_TEST;
+    return hasTokenRefsOrPendingHydration($);
   },
   { fastMode: true }
 );

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -26,7 +26,7 @@ const CONTENT_PLACEHOLDER: CellTypes[] = [
   { type: CellType.LOADING_ASSETS, uid: 'loadings-asset-5' },
 ];
 
-const EMPTY_WALLET_CONTENT_BASE: CellTypes[] = [
+const EMPTY_WALLET_CONTENT: CellTypes[] = [
   {
     type: CellType.RECEIVE_CARD,
     uid: 'receive_card',
@@ -41,18 +41,16 @@ const EMPTY_WALLET_CONTENT_BASE: CellTypes[] = [
   { type: CellType.BIG_EMPTY_WALLET_SPACER, uid: 'big-empty-wallet-spacer-2' },
 ];
 
-const DISCOVER_MORE_BUTTON_CONTENT: CellTypes = {
-  type: CellType.DISCOVER_MORE_BUTTON,
-  uid: 'discover-home-button',
-};
+const EMPTY_WALLET_CONTENT_WITH_DISCOVER: CellTypes[] = [
+  ...EMPTY_WALLET_CONTENT,
+  {
+    type: CellType.DISCOVER_MORE_BUTTON,
+    uid: 'discover-home-button',
+  },
+];
 
 const ONLY_NFTS_CONTENT: CellTypes[] = [{ type: CellType.ETH_CARD, uid: 'eth-card' }];
 const EMPTY_ARRAY: CellTypes[] = [];
-
-const buildEmptyWalletContent = (discoverEnabled: boolean): CellTypes[] => {
-  if (!discoverEnabled) return EMPTY_WALLET_CONTENT_BASE;
-  return [...EMPTY_WALLET_CONTENT_BASE, DISCOVER_MORE_BUTTON_CONTENT];
-};
 
 export type WalletSectionsState = {
   sortedAssets: ParsedAddressAsset[];
@@ -509,7 +507,7 @@ const withBriefBalanceSection = (
   } else if (hasNFTsOnly) {
     content = ONLY_NFTS_CONTENT;
   } else if (isEmpty) {
-    content = buildEmptyWalletContent(discoverEnabled);
+    content = discoverEnabled ? EMPTY_WALLET_CONTENT_WITH_DISCOVER : EMPTY_WALLET_CONTENT;
   }
 
   const result = {

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -26,7 +26,7 @@ const CONTENT_PLACEHOLDER: CellTypes[] = [
   { type: CellType.LOADING_ASSETS, uid: 'loadings-asset-5' },
 ];
 
-const EMPTY_WALLET_CONTENT: CellTypes[] = [
+const EMPTY_WALLET_CONTENT_BASE: CellTypes[] = [
   {
     type: CellType.RECEIVE_CARD,
     uid: 'receive_card',
@@ -39,14 +39,20 @@ const EMPTY_WALLET_CONTENT: CellTypes[] = [
     uid: 'learn-card',
   },
   { type: CellType.BIG_EMPTY_WALLET_SPACER, uid: 'big-empty-wallet-spacer-2' },
-  {
-    type: CellType.DISCOVER_MORE_BUTTON,
-    uid: 'discover-home-button',
-  },
 ];
+
+const DISCOVER_MORE_BUTTON_CONTENT: CellTypes = {
+  type: CellType.DISCOVER_MORE_BUTTON,
+  uid: 'discover-home-button',
+};
 
 const ONLY_NFTS_CONTENT: CellTypes[] = [{ type: CellType.ETH_CARD, uid: 'eth-card' }];
 const EMPTY_ARRAY: CellTypes[] = [];
+
+const buildEmptyWalletContent = (discoverEnabled: boolean): CellTypes[] => {
+  if (!discoverEnabled) return EMPTY_WALLET_CONTENT_BASE;
+  return [...EMPTY_WALLET_CONTENT_BASE, DISCOVER_MORE_BUTTON_CONTENT];
+};
 
 export type WalletSectionsState = {
   sortedAssets: ParsedAddressAsset[];
@@ -67,6 +73,7 @@ export type WalletSectionsState = {
   experimentalConfig: ReturnType<typeof useExperimentalConfig>;
   showcaseTokens: string[];
   collections: Map<CollectionId, Collection> | null;
+  discoverEnabled: boolean;
   isFetchingNfts: boolean;
   positions: RainbowPositions | null;
   claimables: ClaimablesStore | null;
@@ -93,6 +100,7 @@ const sellingTokensSelector = (state: WalletSectionsState) => state.sellingToken
 const showcaseTokensSelector = (state: WalletSectionsState) => state.showcaseTokens;
 const hiddenTokensSelector = (state: WalletSectionsState) => state.hiddenTokens;
 const collectionsSelector = (state: WalletSectionsState) => state.collections;
+const discoverEnabledSelector = (state: WalletSectionsState) => state.discoverEnabled;
 const isFetchingNftsSelector = (state: WalletSectionsState) => state.isFetchingNfts;
 const positionsSelector = (state: WalletSectionsState) => state.positions;
 const claimablesSelector = (state: WalletSectionsState) => state.claimables;
@@ -413,7 +421,8 @@ const withBriefBalanceSection = (
   isCoinListEdited: boolean,
   pinnedCoins: BooleanMap,
   hiddenAssets: Set<UniqueId>,
-  collections: Map<CollectionId, Collection> | null
+  collections: Map<CollectionId, Collection> | null,
+  discoverEnabled: boolean
 ): BalanceSectionResult => {
   const { briefAssets } = buildBriefCoinsList(sortedAssets, nativeCurrency, isCoinListEdited, pinnedCoins, hiddenAssets);
 
@@ -500,7 +509,7 @@ const withBriefBalanceSection = (
   } else if (hasNFTsOnly) {
     content = ONLY_NFTS_CONTENT;
   } else if (isEmpty) {
-    content = EMPTY_WALLET_CONTENT;
+    content = buildEmptyWalletContent(discoverEnabled);
   }
 
   const result = {
@@ -540,6 +549,7 @@ const briefBalanceSectionSelector = createSelector(
     pinnedCoinsSelector,
     hiddenAssetsSelector,
     collectionsSelector,
+    discoverEnabledSelector,
   ],
   withBriefBalanceSection
 );

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -55,12 +55,13 @@ export default function useWalletSectionsData({
   const selectedWallet = useSelectedWallet();
   const { showcaseTokens } = useShowcaseTokens();
   const { hiddenTokens } = useHiddenTokens();
-  const remoteConfig = useRemoteConfig('claimables', 'perps_enabled', 'polymarket_enabled', 'rnbw_rewards_enabled');
+  const remoteConfig = useRemoteConfig('claimables', 'discover_enabled', 'perps_enabled', 'polymarket_enabled', 'rnbw_rewards_enabled');
   const experimentalConfig = useExperimentalConfig();
   const isWalletEthZero = useIsWalletEthZero();
 
   const positionsEnabled = experimentalConfig[DEFI_POSITIONS] && !IS_TEST;
   const claimablesEnabled = (remoteConfig.claimables || experimentalConfig[CLAIMABLES]) && !IS_TEST;
+  const discoverEnabled = remoteConfig.discover_enabled;
   const perpsEnabled = remoteConfig.perps_enabled && !IS_TEST;
   const polymarketEnabled = remoteConfig.polymarket_enabled && !IS_TEST;
   const rnbwRewardsEnabled = (remoteConfig.rnbw_rewards_enabled || experimentalConfig[RNBW_REWARDS]) && !IS_TEST;
@@ -145,6 +146,7 @@ export default function useWalletSectionsData({
       listType: type,
       showcaseTokens,
       collections,
+      discoverEnabled,
       isFetchingNfts,
       experimentalConfig,
       positions,
@@ -187,6 +189,7 @@ export default function useWalletSectionsData({
     type,
     showcaseTokens,
     collections,
+    discoverEnabled,
     isFetchingNfts,
     experimentalConfig,
     positions,

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -555,6 +555,11 @@
         "tokens": "Tokens"
       },
       "show_more": "Show more",
+      "placements": {
+        "perps_title": "Perps",
+        "predictions_title": "Predictions",
+        "see_all": "See all"
+      },
       "strategies": {
         "strategies_title": "Strategies",
         "yearn_finance_description": "Smart yield strategies from yearn.finance"

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -555,11 +555,6 @@
         "tokens": "Tokens"
       },
       "show_more": "Show more",
-      "placements": {
-        "perps_title": "Perps",
-        "predictions_title": "Predictions",
-        "see_all": "See all"
-      },
       "strategies": {
         "strategies_title": "Strategies",
         "yearn_finance_description": "Smart yield strategies from yearn.finance"
@@ -3426,9 +3421,10 @@
       "sports": {
         "vs": "vs",
         "live": "Live",
+        "this_week": "This week",
         "game_best_of": "Game %{currentPeriod} - Best of %{bestOf}",
         "final": "Final",
-        "no_games": "No games today or tomorrow"
+        "no_games": "No games this week"
       },
       "outcomes": {
         "yes": "Yes",

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -101,6 +101,7 @@ export interface RainbowConfig extends Record<
   sponsored_swaps_enabled: boolean;
   sponsored_perps_deposits_enabled: boolean;
   sponsored_polymarket_deposits_enabled: boolean;
+  discover_placements_enabled: boolean;
   go_relay_backend_enabled: boolean;
 }
 
@@ -237,6 +238,7 @@ export const DEFAULT_CONFIG = {
   sponsored_swaps_enabled: true,
   sponsored_perps_deposits_enabled: true,
   sponsored_polymarket_deposits_enabled: true,
+  discover_placements_enabled: true,
   go_relay_backend_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -91,6 +91,7 @@ export interface RainbowConfig extends Record<
   candlestick_charts_enabled: boolean;
   rainbow_toasts_enabled: boolean;
   king_of_the_hill2_enabled: boolean;
+  discover_enabled: boolean;
   perps_enabled: boolean;
   polymarket_enabled: boolean;
   rnbw_rewards_enabled: boolean;
@@ -100,7 +101,6 @@ export interface RainbowConfig extends Record<
   sponsored_swaps_enabled: boolean;
   sponsored_perps_deposits_enabled: boolean;
   sponsored_polymarket_deposits_enabled: boolean;
-  discover_placements_enabled: boolean;
   go_relay_backend_enabled: boolean;
 }
 
@@ -226,6 +226,7 @@ export const DEFAULT_CONFIG = {
   prince_of_the_hill_enabled: false,
   candlestick_charts_enabled: !IS_STORE_INSTALL,
   rainbow_toasts_enabled: !IS_STORE_INSTALL,
+  discover_enabled: true,
   perps_enabled: true,
   polymarket_enabled: true,
   dev_section_enabled: IS_DEV,
@@ -236,7 +237,6 @@ export const DEFAULT_CONFIG = {
   sponsored_swaps_enabled: true,
   sponsored_perps_deposits_enabled: true,
   sponsored_polymarket_deposits_enabled: true,
-  discover_placements_enabled: true,
   go_relay_backend_enabled: true,
 } as const satisfies Readonly<RainbowConfig>;
 

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -192,7 +192,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
         },
       ],
       width: withSpring(
-        showBrowserNavButtons.value ? baseWidth + (TAB_BAR_PILL_HEIGHT * 2 - TAB_BAR_PILL_WIDTH) : baseWidth,
+        showBrowserNavButtons.value ? baseWidth + (TAB_BAR_PILL_HEIGHT * 2 - tabWidth) : baseWidth,
         SPRING_CONFIGS.snappyMediumSpringConfig
       ),
     };
@@ -299,6 +299,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
               route={route}
               showBrowserNavButtons={showBrowserNavButtons}
               tabBarIcon={tabBarIcon}
+              tabWidth={tabWidth}
             />
           </Column>
         ) : (
@@ -502,7 +503,8 @@ export const BrowserTabIconWrapper = memo(function BrowserTabIconWrapper({
   route,
   showBrowserNavButtons,
   tabBarIcon,
-}: BaseTabIconProps & { showBrowserNavButtons: SharedValue<boolean> }) {
+  tabWidth,
+}: BaseTabIconProps & { showBrowserNavButtons: SharedValue<boolean>; tabWidth: number }) {
   const [showBrowserButtons, setShowBrowserButtons] = useState(false);
 
   const canGoBackOrForward = useStoreSharedValue(useBrowserStore, state => {
@@ -523,7 +525,7 @@ export const BrowserTabIconWrapper = memo(function BrowserTabIconWrapper({
 
   const browserPillWidthStyle = useAnimatedStyle(() => {
     return {
-      width: withTiming(showBrowserNavButtons.value ? TAB_BAR_PILL_HEIGHT * 2 : TAB_BAR_PILL_WIDTH, TIMING_CONFIGS.slowFadeConfig),
+      width: withTiming(showBrowserNavButtons.value ? TAB_BAR_PILL_HEIGHT * 2 : tabWidth, TIMING_CONFIGS.slowFadeConfig),
     };
   });
 

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -126,6 +126,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   const showRnbwRewardsTab = useExperimentalFlag(RNBW_REWARDS) || rnbw_rewards_enabled;
   const showRnbwMembership = useExperimentalFlag(RNBW_MEMBERSHIP) || rnbw_membership_enabled || IS_TEST;
   const showRnbwRewardsOrMembershipTab = showRnbwRewardsTab || showRnbwMembership;
+  const showKingOfTheHillTab = useShowKingOfTheHill();
 
   const numberOfTabs = 3 + (showRnbwRewardsOrMembershipTab ? 1 : 0) + (showDappBrowserTab ? 1 : 0);
   const tabWidth = (deviceWidth - TAB_BAR_HORIZONTAL_INSET * 2 - TAB_BAR_INNER_PADDING * 2) / numberOfTabs;
@@ -134,6 +135,16 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   const reanimatedPosition = useSharedValue(0);
   const showBrowserNavButtons = useSharedValue(false);
 
+  const tabRoutes = useDerivedValue<Route[]>(() => {
+    const routes: Route[] = [Routes.WALLET_SCREEN, Routes.DISCOVER_SCREEN];
+    if (showDappBrowserTab) routes.push(Routes.DAPP_BROWSER_SCREEN);
+    routes.push(showKingOfTheHillTab ? Routes.KING_OF_THE_HILL : Routes.PROFILE_SCREEN);
+    if (showRnbwRewardsOrMembershipTab) {
+      routes.push(showRnbwMembership ? Routes.RNBW_MEMBERSHIP_SCREEN : Routes.RNBW_REWARDS_SCREEN);
+    }
+    return routes;
+  }, [showDappBrowserTab, showKingOfTheHillTab, showRnbwMembership, showRnbwRewardsOrMembershipTab]);
+
   const tabPositions = useDerivedValue(() => {
     const inputRange = Array.from({ length: numberOfTabs }, (_, index) => index);
     const outputRange = Array.from({ length: numberOfTabs }, (_, index) => tabPillStartPosition + tabWidth * index);
@@ -141,7 +152,8 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   });
 
   const backgroundPillStyle = useAnimatedStyle(() => {
-    const isDappBrowserTab = showDappBrowserTab && reanimatedPosition.value === 2 && showBrowserNavButtons.value;
+    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const isDappBrowserTab = route === Routes.DAPP_BROWSER_SCREEN && showBrowserNavButtons.value;
     const backgroundOpacity = isDappBrowserTab ? 0 : 1;
     const translateX = interpolate(reanimatedPosition.value, tabPositions.value.inputRange, tabPositions.value.outputRange, 'clamp');
 
@@ -152,7 +164,8 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   });
 
   const dappBrowserTabBarStyle = useAnimatedStyle(() => {
-    const shouldUseBrowserStyle = showDappBrowserTab && reanimatedPosition.value === 2;
+    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const shouldUseBrowserStyle = route === Routes.DAPP_BROWSER_SCREEN;
     return {
       opacity: withTiming(shouldUseBrowserStyle ? 1 : 0, TIMING_CONFIGS.slowFadeConfig),
     };
@@ -312,21 +325,22 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   );
 
   const shadowStyle = useAnimatedStyle(() => {
-    const isDappBrowserTab = showDappBrowserTab && reanimatedPosition.value === 2;
+    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const isDappBrowserTab = route === Routes.DAPP_BROWSER_SCREEN;
     return {
       shadowOpacity: withSpring(isDarkMode ? 0.6 : isDappBrowserTab ? 0 : 0.16, SPRING_CONFIGS.snappyMediumSpringConfig),
     };
   });
 
   const gradientBackgroundStyle = useAnimatedStyle(() => {
-    const route = getRouteFromTabIndex(reanimatedPosition.value, showRnbwMembership);
+    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
     return {
       backgroundColor: route === Routes.DAPP_BROWSER_SCREEN ? 'transparent' : getTabBackgroundColor(route, isDarkMode),
     };
   });
 
   const gradientVisibilityStyle = useAnimatedStyle(() => {
-    const route = getRouteFromTabIndex(reanimatedPosition.value, showRnbwMembership);
+    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
     return {
       opacity: withTiming(route === Routes.RNBW_REWARDS_SCREEN ? 0 : 1, TIMING_CONFIGS.slowFadeConfig),
     };
@@ -493,7 +507,7 @@ export const BrowserTabIconWrapper = memo(function BrowserTabIconWrapper({
   });
 
   useAnimatedReaction(
-    () => activeIndex.value === 2 && canGoBackOrForward.value,
+    () => activeIndex.value === index && canGoBackOrForward.value,
     (current, previous) => {
       if (current !== previous) {
         showBrowserNavButtons.value = current;
@@ -546,24 +560,6 @@ export const BrowserTabIconWrapper = memo(function BrowserTabIconWrapper({
     </Box>
   );
 });
-
-function getRouteFromTabIndex(index: number, isMembership: boolean): RouteProp<ParamListBase, string>['name'] {
-  'worklet';
-  switch (index) {
-    case 0:
-      return Routes.WALLET_SCREEN;
-    case 1:
-      return Routes.DISCOVER_SCREEN;
-    case 2:
-      return Routes.DAPP_BROWSER_SCREEN;
-    case 3:
-      return Routes.PROFILE_SCREEN;
-    case 4:
-      return isMembership ? Routes.RNBW_MEMBERSHIP_SCREEN : Routes.RNBW_REWARDS_SCREEN;
-    default:
-      return Routes.WALLET_SCREEN;
-  }
-}
 
 function getTabBackgroundColor(route: RouteProp<ParamListBase, string>['name'], isDarkMode: boolean): string {
   'worklet';

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -155,7 +155,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   });
 
   const backgroundPillStyle = useAnimatedStyle(() => {
-    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const route = tabRoutes.value[reanimatedPosition.value] ?? Routes.WALLET_SCREEN;
     const isDappBrowserTab = route === Routes.DAPP_BROWSER_SCREEN && showBrowserNavButtons.value;
     const backgroundOpacity = isDappBrowserTab ? 0 : 1;
     const translateX = interpolate(reanimatedPosition.value, tabPositions.value.inputRange, tabPositions.value.outputRange, 'clamp');
@@ -167,7 +167,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   });
 
   const dappBrowserTabBarStyle = useAnimatedStyle(() => {
-    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const route = tabRoutes.value[reanimatedPosition.value] ?? Routes.WALLET_SCREEN;
     const shouldUseBrowserStyle = route === Routes.DAPP_BROWSER_SCREEN;
     return {
       opacity: withTiming(shouldUseBrowserStyle ? 1 : 0, TIMING_CONFIGS.slowFadeConfig),
@@ -330,7 +330,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   );
 
   const shadowStyle = useAnimatedStyle(() => {
-    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const route = tabRoutes.value[reanimatedPosition.value] ?? Routes.WALLET_SCREEN;
     const isDappBrowserTab = route === Routes.DAPP_BROWSER_SCREEN;
     return {
       shadowOpacity: withSpring(isDarkMode ? 0.6 : isDappBrowserTab ? 0 : 0.16, SPRING_CONFIGS.snappyMediumSpringConfig),
@@ -338,14 +338,14 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   });
 
   const gradientBackgroundStyle = useAnimatedStyle(() => {
-    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const route = tabRoutes.value[reanimatedPosition.value] ?? Routes.WALLET_SCREEN;
     return {
       backgroundColor: route === Routes.DAPP_BROWSER_SCREEN ? 'transparent' : getTabBackgroundColor(route, isDarkMode),
     };
   });
 
   const gradientVisibilityStyle = useAnimatedStyle(() => {
-    const route = tabRoutes.value[Math.round(reanimatedPosition.value)] ?? Routes.WALLET_SCREEN;
+    const route = tabRoutes.value[reanimatedPosition.value] ?? Routes.WALLET_SCREEN;
     return {
       opacity: withTiming(route === Routes.RNBW_REWARDS_SCREEN ? 0 : 1, TIMING_CONFIGS.slowFadeConfig),
     };

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -378,7 +378,6 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
           borderRadius={TAB_BAR_BORDER_RADIUS}
           bottom={{ custom: TAB_BAR_HEIGHT - BASE_TAB_BAR_HEIGHT }}
           height={{ custom: BASE_TAB_BAR_HEIGHT }}
-          pointerEvents="box-none"
           position="absolute"
           style={[hideForBrowserTabViewStyle, { alignSelf: 'center' }]}
         >

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -117,18 +117,20 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   const recyclerList = useRecyclerListViewScrollToTopContext();
   const mainList = useMainList();
 
-  const { dapp_browser, rnbw_rewards_enabled, rnbw_membership_enabled } = useRemoteConfig(
+  const { dapp_browser, discover_enabled, rnbw_rewards_enabled, rnbw_membership_enabled } = useRemoteConfig(
     'dapp_browser',
+    'discover_enabled',
     'rnbw_rewards_enabled',
     'rnbw_membership_enabled'
   );
+  const showDiscoverTab = discover_enabled;
   const showDappBrowserTab = useExperimentalFlag(DAPP_BROWSER) || dapp_browser;
   const showRnbwRewardsTab = useExperimentalFlag(RNBW_REWARDS) || rnbw_rewards_enabled;
   const showRnbwMembership = useExperimentalFlag(RNBW_MEMBERSHIP) || rnbw_membership_enabled || IS_TEST;
   const showRnbwRewardsOrMembershipTab = showRnbwRewardsTab || showRnbwMembership;
   const showKingOfTheHillTab = useShowKingOfTheHill();
 
-  const numberOfTabs = 3 + (showRnbwRewardsOrMembershipTab ? 1 : 0) + (showDappBrowserTab ? 1 : 0);
+  const numberOfTabs = 2 + (showDiscoverTab ? 1 : 0) + (showRnbwRewardsOrMembershipTab ? 1 : 0) + (showDappBrowserTab ? 1 : 0);
   const tabWidth = (deviceWidth - TAB_BAR_HORIZONTAL_INSET * 2 - TAB_BAR_INNER_PADDING * 2) / numberOfTabs;
   const tabPillStartPosition = (tabWidth - TAB_BAR_PILL_WIDTH) / 2 + TAB_BAR_INNER_PADDING;
 
@@ -136,14 +138,15 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
   const showBrowserNavButtons = useSharedValue(false);
 
   const tabRoutes = useDerivedValue<Route[]>(() => {
-    const routes: Route[] = [Routes.WALLET_SCREEN, Routes.DISCOVER_SCREEN];
+    const routes: Route[] = [Routes.WALLET_SCREEN];
+    if (showDiscoverTab) routes.push(Routes.DISCOVER_SCREEN);
     if (showDappBrowserTab) routes.push(Routes.DAPP_BROWSER_SCREEN);
     routes.push(showKingOfTheHillTab ? Routes.KING_OF_THE_HILL : Routes.PROFILE_SCREEN);
     if (showRnbwRewardsOrMembershipTab) {
       routes.push(showRnbwMembership ? Routes.RNBW_MEMBERSHIP_SCREEN : Routes.RNBW_REWARDS_SCREEN);
     }
     return routes;
-  }, [showDappBrowserTab, showKingOfTheHillTab, showRnbwMembership, showRnbwRewardsOrMembershipTab]);
+  }, [showDappBrowserTab, showDiscoverTab, showKingOfTheHillTab, showRnbwMembership, showRnbwRewardsOrMembershipTab]);
 
   const tabPositions = useDerivedValue(() => {
     const inputRange = Array.from({ length: numberOfTabs }, (_, index) => index);
@@ -273,6 +276,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
       stateRef.current.routes.map((route: RouteProp<ParamListBase, string>, index: number) => {
         if (
           (!showDappBrowserTab && route.name === Routes.DAPP_BROWSER_SCREEN) ||
+          (!showDiscoverTab && route.name === Routes.DISCOVER_SCREEN) ||
           (!showRnbwRewardsTab && route.name === Routes.RNBW_REWARDS_SCREEN) ||
           (!showRnbwMembership && route.name === Routes.RNBW_MEMBERSHIP_SCREEN)
         ) {
@@ -318,6 +322,7 @@ const TabBar = memo(function TabBar({ activeIndex, descriptorsRef, getIsFocused,
       reanimatedPosition,
       showBrowserNavButtons,
       showDappBrowserTab,
+      showDiscoverTab,
       showRnbwMembership,
       showRnbwRewardsTab,
       stateRef,
@@ -632,11 +637,13 @@ function SwipeNavigatorScreens() {
   const enableLazyTabs = useExperimentalFlag(LAZY_TABS);
   const lazy = useNavigationStore(state => enableLazyTabs || !state.isWalletScreenMounted);
 
-  const { dapp_browser, rnbw_rewards_enabled, rnbw_membership_enabled } = useRemoteConfig(
+  const { dapp_browser, discover_enabled, rnbw_rewards_enabled, rnbw_membership_enabled } = useRemoteConfig(
     'dapp_browser',
+    'discover_enabled',
     'rnbw_rewards_enabled',
     'rnbw_membership_enabled'
   );
+  const showDiscoverTab = discover_enabled;
   const showDappBrowserTab = useExperimentalFlag(DAPP_BROWSER) || dapp_browser;
   const showKingOfTheHillTab = useShowKingOfTheHill();
   const showRnbwRewardsTab = useExperimentalFlag(RNBW_REWARDS) || rnbw_rewards_enabled || IS_TEST;
@@ -663,6 +670,9 @@ function SwipeNavigatorScreens() {
     if (showKingOfTheHillTab) {
       key += '-koth';
     }
+    if (showDiscoverTab) {
+      key += '-discover';
+    }
     if (showRnbwRewardsTab) {
       key += '-rnbw-rewards';
     }
@@ -673,7 +683,7 @@ function SwipeNavigatorScreens() {
       key += `-${language}`;
     }
     return key;
-  }, [showKingOfTheHillTab, showRnbwRewardsTab, showRnbwMembership, language]);
+  }, [showKingOfTheHillTab, showDiscoverTab, showRnbwRewardsTab, showRnbwMembership, language]);
 
   return (
     <Swipe.Navigator
@@ -686,7 +696,9 @@ function SwipeNavigatorScreens() {
       tabBarPosition="bottom"
     >
       <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.WALLET_SCREEN] }} />
-      <Swipe.Screen component={DiscoverScreen} name={Routes.DISCOVER_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.DISCOVER_SCREEN] }} />
+      {showDiscoverTab && (
+        <Swipe.Screen component={DiscoverScreen} name={Routes.DISCOVER_SCREEN} options={{ title: TAB_BAR_ICONS[Routes.DISCOVER_SCREEN] }} />
+      )}
       {showDappBrowserTab && (
         <Swipe.Screen component={DappBrowser} name={Routes.DAPP_BROWSER_SCREEN} options={{ title: 'tabDappBrowser' }} />
       )}

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useCallback, useEffect, useState } from 'react';
-import { Keyboard, RefreshControl } from 'react-native';
+import React, { memo, useEffect } from 'react';
+import { Keyboard } from 'react-native';
 
 import { useIsFocused } from '@react-navigation/native';
 import { useSharedValue } from 'react-native-reanimated';
@@ -10,10 +10,9 @@ import { DiscoverScreenContent } from '@/components/Discover/DiscoverScreenConte
 import { DiscoverScreenProvider } from '@/components/Discover/DiscoverScreenContext';
 import { DiscoverSearchBar } from '@/components/Discover/DiscoverSearchBar';
 import { ScrollHeaderFade } from '@/components/scroll-header-fade/ScrollHeaderFade';
-import { Box, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
+import { Box, useBackgroundColor, useColorMode } from '@/design-system';
 import { type BackgroundColor } from '@/design-system/color/palettes';
 import { DISCOVER_HEADER_HEIGHT, DiscoverHeader } from '@/features/discover/components/DiscoverHeader';
-import { refreshDiscoverSurface } from '@/features/discover/utils/refreshDiscoverSurface';
 import { useSyncDiscoverSurfacePlacements } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
 
 export const DiscoverScreen = () => {
@@ -31,32 +30,16 @@ const Content = () => {
 
   const backgroundToken: BackgroundColor = isDarkMode ? 'black' : 'surfacePrimary';
   const backgroundColor = useBackgroundColor(backgroundToken);
-  const refreshTintColor = useForegroundColor('label');
   const headerFadeTopInset = topInset + DISCOVER_HEADER_HEIGHT;
   const scrollOffset = useSharedValue(0);
-  const [isRefreshing, setIsRefreshing] = useState(false);
   useSyncDiscoverSurfacePlacements();
-
-  const refreshDiscover = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      await refreshDiscoverSurface('discover');
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, []);
-
-  const renderRefreshControl = useCallback(
-    () => <RefreshControl onRefresh={refreshDiscover} refreshing={isRefreshing} tintColor={refreshTintColor} />,
-    [isRefreshing, refreshDiscover, refreshTintColor]
-  );
 
   return (
     <Box background={backgroundToken} height="full" style={{ flex: 1 }}>
       <Box paddingTop={{ custom: topInset }}>{isSearching ? <DiscoverSearchBar /> : <DiscoverHeader />}</Box>
 
       <Box style={{ flex: 1 }} testID="discover-sheet">
-        <DiscoverScreenContent renderRefreshControl={renderRefreshControl} scrollOffset={scrollOffset} />
+        <DiscoverScreenContent scrollOffset={scrollOffset} />
       </Box>
 
       {!isSearching ? <ScrollHeaderFade color={backgroundColor} scrollOffset={scrollOffset} topInset={headerFadeTopInset} /> : null}

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -18,6 +18,7 @@ import { useSyncDiscoverSurfacePlacements } from '@/features/placements/surfaces
 export const DiscoverScreen = () => {
   return (
     <DiscoverScreenProvider>
+      <DiscoverSurfacePlacementSync />
       <Content />
     </DiscoverScreenProvider>
   );
@@ -32,7 +33,6 @@ const Content = () => {
   const backgroundColor = useBackgroundColor(backgroundToken);
   const headerFadeTopInset = topInset + DISCOVER_HEADER_HEIGHT;
   const scrollOffset = useSharedValue(0);
-  useSyncDiscoverSurfacePlacements();
 
   return (
     <Box background={backgroundToken} height="full" style={{ flex: 1 }}>
@@ -48,6 +48,11 @@ const Content = () => {
     </Box>
   );
 };
+
+const DiscoverSurfacePlacementSync = memo(function DiscoverSurfacePlacementSync() {
+  useSyncDiscoverSurfacePlacements();
+  return null;
+});
 
 const KeyboardDismissHandler = memo(function KeyboardDismissHandler() {
   const isFocused = useIsFocused();

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,29 +1,20 @@
-import React, { memo, useEffect } from 'react';
-import { Keyboard, Platform } from 'react-native';
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import { Keyboard, RefreshControl } from 'react-native';
 
 import { useIsFocused } from '@react-navigation/native';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useDiscoverSearchQueryStore } from '@/__swaps__/screens/Swap/resources/search/searchV2';
-import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
-import { ContactAvatar } from '@/components/contacts';
-import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { DiscoverScreenContent } from '@/components/Discover/DiscoverScreenContent';
-import { DiscoverScreenProvider, useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
+import { DiscoverScreenProvider } from '@/components/Discover/DiscoverScreenContext';
 import { DiscoverSearchBar } from '@/components/Discover/DiscoverSearchBar';
-import { Navbar, navbarHeight } from '@/components/navbar/Navbar';
 import { ScrollHeaderFade } from '@/components/scroll-header-fade/ScrollHeaderFade';
-import { useScrollFadeHandler } from '@/components/scroll-header-fade/useScrollFadeHandler';
-import { Box, globalColors, TextIcon, useColorMode } from '@/design-system';
-import * as i18n from '@/languages';
-import Navigation from '@/navigation/Navigation';
-import Routes from '@/navigation/routesNames';
-import { useAccountProfileInfo } from '@/state/wallets/walletsStore';
-import { THICK_BORDER_WIDTH } from '@/styles/constants';
-import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
-
-import { PullToRefresh } from './Airdrops/AirdropsSheet';
+import { Box, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
+import { type BackgroundColor } from '@/design-system/color/palettes';
+import { DISCOVER_HEADER_HEIGHT, DiscoverHeader } from '@/features/discover/components/DiscoverHeader';
+import { refreshDiscoverSurface } from '@/features/discover/utils/refreshDiscoverSurface';
+import { useSyncDiscoverSurfacePlacements } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
 
 export const DiscoverScreen = () => {
   return (
@@ -36,68 +27,36 @@ export const DiscoverScreen = () => {
 const Content = () => {
   const { isDarkMode } = useColorMode();
   const { top: topInset } = useSafeAreaInsets();
-  const { accountSymbol, accountColor, accountImage } = useAccountProfileInfo();
-  const { scrollViewRef, onTapSearch } = useDiscoverScreenContext();
   const isSearching = useDiscoverSearchQueryStore(state => state.isSearching);
 
-  const backgroundColor = isDarkMode ? globalColors.grey100 : '#FBFCFD';
-  const headerFadeTopInset = topInset + navbarHeight;
+  const backgroundToken: BackgroundColor = isDarkMode ? 'black' : 'surfacePrimary';
+  const backgroundColor = useBackgroundColor(backgroundToken);
+  const refreshTintColor = useForegroundColor('label');
+  const headerFadeTopInset = topInset + DISCOVER_HEADER_HEIGHT;
   const scrollOffset = useSharedValue(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  useSyncDiscoverSurfacePlacements();
 
-  const onScroll = useScrollFadeHandler(scrollOffset);
+  const refreshDiscover = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await refreshDiscoverSurface('discover');
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  const renderRefreshControl = useCallback(
+    () => <RefreshControl onRefresh={refreshDiscover} refreshing={isRefreshing} tintColor={refreshTintColor} />,
+    [isRefreshing, refreshDiscover, refreshTintColor]
+  );
 
   return (
-    <Box height="full" style={{ flex: 1, backgroundColor }}>
-      <Box paddingTop={{ custom: topInset }}>
-        {isSearching ? (
-          <DiscoverSearchBar />
-        ) : (
-          <Navbar
-            leftComponent={
-              <ButtonPressAnimation onPress={onChangeWallet} scaleTo={0.8} overflowMargin={50}>
-                {accountImage ? (
-                  <ImageAvatar image={accountImage} marginRight={10} size="header" />
-                ) : (
-                  <ContactAvatar color={accountColor} marginRight={10} size="small" value={accountSymbol} />
-                )}
-              </ButtonPressAnimation>
-            }
-            rightComponent={
-              <ButtonPressAnimation onPress={onTapSearch} scaleTo={0.8} overflowMargin={50} testID="discover-search-icon">
-                <Box
-                  background="fillSecondary"
-                  width={36}
-                  height={36}
-                  borderRadius={18}
-                  alignItems="center"
-                  justifyContent="center"
-                  borderWidth={THICK_BORDER_WIDTH}
-                  borderColor="buttonStroke"
-                >
-                  <TextIcon size="icon 16px" color="label" weight="heavy" containerSize={36}>
-                    {'􀊫'}
-                  </TextIcon>
-                </Box>
-              </ButtonPressAnimation>
-            }
-            testID="discover-header"
-            title={i18n.t(i18n.l.discover.search.discover)}
-          />
-        )}
-      </Box>
+    <Box background={backgroundToken} height="full" style={{ flex: 1 }}>
+      <Box paddingTop={{ custom: topInset }}>{isSearching ? <DiscoverSearchBar /> : <DiscoverHeader />}</Box>
 
-      <Box
-        as={Animated.ScrollView}
-        automaticallyAdjustsScrollIndicatorInsets={false}
-        onScroll={onScroll}
-        ref={scrollViewRef}
-        refreshControl={Platform.OS === 'ios' ? <PullToRefresh /> : undefined}
-        removeClippedSubviews
-        scrollEnabled={!isSearching}
-        scrollIndicatorInsets={{ bottom: safeAreaInsetValues.bottom + 167, top: 16 }}
-        testID="discover-sheet"
-      >
-        <DiscoverScreenContent />
+      <Box style={{ flex: 1 }} testID="discover-sheet">
+        <DiscoverScreenContent renderRefreshControl={renderRefreshControl} scrollOffset={scrollOffset} />
       </Box>
 
       {!isSearching ? <ScrollHeaderFade color={backgroundColor} scrollOffset={scrollOffset} topInset={headerFadeTopInset} /> : null}
@@ -118,7 +77,3 @@ const KeyboardDismissHandler = memo(function KeyboardDismissHandler() {
 
   return null;
 });
-
-function onChangeWallet(): void {
-  Navigation.handleAction(Routes.CHANGE_WALLET_SHEET);
-}


### PR DESCRIPTION
Discover v2 was built but never mounted; this makes it the live Discover screen behind a remote flag, leaving the legacy home dormant for the cleanup PRs on top.

## What changed

- The Discover tab is registered behind `discover_enabled` (replacing `discover_placements_enabled`), with visible tab routes derived from active-route predicates.
- The v2 surface runtime is mounted as the Discover screen in place of the legacy home, and the empty-wallet entry point is gated.
- Pull-to-refresh moves into its own component so refresh state no longer re-renders the screen, and search results are sized below the v2 header.
- IS_TEST gating on Discover sources is dropped; the Discover e2e flow targets the v2 tab nav.

## What to test

- With `discover_enabled` on, the Discover tab shows the v2 surface; with it off, the tab is absent.
- Pull to refresh, run a search, and switch tabs — no clipping under the header.
- An empty wallet routes to the gated entry point.
