### PR TITLE
feat(discover): Discover v2 card and section analytics

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -11,6 +11,7 @@ import { type ENSRapActionType } from '@/features/ens/raps/common';
 import { type PerpPositionSide, type TriggerOrderType } from '@/features/perps/types';
 import { type Destination, type Display, type SectionId, type SurfaceDocument, type SurfaceId } from '@/features/placements/surfaces/types';
 import { type Placement, type PlacementItem } from '@/features/placements/types';
+import { type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
 import { type EthereumWalletType } from '@/helpers/walletTypes';
 import { type WalletLibraryType } from '@/model/wallet';
 import { type PairHardwareWalletNavigatorParams } from '@/navigation/types';
@@ -243,6 +244,11 @@ export const event = {
 
   // discover screen
   timeSpentOnDiscoverScreen: 'Time spent on the Discover screen',
+  discoverCardPressed: 'discover.card_pressed',
+  discoverPredictionOrderPressed: 'discover.prediction_order_pressed',
+  discoverTabPressed: 'discover.tab_pressed',
+  discoverSectionPressed: 'discover.section_pressed',
+  discoverCarouselScrolled: 'discover.carousel_scrolled',
   placementInteraction: 'placement.interaction',
   surfaceInteraction: 'surface.interaction',
 
@@ -994,6 +1000,41 @@ export type EventProperties = {
   // discover screen
   [event.timeSpentOnDiscoverScreen]: {
     durationInMs: number;
+  };
+  [event.discoverCardPressed]: {
+    placementId: Placement['id'];
+    placementSource: Placement['source'];
+    placementTitle: string;
+    itemOrder: number;
+    itemId: PlacementItem['id'];
+    marketId: string;
+    marketName: string;
+    marketSlug?: string;
+    marketSymbol?: string;
+    marketType: Placement['source'];
+  };
+  [event.discoverTabPressed]: {
+    sectionTitle: string;
+    sectionId: SectionId;
+    wasActive: boolean;
+  };
+  [event.discoverPredictionOrderPressed]: {
+    placementId: Placement['id'];
+    itemId: PlacementItem['id'];
+    marketId: PolymarketMarket['id'];
+    marketName: PolymarketMarket['question'];
+    marketSlug: PolymarketMarket['slug'];
+    outcome: PolymarketMarket['outcomes'][number];
+  };
+  [event.discoverSectionPressed]: {
+    destination: Destination;
+    display: Display;
+    sectionId: SectionId;
+    sectionTitle: string;
+  };
+  [event.discoverCarouselScrolled]: {
+    display: Display;
+    sectionId: SectionId;
   };
   [event.placementInteraction]: {
     id: Placement['id'];

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1011,7 +1011,7 @@ export type EventProperties = {
     marketName: string;
     marketSlug?: string;
     marketSymbol?: string;
-    marketType: Placement['source'];
+    marketType: Placement['type'];
   };
   [event.discoverTabPressed]: {
     sectionTitle: string;

--- a/src/features/discover/components/DiscoverHeader.tsx
+++ b/src/features/discover/components/DiscoverHeader.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { ScrollView, StyleSheet, View, type LayoutChangeEvent, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 
+import { analytics } from '@/analytics';
+import { event as analyticsEvent } from '@/analytics/event';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { useDiscoverScreenContext } from '@/components/Discover/DiscoverScreenContext';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
@@ -13,6 +15,7 @@ import {
   useDiscoverNavigationStore,
   type DiscoverSection,
 } from '@/features/discover/stores/discoverNavigationStore';
+import { trackSurfaceInteraction } from '@/features/placements/engagement/trackInteraction';
 import { useDiscoverSurface } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
 import { type DiscoverTab } from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
@@ -126,6 +129,19 @@ function DiscoverCategorySelector() {
   const handlePress = useCallback(
     (section: DiscoverTab) => {
       const wasActive = DiscoverSectionNavigation.isSectionActive(section.id);
+      const sectionTitle = resolveSectionTitle(section);
+      if (surface) {
+        analytics.track(analyticsEvent.discoverTabPressed, {
+          sectionId: section.id,
+          sectionTitle,
+          wasActive,
+        });
+        trackSurfaceInteraction({
+          id: surface.id,
+          sectionId: section.id,
+          sectionTitle,
+        });
+      }
 
       if (wasActive) {
         scrollToSectionTop(section.id);
@@ -133,7 +149,7 @@ function DiscoverCategorySelector() {
         DiscoverSectionNavigation.navigate(section.id);
       }
     },
-    [scrollToSectionTop]
+    [scrollToSectionTop, surface]
   );
 
   if (!tabs.length) return <DiscoverCategorySelectorFallback />;

--- a/src/features/discover/components/DiscoverSection.tsx
+++ b/src/features/discover/components/DiscoverSection.tsx
@@ -3,11 +3,11 @@ import { StyleSheet, View } from 'react-native';
 
 import { isMarketSurface, MarketSection } from '@/features/discover/components/MarketSection';
 import { isPredictionsSurface, PredictionsSection } from '@/features/discover/components/PredictionsSection';
-import { type SurfaceLeafNode } from '@/features/placements/surfaces/types';
+import { type SurfaceId, type SurfaceLeafNode } from '@/features/placements/surfaces/types';
 
 type DiscoverSectionsProps = {
   items: SurfaceLeafNode[];
-  surfaceId: string;
+  surfaceId: SurfaceId;
 };
 
 export function DiscoverSections({ items, surfaceId }: DiscoverSectionsProps) {
@@ -20,7 +20,7 @@ export function DiscoverSections({ items, surfaceId }: DiscoverSectionsProps) {
   );
 }
 
-export const DiscoverSection = memo(function DiscoverSection({ surface, surfaceId }: { surface: SurfaceLeafNode; surfaceId: string }) {
+export const DiscoverSection = memo(function DiscoverSection({ surface, surfaceId }: { surface: SurfaceLeafNode; surfaceId: SurfaceId }) {
   if (isMarketSurface(surface)) return <MarketSection surface={surface} surfaceId={surfaceId} />;
   if (isPredictionsSurface(surface)) return <PredictionsSection surface={surface} surfaceId={surfaceId} />;
   return null;

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/features/discover/stores/discoverNavigationStore';
 import { useDiscoverSurface } from '@/features/placements/surfaces/stores/discoverSurfaceStore';
 import { type DiscoverTab } from '@/features/placements/surfaces/stores/discoverSurfaceTypes';
+import { type SurfaceId } from '@/features/placements/surfaces/types';
 import { useTabBarOffset } from '@/hooks/useTabBarOffset';
 import { useListen } from '@/state/internal/hooks/useListen';
 import { clamp } from '@/worklets/numbers';
@@ -148,7 +149,7 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
   section: DiscoverTab;
   sectionIndex: number;
   sectionScrollOffsets: MutableRefObject<SectionScrollOffsets>;
-  surfaceId: string;
+  surfaceId: SurfaceId;
 }) {
   const { registerSectionScrollView } = useDiscoverScreenContext();
   const tabBarOffset = useTabBarOffset();

--- a/src/features/discover/components/MarketSection.tsx
+++ b/src/features/discover/components/MarketSection.tsx
@@ -20,6 +20,7 @@ import { tokenToMarketPillWidthInput, useTokenMarketDisplay } from '@/features/d
 import { renderSectionLayout } from '@/features/discover/components/SectionLayout';
 import { type MarketDisplayItem } from '@/features/discover/types/marketDisplayItem';
 import {
+  type CardPressHandler,
   type MarketDisplay,
   type PlacementBackedSurfaceLeafWithDisplay,
   type SectionDescriptor,
@@ -32,7 +33,7 @@ import { useTokensPlacement, type TokenPlacementItem } from '@/features/placemen
 import { usePlacementsStore } from '@/features/placements/stores/placementsStore';
 import { MARKET_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
 import { useIsDiscoverSurfacePlacementPending } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
-import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { type SurfaceId, type SurfaceLeaf } from '@/features/placements/surfaces/types';
 import { useRemoteConfig } from '@/model/remoteConfig';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -80,12 +81,18 @@ export function isMarketSurface(surface: SurfaceLeaf): surface is SurfaceLeafWit
   return (MARKET_DISPLAY_VALUES as readonly string[]).includes(surface.display);
 }
 
-export function MarketSection({ surface }: { surface: SurfaceLeafWithDisplay<MarketDisplay>; surfaceId: string }) {
+export function MarketSection({ surface, surfaceId }: { surface: SurfaceLeafWithDisplay<MarketDisplay>; surfaceId: SurfaceId }) {
   if (!hasPlacement(surface)) return null;
-  return <MarketPlacementContent surface={surface} />;
+  return <MarketPlacementContent surface={surface} surfaceId={surfaceId} />;
 }
 
-function MarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
+function MarketPlacementContent({
+  surface,
+  surfaceId,
+}: {
+  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
+  surfaceId: SurfaceId;
+}) {
   const perpsEnabled = useRemoteConfig('perps_enabled').perps_enabled;
   const placement = usePlacementsStore(state => state.getPlacement(surface.placement));
   const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
@@ -96,11 +103,11 @@ function MarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLe
 
   if (placement?.source === 'hyperliquid') {
     if (!perpsEnabled) return null;
-    return <PerpsMarketPlacementContent surface={surface} />;
+    return <PerpsMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
   }
 
   if (placement?.source === 'rainbow') {
-    return <TokenMarketPlacementContent surface={surface} />;
+    return <TokenMarketPlacementContent surface={surface} surfaceId={surfaceId} />;
   }
 
   if (isLoadingPlacementSource || isPendingSurfacePlacement) {
@@ -108,15 +115,23 @@ function MarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLe
       data: [],
       descriptor: MARKET_SECTION_DESCRIPTORS[surface.display],
       loading: true,
-      onPressSeeAll: undefined,
-      surface,
+      onPress: undefined,
+      placement,
+      section: surface,
+      surfaceId,
     });
   }
 
   return null;
 }
 
-function PerpsMarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
+function PerpsMarketPlacementContent({
+  surface,
+  surfaceId,
+}: {
+  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
+  surfaceId: SurfaceId;
+}) {
   const perpsResult = usePerpsPlacement(surface.placement);
   const perpDescriptor = useMemo<SectionDescriptor<PerpMarketPlacementItem>>(() => {
     switch (surface.display) {
@@ -124,29 +139,37 @@ function PerpsMarketPlacementContent({ surface }: { surface: PlacementBackedSurf
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
           getItemWidth: (item: PerpMarketPlacementItem) => computeMarketPillWidth(perpToMarketPillWidthInput(item)),
-          renderItem: (item: PerpMarketPlacementItem) => <PerpMarketItem item={item} variant="pill" />,
+          renderItem: (item: PerpMarketPlacementItem, _: number, onPress: CardPressHandler) => (
+            <PerpMarketItem item={item} onPress={onPress} variant="pill" />
+          ),
         };
       case 'market_tile.carousel':
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
-          renderItem: (item: PerpMarketPlacementItem) => <PerpMarketItem item={item} variant="tile" />,
+          renderItem: (item: PerpMarketPlacementItem, _: number, onPress: CardPressHandler) => (
+            <PerpMarketItem item={item} onPress={onPress} variant="tile" />
+          ),
         };
       case 'market_tile.grid':
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
-          renderItem: (item: PerpMarketPlacementItem, width: number) => <PerpMarketItem item={item} variant="tile" width={width} />,
+          renderItem: (item: PerpMarketPlacementItem, width: number, onPress: CardPressHandler) => (
+            <PerpMarketItem item={item} onPress={onPress} variant="tile" width={width} />
+          ),
         };
       case 'market_cell.list':
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
-          renderItem: (item: PerpMarketPlacementItem) => <PerpMarketItem item={item} variant="cell" />,
+          renderItem: (item: PerpMarketPlacementItem, onPress: CardPressHandler) => (
+            <PerpMarketItem item={item} onPress={onPress} variant="cell" />
+          ),
         };
     }
   }, [surface.display]);
   // Perp "See All" routes to the CMS destination (perps -> perps screen), gated on
   // a perps destination existing.
   const perpsDestination = hasDestinationRoot(surface.destination, 'perps') ? surface.destination : null;
-  const onPressSeeAll = useCallback(() => {
+  const onPress = useCallback(() => {
     if (perpsDestination) navigateDiscoverDestination(perpsDestination);
   }, [perpsDestination]);
 
@@ -154,12 +177,20 @@ function PerpsMarketPlacementContent({ surface }: { surface: PlacementBackedSurf
     data: perpsResult.items,
     descriptor: perpDescriptor,
     loading: perpsResult.isLoading,
-    onPressSeeAll: perpsDestination ? onPressSeeAll : undefined,
-    surface,
+    onPress: perpsDestination && perpsResult.placement ? onPress : undefined,
+    placement: perpsResult.placement,
+    section: surface,
+    surfaceId,
   });
 }
 
-function TokenMarketPlacementContent({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay> }) {
+function TokenMarketPlacementContent({
+  surface,
+  surfaceId,
+}: {
+  surface: PlacementBackedSurfaceLeafWithDisplay<MarketDisplay>;
+  surfaceId: SurfaceId;
+}) {
   const { onTapSearch } = useDiscoverScreenContext();
   const nativeCurrency = userAssetsStoreManager(state => state.currency);
   const tokensResult = useTokensPlacement(surface.placement);
@@ -169,37 +200,43 @@ function TokenMarketPlacementContent({ surface }: { surface: PlacementBackedSurf
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
           getItemWidth: (item: TokenPlacementItem) => computeMarketPillWidth(tokenToMarketPillWidthInput({ item, nativeCurrency })),
-          renderItem: (item: TokenPlacementItem) => <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="pill" />,
+          renderItem: (item: TokenPlacementItem, _: number, onPress: CardPressHandler) => (
+            <TokenMarketItem item={item} nativeCurrency={nativeCurrency} onPress={onPress} variant="pill" />
+          ),
         };
       case 'market_tile.carousel':
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
-          renderItem: (item: TokenPlacementItem) => <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="tile" />,
+          renderItem: (item: TokenPlacementItem, _: number, onPress: CardPressHandler) => (
+            <TokenMarketItem item={item} nativeCurrency={nativeCurrency} onPress={onPress} variant="tile" />
+          ),
         };
       case 'market_tile.grid':
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
-          renderItem: (item: TokenPlacementItem, width: number) => (
-            <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="tile" width={width} />
+          renderItem: (item: TokenPlacementItem, width: number, onPress: CardPressHandler) => (
+            <TokenMarketItem item={item} nativeCurrency={nativeCurrency} onPress={onPress} variant="tile" width={width} />
           ),
         };
       case 'market_cell.list':
         return {
           ...MARKET_SECTION_DESCRIPTORS[surface.display],
-          renderItem: (item: TokenPlacementItem) => <TokenMarketItem item={item} nativeCurrency={nativeCurrency} variant="cell" />,
+          renderItem: (item: TokenPlacementItem, onPress: CardPressHandler) => (
+            <TokenMarketItem item={item} nativeCurrency={nativeCurrency} onPress={onPress} variant="cell" />
+          ),
         };
     }
   }, [nativeCurrency, surface.display]);
-  // Token "See All" opens Discover search rather than routing a CMS destination;
-  // navigateDiscoverDestination('tokens') is intentionally a no-op.
-  const onPressSeeAll = useCallback(() => onTapSearch(), [onTapSearch]);
+  const onPress = useCallback(() => onTapSearch(), [onTapSearch]);
 
   return renderSectionLayout({
     data: tokensResult.items,
     descriptor: tokenDescriptor,
     loading: tokensResult.isLoading,
-    onPressSeeAll: hasDestinationRoot(surface.destination, 'tokens') ? onPressSeeAll : undefined,
-    surface,
+    onPress: hasDestinationRoot(surface.destination, 'tokens') && tokensResult.placement ? onPress : undefined,
+    placement: tokensResult.placement,
+    section: surface,
+    surfaceId,
   });
 }
 
@@ -207,68 +244,86 @@ function hasPlacement(surface: SurfaceLeafWithDisplay<MarketDisplay>): surface i
   return typeof surface.placement === 'string' && surface.placement.length > 0;
 }
 
-function renderMarketPill(item: MarketDisplayItem) {
-  return <MarketPill item={item} />;
+function renderMarketPill(item: MarketDisplayItem, _: number, onPress: CardPressHandler) {
+  return <MarketPill item={item} onPress={() => onPress({ marketId: item.id, marketName: item.displayName })} />;
 }
 
-function renderMarketTile(item: MarketDisplayItem) {
-  return <MarketTileCard item={item} />;
+function renderMarketTile(item: MarketDisplayItem, _: number, onPress: CardPressHandler) {
+  return <MarketTileCard item={item} onPress={() => onPress({ marketId: item.id, marketName: item.displayName })} />;
 }
 
-function renderMarketGridTile(item: MarketDisplayItem, width: number) {
-  return <MarketTileCard item={item} width={width} />;
+function renderMarketGridTile(item: MarketDisplayItem, width: number, onPress: CardPressHandler) {
+  return <MarketTileCard item={item} onPress={() => onPress({ marketId: item.id, marketName: item.displayName })} width={width} />;
 }
 
 function renderMarketGridTileSkeleton(width: number) {
   return <MarketTileCardSkeleton width={width} />;
 }
 
-function renderMarketCell(item: MarketDisplayItem) {
-  return <MarketCell item={item} />;
+function renderMarketCell(item: MarketDisplayItem, onPress: CardPressHandler) {
+  return <MarketCell item={item} onPress={() => onPress({ marketId: item.id, marketName: item.displayName })} />;
 }
 
 function TokenMarketItem({
   item,
   nativeCurrency,
+  onPress,
   variant,
   width,
 }: {
   item: TokenPlacementItem;
   nativeCurrency: NativeCurrencyKey;
+  onPress: CardPressHandler;
   variant: 'cell' | 'pill' | 'tile';
   width?: number;
 }) {
   const displayItem = useTokenMarketDisplay({ item, nativeCurrency });
-  const onPress = useCallback(() => {
+  const handlePress = useCallback(() => {
+    onPress({ marketId: item.id, marketName: item.asset.name, marketSymbol: item.asset.symbol });
     Navigation.handleAction(Routes.EXPANDED_ASSET_SHEET_V2, {
       asset: item.asset,
       address: item.asset.address,
       chainId: item.asset.chainId,
     });
-  }, [item.asset]);
+  }, [item.asset, item.id, onPress]);
 
   switch (variant) {
     case 'cell':
-      return <MarketCell item={displayItem} onPress={onPress} />;
+      return <MarketCell item={displayItem} onPress={handlePress} />;
     case 'pill':
-      return <MarketPill item={displayItem} onPress={onPress} />;
+      return <MarketPill item={displayItem} onPress={handlePress} />;
     case 'tile':
-      return <MarketTileCard item={displayItem} onPress={onPress} width={width} />;
+      return <MarketTileCard item={displayItem} onPress={handlePress} width={width} />;
   }
 }
 
-function PerpMarketItem({ item, variant, width }: { item: PerpMarketPlacementItem; variant: 'cell' | 'pill' | 'tile'; width?: number }) {
+function PerpMarketItem({
+  item,
+  onPress,
+  variant,
+  width,
+}: {
+  item: PerpMarketPlacementItem;
+  onPress: CardPressHandler;
+  variant: 'cell' | 'pill' | 'tile';
+  width?: number;
+}) {
   const displayItem = usePerpMarketDisplay(item);
-  const onPress = useCallback(() => {
+  const handlePress = useCallback(() => {
+    onPress({
+      marketId: item.market.symbol,
+      marketName: item.market.metadata?.name ?? item.market.baseSymbol,
+      marketSymbol: item.market.baseSymbol,
+    });
     maybeNavigateToPerpsExplainSheet(() => Navigation.handleAction(Routes.PERPS_DETAIL_SCREEN, { market: item.market }));
-  }, [item.market]);
+  }, [item.market, onPress]);
 
   switch (variant) {
     case 'cell':
-      return <MarketCell item={displayItem} onPress={onPress} />;
+      return <MarketCell item={displayItem} onPress={handlePress} />;
     case 'pill':
-      return <MarketPill item={displayItem} onPress={onPress} />;
+      return <MarketPill item={displayItem} onPress={handlePress} />;
     case 'tile':
-      return <MarketTileCard item={displayItem} onPress={onPress} width={width} />;
+      return <MarketTileCard item={displayItem} onPress={handlePress} width={width} />;
   }
 }

--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -19,6 +19,8 @@ import {
 } from '@/features/discover/components/markets/cards/PredictionMarketTileCard';
 import { getRenderedHeaderCount, renderSectionLayout } from '@/features/discover/components/SectionLayout';
 import {
+  type CardPressHandler,
+  type OrderPressHandler,
   type PlacementBackedSurfaceLeafWithDisplay,
   type SectionDescriptor,
   type SurfaceLeafWithDisplay,
@@ -33,7 +35,7 @@ import { usePredictionsPlacement, type PredictionPlacementItem } from '@/feature
 import { usePlacementsStore } from '@/features/placements/stores/placementsStore';
 import { isEventCardDisplay, PREDICTION_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
 import { useIsDiscoverSurfacePlacementPending } from '@/features/placements/surfaces/hooks/useDiscoverSurfacePlacements';
-import { type Display, type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { type Display, type SurfaceId, type SurfaceLeaf } from '@/features/placements/surfaces/types';
 import { LeagueIcon } from '@/features/polymarket/components/league-icon/LeagueIcon';
 import { LiveSectionIndicator } from '@/features/polymarket/components/LiveSectionIndicator';
 import {
@@ -53,6 +55,7 @@ import { addSubscribedTokens, removeSubscribedTokens, useLiveTokensStore } from 
 import { DEVICE_WIDTH } from '@/utils/deviceUtils';
 
 type PredictionsDisplay = (typeof PREDICTION_DISPLAY_VALUES)[number];
+type PlacementBackedPredictionsSurface = PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay>;
 
 const PREDICTION_TILE_SHADOW_BLEED = 28;
 const PREDICTION_TILE_WIDTH = Math.round((DEVICE_WIDTH - 20 * 2 - 8) / 2);
@@ -133,24 +136,24 @@ export function isPredictionsSurface(surface: SurfaceLeaf): surface is SurfaceLe
   return (PREDICTION_DISPLAY_VALUES as readonly string[]).includes(surface.display);
 }
 
-export function PredictionsSection({ surface, surfaceId }: { surface: SurfaceLeafWithDisplay<PredictionsDisplay>; surfaceId: string }) {
+export function PredictionsSection({ surface, surfaceId }: { surface: SurfaceLeafWithDisplay<PredictionsDisplay>; surfaceId: SurfaceId }) {
   const sportsIntent = useMemo(() => getSportsSurfaceIntent(surface), [surface]);
 
   if (!hasPlacement(surface)) {
-    if (sportsIntent) return <SportsQuerySection sportsIntent={sportsIntent} surface={surface} />;
+    if (sportsIntent) return <SportsQuerySection sportsIntent={sportsIntent} surface={surface} surfaceId={surfaceId} />;
     return unsupportedUnplacedPredictionSurface(surface, surfaceId);
   }
 
   // Only route to the sports section when there's a real sports intent — otherwise it would
   // mount, run its placement hooks/subscriptions, then immediately delegate, double-mounting.
   if (isEventCardDisplay(surface.display) && sportsIntent) {
-    return <SportsEventPlacementSection sportsIntent={sportsIntent} surface={surface} />;
+    return <SportsEventPlacementSection sportsIntent={sportsIntent} surface={surface} surfaceId={surfaceId} />;
   }
 
-  return <PredictionsPlacementSection surface={surface} />;
+  return <PredictionsPlacementSection surface={surface} surfaceId={surfaceId} />;
 }
 
-function useIsPredictionPlacementPending(surface: PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay>): boolean {
+function useIsPredictionPlacementPending(surface: PlacementBackedPredictionsSurface): boolean {
   const isPendingSurfacePlacement = useIsDiscoverSurfacePlacementPending(surface.placement);
   const isLoadingPlacementSource = usePlacementsStore(state => {
     if (state.getPlacement(surface.placement) !== undefined) return false;
@@ -212,7 +215,7 @@ function usePredictionTokenSubscription({
   }, [display, renderedItems]);
 }
 
-function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay> }) {
+function PredictionsPlacementSection({ surface, surfaceId }: { surface: PlacementBackedPredictionsSurface; surfaceId: SurfaceId }) {
   const result = usePredictionsPlacement(surface.placement);
   const isPlacementPending = useIsPredictionPlacementPending(surface);
   const descriptor = PREDICTIONS_SECTION_DESCRIPTORS[surface.display];
@@ -228,17 +231,21 @@ function PredictionsPlacementSection({ surface }: { surface: PlacementBackedSurf
     descriptor,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: predictionsDestination && result.placement ? onPressSeeAll : undefined,
-    surface,
+    onPress: predictionsDestination && result.placement ? onPressSeeAll : undefined,
+    placement: result.placement,
+    section: surface,
+    surfaceId,
   });
 }
 
 function SportsEventPlacementSection({
   sportsIntent,
   surface,
+  surfaceId,
 }: {
   sportsIntent: SportsSurfaceIntent;
-  surface: PlacementBackedSurfaceLeafWithDisplay<PredictionsDisplay>;
+  surface: PlacementBackedPredictionsSurface;
+  surfaceId: SurfaceId;
 }) {
   const isPlacementPending = useIsPredictionPlacementPending(surface);
   const result = usePredictionsPlacement(surface.placement);
@@ -263,17 +270,21 @@ function SportsEventPlacementSection({
     leadingAccessory,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: predictionsDestination && result.placement ? onPressSeeAll : undefined,
-    surface,
+    onPress: predictionsDestination && result.placement ? onPressSeeAll : undefined,
+    placement: result.placement,
+    section: surface,
+    surfaceId,
   });
 }
 
 function SportsQuerySection({
   sportsIntent,
   surface,
+  surfaceId,
 }: {
   sportsIntent: SportsSurfaceIntent;
   surface: SurfaceLeafWithDisplay<PredictionsDisplay>;
+  surfaceId: SurfaceId;
 }) {
   const events = usePolymarketSportsEventsStore(state => state.getData());
   const isLoading = usePolymarketSportsEventsStore(state => state.enabled && (state.getStatus('isLoading') || state.getStatus('isIdle')));
@@ -302,8 +313,9 @@ function SportsQuerySection({
     leadingAccessory,
     loading: isLoading,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
-    onPressSeeAll: predictionsDestination ? onPressSeeAll : undefined,
-    surface,
+    onPress: predictionsDestination ? onPressSeeAll : undefined,
+    section: surface,
+    surfaceId,
   });
 }
 
@@ -332,7 +344,7 @@ function getSportsHeaderProps(
   };
 }
 
-function unsupportedUnplacedPredictionSurface(surface: SurfaceLeafWithDisplay<PredictionsDisplay>, surfaceId: string) {
+function unsupportedUnplacedPredictionSurface(surface: SurfaceLeafWithDisplay<PredictionsDisplay>, surfaceId: SurfaceId) {
   logger.warn('[PredictionsSection]: unsupported unplaced prediction surface', {
     display: surface.display,
     sectionId: surface.id,
@@ -347,24 +359,34 @@ function hasPlacement<TDisplay extends Display>(
   return typeof surface.placement === 'string' && surface.placement.length > 0;
 }
 
-function renderPredictionTile(item: PredictionPlacementItem) {
-  return <PredictionListItem item={item} style={styles.predictionTile} />;
+function renderPredictionTile(item: PredictionPlacementItem, _: number, onPress: CardPressHandler) {
+  return <PredictionListItem item={item} onPress={onPress} style={styles.predictionTile} />;
 }
 
-function renderPredictionGridTile(item: PredictionPlacementItem, width: number) {
-  return <PredictionListItem item={item} style={{ height: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT, width }} />;
+function renderPredictionGridTile(item: PredictionPlacementItem, width: number, onPress: CardPressHandler) {
+  return <PredictionListItem item={item} onPress={onPress} style={{ height: POLYMARKET_EVENTS_LIST_ITEM_HEIGHT, width }} />;
 }
 
-function PredictionListItem({ item, style }: { item: PredictionPlacementItem; style: StyleProp<ViewStyle> }) {
+function PredictionListItem({
+  item,
+  onPress,
+  style,
+}: {
+  item: PredictionPlacementItem;
+  onPress: CardPressHandler;
+  style: StyleProp<ViewStyle>;
+}) {
   const { isDarkMode } = useColorMode();
-  const onPress = useCallback(() => {
-    navigateToPolymarketEvent({ event: item.event, eventId: item.event.id });
-  }, [item.event]);
+  const handlePress = useCallback(() => {
+    const { event } = item;
+    onPress({ marketId: event.id, marketName: event.title, marketSlug: event.slug, marketSymbol: event.ticker });
+    navigateToPolymarketEvent({ event, eventId: event.id });
+  }, [item, onPress]);
 
   return (
     <PolymarketEventsListItem
       event={item.event}
-      onPress={onPress}
+      onPress={handlePress}
       shouldActivateOnStart={false}
       style={[style, styles.predictionTileShadow, isDarkMode ? styles.predictionTileShadowDark : styles.predictionTileShadowLight]}
     />
@@ -375,8 +397,8 @@ function renderPredictionSkeleton({ borderRadius, height, width }: PredictionSke
   return <Skeleton borderRadius={borderRadius} height={height} width={width} />;
 }
 
-function renderPredictionWidget(item: PredictionPlacementItem) {
-  return <PredictionMarketTileCard event={item.event} />;
+function renderPredictionWidget(item: PredictionPlacementItem, _: number, onPress: CardPressHandler, onOrderPress: OrderPressHandler) {
+  return <PredictionMarketTileCard event={item.event} onPress={onPress} onOrderPress={onOrderPress} />;
 }
 
 function getSportsEventSectionDescriptor(
@@ -407,14 +429,29 @@ function getSportsEventSectionDescriptor(
 }
 
 function renderEventCardList(hideLeagueHeader: boolean) {
-  return function render(item: PredictionPlacementItem): ReactNode {
-    return <PredictionMarketEventCard event={item.event} hideLeagueHeader={hideLeagueHeader} />;
+  return function render(item: PredictionPlacementItem, onPress: CardPressHandler, onOrderPress: OrderPressHandler): ReactNode {
+    return (
+      <PredictionMarketEventCard event={item.event} hideLeagueHeader={hideLeagueHeader} onPress={onPress} onOrderPress={onOrderPress} />
+    );
   };
 }
 
 function renderEventCardSized(hideLeagueHeader: boolean) {
-  return function render(item: PredictionPlacementItem, width: number): ReactNode {
-    return <PredictionMarketEventCard event={item.event} hideLeagueHeader={hideLeagueHeader} width={width} />;
+  return function render(
+    item: PredictionPlacementItem,
+    width: number,
+    onPress: CardPressHandler,
+    onOrderPress: OrderPressHandler
+  ): ReactNode {
+    return (
+      <PredictionMarketEventCard
+        event={item.event}
+        hideLeagueHeader={hideLeagueHeader}
+        onPress={onPress}
+        onOrderPress={onOrderPress}
+        width={width}
+      />
+    );
   };
 }
 

--- a/src/features/discover/components/SectionLayout.tsx
+++ b/src/features/discover/components/SectionLayout.tsx
@@ -1,3 +1,5 @@
+import { analytics } from '@/analytics';
+import { event } from '@/analytics/event';
 import { MarketCarousel } from '@/features/discover/components/markets/layouts/MarketCarousel';
 import { MarketGrid } from '@/features/discover/components/markets/layouts/MarketGrid';
 import { MarketList } from '@/features/discover/components/markets/layouts/MarketList';
@@ -10,8 +12,8 @@ import * as i18n from '@/languages';
  * Resolves a section's display title: a localized `discover.sections.<id>` label
  * when one exists, otherwise the server-provided label, falling back to the raw id.
  */
-export function resolveSectionTitle(surface: Pick<SurfaceLeaf, 'id' | 'label'>): string {
-  return i18n.t(`discover.sections.${surface.id}`, { defaultValue: surface.label || surface.id });
+export function resolveSectionTitle(section: Pick<SurfaceLeaf, 'id' | 'label'>): string {
+  return i18n.t(`discover.sections.${section.id}`, { defaultValue: section.label || section.id });
 }
 
 /**
@@ -39,62 +41,89 @@ export function renderSectionLayout<T extends PlacementItem>({
   headerCount,
   leadingAccessory,
   loading,
-  onPressSeeAll,
-  surface,
+  onPress,
+  placement,
+  section,
+  surfaceId,
 }: SectionLayoutProps<T>) {
-  const hasLimit = surface.limit !== undefined;
-  const renderedData = hasLimit ? data.slice(0, surface.limit) : data;
-  const skeletonCount = hasLimit ? surface.limit : undefined;
-  const descriptorHeaderCaret = 'showHeaderCaret' in descriptor ? descriptor.showHeaderCaret?.(surface) : undefined;
+  const hasLimit = section.limit !== undefined;
+  const renderedData = hasLimit ? data.slice(0, section.limit) : data;
+  const skeletonCount = hasLimit ? section.limit : undefined;
+  const descriptorHeaderCaret = 'showHeaderCaret' in descriptor ? descriptor.showHeaderCaret?.(section) : undefined;
   const showHeaderCaret = headerCaret ?? descriptorHeaderCaret;
-  const title = resolveSectionTitle(surface);
-  const sectionProps = {
-    headerCount,
-    leadingAccessory,
-    loading,
-    onPress: onPressSeeAll,
-    title,
-  };
+  const title = resolveSectionTitle(section);
+  const headerPress = onPress
+    ? () => {
+        analytics.track(event.discoverSectionPressed, {
+          destination: section.destination,
+          display: section.display,
+          sectionId: section.id,
+          sectionTitle: title,
+        });
+        onPress();
+      }
+    : undefined;
 
   switch (descriptor.layout) {
     case 'carousel':
       return (
         <MarketCarousel
-          {...sectionProps}
           data={renderedData}
           getItemWidth={descriptor.getItemWidth}
+          headerCount={headerCount}
           itemHorizontalBleed={descriptor.itemHorizontalBleed}
           itemHeight={descriptor.itemHeight}
           itemVerticalBleed={descriptor.itemVerticalBleed}
           itemWidth={descriptor.itemWidth}
+          leadingAccessory={leadingAccessory}
+          loading={loading}
+          onPress={headerPress}
+          placement={placement}
           renderItem={descriptor.renderItem}
           renderSkeleton={descriptor.renderSkeleton}
           showHeaderCaret={showHeaderCaret}
           singleItemWidth={descriptor.singleItemWidth}
           skeletonCount={skeletonCount}
+          section={section}
+          surfaceId={surfaceId}
+          title={title}
         />
       );
     case 'grid':
       return (
         <MarketGrid
-          {...sectionProps}
           data={renderedData}
+          headerCount={headerCount}
           itemHeight={descriptor.itemHeight}
+          leadingAccessory={leadingAccessory}
+          loading={loading}
+          onPress={headerPress}
+          placement={placement}
           renderItem={descriptor.renderItem}
           renderSkeleton={descriptor.renderSkeleton}
           showHeaderCaret={showHeaderCaret}
           skeletonCount={skeletonCount}
+          section={section}
+          surfaceId={surfaceId}
+          title={title}
         />
       );
     case 'list':
       return (
         <MarketList
-          {...sectionProps}
           data={data}
-          initialVisibleItemCount={surface.limit}
+          headerCount={headerCount}
+          initialVisibleItemCount={section.limit}
+          leadingAccessory={leadingAccessory}
+          loading={loading}
+          onPress={headerPress}
+          placement={placement}
           renderItem={descriptor.renderItem}
           renderSkeleton={descriptor.renderSkeleton}
+          section={section}
           showHeaderCaret={showHeaderCaret}
+          surfaceId={surfaceId}
+          title={title}
         />
       );
   }

--- a/src/features/discover/components/markets/cards/PredictionMarketEventCard.tsx
+++ b/src/features/discover/components/markets/cards/PredictionMarketEventCard.tsx
@@ -8,6 +8,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { GradientBorderView } from '@/components/gradient-border/GradientBorderView';
 import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
 import { globalColors, Text, TextShadow, useBackgroundColor, useColorMode, useForegroundColor } from '@/design-system';
+import { type CardPressHandler, type OrderPressHandler } from '@/features/discover/types/sectionLayout';
 import { LeagueIcon } from '@/features/polymarket/components/league-icon/LeagueIcon';
 import { TeamLogo } from '@/features/polymarket/components/TeamLogo';
 import { usePolymarketSportsBetCellPress } from '@/features/polymarket/hooks/usePolymarketSportsBetCellPress';
@@ -16,7 +17,7 @@ import { getLeagueId, SPORT_LEAGUES, type LeagueId } from '@/features/polymarket
 import { type PolymarketTeamInfo } from '@/features/polymarket/types';
 import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
 import { formatOdds, type BetCellData } from '@/features/polymarket/utils/sportsEventBetData';
-import { getSportsEventOutcomeCellColor } from '@/features/polymarket/utils/sportsEventOutcome';
+import { getSportsEventOutcomeCellColor, type SportsEventOutcomeInfo } from '@/features/polymarket/utils/sportsEventOutcome';
 import { getDiscoverSportsEventTeamLabels } from '@/features/polymarket/utils/sportsEventTeamLabels';
 import { getTeamDisplayInfo } from '@/features/polymarket/utils/sportsEventTeams';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -52,12 +53,16 @@ const BET_CELLS_OVERLAY_TOP_NO_LEAGUE_HEADER = 47;
 type PredictionMarketEventCardProps = {
   event: PolymarketEvent;
   hideLeagueHeader?: boolean;
+  onOrderPress: OrderPressHandler;
+  onPress: CardPressHandler;
   width?: number;
 };
 
 export const PredictionMarketEventCard = memo(function PredictionMarketEventCard({
   event,
   hideLeagueHeader = false,
+  onOrderPress,
+  onPress,
   width = PREDICTION_MARKET_EVENT_CARD_WIDTH,
 }: PredictionMarketEventCardProps) {
   const { isDarkMode } = useColorMode();
@@ -71,12 +76,15 @@ export const PredictionMarketEventCard = memo(function PredictionMarketEventCard
   const cardBorderGradientColors = getPredictionEventCardBorderGradientColors(eventAccentColor, isDarkMode);
   const cardGradientColors = getPredictionEventCardGradientColors(eventAccentColor, isDarkMode);
   const handlePress = useCallback(() => {
+    onPress({ marketId: event.id, marketName: event.title, marketSlug: event.slug, marketSymbol: event.ticker });
     Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, { event, eventId: event.id });
-  }, [event]);
+  }, [event, onPress]);
 
   return (
     <View style={[styles.container, { width }]}>
-      {Platform.OS === 'android' ? <WidgetBetCellsOverlay event={event} hideLeagueHeader={hideLeagueHeader} rows={rows} /> : null}
+      {Platform.OS === 'android' ? (
+        <WidgetBetCellsOverlay event={event} hideLeagueHeader={hideLeagueHeader} rows={rows} onOrderPress={onOrderPress} />
+      ) : null}
       <ButtonPressAnimation onPress={handlePress} scaleTo={0.96} style={styles.flex} wrapperStyle={styles.flex}>
         <GradientBorderView
           backgroundColor={isDarkMode ? globalColors.grey100 : globalColors.white100}
@@ -132,6 +140,7 @@ export const PredictionMarketEventCard = memo(function PredictionMarketEventCard
             moneylineBet={rows.away.moneyline}
             compact={rows.away.isFallback}
             interactiveBetCells={Platform.OS === 'ios'}
+            onOrderPress={onOrderPress}
           />
           <InsetSeparator />
           <TeamRow
@@ -143,6 +152,7 @@ export const PredictionMarketEventCard = memo(function PredictionMarketEventCard
             moneylineBet={rows.home.moneyline}
             compact={rows.home.isFallback}
             interactiveBetCells={Platform.OS === 'ios'}
+            onOrderPress={onOrderPress}
           />
         </GradientBorderView>
       </ButtonPressAnimation>
@@ -171,6 +181,7 @@ const TeamRow = memo(function TeamRow({
   score,
   team,
   interactiveBetCells = true,
+  onOrderPress,
 }: {
   event: PolymarketEvent;
   compact?: boolean;
@@ -180,6 +191,7 @@ const TeamRow = memo(function TeamRow({
   moneylineBet?: BetCellData;
   score?: string;
   team?: PolymarketTeamInfo;
+  onOrderPress: PredictionMarketEventCardProps['onOrderPress'];
 }) {
   return (
     <View style={styles.teamRow}>
@@ -195,7 +207,14 @@ const TeamRow = memo(function TeamRow({
             {score ?? ''}
           </Text>
         ) : null}
-        <TeamBetCells event={event} compact={compact} interactive={interactiveBetCells} lineBet={lineBet} moneylineBet={moneylineBet} />
+        <TeamBetCells
+          event={event}
+          compact={compact}
+          interactive={interactiveBetCells}
+          lineBet={lineBet}
+          moneylineBet={moneylineBet}
+          onOrderPress={onOrderPress}
+        />
       </View>
     </View>
   );
@@ -205,18 +224,32 @@ const WidgetBetCellsOverlay = memo(function WidgetBetCellsOverlay({
   event,
   hideLeagueHeader,
   rows,
+  onOrderPress,
 }: {
   event: PolymarketEvent;
   hideLeagueHeader: boolean;
   rows: SportsEventRows;
+  onOrderPress: PredictionMarketEventCardProps['onOrderPress'];
 }) {
   return (
     <View
       pointerEvents="box-none"
       style={[styles.betCellsOverlay, { top: hideLeagueHeader ? BET_CELLS_OVERLAY_TOP_NO_LEAGUE_HEADER : BET_CELLS_OVERLAY_TOP }]}
     >
-      <TeamBetCells event={event} compact={rows.away.isFallback} lineBet={rows.away.line} moneylineBet={rows.away.moneyline} />
-      <TeamBetCells event={event} compact={rows.home.isFallback} lineBet={rows.home.line} moneylineBet={rows.home.moneyline} />
+      <TeamBetCells
+        event={event}
+        compact={rows.away.isFallback}
+        lineBet={rows.away.line}
+        moneylineBet={rows.away.moneyline}
+        onOrderPress={onOrderPress}
+      />
+      <TeamBetCells
+        event={event}
+        compact={rows.home.isFallback}
+        lineBet={rows.home.line}
+        moneylineBet={rows.home.moneyline}
+        onOrderPress={onOrderPress}
+      />
     </View>
   );
 });
@@ -227,12 +260,14 @@ const TeamBetCells = memo(function TeamBetCells({
   interactive = true,
   lineBet,
   moneylineBet,
+  onOrderPress,
 }: {
   event: PolymarketEvent;
   compact?: boolean;
   interactive?: boolean;
   lineBet?: BetCellData;
   moneylineBet?: BetCellData;
+  onOrderPress: PredictionMarketEventCardProps['onOrderPress'];
 }) {
   const { isDarkMode } = useColorMode();
   const lineColor = getSportsEventOutcomeCellColor(event.markets, lineBet?.outcomeTokenId, isDarkMode, event.teams);
@@ -250,12 +285,12 @@ const TeamBetCells = memo(function TeamBetCells({
   return (
     <View style={styles.betCells}>
       {lineBet ? (
-        <WidgetBetCell event={event} data={lineBet} backgroundColor={lineColor} variant="line" />
+        <WidgetBetCell onOrderPress={onOrderPress} event={event} data={lineBet} backgroundColor={lineColor} variant="line" />
       ) : compact ? null : (
         <View style={styles.lineCellSpacer} />
       )}
       {moneylineBet ? (
-        <WidgetBetCell event={event} data={moneylineBet} backgroundColor={moneylineColor} variant="moneyline" />
+        <WidgetBetCell event={event} data={moneylineBet} backgroundColor={moneylineColor} onOrderPress={onOrderPress} variant="moneyline" />
       ) : compact ? null : (
         <View style={styles.moneylineCellSpacer} />
       )}
@@ -267,16 +302,33 @@ const WidgetBetCell = memo(function WidgetBetCell({
   backgroundColor,
   data,
   event,
+  onOrderPress,
   variant,
 }: {
   backgroundColor?: string;
   data: BetCellData;
   event: PolymarketEvent;
+  onOrderPress: PredictionMarketEventCardProps['onOrderPress'];
   variant: 'line' | 'moneyline';
 }) {
   const tokenId = getPolymarketTokenId(data.outcomeTokenId, 'sell');
   const color = backgroundColor ?? '#717784';
-  const onPress = usePolymarketSportsBetCellPress({ event, outcomeTokenId: data.outcomeTokenId });
+  const onResolvedOutcomePress = useCallback(
+    (outcomeInfo: SportsEventOutcomeInfo) => {
+      onOrderPress({
+        marketId: outcomeInfo.market.id,
+        marketName: outcomeInfo.market.question,
+        marketSlug: outcomeInfo.market.slug,
+        outcome: outcomeInfo.outcome,
+      });
+    },
+    [onOrderPress]
+  );
+  const onPress = usePolymarketSportsBetCellPress({
+    event,
+    outcomeTokenId: data.outcomeTokenId,
+    onResolvedOutcomePress,
+  });
   const isLine = variant === 'line';
   const buttonStyle = isLine ? styles.lineCellButton : styles.moneylineCellButton;
   const cellStyle = isLine

--- a/src/features/discover/components/markets/cards/PredictionMarketTileCard.tsx
+++ b/src/features/discover/components/markets/cards/PredictionMarketTileCard.tsx
@@ -9,6 +9,7 @@ import { GradientBorderView } from '@/components/gradient-border/GradientBorderV
 import ImgixImage from '@/components/images/ImgixImage';
 import { LiveTokenText } from '@/components/live-token-text/LiveTokenText';
 import { globalColors, Text, useColorMode } from '@/design-system';
+import { type CardPressHandler, type OrderPressHandler } from '@/features/discover/types/sectionLayout';
 import { DOWN_ARROW, UP_ARROW } from '@/features/perps/constants';
 import { type PolymarketEvent, type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
 import { getOutcomeColor } from '@/features/polymarket/utils/getMarketColor';
@@ -74,6 +75,8 @@ const ODDS_PILL_OVERLAY_BOTTOM = 2 * BORDER_WIDTH + CONTENT_PADDING_BOTTOM + (OU
 
 type PredictionMarketTileCardProps = {
   event: PolymarketEvent;
+  onOrderPress: OrderPressHandler;
+  onPress: CardPressHandler;
 };
 
 type OutcomeRowData = {
@@ -84,7 +87,11 @@ type OutcomeRowData = {
   tokenId: string;
 };
 
-export const PredictionMarketTileCard = memo(function PredictionMarketTileCard({ event }: PredictionMarketTileCardProps) {
+export const PredictionMarketTileCard = memo(function PredictionMarketTileCard({
+  event,
+  onOrderPress,
+  onPress,
+}: PredictionMarketTileCardProps) {
   const { isDarkMode } = useColorMode();
   const eventColor = useMemo(() => getTileAccentColor(event, isDarkMode), [event, isDarkMode]);
   const rows = useMemo(() => getOutcomeRows(event), [event]);
@@ -111,15 +118,15 @@ export const PredictionMarketTileCard = memo(function PredictionMarketTileCard({
         : ([opacity(eventColor, 0.06), opacity(eventColor, 0)] as const),
     [colorPalette.opacity0, colorPalette.opacity24, eventColor, isDarkMode]
   );
-
   const handlePress = useCallback(() => {
+    onPress({ marketId: event.id, marketName: event.title, marketSlug: event.slug, marketSymbol: event.ticker });
     Navigation.handleAction(Routes.POLYMARKET_EVENT_SCREEN, { event, eventId: event.id });
-  }, [event]);
+  }, [event, onPress]);
 
   return (
     <View style={styles.container}>
       {Platform.OS === 'android' ? (
-        <AndroidOddsPillsOverlay event={event} eventColor={eventColor} isDarkMode={isDarkMode} rows={rows} />
+        <AndroidOddsPillsOverlay event={event} eventColor={eventColor} isDarkMode={isDarkMode} onOrderPress={onOrderPress} rows={rows} />
       ) : null}
       <ButtonPressAnimation onPress={handlePress} scaleTo={0.96} style={styles.flex} wrapperStyle={styles.flex}>
         <View style={[styles.cardShadow, !isDarkMode && styles.cardShadowLight]}>
@@ -171,6 +178,7 @@ export const PredictionMarketTileCard = memo(function PredictionMarketTileCard({
                     isDarkMode={isDarkMode}
                     key={`${row.market.id}:${row.outcomeIndex}`}
                     row={row}
+                    onOrderPress={onOrderPress}
                   />
                 ))}
               </View>
@@ -187,11 +195,13 @@ const OutcomeRow = memo(function OutcomeRow({
   eventColor,
   isDarkMode,
   row,
+  onOrderPress,
 }: {
   event: PolymarketEvent;
   eventColor: string;
   isDarkMode: boolean;
   row: OutcomeRowData;
+  onOrderPress: PredictionMarketTileCardProps['onOrderPress'];
 }) {
   return (
     <GradientBorderView
@@ -220,7 +230,7 @@ const OutcomeRow = memo(function OutcomeRow({
         {Platform.OS === 'android' ? (
           <View style={styles.oddsButton} />
         ) : (
-          <OutcomeOddsPill event={event} eventColor={eventColor} isDarkMode={isDarkMode} row={row} />
+          <OutcomeOddsPill event={event} eventColor={eventColor} isDarkMode={isDarkMode} onOrderPress={onOrderPress} row={row} />
         )}
         <Text align="left" color="label" numberOfLines={1} size="17pt" style={styles.outcomeTitle} weight="bold">
           {row.title}
@@ -234,11 +244,13 @@ const OutcomeOddsPill = memo(function OutcomeOddsPill({
   event,
   eventColor,
   isDarkMode,
+  onOrderPress,
   row,
 }: {
   event: PolymarketEvent;
   eventColor: string;
   isDarkMode: boolean;
+  onOrderPress: PredictionMarketTileCardProps['onOrderPress'];
   row: OutcomeRowData;
 }) {
   const outcomeColor = getOutcomeColor({
@@ -250,6 +262,12 @@ const OutcomeOddsPill = memo(function OutcomeOddsPill({
   });
 
   const onPress = useCallback(() => {
+    onOrderPress({
+      marketId: row.market.id,
+      marketName: row.market.question,
+      marketSlug: row.market.slug,
+      outcome: row.title,
+    });
     Navigation.handleAction(Routes.POLYMARKET_NEW_POSITION_SHEET, {
       market: row.market,
       event,
@@ -257,7 +275,7 @@ const OutcomeOddsPill = memo(function OutcomeOddsPill({
       outcomeColor,
       fromRoute: Routes.POLYMARKET_BROWSE_EVENTS_SCREEN,
     });
-  }, [event, outcomeColor, row.market, row.outcomeIndex]);
+  }, [event, onOrderPress, outcomeColor, row.market, row.outcomeIndex, row.title]);
 
   return (
     <ButtonPressAnimation onPress={onPress} scaleTo={0.92} style={styles.oddsButton}>
@@ -296,11 +314,13 @@ const AndroidOddsPillsOverlay = memo(function AndroidOddsPillsOverlay({
   event,
   eventColor,
   isDarkMode,
+  onOrderPress,
   rows,
 }: {
   event: PolymarketEvent;
   eventColor: string;
   isDarkMode: boolean;
+  onOrderPress: PredictionMarketTileCardProps['onOrderPress'];
   rows: OutcomeRowData[];
 }) {
   return (
@@ -311,7 +331,7 @@ const AndroidOddsPillsOverlay = memo(function AndroidOddsPillsOverlay({
           pointerEvents="box-none"
           style={[styles.oddsPillSlot, { bottom: ODDS_PILL_OVERLAY_BOTTOM + (rows.length - 1 - index) * OUTCOME_ROW_PITCH }]}
         >
-          <OutcomeOddsPill event={event} eventColor={eventColor} isDarkMode={isDarkMode} row={row} />
+          <OutcomeOddsPill event={event} eventColor={eventColor} isDarkMode={isDarkMode} onOrderPress={onOrderPress} row={row} />
         </View>
       ))}
     </View>

--- a/src/features/discover/components/markets/layouts/MarketCarousel.tsx
+++ b/src/features/discover/components/markets/layouts/MarketCarousel.tsx
@@ -1,16 +1,33 @@
-import React, { Fragment, useCallback, useMemo, type ReactNode } from 'react';
+import React, { Fragment, useCallback, useEffect, useMemo, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { FlatList } from 'react-native-gesture-handler';
+import { useDebouncedCallback } from 'use-debounce';
 
+import { analytics } from '@/analytics';
+import { event } from '@/analytics/event';
 import { Box } from '@/design-system';
 import { SectionHeader } from '@/features/discover/components/markets/layouts/SectionHeader';
-import { type PlacementItem } from '@/features/placements/types';
+import { type CardPressHandler, type CarouselSectionDescriptor, type OrderPressHandler } from '@/features/discover/types/sectionLayout';
+import { trackPlacementInteraction, trackSurfaceInteraction } from '@/features/placements/engagement/trackInteraction';
+import { type SurfaceId, type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { type Placement, type PlacementItem } from '@/features/placements/types';
+import { time } from '@/framework/core/utils/time';
 
 import { computeSnapToOffsets } from './carouselLayout';
 
 const HORIZONTAL_PADDING = 12;
 const CARD_GAP = HORIZONTAL_PADDING;
+const SCROLL_DEBOUNCE_MS = time.ms(500);
+const SCROLL_DEBOUNCE_OPTIONS = Object.freeze({ leading: false, trailing: true });
+
+function noopCardPress(): undefined {
+  return undefined;
+}
+
+function noopOrderPress(): undefined {
+  return undefined;
+}
 
 type MarketCarouselProps<T extends PlacementItem> = {
   data: T[];
@@ -23,11 +40,14 @@ type MarketCarouselProps<T extends PlacementItem> = {
   leadingAccessory?: ReactNode;
   loading?: boolean;
   onPress?: () => void;
-  renderItem: (item: T, width: number) => ReactNode;
+  placement?: Placement;
+  renderItem: CarouselSectionDescriptor<T>['renderItem'];
   renderSkeleton: () => ReactNode;
   showHeaderCaret?: boolean;
   singleItemWidth?: number;
   skeletonCount?: number;
+  section: SurfaceLeaf;
+  surfaceId: SurfaceId;
   title: string;
 };
 
@@ -42,11 +62,14 @@ export function MarketCarousel<T extends PlacementItem>({
   leadingAccessory,
   loading,
   onPress,
+  placement,
   renderItem,
   renderSkeleton,
+  section,
   showHeaderCaret,
   singleItemWidth,
   skeletonCount = 5,
+  surfaceId,
   title,
 }: MarketCarouselProps<T>) {
   const showSkeletons = loading && data.length === 0;
@@ -61,6 +84,47 @@ export function MarketCarousel<T extends PlacementItem>({
 
   const renderCarouselItem = useCallback(
     ({ item, index }: { item: T; index: number }) => {
+      const onCardPress: CardPressHandler = placement
+        ? metadata => {
+            analytics.track(event.discoverCardPressed, {
+              placementId: placement.id,
+              placementSource: placement.source,
+              placementTitle: title,
+              itemOrder: index,
+              itemId: item.id,
+              marketId: metadata.marketId,
+              marketName: metadata.marketName,
+              marketSlug: metadata.marketSlug,
+              marketSymbol: metadata.marketSymbol,
+              marketType: placement.source,
+            });
+            trackPlacementInteraction({
+              display: section.display,
+              id: placement.id,
+              interactionType: 'card_press',
+              itemId: item.id,
+              itemOrder: index,
+              sectionId: section.id,
+              sectionTitle: title,
+              source: placement.source,
+              surfaceId,
+              type: placement.type,
+              version: placement.version,
+            });
+          }
+        : noopCardPress;
+      const onOrderPress: OrderPressHandler = placement
+        ? order => {
+            analytics.track(event.discoverPredictionOrderPressed, {
+              placementId: placement.id,
+              itemId: item.id,
+              marketId: order.marketId,
+              marketName: order.marketName,
+              marketSlug: order.marketSlug,
+              outcome: order.outcome,
+            });
+          }
+        : noopOrderPress;
       const width = itemWidths[index] ?? defaultItemWidth;
 
       return (
@@ -72,12 +136,32 @@ export function MarketCarousel<T extends PlacementItem>({
             width,
           }}
         >
-          {renderItem(item, width)}
+          {renderItem(item, width, onCardPress, onOrderPress)}
         </View>
       );
     },
-    [defaultItemWidth, itemHeight, itemVerticalBleed, itemWidths, renderItem]
+    [defaultItemWidth, itemHeight, itemVerticalBleed, itemWidths, placement, renderItem, section.display, section.id, surfaceId, title]
   );
+
+  const onScrollSettle = useDebouncedCallback(
+    () => {
+      analytics.track(event.discoverCarouselScrolled, {
+        display: section.display,
+        sectionId: section.id,
+      });
+
+      trackSurfaceInteraction({
+        display: section.display,
+        id: surfaceId,
+        sectionId: section.id,
+        sectionTitle: title,
+      });
+    },
+    SCROLL_DEBOUNCE_MS,
+    SCROLL_DEBOUNCE_OPTIONS
+  );
+
+  useEffect(() => () => onScrollSettle.flush(), [onScrollSettle]);
 
   if (!showSkeletons && data.length === 0) return null;
 
@@ -110,6 +194,7 @@ export function MarketCarousel<T extends PlacementItem>({
             snapToAlignment="start"
             renderItem={renderCarouselItem}
             keyExtractor={item => item.id}
+            onMomentumScrollEnd={onScrollSettle}
             initialNumToRender={6}
             windowSize={8}
           />

--- a/src/features/discover/components/markets/layouts/MarketCarousel.tsx
+++ b/src/features/discover/components/markets/layouts/MarketCarousel.tsx
@@ -96,7 +96,7 @@ export function MarketCarousel<T extends PlacementItem>({
               marketName: metadata.marketName,
               marketSlug: metadata.marketSlug,
               marketSymbol: metadata.marketSymbol,
-              marketType: placement.source,
+              marketType: placement.type,
             });
             trackPlacementInteraction({
               display: section.display,

--- a/src/features/discover/components/markets/layouts/MarketCarousel.tsx
+++ b/src/features/discover/components/markets/layouts/MarketCarousel.tsx
@@ -21,11 +21,7 @@ const CARD_GAP = HORIZONTAL_PADDING;
 const SCROLL_DEBOUNCE_MS = time.ms(500);
 const SCROLL_DEBOUNCE_OPTIONS = Object.freeze({ leading: false, trailing: true });
 
-function noopCardPress(): undefined {
-  return undefined;
-}
-
-function noopOrderPress(): undefined {
+function noopPress(): undefined {
   return undefined;
 }
 
@@ -112,7 +108,7 @@ export function MarketCarousel<T extends PlacementItem>({
               version: placement.version,
             });
           }
-        : noopCardPress;
+        : noopPress;
       const onOrderPress: OrderPressHandler = placement
         ? order => {
             analytics.track(event.discoverPredictionOrderPressed, {
@@ -124,7 +120,7 @@ export function MarketCarousel<T extends PlacementItem>({
               outcome: order.outcome,
             });
           }
-        : noopOrderPress;
+        : noopPress;
       const width = itemWidths[index] ?? defaultItemWidth;
 
       return (

--- a/src/features/discover/components/markets/layouts/MarketGrid.tsx
+++ b/src/features/discover/components/markets/layouts/MarketGrid.tsx
@@ -89,7 +89,7 @@ export function MarketGrid<T extends PlacementItem>({
                       marketName: metadata.marketName,
                       marketSlug: metadata.marketSlug,
                       marketSymbol: metadata.marketSymbol,
-                      marketType: placement.source,
+                      marketType: placement.type,
                     });
                     trackPlacementInteraction({
                       display: section.display,

--- a/src/features/discover/components/markets/layouts/MarketGrid.tsx
+++ b/src/features/discover/components/markets/layouts/MarketGrid.tsx
@@ -1,13 +1,26 @@
 import React, { type ReactNode } from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 
+import { analytics } from '@/analytics';
+import { event } from '@/analytics/event';
 import { Box } from '@/design-system';
 import { SectionHeader } from '@/features/discover/components/markets/layouts/SectionHeader';
-import { type PlacementItem } from '@/features/placements/types';
+import { type CardPressHandler, type GridSectionDescriptor, type OrderPressHandler } from '@/features/discover/types/sectionLayout';
+import { trackPlacementInteraction } from '@/features/placements/engagement/trackInteraction';
+import { type SurfaceId, type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { type Placement, type PlacementItem } from '@/features/placements/types';
 import { Grid } from '@/screens/token-launcher/components/Grid';
 
 const GRID_COLUMNS = 2;
 const GRID_SPACING = 12;
+
+function noopCardPress(): undefined {
+  return undefined;
+}
+
+function noopOrderPress(): undefined {
+  return undefined;
+}
 
 type MarketGridProps<T extends PlacementItem> = {
   data: T[];
@@ -16,10 +29,13 @@ type MarketGridProps<T extends PlacementItem> = {
   leadingAccessory?: ReactNode;
   loading?: boolean;
   onPress?: () => void;
-  renderItem: (item: T, cellWidth: number) => ReactNode;
+  placement?: Placement;
+  renderItem: GridSectionDescriptor<T>['renderItem'];
   renderSkeleton: (cellWidth: number) => ReactNode;
+  section: SurfaceLeaf;
   showHeaderCaret?: boolean;
   skeletonCount?: number;
+  surfaceId: SurfaceId;
   title: string;
 };
 
@@ -30,10 +46,13 @@ export function MarketGrid<T extends PlacementItem>({
   leadingAccessory,
   loading,
   onPress,
+  placement,
   renderItem,
   renderSkeleton,
+  section,
   showHeaderCaret,
   skeletonCount = GRID_COLUMNS * 2,
+  surfaceId,
   title,
 }: MarketGridProps<T>) {
   const { width: screenWidth } = useWindowDimensions();
@@ -57,11 +76,54 @@ export function MarketGrid<T extends PlacementItem>({
           </Grid>
         ) : (
           <Grid columns={GRID_COLUMNS} spacing={GRID_SPACING}>
-            {data.map(item => (
-              <View key={item.id} style={{ height: itemHeight }}>
-                {renderItem(item, cellWidth)}
-              </View>
-            ))}
+            {data.map((item, index) => {
+              const onCardPress: CardPressHandler = placement
+                ? metadata => {
+                    analytics.track(event.discoverCardPressed, {
+                      placementId: placement.id,
+                      placementSource: placement.source,
+                      placementTitle: title,
+                      itemOrder: index,
+                      itemId: item.id,
+                      marketId: metadata.marketId,
+                      marketName: metadata.marketName,
+                      marketSlug: metadata.marketSlug,
+                      marketSymbol: metadata.marketSymbol,
+                      marketType: placement.source,
+                    });
+                    trackPlacementInteraction({
+                      display: section.display,
+                      id: placement.id,
+                      interactionType: 'card_press',
+                      itemId: item.id,
+                      itemOrder: index,
+                      sectionId: section.id,
+                      sectionTitle: title,
+                      source: placement.source,
+                      surfaceId,
+                      type: placement.type,
+                      version: placement.version,
+                    });
+                  }
+                : noopCardPress;
+              const onOrderPress: OrderPressHandler = placement
+                ? order => {
+                    analytics.track(event.discoverPredictionOrderPressed, {
+                      placementId: placement.id,
+                      itemId: item.id,
+                      marketId: order.marketId,
+                      marketName: order.marketName,
+                      marketSlug: order.marketSlug,
+                      outcome: order.outcome,
+                    });
+                  }
+                : noopOrderPress;
+              return (
+                <View key={item.id} style={{ height: itemHeight }}>
+                  {renderItem(item, cellWidth, onCardPress, onOrderPress)}
+                </View>
+              );
+            })}
           </Grid>
         )}
       </View>

--- a/src/features/discover/components/markets/layouts/MarketGrid.tsx
+++ b/src/features/discover/components/markets/layouts/MarketGrid.tsx
@@ -14,11 +14,7 @@ import { Grid } from '@/screens/token-launcher/components/Grid';
 const GRID_COLUMNS = 2;
 const GRID_SPACING = 12;
 
-function noopCardPress(): undefined {
-  return undefined;
-}
-
-function noopOrderPress(): undefined {
+function noopPress(): undefined {
   return undefined;
 }
 
@@ -105,7 +101,7 @@ export function MarketGrid<T extends PlacementItem>({
                       version: placement.version,
                     });
                   }
-                : noopCardPress;
+                : noopPress;
               const onOrderPress: OrderPressHandler = placement
                 ? order => {
                     analytics.track(event.discoverPredictionOrderPressed, {
@@ -117,7 +113,7 @@ export function MarketGrid<T extends PlacementItem>({
                       outcome: order.outcome,
                     });
                   }
-                : noopOrderPress;
+                : noopPress;
               return (
                 <View key={item.id} style={{ height: itemHeight }}>
                   {renderItem(item, cellWidth, onCardPress, onOrderPress)}

--- a/src/features/discover/components/markets/layouts/MarketList.tsx
+++ b/src/features/discover/components/markets/layouts/MarketList.tsx
@@ -12,11 +12,7 @@ import { type Placement, type PlacementItem } from '@/features/placements/types'
 
 import { ShowMoreButton, ShowMoreCellEnterAnimation } from './ShowMoreButton';
 
-function noopCardPress(): undefined {
-  return undefined;
-}
-
-function noopOrderPress(): undefined {
+function noopPress(): undefined {
   return undefined;
 }
 
@@ -104,7 +100,7 @@ export function MarketList<T extends PlacementItem>({
                       version: placement.version,
                     });
                   }
-                : noopCardPress;
+                : noopPress;
               const onOrderPress: OrderPressHandler = placement
                 ? order => {
                     analytics.track(event.discoverPredictionOrderPressed, {
@@ -116,7 +112,7 @@ export function MarketList<T extends PlacementItem>({
                       outcome: order.outcome,
                     });
                   }
-                : noopOrderPress;
+                : noopPress;
               const listItem = <View>{renderItem(item, onCardPress, onOrderPress)}</View>;
 
               if (!hasInitialLimit || !isExpanded || index < (initialVisibleItemCount ?? 0)) {

--- a/src/features/discover/components/markets/layouts/MarketList.tsx
+++ b/src/features/discover/components/markets/layouts/MarketList.tsx
@@ -1,11 +1,24 @@
 import { Fragment, useState, type ReactNode } from 'react';
 import { View } from 'react-native';
 
+import { analytics } from '@/analytics';
+import { event } from '@/analytics/event';
 import { Box } from '@/design-system';
 import { SectionHeader } from '@/features/discover/components/markets/layouts/SectionHeader';
-import { type PlacementItem } from '@/features/placements/types';
+import { type CardPressHandler, type ListSectionDescriptor, type OrderPressHandler } from '@/features/discover/types/sectionLayout';
+import { trackPlacementInteraction } from '@/features/placements/engagement/trackInteraction';
+import { type SurfaceId, type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { type Placement, type PlacementItem } from '@/features/placements/types';
 
 import { ShowMoreButton, ShowMoreCellEnterAnimation } from './ShowMoreButton';
+
+function noopCardPress(): undefined {
+  return undefined;
+}
+
+function noopOrderPress(): undefined {
+  return undefined;
+}
 
 type MarketListProps<T extends PlacementItem> = {
   data: T[];
@@ -14,9 +27,12 @@ type MarketListProps<T extends PlacementItem> = {
   leadingAccessory?: ReactNode;
   loading?: boolean;
   onPress?: () => void;
-  renderItem: (item: T) => ReactNode;
+  placement?: Placement;
+  renderItem: ListSectionDescriptor<T>['renderItem'];
   renderSkeleton: () => ReactNode;
+  section: SurfaceLeaf;
   showHeaderCaret?: boolean;
+  surfaceId: SurfaceId;
   title: string;
 };
 
@@ -36,9 +52,12 @@ export function MarketList<T extends PlacementItem>({
   leadingAccessory,
   loading,
   onPress,
+  placement,
   renderItem,
   renderSkeleton,
+  section,
   showHeaderCaret,
+  surfaceId,
   title,
 }: MarketListProps<T>) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -57,7 +76,48 @@ export function MarketList<T extends PlacementItem>({
         {showSkeletons
           ? Array.from({ length: skeletonItemCount }).map((_, index) => <SkeletonSlot key={index} render={renderSkeleton} />)
           : visibleItems.map((item, index) => {
-              const listItem = <View>{renderItem(item)}</View>;
+              const onCardPress: CardPressHandler = placement
+                ? metadata => {
+                    analytics.track(event.discoverCardPressed, {
+                      placementId: placement.id,
+                      placementSource: placement.source,
+                      placementTitle: title,
+                      itemOrder: index,
+                      itemId: item.id,
+                      marketId: metadata.marketId,
+                      marketName: metadata.marketName,
+                      marketSlug: metadata.marketSlug,
+                      marketSymbol: metadata.marketSymbol,
+                      marketType: placement.source,
+                    });
+                    trackPlacementInteraction({
+                      display: section.display,
+                      id: placement.id,
+                      interactionType: 'card_press',
+                      itemId: item.id,
+                      itemOrder: index,
+                      sectionId: section.id,
+                      sectionTitle: title,
+                      source: placement.source,
+                      surfaceId,
+                      type: placement.type,
+                      version: placement.version,
+                    });
+                  }
+                : noopCardPress;
+              const onOrderPress: OrderPressHandler = placement
+                ? order => {
+                    analytics.track(event.discoverPredictionOrderPressed, {
+                      placementId: placement.id,
+                      itemId: item.id,
+                      marketId: order.marketId,
+                      marketName: order.marketName,
+                      marketSlug: order.marketSlug,
+                      outcome: order.outcome,
+                    });
+                  }
+                : noopOrderPress;
+              const listItem = <View>{renderItem(item, onCardPress, onOrderPress)}</View>;
 
               if (!hasInitialLimit || !isExpanded || index < (initialVisibleItemCount ?? 0)) {
                 return <Fragment key={item.id}>{listItem}</Fragment>;

--- a/src/features/discover/components/markets/layouts/MarketList.tsx
+++ b/src/features/discover/components/markets/layouts/MarketList.tsx
@@ -88,7 +88,7 @@ export function MarketList<T extends PlacementItem>({
                       marketName: metadata.marketName,
                       marketSlug: metadata.marketSlug,
                       marketSymbol: metadata.marketSymbol,
-                      marketType: placement.source,
+                      marketType: placement.type,
                     });
                     trackPlacementInteraction({
                       display: section.display,

--- a/src/features/discover/types/sectionLayout.ts
+++ b/src/features/discover/types/sectionLayout.ts
@@ -1,8 +1,18 @@
 import { type ReactNode } from 'react';
 
 import { type MARKET_DISPLAY_VALUES } from '@/features/placements/surfaces/constants';
-import { type Display, type SurfaceLeaf } from '@/features/placements/surfaces/types';
-import { type PlacementItem } from '@/features/placements/types';
+import { type Display, type SurfaceId, type SurfaceLeaf } from '@/features/placements/surfaces/types';
+import { type Placement, type PlacementItem } from '@/features/placements/types';
+import { type PolymarketMarket } from '@/features/polymarket/types/polymarket-event';
+
+export type CardPressHandler = (metadata: { marketId: string; marketName: string; marketSlug?: string; marketSymbol?: string }) => void;
+
+export type OrderPressHandler = (order: {
+  marketId: PolymarketMarket['id'];
+  marketName: PolymarketMarket['question'];
+  marketSlug: PolymarketMarket['slug'];
+  outcome: PolymarketMarket['outcomes'][number];
+}) => void;
 
 export type CarouselSectionDescriptor<T extends PlacementItem> = {
   layout: 'carousel';
@@ -11,7 +21,7 @@ export type CarouselSectionDescriptor<T extends PlacementItem> = {
   itemHeight: number;
   itemVerticalBleed?: number;
   itemWidth: number;
-  renderItem: (item: T, width: number) => ReactNode;
+  renderItem: (item: T, width: number, onPress: CardPressHandler, onOrderPress: OrderPressHandler) => ReactNode;
   renderSkeleton: () => ReactNode;
   showHeaderCaret?: (surface: SurfaceLeaf) => boolean;
   singleItemWidth?: number;
@@ -20,14 +30,14 @@ export type CarouselSectionDescriptor<T extends PlacementItem> = {
 export type GridSectionDescriptor<T extends PlacementItem> = {
   layout: 'grid';
   itemHeight: number;
-  renderItem: (item: T, width: number) => ReactNode;
+  renderItem: (item: T, width: number, onPress: CardPressHandler, onOrderPress: OrderPressHandler) => ReactNode;
   renderSkeleton: (width: number) => ReactNode;
   showHeaderCaret?: (surface: SurfaceLeaf) => boolean;
 };
 
 export type ListSectionDescriptor<T extends PlacementItem> = {
   layout: 'list';
-  renderItem: (item: T) => ReactNode;
+  renderItem: (item: T, onPress: CardPressHandler, onOrderPress: OrderPressHandler) => ReactNode;
   renderSkeleton: () => ReactNode;
 };
 
@@ -44,6 +54,8 @@ export type SectionLayoutProps<T extends PlacementItem> = {
   headerCount?: number;
   leadingAccessory?: ReactNode;
   loading: boolean;
-  onPressSeeAll?: () => void;
-  surface: SurfaceLeaf;
+  onPress?: () => void;
+  placement?: Placement;
+  section: SurfaceLeaf;
+  surfaceId: SurfaceId;
 };

--- a/src/features/placements/types.ts
+++ b/src/features/placements/types.ts
@@ -20,12 +20,3 @@ export type Placement = {
   items: PlacementItem[];
   updatedAt?: string;
 };
-
-// ============ Analytics ====================================================== //
-
-export type PlacementItemAnalyticsMetadata = {
-  marketId?: string;
-  marketName?: string;
-  marketSlug?: string;
-  marketSymbol?: string;
-};


### PR DESCRIPTION
## What changed
- Section layouts own analytics emission — card press, "see all" press, tab press, and carousel scroll are tracked from the layout, not individual cards.
- Cards report market metadata up through a shared `CardPressHandler` (predictions via an `OrderPressHandler`) passed into each `renderItem`.
- The layout contract moves from `onPressSeeAll` + `surface` to `onPress` + `placement` + `section` + `surfaceId`.
- Carousel scroll tracking is debounced (500ms trailing), flushed on unmount.
- Sections with no placement use no-op handlers, so tracking only fires for placement-backed content.
- Retires the unused `PlacementItemAnalyticsMetadata` type; tightens `surfaceId` props to `SurfaceId`.
