### PR TITLE
ci: extract shared workspace setup into a composite action

### DIFF
--- a/.github/actions/ios-build/action.yaml
+++ b/.github/actions/ios-build/action.yaml
@@ -68,11 +68,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-      with:
-        node-version-file: '.node-version'
-
     - name: Set Xcode version
       shell: bash
       run: |
@@ -80,23 +75,15 @@ runs:
         sudo xcode-select --switch /Applications/Xcode_${XCODE_VERSION}.app
         xcodebuild -version
 
-    - name: Setup env key
-      uses: ./.github/actions/ssh/
+    - name: Setup workspace
+      uses: ./.github/actions/setup
       with:
-        name: env
-        key: ${{ inputs.deploy-pkey-dotenv }}
-
-    - name: Setup scripts key
-      uses: ./.github/actions/ssh/
-      with:
-        name: scripts
-        key: ${{ inputs.deploy-pkey-scripts }}
-
-    - name: Setup sandbox key
-      uses: ./.github/actions/ssh/
-      with:
-        name: sandbox
-        key: ${{ inputs.deploy-pkey-sandbox }}
+        deploy-pkey-dotenv: ${{ inputs.deploy-pkey-dotenv }}
+        deploy-pkey-scripts: ${{ inputs.deploy-pkey-scripts }}
+        deploy-pkey-sandbox: ${{ inputs.deploy-pkey-sandbox }}
+        ci-scripts: ${{ inputs.ci-scripts }}
+        is-testing: ${{ inputs.is-testing }}
+        enable-dev-mode: ${{ inputs.enable-dev-mode }}
 
     - name: Setup code signing key
       if: inputs.destination == 'device'
@@ -104,57 +91,6 @@ runs:
       with:
         name: codesigning
         key: ${{ inputs.deploy-pkey-codesigning }}
-
-    - name: Setup env
-      shell: bash
-      env:
-        SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
-        IS_TESTING: ${{ inputs.is-testing }}
-        ENABLE_DEV_MODE: ${{ inputs.enable-dev-mode }}
-      run: |
-        git clone git@github.com:rainbow-me/rainbow-env.git
-        mv rainbow-env/dotenv .env
-        rm -rf rainbow-env
-        if [ "$IS_TESTING" = "true" ]; then
-          sed -i'' -e "s/IS_TESTING=false/IS_TESTING=true/" .env && rm -f .env-e
-          echo "1" > is_testing
-        else
-          echo "0" > is_testing
-        fi
-        if [ -n "$ENABLE_DEV_MODE" ]; then
-          sed -i'' -e "s/ENABLE_DEV_MODE=1/ENABLE_DEV_MODE=$ENABLE_DEV_MODE/" .env && rm -f .env-e
-        fi
-
-    - name: Setup scripts
-      shell: bash
-      env:
-        CI_SCRIPTS: ${{ inputs.ci-scripts }}
-        SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
-      run: |
-        eval $CI_SCRIPTS
-
-    - name: Get Yarn cache directory path
-      id: yarn-cache-dir-path
-      shell: bash
-      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-    - name: Cache Yarn dependencies
-      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-      with:
-        path: |
-          ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          .yarn/cache
-          .yarn/install-state.gz
-          !.eslintcache
-        key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
-    - name: Install dependencies
-      shell: bash
-      env:
-        SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-      run: yarn install --immutable && yarn setup
 
     - name: Set up Ruby
       if: inputs.destination == 'device'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,120 @@
