### PR TITLE
feat(send): add USD and token amounts to the Sent transaction event

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1129,6 +1129,9 @@ export type EventProperties = {
   [event.changedTokenInputSend]: undefined;
   [event.sentTransaction]: {
     assetName: string;
+    assetSymbol: string | undefined;
+    assetAmount: number | undefined;
+    usdValue: number | undefined;
     network: string;
     chainId: ChainId;
     isSponsored: boolean;

--- a/src/analytics/utils.ts
+++ b/src/analytics/utils.ts
@@ -81,3 +81,15 @@ export function securelyHashWalletAddress(walletAddress: Address): string | unde
     logger.error(new RainbowError(`[securelyHashWalletAddress]: Wallet address hashing failed`));
   }
 }
+
+/**
+ * Rounds an amount to 3 significant figures before it leaves the app, so
+ * exact values cannot be used to fingerprint on-chain transactions.
+ */
+export function toAnalyticsAmount(value: string | number): number | undefined {
+  const amount = typeof value === 'string' ? (value ? Number(value) : NaN) : value;
+  if (!Number.isFinite(amount)) {
+    return undefined;
+  }
+  return Number(amount.toPrecision(3));
+}

--- a/src/features/currency/stores/currencyConversionStore.ts
+++ b/src/features/currency/stores/currencyConversionStore.ts
@@ -8,11 +8,14 @@ import { createQueryStore } from '@/state/internal/createQueryStore';
 
 import { NativeCurrencyKeys, type NativeCurrencyKey } from '../types';
 
+type CurrencyConverter = {
+  (value: number): number;
+  (value: string): string;
+};
+
 type CurrencyConversionStore = {
-  convertToNativeCurrency: {
-    (usdValue: number): number;
-    (usdValue: string): string;
-  };
+  convertToNativeCurrency: CurrencyConverter;
+  convertToUsd: CurrencyConverter;
   getConversionRate: () => number;
 };
 
@@ -36,6 +39,7 @@ export const useCurrencyConversionStore = createQueryStore<CurrencyConversionDat
 
   (_, get) => ({
     convertToNativeCurrency: buildCurrencyConverter(() => get().getConversionRate()),
+    convertToUsd: buildCurrencyConverter(() => 1 / get().getConversionRate()),
     getConversionRate: () => get().getData()?.usdToNativeCurrencyConversionRate || 1,
   }),
 
@@ -46,20 +50,20 @@ export const useCurrencyConversionStore = createQueryStore<CurrencyConversionDat
  * Builds an overloaded currency converter that works equivalently with
  * strings and numbers, respecting the type of the input in its output.
  */
