### PR TITLE
feat(ramp): add Add Cash screen + routing based on user's ramp status

### DIFF
--- a/e2e/flows/cash/AddCash.yaml
+++ b/e2e/flows/cash/AddCash.yaml
@@ -1,0 +1,32 @@
+appId: ${APP_ID}
+tags:
+  - cash
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- runFlow: ../../utils/ImportWalletWithKey.yaml
+- runFlow:
+    file: ../../utils/SetExperimentalFlag.yaml
+    env:
+      FLAG: Cash
+      VALUE: 'true'
+- runFlow:
+    file: ../../utils/SetCashDepositSetupStatus.yaml
+    env:
+      STATUS: ready
+# A ready member skips the intro panel and lands straight on the Add Cash sheet.
+- tapOn:
+    id: buy-button
+- assertVisible:
+    id: cash-deposit-add-cash-add-from
+- assertVisible:
+    id: cash-deposit-add-cash-amount-50
+- assertVisible:
+    id: cash-deposit-add-cash-hold-to-add
+- assertNotVisible:
+    id: cash-deposit-intro-set-up-account

--- a/e2e/utils/SetCashDepositSetupStatus.yaml
+++ b/e2e/utils/SetCashDepositSetupStatus.yaml
@@ -1,0 +1,9 @@
+appId: ${APP_ID}
+---
+- openLink: rainbow://e2e/setCashDepositSetupStatus?status=${STATUS}
+- runFlow:
+    when:
+      visible: 'Open in .*'
+      platform: iOS
+    commands:
+      - tapOn: 'Open'

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -119,7 +119,8 @@ export const event = {
   pairHwWalletNavEntered: 'pair_hw_wallet_nav.entered',
   pairHwWalletNavExited: 'pair_hw_wallet_nav.exited',
   rewardsViewedSheet: 'rewards.viewed_sheet',
-  cashDepositIntroViewed: 'cash_deposit_intro_viewed',
+  cashDepositIntroViewed: 'cash.deposit_intro_viewed',
+  addCashViewed: 'cash.add_cash_viewed',
   rewardsPressedPendingEarningsCard: 'rewards.pressed_pending_earnings_card',
   rewardsPressedAvailableCard: 'rewards.pressed_available_card',
   rewardsPressedPositionCard: 'rewards.pressed_position_card',
@@ -525,6 +526,7 @@ export type EventProperties = {
   };
   [event.rewardsViewedSheet]: undefined;
   [event.cashDepositIntroViewed]: undefined;
+  [event.addCashViewed]: undefined;
   [event.rewardsPressedPendingEarningsCard]: undefined;
   [event.rewardsPressedAvailableCard]: undefined;
   [event.rewardsPressedPositionCard]: { position: number };

--- a/src/components/TestDeeplinkHandler.tsx
+++ b/src/components/TestDeeplinkHandler.tsx
@@ -5,6 +5,8 @@ import URL from 'url-parse';
 
 import { type ExperimentalConfigKey } from '@/config/experimental';
 import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
+import { type CashDepositSetupStatus } from '@/features/cash/stores/cashDepositSetupStatus';
+import { useCashDepositSetupStore } from '@/features/cash/stores/cashDepositSetupStore';
 import { savePIN } from '@/features/local-auth/pinAuthentication';
 import { logger } from '@/logger';
 import Navigation from '@/navigation/Navigation';
@@ -38,6 +40,9 @@ export function TestDeeplinkHandler() {
           break;
         case 'setExperimentalFlag':
           useExperimentalConfigStore.getState().setFlag(query.flag as ExperimentalConfigKey, query.value === 'true');
+          break;
+        case 'setCashDepositSetupStatus':
+          useCashDepositSetupStore.getState().setStatus(query.status as CashDepositSetupStatus);
           break;
         default:
           logger.debug(`[TestDeeplinkHandler]: unknown path`, { url });

--- a/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
+++ b/src/components/asset-list/RecyclerAssetList2/profile-header/ProfileActionButtonsRow.tsx
@@ -9,8 +9,7 @@ import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { CopyFloatingEmojis } from '@/components/floating-emojis';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
 import { AccentColorProvider, Box, Column, Columns, Inset, Stack, Text, useColorMode } from '@/design-system';
-import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
-import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import { watchingAlert } from '@/features/wallet/utils/watchingAlert';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
 import * as i18n from '@/languages';
@@ -130,7 +129,7 @@ function ActionButton({ children, icon, onPress, testID }: { children: string; i
 }
 
 function BuyButton() {
-  const isCashEnabled = useIsCashEnabled();
+  const { route: addCashRoute, isCashEnabled } = useAddCashRoute();
   const handlePress = React.useCallback(() => {
     if (getIsDamagedWallet()) {
       Navigation.handleAction(Routes.WALLET_ERROR_SHEET);
@@ -139,8 +138,8 @@ function BuyButton() {
 
     analytics.track(analytics.event.navigationAddCash, { category: 'home screen' });
 
-    Navigation.handleAction(getAddCashRoute(isCashEnabled));
-  }, [isCashEnabled]);
+    Navigation.handleAction(addCashRoute);
+  }, [addCashRoute]);
 
   return (
     <Box>

--- a/src/components/cards/EthCard.tsx
+++ b/src/components/cards/EthCard.tsx
@@ -7,8 +7,7 @@ import { analytics } from '@/analytics';
 import { ChainImage } from '@/components/coin-icon/ChainImage';
 import { ExtremeLabels } from '@/components/value-chart/ExtremeLabels';
 import { AccentColorProvider, Bleed, Box, Inline, Stack, Text } from '@/design-system';
-import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
-import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useChartThrottledPoints from '@/hooks/charts/useChartThrottledPoints';
 import { useAccountAccentColor } from '@/hooks/useAccountAccentColor';
@@ -56,7 +55,7 @@ export const EthCard = () => {
 
   const { loaded: accentColorLoaded } = useAccountAccentColor();
   const { name: routeName } = useRoute();
-  const isCashEnabled = useIsCashEnabled();
+  const { route: addCashRoute, isCashEnabled } = useAddCashRoute();
   const cardType = 'stretch';
 
   const handlePressBuy = useCallback(
@@ -70,14 +69,14 @@ export const EthCard = () => {
         return;
       }
 
-      navigate(getAddCashRoute(isCashEnabled));
+      navigate(addCashRoute);
 
       analytics.track(analytics.event.buyButtonPressed, {
         componentName: 'EthCard',
         routeName,
       });
     },
-    [isCashEnabled, navigate, routeName]
+    [addCashRoute, navigate, routeName]
   );
 
   const handleAssetPress = useCallback(() => {

--- a/src/components/sheet/sheet-action-buttons/BuyActionButton.tsx
+++ b/src/components/sheet/sheet-action-buttons/BuyActionButton.tsx
@@ -4,8 +4,7 @@ import { useRoute } from '@react-navigation/native';
 
 import { analytics } from '@/analytics';
 import { Text } from '@/design-system';
-import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
-import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadOnlyWallets';
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
@@ -20,7 +19,7 @@ function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) 
   const color = givenColor || colors.paleBlue;
   const navigate = useNavigationForNonReadOnlyWallets();
   const { name: routeName } = useRoute();
-  const isCashEnabled = useIsCashEnabled();
+  const { route: addCashRoute, isCashEnabled } = useAddCashRoute();
 
   const handlePress = useCallback(() => {
     if (getIsDamagedWallet()) {
@@ -28,13 +27,13 @@ function BuyActionButton({ color: givenColor, ...props }: BuyActionButtonProps) 
       return;
     }
 
-    navigate(getAddCashRoute(isCashEnabled));
+    navigate(addCashRoute);
 
     analytics.track(analytics.event.buyButtonPressed, {
       componentName: 'BuyActionButton',
       routeName,
     });
-  }, [isCashEnabled, navigate, routeName]);
+  }, [addCashRoute, navigate, routeName]);
 
   return (
     <SheetActionButton

--- a/src/features/cash/navigation/getAddCashRoute.ts
+++ b/src/features/cash/navigation/getAddCashRoute.ts
@@ -1,7 +1,14 @@
+import { isCashDepositSetupComplete, type CashDepositSetupStatus } from '@/features/cash/stores/cashDepositSetupStatus';
 import Routes from '@/navigation/routesNames';
 
-type AddCashRoute = typeof Routes.CASH_DEPOSIT_INTRO_PANEL | typeof Routes.FIAT_ON_RAMP_SHEET;
+type AddCashRoute = typeof Routes.ADD_CASH_SHEET | typeof Routes.CASH_DEPOSIT_INTRO_PANEL | typeof Routes.FIAT_ON_RAMP_SHEET;
 
-export function getAddCashRoute(isCashEnabled: boolean): AddCashRoute {
-  return isCashEnabled ? Routes.CASH_DEPOSIT_INTRO_PANEL : Routes.FIAT_ON_RAMP_SHEET;
+/**
+ * Where the Add Cash entry point lands. Cash off keeps today's behavior; once it's on,
+ * a ready member skips the intro panel and goes straight to Add Cash, while a member
+ * who still has setup gates lands on the intro panel.
+ */
+export function getAddCashRoute(isCashEnabled: boolean, setupStatus: CashDepositSetupStatus): AddCashRoute {
+  if (!isCashEnabled) return Routes.FIAT_ON_RAMP_SHEET;
+  return isCashDepositSetupComplete(setupStatus) ? Routes.ADD_CASH_SHEET : Routes.CASH_DEPOSIT_INTRO_PANEL;
 }

--- a/src/features/cash/navigation/useAddCashRoute.ts
+++ b/src/features/cash/navigation/useAddCashRoute.ts
@@ -1,0 +1,14 @@
+import { useIsCashEnabled } from '@/features/cash/hooks/useIsCashEnabled';
+import { getAddCashRoute } from '@/features/cash/navigation/getAddCashRoute';
+import { useCashDepositSetupStatus } from '@/features/cash/stores/cashDepositSetupStore';
+
+/**
+ * The Add Cash entry point: the `route` to open (given the cash flag and the member's setup
+ * status) plus `isCashEnabled`, so a call site can both route and label its button from one
+ * flag subscription.
+ */
+export function useAddCashRoute() {
+  const isCashEnabled = useIsCashEnabled();
+  const setupStatus = useCashDepositSetupStatus();
+  return { route: getAddCashRoute(isCashEnabled, setupStatus), isCashEnabled };
+}

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -1,0 +1,228 @@
+import React, { memo, useCallback, useState } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { useFocusEffect } from '@react-navigation/native';
+
+import { analytics } from '@/analytics';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import ContactAvatar from '@/components/contacts/ContactAvatar';
+import ImageAvatar from '@/components/contacts/ImageAvatar';
+import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
+import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Inline, Text, useForegroundColor } from '@/design-system';
+import * as i18n from '@/languages';
+import { useAccountProfileInfo } from '@/state/wallets/walletsStore';
+
+type AmountPreset = { amount: number; label: string };
+const AMOUNT_PRESETS: AmountPreset[] = [
+  { amount: 10, label: '$10' },
+  { amount: 25, label: '$25' },
+  { amount: 50, label: '$50' },
+  { amount: 100, label: '$100' },
+  { amount: 1000, label: '$1k' },
+];
+const DEFAULT_SELECTED_AMOUNT = 50;
+
+// Placeholder payment method — the real "Add From" source lands with card linking.
+const MOCK_PAYMENT_METHOD = { brand: 'Visa Debit', maskedNumber: '*8990' };
+
+function AccountAvatar() {
+  const { accountSymbol, accountColor, accountImage } = useAccountProfileInfo();
+
+  return accountImage ? (
+    <ImageAvatar image={accountImage} size="header" />
+  ) : (
+    <ContactAvatar color={accountColor} size="small" value={accountSymbol} />
+  );
+}
+
+function VisaBadge() {
+  return (
+    <Box
+      alignItems="center"
+      borderRadius={6}
+      height={{ custom: 20 }}
+      justifyContent="center"
+      style={styles.visaBadge}
+      width={{ custom: 28 }}
+    >
+      <Text align="center" color="white" size="icon 8px" weight="heavy">
+        {'VISA'}
+      </Text>
+    </Box>
+  );
+}
+
+function AmountChip({ label, selected, onPress, testID }: { label: string; selected: boolean; onPress: () => void; testID: string }) {
+  const blue = useForegroundColor('blue');
+  const shadowFar = useForegroundColor('shadowFar');
+  return (
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.94} style={styles.chip} testID={testID} wrapperStyle={styles.chip}>
+      <Box
+        alignItems="center"
+        background="surfaceSecondaryElevated"
+        justifyContent="center"
+        style={[styles.chipInner, { borderColor: selected ? blue : 'transparent', shadowColor: shadowFar }]}
+      >
+        <Text align="center" color="label" size="22pt" weight="heavy">
+          {label}
+        </Text>
+      </Box>
+    </ButtonPressAnimation>
+  );
+}
+
+export const AddCashSheet = memo(function AddCashSheet() {
+  const blue = useForegroundColor('blue');
+  const separatorTertiary = useForegroundColor('separatorTertiary');
+  const shadowFar = useForegroundColor('shadowFar');
+  const [selectedAmount, setSelectedAmount] = useState(DEFAULT_SELECTED_AMOUNT);
+
+  useFocusEffect(
+    useCallback(() => {
+      analytics.track(analytics.event.addCashViewed);
+    }, [])
+  );
+
+  // Hold to Add → create buy order. Buy pipeline lands in a later unit; inert for now.
+  const handleHoldToAdd = useCallback(() => {
+    // TODO(cash): createBuyOrder + register pending transaction once the Add Cash buy unit lands.
+  }, []);
+
+  // Add From → payment-method picker. Lands with card linking; inert for now.
+  const handleAddFrom = useCallback(() => {
+    // TODO(cash): open the payment-method picker once card linking lands.
+  }, []);
+
+  // Custom amount entry. Lands with the keypad; inert for now.
+  const handleMore = useCallback(() => {
+    // TODO(cash): open custom amount entry once the keypad unit lands.
+  }, []);
+
+  const handleSettings = useCallback(() => {
+    // TODO(cash): open cash settings once they land.
+  }, []);
+
+  return (
+    <PanelSheet>
+      <Box background="surfaceSecondary">
+        <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="24px" paddingTop="28px">
+          <AccountAvatar />
+          <Text align="center" color="label" size="22pt" weight="heavy">
+            {i18n.t(i18n.l.cash.add_cash)}
+          </Text>
+          <ButtonPressAnimation onPress={handleSettings} scaleTo={0.8} testID="cash-deposit-add-cash-settings">
+            <Box alignItems="center" height={{ custom: 36 }} justifyContent="center" width={{ custom: 36 }}>
+              <Text align="center" color="blue" size="20pt" weight="heavy">
+                {'􀣋'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+        </Box>
+
+        <Box flexDirection="row" flexWrap="wrap" paddingHorizontal="28px" paddingTop="32px" style={styles.presetGrid}>
+          {AMOUNT_PRESETS.map(preset => (
+            <AmountChip
+              key={preset.amount}
+              label={preset.label}
+              onPress={() => setSelectedAmount(preset.amount)}
+              selected={selectedAmount === preset.amount}
+              testID={`cash-deposit-add-cash-amount-${preset.amount}`}
+            />
+          ))}
+          <ButtonPressAnimation
+            onPress={handleMore}
+            scaleTo={0.94}
+            style={styles.chip}
+            testID="cash-deposit-add-cash-amount-more"
+            wrapperStyle={styles.chip}
+          >
+            <Box
+              alignItems="center"
+              background="surfaceSecondaryElevated"
+              justifyContent="center"
+              style={[styles.chipInner, styles.chipUnselected, { shadowColor: shadowFar }]}
+            >
+              <Text align="center" color="label" size="22pt" weight="heavy">
+                {'􀍠'}
+              </Text>
+            </Box>
+          </ButtonPressAnimation>
+        </Box>
+
+        <Box paddingTop="24px">
+          <Box style={[styles.separator, { backgroundColor: separatorTertiary }]} />
+          <ButtonPressAnimation onPress={handleAddFrom} scaleTo={0.96} testID="cash-deposit-add-cash-add-from">
+            <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="28px" paddingTop="20px">
+              <Text color="labelQuaternary" size="17pt" weight="bold">
+                {i18n.t(i18n.l.cash.add_cash_screen.add_from)}
+              </Text>
+              <Inline alignVertical="center" space="8px">
+                <VisaBadge />
+                <Text color="label" size="17pt" weight="bold">
+                  {MOCK_PAYMENT_METHOD.brand}
+                </Text>
+                <Text color="labelTertiary" size="17pt" weight="semibold">
+                  {MOCK_PAYMENT_METHOD.maskedNumber}
+                </Text>
+                <Text color="labelSecondary" size="13pt" weight="heavy">
+                  {'􀆊'}
+                </Text>
+              </Inline>
+            </Box>
+          </ButtonPressAnimation>
+        </Box>
+
+        <Box paddingBottom="32px" paddingHorizontal="20px" paddingTop="36px">
+          <HoldToActivateButton
+            backgroundColor={blue}
+            color="white"
+            disabledBackgroundColor={blue}
+            height={48}
+            isProcessing={false}
+            label={`􀎽  ${i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}`}
+            onLongPress={handleHoldToAdd}
+            processingLabel={i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}
+            showBiometryIcon={false}
+            size="22pt"
+            testID="cash-deposit-add-cash-hold-to-add"
+            weight="heavy"
+          />
+        </Box>
+      </Box>
+    </PanelSheet>
+  );
+});
+
+const styles = StyleSheet.create({
+  chip: {
+    flexBasis: '30%',
+    flexGrow: 1,
+    height: 56,
+    minWidth: 0,
+  },
+  chipInner: {
+    borderCurve: 'continuous',
+    borderRadius: 20,
+    borderWidth: 4,
+    flex: 1,
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.06,
+    shadowRadius: 18,
+  },
+  chipUnselected: {
+    borderColor: 'transparent',
+  },
+  presetGrid: {
+    columnGap: 10,
+    rowGap: 12,
+  },
+  separator: {
+    borderRadius: 1,
+    height: 1,
+    marginHorizontal: 28,
+  },
+  visaBadge: {
+    backgroundColor: '#1B33C3',
+  },
+});

--- a/src/features/cash/stores/cashDepositSetupStatus.test.ts
+++ b/src/features/cash/stores/cashDepositSetupStatus.test.ts
@@ -1,0 +1,13 @@
+import { isCashDepositSetupComplete } from './cashDepositSetupStatus';
+
+describe('isCashDepositSetupComplete', () => {
+  it('is complete only when the member is ready to add cash', () => {
+    expect(isCashDepositSetupComplete('ready')).toBe(true);
+  });
+
+  it('is not complete while any setup gate remains', () => {
+    expect(isCashDepositSetupComplete('needsIdentity')).toBe(false);
+    expect(isCashDepositSetupComplete('needsCard')).toBe(false);
+    expect(isCashDepositSetupComplete('needsWallet')).toBe(false);
+  });
+});

--- a/src/features/cash/stores/cashDepositSetupStatus.ts
+++ b/src/features/cash/stores/cashDepositSetupStatus.ts
@@ -1,0 +1,21 @@
+/**
+ * The member's progress through Cash Setup, in canonical order. Anything short of `ready`
+ * keeps them on the Setup flow; `ready` lets the entry point open Add Cash directly.
+ *
+ * This array is the single source of truth: `CashDepositSetupStatus` is derived from it, and the
+ * dev select renders it in order.
+ *
+ * Stubbed for now: the real status derives from JWT claims + ramp GETs once auth lands.
+ * Until then it is a mock driven from Developer Settings.
+ */
+export const CASH_DEPOSIT_SETUP_STATUSES = ['needsIdentity', 'needsCard', 'needsWallet', 'ready'] as const;
+
+export type CashDepositSetupStatus = (typeof CASH_DEPOSIT_SETUP_STATUSES)[number];
+
+export function isCashDepositSetupComplete(status: CashDepositSetupStatus): boolean {
+  return status === 'ready';
+}
+
+export function isCashDepositSetupStatus(status: string): status is CashDepositSetupStatus {
+  return CASH_DEPOSIT_SETUP_STATUSES.some(s => s === status);
+}

--- a/src/features/cash/stores/cashDepositSetupStore.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.ts
@@ -1,0 +1,30 @@
+import { type CashDepositSetupStatus } from '@/features/cash/stores/cashDepositSetupStatus';
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
+
+type CashDepositSetupStore = {
+  /**
+   * Cached Setup status — a fast-path hint only, never a gate. The server is authoritative
+   * once auth lands; this is a mock driven from Developer Settings until then, and becomes
+   * keyed by User (passkey identity) at that point.
+   */
+  cachedStatus: CashDepositSetupStatus;
+  setStatus: (status: CashDepositSetupStatus) => void;
+};
+
+const DEFAULT_STATUS: CashDepositSetupStatus = 'needsIdentity';
+
+export const useCashDepositSetupStore = createRainbowStore<CashDepositSetupStore>(
+  set => ({
+    cachedStatus: DEFAULT_STATUS,
+    setStatus: status => set({ cachedStatus: status }),
+  }),
+  { storageKey: 'cashDepositSetup' }
+);
+
+/**
+ * Stubbed `CashDepositSetupStatus` derivation: today it just reads the cached hint. The real
+ * derivation (JWT claims + ramp GETs) lands with auth in Slice 7.
+ */
+export function useCashDepositSetupStatus(): CashDepositSetupStatus {
+  return useCashDepositSetupStore(state => state.cachedStatus);
+}

--- a/src/features/perps/components/PerpsNavigatorFooter.tsx
+++ b/src/features/perps/components/PerpsNavigatorFooter.tsx
@@ -13,6 +13,7 @@ import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldT
 import { DEFAULT_MOUNT_ANIMATIONS } from '@/components/utilities/MountWhenFocused';
 import { Box, Text, TextShadow, useColorMode } from '@/design-system';
 import { typeHierarchy } from '@/design-system/typography/typeHierarchy';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import { HyperliquidButton } from '@/features/perps/components/HyperliquidButton';
 import { usePerpsAccentColorContext } from '@/features/perps/context/PerpsAccentColorContext';
 import { PerpsNavigation, usePerpsNavigationStore } from '@/features/perps/screens/PerpsNavigator';
@@ -127,6 +128,7 @@ const PerpsAccountScreenFooter = () => {
   const balance = useHyperliquidAccountStore(state => state.getBalance());
   const hasZeroBalance = Number(balance) === 0;
   const hasNoAssets = useUserAssetsStore(state => !state.getFilteredUserAssetIds().length);
+  const { route: addCashRoute } = useAddCashRoute();
 
   return (
     <>
@@ -151,7 +153,7 @@ const PerpsAccountScreenFooter = () => {
       <HyperliquidButton
         onPress={() => {
           if (hasZeroBalance) {
-            Navigation.handleAction(hasNoAssets ? Routes.FIAT_ON_RAMP_SHEET : Routes.PERPS_DEPOSIT_SCREEN);
+            Navigation.handleAction(hasNoAssets ? addCashRoute : Routes.PERPS_DEPOSIT_SCREEN);
           } else {
             PerpsNavigation.navigate(Routes.PERPS_SEARCH_SCREEN, { type: 'newPosition' });
           }

--- a/src/features/perps/screens/perp-detail-screen/SheetFooter.tsx
+++ b/src/features/perps/screens/perp-detail-screen/SheetFooter.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
 import { Box, Text, useColorMode } from '@/design-system';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import { HyperliquidButton } from '@/features/perps/components/HyperliquidButton';
 import { useHyperliquidAccountStore } from '@/features/perps/stores/hyperliquidAccountStore';
 import { type PerpMarket } from '@/features/perps/types';
@@ -32,12 +33,13 @@ export function SheetFooter({ backgroundColor, market }: SheetFooterProps) {
   const hasPosition = !!position;
   const hasPerpsBalance = useHyperliquidAccountStore(state => Number(state.getBalance()) !== 0);
   const hasUserAssets = useUserAssetsStore(state => state.getFilteredUserAssetIds().length > 0);
+  const { route: addCashRoute } = useAddCashRoute();
 
   const noPositionButton = useMemo(() => {
     if (!hasUserAssets) {
       return {
         onPress: () => {
-          Navigation.handleAction(Routes.FIAT_ON_RAMP_SHEET);
+          Navigation.handleAction(addCashRoute);
         },
         text: i18n.t(i18n.l.perps.actions.fund_wallet),
       };
@@ -63,7 +65,7 @@ export function SheetFooter({ backgroundColor, market }: SheetFooterProps) {
       },
       text: i18n.t(i18n.l.perps.actions.open_position),
     };
-  }, [hasUserAssets, hasPerpsBalance, market, navigation]);
+  }, [addCashRoute, hasUserAssets, hasPerpsBalance, market, navigation]);
 
   return (
     <Box pointerEvents="box-none" position="absolute" bottom="0px" width="full">

--- a/src/features/perps/screens/perps-account-screen/AccountBalanceCard.tsx
+++ b/src/features/perps/screens/perps-account-screen/AccountBalanceCard.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ImgixImage } from '@/components/images';
 import { Box, Stack, Text, TextIcon, TextShadow, useColorMode } from '@/design-system';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import { formatUsd } from '@/features/currency/utils/formatUsd';
 import { HyperliquidButton } from '@/features/perps/components/HyperliquidButton';
 import { USDC_ICON_URL } from '@/features/perps/constants';
@@ -22,6 +23,7 @@ export const PerpsAccountBalanceCard = memo(function PerpsAccountBalanceCard() {
   const isBalanceZero = useHyperliquidAccountStore(state => Number(state.getBalance()) === 0);
   const hasNoAssets = useUserAssetsStore(state => !state.getFilteredUserAssetIds().length);
   const accountAddress = useWalletsStore(state => state.accountAddress);
+  const { route: addCashRoute } = useAddCashRoute();
 
   return (
     <Box
@@ -96,7 +98,7 @@ export const PerpsAccountBalanceCard = memo(function PerpsAccountBalanceCard() {
             onPress={() => {
               if (checkIfReadOnlyWallet(accountAddress)) return;
               if (hasNoAssets) {
-                Navigation.handleAction(Routes.FIAT_ON_RAMP_SHEET);
+                Navigation.handleAction(addCashRoute);
               } else {
                 Navigation.handleAction(Routes.PERPS_DEPOSIT_SCREEN);
               }

--- a/src/features/polymarket/components/PolymarketAccountBalanceCard.tsx
+++ b/src/features/polymarket/components/PolymarketAccountBalanceCard.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { ImgixImage } from '@/components/images';
 import { Box, Stack, Text, TextIcon, TextShadow, useColorMode } from '@/design-system';
+import { useAddCashRoute } from '@/features/cash/navigation/useAddCashRoute';
 import { formatUsd } from '@/features/currency/utils/formatUsd';
 import { USDC_ICON_URL } from '@/features/perps/constants';
 import { PolymarketButton } from '@/features/polymarket/components/PolymarketButton';
@@ -21,6 +22,7 @@ export const PolymarketAccountBalanceCard = memo(function PolymarketAccountBalan
   const isBalanceZero = usePolymarketBalanceStore(state => state.isBalanceZero());
   const balance = usePolymarketBalanceStore(state => state.getBalance());
   const hasNoAssets = useUserAssetsStore(state => !state.getFilteredUserAssetIds().length);
+  const { route: addCashRoute } = useAddCashRoute();
 
   return (
     <Box
@@ -94,7 +96,7 @@ export const PolymarketAccountBalanceCard = memo(function PolymarketAccountBalan
             onPress={() => {
               if (getIsReadOnlyWallet()) return;
               if (hasNoAssets) {
-                Navigation.handleAction(Routes.FIAT_ON_RAMP_SHEET);
+                Navigation.handleAction(addCashRoute);
               } else {
                 Navigation.handleAction(Routes.POLYMARKET_DEPOSIT_SCREEN);
               }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -505,6 +505,13 @@
       },
       "restart_app": "Restart App",
       "reset_experimental_config": "Reset Experimental Config",
+      "cash_deposit_setup_status": {
+        "title": "Cash Deposit Setup Status",
+        "needsIdentity": "Needs Identity",
+        "needsCard": "Needs Card",
+        "needsWallet": "Needs Wallet",
+        "ready": "Ready"
+      },
       "status": "Status",
       "sync_codepush": "Sync CodePush",
       "simulate_device_transfer": "Simulate Device Transfer",
@@ -512,7 +519,8 @@
         "normie_settings": "Normie Settings",
         "rainbow_developer_settings": "Rainbow Developer Settings",
         "feature_flags": "Feature Flags",
-        "delegation_settings": "Delegation Settings"
+        "delegation_settings": "Delegation Settings",
+        "cash_settings": "Cash Settings"
       },
       "delegation_settings": {
         "simulate_disable_smart_wallet": "Simulate Disable Smart Wallet",
@@ -1660,6 +1668,10 @@
         "set_up_account": "Set Up Account",
         "other_deposit_methods": "Other Deposit Methods",
         "sign_in": "Sign In"
+      },
+      "add_cash_screen": {
+        "add_from": "Add From",
+        "hold_to_add": "Hold to Add"
       }
     },
     "points": {

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -12,6 +12,7 @@ import { PROFILES } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
+import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { SignTransactionSheet } from '@/features/dapp-request/screens/SignTransactionSheet';
 import RegisterENSNavigator from '@/features/ens/navigation/RegisterENSNavigator';
@@ -305,6 +306,7 @@ function BSNavigator() {
       <BSStack.Screen component={PerpsAddToPositionSheet} name={Routes.PERPS_ADD_TO_POSITION_SHEET} />
       <BSStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} />
       <BSStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} />
+      <BSStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} />
       <BSStack.Screen component={PerpsTradeDetailsSheet} name={Routes.PERPS_TRADE_DETAILS_SHEET} />
       <BSStack.Screen component={PolymarketEventScreen} name={Routes.POLYMARKET_EVENT_SCREEN} />
       <BSStack.Screen component={PolymarketRedeemPositionSheet} name={Routes.POLYMARKET_MANAGE_POSITION_SHEET} />

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -12,6 +12,7 @@ import { PROFILES } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import AppIconUnlockSheet from '@/features/app-icon/screens/AppIconUnlockSheet';
 import BackupSheet from '@/features/backup/components/BackupSheet';
+import { AddCashSheet } from '@/features/cash/screens/add-cash-sheet/AddCashSheet';
 import { CashDepositIntroPanel } from '@/features/cash/screens/cash-deposit-intro-panel/CashDepositIntroPanel';
 import { SignTransactionSheet } from '@/features/dapp-request/screens/SignTransactionSheet';
 import RegisterENSNavigator from '@/features/ens/navigation/RegisterENSNavigator';
@@ -339,6 +340,7 @@ function NativeStackNavigator() {
       <NativeStack.Screen component={PerpsExplainSheet} name={Routes.PERPS_EXPLAIN_SHEET} {...perpsExplainSheetConfig} />
       <NativeStack.Screen component={PerpsAboutSheet} name={Routes.PERPS_ABOUT_SHEET} {...panelConfig} />
       <NativeStack.Screen component={CashDepositIntroPanel} name={Routes.CASH_DEPOSIT_INTRO_PANEL} {...panelConfig} />
+      <NativeStack.Screen component={AddCashSheet} name={Routes.ADD_CASH_SHEET} {...panelConfig} />
       <NativeStack.Screen
         component={PerpsTradeDetailsSheet}
         name={Routes.PERPS_TRADE_DETAILS_SHEET}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 
 const Routes = {
+  ADD_CASH_SHEET: 'AddCashSheet',
   ADD_WALLET_NAVIGATOR: 'AddWalletNavigator',
   ADD_WALLET_SHEET: 'AddWalletSheet',
   AIRDROPS_SHEET: 'AirdropsSheet',

--- a/src/screens/SettingsSheet/components/DevSection.tsx
+++ b/src/screens/SettingsSheet/components/DevSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -9,9 +9,16 @@ import { getAllInternetCredentials, resetInternetCredentials } from 'react-nativ
 import Restart from 'react-native-restart';
 
 import { ImgixImage } from '@/components/images';
+import ContextMenuButton, { type MenuConfig } from '@/components/native-context-menu/contextMenu';
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from '@/config/experimental';
 import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
 import { IS_STORE_INSTALL } from '@/env';
+import {
+  CASH_DEPOSIT_SETUP_STATUSES,
+  isCashDepositSetupStatus,
+  type CashDepositSetupStatus,
+} from '@/features/cash/stores/cashDepositSetupStatus';
+import { useCashDepositSetupStore } from '@/features/cash/stores/cashDepositSetupStore';
 import { getDelegationContractAddress, isRainbowDelegated, isThirdPartyDelegated } from '@/features/delegation/status';
 import { isAuthenticated } from '@/features/local-auth/isAuthenticated';
 import { wipeKeychain } from '@/features/local-auth/legacyKeychain';
@@ -40,6 +47,51 @@ import { delegation, type DelegationWithChainId } from '@rainbow-me/delegation';
 import Menu from './Menu';
 import MenuContainer from './MenuContainer';
 import MenuItem from './MenuItem';
+
+// Dev-only select that drives the mock CashDepositSetupStatus, so QA can exercise every entry-point branch.
+function CashDepositSetupStatusMenuItem() {
+  const cachedStatus = useCashDepositSetupStore(state => state.cachedStatus);
+  const setStatus = useCashDepositSetupStore(state => state.setStatus);
+
+  const statusLabel = useCallback(
+    (status: CashDepositSetupStatus) => i18n.t(i18n.l.developer_settings.cash_deposit_setup_status[status]),
+    []
+  );
+
+  const menuConfig = useMemo<MenuConfig>(
+    () => ({
+      menuTitle: i18n.t(i18n.l.developer_settings.cash_deposit_setup_status.title),
+      menuItems: CASH_DEPOSIT_SETUP_STATUSES.map(status => ({
+        actionKey: status,
+        actionTitle: statusLabel(status),
+        menuState: status === cachedStatus ? 'on' : 'off',
+      })),
+    }),
+    [cachedStatus, statusLabel]
+  );
+
+  const onPressMenuItem = useCallback(
+    ({ nativeEvent: { actionKey } }: { nativeEvent: { actionKey: string } }) => {
+      if (isCashDepositSetupStatus(actionKey)) {
+        setStatus(actionKey);
+      }
+    },
+    [setStatus]
+  );
+
+  return (
+    <ContextMenuButton menuConfig={menuConfig} isMenuPrimaryAction onPressMenuItem={onPressMenuItem} useActionSheetFallback={false}>
+      <MenuItem
+        hasChevron
+        leftComponent={<MenuItem.TextIcon icon="💵" isEmoji />}
+        rightComponent={<MenuItem.Selection>{statusLabel(cachedStatus)}</MenuItem.Selection>}
+        size={52}
+        testID="cash-deposit-setup-status-select"
+        titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_deposit_setup_status.title)} />}
+      />
+    </ContextMenuButton>
+  );
+}
 
 const DevSection = () => {
   const { navigate } = useNavigation();
@@ -461,6 +513,9 @@ const DevSection = () => {
                 />
               );
             })}
+          </Menu>
+          <Menu header={i18n.t(i18n.l.developer_settings.headers.cash_settings)}>
+            <CashDepositSetupStatusMenuItem />
           </Menu>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.feature_flags)}>
             {(Object.keys(config) as ExperimentalConfigKey[])

--- a/src/screens/SettingsSheet/components/MenuItem.tsx
+++ b/src/screens/SettingsSheet/components/MenuItem.tsx
@@ -195,7 +195,7 @@ const MenuItem = ({
       testID={disabled ? testID : undefined}
       width="full"
     >
-      <Inline alignHorizontal="justify" alignVertical="center">
+      <Inline alignHorizontal="justify" alignVertical="center" wrap={false}>
         <Box flexShrink={1}>
           <Inline alignVertical="center" wrap={false}>
             {leftComponent && (
@@ -219,7 +219,7 @@ const MenuItem = ({
           </Inline>
         </Box>
         <Box paddingLeft="8px">
-          <Inline alignVertical="center" space={{ custom: 9 }}>
+          <Inline alignVertical="center" space={{ custom: 9 }} wrap={false}>
             {rightComponent}
             {hasRightArrow && (
               <Box


### PR DESCRIPTION
Fixes [APP-3776](https://linear.app/rainbow/issue/APP-3776/ramp-entry-point-status-driven-routing-add-cash-screen)

## What changed (plus any additional context for devs)

This is the next Ramp entry-point slice: once Ramp is enabled, the existing Add Cash / Buy entry points now route based on the member's Ramp Setup status instead of always showing the intro panel.

- Ramp disabled → legacy Add Cash sheet, unchanged.
- Ramp enabled + `needsIdentity`, `needsCard`, or `needsWallet` → Cash Deposits intro panel.
- Ramp enabled + `ready` → new Ramp Add Cash sheet directly, skipping the intro panel.

The setup status is intentionally mocked for this slice via an MMKV-backed `rampSetupStore`; the real derivation will come from server-truth JWT claims / ramp APIs once auth lands. Dev Settings now has a Ramp Setup Status selector, and e2e can drive the same status through a test deeplink.

This also adds the first Add Cash sheet UI for a ready member: preset amount chips, a placeholder Visa “Add From” row, and the Hold to Add button. This PR is UI + routing only: order creation/polling, card linking/picking, custom amount entry, and settings are intentionally inert for later Ramp slices.

## Screen recordings / screenshots

**Please use** `Cash` **Experimental Flag, not** `Ramp` **as on the videos**

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-06-04 at 16.43.43.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9b24f005-04fb-43f3-9d96-7531bde3ae34.mov" />](https://app.graphite.com/user-attachments/video/9b24f005-04fb-43f3-9d96-7531bde3ae34.mov)<br> | [untitled.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0f4511a5-cb6b-4425-abe3-696be93d730b.webm" />](https://app.graphite.com/user-attachments/video/0f4511a5-cb6b-4425-abe3-696be93d730b.webm) |

## What to test

- With Ramp disabled, tap Add Cash / Buy from the primary wallet entry points and confirm the legacy Add Cash sheet still opens.
- With Ramp enabled and Ramp Setup Status set to `Ready`, tap Add Cash / Buy and confirm the new Add Cash sheet opens directly.
- With Ramp enabled and Ramp Setup Status set to `Needs Identity`, `Needs Card`, and `Needs Wallet`, confirm each status opens the Cash Deposits intro panel instead of the Add Cash sheet.