### PR TITLE
feat(predictions): add FIFA sports league filter

### DIFF
--- a/src/features/discover/utils/sportsSurfaceIntent.test.ts
+++ b/src/features/discover/utils/sportsSurfaceIntent.test.ts
@@ -7,15 +7,19 @@ function makeEvent(id: string, slug: string): PolymarketEvent {
 }
 
 describe('selectSportsEventsForIntent', () => {
-  it('includes FIFA World Cup events in the FIFA league intent', () => {
-    const events = [
-      makeEvent('fifa-event', 'fifa-club-world-cup'),
-      makeEvent('fifwc-event', 'fifwc-world-cup-winner'),
-      makeEvent('epl-event', 'epl-title-winner'),
-    ];
+  it('includes FIFA and FIFA World Cup events in the FIFA league intent', () => {
+    const events = [makeEvent('fifa-event', 'fifa-club-world-cup'), makeEvent('fifwc-event', 'fifwc-world-cup-winner')];
 
     const selectedEvents = selectSportsEventsForIntent(events, { leagueId: 'fifa' });
 
     expect(selectedEvents.map(event => event.id)).toEqual(['fifa-event', 'fifwc-event']);
+  });
+
+  it('excludes non-FIFA events from the FIFA league intent', () => {
+    const events = [makeEvent('fifa-event', 'fifa-club-world-cup'), makeEvent('epl-event', 'epl-title-winner')];
+
+    const selectedEvents = selectSportsEventsForIntent(events, { leagueId: 'fifa' });
+
+    expect(selectedEvents.map(event => event.id)).toEqual(['fifa-event']);
   });
 });

--- a/src/features/discover/utils/sportsSurfaceIntent.test.ts
+++ b/src/features/discover/utils/sportsSurfaceIntent.test.ts
@@ -1,0 +1,21 @@
+import { type PolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+
+import { selectSportsEventsForIntent } from './sportsSurfaceIntent';
+
+function makeEvent(id: string, slug: string): PolymarketEvent {
+  return { id, slug, live: false, ended: false } as unknown as PolymarketEvent;
+}
+
+describe('selectSportsEventsForIntent', () => {
+  it('includes FIFA World Cup events in the FIFA league intent', () => {
+    const events = [
+      makeEvent('fifa-event', 'fifa-club-world-cup'),
+      makeEvent('fifwc-event', 'fifwc-world-cup-winner'),
+      makeEvent('epl-event', 'epl-title-winner'),
+    ];
+
+    const selectedEvents = selectSportsEventsForIntent(events, { leagueId: 'fifa' });
+
+    expect(selectedEvents.map(event => event.id)).toEqual(['fifa-event', 'fifwc-event']);
+  });
+});

--- a/src/features/polymarket/leagues.ts
+++ b/src/features/polymarket/leagues.ts
@@ -969,6 +969,7 @@ export function isLeagueId(value: string): value is LeagueId {
 export function getLeagueId(value: string): LeagueId | undefined {
   const slugId = getLeagueSlugId(value);
   if (!slugId) return undefined;
+  // FIFA World Cup events should appear under the FIFA filter.
   if (slugId === 'fifwc') return 'fifa';
   return isLeagueId(slugId) ? slugId : undefined;
 }

--- a/src/features/polymarket/leagues.ts
+++ b/src/features/polymarket/leagues.ts
@@ -233,6 +233,12 @@ export const SPORT_LEAGUES = {
     sportId: 'baseball',
     color: SPORTS.baseball.color,
   },
+  fifa: {
+    name: 'FIFA',
+    fullName: 'FIFA',
+    sportId: 'soccer',
+    color: SPORTS.soccer.color,
+  },
   epl: {
     name: 'Premier League',
     fullName: 'English Premier League',
@@ -943,7 +949,7 @@ export const SPORT_LEAGUES = {
   },
 } as const;
 
-export const LEAGUE_SELECTOR_ORDER: LeagueId[] = ['nfl', 'nba', 'mlb', 'cfb', 'cbb', 'epl', 'nhl', 'atp', 'ufc', 'cs2', 'crint'];
+export const LEAGUE_SELECTOR_ORDER: LeagueId[] = ['fifa', 'nfl', 'nba', 'mlb', 'cfb', 'cbb', 'epl', 'nhl', 'atp', 'ufc', 'cs2', 'crint'];
 
 export const LEAGUE_LIST_ORDER: LeagueId[] = [...LEAGUE_SELECTOR_ORDER, 'dota2', 'val'];
 
@@ -963,6 +969,7 @@ export function isLeagueId(value: string): value is LeagueId {
 export function getLeagueId(value: string): LeagueId | undefined {
   const slugId = getLeagueSlugId(value);
   if (!slugId) return undefined;
+  if (slugId === 'fifwc') return 'fifa';
   return isLeagueId(slugId) ? slugId : undefined;
 }
 


### PR DESCRIPTION
Fixes APP-3788, APP-3792

Soccer/World Cup events surfaced but had no league chip to filter them. Registers FIFA as a first-class soccer league so it resolves through the existing parser everywhere.

## What changed
- Add `fifa` to `SPORT_LEAGUES` (soccer `sportId`) and prepend it to `LEAGUE_SELECTOR_ORDER`.
- Deep links, surfaces, and the filter chip all resolve it via the existing league parser; the soccer-ball glyph comes from the `SPORT_ICONS.soccer` fallback — no new assets.

## What to test
- Predictions → Sports: the FIFA chip leads the selector with a soccer-ball icon.
- Tap it — events filter to soccer.
- A FIFA deep link lands on the Sports tab with FIFA selected.

## Screen recordings / screenshots

_For You "World Cup" section (left) · FIFA chip selected in the Sports filter bar (right)._
