### PR TITLE
fix(predictions): consistent league slug grouping and filtering

### DIFF
--- a/src/features/polymarket/leagues.test.ts
+++ b/src/features/polymarket/leagues.test.ts
@@ -1,0 +1,46 @@
+import { getGammaLeagueId, getLeagueId } from './leagues';
+
+describe('Polymarket league ids', () => {
+  describe('getLeagueId', () => {
+    it.each([
+      ['nba-lal-bos-2026-01-01', 'nba'],
+      ['mlb-bos-nyy-2026-06-06', 'mlb'],
+      ['epl-ars-che-2026-06-11', 'epl'],
+      ['atp-zhou-kotov-2026-04-12', 'atp'],
+      ['dota2-tundra-lgd-2026-05-29', 'dota2'],
+    ])('parses %s as %s', (slug, leagueId) => {
+      expect(getLeagueId(slug)).toBe(leagueId);
+    });
+
+    it('places World Cup events under fifa', () => {
+      expect(getLeagueId('fifwc-kr-cze-2026-06-11')).toBe('fifa');
+    });
+  });
+
+  describe('getGammaLeagueId', () => {
+    it.each([
+      ['fifwc-kr-cze-2026-06-11', 'fifwc'],
+      ['nba-lal-bos-2026-01-01', 'nba'],
+      ['mlb-bos-nyy-2026-06-06', 'mlb'],
+      ['epl-ars-che-2026-06-11', 'epl'],
+      ['atp-zhou-kotov-2026-04-12', 'atp'],
+      ['dota2-tundra-lgd-2026-05-29', 'dota2'],
+    ])('uses the event slug prefix for team metadata: %s', (slug, leagueId) => {
+      expect(getGammaLeagueId(slug)).toBe(leagueId);
+    });
+
+    it.each([
+      ['ufc-jon-jones-next-fight', 'mma'],
+      ['cs2-arc-red-venom-map-2', 'csgo'],
+      ['val-sen-g2-2026-06-11', 'valorant'],
+      ['lol-t1-geng-2026-06-11', 'league-of-legends'],
+      ['sc2-maru-serral-2026-06-11', 'starcraft2'],
+    ])('uses configured team metadata league for %s', (slug, leagueId) => {
+      expect(getGammaLeagueId(slug)).toBe(leagueId);
+    });
+
+    it('passes through unknown event slug prefixes', () => {
+      expect(getGammaLeagueId('newleague-team-a-team-b')).toBe('newleague');
+    });
+  });
+});

