### PR TITLE
refactor: convert the transfer domain to named exports

### DIFF
--- a/src/components/expanded-state/UniqueTokenExpandedState.tsx
+++ b/src/components/expanded-state/UniqueTokenExpandedState.tsx
@@ -37,7 +37,7 @@ import ProfileInfoSection from '@/features/ens/components/expanded-state/Profile
 import useENSProfile from '@/features/ens/hooks/useENSProfile';
 import useENSRegistration from '@/features/ens/hooks/useENSRegistration';
 import { ENS_RECORDS, REGISTRATION_MODES } from '@/features/ens/utils/helpers';
-import SendActionButton from '@/features/transfer/components/SendActionButton';
+import { SendActionButton } from '@/features/transfer/components/SendActionButton';
 import styled from '@/framework/ui/styled-thing';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { buildUniqueTokenName } from '@/helpers/assets';

--- a/src/features/transfer/components/CollectiblesSendRow.tsx
+++ b/src/features/transfer/components/CollectiblesSendRow.tsx
@@ -75,7 +75,7 @@ const UniqueTokenCoinIcon = magicMemo(
   ['backgroundColor', 'images.lowResUrl', 'images.highResUrl']
 );
 
-const CollectiblesSendRow = React.memo(
+export const CollectiblesSendRow = React.memo(
   ({
     disablePressAnimation,
     item,
@@ -130,5 +130,3 @@ CollectiblesSendRow.displayName = 'CollectiblesSendRow';
 CollectiblesSendRow.dividerHeight = dividerHeight;
 // @ts-expect-error
 CollectiblesSendRow.selectedHeight = selectedHeight;
-
-export default CollectiblesSendRow;

--- a/src/features/transfer/components/SendActionButton.tsx
+++ b/src/features/transfer/components/SendActionButton.tsx
@@ -14,7 +14,7 @@ type SendActionButtonProps = SheetActionButtonProps & {
   asset: RainbowToken | UniqueAsset | ParsedAddressAsset;
 };
 
-function SendActionButton({ asset, color: givenColor, textColor, ...props }: SendActionButtonProps) {
+function SendActionButtonComponent({ asset, color: givenColor, textColor, ...props }: SendActionButtonProps) {
   const color = givenColor || colors.paleBlue;
   const navigate = useNavigationForNonReadOnlyWallets();
 
@@ -42,4 +42,4 @@ function SendActionButton({ asset, color: givenColor, textColor, ...props }: Sen
   );
 }
 
-export default React.memo(SendActionButton);
+export const SendActionButton = React.memo(SendActionButtonComponent);

--- a/src/features/transfer/components/SendAssetForm.js
+++ b/src/features/transfer/components/SendAssetForm.js
@@ -15,10 +15,10 @@ import { padding, position } from '@/styles';
 import { useTheme } from '@/theme/ThemeContext';
 import { NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 
-import CollectiblesSendRow from './CollectiblesSendRow';
-import SendAssetFormCollectible from './SendAssetFormCollectible';
-import SendAssetFormToken from './SendAssetFormToken';
-import SendCoinRow from './SendCoinRow';
+import { CollectiblesSendRow } from './CollectiblesSendRow';
+import { SendAssetFormCollectible } from './SendAssetFormCollectible';
+import { SendAssetFormToken } from './SendAssetFormToken';
+import { SendCoinRow } from './SendCoinRow';
 
 const AssetRowShadow = colors => [
   [0, 10, 30, colors.shadow, 0.12],
@@ -55,7 +55,7 @@ const FormContainer = styled(Column).attrs(
   ...(isUniqueAsset ? padding.object(0) : padding.object(0, 19)),
 }));
 
-export default function SendAssetForm({
+export function SendAssetForm({
   assetAmount,
   buttonRenderer,
   colorForAsset,

--- a/src/features/transfer/components/SendAssetFormCollectible.js
+++ b/src/features/transfer/components/SendAssetFormCollectible.js
@@ -48,7 +48,7 @@ const GradientToggler = styled(OpacityToggler).attrs({
   tension: 500,
 })(position.coverAsObject);
 
-export default function SendAssetFormCollectible({ asset, buttonRenderer, txSpeedRenderer, ...props }) {
+export function SendAssetFormCollectible({ asset, buttonRenderer, txSpeedRenderer, ...props }) {
   const { height: deviceHeight, isTallPhone, isTinyPhone, width: deviceWidth } = useDimensions();
 
   const [containerHeight, setContainerHeight] = useState();

--- a/src/features/transfer/components/SendAssetFormField.js
+++ b/src/features/transfer/components/SendAssetFormField.js
@@ -44,7 +44,7 @@ const Wrapper = styled(Platform.OS === 'android' ? Row : ButtonPressAnimation).a
   width: ({ width }) => (Platform.OS === 'android' ? width - 38 : '100%'),
 });
 
-const SendAssetFormField = (
+const SendAssetFormFieldComponent = (
   {
     autoFocus,
     colorForAsset,
@@ -120,4 +120,4 @@ const SendAssetFormField = (
   );
 };
 
-export default React.forwardRef(SendAssetFormField);
+export const SendAssetFormField = React.forwardRef(SendAssetFormFieldComponent);

--- a/src/features/transfer/components/SendAssetFormToken.js
+++ b/src/features/transfer/components/SendAssetFormToken.js
@@ -10,7 +10,7 @@ import { useTheme } from '@/theme/ThemeContext';
 import { NAVIGATION_BAR_HEIGHT } from '@/utils/deviceUtils';
 import { removeLeadingZeros } from '@/utils/formatters';
 
-import SendAssetFormField from './SendAssetFormField';
+import { SendAssetFormField } from './SendAssetFormField';
 
 const FooterContainer = styled(Column).attrs({
   justify: 'end',
@@ -34,7 +34,7 @@ const Spacer = styled.View({
   width: '100%',
 });
 
-export default function SendAssetFormToken({
+export function SendAssetFormToken({
   assetAmount,
   assetInputRef,
   buttonRenderer,

--- a/src/features/transfer/components/SendAssetList.js
+++ b/src/features/transfer/components/SendAssetList.js
@@ -14,8 +14,8 @@ import { buildCoinsList } from '@/helpers/assets';
 import deviceUtils from '@/utils/deviceUtils';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
-import CollectiblesSendRow from './CollectiblesSendRow';
-import SendCoinRow from './SendCoinRow';
+import { CollectiblesSendRow } from './CollectiblesSendRow';
+import { SendCoinRow } from './SendCoinRow';
 
 const dividerMargin = 5;
 const dividerHeight = DividerSize + dividerMargin * 4;
@@ -41,7 +41,7 @@ const SendAssetListFooter = () => {
   return <View style={{ height: safeAreaInsetValues.bottom, width: '100%' }} />;
 };
 
-export default class SendAssetList extends React.Component {
+export class SendAssetList extends React.Component {
   constructor(props) {
     super(props);
 

--- a/src/features/transfer/components/SendButton.js
+++ b/src/features/transfer/components/SendButton.js
@@ -4,7 +4,7 @@ import { HoldToAuthorizeButton } from '@/components/buttons';
 import * as i18n from '@/languages';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 
-export default function SendButton({
+export function SendButton({
   backgroundColor,
   disabled,
   insufficientEth,

--- a/src/features/transfer/components/SendCoinRow.js
+++ b/src/features/transfer/components/SendCoinRow.js
@@ -77,7 +77,7 @@ const TopRow = ({ item, name, selected }) => {
   );
 };
 
-const SendCoinRow = ({
+export const SendCoinRow = ({
   children,
   disablePressAnimation,
   item,
@@ -142,5 +142,3 @@ const SendCoinRow = ({
 
 SendCoinRow.displayName = 'SendCoinRow';
 SendCoinRow.selectedHeight = selectedHeight;
-
-export default SendCoinRow;

--- a/src/features/transfer/components/SendContactList.js
+++ b/src/features/transfer/components/SendContactList.js
@@ -23,7 +23,7 @@ import { useTheme } from '@/theme/ThemeContext';
 import isLowerCaseMatch from '@/utils/isLowerCaseMatch';
 import { filterList } from '@/utils/search';
 
-import SendEmptyState from './SendEmptyState';
+import { SendEmptyState } from './SendEmptyState';
 
 const KeyboardArea = styled.View({
   height: ({ keyboardHeight }) => keyboardHeight,
@@ -69,7 +69,7 @@ const SendContactFlatList = styled(SectionList).attrs({
   flex: 1,
 });
 
-export default function SendContactList({
+export function SendContactList({
   contacts,
   currentInput,
   ensSuggestions,

--- a/src/features/transfer/components/SendEmptyState.js
+++ b/src/features/transfer/components/SendEmptyState.js
@@ -7,7 +7,7 @@ import { opacity } from '@/framework/ui/utils/opacity';
 import { sheetVerticalOffset } from '@/navigation/effects';
 import { useTheme } from '@/theme/ThemeContext';
 
-const SendEmptyState = () => {
+export const SendEmptyState = () => {
   const { colors } = useTheme();
 
   const icon = <Icon color={opacity(colors.blueGreyDark, 0.06)} height={88} name="send" style={sx.icon} width={91} />;
@@ -22,8 +22,6 @@ const SendEmptyState = () => {
     </Centered>
   );
 };
-
-export default SendEmptyState;
 
 const sx = StyleSheet.create({
   androidContainer: { alignItems: 'center', flex: 1 },

--- a/src/features/transfer/components/SendHeader.tsx
+++ b/src/features/transfer/components/SendHeader.tsx
@@ -93,7 +93,7 @@ type SendHeaderProps = {
   watchedAccounts: RainbowAccount[];
 };
 
-export default function SendHeader({
+export function SendHeader({
   contacts,
   hideDivider,
   isValidAddress,

--- a/src/features/transfer/hooks/useMaxSendableBalance.ts
+++ b/src/features/transfer/hooks/useMaxSendableBalance.ts
@@ -12,18 +12,18 @@ export function useMaxSendableBalance({ ignoreGasFee = false }: { ignoreGasFee?:
   const { selectedGasFee, l1GasFeeOptimism } = useGas();
 
   const updateMaxSendableBalance = useCallback(
-    (inputCurrency: ParsedAddressAsset | UniqueAsset | undefined) => {
-      if (!inputCurrency || assetIsUniqueAsset(inputCurrency)) {
+    (asset: ParsedAddressAsset | UniqueAsset | undefined) => {
+      if (!asset || assetIsUniqueAsset(asset)) {
         return '0';
       }
 
-      const accountAsset = ethereumUtils.getAccountAsset(inputCurrency.uniqueId);
-      const newInputBalance = ignoreGasFee
-        ? (inputCurrency.balance?.amount ?? accountAsset?.balance?.amount ?? '0')
-        : ethereumUtils.getBalanceAmount(selectedGasFee, inputCurrency, l1GasFeeOptimism);
+      const accountAsset = ethereumUtils.getAccountAsset(asset.uniqueId);
+      const newBalance = ignoreGasFee
+        ? (asset.balance?.amount ?? accountAsset?.balance?.amount ?? '0')
+        : ethereumUtils.getBalanceAmount(selectedGasFee, asset, l1GasFeeOptimism);
 
-      setMaxSendableBalance(newInputBalance);
-      return newInputBalance;
+      setMaxSendableBalance(newBalance);
+      return newBalance;
     },
     [ignoreGasFee, l1GasFeeOptimism, selectedGasFee]
   );

--- a/src/features/transfer/hooks/useMaxSendableBalance.ts
+++ b/src/features/transfer/hooks/useMaxSendableBalance.ts
@@ -6,12 +6,12 @@ import useGas from '@/features/gas/hooks/useGas';
 import { assetIsUniqueAsset } from '@/handlers/web3';
 import ethereumUtils from '@/utils/ethereumUtils';
 
-export default function useMaxInputBalance({ ignoreGasFee = false }: { ignoreGasFee?: boolean } = {}) {
-  const [maxInputBalance, setMaxInputBalance] = useState<string>('0');
+export function useMaxSendableBalance({ ignoreGasFee = false }: { ignoreGasFee?: boolean } = {}) {
+  const [maxSendableBalance, setMaxSendableBalance] = useState<string>('0');
 
   const { selectedGasFee, l1GasFeeOptimism } = useGas();
 
-  const updateMaxInputBalance = useCallback(
+  const updateMaxSendableBalance = useCallback(
     (inputCurrency: ParsedAddressAsset | UniqueAsset | undefined) => {
       if (!inputCurrency || assetIsUniqueAsset(inputCurrency)) {
         return '0';
@@ -22,14 +22,14 @@ export default function useMaxInputBalance({ ignoreGasFee = false }: { ignoreGas
         ? (inputCurrency.balance?.amount ?? accountAsset?.balance?.amount ?? '0')
         : ethereumUtils.getBalanceAmount(selectedGasFee, inputCurrency, l1GasFeeOptimism);
 
-      setMaxInputBalance(newInputBalance);
+      setMaxSendableBalance(newInputBalance);
       return newInputBalance;
     },
     [ignoreGasFee, l1GasFeeOptimism, selectedGasFee]
   );
 
   return {
-    maxInputBalance,
-    updateMaxInputBalance,
+    maxSendableBalance,
+    updateMaxSendableBalance,
   };
 }

--- a/src/features/transfer/hooks/useSendSheetInputRefs.ts
+++ b/src/features/transfer/hooks/useSendSheetInputRefs.ts
@@ -3,7 +3,7 @@ import { type TextInput } from 'react-native';
 
 import useMagicAutofocus from '@/hooks/useMagicAutofocus';
 
-export default function useSendSheetInputRefs() {
+export function useSendSheetInputRefs() {
   const assetInputRef = useRef<TextInput>(undefined);
   const nativeCurrencyInputRef = useRef<TextInput | null>(null);
 

--- a/src/features/transfer/hooks/useSendableUniqueTokens.ts
+++ b/src/features/transfer/hooks/useSendableUniqueTokens.ts
@@ -5,7 +5,7 @@ import { groupBy } from 'lodash';
 import { useLegacyNFTs } from '@/resources/nfts';
 import { useAccountAddress } from '@/state/wallets/walletsStore';
 
-export default function useUniqueTokens() {
+export function useSendableUniqueTokens() {
   const accountAddress = useAccountAddress();
   const {
     data: { nfts: uniqueTokens },

--- a/src/features/transfer/navigation/SendFlowNavigator.tsx
+++ b/src/features/transfer/navigation/SendFlowNavigator.tsx
@@ -7,7 +7,7 @@ import { overlayExpandedPreset, sheetPreset } from '@/navigation/effects';
 import Routes from '@/navigation/routesNames';
 import ModalScreen from '@/screens/ModalScreen';
 
-import SendSheet from '../screens/SendSheet';
+import { SendSheet } from '../screens/SendSheet';
 
 const Stack = createStackNavigator();
 

--- a/src/features/transfer/screens/SendConfirmationSheet.tsx
+++ b/src/features/transfer/screens/SendConfirmationSheet.tsx
@@ -67,7 +67,7 @@ import { addressHashedColorIndex, addressHashedEmoji } from '@/utils/profileUtil
 import promiseUtils from '@/utils/promise';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
-import SendButton from '../components/SendButton';
+import { SendButton } from '../components/SendButton';
 
 const Container = styled(Centered).attrs({
   direction: 'column',

--- a/src/features/transfer/screens/SendSheet.tsx
+++ b/src/features/transfer/screens/SendSheet.tsx
@@ -59,14 +59,14 @@ import ethereumUtils from '@/utils/ethereumUtils';
 import isLowerCaseMatch from '@/utils/isLowerCaseMatch';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 
-import SendAssetForm from '../components/SendAssetForm';
-import SendAssetList from '../components/SendAssetList';
-import SendContactList from '../components/SendContactList';
-import SendHeader from '../components/SendHeader';
-import useMaxInputBalance from '../hooks/useMaxInputBalance';
-import useSendableUniqueTokens from '../hooks/useSendableUniqueTokens';
+import { SendAssetForm } from '../components/SendAssetForm';
+import { SendAssetList } from '../components/SendAssetList';
+import { SendContactList } from '../components/SendContactList';
+import { SendHeader } from '../components/SendHeader';
+import { useMaxSendableBalance } from '../hooks/useMaxSendableBalance';
+import { useSendableUniqueTokens } from '../hooks/useSendableUniqueTokens';
 import { useSendChainState } from '../hooks/useSendChainState';
-import useSendSheetInputRefs from '../hooks/useSendSheetInputRefs';
+import { useSendSheetInputRefs } from '../hooks/useSendSheetInputRefs';
 import { useSendSubmit } from '../hooks/useSendSubmit';
 import { useSponsoredSendPreparation } from '../hooks/useSponsoredSendPreparation';
 import { getSendSubmitButtonState } from '../utils/sendSheetUtils';
@@ -131,10 +131,10 @@ const validateRecipientDamagedState = (toAddress?: string) => {
   return true;
 };
 
-const hasSufficientAssetBalance = (assetAmount: string, maxInputBalance: string): boolean =>
-  !assetAmount || greaterThanOrEqualTo(maxInputBalance || '0', assetAmount);
+const hasSufficientAssetBalance = (assetAmount: string, maxSendableBalance: string): boolean =>
+  !assetAmount || greaterThanOrEqualTo(maxSendableBalance || '0', assetAmount);
 
-export default function SendSheet() {
+export function SendSheet() {
   const { navigate } = useNavigation();
   const sortedAssets = useUserAssetsStore(state => state.legacyUserAssets);
   const isLoadingUserAssets = useUserAssetsStore(state => state.getStatus('isInitialLoad'));
@@ -230,7 +230,7 @@ export default function SendSheet() {
     selected: selectedAddressAsset,
     toAddress,
   });
-  const { maxInputBalance, updateMaxInputBalance } = useMaxInputBalance({ ignoreGasFee: isSponsorshipSupported });
+  const { maxSendableBalance, updateMaxSendableBalance } = useMaxSendableBalance({ ignoreGasFee: isSponsorshipSupported });
 
   let colorForAsset = useColorForAsset(selected, undefined, false, true);
   const uniqueAssetColor = usePersistentDominantColorFromImage(isUniqueAsset ? selected?.images.lowResUrl : null) ?? colors.appleBlue;
@@ -254,7 +254,7 @@ export default function SendSheet() {
         _nativeAmount = formatInputDecimals(convertedNativeAmount, _assetAmount);
       }
 
-      const _isSufficientBalance = hasSufficientAssetBalance(_assetAmount, maxInputBalance);
+      const _isSufficientBalance = hasSufficientAssetBalance(_assetAmount, maxSendableBalance);
 
       setAmountDetails({
         assetAmount: _assetAmount,
@@ -262,13 +262,13 @@ export default function SendSheet() {
         nativeAmount: _nativeAmount,
       });
     },
-    [isUniqueAsset, maxInputBalance, nativeCurrency, selected]
+    [isUniqueAsset, maxSendableBalance, nativeCurrency, selected]
   );
 
   const sendUpdateSelected = useCallback(
     (newSelected: ParsedAddressAsset | UniqueAsset | undefined) => {
       if (isEqual(newSelected, selected)) return;
-      updateMaxInputBalance(newSelected);
+      updateMaxSendableBalance(newSelected);
       if (assetIsUniqueAsset(newSelected)) {
         setAmountDetails({
           assetAmount: '1',
@@ -287,16 +287,16 @@ export default function SendSheet() {
         sendUpdateAssetAmount('');
       }
     },
-    [selected, sendUpdateAssetAmount, updateMaxInputBalance]
+    [selected, sendUpdateAssetAmount, updateMaxSendableBalance]
   );
 
   // Update all fields passed via params if needed
   useEffect(() => {
     if (!selected || isUniqueAsset) return;
 
-    const newMaxInputBalance = updateMaxInputBalance(selected);
+    const newMaxSendableBalance = updateMaxSendableBalance(selected);
     setAmountDetails(currentAmountDetails => {
-      const isSufficientBalance = hasSufficientAssetBalance(currentAmountDetails.assetAmount, newMaxInputBalance);
+      const isSufficientBalance = hasSufficientAssetBalance(currentAmountDetails.assetAmount, newMaxSendableBalance);
       if (currentAmountDetails.isSufficientBalance === isSufficientBalance) return currentAmountDetails;
 
       return {
@@ -304,7 +304,7 @@ export default function SendSheet() {
         isSufficientBalance,
       };
     });
-  }, [isUniqueAsset, isSponsorshipSupported, selected, updateMaxInputBalance]);
+  }, [isUniqueAsset, isSponsorshipSupported, selected, updateMaxSendableBalance]);
 
   useEffect(() => {
     if (recipientOverride && !recipient) {
@@ -314,23 +314,23 @@ export default function SendSheet() {
 
     if (assetOverride && assetOverride !== prevAssetOverride) {
       sendUpdateSelected(assetOverride);
-      updateMaxInputBalance(assetOverride);
+      updateMaxSendableBalance(assetOverride);
     }
 
-    if (nativeAmountOverride && maxInputBalance) {
+    if (nativeAmountOverride && maxSendableBalance) {
       sendUpdateAssetAmount(nativeAmountOverride);
     }
   }, [
     amountDetails,
     assetOverride,
-    maxInputBalance,
+    maxSendableBalance,
     nativeAmountOverride,
     prevAssetOverride,
     recipient,
     recipientOverride,
     sendUpdateAssetAmount,
     sendUpdateSelected,
-    updateMaxInputBalance,
+    updateMaxSendableBalance,
   ]);
 
   const onChangeNativeAmount = useCallback(
@@ -348,7 +348,7 @@ export default function SendSheet() {
         _assetAmount = formatInputDecimals(convertedAssetAmount, _nativeAmount);
       }
 
-      const _isSufficientBalance = hasSufficientAssetBalance(_assetAmount, maxInputBalance);
+      const _isSufficientBalance = hasSufficientAssetBalance(_assetAmount, maxSendableBalance);
       setAmountDetails({
         assetAmount: _assetAmount,
         isSufficientBalance: _isSufficientBalance,
@@ -356,17 +356,17 @@ export default function SendSheet() {
       });
       analytics.track(analytics.event.changedNativeCurrencyInputSend);
     },
-    [maxEnabled, maxInputBalance, isUniqueAsset, selected]
+    [maxEnabled, maxSendableBalance, isUniqueAsset, selected]
   );
 
   useEffect(() => {
     if (maxEnabled) {
-      const newBalanceAmount = updateMaxInputBalance(selected);
+      const newBalanceAmount = updateMaxSendableBalance(selected);
       sendUpdateAssetAmount(newBalanceAmount);
     }
     // we want to listen to the gas fee and update when it changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected, sendUpdateAssetAmount, updateMaxInputBalance, selectedGasFee, maxEnabled]);
+  }, [selected, sendUpdateAssetAmount, updateMaxSendableBalance, selectedGasFee, maxEnabled]);
 
   const onChangeAssetAmount = useCallback(
     (newAssetAmount: string) => {

--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -56,7 +56,7 @@ import { RnbwStakingLearnScreen } from '@/features/rnbw-staking/screens/rnbw-sta
 import { RnbwStakingScreen } from '@/features/rnbw-staking/screens/rnbw-staking-screen/RnbwStakingScreen';
 import { RnbwUnstakeSheet } from '@/features/rnbw-staking/screens/rnbw-unstake-sheet/RnbwUnstakeSheet';
 import { SendConfirmationSheet } from '@/features/transfer/screens/SendConfirmationSheet';
-import SendSheet from '@/features/transfer/screens/SendSheet';
+import { SendSheet } from '@/features/transfer/screens/SendSheet';
 import ConnectedDappsSheet from '@/features/wallet-connect/screens/ConnectedDappsSheet';
 import walletBackupStepTypes from '@/helpers/walletBackupStepTypes';
 import { Portal as CMPortal } from '@/react-native-cool-modals/Portal';

--- a/src/screens/expandedAssetSheet/components/SheetFooter.tsx
+++ b/src/screens/expandedAssetSheet/components/SheetFooter.tsx
@@ -9,7 +9,7 @@ import { BuyActionButton, SwapActionButton } from '@/components/sheet';
 import { Box, ColorModeProvider, Column, Columns, useColorMode } from '@/design-system';
 import { globalColors, type ColorMode } from '@/design-system/color/palettes';
 import type { ParsedAddressAsset } from '@/entities/tokens';
-import SendActionButton from '@/features/transfer/components/SendActionButton';
+import { SendActionButton } from '@/features/transfer/components/SendActionButton';
 import { isTestnetChain } from '@/handlers/web3';
 import * as i18n from '@/languages';
 import { useRemoteConfig } from '@/model/remoteConfig';


### PR DESCRIPTION
The transfer domain is freshly consolidated but still uses default exports throughout, a leftover from its legacy-directory days.

This change converts every export in the domain to a named export . Two naming fixes ride along since they're the same kind of identifier-only change:
* `useMaxInputBalance` becomes `useMaxSendableBalance` (the old name is swap-era vocabulary; the hook is send-flow state glue)
*  `useSendableUniqueTokens` internally declared itself `useUniqueTokens`, which now matches the file and export. 