### PR TITLE
fix(ios-e2e): treat test builds as non-store installs

### DIFF
--- a/ios/AppInstallInfo.swift
+++ b/ios/AppInstallInfo.swift
@@ -14,11 +14,19 @@ class AppInstallInfo: NSObject {
 
   @objc
   func isStoreInstall() -> NSNumber {
+    // The App Store only ever distributes device builds; a simulator install is
+    // never a store install. Simulators also have no embedded.mobileprovision, so
+    // without this they fall through to the receipt heuristic and get misclassified.
+    #if targetEnvironment(simulator)
+      return false
+    #endif
+
     // Local/ad-hoc builds have a provisioning profile.
     // App Store and TestFlight do not; Apple strips it.
-    let hasProfile = Bundle.main.path(
-      forResource: "embedded", ofType: "mobileprovision"
-    ) != nil
+    let hasProfile =
+      Bundle.main.path(
+        forResource: "embedded", ofType: "mobileprovision"
+      ) != nil
     if hasProfile { return false }
 
     // No profile = went through Apple's pipeline.


### PR DESCRIPTION
## Description

This makes `AppInstallInfo.isStoreInstall()` return `false` for iOS simulator builds.

The previous classifier only treated local/ad-hoc installs as non-store when the app bundle contained `embedded.mobileprovision`, then used the receipt path to distinguish TestFlight from App Store. Simulator bundles do not come from the App Store and do not include `embedded.mobileprovision`, so an iOS e2e simulator build could fall through to the receipt heuristic and be reported as store-installed when no sandbox receipt is present.

Device behavior is unchanged: local/ad-hoc device builds still return non-store when a provisioning profile is present, TestFlight still returns non-store via `sandboxReceipt`, and App Store installs still return store-installed.