--- a/src/features/polymarket/leagues.ts
+++ b/src/features/polymarket/leagues.ts
@@ -982,10 +982,11 @@ export function getLeague(value: string): League | undefined {
 export function getGammaLeagueId(value: string): string | undefined {
   const slugId = getLeagueSlugId(value);
   if (!slugId) return undefined;
-  const leagueId = getLeagueId(value);
-  if (leagueId) {
-    const league = SPORT_LEAGUES[leagueId];
-    return 'gammaLeagueId' in league ? league.gammaLeagueId : leagueId;
-  }
-  return slugId;
+
+  // Preserve the event prefix for fetchTeamsForEvent; `fifwc` groups as `fifa`
+  // but Gamma team lookup expects `fifwc`.
+  if (!isLeagueId(slugId)) return slugId;
+
+  const league = SPORT_LEAGUES[slugId];
+  return 'gammaLeagueId' in league ? league.gammaLeagueId : slugId;
 }

--- a/src/features/polymarket/stores/polymarketSportsEventsStore.test.ts
+++ b/src/features/polymarket/stores/polymarketSportsEventsStore.test.ts
@@ -1,0 +1,126 @@
+import { fetchPolymarketTeamMetadataForGameEvents } from '@/features/polymarket/stores/polymarketTeamMetadataStore';
+import { type PolymarketEvent, type RawPolymarketEvent } from '@/features/polymarket/types/polymarket-event';
+import { processRawPolymarketEvent } from '@/features/polymarket/utils/transforms';
+import { rainbowFetch } from '@/framework/data/http/rainbowFetch';
+
+import { fetchPolymarketSportsEvents } from './polymarketSportsEventsStore';
+
+jest.mock('@/config/experimental', () => ({
+  POLYMARKET: 'polymarket',
+}));
+
+jest.mock('@/config/experimentalConfigStore', () => ({
+  useExperimentalConfigStore: mockStore({
+    getFlag: jest.fn(() => false),
+  }),
+}));
+
+jest.mock('@/features/polymarket/constants', () => ({
+  DEFAULT_SPORTS_LEAGUE_KEY: 'all',
+  POLYMARKET_GAMMA_API_URL: 'https://gamma-api.polymarket.com',
+  POLYMARKET_SPORTS_MARKET_TYPE: {
+    MONEYLINE: 'moneyline',
+  },
+}));
+
+jest.mock('@/features/polymarket/stores/polymarketTeamMetadataStore', () => ({
+  fetchPolymarketTeamMetadataForGameEvents: jest.fn(),
+}));
+
+jest.mock('@/features/polymarket/utils/transforms', () => ({
+  processRawPolymarketEvent: jest.fn(),
+}));
+
+jest.mock('@/framework/data/http/rainbowFetch', () => ({
+  rainbowFetch: jest.fn(),
+}));
+
+jest.mock('@/model/remoteConfig', () => ({
+  useRemoteConfigStore: mockStore({
+    getRemoteConfigKey: jest.fn(() => false),
+  }),
+}));
+
+function mockStore<T>(state: T) {
+  return Object.assign(jest.fn(), {
+    getState: jest.fn(() => state),
+    subscribe: jest.fn(() => jest.fn()),
+  });
+}
+
+const mockFetchPolymarketTeamMetadataForGameEvents = fetchPolymarketTeamMetadataForGameEvents as jest.MockedFunction<
+  typeof fetchPolymarketTeamMetadataForGameEvents
+>;
+const mockProcessRawPolymarketEvent = processRawPolymarketEvent as jest.MockedFunction<typeof processRawPolymarketEvent>;
+const mockRainbowFetch = rainbowFetch as jest.MockedFunction<typeof rainbowFetch>;
+
+type EventOptions = {
+  id: string;
+  ended?: boolean;
+  gameId?: number | null;
+  startTime?: string;
+  sportsMarketType?: string;
+  umaResolutionStatus?: string;
+};
+
+function makeEvent({
+  id,
+  ended = false,
+  gameId = 1,
+  startTime = '2026-06-15T20:00:00Z',
+  sportsMarketType = 'moneyline',
+  umaResolutionStatus,
+}: EventOptions): RawPolymarketEvent {
+  return {
+    id,
+    ended,
+    endDate: startTime,
+    gameId,
+    markets: [
+      {
+        active: true,
+        closed: false,
+        clobTokenIds: JSON.stringify(['token-a', 'token-b']),
+        sportsMarketType,
+        umaResolutionStatus,
+      },
+    ],
+    startTime,
+    ticker: id,
+  } as RawPolymarketEvent;
+}
+
+describe('fetchPolymarketSportsEvents', () => {
+  beforeEach(() => {
+    mockRainbowFetch.mockResolvedValue({
+      data: [],
+      headers: new Headers(),
+      status: 200,
+    });
+    mockFetchPolymarketTeamMetadataForGameEvents.mockResolvedValue(new Map());
+    mockProcessRawPolymarketEvent.mockImplementation(async event => ({ id: event.id }) as PolymarketEvent);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the primary game event and drops companion, derivative, and resolved events', async () => {
+    const primaryGameEvent = makeEvent({ id: 'primary-game-event' });
+    const moreMarketsCompanion = makeEvent({ id: 'more-markets-companion', gameId: null, sportsMarketType: 'spreads' });
+    const halftimeDerivative = makeEvent({ id: 'halftime-derivative', sportsMarketType: 'soccer_halftime_result' });
+    const resolvedGameEvent = makeEvent({ id: 'resolved-game-event', umaResolutionStatus: 'resolved' });
+
+    mockRainbowFetch.mockResolvedValueOnce({
+      data: [moreMarketsCompanion, primaryGameEvent, halftimeDerivative, resolvedGameEvent],
+      headers: new Headers(),
+      status: 200,
+    });
+
+    const events = await fetchPolymarketSportsEvents(undefined as never, null);
+
+    expect(mockFetchPolymarketTeamMetadataForGameEvents).toHaveBeenCalledWith([primaryGameEvent], null);
+    expect(mockProcessRawPolymarketEvent).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ id: 'primary-game-event' }]);
+  });
+});