+name: Setup workspace
+description: Shared setup. Expects the repo to already be checked out.
+
+inputs:
+  deploy-pkey-dotenv:
+    description: SSH key for the rainbow-env repo (.env source)
+    required: true
+  deploy-pkey-scripts:
+    description: SSH key for the CI scripts repo
+    required: true
+  deploy-pkey-sandbox:
+    description: SSH key used by yarn install for sandbox-protected deps
+    required: true
+  ci-scripts:
+    description: Shell snippet evaluated to set up CI scripts
+    required: true
+  dotenv-file:
+    description: File inside rainbow-env to install as .env (e.g. dotenv-prod-android for release builds)
+    required: false
+    default: 'dotenv'
+  google-services:
+    description: When 'true', moves rainbow-env's google-services.json into android/app/
+    required: false
+    default: 'false'
+  is-testing:
+    description: When 'true', rewrites .env IS_TESTING=true. Always records '1'/'0' in the is_testing file, a Rock build-fingerprint source (see rock.config.mjs).
+    required: false
+    default: 'false'
+  enable-dev-mode:
+    description: When non-empty, rewrites .env ENABLE_DEV_MODE to this value (e.g. '0'). Empty leaves .env untouched.
+    required: false
+    default: ''
+  cache-restore-fallback:
+    description: When 'false', the yarn cache only restores on an exact lockfile match, never a stale fallback. For release builds, which require an exact match or a clean install.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version-file: '.node-version'
+
+    - name: Install secret tools
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt install libsecret-tools
+
+    - name: Setup env key
+      uses: ./.github/actions/ssh/
+      with:
+        name: env
+        key: ${{ inputs.deploy-pkey-dotenv }}
+
+    - name: Setup scripts key
+      uses: ./.github/actions/ssh/
+      with:
+        name: scripts
+        key: ${{ inputs.deploy-pkey-scripts }}
+
+    - name: Setup sandbox key
+      uses: ./.github/actions/ssh/
+      with:
+        name: sandbox
+        key: ${{ inputs.deploy-pkey-sandbox }}
+
+    - name: Setup env
+      shell: bash
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
+        DOTENV_FILE: ${{ inputs.dotenv-file }}
+        GOOGLE_SERVICES: ${{ inputs.google-services }}
+        IS_TESTING: ${{ inputs.is-testing }}
+        ENABLE_DEV_MODE: ${{ inputs.enable-dev-mode }}
+      run: |
+        git clone git@github.com:rainbow-me/rainbow-env.git
+        mv "rainbow-env/$DOTENV_FILE" .env
+        if [ "$GOOGLE_SERVICES" = "true" ]; then
+          mv rainbow-env/android/app/google-services.json android/app/google-services.json
+        fi
+        rm -rf rainbow-env
+        if [ "$IS_TESTING" = "true" ]; then
+          sed -i'' -e "s/IS_TESTING=false/IS_TESTING=true/" .env && rm -f .env-e
+          echo "1" > is_testing
+        else
+          echo "0" > is_testing
+        fi
+        if [ -n "$ENABLE_DEV_MODE" ]; then
+          sed -i'' -e "s/ENABLE_DEV_MODE=1/ENABLE_DEV_MODE=$ENABLE_DEV_MODE/" .env && rm -f .env-e
+        fi
+
+    - name: Setup scripts
+      shell: bash
+      env:
+        CI_SCRIPTS: ${{ inputs.ci-scripts }}
+        SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
+      run: eval "$CI_SCRIPTS"
+
+    - name: Get Yarn cache directory path
+      id: yarn-cache-dir-path
+      shell: bash
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+    - name: Cache Yarn dependencies
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: |
+          ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          .yarn/cache
+          .yarn/install-state.gz
+        key: ${{ runner.os }}-${{ runner.arch }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: ${{ inputs.cache-restore-fallback == 'true' && format('{0}-{1}-yarn-', runner.os, runner.arch) || '' }}
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
+      run: yarn install --immutable && yarn setup

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -33,69 +33,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - name: Setup workspace
+        uses: ./.github/actions/setup
         with:
-          node-version-file: '.node-version'
-
-      - name: Install secret tools
-        run: sudo apt install libsecret-tools
-
-      - name: Setup env key
-        uses: ./.github/actions/ssh/
-        with:
-          name: env
-          key: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
-
-      - name: Setup scripts key
-        uses: ./.github/actions/ssh/
-        with:
-          name: scripts
-          key: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
-
-      - name: Setup sandbox key
-        uses: ./.github/actions/ssh/
-        with:
-          name: sandbox
-          key: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
-
-      - name: Setup env
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
-        run: |
-          git clone git@github.com:rainbow-me/rainbow-env.git
-          mv rainbow-env/dotenv .env
-          mv rainbow-env/android/app/google-services.json android/app/google-services.json
-          rm -rf rainbow-env
-          sed -i "s/IS_TESTING=false/IS_TESTING=true/" .env
-          sed -i "s/ENABLE_DEV_MODE=1/ENABLE_DEV_MODE=0/" .env
-          echo "1" > is_testing
-      - name: Setup scripts
-        env:
-          CI_SCRIPTS: ${{ secrets.CI_SCRIPTS }}
-          SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
-        run: |
-          eval $CI_SCRIPTS
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Cache Yarn dependencies
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .yarn/cache
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install dependencies
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-        run: |
-          yarn install --immutable && yarn setup
+          deploy-pkey-dotenv: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
+          deploy-pkey-scripts: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
+          deploy-pkey-sandbox: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
+          ci-scripts: ${{ secrets.CI_SCRIPTS }}
+          google-services: 'true'
+          is-testing: 'true'
+          enable-dev-mode: '0'
 
       - name: Audit CI
         run: yarn audit-ci --config audit-ci.jsonc

--- a/.github/workflows/android-play-store.yml
+++ b/.github/workflows/android-play-store.yml
@@ -34,37 +34,16 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - name: Setup workspace
+        uses: ./.github/actions/setup
         with:
-          node-version-file: '.node-version'
-
-      - name: Setup env SSH key
-        uses: ./.github/actions/ssh/
-        with:
-          name: env
-          key: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
-
-      - name: Setup scripts SSH key
-        uses: ./.github/actions/ssh/
-        with:
-          name: scripts
-          key: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
-
-      - name: Setup sandbox SSH key
-        uses: ./.github/actions/ssh/
-        with:
-          name: sandbox
-          key: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
-
-      - name: Fetch prod env from rainbow-env
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
-        run: |
-          git clone --depth 1 git@github.com:rainbow-me/rainbow-env.git
-          mv rainbow-env/dotenv-prod-android .env
-          mv rainbow-env/android/app/google-services.json android/app/google-services.json
-          rm -rf rainbow-env
+          deploy-pkey-dotenv: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
+          deploy-pkey-scripts: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
+          deploy-pkey-sandbox: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
+          ci-scripts: ${{ secrets.CI_SCRIPTS }}
+          dotenv-file: dotenv-prod-android
+          google-services: 'true'
+          cache-restore-fallback: 'false'
 
       - name: Verify prod env
         run: |
@@ -120,31 +99,6 @@ jobs:
             echo "::error::Either the wrong keystore is configured for the release-android env, or the upload key was rotated without updating AppInstallInfoModule.kt."
             exit 1
           fi
-
-      - name: Run CI scripts
-        env:
-          CI_SCRIPTS: ${{ secrets.CI_SCRIPTS }}
-          SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
-        run: eval "$CI_SCRIPTS"
-
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Yarn dependencies
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .yarn/cache
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          # No restore-keys: release builds require an exact lockfile match or a clean install.
-
-      - name: Install dependencies
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-        run: yarn install --immutable && yarn setup
 
       - name: Dependency rules
         env:

--- a/.github/workflows/android-play-store.yml
+++ b/.github/workflows/android-play-store.yml
@@ -147,10 +147,6 @@ jobs:
           RNEF_UPLOAD_STORE_PASSWORD: ${{ secrets.ANDROID_PROD_KEYSTORE_PASSWORD }}
           RNEF_UPLOAD_KEY_ALIAS: ${{ vars.ANDROID_PROD_KEY_ALIAS }}
           RNEF_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_PROD_KEY_PASSWORD }}
