### PR TITLE
fix(discover): disable swipe nav, fix tab bar padding

### DIFF
--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -116,11 +116,11 @@ const DiscoverSectionsFallback = memo(function DiscoverSectionsFallback() {
   return (
     <ScrollView
       automaticallyAdjustsScrollIndicatorInsets={false}
-      contentContainerStyle={styles.fallbackContent}
+      contentContainerStyle={[styles.fallbackContent, Platform.OS === 'android' && { paddingBottom: bottomInset }]}
       refreshControl={<DiscoverRefreshControl />}
       showsVerticalScrollIndicator={false}
       contentInset={{ bottom: bottomInset }}
-      style={[styles.scrollView, { paddingBottom: Platform.OS === 'android' ? bottomInset : 0 }]}
+      style={styles.scrollView}
       testID="discover-section-fallback"
     >
       {Array.from({ length: FALLBACK_SECTION_COUNT }, (_, sectionIndex) => (
@@ -206,7 +206,7 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
   return (
     <SectionScrollView
       automaticallyAdjustsScrollIndicatorInsets={false}
-      contentContainerStyle={styles.scrollContent}
+      contentContainerStyle={[styles.scrollContent, Platform.OS === 'android' && { paddingBottom: bottomInset }]}
       onScroll={sectionScrollHandler}
       pointerEvents={isActive ? 'auto' : 'none'}
       ref={setScrollViewRef}
@@ -214,7 +214,7 @@ const DiscoverSectionScrollView = memo(function DiscoverSectionScrollView({
       scrollEventThrottle={16}
       showsVerticalScrollIndicator={false}
       contentInset={{ bottom: bottomInset }}
-      style={[styles.scrollView, { paddingBottom: Platform.OS === 'android' ? bottomInset : 0 }]}
+      style={styles.scrollView}
       testID={`discover-section-page-${sectionIndex + 1}`}
     >
       <Box testID={`discover-section-${section.id}`}>

--- a/src/features/discover/components/DiscoverSectionsPager.tsx
+++ b/src/features/discover/components/DiscoverSectionsPager.tsx
@@ -76,7 +76,8 @@ export const DiscoverSectionsPager = memo(function DiscoverSectionsPager({ scrol
   return (
     <Box style={styles.container} testID="discover-sections-pager">
       <SmoothPager
-        enableSwipeToGoForward="always"
+        enableSwipeToGoBack={false}
+        enableSwipeToGoForward={false}
         fillHeight
         initialPage={initialSection}
         key={pagerKey}

--- a/src/features/polymarket/stores/polymarketEventsStore.test.ts
+++ b/src/features/polymarket/stores/polymarketEventsStore.test.ts
@@ -1,0 +1,52 @@
+import { rainbowFetch } from '@/framework/data/http/rainbowFetch';
+
+import { fetchPolymarketEventsByIds } from './polymarketEventsStore';
+
+jest.mock('@/framework/data/http/rainbowFetch', () => ({
+  rainbowFetch: jest.fn(),
+}));
+
+jest.mock('@/features/polymarket/constants', () => ({
+  CATEGORIES: {
+    sports: { tagId: 'sports' },
+  },
+  DEFAULT_CATEGORY_KEY: 'trending',
+  POLYMARKET_GAMMA_API_URL: 'https://gamma-api.polymarket.com',
+}));
+
+jest.mock('@/features/polymarket/utils/transforms', () => ({
+  processRawPolymarketEvent: jest.fn(),
+}));
+
+const mockRainbowFetch = rainbowFetch as jest.MockedFunction<typeof rainbowFetch>;
+
+describe('fetchPolymarketEventsByIds', () => {
+  beforeEach(() => {
+    mockRainbowFetch.mockClear();
+    mockRainbowFetch.mockResolvedValue({
+      data: [],
+      headers: new Headers(),
+      status: 200,
+    });
+  });
+
+  it('requests enough events for every requested id', async () => {
+    const eventIds = Array.from({ length: 61 }, (_, index) => `event-${index + 1}`);
+
+    await fetchPolymarketEventsByIds(eventIds, null);
+
+    expect(mockRainbowFetch).toHaveBeenCalledTimes(1);
+
+    const [requestUrl] = mockRainbowFetch.mock.calls[0];
+    const url = new URL(String(requestUrl));
+
+    expect(url.searchParams.get('limit')).toBe('61');
+    expect(url.searchParams.getAll('id')).toEqual(eventIds);
+  });
+
+  it('skips the fetch when there are no ids', async () => {
+    await expect(fetchPolymarketEventsByIds([], null)).resolves.toEqual([]);
+
+    expect(mockRainbowFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/polymarket/stores/polymarketEventsStore.ts
+++ b/src/features/polymarket/stores/polymarketEventsStore.ts
@@ -230,6 +230,7 @@ export async function fetchPolymarketEventsByIds(
 ): Promise<RawPolymarketEvent[]> {
   if (eventIds.length === 0) return [];
   const url = new URL(`${POLYMARKET_GAMMA_API_URL}/events`);
+  url.searchParams.set('limit', String(eventIds.length));
   for (const id of eventIds) url.searchParams.append('id', id);
   const { data } = await rainbowFetch<RawPolymarketEvent[]>(url.toString(), {
     abortController,


### PR DESCRIPTION
Fixes APP-3796, APP-3793, APP-3797

Two Discover v2 UI behavior fixes.

## What changed
- **Swipe navigation disabled:** horizontal swipe paging between sections was erratic, so it's turned off via `enableSwipeToGoBack={false}` / `enableSwipeToGoForward={false}` on the sections `SmoothPager`. Tab taps, vertical scroll, and `fillHeight` are unchanged.
- **Tab bar padding:** the floating tab bar's bottom clearance moved from the ScrollView `style` to `contentContainerStyle`, so on Android the last row scrolls clear of the bar instead of staying pinned behind it. iOS keeps `contentInset`.

## What to test
- Swipe horizontally on Discover — sections don't change; tab taps still switch them.
- Android: scroll a section to the end — the last row clears the tab bar (and the system nav bar in 3-button mode).
- iOS: bottom spacing unchanged.

## Screen recordings / screenshots

_Before / after (Pixel 9a, gesture nav) + 4-config matrix below._
