### PR TITLE
ci: upgrade foundry-toolchain off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -171,7 +171,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
         with:
           version: stable
 

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -80,7 +80,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
         with:
           version: stable
 


### PR DESCRIPTION
Follows #7622, which moved our first-party `actions/*` core actions off the deprecated `node16`/`node20` runtimes. The Anvil install step in our e2e suites still pulls `foundry-rs/foundry-toolchain` on `node20`, so those runs keep surfacing GitHub's Node.js deprecation warning.

This change bumps it to the latest release, which runs on Node 24. Incidentally this bump also improves the caching, so the action now caches all ` ~/.foundry/cache` instead of just RPC.