### PR TITLE
chore: bump webview fork to include the blocked-nav host callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "react-native-video": "6.19.1",
     "react-native-view-shot": "4.0.3",
     "react-native-vision-camera": "4.7.3",
-    "react-native-webview": "rainbow-me/rainbow-react-native-webview#ffa216cb4542f19f42c3e5cb56743f041867c65a",
+    "react-native-webview": "rainbow-me/rainbow-react-native-webview#02b6fd05212f049305bf1efc16e2dd8bd844e6e9",
     "react-native-widgetkit": "1.0.9",
     "react-navigation-backhandler": "2.0.3",
     "react-primitives": "0.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9177,7 +9177,7 @@ __metadata:
     react-native-video: "npm:6.19.1"
     react-native-view-shot: "npm:4.0.3"
     react-native-vision-camera: "npm:4.7.3"
-    react-native-webview: "rainbow-me/rainbow-react-native-webview#ffa216cb4542f19f42c3e5cb56743f041867c65a"
+    react-native-webview: "rainbow-me/rainbow-react-native-webview#02b6fd05212f049305bf1efc16e2dd8bd844e6e9"
     react-native-widgetkit: "npm:1.0.9"
     react-navigation-backhandler: "npm:2.0.3"
     react-primitives: "npm:0.8.1"
@@ -22812,16 +22812,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@rainbow-me/rainbow-react-native-webview#ffa216cb4542f19f42c3e5cb56743f041867c65a":
+"react-native-webview@rainbow-me/rainbow-react-native-webview#02b6fd05212f049305bf1efc16e2dd8bd844e6e9":
   version: 13.16.1
-  resolution: "react-native-webview@https://github.com/rainbow-me/rainbow-react-native-webview.git#commit=ffa216cb4542f19f42c3e5cb56743f041867c65a"
+  resolution: "react-native-webview@https://github.com/rainbow-me/rainbow-react-native-webview.git#commit=02b6fd05212f049305bf1efc16e2dd8bd844e6e9"
   dependencies:
     escape-string-regexp: "npm:^4.0.0"
     invariant: "npm:2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/c74ec0b60f026db1c148c4fdec4734e3143e522e9393b792a1038836b3f0810aa2879d8381404616e56f303a2891d6abc8e826669836e2bdc65396002aafa105
+  checksum: 10c0/3ca5c419a569e789199591d7ab61a716c0acfd19c474da87cc9c466c8689be8cd58ca14a3903d20fa918943b0a3277395edf1f60e0daa4b940e1b7638f2b49f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the `react-native-webview` fork to rainbow-me/rainbow-react-native-webview#21, which adds an optional host callback that fires when a navigation is blocked. The callback is a no-op until a consumer registers a reporter, so this bump changes no behavior on its own.