### PR TITLE
chore(navigation): remove vestigial single-screen wrapper stack navigators

### DIFF
--- a/src/navigation/Routes.android.tsx
+++ b/src/navigation/Routes.android.tsx
@@ -128,7 +128,6 @@ import { SwipeNavigator } from './SwipeNavigator';
 import { type RootStackParamList } from './types';
 
 const Stack = createStackNavigator();
-const OuterStack = createStackNavigator();
 const AuthStack = createStackNavigator();
 const BSStack = createBottomSheetNavigator();
 
@@ -161,22 +160,13 @@ function MainNavigator() {
   );
 }
 
-// FIXME do it in one navigator
-function MainOuterNavigator() {
-  return (
-    <OuterStack.Navigator initialRouteName={Routes.MAIN_NAVIGATOR} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <OuterStack.Screen component={MainNavigator} name={Routes.MAIN_NAVIGATOR} />
-    </OuterStack.Navigator>
-  );
-}
-
 function BSNavigator() {
   const profilesEnabled = useExperimentalFlag(PROFILES);
   const showKingOfTheHillTab = useShowKingOfTheHill();
 
   return (
     <BSStack.Navigator>
-      <BSStack.Screen component={MainOuterNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
+      <BSStack.Screen component={MainNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
       <BSStack.Screen
         component={NotificationPermissionScreen}
         name={Routes.NOTIFICATION_PERMISSION_SCREEN}

--- a/src/navigation/Routes.ios.tsx
+++ b/src/navigation/Routes.ios.tsx
@@ -165,21 +165,13 @@ function MainNavigator() {
   );
 }
 
-function MainStack() {
-  return (
-    <Stack.Navigator initialRouteName={Routes.MAIN_NAVIGATOR_WRAPPER} {...stackNavigationConfig} screenOptions={defaultScreenStackOptions}>
-      <Stack.Screen component={MainNavigator} name={Routes.MAIN_NAVIGATOR_WRAPPER} />
-    </Stack.Navigator>
-  );
-}
-
 function NativeStackNavigator() {
   const profilesEnabled = useExperimentalFlag(PROFILES);
   const showKingOfTheHillTab = useShowKingOfTheHill();
 
   return (
     <NativeStack.Navigator {...nativeStackConfig}>
-      <NativeStack.Screen component={MainStack} name={Routes.STACK} />
+      <NativeStack.Screen component={MainNavigator} name={Routes.STACK} />
       <NativeStack.Screen
         component={NotificationPermissionScreen}
         name={Routes.NOTIFICATION_PERMISSION_SCREEN}

--- a/src/navigation/routesNames.ts
+++ b/src/navigation/routesNames.ts
@@ -43,7 +43,6 @@ const Routes = {
   LEARN_WEB_VIEW_SCREEN: 'LearnWebViewScreen',
   LOG_SHEET: 'LogSheet',
   MAIN_NATIVE_BOTTOM_SHEET_NAVIGATOR: 'MainNativeBottomSheetNavigation',
-  MAIN_NAVIGATOR: 'MainNavigator',
   MAIN_NAVIGATOR_WRAPPER: 'MainNavigatorWrapper',
   MODAL_SCREEN: 'ModalScreen',
   NATIVE_STACK: 'NativeStack',


### PR DESCRIPTION
## Why?

Our iOS e2e tests intermittently fail assertions like `"Purchased" is visible` while the text is plainly visible in the failure screenshot ([example run](https://github.com/rainbow-me/rainbow/actions/runs/28457864110/attempts/1)). Potentially the root cause is in Maestro's iOS driver: it snapshots the accessibility hierarchy with a hard depth [limit of 60](https://github.com/mobile-dev-inc/Maestro/blob/a7f15d4b12cb1a4292f760802ad07e7a5b02b14f/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift#L150), and when a screen exceeds it, it degrades to a lossy fallback that silently drops deeply-nested text nodes and does many snapshot round-trips per poll instead of one — in our CI logs, each hierarchy poll went from ~150 ms to ~4 s.

Running the following script:

```
maestro hierarchy 2>/dev/null | python3 -c '
import sys, json
raw = sys.stdin.read()
tree = json.loads(raw[raw.find("{"):])
def find(n, d, rid):
    if (n.get("attributes", {}).get("resource-id") or "") == rid: return d
    for c in n.get("children", []):
        r = find(c, d + 1, rid)
        if r: return r
def depth(n): return 1 + max((depth(c) for c in n.get("children", [])), default=0)
print("max depth:", depth(tree))
'
```

on `develop` after running `./scripts/e2e-run.sh --flow ./e2e/flows/cash/AddCashChips.yaml` outputs:

```
max depth: 62
```

## Approach

All screens share the app shell, and the shell carried a pure-waste layer: a JS stack navigator wrapping a single screen, which is itself another stack navigator. One JS stack layer costs ~7.

Running the script above on this branch outputs:

```
max depth: 55
```

## History — why the wrappers exist and why removal is safe

The iOS wrapper was introduced in the React Navigation 5 migration (#777, Jun 2020) with a real job: hosting the savings Withdraw/Deposit modals above the main navigator. #921 (Jul 2020) moved those modals to cool-modals, leaving the wrapper with exactly one screen — it has been vestigial ever since, and a later rename (`MainNavigatorWrapper` → `MainStack`, #4327) made it look load-bearing. Android's equivalent has carried `// FIXME do it in one navigator` since Nov 2020 (#1292).

Why removing it changes no behavior:

- Nothing navigates to the wrapper's route name; the `MAIN_NAVIGATOR` route removed here had no remaining references.
- Every option the wrappers passed (`mode: 'modal'`, `keyboardHandlingEnabled`, `gestureEnabled`, `animationTypeForReplace`) only takes effect on transitions between that navigator's own screens — with a single screen, none ever fired. The one rendering-relevant option, `presentation: 'transparentModal'`, is applied verbatim by the inner navigator too, so the outermost card inside the native stack keeps the same transparency.
- Basic smoke testing on this branch did not show anything wrong, also all `e2e` test are still passing

## Result

Accessibility-hierarchy depth on the Activity screen drops **62 → 55**, measured on the same build, simulator, and screen state. Text assertions on deep screens now sit ~7 levels below Maestro's fallback threshold instead of straddling it, hopefully removing this source of e2e flakiness on every screen at once.

This is also visible in CI: on `develop`, the `maestro.log` files in the e2e debug artifacts contained Maestro's depth warning (`The current depth of the hierarchy is N…`); in this branch's e2e runs the warning no longer appears (deepest screen observed so far is Discover at 60).

