### PR TITLE
ci: fix missing NDK provision in Android Play Store workflow

### DIFF
--- a/.github/workflows/android-play-store.yml
+++ b/.github/workflows/android-play-store.yml
@@ -171,6 +171,15 @@ jobs:
             echo "- versionCode: \`$VERSION_CODE\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Provision Android NDK
+        run: |
+          set -euo pipefail
+          NDK_VERSION=$(grep -m1 -oP 'ndkVersion\s*=\s*"\K[^"]+' android/build.gradle)
+          echo "Installing NDK ${NDK_VERSION} (source of truth: android/build.gradle)"
+          "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "ndk;${NDK_VERSION}"
+          test -d "${ANDROID_HOME}/ndk/${NDK_VERSION}" \
+            || { echo "::error::NDK ${NDK_VERSION} not present after install"; exit 1; }
+
       - name: Build signed AAB + APK
         working-directory: android
         env:


### PR DESCRIPTION
The Android Play Store build fails during Gradle configuration because the CI runner has no Android NDK, and AGP's build-time auto-download of it is unreliable (we hit `Archive is not a ZIP archive` on the first real run). Local release builds never hit this: dev machines already have the NDK via Android Studio, but a clean runner doesn't, so the gap only shows up in CI.

This change installs the pinned NDK before Gradle runs, reading the version straight from the Gradle config so the two can't drift. AGP then resolves it locally and never attempts the download.

Ref APP-3837.