### PR TITLE
feat(cash): add success screen component

### DIFF
--- a/src/features/cash/screens/cash-deposit-setup/components/SetupActionButton.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupActionButton.tsx
@@ -1,0 +1,73 @@
+import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
+
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import Spinner from '@/components/Spinner';
+import { Box, Text, useForegroundColor, type TextProps } from '@/design-system';
+
+type SetupActionButtonProps = {
+  disabled?: boolean;
+  label: string;
+  loading?: boolean;
+  onPress: () => void;
+  shadow?: boolean;
+  testID: string;
+  textSize?: TextProps['size'];
+};
+
+export const SetupActionButton = memo(function SetupActionButton({
+  disabled = false,
+  label,
+  loading = false,
+  onPress,
+  shadow = false,
+  testID,
+  textSize = '22pt',
+}: SetupActionButtonProps) {
+  const blue = useForegroundColor('blue');
+  const isDisabled = disabled || loading;
+
+  return (
+    <ButtonPressAnimation
+      disabled={isDisabled}
+      onPress={onPress}
+      scaleTo={0.96}
+      style={styles.fullWidth}
+      testID={testID}
+      wrapperStyle={styles.fullWidth}
+    >
+      <Box
+        alignItems="center"
+        background="blue"
+        borderRadius={24}
+        height={{ custom: 48 }}
+        justifyContent="center"
+        style={[shadow && styles.shadow, shadow && { shadowColor: blue }, isDisabled && styles.disabled]}
+        width="full"
+      >
+        {loading ? (
+          <Spinner color="white" size={24} />
+        ) : (
+          <Text align="center" color="white" size={textSize} weight="heavy">
+            {label}
+          </Text>
+        )}
+      </Box>
+    </ButtonPressAnimation>
+  );
+});
+
+const styles = StyleSheet.create({
+  disabled: {
+    opacity: 0.5,
+  },
+  fullWidth: {
+    width: '100%',
+  },
+  shadow: {
+    elevation: 8,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 12,
+  },
+});

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupCancelButton.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupCancelButton.tsx
@@ -1,0 +1,29 @@
+import React, { memo } from 'react';
+
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Text } from '@/design-system';
+import * as i18n from '@/languages';
+
+type SetupCancelButtonProps = {
+  onPress: () => void;
+  testID?: string;
+};
+
+export const SetupCancelButton = memo(function SetupCancelButton({ onPress, testID = 'cash-setup-cancel' }: SetupCancelButtonProps) {
+  return (
+    <ButtonPressAnimation onPress={onPress} scaleTo={0.92} testID={testID}>
+      <Box
+        alignItems="center"
+        background="surfaceSecondary"
+        borderRadius={18}
+        height={{ custom: 36 }}
+        justifyContent="center"
+        paddingHorizontal="12px"
+      >
+        <Text color="label" size="17pt" weight="bold">
+          {i18n.t(i18n.l.button.cancel)}
+        </Text>
+      </Box>
+    </ButtonPressAnimation>
+  );
+});

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
@@ -4,11 +4,11 @@ import { StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
-import Spinner from '@/components/Spinner';
-import { Box, Text, useBackgroundColor, useForegroundColor } from '@/design-system';
+import { Box, Text, useBackgroundColor } from '@/design-system';
 import * as i18n from '@/languages';
 
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+import { SetupActionButton } from './SetupActionButton';
 
 type SetupStepLayoutProps = {
   title: string;
@@ -32,11 +32,8 @@ export const SetupStepLayout = memo(function SetupStepLayout({
   backDisabled = false,
 }: SetupStepLayoutProps) {
   const { next, back } = useCashDepositSetupNavigation();
-  const blue = useForegroundColor('blue');
   const surfaceSecondaryElevated = useBackgroundColor('surfaceSecondaryElevated');
   const insets = useSafeAreaInsets();
-
-  const disabled = actionDisabled || actionLoading;
 
   return (
     <Box
@@ -69,31 +66,19 @@ export const SetupStepLayout = memo(function SetupStepLayout({
 
       <Box style={styles.body}>{children}</Box>
 
-      <ButtonPressAnimation disabled={disabled} onPress={onAction ?? next} scaleTo={0.96} testID="cash-setup-next">
-        <Box
-          alignItems="center"
-          borderRadius={52}
-          height={{ custom: 48 }}
-          justifyContent="center"
-          style={[{ backgroundColor: blue }, disabled && styles.actionDisabled]}
-        >
-          {actionLoading ? (
-            <Spinner color="white" size={24} />
-          ) : (
-            <Text align="center" color="white" size="20pt" weight="heavy">
-              {actionLabel ?? i18n.t(i18n.l.cash.deposit_setup.next)}
-            </Text>
-          )}
-        </Box>
-      </ButtonPressAnimation>
+      <SetupActionButton
+        disabled={actionDisabled}
+        label={actionLabel ?? i18n.t(i18n.l.cash.deposit_setup.next)}
+        loading={actionLoading}
+        onPress={onAction ?? next}
+        testID="cash-setup-next"
+        textSize="20pt"
+      />
     </Box>
   );
 });
 
 const styles = StyleSheet.create({
-  actionDisabled: {
-    opacity: 0.5,
-  },
   body: {
     flex: 1,
   },

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupSuccessStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupSuccessStepLayout.tsx
@@ -1,0 +1,97 @@
+import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { DEFAULT_HANDLE_COLOR_DARK, DEFAULT_HANDLE_COLOR_LIGHT } from '@/components/PanelSheet/PanelSheet';
+import { Box, Text, useColorMode } from '@/design-system';
+
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+import { SetupActionButton } from './SetupActionButton';
+import { SetupCancelButton } from './SetupCancelButton';
+
+type SetupSuccessStepAccessory =
+  | {
+      type: 'cancel';
+      onPress: () => void;
+    }
+  | {
+      type: 'handle';
+    };
+
+type SetupSuccessStepLayoutProps = {
+  actionLabel: string;
+  accessory: SetupSuccessStepAccessory;
+  description: string;
+  onAction?: () => void;
+  title: string;
+};
+
+const CHECKMARK_CIRCLE = '􀁢';
+
+export const SetupSuccessStepLayout = memo(function SetupSuccessStepLayout({
+  actionLabel,
+  accessory,
+  description,
+  onAction,
+  title,
+}: SetupSuccessStepLayoutProps) {
+  const { next } = useCashDepositSetupNavigation();
+  const insets = useSafeAreaInsets();
+  const { isDarkMode } = useColorMode();
+  const handleColor = isDarkMode ? DEFAULT_HANDLE_COLOR_DARK : DEFAULT_HANDLE_COLOR_LIGHT;
+  const actionBottom = Math.max(insets.bottom + 2, 24);
+
+  return (
+    <Box background="surfacePrimaryElevated" height="full" width="full">
+      {accessory.type === 'cancel' ? (
+        <Box position="absolute" right={{ custom: 16 }} top={{ custom: insets.top + 4 }} zIndex={1}>
+          <SetupCancelButton onPress={accessory.onPress} testID="cash-setup-success-cancel" />
+        </Box>
+      ) : (
+        <Box alignItems="center" left="0px" position="absolute" right="0px" top={{ custom: insets.top + 4 }} zIndex={1}>
+          <Box backgroundColor={handleColor} borderRadius={3} height={{ custom: 5 }} width={{ custom: 36 }} />
+        </Box>
+      )}
+
+      <Box
+        alignItems="center"
+        bottom="0px"
+        justifyContent="center"
+        left="0px"
+        paddingHorizontal={{ custom: 32 }}
+        pointerEvents="box-none"
+        position="absolute"
+        right="0px"
+        top="0px"
+      >
+        <Box alignItems="center" gap={24} width="full">
+          <Box alignItems="center" height={{ custom: 64 }} justifyContent="center" width={{ custom: 64 }}>
+            <Text align="center" color="green" size="44pt" style={styles.checkmark} weight="heavy">
+              {CHECKMARK_CIRCLE}
+            </Text>
+          </Box>
+          <Box alignItems="center" gap={20} width="full">
+            <Text align="center" color="label" size="30pt" weight="heavy">
+              {title}
+            </Text>
+            <Text align="center" color="labelQuaternary" size="17pt / 135%" weight="bold">
+              {description}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box bottom={{ custom: actionBottom }} left={{ custom: 20 }} position="absolute" right={{ custom: 20 }}>
+        <SetupActionButton label={actionLabel} onPress={onAction ?? next} shadow testID="cash-setup-success-action" />
+      </Box>
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  checkmark: {
+    fontSize: 46,
+    lineHeight: 64,
+  },
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/AllDoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/AllDoneStep.tsx
@@ -2,8 +2,20 @@ import React, { memo } from 'react';
 
 import * as i18n from '@/languages';
 
-import { SetupStepLayout } from '../components/SetupStepLayout';
+import { SetupSuccessStepLayout } from '../components/SetupSuccessStepLayout';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+const l = i18n.l.cash.deposit_setup.all_done;
 
 export const AllDoneStep = memo(function AllDoneStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.all_done.title)} />;
+  const { dismiss } = useCashDepositSetupNavigation();
+
+  return (
+    <SetupSuccessStepLayout
+      accessory={{ type: 'cancel', onPress: dismiss }}
+      actionLabel={i18n.t(l.add_bank_card)}
+      description={i18n.t(l.description)}
+      title={i18n.t(l.title)}
+    />
+  );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/CardAddedStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/CardAddedStep.tsx
@@ -2,10 +2,15 @@ import React, { memo } from 'react';
 
 import * as i18n from '@/languages';
 
-import { SetupStepLayout } from '../components/SetupStepLayout';
+import { SetupSuccessStepLayout } from '../components/SetupSuccessStepLayout';
 
 export const CardAddedStep = memo(function CardAddedStep() {
   return (
-    <SetupStepLayout actionLabel={i18n.t(i18n.l.cash.deposit_setup.finish)} title={i18n.t(i18n.l.cash.deposit_setup.card_added.title)} />
+    <SetupSuccessStepLayout
+      accessory={{ type: 'handle' }}
+      actionLabel={i18n.t(i18n.l.cash.deposit_setup.finish)}
+      description={i18n.t(i18n.l.cash.deposit_setup.card_added.description)}
+      title={i18n.t(i18n.l.cash.deposit_setup.card_added.title)}
+    />
   );
 });

--- a/src/features/cash/screens/cash-deposit-setup/useCashDepositSetupNavigation.ts
+++ b/src/features/cash/screens/cash-deposit-setup/useCashDepositSetupNavigation.ts
@@ -37,5 +37,5 @@ export function useCashDepositSetupNavigation() {
     }
   }, [dismissScreen]);
 
-  return { next, back };
+  return { next, back, dismiss: dismissScreen };
 }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1592,7 +1592,11 @@
         "review": { "title": "Review" },
         "passkey": { "title": "Add a Passkey" },
         "email": { "title": "Enter email" },
-        "all_done": { "title": "You're all done" },
+        "all_done": {
+          "title": "You’re all done!",
+          "description": "You’re good to go. Add a payment method and you’re ready.",
+          "add_bank_card": "Add Bank Card"
+        },
         "card_details": {
           "title": "Enter card details",
           "card_number": "Card number",
@@ -1602,7 +1606,10 @@
           "try_again": "Try again",
           "submit_error": "We couldn't link your card. Please try again."
         },
-        "card_added": { "title": "Card added" }
+        "card_added": {
+          "title": "Card added",
+          "description": "You’re all set. You can now deposit with your card."
+        }
       }
     },
     "points": {


### PR DESCRIPTION
## Description

Adds the final cash setup success states so members get a clear completion screen after finishing identity setup and after adding a card.

## Visuals

| Identity setup complete | Card added |
| --- | --- |
| ![Simulator Screenshot - iPhone 17 Pro - 2026-07-03 at 18.24.56.png](https://app.graphite.com/user-attachments/assets/cc99495e-54d4-4377-9cdb-5128e3850ae4.png)<br> | ![Simulator Screenshot - iPhone 17 Pro - 2026-07-03 at 18.26.46.png](https://app.graphite.com/user-attachments/assets/559e8ee1-f229-4e9e-a660-27c669914bfd.png)<br> |

