### PR TITLE
feat(cash): add RampClient seam + order types mirroring the ramp OpenAPI spec

### DIFF
--- a/e2e/flows/cash/AddCashChips.yaml
+++ b/e2e/flows/cash/AddCashChips.yaml
@@ -19,7 +19,7 @@ tags:
     file: ../../utils/SetCashDepositSetupStatus.yaml
     env:
       STATUS: ready
-# A ready member skips the intro panel and lands straight on the Add Cash sheet.
+# A ready member skips the intro panel and lands straight on the Add Cash presets sheet.
 - tapOn:
     id: buy-button
 - assertVisible:
@@ -30,3 +30,18 @@ tags:
     id: cash-deposit-add-cash-hold-to-add
 - assertNotVisible:
     id: cash-deposit-intro-set-up-account
+# Selecting a preset chip and holding the action button creates a mock Ramp buy order.
+# The mock advances one status per ~2s poll: Pending -> Processing -> Processing -> Completed (~6s total).
+- tapOn:
+    id: cash-deposit-add-cash-amount-100
+- longPressOn:
+    id: cash-deposit-add-cash-hold-to-add
+# On completion the order watcher surfaces the "Request Successful" alert; dismissing it returns to home.
+- extendedWaitUntil:
+    visible:
+      text: 'Request Successful'
+    timeout: 10000
+- tapOn:
+    text: 'OK'
+- assertVisible:
+    id: buy-button

--- a/e2e/flows/cash/AddCashCustomAmount.yaml
+++ b/e2e/flows/cash/AddCashCustomAmount.yaml
@@ -47,3 +47,16 @@ tags:
     text: '.*Hold to Add'
 - assertNotVisible:
     text: 'Enter Amount'
+# Holding the action button submits the custom amount as a mock Ramp buy order.
+# The mock advances one status per ~2s poll: Pending -> Processing -> Processing -> Completed (~6s total).
+- longPressOn:
+    id: cash-deposit-add-cash-hold-to-add
+# On completion the order watcher surfaces the "Request Successful" alert; dismissing it returns to home.
+- extendedWaitUntil:
+    visible:
+      text: 'Request Successful'
+    timeout: 10000
+- tapOn:
+    text: 'OK'
+- assertVisible:
+    id: buy-button

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -5,6 +5,7 @@ import { type CardType } from '@/components/cards/GenericCard';
 import { type LearnCategory } from '@/components/cards/utils/types';
 import { type FiatProviderName } from '@/entities/f2c';
 import { type UnlockableAppIconKey } from '@/features/app-icon/models/appIcons';
+import { type OrderFailureReason, type RampNetwork } from '@/features/cash/services/rampClient';
 import { type CandleResolution, type ChartType } from '@/features/charts/types';
 import { type RequestSource } from '@/features/dapp-request/types';
 import { type ENSRapActionType } from '@/features/ens/raps/common';
