### PR TITLE
feat: add sandbox dev feature and accompanying e2e test

### DIFF
--- a/e2e/flows/security/Sandbox.yaml
+++ b/e2e/flows/security/Sandbox.yaml
@@ -1,0 +1,45 @@
+appId: ${APP_ID}
+tags:
+  - security
+  - sandbox
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- extendedWaitUntil:
+    visible:
+      id: welcome-screen
+    timeout: 60000
+- openLink: rainbow://e2e/sandbox-test
+- runFlow:
+    when:
+      visible: 'Open in .*'
+      platform: iOS
+    commands:
+      - tapOn: 'Open'
+- extendedWaitUntil:
+    visible:
+      id: sandbox-run-all
+    timeout: 15000
+- tapOn:
+    id: sandbox-run-all
+- extendedWaitUntil:
+    visible:
+      id: sandbox-case-http_allowed-pass
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      id: sandbox-case-http_blocked-pass
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      id: sandbox-case-webview_allowed-pass
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      id: sandbox-case-webview_blocked-pass
+    timeout: 30000

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { IS_DEV, IS_PROD, IS_STORE_INSTALL, IS_TEST } from '@/env';
 import { initializeRemoteConfig } from '@/features/config/stores/remoteConfig';
 import { monitorNetwork } from '@/features/debug/utils/network';
 import { configureDelegationSdk } from '@/features/delegation/utils/configureClient';
+import { SandboxDiagnosticsOverlay } from '@/features/sandbox/ui/components/SandboxDiagnosticsOverlay';
 import RainbowContextWrapper from '@/helpers/RainbowContext';
 import { useApplicationSetup } from '@/hooks/useApplicationSetup';
 import { logger, RainbowError } from '@/logger';
