### PR TITLE
refactor: extract useWatcher from useTransactionWatcher

### DIFF
--- a/src/framework/ui/hooks/useWatcher.ts
+++ b/src/framework/ui/hooks/useWatcher.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+import { time } from '@/framework/core/utils/time';
+import { logger, RainbowError } from '@/logger';
+
+interface UseWatcherProps {
+  /** Poll only while true; toggling it starts or stops the loop. */
+  enabled?: boolean;
+  /** Delay between runs, in ms. */
+  interval?: number;
+  /** Invoked once per tick; rejections are caught and logged. */
+  watchFunction: (abortController: AbortController) => Promise<void>;
+}
+
+/**
+ * Generic self-rescheduling poll loop: runs `watch` immediately, then every `interval` ms while
+ * `enabled`, passing an `AbortController` that is aborted on disable/unmount.
+ */
+export function useWatcher({ enabled = true, interval = time.seconds(1), watchFunction }: UseWatcherProps): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const run = async () => {
+      if (abortController.signal.aborted) return;
+      try {
+        await watchFunction(abortController);
+      } catch (error) {
+        if (!abortController.signal.aborted) logger.error(new RainbowError('[useWatcher]: watch failed', error));
+      }
+      if (!abortController.signal.aborted) {
+        timeoutId = setTimeout(run, interval);
+      }
+    };
+
+    run();
+
+    return () => {
+      abortController.abort();
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [enabled, interval, watchFunction]);
+}

--- a/src/hooks/useTransactionWatcher.ts
+++ b/src/hooks/useTransactionWatcher.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 
 import { time } from '@/framework/core/utils/time';
-import { logger, RainbowError } from '@/logger';
+import { useWatcher } from '@/framework/ui/hooks/useWatcher';
 
 interface UseTransactionWatcherProps<T> {
   interval?: number;
@@ -9,54 +9,17 @@ interface UseTransactionWatcherProps<T> {
   watchFunction: (transactions: T[], abortController: AbortController) => Promise<void>;
 }
 
+/**
+ * Watches a set of transactions: polls `watchFunction` with the latest `transactions` while there
+ * are any, stopping when the set empties. A thin wrapper over `useWatcher`.
+ */
 export function useTransactionWatcher<T>({ interval = time.seconds(1), transactions, watchFunction }: UseTransactionWatcherProps<T>) {
-  const abortRef = useRef<AbortController | null>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const transactionsRef = useRef<T[]>(transactions);
-
-  transactionsRef.current = transactions;
-
-  const runWatcher = useCallback(
-    async (abortController: AbortController) => {
-      if (abortController.signal.aborted) return;
-
-      const currentTransactions = transactionsRef.current;
-      if (currentTransactions.length) {
-        try {
-          await watchFunction(currentTransactions, abortController);
-        } catch (e) {
-          if (!abortController.signal.aborted) logger.error(new RainbowError('[useTransactionWatcher]: Error watching transactions', e));
-        }
-      }
-
-      if (!abortController.signal.aborted) {
-        timeoutRef.current = setTimeout(() => runWatcher(abortController), interval);
-      }
-    },
-    [interval, watchFunction]
-  );
-
-  useEffect(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-    abortRef.current?.abort();
-
-    if (!transactions.length) return;
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    runWatcher(controller);
-
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
-      controller.abort();
-      abortRef.current = null;
-    };
-  }, [interval, runWatcher, transactions]);
+  useWatcher({
+    enabled: transactions.length > 0,
+    interval,
+    watchFunction: useCallback(
+      (abortController: AbortController) => watchFunction(transactions, abortController),
+      [watchFunction, transactions]
+    ),
+  });
 }


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Extracts the generic polling logic from `useTransactionWatcher` into a new `useWatcher` hook. `useWatcher` runs a self-rescheduling poll loop that calls `watchFunction` immediately and then every `interval` ms while `enabled`, aborting on disable or unmount. `useTransactionWatcher` is now a thin wrapper over `useWatcher`, delegating all lifecycle and abort management to it.