### PR TITLE
feat(ramp): add Cash Deposits intro panel entry point (APP-3775)

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -1,0 +1,27 @@
+appId: ${APP_ID}
+tags:
+  - cash
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- runFlow: ../../utils/ImportWalletWithKey.yaml
+- runFlow:
+    file: ../../utils/SetExperimentalFlag.yaml
+    env:
+      FLAG: Cash
+      VALUE: 'true'
+- tapOn:
+    id: buy-button
+- assertVisible:
+    text: 'Cash Deposits'
+- assertVisible:
+    id: cash-deposit-intro-set-up-account
+- assertVisible:
+    id: cash-deposit-intro-other-deposit-methods
+- assertVisible:
+    id: cash-deposit-intro-sign-in

--- a/e2e/utils/SetExperimentalFlag.yaml
+++ b/e2e/utils/SetExperimentalFlag.yaml
@@ -1,0 +1,9 @@
+appId: ${APP_ID}
+---
+- openLink: rainbow://e2e/setExperimentalFlag?flag=${FLAG}&value=${VALUE}
+- runFlow:
+    when:
+      visible: 'Open in .*'
+      platform: iOS
+    commands:
+      - tapOn: 'Open'

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -119,6 +119,7 @@ export const event = {
   pairHwWalletNavEntered: 'pair_hw_wallet_nav.entered',
   pairHwWalletNavExited: 'pair_hw_wallet_nav.exited',
   rewardsViewedSheet: 'rewards.viewed_sheet',
+  cashDepositIntroViewed: 'cash_deposit_intro_viewed',
   rewardsPressedPendingEarningsCard: 'rewards.pressed_pending_earnings_card',
   rewardsPressedAvailableCard: 'rewards.pressed_available_card',
   rewardsPressedPositionCard: 'rewards.pressed_position_card',
@@ -523,6 +524,7 @@ export type EventProperties = {
     step: string;
   };
   [event.rewardsViewedSheet]: undefined;
+  [event.cashDepositIntroViewed]: undefined;
   [event.rewardsPressedPendingEarningsCard]: undefined;
   [event.rewardsPressedAvailableCard]: undefined;
   [event.rewardsPressedPositionCard]: { position: number };

--- a/src/components/TestDeeplinkHandler.tsx
+++ b/src/components/TestDeeplinkHandler.tsx
@@ -3,6 +3,8 @@ import { Linking } from 'react-native';
 
 import URL from 'url-parse';
 
+import { type ExperimentalConfigKey } from '@/config/experimental';
+import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
 import { savePIN } from '@/features/local-auth/pinAuthentication';
 import { logger } from '@/logger';
 import Navigation from '@/navigation/Navigation';
@@ -33,6 +35,9 @@ export function TestDeeplinkHandler() {
           Navigation.replace(Routes.SWIPE_LAYOUT, {
             screen: Routes.WALLET_SCREEN,
           });
+          break;
+        case 'setExperimentalFlag':
+          useExperimentalConfigStore.getState().setFlag(query.flag as ExperimentalConfigKey, query.value === 'true');
           break;
         default:
           logger.debug(`[TestDeeplinkHandler]: unknown path`, { url });

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -9,6 +9,8 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { CopyFloatingEmojis } from '@/components/floating-emojis';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { AccentColorProvider, Box, Column, Columns, Inset, Stack, Text, useColorMode } from '@/design-system';
+import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
+import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
 import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import * as i18n from '@/languages';
@@ -128,6 +130,7 @@ function ActionButton({ children, icon, onPress, testID }: { children: string; i
 }
 
 function BuyButton() {
+  const isCashEnabled = useIsCashEnabled();
   const handlePress = React.useCallback(() => {
     if (getIsDamagedWallet()) {
       Navigation.handleAction(Routes.WALLET_ERROR_SHEET);
@@ -136,13 +139,13 @@ function BuyButton() {
 
     analytics.track(analytics.event.navigationAddCash, { category: 'home screen' });
 
-    Navigation.handleAction(Routes.ADD_CASH_SHEET);
-  }, []);
+    Navigation.handleAction(getAddCashRoute(isCashEnabled));
+  }, [isCashEnabled]);
 
   return (
     <Box>
       <ActionButton icon="􀁌" onPress={handlePress} testID="buy-button">
-        {i18n.t(i18n.l.wallet.buy)}
+        {isCashEnabled ? i18n.t(i18n.l.cash.add_cash) : i18n.t(i18n.l.wallet.buy)}
       </ActionButton>
     </Box>
   );

--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -7,6 +7,8 @@ import { analytics } from '@/analytics';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
 import { ExtremeLabels } from '@/components/value-chart/ExtremeLabels';
 import { AccentColorProvider, Bleed, Box, Inline, Stack, Text } from '@/design-system';
+import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
+import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useChartThrottledPoints from '@/hooks/charts/useChartThrottledPoints';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
@@ -54,6 +56,7 @@ export const EthCard = () => {
 
   const { loaded: accentColorLoaded } = useAccountAccentColor();
   const { name: routeName } = useRoute();
+  const isCashEnabled = useIsCashEnabled();
   const cardType = 'stretch';
 
   const handlePressBuy = useCallback(
@@ -67,14 +70,14 @@ export const EthCard = () => {
         return;
       }
 
-      navigate(Routes.ADD_CASH_SHEET);
+      navigate(getAddCashRoute(isCashEnabled));
 
       analytics.track(analytics.event.buyButtonPressed, {
         componentName: 'EthCard',
         routeName,
       });
     },
-    [navigate, routeName]
+    [isCashEnabled, navigate, routeName]
   );
 
   const handleAssetPress = useCallback(() => {
@@ -262,7 +265,7 @@ export const EthCard = () => {
             <AccentColorProvider color={opacity(colorForAsset, 0.1)}>
               <Box width="full" height={{ custom: 36 }} borderRadius={99} alignItems="center" justifyContent="center" background="accent">
                 <Text color={{ custom: colorForAsset }} containsEmoji size="15pt" weight="bold">
-                  {`􀍯 ${i18n.t(i18n.l.button.buy_eth)}`}
+                  {`􀍯 ${isCashEnabled ? i18n.t(i18n.l.cash.add_cash) : i18n.t(i18n.l.button.buy_eth)}`}
                 </Text>
               </Box>
             </AccentColorProvider>

--- a/src/components/sheet/sheet-action-buttons/BuyActionButton.tsx
+++ b/src/components/sheet/sheet-action-buttons/BuyActionButton.tsx
@@ -4,6 +4,8 @@ import { useRoute } from '@react-navigation/native';
 
 import { analytics } from '@/analytics';
 import { Text } from '@/design-system';
+import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
+import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
 import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
@@ -18,6 +20,7 @@ function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) 
   const color = givenColor || colors.paleBlue;
   const navigate = useNavigationForNonReadOnlyWallets();
   const { name: routeName } = useRoute();
+  const isCashEnabled = useIsCashEnabled();
 
   const handlePress = useCallback(() => {
     if (getIsDamagedWallet()) {
@@ -25,13 +28,13 @@ function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) 
       return;
     }
 
-    navigate(Routes.ADD_CASH_SHEET);
+    navigate(getAddCashRoute(isCashEnabled));
 
     analytics.track(analytics.event.buyButtonPressed, {
       componentName: 'BuyActionButton',
       routeName,
     });
-  }, [navigate, routeName]);
+  }, [isCashEnabled, navigate, routeName]);
 
   return (
     <SheetActionButton
@@ -42,7 +45,7 @@ function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) 
       onPress={handlePress}
     >
       <Text align="center" color="label" size="20pt" weight="heavy">
-        {`􀍰 ${i18n.t(i18n.l.button.buy_eth)}`}
+        {`􀍰 ${isCashEnabled ? i18n.t(i18n.l.cash.add_cash) : i18n.t(i18n.l.button.buy_eth)}`}
       </Text>
     </SheetActionButton>
   );

--- a/src/config/experimental.ts
+++ b/src/config/experimental.ts
@@ -31,6 +31,7 @@ export const KING_OF_THE_HILL_TAB = 'King of the Hill Tab';
 export const RAINBOW_TOASTS = 'Rainbow Toasts';
 export const PERPS = 'Perps';
 export const POLYMARKET = 'Polymarket';
+export const CASH = 'Cash';
 export const DEFI_POSITIONS_THRESHOLD_FILTER = 'DeFi Minimum Value Filter';
 export const RNBW_REWARDS = 'RNBW Rewards';
 export const RNBW_MEMBERSHIP = 'RNBW Membership';
@@ -72,6 +73,7 @@ const config = {
   [PERPS]: { settings: true, value: false },
   [DEFI_POSITIONS_THRESHOLD_FILTER]: { settings: true, value: true },
   [POLYMARKET]: { settings: true, value: false },
+  [CASH]: { settings: true, value: false },
   [RNBW_REWARDS]: { settings: true, value: false },
   [RNBW_MEMBERSHIP]: { settings: true, value: false },
   [DELEGATION]: { settings: true, value: false },

--- a/src/config/experimentalConfigStore.ts
+++ b/src/config/experimentalConfigStore.ts
@@ -6,6 +6,7 @@ import { createRainbowStore } from '@/state/internal/createRainbowStore';
 export type ExperimentalConfigState = {
   config: Record<ExperimentalConfigKey, boolean>;
   getFlag: (key: ExperimentalConfigKey) => boolean;
+  setFlag: (key: ExperimentalConfigKey, value: boolean) => void;
   toggleFlag: (key: ExperimentalConfigKey) => void;
 };
 
@@ -18,8 +19,12 @@ export const useExperimentalConfigStore = createRainbowStore<ExperimentalConfigS
       return get().config[key] ?? defaultConfig[key].value;
     },
 
+    setFlag: (key, value) => {
+      set(state => ({ config: { ...state.config, [key]: value } }));
+    },
+
     toggleFlag: key => {
-      set(state => ({ config: { ...state.config, [key]: !(state.config[key] ?? defaultConfig[key].value) } }));
+      get().setFlag(key, !(get().config[key] ?? defaultConfig[key].value));
     },
   }),
 

