### PR TITLE
ci: drop workspace install from the audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup workspace
-        uses: ./.github/actions/setup
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          deploy-pkey-dotenv: ${{ secrets.DEPLOY_PKEY_DOTENV_REPO }}
-          deploy-pkey-scripts: ${{ secrets.DEPLOY_PKEY_SCRIPTS_REPO }}
-          deploy-pkey-sandbox: ${{ secrets.DEPLOY_PKEY_SANDBOX_REPO }}
-          ci-scripts: ${{ secrets.CI_SCRIPTS }}
-          google-services: 'true'
-          is-testing: 'true'
+          node-version-file: '.node-version'
 
+      # The audit only needs yarn.lock and the advisory API, not the workspace, so we run it
+      # via yarn dlx pinned to the version in our devDeps.
       - name: Audit CI
-        run: yarn audit-ci --config audit-ci.jsonc
+        run: yarn dlx "audit-ci@$(node -p "require('./package.json').devDependencies['audit-ci']")" --config audit-ci.jsonc
 
   lint:
     name: Lint


### PR DESCRIPTION
The audit job currently pays the full workspace setup (deploy keys, `.env`, CI scripts, ~2m install) for a few seconds of actual work. It only needs the workspace to locate the audit-ci binary in `node_modules`: the audit itself is audit-ci driving `yarn npm audit`, which resolves versions from `yarn.lock` and queries the registry's advisory API. It never reads installed packages.

This change runs the audit after a bare checkout via `yarn dlx`, pinned to the audit-ci version in our devDeps so the workflow and local runs stay on one reviewed version rather than floating to latest. The job needs no secrets at all now and should drop from ~2.5min to ~30s, recouping most of the billed-minutes cost of the job split in #7662.