### PR TITLE
feat(cash): Setup: SSN + Review Details

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -73,7 +73,23 @@ tags:
 - tapOn:
     id: cash-setup-next
 - assertVisible:
-    text: 'Last 4 of SSN'
+    text: 'Enter the last 4 digits of your SSN'
+- tapOn:
+    id: cash-setup-ssn-input
+- inputText: '6789'
+- tapOn:
+    id: cash-setup-next
+- assertVisible:
+    text: 'Review your information'
+- assertVisible:
+    text: 'Ada Lovelace'
+# Confirm submits KYC; the mock approves after ~1s, then the repeat loop walks the placeholder steps.
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Add a Passkey'
+    timeout: 10000
 - repeat:
     while:
       notVisible:

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -129,6 +129,9 @@ export const event = {
   cashPhoneSubmitted: 'cash.phone_submitted',
   cashPhoneVerified: 'cash.phone_verified',
   cashPhoneVerifyFailed: 'cash.phone_verify_failed',
+  cashKycSubmitted: 'cash.kyc_submitted',
+  cashKycApproved: 'cash.kyc_approved',
+  cashKycFailed: 'cash.kyc_failed',
   cashCardLinked: 'cash.card_linked',
   cashCardLinkFailed: 'cash.card_link_failed',
   rewardsPressedPendingEarningsCard: 'rewards.pressed_pending_earnings_card',
@@ -542,6 +545,11 @@ export type EventProperties = {
   [event.cashPhoneSubmitted]: undefined;
   [event.cashPhoneVerified]: undefined;
   [event.cashPhoneVerifyFailed]: {
+    reason: string;
+  };
+  [event.cashKycSubmitted]: undefined;
+  [event.cashKycApproved]: undefined;
+  [event.cashKycFailed]: {
     reason: string;
   };
   [event.cashCardLinked]: {

--- a/src/app/navigation/TestDeeplinkHandler.tsx
+++ b/src/app/navigation/TestDeeplinkHandler.tsx
@@ -60,6 +60,7 @@ export function TestDeeplinkHandler() {
                 bootstrapToken: 'bst_e2e',
                 bootstrapTokenExpiresAt: Date.now() + time.days(1),
                 identity: null,
+                governmentId: null,
               },
             });
           } else {

--- a/src/features/cash/screens/cash-deposit-setup/steps.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.test.ts
@@ -26,8 +26,8 @@ describe('Cash Deposit Setup steps', () => {
   });
 
   it('maps the milestone steps to their facts', () => {
-    expect(getSetupStep(Routes.CASH_SETUP_REVIEW)?.milestone).toBe('kycPassed');
     expect(getSetupStep(Routes.CASH_SETUP_PASSKEY)?.milestone).toBe('passkeyRegistered');
+    expect(getSetupStep(Routes.CASH_SETUP_REVIEW)?.milestone).toBeUndefined();
     expect(getSetupStep(Routes.CASH_SETUP_CARD_DETAILS)?.milestone).toBeUndefined();
     expect(getSetupStep(Routes.CASH_SETUP_CONFIRM_PHONE)?.milestone).toBeUndefined();
     expect(getSetupStep(Routes.CASH_SETUP_PHONE)?.milestone).toBeUndefined();

--- a/src/features/cash/screens/cash-deposit-setup/steps.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.ts
@@ -19,7 +19,7 @@ export const SETUP_STEP_ORDER: readonly CashDepositSetupStep[] = [
   { id: Routes.CASH_SETUP_CONFIRM_PHONE },
   { id: Routes.CASH_SETUP_IDENTITY },
   { id: Routes.CASH_SETUP_SSN },
-  { id: Routes.CASH_SETUP_REVIEW, milestone: 'kycPassed' },
+  { id: Routes.CASH_SETUP_REVIEW },
   { id: Routes.CASH_SETUP_PASSKEY, milestone: 'passkeyRegistered' },
   { id: Routes.CASH_SETUP_EMAIL },
   { id: Routes.CASH_SETUP_ALL_DONE },

--- a/src/features/cash/screens/cash-deposit-setup/steps/IdentityStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/IdentityStep.tsx
@@ -5,17 +5,13 @@ import { Box, Text, useForegroundColor } from '@/design-system';
 import { useDatePicker } from '@/framework/ui/hooks/useDatePicker';
 import * as i18n from '@/languages';
 
-import { isValidDateOfBirth, isValidLegalName, toDate, toDateOfBirth } from '../../../services/cashSetupIdentityService';
+import { formatDateOfBirth, isValidDateOfBirth, isValidLegalName, toDate, toDateOfBirth } from '../../../services/cashSetupIdentityService';
 import { useCashSetupSessionStore, type CashSetupDateOfBirth } from '../../../stores/cashSetupSessionStore';
 import { SetupStepLayout } from '../components/SetupStepLayout';
 import { useSetupInputTextStyle } from '../components/useSetupInputTextStyle';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
 
 const l = i18n.l.cash.deposit_setup.identity;
-
-function formatDateOfBirth({ year, month, day }: CashSetupDateOfBirth): string {
-  return `${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}/${year}`;
-}
 
 function getMaximumDateOfBirth(): Date {
   const date = new Date();

--- a/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ReviewStep.tsx
@@ -1,9 +1,99 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 
+import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
+import { Box, Separator, Text } from '@/design-system';
 import * as i18n from '@/languages';
+import Routes from '@/navigation/routesNames';
 
+import { formatDateOfBirth, formatUsSsnMasked } from '../../../services/cashSetupIdentityService';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { CashDepositSetupNavigation } from '../cashDepositSetupNavigator';
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useSubmitKycFlow } from './useSubmitKycFlow';
+
+const l = i18n.l.cash.deposit_setup.review;
+
+function ReviewRow({
+  disabled,
+  label,
+  onEdit,
+  testID,
+  value,
+}: {
+  disabled: boolean;
+  label: string;
+  onEdit: () => void;
+  testID: string;
+  value: string;
+}) {
+  return (
+    <Box alignItems="center" flexDirection="row" justifyContent="space-between" paddingVertical="12px">
+      <Box gap={10}>
+        <Text color="labelSecondary" size="13pt" weight="semibold">
+          {label}
+        </Text>
+        <Text color="label" size="17pt" weight="bold">
+          {value}
+        </Text>
+      </Box>
+      <ButtonPressAnimation disabled={disabled} onPress={onEdit} scaleTo={0.9} testID={testID}>
+        <Box background="fillTertiary" borderRadius={14} height={{ custom: 28 }} justifyContent="center" paddingHorizontal="12px">
+          <Text color="label" size="13pt" weight="bold">
+            {i18n.t(l.edit)}
+          </Text>
+        </Box>
+      </ButtonPressAnimation>
+    </Box>
+  );
+}
 
 export const ReviewStep = memo(function ReviewStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.review.title)} />;
+  const identity = useCashSetupSessionStore(state => (state.session.status === 'phoneVerified' ? state.session.identity : null));
+  const governmentId = useCashSetupSessionStore(state => (state.session.status === 'phoneVerified' ? state.session.governmentId : null));
+  const { submitting, submit } = useSubmitKycFlow();
+
+  const editIdentity = useCallback(() => CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_IDENTITY), []);
+  const editSsn = useCallback(() => CashDepositSetupNavigation.navigate(Routes.CASH_SETUP_SSN), []);
+
+  return (
+    <SetupStepLayout
+      actionDisabled={!identity || !governmentId}
+      actionLabel={i18n.t(l.confirm)}
+      actionLoading={submitting}
+      backDisabled={submitting}
+      onAction={submit}
+      subtitle={i18n.t(l.subtitle)}
+      title={i18n.t(l.title)}
+    >
+      {identity && governmentId && (
+        <Box paddingTop="24px">
+          <Box background="fillTertiary" borderRadius={20} paddingHorizontal="16px" paddingVertical="4px">
+            <ReviewRow
+              disabled={submitting}
+              label={i18n.t(l.name)}
+              onEdit={editIdentity}
+              testID="cash-setup-review-edit-identity"
+              value={`${identity.firstName} ${identity.lastName}`}
+            />
+            <Separator color="separatorTertiary" />
+            <ReviewRow
+              disabled={submitting}
+              label={i18n.t(l.date_of_birth)}
+              onEdit={editIdentity}
+              testID="cash-setup-review-edit-dob"
+              value={formatDateOfBirth(identity.dateOfBirth)}
+            />
+            <Separator color="separatorTertiary" />
+            <ReviewRow
+              disabled={submitting}
+              label={i18n.t(l.ssn)}
+              onEdit={editSsn}
+              testID="cash-setup-review-edit-ssn"
+              value={formatUsSsnMasked(governmentId.value)}
+            />
+          </Box>
+        </Box>
+      )}
+    </SetupStepLayout>
+  );
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/SsnStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/SsnStep.tsx
@@ -1,9 +1,84 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback, useRef, useState } from 'react';
+import { Pressable, StyleSheet, TextInput } from 'react-native';
 
+import { Box, Text } from '@/design-system';
 import * as i18n from '@/languages';
 
+import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from '../../../services/cashSetupIdentityService';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useSetupInputTextStyle } from '../components/useSetupInputTextStyle';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+const l = i18n.l.cash.deposit_setup.ssn;
 
 export const SsnStep = memo(function SsnStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.ssn.title)} />;
