### PR TITLE
fix: filter remaining benign Branch noise from Sentry

### DIFF
--- a/src/utils/branch.ts
+++ b/src/utils/branch.ts
@@ -18,9 +18,13 @@ export const branchListener = async (handleOpenLinkingURL: (url: string) => void
    */
   const unsubscribe = branch.subscribe(({ error, params, uri }) => {
     if (error) {
-      const isNetworkNoise = error.includes('poor network connectivity') || error.includes('Trouble reaching the Branch servers');
-      if (isNetworkNoise) {
-        logger.debug(`[branchListener]: network noise`, { error }, logger.DebugContext.deeplinks);
+      const isNoise =
+        error.includes('poor network connectivity') ||
+        error.includes('Trouble reaching the Branch servers') ||
+        error.includes('Request to Branch server timed out') || // init timeout
+        error.includes('Session initialization already happened'); // benign re-foreground re-init
+      if (isNoise) {
+        logger.debug(`[branchListener]: error (noise)`, { error }, logger.DebugContext.deeplinks);
       } else {
         logger.warn(`[branchListener]: error when handling event`, { error });
       }


### PR DESCRIPTION
After #7509 (May 2026) we downgraded `branchListener` failures from `logger.error` to `logger.warn` and filtered the known network-noise strings down to debug. The `error` channel on `branch.subscribe` is Branch's catch-all for any non-fatal condition though, and it carries other equally unactionable messages the filter doesn't match. Two stable ones still surface as warning-level events in Sentry: 

* the Branch init timeout, and 
* the benign "session initialization already happened" notice Branch emits when `subscribe` re-runs on app re-foreground

Neither is something we can act on, and together they keep [RAINBOW-WALLET-3ZP9](https://rainbow-me.sentry.io/issues/RAINBOW-WALLET-3ZP9) (~6.3k events / 1.7k users since late May) alive.

This change extends the noise filter to match those two phrases as well, so they log at debug (breadcrumb only, no Sentry capture) like the existing network noise. Anything not on the list still goes through `logger.warn`, so we keep a tripwire for genuinely unexpected Branch errors. As with the previous fix, this only takes effect on builds from the next release onward, so the issue should taper rather than drop immediately.