### PR TITLE
refactor: move send flow components into the transfer domain

### DIFF
--- a/src/components/coin-row/index.js
+++ b/src/components/coin-row/index.js
@@ -1,5 +1,3 @@
 export { default as BottomRowText } from './BottomRowText';
 export { default as CoinRow, CoinRowHeight } from './CoinRow';
-export { default as CollectiblesSendRow } from './CollectiblesSendRow';
-export { default as SendCoinRow } from './SendCoinRow';
 export { default as FastTransactionCoinRow } from './FastTransactionCoinRow';

--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -37,6 +37,7 @@ import ProfileInfoSection from '@/features/ens/components/expanded-state/Profile
 import useENSProfile from '@/features/ens/hooks/useENSProfile';
 import useENSRegistration from '@/features/ens/hooks/useENSRegistration';
 import { ENS_RECORDS, REGISTRATION_MODES } from '@/features/ens/utils/helpers';
+import SendActionButton from '@/features/transfer/components/SendActionButton';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { buildUniqueTokenName } from '@/helpers/assets';
@@ -68,7 +69,7 @@ import ImagePreviewOverlay from '../images/ImagePreviewOverlay';
 import ImgixImage from '../images/ImgixImage';
 import L2Disclaimer from '../L2Disclaimer';
 import Link from '../Link';
-import { SendActionButton, SheetActionButton, SheetHandle, SlackSheet } from '../sheet';
+import { SheetActionButton, SheetHandle, SlackSheet } from '../sheet';
 import { Toast, ToastPositionContainer, ToggleStateToast } from '../toasts';
 import { UniqueTokenAttributes, UniqueTokenImage } from '../unique-token';
 import { UniqueTokenExpandedStateContent, UniqueTokenExpandedStateHeader } from './unique-token';

--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -1,9 +1,0 @@
-export { default as SendAssetForm } from './SendAssetForm';
-export { default as SendAssetFormCollectible } from './SendAssetFormCollectible';
-export { default as SendAssetFormField } from './SendAssetFormField';
-export { default as SendAssetFormToken } from './SendAssetFormToken';
-export { default as SendAssetList } from './SendAssetList';
-export { default as SendButton } from './SendButton';
-export { default as SendContactList } from './SendContactList';
-export { default as SendEmptyState } from './SendEmptyState';
-export { default as SendHeader } from './SendHeader';

--- a/src/components/sheet/index.js
+++ b/src/components/sheet/index.js
@@ -7,4 +7,4 @@ export { default as SheetSubtitleCycler } from './SheetSubtitleCycler';
 export { default as SheetTitle } from './SheetTitle';
 export { default as DynamicHeightSheet } from './DynamicHeightSheet';
 export { default as SlackSheet } from './SlackSheet';
-export { BuyActionButton, SendActionButton, SheetActionButton, SheetActionButtonRow, SwapActionButton } from './sheet-action-buttons';
+export { BuyActionButton, SheetActionButton, SheetActionButtonRow, SwapActionButton } from './sheet-action-buttons';

--- a/src/components/sheet/sheet-action-buttons/index.ts
+++ b/src/components/sheet/sheet-action-buttons/index.ts
@@ -1,5 +1,4 @@
 export { default as BuyActionButton } from './BuyActionButton';
-export { default as SendActionButton } from './SendActionButton';
 export { default as SheetActionButton } from './SheetActionButton';
 export { default as SheetActionButtonRow } from './SheetActionButtonRow';
 export { default as SwapActionButton } from './SwapActionButton';

--- a/src/features/transfer/components/CollectiblesSendRow.tsx
+++ b/src/features/transfer/components/CollectiblesSendRow.tsx
@@ -1,22 +1,21 @@
 import React, { Fragment, useMemo } from 'react';
 import { TouchableWithoutFeedback } from 'react-native';
 
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import RequestVendorLogoIcon from '@/components/coin-icon/RequestVendorLogoIcon';
+import CoinName from '@/components/coin-row/CoinName';
+import CoinRow from '@/components/coin-row/CoinRow';
 import Divider from '@/components/Divider';