+  const storedLast4 = useCashSetupSessionStore(state =>
+    state.session.status === 'phoneVerified' ? (state.session.governmentId?.value ?? '') : ''
+  );
+  const [digits, setDigits] = useState(storedLast4);
+  const inputRef = useRef<TextInput>(null);
+  const inputTextStyle = useSetupInputTextStyle();
+  const { next } = useCashDepositSetupNavigation();
+  const canContinue = isValidUsSsnLast4(digits);
+
+  const focusInput = useCallback(() => inputRef.current?.focus(), []);
+  const onChangeText = useCallback((text: string) => setDigits(text.replace(/\D/g, '')), []);
+
+  const submit = useCallback(() => {
+    if (!isValidUsSsnLast4(digits)) return;
+    inputRef.current?.blur();
+    useCashSetupSessionStore.getState().setGovernmentId(createUsSsnLast4GovernmentId(digits));
+    next();
+  }, [digits, next]);
+
+  return (
+    <SetupStepLayout actionDisabled={!canContinue} onAction={submit} title={i18n.t(l.title)}>
+      <Box gap={12} paddingTop="24px">
+        <Pressable accessible={false} onPress={focusInput}>
+          <Box alignItems="center" background="fillTertiary" borderRadius={20} flexDirection="row" style={styles.inputRow}>
+            <Text color={digits ? 'label' : 'labelQuaternary'} size="17pt" weight="bold">
+              {'*** **'}
+            </Text>
+            <TextInput
+              autoFocus
+              keyboardType="number-pad"
+              maxLength={4}
+              onChangeText={onChangeText}
+              ref={inputRef}
+              style={[inputTextStyle, styles.input]}
+              testID="cash-setup-ssn-input"
+              value={digits}
+            />
+            <Text color="blue" size="17pt" weight="heavy">
+              {'􀞙'}
+            </Text>
+          </Box>
+        </Pressable>
+        <Box style={styles.helper}>
+          <Text color="labelQuaternary" size="13pt" weight="semibold">
+            {i18n.t(l.helper)}
+          </Text>
+        </Box>
+      </Box>
+    </SetupStepLayout>
+  );
+});
+
+const styles = StyleSheet.create({
+  helper: {
+    paddingLeft: 14,
+  },
+  input: {
+    backgroundColor: 'transparent',
+    borderRadius: 0,
+    flex: 1,
+    paddingLeft: 8,
+    paddingRight: 0,
+  },
+  inputRow: {
+    height: 45,
+    paddingLeft: 14,
+    paddingRight: 16,
+  },
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
@@ -1,0 +1,183 @@
+import { analytics } from '@/analytics';
+import { logger } from '@/logger';
+import { delay } from '@/utils/delay';
+
+import { createUsSsnLast4GovernmentId, isValidUsSsnLast4 } from '../../../services/cashSetupIdentityService';
+import { getUserStatus, KycStatus, submitOnboarding } from '../../../services/userClient';
+import { useCashDepositSetupStore } from '../../../stores/cashDepositSetupStore';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { KYC_POLL_BUDGET_MS, KYC_POLL_INTERVAL_MS, useSubmitKycFlowStore } from './useSubmitKycFlow';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: { cashKycSubmitted: 'cash.kyc_submitted', cashKycApproved: 'cash.kyc_approved', cashKycFailed: 'cash.kyc_failed' },
+  },
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('@/helpers/alert', () => ({
+  WrappedAlert: { alert: jest.fn() },
+}));
+
+jest.mock('@/utils/delay', () => ({
+  delay: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../../services/userClient', () => ({
+  KycStatus: {
+    Unspecified: 'KYC_STATUS_UNSPECIFIED',
+    Pending: 'KYC_STATUS_PENDING',
+    Approved: 'KYC_STATUS_APPROVED',
+    Rejected: 'KYC_STATUS_REJECTED',
+    Review: 'KYC_STATUS_REVIEW',
+  },
+  getUserStatus: jest.fn(),
+  submitOnboarding: jest.fn(),
+}));
+
+jest.mock('../../../stores/cashDepositSetupStore', () => ({
+  useCashDepositSetupStore: { getState: jest.fn() },
+}));
+
+jest.mock('../useCashDepositSetupNavigation', () => ({
+  useCashDepositSetupNavigation: jest.fn(),
+}));
+
+const mockSubmitOnboarding = submitOnboarding as jest.Mock;
+const mockGetUserStatus = getUserStatus as jest.Mock;
+const mockDelay = delay as jest.Mock;
+const track = analytics.track as jest.Mock;
+const setFact = jest.fn();
+
+const TOKEN = 'bst_1';
+const IDENTITY = { firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: { year: 1990, month: 1, day: 2 } };
+const SSN_LAST4 = '6789';
+if (!isValidUsSsnLast4(SSN_LAST4)) throw new Error('expected a valid SSN last four');
+const GOVERNMENT_ID = createUsSsnLast4GovernmentId(SSN_LAST4);
+const POLL_ATTEMPTS = KYC_POLL_BUDGET_MS / KYC_POLL_INTERVAL_MS;
+
+const flow = () => useSubmitKycFlowStore.getState();
+const session = () => useCashSetupSessionStore.getState();
+const challenge = () => {
+  const current = session().session;
+  if (current.status !== 'phoneSubmitted') throw new Error('expected a phoneSubmitted session');
+  return current.challenge;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useCashDepositSetupStore.getState as jest.Mock).mockReturnValue({ setFact });
+  session().reset();
+  session().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+  session().setPhoneVerified(challenge(), { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
+  session().setIdentity(IDENTITY);
+  session().setGovernmentId(GOVERNMENT_ID);
+  mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Approved });
+  mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Approved });
+});
+
+describe('useSubmitKycFlowStore.submit', () => {
+  it('submits, flips the fact, tracks, and resolves approved — in order', async () => {
+    await expect(flow().submit()).resolves.toBe('approved');
+
+    expect(mockSubmitOnboarding).toHaveBeenCalledWith({
+      bootstrapToken: TOKEN,
+      countryCode: 'US',
+      identity: IDENTITY,
+      governmentId: GOVERNMENT_ID,
+    });
+    expect(setFact).toHaveBeenCalledWith('kycPassed', true);
+    expect(track).toHaveBeenNthCalledWith(1, 'cash.kyc_submitted');
+    expect(track).toHaveBeenNthCalledWith(2, 'cash.kyc_approved');
+
+    const [trackSubmittedOrder, trackApprovedOrder] = track.mock.invocationCallOrder;
+    const [submitOrder] = mockSubmitOnboarding.mock.invocationCallOrder;
+    const [setFactOrder] = setFact.mock.invocationCallOrder;
+    expect(trackSubmittedOrder).toBeLessThan(submitOrder);
+    expect(submitOrder).toBeLessThan(setFactOrder);
+    expect(setFactOrder).toBeLessThan(trackApprovedOrder);
+
+    expect(mockGetUserStatus).not.toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+  });
+
+  it('polls while pending, then approves', async () => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockGetUserStatus.mockResolvedValueOnce({ kycStatus: KycStatus.Pending }).mockResolvedValueOnce({ kycStatus: KycStatus.Approved });
+
+    await expect(flow().submit()).resolves.toBe('approved');
+
+    expect(mockGetUserStatus).toHaveBeenCalledTimes(2);
+    expect(mockGetUserStatus).toHaveBeenCalledWith({ bootstrapToken: TOKEN });
+    expect(mockDelay).toHaveBeenCalledWith(KYC_POLL_INTERVAL_MS);
+    expect(setFact).toHaveBeenCalledWith('kycPassed', true);
+  });
+
+  it('fails with timeout when pending never resolves within the poll budget', async () => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus: KycStatus.Pending });
+    mockGetUserStatus.mockResolvedValue({ kycStatus: KycStatus.Pending });
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(mockGetUserStatus).toHaveBeenCalledTimes(POLL_ATTEMPTS);
+    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'timeout' });
+    expect(setFact).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+  });
+
+  it.each([
+    { kycStatus: 'KYC_STATUS_UNSPECIFIED', reason: 'unspecified' },
+    { kycStatus: 'KYC_STATUS_REJECTED', reason: 'rejected' },
+    { kycStatus: 'KYC_STATUS_REVIEW', reason: 'review' },
+  ])('fails with $reason without polling', async ({ kycStatus, reason }) => {
+    mockSubmitOnboarding.mockResolvedValue({ kycStatus });
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(mockGetUserStatus).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason });
+    expect(setFact).not.toHaveBeenCalled();
+  });
+
+  it('fails with the error message when the submission throws', async () => {
+    mockSubmitOnboarding.mockRejectedValue(new Error('network down'));
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(track).toHaveBeenCalledWith('cash.kyc_failed', { reason: 'network down' });
+    expect(setFact).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+  });
+
+  it('skips a second submit while one is in flight', async () => {
+    let resolveSubmit!: (value: { kycStatus: KycStatus }) => void;
+    mockSubmitOnboarding.mockReturnValue(
+      new Promise(resolve => {
+        resolveSubmit = resolve;
+      })
+    );
+
+    const first = flow().submit();
+    await expect(flow().submit()).resolves.toBe('skipped');
+
+    expect(mockSubmitOnboarding).toHaveBeenCalledTimes(1);
+    resolveSubmit({ kycStatus: KycStatus.Approved });
+    await expect(first).resolves.toBe('approved');
+  });
+
+  it('skips when the session is missing identity or government id', async () => {
+    session().reset();
+
+    await expect(flow().submit()).resolves.toBe('skipped');
+
+    expect(mockSubmitOnboarding).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.ts
@@ -1,0 +1,91 @@
+import { useCallback } from 'react';
+
+import { createBaseStore, createStoreActions } from '@storesjs/stores';
+
+import { analytics } from '@/analytics';
+import { time } from '@/framework/core/utils/time';
+import { WrappedAlert as Alert } from '@/helpers/alert';
+import * as i18n from '@/languages';
+import { logger, RainbowError } from '@/logger';
+import { delay } from '@/utils/delay';
+
+import { US_COUNTRY_CODE } from '../../../services/cashSetupIdentityService';
+import { getUserStatus, KycStatus, submitOnboarding } from '../../../services/userClient';
+import { useCashDepositSetupStore } from '../../../stores/cashDepositSetupStore';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+export const KYC_POLL_INTERVAL_MS = time.seconds(3);
+export const KYC_POLL_BUDGET_MS = time.seconds(30);
+
+const KYC_POLL_ATTEMPTS = Math.floor(KYC_POLL_BUDGET_MS / KYC_POLL_INTERVAL_MS);
+
+const KYC_FAILURE_REASONS: Record<Exclude<KycStatus, KycStatus.Approved>, string> = {
+  [KycStatus.Unspecified]: 'unspecified',
+  [KycStatus.Pending]: 'timeout',
+  [KycStatus.Rejected]: 'rejected',
+  [KycStatus.Review]: 'review',
+};
+
+export type SubmitKycState = 'entry' | 'submitting';
+
+export type SubmitKycResult = 'approved' | 'failed' | 'skipped';
+
+type SubmitKycFlowStore = {
+  state: SubmitKycState;
+  submit: () => Promise<SubmitKycResult>;
+};
+
+export const useSubmitKycFlowStore = createBaseStore<SubmitKycFlowStore>((set, get) => ({
+  state: 'entry',
+
+  submit: async () => {
+    if (get().state !== 'entry') return 'skipped';
+    const { session } = useCashSetupSessionStore.getState();
+    if (session.status !== 'phoneVerified' || !session.identity || !session.governmentId) return 'skipped';
+
+    set({ state: 'submitting' });
+    analytics.track(analytics.event.cashKycSubmitted);
+    try {
+      const { bootstrapToken, identity, governmentId } = session;
+      let { kycStatus } = await submitOnboarding({ bootstrapToken, countryCode: US_COUNTRY_CODE, identity, governmentId });
+
+      for (let attempt = 0; kycStatus === KycStatus.Pending && attempt < KYC_POLL_ATTEMPTS; attempt++) {
+        await delay(KYC_POLL_INTERVAL_MS);
+        ({ kycStatus } = await getUserStatus({ bootstrapToken }));
+      }
+
+      if (kycStatus !== KycStatus.Approved) {
+        const reason = KYC_FAILURE_REASONS[kycStatus];
+        logger.error(new RainbowError(`[useSubmitKycFlow]: KYC not approved: ${reason}`));
+        analytics.track(analytics.event.cashKycFailed, { reason });
+        return 'failed';
+      }
+
+      useCashDepositSetupStore.getState().setFact('kycPassed', true);
+      analytics.track(analytics.event.cashKycApproved);
+      return 'approved';
+    } catch (e) {
+      logger.error(new RainbowError('[useSubmitKycFlow]: Failed to submit KYC', e));
+      analytics.track(analytics.event.cashKycFailed, { reason: e instanceof Error ? e.message : String(e) });
+      return 'failed';
+    } finally {
+      set({ state: 'entry' });
+    }
+  },
+}));
+
+const submitKycFlowActions = createStoreActions(useSubmitKycFlowStore);
+
+export function useSubmitKycFlow(): { submitting: boolean; submit: () => Promise<void> } {
+  const { next } = useCashDepositSetupNavigation();
+  const submitting = useSubmitKycFlowStore(state => state.state === 'submitting');
+
+  const submit = useCallback(async () => {
+    const result = await submitKycFlowActions.submit();
+    if (result === 'approved') next();
+    else if (result === 'failed') Alert.alert(i18n.t(i18n.l.cash.deposit_setup.review.error));
+  }, [next]);
+
+  return { submitting, submit };
+}

--- a/src/features/cash/services/cashSetupIdentityService.test.ts
+++ b/src/features/cash/services/cashSetupIdentityService.test.ts
@@ -1,4 +1,4 @@
-import { isValidDateOfBirth, isValidLegalName } from './cashSetupIdentityService';
+import { formatUsSsnMasked, isValidDateOfBirth, isValidLegalName, isValidUsSsnLast4 } from './cashSetupIdentityService';
 
 const TODAY = new Date(2026, 6, 13);
 
@@ -37,5 +37,28 @@ describe('isValidDateOfBirth', () => {
 
   it.each(cases)('returns $expected for $input', ({ input, expected }) => {
     expect(isValidDateOfBirth(input, TODAY)).toBe(expected);
+  });
+});
+
+describe('isValidUsSsnLast4', () => {
+  const cases = [
+    { input: '6789', expected: true },
+    { input: '0001', expected: true },
+    { input: '678', expected: false },
+    { input: '67890', expected: false },
+    { input: '67a9', expected: false },
+    { input: '67 9', expected: false },
+    { input: '0000', expected: false },
+    { input: '', expected: false },
+  ];
+
+  it.each(cases)('returns $expected for "$input"', ({ input, expected }) => {
+    expect(isValidUsSsnLast4(input)).toBe(expected);
+  });
+});
+
+describe('formatUsSsnMasked', () => {
+  it('masks all but the last 4 digits', () => {
+    expect(formatUsSsnMasked('6789')).toBe('*** ** 6789');
   });
 });

--- a/src/features/cash/services/cashSetupIdentityService.ts
+++ b/src/features/cash/services/cashSetupIdentityService.ts
@@ -1,6 +1,6 @@
 import { isExists, startOfDay } from 'date-fns';
 
-import { type CashSetupDateOfBirth } from '../stores/cashSetupSessionStore';
+import { type CashSetupDateOfBirth, type CashSetupGovernmentId, type CashSetupUsSsnLast4 } from '../stores/cashSetupSessionStore';
 
 const MAX_LEGAL_NAME_LENGTH = 100;
 const LEGAL_NAME_PATTERN = /^\p{L}+(?:[ '-]\p{L}+)*$/u;
@@ -25,4 +25,25 @@ export function toDateOfBirth(date: Date): CashSetupDateOfBirth {
     month: date.getMonth() + 1,
     year: date.getFullYear(),
   };
+}
+
+export function formatDateOfBirth({ year, month, day }: CashSetupDateOfBirth): string {
+  return `${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}/${year}`;
+}
+
+export const US_COUNTRY_CODE = 'US';
+
+const US_SSN_LAST4_PATTERN = /^\d{4}$/;
+
+export function isValidUsSsnLast4(value: string): value is CashSetupUsSsnLast4 {
+  // An SSN serial of 0000 is never issued.
+  return US_SSN_LAST4_PATTERN.test(value) && value !== '0000';
+}
+
+export function formatUsSsnMasked(last4: string): string {
+  return `*** ** ${last4}`;
+}
+
+export function createUsSsnLast4GovernmentId(last4: CashSetupUsSsnLast4): CashSetupGovernmentId {
+  return { countryCode: US_COUNTRY_CODE, kind: 'GOVERNMENT_ID_KIND_SSN_LAST4', value: last4 };
 }

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -3,6 +3,7 @@ import { IS_TESTING } from 'react-native-dotenv';
 import { time } from '@/framework/core/utils/time';
 import { delay } from '@/utils/delay';
 
+import { type CashSetupDateOfBirth, type CashSetupGovernmentId, type CashSetupIdentity } from '../stores/cashSetupSessionStore';
 import { getCashPlatformClient } from './rampClient';
 
 export const US_COUNTRY_CALLING_CODE = '1';
@@ -37,6 +38,14 @@ function parseResendAfter(resendAfter: unknown): number {
   return Date.now();
 }
 
+export enum KycStatus {
+  Unspecified = 'KYC_STATUS_UNSPECIFIED',
+  Pending = 'KYC_STATUS_PENDING',
+  Approved = 'KYC_STATUS_APPROVED',
+  Rejected = 'KYC_STATUS_REJECTED',
+  Review = 'KYC_STATUS_REVIEW',
+}
+
 type CreateUserWithPhoneResponse = {
   userId: string;
   resendAfter: number;
@@ -44,6 +53,40 @@ type CreateUserWithPhoneResponse = {
 
 type ResendPhoneCodeResponse = {
   resendAfter: number;
+};
+
+type SubmitOnboardingParams = {
+  bootstrapToken: string;
+  /** Country of residence, ISO 3166-1 alpha-2. */
+  countryCode: string;
+  identity: CashSetupIdentity;
+  governmentId: CashSetupGovernmentId;
+};
+
+type SubmitOnboardingRequest = {
+  countryCode: string;
+  legalName: {
+    firstName: string;
+    lastName: string;
+  };
+  dateOfBirth: CashSetupDateOfBirth;
+  governmentId: CashSetupGovernmentId;
+};
+
+type SubmitOnboardingResponse = {
+  kycStatus: KycStatus;
+};
+
+type GetUserStatusParams = {
+  bootstrapToken: string;
+};
+
+type GetUserStatusResponse = {
+  status: {
+    kyc: {
+      status: KycStatus;
+    };
+  };
 };
 
 export async function createUserWithPhone({ nationalNumber }: { nationalNumber: string }): Promise<CreateUserWithPhoneResponse> {
@@ -83,4 +126,39 @@ export async function resendPhoneCode({ userId }: { userId: string }): Promise<R
 
   const { data } = await getCashPlatformClient().post<{ resendAfter: unknown }>('/signup/ResendPhoneCode', { userId });
   return { resendAfter: parseResendAfter(data.resendAfter) };
+}
+
+export async function submitOnboarding({
+  bootstrapToken,
+  countryCode,
+  identity,
+  governmentId,
+}: SubmitOnboardingParams): Promise<SubmitOnboardingResponse> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return { kycStatus: KycStatus.Approved };
+  }
+
+  const request: SubmitOnboardingRequest = {
+    countryCode,
+    legalName: { firstName: identity.firstName, lastName: identity.lastName },
+    dateOfBirth: identity.dateOfBirth,
+    governmentId,
+  };
+  const { data } = await getCashPlatformClient().post<SubmitOnboardingResponse>('/onboarding/SubmitOnboarding', request, {
+    headers: { Authorization: `Bearer ${bootstrapToken}` },
+  });
+  return data;
+}
+
+export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Promise<{ kycStatus: KycStatus }> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return { kycStatus: KycStatus.Approved };
+  }
+
+  const { data } = await getCashPlatformClient().get<GetUserStatusResponse>('/status/GetUserStatus', {
+    headers: { Authorization: `Bearer ${bootstrapToken}` },
+  });
+  return { kycStatus: data.status.kyc.status };
 }

--- a/src/features/cash/stores/cashDepositSetupStore.test.ts
+++ b/src/features/cash/stores/cashDepositSetupStore.test.ts
@@ -18,6 +18,7 @@ const verifiedSession = (tokenExpiresAt: number) =>
     bootstrapToken: 'bst_test',
     bootstrapTokenExpiresAt: tokenExpiresAt,
     identity: null,
+    governmentId: null,
   }) as const;
 
 type Case = {

--- a/src/features/cash/stores/cashSetupSessionStore.ts
+++ b/src/features/cash/stores/cashSetupSessionStore.ts
@@ -16,6 +16,18 @@ export type CashSetupIdentity = {
 // be checked against the submission that started them.
 export type PhoneChallenge = Readonly<{ userId: string }>;
 
+export type CashSetupGovernmentIdKind = 'GOVERNMENT_ID_KIND_SSN_LAST4';
+
+declare const cashSetupUsSsnLast4Brand: unique symbol;
+
+export type CashSetupUsSsnLast4 = string & { readonly [cashSetupUsSsnLast4Brand]: true };
+
+export type CashSetupGovernmentId = {
+  countryCode: 'US';
+  kind: CashSetupGovernmentIdKind;
+  value: CashSetupUsSsnLast4;
+};
+
 type EmptyCashSetupSession = {
   status: 'empty';
 };
@@ -34,6 +46,7 @@ type VerifiedCashSetupSession = {
   bootstrapToken: string;
   bootstrapTokenExpiresAt: number;
   identity: CashSetupIdentity | null;
+  governmentId: CashSetupGovernmentId | null;
 };
 
 type CashSetupSession = EmptyCashSetupSession | PhoneSubmittedCashSetupSession | VerifiedCashSetupSession;
@@ -45,6 +58,7 @@ type CashSetupSessionStore = {
   setResendAfter: (challenge: PhoneChallenge, resendAfter: number) => void;
   setPhoneVerified: (challenge: PhoneChallenge, credential: { bootstrapToken: string; expiresAt: number }) => void;
   setIdentity: (identity: CashSetupIdentity) => void;
+  setGovernmentId: (governmentId: CashSetupGovernmentId) => void;
   reset: () => void;
 };
 
@@ -77,6 +91,7 @@ export const useCashSetupSessionStore = createBaseStore<CashSetupSessionStore>((
           bootstrapToken,
           bootstrapTokenExpiresAt: expiresAt,
           identity: null,
+          governmentId: null,
         },
       };
     }),
