### PR TITLE
chore: remove useIsWalletEthZero and its dead threading

### DIFF
--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -1022,9 +1022,7 @@ export type EventProperties = {
     address: string;
     type: string;
   };
-  [event.importedSeedPhrase]: {
-    isWalletEthZero: boolean;
-  };
+  [event.importedSeedPhrase]: undefined;
   [event.iCloudNotEnabled]: {
     category: string;
   };

--- a/src/helpers/buildWalletSections.tsx
+++ b/src/helpers/buildWalletSections.tsx
@@ -60,7 +60,6 @@ export type WalletSectionsState = {
   isLoadingUserAssets: boolean;
   isLoadingBalance: boolean;
   isReadOnlyWallet: boolean;
-  isWalletEthZero: boolean;
   hiddenTokens: string[];
   listType?: AssetListType;
   language: Language;

--- a/src/hooks/useImportingWallet.ts
+++ b/src/hooks/useImportingWallet.ts
@@ -30,7 +30,6 @@ import { sanitizeSeedPhrase } from '@/utils/formatters';
 import { deriveAccountFromWalletInput } from '@/utils/wallet';
 
 import { initializeWallet } from '../state/wallets/initializeWallet';
-import useIsWalletEthZero from './useIsWalletEthZero';
 import usePrevious from './usePrevious';
 
 export default function useImportingWallet({
@@ -44,7 +43,6 @@ export default function useImportingWallet({
   const wallets = useWallets();
 
   const { navigate, goBack, getParent: dangerouslyGetParent } = useNavigation<typeof Routes.MODAL_SCREEN>();
-  const isWalletEthZero = useIsWalletEthZero();
   const [isImporting, setImporting] = useState(false);
   const [seedPhrase, setSeedPhrase] = useState('');
   const [color, setColor] = useState<number | null>(null);
@@ -297,7 +295,7 @@ export default function useImportingWallet({
       return;
     }
 
-    const handleImportSuccess = async (input: string, isWalletEthZero: boolean, backupProvider: string | undefined) => {
+    const handleImportSuccess = async (input: string, backupProvider: string | undefined) => {
       setImporting(false);
       setBusy(false);
       walletLoadingStore.setState({ loadingState: null });
@@ -335,9 +333,7 @@ export default function useImportingWallet({
           });
         }
 
-        analytics.track(analytics.event.importedSeedPhrase, {
-          isWalletEthZero,
-        });
+        analytics.track(analytics.event.importedSeedPhrase);
       });
     };
 
@@ -360,7 +356,7 @@ export default function useImportingWallet({
 
         if (success) {
           // Navigate to wallet screen
-          await handleImportSuccess(input, isWalletEthZero, backupProvider);
+          await handleImportSuccess(input, backupProvider);
         } else {
           // Import failed
           logger.error(new RainbowError('[useImportingWallet]: Import failed'));
@@ -386,7 +382,6 @@ export default function useImportingWallet({
   }, [
     checkedWallet,
     color,
-    isWalletEthZero,
     isImporting,
     name,
     resolvedAddress,

--- a/src/hooks/useIsWalletEthZero.ts
+++ b/src/hooks/useIsWalletEthZero.ts
@@ -1,7 +1,0 @@
-import { useMemo } from 'react';
-
-import { checkWalletEthZero } from '../utils/ethereumUtils';
-
-export default function useIsWalletEthZero() {
-  return useMemo(() => checkWalletEthZero(), []);
-}

--- a/src/hooks/useWalletSectionsData.ts
+++ b/src/hooks/useWalletSectionsData.ts
@@ -32,13 +32,11 @@ import { shallowEqual } from '@/worklets/comparisons';
 import useAccountSettings from './useAccountSettings';
 import useCoinListEdited from './useCoinListEdited';
 import useCoinListEditOptions from './useCoinListEditOptions';
-import useIsWalletEthZero from './useIsWalletEthZero';
 import useWalletsWithBalancesAndNames from './useWalletsWithBalancesAndNames';
 
 export interface WalletSectionsResult {
   briefSectionsData: CellTypes[];
   isEmpty: boolean;
-  isWalletEthZero: boolean;
   isLoadingUserAssets: boolean;
   isLoadingBalance: boolean;
   hasNFTs: boolean;
@@ -57,7 +55,6 @@ export default function useWalletSectionsData({
   const { hiddenTokens } = useHiddenTokens();
   const remoteConfig = useRemoteConfig('claimables', 'discover_enabled', 'perps_enabled', 'polymarket_enabled', 'rnbw_rewards_enabled');
   const experimentalConfig = useExperimentalConfig();
-  const isWalletEthZero = useIsWalletEthZero();
 
   const positionsEnabled = experimentalConfig[DEFI_POSITIONS] && !IS_TEST;
   const claimablesEnabled = (remoteConfig.claimables || experimentalConfig[CLAIMABLES]) && !IS_TEST;
@@ -140,7 +137,6 @@ export default function useWalletSectionsData({
       sortedAssets,
       accountBalanceDisplay: accountWithBalance?.balancesMinusHiddenBalances,
       isLoadingBalance: !accountWithBalance?.balancesMinusHiddenBalances,
-      isWalletEthZero,
       hiddenTokens,
       isReadOnlyWallet,
       listType: type,
@@ -170,7 +166,6 @@ export default function useWalletSectionsData({
       isEmpty,
       isLoadingBalance: !accountWithBalance?.balancesMinusHiddenBalances,
       isLoadingUserAssets,
-      isWalletEthZero,
       briefSectionsData,
     };
   }, [
@@ -183,7 +178,6 @@ export default function useWalletSectionsData({
     pinnedCoins,
     sortedAssets,
     accountWithBalance?.balancesMinusHiddenBalances,
-    isWalletEthZero,
     hiddenTokens,
     isReadOnlyWallet,
     type,

--- a/src/utils/ethereumUtils.ts
+++ b/src/utils/ethereumUtils.ts
@@ -16,7 +16,7 @@ import { useBackendNetworksStore } from '@/features/network/stores/backendNetwor
 import { ChainId, type Network } from '@/features/network/types/backendNetworks';
 import { getOnchainAssetBalance } from '@/handlers/assets';
 import { getProvider, isTestnetChain, toHex } from '@/handlers/web3';
-import { add, fromWei, greaterThan, isZero, subtract } from '@/helpers/utilities';
+import { add, fromWei, greaterThan, subtract } from '@/helpers/utilities';
 import { logger, RainbowError } from '@/logger';
 import { queryClient } from '@/react-query';
 import store from '@/redux/store';
@@ -247,12 +247,6 @@ const getBalanceAmount = (
 };
 
 const getHash = (txn: RainbowTransaction | NewTransaction) => txn.hash?.split('-').shift();
-
-export const checkWalletEthZero = () => {
-  const ethAsset = getAccountAsset(ETH_ADDRESS);
-  const amount = ethAsset?.balance?.amount ?? 0;
-  return isZero(amount);
-};
 
 /**
  * @desc remove hex prefix


### PR DESCRIPTION
Companion to #7682, which removes the add-funds interstitial this hook originally powered. `useIsWalletEthZero` still has two consumers, but neither does anything useful:

* the wallet sections hook threads the value into the section builder and its own return value, but nothing reads it at either end; the last real reader left with the `AssetList` wrapper removal in #7130 (Feb 2026)
* the import flow attaches it to the seed-import analytics event, but the property is broken: it's captured when the import screen mounts, so it describes the previously selected account (or nothing at all during onboarding), never the wallet being imported. It also has zero saved charts and zero views in Amplitude.

This change deletes the hook and its underlying balance-check util and unwinds the threading; the seed-import event now fires without a payload.