### PR TITLE
refactor: move shared request routing into the dapp-request domain

### DIFF
--- a/.dependency-cruiser-known-violations.android.json
+++ b/.dependency-cruiser-known-violations.android.json
@@ -12359,127 +12359,6 @@
   },
   {
     "type": "cycle",
-    "from": "src/components/DappBrowser/Homepage.tsx",
-    "to": "src/components/DappBrowser/handleProviderRequest.ts",
-    "unresolvedTo": "./handleProviderRequest",
-    "dependencyTypes": [
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/DappBrowser/handleProviderRequest.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/requestNavigationHandlers.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/components/showErrorSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Explain/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Portal/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/ListPanel.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/Dimensions.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/SwipeNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/DappBrowser.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/BrowserTab.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/Homepage.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
     "from": "src/components/DappBrowser/hooks/useAnimatedTab.ts",
     "to": "src/components/DappBrowser/BrowserWorkletsContext.tsx",
     "unresolvedTo": "../BrowserWorkletsContext",
@@ -13438,7 +13317,7 @@
         ]
       },
       {
-        "name": "src/utils/requestNavigationHandlers.ts",
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -13650,127 +13529,6 @@
       {
         "name": "src/components/DappBrowser/BrowserContext.tsx",
         "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/Dimensions.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/SwipeNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/DappBrowser.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/search/Search.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/search-input/AccountIcon.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/components/DappBrowser/search-input/AccountIcon.tsx",
-    "to": "src/components/DappBrowser/handleProviderRequest.ts",
-    "unresolvedTo": "../handleProviderRequest",
-    "dependencyTypes": [
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/DappBrowser/handleProviderRequest.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/requestNavigationHandlers.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/components/showErrorSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Explain/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Portal/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/ListPanel.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
           "local",
           "import"
         ]
@@ -23843,8 +23601,8 @@
   {
     "type": "cycle",
     "from": "src/components/MobileWalletProtocolListener.tsx",
-    "to": "src/utils/requestNavigationHandlers.ts",
-    "unresolvedTo": "@/utils/requestNavigationHandlers",
+    "to": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
+    "unresolvedTo": "@/features/dapp-request/utils/requestNavigationHandlers",
     "dependencyTypes": [
       "aliased",
       "aliased-tsconfig",
@@ -23858,7 +23616,7 @@
     },
     "cycle": [
       {
-        "name": "src/utils/requestNavigationHandlers.ts",
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -33887,6 +33645,45 @@
       },
       {
         "name": "src/features/currency/stores/currencyConversionStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
+    "to": "src/features/wallet-connect/handlers/onSessionRequest.ts",
+    "unresolvedTo": "@/features/wallet-connect/handlers/onSessionRequest",
+    "dependencyTypes": [
+      "aliased",
+      "aliased-tsconfig",
+      "aliased-tsconfig-paths",
+      "local",
+      "import"
+    ],
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -104728,45 +104525,6 @@
   },
   {
     "type": "cycle",
-    "from": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-    "to": "src/utils/requestNavigationHandlers.ts",
-    "unresolvedTo": "@/utils/requestNavigationHandlers",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/utils/requestNavigationHandlers.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
     "from": "src/features/wallet/utils/watchingAlert.ts",
     "to": "src/navigation/Navigation.tsx",
     "unresolvedTo": "@/navigation/Navigation",
@@ -108948,7 +108706,7 @@
         ]
       },
       {
-        "name": "src/utils/requestNavigationHandlers.ts",
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",

--- a/.dependency-cruiser-known-violations.ios.json
+++ b/.dependency-cruiser-known-violations.ios.json
@@ -12359,127 +12359,6 @@
   },
   {
     "type": "cycle",
-    "from": "src/components/DappBrowser/Homepage.tsx",
-    "to": "src/components/DappBrowser/handleProviderRequest.ts",
-    "unresolvedTo": "./handleProviderRequest",
-    "dependencyTypes": [
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/DappBrowser/handleProviderRequest.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/requestNavigationHandlers.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/components/showErrorSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Explain/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Portal/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/ListPanel.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/Dimensions.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/SwipeNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/DappBrowser.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/BrowserTab.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/Homepage.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
     "from": "src/components/DappBrowser/hooks/useAnimatedTab.ts",
     "to": "src/components/DappBrowser/BrowserWorkletsContext.tsx",
     "unresolvedTo": "../BrowserWorkletsContext",
@@ -13438,7 +13317,7 @@
         ]
       },
       {
-        "name": "src/utils/requestNavigationHandlers.ts",
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -13650,127 +13529,6 @@
       {
         "name": "src/components/DappBrowser/BrowserContext.tsx",
         "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/Dimensions.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/navigation/SwipeNavigator.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/DappBrowser.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/search/Search.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/components/DappBrowser/search-input/AccountIcon.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/components/DappBrowser/search-input/AccountIcon.tsx",
-    "to": "src/components/DappBrowser/handleProviderRequest.ts",
-    "unresolvedTo": "../handleProviderRequest",
-    "dependencyTypes": [
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/components/DappBrowser/handleProviderRequest.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/utils/requestNavigationHandlers.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/components/showErrorSheet.tsx",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Explain/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/screens/Portal/index.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "export"
-        ]
-      },
-      {
-        "name": "src/components/SmoothPager/ListPanel.tsx",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
           "local",
           "import"
         ]
@@ -23843,8 +23601,8 @@
   {
     "type": "cycle",
     "from": "src/components/MobileWalletProtocolListener.tsx",
-    "to": "src/utils/requestNavigationHandlers.ts",
-    "unresolvedTo": "@/utils/requestNavigationHandlers",
+    "to": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
+    "unresolvedTo": "@/features/dapp-request/utils/requestNavigationHandlers",
     "dependencyTypes": [
       "aliased",
       "aliased-tsconfig",
@@ -23858,7 +23616,7 @@
     },
     "cycle": [
       {
-        "name": "src/utils/requestNavigationHandlers.ts",
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -33887,6 +33645,45 @@
       },
       {
         "name": "src/features/currency/stores/currencyConversionStore.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "cycle",
+    "from": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
+    "to": "src/features/wallet-connect/handlers/onSessionRequest.ts",
+    "unresolvedTo": "@/features/wallet-connect/handlers/onSessionRequest",
+    "dependencyTypes": [
+      "aliased",
+      "aliased-tsconfig",
+      "aliased-tsconfig-paths",
+      "local",
+      "import"
+    ],
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
+        "dependencyTypes": [
+          "aliased",
+          "aliased-tsconfig",
+          "aliased-tsconfig-paths",
+          "local",
+          "import"
+        ]
+      },
+      {
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",
@@ -104728,45 +104525,6 @@
   },
   {
     "type": "cycle",
-    "from": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-    "to": "src/utils/requestNavigationHandlers.ts",
-    "unresolvedTo": "@/utils/requestNavigationHandlers",
-    "dependencyTypes": [
-      "aliased",
-      "aliased-tsconfig",
-      "aliased-tsconfig-paths",
-      "local",
-      "import"
-    ],
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/utils/requestNavigationHandlers.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      },
-      {
-        "name": "src/features/wallet-connect/handlers/onSessionRequest.ts",
-        "dependencyTypes": [
-          "aliased",
-          "aliased-tsconfig",
-          "aliased-tsconfig-paths",
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
-    "type": "cycle",
     "from": "src/features/wallet/utils/watchingAlert.ts",
     "to": "src/navigation/Navigation.tsx",
     "unresolvedTo": "@/navigation/Navigation",
@@ -108948,7 +108706,7 @@
         ]
       },
       {
-        "name": "src/utils/requestNavigationHandlers.ts",
+        "name": "src/features/dapp-request/utils/requestNavigationHandlers.ts",
         "dependencyTypes": [
           "aliased",
           "aliased-tsconfig",

--- a/src/components/DappBrowser/handleProviderRequest.ts
+++ b/src/components/DappBrowser/handleProviderRequest.ts
@@ -5,6 +5,7 @@ import { debounce } from 'lodash';
 import { UserRejectedRequestError } from 'viem';
 
 import { type Messenger } from '@/browserMessaging/AppMessenger';
+import { handleDappBrowserConnectionPrompt, handleDappBrowserRequest } from '@/features/dapp-request/utils/requestNavigationHandlers';
 import { getDappMetadata } from '@/features/dapp/resources/dapp';
 import { getDappHost } from '@/features/dapp/utils/dappUrls';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
@@ -17,7 +18,6 @@ import { logger } from '@/logger';
 import Routes from '@/navigation/routesNames';
 import { useAppSessionsStore } from '@/state/appSessions';
 import { useNavigationStore } from '@/state/navigation/navigationStore';
-import { handleDappBrowserConnectionPrompt, handleDappBrowserRequest } from '@/utils/requestNavigationHandlers';
 import {
   handleProviderRequest,
   type AddEthereumChainProposedChain,

--- a/src/components/MobileWalletProtocolListener.tsx
+++ b/src/components/MobileWalletProtocolListener.tsx
@@ -9,8 +9,8 @@ import {
 } from '@coinbase/mobile-wallet-protocol-host';
 
 import { IS_DEV } from '@/env';
+import { handleMobileWalletProtocolRequest } from '@/features/dapp-request/utils/requestNavigationHandlers';
 import { logger, RainbowError } from '@/logger';
-import { handleMobileWalletProtocolRequest } from '@/utils/requestNavigationHandlers';
 
 export enum MobileWalletProtocolUserErrors {
   USER_REJECTED_HANDSHAKE = 'User rejected the handshake',

--- a/src/features/dapp-request/utils/requestNavigationHandlers.ts
+++ b/src/features/dapp-request/utils/requestNavigationHandlers.ts
@@ -17,9 +17,6 @@ import { type Address } from 'viem';
 import { MobileWalletProtocolUserErrors } from '@/components/MobileWalletProtocolListener';
 import { hideWalletConnectToast } from '@/components/toasts/WalletConnectToast';
 import { enableActionsOnReadOnlyWallet } from '@/config/debug';
-import { RequestSource, type RequestData } from '@/features/dapp-request/types';
-import { SEND_TRANSACTION } from '@/features/dapp-request/utils/requestMethods';
-import { getRequestDisplayDetails } from '@/features/dapp-request/utils/requests';
 import { useBackendNetworksStore } from '@/features/network/stores/backendNetworksStore';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { handleSessionRequestResponse } from '@/features/wallet-connect/handlers/onSessionRequest';
@@ -37,6 +34,10 @@ import Navigation, { getActiveRoute } from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import store from '@/redux/store';
 import { getAccountAddress, getIsReadOnlyWallet, getWalletWithAccount } from '@/state/wallets/walletsStore';
+
+import { RequestSource, type RequestData } from '../types';
+import { SEND_TRANSACTION } from './requestMethods';
+import { getRequestDisplayDetails } from './requests';
 
 // Mobile Wallet Protocol
 

--- a/src/features/wallet-connect/handlers/onSessionRequest.ts
+++ b/src/features/wallet-connect/handlers/onSessionRequest.ts
@@ -4,6 +4,7 @@ import { formatJsonRpcError, formatJsonRpcResult } from '@json-rpc-tools/utils';
 import type { SignClientTypes } from '@walletconnect/types';
 
 import { analytics } from '@/analytics';
+import { handleWalletConnectRequest } from '@/features/dapp-request/utils/requestNavigationHandlers';
 import { getRequestDisplayDetails } from '@/features/dapp-request/utils/requests';
 import { fetchDappMetadata } from '@/features/dapp/resources/dapp';
 import { maybeSignUri } from '@/handlers/imgix';
@@ -14,7 +15,6 @@ import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
 import store from '@/redux/store';
 import { getWallets, getWalletWithAccount } from '@/state/wallets/walletsStore';
-import { handleWalletConnectRequest } from '@/utils/requestNavigationHandlers';
 
 import { showErrorSheet } from '../components/showErrorSheet';
 import { getWalletKitClient } from '../services/client';


### PR DESCRIPTION
The logic that routes an incoming dapp request to the approval UI and resolves the user's decision currently lives in a catch-all `utils/` file, even though it's the orchestration core of the dapp-request domain. It's fed by three transports: the in-app browser's provider handler, WalletConnect, and the Coinbase Mobile Wallet Protocol listener. So the domain's central flow sits outside the domain.

This change moves that routing into `features/dapp-request/`, alongside the approval screens and request types it already drives; the three transports now import it from the domain rather than a shared util. Behavior is unchanged.

Note: this change reduces cycles from 609 -> 607. The grandfathering file changes are for the existing cycles these files touch that now move due to the new location.