@@ -121,6 +122,10 @@ export const event = {
   rewardsViewedSheet: 'rewards.viewed_sheet',
   cashDepositIntroViewed: 'cash.deposit_intro_viewed',
   addCashViewed: 'cash.add_cash_viewed',
+  cashAmountEntered: 'cash.amount_entered',
+  cashBuyOrderSubmitted: 'cash.buy_submitted',
+  cashBuyOrderCompleted: 'cash.buy_completed',
+  cashBuyOrderFailed: 'cash.buy_failed',
   rewardsPressedPendingEarningsCard: 'rewards.pressed_pending_earnings_card',
   rewardsPressedAvailableCard: 'rewards.pressed_available_card',
   rewardsPressedPositionCard: 'rewards.pressed_position_card',
@@ -527,6 +532,30 @@ export type EventProperties = {
   [event.rewardsViewedSheet]: undefined;
   [event.cashDepositIntroViewed]: undefined;
   [event.addCashViewed]: undefined;
+  [event.cashAmountEntered]: {
+    /** The chosen USD amount as a decimal string, e.g. "50". */
+    amount: string;
+    /** Which amount-entry surface the user used first. */
+    entryMode: 'preset' | 'keypad';
+  };
+  [event.cashBuyOrderSubmitted]: {
+    /** The submitted USD amount as a decimal string. */
+    amount: string;
+  };
+  [event.cashBuyOrderCompleted]: {
+    orderId: string;
+    fiatAmount: string;
+    fiatCurrency: string;
+    cryptoAmount: string;
+    network: RampNetwork;
+    /** Milliseconds from order creation to completion, derived from the backend `createdTime`/`completedTime`. */
+    timeToUsdcMs: number;
+  };
+  [event.cashBuyOrderFailed]: {
+    orderId: string;
+    failureReason: OrderFailureReason | null;
+    errorCode: 'PAYMENT_REJECTED' | 'GENERIC';
+  };
   [event.rewardsPressedPendingEarningsCard]: undefined;
   [event.rewardsPressedAvailableCard]: undefined;
   [event.rewardsPressedPositionCard]: { position: number };

--- a/src/features/cash/components/CashBuyOrderWatcher.tsx
+++ b/src/features/cash/components/CashBuyOrderWatcher.tsx
@@ -1,0 +1,31 @@
+import { memo, useEffect } from 'react';
+
+import { useWatcher } from '@/framework/ui/hooks/useWatcher';
+
+import { ORDER_POLL_INTERVAL_MS } from '../constants';
+import { isTerminalOrderStatus } from '../services/rampClient';
+import { cashBuyOrderActions, useCashBuyOrderStore } from '../stores/cashBuyOrderStore';
+
+/**
+ * App-level owner of buy-order tracking. Mounted in SwipeNavigator so it runs regardless of which
+ * screen is open (and on launch after a crash/OS kill): it recovers a submit interrupted before an
+ * order id came back, then polls the active order to a terminal status. Completion surfaces through
+ * the global toast (`applyTerminalOrder` -> `handleTransaction`), so the user sees the result without
+ * reopening the add-cash sheet.
+ */
+export const CashBuyOrderWatcher = memo(function CashBuyOrderWatcher() {
+  const order = useCashBuyOrderStore(state => state.order);
+
+  // On launch, replay a submit interrupted before an order id came back.
+  useEffect(() => {
+    cashBuyOrderActions.resumePendingSubmission();
+  }, []);
+
+  useWatcher({
+    enabled: order !== null && !isTerminalOrderStatus(order.status),
+    interval: ORDER_POLL_INTERVAL_MS,
+    watchFunction: cashBuyOrderActions.syncActiveOrder,
+  });
+
+  return null;
+});

--- a/src/features/cash/constants.ts
+++ b/src/features/cash/constants.ts
@@ -1,0 +1,7 @@
+import { time } from '@/framework/core/utils/time';
+
+export const USDC_NAME = 'USD Coin';
+export const USDC_SYMBOL = 'USDC';
+export const USDC_DECIMALS = 6;
+
+export const ORDER_POLL_INTERVAL_MS = time.seconds(2);

--- a/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddCashSheet.tsx
@@ -1,7 +1,7 @@
-import React, { memo, useCallback, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import { Platform, StyleSheet } from 'react-native';
 
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { analytics } from '@/analytics';
@@ -14,11 +14,16 @@ import { HoldToActivateButton } from '@/components/hold-to-activate-button/HoldT
 import { NumberPad } from '@/components/number-pad/NumberPad';
 import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT, PanelSheet } from '@/components/PanelSheet/PanelSheet';
 import { Box, Inline, Text, useColorMode, useForegroundColor } from '@/design-system';
+import { type LinkedCard } from '@/features/cash/services/authSession';
+import { cashOrderService } from '@/features/cash/services/cashOrderService';
+import { cashBuyOrderActions, useCashBuyOrderStore, useCashBuyPhase } from '@/features/cash/stores/cashBuyOrderStore';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { opacity } from '@/framework/ui/utils/opacity';
+import { WrappedAlert as Alert } from '@/helpers/alert';
+import usePrevious from '@/hooks/usePrevious';
 import * as i18n from '@/languages';
 import { USDC_ADDRESS } from '@/references/constants';
-import { useAccountProfileInfo } from '@/state/wallets/walletsStore';
+import { useAccountAddress, useAccountProfileInfo } from '@/state/wallets/walletsStore';
 import { DEVICE_HEIGHT, DEVICE_WIDTH } from '@/utils/deviceUtils';
 import getUrlForTrustIconFallback from '@/utils/getUrlForTrustIconFallback';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
@@ -176,25 +181,36 @@ function KeypadFundingCaption() {
   );
 }
 
-function AddCashActionButton({ canSubmit, isKeypad, onHoldToAdd }: { canSubmit: boolean; isKeypad: boolean; onHoldToAdd: () => void }) {
+function getActionButtonLabel(canSubmitAmount: boolean): string {
+  return canSubmitAmount ? `􀎽  ${i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}` : i18n.t(i18n.l.cash.add_cash_screen.enter_amount);
+}
+
+function AddCashActionButton({
+  canSubmitAmount,
+  isKeypad,
+  isProcessing,
+  onHoldToAdd,
+}: {
+  canSubmitAmount: boolean;
+  isKeypad: boolean;
+  isProcessing: boolean;
+  onHoldToAdd: () => void;
+}) {
   const { isDarkMode } = useColorMode();
   const accent = useForegroundColor('accent');
-  const buttonLabel = canSubmit
-    ? `􀎽  ${i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}`
-    : i18n.t(i18n.l.cash.add_cash_screen.enter_amount);
 
   return (
     <Box paddingHorizontal="20px" style={{ paddingBottom: isKeypad ? safeAreaInsetValues.bottom + 16 : 32 }}>
       <HoldToActivateButton
         backgroundColor="accent"
-        color={canSubmit ? 'label' : 'labelTertiary'}
-        disabled={!canSubmit}
+        color={canSubmitAmount ? 'label' : 'labelTertiary'}
+        disabled={!canSubmitAmount || isProcessing}
         disabledBackgroundColor={isDarkMode ? opacity(accent, 0.1) : 'fillTertiary'}
         height={48}
-        isProcessing={false}
-        label={buttonLabel}
+        isProcessing={isProcessing}
+        label={getActionButtonLabel(canSubmitAmount)}
         onLongPress={onHoldToAdd}
-        processingLabel={i18n.t(i18n.l.cash.add_cash_screen.hold_to_add)}
+        processingLabel={i18n.t(i18n.l.cash.add_cash_screen.adding_cash)}
         showBiometryIcon={false}
         size="22pt"
         testID="cash-deposit-add-cash-hold-to-add"
@@ -206,34 +222,48 @@ function AddCashActionButton({ canSubmit, isKeypad, onHoldToAdd }: { canSubmit: 
 
 function PresetAmountContent({
   amount,
+  canSubmitAmount,
+  isProcessing,
+  linkedCard,
   onAddFrom,
   onHoldToAdd,
   onMore,
+  onSelectPreset,
   onSettings,
 }: {
   amount: AddCashAmount;
+  canSubmitAmount: boolean;
+  isProcessing: boolean;
+  linkedCard: LinkedCard;
   onAddFrom: () => void;
   onHoldToAdd: () => void;
   onMore: () => void;
+  onSelectPreset: (amount: number) => void;
   onSettings: () => void;
 }) {
   return (
     <>
       <AddCashHeader onSettings={onSettings} topPadding="28px" />
-      <AmountPresetGrid onMore={onMore} onSelectPreset={amount.selectPresetAmount} selectedAmount={amount.selectedPresetAmount} />
-      <AddFromRow onPress={onAddFrom} />
-      <AddCashActionButton canSubmit={amount.canSubmit} isKeypad={false} onHoldToAdd={onHoldToAdd} />
+      <AmountPresetGrid onMore={onMore} onSelectPreset={onSelectPreset} selectedAmount={amount.selectedPresetAmount} />
+      <AddFromRow card={linkedCard} onPress={onAddFrom} />
+      <AddCashActionButton canSubmitAmount={canSubmitAmount} isKeypad={false} isProcessing={isProcessing} onHoldToAdd={onHoldToAdd} />
     </>
   );
 }
 
 function KeypadAmountContent({
   amount,
+  canSubmitAmount,
+  isProcessing,
+  linkedCard,
   onAddFrom,
   onHoldToAdd,
   onSettings,
 }: {
   amount: AddCashAmount;
+  canSubmitAmount: boolean;
+  isProcessing: boolean;
+  linkedCard: LinkedCard;
   onAddFrom: () => void;
   onHoldToAdd: () => void;
   onSettings: () => void;
@@ -246,7 +276,7 @@ function KeypadAmountContent({
         <AmountDisplay displayedAmount={amount.displayedAmount} />
       </Box>
       <KeypadFundingCaption />
-      <AddFromRow onPress={onAddFrom} />
+      <AddFromRow card={linkedCard} onPress={onAddFrom} />
       <Box as={Animated.View} entering={FadeIn.duration(160)} paddingBottom="8px">
         <NumberPad
           activeFieldId={amount.activeFieldId}
@@ -255,7 +285,7 @@ function KeypadAmountContent({
           stripFormatting={sanitizeAmount}
         />
       </Box>
-      <AddCashActionButton canSubmit={amount.canSubmit} isKeypad onHoldToAdd={onHoldToAdd} />
+      <AddCashActionButton canSubmitAmount={canSubmitAmount} isKeypad isProcessing={isProcessing} onHoldToAdd={onHoldToAdd} />
     </>
   );
 }
@@ -265,20 +295,74 @@ export const AddCashSheet = memo(function AddCashSheet() {
   const amount = useAddCashAmount(DEFAULT_SELECTED_AMOUNT);
   const { resetKeypadAmount } = amount;
 
+  const navigation = useNavigation();
+  const accountAddress = useAccountAddress();
+  const phase = useCashBuyPhase();
+  const previousPhase = usePrevious(phase);
+  const errorCode = useCashBuyOrderStore(state => state.errorCode);
+  const isProcessing = phase === 'pending';
+  const linkedCard = cashOrderService.getLinkedCard();
+
+  useEffect(() => {
+    if (previousPhase !== undefined) return;
+    // TODO(cash): Replace this block with the DES-133 pending-order flow once it is ready:
+    // https://linear.app/rainbow/issue/DES-133/if-when-creating-a-buy-cash-order-takes-a-lot-of-time
+    if (isProcessing) {
+      Alert.alert('Request Pending');
+      if (Platform.OS === 'android') {
+        // navigation.goBack() does not work immediately on Android,
+        // so this would do until we know for sure how pending-order flow
+        // is going to look like
+        setTimeout(() => navigation.goBack(), 500);
+      } else {
+        navigation.goBack();
+      }
+    } else {
+      cashBuyOrderActions.reset();
+    }
+  }, [isProcessing, navigation, previousPhase]);
+
+  useEffect(() => {
+    if (previousPhase === undefined) return;
+    if (phase === 'error') {
+      // TODO(cash): replace this Alert with an in-place error state once the design is ready.
+      Alert.alert(
+        i18n.t(i18n.l.cash.add_cash_screen.buy_error_title),
+        errorCode === 'PAYMENT_REJECTED'
+          ? i18n.t(i18n.l.cash.add_cash_screen.payment_rejected)
+          : i18n.t(i18n.l.cash.add_cash_screen.buy_error_generic)
+      );
+    }
+    if (phase === 'success') navigation.goBack();
+  }, [phase, errorCode, navigation, previousPhase]);
+
   useFocusEffect(
     useCallback(() => {
       analytics.track(analytics.event.addCashViewed);
     }, [])
   );
 
-  // Hold to Add -> create buy order. Buy pipeline lands in a later unit; inert for now.
-  const handleHoldToAdd = useCallback(() => {
-    // TODO(cash): createBuyOrder + register pending transaction once the Add Cash buy unit lands.
-  }, []);
+  // Sample the amount whenever the user taps a preset chip.
+  const handleSelectPreset = useCallback(
+    (presetAmount: number) => {
+      analytics.track(analytics.event.cashAmountEntered, { amount: String(presetAmount), entryMode: 'preset' });
+      amount.selectPresetAmount(presetAmount);
+    },
+    [amount]
+  );
 
-  // Add From -> payment-method picker. Lands with card linking; inert for now.
+  // Sample each keypad amount the user types; `canSubmit` skips the "0" reset and empty values.
+  useEffect(() => {
+    if (mode !== 'keypad' || !amount.canSubmit) return;
+    analytics.track(analytics.event.cashAmountEntered, { amount: amount.amount, entryMode: 'keypad' });
+  }, [mode, amount.canSubmit, amount.amount]);
+
+  const handleHoldToAdd = useCallback(() => {
+    cashBuyOrderActions.submitBuyOrder({ depositAmount: amount.amount, walletAddress: accountAddress });
+  }, [amount.amount, accountAddress]);
+
   const handleAddFrom = useCallback(() => {
-    // TODO(cash): open the payment-method picker once card linking lands.
+    // TODO(cash): open the payment-method picker once card linking lands (APP-3780).
   }, []);
 
   const handleSettings = useCallback(() => {
@@ -302,13 +386,25 @@ export const AddCashSheet = memo(function AddCashSheet() {
     >
       <Box background="surfaceSecondary" style={isKeypad ? styles.fullScreenContent : undefined}>
         {isKeypad ? (
-          <KeypadAmountContent amount={amount} onAddFrom={handleAddFrom} onHoldToAdd={handleHoldToAdd} onSettings={handleSettings} />
+          <KeypadAmountContent
+            amount={amount}
+            canSubmitAmount={amount.canSubmit}
+            isProcessing={isProcessing}
+            linkedCard={linkedCard}
+            onAddFrom={handleAddFrom}
+            onHoldToAdd={handleHoldToAdd}
+            onSettings={handleSettings}
+          />
         ) : (
           <PresetAmountContent
             amount={amount}
+            canSubmitAmount={amount.canSubmit}
+            isProcessing={isProcessing}
+            linkedCard={linkedCard}
             onAddFrom={handleAddFrom}
             onHoldToAdd={handleHoldToAdd}
             onMore={handleMore}
+            onSelectPreset={handleSelectPreset}
             onSettings={handleSettings}
           />
         )}

--- a/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
+++ b/src/features/cash/screens/add-cash-sheet/AddFromRow.tsx
@@ -3,10 +3,8 @@ import { StyleSheet } from 'react-native';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Inline, Text, useForegroundColor } from '@/design-system';
+import { type LinkedCard } from '@/features/cash/services/authSession';
 import * as i18n from '@/languages';
-
-// Placeholder payment method — the real "Add From" source lands with card linking.
-const MOCK_PAYMENT_METHOD = { brand: 'Visa Debit', maskedNumber: '*8990' };
 
 function VisaBadge() {
   return (
@@ -25,7 +23,7 @@ function VisaBadge() {
   );
 }
 
-export function AddFromRow({ onPress }: { onPress: () => void }) {
+export function AddFromRow({ card, onPress }: { card: LinkedCard; onPress: () => void }) {
   const separatorTertiary = useForegroundColor('separatorTertiary');
 
   return (
@@ -39,10 +37,10 @@ export function AddFromRow({ onPress }: { onPress: () => void }) {
           <Inline alignVertical="center" space="8px">
             <VisaBadge />
             <Text color="label" size="17pt" weight="bold">
-              {MOCK_PAYMENT_METHOD.brand}
+              {card.brand}
             </Text>
             <Text color="labelTertiary" size="17pt" weight="semibold">
-              {MOCK_PAYMENT_METHOD.maskedNumber}
+              {`*${card.last4}`}
             </Text>
             <Text color="labelSecondary" size="13pt" weight="heavy">
               {'􀆊'}

--- a/src/features/cash/services/authSession.ts
+++ b/src/features/cash/services/authSession.ts
@@ -1,0 +1,12 @@
+export type LinkedCard = {
+  /** Rainbow internal card token id, sent as `cardId` on a buy order. */
+  id: string;
+  /** e.g. "Visa Debit" */
+  brand: string;
+  /** e.g. "8990" (no mask prefix) */
+  last4: string;
+};
+
+export interface AuthSession {
+  getLinkedCard(): LinkedCard;
+}

--- a/src/features/cash/services/cashOrderService.ts
+++ b/src/features/cash/services/cashOrderService.ts
@@ -1,0 +1,84 @@
+import { nanoid } from 'nanoid';
+
+import { ChainId } from '@/features/network/types/backendNetworks';
+
+import { type AuthSession, type LinkedCard } from './authSession';
+import { mockAuthSession } from './mockAuthSession';
+import { mockRampClient } from './mockRampClient';
+import { RampCryptoAsset, RampNetwork, type BuyOrder, type BuyOrderSpec, type RampAsset, type RampClient } from './rampClient';
+
+export type CashOrderDestination = {
+  chainId: ChainId;
+  cryptoAsset: RampAsset;
+};
+
+export type CreateCashBuyOrderParams = {
+  depositAmount: string;
+  id: string;
+  walletAddress: string;
+};
+
+export interface CashOrderService {
+  createBuyOrder(params: CreateCashBuyOrderParams): Promise<BuyOrder>;
+  createBuyOrderSpec(params: Omit<BuyOrderSpec, 'id'>): BuyOrderSpec;
+  getDestination(): CashOrderDestination;
+  getLinkedCard(): LinkedCard;
+  getOrder(orderId: string): Promise<BuyOrder>;
+}
+
+class MockCashOrderService implements CashOrderService {
+  private readonly authSession: AuthSession;
+  private readonly destination: CashOrderDestination;
+  private readonly rampClient: RampClient;
+
+  constructor({
+    authSession,
+    destination,
+    rampClient,
+  }: {
+    authSession: AuthSession;
+    destination: CashOrderDestination;
+    rampClient: RampClient;
+  }) {
+    this.authSession = authSession;
+    this.destination = destination;
+    this.rampClient = rampClient;
+  }
+
+  createBuyOrder({ depositAmount, id, walletAddress }: BuyOrderSpec): Promise<BuyOrder> {
+    return this.rampClient.createBuyOrder({
+      cardId: this.getLinkedCard().id,
+      cryptoAsset: this.destination.cryptoAsset,
+      depositAmount,
+      id,
+      walletAddress,
+    });
+  }
+
+  createBuyOrderSpec({ depositAmount, walletAddress }: Omit<BuyOrderSpec, 'id'>): BuyOrderSpec {
+    return { depositAmount, walletAddress, id: nanoid() };
+  }
+
+  getDestination(): CashOrderDestination {
+    return this.destination;
+  }
+
+  getLinkedCard(): LinkedCard {
+    return this.authSession.getLinkedCard();
+  }
+
+  getOrder(orderId: string): Promise<BuyOrder> {
+    return this.rampClient.getOrder(orderId);
+  }
+}
+
+export const cashOrderService: CashOrderService = new MockCashOrderService({
+  authSession: mockAuthSession,
+  // For now we're hardcoding it, we might later make it configurable form firebase
+  // or allow user to pick it themselves
+  destination: {
+    chainId: ChainId.base,
+    cryptoAsset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base },
+  },
+  rampClient: mockRampClient,
+});

--- a/src/features/cash/services/mockAuthSession.ts
+++ b/src/features/cash/services/mockAuthSession.ts
@@ -1,0 +1,11 @@
+import { type AuthSession, type LinkedCard } from './authSession';
+
+export const MOCK_LINKED_CARD: LinkedCard = { id: 'mock-card-1', brand: 'Visa Debit', last4: '8990' };
+
+export class MockAuthSession implements AuthSession {
+  getLinkedCard(): LinkedCard {
+    return MOCK_LINKED_CARD;
+  }
+}
+
+export const mockAuthSession = new MockAuthSession();

--- a/src/features/cash/services/mockRampClient.ts
+++ b/src/features/cash/services/mockRampClient.ts
@@ -1,0 +1,86 @@
+import { useCashMockOrderOutcomeStore } from '@/features/cash/stores/cashMockOrderOutcomeStore';
+
+import {
+  OrderFailureReason,
+  OrderStatus,
+  RampError,
+  type BuyOrder,
+  type CreateBuyOrderParams,
+  type RampAsset,
+  type RampClient,
+} from './rampClient';
+
+export type MockRampScenario = 'success' | 'orderFailure';
+
+const SUCCESS_PATH: readonly OrderStatus[] = [OrderStatus.Pending, OrderStatus.Processing, OrderStatus.Processing, OrderStatus.Completed];
+const FAILURE_PATH: readonly OrderStatus[] = [OrderStatus.Pending, OrderStatus.Processing, OrderStatus.Failed];
+
+type MockOrderRecord = {
+  completedTime?: string;
+  createdTime: string;
+  cryptoAsset: RampAsset;
+  depositAmount: string;
+  path: readonly OrderStatus[];
+  step: number;
+};
+
+export type MockRampClientConfig = {
+  getScenario?: () => MockRampScenario;
+};
+
+/** In-memory `RampClient`. `getOrder` advances one scripted step per call. */
+export class MockRampClient implements RampClient {
+  private readonly getScenario: () => MockRampScenario;
+  private readonly orders = new Map<string, MockOrderRecord>();
+
+  constructor(config: MockRampClientConfig = {}) {
+    this.getScenario = config.getScenario ?? (() => 'success');
+  }
+
+  createBuyOrder(params: CreateBuyOrderParams): Promise<BuyOrder> {
+    // The client owns the id; a replay with a known id returns that order at its current step, never re-creating.
+    if (this.orders.has(params.id)) return Promise.resolve(this.toBuyOrder(params.id));
+
+    const path = this.getScenario() === 'orderFailure' ? FAILURE_PATH : SUCCESS_PATH;
+    this.orders.set(params.id, {
+      createdTime: new Date().toISOString(),
+      cryptoAsset: params.cryptoAsset,
+      depositAmount: params.depositAmount,
+      path,
+      step: 0,
+    });
+    return Promise.resolve(this.toBuyOrder(params.id));
+  }
+
+  getOrder(orderId: string): Promise<BuyOrder> {
+    const record = this.orders.get(orderId);
+    if (!record) return Promise.reject(new RampError(`Unknown order ${orderId}`));
+    if (record.step < record.path.length - 1) record.step += 1;
+    return Promise.resolve(this.toBuyOrder(orderId));
+  }
+
+  private toBuyOrder(orderId: string): BuyOrder {
+    const record = this.orders.get(orderId);
+    if (!record) throw new RampError(`Unknown order ${orderId}`);
+    const fiatAmount = { amount: record.depositAmount, currency: 'USD' };
+    // Mock treats USDC as 1:1 with USD; the real backend returns the quoted crypto amount.
+    const cryptoAmount = { amount: record.depositAmount, asset: record.cryptoAsset };
+    const common = { id: orderId, cryptoAmount, fiatAmount, createdTime: record.createdTime };
+    const status = record.path[record.step];
+    switch (status) {
+      case OrderStatus.Failed:
+        return { ...common, status, failureReason: OrderFailureReason.PaymentRejected };
+      case OrderStatus.Completed:
+        record.completedTime ??= new Date().toISOString();
+        return { ...common, status, transactionHash: `mock-tx-${orderId}`, completedTime: record.completedTime };
+      case OrderStatus.Processing:
+        return { ...common, status };
+      default:
+        return { ...common, status: OrderStatus.Pending };
+    }
+  }
+}
+
+export const mockRampClient = new MockRampClient({
+  getScenario: () => (useCashMockOrderOutcomeStore.getState().outcome === 'fail' ? 'orderFailure' : 'success'),
+});

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -1,0 +1,77 @@
+// ---- Wire enums (values mirror the platform `/v1/ramp` OpenAPI spec) --------
+
+export enum OrderStatus {
+  Unspecified = 'ORDER_STATUS_UNSPECIFIED',
+  Pending = 'ORDER_STATUS_PENDING',
+  Processing = 'ORDER_STATUS_PROCESSING',
+  Completed = 'ORDER_STATUS_COMPLETED',
+  Failed = 'ORDER_STATUS_FAILED',
+}
+
+export enum OrderFailureReason {
+  Unspecified = 'ORDER_FAILURE_REASON_UNSPECIFIED',
+  PaymentRejected = 'ORDER_FAILURE_REASON_PAYMENT_REJECTED',
+}
+
+export enum RampCryptoAsset {
+  Unspecified = 'CRYPTO_ASSET_UNSPECIFIED',
+  USDC = 'CRYPTO_ASSET_USDC',
+}
+
+export enum RampNetwork {
+  Unspecified = 'NETWORK_UNSPECIFIED',
+  Arbitrum = 'NETWORK_ARBITRUM',
+  Base = 'NETWORK_BASE',
+}
+
+export function isTerminalOrderStatus(status: OrderStatus): boolean {
+  return status === OrderStatus.Completed || status === OrderStatus.Failed;
+}
+
+// ---- Request / response shapes ---------------------------------------------
+
+export type RampAsset = { asset: RampCryptoAsset; network: RampNetwork };
+export type CryptoAmount = { amount: string; asset: RampAsset };
+export type FiatAmount = { amount: string; currency: string };
+
+export type BuyOrderSpec = {
+  /** Fiat amount as a decimal string, e.g. "50". */
+  depositAmount: string;
+  /** Client-generated order id. The backend adopts it as the order's id; a replay with the same id is idempotent (returns the existing order's status, never re-creates). */
+  id: string;
+  walletAddress: string;
+};
+
+export type CreateBuyOrderParams = BuyOrderSpec & {
+  cardId: string;
+  cryptoAsset: RampAsset;
+};
+
+type BuyOrderCommon = {
+  id: string;
+  cryptoAmount: CryptoAmount;
+  fiatAmount: FiatAmount;
+  /** ISO 8601 timestamp of when the order was created. */
+  createdTime: string;
+};
+
+export type BuyOrder =
+  | (BuyOrderCommon & { status: OrderStatus.Pending })
+  | (BuyOrderCommon & { status: OrderStatus.Processing })
+  | (BuyOrderCommon & { status: OrderStatus.Completed; transactionHash: string; completedTime: string })
+  | (BuyOrderCommon & { status: OrderStatus.Failed; failureReason: OrderFailureReason });
+
+export class RampError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RampError';
+  }
+}
+
+/**
+ * The seam over the platform `/v1/ramp/orders/*` surface.
+ */
+export interface RampClient {
+  createBuyOrder(params: CreateBuyOrderParams): Promise<BuyOrder>;
+  getOrder(orderId: string): Promise<BuyOrder>;
+}

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -1,0 +1,314 @@
+import { Alert } from 'react-native';
+
+import { logger } from '@/logger';
+import { rainbowStorage } from '@/state/internal/rainbowStorage';
+
+import { cashOrderService } from '../services/cashOrderService';
+import { OrderFailureReason, OrderStatus, RampCryptoAsset, RampNetwork, type BuyOrder, type BuyOrderSpec } from '../services/rampClient';
+import {
+  cashBuyOrderActions,
+  selectCashBuyPhase,
+  useCashBuyOrderStore,
+  type CashBuyErrorCode,
+  type CashBuyPhase,
+} from './cashBuyOrderStore';
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('../services/cashOrderService', () => ({
+  cashOrderService: {
+    createBuyOrder: jest.fn(),
+    createBuyOrderSpec: jest.fn(),
+    getOrder: jest.fn(),
+  },
+}));
+
+const createBuyOrder = cashOrderService.createBuyOrder as jest.Mock;
+const createBuyOrderSpec = cashOrderService.createBuyOrderSpec as jest.Mock;
+const getOrder = cashOrderService.getOrder as jest.Mock;
+
+// ---- Fixtures --------------------------------------------------------------
+
+const SPEC: BuyOrderSpec = { depositAmount: '50', id: 'order-1', walletAddress: '0xabc' };
+
+const ORDER_COMMON = {
+  id: 'order-1',
+  cryptoAmount: { amount: '50', asset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base } },
+  fiatAmount: { amount: '50', currency: 'USD' },
+  createdTime: '2026-06-24T18:31:25.000Z',
+};
+const PENDING_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Pending };
+const PROCESSING_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Processing };
+const COMPLETED_ORDER: BuyOrder = {
+  ...ORDER_COMMON,
+  status: OrderStatus.Completed,
+  transactionHash: '0xtx',
+  completedTime: '2026-06-24T18:31:31.000Z',
+};
+const FAILED_PAYMENT_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Failed, failureReason: OrderFailureReason.PaymentRejected };
+const FAILED_GENERIC_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Failed, failureReason: OrderFailureReason.Unspecified };
+
+const SUBMIT_INPUT = { depositAmount: '50', walletAddress: '0xabc' };
+
+const store = useCashBuyOrderStore;
+const getState = () => store.getState();
+const phase = () => selectCashBuyPhase(getState());
+
+let alertSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+  rainbowStorage.remove('cashBuyOrder:cashBuyOrder');
+  store.setState({ spec: null, order: null, errorCode: null });
+  createBuyOrderSpec.mockImplementation(({ depositAmount, walletAddress }) => ({ depositAmount, walletAddress, id: 'order-1' }));
+});
+
+// ---------------------------------------------------------------------------
+
+describe('selectCashBuyPhase', () => {
+  // Reads as a truth table: each row pins which (errorCode, spec, order) inputs produce which phase.
+  const ORDERS = {
+    none: null,
+    pending: PENDING_ORDER,
+    processing: PROCESSING_ORDER,
+    completed: COMPLETED_ORDER,
+    failed: FAILED_PAYMENT_ORDER,
+  } satisfies Record<string, BuyOrder | null>;
+
+  const cases: { errorCode: CashBuyErrorCode | null; spec: 'set' | 'null'; order: keyof typeof ORDERS; expected: CashBuyPhase }[] = [
+    // errorCode is the highest-priority signal — it short-circuits spec and order entirely.
+    { errorCode: 'GENERIC', /*         */ spec: 'null', order: 'none', /*      */ expected: 'error' },
+    { errorCode: 'PAYMENT_REJECTED', /**/ spec: 'null', order: 'none', /*      */ expected: 'error' },
+    { errorCode: 'GENERIC', /*         */ spec: 'set', /* */ order: 'none', /*      */ expected: 'error' },
+    { errorCode: 'GENERIC', /*         */ spec: 'null', order: 'completed', /* */ expected: 'error' },
+    // spec set + no order = a submission is in flight.
+    { errorCode: null, /*              */ spec: 'set', /* */ order: 'none', /*      */ expected: 'pending' },
+    // no spec, no error: the phase is a pure projection of the order's status.
+    { errorCode: null, /*              */ spec: 'null', order: 'none', /*      */ expected: 'idle' },
+    { errorCode: null, /*              */ spec: 'null', order: 'pending', /*   */ expected: 'pending' },
+    { errorCode: null, /*              */ spec: 'null', order: 'processing', /**/ expected: 'pending' },
+    { errorCode: null, /*              */ spec: 'null', order: 'completed', /* */ expected: 'success' },
+    { errorCode: null, /*              */ spec: 'null', order: 'failed', /*    */ expected: 'error' },
+  ];
+
+  it.each(cases)('errorCode=$errorCode, spec=$spec, order=$order → $expected', ({ errorCode, spec, order, expected }) => {
+    expect(selectCashBuyPhase({ errorCode, spec: spec === 'set' ? SPEC : null, order: ORDERS[order] })).toBe(expected);
+  });
+
+  it('logs and returns error for the impossible spec-and-order coexistence', () => {
+    expect(selectCashBuyPhase({ errorCode: null, spec: SPEC, order: PENDING_ORDER })).toBe('error');
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const loggedError = (logger.error as jest.Mock).mock.calls[0][0] as Error;
+    expect(loggedError.message).toContain('Impossible state');
+  });
+});
+
+describe('submitBuyOrder', () => {
+  it('builds a spec, creates the order, and surfaces a non-terminal order as pending', async () => {
+    createBuyOrder.mockResolvedValue(PENDING_ORDER);
+
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+
+    expect(createBuyOrderSpec).toHaveBeenCalledWith(SUBMIT_INPUT);
+    expect(createBuyOrder).toHaveBeenCalledWith(SPEC);
+    expect(getState()).toMatchObject({ order: PENDING_ORDER, spec: null, errorCode: null });
+    expect(phase()).toBe('pending');
+  });
+
+  // A created order that arrives already-terminal is stored verbatim: submit neither alerts nor maps an
+  // error code. Terminal presentation is deferred to the phase projection (and, for ongoing orders, polling).
+  const terminalOnCreate: { label: string; order: BuyOrder; expected: CashBuyPhase }[] = [
+    { label: 'completed', order: COMPLETED_ORDER, expected: 'success' },
+    { label: 'payment-rejected', order: FAILED_PAYMENT_ORDER, expected: 'error' },
+    { label: 'generically failed', order: FAILED_GENERIC_ORDER, expected: 'error' },
+  ];
+
+  it.each(terminalOnCreate)('stores a created-$label order verbatim without alerting → $expected', async ({ order, expected }) => {
+    createBuyOrder.mockResolvedValue(order);
+
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(getState()).toMatchObject({ spec: null, order, errorCode: null });
+    expect(phase()).toBe(expected);
+  });
+
+  it('clears the spec and surfaces a GENERIC error when order creation throws', async () => {
+    createBuyOrder.mockRejectedValue(new Error('network down'));
+
+    await getState().submitBuyOrder(SUBMIT_INPUT);
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(getState()).toMatchObject({ errorCode: 'GENERIC', order: null, spec: null });
+    expect(phase()).toBe('error');
+  });
+
+  it('ignores a second submission while one is already in flight', async () => {
+    let resolveOrder: (order: BuyOrder) => void = () => undefined;
+    createBuyOrder.mockReturnValue(
+      new Promise<BuyOrder>(resolve => {
+        resolveOrder = resolve;
+      })
+    );
+
+    const inFlight = getState().submitBuyOrder(SUBMIT_INPUT); // sets spec → pending, then awaits createBuyOrder
+    await getState().submitBuyOrder(SUBMIT_INPUT); // guard sees 'pending' and returns immediately
+
+    expect(createBuyOrderSpec).toHaveBeenCalledTimes(1);
+    expect(createBuyOrder).toHaveBeenCalledTimes(1);
+
+    resolveOrder(PENDING_ORDER);
+    await inFlight;
+  });
+});
+
+describe('syncActiveOrder', () => {
+  const startPolling = (order: BuyOrder) => store.setState({ spec: null, order, errorCode: null });
+
+  it('advances the order to the next non-terminal status', async () => {
+    startPolling(PENDING_ORDER);
+    getOrder.mockResolvedValue(PROCESSING_ORDER);
+
+    await getState().syncActiveOrder();
+
+    expect(getOrder).toHaveBeenCalledWith(PENDING_ORDER.id);
+    expect(getState().order).toBe(PROCESSING_ORDER);
+    expect(phase()).toBe('pending');
+  });
+
+  it('alerts and surfaces the order as success when polling resolves to completed', async () => {
+    startPolling(PROCESSING_ORDER);
+    getOrder.mockResolvedValue(COMPLETED_ORDER);
+
+    await getState().syncActiveOrder();
+
+    expect(alertSpy).toHaveBeenCalledWith('Request Successful');
+    expect(getState()).toMatchObject({ spec: null, order: COMPLETED_ORDER, errorCode: null });
+    expect(phase()).toBe('success');
+  });
+
+  it('surfaces a payment-rejected error when polling resolves to failed', async () => {
+    startPolling(PROCESSING_ORDER);
+    getOrder.mockResolvedValue(FAILED_PAYMENT_ORDER);
+
+    await getState().syncActiveOrder();
+
+    expect(getState()).toMatchObject({ errorCode: 'PAYMENT_REJECTED', order: FAILED_PAYMENT_ORDER });
+    expect(phase()).toBe('error');
+  });
+
+  it('keeps the current order and logs when polling throws', async () => {
+    startPolling(PENDING_ORDER);
+    getOrder.mockRejectedValue(new Error('timeout'));
+
+    await getState().syncActiveOrder();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(getState().order).toBe(PENDING_ORDER);
+    expect(phase()).toBe('pending');
+  });
+
+  it('does nothing when there is no active order', async () => {
+    await getState().syncActiveOrder(); // idle from beforeEach
+    expect(getOrder).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the order has already reached a terminal status', async () => {
+    store.setState({ spec: null, order: COMPLETED_ORDER, errorCode: null });
+    await getState().syncActiveOrder();
+    expect(getOrder).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the request has already been aborted', async () => {
+    startPolling(PENDING_ORDER);
+    const controller = new AbortController();
+    controller.abort();
+
+    await getState().syncActiveOrder(controller);
+
+    expect(getOrder).not.toHaveBeenCalled();
+  });
+});
+
+describe('resumePendingSubmission', () => {
+  it('replays a rehydrated spec to (idempotently) recreate the order', async () => {
+    // Mimics state restored from disk after a crash mid-submission: spec present, no order yet.
+    store.setState({ spec: SPEC, order: null, errorCode: null });
+    createBuyOrder.mockResolvedValue(PENDING_ORDER);
+
+    await getState().resumePendingSubmission();
+
+    expect(createBuyOrder).toHaveBeenCalledWith(SPEC); // same id ⇒ the backend replays, never re-creates
+    expect(getState()).toMatchObject({ order: PENDING_ORDER, spec: null });
+    expect(phase()).toBe('pending');
+  });
+
+  it('is a no-op when there is no pending spec', async () => {
+    await getState().resumePendingSubmission(); // idle from beforeEach
+    expect(createBuyOrder).not.toHaveBeenCalled();
+  });
+});
+
+describe('reset', () => {
+  it('returns the store to the idle initial state', () => {
+    store.setState({ spec: SPEC, order: FAILED_PAYMENT_ORDER, errorCode: 'GENERIC' });
+
+    getState().reset();
+
+    expect(getState()).toMatchObject({ spec: null, order: null, errorCode: null });
+    expect(phase()).toBe('idle');
+  });
+
+  it('is reachable through the exported actions bundle', () => {
+    store.setState({ spec: SPEC, order: null, errorCode: 'GENERIC' });
+
+    cashBuyOrderActions.reset();
+
+    expect(phase()).toBe('idle');
+  });
+});
+
+describe('persistence', () => {
+  const STORAGE_KEY = 'cashBuyOrder:cashBuyOrder';
+  // persistThrottleMs is 0, but the write still lands on the next macrotask — let it flush.
+  const flushPersist = () =>
+    new Promise<void>(resolve => {
+      setTimeout(resolve, 5);
+    });
+  const readPersisted = (): Record<string, unknown> => {
+    const raw = rainbowStorage.getString(STORAGE_KEY);
+    if (!raw) throw new Error('nothing persisted');
+    return (JSON.parse(raw) as { state: Record<string, unknown> }).state;
+  };
+
+  it('persists only spec and order — never the transient errorCode or any methods', async () => {
+    store.setState({ spec: SPEC, order: PENDING_ORDER, errorCode: 'GENERIC' });
+
+    await flushPersist();
+
+    const persisted = readPersisted();
+    expect(Object.keys(persisted).sort()).toEqual(['order', 'spec']);
+    expect(persisted).toEqual({ spec: SPEC, order: PENDING_ORDER });
+  });
+
+  it('keeps the spec on disk while a submission is mid-flight (crash-during-submission recovery)', async () => {
+    store.setState({ spec: SPEC, order: null, errorCode: null });
+
+    await flushPersist();
+
+    expect(readPersisted()).toEqual({ spec: SPEC, order: null });
+  });
+
+  it('keeps a non-terminal order on disk so polling can resume after a crash', async () => {
+    store.setState({ spec: null, order: PROCESSING_ORDER, errorCode: null });
+
+    await flushPersist();
+
+    expect(readPersisted()).toEqual({ spec: null, order: PROCESSING_ORDER });
+  });
+});

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -1,0 +1,141 @@
+import { Alert } from 'react-native';
+
+import { analytics } from '@/analytics';
+import { logger, RainbowError } from '@/logger';
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
+import { createStoreActions } from '@/state/internal/utils/createStoreActions';
+
+import { cashOrderService } from '../services/cashOrderService';
+import { isTerminalOrderStatus, OrderFailureReason, OrderStatus, type BuyOrder, type BuyOrderSpec } from '../services/rampClient';
+
+export type CashBuyPhase = 'idle' | 'pending' | 'error' | 'success';
+export type CashBuyErrorCode = 'PAYMENT_REJECTED' | 'GENERIC';
+
+type CashBuyOrderState = {
+  spec: BuyOrderSpec | null;
+  order: BuyOrder | null;
+  errorCode: CashBuyErrorCode | null;
+
+  submitBuyOrder: (input: { depositAmount: string; walletAddress: string }) => Promise<void>;
+  syncActiveOrder: (abortController?: AbortController) => Promise<void>;
+  resumePendingSubmission: () => Promise<void>;
+  reset: () => void;
+};
+
+const INITIAL_STATE = {
+  spec: null,
+  order: null,
+  errorCode: null,
+};
+
+/**
+ * Pure projection of the buy-order data fields onto a UI phase. Usable both inside the store
+ * (`selectCashBuyPhase(get())`) and as a React selector (`useCashBuyOrderStore(selectCashBuyPhase)`).
+ */
+export function selectCashBuyPhase(state: Pick<CashBuyOrderState, 'spec' | 'order' | 'errorCode'>): CashBuyPhase {
+  const { spec, order, errorCode } = state;
+  if (errorCode) return 'error';
+  if (spec !== null) {
+    if (order === null) return 'pending';
+    // Unreachable invariant: a spec and a resolved order should never coexist. The state is persisted,
+    // so a migration/restore bug shouldn't white-screen render — log and treat the resolved order as success.
+    logger.error(new RainbowError('[cashBuyOrderStore] Impossible state: order spec can not exist if order already exists'));
+    return 'error';
+  }
+  // at this point spec is guaranteed to be null
+  if (order === null) return 'idle';
+  if (order.status === OrderStatus.Completed) return 'success';
+  if (order.status === OrderStatus.Failed) return 'error';
+  return 'pending';
+}
+
+export const useCashBuyOrderStore = createRainbowStore<CashBuyOrderState>(
+  (set, get) => {
+    function applyTerminalOrder(order: BuyOrder): void {
+      if (order.status === OrderStatus.Completed) {
+        analytics.track(analytics.event.cashBuyOrderCompleted, {
+          orderId: order.id,
+          fiatAmount: order.fiatAmount.amount,
+          fiatCurrency: order.fiatAmount.currency,
+          cryptoAmount: order.cryptoAmount.amount,
+          network: order.cryptoAmount.asset.network,
+          timeToUsdcMs: new Date(order.completedTime).getTime() - new Date(order.createdTime).getTime(),
+        });
+        // TODO: start watching pending transaction using order transactionHash
+        Alert.alert('Request Successful');
+        set({ errorCode: null, order });
+      } else if (order.status === OrderStatus.Failed) {
+        const errorCode: CashBuyErrorCode = order.failureReason === OrderFailureReason.PaymentRejected ? 'PAYMENT_REJECTED' : 'GENERIC';
+        analytics.track(analytics.event.cashBuyOrderFailed, { orderId: order.id, failureReason: order.failureReason, errorCode });
+        set({ errorCode, order });
+      }
+    }
+
+    async function submitBuyOrderSpec(orderSpec: BuyOrderSpec): Promise<void> {
+      try {
+        const order = await cashOrderService.createBuyOrder(orderSpec);
+        set({ order, spec: null, errorCode: null });
+      } catch (error) {
+        logger.error(new RainbowError('[cashBuyOrderStore] createBuyOrder failed'), { error });
+        analytics.track(analytics.event.cashBuyOrderFailed, { orderId: orderSpec.id, failureReason: null, errorCode: 'GENERIC' });
+        set({ errorCode: 'GENERIC', order: null, spec: null });
+      }
+    }
+
+    return {
+      ...INITIAL_STATE,
+
+      submitBuyOrder: async ({ depositAmount, walletAddress }) => {
+        if (selectCashBuyPhase(get()) === 'pending') return;
+
+        analytics.track(analytics.event.cashBuyOrderSubmitted, { amount: depositAmount });
+
+        const orderSpec = cashOrderService.createBuyOrderSpec({ depositAmount, walletAddress });
+        set({ spec: orderSpec, order: null, errorCode: null });
+        await submitBuyOrderSpec(orderSpec);
+      },
+
+      syncActiveOrder: async abortController => {
+        const { order } = get();
+        if (selectCashBuyPhase(get()) !== 'pending' || !order || isTerminalOrderStatus(order.status)) return;
+        if (abortController?.signal.aborted || get().order?.id !== order.id) return;
+
+        try {
+          const next = await cashOrderService.getOrder(order.id);
+          if (isTerminalOrderStatus(next.status)) {
+            applyTerminalOrder(next);
+          } else {
+            set({ order: next });
+          }
+        } catch (error) {
+          // Transient poll failure; retry on the watcher's next tick.
+          logger.error(new RainbowError('[cashBuyOrderStore] getOrder failed'), { error });
+        }
+      },
+
+      resumePendingSubmission: async () => {
+        const { spec: orderSpec } = get();
+        if (orderSpec !== null) await submitBuyOrderSpec(orderSpec);
+      },
+
+      reset: () => set({ ...INITIAL_STATE }),
+    };
+  },
+  {
+    storageKey: 'cashBuyOrder',
+    version: 0,
+    // Flush the submit intent on the next tick rather than the default 3-5s debounce, so a kill shortly
+    // after submit can still be recovered. (Not a hard guarantee: a same-frame crash can still beat it.)
+    persistThrottleMs: 0,
+    // Persist only the fail-recovery fields, dropping the transient `errorCode`:
+    // - `spec` is needed if the app fails during spec submission, before we know whether the order
+    //   reached the backend — on restart we replay it (idempotently) via `resumePendingSubmission`.
+    // - `order` is needed if the app fails after the order is created but before it resolves to a
+    //   success status carrying a `transactionHash` — on restart we keep polling it to terminal status.
+    partialize: state => ({ spec: state.spec, order: state.order }),
+  }
+);
+
+export const cashBuyOrderActions = createStoreActions(useCashBuyOrderStore);
+
+export const useCashBuyPhase = () => useCashBuyOrderStore(selectCashBuyPhase);

--- a/src/features/cash/stores/cashMockOrderOutcomeStore.ts
+++ b/src/features/cash/stores/cashMockOrderOutcomeStore.ts
@@ -1,0 +1,19 @@
+import { createRainbowStore } from '@/state/internal/createRainbowStore';
+
+/** Dev-only switch for the mock buy-order outcome. Removed when real ramp endpoints land */
+export const CASH_MOCK_ORDER_OUTCOMES = ['succeed', 'fail'] as const;
+export type CashMockOrderOutcome = (typeof CASH_MOCK_ORDER_OUTCOMES)[number];
+
+export function isCashMockOrderOutcome(value: string): value is CashMockOrderOutcome {
+  return CASH_MOCK_ORDER_OUTCOMES.some(outcome => outcome === value);
+}
+
+type CashMockOrderOutcomeStore = {
+  outcome: CashMockOrderOutcome;
+  setOutcome: (outcome: CashMockOrderOutcome) => void;
+};
+
+export const useCashMockOrderOutcomeStore = createRainbowStore<CashMockOrderOutcomeStore>(set => ({
+  outcome: 'succeed',
+  setOutcome: outcome => set({ outcome }),
+}));

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -17,6 +17,12 @@ import {
   type CashDepositSetupStatus,
 } from '@/features/cash/stores/cashDepositSetupStatus';
 import { useCashDepositSetupStore } from '@/features/cash/stores/cashDepositSetupStore';
+import {
+  CASH_MOCK_ORDER_OUTCOMES,
+  isCashMockOrderOutcome,
+  useCashMockOrderOutcomeStore,
+  type CashMockOrderOutcome,
+} from '@/features/cash/stores/cashMockOrderOutcomeStore';
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from '@/features/config/constants/experimental';
 import { useExperimentalConfigStore } from '@/features/config/stores/experimentalConfigStore';
 import { getDelegationContractAddress, isRainbowDelegated, isThirdPartyDelegated } from '@/features/delegation/status';
@@ -88,6 +94,46 @@ function CashDepositSetupStatusMenuItem() {
         size={52}
         testID="cash-deposit-setup-status-select"
         titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_deposit_setup_status.title)} />}
+      />
+    </ContextMenuButton>
+  );
+}
+
+// Dev-only select that drives the mock buy-order outcome (success vs PAYMENT_REJECTED failure).
+function CashMockOrderOutcomeMenuItem() {
+  const outcome = useCashMockOrderOutcomeStore(state => state.outcome);
+  const setOutcome = useCashMockOrderOutcomeStore(state => state.setOutcome);
+
+  const outcomeLabel = useCallback((value: CashMockOrderOutcome) => i18n.t(i18n.l.developer_settings.cash_order_outcome[value]), []);
+
+  const menuConfig = useMemo<MenuConfig>(
+    () => ({
+      menuTitle: i18n.t(i18n.l.developer_settings.cash_order_outcome.title),
+      menuItems: CASH_MOCK_ORDER_OUTCOMES.map(value => ({
+        actionKey: value,
+        actionTitle: outcomeLabel(value),
+        menuState: value === outcome ? 'on' : 'off',
+      })),
+    }),
+    [outcome, outcomeLabel]
+  );
+
+  const onPressMenuItem = useCallback(
+    ({ nativeEvent: { actionKey } }: { nativeEvent: { actionKey: string } }) => {
+      if (isCashMockOrderOutcome(actionKey)) setOutcome(actionKey);
+    },
+    [setOutcome]
+  );
+
+  return (
+    <ContextMenuButton menuConfig={menuConfig} isMenuPrimaryAction onPressMenuItem={onPressMenuItem} useActionSheetFallback={false}>
+      <MenuItem
+        hasChevron
+        leftComponent={<MenuItem.TextIcon icon="🧪" isEmoji />}
+        rightComponent={<MenuItem.Selection>{outcomeLabel(outcome)}</MenuItem.Selection>}
+        size={52}
+        testID="cash-mock-order-outcome-select"
+        titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_order_outcome.title)} />}
       />
     </ContextMenuButton>
   );
@@ -516,6 +562,7 @@ export const DevSection = () => {
           </Menu>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.cash_settings)}>
             <CashDepositSetupStatusMenuItem />
+            <CashMockOrderOutcomeMenuItem />
           </Menu>
           <Menu header={i18n.t(i18n.l.developer_settings.headers.feature_flags)}>
             {(Object.keys(config) as ExperimentalConfigKey[])

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -508,6 +508,11 @@
         "needsWallet": "Needs Wallet",
         "ready": "Ready"
       },
+      "cash_order_outcome": {
+        "title": "Cash order outcome",
+        "succeed": "Will succeed",
+        "fail": "Will fail"
+      },
       "status": "Status",
       "sync_codepush": "Sync CodePush",
       "simulate_device_transfer": "Simulate Device Transfer",
@@ -1670,7 +1675,11 @@
         "hold_to_add": "Hold to Add",
         "enter_amount": "Enter Amount",
         "money_is_added_in": "Money is added in",
-        "usdc": "USDC"
+        "usdc": "USDC",
+        "adding_cash": "Adding Cash",
+        "buy_error_title": "Purchase Failed",
+        "buy_error_generic": "Something went wrong. Try again",
+        "payment_rejected": "Your card declined this payment"
       }
     },
     "points": {

--- a/src/navigation/SwipeNavigator.tsx
+++ b/src/navigation/SwipeNavigator.tsx
@@ -50,6 +50,7 @@ import {
 import { TabBarIcon } from '@/components/tab-bar/TabBarIcon';
 import { Box, ColorModeProvider, Column, Columns, globalColors, useColorMode } from '@/design-system';
 import { IS_TEST } from '@/env';
+import { CashBuyOrderWatcher } from '@/features/cash/components/CashBuyOrderWatcher';
 import { DAPP_BROWSER, LAZY_TABS, RNBW_MEMBERSHIP, RNBW_REWARDS } from '@/features/config/constants/experimental';
 import { useExperimentalFlag } from '@/features/config/hooks/experimentalHooks';
 import { useRemoteConfig } from '@/features/config/stores/remoteConfig';
@@ -743,6 +744,7 @@ export function SwipeNavigator() {
 
       <PendingTransactionWatcher />
       <AssetUpdateTransactionWatcher />
+      <CashBuyOrderWatcher />
     </FlexItem>
   );
 }


### PR DESCRIPTION
Fixes APP-3779

## Why?

This lands the first working slice of the cash buy flow end-to-end against mocks: holding to add now creates a buy order and monitors it to a terminal state, exercising the full order lifecycle (submit → poll → success/failure) before the real ramp API exists.

The order surface is typed from the platform `/v1/ramp` OpenAPI spec and hidden behind a `RampClient` seam, so everything above it depends only on the contract — dropping in the real client later is an implementation detail. And because a buy moves money, the submit intent is persisted and recovered across an app kill or reload.

## Approach

- **Seam + mocks.** `RampClient` is a thin interface over the ramp order surface, with order types mirroring the spec's enums and shapes. `MockRampClient` scripts an order through `PENDING → PROCESSING → COMPLETED / FAILED`, `MockAuthSession` supplies a linked card, and `cashOrderService` composes them so no UI or state code knows it's talking to mocks.
- **Lifecycle + recovery.** The order store generates the order id client-side and persists it (with the submitted amount) before the create call, so a response lost to a crash is replayed idempotently on next launch. An app-level watcher polls the active order to a terminal status regardless of which screen is open.
- **Feature-owned USDC metadata.** The backend returns only asset/network enums, never the on-chain address, so the cash feature owns the USDC deployment table and the builder that turns a completed order into a pending purchase transaction — as perps and polymarket own their deposit token.
- **Placeholder UX.** Success, pending, and failure (payment-rejected vs generic) currently surface as alerts, pending the DES-133 pending-order design Low. A dev-only switch in Settings forces the mock success or failure path for QA.

## Visuals

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-06-23 at 18.38.43.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/071eabd0-2332-426d-a091-645d7efd352a.mov" />](https://app.graphite.com/user-attachments/video/071eabd0-2332-426d-a091-645d7efd352a.mov) | [untitled.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/80250615-b054-4f96-af00-687ad160035f.webm" />](https://app.graphite.com/user-attachments/video/80250615-b054-4f96-af00-687ad160035f.webm) |

## Testing

- Pick a preset or enter a custom amount, then hold **Add Cash** — the order goes pending and then resolves.
- Settings → Developer: flip the mock buy-order outcome to **fail** and confirm the failure alert (payment-rejected vs generic).
- Hold to add, then kill and relaunch mid-request — the pending order is recovered, not lost.