-          # Short-circuits the ? in build.gradle's `def pass = ...` so getPassword()
-          # (which shells to `secret-tool` on Linux) is never called. `pass` is unused
-          # on the CI signing path anyway; this just avoids needing libsecret-tools.
-          RAINBOW_KEY_ANDROID_PASSWORD: unused
         run: |
           ./gradlew bundleRelease assembleRelease \
             -PRNEF_UPLOAD_STORE_FILE="$RUNNER_TEMP/rainbow.keystore" \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,67 +19,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      - name: Setup workspace
+        uses: ./.github/actions/setup
         with:
-          node-version-file: '.node-version'
-
-      - name: Install secret tools
-        run: sudo apt install libsecret-tools
-
-      - name: Setup env key
-        uses: ./.github/actions/ssh/
-        with:
-          name: env
-          key: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
-
-      - name: Setup scripts key
-        uses: ./.github/actions/ssh/
-        with:
-          name: scripts
-          key: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
-
-      - name: Setup sandbox key
-        uses: ./.github/actions/ssh/
-        with:
-          name: sandbox
-          key: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
-
-      - name: Setup env
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent_env.sock
-        run: |
-          git clone git@github.com:rainbow-me/rainbow-env.git
-          mv rainbow-env/dotenv .env
-          mv rainbow-env/android/app/google-services.json android/app/google-services.json
-          rm -rf rainbow-env
-          sed -i "s/IS_TESTING=false/IS_TESTING=true/" .env
-      - name: Setup scripts
-        env:
-          CI_SCRIPTS: ${{ secrets.CI_SCRIPTS }}
-          SSH_AUTH_SOCK: /tmp/ssh_agent_scripts.sock
-        run: |
-          eval $CI_SCRIPTS
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Cache Yarn dependencies
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .yarn/cache
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install dependencies
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent_sandbox.sock
-        run: |
-          yarn install --immutable && yarn setup
+          deploy-pkey-dotenv: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
+          deploy-pkey-scripts: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
+          deploy-pkey-sandbox: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
+          ci-scripts: ${{ secrets.CI_SCRIPTS }}
+          google-services: 'true'
+          is-testing: 'true'
 
       - name: Audit CI
         run: yarn audit-ci --config audit-ci.jsonc


