### PR TITLE
feat(analytics): track Android bottom navigation bar mode

### DIFF
--- a/android/app/src/main/java/me/rainbow/NativeModules/NavbarHeight/NavbarHeightModule.java
+++ b/android/app/src/main/java/me/rainbow/NativeModules/NavbarHeight/NavbarHeightModule.java
@@ -16,6 +16,7 @@ import java.lang.NoSuchMethodException;
 import android.view.WindowInsets;
 import android.os.Build;
 import android.content.Context;
+import android.provider.Settings;
 
 @ReactModule(name = NavbarHeightModule.NAME)
 public class NavbarHeightModule extends ReactContextBaseJavaModule {
@@ -80,6 +81,29 @@ public class NavbarHeightModule extends ReactContextBaseJavaModule {
 
             // navigation bar is not present
             return 0;
+        }
+    }
+
+    /**
+     * Returns the device's system navigation mode, either the on-screen
+     * navigation bar (3- or 2-button), gesture navigation, or -1 if undetermined.
+     */
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public int getNavigationMode() {
+        try {
+            Context context = getReactApplicationContext();
+            // The internal resource that is authoritative of the "currently rendered"
+            // state of the navigation bar style, and is available before user settings.
+            // Since it's not public API, some OEM ROMs drop it (value 0)
+            int resourceId = context.getResources().getIdentifier("config_navBarInteractionMode", "integer", "android");
+            if (resourceId > 0) {
+                return context.getResources().getInteger(resourceId);
+            }
+            // As a fallback, read the Secure "navigation_mode" setting the system
+            // writes on mode change (API 29+) instead; throws if it was never set
+            return Settings.Secure.getInt(context.getContentResolver(), "navigation_mode");
+        } catch (Exception e) {
+            return -1;
         }
     }
 }

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -11,6 +11,7 @@ import { IS_TEST } from '@/env';
 import { logger, RainbowError } from '@/logger';
 import type Routes from '@/navigation/routesNames';
 import { device } from '@/storage';
+import { isUsingButtonNavigation } from '@/utils/deviceUtils';
 
 import { type WalletContext } from './getWalletContext';
 
@@ -21,6 +22,8 @@ type DefaultMetadata = {
   device_brand?: string;
   device_manufacturer?: string;
   device_model?: string;
+  /* Android only: bottom navigation bar mode */
+  navigation_mode?: '3-button' | 'gesture';
 };
 
 type ExternalIds = { externalId?: { id: string; type: string }[] };
@@ -39,6 +42,7 @@ export class Analytics {
   private deviceId?: string;
   private deviceManufacturer?: string;
   private deviceModel?: string;
+  private navigationMode?: '3-button' | 'gesture';
 
   private walletAddressHash?: WalletContext['walletAddressHash'];
   private walletType?: WalletContext['walletType'];
@@ -54,6 +58,7 @@ export class Analytics {
       this.deviceBrand = DeviceInfo.getBrand();
       this.deviceManufacturer = DeviceInfo.getManufacturerSync();
       this.deviceModel = DeviceInfo.getModel();
+      this.navigationMode = isUsingButtonNavigation() ? '3-button' : 'gesture';
     }
   }
 
@@ -143,6 +148,7 @@ export class Analytics {
       metadata.device_brand = this.deviceBrand;
       metadata.device_manufacturer = this.deviceManufacturer;
       metadata.device_model = this.deviceModel;
+      metadata.navigation_mode = this.navigationMode;
     }
 
     return metadata;

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -8,10 +8,10 @@ import { AppsFlyer } from '@/analytics/appsflyer';
 import { event, type EventProperties } from '@/analytics/event';
 import { type UserProperties } from '@/analytics/userProperties';
 import { IS_TEST } from '@/env';
+import { getAndroidNavigationMode, type AndroidNavigationMode } from '@/framework/ui/utils/androidNavigationMode';
 import { logger, RainbowError } from '@/logger';
 import type Routes from '@/navigation/routesNames';
 import { device } from '@/storage';
-import { isUsingButtonNavigation } from '@/utils/deviceUtils';
 
 import { type WalletContext } from './getWalletContext';
 
@@ -23,7 +23,7 @@ type DefaultMetadata = {
   device_manufacturer?: string;
   device_model?: string;
   /* Android only: bottom navigation bar mode */
-  navigation_mode?: '3-button' | 'gesture';
+  navigation_mode?: AndroidNavigationMode;
 };
 
 type ExternalIds = { externalId?: { id: string; type: string }[] };
@@ -42,7 +42,7 @@ export class Analytics {
   private deviceId?: string;
   private deviceManufacturer?: string;
   private deviceModel?: string;
-  private navigationMode?: '3-button' | 'gesture';
+  private navigationMode?: AndroidNavigationMode;
 
   private walletAddressHash?: WalletContext['walletAddressHash'];
   private walletType?: WalletContext['walletType'];
@@ -58,7 +58,7 @@ export class Analytics {
       this.deviceBrand = DeviceInfo.getBrand();
       this.deviceManufacturer = DeviceInfo.getManufacturerSync();
       this.deviceModel = DeviceInfo.getModel();
-      this.navigationMode = isUsingButtonNavigation() ? '3-button' : 'gesture';
+      this.navigationMode = getAndroidNavigationMode();
     }
   }
 

--- a/src/framework/ui/utils/androidNavigationMode.ts
+++ b/src/framework/ui/utils/androidNavigationMode.ts
@@ -1,0 +1,18 @@
+import { NativeModules } from 'react-native';
+
+export enum AndroidNavigationMode {
+  ThreeButton = '3-button',
+  TwoButton = '2-button',
+  Gesture = 'gesture',
+}
+
+export function getAndroidNavigationMode(): AndroidNavigationMode {
+  switch (NativeModules.NavbarHeight?.getNavigationMode?.()) {
+    case 1:
+      return AndroidNavigationMode.TwoButton;
+    case 2:
+      return AndroidNavigationMode.Gesture;
+    default:
+      return AndroidNavigationMode.ThreeButton;
+  }
+}

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -39,11 +39,6 @@ const deviceUtils = (function () {
   };
 })();
 
-export function isUsingButtonNavigation() {
-  if (Platform.OS !== 'android') return false;
-  return NAVIGATION_BAR_HEIGHT > 40;
-}
-
 export const DEVICE_WIDTH = deviceUtils.dimensions.width;
 export const DEVICE_HEIGHT = deviceUtils.dimensions.height;
 export const PIXEL_RATIO = PixelRatio.get();


### PR DESCRIPTION
Fixes: APP-3806

Adds a `navigation_mode` field to the Android-only device metadata that rides
along on every analytics event, alongside the existing device brand /
manufacturer / model fingerprinting.

Values:
- `3-button` — classic 3-button navigation bar
- `2-button` — Android Pie two-button navigation
- `gesture` — swipe/gesture navigation

The mode is read once at startup from the system's own navigation configuration —
the framework `config_navBarInteractionMode` resource, falling back to the
`navigation_mode` secure setting — and defaults to `3-button` when neither
resolves. 
