### PR TITLE
refactor: move sponsored-swap store out of delegation domain

### DIFF
--- a/src/__swaps__/screens/Swap/Swap.tsx
+++ b/src/__swaps__/screens/Swap/Swap.tsx
@@ -19,12 +19,12 @@ import { Page } from '@/components/layout';
 import { navbarHeight } from '@/components/navbar/Navbar';
 import { DecoyScrollView } from '@/components/sheet/DecoyScrollView';
 import { Box } from '@/design-system';
-import { useSponsoredSwapStore } from '@/features/delegation/sponsoredSwapStore';
 import { clearCustomGasSettings } from '@/features/gas/hooks/useCustomGas';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { useDelayedMount } from '@/hooks/useDelayedMount';
 import { userAssetsStore } from '@/state/assets/userAssets';
 import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
+import { useSponsoredSwapStore } from '@/state/swaps/sponsoredSwapStore';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 

--- a/src/__swaps__/screens/Swap/components/EstimatedSwapGasFee.tsx
+++ b/src/__swaps__/screens/Swap/components/EstimatedSwapGasFee.tsx
@@ -16,11 +16,11 @@ import { useSwapEstimatedGasFee } from '@/__swaps__/screens/Swap/hooks/useEstima
 import { useSwapContext } from '@/__swaps__/screens/Swap/providers/swap-provider';
 import { TIMING_CONFIGS } from '@/components/animations/animationConfigs';
 import { AnimatedText, useForegroundColor, type TextProps } from '@/design-system';
-import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useDelayedValue } from '@/hooks/reanimated/useDelayedValue';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { useIsSponsoredSwap } from '@/state/swaps/sponsoredSwapStore';
 
 type EstimatedSwapGasFeeProps = { gasSettings?: GasSettings } & Partial<
   Pick<TextProps, 'align' | 'color' | 'size' | 'style' | 'weight' | 'tabularNumbers'>

--- a/src/__swaps__/screens/Swap/components/GasButton.tsx
+++ b/src/__swaps__/screens/Swap/components/GasButton.tsx
@@ -7,7 +7,6 @@ import { getColorValueForThemeWorklet } from '@/__swaps__/utils/swaps';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { GestureHandlerButton } from '@/components/buttons/GestureHandlerButton';
 import { Box, Inline, Text, TextIcon, useColorMode, useForegroundColor } from '@/design-system';
