### PR TITLE
ci: upgrade setup-ruby off the deprecated Node 20 runtime

### DIFF
--- a/.github/actions/ios-build/action.yaml
+++ b/.github/actions/ios-build/action.yaml
@@ -158,7 +158,7 @@ runs:
 
     - name: Set up Ruby
       if: inputs.destination == 'device'
-      uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         bundler-cache: true
 


### PR DESCRIPTION
Follows #7622 to move our actions off the deprecated `node16`/`node20` runtimes. The Ruby setup step in our iOS device builds still runs `ruby/setup-ruby` on `node20`, surfacing GitHub's Node.js deprecation warning.

This change bumps it to the latest release, which runs on Node 24. It's a same-major (`v1.x`) bump with our `bundler-cache` usage unchanged, so no behavior change is expected.