--- a/src/features/cash/components/CashDepositIntroFeatureRow.tsx
+++ b/src/features/cash/components/CashDepositIntroFeatureRow.tsx
@@ -1,0 +1,27 @@
+import React, { memo, type ReactNode } from 'react';
+
+import { Box, Text } from '@/design-system';
+
+type CashDepositIntroFeatureRowProps = {
+  icon: ReactNode;
+  text: string;
+};
+
+/**
+ * A non-tappable "feature bullet" row in the Cash Deposit intro panel: a fixed-width
+ * leading icon slot followed by wrapping copy
+ */
+export const CashDepositIntroFeatureRow = memo(function CashDepositIntroFeatureRow({ icon, text }: CashDepositIntroFeatureRowProps) {
+  return (
+    <Box alignItems="center" flexDirection="row" gap={16}>
+      <Box alignItems="center" justifyContent="center" width={{ custom: 40 }}>
+        {icon}
+      </Box>
+      <Box flexShrink={1}>
+        <Text color="label" size="17pt / 135%" weight="semibold">
+          {text}
+        </Text>
+      </Box>
+    </Box>
+  );
+});

--- a/src/features/cash/hooks/useIsCashEnabled.ts
+++ b/src/features/cash/hooks/useIsCashEnabled.ts
@@ -1,0 +1,13 @@
+import { CASH } from '@/config/experimental';
+import useExperimentalFlag from '@/config/experimentalHooks';
+import { useRemoteConfig } from '@/model/remoteConfig';
+
+/**
+ * Cash is gated by the remote `cash_enabled` flag in production. The `CASH`
+ * experimental flag is an in-app override so it can be toggled from Developer Settings.
+ */
+export function useIsCashEnabled(): boolean {
+  const { cash_enabled } = useRemoteConfig('cash_enabled');
+  const cashExperimentalEnabled = useExperimentalFlag(CASH);
+  return cashExperimentalEnabled || cash_enabled;
+}

