### PR TITLE
ci(android): fix unstripped native libraries in release builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -146,6 +146,7 @@ android {
         }
     }
 
+    ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 


### PR DESCRIPTION
Our `:app` module never sets `ndkVersion`, so it can't resolve the NDK toolchain on its own. On CI the final native merge/strip and debug-symbol extraction can't find the NDK's `llvm-strip`/`llvm-objcopy`, so AGP packages the libraries unstripped ("Unable to strip the following libraries, packaging them as they are") and skips native symbol extraction. That results in:
* More than doubles the release artifact (a single `.so` balloons from ~460 KB stripped to ~5.9 MB)
* Bakes absolute build paths into the shipped binary
* And leaves the AAB without the native debug symbols Play Console needs to symbolicate crashes

This is not an issue locally because dev machines fall back to an ambient NDK automatically.

This change points `:app` at the NDK already pinned in the root `ext.ndkVersion`, restoring both stripping and the Sentry-driven symbol extraction. The line is standard in the React Native template; our customized app `build.gradle` just never carried it for some reason.

Ref APP-3837.