### PR TITLE
feat(cash): handle already verified phone number without passkey

### DIFF
--- a/e2e/flows/cash/SetupResume.yaml
+++ b/e2e/flows/cash/SetupResume.yaml
@@ -1,0 +1,70 @@
+appId: ${APP_ID}
+tags:
+  - cash
+  - parallel
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      isE2ETest: true
+- runFlow: ../../utils/Prepare.yaml
+- runFlow: ../../utils/ImportWalletWithKey.yaml
+- runFlow:
+    file: ../../utils/SetExperimentalFlag.yaml
+    env:
+      FLAG: Cash
+      VALUE: 'true'
+- tapOn:
+    id: buy-button
+- assertVisible:
+    id: cash-deposit-intro-set-up-account
+- tapOn:
+    id: cash-deposit-intro-set-up-account
+- assertVisible:
+    text: 'Connect your phone number'
+# A phone registered with a passkey (mock 1303) dead-ends with the already-registered message.
+- tapOn:
+    id: cash-setup-phone-input
+- inputText: '5550001303'
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'This number is already connected to an account.'
+    timeout: 10000
+- tapOn:
+    id: cash-setup-phone-input
+- eraseText
+- inputText: '5550001304'
+- assertNotVisible:
+    text: 'This number is already connected to an account.'
+# A phone registered without a passkey (mock 1304) silently resumes into the same OTP screen.
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm your phone'
+    timeout: 10000
+- waitForAnimationToEnd
+# The 1322 guardrail (mock code 001322) pops back to the phone step with the message.
+- inputText: '001322'
+- extendedWaitUntil:
+    visible:
+      text: 'Connect your phone number'
+    timeout: 10000
+- assertVisible:
+    text: 'This number is already connected to an account.'
+# The kept digits resume again; the mock OTP finishes the resume and lands on Identity.
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm your phone'
+    timeout: 10000
+- waitForAnimationToEnd
+- inputText: '000000'
+- extendedWaitUntil:
+    visible:
+      text: 'Enter some information about yourself'
+    timeout: 10000

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -128,6 +128,7 @@ export const event = {
   cashBuyOrderCompleted: 'cash.buy_completed',
   cashBuyOrderFailed: 'cash.buy_failed',
   cashPhoneSubmitted: 'cash.phone_submitted',
+  cashPhoneAlreadyRegistered: 'cash.phone_already_registered',
   cashPhoneVerified: 'cash.phone_verified',
   cashPhoneVerifyFailed: 'cash.phone_verify_failed',
   cashKycSubmitted: 'cash.kyc_submitted',
@@ -550,10 +551,18 @@ export type EventProperties = {
     failureReason: OrderFailureReason | null;
     errorCode: 'PAYMENT_REJECTED' | 'GENERIC';
   };
-  [event.cashPhoneSubmitted]: undefined;
-  [event.cashPhoneVerified]: undefined;
+  [event.cashPhoneSubmitted]: {
+    mode: 'signup' | 'resume';
+  };
+  [event.cashPhoneAlreadyRegistered]: {
+    outcome: 'registeredWithPasskey' | 'alreadyRegistered' | 'signupAlreadyComplete';
+  };
+  [event.cashPhoneVerified]: {
+    mode: 'signup' | 'resume';
+  };
   [event.cashPhoneVerifyFailed]: {
     reason: string;
+    mode: 'signup' | 'resume';
   };
   [event.cashKycSubmitted]: undefined;
   [event.cashKycApproved]: undefined;

--- a/src/features/cash/components/OtpInput.tsx
+++ b/src/features/cash/components/OtpInput.tsx
@@ -9,6 +9,7 @@ type OtpInputProps = {
   length: number;
   disabled?: boolean;
   error?: boolean;
+  focused?: boolean;
   testID?: string;
 };
 
@@ -18,15 +19,16 @@ export const OtpInput = memo(function OtpInput({
   length,
   disabled = false,
   error = false,
+  focused = true,
   testID = 'otp-input',
 }: OtpInputProps) {
   const red = useForegroundColor('red');
   const inputRef = useRef<TextInput>(null);
 
   useEffect(() => {
-    if (disabled) inputRef.current?.blur();
-    else if (error) inputRef.current?.focus();
-  }, [disabled, error]);
+    if (disabled || !focused) inputRef.current?.blur();
+    else inputRef.current?.focus();
+  }, [disabled, focused]);
 
   const onChangeText = useCallback(
     (text: string) => {
@@ -59,7 +61,6 @@ export const OtpInput = memo(function OtpInput({
       ))}
       <TextInput
         autoComplete="sms-otp"
-        autoFocus
         caretHidden
         keyboardType="number-pad"
         maxLength={length}

--- a/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/ConfirmPhoneStep.tsx
@@ -3,15 +3,20 @@ import React, { memo } from 'react';
 import ButtonPressAnimation from '@/components/animations/ButtonPressAnimation';
 import { Box, Text } from '@/design-system';
 import * as i18n from '@/languages';
+import Routes from '@/navigation/routesNames';
 
 import { OtpInput } from '../../../components/OtpInput';
+import { OTP_LENGTH } from '../../../stores/verifyPhoneFlowStore';
+import { useCashDepositSetupNavigationStore } from '../cashDepositSetupNavigator';
 import { SetupStepLayout } from '../components/SetupStepLayout';
-import { OTP_LENGTH, useVerifyPhoneFlow } from './useVerifyPhoneFlow';
+import { useVerifyPhoneFlow } from './useVerifyPhoneFlow';
 
 const l = i18n.l.cash.deposit_setup.confirm_phone;
 
 export const ConfirmPhoneStep = memo(function ConfirmPhoneStep() {
   const { state, code, setCode, submit, resend, resending, resendCooldownSeconds } = useVerifyPhoneFlow();
+  // The pager keeps visited steps mounted, so focus is tied to the step being active rather than to mount.
+  const isActiveStep = useCashDepositSetupNavigationStore(s => s.activeRoute === Routes.CASH_SETUP_CONFIRM_PHONE);
   const verifying = state === 'verifying';
   const cooling = resendCooldownSeconds > 0;
 
@@ -28,6 +33,7 @@ export const ConfirmPhoneStep = memo(function ConfirmPhoneStep() {
         <OtpInput
           disabled={verifying}
           error={state === 'error'}
+          focused={isActiveStep}
           length={OTP_LENGTH}
           onChange={newCode => {
             setCode(newCode);

--- a/src/features/cash/screens/cash-deposit-setup/steps/PhoneStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PhoneStep.tsx
@@ -5,6 +5,7 @@ import { Box, Text, useForegroundColor } from '@/design-system';
 import * as i18n from '@/languages';
 
 import { US_COUNTRY_CALLING_CODE } from '../../../services/userClient';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
 import { SetupStepLayout } from '../components/SetupStepLayout';
 import { useSetupInputTextStyle } from '../components/useSetupInputTextStyle';
 import { NATIONAL_NUMBER_LENGTH, useSubmitPhoneFlow } from './useSubmitPhoneFlow';
@@ -20,6 +21,7 @@ function formatNationalNumber(digits: string): string {
 
 export const PhoneStep = memo(function PhoneStep() {
   const { state, digits, setDigits, submit } = useSubmitPhoneFlow();
+  const alreadyRegistered = useCashSetupSessionStore(s => s.session.status === 'phoneAlreadyRegistered');
   const submitting = state === 'submitting';
 
   const labelQuaternary = useForegroundColor('labelQuaternary');
@@ -54,9 +56,9 @@ export const PhoneStep = memo(function PhoneStep() {
             value={formatNationalNumber(digits)}
           />
         </Box>
-        {state === 'error' && (
+        {(state === 'error' || alreadyRegistered) && (
           <Text color="red" size="17pt" weight="semibold">
-            {i18n.t(l.error)}
+            {i18n.t(alreadyRegistered ? l.already_registered : l.error)}
           </Text>
         )}
       </Box>

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -68,7 +68,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   (useCashAccountStore.getState as jest.Mock).mockReturnValue({ setUserId });
   session().reset();
-  session().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+  session().setPhoneSubmitted({ challenge: { kind: 'signup', userId: 'user-1' }, phoneNationalNumber: '4155550100', resendAfter: 0 });
   session().setPhoneVerified(challenge(), { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
   mockAddPasskey.mockResolvedValue({ passkeyId: 'pk-1', publicKeyOptionsJson: OPTIONS_JSON, userId: 'user-1' });
   mockCreatePasskeyCredential.mockResolvedValue(CREDENTIAL_JSON);

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitKycFlow.test.ts
@@ -66,7 +66,7 @@ const challenge = () => {
 beforeEach(() => {
   jest.clearAllMocks();
   session().reset();
-  session().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+  session().setPhoneSubmitted({ challenge: { kind: 'signup', userId: 'user-1' }, phoneNationalNumber: '4155550100', resendAfter: 0 });
   session().setPhoneVerified(challenge(), { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
   session().setIdentity(IDENTITY);
   session().setGovernmentId(GOVERNMENT_ID);

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.test.ts
@@ -1,15 +1,15 @@
 import { analytics } from '@/analytics';
 import { logger } from '@/logger';
 
-import { createUserWithPhone } from '../../../services/userClient';
+import { createUserWithPhone, startSignupResume } from '../../../services/userClient';
 import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useVerifyPhoneFlowStore } from '../../../stores/verifyPhoneFlowStore';
 import { useSubmitPhoneFlowStore } from './useSubmitPhoneFlow';
-import { useVerifyPhoneFlowStore } from './useVerifyPhoneFlow';
 
 jest.mock('@/analytics', () => ({
   analytics: {
     track: jest.fn(),
-    event: { cashPhoneSubmitted: 'cash.phone_submitted' },
+    event: { cashPhoneSubmitted: 'cash.phone_submitted', cashPhoneAlreadyRegistered: 'cash.phone_already_registered' },
   },
 }));
 
@@ -22,6 +22,7 @@ jest.mock('../../../services/userClient', () => ({
   US_COUNTRY_CALLING_CODE: '1',
   createUserWithPhone: jest.fn(),
   resendPhoneCode: jest.fn(),
+  startSignupResume: jest.fn(),
   verifyPhone: jest.fn(),
 }));
 
@@ -30,10 +31,11 @@ jest.mock('../useCashDepositSetupNavigation', () => ({
 }));
 
 const mockCreateUserWithPhone = createUserWithPhone as jest.Mock;
+const mockStartSignupResume = startSignupResume as jest.Mock;
 const track = analytics.track as jest.Mock;
 
 const DIGITS = '4155550100';
-const RESPONSE = { userId: 'user-1', resendAfter: 1_750_000_030_000 };
+const RESPONSE = { outcome: 'created', userId: 'user-1', resendAfter: 1_750_000_030_000 };
 
 const flow = () => useSubmitPhoneFlowStore.getState();
 const session = () => useCashSetupSessionStore.getState().session;
@@ -63,6 +65,16 @@ describe('useSubmitPhoneFlowStore.setDigits', () => {
   });
 });
 
+describe('useSubmitPhoneFlowStore.reset', () => {
+  it('clears an already-registered phone result', () => {
+    useCashSetupSessionStore.getState().setPhoneAlreadyRegistered(DIGITS);
+
+    flow().reset();
+
+    expect(session().status).toBe('empty');
+  });
+});
+
 describe('useSubmitPhoneFlowStore.submit', () => {
   it('creates the user, stores the submitted phone session, and tracks', async () => {
     flow().setDigits(DIGITS);
@@ -72,13 +84,59 @@ describe('useSubmitPhoneFlowStore.submit', () => {
     expect(mockCreateUserWithPhone).toHaveBeenCalledWith({ nationalNumber: DIGITS });
     expect(session()).toEqual({
       status: 'phoneSubmitted',
-      challenge: { userId: RESPONSE.userId },
+      challenge: { kind: 'signup', userId: RESPONSE.userId },
       phoneNationalNumber: DIGITS,
       resendAfter: RESPONSE.resendAfter,
     });
-    expect(track).toHaveBeenCalledWith('cash.phone_submitted');
+    expect(track).toHaveBeenCalledWith('cash.phone_submitted', { mode: 'signup' });
     expect(flow().state).toBe('entry');
     expect(flow().digits).toBe(DIGITS);
+  });
+
+  it('starts a signup resume for a phone registered without a passkey', async () => {
+    mockCreateUserWithPhone.mockResolvedValue({ outcome: 'registeredWithoutPasskey' });
+    mockStartSignupResume.mockResolvedValue({ resumeId: 'rcv_1', resendAfter: 1_750_000_060_000 });
+    flow().setDigits(DIGITS);
+
+    await expect(flow().submit()).resolves.toBe(true);
+
+    expect(mockStartSignupResume).toHaveBeenCalledWith({ nationalNumber: DIGITS });
+    expect(session()).toEqual({
+      status: 'phoneSubmitted',
+      challenge: { kind: 'resume', resumeId: 'rcv_1' },
+      phoneNationalNumber: DIGITS,
+      resendAfter: 1_750_000_060_000,
+    });
+    expect(track).toHaveBeenCalledWith('cash.phone_submitted', { mode: 'resume' });
+    expect(flow().state).toBe('entry');
+  });
+
+  it('reports a generic failure when starting the resume throws', async () => {
+    mockCreateUserWithPhone.mockResolvedValue({ outcome: 'registeredWithoutPasskey' });
+    mockStartSignupResume.mockRejectedValue(new Error('network down'));
+    flow().setDigits(DIGITS);
+
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(flow().state).toBe('error');
+    expect(session().status).toBe('empty');
+    expect(track).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it.each(['registeredWithPasskey', 'alreadyRegistered'])('shows the already-registered message on the %s outcome', async outcome => {
+    mockCreateUserWithPhone.mockResolvedValue({ outcome });
+    flow().setDigits(DIGITS);
+
+    await expect(flow().submit()).resolves.toBe(false);
+
+    expect(flow().state).toBe('entry');
+    expect(session()).toEqual({ status: 'phoneAlreadyRegistered', phoneNationalNumber: DIGITS });
+    expect(track).toHaveBeenCalledWith('cash.phone_already_registered', { outcome });
+
+    flow().setDigits('415');
+    expect(flow().state).toBe('entry');
+    expect(session().status).toBe('empty');
   });
 
   it('drops any code/error left in the confirm step so a resubmitted phone starts fresh', async () => {

--- a/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useSubmitPhoneFlow.ts
@@ -5,10 +5,10 @@ import { createBaseStore, createStoreActions } from '@storesjs/stores';
 import { analytics } from '@/analytics';
 import { logger, RainbowError } from '@/logger';
 
-import { createUserWithPhone, US_COUNTRY_CALLING_CODE } from '../../../services/userClient';
-import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { createUserWithPhone, startSignupResume, US_COUNTRY_CALLING_CODE } from '../../../services/userClient';
+import { useCashSetupSessionStore, type PhoneChallenge } from '../../../stores/cashSetupSessionStore';
+import { useVerifyPhoneFlowStore } from '../../../stores/verifyPhoneFlowStore';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
-import { useVerifyPhoneFlowStore } from './useVerifyPhoneFlow';
 
 export const NATIONAL_NUMBER_LENGTH = 10;
 
@@ -22,6 +22,11 @@ type SubmitPhoneFlowStore = {
   reset: () => void;
 };
 
+async function startResume(nationalNumber: string): Promise<{ challenge: PhoneChallenge; resendAfter: number }> {
+  const { resumeId, resendAfter } = await startSignupResume({ nationalNumber });
+  return { challenge: { kind: 'resume', resumeId }, resendAfter };
+}
+
 // Pasted or AutoFilled values may carry the +1 country code on top of the 10 national digits.
 function extractNationalDigits(text: string): string {
   let digits = text.replace(/\D/g, '');
@@ -31,23 +36,44 @@ function extractNationalDigits(text: string): string {
   return digits.slice(0, NATIONAL_NUMBER_LENGTH);
 }
 
+function clearPhoneAlreadyRegistered() {
+  const sessionStore = useCashSetupSessionStore.getState();
+  if (sessionStore.session.status === 'phoneAlreadyRegistered') sessionStore.reset();
+}
+
 export const useSubmitPhoneFlowStore = createBaseStore<SubmitPhoneFlowStore>((set, get) => ({
   state: 'entry',
   digits: '',
 
-  setDigits: text => set(({ state }) => ({ digits: extractNationalDigits(text), state: state === 'error' ? 'entry' : state })),
+  setDigits: text => {
+    clearPhoneAlreadyRegistered();
+    set(({ state }) => ({ digits: extractNationalDigits(text), state: state === 'submitting' ? state : 'entry' }));
+  },
 
   submit: async () => {
     const { digits, state } = get();
     if (digits.length !== NATIONAL_NUMBER_LENGTH || state === 'submitting') return false;
 
+    clearPhoneAlreadyRegistered();
     set({ state: 'submitting' });
     try {
-      const { userId, resendAfter } = await createUserWithPhone({ nationalNumber: digits });
-      useCashSetupSessionStore.getState().setPhoneSubmitted({ userId, phoneNationalNumber: digits, resendAfter });
+      const result = await createUserWithPhone({ nationalNumber: digits });
+
+      if (result.outcome === 'registeredWithPasskey' || result.outcome === 'alreadyRegistered') {
+        analytics.track(analytics.event.cashPhoneAlreadyRegistered, { outcome: result.outcome });
+        useCashSetupSessionStore.getState().setPhoneAlreadyRegistered(digits);
+        set({ state: 'entry' });
+        return false;
+      }
+
+      const { challenge, resendAfter } =
+        result.outcome === 'created'
+          ? { challenge: { kind: 'signup', userId: result.userId } satisfies PhoneChallenge, resendAfter: result.resendAfter }
+          : await startResume(digits);
+      useCashSetupSessionStore.getState().setPhoneSubmitted({ challenge, phoneNationalNumber: digits, resendAfter });
       // A fresh code is on its way; drop any code/error left in the kept-mounted confirm step.
       useVerifyPhoneFlowStore.getState().reset();
-      analytics.track(analytics.event.cashPhoneSubmitted);
+      analytics.track(analytics.event.cashPhoneSubmitted, { mode: challenge.kind });
       set({ state: 'entry' });
       return true;
     } catch (e) {
@@ -57,7 +83,10 @@ export const useSubmitPhoneFlowStore = createBaseStore<SubmitPhoneFlowStore>((se
     }
   },
 
-  reset: () => set({ digits: '', state: 'entry' }),
+  reset: () => {
+    clearPhoneAlreadyRegistered();
+    set({ digits: '', state: 'entry' });
+  },
 }));
 
 const submitPhoneFlowActions = createStoreActions(useSubmitPhoneFlowStore);

--- a/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useVerifyPhoneFlow.ts
@@ -1,91 +1,25 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { createBaseStore, createStoreActions } from '@storesjs/stores';
+import { createStoreActions } from '@storesjs/stores';
 
-import { analytics } from '@/analytics';
 import { time } from '@/framework/core/utils/time';
-import { logger, RainbowError } from '@/logger';
 
-import { resendPhoneCode, verifyPhone } from '../../../services/userClient';
-import { selectResendAfter, useCashSetupSessionStore, type PhoneChallenge } from '../../../stores/cashSetupSessionStore';
+import { selectResendAfter, useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useVerifyPhoneFlowStore, type VerifyPhoneState } from '../../../stores/verifyPhoneFlowStore';
 import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
-
-export const OTP_LENGTH = 6;
-
-export type VerifyPhoneState = 'entry' | 'verifying' | 'error';
-
-type VerifyPhoneFlowStore = {
-  state: VerifyPhoneState;
-  code: string;
-  resending: PhoneChallenge | null;
-  setCode: (code: string) => void;
-  submit: () => Promise<boolean>;
-  resend: () => Promise<void>;
-  reset: () => void;
-};
-
-export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((set, get) => ({
-  state: 'entry',
-  code: '',
-  resending: null,
-
-  setCode: code => set(({ state }) => ({ code, state: state === 'error' ? 'entry' : state })),
-
-  submit: async () => {
-    const { code, state } = get();
-    if (code.length !== OTP_LENGTH || state === 'verifying') return false;
-    const sessionStore = useCashSetupSessionStore.getState();
-    const { session } = sessionStore;
-    if (session.status !== 'phoneSubmitted') return false;
-    const { challenge } = session;
-
-    set({ state: 'verifying' });
-    try {
-      const credential = await verifyPhone({ userId: challenge.userId, code });
-      if (!sessionStore.getIsCurrentChallenge(challenge)) return false;
-      sessionStore.setPhoneVerified(challenge, credential);
-      analytics.track(analytics.event.cashPhoneVerified);
-      set({ code: '', state: 'entry' });
-      return true;
-    } catch (e) {
-      if (!sessionStore.getIsCurrentChallenge(challenge)) return false;
-      logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to verify phone', e));
-      analytics.track(analytics.event.cashPhoneVerifyFailed, { reason: e instanceof Error ? e.message : String(e) });
-      set({ code: '', state: 'error' });
-      return false;
-    }
-  },
-
-  resend: async () => {
-    if (get().resending !== null) return;
-    const sessionStore = useCashSetupSessionStore.getState();
-    const { session } = sessionStore;
-    if (session.status !== 'phoneSubmitted' || Date.now() < session.resendAfter) return;
-    const { challenge } = session;
-
-    set(({ state }) => ({ resending: challenge, state: state === 'error' ? 'entry' : state }));
-    try {
-      const { resendAfter } = await resendPhoneCode({ userId: challenge.userId });
-      sessionStore.setResendAfter(challenge, resendAfter);
-    } catch (e) {
-      if (!sessionStore.getIsCurrentChallenge(challenge)) return;
-      logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to resend code', e));
-    } finally {
-      set(state => (state.resending === challenge ? { resending: null } : state));
-    }
-  },
-
-  reset: () => set({ code: '', resending: null, state: 'entry' }),
-}));
 
 const verifyPhoneFlowActions = createStoreActions(useVerifyPhoneFlowStore);
 
-export function useVerifyPhoneFlow(): Pick<VerifyPhoneFlowStore, 'state' | 'code' | 'setCode' | 'resend'> & {
+export function useVerifyPhoneFlow(): {
+  state: VerifyPhoneState;
+  code: string;
+  setCode: (code: string) => void;
   submit: () => Promise<void>;
+  resend: () => Promise<void>;
   resending: boolean;
   resendCooldownSeconds: number;
 } {
-  const { next } = useCashDepositSetupNavigation();
+  const { next, back } = useCashDepositSetupNavigation();
   const state = useVerifyPhoneFlowStore(s => s.state);
   const code = useVerifyPhoneFlowStore(s => s.code);
   const resending = useVerifyPhoneFlowStore(s => s.resending !== null);
@@ -93,8 +27,10 @@ export function useVerifyPhoneFlow(): Pick<VerifyPhoneFlowStore, 'state' | 'code
   const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
 
   const submit = useCallback(async () => {
-    if (await verifyPhoneFlowActions.submit()) next();
-  }, [next]);
+    const result = await verifyPhoneFlowActions.submit();
+    if (result === 'verified') next();
+    if (result === 'signupAlreadyComplete') back();
+  }, [back, next]);
 
   useEffect(() => {
     if (resendAfter == null) {

--- a/src/features/cash/services/userClient.test.ts
+++ b/src/features/cash/services/userClient.test.ts
@@ -1,5 +1,7 @@
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
+
 import { getCashPlatformClient } from './cashPlatformClient';
-import { verifyPhone } from './userClient';
+import { createUserWithPhone, finishSignupResume, startSignupResume, verifyPhone } from './userClient';
 
 jest.mock('react-native-dotenv', () => ({ IS_TESTING: 'false' }));
 
@@ -15,6 +17,74 @@ const PARAMS = { userId: 'user-1', code: '123456' };
 
 beforeEach(() => {
   post.mockReset();
+});
+
+function platformError(code: unknown) {
+  return new RainbowFetchError({ message: 'phone already registered', responseBody: { code, message: 'phone already registered' } });
+}
+
+describe('createUserWithPhone', () => {
+  const submit = () => createUserWithPhone({ nationalNumber: '5869132511' });
+
+  it('maps a success response to the created outcome', async () => {
+    post.mockResolvedValue({ data: { userId: 'user-1', resendAfter: '30s' } });
+
+    await expect(submit()).resolves.toMatchObject({ outcome: 'created', userId: 'user-1' });
+  });
+
+  it.each([
+    { code: 1304, outcome: 'registeredWithoutPasskey' },
+    { code: 1303, outcome: 'registeredWithPasskey' },
+    { code: 1300, outcome: 'alreadyRegistered' },
+  ])('maps error code $code to $outcome', async ({ code, outcome }) => {
+    post.mockRejectedValue(platformError(code));
+
+    await expect(submit()).resolves.toEqual({ outcome });
+  });
+
+  it.each([platformError(1399), platformError('1304'), platformError(undefined), new Error('network down')])(
+    'rethrows unrecognized errors',
+    async error => {
+      post.mockRejectedValue(error);
+
+      await expect(submit()).rejects.toBe(error);
+    }
+  );
+});
+
+describe('startSignupResume', () => {
+  it('parses the resend cooldown from the response', async () => {
+    const now = 1_750_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    post.mockResolvedValue({ data: { resumeId: 'rcv_1', resendAfter: '30s' } });
+
+    await expect(startSignupResume({ nationalNumber: '5869132511' })).resolves.toEqual({ resumeId: 'rcv_1', resendAfter: now + 30_000 });
+
+    jest.restoreAllMocks();
+  });
+});
+
+describe('finishSignupResume', () => {
+  const submit = () => finishSignupResume({ resumeId: 'rcv_1', code: '123456' });
+
+  it('returns the credential on success', async () => {
+    post.mockResolvedValue({ data: { bootstrapToken: 'bst_test', expiresIn: '600s' } });
+
+    await expect(submit()).resolves.toMatchObject({ outcome: 'verified', bootstrapToken: 'bst_test' });
+  });
+
+  it('maps error code 1322 to signupAlreadyComplete', async () => {
+    post.mockRejectedValue(platformError(1322));
+
+    await expect(submit()).resolves.toEqual({ outcome: 'signupAlreadyComplete' });
+  });
+
+  it('rethrows other errors', async () => {
+    const error = platformError(1300);
+    post.mockRejectedValue(error);
+
+    await expect(submit()).rejects.toBe(error);
+  });
 });
 
 describe('verifyPhone', () => {

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -1,12 +1,28 @@
 import { IS_TESTING } from 'react-native-dotenv';
 
 import { time } from '@/framework/core/utils/time';
+import { RainbowFetchError } from '@/framework/data/http/rainbowFetch';
 import { delay } from '@/utils/delay';
 
 import { type CashSetupDateOfBirth, type CashSetupGovernmentId, type CashSetupIdentity } from '../stores/cashSetupSessionStore';
 import { buildAuthenticatedHeader, getCashPlatformClient } from './cashPlatformClient';
 
 export const US_COUNTRY_CALLING_CODE = '1';
+
+const PHONE_ALREADY_REGISTERED = 1300;
+const REGISTERED_WITH_PASSKEY = 1303;
+const REGISTERED_WITHOUT_PASSKEY = 1304;
+const SIGNUP_ALREADY_COMPLETE = 1322;
+
+const MOCK_REGISTERED_WITHOUT_PASSKEY_NUMBER = '5550001304';
+const MOCK_REGISTERED_WITH_PASSKEY_NUMBER = '5550001303';
+const MOCK_SIGNUP_ALREADY_COMPLETE_CODE = '001322';
+
+function getPlatformErrorCode(error: unknown): number | null {
+  if (!(error instanceof RainbowFetchError)) return null;
+  const code = error.responseBody?.code;
+  return typeof code === 'number' ? code : null;
+}
 
 const BOOTSTRAP_TOKEN_PATTERN = /^bst_.+/;
 // ProtoJSON encoding of google.protobuf.Duration, e.g. "600s" or "0.5s".
@@ -59,10 +75,11 @@ export enum KycStatus {
   Review = 'KYC_STATUS_REVIEW',
 }
 
-type CreateUserWithPhoneResponse = {
-  userId: string;
-  resendAfter: number;
-};
+export type CreateUserWithPhoneResult =
+  | { outcome: 'created'; userId: string; resendAfter: number }
+  | { outcome: 'registeredWithoutPasskey' }
+  | { outcome: 'registeredWithPasskey' }
+  | { outcome: 'alreadyRegistered' };
 
 type ResendPhoneCodeResponse = {
   resendAfter: number;
@@ -136,16 +153,31 @@ type GetUserStatusResponse = {
   };
 };
 
-export async function createUserWithPhone({ nationalNumber }: { nationalNumber: string }): Promise<CreateUserWithPhoneResponse> {
+export async function createUserWithPhone({ nationalNumber }: { nationalNumber: string }): Promise<CreateUserWithPhoneResult> {
   if (IS_TESTING === 'true') {
     await delay(time.seconds(1));
-    return { userId: 'e2e-user-id', resendAfter: Date.now() + time.seconds(30) };
+    if (nationalNumber === MOCK_REGISTERED_WITHOUT_PASSKEY_NUMBER) return { outcome: 'registeredWithoutPasskey' };
+    if (nationalNumber === MOCK_REGISTERED_WITH_PASSKEY_NUMBER) return { outcome: 'registeredWithPasskey' };
+    return { outcome: 'created', userId: 'e2e-user-id', resendAfter: Date.now() + time.seconds(30) };
   }
 
-  const { data } = await getCashPlatformClient().post<{ userId: string; resendAfter: unknown }>('/signup/CreateUserWithPhone', {
-    phone: { countryCode: US_COUNTRY_CALLING_CODE, nationalNumber },
-  });
-  return { userId: data.userId, resendAfter: parseResendAfter(data.resendAfter) };
+  try {
+    const { data } = await getCashPlatformClient().post<{ userId: string; resendAfter: unknown }>('/signup/CreateUserWithPhone', {
+      phone: { countryCode: US_COUNTRY_CALLING_CODE, nationalNumber },
+    });
+    return { outcome: 'created', userId: data.userId, resendAfter: parseResendAfter(data.resendAfter) };
+  } catch (e) {
+    switch (getPlatformErrorCode(e)) {
+      case REGISTERED_WITHOUT_PASSKEY:
+        return { outcome: 'registeredWithoutPasskey' };
+      case REGISTERED_WITH_PASSKEY:
+        return { outcome: 'registeredWithPasskey' };
+      case PHONE_ALREADY_REGISTERED:
+        return { outcome: 'alreadyRegistered' };
+      default:
+        throw e;
+    }
+  }
 }
 
 export async function verifyPhone({
@@ -283,4 +315,44 @@ export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Pr
     headers: buildAuthenticatedHeader(bootstrapToken),
   });
   return { kycStatus: data.status.kyc.status };
+}
+
+export async function startSignupResume({
+  nationalNumber,
+}: {
+  nationalNumber: string;
+}): Promise<{ resumeId: string; resendAfter: number }> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return { resumeId: 'e2e-resume-id', resendAfter: Date.now() + time.seconds(30) };
+  }
+
+  const { data } = await getCashPlatformClient().post<{ resumeId: string; resendAfter: unknown }>('/signup/resume/StartSignupResume', {
+    phone: { countryCode: US_COUNTRY_CALLING_CODE, nationalNumber },
+  });
+  return { resumeId: data.resumeId, resendAfter: parseResendAfter(data.resendAfter) };
+}
+
+export type FinishSignupResumeResult =
+  | { outcome: 'verified'; bootstrapToken: string; expiresAt: number }
+  | { outcome: 'signupAlreadyComplete' };
+
+export async function finishSignupResume({ resumeId, code }: { resumeId: string; code: string }): Promise<FinishSignupResumeResult> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    if (code === MOCK_SIGNUP_ALREADY_COMPLETE_CODE) return { outcome: 'signupAlreadyComplete' };
+    if (code !== '000000') throw new Error('Invalid verification code');
+    return { outcome: 'verified', bootstrapToken: 'bst_e2e', expiresAt: Date.now() + time.hours(1) };
+  }
+
+  try {
+    const { data } = await getCashPlatformClient().post<{ bootstrapToken: unknown; expiresIn: unknown }>(
+      '/signup/resume/FinishSignupResume',
+      { resumeId, code }
+    );
+    return { outcome: 'verified', ...parseBootstrapCredential(data) };
+  } catch (e) {
+    if (getPlatformErrorCode(e) === SIGNUP_ALREADY_COMPLETE) return { outcome: 'signupAlreadyComplete' };
+    throw e;
+  }
 }

--- a/src/features/cash/stores/cashSetupSessionStore.ts
+++ b/src/features/cash/stores/cashSetupSessionStore.ts
@@ -14,7 +14,7 @@ export type CashSetupIdentity = {
 
 // Identifies one accepted phone submission by reference, so async results can
 // be checked against the submission that started them.
-export type PhoneChallenge = Readonly<{ userId: string }>;
+export type PhoneChallenge = Readonly<{ kind: 'signup'; userId: string }> | Readonly<{ kind: 'resume'; resumeId: string }>;
 
 export type CashSetupGovernmentIdKind = 'GOVERNMENT_ID_KIND_SSN_LAST4';
 
@@ -39,22 +39,31 @@ type PhoneSubmittedCashSetupSession = {
   resendAfter: number;
 };
 
+type PhoneAlreadyRegisteredCashSetupSession = {
+  status: 'phoneAlreadyRegistered';
+  phoneNationalNumber: string;
+};
+
 type VerifiedCashSetupSession = {
   status: 'phoneVerified';
   phoneNationalNumber: string;
-  userId: string;
   bootstrapToken: string;
   bootstrapTokenExpiresAt: number;
   identity: CashSetupIdentity | null;
   governmentId: CashSetupGovernmentId | null;
 };
 
-type CashSetupSession = EmptyCashSetupSession | PhoneSubmittedCashSetupSession | VerifiedCashSetupSession;
+type CashSetupSession =
+  | EmptyCashSetupSession
+  | PhoneSubmittedCashSetupSession
+  | PhoneAlreadyRegisteredCashSetupSession
+  | VerifiedCashSetupSession;
 
 type CashSetupSessionStore = {
   session: CashSetupSession;
   getIsCurrentChallenge: (challenge: PhoneChallenge) => boolean;
-  setPhoneSubmitted: (params: { userId: string; phoneNationalNumber: string; resendAfter: number }) => void;
+  setPhoneSubmitted: (params: { challenge: PhoneChallenge; phoneNationalNumber: string; resendAfter: number }) => void;
+  setPhoneAlreadyRegistered: (phoneNationalNumber: string) => void;
   setResendAfter: (challenge: PhoneChallenge, resendAfter: number) => void;
   setPhoneVerified: (challenge: PhoneChallenge, credential: { bootstrapToken: string; expiresAt: number }) => void;
   setIdentity: (identity: CashSetupIdentity) => void;
@@ -71,8 +80,9 @@ export const useCashSetupSessionStore = createBaseStore<CashSetupSessionStore>((
     const { session } = get();
     return session.status === 'phoneSubmitted' && session.challenge === challenge;
   },
-  setPhoneSubmitted: ({ userId, phoneNationalNumber, resendAfter }) =>
-    set({ session: { status: 'phoneSubmitted', challenge: { userId }, phoneNationalNumber, resendAfter } }),
+  setPhoneSubmitted: ({ challenge, phoneNationalNumber, resendAfter }) =>
+    set({ session: { status: 'phoneSubmitted', challenge, phoneNationalNumber, resendAfter } }),
+  setPhoneAlreadyRegistered: phoneNationalNumber => set({ session: { status: 'phoneAlreadyRegistered', phoneNationalNumber } }),
   setResendAfter: (challenge, resendAfter) =>
     set(state => {
       const { session } = state;
@@ -86,7 +96,6 @@ export const useCashSetupSessionStore = createBaseStore<CashSetupSessionStore>((
       return {
         session: {
           status: 'phoneVerified',
-          userId: challenge.userId,
           phoneNationalNumber: session.phoneNationalNumber,
           bootstrapToken,
           bootstrapTokenExpiresAt: expiresAt,

--- a/src/features/cash/stores/verifyPhoneFlowStore.test.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.test.ts
@@ -1,14 +1,18 @@
 import { analytics } from '@/analytics';
 import { logger } from '@/logger';
 
-import { resendPhoneCode, verifyPhone } from '../../../services/userClient';
-import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
-import { useVerifyPhoneFlowStore } from './useVerifyPhoneFlow';
+import { finishSignupResume, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
+import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessionStore';
+import { useVerifyPhoneFlowStore } from './verifyPhoneFlowStore';
 
 jest.mock('@/analytics', () => ({
   analytics: {
     track: jest.fn(),
-    event: { cashPhoneVerified: 'cash.phone_verified', cashPhoneVerifyFailed: 'cash.phone_verify_failed' },
+    event: {
+      cashPhoneVerified: 'cash.phone_verified',
+      cashPhoneVerifyFailed: 'cash.phone_verify_failed',
+      cashPhoneAlreadyRegistered: 'cash.phone_already_registered',
+    },
   },
 }));
 
@@ -17,17 +21,17 @@ jest.mock('@/logger', () => ({
   RainbowError: class RainbowError extends Error {},
 }));
 
-jest.mock('../../../services/userClient', () => ({
+jest.mock('../services/userClient', () => ({
+  finishSignupResume: jest.fn(),
   resendPhoneCode: jest.fn(),
+  startSignupResume: jest.fn(),
   verifyPhone: jest.fn(),
 }));
 
-jest.mock('../useCashDepositSetupNavigation', () => ({
-  useCashDepositSetupNavigation: jest.fn(),
-}));
-
 const mockVerifyPhone = verifyPhone as jest.Mock;
+const mockFinishSignupResume = finishSignupResume as jest.Mock;
 const mockResendPhoneCode = resendPhoneCode as jest.Mock;
+const mockStartSignupResume = startSignupResume as jest.Mock;
 const track = analytics.track as jest.Mock;
 
 const CODE = '123456';
@@ -42,14 +46,18 @@ const challenge = () => {
   if (current.status !== 'phoneSubmitted') throw new Error('expected a phoneSubmitted session');
   return current.challenge;
 };
+const submitPhone = (challenge: PhoneChallenge, phoneNationalNumber = '4155550100') =>
+  store().setPhoneSubmitted({ challenge, phoneNationalNumber, resendAfter: 0 });
 
 beforeEach(() => {
   jest.clearAllMocks();
   store().reset();
-  store().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+  submitPhone({ kind: 'signup', userId: 'user-1' });
   useVerifyPhoneFlowStore.getState().reset();
   mockVerifyPhone.mockResolvedValue(TOKEN);
+  mockFinishSignupResume.mockResolvedValue({ outcome: 'verified', ...TOKEN });
   mockResendPhoneCode.mockResolvedValue({ resendAfter: RESEND_AFTER });
+  mockStartSignupResume.mockResolvedValue({ resumeId: 'rcv_2', resendAfter: RESEND_AFTER });
 });
 
 afterEach(() => {
@@ -60,16 +68,41 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   it('verifies the code, stores the token, tracks, then resets to a clean entry state', async () => {
     flow().setCode(CODE);
 
-    await expect(flow().submit()).resolves.toBe(true);
+    await expect(flow().submit()).resolves.toBe('verified');
 
     expect(mockVerifyPhone).toHaveBeenCalledWith({ userId: 'user-1', code: CODE });
     expect(session()).toMatchObject({
       status: 'phoneVerified',
-      userId: 'user-1',
       bootstrapToken: TOKEN.bootstrapToken,
       bootstrapTokenExpiresAt: TOKEN.expiresAt,
     });
-    expect(track).toHaveBeenCalledWith('cash.phone_verified');
+    expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'signup' });
+    expect(flow().state).toBe('entry');
+    expect(flow().code).toBe('');
+  });
+
+  it('verifies a resume challenge through FinishSignupResume', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('verified');
+
+    expect(mockFinishSignupResume).toHaveBeenCalledWith({ resumeId: 'rcv_1', code: CODE });
+    expect(mockVerifyPhone).not.toHaveBeenCalled();
+    expect(session()).toMatchObject({ status: 'phoneVerified', bootstrapToken: TOKEN.bootstrapToken });
+    expect(track).toHaveBeenCalledWith('cash.phone_verified', { mode: 'resume' });
+  });
+
+  it('marks the phone as already registered when the resumed account turns out to have a passkey', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    mockFinishSignupResume.mockResolvedValue({ outcome: 'signupAlreadyComplete' });
+    flow().setCode(CODE);
+
+    await expect(flow().submit()).resolves.toBe('signupAlreadyComplete');
+
+    expect(session()).toEqual({ status: 'phoneAlreadyRegistered', phoneNationalNumber: '4155550100' });
+    expect(track).toHaveBeenCalledWith('cash.phone_already_registered', { outcome: 'signupAlreadyComplete' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
     expect(flow().state).toBe('entry');
     expect(flow().code).toBe('');
   });
@@ -78,13 +111,13 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     mockVerifyPhone.mockRejectedValue(new Error('wrong code'));
     flow().setCode(CODE);
 
-    await expect(flow().submit()).resolves.toBe(false);
+    await expect(flow().submit()).resolves.toBe('failed');
 
     expect(flow().state).toBe('error');
     expect(flow().code).toBe('');
     expect(session().status).toBe('phoneSubmitted');
-    expect(track).toHaveBeenCalledWith('cash.phone_verify_failed', { reason: 'wrong code' });
-    expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+    expect(track).toHaveBeenCalledWith('cash.phone_verify_failed', { reason: 'wrong code', mode: 'signup' });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
     expect(logger.error).toHaveBeenCalled();
   });
 
@@ -103,7 +136,7 @@ describe('useVerifyPhoneFlowStore.submit', () => {
   it('ignores an incomplete code', async () => {
     flow().setCode('12345');
 
-    await expect(flow().submit()).resolves.toBe(false);
+    await expect(flow().submit()).resolves.toBe('failed');
 
     expect(mockVerifyPhone).not.toHaveBeenCalled();
     expect(flow().state).toBe('entry');
@@ -119,12 +152,12 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     flow().setCode(CODE);
 
     const pending = flow().submit();
-    store().setPhoneSubmitted({ userId: 'user-2', phoneNationalNumber: '4155550101', resendAfter: 0 });
+    submitPhone({ kind: 'signup', userId: 'user-2' }, '4155550101');
     resolveVerify(TOKEN);
 
-    await expect(pending).resolves.toBe(false);
-    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { userId: 'user-2' } });
-    expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+    await expect(pending).resolves.toBe('failed');
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { kind: 'signup', userId: 'user-2' } });
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
   });
 
   it('discards a verification that resolves after a replacement submission for the same user', async () => {
@@ -137,12 +170,12 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     flow().setCode(CODE);
 
     const pending = flow().submit();
-    store().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+    submitPhone({ kind: 'signup', userId: 'user-1' });
     resolveVerify(TOKEN);
 
-    await expect(pending).resolves.toBe(false);
+    await expect(pending).resolves.toBe('failed');
     expect(session().status).toBe('phoneSubmitted');
-    expect(track).not.toHaveBeenCalledWith('cash.phone_verified');
+    expect(track).not.toHaveBeenCalledWith('cash.phone_verified', expect.anything());
   });
 
   it('leaves the replacement flow untouched when an old verification rejects', async () => {
@@ -155,12 +188,12 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     flow().setCode(CODE);
 
     const pending = flow().submit();
-    store().setPhoneSubmitted({ userId: 'user-2', phoneNationalNumber: '4155550101', resendAfter: 0 });
+    submitPhone({ kind: 'signup', userId: 'user-2' }, '4155550101');
     flow().reset();
     flow().setCode('654321');
     rejectVerify(new Error('expired code'));
 
-    await expect(pending).resolves.toBe(false);
+    await expect(pending).resolves.toBe('failed');
     expect(flow().state).toBe('entry');
     expect(flow().code).toBe('654321');
     expect(track).not.toHaveBeenCalledWith('cash.phone_verify_failed', expect.anything());
@@ -180,8 +213,8 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     store().setResendAfter(challenge(), RESEND_AFTER);
     resolveVerify(TOKEN);
 
-    await expect(pending).resolves.toBe(true);
-    expect(session()).toMatchObject({ status: 'phoneVerified', userId: 'user-1' });
+    await expect(pending).resolves.toBe('verified');
+    expect(session()).toMatchObject({ status: 'phoneVerified' });
   });
 
   it('ignores a second submit while verifying', async () => {
@@ -194,11 +227,11 @@ describe('useVerifyPhoneFlowStore.submit', () => {
     flow().setCode(CODE);
 
     const first = flow().submit();
-    await expect(flow().submit()).resolves.toBe(false);
+    await expect(flow().submit()).resolves.toBe('failed');
 
     expect(mockVerifyPhone).toHaveBeenCalledTimes(1);
     resolveVerify(TOKEN);
-    await expect(first).resolves.toBe(true);
+    await expect(first).resolves.toBe('verified');
   });
 });
 
@@ -217,6 +250,40 @@ describe('useVerifyPhoneFlowStore.resend', () => {
     expect(session()).toMatchObject({ status: 'phoneSubmitted', resendAfter: RESEND_AFTER });
   });
 
+  it('re-arms a resume challenge with a fresh StartSignupResume, replacing the resumeId', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+
+    await flow().resend();
+
+    expect(mockStartSignupResume).toHaveBeenCalledWith({ nationalNumber: '4155550100' });
+    expect(mockResendPhoneCode).not.toHaveBeenCalled();
+    expect(session()).toEqual({
+      status: 'phoneSubmitted',
+      challenge: { kind: 'resume', resumeId: 'rcv_2' },
+      phoneNationalNumber: '4155550100',
+      resendAfter: RESEND_AFTER,
+    });
+    expect(flow().resending).toBeNull();
+  });
+
+  it('discards a resume re-arm that resolves after the session was replaced', async () => {
+    submitPhone({ kind: 'resume', resumeId: 'rcv_1' });
+    let resolveStart!: (value: { resumeId: string; resendAfter: number }) => void;
+    mockStartSignupResume.mockReturnValue(
+      new Promise(resolve => {
+        resolveStart = resolve;
+      })
+    );
+
+    const pending = flow().resend();
+    submitPhone({ kind: 'signup', userId: 'user-2' }, '4155550101');
+    resolveStart({ resumeId: 'rcv_2', resendAfter: RESEND_AFTER });
+
+    await pending;
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { kind: 'signup', userId: 'user-2' }, resendAfter: 0 });
+    expect(flow().resending).toBeNull();
+  });
+
   it('discards a resend that resolves after the session was replaced', async () => {
     let resolveResend!: (value: { resendAfter: number }) => void;
     mockResendPhoneCode.mockReturnValue(
@@ -226,11 +293,11 @@ describe('useVerifyPhoneFlowStore.resend', () => {
     );
 
     const pending = flow().resend();
-    store().setPhoneSubmitted({ userId: 'user-2', phoneNationalNumber: '4155550101', resendAfter: 0 });
+    submitPhone({ kind: 'signup', userId: 'user-2' }, '4155550101');
     resolveResend({ resendAfter: RESEND_AFTER });
 
     await pending;
-    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { userId: 'user-2' }, resendAfter: 0 });
+    expect(session()).toMatchObject({ status: 'phoneSubmitted', challenge: { kind: 'signup', userId: 'user-2' }, resendAfter: 0 });
     expect(flow().resending).toBeNull();
   });
 
@@ -250,7 +317,7 @@ describe('useVerifyPhoneFlowStore.resend', () => {
       );
 
     const first = flow().resend();
-    store().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+    submitPhone({ kind: 'signup', userId: 'user-1' });
     flow().reset();
     const second = flow().resend();
     expect(mockResendPhoneCode).toHaveBeenCalledTimes(2);

--- a/src/features/cash/stores/verifyPhoneFlowStore.ts
+++ b/src/features/cash/stores/verifyPhoneFlowStore.ts
@@ -1,0 +1,99 @@
+import { createBaseStore } from '@storesjs/stores';
+
+import { analytics } from '@/analytics';
+import { logger, RainbowError } from '@/logger';
+
+import { finishSignupResume, resendPhoneCode, startSignupResume, verifyPhone } from '../services/userClient';
+import { useCashSetupSessionStore, type PhoneChallenge } from './cashSetupSessionStore';
+
+export const OTP_LENGTH = 6;
+
+export type VerifyPhoneState = 'entry' | 'verifying' | 'error';
+
+export type VerifyPhoneResult = 'verified' | 'failed' | 'signupAlreadyComplete';
+
+type VerifyPhoneFlowStore = {
+  state: VerifyPhoneState;
+  code: string;
+  resending: PhoneChallenge | null;
+  setCode: (code: string) => void;
+  submit: () => Promise<VerifyPhoneResult>;
+  resend: () => Promise<void>;
+  reset: () => void;
+};
+
+export const useVerifyPhoneFlowStore = createBaseStore<VerifyPhoneFlowStore>((set, get) => ({
+  state: 'entry',
+  code: '',
+  resending: null,
+
+  setCode: code => set(({ state }) => ({ code, state: state === 'error' ? 'entry' : state })),
+
+  submit: async () => {
+    const { code, state } = get();
+    if (code.length !== OTP_LENGTH || state === 'verifying') return 'failed';
+    const sessionStore = useCashSetupSessionStore.getState();
+    const { session } = sessionStore;
+    if (session.status !== 'phoneSubmitted') return 'failed';
+    const { challenge } = session;
+
+    set({ state: 'verifying' });
+    try {
+      const result =
+        challenge.kind === 'signup'
+          ? { outcome: 'verified' as const, ...(await verifyPhone({ userId: challenge.userId, code })) }
+          : await finishSignupResume({ resumeId: challenge.resumeId, code });
+      if (!sessionStore.getIsCurrentChallenge(challenge)) return 'failed';
+
+      if (result.outcome === 'signupAlreadyComplete') {
+        analytics.track(analytics.event.cashPhoneAlreadyRegistered, { outcome: 'signupAlreadyComplete' });
+        sessionStore.setPhoneAlreadyRegistered(session.phoneNationalNumber);
+        set({ code: '', state: 'entry' });
+        return 'signupAlreadyComplete';
+      }
+
+      sessionStore.setPhoneVerified(challenge, { bootstrapToken: result.bootstrapToken, expiresAt: result.expiresAt });
+      analytics.track(analytics.event.cashPhoneVerified, { mode: challenge.kind });
+      set({ code: '', state: 'entry' });
+      return 'verified';
+    } catch (e) {
+      if (!sessionStore.getIsCurrentChallenge(challenge)) return 'failed';
+      logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to verify phone', e));
+      analytics.track(analytics.event.cashPhoneVerifyFailed, {
+        reason: e instanceof Error ? e.message : String(e),
+        mode: challenge.kind,
+      });
+      set({ code: '', state: 'error' });
+      return 'failed';
+    }
+  },
+
+  resend: async () => {
+    if (get().resending !== null) return;
+    const sessionStore = useCashSetupSessionStore.getState();
+    const { session } = sessionStore;
+    if (session.status !== 'phoneSubmitted' || Date.now() < session.resendAfter) return;
+    const { challenge, phoneNationalNumber } = session;
+
+    set(({ state }) => ({ resending: challenge, state: state === 'error' ? 'entry' : state }));
+    try {
+      if (challenge.kind === 'signup') {
+        const { resendAfter } = await resendPhoneCode({ userId: challenge.userId });
+        sessionStore.setResendAfter(challenge, resendAfter);
+      } else {
+        // Resume has no resend endpoint; re-arming the OTP means a fresh
+        // StartSignupResume, whose resumeId replaces the current challenge.
+        const { resumeId, resendAfter } = await startSignupResume({ nationalNumber: phoneNationalNumber });
+        if (!sessionStore.getIsCurrentChallenge(challenge)) return;
+        sessionStore.setPhoneSubmitted({ challenge: { kind: 'resume', resumeId }, phoneNationalNumber, resendAfter });
+      }
+    } catch (e) {
+      if (!sessionStore.getIsCurrentChallenge(challenge)) return;
+      logger.error(new RainbowError('[useVerifyPhoneFlow]: Failed to resend code', e));
+    } finally {
+      set(state => (state.resending === challenge ? { resending: null } : state));
+    }
+  },
+
+  reset: () => set({ code: '', resending: null, state: 'entry' }),
+}));

--- a/src/features/debug/screens/DevSection.tsx
+++ b/src/features/debug/screens/DevSection.tsx
@@ -541,7 +541,6 @@ export const DevSection = () => {
                 useCashSetupSessionStore.setState({
                   session: {
                     status: 'phoneVerified',
-                    userId: 'dev-user-id',
                     phoneNationalNumber: '4155550100',
                     bootstrapToken: 'bst_dev',
                     bootstrapTokenExpiresAt: Date.now() + time.hours(1),

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1587,7 +1587,8 @@
           "title": "Connect your phone number",
           "subtitle": "This will be how you login in the future.",
           "placeholder": "Phone Number",
-          "error": "We couldn't send a code to that number. Please try again."
+          "error": "We couldn't send a code to that number. Please try again.",
+          "already_registered": "This number is already connected to an account."
         },
         "confirm_phone": {
           "title": "Confirm your phone",


### PR DESCRIPTION
Fixes https://linear.app/rainbow/issue/APP-3914/handle-case-when-user-has-already-verified-phone-number-but-has-not

## Why?

`CreateUserWithPhone` was treated as success-only: any non-2xx collapsed into the generic "try again" error. For the backend, though, an already-registered phone isn't a failure — it's one of three expected answers, each with its own resolution:

- **1304** — the phone has an account that never enrolled a passkey (signup stalled). Resolution: the **Signup Resume** flow (`StartSignupResume` → `FinishSignupResume`), a non-destructive SMS challenge that re-issues a bootstrap token so the user can finish setup. Re-running signup's own verify isn't an option — it mutates an already-verified account, which is why the backend split resume into explicit endpoints.
- **1303** — the account is complete (has a passkey). Needs recovery/sign-in, which doesn't exist yet, so the user gets an "already registered" message instead of a lying generic error.
- **1300** — ambiguous "already on file"; same message.

This PR implements the 1304 resume path end-to-end and gives 1303/1300 honest copy.

## Approach

Decisions that shaped the implementation:

- **Resume is invisible to the user.** Same phone screen, same OTP screen — on 1304 the app silently chains the resume start into the same submit. The protocol difference lives in the session's phone challenge, now a discriminated union (`signup`/`userId` vs `resume`/`resumeId`); verify and resend dispatch on the kind, so a resume id can't reach the signup endpoints by construction.
- **Resend in resume mode = a fresh** **`StartSignupResume`.** There's no resume resend endpoint, and the backend deliberately never reveals the account's user id on this path (so responses don't leak whether a phone is registered). Each resend replaces the challenge with the new resume id.
- **1322 guardrail** (finish-resume on an account that got a passkey after all): the session resets and the user pops back to the phone step with the already-registered message.
- **The verify-flow store moved to its own file**: the submit flow resets it, and the verify side now marks the phone step's already-registered state — at file level that's a dependency cycle unless the store is separate.

## Testing

Staging (real SMS):

1. Fresh number → signup unchanged.
2. The same number again, before enrolling a passkey → a new SMS arrives and the code continues to the identity step as if nothing happened.
3. On that OTP screen, "Resend code" → a new SMS arrives.
4. A number with an enrolled passkey → "This number is already connected to an account." on the phone step; editing the number clears it.

Dev/e2e build (mocks): `5550001304` walks the resume path, `5550001303` shows the already-registered message, OTP `001322` in resume mode triggers the wrong-flow guardrail, `000000` verifies. `e2e/flows/cash/SetupResume.yaml` covers the whole walk.

## Before merge

- [x]  Remove TODO with hardcoding 300s