### PR TITLE
feat(cash): Add Passkey Screen

### DIFF
--- a/e2e/flows/cash/Setup.yaml
+++ b/e2e/flows/cash/Setup.yaml
@@ -90,6 +90,13 @@ tags:
     visible:
       text: 'Add a Passkey'
     timeout: 10000
+# Add Passkey runs the mock enrollment (~3s of mocked RPC + ceremony delays) before advancing.
+- tapOn:
+    id: cash-setup-next
+- extendedWaitUntil:
+    visible:
+      text: 'Enter email'
+    timeout: 10000
 - repeat:
     while:
       notVisible:

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4337,6 +4337,8 @@ PODS:
     - React
   - ReactNativeMeasureText (0.1.8):
     - ExpoModulesCore
+  - ReactNativePasskeys (0.4.1):
+    - ExpoModulesCore
   - ReactNativePerformance (4.1.2):
     - React-Core
   - rn-fetch-blob (0.12.0):
@@ -5042,6 +5044,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - "ReactNativeMeasureText (from `../node_modules/@domir/react-native-measure-text/ios`)"
+  - ReactNativePasskeys (from `../node_modules/react-native-passkeys/ios`)
   - "ReactNativePerformance (from `../node_modules/@shopify/react-native-performance`)"
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - RNBootSplash (from `../node_modules/react-native-bootsplash`)
@@ -5380,6 +5383,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-dark-mode"
   ReactNativeMeasureText:
     :path: "../node_modules/@domir/react-native-measure-text/ios"
+  ReactNativePasskeys:
+    :path: "../node_modules/react-native-passkeys/ios"
   ReactNativePerformance:
     :path: "../node_modules/@shopify/react-native-performance"
   rn-fetch-blob:
@@ -5614,6 +5619,7 @@ SPEC CHECKSUMS:
   ReactCommon: 8fafefb37d562f9e4bbbc9081ca4501f178a97ec
   ReactNativeDarkMode: 24151d23f70a51eea4b8db0166e79d28b6f2ae57
   ReactNativeMeasureText: 715dcf137d43c76ce2ed8104212abffcc2af428e
+  ReactNativePasskeys: dd0174b0fde61df59cd2aad2312bce31c5e90296
   ReactNativePerformance: fa4952a58739e1a1f6b90a4e9777657d463499a3
   rn-fetch-blob: 25612b6d6f6e980c6f17ed98ba2f58f5696a51ca
   RNBootSplash: 38a079811ede5f999aee49aa26808265cfc9263d

--- a/ios/Rainbow/Rainbow.entitlements
+++ b/ios/Rainbow/Rainbow.entitlements
@@ -15,6 +15,8 @@
 		<string>applinks:rainbow-web.vercel.app</string>
 		<string>applinks:rainbow.me</string>
 		<string>webcredentials:rainbow.me</string>
+		<string>webcredentials:platform.s.rainbow.me</string>
+		<string>webcredentials:platform.p.rainbow.me</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/ios/Rainbow/RainbowDebug.entitlements
+++ b/ios/Rainbow/RainbowDebug.entitlements
@@ -14,6 +14,8 @@
 		<string>applinks:rainbowdotme-alternate.app.link</string>
 		<string>applinks:rainbow.me</string>
 		<string>webcredentials:rainbow.me</string>
+		<string>webcredentials:platform.s.rainbow.me?mode=developer</string>
+		<string>webcredentials:platform.p.rainbow.me?mode=developer</string>
 		<string>applinks:rainbow-web.vercel.app</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>

--- a/ios/Rainbow/RainbowRelease.entitlements
+++ b/ios/Rainbow/RainbowRelease.entitlements
@@ -15,6 +15,8 @@
 		<string>applinks:rainbow-web.vercel.app</string>
 		<string>applinks:rainbow.me</string>
 		<string>webcredentials:rainbow.me</string>
+		<string>webcredentials:platform.s.rainbow.me</string>
+		<string>webcredentials:platform.p.rainbow.me</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/package.json
+++ b/package.json
@@ -334,6 +334,7 @@
     "react-native-os": "rainbow-me/react-native-os#41a08e45260b8c1c53c77ad00e13ae954cb9337c",
     "react-native-pager-view": "6.8.1",
     "react-native-palette-full": "1.2.0",
+    "react-native-passkeys": "0.4.1",
     "react-native-permissions": "3.10.1",
     "react-native-quick-md5": "3.0.9",
     "react-native-radial-gradient": "rainbow-me/react-native-radial-gradient#b99ab59d27dba70364ef516bd5193c37657ba95c",