@@ -84,6 +99,11 @@ export const useCashSetupSessionStore = createBaseStore<CashSetupSessionStore>((
     const { session } = get();
     if (session.status !== 'phoneVerified') return;
     set({ session: { ...session, identity } });
+  },
+  setGovernmentId: governmentId => {
+    const { session } = get();
+    if (session.status !== 'phoneVerified') return;
+    set({ session: { ...session, governmentId } });
   },
   reset: () => set(state => (state.session === EMPTY_SESSION ? state : { session: EMPTY_SESSION })),
 }));

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -543,6 +543,7 @@ export const DevSection = () => {
                     bootstrapToken: 'bst_dev',
                     bootstrapTokenExpiresAt: Date.now() + time.hours(1),
                     identity: null,
+                    governmentId: null,
                   },
                 })
               }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1604,8 +1604,20 @@
           "date_of_birth": "Date of Birth",
           "date_of_birth_placeholder": "MM/DD/YYYY"
         },
-        "ssn": { "title": "Last 4 of SSN" },
-        "review": { "title": "Review" },
+        "ssn": {
+          "title": "Enter the last 4 digits of your SSN",
+          "helper": "All data is encrypted and secured."
+        },
+        "review": {
+          "title": "Review your information",
+          "subtitle": "Carefully review your information to ensure it is accurate and up-to-date.",
+          "confirm": "Confirm",
+          "name": "Name",
+          "date_of_birth": "Date of Birth",
+          "ssn": "Social Security Number",
+          "edit": "Edit",
+          "error": "We couldn’t verify your details. Please try again."
+        },
         "passkey": { "title": "Add a Passkey" },
         "email": { "title": "Enter email" },
         "all_done": {


### PR DESCRIPTION
## Why?

This completes the identity-verification portion of Cash setup. Users can now provide the last four digits of their SSN, review their name, date of birth, and masked SSN, and correct mistakes before submitting their details.

After confirmation, the app submits the KYC request and waits briefly for pending decisions to resolve. Users advance only after approval; rejected, unresolved, or failed submissions remain on the review step with a retryable error.

## Videos

| iOS | Android |
| --- | --- |
| [Simulator Screen Recording - iPhone 17 Pro - 2026-07-15 at 19.40.18.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a1c70d31-5b7f-4261-9c17-86712b1378f9.mov" />](https://app.graphite.com/user-attachments/video/a1c70d31-5b7f-4261-9c17-86712b1378f9.mov) | [untitled.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f9b3a92b-98a1-4de1-915e-5c96208847ee.webm" />](https://app.graphite.com/user-attachments/video/f9b3a92b-98a1-4de1-915e-5c96208847ee.webm)<br> |

## Testing

- Verify Continue is enabled only for four valid SSN digits and that the value remains masked.
- Verify the review screen shows the correct name, date of birth, and masked SSN.
- Verify each Edit action returns to the corresponding screen and updated details appear on review.
- Confirm the details and verify an approved submission advances to the passkey step.
- Verify failed or unresolved verification displays an error and can be retried.