### PR TITLE
fix(discover): remove section count badges

### DIFF
--- a/src/features/discover/components/PredictionsSection.tsx
+++ b/src/features/discover/components/PredictionsSection.tsx
@@ -17,7 +17,7 @@ import {
   PREDICTION_MARKET_TILE_CARD_WIDTH,
   PredictionMarketTileCard,
 } from '@/features/discover/components/markets/cards/PredictionMarketTileCard';
-import { getRenderedHeaderCount, renderSectionLayout } from '@/features/discover/components/SectionLayout';
+import { renderSectionLayout } from '@/features/discover/components/SectionLayout';
 import {
   type CardPressHandler,
   type OrderPressHandler,
@@ -257,16 +257,12 @@ function SportsEventPlacementSection({
 
   usePredictionTokenSubscription({ display: surface.display, items: result.items, limit: surface.limit });
 
-  // Header count comes from the curated placement items the layout actually renders (list shows
-  // the expandable full count; carousel/grid cap at surface.limit), not the live sports store.
-  const headerCount = getRenderedHeaderCount({ descriptor, itemCount: result.items.length, limit: surface.limit });
   const { headerCaret, leadingAccessory } = getSportsHeaderProps(sportsIntent, surface);
 
   return renderSectionLayout({
     data: result.items,
     descriptor,
     headerCaret,
-    headerCount,
     leadingAccessory,
     loading: result.isLoading || isPlacementPending,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).
@@ -295,7 +291,6 @@ function SportsQuerySection({
     return selectedEvents.map(event => ({ id: event.id, event }));
   }, [events, sportsIntent]);
   const descriptor = getSportsEventSectionDescriptor(surface, sportsIntent);
-  const headerCount = getRenderedHeaderCount({ descriptor, itemCount: items.length, limit: surface.limit });
   const predictionsDestination = hasDestinationRoot(surface.destination, 'predictions') ? surface.destination : null;
   const onPressSeeAll = useCallback(() => {
     if (predictionsDestination) navigateDiscoverDestination(predictionsDestination);
@@ -309,7 +304,6 @@ function SportsQuerySection({
     data: items,
     descriptor,
     headerCaret,
-    headerCount,
     leadingAccessory,
     loading: isLoading,
     // Prediction "See All" routes to the CMS destination (predictions -> Polymarket).

--- a/src/features/discover/components/SectionLayout.tsx
+++ b/src/features/discover/components/SectionLayout.tsx
@@ -3,7 +3,7 @@ import { event } from '@/analytics/event';
 import { MarketCarousel } from '@/features/discover/components/markets/layouts/MarketCarousel';
 import { MarketGrid } from '@/features/discover/components/markets/layouts/MarketGrid';
 import { MarketList } from '@/features/discover/components/markets/layouts/MarketList';
-import { type SectionDescriptor, type SectionLayoutProps } from '@/features/discover/types/sectionLayout';
+import { type SectionLayoutProps } from '@/features/discover/types/sectionLayout';
 import { type SurfaceLeaf } from '@/features/placements/surfaces/types';
 import { type PlacementItem } from '@/features/placements/types';
 import * as i18n from '@/languages';
@@ -14,24 +14,6 @@ import * as i18n from '@/languages';
  */
 export function resolveSectionTitle(section: Pick<SurfaceLeaf, 'id' | 'label'>): string {
   return i18n.t(`discover.sections.${section.id}`, { defaultValue: section.label || section.id });
-}
-
-/**
- * Header count that matches what the layout actually renders: list layouts show the full
- * (expandable) item count; carousel/grid cap at `limit` exactly as renderSectionLayout slices.
- * Returns undefined for an empty count so the header omits the badge.
- */
-export function getRenderedHeaderCount<T extends PlacementItem>({
-  descriptor,
-  itemCount,
-  limit,
-}: {
-  descriptor: SectionDescriptor<T>;
-  itemCount: number;
-  limit: number | undefined;
-}): number | undefined {
-  const count = descriptor.layout === 'list' ? itemCount : limit !== undefined ? Math.min(itemCount, limit) : itemCount;
-  return count > 0 ? count : undefined;
 }
 
 export function renderSectionLayout<T extends PlacementItem>({


### PR DESCRIPTION
Fixes APP-3873

## What changed

Removes the prediction market count badge from the Discover section headers (World Cup, Sports, and individual leagues) to resolve the count conflict between the Discover curation and live market filtering in the Polymarket flow.

## Screen recordings / screenshots
<img width="300" alt="World Cup section without count badge" src="https://github.com/user-attachments/assets/c1be45a1-5468-48a9-a0a9-e8503786292c" />

## What to test

- Discover → For You and Sports: section headers (World Cup, Sports, leagues) show the title + caret with no count badge.
- The caret still opens the full league list.
- Non-sports prediction sections look unchanged.