--- a/src/features/polymarket/stores/polymarketSportsEventsStore.test.ts
+++ b/src/features/polymarket/stores/polymarketSportsEventsStore.test.ts
@@ -56,25 +56,30 @@ const mockRainbowFetch = rainbowFetch as jest.MockedFunction<typeof rainbowFetch
 
 type EventOptions = {
   id: string;
+  endDate?: string;
   ended?: boolean;
   gameId?: number | null;
-  startTime?: string;
+  startTime?: string | null;
   sportsMarketType?: string;
   umaResolutionStatus?: string;
 };
 
 function makeEvent({
   id,
+  endDate,
   ended = false,
   gameId = 1,
-  startTime = '2026-06-15T20:00:00Z',
+  startTime,
   sportsMarketType = 'moneyline',
   umaResolutionStatus,
 }: EventOptions): RawPolymarketEvent {
+  const eventStartTime = startTime === undefined ? '2026-06-15T20:00:00Z' : startTime;
+  const eventEndDate = endDate ?? eventStartTime ?? '2026-06-15T20:00:00Z';
+
   return {
     id,
     ended,
-    endDate: startTime,
+    endDate: eventEndDate,
     gameId,
     markets: [
       {
@@ -85,13 +90,16 @@ function makeEvent({
         umaResolutionStatus,
       },
     ],
-    startTime,
+    startTime: eventStartTime ?? undefined,
     ticker: id,
   } as RawPolymarketEvent;
 }
 
 describe('fetchPolymarketSportsEvents', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+
     mockRainbowFetch.mockResolvedValue({
       data: [],
       headers: new Headers(),
@@ -102,6 +110,7 @@ describe('fetchPolymarketSportsEvents', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
@@ -122,5 +131,48 @@ describe('fetchPolymarketSportsEvents', () => {
     expect(mockFetchPolymarketTeamMetadataForGameEvents).toHaveBeenCalledWith([primaryGameEvent], null);
     expect(mockProcessRawPolymarketEvent).toHaveBeenCalledTimes(1);
     expect(events).toEqual([{ id: 'primary-game-event' }]);
+  });
+
+  it('keeps same-day finals and drops finals from previous days', async () => {
+    const sameDayFinal = makeEvent({ id: 'same-day-final', ended: true, startTime: '2026-06-15T10:00:00Z' });
+    const oldFinal = makeEvent({ id: 'old-final', ended: true, startTime: '2026-06-14T10:00:00Z' });
+
+    mockRainbowFetch.mockResolvedValueOnce({
+      data: [oldFinal, sameDayFinal],
+      headers: new Headers(),
+      status: 200,
+    });
+
+    const events = await fetchPolymarketSportsEvents(undefined as never, null);
+
+    expect(mockFetchPolymarketTeamMetadataForGameEvents).toHaveBeenCalledWith([sameDayFinal], null);
+    expect(mockProcessRawPolymarketEvent).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ id: 'same-day-final' }]);
+  });
+
+  it('keeps same-day finals when Gamma omits startTime but sends endDate', async () => {
+    const sameDayFinalWithoutStartTime = makeEvent({
+      id: 'same-day-final-without-start-time',
+      ended: true,
+      startTime: null,
+      endDate: '2026-06-15T10:00:00Z',
+    });
+    const oldFinalWithoutStartTime = makeEvent({
+      id: 'old-final-without-start-time',
+      ended: true,
+      startTime: null,
+      endDate: '2026-06-14T10:00:00Z',
+    });
+
+    mockRainbowFetch.mockResolvedValueOnce({
+      data: [oldFinalWithoutStartTime, sameDayFinalWithoutStartTime],
+      headers: new Headers(),
+      status: 200,
+    });
+
+    const events = await fetchPolymarketSportsEvents(undefined as never, null);
+
+    expect(mockFetchPolymarketTeamMetadataForGameEvents).toHaveBeenCalledWith([sameDayFinalWithoutStartTime], null);
+    expect(events).toEqual([{ id: 'same-day-final-without-start-time' }]);
   });
 });

--- a/src/features/polymarket/stores/polymarketSportsEventsStore.ts
+++ b/src/features/polymarket/stores/polymarketSportsEventsStore.ts
@@ -5,7 +5,7 @@ import { DEFAULT_SPORTS_LEAGUE_KEY, POLYMARKET_GAMMA_API_URL, POLYMARKET_SPORTS_
 import { type LeagueId } from '@/features/polymarket/leagues';
 import { fetchPolymarketTeamMetadataForGameEvents } from '@/features/polymarket/stores/polymarketTeamMetadataStore';
 import { type PolymarketEvent, type RawPolymarketEvent } from '@/features/polymarket/types/polymarket-event';
-import { getSportsEventsStartTimeRange } from '@/features/polymarket/utils/getSportsEventsDateRange';
+import { getSportsEventsDayBoundaries, getSportsEventsStartTimeRange } from '@/features/polymarket/utils/getSportsEventsDateRange';
 import { processRawPolymarketEvent } from '@/features/polymarket/utils/transforms';
 import { time } from '@/framework/core/utils/time';
 import { rainbowFetch } from '@/framework/data/http/rainbowFetch';
@@ -52,6 +52,7 @@ export function prefetchPolymarketSportsEvents() {
 
 export async function fetchPolymarketSportsEvents(_: never, abortController: AbortController | null): Promise<PolymarketEvent[]> {
   const { minStartTime, maxStartTime } = getSportsEventsStartTimeRange();
+  const { startOfToday, startOfTomorrow } = getSportsEventsDayBoundaries();
   const url = new URL(`${POLYMARKET_GAMMA_API_URL}/events`);
   url.searchParams.set('limit', '500');
   url.searchParams.set('tag_slug', 'games');
@@ -70,7 +71,7 @@ export async function fetchPolymarketSportsEvents(_: never, abortController: Abo
   });
 
   const filteredEvents = events.filter(event => {
-    if (event.ended === true || event.gameId == null) return false;
+    if (event.gameId == null) return false;
 
     const hasActiveMoneylineMarket = event.markets.some(
       market =>
@@ -79,7 +80,11 @@ export async function fetchPolymarketSportsEvents(_: never, abortController: Abo
         market.umaResolutionStatus !== 'resolved' &&
         market.sportsMarketType === POLYMARKET_SPORTS_MARKET_TYPE.MONEYLINE
     );
-    return hasActiveMoneylineMarket;
+    if (!hasActiveMoneylineMarket) return false;
+    if (event.ended !== true) return true;
+
+    const timestamp = new Date(event.startTime || event.endDate).getTime();
+    return timestamp >= startOfToday.getTime() && timestamp < startOfTomorrow.getTime();
   });
 
   const teamsByTicker = await fetchPolymarketTeamMetadataForGameEvents(filteredEvents, abortController);

--- a/src/features/polymarket/stores/polymarketSportsEventsStore.ts
+++ b/src/features/polymarket/stores/polymarketSportsEventsStore.ts
@@ -1,7 +1,7 @@
 import { POLYMARKET } from '@/config/experimental';
 import { useExperimentalConfigStore } from '@/config/experimentalConfigStore';
 import { IS_TEST } from '@/env';
-import { DEFAULT_SPORTS_LEAGUE_KEY, POLYMARKET_GAMMA_API_URL } from '@/features/polymarket/constants';
+import { DEFAULT_SPORTS_LEAGUE_KEY, POLYMARKET_GAMMA_API_URL, POLYMARKET_SPORTS_MARKET_TYPE } from '@/features/polymarket/constants';
 import { type LeagueId } from '@/features/polymarket/leagues';
 import { fetchPolymarketTeamMetadataForGameEvents } from '@/features/polymarket/stores/polymarketTeamMetadataStore';
 import { type PolymarketEvent, type RawPolymarketEvent } from '@/features/polymarket/types/polymarket-event';
@@ -50,7 +50,7 @@ export function prefetchPolymarketSportsEvents() {
   usePolymarketSportsEventsStore.getState().fetch();
 }
 
-async function fetchPolymarketSportsEvents(_: never, abortController: AbortController | null): Promise<PolymarketEvent[]> {
+export async function fetchPolymarketSportsEvents(_: never, abortController: AbortController | null): Promise<PolymarketEvent[]> {
   const { minStartTime, maxStartTime } = getSportsEventsStartTimeRange();
   const url = new URL(`${POLYMARKET_GAMMA_API_URL}/events`);
   url.searchParams.set('limit', '500');
@@ -69,7 +69,18 @@ async function fetchPolymarketSportsEvents(_: never, abortController: AbortContr
     timeout: time.seconds(30),
   });
 
-  const filteredEvents = events.filter(event => event.ended !== true && event.gameId != null);
+  const filteredEvents = events.filter(event => {
+    if (event.ended === true || event.gameId == null) return false;
+
+    const hasActiveMoneylineMarket = event.markets.some(
+      market =>
+        market.active !== false &&
+        market.closed !== true &&
+        market.umaResolutionStatus !== 'resolved' &&
+        market.sportsMarketType === POLYMARKET_SPORTS_MARKET_TYPE.MONEYLINE
+    );
+    return hasActiveMoneylineMarket;
+  });
 
   const teamsByTicker = await fetchPolymarketTeamMetadataForGameEvents(filteredEvents, abortController);
 


### PR DESCRIPTION
Fixes APP-3803, APP-3869.

## What changed

### Use the event slug for team metadata lookup

World Cup events still group under FIFA for league display, but team metadata lookup now uses the original Polymarket event slug prefix.

This fixes cards where the odds rendered, but the matchup itself was blank. For example, Korea Republic vs Czechia showed prediction percentages, while the team names and flags were missing.

This happened when:
- the event slug started with `fifwc`
- the team lookup queried the grouped `fifa` team pool
- the teams existed in Gamma under `fifwc`, not `fifa`

### Filter sports feeds to primary moneyline game events

Sports event filtering now requires both a `gameId` and an active moneyline market before rendering an event as a game card.

This fixes duplicate and incomplete sports cards. For example, the same matchup could appear twice: one card with normal prediction prices, and another sparse card with missing or irrelevant markets. Tapping the sparse card could open an incomplete event detail screen.

This happened when:
- Gamma returned multiple events for the same game
- companion or derivative events included spreads, totals, props, halftime markets, or `more-markets`
- those non-primary events still passed the old `gameId` filter

### Keep same-day ended sports events

Ended events are no longer removed immediately when their event time is still within today’s sports window.

This fixes Today sections showing fewer games than expected. A game that finished earlier the same day could disappear from the sports feed even while its moneyline market was still active or unresolved.

This happened when:
- Gamma marked the event as `ended`
- the game was still part of today’s schedule
- the store filtered all ended events before checking market state or day boundaries

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://subtle-fresco-8644.here.now/before-discover-world-cup.png" width="280" /> | <img src="https://subtle-fresco-8644.here.now/after-discover-world-cup.png" width="280" /> |
| <img src="https://subtle-fresco-8644.here.now/before-sports-fifa.png" width="280" /> | <img src="https://subtle-fresco-8644.here.now/after-sports-fifa.png" width="280" /> |

## What to test

- World Cup cards like Korea Republic vs Czechia show team names, flags, and prices.
- Predictions → Sports → All does not show companion, halftime, spreads, totals, or prop-only events as full game cards.
- Same-day completed games can still appear, while older ended games are removed.