### PR DESCRIPTION
Every CI job that needs the JS workspace repeats the same setup dance: Node, deploy keys, fetching `.env` from rainbow-env, evaluating CI scripts, and a cached yarn install. The copies have drifted (different cache key formats, different env mutations), and upcoming work will add more jobs needing the same block, each another ~60-line copy.

This change moves the shared block into one composite action with inputs for the real variation points: which dotenv file, whether `google-services.json` is installed, the `IS_TESTING`/`ENABLE_DEV_MODE` rewrites, and whether the yarn cache may fall back to a stale entry (release builds keep exact-match-only). Workflows now do checkout plus one setup step.

Deliberate behavior changes riding with the change:
* The yarn cache `restore-keys` prefix never matched the actual key format in any copy, so stale-cache fallback has been silently dead everywhere. The action fixes the prefix. Measured effect is small (a cold fetch is only ~25s on our runners), so this is hygiene and registry-outage resilience, not a speedup.
* The `is_testing` marker file (a Rock build-fingerprint source) is now written unconditionally (`1` or `0`) by the shared setup, instead of each build workflow having to remember it. Existing builds already wrote it correctly wherever it mattered, so fingerprints don't change; jobs that never build just get an inert file.
* In the Play Store workflow, the prod-env verification and keystore checks now run after the install block instead of before it. All gates still precede the build; failures just surface a few minutes later.

Prep work for splitting CI into per-concern jobs and improving our dependency-cycle checks.