### PR TITLE
feat(cash): add entering firstname/lastname/dob screen

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -43,8 +43,37 @@ tags:
 - inputText: '000000'
 - extendedWaitUntil:
     visible:
-      text: 'Enter your information'
+      text: 'Enter some information about yourself'
     timeout: 10000
+- tapOn:
+    id: cash-setup-first-name-input
+- inputText: 'Ada'
+- tapOn:
+    id: cash-setup-last-name-input
+- inputText: 'Lovelace'
+- tapOn:
+    id: cash-setup-dob-input
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible:
+          id: cash-setup-dob-picker
+      - tapOn:
+          id: cash-setup-dob-picker-confirm
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      # RN testID is not applied to the native dialog on Android (Detox-only), so target the platform ids
+      - assertVisible:
+          id: android:id/datePicker
+      - tapOn:
+          id: android:id/button1
+- tapOn:
+    id: cash-setup-next
+- assertVisible:
+    text: 'Last 4 of SSN'
 - repeat:
     while:
       notVisible:

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4375,6 +4375,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - RNDateTimePicker (9.1.0):
+    - React-Core
   - RNDeviceInfo (15.0.1):
     - React-Core
   - RNFastImage (8.5.11):
@@ -5046,6 +5048,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFastImage (from `../node_modules/react-native-fast-image`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
@@ -5389,6 +5392,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
+  RNDateTimePicker:
+    :path: "../node_modules/@react-native-community/datetimepicker"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNFastImage:
@@ -5615,6 +5620,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: aa75595c1aefa18f868452091fa0c411a516ce11
   RNCClipboard: e1d17c9d093d8129ef50b39b63a17a0e8ccd0ade
   RNCMaskedView: 84430d0d76eff7473af742c3c2298ed23cc4a296
+  RNDateTimePicker: a4679e6488003e5fb68502b50ffb1b74b8b31ca0
   RNDeviceInfo: 36d7f232bfe7c9b5c494cb7793230424ed32c388
   RNFastImage: b4741be7fc96457586f610a1a454817518376819
   RNFBApp: a82d90b5d0bdf193b5ea570323df8ad2729c1326

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-camera-roll/camera-roll": "7.10.0",
     "@react-native-clipboard/clipboard": "1.16.2",
+    "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-firebase/app": "23.8.8",
     "@react-native-firebase/firestore": "23.8.8",

--- a/src/app/navigation/TestDeeplinkHandler.tsx
+++ b/src/app/navigation/TestDeeplinkHandler.tsx
@@ -52,11 +52,15 @@ export function TestDeeplinkHandler() {
           break;
         case 'setCashPhoneVerified':
           if (query.value === 'true') {
-            useCashSetupSessionStore.getState().setPhoneVerified({
-              userId: 'e2e-user-id',
-              phoneNationalNumber: '4155550100',
-              token: 'bst_e2e',
-              expiresAt: Date.now() + time.days(1),
+            useCashSetupSessionStore.setState({
+              session: {
+                status: 'phoneVerified',
+                userId: 'e2e-user-id',
+                phoneNationalNumber: '4155550100',
+                bootstrapToken: 'bst_e2e',
+                bootstrapTokenExpiresAt: Date.now() + time.days(1),
+                identity: null,
+              },
             });
           } else {
             useCashSetupSessionStore.getState().reset();

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -25,6 +25,7 @@ import { PasskeyStep } from './steps/PasskeyStep';
 import { PhoneStep } from './steps/PhoneStep';
 import { ReviewStep } from './steps/ReviewStep';
 import { SsnStep } from './steps/SsnStep';
+import { useSubmitPhoneFlowStore } from './steps/useSubmitPhoneFlow';
 
 const STEP_COMPONENTS: Record<CashDepositSetupRoute, React.ReactElement> = {
   [Routes.CASH_SETUP_PHONE]: <PhoneStep />,
@@ -57,7 +58,10 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
     route => goToPage(route)
   );
 
-  useCleanup(CashDepositSetupNavigation.resetNavigationState);
+  useCleanup(() => {
+    CashDepositSetupNavigation.resetNavigationState();
+    useSubmitPhoneFlowStore.getState().reset();
+  });
 
   return (
     <Box style={styles.container}>

--- a/src/features/cash/screens/cash-deposit-setup/steps/IdentityStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/IdentityStep.tsx
@@ -1,9 +1,135 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback, useState } from 'react';
+import { Pressable, StyleSheet, TextInput } from 'react-native';
 
+import { Box, Text, useForegroundColor } from '@/design-system';
+import { useDatePicker } from '@/framework/ui/hooks/useDatePicker';
 import * as i18n from '@/languages';
 
+import { isValidDateOfBirth, isValidLegalName, toDate, toDateOfBirth } from '../../../services/cashSetupIdentityService';
+import { useCashSetupSessionStore, type CashSetupDateOfBirth } from '../../../stores/cashSetupSessionStore';
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useSetupInputTextStyle } from '../components/useSetupInputTextStyle';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+const l = i18n.l.cash.deposit_setup.identity;
+
+function formatDateOfBirth({ year, month, day }: CashSetupDateOfBirth): string {
+  return `${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}/${year}`;
+}
+
+function getMaximumDateOfBirth(): Date {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() - 1);
+  return date;
+}
+
+function getInitialDateOfBirth(maximumDate: Date): Date {
+  const date = new Date(maximumDate);
+  date.setFullYear(date.getFullYear() - 18);
+  return date;
+}
 
 export const IdentityStep = memo(function IdentityStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.identity.title)} />;
+  const storedIdentity = useCashSetupSessionStore(state => (state.session.status === 'phoneVerified' ? state.session.identity : null));
+  const [firstName, setFirstName] = useState(storedIdentity?.firstName ?? '');
+  const [lastName, setLastName] = useState(storedIdentity?.lastName ?? '');
+  const [maximumDateOfBirth] = useState(getMaximumDateOfBirth);
+  const [initialDateOfBirth] = useState(() => getInitialDateOfBirth(maximumDateOfBirth));
+  const [dateOfBirth, setDateOfBirth] = useState<CashSetupDateOfBirth | null>(storedIdentity?.dateOfBirth ?? null);
+  const canContinue = isValidLegalName(firstName) && isValidLegalName(lastName) && dateOfBirth !== null && isValidDateOfBirth(dateOfBirth);
+  const inputTextStyle = useSetupInputTextStyle();
+  const labelQuaternary = useForegroundColor('labelQuaternary');
+  const { next } = useCashDepositSetupNavigation();
+  const handleDateOfBirthChange = useCallback((date: Date) => setDateOfBirth(toDateOfBirth(date)), []);
+  const { openPicker, picker } = useDatePicker({
+    confirmLabel: i18n.t(i18n.l.button.done),
+    initialDate: initialDateOfBirth,
+    maximumDate: maximumDateOfBirth,
+    onChange: handleDateOfBirthChange,
+    testID: 'cash-setup-dob-picker',
+    value: dateOfBirth ? toDate(dateOfBirth) : null,
+  });
+
+  const submit = useCallback(() => {
+    if (!canContinue) return;
+    useCashSetupSessionStore.getState().setIdentity({
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+      dateOfBirth,
+    });
+    next();
+  }, [canContinue, dateOfBirth, firstName, lastName, next]);
+
+  return (
+    <SetupStepLayout actionDisabled={!canContinue} onAction={submit} title={i18n.t(l.title)}>
+      <Box paddingTop="24px">
+        <Box flexDirection="row" gap={12}>
+          <TextInput
+            autoCapitalize="words"
+            autoCorrect={false}
+            autoFocus
+            maxLength={100}
+            onChangeText={setFirstName}
+            placeholder={i18n.t(l.first_name)}
+            placeholderTextColor={labelQuaternary}
+            style={[inputTextStyle, styles.nameInput]}
+            testID="cash-setup-first-name-input"
+            textContentType="givenName"
+            value={firstName}
+          />
+          <TextInput
+            autoCapitalize="words"
+            autoCorrect={false}
+            maxLength={100}
+            onChangeText={setLastName}
+            placeholder={i18n.t(l.last_name)}
+            placeholderTextColor={labelQuaternary}
+            style={[inputTextStyle, styles.nameInput]}
+            testID="cash-setup-last-name-input"
+            textContentType="familyName"
+            value={lastName}
+          />
+        </Box>
+
+        <Box paddingTop="24px" style={styles.dateOfBirthLabel}>
+          <Text color="label" size="17pt" weight="bold">
+            {i18n.t(l.date_of_birth)}
+          </Text>
+        </Box>
+        <Box paddingTop="12px">
+          <Pressable
+            accessibilityLabel={i18n.t(l.date_of_birth)}
+            accessibilityRole="button"
+            onPress={openPicker}
+            style={({ pressed }) => [styles.dateOfBirthInput, pressed && styles.dateOfBirthInputPressed]}
+            testID="cash-setup-dob-input"
+          >
+            <Box background="fillTertiary" borderRadius={20} height={45} justifyContent="center" paddingHorizontal="16px">
+              <Text color={dateOfBirth ? 'label' : 'labelQuaternary'} size="17pt" tabularNumbers weight="bold">
+                {dateOfBirth ? formatDateOfBirth(dateOfBirth) : i18n.t(l.date_of_birth_placeholder)}
+              </Text>
+            </Box>
+          </Pressable>
+        </Box>
+        {picker}
+      </Box>
+    </SetupStepLayout>
+  );
+});
+
+const styles = StyleSheet.create({
+  dateOfBirthInput: {
+    width: '100%',
+  },
+  dateOfBirthInputPressed: {
+    opacity: 0.7,
+  },
+  dateOfBirthLabel: {
+    paddingLeft: 14,
+  },
+  nameInput: {
+    flex: 1,
+    minWidth: 0,
+  },
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
@@ -72,7 +72,7 @@ describe('useSubmitPhoneFlowStore.submit', () => {
     expect(mockCreateUserWithPhone).toHaveBeenCalledWith({ nationalNumber: DIGITS });
     expect(session()).toEqual({
       status: 'phoneSubmitted',
-      userId: RESPONSE.userId,
+      challenge: { userId: RESPONSE.userId },
       phoneNationalNumber: DIGITS,
       resendAfter: RESPONSE.resendAfter,
     });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
@@ -19,6 +19,7 @@ type SubmitPhoneFlowStore = {
   digits: string;
   setDigits: (text: string) => void;
   submit: () => Promise<boolean>;
+  reset: () => void;
 };
 
 // Pasted or AutoFilled values may carry the +1 country code on top of the 10 national digits.
@@ -55,6 +56,8 @@ export const useSubmitPhoneFlowStore = createBaseStore<SubmitPhoneFlowStore>((se
       return false;
     }
   },
+
+  reset: () => set({ digits: '', state: 'entry' }),
 }));
 
 const submitPhoneFlowActions = createStoreActions(useSubmitPhoneFlowStore);

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.test.ts
@@ -37,6 +37,11 @@ const RESEND_AFTER = 1_750_000_030_000;
 const flow = () => useVerifyPhoneFlowStore.getState();
 const store = () => useCashSetupSessionStore.getState();
 const session = () => store().session;
+const challenge = () => {
+  const current = session();
+  if (current.status !== 'phoneSubmitted') throw new Error('expected a phoneSubmitted session');
+  return current.challenge;
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -60,6 +65,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     expect(mockVerifyPhone).toHaveBeenCalledWith({ userId: 'user-1', code: CODE });
     expect(session()).toMatchObject({
       status: 'phoneVerified',
+      userId: 'user-1',
       bootstrapToken: TOKEN.bootstrapToken,
       bootstrapTokenExpiresAt: TOKEN.expiresAt,
     });
@@ -117,8 +123,65 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     resolveVerify(TOKEN);
 
     await expect(pending).resolves.toBe(false);
-    expect(session()).toMatchObject({ status: 'phoneSubmitted', userId: 'user-2' });
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { userId: 'user-2' } });
     expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+  });
