### PR TITLE
chore: remove dead CodePush/AppCenter env vars

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -31,10 +31,6 @@ declare module 'react-native-dotenv' {
   export const PINATA_API_SECRET: string;
   export const PINATA_API_URL: string;
   export const PINATA_GATEWAY_URL: string;
-  export const APP_CENTER_READ_ONLY_TOKEN_ANDROID: string;
-  export const APP_CENTER_READ_ONLY_TOKEN_IOS: string;
-  export const CODE_PUSH_DEPLOYMENT_KEY_ANDROID: string;
-  export const CODE_PUSH_DEPLOYMENT_KEY_IOS: string;
   export const NFT_API_KEY: string;
   export const NFT_API_URL: string;
   export const ETHERSCAN_API_KEY: string;

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -62,7 +62,6 @@ if [ -e .env ]; then
 
     rewrite_xcode_configs "BRANCH"
     rewrite_xcode_configs "GOOGLE"
-    rewrite_xcode_configs "CODE_PUSH_DEPLOYMENT_KEY_IOS"
     rewrite_xcode_configs_native_prefix "METADATA_BASE_URL"
     # Override Google Services API Key
     if [ -n "$GOOGLE_SERVICE_API_KEY" ]; then


### PR DESCRIPTION
CodePush has been dead since AppCenter's retirement and we no longer ship `react-native-code-push`, but its env vars are still wired into the build. The postinstall step hard-requires `CODE_PUSH_DEPLOYMENT_KEY_IOS` in `.env` (failing the install with an `exit 1` if it's absent) and copies it into the iOS xcconfig, where nothing reads it; the dotenv type declarations also still list it alongside the AppCenter read-only tokens.

This surfaced while removing these vars from our Bitrise `.env` generators: the install then failed because postinstall still demanded the deployment key. This change drops that requirement and the unused declarations, so none of the CodePush/AppCenter env vars are needed anywhere in the app build path. No runtime impact, since the app doesn't use CodePush. The matching secrets in `rainbow-env` and Bitrise will be cleaned up separately.