### PR TITLE
feat(ramp): add custom amount view with keypad

### DIFF
--- a/e2e/flows/cash/CashDepositAddCashKeypad.yaml
+++ b/e2e/flows/cash/CashDepositAddCashKeypad.yaml
@@ -1,0 +1,49 @@
+appId: ${APP_ID}
+tags:
+  - cash
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- runFlow: ../../utils/ImportWalletWithKey.yaml
+- runFlow:
+    file: ../../utils/SetExperimentalFlag.yaml
+    env:
+      FLAG: Cash
+      VALUE: 'true'
+- runFlow:
+    file: ../../utils/SetCashDepositSetupStatus.yaml
+    env:
+      STATUS: ready
+# A ready member lands straight on the Add Cash presets sheet.
+- tapOn:
+    id: buy-button
+- assertVisible:
+    id: cash-deposit-add-cash-amount-more
+# Tapping the "•••" chip flips the sheet into the full-screen keypad amount entry.
+- tapOn:
+    id: cash-deposit-add-cash-amount-more
+- assertVisible:
+    id: cash-deposit-add-cash-amount-display
+# With nothing entered the action button is disabled — its label reads "Enter Amount".
+# The enabled "Hold to Add" label is prefixed with an SF Symbol glyph, so match it with a leading `.*`.
+- assertVisible:
+    text: 'Enter Amount'
+- assertNotVisible:
+    text: '.*Hold to Add'
+# Entering a non-zero amount updates the big-number display and enables the button.
+# The display formats the value with a "$" prefix; `text` is a full-match regex, so escape the "$".
+- tapOn:
+    id: number-pad-key-5
+- assertVisible:
+    text: '\$5'
+    childOf:
+      id: cash-deposit-add-cash-amount-display-container
+- assertVisible:
+    text: '.*Hold to Add'
+- assertNotVisible:
+    text: 'Enter Amount'

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -2,18 +2,36 @@ import React, { memo, useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { analytics } from '@/analytics';
+import { SPRING_CONFIGS } from '@/components/animations/animationConfigs';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
 import ContactAvatar from '@/components/contacts/ContactAvatar';
 import ImageAvatar from '@/components/contacts/ImageAvatar';
 import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldToActivateButton';
-import { PanelSheet } from '@/components/PanelSheet/PanelSheet';
-import { Box, Inline, Text, useForegroundColor } from '@/design-system';
+import { NumberPad } from '@/components/number-pad/NumberPad';
+import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT, PanelSheet } from '@/components/PanelSheet/PanelSheet';
+import { Box, Inline, Text, useColorMode, useForegroundColor } from '@/design-system';
+import { opacity } from '@/framework/ui/utils/opacity';
 import * as i18n from '@/languages';
+import { USDC_ADDRESS } from '@/references/constants';
+import { ChainId } from '@/state/backendNetworks/types';
 import { useAccountProfileInfo } from '@/state/wallets/walletsStore';
+import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
+import getUrlForTrustIconFallback from '@/utils/getUrlForTrustIconFallback';
+import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
+import { sanitizeAmount } from '@/worklets/strings';
 
+import { AddFromRow } from './AddFromRow';
+import { AmountDisplay } from './AmountDisplay';
+import { useAddCashAmount } from './useAddCashAmount';
+
+type AddCashMode = 'presets' | 'keypad';
 type AmountPreset = { amount: number; label: string };
