### PR TITLE
fix: temp disable App Store rating prompt

### DIFF
--- a/src/utils/reviewAlert.ts
+++ b/src/utils/reviewAlert.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import * as StoreReview from 'expo-store-review';
 
 import { analytics } from '@/analytics';
@@ -51,6 +53,11 @@ function getReviewActions() {
 
 export async function handleReviewPromptAction(action: ReviewPromptAction) {
   if (IS_TEST || (IS_DEV && action !== ReviewPromptAction.UserPrompt)) return;
+
+  // Temporarily disabled on iOS: App Store Review rejected us under Guideline 5.6.3
+  // for requesting a rating on first launch / during onboarding. Disabled until we
+  // find a store compliant way to do this (APP-3885).
+  if (Platform.OS === 'ios' && action !== ReviewPromptAction.UserPrompt) return;
 
   logger.debug(`[reviewAlert]: handleReviewPromptAction: ${action}`);
 


### PR DESCRIPTION
Apple rejected our release under Guideline 5.6.3: the app requests a native rating prompt the first time the wallet screen appears, which for a new user is right after onboarding, before they've engaged with the app. On a fresh install our own throttles (one prompt per week, three per year) are trivially satisfied, so the request fires on the very first session and blocks the release.

This change stops every automatic rating request on iOS; only the explicit "Rate App" action in Settings still prompts. We disable all the automatic triggers rather than just the onboarding one because each fires on its first occurrence, so a reviewer using any feature in their first session could trip the same guideline again.

This is a stopgap to get the resubmission through; APP-3885 tracks the proper fix to re-enable.

Ref APP-3885 .