### PR TITLE
ci: scope GITHUB_TOKEN to least privilege across all workflows

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened]
 
+permissions: {}
+
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
 
@@ -19,6 +21,8 @@ jobs:
        (github.event.action != 'labeled' || github.event.label.name == 'e2e'))
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
+    permissions:
+      contents: read
     concurrency:
       group: e2e-android-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -135,6 +139,9 @@ jobs:
     runs-on: app-e2e-runner
     needs: build
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
     concurrency:
       group: e2e-android-${{ github.workflow }}-${{ github.ref }}-shard-${{ matrix.shard-index }}
       cancel-in-progress: false
@@ -226,6 +233,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     concurrency:
       group: e2e-android-${{ github.workflow }}-${{ github.ref }}-perf
       cancel-in-progress: true
@@ -292,6 +303,10 @@ jobs:
       github.ref == 'refs/heads/develop' &&
       (needs.build.result == 'failure' || needs.e2e-tests.result == 'failure')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/android-play-store.yml
+++ b/.github/workflows/android-play-store.yml
@@ -8,14 +8,15 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
     name: Build
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 60
+    permissions:
+      contents: read
     environment: release-android
 
     steps:

--- a/.github/workflows/comments-watchdog.yml
+++ b/.github/workflows/comments-watchdog.yml
@@ -8,9 +8,15 @@ on:
   discussion_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   remove_spam_comments:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      discussions: write
     steps:
       - name: Set up environment
         run: |

--- a/.github/workflows/ios-builds.yml
+++ b/.github/workflows/ios-builds.yml
@@ -4,10 +4,14 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build-simulator:
     name: Simulator
     runs-on: macos-26-xlarge
+    permissions:
+      contents: read
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
@@ -36,6 +40,8 @@ jobs:
   build-device:
     name: Device
     runs-on: macos-26-xlarge
+    permissions:
+      contents: read
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     timeout-minutes: 45
@@ -72,6 +78,9 @@ jobs:
     name: Post Builds
     needs: [build-simulator, build-device]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
     if: github.event_name == 'pull_request' && needs.build-simulator.result == 'success' && needs.build-device.result == 'success'
     steps:
       - name: Download simulator artifact

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -4,6 +4,9 @@ on:
     branches: [develop]
   pull_request:
     types: [labeled, synchronize, reopened]
+
+permissions: {}
+
 env:
   NODE_OPTIONS: '--max-old-space-size=6144'
 
@@ -17,6 +20,8 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'e2e') &&
        (github.event.action != 'labeled' || github.event.label.name == 'e2e'))
     runs-on: macos-26-xlarge
+    permissions:
+      contents: read
     concurrency:
       group: e2e-ios-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -46,6 +51,9 @@ jobs:
     name: E2E Tests (Shard ${{ matrix.shard-index }})
     needs: build
     runs-on: macos-26-xlarge
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +131,10 @@ jobs:
       github.ref == 'refs/heads/develop' &&
       (needs.build.result == 'failure' || needs.e2e-tests.result == 'failure')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,6 +2,9 @@ name: Automatic Rebase
 on:
   issue_comment:
     types: [created]
+
+permissions: {}
+
 jobs:
   rebase:
     name: Rebase
@@ -10,6 +13,9 @@ jobs:
       contains(github.event.comment.body, '/rebase') &&
       github.event.comment.author_association == 'MEMBER'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '30 20 * * 1' # Runs every Monday at 20:30 UTC
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,9 +1,14 @@
 name: Unit tests
 
 on: [pull_request]
+
+permissions: {}
+
 jobs:
   lint-and-unit-test:
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    permissions:
+      contents: read
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
     concurrency:


### PR DESCRIPTION
Most of our CI workflows declare no `permissions:` block, so each job's `GITHUB_TOKEN` inherits the repository default. That grant is far broader than any job needs, which means a compromised action or transitive dependency in even a read-only test job could write to the repo, comments, or releases. The risk is sharpest in the comment-triggered workflows (spam watchdog, automatic rebase), where the token runs in response to activity from outside collaborators.

This change makes every workflow deny-all by default (`permissions: {}` at the top) and grants each job only the scopes it actually exercises:
* Build, lint, and test jobs stay read-only
* jobs that pull build artifacts over the REST API also get `actions: read`
* jobs that post PR comments or delete spam get the matching write scope
* rebase keeps `contents: write` to push