### PR TITLE
Bump iOS and Android to v2.0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 
 ### Testing
 
+## [2.0.39](https://github.com/rainbow-me/rainbow/releases/tag/v2.0.39)
+
+### Fixed
+
+- Fixed Polymarket orders failing on markets with certain tick sizes — [#7665](https://github.com/rainbow-me/rainbow/pull/7665)
+
+### Internal
+
+- Extracted the dapp browser into its own feature domain and consolidated its utilities, referrals, and request routing — [#7646](https://github.com/rainbow-me/rainbow/pull/7646), [#7647](https://github.com/rainbow-me/rainbow/pull/7647), [#7648](https://github.com/rainbow-me/rainbow/pull/7648), [#7649](https://github.com/rainbow-me/rainbow/pull/7649), [#7651](https://github.com/rainbow-me/rainbow/pull/7651)
+- Updated the dependency-cycle baseline — [#7660](https://github.com/rainbow-me/rainbow/pull/7660)
+- Switched iOS CI builds back to the upstream callstackincubator action — [#7659](https://github.com/rainbow-me/rainbow/pull/7659)
+
 ## [2.0.38](https://github.com/rainbow-me/rainbow/releases/tag/v2.0.38)
 
 ### Changed

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -160,8 +160,8 @@ android {
         applicationId "me.rainbow"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 317
-        versionName "2.0.39"
+        versionCode 318
+        versionName "2.0.40"
         missingDimensionStrategy 'react-native-camera', 'general'
         renderscriptTargetApi 23
         renderscriptSupportModeEnabled true

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1990,7 +1990,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.39;
+				MARKETING_VERSION = 2.0.40;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2057,7 +2057,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.39;
+				MARKETING_VERSION = 2.0.40;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2176,7 +2176,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.39;
+				MARKETING_VERSION = 2.0.40;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2294,7 +2294,7 @@ Upload Debug Symbols to Sentry */ = {
 					"$(PROJECT_DIR)",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 2.0.39;
+				MARKETING_VERSION = 2.0.40;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainbow",
-  "version": "2.0.39-1",
+  "version": "2.0.40-1",
   "private": true,
   "browser": {
     "@tanstack/query-async-storage-persister": "@tanstack/query-async-storage-persister/build/esm/index",


### PR DESCRIPTION
Version bump to 2.0.40 (versionCode 318) for the next patch, and records the 2.0.39 release notes in CHANGELOG.md.

Sequenced after #7664 — rebased on develop, so the effective diff is the 2.0.39→2.0.40 bump plus the changelog entry.