### PR TITLE
fix(cash): onboarding should respect opened keyboard

### DIFF
--- a/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/components/SetupStepLayout.tsx
@@ -1,6 +1,7 @@
 import React, { memo, type ReactNode } from 'react';
 import { StyleSheet } from 'react-native';
 
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
@@ -32,54 +33,66 @@ export const SetupStepLayout = memo(function SetupStepLayout({
   backDisabled = false,
 }: SetupStepLayoutProps) {
   const { next, back } = useCashDepositSetupNavigation();
+  const surfacePrimaryElevated = useBackgroundColor('surfacePrimaryElevated');
   const surfaceSecondaryElevated = useBackgroundColor('surfaceSecondaryElevated');
   const insets = useSafeAreaInsets();
 
   return (
-    <Box
-      background="surfacePrimaryElevated"
-      height="full"
-      paddingHorizontal="24px"
-      width="full"
-      style={{ paddingBottom: insets.bottom + 16, paddingTop: insets.top + 24 }}
+    <KeyboardAvoidingView
+      behavior="padding"
+      // Closed keyboard: the button sits insets.bottom above the screen bottom; open: 20 above the keyboard.
+      keyboardVerticalOffset={20 - insets.bottom}
+      style={[styles.keyboardAvoidingView, { backgroundColor: surfacePrimaryElevated }]}
     >
-      <ButtonPressAnimation disabled={backDisabled} onPress={back} scaleTo={0.8} testID="cash-setup-back">
-        <Box
-          alignItems="center"
-          borderRadius={18}
-          height={{ custom: 36 }}
-          justifyContent="center"
-          style={{ backgroundColor: surfaceSecondaryElevated }}
-          width={{ custom: 36 }}
-        >
-          <Text align="center" color="label" size="17pt" weight="heavy">
-            {'􀆉'}
+      <Box
+        background="surfacePrimaryElevated"
+        height="full"
+        paddingHorizontal="24px"
+        width="full"
+        style={{ paddingBottom: insets.bottom, paddingTop: insets.top + 24 }}
+      >
+        <ButtonPressAnimation disabled={backDisabled} onPress={back} scaleTo={0.8} testID="cash-setup-back">
+          <Box
+            alignItems="center"
+            borderRadius={18}
+            height={{ custom: 36 }}
+            justifyContent="center"
+            style={{ backgroundColor: surfaceSecondaryElevated }}
+            width={{ custom: 36 }}
+          >
+            <Text align="center" color="label" size="17pt" weight="heavy">
+              {'􀆉'}
+            </Text>
+          </Box>
+        </ButtonPressAnimation>
+
+        <Box paddingTop="24px">
+          <Text color="label" size="26pt" weight="heavy">
+            {title}
           </Text>
         </Box>
-      </ButtonPressAnimation>
 
-      <Box paddingTop="24px">
-        <Text color="label" size="26pt" weight="heavy">
-          {title}
-        </Text>
+        <Box style={styles.body}>{children}</Box>
+
+        <SetupActionButton
+          disabled={actionDisabled}
+          label={actionLabel ?? i18n.t(i18n.l.cash.deposit_setup.next)}
+          loading={actionLoading}
+          onPress={onAction ?? next}
+          testID="cash-setup-next"
+          textSize="20pt"
+        />
       </Box>
-
-      <Box style={styles.body}>{children}</Box>
-
-      <SetupActionButton
-        disabled={actionDisabled}
-        label={actionLabel ?? i18n.t(i18n.l.cash.deposit_setup.next)}
-        loading={actionLoading}
-        onPress={onAction ?? next}
-        testID="cash-setup-next"
-        textSize="20pt"
-      />
-    </Box>
+    </KeyboardAvoidingView>
   );
 });
 
 const styles = StyleSheet.create({
   body: {
     flex: 1,
+  },
+  keyboardAvoidingView: {
+    flex: 1,
+    width: '100%',
   },
 });


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3905/make-sure-setupsteplayout-respect-keyboard

## What changed (plus any additional context for devs)

`SetupStepLayout` now wraps its content in a `KeyboardAvoidingView` (from `react-native-keyboard-controller`) so the action button stays visible and accessible when the keyboard is open. The vertical offset is calculated as `20 - insets.bottom` so the button sits `insets.bottom` above the screen bottom when the keyboard is closed, and 20pt above the keyboard when it's open.

## Screen recordings / screenshots

| Before | After |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-07-09 at 17.31.12.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5b67f61c-d7bd-48bc-8afb-bbee66dd6d64.mov" />](https://app.graphite.com/user-attachments/video/5b67f61c-d7bd-48bc-8afb-bbee66dd6d64.mov)<br> | [Simulator Screen Recording - iPhone 17 Pro - 2026-07-09 at 17.50.02.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2a1f26a9-16a2-4e40-8e42-bdad70871405.mov" />](https://app.graphite.com/user-attachments/video/2a1f26a9-16a2-4e40-8e42-bdad70871405.mov)<br> |
| [before.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7e269e57-4d6f-4eae-9436-5c0eb46ee38f.webm" />](https://app.graphite.com/user-attachments/video/7e269e57-4d6f-4eae-9436-5c0eb46ee38f.webm)<br> | [after.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/b3e5940e-91e1-44f5-8d91-811f6adf8767.webm" />](https://app.graphite.com/user-attachments/video/b3e5940e-91e1-44f5-8d91-811f6adf8767.webm) |

## What to test

- Open the cash deposit setup flow and navigate to a step that has a text input (e.g. an amount or account field).
- Tap the input to bring up the keyboard and confirm the action button remains visible above the keyboard rather than being obscured.
- Verify the back button still works and is not disabled where expected.