### PR TITLE
chore(helpers): remove unused timestampsCalculation

### DIFF
--- a/src/helpers/transactions.ts
+++ b/src/helpers/transactions.ts
@@ -43,7 +43,6 @@ export const calculateTimestampOfThisYear = () => {
   return d.getTime();
 };
 
-export const timestampsCalculation = new Date();
 export const todayTimestamp = calculateTimestampOfToday();
 export const yesterdayTimestamp = calculateTimestampOfYesterday();
 export const thisMonthTimestamp = calculateTimestampOfThisMonth();


### PR DESCRIPTION
`timestampsCalculation` is a `new Date()` snapshot that powered day-rollover recalculation of the activity section timestamps until #1306 (Nov 2020) removed that logic. It has had zero consumers since.

Ref FEPLAT-34.