### PR TITLE
chore(raps): remove unused revoke-approval helpers and rap types

### DIFF
--- a/src/raps/actions/unlock.ts
+++ b/src/raps/actions/unlock.ts
@@ -1,8 +1,7 @@
 import { type Signer } from '@ethersproject/abstract-signer';
 import { MaxUint256 } from '@ethersproject/constants';
 import { Contract, type PopulatedTransaction } from '@ethersproject/contracts';
-import { parseUnits } from '@ethersproject/units';
-import { erc20Abi, erc721Abi, type Address } from 'viem';
+import { erc20Abi, type Address } from 'viem';
 
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
 import { type TransactionGasParams, type TransactionLegacyGasParams } from '@/features/gas/types/gasSpeed';
@@ -237,56 +236,6 @@ function buildUnlockTransaction(
     ...gasParams,
   };
 }
-
-export const estimateERC721Approval = async ({
-  owner,
-  tokenAddress,
-  spender,
-  chainId,
-}: {
-  owner: Address;
-  tokenAddress: Address;
-  spender: Address;
-  chainId: ChainId;
-}): Promise<string> => {
-  try {
-    const provider = getProvider({ chainId });
-    const tokenContract = new Contract(tokenAddress, erc721Abi, provider);
-    const gasLimit = await tokenContract.estimateGas.setApprovalForAll(spender, false, {
-      from: owner,
-    });
-    return gasLimit ? gasLimit.toString() : `${gasUnits.basic_approval}`;
-  } catch (error) {
-    logger.error(new RainbowError('[raps/unlock]: error estimateApproval'), {
-      message: ensureError(error).message,
-    });
-    return `${gasUnits.basic_approval}`;
-  }
-};
-
-export const populateRevokeApproval = async ({
-  tokenAddress,
-  spenderAddress,
-  chainId,
-  type = 'erc20',
-}: {
-  tokenAddress?: Address;
-  spenderAddress?: Address;
-  chainId?: ChainId;
-  type: 'erc20' | 'nft';
-}): Promise<PopulatedTransaction> => {
-  if (!tokenAddress || !spenderAddress || !chainId) return {};
-  const provider = getProvider({ chainId });
-  const tokenContract = new Contract(tokenAddress, erc721Abi, provider);
-  if (type === 'erc20') {
-    const amountToApprove = parseUnits('0', 'ether');
-    const txObject = await tokenContract.populateTransaction.approve(spenderAddress, amountToApprove);
-    return txObject;
-  } else {
-    const txObject = await tokenContract.populateTransaction.setApprovalForAll(spenderAddress, false);
-    return txObject;
-  }
-};
 
 export const executeApprove = async ({
   gasLimit,

--- a/src/raps/references.ts
+++ b/src/raps/references.ts
@@ -25,13 +25,6 @@ export enum Source {
   Socket = 'socket',
 }
 
-export interface UnlockActionParameters {
-  amount: string;
-  assetToUnlock: ParsedAsset;
-  contractAddress: Address;
-  chainId: number;
-}
-
 export type SwapMetadata = {
   slippage: number;
   route: Source;
@@ -82,12 +75,6 @@ export interface RapUnlockActionParameters {
 }
 
 export type RapClaimClaimableActionParameters = { claimTx: TransactionClaimableTxPayload; asset: ParsedAsset };
-
-export type RapActionParameters =
-  | RapSwapActionParameters<'swap'>
-  | RapSwapActionParameters<'crosschainSwap'>
-  | RapUnlockActionParameters
-  | RapClaimClaimableActionParameters;
 
 export interface RapActionTransaction {
   hash: string | null;
@@ -159,9 +146,4 @@ export interface PrepareActionProps<T extends RapActionTypes> {
   parameters: RapActionParameterMap[T];
   wallet: Signer;
   quote: PrepareActionQuoteMap[T];
-}
-
-export interface WalletExecuteRapProps {
-  rapActionParameters: RapSwapActionParameters<'swap' | 'crosschainSwap' | 'claimClaimable'>;
-  type: RapTypes;
 }


### PR DESCRIPTION
The raps module was copied from the browser extension's implementation in #5608 (May 2024). That copy includes the plumbing for the extension's approvals-revoking feature, which the app never built, so the revoke helpers have had zero callers here from day one. A few rap parameter types arrived in the same state.

This change removes those helpers and types along with the imports only they consumed.

Ref FEPLAT-34.