-import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { GasSpeedMenu } from '@/features/gas/components/GasSpeedMenu';
 import { useCustomGasSettings, type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { setSelectedGasSpeed, useSelectedGasSpeed } from '@/features/gas/hooks/useSelectedGas';
@@ -18,6 +17,7 @@ import { weiToGwei } from '@/features/gas/utils/parseGas';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { add, formatNumber } from '@/helpers/utilities';
 import * as i18n from '@/languages';
+import { useIsSponsoredSwap } from '@/state/swaps/sponsoredSwapStore';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 

--- a/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
+++ b/src/__swaps__/screens/Swap/components/ReviewPanel.tsx
@@ -30,7 +30,6 @@ import {
   useColorMode,
   useForegroundColor,
 } from '@/design-system';
-import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { useWillExecuteDelegation, willExecuteDelegation } from '@/features/delegation/willDelegate';
 import { useSelectedGasSpeed } from '@/features/gas/hooks/useSelectedGas';
 import { useEstimatedTime } from '@/features/gas/utils/meteorology';
@@ -41,6 +40,7 @@ import { convertRawAmountToBalance, convertRawAmountToBalanceWorklet, handleSign
 import * as i18n from '@/languages';
 import { useNavigation } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
+import { useIsSponsoredSwap } from '@/state/swaps/sponsoredSwapStore';
 import { swapsStore, useSwapsStore } from '@/state/swaps/swapsStore';
 import { getAccountAddress, useAccountAddress } from '@/state/wallets/walletsStore';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';

--- a/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
+++ b/src/__swaps__/screens/Swap/hooks/useAnimatedSwapStyles.ts
@@ -30,9 +30,9 @@ import { TOKEN_SEARCH_FOCUSED_INPUT_HEIGHT } from '@/components/token-search/con
 import { getTokenSearchButtonWrapperStyle } from '@/components/token-search/styles';
 import { useColorMode } from '@/design-system';
 import { foregroundColors } from '@/design-system/color/palettes';
-import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { opacity } from '@/framework/ui/utils/opacity';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { useIsSponsoredSwap } from '@/state/swaps/sponsoredSwapStore';
 import { THICK_BORDER_WIDTH } from '@/styles/constants';
 import safeAreaInsetValues from '@/utils/safeAreaInsetValues';
 

--- a/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx
+++ b/src/__swaps__/screens/Swap/providers/SyncSwapStateAndSharedValues.tsx
@@ -7,7 +7,6 @@ import { create } from 'zustand';
 
 import { type ExtendedAnimatedAssetWithColors } from '@/__swaps__/types/assets';
 import { analytics } from '@/analytics';
-import { useIsSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { type GasSettings } from '@/features/gas/hooks/useCustomGas';
 import { useSelectedGas } from '@/features/gas/hooks/useSelectedGas';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
@@ -29,6 +28,7 @@ import {
 import Routes from '@/navigation/routesNames';
 import { useUserAssetsStore } from '@/state/assets/userAssets';
 import { useStoreSharedValue } from '@/state/internal/hooks/useStoreSharedValue';
+import { useIsSponsoredSwap } from '@/state/swaps/sponsoredSwapStore';
 import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { getUniqueId } from '@/utils/ethereumUtils';
 import { deepEqual } from '@/worklets/comparisons';

--- a/src/__swaps__/screens/Swap/providers/swap-provider.tsx
+++ b/src/__swaps__/screens/Swap/providers/swap-provider.tsx
@@ -38,7 +38,6 @@ import { trackSwapEvent } from '@/__swaps__/utils/trackSwapEvent';
 import { analytics } from '@/analytics';
 import { getRemoteConfig } from '@/features/config/stores/remoteConfig';
 import { isInsufficientSponsorBalanceError } from '@/features/delegation/sponsoredCalls';
-import { getPreparedSponsoredSwap } from '@/features/delegation/sponsoredSwapStore';
 import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
 import { clearCustomGasSettings } from '@/features/gas/hooks/useCustomGas';
 import { getGasSettingsBySpeed, getSelectedGas } from '@/features/gas/hooks/useSelectedGas';
@@ -62,6 +61,7 @@ import { userAssetsStoreManager } from '@/state/assets/userAssetsStoreManager';
 import { useConnectedToAnvilStore } from '@/state/connectedToAnvil';
 import { getNextNonce } from '@/state/nonces';
 import { executeFn, Screens, startTimeToSignTracking, TimeToSignOperation } from '@/state/performance/performance';
+import { getPreparedSponsoredSwap } from '@/state/swaps/sponsoredSwapStore';
 import { swapsStore } from '@/state/swaps/swapsStore';
 import { SwapType, type CrosschainQuote, type Quote, type QuoteError } from '@rainbow-me/swaps';
 

--- a/src/state/swaps/sponsoredSwapStore.ts
+++ b/src/state/swaps/sponsoredSwapStore.ts
@@ -5,6 +5,7 @@ import { useRemoteConfigStore } from '@/features/config/stores/remoteConfig';
 import { createDelegationPublicClient, isPreparedCallsExecutionSponsored } from '@/features/delegation/calls';
 import { createPreparedCallsStore } from '@/features/delegation/preparedCallsStore';
 import { predictSponsoredCallsExecution } from '@/features/delegation/sponsoredCalls';
+import { supportsDelegatedExecution } from '@/features/delegation/willDelegate';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { time } from '@/framework/core/utils/time';
 import { getProvider } from '@/handlers/web3';
@@ -13,8 +14,6 @@ import { useSwapsStore } from '@/state/swaps/swapsStore';
 import { getAccountAddress, useWalletsStore } from '@/state/wallets/walletsStore';
 import { execute, type PreparedCallsExecution } from '@rainbow-me/delegation';
 import { type CrosschainQuote, type Quote, type QuoteError } from '@rainbow-me/swaps';
-
-import { supportsDelegatedExecution } from './willDelegate';
 
 // ============ Types ========================================================== //
 


### PR DESCRIPTION
`features/delegation` is our shared smart-wallet / sponsored-execution engine that a number of features plug into (transfer, swaps, staking, perps, funding). It currently also holds the sponsored-swap store, which is swap-specific orchestration consumed only by the swap screens. Folding feature-owned orchestration into the shared engine blurs the boundary and makes the engine look like it owns swap concerns it doesn't.

This change relocates the sponsored-swap store to sit alongside the main swap store, leaving the delegation engine with only the generic pieces every consumer shares. Behavior is unchanged; it's a pure move plus import updates, so there's no user-facing impact.

This is the first step in tidying up the delegation domain.