### PR TITLE
fix(i18n): localize backup type noun in wallet backup messages

### DIFF
--- a/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
+++ b/src/screens/SettingsSheet/components/Backups/ViewWalletBackup.tsx
@@ -127,6 +127,9 @@ const ViewWalletBackup = () => {
   const wallet = useWallet(walletId);
 
   const isSecretPhrase = WalletTypes.mnemonic === wallet?.type;
+  const backupTypeLabel = isSecretPhrase
+    ? i18n.t(i18n.l.back_up.secret.secret_phrase_title)
+    : i18n.t(i18n.l.back_up.secret.private_key_title);
   const title = wallet?.type === WalletTypes.privateKey ? wallet?.addresses[0].label : incomingTitle;
   const isBackedUp = isWalletBackedUpForCurrentAccount({
     backupType: wallet?.backupType,
@@ -330,7 +333,7 @@ const ViewWalletBackup = () => {
                   {backupProvider === walletBackupTypes.cloud && (
                     <MenuHeader.Label
                       text={i18n.t(i18n.l.wallet.back_ups.not_backed_up_to_cloud_message, {
-                        backupType: isSecretPhrase ? 'Secret Phrase' : 'Private Key',
+                        backupType: backupTypeLabel,
                         cloudPlatform,
                       })}
                     />
@@ -338,7 +341,7 @@ const ViewWalletBackup = () => {
                   {backupProvider !== walletBackupTypes.cloud && (
                     <MenuHeader.Label
                       text={i18n.t(i18n.l.wallet.back_ups.not_backed_up_message, {
-                        backupType: isSecretPhrase ? 'Secret Phrase' : 'Private Key',
+                        backupType: backupTypeLabel,
                       })}
                     />
                   )}
@@ -410,7 +413,7 @@ const ViewWalletBackup = () => {
                             cloudPlatform,
                           })
                         : i18n.t(i18n.l.wallet.back_ups.backed_up_message, {
-                            backupType: isSecretPhrase ? 'Secret Phrase' : 'Private Key',
+                            backupType: backupTypeLabel,
                           })
                     }
                   />


### PR DESCRIPTION
## What changed (plus any additional context for devs)

Backup status messages interpolated the secret-type noun ("Secret Phrase"/"Private Key") as a hardcoded English literal, so it stayed English in every locale even when the surrounding string was translated. Now pulls it from the localized secret-type labels (same keys the secret-warning screen uses), shared across the three backup messages. Pairs with a Crowdin fix that restored the `%{backupType}` placeholder in the Thai translations.

## What to test

- Settings → Backups → a wallet that isn't backed up: the message shows the secret type localized in the selected language.
- A backed-up wallet (cloud + manual): noun is localized.
- Switch to a non-English locale (e.g. Thai) and confirm the noun is translated, not English.