--- a/src/features/cash/navigation/getAddCashRoute.ts
+++ b/src/features/cash/navigation/getAddCashRoute.ts
@@ -1,0 +1,7 @@
+import Routes from '@/navigation/routesNames';
+
+type AddCashRoute = typeof Routes.CASH_DEPOSIT_INTRO_PANEL | typeof Routes.ADD_CASH_SHEET;
+
+export function getAddCashRoute(isCashEnabled: boolean): AddCashRoute {
+  return isCashEnabled ? Routes.CASH_DEPOSIT_INTRO_PANEL : Routes.ADD_CASH_SHEET;
+}

--- a/src/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel.tsx
+++ b/src/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel.tsx
@@ -1,0 +1,194 @@
+import React, { memo, useCallback } from 'react';
+import { Text as NativeText, Platform, StyleSheet } from 'react-native';
+
+import { useFocusEffect } from '@react-navigation/native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { analytics } from '@/analytics';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Stack, Text, TextShadow, useColorMode, useForegroundColor } from '@/design-system';
+import { opacity } from '@/framework/ui/utils/opacity';
+import * as i18n from '@/languages';
+import { useNavigation } from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { fontWithWidth } from '@/styles/buildTextStyles';
+
+import { CashDepositIntroFeatureRow } from '../../components/CashDepositIntroFeatureRow';
+
+const HERO_DOLLAR_COLOR = '#0086FF';
+
+function VisaBadge({ color }: { color: string }) {
+  return (
+    <Box alignItems="center" justifyContent="center" paddingLeft="2px" style={[styles.visaBadge, { borderColor: color }]}>
+      <Text color="blue" size="11pt" weight="heavy">
+        {'VISA'}
+      </Text>
+    </Box>
+  );
+}
+
+export const CashDepositIntroPanel = memo(function CashDepositIntroPanel() {
+  const { navigate } = useNavigation();
+  const { isDarkMode } = useColorMode();
+  const blue = useForegroundColor('blue');
+
+  const backgroundGradientColors = isDarkMode
+    ? ([opacity(HERO_DOLLAR_COLOR, 0.2), opacity(HERO_DOLLAR_COLOR, 0)] as const)
+    : ([opacity(HERO_DOLLAR_COLOR, 0.16), opacity(HERO_DOLLAR_COLOR, 0)] as const);
+  const backgroundGradientLocations = isDarkMode ? ([0, 1] as const) : ([0, 0.4583] as const);
+
+  useFocusEffect(
+    useCallback(() => {
+      analytics.track(analytics.event.cashDepositIntroViewed);
+    }, [])
+  );
+
+  // Set Up Account → Cash Deposit Setup wizard. Destination lands in a later unit; inert for now.
+  const handleSetUpAccount = useCallback(() => {
+    // TODO(cash): navigate to CashDepositSetupScreen once the Setup wizard unit lands.
+  }, []);
+
+  // Other Deposit Methods → legacy third-party provider widgets.
+  const handleOtherDepositMethods = useCallback(() => {
+    navigate(Routes.ADD_CASH_SHEET);
+  }, [navigate]);
+
+  // Sign In → passkey login. Destination lands in a later unit; inert for now.
+  const handleSignIn = useCallback(() => {
+    // TODO(cash): start passkey OAuth login once the auth unit lands.
+  }, []);
+
+  return (
+    <PanelSheet>
+      <Box>
+        <LinearGradient
+          colors={backgroundGradientColors}
+          end={{ x: 0.5, y: 1 }}
+          locations={backgroundGradientLocations}
+          pointerEvents="none"
+          start={{ x: 0.5, y: 0 }}
+          style={styles.gradient}
+        />
+
+        <Box flexDirection="row" justifyContent="flex-end" paddingHorizontal="24px" paddingTop="28px">
+          <ButtonPressAnimation onPress={handleSignIn} scaleTo={0.92} testID="cash-deposit-intro-sign-in">
+            <Text color="blue" size="17pt" weight="bold">
+              {i18n.t(i18n.l.cash.deposit_intro.sign_in)}
+            </Text>
+          </ButtonPressAnimation>
+        </Box>
+
+        <Box alignItems="center" paddingTop="32px">
+          {Platform.OS === 'android' ? (
+            // The DS Text pins Android's line box to the size token's metrics, which crops a glyph
+            // scaled this far past the token. Render it raw, with room for the $'s stems.
+            <NativeText allowFontScaling={false} style={styles.heroAndroid}>
+              {'$'}
+            </NativeText>
+          ) : (
+            <TextShadow blur={36} color={HERO_DOLLAR_COLOR} shadowOpacity={0.2}>
+              <Text align="center" color="blue" size="64pt" style={styles.hero} weight="black">
+                {'$'}
+              </Text>
+            </TextShadow>
+          )}
+          <Box alignItems="center" gap={24} paddingTop="24px">
+            <Text align="center" color="blue" size="17pt" style={styles.eyebrow} weight="heavy">
+              {i18n.t(i18n.l.cash.deposit_intro.introducing).toUpperCase()}
+            </Text>
+            <Text align="center" color="label" size="44pt" style={styles.title} weight="heavy">
+              {i18n.t(i18n.l.cash.deposit_intro.title)}
+            </Text>
+          </Box>
+        </Box>
+
+        <Box paddingHorizontal="28px" paddingTop="44px">
+          <Stack space="32px">
+            <CashDepositIntroFeatureRow
+              icon={
+                <Text align="center" color="blue" size="30pt" weight="medium">
+                  {'􀓣'}
+                </Text>
+              }
+              text={i18n.t(i18n.l.cash.deposit_intro.encrypted_feature)}
+            />
+            <CashDepositIntroFeatureRow icon={<VisaBadge color={blue} />} text={i18n.t(i18n.l.cash.deposit_intro.visa_feature)} />
+          </Stack>
+        </Box>
+
+        <Box gap={32} paddingBottom="32px" paddingHorizontal="20px" paddingTop="44px">
+          <ButtonPressAnimation onPress={handleSetUpAccount} scaleTo={0.96} testID="cash-deposit-intro-set-up-account">
+            <Box
+              alignItems="center"
+              borderRadius={52}
+              height={{ custom: 48 }}
+              justifyContent="center"
+              style={[styles.cta, { backgroundColor: blue, shadowColor: blue }]}
+            >
+              <Text align="center" color="white" size="22pt" weight="heavy">
+                {i18n.t(i18n.l.cash.deposit_intro.set_up_account)}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+          <ButtonPressAnimation onPress={handleOtherDepositMethods} scaleTo={0.96} testID="cash-deposit-intro-other-deposit-methods">
+            <Text align="center" color="blue" size="17pt" weight="heavy">
+              {i18n.t(i18n.l.cash.deposit_intro.other_deposit_methods)}
+            </Text>
+          </ButtonPressAnimation>
+        </Box>
+      </Box>
+    </PanelSheet>
+  );
+});
+
+const styles = StyleSheet.create({
+  cta: {
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 12,
+  },
+  eyebrow: {
+    fontSize: 16,
+    letterSpacing: 0.6,
+    lineHeight: 18,
+  },
+  gradient: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  hero: {
+    color: HERO_DOLLAR_COLOR,
+    fontSize: 118,
+    letterSpacing: 0.37,
+    lineHeight: 120,
+    transform: [{ rotate: '-4.7deg' }],
+  },
+  // Raw Android counterpart: a tall line box + restored font padding so the stems aren't cropped,
+  // then negative margins claw the extra height back so spacing matches the iOS hero.
+  heroAndroid: {
+    color: HERO_DOLLAR_COLOR,
+    fontSize: 118,
+    includeFontPadding: true,
+    letterSpacing: 0.37,
+    lineHeight: 150,
+    marginVertical: -15,
+    textAlign: 'center',
+    textAlignVertical: 'center',
+    transform: [{ rotate: '-4.7deg' }],
+    ...fontWithWidth(900),
+  },
+  title: {
+    fontSize: 41,
+    lineHeight: 45,
+  },
+  visaBadge: {
+    borderRadius: 8,
+    borderWidth: 2,
+    height: 25,
+    width: 40,
+  },
+});

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1650,6 +1650,18 @@
       "leverage": "Leverage",
       "up_to": "Up to"
     },
