### PR TITLE
fix(ci): manual graphql introspection

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -20,3 +20,4 @@ rainbow-scripts
 src/__swaps__/README.md
 InjectedJSBundle.js
 src/features/positions/types/generated/**
+src/graphql/schemas/*.graphql

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,4 @@ InjectedJSBundle.js
 src/languages/*.json
 !src/languages/en_US.json
 **/__fixtures__/*.json
+src/graphql/schemas/*.graphql

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "gradle": "cd android && ./gradlew",
     "graphql-codegen": "yarn graphql-prepare && cd src/graphql && yarn codegen",
     "graphql-codegen:install": "cd src/graphql && yarn install",
+    "graphql-introspect": "yarn graphql-prepare && cd src/graphql && yarn graphql-codegen --config introspection.config.js",
     "graphql-prepare": "./scripts/graph-ens-key.sh",
     "postinstall": "./scripts/postinstall.sh",
     "install-all": "yarn install && yarn setup && yarn install-pods",

--- a/src/graphql/README.md
+++ b/src/graphql/README.md
@@ -2,6 +2,18 @@
 
 Here, you will find our GraphQL clients & query/mutation definitions!
 
+## Schema introspection
+
+GraphQL codegen uses checked-in SDL files from `src/graphql/schemas`. It does not introspect live services during setup, CI, or `yarn graphql-codegen`.
+
+When remote schemas change, introspect them explicitly from the root directory of the `rainbow` repository:
+
+```
+> yarn graphql-introspect
+```
+
+Then run `yarn graphql-codegen` when generated clients need to be updated.
+
 ## Adding a new query
 
 - If you are adding a new query to an existing GraphQL client, [follow these steps](#existing-graphql-client).
@@ -44,6 +56,8 @@ Ensure you are in the root directory of the `rainbow` repository.
 ```
 > yarn graphql-codegen
 ```
+
+If the query depends on schema fields that are not in the checked-in schemas, run `yarn graphql-introspect` first, then run `yarn graphql-codegen`.
 
 #### 3. Consume!
 
@@ -90,7 +104,11 @@ exports.config = {
 };
 ```
 
-#### 3. Run the codegen
+#### 3. Add a checked-in schema
+
+Add a schema for the new client under `src/graphql/schemas` and map it in `codegen.config.js`. If the schema should be refreshed by `yarn graphql-introspect`, add it to `introspection.config.js` too.
+
+#### 4. Run the codegen
 
 Run the codegen tool to generate types & a fetcher for your newly defined query.
 
@@ -100,7 +118,7 @@ Ensure you are in the root directory of the `rainbow` repository.
 > yarn graphql-codegen
 ```
 
-#### 4. Create a new client in `index.ts`:
+#### 5. Create a new client in `index.ts`:
 
 ```diff
 import { config } from './config';
@@ -116,7 +134,7 @@ export const metadataClient = getMetadataSdk(
 + export const exampleClient = getEnsSdk(getFetchRequester(config.example.schema.url));
 ```
 
-#### 5. Consume!
+#### 6. Consume!
 
 ```tsx
 import { exampleClient } from '@/graphql';

--- a/src/graphql/codegen.config.js
+++ b/src/graphql/codegen.config.js
@@ -1,14 +1,27 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { config } = require('./config');
 
+const SERVICE_SCHEMAS = {
+  arc: './schemas/arc.graphql',
+  arcDev: './schemas/arcDev.graphql',
+  ens: './schemas/ens.graphql',
+  metadata: './schemas/metadata.graphql',
+  metadataPOST: './schemas/metadata.graphql',
+};
+
 module.exports = {
-  generates: Object.entries(config).reduce((config, [key, value]) => {
+  generates: Object.entries(config).reduce((generatedConfig, [key, value]) => {
+    const schema = SERVICE_SCHEMAS[key];
+    if (!schema) {
+      throw new Error(`Missing GraphQL schema for "${key}". Run yarn graphql-introspect.`);
+    }
+
     return {
-      ...config,
+      ...generatedConfig,
       [`./__generated__/${key}.ts`]: {
         documents: [value.document],
         plugins: ['typescript', 'typescript-operations', 'typescript-generic-sdk'],
-        schema: [{ [value.schema.url]: { method: value.schema.method } }],
+        schema,
       },
     };
   }, {}),

--- a/src/graphql/introspection.config.js
+++ b/src/graphql/introspection.config.js
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { config } = require('./config');
+
+const SCHEMA_AST_CONFIG = {
+  plugins: ['schema-ast'],
+  config: {
+    sort: true,
+  },
+};
+
+function schemaTarget(url, method) {
+  return {
+    schema: [{ [url]: { method } }],
+    ...SCHEMA_AST_CONFIG,
+  };
+}
+
+module.exports = {
+  generates: {
+    './schemas/arc.graphql': schemaTarget(config.arc.schema.url, config.arc.schema.method),
+    './schemas/arcDev.graphql': schemaTarget(config.arcDev.schema.url, config.arcDev.schema.method),
+    './schemas/ens.graphql': schemaTarget(config.ens.schema.url, config.ens.schema.method),
+    './schemas/metadata.graphql': schemaTarget(config.metadata.schema.url, config.metadata.schema.method),
+  },
+};

--- a/src/graphql/package.json
+++ b/src/graphql/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.11.7",
+    "@graphql-codegen/schema-ast": "2.5.1",
     "@graphql-codegen/typescript": "2.7.3",
     "@graphql-codegen/typescript-generic-sdk": "3.0.1",
     "@graphql-codegen/typescript-operations": "2.5.3",

--- a/src/graphql/schemas/arc.graphql
+++ b/src/graphql/schemas/arc.graphql
@@ -1,0 +1,2143 @@
+"""
+Indicates exactly one field must be supplied and this field must not be `null`.
+"""
+directive @oneOf on INPUT_OBJECT
+
+type Asset {
+  address: String!
+  decimals: Int!
+  name: String!
+  symbol: String!
+}
+
+type AssetAmount {
+  decimal: Float!
+  raw: String!
+  usd: Float!
+}
+
+type AssetCollection {
+  items: [ContentfulAsset]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input AssetFilter {
+  AND: [AssetFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  contentType: String
+  contentType_contains: String
+  contentType_exists: Boolean
+  contentType_in: [String]
+  contentType_not: String
+  contentType_not_contains: String
+  contentType_not_in: [String]
+  description: String
+  description_contains: String
+  description_exists: Boolean
+  description_in: [String]
+  description_not: String
+  description_not_contains: String
+  description_not_in: [String]
+  fileName: String
+  fileName_contains: String
+  fileName_exists: Boolean
+  fileName_in: [String]
+  fileName_not: String
+  fileName_not_contains: String
+  fileName_not_in: [String]
+  height: Int
+  height_exists: Boolean
+  height_gt: Int
+  height_gte: Int
+  height_in: [Int]
+  height_lt: Int
+  height_lte: Int
+  height_not: Int
+  height_not_in: [Int]
+  OR: [AssetFilter]
+  size: Int
+  size_exists: Boolean
+  size_gt: Int
+  size_gte: Int
+  size_in: [Int]
+  size_lt: Int
+  size_lte: Int
+  size_not: Int
+  size_not_in: [Int]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+  url: String
+  url_contains: String
+  url_exists: Boolean
+  url_in: [String]
+  url_not: String
+  url_not_contains: String
+  url_not_in: [String]
+  width: Int
+  width_exists: Boolean
+  width_gt: Int
+  width_gte: Int
+  width_in: [Int]
+  width_lt: Int
+  width_lte: Int
+  width_not: Int
+  width_not_in: [Int]
+}
+
+type AssetLinkingCollections {
+  dropCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsDropCollectionOrder], preview: Boolean, skip: Int = 0): DropCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  personCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsPersonCollectionOrder], preview: Boolean, skip: Int = 0): PersonCollection
+  postCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsPostCollectionOrder], preview: Boolean, skip: Int = 0): PostCollection
+  promoSheetCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsPromoSheetCollectionOrder], preview: Boolean, skip: Int = 0): PromoSheetCollection
+}
+
+enum AssetLinkingCollectionsDropCollectionOrder {
+  backgroundColor_ASC
+  backgroundColor_DESC
+  buttonColor_ASC
+  buttonColor_DESC
+  buttonShadowColor_ASC
+  buttonShadowColor_DESC
+  buttonTextColor_ASC
+  buttonTextColor_DESC
+  contractAddress_ASC
+  contractAddress_DESC
+  downloadLink_ASC
+  downloadLink_DESC
+  firstProductHighlightBackground_ASC
+  firstProductHighlightBackground_DESC
+  firstProductHighlightTextColor_ASC
+  firstProductHighlightTextColor_DESC
+  firstProductHighlightTitle_ASC
+  firstProductHighlightTitle_DESC
+  gradientColor_ASC
+  gradientColor_DESC
+  linearGradientColor_ASC
+  linearGradientColor_DESC
+  linkColor_ASC
+  linkColor_DESC
+  partnerLink_ASC
+  partnerLink_DESC
+  partnerTitle_ASC
+  partnerTitle_DESC
+  presaleName_ASC
+  presaleName_DESC
+  radialGradientColor_ASC
+  radialGradientColor_DESC
+  secondProductHighlightBackground_ASC
+  secondProductHighlightBackground_DESC
+  secondProductHighlightTextColor_ASC
+  secondProductHighlightTextColor_DESC
+  secondProductHighlightTitle_ASC
+  secondProductHighlightTitle_DESC
+  showFooter_ASC
+  showFooter_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  textColor_ASC
+  textColor_DESC
+  title_ASC
+  title_DESC
+  unlockableTitle_ASC
+  unlockableTitle_DESC
+}
+
+enum AssetLinkingCollectionsPersonCollectionOrder {
+  name_ASC
+  name_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+enum AssetLinkingCollectionsPostCollectionOrder {
+  date_ASC
+  date_DESC
+  seoTitle_ASC
+  seoTitle_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum AssetLinkingCollectionsPromoSheetCollectionOrder {
+  accentColor_ASC
+  accentColor_DESC
+  backgroundColor_ASC
+  backgroundColor_DESC
+  campaignKey_ASC
+  campaignKey_DESC
+  headerImageAspectRatio_ASC
+  headerImageAspectRatio_DESC
+  launchDate_ASC
+  launchDate_DESC
+  priority_ASC
+  priority_DESC
+  sheetHandleColor_ASC
+  sheetHandleColor_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+enum AssetOrder {
+  contentType_ASC
+  contentType_DESC
+  fileName_ASC
+  fileName_DESC
+  height_ASC
+  height_DESC
+  size_ASC
+  size_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  url_ASC
+  url_DESC
+  width_ASC
+  width_DESC
+}
+
+type Bridging {
+  bridgeable: Boolean!
+  networks: Networks
+}
+
+type Card implements Entry {
+  accentColor(locale: String): String
+  backgroundColor(locale: String): String
+  borderRadius(locale: String): Int
+  cardKey(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  dismissable(locale: String): Boolean
+  imageCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): AssetCollection
+  imageIcon(locale: String): String
+  imageRadius(locale: String): Int
+  index(locale: String): Int
+  linkedFrom(allowedLocales: [String]): CardLinkingCollections
+  padding(locale: String): Int
+  placement(locale: String): String
+  primaryButton(locale: String): JSON
+  subtitle(locale: String): JSON
+  subtitleColor(locale: String): String
+  sys: Sys!
+  title(locale: String): JSON
+  titleColor(locale: String): String
+}
+
+type CardCollection {
+  items: [Card]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input CardFilter {
+  accentColor: String
+  accentColor_contains: String
+  accentColor_exists: Boolean
+  accentColor_in: [String]
+  accentColor_not: String
+  accentColor_not_contains: String
+  accentColor_not_in: [String]
+  AND: [CardFilter]
+  backgroundColor: String
+  backgroundColor_contains: String
+  backgroundColor_exists: Boolean
+  backgroundColor_in: [String]
+  backgroundColor_not: String
+  backgroundColor_not_contains: String
+  backgroundColor_not_in: [String]
+  borderRadius: Int
+  borderRadius_exists: Boolean
+  borderRadius_gt: Int
+  borderRadius_gte: Int
+  borderRadius_in: [Int]
+  borderRadius_lt: Int
+  borderRadius_lte: Int
+  borderRadius_not: Int
+  borderRadius_not_in: [Int]
+  cardKey: String
+  cardKey_contains: String
+  cardKey_exists: Boolean
+  cardKey_in: [String]
+  cardKey_not: String
+  cardKey_not_contains: String
+  cardKey_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  dismissable: Boolean
+  dismissable_exists: Boolean
+  dismissable_not: Boolean
+  imageCollection_exists: Boolean
+  imageIcon: String
+  imageIcon_contains: String
+  imageIcon_exists: Boolean
+  imageIcon_in: [String]
+  imageIcon_not: String
+  imageIcon_not_contains: String
+  imageIcon_not_in: [String]
+  imageRadius: Int
+  imageRadius_exists: Boolean
+  imageRadius_gt: Int
+  imageRadius_gte: Int
+  imageRadius_in: [Int]
+  imageRadius_lt: Int
+  imageRadius_lte: Int
+  imageRadius_not: Int
+  imageRadius_not_in: [Int]
+  index: Int
+  index_exists: Boolean
+  index_gt: Int
+  index_gte: Int
+  index_in: [Int]
+  index_lt: Int
+  index_lte: Int
+  index_not: Int
+  index_not_in: [Int]
+  OR: [CardFilter]
+  padding: Int
+  padding_exists: Boolean
+  padding_gt: Int
+  padding_gte: Int
+  padding_in: [Int]
+  padding_lt: Int
+  padding_lte: Int
+  padding_not: Int
+  padding_not_in: [Int]
+  placement: String
+  placement_contains: String
+  placement_exists: Boolean
+  placement_in: [String]
+  placement_not: String
+  placement_not_contains: String
+  placement_not_in: [String]
+  primaryButton_exists: Boolean
+  subtitle_exists: Boolean
+  subtitleColor: String
+  subtitleColor_contains: String
+  subtitleColor_exists: Boolean
+  subtitleColor_in: [String]
+  subtitleColor_not: String
+  subtitleColor_not_contains: String
+  subtitleColor_not_in: [String]
+  sys: SysFilter
+  title_exists: Boolean
+  titleColor: String
+  titleColor_contains: String
+  titleColor_exists: Boolean
+  titleColor_in: [String]
+  titleColor_not: String
+  titleColor_not_contains: String
+  titleColor_not_in: [String]
+}
+
+type CardLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum CardOrder {
+  accentColor_ASC
+  accentColor_DESC
+  backgroundColor_ASC
+  backgroundColor_DESC
+  borderRadius_ASC
+  borderRadius_DESC
+  cardKey_ASC
+  cardKey_DESC
+  dismissable_ASC
+  dismissable_DESC
+  imageIcon_ASC
+  imageIcon_DESC
+  imageRadius_ASC
+  imageRadius_DESC
+  index_ASC
+  index_DESC
+  padding_ASC
+  padding_DESC
+  placement_ASC
+  placement_DESC
+  subtitleColor_ASC
+  subtitleColor_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  titleColor_ASC
+  titleColor_DESC
+}
+
+type CollectionsForAddressResponse {
+  data: [NftCollectionData]!
+  nextPageKey: String
+  totalCollections: Int!
+}
+
+type Colors {
+  fallback: String
+  primary: String!
+  shadow: String
+}
+
+type ContentfulAsset {
+  contentfulMetadata: ContentfulMetadata!
+  contentType(locale: String): String
+  description(locale: String): String
+  fileName(locale: String): String
+  height(locale: String): Int
+  linkedFrom(allowedLocales: [String]): AssetLinkingCollections
+  size(locale: String): Int
+  sys: Sys!
+  title(locale: String): String
+  url(locale: String, transform: ImageTransformOptions): String
+  width(locale: String): Int
+}
+
+type ContentfulMetadata {
+  tags: [ContentfulTag]!
+}
+
+input ContentfulMetadataFilter {
+  tags: ContentfulMetadataTagsFilter
+  tags_exists: Boolean
+}
+
+input ContentfulMetadataTagsFilter {
+  id_contains_all: [String]
+  id_contains_none: [String]
+  id_contains_some: [String]
+}
+
+type ContentfulTag {
+  id: String
+  name: String
+}
+
+"""Custom scalar type for handling DateTime strings in ISO 8601 format"""
+scalar DateTime
+
+scalar Dimension
+
+type Drop implements Entry {
+  backgroundColor(locale: String): String
+  backgroundImage(locale: String, preview: Boolean): ContentfulAsset
+  buttonColor(locale: String): String
+  buttonShadowColor(locale: String): String
+  buttonTextColor(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  contractAddress(locale: String): String
+  description(locale: String): String
+  downloadLink(locale: String): String
+  dropAsset(locale: String, preview: Boolean): ContentfulAsset
+  firstProductHighlightBackground(locale: String): String
+  firstProductHighlightDescription(locale: String): String
+  firstProductHighlightImage(locale: String, preview: Boolean): ContentfulAsset
+  firstProductHighlightTextColor(locale: String): String
+  firstProductHighlightTitle(locale: String): String
+  gradientColor(locale: String): String
+  linearGradientColor(locale: String): String
+  linkColor(locale: String): String
+  linkedFrom(allowedLocales: [String]): DropLinkingCollections
+  metaImage(locale: String, preview: Boolean): ContentfulAsset
+  partnerAsset(locale: String, preview: Boolean): ContentfulAsset
+  partnerDescription(locale: String): String
+  partnerLink(locale: String): String
+  partnerTitle(locale: String): String
+  presaleName(locale: String): String
+  radialGradientColor(locale: String): String
+  secondProductHighlightBackground(locale: String): String
+  secondProductHighlightDescription(locale: String): String
+  secondProductHighlightImage(locale: String, preview: Boolean): ContentfulAsset
+  secondProductHighlightTextColor(locale: String): String
+  secondProductHighlightTitle(locale: String): String
+  showFooter(locale: String): Boolean
+  slug(locale: String): String
+  sys: Sys!
+  textColor(locale: String): String
+  title(locale: String): String
+  unlockableAsset(locale: String, preview: Boolean): ContentfulAsset
+  unlockableDescription(locale: String): String
+  unlockableTitle(locale: String): String
+}
+
+type DropCollection {
+  items: [Drop]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input DropFilter {
+  AND: [DropFilter]
+  backgroundColor: String
+  backgroundColor_contains: String
+  backgroundColor_exists: Boolean
+  backgroundColor_in: [String]
+  backgroundColor_not: String
+  backgroundColor_not_contains: String
+  backgroundColor_not_in: [String]
+  backgroundImage_exists: Boolean
+  buttonColor: String
+  buttonColor_contains: String
+  buttonColor_exists: Boolean
+  buttonColor_in: [String]
+  buttonColor_not: String
+  buttonColor_not_contains: String
+  buttonColor_not_in: [String]
+  buttonShadowColor: String
+  buttonShadowColor_contains: String
+  buttonShadowColor_exists: Boolean
+  buttonShadowColor_in: [String]
+  buttonShadowColor_not: String
+  buttonShadowColor_not_contains: String
+  buttonShadowColor_not_in: [String]
+  buttonTextColor: String
+  buttonTextColor_contains: String
+  buttonTextColor_exists: Boolean
+  buttonTextColor_in: [String]
+  buttonTextColor_not: String
+  buttonTextColor_not_contains: String
+  buttonTextColor_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  contractAddress: String
+  contractAddress_contains: String
+  contractAddress_exists: Boolean
+  contractAddress_in: [String]
+  contractAddress_not: String
+  contractAddress_not_contains: String
+  contractAddress_not_in: [String]
+  description: String
+  description_contains: String
+  description_exists: Boolean
+  description_in: [String]
+  description_not: String
+  description_not_contains: String
+  description_not_in: [String]
+  downloadLink: String
+  downloadLink_contains: String
+  downloadLink_exists: Boolean
+  downloadLink_in: [String]
+  downloadLink_not: String
+  downloadLink_not_contains: String
+  downloadLink_not_in: [String]
+  dropAsset_exists: Boolean
+  firstProductHighlightBackground: String
+  firstProductHighlightBackground_contains: String
+  firstProductHighlightBackground_exists: Boolean
+  firstProductHighlightBackground_in: [String]
+  firstProductHighlightBackground_not: String
+  firstProductHighlightBackground_not_contains: String
+  firstProductHighlightBackground_not_in: [String]
+  firstProductHighlightDescription: String
+  firstProductHighlightDescription_contains: String
+  firstProductHighlightDescription_exists: Boolean
+  firstProductHighlightDescription_in: [String]
+  firstProductHighlightDescription_not: String
+  firstProductHighlightDescription_not_contains: String
+  firstProductHighlightDescription_not_in: [String]
+  firstProductHighlightImage_exists: Boolean
+  firstProductHighlightTextColor: String
+  firstProductHighlightTextColor_contains: String
+  firstProductHighlightTextColor_exists: Boolean
+  firstProductHighlightTextColor_in: [String]
+  firstProductHighlightTextColor_not: String
+  firstProductHighlightTextColor_not_contains: String
+  firstProductHighlightTextColor_not_in: [String]
+  firstProductHighlightTitle: String
+  firstProductHighlightTitle_contains: String
+  firstProductHighlightTitle_exists: Boolean
+  firstProductHighlightTitle_in: [String]
+  firstProductHighlightTitle_not: String
+  firstProductHighlightTitle_not_contains: String
+  firstProductHighlightTitle_not_in: [String]
+  gradientColor: String
+  gradientColor_contains: String
+  gradientColor_exists: Boolean
+  gradientColor_in: [String]
+  gradientColor_not: String
+  gradientColor_not_contains: String
+  gradientColor_not_in: [String]
+  linearGradientColor: String
+  linearGradientColor_contains: String
+  linearGradientColor_exists: Boolean
+  linearGradientColor_in: [String]
+  linearGradientColor_not: String
+  linearGradientColor_not_contains: String
+  linearGradientColor_not_in: [String]
+  linkColor: String
+  linkColor_contains: String
+  linkColor_exists: Boolean
+  linkColor_in: [String]
+  linkColor_not: String
+  linkColor_not_contains: String
+  linkColor_not_in: [String]
+  metaImage_exists: Boolean
+  OR: [DropFilter]
+  partnerAsset_exists: Boolean
+  partnerDescription: String
+  partnerDescription_contains: String
+  partnerDescription_exists: Boolean
+  partnerDescription_in: [String]
+  partnerDescription_not: String
+  partnerDescription_not_contains: String
+  partnerDescription_not_in: [String]
+  partnerLink: String
+  partnerLink_contains: String
+  partnerLink_exists: Boolean
+  partnerLink_in: [String]
+  partnerLink_not: String
+  partnerLink_not_contains: String
+  partnerLink_not_in: [String]
+  partnerTitle: String
+  partnerTitle_contains: String
+  partnerTitle_exists: Boolean
+  partnerTitle_in: [String]
+  partnerTitle_not: String
+  partnerTitle_not_contains: String
+  partnerTitle_not_in: [String]
+  presaleName: String
+  presaleName_contains: String
+  presaleName_exists: Boolean
+  presaleName_in: [String]
+  presaleName_not: String
+  presaleName_not_contains: String
+  presaleName_not_in: [String]
+  radialGradientColor: String
+  radialGradientColor_contains: String
+  radialGradientColor_exists: Boolean
+  radialGradientColor_in: [String]
+  radialGradientColor_not: String
+  radialGradientColor_not_contains: String
+  radialGradientColor_not_in: [String]
+  secondProductHighlightBackground: String
+  secondProductHighlightBackground_contains: String
+  secondProductHighlightBackground_exists: Boolean
+  secondProductHighlightBackground_in: [String]
+  secondProductHighlightBackground_not: String
+  secondProductHighlightBackground_not_contains: String
+  secondProductHighlightBackground_not_in: [String]
+  secondProductHighlightDescription: String
+  secondProductHighlightDescription_contains: String
+  secondProductHighlightDescription_exists: Boolean
+  secondProductHighlightDescription_in: [String]
+  secondProductHighlightDescription_not: String
+  secondProductHighlightDescription_not_contains: String
+  secondProductHighlightDescription_not_in: [String]
+  secondProductHighlightImage_exists: Boolean
+  secondProductHighlightTextColor: String
+  secondProductHighlightTextColor_contains: String
+  secondProductHighlightTextColor_exists: Boolean
+  secondProductHighlightTextColor_in: [String]
+  secondProductHighlightTextColor_not: String
+  secondProductHighlightTextColor_not_contains: String
+  secondProductHighlightTextColor_not_in: [String]
+  secondProductHighlightTitle: String
+  secondProductHighlightTitle_contains: String
+  secondProductHighlightTitle_exists: Boolean
+  secondProductHighlightTitle_in: [String]
+  secondProductHighlightTitle_not: String
+  secondProductHighlightTitle_not_contains: String
+  secondProductHighlightTitle_not_in: [String]
+  showFooter: Boolean
+  showFooter_exists: Boolean
+  showFooter_not: Boolean
+  slug: String
+  slug_contains: String
+  slug_exists: Boolean
+  slug_in: [String]
+  slug_not: String
+  slug_not_contains: String
+  slug_not_in: [String]
+  sys: SysFilter
+  textColor: String
+  textColor_contains: String
+  textColor_exists: Boolean
+  textColor_in: [String]
+  textColor_not: String
+  textColor_not_contains: String
+  textColor_not_in: [String]
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+  unlockableAsset_exists: Boolean
+  unlockableDescription: String
+  unlockableDescription_contains: String
+  unlockableDescription_exists: Boolean
+  unlockableDescription_in: [String]
+  unlockableDescription_not: String
+  unlockableDescription_not_contains: String
+  unlockableDescription_not_in: [String]
+  unlockableTitle: String
+  unlockableTitle_contains: String
+  unlockableTitle_exists: Boolean
+  unlockableTitle_in: [String]
+  unlockableTitle_not: String
+  unlockableTitle_not_contains: String
+  unlockableTitle_not_in: [String]
+}
+
+type DropLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum DropOrder {
+  backgroundColor_ASC
+  backgroundColor_DESC
+  buttonColor_ASC
+  buttonColor_DESC
+  buttonShadowColor_ASC
+  buttonShadowColor_DESC
+  buttonTextColor_ASC
+  buttonTextColor_DESC
+  contractAddress_ASC
+  contractAddress_DESC
+  downloadLink_ASC
+  downloadLink_DESC
+  firstProductHighlightBackground_ASC
+  firstProductHighlightBackground_DESC
+  firstProductHighlightTextColor_ASC
+  firstProductHighlightTextColor_DESC
+  firstProductHighlightTitle_ASC
+  firstProductHighlightTitle_DESC
+  gradientColor_ASC
+  gradientColor_DESC
+  linearGradientColor_ASC
+  linearGradientColor_DESC
+  linkColor_ASC
+  linkColor_DESC
+  partnerLink_ASC
+  partnerLink_DESC
+  partnerTitle_ASC
+  partnerTitle_DESC
+  presaleName_ASC
+  presaleName_DESC
+  radialGradientColor_ASC
+  radialGradientColor_DESC
+  secondProductHighlightBackground_ASC
+  secondProductHighlightBackground_DESC
+  secondProductHighlightTextColor_ASC
+  secondProductHighlightTextColor_DESC
+  secondProductHighlightTitle_ASC
+  secondProductHighlightTitle_DESC
+  showFooter_ASC
+  showFooter_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  textColor_ASC
+  textColor_DESC
+  title_ASC
+  title_DESC
+  unlockableTitle_ASC
+  unlockableTitle_DESC
+}
+
+interface Entry {
+  contentfulMetadata: ContentfulMetadata!
+  sys: Sys!
+}
+
+type EntryCollection {
+  items: [Entry]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input EntryFilter {
+  AND: [EntryFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  OR: [EntryFilter]
+  sys: SysFilter
+}
+
+enum EntryOrder {
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type FaqEntry implements Entry {
+  answer(locale: String): FaqEntryAnswer
+  contentfulMetadata: ContentfulMetadata!
+  featured(locale: String): Boolean
+  linkedFrom(allowedLocales: [String]): FaqEntryLinkingCollections
+  order(locale: String): Int
+  question(locale: String): String
+  sys: Sys!
+}
+
+type FaqEntryAnswer {
+  json: JSON!
+  links: FaqEntryAnswerLinks!
+}
+
+type FaqEntryAnswerAssets {
+  block: [ContentfulAsset]!
+  hyperlink: [ContentfulAsset]!
+}
+
+type FaqEntryAnswerEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type FaqEntryAnswerLinks {
+  assets: FaqEntryAnswerAssets!
+  entries: FaqEntryAnswerEntries!
+  resources: FaqEntryAnswerResources!
+}
+
+type FaqEntryAnswerResources {
+  block: [ResourceLink!]!
+  hyperlink: [ResourceLink!]!
+  inline: [ResourceLink!]!
+}
+
+type FaqEntryCollection {
+  items: [FaqEntry]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input FaqEntryFilter {
+  AND: [FaqEntryFilter]
+  answer_contains: String
+  answer_exists: Boolean
+  answer_not_contains: String
+  contentfulMetadata: ContentfulMetadataFilter
+  featured: Boolean
+  featured_exists: Boolean
+  featured_not: Boolean
+  OR: [FaqEntryFilter]
+  order: Int
+  order_exists: Boolean
+  order_gt: Int
+  order_gte: Int
+  order_in: [Int]
+  order_lt: Int
+  order_lte: Int
+  order_not: Int
+  order_not_in: [Int]
+  question: String
+  question_contains: String
+  question_exists: Boolean
+  question_in: [String]
+  question_not: String
+  question_not_contains: String
+  question_not_in: [String]
+  sys: SysFilter
+}
+
+type FaqEntryLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum FaqEntryOrder {
+  featured_ASC
+  featured_DESC
+  order_ASC
+  order_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type FarcasterUser {
+  fid: Int!
+  follower_count: Int!
+  following_count: Int!
+  pfp_url: String
+  power_badge: Boolean!
+  username: String
+}
+
+type FeaturedMint implements Entry {
+  chainId(locale: String): Int
+  contentfulMetadata: ContentfulMetadata!
+  contractAddress(locale: String): String
+  linkedFrom(allowedLocales: [String]): FeaturedMintLinkingCollections
+  name(locale: String): String
+  sys: Sys!
+}
+
+type FeaturedMintCollection {
+  items: [FeaturedMint]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input FeaturedMintFilter {
+  AND: [FeaturedMintFilter]
+  chainId: Int
+  chainId_exists: Boolean
+  chainId_gt: Int
+  chainId_gte: Int
+  chainId_in: [Int]
+  chainId_lt: Int
+  chainId_lte: Int
+  chainId_not: Int
+  chainId_not_in: [Int]
+  contentfulMetadata: ContentfulMetadataFilter
+  contractAddress: String
+  contractAddress_contains: String
+  contractAddress_exists: Boolean
+  contractAddress_in: [String]
+  contractAddress_not: String
+  contractAddress_not_contains: String
+  contractAddress_not_in: [String]
+  name: String
+  name_contains: String
+  name_exists: Boolean
+  name_in: [String]
+  name_not: String
+  name_not_contains: String
+  name_not_in: [String]
+  OR: [FeaturedMintFilter]
+  sys: SysFilter
+}
+
+type FeaturedMintLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum FeaturedMintOrder {
+  chainId_ASC
+  chainId_DESC
+  contractAddress_ASC
+  contractAddress_DESC
+  name_ASC
+  name_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type FeaturedResult {
+  advertiserId: String!
+  category: String
+  context: FeaturedResultContext
+  ctas: [FeaturedResultCallToAction!]
+  description: String!
+  id: String!
+  imageAltText: String!
+  imageUrl: String!
+  imageVariants: ImageVariants
+  impressionId: String!
+  placementSlug: String!
+  title: String!
+  type: FeaturedResultType!
+}
+
+type FeaturedResultCallToAction {
+  href: String!
+  title: String!
+}
+
+type FeaturedResultContext {
+  text: String!
+}
+
+type FeaturedResultsResponse {
+  items: [FeaturedResult!]
+}
+
+enum FeaturedResultType {
+  CARD
+  DISCORD
+  IFRAME
+}
+
+scalar HexColor
+
+enum ImageFormat {
+  AVIF
+  JPG
+  JPG_PROGRESSIVE
+  PNG
+  PNG8
+  WEBP
+}
+
+enum ImageResizeFocus {
+  BOTTOM
+  BOTTOM_LEFT
+  BOTTOM_RIGHT
+  CENTER
+  FACE
+  FACES
+  LEFT
+  RIGHT
+  TOP
+  TOP_LEFT
+  TOP_RIGHT
+}
+
+enum ImageResizeStrategy {
+  CROP
+  FILL
+  FIT
+  PAD
+  SCALE
+  THUMB
+}
+
+input ImageTransformOptions {
+  backgroundColor: HexColor
+  cornerRadius: Int
+  format: ImageFormat
+  height: Dimension
+  quality: Quality
+  resizeFocus: ImageResizeFocus
+  resizeStrategy: ImageResizeStrategy
+  width: Dimension
+}
+
+type ImageVariant {
+  url: String
+}
+
+type ImageVariants {
+  orig: ImageVariant
+  x1: ImageVariant
+  x2: ImageVariant
+  x3: ImageVariant
+}
+
+scalar JSON
+
+type Market {
+  ath: PricePoint
+  atl: PricePoint
+  circulating_supply: Float
+  currency_used: String
+  fdv: Float
+  market_cap: MarketCap
+  max_supply: Float
+  price: Price
+  total_supply: Float
+  updated_at: DateTime
+  volume_24h: Float
+}
+
+type MarketCap {
+  change_24h: Float
+  value: Float
+}
+
+type MintableCollection {
+  addressesLastHour: Int
+  chainId: Int!
+  contract: String!
+  contractAddress: String!
+  deployer: String
+  externalURL: String!
+  firstEvent: String!
+  imageMimeType: String
+  imageURL: String
+  lastEvent: String
+  maxSupply: String
+  mintsLastHour: Int!
+  mintStatus: MintStatus!
+  name: String!
+  recentMints: [MintedNFT!]!
+  totalMints: Int!
+}
+
+type MintableCollectionResult {
+  collection: MintableCollection!
+}
+
+type MintableCollectionsResult {
+  collections: [MintableCollection!]!
+}
+
+type MintedNFT {
+  imageURI: String
+  mimeType: String
+  mintTime: String
+  title: String
+  tokenID: String!
+  value: String
+}
+
+type MintStatus {
+  isMintable: Boolean!
+  price: String!
+}
+
+type Mutation {
+  trackFeaturedResult(featuredResultCreativeId: String!, impressionId: String!, placementId: String!, type: TrackFeaturedResultType!): TrackFeaturedResultResponse
+}
+
+type NetworkInfo {
+  address: String!
+  decimals: Int!
+}
+
+type Networks {
+  """Chain IDs as keys (e.g. '8453')"""
+  _: NetworkInfo
+}
+
+type NftCollectionData {
+  id: String!
+  imageUrl: String!
+  name: String!
+  totalCount: String!
+}
+
+enum NFTCollectionSortCriterion {
+  ABC
+  FLOOR_PRICE
+  MOST_RECENT
+}
+
+type NFTFloorPrice {
+  amount: AssetAmount!
+  paymentToken: Asset!
+}
+
+type NFTMarketplace {
+  imageUrl: String!
+  name: String!
+}
+
+type NFTOffer {
+  createdAt: Int!
+  feesPercentage: Float!
+  floorDifferencePercentage: Float!
+  floorPrice: NFTFloorPrice!
+  grossAmount: AssetAmount!
+  marketplace: NFTMarketplace!
+  netAmount: AssetAmount!
+  network: String!
+  nft: PartialNFT!
+  paymentToken: Asset!
+  royaltiesPercentage: Float!
+  url: String!
+  validUntil: Int!
+}
+
+type NFTs {
+  data: [SimpleHashNFT!]!
+  nextCursor: String
+  previousCursor: String
+}
+
+enum NftTokenType {
+  ERC1155
+  ERC721
+  NO_SUPPORTED_NFT_STANDARD
+  NOT_A_CONTRACT
+  UNKNOWN
+}
+
+type PartialNFT {
+  aspectRatio: Float
+  collectionName: String!
+  contractAddress: String!
+  imageUrl: String!
+  name: String!
+  predominantColor: String
+  tokenId: String!
+  uniqueId: String!
+}
+
+type Person implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  linkedFrom(allowedLocales: [String]): PersonLinkingCollections
+  name(locale: String): String
+  profilePic(locale: String, preview: Boolean): ContentfulAsset
+  sys: Sys!
+}
+
+type PersonCollection {
+  items: [Person]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input PersonFilter {
+  AND: [PersonFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  name: String
+  name_contains: String
+  name_exists: Boolean
+  name_in: [String]
+  name_not: String
+  name_not_contains: String
+  name_not_in: [String]
+  OR: [PersonFilter]
+  profilePic_exists: Boolean
+  sys: SysFilter
+}
+
+type PersonLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PersonOrder {
+  name_ASC
+  name_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type PoapClaimResult {
+  error: String
+  success: Boolean!
+}
+
+type PoapEvent {
+  createdAt: String!
+  id: Int!
+  imageUrl: String!
+  name: String!
+  qrHash: String
+  secret: String
+  secretWord: String
+}
+
+type PointsTweetIntent implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  key(locale: String): String
+  linkedFrom(allowedLocales: [String]): PointsTweetIntentLinkingCollections
+  sys: Sys!
+  text(locale: String): String
+  url(locale: String): String
+  via(locale: String): String
+}
+
+type PointsTweetIntentCollection {
+  items: [PointsTweetIntent]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input PointsTweetIntentFilter {
+  AND: [PointsTweetIntentFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  key: String
+  key_contains: String
+  key_exists: Boolean
+  key_in: [String]
+  key_not: String
+  key_not_contains: String
+  key_not_in: [String]
+  OR: [PointsTweetIntentFilter]
+  sys: SysFilter
+  text: String
+  text_contains: String
+  text_exists: Boolean
+  text_in: [String]
+  text_not: String
+  text_not_contains: String
+  text_not_in: [String]
+  url: String
+  url_contains: String
+  url_exists: Boolean
+  url_in: [String]
+  url_not: String
+  url_not_contains: String
+  url_not_in: [String]
+  via: String
+  via_contains: String
+  via_exists: Boolean
+  via_in: [String]
+  via_not: String
+  via_not_contains: String
+  via_not_in: [String]
+}
+
+type PointsTweetIntentLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PointsTweetIntentOrder {
+  key_ASC
+  key_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  text_ASC
+  text_DESC
+  url_ASC
+  url_DESC
+  via_ASC
+  via_DESC
+}
+
+type PoolData {
+  currency_used: String!
+  h1_price_change: Float
+  h1_volume: Float
+  h24_price_change: Float
+  h24_volume: Float
+  h6_price_change: Float
+  h6_volume: Float
+  m5_price_change: Float
+  m5_volume: Float
+  reserve: Float
+}
+
+type Post implements Entry {
+  content(locale: String): PostContent
+  contentfulMetadata: ContentfulMetadata!
+  coverImage(locale: String, preview: Boolean): ContentfulAsset
+  date(locale: String): DateTime
+  excerpt(locale: String): String
+  linkedFrom(allowedLocales: [String]): PostLinkingCollections
+  person(locale: String, preview: Boolean): Entry
+  seoTitle(locale: String): String
+  slug(locale: String): String
+  sys: Sys!
+  title(locale: String): String
+}
+
+type PostCollection {
+  items: [Post]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+type PostContent {
+  json: JSON!
+  links: PostContentLinks!
+}
+
+type PostContentAssets {
+  block: [ContentfulAsset]!
+  hyperlink: [ContentfulAsset]!
+}
+
+type PostContentEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type PostContentLinks {
+  assets: PostContentAssets!
+  entries: PostContentEntries!
+  resources: PostContentResources!
+}
+
+type PostContentResources {
+  block: [ResourceLink!]!
+  hyperlink: [ResourceLink!]!
+  inline: [ResourceLink!]!
+}
+
+input PostFilter {
+  AND: [PostFilter]
+  content_contains: String
+  content_exists: Boolean
+  content_not_contains: String
+  contentfulMetadata: ContentfulMetadataFilter
+  coverImage_exists: Boolean
+  date: DateTime
+  date_exists: Boolean
+  date_gt: DateTime
+  date_gte: DateTime
+  date_in: [DateTime]
+  date_lt: DateTime
+  date_lte: DateTime
+  date_not: DateTime
+  date_not_in: [DateTime]
+  excerpt: String
+  excerpt_contains: String
+  excerpt_exists: Boolean
+  excerpt_in: [String]
+  excerpt_not: String
+  excerpt_not_contains: String
+  excerpt_not_in: [String]
+  OR: [PostFilter]
+  person_exists: Boolean
+  seoTitle: String
+  seoTitle_contains: String
+  seoTitle_exists: Boolean
+  seoTitle_in: [String]
+  seoTitle_not: String
+  seoTitle_not_contains: String
+  seoTitle_not_in: [String]
+  slug: String
+  slug_contains: String
+  slug_exists: Boolean
+  slug_in: [String]
+  slug_not: String
+  slug_not_contains: String
+  slug_not_in: [String]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+type PostLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PostOrder {
+  date_ASC
+  date_DESC
+  seoTitle_ASC
+  seoTitle_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+type Price {
+  change_24h: Float
+  value: Float
+}
+
+type PricePoint {
+  change_percentage: Float
+  date: DateTime
+  value: Float
+}
+
+type PromoSheet implements Entry {
+  accentColor(locale: String): String
+  actions(locale: String): JSON
+  backgroundColor(locale: String): String
+  backgroundImage(locale: String, preview: Boolean): ContentfulAsset
+  campaignKey(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  header(locale: String): JSON
+  headerImage(locale: String, preview: Boolean): ContentfulAsset
+  headerImageAspectRatio(locale: String): Float
+  items(locale: String): JSON
+  launchDate(locale: String): DateTime
+  linkedFrom(allowedLocales: [String]): PromoSheetLinkingCollections
+  primaryButtonProps(locale: String): JSON
+  priority(locale: String): Int
+  secondaryButtonProps(locale: String): JSON
+  sheetHandleColor(locale: String): String
+  subHeader(locale: String): JSON
+  sys: Sys!
+}
+
+type PromoSheetCollection {
+  items: [PromoSheet]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input PromoSheetFilter {
+  accentColor: String
+  accentColor_contains: String
+  accentColor_exists: Boolean
+  accentColor_in: [String]
+  accentColor_not: String
+  accentColor_not_contains: String
+  accentColor_not_in: [String]
+  actions_exists: Boolean
+  AND: [PromoSheetFilter]
+  backgroundColor: String
+  backgroundColor_contains: String
+  backgroundColor_exists: Boolean
+  backgroundColor_in: [String]
+  backgroundColor_not: String
+  backgroundColor_not_contains: String
+  backgroundColor_not_in: [String]
+  backgroundImage_exists: Boolean
+  campaignKey: String
+  campaignKey_contains: String
+  campaignKey_exists: Boolean
+  campaignKey_in: [String]
+  campaignKey_not: String
+  campaignKey_not_contains: String
+  campaignKey_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  header_exists: Boolean
+  headerImage_exists: Boolean
+  headerImageAspectRatio: Float
+  headerImageAspectRatio_exists: Boolean
+  headerImageAspectRatio_gt: Float
+  headerImageAspectRatio_gte: Float
+  headerImageAspectRatio_in: [Float]
+  headerImageAspectRatio_lt: Float
+  headerImageAspectRatio_lte: Float
+  headerImageAspectRatio_not: Float
+  headerImageAspectRatio_not_in: [Float]
+  items_exists: Boolean
+  launchDate: DateTime
+  launchDate_exists: Boolean
+  launchDate_gt: DateTime
+  launchDate_gte: DateTime
+  launchDate_in: [DateTime]
+  launchDate_lt: DateTime
+  launchDate_lte: DateTime
+  launchDate_not: DateTime
+  launchDate_not_in: [DateTime]
+  OR: [PromoSheetFilter]
+  primaryButtonProps_exists: Boolean
+  priority: Int
+  priority_exists: Boolean
+  priority_gt: Int
+  priority_gte: Int
+  priority_in: [Int]
+  priority_lt: Int
+  priority_lte: Int
+  priority_not: Int
+  priority_not_in: [Int]
+  secondaryButtonProps_exists: Boolean
+  sheetHandleColor: String
+  sheetHandleColor_contains: String
+  sheetHandleColor_exists: Boolean
+  sheetHandleColor_in: [String]
+  sheetHandleColor_not: String
+  sheetHandleColor_not_contains: String
+  sheetHandleColor_not_in: [String]
+  subHeader_exists: Boolean
+  sys: SysFilter
+}
+
+type PromoSheetLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PromoSheetOrder {
+  accentColor_ASC
+  accentColor_DESC
+  backgroundColor_ASC
+  backgroundColor_DESC
+  campaignKey_ASC
+  campaignKey_DESC
+  headerImageAspectRatio_ASC
+  headerImageAspectRatio_DESC
+  launchDate_ASC
+  launchDate_DESC
+  priority_ASC
+  priority_DESC
+  sheetHandleColor_ASC
+  sheetHandleColor_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+scalar Quality
+
+type Query {
+  asset(id: String!, locale: String, preview: Boolean): ContentfulAsset
+  assetCollection(limit: Int = 100, locale: String, order: [AssetOrder], preview: Boolean, skip: Int = 0, where: AssetFilter): AssetCollection
+  card(id: String!, locale: String, preview: Boolean): Card
+  cardCollection(limit: Int = 100, locale: String, order: [CardOrder], preview: Boolean, skip: Int = 0, where: CardFilter): CardCollection
+  claimPoapByQrHash(qrHash: String!, secret: String!, walletAddress: String!): PoapClaimResult
+  claimPoapBySecretWord(secretWord: String!, walletAddress: String!): PoapClaimResult
+  drop(id: String!, locale: String, preview: Boolean): Drop
+  dropCollection(limit: Int = 100, locale: String, order: [DropOrder], preview: Boolean, skip: Int = 0, where: DropFilter): DropCollection
+  entryCollection(limit: Int = 100, locale: String, order: [EntryOrder], preview: Boolean, skip: Int = 0, where: EntryFilter): EntryCollection
+  faqEntry(id: String!, locale: String, preview: Boolean): FaqEntry
+  faqEntryCollection(limit: Int = 100, locale: String, order: [FaqEntryOrder], preview: Boolean, skip: Int = 0, where: FaqEntryFilter): FaqEntryCollection
+  featuredResults(country: String, limit: Int, placementId: String!, walletAddress: String!): FeaturedResultsResponse!
+  getMintableCollection(chain: Int!, contractAddress: String!, walletAddress: String!): MintableCollectionResult
+  getMintableCollections(walletAddress: String!): MintableCollectionsResult
+  getNftsMetadata(tokens: JSON!, walletAddress: String!): [UniqueAsset!]!
+  getPoapEventByQrHash(qrHash: String!): PoapEvent
+  getPoapEventBySecretWord(secretWord: String!): PoapEvent
+  getReservoirCollection(chainId: Int!, contractAddress: String!): ReservoirCollectionResult
+  nftCollections(limit: Int, pageKey: String, walletAddress: String!): CollectionsForAddressResponse!
+  nftOffers(sortBy: SortCriterion!, walletAddress: String!): [NFTOffer!]
+  nfts(walletAddress: String!): [SimpleHashNFT!]
+  nftsByCollection(collectionId: String!, walletAddress: String!): [UniqueAsset!]!
+  nftsByPage(cursor: String, limit: Int, networks: [String!], walletAddress: String!): NFTs
+  nftsV2(sortBy: NFTCollectionSortCriterion, sortDirection: SortDirection, walletAddress: String!): [SimpleHashNFT!]
+  person(id: String!, locale: String, preview: Boolean): Person
+  personCollection(limit: Int = 100, locale: String, order: [PersonOrder], preview: Boolean, skip: Int = 0, where: PersonFilter): PersonCollection
+  pointsTweetIntent(id: String!, locale: String, preview: Boolean): PointsTweetIntent
+  pointsTweetIntentCollection(limit: Int = 100, locale: String, order: [PointsTweetIntentOrder], preview: Boolean, skip: Int = 0, where: PointsTweetIntentFilter): PointsTweetIntentCollection
+  post(id: String!, locale: String, preview: Boolean): Post
+  postCollection(limit: Int = 100, locale: String, order: [PostOrder], preview: Boolean, skip: Int = 0, where: PostFilter): PostCollection
+  promoSheet(id: String!, locale: String, preview: Boolean): PromoSheet
+  promoSheetCollection(limit: Int = 100, locale: String, order: [PromoSheetOrder], preview: Boolean, skip: Int = 0, where: PromoSheetFilter): PromoSheetCollection
+  trendingTokens(category: TrendingCategory! = TRENDING, chainId: Int = 0, currency: String! = "usd", limit: Int, sortBy: TrendingSort! = RECOMMENDED, sortDirection: SortDirection, timeframe: Timeframe! = H12, walletAddress: String): TrendingTokens!
+}
+
+type RainbowCollectionWithDetails {
+  collection_details: SimpleHashCollectionDetails!
+  collection_id: String!
+  distinct_nfts_owned: String!
+  last_acquired_date: String
+  nft_ids: [String!]!
+  total_copies_owned: String!
+}
+
+type ReservoirCollection {
+  chainId: Int!
+  createdAt: String
+  creator: String
+  description: String
+  id: String
+  image: String
+  isMintingPublicSale: Boolean
+  name: String
+  ownerCount: Int
+  publicMintInfo: ReservoirMintStages
+  sampleImages: [String]
+  tokenCount: String
+}
+
+type ReservoirCollectionResult {
+  collection: ReservoirCollection
+}
+
+type ReservoirCurrency {
+  contract: String
+  decimals: Int
+  name: String
+  symbol: String
+}
+
+type ReservoirMintStages {
+  endTime: String
+  kind: String
+  maxMintsPerWallet: String
+  price: ReservoirPrice
+  stage: String
+  startTime: String
+}
+
+type ReservoirNumber {
+  decimal: Float
+  native: Float
+  raw: String
+  usd: Float
+}
+
+type ReservoirPrice {
+  amount: ReservoirNumber
+  currency: ReservoirCurrency
+  netAmount: ReservoirNumber
+}
+
+type ResourceLink {
+  sys: ResourceSys!
+}
+
+type ResourceSys {
+  linkType: String!
+  type: String!
+  urn: String!
+}
+
+type schema {
+  query: Query
+}
+
+type SimpleHashAttributes {
+  display_type: String
+  trait_type: String
+  value: String
+}
+
+type SimpleHashAudioProperties {
+  audio_coding: String
+  duration: Float
+  mime_type: String
+  size: Float
+}
+
+type SimpleHashCollection {
+  banner_image_url: String
+  category: String
+  chains: [String!]
+  collection_id: String
+  collection_royalties: [SimpleHashRoyalty!]
+  description: String
+  discord_url: String
+  distinct_nft_count: Float
+  distinct_owner_count: Float
+  external_url: String
+  floor_prices: [SimpleHashCollectionFloorPrice!]
+  image_url: String
+  instagram_url: String
+  is_nsfw: Boolean
+  marketplace_pages: [SimpleHashCollectionMarketplacePage!]
+  medium_username: String
+  metaplex_candy_machine: String
+  metaplex_first_verified_creator: String
+  metaplex_mint: String
+  name: String!
+  spam_score: Float
+  telegram_url: String
+  top_bids: [SimpleHashCollectionTopBid!]
+  top_contracts: [String!]
+  total_quantity: Float
+  twitter_username: String
+}
+
+type SimpleHashCollectionDetails {
+  banner_image_url: String
+  category: String
+  chains: [String!]!
+  collection_id: String!
+  collection_royalties: [SimpleHashRoyalty!]!
+  description: String
+  discord_url: String
+  distinct_nft_count: Int!
+  distinct_owner_count: Int!
+  external_url: String
+  floor_prices: [SimpleHashCollectionFloorPrice!]!
+  image_url: String
+  instagram_username: String
+  is_nsfw: Boolean!
+  marketplace_pages: [SimpleHashCollectionMarketplacePage!]!
+  medium_username: String
+  metaplex_first_verified_creator: String
+  metaplex_mint: String
+  name: String!
+  spam_score: Float!
+  telegram_url: String
+  top_contracts: [String!]!
+  total_quantity: Int!
+  twitter_username: String
+}
+
+type SimpleHashCollectionFloorPrice {
+  marketplace_id: String
+  payment_token: SimpleHashPaymentToken
+  value: Float
+  value_usd_cents: Float
+}
+
+type SimpleHashCollectionMarketplacePage {
+  collection_url: String
+  marketplace_collection_id: String
+  marketplace_id: String
+  marketplace_name: String
+  nft_url: String
+  verified: Boolean
+}
+
+type SimpleHashCollectionTopBid {
+  marketplace_id: String
+  payment_token: SimpleHashPaymentToken
+  value: Float
+  value_usd_cents: Float
+}
+
+type SimpleHashContract {
+  deployed_by: String
+  deployed_via_contract: String
+  has_multiple_collections: Boolean
+  name: String
+  owned_by: String
+  symbol: String
+  type: String
+}
+
+type SimpleHashExtraMetadata {
+  animation_original_url: String
+  attributes: [SimpleHashAttributes!]
+  image_original_url: String
+  metadata_original_url: String
+}
+
+type SimpleHashFirstCreated {
+  block_number: Float
+  minted_to: String
+  quantity: Float
+  quantity_string: String
+  timestamp: String
+  transaction: String
+  transaction_initiator: String
+}
+
+type SimpleHashImageProperties {
+  height: Float
+  mime_type: String
+  size: Float
+  width: Float
+}
+
+type SimpleHashLastSale {
+  from_address: String
+  is_bundle_sale: Boolean
+  marketplace_id: String
+  marketplace_name: String
+  payment_token: SimpleHashPaymentToken
+  quantity: Float
+  quantity_string: String
+  timestamp: String
+  to_address: String
+  total_price: Float
+  transaction: String
+  unit_price: Float
+  unit_price_usd_cents: Float
+}
+
+type SimpleHashModelProperties {
+  mime_type: String
+  size: Float
+}
+
+type SimpleHashNFT {
+  audio_properties: SimpleHashAudioProperties
+  audio_url: String
+  background_color: String
+  chain: String!
+  collection: SimpleHashCollection!
+  contract: SimpleHashContract
+  contract_address: String!
+  created_date: String
+  description: String
+  external_url: String
+  extra_metadata: SimpleHashExtraMetadata
+  first_created: SimpleHashFirstCreated
+  image_properties: SimpleHashImageProperties
+  image_url: String
+  last_sale: SimpleHashLastSale
+  model_properties: SimpleHashModelProperties
+  model_url: String
+  name: String!
+  nft_id: String
+  owner_count: Float
+  owners: [SimpleHashOwners!]
+  previews: SimpleHashPreviews
+  queried_wallet_balances: [SimpleHashQueriedWalletBalance]
+  rarity: SimpleHashRarity
+  royalty: [SimpleHashRoyalty!]
+  status: String
+  token_count: Float
+  token_id: String!
+  video_properties: SimpleHashVideoProperties
+  video_url: String
+}
+
+type SimpleHashOwners {
+  first_acquired_date: String
+  last_acquired_date: String
+  owner_address: String
+  quantity: Float
+}
+
+type SimpleHashPaymentToken {
+  address: String
+  decimals: Float
+  name: String
+  payment_token_id: String
+  symbol: String
+}
+
+type SimpleHashPreviews {
+  blurhash: String
+  image_large_url: String
+  image_medium_url: String
+  image_opengraph_url: String
+  image_small_url: String
+  predominant_color: String
+}
+
+type SimpleHashQueriedWalletBalance {
+  address: String
+  first_acquired_date: String
+  last_acquired_date: String
+  quantity: Int
+  quantity_string: String
+}
+
+type SimpleHashRarity {
+  rank: Float
+  score: Float
+  unique_attributes: Float
+}
+
+type SimpleHashRoyalty {
+  recipients: [SimpleHashRoyaltyRecipient!]
+  source: String
+  total_creator_fee_basis_points: Float
+}
+
+type SimpleHashRoyaltyRecipient {
+  address: String
+  basis_points: Float
+  percentage: Float
+}
+
+type SimpleHashVideoProperties {
+  audio_coding: String
+  duration: Float
+  height: Float
+  mime_type: String
+  size: Float
+  video_coding: String
+  width: Float
+}
+
+enum SortCriterion {
+  DATE_CREATED
+  FLOOR_DIFFERENCE_PERCENTAGE
+  TOP_BID_VALUE
+}
+
+enum SortDirection {
+  ASC
+  DESC
+}
+
+type SwapData {
+  bought_stats: SwapStats!
+  currency_used: String!
+  sold_stats: SwapStats!
+}
+
+type SwapStats {
+  farcaster_users: [FarcasterUser!]
+  total_transactions: Int
+  total_volume: Float
+  unique_users: Int
+}
+
+type Sys {
+  environmentId: String!
+  firstPublishedAt: DateTime
+  id: String!
+  publishedAt: DateTime
+  publishedVersion: Int
+  spaceId: String!
+}
+
+input SysFilter {
+  firstPublishedAt: DateTime
+  firstPublishedAt_exists: Boolean
+  firstPublishedAt_gt: DateTime
+  firstPublishedAt_gte: DateTime
+  firstPublishedAt_in: [DateTime]
+  firstPublishedAt_lt: DateTime
+  firstPublishedAt_lte: DateTime
+  firstPublishedAt_not: DateTime
+  firstPublishedAt_not_in: [DateTime]
+  id: String
+  id_contains: String
+  id_exists: Boolean
+  id_in: [String]
+  id_not: String
+  id_not_contains: String
+  id_not_in: [String]
+  publishedAt: DateTime
+  publishedAt_exists: Boolean
+  publishedAt_gt: DateTime
+  publishedAt_gte: DateTime
+  publishedAt_in: [DateTime]
+  publishedAt_lt: DateTime
+  publishedAt_lte: DateTime
+  publishedAt_not: DateTime
+  publishedAt_not_in: [DateTime]
+  publishedVersion: Float
+  publishedVersion_exists: Boolean
+  publishedVersion_gt: Float
+  publishedVersion_gte: Float
+  publishedVersion_in: [Float]
+  publishedVersion_lt: Float
+  publishedVersion_lte: Float
+  publishedVersion_not: Float
+  publishedVersion_not_in: [Float]
+}
+
+enum Timeframe {
+  D3
+  D7
+  H12
+  H24
+}
+
+type TrackFeaturedResultResponse {
+  message: String!
+}
+
+enum TrackFeaturedResultType {
+  CLICK
+  IMPRESSION
+}
+
+enum TrendingCategory {
+  FARCASTER
+  NEW
+  TRENDING
+}
+
+type TrendingData {
+  pool_data: PoolData!
+  rank: Int!
+  swap_data: SwapData!
+  trending_since: DateTime!
+}
+
+enum TrendingSort {
+  MARKET_CAP
+  RECOMMENDED
+  TOP_GAINERS
+  TOP_LOSERS
+  VOLUME
+}
+
+type TrendingToken {
+  address: String!
+  bridging: Bridging!
+  chainId: Int!
+  colors: Colors!
+  creationDate: DateTime
+  decimals: Int!
+  highLiquidity: Boolean!
+  icon_url: String!
+  isRainbowCurated: Boolean!
+  isVerified: Boolean!
+  market: Market!
+  name: String!
+  networks: Networks!
+  symbol: String!
+  transferable: Boolean!
+  trending: TrendingData!
+  uniqueId: String!
+}
+
+type TrendingTokens {
+  data: [TrendingToken!]!
+}
+
+type UniqueAsset {
+  acquiredAt: String
+  backgroundColor: String
+  collectionDescription: String
+  collectionImageUrl: String
+  collectionName: String
+  collectionUrl: String
+  description: String
+  discordUrl: String
+  floorPrice: Float
+  images: UniqueAssetImages!
+  isSendable: Boolean!
+  marketplaceName: String
+  marketplaceUrl: String
+  name: String!
+  standard: NftTokenType!
+  traits: [UniqueAssetTrait!]!
+  twitterUrl: String
+  type: String!
+  uniqueId: String!
+  websiteUrl: String
+}
+
+type UniqueAssetImages {
+  animatedMimeType: String
+  animatedUrl: String
+  highResUrl: String
+  lowResUrl: String
+  mimeType: String
+}
+
+type UniqueAssetTrait {
+  trait_type: String!
+  value: String!
+}

--- a/src/graphql/schemas/arcDev.graphql
+++ b/src/graphql/schemas/arcDev.graphql
@@ -1,0 +1,2142 @@
+"""
+Indicates exactly one field must be supplied and this field must not be `null`.
+"""
+directive @oneOf on INPUT_OBJECT
+
+type Asset {
+  address: String!
+  decimals: Int!
+  name: String!
+  symbol: String!
+}
+
+type AssetAmount {
+  decimal: Float!
+  raw: String!
+  usd: Float!
+}
+
+type AssetCollection {
+  items: [ContentfulAsset]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input AssetFilter {
+  AND: [AssetFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  contentType: String
+  contentType_contains: String
+  contentType_exists: Boolean
+  contentType_in: [String]
+  contentType_not: String
+  contentType_not_contains: String
+  contentType_not_in: [String]
+  description: String
+  description_contains: String
+  description_exists: Boolean
+  description_in: [String]
+  description_not: String
+  description_not_contains: String
+  description_not_in: [String]
+  fileName: String
+  fileName_contains: String
+  fileName_exists: Boolean
+  fileName_in: [String]
+  fileName_not: String
+  fileName_not_contains: String
+  fileName_not_in: [String]
+  height: Int
+  height_exists: Boolean
+  height_gt: Int
+  height_gte: Int
+  height_in: [Int]
+  height_lt: Int
+  height_lte: Int
+  height_not: Int
+  height_not_in: [Int]
+  OR: [AssetFilter]
+  size: Int
+  size_exists: Boolean
+  size_gt: Int
+  size_gte: Int
+  size_in: [Int]
+  size_lt: Int
+  size_lte: Int
+  size_not: Int
+  size_not_in: [Int]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+  url: String
+  url_contains: String
+  url_exists: Boolean
+  url_in: [String]
+  url_not: String
+  url_not_contains: String
+  url_not_in: [String]
+  width: Int
+  width_exists: Boolean
+  width_gt: Int
+  width_gte: Int
+  width_in: [Int]
+  width_lt: Int
+  width_lte: Int
+  width_not: Int
+  width_not_in: [Int]
+}
+
+type AssetLinkingCollections {
+  dropCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsDropCollectionOrder], preview: Boolean, skip: Int = 0): DropCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  personCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsPersonCollectionOrder], preview: Boolean, skip: Int = 0): PersonCollection
+  postCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsPostCollectionOrder], preview: Boolean, skip: Int = 0): PostCollection
+  promoSheetCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsPromoSheetCollectionOrder], preview: Boolean, skip: Int = 0): PromoSheetCollection
+}
+
+enum AssetLinkingCollectionsDropCollectionOrder {
+  backgroundColor_ASC
+  backgroundColor_DESC
+  buttonColor_ASC
+  buttonColor_DESC
+  buttonShadowColor_ASC
+  buttonShadowColor_DESC
+  buttonTextColor_ASC
+  buttonTextColor_DESC
+  contractAddress_ASC
+  contractAddress_DESC
+  downloadLink_ASC
+  downloadLink_DESC
+  firstProductHighlightBackground_ASC
+  firstProductHighlightBackground_DESC
+  firstProductHighlightTextColor_ASC
+  firstProductHighlightTextColor_DESC
+  firstProductHighlightTitle_ASC
+  firstProductHighlightTitle_DESC
+  gradientColor_ASC
+  gradientColor_DESC
+  linearGradientColor_ASC
+  linearGradientColor_DESC
+  linkColor_ASC
+  linkColor_DESC
+  partnerLink_ASC
+  partnerLink_DESC
+  partnerTitle_ASC
+  partnerTitle_DESC
+  presaleName_ASC
+  presaleName_DESC
+  radialGradientColor_ASC
+  radialGradientColor_DESC
+  secondProductHighlightBackground_ASC
+  secondProductHighlightBackground_DESC
+  secondProductHighlightTextColor_ASC
+  secondProductHighlightTextColor_DESC
+  secondProductHighlightTitle_ASC
+  secondProductHighlightTitle_DESC
+  showFooter_ASC
+  showFooter_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  textColor_ASC
+  textColor_DESC
+  title_ASC
+  title_DESC
+  unlockableTitle_ASC
+  unlockableTitle_DESC
+}
+
+enum AssetLinkingCollectionsPersonCollectionOrder {
+  name_ASC
+  name_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+enum AssetLinkingCollectionsPostCollectionOrder {
+  date_ASC
+  date_DESC
+  seoTitle_ASC
+  seoTitle_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum AssetLinkingCollectionsPromoSheetCollectionOrder {
+  accentColor_ASC
+  accentColor_DESC
+  backgroundColor_ASC
+  backgroundColor_DESC
+  campaignKey_ASC
+  campaignKey_DESC
+  headerImageAspectRatio_ASC
+  headerImageAspectRatio_DESC
+  launchDate_ASC
+  launchDate_DESC
+  priority_ASC
+  priority_DESC
+  sheetHandleColor_ASC
+  sheetHandleColor_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+enum AssetOrder {
+  contentType_ASC
+  contentType_DESC
+  fileName_ASC
+  fileName_DESC
+  height_ASC
+  height_DESC
+  size_ASC
+  size_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  url_ASC
+  url_DESC
+  width_ASC
+  width_DESC
+}
+
+type Bridging {
+  bridgeable: Boolean!
+  networks: Networks
+}
+
+type Card implements Entry {
+  accentColor(locale: String): String
+  backgroundColor(locale: String): String
+  borderRadius(locale: String): Int
+  cardKey(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  dismissable(locale: String): Boolean
+  imageCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): AssetCollection
+  imageIcon(locale: String): String
+  imageRadius(locale: String): Int
+  index(locale: String): Int
+  linkedFrom(allowedLocales: [String]): CardLinkingCollections
+  padding(locale: String): Int
+  placement(locale: String): String
+  primaryButton(locale: String): JSON
+  subtitle(locale: String): JSON
+  subtitleColor(locale: String): String
+  sys: Sys!
+  title(locale: String): JSON
+  titleColor(locale: String): String
+}
+
+type CardCollection {
+  items: [Card]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input CardFilter {
+  accentColor: String
+  accentColor_contains: String
+  accentColor_exists: Boolean
+  accentColor_in: [String]
+  accentColor_not: String
+  accentColor_not_contains: String
+  accentColor_not_in: [String]
+  AND: [CardFilter]
+  backgroundColor: String
+  backgroundColor_contains: String
+  backgroundColor_exists: Boolean
+  backgroundColor_in: [String]
+  backgroundColor_not: String
+  backgroundColor_not_contains: String
+  backgroundColor_not_in: [String]
+  borderRadius: Int
+  borderRadius_exists: Boolean
+  borderRadius_gt: Int
+  borderRadius_gte: Int
+  borderRadius_in: [Int]
+  borderRadius_lt: Int
+  borderRadius_lte: Int
+  borderRadius_not: Int
+  borderRadius_not_in: [Int]
+  cardKey: String
+  cardKey_contains: String
+  cardKey_exists: Boolean
+  cardKey_in: [String]
+  cardKey_not: String
+  cardKey_not_contains: String
+  cardKey_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  dismissable: Boolean
+  dismissable_exists: Boolean
+  dismissable_not: Boolean
+  imageCollection_exists: Boolean
+  imageIcon: String
+  imageIcon_contains: String
+  imageIcon_exists: Boolean
+  imageIcon_in: [String]
+  imageIcon_not: String
+  imageIcon_not_contains: String
+  imageIcon_not_in: [String]
+  imageRadius: Int
+  imageRadius_exists: Boolean
+  imageRadius_gt: Int
+  imageRadius_gte: Int
+  imageRadius_in: [Int]
+  imageRadius_lt: Int
+  imageRadius_lte: Int
+  imageRadius_not: Int
+  imageRadius_not_in: [Int]
+  index: Int
+  index_exists: Boolean
+  index_gt: Int
+  index_gte: Int
+  index_in: [Int]
+  index_lt: Int
+  index_lte: Int
+  index_not: Int
+  index_not_in: [Int]
+  OR: [CardFilter]
+  padding: Int
+  padding_exists: Boolean
+  padding_gt: Int
+  padding_gte: Int
+  padding_in: [Int]
+  padding_lt: Int
+  padding_lte: Int
+  padding_not: Int
+  padding_not_in: [Int]
+  placement: String
+  placement_contains: String
+  placement_exists: Boolean
+  placement_in: [String]
+  placement_not: String
+  placement_not_contains: String
+  placement_not_in: [String]
+  primaryButton_exists: Boolean
+  subtitle_exists: Boolean
+  subtitleColor: String
+  subtitleColor_contains: String
+  subtitleColor_exists: Boolean
+  subtitleColor_in: [String]
+  subtitleColor_not: String
+  subtitleColor_not_contains: String
+  subtitleColor_not_in: [String]
+  sys: SysFilter
+  title_exists: Boolean
+  titleColor: String
+  titleColor_contains: String
+  titleColor_exists: Boolean
+  titleColor_in: [String]
+  titleColor_not: String
+  titleColor_not_contains: String
+  titleColor_not_in: [String]
+}
+
+type CardLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum CardOrder {
+  accentColor_ASC
+  accentColor_DESC
+  backgroundColor_ASC
+  backgroundColor_DESC
+  borderRadius_ASC
+  borderRadius_DESC
+  cardKey_ASC
+  cardKey_DESC
+  dismissable_ASC
+  dismissable_DESC
+  imageIcon_ASC
+  imageIcon_DESC
+  imageRadius_ASC
+  imageRadius_DESC
+  index_ASC
+  index_DESC
+  padding_ASC
+  padding_DESC
+  placement_ASC
+  placement_DESC
+  subtitleColor_ASC
+  subtitleColor_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  titleColor_ASC
+  titleColor_DESC
+}
+
+type CollectionsForAddressResponse {
+  data: [NftCollectionData]!
+  nextPageKey: String
+
+  """
+  Number of collections in the current page (i.e. `data.length`), NOT a
+  wallet-wide total. The NFT gateway does not expose a total collection count,
+  so this no longer reflects all pages. Use `nextPageKey` for "has more"
+  semantics.
+  """
+  totalCollections: Int! @deprecated(reason: "Gateway has no wallet-wide collection total; this now returns the current page count. Use nextPageKey for pagination.")
+}
+
+type Colors {
+  fallback: String
+  primary: String!
+  shadow: String
+}
+
+type ContentfulAsset {
+  contentfulMetadata: ContentfulMetadata!
+  contentType(locale: String): String
+  description(locale: String): String
+  fileName(locale: String): String
+  height(locale: String): Int
+  linkedFrom(allowedLocales: [String]): AssetLinkingCollections
+  size(locale: String): Int
+  sys: Sys!
+  title(locale: String): String
+  url(locale: String, transform: ImageTransformOptions): String
+  width(locale: String): Int
+}
+
+type ContentfulMetadata {
+  tags: [ContentfulTag]!
+}
+
+input ContentfulMetadataFilter {
+  tags: ContentfulMetadataTagsFilter
+  tags_exists: Boolean
+}
+
+input ContentfulMetadataTagsFilter {
+  id_contains_all: [String]
+  id_contains_none: [String]
+  id_contains_some: [String]
+}
+
+type ContentfulTag {
+  id: String
+  name: String
+}
+
+"""Custom scalar type for handling DateTime strings in ISO 8601 format"""
+scalar DateTime
+
+scalar Dimension
+
+type Drop implements Entry {
+  backgroundColor(locale: String): String
+  backgroundImage(locale: String, preview: Boolean): ContentfulAsset
+  buttonColor(locale: String): String
+  buttonShadowColor(locale: String): String
+  buttonTextColor(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  contractAddress(locale: String): String
+  description(locale: String): String
+  downloadLink(locale: String): String
+  dropAsset(locale: String, preview: Boolean): ContentfulAsset
+  firstProductHighlightBackground(locale: String): String
+  firstProductHighlightDescription(locale: String): String
+  firstProductHighlightImage(locale: String, preview: Boolean): ContentfulAsset
+  firstProductHighlightTextColor(locale: String): String
+  firstProductHighlightTitle(locale: String): String
+  gradientColor(locale: String): String
+  linearGradientColor(locale: String): String
+  linkColor(locale: String): String
+  linkedFrom(allowedLocales: [String]): DropLinkingCollections
+  metaImage(locale: String, preview: Boolean): ContentfulAsset
+  partnerAsset(locale: String, preview: Boolean): ContentfulAsset
+  partnerDescription(locale: String): String
+  partnerLink(locale: String): String
+  partnerTitle(locale: String): String
+  presaleName(locale: String): String
+  radialGradientColor(locale: String): String
+  secondProductHighlightBackground(locale: String): String
+  secondProductHighlightDescription(locale: String): String
+  secondProductHighlightImage(locale: String, preview: Boolean): ContentfulAsset
+  secondProductHighlightTextColor(locale: String): String
+  secondProductHighlightTitle(locale: String): String
+  showFooter(locale: String): Boolean
+  slug(locale: String): String
+  sys: Sys!
+  textColor(locale: String): String
+  title(locale: String): String
+  unlockableAsset(locale: String, preview: Boolean): ContentfulAsset
+  unlockableDescription(locale: String): String
+  unlockableTitle(locale: String): String
+}
+
+type DropCollection {
+  items: [Drop]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input DropFilter {
+  AND: [DropFilter]
+  backgroundColor: String
+  backgroundColor_contains: String
+  backgroundColor_exists: Boolean
+  backgroundColor_in: [String]
+  backgroundColor_not: String
+  backgroundColor_not_contains: String
+  backgroundColor_not_in: [String]
+  backgroundImage_exists: Boolean
+  buttonColor: String
+  buttonColor_contains: String
+  buttonColor_exists: Boolean
+  buttonColor_in: [String]
+  buttonColor_not: String
+  buttonColor_not_contains: String
+  buttonColor_not_in: [String]
+  buttonShadowColor: String
+  buttonShadowColor_contains: String
+  buttonShadowColor_exists: Boolean
+  buttonShadowColor_in: [String]
+  buttonShadowColor_not: String
+  buttonShadowColor_not_contains: String
+  buttonShadowColor_not_in: [String]
+  buttonTextColor: String
+  buttonTextColor_contains: String
+  buttonTextColor_exists: Boolean
+  buttonTextColor_in: [String]
+  buttonTextColor_not: String
+  buttonTextColor_not_contains: String
+  buttonTextColor_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  contractAddress: String
+  contractAddress_contains: String
+  contractAddress_exists: Boolean
+  contractAddress_in: [String]
+  contractAddress_not: String
+  contractAddress_not_contains: String
+  contractAddress_not_in: [String]
+  description: String
+  description_contains: String
+  description_exists: Boolean
+  description_in: [String]
+  description_not: String
+  description_not_contains: String
+  description_not_in: [String]
+  downloadLink: String
+  downloadLink_contains: String
+  downloadLink_exists: Boolean
+  downloadLink_in: [String]
+  downloadLink_not: String
+  downloadLink_not_contains: String
+  downloadLink_not_in: [String]
+  dropAsset_exists: Boolean
+  firstProductHighlightBackground: String
+  firstProductHighlightBackground_contains: String
+  firstProductHighlightBackground_exists: Boolean
+  firstProductHighlightBackground_in: [String]
+  firstProductHighlightBackground_not: String
+  firstProductHighlightBackground_not_contains: String
+  firstProductHighlightBackground_not_in: [String]
+  firstProductHighlightDescription: String
+  firstProductHighlightDescription_contains: String
+  firstProductHighlightDescription_exists: Boolean
+  firstProductHighlightDescription_in: [String]
+  firstProductHighlightDescription_not: String
+  firstProductHighlightDescription_not_contains: String
+  firstProductHighlightDescription_not_in: [String]
+  firstProductHighlightImage_exists: Boolean
+  firstProductHighlightTextColor: String
+  firstProductHighlightTextColor_contains: String
+  firstProductHighlightTextColor_exists: Boolean
+  firstProductHighlightTextColor_in: [String]
+  firstProductHighlightTextColor_not: String
+  firstProductHighlightTextColor_not_contains: String
+  firstProductHighlightTextColor_not_in: [String]
+  firstProductHighlightTitle: String
+  firstProductHighlightTitle_contains: String
+  firstProductHighlightTitle_exists: Boolean
+  firstProductHighlightTitle_in: [String]
+  firstProductHighlightTitle_not: String
+  firstProductHighlightTitle_not_contains: String
+  firstProductHighlightTitle_not_in: [String]
+  gradientColor: String
+  gradientColor_contains: String
+  gradientColor_exists: Boolean
+  gradientColor_in: [String]
+  gradientColor_not: String
+  gradientColor_not_contains: String
+  gradientColor_not_in: [String]
+  linearGradientColor: String
+  linearGradientColor_contains: String
+  linearGradientColor_exists: Boolean
+  linearGradientColor_in: [String]
+  linearGradientColor_not: String
+  linearGradientColor_not_contains: String
+  linearGradientColor_not_in: [String]
+  linkColor: String
+  linkColor_contains: String
+  linkColor_exists: Boolean
+  linkColor_in: [String]
+  linkColor_not: String
+  linkColor_not_contains: String
+  linkColor_not_in: [String]
+  metaImage_exists: Boolean
+  OR: [DropFilter]
+  partnerAsset_exists: Boolean
+  partnerDescription: String
+  partnerDescription_contains: String
+  partnerDescription_exists: Boolean
+  partnerDescription_in: [String]
+  partnerDescription_not: String
+  partnerDescription_not_contains: String
+  partnerDescription_not_in: [String]
+  partnerLink: String
+  partnerLink_contains: String
+  partnerLink_exists: Boolean
+  partnerLink_in: [String]
+  partnerLink_not: String
+  partnerLink_not_contains: String
+  partnerLink_not_in: [String]
+  partnerTitle: String
+  partnerTitle_contains: String
+  partnerTitle_exists: Boolean
+  partnerTitle_in: [String]
+  partnerTitle_not: String
+  partnerTitle_not_contains: String
+  partnerTitle_not_in: [String]
+  presaleName: String
+  presaleName_contains: String
+  presaleName_exists: Boolean
+  presaleName_in: [String]
+  presaleName_not: String
+  presaleName_not_contains: String
+  presaleName_not_in: [String]
+  radialGradientColor: String
+  radialGradientColor_contains: String
+  radialGradientColor_exists: Boolean
+  radialGradientColor_in: [String]
+  radialGradientColor_not: String
+  radialGradientColor_not_contains: String
+  radialGradientColor_not_in: [String]
+  secondProductHighlightBackground: String
+  secondProductHighlightBackground_contains: String
+  secondProductHighlightBackground_exists: Boolean
+  secondProductHighlightBackground_in: [String]
+  secondProductHighlightBackground_not: String
+  secondProductHighlightBackground_not_contains: String
+  secondProductHighlightBackground_not_in: [String]
+  secondProductHighlightDescription: String
+  secondProductHighlightDescription_contains: String
+  secondProductHighlightDescription_exists: Boolean
+  secondProductHighlightDescription_in: [String]
+  secondProductHighlightDescription_not: String
+  secondProductHighlightDescription_not_contains: String
+  secondProductHighlightDescription_not_in: [String]
+  secondProductHighlightImage_exists: Boolean
+  secondProductHighlightTextColor: String
+  secondProductHighlightTextColor_contains: String
+  secondProductHighlightTextColor_exists: Boolean
+  secondProductHighlightTextColor_in: [String]
+  secondProductHighlightTextColor_not: String
+  secondProductHighlightTextColor_not_contains: String
+  secondProductHighlightTextColor_not_in: [String]
+  secondProductHighlightTitle: String
+  secondProductHighlightTitle_contains: String
+  secondProductHighlightTitle_exists: Boolean
+  secondProductHighlightTitle_in: [String]
+  secondProductHighlightTitle_not: String
+  secondProductHighlightTitle_not_contains: String
+  secondProductHighlightTitle_not_in: [String]
+  showFooter: Boolean
+  showFooter_exists: Boolean
+  showFooter_not: Boolean
+  slug: String
+  slug_contains: String
+  slug_exists: Boolean
+  slug_in: [String]
+  slug_not: String
+  slug_not_contains: String
+  slug_not_in: [String]
+  sys: SysFilter
+  textColor: String
+  textColor_contains: String
+  textColor_exists: Boolean
+  textColor_in: [String]
+  textColor_not: String
+  textColor_not_contains: String
+  textColor_not_in: [String]
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+  unlockableAsset_exists: Boolean
+  unlockableDescription: String
+  unlockableDescription_contains: String
+  unlockableDescription_exists: Boolean
+  unlockableDescription_in: [String]
+  unlockableDescription_not: String
+  unlockableDescription_not_contains: String
+  unlockableDescription_not_in: [String]
+  unlockableTitle: String
+  unlockableTitle_contains: String
+  unlockableTitle_exists: Boolean
+  unlockableTitle_in: [String]
+  unlockableTitle_not: String
+  unlockableTitle_not_contains: String
+  unlockableTitle_not_in: [String]
+}
+
+type DropLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum DropOrder {
+  backgroundColor_ASC
+  backgroundColor_DESC
+  buttonColor_ASC
+  buttonColor_DESC
+  buttonShadowColor_ASC
+  buttonShadowColor_DESC
+  buttonTextColor_ASC
+  buttonTextColor_DESC
+  contractAddress_ASC
+  contractAddress_DESC
+  downloadLink_ASC
+  downloadLink_DESC
+  firstProductHighlightBackground_ASC
+  firstProductHighlightBackground_DESC
+  firstProductHighlightTextColor_ASC
+  firstProductHighlightTextColor_DESC
+  firstProductHighlightTitle_ASC
+  firstProductHighlightTitle_DESC
+  gradientColor_ASC
+  gradientColor_DESC
+  linearGradientColor_ASC
+  linearGradientColor_DESC
+  linkColor_ASC
+  linkColor_DESC
+  partnerLink_ASC
+  partnerLink_DESC
+  partnerTitle_ASC
+  partnerTitle_DESC
+  presaleName_ASC
+  presaleName_DESC
+  radialGradientColor_ASC
+  radialGradientColor_DESC
+  secondProductHighlightBackground_ASC
+  secondProductHighlightBackground_DESC
+  secondProductHighlightTextColor_ASC
+  secondProductHighlightTextColor_DESC
+  secondProductHighlightTitle_ASC
+  secondProductHighlightTitle_DESC
+  showFooter_ASC
+  showFooter_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  textColor_ASC
+  textColor_DESC
+  title_ASC
+  title_DESC
+  unlockableTitle_ASC
+  unlockableTitle_DESC
+}
+
+interface Entry {
+  contentfulMetadata: ContentfulMetadata!
+  sys: Sys!
+}
+
+type EntryCollection {
+  items: [Entry]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input EntryFilter {
+  AND: [EntryFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  OR: [EntryFilter]
+  sys: SysFilter
+}
+
+enum EntryOrder {
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type FaqEntry implements Entry {
+  answer(locale: String): FaqEntryAnswer
+  contentfulMetadata: ContentfulMetadata!
+  featured(locale: String): Boolean
+  linkedFrom(allowedLocales: [String]): FaqEntryLinkingCollections
+  order(locale: String): Int
+  question(locale: String): String
+  sys: Sys!
+}
+
+type FaqEntryAnswer {
+  json: JSON!
+  links: FaqEntryAnswerLinks!
+}
+
+type FaqEntryAnswerAssets {
+  block: [ContentfulAsset]!
+  hyperlink: [ContentfulAsset]!
+}
+
+type FaqEntryAnswerEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type FaqEntryAnswerLinks {
+  assets: FaqEntryAnswerAssets!
+  entries: FaqEntryAnswerEntries!
+  resources: FaqEntryAnswerResources!
+}
+
+type FaqEntryAnswerResources {
+  block: [ResourceLink!]!
+  hyperlink: [ResourceLink!]!
+  inline: [ResourceLink!]!
+}
+
+type FaqEntryCollection {
+  items: [FaqEntry]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input FaqEntryFilter {
+  AND: [FaqEntryFilter]
+  answer_contains: String
+  answer_exists: Boolean
+  answer_not_contains: String
+  contentfulMetadata: ContentfulMetadataFilter
+  featured: Boolean
+  featured_exists: Boolean
+  featured_not: Boolean
+  OR: [FaqEntryFilter]
+  order: Int
+  order_exists: Boolean
+  order_gt: Int
+  order_gte: Int
+  order_in: [Int]
+  order_lt: Int
+  order_lte: Int
+  order_not: Int
+  order_not_in: [Int]
+  question: String
+  question_contains: String
+  question_exists: Boolean
+  question_in: [String]
+  question_not: String
+  question_not_contains: String
+  question_not_in: [String]
+  sys: SysFilter
+}
+
+type FaqEntryLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum FaqEntryOrder {
+  featured_ASC
+  featured_DESC
+  order_ASC
+  order_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type FarcasterUser {
+  fid: Int!
+  follower_count: Int!
+  following_count: Int!
+  pfp_url: String
+  power_badge: Boolean!
+  username: String
+}
+
+type FeaturedMint implements Entry {
+  chainId(locale: String): Int
+  contentfulMetadata: ContentfulMetadata!
+  contractAddress(locale: String): String
+  linkedFrom(allowedLocales: [String]): FeaturedMintLinkingCollections
+  name(locale: String): String
+  sys: Sys!
+}
+
+type FeaturedMintCollection {
+  items: [FeaturedMint]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input FeaturedMintFilter {
+  AND: [FeaturedMintFilter]
+  chainId: Int
+  chainId_exists: Boolean
+  chainId_gt: Int
+  chainId_gte: Int
+  chainId_in: [Int]
+  chainId_lt: Int
+  chainId_lte: Int
+  chainId_not: Int
+  chainId_not_in: [Int]
+  contentfulMetadata: ContentfulMetadataFilter
+  contractAddress: String
+  contractAddress_contains: String
+  contractAddress_exists: Boolean
+  contractAddress_in: [String]
+  contractAddress_not: String
+  contractAddress_not_contains: String
+  contractAddress_not_in: [String]
+  name: String
+  name_contains: String
+  name_exists: Boolean
+  name_in: [String]
+  name_not: String
+  name_not_contains: String
+  name_not_in: [String]
+  OR: [FeaturedMintFilter]
+  sys: SysFilter
+}
+
+type FeaturedMintLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum FeaturedMintOrder {
+  chainId_ASC
+  chainId_DESC
+  contractAddress_ASC
+  contractAddress_DESC
+  name_ASC
+  name_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type FeaturedResult {
+  advertiserId: String!
+  category: String
+  context: FeaturedResultContext
+  ctas: [FeaturedResultCallToAction!]
+  description: String!
+  id: String!
+  imageAltText: String!
+  imageUrl: String!
+  imageVariants: ImageVariants
+  impressionId: String!
+  placementSlug: String!
+  title: String!
+  type: FeaturedResultType!
+}
+
+type FeaturedResultCallToAction {
+  href: String!
+  title: String!
+}
+
+type FeaturedResultContext {
+  text: String!
+}
+
+type FeaturedResultsResponse {
+  items: [FeaturedResult!]
+}
+
+enum FeaturedResultType {
+  CARD
+  DISCORD
+  IFRAME
+}
+
+scalar HexColor
+
+enum ImageFormat {
+  AVIF
+  JPG
+  JPG_PROGRESSIVE
+  PNG
+  PNG8
+  WEBP
+}
+
+enum ImageResizeFocus {
+  BOTTOM
+  BOTTOM_LEFT
+  BOTTOM_RIGHT
+  CENTER
+  FACE
+  FACES
+  LEFT
+  RIGHT
+  TOP
+  TOP_LEFT
+  TOP_RIGHT
+}
+
+enum ImageResizeStrategy {
+  CROP
+  FILL
+  FIT
+  PAD
+  SCALE
+  THUMB
+}
+
+input ImageTransformOptions {
+  backgroundColor: HexColor
+  cornerRadius: Int
+  format: ImageFormat
+  height: Dimension
+  quality: Quality
+  resizeFocus: ImageResizeFocus
+  resizeStrategy: ImageResizeStrategy
+  width: Dimension
+}
+
+type ImageVariant {
+  url: String
+}
+
+type ImageVariants {
+  orig: ImageVariant
+  x1: ImageVariant
+  x2: ImageVariant
+  x3: ImageVariant
+}
+
+scalar JSON
+
+type Market {
+  ath: PricePoint
+  atl: PricePoint
+  circulating_supply: Float
+  currency_used: String
+  fdv: Float
+  market_cap: MarketCap
+  max_supply: Float
+  price: Price
+  total_supply: Float
+  updated_at: DateTime
+  volume_24h: Float
+}
+
+type MarketCap {
+  change_24h: Float
+  value: Float
+}
+
+type MintableCollection {
+  addressesLastHour: Int
+  chainId: Int!
+  contract: String!
+  contractAddress: String!
+  deployer: String
+  externalURL: String!
+  firstEvent: String!
+  imageMimeType: String
+  imageURL: String
+  lastEvent: String
+  maxSupply: String
+  mintsLastHour: Int!
+  mintStatus: MintStatus!
+  name: String!
+  recentMints: [MintedNFT!]!
+  totalMints: Int!
+}
+
+type MintableCollectionResult {
+  collection: MintableCollection!
+}
+
+type MintableCollectionsResult {
+  collections: [MintableCollection!]!
+}
+
+type MintedNFT {
+  imageURI: String
+  mimeType: String
+  mintTime: String
+  title: String
+  tokenID: String!
+  value: String
+}
+
+type MintStatus {
+  isMintable: Boolean!
+  price: String!
+}
+
+type Mutation {
+  trackFeaturedResult(featuredResultCreativeId: String!, impressionId: String!, placementId: String!, type: TrackFeaturedResultType!): TrackFeaturedResultResponse
+}
+
+type NetworkInfo {
+  address: String!
+  decimals: Int!
+}
+
+type Networks {
+  """Chain IDs as keys (e.g. '8453')"""
+  _: NetworkInfo
+}
+
+type NftCollectionData {
+  id: String!
+  imageUrl: String!
+  name: String!
+  totalCount: String!
+}
+
+enum NFTCollectionSortCriterion {
+  ABC
+  FLOOR_PRICE
+  MOST_RECENT
+}
+
+type NFTFloorPrice {
+  amount: AssetAmount!
+  paymentToken: Asset!
+}
+
+type NFTMarketplace {
+  imageUrl: String!
+  name: String!
+}
+
+type NFTOffer {
+  createdAt: Int!
+  feesPercentage: Float!
+  floorDifferencePercentage: Float!
+  floorPrice: NFTFloorPrice!
+  grossAmount: AssetAmount!
+  marketplace: NFTMarketplace!
+  netAmount: AssetAmount!
+  network: String!
+  nft: PartialNFT!
+  paymentToken: Asset!
+  royaltiesPercentage: Float!
+  url: String!
+  validUntil: Int!
+}
+
+enum NftTokenType {
+  ERC1155
+  ERC721
+  NO_SUPPORTED_NFT_STANDARD
+  NOT_A_CONTRACT
+  UNKNOWN
+}
+
+type PartialNFT {
+  aspectRatio: Float
+  collectionName: String!
+  contractAddress: String!
+  imageUrl: String!
+  name: String!
+  predominantColor: String
+  tokenId: String!
+  uniqueId: String!
+}
+
+type Person implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  linkedFrom(allowedLocales: [String]): PersonLinkingCollections
+  name(locale: String): String
+  profilePic(locale: String, preview: Boolean): ContentfulAsset
+  sys: Sys!
+}
+
+type PersonCollection {
+  items: [Person]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input PersonFilter {
+  AND: [PersonFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  name: String
+  name_contains: String
+  name_exists: Boolean
+  name_in: [String]
+  name_not: String
+  name_not_contains: String
+  name_not_in: [String]
+  OR: [PersonFilter]
+  profilePic_exists: Boolean
+  sys: SysFilter
+}
+
+type PersonLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PersonOrder {
+  name_ASC
+  name_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+type PoapClaimResult {
+  error: String
+  success: Boolean!
+}
+
+type PoapEvent {
+  createdAt: String!
+  id: Int!
+  imageUrl: String!
+  name: String!
+  qrHash: String
+  secret: String
+  secretWord: String
+}
+
+type PointsTweetIntent implements Entry {
+  contentfulMetadata: ContentfulMetadata!
+  key(locale: String): String
+  linkedFrom(allowedLocales: [String]): PointsTweetIntentLinkingCollections
+  sys: Sys!
+  text(locale: String): String
+  url(locale: String): String
+  via(locale: String): String
+}
+
+type PointsTweetIntentCollection {
+  items: [PointsTweetIntent]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input PointsTweetIntentFilter {
+  AND: [PointsTweetIntentFilter]
+  contentfulMetadata: ContentfulMetadataFilter
+  key: String
+  key_contains: String
+  key_exists: Boolean
+  key_in: [String]
+  key_not: String
+  key_not_contains: String
+  key_not_in: [String]
+  OR: [PointsTweetIntentFilter]
+  sys: SysFilter
+  text: String
+  text_contains: String
+  text_exists: Boolean
+  text_in: [String]
+  text_not: String
+  text_not_contains: String
+  text_not_in: [String]
+  url: String
+  url_contains: String
+  url_exists: Boolean
+  url_in: [String]
+  url_not: String
+  url_not_contains: String
+  url_not_in: [String]
+  via: String
+  via_contains: String
+  via_exists: Boolean
+  via_in: [String]
+  via_not: String
+  via_not_contains: String
+  via_not_in: [String]
+}
+
+type PointsTweetIntentLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PointsTweetIntentOrder {
+  key_ASC
+  key_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  text_ASC
+  text_DESC
+  url_ASC
+  url_DESC
+  via_ASC
+  via_DESC
+}
+
+type PoolData {
+  currency_used: String!
+  h1_price_change: Float
+  h1_volume: Float
+  h24_price_change: Float
+  h24_volume: Float
+  h6_price_change: Float
+  h6_volume: Float
+  m5_price_change: Float
+  m5_volume: Float
+  reserve: Float
+}
+
+type Post implements Entry {
+  content(locale: String): PostContent
+  contentfulMetadata: ContentfulMetadata!
+  coverImage(locale: String, preview: Boolean): ContentfulAsset
+  date(locale: String): DateTime
+  excerpt(locale: String): String
+  linkedFrom(allowedLocales: [String]): PostLinkingCollections
+  person(locale: String, preview: Boolean): Entry
+  seoTitle(locale: String): String
+  slug(locale: String): String
+  sys: Sys!
+  title(locale: String): String
+}
+
+type PostCollection {
+  items: [Post]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+type PostContent {
+  json: JSON!
+  links: PostContentLinks!
+}
+
+type PostContentAssets {
+  block: [ContentfulAsset]!
+  hyperlink: [ContentfulAsset]!
+}
+
+type PostContentEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type PostContentLinks {
+  assets: PostContentAssets!
+  entries: PostContentEntries!
+  resources: PostContentResources!
+}
+
+type PostContentResources {
+  block: [ResourceLink!]!
+  hyperlink: [ResourceLink!]!
+  inline: [ResourceLink!]!
+}
+
+input PostFilter {
+  AND: [PostFilter]
+  content_contains: String
+  content_exists: Boolean
+  content_not_contains: String
+  contentfulMetadata: ContentfulMetadataFilter
+  coverImage_exists: Boolean
+  date: DateTime
+  date_exists: Boolean
+  date_gt: DateTime
+  date_gte: DateTime
+  date_in: [DateTime]
+  date_lt: DateTime
+  date_lte: DateTime
+  date_not: DateTime
+  date_not_in: [DateTime]
+  excerpt: String
+  excerpt_contains: String
+  excerpt_exists: Boolean
+  excerpt_in: [String]
+  excerpt_not: String
+  excerpt_not_contains: String
+  excerpt_not_in: [String]
+  OR: [PostFilter]
+  person_exists: Boolean
+  seoTitle: String
+  seoTitle_contains: String
+  seoTitle_exists: Boolean
+  seoTitle_in: [String]
+  seoTitle_not: String
+  seoTitle_not_contains: String
+  seoTitle_not_in: [String]
+  slug: String
+  slug_contains: String
+  slug_exists: Boolean
+  slug_in: [String]
+  slug_not: String
+  slug_not_contains: String
+  slug_not_in: [String]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+type PostLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PostOrder {
+  date_ASC
+  date_DESC
+  seoTitle_ASC
+  seoTitle_DESC
+  slug_ASC
+  slug_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+type Price {
+  change_24h: Float
+  value: Float
+}
+
+type PricePoint {
+  change_percentage: Float
+  date: DateTime
+  value: Float
+}
+
+type PromoSheet implements Entry {
+  accentColor(locale: String): String
+  actions(locale: String): JSON
+  backgroundColor(locale: String): String
+  backgroundImage(locale: String, preview: Boolean): ContentfulAsset
+  campaignKey(locale: String): String
+  contentfulMetadata: ContentfulMetadata!
+  header(locale: String): JSON
+  headerImage(locale: String, preview: Boolean): ContentfulAsset
+  headerImageAspectRatio(locale: String): Float
+  items(locale: String): JSON
+  launchDate(locale: String): DateTime
+  linkedFrom(allowedLocales: [String]): PromoSheetLinkingCollections
+  primaryButtonProps(locale: String): JSON
+  priority(locale: String): Int
+  secondaryButtonProps(locale: String): JSON
+  sheetHandleColor(locale: String): String
+  subHeader(locale: String): JSON
+  sys: Sys!
+}
+
+type PromoSheetCollection {
+  items: [PromoSheet]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+input PromoSheetFilter {
+  accentColor: String
+  accentColor_contains: String
+  accentColor_exists: Boolean
+  accentColor_in: [String]
+  accentColor_not: String
+  accentColor_not_contains: String
+  accentColor_not_in: [String]
+  actions_exists: Boolean
+  AND: [PromoSheetFilter]
+  backgroundColor: String
+  backgroundColor_contains: String
+  backgroundColor_exists: Boolean
+  backgroundColor_in: [String]
+  backgroundColor_not: String
+  backgroundColor_not_contains: String
+  backgroundColor_not_in: [String]
+  backgroundImage_exists: Boolean
+  campaignKey: String
+  campaignKey_contains: String
+  campaignKey_exists: Boolean
+  campaignKey_in: [String]
+  campaignKey_not: String
+  campaignKey_not_contains: String
+  campaignKey_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  header_exists: Boolean
+  headerImage_exists: Boolean
+  headerImageAspectRatio: Float
+  headerImageAspectRatio_exists: Boolean
+  headerImageAspectRatio_gt: Float
+  headerImageAspectRatio_gte: Float
+  headerImageAspectRatio_in: [Float]
+  headerImageAspectRatio_lt: Float
+  headerImageAspectRatio_lte: Float
+  headerImageAspectRatio_not: Float
+  headerImageAspectRatio_not_in: [Float]
+  items_exists: Boolean
+  launchDate: DateTime
+  launchDate_exists: Boolean
+  launchDate_gt: DateTime
+  launchDate_gte: DateTime
+  launchDate_in: [DateTime]
+  launchDate_lt: DateTime
+  launchDate_lte: DateTime
+  launchDate_not: DateTime
+  launchDate_not_in: [DateTime]
+  OR: [PromoSheetFilter]
+  primaryButtonProps_exists: Boolean
+  priority: Int
+  priority_exists: Boolean
+  priority_gt: Int
+  priority_gte: Int
+  priority_in: [Int]
+  priority_lt: Int
+  priority_lte: Int
+  priority_not: Int
+  priority_not_in: [Int]
+  secondaryButtonProps_exists: Boolean
+  sheetHandleColor: String
+  sheetHandleColor_contains: String
+  sheetHandleColor_exists: Boolean
+  sheetHandleColor_in: [String]
+  sheetHandleColor_not: String
+  sheetHandleColor_not_contains: String
+  sheetHandleColor_not_in: [String]
+  subHeader_exists: Boolean
+  sys: SysFilter
+}
+
+type PromoSheetLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+}
+
+enum PromoSheetOrder {
+  accentColor_ASC
+  accentColor_DESC
+  backgroundColor_ASC
+  backgroundColor_DESC
+  campaignKey_ASC
+  campaignKey_DESC
+  headerImageAspectRatio_ASC
+  headerImageAspectRatio_DESC
+  launchDate_ASC
+  launchDate_DESC
+  priority_ASC
+  priority_DESC
+  sheetHandleColor_ASC
+  sheetHandleColor_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+}
+
+scalar Quality
+
+type Query {
+  asset(id: String!, locale: String, preview: Boolean): ContentfulAsset
+  assetCollection(limit: Int = 100, locale: String, order: [AssetOrder], preview: Boolean, skip: Int = 0, where: AssetFilter): AssetCollection
+  card(id: String!, locale: String, preview: Boolean): Card
+  cardCollection(limit: Int = 100, locale: String, order: [CardOrder], preview: Boolean, skip: Int = 0, where: CardFilter): CardCollection
+  claimPoapByQrHash(qrHash: String!, secret: String!, walletAddress: String!): PoapClaimResult
+  claimPoapBySecretWord(secretWord: String!, walletAddress: String!): PoapClaimResult
+  drop(id: String!, locale: String, preview: Boolean): Drop
+  dropCollection(limit: Int = 100, locale: String, order: [DropOrder], preview: Boolean, skip: Int = 0, where: DropFilter): DropCollection
+  entryCollection(limit: Int = 100, locale: String, order: [EntryOrder], preview: Boolean, skip: Int = 0, where: EntryFilter): EntryCollection
+  faqEntry(id: String!, locale: String, preview: Boolean): FaqEntry
+  faqEntryCollection(limit: Int = 100, locale: String, order: [FaqEntryOrder], preview: Boolean, skip: Int = 0, where: FaqEntryFilter): FaqEntryCollection
+  featuredResults(country: String, limit: Int, placementId: String!, walletAddress: String!): FeaturedResultsResponse!
+  getMintableCollection(chain: Int!, contractAddress: String!, walletAddress: String!): MintableCollectionResult
+  getMintableCollections(walletAddress: String!): MintableCollectionsResult
+  getNftsMetadata(tokens: JSON!, walletAddress: String!): [UniqueAsset!]!
+  getPoapEventByQrHash(qrHash: String!): PoapEvent
+  getPoapEventBySecretWord(secretWord: String!): PoapEvent
+  getReservoirCollection(chainId: Int!, contractAddress: String!): ReservoirCollectionResult
+  nftCollections(limit: Int, pageKey: String, walletAddress: String!): CollectionsForAddressResponse!
+  nftOffers(sortBy: SortCriterion!, walletAddress: String!): [NFTOffer!]
+  nftsByCollection(collectionId: String!, walletAddress: String!): [UniqueAsset!]!
+  nftsV2(sortBy: NFTCollectionSortCriterion, sortDirection: SortDirection, walletAddress: String!): [SimpleHashNFT!]
+  person(id: String!, locale: String, preview: Boolean): Person
+  personCollection(limit: Int = 100, locale: String, order: [PersonOrder], preview: Boolean, skip: Int = 0, where: PersonFilter): PersonCollection
+  pointsTweetIntent(id: String!, locale: String, preview: Boolean): PointsTweetIntent
+  pointsTweetIntentCollection(limit: Int = 100, locale: String, order: [PointsTweetIntentOrder], preview: Boolean, skip: Int = 0, where: PointsTweetIntentFilter): PointsTweetIntentCollection
+  post(id: String!, locale: String, preview: Boolean): Post
+  postCollection(limit: Int = 100, locale: String, order: [PostOrder], preview: Boolean, skip: Int = 0, where: PostFilter): PostCollection
+  promoSheet(id: String!, locale: String, preview: Boolean): PromoSheet
+  promoSheetCollection(limit: Int = 100, locale: String, order: [PromoSheetOrder], preview: Boolean, skip: Int = 0, where: PromoSheetFilter): PromoSheetCollection
+  trendingTokens(category: TrendingCategory! = TRENDING, chainId: Int = 0, currency: String! = "usd", limit: Int, sortBy: TrendingSort! = RECOMMENDED, sortDirection: SortDirection, timeframe: Timeframe! = H12, walletAddress: String): TrendingTokens!
+}
+
+type RainbowCollectionWithDetails {
+  collection_details: SimpleHashCollectionDetails!
+  collection_id: String!
+  distinct_nfts_owned: String!
+  last_acquired_date: String
+  nft_ids: [String!]!
+  total_copies_owned: String!
+}
+
+type ReservoirCollection {
+  chainId: Int!
+  createdAt: String
+  creator: String
+  description: String
+  id: String
+  image: String
+  isMintingPublicSale: Boolean
+  name: String
+  ownerCount: Int
+  publicMintInfo: ReservoirMintStages
+  sampleImages: [String]
+  tokenCount: String
+}
+
+type ReservoirCollectionResult {
+  collection: ReservoirCollection
+}
+
+type ReservoirCurrency {
+  contract: String
+  decimals: Int
+  name: String
+  symbol: String
+}
+
+type ReservoirMintStages {
+  endTime: String
+  kind: String
+  maxMintsPerWallet: String
+  price: ReservoirPrice
+  stage: String
+  startTime: String
+}
+
+type ReservoirNumber {
+  decimal: Float
+  native: Float
+  raw: String
+  usd: Float
+}
+
+type ReservoirPrice {
+  amount: ReservoirNumber
+  currency: ReservoirCurrency
+  netAmount: ReservoirNumber
+}
+
+type ResourceLink {
+  sys: ResourceSys!
+}
+
+type ResourceSys {
+  linkType: String!
+  type: String!
+  urn: String!
+}
+
+type schema {
+  query: Query
+}
+
+type SimpleHashAttributes {
+  display_type: String
+  trait_type: String
+  value: String
+}
+
+type SimpleHashAudioProperties {
+  audio_coding: String
+  duration: Float
+  mime_type: String
+  size: Float
+}
+
+type SimpleHashCollection {
+  banner_image_url: String
+  category: String
+  chains: [String!]
+  collection_id: String
+  collection_royalties: [SimpleHashRoyalty!]
+  description: String
+  discord_url: String
+  distinct_nft_count: Float
+  distinct_owner_count: Float
+  external_url: String
+  floor_prices: [SimpleHashCollectionFloorPrice!]
+  image_url: String
+  instagram_url: String
+  is_nsfw: Boolean
+  marketplace_pages: [SimpleHashCollectionMarketplacePage!]
+  medium_username: String
+  metaplex_candy_machine: String
+  metaplex_first_verified_creator: String
+  metaplex_mint: String
+  name: String!
+  spam_score: Float
+  telegram_url: String
+  top_bids: [SimpleHashCollectionTopBid!]
+  top_contracts: [String!]
+  total_quantity: Float
+  twitter_username: String
+}
+
+type SimpleHashCollectionDetails {
+  banner_image_url: String
+  category: String
+  chains: [String!]!
+  collection_id: String!
+  collection_royalties: [SimpleHashRoyalty!]!
+  description: String
+  discord_url: String
+  distinct_nft_count: Int!
+  distinct_owner_count: Int!
+  external_url: String
+  floor_prices: [SimpleHashCollectionFloorPrice!]!
+  image_url: String
+  instagram_username: String
+  is_nsfw: Boolean!
+  marketplace_pages: [SimpleHashCollectionMarketplacePage!]!
+  medium_username: String
+  metaplex_first_verified_creator: String
+  metaplex_mint: String
+  name: String!
+  spam_score: Float!
+  telegram_url: String
+  top_contracts: [String!]!
+  total_quantity: Int!
+  twitter_username: String
+}
+
+type SimpleHashCollectionFloorPrice {
+  marketplace_id: String
+  payment_token: SimpleHashPaymentToken
+  value: Float
+  value_usd_cents: Float
+}
+
+type SimpleHashCollectionMarketplacePage {
+  collection_url: String
+  marketplace_collection_id: String
+  marketplace_id: String
+  marketplace_name: String
+  nft_url: String
+  verified: Boolean
+}
+
+type SimpleHashCollectionTopBid {
+  marketplace_id: String
+  payment_token: SimpleHashPaymentToken
+  value: Float
+  value_usd_cents: Float
+}
+
+type SimpleHashContract {
+  deployed_by: String
+  deployed_via_contract: String
+  has_multiple_collections: Boolean
+  name: String
+  owned_by: String
+  symbol: String
+  type: String
+}
+
+type SimpleHashExtraMetadata {
+  animation_original_url: String
+  attributes: [SimpleHashAttributes!]
+  image_original_url: String
+  metadata_original_url: String
+}
+
+type SimpleHashFirstCreated {
+  block_number: Float
+  minted_to: String
+  quantity: Float
+  quantity_string: String
+  timestamp: String
+  transaction: String
+  transaction_initiator: String
+}
+
+type SimpleHashImageProperties {
+  height: Float
+  mime_type: String
+  size: Float
+  width: Float
+}
+
+type SimpleHashLastSale {
+  from_address: String
+  is_bundle_sale: Boolean
+  marketplace_id: String
+  marketplace_name: String
+  payment_token: SimpleHashPaymentToken
+  quantity: Float
+  quantity_string: String
+  timestamp: String
+  to_address: String
+  total_price: Float
+  transaction: String
+  unit_price: Float
+  unit_price_usd_cents: Float
+}
+
+type SimpleHashModelProperties {
+  mime_type: String
+  size: Float
+}
+
+type SimpleHashNFT {
+  audio_properties: SimpleHashAudioProperties
+  audio_url: String
+  background_color: String
+  chain: String!
+  collection: SimpleHashCollection!
+  contract: SimpleHashContract
+  contract_address: String!
+  created_date: String
+  description: String
+  external_url: String
+  extra_metadata: SimpleHashExtraMetadata
+  first_created: SimpleHashFirstCreated
+  image_properties: SimpleHashImageProperties
+  image_url: String
+  last_sale: SimpleHashLastSale
+  model_properties: SimpleHashModelProperties
+  model_url: String
+  name: String!
+  nft_id: String
+  owner_count: Float
+  owners: [SimpleHashOwners!]
+  previews: SimpleHashPreviews
+  queried_wallet_balances: [SimpleHashQueriedWalletBalance]
+  rarity: SimpleHashRarity
+  royalty: [SimpleHashRoyalty!]
+  status: String
+  token_count: Float
+  token_id: String!
+  video_properties: SimpleHashVideoProperties
+  video_url: String
+}
+
+type SimpleHashOwners {
+  first_acquired_date: String
+  last_acquired_date: String
+  owner_address: String
+  quantity: Float
+}
+
+type SimpleHashPaymentToken {
+  address: String
+  decimals: Float
+  name: String
+  payment_token_id: String
+  symbol: String
+}
+
+type SimpleHashPreviews {
+  blurhash: String
+  image_large_url: String
+  image_medium_url: String
+  image_opengraph_url: String
+  image_small_url: String
+  predominant_color: String
+}
+
+type SimpleHashQueriedWalletBalance {
+  address: String
+  first_acquired_date: String
+  last_acquired_date: String
+  quantity: Int
+  quantity_string: String
+}
+
+type SimpleHashRarity {
+  rank: Float
+  score: Float
+  unique_attributes: Float
+}
+
+type SimpleHashRoyalty {
+  recipients: [SimpleHashRoyaltyRecipient!]
+  source: String
+  total_creator_fee_basis_points: Float
+}
+
+type SimpleHashRoyaltyRecipient {
+  address: String
+  basis_points: Float
+  percentage: Float
+}
+
+type SimpleHashVideoProperties {
+  audio_coding: String
+  duration: Float
+  height: Float
+  mime_type: String
+  size: Float
+  video_coding: String
+  width: Float
+}
+
+enum SortCriterion {
+  DATE_CREATED
+  FLOOR_DIFFERENCE_PERCENTAGE
+  TOP_BID_VALUE
+}
+
+enum SortDirection {
+  ASC
+  DESC
+}
+
+type SwapData {
+  bought_stats: SwapStats!
+  currency_used: String!
+  sold_stats: SwapStats!
+}
+
+type SwapStats {
+  farcaster_users: [FarcasterUser!]
+  total_transactions: Int
+  total_volume: Float
+  unique_users: Int
+}
+
+type Sys {
+  environmentId: String!
+  firstPublishedAt: DateTime
+  id: String!
+  publishedAt: DateTime
+  publishedVersion: Int
+  spaceId: String!
+}
+
+input SysFilter {
+  firstPublishedAt: DateTime
+  firstPublishedAt_exists: Boolean
+  firstPublishedAt_gt: DateTime
+  firstPublishedAt_gte: DateTime
+  firstPublishedAt_in: [DateTime]
+  firstPublishedAt_lt: DateTime
+  firstPublishedAt_lte: DateTime
+  firstPublishedAt_not: DateTime
+  firstPublishedAt_not_in: [DateTime]
+  id: String
+  id_contains: String
+  id_exists: Boolean
+  id_in: [String]
+  id_not: String
+  id_not_contains: String
+  id_not_in: [String]
+  publishedAt: DateTime
+  publishedAt_exists: Boolean
+  publishedAt_gt: DateTime
+  publishedAt_gte: DateTime
+  publishedAt_in: [DateTime]
+  publishedAt_lt: DateTime
+  publishedAt_lte: DateTime
+  publishedAt_not: DateTime
+  publishedAt_not_in: [DateTime]
+  publishedVersion: Float
+  publishedVersion_exists: Boolean
+  publishedVersion_gt: Float
+  publishedVersion_gte: Float
+  publishedVersion_in: [Float]
+  publishedVersion_lt: Float
+  publishedVersion_lte: Float
+  publishedVersion_not: Float
+  publishedVersion_not_in: [Float]
+}
+
+enum Timeframe {
+  D3
+  D7
+  H12
+  H24
+}
+
+type TrackFeaturedResultResponse {
+  message: String!
+}
+
+enum TrackFeaturedResultType {
+  CLICK
+  IMPRESSION
+}
+
+enum TrendingCategory {
+  FARCASTER
+  NEW
+  TRENDING
+}
+
+type TrendingData {
+  pool_data: PoolData!
+  rank: Int!
+  swap_data: SwapData!
+  trending_since: DateTime!
+}
+
+enum TrendingSort {
+  MARKET_CAP
+  RECOMMENDED
+  TOP_GAINERS
+  TOP_LOSERS
+  VOLUME
+}
+
+type TrendingToken {
+  address: String!
+  bridging: Bridging!
+  chainId: Int!
+  colors: Colors!
+  creationDate: DateTime
+  decimals: Int!
+  highLiquidity: Boolean!
+  icon_url: String!
+  isRainbowCurated: Boolean!
+  isVerified: Boolean!
+  market: Market!
+  name: String!
+  networks: Networks!
+  symbol: String!
+  transferable: Boolean!
+  trending: TrendingData!
+  uniqueId: String!
+}
+
+type TrendingTokens {
+  data: [TrendingToken!]!
+}
+
+type UniqueAsset {
+  acquiredAt: String
+  backgroundColor: String
+  collectionDescription: String
+  collectionImageUrl: String
+  collectionName: String
+  collectionUrl: String
+  description: String
+  discordUrl: String
+  floorPrice: Float
+  images: UniqueAssetImages!
+  isSendable: Boolean!
+  marketplaceName: String
+  marketplaceUrl: String
+  name: String!
+  standard: NftTokenType!
+  traits: [UniqueAssetTrait!]!
+  twitterUrl: String
+  type: String!
+  uniqueId: String!
+  websiteUrl: String
+}
+
+type UniqueAssetImages {
+  animatedMimeType: String
+  animatedUrl: String
+  highResUrl: String
+  lowResUrl: String
+  mimeType: String
+}
+
+type UniqueAssetTrait {
+  trait_type: String!
+  value: String!
+}

--- a/src/graphql/schemas/ens.graphql
+++ b/src/graphql/schemas/ens.graphql
@@ -1,0 +1,4359 @@
+"""
+creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
+"""
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+"""
+Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.
+"""
+directive @entity on OBJECT
+
+"""Defined a Subgraph ID for an object type"""
+directive @subgraphId(id: String!) on OBJECT
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+
+  """The block number"""
+  number: Int!
+
+  """The hash of the parent block"""
+  parentHash: Bytes
+
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  """
+  block: _Block_!
+
+  """The deployment ID"""
+  deployment: String!
+
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
+
+type AbiChanged implements ResolverEvent {
+  """The block number at which the event was emitted"""
+  blockNumber: Int!
+
+  """The content type of the ABI change"""
+  contentType: BigInt!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """The transaction hash of the transaction in which the event was emitted"""
+  transactionID: Bytes!
+}
+
+input AbiChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AbiChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  contentType: BigInt
+  contentType_gt: BigInt
+  contentType_gte: BigInt
+  contentType_in: [BigInt!]
+  contentType_lt: BigInt
+  contentType_lte: BigInt
+  contentType_not: BigInt
+  contentType_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [AbiChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum AbiChanged_orderBy {
+  blockNumber
+  contentType
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type Account {
+  """The domains owned by the account"""
+  domains(first: Int = 100, orderBy: Domain_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Domain_filter): [Domain!]!
+
+  """The unique identifier for the account"""
+  id: ID!
+
+  """The Registrations made by the account"""
+  registrations(first: Int = 100, orderBy: Registration_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Registration_filter): [Registration!]
+
+  """The WrappedDomains owned by the account"""
+  wrappedDomains(first: Int = 100, orderBy: WrappedDomain_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: WrappedDomain_filter): [WrappedDomain!]
+}
+
+input Account_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Account_filter]
+  domains_: Domain_filter
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [Account_filter]
+  registrations_: Registration_filter
+  wrappedDomains_: WrappedDomain_filter
+}
+
+enum Account_orderBy {
+  domains
+  id
+  registrations
+  wrappedDomains
+}
+
+type AddrChanged implements ResolverEvent {
+  """The new address associated with the resolver"""
+  addr: Account!
+
+  """The block number at which this event occurred"""
+  blockNumber: Int!
+
+  """Unique identifier for this event"""
+  id: ID!
+
+  """The resolver associated with this event"""
+  resolver: Resolver!
+
+  """The transaction ID for the transaction in which this event occurred"""
+  transactionID: Bytes!
+}
+
+input AddrChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  addr: String
+  addr_: Account_filter
+  addr_contains: String
+  addr_contains_nocase: String
+  addr_ends_with: String
+  addr_ends_with_nocase: String
+  addr_gt: String
+  addr_gte: String
+  addr_in: [String!]
+  addr_lt: String
+  addr_lte: String
+  addr_not: String
+  addr_not_contains: String
+  addr_not_contains_nocase: String
+  addr_not_ends_with: String
+  addr_not_ends_with_nocase: String
+  addr_not_in: [String!]
+  addr_not_starts_with: String
+  addr_not_starts_with_nocase: String
+  addr_starts_with: String
+  addr_starts_with_nocase: String
+  and: [AddrChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [AddrChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum AddrChanged_orderBy {
+  addr
+  addr__id
+  blockNumber
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+enum Aggregation_interval {
+  day
+  hour
+}
+
+type AuthorisationChanged implements ResolverEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """Unique identifier for this event"""
+  id: ID!
+
+  """Whether the authorisation was added or removed"""
+  isAuthorized: Boolean!
+
+  """The owner of the authorisation"""
+  owner: Bytes!
+
+  """The resolver associated with this event"""
+  resolver: Resolver!
+
+  """The target of the authorisation"""
+  target: Bytes!
+
+  """The transaction hash associated with the event"""
+  transactionID: Bytes!
+}
+
+input AuthorisationChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AuthorisationChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  isAuthorized: Boolean
+  isAuthorized_in: [Boolean!]
+  isAuthorized_not: Boolean
+  isAuthorized_not_in: [Boolean!]
+  or: [AuthorisationChanged_filter]
+  owner: Bytes
+  owner_contains: Bytes
+  owner_gt: Bytes
+  owner_gte: Bytes
+  owner_in: [Bytes!]
+  owner_lt: Bytes
+  owner_lte: Bytes
+  owner_not: Bytes
+  owner_not_contains: Bytes
+  owner_not_in: [Bytes!]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  target: Bytes
+  target_contains: Bytes
+  target_gt: Bytes
+  target_gte: Bytes
+  target_in: [Bytes!]
+  target_lt: Bytes
+  target_lte: Bytes
+  target_not: Bytes
+  target_not_contains: Bytes
+  target_not_in: [Bytes!]
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum AuthorisationChanged_orderBy {
+  blockNumber
+  id
+  isAuthorized
+  owner
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  target
+  transactionID
+}
+
+scalar BigDecimal
+
+scalar BigInt
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+scalar Bytes
+
+type ContenthashChanged implements ResolverEvent {
+  """The block number where the event occurred"""
+  blockNumber: Int!
+
+  """The new content hash for the domain"""
+  hash: Bytes!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """The ID of the transaction where the event occurred"""
+  transactionID: Bytes!
+}
+
+input ContenthashChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ContenthashChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  hash: Bytes
+  hash_contains: Bytes
+  hash_gt: Bytes
+  hash_gte: Bytes
+  hash_in: [Bytes!]
+  hash_lt: Bytes
+  hash_lte: Bytes
+  hash_not: Bytes
+  hash_not_contains: Bytes
+  hash_not_in: [Bytes!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [ContenthashChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum ContenthashChanged_orderBy {
+  blockNumber
+  hash
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type Domain {
+  """The time when the domain was created"""
+  createdAt: BigInt!
+
+  """The events associated with the domain"""
+  events(first: Int = 100, orderBy: DomainEvent_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: DomainEvent_filter): [DomainEvent!]!
+
+  """
+  The expiry date for the domain, from either the registration, or the wrapped domain if PCC is burned
+  """
+  expiryDate: BigInt
+
+  """The namehash of the name"""
+  id: ID!
+
+  """Indicates whether the domain has been migrated to a new registrar"""
+  isMigrated: Boolean!
+
+  """keccak256(labelName)"""
+  labelhash: Bytes
+
+  """The human readable label name (imported from CSV), if known"""
+  labelName: String
+
+  """
+  The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
+  """
+  name: String
+
+  """The account that owns the domain"""
+  owner: Account!
+
+  """The namehash (id) of the parent name"""
+  parent: Domain
+
+  """The account that owns the ERC721 NFT for the domain"""
+  registrant: Account
+
+  """The registration associated with the domain"""
+  registration: Registration
+
+  """Address logged from current resolver, if any"""
+  resolvedAddress: Account
+
+  """The resolver that controls the domain's settings"""
+  resolver: Resolver
+
+  """The number of subdomains"""
+  subdomainCount: Int!
+
+  """Can count domains from length of array"""
+  subdomains(first: Int = 100, orderBy: Domain_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Domain_filter): [Domain!]!
+
+  """The time-to-live (TTL) value of the domain's records"""
+  ttl: BigInt
+
+  """The wrapped domain associated with the domain"""
+  wrappedDomain: WrappedDomain
+
+  """The account that owns the wrapped domain"""
+  wrappedOwner: Account
+}
+
+input Domain_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Domain_filter]
+  createdAt: BigInt
+  createdAt_gt: BigInt
+  createdAt_gte: BigInt
+  createdAt_in: [BigInt!]
+  createdAt_lt: BigInt
+  createdAt_lte: BigInt
+  createdAt_not: BigInt
+  createdAt_not_in: [BigInt!]
+  events_: DomainEvent_filter
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  isMigrated: Boolean
+  isMigrated_in: [Boolean!]
+  isMigrated_not: Boolean
+  isMigrated_not_in: [Boolean!]
+  labelhash: Bytes
+  labelhash_contains: Bytes
+  labelhash_gt: Bytes
+  labelhash_gte: Bytes
+  labelhash_in: [Bytes!]
+  labelhash_lt: Bytes
+  labelhash_lte: Bytes
+  labelhash_not: Bytes
+  labelhash_not_contains: Bytes
+  labelhash_not_in: [Bytes!]
+  labelName: String
+  labelName_contains: String
+  labelName_contains_nocase: String
+  labelName_ends_with: String
+  labelName_ends_with_nocase: String
+  labelName_gt: String
+  labelName_gte: String
+  labelName_in: [String!]
+  labelName_lt: String
+  labelName_lte: String
+  labelName_not: String
+  labelName_not_contains: String
+  labelName_not_contains_nocase: String
+  labelName_not_ends_with: String
+  labelName_not_ends_with_nocase: String
+  labelName_not_in: [String!]
+  labelName_not_starts_with: String
+  labelName_not_starts_with_nocase: String
+  labelName_starts_with: String
+  labelName_starts_with_nocase: String
+  name: String
+  name_contains: String
+  name_contains_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_gt: String
+  name_gte: String
+  name_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_not: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  name_not_in: [String!]
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  or: [Domain_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+  parent: String
+  parent_: Domain_filter
+  parent_contains: String
+  parent_contains_nocase: String
+  parent_ends_with: String
+  parent_ends_with_nocase: String
+  parent_gt: String
+  parent_gte: String
+  parent_in: [String!]
+  parent_lt: String
+  parent_lte: String
+  parent_not: String
+  parent_not_contains: String
+  parent_not_contains_nocase: String
+  parent_not_ends_with: String
+  parent_not_ends_with_nocase: String
+  parent_not_in: [String!]
+  parent_not_starts_with: String
+  parent_not_starts_with_nocase: String
+  parent_starts_with: String
+  parent_starts_with_nocase: String
+  registrant: String
+  registrant_: Account_filter
+  registrant_contains: String
+  registrant_contains_nocase: String
+  registrant_ends_with: String
+  registrant_ends_with_nocase: String
+  registrant_gt: String
+  registrant_gte: String
+  registrant_in: [String!]
+  registrant_lt: String
+  registrant_lte: String
+  registrant_not: String
+  registrant_not_contains: String
+  registrant_not_contains_nocase: String
+  registrant_not_ends_with: String
+  registrant_not_ends_with_nocase: String
+  registrant_not_in: [String!]
+  registrant_not_starts_with: String
+  registrant_not_starts_with_nocase: String
+  registrant_starts_with: String
+  registrant_starts_with_nocase: String
+  registration_: Registration_filter
+  resolvedAddress: String
+  resolvedAddress_: Account_filter
+  resolvedAddress_contains: String
+  resolvedAddress_contains_nocase: String
+  resolvedAddress_ends_with: String
+  resolvedAddress_ends_with_nocase: String
+  resolvedAddress_gt: String
+  resolvedAddress_gte: String
+  resolvedAddress_in: [String!]
+  resolvedAddress_lt: String
+  resolvedAddress_lte: String
+  resolvedAddress_not: String
+  resolvedAddress_not_contains: String
+  resolvedAddress_not_contains_nocase: String
+  resolvedAddress_not_ends_with: String
+  resolvedAddress_not_ends_with_nocase: String
+  resolvedAddress_not_in: [String!]
+  resolvedAddress_not_starts_with: String
+  resolvedAddress_not_starts_with_nocase: String
+  resolvedAddress_starts_with: String
+  resolvedAddress_starts_with_nocase: String
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  subdomainCount: Int
+  subdomainCount_gt: Int
+  subdomainCount_gte: Int
+  subdomainCount_in: [Int!]
+  subdomainCount_lt: Int
+  subdomainCount_lte: Int
+  subdomainCount_not: Int
+  subdomainCount_not_in: [Int!]
+  subdomains_: Domain_filter
+  ttl: BigInt
+  ttl_gt: BigInt
+  ttl_gte: BigInt
+  ttl_in: [BigInt!]
+  ttl_lt: BigInt
+  ttl_lte: BigInt
+  ttl_not: BigInt
+  ttl_not_in: [BigInt!]
+  wrappedDomain_: WrappedDomain_filter
+  wrappedOwner: String
+  wrappedOwner_: Account_filter
+  wrappedOwner_contains: String
+  wrappedOwner_contains_nocase: String
+  wrappedOwner_ends_with: String
+  wrappedOwner_ends_with_nocase: String
+  wrappedOwner_gt: String
+  wrappedOwner_gte: String
+  wrappedOwner_in: [String!]
+  wrappedOwner_lt: String
+  wrappedOwner_lte: String
+  wrappedOwner_not: String
+  wrappedOwner_not_contains: String
+  wrappedOwner_not_contains_nocase: String
+  wrappedOwner_not_ends_with: String
+  wrappedOwner_not_ends_with_nocase: String
+  wrappedOwner_not_in: [String!]
+  wrappedOwner_not_starts_with: String
+  wrappedOwner_not_starts_with_nocase: String
+  wrappedOwner_starts_with: String
+  wrappedOwner_starts_with_nocase: String
+}
+
+enum Domain_orderBy {
+  createdAt
+  events
+  expiryDate
+  id
+  isMigrated
+  labelhash
+  labelName
+  name
+  owner
+  owner__id
+  parent
+  parent__createdAt
+  parent__expiryDate
+  parent__id
+  parent__isMigrated
+  parent__labelhash
+  parent__labelName
+  parent__name
+  parent__subdomainCount
+  parent__ttl
+  registrant
+  registrant__id
+  registration
+  registration__cost
+  registration__expiryDate
+  registration__id
+  registration__labelName
+  registration__registrationDate
+  resolvedAddress
+  resolvedAddress__id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  subdomainCount
+  subdomains
+  ttl
+  wrappedDomain
+  wrappedDomain__expiryDate
+  wrappedDomain__fuses
+  wrappedDomain__id
+  wrappedDomain__name
+  wrappedOwner
+  wrappedOwner__id
+}
+
+interface DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input DomainEvent_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [DomainEvent_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [DomainEvent_filter]
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum DomainEvent_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  transactionID
+}
+
+type ExpiryExtended implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """
+  The new expiry date associated with the domain after the extension event
+  """
+  expiryDate: BigInt!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input ExpiryExtended_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ExpiryExtended_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [ExpiryExtended_filter]
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum ExpiryExtended_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  expiryDate
+  id
+  transactionID
+}
+
+type FusesSet implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The number of fuses associated with the domain after the set event"""
+  fuses: Int!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input FusesSet_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [FusesSet_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  fuses: Int
+  fuses_gt: Int
+  fuses_gte: Int
+  fuses_in: [Int!]
+  fuses_lt: Int
+  fuses_lte: Int
+  fuses_not: Int
+  fuses_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [FusesSet_filter]
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum FusesSet_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  fuses
+  id
+  transactionID
+}
+
+"""8 bytes signed integer"""
+scalar Int8
+
+type InterfaceChanged implements ResolverEvent {
+  """The block number in which the event occurred"""
+  blockNumber: Int!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """The address of the contract that implements the interface"""
+  implementer: Bytes!
+
+  """The ID of the EIP-1820 interface that was changed"""
+  interfaceID: Bytes!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """The transaction ID for the transaction in which the event occurred"""
+  transactionID: Bytes!
+}
+
+input InterfaceChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [InterfaceChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  implementer: Bytes
+  implementer_contains: Bytes
+  implementer_gt: Bytes
+  implementer_gte: Bytes
+  implementer_in: [Bytes!]
+  implementer_lt: Bytes
+  implementer_lte: Bytes
+  implementer_not: Bytes
+  implementer_not_contains: Bytes
+  implementer_not_in: [Bytes!]
+  interfaceID: Bytes
+  interfaceID_contains: Bytes
+  interfaceID_gt: Bytes
+  interfaceID_gte: Bytes
+  interfaceID_in: [Bytes!]
+  interfaceID_lt: Bytes
+  interfaceID_lte: Bytes
+  interfaceID_not: Bytes
+  interfaceID_not_contains: Bytes
+  interfaceID_not_in: [Bytes!]
+  or: [InterfaceChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum InterfaceChanged_orderBy {
+  blockNumber
+  id
+  implementer
+  interfaceID
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type MulticoinAddrChanged implements ResolverEvent {
+  """The new address value for the given coin type"""
+  addr: Bytes!
+
+  """Block number in which this event was emitted"""
+  blockNumber: Int!
+
+  """The coin type of the changed address"""
+  coinType: BigInt!
+
+  """Unique identifier for the event"""
+  id: ID!
+
+  """Resolver associated with this event"""
+  resolver: Resolver!
+
+  """Transaction ID in which this event was emitted"""
+  transactionID: Bytes!
+}
+
+input MulticoinAddrChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  addr: Bytes
+  addr_contains: Bytes
+  addr_gt: Bytes
+  addr_gte: Bytes
+  addr_in: [Bytes!]
+  addr_lt: Bytes
+  addr_lte: Bytes
+  addr_not: Bytes
+  addr_not_contains: Bytes
+  addr_not_in: [Bytes!]
+  and: [MulticoinAddrChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  coinType: BigInt
+  coinType_gt: BigInt
+  coinType_gte: BigInt
+  coinType_in: [BigInt!]
+  coinType_lt: BigInt
+  coinType_lte: BigInt
+  coinType_not: BigInt
+  coinType_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [MulticoinAddrChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum MulticoinAddrChanged_orderBy {
+  addr
+  blockNumber
+  coinType
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type NameChanged implements ResolverEvent {
+  """Block number where event occurred"""
+  blockNumber: Int!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """New ENS name value"""
+  name: String!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """Unique transaction ID where event occurred"""
+  transactionID: Bytes!
+}
+
+input NameChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NameChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  name: String
+  name_contains: String
+  name_contains_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_gt: String
+  name_gte: String
+  name_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_not: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  name_not_in: [String!]
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  or: [NameChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NameChanged_orderBy {
+  blockNumber
+  id
+  name
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type NameRegistered implements RegistrationEvent {
+  """The block number of the event"""
+  blockNumber: Int!
+
+  """The expiry date of the registration"""
+  expiryDate: BigInt!
+
+  """The unique identifier of the NameRegistered event"""
+  id: ID!
+
+  """The account that registered the name"""
+  registrant: Account!
+
+  """The registration associated with the event"""
+  registration: Registration!
+
+  """The transaction ID associated with the event"""
+  transactionID: Bytes!
+}
+
+input NameRegistered_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NameRegistered_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [NameRegistered_filter]
+  registrant: String
+  registrant_: Account_filter
+  registrant_contains: String
+  registrant_contains_nocase: String
+  registrant_ends_with: String
+  registrant_ends_with_nocase: String
+  registrant_gt: String
+  registrant_gte: String
+  registrant_in: [String!]
+  registrant_lt: String
+  registrant_lte: String
+  registrant_not: String
+  registrant_not_contains: String
+  registrant_not_contains_nocase: String
+  registrant_not_ends_with: String
+  registrant_not_ends_with_nocase: String
+  registrant_not_in: [String!]
+  registrant_not_starts_with: String
+  registrant_not_starts_with_nocase: String
+  registrant_starts_with: String
+  registrant_starts_with_nocase: String
+  registration: String
+  registration_: Registration_filter
+  registration_contains: String
+  registration_contains_nocase: String
+  registration_ends_with: String
+  registration_ends_with_nocase: String
+  registration_gt: String
+  registration_gte: String
+  registration_in: [String!]
+  registration_lt: String
+  registration_lte: String
+  registration_not: String
+  registration_not_contains: String
+  registration_not_contains_nocase: String
+  registration_not_ends_with: String
+  registration_not_ends_with_nocase: String
+  registration_not_in: [String!]
+  registration_not_starts_with: String
+  registration_not_starts_with_nocase: String
+  registration_starts_with: String
+  registration_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NameRegistered_orderBy {
+  blockNumber
+  expiryDate
+  id
+  registrant
+  registrant__id
+  registration
+  registration__cost
+  registration__expiryDate
+  registration__id
+  registration__labelName
+  registration__registrationDate
+  transactionID
+}
+
+type NameRenewed implements RegistrationEvent {
+  """The block number of the event"""
+  blockNumber: Int!
+
+  """The new expiry date of the registration"""
+  expiryDate: BigInt!
+
+  """The unique identifier of the NameRenewed event"""
+  id: ID!
+
+  """The registration associated with the event"""
+  registration: Registration!
+
+  """The transaction ID associated with the event"""
+  transactionID: Bytes!
+}
+
+input NameRenewed_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NameRenewed_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [NameRenewed_filter]
+  registration: String
+  registration_: Registration_filter
+  registration_contains: String
+  registration_contains_nocase: String
+  registration_ends_with: String
+  registration_ends_with_nocase: String
+  registration_gt: String
+  registration_gte: String
+  registration_in: [String!]
+  registration_lt: String
+  registration_lte: String
+  registration_not: String
+  registration_not_contains: String
+  registration_not_contains_nocase: String
+  registration_not_ends_with: String
+  registration_not_ends_with_nocase: String
+  registration_not_in: [String!]
+  registration_not_starts_with: String
+  registration_not_starts_with_nocase: String
+  registration_starts_with: String
+  registration_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NameRenewed_orderBy {
+  blockNumber
+  expiryDate
+  id
+  registration
+  registration__cost
+  registration__expiryDate
+  registration__id
+  registration__labelName
+  registration__registrationDate
+  transactionID
+}
+
+type NameTransferred implements RegistrationEvent {
+  """The block number of the event"""
+  blockNumber: Int!
+
+  """The ID of the event"""
+  id: ID!
+
+  """The new owner of the domain"""
+  newOwner: Account!
+
+  """The registration associated with the event"""
+  registration: Registration!
+
+  """The transaction ID of the event"""
+  transactionID: Bytes!
+}
+
+input NameTransferred_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NameTransferred_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  newOwner: String
+  newOwner_: Account_filter
+  newOwner_contains: String
+  newOwner_contains_nocase: String
+  newOwner_ends_with: String
+  newOwner_ends_with_nocase: String
+  newOwner_gt: String
+  newOwner_gte: String
+  newOwner_in: [String!]
+  newOwner_lt: String
+  newOwner_lte: String
+  newOwner_not: String
+  newOwner_not_contains: String
+  newOwner_not_contains_nocase: String
+  newOwner_not_ends_with: String
+  newOwner_not_ends_with_nocase: String
+  newOwner_not_in: [String!]
+  newOwner_not_starts_with: String
+  newOwner_not_starts_with_nocase: String
+  newOwner_starts_with: String
+  newOwner_starts_with_nocase: String
+  or: [NameTransferred_filter]
+  registration: String
+  registration_: Registration_filter
+  registration_contains: String
+  registration_contains_nocase: String
+  registration_ends_with: String
+  registration_ends_with_nocase: String
+  registration_gt: String
+  registration_gte: String
+  registration_in: [String!]
+  registration_lt: String
+  registration_lte: String
+  registration_not: String
+  registration_not_contains: String
+  registration_not_contains_nocase: String
+  registration_not_ends_with: String
+  registration_not_ends_with_nocase: String
+  registration_not_in: [String!]
+  registration_not_starts_with: String
+  registration_not_starts_with_nocase: String
+  registration_starts_with: String
+  registration_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NameTransferred_orderBy {
+  blockNumber
+  id
+  newOwner
+  newOwner__id
+  registration
+  registration__cost
+  registration__expiryDate
+  registration__id
+  registration__labelName
+  registration__registrationDate
+  transactionID
+}
+
+type NameUnwrapped implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The account that owns the domain after it was unwrapped"""
+  owner: Account!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input NameUnwrapped_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NameUnwrapped_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [NameUnwrapped_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NameUnwrapped_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  owner
+  owner__id
+  transactionID
+}
+
+type NameWrapped implements DomainEvent {
+  """The block number at which the wrapped domain was wrapped"""
+  blockNumber: Int!
+
+  """The domain name associated with the wrapped domain"""
+  domain: Domain!
+
+  """The expiry date of the wrapped domain registration"""
+  expiryDate: BigInt!
+
+  """The number of fuses associated with the wrapped domain"""
+  fuses: Int!
+
+  """The unique identifier of the wrapped domain"""
+  id: ID!
+
+  """The human-readable name of the wrapped domain"""
+  name: String
+
+  """The account that owns the wrapped domain"""
+  owner: Account!
+
+  """The transaction hash of the transaction that wrapped the domain"""
+  transactionID: Bytes!
+}
+
+input NameWrapped_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NameWrapped_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  fuses: Int
+  fuses_gt: Int
+  fuses_gte: Int
+  fuses_in: [Int!]
+  fuses_lt: Int
+  fuses_lte: Int
+  fuses_not: Int
+  fuses_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  name: String
+  name_contains: String
+  name_contains_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_gt: String
+  name_gte: String
+  name_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_not: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  name_not_in: [String!]
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  or: [NameWrapped_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NameWrapped_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  expiryDate
+  fuses
+  id
+  name
+  owner
+  owner__id
+  transactionID
+}
+
+type NewOwner implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The new account that owns the domain"""
+  owner: Account!
+
+  """The parent domain of the domain name associated with the event"""
+  parentDomain: Domain!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input NewOwner_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewOwner_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [NewOwner_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+  parentDomain: String
+  parentDomain_: Domain_filter
+  parentDomain_contains: String
+  parentDomain_contains_nocase: String
+  parentDomain_ends_with: String
+  parentDomain_ends_with_nocase: String
+  parentDomain_gt: String
+  parentDomain_gte: String
+  parentDomain_in: [String!]
+  parentDomain_lt: String
+  parentDomain_lte: String
+  parentDomain_not: String
+  parentDomain_not_contains: String
+  parentDomain_not_contains_nocase: String
+  parentDomain_not_ends_with: String
+  parentDomain_not_ends_with_nocase: String
+  parentDomain_not_in: [String!]
+  parentDomain_not_starts_with: String
+  parentDomain_not_starts_with_nocase: String
+  parentDomain_starts_with: String
+  parentDomain_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NewOwner_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  owner
+  owner__id
+  parentDomain
+  parentDomain__createdAt
+  parentDomain__expiryDate
+  parentDomain__id
+  parentDomain__isMigrated
+  parentDomain__labelhash
+  parentDomain__labelName
+  parentDomain__name
+  parentDomain__subdomainCount
+  parentDomain__ttl
+  transactionID
+}
+
+type NewResolver implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The new resolver contract address associated with the domain"""
+  resolver: Resolver!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input NewResolver_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewResolver_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [NewResolver_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum NewResolver_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type NewTTL implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+
+  """The new TTL value (in seconds) associated with the domain"""
+  ttl: BigInt!
+}
+
+input NewTTL_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [NewTTL_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [NewTTL_filter]
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+  ttl: BigInt
+  ttl_gt: BigInt
+  ttl_gte: BigInt
+  ttl_in: [BigInt!]
+  ttl_lt: BigInt
+  ttl_lte: BigInt
+  ttl_not: BigInt
+  ttl_not_in: [BigInt!]
+}
+
+enum NewTTL_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  transactionID
+  ttl
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type PubkeyChanged implements ResolverEvent {
+  """Block number of the Ethereum block where the event occurred"""
+  blockNumber: Int!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """Transaction hash of the Ethereum transaction where the event occurred"""
+  transactionID: Bytes!
+
+  """The x-coordinate of the new public key"""
+  x: Bytes!
+
+  """The y-coordinate of the new public key"""
+  y: Bytes!
+}
+
+input PubkeyChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [PubkeyChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [PubkeyChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+  x: Bytes
+  x_contains: Bytes
+  x_gt: Bytes
+  x_gte: Bytes
+  x_in: [Bytes!]
+  x_lt: Bytes
+  x_lte: Bytes
+  x_not: Bytes
+  x_not_contains: Bytes
+  x_not_in: [Bytes!]
+  y: Bytes
+  y_contains: Bytes
+  y_gt: Bytes
+  y_gte: Bytes
+  y_in: [Bytes!]
+  y_lt: Bytes
+  y_lte: Bytes
+  y_not: Bytes
+  y_not_contains: Bytes
+  y_not_in: [Bytes!]
+}
+
+enum PubkeyChanged_orderBy {
+  blockNumber
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+  x
+  y
+}
+
+type Query {
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+  abiChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AbiChanged
+  abiChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: AbiChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: AbiChanged_filter
+  ): [AbiChanged!]!
+  account(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Account
+  accounts(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Account_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Account_filter
+  ): [Account!]!
+  addrChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AddrChanged
+  addrChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: AddrChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: AddrChanged_filter
+  ): [AddrChanged!]!
+  authorisationChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AuthorisationChanged
+  authorisationChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: AuthorisationChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: AuthorisationChanged_filter
+  ): [AuthorisationChanged!]!
+  contenthashChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ContenthashChanged
+  contenthashChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: ContenthashChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: ContenthashChanged_filter
+  ): [ContenthashChanged!]!
+  domain(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Domain
+  domainEvent(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): DomainEvent
+  domainEvents(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: DomainEvent_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: DomainEvent_filter
+  ): [DomainEvent!]!
+  domains(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Domain_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Domain_filter
+  ): [Domain!]!
+  expiryExtended(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ExpiryExtended
+  expiryExtendeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: ExpiryExtended_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: ExpiryExtended_filter
+  ): [ExpiryExtended!]!
+  fusesSet(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): FusesSet
+  fusesSets(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: FusesSet_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: FusesSet_filter
+  ): [FusesSet!]!
+  interfaceChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): InterfaceChanged
+  interfaceChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: InterfaceChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: InterfaceChanged_filter
+  ): [InterfaceChanged!]!
+  multicoinAddrChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): MulticoinAddrChanged
+  multicoinAddrChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: MulticoinAddrChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: MulticoinAddrChanged_filter
+  ): [MulticoinAddrChanged!]!
+  nameChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NameChanged
+  nameChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NameChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NameChanged_filter
+  ): [NameChanged!]!
+  nameRegistered(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NameRegistered
+  nameRegistereds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NameRegistered_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NameRegistered_filter
+  ): [NameRegistered!]!
+  nameRenewed(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NameRenewed
+  nameReneweds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NameRenewed_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NameRenewed_filter
+  ): [NameRenewed!]!
+  nameTransferred(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NameTransferred
+  nameTransferreds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NameTransferred_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NameTransferred_filter
+  ): [NameTransferred!]!
+  nameUnwrapped(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NameUnwrapped
+  nameUnwrappeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NameUnwrapped_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NameUnwrapped_filter
+  ): [NameUnwrapped!]!
+  nameWrapped(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NameWrapped
+  nameWrappeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NameWrapped_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NameWrapped_filter
+  ): [NameWrapped!]!
+  newOwner(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewOwner
+  newOwners(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NewOwner_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NewOwner_filter
+  ): [NewOwner!]!
+  newResolver(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewResolver
+  newResolvers(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NewResolver_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NewResolver_filter
+  ): [NewResolver!]!
+  newTTL(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): NewTTL
+  newTTLs(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: NewTTL_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: NewTTL_filter
+  ): [NewTTL!]!
+  pubkeyChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): PubkeyChanged
+  pubkeyChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: PubkeyChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: PubkeyChanged_filter
+  ): [PubkeyChanged!]!
+  registration(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Registration
+  registrationEvent(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegistrationEvent
+  registrationEvents(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: RegistrationEvent_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: RegistrationEvent_filter
+  ): [RegistrationEvent!]!
+  registrations(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Registration_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Registration_filter
+  ): [Registration!]!
+  resolver(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Resolver
+  resolverEvent(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): ResolverEvent
+  resolverEvents(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: ResolverEvent_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: ResolverEvent_filter
+  ): [ResolverEvent!]!
+  resolvers(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Resolver_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Resolver_filter
+  ): [Resolver!]!
+  textChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TextChanged
+  textChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TextChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TextChanged_filter
+  ): [TextChanged!]!
+  transfer(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transfer
+  transfers(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Transfer_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Transfer_filter
+  ): [Transfer!]!
+  versionChanged(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VersionChanged
+  versionChangeds(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: VersionChanged_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: VersionChanged_filter
+  ): [VersionChanged!]!
+  wrappedDomain(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): WrappedDomain
+  wrappedDomains(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: WrappedDomain_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: WrappedDomain_filter
+  ): [WrappedDomain!]!
+  wrappedTransfer(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): WrappedTransfer
+  wrappedTransfers(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: WrappedTransfer_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: WrappedTransfer_filter
+  ): [WrappedTransfer!]!
+}
+
+type Registration {
+  """The cost associated with the domain registration"""
+  cost: BigInt
+
+  """The domain name associated with the registration"""
+  domain: Domain!
+
+  """The events associated with the domain registration"""
+  events(first: Int = 100, orderBy: RegistrationEvent_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: RegistrationEvent_filter): [RegistrationEvent!]!
+
+  """The expiry date of the domain"""
+  expiryDate: BigInt!
+
+  """The unique identifier of the registration"""
+  id: ID!
+
+  """The human-readable label name associated with the domain registration"""
+  labelName: String
+
+  """The account that registered the domain"""
+  registrant: Account!
+
+  """The registration date of the domain"""
+  registrationDate: BigInt!
+}
+
+input Registration_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Registration_filter]
+  cost: BigInt
+  cost_gt: BigInt
+  cost_gte: BigInt
+  cost_in: [BigInt!]
+  cost_lt: BigInt
+  cost_lte: BigInt
+  cost_not: BigInt
+  cost_not_in: [BigInt!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  events_: RegistrationEvent_filter
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  labelName: String
+  labelName_contains: String
+  labelName_contains_nocase: String
+  labelName_ends_with: String
+  labelName_ends_with_nocase: String
+  labelName_gt: String
+  labelName_gte: String
+  labelName_in: [String!]
+  labelName_lt: String
+  labelName_lte: String
+  labelName_not: String
+  labelName_not_contains: String
+  labelName_not_contains_nocase: String
+  labelName_not_ends_with: String
+  labelName_not_ends_with_nocase: String
+  labelName_not_in: [String!]
+  labelName_not_starts_with: String
+  labelName_not_starts_with_nocase: String
+  labelName_starts_with: String
+  labelName_starts_with_nocase: String
+  or: [Registration_filter]
+  registrant: String
+  registrant_: Account_filter
+  registrant_contains: String
+  registrant_contains_nocase: String
+  registrant_ends_with: String
+  registrant_ends_with_nocase: String
+  registrant_gt: String
+  registrant_gte: String
+  registrant_in: [String!]
+  registrant_lt: String
+  registrant_lte: String
+  registrant_not: String
+  registrant_not_contains: String
+  registrant_not_contains_nocase: String
+  registrant_not_ends_with: String
+  registrant_not_ends_with_nocase: String
+  registrant_not_in: [String!]
+  registrant_not_starts_with: String
+  registrant_not_starts_with_nocase: String
+  registrant_starts_with: String
+  registrant_starts_with_nocase: String
+  registrationDate: BigInt
+  registrationDate_gt: BigInt
+  registrationDate_gte: BigInt
+  registrationDate_in: [BigInt!]
+  registrationDate_lt: BigInt
+  registrationDate_lte: BigInt
+  registrationDate_not: BigInt
+  registrationDate_not_in: [BigInt!]
+}
+
+enum Registration_orderBy {
+  cost
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  events
+  expiryDate
+  id
+  labelName
+  registrant
+  registrant__id
+  registrationDate
+}
+
+interface RegistrationEvent {
+  """The block number of the event"""
+  blockNumber: Int!
+
+  """The unique identifier of the registration event"""
+  id: ID!
+
+  """The registration associated with the event"""
+  registration: Registration!
+
+  """The transaction ID associated with the event"""
+  transactionID: Bytes!
+}
+
+input RegistrationEvent_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [RegistrationEvent_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [RegistrationEvent_filter]
+  registration: String
+  registration_: Registration_filter
+  registration_contains: String
+  registration_contains_nocase: String
+  registration_ends_with: String
+  registration_ends_with_nocase: String
+  registration_gt: String
+  registration_gte: String
+  registration_in: [String!]
+  registration_lt: String
+  registration_lte: String
+  registration_not: String
+  registration_not_contains: String
+  registration_not_contains_nocase: String
+  registration_not_ends_with: String
+  registration_not_ends_with_nocase: String
+  registration_not_in: [String!]
+  registration_not_starts_with: String
+  registration_not_starts_with_nocase: String
+  registration_starts_with: String
+  registration_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum RegistrationEvent_orderBy {
+  blockNumber
+  id
+  registration
+  registration__cost
+  registration__expiryDate
+  registration__id
+  registration__labelName
+  registration__registrationDate
+  transactionID
+}
+
+type Resolver {
+  """
+  The current value of the 'addr' record for this resolver, as determined by the associated events
+  """
+  addr: Account
+
+  """The address of the resolver contract"""
+  address: Bytes!
+
+  """The set of observed SLIP-44 coin types for this resolver"""
+  coinTypes: [BigInt!]
+
+  """The content hash for this resolver, in binary format"""
+  contentHash: Bytes
+
+  """The domain that this resolver is associated with"""
+  domain: Domain
+
+  """The events associated with this resolver"""
+  events(first: Int = 100, orderBy: ResolverEvent_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: ResolverEvent_filter): [ResolverEvent!]!
+
+  """
+  The unique identifier for this resolver, which is a concatenation of the resolver address and the domain namehash
+  """
+  id: ID!
+
+  """The set of observed text record keys for this resolver"""
+  texts: [String!]
+}
+
+input Resolver_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  addr: String
+  addr_: Account_filter
+  addr_contains: String
+  addr_contains_nocase: String
+  addr_ends_with: String
+  addr_ends_with_nocase: String
+  addr_gt: String
+  addr_gte: String
+  addr_in: [String!]
+  addr_lt: String
+  addr_lte: String
+  addr_not: String
+  addr_not_contains: String
+  addr_not_contains_nocase: String
+  addr_not_ends_with: String
+  addr_not_ends_with_nocase: String
+  addr_not_in: [String!]
+  addr_not_starts_with: String
+  addr_not_starts_with_nocase: String
+  addr_starts_with: String
+  addr_starts_with_nocase: String
+  address: Bytes
+  address_contains: Bytes
+  address_gt: Bytes
+  address_gte: Bytes
+  address_in: [Bytes!]
+  address_lt: Bytes
+  address_lte: Bytes
+  address_not: Bytes
+  address_not_contains: Bytes
+  address_not_in: [Bytes!]
+  and: [Resolver_filter]
+  coinTypes: [BigInt!]
+  coinTypes_contains: [BigInt!]
+  coinTypes_contains_nocase: [BigInt!]
+  coinTypes_not: [BigInt!]
+  coinTypes_not_contains: [BigInt!]
+  coinTypes_not_contains_nocase: [BigInt!]
+  contentHash: Bytes
+  contentHash_contains: Bytes
+  contentHash_gt: Bytes
+  contentHash_gte: Bytes
+  contentHash_in: [Bytes!]
+  contentHash_lt: Bytes
+  contentHash_lte: Bytes
+  contentHash_not: Bytes
+  contentHash_not_contains: Bytes
+  contentHash_not_in: [Bytes!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  events_: ResolverEvent_filter
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [Resolver_filter]
+  texts: [String!]
+  texts_contains: [String!]
+  texts_contains_nocase: [String!]
+  texts_not: [String!]
+  texts_not_contains: [String!]
+  texts_not_contains_nocase: [String!]
+}
+
+enum Resolver_orderBy {
+  addr
+  addr__id
+  address
+  coinTypes
+  contentHash
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  events
+  id
+  texts
+}
+
+interface ResolverEvent {
+  """The block number that the event occurred on"""
+  blockNumber: Int!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """The transaction hash of the event"""
+  transactionID: Bytes!
+}
+
+input ResolverEvent_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [ResolverEvent_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [ResolverEvent_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum ResolverEvent_orderBy {
+  blockNumber
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+}
+
+type TextChanged implements ResolverEvent {
+  """Block number of the Ethereum block in which the event occurred"""
+  blockNumber: Int!
+
+  """Concatenation of block number and log ID"""
+  id: ID!
+
+  """The key of the text record that was changed"""
+  key: String!
+
+  """Used to derive relationships to Resolvers"""
+  resolver: Resolver!
+
+  """Hash of the Ethereum transaction in which the event occurred"""
+  transactionID: Bytes!
+
+  """The new value of the text record that was changed"""
+  value: String
+}
+
+input TextChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [TextChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  key: String
+  key_contains: String
+  key_contains_nocase: String
+  key_ends_with: String
+  key_ends_with_nocase: String
+  key_gt: String
+  key_gte: String
+  key_in: [String!]
+  key_lt: String
+  key_lte: String
+  key_not: String
+  key_not_contains: String
+  key_not_contains_nocase: String
+  key_not_ends_with: String
+  key_not_ends_with_nocase: String
+  key_not_in: [String!]
+  key_not_starts_with: String
+  key_not_starts_with_nocase: String
+  key_starts_with: String
+  key_starts_with_nocase: String
+  or: [TextChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+  value: String
+  value_contains: String
+  value_contains_nocase: String
+  value_ends_with: String
+  value_ends_with_nocase: String
+  value_gt: String
+  value_gte: String
+  value_in: [String!]
+  value_lt: String
+  value_lte: String
+  value_not: String
+  value_not_contains: String
+  value_not_contains_nocase: String
+  value_not_ends_with: String
+  value_not_ends_with_nocase: String
+  value_not_in: [String!]
+  value_not_starts_with: String
+  value_not_starts_with_nocase: String
+  value_starts_with: String
+  value_starts_with_nocase: String
+}
+
+enum TextChanged_orderBy {
+  blockNumber
+  id
+  key
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+  value
+}
+
+"""A string representation of microseconds UNIX timestamp (16 digits)"""
+scalar Timestamp
+
+type Transfer implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The account that owns the domain after the transfer"""
+  owner: Account!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input Transfer_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Transfer_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [Transfer_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum Transfer_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  owner
+  owner__id
+  transactionID
+}
+
+type VersionChanged implements ResolverEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """Unique identifier for this event"""
+  id: ID!
+
+  """The resolver associated with this event"""
+  resolver: Resolver!
+
+  """The transaction hash associated with the event"""
+  transactionID: Bytes!
+
+  """The new version number of the resolver"""
+  version: BigInt!
+}
+
+input VersionChanged_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [VersionChanged_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [VersionChanged_filter]
+  resolver: String
+  resolver_: Resolver_filter
+  resolver_contains: String
+  resolver_contains_nocase: String
+  resolver_ends_with: String
+  resolver_ends_with_nocase: String
+  resolver_gt: String
+  resolver_gte: String
+  resolver_in: [String!]
+  resolver_lt: String
+  resolver_lte: String
+  resolver_not: String
+  resolver_not_contains: String
+  resolver_not_contains_nocase: String
+  resolver_not_ends_with: String
+  resolver_not_ends_with_nocase: String
+  resolver_not_in: [String!]
+  resolver_not_starts_with: String
+  resolver_not_starts_with_nocase: String
+  resolver_starts_with: String
+  resolver_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+  version: BigInt
+  version_gt: BigInt
+  version_gte: BigInt
+  version_in: [BigInt!]
+  version_lt: BigInt
+  version_lte: BigInt
+  version_not: BigInt
+  version_not_in: [BigInt!]
+}
+
+enum VersionChanged_orderBy {
+  blockNumber
+  id
+  resolver
+  resolver__address
+  resolver__contentHash
+  resolver__id
+  transactionID
+  version
+}
+
+type WrappedDomain {
+  """The domain that is wrapped by this WrappedDomain"""
+  domain: Domain!
+
+  """The expiry date of the wrapped domain"""
+  expiryDate: BigInt!
+
+  """The number of fuses remaining on the wrapped domain"""
+  fuses: Int!
+
+  """unique identifier for each instance of the WrappedDomain entity"""
+  id: ID!
+
+  """The name of the wrapped domain"""
+  name: String
+
+  """The account that owns this WrappedDomain"""
+  owner: Account!
+}
+
+input WrappedDomain_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [WrappedDomain_filter]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  expiryDate: BigInt
+  expiryDate_gt: BigInt
+  expiryDate_gte: BigInt
+  expiryDate_in: [BigInt!]
+  expiryDate_lt: BigInt
+  expiryDate_lte: BigInt
+  expiryDate_not: BigInt
+  expiryDate_not_in: [BigInt!]
+  fuses: Int
+  fuses_gt: Int
+  fuses_gte: Int
+  fuses_in: [Int!]
+  fuses_lt: Int
+  fuses_lte: Int
+  fuses_not: Int
+  fuses_not_in: [Int!]
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  name: String
+  name_contains: String
+  name_contains_nocase: String
+  name_ends_with: String
+  name_ends_with_nocase: String
+  name_gt: String
+  name_gte: String
+  name_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_not: String
+  name_not_contains: String
+  name_not_contains_nocase: String
+  name_not_ends_with: String
+  name_not_ends_with_nocase: String
+  name_not_in: [String!]
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  or: [WrappedDomain_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+}
+
+enum WrappedDomain_orderBy {
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  expiryDate
+  fuses
+  id
+  name
+  owner
+  owner__id
+}
+
+type WrappedTransfer implements DomainEvent {
+  """The block number at which the event occurred"""
+  blockNumber: Int!
+
+  """The domain name associated with the event"""
+  domain: Domain!
+
+  """The unique identifier of the event"""
+  id: ID!
+
+  """The account that owns the wrapped domain after the transfer"""
+  owner: Account!
+
+  """The transaction hash of the transaction that triggered the event"""
+  transactionID: Bytes!
+}
+
+input WrappedTransfer_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [WrappedTransfer_filter]
+  blockNumber: Int
+  blockNumber_gt: Int
+  blockNumber_gte: Int
+  blockNumber_in: [Int!]
+  blockNumber_lt: Int
+  blockNumber_lte: Int
+  blockNumber_not: Int
+  blockNumber_not_in: [Int!]
+  domain: String
+  domain_: Domain_filter
+  domain_contains: String
+  domain_contains_nocase: String
+  domain_ends_with: String
+  domain_ends_with_nocase: String
+  domain_gt: String
+  domain_gte: String
+  domain_in: [String!]
+  domain_lt: String
+  domain_lte: String
+  domain_not: String
+  domain_not_contains: String
+  domain_not_contains_nocase: String
+  domain_not_ends_with: String
+  domain_not_ends_with_nocase: String
+  domain_not_in: [String!]
+  domain_not_starts_with: String
+  domain_not_starts_with_nocase: String
+  domain_starts_with: String
+  domain_starts_with_nocase: String
+  id: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_not: ID
+  id_not_in: [ID!]
+  or: [WrappedTransfer_filter]
+  owner: String
+  owner_: Account_filter
+  owner_contains: String
+  owner_contains_nocase: String
+  owner_ends_with: String
+  owner_ends_with_nocase: String
+  owner_gt: String
+  owner_gte: String
+  owner_in: [String!]
+  owner_lt: String
+  owner_lte: String
+  owner_not: String
+  owner_not_contains: String
+  owner_not_contains_nocase: String
+  owner_not_ends_with: String
+  owner_not_ends_with_nocase: String
+  owner_not_in: [String!]
+  owner_not_starts_with: String
+  owner_not_starts_with_nocase: String
+  owner_starts_with: String
+  owner_starts_with_nocase: String
+  transactionID: Bytes
+  transactionID_contains: Bytes
+  transactionID_gt: Bytes
+  transactionID_gte: Bytes
+  transactionID_in: [Bytes!]
+  transactionID_lt: Bytes
+  transactionID_lte: Bytes
+  transactionID_not: Bytes
+  transactionID_not_contains: Bytes
+  transactionID_not_in: [Bytes!]
+}
+
+enum WrappedTransfer_orderBy {
+  blockNumber
+  domain
+  domain__createdAt
+  domain__expiryDate
+  domain__id
+  domain__isMigrated
+  domain__labelhash
+  domain__labelName
+  domain__name
+  domain__subdomainCount
+  domain__ttl
+  id
+  owner
+  owner__id
+  transactionID
+}

--- a/src/graphql/schemas/metadata.graphql
+++ b/src/graphql/schemas/metadata.graphql
@@ -1,0 +1,1243 @@
+directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+"""
+Directs the executor to defer this fragment when the `if` argument is true or undefined.
+"""
+directive @defer(
+  """Deferred when true or undefined."""
+  if: Boolean = true
+
+  """Unique name"""
+  label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""
+Indicates exactly one field must be supplied and this field must not be `null`.
+"""
+directive @oneOf on INPUT_OBJECT
+
+directive @requireAuth on FIELD_DEFINITION
+
+scalar Any
+
+input Authorization {
+  address: String!
+  chainId: String!
+  nonce: String!
+}
+
+enum CacheControlScope {
+  PRIVATE
+  PUBLIC
+}
+
+type ClaimablePoints {
+  error: PointsError
+  meta: PointsMeta!
+  user: UserClaimablePoints!
+}
+
+type Colors {
+  """Fallback color for secondary UI elements"""
+  fallback: String!
+
+  """Primary brand color in hex format (e.g., #FF0000)"""
+  primary: String!
+
+  """Shadow color for depth and emphasis"""
+  shadow: String!
+}
+
+"""
+CompetitionWindow defines a time period for the King of the Hill competition
+"""
+type CompetitionWindow {
+  """Total duration of the window in seconds"""
+  durationSeconds: Int!
+
+  """UTC timestamp when the competition window ends"""
+  end: Int!
+
+  """Time interval representation (e.g., "1h", "24h")"""
+  interval: String!
+
+  """Whether this is the currently active competition window"""
+  isActive: Boolean!
+
+  """How much time is left in the current window"""
+  secondsRemaining: Int!
+
+  """UTC timestamp when the competition window begins"""
+  start: Int!
+}
+
+type Contract {
+  address: String!
+  chainID: Int!
+  created: Time
+  iconURL: String!
+  name: String!
+  sourceCodeVerified: Boolean
+  type: Int!
+  typeLabel: String!
+}
+
+type ContractFunction {
+  address: String
+  chainID: Int!
+  hex: String!
+  humanText: String!
+  text: String!
+}
+
+type CustomNetwork {
+  defaultExplorerURL: String!
+  defaultRPCURL: String!
+  iconURL: String!
+  id: Int!
+  name: String!
+  nativeAsset: CustomNetworkNativeAsset!
+  testnet: CustomNetworkTestnet!
+}
+
+type CustomNetworkNativeAsset {
+  address: String!
+  decimals: Int!
+  iconURL: String!
+  symbol: String!
+}
+
+type CustomNetworkTestnet {
+  FaucetURL: String!
+  isTestnet: Boolean!
+  mainnetChainID: Int!
+}
+
+type DApp {
+  colors: DAppColors!
+  description: String!
+  iconURL: String!
+  name: String!
+  report: DAppReport!
+  shortName: String!
+  status: DAppStatus!
+  trending: Boolean
+  url: String!
+}
+
+type DAppColors {
+  fallback: String
+  primary: String!
+  shadow: String
+}
+
+enum DAppRankingPeriod {
+  DAY
+  WEEK
+}
+
+type DAppReport {
+  url: String!
+}
+
+enum DAppStatus {
+  SCAM
+  UNVERIFIED
+  VERIFIED
+}
+
+type DAppV2 {
+  """Canonical name of the DApp protocol"""
+  canonicalProtocolName: String!
+
+  """Blockchain network ID where the DApp is deployed"""
+  chainId: Int!
+
+  """Color theme configuration for the DApp"""
+  colors: Colors!
+
+  """URL to the DApp's logo/icon image"""
+  iconURL: String!
+
+  """Unique identifier for the DApp"""
+  protocolID: String!
+
+  """Display name of the DApp"""
+  protocolName: String!
+
+  """Normalized identifier for the DApp (e.g., 'uniswap', 'aave')"""
+  protocolNameID: String!
+
+  """Version of the DApp protocol"""
+  protocolVersion: String!
+
+  """Website URL of the DApp"""
+  siteURL: String!
+}
+
+type DAppV2Result {
+  count: Int!
+  result: [DAppV2!]!
+}
+
+enum Device {
+  APP
+  BX
+}
+
+type DurationSummary {
+  """The duration period this summary covers"""
+  duration: String!
+
+  """End timestamp of the summary period (Unix timestamp)"""
+  end: Time!
+
+  """Start timestamp of the summary period (Unix timestamp)"""
+  start: Time!
+
+  """Detailed trade statistics for this duration"""
+  stats: Stats!
+}
+
+type ENSMarquee {
+  accounts: [ENSMarqueeAccount!]
+}
+
+type ENSMarqueeAccount {
+  address: String!
+  avatar: String!
+  name: String!
+}
+
+type ENSProfile {
+  address: String!
+  chainID: Int!
+  fields: [ENSProfileField!]!
+  name: String!
+  resolverAddress: String!
+  reverseResolverAddress: String!
+}
+
+type ENSProfileField {
+  key: String!
+  value: String!
+}
+
+type KingOfTheHill {
+  """The current token in the King of the Hill competition"""
+  current: KingOfTheHillToken!
+
+  """The previous token that held the title"""
+  lastWinner: KingOfTheHillToken
+}
+
+""" KingOfTheHill represents token in the King of the Hill competition"""
+type KingOfTheHillRankingElem {
+  """Ranking position of the token in the competition"""
+  rank: Int!
+
+  """
+  Token details.
+  Note: This object may not resolve all fields defined in the Token type,
+  as only a subset of data is available in this context.
+  """
+  token: Token!
+
+  """Current time window for the competition"""
+  windowTradingVolume: String!
+}
+
+type KingOfTheHillRankings {
+  """The leaderboard of the King of the Hill competition"""
+  rankings: [KingOfTheHillRankingElem!]!
+
+  """Current time window for the competition"""
+  window: CompetitionWindow!
+}
+
+"""
+KingOfTheHillToken represents a token in the King of the Hill competition.
+"""
+type KingOfTheHillToken {
+  """Ranking details for the token in the competition"""
+  rankingDetails: RankingDetails!
+
+  """
+  Token details.
+  Note: This object may not resolve all fields defined in the Token type,
+  as only a subset of data is available in this context.
+  """
+  token: Token!
+
+  """Current time window for the competition"""
+  window: CompetitionWindow!
+}
+
+type Launchpad {
+  """The name of the launchpad or associated launch platform."""
+  name: String!
+
+  """Platform associated with the launchpad."""
+  platform: String!
+
+  """URL to the platform's icon or logo."""
+  platformIconURL: String!
+
+  """The protocol or platform powering the launchpad."""
+  protocol: String!
+
+  """URL to the protocol's icon or logo."""
+  protocolIconURL: String!
+
+  """
+  The social interface or community platform associated with the launchpad.
+  """
+  socialInterface: String!
+
+  """URL to the social interface's icon or logo."""
+  socialInterfaceIconURL: String!
+}
+
+type LaunchpadResult {
+  """Token Creator address."""
+  creatorAddress: String!
+
+  """Indicates whether launchpad information is available for this token."""
+  isLaunchpadAvailable: Boolean!
+
+  """launchpad associated with tokens."""
+  launchpad: Launchpad
+}
+
+"""
+Represents a liquidity pool of Rainbow token, typically pairing the token with another asset.
+"""
+type LiquidityPool {
+  """The contract address of the liquidity pool."""
+  address: ID!
+  chainId: Int!
+
+  """The contract address of the first token in the pair."""
+  token0Address: String!
+
+  """
+  The contract address of the second token in the pair (often the base currency like WETH).
+  """
+  token1Address: String!
+}
+
+"""Represents market data for a token."""
+type MarketData {
+  """Number of unique holders of the token."""
+  holders: Int
+
+  """The fully diluted market cap."""
+  marketCapFDV: String!
+
+  """Trading volume for the last 24 hours in USD."""
+  volume24h: String!
+}
+
+input Message {
+  method: String!
+  params: [String!]!
+}
+
+type MessageResult {
+  error: TransactionError
+  report: TransactionReport
+  scanning: TransactionScanningResult
+  simulation: TransactionSimulationResult
+}
+
+type Mutation {
+  onboardPoints(address: String!, referral: String, signature: String!): Points
+  redeemCode(address: String!, code: String!): RedeemedPoints
+}
+
+type Network {
+  colors: NetworkColors!
+  defaultExplorer: NetworkExplorer!
+  defaultRPC: NetworkRPC!
+  enabledServices: NetworkEnabledServices!
+  favorites: [NetworkTokenFavorites]!
+  gasUnits: NetworkGasUnits!
+  icons: NetworkIcons!
+  id: ID!
+  internal: Boolean!
+  label: String!
+  mainnetId: ID!
+  name: String!
+  nativeAsset: NetworkAsset!
+  nativeAssetNeedsApproval: Boolean!
+  nativeWrappedAsset: NetworkAsset!
+  opStack: Boolean!
+  testnet: Boolean!
+}
+
+type NetworkAddys {
+  approvals: Boolean!
+  assets: Boolean!
+  interactionsWith: Boolean!
+  positions: Boolean!
+  summary: Boolean!
+  transactions: Boolean!
+}
+
+type NetworkAsset {
+  address: String!
+  colors: NetworkAssetColors!
+  decimals: Int!
+  iconURL: String!
+  name: String!
+  symbol: String!
+}
+
+type NetworkAssetColors {
+  fallback: String!
+  primary: String!
+  shadow: String!
+}
+
+type NetworkColors {
+  dark: String!
+  light: String!
+}
+
+type NetworkDelegation {
+  enabled7702: Boolean!
+}
+
+type NetworkEnabledServices {
+  addys: NetworkAddys!
+  delegation: NetworkDelegation!
+  launcher: NetworkLauncher!
+  meteorology: NetworkMeteorology!
+  nftProxy: NetworkNFTProxy!
+  notifications: NetworkNotifications!
+  sponsorship: NetworkSponsorship!
+  swap: NetworkSwap!
+  tokenSearch: NetworkTokenSearch!
+}
+
+type NetworkExplorer {
+  label: String!
+  tokenURL: String!
+  transactionURL: String!
+  url: String!
+}
+
+type NetworkGasBasicUnits {
+  approval: String!
+  eoaTransfer: String!
+  swap: String!
+  swapPermit: String!
+  tokenTransfer: String!
+}
+
+type NetworkGasUnits {
+  basic: NetworkGasBasicUnits!
+  wrapped: NetworkGasWrappedUnits!
+}
+
+type NetworkGasWrappedUnits {
+  unwrap: String!
+  wrap: String!
+}
+
+type NetworkIcon {
+  largeURL: String!
+  smallURL: String!
+}
+
+type NetworkIcons {
+  badge: NetworkIcon!
+  badgeURL: String!
+  dark: NetworkIcon!
+  light: NetworkIcon!
+  uncropped: NetworkIcon!
+}
+
+type NetworkLauncher {
+  v1: NetworkLauncherVersion!
+}
+
+type NetworkLauncherVersion {
+  contractAddress: String!
+  enabled: Boolean!
+}
+
+type NetworkMeteorology {
+  eip1559: Boolean!
+  enabled: Boolean!
+  legacy: Boolean!
+}
+
+type NetworkNFTProxy {
+  enabled: Boolean!
+}
+
+type NetworkNotifications {
+  enabled: Boolean!
+  transactions: Boolean!
+}
+
+type NetworkRPC {
+  enabledDevices: [Device]!
+  url: String!
+}
+
+type NetworkSponsorship {
+  enabled: Boolean!
+}
+
+type NetworkSwap {
+  bridge: Boolean!
+  bridgeExactOutput: Boolean!
+  enabled: Boolean!
+  swap: Boolean!
+  swapExactOutput: Boolean!
+}
+
+type NetworkTokenFavorites {
+  address: String!
+}
+
+type NetworkTokenSearch {
+  enabled: Boolean!
+}
+
+type NFTAllowlist {
+  addresses: [String!]
+  chainID: Int!
+}
+
+type Points {
+  error: PointsError
+  leaderboard: PointsLeaderboard!
+  meta: PointsMeta!
+  user: PointsUser!
+}
+
+type PointsEarnings {
+  total: Int!
+}
+
+type PointsError {
+  message: String!
+  type: PointsErrorType!
+}
+
+enum PointsErrorType {
+  ALREADY_CLAIMED
+  ALREADY_USED_CODE
+  AWARDING_NOT_ONGOING
+  BLOCKED_USER
+  EXISTING_USER
+  INVALID_REDEMPTION_CODE
+  INVALID_REFERRAL_CODE
+  NO_BALANCE
+  NO_CLAIM
+  NON_EXISTING_USER
+}
+
+type PointsLeaderboard {
+  accounts: [PointsLeaderboardAccount!]
+  stats: PointsLeaderboardStats!
+}
+
+type PointsLeaderboardAccount {
+  address: String!
+  avatarURL: String!
+  earnings: PointsLeaderboardEarnings!
+  ens: String!
+}
+
+type PointsLeaderboardEarnings {
+  total: Int!
+}
+
+type PointsLeaderboardStats {
+  rank_cutoff: Int!
+  total_points: Int!
+  total_users: Int!
+}
+
+type PointsMeta {
+  distribution: PointsMetaDistribution!
+  rewards: PointsMetaRewards!
+  status: PointsMetaStatus!
+}
+
+type PointsMetaDistribution {
+  last: PointsMetaLastDistribution!
+  next: Int!
+}
+
+type PointsMetaLastDistribution {
+  ended_at: Int!
+  started_at: Int!
+}
+
+type PointsMetaRewards {
+  total: String!
+}
+
+enum PointsMetaStatus {
+  FINISHED
+  ONGOING
+  PAUSED
+}
+
+enum PointsOnboardDisplayType {
+  BONUS
+  NFT_COLLECTION
+  USD_AMOUNT
+}
+
+type PointsOnboarding {
+  categories: [PointsOnboardingCategory!]
+  earnings: PointsOnboardingEarnings!
+}
+
+type PointsOnboardingCategory {
+  data: PointsOnboardingCategoryData!
+  display_type: PointsOnboardDisplayType!
+  earnings: PointsOnboardingEarnings!
+  type: String!
+}
+
+type PointsOnboardingCategoryData {
+  owned_collections: Int!
+  total_collections: Int!
+  usd_amount: Float!
+}
+
+type PointsOnboardingEarnings {
+  total: Int!
+}
+
+type PointsRewards {
+  claimable: String!
+  claimed: String!
+  total: String!
+}
+
+type PointsStats {
+  last_airdrop: PointsStatsPositionLastAirdrop!
+  last_period: PointsStatsPositionLastPeriod!
+  onboarding: PointsStatsOnboarding!
+  position: PointsStatsPosition!
+  referral: PointsStatsReferral!
+}
+
+type PointsStatsOnboarding {
+  onboarded_at: Time!
+}
+
+type PointsStatsPosition {
+  current: Int!
+  unranked: Boolean!
+}
+
+type PointsStatsPositionLastAirdrop {
+  differences: [PointsStatsPositionLastAirdropDifference]!
+  earnings: PointsEarnings!
+  position: PointsStatsPosition!
+}
+
+type PointsStatsPositionLastAirdropDifference {
+  earnings: PointsEarnings!
+  group_id: String!
+  type: String!
+}
+
+type PointsStatsPositionLastPeriod {
+  earnings: PointsEarnings!
+  position: PointsStatsPosition!
+}
+
+type PointsStatsReferral {
+  qualified_referees: Int!
+  total_referees: Int!
+}
+
+type PointsUser {
+  earnings: PointsEarnings!
+  earnings_by_type: [PointsUserEarningByType]!
+  onboarding: PointsOnboarding!
+  referralCode: String!
+  rewards: PointsRewards!
+  stats: PointsStats!
+}
+
+type PointsUserEarningByType {
+  earnings: PointsEarnings!
+  type: String!
+}
+
+type Query {
+  claimablePoints(address: String): ClaimablePoints
+  contract(address: String!, chainID: Int!): Contract
+  contractFunction(address: String, chainID: Int!, hex: String!): ContractFunction
+  contracts(chainID: Int, limit: Int, offset: Int, typeID: Int): [Contract]
+  customNetworks(includeTestnets: Boolean): [CustomNetwork]
+  dApp(shortName: String, url: String): DApp
+  dApps(period: DAppRankingPeriod, trending: Boolean): [DApp]
+  dAppsV2(limit: Int, offset: Int, protocolIDs: [String!]): DAppV2Result
+  ensMarquee: ENSMarquee
+  kingOfTheHill(currency: String): KingOfTheHill
+  kingOfTheHillLeaderBoard(currency: String): KingOfTheHillRankings
+  network(chainID: Int!): Network
+  networks(device: Device, includeTestnets: Boolean): [Network]
+  nftAllowlist(chainID: Int!): NFTAllowlist
+  points(address: String): Points
+  pointsOnboardChallenge(address: String!, referral: String): String!
+  redemptionCode(code: String!): RedemptionCodeInfo
+  resolveENSProfile(chainID: Int!, fields: [String!], name: String!): ENSProfile
+  reverseResolveENSProfile(address: String!, chainID: Int!, fields: [String!]): ENSProfile
+  rewards(address: String, project: RewardsProject!): Rewards
+  simulateMessage(address: String!, chainID: Int!, currency: String, domain: String, message: Message!): MessageResult
+  simulateTransactions(chainID: Int!, currency: String, domain: String, transactions: [Transaction!]): [TransactionResult]
+  stats(address: String!, chainID: Int!, currency: String): RainbowTokenStats
+  token(address: String!, chainID: Int!, currency: String): Token
+  tokenInteractions(address: String!, chainID: Int!, currency: String, tokenAddress: String!): [TokenInteraction]
+  validateReferral(referral: String!): ValidatedReferral
+}
+
+type RainbowTokenDetails {
+  """
+  Information about the primary liquidity pool associated with this token, if available.
+  """
+  liquidityPool: LiquidityPool
+
+  """Descriptive metadata associated with the token."""
+  metadata: RainbowTokenMetadata
+
+  """Data retrieved directly from the blockchain regarding the token."""
+  onchainData: RainbowTokenOnchainData
+}
+
+"""Contains descriptive metadata for a token."""
+type RainbowTokenMetadata {
+  """A text description of the token."""
+  description: String
+
+  """A URL pointing to the token's logo image."""
+  logoUrl: String
+
+  """
+  A URI (often IPFS or HTTP) pointing to more detailed token metadata conforming to a standard (e.g., ERC721/ERC1155).
+  """
+  tokenUri: String
+}
+
+"""Contains data about the token fetched directly from the blockchain."""
+type RainbowTokenOnchainData {
+  """
+  The address of the account that originally deployed the token contract.
+  """
+  creatorAddress: String
+
+  """
+  The Merkle root hash, often used for verified airdrop distributions.
+  May be zero if not applicable. (Included for completeness, might be niche)
+  """
+  merkleRoot: String
+
+  """
+  The total supply of the token currently in existence (as a string to handle large numbers).
+  """
+  totalSupply: String!
+}
+
+type RainbowTokenStats {
+  """
+  Number of data buckets used (meaning might need clarification from source)
+  """
+  bucketCount: Int!
+
+  """
+  Timestamp of the last known transaction included in the summary (Unix timestamp)
+  """
+  lastTransaction: Time!
+
+  """liquidity pool"""
+  liquidityPool: LiquidityPool!
+
+  """An array of summaries for different predefined time durations"""
+  summary: [DurationSummary]!
+}
+
+type RankingDetails {
+  """Timestamp when this market data was last refreshed"""
+  lastUpdated: Int!
+
+  """
+  Metric that determined the winner , supported values are "volume", "latestTransaction", "volume24h" 
+  """
+  rankingCriteria: String!
+
+  """Reason for the token's victory (e.g., "highest volume")"""
+  rankingCriteriaDesc: String!
+
+  """Trading volume specific to the current competition window"""
+  windowTradingVolume: String!
+}
+
+type RedeemedPoints {
+  earnings: RedeemedPointsEarnings!
+  error: PointsError
+  redemption_code: RedemptionCode!
+}
+
+type RedeemedPointsEarnings {
+  total: Int!
+}
+
+type RedemptionCode {
+  code: String!
+}
+
+type RedemptionCodeEarnings {
+  max: Int!
+  min: Int!
+  type: RedemptionCodeScoringType!
+}
+
+type RedemptionCodeInfo {
+  earnings: RedemptionCodeEarnings!
+  error: PointsError
+  redemption_code: RedemptionCode!
+}
+
+enum RedemptionCodeScoringType {
+  FIXED
+  RANGE
+  UNKNOWN
+}
+
+type Rewards {
+  earnings: RewardsEarnings
+  leaderboard: RewardsLeaderboard!
+  meta: RewardsMeta!
+  stats: RewardStats
+}
+
+type RewardsAmount {
+  token: Float!
+  usd: Float!
+}
+
+type RewardsAsset {
+  assetCode: String!
+  chainID: Int!
+  colors: TokenColors!
+  decimals: Int!
+  iconURL: String
+  name: String!
+  symbol: String!
+}
+
+type RewardsDailyAmount {
+  day: Int!
+  token: Float!
+  usd: Float!
+}
+
+type RewardsEarnings {
+  daily: [RewardsDailyAmount!]
+  multiplier: RewardsEarningsMultiplierMultiplier!
+  pending: RewardsAmount!
+  total: RewardsAmount!
+  updatedAt: Int!
+}
+
+type RewardsEarningsMultiplierBreakdown {
+  amount: Float!
+  qualifier: String!
+}
+
+type RewardsEarningsMultiplierMultiplier {
+  amount: Float!
+  breakdown: [RewardsEarningsMultiplierBreakdown!]!
+}
+
+type RewardsLeaderboard {
+  accounts: [RewardsLeaderboardAccount!]
+  updatedAt: Int!
+}
+
+type RewardsLeaderboardAccount {
+  address: String!
+  avatarURL: String
+  earnings: RewardsLeaderboardEarnings!
+  ens: String
+}
+
+type RewardsLeaderboardEarnings {
+  base: RewardsAmount!
+  bonus: RewardsAmount!
+}
+
+type RewardsMeta {
+  color: String!
+  distribution: RewardsMetaDistribution!
+  end: Int!
+  status: RewardsMetaStatus!
+  title: String!
+  token: RewardsMetaToken!
+}
+
+type RewardsMetaDistribution {
+  left: Float!
+  next: Int!
+  total: Float!
+}
+
+enum RewardsMetaStatus {
+  FINISHED
+  ONGOING
+  PAUSED
+}
+
+type RewardsMetaToken {
+  asset: RewardsAsset!
+}
+
+enum RewardsProject {
+  OPTIMISM
+}
+
+type RewardsStatsPosition {
+  change: RewardsStatsPositionChange!
+  current: Int!
+}
+
+type RewardsStatsPositionChange {
+  h24: Int
+}
+
+type RewardStats {
+  actions: [RewardStatsAction!]!
+  position: RewardsStatsPosition!
+}
+
+type RewardStatsAction {
+  amount: RewardsAmount!
+  rewardPercent: Float!
+  type: RewardStatsActionType!
+}
+
+enum RewardStatsActionType {
+  BRIDGE
+  SWAP
+}
+
+type Stats {
+  """Number of unique wallets that bought"""
+  buyers: Int!
+
+  """Number of buy transactions"""
+  buys: Int!
+
+  """Volume attributed to buy transactions"""
+  buyVolume: Float!
+
+  """Price change in percentage (e.g., 5.0 means +5%, -3.2 means -3.2%)"""
+  priceChangePct: Float!
+
+  """Number of unique wallets that sold"""
+  sellers: Int!
+
+  """Number of sell transactions"""
+  sells: Int!
+
+  """Volume attributed to sell transactions"""
+  sellVolume: Float!
+
+  """Total number of transactions (buys + sells)"""
+  transactions: Int!
+
+  """Number of unique wallets that traded"""
+  uniques: Int!
+
+  """Total volume of trades in the specified currency"""
+  volume: Float!
+}
+
+scalar Time
+
+type Token {
+  address: String!
+  allTime: TokenAllTime!
+  bridging: TokenBridging!
+  chainId: Int!
+  circulatingSupply: Float
+  colors: TokenColors!
+  creationDate: Time
+  decimals: Int!
+  description: String
+  fullyDilutedValuation: Float
+  iconUrl: String
+  launchpad: LaunchpadResult
+  links: TokenLinks
+  marketCap: Float
+
+  """
+  Grouped market-related for the token.
+  
+  Note: All internal fields related to market performance (e.g., market cap, volume, holders)
+  are being consolidated under this object for better structure and maintainability.
+  Prefer accessing market-related values through this field going forward.
+  """
+  marketData: MarketData
+  name: String!
+  networks: TokenNetworks!
+  price: TokenPrice!
+  priceCharts: TokenPriceCharts!
+  rainbow: Boolean!
+  rainbowTokenDetails: RainbowTokenDetails
+  status: TokenStatus!
+  symbol: String!
+  totalSupply: Float
+  transferable: Boolean!
+  type: String!
+  volume1d: Float
+}
+
+type TokenAllTime {
+  highDate: Time
+  highValue: Float
+  lowDate: Time
+  lowValue: Float
+}
+
+scalar TokenBridging
+
+type TokenColors {
+  fallback: String
+  primary: String!
+  shadow: String
+}
+
+type TokenInteraction {
+  amount: String!
+  chainID: Int!
+  direction: TokenInteractionDirection!
+  explorerLabel: String!
+  explorerURL: String!
+  interactedAt: Int!
+  price: Float!
+  transactionHash: String!
+  type: TokenInteractionType!
+}
+
+enum TokenInteractionDirection {
+  IN
+  OUT
+  UNKNOWN
+}
+
+enum TokenInteractionType {
+  BOUGHT
+  RECEIVED
+  SENT
+  SOLD
+  UNKNOWN
+}
+
+type TokenLink {
+  url: String!
+}
+
+type TokenLinks {
+  coingecko: TokenLink
+  facebook: TokenLink
+  farcaster: TokenLink
+  homepage: TokenLink
+  other: TokenLink
+  rainbow: TokenLink
+  reddit: TokenLink
+  telegram: TokenLink
+  twitter: TokenLink
+}
+
+scalar TokenNetworks
+
+type TokenPrice {
+  relativeChange24h: Float
+  updatedAt: Time
+  value: Float
+}
+
+type TokenPriceChart {
+  aggregates: TokenPriceChartAggregates
+
+  """
+  points is an array of [Int, Float] pairs
+      where the first element is the timestamp and the second is the price
+  """
+  points: [[Any]]
+
+  """pricePresentAt time when the price is present for the first time"""
+  pricePresentAt: Time
+  timeEnd: Time
+  timeStart: Time
+}
+
+type TokenPriceChartAggregates {
+  avg: Float
+  first: Float
+  last: Float
+  max: Float
+  min: Float
+}
+
+type TokenPriceCharts {
+  day: TokenPriceChart
+  hour: TokenPriceChart
+  max: TokenPriceChart
+  month: TokenPriceChart
+  week: TokenPriceChart
+  year: TokenPriceChart
+}
+
+enum TokenStatus {
+  SCAM
+  UNKNOWN
+  UNVERIFIED
+  VERIFIED
+}
+
+input Transaction {
+  authorization_list: [Authorization]
+  data: String!
+  from: String!
+  to: String!
+  value: String!
+}
+
+enum TransactionAssetInterface {
+  ERC1155
+  ERC20
+  ERC721
+}
+
+enum TransactionAssetType {
+  NATIVE
+  NFT
+  TOKEN
+}
+
+type TransactionError {
+  message: String!
+  type: TransactionErrorType!
+}
+
+enum TransactionErrorType {
+  INSUFFICIENT_BALANCE
+  REVERT
+  UNSUPPORTED
+}
+
+type TransactionGasResult {
+  estimate: String!
+  used: String!
+}
+
+type TransactionReport {
+  url: String!
+}
+
+type TransactionResult {
+  error: TransactionError
+  gas: TransactionGasResult
+  report: TransactionReport
+  scanning: TransactionScanningResult
+  simulation: TransactionSimulationResult
+}
+
+type TransactionScanningResult {
+  description: String!
+  result: TransactionScanResultType!
+}
+
+enum TransactionScanResultType {
+  MALICIOUS
+  OK
+  WARNING
+}
+
+type TransactionSimulationApproval {
+  asset: TransactionSimulationAsset!
+  expiration: Time
+  quantityAllowed: String!
+  quantityAtRisk: String!
+  spender: TransactionSimulationTarget!
+}
+
+type TransactionSimulationAsset {
+  assetCode: String!
+  creationDate: Time
+  decimals: Int!
+  iconURL: String!
+  interface: TransactionAssetInterface!
+  name: String!
+  network: String!
+  status: VerificationStatus!
+  symbol: String!
+  tokenId: String!
+  type: TransactionAssetType!
+}
+
+type TransactionSimulationChange {
+  asset: TransactionSimulationAsset!
+  price: Float!
+  quantity: String!
+}
+
+type TransactionSimulationDelegation {
+  address: String!
+  created: Time
+  iconURL: String!
+  name: String!
+  sourceCodeStatus: VerificationStatus
+}
+
+type TransactionSimulationMeta {
+  to: TransactionSimulationTarget
+  transferTo: TransactionSimulationTarget
+}
+
+type TransactionSimulationResult {
+  approvals: [TransactionSimulationApproval]
+  delegation: TransactionSimulationDelegation
+  in: [TransactionSimulationChange]
+  meta: TransactionSimulationMeta
+  out: [TransactionSimulationChange]
+}
+
+type TransactionSimulationTarget {
+  address: String!
+  created: Time
+  function: String!
+  iconURL: String!
+  name: String!
+  sourceCodeStatus: VerificationStatus
+}
+
+type UserClaimablePoints {
+  earnings: PointsEarnings!
+}
+
+type ValidatedReferral {
+  error: PointsError
+  valid: Boolean!
+}
+
+enum VerificationStatus {
+  UNKNOWN
+  UNVERIFIED
+  VERIFIED
+}

--- a/src/graphql/yarn.lock
+++ b/src/graphql/yarn.lock
@@ -787,7 +787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/schema-ast@npm:^2.5.1":
+"@graphql-codegen/schema-ast@npm:2.5.1, @graphql-codegen/schema-ast@npm:^2.5.1":
   version: 2.5.1
   resolution: "@graphql-codegen/schema-ast@npm:2.5.1"
   dependencies:
@@ -1362,6 +1362,7 @@ __metadata:
   resolution: "@rainbow-me/graphql-client@workspace:."
   dependencies:
     "@graphql-codegen/cli": "npm:2.11.7"
+    "@graphql-codegen/schema-ast": "npm:2.5.1"
     "@graphql-codegen/typescript": "npm:2.7.3"
     "@graphql-codegen/typescript-generic-sdk": "npm:3.0.1"
     "@graphql-codegen/typescript-operations": "npm:2.5.3"


### PR DESCRIPTION
Introspecting live GraphQL services during `setup` let a rate-limited or down provider (e.g. the ENS gateway) fail codegen and block CI, so codegen now reads checked-in SDL and introspection is a manual refresh.

## What changed

- New introspection config drives the manual refresh via codegen's `schema-ast` plugin — already bundled with the codegen CLI, so no new dependency.
- The codegen config now maps each client to its checked-in SDL (and throws on a missing mapping) instead of pointing at a live URL.
- Per-service SDL files are checked in for ENS, metadata, and arc.
- New `graphql-introspect` script; `graphql-codegen` and `setup` are otherwise untouched.
- The checked-in SDL is excluded from eslint and prettier as generated output, and the refresh flow is documented in the GraphQL README.

## What to test

- `yarn setup` generates the clients with no network access and produces unchanged output.
- `yarn graphql-introspect` re-introspects and leaves the schemas unchanged.

## GraphQL Codegen flows:
Generating a client (build, offline):
1. A query is authored as a document alongside the others for that service.
2. Codegen resolves the service to its checked-in SDL schema instead of a live endpoint, erroring if a schema mapping is missing.
3. It validates the query documents against that SDL — a query referencing a field the schema doesn't have fails the build.
4. It emits the typed operations and a typed SDK/fetcher for the service as generated output.
5. The app consumes that generated SDK through the existing per-service client, unchanged at runtime.

Refreshing a schema (manual, `yarn graphql-introspect`):
1. Each live service is introspected (ENS from the keyless public subgraph by default; overridable via env).
2. The sorted SDL for each service is written over the checked-in files — refreshing the SDL is this command's only output.
3. The maintainer re-runs `yarn graphql-codegen` to regenerate the clients from the refreshed SDL.
4. Only the updated SDL is committed; generated client code stays uncommitted.

Setup script impact (commands unchanged; behavior shifts because codegen now reads local SDL):
- `setup` — same steps, but its codegen step is fully offline and can no longer be broken by a provider outage or rate-limit.
- `graphql-codegen` — generates the clients from checked-in SDL instead of live introspection (the prior failure point).
- `graphql-codegen:install` — unchanged; still installs the codegen workspace used during setup.
- `graphql-prepare` — legacy ENS key injection; now inert, since the build no longer introspects.
- `graphql-introspect` — new, and the only path that touches the network; run manually to refresh the SDL.