@@ -84,6 +85,7 @@ function AppComponent() {
       <NotificationsHandler />
       <DeeplinkHandler initialRoute={initialRoute} />
       {IS_TEST && <TestDeeplinkHandler />}
+      {(!IS_STORE_INSTALL || IS_TEST) && <SandboxDiagnosticsOverlay />}
       <BackupsSync />
       <AbsolutePortalRoot />
     </>

--- a/src/app/navigation/TestDeeplinkHandler.tsx
+++ b/src/app/navigation/TestDeeplinkHandler.tsx
@@ -8,6 +8,7 @@ import { useCashDepositSetupStore } from '@/features/cash/stores/cashDepositSetu
 import { type ExperimentalConfigKey } from '@/features/config/constants/experimental';
 import { useExperimentalConfigStore } from '@/features/config/stores/experimentalConfigStore';
 import { savePIN } from '@/features/local-auth/pinAuthentication';
+import { useSandboxDiagnosticsStore } from '@/features/sandbox/data/stores/sandboxDiagnosticsStore';
 import { logger } from '@/logger';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -43,6 +44,9 @@ export function TestDeeplinkHandler() {
           break;
         case 'setCashDepositSetupStatus':
           useCashDepositSetupStore.getState().setStatus(query.status as CashDepositSetupStatus);
+          break;
+        case 'sandbox-test':
+          useSandboxDiagnosticsStore.getState().open();
           break;
         default:
           logger.debug(`[TestDeeplinkHandler]: unknown path`, { url });

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -30,6 +30,7 @@ import { getDelegationContractAddress, isRainbowDelegated, isThirdPartyDelegated
 import { isAuthenticated } from '@/features/local-auth/isAuthenticated';
 import { wipeKeychain } from '@/features/local-auth/legacyKeychain';
 import { ChainId } from '@/features/network/types/backendNetworks';
+import { useSandboxDiagnosticsStore } from '@/features/sandbox/data/stores/sandboxDiagnosticsStore';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { getPublicKeyOfTheSigningWalletAndCreateWalletIfNeeded } from '@/helpers/signingWallet';
 import * as i18n from '@/languages';
@@ -380,6 +381,13 @@ export const DevSection = () => {
               onPress={() => Restart.Restart()}
               size={52}
               titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.restart_app)} />}
+            />
+            <MenuItem
+              leftComponent={<MenuItem.TextIcon icon="🏝️" isEmoji />}
+              onPress={() => useSandboxDiagnosticsStore.getState().open()}
+              size={52}
+              testID="sandbox-diagnostics-section"
+              titleComponent={<MenuItem.Title text="Sandbox diagnostics" />}
             />
             <MenuItem
               leftComponent={<MenuItem.TextIcon icon="🧨" isEmoji />}

--- a/src/features/sandbox/core/models/cases.ts
+++ b/src/features/sandbox/core/models/cases.ts
@@ -1,0 +1,22 @@
+export type SandboxChannel = 'http' | 'webview';
+export type SandboxTestCaseId = 'http_allowed' | 'http_blocked' | 'webview_allowed' | 'webview_blocked';
+export type SandboxTestCaseStatus = 'idle' | 'running' | 'pass' | 'fail';
+
+export interface SandboxTestCase {
+  id: SandboxTestCaseId;
+  channel: SandboxChannel;
+  status: SandboxTestCaseStatus;
+  detail?: string;
+}
+
+export interface SandboxTestCaseResult {
+  passed: boolean;
+  detail: string;
+}
+
+export const SANDBOX_TEST_CASES: SandboxTestCase[] = [
+  { id: 'http_allowed', channel: 'http', status: 'idle' },
+  { id: 'http_blocked', channel: 'http', status: 'idle' },
+  { id: 'webview_allowed', channel: 'webview', status: 'idle' },
+  { id: 'webview_blocked', channel: 'webview', status: 'idle' },
+];

--- a/src/features/sandbox/core/models/hosts.ts
+++ b/src/features/sandbox/core/models/hosts.ts
@@ -1,0 +1,3 @@
+export const ALLOWED_URL = 'https://rainbow.me/';
+export const BLOCKED_URL = 'https://example.com/';
+export const BLOCKED_HOST = 'example.com';

--- a/src/features/sandbox/core/services/classifier.test.ts
+++ b/src/features/sandbox/core/services/classifier.test.ts
@@ -1,0 +1,85 @@
+import { type SandboxTestCaseResult } from '../models/cases';
+import {
+  classifyHttpAllowed,
+  classifyHttpBlocked,
+  classifyWebViewAllowed,
+  classifyWebViewBlocked,
+  type BlockedHttpOutcome,
+} from './classifier';
+
+describe('sandbox classifier', () => {
+  describe('#classifyHttpAllowed', () => {
+    it('passes when the allow-listed request succeeds', () => {
+      expect(classifyHttpAllowed({ ok: true, status: 200 })).toEqual({ passed: true, detail: 'reachable (status 200)' });
+    });
+
+    it('fails on a non-ok response (the host should be reachable)', () => {
+      expect(classifyHttpAllowed({ ok: false, status: 500 })).toEqual({ passed: false, detail: 'unexpected status 500' });
+    });
+
+    it('fails when the request errors', () => {
+      expect(classifyHttpAllowed({ error: 'network down' })).toEqual({ passed: false, detail: 'errored: network down' });
+    });
+  });
+
+  describe('#classifyHttpBlocked', () => {
+    // The security-critical boundary: a blocked host is a breach ONLY if it
+    // returns a real 2xx. Everything else (non-2xx, reject, timeout) is blocked.
+    it.each<[BlockedHttpOutcome, SandboxTestCaseResult]>([
+      [
+        { kind: 'resolved', status: 200 },
+        { passed: false, detail: 'not blocked (status 200)' },
+      ], // real 2xx -> breach
+      [
+        { kind: 'resolved', status: 299 },
+        { passed: false, detail: 'not blocked (status 299)' },
+      ], // upper 2xx bound -> breach
+      [
+        { kind: 'resolved', status: 199 },
+        { passed: true, detail: 'blocked (status 199)' },
+      ], // below 2xx -> blocked
+      [
+        { kind: 'resolved', status: 300 },
+        { passed: true, detail: 'blocked (status 300)' },
+      ], // above 2xx -> blocked
+      [
+        { kind: 'resolved', status: 500 },
+        { passed: true, detail: 'blocked (status 500)' },
+      ], // Android synthetic 500 -> blocked
+      [
+        { kind: 'rejected', error: 'refused' },
+        { passed: true, detail: 'blocked (request failed)' },
+      ], // reject -> blocked
+      [{ kind: 'timeout' }, { passed: true, detail: 'blocked (no response)' }], // iOS hang/drop -> blocked
+    ])('outcome %o -> %o', (outcome, expected) => {
+      expect(classifyHttpBlocked(outcome)).toEqual(expected);
+    });
+  });
+
+  describe('#classifyWebViewAllowed', () => {
+    it('passes when the allow-listed page loads', () => {
+      expect(classifyWebViewAllowed(true)).toEqual({ passed: true, detail: 'allow-listed page loaded' });
+    });
+
+    it('fails when the allow-listed page does not load', () => {
+      expect(classifyWebViewAllowed(false)).toEqual({ passed: false, detail: 'allow-listed page did not load' });
+    });
+  });
+
+  describe('#classifyWebViewBlocked', () => {
+    it('passes when the blocked host is never reached', () => {
+      expect(classifyWebViewBlocked(false)).toEqual({ passed: true, detail: 'blocked (did not load)' });
+    });
+
+    it('fails when the blocked host loads, naming the observed url', () => {
+      expect(classifyWebViewBlocked(true, 'https://example.com/')).toEqual({
+        passed: false,
+        detail: 'loaded blocked host: https://example.com/',
+      });
+    });
+
+    it('fails with an empty url when none is observed', () => {
+      expect(classifyWebViewBlocked(true)).toEqual({ passed: false, detail: 'loaded blocked host: ' });
+    });
+  });
+});

--- a/src/features/sandbox/core/services/classifier.ts
+++ b/src/features/sandbox/core/services/classifier.ts
@@ -1,0 +1,43 @@
+import { type SandboxTestCaseResult } from '../models/cases';
+
+export function classifyHttpAllowed(outcome: { ok: boolean; status: number } | { error: string }): SandboxTestCaseResult {
+  if ('error' in outcome) {
+    return { passed: false, detail: `errored: ${outcome.error}` };
+  }
+  return {
+    passed: outcome.ok,
+    detail: outcome.ok ? `reachable (status ${outcome.status})` : `unexpected status ${outcome.status}`,
+  };
+}
+
+export type BlockedHttpOutcome = { kind: 'resolved'; status: number } | { kind: 'rejected'; error: string } | { kind: 'timeout' };
+
+export function classifyHttpBlocked(outcome: BlockedHttpOutcome): SandboxTestCaseResult {
+  // Only a real success response means the sandbox let the request through. A
+  // reject, a non-2xx (Android returns a synthetic 500), or a hang we time out
+  // (iOS currently drops the task) all satisfy the invariant.
+  if (outcome.kind === 'resolved' && outcome.status >= 200 && outcome.status < 300) {
+    return { passed: false, detail: `not blocked (status ${outcome.status})` };
+  }
+  const detail =
+    outcome.kind === 'resolved'
+      ? `blocked (status ${outcome.status})`
+      : outcome.kind === 'rejected'
+        ? 'blocked (request failed)'
+        : 'blocked (no response)';
+  return { passed: true, detail };
+}
+
+export function classifyWebViewAllowed(loaded: boolean): SandboxTestCaseResult {
+  return {
+    passed: loaded,
+    detail: loaded ? 'allow-listed page loaded' : 'allow-listed page did not load',
+  };
+}
+
+export function classifyWebViewBlocked(reachedBlockedHost: boolean, observedUrl?: string): SandboxTestCaseResult {
+  return {
+    passed: !reachedBlockedHost,
+    detail: reachedBlockedHost ? `loaded blocked host: ${observedUrl ?? ''}` : 'blocked (did not load)',
+  };
+}

--- a/src/features/sandbox/data/api/httpProbes.ts
+++ b/src/features/sandbox/data/api/httpProbes.ts
@@ -1,0 +1,34 @@
+import { type SandboxTestCaseResult } from '../../core/models/cases';
+import { ALLOWED_URL, BLOCKED_URL } from '../../core/models/hosts';
+import { classifyHttpAllowed, classifyHttpBlocked } from '../../core/services/classifier';
+
+// A blocked HTTP request must never return a real 2xx; on iOS it currently
+// hangs, so we cap the wait and treat the hang as a block.
+const HTTP_BLOCKED_TIMEOUT_MS = 4000;
+
+export async function probeHttpAllowed(): Promise<SandboxTestCaseResult> {
+  try {
+    const response = await fetch(ALLOWED_URL);
+    return classifyHttpAllowed({ ok: response.ok, status: response.status });
+  } catch (error) {
+    return classifyHttpAllowed({ error: (error as Error).message });
+  }
+}
+
+export function probeHttpBlocked(): Promise<SandboxTestCaseResult> {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = (result: SandboxTestCaseResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
+    const timer = setTimeout(() => finish(classifyHttpBlocked({ kind: 'timeout' })), HTTP_BLOCKED_TIMEOUT_MS);
+    fetch(BLOCKED_URL)
+      .then(response => finish(classifyHttpBlocked({ kind: 'resolved', status: response.status })))
+      .catch((error: Error) => finish(classifyHttpBlocked({ kind: 'rejected', error: error.message })))
+      .finally(() => clearTimeout(timer));
+  });
+}

