### PR TITLE
chore: dedupe runtime helpers across the production bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -42,7 +42,17 @@ module.exports = function (api) {
     ]);
   }
 
-  const presets = ['module:@react-native/babel-preset'];
+  const presets = [
+    [
+      'module:@react-native/babel-preset',
+      {
+        // Matches the @babel/runtime version range in package.json. Lets
+        // transform-runtime import helpers added after 7.0 instead of
+        // inlining a copy into every module (reduces bundle size).
+        enableBabelRuntime: '^7.25.0',
+      },
+    ],
+  ];
 
   return {
     env: {
@@ -51,7 +61,7 @@ module.exports = function (api) {
         presets: presets,
       },
       production: {
-        plugins: [...plugins, '@babel/plugin-transform-runtime', ['transform-remove-console', { exclude: ['error'] }]],
+        plugins: [...plugins, ['transform-remove-console', { exclude: ['error'] }]],
         presets: presets,
       },
     },


### PR DESCRIPTION
`@babel/plugin-transform-runtime` (applied by the React Native babel preset) deduplicates babel helpers by importing them from `@babel/runtime` instead of inlining them, but for compatibility it assumes runtime version 7.0.0 unless told otherwise. Helpers introduced after 7.0 can't be imported under that assumption, so a private copy is inlined into every module that uses one, and across our bundle that duplication adds up.

This change declares our actual runtime version through the preset's `enableBabelRuntime` option, matching the `@babel/runtime` range in `package.json`, so post-7.0 helpers become shared imports instead of per-module copies, shrinking out production bundle by ~0.85MB.

We also drop the `transform-runtime` registration from the production env in the plugins array. The preset always registers the plugin itself, and its helper-generator hook is installed after ours and wins, so the explicit entry has no effect beyond suggesting, misleadingly, that it's where the plugin gets configured. This is also true on develop, just a drive by cleanup in this change.

Internal mirror of #7586 (thanks @retyui).