+import { Centered } from '@/components/layout';
+import { TruncatedText } from '@/components/text';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
 import { opacity } from '@/framework/ui/utils/opacity';
 import svgToPngIfNeeded from '@/handlers/svgs';
+import { buildAssetUniqueIdentifier } from '@/helpers/assets';
 import { padding } from '@/styles';
+import { useTheme } from '@/theme/ThemeContext';
 import deviceUtils from '@/utils/deviceUtils';
 import magicMemo from '@/utils/magicMemo';
-
-import { buildAssetUniqueIdentifier } from '../../helpers/assets';
-import { useTheme } from '../../theme/ThemeContext';
-import ButtonPressAnimation from '../animations/ButtonPressAnimation';
-import RequestVendorLogoIcon from '../coin-icon/RequestVendorLogoIcon';
-import { Centered } from '../layout';
-import { TruncatedText } from '../text';
-import CoinName from './CoinName';
-import CoinRow from './CoinRow';
 
 const dividerHeight = 22;
 const isSmallPhone = deviceUtils.dimensions.height <= 667;

--- a/src/features/transfer/components/SendActionButton.tsx
+++ b/src/features/transfer/components/SendActionButton.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { Platform } from 'react-native';
 
+import SheetActionButton, { type SheetActionButtonProps } from '@/components/sheet/sheet-action-buttons/SheetActionButton';
 import { Text } from '@/design-system';
 import type { ParsedAddressAsset, RainbowToken } from '@/entities/tokens';
 import type { UniqueAsset } from '@/entities/uniqueAssets';
@@ -8,8 +9,6 @@ import useNavigationForNonReadOnlyWallets from '@/hooks/useNavigationForNonReadO
 import * as i18n from '@/languages';
 import Routes from '@/navigation/routesNames';
 import { colors } from '@/styles';
