### PR TITLE
feat(cash): handle succefull buy order

### DIFF
--- a/e2e/flows/cash/AddCashChips.yaml
+++ b/e2e/flows/cash/AddCashChips.yaml
@@ -36,12 +36,19 @@ tags:
     id: cash-deposit-add-cash-amount-100
 - longPressOn:
     id: cash-deposit-add-cash-hold-to-add
-# On completion the order watcher surfaces the "Request Successful" alert; dismissing it returns to home.
+# On completion the sheet closes back to home; wait for that before switching tabs.
 - extendedWaitUntil:
     visible:
-      text: 'Request Successful'
-    timeout: 10000
+      id: buy-button
+    timeout: 20000
+# The tab bar has no testID, so tap the Activity tab by coordinate.
+- runScript:
+    file: ../../utils/coordinates.js
 - tapOn:
-    text: 'OK'
+    point: ${output.tabCoordinates.activityTab}
+- extendedWaitUntil:
+    visible:
+      text: 'Purchased'
+    timeout: 30000
 - assertVisible:
-    id: buy-button
+    text: '.*\+\$100.*'

--- a/e2e/flows/cash/AddCashCustomAmount.yaml
+++ b/e2e/flows/cash/AddCashCustomAmount.yaml
@@ -51,12 +51,19 @@ tags:
 # The mock advances one status per ~2s poll: Pending -> Processing -> Processing -> Completed (~6s total).
 - longPressOn:
     id: cash-deposit-add-cash-hold-to-add
-# On completion the order watcher surfaces the "Request Successful" alert; dismissing it returns to home.
+# On completion the sheet closes back to home; wait for that before switching tabs.
 - extendedWaitUntil:
     visible:
-      text: 'Request Successful'
-    timeout: 10000
+      id: buy-button
+    timeout: 20000
+# The tab bar has no testID, so tap the Activity tab by coordinate.
+- runScript:
+    file: ../../utils/coordinates.js
 - tapOn:
-    text: 'OK'
+    point: ${output.tabCoordinates.activityTab}
+- extendedWaitUntil:
+    visible:
+      text: 'Purchased'
+    timeout: 30000
 - assertVisible:
-    id: buy-button
+    text: '.*\+\$5.*'

--- a/src/components/rainbow-toast/useRainbowToastsStore.ts
+++ b/src/components/rainbow-toast/useRainbowToastsStore.ts
@@ -7,7 +7,8 @@ import type { RainbowToast } from '@/components/rainbow-toast/types';
 import type { RainbowTransaction } from '@/entities/transactions';
 
 function toToastId(tx: RainbowTransaction): string {
-  const identity = tx.relayExecutionId ?? (tx.nonce !== null && tx.nonce !== undefined ? String(tx.nonce) : tx.hash);
+  const hasWalletNonce = tx.nonce !== null && tx.nonce !== undefined && tx.nonce >= 0;
+  const identity = tx.relayExecutionId ?? (hasWalletNonce ? String(tx.nonce) : tx.hash);
 
   return `${identity}-${tx.chainId || tx.asset?.chainId}`;
 }

--- a/src/features/cash/constants.ts
+++ b/src/features/cash/constants.ts
@@ -1,7 +1,21 @@
 import { time } from '@/framework/core/utils/time';
 
+import { RampNetwork } from './services/rampClient';
+
 export const USDC_NAME = 'USD Coin';
 export const USDC_SYMBOL = 'USDC';
 export const USDC_DECIMALS = 6;
 
 export const ORDER_POLL_INTERVAL_MS = time.seconds(2);
