### PR TITLE
chore: remove no-op chain-balance grouping from the asset sort

### DIFF
--- a/src/state/assets/utils.ts
+++ b/src/state/assets/utils.ts
@@ -180,13 +180,8 @@ export function setUserAssets({
   }
   const allIds: UniqueId[] = [];
 
-  // Sort all assets by chain balance first, then by individual asset value
-  allAssets.sort((a, b) => {
-    const balanceA = unsortedChainBalances.get(a.chainId) ?? 0;
-    const balanceB = unsortedChainBalances.get(b.chainId) ?? 0;
-    if (balanceA !== balanceB) return balanceB - balanceA;
-    return (Number(b.native.balance.amount) ?? 0) - (Number(a.native.balance.amount) ?? 0);
-  });
+  // Sort all assets by value, descending
+  allAssets.sort((a, b) => (Number(b.native.balance.amount) || 0) - (Number(a.native.balance.amount) || 0));
 
   // Process sorted assets in a single pass - build the map in sorted order
   newUserAssetsMap = new Map<UniqueId, ParsedSearchAsset>();
@@ -194,7 +189,7 @@ export function setUserAssets({
     newUserAssetsMap.set(asset.uniqueId, asset);
     allIds.push(asset.uniqueId);
 
-    const balance = Number(asset.native.balance.amount) ?? 0;
+    const balance = Number(asset.native.balance.amount) || 0;
     unsortedChainBalances.set(asset.chainId, (unsortedChainBalances.get(asset.chainId) ?? 0) + balance);
     idsByChain.set(asset.chainId, (idsByChain.get(asset.chainId) ?? []).concat(asset.uniqueId));
   }


### PR DESCRIPTION
The user-assets ingest claims to sort assets by chain balance first, but the comparator reads the chain totals before the loop that computes them runs, so that branch has compared 0 vs 0 on every call since it landed in #6450 (Feb 2025). The asset order users actually see is thus a plain sort by asset value (which also matches what the browser extension does).

This change deletes the dead branch and makes the comment describe the real behavior. It also swaps the `?? 0` fallbacks around `Number(...)` for `|| 0` because `Number()` returns `NaN` rather than a nullish value for bad input, so the old guards were no-ops. A missing balance amount would make the affected asset sort as "equal" to everything (landing at an arbitrary spot in the wallet list) and permanently affect its chain's total for that ingest, since `NaN` propagates through the sum.