-
-import SheetActionButton, { type SheetActionButtonProps } from './SheetActionButton';
 
 type SendActionButtonProps = SheetActionButtonProps & {
   asset: RainbowToken | UniqueAsset | ParsedAddressAsset;

--- a/src/features/transfer/components/SendAssetForm.js
+++ b/src/features/transfer/components/SendAssetForm.js
@@ -4,6 +4,9 @@ import { Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Column } from '@/components/layout';
+import { Text } from '@/components/text';
 import styled from '@/framework/ui/styled-thing';
 import { assetIsUniqueAsset } from '@/handlers/web3';
 import useDimensions from '@/hooks/useDimensions';
@@ -12,13 +15,10 @@ import { padding, position } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
 import { NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 
-import ButtonPressAnimation from '../animations/ButtonPressAnimation';
-import { SendCoinRow } from '../coin-row';
-import CollectiblesSendRow from '../coin-row/CollectiblesSendRow';
-import { Column } from '../layout';
-import { Text } from '../text';
+import CollectiblesSendRow from './CollectiblesSendRow';
 import SendAssetFormCollectible from './SendAssetFormCollectible';
 import SendAssetFormToken from './SendAssetFormToken';
+import SendCoinRow from './SendCoinRow';
 
 const AssetRowShadow = colors => [
   [0, 10, 30, colors.shadow, 0.12],

--- a/src/features/transfer/components/SendAssetFormCollectible.js
+++ b/src/features/transfer/components/SendAssetFormCollectible.js
@@ -3,14 +3,13 @@ import { Platform } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
+import OpacityToggler from '@/components/animations/OpacityToggler';
+import { UniqueTokenExpandedStateContent } from '@/components/expanded-state/unique-token';
+import { Column } from '@/components/layout';
 import styled from '@/framework/ui/styled-thing';
 import useDimensions from '@/hooks/useDimensions';
 import useImageMetadata from '@/hooks/useImageMetadata';
 import { padding, position } from '@/styles';
-
-import OpacityToggler from '../animations/OpacityToggler';
-import { UniqueTokenExpandedStateContent } from '../expanded-state/unique-token';
-import { Column } from '../layout';
 
 const defaultImageDimensions = { height: 512, width: 512 };
 

--- a/src/features/transfer/components/SendAssetFormField.js
+++ b/src/features/transfer/components/SendAssetFormField.js
@@ -4,16 +4,15 @@ import { Platform } from 'react-native';
 import RadialGradient from 'react-native-radial-gradient';
 
 import { analytics } from '@/analytics';
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { BubbleField } from '@/components/fields';
+import { Row, RowWithMargins } from '@/components/layout';
+import { Text } from '@/components/text';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { useTheme } from '@/theme/ThemeContext';
-
-import ButtonPressAnimation from '../animations/ButtonPressAnimation';
-import { BubbleField } from '../fields';
-import { Row, RowWithMargins } from '../layout';
-import { Text } from '../text';
 
 const GradientBackground = styled(RadialGradient).attrs(({ colorForAsset, theme: { colors }, width }) => {
   const FieldWidth = width - 38;

--- a/src/features/transfer/components/SendAssetFormToken.js
+++ b/src/features/transfer/components/SendAssetFormToken.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { Platform } from 'react-native';
 
+import { Column } from '@/components/layout';
 import { supportedCurrencies as supportedNativeCurrencies } from '@/features/currency/supportedCurrencies';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
@@ -9,7 +10,6 @@ import { useTheme } from '@/theme/ThemeContext';
 import { NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 import { removeLeadingZeros } from '@/utils/formatters';
 
-import { Column } from '../layout';
 import SendAssetFormField from './SendAssetFormField';
 
 const FooterContainer = styled(Column).attrs({

--- a/src/features/transfer/components/SendAssetList.js
+++ b/src/features/transfer/components/SendAssetList.js
@@ -4,17 +4,18 @@ import { LayoutAnimation } from 'react-native';
 import { View } from 'react-primitives';
 import { DataProvider, LayoutProvider, RecyclerListView } from 'recyclerlistview';
 
+import FlyInAnimation from '@/components/animations/FlyInAnimation';
+import { CoinDividerOpenButton } from '@/components/coin-divider';
 import Divider, { DividerSize } from '@/components/Divider';
+import { Centered } from '@/components/layout';
+import TokenFamilyHeader from '@/components/token-family/TokenFamilyHeader';
 import styled from '@/framework/ui/styled-thing';
+import { buildCoinsList } from '@/helpers/assets';
 import deviceUtils from '@/utils/deviceUtils';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
-import { buildCoinsList } from '../../helpers/assets';
-import FlyInAnimation from '../animations/FlyInAnimation';
-import { CoinDividerOpenButton } from '../coin-divider';
-import { CollectiblesSendRow, SendCoinRow } from '../coin-row';
-import { Centered } from '../layout';
-import TokenFamilyHeader from '../token-family/TokenFamilyHeader';
+import CollectiblesSendRow from './CollectiblesSendRow';
+import SendCoinRow from './SendCoinRow';
 
 const dividerMargin = 5;
 const dividerHeight = DividerSize + dividerMargin * 4;

--- a/src/features/transfer/components/SendButton.js
+++ b/src/features/transfer/components/SendButton.js
@@ -1,9 +1,8 @@
 import React from 'react';
 
+import { HoldToAuthorizeButton } from '@/components/buttons';
 import * as i18n from '@/languages';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
-
-import { HoldToAuthorizeButton } from '../buttons';
 
 export default function SendButton({
   backgroundColor,

--- a/src/features/transfer/components/SendCoinRow.js
+++ b/src/features/transfer/components/SendCoinRow.js
@@ -3,19 +3,18 @@ import { Platform, TouchableWithoutFeedback } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
 
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import RainbowCoinIcon from '@/components/coin-icon/RainbowCoinIcon';
+import CoinName from '@/components/coin-row/CoinName';
+import CoinRow from '@/components/coin-row/CoinRow';
+import { Text } from '@/components/text';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { isL2Chain } from '@/handlers/web3';
 import useColorForAsset from '@/hooks/useColorForAsset';
 import { padding } from '@/styles';
+import { useTheme } from '@/theme/ThemeContext';
 import deviceUtils from '@/utils/deviceUtils';
-
-import { useTheme } from '../../theme/ThemeContext';
-import ButtonPressAnimation from '../animations/ButtonPressAnimation';
-import RainbowCoinIcon from '../coin-icon/RainbowCoinIcon';
-import { Text } from '../text';
-import CoinName from './CoinName';
-import CoinRow from './CoinRow';
 
 const isSmallPhone = deviceUtils.dimensions.height <= 667;
 const isTinyPhone = deviceUtils.dimensions.height <= 568;

--- a/src/features/transfer/components/SendContactList.js
+++ b/src/features/transfer/components/SendContactList.js
@@ -7,6 +7,11 @@ import { sortBy } from 'lodash';
 import * as DeviceInfo from 'react-native-device-info';
 import { useDeepCompareMemo } from 'use-deep-compare';
 
+import FlyInAnimation from '@/components/animations/FlyInAnimation';
+import { ContactRow, SwipeableContactRow } from '@/components/contacts';
+import { SheetHandleFixedToTopHeight } from '@/components/sheet';
+import { Text } from '@/components/text';
+import { InvalidPasteToast, ToastPositionContainer } from '@/components/toasts';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import useKeyboardHeight from '@/hooks/useKeyboardHeight';
@@ -18,11 +23,6 @@ import { useTheme } from '@/theme/ThemeContext';
 import isLowerCaseMatch from '@/utils/isLowerCaseMatch';
 import { filterList } from '@/utils/search';
 
-import FlyInAnimation from '../animations/FlyInAnimation';
-import { ContactRow, SwipeableContactRow } from '../contacts';
-import { SheetHandleFixedToTopHeight } from '../sheet';
-import { Text } from '../text';
-import { InvalidPasteToast, ToastPositionContainer } from '../toasts';
 import SendEmptyState from './SendEmptyState';
 
 const KeyboardArea = styled.View({

--- a/src/features/transfer/components/SendEmptyState.js
+++ b/src/features/transfer/components/SendEmptyState.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
+import { Icon } from '@/components/icons';
+import { Centered } from '@/components/layout';
 import { opacity } from '@/framework/ui/utils/opacity';
+import { sheetVerticalOffset } from '@/navigation/effects';
 import { useTheme } from '@/theme/ThemeContext';
-
-import { sheetVerticalOffset } from '../../navigation/effects';
-import { Icon } from '../icons';
-import { Centered } from '../layout';
 
 const SendEmptyState = () => {
   const { colors } = useTheme();

--- a/src/features/transfer/components/SendHeader.tsx
+++ b/src/features/transfer/components/SendHeader.tsx
@@ -5,8 +5,14 @@ import { isHexString } from '@ethersproject/bytes';
 import isEmpty from 'lodash/isEmpty';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { PasteAddressButton } from '@/components/buttons';
+import showDeleteContactActionSheet from '@/components/contacts/showDeleteContactActionSheet';
 import Divider from '@/components/Divider';
+import { AddressField } from '@/components/fields';
+import { Row } from '@/components/layout';
+import { SheetHandleFixedToTop, SheetTitle } from '@/components/sheet';
 import Spinner from '@/components/Spinner';
+import { Label, Text } from '@/components/text';
 import { PROFILES } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
 import styled from '@/framework/ui/styled-thing';
@@ -19,18 +25,11 @@ import type useContacts from '@/hooks/useContacts';
 import useDimensions from '@/hooks/useDimensions';
 import * as i18n from '@/languages';
 import { type RainbowAccount } from '@/model/wallet';
+import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import { padding } from '@/styles';
+import { useTheme, type ThemeContextProps } from '@/theme/ThemeContext';
 import profileUtils from '@/utils/profileUtils';
-
-import { useNavigation } from '../../navigation/Navigation';
-import { useTheme, type ThemeContextProps } from '../../theme/ThemeContext';
-import { PasteAddressButton } from '../buttons';
-import showDeleteContactActionSheet from '../contacts/showDeleteContactActionSheet';
-import { AddressField } from '../fields';
-import { Row } from '../layout';
-import { SheetHandleFixedToTop, SheetTitle } from '../sheet';
-import { Label, Text } from '../text';
 
 type ComponentPropsWithTheme = {
   theme: ThemeContextProps;

--- a/src/features/transfer/screens/SendSheet.tsx
+++ b/src/features/transfer/screens/SendSheet.tsx
@@ -9,7 +9,6 @@ import { analytics } from '@/analytics';
 import { Column } from '@/components/layout';
 import { NoResults } from '@/components/list';
 import { NoResultsType } from '@/components/list/NoResults';
-import { SendAssetForm, SendAssetList, SendContactList, SendHeader } from '@/components/send';
 import { SheetActionButton } from '@/components/sheet';
 import { PROFILES } from '@/config/experimental';
 import useExperimentalFlag from '@/config/experimentalHooks';
@@ -64,6 +63,10 @@ import ethereumUtils from '@/utils/ethereumUtils';
 import isLowerCaseMatch from '@/utils/isLowerCaseMatch';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
+import SendAssetForm from '../components/SendAssetForm';
+import SendAssetList from '../components/SendAssetList';
+import SendContactList from '../components/SendContactList';
+import SendHeader from '../components/SendHeader';
 import { useSendChainState } from '../hooks/useSendChainState';
 import { useSendSubmit } from '../hooks/useSendSubmit';
 import { useSponsoredSendPreparation } from '../hooks/useSponsoredSendPreparation';

--- a/src/screens/SendConfirmationSheet.tsx
+++ b/src/screens/SendConfirmationSheet.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/features/ens/utils/handlers';
 import GasSpeedButton from '@/features/gas/components/GasSpeedButton';
 import useGas from '@/features/gas/hooks/useGas';
+import SendButton from '@/features/transfer/components/SendButton';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import svgToPngIfNeeded from '@/handlers/svgs';
@@ -62,7 +63,6 @@ import CheckboxField from '../components/fields/CheckboxField';
 import L2Disclaimer from '../components/L2Disclaimer';
 import { Centered, Column, Row } from '../components/layout';
 import Pill from '../components/Pill';
-import { SendButton } from '../components/send';
 import { SheetHandleFixedToTopHeight, SheetTitle, SlackSheet } from '../components/sheet';
 import { Text as OldText } from '../components/text';
 import TouchableBackdrop from '../components/TouchableBackdrop';

--- a/src/screens/expandedAssetSheet/components/SheetFooter.tsx
+++ b/src/screens/expandedAssetSheet/components/SheetFooter.tsx
@@ -5,10 +5,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SwapAssetType } from '@/__swaps__/types/swap';
 import { EasingGradient } from '@/components/easing-gradient/EasingGradient';
-import { BuyActionButton, SendActionButton, SwapActionButton } from '@/components/sheet';
+import { BuyActionButton, SwapActionButton } from '@/components/sheet';
 import { Box, ColorModeProvider, Column, Columns, useColorMode } from '@/design-system';
 import { globalColors, type ColorMode } from '@/design-system/color/palettes';
 import type { ParsedAddressAsset } from '@/entities/tokens';
+import SendActionButton from '@/features/transfer/components/SendActionButton';
 import { isTestnetChain } from '@/handlers/web3';
 import * as i18n from '@/languages';
 import { useRemoteConfig } from '@/model/remoteConfig';


### PR DESCRIPTION
The transfer domain holds the send screen and its hooks, but the flow's components still live scattered across the legacy component tree: a dedicated send folder, two send-only rows among the generic coin rows, and the send action button among the generic sheet buttons. All of them exist solely to serve the send flow.

This change moves them into the domain's components folder and deletes the send components barrel; consumers now import the components directly, per our no-barrel convention. Pure moves with import updates, no behavior change. 

Follow-ups that are a bit more involved will bring in the confirmation sheet, the remaining send-only hooks, and the flow navigator, then a named-exports sweep across the domain.