+type AddCashAmount = ReturnType<typeof useAddCashAmount>;
+
 const AMOUNT_PRESETS: AmountPreset[] = [
   { amount: 10, label: '$10' },
   { amount: 25, label: '$25' },
@@ -23,8 +41,13 @@ const AMOUNT_PRESETS: AmountPreset[] = [
 ];
 const DEFAULT_SELECTED_AMOUNT = 50;
 
-// Placeholder payment method — the real "Add From" source lands with card linking.
-const MOCK_PAYMENT_METHOD = { brand: 'Visa Debit', maskedNumber: '*8990' };
+const KEYPAD_PANEL_HEIGHT = DEVICE_HEIGHT;
+const USDC_ICON_URL = getUrlForTrustIconFallback(USDC_ADDRESS, ChainId.mainnet) ?? undefined;
+
+const PANEL_LAYOUT = LinearTransition.springify()
+  .mass(SPRING_CONFIGS.snappierSpringConfig.mass)
+  .damping(SPRING_CONFIGS.snappierSpringConfig.damping)
+  .stiffness(SPRING_CONFIGS.snappierSpringConfig.stiffness);
 
 function AccountAvatar() {
   const { accountSymbol, accountColor, accountImage } = useAccountProfileInfo();
@@ -36,33 +59,34 @@ function AccountAvatar() {
   );
 }
 
-function VisaBadge() {
+function AddCashHeader({ onSettings, topPadding }: { onSettings: () => void; topPadding: '8px' | '28px' }) {
   return (
-    <Box
-      alignItems="center"
-      borderRadius={6}
-      height={{ custom: 20 }}
-      justifyContent="center"
-      style={styles.visaBadge}
-      width={{ custom: 28 }}
-    >
-      <Text align="center" color="white" size="icon 8px" weight="heavy">
-        {'VISA'}
+    <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="24px" paddingTop={topPadding}>
+      <AccountAvatar />
+      <Text align="center" color="label" size="22pt" weight="heavy">
+        {i18n.t(i18n.l.cash.add_cash)}
       </Text>
+      <ButtonPressAnimation onPress={onSettings} scaleTo={0.8} testID="cash-deposit-add-cash-settings">
+        <Box alignItems="center" height={{ custom: 36 }} justifyContent="center" width={{ custom: 36 }}>
+          <Text align="center" color="accent" size="20pt" weight="heavy">
+            {'􀣋'}
+          </Text>
+        </Box>
+      </ButtonPressAnimation>
     </Box>
   );
 }
 
 function AmountChip({ label, selected, onPress, testID }: { label: string; selected: boolean; onPress: () => void; testID: string }) {
-  const blue = useForegroundColor('blue');
   const shadowFar = useForegroundColor('shadowFar');
+  const accent = useForegroundColor('accent');
   return (
     <ButtonPressAnimation onPress={onPress} scaleTo={0.94} style={styles.chip} testID={testID} wrapperStyle={styles.chip}>
       <Box
         alignItems="center"
         background="surfaceSecondaryElevated"
         justifyContent="center"
-        style={[styles.chipInner, { borderColor: selected ? blue : 'transparent', shadowColor: shadowFar }]}
+        style={[styles.chipInner, { borderColor: selected ? accent : 'transparent', shadowColor: shadowFar }]}
       >
         <Text align="center" color="label" size="22pt" weight="heavy">
           {label}
@@ -72,11 +96,174 @@ function AmountChip({ label, selected, onPress, testID }: { label: string; selec
   );
 }
 
+function AmountPresetGrid({
+  onMore,
+  onSelectPreset,
+  selectedAmount,
+}: {
+  onMore: () => void;
+  onSelectPreset: (amount: number) => void;
+  selectedAmount: number;
+}) {
+  return (
+    <Box
+      as={Animated.View}
+      entering={FadeIn.duration(160)}
+      exiting={FadeOut.duration(160)}
+      flexDirection="row"
+      flexWrap="wrap"
+      paddingHorizontal="28px"
+      paddingTop="32px"
+      style={styles.presetGrid}
+    >
+      {AMOUNT_PRESETS.map(preset => (
+        <AmountChip
+          key={preset.amount}
+          label={preset.label}
+          onPress={() => onSelectPreset(preset.amount)}
+          selected={selectedAmount === preset.amount}
+          testID={`cash-deposit-add-cash-amount-${preset.amount}`}
+        />
+      ))}
+      <ButtonPressAnimation
+        onPress={onMore}
+        scaleTo={0.94}
+        style={styles.chip}
+        testID="cash-deposit-add-cash-amount-more"
+        wrapperStyle={styles.chip}
+      >
+        <Box
+          alignItems="center"
+          background="surfaceSecondaryElevated"
+          justifyContent="center"
+          style={[styles.chipInner, styles.chipUnselected]}
+        >
+          <Text align="center" color="label" size="22pt" weight="heavy">
+            {'􀍠'}
+          </Text>
+        </Box>
+      </ButtonPressAnimation>
+    </Box>
+  );
+}
+
+function KeypadHandle() {
+  const { isDarkMode } = useColorMode();
+  const handleColor = isDarkMode ? DEFAULT_HANDLE_COLOR_DARK : DEFAULT_HANDLE_COLOR_LIGHT;
+
+  return (
+    <Box alignItems="center" paddingBottom="8px" style={{ paddingTop: safeAreaInsetValues.top + 8 }}>
+      <Box style={[styles.handle, { backgroundColor: handleColor }]} />
+    </Box>
+  );
+}
+
+function KeypadFundingCaption() {
+  return (
+    <Box alignItems="center" as={Animated.View} entering={FadeIn.duration(160)}>
+      <Inline alignVertical="center" space="6px">
+        <Text align="center" color="labelTertiary" size="15pt" weight="semibold">
+          {i18n.t(i18n.l.cash.add_cash_screen.money_is_added_in)}
+        </Text>
+        <Inline alignVertical="center" space="3px">
+          <RainbowCoinIcon chainId={ChainId.mainnet} icon={USDC_ICON_URL} showBadge={false} size={16} symbol="USDC" />
+          <Text align="center" color="labelSecondary" size="15pt" weight="bold">
+            {i18n.t(i18n.l.cash.add_cash_screen.usdc)}
+          </Text>
+        </Inline>
+      </Inline>
+    </Box>
+  );
+}
+
+function AddCashActionButton({ canSubmit, isKeypad, onHoldToAdd }: { canSubmit: boolean; isKeypad: boolean; onHoldToAdd: () => void }) {
+  const { isDarkMode } = useColorMode();
+  const accent = useForegroundColor('accent');
+  const buttonLabel = canSubmit
+    ? `􀎽  ${i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}`
+    : i18n.t(i18n.l.cash.add_cash_screen.enter_amount);
+
+  return (
+    <Box paddingHorizontal="20px" style={{ paddingBottom: isKeypad ? safeAreaInsetValues.bottom + 16 : 32 }}>
+      <HoldToActivateButton
+        backgroundColor="accent"
+        color={canSubmit ? 'label' : 'labelTertiary'}
+        disabled={!canSubmit}
+        disabledBackgroundColor={isDarkMode ? opacity(accent, 0.1) : 'fillTertiary'}
+        height={48}
+        isProcessing={false}
+        label={buttonLabel}
+        onLongPress={onHoldToAdd}
+        processingLabel={i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}
+        showBiometryIcon={false}
+        size="22pt"
+        testID="cash-deposit-add-cash-hold-to-add"
+        weight="heavy"
+      />
+    </Box>
+  );
+}
+
+function PresetAmountContent({
+  amount,
+  onAddFrom,
+  onHoldToAdd,
+  onMore,
+  onSettings,
+}: {
+  amount: AddCashAmount;
+  onAddFrom: () => void;
+  onHoldToAdd: () => void;
+  onMore: () => void;
+  onSettings: () => void;
+}) {
+  return (
+    <>
+      <AddCashHeader onSettings={onSettings} topPadding="28px" />
+      <AmountPresetGrid onMore={onMore} onSelectPreset={amount.selectPresetAmount} selectedAmount={amount.selectedPresetAmount} />
+      <AddFromRow onPress={onAddFrom} />
+      <AddCashActionButton canSubmit={amount.canSubmit} isKeypad={false} onHoldToAdd={onHoldToAdd} />
+    </>
+  );
+}
+
+function KeypadAmountContent({
+  amount,
+  onAddFrom,
+  onHoldToAdd,
+  onSettings,
+}: {
+  amount: AddCashAmount;
+  onAddFrom: () => void;
+  onHoldToAdd: () => void;
+  onSettings: () => void;
+}) {
+  return (
+    <>
+      <KeypadHandle />
+      <AddCashHeader onSettings={onSettings} topPadding="8px" />
+      <Box as={Animated.View} entering={FadeIn.duration(160)} exiting={FadeOut.duration(160)} style={styles.amountArea}>
+        <AmountDisplay displayedAmount={amount.displayedAmount} />
+      </Box>
+      <KeypadFundingCaption />
+      <AddFromRow onPress={onAddFrom} />
+      <Box as={Animated.View} entering={FadeIn.duration(160)} paddingBottom="8px">
+        <NumberPad
+          activeFieldId={amount.activeFieldId}
+          fields={amount.fields}
+          onValueChange={amount.onValueChange}
+          stripFormatting={sanitizeAmount}
+        />
+      </Box>
+      <AddCashActionButton canSubmit={amount.canSubmit} isKeypad onHoldToAdd={onHoldToAdd} />
+    </>
+  );
+}
+
 export const AddCashSheet = memo(function AddCashSheet() {
-  const blue = useForegroundColor('blue');
-  const separatorTertiary = useForegroundColor('separatorTertiary');
-  const shadowFar = useForegroundColor('shadowFar');
-  const [selectedAmount, setSelectedAmount] = useState(DEFAULT_SELECTED_AMOUNT);
+  const [mode, setMode] = useState<AddCashMode>('presets');
+  const amount = useAddCashAmount(DEFAULT_SELECTED_AMOUNT);
+  const { resetKeypadAmount } = amount;
 
   useFocusEffect(
     useCallback(() => {
@@ -84,117 +271,58 @@ export const AddCashSheet = memo(function AddCashSheet() {
     }, [])
   );
 
-  // Hold to Add → create buy order. Buy pipeline lands in a later unit; inert for now.
+  // Hold to Add -> create buy order. Buy pipeline lands in a later unit; inert for now.
   const handleHoldToAdd = useCallback(() => {
     // TODO(cash): createBuyOrder + register pending transaction once the Add Cash buy unit lands.
   }, []);
 
-  // Add From → payment-method picker. Lands with card linking; inert for now.
+  // Add From -> payment-method picker. Lands with card linking; inert for now.
   const handleAddFrom = useCallback(() => {
     // TODO(cash): open the payment-method picker once card linking lands.
-  }, []);
-
-  // Custom amount entry. Lands with the keypad; inert for now.
-  const handleMore = useCallback(() => {
-    // TODO(cash): open custom amount entry once the keypad unit lands.
   }, []);
 
   const handleSettings = useCallback(() => {
     // TODO(cash): open cash settings once they land.
   }, []);
 
+  const handleMore = useCallback(() => {
+    resetKeypadAmount();
+    setMode('keypad');
+  }, [resetKeypadAmount]);
+
+  const isKeypad = mode === 'keypad';
+
   return (
-    <PanelSheet>
-      <Box background="surfaceSecondary">
-        <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="24px" paddingTop="28px">
-          <AccountAvatar />
-          <Text align="center" color="label" size="22pt" weight="heavy">
-            {i18n.t(i18n.l.cash.add_cash)}
-          </Text>
-          <ButtonPressAnimation onPress={handleSettings} scaleTo={0.8} testID="cash-deposit-add-cash-settings">
-            <Box alignItems="center" height={{ custom: 36 }} justifyContent="center" width={{ custom: 36 }}>
-              <Text align="center" color="blue" size="20pt" weight="heavy">
-                {'􀣋'}
-              </Text>
-            </Box>
-          </ButtonPressAnimation>
-        </Box>
-
-        <Box flexDirection="row" flexWrap="wrap" paddingHorizontal="28px" paddingTop="32px" style={styles.presetGrid}>
-          {AMOUNT_PRESETS.map(preset => (
-            <AmountChip
-              key={preset.amount}
-              label={preset.label}
-              onPress={() => setSelectedAmount(preset.amount)}
-              selected={selectedAmount === preset.amount}
-              testID={`cash-deposit-add-cash-amount-${preset.amount}`}
-            />
-          ))}
-          <ButtonPressAnimation
-            onPress={handleMore}
-            scaleTo={0.94}
-            style={styles.chip}
-            testID="cash-deposit-add-cash-amount-more"
-            wrapperStyle={styles.chip}
-          >
-            <Box
-              alignItems="center"
-              background="surfaceSecondaryElevated"
-              justifyContent="center"
-              style={[styles.chipInner, styles.chipUnselected, { shadowColor: shadowFar }]}
-            >
-              <Text align="center" color="label" size="22pt" weight="heavy">
-                {'􀍠'}
-              </Text>
-            </Box>
-          </ButtonPressAnimation>
-        </Box>
-
-        <Box paddingTop="24px">
-          <Box style={[styles.separator, { backgroundColor: separatorTertiary }]} />
-          <ButtonPressAnimation onPress={handleAddFrom} scaleTo={0.96} testID="cash-deposit-add-cash-add-from">
-            <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="28px" paddingTop="20px">
-              <Text color="labelQuaternary" size="17pt" weight="bold">
-                {i18n.t(i18n.l.cash.add_cash_screen.add_from)}
-              </Text>
-              <Inline alignVertical="center" space="8px">
-                <VisaBadge />
-                <Text color="label" size="17pt" weight="bold">
-                  {MOCK_PAYMENT_METHOD.brand}
-                </Text>
-                <Text color="labelTertiary" size="17pt" weight="semibold">
-                  {MOCK_PAYMENT_METHOD.maskedNumber}
-                </Text>
-                <Text color="labelSecondary" size="13pt" weight="heavy">
-                  {'􀆊'}
-                </Text>
-              </Inline>
-            </Box>
-          </ButtonPressAnimation>
-        </Box>
-
-        <Box paddingBottom="32px" paddingHorizontal="20px" paddingTop="36px">
-          <HoldToActivateButton
-            backgroundColor={blue}
-            color="white"
-            disabledBackgroundColor={blue}
-            height={48}
-            isProcessing={false}
-            label={`􀎽  ${i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}`}
-            onLongPress={handleHoldToAdd}
-            processingLabel={i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}
-            showBiometryIcon={false}
-            size="22pt"
-            testID="cash-deposit-add-cash-hold-to-add"
-            weight="heavy"
+    <PanelSheet
+      bottomOffset={isKeypad ? 0 : undefined}
+      height={isKeypad ? KEYPAD_PANEL_HEIGHT : undefined}
+      layoutAnimation={PANEL_LAYOUT}
+      panelStyle={isKeypad ? styles.fullScreenPanel : undefined}
+      showHandle={!isKeypad}
+    >
+      <Box background="surfaceSecondary" style={isKeypad ? styles.fullScreenContent : undefined}>
+        {isKeypad ? (
+          <KeypadAmountContent amount={amount} onAddFrom={handleAddFrom} onHoldToAdd={handleHoldToAdd} onSettings={handleSettings} />
+        ) : (
+          <PresetAmountContent
+            amount={amount}
+            onAddFrom={handleAddFrom}
+            onHoldToAdd={handleHoldToAdd}
+            onMore={handleMore}
+            onSettings={handleSettings}
           />
-        </Box>
+        )}
       </Box>
     </PanelSheet>
   );
 });
 
 const styles = StyleSheet.create({
+  amountArea: {
+    alignItems: 'center',
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
   chip: {
     flexBasis: '30%',
     flexGrow: 1,
@@ -213,16 +341,19 @@ const styles = StyleSheet.create({
   chipUnselected: {
     borderColor: 'transparent',
   },
+  fullScreenContent: {
+    flex: 1,
+  },
+  fullScreenPanel: {
+    width: DEVICE_WIDTH,
+  },
+  handle: {
+    borderRadius: 3,
+    height: 5,
+    width: 36,
+  },
   presetGrid: {
     columnGap: 10,
     rowGap: 12,
-  },
-  separator: {
-    borderRadius: 1,
-    height: 1,
-    marginHorizontal: 28,
-  },
-  visaBadge: {
-    backgroundColor: '#1B33C3',
   },
 });

--- a/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Inline, Text, useForegroundColor } from '@/design-system';
+import * as i18n from '@/languages';
+
+// Placeholder payment method — the real "Add From" source lands with card linking.
+const MOCK_PAYMENT_METHOD = { brand: 'Visa Debit', maskedNumber: '*8990' };
+
+function VisaBadge() {
+  return (
+    <Box
+      alignItems="center"
+      borderRadius={6}
+      height={{ custom: 20 }}
+      justifyContent="center"
+      style={styles.visaBadge}
+      width={{ custom: 28 }}
+    >
+      <Text align="center" color="white" size="icon 8px" weight="heavy">
+        {'VISA'}
+      </Text>
+    </Box>
+  );
+}
+
+export function AddFromRow({ onPress }: { onPress: () => void }) {
+  const separatorTertiary = useForegroundColor('separatorTertiary');
+
+  return (
+    <Box paddingTop="12px" paddingBottom="24px">
+      <Box style={[styles.separator, { backgroundColor: separatorTertiary }]} />
+      <ButtonPressAnimation onPress={onPress} scaleTo={0.96} testID="cash-deposit-add-cash-add-from">
+        <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingHorizontal="28px" paddingTop="20px">
+          <Text color="labelQuaternary" size="17pt" weight="bold">
+            {i18n.t(i18n.l.cash.add_cash_screen.add_from)}
+          </Text>
+          <Inline alignVertical="center" space="8px">
+            <VisaBadge />
+            <Text color="label" size="17pt" weight="bold">
+              {MOCK_PAYMENT_METHOD.brand}
+            </Text>
+            <Text color="labelTertiary" size="17pt" weight="semibold">
+              {MOCK_PAYMENT_METHOD.maskedNumber}
+            </Text>
+            <Text color="labelSecondary" size="13pt" weight="heavy">
+              {'􀆊'}
+            </Text>
+          </Inline>
+        </Box>
+      </ButtonPressAnimation>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  separator: {
+    borderRadius: 1,
+    height: 1,
+    marginHorizontal: 28,
+  },
+  visaBadge: {
+    backgroundColor: '#1B33C3',
+  },
+});

--- a/src/features/cash/screens/add-cash-sheet/AmountDisplay.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AmountDisplay.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { type SharedValue } from 'react-native-reanimated';
+
+import { InputValueCaret } from '@/components/number-pad/InputValueCaret';
+import { AnimatedText, Box, useForegroundColor } from '@/design-system';
+import { addCommasToNumber } from '@/framework/ui/utils/addCommasToNumber';
+
+// Mirror the Deposit/Withdrawal amount formatting: "$" + comma-grouped value, "$0" when empty.
+const selectFormattedAmount = (value: SharedValue<string>) => {
+  'worklet';
+  const amount = value.value;
+  if (!amount || amount === '0') return '$0';
+  return `$${addCommasToNumber(amount, '0')}`;
+};
+
+export function AmountDisplay({ displayedAmount }: { displayedAmount: SharedValue<string> }) {
+  const accent = useForegroundColor('accent');
+
+  return (
+    <Box
+      alignItems="center"
+      flexDirection="row"
+      justifyContent="center"
+      paddingHorizontal="20px"
+      testID="cash-deposit-add-cash-amount-display-container"
+      width="full"
+    >
+      <AnimatedText
+        align="center"
+        color="label"
+        ellipsizeMode="middle"
+        numberOfLines={1}
+        selector={selectFormattedAmount}
+        size="64pt"
+        style={styles.glyph}
+        tabularNumbers
+        testID="cash-deposit-add-cash-amount-display"
+        weight="heavy"
+      >
+        {displayedAmount}
+      </AnimatedText>
+      <Box style={styles.caret}>
+        <InputValueCaret color={accent} height={57} value={displayedAmount} />
+      </Box>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  caret: {
+    marginLeft: 4,
+  },
+  glyph: {
+    flexShrink: 1,
+  },
+});

--- a/src/features/cash/screens/add-cash-sheet/addCashAmountModel.test.ts
+++ b/src/features/cash/screens/add-cash-sheet/addCashAmountModel.test.ts
@@ -1,0 +1,23 @@
+import { ADD_CASH_AMOUNT_FIELD_ID, createCashAmountField, isSubmittableCashAmount } from './addCashAmountModel';
+
+describe('addCashAmountModel', () => {
+  it('builds the constrained cash keypad field', () => {
+    expect(createCashAmountField()).toEqual({
+      [ADD_CASH_AMOUNT_FIELD_ID]: {
+        allowDecimals: true,
+        allowNegative: false,
+        id: ADD_CASH_AMOUNT_FIELD_ID,
+        maxDecimals: 2,
+        value: '0',
+      },
+    });
+  });
+
+  it('derives submit eligibility from the canonical amount string', () => {
+    expect(isSubmittableCashAmount('0')).toBe(false);
+    expect(isSubmittableCashAmount('0.')).toBe(false);
+    expect(isSubmittableCashAmount('0.00')).toBe(false);
+    expect(isSubmittableCashAmount('0.01')).toBe(true);
+    expect(isSubmittableCashAmount('50')).toBe(true);
+  });
+});

--- a/src/features/cash/screens/add-cash-sheet/addCashAmountModel.ts
+++ b/src/features/cash/screens/add-cash-sheet/addCashAmountModel.ts
@@ -1,0 +1,23 @@
+import { type NumberPadField } from '@/components/number-pad/NumberPadKey';
+
+export const ADD_CASH_AMOUNT_FIELD_ID = 'cash';
+export const ADD_CASH_AMOUNT_MAX_DECIMALS = 2;
+export const ADD_CASH_DEFAULT_VALUE = '0';
+
+export type CashFieldId = typeof ADD_CASH_AMOUNT_FIELD_ID;
+
+export function createCashAmountField(value = ADD_CASH_DEFAULT_VALUE): Record<CashFieldId, NumberPadField> {
+  return {
+    [ADD_CASH_AMOUNT_FIELD_ID]: {
+      allowDecimals: true,
+      allowNegative: false,
+      id: ADD_CASH_AMOUNT_FIELD_ID,
+      maxDecimals: ADD_CASH_AMOUNT_MAX_DECIMALS,
+      value,
+    },
+  };
+}
+
+export function isSubmittableCashAmount(amount: string): boolean {
+  return Number(amount) > 0;
+}

--- a/src/features/cash/screens/add-cash-sheet/useAddCashAmount.ts
+++ b/src/features/cash/screens/add-cash-sheet/useAddCashAmount.ts
@@ -1,0 +1,63 @@
+import { useCallback, useState } from 'react';
+
+import { runOnJS, useSharedValue } from 'react-native-reanimated';
+
+import {
+  ADD_CASH_AMOUNT_FIELD_ID,
+  ADD_CASH_DEFAULT_VALUE,
+  createCashAmountField,
+  isSubmittableCashAmount,
+  type CashFieldId,
+} from './addCashAmountModel';
+
+/**
+ * Owns the Add Cash amount as one canonical JS string while exposing the shared
+ * values the on-thread NumberPad and AnimatedText need.
+ */
+export function useAddCashAmount(defaultPresetAmount: number) {
+  const defaultPresetValue = String(defaultPresetAmount);
+  const fields = useSharedValue(createCashAmountField());
+  const activeFieldId = useSharedValue<CashFieldId>(ADD_CASH_AMOUNT_FIELD_ID);
+  const displayedAmount = useSharedValue(ADD_CASH_DEFAULT_VALUE);
+
+  const [amount, setAmount] = useState(defaultPresetValue);
+  const [selectedPresetAmount, setSelectedPresetAmount] = useState(defaultPresetAmount);
+
+  const selectPresetAmount = useCallback((presetAmount: number) => {
+    setSelectedPresetAmount(presetAmount);
+    setAmount(String(presetAmount));
+  }, []);
+
+  // The NumberPad calls this on the UI thread, so it must be a worklet.
+  const onValueChange = useCallback(
+    (_fieldId: CashFieldId, newValue: string | number) => {
+      'worklet';
+      const nextAmount = String(newValue);
+      displayedAmount.value = nextAmount;
+      runOnJS(setAmount)(nextAmount);
+    },
+    [displayedAmount]
+  );
+
+  const resetKeypadAmount = useCallback(() => {
+    setAmount(ADD_CASH_DEFAULT_VALUE);
+    displayedAmount.value = ADD_CASH_DEFAULT_VALUE;
+    fields.modify(current => {
+      'worklet';
+      current[ADD_CASH_AMOUNT_FIELD_ID].value = ADD_CASH_DEFAULT_VALUE;
+      return current;
+    });
+  }, [displayedAmount, fields]);
+
+  return {
+    activeFieldId,
+    amount,
+    canSubmit: isSubmittableCashAmount(amount),
+    displayedAmount,
+    fields,
+    onValueChange,
+    resetKeypadAmount,
+    selectPresetAmount,
+    selectedPresetAmount,
+  };
+}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1671,7 +1671,10 @@
       },
       "add_cash_screen": {
         "add_from": "Add From",
-        "hold_to_add": "Hold to Add"
+        "hold_to_add": "Hold to Add",
+        "enter_amount": "Enter Amount",
+        "money_is_added_in": "Money is added in",
+        "usdc": "USDC"
       }
     },
     "points": {


### PR DESCRIPTION
Fixes APP-3777

## What changed (plus any additional context for devs)

Adds a custom-amount **keypad** to the Add Cash sheet (behind the `ramp` flag). Tapping the `•••` chip flips the **same** sheet, in place, from the compact presets panel into a full-screen amount-entry layout.

`Add From`, `Hold to Add`, and settings are intentionally inert placeholders (card linking + buy pipeline are separate units).

## Screen recordings / screenshots

**Please use** `Cash` **Experimental Flag, not** `Ramp` **as on the videos**

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-06-08 at 23.14.35.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/682db92b-d3ef-47b4-bd72-020c8c6d6ab4.mov" />](https://app.graphite.com/user-attachments/video/682db92b-d3ef-47b4-bd72-020c8c6d6ab4.mov)<br> | [after.mov.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a2f362a8-549a-40e1-a802-d66d5f8b814f.webm" />](https://app.graphite.com/user-attachments/video/a2f362a8-549a-40e1-a802-d66d5f8b814f.webm) |

