### PR TITLE
fix(e2e): Anvil forking broken due to Alchemy issue

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -22,7 +22,6 @@ declare module 'react-native-dotenv' {
   export const ENABLE_DEV_MODE: '0' | '1';
   export const SENTRY_ENDPOINT: string;
   export const ADDYS_API_KEY: string;
-  export const ETHEREUM_MAINNET_RPC_DEV: string;
   export const IMGIX_DOMAIN: string;
   export const IMGIX_TOKEN: string;
   export const CLOUDINARY_CLOUD_NAME: string;

--- a/scripts/anvil.sh
+++ b/scripts/anvil.sh
@@ -14,9 +14,15 @@ else
   exit 1
 fi
 
+if [ -z "$RPC_PROXY_BASE_URL_PROD" ] || [ -z "$RPC_PROXY_API_KEY_PROD" ]; then
+  echo "ERROR: RPC_PROXY_BASE_URL_PROD / RPC_PROXY_API_KEY_PROD missing from .env"
+  exit 1
+fi
+FORK_URL="$RPC_PROXY_BASE_URL_PROD/1/$RPC_PROXY_API_KEY_PROD"
+
 # Run anvil, passing through any flags from the calling script
 # NOTE: Fork block should be updated periodically (e.g., monthly) to ensure
 # Rainbow Router's swapTargets authorization list includes current DEX targets.
 # Stale blocks cause TARGET_NOT_AUTH errors in swap e2e tests.
 # Last updated: 2025-01-28 (block 24333000)
-anvil --fork-url "$ETHEREUM_MAINNET_RPC_DEV" --fork-block-number 24333000 --block-base-fee-per-gas 100000000 --block-gas-limit 30000000 --steps-tracing "$@"
+anvil --fork-url "$FORK_URL" --fork-block-number 24333000 --block-base-fee-per-gas 100000000 --block-gas-limit 30000000 --steps-tracing "$@"


### PR DESCRIPTION
Our e2e suite is currently failing on every PR due to Alchemy issues, because the Anvil fork request returns `403`. With no fork, the test wallet's funded balance never loads, which is what surfaces downstream as assertion failures.

With this change Anvil now forks from the `rpc.rainbow.me` proxy reusing the proxy env vars the app already relies on. The proxy serves archive state at our pinned fork block, so Anvil boots and the transaction tests can run again. 

Because it abstracts the provider, a future provider migration shouldn't silently break e2e the way this one did. A guard now fails loudly if the proxy vars are missing, so a misconfiguration shows a clear error instead of a malformed fork URL; the now-unused Alchemy env var is dropped.