### PR TITLE
refactor: move EIP-681 send launcher into the transfer domain

### DIFF
--- a/src/features/transfer/utils/startSendFromEthereumUrl.ts
+++ b/src/features/transfer/utils/startSendFromEthereumUrl.ts
@@ -1,0 +1,73 @@
+import { InteractionManager, Platform } from 'react-native';
+
+// @ts-expect-error eth-url-parser ships no type declarations
+import { parse } from 'eth-url-parser';
+
+import { WrappedAlert as Alert } from '@/helpers/alert';
+import { convertRawAmountToDecimalFormat, fromWei, isZero } from '@/helpers/utilities';
+import * as i18n from '@/languages';
+import Navigation from '@/navigation/Navigation';
+import Routes from '@/navigation/routesNames';
+import { parseAssetNative } from '@/parsers/accounts';
+import store from '@/redux/store';
+import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
+import { ChainId } from '@/state/backendNetworks/types';
+import ethereumUtils from '@/utils/ethereumUtils';
+
+export async function startSendFromEthereumUrl(data: string) {
+  let ethUrl;
+  try {
+    ethUrl = parse(data);
+  } catch (e) {
+    Alert.alert(i18n.t(i18n.l.wallet.alerts.invalid_ethereum_url));
+    return;
+  }
+
+  const functionName = ethUrl.function_name;
+  let asset = null;
+  const chainId = (ethUrl.chain_id as ChainId) || ChainId.mainnet;
+  const network = useBackendNetworksStore.getState().getChainsName()[chainId];
+  let address: any = null;
+  let nativeAmount: any = null;
+  const { nativeCurrency } = store.getState().settings;
+
+  if (!functionName) {
+    // Send native asset
+    const chainId = useBackendNetworksStore.getState().getChainsIdByName()[network];
+    asset = ethereumUtils.getNetworkNativeAsset({ chainId });
+
+    if (!asset || isZero(asset?.balance?.amount ?? '0')) {
+      Alert.alert(i18n.t(i18n.l.wallet.alerts.ooops), i18n.t(i18n.l.wallet.alerts.dont_have_asset_in_wallet));
+      return;
+    }
+    address = ethUrl.target_address;
+    nativeAmount = ethUrl.parameters?.value && fromWei(ethUrl.parameters.value);
+  } else if (functionName === 'transfer') {
+    // Send ERC-20
+    const targetUniqueId = ethereumUtils.getUniqueId(ethUrl.target_address, chainId);
+    asset = ethereumUtils.getAccountAsset(targetUniqueId);
+    if (!asset || isZero(asset?.balance?.amount ?? '0')) {
+      Alert.alert(i18n.t(i18n.l.wallet.alerts.ooops), i18n.t(i18n.l.wallet.alerts.dont_have_asset_in_wallet));
+      return;
+    }
+    address = ethUrl.parameters?.address;
+    nativeAmount = ethUrl.parameters?.uint256 && convertRawAmountToDecimalFormat(ethUrl.parameters.uint256, asset.decimals);
+  } else {
+    Alert.alert(i18n.t(i18n.l.wallet.alerts.this_action_not_supported));
+    return;
+  }
+
+  const assetWithPrice = parseAssetNative(asset, nativeCurrency);
+
+  InteractionManager.runAfterInteractions(() => {
+    const params = { address, asset: assetWithPrice, nativeAmount };
+    if (Platform.OS === 'ios') {
+      Navigation.handleAction(Routes.SEND_FLOW, {
+        params,
+        screen: Routes.SEND_SHEET,
+      });
+    } else {
+      Navigation.handleAction(Routes.SEND_FLOW, params);
+    }
+  });
+}

--- a/src/handlers/deeplinks.ts
+++ b/src/handlers/deeplinks.ts
@@ -12,6 +12,7 @@ import { analytics } from '@/analytics';
 import { showWalletConnectToast } from '@/components/toasts/WalletConnectToast';
 import { FiatProviderName } from '@/entities/f2c';
 import { GasSpeed } from '@/features/gas/types/gasSpeed';
+import { startSendFromEthereumUrl } from '@/features/transfer/utils/startSendFromEthereumUrl';
 import { pair as pairWalletConnect, setHasPendingDeeplinkPendingRedirect } from '@/features/wallet-connect/services/pair';
 import { checkIsValidAddressOrDomain, isENSAddressFormat } from '@/helpers/validators';
 import { logger } from '@/logger';
