### PR TITLE
Ensure shim loading precedes log-producing code

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ PerformanceTracking.startReport(PerformanceReports.appStartup, APP_START_TIME);
 PerformanceTracking.logReportSegmentRelative(PerformanceReports.appStartup, PerformanceReportSegments.appStartup.loadJSBundle);
 PerformanceTracking.startReportSegment(PerformanceReports.appStartup, PerformanceReportSegments.appStartup.loadMainModule);
 
+// Must precede log-producing code for successful debug log propagation
+require('./shim');
+
 initSentry();
 initStores();
 
@@ -28,6 +31,5 @@ to the top of the file above all other calls. We want Performance tracking
 to start before all of the imports.
  */
 require('react-native-gesture-handler');
-require('./shim');
 require('./src/App');
 PerformanceTracking.finishReportSegment(PerformanceReports.appStartup, PerformanceReportSegments.appStartup.loadMainModule);


### PR DESCRIPTION
## What changed (plus any additional context for devs)
- Logs preceding shim initialization weren't propagating in debug mode because the shim's `global.console = global.originalConsole` fix was applied after `initSentry()` and `initStores()` — the shim is now loaded before these init functions are called

## Screen recordings / screenshots

## What to test
