### PR TITLE
ci: upgrade android-emulator-runner off the deprecated Node 20 runtime

### DIFF
--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Create AVD and Generate Snapshot for Caching
       if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed
+      uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
       with:
         api-level: ${{ inputs.api-level }}
         target: google_apis_playstore

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -195,7 +195,7 @@ jobs:
           arch: ${{ env.ARCH }}
 
       - name: Run tests
-        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         id: e2e_test
         with:
           api-level: ${{ env.ANDROID_EMULATOR_API_LEVEL }}


### PR DESCRIPTION
Follows #7622, which moved the first-party `actions/*` core actions off the deprecated `node16`/`node20` runtimes. The Android e2e suite still runs `reactivecircus/android-emulator-runner` on `node20`, so those runs keep surfacing GitHub's Node.js deprecation warning.

This change bumps it to the latest release, which runs on Node 24; the action's inputs are unchanged, so emulator boot and test behavior should be identical.