--- a/patches/react-native-passkeys+0.4.1.patch
+++ b/patches/react-native-passkeys+0.4.1.patch
@@ -1,0 +1,23 @@
+# PATCH CONTEXT
+# Why: Rainbow's default React Native Babel profile compiles the package's
+#   native-module spread to Object.assign. Hermes does not expose the lazy JSI
+#   host methods as enumerable to Object.assign, so `this.isSupported` is
+#   undefined and create() throws before reaching native code. Check support
+#   on the native module directly.
+# Upstream Issue: https://github.com/peterferguson/react-native-passkeys/issues/13
+#   (same symptom; the issue does not establish the root cause).
+# Linear Issue: none.
+# Remove when: react-native-passkeys calls the native support method directly.
+
+diff --git a/node_modules/react-native-passkeys/build/ReactNativePasskeysModule.js b/node_modules/react-native-passkeys/build/ReactNativePasskeysModule.js
+--- a/node_modules/react-native-passkeys/build/ReactNativePasskeysModule.js
++++ b/node_modules/react-native-passkeys/build/ReactNativePasskeysModule.js
+@@ -6,7 +6,7 @@ const passkeys = requireNativeModule("ReactNativePasskeys");
+ export default {
+     ...passkeys,
+     async create(request) {
+-        if (!this.isSupported)
++        if (!passkeys.isSupported())
+             throw new NotSupportedError();
+         const credential = await passkeys.create(request);
+         return {

--- a/src/analytics/event.ts
+++ b/src/analytics/event.ts
@@ -132,6 +132,9 @@ export const event = {
   cashKycSubmitted: 'cash.kyc_submitted',
   cashKycApproved: 'cash.kyc_approved',
   cashKycFailed: 'cash.kyc_failed',
+  cashPasskeySubmitted: 'cash.passkey_submitted',
+  cashPasskeyAdded: 'cash.passkey_added',
+  cashPasskeyFailed: 'cash.passkey_failed',
   cashCardLinked: 'cash.card_linked',
   cashCardLinkFailed: 'cash.card_link_failed',
   rewardsPressedPendingEarningsCard: 'rewards.pressed_pending_earnings_card',
@@ -550,6 +553,11 @@ export type EventProperties = {
   [event.cashKycSubmitted]: undefined;
   [event.cashKycApproved]: undefined;
   [event.cashKycFailed]: {
+    reason: string;
+  };
+  [event.cashPasskeySubmitted]: undefined;
+  [event.cashPasskeyAdded]: undefined;
+  [event.cashPasskeyFailed]: {
     reason: string;
   };
   [event.cashCardLinked]: {

--- a/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/CashDepositSetupScreen.tsx
@@ -44,7 +44,7 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
   const { params } = useRoute<RouteProp<RootStackParamList, typeof Routes.CASH_DEPOSIT_SETUP_SCREEN>>();
   const { ref, goToPage } = usePagerNavigation();
   const initialPage = useStableValue(
-    () => params?.initialStep ?? getFirstSetupStep(useCashDepositSetupStatusStore.getState()) ?? SETUP_STEP_ORDER[0].id
+    () => params?.initialStep ?? getFirstSetupStep(useCashDepositSetupStatusStore.getState()) ?? SETUP_STEP_ORDER[0]
   );
 
   // onNewIndex doesn't fire on mount, so seed the navigator with the page the pager opens on.
@@ -75,11 +75,11 @@ export const CashDepositSetupScreen = memo(function CashDepositSetupScreen() {
           scaleTo={1}
           springConfig={SPRING_CONFIGS.snappyMediumSpringConfig}
         >
-          {SETUP_STEP_ORDER.map(step => (
+          {SETUP_STEP_ORDER.map(route => (
             <SmoothPager.Page
-              component={<CashDepositSetupNavigator.Route name={step.id}>{STEP_COMPONENTS[step.id]}</CashDepositSetupNavigator.Route>}
-              id={step.id}
-              key={step.id}
+              component={<CashDepositSetupNavigator.Route name={route}>{STEP_COMPONENTS[route]}</CashDepositSetupNavigator.Route>}
+              id={route}
+              key={route}
             />
           ))}
         </SmoothPager>

--- a/src/features/cash/screens/cash-deposit-setup/cashDepositSetupNavigator.ts
+++ b/src/features/cash/screens/cash-deposit-setup/cashDepositSetupNavigator.ts
@@ -4,8 +4,8 @@ import { type CashDepositSetupRoute } from '@/navigation/types';
 import { SETUP_STEP_ORDER } from './steps';
 
 const Navigator = createVirtualNavigator<CashDepositSetupRoute>({
-  initialRoute: SETUP_STEP_ORDER[0].id,
-  routes: SETUP_STEP_ORDER.map(step => step.id),
+  initialRoute: SETUP_STEP_ORDER[0],
+  routes: [...SETUP_STEP_ORDER],
 });
 
 export const CashDepositSetupNavigator = Navigator;

--- a/src/features/cash/screens/cash-deposit-setup/steps.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.test.ts
@@ -1,7 +1,7 @@
 import Routes from '@/navigation/routesNames';
 import { type CashDepositSetupRoute } from '@/navigation/types';
 
-import { getFirstSetupStep, getNextSetupStep, getSetupStep, SETUP_STEP_ORDER } from './steps';
+import { getFirstSetupStep, getNextSetupStep, SETUP_STEP_ORDER } from './steps';
 
 describe('Cash Deposit Setup steps', () => {
   it('maps a setup status to its first step', () => {
@@ -16,20 +16,12 @@ describe('Cash Deposit Setup steps', () => {
 
   it('walks every step in order then terminates', () => {
     const visited: CashDepositSetupRoute[] = [];
-    let current: CashDepositSetupRoute | null = SETUP_STEP_ORDER[0].id;
+    let current: CashDepositSetupRoute | null = SETUP_STEP_ORDER[0];
     while (current) {
       visited.push(current);
       current = getNextSetupStep(current);
     }
-    expect(visited).toEqual(SETUP_STEP_ORDER.map(step => step.id));
+    expect(visited).toEqual([...SETUP_STEP_ORDER]);
     expect(getNextSetupStep(Routes.CASH_SETUP_CARD_ADDED)).toBeNull();
-  });
-
-  it('maps the milestone steps to their facts', () => {
-    expect(getSetupStep(Routes.CASH_SETUP_PASSKEY)?.milestone).toBe('passkeyRegistered');
-    expect(getSetupStep(Routes.CASH_SETUP_REVIEW)?.milestone).toBeUndefined();
-    expect(getSetupStep(Routes.CASH_SETUP_CARD_DETAILS)?.milestone).toBeUndefined();
-    expect(getSetupStep(Routes.CASH_SETUP_CONFIRM_PHONE)?.milestone).toBeUndefined();
-    expect(getSetupStep(Routes.CASH_SETUP_PHONE)?.milestone).toBeUndefined();
   });
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps.ts
@@ -1,40 +1,25 @@
 import Routes from '@/navigation/routesNames';
 import { type CashDepositSetupRoute } from '@/navigation/types';
 
-import {
-  isCashDepositSetupComplete,
-  type CashDepositSetupFacts,
-  type CashDepositSetupStatus,
-} from '../../stores/deriveCashDepositSetupStatus';
+import { isCashDepositSetupComplete, type CashDepositSetupStatus } from '../../stores/deriveCashDepositSetupStatus';
 
-export type CashDepositSetupStep = {
-  id: CashDepositSetupRoute;
-  /** Fact this step is responsible for. */
-  milestone?: keyof CashDepositSetupFacts;
-};
-
-/** The Setup flow order and each step's milestone fact; reorder by editing this array. */
-export const SETUP_STEP_ORDER: readonly CashDepositSetupStep[] = [
-  { id: Routes.CASH_SETUP_PHONE },
-  { id: Routes.CASH_SETUP_CONFIRM_PHONE },
-  { id: Routes.CASH_SETUP_IDENTITY },
-  { id: Routes.CASH_SETUP_SSN },
-  { id: Routes.CASH_SETUP_REVIEW },
-  { id: Routes.CASH_SETUP_PASSKEY, milestone: 'passkeyRegistered' },
-  { id: Routes.CASH_SETUP_EMAIL },
-  { id: Routes.CASH_SETUP_ALL_DONE },
-  { id: Routes.CASH_SETUP_CARD_DETAILS },
-  { id: Routes.CASH_SETUP_CARD_ADDED },
+/** The Setup flow order; reorder by editing this array. */
+export const SETUP_STEP_ORDER: readonly CashDepositSetupRoute[] = [
+  Routes.CASH_SETUP_PHONE,
+  Routes.CASH_SETUP_CONFIRM_PHONE,
+  Routes.CASH_SETUP_IDENTITY,
+  Routes.CASH_SETUP_SSN,
+  Routes.CASH_SETUP_REVIEW,
+  Routes.CASH_SETUP_PASSKEY,
+  Routes.CASH_SETUP_EMAIL,
+  Routes.CASH_SETUP_ALL_DONE,
+  Routes.CASH_SETUP_CARD_DETAILS,
+  Routes.CASH_SETUP_CARD_ADDED,
 ];
 
-export function getSetupStep(current: CashDepositSetupRoute): CashDepositSetupStep | undefined {
-  return SETUP_STEP_ORDER.find(step => step.id === current);
-}
-
 export function getNextSetupStep(current: CashDepositSetupRoute): CashDepositSetupRoute | null {
-  const index = SETUP_STEP_ORDER.findIndex(step => step.id === current);
-  const next = SETUP_STEP_ORDER[index + 1];
-  return next ? next.id : null;
+  const index = SETUP_STEP_ORDER.indexOf(current);
+  return SETUP_STEP_ORDER[index + 1] ?? null;
 }
 
 const SETUP_STEP_FOR_STATUS: Record<Exclude<CashDepositSetupStatus, 'ready'>, CashDepositSetupRoute> = {

--- a/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
+++ b/src/features/cash/screens/cash-deposit-setup/steps/PasskeyStep.tsx
@@ -1,9 +1,39 @@
 import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
 
+import { Box, Text } from '@/design-system';
 import * as i18n from '@/languages';
 
 import { SetupStepLayout } from '../components/SetupStepLayout';
+import { useAddPasskeyFlow } from './useAddPasskeyFlow';
+
+const l = i18n.l.cash.deposit_setup.passkey;
+
+const KEY_ICON = '􀟖';
 
 export const PasskeyStep = memo(function PasskeyStep() {
-  return <SetupStepLayout title={i18n.t(i18n.l.cash.deposit_setup.passkey.title)} />;
+  const { submitting, submit } = useAddPasskeyFlow();
+
+  return (
+    <SetupStepLayout
+      actionLabel={i18n.t(l.action)}
+      actionLoading={submitting}
+      backDisabled={submitting}
+      onAction={submit}
+      subtitle={i18n.t(l.subtitle)}
+      title={i18n.t(l.title)}
+    >
+      <Box alignItems="center" height="full" justifyContent="center">
+        <Text align="center" color="blue" size="44pt" style={styles.keyIcon} weight="heavy">
+          {KEY_ICON}
+        </Text>
+      </Box>
+    </SetupStepLayout>
+  );
+});
+
+const styles = StyleSheet.create({
+  keyIcon: {
+    lineHeight: 64,
+  },
 });

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.test.ts
@@ -1,0 +1,171 @@
+import { analytics } from '@/analytics';
+import { logger } from '@/logger';
+
+import { createPasskeyCredential } from '../../../services/cashPasskeyService';
+import { addPasskey, finishAddPasskey } from '../../../services/userClient';
+import { useCashDepositSetupStore } from '../../../stores/cashDepositSetupStore';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useAddPasskeyFlowStore } from './useAddPasskeyFlow';
+
+jest.mock('@/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    event: {
+      cashPasskeySubmitted: 'cash.passkey_submitted',
+      cashPasskeyAdded: 'cash.passkey_added',
+      cashPasskeyFailed: 'cash.passkey_failed',
+    },
+  },
+}));
+
+jest.mock('@/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  RainbowError: class RainbowError extends Error {},
+}));
+
+jest.mock('@/helpers/alert', () => ({
+  WrappedAlert: { alert: jest.fn() },
+}));
+
+jest.mock('../../../services/userClient', () => ({
+  addPasskey: jest.fn(),
+  finishAddPasskey: jest.fn(),
+}));
+
+jest.mock('../../../services/cashPasskeyService', () => ({
+  createPasskeyCredential: jest.fn(),
+  getPasskeyName: jest.fn(() => 'iPhone 15 Pro'),
+  isPasskeyCancellation: jest.fn((error: unknown) => error instanceof Error && error.message === 'UserCancelled'),
+}));
+
+jest.mock('../../../stores/cashDepositSetupStore', () => ({
+  useCashDepositSetupStore: { getState: jest.fn() },
+}));
+
+jest.mock('../useCashDepositSetupNavigation', () => ({
+  useCashDepositSetupNavigation: jest.fn(),
+}));
+
+const mockAddPasskey = addPasskey as jest.Mock;
+const mockFinishAddPasskey = finishAddPasskey as jest.Mock;
+const mockCreatePasskeyCredential = createPasskeyCredential as jest.Mock;
+const track = analytics.track as jest.Mock;
+const setFact = jest.fn();
+
+const TOKEN = 'bst_1';
+const OPTIONS_JSON = '{"publicKey":{"challenge":"abc"}}';
+const CREDENTIAL_JSON = '{"id":"cred-1"}';
+
+const flow = () => useAddPasskeyFlowStore.getState();
+const session = () => useCashSetupSessionStore.getState();
+const challenge = () => {
+  const current = session().session;
+  if (current.status !== 'phoneSubmitted') throw new Error('expected a phoneSubmitted session');
+  return current.challenge;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useCashDepositSetupStore.getState as jest.Mock).mockReturnValue({ setFact });
+  session().reset();
+  session().setPhoneSubmitted({ userId: 'user-1', phoneNationalNumber: '4155550100', resendAfter: 0 });
+  session().setPhoneVerified(challenge(), { bootstrapToken: TOKEN, expiresAt: Date.now() + 60_000 });
+  mockAddPasskey.mockResolvedValue({ passkeyId: 'pk-1', publicKeyOptionsJson: OPTIONS_JSON });
+  mockCreatePasskeyCredential.mockResolvedValue(CREDENTIAL_JSON);
+  mockFinishAddPasskey.mockResolvedValue(undefined);
+});
+
+describe('useAddPasskeyFlowStore.submit', () => {
+  it('enrolls, flips the fact, tracks, and resolves completed — in order', async () => {
+    await expect(flow().submit()).resolves.toBe('completed');
+
+    expect(mockAddPasskey).toHaveBeenCalledWith({ bootstrapToken: TOKEN });
+    expect(mockCreatePasskeyCredential).toHaveBeenCalledWith(OPTIONS_JSON);
+    expect(mockFinishAddPasskey).toHaveBeenCalledWith({
+      bootstrapToken: TOKEN,
+      passkeyId: 'pk-1',
+      credentialCreationJson: CREDENTIAL_JSON,
+      passkeyName: 'iPhone 15 Pro',
+    });
+    expect(setFact).toHaveBeenCalledWith('passkeyRegistered', true);
+    expect(track).toHaveBeenNthCalledWith(1, 'cash.passkey_submitted');
+    expect(track).toHaveBeenNthCalledWith(2, 'cash.passkey_added');
+
+    const [addOrder] = mockAddPasskey.mock.invocationCallOrder;
+    const [ceremonyOrder] = mockCreatePasskeyCredential.mock.invocationCallOrder;
+    const [finishOrder] = mockFinishAddPasskey.mock.invocationCallOrder;
+    const [setFactOrder] = setFact.mock.invocationCallOrder;
+    expect(addOrder).toBeLessThan(ceremonyOrder);
+    expect(ceremonyOrder).toBeLessThan(finishOrder);
+    expect(finishOrder).toBeLessThan(setFactOrder);
+
+    expect(flow().state).toBe('entry');
+  });
+
+  it('resolves cancelled when the user dismisses the ceremony — no fact, no failure event', async () => {
+    mockCreatePasskeyCredential.mockRejectedValue(new Error('UserCancelled'));
+
+    await expect(flow().submit()).resolves.toBe('cancelled');
+
+    expect(mockFinishAddPasskey).not.toHaveBeenCalled();
+    expect(setFact).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith('cash.passkey_submitted');
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(flow().state).toBe('entry');
+  });
+
+  it('fails with the error message when the ceremony throws', async () => {
+    mockCreatePasskeyCredential.mockRejectedValue(new Error('ceremony broke'));
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'ceremony broke' });
+    expect(setFact).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('fails without the fact when FinishAddPasskey throws', async () => {
+    mockFinishAddPasskey.mockRejectedValue(new Error('network down'));
+
+    await expect(flow().submit()).resolves.toBe('failed');
+
+    expect(track).toHaveBeenCalledWith('cash.passkey_failed', { reason: 'network down' });
+    expect(setFact).not.toHaveBeenCalled();
+  });
+
+  it('retries the whole enrollment after a failure — a fresh challenge', async () => {
+    mockAddPasskey.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(flow().submit()).resolves.toBe('failed');
+    await expect(flow().submit()).resolves.toBe('completed');
+
+    expect(mockAddPasskey).toHaveBeenCalledTimes(2);
+    expect(setFact).toHaveBeenCalledWith('passkeyRegistered', true);
+  });
+
+  it('skips a second submit while one is in flight', async () => {
+    let resolveAdd!: (value: { passkeyId: string; publicKeyOptionsJson: string }) => void;
+    mockAddPasskey.mockReturnValue(
+      new Promise(resolve => {
+        resolveAdd = resolve;
+      })
+    );
+
+    const first = flow().submit();
+    await expect(flow().submit()).resolves.toBe('skipped');
+
+    expect(mockAddPasskey).toHaveBeenCalledTimes(1);
+    resolveAdd({ passkeyId: 'pk-1', publicKeyOptionsJson: OPTIONS_JSON });
+    await expect(first).resolves.toBe('completed');
+  });
+
+  it('skips when the session is not phone-verified', async () => {
+    session().reset();
+
+    await expect(flow().submit()).resolves.toBe('skipped');
+
+    expect(mockAddPasskey).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
+++ b/src/features/cash/screens/cash-deposit-setup/steps/useAddPasskeyFlow.ts
@@ -1,0 +1,68 @@
+import { useCallback } from 'react';
+
+import { createBaseStore, createStoreActions } from '@storesjs/stores';
+
+import { analytics } from '@/analytics';
+import { WrappedAlert as Alert } from '@/helpers/alert';
+import * as i18n from '@/languages';
+import { logger, RainbowError } from '@/logger';
+
+import { createPasskeyCredential, getPasskeyName, isPasskeyCancellation } from '../../../services/cashPasskeyService';
+import { addPasskey, finishAddPasskey } from '../../../services/userClient';
+import { useCashDepositSetupStore } from '../../../stores/cashDepositSetupStore';
+import { useCashSetupSessionStore } from '../../../stores/cashSetupSessionStore';
+import { useCashDepositSetupNavigation } from '../useCashDepositSetupNavigation';
+
+export type AddPasskeyState = 'entry' | 'submitting';
+
+export type AddPasskeyResult = 'completed' | 'cancelled' | 'failed' | 'skipped';
+
+type AddPasskeyFlowStore = {
+  state: AddPasskeyState;
+  submit: () => Promise<AddPasskeyResult>;
+};
+
+export const useAddPasskeyFlowStore = createBaseStore<AddPasskeyFlowStore>((set, get) => ({
+  state: 'entry',
+
+  submit: async () => {
+    if (get().state !== 'entry') return 'skipped';
+    const { session } = useCashSetupSessionStore.getState();
+    if (session.status !== 'phoneVerified') return 'skipped';
+
+    set({ state: 'submitting' });
+    analytics.track(analytics.event.cashPasskeySubmitted);
+    try {
+      const { bootstrapToken } = session;
+      const { passkeyId, publicKeyOptionsJson } = await addPasskey({ bootstrapToken });
+      const credentialCreationJson = await createPasskeyCredential(publicKeyOptionsJson);
+      await finishAddPasskey({ bootstrapToken, passkeyId, credentialCreationJson, passkeyName: getPasskeyName() });
+
+      useCashDepositSetupStore.getState().setFact('passkeyRegistered', true);
+      analytics.track(analytics.event.cashPasskeyAdded);
+      return 'completed';
+    } catch (e) {
+      if (isPasskeyCancellation(e)) return 'cancelled';
+      logger.error(new RainbowError('[useAddPasskeyFlow]: Failed to add passkey', e));
+      analytics.track(analytics.event.cashPasskeyFailed, { reason: e instanceof Error ? e.message : String(e) });
+      return 'failed';
+    } finally {
+      set({ state: 'entry' });
+    }
+  },
+}));
+
+const addPasskeyFlowActions = createStoreActions(useAddPasskeyFlowStore);
+
+export function useAddPasskeyFlow(): { submitting: boolean; submit: () => Promise<void> } {
+  const { next } = useCashDepositSetupNavigation();
+  const submitting = useAddPasskeyFlowStore(state => state.state === 'submitting');
+
+  const submit = useCallback(async () => {
+    const result = await addPasskeyFlowActions.submit();
+    if (result === 'completed') next();
+    else if (result === 'failed') Alert.alert(i18n.t(i18n.l.cash.deposit_setup.passkey.error));
+  }, [next]);
+
+  return { submitting, submit };
+}

--- a/src/features/cash/screens/cash-deposit-setup/useCashDepositSetupNavigation.ts
+++ b/src/features/cash/screens/cash-deposit-setup/useCashDepositSetupNavigation.ts
@@ -5,18 +5,13 @@ import Routes from '@/navigation/routesNames';
 
 import { useCashDepositSetupStore } from '../../stores/cashDepositSetupStore';
 import { CashDepositSetupNavigation, useCashDepositSetupNavigationStore } from './cashDepositSetupNavigator';
-import { getNextSetupStep, getSetupStep } from './steps';
+import { getNextSetupStep } from './steps';
 
 export function useCashDepositSetupNavigation() {
   const { navigate, goBack: dismissScreen } = useNavigation();
 
   const next = useCallback(() => {
     const current = CashDepositSetupNavigation.getActiveRoute();
-    const step = getSetupStep(current);
-    if (step?.milestone) {
-      useCashDepositSetupStore.getState().setFact(step.milestone, true);
-    }
-
     const upcoming = getNextSetupStep(current);
     if (upcoming) {
       CashDepositSetupNavigation.navigate(upcoming);

--- a/src/features/cash/services/cashPasskeyService.ts
+++ b/src/features/cash/services/cashPasskeyService.ts
@@ -1,0 +1,31 @@
+import DeviceInfo from 'react-native-device-info';
+import { IS_TESTING } from 'react-native-dotenv';
+import { create } from 'react-native-passkeys';
+
+import { time } from '@/framework/core/utils/time';
+import { delay } from '@/utils/delay';
+
+type PasskeyCreationOptions = Parameters<typeof create>[0];
+
+export async function createPasskeyCredential(publicKeyOptionsJson: string): Promise<string> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return '{}';
+  }
+
+  // The backend wraps the WebAuthn options in a `publicKey` envelope
+  const { publicKey } = JSON.parse(publicKeyOptionsJson) as { publicKey: PasskeyCreationOptions };
+  const credential = await create(publicKey);
+  if (!credential) throw new Error('Passkey creation returned no credential');
+  return JSON.stringify(credential);
+}
+
+export function isPasskeyCancellation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = 'code' in error && typeof error.code === 'string' ? error.code : '';
+  return code === 'ERR_USER_CANCELLED' || error.message === 'UserCancelled';
+}
+
+export function getPasskeyName(): string {
+  return DeviceInfo.getModel() || 'passkey';
+}

--- a/src/features/cash/services/userClient.ts
+++ b/src/features/cash/services/userClient.ts
@@ -81,6 +81,20 @@ type GetUserStatusParams = {
   bootstrapToken: string;
 };
 
+type AddPasskeyResponse = {
+  passkeyId: string;
+  /** WebAuthn PublicKeyCredentialCreationOptions, JSON-encoded. */
+  publicKeyOptionsJson: string;
+};
+
+type FinishAddPasskeyParams = {
+  bootstrapToken: string;
+  passkeyId: string;
+  /** WebAuthn attestation, JSON-encoded. */
+  credentialCreationJson: string;
+  passkeyName: string;
+};
+
 type GetUserStatusResponse = {
   status: {
     kyc: {
@@ -88,6 +102,10 @@ type GetUserStatusResponse = {
     };
   };
 };
+
+function buildAuthenticatedHeader(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
 
 export async function createUserWithPhone({ nationalNumber }: { nationalNumber: string }): Promise<CreateUserWithPhoneResponse> {
   if (IS_TESTING === 'true') {
@@ -146,9 +164,41 @@ export async function submitOnboarding({
     governmentId,
   };
   const { data } = await getCashPlatformClient().post<SubmitOnboardingResponse>('/onboarding/SubmitOnboarding', request, {
-    headers: { Authorization: `Bearer ${bootstrapToken}` },
+    headers: buildAuthenticatedHeader(bootstrapToken),
   });
   return data;
+}
+
+export async function addPasskey({ bootstrapToken }: { bootstrapToken: string }): Promise<AddPasskeyResponse> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return { passkeyId: 'e2e-passkey-id', publicKeyOptionsJson: '{}' };
+  }
+
+  const { data } = await getCashPlatformClient().post<AddPasskeyResponse>(
+    '/passkeys/AddPasskey',
+    {},
+    { headers: buildAuthenticatedHeader(bootstrapToken) }
+  );
+  return data;
+}
+
+export async function finishAddPasskey({
+  bootstrapToken,
+  passkeyId,
+  credentialCreationJson,
+  passkeyName,
+}: FinishAddPasskeyParams): Promise<void> {
+  if (IS_TESTING === 'true') {
+    await delay(time.seconds(1));
+    return;
+  }
+
+  await getCashPlatformClient().post(
+    '/passkeys/FinishAddPasskey',
+    { passkeyId, credentialCreationJson, passkeyName },
+    { headers: buildAuthenticatedHeader(bootstrapToken) }
+  );
 }
 
 export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Promise<{ kycStatus: KycStatus }> {
@@ -158,7 +208,7 @@ export async function getUserStatus({ bootstrapToken }: GetUserStatusParams): Pr
   }
 
   const { data } = await getCashPlatformClient().get<GetUserStatusResponse>('/status/GetUserStatus', {
-    headers: { Authorization: `Bearer ${bootstrapToken}` },
+    headers: buildAuthenticatedHeader(bootstrapToken),
   });
   return { kycStatus: data.status.kyc.status };
 }

--- a/src/languages/en_US.json
+++ b/src/languages/en_US.json
@@ -1618,7 +1618,12 @@
           "edit": "Edit",
           "error": "We couldn’t verify your details. Please try again."
         },
-        "passkey": { "title": "Add a Passkey" },
+        "passkey": {
+          "title": "Add a Passkey",
+          "subtitle": "Add a secure passkey to make signing in easier and keep your account protected.",
+          "action": "Add Passkey",
+          "error": "We couldn’t add your passkey. Please try again."
+        },
         "email": { "title": "Enter email" },
         "all_done": {
           "title": "You’re all done!",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,6 +9271,7 @@ __metadata:
     react-native-os: "rainbow-me/react-native-os#41a08e45260b8c1c53c77ad00e13ae954cb9337c"
     react-native-pager-view: "npm:6.8.1"
     react-native-palette-full: "npm:1.2.0"
+    react-native-passkeys: "npm:0.4.1"
     react-native-permissions: "npm:3.10.1"
     react-native-quick-md5: "npm:3.0.9"
     react-native-radial-gradient: "rainbow-me/react-native-radial-gradient#b99ab59d27dba70364ef516bd5193c37657ba95c"
@@ -22319,6 +22320,17 @@ __metadata:
     react: "*"
     react-native: ">=0.46"
   checksum: 10c0/56e1f73775f17d4cf7cbb63e73b80ed709af12f92b6c95da1151bf63baf31acc5153ed8d3a62e507b300ddf7a394d5cd1854efba23575142e4ced1c49bbb7d1d
+  languageName: node
+  linkType: hard
+
+"react-native-passkeys@npm:0.4.1":
+  version: 0.4.1
+  resolution: "react-native-passkeys@npm:0.4.1"
+  peerDependencies:
+    expo: ">=53.0.0"
+    react: "*"
+    react-native: ">=0.71.0"
+  checksum: 10c0/3651d434b806182d165035034c962d84beeca453c456e65f6eb6b943f1155a347a9ec11da35a5d228b47f33b867c0949696ec015d5fb894fa67e35a14910e89c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why?

Cash onboarding had a placeholder passkey step that did not enroll a credential. This completes the passkey setup flow so users can securely sign in after onboarding.

## What changed

- Replaced the placeholder with a functional enrollment screen and loading, cancellation, retry, and error states.
- Enrollment now requests a fresh challenge, completes the native passkey ceremony, and confirms it with the backend before advancing.
- Removed step-level milestones and navigation-owned state mutations, so we derive next screen based on real artifacts related to the user; next steps are:
    - If user did not finish adding passkey, but pass KYC - navigate them directly to "Add Passkey" https://linear.app/rainbow/issue/APP-3917/setup-resume-skip-kyc-for-already-approved-users
    - When user sign in using passkey - navigate to add Credit card step if they have not done that previously https://linear.app/rainbow/issue/APP-3925/navigate-to-add-credit-card-step-after-passkey-sign-in-if-no-card-is
- Added submission, success, and failure telemetry.
- Added the required associated domains and a narrow dependency patch for Rainbow’s Babel/Hermes interoperability, avoiding an app-wide transform change.

## Visuals

I've tested it on a real Android device and it works, but did not record a video

[Simulator Screen Recording - iPhone 17 Pro - 2026-07-22 at 23.18.54.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5351dab2-933c-4ca1-a0b6-b1c2f1c9023c.mov" />](https://app.graphite.com/user-attachments/video/5351dab2-933c-4ca1-a0b6-b1c2f1c9023c.mov)

## Testing

- Complete passkey enrollment and confirm onboarding advances to email.
- Cancel the native prompt and confirm the user remains on the passkey step without an error.
- Retry after a failure and confirm a new enrollment attempt succeeds.
- Confirm repeated taps cannot start concurrent enrollment attempts.