--- a/src/features/sandbox/data/stores/sandboxDiagnosticsStore.test.ts
+++ b/src/features/sandbox/data/stores/sandboxDiagnosticsStore.test.ts
@@ -1,0 +1,164 @@
+import { type SandboxTestCaseId, type SandboxTestCaseResult } from '../../core/models/cases';
+import { probeHttpAllowed, probeHttpBlocked } from '../api/httpProbes';
+import { useSandboxDiagnosticsStore } from './sandboxDiagnosticsStore';
+
+jest.mock('../api/httpProbes', () => ({
+  probeHttpAllowed: jest.fn(),
+  probeHttpBlocked: jest.fn(),
+}));
+
+const mockProbeAllowed = jest.mocked(probeHttpAllowed);
+const mockProbeBlocked = jest.mocked(probeHttpBlocked);
+
+const store = () => useSandboxDiagnosticsStore.getState();
+const allCasesIdle = () => Object.values(store().cases).every(testCase => testCase.status === 'idle' && testCase.detail === undefined);
+const markRunning = (caseId: SandboxTestCaseId) =>
+  useSandboxDiagnosticsStore.setState(state => ({ cases: { ...state.cases, [caseId]: { ...state.cases[caseId], status: 'running' } } }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockProbeAllowed.mockResolvedValue({ passed: true, detail: 'reachable (status 200)' });
+  mockProbeBlocked.mockResolvedValue({ passed: true, detail: 'blocked (no response)' });
+  useSandboxDiagnosticsStore.setState(useSandboxDiagnosticsStore.getInitialState());
+});
+
+describe('useSandboxDiagnosticsStore', () => {
+  it('starts closed with every case idle', () => {
+    expect(store().isOpen).toBe(false);
+    expect(allCasesIdle()).toBe(true);
+  });
+
+  describe('#open', () => {
+    it('opens the overlay', () => {
+      store().open();
+      expect(store().isOpen).toBe(true);
+    });
+  });
+
+  describe('#close', () => {
+    it('closes and resets every case to idle', async () => {
+      store().open();
+      store().runCase('http_allowed');
+      await Promise.resolve();
+      store().runCase('webview_blocked');
+      store().recordResult('webview_blocked', { passed: false, detail: 'loaded blocked host: x' });
+
+      store().close();
+
+      expect(store().isOpen).toBe(false);
+      expect(allCasesIdle()).toBe(true);
+    });
+
+    it('drops an http probe that resolves after close, leaving the case idle', async () => {
+      let resolveProbe!: (result: SandboxTestCaseResult) => void;
+      mockProbeAllowed.mockReturnValue(new Promise<SandboxTestCaseResult>(resolve => (resolveProbe = resolve)));
+
+      store().open();
+      store().runCase('http_allowed');
+      store().close();
+      resolveProbe({ passed: false, detail: 'unexpected status 500' });
+      await Promise.resolve();
+
+      expect(store().cases.http_allowed.status).toBe('idle');
+      expect(store().cases.http_allowed.detail).toBeUndefined();
+    });
+  });
+
+  describe('#recordResult', () => {
+    it('records a pass with its detail', () => {
+      markRunning('http_allowed');
+      store().recordResult('http_allowed', { passed: true, detail: 'reachable (status 200)' });
+      expect(store().cases.http_allowed).toEqual({
+        id: 'http_allowed',
+        channel: 'http',
+        status: 'pass',
+        detail: 'reachable (status 200)',
+      });
+    });
+
+    it('records a fail with its detail', () => {
+      markRunning('http_blocked');
+      store().recordResult('http_blocked', { passed: false, detail: 'not blocked (status 200)' });
+      expect(store().cases.http_blocked).toEqual({
+        id: 'http_blocked',
+        channel: 'http',
+        status: 'fail',
+        detail: 'not blocked (status 200)',
+      });
+    });
+
+    it('drops a result for a case that is not running (e.g. settled late after close)', () => {
+      store().runCase('webview_blocked');
+      store().close();
+      store().recordResult('webview_blocked', { passed: false, detail: 'loaded blocked host: x' });
+
+      expect(store().cases.webview_blocked.status).toBe('idle');
+      expect(store().cases.webview_blocked.detail).toBeUndefined();
+    });
+  });
+
+  describe('#runCase', () => {
+    it('marks a webview case running and fires no http probe', () => {
+      store().runCase('webview_blocked');
+      store().recordResult('webview_blocked', { passed: false, detail: 'stale' });
+      store().runCase('webview_blocked');
+
+      expect(store().cases.webview_blocked).toMatchObject({ status: 'running', detail: undefined });
+      expect(mockProbeAllowed).not.toHaveBeenCalled();
+      expect(mockProbeBlocked).not.toHaveBeenCalled();
+    });
+
+    it('marks an http case running, clears the prior outcome, then records the probe result', async () => {
+      store().runCase('http_allowed');
+      await Promise.resolve();
+      expect(store().cases.http_allowed.status).toBe('pass');
+
+      mockProbeAllowed.mockResolvedValue({ passed: false, detail: 'unexpected status 500' });
+      store().runCase('http_allowed');
+
+      // Synchronous: running with the previous detail cleared, probe kicked off again.
+      expect(store().cases.http_allowed).toMatchObject({ status: 'running', detail: undefined });
+      expect(mockProbeAllowed).toHaveBeenCalledTimes(2);
+
+      await Promise.resolve();
+      expect(store().cases.http_allowed).toMatchObject({ status: 'fail', detail: 'unexpected status 500' });
+    });
+
+    it('ignores a re-tap while the case is already running', () => {
+      mockProbeAllowed.mockReturnValue(new Promise<SandboxTestCaseResult>(() => undefined));
+
+      store().runCase('http_allowed');
+      store().runCase('http_allowed');
+
+      expect(store().cases.http_allowed.status).toBe('running');
+      expect(mockProbeAllowed).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops a pre-close probe so it cannot affect a run started after reopen', async () => {
+      const resolvers: Array<(result: SandboxTestCaseResult) => void> = [];
+      mockProbeAllowed.mockImplementation(() => new Promise<SandboxTestCaseResult>(resolve => resolvers.push(resolve)));
+
+      store().open();
+      store().runCase('http_allowed'); // run 1, probe still in flight
+      store().close(); // resets to idle; the run-1 probe is not cancelled
+      store().open();
+      store().runCase('http_allowed'); // run 2, fresh probe
+
+      resolvers[0]({ passed: false, detail: 'unexpected status 500' }); // run-1 probe lands late
+      resolvers[1]({ passed: true, detail: 'reachable (status 200)' }); // run-2 probe lands
+      await Promise.resolve();
+
+      expect(store().cases.http_allowed).toMatchObject({ status: 'pass', detail: 'reachable (status 200)' });
+    });
+  });
+
+  describe('#runAll', () => {
+    it('marks every case running and fires each http probe once', () => {
+      store().runAll();
+
+      expect(Object.values(store().cases).every(testCase => testCase.status === 'running')).toBe(true);
+      expect(mockProbeAllowed).toHaveBeenCalledTimes(1);
+      expect(mockProbeBlocked).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/features/sandbox/data/stores/sandboxDiagnosticsStore.ts
+++ b/src/features/sandbox/data/stores/sandboxDiagnosticsStore.ts
@@ -1,0 +1,59 @@
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
+
+import { SANDBOX_TEST_CASES, type SandboxTestCase, type SandboxTestCaseId, type SandboxTestCaseResult } from '../../core/models/cases';
+import { probeHttpAllowed, probeHttpBlocked } from '../api/httpProbes';
+
+interface SandboxDiagnosticsState {
+  isOpen: boolean;
+  cases: Record<SandboxTestCaseId, SandboxTestCase>;
+  open: () => void;
+  close: () => void;
+  runCase: (caseId: SandboxTestCaseId) => void;
+  runAll: () => void;
+  recordResult: (caseId: SandboxTestCaseId, result: SandboxTestCaseResult) => void;
+}
+
+function idleCases(): Record<SandboxTestCaseId, SandboxTestCase> {
+  return Object.fromEntries(SANDBOX_TEST_CASES.map(testCase => [testCase.id, { ...testCase }])) as Record<
+    SandboxTestCaseId,
+    SandboxTestCase
+  >;
+}
+
+export const useSandboxDiagnosticsStore = createRainbowStore<SandboxDiagnosticsState>((set, get) => ({
+  isOpen: false,
+  cases: idleCases(),
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false, cases: idleCases() }),
+  recordResult: (caseId, result) => {
+    // A result only makes sense for a run that's still in flight. close() resets
+    // cases to idle, so a probe that settles late (e.g. a WebView event already
+    // queued at unmount) is dropped here rather than repopulating a cancelled run.
+    if (get().cases[caseId].status !== 'running') {
+      return;
+    }
+    set(state => ({
+      cases: { ...state.cases, [caseId]: { ...state.cases[caseId], status: result.passed ? 'pass' : 'fail', detail: result.detail } },
+    }));
+  },
+  runCase: caseId => {
+    // A run that's still in flight isn't restarted: re-tapping a running case is a
+    // no-op.
+    if (get().cases[caseId].status === 'running') {
+      return;
+    }
+    set(state => ({ cases: { ...state.cases, [caseId]: { ...state.cases[caseId], status: 'running', detail: undefined } } }));
+    const run = get().cases[caseId];
+    const record = (result: SandboxTestCaseResult) => {
+      if (get().cases[caseId] === run) {
+        get().recordResult(caseId, result);
+      }
+    };
+    if (caseId === 'http_allowed') {
+      probeHttpAllowed().then(record);
+    } else if (caseId === 'http_blocked') {
+      probeHttpBlocked().then(record);
+    }
+  },
+  runAll: () => Object.values(get().cases).forEach(testCase => get().runCase(testCase.id)),
+}));

--- a/src/features/sandbox/data/stores/sandboxDiagnosticsStore.ts
+++ b/src/features/sandbox/data/stores/sandboxDiagnosticsStore.ts
@@ -1,4 +1,4 @@
-import { createRainbowStore } from '@/state/internal/createRainbowStore';
+import { createBaseStore } from '@storesjs/stores';
 
 import { SANDBOX_TEST_CASES, type SandboxTestCase, type SandboxTestCaseId, type SandboxTestCaseResult } from '../../core/models/cases';
 import { probeHttpAllowed, probeHttpBlocked } from '../api/httpProbes';
@@ -20,7 +20,7 @@ function idleCases(): Record<SandboxTestCaseId, SandboxTestCase> {
   >;
 }
 
-export const useSandboxDiagnosticsStore = createRainbowStore<SandboxDiagnosticsState>((set, get) => ({
+export const useSandboxDiagnosticsStore = createBaseStore<SandboxDiagnosticsState>((set, get) => ({
   isOpen: false,
   cases: idleCases(),
   open: () => set({ isOpen: true }),

--- a/src/features/sandbox/ui/components/SandboxCaseRow.tsx
+++ b/src/features/sandbox/ui/components/SandboxCaseRow.tsx
@@ -1,0 +1,39 @@
+import { Pressable } from 'react-native';
+
+import { Box, Text } from '@/design-system';
+
+import { type SandboxTestCaseId } from '../../core/models/cases';
+import { useSandboxDiagnosticsStore } from '../../data/stores/sandboxDiagnosticsStore';
+
+const LABELS: Record<SandboxTestCaseId, string> = {
+  http_allowed: 'HTTP: allowed host reachable',
+  http_blocked: 'HTTP: blocked host unreachable',
+  webview_allowed: 'WebView: allowed page loads',
+  webview_blocked: 'WebView: blocked navigation prevented',
+};
+
+export function SandboxCaseRow({ caseId }: { caseId: SandboxTestCaseId }) {
+  const { status, detail } = useSandboxDiagnosticsStore(state => state.cases[caseId]);
+  const runCase = useSandboxDiagnosticsStore(state => state.runCase);
+  const statusColor = status === 'pass' ? 'green' : status === 'fail' ? 'red' : 'labelTertiary';
+
+  return (
+    <Pressable onPress={() => runCase(caseId)} testID={`sandbox-case-${caseId}-${status}`}>
+      <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingVertical="12px">
+        <Box gap={2} paddingRight="12px" style={{ flex: 1 }}>
+          <Text color="label" size="15pt" weight="medium">
+            {LABELS[caseId]}
+          </Text>
+          {detail ? (
+            <Text color="labelQuaternary" size="11pt">
+              {detail}
+            </Text>
+          ) : null}
+        </Box>
+        <Text color={statusColor} size="13pt" weight="bold">
+          {status.toUpperCase()}
+        </Text>
+      </Box>
+    </Pressable>
+  );
+}

--- a/src/features/sandbox/ui/components/SandboxDiagnosticsOverlay.tsx
+++ b/src/features/sandbox/ui/components/SandboxDiagnosticsOverlay.tsx
@@ -1,0 +1,106 @@
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+
+import { Box, Separator, Stack, Text } from '@/design-system';
+
+import { SANDBOX_TEST_CASES } from '../../core/models/cases';
+import { useSandboxDiagnosticsStore } from '../../data/stores/sandboxDiagnosticsStore';
+import { SandboxCaseRow } from './SandboxCaseRow';
+import { WebViewAllowedProbe } from './WebViewAllowedProbe';
+import { WebViewBlockedProbe } from './WebViewBlockedProbe';
+
+export function SandboxDiagnosticsOverlay() {
+  const isOpen = useSandboxDiagnosticsStore(state => state.isOpen);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <View style={styles.overlay}>
+      <Box background="surfacePrimary" borderRadius={16} padding="20px" style={styles.card} width="full">
+        <Text color="label" size="20pt" weight="bold">
+          Sandbox diagnostics
+        </Text>
+        <ScrollView style={styles.rows}>
+          <Stack separator={<Separator color="separatorTertiary" thickness={1} />}>
+            {SANDBOX_TEST_CASES.map(testCase => (
+              <SandboxCaseRow key={testCase.id} caseId={testCase.id} />
+            ))}
+          </Stack>
+        </ScrollView>
+        <Box flexDirection="row" gap={12} paddingTop="16px">
+          <RunAllButton />
+          <CloseButton />
+        </Box>
+      </Box>
+
+      <View pointerEvents="none" style={styles.webviews}>
+        <WebViewProbes />
+      </View>
+    </View>
+  );
+}
+
+function RunAllButton() {
+  const runAll = useSandboxDiagnosticsStore(state => state.runAll);
+
+  return (
+    <Pressable onPress={runAll} style={styles.button} testID="sandbox-run-all">
+      <Box alignItems="center" background="accent" borderRadius={10} paddingVertical="12px">
+        <Text color="white" size="15pt" weight="semibold">
+          Run all
+        </Text>
+      </Box>
+    </Pressable>
+  );
+}
+
+function CloseButton() {
+  const close = useSandboxDiagnosticsStore(state => state.close);
+
+  return (
+    <Pressable onPress={close} style={styles.button} testID="sandbox-close">
+      <Box alignItems="center" background="fillSecondary" borderRadius={10} paddingVertical="12px">
+        <Text color="label" size="15pt" weight="semibold">
+          Close
+        </Text>
+      </Box>
+    </Pressable>
+  );
+}
+
+function WebViewProbes() {
+  const cases = useSandboxDiagnosticsStore(state => state.cases);
+  const runningWebViewCases = Object.values(cases).filter(testCase => testCase.channel === 'webview' && testCase.status === 'running');
+
+  return runningWebViewCases.map(testCase =>
+    testCase.id === 'webview_allowed' ? <WebViewAllowedProbe key={testCase.id} /> : <WebViewBlockedProbe key={testCase.id} />
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    flex: 1,
+  },
+  card: {
+    maxHeight: '80%',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    padding: 20,
+    zIndex: 9999,
+  },
+  rows: {
+    marginTop: 12,
+  },
+  webviews: {
+    bottom: 0,
+    flexDirection: 'row',
+    height: 100,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+  },
+});

--- a/src/features/sandbox/ui/components/WebViewAllowedProbe.tsx
+++ b/src/features/sandbox/ui/components/WebViewAllowedProbe.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+import { ALLOWED_URL } from '../../core/models/hosts';
+import { classifyWebViewAllowed } from '../../core/services/classifier';
+import { useReportOnce } from '../hooks/useReportOnce';
+
+// Depends on real network reachability, so it gets a long window.
+const ALLOWED_TIMEOUT_MS = 12000;
+
+/**
+ * Verifies the allow-listed page loads in a WebView. The overlay mounts this only
+ * while the case is running, so each run gets a fresh instance. Pass on `onLoad`;
+ * fail on `onError` or no load within the window.
+ */
+export function WebViewAllowedProbe() {
+  const report = useReportOnce('webview_allowed');
+
+  useEffect(() => {
+    const timeout = setTimeout(() => report(classifyWebViewAllowed(false)), ALLOWED_TIMEOUT_MS);
+    return () => clearTimeout(timeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <WebView
+      source={{ uri: ALLOWED_URL }}
+      sandbox
+      style={styles.webview}
+      onLoad={() => report(classifyWebViewAllowed(true))}
+      onError={() => report(classifyWebViewAllowed(false))}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  webview: {
+    flex: 1,
+  },
+});

--- a/src/features/sandbox/ui/components/WebViewBlockedProbe.tsx
+++ b/src/features/sandbox/ui/components/WebViewBlockedProbe.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+import { StyleSheet } from 'react-native';
+
+import WebView from 'react-native-webview';
+
+import { BLOCKED_HOST, BLOCKED_URL } from '../../core/models/hosts';
+import { classifyWebViewBlocked } from '../../core/services/classifier';
+import { useReportOnce } from '../hooks/useReportOnce';
+
+// No event within this window means the blocked host never loaded (iOS cancels
+// the navigation silently), which is a pass.
+const BLOCKED_TIMEOUT_MS = 8000;
+// Android fires a spurious onLoad for the stopped page in addition to the block
+// error. An onLoad of the blocked host counts as a breach only if no block error
+// lands within this window, giving the authoritative onError time to win.
+const BLOCKED_CONFIRM_MS = 1500;
+
+/**
+ * Verifies a navigation to the blocked host is prevented. The sandbox surfaces a
+ * block differently per platform, so the authoritative pass is the block *error*,
+ * not onLoad:
+ *  - Android fires onError ("Navigation blocked by sandbox") AND a spurious
+ *    onLoad for the stopped page, so onError is the pass, and a lone onLoad is a
+ *    breach only if no error follows within BLOCKED_CONFIRM_MS.
+ *  - iOS cancels the navigation silently (no event), so no load within the
+ *    window is the pass.
+ * A genuine load of the blocked host with no block error is the only failure.
+ */
+export function WebViewBlockedProbe() {
+  const report = useReportOnce('webview_blocked');
+  const breachTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => report(classifyWebViewBlocked(false)), BLOCKED_TIMEOUT_MS);
+    return () => {
+      clearTimeout(timeout);
+      clearTimeout(breachTimer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <WebView
+      source={{ uri: BLOCKED_URL }}
+      sandbox
+      style={styles.webview}
+      // The sandbox reports a blocked navigation as a load error; that's the
+      // authoritative pass and beats any pending breach verdict.
+      onError={() => report(classifyWebViewBlocked(false))}
+      onLoad={(event: { nativeEvent: { url: string } }) => {
+        const { url } = event.nativeEvent;
+        // Android fires this onLoad even when it blocked, so a load of the blocked
+        // host is only a breach if no block error follows shortly.
+        if (url.includes(BLOCKED_HOST)) {
+          clearTimeout(breachTimer.current);
+          breachTimer.current = setTimeout(() => report(classifyWebViewBlocked(true, url)), BLOCKED_CONFIRM_MS);
+        }
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  webview: {
+    flex: 1,
+  },
+});

--- a/src/features/sandbox/ui/hooks/useReportOnce.ts
+++ b/src/features/sandbox/ui/hooks/useReportOnce.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+
+import { type SandboxTestCaseId, type SandboxTestCaseResult } from '../../core/models/cases';
+import { useSandboxDiagnosticsStore } from '../../data/stores/sandboxDiagnosticsStore';
+
+export function useReportOnce(caseId: SandboxTestCaseId) {
+  const recordResult = useSandboxDiagnosticsStore(state => state.recordResult);
+  const settled = useRef(false);
+
+  return (result: SandboxTestCaseResult) => {
+    if (settled.current) {
+      return;
+    }
+    settled.current = true;
+    recordResult(caseId, result);
+  };
+}


### PR DESCRIPTION
Adds a new `Sandbox diagnostics` overlay accessible from dev settings or a new deep link that can be used to test the sandbox integration and make sure it works in all cases. The overlay is used as basis for a new Sandbox e2e test triggering it from the e2e deeplink.

The current test cases are deliberately minimallys scoped to: http blocked/allowed and webview load nav blocked/allowed. We'll add websocket and webview in-page nav tests later.
 
Note that this is the first feature that fully follows the level 2 domain architecture layout with strict ui/data/core layer separations.

| Default | Pass |
--|--
<img width="350" alt="Screenshot_20260622_114539" src="https://github.com/user-attachments/assets/c2152946-ccea-4e19-b40c-27a3cc8d52f5" /> | <img width="350" alt="Screenshot_20260622_114601" src="https://github.com/user-attachments/assets/c8497b12-989e-4ad0-8931-6ddd1c8b42c7" />