@@ -24,7 +25,7 @@ import { userAssetsStore } from '@/state/assets/userAssets';
 import { useBackendNetworksStore } from '@/state/backendNetworks/backendNetworks';
 import { getWalletReady, getWallets, setSelectedWallet } from '@/state/wallets/walletsStore';
 import { delay } from '@/utils/delay';
-import ethereumUtils, { getAddressAndChainIdFromUniqueId, getUniqueId } from '@/utils/ethereumUtils';
+import { getAddressAndChainIdFromUniqueId, getUniqueId } from '@/utils/ethereumUtils';
 import { getPoapAndOpenSheetWithQRHash, getPoapAndOpenSheetWithSecretWord } from '@/utils/poaps';
 import { fetchReverseRecordWithRetry } from '@/utils/profileUtils';
 
@@ -68,7 +69,7 @@ export default async function handleDeeplink({ url, initialRoute, handleRequestU
      * Handling send deep links
      */
     logger.debug(`[handleDeeplink]: ethereum:// protocol`);
-    ethereumUtils.parseEthereumUrl(url);
+    startSendFromEthereumUrl(url);
   } else if (protocol === 'https:' || protocol === 'rainbow:') {
     /**
      * Any native iOS deep link OR universal links via HTTPS

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -8,6 +8,7 @@ import { triggerHaptics } from 'react-native-turbo-haptics';
 import URL from 'url-parse';
 
 import { analytics } from '@/analytics';
+import { startSendFromEthereumUrl } from '@/features/transfer/utils/startSendFromEthereumUrl';
 import { pair as pairWalletConnect } from '@/features/wallet-connect/services/pair';
 import { checkIsValidAddressOrDomain, isENSAddressFormat } from '@/helpers/validators';
 import * as i18n from '@/languages';
@@ -16,7 +17,6 @@ import Routes from '@/navigation/routesNames';
 import { checkPushNotificationPermissions } from '@/notifications/permissions';
 import { POAP_BASE_URL, RAINBOW_PROFILES_BASE_URL } from '@/references/constants';
 import addressUtils from '@/utils/address';
-import ethereumUtils from '@/utils/ethereumUtils';
 import { getPoapAndOpenSheetWithQRHash, getPoapAndOpenSheetWithSecretWord } from '@/utils/poaps';
 import { fetchReverseRecordWithRetry } from '@/utils/profileUtils';
 
@@ -48,7 +48,7 @@ export default function useScanner(enabled: boolean, onSuccess: () => unknown) {
   }, [enabled, disableScanning, enableScanning]);
 
   const handleScanEthereumUrl = useCallback((data: string) => {
-    ethereumUtils.parseEthereumUrl(data);
+    startSendFromEthereumUrl(data);
   }, []);
 
   const handleScanAddress = useCallback(

--- a/src/utils/__mocks__/ethereumUtils.ts
+++ b/src/utils/__mocks__/ethereumUtils.ts
@@ -25,6 +25,5 @@ export default {
   openTokenEtherscanURL: jest.fn(),
   openTransactionInBlockExplorer: jest.fn(),
   padLeft: jest.fn(),
-  parseEthereumUrl: jest.fn(),
   removeHexPrefix: jest.fn(),
 };

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -1,12 +1,8 @@
-import { InteractionManager, Platform } from 'react-native';
-
 import { type BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { type StaticJsonRpcProvider, type TransactionRequest } from '@ethersproject/providers';
 import { serialize } from '@ethersproject/transactions';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'eth-... Remove this comment to see the full error message
-import { parse } from 'eth-url-parser';
 import { addHexPrefix, isValidAddress, toChecksumAddress } from 'ethereumjs-util';
 import { cloneDeep, isEmpty, isString, replace } from 'lodash';
 import { ETHERSCAN_API_KEY } from 'react-native-dotenv';
@@ -18,13 +14,8 @@ import { type EthereumAddress } from '@/entities/wallet';
 import { type GasFee, type LegacySelectedGasFee, type SelectedGasFee } from '@/features/gas/types/gas';
 import { getOnchainAssetBalance } from '@/handlers/assets';
 import { getProvider, isTestnetChain, toHex } from '@/handlers/web3';
-import { WrappedAlert as Alert } from '@/helpers/alert';
-import { add, convertRawAmountToDecimalFormat, fromWei, greaterThan, isZero, subtract } from '@/helpers/utilities';
-import * as i18n from '@/languages';
+import { add, fromWei, greaterThan, isZero, subtract } from '@/helpers/utilities';
 import { logger, RainbowError } from '@/logger';
-import Navigation from '@/navigation/Navigation';
-import Routes from '@/navigation/routesNames';
-import { parseAssetNative } from '@/parsers/accounts';
 import { queryClient } from '@/react-query';
 import store from '@/redux/store';
 import { ETH_ADDRESS, OVM_GAS_PRICE_ORACLE } from '@/references/constants';
@@ -411,64 +402,6 @@ function openTransactionInBlockExplorer({ hash, chainId }: { hash: string; chain
   if (url) openInBrowser(url);
 }
 
-async function parseEthereumUrl(data: string) {
-  let ethUrl;
-  try {
-    ethUrl = parse(data);
-  } catch (e) {
-    Alert.alert(i18n.t(i18n.l.wallet.alerts.invalid_ethereum_url));
-    return;
-  }
-
-  const functionName = ethUrl.function_name;
-  let asset = null;
-  const chainId = (ethUrl.chain_id as ChainId) || ChainId.mainnet;
-  const network = useBackendNetworksStore.getState().getChainsName()[chainId];
-  let address: any = null;
-  let nativeAmount: any = null;
-  const { nativeCurrency } = store.getState().settings;
-
-  if (!functionName) {
-    // Send native asset
-    const chainId = useBackendNetworksStore.getState().getChainsIdByName()[network];
-    asset = getNetworkNativeAsset({ chainId });
-
-    if (!asset || isZero(asset?.balance?.amount ?? '0')) {
-      Alert.alert(i18n.t(i18n.l.wallet.alerts.ooops), i18n.t(i18n.l.wallet.alerts.dont_have_asset_in_wallet));
-      return;
-    }
-    address = ethUrl.target_address;
-    nativeAmount = ethUrl.parameters?.value && fromWei(ethUrl.parameters.value);
-  } else if (functionName === 'transfer') {
-    // Send ERC-20
-    const targetUniqueId = getUniqueId(ethUrl.target_address, chainId);
-    asset = getAccountAsset(targetUniqueId);
-    if (!asset || isZero(asset?.balance?.amount ?? '0')) {
-      Alert.alert(i18n.t(i18n.l.wallet.alerts.ooops), i18n.t(i18n.l.wallet.alerts.dont_have_asset_in_wallet));
-      return;
-    }
-    address = ethUrl.parameters?.address;
-    nativeAmount = ethUrl.parameters?.uint256 && convertRawAmountToDecimalFormat(ethUrl.parameters.uint256, asset.decimals);
-  } else {
-    Alert.alert(i18n.t(i18n.l.wallet.alerts.this_action_not_supported));
-    return;
-  }
-
-  const assetWithPrice = parseAssetNative(asset, nativeCurrency);
-
-  InteractionManager.runAfterInteractions(() => {
-    const params = { address, asset: assetWithPrice, nativeAmount };
-    if (Platform.OS === 'ios') {
-      Navigation.handleAction(Routes.SEND_FLOW, {
-        params,
-        screen: Routes.SEND_SHEET,
-      });
-    } else {
-      Navigation.handleAction(Routes.SEND_FLOW, params);
-    }
-  });
-}
-
 const calculateL1FeeOptimism = async (
   tx: RainbowTransaction | TransactionRequest,
   provider: StaticJsonRpcProvider
@@ -545,6 +478,5 @@ export default {
   openTokenEtherscanURL,
   openTransactionInBlockExplorer,
   padLeft,
-  parseEthereumUrl,
   removeHexPrefix,
 };


### PR DESCRIPTION
The send flow can be launched from an `ethereum:` payment URI (a QR scan or a deeplink), but the function that does so currently lives in the shared `ethereumUtils` grab-bag. Its name, `parseEthereumUrl`, reads like generic URL parsing, but the actual parsing is the `eth-url-parser` package; what this code adds is transfer-specific: resolve the referenced asset, then launch the send flow prefilled with recipient and amount. It only handles native and ERC-20 transfers and rejects everything else.

This change moves it into the transfer domain and renames it to `startSendFromEthereumUrl`, so the name states the effect (it starts the send flow) rather than implying a pure parser.