### PR TITLE
fix(ci): stale JS bundle in iOS E2E runs on develop

### DIFF
--- a/.github/actions/ios-build/action.yaml
+++ b/.github/actions/ios-build/action.yaml
@@ -226,7 +226,9 @@ runs:
 
     - name: Build
       id: build
-      uses: callstackincubator/ios@0bfe6ed5c14bdf3fb88a638d5a19b440e59e845f
+      # Fork of callstackincubator/ios that repacks the simulator .app on push events,
+      # fixing stale E2E bundles on develop (FEPLAT-114). Repoint upstream once fixed there.
+      uses: rainbow-me/rock-ios@81353eb09c6e6337a5c6db66feda0c86f6bc941c # fix/repack-app-on-push
       env:
         SENTRY_AUTH_TOKEN: ${{ inputs.sentry-auth-token }}
       with:


### PR DESCRIPTION
On develop pushes, the iOS E2E build usually hits the remote cache for the native build and only rebuilds the JS bundle into the cached `.app`. The upstream build action ([callstackincubator/ios](https://github.com/callstackincubator/ios)) only repacks the archive on `pull_request` events though, so on push events the fresh bundle is discarded and the stale cached archive gets uploaded under the new commit's artifact name. Our develop E2E shards have been testing old bundles whenever the native fingerprint hasn't changed which is what caused recent failures in the suite.

This change repins the build to our fork, [rainbow-me/rock-ios](https://github.com/rainbow-me/rock-ios), which carries a [one-line fix](https://github.com/rainbow-me/rock-ios/commit/81353eb09c6e6337a5c6db66feda0c86f6bc941c) aligning the repack condition with the re-bundle step. The new pin is current upstream `main` plus that fix, a few commits ahead of our previous pin. We'll PR the fix upstream and repoint once it lands. Merging this change should show the repack step executing and the shards running against a fresh bundle and thus the suite to succeed again.

Ref FEPLAT-114.