### PR TITLE
fix(discover): show all predictions in large placements

### DIFF
--- a/src/features/polymarket/stores/polymarketEventsStore.test.ts
+++ b/src/features/polymarket/stores/polymarketEventsStore.test.ts
@@ -1,0 +1,52 @@
+import { rainbowFetch } from '@/framework/data/http/rainbowFetch';
+
+import { fetchPolymarketEventsByIds } from './polymarketEventsStore';
+
+jest.mock('@/framework/data/http/rainbowFetch', () => ({
+  rainbowFetch: jest.fn(),
+}));
+
+jest.mock('@/features/polymarket/constants', () => ({
+  CATEGORIES: {
+    sports: { tagId: 'sports' },
+  },
+  DEFAULT_CATEGORY_KEY: 'trending',
+  POLYMARKET_GAMMA_API_URL: 'https://gamma-api.polymarket.com',
+}));
+
+jest.mock('@/features/polymarket/utils/transforms', () => ({
+  processRawPolymarketEvent: jest.fn(),
+}));
+
+const mockRainbowFetch = rainbowFetch as jest.MockedFunction<typeof rainbowFetch>;
+
+describe('fetchPolymarketEventsByIds', () => {
+  beforeEach(() => {
+    mockRainbowFetch.mockClear();
+    mockRainbowFetch.mockResolvedValue({
+      data: [],
+      headers: new Headers(),
+      status: 200,
+    });
+  });
+
+  it('requests enough events for every requested id', async () => {
+    const eventIds = Array.from({ length: 61 }, (_, index) => `event-${index + 1}`);
+
+    await fetchPolymarketEventsByIds(eventIds, null);
+
+    expect(mockRainbowFetch).toHaveBeenCalledTimes(1);
+
+    const [requestUrl] = mockRainbowFetch.mock.calls[0];
+    const url = new URL(String(requestUrl));
+
+    expect(url.searchParams.get('limit')).toBe('61');
+    expect(url.searchParams.getAll('id')).toEqual(eventIds);
+  });
+
+  it('skips the fetch when there are no ids', async () => {
+    await expect(fetchPolymarketEventsByIds([], null)).resolves.toEqual([]);
+
+    expect(mockRainbowFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/polymarket/stores/polymarketEventsStore.ts
+++ b/src/features/polymarket/stores/polymarketEventsStore.ts
@@ -230,6 +230,7 @@ export async function fetchPolymarketEventsByIds(
 ): Promise<RawPolymarketEvent[]> {
   if (eventIds.length === 0) return [];
   const url = new URL(`${POLYMARKET_GAMMA_API_URL}/events`);
+  url.searchParams.set('limit', String(eventIds.length));
   for (const id of eventIds) url.searchParams.append('id', id);
   const { data } = await rainbowFetch<RawPolymarketEvent[]>(url.toString(), {
     abortController,


### PR DESCRIPTION
Discover placements backed by more than 20 prediction events silently dropped the extras — the Gamma `/events` fetch sent no `limit` and capped at its default of 20.

## What changed
- Set the request `limit` to the requested id count, so every event in a placement resolves.
- Added coverage asserting the limit tracks the id count and that an empty id list skips the fetch.

## What to test
- Open a Discover section backed by more than 20 prediction ids — every card renders.
- Empty id list fires no request.