+
+  it('discards a verification that resolves after a replacement submission for the same user', async () => {
+    let resolveVerify!: (value: typeof TOKEN) => void;
+    mockVerifyPhone.mockReturnValue(
+      new Promise(resolve => {
+        resolveVerify = resolve;
+      })
+    );
+    flow().setCode(CODE);
+
+    const pending = flow().submit();
+    store().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+    resolveVerify(TOKEN);
+
+    await expect(pending).resolves.toBe(false);
+    expect(session().status).toBe('phoneSubmitted');
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+  });
+
+  it('leaves the replacement flow untouched when an old verification rejects', async () => {
+    let rejectVerify!: (error: Error) => void;
+    mockVerifyPhone.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectVerify = reject;
+      })
+    );
+    flow().setCode(CODE);
+
+    const pending = flow().submit();
+    store().setPhoneSubmitted({ userId: 'user-2', phoneNationalNumber: '4155550101', resendAfter: 0 });
+    flow().reset();
+    flow().setCode('654321');
+    rejectVerify(new Error('expired code'));
+
+    await expect(pending).resolves.toBe(false);
+    expect(flow().state).toBe('entry');
+    expect(flow().code).toBe('654321');
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verify_failed', expect.anything());
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('completes a verification when only the resend cooldown changed meanwhile', async () => {
+    let resolveVerify!: (value: typeof TOKEN) => void;
+    mockVerifyPhone.mockReturnValue(
+      new Promise(resolve => {
+        resolveVerify = resolve;
+      })
+    );
+    flow().setCode(CODE);
+
+    const pending = flow().submit();
+    store().setResendAfter(challenge(), RESEND_AFTER);
+    resolveVerify(TOKEN);
+
+    await expect(pending).resolves.toBe(true);
+    expect(session()).toMatchObject({ status: 'phoneVerified', userId: 'user-1' });
   });
 
   it('ignores a second submit while verifying', async () => {
@@ -143,7 +206,7 @@ describe('useVerifyPhoneFlowStore.resend', () => {
   it('resends only after the backend resendAfter time, then stores the next backend resendAfter', async () => {
     const now = 1_750_000_000_000;
     const dateNow = jest.spyOn(Date, 'now').mockReturnValue(now);
-    store().setResendAfter(now + 1);
+    store().setResendAfter(challenge(), now + 1);
 
     await flow().resend();
     expect(mockResendPhoneCode).not.toHaveBeenCalled();
@@ -167,8 +230,40 @@ describe('useVerifyPhoneFlowStore.resend', () => {
     resolveResend({ resendAfter: RESEND_AFTER });
 
     await pending;
-    expect(session()).toMatchObject({ status: 'phoneSubmitted', userId: 'user-2', resendAfter: 0 });
-    expect(flow().resending).toBe(false);
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { userId: 'user-2' }, resendAfter: 0 });
+    expect(flow().resending).toBeNull();
+  });
+
+  it("does not clear a newer resend when an old resend's cleanup runs", async () => {
+    let resolveFirst!: (value: { resendAfter: number }) => void;
+    let resolveSecond!: (value: { resendAfter: number }) => void;
+    mockResendPhoneCode
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveFirst = resolve;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveSecond = resolve;
+        })
+      );
+
+    const first = flow().resend();
+    store().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+    flow().reset();
+    const second = flow().resend();
+    expect(mockResendPhoneCode).toHaveBeenCalledTimes(2);
+
+    resolveFirst({ resendAfter: RESEND_AFTER + 1 });
+    await first;
+    expect(flow().resending).not.toBeNull();
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', resendAfter: 0 });
+
+    resolveSecond({ resendAfter: RESEND_AFTER });
+    await second;
+    expect(flow().resending).toBeNull();
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', resendAfter: RESEND_AFTER });
   });
 
   it('ignores a second resend while one is pending', async () => {
@@ -185,6 +280,6 @@ describe('useVerifyPhoneFlowStore.resend', () => {
 
     resolveResend({ resendAfter: RESEND_AFTER });
     await first;
-    expect(flow().resending).toBe(false);
+    expect(flow().resending).toBeNull();
   });
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
@@ -7,7 +7,7 @@ import { time } from '@/framework/core/utils/time';
 import { logger, RainbowError } from '@/logger';
 
 import { resendPhoneCode, verifyPhone } from '../../../services/userClient';
-import { selectResendAfter, useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { selectResendAfter, useCashSetupSessionStore, type PhoneChallenge } from '../../../stores/cashSetupSessionStore';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
 export const OTP_LENGTH = 6;
@@ -17,7 +17,7 @@ export type VerifyPhoneState = 'entry' | 'verifying' | 'error';
 type VerifyPhoneFlowStore = {
   state: VerifyPhoneState;
   code: string;
-  resending: boolean;
+  resending: PhoneChallenge | null;
   setCode: (code: string) => void;
   submit: () => Promise<boolean>;
   resend: () => Promise<void>;
@@ -27,31 +27,28 @@ type VerifyPhoneFlowStore = {
 export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((set, get) => ({
   state: 'entry',
   code: '',
-  resending: false,
+  resending: null,
 
   setCode: code => set(({ state }) => ({ code, state: state === 'error' ? 'entry' : state })),
 
   submit: async () => {
     const { code, state } = get();
     if (code.length !== OTP_LENGTH || state === 'verifying') return false;
-    const { session } = useCashSetupSessionStore.getState();
+    const sessionStore = useCashSetupSessionStore.getState();
+    const { session } = sessionStore;
     if (session.status !== 'phoneSubmitted') return false;
+    const { challenge } = session;
 
     set({ state: 'verifying' });
     try {
-      const { bootstrapToken, expiresAt } = await verifyPhone({ userId: session.userId, code });
-      const { session: current } = useCashSetupSessionStore.getState();
-      if (current.status !== 'phoneSubmitted' || current.userId !== session.userId) return false;
-      useCashSetupSessionStore.getState().setPhoneVerified({
-        userId: session.userId,
-        phoneNationalNumber: session.phoneNationalNumber,
-        token: bootstrapToken,
-        expiresAt,
-      });
+      const credential = await verifyPhone({ userId: challenge.userId, code });
+      if (!sessionStore.getIsCurrentChallenge(challenge)) return false;
+      sessionStore.setPhoneVerified(challenge, credential);
       analytics.track(analytics.event.cashPhoneVerified);
       set({ code: '', state: 'entry' });
       return true;
     } catch (e) {
+      if (!sessionStore.getIsCurrentChallenge(challenge)) return false;
       logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to verify phone', e));
       analytics.track(analytics.event.cashPhoneVerifyFailed, { reason: e instanceof Error ? e.message : String(e) });
       set({ code: '', state: 'error' });
@@ -60,37 +57,38 @@ export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((se
   },
 
   resend: async () => {
-    if (get().resending) return;
-    const { session } = useCashSetupSessionStore.getState();
+    if (get().resending !== null) return;
+    const sessionStore = useCashSetupSessionStore.getState();
+    const { session } = sessionStore;
     if (session.status !== 'phoneSubmitted' || Date.now() < session.resendAfter) return;
+    const { challenge } = session;
 
-    set({ resending: true });
+    set(({ state }) => ({ resending: challenge, state: state === 'error' ? 'entry' : state }));
     try {
-      const result = await resendPhoneCode({ userId: session.userId });
-      const { session: current } = useCashSetupSessionStore.getState();
-      if (current.status === 'phoneSubmitted' && current.userId === session.userId) {
-        useCashSetupSessionStore.getState().setResendAfter(result.resendAfter);
-      }
+      const { resendAfter } = await resendPhoneCode({ userId: challenge.userId });
+      sessionStore.setResendAfter(challenge, resendAfter);
     } catch (e) {
+      if (!sessionStore.getIsCurrentChallenge(challenge)) return;
       logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to resend code', e));
     } finally {
-      set({ resending: false });
+      set(state => (state.resending === challenge ? { resending: null } : state));
     }
   },
 
-  reset: () => set({ code: '', resending: false, state: 'entry' }),
+  reset: () => set({ code: '', resending: null, state: 'entry' }),
 }));
 
 const verifyPhoneFlowActions = createStoreActions(useVerifyPhoneFlowStore);
 
-export function useVerifyPhoneFlow(): Pick<VerifyPhoneFlowStore, 'state' | 'code' | 'setCode' | 'resend' | 'resending'> & {
+export function useVerifyPhoneFlow(): Pick<VerifyPhoneFlowStore, 'state' | 'code' | 'setCode' | 'resend'> & {
   submit: () => Promise<void>;
+  resending: boolean;
   resendCooldownSeconds: number;
 } {
   const { next } = useCashDepositSetupNavigation();
   const state = useVerifyPhoneFlowStore(s => s.state);
   const code = useVerifyPhoneFlowStore(s => s.code);
-  const resending = useVerifyPhoneFlowStore(s => s.resending);
+  const resending = useVerifyPhoneFlowStore(s => s.resending !== null);
   const resendAfter = useCashSetupSessionStore(selectResendAfter);
   const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
 

--- a/src/features/cash/services/cashSetupIdentityService.test.ts
+++ b/src/features/cash/services/cashSetupIdentityService.test.ts
@@ -1,0 +1,41 @@
+import { isValidDateOfBirth, isValidLegalName } from './cashSetupIdentityService';
+
+const TODAY = new Date(2026, 6, 13);
+
+describe('isValidLegalName', () => {
+  const cases = [
+    { input: 'Ada', expected: true },
+    { input: 'Jean-Luc', expected: true },
+    { input: "O'Connor", expected: true },
+    { input: 'María José', expected: true },
+    { input: '  Ada  ', expected: true },
+    { input: '', expected: false },
+    { input: ' ', expected: false },
+    { input: '-Ada', expected: false },
+    { input: 'Ada-', expected: false },
+    { input: 'Ada  Lovelace', expected: false },
+    { input: 'Ada--Lovelace', expected: false },
+    { input: 'Ada2', expected: false },
+    { input: 'A'.repeat(101), expected: false },
+  ];
+
+  it.each(cases)('returns $expected for "$input"', ({ input, expected }) => {
+    expect(isValidLegalName(input)).toBe(expected);
+  });
+});
+
+describe('isValidDateOfBirth', () => {
+  const cases = [
+    { input: { year: 1990, month: 1, day: 2 }, expected: true },
+    { input: { year: 2024, month: 2, day: 29 }, expected: true },
+    { input: { year: 2023, month: 2, day: 29 }, expected: false },
+    { input: { year: 2000, month: 4, day: 31 }, expected: false },
+    { input: { year: 2000, month: 0, day: 1 }, expected: false },
+    { input: { year: 2026, month: 7, day: 13 }, expected: false },
+    { input: { year: 2026, month: 7, day: 14 }, expected: false },
+  ];
+
+  it.each(cases)('returns $expected for $input', ({ input, expected }) => {
+    expect(isValidDateOfBirth(input, TODAY)).toBe(expected);
+  });
+});

--- a/src/features/cash/services/cashSetupIdentityService.ts
+++ b/src/features/cash/services/cashSetupIdentityService.ts
@@ -1,0 +1,28 @@
+import { isExists, startOfDay } from 'date-fns';
+
+import { type CashSetupDateOfBirth } from '../stores/cashSetupSessionStore';
+
+const MAX_LEGAL_NAME_LENGTH = 100;
+const LEGAL_NAME_PATTERN = /^\p{L}+(?:[ '-]\p{L}+)*$/u;
+
+export function isValidLegalName(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length <= MAX_LEGAL_NAME_LENGTH && LEGAL_NAME_PATTERN.test(trimmed);
+}
+
+export function isValidDateOfBirth(dateOfBirth: CashSetupDateOfBirth, today = new Date()): boolean {
+  const { year, month, day } = dateOfBirth;
+  return isExists(year, month - 1, day) && toDate(dateOfBirth) < startOfDay(today);
+}
+
+export function toDate(dateOfBirth: CashSetupDateOfBirth): Date {
+  return new Date(dateOfBirth.year, dateOfBirth.month - 1, dateOfBirth.day);
+}
+
+export function toDateOfBirth(date: Date): CashSetupDateOfBirth {
+  return {
+    day: date.getDate(),
+    month: date.getMonth() + 1,
+    year: date.getFullYear(),
+  };
+}

--- a/src/features/cash/services/userClient.test.ts
+++ b/src/features/cash/services/userClient.test.ts
@@ -1,0 +1,53 @@
+import { getCashPlatformClient } from './rampClient';
+import { verifyPhone } from './userClient';
+
+jest.mock('react-native-dotenv', () => ({ IS_TESTING: 'false' }));
+
+jest.mock('./rampClient', () => ({
+  getCashPlatformClient: jest.fn(),
+}));
+
+const post = jest.fn();
+(getCashPlatformClient as jest.Mock).mockReturnValue({ post });
+
+const PARAMS = { userId: 'user-1', code: '123456' };
+
+beforeEach(() => {
+  post.mockReset();
+});
+
+describe('verifyPhone', () => {
+  it('rejects an empty bootstrap token', async () => {
+    post.mockResolvedValue({ data: { bootstrapToken: '', expiresIn: '600s' } });
+
+    await expect(verifyPhone(PARAMS)).rejects.toThrow('invalid bootstrap token');
+  });
+
+  it('rejects a token without the contract prefix', async () => {
+    post.mockResolvedValue({ data: { bootstrapToken: 'token-1', expiresIn: '600s' } });
+
+    await expect(verifyPhone(PARAMS)).rejects.toThrow('invalid bootstrap token');
+  });
+
+  it.each(['300', '0s', '-1s', 'NaNs', '1.0000000001s', 600, undefined])('rejects invalid expiry %p', async expiresIn => {
+    post.mockResolvedValue({ data: { bootstrapToken: 'bst_test', expiresIn } });
+
+    await expect(verifyPhone(PARAMS)).rejects.toThrow('invalid bootstrap token expiry');
+  });
+
+  it.each(['300s', '300.5s', '1.000340012s'])('accepts contract-valid expiry %s', async expiresIn => {
+    post.mockResolvedValue({ data: { bootstrapToken: 'bst_test', expiresIn } });
+
+    await expect(verifyPhone(PARAMS)).resolves.toMatchObject({ bootstrapToken: 'bst_test' });
+  });
+
+  it('converts the duration into an absolute expiry', async () => {
+    const now = 1_750_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    post.mockResolvedValue({ data: { bootstrapToken: 'bst_test', expiresIn: '600s' } });
+
+    await expect(verifyPhone(PARAMS)).resolves.toEqual({ bootstrapToken: 'bst_test', expiresAt: now + 600_000 });
+
+    jest.restoreAllMocks();
+  });
+});

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -7,6 +7,36 @@ import { getCashPlatformClient } from './rampClient';
 
 export const US_COUNTRY_CALLING_CODE = '1';
 
+const BOOTSTRAP_TOKEN_PATTERN = /^bst_.+/;
+// ProtoJSON encoding of google.protobuf.Duration, e.g. "600s" or "0.5s".
+const PROTO_DURATION_PATTERN = /^(?:0|[1-9]\d*)(?:\.\d{1,9})?s$/;
+
+function parseBootstrapCredential({ bootstrapToken, expiresIn }: { bootstrapToken: unknown; expiresIn: unknown }): {
+  bootstrapToken: string;
+  expiresAt: number;
+} {
+  if (typeof bootstrapToken !== 'string' || !BOOTSTRAP_TOKEN_PATTERN.test(bootstrapToken)) {
+    throw new Error('UserService returned an invalid bootstrap token');
+  }
+  if (typeof expiresIn !== 'string' || !PROTO_DURATION_PATTERN.test(expiresIn)) {
+    throw new Error('UserService returned an invalid bootstrap token expiry');
+  }
+  const expiresInMs = Number(expiresIn.slice(0, -1)) * 1000;
+  if (expiresInMs <= 0 || expiresInMs > Number.MAX_SAFE_INTEGER - Date.now()) {
+    throw new Error('UserService returned an invalid bootstrap token expiry');
+  }
+  return { bootstrapToken, expiresAt: Date.now() + expiresInMs };
+}
+
+// Absent means a resend is already allowed; the server enforces the real rate
+// limit, so a malformed duration degrades to no client-side cooldown.
+function parseResendAfter(resendAfter: unknown): number {
+  if (typeof resendAfter === 'string' && PROTO_DURATION_PATTERN.test(resendAfter)) {
+    return Date.now() + Number(resendAfter.slice(0, -1)) * 1000;
+  }
+  return Date.now();
+}
+
 type CreateUserWithPhoneResponse = {
   userId: string;
   resendAfter: number;
@@ -22,11 +52,10 @@ export async function createUserWithPhone({ nationalNumber }: { nationalNumber: 
     return { userId: 'e2e-user-id', resendAfter: Date.now() + time.seconds(30) };
   }
 
-  const { data } = await getCashPlatformClient().post<CreateUserWithPhoneResponse>('/signup/CreateUserWithPhone', {
+  const { data } = await getCashPlatformClient().post<{ userId: string; resendAfter: unknown }>('/signup/CreateUserWithPhone', {
     phone: { countryCode: US_COUNTRY_CALLING_CODE, nationalNumber },
   });
-  // TODO: remove `resendAfter` harcode once backend returns it
-  return { ...data, resendAfter: Date.now() + time.seconds(30) };
+  return { userId: data.userId, resendAfter: parseResendAfter(data.resendAfter) };
 }
 
 export async function verifyPhone({
@@ -42,18 +71,16 @@ export async function verifyPhone({
     return { bootstrapToken: 'bst_e2e', expiresAt: Date.now() + time.hours(1) };
   }
 
-  const { data } = await getCashPlatformClient().post<{ bootstrapToken: string; expiresIn: string }>('/signup/VerifyPhone', {
+  const { data } = await getCashPlatformClient().post<{ bootstrapToken: unknown; expiresIn: unknown }>('/signup/VerifyPhone', {
     userId,
     code,
   });
-  const expiresInSeconds = Number(data.expiresIn.replace(/s$/, ''));
-  return { bootstrapToken: data.bootstrapToken, expiresAt: Date.now() + expiresInSeconds * 1000 };
+  return parseBootstrapCredential(data);
 }
 
 export async function resendPhoneCode({ userId }: { userId: string }): Promise<ResendPhoneCodeResponse> {
   if (IS_TESTING === 'true') return { resendAfter: Date.now() + time.seconds(30) };
 
-  const { data } = await getCashPlatformClient().post<ResendPhoneCodeResponse>('/signup/ResendPhoneCode', { userId });
-  // TODO: remove `resendAfter` harcode once backend returns it
-  return { ...data, resendAfter: Date.now() + time.seconds(30) };
+  const { data } = await getCashPlatformClient().post<{ resendAfter: unknown }>('/signup/ResendPhoneCode', { userId });
+  return { resendAfter: parseResendAfter(data.resendAfter) };
 }

--- a/src/features/cash/stores/cashDepositSetupStore.test.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.test.ts
@@ -10,6 +10,16 @@ const IDENTITY_DONE: CashDepositSetupFacts = {
 };
 const A_CARD: LinkedCard = { id: 'card-1', brand: 'Visa', last4: '4242' };
 
+const verifiedSession = (tokenExpiresAt: number) =>
+  ({
+    status: 'phoneVerified',
+    userId: 'user-1',
+    phoneNationalNumber: '4155550100',
+    bootstrapToken: 'bst_test',
+    bootstrapTokenExpiresAt: tokenExpiresAt,
+    identity: null,
+  }) as const;
+
 type Case = {
   name: string;
   facts: CashDepositSetupFacts;
@@ -73,9 +83,7 @@ describe('useCashDepositSetupStatusStore', () => {
   it.each(cases)('$name', ({ facts, tokenExpiresAt, linkedCard, expected }) => {
     useCashDepositSetupStore.setState({ facts });
     if (tokenExpiresAt != null) {
-      useCashSetupSessionStore
-        .getState()
-        .setPhoneVerified({ userId: 'user-1', phoneNationalNumber: '4155550100', token: 'bst_test', expiresAt: tokenExpiresAt });
+      useCashSetupSessionStore.setState({ session: verifiedSession(tokenExpiresAt) });
     }
     useCashPaymentMethodStore.setState({ linkedCard });
     expect(useCashDepositSetupStatusStore.getState()).toBe(expected);
@@ -83,9 +91,7 @@ describe('useCashDepositSetupStatusStore', () => {
 
   it('regresses from ready to needsIdentity when the session store resets', () => {
     useCashDepositSetupStore.setState({ facts: { ...IDENTITY_DONE, hasLinkedWallet: true } });
-    useCashSetupSessionStore
-      .getState()
-      .setPhoneVerified({ userId: 'user-1', phoneNationalNumber: '4155550100', token: 'bst_test', expiresAt: Date.now() + 60_000 });
+    useCashSetupSessionStore.setState({ session: verifiedSession(Date.now() + 60_000) });
     useCashPaymentMethodStore.setState({ linkedCard: A_CARD });
     expect(useCashDepositSetupStatusStore.getState()).toBe('ready');
 

--- a/src/features/cash/stores/cashSetupSessionStore.ts
+++ b/src/features/cash/stores/cashSetupSessionStore.ts
@@ -1,5 +1,21 @@
 import { createBaseStore } from '@storesjs/stores';
 
+export type CashSetupDateOfBirth = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+export type CashSetupIdentity = {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: CashSetupDateOfBirth;
+};
+
+// Identifies one accepted phone submission by reference, so async results can
+// be checked against the submission that started them.
+export type PhoneChallenge = Readonly<{ userId: string }>;
+
 type EmptyCashSetupSession = {
   status: 'empty';
 };
@@ -7,7 +23,7 @@ type EmptyCashSetupSession = {
 type PhoneSubmittedCashSetupSession = {
   status: 'phoneSubmitted';
   phoneNationalNumber: string;
-  userId: string;
+  challenge: PhoneChallenge;
   resendAfter: number;
 };
 
@@ -17,15 +33,18 @@ type VerifiedCashSetupSession = {
   userId: string;
   bootstrapToken: string;
   bootstrapTokenExpiresAt: number;
+  identity: CashSetupIdentity | null;
 };
 
 type CashSetupSession = EmptyCashSetupSession | PhoneSubmittedCashSetupSession | VerifiedCashSetupSession;
 
 type CashSetupSessionStore = {
   session: CashSetupSession;
+  getIsCurrentChallenge: (challenge: PhoneChallenge) => boolean;
   setPhoneSubmitted: (params: { userId: string; phoneNationalNumber: string; resendAfter: number }) => void;
-  setResendAfter: (resendAfter: number) => void;
-  setPhoneVerified: (params: { userId: string; phoneNationalNumber: string; token: string; expiresAt: number }) => void;
+  setResendAfter: (challenge: PhoneChallenge, resendAfter: number) => void;
+  setPhoneVerified: (challenge: PhoneChallenge, credential: { bootstrapToken: string; expiresAt: number }) => void;
+  setIdentity: (identity: CashSetupIdentity) => void;
   reset: () => void;
 };
 
@@ -34,16 +53,39 @@ const EMPTY_SESSION: EmptyCashSetupSession = { status: 'empty' };
 // Intentionally memory-only (PII)
 export const useCashSetupSessionStore = createBaseStore<CashSetupSessionStore>((set, get) => ({
   session: EMPTY_SESSION,
-  setPhoneSubmitted: ({ userId, phoneNationalNumber, resendAfter }) =>
-    set({ session: { status: 'phoneSubmitted', userId, phoneNationalNumber, resendAfter } }),
-  setResendAfter: resendAfter => {
+  getIsCurrentChallenge: challenge => {
     const { session } = get();
-    if (session.status !== 'phoneSubmitted') return;
-    set({ session: { ...session, resendAfter } });
+    return session.status === 'phoneSubmitted' && session.challenge === challenge;
   },
-  setPhoneVerified: ({ userId, phoneNationalNumber, token, expiresAt }) =>
-    set({ session: { status: 'phoneVerified', userId, phoneNationalNumber, bootstrapToken: token, bootstrapTokenExpiresAt: expiresAt } }),
-  reset: () => set({ session: EMPTY_SESSION }),
+  setPhoneSubmitted: ({ userId, phoneNationalNumber, resendAfter }) =>
+    set({ session: { status: 'phoneSubmitted', challenge: { userId }, phoneNationalNumber, resendAfter } }),
+  setResendAfter: (challenge, resendAfter) =>
+    set(state => {
+      const { session } = state;
+      if (session.status !== 'phoneSubmitted' || session.challenge !== challenge || session.resendAfter === resendAfter) return state;
+      return { session: { ...session, resendAfter } };
+    }),
+  setPhoneVerified: (challenge, { bootstrapToken, expiresAt }) =>
+    set(state => {
+      const { session } = state;
+      if (session.status !== 'phoneSubmitted' || session.challenge !== challenge) return state;
+      return {
+        session: {
+          status: 'phoneVerified',
+          userId: challenge.userId,
+          phoneNationalNumber: session.phoneNationalNumber,
+          bootstrapToken,
+          bootstrapTokenExpiresAt: expiresAt,
+          identity: null,
+        },
+      };
+    }),
+  setIdentity: identity => {
+    const { session } = get();
+    if (session.status !== 'phoneVerified') return;
+    set({ session: { ...session, identity } });
+  },
+  reset: () => set(state => (state.session === EMPTY_SESSION ? state : { session: EMPTY_SESSION })),
 }));
 
 export function selectIsPhoneVerified(state: CashSetupSessionStore): boolean {

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -535,11 +535,15 @@ export const DevSection = () => {
             ))}
             <MenuItem
               onPress={() =>
-                useCashSetupSessionStore.getState().setPhoneVerified({
-                  userId: 'dev-user-id',
-                  phoneNationalNumber: '4155550100',
-                  token: 'bst_dev',
-                  expiresAt: Date.now() + time.hours(1),
+                useCashSetupSessionStore.setState({
+                  session: {
+                    status: 'phoneVerified',
+                    userId: 'dev-user-id',
+                    phoneNationalNumber: '4155550100',
+                    bootstrapToken: 'bst_dev',
+                    bootstrapTokenExpiresAt: Date.now() + time.hours(1),
+                    identity: null,
+                  },
                 })
               }
               size={52}

--- a/src/framework/ui/hooks/useDatePicker.tsx
+++ b/src/framework/ui/hooks/useDatePicker.tsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useState, type ReactNode } from 'react';
+import { Keyboard, Modal, Platform, Pressable, StyleSheet, View } from 'react-native';
+
+import NativeDateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text, useBackgroundColor, useColorMode } from '@/design-system';
+
+type UseDatePickerOptions = {
+  confirmLabel: string;
+  initialDate: Date;
+  onChange: (date: Date) => void;
+  value: Date | null;
+  maximumDate?: Date;
+  minimumDate?: Date;
+  testID?: string;
+};
+
+type UseDatePickerResult = {
+  openPicker: () => void;
+  picker: ReactNode;
+};
+
+export function useDatePicker({
+  confirmLabel,
+  initialDate,
+  onChange,
+  value,
+  maximumDate,
+  minimumDate,
+  testID,
+}: UseDatePickerOptions): UseDatePickerResult {
+  const [draftDate, setDraftDate] = useState(initialDate);
+  const [isIOSPickerVisible, setIsIOSPickerVisible] = useState(false);
+
+  const closeIOSPicker = useCallback(() => setIsIOSPickerVisible(false), []);
+
+  const confirmIOSPicker = useCallback(() => {
+    onChange(draftDate);
+    setIsIOSPickerVisible(false);
+  }, [draftDate, onChange]);
+
+  const openPicker = useCallback(() => {
+    Keyboard.dismiss();
+    const selectedDate = value ?? initialDate;
+    setDraftDate(selectedDate);
+
+    if (Platform.OS === 'android') {
+      DateTimePickerAndroid.open({
+        maximumDate,
+        minimumDate,
+        mode: 'date',
+        onValueChange: (_event, date) => onChange(date),
+        positiveButton: { label: confirmLabel },
+        testID,
+        value: selectedDate,
+      });
+      return;
+    }
+
+    setIsIOSPickerVisible(true);
+  }, [confirmLabel, initialDate, maximumDate, minimumDate, onChange, testID, value]);
+
+  const picker =
+    Platform.OS === 'ios' ? (
+      <DatePickerSheet
+        confirmLabel={confirmLabel}
+        date={draftDate}
+        maximumDate={maximumDate}
+        minimumDate={minimumDate}
+        onChangeDate={setDraftDate}
+        onClose={closeIOSPicker}
+        onConfirm={confirmIOSPicker}
+        testID={testID}
+        visible={isIOSPickerVisible}
+      />
+    ) : null;
+
+  return { openPicker, picker };
+}
+
+type DatePickerSheetProps = {
+  confirmLabel: string;
+  date: Date;
+  onChangeDate: (date: Date) => void;
+  onClose: () => void;
+  onConfirm: () => void;
+  visible: boolean;
+  maximumDate?: Date;
+  minimumDate?: Date;
+  testID?: string;
+};
+
+function DatePickerSheet({
+  confirmLabel,
+  date,
+  onChangeDate,
+  onClose,
+  onConfirm,
+  visible,
+  maximumDate,
+  minimumDate,
+  testID,
+}: DatePickerSheetProps) {
+  const surfacePrimaryElevated = useBackgroundColor('surfacePrimaryElevated');
+  const { isDarkMode } = useColorMode();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal animationType="fade" onRequestClose={onClose} transparent visible={visible}>
+      <View style={styles.modal}>
+        <Pressable accessibilityRole="button" onPress={onClose} style={StyleSheet.absoluteFill} />
+        <View style={[styles.pickerContainer, { backgroundColor: surfacePrimaryElevated, paddingBottom: Math.max(insets.bottom, 12) }]}>
+          <View style={styles.pickerHeader}>
+            <Pressable accessibilityRole="button" onPress={onConfirm} testID={testID ? `${testID}-confirm` : undefined}>
+              <Text color="blue" size="17pt" weight="bold">
+                {confirmLabel}
+              </Text>
+            </Pressable>
+          </View>
+          <NativeDateTimePicker
+            display="spinner"
+            maximumDate={maximumDate}
+            minimumDate={minimumDate}
+            mode="date"
+            onValueChange={(_event, newDate) => onChangeDate(newDate)}
+            style={styles.iosPicker}
+            testID={testID}
+            themeVariant={isDarkMode ? 'dark' : 'light'}
+            value={date}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  iosPicker: {
+    height: 216,
+    width: '100%',
+  },
+  modal: {
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  pickerContainer: {
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+    overflow: 'hidden',
+  },
+  pickerHeader: {
+    alignItems: 'flex-end',
+    paddingHorizontal: 24,
+    paddingTop: 16,
+  },
+});

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1597,7 +1597,13 @@
           "resend_code": "Resend code",
           "error": "That code didn’t work. Please try again."
         },
-        "identity": { "title": "Enter your information" },
+        "identity": {
+          "title": "Enter some information about yourself",
+          "first_name": "First Name",
+          "last_name": "Last Name",
+          "date_of_birth": "Date of Birth",
+          "date_of_birth_placeholder": "MM/DD/YYYY"
+        },
         "ssn": { "title": "Last 4 of SSN" },
         "review": { "title": "Review" },
         "passkey": { "title": "Add a Passkey" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6253,6 +6253,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/datetimepicker@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@react-native-community/datetimepicker@npm:9.1.0"
+  dependencies:
+    invariant: "npm:^2.2.4"
+  peerDependencies:
+    expo: ">=52.0.0"
+    react: "*"
+    react-native: "*"
+    react-native-windows: "*"
+  peerDependenciesMeta:
+    expo:
+      optional: true
+    react-native-windows:
+      optional: true
+  checksum: 10c0/3f31baec58c1245204a9b4057809027019aa1abb4b8caea4cb4d44ab70f5a97dfe5114a8aa315299aa47ad31971059181c355aa056d9c3a14b7892582da9f4cb
+  languageName: node
+  linkType: hard
+
 "@react-native-community/netinfo@npm:11.4.1":
   version: 11.4.1
   resolution: "@react-native-community/netinfo@npm:11.4.1"
@@ -9083,6 +9102,7 @@ __metadata:
     "@react-native-community/cli": "npm:20.0.2"
     "@react-native-community/cli-platform-android": "npm:20.0.2"
     "@react-native-community/cli-platform-ios": "npm:20.0.2"
+    "@react-native-community/datetimepicker": "npm:9.1.0"
     "@react-native-community/netinfo": "npm:11.4.1"
     "@react-native-firebase/app": "npm:23.8.8"
     "@react-native-firebase/firestore": "npm:23.8.8"


### PR DESCRIPTION
## Why?

The US identity match for Cash Deposits requires the member's legal name and date of birth, and the Setup wizard's identity step was still a placeholder. This implements the real form:

- Side-by-side first/last name inputs and a full-width DOB field per Figma, using the native date picker on both platforms (bottom-sheet spinner on iOS, dialog on Android).
- Validation mirrors the backend contract: names are 1–100 letters with single space/apostrophe/hyphen separators; DOB must be a real calendar date in the past. Next stays disabled until everything is valid.
- All three values are PII: they live only in the in-memory Setup session (no persistence, no network in this slice), and DOB is stored as a calendar date rather than a formatted string or timestamp.

## Approach

Date selection is a small app-agnostic framework hook wrapping `@react-native-community/datetimepicker` (new dependency), since the library exposes different surfaces per platform (inline iOS component vs imperative Android dialog). On Android the native dialog ignores React Native test IDs (the library applies them Detox-only), so the Maestro flow targets the platform's own dialog ids.

## Visuals

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-07-14 at 17.54.25.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/99e82ba6-25d8-4c28-b393-b44be6929e47.mov" />](https://app.graphite.com/user-attachments/video/99e82ba6-25d8-4c28-b393-b44be6929e47.mov) | [untitled.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/bb72a4e3-1b30-4f16-8c7c-a2d9f8998f2d.webm" />](https://app.graphite.com/user-attachments/video/bb72a4e3-1b30-4f16-8c7c-a2d9f8998f2d.webm) |

