### PR TITLE
Minimize Polymarket errors, update `@polymarket/clob-client-v2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@notifee/react-native": "7.8.2",
     "@polymarket/builder-relayer-client": "0.0.10",
     "@polymarket/builder-signing-sdk": "0.0.8",
-    "@polymarket/clob-client-v2": "1.0.8",
+    "@polymarket/clob-client-v2": "1.1.0",
     "@rainbow-me/provider": "0.1.2",
     "@rainbow-me/react-native-animated-number": "0.0.2",
     "@rainbow-me/sdk": "0.4.0",

--- a/patches/@polymarket+clob-client-v2+1.1.0.patch
+++ b/patches/@polymarket+clob-client-v2+1.1.0.patch
@@ -1,5 +1,6 @@
 # PATCH CONTEXT
-# Why: Rainbow needs v1.0.8 for 0.0025 tick-size markets.
+# Why: Rainbow needs v1.1.0 for async order settlement hash resolution and
+#   0.0025 tick-size markets.
 #   This patch removes the parts of the SDK that break in our app:
 #   Node-only request headers, stale tick-size reads, and WebCrypto
 #   HMAC signing.
@@ -8,7 +9,7 @@
 # Remove when: @polymarket/clob-client-v2 handles those cases upstream.
 
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.cjs b/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.cjs
-index 946edd341a..5c8cc29f67 100644
+index 946edd3..10a85dc 100644
 --- a/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.cjs
 +++ b/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.cjs
 @@ -1,22 +1,12 @@
@@ -16,7 +17,8 @@ index 946edd341a..5c8cc29f67 100644
  let axios = require("axios");
  axios = require_rolldown_runtime.__toESM(axios);
 -let browser_or_node = require("browser-or-node");
- 
+-
++
  //#region src/http-helpers/index.ts
  const GET = "GET";
  const POST = "POST";
@@ -35,13 +37,14 @@ index 946edd341a..5c8cc29f67 100644
  		method,
  		url: endpoint,
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.js b/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.js
-index d7e38a4b5e..4c5ef057eb 100644
+index d7e38a4..40a2358 100644
 --- a/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.js
 +++ b/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.js
 @@ -1,20 +1,10 @@
  import axios from "axios";
 -import { isBrowser } from "browser-or-node";
- 
+-
++
  //#region src/http-helpers/index.ts
  const GET = "GET";
  const POST = "POST";
@@ -60,10 +63,10 @@ index d7e38a4b5e..4c5ef057eb 100644
  		method,
  		url: endpoint,
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/client.cjs b/node_modules/@polymarket/clob-client-v2/dist/client.cjs
-index 55bbc87c9a..e158a4bcfe 100644
+index fd6d479..9a3b60b 100644
 --- a/node_modules/@polymarket/clob-client-v2/dist/client.cjs
 +++ b/node_modules/@polymarket/clob-client-v2/dist/client.cjs
-@@ -102,7 +102,6 @@ var ClobClient = class {
+@@ -107,7 +107,6 @@ var ClobClient = class {
  			if (!token) continue;
  			const tokenId = token.t;
  			this.tokenConditionMap[tokenId] = conditionID;
@@ -71,7 +74,7 @@ index 55bbc87c9a..e158a4bcfe 100644
  			this.negRisk[tokenId] = result.nr ?? false;
  			this.feeInfos[tokenId] = {
  				rate: result.fd?.r ?? 0,
-@@ -118,14 +117,12 @@ var ClobClient = class {
+@@ -123,14 +122,12 @@ var ClobClient = class {
  		return this.post(`${this.host}${require_endpoints.GET_ORDER_BOOKS}`, { data: params });
  	}
  	async getTickSize(tokenID) {
@@ -90,10 +93,10 @@ index 55bbc87c9a..e158a4bcfe 100644
  	async getNegRisk(tokenID) {
  		if (tokenID in this.negRisk) return this.negRisk[tokenID];
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/client.js b/node_modules/@polymarket/clob-client-v2/dist/client.js
-index a56b88ee8b..3a8cc1da1b 100644
+index 06eb6ee..d8a800e 100644
 --- a/node_modules/@polymarket/clob-client-v2/dist/client.js
 +++ b/node_modules/@polymarket/clob-client-v2/dist/client.js
-@@ -102,7 +102,6 @@ var ClobClient = class {
+@@ -107,7 +107,6 @@ var ClobClient = class {
  			if (!token) continue;
  			const tokenId = token.t;
  			this.tokenConditionMap[tokenId] = conditionID;
@@ -101,7 +104,7 @@ index a56b88ee8b..3a8cc1da1b 100644
  			this.negRisk[tokenId] = result.nr ?? false;
  			this.feeInfos[tokenId] = {
  				rate: result.fd?.r ?? 0,
-@@ -118,14 +117,12 @@ var ClobClient = class {
+@@ -123,14 +122,12 @@ var ClobClient = class {
  		return this.post(`${this.host}${GET_ORDER_BOOKS}`, { data: params });
  	}
  	async getTickSize(tokenID) {
@@ -120,11 +123,12 @@ index a56b88ee8b..3a8cc1da1b 100644
  	async getNegRisk(tokenID) {
  		if (tokenID in this.negRisk) return this.negRisk[tokenID];
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.cjs b/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.cjs
-index 909745afcf..2fd69198ac 100644
+index 909745a..cc87ff4 100644
 --- a/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.cjs
 +++ b/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.cjs
 @@ -1,4 +1,8 @@
- 
+-
++
 +const require_bytes = require('@ethersproject/bytes');
 +const require_sha2 = require('@ethersproject/sha2');
 +const require_strings = require('@ethersproject/strings');
@@ -144,7 +148,7 @@ index 909745afcf..2fd69198ac 100644
  /**
  * Builds the canonical Polymarket CLOB HMAC signature
  * @param secret
-@@ -20,20 +29,12 @@ const decodeBase64Secret = (secret) => {
+@@ -20,19 +29,11 @@ const decodeBase64Secret = (secret) => {
  */
  const buildPolyHmacSignature = async (secret, timestamp, method, requestPath, body) => {
  	if (!secret) throw new Error("buildPolyHmacSignature: secret is empty");
@@ -164,11 +168,11 @@ index 909745afcf..2fd69198ac 100644
 +	const signature = require_sha2.computeHmac(require_sha2.SupportedAlgorithm.sha256, keyBytes, require_strings.toUtf8Bytes(message));
 +	return encodeBase64Url(require_bytes.arrayify(signature));
  };
- 
+-
++
  //#endregion
- exports.buildPolyHmacSignature = buildPolyHmacSignature;
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.js b/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.js
-index fa4021a314..f468296891 100644
+index fa4021a..53a084f 100644
 --- a/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.js
 +++ b/node_modules/@polymarket/clob-client-v2/dist/signing/hmac.js
 @@ -1,3 +1,7 @@
@@ -191,7 +195,7 @@ index fa4021a314..f468296891 100644
  /**
  * Builds the canonical Polymarket CLOB HMAC signature
  * @param secret
-@@ -19,20 +28,12 @@ const decodeBase64Secret = (secret) => {
+@@ -19,19 +28,11 @@ const decodeBase64Secret = (secret) => {
  */
  const buildPolyHmacSignature = async (secret, timestamp, method, requestPath, body) => {
  	if (!secret) throw new Error("buildPolyHmacSignature: secret is empty");
@@ -211,6 +215,6 @@ index fa4021a314..f468296891 100644
 +	const signature = computeHmac(SupportedAlgorithm.sha256, keyBytes, toUtf8Bytes(message));
 +	return encodeBase64Url(arrayify(signature));
  };
- 
+-
++
  //#endregion
- export { buildPolyHmacSignature };

--- a/patches/@polymarket+clob-client-v2+1.1.0.patch
+++ b/patches/@polymarket+clob-client-v2+1.1.0.patch
@@ -1,12 +1,12 @@
 # PATCH CONTEXT
-# Why: Rainbow needs v1.1.0 for async order settlement hash resolution and
-#   0.0025 tick-size markets.
-#   This patch removes the parts of the SDK that break in our app:
-#   Node-only request headers, stale tick-size reads, and WebCrypto
-#   HMAC signing.
+# Why: @polymarket/clob-client-v2 assumes a browser or Node runtime. In React
+#   Native it adds Node-only request headers and uses unavailable WebCrypto
+#   APIs for HMAC signing. This patch makes the package React Native compatible
+#   and bypasses cached tick sizes so orders use the market's current value.
 # Upstream Issue: none filed yet.
 # Linear Issue: none.
-# Remove when: @polymarket/clob-client-v2 handles those cases upstream.
+# Remove when: @polymarket/clob-client-v2 supports React Native requests and
+#   signing, and no longer serves cached tick sizes.
 
 diff --git a/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.cjs b/node_modules/@polymarket/clob-client-v2/dist/http-helpers/index.cjs
 index 946edd3..10a85dc 100644

--- a/src/features/polymarket/screens/polymarket-new-position-sheet/utils/calculateBuyOrderExecution.test.ts
+++ b/src/features/polymarket/screens/polymarket-new-position-sheet/utils/calculateBuyOrderExecution.test.ts
@@ -46,7 +46,8 @@ describe('calculateBuyOrderExecution', () => {
     expect(10 - totalSpendUsd).toBeLessThan(0.00001);
     expect(Number(execution.orderSpendCap)).toBeLessThan(10);
     expect(execution.worstPrice).toBe('0.8');
-    expect(Number(execution.fee)).toBeCloseTo(Number(execution.rainbowFee) + Number(execution.tokensBought) * platformFeeRate, 9);
+    const platformFee = Number((Number(execution.tokensBought) * platformFeeRate).toFixed(5));
+    expect(Number(execution.fee)).toBeCloseTo(Number(execution.rainbowFee) + platformFee, 9);
     expect(execution.minBuyAmountUsd).toBe('1.07');
     expect(mockAdjustBuyAmountForFees).toHaveBeenCalledWith(
       expect.any(Number),

--- a/src/features/polymarket/screens/polymarket-new-position-sheet/utils/calculateBuyOrderExecution.ts
+++ b/src/features/polymarket/screens/polymarket-new-position-sheet/utils/calculateBuyOrderExecution.ts
@@ -10,7 +10,7 @@ import {
 } from '@/features/polymarket/utils/fees';
 import { calculateOrderBookSpread, getBestOrderBookPrice, simulateMarketFills } from '@/features/polymarket/utils/orderBookFills';
 import { calculateTradeFeeUsd } from '@/features/polymarket/utils/polymarketTradeFee';
-import { ceilWorklet, divWorklet, mulWorklet } from '@/framework/core/safeMath';
+import { ceilWorklet, divWorklet, mulWorklet, toFixedWorklet, trimTrailingZeros } from '@/framework/core/safeMath';
 
 export type BuyOrderExecution = {
   averagePrice: string;
@@ -78,7 +78,7 @@ export function calculateBuyOrderExecution({
     averagePrice: String(execution.averagePrice),
     worstPrice: String(execution.priceLimit),
     bestPrice: bestAskPrice,
-    fee: String(execution.feeAmountUsd),
+    fee: trimTrailingZeros(toFixedWorklet(execution.feeAmountUsd, POLYMARKET_PUSD_DECIMALS)),
     orderSpendCap: String(execution.orderSpendCapUsd),
     rainbowFee: String(execution.rainbowFeeAmountUsd),
     tokensBought: String(execution.tokensBought),
@@ -108,6 +108,7 @@ function resolveBuyExecution({
       priceLimit: 0,
       rainbowFeeAmountUsd: 0,
       tokensBought: 0,
+      totalSpendUsd: 0,
     };
   }
 

--- a/src/features/polymarket/screens/polymarket-sell-position-sheet/utils/calculateSellExecution.ts
+++ b/src/features/polymarket/screens/polymarket-sell-position-sheet/utils/calculateSellExecution.ts
@@ -1,8 +1,9 @@
+import { POLYMARKET_PUSD_DECIMALS } from '@/features/polymarket/constants';
 import { type OrderBook } from '@/features/polymarket/stores/polymarketOrderBookStore';
 import { calculateFillFeesUsd, type PolymarketFeeInfo } from '@/features/polymarket/utils/fees';
 import { calculateOrderBookSpread, getBestOrderBookPrice, simulateMarketFills } from '@/features/polymarket/utils/orderBookFills';
 import { calculateTradeFeeUsd } from '@/features/polymarket/utils/polymarketTradeFee';
-import { greaterThanWorklet } from '@/framework/core/safeMath';
+import { greaterThanWorklet, subWorklet, sumWorklet, toFixedWorklet, trimTrailingZeros } from '@/framework/core/safeMath';
 
 export type SellExecution = {
   averagePrice: string;
@@ -48,10 +49,10 @@ export function calculateSellExecution({
   const execution = simulateMarketFills({ levels: orderBook.bids, targetAmount: Number(sellAmountTokens), targetType: 'shares' });
   const averagePrice = execution.totalShares > 0 ? execution.totalNotionalUsd / execution.totalShares : 0;
   const providerFee = calculateFillFeesUsd({ feeInfo, fills: execution.fills });
-  const rainbowFee = Number(calculateTradeFeeUsd({ notionalUsd: execution.totalNotionalUsd, price: averagePrice }));
-  const fee = providerFee + rainbowFee;
-  const grossProceedsUsd = String(execution.totalNotionalUsd);
-  const expectedPayoutUsd = String(execution.totalNotionalUsd - fee);
+  const rainbowFee = calculateTradeFeeUsd({ notionalUsd: execution.totalNotionalUsd, price: averagePrice });
+  const fee = sumWorklet(providerFee, rainbowFee);
+  const grossProceedsUsd = trimTrailingZeros(toFixedWorklet(execution.totalNotionalUsd, POLYMARKET_PUSD_DECIMALS));
+  const expectedPayoutUsd = subWorklet(grossProceedsUsd, fee);
   const tokensSold = String(execution.totalShares);
 
   const bestBidPrice = getBestOrderBookPrice(orderBook.bids);
@@ -62,8 +63,8 @@ export function calculateSellExecution({
     averagePrice: String(averagePrice),
     worstPrice: String(execution.worstPrice),
     bestPrice: bestBidPrice,
-    fee: String(fee),
-    rainbowFee: String(rainbowFee),
+    fee,
+    rainbowFee,
     tokensSold,
     grossProceedsUsd,
     expectedPayoutUsd,

--- a/src/features/polymarket/utils/collectPolymarketTradeFee.test.ts
+++ b/src/features/polymarket/utils/collectPolymarketTradeFee.test.ts
@@ -73,6 +73,7 @@ describe('collectPolymarketTradeFee', () => {
       matchedAmounts: { tokens: '25', usd: '12.5' },
       orderId: 'order-1',
       quotedFeeUsd: '0.1',
+      settlementTransactionHashes: ['0xsettlement'],
       side: 'buy',
       tokenId: 'token-1',
     });
@@ -92,7 +93,7 @@ describe('collectPolymarketTradeFee', () => {
       operation: OperationType.Call,
     };
     let confirmSettlement!: () => void;
-    mockAwaitPolygonConfirmation.mockReturnValueOnce(
+    mockAwaitPolygonConfirmation.mockResolvedValueOnce(undefined).mockReturnValueOnce(
       new Promise<void>(resolve => {
         confirmSettlement = resolve;
       })
@@ -103,13 +104,14 @@ describe('collectPolymarketTradeFee', () => {
       matchedAmounts: { tokens: '25', usd: '12.5' },
       orderId: 'order-1',
       quotedFeeUsd: '0.1',
-      settlementTransactionHashes: ['0xsettlement'],
+      settlementTransactionHashes: ['0xsettlement-1', '0xsettlement-2'],
       side: 'buy',
       tokenId: 'token-1',
     });
     await Promise.resolve();
 
-    expect(mockAwaitPolygonConfirmation).toHaveBeenCalledWith('0xsettlement');
+    expect(mockAwaitPolygonConfirmation).toHaveBeenNthCalledWith(1, '0xsettlement-1');
+    expect(mockAwaitPolygonConfirmation).toHaveBeenNthCalledWith(2, '0xsettlement-2');
     expect(mockBuildUnwrapPusdToUsdcTransactions).not.toHaveBeenCalled();
     expect(mockExecuteRelayTransaction).not.toHaveBeenCalled();
 
@@ -128,6 +130,7 @@ describe('collectPolymarketTradeFee', () => {
         matchedAmounts: { tokens: '5', usd: '2.5' },
         orderId: 'order-2',
         quotedFeeUsd: '0.1',
+        settlementTransactionHashes: ['0xsettlement'],
         side: 'sell',
         tokenId: 'token-2',
       })
@@ -150,6 +153,7 @@ describe('collectPolymarketTradeFee', () => {
       matchedAmounts: { tokens: '0', usd: '0' },
       orderId: 'order-3',
       quotedFeeUsd: '0.1',
+      settlementTransactionHashes: ['0xsettlement'],
       side: 'buy',
       tokenId: 'token-3',
     });

--- a/src/features/polymarket/utils/collectPolymarketTradeFee.test.ts
+++ b/src/features/polymarket/utils/collectPolymarketTradeFee.test.ts
@@ -1,6 +1,7 @@
 import { OperationType } from '@polymarket/builder-relayer-client';
 
 import { buildUnwrapPusdToUsdcTransactions } from '@/features/polymarket/utils/collateral';
+import { awaitPolygonConfirmation } from '@/features/polymarket/utils/confirmation';
 import { getPolymarketWallet } from '@/features/polymarket/utils/polymarketWallet';
 import { executeRelayTransaction } from '@/features/polymarket/utils/relayExecution';
 import { logger } from '@/logger';
@@ -18,6 +19,10 @@ jest.mock('@/state/wallets/walletsStore', () => ({
 jest.mock('@/features/polymarket/constants', () => ({
   POLYMARKET_PUSD_DECIMALS: 6,
   POLYMARKET_RAINBOW_FEE_RECIPIENT_ADDRESS: '0x757758506d6a4F8a433F8BECaFd52545f9Cb050a',
+}));
+
+jest.mock('@/features/polymarket/utils/confirmation', () => ({
+  awaitPolygonConfirmation: jest.fn(),
 }));
 
 jest.mock('@/features/polymarket/utils/collateral', () => ({
@@ -41,14 +46,18 @@ jest.mock('@/logger', () => ({
 const mockBuildUnwrapPusdToUsdcTransactions = jest.mocked(buildUnwrapPusdToUsdcTransactions);
 const mockExecuteRelayTransaction = jest.mocked(executeRelayTransaction);
 const mockGetPolymarketWallet = jest.mocked(getPolymarketWallet);
+const mockAwaitPolygonConfirmation = jest.mocked(awaitPolygonConfirmation);
 const mockLoggerError = jest.mocked(logger.error);
 
 describe('collectPolymarketTradeFee', () => {
   beforeEach(() => {
+    mockAwaitPolygonConfirmation.mockReset();
     mockBuildUnwrapPusdToUsdcTransactions.mockReset();
     mockExecuteRelayTransaction.mockReset();
     mockGetPolymarketWallet.mockClear();
     mockLoggerError.mockReset();
+
+    mockAwaitPolygonConfirmation.mockResolvedValue(undefined);
   });
 
   it('submits capped fee transactions through the current relayer', async () => {
@@ -72,6 +81,42 @@ describe('collectPolymarketTradeFee', () => {
     expect(buildCall?.[0].amount.toString()).toBe('100000');
     expect(buildCall?.[0].proxyAddress).toBe('0xProxy');
     expect(buildCall?.[0].recipient).toBe(expectedFeeRecipient);
+    expect(mockExecuteRelayTransaction).toHaveBeenCalledWith([transaction], 'collect Rainbow Polymarket fee');
+  });
+
+  it('waits for matched order settlement before submitting fee transactions', async () => {
+    const transaction = {
+      to: '0xRecipient',
+      data: '0x',
+      value: '0',
+      operation: OperationType.Call,
+    };
+    let confirmSettlement!: () => void;
+    mockAwaitPolygonConfirmation.mockReturnValueOnce(
+      new Promise<void>(resolve => {
+        confirmSettlement = resolve;
+      })
+    );
+    mockBuildUnwrapPusdToUsdcTransactions.mockResolvedValue([transaction]);
+
+    const promise = collectPolymarketTradeFee({
+      matchedAmounts: { tokens: '25', usd: '12.5' },
+      orderId: 'order-1',
+      quotedFeeUsd: '0.1',
+      settlementTransactionHashes: ['0xsettlement'],
+      side: 'buy',
+      tokenId: 'token-1',
+    });
+    await Promise.resolve();
+
+    expect(mockAwaitPolygonConfirmation).toHaveBeenCalledWith('0xsettlement');
+    expect(mockBuildUnwrapPusdToUsdcTransactions).not.toHaveBeenCalled();
+    expect(mockExecuteRelayTransaction).not.toHaveBeenCalled();
+
+    confirmSettlement();
+    await promise;
+
+    expect(mockBuildUnwrapPusdToUsdcTransactions).toHaveBeenCalled();
     expect(mockExecuteRelayTransaction).toHaveBeenCalledWith([transaction], 'collect Rainbow Polymarket fee');
   });
 

--- a/src/features/polymarket/utils/collectPolymarketTradeFee.ts
+++ b/src/features/polymarket/utils/collectPolymarketTradeFee.ts
@@ -9,6 +9,9 @@ import { executeRelayTransaction } from '@/features/polymarket/utils/relayExecut
 import { ensureError, logger, RainbowError } from '@/logger';
 import { useWalletsStore } from '@/state/wallets/walletsStore';
 
+/** Polygon transactions that settle a matched Polymarket order. */
+export type SettlementTransactionHashes = readonly [string, ...string[]];
+
 type CollectTradeFeeParams = {
   matchedAmounts: {
     tokens: string | number;
@@ -17,7 +20,7 @@ type CollectTradeFeeParams = {
   orderId: string;
   quotedFeeUsd: string | number;
   side: 'buy' | 'sell';
-  settlementTransactionHashes?: string[];
+  settlementTransactionHashes: SettlementTransactionHashes;
   tokenId: string;
 };
 
@@ -71,8 +74,6 @@ export async function collectPolymarketTradeFee({
   }
 }
 
-async function waitForSettlementTransactions(transactionHashes?: string[]): Promise<void> {
-  if (!transactionHashes?.length) return;
-
+async function waitForSettlementTransactions(transactionHashes: SettlementTransactionHashes): Promise<void> {
   await Promise.all(transactionHashes.map(hash => awaitPolygonConfirmation(hash)));
 }

--- a/src/features/polymarket/utils/collectPolymarketTradeFee.ts
+++ b/src/features/polymarket/utils/collectPolymarketTradeFee.ts
@@ -2,6 +2,7 @@ import { type Address } from 'viem';
 
 import { POLYMARKET_RAINBOW_FEE_RECIPIENT_ADDRESS } from '@/features/polymarket/constants';
 import { buildUnwrapPusdToUsdcTransactions } from '@/features/polymarket/utils/collateral';
+import { awaitPolygonConfirmation } from '@/features/polymarket/utils/confirmation';
 import { calculateFeeToCollectUsd, getTradeFeeAmount } from '@/features/polymarket/utils/polymarketTradeFee';
 import { getPolymarketWallet } from '@/features/polymarket/utils/polymarketWallet';
 import { executeRelayTransaction } from '@/features/polymarket/utils/relayExecution';
@@ -16,6 +17,7 @@ type CollectTradeFeeParams = {
   orderId: string;
   quotedFeeUsd: string | number;
   side: 'buy' | 'sell';
+  settlementTransactionHashes?: string[];
   tokenId: string;
 };
 
@@ -27,6 +29,7 @@ export async function collectPolymarketTradeFee({
   orderId,
   quotedFeeUsd,
   side,
+  settlementTransactionHashes,
   tokenId,
 }: CollectTradeFeeParams): Promise<void> {
   let feeAmountUsd = '0';
@@ -43,6 +46,8 @@ export async function collectPolymarketTradeFee({
 
     const wallet = await getPolymarketWallet(owner);
     proxyAddress = wallet.address;
+
+    await waitForSettlementTransactions(settlementTransactionHashes);
 
     const transactions = await buildUnwrapPusdToUsdcTransactions({
       amount,
@@ -64,4 +69,10 @@ export async function collectPolymarketTradeFee({
       tokenId,
     });
   }
+}
+
+async function waitForSettlementTransactions(transactionHashes?: string[]): Promise<void> {
+  if (!transactionHashes?.length) return;
+
+  await Promise.all(transactionHashes.map(hash => awaitPolygonConfirmation(hash)));
 }

--- a/src/features/polymarket/utils/executePolymarketOrder.test.ts
+++ b/src/features/polymarket/utils/executePolymarketOrder.test.ts
@@ -92,6 +92,7 @@ describe('executePolymarketOrder', () => {
         orderID: 'buy-order',
         status: 'matched',
         takingAmount: '10',
+        transactionsHashes: ['0xsettlement'],
       })
     );
 
@@ -133,6 +134,7 @@ describe('executePolymarketOrder', () => {
       matchedAmounts: { tokens: '10', usd: '5' },
       orderId: 'buy-order',
       quotedFeeUsd: '0.1',
+      settlementTransactionHashes: ['0xsettlement'],
       side: 'buy',
       tokenId: 'token-1',
     });
@@ -311,11 +313,13 @@ function createOrderResult({
   orderID,
   status,
   takingAmount = '0',
+  transactionsHashes = [],
 }: {
   makingAmount?: string;
   orderID: string;
   status: string;
   takingAmount?: string;
+  transactionsHashes?: string[];
 }): SuccessfulOrderResult {
   return {
     success: true,
@@ -324,7 +328,7 @@ function createOrderResult({
     orderID,
     status,
     takingAmount,
-    transactionsHashes: [],
+    transactionsHashes,
   };
 }
 

--- a/src/features/polymarket/utils/executePolymarketOrder.test.ts
+++ b/src/features/polymarket/utils/executePolymarketOrder.test.ts
@@ -12,6 +12,7 @@ import { executePolymarketBuyPosition, executePolymarketSellPosition } from './e
 
 const mockCreateAndPostMarketOrder = jest.fn();
 const mockGetOrder = jest.fn();
+const mockGetTrades = jest.fn();
 const mockUpdateBalanceAllowance = jest.fn();
 
 jest.mock('@/state/wallets/walletsStore', () => ({
@@ -34,6 +35,7 @@ jest.mock('@/features/polymarket/stores/derived/usePolymarketClients', () => ({
   getPolymarketClobClient: jest.fn(async () => ({
     createAndPostMarketOrder: mockCreateAndPostMarketOrder,
     getOrder: mockGetOrder,
+    getTrades: mockGetTrades,
     updateBalanceAllowance: mockUpdateBalanceAllowance,
   })),
 }));
@@ -79,6 +81,7 @@ describe('executePolymarketOrder', () => {
     mockEnsureTradingApprovals.mockReset();
     mockGetPolygonUsdcBalance.mockReset();
     mockGetOrder.mockReset();
+    mockGetTrades.mockReset();
     mockUpdateBalanceAllowance.mockReset();
     mockWrapUsdcAmountToPusd.mockReset();
 
@@ -140,6 +143,46 @@ describe('executePolymarketOrder', () => {
     });
   });
 
+  it('resolves settlement hashes before collecting when an immediate match omits them', async () => {
+    let resolveTrades!: (trades: { id: string; status: string; transaction_hash: string }[]) => void;
+    mockCreateAndPostMarketOrder.mockResolvedValue(
+      createOrderResult({
+        makingAmount: '5',
+        orderID: 'buy-order',
+        status: 'matched',
+        takingAmount: '10',
+      })
+    );
+    mockGetOrder.mockResolvedValue({
+      associate_trades: ['trade-1'],
+      price: '0.5',
+      size_matched: '10',
+      status: 'matched',
+    });
+    mockGetTrades.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveTrades = resolve;
+      })
+    );
+
+    await executePolymarketBuyPosition({
+      tokenId: 'token-1',
+      amount: '5',
+      price: '0.5',
+      negRisk: false,
+      matchedOrderMetadata: createMatchedOrderMetadata({ quotedTradeFeeUsd: '0.1' }),
+    });
+    await flushPromises();
+
+    expect(mockGetTrades).toHaveBeenCalledWith({ id: 'trade-1' }, true);
+    expect(mockCollectPolymarketTradeFee).not.toHaveBeenCalled();
+
+    resolveTrades([{ id: 'trade-1', status: 'confirmed', transaction_hash: '0xsettlement' }]);
+    await flushPromises();
+
+    expect(mockCollectPolymarketTradeFee).toHaveBeenCalledWith(expect.objectContaining({ settlementTransactionHashes: ['0xsettlement'] }));
+  });
+
   it('wraps existing Polygon USDC before placing a buy order', async () => {
     const usdcBalance = ethers.utils.parseUnits('3', 6);
     mockGetPolygonUsdcBalance.mockResolvedValueOnce(usdcBalance);
@@ -153,6 +196,7 @@ describe('executePolymarketOrder', () => {
         orderID: 'buy-order',
         status: 'matched',
         takingAmount: '10',
+        transactionsHashes: ['0xsettlement'],
       })
     );
 
@@ -214,6 +258,7 @@ describe('executePolymarketOrder', () => {
         orderID: 'sell-order',
         status: 'matched',
         takingAmount: '5',
+        transactionsHashes: ['0xsettlement'],
       })
     );
 
@@ -252,6 +297,7 @@ describe('executePolymarketOrder', () => {
       matchedAmounts: { tokens: '10', usd: '5' },
       orderId: 'sell-order',
       quotedFeeUsd: '0.1',
+      settlementTransactionHashes: ['0xsettlement'],
       side: 'sell',
       tokenId: 'token-1',
     });
@@ -259,7 +305,8 @@ describe('executePolymarketOrder', () => {
 
   it('polls after an accepted live order and collects after the match', async () => {
     mockCreateAndPostMarketOrder.mockResolvedValue(createOrderResult({ orderID: 'polled-order', status: 'live' }));
-    mockGetOrder.mockResolvedValue({ price: '0.5', size_matched: '10', status: 'matched' });
+    mockGetOrder.mockResolvedValue({ associate_trades: ['trade-1'], price: '0.5', size_matched: '10', status: 'matched' });
+    mockGetTrades.mockResolvedValue([{ id: 'trade-1', status: 'confirmed', transaction_hash: '0xsettlement' }]);
 
     await executePolymarketBuyPosition({
       tokenId: 'token-1',
@@ -275,9 +322,36 @@ describe('executePolymarketOrder', () => {
       matchedAmounts: { tokens: '10', usd: '5' },
       orderId: 'polled-order',
       quotedFeeUsd: '0.1',
+      settlementTransactionHashes: ['0xsettlement'],
       side: 'buy',
       tokenId: 'token-1',
     });
+  });
+
+  it('does not collect fees when a matched trade fails before settlement', async () => {
+    mockCreateAndPostMarketOrder.mockResolvedValue(createOrderResult({ orderID: 'failed-trade-order', status: 'live' }));
+    mockGetOrder.mockResolvedValue({
+      associate_trades: ['trade-1'],
+      price: '0.5',
+      size_matched: '10',
+      status: 'matched',
+    });
+    mockGetTrades.mockResolvedValue([{ id: 'trade-1', status: 'failed' }]);
+
+    await executePolymarketBuyPosition({
+      tokenId: 'token-1',
+      amount: '5',
+      price: '0.5',
+      negRisk: false,
+      matchedOrderMetadata: createMatchedOrderMetadata({ quotedTradeFeeUsd: '0.1' }),
+    });
+    await flushPromises();
+
+    expect(mockCollectPolymarketTradeFee).not.toHaveBeenCalled();
+    expect(mockAnalyticsTrack).toHaveBeenCalledWith(
+      'predictions.order_match.failed',
+      expect.objectContaining({ orderId: 'failed-trade-order', reason: 'failed', status: 'failed' })
+    );
   });
 
   it('tracks a terminal match failure without collecting fees', async () => {
@@ -313,7 +387,7 @@ function createOrderResult({
   orderID,
   status,
   takingAmount = '0',
-  transactionsHashes = [],
+  transactionsHashes,
 }: {
   makingAmount?: string;
   orderID: string;
@@ -346,6 +420,7 @@ function createMatchedOrderMetadata({ quotedTradeFeeUsd }: { quotedTradeFeeUsd: 
 }
 
 async function flushPromises(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
+  await new Promise<void>(resolve => {
+    setImmediate(resolve);
+  });
 }

--- a/src/features/polymarket/utils/executePolymarketOrder.ts
+++ b/src/features/polymarket/utils/executePolymarketOrder.ts
@@ -66,6 +66,10 @@ type MatchedOrderAmounts = {
   usd: string;
 };
 
+type MatchedOrderSettlement = {
+  transactionHashes?: string[];
+};
+
 // ============ Constants ====================================================== //
 
 const POLL_INTERVAL = time.seconds(1);
@@ -212,7 +216,7 @@ function startMatchedOrderFeeCollection({ orderResult, context }: { orderResult:
   const immediateAmounts = getMatchedAmountsFromAcceptedOrder(orderResult, context.side);
 
   if (immediateAmounts) {
-    recordMatchedOrderAndCollectFee(context, immediateAmounts, orderId);
+    recordMatchedOrderAndCollectFee(context, immediateAmounts, orderId, { transactionHashes: orderResult.transactionsHashes });
     return;
   }
 
@@ -260,14 +264,22 @@ async function pollForMatchedOrderFeeCollection({
   }
 }
 
-function recordMatchedOrderAndCollectFee(context: MatchedOrderContext, amounts: MatchedOrderAmounts, orderId: string) {
+function recordMatchedOrderAndCollectFee(
+  context: MatchedOrderContext,
+  amounts: MatchedOrderAmounts,
+  orderId: string,
+  settlement?: MatchedOrderSettlement
+) {
   trackMatchedOrderAnalytics(context, amounts);
+
+  const settlementTransactionHashes = settlement?.transactionHashes?.filter(Boolean);
 
   void collectPolymarketTradeFee({
     matchedAmounts: amounts,
     orderId,
     quotedFeeUsd: context.quotedTradeFeeUsd,
     side: context.side,
+    ...(settlementTransactionHashes?.length ? { settlementTransactionHashes } : {}),
     tokenId: context.tokenId,
   });
 }

--- a/src/features/polymarket/utils/executePolymarketOrder.ts
+++ b/src/features/polymarket/utils/executePolymarketOrder.ts
@@ -7,7 +7,7 @@ import { getPolymarketClobClient } from '@/features/polymarket/stores/derived/us
 import { usePolymarketBalanceStore } from '@/features/polymarket/stores/polymarketBalanceStore';
 import { type PolymarketOrderResult, type SuccessfulOrderResult } from '@/features/polymarket/types';
 import { getPolygonUsdcBalance, wrapUsdcAmountToPusd } from '@/features/polymarket/utils/collateral';
-import { collectPolymarketTradeFee } from '@/features/polymarket/utils/collectPolymarketTradeFee';
+import { collectPolymarketTradeFee, type SettlementTransactionHashes } from '@/features/polymarket/utils/collectPolymarketTradeFee';
 import { getPolymarketWallet } from '@/features/polymarket/utils/polymarketWallet';
 import { ensureTradingApprovals } from '@/features/polymarket/utils/tradingApprovals';
 import { divWorklet, mulWorklet } from '@/framework/core/safeMath';
@@ -66,9 +66,10 @@ type MatchedOrderAmounts = {
   usd: string;
 };
 
-type MatchedOrderSettlement = {
-  transactionHashes?: string[];
-};
+type MatchedOrderSettlement =
+  | { status: 'pending' }
+  | { status: 'failed' }
+  | { status: 'resolved'; transactionHashes: SettlementTransactionHashes };
 
 // ============ Constants ====================================================== //
 
@@ -214,9 +215,10 @@ function resolveSuccessfulOrderResult(result: PolymarketOrderResult): Successful
 function startMatchedOrderFeeCollection({ orderResult, context }: { orderResult: SuccessfulOrderResult; context: MatchedOrderContext }) {
   const { orderID: orderId } = orderResult;
   const immediateAmounts = getMatchedAmountsFromAcceptedOrder(orderResult, context.side);
+  const settlementTransactionHashes = toSettlementTransactionHashes(orderResult.transactionsHashes);
 
-  if (immediateAmounts) {
-    recordMatchedOrderAndCollectFee(context, immediateAmounts, orderId, { transactionHashes: orderResult.transactionsHashes });
+  if (immediateAmounts && settlementTransactionHashes) {
+    recordMatchedOrderAndCollectFee(context, immediateAmounts, orderId, settlementTransactionHashes);
     return;
   }
 
@@ -244,8 +246,14 @@ async function pollForMatchedOrderFeeCollection({
 
       if (status === MATCHED_STATUS) {
         const amounts = getMatchedAmountsFromPolledOrder(order);
-        if (amounts) {
-          recordMatchedOrderAndCollectFee(context, amounts, orderId);
+        const settlement = await getMatchedOrderSettlement(client, order.associate_trades);
+
+        if (settlement.status === 'failed') {
+          trackOrderMatchFailedAnalytics({ orderId, context, reason: settlement.status, status: settlement.status });
+          return;
+        }
+        if (amounts && settlement.status === 'resolved') {
+          recordMatchedOrderAndCollectFee(context, amounts, orderId, settlement.transactionHashes);
           return;
         }
       }
@@ -268,20 +276,44 @@ function recordMatchedOrderAndCollectFee(
   context: MatchedOrderContext,
   amounts: MatchedOrderAmounts,
   orderId: string,
-  settlement?: MatchedOrderSettlement
+  settlementTransactionHashes: SettlementTransactionHashes
 ) {
   trackMatchedOrderAnalytics(context, amounts);
-
-  const settlementTransactionHashes = settlement?.transactionHashes?.filter(Boolean);
 
   void collectPolymarketTradeFee({
     matchedAmounts: amounts,
     orderId,
     quotedFeeUsd: context.quotedTradeFeeUsd,
     side: context.side,
-    ...(settlementTransactionHashes?.length ? { settlementTransactionHashes } : {}),
+    settlementTransactionHashes,
     tokenId: context.tokenId,
   });
+}
+
+async function getMatchedOrderSettlement(client: ClobClient, associatedTradeIds: readonly string[]): Promise<MatchedOrderSettlement> {
+  const tradeIds = associatedTradeIds.filter(id => id.length > 0);
+  const trades = await Promise.all(tradeIds.map(async id => (await client.getTrades({ id }, true)).find(trade => trade.id === id)));
+  let transactionHashes: SettlementTransactionHashes | undefined;
+
+  for (const trade of trades) {
+    if (trade === undefined) return { status: 'pending' };
+    if (trade.status.toLowerCase() === 'failed') return { status: 'failed' };
+
+    const transactionHash = trade.transaction_hash;
+    if (transactionHash === undefined || transactionHash.length === 0) return { status: 'pending' };
+
+    transactionHashes = transactionHashes === undefined ? [transactionHash] : [...transactionHashes, transactionHash];
+  }
+
+  return transactionHashes === undefined ? { status: 'pending' } : { status: 'resolved', transactionHashes };
+}
+
+function toSettlementTransactionHashes(transactionHashes: readonly string[] | undefined): SettlementTransactionHashes | undefined {
+  if (!transactionHashes) return undefined;
+
+  const [firstHash, ...remainingHashes] = transactionHashes.filter(hash => hash.length > 0);
+  if (firstHash === undefined) return undefined;
+  return [firstHash, ...remainingHashes];
 }
 
 // ============ Analytics ====================================================== //

--- a/src/features/polymarket/utils/fees.ts
+++ b/src/features/polymarket/utils/fees.ts
@@ -1,4 +1,5 @@
 import { type MarketFill } from '@/features/polymarket/utils/orderBookFills';
+import { toFixedWorklet } from '@/framework/core/safeMath';
 
 export type PolymarketFeeInfo = {
   minimumOrderSize: number;
@@ -8,16 +9,21 @@ export type PolymarketFeeInfo = {
 
 export const DEFAULT_MINIMUM_ORDER_SIZE_USD = 1;
 
+const PLATFORM_FEE_SETTLEMENT_DECIMALS = 5;
+
 export const EMPTY_POLYMARKET_FEE_INFO: PolymarketFeeInfo = {
   minimumOrderSize: DEFAULT_MINIMUM_ORDER_SIZE_USD,
   platformFeeExponent: 0,
   platformFeeRate: 0,
 };
 
+/** Calculates an aggregate fill's platform fee at Polymarket settlement precision. */
 export function calculateFillFeesUsd({ feeInfo, fills }: { feeInfo: PolymarketFeeInfo; fills: readonly MarketFill[] }): number {
-  return fills.reduce((feeAmountUsd, fill) => {
+  const feeAmountUsd = fills.reduce((feeAmountUsd, fill) => {
     return feeAmountUsd + calculateTakerFeeUsd({ feeInfo, price: fill.price, shares: fill.shares });
   }, 0);
+
+  return Number(toFixedWorklet(feeAmountUsd, PLATFORM_FEE_SETTLEMENT_DECIMALS));
 }
 
 export function calculateTakerFeeUsd({ feeInfo, price, shares }: { feeInfo: PolymarketFeeInfo; price: number; shares: number }): number {

--- a/src/features/polymarket/utils/polymarketTradeFee.ts
+++ b/src/features/polymarket/utils/polymarketTradeFee.ts
@@ -8,6 +8,7 @@ import {
   mulWorklet,
   subWorklet,
   toStringWorklet,
+  trimTrailingZeros,
   truncateToDecimals,
 } from '@/framework/core/safeMath';
 
@@ -33,7 +34,7 @@ const FEE_TAPER_MULTIPLIER = '0.14';
  * Calculates the trade fee for one executed notional at one price.
  */
 export function calculateTradeFeeUsd({ notionalUsd, price }: FeeValue): string {
-  return mulWorklet(notionalUsd, calculateFeeRate(price));
+  return trimTrailingZeros(truncateToDecimals(mulWorklet(notionalUsd, calculateFeeRate(price)), POLYMARKET_PUSD_DECIMALS));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,9 +5280,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymarket/clob-client-v2@npm:1.0.8":
-  version: 1.0.8
-  resolution: "@polymarket/clob-client-v2@npm:1.0.8"
+"@polymarket/clob-client-v2@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@polymarket/clob-client-v2@npm:1.1.0"
   dependencies:
     "@ethersproject/providers": "npm:^5.8.0"
     "@ethersproject/wallet": "npm:^5.8.0"
@@ -5290,7 +5290,7 @@ __metadata:
     browser-or-node: "npm:^3.0.0"
     tslib: "npm:^2.8.1"
     viem: "npm:^2.46.3"
-  checksum: 10c0/3591ee3e4960bbcd486886d736e7b3c2436fabb85af1d5662bdfc85e70c149f00d78a464b3ebc02d915c873e5dbab6bdc2649e06d63033fd79d5bda05024bd42
+  checksum: 10c0/c570822bae202cabb56100621d3c4626763d092fe89dfcae882c24b9a78ffac1fd7564c9c567bfdd3867bdd1b716e3aeedb52a8ed535a1eb8a9d53220d3422e1
   languageName: node
   linkType: hard
 
@@ -9071,7 +9071,7 @@ __metadata:
     "@notifee/react-native": "npm:7.8.2"
     "@polymarket/builder-relayer-client": "npm:0.0.10"
     "@polymarket/builder-signing-sdk": "npm:0.0.8"
-    "@polymarket/clob-client-v2": "npm:1.0.8"
+    "@polymarket/clob-client-v2": "npm:1.1.0"
     "@rainbow-me/provider": "npm:0.1.2"
     "@rainbow-me/react-native-animated-number": "npm:0.0.2"
     "@rainbow-me/sdk": "npm:0.4.0"


### PR DESCRIPTION
Fixes APP-3910

## What changed (plus any additional context for devs)
- Updates `@polymarket/clob-client-v2` to `1.1.0` for Polymarket’s breaking July 24 order response change (https://docs.polymarket.com/changelog#jul-17-2026)
- Now waits for matched Polymarket orders to settle onchain before initiating Rainbow fee collection
  - Should help to minimize these submission errors: [`RAINBOW-WALLET-402M`](https://rainbow-me.sentry.io/issues/7580811314)
- Fee calculations now explicitly use Polymarket’s 5-decimal fee precision and pUSD’s 6-decimal precision

## Screen recordings / screenshots

## What to test
