### PR TITLE
fix: route preferences API errors through Sentry's fetch-error filter

### DIFF
--- a/src/model/preferences.ts
+++ b/src/model/preferences.ts
@@ -4,7 +4,7 @@ import type { EthereumAddress } from '@/entities/wallet';
 import { type Network } from '@/features/network/types/backendNetworks';
 import { RainbowFetchClient } from '@/framework/data/http/rainbowFetch';
 import { getSignatureForSigningWalletAndCreateSignatureIfNeeded, signWithSigningWallet } from '@/helpers/signingWallet';
-import { logger } from '@/logger';
+import { logger, RainbowError } from '@/logger';
 
 export const PREFS_ENDPOINT = 'https://api.rainbow.me';
 const preferencesAPI = new RainbowFetchClient({
@@ -120,7 +120,7 @@ export async function setPreference<K extends keyof Omit<PreferencesDataMap, 'ad
 
     return data?.success;
   } catch (e) {
-    logger.warn(`[preferences]: Preferences API failed to set preference`, {
+    logger.error(new RainbowError(`[preferences]: Preferences API failed to set preference`, e), {
       preferenceKey: key,
     });
     return false;
@@ -146,9 +146,8 @@ export async function getPreference<K extends keyof PreferencesDataMap>(
 
     return data.data;
   } catch (e) {
-    logger.warn(`[preferences]: Preferences API failed to get preference`, {
+    logger.error(new RainbowError(`[preferences]: Preferences API failed to get preference`, e), {
       preferenceKey: key,
-      error: e,
     });
     return null;
   }


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3884/sentrytransport-noise

Fixes Sentry [RAINBOW-WALLET-3XA8](https://rainbow-me.sentry.io/issues/7315278395/)

Preference get/set failures were logged via `logger.warn`, which buried the `RainbowFetchError` in Sentry's `extra` where the central `beforeSend` filter couldn't see it — so transient connectivity blips (offline, timeout, 5xx) generated ~444K events across ~21K users. Logging via `logger.error(new RainbowError(msg, e))` attaches the error as `cause`, the shape `beforeSend` already filters on, so non-actionable failures are dropped centrally while genuine errors (4xx, `success: false`) still report.