-function buildCurrencyConverter(getConversionRate: () => number): CurrencyConversionStore['convertToNativeCurrency'] {
-  function convertToNativeCurrency(usdValue: number): number;
-  function convertToNativeCurrency(usdValue: string): string;
-  function convertToNativeCurrency(usdValue: number | string): number | string {
-    const conversionRate = getConversionRate();
-    const skipConversion = conversionRate === 1;
-    switch (typeof usdValue) {
+function buildCurrencyConverter(getRate: () => number): CurrencyConverter {
+  function convert(value: number): number;
+  function convert(value: string): string;
+  function convert(value: number | string): number | string {
+    const rate = getRate();
+    const skipConversion = rate === 1;
+    switch (typeof value) {
       case 'number':
-        return skipConversion ? usdValue : multiply(usdValue, conversionRate);
+        return skipConversion ? value : multiply(value, rate);
       case 'string':
-        return skipConversion ? usdValue : multiply(stripNonDecimalNumbers(usdValue), conversionRate);
+        return skipConversion ? value : multiply(stripNonDecimalNumbers(value), rate);
     }
   }
-  return convertToNativeCurrency;
+  return convert;
 }
 
 type CurrencyConversionResponse = PlatformResponse<{

--- a/src/features/send/hooks/useSendSubmit.ts
+++ b/src/features/send/hooks/useSendSubmit.ts
@@ -6,7 +6,6 @@ import { Wallet } from '@ethersproject/wallet';
 import { useQueryClient } from '@tanstack/react-query';
 import { isEmpty } from 'lodash';
 
-import { analytics } from '@/analytics';
 import { useRainbowToastEnabled } from '@/components/rainbow-toast/useRainbowToastEnabled';
 import { type ParsedAddressAsset } from '@/entities/tokens';
 import { TransactionStatus, type NewTransaction } from '@/entities/transactions';
@@ -19,6 +18,7 @@ import type useENSProfile from '@/features/ens/hooks/useENSProfile';
 import { type ActionTypes } from '@/features/ens/hooks/useENSRegistrationActionHandler';
 import { type REGISTRATION_STEPS } from '@/features/ens/utils/helpers';
 import { parseGasParamsForTransaction } from '@/features/gas/utils/parseGas';
+import { trackSentTransaction } from '@/features/send/utils/trackSentTransaction';
 import { time } from '@/framework/core/utils/time';
 import { isNativeAsset } from '@/handlers/assets';
 import {
@@ -335,13 +335,14 @@ export function useSendSubmit({
         return false;
       }
       const submitSuccessful = await onSubmit(args);
-      analytics.track(analytics.event.sentTransaction, {
-        assetName: selected?.name || '',
-        network: selected?.network || '',
+      void trackSentTransaction({
+        asset: selected,
+        assetAmount: amountDetails.assetAmount,
         chainId: currentChainId,
-        isSponsored: isSponsoredSend,
-        isRecepientENS: recipient.slice(-4).toLowerCase() === '.eth',
         isHardwareWallet,
+        isSponsored: isSponsoredSend,
+        nativeAmount: amountDetails.nativeAmount,
+        recipient,
         submitSuccessful: submitSuccessful === true,
       });
 

--- a/src/features/send/utils/trackSentTransaction.ts
+++ b/src/features/send/utils/trackSentTransaction.ts
@@ -1,0 +1,63 @@
+import { analytics } from '@/analytics';
+import { toAnalyticsAmount } from '@/analytics/utils';
+import { type ParsedAddressAsset } from '@/entities/tokens';
+import { type UniqueAsset } from '@/entities/uniqueAssets';
+import { useCurrencyConversionStore } from '@/features/currency/stores/currencyConversionStore';
+import { assetIsParsedAddressAsset } from '@/handlers/web3';
+import { ensureError, logger } from '@/logger';
+import { type ChainId } from '@/state/backendNetworks/types';
+
+type TrackSentTransactionParams = {
+  asset: ParsedAddressAsset | UniqueAsset | undefined;
+  assetAmount: string;
+  chainId: ChainId;
+  isHardwareWallet: boolean;
+  isSponsored: boolean;
+  nativeAmount: string;
+  recipient: string;
+  submitSuccessful: boolean;
+};
+
+export async function trackSentTransaction({
+  asset,
+  assetAmount,
+  chainId,
+  isHardwareWallet,
+  isSponsored,
+  nativeAmount,
+  recipient,
+  submitSuccessful,
+}: TrackSentTransactionParams): Promise<void> {
+  try {
+    analytics.track(analytics.event.sentTransaction, {
+      assetName: asset?.name || '',
+      assetSymbol: asset && assetIsParsedAddressAsset(asset) ? asset.symbol : undefined,
+      assetAmount: toAnalyticsAmount(assetAmount),
+      usdValue: await getUsdValue(nativeAmount),
+      network: asset?.network || '',
+      chainId,
+      isSponsored,
+      isRecepientENS: recipient.slice(-4).toLowerCase() === '.eth',
+      isHardwareWallet,
+      submitSuccessful,
+    });
+  } catch (error) {
+    logger.warn('[trackSentTransaction]: failed to track', { error: ensureError(error) });
+  }
+}
+
+async function getUsdValue(nativeAmount: string): Promise<number | undefined> {
+  const amount = toAnalyticsAmount(nativeAmount);
+  if (amount === undefined) {
+    return undefined;
+  }
+
+  // fetch() returns null on a failed refetch even when a cached rate exists,
+  // so fall back to the cached data before treating the rate as unavailable.
+  const data = (await useCurrencyConversionStore.getState().fetch()) ?? useCurrencyConversionStore.getState().getData();
+  if (!data) {
+    return undefined;
+  }
+
+  return toAnalyticsAmount(useCurrencyConversionStore.getState().convertToUsd(amount));
+}

--- a/src/features/send/utils/trackSentTransaction.ts
+++ b/src/features/send/utils/trackSentTransaction.ts
@@ -52,12 +52,14 @@ async function getUsdValue(nativeAmount: string): Promise<number | undefined> {
     return undefined;
   }
 
+  const store = useCurrencyConversionStore.getState();
   // fetch() returns null on a failed refetch even when a cached rate exists,
   // so fall back to the cached data before treating the rate as unavailable.
-  const data = (await useCurrencyConversionStore.getState().fetch()) ?? useCurrencyConversionStore.getState().getData();
-  if (!data) {
+  const data = (await store.fetch()) ?? store.getData();
+  const rate = data?.usdToNativeCurrencyConversionRate;
+  if (rate == null || !Number.isFinite(rate) || rate <= 0) {
     return undefined;
   }
 
-  return toAnalyticsAmount(useCurrencyConversionStore.getState().convertToUsd(amount));
+  return toAnalyticsAmount(store.convertToUsd(amount));
 }


### PR DESCRIPTION
We'd like better insight into send sizes for future product decisions.

This change adds the USD value, token amount, and token symbol to the analytics event when sending (matching what the BX already tracks on its send event). Amounts are rounded to 3 significant figures before leaving the app so exact values can't be matched against on-chain transactions, which would otherwise defeat our wallet address hashing for privacy. When the user's display currency isn't USD and no conversion rate is available, the USD value is omitted rather than recorded incorrectly.

Some small cleanup done part of this change is that the tracking itself moves out of the submit hook into a fire-and-forget handler that lives _outside_ the send hook itself to keep responsibilities decoupled.

Ref DES-121, APP-3769.