### PR TITLE
fix(graphql): codegen parse failure on arc's updated schema

### DIFF
--- a/src/graphql/package.json
+++ b/src/graphql/package.json
@@ -10,6 +10,7 @@
     "@graphql-codegen/typescript": "2.7.3",
     "@graphql-codegen/typescript-generic-sdk": "3.0.1",
     "@graphql-codegen/typescript-operations": "2.5.3",
-    "@graphql-eslint/eslint-plugin": "3.10.7"
+    "@graphql-eslint/eslint-plugin": "3.10.7",
+    "graphql": "16.14.2"
   }
 }

--- a/src/graphql/yarn.lock
+++ b/src/graphql/yarn.lock
@@ -1366,6 +1366,7 @@ __metadata:
     "@graphql-codegen/typescript-generic-sdk": "npm:3.0.1"
     "@graphql-codegen/typescript-operations": "npm:2.5.3"
     "@graphql-eslint/eslint-plugin": "npm:3.10.7"
+    graphql: "npm:16.14.2"
   languageName: unknown
   linkType: soft
 
@@ -2758,6 +2759,13 @@ __metadata:
   peerDependencies:
     graphql: ">=0.11 <=16"
   checksum: 10c0/53cc27c9bcf497fe26ab5be8205ac98f3b83d40d6c413ad578329d42a0e1f8912fb4cdd6df1e5015b1f96da01ccb2a7815b6e327806f740e6b14ff267680301d
+  languageName: node
+  linkType: hard
+
+"graphql@npm:16.14.2":
+  version: 16.14.2
+  resolution: "graphql@npm:16.14.2"
+  checksum: 10c0/a95a96961eaff55cc9fe9d31fae6f33499ac988b972d07ea5085024cb1333f515b902f376e7393a5489aa82200a8aff3eb96580e4d1b69d702ed19b6eb1ce97a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Our GraphQL codegen runs on `postinstall` and introspects arc's production schema to generate types. The codegen workspace ships no `graphql` of its own, so it borrows the app's `graphql@15.3.0`. After [rainbow-me/arc#559](https://github.com/rainbow-me/arc/pull/559) merged, the schema now serves the built-in `@deprecated` directive carrying a `DIRECTIVE_DEFINITION` location, a spec addition that landed in graphql-js 16.14.0. However, the 15.3.0 parser rejects it with `Unexpected Name "DIRECTIVE_DEFINITION"`. Codegen crashes during install, so CI currently fails on `develop` and every open PR. This isn't an arc bug; its schema is spec-current and our codegen parser is just from 2020.

This change gives the codegen workspace its own pinned `graphql` on the latest 16.x, so its parser understands the schema arc serves today. Generated output is identical; it's purely a parser capability bump. The version stays inside the codegen plugins' peer range, and the app's runtime `graphql@15.3.0` is left alone, so there's no app or bundle impact.