+    "cash": {
+      "add_cash": "Add Cash",
+      "deposit_intro": {
+        "introducing": "Introducing",
+        "title": "Cash Deposits",
+        "encrypted_feature": "Your information is encrypted and protected.",
+        "visa_feature": "Available for US-based customers using a Visa card.",
+        "set_up_account": "Set Up Account",
+        "other_deposit_methods": "Other Deposit Methods",
+        "sign_in": "Sign In"
+      }
+    },
     "points": {
       "points": {
         "try_again": "Try Again"

--- a/src/model/remoteConfig.ts
+++ b/src/model/remoteConfig.ts
@@ -91,6 +91,7 @@ export interface RainbowConfig extends Record<
   discover_enabled: boolean;
   perps_enabled: boolean;
   polymarket_enabled: boolean;
+  cash_enabled: boolean;
   rnbw_rewards_enabled: boolean;
   rnbw_membership_enabled: boolean;
   delegation_enabled: boolean;
@@ -225,6 +226,7 @@ export const DEFAULT_CONFIG = {
   discover_enabled: true,
   perps_enabled: true,
   polymarket_enabled: true,
+  cash_enabled: false,
   dev_section_enabled: IS_DEV,
   rnbw_rewards_enabled: false,
   rnbw_membership_enabled: false,

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -12,6 +12,7 @@ import { PROFILES } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
+import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { SignTransactionSheet } from '@/features/dapp-request/screens/SignTransactionSheet';
 import RegisterENSNavigator from '@/features/ens/navigation/RegisterENSNavigator';
 import ENSAdditionalRecordsSheet from '@/features/ens/screens/ENSAdditionalRecordsSheet';
@@ -303,6 +304,7 @@ function BSNavigator() {
       <BSStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} />
       <BSStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
       <BSStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
+      <BSStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
       <BSStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -12,6 +12,7 @@ import { PROFILES } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
+import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { SignTransactionSheet } from '@/features/dapp-request/screens/SignTransactionSheet';
 import RegisterENSNavigator from '@/features/ens/navigation/RegisterENSNavigator';
 import ENSAdditionalRecordsSheet from '@/features/ens/screens/ENSAdditionalRecordsSheet';
@@ -337,6 +338,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={KingOfTheHillExplainSheet} name={Routes.KING_OF_THE_HILL_EXPLAIN_SHEET} {...learnSheetConfig} />
       <NativeStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
       <NativeStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
+      <NativeStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} {...panelConfig} />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -68,6 +68,7 @@ const Routes = {
   PROFILE_SCREEN: 'ProfileScreen',
   PROFILE_SHEET: 'ProfileSheet',
   QR_SCANNER_SCREEN: 'QRScannerScreen',
+  CASH_DEPOSIT_INTRO_PANEL: 'CashDepositIntroPanel',
   RECEIVE_MODAL: 'ReceiveModal',
   REGISTER_ENS_NAVIGATOR: 'RegisterEnsNavigator',
   CHOOSE_BACKUP_SHEET: 'ChooseBackupSheet',


### PR DESCRIPTION
Fixed: APP-3775

## Description

Adds the Cash Deposits intro panel entry point behind the Cash gate. With the gate off, Buy / Add Cash still opens the legacy Add Cash flow unchanged.

With the gate on, the Buy / Add Cash entry points relabel to Add Cash and open the Cash Deposits intro panel. From there, Other Deposit Methods continues to the legacy provider widgets, while Set Up Account and Sign In remain placeholders for later Cash units.

## Visuals

Videos were recorded before the final flag naming; use Developer Settings -> Cash for QA.

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-06-03 at 15.05.46.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f522a405-1be6-4175-9683-3820078aa508.mov" />](https://app.graphite.com/user-attachments/video/f522a405-1be6-4175-9683-3820078aa508.mov) | [untitled1.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2111e056-1cb2-4e34-b2b4-363cb0835f24.webm" />](https://app.graphite.com/user-attachments/video/2111e056-1cb2-4e34-b2b4-363cb0835f24.webm) |

## Testing

- Flag off -> Buy / Add Cash opens the legacy Add Cash flow.
- Developer Settings -> Cash on -> Buy / Add Cash opens Cash Deposits with Set Up Account, Other Deposit Methods, and Sign In.
- Other Deposit Methods still opens the legacy provider widgets.