+
+/**
+ * USDC deployments the ramp can deposit to, keyed by the wire `RampNetwork`. The
+ * backend returns only the asset/network enums, never the on-chain address, so the
+ * cash feature owns it — as perps (HYPERLIQUID_USDC_ADDRESS) and polymarket
+ * (POLYGON_USDC_ADDRESS) own theirs. `chainName` resolves to a ChainId at call time
+ * via the backend networks store.
+ */
+export const CASH_USDC_BY_NETWORK: Partial<Record<RampNetwork, { chainName: string; address: string }>> = {
+  [RampNetwork.Arbitrum]: { chainName: 'arbitrum', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+  [RampNetwork.Base]: { chainName: 'base', address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' },
+};

--- a/src/features/cash/services/mockRampClient.ts
+++ b/src/features/cash/services/mockRampClient.ts
@@ -22,6 +22,7 @@ type MockOrderRecord = {
   depositAmount: string;
   path: readonly OrderStatus[];
   step: number;
+  walletAddress: string;
 };
 
 export type MockRampClientConfig = {
@@ -48,6 +49,7 @@ export class MockRampClient implements RampClient {
       depositAmount: params.depositAmount,
       path,
       step: 0,
+      walletAddress: params.walletAddress,
     });
     return Promise.resolve(this.toBuyOrder(params.id));
   }
@@ -65,7 +67,7 @@ export class MockRampClient implements RampClient {
     const fiatAmount = { amount: record.depositAmount, currency: 'USD' };
     // Mock treats USDC as 1:1 with USD; the real backend returns the quoted crypto amount.
     const cryptoAmount = { amount: record.depositAmount, asset: record.cryptoAsset };
-    const common = { id: orderId, cryptoAmount, fiatAmount, createdTime: record.createdTime };
+    const common = { id: orderId, cryptoAmount, fiatAmount, walletAddress: record.walletAddress, createdTime: record.createdTime };
     const status = record.path[record.step];
     switch (status) {
       case OrderStatus.Failed:

--- a/src/features/cash/services/rampClient.ts
+++ b/src/features/cash/services/rampClient.ts
@@ -53,6 +53,7 @@ type BuyOrderCommon = {
   fiatAmount: FiatAmount;
   /** ISO 8601 timestamp of when the order was created. */
   createdTime: string;
+  walletAddress: string;
 };
 
 export type BuyOrder =

--- a/src/features/cash/stores/cashBuyOrderStore.test.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.test.ts
@@ -1,9 +1,9 @@
-import { Alert } from 'react-native';
-
 import { logger } from '@/logger';
+import { pendingTransactionsActions } from '@/state/pendingTransactions';
 
 import { cashOrderService } from '../services/cashOrderService';
 import { OrderFailureReason, OrderStatus, RampCryptoAsset, RampNetwork, type BuyOrder, type BuyOrderSpec } from '../services/rampClient';
+import { buildCashPurchaseTransaction } from '../utils/buildCashPurchaseTransaction';
 import {
   cashBuyOrderActions,
   selectCashBuyPhase,
@@ -25,9 +25,21 @@ jest.mock('../services/cashOrderService', () => ({
   },
 }));
 
+jest.mock('@/state/pendingTransactions', () => ({
+  pendingTransactionsActions: { addPendingTransaction: jest.fn() },
+}));
+
+jest.mock('../utils/buildCashPurchaseTransaction', () => ({
+  buildCashPurchaseTransaction: jest.fn(),
+}));
+
 const createBuyOrder = cashOrderService.createBuyOrder as jest.Mock;
 const createBuyOrderSpec = cashOrderService.createBuyOrderSpec as jest.Mock;
 const getOrder = cashOrderService.getOrder as jest.Mock;
+const addPendingTransaction = pendingTransactionsActions.addPendingTransaction as jest.Mock;
+const buildPurchaseTransaction = buildCashPurchaseTransaction as jest.Mock;
+
+const PURCHASE_TRANSACTION = { hash: '0xtx', type: 'purchase' };
 
 // ---- Fixtures --------------------------------------------------------------
 
@@ -38,6 +50,7 @@ const ORDER_COMMON = {
   cryptoAmount: { amount: '50', asset: { asset: RampCryptoAsset.USDC, network: RampNetwork.Base } },
   fiatAmount: { amount: '50', currency: 'USD' },
   createdTime: '2026-06-24T18:31:25.000Z',
+  walletAddress: '0xabc',
 };
 const PENDING_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Pending };
 const PROCESSING_ORDER: BuyOrder = { ...ORDER_COMMON, status: OrderStatus.Processing };
@@ -56,13 +69,11 @@ const store = useCashBuyOrderStore;
 const getState = () => store.getState();
 const phase = () => selectCashBuyPhase(getState());
 
-let alertSpy: jest.SpyInstance;
-
 beforeEach(() => {
   jest.clearAllMocks();
-  alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
   store.setState({ spec: null, order: null, errorCode: null });
   createBuyOrderSpec.mockImplementation(({ depositAmount, walletAddress }) => ({ depositAmount, walletAddress, id: 'order-1' }));
+  buildPurchaseTransaction.mockReturnValue(PURCHASE_TRANSACTION);
 });
 
 // ---------------------------------------------------------------------------
@@ -118,20 +129,20 @@ describe('submitBuyOrder', () => {
     expect(phase()).toBe('pending');
   });
 
-  // A created order that arrives already-terminal is stored verbatim: submit neither alerts nor maps an
-  // error code. Terminal presentation is deferred to the phase projection (and, for ongoing orders, polling).
+  // A created order that arrives already-terminal is stored verbatim: submit neither enqueues a pending
+  // transaction nor maps an error code. Terminal handling is deferred to polling (`syncActiveOrder`).
   const terminalOnCreate: { label: string; order: BuyOrder; expected: CashBuyPhase }[] = [
     { label: 'completed', order: COMPLETED_ORDER, expected: 'success' },
     { label: 'payment-rejected', order: FAILED_PAYMENT_ORDER, expected: 'error' },
     { label: 'generically failed', order: FAILED_GENERIC_ORDER, expected: 'error' },
   ];
 
-  it.each(terminalOnCreate)('stores a created-$label order verbatim without alerting → $expected', async ({ order, expected }) => {
+  it.each(terminalOnCreate)('stores a created-$label order verbatim without enqueuing → $expected', async ({ order, expected }) => {
     createBuyOrder.mockResolvedValue(order);
 
     await getState().submitBuyOrder(SUBMIT_INPUT);
 
-    expect(alertSpy).not.toHaveBeenCalled();
+    expect(addPendingTransaction).not.toHaveBeenCalled();
     expect(getState()).toMatchObject({ spec: null, order, errorCode: null });
     expect(phase()).toBe(expected);
   });
@@ -179,13 +190,17 @@ describe('syncActiveOrder', () => {
     expect(phase()).toBe('pending');
   });
 
-  it('alerts and surfaces the order as success when polling resolves to completed', async () => {
+  it('enqueues the purchase transaction and surfaces the order as success when polling resolves to completed', async () => {
     startPolling(PROCESSING_ORDER);
     getOrder.mockResolvedValue(COMPLETED_ORDER);
 
     await getState().syncActiveOrder();
 
-    expect(alertSpy).toHaveBeenCalledWith('Request Successful');
+    expect(buildPurchaseTransaction).toHaveBeenCalledWith({ order: COMPLETED_ORDER, walletAddress: COMPLETED_ORDER.walletAddress });
+    expect(addPendingTransaction).toHaveBeenCalledWith({
+      address: COMPLETED_ORDER.walletAddress,
+      pendingTransaction: PURCHASE_TRANSACTION,
+    });
     expect(getState()).toMatchObject({ spec: null, order: COMPLETED_ORDER, errorCode: null });
     expect(phase()).toBe('success');
   });

--- a/src/features/cash/stores/cashBuyOrderStore.ts
+++ b/src/features/cash/stores/cashBuyOrderStore.ts
@@ -1,12 +1,12 @@
-import { Alert } from 'react-native';
-
 import { createBaseStore, createStoreActions } from '@storesjs/stores';
 
 import { analytics } from '@/analytics';
 import { logger, RainbowError } from '@/logger';
+import { pendingTransactionsActions } from '@/state/pendingTransactions';
 
 import { cashOrderService } from '../services/cashOrderService';
 import { isTerminalOrderStatus, OrderFailureReason, OrderStatus, type BuyOrder, type BuyOrderSpec } from '../services/rampClient';
+import { buildCashPurchaseTransaction } from '../utils/buildCashPurchaseTransaction';
 
 export type CashBuyPhase = 'idle' | 'pending' | 'error' | 'success';
 export type CashBuyErrorCode = 'PAYMENT_REJECTED' | 'GENERIC';
@@ -61,8 +61,17 @@ export const useCashBuyOrderStore = createBaseStore<CashBuyOrderState>(
           network: order.cryptoAmount.asset.network,
           timeToUsdcMs: new Date(order.completedTime).getTime() - new Date(order.createdTime).getTime(),
         });
-        // TODO: start watching pending transaction using order transactionHash
-        Alert.alert('Request Successful');
+        try {
+          pendingTransactionsActions.addPendingTransaction({
+            address: order.walletAddress,
+            pendingTransaction: buildCashPurchaseTransaction({ order, walletAddress: order.walletAddress }),
+          });
+        } catch (error) {
+          logger.error(new RainbowError('[cashBuyOrderStore] failed to enqueue purchase transaction', { error }), {
+            orderId: order.id,
+            transactionHash: order.transactionHash,
+          });
+        }
         set({ errorCode: null, order });
       } else if (order.status === OrderStatus.Failed) {
         const errorCode: CashBuyErrorCode = order.failureReason === OrderFailureReason.PaymentRejected ? 'PAYMENT_REJECTED' : 'GENERIC';

--- a/src/features/cash/utils/buildCashPurchaseTransaction.ts
+++ b/src/features/cash/utils/buildCashPurchaseTransaction.ts
@@ -1,0 +1,73 @@
+import { buildTransactionTitle, TransactionDirection, TransactionStatus, type RainbowTransaction } from '@/entities/transactions';
+import { supportedCurrencies } from '@/features/currency/supportedCurrencies';
+import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
+import { convertAmountToRawAmount, convertRawAmountToBalance } from '@/helpers/utilities';
+import { getUniqueId } from '@/utils/ethereumUtils';
+import getUrlForTrustIconFallback from '@/utils/getUrlForTrustIconFallback';
+
+import { CASH_USDC_BY_NETWORK, USDC_DECIMALS, USDC_NAME, USDC_SYMBOL } from '../constants';
+import { RampError, type BuyOrder, type OrderStatus } from '../services/rampClient';
+
+type CompletedBuyOrder = Extract<BuyOrder, { status: OrderStatus.Completed }>;
+
+export function buildCashPurchaseTransaction({
+  order,
+  walletAddress,
+}: {
+  order: CompletedBuyOrder;
+  walletAddress: string;
+}): RainbowTransaction {
+  const status = TransactionStatus.pending;
+
+  const { network: rampNetwork } = order.cryptoAmount.asset;
+  const usdc = CASH_USDC_BY_NETWORK[rampNetwork];
+  if (!usdc) throw new RampError(`Unsupported ramp network: ${rampNetwork}`);
+
+  const { address } = usdc;
+  const { getChainsIdByName, getChainsName } = useBackendNetworksStore.getState();
+  const chainId = getChainsIdByName()[usdc.chainName];
+  if (!chainId) throw new RampError(`Missing backend chain id mapping for: ${usdc.chainName}`);
+  const network = getChainsName()[chainId];
+  if (!network) throw new RampError(`Missing backend chain name mapping for chainId: ${String(chainId)}`);
+  const fiatSymbol = supportedCurrencies[order.fiatAmount.currency as keyof typeof supportedCurrencies]?.symbol ?? '';
+  const rawCryptoAmount = convertAmountToRawAmount(order.cryptoAmount.amount, USDC_DECIMALS);
+  const asset = {
+    address,
+    balance: convertRawAmountToBalance(rawCryptoAmount, { decimals: USDC_DECIMALS, symbol: USDC_SYMBOL }),
+    chainId,
+    decimals: USDC_DECIMALS,
+    icon_url: getUrlForTrustIconFallback(address, chainId) ?? undefined,
+    name: USDC_NAME,
+    network,
+    price: {
+      value: 1,
+    },
+    symbol: USDC_SYMBOL,
+    uniqueId: getUniqueId(address, chainId),
+  };
+
+  return {
+    amount: order.cryptoAmount.amount,
+    asset,
+    chainId,
+    changes: [
+      {
+        address_to: walletAddress,
+        asset,
+        direction: TransactionDirection.IN,
+        price: 1,
+        value: rawCryptoAmount,
+      },
+    ],
+    description: `${fiatSymbol}${order.fiatAmount.amount}`,
+    direction: TransactionDirection.IN,
+    from: null,
+    hash: order.transactionHash,
+    network,
+    nonce: null,
+    status,
+    title: buildTransactionTitle('purchase', status),
+    to: walletAddress,
+    type: 'purchase',
+  };
+}

--- a/src/features/cash/utils/mockCashTransactionByHash.ts
+++ b/src/features/cash/utils/mockCashTransactionByHash.ts
@@ -1,0 +1,123 @@
+import { TransactionStatus, type RainbowTransaction } from '@/entities/transactions';
+import { type NativeCurrencyKey } from '@/features/currency/types';
+import { backendNetworksActions } from '@/features/network/stores/backendNetworksStore';
+import { type ChainId } from '@/features/network/types/backendNetworks';
+import {
+  type Asset,
+  type GetTransactionByHashResponse,
+  type Transaction,
+} from '@/features/positions/types/generated/transaction/transaction';
+import { time } from '@/framework/core/utils/time';
+import { convertAmountToRawAmount } from '@/helpers/utilities';
+import { parseTransaction } from '@/parsers/transactions';
+
+const MOCK_CASH_TRANSACTION_HASH_PREFIX = 'mock-tx-';
+const MOCK_CASH_USDC_ADDRESS = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const MOCK_CASH_USDC_AMOUNT = '25';
+const MOCK_CASH_USDC_DECIMALS = 6;
+
+export async function getMockCashTransactionByHash({
+  address,
+  currency,
+  chainId,
+  hash,
+}: {
+  address: string;
+  currency: NativeCurrencyKey;
+  chainId: ChainId;
+  hash: string;
+}): Promise<RainbowTransaction | null> {
+  if (!hash.startsWith(MOCK_CASH_TRANSACTION_HASH_PREFIX)) return Promise.resolve(null);
+
+  const network = backendNetworksActions.getChainsName()[chainId] || 'base';
+  const rawAmount = convertAmountToRawAmount(MOCK_CASH_USDC_AMOUNT, MOCK_CASH_USDC_DECIMALS);
+  const response: GetTransactionByHashResponse = {
+    errors: [],
+    metadata: undefined,
+    result: {
+      addressFrom: '0x0000000000000000000000000000000000000000',
+      addressTo: address,
+      blockConfirmations: 1,
+      blockNumber: 1,
+      callData: new Uint8Array(),
+      chainId: String(chainId),
+      changes: [
+        {
+          addressFrom: '0x0000000000000000000000000000000000000000',
+          addressTo: address,
+          asset: buildMockUsdcAsset({ chainId, network }),
+          direction: 'in',
+          price: '1',
+          quantity: rawAmount,
+          value: rawAmount,
+        },
+      ],
+      direction: 'in',
+      fee: undefined,
+      hash,
+      id: hash,
+      meta: {
+        action: 'Purchased',
+        approvalTo: '',
+        asset: buildMockUsdcAsset({ chainId, network }),
+        contractIconUrl: '',
+        contractName: '',
+        explorerLabel: '',
+        explorerUrl: '',
+        fourbyte: '',
+        publicSubType: '',
+        quantity: MOCK_CASH_USDC_AMOUNT,
+        subType: '',
+        type: 'purchase',
+      },
+      minedAt: new Date(),
+      network,
+      nonce: -2,
+      status: TransactionStatus.confirmed,
+      type: 'purchase',
+    },
+  };
+
+  await new Promise(resolve => {
+    setTimeout(resolve, time.seconds(5));
+  });
+  return parseTransaction(response.result as Transaction, currency, chainId);
+}
+
+function buildMockUsdcAsset({ chainId, network }: { chainId: ChainId; network: string }): Asset {
+  return {
+    assetCode: MOCK_CASH_USDC_ADDRESS,
+    bridging: undefined,
+    chainId: String(chainId),
+    colors: undefined,
+    creationDate: undefined,
+    decimals: 6,
+    defiPosition: false,
+    hasTransferable: true,
+    iconUrl: '',
+    interface: 'ERC20',
+    name: 'USD Coin',
+    network,
+    networks: [
+      {
+        chainId: String(chainId),
+        tokenMapping: {
+          address: MOCK_CASH_USDC_ADDRESS,
+          decimals: 6,
+        },
+      },
+    ],
+    price: {
+      changedAt: new Date(),
+      relativeChange24h: '0',
+      value: '1',
+    },
+    probableSpam: false,
+    symbol: 'USDC',
+    tokenId: '',
+    transferable: true,
+    trash: false,
+    type: 'erc20',
+    verified: true,
+  };
+}

--- a/src/hooks/pendingTransactionResolution.test.ts
+++ b/src/hooks/pendingTransactionResolution.test.ts
@@ -254,6 +254,52 @@ describe('pendingTransactionResolution', () => {
     });
   });
 
+  it('preserves local purchase display metadata when the fetched onchain transaction confirms', async () => {
+    const originalTransaction = {
+      ...buildPurchasePendingTransaction(),
+      amount: '25',
+      description: '$25',
+    };
+    mockFetchRawTransaction.mockResolvedValue({
+      ...buildPurchasePendingTransaction(),
+      asset: {
+        address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        chainId: 8453,
+        decimals: 6,
+        name: 'USD Coin',
+        network: 'base',
+        symbol: 'USDC',
+        uniqueId: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913_8453',
+      },
+      blockNumber: 1,
+      confirmations: 1,
+      description: 'USD Coin',
+      minedAt: 100,
+      nonce: -2,
+      status: TransactionStatus.confirmed,
+      title: 'purchase.confirmed',
+    });
+
+    const resolution = await resolveTrackedTransaction({
+      abortController: null,
+      address: '0x123',
+      currency: 'ETH',
+      transaction: originalTransaction,
+    });
+
+    expect(resolution).toEqual({
+      kind: 'settled',
+      transaction: expect.objectContaining({
+        amount: '25',
+        description: '$25',
+        hash: 'mock-tx-order-1',
+        nonce: null,
+        status: TransactionStatus.confirmed,
+        title: 'purchase.confirmed',
+      }),
+    });
+  });
+
   it('settles a managed failure after an onchain hash exists', async () => {
     mockGetStatus.mockResolvedValue(
       buildRelayStatus({
@@ -434,6 +480,21 @@ function buildOnchainPendingTransaction() {
     title: 'swap.pending',
     to: null,
     type: 'swap' as const,
+  };
+}
+
+function buildPurchasePendingTransaction() {
+  return {
+    asset: null,
+    chainId: 8453,
+    from: null,
+    hash: 'mock-tx-order-1',
+    network: 'base',
+    nonce: null,
+    status: TransactionStatus.pending,
+    title: 'purchase.pending',
+    to: '0x123',
+    type: 'purchase' as const,
   };
 }
 

--- a/src/hooks/pendingTransactionResolution.ts
+++ b/src/hooks/pendingTransactionResolution.ts
@@ -265,6 +265,7 @@ function shouldPreferLocalTransaction(originalType: TransactionType): boolean {
   switch (originalType) {
     case 'bridge':
     case 'cancel':
+    case 'purchase':
     case 'speed_up':
     case 'swap':
       return true;

--- a/src/resources/transactions/transaction.ts
+++ b/src/resources/transactions/transaction.ts
@@ -6,6 +6,9 @@ import { foundry } from 'viem/chains';
 
 import { TransactionStatus, type MinedTransaction, type RainbowTransaction, type TransactionType } from '@/entities/transactions';
 import { IS_TEST } from '@/env';
+import { getMockCashTransactionByHash } from '@/features/cash/utils/mockCashTransactionByHash';
+import { CASH } from '@/features/config/constants/experimental';
+import { getExperimentalFlag } from '@/features/config/stores/experimentalConfigStore';
 import { type NativeCurrencyKey } from '@/features/currency/types';
 import { backendNetworksActions } from '@/features/network/stores/backendNetworksStore';
 import { type ChainId } from '@/features/network/types/backendNetworks';
@@ -82,6 +85,12 @@ export const fetchRawTransaction = async ({
   hash: string;
   originalType?: TransactionType;
 }): Promise<RainbowTransaction | null> => {
+  // this would never be `true` for prod builds
+  if (getExperimentalFlag(CASH)) {
+    const mockCashTransaction = await getMockCashTransactionByHash({ address, currency, chainId, hash });
+    if (mockCashTransaction) return mockCashTransaction;
+  }
+
   if (IS_TEST && localPublicClient && chainId === anvilChain.id) {
     try {
       if (!isHash(hash)) throw new Error('Invalid transaction hash');

--- a/src/state/pendingTransactions/index.ts
+++ b/src/state/pendingTransactions/index.ts
@@ -126,6 +126,17 @@ function findTransactionIndex(transactions: RainbowTransaction[], nextTransactio
     );
   }
 
+  // no `relayExecutionId` and no `nonce` means an incoming tx (like in add cash flow)
+  if (nextTransaction.nonce == null) {
+    return transactions.findIndex(
+      transaction =>
+        transaction.chainId === nextTransaction.chainId &&
+        !transaction.relayExecutionId &&
+        transaction.nonce == null &&
+        transaction.hash === nextTransaction.hash
+    );
+  }
+
   return transactions.findIndex(
     transaction => transaction.chainId === nextTransaction.chainId && transaction.nonce === nextTransaction.nonce
   );


### PR DESCRIPTION
## Why?

Completing a Cash buy order previously dead-ended at a "Request Successful" alert — the purchased USDC never appeared anywhere. This wires a completed order into the existing pending-transaction pipeline so the buy shows up in the activity list and as a toast immediately as a pending incoming purchase, then resolves to confirmed while keeping the fiat amount and purchase display we already know locally (instead of overwriting it with the generic on-chain values).

## Approach

- A completed buy order becomes a pending incoming `purchase` transaction and goes through the normal pending-transaction resolution path; on settle we keep the local fiat amount/description rather than the on-chain ones.
- Purchases carry no wallet nonce, so toast/activity de-duplication falls back to the transaction hash for them.
- The on-chain `getTransactionByHash` lookup for these purchases isn't available yet, so it's mocked behind the `CASH` experimental flag and never runs in production builds.

## Visuals

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-06-23 at 19.53.24.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/83e79bda-e5bd-4161-8910-6dd04a98837f.mov" />](https://app.graphite.com/user-attachments/video/83e79bda-e5bd-4161-8910-6dd04a98837f.mov)<br> | [untitled.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2075d754-7cc8-482e-82ba-021a9e7a19b4.webm" />](https://app.graphite.com/user-attachments/video/2075d754-7cc8-482e-82ba-021a9e7a19b4.webm)<br> |

## Testing

- Complete a Cash buy order and verify the app reaches the success state.
- Confirm the purchased USDC appears in the activity list as a pending incoming purchase (and as a toast).
- Wait for it to resolve and verify it flips to confirmed while still showing the original fiat amount.
