### PR TITLE
feat(cash): add phone verification

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -27,6 +27,24 @@ tags:
     id: cash-deposit-intro-sign-in
 - tapOn:
     id: cash-deposit-intro-set-up-account
+- assertVisible:
+    text: 'Connect your phone number'
+- tapOn:
+    id: cash-setup-phone-input
+- inputText: '4155550100'
+- tapOn:
+    id: cash-setup-next
+# The OTP input autofocuses; the mock verify accepts only 000000 and advances on fill.
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm your phone'
+    timeout: 10000
+- waitForAnimationToEnd
+- inputText: '000000'
+- extendedWaitUntil:
+    visible:
+      text: 'Enter your information'
+    timeout: 10000
 - repeat:
     while:
       notVisible:

--- a/e2e/utils/SetCashDepositReady.yaml
+++ b/e2e/utils/SetCashDepositReady.yaml
@@ -1,9 +1,8 @@
 appId: ${APP_ID}
 ---
 - runFlow:
-    file: SetCashDepositSetupFact.yaml
+    file: SetCashPhoneVerified.yaml
     env:
-      FACT: phoneVerified
       VALUE: 'true'
 - runFlow:
     file: SetCashDepositSetupFact.yaml

--- a/e2e/utils/SetCashPhoneVerified.yaml
+++ b/e2e/utils/SetCashPhoneVerified.yaml
@@ -1,0 +1,9 @@
+appId: ${APP_ID}
+---
+- openLink: rainbow://e2e/setCashPhoneVerified?value=${VALUE}
+- runFlow:
+    when:
+      visible: 'Open in .*'
+      platform: iOS
+    commands:
+      - tapOn: 'Open'

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -126,6 +126,9 @@ export const event = {
   cashBuyOrderSubmitted: 'cash.buy_submitted',
   cashBuyOrderCompleted: 'cash.buy_completed',
   cashBuyOrderFailed: 'cash.buy_failed',
+  cashPhoneSubmitted: 'cash.phone_submitted',
+  cashPhoneVerified: 'cash.phone_verified',
+  cashPhoneVerifyFailed: 'cash.phone_verify_failed',
   cashCardLinked: 'cash.card_linked',
   cashCardLinkFailed: 'cash.card_link_failed',
   rewardsPressedPendingEarningsCard: 'rewards.pressed_pending_earnings_card',
@@ -535,6 +538,11 @@ export type EventProperties = {
     orderId: string;
     failureReason: OrderFailureReason | null;
     errorCode: 'PAYMENT_REJECTED' | 'GENERIC';
+  };
+  [event.cashPhoneSubmitted]: undefined;
+  [event.cashPhoneVerified]: undefined;
+  [event.cashPhoneVerifyFailed]: {
+    reason: string;
   };
   [event.cashCardLinked]: {
     /** Display brand of the linked card, e.g. "Visa". */

--- a/src/app/navigation/TestDeeplinkHandler.tsx
+++ b/src/app/navigation/TestDeeplinkHandler.tsx
@@ -5,11 +5,13 @@ import URL from 'url-parse';
 
 import { useCashDepositSetupStore } from '@/features/cash/stores/cashDepositSetupStore';
 import { MOCK_LINKED_CARD, useCashPaymentMethodStore } from '@/features/cash/stores/cashPaymentMethodStore';
+import { useCashSetupSessionStore } from '@/features/cash/stores/cashSetupSessionStore';
 import { isCashDepositSetupFactKey } from '@/features/cash/stores/deriveCashDepositSetupStatus';
 import { type ExperimentalConfigKey } from '@/features/config/constants/experimental';
 import { useExperimentalConfigStore } from '@/features/config/stores/experimentalConfigStore';
 import { savePIN } from '@/features/local-auth/pinAuthentication';
 import { useSandboxDiagnosticsStore } from '@/features/sandbox/data/stores/sandboxDiagnosticsStore';
+import { time } from '@/framework/core/utils/time';
 import { logger } from '@/logger';
 import Navigation from '@/navigation/Navigation';
 import Routes from '@/navigation/routesNames';
@@ -46,6 +48,18 @@ export function TestDeeplinkHandler() {
         case 'setCashDepositSetupFact':
           if (query.fact && isCashDepositSetupFactKey(query.fact)) {
             useCashDepositSetupStore.getState().setFact(query.fact, query.value === 'true');
+          }
+          break;
+        case 'setCashPhoneVerified':
+          if (query.value === 'true') {
+            useCashSetupSessionStore.getState().setPhoneVerified({
+              userId: 'e2e-user-id',
+              phoneNationalNumber: '4155550100',
+              token: 'bst_e2e',
+              expiresAt: Date.now() + time.days(1),
+            });
+          } else {
+            useCashSetupSessionStore.getState().reset();
           }
           break;
         case 'setCashLinkedCard':

--- a/src/components/GweiInputPill.tsx
+++ b/src/components/GweiInputPill.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import { Platform, type TextInput } from 'react-native';
 
 import { LinearGradient } from 'expo-linear-gradient';
-// @ts-expect-error - no declaration file
 import TextInputMask from 'react-native-text-input-mask';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';

--- a/src/features/cash/components/OtpInput.tsx
+++ b/src/features/cash/components/OtpInput.tsx
@@ -1,0 +1,82 @@
+import React, { memo, useCallback, useEffect, useRef } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
+
+import { Box, Text, useForegroundColor } from '@/design-system';
+
+type OtpInputProps = {
+  value: string;
+  onChange: (code: string) => void;
+  length: number;
+  disabled?: boolean;
+  error?: boolean;
+  testID?: string;
+};
+
+export const OtpInput = memo(function OtpInput({
+  value,
+  onChange,
+  length,
+  disabled = false,
+  error = false,
+  testID = 'otp-input',
+}: OtpInputProps) {
+  const red = useForegroundColor('red');
+  const inputRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    if (disabled) inputRef.current?.blur();
+    else if (error) inputRef.current?.focus();
+  }, [disabled, error]);
+
+  const onChangeText = useCallback(
+    (text: string) => {
+      if (disabled) return;
+      const digits = text.replace(/\D/g, '').slice(0, length);
+      if (digits === value) return;
+      onChange(digits);
+    },
+    [disabled, length, onChange, value]
+  );
+
+  return (
+    <Box flexDirection="row" gap={8}>
+      {Array.from({ length }, (_, index) => (
+        <Box
+          alignItems="center"
+          background="fillTertiary"
+          borderRadius={20}
+          flexBasis={0}
+          flexGrow={1}
+          height={{ custom: 56 }}
+          justifyContent="center"
+          key={index}
+          style={{ borderColor: error ? red : 'transparent', borderWidth: 2 }}
+        >
+          <Text align="center" color={error ? 'red' : 'label'} size="22pt" weight="heavy">
+            {value[index] ?? ''}
+          </Text>
+        </Box>
+      ))}
+      <TextInput
+        autoComplete="sms-otp"
+        autoFocus
+        caretHidden
+        keyboardType="number-pad"
+        maxLength={length}
+        onChangeText={onChangeText}
+        ref={inputRef}
+        style={styles.hiddenInput}
+        testID={testID}
+        textContentType="oneTimeCode"
+        value={value}
+      />
+    </Box>
+  );
+});
+
+const styles = StyleSheet.create({
+  hiddenInput: {
+    ...StyleSheet.absoluteFillObject,
+    opacity: 0,
+  },
+});

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupCancelButton.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupCancelButton.tsx
@@ -14,7 +14,7 @@ export const SetupCancelButton = memo(function SetupCancelButton({ onPress, test
     <ButtonPressAnimation onPress={onPress} scaleTo={0.92} testID={testID}>
       <Box
         alignItems="center"
-        background="surfaceSecondary"
+        background="fillTertiary"
         borderRadius={18}
         height={{ custom: 36 }}
         justifyContent="center"

--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
@@ -13,6 +13,7 @@ import { SetupActionButton } from './SetupActionButton';
 
 type SetupStepLayoutProps = {
   title: string;
+  subtitle?: string;
   children?: ReactNode;
   /** Overrides the default "Next" CTA label. */
   actionLabel?: string;
@@ -25,6 +26,7 @@ type SetupStepLayoutProps = {
 
 export const SetupStepLayout = memo(function SetupStepLayout({
   title,
+  subtitle,
   children,
   actionLabel,
   onAction,
@@ -34,7 +36,6 @@ export const SetupStepLayout = memo(function SetupStepLayout({
 }: SetupStepLayoutProps) {
   const { next, back } = useCashDepositSetupNavigation();
   const surfacePrimaryElevated = useBackgroundColor('surfacePrimaryElevated');
-  const surfaceSecondaryElevated = useBackgroundColor('surfaceSecondaryElevated');
   const insets = useSafeAreaInsets();
 
   return (
@@ -54,10 +55,10 @@ export const SetupStepLayout = memo(function SetupStepLayout({
         <ButtonPressAnimation disabled={backDisabled} onPress={back} scaleTo={0.8} testID="cash-setup-back">
           <Box
             alignItems="center"
+            background="fillTertiary"
             borderRadius={18}
             height={{ custom: 36 }}
             justifyContent="center"
-            style={{ backgroundColor: surfaceSecondaryElevated }}
             width={{ custom: 36 }}
           >
             <Text align="center" color="label" size="17pt" weight="heavy">
@@ -66,10 +67,15 @@ export const SetupStepLayout = memo(function SetupStepLayout({
           </Box>
         </ButtonPressAnimation>
 
-        <Box paddingTop="24px">
+        <Box gap={24} paddingTop="24px">
           <Text color="label" size="26pt" weight="heavy">
             {title}
           </Text>
+          {subtitle != null && (
+            <Text color="labelSecondary" size="17pt / 135%" weight="bold">
+              {subtitle}
+            </Text>
+          )}
         </Box>
 
         <Box style={styles.body}>{children}</Box>

--- a/src/features/cash/screens/cash-deposit-setup/components/useSetupInputTextStyle.ts
+++ b/src/features/cash/screens/cash-deposit-setup/components/useSetupInputTextStyle.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { Platform, type TextStyle } from 'react-native';
+
+import { useBackgroundColor, useForegroundColor } from '@/design-system';
+import { fonts } from '@/design-system/typography/typography';
+
+export function useSetupInputTextStyle(): TextStyle {
+  const fillTertiary = useBackgroundColor('fillTertiary');
+  const label = useForegroundColor('label');
+  return useMemo(
+    () => ({
+      ...fonts.SFProRounded.bold,
+      backgroundColor: fillTertiary,
+      borderRadius: 20,
+      borderWidth: 0,
+      color: label,
+      fontSize: 17,
+      letterSpacing: 0.37,
+      paddingLeft: 14,
+      paddingRight: 16,
+      // Fixed height + zero vertical padding lets Android gravity center the text; a snug
+      // padding-derived height positions it baseline-from-top, which sits high with this font.
+      ...(Platform.OS === 'android'
+        ? ({ height: 45, includeFontPadding: false, paddingVertical: 0, textAlignVertical: 'center' } as const)
+        : { paddingVertical: 12 }),
+    }),
+    [fillTertiary, label]
+  );
+}

--- a/src/features/cash/screens/cash-deposit-setup/steps.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.test.ts
@@ -26,10 +26,10 @@ describe('Cash Deposit Setup steps', () => {
   });
 
   it('maps the milestone steps to their facts', () => {
-    expect(getSetupStep(Routes.CASH_SETUP_CONFIRM_PHONE)?.milestone).toBe('phoneVerified');
     expect(getSetupStep(Routes.CASH_SETUP_REVIEW)?.milestone).toBe('kycPassed');
     expect(getSetupStep(Routes.CASH_SETUP_PASSKEY)?.milestone).toBe('passkeyRegistered');
     expect(getSetupStep(Routes.CASH_SETUP_CARD_DETAILS)?.milestone).toBeUndefined();
+    expect(getSetupStep(Routes.CASH_SETUP_CONFIRM_PHONE)?.milestone).toBeUndefined();
     expect(getSetupStep(Routes.CASH_SETUP_PHONE)?.milestone).toBeUndefined();
   });
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.ts
@@ -16,7 +16,7 @@ export type CashDepositSetupStep = {
 /** The Setup flow order and each step's milestone fact; reorder by editing this array. */
 export const SETUP_STEP_ORDER: readonly CashDepositSetupStep[] = [
   { id: Routes.CASH_SETUP_PHONE },
-  { id: Routes.CASH_SETUP_CONFIRM_PHONE, milestone: 'phoneVerified' },
+  { id: Routes.CASH_SETUP_CONFIRM_PHONE },
   { id: Routes.CASH_SETUP_IDENTITY },
   { id: Routes.CASH_SETUP_SSN },
   { id: Routes.CASH_SETUP_REVIEW, milestone: 'kycPassed' },

--- a/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/CardDetailsStep.tsx
@@ -1,13 +1,12 @@
-import React, { memo, useEffect, useMemo } from 'react';
-import { type TextStyle } from 'react-native';
+import React, { memo, useEffect } from 'react';
 
 import { BivoCardInput, BivoCVCInput, BivoTextInput } from '@bivoglobal/payment-react-native';
 
-import { Box, Text, useBackgroundColor, useForegroundColor } from '@/design-system';
-import { fonts } from '@/design-system/typography/typography';
+import { Box, Text } from '@/design-system';
 import * as i18n from '@/languages';
 
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useSetupInputTextStyle } from '../components/useSetupInputTextStyle';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 import { CARD_FIELD, useCardLinkFlow } from './useCardLinkFlow';
 
@@ -16,23 +15,7 @@ const l = i18n.l.cash.deposit_setup.card_details;
 export const CardDetailsStep = memo(function CardLinkForm() {
   const { state, bivoStore, isReady, onFieldStateChange, submit, retry } = useCardLinkFlow();
   const { next } = useCashDepositSetupNavigation();
-  const surfaceSecondary = useBackgroundColor('surfaceSecondary');
-  const label = useForegroundColor('label');
-  const textStyle: TextStyle = useMemo(
-    () => ({
-      ...fonts.SFProRounded.bold,
-      backgroundColor: surfaceSecondary,
-      borderRadius: 20,
-      borderWidth: 0,
-      color: label,
-      fontSize: 17,
-      letterSpacing: 0.37,
-      paddingLeft: 14,
-      paddingRight: 16,
-      paddingVertical: 12,
-    }),
-    [label, surfaceSecondary]
-  );
+  const textStyle = useSetupInputTextStyle();
 
   useEffect(() => {
     if (state === 'success') {

--- a/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
@@ -1,9 +1,51 @@
 import React, { memo } from 'react';
 
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Text } from '@/design-system';
 import * as i18n from '@/languages';
 
+import { OtpInput } from '../../../components/OtpInput';
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { OTP_LENGTH, useVerifyPhoneFlow } from './useVerifyPhoneFlow';
+
+const l = i18n.l.cash.deposit_setup.confirm_phone;
 
 export const ConfirmPhoneStep = memo(function ConfirmPhoneStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.confirm_phone.title)} />;
+  const { state, code, setCode, submit, resend, resending, resendCooldownSeconds } = useVerifyPhoneFlow();
+  const verifying = state === 'verifying';
+  const cooling = resendCooldownSeconds > 0;
+
+  return (
+    <SetupStepLayout
+      actionDisabled={code.length !== OTP_LENGTH}
+      actionLabel={i18n.t(l.confirm)}
+      actionLoading={verifying}
+      backDisabled={verifying}
+      onAction={submit}
+      title={i18n.t(l.title)}
+    >
+      <Box gap={16} paddingTop="24px">
+        <OtpInput
+          disabled={verifying}
+          error={state === 'error'}
+          length={OTP_LENGTH}
+          onChange={newCode => {
+            setCode(newCode);
+            if (newCode.length === OTP_LENGTH) submit();
+          }}
+          value={code}
+        />
+        <ButtonPressAnimation disabled={cooling || resending} onPress={resend} testID="cash-setup-resend-code">
+          <Text color={cooling ? 'labelQuaternary' : 'blue'} size="17pt" weight="bold">
+            {cooling ? `${i18n.t(l.resend_code)} (${resendCooldownSeconds})` : i18n.t(l.resend_code)}
+          </Text>
+        </ButtonPressAnimation>
+        {state === 'error' && (
+          <Text color="red" size="17pt" weight="semibold">
+            {i18n.t(l.error)}
+          </Text>
+        )}
+      </Box>
+    </SetupStepLayout>
+  );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/PhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PhoneStep.tsx
@@ -1,9 +1,71 @@
 import React, { memo } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
 
+import { Box, Text, useForegroundColor } from '@/design-system';
 import * as i18n from '@/languages';
 
+import { US_COUNTRY_CALLING_CODE } from '../../../services/userClient';
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useSetupInputTextStyle } from '../components/useSetupInputTextStyle';
+import { NATIONAL_NUMBER_LENGTH, useSubmitPhoneFlow } from './useSubmitPhoneFlow';
+
+const l = i18n.l.cash.deposit_setup.phone;
+
+function formatNationalNumber(digits: string): string {
+  if (!digits) return '';
+  if (digits.length <= 3) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+}
 
 export const PhoneStep = memo(function PhoneStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.phone.title)} />;
+  const { state, digits, setDigits, submit } = useSubmitPhoneFlow();
+  const submitting = state === 'submitting';
+
+  const labelQuaternary = useForegroundColor('labelQuaternary');
+  const inputTextStyle = useSetupInputTextStyle();
+
+  return (
+    <SetupStepLayout
+      actionDisabled={digits.length !== NATIONAL_NUMBER_LENGTH}
+      actionLoading={submitting}
+      backDisabled={submitting}
+      onAction={submit}
+      subtitle={i18n.t(l.subtitle)}
+      title={i18n.t(l.title)}
+    >
+      <Box gap={12} paddingTop="24px">
+        <Box flexDirection="row" gap={12}>
+          <Box background="fillTertiary" borderRadius={20} justifyContent="center" paddingHorizontal="16px">
+            <Text color="label" size="17pt" weight="bold">
+              {`+${US_COUNTRY_CALLING_CODE}`}
+            </Text>
+          </Box>
+          <TextInput
+            autoFocus
+            editable={!submitting}
+            keyboardType="phone-pad"
+            onChangeText={setDigits}
+            placeholder={i18n.t(l.placeholder)}
+            placeholderTextColor={labelQuaternary}
+            style={[inputTextStyle, styles.input]}
+            testID="cash-setup-phone-input"
+            textContentType="telephoneNumber"
+            value={formatNationalNumber(digits)}
+          />
+        </Box>
+        {state === 'error' && (
+          <Text color="red" size="17pt" weight="semibold">
+            {i18n.t(l.error)}
+          </Text>
+        )}
+      </Box>
+    </SetupStepLayout>
+  );
+});
+
+const styles = StyleSheet.create({
+  input: {
+    flex: 1,
+  },
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
@@ -1,0 +1,144 @@
+import { analytics } from '@/analytics';
+import { logger } from '@/logger';
+
+import { createUserWithPhone } from '../../../services/userClient';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useSubmitPhoneFlowStore } from './useSubmitPhoneFlow';
+import { useVerifyPhoneFlowStore } from './useVerifyPhoneFlow';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: { cashPhoneSubmitted: 'cash.phone_submitted' },
+  },
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('../../../services/userClient', () => ({
+  US_COUNTRY_CALLING_CODE: '1',
+  createUserWithPhone: jest.fn(),
+  resendPhoneCode: jest.fn(),
+  verifyPhone: jest.fn(),
+}));
+
+jest.mock('../useCashDepositSetupNavigation', () => ({
+  useCashDepositSetupNavigation: jest.fn(),
+}));
+
+const mockCreateUserWithPhone = createUserWithPhone as jest.Mock;
+const track = analytics.track as jest.Mock;
+
+const DIGITS = '4155550100';
+const RESPONSE = { userId: 'user-1', resendAfter: 1_750_000_030_000 };
+
+const flow = () => useSubmitPhoneFlowStore.getState();
+const session = () => useCashSetupSessionStore.getState().session;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useCashSetupSessionStore.getState().reset();
+  useSubmitPhoneFlowStore.setState({ state: 'entry', digits: '' });
+  useVerifyPhoneFlowStore.getState().reset();
+  mockCreateUserWithPhone.mockResolvedValue(RESPONSE);
+});
+
+describe('useSubmitPhoneFlowStore.setDigits', () => {
+  const cases = [
+    { input: '4155550100', expected: '4155550100' },
+    { input: '(415) 555-0100', expected: '4155550100' },
+    { input: '+14155550100', expected: '4155550100' },
+    { input: '+1 (415) 555-0100', expected: '4155550100' },
+    { input: '14155550100', expected: '4155550100' },
+    { input: '1234567890', expected: '1234567890' },
+    { input: '(415) 555-01004', expected: '4155550100' },
+  ];
+
+  it.each(cases)('normalizes $input to $expected', ({ input, expected }) => {
+    flow().setDigits(input);
+    expect(flow().digits).toBe(expected);
+  });
+});
+
+describe('useSubmitPhoneFlowStore.submit', () => {
+  it('creates the user, stores the submitted phone session, and tracks', async () => {
+    flow().setDigits(DIGITS);
+
+    await expect(flow().submit()).resolves.toBe(true);
+
+    expect(mockCreateUserWithPhone).toHaveBeenCalledWith({ nationalNumber: DIGITS });
+    expect(session()).toEqual({
+      status: 'phoneSubmitted',
+      userId: RESPONSE.userId,
+      phoneNationalNumber: DIGITS,
+      resendAfter: RESPONSE.resendAfter,
+    });
+    expect(track).toHaveBeenCalledWith('cash.phone_submitted');
+    expect(flow().state).toBe('entry');
+    expect(flow().digits).toBe(DIGITS);
+  });
+
+  it('drops any code/error left in the confirm step so a resubmitted phone starts fresh', async () => {
+    useVerifyPhoneFlowStore.getState().setCode('123456');
+    flow().setDigits(DIGITS);
+
+    await flow().submit();
+
+    expect(useVerifyPhoneFlowStore.getState().code).toBe('');
+    expect(useVerifyPhoneFlowStore.getState().state).toBe('entry');
+  });
+
+  it('keeps the digits, stores no session, and reports the failure when creation throws', async () => {
+    mockCreateUserWithPhone.mockRejectedValue(new Error('network down'));
+    flow().setDigits(DIGITS);
+
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(flow().state).toBe('error');
+    expect(flow().digits).toBe(DIGITS);
+    expect(session().status).toBe('empty');
+    expect(track).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns to entry when the digits are edited after an error', async () => {
+    mockCreateUserWithPhone.mockRejectedValue(new Error('network down'));
+    flow().setDigits(DIGITS);
+    await flow().submit();
+    expect(flow().state).toBe('error');
+
+    flow().setDigits('415');
+
+    expect(flow().state).toBe('entry');
+    expect(flow().digits).toBe('415');
+  });
+
+  it('ignores an incomplete number', async () => {
+    flow().setDigits('415555010');
+
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(mockCreateUserWithPhone).not.toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+  });
+
+  it('ignores a second submit while submitting', async () => {
+    let resolveCreate!: (value: typeof RESPONSE) => void;
+    mockCreateUserWithPhone.mockReturnValue(
+      new Promise(resolve => {
+        resolveCreate = resolve;
+      })
+    );
+    flow().setDigits(DIGITS);
+
+    const first = flow().submit();
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(mockCreateUserWithPhone).toHaveBeenCalledTimes(1);
+    resolveCreate(RESPONSE);
+    await expect(first).resolves.toBe(true);
+  });
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
@@ -1,0 +1,72 @@
+import { useCallback } from 'react';
+
+import { createBaseStore, createStoreActions } from '@storesjs/stores';
+
+import { analytics } from '@/analytics';
+import { logger, RainbowError } from '@/logger';
+
+import { createUserWithPhone, US_COUNTRY_CALLING_CODE } from '../../../services/userClient';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+import { useVerifyPhoneFlowStore } from './useVerifyPhoneFlow';
+
+export const NATIONAL_NUMBER_LENGTH = 10;
+
+export type SubmitPhoneState = 'entry' | 'submitting' | 'error';
+
+type SubmitPhoneFlowStore = {
+  state: SubmitPhoneState;
+  digits: string;
+  setDigits: (text: string) => void;
+  submit: () => Promise<boolean>;
+};
+
+// Pasted or AutoFilled values may carry the +1 country code on top of the 10 national digits.
+function extractNationalDigits(text: string): string {
+  let digits = text.replace(/\D/g, '');
+  if (digits.length > NATIONAL_NUMBER_LENGTH && digits.startsWith(US_COUNTRY_CALLING_CODE)) {
+    digits = digits.slice(US_COUNTRY_CALLING_CODE.length);
+  }
+  return digits.slice(0, NATIONAL_NUMBER_LENGTH);
+}
+
+export const useSubmitPhoneFlowStore = createBaseStore<SubmitPhoneFlowStore>((set, get) => ({
+  state: 'entry',
+  digits: '',
+
+  setDigits: text => set(({ state }) => ({ digits: extractNationalDigits(text), state: state === 'error' ? 'entry' : state })),
+
+  submit: async () => {
+    const { digits, state } = get();
+    if (digits.length !== NATIONAL_NUMBER_LENGTH || state === 'submitting') return false;
+
+    set({ state: 'submitting' });
+    try {
+      const { userId, resendAfter } = await createUserWithPhone({ nationalNumber: digits });
+      useCashSetupSessionStore.getState().setPhoneSubmitted({ userId, phoneNationalNumber: digits, resendAfter });
+      // A fresh code is on its way; drop any code/error left in the kept-mounted confirm step.
+      useVerifyPhoneFlowStore.getState().reset();
+      analytics.track(analytics.event.cashPhoneSubmitted);
+      set({ state: 'entry' });
+      return true;
+    } catch (e) {
+      logger.error(new RainbowError('[useSubmitPhoneFlow]: Failed to create user with phone', e));
+      set({ state: 'error' });
+      return false;
+    }
+  },
+}));
+
+const submitPhoneFlowActions = createStoreActions(useSubmitPhoneFlowStore);
+
+export function useSubmitPhoneFlow(): Pick<SubmitPhoneFlowStore, 'state' | 'digits' | 'setDigits'> & { submit: () => Promise<void> } {
+  const { next } = useCashDepositSetupNavigation();
+  const state = useSubmitPhoneFlowStore(s => s.state);
+  const digits = useSubmitPhoneFlowStore(s => s.digits);
+
+  const submit = useCallback(async () => {
+    if (await submitPhoneFlowActions.submit()) next();
+  }, [next]);
+
+  return { state, digits, setDigits: submitPhoneFlowActions.setDigits, submit };
+}

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.test.ts
@@ -1,0 +1,190 @@
+import { analytics } from '@/analytics';
+import { logger } from '@/logger';
+
+import { resendPhoneCode, verifyPhone } from '../../../services/userClient';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useVerifyPhoneFlowStore } from './useVerifyPhoneFlow';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: { cashPhoneVerified: 'cash.phone_verified', cashPhoneVerifyFailed: 'cash.phone_verify_failed' },
+  },
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('../../../services/userClient', () => ({
+  resendPhoneCode: jest.fn(),
+  verifyPhone: jest.fn(),
+}));
+
+jest.mock('../useCashDepositSetupNavigation', () => ({
+  useCashDepositSetupNavigation: jest.fn(),
+}));
+
+const mockVerifyPhone = verifyPhone as jest.Mock;
+const mockResendPhoneCode = resendPhoneCode as jest.Mock;
+const track = analytics.track as jest.Mock;
+
+const CODE = '123456';
+const TOKEN = { bootstrapToken: 'bst_1', expiresAt: 1_750_000_000_000 };
+const RESEND_AFTER = 1_750_000_030_000;
+
+const flow = () => useVerifyPhoneFlowStore.getState();
+const store = () => useCashSetupSessionStore.getState();
+const session = () => store().session;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  store().reset();
+  store().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+  useVerifyPhoneFlowStore.getState().reset();
+  mockVerifyPhone.mockResolvedValue(TOKEN);
+  mockResendPhoneCode.mockResolvedValue({ resendAfter: RESEND_AFTER });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useVerifyPhoneFlowStore.submit', () => {
+  it('verifies the code, stores the token, tracks, then resets to a clean entry state', async () => {
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe(true);
+
+    expect(mockVerifyPhone).toHaveBeenCalledWith({ userId: 'user-1', code: CODE });
+    expect(session()).toMatchObject({
+      status: 'phoneVerified',
+      bootstrapToken: TOKEN.bootstrapToken,
+      bootstrapTokenExpiresAt: TOKEN.expiresAt,
+    });
+    expect(track).toHaveBeenCalledWith('cash.phone_verified');
+    expect(flow().state).toBe('entry');
+    expect(flow().code).toBe('');
+  });
+
+  it('clears the code, stores no token, and reports the failure when verification throws', async () => {
+    mockVerifyPhone.mockRejectedValue(new Error('wrong code'));
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(flow().state).toBe('error');
+    expect(flow().code).toBe('');
+    expect(session().status).toBe('phoneSubmitted');
+    expect(track).toHaveBeenCalledWith('cash.phone_verify_failed', { reason: 'wrong code' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns to entry when the code is edited after an error', async () => {
+    mockVerifyPhone.mockRejectedValue(new Error('wrong code'));
+    flow().setCode(CODE);
+    await flow().submit();
+    expect(flow().state).toBe('error');
+
+    flow().setCode('1');
+
+    expect(flow().state).toBe('entry');
+    expect(flow().code).toBe('1');
+  });
+
+  it('ignores an incomplete code', async () => {
+    flow().setCode('12345');
+
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(mockVerifyPhone).not.toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+  });
+
+  it('discards a verification that resolves after the session was replaced', async () => {
+    let resolveVerify!: (value: typeof TOKEN) => void;
+    mockVerifyPhone.mockReturnValue(
+      new Promise(resolve => {
+        resolveVerify = resolve;
+      })
+    );
+    flow().setCode(CODE);
+
+    const pending = flow().submit();
+    store().setPhoneSubmitted({ userId: 'user-2', phoneNationalNumber: '4155550101', resendAfter: 0 });
+    resolveVerify(TOKEN);
+
+    await expect(pending).resolves.toBe(false);
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', userId: 'user-2' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+  });
+
+  it('ignores a second submit while verifying', async () => {
+    let resolveVerify!: (value: typeof TOKEN) => void;
+    mockVerifyPhone.mockReturnValue(
+      new Promise(resolve => {
+        resolveVerify = resolve;
+      })
+    );
+    flow().setCode(CODE);
+
+    const first = flow().submit();
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(mockVerifyPhone).toHaveBeenCalledTimes(1);
+    resolveVerify(TOKEN);
+    await expect(first).resolves.toBe(true);
+  });
+});
+
+describe('useVerifyPhoneFlowStore.resend', () => {
+  it('resends only after the backend resendAfter time, then stores the next backend resendAfter', async () => {
+    const now = 1_750_000_000_000;
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(now);
+    store().setResendAfter(now + 1);
+
+    await flow().resend();
+    expect(mockResendPhoneCode).not.toHaveBeenCalled();
+
+    dateNow.mockReturnValue(now + 1);
+    await flow().resend();
+    expect(mockResendPhoneCode).toHaveBeenCalledWith({ userId: 'user-1' });
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', resendAfter: RESEND_AFTER });
+  });
+
+  it('discards a resend that resolves after the session was replaced', async () => {
+    let resolveResend!: (value: { resendAfter: number }) => void;
+    mockResendPhoneCode.mockReturnValue(
+      new Promise(resolve => {
+        resolveResend = resolve;
+      })
+    );
+
+    const pending = flow().resend();
+    store().setPhoneSubmitted({ userId: 'user-2', phoneNationalNumber: '4155550101', resendAfter: 0 });
+    resolveResend({ resendAfter: RESEND_AFTER });
+
+    await pending;
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', userId: 'user-2', resendAfter: 0 });
+    expect(flow().resending).toBe(false);
+  });
+
+  it('ignores a second resend while one is pending', async () => {
+    let resolveResend!: (value: { resendAfter: number }) => void;
+    mockResendPhoneCode.mockReturnValue(
+      new Promise(resolve => {
+        resolveResend = resolve;
+      })
+    );
+
+    const first = flow().resend();
+    await flow().resend();
+    expect(mockResendPhoneCode).toHaveBeenCalledTimes(1);
+
+    resolveResend({ resendAfter: RESEND_AFTER });
+    await first;
+    expect(flow().resending).toBe(false);
+  });
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { createBaseStore, createStoreActions } from '@storesjs/stores';
+
+import { analytics } from '@/analytics';
+import { time } from '@/framework/core/utils/time';
+import { logger, RainbowError } from '@/logger';
+
+import { resendPhoneCode, verifyPhone } from '../../../services/userClient';
+import { selectResendAfter, useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+export const OTP_LENGTH = 6;
+
+export type VerifyPhoneState = 'entry' | 'verifying' | 'error';
+
+type VerifyPhoneFlowStore = {
+  state: VerifyPhoneState;
+  code: string;
+  resending: boolean;
+  setCode: (code: string) => void;
+  submit: () => Promise<boolean>;
+  resend: () => Promise<void>;
+  reset: () => void;
+};
+
+export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((set, get) => ({
+  state: 'entry',
+  code: '',
+  resending: false,
+
+  setCode: code => set(({ state }) => ({ code, state: state === 'error' ? 'entry' : state })),
+
+  submit: async () => {
+    const { code, state } = get();
+    if (code.length !== OTP_LENGTH || state === 'verifying') return false;
+    const { session } = useCashSetupSessionStore.getState();
+    if (session.status !== 'phoneSubmitted') return false;
+
+    set({ state: 'verifying' });
+    try {
+      const { bootstrapToken, expiresAt } = await verifyPhone({ userId: session.userId, code });
+      const { session: current } = useCashSetupSessionStore.getState();
+      if (current.status !== 'phoneSubmitted' || current.userId !== session.userId) return false;
+      useCashSetupSessionStore.getState().setPhoneVerified({
+        userId: session.userId,
+        phoneNationalNumber: session.phoneNationalNumber,
+        token: bootstrapToken,
+        expiresAt,
+      });
+      analytics.track(analytics.event.cashPhoneVerified);
+      set({ code: '', state: 'entry' });
+      return true;
+    } catch (e) {
+      logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to verify phone', e));
+      analytics.track(analytics.event.cashPhoneVerifyFailed, { reason: e instanceof Error ? e.message : String(e) });
+      set({ code: '', state: 'error' });
+      return false;
+    }
+  },
+
+  resend: async () => {
+    if (get().resending) return;
+    const { session } = useCashSetupSessionStore.getState();
+    if (session.status !== 'phoneSubmitted' || Date.now() < session.resendAfter) return;
+
+    set({ resending: true });
+    try {
+      const result = await resendPhoneCode({ userId: session.userId });
+      const { session: current } = useCashSetupSessionStore.getState();
+      if (current.status === 'phoneSubmitted' && current.userId === session.userId) {
+        useCashSetupSessionStore.getState().setResendAfter(result.resendAfter);
+      }
+    } catch (e) {
+      logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to resend code', e));
+    } finally {
+      set({ resending: false });
+    }
+  },
+
+  reset: () => set({ code: '', resending: false, state: 'entry' }),
+}));
+
+const verifyPhoneFlowActions = createStoreActions(useVerifyPhoneFlowStore);
+
+export function useVerifyPhoneFlow(): Pick<VerifyPhoneFlowStore, 'state' | 'code' | 'setCode' | 'resend' | 'resending'> & {
+  submit: () => Promise<void>;
+  resendCooldownSeconds: number;
+} {
+  const { next } = useCashDepositSetupNavigation();
+  const state = useVerifyPhoneFlowStore(s => s.state);
+  const code = useVerifyPhoneFlowStore(s => s.code);
+  const resending = useVerifyPhoneFlowStore(s => s.resending);
+  const resendAfter = useCashSetupSessionStore(selectResendAfter);
+  const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
+
+  const submit = useCallback(async () => {
+    if (await verifyPhoneFlowActions.submit()) next();
+  }, [next]);
+
+  useEffect(() => {
+    if (resendAfter == null) {
+      setResendCooldownSeconds(0);
+      return;
+    }
+
+    const update = () => {
+      const seconds = Math.max(0, Math.ceil((resendAfter - Date.now()) / 1000));
+      setResendCooldownSeconds(seconds);
+      if (seconds <= 0) clearInterval(id);
+    };
+    const id = setInterval(update, time.seconds(1));
+    update();
+    return () => clearInterval(id);
+  }, [resendAfter]);
+
+  return {
+    state,
+    code,
+    setCode: verifyPhoneFlowActions.setCode,
+    submit,
+    resend: verifyPhoneFlowActions.resend,
+    resending,
+    resendCooldownSeconds,
+  };
+}

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -1,0 +1,59 @@
+import { IS_TESTING } from 'react-native-dotenv';
+
+import { time } from '@/framework/core/utils/time';
+import { delay } from '@/utils/delay';
+
+import { getCashPlatformClient } from './rampClient';
+
+export const US_COUNTRY_CALLING_CODE = '1';
+
+type CreateUserWithPhoneResponse = {
+  userId: string;
+  resendAfter: number;
+};
+
+type ResendPhoneCodeResponse = {
+  resendAfter: number;
+};
+
+export async function createUserWithPhone({ nationalNumber }: { nationalNumber: string }): Promise<CreateUserWithPhoneResponse> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return { userId: 'e2e-user-id', resendAfter: Date.now() + time.seconds(30) };
+  }
+
+  const { data } = await getCashPlatformClient().post<CreateUserWithPhoneResponse>('/signup/CreateUserWithPhone', {
+    phone: { countryCode: US_COUNTRY_CALLING_CODE, nationalNumber },
+  });
+  // TODO: remove `resendAfter` harcode once backend returns it
+  return { ...data, resendAfter: Date.now() + time.seconds(30) };
+}
+
+export async function verifyPhone({
+  userId,
+  code,
+}: {
+  userId: string;
+  code: string;
+}): Promise<{ bootstrapToken: string; expiresAt: number }> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    if (code !== '000000') throw new Error('Invalid verification code');
+    return { bootstrapToken: 'bst_e2e', expiresAt: Date.now() + time.hours(1) };
+  }
+
+  const { data } = await getCashPlatformClient().post<{ bootstrapToken: string; expiresIn: string }>('/signup/VerifyPhone', {
+    userId,
+    code,
+  });
+  const expiresInSeconds = Number(data.expiresIn.replace(/s$/, ''));
+  return { bootstrapToken: data.bootstrapToken, expiresAt: Date.now() + expiresInSeconds * 1000 };
+}
+
+export async function resendPhoneCode({ userId }: { userId: string }): Promise<ResendPhoneCodeResponse> {
+  if (IS_TESTING === 'true') return { resendAfter: Date.now() + time.seconds(30) };
+
+  const { data } = await getCashPlatformClient().post<ResendPhoneCodeResponse>('/signup/ResendPhoneCode', { userId });
+  // TODO: remove `resendAfter` harcode once backend returns it
+  return { ...data, resendAfter: Date.now() + time.seconds(30) };
+}

--- a/src/features/cash/stores/cashDepositSetupStore.test.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.test.ts
@@ -1,9 +1,9 @@
 import { useCashDepositSetupStatusStore, useCashDepositSetupStore } from './cashDepositSetupStore';
 import { useCashPaymentMethodStore, type LinkedCard } from './cashPaymentMethodStore';
+import { useCashSetupSessionStore } from './cashSetupSessionStore';
 import { EMPTY_CASH_DEPOSIT_SETUP_FACTS, type CashDepositSetupFacts, type CashDepositSetupStatus } from './deriveCashDepositSetupStatus';
 
 const IDENTITY_DONE: CashDepositSetupFacts = {
-  phoneVerified: true,
   kycPassed: true,
   passkeyRegistered: true,
   hasLinkedWallet: false,
@@ -13,6 +13,7 @@ const A_CARD: LinkedCard = { id: 'card-1', brand: 'Visa', last4: '4242' };
 type Case = {
   name: string;
   facts: CashDepositSetupFacts;
+  tokenExpiresAt: number | null;
   linkedCard: LinkedCard | null;
   expected: CashDepositSetupStatus;
 };
@@ -21,24 +22,42 @@ const cases: Case[] = [
   {
     name: 'identity incomplete → needsIdentity',
     facts: EMPTY_CASH_DEPOSIT_SETUP_FACTS,
+    tokenExpiresAt: null,
     linkedCard: null,
+    expected: 'needsIdentity',
+  },
+  {
+    name: 'facts done but no bootstrap token → needsIdentity',
+    facts: IDENTITY_DONE,
+    tokenExpiresAt: null,
+    linkedCard: A_CARD,
+    expected: 'needsIdentity',
+  },
+  {
+    name: 'facts done but expired bootstrap token → needsIdentity',
+    facts: IDENTITY_DONE,
+    tokenExpiresAt: Date.now() - 1,
+    linkedCard: A_CARD,
     expected: 'needsIdentity',
   },
   {
     name: 'identity done, no card → needsCard',
     facts: IDENTITY_DONE,
+    tokenExpiresAt: Date.now() + 60_000,
     linkedCard: null,
     expected: 'needsCard',
   },
   {
     name: 'identity done, real card linked → needsWallet',
     facts: IDENTITY_DONE,
+    tokenExpiresAt: Date.now() + 60_000,
     linkedCard: A_CARD,
     expected: 'needsWallet',
   },
   {
     name: 'everything done, real card linked → ready',
     facts: { ...IDENTITY_DONE, hasLinkedWallet: true },
+    tokenExpiresAt: Date.now() + 60_000,
     linkedCard: A_CARD,
     expected: 'ready',
   },
@@ -47,12 +66,30 @@ const cases: Case[] = [
 describe('useCashDepositSetupStatusStore', () => {
   beforeEach(() => {
     useCashDepositSetupStore.setState({ facts: EMPTY_CASH_DEPOSIT_SETUP_FACTS });
+    useCashSetupSessionStore.getState().reset();
     useCashPaymentMethodStore.setState({ linkedCard: null });
   });
 
-  it.each(cases)('$name', ({ facts, linkedCard, expected }) => {
+  it.each(cases)('$name', ({ facts, tokenExpiresAt, linkedCard, expected }) => {
     useCashDepositSetupStore.setState({ facts });
+    if (tokenExpiresAt != null) {
+      useCashSetupSessionStore
+        .getState()
+        .setPhoneVerified({ userId: 'user-1', phoneNationalNumber: '4155550100', token: 'bst_test', expiresAt: tokenExpiresAt });
+    }
     useCashPaymentMethodStore.setState({ linkedCard });
     expect(useCashDepositSetupStatusStore.getState()).toBe(expected);
+  });
+
+  it('regresses from ready to needsIdentity when the session store resets', () => {
+    useCashDepositSetupStore.setState({ facts: { ...IDENTITY_DONE, hasLinkedWallet: true } });
+    useCashSetupSessionStore
+      .getState()
+      .setPhoneVerified({ userId: 'user-1', phoneNationalNumber: '4155550100', token: 'bst_test', expiresAt: Date.now() + 60_000 });
+    useCashPaymentMethodStore.setState({ linkedCard: A_CARD });
+    expect(useCashDepositSetupStatusStore.getState()).toBe('ready');
+
+    useCashSetupSessionStore.getState().reset();
+    expect(useCashDepositSetupStatusStore.getState()).toBe('needsIdentity');
   });
 });

--- a/src/features/cash/stores/cashDepositSetupStore.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.ts
@@ -1,6 +1,7 @@
 import { createBaseStore, createDerivedStore } from '@storesjs/stores';
 
 import { useCashPaymentMethodStore } from './cashPaymentMethodStore';
+import { selectIsPhoneVerified, useCashSetupSessionStore } from './cashSetupSessionStore';
 import {
   deriveCashDepositSetupStatus,
   EMPTY_CASH_DEPOSIT_SETUP_FACTS,
@@ -24,8 +25,9 @@ export const useCashDepositSetupStore = createBaseStore<CashDepositSetupStore>(
 export const useCashDepositSetupStatusStore = createDerivedStore<CashDepositSetupStatus>(
   $ => {
     const facts = $(useCashDepositSetupStore, state => state.facts);
+    const phoneVerified = $(useCashSetupSessionStore, selectIsPhoneVerified);
     const linkedCard = $(useCashPaymentMethodStore, state => state.linkedCard);
-    return deriveCashDepositSetupStatus(facts, linkedCard != null);
+    return deriveCashDepositSetupStatus({ ...facts, phoneVerified, hasLinkedCard: linkedCard != null });
   },
   { lockDependencies: true }
 );

--- a/src/features/cash/stores/cashSetupSessionStore.ts
+++ b/src/features/cash/stores/cashSetupSessionStore.ts
@@ -1,0 +1,55 @@
+import { createBaseStore } from '@storesjs/stores';
+
+type EmptyCashSetupSession = {
+  status: 'empty';
+};
+
+type PhoneSubmittedCashSetupSession = {
+  status: 'phoneSubmitted';
+  phoneNationalNumber: string;
+  userId: string;
+  resendAfter: number;
+};
+
+type VerifiedCashSetupSession = {
+  status: 'phoneVerified';
+  phoneNationalNumber: string;
+  userId: string;
+  bootstrapToken: string;
+  bootstrapTokenExpiresAt: number;
+};
+
+type CashSetupSession = EmptyCashSetupSession | PhoneSubmittedCashSetupSession | VerifiedCashSetupSession;
+
+type CashSetupSessionStore = {
+  session: CashSetupSession;
+  setPhoneSubmitted: (params: { userId: string; phoneNationalNumber: string; resendAfter: number }) => void;
+  setResendAfter: (resendAfter: number) => void;
+  setPhoneVerified: (params: { userId: string; phoneNationalNumber: string; token: string; expiresAt: number }) => void;
+  reset: () => void;
+};
+
+const EMPTY_SESSION: EmptyCashSetupSession = { status: 'empty' };
+
+// Intentionally memory-only (PII)
+export const useCashSetupSessionStore = createBaseStore<CashSetupSessionStore>((set, get) => ({
+  session: EMPTY_SESSION,
+  setPhoneSubmitted: ({ userId, phoneNationalNumber, resendAfter }) =>
+    set({ session: { status: 'phoneSubmitted', userId, phoneNationalNumber, resendAfter } }),
+  setResendAfter: resendAfter => {
+    const { session } = get();
+    if (session.status !== 'phoneSubmitted') return;
+    set({ session: { ...session, resendAfter } });
+  },
+  setPhoneVerified: ({ userId, phoneNationalNumber, token, expiresAt }) =>
+    set({ session: { status: 'phoneVerified', userId, phoneNationalNumber, bootstrapToken: token, bootstrapTokenExpiresAt: expiresAt } }),
+  reset: () => set({ session: EMPTY_SESSION }),
+}));
+
+export function selectIsPhoneVerified(state: CashSetupSessionStore): boolean {
+  return state.session.status === 'phoneVerified' && state.session.bootstrapTokenExpiresAt > Date.now();
+}
+
+export function selectResendAfter(state: CashSetupSessionStore): number | null {
+  return state.session.status === 'phoneSubmitted' ? state.session.resendAfter : null;
+}

--- a/src/features/cash/stores/deriveCashDepositSetupStatus.test.ts
+++ b/src/features/cash/stores/deriveCashDepositSetupStatus.test.ts
@@ -1,29 +1,39 @@
-import { deriveCashDepositSetupStatus, EMPTY_CASH_DEPOSIT_SETUP_FACTS, type CashDepositSetupFacts } from './deriveCashDepositSetupStatus';
+import { deriveCashDepositSetupStatus, EMPTY_CASH_DEPOSIT_SETUP_FACTS } from './deriveCashDepositSetupStatus';
 
-const facts = (overrides: Partial<CashDepositSetupFacts>): CashDepositSetupFacts => ({
+const inputs = (overrides: Partial<Parameters<typeof deriveCashDepositSetupStatus>[0]>) => ({
   ...EMPTY_CASH_DEPOSIT_SETUP_FACTS,
+  phoneVerified: false,
+  hasLinkedCard: false,
   ...overrides,
 });
 
 describe('deriveCashDepositSetupStatus', () => {
   it('is needsIdentity when the identity half is incomplete', () => {
-    expect(deriveCashDepositSetupStatus(EMPTY_CASH_DEPOSIT_SETUP_FACTS, false)).toBe('needsIdentity');
-    expect(deriveCashDepositSetupStatus(facts({ phoneVerified: true, kycPassed: true }), false)).toBe('needsIdentity');
+    expect(deriveCashDepositSetupStatus(inputs({}))).toBe('needsIdentity');
+    expect(deriveCashDepositSetupStatus(inputs({ phoneVerified: true, kycPassed: true }))).toBe('needsIdentity');
+  });
+
+  it('is needsIdentity when the phone is not verified, even with every fact true', () => {
+    expect(
+      deriveCashDepositSetupStatus(inputs({ kycPassed: true, passkeyRegistered: true, hasLinkedWallet: true, hasLinkedCard: true }))
+    ).toBe('needsIdentity');
   });
 
   it('is needsCard once identity is complete but no card is linked', () => {
-    expect(deriveCashDepositSetupStatus(facts({ phoneVerified: true, kycPassed: true, passkeyRegistered: true }), false)).toBe('needsCard');
+    expect(deriveCashDepositSetupStatus(inputs({ phoneVerified: true, kycPassed: true, passkeyRegistered: true }))).toBe('needsCard');
   });
 
   it('is needsWallet once a card is linked but no wallet is', () => {
-    expect(deriveCashDepositSetupStatus(facts({ phoneVerified: true, kycPassed: true, passkeyRegistered: true }), true)).toBe(
-      'needsWallet'
-    );
+    expect(
+      deriveCashDepositSetupStatus(inputs({ phoneVerified: true, kycPassed: true, passkeyRegistered: true, hasLinkedCard: true }))
+    ).toBe('needsWallet');
   });
 
   it('is ready when every fact is satisfied', () => {
     expect(
-      deriveCashDepositSetupStatus({ phoneVerified: true, kycPassed: true, passkeyRegistered: true, hasLinkedWallet: true }, true)
+      deriveCashDepositSetupStatus(
+        inputs({ phoneVerified: true, kycPassed: true, passkeyRegistered: true, hasLinkedCard: true, hasLinkedWallet: true })
+      )
     ).toBe('ready');
   });
 });

--- a/src/features/cash/stores/deriveCashDepositSetupStatus.ts
+++ b/src/features/cash/stores/deriveCashDepositSetupStatus.ts
@@ -1,24 +1,24 @@
 export type CashDepositSetupStatus = 'needsIdentity' | 'needsCard' | 'needsWallet' | 'ready';
 
 export type CashDepositSetupFacts = {
-  phoneVerified: boolean;
   kycPassed: boolean;
   passkeyRegistered: boolean;
   hasLinkedWallet: boolean;
 };
 
 export const EMPTY_CASH_DEPOSIT_SETUP_FACTS: CashDepositSetupFacts = {
-  phoneVerified: false,
   kycPassed: false,
   passkeyRegistered: false,
   hasLinkedWallet: false,
 };
 
-export function deriveCashDepositSetupStatus(facts: CashDepositSetupFacts, hasLinkedCard: boolean): CashDepositSetupStatus {
-  const identityComplete = facts.phoneVerified && facts.kycPassed && facts.passkeyRegistered;
+export function deriveCashDepositSetupStatus(
+  inputs: CashDepositSetupFacts & { phoneVerified: boolean; hasLinkedCard: boolean }
+): CashDepositSetupStatus {
+  const identityComplete = inputs.phoneVerified && inputs.kycPassed && inputs.passkeyRegistered;
   if (!identityComplete) return 'needsIdentity';
-  if (!hasLinkedCard) return 'needsCard';
-  if (!facts.hasLinkedWallet) return 'needsWallet';
+  if (!inputs.hasLinkedCard) return 'needsCard';
+  if (!inputs.hasLinkedWallet) return 'needsWallet';
   return 'ready';
 }
 

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -19,6 +19,7 @@ import {
   type CashMockOrderOutcome,
 } from '@/features/cash/stores/cashMockOrderOutcomeStore';
 import { useCashPaymentMethodStore } from '@/features/cash/stores/cashPaymentMethodStore';
+import { useCashSetupSessionStore } from '@/features/cash/stores/cashSetupSessionStore';
 import { EMPTY_CASH_DEPOSIT_SETUP_FACTS, type CashDepositSetupFacts } from '@/features/cash/stores/deriveCashDepositSetupStatus';
 import { defaultConfig, defaultConfigValues, type ExperimentalConfigKey } from '@/features/config/constants/experimental';
 import { useExperimentalConfigStore } from '@/features/config/stores/experimentalConfigStore';
@@ -28,6 +29,7 @@ import { isAuthenticated } from '@/features/local-auth/isAuthenticated';
 import { wipeKeychain } from '@/features/local-auth/legacyKeychain';
 import { ChainId } from '@/features/network/types/backendNetworks';
 import { useSandboxDiagnosticsStore } from '@/features/sandbox/data/stores/sandboxDiagnosticsStore';
+import { time } from '@/framework/core/utils/time';
 import { WrappedAlert as Alert } from '@/helpers/alert';
 import { getPublicKeyOfTheSigningWalletAndCreateWalletIfNeeded } from '@/helpers/signingWallet';
 import * as i18n from '@/languages';
@@ -531,6 +533,18 @@ export const DevSection = () => {
                 titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_deposit_setup_facts[key])} />}
               />
             ))}
+            <MenuItem
+              onPress={() =>
+                useCashSetupSessionStore.getState().setPhoneVerified({
+                  userId: 'dev-user-id',
+                  phoneNationalNumber: '4155550100',
+                  token: 'bst_dev',
+                  expiresAt: Date.now() + time.hours(1),
+                })
+              }
+              size={52}
+              titleComponent={<MenuItem.Title text={i18n.t(i18n.l.developer_settings.cash_set_phone_verified)} />}
+            />
             <MenuItem
               onPress={() => useCashPaymentMethodStore.getState().clearLinkedCard()}
               size={52}

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -502,11 +502,11 @@
       "restart_app": "Restart App",
       "reset_experimental_config": "Reset Experimental Config",
       "cash_deposit_setup_facts": {
-        "phoneVerified": "Phone verified",
         "kycPassed": "KYC passed",
         "passkeyRegistered": "Passkey registered",
         "hasLinkedWallet": "Has linked wallet"
       },
+      "cash_set_phone_verified": "Set phone verified",
       "cash_clear_linked_card": "Clear linked card",
       "cash_order_outcome": {
         "title": "Cash order outcome",
@@ -1585,8 +1585,18 @@
       "deposit_setup": {
         "next": "Next",
         "finish": "Finish",
-        "phone": { "title": "Connect your phone number" },
-        "confirm_phone": { "title": "Confirm your phone" },
+        "phone": {
+          "title": "Connect your phone number",
+          "subtitle": "This will be how you login in the future.",
+          "placeholder": "Phone Number",
+          "error": "We couldn't send a code to that number. Please try again."
+        },
+        "confirm_phone": {
+          "title": "Confirm your phone",
+          "confirm": "Confirm",
+          "resend_code": "Resend code",
+          "error": "That code didn’t work. Please try again."
+        },
         "identity": { "title": "Enter your information" },
         "ssn": { "title": "Last 4 of SSN" },
         "review": { "title": "Review" },

--- a/types/react-native-text-input-mask.d.ts
+++ b/types/react-native-text-input-mask.d.ts
@@ -1,0 +1,14 @@
+declare module 'react-native-text-input-mask' {
+  import { type ForwardRefExoticComponent, type RefAttributes } from 'react';
+  import { type TextInput, type TextInputProps } from 'react-native';
+
+  export interface TextInputMaskProps extends Omit<TextInputProps, 'onChangeText'> {
+    mask?: string;
+    maskDefaultValue?: boolean;
+    /** `extracted` is the raw value with the mask's literal characters stripped. */
+    onChangeText?: (formatted: string, extracted?: string) => void;
+  }
+
+  const TextInputMask: ForwardRefExoticComponent<TextInputMaskProps & RefAttributes<TextInput>>;
+  export default TextInputMask;
+}


### PR DESCRIPTION
## Why?

Setup's two phone steps were placeholders — "phone verified" was a mock fact toggled from dev settings. This PR wires them to the staging UserService: entering a US phone number triggers a real SMS, and confirming the 6-digit code stores the bootstrap token that identity submission has to present later. It's the first real signup call in the Cash Setup wizard.

## Approach

- **"Phone verified" is now derived, not persisted** — it means "a live, unexpired bootstrap token is in memory". The mid-setup session (phone number, user id, token) is deliberately memory-only: the token is a short-lived bearer and the phone number is PII, so neither touches disk. Intended consequence: app restart or token expiry regresses Setup back to the phone step, which guarantees identity can never be submitted against a dead token.
- **Bootstrap token expiry is checked only when the setup status recomputes** — there's no timer watching the token (the only interval in the change is the resend-cooldown countdown on the confirm step). Accepted staleness; worst case is one failed call on a token that died while the app sat idle.
- **The 30s resend cooldown is hardcoded client-side** but modeled as if the backend returned it (TODOs mark both spots) — the contract doesn't specify a cadence yet, and this keeps the eventual swap to a real value one-line.
- **All failures show one generic error + retry** — the gateway has no error contract yet, so wrong code, attempt limit, and network errors aren't distinguishable.

## Going back

Going back during the Setup process shouldn't always be allowed and I'm tracking this as a separate task https://linear.app/rainbow/issue/APP-3906/investigate-do-we-want-to-disable-go-back-both-software-and-hardware

## Known gaps

- US numbers only; +1 is fixed, no country picker.
- An already-registered phone isn't recognized. The backend signals it by returning an empty bootstrap token on verify; this PR doesn't special-case that yet, so such a user advances into a wizard they can't finish.
- Pasting the OTP from a real SMS on physical iPhone/Android (auto-paste / keyboard suggestion) isn't verified yet — tracked in [APP-3907](https://linear.app/rainbow/issue/APP-3907/ensure-pasting-otp-on-real-iphoneandroid-works-using-auto-paste).

## Visuals

Buttons do not have proper loading state as I'm using e2e env to demo it

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-07-10 at 00.49.09.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2accaa5a-f2fb-4d81-b74c-d63372aaec71.mov" />](https://app.graphite.com/user-attachments/video/2accaa5a-f2fb-4d81-b74c-d63372aaec71.mov)<br><br> | [android.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2995ebed-447c-474f-9ee9-e1661943fab7.webm" />](https://app.graphite.com/user-attachments/video/2995ebed-447c-474f-9ee9-e1661943fab7.webm)<br> |

## What to test

Against staging — real SMS goes to real numbers (in dev mode the code is logged server-side instead):

1. Add Cash → start Setup, enter a US phone number → SMS arrives.
2. Type the 6-digit code — it verifies on the last digit without pressing Confirm → lands on the Identity step.
3. Enter a wrong code → generic error, code clears, retyping works immediately.
4. "Resend code" is disabled with a countdown for 30s after submitting the number or resending.
5. Kill and relaunch the app mid-Setup → Setup restarts at the phone step (nothing is persisted).