### PR TITLE
fix(ios): use the project-pinned Node version in Xcode builds

### DIFF
--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -9,25 +9,35 @@
 # that does NOT load your shell rc files, so version managers (mise/nvm) aren't
 # auto-activated and a bare `command -v node` can resolve to the wrong Node
 # (e.g. a Homebrew install) or none at all. We probe known version managers
-# first, then fall back to whatever `node` is on PATH for e.g CI where NODE is
+# first, then fall back to whatever `node` is on PATH, e.g. in CI where node is
 # usually on the path.
 
 __resolve_node_binary() {
   local mise_bin resolved nvm_sh
 
-  # 1) mise -- reads .node-version/.nvmrc/mise.toml based on the working dir.
-  # Probe an absolute path too, since mise is often not on Xcode's stripped PATH.
+  # 1) mise -- resolves Node from the repo's mise config (mise.toml/.tool-versions),
+  # or from .node-version/.nvmrc only when idiomatic version files are enabled.
+  # Probe absolute paths too, since mise is often not on Xcode's stripped PATH:
+  # the official curl installer lands in ~/.local/bin, Homebrew in /opt/homebrew
+  # (Apple Silicon) or /usr/local (Intel).
   for mise_bin in \
     "$(command -v mise 2>/dev/null)" \
-    /opt/homebrew/bin/mise; do
+    "$HOME/.local/bin/mise" \
+    /opt/homebrew/bin/mise \
+    /usr/local/bin/mise; do
     if [ -n "$mise_bin" ] && [ -x "$mise_bin" ]; then
       resolved="$("$mise_bin" which node 2>/dev/null)"
       [ -n "$resolved" ] && [ -x "$resolved" ] && { echo "$resolved"; return 0; }
     fi
   done
 
-  # 2) nvm -- source it and honor .nvmrc when present
-  for nvm_sh in "$HOME/.nvm/nvm.sh" "$(brew --prefix nvm 2>/dev/null)/nvm.sh"; do
+  # 2) nvm -- source it and honor .nvmrc when present. Probe absolute Homebrew
+  # paths too, since `brew` itself may not be on Xcode's stripped PATH.
+  for nvm_sh in \
+    "$HOME/.nvm/nvm.sh" \
+    /opt/homebrew/opt/nvm/nvm.sh \
+    /usr/local/opt/nvm/nvm.sh \
+    "$(brew --prefix nvm 2>/dev/null)/nvm.sh"; do
     if [ -s "$nvm_sh" ]; then
       . "$nvm_sh" --no-use
       nvm use >/dev/null 2>&1 || nvm use default >/dev/null 2>&1
@@ -35,8 +45,10 @@ __resolve_node_binary() {
     fi
   done
 
-  # 3) fall back to whatever Node is on PATH (correct in CI and plain installs)
-  command -v node 2>/dev/null
+  # 3) fall back to whatever Node is on PATH (correct in CI and plain installs).
+  # `|| true` keeps an empty result from aborting `set -e` consumers (e.g.
+  # expo-configure-project.sh) before they reach their own node-not-found path.
+  command -v node 2>/dev/null || true
 }
 
 NODE_BINARY="$(__resolve_node_binary)"

--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -1,17 +1,44 @@
-# This `.xcode.env` file is versioned and is used to source the environment
-# used when running script phases inside Xcode.
-# To customize your local environment, you can create an `.xcode.env.local`
-# file that is not versioned.
-
-# NODE_BINARY variable contains the PATH to the node executable.
+# This `.xcode.env` file is versioned and sources the environment used when
+# running script phases inside Xcode. For local-only overrides, create an
+# `.xcode.env.local` (gitignored) -- it is sourced after this file and wins.
 #
-# Customize the NODE_BINARY variable here.
-# For example, to use nvm with brew, add the following line
-# . "$(brew --prefix nvm)/nvm.sh" --no-use
-# Fix for machines using nvm
-if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
-. "$HOME/.nvm/nvm.sh"
-elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
-. "$(brew --prefix nvm)/nvm.sh"
-fi
-export NODE_BINARY=$(command -v node)
+# NODE_BINARY must point at the Node version this project pins (.node-version /
+# .nvmrc) so Xcode GUI builds use the same Node as the CLI and CI.
+#
+# Why this logic exists: Xcode runs build phases in a minimal, non-login shell
+# that does NOT load your shell rc files, so version managers (mise/nvm) aren't
+# auto-activated and a bare `command -v node` can resolve to the wrong Node
+# (e.g. a Homebrew install) or none at all. We probe known version managers
+# first, then fall back to whatever `node` is on PATH for e.g CI where NODE is
+# usually on the path.
+
+__resolve_node_binary() {
+  local mise_bin resolved nvm_sh
+
+  # 1) mise -- reads .node-version/.nvmrc/mise.toml based on the working dir.
+  # Probe an absolute path too, since mise is often not on Xcode's stripped PATH.
+  for mise_bin in \
+    "$(command -v mise 2>/dev/null)" \
+    /opt/homebrew/bin/mise; do
+    if [ -n "$mise_bin" ] && [ -x "$mise_bin" ]; then
+      resolved="$("$mise_bin" which node 2>/dev/null)"
+      [ -n "$resolved" ] && [ -x "$resolved" ] && { echo "$resolved"; return 0; }
+    fi
+  done
+
+  # 2) nvm -- source it and honor .nvmrc when present
+  for nvm_sh in "$HOME/.nvm/nvm.sh" "$(brew --prefix nvm 2>/dev/null)/nvm.sh"; do
+    if [ -s "$nvm_sh" ]; then
+      . "$nvm_sh" --no-use
+      nvm use >/dev/null 2>&1 || nvm use default >/dev/null 2>&1
+      break
+    fi
+  done
+
+  # 3) fall back to whatever Node is on PATH (correct in CI and plain installs)
+  command -v node 2>/dev/null
+}
+
+NODE_BINARY="$(__resolve_node_binary)"
+export NODE_BINARY
+unset -f __resolve_node_binary


### PR DESCRIPTION
Our committed `.xcode.env` resolves `NODE_BINARY` from `command -v node`, with an nvm fallback. But Xcode runs build phases in a minimal, non-login shell that doesn't load shell rc files, so version managers aren't activated there. For anyone on mise (we only handle nvm today), `command -v node` resolves to whatever Node is on the GUI build's PATH, typically an unrelated Homebrew install, or nothing at all, rather than the version pinned in `.node-version`, thus failing Xcode build locally.

This change makes `.xcode.env` resolve the project-pinned Node directly: it asks mise, then nvm (both read `.node-version`/`.nvmrc`), and falls back to `command -v node` for CI and plain installs.